### PR TITLE
perf(agents): ship one automations job schema for add and update

### DIFF
--- a/src/agents/tools/cron-tool-canonicalize.ts
+++ b/src/agents/tools/cron-tool-canonicalize.ts
@@ -313,6 +313,31 @@ export function canonicalizeCronToolObject(
   return next;
 }
 
+// cron.add accepts these nulls, and a null sessionKey intentionally suppresses
+// default creator-session binding on create.
+const CRON_CREATE_NULLABLE_TOP_LEVEL_KEYS: ReadonlySet<string> = new Set(["agentId", "sessionKey"]);
+
+function deleteNullFields(record: Record<string, unknown>, keep?: ReadonlySet<string>): void {
+  for (const [key, entry] of Object.entries(record)) {
+    if (entry === null && !keep?.has(key)) {
+      delete record[key];
+    } else if (isRecord(entry)) {
+      deleteNullFields(entry);
+    }
+  }
+}
+
+/**
+ * Drops null-valued fields from a create job in place. The model-facing job
+ * schema is shared with update, where null means "clear this field"; on create
+ * there is nothing to clear, and the strict gateway cron.add contract rejects
+ * the nulls its update patch accepts.
+ */
+export function stripCronCreateNullClears(value: Record<string, unknown>): Record<string, unknown> {
+  deleteNullFields(value, CRON_CREATE_NULLABLE_TOP_LEVEL_KEYS);
+  return value;
+}
+
 /** Detects recovered update patches that contain no meaningful cron fields after normalization. */
 export function isEmptyRecoveredCronPatch(value: unknown): boolean {
   if (!isRecord(value)) {

--- a/src/agents/tools/cron-tool-schema.ts
+++ b/src/agents/tools/cron-tool-schema.ts
@@ -16,8 +16,10 @@ import { gatewayCallOptionSchemaProperties } from "./gateway-schema.js";
 export const REMINDER_CONTEXT_MESSAGES_MAX = 10;
 export const CRON_TOOL_LIST_MAX_LIMIT = 200;
 
-// Spell out job/patch properties for model-facing schema; runtime validation
-// still happens in normalizeCronJob* to avoid nested union schemas.
+// Spell out job properties for the model-facing schema; runtime validation
+// still happens in normalizeCronJob* to avoid nested union schemas. One object
+// schema serves both add (full job) and update (partial patch; null clears) so
+// the near-duplicate shape ships once per prompt instead of twice (#121606).
 
 const CRON_ACTIONS = [
   "status",
@@ -45,54 +47,8 @@ function nullableStringArraySchema(description: string) {
   return Type.Optional(Type.Union([Type.Array(Type.String()), Type.Null()], { description }));
 }
 
-function deliveryStringSchema(params: { description: string; nullableClears: boolean }) {
-  return params.nullableClears
-    ? nullableStringSchema(`${params.description}, or null to clear`)
-    : Type.Optional(Type.String({ description: params.description }));
-}
-
-function deliveryThreadIdSchema(params: { nullableClears: boolean }) {
-  const variants = params.nullableClears
-    ? [Type.String(), Type.Number(), Type.Null()]
-    : [Type.String(), Type.Number()];
-  return Type.Optional(Type.Union(variants, { description: "Thread/topic id" }));
-}
-
-function failureDestinationModeSchema(params: { nullableClears: boolean }) {
-  const variants = params.nullableClears
-    ? [Type.Literal("announce"), Type.Literal("webhook"), Type.Null()]
-    : [Type.Literal("announce"), Type.Literal("webhook")];
-  return Type.Optional(Type.Union(variants));
-}
-
-function cronPayloadObjectSchema(params: {
-  model: TSchema;
-  toolsAllow: TSchema;
-  fallbacks: TSchema;
-}) {
-  return Type.Object(
-    {
-      kind: optionalStringEnum(CRON_PAYLOAD_KINDS, { description: "Payload kind" }),
-      text: Type.Optional(Type.String({ description: "systemEvent text" })),
-      message: Type.Optional(Type.String({ description: "agentTurn prompt" })),
-      script: Type.Optional(Type.String({ description: "Headless code-mode script" })),
-      model: params.model,
-      thinking: Type.Optional(Type.String({ description: "Thinking override" })),
-      timeoutSeconds: optionalFiniteNumberSchema({ minimum: 0 }),
-      toolBudget: optionalPositiveIntegerSchema({ description: "Maximum script tool calls" }),
-      lightContext: Type.Optional(
-        Type.Boolean({
-          description: "Lightweight bootstrap context (skip full workspace context)",
-        }),
-      ),
-      allowUnsafeExternalContent: Type.Optional(
-        Type.Boolean({ description: "Allow untrusted external content in prompt" }),
-      ),
-      fallbacks: params.fallbacks,
-      toolsAllow: params.toolsAllow,
-    },
-    { additionalProperties: true },
-  );
+function deliveryStringSchema(description: string) {
+  return nullableStringSchema(`${description}, or null to clear`);
 }
 
 function createCronScheduleSchema(): TSchema {
@@ -142,7 +98,7 @@ function createCronScheduleSchema(): TSchema {
   );
 }
 
-function createCronPacingSchema(params: { nullableClears: boolean }): TSchema {
+function createCronPacingSchema(): TSchema {
   const pacing = Type.Object(
     {
       min: Type.Optional(Type.String({ description: "Minimum dynamic delay" })),
@@ -153,11 +109,11 @@ function createCronPacingSchema(params: { nullableClears: boolean }): TSchema {
       description: "Dynamic-cadence bounds; at least one of min or max is required",
     },
   );
-  return Type.Optional(params.nullableClears ? Type.Union([pacing, Type.Null()]) : pacing);
+  return Type.Optional(Type.Union([pacing, Type.Null()]));
 }
 
-export function assertCronPacingInput(value: unknown, params: { nullableClears: boolean }): void {
-  if (value === undefined || (params.nullableClears && value === null)) {
+export function assertCronPacingInput(value: unknown): void {
+  if (value === undefined || value === null) {
     return;
   }
   if (!isRecord(value)) {
@@ -168,15 +124,33 @@ export function assertCronPacingInput(value: unknown, params: { nullableClears: 
 
 function createCronPayloadSchema(): TSchema {
   return Type.Optional(
-    cronPayloadObjectSchema({
-      model: Type.Optional(Type.String({ description: "Model override" })),
-      toolsAllow: Type.Optional(Type.Array(Type.String(), { description: "Allowed tools" })),
-      fallbacks: Type.Optional(Type.Array(Type.String(), { description: "Fallback models" })),
-    }),
+    Type.Object(
+      {
+        kind: optionalStringEnum(CRON_PAYLOAD_KINDS, { description: "Payload kind" }),
+        text: Type.Optional(Type.String({ description: "systemEvent text" })),
+        message: Type.Optional(Type.String({ description: "agentTurn prompt" })),
+        script: Type.Optional(Type.String({ description: "Headless code-mode script" })),
+        model: nullableStringSchema("Model override, or null to clear"),
+        thinking: Type.Optional(Type.String({ description: "Thinking override" })),
+        timeoutSeconds: optionalFiniteNumberSchema({ minimum: 0 }),
+        toolBudget: optionalPositiveIntegerSchema({ description: "Maximum script tool calls" }),
+        lightContext: Type.Optional(
+          Type.Boolean({
+            description: "Lightweight bootstrap context (skip full workspace context)",
+          }),
+        ),
+        allowUnsafeExternalContent: Type.Optional(
+          Type.Boolean({ description: "Allow untrusted external content in prompt" }),
+        ),
+        fallbacks: nullableStringArraySchema("Fallback models, or null to clear"),
+        toolsAllow: nullableStringArraySchema("Allowed tool ids, or null to clear"),
+      },
+      { additionalProperties: true },
+    ),
   );
 }
 
-function createCronTriggerSchema(params: { nullableClears: boolean }): TSchema {
+function createCronTriggerSchema(): TSchema {
   const trigger = Type.Object(
     {
       script: Type.String({ minLength: 1, maxLength: 65_536 }),
@@ -184,25 +158,18 @@ function createCronTriggerSchema(params: { nullableClears: boolean }): TSchema {
     },
     { additionalProperties: false },
   );
-  return Type.Optional(params.nullableClears ? Type.Union([trigger, Type.Null()]) : trigger);
+  return Type.Optional(Type.Union([trigger, Type.Null()]));
 }
 
-function cronDeliverySchema(params: { nullableClears: boolean }) {
+function createCronDeliverySchema(): TSchema {
   const failureDestinationObject = Type.Object(
     {
-      channel: deliveryStringSchema({
-        description: "Failure delivery channel",
-        nullableClears: params.nullableClears,
-      }),
-      to: deliveryStringSchema({
-        description: "Failure delivery target",
-        nullableClears: params.nullableClears,
-      }),
-      accountId: deliveryStringSchema({
-        description: "Failure delivery account",
-        nullableClears: params.nullableClears,
-      }),
-      mode: failureDestinationModeSchema({ nullableClears: params.nullableClears }),
+      channel: deliveryStringSchema("Failure delivery channel"),
+      to: deliveryStringSchema("Failure delivery target"),
+      accountId: deliveryStringSchema("Failure delivery account"),
+      mode: Type.Optional(
+        Type.Union([Type.Literal("announce"), Type.Literal("webhook"), Type.Null()]),
+      ),
     },
     { additionalProperties: true },
   );
@@ -214,57 +181,36 @@ function cronDeliverySchema(params: { nullableClears: boolean }) {
         description: "Completion webhook target; only valid with delivery.mode=announce",
       }),
     },
-    {
-      additionalProperties: true,
-      description: "Additional completion webhook; requires delivery.mode=announce",
-    },
+    { additionalProperties: true },
   );
 
   return Type.Optional(
     Type.Object(
       {
         mode: optionalStringEnum(CRON_DELIVERY_MODES, { description: "Delivery mode" }),
-        channel: deliveryStringSchema({
-          description: "Delivery channel",
-          nullableClears: params.nullableClears,
-        }),
-        to: deliveryStringSchema({
-          description: "Delivery target",
-          nullableClears: params.nullableClears,
-        }),
-        threadId: deliveryThreadIdSchema({ nullableClears: params.nullableClears }),
+        channel: deliveryStringSchema("Delivery channel"),
+        to: deliveryStringSchema("Delivery target"),
+        threadId: Type.Optional(
+          Type.Union([Type.String(), Type.Number(), Type.Null()], {
+            description: "Thread/topic id",
+          }),
+        ),
         bestEffort: Type.Optional(Type.Boolean()),
-        accountId: deliveryStringSchema({
-          description: "Delivery account",
-          nullableClears: params.nullableClears,
-        }),
-        failureDestination: params.nullableClears
-          ? Type.Optional(
-              Type.Union([failureDestinationObject, Type.Null()], {
-                description: "Failure destination; null clears.",
-              }),
-            )
-          : Type.Optional(failureDestinationObject),
-        completionDestination: params.nullableClears
-          ? Type.Optional(
-              Type.Union([completionDestinationObject, Type.Null()], {
-                description:
-                  "Completion webhook destination; requires delivery.mode=announce; null clears.",
-              }),
-            )
-          : Type.Optional(completionDestinationObject),
+        accountId: deliveryStringSchema("Delivery account"),
+        failureDestination: Type.Optional(
+          Type.Union([failureDestinationObject, Type.Null()], {
+            description: "Failure destination; null clears.",
+          }),
+        ),
+        completionDestination: Type.Optional(
+          Type.Union([completionDestinationObject, Type.Null()], {
+            description: "Completion webhook; requires delivery.mode=announce; null clears.",
+          }),
+        ),
       },
       { additionalProperties: true },
     ),
   );
-}
-
-function createCronDeliverySchema(): TSchema {
-  return cronDeliverySchema({ nullableClears: false });
-}
-
-function createCronDeliveryPatchSchema(): TSchema {
-  return cronDeliverySchema({ nullableClears: true });
 }
 
 // Omitting `failureAlert` means "leave defaults/unchanged"; `false` explicitly disables alerts.
@@ -298,13 +244,15 @@ function createCronJobObjectSchema(): TSchema {
         name: Type.Optional(Type.String({ description: "Job name" })),
         declarationKey: Type.Optional(
           Type.String({
-            description: "Idempotent declaration key.",
+            description: "Idempotent declaration key (add only).",
             minLength: 1,
             maxLength: 200,
           }),
         ),
         displayName: Type.Optional(
-          Type.String({ description: "Human-readable declarative job label", maxLength: 200 }),
+          Type.Union([Type.String({ maxLength: 200 }), Type.Null()], {
+            description: "Human-readable label; null clears it",
+          }),
         ),
         owner: Type.Optional(
           Type.Object(
@@ -316,8 +264,8 @@ function createCronJobObjectSchema(): TSchema {
           ),
         ),
         schedule: createCronScheduleSchema(),
-        pacing: createCronPacingSchema({ nullableClears: false }),
-        trigger: createCronTriggerSchema({ nullableClears: false }),
+        pacing: createCronPacingSchema(),
+        trigger: createCronTriggerSchema(),
         sessionTarget: Type.Optional(
           Type.String({
             description: "main | isolated | current (agentTurn default) | session:<id>",
@@ -326,53 +274,18 @@ function createCronJobObjectSchema(): TSchema {
         wakeMode: optionalStringEnum(CRON_WAKE_MODES, { description: "Wake timing" }),
         payload: createCronPayloadSchema(),
         delivery: createCronDeliverySchema(),
-        agentId: nullableStringSchema("Agent id, or null to keep it unset"),
+        agentId: nullableStringSchema("Agent id, or null to clear it"),
         description: Type.Optional(Type.String({ description: "Human description" })),
         enabled: Type.Optional(Type.Boolean()),
         deleteAfterRun: Type.Optional(Type.Boolean({ description: "Delete after first run" })),
         sessionKey: nullableStringSchema("Explicit session key, or null to clear it"),
         failureAlert: createCronFailureAlertSchema(),
       },
-      { additionalProperties: true },
-    ),
-  );
-}
-
-function createCronPatchObjectSchema(): TSchema {
-  return Type.Optional(
-    Type.Object(
       {
-        name: Type.Optional(Type.String({ description: "Job name" })),
-        displayName: Type.Optional(
-          Type.Union([Type.String({ maxLength: 200 }), Type.Null()], {
-            description: "Human-readable label; null clears it",
-          }),
-        ),
-        schedule: createCronScheduleSchema(),
-        pacing: createCronPacingSchema({ nullableClears: true }),
-        trigger: createCronTriggerSchema({ nullableClears: true }),
-        sessionTarget: Type.Optional(
-          Type.String({
-            description: "main | isolated | current (agentTurn default) | session:<id>",
-          }),
-        ),
-        wakeMode: optionalStringEnum(CRON_WAKE_MODES),
-        payload: Type.Optional(
-          cronPayloadObjectSchema({
-            model: nullableStringSchema("Model override, or null to clear"),
-            toolsAllow: nullableStringArraySchema("Allowed tool ids, or null to clear"),
-            fallbacks: nullableStringArraySchema("Fallback models, or null to clear"),
-          }),
-        ),
-        delivery: createCronDeliveryPatchSchema(),
-        description: Type.Optional(Type.String()),
-        enabled: Type.Optional(Type.Boolean()),
-        deleteAfterRun: Type.Optional(Type.Boolean()),
-        agentId: nullableStringSchema("Agent id, or null to clear it"),
-        sessionKey: nullableStringSchema("Explicit session key, or null to clear it"),
-        failureAlert: createCronFailureAlertSchema(),
+        additionalProperties: true,
+        description:
+          'Job fields. action="add": full job. action="update": partial patch — only supplied fields change; null clears.',
       },
-      { additionalProperties: true },
     ),
   );
 }
@@ -394,7 +307,6 @@ export function createCronToolSchema(): TSchema {
       job: createCronJobObjectSchema(),
       jobId: Type.Optional(Type.String()),
       id: Type.Optional(Type.String()),
-      patch: createCronPatchObjectSchema(),
       in: Type.Optional(
         Type.String({
           description: 'Relative duration for action="next_check" (for example, "15m")',

--- a/src/agents/tools/cron-tool.flat-params.test.ts
+++ b/src/agents/tools/cron-tool.flat-params.test.ts
@@ -431,7 +431,7 @@ describe("cron tool flat-params", () => {
     await tool.execute("call-patch-trailing-space", {
       action: "update",
       jobId: "job-123",
-      patch: {
+      job: {
         "schedule ": { kind: "cron", expr: "0 9 * * 1-5", tz: "America/New_York" },
         "enabled ": false,
       },

--- a/src/agents/tools/cron-tool.schema.test.ts
+++ b/src/agents/tools/cron-tool.schema.test.ts
@@ -9,14 +9,22 @@ import { Value } from "typebox/value";
 import { describe, expect, it } from "vitest";
 import { createCronTool } from "./cron-tool.js";
 
+/** Unwraps nullable anyOf unions to their object variant so paths can descend. */
+function objectVariant(
+  node: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!node || node.properties) {
+    return node;
+  }
+  const variants = node.anyOf as Array<Record<string, unknown>> | undefined;
+  return variants?.find((entry) => entry.type === "object") ?? node;
+}
+
 /** Walk a TypeBox schema by dot-separated property path and return sorted keys. */
 function keysAt(schema: Record<string, unknown>, path: string): string[] {
-  let cursor: Record<string, unknown> | undefined = schema;
-  for (const segment of path.split(".")) {
-    const props = cursor?.["properties"] as Record<string, Record<string, unknown>> | undefined;
-    cursor = props?.[segment];
-  }
-  const leaf = cursor?.["properties"] as Record<string, unknown> | undefined;
+  const leaf = objectVariant(propertyAt(schema, path))?.["properties"] as
+    | Record<string, unknown>
+    | undefined;
   return leaf ? Object.keys(leaf).toSorted() : [];
 }
 
@@ -26,7 +34,9 @@ function propertyAt(
 ): Record<string, unknown> | undefined {
   let cursor: Record<string, unknown> | undefined = schema;
   for (const segment of path.split(".")) {
-    const props = cursor?.["properties"] as Record<string, Record<string, unknown>> | undefined;
+    const props = objectVariant(cursor)?.["properties"] as
+      | Record<string, Record<string, unknown>>
+      | undefined;
     cursor = props?.[segment];
   }
   return cursor;
@@ -95,34 +105,15 @@ describe("createCronToolSchema", () => {
     expect(findLlamacppGbnfSchemaViolations(llamacppSchemaRecord, "cron.parameters")).toEqual([]);
   });
 
-  it("patch exposes the expected top-level fields", () => {
-    expect(keysAt(schemaRecord, "patch")).toEqual(
-      [
-        "agentId",
-        "deleteAfterRun",
-        "delivery",
-        "description",
-        "displayName",
-        "enabled",
-        "failureAlert",
-        "name",
-        "pacing",
-        "payload",
-        "schedule",
-        "sessionKey",
-        "sessionTarget",
-        "trigger",
-        "wakeMode",
-      ].toSorted(),
-    );
+  it("does not ship a separate patch object schema (#121606)", () => {
+    expect(schemaRecord.properties).not.toHaveProperty("patch");
   });
 
   it("exposes next_check with its relative duration parameter", () => {
     expect(Value.Check(schema, { action: "next_check", in: "15m" })).toBe(true);
     expect(propertyAt(schemaRecord, "in")?.description).toContain("next_check");
-    expect(keysAt(schemaRecord, "job.pacing")).toEqual(["max", "min"]);
-    const patchPacing = propertyAt(schemaRecord, "patch.pacing");
-    const pacingObject = (patchPacing?.anyOf as Array<Record<string, unknown>> | undefined)?.find(
+    const jobPacing = propertyAt(schemaRecord, "job.pacing");
+    const pacingObject = (jobPacing?.anyOf as Array<Record<string, unknown>> | undefined)?.find(
       (entry) => entry.type === "object",
     );
     expect(
@@ -181,82 +172,67 @@ describe("createCronToolSchema", () => {
     expect(propertyAt(schemaRecord, "mode")?.description).toBe(
       'Wake mode for action="wake" (default next-heartbeat)',
     );
-    for (const path of ["job.sessionTarget", "patch.sessionTarget"]) {
-      expect(propertyAt(schemaRecord, path)?.description).toBe(
-        "main | isolated | current (agentTurn default) | session:<id>",
-      );
-    }
-    for (const path of ["job.payload", "patch.payload"]) {
-      expect(propertyAt(schemaRecord, `${path}.lightContext`)?.description).toBe(
-        "Lightweight bootstrap context (skip full workspace context)",
-      );
-      expect(propertyAt(schemaRecord, `${path}.allowUnsafeExternalContent`)?.description).toBe(
-        "Allow untrusted external content in prompt",
-      );
-    }
+    expect(propertyAt(schemaRecord, "job.sessionTarget")?.description).toBe(
+      "main | isolated | current (agentTurn default) | session:<id>",
+    );
+    expect(propertyAt(schemaRecord, "job.payload.lightContext")?.description).toBe(
+      "Lightweight bootstrap context (skip full workspace context)",
+    );
+    expect(propertyAt(schemaRecord, "job.payload.allowUnsafeExternalContent")?.description).toBe(
+      "Allow untrusted external content in prompt",
+    );
   });
 
-  it("marks staggerMs as cron-only in both job and patch schedule schemas", () => {
-    const jobStagger = propertyAt(schemaRecord, "job.schedule.staggerMs");
-    const patchStagger = propertyAt(schemaRecord, "patch.schedule.staggerMs");
-
-    expect(jobStagger?.description).toBe("Jitter ms (kind=cron)");
-    expect(patchStagger?.description).toBe("Jitter ms (kind=cron)");
+  it("marks staggerMs as cron-only in the job schedule schema", () => {
+    expect(propertyAt(schemaRecord, "job.schedule.staggerMs")?.description).toBe(
+      "Jitter ms (kind=cron)",
+    );
   });
 
   it("advertises numeric cron params with runtime bounds", () => {
-    for (const path of ["job.schedule.everyMs", "patch.schedule.everyMs"]) {
-      expect(propertyAt(schemaRecord, path)).toMatchObject({
-        type: "integer",
-        minimum: 1,
-        maximum: MAX_DATE_TIMESTAMP_MS,
-      });
-    }
-    for (const path of ["job.schedule.anchorMs", "patch.schedule.anchorMs"]) {
-      expect(propertyAt(schemaRecord, path)).toMatchObject({
-        type: "integer",
-        minimum: 0,
-        maximum: MAX_DATE_TIMESTAMP_MS,
-      });
-    }
-    for (const path of ["job.schedule.staggerMs", "patch.schedule.staggerMs"]) {
-      expect(propertyAt(schemaRecord, path)).toMatchObject({
-        type: "integer",
-        minimum: 0,
-        maximum: MAX_DATE_TIMESTAMP_MS,
-      });
-    }
-    for (const path of ["job.failureAlert.cooldownMs", "patch.failureAlert.cooldownMs"]) {
-      expect(propertyAt(schemaRecord, path)).toMatchObject({ type: "integer", minimum: 0 });
-    }
-    for (const path of ["job.failureAlert.after", "patch.failureAlert.after"]) {
-      expect(propertyAt(schemaRecord, path)).toMatchObject({ type: "integer", minimum: 1 });
-    }
-    for (const path of ["job.payload.timeoutSeconds", "patch.payload.timeoutSeconds"]) {
-      expect(propertyAt(schemaRecord, path)).toMatchObject({ type: "number", minimum: 0 });
-    }
+    expect(propertyAt(schemaRecord, "job.schedule.everyMs")).toMatchObject({
+      type: "integer",
+      minimum: 1,
+      maximum: MAX_DATE_TIMESTAMP_MS,
+    });
+    expect(propertyAt(schemaRecord, "job.schedule.anchorMs")).toMatchObject({
+      type: "integer",
+      minimum: 0,
+      maximum: MAX_DATE_TIMESTAMP_MS,
+    });
+    expect(propertyAt(schemaRecord, "job.schedule.staggerMs")).toMatchObject({
+      type: "integer",
+      minimum: 0,
+      maximum: MAX_DATE_TIMESTAMP_MS,
+    });
+    expect(propertyAt(schemaRecord, "job.failureAlert.cooldownMs")).toMatchObject({
+      type: "integer",
+      minimum: 0,
+    });
+    expect(propertyAt(schemaRecord, "job.failureAlert.after")).toMatchObject({
+      type: "integer",
+      minimum: 1,
+    });
+    expect(propertyAt(schemaRecord, "job.payload.timeoutSeconds")).toMatchObject({
+      type: "number",
+      minimum: 0,
+    });
   });
 
   it("describes cron expressions as local wall-clock time in the supplied timezone", () => {
     // Cron expressions are interpreted by the gateway scheduler; model-facing
     // docs must not encourage UTC conversion by the agent.
     const jobExpr = propertyAt(schemaRecord, "job.schedule.expr");
-    const patchExpr = propertyAt(schemaRecord, "patch.schedule.expr");
     const jobTz = propertyAt(schemaRecord, "job.schedule.tz");
-    const patchTz = propertyAt(schemaRecord, "patch.schedule.tz");
 
-    for (const prop of [jobExpr, patchExpr]) {
-      expect(prop?.description).toMatch(/wall-time/i);
-      expect(prop?.description).toMatch(/never UTC-convert/i);
-      expect(prop?.description).toContain("Gateway local");
-      expect(prop?.description).toContain("0 18 * * *");
-      expect(prop?.description).toContain("Asia/Shanghai");
-    }
-    for (const prop of [jobTz, patchTz]) {
-      expect(prop?.description).toMatch(/wall-clock fields/i);
-      expect(prop?.description).toContain("Gateway host local timezone");
-      expect(prop?.description).toContain("Asia/Shanghai");
-    }
+    expect(jobExpr?.description).toMatch(/wall-time/i);
+    expect(jobExpr?.description).toMatch(/never UTC-convert/i);
+    expect(jobExpr?.description).toContain("Gateway local");
+    expect(jobExpr?.description).toContain("0 18 * * *");
+    expect(jobExpr?.description).toContain("Asia/Shanghai");
+    expect(jobTz?.description).toMatch(/wall-clock fields/i);
+    expect(jobTz?.description).toContain("Gateway host local timezone");
+    expect(jobTz?.description).toContain("Asia/Shanghai");
   });
 
   it("job.delivery exposes all supported delivery destinations", () => {
@@ -273,21 +249,15 @@ describe("createCronToolSchema", () => {
       ].toSorted(),
     );
     const jobCompletion = propertyAt(schemaRecord, "job.delivery.completionDestination");
-    expect(keysAt(schemaRecord, "job.delivery.completionDestination")).toEqual(["mode", "to"]);
-    expect(jobCompletion?.required).toEqual(["mode", "to"]);
-    expect(propertyAt(schemaRecord, "job.delivery.completionDestination.to")).toMatchObject({
-      type: "string",
-      minLength: 1,
-    });
-    const patchCompletion = propertyAt(schemaRecord, "patch.delivery.completionDestination");
-    const patchCompletionObject = (
-      patchCompletion?.anyOf as Array<Record<string, unknown>> | undefined
+    const jobCompletionObject = (
+      jobCompletion?.anyOf as Array<Record<string, unknown>> | undefined
     )?.find((entry) => entry.type === "object");
     expect(
       Object.keys(
-        (patchCompletionObject?.properties as Record<string, unknown> | undefined) ?? {},
+        (jobCompletionObject?.properties as Record<string, unknown> | undefined) ?? {},
       ).toSorted(),
     ).toEqual(["mode", "to"]);
+    expect(jobCompletionObject?.required).toEqual(["mode", "to"]);
     expect(
       Value.Check(schema, {
         action: "add",
@@ -301,15 +271,16 @@ describe("createCronToolSchema", () => {
         },
       }),
     ).toBe(true);
+    // Null is schema-valid (shared update shape); the add path strips it before
+    // the strict gateway create contract.
     expect(
       Value.Check(schema, {
         action: "update",
         id: "job-1",
-        patch: { delivery: { completionDestination: null } },
+        job: { delivery: { completionDestination: null } },
       }),
     ).toBe(true);
     for (const completionDestination of [
-      null,
       {},
       { mode: "webhook" },
       { to: "https://example.invalid/done" },
@@ -328,25 +299,15 @@ describe("createCronToolSchema", () => {
         }),
       ).toBe(false);
     }
-    for (const providerSchema of [
-      providerSchemaRecord,
-      jjccGeminiSchemaRecord,
-      llamacppSchemaRecord,
-    ]) {
-      expect(propertyAt(providerSchema, "job.delivery.completionDestination")).toMatchObject({
-        type: "object",
-        required: ["mode", "to"],
-      });
-    }
     for (const providerSchema of [providerSchemaRecord, jjccGeminiSchemaRecord]) {
-      expect(propertyAt(providerSchema, "patch.delivery.completionDestination")).toMatchObject({
+      expect(propertyAt(providerSchema, "job.delivery.completionDestination")).toMatchObject({
         type: "object",
         required: ["mode", "to"],
         description: expect.stringContaining("null clears"),
       });
     }
     expect(
-      propertyAt(llamacppSchemaRecord, "patch.delivery.completionDestination")?.anyOf,
+      propertyAt(llamacppSchemaRecord, "job.delivery.completionDestination")?.anyOf,
     ).toContainEqual({ type: "null" });
   });
 
@@ -373,26 +334,7 @@ describe("createCronToolSchema", () => {
     expect(keysAt(schemaRecord, "job.payload")).toContain("fallbacks");
   });
 
-  it("patch.payload exposes agentTurn fallback overrides", () => {
-    expect(keysAt(schemaRecord, "patch.payload")).toEqual(
-      [
-        "allowUnsafeExternalContent",
-        "fallbacks",
-        "kind",
-        "lightContext",
-        "message",
-        "model",
-        "script",
-        "text",
-        "thinking",
-        "toolBudget",
-        "toolsAllow",
-        "timeoutSeconds",
-      ].toSorted(),
-    );
-  });
-
-  it("accepts script payloads in create and patch schemas", () => {
+  it("accepts script payloads in create and update calls", () => {
     expect(
       Value.Check(schema, {
         action: "add",
@@ -414,7 +356,7 @@ describe("createCronToolSchema", () => {
       Value.Check(schema, {
         action: "update",
         id: "job-1",
-        patch: { payload: { kind: "script", toolBudget: 75 } },
+        job: { payload: { kind: "script", toolBudget: 75 } },
       }),
     ).toBe(true);
   });
@@ -440,12 +382,12 @@ describe("createCronToolSchema", () => {
     expect(failureAlertSchema?.description).toMatch(/false/i);
   });
 
-  it("accepts nullable cron patch clears in the runtime schema", () => {
+  it("accepts nullable cron update clears in the runtime schema", () => {
     expect(
       Value.Check(schema, {
         action: "update",
         jobId: "job-1",
-        patch: {
+        job: {
           agentId: null,
           displayName: null,
           sessionKey: null,
@@ -457,12 +399,12 @@ describe("createCronToolSchema", () => {
     ).toBe(true);
   });
 
-  it("accepts payload.model and payload.fallbacks null in patch (clear-to-inherit)", () => {
+  it("accepts payload.model and payload.fallbacks null in updates (clear-to-inherit)", () => {
     expect(
       Value.Check(schema, {
         action: "update",
         jobId: "job-1",
-        patch: {
+        job: {
           payload: {
             model: null,
             fallbacks: null,
@@ -483,25 +425,25 @@ describe("createCronToolSchema", () => {
     // Provider projection must be plain "string" rather than a nullable union.
     // The raw runtime schema remains nullable so local validation accepts clears.
     expect(jobProps?.agentId?.type).toBe("string");
-    expect(jobProps?.agentId?.description).toMatch(/null to keep it unset/i);
+    expect(jobProps?.agentId?.description).toMatch(/null to clear it/i);
     expect(jobProps?.sessionKey?.type).toBe("string");
     expect(jobProps?.sessionKey?.description).toMatch(/null to clear it/i);
   });
 
-  it("patch.payload.toolsAllow projects to plain array type for OpenAPI 3.0 compat", () => {
+  it("job.payload.toolsAllow projects to plain array type for OpenAPI 3.0 compat", () => {
     const root = providerSchemaRecord.properties as
       | Record<string, { properties?: Record<string, unknown> }>
       | undefined;
-    const patchProps = root?.patch?.properties as
+    const jobProps = root?.job?.properties as
       | Record<string, { properties?: Record<string, { type?: unknown; description?: string }> }>
       | undefined;
 
     // Provider-facing schemas must be plain "array" rather than JSON Schema
     // unions so OpenAPI 3.0 subset validators accept them.
-    expect(patchProps?.payload?.properties?.toolsAllow?.type).toBe("array");
-    expect(patchProps?.payload?.properties?.toolsAllow?.description).toMatch(/null to clear/i);
-    expect(patchProps?.payload?.properties?.model?.type).toBe("string");
-    expect(patchProps?.payload?.properties?.model?.description).toMatch(/null to clear/i);
+    expect(jobProps?.payload?.properties?.toolsAllow?.type).toBe("array");
+    expect(jobProps?.payload?.properties?.toolsAllow?.description).toMatch(/null to clear/i);
+    expect(jobProps?.payload?.properties?.model?.type).toBe("string");
+    expect(jobProps?.payload?.properties?.model?.description).toMatch(/null to clear/i);
   });
 
   it("projects nullable cron fields for Gemini models behind OpenAI-compatible providers", () => {
@@ -511,10 +453,10 @@ describe("createCronToolSchema", () => {
     expect(propertyAt(jjccGeminiSchemaRecord, "job.sessionKey")).toMatchObject({
       type: "string",
     });
-    expect(propertyAt(jjccGeminiSchemaRecord, "patch.payload.toolsAllow")).toMatchObject({
+    expect(propertyAt(jjccGeminiSchemaRecord, "job.payload.toolsAllow")).toMatchObject({
       type: "array",
     });
-    expect(propertyAt(jjccGeminiSchemaRecord, "patch.delivery.channel")).toMatchObject({
+    expect(propertyAt(jjccGeminiSchemaRecord, "job.delivery.channel")).toMatchObject({
       type: "string",
     });
     expect(JSON.stringify(jjccGeminiSchemaRecord)).not.toContain('"anyOf"');

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -596,7 +596,7 @@ describe("cron tool", () => {
 
   it.each([
     ["add", { action: "add", job: buildReminderAgentTurnJob() }],
-    ["update", { action: "update", jobId: "job-current", patch: { enabled: false } }],
+    ["update", { action: "update", jobId: "job-current", job: { enabled: false } }],
     ["run", { action: "run", jobId: "job-current" }],
     ["wake", { action: "wake", text: "wake up" }],
   ])("denies scoped isolated cron runs from using %s", async (_action, args) => {
@@ -956,40 +956,29 @@ describe("cron tool", () => {
     const tool = createTestCronTool();
     const parameters = tool.parameters as SchemaLike;
     const jobThreadId = parameters.properties?.job?.properties?.delivery?.properties?.threadId;
-    const patchThreadId = parameters.properties?.patch?.properties?.delivery?.properties?.threadId;
 
     expect(jobThreadId?.description).toContain("Thread/topic id");
-    expect(jobThreadId?.anyOf?.map((entry) => entry.type)).toEqual(["string", "number"]);
-    expect(patchThreadId?.description).toContain("Thread/topic id");
-    expect(patchThreadId?.anyOf?.map((entry) => entry.type)).toEqual(["string", "number", "null"]);
+    expect(jobThreadId?.anyOf?.map((entry) => entry.type)).toEqual(["string", "number", "null"]);
   });
 
-  it("advertises nullable cron update clears in the tool schema", () => {
+  it("advertises nullable cron update clears in the shared job schema", () => {
     const tool = createTestCronTool();
     const parameters = tool.parameters as SchemaLike;
-    const jobDelivery = parameters.properties?.job?.properties?.delivery;
-    const patch = parameters.properties?.patch;
-    const payload = patch?.properties?.payload;
-    const delivery = patch?.properties?.delivery;
-    const jobPacing = parameters.properties?.job?.properties?.pacing;
-    const patchPacing = patch?.properties?.pacing?.anyOf?.find((entry) => entry.type === "object");
+    const job = parameters.properties?.job;
+    const payload = job?.properties?.payload;
+    const delivery = job?.properties?.delivery;
+    const jobPacing = job?.properties?.pacing?.anyOf?.find((entry) => entry.type === "object");
 
-    expect(jobDelivery?.properties?.channel?.anyOf).toBeUndefined();
-    expect(jobDelivery?.properties?.channel?.type).toBe("string");
-    expect(jobDelivery?.properties?.failureDestination?.anyOf).toBeUndefined();
-    expect(jobDelivery?.properties?.failureDestination?.type).toBe("object");
-    expect(patch?.properties?.agentId?.anyOf?.map((entry) => entry.type)).toEqual([
+    expect(parameters.properties?.patch).toBeUndefined();
+    expect(job?.properties?.agentId?.anyOf?.map((entry) => entry.type)).toEqual(["string", "null"]);
+    expect(job?.properties?.agentId?.type).toBeUndefined();
+    expect(job?.properties?.agentId?.description).toContain("null to clear");
+    expect(job?.properties?.sessionKey?.anyOf?.map((entry) => entry.type)).toEqual([
       "string",
       "null",
     ]);
-    expect(patch?.properties?.agentId?.type).toBeUndefined();
-    expect(patch?.properties?.agentId?.description).toContain("null to clear");
-    expect(patch?.properties?.sessionKey?.anyOf?.map((entry) => entry.type)).toEqual([
-      "string",
-      "null",
-    ]);
-    expect(patch?.properties?.sessionKey?.type).toBeUndefined();
-    expect(patch?.properties?.sessionKey?.description).toContain("null to clear");
+    expect(job?.properties?.sessionKey?.type).toBeUndefined();
+    expect(job?.properties?.sessionKey?.description).toContain("null to clear");
     expect(payload?.properties?.toolsAllow?.anyOf?.map((entry) => entry.type)).toEqual([
       "array",
       "null",
@@ -1007,18 +996,17 @@ describe("cron tool", () => {
       "null",
     ]);
     expect(jobPacing?.description).toContain("at least one of min or max is required");
-    expect(patchPacing?.description).toContain("at least one of min or max is required");
   });
 
   it.each([
     [
       "update",
-      { action: "update", jobId: "job-1", patch: { foo: "bar" } },
+      { action: "update", jobId: "job-1", job: { foo: "bar" } },
       { id: "job-1", patch: { foo: "bar" } },
     ],
     [
       "update",
-      { action: "update", id: "job-2", patch: { foo: "bar" } },
+      { action: "update", id: "job-2", job: { foo: "bar" } },
       { id: "job-2", patch: { foo: "bar" } },
     ],
     ["remove", { action: "remove", jobId: "job-1" }, { id: "job-1" }],
@@ -1173,7 +1161,7 @@ describe("cron tool", () => {
       tool.execute("call-blank-display-update", {
         action: "update",
         jobId: "daily",
-        patch: { displayName: "   " },
+        job: { displayName: "   " },
       }),
     ).rejects.toThrow("displayName must be a non-empty string or null");
     expect(callGatewayMock).not.toHaveBeenCalled();
@@ -1192,7 +1180,7 @@ describe("cron tool", () => {
       {
         action: "update",
         jobId: "paced-job",
-        patch: { pacing: {} },
+        job: { pacing: {} },
       },
     ],
   ])("rejects empty pacing on cron.%s before calling the gateway", async (_action, args) => {
@@ -1967,7 +1955,7 @@ describe("cron tool", () => {
     await tool.execute("call-capped-trigger-system-event-update", {
       action: "update",
       id: "job-trigger",
-      patch: { trigger: { script: "return { fire: false }" } },
+      job: { trigger: { script: "return { fire: false }" } },
     });
 
     expect(readGatewayCall(1)).toEqual({
@@ -1997,7 +1985,7 @@ describe("cron tool", () => {
     await tool.execute("call-capped-dormant-system-event-update", {
       action: "update",
       id: "job-dormant",
-      patch: {
+      job: {
         payload: { kind: "systemEvent", toolsAllow: ["read", "exec"] },
       },
     });
@@ -2335,6 +2323,38 @@ describe("cron tool", () => {
     ).rejects.toThrow("automation agentId must match the calling agent");
 
     expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("strips null clears from add jobs before the strict gateway create contract (#121606)", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+    const tool = createTestCronTool();
+
+    await tool.execute("call-add-null-clears", {
+      action: "add",
+      job: {
+        ...buildReminderAgentTurnJob(),
+        displayName: null,
+        pacing: null,
+        trigger: null,
+        sessionKey: null,
+        payload: { kind: "agentTurn", message: "hello", model: null, fallbacks: null },
+        delivery: { mode: "announce", channel: null, failureDestination: null },
+      },
+    });
+
+    const call = readGatewayCall();
+    expect(call.method).toBe("cron.add");
+    const params = call.params as Record<string, unknown>;
+    expect(params).not.toHaveProperty("displayName");
+    expect(params).not.toHaveProperty("pacing");
+    expect(params).not.toHaveProperty("trigger");
+    // Null sessionKey stays: cron.add accepts it and it suppresses default
+    // creator-session binding.
+    expect(params.sessionKey).toBeNull();
+    expect(params.payload).not.toHaveProperty("model");
+    expect(params.payload).not.toHaveProperty("fallbacks");
+    expect(params.delivery).not.toHaveProperty("channel");
+    expect(params.delivery).not.toHaveProperty("failureDestination");
   });
 
   it("does not infer delivery from raw session-key fragments without delivery context", async () => {
@@ -2842,7 +2862,7 @@ describe("cron tool", () => {
       tool.execute("call-blank-delivery-update", {
         action: "update",
         id: "job-blank-delivery",
-        patch: { delivery },
+        job: { delivery },
       }),
     ).rejects.toThrow(`${field} must be a non-empty string`);
     expect(callGatewayMock).not.toHaveBeenCalled();
@@ -2853,7 +2873,7 @@ describe("cron tool", () => {
     await tool.execute("call-null-delivery-update", {
       action: "update",
       id: "job-clear-delivery",
-      patch: {
+      job: {
         delivery: {
           channel: null,
           to: null,
@@ -2888,7 +2908,7 @@ describe("cron tool", () => {
       tool.execute("call-update-agent-id", {
         action: "update",
         id: "job-1",
-        patch: { agentId: "worker" },
+        job: { agentId: "worker" },
       }),
     ).rejects.toThrow("automation patch agentId cannot be changed");
     expect(callGatewayMock).not.toHaveBeenCalled();
@@ -2901,7 +2921,7 @@ describe("cron tool", () => {
     await tool.execute("call-unscoped-update-agent-id", {
       action: "update",
       id: "job-1",
-      patch: { agentId: "worker" },
+      job: { agentId: "worker" },
     });
 
     const params = expectSingleGatewayCallMethod("cron.update") as
@@ -2922,7 +2942,7 @@ describe("cron tool", () => {
       tool.execute("call-update-session-target", {
         action: "update",
         id: "job-1",
-        patch: { sessionTarget: "session:agent:worker:telegram:direct:alice" },
+        job: { sessionTarget: "session:agent:worker:telegram:direct:alice" },
       }),
     ).rejects.toThrow("automations sessionTarget must match the calling agent");
     expect(callGatewayMock).not.toHaveBeenCalled();
@@ -2959,7 +2979,7 @@ describe("cron tool", () => {
     await tool.execute("call-update-disable-alerts", {
       action: "update",
       id: "job-4",
-      patch: { failureAlert: false },
+      job: { failureAlert: false },
     });
 
     const params = expectSingleGatewayCallMethod("cron.update") as
@@ -2979,7 +2999,7 @@ describe("cron tool", () => {
       tool.execute("call-command-update", {
         action: "update",
         id: "job-4",
-        patch: {
+        job: {
           payload: { kind, argv: ["sh", "-lc", "echo ok"] },
         },
       }),
@@ -2999,7 +3019,7 @@ describe("cron tool", () => {
       tool.execute("call-kindless-command-update", {
         action: "update",
         id: "job-command",
-        patch: {
+        job: {
           payload: { argv: ["sh", "-lc", "echo bypass"] },
         },
       }),
@@ -3019,7 +3039,7 @@ describe("cron tool", () => {
     await tool.execute("call-command-disable", {
       action: "update",
       id: "job-command",
-      patch: { enabled: false },
+      job: { enabled: false },
     });
 
     expect(callGatewayMock).toHaveBeenCalledTimes(1);
@@ -3039,7 +3059,7 @@ describe("cron tool", () => {
       tool.execute("call-on-exit-update", {
         action: "update",
         id: "job-4",
-        patch: {
+        job: {
           schedule: { kind: "on-exit", command: "make" },
         },
       }),
@@ -3159,7 +3179,7 @@ describe("cron tool", () => {
     await tool.execute("call-update-concatenated", {
       action: "update",
       id: "job-concat",
-      patch: {
+      job: {
         namePayload: { kind: "agentTurn", message: "Updated prompt.", timeoutSeconds: 20 },
         scheduleKind: { everyMs: 60_000, kind: "every" },
         sessionTargetName: "updated-name",
@@ -3245,7 +3265,7 @@ describe("cron tool", () => {
         id: "job-9",
         fallbacks: [123],
       }),
-    ).rejects.toThrow("patch required");
+    ).rejects.toThrow("job required");
     expect(callGatewayMock).toHaveBeenCalledTimes(0);
   });
 
@@ -3258,7 +3278,7 @@ describe("cron tool", () => {
         id: "job-10",
         toolsAllow: [123],
       }),
-    ).rejects.toThrow("patch required");
+    ).rejects.toThrow("job required");
     expect(callGatewayMock).toHaveBeenCalledTimes(0);
   });
 
@@ -3269,7 +3289,7 @@ describe("cron tool", () => {
     await tool.execute("call-update-nested-fallbacks-only", {
       action: "update",
       id: "job-6",
-      patch: {
+      job: {
         payload: {
           fallbacks: [" openrouter/gpt-4.1-mini ", "anthropic/claude-haiku-3-5"],
         },
@@ -3306,7 +3326,7 @@ describe("cron tool", () => {
     await tool.execute("call-update-nested-tools-only", {
       action: "update",
       id: "job-7",
-      patch: {
+      job: {
         payload: {
           toolsAllow: [" exec ", " read "],
         },
@@ -3343,7 +3363,7 @@ describe("cron tool", () => {
     await tool.execute("call-update-clear-tools", {
       action: "update",
       id: "job-8",
-      patch: {
+      job: {
         payload: {
           toolsAllow: null,
         },
@@ -3380,7 +3400,7 @@ describe("cron tool", () => {
     await tool.execute("call-update-system-event-tools", {
       action: "update",
       id: "job-system-event",
-      patch: { payload: { toolsAllow: ["cron"] } },
+      job: { payload: { toolsAllow: ["cron"] } },
     });
 
     expect(readGatewayCall(1)).toEqual({
@@ -3408,7 +3428,7 @@ describe("cron tool", () => {
     await tool.execute("call-update-capped-tools", {
       action: "update",
       id: "job-7",
-      patch: {
+      job: {
         payload: {
           toolsAllow: [" exec ", " read "],
         },
@@ -3447,7 +3467,7 @@ describe("cron tool", () => {
     await tool.execute("call-update-capped-tools-clear", {
       action: "update",
       id: "job-8",
-      patch: {
+      job: {
         payload: {
           toolsAllow: null,
         },
@@ -3481,7 +3501,7 @@ describe("cron tool", () => {
     await tool.execute("call-update-capped-no-payload", {
       action: "update",
       id: "job-9",
-      patch: { enabled: false },
+      job: { enabled: false },
     });
 
     expect(callGatewayMock).toHaveBeenCalledTimes(1);
@@ -3518,7 +3538,7 @@ describe("cron tool", () => {
     await tool.execute("call-update-metadata-offline", {
       action: "update",
       id: "job-metadata",
-      patch: { payload: { kind: "agentTurn", message: "after" } },
+      job: { payload: { kind: "agentTurn", message: "after" } },
     });
 
     expect(resolveCreatorToolAuthority).not.toHaveBeenCalled();
@@ -3545,7 +3565,7 @@ describe("cron tool", () => {
     await tool.execute("call-update-finite-offline", {
       action: "update",
       id: "job-finite",
-      patch: { payload: { kind: "agentTurn", toolsAllow: ["read"] } },
+      job: { payload: { kind: "agentTurn", toolsAllow: ["read"] } },
     });
 
     expect(resolveCreatorToolAuthority).not.toHaveBeenCalled();
@@ -3597,7 +3617,7 @@ describe("cron tool", () => {
       {
         action: "update",
         id: "job-resolve-race",
-        patch: { payload: { toolsAllow: ["*"] } },
+        job: { payload: { toolsAllow: ["*"] } },
       },
       operation.signal,
     );
@@ -3653,7 +3673,7 @@ describe("cron tool", () => {
       tool.execute("call-update-no-caller-identity", {
         action: "update",
         id: "job-no-caller-identity",
-        patch: { payload: { toolsAllow: ["*"] } },
+        job: { payload: { toolsAllow: ["*"] } },
       }),
     ).rejects.toThrow("requires an authenticated local agent run");
     expect(callGatewayMock).toHaveBeenCalledOnce();
@@ -3676,7 +3696,7 @@ describe("cron tool", () => {
       tool.execute("call-queued-configured-mcp-update", {
         action: "update",
         id: "job-queued-authority",
-        patch: { payload: { toolsAllow: ["*"] } },
+        job: { payload: { toolsAllow: ["*"] } },
       }),
     ).rejects.toThrow("no automation changes were saved");
     expect(callGatewayMock).toHaveBeenCalledOnce();
@@ -3699,7 +3719,7 @@ describe("cron tool", () => {
       tool.execute("call-incomplete-authority-update", {
         action: "update",
         id: "job-incomplete-authority",
-        patch: { payload: { kind: "agentTurn", toolsAllow: ["future__tool"] } },
+        job: { payload: { kind: "agentTurn", toolsAllow: ["future__tool"] } },
       }),
     ).rejects.toThrow("fresh authenticated direct-local operator turn");
     expect(callGatewayMock).toHaveBeenCalledOnce();
@@ -3726,7 +3746,7 @@ describe("cron tool", () => {
       tool.execute("call-update-auth-failure", {
         action: "update",
         id: "job-auth-failure",
-        patch: { payload: { toolsAllow: ["*"] } },
+        job: { payload: { toolsAllow: ["*"] } },
       }),
     ).rejects.toThrow("no automation changes were saved");
     expect(callGatewayMock).toHaveBeenCalledOnce();
@@ -3743,7 +3763,7 @@ describe("cron tool", () => {
     await tool.execute("call-update-preserve-existing-tools", {
       action: "update",
       id: "job-10",
-      patch: { enabled: false },
+      job: { enabled: false },
     });
 
     expect(callGatewayMock).toHaveBeenCalledTimes(1);
@@ -3788,7 +3808,7 @@ describe("cron tool", () => {
     await tool.execute("call-update-retry-cap-race", {
       action: "update",
       id: "job-race",
-      patch: { payload: { message: "updated" } },
+      job: { payload: { message: "updated" } },
     });
 
     expect(callGatewayMock).toHaveBeenCalledTimes(4);
@@ -3822,7 +3842,7 @@ describe("cron tool", () => {
       tool.execute("call-update-no-revision", {
         action: "update",
         id: "job-no-revision",
-        patch: { payload: { message: "updated" } },
+        job: { payload: { message: "updated" } },
       }),
     ).rejects.toThrow("cron.get response is missing configRevision");
     expect(callGatewayMock).toHaveBeenCalledTimes(1);
@@ -3843,7 +3863,7 @@ describe("cron tool", () => {
     await tool.execute("call-update-preserve-existing-payload-tools", {
       action: "update",
       id: "job-11",
-      patch: {
+      job: {
         payload: { model: "openai/gpt-5.5" },
       },
     });
@@ -3874,7 +3894,7 @@ describe("cron tool", () => {
     await tool.execute("call-update-preserve-default-flag", {
       action: "update",
       id: "job-13",
-      patch: { enabled: false },
+      job: { enabled: false },
     });
 
     expect(callGatewayMock).toHaveBeenCalledTimes(1);
@@ -3902,7 +3922,7 @@ describe("cron tool", () => {
     await tool.execute("call-update-convert-capped-agent-turn", {
       action: "update",
       id: "job-12",
-      patch: {
+      job: {
         sessionTarget: "isolated",
         payload: { kind: "agentTurn", message: "run later" },
       },
@@ -3934,7 +3954,7 @@ describe("cron tool", () => {
     await tool.execute("call-update-clear-model", {
       action: "update",
       id: "job-9",
-      patch: {
+      job: {
         payload: {
           model: null,
         },

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -37,6 +37,7 @@ import {
   hasCronCreateSignal,
   isEmptyRecoveredCronPatch,
   recoverCronObjectFromFlatParams,
+  stripCronCreateNullClears,
 } from "./cron-tool-canonicalize.js";
 import {
   buildReminderContextLines,
@@ -173,7 +174,7 @@ export function createCronTool(opts?: CronToolOptions, deps?: CronToolDeps): Any
     displaySummary: CRON_TOOL_DISPLAY_SUMMARY,
     description: `Gateway scheduler: reminders, delayed self-wakeups, loops, recurring work, event watchers. Never exec sleep/poll as timer.
 
-ACTIONS: status | list [includeDisabled,limit?,offset?] (use nextOffset for the next page) | get jobId | add job | update jobId patch | remove jobId | run jobId (runMode "force"=now) | runs jobId = history | next_check in:"30m" (own paced run only) | wake text mode?:"now"|"next-heartbeat"(default) nudges a caller-owned lane (sessionKey/agentId to pick another).
+ACTIONS: status | list [includeDisabled,limit?,offset?] (use nextOffset for the next page) | get jobId | add job | update jobId job (partial: only supplied fields change; null clears) | remove jobId | run jobId (runMode "force"=now) | runs jobId = history | next_check in:"30m" (own paced run only) | wake text mode?:"now"|"next-heartbeat"(default) nudges a caller-owned lane (sessionKey/agentId to pick another).
 
 ADD: {name?,schedule,payload,sessionTarget?,pacing?,trigger?,delivery?,enabled?}. Required: schedule+payload.
 
@@ -321,10 +322,12 @@ Job wakeMode (main jobs): "now"(default)|"next-heartbeat". Restricted automation
             if (!params.job || typeof params.job !== "object") {
               throw new Error("job required");
             }
-            const canonicalJob = canonicalizeCronToolObject(params.job as Record<string, unknown>);
+            const canonicalJob = stripCronCreateNullClears(
+              canonicalizeCronToolObject(params.job as Record<string, unknown>),
+            );
             assertNoCronShellExecution(canonicalJob);
             assertCronDeliveryInputNonBlankFields(canonicalJob.delivery);
-            assertCronPacingInput(canonicalJob.pacing, { nullableClears: false });
+            assertCronPacingInput(canonicalJob.pacing);
             if (
               typeof canonicalJob.declarationKey === "string" &&
               canonicalJob.declarationKey.trim().length === 0
@@ -491,25 +494,25 @@ Job wakeMode (main jobs): "now"(default)|"next-heartbeat". Restricted automation
               throw new Error("jobId required (id accepted for backward compatibility)");
             }
 
-            // Flat-params recovery for patch
+            // Flat-params recovery for update patches
             let recoveredFlatPatch = false;
-            if (isMissingOrEmptyObject(params.patch)) {
+            if (isMissingOrEmptyObject(params.job)) {
               const synthetic = recoverCronObjectFromFlatParams(params);
               if (synthetic.found) {
-                params.patch = synthetic.value;
+                params.job = synthetic.value;
                 recoveredFlatPatch = true;
               }
             }
 
-            if (!params.patch || typeof params.patch !== "object") {
-              throw new Error("patch required");
+            if (!params.job || typeof params.job !== "object") {
+              throw new Error("job required");
             }
             const canonicalPatch = canonicalizeCronToolObject(
-              params.patch as Record<string, unknown>,
+              params.job as Record<string, unknown>,
             );
             assertNoCronShellExecution(canonicalPatch);
             assertCronDeliveryInputNonBlankFields(canonicalPatch.delivery);
-            assertCronPacingInput(canonicalPatch.pacing, { nullableClears: true });
+            assertCronPacingInput(canonicalPatch.pacing);
             if (
               typeof canonicalPatch.displayName === "string" &&
               canonicalPatch.displayName.trim().length === 0
@@ -518,7 +521,7 @@ Job wakeMode (main jobs): "now"(default)|"next-heartbeat". Restricted automation
             }
             const patch = normalizeCronJobPatch(canonicalPatch) ?? canonicalPatch;
             if (recoveredFlatPatch && isEmptyRecoveredCronPatch(patch)) {
-              throw new Error("patch required");
+              throw new Error("job required");
             }
             if (callerScope && "agentId" in patch) {
               throw new Error("automation patch agentId cannot be changed by the automations tool");

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -261,7 +261,7 @@
     "tools": [
       {
         "deferLoading": true,
-        "description": "Gateway scheduler: reminders, delayed self-wakeups, loops, recurring work, event watchers. Never exec sleep/poll as timer.\n\nACTIONS: status | list [includeDisabled,limit?,offset?] (use nextOffset for the next page) | get jobId | add job | update jobId patch | remove jobId | run jobId (runMode \"force\"=now) | runs jobId = history | next_check in:\"30m\" (own paced run only) | wake text mode?:\"now\"|\"next-heartbeat\"(default) nudges a caller-owned lane (sessionKey/agentId to pick another).\n\nADD: {name?,schedule,payload,sessionTarget?,pacing?,trigger?,delivery?,enabled?}. Required: schedule+payload.\n\nSCHEDULE:\n- {kind:\"at\",at:\"ISO-8601\"} one-shot; no tz=UTC; auto-deletes after run.\n- {kind:\"every\",everyMs}.\n- {kind:\"cron\",expr,tz?:\"IANA\"}: expr is wall time in tz; never pre-convert to UTC; no tz=gateway host local. 18:00 Shanghai => {expr:\"0 18 * * *\",tz:\"Asia/Shanghai\"}.\n- {kind:\"stream\",command:[argv],mode?:\"line\"|\"match\",match?}: fires on supervised process output; needs cron.triggers.enabled.\n\nTARGET+PAYLOAD:\n- \"current\" (agentTurn default) = this conversation: run carries this chat's context, result lands here. Self-wakeup/\"continue later\"/loop = at|every + agentTurn + current.\n- \"isolated\" = fresh detached session (shows in `openclaw tasks`); standalone background work.\n- \"main\" = heartbeat lane; payload {kind:\"systemEvent\",text} (systemEvent default target).\n- \"session:<key>\" = named session.\n- agentTurn {kind:\"agentTurn\",message,model?,thinking?,timeoutSeconds?}; timeoutSeconds 0=none.\n- Inherited configured MCP authority includes only model-callable tools; interactive app-view-only capabilities are excluded from headless jobs.\n- script {kind:\"script\",script,timeoutSeconds?,toolBudget?}: main|isolated only; needs cron.triggers.enabled.\n\nPACED LOOP: recurring job + pacing{min?,max?} durations (\"15m\",\"4h\"; at least one). Inside its run, job calls next_check in:\"<dur>\" to set the next delay (clamped to bounds, measured from run end; failed runs keep normal backoff). Adaptive polling: tighten when active, back off when quiet.\n\nTRIGGER (condition watcher on every/cron): {script,once?}; needs cron.triggers.enabled — if off, say so; never model-poll instead. Quiet headless check, no model; 30s/5 tool calls/16KB state. Read frozen trigger.state, return json({fire,message?,state?}) with NEW state; dedupe via state, never memory. fire:false saves state only. fire:true runs payload; message is that run's entire context — self-contained. Fire on failures/timeouts too; success-only watchers look healthy when broken. Script stays read-only; actions belong in payload. once:true disables after first fire. Code Mode: await tools.call(\"exec\",{command:\"...\"}).\n\nDELIVERY {mode:\"none\"|\"announce\"|\"webhook\",channel?,to?,threadId?,bestEffort?,completionDestination?}: where detached run output goes. Omitted=announce (current=>this chat; isolated=>last route; set channel/to for a specific chat — no messaging tool inside the run). Silent watcher=>mode:\"none\". webhook posts finished-run event to URL in `to`. To keep announce delivery and also POST completion, use mode:\"announce\" with completionDestination:{mode:\"webhook\",to:\"https://...\"}.\n\nJob wakeMode (main jobs): \"now\"(default)|\"next-heartbeat\". Restricted automation-run sessions: self status/list/get/runs/remove + own next_check only. failureAlert {...}|false disables. jobId canonical (id=compat). contextMessages 0-10 embeds recent chat lines into reminder text.",
+        "description": "Gateway scheduler: reminders, delayed self-wakeups, loops, recurring work, event watchers. Never exec sleep/poll as timer.\n\nACTIONS: status | list [includeDisabled,limit?,offset?] (use nextOffset for the next page) | get jobId | add job | update jobId job (partial: only supplied fields change; null clears) | remove jobId | run jobId (runMode \"force\"=now) | runs jobId = history | next_check in:\"30m\" (own paced run only) | wake text mode?:\"now\"|\"next-heartbeat\"(default) nudges a caller-owned lane (sessionKey/agentId to pick another).\n\nADD: {name?,schedule,payload,sessionTarget?,pacing?,trigger?,delivery?,enabled?}. Required: schedule+payload.\n\nSCHEDULE:\n- {kind:\"at\",at:\"ISO-8601\"} one-shot; no tz=UTC; auto-deletes after run.\n- {kind:\"every\",everyMs}.\n- {kind:\"cron\",expr,tz?:\"IANA\"}: expr is wall time in tz; never pre-convert to UTC; no tz=gateway host local. 18:00 Shanghai => {expr:\"0 18 * * *\",tz:\"Asia/Shanghai\"}.\n- {kind:\"stream\",command:[argv],mode?:\"line\"|\"match\",match?}: fires on supervised process output; needs cron.triggers.enabled.\n\nTARGET+PAYLOAD:\n- \"current\" (agentTurn default) = this conversation: run carries this chat's context, result lands here. Self-wakeup/\"continue later\"/loop = at|every + agentTurn + current.\n- \"isolated\" = fresh detached session (shows in `openclaw tasks`); standalone background work.\n- \"main\" = heartbeat lane; payload {kind:\"systemEvent\",text} (systemEvent default target).\n- \"session:<key>\" = named session.\n- agentTurn {kind:\"agentTurn\",message,model?,thinking?,timeoutSeconds?}; timeoutSeconds 0=none.\n- Inherited configured MCP authority includes only model-callable tools; interactive app-view-only capabilities are excluded from headless jobs.\n- script {kind:\"script\",script,timeoutSeconds?,toolBudget?}: main|isolated only; needs cron.triggers.enabled.\n\nPACED LOOP: recurring job + pacing{min?,max?} durations (\"15m\",\"4h\"; at least one). Inside its run, job calls next_check in:\"<dur>\" to set the next delay (clamped to bounds, measured from run end; failed runs keep normal backoff). Adaptive polling: tighten when active, back off when quiet.\n\nTRIGGER (condition watcher on every/cron): {script,once?}; needs cron.triggers.enabled — if off, say so; never model-poll instead. Quiet headless check, no model; 30s/5 tool calls/16KB state. Read frozen trigger.state, return json({fire,message?,state?}) with NEW state; dedupe via state, never memory. fire:false saves state only. fire:true runs payload; message is that run's entire context — self-contained. Fire on failures/timeouts too; success-only watchers look healthy when broken. Script stays read-only; actions belong in payload. once:true disables after first fire. Code Mode: await tools.call(\"exec\",{command:\"...\"}).\n\nDELIVERY {mode:\"none\"|\"announce\"|\"webhook\",channel?,to?,threadId?,bestEffort?,completionDestination?}: where detached run output goes. Omitted=announce (current=>this chat; isolated=>last route; set channel/to for a specific chat — no messaging tool inside the run). Silent watcher=>mode:\"none\". webhook posts finished-run event to URL in `to`. To keep announce delivery and also POST completion, use mode:\"announce\" with completionDestination:{mode:\"webhook\",to:\"https://...\"}.\n\nJob wakeMode (main jobs): \"now\"(default)|\"next-heartbeat\". Restricted automation-run sessions: self status/list/get/runs/remove + own next_check only. failureAlert {...}|false disables. jobId canonical (id=compat). contextMessages 0-10 embeds recent chat lines into reminder text.",
         "inputSchema": {
           "additionalProperties": true,
           "properties": {
@@ -307,382 +307,7 @@
             },
             "job": {
               "additionalProperties": true,
-              "properties": {
-                "agentId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Agent id, or null to keep it unset"
-                },
-                "declarationKey": {
-                  "description": "Idempotent declaration key.",
-                  "maxLength": 200,
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "deleteAfterRun": {
-                  "description": "Delete after first run",
-                  "type": "boolean"
-                },
-                "delivery": {
-                  "additionalProperties": true,
-                  "properties": {
-                    "accountId": {
-                      "description": "Delivery account",
-                      "type": "string"
-                    },
-                    "bestEffort": {
-                      "type": "boolean"
-                    },
-                    "channel": {
-                      "description": "Delivery channel",
-                      "type": "string"
-                    },
-                    "completionDestination": {
-                      "additionalProperties": true,
-                      "description": "Additional completion webhook; requires delivery.mode=announce",
-                      "properties": {
-                        "mode": {
-                          "const": "webhook",
-                          "type": "string"
-                        },
-                        "to": {
-                          "description": "Completion webhook target; only valid with delivery.mode=announce",
-                          "minLength": 1,
-                          "type": "string"
-                        }
-                      },
-                      "required": ["mode", "to"],
-                      "type": "object"
-                    },
-                    "failureDestination": {
-                      "additionalProperties": true,
-                      "properties": {
-                        "accountId": {
-                          "description": "Failure delivery account",
-                          "type": "string"
-                        },
-                        "channel": {
-                          "description": "Failure delivery channel",
-                          "type": "string"
-                        },
-                        "mode": {
-                          "anyOf": [
-                            {
-                              "const": "announce",
-                              "type": "string"
-                            },
-                            {
-                              "const": "webhook",
-                              "type": "string"
-                            }
-                          ]
-                        },
-                        "to": {
-                          "description": "Failure delivery target",
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "mode": {
-                      "description": "Delivery mode",
-                      "enum": ["none", "announce", "webhook"],
-                      "type": "string"
-                    },
-                    "threadId": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "number"
-                        }
-                      ],
-                      "description": "Thread/topic id"
-                    },
-                    "to": {
-                      "description": "Delivery target",
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                },
-                "description": {
-                  "description": "Human description",
-                  "type": "string"
-                },
-                "displayName": {
-                  "description": "Human-readable declarative job label",
-                  "maxLength": 200,
-                  "type": "string"
-                },
-                "enabled": {
-                  "type": "boolean"
-                },
-                "failureAlert": {
-                  "additionalProperties": true,
-                  "description": "Failure alert; false disables.",
-                  "properties": {
-                    "accountId": {
-                      "type": "string"
-                    },
-                    "after": {
-                      "description": "Failures before alert",
-                      "minimum": 1,
-                      "type": "integer"
-                    },
-                    "channel": {
-                      "description": "Alert channel",
-                      "type": "string"
-                    },
-                    "cooldownMs": {
-                      "description": "Alert cooldown ms",
-                      "minimum": 0,
-                      "type": "integer"
-                    },
-                    "includeSkipped": {
-                      "description": "Count skipped runs.",
-                      "type": "boolean"
-                    },
-                    "mode": {
-                      "enum": ["announce", "webhook"],
-                      "type": "string"
-                    },
-                    "to": {
-                      "description": "Alert target",
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                },
-                "name": {
-                  "description": "Job name",
-                  "type": "string"
-                },
-                "owner": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "agentId": {
-                      "type": "string"
-                    },
-                    "sessionKey": {
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                },
-                "pacing": {
-                  "additionalProperties": false,
-                  "description": "Dynamic-cadence bounds; at least one of min or max is required",
-                  "properties": {
-                    "max": {
-                      "description": "Maximum dynamic delay",
-                      "type": "string"
-                    },
-                    "min": {
-                      "description": "Minimum dynamic delay",
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                },
-                "payload": {
-                  "additionalProperties": true,
-                  "properties": {
-                    "allowUnsafeExternalContent": {
-                      "description": "Allow untrusted external content in prompt",
-                      "type": "boolean"
-                    },
-                    "fallbacks": {
-                      "description": "Fallback models",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "kind": {
-                      "description": "Payload kind",
-                      "enum": ["systemEvent", "agentTurn", "script"],
-                      "type": "string"
-                    },
-                    "lightContext": {
-                      "description": "Lightweight bootstrap context (skip full workspace context)",
-                      "type": "boolean"
-                    },
-                    "message": {
-                      "description": "agentTurn prompt",
-                      "type": "string"
-                    },
-                    "model": {
-                      "description": "Model override",
-                      "type": "string"
-                    },
-                    "script": {
-                      "description": "Headless code-mode script",
-                      "type": "string"
-                    },
-                    "text": {
-                      "description": "systemEvent text",
-                      "type": "string"
-                    },
-                    "thinking": {
-                      "description": "Thinking override",
-                      "type": "string"
-                    },
-                    "timeoutSeconds": {
-                      "minimum": 0,
-                      "type": "number"
-                    },
-                    "toolBudget": {
-                      "description": "Maximum script tool calls",
-                      "minimum": 1,
-                      "type": "integer"
-                    },
-                    "toolsAllow": {
-                      "description": "Allowed tools",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    }
-                  },
-                  "type": "object"
-                },
-                "schedule": {
-                  "additionalProperties": true,
-                  "properties": {
-                    "anchorMs": {
-                      "description": "Start anchor ms (kind=every)",
-                      "maximum": 8640000000000000,
-                      "minimum": 0,
-                      "type": "integer"
-                    },
-                    "at": {
-                      "description": "ISO-8601 time (kind=at)",
-                      "type": "string"
-                    },
-                    "batchMs": {
-                      "minimum": 0,
-                      "type": "integer"
-                    },
-                    "command": {
-                      "description": "Supervised source argv (kind=stream; requires cron.triggers.enabled)",
-                      "items": {
-                        "minLength": 1,
-                        "type": "string"
-                      },
-                      "minItems": 1,
-                      "type": "array"
-                    },
-                    "cwd": {
-                      "description": "Working directory (kind=stream)",
-                      "type": "string"
-                    },
-                    "everyMs": {
-                      "description": "Interval ms (kind=every)",
-                      "maximum": 8640000000000000,
-                      "minimum": 1,
-                      "type": "integer"
-                    },
-                    "expr": {
-                      "description": "Cron wall-time expr; never UTC-convert. Missing tz=Gateway local. Example \"0 18 * * *\", \"Asia/Shanghai\".",
-                      "type": "string"
-                    },
-                    "kind": {
-                      "description": "Schedule kind",
-                      "enum": ["at", "every", "cron", "stream"],
-                      "type": "string"
-                    },
-                    "match": {
-                      "description": "Regex source (stream match mode)",
-                      "type": "string"
-                    },
-                    "maxBatchBytes": {
-                      "minimum": 0,
-                      "type": "integer"
-                    },
-                    "mode": {
-                      "enum": ["line", "match"],
-                      "type": "string"
-                    },
-                    "staggerMs": {
-                      "description": "Jitter ms (kind=cron)",
-                      "maximum": 8640000000000000,
-                      "minimum": 0,
-                      "type": "integer"
-                    },
-                    "tz": {
-                      "description": "IANA timezone for wall-clock fields; missing=Gateway host local timezone. Example \"Asia/Shanghai\".",
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                },
-                "sessionKey": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Explicit session key, or null to clear it"
-                },
-                "sessionTarget": {
-                  "description": "main | isolated | current (agentTurn default) | session:<id>",
-                  "type": "string"
-                },
-                "trigger": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "once": {
-                      "type": "boolean"
-                    },
-                    "script": {
-                      "maxLength": 65536,
-                      "minLength": 1,
-                      "type": "string"
-                    }
-                  },
-                  "required": ["script"],
-                  "type": "object"
-                },
-                "wakeMode": {
-                  "description": "Wake timing",
-                  "enum": ["now", "next-heartbeat"],
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "jobId": {
-              "type": "string"
-            },
-            "limit": {
-              "description": "Maximum jobs returned by action=\"list\"",
-              "maximum": 200,
-              "minimum": 1,
-              "type": "integer"
-            },
-            "mode": {
-              "description": "Wake mode for action=\"wake\" (default next-heartbeat)",
-              "enum": ["now", "next-heartbeat"],
-              "type": "string"
-            },
-            "offset": {
-              "description": "Job offset for action=\"list\"; use nextOffset to load the next page",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "patch": {
-              "additionalProperties": true,
+              "description": "Job fields. action=\"add\": full job. action=\"update\": partial patch — only supplied fields change; null clears.",
               "properties": {
                 "agentId": {
                   "anyOf": [
@@ -695,7 +320,14 @@
                   ],
                   "description": "Agent id, or null to clear it"
                 },
+                "declarationKey": {
+                  "description": "Idempotent declaration key (add only).",
+                  "maxLength": 200,
+                  "minLength": 1,
+                  "type": "string"
+                },
                 "deleteAfterRun": {
+                  "description": "Delete after first run",
                   "type": "boolean"
                 },
                 "delivery": {
@@ -730,7 +362,6 @@
                       "anyOf": [
                         {
                           "additionalProperties": true,
-                          "description": "Additional completion webhook; requires delivery.mode=announce",
                           "properties": {
                             "mode": {
                               "const": "webhook",
@@ -749,7 +380,7 @@
                           "type": "null"
                         }
                       ],
-                      "description": "Completion webhook destination; requires delivery.mode=announce; null clears."
+                      "description": "Completion webhook; requires delivery.mode=announce; null clears."
                     },
                     "failureDestination": {
                       "anyOf": [
@@ -847,6 +478,7 @@
                   "type": "object"
                 },
                 "description": {
+                  "description": "Human description",
                   "type": "string"
                 },
                 "displayName": {
@@ -903,6 +535,18 @@
                 "name": {
                   "description": "Job name",
                   "type": "string"
+                },
+                "owner": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "agentId": {
+                      "type": "string"
+                    },
+                    "sessionKey": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
                 },
                 "pacing": {
                   "anyOf": [
@@ -1117,11 +761,31 @@
                   ]
                 },
                 "wakeMode": {
+                  "description": "Wake timing",
                   "enum": ["now", "next-heartbeat"],
                   "type": "string"
                 }
               },
               "type": "object"
+            },
+            "jobId": {
+              "type": "string"
+            },
+            "limit": {
+              "description": "Maximum jobs returned by action=\"list\"",
+              "maximum": 200,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "mode": {
+              "description": "Wake mode for action=\"wake\" (default next-heartbeat)",
+              "enum": ["now", "next-heartbeat"],
+              "type": "string"
+            },
+            "offset": {
+              "description": "Job offset for action=\"list\"; use nextOffset to load the next page",
+              "minimum": 0,
+              "type": "integer"
             },
             "runMode": {
               "description": "Run mode for action=\"run\": omitted defaults to \"due\"; use \"force\" to trigger now.",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -227,8 +227,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 65442,
-    "roughTokens": 16361
+    "chars": 52171,
+    "roughTokens": 13043
   },
   "openClawDeveloperInstructions": {
     "chars": 4390,
@@ -239,8 +239,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7194
   },
   "totalWithDynamicToolsJson": {
-    "chars": 94217,
-    "roughTokens": 23555
+    "chars": 80946,
+    "roughTokens": 20237
   },
   "userInputText": {
     "chars": 1300,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -227,8 +227,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 65134,
-    "roughTokens": 16284
+    "chars": 51863,
+    "roughTokens": 12966
   },
   "openClawDeveloperInstructions": {
     "chars": 3281,
@@ -239,8 +239,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6824
   },
   "totalWithDynamicToolsJson": {
-    "chars": 92429,
-    "roughTokens": 23108
+    "chars": 79158,
+    "roughTokens": 19790
   },
   "userInputText": {
     "chars": 929,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -222,8 +222,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 66668,
-    "roughTokens": 16667
+    "chars": 53397,
+    "roughTokens": 13350
   },
   "openClawDeveloperInstructions": {
     "chars": 3281,
@@ -234,8 +234,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6928
   },
   "totalWithDynamicToolsJson": {
-    "chars": 94379,
-    "roughTokens": 23595
+    "chars": 81108,
+    "roughTokens": 20277
   },
   "userInputText": {
     "chars": 1271,


### PR DESCRIPTION
## What Problem This Solves

The `automations` tool's JSON Schema was the single largest tool-schema item on the default tool path: 13,016 chars (~3.25k tokens) in every prompt, 88% of it two hand-maintained near-duplicate parameters — `job` (5,533 chars, `add` only) and `patch` (5,922 chars, `update` only). Both shipped on every turn even though each applies to one of ten actions. Fixes #121606.

## Why This Change Was Made

Issue #121606 listed three options. `$defs`/`$ref` sharing (option 1) is blocked by the llama.cpp GBNF projection guard (`findLlamacppGbnfSchemaViolations` in `cron-tool.schema.test.ts`) and OpenAPI-3.0-subset providers. This PR implements option 2: one shared object schema for both actions, matching the repo's one-canonical-flow preference.

- `src/agents/tools/cron-tool-schema.ts`: `createCronPatchObjectSchema()` and the entire `nullableClears` parameterization are deleted. One `createCronJobObjectSchema()` (nullable-clear everywhere the patch was, plus the add-only `declarationKey`/`owner` fields) serves `add` and `update`. The object's description states the per-action semantics.
- `update` now reads the `job` parameter; the `patch` parameter is removed cleanly (root `AGENTS.md`: no hidden compat for model-facing params). The tool description documents `update jobId job (partial: only supplied fields change; null clears)`.
- The `add` path strips null-valued fields (`stripCronCreateNullClears`) before the strict gateway `cron.add` contract, which rejects the nulls `cron.update` accepts. A null clear on create is a no-op. Top-level `agentId`/`sessionKey` nulls are preserved: `CronAddParamsSchema` accepts them and a null `sessionKey` intentionally suppresses default creator-session binding (cron-tool.ts).
- The gateway protocol (`CronAddParamsSchema`/`CronUpdateParamsSchema`) is untouched; this is a model-facing tool-boundary change only.

## User Impact

Every turn of every agent on the default tool path gets ~5.2k fewer schema chars (~1.3k tokens, −40% of the automations schema): 13,016 → 7,864 chars. The Codex dynamic-tools catalog snapshot dropped from 65,134 to 51,863 chars (~3.3k rough tokens including serialization overhead). Accepted inputs are unchanged for `add`; `update` calls move their patch object from `patch` to `job`, and nulls sent on `add` (previously schema-invalid) are now tolerated as no-ops instead of failing at the gateway.

Note: this branch briefly carried a `config/env-var-count-budget.txt` 507→503 ratchet fix for then-red `main`; #121644 landed the identical change first and the commit auto-dropped on rebase.

## Evidence

- Baseline vs. after (`createCronToolSchema()` serialized): 13,016 chars / `patch` 5,922 + `job` 5,533 → 7,864 chars / `job` 6,312, no `patch`. ~1,290 tokens saved per prompt.
- `node scripts/run-vitest.mjs src/agents/tools/cron-tool.test.ts src/agents/tools/cron-tool.flat-params.test.ts src/agents/tools/cron-tool.schema.test.ts` — 245 tests green, including the llama.cpp GBNF projection guard, OpenAPI-3.0 provider projections (Gemini/jjcc), and a new regression test proving `add` strips null clears before `cron.add` while preserving the `sessionKey: null` binding-suppression contract.
- `node scripts/run-vitest.mjs src/agents/tools/cron-tool-creator-cap.test.ts src/cron/normalize.test.ts src/gateway/server-methods` — green.
- `pnpm prompt:snapshots:gen` + `pnpm prompt:snapshots:check` — snapshots current.
- Production LOC net −59 (schema −87, canonicalize +27, tool +1); tests net −35.
