### PR TITLE
fix(ci): align memory test with safe path contract

### DIFF
--- a/packages/memory-host-sdk/src/host/read-file.test.ts
+++ b/packages/memory-host-sdk/src/host/read-file.test.ts
@@ -19,7 +19,7 @@ async function createDirectorySymlink(target: string, linkPath: string): Promise
 }
 
 describe("readMemoryFile", () => {
-  it("returns empty text for missing files under extra path directories", async () => {
+  it("returns empty text for absent extra paths and rejects non-directory parents", async () => {
     const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-read-file-"));
     try {
       const workspaceDir = path.join(tmpRoot, "workspace");
@@ -47,10 +47,7 @@ describe("readMemoryFile", () => {
           extraPaths: [extraDir],
           relPath: nonDirectoryParentPath,
         }),
-      ).resolves.toEqual({
-        text: "",
-        path: path.relative(workspaceDir, nonDirectoryParentPath).replace(/\\/g, "/"),
-      });
+      ).rejects.toThrow("path required");
     } finally {
       await fs.rm(tmpRoot, { recursive: true, force: true });
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes the Linux Node shard after the fs-safe 0.5.4 upgrade. The memory host test still treated a path below a regular-file ancestor as an ordinary missing file.

## Why This Change Was Made

fs-safe 0.5.4 deliberately reports that ancestor as `not-file`. The production memory reader already converts that unsafe candidate into its existing `path required` rejection, so the stale test now asserts the safety contract instead of weakening production validation.

## User Impact

No user-visible behavior change. This is a test-only correction; production LOC delta is zero.

## Maintainer Cleanup

- Semantically replayed the original one-commit change onto current `main` `896592b747a839f11eb834e744e5a7a204678f16`.
- Preserved Peter Steinberger authorship and the original commit message.
- Clean head: `4b029e5f5893ae6495ab66347e997e456751441c`.

## Evidence

- Direct dependency inspection: fs-safe 0.5.4 documents `not-file` for a non-directory path component; its root resolver emits that code rather than `not-found`.
- Negative control with stale fs-safe 0.5.2: focused test failed 1 of 4 by resolving empty, reproducing the obsolete expectation.
- Exact lockfile install with fs-safe 0.5.4: `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/read-file.test.ts` passed 4 of 4.
- `pnpm format:check --no-error-on-unmatched-pattern -- packages/memory-host-sdk/src/host/read-file.test.ts` passed.
- `git diff --check origin/main...HEAD` passed.
- Targeted lint was stopped after it stalled behind the shared repository heavy-check lock; exact-head CI is authoritative for lint and test types.
