### PR TITLE
fix(ci): restore release workflow checks

### DIFF
--- a/scripts/full-release-validation-at-sha.mts
+++ b/scripts/full-release-validation-at-sha.mts
@@ -461,6 +461,7 @@ export function assertTrustedWorkflowHarness(
   } catch (error) {
     throw new Error(
       `Tooling SHA ${workflowSha} contains invalid ${TRUSTED_WORKFLOW_PATH}: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
     );
   }
   if (

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2700,8 +2700,8 @@ describe("package artifact reuse", () => {
         ),
       )
       .map(([jobId]) => jobId)
-      .sort();
-    expect(typedHarnessJobIds).toEqual(harnessJobCases.map(({ jobId }) => jobId).sort());
+      .toSorted();
+    expect(typedHarnessJobIds).toEqual(harnessJobCases.map(({ jobId }) => jobId).toSorted());
 
     for (const { jobId, planStepName, setupIf } of harnessJobCases) {
       const harnessJob = workflowJob(LIVE_E2E_WORKFLOW, jobId);
@@ -6249,7 +6249,6 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     const crossOs = readWorkflow(CROSS_OS_RELEASE_CHECKS_REUSABLE_WORKFLOW);
     const packageAcceptance = readWorkflow(PACKAGE_ACCEPTANCE_WORKFLOW);
     const qaLive = readWorkflow(QA_LIVE_TRANSPORTS_WORKFLOW);
-    const performance = readWorkflow(PERFORMANCE_WORKFLOW);
     const profiles = ["beta", "stable", "full"] as const;
 
     const ciPreflight = workflowJob(CI_WORKFLOW, "preflight");
@@ -6362,7 +6361,7 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
         profile,
         releasePackagePaths[profile].reduce((total, timeout) => total + timeout, 0),
       ]),
-    );
+    ) as Record<(typeof profiles)[number], number>;
     expect(releasePackageTimeouts).toEqual({ beta: 280, stable: 280, full: 310 });
     for (const profile of profiles) {
       const childTimeout = releasePackageTimeouts[profile];

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1908,6 +1908,7 @@ describe("scripts/test-projects changed-target routing", () => {
         "test/scripts/plugin-release-pretag-pack-check.test.ts",
       ],
       "scripts/plan-release-workflow-matrix.mjs": [
+        "test/scripts/package-acceptance-workflow.test.ts",
         "test/scripts/release-workflow-matrix-plan.test.ts",
         "test/scripts/direct-run-entrypoints.test.ts",
       ],


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where main CI failed its release-workflow test typecheck, lint, and changed-target routing checks after the release timeout coverage began importing the workflow matrix planner.

## Why This Change Was Made

The new release test left one parsed workflow unused, lost the finite profile-key type through `Object.fromEntries`, rethrew a workflow-parse failure without preserving its cause, and added a planner importer without refreshing the routing contract. This keeps the existing timeout assertions and canonical changed-target resolver intact: it removes the unused read, types the aggregate map consistently with its sibling maps, preserves the parse error chain, and records the newly observed owner test. It also switches the two pre-existing array comparisons to the repository's non-mutating `toSorted()` contract.

Production is +1/-0 for the required error-cause contract. Tests are +4/-4.

## User Impact

There is no user-visible behavior change. Main CI can validate the release workflow contracts again without weakening assertions, widening timeouts, or skipping checks.

## Evidence

- Original failure: https://github.com/openclaw/openclaw/actions/runs/31400441722
  - `check-test-types`: unused workflow read and possibly-undefined profile aggregate.
  - `check-lint`: two mutating array sorts in the release workflow test.
  - `checks-node-compact-small-2`: changed-target routing expected two planner owner tests but resolved the new package-acceptance importer as a third owner.
- `pnpm tsgo:test:root` passes.
- `pnpm tsgo:scripts` passes.
- Targeted type-aware oxlint passes for all three changed files.
- The focused trusted-harness rejection test passes and preserves the original parse error as `cause`.
- The two affected package-acceptance assertions pass; the changed-target plan was also executed directly and returned the expected three canonical targets. The broad local routing table test hit its existing 120-second timeout under host contention after 230 seconds, rather than an assertion failure.
- Targeted `oxfmt --check`, `git diff --check`, and Codex autoreview pass.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/31407217027
  - `check-lint` and `checks-node-compact-small-2` are green.
  - The remaining `check-test-types` diagnostics are confined to current-main generated-image tests outside this PR (`managed-image-actions.e2e.test.ts` and `chat-message.test.ts`).
  - The remaining Node failures are the independently owned memory read-file and shared-wizard regressions; this PR does not touch either surface.
