### PR TITLE
fix(ui): prevent duplicated worktree base branches

### DIFF
--- a/ui/src/e2e/model-setup.e2e.test.ts
+++ b/ui/src/e2e/model-setup.e2e.test.ts
@@ -624,13 +624,28 @@ suite.define(() => {
           page
             .locator("[data-manual-provider]")
             .evaluateAll((options) => options.some((option) => option === document.activeElement));
-        const waitForProviderHide = () =>
-          providerPicker.evaluate(
-            (element) =>
-              new Promise<void>((resolve) => {
-                element.addEventListener("wa-after-hide", () => resolve(), { once: true });
-              }),
+        const providerHideMarker = "data-openclaw-test-after-hide";
+        const armProviderHide = () =>
+          providerPicker.evaluate((element, marker) => {
+            element.removeAttribute(marker);
+            element.addEventListener("wa-after-hide", () => element.setAttribute(marker, ""), {
+              once: true,
+            });
+          }, providerHideMarker);
+        const waitForProviderHide = async () => {
+          await expect
+            .poll(() =>
+              providerPicker.evaluate(
+                (element, marker) => element.hasAttribute(marker),
+                providerHideMarker,
+              ),
+            )
+            .toBe(true);
+          await providerPicker.evaluate(
+            (element, marker) => element.removeAttribute(marker),
+            providerHideMarker,
           );
+        };
         const providerIds = await page
           .locator("[data-manual-provider]")
           .evaluateAll((options) =>
@@ -673,9 +688,9 @@ suite.define(() => {
           });
           await page.setViewportSize({ height: 1000, width: 1440 });
         }
-        const providerHidden = waitForProviderHide();
+        await armProviderHide();
         await page.keyboard.press("Escape");
-        await providerHidden;
+        await waitForProviderHide();
         await expect
           .poll(() => providerPicker.evaluate((element) => element.hasAttribute("open")))
           .toBe(false);
@@ -698,9 +713,9 @@ suite.define(() => {
         await page.keyboard.press("ArrowDown");
         await page.keyboard.press("ArrowDown");
         await expect.poll(() => manualProviderHasFocus("zai-cn")).toBe(true);
-        const zaiProviderHidden = waitForProviderHide();
+        await armProviderHide();
         await page.keyboard.press("Enter");
-        await zaiProviderHidden;
+        await waitForProviderHide();
         await expect.poll(() => providerTrigger.textContent()).toContain("Z.AI");
         await expect
           .poll(() => providerTrigger.evaluate((element) => element === document.activeElement))
@@ -709,9 +724,9 @@ suite.define(() => {
         await accessValue.fill("same-provider-secret");
         await providerTrigger.click();
         await expect.poll(manualProviderMenuReady).toBe(true);
-        const sameProviderHidden = waitForProviderHide();
+        await armProviderHide();
         await page.locator('[data-manual-provider="zai-cn"]').click();
-        await sameProviderHidden;
+        await waitForProviderHide();
         await expect.poll(() => accessValue.inputValue()).toBe("same-provider-secret");
         await expect
           .poll(() => providerTrigger.evaluate((element) => element === document.activeElement))
@@ -719,9 +734,9 @@ suite.define(() => {
 
         await providerTrigger.click();
         await expect.poll(manualProviderMenuReady).toBe(true);
-        const providerHiddenBackward = waitForProviderHide();
+        await armProviderHide();
         await page.keyboard.press("Shift+Tab");
-        await providerHiddenBackward;
+        await waitForProviderHide();
         await expect
           .poll(() => providerTrigger.evaluate((element) => element === document.activeElement))
           .toBe(true);
@@ -739,9 +754,9 @@ suite.define(() => {
         await accessValue.fill("sk-old-provider-secret");
         await providerTrigger.click();
         await expect.poll(manualProviderMenuReady).toBe(true);
-        const googleProviderHidden = waitForProviderHide();
+        await armProviderHide();
         await page.locator('[data-manual-provider="gemini-api-key"]').click();
-        await googleProviderHidden;
+        await waitForProviderHide();
         await expect.poll(() => providerTrigger.textContent()).toContain("Google");
         await expect.poll(() => providerTrigger.textContent()).toContain("AI Studio API key");
         await expect.poll(() => accessValue.inputValue()).toBe("");
@@ -750,9 +765,9 @@ suite.define(() => {
           .toBe(true);
 
         await providerTrigger.click();
-        const qwenProviderHidden = waitForProviderHide();
+        await armProviderHide();
         await page.locator('[data-manual-provider="qwen-cn"]').click();
-        await qwenProviderHidden;
+        await waitForProviderHide();
         await expect
           .poll(() => providerPicker.evaluate((element) => element.hasAttribute("open")))
           .toBe(false);
@@ -811,9 +826,9 @@ suite.define(() => {
           .toBe(detectCountBeforeDismiss + 1);
         await providerTrigger.click();
         await expect.poll(manualProviderMenuReady).toBe(true);
-        const googleProviderHiddenAfterDismiss = waitForProviderHide();
+        await armProviderHide();
         await page.locator('[data-manual-provider="gemini-api-key"]').click();
-        await googleProviderHiddenAfterDismiss;
+        await waitForProviderHide();
         await expect.poll(() => providerTrigger.textContent()).toContain("Google");
         await expect.poll(() => page.getByText("Gemini CLI OAuth").count()).toBe(0);
       },

--- a/ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts
@@ -299,7 +299,10 @@ suite.define(() => {
 
       await page.locator("#new-session-place-trigger").click();
       const placePopover = page.locator("wa-popover.new-session-page__place-popover");
-      await placePopover.getByRole("button", { name: "Worktree" }).click();
+      const worktreeButton = placePopover.getByRole("button", { name: "Worktree" });
+      await worktreeButton.waitFor({ state: "visible" });
+      const initialBranchRequestCount = (await gateway.getRequests("worktrees.branches")).length;
+      await worktreeButton.click();
       await expect.poll(() => placePopover.getByLabel("Base branch").inputValue()).toBe("main");
       await placePopover.getByLabel("Worktree name").fill("terminal-task");
       await page.locator("#new-session-place-trigger").click();
@@ -329,6 +332,9 @@ suite.define(() => {
         cwd: worktreePath,
         initialMessage: "inspect the checkout",
       });
+      expect(await gateway.getRequests("worktrees.branches")).toHaveLength(
+        initialBranchRequestCount,
+      );
       const requests = await gateway.getRequests();
       const methods = requests.map((request) => request.method);
       expect(methods.indexOf("worktrees.create")).toBeLessThan(

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -2047,7 +2047,7 @@ class NewSessionPage extends OpenClawLightDomElement {
           folder: this.folder.trim() || this.workspacePath(),
           worktree: this.worktree,
         });
-        if (this.worktree) {
+        if (this.worktree && this.repository.kind !== "git") {
           this.maybeLoadBranches();
         }
       },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting a Control UI session in a worktree could intermittently submit a duplicated base branch such as `mainmain`. The failure was captured in [CI run 31363964382, attempt 1](https://github.com/openclaw/openclaw/actions/runs/31363964382) in `checks-ui-e2e (1/4)`; attempt 2 passed, confirming a narrow probabilistic race.

While landing that repair, exact-head CI also reproduced an unrelated current-main E2E race in the model-setup provider picker: a dismissal could fire `wa-after-hide` before the browser-side listener was installed, leaving an unbounded Promise pending until the global 120s test timeout.

## Why This Change Was Made

Enabling Worktree unconditionally reloaded branches even when the current repository snapshot was already authoritative and Git-backed. That redundant async response could land between Playwright's native-input selection/focus and text insertion, reset the base branch, and move the caret. The canonical owner repair reuses the loaded Git snapshot and only discovers branches when the repository is not yet known to be Git-backed, preserving discovery and retry behavior for unresolved repository states.

Current `main` independently adopted the test-side `inputValue() === "main"` wait. This PR retains that wait and adds the missing owner-boundary proof: the Worktree toggle must not issue another `worktrees.branches` request after the authoritative Git snapshot is loaded.

Current `main` also independently adopted focus-based provider-picker assertions and ArrowDown navigation. This PR preserves those changes and adds only the missing synchronization repair: every provider-menu dismissal arms a durable `wa-after-hide` marker before the action and boundedly asserts it afterward. No timeout, retry, product guard, or weaker assertion was added.

The worktree change is the best fix because it removes the redundant request at its producer. Waiting around fill/insertText, adding retries or timeouts, sanitizing `createManagedWorktree` input, using a synchronous mock, or changing focus ownership would leave the redundant production request intact.

## User Impact

Starting a catalog session in a worktree now keeps the discovered default branch stable instead of occasionally duplicating it. Release-note context: prevent intermittent duplicated worktree base branch names in the Control UI. The model-setup change affects test synchronization only. There is no visual product change, so before/after screenshots are not meaningful.

## Evidence

### Worktree base branch

- Pre-fix red proof: the extended boundary E2E observed `worktrees.branches` increase from 2 requests to 3 under the old unconditional reload.
- Focused E2E on the identical worktree file blobs: 1 passed, 12 skipped.
- Trusted Linux Testbox `tbx_01kzp3g46b8dchrc62erj47151`: [run 31401999898](https://github.com/openclaw/openclaw/actions/runs/31401999898) — 50/50 focused iterations, sibling workspace-validation 9/9, and `check:changed` passed.
- Trusted Linux Testbox `tbx_01kzp4kmcwh6jfcpsm7rd0qv3z`: [run 31403747618](https://github.com/openclaw/openclaw/actions/runs/31403747618) — 20/20 focused iterations and `check:changed` passed.
- Exact-head CI [run 31427186554](https://github.com/openclaw/openclaw/actions/runs/31427186554) executed the changed worktree test successfully in 2.1s; that run failed only on the unrelated model-setup timeout repaired here.

### Model setup picker

- Pre-fix reproduction: exact-head CI run 31427186554 timed out the Google provider-picker scenario at 120s with no bounded assertion failure.
- A marker-only candidate removed the hang but Testbox stress exposed the then-current private `.active` assertion on iteration 4; current `main` now owns the focus-based replacement.
- Trusted Linux Testbox, provider `blacksmith-testbox`, id `tbx_01kzpnyybybpeggw48zhw00ekm`: [run 31429441490](https://github.com/openclaw/openclaw/actions/runs/31429441490) — marker synchronization plus focus assertions passed the provider-picker scenario 20/20 and full model-setup file 5/5.
- The final rebase preserves current-main `/chat/main` routing, focus assertions, and ArrowDown navigation; its model-setup diff contains only the pre-armed marker synchronization.

### Final gates

- Exact head: `35cd9ac327c7af4aa1ed233fdd1eb21d6c7f8d92`, based on `2ae316e2f33d0a196192731e5fe1b66117d348b1`.
- Targeted oxfmt, oxlint, and `git diff --check` passed.
- Fresh exact-head Codex-backed branch autoreview and TruffleHog scan are clean with no accepted/actionable findings.
- Native review artifacts validate as `READY FOR /prepare-pr` with zero findings.
- Fresh exact-head CI is running.

AI-assisted: yes. The implementation, owner boundaries, dependency behavior, history, regression proof, stress proof, and final diff were manually inspected.

## Scope and LOC

Production: `+1/-1` (net `0`). Tests: `+42/-21` (net `+21`). Overall: `+43/-22` (net `+21`) across three files. No config, protocol, schema, dependency, release, version, generated baseline, lockfile, or changelog changes.
