### PR TITLE
fix: allow setup retry after wizard settles

### DIFF
--- a/src/gateway/server-methods/setup-admission.test.ts
+++ b/src/gateway/server-methods/setup-admission.test.ts
@@ -1,9 +1,14 @@
+import { __setFsSafeTestHooksForTest } from "@openclaw/fs-safe/test-hooks";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { withSetupMigrationTargetLock } from "../../wizard/setup.migration-snapshot.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  __setFsSafeTestHooksForTest(undefined);
+});
 
 const mocks = vi.hoisted(() => ({ stateDir: "" }));
 
@@ -67,35 +72,70 @@ describe("setup admission", () => {
     ).rejects.toBe(taskError);
   });
 
-  it("holds an admitted session lease until its runner settles", async () => {
-    const settled = createDeferred();
-    await createAdmittedWizardSession(() => ({
-      whenSettled: () => settled.promise,
-    }));
-
-    await expect(
-      createAdmittedWizardSession(() => ({ whenSettled: () => Promise.resolve() })),
-    ).resolves.toBeUndefined();
-    settled.resolve();
-    await settled.promise;
-    await vi.waitFor(async () => {
-      const next = await createAdmittedWizardSession(() => ({
-        whenSettled: () => Promise.resolve(),
-      }));
-      expect(next).toBeDefined();
-      await next?.whenSettled();
+  it("settles an admitted session only after releasing setup ownership", async () => {
+    const releaseRunner = createDeferred();
+    const session = await createAdmittedWizardSession(async () => {
+      await releaseRunner.promise;
     });
+    expect(session).toBeDefined();
+
+    await expect(createAdmittedWizardSession(async () => {})).resolves.toBeUndefined();
+
+    releaseRunner.resolve();
+    await session?.whenSettled();
+    await expect(runExclusiveSystemAgentSetupActivation(async () => "ok")).resolves.toBe("ok");
+
+    const replacement = await createAdmittedWizardSession(async () => {});
+    expect(replacement).toBeDefined();
+    await replacement?.whenSettled();
   });
 
-  it("releases an admitted session lease when construction fails", async () => {
-    await expect(
-      createAdmittedWizardSession(() => {
-        throw new Error("construction failed");
-      }),
-    ).rejects.toThrow("construction failed");
-    await expect(
-      createAdmittedWizardSession(() => ({ whenSettled: () => Promise.resolve() })),
-    ).resolves.toBeDefined();
+  it("rejects settlement when the canonical target lock cannot be released", async () => {
+    const releaseRunner = createDeferred();
+    const session = await createAdmittedWizardSession(async () => {
+      await releaseRunner.promise;
+    });
+    if (!session) {
+      throw new Error("expected admitted session");
+    }
+    const releaseError = new Error("target lock release failed");
+    __setFsSafeTestHooksForTest({
+      beforeSidecarLockSnapshotOpen: () => {
+        throw releaseError;
+      },
+    });
+
+    const settlement = expect(session.whenSettled()).rejects.toBe(releaseError);
+    releaseRunner.resolve();
+    await settlement;
+    expect(session.isSettled()).toBe(true);
+    expect(session.getStatus()).toBe("error");
+    expect(session.getError()).toContain(releaseError.message);
+
+    __setFsSafeTestHooksForTest(undefined);
+    const channel = await createAdmittedWizardSession(async () => {}, {
+      lockSetupTarget: false,
+    });
+    expect(channel).toBeDefined();
+    await channel?.whenSettled();
+
+    const structuredTask = vi.fn(async () => "unexpected");
+    await expect(runExclusiveSystemAgentSetupActivation(structuredTask)).rejects.toThrow(
+      "setup is already in progress",
+    );
+    expect(structuredTask).not.toHaveBeenCalled();
+  });
+
+  it("releases an admitted session lease when its runner fails", async () => {
+    const failed = await createAdmittedWizardSession(async () => {
+      throw new Error("runner failed");
+    });
+    await failed?.whenSettled();
+    expect(failed?.getError()).toContain("runner failed");
+
+    const replacement = await createAdmittedWizardSession(async () => {});
+    expect(replacement).toBeDefined();
+    await replacement?.whenSettled();
   });
 
   it("reserves wizard admission while setup waits to acquire its target lock", async () => {
@@ -107,12 +147,12 @@ describe("setup admission", () => {
     });
     await lockAcquired.promise;
 
-    const setupAttempt = createAdmittedWizardSession(() => ({
-      whenSettled: () => Promise.resolve(),
-    }));
-    const channelFactory = vi.fn(() => ({ whenSettled: () => Promise.resolve() }));
-    await expect(createAdmittedWizardSession(channelFactory, false)).resolves.toBeUndefined();
-    expect(channelFactory).not.toHaveBeenCalled();
+    const setupAttempt = createAdmittedWizardSession(async () => {});
+    const channelRunner = vi.fn(async () => {});
+    await expect(
+      createAdmittedWizardSession(channelRunner, { lockSetupTarget: false }),
+    ).resolves.toBeUndefined();
+    expect(channelRunner).not.toHaveBeenCalled();
     await expect(setupAttempt).resolves.toBeUndefined();
 
     releaseLock.resolve();

--- a/src/gateway/server-methods/setup-admission.test.ts
+++ b/src/gateway/server-methods/setup-admission.test.ts
@@ -90,6 +90,20 @@ describe("setup admission", () => {
     await replacement?.whenSettled();
   });
 
+  it("reports an admitted lifecycle as unsettled during synchronous runner startup", async () => {
+    let settledAtStart: boolean | undefined;
+    let settlementAtStart: Promise<void> | undefined;
+    const session = await createAdmittedWizardSession(async (_prompter, _signal, owner) => {
+      settledAtStart = owner.isSettled();
+      settlementAtStart = owner.whenSettled();
+    });
+
+    expect(settledAtStart).toBe(false);
+    expect(settlementAtStart).toBe(session?.whenSettled());
+    await session?.whenSettled();
+    expect(session?.isSettled()).toBe(true);
+  });
+
   it("rejects settlement when the canonical target lock cannot be released", async () => {
     const releaseRunner = createDeferred();
     const session = await createAdmittedWizardSession(async () => {

--- a/src/gateway/server-methods/setup-admission.ts
+++ b/src/gateway/server-methods/setup-admission.ts
@@ -1,5 +1,7 @@
 import { resolveStateDir } from "../../config/paths.js";
 import { FILE_LOCK_TIMEOUT_ERROR_CODE } from "../../infra/file-lock.js";
+import { createDeferred } from "../../shared/deferred.js";
+import { WizardSession } from "../../wizard/session.js";
 import { withSetupMigrationTargetLock } from "../../wizard/setup.migration-snapshot.js";
 
 export const SETUP_ADMISSION_BUSY_MESSAGE =
@@ -27,34 +29,58 @@ export async function runExclusiveSystemAgentSetupActivation<T>(
   }
 }
 
-export async function createAdmittedWizardSession<T extends { whenSettled(): Promise<unknown> }>(
-  createSession: () => T,
-  lockSetupTarget = true,
-): Promise<T | undefined> {
+export async function createAdmittedWizardSession(
+  runner: ConstructorParameters<typeof WizardSession>[0],
+  options?: { lockSetupTarget?: boolean; timeoutMs?: number },
+): Promise<WizardSession | undefined> {
   if (wizardSessionInProgress) {
     return undefined;
   }
   wizardSessionInProgress = true;
-  const releaseSession = () => {
+  const runnerSettled = createDeferred();
+  let ownerRelease: Promise<void>;
+  const releaseProcessAdmission = () => {
     wizardSessionInProgress = false;
   };
-  try {
-    const session = lockSetupTarget
-      ? await new Promise<T>((resolve, reject) => {
-          void runExclusiveSystemAgentSetupActivation(async () => {
-            const createdSession = createSession();
-            resolve(createdSession);
-            await createdSession.whenSettled();
-          }).catch(reject);
-        })
-      : createSession();
-    void session.whenSettled().then(releaseSession, releaseSession);
-    return session;
-  } catch (error) {
-    releaseSession();
-    if (error instanceof SetupAdmissionBusyError) {
-      return undefined;
+  const createSession = () =>
+    new WizardSession(runner, {
+      ...(options?.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
+      // The lock owner observes raw runner completion; public settlement waits
+      // for this admission's process reservation and target lock to be released.
+      awaitOwnerRelease: async () => {
+        runnerSettled.resolve(undefined);
+        await ownerRelease;
+      },
+    });
+  if (options?.lockSetupTarget !== false) {
+    const sessionStarted = createDeferred<WizardSession>();
+    let sessionCreated = false;
+    const admission = runExclusiveSystemAgentSetupActivation(async () => {
+      const session = createSession();
+      sessionCreated = true;
+      sessionStarted.resolve(session);
+      await runnerSettled.promise;
+    });
+    ownerRelease = admission.finally(releaseProcessAdmission);
+    void ownerRelease.catch((error: unknown) => {
+      if (!sessionCreated) {
+        sessionStarted.reject(error);
+      }
+    });
+    try {
+      return await sessionStarted.promise;
+    } catch (error) {
+      if (error instanceof SetupAdmissionBusyError) {
+        return undefined;
+      }
+      throw error;
     }
+  }
+  ownerRelease = runnerSettled.promise.finally(releaseProcessAdmission);
+  try {
+    return createSession();
+  } catch (error) {
+    releaseProcessAdmission();
     throw error;
   }
 }

--- a/src/gateway/server-methods/setup-admission.ts
+++ b/src/gateway/server-methods/setup-admission.ts
@@ -11,6 +11,59 @@ let wizardSessionInProgress = false;
 
 export class SetupAdmissionBusyError extends Error {}
 
+type WizardSessionRunner = ConstructorParameters<typeof WizardSession>[0];
+
+class AdmittedWizardSession extends WizardSession {
+  private readonly admittedSettlement: Promise<void>;
+  private lifecycleSettled = false;
+  private ownerReleaseError: string | undefined;
+
+  constructor(
+    runner: WizardSessionRunner,
+    options: { ownerRelease: () => Promise<void>; timeoutMs?: number },
+  ) {
+    super(
+      async (...args) => {
+        // The base constructor starts its runner immediately. Yield until this
+        // subtype's settlement overrides are initialized before exposing it.
+        await Promise.resolve();
+        await runner(...args);
+      },
+      options.timeoutMs === undefined ? undefined : { timeoutMs: options.timeoutMs },
+    );
+    // Base settlement is raw runner completion. Only this Gateway-owned subtype
+    // extends it through release of the process reservation and target lock.
+    this.admittedSettlement = super
+      .whenSettled()
+      .then(() => options.ownerRelease())
+      .catch((error: unknown) => {
+        this.ownerReleaseError = String(error);
+        throw error;
+      })
+      .finally(() => {
+        this.lifecycleSettled = true;
+      });
+    // Release can fail before a detached Gateway caller observes settlement.
+    void this.admittedSettlement.catch(() => undefined);
+  }
+
+  override getStatus() {
+    return this.ownerReleaseError === undefined ? super.getStatus() : "error";
+  }
+
+  override isSettled(): boolean {
+    return this.lifecycleSettled;
+  }
+
+  override whenSettled(): Promise<void> {
+    return this.admittedSettlement;
+  }
+
+  override getError(): string | undefined {
+    return this.ownerReleaseError ?? super.getError();
+  }
+}
+
 export async function runExclusiveSystemAgentSetupActivation<T>(
   task: () => Promise<T>,
 ): Promise<T> {
@@ -30,7 +83,7 @@ export async function runExclusiveSystemAgentSetupActivation<T>(
 }
 
 export async function createAdmittedWizardSession(
-  runner: ConstructorParameters<typeof WizardSession>[0],
+  runner: WizardSessionRunner,
   options?: { lockSetupTarget?: boolean; timeoutMs?: number },
 ): Promise<WizardSession | undefined> {
   if (wizardSessionInProgress) {
@@ -43,11 +96,9 @@ export async function createAdmittedWizardSession(
     wizardSessionInProgress = false;
   };
   const createSession = () =>
-    new WizardSession(runner, {
+    new AdmittedWizardSession(runner, {
       ...(options?.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
-      // The lock owner observes raw runner completion; public settlement waits
-      // for this admission's process reservation and target lock to be released.
-      awaitOwnerRelease: async () => {
+      ownerRelease: async () => {
         runnerSettled.resolve(undefined);
         await ownerRelease;
       },

--- a/src/gateway/server-methods/system-agent.test.ts
+++ b/src/gateway/server-methods/system-agent.test.ts
@@ -406,6 +406,7 @@ describe("openclaw.setup", () => {
     });
     await session.answer(first.step.id, null);
     await expect(session.next()).resolves.toMatchObject({ done: true, status: "done" });
+    await session.whenSettled();
   });
   it("runs the selected provider method in a shared wizard session and commits its config", async () => {
     const preparedConfig: OpenClawConfig = {
@@ -464,6 +465,7 @@ describe("openclaw.setup", () => {
       baseSnapshot: expect.objectContaining({ hash: "prepare-base-hash" }),
       baseHash: "prepare-base-hash",
     });
+    await session.whenSettled();
   });
 });
 

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -44,7 +44,6 @@ import {
   readTranscriptTail,
 } from "../../system-agent/transcript-store.js";
 import { resolveUserPath } from "../../utils.js";
-import { WizardSession } from "../../wizard/session.js";
 import {
   buildRequestedApprovalEvent,
   handlePendingApprovalRequest,
@@ -329,35 +328,31 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
     }
     const sessionId = params.sessionId;
     const session = await createAdmittedWizardSession(
-      () =>
-        new WizardSession(
-          async (prompter, signal, runnerSession) => {
-            const result = await runSystemAgentGatewayTask(async () => {
-              const { activateSetupInference } =
-                await import("../../system-agent/setup-inference.js");
-              return await activateSetupInference({
-                kind: "provider-auth",
-                authChoice: params.authChoice,
-                ...(params.workspace !== undefined ? { workspace: params.workspace } : {}),
-                surface: "gateway",
-                runtime: {
-                  ...defaultRuntime,
-                  exit: (code: number | undefined): never => {
-                    throw new Error(`setup step exited with code ${String(code)}`);
-                  },
-                },
-                prompter,
-                signal,
-                isCancelled: () => signal.aborted,
-                onCommitStarted: () => runnerSession.lockCancellation(),
-              });
-            });
-            if (!result.ok) {
-              throw new Error(result.error);
-            }
-          },
-          { timeoutMs: PROVIDER_AUTH_SESSION_TIMEOUT_MS },
-        ),
+      async (prompter, signal, runnerSession) => {
+        const result = await runSystemAgentGatewayTask(async () => {
+          const { activateSetupInference } = await import("../../system-agent/setup-inference.js");
+          return await activateSetupInference({
+            kind: "provider-auth",
+            authChoice: params.authChoice,
+            ...(params.workspace !== undefined ? { workspace: params.workspace } : {}),
+            surface: "gateway",
+            runtime: {
+              ...defaultRuntime,
+              exit: (code: number | undefined): never => {
+                throw new Error(`setup step exited with code ${String(code)}`);
+              },
+            },
+            prompter,
+            signal,
+            isCancelled: () => signal.aborted,
+            onCommitStarted: () => runnerSession.lockCancellation(),
+          });
+        });
+        if (!result.ok) {
+          throw new Error(result.error);
+        }
+      },
+      { timeoutMs: PROVIDER_AUTH_SESSION_TIMEOUT_MS },
     );
     if (!session) {
       respondRetryableSetupUnavailable(respond, SETUP_ADMISSION_BUSY_MESSAGE);
@@ -381,63 +376,58 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
     }
     const sessionId = params.sessionId;
     const session = await createAdmittedWizardSession(
-      () =>
-        new WizardSession(
-          async (prompter, signal, runnerSession) => {
-            await runSystemAgentGatewayTask(async () => {
-              const [{ applyAuthChoiceLoadedPluginProvider }, setupShared] = await Promise.all([
-                import("../../plugins/provider-auth-choice.js"),
-                import("../../wizard/setup.shared.js"),
-              ]);
-              const snapshot = await setupShared.readSetupConfigFileSnapshot();
-              if (!snapshot.valid) {
-                throw new Error(
-                  "Config is invalid. Run `openclaw doctor` before preparing a model.",
-                );
-              }
-              // Match the classic wizard: mutate the authored shape, not runtimeConfig,
-              // so setup never writes resolved runtime defaults into openclaw.json.
-              const baseConfig = snapshot.exists ? snapshot.sourceConfig : {};
-              const workspaceDir = params.workspace?.trim()
-                ? resolveUserPath(params.workspace.trim())
-                : undefined;
-              const applied = await applyAuthChoiceLoadedPluginProvider({
-                authChoice: params.authChoice,
-                config: baseConfig,
-                prompter,
-                runtime: {
-                  ...defaultRuntime,
-                  exit: (code: number | undefined): never => {
-                    throw new Error(`setup step exited with code ${String(code)}`);
-                  },
-                },
-                setDefaultModel: false,
-                preserveExistingDefaultModel: true,
-                ...(workspaceDir ? { workspaceDir } : {}),
-                signal,
-                isRemote: true,
-                beforePersistentEffect: () => {
-                  signal.throwIfAborted();
-                  runnerSession.lockCancellation();
-                },
-              });
-              if (!applied || applied.retrySelection) {
-                throw new Error(`Provider prepare method is unavailable: ${params.authChoice}`);
-              }
+      async (prompter, signal, runnerSession) => {
+        await runSystemAgentGatewayTask(async () => {
+          const [{ applyAuthChoiceLoadedPluginProvider }, setupShared] = await Promise.all([
+            import("../../plugins/provider-auth-choice.js"),
+            import("../../wizard/setup.shared.js"),
+          ]);
+          const snapshot = await setupShared.readSetupConfigFileSnapshot();
+          if (!snapshot.valid) {
+            throw new Error("Config is invalid. Run `openclaw doctor` before preparing a model.");
+          }
+          // Match the classic wizard: mutate the authored shape, not runtimeConfig,
+          // so setup never writes resolved runtime defaults into openclaw.json.
+          const baseConfig = snapshot.exists ? snapshot.sourceConfig : {};
+          const workspaceDir = params.workspace?.trim()
+            ? resolveUserPath(params.workspace.trim())
+            : undefined;
+          const applied = await applyAuthChoiceLoadedPluginProvider({
+            authChoice: params.authChoice,
+            config: baseConfig,
+            prompter,
+            runtime: {
+              ...defaultRuntime,
+              exit: (code: number | undefined): never => {
+                throw new Error(`setup step exited with code ${String(code)}`);
+              },
+            },
+            setDefaultModel: false,
+            preserveExistingDefaultModel: true,
+            ...(workspaceDir ? { workspaceDir } : {}),
+            signal,
+            isRemote: true,
+            beforePersistentEffect: () => {
               signal.throwIfAborted();
               runnerSession.lockCancellation();
-              await setupShared.writeWizardConfigFile(applied.config, {
-                allowConfigSizeDrop: false,
-                baseSnapshot: snapshot,
-                ...(snapshot.hash ? { baseHash: snapshot.hash } : {}),
-              });
-              if (applied.agentModelOverride) {
-                runnerSession.setPreparedModelRef(applied.agentModelOverride);
-              }
-            });
-          },
-          { timeoutMs: PROVIDER_PREPARE_SESSION_TIMEOUT_MS },
-        ),
+            },
+          });
+          if (!applied || applied.retrySelection) {
+            throw new Error(`Provider prepare method is unavailable: ${params.authChoice}`);
+          }
+          signal.throwIfAborted();
+          runnerSession.lockCancellation();
+          await setupShared.writeWizardConfigFile(applied.config, {
+            allowConfigSizeDrop: false,
+            baseSnapshot: snapshot,
+            ...(snapshot.hash ? { baseHash: snapshot.hash } : {}),
+          });
+          if (applied.agentModelOverride) {
+            runnerSession.setPreparedModelRef(applied.agentModelOverride);
+          }
+        });
+      },
+      { timeoutMs: PROVIDER_PREPARE_SESSION_TIMEOUT_MS },
     );
     if (!session) {
       respondRetryableSetupUnavailable(respond, SETUP_ADMISSION_BUSY_MESSAGE);

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -17,7 +17,7 @@ import { createNonExitingRuntime, ExitError, type RuntimeEnv } from "../../runti
 import type { WizardPrompter } from "../../wizard/prompts.js";
 import {
   sanitizeWizardStepForClient,
-  WizardSession,
+  type WizardSession,
   type WizardStep,
 } from "../../wizard/session.js";
 import { formatForLog } from "../ws-log.js";
@@ -80,7 +80,7 @@ function retainGatewayWorkUntilSettled(session: WizardSession): void {
   // active between steps or a config reload can erase the process-local session.
   const release = retainGatewayRootWorkAdmissionContinuation();
   if (release) {
-    void session.whenSettled().then(release);
+    void session.whenSettled().then(release, release);
   }
 }
 
@@ -112,9 +112,9 @@ export const wizardHandlers: GatewayRequestHandlers = {
     }
     const sessionId = randomUUID();
     const flow = params.flow ?? "setup";
-    const createSession = () =>
+    const runner: Parameters<typeof createAdmittedWizardSession>[0] =
       flow === "channels"
-        ? new WizardSession((prompter, _signal, wizardSession) =>
+        ? (prompter, _signal, wizardSession) =>
             runHostedWizard((runtime) =>
               context.channelWizardRunner(
                 {
@@ -127,9 +127,8 @@ export const wizardHandlers: GatewayRequestHandlers = {
                 runtime,
                 prompter,
               ),
-            ),
-          )
-        : new WizardSession((prompter) =>
+            )
+        : (prompter) =>
             runHostedWizard((runtime) =>
               context.wizardRunner(
                 {
@@ -140,9 +139,10 @@ export const wizardHandlers: GatewayRequestHandlers = {
                 runtime,
                 prompter,
               ),
-            ),
-          );
-    const session = await createAdmittedWizardSession(createSession, flow === "setup");
+            );
+    const session = await createAdmittedWizardSession(runner, {
+      lockSetupTarget: flow === "setup",
+    });
     if (!session) {
       respond(
         false,
@@ -157,8 +157,7 @@ export const wizardHandlers: GatewayRequestHandlers = {
     if (result.done) {
       // Let the runner release setup admission before the terminal response,
       // so an immediate replacement wizard is not rejected as still busy.
-      await session.whenSettled();
-      context.purgeWizardSession(sessionId);
+      await session.whenSettled().finally(() => context.purgeWizardSession(sessionId));
     }
     respond(true, { sessionId, ...sanitizeWizardResultForClient(result) }, undefined);
   },
@@ -198,8 +197,7 @@ export const wizardHandlers: GatewayRequestHandlers = {
     const result = await session.next();
     if (result.done) {
       // Keep terminal response ordering identical to wizard.start.
-      await session.whenSettled();
-      context.purgeWizardSession(sessionId);
+      await session.whenSettled().finally(() => context.purgeWizardSession(sessionId));
     }
     respond(true, sanitizeWizardResultForClient(result), undefined);
   },
@@ -215,7 +213,8 @@ export const wizardHandlers: GatewayRequestHandlers = {
     const cancelled = session.cancel();
     const status = readWizardStatus(session);
     if (cancelled) {
-      void session.whenSettled().then(() => context.purgeWizardSession(sessionId));
+      const purge = () => context.purgeWizardSession(sessionId);
+      void session.whenSettled().then(purge, purge);
     } else {
       context.purgeWizardSession(sessionId);
     }

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -257,7 +257,7 @@ class WizardSessionPrompter implements WizardPrompter {
 export class WizardSession {
   private readonly abortController = new AbortController();
   private readonly expiryTimer: ReturnType<typeof setTimeout> | undefined;
-  private readonly runnerPromise: Promise<void>;
+  private readonly settlementPromise: Promise<void>;
   private currentStep: WizardStep | null = null;
   private progressSteps: WizardStep[] = [];
   private deliveredProgressStepIds = new Set<string>();
@@ -285,14 +285,31 @@ export class WizardSession {
       signal: AbortSignal,
       session: WizardSession,
     ) => Promise<void>,
-    options?: { timeoutMs?: number },
+    options?: { timeoutMs?: number; awaitOwnerRelease?: () => Promise<void> },
   ) {
     const prompter = new WizardSessionPrompter(this);
     if (options?.timeoutMs !== undefined) {
       this.expiryTimer = setTimeout(() => this.cancel(), options.timeoutMs);
       this.expiryTimer.unref?.();
     }
-    this.runnerPromise = this.run(prompter);
+    const awaitOwnerRelease = options?.awaitOwnerRelease;
+    const runnerPromise = this.run(prompter, awaitOwnerRelease === undefined);
+    this.settlementPromise = awaitOwnerRelease
+      ? runnerPromise.then(awaitOwnerRelease).then(
+          () => {
+            this.settled = true;
+          },
+          (error: unknown) => {
+            this.status = "error";
+            this.error = String(error);
+            this.settled = true;
+            throw error;
+          },
+        )
+      : runnerPromise;
+    // Owner release can fail before a remote client observes the session.
+    // Mark this promise handled without converting the rejection returned to callers.
+    void this.settlementPromise.catch(() => undefined);
   }
 
   async next(): Promise<WizardNextResult> {
@@ -452,7 +469,7 @@ export class WizardSession {
     return url;
   }
 
-  private async run(prompter: WizardPrompter) {
+  private async run(prompter: WizardPrompter, settleWithRunner: boolean) {
     try {
       await this.runner(prompter, this.signal, this);
       if (this.status === "running") {
@@ -470,7 +487,9 @@ export class WizardSession {
         this.error = String(err);
       }
     } finally {
-      this.settled = true;
+      if (settleWithRunner) {
+        this.settled = true;
+      }
       if (this.expiryTimer) {
         clearTimeout(this.expiryTimer);
       }
@@ -509,14 +528,14 @@ export class WizardSession {
     return this.status;
   }
 
-  /** Whether the runner has stopped and can no longer mutate setup state. */
+  /** Whether the runner and its owning lifecycle have both finished. */
   isSettled(): boolean {
     return this.settled;
   }
 
-  /** Resolves after the runner can no longer mutate setup state. */
+  /** Resolves after the runner and its owning lifecycle have both finished. */
   whenSettled(): Promise<void> {
-    return this.runnerPromise;
+    return this.settlementPromise;
   }
 
   getError(): string | undefined {

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -257,7 +257,7 @@ class WizardSessionPrompter implements WizardPrompter {
 export class WizardSession {
   private readonly abortController = new AbortController();
   private readonly expiryTimer: ReturnType<typeof setTimeout> | undefined;
-  private readonly settlementPromise: Promise<void>;
+  private readonly runnerPromise: Promise<void>;
   private currentStep: WizardStep | null = null;
   private progressSteps: WizardStep[] = [];
   private deliveredProgressStepIds = new Set<string>();
@@ -285,31 +285,14 @@ export class WizardSession {
       signal: AbortSignal,
       session: WizardSession,
     ) => Promise<void>,
-    options?: { timeoutMs?: number; awaitOwnerRelease?: () => Promise<void> },
+    options?: { timeoutMs?: number },
   ) {
     const prompter = new WizardSessionPrompter(this);
     if (options?.timeoutMs !== undefined) {
       this.expiryTimer = setTimeout(() => this.cancel(), options.timeoutMs);
       this.expiryTimer.unref?.();
     }
-    const awaitOwnerRelease = options?.awaitOwnerRelease;
-    const runnerPromise = this.run(prompter, awaitOwnerRelease === undefined);
-    this.settlementPromise = awaitOwnerRelease
-      ? runnerPromise.then(awaitOwnerRelease).then(
-          () => {
-            this.settled = true;
-          },
-          (error: unknown) => {
-            this.status = "error";
-            this.error = String(error);
-            this.settled = true;
-            throw error;
-          },
-        )
-      : runnerPromise;
-    // Owner release can fail before a remote client observes the session.
-    // Mark this promise handled without converting the rejection returned to callers.
-    void this.settlementPromise.catch(() => undefined);
+    this.runnerPromise = this.run(prompter);
   }
 
   async next(): Promise<WizardNextResult> {
@@ -469,7 +452,7 @@ export class WizardSession {
     return url;
   }
 
-  private async run(prompter: WizardPrompter, settleWithRunner: boolean) {
+  private async run(prompter: WizardPrompter) {
     try {
       await this.runner(prompter, this.signal, this);
       if (this.status === "running") {
@@ -487,9 +470,7 @@ export class WizardSession {
         this.error = String(err);
       }
     } finally {
-      if (settleWithRunner) {
-        this.settled = true;
-      }
+      this.settled = true;
       if (this.expiryTimer) {
         clearTimeout(this.expiryTimer);
       }
@@ -528,14 +509,14 @@ export class WizardSession {
     return this.status;
   }
 
-  /** Whether the runner and its owning lifecycle have both finished. */
+  /** Whether the runner has stopped and can no longer mutate setup state. */
   isSettled(): boolean {
     return this.settled;
   }
 
-  /** Resolves after the runner and its owning lifecycle have both finished. */
+  /** Resolves after the runner can no longer mutate setup state. */
   whenSettled(): Promise<void> {
-    return this.settlementPromise;
+    return this.runnerPromise;
   }
 
   getError(): string | undefined {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who completed a setup wizard and immediately started setup again could spuriously receive `OpenClaw setup is already in progress` even after awaiting wizard settlement. The unreleased admission could also leak into later wizard operations and make otherwise independent tests fail intermittently.

The failure was observed in [PR #121621 CI attempt 1](https://github.com/openclaw/openclaw/actions/runs/31398300239/job/93487045847?pr=121621). The retry passed, matching the timing-sensitive local reproduction.

## Why This Change Was Made

The base `WizardSession.whenSettled()` contract represents runner completion, while Gateway setup admission also owns a process-local reservation and the canonical filesystem target lock. [PR #121415](https://github.com/openclaw/openclaw/pull/121415) composed those owners on later promise chains, and [commit `5c308e0`](https://github.com/openclaw/openclaw/commit/5c308e0ebacfa92a9992d77f342facd0bbcef90e) later relied on settlement to guarantee release before terminal responses. The session promise could therefore resolve before the admission owner finished releasing.

This change keeps the public `WizardSession` contract unchanged and introduces a private Gateway-owned admitted-session subtype. It observes base runner settlement, then extends only the admitted session's `whenSettled()` through process reservation and target-lock release. Lock-release failure rejects settlement and is exposed as a terminal session error. Cancellation, timeout options, non-locking channel sessions, and ordinary runner failures retain their existing behavior.

This is the owner-boundary fix: sleeps, retries, and consumer-side polling would mask the race, while a public `WizardSession` constructor option would unnecessarily change a transitive Plugin SDK contract.

## User Impact

Immediate setup retries and replacement wizards no longer fail spuriously as still busy after the previous wizard has settled. A caller awaiting an admitted session's settlement can rely on setup ownership having been released; if lock release itself fails, the caller receives a truthful terminal failure instead of false settlement.

## Evidence

- Pre-fix reproduction: 10 sequential runs of `node scripts/run-vitest.mjs src/gateway/server-methods/wizard.test.ts` failed 6/10, including the reported busy assertion, later leaked-admission failures, and one timeout.
- Final post-fix stress: the same bounded loop passed 10/10 (160 test executions) with 0 failures.
- Focused owner and sibling suite: `node scripts/run-vitest.mjs src/gateway/server-methods/system-agent.test.ts src/gateway/server-methods/setup-admission.test.ts src/gateway/server-methods/wizard.test.ts src/gateway/server-wizard-sessions.test.ts src/wizard/session.test.ts` passed 80 tests.
- Exact core test types passed.
- Plugin SDK API baseline passed without generated changes; the final PR has no `src/wizard/session.ts` diff.
- Targeted `oxfmt --check`, core `oxlint`, `git diff --check`, and production/full-tree/script unused-export checks passed.
- Fresh uncommitted and branch-mode Codex-backed autoreviews completed with no accepted/actionable P0-P2 findings.
- Direct dependency proof: inspected `@openclaw/fs-safe` file-lock and sidecar-lock implementations. `withLock` awaits `lock.release`; release can reject after dropping its in-process held entry while leaving the sidecar. Regression coverage uses the dependency's official test hook to verify admitted settlement rejects and reports a terminal error on that path.
- A synchronous-start regression verifies the subclass settlement overrides are initialized before the wrapped runner can observe its owner session.
- Test cleanup explicitly awaits full admitted settlement in system-agent auth and prepare sessions so ownership cannot leak between tests.
- Production LOC: +186/-120 (net +66), establishing the private owner lifecycle while deleting duplicate session construction from wizard and system-agent callers. Tests: +87/-31 (net +56).
- No public Plugin SDK, config, schema, protocol, dependency, docs, changelog, release, or version change.

### Remote and CI status

- Earlier Blacksmith Testbox changed-gate attempt: `provider=blacksmith-testbox`, id `tbx_01kzp6kxbhkh0kks0v2bgh2s9r`, [run 31406899674](https://github.com/openclaw/openclaw/actions/runs/31406899674). It stopped before typecheck/lint because that then-current base measured 503 `OPENCLAW_*` names against a stale shrink-only budget of 507. Current `main` later lowered the budget to 503; this PR does not modify that baseline.
- A prior exact-head run exposed that the first implementation's `WizardSession` constructor option changed transitive Plugin SDK closure hashes. The final private subtype removes that public-contract drift; the SDK baseline is green without generated changes.
- Final exact-head CI: [run 31420901957](https://github.com/openclaw/openclaw/actions/runs/31420901957).

## AI Assistance

- [x] AI-assisted
- [x] I understand the change and verified the owner boundary, tests, dependency contract, and exact branch diff.
- [x] No agent transcript is included.
