### PR TITLE
fix(agents): repair failover retry accounting ownership

### DIFF
--- a/src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts
@@ -182,7 +182,12 @@ function makeAttemptForFault(
       terminal: {
         kind: "failed",
         source: "prompt",
-        error: Object.assign(new Error("500 Internal Server Error"), { status: 500 }),
+        error: Object.assign(
+          new Error(
+            '500 Internal Server Error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request."}}',
+          ),
+          { status: 500 },
+        ),
       },
     });
   }
@@ -371,7 +376,7 @@ describe("runEmbeddedAgent provider fault sequences", () => {
       expect(outcome.model).toBe("mock-3");
       expect(outcome.attempts).toMatchObject([
         { provider: "openai", model: "mock-1", reason: expect.stringMatching(/^auth/) },
-        // FIXED(refactor-02): the prompt-stage HTTP 500 keeps its concrete server-error reason.
+        // FIXED(refactor-02): shared message evidence keeps the concrete server-error reason.
         { provider: "groq", model: "mock-2", reason: "server_error" },
       ]);
       expect(outcome.result.payloads?.[0]?.text).toContain("fallback chain ok");
@@ -471,7 +476,7 @@ describe("runEmbeddedAgent provider fault sequences", () => {
         ["groq", "mock-2", "groq:p1"],
         ["groq", "mock-3", "groq:p1"],
       ]);
-      // FIXED(refactor-02): the concrete prompt reason propagates through exhaustion prose and attempts.
+      // FIXED(refactor-02): the shared concrete reason propagates through exhaustion prose and attempts.
       expect(error.message).toMatch(/^All models failed \(3\): /);
       expect(error.message).toMatch(
         /openai\/mock-1: .* \(auth(?:_permanent)?\) \| groq\/mock-2: .* \(server_error\) \| groq\/mock-3: .* \(billing\)/,

--- a/src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts
@@ -371,9 +371,8 @@ describe("runEmbeddedAgent provider fault sequences", () => {
       expect(outcome.model).toBe("mock-3");
       expect(outcome.attempts).toMatchObject([
         { provider: "openai", model: "mock-1", reason: expect.stringMatching(/^auth/) },
-        // BUG(refactor-02): prompt-stage HTTP 500 currently records as timeout even though it
-        // takes the intended cross-model failover path.
-        { provider: "groq", model: "mock-2", reason: "timeout" },
+        // FIXED(refactor-02): the prompt-stage HTTP 500 keeps its concrete server-error reason.
+        { provider: "groq", model: "mock-2", reason: "server_error" },
       ]);
       expect(outcome.result.payloads?.[0]?.text).toContain("fallback chain ok");
 
@@ -472,10 +471,10 @@ describe("runEmbeddedAgent provider fault sequences", () => {
         ["groq", "mock-2", "groq:p1"],
         ["groq", "mock-3", "groq:p1"],
       ]);
-      // FIXED(refactor-02): exhaustion retains the exact prose and carries typed candidate attempts.
+      // FIXED(refactor-02): the concrete prompt reason propagates through exhaustion prose and attempts.
       expect(error.message).toMatch(/^All models failed \(3\): /);
       expect(error.message).toMatch(
-        /openai\/mock-1: .* \(auth(?:_permanent)?\) \| groq\/mock-2: .* \(timeout\) \| groq\/mock-3: .* \(billing\)/,
+        /openai\/mock-1: .* \(auth(?:_permanent)?\) \| groq\/mock-2: .* \(server_error\) \| groq\/mock-3: .* \(billing\)/,
       );
       expect(isFailoverError(error)).toBe(true);
       if (!isFailoverError(error)) {
@@ -483,7 +482,7 @@ describe("runEmbeddedAgent provider fault sequences", () => {
       }
       expect(error.attempts).toMatchObject([
         { provider: "openai", model: "mock-1", reason: "auth" },
-        { provider: "groq", model: "mock-2", reason: "timeout" },
+        { provider: "groq", model: "mock-2", reason: "server_error" },
         { provider: "groq", model: "mock-3", reason: "billing" },
       ]);
       const usageStats = await readUsageStats(agentDir);

--- a/src/agents/embedded-agent-runner/run-loop.ts
+++ b/src/agents/embedded-agent-runner/run-loop.ts
@@ -51,6 +51,7 @@ import {
   createRunRetryBudget,
   isRunRetryBudgetExhausted,
   recordRunRetry,
+  type RunRetryBudget,
 } from "./run/retry-budget.js";
 import { handleRetryLimitExhaustion } from "./run/retry-limit.js";
 import { prepareEmbeddedRunRuntime } from "./run/runtime-preparation.js";
@@ -182,7 +183,7 @@ export async function runPreparedEmbeddedLoop(
   const maxEmptyResponseRetryAttempts = DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT;
 
   const MAX_RUN_RETRY_ATTEMPTS = resolveMaxRunRetryIterations(profileCandidates.length);
-  const runRetryBudget = createRunRetryBudget(MAX_RUN_RETRY_ATTEMPTS);
+  const runRetryBudget: RunRetryBudget = createRunRetryBudget(MAX_RUN_RETRY_ATTEMPTS);
   const contextRecoveryState = createEmbeddedRunContextRecoveryState();
   let bootstrapPromptWarningSignaturesSeen =
     params.bootstrapPromptWarningSignaturesSeen ??

--- a/src/agents/embedded-agent-runner/run/failover-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.test.ts
@@ -747,4 +747,14 @@ describe("mergeRetryFailoverReason", () => {
       }),
     ).toBe("timeout");
   });
+
+  it("preserves a previous concrete reason over a later coarse timeout", () => {
+    expect(
+      mergeRetryFailoverReason({
+        previous: "server_error",
+        failoverReason: null,
+        timedOut: true,
+      }),
+    ).toBe("server_error");
+  });
 });

--- a/src/agents/embedded-agent-runner/run/failover-policy.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.ts
@@ -151,7 +151,7 @@ export function mergeRetryFailoverReason(params: {
   failoverReason: FailoverReason | null;
   timedOut?: boolean;
 }): FailoverReason | null {
-  return params.failoverReason ?? (params.timedOut ? "timeout" : null) ?? params.previous;
+  return params.failoverReason ?? params.previous ?? (params.timedOut ? "timeout" : null);
 }
 
 export function resolveRunFailoverDecision(

--- a/src/agents/embedded-agent-runner/run/helpers.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.ts
@@ -122,6 +122,8 @@ const RUN_RETRY_ITERATIONS_PER_PROFILE = 8;
 const MIN_RUN_RETRY_ITERATIONS = 32;
 const MAX_RUN_RETRY_ITERATIONS = 160;
 
+// This per-run bound multiplies whole-turn overload replays in
+// auto-reply/reply/agent-runner-error-handler.ts; keep their product test aligned.
 // Defensive guard for the outer run loop across all retry branches.
 export function resolveMaxRunRetryIterations(profileCandidateCount: number): number {
   const scaled =

--- a/src/agents/embedded-agent-runner/run/prompt-failure.ts
+++ b/src/agents/embedded-agent-runner/run/prompt-failure.ts
@@ -125,8 +125,12 @@ export async function handleEmbeddedPromptFailure(input: {
     return { action: "complete", result: blockedResult };
   }
 
-  const promptFailoverReason =
+  const classifiedPromptReason =
     promptErrorDetails.reason ?? classifyFailoverReason(errorText, { provider: input.provider });
+  const promptFailoverReason =
+    promptErrorDetails.status === 500 && classifiedPromptReason === "timeout"
+      ? "server_error"
+      : classifiedPromptReason;
   const promptProfileFailureReason = input.resolveAuthProfileFailureReason(promptFailoverReason, {
     providerStarted: input.promptErrorSource === "prompt",
     transientRateLimit:
@@ -268,7 +272,7 @@ export async function handleEmbeddedPromptFailure(input: {
     logFailoverDecision("fallback_model", { status });
     await input.maybeBackoffBeforeOverloadFailover(promptFailoverReason);
     throw (
-      normalizedPromptFailover ??
+      (normalizedPromptFailover?.reason === fallbackReason ? normalizedPromptFailover : null) ??
       new FailoverError(errorText, {
         reason: fallbackReason,
         provider: input.provider,

--- a/src/agents/embedded-agent-runner/run/prompt-failure.ts
+++ b/src/agents/embedded-agent-runner/run/prompt-failure.ts
@@ -125,12 +125,8 @@ export async function handleEmbeddedPromptFailure(input: {
     return { action: "complete", result: blockedResult };
   }
 
-  const classifiedPromptReason =
-    promptErrorDetails.reason ?? classifyFailoverReason(errorText, { provider: input.provider });
   const promptFailoverReason =
-    promptErrorDetails.status === 500 && classifiedPromptReason === "timeout"
-      ? "server_error"
-      : classifiedPromptReason;
+    promptErrorDetails.reason ?? classifyFailoverReason(errorText, { provider: input.provider });
   const promptProfileFailureReason = input.resolveAuthProfileFailureReason(promptFailoverReason, {
     providerStarted: input.promptErrorSource === "prompt",
     transientRateLimit:

--- a/src/agents/embedded-agent-runner/run/retry-budget.ts
+++ b/src/agents/embedded-agent-runner/run/retry-budget.ts
@@ -1,6 +1,6 @@
 export type RunRetryKind = "progress_continuation" | "recovery";
 
-type RunRetryBudget = {
+export type RunRetryBudget = {
   attemptsDispatched: number;
   attemptsCounted: number;
   maxAttempts: number;

--- a/src/agents/failover/signal.ts
+++ b/src/agents/failover/signal.ts
@@ -1,4 +1,8 @@
 /** Persisted and wire-visible failover reason codes. Spellings are frozen. */
+// Retry accounting owners: per-attempt LLM retry — src/llm/utils/retry.ts.
+// Per-run attempt/profile/model rotation — embedded-agent-runner/run/retry-budget.ts.
+// Cross-run process probe throttle — model-fallback-cooldown.ts.
+// Persisted auth-profile cooldowns — auth-profiles/usage.ts.
 export const FAILOVER_REASONS = [
   "auth",
   "auth_permanent",

--- a/src/auto-reply/reply/agent-runner-error-handler.ts
+++ b/src/auto-reply/reply/agent-runner-error-handler.ts
@@ -53,6 +53,8 @@ const MAX_LIVE_SWITCH_RETRIES = 2;
 const TRANSIENT_HTTP_RETRY_DELAY_MS = 2_500;
 // Overload recovery stays inside one turn: bounded backoff absorbs short provider incidents,
 // while the delayed notice prevents a long silent wait without becoming assistant content.
+// This whole-turn bound multiplies the 32..160 per-run budget in
+// agents/embedded-agent-runner/run/helpers.ts; keep their product test aligned.
 const MAX_OVERLOAD_RETRIES = 10;
 const OVERLOAD_RETRY_BASE_DELAY_MS = 2_500;
 const OVERLOAD_RETRY_MAX_DELAY_MS = 30_000;

--- a/src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { formatBillingErrorMessage } from "../../agents/embedded-agent-helpers.js";
+import { resolveMaxRunRetryIterations } from "../../agents/embedded-agent-runner/run/helpers.js";
 import { FailoverError } from "../../agents/failover-error.js";
 import { BILLING_ERROR_USER_MESSAGE } from "../../agents/failover/user-copy.js";
 import { ProviderAuthError } from "../../agents/model-auth.js";
@@ -432,6 +433,8 @@ describe("executeAgentTurn: provider failures", () => {
       const result = await resultPromise;
 
       expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(11);
+      const wholeTurnReruns = state.runEmbeddedAgentMock.mock.calls.length - 1;
+      expect(wholeTurnReruns * resolveMaxRunRetryIterations(17)).toBe(1_600);
       expect(result.kind).toBe("final");
       if (result.kind === "final") {
         expect(result.payload.isError).toBe(true);


### PR DESCRIPTION
## What Problem This Solves

Repairs retry-reason accounting so a concrete classified failure survives later coarse timeout state. Without that precedence, cooldown diagnostics and fallback exhaustion summaries can report `timeout` instead of the real classified terminal reason.

The retry layers also lacked a single ownership map, and the reply layer's 10 whole-turn overload reruns multiplied the embedded run's 32..160-attempt budget without a tested cross-layer invariant.

## Maintainer Decision

| Question | Decision |
|---|---|
| How is a bare status-only HTTP 500 classified? | It stays `timeout` under the shared classifier contract. No stage overrides it. |
| What behavior changes here? | Merge precedence only: a concrete classified reason is never overwritten by the coarse `timedOut` flag or by an earlier normalized timeout error. |
| How do the E2E 500 cases produce `server_error`? | Their fixtures now include a realistic OpenAI-compatible `server_error` response body, so the shared classifier derives `server_error` from message evidence. |

Changing bare-500 routing globally would alter profile rotation and model fallback behavior repo-wide and is intentionally out of scope. The former prompt-only remap has been removed.

## Why This Change Was Made

`mergeRetryFailoverReason` previously gave the coarse `timedOut` flag precedence over an already-recorded concrete reason. The merge now prefers the current classified reason, then the prior concrete reason, and only then synthesizes `timeout`. Fallback escalation also rebuilds an attributed error when an earlier normalized error carries a different coarse reason.

The run retry budget type is exported and used explicitly at its consumers. A compact owner map documents per-attempt, per-run, cross-run process, and persisted accounting. Paired invariant comments and a regression assertion document the current 10 × 160 = 1,600 combined retry ceiling without changing either limit.

The fallback skip cache was evaluated for removal and retained. `docs/concepts/model-failover.md` documents `OPENCLAW_FALLBACK_SKIP_TTL_MS` as an operator-supported opt-in contract, so deleting it would silently change configured behavior.

Production LOC: +13/-4 (net +9) | Tests: +24/-7 (net +17). The remaining production growth is the exported retry-budget typing and the owner-map/cross-path invariant comments required at their owning sites; removing the prompt-only remap shrank the behavioral repair itself.

AI-assisted: yes. I understand and reviewed the resulting code and behavior.

## User Impact

Operators retain the existing bare-HTTP-500 routing contract. When a provider supplies concrete `server_error` evidence, that reason now remains authoritative through cooldown persistence and fallback exhaustion instead of being flattened to `timeout`. Retry counts, cooldown durations, configuration, and environment surfaces are unchanged.

Release-note context: preserve concrete server-error cooldown and exhaustion reasons when later run state also reports a timeout.

## Regression Coverage

- Shared bare-status contract: `src/agents/failover-error.test.ts` asserts `{ status: 500 }` → `timeout`.
- Shared message-evidence contract: the same suite asserts `{ status: 500, message: <OpenAI-compatible server_error payload> }` → `server_error`.
- Merge precedence: `failover-policy.test.ts` asserts prior `server_error` + later `timedOut: true` + no new reason → `server_error`.
- Prompt path: the fault-sequence harness uses the message-bearing 500 fixture and expects the scenario-3 attempt reason to remain `server_error`.
- Outer fallback/exhaustion: the all-fault harness expects both the typed attempt and exhaustion summary segment for the 500 candidate to remain `server_error`.
- Assistant and outer-fallback symmetry comes from all stages consuming the shared classifier contract; there is no prompt-specific classification branch.

## Evidence

- Shared-classifier and merge-policy unit surface: 2 files, 145 tests passed.
- Exact-head CI [31444940305](https://github.com/openclaw/openclaw/actions/runs/31444940305): green; the agent-runner shard includes all five fault-sequence scenarios with the approved concrete-reason expectations.
- Embedded run surface: 383/384 files and 4,716 tests passed locally; 8 async-task tests were blocked by the base-owned local `secret_store_entries` schema guard, while exact-head CI passed.
- Focused fallback/reply proof: reply provider failures 74/74 passed; model fallback core 179/179 passed.
- `pnpm build`: passed, including Plugin SDK export checks, runtime post-build, and Control UI performance budgets.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- `node scripts/check-changed.mjs`: passed on the final rebased head, including formatting, ratchets, API/boundary checks, dead exports, typechecks, lint, and runtime import cycles.
- `git diff --check` and targeted `pnpm format`: passed.
- Autoreview of the policy adjustment: clean, no accepted/actionable findings, confidence 0.99.

The local E2E harness was affected by shared-host setup contention: all five scenarios returned before the first scripted provider attempt (`observations=[]`) against the harness's 250 ms run timeout. Exact-head CI is the authoritative proof and passed the complete fault-sequence file.

## Red-Main Recovery

The original seven failures and two follow-on failures were healed on `main`; temporary branch copies were dropped during rebase:

- Fixes red main: test types (`4e5029e43bb`), lint (`511db367fec`), generated-image cursor/preview (`519c8ed38dc`), memory extra paths (`2d06d46c891`), cron alerts (`21e7f200aa8`), progress/routing expectations (`55afad26c07`).
- Fixes follow-on red main: setup-admission lint (`620ca5f0088`) and lifecycle cleanup (`f8916e4eb2d`).

