### PR TITLE
fix(ci): clear shared main reds for types, memory read, lint

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test-harness.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test-harness.ts
@@ -158,6 +158,7 @@ export type DispatchInboundParams = {
     }) => Promise<void> | void;
     onReasoningEnd?: () => Promise<void> | void;
     onToolStart?: (payload: {
+      toolCallId?: string;
       name?: string;
       phase?: string;
       args?: Record<string, unknown>;
@@ -189,6 +190,7 @@ export type DispatchInboundParams = {
     }) => Promise<void> | void;
     onApprovalEvent?: (payload: { phase?: string; command?: string }) => Promise<void> | void;
     onCommandOutput?: (payload: {
+      toolCallId?: string;
       phase?: string;
       name?: string;
       title?: string;

--- a/packages/memory-host-sdk/src/host/read-file.ts
+++ b/packages/memory-host-sdk/src/host/read-file.ts
@@ -41,8 +41,19 @@ async function isAllowedAdditionalDirectoryPath(
   }
   try {
     await assertNoSymlinkParents({ rootDir: additionalPath, targetPath: absPath });
-  } catch {
-    return false;
+  } catch (err) {
+    // Missing / non-directory intermediate segments under an allowed extra root
+    // should resolve to empty text later, not hard-fail path validation.
+    // fs-safe emits code "not-file" when a parent path component is a regular file.
+    if (isFileMissingError(err)) {
+      return true;
+    }
+    return Boolean(
+      err &&
+      typeof err === "object" &&
+      "code" in err &&
+      (err as { code?: unknown }).code === "not-file",
+    );
   }
   if (!isPathInsideWithRealpath(additionalPath, absPath)) {
     try {

--- a/scripts/full-release-validation-at-sha.mts
+++ b/scripts/full-release-validation-at-sha.mts
@@ -461,6 +461,7 @@ export function assertTrustedWorkflowHarness(
   } catch (error) {
     throw new Error(
       `Tooling SHA ${workflowSha} contains invalid ${TRUSTED_WORKFLOW_PATH}: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
     );
   }
   if (

--- a/src/gateway/managed-image-actions.e2e.test.ts
+++ b/src/gateway/managed-image-actions.e2e.test.ts
@@ -122,7 +122,8 @@ describe("managed image actions Gateway E2E", () => {
             height: 84,
           });
 
-          const authenticated = await fetch(new URL(block.url, fullUrl), {
+          const blockUrl = block.url as string;
+          const authenticated = await fetch(new URL(blockUrl, fullUrl), {
             headers: { Authorization: `Bearer ${GATEWAY_TOKEN}` },
           });
           expect(authenticated.status).toBe(200);

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -6249,7 +6249,6 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     const crossOs = readWorkflow(CROSS_OS_RELEASE_CHECKS_REUSABLE_WORKFLOW);
     const packageAcceptance = readWorkflow(PACKAGE_ACCEPTANCE_WORKFLOW);
     const qaLive = readWorkflow(QA_LIVE_TRANSPORTS_WORKFLOW);
-    const performance = readWorkflow(PERFORMANCE_WORKFLOW);
     const profiles = ["beta", "stable", "full"] as const;
 
     const ciPreflight = workflowJob(CI_WORKFLOW, "preflight");
@@ -6366,8 +6365,11 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     expect(releasePackageTimeouts).toEqual({ beta: 280, stable: 280, full: 310 });
     for (const profile of profiles) {
       const childTimeout = releasePackageTimeouts[profile];
-      expect(childTimeout, `release-package:${profile}`).toBeLessThanOrEqual(420);
-      expect(420 - childTimeout, `release-package:${profile}`).toBeGreaterThanOrEqual(60);
+      expect(childTimeout, `release-package:${profile}`).toEqual(expect.any(Number));
+      expect(childTimeout as number, `release-package:${profile}`).toBeLessThanOrEqual(420);
+      expect(420 - (childTimeout as number), `release-package:${profile}`).toBeGreaterThanOrEqual(
+        60,
+      );
     }
 
     const releaseSummary = workflowJob(RELEASE_CHECKS_WORKFLOW, "summary");

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -4587,12 +4587,15 @@ describe("grouped chat rendering", () => {
 
     expectElement(container, 'button[aria-label="Download image"]', HTMLButtonElement).click();
     await vi.waitFor(() => expect(click).toHaveBeenCalledOnce());
-    expect(click.mock.instances[0]?.download).toBe("Ticketed image.png");
+    const downloadAnchor = click.mock.instances[0] as HTMLAnchorElement | undefined;
+    expect(downloadAnchor?.download).toBe("Ticketed image.png");
 
     expectElement(container, 'button[aria-label="Copy image"]', HTMLButtonElement).click();
     await vi.waitFor(() => expect(copiedBlob?.type).toBe("image/png"));
     await vi.waitFor(() => expect(toastHost.textContent).toContain("Copied!"));
-    expect(fetchMock.mock.calls.filter(([url]) => url === ticketedUrl)).toHaveLength(1);
+    expect(
+      fetchMock.mock.calls.filter((call) => (call as unknown as [string])[0] === ticketedUrl),
+    ).toHaveLength(1);
     expect(resolveArtifactDownload).toHaveBeenCalledTimes(2);
     toastHost.remove();
     container.remove();


### PR DESCRIPTION
## What Problem This Solves

Several independent contributor PRs fail the same CI jobs after rebasing onto current main: `check-test-types`, `checks-node-compact-small-12`, and (on some runs) `check-lint`. The failures are in mainline tests and helpers unrelated to those PR diffs (memory-host-sdk empty-path reads, managed-image download typing, package-acceptance timeouts, Discord draft-progress harness shapes, release validation oxlint).

## Evidence

Local verification on tip of this branch (macOS, Node 26):

```console
$ pnpm exec vitest run packages/memory-host-sdk/src/host/read-file.test.ts
Test Files  1 passed (1)
Tests  4 passed (4)

$ pnpm tsgo:test:root
# exit 0 after package-acceptance timeout typing fix

$ pnpm tsgo:extensions:test
# exit 0 after Discord harness toolCallId fields
```

## Real behavior proof

- **Behavior or issue addressed:** Shared main CI reds that fail every rebased fork PR: memory empty-read under extra paths when a parent path component is a file; tsgo errors in managed-image e2e, chat download mocks, package-acceptance timeouts, Discord draft harness; oxlint preserve-caught-error on full-release validation script.
- **Real environment tested:** macOS arm64, worktree `/tmp/oc-main-ci-fix` on this branch tip.
- **Exact steps or command run after this patch:** ran the memory-host-sdk read-file suite; ran `pnpm tsgo:test:root` and `pnpm tsgo:extensions:test`.
- **Evidence after fix:** terminal results under Evidence (4/4 read-file tests pass; root and extensions test typechecks exit 0).
- **Observed result after fix:** The previously failing empty-path case returns empty text instead of throwing path required; typechecks no longer report the listed TS errors.
- **What was not tested:** Full GitHub Actions matrix on this branch (CI will run after open); cron compact-small-11 stream-trigger assertion drift if still present on main.

## Summary

Small, focused fixes so contributor PRs can go green without bundling unrelated main repairs into product PRs.
