### PR TITLE
fix(ui): stabilize mobile drawer focus E2E

### DIFF
--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -311,6 +311,15 @@ suite.define(() => {
     const drawer = navigation.locator("openclaw-modal-dialog.nav-drawer");
     const dialog = page.getByRole("dialog", { name: "Navigation" });
     const trigger = page.locator(".chat-pane__nav-toggle").first();
+    const readFocusLocation = () =>
+      page.evaluate(() => {
+        // Native dialog tab order may hand focus to browser chrome when no document candidate remains.
+        // `document.hasFocus()` distinguishes that from focus on the underlying inert page.
+        if (!document.hasFocus()) {
+          return "browser-chrome";
+        }
+        return document.activeElement?.closest(".shell-nav") ? "navigation" : "page";
+      });
 
     await expect.poll(() => navigation.getAttribute("inert")).toBe("");
     await expect.poll(() => page.locator(".shell-nav-backdrop").count()).toBe(0);
@@ -333,6 +342,7 @@ suite.define(() => {
     }, afterShowMarker);
     await page.keyboard.press("Enter");
     await expect.poll(() => drawer.getAttribute(afterShowMarker)).toBe("");
+    await expect.poll(readFocusLocation).toBe("navigation");
 
     await expect
       .poll(() => page.locator(".shell").getAttribute("class"))
@@ -341,15 +351,10 @@ suite.define(() => {
     await expect.poll(() => dialog.isVisible()).toBe(true);
     await expect.poll(() => trigger.getAttribute("aria-expanded")).toBe("true");
     await expect.poll(() => trigger.getAttribute("aria-label")).toBe("Collapse sidebar");
-    await expect
-      .poll(() => navigation.evaluate((element) => element.contains(document.activeElement)))
-      .toBe(true);
 
     for (const key of ["Tab", "Tab", "Shift+Tab", "Shift+Tab"] as const) {
       await page.keyboard.press(key);
-      await expect
-        .poll(() => navigation.evaluate((element) => element.contains(document.activeElement)))
-        .toBe(true);
+      await expect.poll(readFocusLocation).not.toBe("page");
     }
 
     expect(

--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -324,7 +324,15 @@ suite.define(() => {
     await expect.poll(() => trigger.getAttribute("aria-expanded")).toBe("false");
     await expect.poll(() => trigger.getAttribute("aria-label")).toBe("Expand sidebar");
     await trigger.focus();
+    const afterShowMarker = "data-e2e-after-show";
+    await drawer.evaluate((element, marker) => {
+      element.removeAttribute(marker);
+      element.addEventListener("wa-after-show", () => element.setAttribute(marker, ""), {
+        once: true,
+      });
+    }, afterShowMarker);
     await page.keyboard.press("Enter");
+    await expect.poll(() => drawer.getAttribute(afterShowMarker)).toBe("");
 
     await expect
       .poll(() => page.locator(".shell").getAttribute("class"))


### PR DESCRIPTION
Related: #121417

## What Problem This Solves

Fixes an issue where the Control UI mobile drawer focus E2E could intermittently fail while exercising keyboard containment, even though the same commit passed unchanged on rerun. The test conflated two browser states: focus on underlying page content, which a modal must prevent, and standards-compliant focus transfer to browser chrome at the edge of native dialog tab order.

## Why This Change Was Made

The test installs a one-shot listener before opening the drawer and waits for Web Awesome's `wa-after-show` lifecycle event before exercising keyboard navigation. It then requires initial autofocus inside navigation and rejects focus on underlying page content during Tab traversal, while allowing native `<dialog>` to transfer focus to browser chrome as permitted by the [HTML sequential-focus-navigation contract](https://html.spec.whatwg.org/multipage/interaction.html) and discussed in [WHATWG HTML #8339](https://github.com/whatwg/html/issues/8339).

The existing forced-focus rejection, nested menu, Escape, backdrop dismissal, and trigger restoration assertions remain unchanged. No sleeps, retries, larger timeouts, browser/OS special cases, or production test seams were added.

AI-assisted; the final patch was independently reviewed with the repository autoreview workflow.

## User Impact

There is no runtime product behavior change. Maintainers get portable Chromium coverage for the mobile drawer's modal isolation, nested menu behavior, dismissal, and focus restoration without treating browser chrome as underlying page content.

Production LOC: +0/-0 | Tests: +19/-6 (net +13)

## Evidence

- Original failure: [CI run 31359658183 attempt 1, `checks-ui-e2e (3/4)`](https://github.com/openclaw/openclaw/actions/runs/31359658183/attempts/1), where `native-nav-sidebar-toggle.e2e.test.ts` timed out at the Tab-containment assertion; the same head SHA passed untouched on attempt 2.
- First repair head proved `wa-after-show` alone was insufficient: Linux still failed the strict “active element always inside navigation” assertion.
- Corrected head `ee90ab91c76923839f7cc44084d43e6e8b45e236`: Linux `checks-ui-e2e (3/4)` passed, proving the browser-chrome/page focus classification on the platform that exposed the flake.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts` — 10/10 passed after the final rebase.
- Bounded stability loop of that exact command — 10/10 fresh file runs passed; 100/100 tests.
- `node scripts/check-changed.mjs -- ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts` — passed via the repository's approved local fallback after Crabbox was unavailable.
- `./node_modules/.bin/oxfmt --check ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts` and `git diff --check` — passed.
- Fresh Codex autoreview — clean; no accepted/actionable findings, 0.99 confidence.
- During landing, unrelated current-main image-preview failures were repaired upstream. Range-diff confirmed those fixes were equivalent or better, so the duplicate temporary commit was dropped and this PR remains focus-only.
