### PR TITLE
fix(update): record verified install receipts even when the handoff fails

### DIFF
--- a/src/infra/restart-sentinel-store.ts
+++ b/src/infra/restart-sentinel-store.ts
@@ -612,8 +612,8 @@ export function writeUpdateInstallReceiptRowSync(
   rawPayload: RestartSentinelPayload,
 ): RestartSentinel {
   const payload = requireValidPayload(rawPayload);
-  if (payload.kind !== "update" || payload.status !== "ok") {
-    throw new TypeError("Update install receipt requires a successful update payload");
+  if (payload.kind !== "update" || payload.stats?.mode !== "git") {
+    throw new TypeError("Update install receipt requires a git update payload");
   }
   const current = readRestartSentinelRowForKeySync(db, UPDATE_INSTALL_RECEIPT_KEY);
   const currentRevision =

--- a/src/infra/restart-sentinel.test.ts
+++ b/src/infra/restart-sentinel.test.ts
@@ -52,7 +52,7 @@ import {
   hasRestartSentinel,
   markUpdateRestartSentinelFailure,
   readRestartSentinel,
-  readSuccessfulGitUpdateReceipt,
+  readVerifiedGitUpdateReceipt,
   summarizeRestartSentinel,
   trimLogTail,
   writeRestartSentinel,
@@ -541,7 +541,14 @@ describe("restart sentinel", () => {
     });
   });
 
-  it("persists the verified Git install receipt after restart", async () => {
+  it.each([
+    { name: "successful update", status: "ok", reason: undefined },
+    {
+      name: "failed handoff",
+      status: "error",
+      reason: "managed-service-handoff-failed",
+    },
+  ] as const)("persists the verified Git install receipt after a $name", async (testCase) => {
     await withRestartSentinelStateDir(async () => {
       await withTempDir({ prefix: "openclaw-install-root-" }, async (tempDir) => {
         const installRoot = path.join(tempDir, "checkout");
@@ -551,10 +558,11 @@ describe("restart sentinel", () => {
         const ts = Date.now();
         await writeRestartSentinel({
           kind: "update",
-          status: "ok",
+          status: testCase.status,
           ts,
           stats: {
             mode: "git",
+            ...(testCase.reason ? { reason: testCase.reason } : {}),
             root: installAlias,
             before: { sha: "aaaaaaaa" },
             after: {
@@ -573,7 +581,7 @@ describe("restart sentinel", () => {
         );
         await clearRestartSentinel();
 
-        await expect(readSuccessfulGitUpdateReceipt()).resolves.toEqual({
+        await expect(readVerifiedGitUpdateReceipt()).resolves.toEqual({
           root: await fs.realpath(installRoot),
           sha: "bbbbbbbb",
           upstreamRef: "origin/main",
@@ -604,19 +612,36 @@ describe("restart sentinel", () => {
         process.cwd(),
       );
 
-      await expect(readSuccessfulGitUpdateReceipt()).resolves.toBeNull();
+      await expect(readVerifiedGitUpdateReceipt()).resolves.toBeNull();
     });
   });
 
-  it("rejects a restarted Git revision that does not match the update result", async () => {
+  it.each([
+    {
+      name: "successful update",
+      status: "ok",
+      runningCommit: "cccccccc",
+      beforeSha: undefined,
+      expectedReason: "restart-revision-mismatch",
+    },
+    {
+      name: "error-status update",
+      status: "error",
+      runningCommit: "aaaaaaaa",
+      beforeSha: "aaaaaaaa",
+      expectedReason: "managed-service-handoff-failed",
+    },
+  ] as const)("rejects a $name whose running Git revision does not match", async (testCase) => {
     await withRestartSentinelStateDir(async () => {
       await writeRestartSentinel({
         kind: "update",
-        status: "ok",
+        status: testCase.status,
         ts: Date.now(),
         stats: {
           mode: "git",
           root: process.cwd(),
+          ...(testCase.beforeSha ? { before: { sha: testCase.beforeSha } } : {}),
+          ...(testCase.status === "error" ? { reason: "managed-service-handoff-failed" } : {}),
           after: { sha: "bbbbbbbb", version: "expected-version" },
         },
       });
@@ -624,17 +649,17 @@ describe("restart sentinel", () => {
       await finalizeUpdateRestartSentinelRunningVersion(
         "actual-version",
         process.env,
-        "cccccccc",
+        testCase.runningCommit,
         process.cwd(),
       );
 
       await expect(readRestartSentinel()).resolves.toMatchObject({
         payload: {
           status: "error",
-          stats: { reason: "restart-revision-mismatch" },
+          stats: { reason: testCase.expectedReason },
         },
       });
-      await expect(readSuccessfulGitUpdateReceipt()).resolves.toBeNull();
+      await expect(readVerifiedGitUpdateReceipt()).resolves.toBeNull();
     });
   });
 
@@ -670,7 +695,7 @@ describe("restart sentinel", () => {
             stats: { reason: "restart-root-mismatch" },
           },
         });
-        await expect(readSuccessfulGitUpdateReceipt()).resolves.toBeNull();
+        await expect(readVerifiedGitUpdateReceipt()).resolves.toBeNull();
       });
     });
   });

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -29,7 +29,7 @@ export type {
   RestartSentinelPayload,
 } from "./restart-sentinel-store.js";
 
-export type SuccessfulGitUpdateReceipt = {
+export type VerifiedGitUpdateReceipt = {
   root: string;
   sha: string;
   upstreamRef?: string;
@@ -175,7 +175,10 @@ export async function finalizeUpdateRestartSentinelRunningVersion(
       if (!finalized) {
         return null;
       }
-      if (payload.status === "ok" && verifiesInstallRoot && verifiesGitRevision && changedInstall) {
+      // This receipt records the install fact proven by the running process. Post-install
+      // failures such as managed-service-handoff-failed keep the sentinel in error without
+      // erasing the upstream fallback for campaign-managed detached installs (#121634).
+      if (stats.mode === "git" && verifiesInstallRoot && verifiesGitRevision && changedInstall) {
         writeUpdateInstallReceiptRowSync(db, payload);
       }
       return changed ? finalized : null;
@@ -264,12 +267,13 @@ async function readUpdateInstallReceiptPayload(
   }
 }
 
-function normalizeSuccessfulGitUpdateReceipt(
+function normalizeVerifiedGitUpdateReceipt(
   payload: RestartSentinelPayload | null,
-): SuccessfulGitUpdateReceipt | null {
+): VerifiedGitUpdateReceipt | null {
+  // Receipt rows are only written after the running install verifies root and revision.
+  // An error status records a post-install failure, not an untrusted install.
   if (
     payload?.kind !== "update" ||
-    payload.status !== "ok" ||
     payload.stats?.mode !== "git" ||
     !isPlainRecord(payload.stats.after)
   ) {
@@ -292,10 +296,10 @@ function normalizeSuccessfulGitUpdateReceipt(
   };
 }
 
-export async function readSuccessfulGitUpdateReceipt(
+export async function readVerifiedGitUpdateReceipt(
   env: NodeJS.ProcessEnv = process.env,
-): Promise<SuccessfulGitUpdateReceipt | null> {
-  return normalizeSuccessfulGitUpdateReceipt(await readUpdateInstallReceiptPayload(env));
+): Promise<VerifiedGitUpdateReceipt | null> {
+  return normalizeVerifiedGitUpdateReceipt(await readUpdateInstallReceiptPayload(env));
 }
 
 export async function hasRestartSentinel(env: NodeJS.ProcessEnv = process.env): Promise<boolean> {

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -1214,14 +1214,22 @@ describe("update-startup", () => {
     });
   });
 
-  it("continues automatic dev campaigns from receipt-backed detached HEAD", async () => {
+  it.each([
+    { name: "successful install", status: "ok", reason: undefined },
+    {
+      name: "failed handoff",
+      status: "error",
+      reason: "managed-service-handoff-failed",
+    },
+  ] as const)("continues automatic dev campaigns from a $name receipt", async (testCase) => {
     runOpenClawStateWriteTransaction(({ db }) => {
       writeUpdateInstallReceiptRowSync(db, {
         kind: "update",
-        status: "ok",
+        status: testCase.status,
         ts: Date.now() - 60_000,
         stats: {
           mode: "git",
+          ...(testCase.reason ? { reason: testCase.reason } : {}),
           root: "/opt/openclaw",
           after: {
             sha: "current-sha",

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -36,10 +36,7 @@ import {
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
 import { resolveOpenClawPackageRoot } from "./openclaw-root.js";
-import {
-  readSuccessfulGitUpdateReceipt,
-  type SuccessfulGitUpdateReceipt,
-} from "./restart-sentinel.js";
+import { readVerifiedGitUpdateReceipt, type VerifiedGitUpdateReceipt } from "./restart-sentinel.js";
 import {
   resolveGatewayRestartDeferralTimeoutMs,
   scheduleGatewaySigusr1Restart,
@@ -577,7 +574,7 @@ async function resolveStartupInstallStatus(fetchGit: boolean) {
       argv1: process.argv[1],
       cwd: process.cwd(),
     }),
-    readSuccessfulGitUpdateReceipt(),
+    readVerifiedGitUpdateReceipt(),
   ]);
   const gitUpstreamFallback =
     installReceipt?.upstreamRef && root && updateInstallRootsMatch(root, installReceipt.root)
@@ -607,7 +604,7 @@ function gitCommitsMatch(left: string, right: string): boolean {
 
 function resolveGitInstalledAtMs(
   git: NonNullable<UpdateCheckResult["git"]>,
-  installReceipt: SuccessfulGitUpdateReceipt | null,
+  installReceipt: VerifiedGitUpdateReceipt | null,
   root: string | null,
 ): number | undefined {
   return installReceipt &&
@@ -621,7 +618,7 @@ function resolveGitInstalledAtMs(
 
 function resolveGitScheduleStatus(
   update: UpdateCheckResult,
-  installReceipt: SuccessfulGitUpdateReceipt | null,
+  installReceipt: VerifiedGitUpdateReceipt | null,
   root: string | null,
 ): GitScheduleStatus | undefined {
   if (update.installKind !== "git") {
@@ -672,7 +669,7 @@ function withInstallStatus(
   schedule: UpdateScheduleState,
   update: UpdateCheckResult,
   includeGitStatus: boolean,
-  installReceipt: SuccessfulGitUpdateReceipt | null,
+  installReceipt: VerifiedGitUpdateReceipt | null,
   root: string | null,
 ): UpdateScheduleState {
   const git = includeGitStatus ? resolveGitScheduleStatus(update, installReceipt, root) : undefined;


### PR DESCRIPTION
## What Problem This Solves

Fixes #121634: dev-channel campaigns stall again — the exact `no-upstream` failure class #121328 closed — when a campaign apply succeeds at the git level but the managed-service handoff's post-restart health check false-negatives. The handoff helper marks the update sentinel `status: "error"` (`reason: "managed-service-handoff-failed"`), and the receipt-backed upstream fallback from #121328 never engages: the install receipt row is only written for `status === "ok"` payloads, and the reader filters non-ok payloads a second time. HEAD stays detached with no resolvable upstream, and `update.status` reports `install.git.status: "unavailable", reason: "no-upstream"` until a human re-attaches the branch. Observed in production 2026-08-10 (3.7 h silent scheduler stall on a Hetzner dev-channel host after a 3000 ms health-probe timeout under post-restart SQLite load; the gateway was healthy moments later).

## Why This Change Was Made

The receipt exists to record one fact: the verified running install — this process is provably running the expected root at the expected revision. The handoff/health outcome is a different fact that already lives in the sentinel status. Conflating them (only trusting the receipt when the whole update including handoff succeeded) is the root cause. Per doctrine, the fact is recorded where it is proven:

- `finalizeUpdateRestartSentinelRunningVersion` now writes the receipt whenever the running install verifies (`mode === "git"` + root match + revision match + install changed), regardless of sentinel status. When the finalize step itself detects a root/revision mismatch, verification fails and no receipt is written — a genuinely failed update still leaves no receipt.
- The receipt write is scoped to git mode: the reader only ever consumed git receipts, and for non-git modes the verification conditions were trivially true, so the old code wrote dead npm rows that could clobber a valid git receipt.
- The reader's redundant `status !== "ok"` filter is removed; receipt rows only exist for verified installs.
- The concept is renamed `Successful…` → `Verified…` (`readVerifiedGitUpdateReceipt`, `VerifiedGitUpdateReceipt`) to match the actual contract. Internal symbols; no compat aliases.

Not in scope (tracked in #121634 as a separate calibration decision): the 3000 ms per-probe health timeout that produced the false negative.

## User Impact

Dev-channel git installs with campaign auto-update keep updating hourly even when a post-restart health probe false-negatives (e.g. large gateways under post-restart SQLite load). The sentinel still reports the handoff error to the operator; the scheduler just no longer loses upstream comparability over it. No config, protocol, or CLI surface changes.

## Evidence

- Regression test written first and confirmed failing on pre-fix code for the intended reason (`1 failed | 40 passed` — `expected null to deeply equal` the receipt in `src/infra/restart-sentinel.test.ts`); passes post-fix.
- Focused suites green via `node scripts/run-vitest.mjs`: `restart-sentinel` + `update-startup` (112 passed), plus #121328 sibling coverage — `update-check`, `update-runner`, `update-managed-service-handoff-command` (116 passed), `update-run-campaign` (13 passed).
- `node scripts/check-changed.mjs` run post-rebase on latest `origin/main` (an earlier run failed only on the env-var-count ratchet already tightened on `main`, plus one Testbox hydration timeout).
- Codex autoreview (`gpt-5.6-sol`, xhigh): clean, no accepted/actionable findings.
- LOC: production +20/−16 (net +4; the growth is the two required inline invariant comments — executable code is net negative), tests +48/−13 (near-duplicate receipt tests folded into `it.each` tables).
- Production incident this repairs: 2026-08-10 dev-channel campaign apply on a Hetzner host — sentinel `status: "error"`, `reason: "managed-service-handoff-failed"` with valid `stats.after.upstreamRef: "origin/main"`, followed by a 3.7 h silent `no-upstream` campaign stall (details in #121634).

## Shared main breakage encountered while landing

`main` was red while this PR was in flight, blocking the merge gate with failures unrelated to the receipt change (type errors, lint, Plugin SDK baseline drift, and stale #121600 sibling tests in cron and auto-reply). Earlier revisions of this branch temporarily carried the cron (`checks-node-compact-small-11`) and auto-reply lifecycle (`checks-node-compact-small-9`) test repairs per the red-main policy; they were dropped once `main` landed equivalent fixes (21e7f200 cron alerts, 55afad26 lifecycle expectations, 4e5029e4 test types, 3d2f134d / #121670 baseline, aa33c63c lint). The branch is now the receipt fix alone on top of healed `main`.
