### PR TITLE
fix(memory): prune stale session index rows at startup

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -13,7 +13,7 @@ import {
   type MemorySyncParams,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { resolveSessionTranscriptsDirForAgent } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
-import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { deleteSessionEntry, upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { resolveOpenClawAgentSqlitePath } from "openclaw/plugin-sdk/sqlite-runtime";
 import {
@@ -5182,6 +5182,68 @@ describe("memory index", () => {
 
       const result = manager.status();
       expect(result.dirty).toBe(true);
+    } finally {
+      restoreMemoryIndexStateDir();
+    }
+  });
+
+  it("status detects and no-force sync prunes indexed sessions removed from the corpus", async () => {
+    forceNoProvider = true;
+    const cfg = createCfg({
+      provider: "none",
+      sources: ["sessions"],
+      sessionMemory: true,
+      minScore: 0,
+    });
+    const stateDirName = ".state-status-stale-session-test";
+    setMemoryIndexStateDir(path.join(workspaceDir, stateDirName));
+    const sessionId = "status-stale-session-test";
+    const sessionKey = `agent:main:memory:${sessionId}`;
+    const storePath = path.join(resolveSessionTranscriptsDirForAgent("main"), "sessions.json");
+    try {
+      await seedMemoryIndexSessionTranscript({
+        sessionId,
+        sessionKey,
+        messages: [
+          {
+            role: "user",
+            timestamp: 1,
+            content: "Deleted session index canary ORBIT-DELETE-91.",
+          },
+        ],
+      });
+
+      const initial = await getFreshManager(cfg, "cli");
+      managersForCleanup.add(initial);
+      await initial.sync({ reason: "cli", force: true });
+      await expect(
+        initial.search("ORBIT-DELETE-91", { minScore: 0, sources: ["sessions"] }),
+      ).resolves.not.toEqual([]);
+      await initial.close?.();
+
+      await expect(
+        deleteSessionEntry({
+          agentId: "main",
+          archiveTranscript: false,
+          expectedSessionId: sessionId,
+          sessionKey,
+          storePath,
+        }),
+      ).resolves.toBe(true);
+
+      const statusManager = await getFreshManager(cfg, "status");
+      managersForCleanup.add(statusManager);
+      expect(statusManager.status().dirty).toBe(true);
+
+      await statusManager.sync({ reason: "cli" });
+      await expect(
+        statusManager.search("ORBIT-DELETE-91", { minScore: 0, sources: ["sessions"] }),
+      ).resolves.toEqual([]);
+      const db = Reflect.get(statusManager, "db") as DatabaseSync;
+      const sourceCount = db
+        .prepare("SELECT COUNT(*) AS count FROM memory_index_sources WHERE source = 'sessions'")
+        .get() as { count: number };
+      expect(sourceCount.count).toBe(0);
     } finally {
       restoreMemoryIndexStateDir();
     }

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -5187,10 +5187,9 @@ describe("memory index", () => {
     }
   });
 
-  it("status detects and no-force sync prunes indexed sessions removed from the corpus", async () => {
-    forceNoProvider = true;
+  it("prunes removed sessions without re-embedding unchanged survivors", async () => {
     const cfg = createCfg({
-      provider: "none",
+      provider: "gemini",
       sources: ["sessions"],
       sessionMemory: true,
       minScore: 0,
@@ -5199,6 +5198,8 @@ describe("memory index", () => {
     setMemoryIndexStateDir(path.join(workspaceDir, stateDirName));
     const sessionId = "status-stale-session-test";
     const sessionKey = `agent:main:memory:${sessionId}`;
+    const survivorId = "status-stale-session-survivor";
+    const survivorKey = `agent:main:memory:${survivorId}`;
     const storePath = path.join(resolveSessionTranscriptsDirForAgent("main"), "sessions.json");
     try {
       await seedMemoryIndexSessionTranscript({
@@ -5212,6 +5213,17 @@ describe("memory index", () => {
           },
         ],
       });
+      await seedMemoryIndexSessionTranscript({
+        sessionId: survivorId,
+        sessionKey: survivorKey,
+        messages: [
+          {
+            role: "user",
+            timestamp: 2,
+            content: "Surviving session index canary ORBIT-SURVIVE-92.",
+          },
+        ],
+      });
 
       const initial = await getFreshManager(cfg, "cli");
       managersForCleanup.add(initial);
@@ -5220,6 +5232,10 @@ describe("memory index", () => {
         initial.search("ORBIT-DELETE-91", { minScore: 0, sources: ["sessions"] }),
       ).resolves.not.toEqual([]);
       await initial.close?.();
+      const agentDb = new DatabaseSync(resolveOpenClawAgentSqlitePath({ agentId: "main" }));
+      agentDb.exec("DELETE FROM memory_embedding_cache");
+      agentDb.close();
+      embedBatchCalls = 0;
 
       await expect(
         deleteSessionEntry({
@@ -5236,14 +5252,20 @@ describe("memory index", () => {
       expect(statusManager.status().dirty).toBe(true);
 
       await statusManager.sync({ reason: "cli" });
+      expect(embedBatchCalls).toBe(0);
+      const deletedResults = await statusManager.search("ORBIT-DELETE-91", {
+        minScore: 0,
+        sources: ["sessions"],
+      });
+      expect(deletedResults.some((result) => result.path.includes(sessionId))).toBe(false);
       await expect(
-        statusManager.search("ORBIT-DELETE-91", { minScore: 0, sources: ["sessions"] }),
-      ).resolves.toEqual([]);
+        statusManager.search("ORBIT-SURVIVE-92", { minScore: 0, sources: ["sessions"] }),
+      ).resolves.not.toEqual([]);
       const db = Reflect.get(statusManager, "db") as DatabaseSync;
       const sourceCount = db
         .prepare("SELECT COUNT(*) AS count FROM memory_index_sources WHERE source = 'sessions'")
         .get() as { count: number };
-      expect(sourceCount.count).toBe(0);
+      expect(sourceCount.count).toBe(1);
     } finally {
       restoreMemoryIndexStateDir();
     }

--- a/extensions/memory-core/src/memory/manager-session-reindex.ts
+++ b/extensions/memory-core/src/memory/manager-session-reindex.ts
@@ -5,7 +5,6 @@ export function shouldSyncSessionsForReindex(params: {
   hasSessionSource: boolean;
   sessionsDirty: boolean;
   sessionsFullRetryDirty?: boolean;
-  dirtySessionFileCount: number;
   sync?: MemorySyncParams;
   needsFullReindex?: boolean;
 }): boolean {
@@ -31,5 +30,5 @@ export function shouldSyncSessionsForReindex(params: {
   if (reason === "session-start" || reason === "watch") {
     return false;
   }
-  return params.sessionsDirty && params.dirtySessionFileCount > 0;
+  return params.sessionsDirty;
 }

--- a/extensions/memory-core/src/memory/manager-session-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-session-sync-ops.ts
@@ -21,7 +21,7 @@ import {
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { shouldSyncSessionsForReindex } from "./manager-session-reindex.js";
 import {
-  resolveMemorySessionStartupDirtyFiles,
+  resolveMemorySessionStartupState,
   type MemorySessionStartupFileState,
 } from "./manager-session-sync-state.js";
 import { loadMemorySourceFileState } from "./manager-source-state.js";
@@ -128,7 +128,7 @@ export abstract class MemoryManagerSessionSyncOps extends MemoryManagerWatchOps 
       return [];
     }
     const corpusEntries = await this.listSessionCorpusEntries();
-    if (corpusEntries.length === 0 || this.closed) {
+    if (this.closed) {
       return [];
     }
     const existingRows = loadMemorySourceFileState({
@@ -168,14 +168,23 @@ export abstract class MemoryManagerSessionSyncOps extends MemoryManagerWatchOps 
         this.getIndexConcurrency(),
       )
     ).filter((file): file is MemorySessionStartupFileState => file !== null);
-    const dirtyFiles = resolveMemorySessionStartupDirtyFiles({ files: fileStates, existingRows });
-    if (dirtyFiles.length === 0 || this.closed) {
+    const { dirtyFiles, hasStaleIndexedPaths } = resolveMemorySessionStartupState({
+      files: fileStates,
+      existingRows,
+    });
+    if (this.closed) {
       return dirtyFiles;
+    }
+    if (hasStaleIndexedPaths) {
+      this.sessionsDirty = true;
+      this.sessionsFullRetryDirty = true;
     }
     for (const file of dirtyFiles) {
       this.sessionsDirtyFiles.add(file);
     }
-    this.sessionsDirty = true;
+    if (dirtyFiles.length > 0) {
+      this.sessionsDirty = true;
+    }
     return dirtyFiles;
   }
 

--- a/extensions/memory-core/src/memory/manager-session-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-session-sync-ops.ts
@@ -177,7 +177,7 @@ export abstract class MemoryManagerSessionSyncOps extends MemoryManagerWatchOps 
     }
     if (hasStaleIndexedPaths) {
       this.sessionsDirty = true;
-      this.sessionsFullRetryDirty = true;
+      this.sessionsReconcileDirty = true;
     }
     for (const file of dirtyFiles) {
       this.sessionsDirtyFiles.add(file);
@@ -190,7 +190,7 @@ export abstract class MemoryManagerSessionSyncOps extends MemoryManagerWatchOps 
 
   protected async runSessionStartupCatchup(): Promise<string[]> {
     const dirtyFiles = await this.markSessionStartupCatchupDirtyFiles();
-    if ((dirtyFiles.length === 0 && !this.sessionsFullRetryDirty) || this.closed) {
+    if (!this.sessionsDirty || this.closed) {
       return dirtyFiles;
     }
     void this.sync({ reason: "session-startup-catchup" }).catch((err: unknown) => {
@@ -344,7 +344,6 @@ export abstract class MemoryManagerSessionSyncOps extends MemoryManagerWatchOps 
       hasSessionSource: this.sources.has("sessions"),
       sessionsDirty: this.sessionsDirty,
       sessionsFullRetryDirty: this.sessionsFullRetryDirty,
-      dirtySessionFileCount: this.sessionsDirtyFiles.size,
       sync: params,
       needsFullReindex,
     });

--- a/extensions/memory-core/src/memory/manager-session-sync-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-session-sync-state.test.ts
@@ -1,7 +1,7 @@
 // Memory Core tests cover manager session sync state plugin behavior.
 import { describe, expect, it } from "vitest";
 import {
-  resolveMemorySessionStartupDirtyFiles,
+  resolveMemorySessionStartupState,
   resolveMemorySessionSyncPlan,
 } from "./manager-session-sync-state.js";
 
@@ -80,7 +80,7 @@ describe("memory session sync state", () => {
   });
 
   it("marks missing and changed startup session files dirty", () => {
-    const dirtyFiles = resolveMemorySessionStartupDirtyFiles({
+    const { dirtyFiles } = resolveMemorySessionStartupState({
       files: [
         {
           absPath: "/tmp/sessions/unchanged.jsonl",
@@ -143,5 +143,16 @@ describe("memory session sync state", () => {
       "/tmp/sessions/resized.jsonl",
       "/tmp/sessions/missing.jsonl",
     ]);
+  });
+
+  it("detects indexed session paths that are absent from the live corpus", () => {
+    expect(
+      resolveMemorySessionStartupState({
+        files: [],
+        existingRows: [
+          { path: "sessions/deleted.jsonl", hash: "hash-deleted", mtime: 100, size: 10 },
+        ],
+      }),
+    ).toEqual({ dirtyFiles: [], hasStaleIndexedPaths: true });
   });
 });

--- a/extensions/memory-core/src/memory/manager-session-sync-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-session-sync-state.test.ts
@@ -6,12 +6,11 @@ import {
 } from "./manager-session-sync-state.js";
 
 describe("memory session sync state", () => {
-  it("tracks active paths and bulk hashes for full scans", () => {
+  it("tracks active paths and bulk hashes without rebuilding unchanged full scans", () => {
     const plan = resolveMemorySessionSyncPlan({
       needsFullReindex: false,
       files: ["/tmp/a.jsonl", "/tmp/b.jsonl"],
       targetSessionFiles: null,
-      sessionsDirtyFiles: new Set(),
       existingRows: [
         { path: "sessions/a.jsonl", hash: "hash-a" },
         { path: "sessions/b.jsonl", hash: "hash-b" },
@@ -19,7 +18,7 @@ describe("memory session sync state", () => {
       sessionPathForFile: (file) => `sessions/${file.split("/").at(-1)}`,
     });
 
-    expect(plan.indexAll).toBe(true);
+    expect(plan.indexAll).toBe(false);
     expect(plan.activePaths).toEqual(new Set(["sessions/a.jsonl", "sessions/b.jsonl"]));
     expect(plan.existingRows).toEqual([
       { path: "sessions/a.jsonl", hash: "hash-a" },
@@ -38,7 +37,6 @@ describe("memory session sync state", () => {
       needsFullReindex: false,
       files: ["/tmp/targeted-first.jsonl"],
       targetSessionFiles: new Set(["/tmp/targeted-first.jsonl"]),
-      sessionsDirtyFiles: new Set(["/tmp/targeted-first.jsonl"]),
       existingRows: [
         { path: "sessions/targeted-first.jsonl", hash: "hash-first" },
         { path: "sessions/targeted-second.jsonl", hash: "hash-second" },
@@ -52,20 +50,6 @@ describe("memory session sync state", () => {
     expect(plan.existingHashes).toBeNull();
   });
 
-  it("keeps dirty-only incremental mode when no targeted sync is requested", () => {
-    const plan = resolveMemorySessionSyncPlan({
-      needsFullReindex: false,
-      files: ["/tmp/incremental.jsonl"],
-      targetSessionFiles: null,
-      sessionsDirtyFiles: new Set(["/tmp/incremental.jsonl"]),
-      existingRows: [],
-      sessionPathForFile: (file) => `sessions/${file.split("/").at(-1)}`,
-    });
-
-    expect(plan.indexAll).toBe(false);
-    expect(plan.activePaths).toEqual(new Set(["sessions/incremental.jsonl"]));
-  });
-
   it("marks identity-targeted syncs as session work", async () => {
     const { shouldSyncSessionsForReindex } = await import("./manager-session-reindex.js");
 
@@ -73,7 +57,6 @@ describe("memory session sync state", () => {
       shouldSyncSessionsForReindex({
         hasSessionSource: true,
         sessionsDirty: false,
-        dirtySessionFileCount: 0,
         sync: { sessions: [{ agentId: "main", sessionId: "targeted" }] },
       }),
     ).toBe(true);

--- a/extensions/memory-core/src/memory/manager-session-sync-state.ts
+++ b/extensions/memory-core/src/memory/manager-session-sync-state.ts
@@ -44,7 +44,6 @@ export function resolveMemorySessionSyncPlan(params: {
   needsFullReindex: boolean;
   files: string[];
   targetSessionFiles: Set<string> | null;
-  sessionsDirtyFiles: Set<string>;
   existingRows?: MemorySourceFileStateRow[] | null;
   sessionPathForFile: (file: string) => string;
 }): {
@@ -61,9 +60,6 @@ export function resolveMemorySessionSyncPlan(params: {
     activePaths,
     existingRows,
     existingHashes: existingRows ? new Map(existingRows.map((row) => [row.path, row.hash])) : null,
-    indexAll:
-      params.needsFullReindex ||
-      Boolean(params.targetSessionFiles) ||
-      params.sessionsDirtyFiles.size === 0,
+    indexAll: params.needsFullReindex || Boolean(params.targetSessionFiles),
   };
 }

--- a/extensions/memory-core/src/memory/manager-session-sync-state.ts
+++ b/extensions/memory-core/src/memory/manager-session-sync-state.ts
@@ -8,11 +8,13 @@ export type MemorySessionStartupFileState = {
   size: number;
 };
 
-export function resolveMemorySessionStartupDirtyFiles(params: {
+export function resolveMemorySessionStartupState(params: {
   files: MemorySessionStartupFileState[];
   existingRows?: MemorySourceFileStateRow[] | null;
-}): string[] {
-  const indexedRows = new Map((params.existingRows ?? []).map((row) => [row.path, row]));
+}): { dirtyFiles: string[]; hasStaleIndexedPaths: boolean } {
+  const existingRows = params.existingRows ?? [];
+  const indexedRows = new Map(existingRows.map((row) => [row.path, row]));
+  const activePaths = new Set(params.files.map((file) => file.path));
   const dirtyFiles: string[] = [];
   for (const file of params.files) {
     const existing = indexedRows.get(file.path);
@@ -32,7 +34,10 @@ export function resolveMemorySessionStartupDirtyFiles(params: {
       dirtyFiles.push(file.absPath);
     }
   }
-  return dirtyFiles;
+  return {
+    dirtyFiles,
+    hasStaleIndexedPaths: existingRows.some((row) => !activePaths.has(row.path)),
+  };
 }
 
 export function resolveMemorySessionSyncPlan(params: {

--- a/extensions/memory-core/src/memory/manager-source-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-source-sync-ops.ts
@@ -205,7 +205,6 @@ export abstract class MemoryManagerSourceSyncOps extends MemoryManagerSessionSyn
       needsFullReindex: params.needsFullReindex,
       files,
       targetSessionFiles: targetArchiveFiles,
-      sessionsDirtyFiles: this.sessionsDirtyFiles,
       existingRows: targetArchiveFiles
         ? null
         : loadMemorySourceFileState({

--- a/extensions/memory-core/src/memory/manager-sync-base.ts
+++ b/extensions/memory-core/src/memory/manager-sync-base.ts
@@ -86,6 +86,7 @@ type MemoryReindexRetryState = {
   memoryFullRetryDirty: boolean;
   sessionsDirty: boolean;
   sessionsFullRetryDirty: boolean;
+  sessionsReconcileDirty: boolean;
   sessionsDirtyFiles: Set<string>;
 };
 
@@ -154,6 +155,9 @@ export abstract class MemoryManagerSyncBase {
   // Failed full reindexes can start with no per-file dirty set. Keep a
   // one-shot all-sessions retry marker so the next non-force sync cannot skip.
   protected sessionsFullRetryDirty = false;
+  // A corpus reconciliation deletes stale indexed paths while leaving unchanged
+  // live sessions untouched. Keep it distinct from a failed full reindex retry.
+  protected sessionsReconcileDirty = false;
   protected sessionsDirtyFiles = new Set<string>();
   protected sessionPendingFiles = new Set<string>();
   protected sessionPendingTargets = new Map<string, MemorySessionSyncTarget>();
@@ -206,6 +210,7 @@ export abstract class MemoryManagerSyncBase {
       memoryFullRetryDirty: this.memoryFullRetryDirty,
       sessionsDirty: this.sessionsDirty,
       sessionsFullRetryDirty: this.sessionsFullRetryDirty,
+      sessionsReconcileDirty: this.sessionsReconcileDirty,
       sessionsDirtyFiles: new Set(this.sessionsDirtyFiles),
     };
   }
@@ -214,11 +219,13 @@ export abstract class MemoryManagerSyncBase {
     this.dirty = snapshot.dirty || this.dirty;
     this.memoryFullRetryDirty = snapshot.memoryFullRetryDirty || this.memoryFullRetryDirty;
     this.sessionsFullRetryDirty = snapshot.sessionsFullRetryDirty || this.sessionsFullRetryDirty;
+    this.sessionsReconcileDirty = snapshot.sessionsReconcileDirty || this.sessionsReconcileDirty;
     this.sessionsDirtyFiles = new Set([...snapshot.sessionsDirtyFiles, ...this.sessionsDirtyFiles]);
     this.sessionsDirty =
       snapshot.sessionsDirty ||
       this.sessionsDirty ||
       this.sessionsFullRetryDirty ||
+      this.sessionsReconcileDirty ||
       this.sessionsDirtyFiles.size > 0;
   }
 
@@ -236,6 +243,7 @@ export abstract class MemoryManagerSyncBase {
   protected clearSessionRetryState(): void {
     this.sessionsDirty = false;
     this.sessionsFullRetryDirty = false;
+    this.sessionsReconcileDirty = false;
     this.sessionsDirtyFiles.clear();
   }
 
@@ -245,7 +253,10 @@ export abstract class MemoryManagerSyncBase {
   }
 
   protected refreshSessionDirtyFlag(): void {
-    this.sessionsDirty = this.sessionsFullRetryDirty || this.sessionsDirtyFiles.size > 0;
+    this.sessionsDirty =
+      this.sessionsFullRetryDirty ||
+      this.sessionsReconcileDirty ||
+      this.sessionsDirtyFiles.size > 0;
   }
 
   protected shouldDeferSourceWideBatch(): boolean {

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -238,6 +238,11 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
     });
   }
 
+  async getCorpusPathsForTest(): Promise<string[]> {
+    const entries = await this.listSessionCorpusEntries();
+    return entries.map((entry) => this.sessionPathForCorpusEntry(entry));
+  }
+
   getDirtyArchiveFiles(): string[] {
     return Array.from(this.sessionsDirtyFiles);
   }
@@ -513,6 +518,20 @@ describe("session startup catch-up", () => {
     expect(harness.syncCalls).toEqual([{ reason: "session-startup-catchup" }]);
   });
 
+  it("prunes indexed sessions that are absent from the live corpus", async () => {
+    const stalePath = "sessions/main/deleted.jsonl";
+    const harness = new SessionStartupCatchupHarness(
+      [{ path: stalePath, hash: "stale-hash", mtime: 10, size: 20 }],
+      true,
+    );
+
+    await expect(harness.catchUp()).resolves.toEqual([]);
+    await harness.waitForSessionSync();
+
+    expect(harness.syncCalls).toEqual([{ reason: "session-startup-catchup" }]);
+    expect(harness.getIndexedSourceState(stalePath)).toBeUndefined();
+  });
+
   it("retries transient session transcript reads during session indexing", async () => {
     const session = await writeSessionFile("thread.jsonl.deleted.2026-02-16T22-27-33.000Z");
     const harness = new SessionStartupCatchupHarness([]);
@@ -595,10 +614,15 @@ describe("session startup catch-up", () => {
   });
 
   it("leaves unchanged indexed session files clean", async () => {
-    const session = await writeSessionFile("thread.jsonl");
+    const session = await writeSessionFile("thread.jsonl.deleted.2026-08-09T00-00-00.000Z");
+    const discovery = new SessionStartupCatchupHarness([]);
+    const [corpusPath] = await discovery.getCorpusPathsForTest();
+    if (!corpusPath) {
+      throw new Error("expected session transcript corpus path");
+    }
     const harness = new SessionStartupCatchupHarness([
       {
-        path: "sessions/main/thread.jsonl",
+        path: corpusPath,
         hash: "current-hash",
         mtime: session.mtimeMs,
         size: session.size,

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -1,4 +1,5 @@
 // Memory Core tests cover manager sync ops.startup catchup plugin behavior.
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -530,6 +531,36 @@ describe("session startup catch-up", () => {
 
     expect(harness.syncCalls).toEqual([{ reason: "session-startup-catchup" }]);
     expect(harness.getIndexedSourceState(stalePath)).toBeUndefined();
+  });
+
+  it("preserves indexed sessions when corpus enumeration fails", async () => {
+    const stalePath = "sessions/main/preserved.jsonl";
+    const harness = new SessionStartupCatchupHarness(
+      [{ path: stalePath, hash: "preserved-hash", mtime: 10, size: 20 }],
+      true,
+    );
+    const scanError = Object.assign(new Error("transient session archive scan failure"), {
+      code: "EIO",
+    });
+    const readdirSpy = vi.spyOn(fsSync, "readdirSync").mockImplementation(() => {
+      throw scanError;
+    });
+
+    try {
+      const catchUp = harness.catchUp();
+      const corpusList = harness.waitForCorpusList();
+      await expect(catchUp).rejects.toBe(scanError);
+      await expect(corpusList).rejects.toBe(scanError);
+      expect(harness.syncCalls).toEqual([]);
+      expect(harness.getIndexedSourceState(stalePath)).toEqual({
+        path: stalePath,
+        hash: "preserved-hash",
+        mtime: 10,
+        size: 20,
+      });
+    } finally {
+      readdirSpy.mockRestore();
+    }
   });
 
   it("retries transient session transcript reads during session indexing", async () => {

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -275,6 +275,7 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
         reason: params?.reason,
         progress: progress ?? undefined,
         sessionsFullRetryDirty: this.sessionsFullRetryDirty,
+        sessionsReconcileDirty: this.sessionsReconcileDirty,
         sessionsDirtyFiles: this.sessionsDirtyFiles,
         syncArchiveFiles: async (targetedParams) => {
           await this.syncArchiveFiles({

--- a/extensions/memory-core/src/memory/manager-targeted-sync.test.ts
+++ b/extensions/memory-core/src/memory/manager-targeted-sync.test.ts
@@ -70,4 +70,22 @@ describe("memory targeted session sync", () => {
     expect(result).toEqual({ handled: true, sessionsDirty: true });
     expect(sessionsDirtyFiles.size).toBe(0);
   });
+
+  it("preserves source reconciliation after targeted cleanup", async () => {
+    const sessionsDirtyFiles = new Set(["/tmp/targeted-reconcile.jsonl"]);
+
+    const result = await runMemoryTargetedSessionSync({
+      hasSessionSource: true,
+      targetArchiveFiles: new Set(["/tmp/targeted-reconcile.jsonl"]),
+      reason: "post-compaction",
+      sessionsReconcileDirty: true,
+      sessionsDirtyFiles,
+      syncArchiveFiles: async () => undefined,
+      shouldFallbackOnError: () => false,
+      activateFallbackProvider: async () => false,
+    });
+
+    expect(result).toEqual({ handled: true, sessionsDirty: true });
+    expect(sessionsDirtyFiles.size).toBe(0);
+  });
 });

--- a/extensions/memory-core/src/memory/manager-targeted-sync.ts
+++ b/extensions/memory-core/src/memory/manager-targeted-sync.ts
@@ -41,6 +41,7 @@ export async function runMemoryTargetedSessionSync(params: {
   reason?: string;
   progress?: TargetedSyncProgress;
   sessionsFullRetryDirty?: boolean;
+  sessionsReconcileDirty?: boolean;
   sessionsDirtyFiles: Set<string>;
   syncArchiveFiles: (params: {
     needsFullReindex: boolean;
@@ -50,10 +51,12 @@ export async function runMemoryTargetedSessionSync(params: {
   shouldFallbackOnError: (err: unknown) => boolean;
   activateFallbackProvider: (reason: string) => Promise<boolean>;
 }): Promise<{ handled: boolean; sessionsDirty: boolean }> {
+  const hasPendingSessionWork = (hasDirtyFiles = params.sessionsDirtyFiles.size > 0) =>
+    params.sessionsFullRetryDirty || params.sessionsReconcileDirty || hasDirtyFiles;
   if (!params.hasSessionSource || !params.targetArchiveFiles) {
     return {
       handled: false,
-      sessionsDirty: Boolean(params.sessionsFullRetryDirty) || params.sessionsDirtyFiles.size > 0,
+      sessionsDirty: hasPendingSessionWork(),
     };
   }
 
@@ -69,7 +72,7 @@ export async function runMemoryTargetedSessionSync(params: {
     });
     return {
       handled: true,
-      sessionsDirty: Boolean(params.sessionsFullRetryDirty) || remainingSessionsDirty,
+      sessionsDirty: hasPendingSessionWork(remainingSessionsDirty),
     };
   } catch (err) {
     const reason = formatErrorMessage(err);
@@ -84,7 +87,7 @@ export async function runMemoryTargetedSessionSync(params: {
     });
     return {
       handled: true,
-      sessionsDirty: Boolean(params.sessionsFullRetryDirty) || remainingSessionsDirty,
+      sessionsDirty: hasPendingSessionWork(remainingSessionsDirty),
     };
   }
 }

--- a/extensions/memory-core/src/memory/manager.session-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.session-reindex.test.ts
@@ -8,7 +8,6 @@ describe("memory manager session reindex gating", () => {
       shouldSyncSessionsForReindex({
         hasSessionSource: true,
         sessionsDirty: false,
-        dirtySessionFileCount: 0,
         sync: { reason: "session-start" },
         needsFullReindex: true,
       }),
@@ -17,7 +16,6 @@ describe("memory manager session reindex gating", () => {
       shouldSyncSessionsForReindex({
         hasSessionSource: true,
         sessionsDirty: false,
-        dirtySessionFileCount: 0,
         sync: { reason: "watch" },
         needsFullReindex: true,
       }),
@@ -26,7 +24,6 @@ describe("memory manager session reindex gating", () => {
       shouldSyncSessionsForReindex({
         hasSessionSource: true,
         sessionsDirty: false,
-        dirtySessionFileCount: 0,
         sync: { reason: "session-start" },
         needsFullReindex: false,
       }),
@@ -35,7 +32,6 @@ describe("memory manager session reindex gating", () => {
       shouldSyncSessionsForReindex({
         hasSessionSource: true,
         sessionsDirty: false,
-        dirtySessionFileCount: 0,
         sync: { reason: "watch" },
         needsFullReindex: false,
       }),
@@ -48,8 +44,15 @@ describe("memory manager session reindex gating", () => {
         hasSessionSource: true,
         sessionsDirty: true,
         sessionsFullRetryDirty: true,
-        dirtySessionFileCount: 0,
         sync: { reason: "interval" },
+        needsFullReindex: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldSyncSessionsForReindex({
+        hasSessionSource: true,
+        sessionsDirty: true,
+        sync: { reason: "session-startup-catchup" },
         needsFullReindex: false,
       }),
     ).toBe(true);

--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -6,7 +6,7 @@ import {
   clearConfigCache,
   clearRuntimeConfigSnapshot,
 } from "openclaw/plugin-sdk/runtime-config-snapshot";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { markInboundContextLabel } from "../../../../src/auto-reply/reply/inbound-context-marker.js";
 import { encodeSessionArchiveContent } from "../../../../src/config/sessions/archive-compression.js";
 import {
@@ -130,6 +130,23 @@ describe("listSessionFilesForAgent", () => {
 });
 
 describe("listSessionTranscriptCorpusEntriesForAgent", () => {
+  it("surfaces unexpected archive-directory scan failures", async () => {
+    const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    fsSync.mkdirSync(sessionsDir, { recursive: true });
+    const scanError = Object.assign(new Error("transient session archive scan failure"), {
+      code: "EIO",
+    });
+    const readdirSpy = vi.spyOn(fsSync, "readdirSync").mockImplementation(() => {
+      throw scanError;
+    });
+
+    try {
+      await expect(listSessionTranscriptCorpusEntriesForAgent("main")).rejects.toBe(scanError);
+    } finally {
+      readdirSpy.mockRestore();
+    }
+  });
+
   it("includes rotated SQLite sessions only when retained history is requested", async () => {
     const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
     const storePath = path.join(sessionsDir, "sessions.json");

--- a/packages/memory-host-sdk/src/host/session-transcript-corpus.ts
+++ b/packages/memory-host-sdk/src/host/session-transcript-corpus.ts
@@ -284,8 +284,13 @@ function listSessionTranscriptArtifactFiles(sessionsDir: string): string[] {
       .filter((name) => isUsageCountedSessionTranscriptFileName(name))
       .filter((name) => isSessionArchiveArtifactName(name))
       .map((name) => path.join(sessionsDir, name));
-  } catch {
-    return [];
+  } catch (err) {
+    // A missing artifact directory is authoritatively empty. Other failures
+    // make the corpus incomplete, so destructive consumers must not proceed.
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw err;
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Memory Core startup reconciliation only walks the current live session corpus. When an indexed session disappears from that corpus—or the corpus becomes empty—the indexed-only row is never marked dirty and survives indefinitely.

This is silent: startup catch-up completes without an error or warning, while status and search continue to see a source that no longer exists.

### Deterministic reproduction

1. Index a session source such as `sessions/main/deleted.jsonl` alongside an unchanged surviving session.
2. Remove the first session from the live session corpus.
3. Restart Memory Core and let `session-startup-catchup` finish.
4. Query the indexed source state or run Memory Core status/sync.

Before this change:

```text
live corpus paths: [sessions/main/survivor.jsonl]
indexed paths before startup: [sessions/main/deleted.jsonl, sessions/main/survivor.jsonl]
startup dirty files: []
indexed paths after startup:  [sessions/main/deleted.jsonl, sessions/main/survivor.jsonl]  # stale
```

The initial implementation reused the failed-full-reindex marker to trigger cleanup. That deleted the stale path but also reindexed and re-embedded every unchanged surviving session.

After this change:

```text
startup sync reason: session-startup-catchup
indexed paths after startup: [sessions/main/survivor.jsonl]
embedding calls for unchanged survivor: 0
```

## Why This Change Was Made

- Reconcile startup state bidirectionally: live-to-indexed changes **and** indexed-to-live deletions.
- Keep corpus reconciliation distinct from failed full-reindex retries.
- Delete stale derived index rows through the existing source-wide sync path.
- Preserve normal incremental dirty-file handling for added or changed live sessions.
- Leave unchanged sessions, chunks, and embeddings untouched.

The context-engine discovery/fresh-turn failure found during the same operational investigation is addressed upstream by #121461 and is intentionally not duplicated here. The separate `transcript range is too-large`/8 MiB history-reader defect is also outside this PR.

## User Impact

- Deleted or expired session transcripts no longer leave stale Memory Core index rows after restart.
- Empty live corpora correctly converge to an empty indexed session set.
- Unchanged surviving sessions are not rebuilt or re-embedded merely to remove stale rows.
- No source transcripts, agent databases, workspaces, or configuration are deleted.
- No configuration or database migration is required.

## Evidence

Rebased onto `origin/main` at `86fe45ce17`.

The regression test empties the embedding cache before reconciliation and asserts:

```text
stale session search result: removed
surviving session search result: preserved
embedding batch calls: 0
```

Focused command:

```text
node scripts/run-vitest.mjs \
  extensions/memory-core/src/memory/index.test.ts \
  extensions/memory-core/src/memory/manager-session-sync-state.test.ts \
  extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts \
  extensions/memory-core/src/memory/manager-targeted-sync.test.ts \
  extensions/memory-core/src/memory/manager.session-reindex.test.ts
```

Post-rebase result:

```text
Test Files  5 passed (5)
Tests       151 passed (151)
[test] passed 1 Vitest shard
```

Additional validation:

```text
extension production typecheck   PASS
focused formatting and lint      PASS
git diff --check                 PASS
TruffleHog local-diff scan       PASS
Autoreview                       PASS; no actionable findings (0.98 confidence)
```

The repository-wide changed gate still encounters unrelated failures already present on current `main`: Plugin SDK closure-baseline drift and test-type errors in untouched gateway/UI tests. Their upstream repairs are #121670 and #121658; this PR does not duplicate them.

Production delta for the cleanup-only state machine is +8 lines; the dedicated reconciliation marker prevents reuse of the semantically different full-reindex retry state.

## AI Assistance

This change was developed and reviewed with AI assistance. The failing stale-row reproduction was captured before the cleanup-only refinement; focused regressions, formatting, type/lint checks, secret scanning, and structured autoreview were rerun before the corrected head was pushed.
