### PR TITLE
fix(ci): prevent ClawSweeper dispatch branch lookups

### DIFF
--- a/.github/workflows/clawsweeper-dispatch.yml
+++ b/.github/workflows/clawsweeper-dispatch.yml
@@ -289,6 +289,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           TARGET_REPO: ${{ github.repository }}
+          TARGET_BRANCH: ${{ github.event.repository.default_branch }}
           ITEM_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
           ITEM_KIND: ${{ github.event_name == 'pull_request_target' && 'pull_request' || 'issue' }}
           SOURCE_EVENT: ${{ github.event_name }}
@@ -299,14 +300,52 @@ jobs:
             exit 0
           fi
           . "$RUNNER_TEMP/github-api-backoff.sh"
+          ingress_fingerprint="$(node <<'NODE'
+          const crypto = require("node:crypto");
+          const fs = require("node:fs");
+          const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
+          const pullRequest = event.pull_request && typeof event.pull_request === "object"
+            ? event.pull_request
+            : {};
+          const headSha = String(pullRequest.head?.sha || "").trim().toLowerCase();
+          const updatedAt = String(pullRequest.updated_at || "").trim();
+          if (
+            process.env.ITEM_KIND !== "pull_request" ||
+            !/^[0-9a-f]{40}$/.test(headSha) ||
+            !updatedAt
+          ) {
+            process.stdout.write("");
+          } else {
+            process.stdout.write(
+              crypto
+                .createHash("sha256")
+                .update(
+                  JSON.stringify({
+                    version: 1,
+                    target_repo: String(process.env.TARGET_REPO || "").toLowerCase(),
+                    item_number: Number(process.env.ITEM_NUMBER),
+                    action: String(process.env.SOURCE_ACTION || ""),
+                    head_sha: headSha,
+                    updated_at: updatedAt,
+                    body: typeof pullRequest.body === "string" ? pullRequest.body : "",
+                    label: String(event.label?.name || ""),
+                  }),
+                )
+                .digest("hex"),
+            );
+          }
+          NODE
+          )"
           payload="$(jq -nc \
             --arg target_repo "$TARGET_REPO" \
+            --arg target_branch "$TARGET_BRANCH" \
             --argjson item_number "$ITEM_NUMBER" \
             --arg item_kind "$ITEM_KIND" \
             --arg source_event "$SOURCE_EVENT" \
             --arg source_action "$SOURCE_ACTION" \
+            --arg ingress_fingerprint "$ingress_fingerprint" \
             --argjson supersedes_in_progress "$SUPERSEDES_IN_PROGRESS" \
-            '{event_type:"clawsweeper_item",client_payload:{target_repo:$target_repo,item_number:$item_number,item_kind:$item_kind,source_event:$source_event,source_action:$source_action,supersedes_in_progress:$supersedes_in_progress}}')"
+            '{event_type:"clawsweeper_item",client_payload:({target_repo:$target_repo,target_branch:$target_branch,item_number:$item_number,item_kind:$item_kind,source_event:$source_event,source_action:$source_action,supersedes_in_progress:$supersedes_in_progress} + (if $ingress_fingerprint != "" then {ingress_route:"target_dispatcher",ingress_fingerprint:$ingress_fingerprint} else {} end))}')"
           if gh_api_with_retry repos/openclaw/clawsweeper/dispatches \
             --method POST \
             --input - <<< "$payload"; then

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1363,6 +1363,18 @@ NODE
     expect(activityRun).toMatch(
       /push: \(if \$event_name == "push" then \{\s+before: \.before,\s+after: \.after,\s+ref: \.ref,\s+compare: \.compare,\s+head_commit: \.head_commit\.id\s+\} else null end\)/u,
     );
+
+    const exactReviewStep = expectDefined(
+      steps.find((step) => step.name === "Dispatch exact ClawSweeper review"),
+      "ClawSweeper exact-review dispatch",
+    );
+    expect(exactReviewStep.env?.TARGET_BRANCH).toBe(
+      "${{ github.event.repository.default_branch }}",
+    );
+    expect(exactReviewStep.run).toContain('--arg target_branch "$TARGET_BRANCH"');
+    expect(exactReviewStep.run).toContain("target_branch:$target_branch");
+    expect(exactReviewStep.run).toContain('ingress_route:"target_dispatcher"');
+    expect(exactReviewStep.run).toContain("ingress_fingerprint:$ingress_fingerprint");
   });
 
   it("runs the PR context and evidence gate only for relevant PR changes", () => {


### PR DESCRIPTION
## What Problem This Solves

OpenClaw issue and pull-request events omitted the repository branch from their ClawSweeper dispatch. The receiver then had to perform an avoidable default-branch GitHub API lookup before durable review admission; [ClawSweeper run 31409599011](https://github.com/openclaw/clawsweeper/actions/runs/31409599011) shows that lookup failing with an installation-quota 403 before enqueue.

## Implementation

- Carry GitHub's authenticated `github.event.repository.default_branch` as `client_payload.target_branch`.
- For pull requests, carry the canonical `target_dispatcher` ingress route and fingerprint used to deduplicate the target-dispatch and direct-webhook routes.
- Preserve the existing bounded GitHub API retry helper for the one remaining operation: repository dispatch to `openclaw/clawsweeper`.

The durable fallback for genuinely legacy branchless events is handled separately by openclaw/clawsweeper#1105.

## User Impact

Normal OpenClaw ClawSweeper review events no longer require a pre-enqueue repository lookup, reducing shared GitHub API pressure and preventing this specific loss mode. No admission limit, review policy, or production queue state changes here.

## Validation

Exact head: `8ef31c882547cde783aca29fd84addd83c7e2989`  
Rebased base: `20d928e3c3b072908e71d2b37652c96108ed5656`

- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts -t "keeps ClawSweeper dispatch events aligned with receiver workflows"` — 1 passed, 115 skipped.
- `pnpm exec oxfmt --check test/scripts/ci-workflow-guards.test.ts .github/workflows/clawsweeper-dispatch.yml` — clean.
- `git diff --check origin/main...HEAD` — clean at the rebased base.
- Dirty `codex review --uncommitted` — no actionable finding.
- Committed `codex review --base origin/main` after the conflict-free rebase — no actionable regression; the dispatcher branch and fingerprint match the receiver contract.

The first ready-state CI merge used base `620ca5f00880f8584b2d29ceb2a777951bad61b5` and exposed the unrelated `system-agent.test.ts` setup-admission cleanup race. Current main already fixed that exact test in `f8916e4eb2d10f042b01adf80a3513a79725618b`; this branch was refreshed through `20d928e3c3b072908e71d2b37652c96108ed5656` before the proof below.

The full workflow-guard file retains unrelated native-Windows baseline failures because hosted-Linux shell fixtures require `/bin/bash` and existing temporary-directory cleanup cases can hit Windows `EPERM`. The changed test passes through the repository wrapper on Windows and the actual workflow shell block passes in Linux below.

## Real Behavior Proof

- **Claim:** The exact workflow step serializes the event repository's authoritative default branch for issues and pull requests, retains canonical pull-request cross-route identity, and performs no repository metadata lookup before dispatch.
- **Exercised surface:** The literal `run: |` block and `TARGET_BRANCH` environment contract from `.github/workflows/clawsweeper-dispatch.yml`, executed by Bash with the production Node fingerprint code and real `jq` payload builder.
- **Scenario:** Controlled `issues/opened` item 123 and `pull_request_target/synchronize` item 456 events for `openclaw/openclaw`, both with event repository `default_branch=main`. The pull-request fixture has a fixed head, timestamp, and body. A controlled sink captures the arguments and stdin of `gh_api_with_retry` without contacting GitHub.
- **Command/environment:** `crabbox run --provider local-container --local-container-image openclaw-csw-dispatch-proof:node24-jq --fresh-pr openclaw/openclaw#121674 --timing-json --script C:\oc-work\notes\csw-review-branch-dispatch-proof.sh`.
- **Provider / lease:** Docker-backed `local-container`; lease `cbx_9aa99ede31af`; slug `swift-barnacle`; target `linux`; image derived from Node 24 Bookworm with only Debian `jq` added. Local-container does not emit a separate remote run ID.
- **Observed issue payload:** `target_repo=openclaw/openclaw`, `target_branch=main`, item 123, no ingress fingerprint.
- **Observed pull-request payload:** `target_branch=main`, `ingress_route=target_dispatcher`, fingerprint `c82f525fe0e21de03ce810938eb04aa24cdeb21a26d1cbb36809eed593188b33` for the controlled event.
- **Observed transport:** The only captured call was `repos/openclaw/clawsweeper/dispatches --method POST --input -`; there was no default-branch or repository metadata lookup.
- **Result:** Exact fresh-PR head asserted; exit 0. Sync 62.026s, command 0.767s, total 62.794s. Lease stopped automatically.
- **Artifact/trace:** Redacted `PROOF_TRACE` output records the exact head, extracted workflow block, both branch values, PR fingerprint, dispatch-only call set, absent lookup, and zero production mutations.
- **Limits:** The final GitHub dispatch transport is a controlled sink, so no workflow dispatch, GitHub write, production queue mutation, deployment, or gate change occurred. Legacy branchless durability and reset-aware circuit behavior are proven in the companion ClawSweeper PR rather than duplicated here.

## Risks and Rollout

- `github.event.repository.default_branch` is GitHub-authenticated event data and the receiver already accepts a valid carried branch; no branch is guessed.
- The fingerprint mirrors the existing direct-webhook identity fields so the two trusted routes converge instead of creating duplicate review work.
- The patch changes one hosted-Linux workflow and its focused guard only: production +40/-1 workflow lines, tests +12/-0.
- The branch is conflict-free on base `20d928e3c3b072908e71d2b37652c96108ed5656`, which includes the upstream fix for the unrelated CI race. Per repository policy it will not chase later non-overlapping main movement after this clean refresh; exact-head CI and mergeability remain the landing checks.

Release note: OpenClaw now supplies branch authority with ClawSweeper review events, avoiding an extra pre-queue GitHub repository lookup.
