### PR TITLE
fix: make gateway stress results reflect real concurrency

### DIFF
--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -1007,8 +1007,8 @@ describe("buildQaRuntimeEnv", () => {
 
   it("keeps restart offsets stable after stderr output", async () => {
     const output = testing.createQaGatewayChildLogCollector();
-    output.push(Buffer.from("gateway ready\n"));
-    output.push(Buffer.from("stderr warning\n"));
+    output.push("stdout", Buffer.from("gateway ready\n"));
+    output.push("stderr", Buffer.from("stderr warning\n"));
     const mark = output.mark();
     const wait = testing.waitForQaGatewayRestartBoundary({
       readLogsSince: (since) => output.readSince(since),
@@ -1017,16 +1017,19 @@ describe("buildQaRuntimeEnv", () => {
       timeoutMs: 100,
     });
 
-    output.push(Buffer.from("signal SIGUSR1 received\nrestart mode: in-process restart\n"));
+    output.push(
+      "stdout",
+      Buffer.from("signal SIGUSR1 received\nrestart mode: in-process restart\n"),
+    );
 
     await expect(wait).resolves.toBeUndefined();
   });
 
   it("bounds diagnostics while monotonic marks retain fresh output semantics", () => {
     const output = testing.createQaGatewayChildLogCollector();
-    output.push(Buffer.from(`old😀${"x".repeat(70_000)}`));
+    output.push("stdout", Buffer.from(`old😀${"x".repeat(70_000)}`));
     const mark = output.mark();
-    output.push(Buffer.from("fresh restart mode: in-process restart\n"));
+    output.push("stdout", Buffer.from("fresh restart mode: in-process restart\n"));
 
     expect(output.text()).toContain("[qa-lab] older gateway logs truncated");
     expect(output.text().length).toBeLessThan(66_000);
@@ -1034,6 +1037,18 @@ describe("buildQaRuntimeEnv", () => {
     expect(output.text()).not.toMatch(
       /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u,
     );
+  });
+
+  it("decodes interleaved stdout and stderr independently", () => {
+    const output = testing.createQaGatewayChildLogCollector();
+    const stdout = Buffer.from("before 😀 after\n");
+
+    output.push("stdout", stdout.subarray(0, 9));
+    output.push("stderr", Buffer.from("warning ⚠️\n"));
+    output.push("stdout", stdout.subarray(9));
+
+    expect(output.text()).toBe("before warning ⚠️\n😀 after");
+    expect(output.text()).not.toContain("�");
   });
 
   it("times out when a SIGUSR1 restart never reaches the boundary", async () => {

--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -992,10 +992,10 @@ describe("buildQaRuntimeEnv", () => {
 
   it("waits for a fresh in-process restart boundary after the current log offset", async () => {
     let logs = "old restart mode: in-process restart\n";
-    const offset = logs.length;
+    const mark = logs.length;
     const wait = testing.waitForQaGatewayRestartBoundary({
-      logs: () => logs,
-      offset,
+      readLogsSince: (since) => logs.slice(since),
+      mark,
       pollMs: 1,
       timeoutMs: 100,
     });
@@ -1009,10 +1009,10 @@ describe("buildQaRuntimeEnv", () => {
     const output = testing.createQaGatewayChildLogCollector();
     output.push(Buffer.from("gateway ready\n"));
     output.push(Buffer.from("stderr warning\n"));
-    const offset = output.text().length;
+    const mark = output.mark();
     const wait = testing.waitForQaGatewayRestartBoundary({
-      logs: () => output.text(),
-      offset,
+      readLogsSince: (since) => output.readSince(since),
+      mark,
       pollMs: 1,
       timeoutMs: 100,
     });
@@ -1022,11 +1022,25 @@ describe("buildQaRuntimeEnv", () => {
     await expect(wait).resolves.toBeUndefined();
   });
 
+  it("bounds diagnostics while monotonic marks retain fresh output semantics", () => {
+    const output = testing.createQaGatewayChildLogCollector();
+    output.push(Buffer.from(`old😀${"x".repeat(70_000)}`));
+    const mark = output.mark();
+    output.push(Buffer.from("fresh restart mode: in-process restart\n"));
+
+    expect(output.text()).toContain("[qa-lab] older gateway logs truncated");
+    expect(output.text().length).toBeLessThan(66_000);
+    expect(output.readSince(mark)).toBe("fresh restart mode: in-process restart\n");
+    expect(output.text()).not.toMatch(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u,
+    );
+  });
+
   it("times out when a SIGUSR1 restart never reaches the boundary", async () => {
     await expect(
       testing.waitForQaGatewayRestartBoundary({
-        logs: () => "signal SIGUSR1 received\n",
-        offset: 0,
+        readLogsSince: () => "signal SIGUSR1 received\n",
+        mark: 0,
         pollMs: 1,
         timeoutMs: 1,
       }),
@@ -1036,8 +1050,8 @@ describe("buildQaRuntimeEnv", () => {
   it("keeps oversized restart-boundary poll intervals within the timeout", async () => {
     await expect(
       testing.waitForQaGatewayRestartBoundary({
-        logs: () => "signal SIGUSR1 received\n",
-        offset: 0,
+        readLogsSince: () => "signal SIGUSR1 received\n",
+        mark: 0,
         pollMs: Number.MAX_SAFE_INTEGER,
         timeoutMs: 5,
       }),

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -672,8 +672,14 @@ async function callQaGatewayWithRetry<T>(params: {
   throw new Error(`${lastDetails}${formatQaGatewayLogsForError(params.logs())}`);
 }
 
+type QaGatewayChildLogSource = "internal" | "stderr" | "stdout";
+
 function createQaGatewayChildLogCollector() {
-  const decoder = new StringDecoder("utf8");
+  const decoders: Record<QaGatewayChildLogSource, StringDecoder> = {
+    internal: new StringDecoder("utf8"),
+    stderr: new StringDecoder("utf8"),
+    stdout: new StringDecoder("utf8"),
+  };
   let recent = "";
   let end = 0;
   let dropped = false;
@@ -685,8 +691,8 @@ function createQaGatewayChildLogCollector() {
     return `${wasTruncated ? QA_GATEWAY_CHILD_LOG_TRUNCATION_MARKER : ""}${text}`;
   };
   return {
-    push(chunk: Buffer) {
-      const text = decoder.write(chunk);
+    push(source: QaGatewayChildLogSource, chunk: Buffer) {
+      const text = decoders[source].write(chunk);
       end += text.length;
       recent += text;
       if (recent.length > QA_GATEWAY_CHILD_RECENT_LOG_CHARS) {
@@ -727,7 +733,10 @@ function throwQaGatewayChildFailure(
   );
 }
 
-function monitorQaGatewayChildFailure(child: ChildProcess, output: { push(chunk: Buffer): void }) {
+function monitorQaGatewayChildFailure(
+  child: ChildProcess,
+  output: { push(source: QaGatewayChildLogSource, chunk: Buffer): void },
+) {
   let childFailure: QaChildFailure | null = null;
   monitorQaChildFailure(child, (failure) => {
     childFailure = failure;
@@ -735,7 +744,7 @@ function monitorQaGatewayChildFailure(child: ChildProcess, output: { push(chunk:
       failure.source === "process"
         ? `gateway child process error: ${formatErrorMessage(failure.error)}`
         : formatQaGatewayChildFailure(failure);
-    output.push(Buffer.from(`[qa-lab] ${description}\n`));
+    output.push("internal", Buffer.from(`[qa-lab] ${description}\n`));
     if (failure.source !== "process" && !hasChildExited(child)) {
       // A broken parent-side pipe means QA can no longer observe the Gateway.
       // Stop the detached process tree so the existing lifecycle reports the failure.
@@ -1428,12 +1437,12 @@ export async function startQaGatewayChild(params: {
       });
       spawnedChild.stdout.on("data", (chunk) => {
         const buffer = Buffer.from(chunk);
-        output.push(buffer);
+        output.push("stdout", buffer);
         stdoutLog.write(buffer);
       });
       spawnedChild.stderr.on("data", (chunk) => {
         const buffer = Buffer.from(chunk);
-        output.push(buffer);
+        output.push("stderr", buffer);
         stderrLog.write(buffer);
       });
       const getSpawnedChildFailure = monitorQaGatewayChildFailure(spawnedChild, output);
@@ -1718,7 +1727,7 @@ export async function startQaGatewayChild(params: {
             ? `[qa-lab] gateway child startup attempt ${attempt}/${QA_GATEWAY_CHILD_STARTUP_MAX_ATTEMPTS} completed plugin migration convergence; restarting once with the same state, config, and port ${gatewayPort}\n`
             : `[qa-lab] gateway child startup attempt ${attempt}/${QA_GATEWAY_CHILD_STARTUP_MAX_ATTEMPTS} hit a transient startup race on port ${gatewayPort}; retrying with a new port\n`;
         const retryBuffer = Buffer.from(retryMessage);
-        output.push(retryBuffer);
+        output.push("internal", retryBuffer);
         stdoutLog.write(retryBuffer);
       }
     }

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -7,6 +7,7 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { finished } from "node:stream/promises";
+import { StringDecoder } from "node:string_decoder";
 import { setTimeout as sleep } from "node:timers/promises";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage, toErrorObject } from "openclaw/plugin-sdk/error-runtime";
@@ -88,6 +89,8 @@ const QA_GATEWAY_CHILD_GRACEFUL_SHUTDOWN_TIMEOUT_MS = 30_000;
 // Loaded Docker runners can take several seconds to reap a force-killed process group.
 const QA_GATEWAY_CHILD_FORCE_SHUTDOWN_TIMEOUT_MS = 10_000;
 const QA_GATEWAY_LOG_CLOSE_TIMEOUT_MS = 5_000;
+const QA_GATEWAY_CHILD_RECENT_LOG_CHARS = 64 * 1_024;
+const QA_GATEWAY_CHILD_LOG_TRUNCATION_MARKER = "[qa-lab] older gateway logs truncated\n";
 const QA_PACKAGE_AUTH_FAILURE_MAX_CHARS = 2_048;
 const QA_MOCK_OPENAI_API_KEY = ["qa", "mock", "openai", "key"].join("-");
 const QA_GATEWAY_CHILD_BLOCKED_SECRET_ENV_VARS = Object.freeze([
@@ -670,13 +673,35 @@ async function callQaGatewayWithRetry<T>(params: {
 }
 
 function createQaGatewayChildLogCollector() {
-  const chunks: Buffer[] = [];
+  const decoder = new StringDecoder("utf8");
+  let recent = "";
+  let end = 0;
+  let dropped = false;
+
+  const readFrom = (mark: number) => {
+    const start = end - recent.length;
+    const wasTruncated = mark < start;
+    const text = recent.slice(Math.max(0, mark - start));
+    return `${wasTruncated ? QA_GATEWAY_CHILD_LOG_TRUNCATION_MARKER : ""}${text}`;
+  };
   return {
     push(chunk: Buffer) {
-      chunks.push(Buffer.from(chunk));
+      const text = decoder.write(chunk);
+      end += text.length;
+      recent += text;
+      if (recent.length > QA_GATEWAY_CHILD_RECENT_LOG_CHARS) {
+        recent = sliceUtf16Safe(recent, -QA_GATEWAY_CHILD_RECENT_LOG_CHARS);
+        dropped = true;
+      }
+    },
+    mark() {
+      return end;
+    },
+    readSince(mark: number) {
+      return readFrom(mark);
     },
     text() {
-      return Buffer.concat(chunks).toString("utf8").trim();
+      return `${dropped ? QA_GATEWAY_CHILD_LOG_TRUNCATION_MARKER : ""}${recent}`.trim();
     },
   };
 }
@@ -772,8 +797,8 @@ async function fetchLocalGatewayListening(baseUrl: string): Promise<boolean> {
 }
 
 async function waitForQaGatewayRestartBoundary(params: {
-  logs: () => string;
-  offset: number;
+  readLogsSince: (mark: number) => string;
+  mark: number;
   pollMs?: number;
   timeoutMs?: number;
 }) {
@@ -781,7 +806,7 @@ async function waitForQaGatewayRestartBoundary(params: {
   const pollMs = resolveTimerTimeoutMs(params.pollMs ?? 100, 100, 0);
   const startedAt = Date.now();
   while (Date.now() - startedAt < timeoutMs) {
-    if (params.logs().slice(params.offset).includes("restart mode:")) {
+    if (params.readLogsSince(params.mark).includes("restart mode:")) {
       return;
     }
     const remainingMs = timeoutMs - (Date.now() - startedAt);
@@ -1346,8 +1371,6 @@ export async function startQaGatewayChild(params: {
       }
       return params.mutateConfig ? params.mutateConfig(cfg) : cfg;
     };
-    const stdout: Buffer[] = [];
-    const stderr: Buffer[] = [];
     const output = createQaGatewayChildLogCollector();
     const stdoutLogPath = path.join(tempRoot, "gateway.stdout.log");
     const stderrLogPath = path.join(tempRoot, "gateway.stderr.log");
@@ -1405,13 +1428,11 @@ export async function startQaGatewayChild(params: {
       });
       spawnedChild.stdout.on("data", (chunk) => {
         const buffer = Buffer.from(chunk);
-        stdout.push(buffer);
         output.push(buffer);
         stdoutLog.write(buffer);
       });
       spawnedChild.stderr.on("data", (chunk) => {
         const buffer = Buffer.from(chunk);
-        stderr.push(buffer);
         output.push(buffer);
         stderrLog.write(buffer);
       });
@@ -1576,7 +1597,7 @@ export async function startQaGatewayChild(params: {
       }
       reuseStartupLaunchState = false;
 
-      const attemptLogOffset = logs().length;
+      const attemptLogMark = output.mark();
       const spawnedAttempt = await spawnGatewayProcess(env);
       const attemptChild = spawnedAttempt.child;
       child = attemptChild;
@@ -1661,7 +1682,7 @@ export async function startQaGatewayChild(params: {
         break;
       } catch (error) {
         const details = formatErrorMessage(error);
-        const attemptLogs = logs().slice(attemptLogOffset);
+        const attemptLogs = redactQaGatewayDebugText(output.readSince(attemptLogMark));
         const startupRetry = resolveQaGatewayStartupRetry({
           attempt,
           details: attemptLogs.trim() ? attemptLogs : details,
@@ -1843,12 +1864,12 @@ export async function startQaGatewayChild(params: {
       },
       async restart(signal: NodeJS.Signals = "SIGUSR1") {
         throwActiveChildFailure();
-        const restartLogOffset = logs().length;
+        const restartLogMark = output.mark();
         await signalActiveProcess(signal);
         if (signal === "SIGUSR1") {
           await waitForQaGatewayRestartBoundary({
-            logs,
-            offset: restartLogOffset,
+            readLogsSince: (mark) => redactQaGatewayDebugText(output.readSince(mark)),
+            mark: restartLogMark,
           });
           await waitForGatewayReady({
             baseUrl,

--- a/extensions/qa-lab/src/gateway-rpc-client.test.ts
+++ b/extensions/qa-lab/src/gateway-rpc-client.test.ts
@@ -2,120 +2,59 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const gatewayRpcMock = vi.hoisted(() => {
-  const callGatewayFromCli = vi.fn(async () => ({ ok: true }));
+  const request = vi.fn(async () => ({ ok: true }));
+  const stopAndWait = vi.fn(async () => {});
+  const clients: Array<{ options: Record<string, unknown> }> = [];
+  class GatewayClient {
+    options: Record<string, unknown>;
+    request = request;
+    stopAndWait = stopAndWait;
+
+    constructor(options: Record<string, unknown>) {
+      this.options = options;
+      clients.push(this);
+    }
+  }
+  const connectImmediately = async (client: GatewayClient) => {
+    (client.options.onHelloOk as () => void)();
+    return { ready: true, aborted: false };
+  };
+  const startGatewayClientWhenEventLoopReady = vi.fn(connectImmediately);
   return {
-    callGatewayFromCli,
+    GatewayClient,
+    clients,
+    request,
+    startGatewayClientWhenEventLoopReady,
+    stopAndWait,
     reset() {
-      callGatewayFromCli.mockReset().mockResolvedValue({ ok: true });
+      clients.length = 0;
+      request.mockReset().mockResolvedValue({ ok: true });
+      stopAndWait.mockReset().mockResolvedValue(undefined);
+      startGatewayClientWhenEventLoopReady.mockReset().mockImplementation(connectImmediately);
     },
   };
 });
 
 vi.mock("openclaw/plugin-sdk/gateway-runtime", () => ({
-  callGatewayFromCli: gatewayRpcMock.callGatewayFromCli,
+  GatewayClient: gatewayRpcMock.GatewayClient,
+  startGatewayClientWhenEventLoopReady: gatewayRpcMock.startGatewayClientWhenEventLoopReady,
 }));
 
 import { startQaGatewayRpcClient } from "./gateway-rpc-client.js";
 
-function expectRequestResolver(
-  callback: ((value: { ok: boolean }) => void) | null,
-): (value: { ok: boolean }) => void {
-  if (callback === null) {
-    throw new Error("Expected first request resolver callback to be captured");
+function gatewayClientCallback(name: "onClose" | "onHelloOk") {
+  const callback = gatewayRpcMock.clients[0]?.options[name];
+  if (typeof callback !== "function") {
+    throw new Error(`expected Gateway client ${name} callback`);
   }
-  return callback;
-}
-
-function expectReleaseCallback(callback: (() => void) | null): () => void {
-  if (callback === null) {
-    throw new Error("Expected first request release callback to be captured");
-  }
-  return callback;
-}
-
-function expectRejectCallback(
-  callback: ((reason?: unknown) => void) | null,
-): (reason?: unknown) => void {
-  if (callback === null) {
-    throw new Error("Expected request rejection callback to be captured");
-  }
-  return callback;
+  return callback as () => void;
 }
 
 describe("startQaGatewayRpcClient", () => {
-  beforeEach(() => {
-    gatewayRpcMock.reset();
-  });
+  beforeEach(() => gatewayRpcMock.reset());
+  afterEach(() => vi.useRealTimers());
 
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it("calls the in-process gateway cli helper without mutating process.env", async () => {
-    const originalHome = process.env.OPENCLAW_HOME;
-    delete process.env.OPENCLAW_HOME;
-
-    try {
-      gatewayRpcMock.callGatewayFromCli.mockImplementationOnce(async () => {
-        expect(process.env.OPENCLAW_HOME).toBeUndefined();
-        return { ok: true };
-      });
-
-      const client = await startQaGatewayRpcClient({
-        wsUrl: "ws://127.0.0.1:18789",
-        token: "qa-token",
-        logs: () => "qa logs",
-      });
-
-      await expect(
-        client.request("agent.run", { prompt: "hi" }, { expectFinal: true, timeoutMs: 45_000 }),
-      ).resolves.toEqual({ ok: true });
-
-      expect(gatewayRpcMock.callGatewayFromCli).toHaveBeenCalledWith(
-        "agent.run",
-        {
-          url: "ws://127.0.0.1:18789",
-          token: "qa-token",
-          timeout: "45000",
-          expectFinal: true,
-          json: true,
-        },
-        { prompt: "hi" },
-        {
-          clientName: "gateway-client",
-          deviceIdentity: null,
-          expectFinal: true,
-          mode: "backend",
-          progress: false,
-          scopes: ["operator.admin"],
-        },
-      );
-    } finally {
-      if (originalHome === undefined) {
-        delete process.env.OPENCLAW_HOME;
-      } else {
-        process.env.OPENCLAW_HOME = originalHome;
-      }
-    }
-
-    expect(process.env.OPENCLAW_HOME).toBe(originalHome);
-  });
-
-  it("wraps request failures with gateway logs", async () => {
-    gatewayRpcMock.callGatewayFromCli.mockRejectedValueOnce(new Error("gateway not connected"));
-    const client = await startQaGatewayRpcClient({
-      wsUrl: "ws://127.0.0.1:18789",
-      token: "qa-token",
-      logs: () => "OPENCLAW_GATEWAY_TOKEN=secret-token\nAuthorization: Bearer secret+/token=123456",
-    });
-
-    await expect(client.request("health")).rejects.toThrow(
-      "gateway not connected\nGateway logs:\nOPENCLAW_GATEWAY_TOKEN=<redacted>\nAuthorization: Bearer <redacted>",
-    );
-  });
-
-  it("normalizes non-Error request failures before wrapping with gateway logs", async () => {
-    gatewayRpcMock.callGatewayFromCli.mockRejectedValueOnce("gateway not connected");
+  it("starts one authenticated backend operator client and forwards request options", async () => {
     const client = await startQaGatewayRpcClient({
       wsUrl: "ws://127.0.0.1:18789",
       token: "qa-token",
@@ -123,81 +62,36 @@ describe("startQaGatewayRpcClient", () => {
     });
 
     await expect(
-      client.request("health", {}, { deadlineMs: Date.now() + 5_000 }),
-    ).rejects.toMatchObject({
-      cause: expect.objectContaining({ message: "gateway not connected" }),
-      message: "gateway not connected\nGateway logs:\nqa logs",
-    });
-  });
+      client.request("agent.run", { prompt: "hi" }, { expectFinal: true, timeoutMs: 45_000 }),
+    ).resolves.toEqual({ ok: true });
 
-  it("rejects new requests after stop", async () => {
-    const client = await startQaGatewayRpcClient({
-      wsUrl: "ws://127.0.0.1:18789",
+    expect(gatewayRpcMock.clients).toHaveLength(1);
+    expect(gatewayRpcMock.clients[0]?.options).toMatchObject({
+      url: "ws://127.0.0.1:18789",
       token: "qa-token",
-      logs: () => "url=http://127.0.0.1:18789/#token=abc123",
+      requestTimeoutMs: 20_000,
+      clientName: "gateway-client",
+      deviceIdentity: null,
+      mode: "backend",
+      scopes: ["operator.admin"],
     });
-
-    await client.stop();
-
-    await expect(client.request("health")).rejects.toThrow(
-      "gateway rpc client already stopped\nGateway logs:\nurl=http://127.0.0.1:18789/#token=<redacted>",
+    expect(gatewayRpcMock.startGatewayClientWhenEventLoopReady).toHaveBeenCalledWith(
+      gatewayRpcMock.clients[0],
+      { timeoutMs: 20_000 },
     );
+    expect(gatewayRpcMock.request).toHaveBeenCalledWith(
+      "agent.run",
+      { prompt: "hi" },
+      expect.objectContaining({ expectFinal: true, timeoutMs: expect.any(Number) }),
+    );
+    const requestOptions = gatewayRpcMock.request.mock.calls[0]?.[2] as { timeoutMs: number };
+    expect(requestOptions.timeoutMs).toBeGreaterThanOrEqual(44_900);
+    expect(requestOptions.timeoutMs).toBeLessThanOrEqual(45_000);
   });
 
-  it("does not serialize requests across different gateway clients", async () => {
-    let resolveFirst: ((value: { ok: boolean }) => void) | null = null;
-    gatewayRpcMock.callGatewayFromCli
-      .mockImplementationOnce(
-        async () =>
-          await new Promise<{ ok: boolean }>((resolve) => {
-            resolveFirst = resolve;
-          }),
-      )
-      .mockResolvedValueOnce({ ok: true });
-
-    const firstClient = await startQaGatewayRpcClient({
-      wsUrl: "ws://127.0.0.1:18789",
-      token: "qa-token-a",
-      logs: () => "qa logs a",
-    });
-    const secondClient = await startQaGatewayRpcClient({
-      wsUrl: "ws://127.0.0.1:28789",
-      token: "qa-token-b",
-      logs: () => "qa logs b",
-    });
-
-    const firstRequest = firstClient.request("health");
-    await Promise.resolve();
-
-    await expect(secondClient.request("status")).resolves.toEqual({ ok: true });
-    expect(gatewayRpcMock.callGatewayFromCli).toHaveBeenNthCalledWith(
-      2,
-      "status",
-      {
-        url: "ws://127.0.0.1:28789",
-        token: "qa-token-b",
-        timeout: "20000",
-        expectFinal: undefined,
-        json: true,
-      },
-      {},
-      {
-        clientName: "gateway-client",
-        deviceIdentity: null,
-        expectFinal: undefined,
-        mode: "backend",
-        progress: false,
-        scopes: ["operator.admin"],
-      },
-    );
-
-    expectRequestResolver(resolveFirst)({ ok: true });
-    await expect(firstRequest).resolves.toEqual({ ok: true });
-  });
-
-  it("still serializes requests within the same gateway client", async () => {
-    let releaseFirst: (() => void) | null = null;
-    gatewayRpcMock.callGatewayFromCli
+  it("dispatches concurrent requests over the same client", async () => {
+    let releaseFirst: (() => void) | undefined;
+    gatewayRpcMock.request
       .mockImplementationOnce(
         async () =>
           await new Promise<{ ok: boolean }>((resolve) => {
@@ -205,7 +99,6 @@ describe("startQaGatewayRpcClient", () => {
           }),
       )
       .mockResolvedValueOnce({ ok: true });
-
     const client = await startQaGatewayRpcClient({
       wsUrl: "ws://127.0.0.1:18789",
       token: "qa-token",
@@ -217,100 +110,16 @@ describe("startQaGatewayRpcClient", () => {
     const secondRequest = client.request("status");
     await Promise.resolve();
 
-    expect(gatewayRpcMock.callGatewayFromCli).toHaveBeenCalledTimes(1);
-
-    expectReleaseCallback(releaseFirst)();
-
-    await expect(firstRequest).resolves.toEqual({ ok: true });
+    await vi.waitFor(() => expect(gatewayRpcMock.request).toHaveBeenCalledTimes(2));
     await expect(secondRequest).resolves.toEqual({ ok: true });
-    expect(gatewayRpcMock.callGatewayFromCli).toHaveBeenCalledTimes(2);
-  });
-
-  it("expires queued requests promptly without dispatching them later", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(0);
-    let releaseFirst: (() => void) | null = null;
-    gatewayRpcMock.callGatewayFromCli.mockImplementationOnce(
-      async () =>
-        await new Promise<{ ok: boolean }>((resolve) => {
-          releaseFirst = () => resolve({ ok: true });
-        }),
-    );
-    const client = await startQaGatewayRpcClient({
-      wsUrl: "ws://127.0.0.1:18789",
-      token: "qa-token",
-      logs: () => "qa logs",
-    });
-
-    const firstRequest = client.request("health");
-    await Promise.resolve();
-    const queuedRequest = client.request("status", {}, { deadlineMs: 100, timeoutMs: 5_000 });
-    const rejection = expect(queuedRequest).rejects.toThrow(
-      "gateway request deadline exceeded\nGateway logs:\nqa logs",
-    );
-
-    await vi.advanceTimersByTimeAsync(100);
-    await rejection;
-    expect(gatewayRpcMock.callGatewayFromCli).toHaveBeenCalledTimes(1);
-
-    expectReleaseCallback(releaseFirst)();
-    await expect(firstRequest).resolves.toEqual({ ok: true });
-    await Promise.resolve();
-    expect(gatewayRpcMock.callGatewayFromCli).toHaveBeenCalledTimes(1);
-  });
-
-  it("keeps the queue serialized when a running request expires", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(0);
-    let rejectRunning: ((reason?: unknown) => void) | null = null;
-    const unhandledRejections: unknown[] = [];
-    const onUnhandledRejection = (reason: unknown) => {
-      unhandledRejections.push(reason);
-    };
-    gatewayRpcMock.callGatewayFromCli
-      .mockImplementationOnce(
-        async () =>
-          await new Promise<never>((_resolve, reject) => {
-            rejectRunning = reject;
-          }),
-      )
-      .mockResolvedValueOnce({ ok: true });
-    process.on("unhandledRejection", onUnhandledRejection);
-
-    try {
-      const client = await startQaGatewayRpcClient({
-        wsUrl: "ws://127.0.0.1:18789",
-        token: "qa-token",
-        logs: () => "qa logs",
-      });
-      const runningRequest = client.request("health", {}, { deadlineMs: 100, timeoutMs: 5_000 });
-      const runningRejection = expect(runningRequest).rejects.toThrow(
-        "gateway request deadline exceeded\nGateway logs:\nqa logs",
-      );
-      await Promise.resolve();
-      const queuedRequest = client.request("status");
-      await Promise.resolve();
-
-      expect(gatewayRpcMock.callGatewayFromCli).toHaveBeenCalledTimes(1);
-      await vi.advanceTimersByTimeAsync(100);
-      await runningRejection;
-      expect(gatewayRpcMock.callGatewayFromCli).toHaveBeenCalledTimes(1);
-
-      vi.useRealTimers();
-      expectRejectCallback(rejectRunning)(new Error("late gateway rejection"));
-      await expect(queuedRequest).resolves.toEqual({ ok: true });
-      expect(gatewayRpcMock.callGatewayFromCli).toHaveBeenCalledTimes(2);
-      await new Promise<void>((resolve) => {
-        setImmediate(resolve);
-      });
-      expect(unhandledRejections).toStrictEqual([]);
-    } finally {
-      process.off("unhandledRejection", onUnhandledRejection);
-      expect(process.listeners("unhandledRejection")).not.toContain(onUnhandledRejection);
+    if (!releaseFirst) {
+      throw new Error("expected first request to be held");
     }
+    releaseFirst();
+    await expect(firstRequest).resolves.toEqual({ ok: true });
   });
 
-  it("clamps the dispatched CLI timeout to the remaining deadline", async () => {
+  it("clamps request timeout to the remaining absolute deadline", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);
     const client = await startQaGatewayRpcClient({
@@ -319,65 +128,152 @@ describe("startQaGatewayRpcClient", () => {
       logs: () => "qa logs",
     });
 
-    await expect(
-      client.request("status", {}, { deadlineMs: 1_250, timeoutMs: 5_000 }),
-    ).resolves.toEqual({ ok: true });
+    await client.request("status", {}, { deadlineMs: 1_250, timeoutMs: 5_000 });
 
-    expect(gatewayRpcMock.callGatewayFromCli).toHaveBeenCalledWith(
+    expect(gatewayRpcMock.request).toHaveBeenCalledWith(
       "status",
-      expect.objectContaining({ timeout: "250" }),
       {},
-      expect.any(Object),
+      expect.objectContaining({
+        expectFinal: undefined,
+        timeoutMs: 250,
+      }),
     );
   });
 
-  it("rejects queued requests that have not started before stop", async () => {
-    let releaseFirst: (() => void) | null = null;
-    gatewayRpcMock.callGatewayFromCli.mockImplementationOnce(
-      async () =>
-        await new Promise<{ ok: boolean }>((resolve) => {
-          releaseFirst = () => resolve({ ok: true });
-        }),
-    );
+  it("bounds startup when readiness completes but the Gateway never sends hello", async () => {
+    vi.useFakeTimers();
+    gatewayRpcMock.startGatewayClientWhenEventLoopReady.mockResolvedValueOnce({
+      ready: true,
+      aborted: false,
+    });
 
+    const startup = startQaGatewayRpcClient({
+      wsUrl: "ws://127.0.0.1:18789",
+      token: "qa-token",
+      logs: () => "qa logs",
+    });
+    const rejection = expect(startup).rejects.toThrow(
+      "gateway request deadline exceeded\nGateway logs:\nqa logs",
+    );
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    await rejection;
+    expect(gatewayRpcMock.stopAndWait).toHaveBeenCalledOnce();
+  });
+
+  it("waits for reconnect before dispatching a request", async () => {
+    const client = await startQaGatewayRpcClient({
+      wsUrl: "ws://127.0.0.1:18789",
+      token: "qa-token",
+      logs: () => "qa logs",
+    });
+    gatewayClientCallback("onClose")();
+
+    const request = client.request("status", {}, { timeoutMs: 5_000 });
+    await Promise.resolve();
+    expect(gatewayRpcMock.request).not.toHaveBeenCalled();
+
+    gatewayClientCallback("onHelloOk")();
+    await expect(request).resolves.toEqual({ ok: true });
+    expect(gatewayRpcMock.request).toHaveBeenCalledOnce();
+  });
+
+  it("applies the request deadline while waiting for reconnect", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const client = await startQaGatewayRpcClient({
+      wsUrl: "ws://127.0.0.1:18789",
+      token: "qa-token",
+      logs: () => "qa logs",
+    });
+    gatewayClientCallback("onClose")();
+
+    const request = client.request("status", {}, { deadlineMs: 1_250, timeoutMs: 5_000 });
+    const rejection = expect(request).rejects.toThrow("gateway request deadline exceeded");
+    await vi.advanceTimersByTimeAsync(250);
+
+    await rejection;
+    expect(gatewayRpcMock.request).not.toHaveBeenCalled();
+  });
+
+  it("does not retry a sent request whose Gateway error says it is not connected", async () => {
+    gatewayRpcMock.request.mockImplementationOnce(async (_method, _params, options) => {
+      options.onSent();
+      throw new Error("gateway not connected");
+    });
     const client = await startQaGatewayRpcClient({
       wsUrl: "ws://127.0.0.1:18789",
       token: "qa-token",
       logs: () => "qa logs",
     });
 
-    const firstRequest = client.request("health");
-    await Promise.resolve();
-    const secondRequest = client.request("status");
-    await Promise.resolve();
-
-    await client.stop();
-    expectReleaseCallback(releaseFirst)();
-
-    await expect(firstRequest).resolves.toEqual({ ok: true });
-    await expect(secondRequest).rejects.toThrow(
-      "gateway rpc client already stopped\nGateway logs:\nqa logs",
-    );
-    expect(gatewayRpcMock.callGatewayFromCli).toHaveBeenCalledTimes(1);
+    await expect(client.request("agent.run")).rejects.toThrow("gateway not connected");
+    expect(gatewayRpcMock.request).toHaveBeenCalledOnce();
   });
 
-  it("preserves the structured gateway request failure as the cause", async () => {
-    const gatewayError = Object.assign(new Error("history temporarily unavailable"), {
-      gatewayCode: "UNAVAILABLE",
-      retryable: true,
-      retryAfterMs: 250,
-      details: { method: "chat.history" },
-    });
-    gatewayRpcMock.callGatewayFromCli.mockRejectedValueOnce(gatewayError);
+  it("wraps normalized request failures with redacted gateway logs", async () => {
+    gatewayRpcMock.request.mockRejectedValueOnce("gateway rejected request");
     const client = await startQaGatewayRpcClient({
       wsUrl: "ws://127.0.0.1:18789",
-      token: "fixture",
-      logs: () => "qa gateway diagnostics",
+      token: "qa-token",
+      logs: () => "OPENCLAW_GATEWAY_TOKEN=secret-token",
     });
 
-    await expect(client.request("chat.history")).rejects.toMatchObject({
-      message: "history temporarily unavailable\nGateway logs:\nqa gateway diagnostics",
-      cause: gatewayError,
+    await expect(client.request("health")).rejects.toMatchObject({
+      cause: expect.objectContaining({ message: "gateway rejected request" }),
+      message: "gateway rejected request\nGateway logs:\nOPENCLAW_GATEWAY_TOKEN=<redacted>",
     });
+  });
+
+  it("stops the transport and rejects later requests", async () => {
+    const client = await startQaGatewayRpcClient({
+      wsUrl: "ws://127.0.0.1:18789",
+      token: "qa-token",
+      logs: () => "qa logs",
+    });
+
+    await client.stop();
+
+    expect(gatewayRpcMock.stopAndWait).toHaveBeenCalledOnce();
+    await expect(client.request("health")).rejects.toThrow(
+      "gateway rpc client already stopped\nGateway logs:\nqa logs",
+    );
+  });
+
+  it("rejects a request waiting for reconnect when stopped", async () => {
+    const client = await startQaGatewayRpcClient({
+      wsUrl: "ws://127.0.0.1:18789",
+      token: "qa-token",
+      logs: () => "qa logs",
+    });
+    gatewayClientCallback("onClose")();
+    const request = client.request("health");
+
+    await client.stop();
+
+    await expect(request).rejects.toThrow("gateway rpc client stopped\nGateway logs:\nqa logs");
+  });
+
+  it("does not create a new reconnect waiter after stop races a pre-dispatch rejection", async () => {
+    let rejectRequest!: (error: Error) => void;
+    gatewayRpcMock.request.mockImplementationOnce(
+      async () =>
+        await new Promise((_resolve, reject) => {
+          rejectRequest = reject;
+        }),
+    );
+    const client = await startQaGatewayRpcClient({
+      wsUrl: "ws://127.0.0.1:18789",
+      token: "qa-token",
+      logs: () => "qa logs",
+    });
+    const request = client.request("agent.run");
+    await vi.waitFor(() => expect(gatewayRpcMock.request).toHaveBeenCalledOnce());
+
+    await client.stop();
+    rejectRequest(new Error("gateway not connected"));
+
+    await expect(request).rejects.toThrow("gateway rpc client already stopped");
+    expect(gatewayRpcMock.request).toHaveBeenCalledOnce();
   });
 });

--- a/extensions/qa-lab/src/gateway-rpc-client.test.ts
+++ b/extensions/qa-lab/src/gateway-rpc-client.test.ts
@@ -1,8 +1,16 @@
 // Qa Lab tests cover gateway rpc client plugin behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+type GatewayRequestOptions = {
+  expectFinal?: boolean;
+  onSent?: () => void;
+  timeoutMs?: number;
+};
+
 const gatewayRpcMock = vi.hoisted(() => {
-  const request = vi.fn(async () => ({ ok: true }));
+  const request = vi.fn(
+    async (_method: string, _params: unknown, _options: GatewayRequestOptions) => ({ ok: true }),
+  );
   const stopAndWait = vi.fn(async () => {});
   const clients: Array<{ options: Record<string, unknown> }> = [];
   class GatewayClient {
@@ -198,7 +206,7 @@ describe("startQaGatewayRpcClient", () => {
 
   it("does not retry a sent request whose Gateway error says it is not connected", async () => {
     gatewayRpcMock.request.mockImplementationOnce(async (_method, _params, options) => {
-      options.onSent();
+      options.onSent?.();
       throw new Error("gateway not connected");
     });
     const client = await startQaGatewayRpcClient({

--- a/extensions/qa-lab/src/gateway-rpc-client.test.ts
+++ b/extensions/qa-lab/src/gateway-rpc-client.test.ts
@@ -7,6 +7,12 @@ type GatewayRequestOptions = {
   timeoutMs?: number;
 };
 
+type GatewayReconnectPausedInfo = {
+  code: number;
+  detailCode?: string;
+  reason: string;
+};
+
 const gatewayRpcMock = vi.hoisted(() => {
   const request = vi.fn(
     async (_method: string, _params: unknown, _options: GatewayRequestOptions) => ({ ok: true }),
@@ -56,6 +62,14 @@ function gatewayClientCallback(name: "onClose" | "onHelloOk") {
     throw new Error(`expected Gateway client ${name} callback`);
   }
   return callback as () => void;
+}
+
+function pauseGatewayReconnect(info: GatewayReconnectPausedInfo) {
+  const callback = gatewayRpcMock.clients[0]?.options.onReconnectPaused;
+  if (typeof callback !== "function") {
+    throw new Error("expected Gateway client onReconnectPaused callback");
+  }
+  (callback as (info: GatewayReconnectPausedInfo) => void)(info);
 }
 
 describe("startQaGatewayRpcClient", () => {
@@ -201,6 +215,26 @@ describe("startQaGatewayRpcClient", () => {
     await vi.advanceTimersByTimeAsync(250);
 
     await rejection;
+    expect(gatewayRpcMock.request).not.toHaveBeenCalled();
+  });
+
+  it("preserves a terminal reconnect failure through the following close", async () => {
+    const client = await startQaGatewayRpcClient({
+      wsUrl: "ws://127.0.0.1:18789",
+      token: "qa-token",
+      logs: () => "qa logs",
+    });
+
+    pauseGatewayReconnect({
+      code: 1008,
+      detailCode: "AUTH_FAILED",
+      reason: "authentication failed",
+    });
+    gatewayClientCallback("onClose")();
+
+    await expect(client.request("status")).rejects.toThrow(
+      "gateway reconnect paused (1008): authentication failed [AUTH_FAILED]",
+    );
     expect(gatewayRpcMock.request).not.toHaveBeenCalled();
   });
 

--- a/extensions/qa-lab/src/gateway-rpc-client.ts
+++ b/extensions/qa-lab/src/gateway-rpc-client.ts
@@ -1,6 +1,9 @@
 // Qa Lab plugin module implements gateway rpc client behavior.
 import { formatErrorMessage, toErrorObject } from "openclaw/plugin-sdk/error-runtime";
-import { callGatewayFromCli } from "openclaw/plugin-sdk/gateway-runtime";
+import {
+  GatewayClient,
+  startGatewayClientWhenEventLoopReady,
+} from "openclaw/plugin-sdk/gateway-runtime";
 import { formatQaGatewayLogsForError } from "./gateway-log-redaction.js";
 
 type QaGatewayRpcRequestOptions = {
@@ -14,43 +17,75 @@ type QaGatewayRpcClient = {
   stop(): Promise<void>;
 };
 
-function formatQaGatewayRpcError(error: unknown, logs: () => string) {
-  const details = formatErrorMessage(error);
-  return new Error(`${details}${formatQaGatewayLogsForError(logs())}`, { cause: error });
+type QaGatewayConnectionGate = {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (error: Error) => void;
+  state: "pending" | "connected" | "failed";
+};
+
+const QA_GATEWAY_RPC_TIMEOUT_MS = 20_000;
+
+function createQaGatewayConnectionGate(): QaGatewayConnectionGate {
+  let resolvePromise!: () => void;
+  let rejectPromise!: (error: Error) => void;
+  const gate: QaGatewayConnectionGate = {
+    promise: new Promise<void>((resolve, reject) => {
+      resolvePromise = resolve;
+      rejectPromise = reject;
+    }),
+    resolve: () => {
+      if (gate.state !== "pending") {
+        return;
+      }
+      gate.state = "connected";
+      resolvePromise();
+    },
+    reject: (error) => {
+      if (gate.state !== "pending") {
+        return;
+      }
+      gate.state = "failed";
+      rejectPromise(error);
+    },
+    state: "pending",
+  };
+  // A terminal reconnect error can arrive without an active request waiter.
+  void gate.promise.catch(() => {});
+  return gate;
 }
 
-function runQueuedQaGatewayRpc<T>(queue: Promise<void>, task: () => Promise<T>) {
-  const run = queue.then(task, task);
-  const nextQueue = run.then(
-    () => undefined,
-    () => undefined,
-  );
-  return { run, nextQueue };
+function formatQaGatewayRpcError(error: unknown, logs: () => string) {
+  const cause = toErrorObject(error, "Gateway RPC request failed");
+  const details = formatErrorMessage(cause);
+  return new Error(`${details}${formatQaGatewayLogsForError(logs())}`, { cause });
 }
 
 function qaGatewayDeadlineError() {
   return new Error("gateway request deadline exceeded");
 }
 
-function waitForQaGatewayRpcDeadline<T>(run: Promise<T>, deadlineMs: number) {
-  const remainingMs = deadlineMs - Date.now();
+async function waitForQaGatewayConnection(
+  gate: QaGatewayConnectionGate,
+  expiresAt: number,
+): Promise<void> {
+  const remainingMs = expiresAt - Date.now();
   if (remainingMs <= 0) {
-    return Promise.reject(qaGatewayDeadlineError());
+    throw qaGatewayDeadlineError();
   }
-  return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => reject(qaGatewayDeadlineError()), remainingMs);
-    void run.then(
-      (value) => {
-        clearTimeout(timer);
-        resolve(value);
-      },
-      (error: unknown) => {
-        clearTimeout(timer);
-        const rejectionError: Error = toErrorObject(error, "Gateway RPC request failed");
-        reject(rejectionError);
-      },
-    );
-  });
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      gate.promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(qaGatewayDeadlineError()), remainingMs);
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
 }
 
 export async function startQaGatewayRpcClient(params: {
@@ -60,64 +95,97 @@ export async function startQaGatewayRpcClient(params: {
 }): Promise<QaGatewayRpcClient> {
   const wrapError = (error: unknown) => formatQaGatewayRpcError(error, params.logs);
   let stopped = false;
-  let queue = Promise.resolve();
+  let connection = createQaGatewayConnectionGate();
   const assertNotStopped = () => {
     if (stopped) {
       throw new Error("gateway rpc client already stopped");
     }
   };
 
+  const client = new GatewayClient({
+    url: params.wsUrl,
+    token: params.token,
+    requestTimeoutMs: QA_GATEWAY_RPC_TIMEOUT_MS,
+    clientName: "gateway-client",
+    deviceIdentity: null,
+    mode: "backend",
+    scopes: ["operator.admin"],
+    onHelloOk: () => connection.resolve(),
+    onClose: () => {
+      if (!stopped && connection.state === "connected") {
+        connection = createQaGatewayConnectionGate();
+      }
+    },
+    onReconnectPaused: (info) => {
+      connection.reject(
+        new Error(
+          `gateway reconnect paused (${info.code}): ${info.reason}${info.detailCode ? ` [${info.detailCode}]` : ""}`,
+        ),
+      );
+    },
+  });
+
+  try {
+    const startupExpiresAt = Date.now() + QA_GATEWAY_RPC_TIMEOUT_MS;
+    const readiness = await startGatewayClientWhenEventLoopReady(client, {
+      timeoutMs: QA_GATEWAY_RPC_TIMEOUT_MS,
+    });
+    if (!readiness.ready) {
+      throw new Error("gateway event loop readiness timeout");
+    }
+    await waitForQaGatewayConnection(connection, startupExpiresAt);
+  } catch (error) {
+    stopped = true;
+    await client.stopAndWait().catch(() => {});
+    throw wrapError(error);
+  }
+
   return {
     async request(method, rpcParams, opts) {
       try {
         assertNotStopped();
-      } catch (error) {
-        throw wrapError(error);
-      }
-      try {
-        const { run, nextQueue } = runQueuedQaGatewayRpc(queue, async () => {
+        const startedAt = Date.now();
+        const expiresAt = Math.min(
+          startedAt + (opts?.timeoutMs ?? QA_GATEWAY_RPC_TIMEOUT_MS),
+          opts?.deadlineMs ?? Infinity,
+        );
+        while (true) {
+          const requestConnection = connection;
+          await waitForQaGatewayConnection(requestConnection, expiresAt);
           assertNotStopped();
-          const remainingMs =
-            opts?.deadlineMs === undefined ? undefined : opts.deadlineMs - Date.now();
-          if (remainingMs !== undefined && remainingMs <= 0) {
+          const remainingMs = expiresAt - Date.now();
+          if (remainingMs <= 0) {
             throw qaGatewayDeadlineError();
           }
-          return await callGatewayFromCli(
-            method,
-            {
-              url: params.wsUrl,
-              token: params.token,
-              timeout: String(
-                remainingMs === undefined
-                  ? (opts?.timeoutMs ?? 20_000)
-                  : Math.min(opts?.timeoutMs ?? 20_000, remainingMs),
-              ),
+          let requestSent = false;
+          try {
+            return await client.request(method, rpcParams ?? {}, {
               expectFinal: opts?.expectFinal,
-              json: true,
-            },
-            rpcParams ?? {},
-            {
-              clientName: "gateway-client",
-              deviceIdentity: null,
-              expectFinal: opts?.expectFinal,
-              mode: "backend",
-              progress: false,
-              scopes: ["operator.admin"],
-            },
-          );
-        });
-        // Caller deadline rejection must not release serialization. The queue stays on
-        // the underlying run, which rechecks expiry before dispatch when its turn arrives.
-        queue = nextQueue;
-        return await (opts?.deadlineMs === undefined
-          ? run
-          : waitForQaGatewayRpcDeadline(run, opts.deadlineMs));
+              onSent: () => {
+                requestSent = true;
+              },
+              timeoutMs: remainingMs,
+            });
+          } catch (error) {
+            if (requestSent || formatErrorMessage(error) !== "gateway not connected") {
+              throw error;
+            }
+            assertNotStopped();
+            // A close can race between gate resolution and request dispatch. No frame was sent,
+            // so waiting for the next hello and retrying is safe even for non-idempotent methods.
+            if (connection === requestConnection && connection.state === "connected") {
+              connection = createQaGatewayConnectionGate();
+            }
+          }
+        }
       } catch (error) {
         throw wrapError(error);
       }
     },
     async stop() {
       stopped = true;
+      connection.reject(new Error("gateway rpc client stopped"));
+      await client.stopAndWait();
     },
   };
 }

--- a/extensions/qa-lab/src/gateway-rpc-client.ts
+++ b/extensions/qa-lab/src/gateway-rpc-client.ts
@@ -117,11 +117,13 @@ export async function startQaGatewayRpcClient(params: {
       }
     },
     onReconnectPaused: (info) => {
-      connection.reject(
-        new Error(
-          `gateway reconnect paused (${info.code}): ${info.reason}${info.detailCode ? ` [${info.detailCode}]` : ""}`,
-        ),
+      const error = new Error(
+        `gateway reconnect paused (${info.code}): ${info.reason}${info.detailCode ? ` [${info.detailCode}]` : ""}`,
       );
+      if (connection.state === "connected") {
+        connection = createQaGatewayConnectionGate();
+      }
+      connection.reject(error);
     },
   });
 

--- a/src/agents/embedded-agent-runner/run/lane-controller.writer-claim.test.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.writer-claim.test.ts
@@ -20,11 +20,13 @@ import {
 } from "../../agent-run-terminal-outcome.js";
 import { SessionManager } from "../../sessions/session-manager.js";
 import { buildAssistantMessage, buildUsageWithNoCost } from "../../stream-message-shared.js";
+import { log } from "../logger.js";
 import { setActiveEmbeddedRun } from "../runs.js";
 import { testing as runsTesting } from "../runs.test-support.js";
 import type { EmbeddedAgentRunResult } from "../types.js";
 import { createEmbeddedRunLaneController } from "./lane-controller.js";
 import type { RunEmbeddedAgentParams } from "./params.js";
+import { claimAgentSessionWriter } from "./session-bootstrap.js";
 
 const fixture = useTempSessionsFixture("lane-writer-claim-");
 const sessionId = "writer-session";
@@ -52,6 +54,7 @@ describe("embedded run durable writer admission", () => {
   });
 
   it("supersedes the live prior writer, claims the row, and rejects its late append", async () => {
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
     await replaceSessionEntry({ agentId: "main", sessionKey, storePath: fixture.storePath() }, {
       activeWriterRunId: "run-a",
       lifecycleRevision,
@@ -141,6 +144,7 @@ describe("embedded run durable writer admission", () => {
     }
 
     expect(cancelA).toHaveBeenCalledWith("superseded");
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("live=true"));
     expect(takeoverOrder).toEqual(["record:run-b", "cancel:run-b"]);
     expect(supersededOutcome).toMatchObject({
       reason: "superseded",
@@ -184,6 +188,32 @@ describe("embedded run durable writer admission", () => {
       storePath: fixture.storePath(),
     });
     expect(staleAppend).toMatchObject({ ok: false, code: "session-rebound" });
+  });
+
+  it("silently replaces a persisted claim whose prior run is no longer live", async () => {
+    await replaceSessionEntry({ agentId: "main", sessionKey, storePath: fixture.storePath() }, {
+      activeWriterRunId: "completed-run",
+      lifecycleRevision,
+      sessionId,
+      updatedAt: 1,
+    } as InternalSessionEntry);
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+
+    await claimAgentSessionWriter({
+      agentId: "main",
+      prompt: "next turn",
+      runId: "run-next",
+      sessionId,
+      sessionKey,
+      sessionTarget: { agentId: "main", sessionId, sessionKey, storePath: fixture.storePath() },
+      timeoutMs: 30_000,
+      workspaceDir: "/tmp",
+    });
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(
+      loadSessionEntry({ agentId: "main", sessionKey, storePath: fixture.storePath() }),
+    ).toMatchObject({ activeWriterRunId: "run-next" });
   });
 
   it("leaves the incumbent live when the replacement claim does not commit", async () => {

--- a/src/agents/embedded-agent-runner/run/session-bootstrap.ts
+++ b/src/agents/embedded-agent-runner/run/session-bootstrap.ts
@@ -317,11 +317,13 @@ export async function claimAgentSessionWriter(params: RunEmbeddedAgentParams): P
         throw new Error(`Could not record superseded writer outcome: ${previousWriterRunId}`);
       }
     });
-    log.warn(
-      `[session-writer] replacing claim session=${sanitizeForLog(snapshot.sessionKey)} ` +
-        `previousRunId=${redactRunIdentifier(sanitizeForLog(previousWriterRunId))} ` +
-        `nextRunId=${redactRunIdentifier(sanitizeForLog(params.runId))} live=${superseded}`,
-    );
+    if (superseded) {
+      log.warn(
+        `[session-writer] replacing claim session=${sanitizeForLog(snapshot.sessionKey)} ` +
+          `previousRunId=${redactRunIdentifier(sanitizeForLog(previousWriterRunId))} ` +
+          `nextRunId=${redactRunIdentifier(sanitizeForLog(params.runId))} live=true`,
+      );
+    }
   }
   return {
     expectedLifecycleRevision,

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -10,6 +10,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { Type } from "typebox";
 import { readAcpSessionMeta } from "../../acp/runtime/session-meta.js";
 import { parseSessionThreadInfo } from "../../config/sessions/thread-info.js";
+import { runWithoutOwnedSessionTranscriptWrites } from "../../config/sessions/transcript-write-context.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { AgentRouteBinding } from "../../config/types.agents.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -912,22 +913,24 @@ export function createSessionsSendTool(opts?: {
             // This detached flow can outlive the tool request that launched it.
             // Own a fresh root so parent release cannot retire later nested turns.
             void runWithGatewayIndependentRootWorkContinuation(() =>
-              runSessionsSendA2AFlow({
-                callGateway: gatewayCall,
-                targetSessionKey: flowTargetSessionKey,
-                displayKey: flowDisplayKey,
-                message,
-                announceTimeoutMs,
-                // Cron runs are isolated jobs; target replies must not become new
-                // requester turns, but the target-side announce still runs.
-                maxPingPongTurns: isIsolatedCronRequester ? 0 : maxPingPongTurns,
-                requesterSessionKey: replyRequesterSessionKey,
-                requesterChannel,
-                baseline: flowBaseline,
-                roundOneReply,
-                waitRunId,
-                notifyRequesterOnWaitFailure,
-              }),
+              runWithoutOwnedSessionTranscriptWrites(() =>
+                runSessionsSendA2AFlow({
+                  callGateway: gatewayCall,
+                  targetSessionKey: flowTargetSessionKey,
+                  displayKey: flowDisplayKey,
+                  message,
+                  announceTimeoutMs,
+                  // Cron runs are isolated jobs; target replies must not become new
+                  // requester turns, but the target-side announce still runs.
+                  maxPingPongTurns: isIsolatedCronRequester ? 0 : maxPingPongTurns,
+                  requesterSessionKey: replyRequesterSessionKey,
+                  requesterChannel,
+                  baseline: flowBaseline,
+                  roundOneReply,
+                  waitRunId,
+                  notifyRequesterOnWaitFailure,
+                }),
+              ),
             ).catch((err: unknown) => {
               log.warn("sessions_send announce flow admission failed", {
                 runId: waitRunId ?? "unknown",

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -1190,7 +1190,11 @@ describe("sessions_send gating", () => {
     vi.mocked(runSessionsSendA2AFlow).mockImplementationOnce(async () => {
       inheritedFence = getOwnedSessionTranscriptWriterFence();
     });
-    const parentTranscriptWrite = vi.fn(async <T>(run: () => Promise<T> | T) => await run());
+    let parentTranscriptWriteCalls = 0;
+    const parentTranscriptWrite = async <T>(run: () => Promise<T> | T): Promise<T> => {
+      parentTranscriptWriteCalls += 1;
+      return await run();
+    };
 
     await withOwnedSessionTranscriptWrites(
       {
@@ -1208,7 +1212,7 @@ describe("sessions_send gating", () => {
     await vi.waitFor(() => expect(runSessionsSendA2AFlow).toHaveBeenCalledOnce());
 
     expect(inheritedFence).toBeUndefined();
-    expect(parentTranscriptWrite).not.toHaveBeenCalled();
+    expect(parentTranscriptWriteCalls).toBe(0);
   });
 
   it("canonicalizes aliased requester keys for same-session A2A delivery", async () => {

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -7,6 +7,10 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import type { ChannelMessagingAdapter } from "../../channels/plugins/types.public.js";
 import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/io.js";
 import { parseSessionThreadInfo } from "../../config/sessions/thread-info.js";
+import {
+  getOwnedSessionTranscriptWriterFence,
+  withOwnedSessionTranscriptWrites,
+} from "../../config/sessions/transcript-write-context.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { extractAssistantText, sanitizeTextContent } from "./chat-history-text.js";
@@ -1178,6 +1182,33 @@ describe("sessions_send gating", () => {
     const flowParams = vi.mocked(runSessionsSendA2AFlow).mock.calls[0]?.[0];
     expect(flowParams?.waitRunId).toBe("run-fire-and-forget");
     expect(flowParams?.baseline?.text).toBe("older reply from a previous run");
+  });
+
+  it("detaches fire-and-forget A2A work from parent transcript ownership", async () => {
+    const { runSessionsSendA2AFlow } = await import("./sessions-send-tool.a2a.js");
+    let inheritedFence: ReturnType<typeof getOwnedSessionTranscriptWriterFence>;
+    vi.mocked(runSessionsSendA2AFlow).mockImplementationOnce(async () => {
+      inheritedFence = getOwnedSessionTranscriptWriterFence();
+    });
+    const parentTranscriptWrite = vi.fn(async <T>(run: () => Promise<T> | T) => await run());
+
+    await withOwnedSessionTranscriptWrites(
+      {
+        sessionKey: MAIN_AGENT_SESSION_KEY,
+        sessionTarget: {
+          expectedWriterRunId: "disposed-parent-run",
+          sessionKey: MAIN_AGENT_SESSION_KEY,
+        },
+        withTranscriptWrite: parentTranscriptWrite,
+      },
+      async () => {
+        await executeFireAndForgetA2AFrom(MAIN_AGENT_SESSION_KEY);
+      },
+    );
+    await vi.waitFor(() => expect(runSessionsSendA2AFlow).toHaveBeenCalledOnce());
+
+    expect(inheritedFence).toBeUndefined();
+    expect(parentTranscriptWrite).not.toHaveBeenCalled();
   });
 
   it("canonicalizes aliased requester keys for same-session A2A delivery", async () => {

--- a/src/gateway/client-callsites.guard.test.ts
+++ b/src/gateway/client-callsites.guard.test.ts
@@ -10,6 +10,7 @@ const GATEWAY_CLIENT_CONSTRUCTOR_PATTERN = /new\s+GatewayClient\s*\(/;
 
 const ALLOWED_GATEWAY_CLIENT_CALLSITES = new Set([
   "extensions/google-meet/src/voice-call-gateway.ts",
+  "extensions/qa-lab/src/gateway-rpc-client.ts",
   "src/acp/server.ts",
   "src/gateway/call.ts",
   "src/gateway/gateway-cli-backend.live-helpers.ts",

--- a/src/gateway/server-chat-metadata-lifecycle.test.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.test.ts
@@ -18,7 +18,8 @@ const mocks = vi.hoisted(() => ({
   unregisterSkillsListener: vi.fn(),
 }));
 
-vi.mock("./server-methods/chat-metadata-runtime.js", () => ({
+vi.mock("./server-methods/chat-metadata-runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./server-methods/chat-metadata-runtime.js")>()),
   createGatewayChatMetadataRuntime: mocks.createRuntime,
 }));
 vi.mock("../agents/auth-profiles/runtime-snapshots.js", () => ({
@@ -33,6 +34,8 @@ vi.mock("../skills/runtime/refresh.js", () => ({
 }));
 
 const { createGatewayChatMetadataLifecycle } = await import("./server-chat-metadata-lifecycle.js");
+const { ChatMetadataSnapshotUnavailableError } =
+  await import("./server-methods/chat-metadata-runtime.js");
 
 const config = {} as OpenClawConfig;
 const context = {} as GatewayRequestContext;
@@ -86,42 +89,34 @@ describe("gateway chat metadata lifecycle", () => {
     expect(sidecars).toEqual([]);
   });
 
-  it("registers full Gateway listeners and awaits one catch-up refresh", async () => {
-    let releaseRefresh!: () => void;
-    mocks.refresh.mockReturnValueOnce(
-      new Promise<void>((resolve) => {
-        releaseRefresh = resolve;
-      }),
-    );
-    const { lifecycle: pendingLifecycle } = createLifecycle(false);
+  it("treats an unavailable catch-up snapshot as expected before owner publication", async () => {
+    mocks.refresh.mockRejectedValueOnce(new ChatMetadataSnapshotUnavailableError());
+    const { lifecycle: pendingLifecycle, warn } = createLifecycle(false);
     const lifecycle = await pendingLifecycle;
     const sidecars: Array<{ stop: () => Promise<void> }> = [];
-    let attached = false;
 
-    const attach = lifecycle.attachContext(context, sidecars).then(() => {
-      attached = true;
-    });
-    await vi.waitFor(() => expect(mocks.refresh).toHaveBeenCalledOnce());
+    await lifecycle.attachContext(context, sidecars);
 
     expect(mocks.registerAuthListener).toHaveBeenCalledOnce();
     expect(mocks.registerModelListener).toHaveBeenCalledOnce();
     expect(mocks.registerSkillsListener).toHaveBeenCalledOnce();
     expect(sidecars).toHaveLength(1);
-    expect(attached).toBe(false);
-
-    releaseRefresh();
-    await attach;
-    expect(attached).toBe(true);
     expect(mocks.refresh).toHaveBeenCalledOnce();
+    expect(warn).not.toHaveBeenCalled();
+
+    const listener = mocks.registerModelListener.mock.calls[0]?.[0];
+    expect(listener).toEqual(expect.any(Function));
+    listener({ phase: "published" });
+
+    await vi.waitFor(() => expect(mocks.refresh).toHaveBeenCalledTimes(2));
   });
 
-  it("logs catch-up failures without rejecting full Gateway startup", async () => {
+  it("logs unexpected catch-up failures without rejecting startup", async () => {
     mocks.refresh.mockRejectedValueOnce(new Error("metadata unavailable"));
     const { lifecycle: pendingLifecycle, warn } = createLifecycle(false);
     const lifecycle = await pendingLifecycle;
 
     await expect(lifecycle.attachContext(context, [])).resolves.toBeUndefined();
-
     expect(warn).toHaveBeenCalledWith(
       "chat metadata catch-up refresh failed: Error: metadata unavailable",
     );

--- a/src/gateway/server-chat-metadata-lifecycle.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.ts
@@ -11,7 +11,7 @@ export async function createGatewayChatMetadataLifecycle(params: {
   log: GatewayLogger;
 }) {
   let context: GatewayRequestContext | undefined;
-  const { createGatewayChatMetadataRuntime } =
+  const { ChatMetadataSnapshotUnavailableError, createGatewayChatMetadataRuntime } =
     await import("./server-methods/chat-metadata-runtime.js");
   const runtime = createGatewayChatMetadataRuntime({
     getConfig: params.getConfig,
@@ -94,12 +94,13 @@ export async function createGatewayChatMetadataLifecycle(params: {
       const sidecar = await registerRefreshListeners();
       if (sidecar) {
         sidecars.push(sidecar);
-        // Auth/model snapshots published before listener registration are otherwise never
-        // observed; one awaited catch-up refresh reconciles facts (revision-aware, no-op when
-        // fresh) so post-attach reads cannot serve a pre-publication generation. Failures are
-        // logged, not thrown: startup must not die on a metadata build error.
+        // Publications that complete before listener registration would otherwise be missed.
+        // During ordinary startup the owner is published after attachment, so an unavailable
+        // snapshot here is expected and the publication listener performs the first refresh.
         await runtime.refresh().catch((error: unknown) => {
-          params.log.warn(`chat metadata catch-up refresh failed: ${String(error)}`);
+          if (!(error instanceof ChatMetadataSnapshotUnavailableError)) {
+            params.log.warn(`chat metadata catch-up refresh failed: ${String(error)}`);
+          }
         });
       }
     },

--- a/src/gateway/server-methods/chat-metadata-runtime.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.ts
@@ -118,7 +118,7 @@ function createMetadataReplacement(): MetadataReplacement {
   return { promise, reject, resolve };
 }
 
-class ChatMetadataSnapshotUnavailableError extends Error {
+export class ChatMetadataSnapshotUnavailableError extends Error {
   constructor(message = "prepared chat metadata snapshot is unavailable") {
     super(message);
     this.name = "ChatMetadataSnapshotUnavailableError";

--- a/test/vitest/vitest.ui-isolated-paths.mjs
+++ b/test/vitest/vitest.ui-isolated-paths.mjs
@@ -9,6 +9,7 @@ export const uiIsolatedTestFiles = [
   "ui/src/components/viewer-facepile.test.ts",
   "ui/src/pages/agents/memory/memory-panel.test.ts",
   "ui/src/pages/chat/chat-page-attachment-handoff.test.ts",
+  "ui/src/pages/chat/chat-pane-attachment-handoff.test.ts",
   "ui/src/pages/chat/chat-pane-board.test.ts",
   "ui/src/pages/chat/chat-pane-history.test.ts",
   "ui/src/pages/chat/chat-pane-identity.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where deterministic QA stress runs appeared fully serialized even when Gateway agent lanes were configured for concurrency. The QA RPC helper queued every request before it reached the Gateway, producing misleading concurrency metrics and hiding real contention behavior. The same stress runs also accumulated unbounded parent-process logs and emitted lifecycle warnings for expected detached/stale startup states.

## Why This Change Was Made

QA Lab now uses one persistent multiplexed Gateway client with explicit startup/reconnect generations, whole-call deadlines, sent-frame replay protection, and stop semantics. Recent in-memory Gateway diagnostics are bounded while complete stdout/stderr remain on disk. Detached `sessions_send` continuations no longer inherit attempt-owned transcript writers, stale persisted writer claims are replaced quietly while live takeovers still warn, and metadata startup catch-up suppresses only the explicit pre-publication unavailable state.

The reconnect and ownership changes preserve the existing public protocol and do not add provider calls or credential paths.

AI-assisted: yes. The implementation and review findings were independently inspected and verified; no live provider credentials or paid provider calls were used.

## User Impact

QA and stress operators now see actual Gateway concurrency instead of client-side serialization, can trust reconnect/deadline behavior under load, and retain bounded diagnostics during long runs. Normal users should only see fewer false lifecycle warnings; delivery and writer fencing remain fail-closed.

## Evidence

- Deterministic mock-provider integration probe: 80 provider requests, 48 unique markers; max concurrency custom lanes `16`, configured main lane `8`, `sessions_send` fanout `7`; warning checks clean.
- Focused post-rebase proof: 241 tests passed across Gateway metadata, agent writer/session tools, and QA child/RPC shards.
- Core-test TypeScript check passed after preserving the transcript callback's generic contract.
- `git diff --check`, targeted `oxfmt`, and targeted `oxlint` passed.
- Structured independent review required two RPC lifecycle corrections (bounded initial hello/reconnect gates and sent-frame replay protection); final P0/P1 review: clean.
- Autoreview helper preflight passed TruffleHog, but the orb has no Codex/Claude/Pi CLI executable; independent read-only review was used instead.
