### PR TITLE
fix: Claude live sessions honor session exec restrictions

### DIFF
--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -4641,6 +4641,45 @@ describe("runCliAgent spawn path", () => {
       expectedPermissionMode: "default",
     },
     {
+      name: "denies tools when session exec security overrides broader config",
+      requestId: "req-session-security-deny",
+      toolUseId: "tool-session-security-deny-1",
+      input: { command: "ls" },
+      expected: { behavior: "deny", messageIncludes: "security=deny" },
+      context: {
+        sessionKey: "agent:main:main",
+        sessionEntry: { execSecurity: "deny" } as PreparedCliRunContext["params"]["sessionEntry"],
+        config: {
+          tools: { exec: { security: "full", ask: "off" } },
+          agents: {
+            entries: {
+              main: { default: true, tools: { exec: { security: "full", ask: "off" } } },
+            },
+          },
+        },
+      },
+      expectedPermissionMode: "default",
+    },
+    {
+      name: "denies tools when a partial agent exec block inherits restrictive global security",
+      requestId: "req-partial-agent-global-deny",
+      toolUseId: "tool-partial-agent-global-deny-1",
+      input: { command: "ls" },
+      expected: { behavior: "deny", messageIncludes: "security=deny" },
+      context: {
+        sessionKey: "agent:main:main",
+        config: {
+          tools: { exec: { security: "deny", ask: "off" } },
+          agents: {
+            entries: {
+              main: { default: true, tools: { exec: { ask: "off" } } },
+            },
+          },
+        },
+      },
+      expectedPermissionMode: "default",
+    },
+    {
       name: "denies tools when session exec ask is restrictive",
       requestId: "req-session-ask-deny",
       toolUseId: "tool-session-ask-deny-1",

--- a/src/agents/cli-runner/claude-live-session-policy.test.ts
+++ b/src/agents/cli-runner/claude-live-session-policy.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, it } from "vitest";
 import { resolveClaudeLiveMode } from "./claude-live-session-policy.js";
-import { readConfiguredExecPolicy } from "./claude-live-session.test-support.js";
-import type { PreparedCliRunContext } from "./types.js";
 
 describe("resolveClaudeLiveMode", () => {
   it("keeps root on Claude default permissions while preserving YOLO elsewhere", () => {
@@ -11,30 +9,5 @@ describe("resolveClaudeLiveMode", () => {
 
   it("keeps restrictive OpenClaw policies on Claude default permissions", () => {
     expect(resolveClaudeLiveMode("allowlist", "on-miss", 1000)).toBe("default");
-  });
-});
-
-describe("Claude live configured exec policy", () => {
-  it("uses the configured default agent for an unscoped legacy session key", () => {
-    const context = {
-      params: {
-        sessionKey: "main",
-        config: {
-          tools: { exec: { security: "full", ask: "off" } },
-          agents: {
-            entries: {
-              main: {},
-              ops: { default: true, tools: { exec: { security: "deny", ask: "always" } } },
-            },
-          },
-        },
-      },
-    } as unknown as PreparedCliRunContext;
-
-    expect(readConfiguredExecPolicy(context)).toEqual({
-      agentId: "ops",
-      security: "deny",
-      ask: "always",
-    });
   });
 });

--- a/src/agents/cli-runner/claude-live-session.test-support.ts
+++ b/src/agents/cli-runner/claude-live-session.test-support.ts
@@ -1,6 +1,5 @@
 import type { CliBackendConfig } from "../../plugins/cli-backend.types.js";
 import "./claude-live-session.js";
-import type { PreparedCliRunContext } from "./types.js";
 
 type BuildClaudeLiveArgsParams = {
   args: string[];
@@ -12,11 +11,6 @@ type BuildClaudeLiveArgsParams = {
 
 type ClaudeLiveSessionTestApi = {
   buildClaudeLiveArgs(params: BuildClaudeLiveArgsParams): string[];
-  readConfiguredExecPolicy(context: PreparedCliRunContext): {
-    security: string;
-    ask: string;
-    agentId: string;
-  };
   resetClaudeLiveSessionsForTest(): void;
 };
 
@@ -28,10 +22,6 @@ function getTestApi(): ClaudeLiveSessionTestApi {
 
 export function buildClaudeLiveArgs(params: BuildClaudeLiveArgsParams): string[] {
   return getTestApi().buildClaudeLiveArgs(params);
-}
-
-export function readConfiguredExecPolicy(context: PreparedCliRunContext) {
-  return getTestApi().readConfiguredExecPolicy(context);
 }
 
 export function resetClaudeLiveSessionsForTest(): void {

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -16,16 +16,7 @@ import {
   type DiagnosticToolExecutionErrorEvent,
 } from "../../infra/diagnostic-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import {
-  loadExecApprovals,
-  maxAsk,
-  minSecurity,
-  normalizeExecAsk,
-  resolveExecApprovalsFromFile,
-  resolveExecModePolicy,
-  type ExecAsk,
-  type ExecSecurity,
-} from "../../infra/exec-approvals.js";
+import type { ExecAsk, ExecSecurity } from "../../infra/exec-approvals.js";
 import { BLOCKED_TOOL_CALL_ABORT_FLOOR_MS } from "../../logging/diagnostic-run-activity.js";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
 import type {
@@ -33,11 +24,6 @@ import type {
   CliBackendLiveSessionRequirement,
   CliBackendParseJsonlEvent,
 } from "../../plugins/cli-backend.types.js";
-import {
-  LEGACY_IMPLICIT_AGENT_ID,
-  resolveAgentIdFromSessionKey,
-} from "../../routing/session-key.js";
-import { resolveAgentConfig, resolveDefaultAgentId } from "../agent-scope-config.js";
 import type {
   CliOutput,
   CliStreamingDelta,
@@ -57,6 +43,7 @@ import {
 } from "../cli-output-stream.js";
 import { extractCliErrorMessage, parseCliOutput } from "../cli-output.js";
 import { classifyFailoverReason } from "../embedded-agent-helpers.js";
+import { resolveExecDefaults } from "../exec-defaults.js";
 import {
   type CliTimeoutContext,
   FailoverError,
@@ -356,7 +343,6 @@ function buildClaudeLiveArgs(params: {
 if (process.env.VITEST || process.env.NODE_ENV === "test") {
   (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.claudeLiveSessionTestApi")] = {
     buildClaudeLiveArgs,
-    readConfiguredExecPolicy,
     resetClaudeLiveSessionsForTest,
   };
 }
@@ -988,50 +974,14 @@ function parseSessionId(parsed: Record<string, unknown>): string | undefined {
   return sessionId || undefined;
 }
 
-function readConfiguredExecPolicy(context: PreparedCliRunContext): {
-  security: ExecSecurity;
-  ask: ExecAsk;
-  agentId: string;
-} {
-  const agentId =
-    context.params.agentId ??
-    resolveAgentIdFromSessionKey(
-      context.params.sessionKey,
-      context.params.config
-        ? resolveDefaultAgentId(context.params.config)
-        : LEGACY_IMPLICIT_AGENT_ID,
-    );
-  const agentExec = context.params.config
-    ? resolveAgentConfig(context.params.config, agentId)?.tools?.exec
-    : undefined;
-  const exec = agentExec ?? context.params.config?.tools?.exec;
-  const configured = resolveExecModePolicy({
-    mode: exec?.mode,
-    security: exec?.security ?? "full",
-    ask: exec?.ask ?? "off",
-  });
-  const security = configured.security;
-  const configuredAsk = configured.ask;
-  const sessionAsk = normalizeExecAsk(context.params.sessionEntry?.execAsk);
-  return {
-    agentId,
-    security,
-    ask: sessionAsk ? maxAsk(configuredAsk, sessionAsk) : configuredAsk,
-  };
-}
-
 function resolveClaudeLiveExecPermission(context: PreparedCliRunContext): ClaudeLiveExecPermission {
-  const configured = readConfiguredExecPolicy(context);
-  const approvals = resolveExecApprovalsFromFile({
-    file: loadExecApprovals(),
-    agentId: configured.agentId,
-    overrides: {
-      security: configured.security,
-      ask: configured.ask,
-    },
+  const { security, ask } = resolveExecDefaults({
+    cfg: context.params.config,
+    sessionEntry: context.params.sessionEntry,
+    execOverrides: context.params.execOverrides,
+    agentId: context.params.agentId,
+    sessionKey: context.params.runtimePolicySessionKey ?? context.params.sessionKey,
   });
-  const security = minSecurity(configured.security, approvals.agent.security);
-  const ask = maxAsk(configured.ask, approvals.agent.ask);
   return {
     security,
     ask,

--- a/src/agents/exec-defaults.test.ts
+++ b/src/agents/exec-defaults.test.ts
@@ -302,6 +302,26 @@ describe("resolveExecDefaults", () => {
     });
   });
 
+  it("uses the configured default agent for an unscoped session", () => {
+    expect(
+      resolveExecDefaults({
+        cfg: {
+          tools: { exec: { security: "full", ask: "off" } },
+          agents: {
+            entries: {
+              main: {},
+              ops: { default: true, tools: { exec: { security: "deny", ask: "always" } } },
+            },
+          },
+        },
+        sandboxAvailable: false,
+      }),
+    ).toMatchObject({
+      security: "deny",
+      ask: "always",
+    });
+  });
+
   it("blocks node skill eligibility for deny policy and preserves node bindings", () => {
     expect(
       resolveNodeExecEligibility({


### PR DESCRIPTION
Related: #121566

AI-assisted: yes. No agent transcript is attached.

## What Problem This Solves

Fixes an issue where Claude live sessions could allow a native tool call even when the session set `execSecurity=deny`, or when a partial per-agent exec block inherited a restrictive global security setting. The live-session approval path independently resolved exec policy, replaced the global block with a partial agent block, ignored the session security override, and filled missing values with permissive defaults.

## Why This Change Was Made

Claude live native-tool approval now uses the canonical `resolveExecDefaults` flow, preserving the established global → agent → session → approvals precedence. The duplicate resolver and its obsolete test-only accessor are removed so this path cannot drift from the shared exec-policy owner again.

## User Impact

Operators can expect Claude live sessions to honor configured and session-level exec restrictions consistently. A session marked deny remains denied, and a partial agent override no longer discards a stricter global security policy.

## Evidence

- Pre-fix reproduction: `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/agents/cli-runner.spawn.test.ts` failed 2 tests and passed 128; both new denial cases expected `deny` but received `allow`.
- Post-fix exact command: 130/130 tests passed.
- Owner/sibling proof: `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/agents/exec-defaults.test.ts src/agents/cli-runner/claude-live-session-policy.test.ts` passed 17/17 tests.
- Targeted oxfmt, oxlint, and `git diff --check` passed.
- Structured Codex autoreviews were clean with no actionable findings, including a fresh review of the rebased one-commit branch.
- LOC: production +8/−58 (net −50); tests/test support +59/−37 (net +22); total +67/−95 (net −28).
- Remote proof gaps: the Blacksmith CLI was unavailable and the AWS Crabbox broker was not logged in. The local changed-check wrapper did not execute because other worktrees held the shared heavy-check lock until timeout. These are infrastructure gaps, not test failures.
- Live proof gap: an isolated loopback Gateway persisted the target session row with `execSecurity=deny` and `execAsk=off`, and the sentinel remained absent. The agent turn did not reach Claude because unrelated prepared model-runtime startup did not converge before supersession, so this is not claimed as a passing live proof.
- Exact-head pull-request CI is the remaining broad gate.

Coordination: #121566 moves this code into `claude-live-process.ts`; after this fix lands, that split must preserve the canonical `resolveExecDefaults` call when rebased.
