### PR TITLE
fix(ci): restore SQLite snapshot Windows cleanup proof

### DIFF
--- a/src/infra/sqlite-snapshot.test.ts
+++ b/src/infra/sqlite-snapshot.test.ts
@@ -612,12 +612,12 @@ describe("createVerifiedSqliteSnapshot", () => {
         linked = true;
       }
     });
-    vi.spyOn(fs, "lstat").mockImplementation(async (filePath) => {
+    vi.spyOn(fs, "lstat").mockImplementation(async (filePath, options) => {
       if (linked && !failedInspection && path.resolve(String(filePath)) === targetPath) {
         failedInspection = true;
         throw Object.assign(new Error("target inspection failed"), { code: "EIO" });
       }
-      return await originalLstat(filePath);
+      return await originalLstat(filePath, options as never);
     });
 
     await expectSnapshotFailureWithoutTarget(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where native Windows CI could fail the SQLite publication cleanup regression before reaching its injected post-publication inspection failure after `@openclaw/fs-safe` 0.5.4 enabled exact bigint identity checks.

## Why This Change Was Made

The test's `fs.lstat` spy now forwards the optional `options` argument to the real implementation. This preserves `{ bigint: true }` requests from the production dependency instead of silently returning rounded numeric Windows file identities. Production publication and cleanup behavior is unchanged.

## User Impact

No user-visible runtime change. Windows CI can continue proving that a target is removed when inspection fails after atomic publication.

## Evidence

Before-fix native Windows failures, both on current main base `86fe45ce179`:

- PR #121662 run 31415004148, job 93542150162: expected `target inspection failed`; received `publication source identity did not match`.
- PR #121632 run 31415312759, job 93543196609: independently reproduced the identical failure.

Root-cause proof:

- `@openclaw/fs-safe` 0.5.4 calls `lstat(path, { bigint: true })` to retain exact Windows file indexes.
- The test spy accepted only `filePath` and delegated as `originalLstat(filePath)`, dropping the bigint option.
- The resulting mixed rounded numeric pathname identity and exact bigint descriptor identity fail closed before publication, exactly matching both logs.
- The mock now delegates the complete API call while retaining the original injected target-only `EIO` behavior and exact assertion.

Local `git diff --check` passes. Focused local Vitest was unavailable in this clean orb because dependencies are not installed; exact-head native Windows CI is the decisive after-fix proof.
