### PR TITLE
fix: reject invalid memory parents and trim test facades

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.draft-progress.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.draft-progress.test.ts
@@ -802,12 +802,10 @@ describe("processDiscordMessage draft streaming progress", () => {
 
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.replyOptions?.onToolStart?.({
-        toolCallId: "call-1",
         name: "exec",
         phase: "start",
       });
       await params?.replyOptions?.onCommandOutput?.({
-        toolCallId: "call-1",
         phase: "end",
         title: "pnpm test -- --watch=false",
         name: "exec",

--- a/packages/memory-host-sdk/src/host/read-file.test.ts
+++ b/packages/memory-host-sdk/src/host/read-file.test.ts
@@ -19,7 +19,7 @@ async function createDirectorySymlink(target: string, linkPath: string): Promise
 }
 
 describe("readMemoryFile", () => {
-  it("returns empty text for missing files under extra path directories", async () => {
+  it("returns empty text for absent extra paths and rejects non-directory parents", async () => {
     const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-read-file-"));
     try {
       const workspaceDir = path.join(tmpRoot, "workspace");
@@ -47,10 +47,7 @@ describe("readMemoryFile", () => {
           extraPaths: [extraDir],
           relPath: nonDirectoryParentPath,
         }),
-      ).resolves.toEqual({
-        text: "",
-        path: path.relative(workspaceDir, nonDirectoryParentPath).replace(/\\/g, "/"),
-      });
+      ).rejects.toThrow("path required");
     } finally {
       await fs.rm(tmpRoot, { recursive: true, force: true });
     }

--- a/packages/memory-host-sdk/src/host/read-file.ts
+++ b/packages/memory-host-sdk/src/host/read-file.ts
@@ -41,8 +41,8 @@ async function isAllowedAdditionalDirectoryPath(
   }
   try {
     await assertNoSymlinkParents({ rootDir: additionalPath, targetPath: absPath });
-  } catch (err) {
-    return isFileMissingError(err);
+  } catch {
+    return false;
   }
   if (!isPathInsideWithRealpath(additionalPath, absPath)) {
     try {

--- a/scripts/anthropic-prompt-probe.ts
+++ b/scripts/anthropic-prompt-probe.ts
@@ -1007,7 +1007,6 @@ async function main() {
 export const testing = {
   cleanupPromptProbeTmpDir,
   installGatewayPromptParentSignalHandlers,
-  matchesExtraUsage400,
   promptProbeTmpResult,
   readLogTail,
   readRequestBody,
@@ -1015,8 +1014,6 @@ export const testing = {
   runDirectPrompt,
   startAnthropicProxy,
   stopGatewayPromptChild,
-  summarizeCapture,
-  summarizeText,
 };
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {

--- a/scripts/debug-claude-usage.ts
+++ b/scripts/debug-claude-usage.ts
@@ -542,11 +542,8 @@ const main = async (argv = process.argv.slice(2)) => {
 
 export const testing = {
   CLAUDE_COOKIE_HOST_SQL,
-  CLAUDE_FIREFOX_COOKIE_HOST_SQL,
   FETCH_RESPONSE_MAX_BYTES,
-  browserRootLabel,
   fetchAnthropicOAuthUsage,
-  mask,
   parseArgs,
   readBoundedResponseText,
   resolveFetchTimeoutMs,

--- a/scripts/e2e/npm-telegram-live-runner.ts
+++ b/scripts/e2e/npm-telegram-live-runner.ts
@@ -269,13 +269,11 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
 }
 
 export const testing = {
-  parsePositiveIntegerEnv,
   resolvePackageTelegramOutputDir,
   resolveCredentialRole,
   resolveCredentialSource,
   createRoundTripProbe,
   prioritizeRoundTripProbeScenario,
-  projectExtendedStable2026_6_35QaConfig,
   resolveRttOptions,
   resolveTrustedOpenClawCommand,
   shouldFailPackageTelegramRun,

--- a/scripts/write-cli-startup-metadata.ts
+++ b/scripts/write-cli-startup-metadata.ts
@@ -626,7 +626,7 @@ async function spawnText(
   });
 }
 
-export async function renderBundledRootHelpText(
+async function renderBundledRootHelpText(
   _distDirOverride: string = distDir,
   renderContext?: RootHelpRenderContext,
 ): Promise<string> {
@@ -755,7 +755,7 @@ async function renderSourceSubcommandHelpTextRecord(
   ) as PrecomputedSubcommandHelpText;
 }
 
-export async function writeCliStartupMetadata(options?: {
+async function writeCliStartupMetadata(options?: {
   distDir?: string;
   outputPath?: string;
   extensionsDir?: string;
@@ -981,9 +981,8 @@ export const testing = {
   renderSourceRootHelpText,
   signalCliStartupMetadataProcessTree,
   spawnText,
+  writeCliStartupMetadata,
 };
-
-export { testing as __testing };
 
 if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
   await writeCliStartupMetadata();

--- a/src/gateway/server-methods/setup-admission.ts
+++ b/src/gateway/server-methods/setup-admission.ts
@@ -28,9 +28,9 @@ export async function runExclusiveSystemAgentSetupActivation<T>(
   }
 }
 
-export function whenAdmittedWizardSessionSettled<T extends { whenSettled(): Promise<unknown> }>(
-  session: T,
-): Promise<unknown> {
+export function whenAdmittedWizardSessionSettled(session: {
+  whenSettled(): Promise<unknown>;
+}): Promise<unknown> {
   return wizardSessionAdmissionSettlements.get(session) ?? session.whenSettled();
 }
 

--- a/src/gateway/server-methods/system-agent.test.ts
+++ b/src/gateway/server-methods/system-agent.test.ts
@@ -29,7 +29,10 @@ import type {
 import type { WizardPrompter } from "../../wizard/prompts.js";
 import { ExecApprovalManager } from "../exec-approval-manager.js";
 import { handleGatewayRequest } from "../server-methods.js";
-import { runExclusiveSystemAgentSetupActivation } from "./setup-admission.js";
+import {
+  runExclusiveSystemAgentSetupActivation,
+  whenAdmittedWizardSessionSettled,
+} from "./setup-admission.js";
 import { systemAgentHandlers, type SystemAgentChatSession } from "./system-agent.js";
 import type { GatewayClient, GatewayRequestContext } from "./types.js";
 
@@ -406,6 +409,7 @@ describe("openclaw.setup", () => {
     });
     await session.answer(first.step.id, null);
     await expect(session.next()).resolves.toMatchObject({ done: true, status: "done" });
+    await whenAdmittedWizardSessionSettled(session);
   });
   it("runs the selected provider method in a shared wizard session and commits its config", async () => {
     const preparedConfig: OpenClawConfig = {
@@ -459,6 +463,7 @@ describe("openclaw.setup", () => {
       status: "done",
       preparedModelRef: "ollama/qwen3:0.6b",
     });
+    await whenAdmittedWizardSessionSettled(session);
     expect(setupSharedMocks.writeWizardConfigFile).toHaveBeenCalledWith(preparedConfig, {
       allowConfigSizeDrop: false,
       baseSnapshot: expect.objectContaining({ hash: "prepare-base-hash" }),

--- a/src/infra/sqlite-snapshot.test.ts
+++ b/src/infra/sqlite-snapshot.test.ts
@@ -612,12 +612,13 @@ describe("createVerifiedSqliteSnapshot", () => {
         linked = true;
       }
     });
-    vi.spyOn(fs, "lstat").mockImplementation(async (filePath) => {
+    vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+      const [filePath] = args;
       if (linked && !failedInspection && path.resolve(String(filePath)) === targetPath) {
         failedInspection = true;
         throw Object.assign(new Error("target inspection failed"), { code: "EIO" });
       }
-      return await originalLstat(filePath);
+      return await originalLstat(...args);
     });
 
     await expectSnapshotFailureWithoutTarget(

--- a/test/scripts/write-cli-startup-metadata.test.ts
+++ b/test/scripts/write-cli-startup-metadata.test.ts
@@ -7,7 +7,7 @@ import { PassThrough } from "node:stream";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { resolveWindowsTaskkillPath } from "../../scripts/lib/windows-taskkill.mjs";
-import { __testing, writeCliStartupMetadata } from "../../scripts/write-cli-startup-metadata.ts";
+import { testing } from "../../scripts/write-cli-startup-metadata.ts";
 import { createScriptTestHarness } from "./test-helpers.js";
 
 vi.mock("node:child_process", async (importOriginal) => {
@@ -131,7 +131,7 @@ describe("write-cli-startup-metadata", () => {
       });
     });
 
-    const render = __testing.renderSourceRootHelpText();
+    const render = testing.renderSourceRootHelpText();
     child.stdout.write("Usage: openclaw\n");
     setImmediate(() => {
       child.emit("close", 0, null);
@@ -156,7 +156,7 @@ describe("write-cli-startup-metadata", () => {
 
   it("fails command help rendering when captured output exceeds the byte limit", async () => {
     await expect(
-      __testing.spawnText(["--eval", "process.stdout.write('x'.repeat(2048))"], {
+      testing.spawnText(["--eval", "process.stdout.write('x'.repeat(2048))"], {
         cwd: process.cwd(),
         env: process.env,
         failureMessage: "render failed",
@@ -174,7 +174,7 @@ describe("write-cli-startup-metadata", () => {
       const spawnProcess = vi.fn(() => child as unknown as ReturnType<typeof spawn>);
       const streamError = new Error(`${streamName} pipe failed`);
 
-      const render = __testing.spawnText(["--help"], {
+      const render = testing.spawnText(["--help"], {
         cwd: process.cwd(),
         env: process.env,
         failureMessage: "render failed",
@@ -198,7 +198,7 @@ describe("write-cli-startup-metadata", () => {
   it("preserves an output-limit failure when shutdown also errors a stream", async () => {
     const child = createSpawnTextChild();
     const spawnProcess = vi.fn(() => child as unknown as ReturnType<typeof spawn>);
-    const render = __testing.spawnText(["--help"], {
+    const render = testing.spawnText(["--help"], {
       cwd: process.cwd(),
       env: process.env,
       failureMessage: "render failed",
@@ -219,7 +219,7 @@ describe("write-cli-startup-metadata", () => {
     const childKill = vi.fn(() => true);
     const runTaskkill = vi.fn(() => ({ error: undefined, status: 0 }));
 
-    __testing.signalCliStartupMetadataProcessTree({ pid: 123, kill: childKill }, "SIGTERM", {
+    testing.signalCliStartupMetadataProcessTree({ pid: 123, kill: childKill }, "SIGTERM", {
       platform: "win32",
       runTaskkill,
     });
@@ -227,7 +227,7 @@ describe("write-cli-startup-metadata", () => {
       stdio: "ignore",
     });
 
-    __testing.signalCliStartupMetadataProcessTree({ pid: 123, kill: childKill }, "SIGKILL", {
+    testing.signalCliStartupMetadataProcessTree({ pid: 123, kill: childKill }, "SIGKILL", {
       platform: "win32",
       runTaskkill,
     });
@@ -249,7 +249,7 @@ describe("write-cli-startup-metadata", () => {
       .mockReturnValueOnce({ error: undefined, status: 1 })
       .mockReturnValueOnce({ error: undefined, status: 0 });
 
-    __testing.signalCliStartupMetadataProcessTree({ pid: 123, kill: childKill }, "SIGTERM", {
+    testing.signalCliStartupMetadataProcessTree({ pid: 123, kill: childKill }, "SIGTERM", {
       platform: "win32",
       runTaskkill,
     });
@@ -287,7 +287,7 @@ describe("write-cli-startup-metadata", () => {
       ].join("\n");
 
       await expect(
-        __testing.spawnText(["--input-type=module", "--eval", parentScript], {
+        testing.spawnText(["--input-type=module", "--eval", parentScript], {
           cwd: tempRoot,
           env: process.env,
           failureMessage: "render failed",
@@ -343,10 +343,10 @@ describe("write-cli-startup-metadata", () => {
         tempRoot,
         "runner.mjs",
         [
-          `const { __testing } = await import(${JSON.stringify(
+          `const { testing } = await import(${JSON.stringify(
             pathToFileURL(path.resolve("scripts/write-cli-startup-metadata.ts")).href,
           )});`,
-          "void __testing.spawnText(",
+          "void testing.spawnText(",
           `  [${JSON.stringify(fastCommandPath)}],`,
           "  {",
           `    cwd: ${JSON.stringify(tempRoot)},`,
@@ -357,7 +357,7 @@ describe("write-cli-startup-metadata", () => {
           "    timeoutMs: 30_000,",
           "  },",
           ").catch(() => undefined);",
-          "void __testing.spawnText(",
+          "void testing.spawnText(",
           `  [${JSON.stringify(commandPath)}],`,
           "  {",
           `    cwd: ${JSON.stringify(tempRoot)},`,
@@ -438,7 +438,7 @@ describe("write-cli-startup-metadata", () => {
       "utf8",
     );
 
-    await writeCliStartupMetadata({
+    await testing.writeCliStartupMetadata({
       distDir,
       outputPath,
       extensionsDir,
@@ -513,7 +513,7 @@ describe("write-cli-startup-metadata", () => {
       "async function outputRootHelp() { process.stdout.write('Usage: bundled renderer\\n'); }\nexport { outputRootHelp };\n",
     );
 
-    await writeCliStartupMetadata({
+    await testing.writeCliStartupMetadata({
       distDir,
       outputPath,
       extensionsDir,
@@ -575,7 +575,7 @@ describe("write-cli-startup-metadata", () => {
       throw new Error(`startup help renderers did not start concurrently: ${started.join(", ")}`);
     };
 
-    const writePromise = writeCliStartupMetadata({
+    const writePromise = testing.writeCliStartupMetadata({
       distDir,
       outputPath,
       extensionsDir,
@@ -631,7 +631,7 @@ describe("write-cli-startup-metadata", () => {
     writeStartupMetadataSourceSignatureFixture(tempRoot);
     writeFixtureFile(distDir, "root-help-fixture.js", "export function outputRootHelp() {}\n");
 
-    const writeMetadata = writeCliStartupMetadata({
+    const writeMetadata = testing.writeCliStartupMetadata({
       distDir,
       outputPath,
       extensionsDir,
@@ -695,7 +695,7 @@ describe("write-cli-startup-metadata", () => {
     writeFixtureFile(distDir, "root-help-fixture.js", "export function outputRootHelp() {}\n");
 
     const writeMetadata = async (): Promise<void> => {
-      await writeCliStartupMetadata({
+      await testing.writeCliStartupMetadata({
         distDir,
         outputPath,
         extensionsDir,
@@ -776,7 +776,7 @@ describe("write-cli-startup-metadata", () => {
     writeFixtureFile(distDir, "root-help-fixture.js", "export function outputRootHelp() {}\n");
 
     const writeMetadata = async (): Promise<void> => {
-      await writeCliStartupMetadata({
+      await testing.writeCliStartupMetadata({
         distDir,
         outputPath,
         extensionsDir,


### PR DESCRIPTION
Related: #121632

## What Problem This Solves

Internal scripts retained zero-caller testing facade members, an obsolete `__testing` alias, and named exports used only by tests. Those seams expanded maintenance surface without protecting additional behavior.

Validation also exposed a real memory-path defect: an extra memory path with an existing non-directory parent was silently treated as a missing file, even though pinned fs-safe 0.5.4 rejects that path state.

This PR preserves the audited 10-file scope from #121632 after that PR's head branch acquired unrelated work. Lifecycle, cursor, routing, cron, gateway production, managed-media, and lint repairs from the earlier stack have since landed independently on `main`; only the deterministic gateway owner-test settlement correction remains here.

## Why This Change Was Made

The cleanup keeps one canonical script testing facade and removes unused members from the Telegram live runner and diagnostic/probe scripts.

The remaining validation repairs are at their owning boundaries:

- reject extra memory paths when fs-safe 0.5.4 reports an invalid parent, while still returning empty content for a genuinely absent leaf;
- make the SQLite snapshot fault-injection mock forward the complete `lstat` overload so Windows bigint identity fencing remains intact;
- remove retired Discord progress callback fields from the fixture instead of preserving obsolete call shape;
- make direct gateway owner tests await the canonical wizard admission and filesystem-lock settlement after terminal sessions before starting the next admitted session.

The earlier Vitest and Node compile-cache experiments were disproven by exact CI logs and are intentionally absent from the final branch.

AI-assisted: yes. The changes were manually inspected and passed the repository autoreview gate.

## User Impact

Invalid extra memory paths now fail closed instead of looking like absent files. Maintainers get smaller script testing APIs and deterministic fixtures that follow current callback and setup-admission contracts.

## Evidence

- Script owner suite: 114 tests passed across the Telegram live runner, startup metadata, and developer tooling.
- Discord raw-progress focused test passed; extension-test typecheck passed.
- Fresh Node 24 local-container proof with a frozen dependency install, provider `local-container`, lease `cbx_7de4f31469ac`, run `run_adbcb9411fe4`:
  - memory host and memory plugin readers: 17/17 passed against pinned fs-safe 0.5.4;
  - SQLite snapshot: 30 passed, 2 platform-skipped.
- Gateway settlement proof:
  - the two previously racing system-agent cases passed 20 consecutive runs (40/40 focused cases);
  - setup-admission and wizard owner suites passed 23/23.
- `node scripts/check-changed.mjs -- <all changed paths>` passed the complete selected gate on the validated superset after the documented remote-backend fallback to local execution: env ratchet 503/503, max-lines, formatting, Plugin SDK baseline, dead exports, core/core-test/UI/extension-test/scripts/root-test typechecks, full core/extensions/scripts lint, boundaries, schema guards, and import cycles. The final diff is a byte-identical subset plus the reviewed test-only gateway settlement await.
- Exact fs-safe 0.5.4 source and changelog were inspected for `not-file` parent rejection and Windows bigint publication identities.
- Fresh final autoreview and secret scan: clean, no accepted/actionable findings.
- Exact-head Windows CI remains the platform proof for the bigint-aware SQLite mock.

## Scope and LOC

Production/tooling: `+5/-14` (net `-9`). Tests: `+29/-28` (net `+1`). Overall: `+34/-42` (net `-8`). No config, protocol, schema, dependency, release, version, generated baseline, lockfile, or changelog changes.
