### PR TITLE
fix(codex): let code-mode-only models discover deferred tools

### DIFF
--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -785,12 +785,14 @@ describe("Codex app-server native code mode config", () => {
     });
 
     expect(instructions).toContain("Use Codex native `spawn_agent` for Codex subagents");
-    // Codex defers native collab tools behind tool_search on search-capable
-    // models; the instructions must teach the retrieval path or models fall
-    // back to the always-direct sessions_spawn.
+    // Codex defers native collab tools behind tool_search or code mode; the
+    // instructions must teach both retrieval paths or models fall back to the
+    // always-direct sessions_spawn.
+    expect(instructions).toContain("Use `tool_search` when directly callable");
     expect(instructions).toContain(
-      "when `spawn_agent` is not directly listed, load it with `tool_search` before spawning",
+      "On code-mode-only models, use `exec` instead: filter `ALL_TOOLS` by name and description",
     );
+    expect(instructions).toContain("call the matching entry through `tools`");
     expect(instructions).toContain(
       "Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation, never as a substitute for `spawn_agent`.",
     );
@@ -952,7 +954,11 @@ describe("Codex app-server native code mode config", () => {
     expect(instructions).toContain(
       "Deferred searchable OpenClaw dynamic tools available: image_generate, music_generate.",
     );
-    expect(instructions).toContain("Use `tool_search` to load exact callable specs before use.");
+    expect(instructions).toContain("Use `tool_search` when directly callable");
+    expect(instructions).toContain(
+      "On code-mode-only models, use `exec` instead: filter `ALL_TOOLS` by name and description",
+    );
+    expect(instructions).toContain("call the matching entry through `tools`");
     expect(instructions).not.toContain("message,");
   });
 

--- a/extensions/codex/src/app-server/thread-prompt.ts
+++ b/extensions/codex/src/app-server/thread-prompt.ts
@@ -54,19 +54,24 @@ export function buildDeveloperInstructions(
     !isMessageOnlyCodexSourceReply(params) &&
     !isSystemAgentOnlyCodexDynamicToolAllowlist(params.toolsAllow) &&
     !shouldDisableCodexToolSearchForModel(params.modelId);
+  const deferredToolDiscoveryGuidance =
+    deferredToolNames.size > 0 || nativeDelegationAvailable
+      ? "Deferred tools may be absent from the direct tool list. Use `tool_search` when directly callable. On code-mode-only models, use `exec` instead: filter `ALL_TOOLS` by name and description, then call the matching entry through `tools`."
+      : undefined;
   const sections = [
     "You are a personal agent running inside OpenClaw. OpenClaw has dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes.",
     deferredToolNames.size > 0
       ? `Deferred searchable OpenClaw dynamic tools available: ${[...deferredToolNames]
           .toSorted((left, right) => left.localeCompare(right))
-          .join(", ")}. Use \`tool_search\` to load exact callable specs before use.`
+          .join(", ")}.`
       : undefined,
+    deferredToolDiscoveryGuidance,
     hasSkillWorkshop ? buildSkillWorkshopPromptSection().join("\n") : undefined,
     // Codex defers native collab tools behind tool_search on search-capable
     // models (codex-rs spec_plan add_collaboration_tools). Without this hint
     // models cannot see spawn_agent and grab the always-direct sessions_spawn.
     nativeDelegationAvailable
-      ? `Use Codex native \`spawn_agent\` for Codex subagents. \`spawn_agent\` and the other native collaboration tools may be deferred: when \`spawn_agent\` is not directly listed, load it with \`tool_search\` before spawning.${hasSessionsSpawn ? " Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation, never as a substitute for `spawn_agent`." : ""}`
+      ? `Use Codex native \`spawn_agent\` for Codex subagents. \`spawn_agent\` and the other native collaboration tools may be deferred.${hasSessionsSpawn ? " Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation, never as a substitute for `spawn_agent`." : ""}`
       : undefined,
     hasSessionsYield && nativeDelegationAvailable
       ? "When a native child's result belongs in a later turn, end the current turn with `openclaw_direct.sessions_yield`; the completion arrives as the next model-visible input. Use native `wait_agent` only for an intentional same-turn wait when the immediate next step is blocked on the child. Never loop-poll for native child completion."

--- a/scripts/generate-prompt-snapshots.ts
+++ b/scripts/generate-prompt-snapshots.ts
@@ -197,19 +197,6 @@ async function checkSnapshots() {
     }
     if (actual !== file.content) {
       mismatches.push(`${file.path}: differs from generated output`);
-      let differenceIndex = 0;
-      while (
-        differenceIndex < actual.length &&
-        differenceIndex < file.content.length &&
-        actual[differenceIndex] === file.content[differenceIndex]
-      ) {
-        differenceIndex += 1;
-      }
-      const contextStart = Math.max(0, differenceIndex - 200);
-      console.error(`actual: ${JSON.stringify(actual.slice(contextStart, differenceIndex + 500))}`);
-      console.error(
-        `expected: ${JSON.stringify(file.content.slice(contextStart, differenceIndex + 500))}`,
-      );
     }
   }
   for (const snapshotPath of await listCommittedSnapshotArtifactPaths(repoRoot)) {

--- a/scripts/generate-prompt-snapshots.ts
+++ b/scripts/generate-prompt-snapshots.ts
@@ -197,6 +197,11 @@ async function checkSnapshots() {
     }
     if (actual !== file.content) {
       mismatches.push(`${file.path}: differs from generated output`);
+      const marker = "Deferred searchable OpenClaw dynamic tools available:";
+      const markerIndex = file.content.indexOf(marker);
+      if (markerIndex >= 0) {
+        console.error(file.content.slice(markerIndex, markerIndex + 800));
+      }
     }
   }
   for (const snapshotPath of await listCommittedSnapshotArtifactPaths(repoRoot)) {

--- a/scripts/generate-prompt-snapshots.ts
+++ b/scripts/generate-prompt-snapshots.ts
@@ -197,11 +197,19 @@ async function checkSnapshots() {
     }
     if (actual !== file.content) {
       mismatches.push(`${file.path}: differs from generated output`);
-      const marker = "Deferred searchable OpenClaw dynamic tools available:";
-      const markerIndex = file.content.indexOf(marker);
-      if (markerIndex >= 0) {
-        console.error(file.content.slice(markerIndex, markerIndex + 800));
+      let differenceIndex = 0;
+      while (
+        differenceIndex < actual.length &&
+        differenceIndex < file.content.length &&
+        actual[differenceIndex] === file.content[differenceIndex]
+      ) {
+        differenceIndex += 1;
       }
+      const contextStart = Math.max(0, differenceIndex - 200);
+      console.error(`actual: ${JSON.stringify(actual.slice(contextStart, differenceIndex + 500))}`);
+      console.error(
+        `expected: ${JSON.stringify(file.content.slice(contextStart, differenceIndex + 500))}`,
+      );
     }
   }
   for (const snapshotPath of await listCommittedSnapshotArtifactPaths(repoRoot)) {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -427,9 +427,11 @@ Approval policy is currently never. Do not provide the `sandbox_permissions` for
 ````text
 You are a personal agent running inside OpenClaw. OpenClaw has dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes.
 
-Deferred searchable OpenClaw dynamic tools available: automations, gateway, nodes, session_status, sessions_history, sessions_list, sessions_search, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
+Deferred searchable OpenClaw dynamic tools available: automations, gateway, nodes, session_status, sessions_history, sessions_list, sessions_search, sessions_send, subagents, tts, web_fetch, web_search.
 
-Use Codex native `spawn_agent` for Codex subagents. `spawn_agent` and the other native collaboration tools may be deferred: when `spawn_agent` is not directly listed, load it with `tool_search` before spawning. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation, never as a substitute for `spawn_agent`.
+Deferred tools may be absent from the direct tool list. Use `tool_search` when directly callable. On code-mode-only models, use `exec` instead: filter `ALL_TOOLS` by name and description, then call the matching entry through `tools`.
+
+Use Codex native `spawn_agent` for Codex subagents. `spawn_agent` and the other native collaboration tools may be deferred. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation, never as a substitute for `spawn_agent`.
 
 When a native child's result belongs in a later turn, end the current turn with `openclaw_direct.sessions_yield`; the completion arrives as the next model-visible input. Use native `wait_agent` only for an intentional same-turn wait when the immediate next step is blocked on the child. Never loop-poll for native child completion.
 

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -231,16 +231,16 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 13043
   },
   "openClawDeveloperInstructions": {
-    "chars": 4390,
-    "roughTokens": 1098
+    "chars": 4479,
+    "roughTokens": 1120
   },
   "totalTextOnly": {
-    "chars": 28773,
-    "roughTokens": 7194
+    "chars": 28862,
+    "roughTokens": 7216
   },
   "totalWithDynamicToolsJson": {
-    "chars": 80946,
-    "roughTokens": 20237
+    "chars": 81035,
+    "roughTokens": 20259
   },
   "userInputText": {
     "chars": 1300,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -427,9 +427,11 @@ Approval policy is currently never. Do not provide the `sandbox_permissions` for
 ````text
 You are a personal agent running inside OpenClaw. OpenClaw has dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes.
 
-Deferred searchable OpenClaw dynamic tools available: automations, gateway, nodes, session_status, sessions_history, sessions_list, sessions_search, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
+Deferred searchable OpenClaw dynamic tools available: automations, gateway, nodes, session_status, sessions_history, sessions_list, sessions_search, sessions_send, subagents, tts, web_fetch, web_search.
 
-Use Codex native `spawn_agent` for Codex subagents. `spawn_agent` and the other native collaboration tools may be deferred: when `spawn_agent` is not directly listed, load it with `tool_search` before spawning. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation, never as a substitute for `spawn_agent`.
+Deferred tools may be absent from the direct tool list. Use `tool_search` when directly callable. On code-mode-only models, use `exec` instead: filter `ALL_TOOLS` by name and description, then call the matching entry through `tools`.
+
+Use Codex native `spawn_agent` for Codex subagents. `spawn_agent` and the other native collaboration tools may be deferred. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation, never as a substitute for `spawn_agent`.
 
 When a native child's result belongs in a later turn, end the current turn with `openclaw_direct.sessions_yield`; the completion arrives as the next model-visible input. Use native `wait_agent` only for an intentional same-turn wait when the immediate next step is blocked on the child. Never loop-poll for native child completion.
 

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -231,16 +231,16 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 12966
   },
   "openClawDeveloperInstructions": {
-    "chars": 3281,
-    "roughTokens": 821
+    "chars": 3370,
+    "roughTokens": 843
   },
   "totalTextOnly": {
-    "chars": 27293,
-    "roughTokens": 6824
+    "chars": 27382,
+    "roughTokens": 6846
   },
   "totalWithDynamicToolsJson": {
-    "chars": 79158,
-    "roughTokens": 19790
+    "chars": 79247,
+    "roughTokens": 19812
   },
   "userInputText": {
     "chars": 929,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -235,7 +235,7 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
   },
   "totalWithDynamicToolsJson": {
     "chars": 81197,
-    "roughTokens": 20299
+    "roughTokens": 20300
   },
   "userInputText": {
     "chars": 1271,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -422,9 +422,11 @@ Approval policy is currently never. Do not provide the `sandbox_permissions` for
 ````text
 You are a personal agent running inside OpenClaw. OpenClaw has dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes.
 
-Deferred searchable OpenClaw dynamic tools available: automations, gateway, nodes, session_status, sessions_history, sessions_list, sessions_search, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
+Deferred searchable OpenClaw dynamic tools available: automations, gateway, nodes, session_status, sessions_history, sessions_list, sessions_search, sessions_send, subagents, tts, web_fetch, web_search.
 
-Use Codex native `spawn_agent` for Codex subagents. `spawn_agent` and the other native collaboration tools may be deferred: when `spawn_agent` is not directly listed, load it with `tool_search` before spawning. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation, never as a substitute for `spawn_agent`.
+Deferred tools may be absent from the direct tool list. Use `tool_search` when directly callable. On code-mode-only models, use `exec` instead: filter `ALL_TOOLS` by name and description, then call the matching entry through `tools`.
+
+Use Codex native `spawn_agent` for Codex subagents. `spawn_agent` and the other native collaboration tools may be deferred. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation, never as a substitute for `spawn_agent`.
 
 When a native child's result belongs in a later turn, end the current turn with `openclaw_direct.sessions_yield`; the completion arrives as the next model-visible input. Use native `wait_agent` only for an intentional same-turn wait when the immediate next step is blocked on the child. Never loop-poll for native child completion.
 

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -226,16 +226,16 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 13350
   },
   "openClawDeveloperInstructions": {
-    "chars": 3281,
-    "roughTokens": 821
+    "chars": 3370,
+    "roughTokens": 843
   },
   "totalTextOnly": {
-    "chars": 27709,
-    "roughTokens": 6928
+    "chars": 27798,
+    "roughTokens": 6950
   },
   "totalWithDynamicToolsJson": {
-    "chars": 81108,
-    "roughTokens": 20277
+    "chars": 81197,
+    "roughTokens": 20299
   },
   "userInputText": {
     "chars": 1271,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running Codex code-mode-only models could be told that a configured deferred tool was unavailable when the tool was absent from the direct tool list. The existing Codex developer instructions only pointed models to `tool_search`, even though code-mode-only models access deferred tools through `exec`.

Related downstream fix: https://github.com/openai/openai/pull/1267933

## Why This Change Was Made

The Codex app-server prompt now describes both supported discovery paths once: use `tool_search` when it is directly callable, or use `exec` with `ALL_TOOLS` and the `tools` object on code-mode-only models. Existing direct and searchable tool behavior remains unchanged.

The guidance lives in the Codex prompt owner and applies to both deferred OpenClaw dynamic tools and Codex-native collaboration tools without hard-coding a model id.

## User Impact

Codex code-mode-only models can discover and invoke installed deferred tools instead of incorrectly reporting them as unavailable or falling back to a different direct tool. Models with direct `tool_search` continue using the existing path.

## Evidence

- Added focused assertions for deferred OpenClaw tools and Codex-native collaboration tools covering direct `tool_search` and code-mode-only `exec` discovery.
- Direct inspection of the exact bundled Codex `rust-v0.147.0` tag confirms `CodeModeOnly` selection in `codex-rs/core/src/tools/mod.rs`, deferred executor registration in `codex-rs/core/src/tools/spec_plan.rs`, and the `ALL_TOOLS` catalog plus callable `tools` object in `codex-rs/code-mode-runtime/src/runtime/globals.rs`.
- `git diff --check` passes on head `b9adb7dd3cd2127bb4d6ebb6ae16ba07dba32390`.
- The three generated Codex runtime prompt snapshots affected by the prompt owner were refreshed after the initial exact-head snapshot check identified their drift.
- No dependency, config, or schema surface changed; only the three required generated prompt fixtures were refreshed.
- Local format, lint, and Vitest were not run because this fresh checkout has no `node_modules`, local dependency reconciliation is prohibited by the OpenClaw development workflow, and Crabbox/Testbox is unavailable on this host. Exact-head hosted PR CI is the remaining validation authority.

AI-assisted: yes.
