### PR TITLE
fix(ui): align agent switcher rows on one leading column

### DIFF
--- a/ui/src/e2e/sidebar-interactions.e2e.test.ts
+++ b/ui/src/e2e/sidebar-interactions.e2e.test.ts
@@ -247,6 +247,26 @@ suite.define(() => {
         .poll(() => researchSwitch.locator("img.agent-select__avatar").getAttribute("src"))
         .toContain("data:image/png;base64,");
       await expect.poll(() => menu.getByText(/^New session —/).count()).toBe(0);
+      // The menu mixes avatar rows with command rows. They must share one
+      // leading column, or agent labels drift right of the command labels
+      // (Web Awesome's slotted-icon margin stacking on our own row gap).
+      const columns = await menu.evaluate((dropdown) => {
+        const left = (element: Element | null | undefined) =>
+          element ? Math.round(element.getBoundingClientRect().x) : Number.NaN;
+        const commandRow = dropdown.querySelector('wa-dropdown-item[value="command:new-agent"]');
+        const agentRow = dropdown.querySelector(
+          "wa-dropdown-item.sidebar-agent-menu__agent-switch",
+        );
+        return {
+          agentLead: left(agentRow?.querySelector('[slot="icon"]')),
+          commandLead: left(commandRow?.querySelector('[slot="icon"]')),
+          agentLabel: left(agentRow?.querySelector(".agent-select__option-copy")),
+          commandLabel: left(commandRow?.querySelector(".sidebar-customize-menu__text")),
+        };
+      });
+      expect(columns.agentLead).toBeGreaterThan(0);
+      expect(columns.agentLead).toBe(columns.commandLead);
+      expect(columns.agentLabel).toBe(columns.commandLabel);
       await expect
         .poll(() => mainSwitch.evaluate((element) => element === document.activeElement))
         .toBe(true);

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2448,7 +2448,7 @@ wa-dropdown.sidebar-customize-menu::part(menu) {
 }
 
 .sidebar-customize-menu__title {
-  padding: 6px 10px 8px;
+  padding: 6px 8px 8px;
   font-size: var(--control-ui-text-xs);
   font-weight: 650;
   letter-spacing: 0.07em;
@@ -2457,7 +2457,7 @@ wa-dropdown.sidebar-customize-menu::part(menu) {
 }
 
 .sidebar-customize-menu__provenance {
-  margin: 0 10px 6px;
+  margin: 0 8px 6px;
   color: var(--muted);
   font-size: var(--control-ui-text-xs);
   line-height: 1.35;
@@ -2497,6 +2497,21 @@ wa-dropdown.sidebar-customize-menu::part(menu) {
   background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
 }
 
+/* Web Awesome's shadow row adds `margin-inline-end: 0.75em !important` to the
+   slotted icon, which the light DOM cannot outrank. Dropping the gap leaves
+   that margin as the icon column instead of stacking into a ~17px gutter, and
+   keeps icon-less rows from inheriting a phantom leading indent. */
+wa-dropdown-item.sidebar-customize-menu__item {
+  gap: 0;
+}
+
+/* One leading column for the whole menu family: command glyphs centre inside
+   the agent avatar's box (.agent-select__option .agent-select__avatar) so
+   avatar rows and icon rows share a gutter and their labels start on one x. */
+.sidebar-customize-menu .nav-item__icon {
+  width: 24px;
+}
+
 .sidebar-customize-menu__item > a {
   display: flex;
   align-items: center;
@@ -2511,13 +2526,20 @@ wa-dropdown.sidebar-customize-menu::part(menu) {
    a -1.5em margin. Our compact `padding: 0 8px` above removes that inset, so
    rebuild the check column here or the checkmark lands outside the row edge. */
 .sidebar-pin-editor-menu .sidebar-customize-menu__item[checkbox-adjacent] {
-  padding-inline-start: 30px; /* 8px edge + 14px check column + 8px flex gap */
+  padding-inline-start: 30px; /* 8px edge + 14px check column + 8px gutter */
 }
 
 .sidebar-pin-editor-menu .sidebar-customize-menu__item::part(checkmark) {
   width: 14px;
   min-width: 14px;
-  margin-inline: -22px 0; /* pull back into the padding; the 8px flex gap spaces the icon */
+  margin-inline: -22px 8px; /* pull back into the padding; the end margin spaces the icon */
+}
+
+/* The agent switcher marks its selection in the trailing details rail
+   (.session-menu__check), so the native leading checkmark is layout-only: it
+   reserved a column that pushed avatar rows out of the command rows' gutter. */
+.sidebar-agent-menu .sidebar-customize-menu__item::part(checkmark) {
+  display: none;
 }
 
 .sidebar-customize-menu__text {
@@ -3475,7 +3497,7 @@ wa-dropdown.sidebar-identity-menu::part(menu) {
 }
 
 .sidebar-agent-menu__empty {
-  padding: 6px 10px;
+  padding: 6px 8px;
   font-size: var(--control-ui-text-sm);
   color: var(--muted);
 }


### PR DESCRIPTION
Closes #121704

## What Problem This Solves

Fixes an issue where operators opening the sidebar agent switcher would see a menu whose rows do not line up: agent rows start their avatar 11px and their label 19px to the right of the `New agent` / `What can <agent> do?` / `Agent settings` rows, and the `AGENTS` section label sits 2px off the rows' inline edge. The sibling More menu shows the same class of break inside itself, with its route rows indented 8px past the `Edit pinned items` row.

## Why This Change Was Made

The sidebar dropdown family (`.sidebar-customize-menu__item`, shared by the agent menu, More menu, pin editor, and identity menu) never received the Web Awesome shadow-row corrections that `.session-menu__item` already documents. Three defects stack:

1. Our `gap: 8px` sits on top of Web Awesome's forced `margin-inline-end: 0.75em` on the slotted icon, producing a ~17px gutter and an 8px phantom indent on every row with an empty `slot="icon"`.
2. The agent rows are `type="checkbox"`, so Web Awesome renders its native leading checkmark. Selection is drawn in the trailing details rail instead, so that checkmark is never visible — it renders at x=-3, outside the panel — but it still reserves a column. `.sidebar-session-sort-menu__item` already hides it for exactly this reason.
3. The menu mixes a 24px avatar column with a 16px `.nav-item__icon` column.

The fix gives the family one leading column instead of inventing local values: drop the stacked gap (the `.session-menu__item` solution), hide the agent menu's layout-only native checkmark (the `.sidebar-session-sort-menu__item` solution), widen command glyph boxes to the avatar's existing 24px so glyph centres and avatar centres share an axis, and pull the section label, provenance note, and empty state onto the rows' 8px inline edge (the value the filter input and identity header already use). CSS only; no markup, no new tokens, no behavior change.

Non-goals called out rather than silently fixed:

- `.sidebar-session-sort-menu__title` still carries a different section-label treatment (`4px 8px 2px`, `letter-spacing: 0.05em`) from `.sidebar-customize-menu__title`. That is a separate menu with its own trigger; consolidating the two section-label rules is worth a follow-up but is not this PR's thesis.
- The More menu's route rows keep their existing 1px drift against slotted rows (their anchor's own `gap: 8px` vs Web Awesome's 9px slotted margin). It exists on `main` today and is unchanged here.

## User Impact

The agent switcher reads as one list: avatars and command glyphs sit on the same axis, every label starts on the same x, and the `AGENTS` label lines up with the column below it. The selected-agent checkmark stays on the right, where it was moved by an earlier fix. The More menu's route rows and its `Edit pinned items` row now share a gutter too. Identity menu and pin editor rows are pixel-identical to before.

## Evidence

Agent switcher, mocked Gateway with three agents.

| | before | after |
| --- | --- | --- |
| dark | ![](https://github.com/user-attachments/assets/cda79866-9ee0-4714-82a0-b05ef9963237) | ![](https://github.com/user-attachments/assets/92aac675-041d-4d21-a09a-72004acac452) |
| light | ![](https://github.com/user-attachments/assets/aab2ae07-e975-4d4b-91a7-847095001141) | ![](https://github.com/user-attachments/assets/38535074-f34d-496d-9dc5-b0c72b5dde61) |

More menu (dark), showing the sibling break the same fix closes:

| before | after |
| --- | --- |
| ![](https://github.com/user-attachments/assets/fd55f918-4483-45e4-98ad-4d616240a585) | ![](https://github.com/user-attachments/assets/672eaaaa-97b6-4c4e-b78d-2e7c36fe5608) |

Rendered-DOM geometry, panel-relative x, dark, measured before and after in the same harness:

| menu / row | icon x before -> after | label x before -> after |
| --- | --- | --- |
| agent menu, avatar rows | 26 -> 15 | 67 -> 48 |
| agent menu, command rows | 15 -> 15 | 48 -> 48 |
| agent menu, native checkmark | -3 (w15) -> removed | — |
| more menu, route rows | 15 -> 15 | 23 -> 15 |
| more menu, `Edit pinned items` | 15 -> 15 | 48 -> 48 |
| identity menu, all rows | 15 -> 15 | 48 -> 48 |
| pin editor, all rows | 37 -> 37 | 70 -> 70 |

Row heights (30px) and separator margins (6px above and below) are unchanged in every menu; the divider asymmetry that prompted this was the rows moving, not the divider.

Validation (macOS, this checkout):

- `./node_modules/.bin/stylelint --config config/stylelint.config.mjs ui/src/styles/layout.css` — clean
- `node scripts/run-vitest.mjs run ui/src/styles/theme-contrast.test.ts ui/src/styles/base-theme-contrast.node.test.ts ui/src/styles/base-theme-tokens.node.test.ts ui/src/styles/cursor-policy.node.test.ts` — 4 files, 11 tests passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/sidebar-interactions.e2e.test.ts` — 6 tests passed (covers opening the agent menu, keyboard traversal of agent rows, and switching agents)
- `./node_modules/.bin/oxfmt ui/src/styles/layout.css`

Production LOC: +22 / -5 in one CSS file, no test changes, no new files.
