### PR TITLE
improve(ui): give pinned sessions their own sidebar group

### DIFF
--- a/ui/src/components/app-sidebar-render.ts
+++ b/ui/src/components/app-sidebar-render.ts
@@ -231,6 +231,32 @@ export function renderAppSidebarHomeRow(host: AppSidebarRenderHost) {
   `;
 }
 
+/** Both zone groups accept drops, so dragging a session onto either one pins it
+    and records its slot in the canonical entry order. */
+export function renderAppSidebarZoneGroup(host: AppSidebarRenderHost, content: unknown) {
+  return html`
+    <div
+      class="nav-section__items"
+      @dragover=${(event: DragEvent) => host.sessionOrganizer.handleSidebarZoneDragOver(event)}
+      @dragleave=${(event: DragEvent) => host.sessionOrganizer.handleSidebarZoneDragLeave(event)}
+      @drop=${(event: DragEvent) => host.sessionOrganizer.handleSidebarZoneDrop(event)}
+    >
+      ${content}
+    </div>
+  `;
+}
+
+/** Pinned sessions are elevated content, not navigation, so they carry their own
+    section label instead of trailing the Pages list. No customize affordance:
+    the Pages head owns the pin editor, and pinning is a per-session action. */
+export function renderAppSidebarPinnedHead() {
+  return html`
+    <div class="sidebar-nav__head sidebar-nav__head--pinned">
+      <span class="sidebar-recent-sessions__label-text">${t("nav.pinned")}</span>
+    </div>
+  `;
+}
+
 export function renderAppSidebarPagesHead(host: AppSidebarRenderHost) {
   return html`
     <div class="sidebar-nav__head">

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -27,8 +27,10 @@ import {
   renderAppSidebarFooterBar,
   renderAppSidebarHomeRow,
   renderAppSidebarPagesHead,
+  renderAppSidebarPinnedHead,
   renderAppSidebarPluginTabEntry,
   renderAppSidebarZoneEntry,
+  renderAppSidebarZoneGroup,
 } from "./app-sidebar-render.ts";
 import type { SessionCatalogGroupsRenderer } from "./app-sidebar-session-catalog-render.ts";
 import type { CatalogSessionMenuRequest } from "./app-sidebar-session-catalogs.ts";
@@ -468,6 +470,10 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
 
   override render() {
     const sidebarZone = this.reconciledSidebarZone();
+    // Pinned sessions keep their slot in the canonical entry order but render as
+    // their own group, so navigation entries stay a contiguous Pages list.
+    const pinnedEntries = sidebarZone.entries.filter((entry) => entry.type === "session");
+    const navEntries = sidebarZone.entries.filter((entry) => entry.type !== "session");
     return html`
       <aside
         class="sidebar"
@@ -488,27 +494,37 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
           >
             <nav class="sidebar-nav" @contextmenu=${this.sidebarMenus.openCustomizeMenuFromContext}>
               ${renderAppSidebarPagesHead(this)}
-              <div
-                class="nav-section__items"
-                @dragover=${(event: DragEvent) =>
-                  this.sessionOrganizer.handleSidebarZoneDragOver(event)}
-                @dragleave=${(event: DragEvent) =>
-                  this.sessionOrganizer.handleSidebarZoneDragLeave(event)}
-                @drop=${(event: DragEvent) => this.sessionOrganizer.handleSidebarZoneDrop(event)}
-              >
-                ${renderAppSidebarHomeRow(this)}
-                ${sidebarZone.entries.map((entry) =>
-                  renderAppSidebarZoneEntry(
+              ${renderAppSidebarZoneGroup(
+                this,
+                html`
+                  ${renderAppSidebarHomeRow(this)}
+                  ${navEntries.map((entry) =>
+                    renderAppSidebarZoneEntry(
+                      this,
+                      entry,
+                      sidebarZone.sessionRows,
+                      sidebarZone.workboardRows,
+                    ),
+                  )}
+                  ${sidebarPluginTabs(this.context?.gateway.snapshot.hello?.controlUiTabs).map(
+                    (tab) => renderAppSidebarPluginTabEntry(this, tab),
+                  )}
+                `,
+              )}
+              ${pinnedEntries.length > 0
+                ? html`${renderAppSidebarPinnedHead()}
+                  ${renderAppSidebarZoneGroup(
                     this,
-                    entry,
-                    sidebarZone.sessionRows,
-                    sidebarZone.workboardRows,
-                  ),
-                )}
-                ${sidebarPluginTabs(this.context?.gateway.snapshot.hello?.controlUiTabs).map(
-                  (tab) => renderAppSidebarPluginTabEntry(this, tab),
-                )}
-              </div>
+                    pinnedEntries.map((entry) =>
+                      renderAppSidebarZoneEntry(
+                        this,
+                        entry,
+                        sidebarZone.sessionRows,
+                        sidebarZone.workboardRows,
+                      ),
+                    ),
+                  )}`
+                : nothing}
             </nav>
             ${this.renderSessions()}
           </div>

--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -220,7 +220,16 @@ suite.define(() => {
       ]);
       expect(liveRowsBox).not.toBeNull();
       expect(catalogBox).not.toBeNull();
-      expect(Math.round(catalogBox!.y - (liveRowsBox!.y + liveRowsBox!.height))).toBe(10);
+      // Read the rhythm from the token instead of restating it: the guard is
+      // that catalogs are a separate group, not that the gap is any one number.
+      const groupGap = await page.evaluate(() => {
+        const sidebar = document.querySelector(".sidebar");
+        return sidebar
+          ? Number.parseInt(getComputedStyle(sidebar).getPropertyValue("--sidebar-group-gap"), 10)
+          : Number.NaN;
+      });
+      expect(groupGap).toBeGreaterThan(0);
+      expect(Math.round(catalogBox!.y - (liveRowsBox!.y + liveRowsBox!.height))).toBe(groupGap);
       if (captureUiProofEnabled) {
         await mkdir(uiProofArtifactDir, { recursive: true });
         await sessionGroups.screenshot({

--- a/ui/src/e2e/session-management.sidebar.e2e.test.ts
+++ b/ui/src/e2e/session-management.sidebar.e2e.test.ts
@@ -673,7 +673,7 @@ suite.define(() => {
     }
   });
 
-  it("pins a session dropped into the interleaved sidebar zone", async () => {
+  it("pins a session dropped below an existing row in the Pinned group", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -720,10 +720,19 @@ suite.define(() => {
       await expect
         .poll(() => trimmedTextContents(pinnedEntry.locator(".sidebar-recent-session__name")))
         .toEqual(["Already pinned"]);
+      await expect.poll(() => page.locator(".sidebar-nav__head--pinned").count()).toBe(1);
       await captureUiProof(page, "sidebar-session-before-pinned-drop.png");
+      const pinnedBox = await pinnedEntry.boundingBox();
+      if (!pinnedBox) {
+        throw new Error("expected the pinned row to be laid out");
+      }
+      // The drop slot is decided by which half of the row the pointer is in, so
+      // aim below its midpoint instead of the default centre landing on the edge.
       await researchGroup
         .locator('.sidebar-recent-session[data-session-key="agent:main:candidate"]')
-        .dragTo(pinnedEntry);
+        .dragTo(pinnedEntry, {
+          targetPosition: { x: pinnedBox.width / 2, y: pinnedBox.height - 2 },
+        });
 
       const pinPatch = await waitForPatch(
         gateway,

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1834,6 +1834,7 @@ export const en: TranslationMap = {
     more: "More",
     home: "Home",
     pages: "Pages",
+    pinned: "Pinned",
     customize: "Edit pinned items",
     customizeReset: "Reset pinned items",
     workboardGroup: "WorkBoard",

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -897,6 +897,9 @@ openclaw-settings-save-indicator {
   /* Sticky headers inside the sidebar reuse --sidebar-bg so scrolled rows
      never shine through with a mismatched tone. */
   --sidebar-bg: color-mix(in srgb, var(--bg) 96%, var(--bg-elevated) 4%);
+  /* One rhythm for every group boundary in the sidebar (Pages, Pinned, and each
+     session section) so the column reads as separate shelves, not one list. */
+  --sidebar-group-gap: var(--space-4);
   --scrollbar-size: 6px;
   position: relative;
   display: flex;
@@ -1333,7 +1336,7 @@ html.openclaw-native-macos
   flex-direction: column;
   gap: 8px;
   padding: 0 8px;
-  margin-top: 10px;
+  margin-top: var(--sidebar-group-gap);
   border-radius: var(--radius-md);
   transition:
     background var(--duration-fast) ease,
@@ -1368,7 +1371,7 @@ html.openclaw-native-macos
 
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--sidebar-group-gap);
   margin: 0 -8px;
   /* Sessions are app chrome, not hyperlinks: the whole region follows the
      base.css cursor policy so it tracks the window it is running in. */
@@ -3069,6 +3072,12 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 
 .sidebar-nav__head .sidebar-recent-sessions__label-text {
   flex: 1 1 auto;
+}
+
+/* Pinned sessions are their own group, so they take the sidebar's inter-group
+   rhythm instead of butting against the Pages list. */
+.sidebar-nav__head--pinned {
+  margin-top: var(--sidebar-group-gap);
 }
 
 .sidebar-nav__head-action {

--- a/ui/src/test-helpers/app-sidebar-cases/sidebar-zone.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/sidebar-zone.ts
@@ -227,12 +227,14 @@ describe("AppSidebar interleaved zone", () => {
     expect(sidebar.querySelector(".sidebar-session-pagination")).toBeNull();
   });
 
-  it("renders routes and pinned sessions in entry order while Home stays fixed", async () => {
+  it("renders pinned sessions as their own labelled group below the Pages routes", async () => {
     const { sidebar, sessions } = await mountZone();
     const result = sessions.sessions.state.result;
     if (!result) {
       throw new Error("expected session list");
     }
+    // Nothing pinned yet: the group must not reserve a label or its spacing.
+    expect(sidebar.querySelector(".sidebar-nav__head--pinned")).toBeNull();
     sessions.publish({
       result: {
         ...result,
@@ -249,7 +251,14 @@ describe("AppSidebar interleaved zone", () => {
     const labels = [...sidebar.querySelectorAll<HTMLElement>(".sidebar-zone-entry")].map((entry) =>
       entry.textContent?.trim(),
     );
-    expect(labels).toEqual(["Usage", "Alpha", "Plugins"]);
+    // Routes keep their configured order; the pinned session leaves the Pages
+    // list and heads its own group, so it renders after every route.
+    expect(labels).toEqual(["Usage", "Plugins", "Alpha"]);
+    const pinnedHead = sidebar.querySelector(".sidebar-nav__head--pinned");
+    expect(pinnedHead?.textContent?.trim()).toBe("Pinned");
+    expect(
+      pinnedHead?.nextElementSibling?.contains(zoneEntry(sidebar, "session:agent:main:alpha")),
+    ).toBe(true);
     expect(sidebar.querySelector('[data-session-section="pinned"]')).toBeNull();
     const pinnedRow = sidebar.querySelector('[data-session-key="agent:main:alpha"]');
     const pinnedTree = pinnedRow?.closest(".sidebar-session-tree");


### PR DESCRIPTION
Closes #121710

## What Problem This Solves

Fixes an issue where operators who pin a session would find it rendered as one more row of the sidebar's `PAGES` navigation group — same container, same head, same 2px row gap — directly under Automations or Plugins. Pinned sessions were the only block of session content in the sidebar without a section label of their own, so elevated content read as a navigation destination.

While reviewing that, the sidebar's group boundaries turned out to be too tight to read as boundaries at all: 10px between `PAGES` and the session list, and 10px between `RESEARCH`, `SESSIONS`, and `GROUPS`. At that value the whole column reads as one long list, and a new `Pinned` group would have inherited the same problem.

## Why This Change Was Made

`reconciledSidebarZone().entries` interleaves `route`, `workboard`, and `session` entries in one canonical order array so a pinned session's slot stays drag-orderable. The sidebar rendered that array as a single flat list, which is where navigation and content got mixed.

The render now partitions that list: navigation entries stay in the Pages group, session entries move into a second group carrying a muted `Pinned` label with the same `.sidebar-recent-sessions__label-text` treatment as `PAGES` and `SESSIONS` (title-case content, uppercased in CSS). The canonical order array is untouched, so persisted slots, reconciliation, and drag-to-pin are unaffected; only the projection changed. Both groups keep the zone drop handlers, and the group renders nothing at all when nothing is pinned.

Group spacing becomes one named value instead of three literals. `--sidebar-group-gap` is defined once on `.sidebar` as `var(--space-4)` (16px, on the existing spacing scale in `base.css`) and consumed at all three group boundaries: between session sections, between the nav zone and the session list, and above the new `Pinned` head. Stepping from 10px to 16px is what makes each section read as its own shelf; 20px (`--space-5`) costs noticeably more vertical space in a column that scrolls, so this stops one step up rather than two.

Design decisions worth naming:

- **No collapse affordance on Pinned.** The `SESSIONS`/`GROUPS` toggles belong to the session catalog, which paginates and can grow unbounded. The nav zone's `PAGES` head has no collapse either — it has the pin editor instead — and Pinned is a short, operator-curated list whose whole point is being always visible. Adding a collapse would let an operator hide the thing they explicitly elevated. Consistency here means matching `PAGES`, not `SESSIONS`.
- **Pinned always follows Pages.** An operator could previously drop a pinned session between two routes and keep it there. That interleaving is exactly what this change removes; order *within* the pinned group is still theirs to set by dropping above or below a sibling pinned row.
- **Known follow-up, not fixed here:** pinned rows carry a generic message-bubble glyph that no other session row gets. `renderSessionLeadingState()` resolves one fixed leading slot per row from a priority ladder — attention icon, then pinned, then the creator's avatar chip, then nothing — and the pinned branch outranks the avatar. That slot exists because of #111698 ("keep sidebar session titles aligned"), which made every row reserve one leading slot so titles stop shifting as status changes. Now that pinned sessions no longer sit in the nav icon column, that glyph is worth removing so pinned rows match ordinary session rows; that is a separate change with its own before/after.

## User Impact

Pinned sessions read as their own shelf: a muted `Pinned` label with real separation above it, and the same visual grammar as every other section in the sidebar. Every other sidebar group gains the same breathing room, so `PAGES`, `PINNED`, `RESEARCH`, `SESSIONS`, and `GROUPS` are visually distinct instead of running together. Pin, unpin, and drag-to-pin behave exactly as before, and an operator with nothing pinned sees no label and no extra gap.

## Evidence

Sidebar with two pinned sessions, mocked Gateway fixtures, headless Chromium at 1440x940.

| | before | after |
| --- | --- | --- |
| dark | ![](https://github.com/user-attachments/assets/c8c55db7-51ea-4e96-ae82-5b6c1eaf25a9) | ![](https://github.com/user-attachments/assets/bec0cb46-ba3e-4801-bdec-a9ab4f2b2951) |
| light | ![](https://github.com/user-attachments/assets/c2ab0eae-9411-41e6-9074-b6a6c80d7c2d) | ![](https://github.com/user-attachments/assets/c7d2cb96-e774-4ab0-a398-84309c567570) |

Validation:

- Blacksmith Testbox, `pnpm check:changed` on the branch head — see the run comment below for the lease id and result.
- `node scripts/run-vitest.mjs run ui/src/components/app-sidebar.test.ts ui/src/components/app-sidebar-session-catalogs.test.ts` — 251 tests passed, including the sidebar-zone case updated here. It now asserts the empty state (no `Pinned` head before anything is pinned), the label text, that the pinned entry lands inside the group the head introduces, and that routes keep their configured order.
- `ui/src/e2e/sidebar-customization.e2e.test.ts` and `ui/src/e2e/sidebar-interactions.e2e.test.ts` — 20 tests passed (route pin editing, zone reordering, agent menu).
- `ui/src/e2e/session-management.sidebar.e2e.test.ts` — 10 passed, 1 pre-existing failure (below). The drag-to-pin test passes and now asserts the `Pinned` head is present.
- `node scripts/run-tsgo.mjs -p tsconfig.ui.json`, `control-ui-i18n-verify`, and stylelint on `ui/src/styles/layout.css` — all clean.
- Codex autoreview (`gpt-5.6-sol`, high) on the branch diff — no accepted or actionable findings.

**Drag-to-pin test made deterministic.** The zone decides a drop slot by which half of the target row the pointer is in. `dragTo()` defaults to the row's exact centre, i.e. the boundary, so the outcome depended on where the row happened to sit in the viewport. Moving the pinned group down flipped that coin. The test now aims explicitly below the midpoint and asserts what it always meant to assert: a session dropped below an existing pinned row lands after it.

**Pre-existing failure on this file.** `session-management.sidebar.e2e.test.ts` > "names session-row actions and tabs from their menu into the next visible session" fails identically on a pristine `origin/main` checkout — `getByRole('menu', { name: 'Actions for Research notes' })` never becomes visible. Verified by running the same file on detached `origin/main` before and after this branch. Nothing here touches the session context menu.

**Size.** +55 / -22 production lines across four files (render split, one i18n string, one spacing token replacing three literals, one CSS rule), +26 / -5 test lines. The growth buys a new sidebar group and the shared zone-group renderer that replaces the drop handlers previously inlined once.
