### PR TITLE
chore(agents): trim duplicate fault sequence

### DIFF
--- a/src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts
@@ -297,25 +297,13 @@ function expectError(outcome: ScenarioOutcome): Error & { attempts?: unknown[] }
 }
 
 describe("runEmbeddedAgent provider fault sequences", () => {
-  it.each([
-    {
-      name: "429 -> 429 -> 200 consumes two same-model retries without rotating",
-      faults: [
-        { status: 429, window: "short" },
-        { status: 429, window: "short" },
-        { status: 200, text: "third attempt ok" },
-      ] satisfies ProviderFault[],
-      expectedSleeps: [10_000, 20_000],
-    },
-    {
-      name: "429 -> 200 keeps same-model retry available without a fallback",
-      faults: [
-        { status: 429, window: "short" },
-        { status: 200, text: "retry without fallback ok" },
-      ] satisfies ProviderFault[],
-      expectedSleeps: [10_000],
-    },
-  ])("$name", async ({ faults, expectedSleeps }) => {
+  it("429 -> 429 -> 200 consumes two same-model retries without rotating", async () => {
+    const faults = [
+      { status: 429, window: "short" },
+      { status: 429, window: "short" },
+      { status: 200, text: "third attempt ok" },
+    ] satisfies ProviderFault[];
+
     await withScenarioWorkspace(async ({ agentDir, workspaceDir }) => {
       writeProfiles(agentDir, { openai: 1 });
       const observations: AttemptObservation[] = [];
@@ -336,14 +324,11 @@ describe("runEmbeddedAgent provider fault sequences", () => {
       ).toEqual(
         faults.map(() => ({ provider: "openai", model: "mock-1", profileId: "openai:p1" })),
       );
-      expect(sleepWithAbortMock.mock.calls.map(([delay]) => delay)).toEqual(expectedSleeps);
+      expect(sleepWithAbortMock.mock.calls.map(([delay]) => delay)).toEqual([10_000, 20_000]);
       expect(outcome.provider).toBe("openai");
       expect(outcome.model).toBe("mock-1");
       expect(outcome.attempts).toEqual([]);
-      const finalFault = faults.at(-1);
-      expect(outcome.result.payloads?.[0]?.text).toContain(
-        finalFault?.status === 200 ? finalFault.text : "",
-      );
+      expect(outcome.result.payloads?.[0]?.text).toContain("third attempt ok");
       const usageStats = await readUsageStats(agentDir);
       expect(usageStats["openai:p1"]?.cooldownUntil).toBeUndefined();
       expect(usageStats["openai:p1"]?.disabledUntil).toBeUndefined();


### PR DESCRIPTION
## What Problem This Solves

The embedded-agent fault-sequence suite contained a two-attempt 429 retry case that was a strict subset of the retained three-attempt case. Both exercised the same provider, model, profile, retry policy, and success path, so the shorter row added maintenance cost without protecting another behavior.

## Why This Change Was Made

The redundant case is removed and the stronger retained proof is expressed directly as one named test. That case still verifies two same-model retries, ordered 10-second and 20-second backoff, no model rotation, successful third-attempt payload, and clean profile cooldown state.

AI-assisted: yes. The change was manually inspected and passed the repository autoreview gate.

## User Impact

No runtime or user-visible behavior change. Maintainers get a smaller fault-sequence suite with the same behavioral coverage.

## Evidence

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts` — 5/5 passed.
- `node scripts/check-changed.mjs -- src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts` — passed after the documented remote-backend fallback to local execution, including env ratchet 503/503, formatting, core-test typecheck, and changed-file lint.
- Fresh autoreview and secret scan — clean, no accepted/actionable findings.
- Production LOC: `+0/-0`. Tests: `+9/-24` (net `-15`).
