### PR TITLE
improve(ui): stop marking pinned sidebar rows with a message bubble

### DIFF
--- a/ui/src/components/session-leading-indicator.ts
+++ b/ui/src/components/session-leading-indicator.ts
@@ -123,19 +123,6 @@ export function renderSessionLeadingState(
         trailingIndicator,
       };
     }
-    if (session.pinned) {
-      return {
-        running,
-        leadingIndicator: renderSessionGlyph({
-          content: html`<span class="sidebar-pinned-session__icon" aria-hidden="true"
-            >${icons.messageSquare}</span
-          >`,
-          running,
-          badge: renderGlyphBadge(session, pullRequestState),
-        }),
-        trailingIndicator,
-      };
-    }
     if (running) {
       return {
         running,
@@ -163,18 +150,6 @@ export function renderSessionLeadingState(
       running,
       leadingIndicator: renderSessionGlyph({
         content: renderSessionAttentionIcon(session.attention),
-        running: false,
-      }),
-      trailingIndicator,
-    };
-  }
-  if (session.pinned) {
-    return {
-      running,
-      leadingIndicator: renderSessionGlyph({
-        content: html`<span class="sidebar-pinned-session__icon" aria-hidden="true"
-          >${icons.messageSquare}</span
-        >`,
         running: false,
       }),
       trailingIndicator,

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2924,34 +2924,6 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
   border-color: color-mix(in srgb, var(--accent) 16%, transparent);
 }
 
-.sidebar-pinned-session__icon {
-  width: 16px;
-  height: 16px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  overflow: hidden;
-  opacity: 0.72;
-  transition:
-    opacity var(--duration-fast) ease,
-    color var(--duration-fast) ease;
-}
-
-.sidebar-pinned-session__icon svg {
-  width: 16px;
-  height: 16px;
-}
-
-.sidebar-zone-entry .sidebar-recent-session:hover .sidebar-pinned-session__icon,
-.sidebar-zone-entry .sidebar-recent-session--active .sidebar-pinned-session__icon {
-  opacity: 1;
-}
-
-.sidebar-zone-entry .sidebar-recent-session--active .sidebar-pinned-session__icon {
-  color: var(--accent);
-}
-
 .sidebar-zone-entry .sidebar-recent-session__aside {
   padding-right: 0;
 }

--- a/ui/src/test-helpers/app-sidebar-cases/session-indicators.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-indicators.ts
@@ -13,16 +13,17 @@ function expectEmptyLead(row: Element | null) {
 }
 
 describe("AppSidebar session indicators", () => {
-  it("preserves child PR indicators and concurrent pinned run/unread glyph state", async () => {
+  it("preserves child PR indicators and leads a pinned child like any other", async () => {
     const parentKey = "agent:main:parent";
     const pinnedKey = "agent:main:pinned-child";
+    const runningKey = "agent:main:running-child";
     const openPullRequestKey = "agent:main:open-pr-child";
     const mergedPullRequestKey = "agent:main:merged-pr-child";
     const sessions = createSessionsHarness("main", [parentKey]);
     sessions.list.mockResolvedValue({
       ts: 2,
       path: "",
-      count: 3,
+      count: 4,
       defaults: { modelProvider: null, model: null, contextTokens: null },
       sessions: [
         {
@@ -36,6 +37,17 @@ describe("AppSidebar session indicators", () => {
           status: "running",
           unread: true,
           worktree: { id: "wt-pinned", branch: "feature/pinned", repoRoot: "/repo" },
+        },
+        {
+          key: runningKey,
+          spawnedBy: parentKey,
+          kind: "direct",
+          label: "Running child",
+          updatedAt: 2,
+          hasActiveRun: true,
+          status: "running",
+          unread: true,
+          worktree: { id: "wt-running", branch: "feature/running", repoRoot: "/repo" },
         },
         {
           key: openPullRequestKey,
@@ -69,7 +81,7 @@ describe("AppSidebar session indicators", () => {
             kind: "direct",
             label: "Parent",
             updatedAt: 1,
-            childSessions: [pinnedKey, openPullRequestKey, mergedPullRequestKey],
+            childSessions: [pinnedKey, runningKey, openPullRequestKey, mergedPullRequestKey],
           },
         ],
       },
@@ -77,7 +89,7 @@ describe("AppSidebar session indicators", () => {
     await sidebar.updateComplete;
     sidebar.querySelector<HTMLButtonElement>("[data-child-session-toggle]")?.click();
     await waitForFast(() =>
-      expect(sidebar.querySelectorAll(".sidebar-recent-session--child")).toHaveLength(3),
+      expect(sidebar.querySelectorAll(".sidebar-recent-session--child")).toHaveLength(4),
     );
     Object.assign(sidebar, {
       sessionPullRequestIndicatorState: (key: string) =>
@@ -98,12 +110,15 @@ describe("AppSidebar session indicators", () => {
         ),
       ).not.toBeNull();
     });
+    // Pinning is not a status: a pinned child must lead exactly like an
+    // unpinned child in the same run/unread state.
     const pinnedRow = sidebar.querySelector(`[data-session-key="${pinnedKey}"]`);
-    const glyph = pinnedRow?.querySelector(".sidebar-session-indicator .session-glyph");
-    expect(glyph?.classList.contains("session-glyph--running")).toBe(true);
-    expect(glyph?.querySelector(".session-glyph__ring")).not.toBeNull();
-    expect(glyph?.querySelector(".session-glyph__badge--unread")).not.toBeNull();
-    expect(glyph?.querySelector("[data-session-pr-state]")).toBeNull();
+    const runningRow = sidebar.querySelector(`[data-session-key="${runningKey}"]`);
+    const pinnedLead = pinnedRow?.querySelector(".sidebar-session-indicator");
+    const runningLead = runningRow?.querySelector(".sidebar-session-indicator");
+    expect(pinnedLead).not.toBeNull();
+    expect(pinnedLead?.innerHTML).toBe(runningLead?.innerHTML);
+    expect(pinnedLead?.querySelector("[data-session-pr-state]")).toBeNull();
     expect(pinnedRow?.querySelector(".session-row-state")).toBeNull();
   });
 

--- a/ui/src/test-helpers/app-sidebar-cases/sidebar-zone.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/sidebar-zone.ts
@@ -127,31 +127,8 @@ describe("AppSidebar interleaved zone", () => {
     expect(sidebar.querySelector('[data-session-key="agent:main:extra"]')).toBeNull();
   });
 
-  it("renders the generic icon for pinned sessions", async () => {
-    const keys = ["agent:main:main", "agent:main:pinned"];
-    const sessions = createSessionsHarness("main", keys);
-    const result = sessions.sessions.state.result;
-    expect(result).not.toBeNull();
-    if (!result) {
-      return;
-    }
-    for (const row of result.sessions) {
-      if (row.key === "agent:main:pinned") {
-        Object.assign(row, { pinned: true });
-      }
-    }
-    const gateway = createGateway({} as GatewayBrowserClient);
-    const { sidebar } = await mountSidebar(gateway, sessions.sessions);
-
-    expect(
-      sidebar.querySelector(
-        '[data-session-key="agent:main:pinned"] .sidebar-pinned-session__icon svg',
-      ),
-    ).not.toBeNull();
-  });
-
-  it("keeps a pinned icon leading while activity trails the row", async () => {
-    const keys = ["agent:main:main", "agent:main:page"];
+  it("leads a pinned row like any other session row while activity trails it", async () => {
+    const keys = ["agent:main:main", "agent:main:page", "agent:main:plain"];
     const sessions = createSessionsHarness("main", keys);
     const result = sessions.sessions.state.result;
     expect(result).not.toBeNull();
@@ -162,16 +139,19 @@ describe("AppSidebar interleaved zone", () => {
       if (row.key === "agent:main:page") {
         Object.assign(row, { pinned: true, hasActiveRun: true, unread: true });
       }
+      if (row.key === "agent:main:plain") {
+        Object.assign(row, { hasActiveRun: true, unread: true });
+      }
     }
     const gateway = createGateway({} as GatewayBrowserClient);
     const { sidebar } = await mountSidebar(gateway, sessions.sessions);
 
+    // Pinning is not a status, so it must not claim the row's one leading slot.
     const row = sidebar.querySelector('[data-session-key="agent:main:page"]');
-    const glyph = row?.querySelector(".sidebar-session-indicator .session-glyph");
-    expect(glyph?.querySelector(".sidebar-pinned-session__icon svg")).not.toBeNull();
-    expect(glyph?.classList.contains("session-glyph--running")).toBe(false);
-    expect(glyph?.querySelector(".session-glyph__ring")).toBeNull();
-    expect(glyph?.querySelector(".session-glyph__badge--unread")).toBeNull();
+    const plain = sidebar.querySelector('[data-session-key="agent:main:plain"]');
+    expect(row?.querySelector(".sidebar-session-indicator")?.innerHTML).toBe(
+      plain?.querySelector(".sidebar-session-indicator")?.innerHTML,
+    );
     expect(row?.querySelector(".nav-item__state")).toBeNull();
     expect(row?.querySelector(".session-row-state .sidebar-recent-session__state")).not.toBeNull();
   });


### PR DESCRIPTION
Related: #121710

## What Problem This Solves

Fixes an issue where a pinned session in the Control UI sidebar shows a generic message-bubble glyph that no other session row gets. Ordinary session rows lead with their creator's avatar, or with nothing at all; a pinned row leads with a bubble that carries no information — every row it marks is a session, so "this is a session" is not worth a glyph — and it displaces the owner avatar that same row would otherwise show.

## Why This Change Was Made

Pinned rows are not a separate component. `renderPinnedSidebarSession()` renders the same `renderSessionTree()` row as everything in the session list; only `listItem` differs. The bubble comes from one branch in `renderSessionLeadingState()`, which fills each row's single leading slot from a priority ladder:

1. attention (failed / needs approval)
2. **pinned → `icons.messageSquare`**
3. creator avatar chip
4. nothing

Because `pinned` outranked the avatar, a pinned row could never show who created it.

That slot exists because of #111698 ("keep sidebar session titles aligned"), which made every row reserve one fixed leading slot so titles stop shifting as status changes. The slot is reserved by width — `.sidebar-session-indicator` is `flex: 0 0 16px` — not by its contents, which is why rows that already lead with nothing keep their titles aligned today. Removing the pinned branch therefore drops the glyph without reintroducing the shift #111698 fixed: a pinned row falls through the same ladder as any other session row.

`icons.messageSquare` itself stays; the identity menu's help links still use it.

Related but deliberately not changed here: pinned rows sit in the navigation zone, where the leading slot is 16px, while rows inside `.sidebar-recent-sessions` get 20px from `--sidebar-lead`. On `main` that is correct — it is what keeps a pinned title aligned with `Automations` and `Plugins` directly above it (verified below: pinned titles at x=44 like the nav rows, list titles at x=30). Once #121712 moves pinned sessions into their own group, that 4px difference is worth revisiting; it is a layout question for that surface, not part of removing a glyph.

## User Impact

Pinned sessions look like the sessions they are: same leading slot, same alignment, and the creator's avatar when the row has one, exactly as in the rest of the list. Nothing moves horizontally, and pin/unpin is untouched.

## Evidence

Sidebar with two pinned sessions, mocked Gateway fixtures, headless Chromium at 1440x940.

| | before | after |
| --- | --- | --- |
| dark | ![](https://github.com/user-attachments/assets/c8c55db7-51ea-4e96-ae82-5b6c1eaf25a9) | ![](https://github.com/user-attachments/assets/e34e7c7a-54d6-41bf-b867-bc1ae2ea04a8) |
| light | ![](https://github.com/user-attachments/assets/c2ab0eae-9411-41e6-9074-b6a6c80d7c2d) | ![](https://github.com/user-attachments/assets/d9b24a59-ccdc-444d-b169-2aece274a76b) |

**The #111698 invariant holds.** Measured in the rendered DOM after the change, the two pinned rows still report a 16px leading slot with empty contents, and every title keeps the x it had with the glyph present:

| rows | leading slot width | title x |
| --- | --- | --- |
| pinned (navigation zone) | 16 | 44 |
| session list | 20 | 30 |

The pinned rows' titles still line up with `Automations` and `Plugins` above them; the list rows are unchanged. Nothing shifted, because the slot reserves width rather than being sized by its glyph.

Validation: Blacksmith Testbox tbx_01kzqjvmyce0tyay70sx1y169h and tbx_01kzqkdp3hzjxf0nje334tp21y — the regression test failed on the pre-fix production path (2 intended failures), the fixed head passed 251/251 focused tests, and full pnpm check passed (typecheck, lint, formatting, cycles, and policy guards).

**Size.** Net-negative production: −25 lines from `session-leading-indicator.ts` and −28 from `layout.css`, with no additions. One test that asserted only the glyph is deleted; the test that asserted "pinned activity trails the row" is rewritten to assert the invariant that replaces it — a pinned row's leading slot renders identically to an unpinned row in the same state.