### PR TITLE
refactor(agents): require live edit diff state

### DIFF
--- a/src/agents/agent-tool-handler-state.test-helpers.ts
+++ b/src/agents/agent-tool-handler-state.test-helpers.ts
@@ -13,6 +13,7 @@ export function createBaseToolHandlerState() {
     toolMetas: [] as Array<{ toolName?: string; meta?: string; asyncStarted?: boolean }>,
     acceptedSessionSpawns: [],
     toolSummaryById: new Set<string>(),
+    liveEditDiffStateById: new Map(),
     itemActiveIds: new Set<string>(),
     itemStartedCount: 0,
     itemCompletedCount: 0,

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
@@ -66,6 +66,7 @@ function createContext(
     },
     state: {
       lastAssistant: lastAssistant as EmbeddedAgentSubscribeContext["state"]["lastAssistant"],
+      liveEditDiffStateById: new Map(),
       pendingCompactionRetry: 0,
       pendingToolMediaUrls: [],
       pendingToolMediaTrustByUrl: new Map(),

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -67,7 +67,7 @@ export function handleAgentEnd(
   ctx: EmbeddedAgentSubscribeContext,
   evt?: Extract<AgentSessionEvent, { type: "agent_end" }>,
 ): void | Promise<void> {
-  ctx.state.liveEditDiffStateById?.clear();
+  ctx.state.liveEditDiffStateById.clear();
   type BeforeTerminalDeliveryDecision = void | { suppressTerminalDelivery?: boolean };
   const lastAssistant = ctx.state.lastAssistant;
   const isError = isAssistantMessage(lastAssistant) && lastAssistant.stopReason === "error";

--- a/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
@@ -29,6 +29,7 @@ function createMockContext(overrides?: {
       toolMetaById: new Map(),
       toolMetas: [],
       toolSummaryById: new Set(),
+      liveEditDiffStateById: new Map(),
       itemActiveIds: new Set(),
       itemStartedCount: 0,
       itemCompletedCount: 0,

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -178,6 +178,7 @@ function createTestContext(): {
       toolMetas: [],
       acceptedSessionSpawns: [],
       toolSummaryById: new Set<string>(),
+      liveEditDiffStateById: new Map(),
       itemActiveIds: new Set<string>(),
       itemStartedCount: 0,
       itemCompletedCount: 0,

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -1087,7 +1087,7 @@ export function handleToolExecutionStart(
   },
 ): void | Promise<void> {
   const startToolName = normalizeToolName(evt.toolName);
-  ctx.state.liveEditDiffStateById?.delete(evt.toolCallId);
+  ctx.state.liveEditDiffStateById.delete(evt.toolCallId);
   const askUserPromptReservation =
     startToolName === "ask_user" && ctx.params.onToolResult
       ? buildAskUserPromptPayload(evt.toolCallId, ctx.params.sessionKey, ctx.params.runId, evt.args)
@@ -1491,7 +1491,7 @@ export async function handleToolExecutionEnd(
   const toolName = normalizeToolName(rawToolName);
   const hideFromChannelProgress = evt.hideFromChannelProgress === true;
   const toolCallId = evt.toolCallId;
-  ctx.state.liveEditDiffStateById?.delete(toolCallId);
+  ctx.state.liveEditDiffStateById.delete(toolCallId);
   if (toolName === "ask_user") {
     cancelAskUserPromptDelivery(toolCallId, ctx.params.sessionKey, ctx.params.runId);
   }

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -342,6 +342,7 @@ type ToolHandlerState = Pick<
   | "acceptedSessionSpawns"
   | "toolSummaryById"
   | "execLiveUpdateStateById"
+  | "liveEditDiffStateById"
   | "itemActiveIds"
   | "itemStartedCount"
   | "itemCompletedCount"
@@ -368,9 +369,7 @@ type ToolHandlerState = Pick<
   | "deterministicApprovalPromptSent"
   | "toolExecutionSinceLastBlockReply"
   | "assistantMessageIndex"
-> & {
-  liveEditDiffStateById?: EmbeddedAgentSubscribeState["liveEditDiffStateById"];
-};
+>;
 
 export type ToolHandlerContext = {
   params: ToolHandlerParams;


### PR DESCRIPTION
## What Problem This Solves

Production always initializes `liveEditDiffStateById`, but the tool-handler state projection still declared it optional. That impossible state forced optional cleanup calls and let partial test fixtures omit lifecycle-owned state that real handlers always receive.

## Why This Change Was Made

The map is included directly in the required `Pick` projection, cleanup becomes unconditional at tool start, tool end, and agent end, and partial test fixtures now construct the required map. No new seam or fallback path is added.

AI-assisted: yes. The change was manually inspected and passed the repository autoreview gate.

## User Impact

No user-visible behavior change. The handler type now matches the production lifecycle invariant, and tests can no longer model a state production never creates.

## Evidence

- `node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.handlers.tools.test.ts src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts` — 241/241 passed.
- Changed gate passed conflict markers, env ratchet 503/503, max-lines, formatting, dependency and boundary guards, then stopped only at unrelated current-main Plugin SDK closure-hash baseline drift. The protected generated baseline is intentionally untouched in this PR.
- Fresh autoreview and secret scan — clean, no accepted/actionable findings.
- Production LOC: `+5/-6` (net `-1`). Tests: `+4/-0`. Overall: `+9/-6`.
