### PR TITLE
fix(protocol): refresh approval reviewer models

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -15742,21 +15742,25 @@ public struct ApprovalResolveParams: Codable, Sendable {
     public let id: String
     public let kind: ApprovalKind
     public let decision: ApprovalDecision
+    public let reviewer: [String: AnyCodable]?
 
     public init(
         id: String,
         kind: ApprovalKind,
-        decision: ApprovalDecision)
+        decision: ApprovalDecision,
+        reviewer: [String: AnyCodable]? = nil)
     {
         self.id = id
         self.kind = kind
         self.decision = decision
+        self.reviewer = reviewer
     }
 
     private enum CodingKeys: String, CodingKey {
         case id
         case kind
         case decision
+        case reviewer
     }
 }
 
@@ -16143,18 +16147,22 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
 public struct ExecApprovalResolveParams: Codable, Sendable {
     public let id: String
     public let decision: String
+    public let reviewer: [String: AnyCodable]?
 
     public init(
         id: String,
-        decision: String)
+        decision: String,
+        reviewer: [String: AnyCodable]? = nil)
     {
         self.id = id
         self.decision = decision
+        self.reviewer = reviewer
     }
 
     private enum CodingKeys: String, CodingKey {
         case id
         case decision
+        case reviewer
     }
 }
 
@@ -16513,18 +16521,22 @@ public struct PluginApprovalRequestParams: Codable, Sendable {
 public struct PluginApprovalResolveParams: Codable, Sendable {
     public let id: String
     public let decision: String
+    public let reviewer: [String: AnyCodable]?
 
     public init(
         id: String,
-        decision: String)
+        decision: String,
+        reviewer: [String: AnyCodable]? = nil)
     {
         self.id = id
         self.decision = decision
+        self.reviewer = reviewer
     }
 
     private enum CodingKeys: String, CodingKey {
         case id
         case decision
+        case reviewer
     }
 }
 


### PR DESCRIPTION
## What Problem This Solves

The authoritative approval resolve schemas carry optional reviewer metadata, but the generated Swift gateway models omitted that field. Generated-protocol checks therefore fail, and Swift clients cannot decode or encode reviewer data on those resolve payloads.

## Why This Change Was Made

Regenerate the Swift protocol owner output so `ApprovalResolveParams`, `ExecApprovalResolveParams`, and `PluginApprovalResolveParams` each expose optional `reviewer`, default it to `nil`, assign it, and include its coding key.

The branch previously included a `/learn` assertion refresh. Current `main` now owns a stronger canonical repair in `8ae273603d8`, so that duplicate change was removed during the final rebase.

## User Impact

Swift clients remain compatible with payloads that omit reviewer metadata and now preserve reviewer metadata when it is present. No TypeScript runtime, configuration, dependency, or user workflow changes.

## Evidence

- `pnpm protocol:check` — passed protocol registry, schema generation, Swift generation check, Kotlin generation, protocol-since guard, and generated-diff guard.
- `git diff --check` — passed.
- Autoreview TruffleHog preflight — clean. The external Codex executable is unavailable in this orb; manual review found no issue in the deterministic one-file generated diff.
- Final scope: one generated Swift file, +15/-3; production TypeScript +0/-0; tests +0/-0.
- Required exact-head hosted CI remains the landing gate.
