### PR TITLE
test(acpx): trim private runtime assertions

### DIFF
--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -199,14 +199,6 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     expect(ensureSpy).not.toHaveBeenCalled();
   });
 
-  it("exposes assertSupportedRuntimeSessionMode as a typed guard", () => {
-    expect(testing.assertSupportedRuntimeSessionMode("persistent")).toBeUndefined();
-    expect(testing.assertSupportedRuntimeSessionMode("oneshot")).toBeUndefined();
-    expect(() => testing.assertSupportedRuntimeSessionMode("run" as never)).toThrow(
-      AcpRuntimeError,
-    );
-  });
-
   it("adds the OpenClaw session key to both managed tools MCP bridges", () => {
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => undefined),
@@ -617,7 +609,18 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     });
   });
 
-  it("strips the OpenClaw Anthropic provider prefix for Claude ACP startup", async () => {
+  it.each([
+    {
+      name: "strips the OpenClaw Anthropic provider prefix for Claude ACP startup",
+      model: "anthropic/claude-sonnet-4-6",
+      expectedModel: "claude-sonnet-4-6",
+    },
+    {
+      name: "preserves custom Claude ACP startup models",
+      model: "custom-model",
+      expectedModel: "custom-model",
+    },
+  ])("$name", async ({ model, expectedModel }) => {
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => undefined),
       save: vi.fn(async () => {}),
@@ -639,32 +642,16 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       sessionKey: "agent:claude:acp:test",
       agent: "claude",
       mode: "persistent",
-      model: "anthropic/claude-sonnet-4-6",
+      model,
     });
 
     expect(readFirstEnsureSessionInput(ensure)).toEqual({
       sessionKey: "agent:claude:acp:test",
       agent: "claude",
       mode: "persistent",
-      model: "claude-sonnet-4-6",
-      sessionOptions: { model: "claude-sonnet-4-6" },
+      model: expectedModel,
+      sessionOptions: { model: expectedModel },
     });
-  });
-
-  it("keeps Claude ACP model ids intact after stripping the OpenClaw provider prefix", () => {
-    expect(testing.normalizeClaudeAcpModelOverride("anthropic/claude-sonnet-4-6")).toBe(
-      "claude-sonnet-4-6",
-    );
-    expect(testing.normalizeClaudeAcpModelOverride("anthropic/claude-opus-4-8")).toBe(
-      "claude-opus-4-8",
-    );
-    expect(testing.normalizeClaudeAcpModelOverride("anthropic/claude-haiku-4-5")).toBe(
-      "claude-haiku-4-5",
-    );
-    expect(testing.normalizeClaudeAcpModelOverride("anthropic/claude-sonnet-4-6-1m")).toBe(
-      "claude-sonnet-4-6-1m",
-    );
-    expect(testing.normalizeClaudeAcpModelOverride("custom-model")).toBe("custom-model");
   });
 
   it("leaves Codex ACP startup defaults alone when no model or thinking is provided", async () => {
@@ -1302,56 +1289,6 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     ).not.toContain("gpt-5.6-sol/medium");
   });
 
-  it.each<{ model: string | undefined; thinking?: string; override: Record<string, string> }>([
-    { model: "openai/gpt-5.4", override: { model: "gpt-5.4" } },
-    {
-      model: "openai/gpt-5.4",
-      thinking: "high",
-      override: { model: "gpt-5.4", reasoningEffort: "high" },
-    },
-    { model: "gpt-5.4/high", override: { model: "gpt-5.4", reasoningEffort: "high" } },
-    { model: "gpt-5.4", override: { model: "gpt-5.4" } },
-    { model: undefined, thinking: "low", override: { reasoningEffort: "low" } },
-    { model: "", override: {} },
-  ])(
-    "classifies supported Codex ACP model request ($model, $thinking) as an override",
-    ({ model, thinking, override }) => {
-      expect(testing.classifyCodexAcpModelRequest(model, thinking)).toEqual({
-        kind: "override",
-        override,
-      });
-    },
-  );
-
-  it.each<{ model: string; thinking?: string; expected: Record<string, unknown> }>([
-    { model: "google/gemini-3.1-flash-lite", expected: { kind: "unsupported" } },
-    {
-      model: "google/gemini-3.1-flash-lite",
-      thinking: "low",
-      expected: { kind: "unsupported", thinkingOverride: { reasoningEffort: "low" } },
-    },
-    { model: "gpt-5.4/ultra", expected: { kind: "unsupported" } },
-    { model: "/high", expected: { kind: "unsupported" } },
-  ])(
-    "classifies unsupported Codex ACP model request ($model, $thinking) without thinking-slot routing",
-    ({ model, thinking, expected }) => {
-      expect(testing.classifyCodexAcpModelRequest(model, thinking)).toEqual(expected);
-    },
-  );
-
-  it.each(["openai/foo/bar", "openai/", "openai//high"])(
-    "fails closed on malformed openai-qualified Codex ACP model request %s",
-    (model) => {
-      expect(() => testing.classifyCodexAcpModelRequest(model)).toThrow(AcpRuntimeError);
-    },
-  );
-
-  it("fails closed on an unsupported Codex ACP thinking value", () => {
-    expect(() => testing.classifyCodexAcpModelRequest(undefined, "superhigh")).toThrow(
-      AcpRuntimeError,
-    );
-  });
-
   it("starts Codex ACP without injecting a leaked non-openai default model", async () => {
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => undefined),
@@ -1565,7 +1502,13 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     });
   });
 
-  it("normalizes Codex ACP model config controls to adapter ids", async () => {
+  it.each([
+    {
+      name: "normalizes OpenClaw-qualified Codex ACP model controls",
+      value: "openai/gpt-5.4",
+    },
+    { name: "passes bare Codex ACP model controls through", value: "gpt-5.4" },
+  ])("$name", async ({ value }) => {
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => ({
         acpxRecordId: "agent:codex:acp:test",
@@ -1585,15 +1528,15 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     await runtime.setConfigOption({
       handle,
       key: "model",
-      value: "openai/gpt-5.4",
+      value,
     });
 
-    expect(setConfigOption).toHaveBeenNthCalledWith(1, {
+    expect(setConfigOption).toHaveBeenCalledOnce();
+    expect(setConfigOption).toHaveBeenCalledWith({
       handle,
       key: "model",
       value: "gpt-5.4",
     });
-    expect(setConfigOption).toHaveBeenCalledOnce();
   });
 
   it.each(["google/gemini-3.1-flash-lite", "gpt-5.4/ultra", "openai/foo/bar"])(
@@ -1689,9 +1632,24 @@ describe("AcpxRuntime fresh reset wrapper", () => {
   });
 
   it.each([
-    { key: "thinking", value: "minimal", expected: "low" },
-    { key: "reasoning_effort", value: "x-high", expected: "xhigh" },
-  ])("normalizes Codex ACP $key=$value to reasoning effort", async ({ key, value, expected }) => {
+    {
+      name: "normalizes Codex ACP thinking=minimal to reasoning effort",
+      key: "thinking",
+      value: "minimal",
+      expected: "low",
+    },
+    {
+      name: "normalizes Codex ACP reasoning_effort=x-high",
+      key: "reasoning_effort",
+      value: "x-high",
+      expected: "xhigh",
+    },
+    {
+      name: "rejects unsupported Codex ACP thinking controls",
+      key: "thinking",
+      value: "superhigh",
+    },
+  ])("$name", async ({ key, value, expected }) => {
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => ({
         acpxRecordId: "agent:codex:acp:test",
@@ -1708,12 +1666,18 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       acpxRecordId: "agent:codex:acp:test",
     };
 
-    await runtime.setConfigOption({
+    const update = runtime.setConfigOption({
       handle,
       key,
       value,
     });
+    if (!expected) {
+      await expect(update).rejects.toMatchObject({ code: "ACP_INVALID_RUNTIME_OPTION" });
+      expect(setConfigOption).not.toHaveBeenCalled();
+      return;
+    }
 
+    await update;
     expect(setConfigOption).toHaveBeenCalledWith({
       handle,
       key: "reasoning_effort",

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -1539,31 +1539,34 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     });
   });
 
-  it.each(["google/gemini-3.1-flash-lite", "gpt-5.4/ultra", "openai/foo/bar"])(
-    "fails closed on Codex ACP model config control %s without re-injecting it",
-    async (value) => {
-      const baseStore: TestSessionStore = {
-        load: vi.fn(async () => ({
-          acpxRecordId: "agent:codex:acp:test",
-          agentCommand: CODEX_ACP_COMMAND,
-        })),
-        save: vi.fn(async () => {}),
-      };
-      const { runtime, delegate } = makeRuntime(baseStore);
-      const setConfigOption = vi.spyOn(delegate, "setConfigOption").mockResolvedValue(undefined);
-      const handle: Parameters<NonNullable<AcpRuntime["setConfigOption"]>>[0]["handle"] = {
-        sessionKey: "agent:codex:acp:test",
-        backend: "acpx",
-        runtimeSessionName: "agent:codex:acp:test",
+  it.each([
+    "google/gemini-3.1-flash-lite",
+    "gpt-5.4/ultra",
+    "openai/foo/bar",
+    "openai/",
+    "openai//high",
+  ])("fails closed on Codex ACP model config control %s without re-injecting it", async (value) => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
         acpxRecordId: "agent:codex:acp:test",
-      };
+        agentCommand: CODEX_ACP_COMMAND,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const { runtime, delegate } = makeRuntime(baseStore);
+    const setConfigOption = vi.spyOn(delegate, "setConfigOption").mockResolvedValue(undefined);
+    const handle: Parameters<NonNullable<AcpRuntime["setConfigOption"]>>[0]["handle"] = {
+      sessionKey: "agent:codex:acp:test",
+      backend: "acpx",
+      runtimeSessionName: "agent:codex:acp:test",
+      acpxRecordId: "agent:codex:acp:test",
+    };
 
-      await expect(runtime.setConfigOption({ handle, key: "model", value })).rejects.toMatchObject({
-        code: "ACP_INVALID_RUNTIME_OPTION",
-      });
-      expect(setConfigOption).not.toHaveBeenCalled();
-    },
-  );
+    await expect(runtime.setConfigOption({ handle, key: "model", value })).rejects.toMatchObject({
+      code: "ACP_INVALID_RUNTIME_OPTION",
+    });
+    expect(setConfigOption).not.toHaveBeenCalled();
+  });
 
   it("normalizes Codex ACP slash reasoning suffixes to config controls", async () => {
     const baseStore: TestSessionStore = {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -1884,14 +1884,10 @@ export {
 /** Test-only hooks for ACPX runtime behavior that is otherwise private. */
 export const testing = {
   appendCodexAcpConfigOverrides,
-  assertSupportedRuntimeSessionMode,
-  classifyCodexAcpModelRequest,
   isClaudeAcpCommand,
   isCodexAcpCommand,
   normalizeAgentCommand,
-  normalizeClaudeAcpModelOverride,
 };
 
 export type { AcpAgentRegistry, AcpRuntimeOptions, AcpSessionRecord, AcpSessionStore };
-export { testing as __testing };
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

The ACPX wrapper exposed three private implementation helpers through its test-only facade plus an obsolete `__testing` alias. The associated tests asserted internal guard, classifier, and normalizer representations even though the same regressions are already exercised through `ensureSession` and `setConfigOption`.

That duplicated maintenance and made behavior-preserving refactors of ACPX model handling require test and export churn.

## Why This Change Was Made

This change removes the ACPX-local `__testing` alias and narrows the canonical `testing` facade to the remaining command/wrapper seams. It deletes direct private-helper assertions and keeps the meaningful behavior at the owning runtime boundary:

- invalid session modes still fail before the delegate runs;
- Claude provider-qualified and custom model ids are verified through session startup;
- qualified and bare Codex model ids are verified through config controls;
- unsupported Codex thinking values are verified through config-control rejection;
- leaked defaults, malformed or explicit unsupported models, reasoning suffixes, and applied/dropped model reporting remain covered by existing runtime tests.

The public Plugin SDK ACP compatibility alias is intentionally unchanged.

AI-assisted: yes. The changes were manually inspected and passed the repository autoreview gate.

## User Impact

No user-visible behavior change. Maintainers get a smaller private test surface while the original ACPX regressions remain protected at the public runtime boundary.

## Evidence

- ACPX runtime owner suite: 98 tests passed, including `openai/` and `openai//high` through the public fail-closed config-control boundary.
- Sibling ACPX registration, service, and process-reaper suites: 46 tests passed.
- ACP control-plane runtime-config validation: 6 tests passed.
- Current Codex source was inspected for the model/reasoning contract; ACPX behavior is unchanged.
- Full branch and correction changed-file gates passed formatting, dependency, boundary, dead-export, typecheck, and lint checks. The remote backend was unavailable because the Blacksmith CLI is absent, so the repository wrapper used its trusted local fallback.
- ClawSweeper's malformed qualified-model finding was addressed at the public runtime boundary without restoring a private helper export.
- Fresh autoreview and secret scan after the correction: clean, no accepted/actionable findings.

## Scope and LOC

- Production test surface: `+0/-4`.
- Tests: `+76/-109` (net `-33`).
- Overall: `+76/-113` (net `-37`).

No runtime behavior, config, protocol, schema, dependency, lockfile, generated baseline, release, or changelog change.
