### PR TITLE
test(tooling): trim duplicate coverage

### DIFF
--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -518,27 +518,6 @@ describe("test-projects args", () => {
     );
   });
 
-  it("splits an explicit Vitest filesystem module cache root", () => {
-    const [spec] = applyParallelVitestCachePaths(
-      [
-        {
-          config: "test/vitest/vitest.gateway.config.ts",
-          env: {},
-        },
-      ],
-      {
-        cwd: "/repo",
-        env: {
-          OPENCLAW_VITEST_FS_MODULE_CACHE_PATH: "/tmp/cache",
-        },
-      },
-    );
-
-    expect(spec?.env.OPENCLAW_VITEST_FS_MODULE_CACHE_PATH).toBe(
-      "/tmp/cache/0-test-vitest-vitest.gateway.config.ts",
-    );
-  });
-
   it("routes plugin targets to the plugins config", () => {
     expect(buildVitestRunPlans(["src/plugins/loader.test.ts"])).toEqual([
       {
@@ -881,21 +860,6 @@ describe("test-projects args", () => {
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
-  });
-
-  it("routes explicit test-support helper files to affected tests", () => {
-    expect(
-      findUnmatchedExplicitTestTargets(["src/commands/onboard-non-interactive.test-helpers.ts"]),
-    ).toEqual([]);
-
-    expect(buildVitestRunPlans(["src/commands/onboard-non-interactive.test-helpers.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.commands.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/commands/onboard-non-interactive.gateway.test.ts"],
-        watchMode: false,
-      },
-    ]);
   });
 
   it("accepts explicit Vitest config targets routed as whole config runs", () => {

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -224,13 +224,6 @@ afterEach(() => {
 });
 
 describe("scripts/changed-lanes", () => {
-  it("keeps a non-executed changed-gate warning fixture", () => {
-    // openclaw-temp-dir: allow test fixture for the temp warning report
-    const warningFixture = 'fs.mkdtemp("openclaw-warning-fixture-", () => {})';
-
-    expect(warningFixture).toContain("mkdtemp");
-  });
-
   it("detects direct script execution from Windows argv paths", () => {
     expect(
       isDirectRunPath(

--- a/test/scripts/report-test-temp-creations.test.ts
+++ b/test/scripts/report-test-temp-creations.test.ts
@@ -32,13 +32,6 @@ function createNestedGitEnv(): NodeJS.ProcessEnv {
 }
 
 describe("report-test-temp-creations", () => {
-  it("keeps a non-executed warning fixture for changed-gate proof", () => {
-    // openclaw-temp-dir: allow test fixture for the temp warning report
-    const warningFixture = 'fs.mkdtempSync("openclaw-warning-fixture-")';
-
-    expect(warningFixture).toContain("mkdtempSync");
-  });
-
   it("reports added bare temp creation lines using changed-lane test path scope", () => {
     const bareTempSource = [
       "const tempRoot = fs.",


### PR DESCRIPTION
## What Problem This Solves

Four tooling tests no longer protect independent behavior:

- two landed warning-demo fixtures only assert that their own string literals contain `mkdtemp` text;
- one explicit test-support routing case duplicates the same owner proof in the canonical tooling suite;
- one single-shard cache-root case is a strict subset of the retained two-shard cache split test.

These tests add maintenance and shard time without detecting a regression that stronger retained tests would miss.

## Why This Change Was Made

This change deletes only the four redundant tests. The real contracts remain covered:

- temp-creation diff parsing and changed-gate insertion are exercised directly;
- explicit helper targets remain verified through unmatched-target and routed-plan assertions;
- configured cache roots remain verified across two parallel shards, with a separate already-isolated leaf case.

Production tooling and test support are unchanged.

AI-assisted: yes. The changes were manually inspected and passed the repository autoreview gate.

## User Impact

No user-visible behavior change. The tooling suite carries less self-referential and duplicate coverage while preserving the scanner, routing, and parallel-cache invariants.

## Evidence

- Affected tooling suites: 4 files, 505 tests passed.
- Full changed-file gate passed conflict, env/max-lines, formatting, dependency-pin, deprecated-API, plugin-boundary, wrapper-shadowing, and package-patch checks, then stopped only on two unrelated current-main dead exports in `src/skills/workshop`. The remote backend was unavailable because the Blacksmith CLI is absent, so the repository wrapper used its trusted local fallback.
- Fresh autoreview and secret scan: clean, no accepted/actionable findings.

## Scope and LOC

- Production/tooling: `+0/-0`.
- Tests: `+0/-50`.

No runtime behavior, config, protocol, schema, dependency, lockfile, generated baseline, release, or changelog change.
