### PR TITLE
fix(ui): give the chat header a diff glyph, a task glyph, and one centerline

### DIFF
--- a/ui/src/components/icons.ts
+++ b/ui/src/components/icons.ts
@@ -43,6 +43,16 @@ export const icons = {
     <line x1="10" x2="8" y1="9" y2="9" />`),
   file: strokeIcon(svg` <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
     <polyline points="14 2 14 8 20 8" />`),
+  // Lucide file-diff. The outline keeps the cut corner but drops the fold line
+  // the other file glyphs draw: at the header's 18px the fold collides with the
+  // plus stroke and both marks turn to mush, and the missing fold is also what
+  // separates this silhouette from fileText beside it in the same action row.
+  fileDiff: strokeIcon(svg` <path
+      d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.7.71l3.59 3.58A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"
+    />
+    <path d="M9 10h6" />
+    <path d="M12 13V7" />
+    <path d="M9 17h6" />`),
   mail: strokeIcon(svg` <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
     <polyline points="22,6 12,13 2,6" />`),
   star: strokeIcon(

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -855,7 +855,11 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           <div class="chat-split-view__cell" style="width: 320px;">
             <div class="chat-pane__header">
               <button class="btn btn--ghost btn--icon chat-icon-btn chat-pane__nav-toggle" type="button">N</button>
-              <span class="chat-pane__session-title">A deliberately long split-pane session title</span>
+              <span class="chat-pane__session-title"
+                ><span class="chat-pane__session-title-text"
+                  >A deliberately long split-pane session title</span
+                ></span
+              >
               <openclaw-session-owner-chip>
                 <span class="session-owner-chip session-owner-chip--header">O</span>
               </openclaw-session-owner-chip>

--- a/ui/src/pages/chat/components/chat-background-tasks-render.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks-render.ts
@@ -32,7 +32,7 @@ export function renderBackgroundTasksToggle(
         aria-expanded=${String(expanded)}
         @click=${backgroundTasks.onToggleCollapsed}
       >
-        ${icons.activity}
+        ${icons.listChecks}
         ${!expanded && activeCount > 0
           ? html`<span class="chat-tasks-toggle__badge" aria-hidden="true">${activeCount}</span>`
           : nothing}

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -302,7 +302,7 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
           ? html`<span
               class="chat-pane__session-title"
               title=${props.renameDisabledReason ?? props.title}
-              >${props.title}</span
+              ><span class="chat-pane__session-title-text">${props.title}</span></span
             >`
           : html`<button
               class="chat-pane__session-title chat-pane__session-title-button"
@@ -311,7 +311,7 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
               aria-label=${t("chat.sessionHeader.renameAria", { title: props.title })}
               @click=${props.onBeginRename}
             >
-              ${props.title}
+              <span class="chat-pane__session-title-text">${props.title}</span>
             </button>`}
       ${renderSessionOwnerChip(
         props.showOwnerChip ? props.session?.createdActor : undefined,

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -932,7 +932,7 @@ export function renderSessionDiffToggle(
         ?disabled=${sessionWorkspace.diffNotGit === true}
         @click=${sessionWorkspace.onOpenDiff}
       >
-        ${icons.gitBranch}
+        ${icons.fileDiff}
       </button>
     </openclaw-tooltip>
   `;
@@ -1005,7 +1005,7 @@ export function renderSessionWorkspaceRail(
             ?disabled=${sessionWorkspace.diffNotGit === true}
             @click=${sessionWorkspace.onOpenDiff}
           >
-            ${icons.gitBranch}
+            ${icons.fileDiff}
           </button>
         </openclaw-tooltip>
       `

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -150,7 +150,11 @@ openclaw-chat-pane {
 
 .chat-pane__session-title-button {
   display: block;
+  /* Hover padding is drawn outside the text box: the plain-span title (catalog
+     and rename-disabled panes) has none, and without the pull-back the same
+     title would start 5px further right the moment renaming is allowed. */
   padding: 3px 5px;
+  margin-inline: -5px;
   border: 0;
   border-radius: var(--radius-sm);
   background: transparent;
@@ -242,7 +246,7 @@ openclaw-chat-pane {
 .chat-pane__gateway-chip {
   display: inline-flex;
   max-width: 170px;
-  height: 26px;
+  height: 28px;
   align-items: center;
   gap: 6px;
   padding: 0 8px;
@@ -320,7 +324,8 @@ openclaw-chat-pane {
   flex: 0 0 auto;
 }
 
-.chat-pane__branches-trigger svg,
+/* Menu-item check only. The branches trigger is a .chat-icon-btn in the header
+   row, so it keeps the shared 18px action glyph from .btn--icon svg. */
 .chat-pane__branch-active svg {
   width: 14px;
   height: 14px;
@@ -357,7 +362,9 @@ openclaw-chat-pane {
 .chat-pane__workspace-chip {
   display: inline-flex;
   max-width: 180px;
-  height: 26px;
+  /* Same 28px control height as .chat-icon-btn, so every hit/hover surface in
+     the row starts and ends on the same two lines. */
+  height: 28px;
   align-items: center;
   gap: 5px;
   padding: 0 8px;
@@ -398,6 +405,23 @@ openclaw-chat-pane {
      action cluster stays pinned to the right edge (and doubles as the
      native window-drag surface between chip and actions). */
   margin-left: auto;
+}
+
+/* One box model for every action, whatever wraps it. A custom element defaults
+   to display:inline, so as a flex child it blockifies but keeps a text line
+   box, and the descender space under its button drags the glyph off the row
+   centerline: the session menu measured 29.8px tall and 0.9px low against the
+   28px buttons beside it. Keep this selector at single-class specificity so the
+   container queries below can still hide individual actions. */
+.chat-pane__actions > * {
+  display: inline-flex;
+  align-items: center;
+}
+
+/* The tooltip wrapper stays out of the box tree so the button it wraps remains
+   the flex item that the rule above measures. */
+.chat-pane__actions > openclaw-tooltip {
+  display: contents;
 }
 
 .chat-pane__sharing-menu {

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -144,8 +144,6 @@ openclaw-chat-pane {
   overflow: hidden;
   color: var(--text);
   font-size: 12px;
-  white-space: nowrap;
-  text-overflow: ellipsis;
 }
 
 .chat-pane__session-title-button {
@@ -166,6 +164,15 @@ openclaw-chat-pane {
 .chat-pane__session-title-button:focus-visible {
   background: color-mix(in srgb, var(--text) 7%, transparent);
   outline: none;
+}
+
+.chat-pane__session-title-text {
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  /* Inter's visible ink sits 0.8px above its line-box center at this size. */
+  transform: translateY(1px);
 }
 
 .chat-pane__session-title-input {


### PR DESCRIPTION
## What Problem This Solves

Three things in the chat pane's top bar told the operator the wrong story.

**"Show session changes" drew `icons.gitBranch`.** A branch graph says "this session is on a branch", not "here is what changed". The action opens a diff panel; the glyph never said so, and the same command drew that glyph in two places (`ui/src/pages/chat/components/chat-session-workspace.ts:935` header toggle and `:1008` workspace-rail toggle).

**"Show background tasks" drew `icons.activity`,** a heartbeat line. Vitals monitoring is not the developer's metaphor for work running behind the thread; nothing about the glyph suggests a queue of tasks with states.

**The row's controls did not agree on a box.** Measuring the rendered header (Playwright + `getBoundingClientRect`, real app on a mocked Gateway, 1440x900, both themes) found:

| element | height | glyph | glyph center vs row |
| --- | --- | --- | --- |
| session title (rename button) | 24.59px | – | −0.50px |
| workspace chip | 26px | 14px | −0.50px |
| diff / tasks / files / split buttons | 28px | 18px | −0.52px |
| **`openclaw-chat-header-session-menu`** | **29.8px** | 18px | **−1.41px** |

The session menu is a custom element, so it defaults to `display: inline`. As a flex child it blockifies but keeps a text line box, and the descender space under its inline-flex button made the host 29.8px tall and pushed its glyph **0.89px below every other action icon** — and stretched `.chat-pane__actions` to 29.8px with it. That is a bug class, not one element: any custom element dropped into that row inherits it.

Three more inconsistencies came out of the same measurement: the workspace and gateway pills stood 26px against the 28px icon buttons, so no two hover surfaces in the row started and ended on the same lines; `.chat-pane__branches-trigger svg` was overridden to 14px while every sibling `.chat-icon-btn` drew 18px; and `.chat-pane__session-title-button` added `padding: 3px 5px` that the plain-span title (catalog and rename-disabled panes) does not have, so the same title jumped 5px sideways the moment renaming became allowed.

## Why This Change Was Made

**Diff glyph.** Added `icons.fileDiff` — Lucide's `file-diff`, a file outline carrying a `+` above and a `−` below. That is the established diff glyph in coding tools and the one the maintainer asked for. It is hand-inlined through the existing `strokeIcon()` shell like every other icon in the set; no icon library was added. The outline keeps Lucide's cut corner but omits the interior fold line the other file glyphs draw: at the header's 18px the fold collided with the plus stroke and both marks turned to mush, and the missing fold is also what separates this silhouette from `fileText` ("show session files") two buttons away in the same cluster. Both diff entry points now use it, so the command has one icon.

**Background-tasks glyph.** Picked `icons.listChecks` — already in the set, previously unused, a list with check marks. The rail it opens is literally a list of tasks partitioned into active and recent, and the toggle already carries an active-count badge; "list with some items done" is what the surface actually is, and it reads that way to a developer without a tooltip.

Runners-up, so a different call is cheap:

- **`icons.terminal`** — "processes running" reads well, but `chat-terminal-button.ts:32` and the workspace rail's terminal button (`chat-session-workspace.ts:961`) already own that glyph in this same feature area, so the row would show it twice for two different things.
- **`icons.loader`** (spinner family) — right for "in progress", wrong as a persistent control: the toggle is always present, and a static spinner sitting there while nothing runs reads as a hung UI. Default state loses.
- A layers/stacked-squares glyph would have to be added to the set, and it argues z-order rather than task state.

**Alignment.** Fixed at the row level, not per element. `.chat-pane__actions > *` now declares one box model for every child whatever wraps it, with `openclaw-tooltip` explicitly restored to `display: contents` so the button it wraps stays the flex item. The selector is deliberately held at single-class specificity: the first attempt used `:not(openclaw-tooltip)`, which outranked the `@container (max-width: 800px)` rules that hide individual actions and let the close button overflow a 320px pane — `chat-responsive.browser.test.ts` caught it, and the shipped form keeps the container queries winning. The two pills adopt the 28px `.chat-icon-btn` control height, the branches trigger drops its 14px override and inherits the shared 18px action glyph (the 14px rule stays where it belongs, on the dropdown's `.chat-pane__branch-active` check), and the title button's hover padding is pulled back out of the layout with `margin-inline: -5px` so both title states occupy the same box.

After the change every control and every glyph in the row measures **−0.50px** — one shared centerline, in both themes. (The −0.50px is the header's 1px `border-bottom`: content centers in the 47px band above the rule rather than in the 48px box. Every element agrees, which is the invariant that matters; it is not something this PR changes.)

## User Impact

The diff action looks like a diff and the tasks action looks like tasks. The top bar reads as one row: icon buttons, pills, title, and the session menu all sit on the same centerline at the same control height, and the session-menu glyph no longer floats ~1px low against its neighbours. No behavior, keyboard, or ARIA change — labels, tooltips, and handlers are untouched.

## Evidence

**Measurement + captures.** Real Control UI served by `startControlUiE2eServer()` against `installMockGateway` (mock data only, no live Gateway), Playwright Chromium headless, 1440x900, `colorScheme: dark` and `light`, `sessions.diff` advertised and two running tasks so the full action row renders. The measurement walked `.chat-pane__header` children (descending through `display: contents` tooltip/dropdown hosts to the real box) and recorded each element's rect, computed padding/line-height, and inner SVG box against the row centerline. The capture spec was a scratch file, run and deleted — nothing added to the suite.

Disclosed: these captures were run locally (short headless runs, mock data, server torn down by the suite each time). All gates below ran on Blacksmith Testbox.

Full top bar, before -> after:

| | before | after |
| --- | --- | --- |
| dark | ![before dark](https://github.com/user-attachments/assets/661ed6e2-dd33-42fb-abc5-409af3c1d929) | ![after dark](https://github.com/user-attachments/assets/b32d968e-5679-4e24-9490-5c9fb2d6f2ce) |
| light | ![before light](https://github.com/user-attachments/assets/d171f677-45d1-45ea-8102-7f175aa8348c) | ![after light](https://github.com/user-attachments/assets/256cd8ec-5d6a-40a6-a8da-7985de37e009) |

Action cluster at 5x (diff, tasks, files, split, session menu):

| | before | after |
| --- | --- | --- |
| dark | ![before zoom dark](https://github.com/user-attachments/assets/689e85af-0495-41ce-b15d-c62733fd02cb) | ![after zoom dark](https://github.com/user-attachments/assets/32cd3b3c-8ea6-4f83-8768-aa746d0959a7) |
| light | ![before zoom light](https://github.com/user-attachments/assets/cb56f961-d42a-4dda-8da0-c8571bb8242b) | ![after zoom light](https://github.com/user-attachments/assets/09296e20-40ef-41e2-a696-35fc5f8fbca3) |

Each changed icon with its tooltip open:

| | dark | light |
| --- | --- | --- |
| Show session changes | ![diff dark](https://github.com/user-attachments/assets/c82245e4-7edb-4c02-87b5-df01b6c3d981) | ![diff light](https://github.com/user-attachments/assets/b4c48fab-6c4a-4dff-8906-5300a221fe4d) |
| Show background tasks | ![tasks dark](https://github.com/user-attachments/assets/dd5ae334-0ecd-4d09-b59f-efb1c8985145) | ![tasks light](https://github.com/user-attachments/assets/59df4ce7-adbd-4193-9ee3-f4960404477e) |

Measured after the change, identical in dark and light:

```
header 48px, centerline 24px
  chat-pane__session-title-button        h=24.59  dY=-0.50
  chat-pane__workspace-chip              h=28     dY=-0.50   svg 14x14  dY=-0.50
  chat-pane__actions                     h=28     dY=-0.50
  chat-session-diff-toggle               h=28     dY=-0.50   svg 18x18  dY=-0.50
  chat-tasks-toggle                      h=28     dY=-0.50   svg 18x18  dY=-0.50
  chat-workspace-toggle                  h=28     dY=-0.50   svg 18x18  dY=-0.50
  chat-open-split-view                   h=28     dY=-0.50   svg 18x18  dY=-0.50
  openclaw-chat-header-session-menu      h=28     dY=-0.50   svg 18x18  dY=-0.50
  chat-tasks-toggle__badge               h=14     dY=-6.50   (intentional: absolute, top-right)
```

**Tests / gates (Blacksmith Testbox).**

- `pnpm test ui/src/pages/chat/components/chat-pane-header.test.ts ui/src/pages/chat/chat-responsive.browser.test.ts ui/src/styles/cursor-policy.browser.test.ts ui/src/app-navigation.test.ts` — **176 passed / 176**, lease `tbx_01kzpry1ksrawfvpz8hz248r9e`. An earlier run of this same set failed `keeps the split-pane close button reachable as the pane narrows` (close edge at 339.77px against a 320px pane) because of the specificity problem described above; that is fixed and the rerun is green.
- `pnpm check:changed` — every static gate, formatting, and the Control UI i18n catalog pass. Two failures are pre-existing on `main` and untouched by this branch:
  - dead-export scan: `src/skills/workshop/collection-reconcile.ts`, `collection-review.ts`, `collection-rollback.ts`, all introduced by `bdf202ccc8c` (#121653), the base commit of this branch.
  - `typecheck core tests`: `src/infra/approval-gateway-resolver.test.ts` TS2322/TS2345, last touched by `9935ca3b30d` (#121673).
  Neither file is in this diff. `main` churned today; these are attributed, not inherited work.

**Overlap check.** Diffed against the open PRs touching this area before building. #121652 (session companion) adds `sessionRailAction` to `chat-pane__actions` in `chat-pane-header.ts` and edits `components.css` only inside the `openclaw-chat-session-rail` block; this PR touches neither file — header CSS lives in `styles/chat/split-view.css`, which #121652 does not open. #121682 edits `icons.ts` but inserts after `listFilter` (~line 205); `fileDiff` lands after `file` (~line 45). #121692 and #121721 do not overlap. One soft coupling, not a conflict: #121652's new `chat-session-rail-toggle.ts` carries a comment stating the background-tasks toggle owns `icons.activity`, which this PR makes stale — whichever lands second should update that word. Deliberately left out of this diff so the two branches stay conflict-free.

**LOC.** +40 / −6, all production, no test changes. Production delta is +34: 10 for the new `fileDiff` glyph (a capability the set did not have), 12 comment lines recording the invariants, and 12 lines of CSS.

---

## Follow-up commit: optically centering the session title

The box work above put every control's **box** on 23.50px. It left one thing unfinished: the title's **ink** is not its box. Glyphs sit high in their line box (ascent leading above, descent room below that "Main" never uses), so a title whose box is perfectly centered still reads low.

`.chat-pane__session-title` now wraps its text in `.chat-pane__session-title-text`, which owns the ellipsis and carries a 1px optical nudge.

Measured the same way in both states — a Range over the **text node itself**, with the baseline placed inside that inline box from `fontBoundingBox*` metrics and the ink band taken from `actualBoundingBoxAscent/Descent` around it:

| | ink center | vs row centerline (23.50) | vs header box center (24.00) |
| --- | --- | --- | --- |
| before | 22.79px | −0.71px | −1.21px |
| after | 23.79px | **+0.29px** | −0.21px |

Identical in dark and light. The title's outer box is untouched at 23.50px, so nothing else in the row moves.

Two honest notes on the number:

- **It slightly overshoots.** Landing the ink exactly on 23.50 wants a 0.71px translate; this ships 1px. A sub-pixel transform blurs text on non-retina displays, so the integer wins and the residual is 0.29px — well inside the 0.71px it replaces.
- **Measure the text node, not a wrapper.** A Range over a block child returns that block's border box, not the inline text box. Doing that by accident makes the two states look like the nudge is a 1px regression rather than a 0.42px improvement; the numbers above are same-markup A/B with the transform as the only variable.

| | dark | light |
| --- | --- | --- |
| top bar | ![optical dark](https://github.com/user-attachments/assets/01af3bc2-5a40-4726-98ee-2b494bd07c19) | ![optical light](https://github.com/user-attachments/assets/9fcaf7cf-6d51-4690-ae1b-554efaa69cb3) |

Ellipsis still truncates in a narrow pane, in both title states (the rename button and the plain span):

| narrow, rename button | narrow, plain span |
| --- | --- |
| ![narrow button](https://github.com/user-attachments/assets/a9affa58-0bfa-4ce5-9cc0-db6e5191c25e) | ![narrow plain](https://github.com/user-attachments/assets/61cc7439-7b5a-483e-bc5c-8003713b0a15) |

**Third commit: keeping the split-header fixture honest.** Moving the ellipsis onto the inner span left `chat-responsive.browser.test.ts`'s split-header fixture holding a bare `.chat-pane__session-title`, which no longer carries `white-space: nowrap` or `text-overflow: ellipsis`. Its deliberately long title wrapped instead of truncating — the close-button assertion still passed, but the fixture had quietly stopped exercising the ellipsis path it exists to guard. The fixture now mirrors the shipped markup. Re-proved on Blacksmith Testbox: **176 passed / 176**, lease `tbx_01kzq08y3cexenzzdg93f81f3x`.

**Branch LOC (three commits, vs `bdf202ccc8c`).** +56 / -11 across 6 files. Split: **production +51 / -10**, **test +5 / -1**. Production delta +41: 10 for the `fileDiff` glyph, 4 for the title's text span and its ellipsis/nudge rule, ~15 comment lines recording the measured invariants, and the rest CSS.
