### PR TITLE
test(auto-reply): drop persistence call count

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -373,7 +373,6 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
       // createHookCtx's "private" chat type is undirected, so no fallback
       // attempt follows the timed-out final.
       expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 1 });
-      expect(sessionStoreMocks.updateSessionEntry).toHaveBeenCalledOnce();
       expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toMatchObject({
         kind: "replayable",
         text: "durable reply",


### PR DESCRIPTION
## What Problem This Solves

The `beforeDeliver` timeout test asserted that `updateSessionEntry` was called exactly once even though the reconciliation intentionally preserves the pending final and returns no patch. That assertion pins a no-op persistence pass rather than observable delivery or storage behavior.

A future optimization that skips the SQLite writer lane when no patch is needed would therefore break the test without changing the contract.

## Why This Change Was Made

This change removes only the exact call-count assertion. The same test still proves:

- no transport delivery occurs;
- the final is classified as failed before delivery;
- replayable text and route context remain durably available;
- no timer leaks.

A real SQLite owner test independently verifies that pre-delivery failure preserves pending-final state and restart provenance. Exact write-count assertions on success, late abort, intentional cancellation, and non-admission remain because those protect deliberate storage/idempotency contracts.

AI-assisted: yes. The change was manually inspected and passed the repository autoreview gate.

## User Impact

No user-visible behavior change. The timeout regression remains protected without coupling it to one persistence-helper invocation.

## Evidence

- Dispatch and real SQLite pending-final suites: 2 files, 34 tests passed.
- Full changed-file gate passed conflict, env/max-lines, formatting, dependency-pin, deprecated-API, plugin-boundary, wrapper-shadowing, package-patch, dead-export, temp-directory, typecheck, and targeted lint checks. The remote backend was unavailable because the Blacksmith CLI is absent, so the repository wrapper used its trusted local fallback.
- Fresh autoreview and secret scan: clean, no accepted/actionable findings.

## Scope and LOC

- Production: `+0/-0`.
- Tests: `+0/-1`.

No runtime behavior, config, protocol, schema, dependency, lockfile, generated baseline, release, or changelog change.
