### PR TITLE
test(bench): trim shared helper duplicates

### DIFF
--- a/scripts/bench-gateway-startup.ts
+++ b/scripts/bench-gateway-startup.ts
@@ -6,12 +6,7 @@ import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { pathToFileURL } from "node:url";
 import { delay, stopChild } from "./lib/gateway-bench-child.ts";
-import {
-  getFreePort,
-  parseProcessRssKb,
-  readProcessRssMb,
-  readProcessTreeCpuMs,
-} from "./lib/gateway-bench-probes.ts";
+import { getFreePort, readProcessRssMb, readProcessTreeCpuMs } from "./lib/gateway-bench-probes.ts";
 import {
   BASE_GATEWAY_BENCH_CONFIG,
   buildGatewayBenchChildArgs,
@@ -832,10 +827,6 @@ export const testing = {
   collectResultFailures,
   collectStartupTrace,
   parseOptions,
-  parseNonNegativeInt,
-  parsePositiveInt,
-  parseProcessRssKb,
-  resolveEntry,
   sanitizedEnv,
   stopChild,
   summarizeCase,

--- a/test/scripts/bench-gateway-startup.test.ts
+++ b/test/scripts/bench-gateway-startup.test.ts
@@ -55,8 +55,6 @@ describe("gateway startup benchmark script", () => {
 
   it("rejects ambiguous benchmark CLI values before spawning Node", () => {
     expect(() => testing.parseOptions(["--wat"])).toThrow("Unknown argument: --wat");
-    expect(testing.parsePositiveInt("5", 1, "--runs")).toBe(5);
-    expect(testing.parseNonNegativeInt("0", 1, "--warmup")).toBe(0);
     expect(
       testing.parseOptions([
         "--case",
@@ -76,9 +74,6 @@ describe("gateway startup benchmark script", () => {
       output: "startup.json",
       runs: 2,
     });
-    expect(() => testing.parsePositiveInt("2abc", 1, "--runs")).toThrow(
-      /--runs must be an integer/u,
-    );
     expect(() => testing.parseOptions(["--output", "--case", "default"])).toThrow(
       "--output requires a value",
     );
@@ -92,7 +87,6 @@ describe("gateway startup benchmark script", () => {
     expect(() =>
       testing.parseOptions(["--output", "first.json", "--output", "second.json"]),
     ).toThrow("--output was provided more than once");
-    expect(() => testing.resolveEntry("--inspect")).toThrow(/must be a file path/u);
   });
 
   it("rejects unknown benchmark CLI args before running cases", () => {
@@ -152,14 +146,6 @@ describe("gateway startup benchmark script", () => {
 
     expect(env.OPENCLAW_LOCAL_CHECK).toBeUndefined();
     expect(env.OPENCLAW_GATEWAY_STARTUP_TRACE).toBe("1");
-  });
-
-  it("rejects malformed ps RSS samples", () => {
-    expect(testing.parseProcessRssKb("2048\n")).toBe(2048);
-    expect(testing.parseProcessRssKb("2048kb\n")).toBeNull();
-    expect(testing.parseProcessRssKb("2048 4096\n")).toBeNull();
-    expect(testing.parseProcessRssKb("0\n")).toBeNull();
-    expect(testing.parseProcessRssKb("")).toBeNull();
   });
 
   it("classifies HTTP listen and gateway ready logs separately", () => {


### PR DESCRIPTION
## What Problem This Solves

The gateway startup benchmark re-exported four shared parser/probe helpers only for tests and duplicated their direct assertions from the restart benchmark. Those copies did not protect startup-specific behavior and forced the startup facade and imports to retain test-only surface.

## Why This Change Was Made

This change removes the duplicate startup assertions and narrows its `testing` facade. Shared integer parsing, entry validation, and RSS parsing remain covered in the restart benchmark at their common owner, while startup-specific option composition, diagnostics, child process behavior, trace parsing, and help execution remain covered.

Production benchmark behavior is unchanged; the startup script simply stops importing and exposing the shared RSS parser solely for tests.

AI-assisted: yes. The changes were manually inspected and passed the repository autoreview gate.

## User Impact

No user-visible behavior change. Maintainers get a smaller benchmark test facade and one canonical suite for shared helper contracts.

## Evidence

- Gateway startup and restart benchmark suites: 2 files, 63 tests passed.
- Real startup benchmark help path exited successfully.
- Full changed-file gate passed all tooling, script typecheck, formatting, lint, Docker-E2E, and boundary checks. The remote backend was unavailable because the Blacksmith CLI is absent, so the repository wrapper used its trusted local fallback.
- Fresh autoreview and secret scan: clean, no accepted/actionable findings.

## Scope and LOC

- Production/tooling test surface: `+1/-10` (net `-9`).
- Tests: `+0/-14`.
- Overall: `+1/-24` (net `-23`).

No runtime behavior, config, protocol, schema, dependency, lockfile, generated baseline, release, or changelog change.
