### PR TITLE
fix(ci): refresh generated Swift protocol models

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -15742,21 +15742,25 @@ public struct ApprovalResolveParams: Codable, Sendable {
     public let id: String
     public let kind: ApprovalKind
     public let decision: ApprovalDecision
+    public let reviewer: [String: AnyCodable]?
 
     public init(
         id: String,
         kind: ApprovalKind,
-        decision: ApprovalDecision)
+        decision: ApprovalDecision,
+        reviewer: [String: AnyCodable]? = nil)
     {
         self.id = id
         self.kind = kind
         self.decision = decision
+        self.reviewer = reviewer
     }
 
     private enum CodingKeys: String, CodingKey {
         case id
         case kind
         case decision
+        case reviewer
     }
 }
 
@@ -16143,18 +16147,22 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
 public struct ExecApprovalResolveParams: Codable, Sendable {
     public let id: String
     public let decision: String
+    public let reviewer: [String: AnyCodable]?
 
     public init(
         id: String,
-        decision: String)
+        decision: String,
+        reviewer: [String: AnyCodable]? = nil)
     {
         self.id = id
         self.decision = decision
+        self.reviewer = reviewer
     }
 
     private enum CodingKeys: String, CodingKey {
         case id
         case decision
+        case reviewer
     }
 }
 
@@ -16513,18 +16521,22 @@ public struct PluginApprovalRequestParams: Codable, Sendable {
 public struct PluginApprovalResolveParams: Codable, Sendable {
     public let id: String
     public let decision: String
+    public let reviewer: [String: AnyCodable]?
 
     public init(
         id: String,
-        decision: String)
+        decision: String,
+        reviewer: [String: AnyCodable]? = nil)
     {
         self.id = id
         self.decision = decision
+        self.reviewer = reviewer
     }
 
     private enum CodingKeys: String, CodingKey {
         case id
         case decision
+        case reviewer
     }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Current `main` added optional approval reviewer metadata to the protocol source, but the generated Swift models were not refreshed. `protocol-gen-swift --check` therefore fails in `checks-fast-bundled-protocol`, blocking every pull request against `main`.

The stale Swift structs also omit metadata that the canonical protocol now permits on approval resolution.

## Why This Change Was Made

This change regenerates `GatewayModels.swift` from the current protocol source. It adds the optional `reviewer` field to approval, exec-approval, and plugin-approval resolve params.

No protocol method, version, source schema, or hand-written runtime behavior changes here; this is the missing generated artifact for already-landed source changes.

AI-assisted: yes. The generated delta was manually inspected and passed the repository autoreview gate.

## User Impact

Swift clients regain parity with the canonical Gateway protocol and repository CI can validate pull requests again.

## Evidence

- `pnpm protocol:check` passed: registry, schema, Swift generation, Kotlin generation, and protocol-since guard all agree.
- Exact failed CI job on four unrelated cleanup PRs reported the same stale `GatewayModels.swift` output.
- Full changed-file app/macOS gate passed Swift lint across 710 files, 295 focused CI tests across six Vitest shards, package/boundary checks, and the native state schema guard. The remote backend was unavailable because the Blacksmith CLI is absent, so the repository wrapper used its trusted local fallback.
- Fresh autoreview and secret scan: clean, no accepted/actionable findings.

## Scope and LOC

- Generated Swift: `+15/-3`.
- Production source, tests, config, protocol version, dependencies, lockfiles, release metadata, and changelog: unchanged.
