### PR TITLE
test(macos): remove Tailscale session exerciser

### DIFF
--- a/apps/macos/Sources/OpenClawDiscovery/TailscaleServeGatewayDiscovery.swift
+++ b/apps/macos/Sources/OpenClawDiscovery/TailscaleServeGatewayDiscovery.swift
@@ -268,12 +268,6 @@ enum TailscaleServeGatewayDiscovery {
 
         return event == "connect.challenge"
     }
-
-    #if DEBUG
-    static func probeSessionIdentifierForTesting() -> ObjectIdentifier {
-        ObjectIdentifier(self.probeSession)
-    }
-    #endif
 }
 
 private struct TailscaleStatus: Decodable {

--- a/apps/macos/Tests/OpenClawIPCTests/TailscaleServeGatewayDiscoveryTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TailscaleServeGatewayDiscoveryTests.swift
@@ -54,15 +54,6 @@ struct TailscaleServeGatewayDiscoveryTests {
         #expect(beacons.isEmpty)
     }
 
-    #if DEBUG
-    @Test func `reuses probe session across discovery passes`() {
-        let first = TailscaleServeGatewayDiscovery.probeSessionIdentifierForTesting()
-        let second = TailscaleServeGatewayDiscovery.probeSessionIdentifierForTesting()
-
-        #expect(first == second)
-    }
-    #endif
-
     @Test func `resolves bare executable from PATH`() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)


### PR DESCRIPTION
## What Problem This Solves

The Tailscale discovery suite exposed a DEBUG-only accessor that returned the identity of the static probe `URLSession`, then called that accessor twice and compared the property to itself.

That test never ran discovery or created a probe. Reintroducing a per-probe session while leaving the unused static property behind would still pass, so it provided false confidence and kept production test scaffolding alive.

## Why This Change Was Made

This change removes the DEBUG accessor and the self-referential test. The real static session, its lifecycle comment, and its use by websocket probing remain unchanged. Functional tests still exercise candidate filtering, successful probing, unavailable status, executable resolution, and subprocess environment behavior.

AI-assisted: yes. The changes were manually inspected and passed the repository autoreview gate.

## User Impact

No user-visible behavior change. Maintainers lose a misleading exerciser and six lines of production-only test seam.

## Evidence

- `swift test --package-path apps/macos --filter TailscaleServeGatewayDiscoveryTests`: 6 tests passed.
- Full changed-file app/macOS gate passed Swift lint across 710 files, 295 focused CI tests across six Vitest shards, package/boundary checks, and the native state schema guard. The remote backend was unavailable because the Blacksmith CLI is absent, so the repository wrapper used its trusted local fallback.
- Fresh autoreview and secret scan: clean, no accepted/actionable findings.

## Scope and LOC

- Production DEBUG test seam: `+0/-6`.
- Tests: `+0/-9`.
- Overall: `+0/-15`.

No runtime behavior, config, protocol, schema, dependency, lockfile, generated baseline, release, or changelog change.
