### PR TITLE
fix(ci): heal skills reconciliation fallout

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -417,7 +417,6 @@ const config = {
     "src/gateway/server-methods/chat-webchat-media.ts": ["exports"],
     // Collection reconcile behavior is asserted by the focused review tests;
     // production wires only the scheduled review loop.
-    "src/skills/workshop/collection-review.ts": ["exports"],
     // Greeting cache/fact contracts (hash, alert text, store shapes) are
     // asserted by the focused greeting unit tests, not by another prod module.
     "src/system-agent/greeting.ts": ["exports", "types"],

--- a/src/skills/workshop/collection-review.test.ts
+++ b/src/skills/workshop/collection-review.test.ts
@@ -12,10 +12,7 @@ import {
   isSkillCollectionReviewDue,
   recordSkillCollectionReviewSuccess,
 } from "./collection-review-state.js";
-import {
-  runScheduledSkillCollectionReviews,
-  runSkillCollectionReview,
-} from "./collection-review.js";
+import { runScheduledSkillCollectionReviews } from "./collection-review.js";
 
 const runEmbeddedAgent = vi.hoisted(() => vi.fn());
 const authStoresByAgentDir = vi.hoisted(() => new Map<string, unknown>());
@@ -55,6 +52,7 @@ describe("skill collection review", () => {
     await writeWorkspaceSkills(workspaceDir, [
       { name: "useful", description: "Useful reusable procedure" },
     ]);
+    let reviewResult: unknown;
     runEmbeddedAgent.mockImplementation(async (params) => {
       const tool = createSkillWorkshopTool({
         workspaceDir: params.workspaceDir,
@@ -65,26 +63,31 @@ describe("skill collection review", () => {
         collectionReconcile: params.skillWorkshopCollectionReconcile,
       });
       await tool.execute("read", { action: "read", skill_name: "useful" });
-      await tool.execute("reconcile", {
+      const reconciliation = await tool.execute("reconcile", {
         action: "reconcile",
         collection: [{ action: "keep", name: "useful" }],
       });
+      reviewResult = reconciliation.details;
       return {};
     });
 
-    await expect(
-      runSkillCollectionReview({
-        agentId: "main",
-        config: {
-          agents: {
-            list: [{ id: "main", default: true, model: "openai/gpt-5.6-sol@openai:work" }],
-          },
-          skills: { workshop: { autonomous: { mode: "auto" } } },
+    await runScheduledSkillCollectionReviews({
+      config: {
+        agents: {
+          list: [
+            {
+              id: "main",
+              default: true,
+              model: "openai/gpt-5.6-sol@openai:work",
+              workspace: workspaceDir,
+            },
+          ],
         },
-        workspaceDir,
-        env: testState.env,
-      }),
-    ).resolves.toMatchObject({ kept: ["useful"], written: [], dropped: [] });
+        skills: { workshop: { autonomous: { mode: "auto" } } },
+      },
+      env: testState.env,
+    });
+    expect(reviewResult).toMatchObject({ kept: ["useful"], written: [], dropped: [] });
     expect(runEmbeddedAgent).toHaveBeenCalledWith(
       expect.objectContaining({
         trigger: "cron",
@@ -131,10 +134,11 @@ describe("skill collection review", () => {
       return {};
     });
 
-    await runSkillCollectionReview({
-      agentId: "main",
-      config: { skills: { workshop: { autonomous: { mode: "auto" } } } },
-      workspaceDir,
+    await runScheduledSkillCollectionReviews({
+      config: {
+        agents: { list: [{ id: "main", default: true, workspace: workspaceDir }] },
+        skills: { workshop: { autonomous: { mode: "auto" } } },
+      },
       env: testState.env,
     });
   });
@@ -189,16 +193,16 @@ describe("skill collection review", () => {
       return {};
     });
 
-    await runSkillCollectionReview({
-      agentId: "main",
+    await runScheduledSkillCollectionReviews({
       config: {
-        agents: { list: [{ id: "main", skills: ["enabled", "disabled"] }] },
+        agents: {
+          list: [{ id: "main", workspace: workspaceDir, skills: ["enabled", "disabled"] }],
+        },
         skills: {
           entries: { disabled: { enabled: false } },
           workshop: { autonomous: { mode: "auto" } },
         },
       },
-      workspaceDir,
       env: testState.env,
     });
 
@@ -505,14 +509,20 @@ describe("skill collection review", () => {
       },
     ]);
 
-    await expect(
-      runSkillCollectionReview({
-        agentId: "main",
-        config: { skills: { workshop: { autonomous: { mode: "auto" } } } },
-        workspaceDir,
-        env: testState.env,
-      }),
-    ).rejects.toThrow("review limit");
+    const onError = vi.fn();
+    await runScheduledSkillCollectionReviews({
+      config: {
+        agents: { list: [{ id: "main", default: true, workspace: workspaceDir }] },
+        skills: { workshop: { autonomous: { mode: "auto" } } },
+      },
+      env: testState.env,
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining("review limit") }),
+      await fs.realpath(workspaceDir),
+    );
     expect(runEmbeddedAgent).not.toHaveBeenCalled();
   });
 });

--- a/src/skills/workshop/collection-review.test.ts
+++ b/src/skills/workshop/collection-review.test.ts
@@ -70,6 +70,7 @@ describe("skill collection review", () => {
       reviewResult = reconciliation.details;
       return {};
     });
+    const onError = vi.fn();
 
     await runScheduledSkillCollectionReviews({
       config: {
@@ -86,7 +87,9 @@ describe("skill collection review", () => {
         skills: { workshop: { autonomous: { mode: "auto" } } },
       },
       env: testState.env,
+      onError,
     });
+    expect(onError).not.toHaveBeenCalled();
     expect(reviewResult).toMatchObject({ kept: ["useful"], written: [], dropped: [] });
     expect(runEmbeddedAgent).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -133,6 +136,7 @@ describe("skill collection review", () => {
       });
       return {};
     });
+    const onError = vi.fn();
 
     await runScheduledSkillCollectionReviews({
       config: {
@@ -140,7 +144,9 @@ describe("skill collection review", () => {
         skills: { workshop: { autonomous: { mode: "auto" } } },
       },
       env: testState.env,
+      onError,
     });
+    expect(onError).not.toHaveBeenCalled();
   });
 
   it("persists the daily boundary per workspace", async () => {
@@ -192,6 +198,7 @@ describe("skill collection review", () => {
       });
       return {};
     });
+    const onError = vi.fn();
 
     await runScheduledSkillCollectionReviews({
       config: {
@@ -204,7 +211,9 @@ describe("skill collection review", () => {
         },
       },
       env: testState.env,
+      onError,
     });
+    expect(onError).not.toHaveBeenCalled();
 
     expect((await fs.readdir(path.join(workspaceDir, "skills"))).toSorted()).toEqual([
       "agent-filtered",

--- a/src/skills/workshop/collection-review.ts
+++ b/src/skills/workshop/collection-review.ts
@@ -64,7 +64,7 @@ export function startSkillCollectionMaintenance(options: {
   };
 }
 
-export async function runSkillCollectionReview(params: {
+async function runSkillCollectionReview(params: {
   agentId: string;
   agentIds?: readonly string[];
   config: OpenClawConfig;


### PR DESCRIPTION
Supersedes #121725. @vyctorbrzezowski's generator-owned diagnosis and repair are credited here; the identical Swift output independently reached main in `5fb5eefa611e` while this branch was under review.

## What Problem This Solves

Resolves the remaining fallout from concurrent skills and approval landings that left main CI red across generated Swift protocol models, Skill Workshop dead-export/cycle checks, the Plugin SDK baseline, the `/learn` prompt contract, and approval-handler runtime tests. Those failures blocked unrelated pull requests from landing.

## Why This Change Was Made

Parallel healers landed the mechanical Swift, cycle, SDK-baseline, `/learn`, and approval-fixture repairs on main. This PR completes the consolidated repair by:

- removing the test-only `runSkillCollectionReview` export and exercising collection review through its public scheduled-review entrypoint;
- deleting the temporary Knip export exception, leaving zero unused exports without a suppression.

No production behavior changes or weakened assertions.

## User Impact

No direct user-facing behavior change. Main and dependent pull requests regain clean generated-artifact, dead-export, import-cycle, prompt-contract, and approval-runtime gates.

## Evidence

- `node --import tsx scripts/protocol-gen-swift.ts --check`
- `node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check`
- `node --import tsx scripts/check-import-cycles.ts` — 0 runtime value cycles
- `node --import tsx scripts/check-madge-import-cycles.ts` — 0 cycles
- `node scripts/check-deadcode-exports.mts` — 0 production/full-tree/script unused exports
- `node scripts/run-vitest.mjs src/skills/workshop/collection-review.test.ts src/auto-reply/reply/commands-learn.test.ts src/infra/approval-handler-runtime.test.ts --reporter=verbose` — 33 tests passed
- Branch-level autoreview: clean, no accepted/actionable findings

Provenance:

- #121653 (`bdf202ccc8c`): Skill Workshop reconciliation and reuse-first `/learn` prompt.
- #121673 (`9935ca3b30d`): reviewer schema and approval event-kind routing.
- Upstream heals incorporated: `40817435e81`, `db879e73fa9`, `8ae273603d8`, `0ca0781fec6`, `5fb5eefa611e`.
