### PR TITLE
fix(gateway): restore restart preflight compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Gateway restart preflight compatibility:** restore the shipped, read-only `gateway.restart.preflight` RPC and Android method enum for external control-plane clients while keeping `gateway.restart.request` canonical and documenting that suspension requires the separate atomic `gateway.suspend.prepare` fence.
 - **Control UI staged attachments:** preserve unsent images, files, pasted images, and large pasted text across same-tab route and narrow split-pane remounts while keeping pane close, mismatched pane/session/Gateway remounts, application shutdown, and hard reload as cleanup boundaries. Fixes #121519. Thanks @shakkernerd.
 - **Control UI browser annotations:** keep marked screenshots and generated page context together in structured composer cards, preserve user-written drafts when annotations are removed or replaced, retain complete unsent annotation packages across same-tab route and active split-pane remounts, and offer bounded Undo without restoring removed context into another session. Fixes #120744. Thanks @shakkernerd.
 - **Control UI profile avatar refreshes:** carry canonical content revisions through mutation responses and live presence so rapid replacements refresh every connected browser without stale cache rollback. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Gateway restart preflight compatibility:** restore the shipped, read-only `gateway.restart.preflight` RPC and Android method enum for external control-plane clients while keeping `gateway.restart.request` canonical and documenting that suspension requires the separate atomic `gateway.suspend.prepare` fence.
 - **Control UI staged attachments:** preserve unsent images, files, pasted images, and large pasted text across same-tab route and narrow split-pane remounts while keeping pane close, mismatched pane/session/Gateway remounts, application shutdown, and hard reload as cleanup boundaries. Fixes #121519. Thanks @shakkernerd.
 - **Control UI browser annotations:** keep marked screenshots and generated page context together in structured composer cards, preserve user-written drafts when annotations are removed or replaced, retain complete unsent annotation packages across same-tab route and active split-pane remounts, and offer bounded Undo without restoring removed context into another session. Fixes #120744. Thanks @shakkernerd.
 - **Control UI profile avatar refreshes:** carry canonical content revisions through mutation responses and live presence so rapid replacements refresh every connected browser without stale cache rollback. Thanks @shakkernerd.

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
@@ -405,6 +405,7 @@ enum class GatewayMethod(
   CronRun("cron.run"),
   CronRuns("cron.runs"),
   GatewayIdentityGet("gateway.identity.get"),
+  GatewayRestartPreflight("gateway.restart.preflight"),
   GatewayRestartRequest("gateway.restart.request"),
   SystemPresence("system-presence"),
   SystemEvent("system-event"),

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -519,6 +519,7 @@ methods. Treat this as feature discovery, not a full enumeration of
     - `system-event` appends a system event and can update/broadcast presence context.
     - `last-heartbeat` returns the latest persisted heartbeat event.
     - `set-heartbeats` toggles heartbeat processing on the gateway.
+    - `gateway.restart.preflight` is a deprecated, read-only compatibility preview of restart-specific active work. It does not close admission, create a suspension lease, or provide the atomic full-work fence of `gateway.suspend.prepare`; new restart flows should call `gateway.restart.request`.
     - `gateway.suspend.prepare` creates a short cooperative-suspension lease only when tracked Gateway work is idle. `gateway.suspend.status` checks that lease, and `gateway.suspend.resume` releases it after thaw or an aborted host operation.
 
   </Accordion>

--- a/scripts/check-protocol-since.mts
+++ b/scripts/check-protocol-since.mts
@@ -10,7 +10,12 @@ import { resolveRepoRoot } from "./lib/repo-root.mjs";
 const repoRoot = resolveRepoRoot(import.meta.url);
 const descriptorPath = "src/gateway/methods/core-descriptors.ts";
 
-type MethodSpec = { line: number; name: string; since: string | undefined };
+type MethodSpec = {
+  line: number;
+  name: string;
+  since: string | undefined;
+  compatibilityRestored: boolean;
+};
 
 function runGit(args: string[]): string {
   const result = spawnSync("git", args, { cwd: repoRoot, encoding: "utf8" });
@@ -83,6 +88,20 @@ function stringProperty(object: ts.ObjectLiteralExpression, key: string): string
   return undefined;
 }
 
+function trueProperty(object: ts.ObjectLiteralExpression, key: string): boolean {
+  return object.properties.some((property) => {
+    if (!ts.isPropertyAssignment(property)) {
+      return false;
+    }
+    const propertyName = property.name;
+    const name =
+      ts.isIdentifier(propertyName) || ts.isStringLiteral(propertyName)
+        ? propertyName.text
+        : undefined;
+    return name === key && property.initializer.kind === ts.SyntaxKind.TrueKeyword;
+  });
+}
+
 function collectMethodSpec(
   element: ts.Expression,
   sourceFile: ts.SourceFile,
@@ -96,7 +115,12 @@ function collectMethodSpec(
         `${fileName}:${line} core method spec names must be string literals so additions can be compared with origin/main.`,
       );
     }
-    return { name, since: stringProperty(element, "since"), line };
+    return {
+      name,
+      since: stringProperty(element, "since"),
+      compatibilityRestored: trueProperty(element, "compatibilityRestored"),
+      line,
+    };
   }
   if (ts.isArrayLiteralExpression(element)) {
     const name = element.elements[0];
@@ -106,7 +130,12 @@ function collectMethodSpec(
         `${fileName}:${line} core method spec rows must use string literal names and vintage metadata.`,
       );
     }
-    return { name: name.text, since: since.text, line };
+    const policy = element.elements[4];
+    const compatibilityRestored =
+      policy !== undefined && ts.isObjectLiteralExpression(policy)
+        ? trueProperty(policy, "compatibilityRestored")
+        : false;
+    return { name: name.text, since: since.text, compatibilityRestored, line };
   }
   throw new Error(
     `${fileName}:${line} core method specs must be inline object literals or labeled rows so vintage metadata can be enforced.`,
@@ -166,22 +195,32 @@ try {
     collectMethodSpecs(baseSource, `${descriptorPath}@${mergeBase}`).map((s) => s.name),
   );
   const added = currentSpecs.filter((spec) => !baseNames.has(spec.name));
-  const violations = added.filter((spec) => spec.since !== train);
+  const restored = added.filter((spec) => spec.compatibilityRestored);
+  const newMethods = added.filter((spec) => !spec.compatibilityRestored);
+  // Restored shipped methods retain their historical vintage so discovery and
+  // generated clients see the original availability contract, not a new API.
+  const violations = added.filter((spec) =>
+    spec.compatibilityRestored ? !spec.since?.startsWith("<=") : spec.since !== train,
+  );
 
   if (violations.length > 0) {
     console.error(`Protocol since guard failed for current train ${train}:`);
     for (const spec of violations) {
-      const problem = spec.since
-        ? `has since ${JSON.stringify(spec.since)}`
-        : "is missing since metadata";
+      const problem = spec.compatibilityRestored
+        ? `is marked compatibilityRestored but has non-historical since ${JSON.stringify(spec.since)}`
+        : spec.since
+          ? `has since ${JSON.stringify(spec.since)}`
+          : "is missing since metadata";
       console.error(
-        `- ${descriptorPath}:${spec.line} ${spec.name} ${problem}; add since: ${JSON.stringify(train)}.`,
+        spec.compatibilityRestored
+          ? `- ${descriptorPath}:${spec.line} ${spec.name} ${problem}; restored compatibility methods must retain <= vintage metadata.`
+          : `- ${descriptorPath}:${spec.line} ${spec.name} ${problem}; add since: ${JSON.stringify(train)}.`,
       );
     }
     process.exitCode = 1;
   } else {
     console.log(
-      `protocol since guard passed: ${added.length} new core method${added.length === 1 ? "" : "s"} use train ${train}`,
+      `protocol since guard passed: ${newMethods.length} new core method${newMethods.length === 1 ? "" : "s"} use train ${train}; ${restored.length} restored compatibility method${restored.length === 1 ? "" : "s"} retain historical vintage`,
     );
   }
 } catch (error) {

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -87,6 +87,7 @@ describe("method scope resolution", () => {
     ["session.discussion.open", ["operator.write"]],
     ["environments.status", ["operator.read"]],
     ["diagnostics.stability", ["operator.read"]],
+    ["gateway.restart.preflight", ["operator.read"]],
     ["skills.curator.status", ["operator.read"]],
     ["hooks.status", ["operator.read"]],
     ["skills.curator.pin", ["operator.admin"]],

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -16,12 +16,13 @@ type CoreGatewayMethodSpec = {
   advertise?: false;
   startup?: true;
   controlPlaneWrite?: true;
+  compatibilityRestored?: true;
 };
 
 type CoreGatewayMethodMetadata = Pick<CoreGatewayMethodSpec, "name" | "scope" | "since">;
 type CoreGatewayMethodPolicy = Pick<
   CoreGatewayMethodSpec,
-  "advertise" | "startup" | "controlPlaneWrite"
+  "advertise" | "startup" | "controlPlaneWrite" | "compatibilityRestored"
 >;
 type CoreGatewayMethodSpecRow = readonly [
   name: string,
@@ -301,7 +302,13 @@ const CORE_GATEWAY_METHOD_SPECS = [
   ["gateway.identity.get", "system", "operator.read", "<=2026.7"],
   // Deprecated read-only compatibility preview; new restart flows request the
   // restart directly, while atomic host suspension uses gateway.suspend.prepare.
-  ["gateway.restart.preflight", "restart", "operator.read", "<=2026.7"],
+  [
+    "gateway.restart.preflight",
+    "restart",
+    "operator.read",
+    "<=2026.7",
+    { compatibilityRestored: true },
+  ],
   ["gateway.restart.request", "restart", "operator.admin", "<=2026.7", { controlPlaneWrite: true }],
   ["system-presence", "system", "operator.read", "<=2026.7"],
   ["system-event", "system", "operator.admin", "<=2026.7"],
@@ -505,6 +512,9 @@ const CORE_GATEWAY_METHOD_SPEC_LIST: readonly CoreGatewayMethodSpec[] =
     }
     if (normalizedPolicy?.controlPlaneWrite === true) {
       spec.controlPlaneWrite = true;
+    }
+    if (normalizedPolicy?.compatibilityRestored === true) {
+      spec.compatibilityRestored = true;
     }
     return spec;
   });

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -299,6 +299,9 @@ const CORE_GATEWAY_METHOD_SPECS = [
   ["cron.run", "cron", "operator.admin", "<=2026.7"],
   ["cron.runs", "cron", "operator.read", "<=2026.7"],
   ["gateway.identity.get", "system", "operator.read", "<=2026.7"],
+  // Deprecated read-only compatibility preview; new restart flows request the
+  // restart directly, while atomic host suspension uses gateway.suspend.prepare.
+  ["gateway.restart.preflight", "restart", "operator.read", "<=2026.7"],
   ["gateway.restart.request", "restart", "operator.admin", "<=2026.7", { controlPlaneWrite: true }],
   ["system-presence", "system", "operator.read", "<=2026.7"],
   ["system-event", "system", "operator.admin", "<=2026.7"],

--- a/src/gateway/server-methods-list.test.ts
+++ b/src/gateway/server-methods-list.test.ts
@@ -148,6 +148,25 @@ describe("listGatewayMethods", () => {
     expect(coreGatewayHandlers["update.hold"]).toBeTypeOf("function");
   });
 
+  it("keeps deprecated restart preflight compatibility read-only and advertised", () => {
+    const methods = listGatewayMethods();
+    const descriptor = createCoreGatewayMethodDescriptors(coreGatewayHandlers).find(
+      (candidate) => candidate.name === "gateway.restart.preflight",
+    );
+
+    expect(methods).toContain("gateway.restart.preflight");
+    expect(methods.indexOf("gateway.restart.preflight")).toBe(
+      methods.indexOf("gateway.restart.request") - 1,
+    );
+    expect(coreGatewayHandlers["gateway.restart.preflight"]).toBeTypeOf("function");
+    expect(descriptor).toMatchObject({
+      name: "gateway.restart.preflight",
+      scope: "operator.read",
+      since: "<=2026.7",
+    });
+    expect(descriptor?.controlPlaneWrite).toBeUndefined();
+  });
+
   it("does not advertise hidden core handlers", () => {
     const methods = listGatewayMethods();
     expect(methods).not.toContain("config.openFile");

--- a/src/gateway/server-methods/restart.test.ts
+++ b/src/gateway/server-methods/restart.test.ts
@@ -1,5 +1,5 @@
-// Restart method tests cover safe restart scheduling, deferral flags, and
-// response payloads returned by gateway.restart.request.
+// Restart method tests cover the read-only compatibility preview plus safe
+// restart scheduling, deferral flags, and request response payloads.
 
 import { expectDefined } from "@openclaw/normalization-core";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
@@ -7,10 +7,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { restartHandlers } from "./restart.js";
 
 const requestSafeGatewayRestart = vi.hoisted(() => vi.fn());
+const createSafeGatewayRestartPreflight = vi.hoisted(() => vi.fn());
 const requestGatewayRestartWithSignalAdmission = vi.hoisted(() => vi.fn());
 const readActiveGatewayLockIdentity = vi.hoisted(() => vi.fn());
 
 vi.mock("../../infra/restart-coordinator.js", () => ({
+  createSafeGatewayRestartPreflight: () => createSafeGatewayRestartPreflight(),
   requestSafeGatewayRestart: (opts: unknown) => requestSafeGatewayRestart(opts),
 }));
 
@@ -34,6 +36,20 @@ function invokeRestartRequest(params: unknown) {
       respond,
       params,
       // The handler only reads `params` and `respond`; remaining fields are unused.
+    } as unknown as Parameters<typeof handler>[0]),
+  ).then(() => respond);
+}
+
+function invokeRestartPreflight() {
+  const respond = vi.fn();
+  const handler = expectDefined(
+    restartHandlers["gateway.restart.preflight"],
+    'restartHandlers["gateway.restart.preflight"] test invariant',
+  );
+  return Promise.resolve(
+    handler({
+      respond,
+      params: {},
     } as unknown as Parameters<typeof handler>[0]),
   ).then(() => respond);
 }
@@ -63,9 +79,10 @@ function expectRestartRequest(skipDeferral: boolean) {
   });
 }
 
-describe("gateway.restart.request handler", () => {
+describe("gateway restart handlers", () => {
   beforeEach(() => {
     requestSafeGatewayRestart.mockClear();
+    createSafeGatewayRestartPreflight.mockReset();
     requestGatewayRestartWithSignalAdmission.mockReset();
     requestGatewayRestartWithSignalAdmission.mockReturnValue({ status: "emitted" });
     readActiveGatewayLockIdentity.mockReset();
@@ -75,6 +92,31 @@ describe("gateway.restart.request handler", () => {
       createdAt: "2026-07-16T12:00:00.000Z",
       port: 18_789,
     });
+  });
+
+  it("keeps the deprecated read-only preflight response shape", async () => {
+    const preflight = {
+      safe: false,
+      counts: {
+        queueSize: 1,
+        pendingReplies: 2,
+        embeddedRuns: 3,
+        cronRuns: 4,
+        backgroundExecSessions: 5,
+        rootRequests: 6,
+        activeTasks: 7,
+        totalActive: 28,
+      },
+      blockers: [{ kind: "queue", count: 1, message: "1 queued or active operation(s)" }],
+      summary: "restart deferred: 1 queued or active operation(s)",
+    };
+    createSafeGatewayRestartPreflight.mockReturnValueOnce(preflight);
+
+    const respond = await invokeRestartPreflight();
+
+    expect(respond).toHaveBeenCalledWith(true, preflight);
+    expect(requestSafeGatewayRestart).not.toHaveBeenCalled();
+    expect(requestGatewayRestartWithSignalAdmission).not.toHaveBeenCalled();
   });
 
   it("defaults to skipDeferral: false when the param is absent", async () => {

--- a/src/gateway/server-methods/restart.ts
+++ b/src/gateway/server-methods/restart.ts
@@ -3,7 +3,10 @@ import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coerci
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
 import { readActiveGatewayLockIdentity } from "../../infra/gateway-lock.js";
-import { requestSafeGatewayRestart } from "../../infra/restart-coordinator.js";
+import {
+  createSafeGatewayRestartPreflight,
+  requestSafeGatewayRestart,
+} from "../../infra/restart-coordinator.js";
 import type { GatewayRestartIntent } from "../../infra/restart-intent.js";
 import { requestGatewayRestartWithSignalAdmission } from "../../infra/restart.js";
 import type { GatewayRequestHandlers } from "./types.js";
@@ -158,5 +161,10 @@ export const restartHandlers: GatewayRequestHandlers = {
       skipDeferral: normalizeSkipDeferral(params.skipDeferral),
     });
     respond(true, result);
+  },
+  // Deprecated compatibility preview for shipped read-only clients. This is
+  // restart-specific information, not the atomic fence owned by suspend.prepare.
+  "gateway.restart.preflight": async ({ respond }) => {
+    respond(true, createSafeGatewayRestartPreflight());
   },
 };

--- a/src/infra/restart-coordinator.test.ts
+++ b/src/infra/restart-coordinator.test.ts
@@ -4,7 +4,10 @@ import {
   resetGatewayWorkAdmission,
   tryBeginGatewayRootWorkAdmission,
 } from "../process/gateway-work-admission.js";
-import { requestSafeGatewayRestart } from "./restart-coordinator.js";
+import {
+  createSafeGatewayRestartPreflight,
+  requestSafeGatewayRestart,
+} from "./restart-coordinator.js";
 
 const scheduleGatewaySigusr1Restart = vi.hoisted(() => vi.fn());
 
@@ -32,7 +35,7 @@ afterEach(() => {
 describe("safe gateway restart coordinator", () => {
   const requestPreflight = (
     inspect: NonNullable<Parameters<typeof requestSafeGatewayRestart>[0]>["inspect"],
-  ) => requestSafeGatewayRestart({ inspect }).preflight;
+  ) => createSafeGatewayRestartPreflight(inspect);
 
   it("reports safe when no restart blockers are active", () => {
     const preflight = requestPreflight({

--- a/src/infra/restart-coordinator.ts
+++ b/src/infra/restart-coordinator.ts
@@ -55,7 +55,7 @@ export type SafeGatewayRestartRequestResult = {
   restart: ScheduledRestart;
 };
 
-function createSafeGatewayRestartPreflight(
+export function createSafeGatewayRestartPreflight(
   inspectors: Partial<SafeRestartInspectors> = {},
 ): SafeGatewayRestartPreflight {
   const snapshot = createGatewayActiveWorkSnapshot({

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -782,12 +782,19 @@ function writeExecutable(filePath: string, lines: string[]): void {
 
 function writeProtocolDescriptor(
   repo: string,
-  additions: Array<{ name: string; since?: string }> = [],
+  additions: Array<{
+    name: string;
+    since?: string;
+    compatibilityRestored?: boolean;
+  }> = [],
 ): void {
-  const rows = [{ name: "health", since: "2026.7" }, ...additions].map(({ name, since }) => {
-    const sinceProperty = since === undefined ? "" : `, since: ${JSON.stringify(since)}`;
-    return `  { name: ${JSON.stringify(name)}${sinceProperty} },`;
-  });
+  const rows = [{ name: "health", since: "2026.7" }, ...additions].map(
+    ({ name, since, compatibilityRestored }) => {
+      const sinceProperty = since === undefined ? "" : `, since: ${JSON.stringify(since)}`;
+      const compatibilityProperty = compatibilityRestored ? ", compatibilityRestored: true" : "";
+      return `  { name: ${JSON.stringify(name)}${sinceProperty}${compatibilityProperty} },`;
+    },
+  );
   const descriptor = path.join(repo, "src/gateway/methods/core-descriptors.ts");
   mkdirSync(path.dirname(descriptor), { recursive: true });
   writeFileSync(
@@ -827,6 +834,29 @@ function createQaProtocolTopology() {
   writeFileSync(path.join(origin, "main-tip.txt"), "later main tip\n");
   commitProtocolFixture(origin, "advance main");
 
+  runGit(origin, ["checkout", "-q", "-b", "compatibility/restore", mainBase]);
+  writeProtocolDescriptor(origin, [
+    {
+      name: "gateway.restart.preflight",
+      since: "<=2026.7",
+      compatibilityRestored: true,
+    },
+  ]);
+  const compatibilityHead = commitProtocolFixture(origin, "restore compatibility method");
+
+  runGit(origin, ["checkout", "-q", "-b", "compatibility/invalid", mainBase]);
+  writeProtocolDescriptor(origin, [
+    {
+      name: "gateway.restart.invalid",
+      since: "2026.8",
+      compatibilityRestored: true,
+    },
+  ]);
+  const invalidCompatibilityHead = commitProtocolFixture(
+    origin,
+    "mislabel new method as compatibility",
+  );
+
   runGit(origin, ["checkout", "-q", "-b", releaseBranch, mainBase]);
   writeProtocolDescriptor(origin, [{ name: "sessions.releaseOnly" }]);
   const releaseHead = commitProtocolFixture(origin, "add release protocol method");
@@ -848,8 +878,10 @@ function createQaProtocolTopology() {
 
   return {
     checkout,
+    compatibilityHead,
     fakeBin,
     featureHead,
+    invalidCompatibilityHead,
     mainBase,
     mainHead,
     mainReleaseTag,
@@ -6067,6 +6099,24 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       const mainCheck = runProtocolSinceFixture(topology.checkout, topology.mainBase);
       expect(mainCheck.status, `${mainCheck.stdout}${mainCheck.stderr}`).toBe(0);
       expect(mainCheck.stdout).toContain("1 new core method");
+
+      runGit(topology.checkout, ["checkout", "-q", "--detach", topology.compatibilityHead]);
+      const compatibilityCheck = runProtocolSinceFixture(topology.checkout, topology.mainBase);
+      expect(
+        compatibilityCheck.status,
+        `${compatibilityCheck.stdout}${compatibilityCheck.stderr}`,
+      ).toBe(0);
+      expect(compatibilityCheck.stdout).toContain("1 restored compatibility method");
+
+      runGit(topology.checkout, ["checkout", "-q", "--detach", topology.invalidCompatibilityHead]);
+      const invalidCompatibilityCheck = runProtocolSinceFixture(
+        topology.checkout,
+        topology.mainBase,
+      );
+      expect(invalidCompatibilityCheck.status).not.toBe(0);
+      expect(invalidCompatibilityCheck.stderr).toContain(
+        "restored compatibility methods must retain <= vintage metadata",
+      );
 
       runGit(topology.checkout, ["checkout", "-q", "--detach", topology.releaseHead]);
       const releaseCheck = runProtocolSinceFixture(topology.checkout, topology.mainBase);


### PR DESCRIPTION
Related: #121387

## What Problem This Solves

Fixes a compatibility regression where external control-plane clients received `unknown method` for `gateway.restart.preflight` after #121387 removed the RPC on the incorrect premise that it had no production callers. The read-only method shipped in stable OpenClaw starting with v2026.5.4 and remains used by Mission Control, ClawDeckX, and AgentOS.

## Why This Change Was Made

This restores the exact pre-removal RPC name, `operator.read` descriptor, handler, response shape, advertised ordering, and generated Android method enum. The handler reuses the existing restart coordinator snapshot and never schedules a restart.

The restored method is explicitly documented and tested as deprecated compatibility: `gateway.restart.request` remains the canonical restart operation. `gateway.restart.preflight` is only a restart-specific informational preview; unlike `gateway.suspend.prepare`, it does not close admission, create a lease, or establish an atomic full-work fence.

Production/runtime and protocol-tooling code is +72/-12 (net +60), justified by restoring a shipped public RPC contract and adding a general guard for historically versioned compatibility restorations. Tests are +125/-10. Generated/client surface is +1 and protocol docs are +1; release-note context stays in this PR body because the root changelog is release-owned.

## User Impact

Existing external clients can again inspect restart blockers without admin mutation authority or compatibility failures. New integrations should request restarts through `gateway.restart.request` and use `gateway.suspend.prepare` when they need an atomic suspension fence.

## Evidence

- Historical contract proof: present in stable v2026.5.4 and immediately before #121387; removal merge `bab4546b4189b1c16f319f338a7ac4802e259141` deleted the exact descriptor, handler, and Android enum restored here.
- Focused Gateway, registry, scope, coordinator, and native protocol suites: 198/198 passed on Blacksmith Testbox ([run 31434238110](https://github.com/openclaw/openclaw/actions/runs/31434238110)).
- Final rebased Testbox proof: `check:changed`, generated Plugin SDK contract, typechecks, lint, full build, and an isolated real Gateway/WebSocket call passed ([run 31436361228](https://github.com/openclaw/openclaw/actions/runs/31436361228)). The live RPC returned the exact `safe`, eight-field `counts`, `blockers`, and `summary` shape and left `/readyz` healthy.
- Protocol-vintage follow-up: the guard now permits only explicitly marked restorations with historical `<=` metadata, rejects current-train methods mislabeled as restorations, and passed 140/140 focused tests ([run 31439561227](https://github.com/openclaw/openclaw/actions/runs/31439561227)); formatter output was reproduced exactly in [run 31440170864](https://github.com/openclaw/openclaw/actions/runs/31440170864).
- Android protocol generation reproduced the committed enum byte-for-byte.
- Final Codex autoreview: clean, no accepted/actionable findings, confidence 0.99.
