### PR TITLE
fix(release): support frozen validation tooling

### DIFF
--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -1983,6 +1983,12 @@ jobs:
           workflow="openclaw-release-telegram-qa.yml"
           run_id=""
           run_name=""
+          telegram_target_ref="$TARGET_REF"
+          case "$telegram_target_ref" in
+            validation/target-* | refs/heads/validation/target-*)
+              telegram_target_ref="$TARGET_SHA"
+              ;;
+          esac
 
           find_child_runs() {
             RUN_NAME="$run_name" gh api -X GET \
@@ -2035,7 +2041,7 @@ jobs:
               --ref main \
               -f dispatch_id="$dispatch_id" \
               -f expected_trusted_workflow_sha="$expected_trusted_workflow_sha" \
-              -f target_ref="$TARGET_REF" \
+              -f target_ref="$telegram_target_ref" \
               -f target_sha="$TARGET_SHA"
 
             for _ in $(seq 1 60); do

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -1544,7 +1544,7 @@ if [ -n "${OPENCLAW_CLAWHUB_URL:-}" ]; then
   fi
   phase assert-prepublish-requests node \
     "${OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER:-scripts/e2e/lib/clawhub-fixture-server.cjs}" \
-    assert-prepublish-requests "$OPENCLAW_CLAWHUB_URL" "@openclaw/whatsapp" "$candidate_version" "$clawhub_security_mode"
+    assert-prepublish-requests "$OPENCLAW_CLAWHUB_URL" "@openclaw/matrix" "$candidate_version" "$clawhub_security_mode"
 fi
 phase root-managed-vps-cli-usable assert_root_managed_vps_cli_usable
 phase assert-legacy-plugin-dependency-debris-before-doctor assert_legacy_plugin_dependency_debris_before_doctor

--- a/scripts/test-live-gateway-models-docker.sh
+++ b/scripts/test-live-gateway-models-docker.sh
@@ -50,7 +50,11 @@ openclaw_live_link_runtime_tree "$tmp_dir"
 openclaw_live_stage_state_dir "$tmp_dir/.openclaw-state"
 openclaw_live_prepare_staged_config
 cd "$tmp_dir"
-node --import tsx scripts/test-live.mts -- src/gateway/gateway-models.profiles.live.test.ts
+if [[ -f scripts/test-live.mjs ]]; then
+  node scripts/test-live.mjs -- src/gateway/gateway-models.profiles.live.test.ts
+else
+  node --import tsx scripts/test-live.mts -- src/gateway/gateway-models.profiles.live.test.ts
+fi
 EOF
 
 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$ROOT_DIR" "$TRUSTED_HARNESS_DIR/scripts/test-live-build-docker.sh"

--- a/scripts/test-live-models-docker.sh
+++ b/scripts/test-live-models-docker.sh
@@ -64,7 +64,11 @@ openclaw_live_link_runtime_tree "$tmp_dir"
 openclaw_live_stage_state_dir "$tmp_dir/.openclaw-state"
 openclaw_live_prepare_staged_config
 cd "$tmp_dir"
-node --import tsx scripts/test-live.mts -- src/agents/models.profiles.live.test.ts
+if [[ -f scripts/test-live.mjs ]]; then
+  node scripts/test-live.mjs -- src/agents/models.profiles.live.test.ts
+else
+  node --import tsx scripts/test-live.mts -- src/agents/models.profiles.live.test.ts
+fi
 EOF
 
 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$ROOT_DIR" "$TRUSTED_HARNESS_DIR/scripts/test-live-build-docker.sh"

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -7002,6 +7002,21 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     },
   );
 
+  it("pins transient validation refs before trusted Telegram QA dispatch", () => {
+    const releaseWorkflow = readReleaseChecksWorkflow();
+    const dispatchStep = releaseWorkflow.jobs.qa_live_telegram_release_checks.steps.find(
+      (step: WorkflowStep) => step.name === "Dispatch and await trusted Telegram QA",
+    );
+
+    expect(dispatchStep.env.TARGET_REF).toBe("${{ needs.resolve_target.outputs.ref }}");
+    expect(dispatchStep.env.TARGET_SHA).toBe("${{ needs.resolve_target.outputs.revision }}");
+    expect(dispatchStep.run).toContain('telegram_target_ref="$TARGET_REF"');
+    expect(dispatchStep.run).toContain("validation/target-* | refs/heads/validation/target-*)");
+    expect(dispatchStep.run).toContain('telegram_target_ref="$TARGET_SHA"');
+    expect(dispatchStep.run).toContain('-f target_ref="$telegram_target_ref"');
+    expect(dispatchStep.run).not.toContain("release/* | refs/heads/release/*)");
+  });
+
   it("keeps maturity scorecard release docs opt-in from release checks", () => {
     const releaseWorkflow = readReleaseChecksWorkflow();
     const job = releaseWorkflow.jobs.maturity_scorecard_release_checks;

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2370,6 +2370,9 @@ docker_e2e_docker_run_cmd run demo
       publishedRunner.indexOf("phase assert-prepublish-requests node"),
     );
     expect(publishedRunner).toContain('if [ "$candidate_version" = "2026.6.35" ]; then');
+    expect(publishedRunner).toContain(
+      'assert-prepublish-requests "$OPENCLAW_CLAWHUB_URL" "@openclaw/matrix" "$candidate_version"',
+    );
     expect(publishedRunner).toContain('"$clawhub_security_mode"');
     expect(publishedRunner.indexOf("phase assert-prepublish-requests node")).toBeLessThan(
       publishedRunner.indexOf("phase doctor run_doctor"),
@@ -2476,6 +2479,21 @@ docker_e2e_docker_run_cmd run demo
       encoding: "utf8",
     });
     expect(inner.status, inner.stderr).toBe(0);
+  });
+
+  it("selects the live model test runner shipped by the staged candidate", () => {
+    for (const scriptPath of [
+      "scripts/test-live-gateway-models-docker.sh",
+      "scripts/test-live-models-docker.sh",
+    ]) {
+      const script = readFileSync(scriptPath, "utf8");
+      const legacyRunnerIndex = script.indexOf("node scripts/test-live.mjs --");
+      const currentRunnerIndex = script.indexOf("node --import tsx scripts/test-live.mts --");
+
+      expect(script).toContain("if [[ -f scripts/test-live.mjs ]]; then");
+      expect(legacyRunnerIndex).toBeGreaterThan(-1);
+      expect(currentRunnerIndex).toBeGreaterThan(legacyRunnerIndex);
+    }
   });
 
   it("wraps package-backed scenario OpenClaw CLI calls with the shared timeout helper", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes release validation failures when trusted current tooling validates a frozen release candidate that predates the TypeScript script migration, and when the temporary `validation/target-*` ref is removed before the dispatched Telegram QA workflow resolves it.

The configured-plugin upgrade survivor scenario also asserted a WhatsApp prepublish request even though that scenario installs Matrix.

## Why This Change Was Made

The Docker live-model wrappers now select the entrypoint shipped by the staged candidate: `scripts/test-live.mjs` first, with the current `node --import tsx scripts/test-live.mts` path as fallback.

The upgrade survivor assertion now checks `@openclaw/matrix`. Trusted Telegram QA converts only transient `validation/target-*` refs to the already-validated immutable target SHA; canonical release branches and tags remain unchanged.

This is scoped release tooling repair only. It does not dispatch Full Release Validation, alter the candidate release branch, add retries/timeouts, or weaken assertions.

## User Impact

Release operators can run frozen beta validation through current trusted tooling without stale script paths, mismatched plugin evidence, or a deleted temporary ref breaking Telegram QA.

Production/tooling LOC: +18/-4 (net +14) | Tests: +33/-0

## Evidence

- `node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts` - 191 passed
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` - 115 passed, 2 skipped
- `pnpm format:check --no-error-on-unmatched-pattern -- <six changed files>` - passed
- `bash -n` for all three changed shell scripts - passed
- YAML parse for `.github/workflows/openclaw-release-checks.yml` - passed
- `git diff --check` - passed
- Local autoreview - clean, no accepted/actionable findings
- Changed-file Testbox run: all guards through formatting, dependency pins, package patches, and temp-state checks passed. The test-root typecheck then hit two pre-existing errors in untouched `test/scripts/package-acceptance-workflow.test.ts` at lines 6252 and 6370 on the frozen base. Run: https://github.com/openclaw/openclaw/actions/runs/31441467120
