### PR TITLE
feat(plugin-sdk): add prepared cancellable OAuth refresh hooks

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"81edf86f9ac989d2c85a531a271396c8ca553bd40f80a3e93903b3cf34385146","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}
+{"contentHash":"660a672ba452602e9f5c9df96caf8d08bee759be915646593e9dbec2f2591344","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
@@ -1,1 +1,1 @@
-{"contentHash":"1bb99b68596361bc2ef9f1c8011f1d87fbbdc78d0bde58d9e89625a5e2bf2de7","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
+{"contentHash":"3394f8aa685eaccf622236bebfb9d32dab3be9f1e73ff89978adc7e430d5d981","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-core.json
@@ -1,1 +1,1 @@
-{"contentHash":"6c638b1fcf5a1cadce5a5363ae4cd8f29fe513feb90331272349ef5bf70bc63a","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}
+{"contentHash":"7605b46a92d6b53ff65ef902f6760e5119a2d98b870dde42f30cfae643be56d5","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
@@ -1,1 +1,1 @@
-{"contentHash":"fa4140b50658ecfab11c323c24ba6f0fe0a5cb1608c8fa3e8eefa3e4e4192e77","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}
+{"contentHash":"951adff8ae0ae986eab493109a6c7d7bb3b577f86fc744d262e003c2eda9db55","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-message.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-message.json
@@ -1,1 +1,1 @@
-{"contentHash":"5c1b1998403a8527055fff05caa86f51ccd981c08ebd8ba8c7f9da19a8e16e33","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}
+{"contentHash":"ee077917e8d683d72daeb2fe2bd0ac22e217edf3e82e15f475a7c2bc9b973f14","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"751d37b918948737d4324f6323e1f8f6151f991d55c3794e1908f79225745fc7","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}
+{"contentHash":"2b3d290a7e5e706ab44a268a38240e081a54d46bf2aeb46dc7a698d057b636d3","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
@@ -1,1 +1,1 @@
-{"contentHash":"87d04d89c9a3b50fc63ea3da73e04bf4f6e5ce5738cfe1be11d4023aa680ec78","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}
+{"contentHash":"c48e339d952668f6fc8118bb2825702a6a89b9e3ec5630020bfcdb3597282cdf","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}

--- a/docs/.generated/plugin-sdk-api-baseline/core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/core.json
@@ -1,1 +1,1 @@
-{"contentHash":"2c95ec54b192b730e9a9c606f77e66a2d0dd9eb09dd66a3c6ad8fea9fca31585","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}
+{"contentHash":"24393bb4ee4c7387ad9dd9e5161570f9679321e13b92835e6039cc0468082ce8","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}

--- a/docs/.generated/plugin-sdk-api-baseline/discord.json
+++ b/docs/.generated/plugin-sdk-api-baseline/discord.json
@@ -1,1 +1,1 @@
-{"contentHash":"d2051c433956de7d579b91d4e21e39d48334e63a632baf941bde0cef85ca8ac0","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}
+{"contentHash":"b858f5daeb5bba63da26a1a9919bfc92c69f233de1938e796614ef2774a1deab","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}

--- a/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
+++ b/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
@@ -1,1 +1,1 @@
-{"contentHash":"a9e35fd79c8ba80ca1de7760b0b83a243a383bffbda1730818e5dec2a049ddce","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}
+{"contentHash":"37cede04d32b53b99fdab0be8dcb3088ced37626a446ac8deb348c193e9a9f4f","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}

--- a/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"3ba67320fb902e12fdf2399c4d8e74403e78e74add8dfed8213154f4ab68a858","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}
+{"contentHash":"d4ca42b531260e631847da6a6c7e63d5272ba34814e5728d2bcd86976392b9b8","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
@@ -1,1 +1,1 @@
-{"contentHash":"ca3136e446cf1fc294279e24078e3a4c6342a048b00f8012d519903c887ef3a7","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}
+{"contentHash":"435e4acba82daca9f193a36c291142988214ee21c98ee25aa6218d8dff4a7552","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"5f0b7be43fcb5e2240053e7ada316b35f28cbcdd0619b724463627961927dcb9","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}
+{"contentHash":"c4913579137efed5ad3f77f1b6efe0097c429aed495cd80cd4d6b3cd6588ae2d","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-auth.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-auth.json
@@ -1,1 +1,1 @@
-{"contentHash":"a82f45bdc59736c09a6124e788bae6a54b6d28c19dafde34458445f81ada3b74","entrypoint":"provider-auth","importSpecifier":"openclaw/plugin-sdk/provider-auth"}
+{"contentHash":"8a3d673e08607ab482ec7278379b973d65fd73ce07b0012d427f8b3034a53a8e","entrypoint":"provider-auth","importSpecifier":"openclaw/plugin-sdk/provider-auth"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"5c9f0b8207f962f9c32228970abe15c23de32c08a00e3d42cbdf5fecbd4c1f1e","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
+{"contentHash":"f8a0ea42f6026c627b287e2036db03f6c75c43034512c5c84ed0cc2d1a246724","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
+++ b/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
@@ -1,1 +1,1 @@
-{"contentHash":"018adbdc87ee4a490fdea45b3ee249a55dca337d655cad8929e63986f4e633bb","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}
+{"contentHash":"442f373bb35bb61bdc434cbc1be8797313a17a281ebed825eba7e0a962b69f35","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}

--- a/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
+++ b/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
@@ -1,1 +1,1 @@
-{"contentHash":"1dac77955687176848405413e59d76ea0511e30722eaa32bf3a3cdd44c5a6395","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}
+{"contentHash":"a6ccfda85a7b2869e291c201b3446ad396bd5136ec066d54887ad31f2ffb2fa0","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -716,6 +716,16 @@ catalog, API-key auth, and dynamic model resolution.
       | `validateReplayTurns` | Strict replay-turn validation before the embedded runner |
       | `onModelSelected` | Post-selection callback (e.g. telemetry) |
 
+      OAuth refresh ownership is prepared before OpenClaw enters refresh queues
+      and storage locks. `OAuthProviderInterface.prepareRefreshToken()` can bind
+      a process-stable provider handle once; its returned function and
+      `ProviderPlugin.refreshOAuth` receive
+      `ProviderOAuthRefreshContext.signal`. Forward that signal to token HTTP
+      I/O so caller cancellation can abort cooperative work while the serialized
+      owner retains any late completion long enough to persist rotated tokens.
+      `hasOAuthTokenMaterialChanged()` compares only `access`, `refresh`, and
+      `expires`; identity or other metadata changes do not count as token rotation.
+
       Runtime fallback notes:
 
       - `normalizeConfig` resolves one owning plugin per provider id (bundled providers first, then the matched runtime plugin) and calls only that hook - there is no scan across other providers. Google's own `normalizeConfig` hook is what normalizes `google` / `google-vertex` / `google-antigravity` config entries; it is not a separate core fallback.

--- a/extensions/chutes/oauth.test.ts
+++ b/extensions/chutes/oauth.test.ts
@@ -410,6 +410,22 @@ describe("chutes plugin OAuth", () => {
     expect(timeoutSpy).toHaveBeenCalledOnce();
   });
 
+  it("combines caller cancellation with the refresh deadline", async () => {
+    const controller = new AbortController();
+    const fetchFn = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => await rejectWhenAborted(init),
+    );
+    const refresh = refreshChutesOAuthCredential(createStoredCredential(), {
+      fetchFn,
+      signal: controller.signal,
+    });
+    const reason = new Error("cancelled by refresh owner");
+    controller.abort(reason);
+
+    await expect(refresh).rejects.toBe(reason);
+    expect(fetchFn).toHaveBeenCalledOnce();
+  });
+
   it("falls back to CHUTES_CLIENT_ID when the credential has no client id", async () => {
     vi.stubEnv("CHUTES_CLIENT_ID", "cid_env");
     const fetchFn = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {

--- a/extensions/chutes/oauth.ts
+++ b/extensions/chutes/oauth.ts
@@ -233,7 +233,7 @@ async function exchangeChutesCodeForTokens(params: {
 /** Refreshes a stored Chutes OAuth credential through the provider token endpoint. */
 export async function refreshChutesOAuthCredential(
   credential: OAuthCredential,
-  options: { fetchFn?: typeof fetch; now?: number } = {},
+  options: { fetchFn?: typeof fetch; now?: number; signal?: AbortSignal } = {},
 ): Promise<OAuthCredential> {
   const refreshToken = normalizeOptionalString(credential.refresh);
   if (!refreshToken) {
@@ -259,6 +259,7 @@ export async function refreshChutesOAuthCredential(
     responseLabel: "Chutes token refresh",
     fetchFn: options.fetchFn,
     now: options.now,
+    ...(options.signal ? { signal: options.signal } : {}),
   });
 
   return {

--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
@@ -29,7 +29,7 @@ import {
   resolveOpenAICallbackHost,
   resolveOpenAIRedirectUri,
 } from "./openai-chatgpt-oauth-authorization.runtime.js";
-import { loginOpenAICodex } from "./openai-chatgpt-oauth-flow.runtime.js";
+import { loginOpenAICodex, refreshOpenAICodexToken } from "./openai-chatgpt-oauth-flow.runtime.js";
 import {
   exchangeOpenAIAuthorizationCode,
   refreshOpenAIAccessToken,
@@ -338,6 +338,16 @@ describe("OpenAI Codex OAuth flow", () => {
     });
   });
 
+  it("forwards caller cancellation through the refresh wrapper", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      refreshOpenAICodexToken("old-refresh-token", { signal: controller.signal }),
+    ).rejects.toThrow("Login cancelled");
+    expect(ssrfMocks.fetchWithSsrFGuard).not.toHaveBeenCalled();
+  });
+
   it("rejects unsafe token exchange lifetimes", async () => {
     mockTokenResponseText(
       '{"access_token":"access-token","refresh_token":"refresh-token","expires_in":1e309}',
@@ -385,6 +395,42 @@ describe("OpenAI Codex OAuth flow", () => {
     expect(result).toEqual({
       type: "failed",
       message: "OpenAI Codex token refresh response missing fields: expires_in",
+    });
+  });
+
+  it("preserves the input refresh token when OpenAI omits a replacement", async () => {
+    mockTokenResponse({
+      access_token: "new-access-token",
+      expires_in: 3600,
+    });
+
+    await expect(refreshOpenAIAccessToken("old-refresh-token")).resolves.toMatchObject({
+      type: "success",
+      access: "new-access-token",
+      refresh: "old-refresh-token",
+    });
+  });
+
+  it("reports only fields still missing after refresh-token fallback", async () => {
+    mockTokenResponse({ expires_in: 3600 });
+
+    await expect(refreshOpenAIAccessToken("old-refresh-token")).resolves.toEqual({
+      type: "failed",
+      message: "OpenAI Codex token refresh response missing fields: access_token",
+    });
+  });
+
+  it("uses a rotated refresh token when OpenAI returns one", async () => {
+    mockTokenResponse({
+      access_token: "new-access-token",
+      refresh_token: "rotated-refresh-token",
+      expires_in: 3600,
+    });
+
+    await expect(refreshOpenAIAccessToken("old-refresh-token")).resolves.toMatchObject({
+      type: "success",
+      access: "new-access-token",
+      refresh: "rotated-refresh-token",
     });
   });
 });

--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
@@ -15,6 +15,7 @@ import {
   withOAuthLoginAbort,
   type OAuthCredentials,
   type OAuthPrompt,
+  type ProviderOAuthRefreshContext,
 } from "openclaw/plugin-sdk/provider-oauth-runtime";
 import { resolveCodexAuthIdentity } from "./openai-chatgpt-auth-identity.js";
 import {
@@ -301,6 +302,11 @@ export async function loginOpenAICodex(options: {
 /**
  * Refresh OpenAI Codex OAuth token
  */
-export async function refreshOpenAICodexToken(refreshToken: string): Promise<OAuthCredentials> {
-  return resolveOpenAICredentials(await refreshOpenAIAccessToken(refreshToken));
+export async function refreshOpenAICodexToken(
+  refreshToken: string,
+  context: ProviderOAuthRefreshContext = {},
+): Promise<OAuthCredentials> {
+  return resolveOpenAICredentials(
+    await refreshOpenAIAccessToken(refreshToken, { signal: context.signal }),
+  );
 }

--- a/extensions/openai/openai-chatgpt-oauth-token.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth-token.runtime.ts
@@ -30,12 +30,15 @@ type TokenRequestOptions = {
   timeoutMs?: number;
 };
 
-function formatMissingTokenResponseFields(json: TokenResponseJson): string {
+function formatMissingTokenResponseFields(
+  json: TokenResponseJson,
+  fallbackRefreshToken?: string,
+): string {
   const missing: string[] = [];
   if (!json.access_token) {
     missing.push("access_token");
   }
-  if (!json.refresh_token) {
+  if (!json.refresh_token && !fallbackRefreshToken) {
     missing.push("refresh_token");
   }
   if (resolveOAuthTokenLifetimeMs(json.expires_in) === undefined) {
@@ -103,6 +106,7 @@ async function postTokenForm(
 async function readOpenAITokenResponse(
   response: Response,
   operation: "exchange" | "refresh",
+  fallbackRefreshToken?: string,
 ): Promise<TokenResult> {
   if (!response.ok) {
     const text = await response.text().catch(() => "");
@@ -120,16 +124,17 @@ async function readOpenAITokenResponse(
     };
   }
   const expires = resolveOAuthTokenExpiresAt(json.expires_in);
-  if (!json.access_token || !json.refresh_token || expires === undefined) {
+  const refresh = json.refresh_token || fallbackRefreshToken;
+  if (!json.access_token || !refresh || expires === undefined) {
     return {
       type: "failed",
-      message: `OpenAI Codex token ${operation} response missing fields: ${formatMissingTokenResponseFields(json)}`,
+      message: `OpenAI Codex token ${operation} response missing fields: ${formatMissingTokenResponseFields(json, fallbackRefreshToken)}`,
     };
   }
   return {
     type: "success",
     access: json.access_token,
-    refresh: json.refresh_token,
+    refresh,
     expires,
   };
 }
@@ -176,7 +181,7 @@ export async function refreshOpenAIAccessToken(
       }),
       { signal: options.signal, timeoutMs },
     );
-    return await readOpenAITokenResponse(response, "refresh");
+    return await readOpenAITokenResponse(response, "refresh", refreshToken);
   } catch (error) {
     return {
       type: "failed",

--- a/extensions/openai/openai-chatgpt-provider.test.ts
+++ b/extensions/openai/openai-chatgpt-provider.test.ts
@@ -3,10 +3,12 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const refreshOpenAICodexTokenMock = vi.hoisted(() => vi.fn());
 const loginOpenAICodexDeviceCodeMock = vi.hoisted(() => vi.fn());
+const refreshRuntimeLoadedMock = vi.hoisted(() => vi.fn());
 
-vi.mock("./openai-chatgpt-provider.runtime.js", () => ({
-  refreshOpenAICodexToken: refreshOpenAICodexTokenMock,
-}));
+vi.mock("./openai-chatgpt-provider.runtime.js", () => {
+  refreshRuntimeLoadedMock();
+  return { refreshOpenAICodexToken: refreshOpenAICodexTokenMock };
+});
 
 vi.mock("./openai-chatgpt-device-code.js", () => ({
   loginOpenAICodexDeviceCode: loginOpenAICodexDeviceCodeMock,
@@ -31,6 +33,7 @@ describe("OpenAI provider Codex transport hooks", () => {
   it("exposes ChatGPT OAuth on the canonical OpenAI provider", () => {
     const provider = buildOpenAIProvider();
 
+    expect(refreshRuntimeLoadedMock).not.toHaveBeenCalled();
     expect(provider.id).toBe("openai");
     expect(provider.aliases).toBeUndefined();
     expect(provider.hookAliases).toEqual(["azure-openai", "azure-openai-responses"]);
@@ -295,6 +298,7 @@ describe("OpenAI provider Codex transport hooks", () => {
 
   it("refreshes ChatGPT OAuth credentials under the OpenAI provider", async () => {
     const provider = buildOpenAIProvider();
+    const controller = new AbortController();
     refreshOpenAICodexTokenMock.mockResolvedValueOnce({
       access: "new-access",
       refresh: "new-refresh",
@@ -302,18 +306,25 @@ describe("OpenAI provider Codex transport hooks", () => {
     });
 
     await expect(
-      provider.refreshOAuth?.({
-        type: "oauth",
-        provider: "openai",
-        access: "old-access",
-        refresh: "old-refresh",
-        expires: Date.now() - 60_000,
-      }),
+      provider.refreshOAuth?.(
+        {
+          type: "oauth",
+          provider: "openai",
+          access: "old-access",
+          refresh: "old-refresh",
+          expires: Date.now() - 60_000,
+        },
+        { signal: controller.signal },
+      ),
     ).resolves.toMatchObject({
       type: "oauth",
       provider: "openai",
       access: "new-access",
       refresh: "new-refresh",
     });
+    expect(refreshOpenAICodexTokenMock).toHaveBeenCalledWith("old-refresh", {
+      signal: controller.signal,
+    });
+    expect(refreshRuntimeLoadedMock).toHaveBeenCalledOnce();
   });
 });

--- a/extensions/openai/openai-chatgpt-provider.ts
+++ b/extensions/openai/openai-chatgpt-provider.ts
@@ -15,6 +15,7 @@ import {
   normalizeProviderId,
   type ProviderPlugin,
 } from "openclaw/plugin-sdk/provider-model-shared";
+import type { ProviderOAuthRefreshContext } from "openclaw/plugin-sdk/provider-oauth-runtime";
 import {
   normalizeLowercaseStringOrEmpty,
   readStringValue,
@@ -437,10 +438,13 @@ function buildOpenAICodexAuthConfigPatch(): NonNullable<ProviderAuthResult["conf
   };
 }
 
-async function refreshOpenAICodexOAuthCredential(cred: OAuthCredential) {
+async function refreshOpenAICodexOAuthCredential(
+  cred: OAuthCredential,
+  context?: ProviderOAuthRefreshContext,
+) {
   try {
     const { refreshOpenAICodexToken } = await import("./openai-chatgpt-provider.runtime.js");
-    const refreshed = await refreshOpenAICodexToken(cred.refresh);
+    const refreshed = await refreshOpenAICodexToken(cred.refresh, context);
     const identity = resolveCodexAuthIdentity({
       accessToken: refreshed.access,
       email: cred.email,
@@ -679,7 +683,7 @@ export function buildOpenAICodexProviderHooks(): Pick<
     },
     resolveUsageAuth: resolveOpenAIUsageAuth,
     fetchUsageSnapshot: fetchOpenAIUsage,
-    refreshOAuth: async (cred) => await refreshOpenAICodexOAuthCredential(cred),
+    refreshOAuth: refreshOpenAICodexOAuthCredential,
     augmentModelCatalog: (ctx) => {
       const gpt54Template = findCatalogTemplate({
         entries: ctx.entries,

--- a/extensions/xai/xai-oauth-entry.ts
+++ b/extensions/xai/xai-oauth-entry.ts
@@ -1,5 +1,5 @@
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
-import type { ProviderAuthMethod } from "openclaw/plugin-sdk/plugin-entry";
+import type { ProviderAuthMethod, ProviderPlugin } from "openclaw/plugin-sdk/plugin-entry";
 import type { OAuthCredential } from "openclaw/plugin-sdk/provider-auth";
 
 const PROVIDER_ID = "xai";
@@ -50,7 +50,7 @@ export function createXaiDeviceCodeAuthMethod(): ProviderAuthMethod {
 }
 
 export async function refreshXaiOAuthCredential(
-  credential: OAuthCredential,
+  ...args: Parameters<NonNullable<ProviderPlugin["refreshOAuth"]>>
 ): Promise<OAuthCredential> {
-  return await (await loadXaiOAuthRuntime()).refreshXaiOAuthCredential(credential);
+  return await (await loadXaiOAuthRuntime()).refreshXaiOAuthCredential(...args);
 }

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -274,7 +274,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: QQBot 2.0.1 operator-approval Gateway client compatibility export.
       // +2: narrow channel agent-run terminal reader and outcome contract.
       // +5: narrow string, record, and error coercion helpers.
-      4878,
+      // +1: canonical OAuth token-material comparator for provider auth bridges.
+      4879,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -340,7 +341,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: QQBot 2.0.1 operator-approval Gateway client compatibility export.
       // +1: narrow channel agent-run terminal reader.
       // +5: narrow string, record, and error coercion helpers.
-      2931,
+      // +1: canonical OAuth token-material comparator for provider auth bridges.
+      2932,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/auth-profiles/oauth-common-mocks.test-support.ts
+++ b/src/agents/auth-profiles/oauth-common-mocks.test-support.ts
@@ -9,7 +9,7 @@ import type { OAuthCredential } from "./types.js";
 const oauthProviderRuntimeMocks = vi.hoisted(() => {
   vi.resetModules();
   return {
-    refreshProviderOAuthCredentialWithPluginMock: vi.fn<
+    resolveProviderOAuthCredentialWithPluginMock: vi.fn<
       (_params?: { context?: unknown }) => Promise<OAuthCredential | undefined>
     >(async () => undefined),
     formatProviderAuthProfileApiKeyWithPluginMock: vi.fn(() => undefined),
@@ -29,11 +29,15 @@ vi.mock("../cli-credentials.js", () => ({
 }));
 
 vi.mock("../../plugins/provider-runtime.runtime.js", () => ({
+  resolveProviderRuntimePluginHandle: async (params: object) => ({
+    ...params,
+    plugin: { refreshOAuth: () => undefined },
+  }),
   formatProviderAuthProfileApiKeyWithPlugin: (params: { context?: { access?: string } }) =>
     oauthProviderRuntimeMocks.formatProviderAuthProfileApiKeyWithPluginMock() ??
     params?.context?.access,
   resolveProviderOAuthCredentialWithPlugin: async (params: { credential: OAuthCredential }) => {
-    const credential = await oauthProviderRuntimeMocks.refreshProviderOAuthCredentialWithPluginMock(
+    const credential = await oauthProviderRuntimeMocks.resolveProviderOAuthCredentialWithPluginMock(
       { context: params.credential },
     );
     return credential

--- a/src/agents/auth-profiles/oauth-file-lock-passthrough.test-support.ts
+++ b/src/agents/auth-profiles/oauth-file-lock-passthrough.test-support.ts
@@ -7,6 +7,7 @@ import { afterAll, vi } from "vitest";
 
 const fileLockPassthroughMock = vi.hoisted(() => ({
   drainFileLockStateForTest: async () => undefined,
+  FILE_LOCK_TIMEOUT_ERROR_CODE: "file_lock_timeout",
   resetFileLockStateForTest: () => undefined,
   withFileLock: async <T>(_filePath: string, _options: unknown, run: () => Promise<T>) => run(),
 }));

--- a/src/agents/auth-profiles/oauth-manager.test.ts
+++ b/src/agents/auth-profiles/oauth-manager.test.ts
@@ -10,6 +10,7 @@ import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coerc
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { testing as externalAuthTesting } from "./external-auth.test-support.js";
 import { createOAuthManager, OAuthManagerRefreshError } from "./oauth-manager.js";
@@ -885,7 +886,7 @@ describe("createOAuthManager", () => {
       saveAuthProfileStore({ version: 1, profiles: { [profileId]: credential } }, agentDir, {
         filterExternalAuthProfiles: false,
       });
-      const stalled = Promise.withResolvers<OAuthCredentials>();
+      const stalled = createDeferredCore<OAuthCredentials>();
       const refreshCredential = vi.fn(async () => await stalled.promise);
       const manager = createOAuthManager({
         buildApiKey: async (_provider, value) => value.access,
@@ -929,7 +930,7 @@ describe("createOAuthManager", () => {
       saveAuthProfileStore({ version: 1, profiles: { [profileId]: credential } }, agentDir, {
         filterExternalAuthProfiles: false,
       });
-      const stalled = Promise.withResolvers<OAuthCredentials>();
+      const stalled = createDeferredCore<OAuthCredentials>();
       const refreshCredential = vi.fn(async () => await stalled.promise);
       const prepareRefreshCall = vi.fn(async () => refreshCredential);
       const manager = createOAuthManager({

--- a/src/agents/auth-profiles/oauth-refresh-queue.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-queue.test.ts
@@ -6,6 +6,7 @@
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetFileLockStateForTest } from "../../infra/file-lock.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { captureEnv } from "../../test-utils/env.js";
 import { getOAuthProviderRuntimeMocks } from "./oauth-common-mocks.test-support.js";
 import "./oauth-external-auth-passthrough.test-support.js";
@@ -23,9 +24,10 @@ import { resolveApiKeyForProfile } from "./oauth.js";
 import { resetOAuthRefreshQueuesForTest } from "./oauth.test-support.js";
 import { clearRuntimeAuthProfileStoreSnapshots } from "./runtime-snapshots.js";
 import { ensureAuthProfileStore, saveAuthProfileStore } from "./store.js";
+import type { OAuthCredential } from "./types.js";
 
 const {
-  refreshProviderOAuthCredentialWithPluginMock,
+  resolveProviderOAuthCredentialWithPluginMock,
   formatProviderAuthProfileApiKeyWithPluginMock,
 } = getOAuthProviderRuntimeMocks();
 
@@ -47,7 +49,7 @@ describe("OAuth refresh in-process queue", () => {
   beforeEach(async () => {
     resetFileLockStateForTest();
     resetOAuthProviderRuntimeMocks({
-      refreshProviderOAuthCredentialWithPluginMock,
+      resolveProviderOAuthCredentialWithPluginMock,
       formatProviderAuthProfileApiKeyWithPluginMock,
     });
     clearRuntimeAuthProfileStoreSnapshots();
@@ -73,7 +75,7 @@ describe("OAuth refresh in-process queue", () => {
     saveAuthProfileStore(createExpiredOauthStore({ profileId, provider }), agentDir);
 
     let callCount = 0;
-    refreshProviderOAuthCredentialWithPluginMock.mockImplementation(async () => {
+    resolveProviderOAuthCredentialWithPluginMock.mockImplementation(async () => {
       callCount += 1;
       if (callCount === 1) {
         throw new Error("simulated upstream failure");
@@ -126,7 +128,7 @@ describe("OAuth refresh in-process queue", () => {
     let inFlight = 0;
     let maxInFlight = 0;
     let seq = 0;
-    refreshProviderOAuthCredentialWithPluginMock.mockImplementation(async () => {
+    resolveProviderOAuthCredentialWithPluginMock.mockImplementation(async () => {
       const n = ++seq;
       startOrder.push(n);
       inFlight += 1;
@@ -165,5 +167,55 @@ describe("OAuth refresh in-process queue", () => {
     expect(startOrder).toEqual(endOrder);
     // At no point did two refresh calls run concurrently.
     expect(maxInFlight).toBe(1);
+  });
+
+  it("rejects a queued provider replacement before invoking the stale prepared provider", async () => {
+    const profileId = "shared:default";
+    const initialProvider = "provider-a";
+    saveAuthProfileStore(
+      createExpiredOauthStore({ profileId, provider: initialProvider }),
+      agentDir,
+    );
+    const firstRefresh = createDeferredCore<OAuthCredential>();
+    resolveProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+      async () => await firstRefresh.promise,
+    );
+
+    const resolve = () =>
+      resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+        store: ensureAuthProfileStore(agentDir),
+        profileId,
+        agentDir,
+      }).catch((error: unknown) => error);
+    const first = resolve();
+    await vi.waitFor(() =>
+      expect(resolveProviderOAuthCredentialWithPluginMock).toHaveBeenCalledOnce(),
+    );
+    const second = resolve();
+    await Promise.resolve();
+    saveAuthProfileStore(createExpiredOauthStore({ profileId, provider: "provider-b" }), agentDir);
+    firstRefresh.resolve({
+      type: "oauth",
+      provider: initialProvider,
+      access: "rotated-access",
+      refresh: "rotated-refresh",
+      expires: Date.now() + 60_000,
+    });
+
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+    expect(firstResult).toBeInstanceOf(Error);
+    expect(secondResult).toMatchObject({
+      reason: "sign_in_again",
+      cause: expect.objectContaining({
+        cause: expect.objectContaining({
+          message: "OAuth provider changed while waiting to refresh; sign in again",
+        }),
+      }),
+    });
+    expect(resolveProviderOAuthCredentialWithPluginMock).toHaveBeenCalledOnce();
+    expect(ensureAuthProfileStore(agentDir).profiles[profileId]).toMatchObject({
+      type: "oauth",
+      provider: "provider-b",
+    });
   });
 });

--- a/src/agents/auth-profiles/oauth-test-utils.ts
+++ b/src/agents/auth-profiles/oauth-test-utils.ts
@@ -106,11 +106,11 @@ type ReturnValueMock = ResettableMock & {
 
 /** Reset provider-runtime OAuth mocks to default no-op behavior. */
 export function resetOAuthProviderRuntimeMocks(mocks: {
-  refreshProviderOAuthCredentialWithPluginMock: ResolvedValueMock;
+  resolveProviderOAuthCredentialWithPluginMock: ResolvedValueMock;
   formatProviderAuthProfileApiKeyWithPluginMock: ReturnValueMock;
 }): void {
-  mocks.refreshProviderOAuthCredentialWithPluginMock.mockReset();
-  mocks.refreshProviderOAuthCredentialWithPluginMock.mockResolvedValue(undefined);
+  mocks.resolveProviderOAuthCredentialWithPluginMock.mockReset();
+  mocks.resolveProviderOAuthCredentialWithPluginMock.mockResolvedValue(undefined);
   mocks.formatProviderAuthProfileApiKeyWithPluginMock.mockReset();
   mocks.formatProviderAuthProfileApiKeyWithPluginMock.mockReturnValue(undefined);
 }

--- a/src/agents/auth-profiles/oauth.adopt-identity.test.ts
+++ b/src/agents/auth-profiles/oauth.adopt-identity.test.ts
@@ -30,7 +30,7 @@ import { ensureAuthProfileStore, saveAuthProfileStore } from "./store.js";
 import type { AuthProfileStore } from "./types.js";
 
 const {
-  refreshProviderOAuthCredentialWithPluginMock,
+  resolveProviderOAuthCredentialWithPluginMock,
   formatProviderAuthProfileApiKeyWithPluginMock,
 } = getOAuthProviderRuntimeMocks();
 
@@ -68,7 +68,7 @@ describe("OAuth credential adoption is identity-gated", () => {
   beforeEach(async () => {
     resetFileLockStateForTest();
     resetOAuthProviderRuntimeMocks({
-      refreshProviderOAuthCredentialWithPluginMock,
+      resolveProviderOAuthCredentialWithPluginMock,
       formatProviderAuthProfileApiKeyWithPluginMock,
     });
     clearRuntimeAuthProfileStoreSnapshots();
@@ -188,7 +188,7 @@ describe("OAuth credential adoption is identity-gated", () => {
       mainAgentDir,
     );
 
-    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+    resolveProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
       async () =>
         ({
           type: "oauth",
@@ -208,7 +208,7 @@ describe("OAuth credential adoption is identity-gated", () => {
 
     // Sub-agent performed its own refresh (mock fired once) and got its
     // own new token, not main's foreign one.
-    expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
+    expect(resolveProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
     expect(result?.apiKey).toBe("sub-refreshed-access");
 
     // Main must still hold its foreign cred, untouched (mirror would also
@@ -263,7 +263,7 @@ describe("OAuth credential adoption is identity-gated", () => {
       mainAgentDir,
     );
 
-    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
+    resolveProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
       // Simulate another process writing fresh creds to main for a
       // DIFFERENT account while our refresh is in flight, then our
       // refresh throws a generic upstream error.

--- a/src/agents/auth-profiles/oauth.concurrent-agents.test.ts
+++ b/src/agents/auth-profiles/oauth.concurrent-agents.test.ts
@@ -23,7 +23,7 @@ import { clearRuntimeAuthProfileStoreSnapshots } from "./runtime-snapshots.js";
 import { ensureAuthProfileStore, saveAuthProfileStore } from "./store.js";
 
 const {
-  refreshProviderOAuthCredentialWithPluginMock,
+  resolveProviderOAuthCredentialWithPluginMock,
   formatProviderAuthProfileApiKeyWithPluginMock,
 } = getOAuthProviderRuntimeMocks();
 
@@ -56,7 +56,7 @@ async function runConcurrentRefreshCase(): Promise<ConcurrentRefreshResult> {
   try {
     resetFileLockStateForTest();
     resetOAuthProviderRuntimeMocks({
-      refreshProviderOAuthCredentialWithPluginMock,
+      resolveProviderOAuthCredentialWithPluginMock,
       formatProviderAuthProfileApiKeyWithPluginMock,
     });
     clearRuntimeAuthProfileStoreSnapshots();
@@ -86,7 +86,7 @@ async function runConcurrentRefreshCase(): Promise<ConcurrentRefreshResult> {
 
     // Count invocations, and keep one event-loop turn to widen the race window.
     let callCount = 0;
-    refreshProviderOAuthCredentialWithPluginMock.mockImplementation(async () => {
+    resolveProviderOAuthCredentialWithPluginMock.mockImplementation(async () => {
       callCount += 1;
       await new Promise((resolve) => {
         setImmediate(resolve);

--- a/src/agents/auth-profiles/oauth.fallback-to-main-agent.test.ts
+++ b/src/agents/auth-profiles/oauth.fallback-to-main-agent.test.ts
@@ -14,19 +14,23 @@ import { resolveApiKeyForProfile } from "./oauth.js";
 import { loadPersistedAuthProfileStore } from "./persisted.js";
 import { clearRuntimeAuthProfileStoreSnapshots } from "./runtime-snapshots.js";
 import { ensureAuthProfileStore, saveAuthProfileStore } from "./store.js";
-import type { AuthProfileStore } from "./types.js";
+import type { AuthProfileStore, OAuthCredential } from "./types.js";
 const { getOAuthApiKeyMock } = vi.hoisted(() => {
   vi.resetModules();
   return {
-    getOAuthApiKeyMock: vi.fn(async () => {
-      throw new Error("invalid_grant");
-    }),
+    getOAuthApiKeyMock: vi.fn(
+      async (_provider: string, _credentials: Record<string, OAuthCredential>) => {
+        throw new Error("invalid_grant");
+      },
+    ),
   };
 });
 
 vi.mock("../../llm/oauth.js", () => ({
   getOAuthApiKey: getOAuthApiKeyMock,
   getOAuthProviders: () => [{ id: "anthropic" }, { id: "openai" }],
+  prepareOAuthApiKey: (provider: string) => (credential: OAuthCredential) =>
+    getOAuthApiKeyMock(provider, { [provider]: credential }),
 }));
 
 vi.mock("../cli-credentials.js", () => ({
@@ -41,6 +45,7 @@ vi.mock("../../plugins/provider-runtime.runtime.js", () => ({
   formatProviderAuthProfileApiKeyWithPlugin: async (params: { context?: { access?: string } }) =>
     params.context?.access,
   resolveProviderOAuthCredentialWithPlugin: async () => ({ status: "unhandled" }),
+  resolveProviderRuntimePluginHandle: async (params: object) => ({ ...params, plugin: undefined }),
 }));
 
 vi.mock("../../plugins/provider-runtime.js", () => ({

--- a/src/agents/auth-profiles/oauth.mirror-refresh.test.ts
+++ b/src/agents/auth-profiles/oauth.mirror-refresh.test.ts
@@ -29,7 +29,7 @@ import { ensureAuthProfileStore, saveAuthProfileStore } from "./store.js";
 import type { AuthProfileStore, OAuthCredential } from "./types.js";
 
 const {
-  refreshProviderOAuthCredentialWithPluginMock,
+  resolveProviderOAuthCredentialWithPluginMock,
   formatProviderAuthProfileApiKeyWithPluginMock,
 } = getOAuthProviderRuntimeMocks();
 
@@ -78,7 +78,7 @@ describe("resolveApiKeyForProfile OAuth refresh mirror-to-main (#26322)", () => 
   beforeEach(async () => {
     resetFileLockStateForTest();
     resetOAuthProviderRuntimeMocks({
-      refreshProviderOAuthCredentialWithPluginMock,
+      resolveProviderOAuthCredentialWithPluginMock,
       formatProviderAuthProfileApiKeyWithPluginMock,
     });
     externalAuthTesting.setResolveExternalAuthProfilesForTest(() => []);
@@ -112,7 +112,7 @@ describe("resolveApiKeyForProfile OAuth refresh mirror-to-main (#26322)", () => 
     saveAuthProfileStore(createExpiredOauthStore({ profileId, provider, accountId }), subAgentDir);
     saveAuthProfileStore(createExpiredOauthStore({ profileId, provider, accountId }), mainAgentDir);
 
-    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+    resolveProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
       async () =>
         ({
           type: "oauth",
@@ -156,7 +156,7 @@ describe("resolveApiKeyForProfile OAuth refresh mirror-to-main (#26322)", () => 
       mainAgentDir,
     );
 
-    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+    resolveProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
       async () =>
         ({
           type: "oauth",
@@ -186,7 +186,7 @@ describe("resolveApiKeyForProfile OAuth refresh mirror-to-main (#26322)", () => 
         expires: freshExpiry,
       },
     );
-    expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
+    expect(resolveProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
   });
 
   it("inherits main-agent credentials via the pre-refresh adopt path when main is already fresher", async () => {
@@ -231,7 +231,7 @@ describe("resolveApiKeyForProfile OAuth refresh mirror-to-main (#26322)", () => 
 
     expect(result?.apiKey).toBe("main-fresh-access");
     expect(result?.provider).toBe(provider);
-    expect(refreshProviderOAuthCredentialWithPluginMock).not.toHaveBeenCalled();
+    expect(resolveProviderOAuthCredentialWithPluginMock).not.toHaveBeenCalled();
   });
 
   it("answers app-server forced refresh from fresh main credentials when a sub-agent copy is expired", async () => {
@@ -284,7 +284,7 @@ describe("resolveApiKeyForProfile OAuth refresh mirror-to-main (#26322)", () => 
 
     expect(result?.apiKey).toBe("main-fresh-access");
     expect(result?.provider).toBe(provider);
-    expect(refreshProviderOAuthCredentialWithPluginMock).not.toHaveBeenCalled();
+    expect(resolveProviderOAuthCredentialWithPluginMock).not.toHaveBeenCalled();
   });
 
   it("refreshes the main owner when a stale local OAuth clone shadows a newer main credential", async () => {
@@ -329,7 +329,7 @@ describe("resolveApiKeyForProfile OAuth refresh mirror-to-main (#26322)", () => 
       mainAgentDir,
     );
 
-    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+    resolveProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
       async (params?: { context?: unknown }) => {
         const credential = params?.context as OAuthCredential | undefined;
         expect(credential?.refresh).toBe("main-owner-refresh");
@@ -348,7 +348,7 @@ describe("resolveApiKeyForProfile OAuth refresh mirror-to-main (#26322)", () => 
     });
 
     expect(result?.apiKey).toBe("main-owner-refreshed-access");
-    expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
+    expect(resolveProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
 
     const subRaw = readAuthProfileStoreForTest(subAgentDir);
     expectPersistedOpenAICodexProfile(
@@ -401,7 +401,7 @@ describe("resolveApiKeyForProfile OAuth refresh mirror-to-main (#26322)", () => 
       mainAgentDir,
     );
 
-    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
+    resolveProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
       // Simulate another agent completing its refresh and writing fresh
       // creds to main, concurrent with our attempt.
       saveAuthProfileStore(
@@ -471,7 +471,7 @@ describe("resolveApiKeyForProfile OAuth refresh mirror-to-main (#26322)", () => 
       mainAgentDir,
     );
 
-    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async (params) => {
+    resolveProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async (params) => {
       const context = params?.context as OAuthCredential;
       expect(context.access).toBe("main-existing-access");
       throw new Error("upstream 503 service unavailable");
@@ -485,7 +485,7 @@ describe("resolveApiKeyForProfile OAuth refresh mirror-to-main (#26322)", () => 
         forceRefresh: true,
       }),
     ).rejects.toThrow(/OAuth token refresh failed for openai/);
-    expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
+    expect(resolveProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
   });
 
   it("mirrors refreshed credentials produced by the plugin-refresh path", async () => {
@@ -503,7 +503,7 @@ describe("resolveApiKeyForProfile OAuth refresh mirror-to-main (#26322)", () => 
 
     // Plugin returns a truthy refreshed credential — this takes the plugin
     // branch instead of falling through to getOAuthApiKey.
-    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+    resolveProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
       async () =>
         ({
           access: "plugin-refreshed-access",

--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -25,14 +25,23 @@ let resolveApiKeyForProfile: typeof import("./oauth.js").resolveApiKeyForProfile
 let resolveApiKeyForProviderCore: typeof import("../model-auth.js").resolveApiKeyForProviderCore;
 let hasAvailableAuthForProvider: typeof import("../model-auth.js").hasAvailableAuthForProvider;
 let markAuthProfileSuccess: typeof import("./profiles.js").markAuthProfileSuccess;
-type GetOAuthApiKey = typeof import("../../llm/oauth.js").getOAuthApiKey;
+type ResolveOAuthApiKey = (
+  provider: string,
+  credential: OAuthCredential,
+) => Promise<{ newCredentials: OAuthCredential; apiKey: string } | null>;
 
-const { getOAuthApiKeyMock } = vi.hoisted(() => {
+const { getOAuthApiKeyMock, prepareOAuthApiKeyMock } = vi.hoisted(() => {
   vi.resetModules();
+  const oauthApiKeyMock = vi.fn<ResolveOAuthApiKey>(async () => {
+    throw new Error("Failed to extract accountId from token");
+  });
   return {
-    getOAuthApiKeyMock: vi.fn<GetOAuthApiKey>(async () => {
-      throw new Error("Failed to extract accountId from token");
-    }),
+    getOAuthApiKeyMock: oauthApiKeyMock,
+    prepareOAuthApiKeyMock: vi.fn(
+      (provider: Parameters<ResolveOAuthApiKey>[0]) =>
+        (credentials: Parameters<ResolveOAuthApiKey>[1]) =>
+          oauthApiKeyMock(provider, credentials),
+    ),
   };
 });
 
@@ -43,13 +52,18 @@ const { readCodexCliCredentialsCachedMock } = vi.hoisted(() => ({
 }));
 
 const {
-  refreshProviderOAuthCredentialWithPluginMock,
+  resolveProviderOAuthCredentialWithPluginMock,
+  providerRuntimeState,
   formatProviderAuthProfileApiKeyWithPluginMock,
   buildProviderAuthDoctorHintWithPluginMock,
 } = vi.hoisted(() => ({
-  refreshProviderOAuthCredentialWithPluginMock: vi.fn(
+  resolveProviderOAuthCredentialWithPluginMock: vi.fn(
     async (_params?: { context?: unknown }): Promise<OAuthCredential | undefined> => undefined,
   ),
+  providerRuntimeState: {
+    configuredUnavailable: false,
+    plugin: {} as { refreshOAuth?: () => Promise<OAuthCredential> } | undefined,
+  },
   formatProviderAuthProfileApiKeyWithPluginMock: vi.fn(() => undefined),
   buildProviderAuthDoctorHintWithPluginMock: vi.fn(async () => undefined),
 }));
@@ -62,16 +76,26 @@ vi.mock("../cli-credentials.js", () => ({
 }));
 
 vi.mock("../../llm/oauth.js", () => ({
-  getOAuthApiKey: getOAuthApiKeyMock,
   getOAuthProviders: () => [
     { id: "openai", envApiKey: "OPENAI_API_KEY", oauthTokenEnv: "OPENAI_OAUTH_TOKEN" }, // pragma: allowlist secret
     { id: "anthropic", envApiKey: "ANTHROPIC_API_KEY", oauthTokenEnv: "ANTHROPIC_OAUTH_TOKEN" }, // pragma: allowlist secret
   ],
+  prepareOAuthApiKey: prepareOAuthApiKeyMock,
 }));
 
 vi.mock("../../plugins/provider-runtime.runtime.js", () => ({
-  resolveProviderOAuthCredentialWithPlugin: async (params: { credential: OAuthCredential }) => {
-    const credential = await refreshProviderOAuthCredentialWithPluginMock({
+  resolveProviderRuntimePluginHandle: async (params: object) => ({
+    ...params,
+    plugin: providerRuntimeState.plugin,
+  }),
+  resolveProviderOAuthCredentialWithPlugin: async (params: {
+    credential: OAuthCredential;
+    refresh: boolean;
+  }) => {
+    if (!params.refresh && providerRuntimeState.configuredUnavailable) {
+      return { status: "configured-unavailable" };
+    }
+    const credential = await resolveProviderOAuthCredentialWithPluginMock({
       context: params.credential,
     });
     return credential
@@ -102,7 +126,7 @@ async function readPersistedStore(agentDir: string): Promise<AuthProfileStore> {
 }
 
 function mockRotatedOpenAICodexRefresh() {
-  refreshProviderOAuthCredentialWithPluginMock.mockResolvedValueOnce({
+  resolveProviderOAuthCredentialWithPluginMock.mockResolvedValueOnce({
     type: "oauth",
     provider: "openai",
     access: "rotated-access-token",
@@ -170,10 +194,16 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
     getOAuthApiKeyMock.mockImplementation(async () => {
       throw new Error("Failed to extract accountId from token");
     });
+    prepareOAuthApiKeyMock.mockReset();
+    prepareOAuthApiKeyMock.mockImplementation(
+      (provider) => (credentials) => getOAuthApiKeyMock(provider, credentials),
+    );
+    providerRuntimeState.configuredUnavailable = false;
+    providerRuntimeState.plugin = {};
     readCodexCliCredentialsCachedMock.mockReset();
     readCodexCliCredentialsCachedMock.mockReturnValue(null);
-    refreshProviderOAuthCredentialWithPluginMock.mockReset();
-    refreshProviderOAuthCredentialWithPluginMock.mockResolvedValue(undefined);
+    resolveProviderOAuthCredentialWithPluginMock.mockReset();
+    resolveProviderOAuthCredentialWithPluginMock.mockResolvedValue(undefined);
     formatProviderAuthProfileApiKeyWithPluginMock.mockReset();
     formatProviderAuthProfileApiKeyWithPluginMock.mockReturnValue(undefined);
     buildProviderAuthDoctorHintWithPluginMock.mockReset();
@@ -226,7 +256,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
         agentDir,
       }),
     ).rejects.toThrow(/OAuth token refresh failed for openai/);
-    expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
+    expect(resolveProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
   });
 
   it("fails closed when provider refresh returns an unchanged expired credential", async () => {
@@ -239,14 +269,14 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       agentDir,
       { filterExternalAuthProfiles: false, syncExternalCli: false },
     );
-    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async (params) =>
+    resolveProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async (params) =>
       requireOAuthContext(params?.context),
     );
 
     await expect(resolveOpenAICodexProfile({ profileId, agentDir })).rejects.toThrow(
       /OAuth token refresh failed for openai/,
     );
-    expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
+    expect(resolveProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
     expect(getOAuthApiKeyMock).not.toHaveBeenCalled();
   });
 
@@ -261,7 +291,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       code: FILE_LOCK_TIMEOUT_ERROR_CODE,
       lockPath,
     });
-    refreshProviderOAuthCredentialWithPluginMock.mockRejectedValueOnce(
+    resolveProviderOAuthCredentialWithPluginMock.mockRejectedValueOnce(
       buildRefreshContentionError({ provider: "openai", profileId, cause: lockCause }),
     );
 
@@ -323,7 +353,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
 
     await expect(resolveOpenAICodexProfile({ profileId, agentDir })).resolves.toBeNull();
     expect(readCodexCliCredentialsCachedMock).not.toHaveBeenCalled();
-    expect(refreshProviderOAuthCredentialWithPluginMock).not.toHaveBeenCalled();
+    expect(resolveProviderOAuthCredentialWithPluginMock).not.toHaveBeenCalled();
   });
 
   it("refreshes near-expiry openai credentials before hard expiry", async () => {
@@ -352,7 +382,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       provider: "openai",
       email: undefined,
     });
-    expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
+    expect(resolveProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
   });
 
   it("forces refresh for unexpired openai credentials through the exported resolver", async () => {
@@ -386,7 +416,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       provider: "openai",
       email: undefined,
     });
-    expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
+    expect(resolveProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
   });
 
   it("persists plugin-refreshed openai credentials before returning", async () => {
@@ -445,7 +475,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       expires: Date.now() - 30_000,
       accountId: "acct-cli",
     });
-    refreshProviderOAuthCredentialWithPluginMock.mockResolvedValueOnce({
+    resolveProviderOAuthCredentialWithPluginMock.mockResolvedValueOnce({
       type: "oauth",
       provider: "openai",
       access: "rotated-cli-access-token",
@@ -496,7 +526,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       expires: Date.now() + 86_400_000,
       accountId: "acct-external",
     });
-    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+    resolveProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
       async (params?: { context?: unknown }) => {
         const context = requireOAuthContext(params?.context);
         expect(context.access).toBe("expired-local-access-token");
@@ -563,7 +593,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       expires: Date.now() - 30_000,
       accountId: "acct-cli",
     });
-    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+    resolveProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
       async (params?: { context?: unknown }) => {
         const context = requireOAuthContext(params?.context);
         expect(context.access).toBe("expired-local-access-token");
@@ -626,7 +656,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       expires: Date.now() + 86_400_000,
       accountId: "acct-shared",
     });
-    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
+    resolveProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
       throw new Error(
         '401 {"error":{"message":"Your refresh token is expired.","code":"refresh_token_expired"}}',
       );
@@ -677,7 +707,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       expires: Date.now() + 86_400_000,
       accountId: "acct-shared",
     });
-    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
+    resolveProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
       throw new Error(
         '401 {"error":{"message":"Your refresh token is expired.","code":"refresh_token_expired"}}',
       );
@@ -728,7 +758,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       expires: Date.now() + 86_400_000,
       accountId: "acct-shared",
     });
-    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
+    resolveProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
       throw new Error(
         '401 {"error":{"message":"Your refresh token is expired.","code":"refresh_token_expired"}}',
       );
@@ -770,7 +800,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       expires: Date.now() + 86_400_000,
       accountId: "acct-shared",
     });
-    refreshProviderOAuthCredentialWithPluginMock.mockRejectedValueOnce(
+    resolveProviderOAuthCredentialWithPluginMock.mockRejectedValueOnce(
       new Error(
         '401 {"error":{"message":"Your refresh token is expired.","code":"refresh_token_expired"}}',
       ),
@@ -815,7 +845,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
         agentDir,
       }),
     ).rejects.toThrow('No API key found for provider "openai"');
-    expect(refreshProviderOAuthCredentialWithPluginMock).not.toHaveBeenCalled();
+    expect(resolveProviderOAuthCredentialWithPluginMock).not.toHaveBeenCalled();
   });
 
   it("rejects explicit managed OAuth before refreshing for direct OpenAI API-key models", async () => {
@@ -839,7 +869,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
         agentDir,
       }),
     ).rejects.toThrow(/requires an OpenAI API key profile/);
-    expect(refreshProviderOAuthCredentialWithPluginMock).not.toHaveBeenCalled();
+    expect(resolveProviderOAuthCredentialWithPluginMock).not.toHaveBeenCalled();
   });
 
   it("does not refresh managed OAuth while checking direct OpenAI auth availability", async () => {
@@ -861,7 +891,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
         agentDir,
       }),
     ).resolves.toBe(false);
-    expect(refreshProviderOAuthCredentialWithPluginMock).not.toHaveBeenCalled();
+    expect(resolveProviderOAuthCredentialWithPluginMock).not.toHaveBeenCalled();
   });
 
   it("rejects mismatched Codex CLI fallback after forced local refresh fails", async () => {
@@ -890,7 +920,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       expires: Date.now() + 86_400_000,
       accountId: "acct-other",
     });
-    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
+    resolveProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
       throw new Error(
         '401 {"error":{"message":"Your refresh token is expired.","code":"refresh_token_expired"}}',
       );
@@ -931,7 +961,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       expires: Date.now() + 86_400_000,
       accountId: "acct-cli",
     });
-    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
+    resolveProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
       throw new Error(
         '401 {"error":{"message":"Your refresh token is expired.","code":"refresh_token_expired"}}',
       );
@@ -967,7 +997,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       agentDir,
     );
     readCodexCliCredentialsCachedMock.mockReturnValue({ ...credential });
-    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
+    resolveProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
       throw new Error(
         '401 {"error":{"message":"Your refresh token is expired.","code":"refresh_token_expired"}}',
       );
@@ -1142,8 +1172,8 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       agentDir,
     );
     getOAuthApiKeyMock
-      .mockImplementationOnce(async (_provider, creds) => {
-        expect(creds["openai"]?.refresh).toBe("refresh-token");
+      .mockImplementationOnce(async (_provider, credential) => {
+        expect(credential.refresh).toBe("refresh-token");
         saveAuthProfileStore(
           {
             version: 1,
@@ -1163,11 +1193,13 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
           '401 {"error":{"message":"Your refresh token has already been used to generate a new access token.","code":"refresh_token_reused"}}',
         );
       })
-      .mockImplementationOnce(async (_provider, creds) => {
-        expect(creds["openai"]?.refresh).toBe("rotated-refresh-token");
+      .mockImplementationOnce(async (_provider, credential) => {
+        expect(credential.refresh).toBe("rotated-refresh-token");
         return {
           apiKey: "retried-access-token",
           newCredentials: {
+            type: "oauth",
+            provider: "openai",
             access: "retried-access-token",
             refresh: "retried-refresh-token",
             expires: Date.now() + 10 * 60_000,
@@ -1226,7 +1258,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       }),
       agentDir,
     );
-    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
+    resolveProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
       throw new Error("invalid_grant");
     });
 

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -9,17 +9,8 @@ import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { coerceSecretRef } from "../../config/types.secrets.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import {
-  getOAuthApiKey,
-  getOAuthProviders,
-  type OAuthCredentials,
-  type OAuthProviderId,
-} from "../../llm/oauth.js";
+import { prepareOAuthApiKey } from "../../llm/oauth.js";
 import { OAuthProviderConfiguredUnavailableError } from "../../plugins/provider-runtime.errors.js";
-import {
-  formatProviderAuthProfileApiKeyWithPlugin,
-  resolveProviderOAuthCredentialWithPlugin,
-} from "../../plugins/provider-runtime.runtime.js";
 import { secretRefKey } from "../../secrets/ref-contract.js";
 import { resolveAuthProfileSecretOwnerId } from "../../secrets/runtime-auth-profile-owner.js";
 import {
@@ -34,7 +25,11 @@ import {
 } from "./credential-state.js";
 import { formatAuthDoctorHint } from "./doctor.js";
 import { readExternalCliBootstrapCredential } from "./external-cli-sync.js";
-import { createOAuthManager, OAuthManagerRefreshError } from "./oauth-manager.js";
+import {
+  createOAuthManager,
+  OAuthManagerRefreshError,
+  type PreparedOAuthRefresh,
+} from "./oauth-manager.js";
 import { OAuthRefreshFailureError } from "./oauth-refresh-failure.js";
 import { assertNoOAuthSecretRefPolicyViolations } from "./policy.js";
 import { clearLastGoodProfileWithLock } from "./profiles.js";
@@ -49,34 +44,6 @@ import {
   resolvePersistedAuthProfileOwnerAgentDir,
 } from "./store.js";
 import type { AuthProfileCredential, AuthProfileStore, OAuthCredential } from "./types.js";
-
-function listOAuthProviderIds(): string[] {
-  if (typeof getOAuthProviders !== "function") {
-    return [];
-  }
-  const providers = getOAuthProviders();
-  if (!Array.isArray(providers)) {
-    return [];
-  }
-  return providers
-    .map((provider) =>
-      provider &&
-      typeof provider === "object" &&
-      "id" in provider &&
-      typeof provider.id === "string"
-        ? provider.id
-        : undefined,
-    )
-    .filter((providerId): providerId is string => typeof providerId === "string");
-}
-
-const OAUTH_PROVIDER_IDS = new Set<string>(listOAuthProviderIds());
-
-const isOAuthProvider = (provider: string): provider is OAuthProviderId =>
-  OAUTH_PROVIDER_IDS.has(provider);
-
-const resolveOAuthProvider = (provider: string): OAuthProviderId | null =>
-  isOAuthProvider(provider) ? provider : null;
 
 /** Bearer-token auth modes that are interchangeable (oauth tokens and raw tokens). */
 const BEARER_AUTH_MODES = new Set(["oauth", "token"]);
@@ -109,11 +76,23 @@ function isProfileConfigCompatible(params: {
   return true;
 }
 
+type ProviderRuntimeModule = typeof import("../../plugins/provider-runtime.runtime.js");
+
+let providerRuntimeModulePromise: Promise<ProviderRuntimeModule> | undefined;
+
+function loadProviderRuntimeModule(): Promise<ProviderRuntimeModule> {
+  // Provider runtime metadata is process-stable. Sharing one lazy import keeps
+  // raw OAuth access cold while avoiding duplicate import work under bursts.
+  providerRuntimeModulePromise ??= import("../../plugins/provider-runtime.runtime.js");
+  return providerRuntimeModulePromise;
+}
+
 async function buildOAuthApiKey(
   provider: string,
   credentials: OAuthCredential,
   context: { cfg?: OpenClawConfig },
 ): Promise<string> {
+  const { formatProviderAuthProfileApiKeyWithPlugin } = await loadProviderRuntimeModule();
   const formatted = await formatProviderAuthProfileApiKeyWithPlugin({
     provider,
     config: context.cfg,
@@ -186,31 +165,91 @@ type ResolveApiKeyForProfileParams = {
 
 type SecretDefaults = NonNullable<OpenClawConfig["secrets"]>["defaults"];
 
-async function refreshOAuthCredential(
+type PreparedOAuthCredentialResolverContext = {
+  forceRefresh?: boolean;
+  signal?: AbortSignal;
+};
+
+type PreparedOAuthCredentialResolver = (
+  credential: OAuthCredential,
+  context?: PreparedOAuthCredentialResolverContext,
+) => Promise<{ credential: OAuthCredential; apiKey: string } | null>;
+
+export async function prepareOAuthCredentialResolver(
   credential: OAuthCredential,
   context: { cfg?: OpenClawConfig } = {},
-): Promise<OAuthCredentials | null> {
-  const pluginResult = await resolveProviderOAuthCredentialWithPlugin({
+): Promise<PreparedOAuthCredentialResolver> {
+  const { resolveProviderOAuthCredentialWithPlugin, resolveProviderRuntimePluginHandle } =
+    await loadProviderRuntimeModule();
+  const runtimeHandle = await resolveProviderRuntimePluginHandle({
     provider: credential.provider,
     config: context.cfg,
-    credential,
-    refresh: true,
   });
-  if (pluginResult.status === "available") {
-    return pluginResult.credential;
-  }
-  if (pluginResult.status === "configured-unavailable") {
-    throw new OAuthProviderConfiguredUnavailableError(credential.provider);
-  }
+  const configuredUnavailable =
+    !runtimeHandle.plugin &&
+    (
+      await resolveProviderOAuthCredentialWithPlugin({
+        provider: credential.provider,
+        config: context.cfg,
+        credential,
+        refresh: false,
+        runtimeHandle,
+      })
+    ).status === "configured-unavailable";
+  const fallback =
+    !configuredUnavailable && !runtimeHandle.plugin?.refreshOAuth
+      ? prepareOAuthApiKey(credential.provider)
+      : null;
+  return async (current, options = {}) => {
+    if (current.provider !== credential.provider) {
+      throw new Error("OAuth provider changed while waiting to refresh; sign in again");
+    }
+    const refresh = options.forceRefresh || Date.now() >= current.expires;
+    let resolved: { credential: OAuthCredential; apiKey: string } | null = null;
+    if (runtimeHandle.plugin) {
+      const result = await resolveProviderOAuthCredentialWithPlugin({
+        provider: current.provider,
+        config: context.cfg,
+        credential: current,
+        refresh,
+        runtimeHandle,
+        signal: options.signal,
+      });
+      if (result.status === "available") {
+        resolved = { credential: result.credential, apiKey: result.apiKey };
+      }
+    }
+    if (!resolved && configuredUnavailable) {
+      if (!refresh) {
+        return { credential: current, apiKey: current.access };
+      }
+      throw new OAuthProviderConfiguredUnavailableError(current.provider);
+    }
+    const fallbackResult = !resolved
+      ? await fallback?.(options.forceRefresh ? { ...current, expires: 0 } : current, {
+          signal: options.signal,
+        })
+      : null;
+    resolved ??= fallbackResult
+      ? {
+          credential: { ...current, ...fallbackResult.newCredentials, type: "oauth" },
+          apiKey: fallbackResult.apiKey,
+        }
+      : null;
+    if (refresh && resolved && Date.now() >= resolved.credential.expires) {
+      throw new Error("OAuth provider returned an expired credential");
+    }
+    return resolved;
+  };
+}
 
-  const oauthProvider = resolveOAuthProvider(credential.provider);
-  if (!oauthProvider || typeof getOAuthApiKey !== "function") {
-    return null;
-  }
-  const result = await getOAuthApiKey(oauthProvider, {
-    [credential.provider]: credential,
-  });
-  return result?.newCredentials ?? null;
+async function prepareOAuthRefresh(
+  credential: OAuthCredential,
+  context: { cfg?: OpenClawConfig } = {},
+): Promise<PreparedOAuthRefresh> {
+  const resolveCredential = await prepareOAuthCredentialResolver(credential, context);
+  return async (current, signal) =>
+    (await resolveCredential(current, { forceRefresh: true, signal }))?.credential ?? null;
 }
 
 /** Refresh one OAuth credential and merge provider-returned token fields. */
@@ -218,7 +257,8 @@ export async function refreshOAuthCredentialForRuntime(params: {
   credential: OAuthCredential;
   cfg?: OpenClawConfig;
 }): Promise<OAuthCredential | null> {
-  const refreshed = await refreshOAuthCredential(params.credential, { cfg: params.cfg });
+  const refresh = await prepareOAuthRefresh(params.credential, { cfg: params.cfg });
+  const refreshed = await refresh(params.credential, new AbortController().signal);
   return refreshed
     ? {
         ...params.credential,
@@ -230,10 +270,7 @@ export async function refreshOAuthCredentialForRuntime(params: {
 
 const oauthManager = createOAuthManager({
   buildApiKey: buildOAuthApiKey,
-  prepareRefresh: async (_credential, context) => async (credential, signal) => {
-    signal.throwIfAborted();
-    return await refreshOAuthCredential(credential, { cfg: context.cfg });
-  },
+  prepareRefresh: prepareOAuthRefresh,
   readBootstrapCredential: ({ store, profileId, credential }) =>
     readExternalCliBootstrapCredential({
       store,

--- a/src/agents/sessions/auth-storage-oauth-registry.ts
+++ b/src/agents/sessions/auth-storage-oauth-registry.ts
@@ -5,14 +5,19 @@ import type {
   OAuthProviderId,
 } from "../../llm/utils/oauth/types.js";
 import { OAuthProviderConfiguredUnavailableError } from "../../plugins/provider-runtime.errors.js";
-import {
-  loginProviderOAuthWithPlugin,
-  resolveProviderOAuthCredentialWithPlugin,
-} from "../../plugins/provider-runtime.runtime.js";
+import { loginProviderOAuthWithPlugin } from "../../plugins/provider-runtime.runtime.js";
+import { prepareOAuthCredentialResolver } from "../auth-profiles/oauth.js";
+import type { OAuthCredential as AuthProfileOAuthCredential } from "../auth-profiles/types.js";
 
 // Values belong to one AuthStorage object. The weak attachment keeps ModelRegistry
 // on the same registry without adding lifecycle methods to the public SDK class.
 const registries = new WeakMap<object, OAuthProviderRegistry>();
+
+type PreparedAuthStorageOAuthCredentialContext = { signal?: AbortSignal };
+type PreparedAuthStorageOAuthCredentialResolver = (
+  credential: OAuthCredentials,
+  context?: PreparedAuthStorageOAuthCredentialContext,
+) => Promise<{ apiKey: string; newCredentials: OAuthCredentials } | null>;
 
 export function getAuthStorageOAuthProviderRegistry(authStorage: object): OAuthProviderRegistry {
   let registry = registries.get(authStorage);
@@ -42,20 +47,29 @@ export async function loginAuthStorageOAuthProvider(
   return resolved.credentials;
 }
 
-export async function resolveAuthStoragePluginOAuthCredential(
+export async function prepareAuthStorageOAuthCredentialResolver(
+  authStorage: object,
   providerId: OAuthProviderId,
   credential: OAuthCredentials,
-  refresh: boolean,
-): Promise<{ apiKey: string; newCredentials: OAuthCredentials } | null> {
-  const resolved = await resolveProviderOAuthCredentialWithPlugin({
-    provider: providerId,
-    credential: { ...credential, type: "oauth", provider: providerId },
-    refresh,
-  });
-  if (resolved.status === "configured-unavailable") {
-    throw new OAuthProviderConfiguredUnavailableError(providerId);
+): Promise<PreparedAuthStorageOAuthCredentialResolver> {
+  const registered = getAuthStorageOAuthProviderRegistry(authStorage).prepareApiKey(providerId);
+  if (registered) {
+    return registered;
   }
-  return resolved.status === "available"
-    ? { apiKey: resolved.apiKey, newCredentials: resolved.credential }
-    : null;
+  const prepared = await prepareOAuthCredentialResolver({
+    ...credential,
+    type: "oauth",
+    provider: providerId,
+  });
+  return async (current, context = {}) => {
+    const resolved = await prepared(
+      {
+        ...current,
+        type: "oauth",
+        provider: providerId,
+      } satisfies AuthProfileOAuthCredential,
+      context,
+    );
+    return resolved ? { apiKey: resolved.apiKey, newCredentials: resolved.credential } : null;
+  };
 }

--- a/src/agents/sessions/auth-storage.oauth-refresh.test.ts
+++ b/src/agents/sessions/auth-storage.oauth-refresh.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createDeferredCore } from "../../shared/deferred.js";
 
 vi.mock("../auth-profiles/constants.js", async () => {
   const actual = await vi.importActual<typeof import("../auth-profiles/constants.js")>(
@@ -40,7 +41,7 @@ function createStorage(
 
 describe("AuthStorage OAuth refresh ownership", () => {
   it("persists late success and reuses it after the caller deadline", async () => {
-    const stalled = Promise.withResolvers<{
+    const stalled = createDeferredCore<{
       access: string;
       refresh: string;
       expires: number;
@@ -93,7 +94,7 @@ describe("AuthStorage OAuth refresh ownership", () => {
   });
 
   it("times out a queued follower without a second provider invocation", async () => {
-    const stalled = Promise.withResolvers<{
+    const stalled = createDeferredCore<{
       access: string;
       refresh: string;
       expires: number;

--- a/src/agents/sessions/auth-storage.test.ts
+++ b/src/agents/sessions/auth-storage.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const providerOAuthMocks = vi.hoisted(() => ({
   login: vi.fn(),
   resolveCredential: vi.fn(),
+  resolveHandle: vi.fn(),
 }));
 
 vi.mock("../../plugins/provider-runtime.runtime.js", async () => {
@@ -17,6 +18,7 @@ vi.mock("../../plugins/provider-runtime.runtime.js", async () => {
     ...actual,
     loginProviderOAuthWithPlugin: providerOAuthMocks.login,
     resolveProviderOAuthCredentialWithPlugin: providerOAuthMocks.resolveCredential,
+    resolveProviderRuntimePluginHandle: providerOAuthMocks.resolveHandle,
   };
 });
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
@@ -47,6 +49,8 @@ describe("SQLite auth storage", () => {
     providerOAuthMocks.login.mockResolvedValue({ status: "unowned" });
     providerOAuthMocks.resolveCredential.mockReset();
     providerOAuthMocks.resolveCredential.mockResolvedValue({ status: "unowned" });
+    providerOAuthMocks.resolveHandle.mockReset();
+    providerOAuthMocks.resolveHandle.mockResolvedValue({ plugin: undefined });
   });
 
   afterEach(() => {
@@ -112,6 +116,41 @@ describe("SQLite auth storage", () => {
       providerId: "plugin-oauth",
     });
     await expect(login).rejects.toBeInstanceOf(OAuthProviderConfiguredUnavailableError);
+  });
+
+  it("keeps a valid stored OAuth credential when its configured plugin is unavailable", async () => {
+    const storage = AuthStorage.inMemory({
+      "plugin-oauth": {
+        type: "oauth",
+        access: "stored-access",
+        refresh: "stored-refresh",
+        expires: Date.now() + 60_000,
+      },
+    });
+    providerOAuthMocks.resolveCredential.mockResolvedValue({
+      status: "configured-unavailable",
+    });
+
+    await expect(storage.getApiKey("plugin-oauth")).resolves.toBe("stored-access");
+  });
+
+  it("fails closed when an expired stored OAuth credential needs an unavailable plugin", async () => {
+    const storage = AuthStorage.inMemory({
+      "plugin-oauth": {
+        type: "oauth",
+        access: "expired-access",
+        refresh: "stored-refresh",
+        expires: 1,
+      },
+    });
+    providerOAuthMocks.resolveCredential.mockResolvedValue({
+      status: "configured-unavailable",
+    });
+
+    await expect(storage.getApiKey("plugin-oauth")).rejects.toBeInstanceOf(
+      OAuthProviderConfiguredUnavailableError,
+    );
+    expect(storage.drainErrors()).toEqual([]);
   });
 
   it("persists provider defaults in the canonical agent database", async () => {
@@ -611,6 +650,56 @@ describe("SQLite auth storage", () => {
     ).resolves.toEqual(["fake-fresh-access", "fake-fresh-access"]);
     expect(refreshCalls).toBe(1);
     expect(maxActiveRefreshes).toBe(1);
+  });
+
+  it("prepares provider runtime ownership before storage locks", async () => {
+    let raw = JSON.stringify({
+      "plugin-oauth": {
+        type: "oauth",
+        access: "fake-expired-access",
+        refresh: "fake-refresh",
+        expires: 1,
+      },
+    });
+    let lockDepth = 0;
+    const backend: AuthStorageBackend = {
+      withLock: (fn) => {
+        lockDepth += 1;
+        try {
+          const update = fn(raw);
+          raw = update.next ?? raw;
+          return update.result;
+        } finally {
+          lockDepth -= 1;
+        }
+      },
+    };
+    const storage = AuthStorage.fromStorage(backend);
+    providerOAuthMocks.resolveHandle.mockImplementation(async () => {
+      expect(lockDepth).toBe(0);
+      return { plugin: { refreshOAuth: vi.fn() } };
+    });
+    providerOAuthMocks.resolveCredential.mockImplementation(async (params) => {
+      expect(lockDepth).toBe(0);
+      expect(params.runtimeHandle?.plugin).toBeDefined();
+      return {
+        status: "available",
+        apiKey: "fake-fresh-access",
+        credential: {
+          ...params.credential,
+          access: "fake-fresh-access",
+          refresh: "fake-fresh-refresh",
+          expires: Date.now() + 60_000,
+        },
+      };
+    });
+
+    await expect(storage.getApiKey("plugin-oauth")).resolves.toBe("fake-fresh-access");
+    expect(providerOAuthMocks.resolveHandle).toHaveBeenCalledOnce();
+    expect(JSON.parse(raw)["plugin-oauth"]).toMatchObject({
+      access: "fake-fresh-access",
+      refresh: "fake-fresh-refresh",
+    });
   });
 
   it("falls back to environment auth when a stored token is expired", async () => {

--- a/src/agents/sessions/auth-storage.ts
+++ b/src/agents/sessions/auth-storage.ts
@@ -46,10 +46,10 @@ import {
 } from "../auth-profiles/store.js";
 import type { AuthProfileCredential, AuthProfileStore } from "../auth-profiles/types.js";
 import { getAgentDir } from "../config.js";
+import { getAuthStorageOAuthProviderRegistry } from "./auth-storage-oauth-registry.js";
 import {
-  getAuthStorageOAuthProviderRegistry,
   loginAuthStorageOAuthProvider,
-  resolveAuthStoragePluginOAuthCredential,
+  prepareAuthStorageOAuthCredentialResolver,
 } from "./auth-storage-oauth-registry.js";
 import { resolveConfigValue } from "./resolve-config-value.js";
 
@@ -650,22 +650,15 @@ export class AuthStorage {
     return runRetainedOAuthRefreshOperation({
       timeoutMs: OAUTH_REFRESH_CALL_TIMEOUT_MS,
       run: async (signal) => {
-        const provider = getAuthStorageOAuthProviderRegistry(this).get(providerId);
-        const resolveCredential = async (credential: OAuthCredentials, forceRefresh = false) => {
-          signal.throwIfAborted();
-          if (!provider) {
-            return await resolveAuthStoragePluginOAuthCredential(
-              providerId,
-              credential,
-              forceRefresh,
-            );
-          }
-          if (!forceRefresh) {
-            return { apiKey: provider.getApiKey(credential), newCredentials: credential };
-          }
-          const refreshed = await provider.refreshToken(credential);
-          return { apiKey: provider.getApiKey(refreshed), newCredentials: refreshed };
-        };
+        const initial = this.data[providerId];
+        if (initial?.type !== "oauth") {
+          return null;
+        }
+        const resolveCredential = await prepareAuthStorageOAuthCredentialResolver(
+          this,
+          providerId,
+          initial,
+        );
         signal.throwIfAborted();
         return await this.oauthRefreshQueue.enqueue(providerId, async () => {
           signal.throwIfAborted();
@@ -682,10 +675,10 @@ export class AuthStorage {
             }
             const credential = snapshot.credential;
             if (Date.now() < credential.expires) {
-              return await resolveCredential(credential);
+              return await resolveCredential(credential, { signal });
             }
 
-            const refreshed = await resolveCredential(credential, true);
+            const refreshed = await resolveCredential(credential, { signal });
             if (!refreshed) {
               return null;
             }
@@ -724,7 +717,7 @@ export class AuthStorage {
             }
             return persisted.credential === refreshedCredential
               ? { apiKey: refreshed.apiKey, newCredentials: persisted.credential }
-              : await resolveCredential(persisted.credential);
+              : await resolveCredential(persisted.credential, { signal });
           };
 
           return this.migrationOwnerAgentDir
@@ -782,8 +775,6 @@ export class AuthStorage {
     }
 
     if (cred?.type === "oauth") {
-      const provider = getAuthStorageOAuthProviderRegistry(this).get(providerId);
-
       // Check if token needs refresh
       const needsRefresh = Date.now() >= cred.expires;
 
@@ -813,11 +804,11 @@ export class AuthStorage {
 
           if (updatedCred?.type === "oauth" && Date.now() < updatedCred.expires) {
             // Another instance refreshed successfully, use those credentials
-            if (provider) {
-              return provider.getApiKey(updatedCred);
-            }
-            return (await resolveAuthStoragePluginOAuthCredential(providerId, updatedCred, false))
-              ?.apiKey;
+            return (
+              await (
+                await prepareAuthStorageOAuthCredentialResolver(this, providerId, updatedCred)
+              )(updatedCred)
+            )?.apiKey;
           }
 
           // Refresh truly failed - return undefined so model discovery skips this provider
@@ -825,10 +816,11 @@ export class AuthStorage {
           return undefined;
         }
       } else {
-        if (provider) {
-          return provider.getApiKey(cred);
-        }
-        return (await resolveAuthStoragePluginOAuthCredential(providerId, cred, false))?.apiKey;
+        return (
+          await (
+            await prepareAuthStorageOAuthCredentialResolver(this, providerId, cred)
+          )(cred)
+        )?.apiKey;
       }
     }
 

--- a/src/llm/utils/oauth/anthropic.test.ts
+++ b/src/llm/utils/oauth/anthropic.test.ts
@@ -5,12 +5,15 @@ import { anthropicOAuthProvider } from "./anthropic.js";
 
 const ANTHROPIC_REDIRECT_URI = "http://localhost:53692/callback";
 
-async function refreshThroughAnthropicProvider(refreshToken: string) {
-  return await anthropicOAuthProvider.refreshToken({
-    access: "expired-access-token",
-    refresh: refreshToken,
-    expires: 0,
-  });
+async function refreshThroughAnthropicProvider(refreshToken: string, signal?: AbortSignal) {
+  return await anthropicOAuthProvider.refreshToken(
+    {
+      access: "expired-access-token",
+      refresh: refreshToken,
+      expires: 0,
+    },
+    { signal },
+  );
 }
 
 afterEach(() => {
@@ -29,6 +32,20 @@ async function getLocalCallback(url: string): Promise<void> {
 }
 
 describe("Anthropic OAuth token responses", () => {
+  it("forwards refresh cancellation to provider I/O", async () => {
+    const controller = new AbortController();
+    const fetchMock = vi.fn(async () => {
+      throw controller.signal.reason;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    controller.abort(new Error("refresh cancelled"));
+
+    await expect(
+      refreshThroughAnthropicProvider("old-refresh-token", controller.signal),
+    ).rejects.toThrow("Login cancelled");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("cancels provider login before opening the OAuth flow", async () => {
     const controller = new AbortController();
     controller.abort();

--- a/src/llm/utils/oauth/anthropic.ts
+++ b/src/llm/utils/oauth/anthropic.ts
@@ -379,14 +379,18 @@ async function loginAnthropic(options: {
 /**
  * Refresh Anthropic OAuth token
  */
-async function refreshAnthropicToken(refreshToken: string): Promise<OAuthCredentials> {
+async function refreshAnthropicToken(refreshToken: string, signal?: AbortSignal) {
   let responseBody: string;
   try {
-    responseBody = await postJson(TOKEN_URL, {
-      grant_type: "refresh_token",
-      client_id: CLIENT_ID,
-      refresh_token: refreshToken,
-    });
+    responseBody = await postJson(
+      TOKEN_URL,
+      {
+        grant_type: "refresh_token",
+        client_id: CLIENT_ID,
+        refresh_token: refreshToken,
+      },
+      { signal },
+    );
   } catch (error) {
     throw new Error(
       `Anthropic token refresh request failed. url=${TOKEN_URL}; details=${formatErrorDetails(error)}`,
@@ -415,8 +419,8 @@ export const anthropicOAuthProvider: OAuthProviderInterface = {
     });
   },
 
-  async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
-    return refreshAnthropicToken(credentials.refresh);
+  async refreshToken(credentials, context) {
+    return refreshAnthropicToken(credentials.refresh, context?.signal);
   },
 
   getApiKey(credentials: OAuthCredentials): string {

--- a/src/llm/utils/oauth/index.test.ts
+++ b/src/llm/utils/oauth/index.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import { OAuthProviderRegistry } from "./index.js";
+import type { OAuthProviderInterface } from "./types.js";
+
+function createProvider(overrides: Partial<OAuthProviderInterface> = {}): OAuthProviderInterface {
+  return {
+    id: "test-oauth",
+    name: "Test OAuth",
+    async login() {
+      throw new Error("not used");
+    },
+    async refreshToken(credentials) {
+      return { ...credentials, access: "refreshed-access", expires: Date.now() + 60_000 };
+    },
+    getApiKey(credentials) {
+      return credentials.access;
+    },
+    ...overrides,
+  };
+}
+
+describe("OAuthProviderRegistry refresh preparation", () => {
+  it("keeps legacy one-argument refresh providers working", async () => {
+    const registry = new OAuthProviderRegistry();
+    registry.register(createProvider());
+
+    await expect(
+      registry.getApiKey("test-oauth", {
+        "test-oauth": { access: "expired", refresh: "refresh", expires: 1 },
+      }),
+    ).resolves.toMatchObject({ apiKey: "refreshed-access" });
+  });
+
+  it("prepares once and forwards the exact refresh context", async () => {
+    const controller = new AbortController();
+    const refresh = vi.fn(async (credentials) => ({
+      ...credentials,
+      access: "prepared-access",
+      expires: Date.now() + 60_000,
+    }));
+    const prepareRefreshToken = vi.fn(() => refresh);
+    const registry = new OAuthProviderRegistry();
+    registry.register(createProvider({ prepareRefreshToken }));
+
+    const resolveApiKey = registry.prepareApiKey("test-oauth");
+    await expect(
+      resolveApiKey?.(
+        { access: "expired", refresh: "refresh", expires: 1 },
+        { signal: controller.signal },
+      ),
+    ).resolves.toMatchObject({ apiKey: "prepared-access" });
+
+    expect(prepareRefreshToken).toHaveBeenCalledOnce();
+    expect(refresh).toHaveBeenCalledWith(expect.any(Object), {
+      signal: controller.signal,
+    });
+  });
+});

--- a/src/llm/utils/oauth/index.ts
+++ b/src/llm/utils/oauth/index.ts
@@ -18,7 +18,12 @@ export * from "./types.js";
 
 import { anthropicOAuthProvider } from "./anthropic.js";
 import { openaiCodexOAuthProvider } from "./openai-chatgpt.js";
-import type { OAuthCredentials, OAuthProviderId, OAuthProviderInterface } from "./types.js";
+import type {
+  OAuthCredentials,
+  OAuthProviderId,
+  OAuthProviderInterface,
+  ProviderOAuthRefreshContext,
+} from "./types.js";
 
 const BUILT_IN_OAUTH_PROVIDERS: OAuthProviderInterface[] = [
   anthropicOAuthProvider,
@@ -26,25 +31,24 @@ const BUILT_IN_OAUTH_PROVIDERS: OAuthProviderInterface[] = [
 ];
 
 type OAuthApiKeyResult = { newCredentials: OAuthCredentials; apiKey: string } | null;
+type PreparedOAuthApiKey = (
+  credentials: OAuthCredentials,
+  context?: ProviderOAuthRefreshContext,
+) => Promise<OAuthApiKeyResult>;
 
-async function resolveOAuthApiKey(
-  provider: OAuthProviderInterface,
-  credentials: Record<string, OAuthCredentials>,
-): Promise<OAuthApiKeyResult> {
-  let creds = credentials[provider.id];
-  if (!creds) {
-    return null;
-  }
-
-  if (Date.now() >= creds.expires) {
-    try {
-      creds = await provider.refreshToken(creds);
-    } catch (error) {
-      throw new Error(`Failed to refresh OAuth token for ${provider.id}`, { cause: error });
+function prepareOAuthApiKeyForProvider(provider: OAuthProviderInterface): PreparedOAuthApiKey {
+  const refresh = provider.prepareRefreshToken?.() ?? provider.refreshToken.bind(provider);
+  return async (credentials, context) => {
+    let creds = credentials;
+    if (Date.now() >= creds.expires) {
+      try {
+        creds = await refresh(creds, context);
+      } catch (error) {
+        throw new Error(`Failed to refresh OAuth token for ${provider.id}`, { cause: error });
+      }
     }
-  }
-
-  return { newCredentials: creds, apiKey: provider.getApiKey(creds) };
+    return { newCredentials: creds, apiKey: provider.getApiKey(creds) };
+  };
 }
 
 /** Mutable OAuth provider registrations owned by one auth/session runtime. */
@@ -78,11 +82,17 @@ export class OAuthProviderRegistry {
     providerId: OAuthProviderId,
     credentials: Record<string, OAuthCredentials>,
   ): Promise<OAuthApiKeyResult> {
-    const provider = this.get(providerId);
-    if (!provider) {
+    const resolveApiKey = this.prepareApiKey(providerId);
+    if (!resolveApiKey) {
       throw new Error(`Unknown OAuth provider: ${providerId}`);
     }
-    return resolveOAuthApiKey(provider, credentials);
+    const credential = credentials[providerId];
+    return credential ? resolveApiKey(credential) : null;
+  }
+
+  prepareApiKey(providerId: OAuthProviderId): PreparedOAuthApiKey | null {
+    const provider = this.get(providerId);
+    return provider ? prepareOAuthApiKeyForProvider(provider) : null;
   }
 }
 
@@ -93,31 +103,7 @@ function getOAuthProvider(id: OAuthProviderId): OAuthProviderInterface | undefin
   return BUILT_IN_OAUTH_PROVIDERS.find((provider) => provider.id === id);
 }
 
-/**
- * Get all built-in OAuth providers.
- */
-export function getOAuthProviders(): OAuthProviderInterface[] {
-  return [...BUILT_IN_OAUTH_PROVIDERS];
-}
-
-// ============================================================================
-// High-level built-in provider API
-// ============================================================================
-
-/**
- * Get API key for a provider from OAuth credentials.
- * Automatically refreshes expired tokens.
- *
- * @returns API key string and updated credentials, or null if no credentials
- * @throws Error if refresh fails
- */
-export async function getOAuthApiKey(
-  providerId: OAuthProviderId,
-  credentials: Record<string, OAuthCredentials>,
-): Promise<{ newCredentials: OAuthCredentials; apiKey: string } | null> {
+export function prepareOAuthApiKey(providerId: OAuthProviderId): PreparedOAuthApiKey | null {
   const provider = getOAuthProvider(providerId);
-  if (!provider) {
-    throw new Error(`Unknown OAuth provider: ${providerId}`);
-  }
-  return resolveOAuthApiKey(provider, credentials);
+  return provider ? prepareOAuthApiKeyForProvider(provider) : null;
 }

--- a/src/llm/utils/oauth/openai-chatgpt.test.ts
+++ b/src/llm/utils/oauth/openai-chatgpt.test.ts
@@ -8,15 +8,10 @@ const mocks = vi.hoisted(() => ({
   loginOpenAICodexOAuth: vi.fn<LoginOpenAICodexOAuth>(),
   loadActivatedBundledPluginPublicSurfaceModuleSync: vi.fn(),
   refreshOpenAICodexToken: vi.fn(),
-  refreshProviderOAuthCredentialWithPlugin: vi.fn(),
 }));
 
 vi.mock("../../../plugins/provider-openai-chatgpt-oauth.js", () => ({
   loginOpenAICodexOAuth: mocks.loginOpenAICodexOAuth,
-}));
-
-vi.mock("../../../plugins/provider-runtime.runtime.js", () => ({
-  refreshProviderOAuthCredentialWithPlugin: mocks.refreshProviderOAuthCredentialWithPlugin,
 }));
 
 vi.mock("../../../plugin-sdk/facade-runtime.js", () => ({
@@ -189,37 +184,13 @@ describe("OpenAI Codex OAuth compatibility provider", () => {
     expect(onAuth).not.toHaveBeenCalled();
   });
 
-  it("refreshes through the provider runtime hook without returning auth-profile fields", async () => {
-    mocks.refreshProviderOAuthCredentialWithPlugin.mockResolvedValueOnce(createCredential());
-
-    await expect(refreshThroughOpenAIProvider("old-refresh-token")).resolves.toEqual({
-      access: "access-token",
-      refresh: "refresh-token",
-      expires: 1_700_000_000_000,
-      accountId: "acct_123",
-    });
-
-    expect(mocks.refreshProviderOAuthCredentialWithPlugin).toHaveBeenCalledWith({
-      provider: "openai",
-      context: {
-        type: "oauth",
-        provider: "openai",
-        access: "",
-        refresh: "old-refresh-token",
-        expires: 0,
-      },
-    });
-    expect(mocks.loadActivatedBundledPluginPublicSurfaceModuleSync).not.toHaveBeenCalled();
-  });
-
-  it("falls back to the OpenAI plugin facade when provider runtime refresh is unavailable", async () => {
+  it("refreshes legacy direct callers through the activated OpenAI facade", async () => {
     const credential = {
       access: "facade-access-token",
       refresh: "facade-refresh-token",
       expires: 1_700_000_000_000,
       accountId: "acct_facade",
     };
-    mocks.refreshProviderOAuthCredentialWithPlugin.mockResolvedValueOnce(null);
     mocks.refreshOpenAICodexToken.mockResolvedValueOnce(credential);
 
     await expect(refreshThroughOpenAIProvider("old-refresh-token")).resolves.toEqual(credential);
@@ -228,11 +199,46 @@ describe("OpenAI Codex OAuth compatibility provider", () => {
       dirName: "openai",
       artifactBasename: "api.js",
     });
-    expect(mocks.refreshOpenAICodexToken).toHaveBeenCalledWith("old-refresh-token");
+    expect(mocks.refreshOpenAICodexToken).toHaveBeenCalledWith("old-refresh-token", {
+      signal: undefined,
+    });
   });
 
-  it("preserves activated-facade failures when refresh fallback is disabled", async () => {
-    mocks.refreshProviderOAuthCredentialWithPlugin.mockResolvedValueOnce(null);
+  it("captures one facade refresh callable and reuses it with rotated tokens and signals", async () => {
+    const controller = new AbortController();
+    const refresh = openaiCodexOAuthProvider.prepareRefreshToken?.();
+    expect(refresh).toBeTypeOf("function");
+    if (!refresh) {
+      throw new Error("expected prepared OpenAI OAuth refresh");
+    }
+    mocks.refreshOpenAICodexToken
+      .mockResolvedValueOnce({
+        access: "first-access",
+        refresh: "rotated-refresh",
+        expires: 1_700_000_000_000,
+      })
+      .mockResolvedValueOnce({
+        access: "second-access",
+        refresh: "final-refresh",
+        expires: 1_700_000_100_000,
+      });
+
+    await refresh(
+      { access: "old-access", refresh: "old-refresh", expires: 0 },
+      { signal: controller.signal },
+    );
+    await refresh({ access: "first-access", refresh: "rotated-refresh", expires: 0 });
+
+    expect(mocks.loadActivatedBundledPluginPublicSurfaceModuleSync).toHaveBeenCalledOnce();
+    expect(mocks.refreshOpenAICodexToken).toHaveBeenNthCalledWith(1, "old-refresh", {
+      signal: controller.signal,
+    });
+    expect(mocks.refreshOpenAICodexToken).toHaveBeenNthCalledWith(2, "rotated-refresh", {
+      signal: undefined,
+    });
+  });
+
+  it("preserves activated-facade failures", async () => {
     mocks.loadActivatedBundledPluginPublicSurfaceModuleSync.mockImplementationOnce(() => {
       throw new Error("plugin runtime is not activated");
     });

--- a/src/llm/utils/oauth/openai-chatgpt.ts
+++ b/src/llm/utils/oauth/openai-chatgpt.ts
@@ -3,13 +3,21 @@ import { loadActivatedBundledPluginPublicSurfaceModuleSync } from "../../../plug
 import type { RuntimeEnv } from "../../../runtime.js";
 import type { WizardPrompter } from "../../../wizard/prompts.js";
 import { throwIfOAuthLoginAborted, withOAuthLoginAbort } from "./abort.js";
-import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } from "./types.js";
+import type {
+  OAuthCredentials,
+  OAuthLoginCallbacks,
+  OAuthProviderInterface,
+  ProviderOAuthRefreshContext,
+} from "./types.js";
 
 // OAuth adapter for the bundled OpenAI/ChatGPT provider surface.
 const OPENAI_CODEX_PROVIDER_ID = "openai";
 
 type OpenAICodexOAuthFacade = {
-  refreshOpenAICodexToken: (refreshToken: string) => Promise<OAuthCredentials>;
+  refreshOpenAICodexToken: (
+    refreshToken: string,
+    options?: { signal?: AbortSignal },
+  ) => Promise<OAuthCredentials>;
 };
 
 type OpenAICodexLoginCallbacks = Omit<OAuthLoginCallbacks, "onAuth"> & {
@@ -61,29 +69,6 @@ function createLegacyPrompter(callbacks: OAuthLoginCallbacks): WizardPrompter {
   } as WizardPrompter;
 }
 
-async function refreshViaProviderRuntime(refreshToken: string): Promise<OAuthCredentials> {
-  const { refreshProviderOAuthCredentialWithPlugin } =
-    await import("../../../plugins/provider-runtime.runtime.js");
-  const refreshed = await refreshProviderOAuthCredentialWithPlugin({
-    provider: OPENAI_CODEX_PROVIDER_ID,
-    context: {
-      type: "oauth",
-      provider: OPENAI_CODEX_PROVIDER_ID,
-      access: "",
-      refresh: refreshToken,
-      expires: 0,
-    },
-  });
-  if (!refreshed) {
-    // Fallback keeps refresh working when the plugin runtime is unavailable but the facade is active.
-    return await loadOpenAICodexOAuthFacade().refreshOpenAICodexToken(refreshToken);
-  }
-  const credentials: Record<string, unknown> = { ...refreshed };
-  delete credentials.type;
-  delete credentials.provider;
-  return credentials as OAuthCredentials;
-}
-
 /** Runs the ChatGPT/Codex OAuth login flow and returns normalized credentials. */
 async function loginOpenAICodex(callbacks: OpenAICodexLoginCallbacks): Promise<OAuthCredentials> {
   throwIfOAuthLoginAborted(callbacks.signal);
@@ -113,9 +98,11 @@ async function loginOpenAICodex(callbacks: OpenAICodexLoginCallbacks): Promise<O
   return credentials;
 }
 
-/** Refreshes a ChatGPT/Codex OAuth token through the provider runtime or bundled facade. */
-async function refreshOpenAICodexToken(refreshToken: string): Promise<OAuthCredentials> {
-  return await refreshViaProviderRuntime(refreshToken);
+/** Captures the activated OpenAI facade before entering serialized refresh work. */
+function prepareOpenAICodexOAuthRefresh() {
+  const refresh = loadOpenAICodexOAuthFacade().refreshOpenAICodexToken;
+  return (credentials: OAuthCredentials, context?: ProviderOAuthRefreshContext) =>
+    refresh(credentials.refresh, { signal: context?.signal });
 }
 
 /** OAuth provider descriptor for ChatGPT subscription-backed OpenAI access. */
@@ -128,9 +115,13 @@ export const openaiCodexOAuthProvider: OAuthProviderInterface = {
     return await loginOpenAICodex(callbacks);
   },
 
-  async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
-    return await refreshOpenAICodexToken(credentials.refresh);
+  async refreshToken(
+    credentials: OAuthCredentials,
+    context?: ProviderOAuthRefreshContext,
+  ): Promise<OAuthCredentials> {
+    return await prepareOpenAICodexOAuthRefresh()(credentials, context);
   },
+  prepareRefreshToken: prepareOpenAICodexOAuthRefresh,
 
   getApiKey(credentials: OAuthCredentials): string {
     return credentials.access;

--- a/src/llm/utils/oauth/types.ts
+++ b/src/llm/utils/oauth/types.ts
@@ -5,4 +5,5 @@ export type {
   OAuthPrompt,
   OAuthProviderId,
   OAuthProviderInterface,
+  ProviderOAuthRefreshContext,
 } from "../../../plugin-sdk/provider-oauth-runtime.js";

--- a/src/plugin-sdk/provider-auth.ts
+++ b/src/plugin-sdk/provider-auth.ts
@@ -136,6 +136,7 @@ export {
 } from "./oauth-utils.js";
 export {
   DEFAULT_OAUTH_REFRESH_MARGIN_MS,
+  hasOAuthTokenMaterialChanged,
   hasUsableOAuthCredential,
 } from "../agents/auth-profiles/credential-state.js";
 export {

--- a/src/plugin-sdk/provider-oauth-runtime.ts
+++ b/src/plugin-sdk/provider-oauth-runtime.ts
@@ -86,6 +86,10 @@ export interface OAuthLoginCallbacks {
   signal?: AbortSignal;
 }
 
+export type ProviderOAuthRefreshContext = {
+  signal?: AbortSignal;
+};
+
 /** Provider OAuth contract implemented by provider plugins. */
 export interface OAuthProviderInterface {
   /** Stable provider id used for credential and config routing. */
@@ -100,7 +104,13 @@ export interface OAuthProviderInterface {
   usesCallbackServer?: boolean;
 
   /** Refresh expired credentials and return updated credentials to persist. */
-  refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials>;
+  refreshToken(
+    credentials: OAuthCredentials,
+    context?: ProviderOAuthRefreshContext,
+  ): Promise<OAuthCredentials>;
+
+  /** Bind process-stable provider runtime state before entering refresh locks. */
+  prepareRefreshToken?(): OAuthProviderInterface["refreshToken"];
 
   /** Convert credentials to an API key string for the provider. */
   getApiKey(credentials: OAuthCredentials): string;

--- a/src/plugins/provider-plugin.types.ts
+++ b/src/plugins/provider-plugin.types.ts
@@ -10,6 +10,7 @@ import type { ProviderUsageSnapshot } from "../infra/provider-usage.types.js";
 import type {
   OAuthCredentials as SessionOAuthCredentials,
   OAuthLoginCallbacks,
+  ProviderOAuthRefreshContext,
 } from "../plugin-sdk/provider-oauth-runtime.js";
 import type { PluginTextTransforms } from "./cli-backend.types.js";
 import type {
@@ -574,7 +575,10 @@ export type ProviderPlugin = {
    * the provider needs custom refresh-failure behavior that should stay out of
    * core auth-profile code.
    */
-  refreshOAuth?: (cred: OAuthCredential) => Promise<OAuthCredential>;
+  refreshOAuth?: (
+    cred: OAuthCredential,
+    context?: ProviderOAuthRefreshContext,
+  ) => Promise<OAuthCredential>;
   /**
    * Provider-owned auth-doctor hint.
    *

--- a/src/plugins/provider-runtime.runtime.ts
+++ b/src/plugins/provider-runtime.runtime.ts
@@ -13,8 +13,6 @@ type LoginProviderOAuthWithPlugin = ProviderRuntimeModule["loginProviderOAuthWit
 type ResolveProviderOAuthCredentialWithPlugin =
   ProviderRuntimeModule["resolveProviderOAuthCredentialWithPlugin"];
 type PrepareProviderRuntimeAuth = ProviderRuntimeModule["prepareProviderRuntimeAuth"];
-type RefreshProviderOAuthCredentialWithPlugin =
-  ProviderRuntimeModule["refreshProviderOAuthCredentialWithPlugin"];
 
 const providerRuntimeLoader = createLazyImportLoader<ProviderRuntimeModule>(
   () => import("./provider-runtime.js"),
@@ -66,18 +64,16 @@ export async function resolveProviderOAuthCredentialWithPlugin(
   return runtime.resolveProviderOAuthCredentialWithPlugin(...args);
 }
 
+export async function resolveProviderRuntimePluginHandle(
+  ...args: Parameters<ProviderRuntimeModule["resolveProviderRuntimePluginHandle"]>
+) {
+  return (await loadProviderRuntime()).resolveProviderRuntimePluginHandle(...args);
+}
+
 /** Lazily prepares provider runtime auth for model execution. */
 export async function prepareProviderRuntimeAuth(
   ...args: Parameters<PrepareProviderRuntimeAuth>
 ): Promise<Awaited<ReturnType<PrepareProviderRuntimeAuth>>> {
   const runtime = await loadProviderRuntime();
   return runtime.prepareProviderRuntimeAuth(...args);
-}
-
-/** Lazily refreshes OAuth credentials through provider plugin runtime hooks. */
-export async function refreshProviderOAuthCredentialWithPlugin(
-  ...args: Parameters<RefreshProviderOAuthCredentialWithPlugin>
-): Promise<Awaited<ReturnType<RefreshProviderOAuthCredentialWithPlugin>>> {
-  const runtime = await loadProviderRuntime();
-  return runtime.refreshProviderOAuthCredentialWithPlugin(...args);
 }

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -93,7 +93,6 @@ let listProviderUsagePluginDescriptors: typeof import("./provider-runtime.js").l
 let normalizeProviderResolvedModelWithPlugin: typeof import("./provider-runtime.js").normalizeProviderResolvedModelWithPlugin;
 let prepareProviderDynamicModel: typeof import("./provider-runtime.js").prepareProviderDynamicModel;
 let prepareProviderRuntimeAuth: typeof import("./provider-runtime.js").prepareProviderRuntimeAuth;
-let refreshProviderOAuthCredentialWithPlugin: typeof import("./provider-runtime.js").refreshProviderOAuthCredentialWithPlugin;
 let resolveProviderOAuthCredentialWithPlugin: typeof import("./provider-runtime.js").resolveProviderOAuthCredentialWithPlugin;
 let resolveProviderRuntimePlugin: typeof import("./provider-runtime.js").resolveProviderRuntimePlugin;
 let providerRuntimeTesting: typeof import("./provider-runtime.js").testing;
@@ -344,7 +343,6 @@ describe("provider-runtime", () => {
       normalizeProviderResolvedModelWithPlugin,
       prepareProviderDynamicModel,
       prepareProviderRuntimeAuth,
-      refreshProviderOAuthCredentialWithPlugin,
       resolveProviderOAuthCredentialWithPlugin,
       resolveProviderRuntimePlugin,
       testing: providerRuntimeTesting,
@@ -446,6 +444,43 @@ describe("provider-runtime", () => {
     });
     expect(loginOAuth).toHaveBeenCalledOnce();
     expect(refreshOAuth).toHaveBeenCalledOnce();
+  });
+
+  it("uses a prepared OAuth handle without repeating registry resolution", async () => {
+    const controller = new AbortController();
+    const refreshOAuth = vi.fn(async (credential) => ({
+      ...credential,
+      access: "prepared-access",
+    }));
+    const plugin = {
+      id: "plugin-oauth",
+      label: "Plugin OAuth",
+      auth: [],
+      refreshOAuth,
+    };
+    resolveOwningPluginIdsForProviderMock.mockClear();
+    resolvePluginProvidersMock.mockClear();
+
+    await expect(
+      resolveProviderOAuthCredentialWithPlugin({
+        provider: "plugin-oauth",
+        credential: {
+          type: "oauth",
+          provider: "plugin-oauth",
+          access: "old-access",
+          refresh: "refresh",
+          expires: 1,
+        },
+        refresh: true,
+        runtimeHandle: { provider: "plugin-oauth", plugin },
+        signal: controller.signal,
+      }),
+    ).resolves.toMatchObject({ status: "available", credential: { access: "prepared-access" } });
+    expect(resolveOwningPluginIdsForProviderMock).not.toHaveBeenCalled();
+    expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
+    expect(refreshOAuth).toHaveBeenCalledWith(expect.any(Object), {
+      signal: controller.signal,
+    });
   });
 
   it("distinguishes an owned but unavailable OAuth provider", async () => {
@@ -2414,21 +2449,6 @@ describe("provider-runtime", () => {
       },
       {
         actual: () =>
-          refreshProviderOAuthCredentialWithPlugin({
-            provider: DEMO_PROVIDER_ID,
-            context: createDemoProviderContext({
-              type: "oauth",
-              access: "oauth-access",
-              refresh: "oauth-refresh",
-              expires: Date.now() + 60_000,
-            }),
-          }),
-        expected: {
-          access: "refreshed-access-token",
-        },
-      },
-      {
-        actual: () =>
           resolveProviderUsageAuthWithPlugin({
             provider: DEMO_PROVIDER_ID,
             env: process.env,
@@ -2654,7 +2674,6 @@ describe("provider-runtime", () => {
       normalizeToolSchemas,
       inspectToolSchemas,
       resolveReasoningOutputMode,
-      refreshOAuth,
       resolveSyntheticAuth,
       shouldDeferSyntheticProfileAuth,
       buildUnknownModelHint,

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -37,6 +37,7 @@ import {
   resolveProviderHookPlugin,
   resolveProviderPluginsForHooks,
   resolveProviderRuntimePlugin,
+  resolveProviderRuntimePluginHandle,
   wrapProviderSimpleCompletionStreamFn,
   type ProviderRuntimePluginHandle,
   wrapProviderStreamFn,
@@ -154,6 +155,7 @@ export {
   resolveProviderExtraParamsForTransport,
   resolveProviderFollowupFallbackRoute,
   resolveProviderRuntimePlugin,
+  resolveProviderRuntimePluginHandle,
   wrapProviderSimpleCompletionStreamFn,
   wrapProviderStreamFn,
 };
@@ -864,10 +866,12 @@ export async function resolveProviderOAuthCredentialWithPlugin(params: {
   env?: NodeJS.ProcessEnv;
   credential: OAuthCredential;
   refresh: boolean;
+  runtimeHandle?: ProviderRuntimePluginHandle;
+  signal?: AbortSignal;
 }) {
-  const ownership = resolveProviderRefOwnership(params);
-  const plugin = resolveProviderRuntimePlugin(params);
+  const plugin = ensureProviderRuntimePluginHandle(params).plugin;
   if (!plugin) {
+    const ownership = resolveProviderRefOwnership(params);
     return {
       status: ownership.status === "unowned" ? "unowned" : "configured-unavailable",
     } as const;
@@ -878,7 +882,7 @@ export async function resolveProviderOAuthCredentialWithPlugin(params: {
     if (!refreshOAuth) {
       return { status: "unhandled" } as const;
     }
-    credential = await refreshOAuth(params.credential);
+    credential = await refreshOAuth(params.credential, { signal: params.signal });
   }
   if (!credential) {
     return { status: "unhandled" } as const;
@@ -888,16 +892,6 @@ export async function resolveProviderOAuthCredentialWithPlugin(params: {
     return { status: "unhandled" } as const;
   }
   return { status: "available" as const, credential, apiKey };
-}
-
-export async function refreshProviderOAuthCredentialWithPlugin(params: {
-  provider: string;
-  config?: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-  context: OAuthCredential;
-}) {
-  return await resolveProviderRuntimePlugin(params)?.refreshOAuth?.(params.context);
 }
 
 export async function buildProviderAuthDoctorHintWithPlugin(params: {


### PR DESCRIPTION
Related: #89278

Depends on https://github.com/openclaw/openclaw/pull/121733.

## What Problem This Solves

Resolves a problem where OAuth refresh could rediscover provider ownership under serialization, use a stale prepared provider after a queued credential replacement, fail a configured provider before an existing valid token was needed, ignore caller cancellation, or discard a successful OpenAI refresh when the response omitted an unchanged refresh token.

## Why This Change Was Made

Provider ownership is prepared once before queue and file-lock acquisition, then the same handle and `AbortSignal` flow through registered, plugin, and built-in refresh owners. The prepared owner is rejected if the queued credential now belongs to a different provider. Valid unexpired stored credentials remain usable when a configured plugin is temporarily unavailable; unavailable providers fail closed only when refresh is actually required.

The public Plugin SDK contract adds the narrow optional `ProviderOAuthRefreshContext` and exports the access/refresh/expiry-only token-material comparator. OpenAI preserves the input refresh token when refresh omits a replacement, reports only genuinely missing required fields, and OpenAI/xAI owner runtimes remain lazily loaded. The obsolete generic core refresh helper and duplicate discovery policy were removed.

## User Impact

Provider plugins receive one prepared cancellable refresh contract without runtime lookup under lock. Existing valid credentials survive plugin availability changes, stale queued providers cannot refresh replacement credentials, and OpenAI OAuth refreshes work with either rotated or unchanged refresh tokens.

## Evidence

- Base: `stack/oauth-refresh-lifecycle-cas` at `60784fd8dd558d7347709074abe2d95d856e76e7`
- Exact head: `1b8eb8ce9f295f7212d936f2af1fbaa70fb9008c`
- Tree: `95e7c388683b374bcfbf598e30b0f641ceb34770`
- Full diff SHA-256: `0704e2a0aa3aa00c62f729d967c98d63dfe19e13503b9523fe5656dadc215045`
- Stable non-generated patch ID: `5e47769976829c9a8e39530871aa20dd406a1d32`
- Commit: signed, includes `Punchcard-Session: golden-meadow-cedar-dv`, and was attested by the execution session.
- Production LOC: `+286/-240` (net `+46`)
- Test LOC: `+499/-141` (net `+358`)
- Docs: `+10`; tooling: `+4/-2` (net `+2`); generated SDK baseline: `+17/-17` (net `0`)
- Exact-stack focused proof: `673` tests passed across OAuth ownership, CAS, `AuthStorage`, provider hooks, lazy loading, and the Codex bridge.
- Current-head SDK proof: API generation/check green; surface green at `337` entrypoints / `7,800` exports, public `152` / `4,879` with `2,932` callable; package exports synchronized and forbidden exports `0`.
- Current-head static proof: scoped format, Oxlint, diff, and privacy checks passed.
- Type-aware boundary: zero new OAuth errors; the existing `packages/terminal-core/src/ansi.ts:194` DTS failure reproduced on the parent during prior proof.
- Full proof on the semantically equivalent pre-final-main stack: non-sparse `pnpm check:test-types` and `pnpm build` passed; trusted changed-surface run https://github.com/openclaw/openclaw/actions/runs/31615859746 passed.
- Final delegated Testbox allocation https://github.com/openclaw/openclaw/actions/runs/31621343103 completed the changed-surface wrapper in `15m29s` with exit `0`, including SDK API/surface/export, typecheck, lint, boundary, and database-first guards. The workflow `headSha` is the contemporaneous `main`, not this PR head, and the backing Actions lifecycle may finish `cancelled` after external Testbox cleanup; the operator-captured wrapper exit is the proof source.

The non-generated patch identity remains exact after excluding the current-main-owned numeric-coercion import relocation; the 17 generated SDK baselines were regenerated canonically. Regressions cover preparation before locks, prepared-handle reuse and invalidation, exact signal forwarding, legacy one-argument hooks, registered/plugin/built-in precedence, configured-unavailable upgrades, OpenAI omitted/rotated refresh tokens, and lazy OpenAI/xAI startup imports.

Direct Codex contract check: `openai/codex@4ef836f883c38ba6d39e6920f335ce6452b7de33` keeps the external callback deadline and previous-account boundary in `codex-rs/app-server/src/external_auth.rs:18,33-45` and `codex-rs/app-server-protocol/src/protocol/v2/account.rs:266-275`.

Realtime/GPT-Live remains Platform API-key authenticated. This PR does not enable native GPT-Live OAuth.

Punchcard-Session: golden-meadow-cedar-dv
