### PR TITLE
fix(agents): recover subagent registry after transient restore failures

### DIFF
--- a/src/agents/subagents/registry/subagent-registry-restore.ts
+++ b/src/agents/subagents/registry/subagent-registry-restore.ts
@@ -40,6 +40,9 @@ const restoredQueuedFailureSettlementClaims = new WeakMap<
   RestoredQueuedFailureSettlementClaim
 >();
 
+const RESTORE_RETRY_DELAY_MS = 1_000;
+const RESTORE_RETRY_MAX_DELAY_MS = 30_000;
+
 export function isRestoredQueuedFailureSettlementClaimed(entry: SubagentRunRecord): boolean {
   return restoredQueuedFailureSettlementClaims.has(entry);
 }
@@ -97,19 +100,54 @@ export function createSubagentRegistryRestorer(config: {
     scheduleSweep,
     warn,
   } = config;
-  let restoreAttempted = false;
+  let restoreState: "idle" | "in-progress" | "succeeded" = "idle";
+  // A dependency can merge rows before throwing. Keep their reconciliation
+  // pending because mergeOnly correctly reports them as existing on retry.
+  let restoredRowsPending = false;
+  let restoreRetryTimer: ReturnType<typeof setTimeout> | undefined;
 
-  function restoreSubagentRunsOnce() {
-    if (restoreAttempted) {
+  function clearRestoreRetryTimer() {
+    if (restoreRetryTimer) {
+      clearTimeout(restoreRetryTimer);
+      restoreRetryTimer = undefined;
+    }
+  }
+
+  function scheduleRestoreRetry(delayMs: number) {
+    if (restoreRetryTimer) {
       return;
     }
-    restoreAttempted = true;
+    const timer = setTimeout(() => {
+      if (restoreRetryTimer !== timer) {
+        return;
+      }
+      restoreRetryTimer = undefined;
+      restoreSubagentRunsOnce(Math.min(delayMs * 2, RESTORE_RETRY_MAX_DELAY_MS));
+    }, delayMs);
+    restoreRetryTimer = timer;
+    timer.unref?.();
+  }
+
+  function completeRestore() {
+    restoredRowsPending = false;
+    restoreState = "succeeded";
+    clearRestoreRetryTimer();
+  }
+
+  function restoreSubagentRunsOnce(retryDelayMs = RESTORE_RETRY_DELAY_MS) {
+    if (restoreState !== "idle") {
+      return;
+    }
+    restoreState = "in-progress";
+    const runCountBeforeRestore = runs.size;
     try {
       const restoredCount = deps().restoreSubagentRunsFromDisk({
         runs,
         mergeOnly: true,
       });
-      if (restoredCount === 0) {
+      restoredRowsPending ||= restoredCount > 0;
+      if (!restoredRowsPending) {
+        completeRestore();
         return;
       }
       const cfg = deps().getRuntimeConfig();
@@ -154,6 +192,7 @@ export function createSubagentRegistryRestorer(config: {
         }
       }
       if (runs.size === 0) {
+        completeRestore();
         return;
       }
       // Resume pending work.
@@ -267,10 +306,14 @@ export function createSubagentRegistryRestorer(config: {
       // Cold-start restore can precede instance-runtime registration. The post-attach
       // startup pass retries this seam once the lifecycle-bound principal exists.
       scheduleSweep();
+      completeRestore();
     } catch (err) {
+      restoredRowsPending ||= runs.size > runCountBeforeRestore;
+      restoreState = "idle";
       warn(
         `failed to restore subagent runs from disk: ${err instanceof Error ? err.message : String(err)}`,
       );
+      scheduleRestoreRetry(retryDelayMs);
     }
   }
 
@@ -447,7 +490,9 @@ export function createSubagentRegistryRestorer(config: {
   return {
     restoreOnce: restoreSubagentRunsOnce,
     reset: () => {
-      restoreAttempted = false;
+      clearRestoreRetryTimer();
+      restoreState = "idle";
+      restoredRowsPending = false;
     },
   };
 }

--- a/src/agents/subagents/registry/subagent-registry.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.test.ts
@@ -1247,6 +1247,54 @@ describe("subagent registry seam flow", () => {
     ]);
   });
 
+  it("retries registry restore after a transient partial-merge failure", () => {
+    const runId = "run-restore-retry";
+    const restored = createSubagentRunRecord({
+      runId,
+      task: "retry registry restore",
+      cleanup: "keep",
+      pauseReason: "sessions_yield",
+      createdAt: Date.now(),
+    });
+    mocks.restoreSubagentRunsFromDisk
+      .mockImplementationOnce(((params: { runs: Map<string, SubagentRunRecord> }) => {
+        params.runs.set(runId, restored);
+        throw new Error("transient sqlite read failure");
+      }) as never)
+      .mockReturnValue(0);
+
+    mod.initSubagentRegistry();
+    expect(mocks.restoreSubagentRunsFromDisk).toHaveBeenCalledOnce();
+    expect(mocks.onAgentEvent).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1_000);
+
+    expect(mocks.restoreSubagentRunsFromDisk).toHaveBeenCalledTimes(2);
+    expect(mod.getSubagentRunByRunId(runId)?.runId).toBe(runId);
+    expect(mocks.onAgentEvent).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(1);
+  });
+
+  it("latches registry restore only after success", () => {
+    mocks.restoreSubagentRunsFromDisk.mockReturnValue(0);
+
+    mod.initSubagentRegistry();
+    mod.initSubagentRegistry();
+
+    expect(mocks.restoreSubagentRunsFromDisk).toHaveBeenCalledOnce();
+  });
+
+  it("does not double-run reentrant registry restore calls", () => {
+    mocks.restoreSubagentRunsFromDisk.mockImplementation(() => {
+      mod.initSubagentRegistry();
+      return 0;
+    });
+
+    mod.initSubagentRegistry();
+
+    expect(mocks.restoreSubagentRunsFromDisk).toHaveBeenCalledOnce();
+  });
+
   it("replays a past-due requester-settle obligation during registry restore", async () => {
     const endedAt = Date.now() - 1_000;
     mocks.restoreSubagentRunsFromDisk.mockImplementation(((params: {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where a gateway restart could permanently lose persisted subagent recovery for the lifetime of the process when the initial registry read failed transiently. That left restored runs, completion announcements, and restart reconciliation silently inactive until another gateway restart.

## Why This Change Was Made

The registry restorer now owns an explicit idle/in-progress/succeeded state and only latches after the complete restore pass succeeds. Failures return it to idle and schedule an unref'd, reset-tracked exponential retry capped at 30 seconds; rows merged before an exception remain marked for idempotent reconciliation on the next pass. The deferred bootstrap pending/ready facade is unchanged.

## User Impact

Gateway restart recovery no longer disappears permanently because of one transient SQLite read failure. Persisted subagent runs can recover automatically without requiring an operator to restart the gateway again.

## Evidence

Focused restore and persistence suites:

```text
node scripts/run-vitest.mjs src/agents/subagents/registry/subagent-registry.test.ts src/agents/subagents/registry/subagent-registry.persistence.test.ts src/agents/subagents/registry/subagent-registry.persistence.resume.test.ts src/agents/subagents/registry/subagent-registry.store.sqlite.test.ts
Test Files  4 passed (4)
Tests  190 passed (190)
[test] passed 1 Vitest shard
```

Build and import boundaries (owned AWS runner, exact local diff):

```text
pnpm build
[build-all] phase timings: total 4m 40.2s
exitCode: 0

pnpm check:import-cycles
Import cycle check: 0 runtime value cycle(s).
exitCode: 0
```

Verification report excerpt:

```text
- transient partial merge throws once, then the scheduled restore retries, retains the row, and starts listener/sweeper ownership
- successful restore latches and a second entrypoint call is a no-op
- reentrant restore entrypoints cannot double-run while restoration is in progress
- deferred-bootstrap pending/ready wiring remains unchanged
- production LOC: +51/-6 (net +45); tests: +48/-0
- autoreview clean: no accepted/actionable findings reported
```
