### PR TITLE
test(ai): remove schema cache reset seam

### DIFF
--- a/packages/ai/src/package.e2e.test.ts
+++ b/packages/ai/src/package.e2e.test.ts
@@ -128,7 +128,6 @@ const compatibility = {
       "reconcileOpenAICompletionsToolChoice",
       "findOpenAIStrictSchemaViolations",
       "normalizeOpenAIStrictCompatSchema",
-      "clearOpenAIToolSchemaCacheForTest",
       "normalizeStrictOpenAIJsonSchema",
       "normalizeOpenAIStrictToolParameters",
       "isStrictOpenAIJsonSchemaCompatible",

--- a/packages/ai/src/providers/openai-tool-schema.test.ts
+++ b/packages/ai/src/providers/openai-tool-schema.test.ts
@@ -1,8 +1,7 @@
 // Verifies OpenAI strict tool schema normalization and cache behavior.
-import { beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { projectOpenAITools } from "./openai-tool-projection.js";
 import {
-  clearOpenAIToolSchemaCacheForTest,
   findOpenAIStrictSchemaViolations,
   findOpenAIStrictToolProjectionDiagnostics,
   isStrictOpenAIJsonSchemaCompatible,
@@ -12,10 +11,6 @@ import {
 } from "./openai-tool-schema.js";
 
 describe("OpenAI strict tool schema normalization", () => {
-  beforeEach(() => {
-    clearOpenAIToolSchemaCacheForTest();
-  });
-
   it("repairs top-level object schemas with missing or invalid properties", () => {
     const schemas = [
       { type: "object" },

--- a/packages/ai/src/providers/openai-tool-schema.ts
+++ b/packages/ai/src/providers/openai-tool-schema.ts
@@ -25,7 +25,7 @@ type ToolSchemaCompatInput = {
 };
 
 const MAX_STRICT_SCHEMA_CACHE_ENTRIES_PER_SCHEMA = 8;
-let strictOpenAISchemaCache = new WeakMap<object, Array<{ key: string; value: unknown }>>();
+const strictOpenAISchemaCache = new WeakMap<object, Array<{ key: string; value: unknown }>>();
 
 function resolveToolSchemaModelCompat(
   compat: ToolSchemaCompatInput | null | undefined,
@@ -71,10 +71,6 @@ function rememberStrictOpenAISchema(schema: object, key: string, value: unknown)
     ),
   );
   return value;
-}
-
-export function clearOpenAIToolSchemaCacheForTest(): void {
-  strictOpenAISchemaCache = new WeakMap();
 }
 
 /** Normalizes a tool parameter schema into the OpenAI strict JSON-schema subset. */


### PR DESCRIPTION
## What Problem This Solves

The OpenAI strict-schema cache exposed a `clearOpenAIToolSchemaCacheForTest` runtime function solely for a suite-wide `beforeEach`. Each test already creates its own schema objects, and the actual cache identity regression is asserted directly, so the reset detected no independent behavior.

The test-only function was also swept into the packed `@openclaw/ai/internal/openai` compatibility inventory, accidentally freezing an internal no-semver symbol.

## Why This Change Was Made

This removes the reset function, its test hook/import, and the compatibility inventory entry. With no remaining reassignment, the cache owner becomes a `const`.

The meaningful regression remains unchanged: repeated normalization of the same schema object and compatibility key preserves identity, while a different compatibility key produces a distinct cached result.

AI-assisted: yes. The change was manually inspected and passed repository autoreview.

## User Impact

No user-visible behavior change. The internal AI package exposes one fewer test-only symbol and the schema cache has a simpler immutable owner.

## Evidence

- `node scripts/run-vitest.mjs packages/ai/src/providers/openai-tool-schema.test.ts` — 9 tests passed.
- `node scripts/check-changed.mjs -- packages/ai/src/providers/openai-tool-schema.ts packages/ai/src/providers/openai-tool-schema.test.ts packages/ai/src/package.e2e.test.ts` — passed all selected core/type/lint/dead-export/boundary gates using the trusted local fallback because Blacksmith Testbox is unavailable on this host.
- Targeted oxlint, oxfmt, and `git diff --check` — passed.
- Fresh autoreview and secret scan — clean.
- The packed-package E2E reaches its external consumer but times out inside the consumer `tsgo` command on this host. The unchanged current-`main` test reproduces the same timeout at the same step, so this is a baseline local-host limitation rather than an export mismatch. Exact-head hosted CI remains the authoritative package proof.

## Scope and LOC

- Production: `+1/-5` (net `-4`; test-only export removed and cache binding made immutable).
- Tests: `+1/-7` (net `-6`).
- Overall: `+2/-12` (net `-10`).

No runtime behavior, config, protocol, schema, dependency, lockfile, generated baseline, release, docs, or changelog change.
