### PR TITLE
fix(agents): prevent follow-up replies from overwriting older results

### DIFF
--- a/src/agents/subagents/registry/subagent-registry-lifecycle-delivery.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-delivery.ts
@@ -362,7 +362,7 @@ export function createSubagentRegistryLifecycleDelivery(
     const candidates = listPendingCompletionRunsForSession(sessionKey).filter(
       (entry) => entry.execution.outcome?.status !== "error",
     );
-    const entry = candidates.sort(compareSubagentRunGeneration).at(-1);
+    const entry = candidates.toSorted(compareSubagentRunGeneration).at(-1);
     if (!entry || newerGenerationOwnsSession(entry)) {
       return false;
     }

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-delivery.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-delivery.ts
@@ -36,6 +36,7 @@ import type {
   SubagentRegistryLifecycleState,
 } from "./subagent-registry-lifecycle-contracts.js";
 import type { PendingFinalDeliveryPayload, SubagentRunRecord } from "./subagent-registry.types.js";
+import { compareSubagentRunGeneration } from "./subagent-run-generation.js";
 
 const DELIVERY_MIRROR_HISTORY_MAX_CHARS = 128 * 1024;
 
@@ -361,9 +362,11 @@ export function createSubagentRegistryLifecycleDelivery(
     const candidates = listPendingCompletionRunsForSession(sessionKey).filter(
       (entry) => entry.execution.outcome?.status !== "error",
     );
-    if (candidates.length === 0) {
+    const entry = candidates.sort(compareSubagentRunGeneration).at(-1);
+    if (!entry || newerGenerationOwnsSession(entry)) {
       return false;
     }
+    const generation = entry.generation;
 
     let captured: string | undefined;
     try {
@@ -375,23 +378,25 @@ export function createSubagentRegistryLifecycleDelivery(
     if (!trimmed || isSilentAgentReplyText(trimmed)) {
       return false;
     }
+    // Reply capture yields while registration can transfer session ownership.
+    // Only the exact row and generation that started capture may commit its text.
+    if (
+      params.runs.get(entry.runId) !== entry ||
+      entry.generation !== generation ||
+      newerGenerationOwnsSession(entry)
+    ) {
+      return false;
+    }
 
     const nextFrozen = capFrozenResultText(trimmed);
-    const capturedAt = Date.now();
-    let changed = false;
-    for (const entry of candidates) {
-      const completion = ensureCompletionState(entry);
-      if (completion.resultText === nextFrozen) {
-        continue;
-      }
-      completion.resultText = nextFrozen;
-      completion.capturedAt = capturedAt;
-      changed = true;
+    const completion = ensureCompletionState(entry);
+    if (completion.resultText === nextFrozen) {
+      return false;
     }
-    if (changed) {
-      params.persist(...candidates.map((entry) => entry.runId));
-    }
-    return changed;
+    completion.resultText = nextFrozen;
+    completion.capturedAt = Date.now();
+    params.persist(entry.runId);
+    return true;
   };
 
   const emitCompletionEndedHookIfNeeded = async (

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -1488,6 +1488,104 @@ describe("subagent registry lifecycle hardening", () => {
     expect(entry.completion?.resultText).toBeUndefined();
   });
 
+  it("refreshes only the newest pending completion generation for a shared session", async () => {
+    const childSessionKey = "agent:main:subagent:shared-refresh";
+    const older = createRunEntry({
+      runId: "run-shared-refresh-old",
+      childSessionKey,
+      generation: 1,
+      createdAt: 1_000,
+      expectsCompletionMessage: true,
+      endedAt: 4_000,
+      outcome: { status: "ok" },
+      completion: {
+        required: true,
+        resultText: "older generation result",
+        capturedAt: 4_000,
+      },
+    });
+    const newer = createRunEntry({
+      runId: "run-shared-refresh-new",
+      childSessionKey,
+      generation: 2,
+      createdAt: 2_000,
+      expectsCompletionMessage: true,
+      endedAt: 5_000,
+      outcome: { status: "ok" },
+      completion: {
+        required: true,
+        resultText: "newer generation placeholder",
+        capturedAt: 5_000,
+      },
+    });
+    const olderBefore = structuredClone(older);
+    const persist = vi.fn();
+    const controller = createLifecycleController({
+      entry: newer,
+      runs: new Map([
+        [older.runId, older],
+        [newer.runId, newer],
+      ]),
+      persist,
+      captureSubagentCompletionReply: vi.fn(async () => "latest session reply"),
+    });
+
+    expect(await controller.refreshFrozenResultFromSession(childSessionKey)).toBe(true);
+
+    expect(older).toEqual(olderBefore);
+    expect(newer.completion).toMatchObject({
+      resultText: "latest session reply",
+      capturedAt: expect.any(Number),
+    });
+    expect(persist).toHaveBeenCalledOnce();
+    expect(persist).toHaveBeenCalledWith(newer.runId);
+  });
+
+  it("rejects a frozen-result refresh when a newer generation registers during capture", async () => {
+    const childSessionKey = "agent:main:subagent:refresh-race";
+    const entry = createRunEntry({
+      runId: "run-refresh-race-old",
+      childSessionKey,
+      generation: 1,
+      expectsCompletionMessage: true,
+      endedAt: 4_000,
+      outcome: { status: "ok" },
+    });
+    const runs = new Map([[entry.runId, entry]]);
+    let finishCapture: ((value: string) => void) | undefined;
+    const captureSubagentCompletionReply = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          finishCapture = resolve;
+        }),
+    );
+    const persist = vi.fn();
+    const controller = createLifecycleController({
+      entry,
+      runs,
+      persist,
+      captureSubagentCompletionReply,
+    });
+
+    const refresh = controller.refreshFrozenResultFromSession(childSessionKey);
+    await waitForLifecycleState(() =>
+      expect(captureSubagentCompletionReply).toHaveBeenCalledOnce(),
+    );
+    const successor = createRunEntry({
+      runId: "run-refresh-race-new",
+      childSessionKey,
+      generation: 2,
+      createdAt: 2_000,
+    });
+    runs.set(successor.runId, successor);
+    finishCapture?.("reply owned by the successor");
+
+    expect(await refresh).toBe(false);
+    expect(entry.completion?.resultText).toBeUndefined();
+    expect(successor.completion?.resultText).toBeUndefined();
+    expect(persist).not.toHaveBeenCalled();
+  });
+
   it("keeps success canonical while a killed callback waits behind reply capture", async () => {
     const entry = createRunEntry({ expectsCompletionMessage: true });
     let releaseCapture: ((value: string) => void) | undefined;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a later follow-up reply could silently overwrite the frozen completion result of every older pending subagent run that shared the same child session.

Impact: prevents a follow-up's reply from silently overwriting older pending runs' results.

## Why This Change Was Made

Lifecycle delivery now refreshes only the newest eligible generation, uses the shared session-ownership predicate to reject a newer running or terminal owner, and revalidates the exact row and generation after asynchronous reply capture. Older generations remain untouched. The explicit completion path is unchanged.

## User Impact

Subagent completion results remain attributed to the generation that produced them, even when a child session is reused for a follow-up or a newer registration races reply capture.

## Evidence

- Pre-fix verification: both new boundary cases fail for the intended reasons—the older row is mutated, and a stale capture commits after successor registration.
- Post-fix focused cases: 4 passed.
- Registry lifecycle + listener suites on the pushed tree: 291 passed.
- `pnpm build`: passed; all 151 public plugin SDK subpaths verified, Control UI asset/performance checks passed, and all build phases completed.
- `pnpm check:import-cycles`: `Import cycle check: 0 runtime value cycle(s).`
- Autoreview: `autoreview clean: no accepted/actionable findings reported`.
- Exact-head PR CI: [green on `b10c1cc0`](https://github.com/openclaw/openclaw/actions/runs/31446387501).

Verification excerpt:

```text
Test Files  2 passed (2)
Tests       291 passed (291)
[test] passed 1 Vitest shard

Import cycle check: 0 runtime value cycle(s).
autoreview clean: no accepted/actionable findings reported
```

Blacksmith Testbox was unavailable because its CLI is not installed, and direct AWS Crabbox was unavailable because no broker login is configured. The explicitly requested commands therefore ran locally; exact-head hosted PR CI subsequently passed.
