### PR TITLE
refactor(ui): simplify retained session switching

### DIFF
--- a/ui/src/pages/chat/chat-page-pane-render.ts
+++ b/ui/src/pages/chat/chat-page-pane-render.ts
@@ -1,0 +1,128 @@
+import { html } from "lit";
+import { repeat } from "lit/directives/repeat.js";
+import type { ApplicationContext } from "../../app/context.ts";
+import { nativeGatewaysCapability } from "../../app/native-gateways.runtime.ts";
+import type { BoardFace } from "../../lib/board/settings.ts";
+import { resolveSessionDisplayName } from "../../lib/session-display.ts";
+import { resolveSessionKey } from "../../lib/sessions/index.ts";
+import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
+import type { PaneSessionChangeOptions } from "./chat-pane-shared.ts";
+import type { RouteDraftComposerFocus } from "./route-draft-focus-handoff.ts";
+import { routeDraft } from "./route-draft.ts";
+import type { SessionChatRouteData } from "./route-loader.ts";
+import type { ChatMessageCache } from "./session-message-cache.ts";
+import type { ChatSplitPane } from "./split-layout.ts";
+
+type ChatPagePaneRenderOptions = {
+  active: boolean;
+  chatMessagesBySession: ChatMessageCache;
+  consumedDraftData: SessionChatRouteData | null;
+  context?: ApplicationContext;
+  data?: SessionChatRouteData;
+  draftFocus: RouteDraftComposerFocus;
+  mergedChrome: boolean;
+  narrow: boolean;
+  navDrawerOpen: boolean;
+  onboarding: boolean;
+  onClosePane?: (paneId: string) => void;
+  onFaceChange: (paneId: string, sessionKey: string, face: BoardFace) => void;
+  onFocusPane: (paneId: string) => void;
+  onOpenSplitView?: () => void;
+  onPaneSessionChange: (
+    paneId: string,
+    sourceSessionKey: string,
+    sessionKey: string,
+    options?: PaneSessionChangeOptions,
+  ) => boolean;
+  onSessionDeleted: (paneId: string, sessionKey: string, replacementSessionKey: string) => void;
+  onSplitDown?: (paneId: string) => void;
+  onSplitRight?: (paneId: string) => void;
+  ownerKey: string;
+  pane: ChatSplitPane;
+  sessionKeys: readonly string[];
+  showGatewayPicker: boolean;
+  splitMode: boolean;
+  weight: number;
+};
+
+export function renderChatPagePaneCell(options: ChatPagePaneRenderOptions) {
+  const nativeGateways = options.showGatewayPicker ? nativeGatewaysCapability() : null;
+  const sessions = options.context?.sessions?.state.result?.sessions ?? [];
+  return html`
+    <div
+      class="chat-split-view__cell ${options.splitMode && options.active
+        ? "chat-split-view__cell--active"
+        : ""} ${options.narrow && !options.active ? "chat-split-view__cell--narrow-hidden" : ""}"
+      style="flex: ${options.weight} 1 0"
+      @pointerdown=${() => options.onFocusPane(options.pane.id)}
+      @focusin=${() => options.onFocusPane(options.pane.id)}
+    >
+      <div class="chat-pane-cache">
+        ${repeat(
+          options.sessionKeys,
+          (sessionKey) => sessionKey,
+          (sessionKey) => {
+            const visible =
+              sessionKey === options.pane.sessionKey ||
+              areUiSessionKeysEquivalent(sessionKey, options.pane.sessionKey);
+            const presented = visible && (!options.narrow || options.active);
+            const active = options.active && visible;
+            const draft = active
+              ? routeDraft(options.data, options.consumedDraftData, sessionKey)
+              : undefined;
+            const resolvedKey =
+              resolveSessionKey(sessionKey, options.context?.gateway?.snapshot?.hello) ||
+              sessionKey;
+            const title = resolveSessionDisplayName(
+              resolvedKey,
+              sessions.find((row) => areUiSessionKeysEquivalent(row.key, resolvedKey)),
+            );
+            return html`<openclaw-chat-pane
+              class="chat-pane-cache__pane ${visible
+                ? "chat-pane-cache__pane--visible"
+                : ""} ${active ? "chat-pane-cache__pane--active" : ""} ${options.splitMode
+                ? "chat-split-view__pane"
+                : ""}"
+              data-mcp-app-owner-key=${JSON.stringify([options.ownerKey, sessionKey])}
+              aria-hidden=${presented ? "false" : "true"}
+              ?inert=${!presented}
+              .paneId=${options.pane.id}
+              .presentationId=${JSON.stringify([options.pane.id, sessionKey])}
+              .chatMessagesBySession=${options.chatMessagesBySession}
+              .sessionKey=${sessionKey}
+              .presented=${presented}
+              .active=${active}
+              .draft=${draft}
+              .focusComposer=${options.draftFocus.shouldFocusPane(
+                active,
+                draft,
+                sessionKey,
+                options.data,
+              )}
+              .routeFace=${options.data?.face ?? "chat"}
+              .paneTitle=${title}
+              .narrow=${options.narrow}
+              .mergedChrome=${options.mergedChrome && active}
+              .navDrawerOpen=${options.navDrawerOpen && active}
+              .nativeGateways=${nativeGateways}
+              .gatewaysSnapshot=${nativeGateways?.snapshot ?? null}
+              .onboarding=${options.onboarding}
+              .onOpenSplitView=${options.onOpenSplitView}
+              .onSplitDown=${options.onSplitDown}
+              .onSplitRight=${options.onSplitRight}
+              .onClosePane=${options.onClosePane}
+              .onFocusPane=${options.onFocusPane}
+              .onPaneSessionChange=${(
+                paneId: string,
+                nextSessionKey: string,
+                paneOptions?: PaneSessionChangeOptions,
+              ) => options.onPaneSessionChange(paneId, sessionKey, nextSessionKey, paneOptions)}
+              .onSessionDeleted=${options.onSessionDeleted}
+              .onFaceChange=${options.onFaceChange}
+            ></openclaw-chat-pane>`;
+          },
+        )}
+      </div>
+    </div>
+  `;
+}

--- a/ui/src/pages/chat/chat-page-retained-sessions.test.ts
+++ b/ui/src/pages/chat/chat-page-retained-sessions.test.ts
@@ -76,6 +76,26 @@ function stubMatchMedia() {
   );
 }
 
+async function showSession(page: ChatPage, sessionKey: string): Promise<void> {
+  page.data = { sessionKey };
+  await page.updateComplete;
+  await page.updateComplete;
+}
+
+async function mountRetainedPage(sessionKey: string, ...warmSessionKeys: string[]) {
+  const page = new ChatPage();
+  const navigation = setNavigationContext(page);
+  page.data = { sessionKey };
+  document.body.append(page);
+  await page.updateComplete;
+  for (const key of warmSessionKeys) {
+    await showSession(page, key);
+  }
+  const panes = () => [...page.querySelectorAll<RenderedPane>("openclaw-chat-pane")];
+  const paneFor = (key: string) => panes().find((pane) => pane.sessionKey === key);
+  return { navigation, page, paneFor, panes };
+}
+
 describe("chat page retained sessions", () => {
   beforeEach(() => {
     vi.stubGlobal("localStorage", createStorageMock());
@@ -91,24 +111,11 @@ describe("chat page retained sessions", () => {
   });
 
   it("retains three session panes and reactivates them without remounting", async () => {
-    const page = new ChatPage();
-    setNavigationContext(page);
-    page.data = { sessionKey: "agent:main:a" };
-    document.body.append(page);
-    await page.updateComplete;
-
-    const navigate = async (sessionKey: string) => {
-      page.data = { sessionKey };
-      await page.updateComplete;
-      await page.updateComplete;
-    };
-    const panes = () => [...page.querySelectorAll<RenderedPane>("openclaw-chat-pane")];
-    const paneFor = (sessionKey: string) =>
-      panes().find((candidate) => candidate.sessionKey === sessionKey);
+    const { page, paneFor, panes } = await mountRetainedPage("agent:main:a");
     const paneA = paneFor("agent:main:a");
     expect(paneA).toBeDefined();
 
-    await navigate("agent:main:b");
+    await showSession(page, "agent:main:b");
     const paneB = paneFor("agent:main:b");
     expect(paneB).toBeDefined();
     expect(paneB?.presentationId).not.toBe(paneA?.presentationId);
@@ -120,12 +127,12 @@ describe("chat page retained sessions", () => {
     expect(paneB?.presented).toBe(true);
     expect(paneB?.hasAttribute("inert")).toBe(false);
 
-    await navigate("agent:main:a");
+    await showSession(page, "agent:main:a");
     expect(paneFor("agent:main:a")).toBe(paneA);
     expect(paneFor("agent:main:b")).toBe(paneB);
 
-    await navigate("agent:main:c");
-    await navigate("agent:main:d");
+    await showSession(page, "agent:main:c");
+    await showSession(page, "agent:main:d");
     expect(
       panes()
         .map((pane) => pane.sessionKey)
@@ -194,16 +201,8 @@ describe("chat page retained sessions", () => {
   });
 
   it("rejects navigation and face changes from a hidden retained session", async () => {
-    const page = new ChatPage();
-    const navigation = setNavigationContext(page);
-    page.data = { sessionKey: "agent:main:a" };
-    document.body.append(page);
-    await page.updateComplete;
-    const paneA = page.querySelector<RenderedPane>("openclaw-chat-pane");
-
-    page.data = { sessionKey: "agent:main:b" };
-    await page.updateComplete;
-    await page.updateComplete;
+    const { navigation, page, paneFor } = await mountRetainedPage("agent:main:a", "agent:main:b");
+    const paneA = paneFor("agent:main:a");
     navigation.navigate.mockClear();
     navigation.patch.mockClear();
 
@@ -219,11 +218,7 @@ describe("chat page retained sessions", () => {
   });
 
   it("rejects a pane callback while a newer browser route is loading", async () => {
-    const page = new ChatPage();
-    const navigation = setNavigationContext(page);
-    page.data = { sessionKey: "main" };
-    document.body.append(page);
-    await page.updateComplete;
+    const { navigation, page } = await mountRetainedPage("main");
     const pane = page.querySelector<RenderedPane>("openclaw-chat-pane");
     const previousHref = window.location.href;
 
@@ -238,21 +233,13 @@ describe("chat page retained sessions", () => {
   });
 
   it("presents a retained sidebar destination before route data resolves", async () => {
-    const page = new ChatPage();
-    setNavigationContext(page);
-    page.data = { sessionKey: "agent:main:a" };
-    document.body.append(page);
-    await page.updateComplete;
-
-    page.data = { sessionKey: "agent:main:b" };
-    await page.updateComplete;
-    await page.updateComplete;
-    const panes = () => [...page.querySelectorAll<RenderedPane>("openclaw-chat-pane")];
-    const paneA = panes().find((pane) => pane.sessionKey === "agent:main:a");
-    const paneB = panes().find((pane) => pane.sessionKey === "agent:main:b");
-    page.data = { sessionKey: "agent:main:a" };
-    await page.updateComplete;
-    await page.updateComplete;
+    const { page, paneFor, panes } = await mountRetainedPage(
+      "agent:main:a",
+      "agent:main:b",
+      "agent:main:a",
+    );
+    const paneA = paneFor("agent:main:a");
+    const paneB = paneFor("agent:main:b");
 
     const intent = new CustomEvent(SESSION_NAVIGATION_INTENT_EVENT, {
       cancelable: true,
@@ -315,27 +302,17 @@ describe("chat page retained sessions", () => {
   });
 
   it("evicts a deleted inactive retained session without redirecting the active pane", async () => {
-    const page = new ChatPage();
-    const navigation = setNavigationContext(page);
-    page.data = { sessionKey: "agent:main:a" };
-    document.body.append(page);
-    await page.updateComplete;
-    page.data = { sessionKey: "agent:main:b" };
-    await page.updateComplete;
-    await page.updateComplete;
-    const paneA = [...page.querySelectorAll<RenderedPane>("openclaw-chat-pane")].find(
-      (pane) => pane.sessionKey === "agent:main:a",
+    const { navigation, page, paneFor, panes } = await mountRetainedPage(
+      "agent:main:a",
+      "agent:main:b",
     );
+    const paneA = paneFor("agent:main:a");
     navigation.navigate.mockClear();
 
     paneA?.onSessionDeleted?.("p1", "agent:main:a", "agent:main:main");
     await page.updateComplete;
 
-    expect(
-      [...page.querySelectorAll<RenderedPane>("openclaw-chat-pane")].some(
-        (pane) => pane.sessionKey === "agent:main:a",
-      ),
-    ).toBe(false);
+    expect(panes().some((pane) => pane.sessionKey === "agent:main:a")).toBe(false);
     expect(navigation.navigate).not.toHaveBeenCalled();
     expect(page.data.sessionKey).toBe("agent:main:b");
   });
@@ -343,20 +320,9 @@ describe("chat page retained sessions", () => {
   it("rolls a retained preview back when authoritative navigation never commits", async () => {
     vi.useFakeTimers();
     try {
-      const page = new ChatPage();
-      setNavigationContext(page);
-      page.data = { sessionKey: "agent:main:a" };
-      document.body.append(page);
-      await page.updateComplete;
-      page.data = { sessionKey: "agent:main:b" };
-      await page.updateComplete;
-      await page.updateComplete;
-      page.data = { sessionKey: "agent:main:a" };
-      await page.updateComplete;
-      await page.updateComplete;
-      const panes = [...page.querySelectorAll<RenderedPane>("openclaw-chat-pane")];
-      const paneA = panes.find((pane) => pane.sessionKey === "agent:main:a");
-      const paneB = panes.find((pane) => pane.sessionKey === "agent:main:b");
+      const { paneFor } = await mountRetainedPage("agent:main:a", "agent:main:b", "agent:main:a");
+      const paneA = paneFor("agent:main:a");
+      const paneB = paneFor("agent:main:b");
 
       window.dispatchEvent(
         new CustomEvent(SESSION_NAVIGATION_INTENT_EVENT, {
@@ -389,16 +355,12 @@ describe("chat page retained sessions", () => {
     vi.spyOn(window, "cancelAnimationFrame").mockImplementation((frame) => {
       frames.delete(frame);
     });
-    const page = new ChatPage();
-    setNavigationContext(page);
-    page.data = { sessionKey: "agent:main:a" };
-    document.body.append(page);
-    await page.updateComplete;
-    for (const sessionKey of ["agent:main:b", "agent:main:c", "agent:main:a"]) {
-      page.data = { sessionKey };
-      await page.updateComplete;
-      await page.updateComplete;
-    }
+    const { page } = await mountRetainedPage(
+      "agent:main:a",
+      "agent:main:b",
+      "agent:main:c",
+      "agent:main:a",
+    );
     const commitB = vi.fn(() => true);
     const commitC = vi.fn(() => true);
 

--- a/ui/src/pages/chat/chat-page-retained-sessions.ts
+++ b/ui/src/pages/chat/chat-page-retained-sessions.ts
@@ -1,27 +1,12 @@
-import { html } from "lit";
-import { repeat } from "lit/directives/repeat.js";
 import type { ApplicationContext } from "../../app/context.ts";
-import { nativeGatewaysCapability } from "../../app/native-gateways.runtime.ts";
-import type { BoardFace } from "../../lib/board/settings.ts";
-import { resolveSessionDisplayName } from "../../lib/session-display.ts";
-import { resolveSessionKey } from "../../lib/sessions/index.ts";
 import {
   SESSION_NAVIGATION_INTENT_EVENT,
   type SessionNavigationIntent,
 } from "../../lib/sessions/navigation-handoff.ts";
 import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
-import { persistSessionBoardFace } from "./chat-board-face-persistence.ts";
 import { clearPaneSessionHandoff, clearPaneSessionHandoffs } from "./chat-pane-shared.ts";
-import { RouteDraftComposerFocus, type ChatPaneElement } from "./route-draft-focus-handoff.ts";
-import { routeDraft } from "./route-draft.ts";
-import type { SessionChatRouteData } from "./route-loader.ts";
-import type { ChatMessageCache } from "./session-message-cache.ts";
-import {
-  findPane,
-  setActivePane,
-  type ChatSplitLayout,
-  type ChatSplitPane,
-} from "./split-layout.ts";
+import type { ChatPaneElement } from "./route-draft-focus-handoff.ts";
+import { findPane, type ChatSplitLayout, type ChatSplitPane } from "./split-layout.ts";
 
 const RETAINED_SESSIONS_PER_PANE = 3;
 const SESSION_NAVIGATION_PREVIEW_TIMEOUT_MS = 5_000;
@@ -29,12 +14,9 @@ const SESSION_NAVIGATION_PREVIEW_TIMEOUT_MS = 5_000;
 type RetentionHost = HTMLElement & { requestUpdate(): unknown };
 type RetentionBindings = {
   context: () => ApplicationContext | undefined;
-  face: () => BoardFace;
+  face: () => SessionNavigationIntent["face"];
   layout: () => ChatSplitLayout;
-  splitLayout: () => ChatSplitLayout | undefined;
-  persistLayout: (layout: ChatSplitLayout) => void;
   selectReplacement: (paneId: string, sourceSessionKey: string, sessionKey: string) => void;
-  updateRoute: (sessionKey: string, replace: boolean, face: BoardFace) => void;
 };
 
 export class ChatPageRetainedSessions {
@@ -74,7 +56,17 @@ export class ChatPageRetainedSessions {
     }
   }
 
-  retain(pane: ChatSplitPane): string[] {
+  retain(panes: readonly ChatSplitPane[]): ReadonlyMap<string, readonly string[]> {
+    const paneIds = new Set(panes.map((pane) => pane.id));
+    for (const paneId of this.sessionsByPane.keys()) {
+      if (!paneIds.has(paneId)) {
+        this.sessionsByPane.delete(paneId);
+      }
+    }
+    return new Map(panes.map((pane) => [pane.id, this.retainPane(pane)]));
+  }
+
+  private retainPane(pane: ChatSplitPane): string[] {
     let retained = this.sessionsByPane.get(pane.id);
     if (!retained) {
       retained = [];
@@ -90,14 +82,6 @@ export class ChatPageRetainedSessions {
       this.findPane(pane.id, retained.shift()!)?.prepareForEviction?.();
     }
     return retained.toSorted((left, right) => left.localeCompare(right));
-  }
-
-  prune(validPaneIds: ReadonlySet<string>): void {
-    for (const paneId of this.sessionsByPane.keys()) {
-      if (!validPaneIds.has(paneId)) {
-        this.sessionsByPane.delete(paneId);
-      }
-    }
   }
 
   discardPane(paneId: string): void {
@@ -136,22 +120,6 @@ export class ChatPageRetainedSessions {
       this.bindings.selectReplacement(paneId, sessionKey, replacementSessionKey);
     } else {
       this.host.requestUpdate();
-    }
-  };
-
-  readonly changeFace = (paneId: string, sessionKey: string, face: BoardFace): void => {
-    const selectedSessionKey = findPane(this.bindings.layout(), paneId)?.pane.sessionKey;
-    if (!selectedSessionKey || !areUiSessionKeysEquivalent(selectedSessionKey, sessionKey)) {
-      return;
-    }
-    const layout = this.bindings.splitLayout();
-    if (layout && layout.activePaneId !== paneId) {
-      this.bindings.persistLayout(setActivePane(layout, paneId));
-    }
-    const context = this.bindings.context();
-    if (context) {
-      persistSessionBoardFace(context, sessionKey, face);
-      this.bindings.updateRoute(sessionKey, false, face);
     }
   };
 
@@ -251,95 +219,4 @@ export class ChatPageRetainedSessions {
       this.present(activePane.id, activePane.sessionKey);
     }
   };
-}
-
-export function renderRetainedChatPanes(params: {
-  active: boolean;
-  chatMessagesBySession: ChatMessageCache;
-  consumedDraftData: SessionChatRouteData | null;
-  data: SessionChatRouteData;
-  draftFocus: RouteDraftComposerFocus;
-  mergedChrome: boolean;
-  narrow: boolean;
-  navDrawerOpen: boolean;
-  onboarding: boolean;
-  onClosePane?: (paneId: string) => void;
-  onFaceChange: (paneId: string, sessionKey: string, face: BoardFace) => void;
-  onFocusPane: (paneId: string) => void;
-  onOpenSplitView?: () => void;
-  onPaneSessionChange: (
-    paneId: string,
-    sourceSessionKey: string,
-    sessionKey: string,
-    options?: { replace?: boolean },
-  ) => boolean;
-  onSessionDeleted: (paneId: string, sessionKey: string, replacementSessionKey: string) => void;
-  onSplitDown?: (paneId: string) => void;
-  onSplitRight?: (paneId: string) => void;
-  ownerKey: string;
-  pane: ChatSplitPane;
-  sessionKeys: readonly string[];
-  showGatewayPicker: boolean;
-  splitMode: boolean;
-  context?: ApplicationContext;
-}) {
-  const nativeGateways = nativeGatewaysCapability();
-  const sessions = params.context?.sessions?.state.result?.sessions ?? [];
-  return repeat(
-    params.sessionKeys,
-    (sessionKey) => sessionKey,
-    (sessionKey) => {
-      const visible =
-        sessionKey === params.pane.sessionKey ||
-        areUiSessionKeysEquivalent(sessionKey, params.pane.sessionKey);
-      const presented = visible && (!params.narrow || params.active);
-      const active = params.active && visible;
-      const draft = active
-        ? routeDraft(params.data, params.consumedDraftData, sessionKey)
-        : undefined;
-      const focus = params.draftFocus.shouldFocusPane(active, draft, sessionKey, params.data);
-      const resolvedKey =
-        resolveSessionKey(sessionKey, params.context?.gateway?.snapshot?.hello) || sessionKey;
-      const title = resolveSessionDisplayName(
-        resolvedKey,
-        sessions.find((row) => areUiSessionKeysEquivalent(row.key, resolvedKey)),
-      );
-      return html`<openclaw-chat-pane
-        class="chat-pane-cache__pane ${visible ? "chat-pane-cache__pane--visible" : ""} ${active
-          ? "chat-pane-cache__pane--active"
-          : ""} ${params.splitMode ? "chat-split-view__pane" : ""}"
-        data-mcp-app-owner-key=${JSON.stringify([params.ownerKey, sessionKey])}
-        aria-hidden=${presented ? "false" : "true"}
-        ?inert=${!presented}
-        .paneId=${params.pane.id}
-        .presentationId=${JSON.stringify([params.pane.id, sessionKey])}
-        .chatMessagesBySession=${params.chatMessagesBySession}
-        .sessionKey=${sessionKey}
-        .presented=${presented}
-        .active=${active}
-        .draft=${draft}
-        .focusComposer=${focus}
-        .routeFace=${params.data?.face ?? "chat"}
-        .paneTitle=${title}
-        .narrow=${params.narrow}
-        .mergedChrome=${params.mergedChrome && active}
-        .navDrawerOpen=${params.navDrawerOpen && active}
-        .nativeGateways=${params.showGatewayPicker ? nativeGateways : null}
-        .gatewaysSnapshot=${params.showGatewayPicker ? (nativeGateways?.snapshot ?? null) : null}
-        .onboarding=${params.onboarding}
-        .onOpenSplitView=${params.onOpenSplitView}
-        .onSplitDown=${params.onSplitDown}
-        .onSplitRight=${params.onSplitRight}
-        .onClosePane=${params.onClosePane}
-        .onFocusPane=${params.onFocusPane}
-        .onPaneSessionChange=${(
-          paneId: string,
-          nextSessionKey: string,
-          options?: { replace?: boolean },
-        ) => params.onPaneSessionChange(paneId, sessionKey, nextSessionKey, options)}
-        .onSessionDeleted=${params.onSessionDeleted}
-        .onFaceChange=${params.onFaceChange}
-      ></openclaw-chat-pane>`;
-    },
-  );
 }

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -5,21 +5,21 @@ import { repeat } from "lit/directives/repeat.js";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { mergeChatPageChrome, mobileNavLayoutMediaQuery } from "../../app/mobile-nav-layout.ts";
 import { nativeGatewaysCapability } from "../../app/native-gateways.runtime.ts";
-import { loadSettings, patchSettings } from "../../app/settings.ts";
 import "../../components/resizable-divider.ts";
+import { loadSettings, patchSettings } from "../../app/settings.ts";
 import { McpAppUnmountGate } from "../../components/mcp-app-unmount.ts";
 import { UI_COMMAND_EVENT, type UiCommandDetail } from "../../components/panel-toggle-contract.ts";
 import { t } from "../../i18n/index.ts";
+import type { BoardFace } from "../../lib/board/settings.ts";
 import { readSessionDragData, sessionDragActive } from "../../lib/sessions/drag.ts";
 import { sessionNavigationTarget } from "../../lib/sessions/route-navigation.ts";
 import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
+import { persistSessionBoardFace } from "./chat-board-face-persistence.ts";
 import { stillOwnsCanonicalLocation } from "./chat-canonical-location.ts";
-import {
-  ChatPageRetainedSessions,
-  renderRetainedChatPanes,
-} from "./chat-page-retained-sessions.ts";
+import { renderChatPagePaneCell } from "./chat-page-pane-render.ts";
+import { ChatPageRetainedSessions } from "./chat-page-retained-sessions.ts";
 import { closeStagedPane, resumeStagedPanes } from "./chat-pane-attachment-handoff.ts";
 import { ChatViewerPresenceController } from "./chat-viewer-presence.ts";
 import "../../styles/chat.css";
@@ -48,7 +48,6 @@ import {
   splitRatio,
   splitWeight,
   type ChatSplitLayout,
-  type ChatSplitPane,
 } from "./split-layout.ts";
 
 type DropIndicator = { paneId: string; zone: SplitDropZone; rect: SplitDropRect };
@@ -88,12 +87,9 @@ export class ChatPage extends OpenClawLightDomElement {
     context: () => this.context,
     face: () => this.data?.face ?? "chat",
     layout: () => this.layout ?? this.classicLayout(),
-    splitLayout: () => this.layout,
-    persistLayout: (layout) => this.persistLayout(layout),
     selectReplacement: (paneId, sourceSessionKey, sessionKey) => {
       this.handlePaneSessionChange(paneId, sourceSessionKey, sessionKey);
     },
-    updateRoute: (sessionKey, replace, face) => this.updateRoute(sessionKey, replace, face),
   });
 
   override connectedCallback() {
@@ -228,31 +224,22 @@ export class ChatPage extends OpenClawLightDomElement {
     if (!layout) {
       return;
     }
-    const targetPane =
-      command.kind === "close-pane"
-        ? panesOf(layout).find((pane) => pane.sessionKey === command.sessionKey)
-        : undefined;
-    const survivingPane =
-      command.kind === "close-pane" && targetPane
-        ? closeStagedPane(this.context, this, layout, targetPane.id)
-        : undefined;
-    if (targetPane) {
-      this.retainedSessions.discardPane(targetPane.id);
+    if (command.kind === "close-pane") {
+      const targetPane = panesOf(layout).find((pane) => pane.sessionKey === command.sessionKey);
+      if (!targetPane) {
+        return;
+      }
+      event.preventDefault();
+      this.closeSplitPane(layout, targetPane.id);
+      return;
     }
     const next = applyUiCommandToSplitLayout(layout, command, sourceSessionKey);
     if (next === layout) {
       return;
     }
     event.preventDefault();
-    if (!next && survivingPane) {
-      const survivingLocation = findPane(layout, survivingPane.id);
-      if (survivingLocation) {
-        this.classicColumnId = survivingLocation.column.id;
-        this.classicPaneId = survivingPane.id;
-      }
-    }
     this.persistLayout(next);
-    const activePane = next ? findPane(next, next.activePaneId)?.pane : survivingPane;
+    const activePane = next && findPane(next, next.activePaneId)?.pane;
     if (activePane) {
       this.updateRoute(activePane.sessionKey, true);
     }
@@ -502,6 +489,23 @@ export class ChatPage extends OpenClawLightDomElement {
     return true;
   };
 
+  private readonly handlePaneFaceChange = (
+    paneId: string,
+    sessionKey: string,
+    face: BoardFace,
+  ): void => {
+    const selectedSessionKey = findPane(this.layout ?? this.classicLayout(), paneId)?.pane
+      .sessionKey;
+    if (!selectedSessionKey || !areUiSessionKeysEquivalent(selectedSessionKey, sessionKey)) {
+      return;
+    }
+    if (this.layout && this.layout.activePaneId !== paneId) {
+      this.persistLayout(setActivePane(this.layout, paneId));
+    }
+    persistSessionBoardFace(this.context, sessionKey, face);
+    this.updateRoute(sessionKey, false, face);
+  };
+
   private readonly openSplitView = () => {
     const sessionKey = this.data?.sessionKey?.trim();
     if (sessionKey) {
@@ -523,11 +527,7 @@ export class ChatPage extends OpenClawLightDomElement {
   private readonly handleSplitRight = (paneId: string) => this.handleSplit(paneId, "right");
   private readonly handleSplitDown = (paneId: string) => this.handleSplit(paneId, "down");
 
-  private readonly handleClosePane = (paneId: string) => {
-    const layout = this.layout;
-    if (!layout) {
-      return;
-    }
+  private closeSplitPane(layout: ChatSplitLayout, paneId: string): void {
     const survivingPane = closeStagedPane(this.context, this, layout, paneId);
     this.retainedSessions.discardPane(paneId);
     const next = closePane(layout, paneId);
@@ -539,71 +539,27 @@ export class ChatPage extends OpenClawLightDomElement {
       }
     }
     this.persistLayout(next);
-    if (!next && survivingPane) {
-      this.updateRoute(survivingPane.sessionKey, true);
-      return;
+    const activePane = next ? findPane(next, next.activePaneId)?.pane : survivingPane;
+    if (activePane) {
+      this.updateRoute(activePane.sessionKey, true);
     }
-    if (next) {
-      const activePane = findPane(next, next.activePaneId)?.pane;
-      if (activePane) {
-        this.updateRoute(activePane.sessionKey, true);
-      }
+  }
+
+  private readonly handleClosePane = (paneId: string) => {
+    if (this.layout) {
+      this.closeSplitPane(this.layout, paneId);
     }
   };
-
-  private renderPaneCell(
-    pane: ChatSplitPane,
-    active: boolean,
-    weight: number,
-    splitMode: boolean,
-    ownerKey: string,
-    showGatewayPicker: boolean,
-  ) {
-    return html`
-      <div
-        class="chat-split-view__cell ${splitMode && active
-          ? "chat-split-view__cell--active"
-          : ""} ${this.narrow && !active ? "chat-split-view__cell--narrow-hidden" : ""}"
-        style="flex: ${weight} 1 0"
-        @pointerdown=${() => this.handleFocusPane(pane.id)}
-        @focusin=${() => this.handleFocusPane(pane.id)}
-      >
-        <div class="chat-pane-cache">
-          ${renderRetainedChatPanes({
-            active,
-            chatMessagesBySession: this.chatMessagesBySession,
-            consumedDraftData: this.consumedDraftData,
-            context: this.context,
-            data: this.data,
-            draftFocus: this.draftFocus,
-            mergedChrome: this.mergedChrome,
-            narrow: this.narrow,
-            navDrawerOpen: this.navDrawerOpen,
-            onboarding: this.closest(".shell--onboarding") !== null,
-            onClosePane: splitMode ? this.handleClosePane : undefined,
-            onFaceChange: this.retainedSessions.changeFace,
-            onFocusPane: this.handleFocusPane,
-            onOpenSplitView: splitMode || this.narrow ? undefined : this.openSplitView,
-            onPaneSessionChange: this.handlePaneSessionChange,
-            onSessionDeleted: this.retainedSessions.removeSession,
-            onSplitDown: splitMode ? this.handleSplitDown : undefined,
-            onSplitRight: splitMode ? this.handleSplitRight : undefined,
-            ownerKey,
-            pane,
-            sessionKeys: this.retainedSessions.retain(pane),
-            showGatewayPicker,
-            splitMode,
-          })}
-        </div>
-      </div>
-    `;
-  }
 
   private classicLayout(sessionKey = this.data?.sessionKey?.trim() ?? ""): ChatSplitLayout {
     return singlePaneLayout(this.classicColumnId, this.classicPaneId, sessionKey);
   }
 
-  private renderSplitLayout(layout: ChatSplitLayout, splitMode: boolean) {
+  private renderSplitLayout(
+    layout: ChatSplitLayout,
+    splitMode: boolean,
+    retainedSessions: ReadonlyMap<string, readonly string[]>,
+  ) {
     const activeLocation = findPane(layout, layout.activePaneId);
     const rightmostPane = this.narrow ? activeLocation?.pane : layout.columns.at(-1)?.panes.at(-1);
     return html`
@@ -627,14 +583,36 @@ export class ChatPage extends OpenClawLightDomElement {
                 column.panes,
                 (pane) => pane.id,
                 (pane, paneIndex) => html`
-                  ${this.renderPaneCell(
+                  ${renderChatPagePaneCell({
+                    active: pane.id === layout.activePaneId,
+                    chatMessagesBySession: this.chatMessagesBySession,
+                    consumedDraftData: this.consumedDraftData,
+                    context: this.context,
+                    data: this.data,
+                    draftFocus: this.draftFocus,
+                    mergedChrome: this.mergedChrome,
+                    narrow: this.narrow,
+                    navDrawerOpen: this.navDrawerOpen,
+                    onboarding: this.closest(".shell--onboarding") !== null,
+                    onClosePane: splitMode ? this.handleClosePane : undefined,
+                    onFaceChange: this.handlePaneFaceChange,
+                    onFocusPane: this.handleFocusPane,
+                    onOpenSplitView: splitMode || this.narrow ? undefined : this.openSplitView,
+                    onPaneSessionChange: this.handlePaneSessionChange,
+                    onSessionDeleted: this.retainedSessions.removeSession,
+                    onSplitDown: splitMode ? this.handleSplitDown : undefined,
+                    onSplitRight: splitMode ? this.handleSplitRight : undefined,
+                    ownerKey: JSON.stringify([column.id, pane.id]),
                     pane,
-                    pane.id === layout.activePaneId,
-                    splitWeight(column.paneWeights, paneIndex, "rendered split pane weight"),
+                    sessionKeys: retainedSessions.get(pane.id) ?? [],
+                    showGatewayPicker: pane.id === rightmostPane?.id,
                     splitMode,
-                    JSON.stringify([column.id, pane.id]),
-                    pane.id === rightmostPane?.id,
-                  )}
+                    weight: splitWeight(
+                      column.paneWeights,
+                      paneIndex,
+                      "rendered split pane weight",
+                    ),
+                  })}
                   ${!this.narrow && paneIndex < column.panes.length - 1
                     ? html`
                         <resizable-divider
@@ -692,22 +670,23 @@ export class ChatPage extends OpenClawLightDomElement {
   override render() {
     const indicator = this.dropIndicator;
     const layout = this.layout ?? this.classicLayout();
-    const renderedPaneIds = new Set(panesOf(layout).map((pane) => pane.id));
-    this.retainedSessions.prune(renderedPaneIds);
     const renderedPaneOwners = layout.columns.flatMap((column) =>
       column.panes.map((pane) => ({ columnId: column.id, pane })),
+    );
+    const retainedSessions = this.retainedSessions.retain(
+      renderedPaneOwners.map(({ pane }) => pane),
     );
     const nextPaneKeys = new Set(
       renderedPaneOwners.flatMap(({ columnId, pane }) => {
         const ownerKey = JSON.stringify([columnId, pane.id]);
-        return this.retainedSessions
-          .retain(pane)
-          .map((sessionKey) => JSON.stringify([ownerKey, sessionKey]));
+        return (retainedSessions.get(pane.id) ?? []).map((sessionKey) =>
+          JSON.stringify([ownerKey, sessionKey]),
+        );
       }),
     );
     const rendered = html`
       <div class="chat-split-view__drop-container">
-        ${this.renderSplitLayout(layout, Boolean(this.layout))}
+        ${this.renderSplitLayout(layout, Boolean(this.layout), retainedSessions)}
         ${indicator
           ? html`<div
               class="chat-split-view__drop-indicator ${indicator.zone.kind === "center"


### PR DESCRIPTION
Related: #121624
Follow-up to #121625

## What Problem This Solves

The retained-session path that makes recent chat switches instant mixed lifecycle ownership, routing, and Lit rendering, repeated retention work during each render, and duplicated split-pane close handling. That made the performance-sensitive path harder to reason about and maintain.

## Why This Change Was Made

Keep retention, eviction, and speculative visual preview in the retention controller; keep route and layout authority in `ChatPage`; and move the pure pane-template translation into a focused renderer. One retention snapshot is now built per page render, split-pane close behavior has one path, and repeated test setup is consolidated without changing the three-session retention contract.

Production LOC: +222/-238 (net -16) | Tests: +49/-87 (net -38) | Total: net -54

## User Impact

No intended behavior change. Session switching remains instant for the three retained presentations per logical pane, including background-stream updates and same-session split panes, while the implementation is smaller and has clearer ownership boundaries.

## Evidence

- Exact-tree retained-session boundary suite: 146/146 tests passed across 11 files.
- `pnpm tsgo:test:ui`: passed.
- Targeted `oxfmt`, `oxlint`, `git diff --check`, and max-lines ratchet: passed.
- Structured Codex autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings.
- Production-bundle Playwright benchmark with deterministic in-browser Gateway fixtures, two exact-tree runs:
  - Combined first-useful medians: 2.6 ms (10 short messages), 12.0 ms (100 × ~1 KiB), 5.2 ms (800 KiB Markdown), 3.6 ms (tool-heavy), 4.4 ms (near-5 MiB).
  - Merged-main baseline: 2.5, 11.6, 4.7, 3.4, and 4.2 ms respectively.
  - Every warm sample reused the existing transcript root and issued zero warm `chat.history`, `chat.startup`, `chat.subscribe`, or `chat.unsubscribe` requests.
  - Three retained panes used 18.37 MiB JS heap versus 18.35 MiB on merged main; a fourth session evicted the LRU root and returning to it remounted as expected.
  - Hidden roots remained `inert`/`aria-hidden`; background streaming remained visible after warm activation; two panes showing the same session retained distinct transcript roots and drafts.
- One of 20 medium-transcript samples was delayed to 66.1 ms; the other 19 ranged from 11.6–22.9 ms. This was retained in the reported data rather than discarded.
