### PR TITLE
refactor(agents): simplify turn latency runtime ownership

### DIFF
--- a/extensions/openai/transport-policy.test.ts
+++ b/extensions/openai/transport-policy.test.ts
@@ -86,21 +86,6 @@ describe("openai transport policy", () => {
     expect(state?.headers?.["x-openclaw-turn-attempt"]).toBe("2");
   });
 
-  it("returns websocket session headers and cooldown for native routes", () => {
-    const policy = resolveOpenAITransportTurnState({
-      provider: "openai",
-      modelId: nativeModel.id,
-      model: nativeModel,
-      sessionId: "session-123",
-      turnId: "turn-123",
-      attempt: 1,
-      transport: "websocket",
-    })?.websocket;
-    expect(policy?.headers?.["x-client-request-id"]).toBe("session-123");
-    expect(policy?.headers?.["x-openclaw-session-id"]).toBe("session-123");
-    expect(policy?.degradeCooldownMs).toBe(60_000);
-  });
-
   it.each([
     [
       "Azure",

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -35,7 +35,6 @@ import {
 } from "./openai-responses-debug.js";
 import {
   buildOpenAIResponsesParams,
-  convertOpenAIResponsesMessagesForRequest,
   sanitizeOpenAICodexResponsesParams,
 } from "./openai-responses-params-internal.js";
 import { createResponsesPromptEgressObserver } from "./openai-responses-prompt-observer-internal.js";
@@ -334,13 +333,6 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
               signal: websocketSignal,
               callerSignal: options?.signal,
               degradeCooldownMs: websocketSessionPolicy?.degradeCooldownMs,
-              resolveContinuationItems: () =>
-                convertOpenAIResponsesMessagesForRequest(
-                  model,
-                  { messages: [output] },
-                  responsesOptions,
-                  "checkpoint",
-                ).filter((item) => item.type !== "function_call_output"),
             });
             finishWebSocket = websocket.finish;
             observePrompt?.(websocket.request, {

--- a/packages/ai/src/transports/openai-responses-params-internal.ts
+++ b/packages/ai/src/transports/openai-responses-params-internal.ts
@@ -233,7 +233,7 @@ function resolveOpenAIResponsesTextFormat(
   return responseFormat as unknown as ResponseFormatTextConfig;
 }
 
-export function convertOpenAIResponsesMessagesForRequest(
+function convertOpenAIResponsesMessagesForRequest(
   model: Model,
   context: Context,
   options: OpenAIResponsesOptions | undefined,

--- a/packages/ai/src/transports/openai-responses-websocket-client.test.ts
+++ b/packages/ai/src/transports/openai-responses-websocket-client.test.ts
@@ -131,25 +131,30 @@ function userMessage(text: string, timestamp: number) {
   return { role: "user" as const, content: text, timestamp };
 }
 
-function completedEvent(responseId: string, text?: string) {
-  const output = text
-    ? [
-        {
-          type: "message",
-          id: `msg_${responseId}`,
-          role: "assistant",
-          status: "completed",
-          content: [{ type: "output_text", text, annotations: [] }],
-        },
-      ]
-    : [];
+function completedEvent(responseId: string, content?: string | Array<Record<string, unknown>>) {
+  const output =
+    typeof content === "string"
+      ? [
+          {
+            type: "message",
+            id: `msg_${responseId}`,
+            role: "assistant",
+            status: "completed",
+            content: [{ type: "output_text", text: content, annotations: [] }],
+          },
+        ]
+      : (content ?? []);
   return {
     type: "response.completed",
     response: {
       id: responseId,
       status: "completed",
       output,
-      usage: { input_tokens: 5, output_tokens: text ? 3 : 0, total_tokens: text ? 8 : 5 },
+      usage: {
+        input_tokens: 5,
+        output_tokens: output.length > 0 ? 3 : 0,
+        total_tokens: output.length > 0 ? 8 : 5,
+      },
     },
   };
 }
@@ -159,17 +164,19 @@ function message(event: Record<string, unknown>): StreamMessage {
 }
 
 function toolCallResponse(responseId: string): StreamMessage[] {
+  const functionCall = {
+    type: "function_call",
+    id: "fc_read",
+    call_id: "call_read",
+    name: "read",
+    arguments: '{"path":"README.md"}',
+    status: "completed",
+  };
   return [
     message({
       type: "response.output_item.added",
       output_index: 0,
-      item: {
-        type: "function_call",
-        id: "fc_read",
-        call_id: "call_read",
-        name: "read",
-        arguments: "",
-      },
+      item: { ...functionCall, arguments: "", status: "in_progress" },
     }),
     message({
       type: "response.function_call_arguments.delta",
@@ -187,16 +194,9 @@ function toolCallResponse(responseId: string): StreamMessage[] {
     message({
       type: "response.output_item.done",
       output_index: 0,
-      item: {
-        type: "function_call",
-        id: "fc_read",
-        call_id: "call_read",
-        name: "read",
-        arguments: '{"path":"README.md"}',
-        status: "completed",
-      },
+      item: functionCall,
     }),
-    message(completedEvent(responseId)),
+    message(completedEvent(responseId, [functionCall])),
   ];
 }
 

--- a/packages/ai/src/transports/openai-responses-websocket.test.ts
+++ b/packages/ai/src/transports/openai-responses-websocket.test.ts
@@ -111,17 +111,13 @@ async function consumeResponse(response: ReturnType<typeof createOpenAIResponses
   return events;
 }
 
-function createStream(
-  request: Record<string, unknown>,
-  overrides: { continuationItems?: Array<Record<string, unknown>>; sessionId?: string } = {},
-) {
+function createStream(request: Record<string, unknown>, overrides: { sessionId?: string } = {}) {
   return createOpenAIResponsesWebSocketStream({
     client,
     request,
     mode: "websocket-cached",
     sessionId: overrides.sessionId ?? "session-1",
     headers: { "x-stable-session": "session-1" },
-    resolveContinuationItems: () => (overrides.continuationItems ?? [assistantOutput]) as never,
   });
 }
 
@@ -210,79 +206,13 @@ describe("native OpenAI Responses WebSocket transport", () => {
     });
   });
 
-  it("reuses a session socket and sends only a strict append-compatible input delta", async () => {
-    websocketState.responseBatches.push(
-      [completion("resp_1", [assistantOutput])],
-      [completion("resp_2")],
-    );
-    const stableRequest = {
-      model: "gpt-5.6-luna",
-      stream: true,
-      background: true,
-      store: false,
-      instructions: "stable prompt",
-      tools: [{ type: "function", name: "read", parameters: { type: "object" } }],
-      metadata: {
-        openclaw_session_id: "session-1",
-        openclaw_turn_id: "turn-1",
-        openclaw_turn_attempt: "1",
-      },
-      input: [firstUser],
-    };
-
-    const first = createStream(stableRequest);
-    expect(first.continuationStatus).toBe("no_previous_response");
-    expect(first.request).not.toHaveProperty("stream");
-    expect(first.request).not.toHaveProperty("background");
-    await consumeResponse(first);
-
-    const second = createStream({
-      ...stableRequest,
-      metadata: {
-        openclaw_session_id: "session-1",
-        openclaw_turn_id: "turn-2",
-        openclaw_turn_attempt: "1",
-      },
-      input: [
-        firstUser,
-        {
-          type: "message",
-          role: "assistant",
-          content: assistantOutput.content,
-        },
-        { role: "user", content: "second" },
-      ],
-    });
-    expect(second.continuationStatus).toBe("continued");
-    expect(second.request).toMatchObject({
-      previous_response_id: "resp_1",
-      input: [{ role: "user", content: "second" }],
-    });
-    await consumeResponse(second);
-
-    expect(websocketState.instances).toHaveLength(1);
-    expect(websocketState.requests).toHaveLength(2);
-    expect(websocketState.requests[1]).toMatchObject({
-      type: "response.create",
-      previous_response_id: "resp_1",
-      input: [{ role: "user", content: "second" }],
-    });
-    expect(websocketState.requests[0]).not.toHaveProperty("stream");
-    expect(websocketState.requests[0]).not.toHaveProperty("background");
-  });
-
   it("uses the response id when persisted encrypted reasoning has a different replay shape", async () => {
     const reasoning = { type: "reasoning", id: "rs_1", encrypted_content: "ciphertext" };
     websocketState.responseBatches.push(
       [completion("resp_1", [reasoning, assistantOutput])],
       [completion("resp_2")],
     );
-    await consumeResponse(
-      createStream(
-        { model: "gpt-5.6-luna", input: [firstUser] },
-        { continuationItems: [reasoning, assistantOutput] },
-      ),
-    );
+    await consumeResponse(createStream({ model: "gpt-5.6-luna", input: [firstUser] }));
 
     const second = createStream({
       model: "gpt-5.6-luna",

--- a/packages/ai/src/transports/openai-responses-websocket.ts
+++ b/packages/ai/src/transports/openai-responses-websocket.ts
@@ -1,6 +1,7 @@
 import type OpenAI from "openai";
 import type {
   ResponseInput,
+  ResponseOutputItem,
   ResponsesClientEvent,
   ResponsesServerEvent,
 } from "openai/resources/responses/responses.js";
@@ -27,7 +28,7 @@ type ResponsesWebSocketRequest = Record<string, unknown> & {
 type CachedWebSocketContinuation = {
   lastRequest: ResponsesWebSocketRequest;
   lastResponseId: string;
-  lastResponseItems: ResponseInput;
+  lastResponseItems: ResponseOutputItem[];
 };
 
 type CachedWebSocketConnection = {
@@ -298,7 +299,7 @@ function sanitizeWebSocketRequest(request: Record<string, unknown>): ResponsesWe
   return websocketRequest as ResponsesWebSocketRequest;
 }
 
-function normalizeAssistantReplayInput(input: ResponseInput): unknown[] {
+function normalizeAssistantReplayInput(input: readonly unknown[]): unknown[] {
   return input.map((item) => {
     if (!item || typeof item !== "object" || Array.isArray(item)) {
       return item;
@@ -424,7 +425,6 @@ export function createOpenAIResponsesWebSocketStream(params: {
   signal?: AbortSignal;
   callerSignal?: AbortSignal;
   degradeCooldownMs?: number;
-  resolveContinuationItems?: () => ResponseInput;
 }): OpenAIResponsesWebSocketStream {
   const connection = prepareWebSocketConnection(params.client, params.headers);
   const fullRequest = sanitizeWebSocketRequest(params.request);
@@ -469,7 +469,9 @@ export function createOpenAIResponsesWebSocketStream(params: {
   }
 
   let streamStarted = false;
-  let terminalResponseId: string | undefined;
+  let terminalResponse:
+    | Extract<ResponsesServerEvent, { type: "response.completed" }>["response"]
+    | undefined;
   let terminalReceived = false;
   let released = false;
   const finish = ({ keep = true }: { keep?: boolean } = {}) => {
@@ -477,20 +479,12 @@ export function createOpenAIResponsesWebSocketStream(params: {
       return;
     }
     released = true;
-    try {
-      if (keep && lease.entry && terminalResponseId && params.resolveContinuationItems) {
-        lease.entry.continuation = {
-          lastRequest: fullRequest,
-          lastResponseId: terminalResponseId,
-          lastResponseItems: params.resolveContinuationItems(),
-        };
-      }
-    } catch (error) {
-      if (lease.entry) {
-        lease.entry.continuation = undefined;
-      }
-      lease.release({ keep: false });
-      throw error;
+    if (keep && lease.entry && terminalResponse) {
+      lease.entry.continuation = {
+        lastRequest: fullRequest,
+        lastResponseId: terminalResponse.id,
+        lastResponseItems: terminalResponse.output,
+      };
     }
     lease.release({ keep });
   };
@@ -530,8 +524,8 @@ export function createOpenAIResponsesWebSocketStream(params: {
           if (event.type === "response.failed") {
             throw new OpenAIResponsesWebSocketResponseFailedError(event.response.output.length > 0);
           }
-          if (event.type === "response.completed" && typeof event.response.id === "string") {
-            terminalResponseId = event.response.id;
+          if (event.type === "response.completed") {
+            terminalResponse = event.response;
           }
           terminalReceived =
             event.type === "response.completed" || event.type === "response.incomplete";

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -809,9 +809,6 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
         "createdSession.session.setBaseSystemPrompt.mock.invocationCallOrder[0] test invariant",
       ),
     );
-    expect(createAgentSessionMock.mock.calls[0]?.[1]).toEqual({
-      cleanupProviderSessionResourcesOnDispose: false,
-    });
   });
 
   it("routes compaction through shared stream resolution and extra params", async () => {

--- a/src/agents/embedded-agent-runner/compaction-session-execution.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-execution.ts
@@ -234,10 +234,7 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
               settingsManager,
               resourceLoader,
             },
-            {
-              // Compaction disposal must not close the durable provider session used by later turns.
-              cleanupProviderSessionResourcesOnDispose: false,
-            },
+            {},
           );
           session = createdSession.session;
           session.setActiveToolsByName(sessionToolAllowlist);

--- a/src/agents/embedded-agent-runner/run/attempt-session-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-prepare.ts
@@ -200,8 +200,6 @@ export async function prepareEmbeddedAttemptAgentSession(input: {
   const createdSession = await createAgentSessionForEmbeddedRunner(sessionOptions, {
     // Without a resolved model budget, the outer loop cannot own bounded recovery.
     contextOverflowRecoveryOwner: attempt.contextTokenBudget === undefined ? "session" : "caller",
-    // Attempt disposal must not close the durable provider session shared by later turns.
-    cleanupProviderSessionResourcesOnDispose: false,
     beforeToolBatch: input.clientToolPreparation.catalogToolHookContext
       ? createToolLoopBatchAdmission(input.clientToolPreparation.catalogToolHookContext)
       : undefined,

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -73,7 +73,7 @@ describe("createAgentSession runtime ownership", () => {
           settingsManager: SettingsManager.inMemory(),
           modelRegistry: createTestModelRegistry(),
         },
-        { cleanupProviderSessionResourcesOnDispose: false },
+        {},
       );
 
       session.dispose();

--- a/src/agents/sessions/sdk.ts
+++ b/src/agents/sessions/sdk.ts
@@ -292,17 +292,18 @@ export async function createAgentSession(
   return await createAgentSessionImpl(options);
 }
 
-/** Internal embedded-runner seam; keep recovery ownership out of the public session SDK. */
+/** Internal factory for temporary embedded sessions that do not own durable provider resources. */
 export async function createAgentSessionForEmbeddedRunner(
   options: CreateAgentSessionOptions,
   internalOptions: CreateAgentSessionInternalOptions,
 ): Promise<CreateAgentSessionResult> {
-  return await createAgentSessionImpl(options, internalOptions);
+  return await createAgentSessionImpl(options, internalOptions, false);
 }
 
 async function createAgentSessionImpl(
   options: CreateAgentSessionOptions,
   internalOptions: CreateAgentSessionInternalOptions = {},
+  cleanupProviderSessionResourcesOnDispose = true,
 ): Promise<CreateAgentSessionResult> {
   const cwd = options.cwd ?? options.sessionManager?.getCwd() ?? process.cwd();
   const agentDir = options.agentDir ?? getDefaultAgentDir();
@@ -572,8 +573,7 @@ async function createAgentSessionImpl(
     sessionStartEvent: options.sessionStartEvent,
     withSessionWriteSettlement: options.withSessionWriteSettlement,
     contextOverflowRecoveryOwner: internalOptions.contextOverflowRecoveryOwner,
-    cleanupProviderSessionResourcesOnDispose:
-      internalOptions.cleanupProviderSessionResourcesOnDispose,
+    cleanupProviderSessionResourcesOnDispose,
   });
   const extensionsResult = resourceLoader.getExtensions();
 


### PR DESCRIPTION
Related: #121687

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The OpenAI turn-latency implementation retained two ownership seams after its initial performance work: completed provider output was converted back from parsed OpenClaw assistant messages before WebSocket continuation, and temporary embedded sessions repeated a low-level provider-resource cleanup flag at each caller.

## Why This Change Was Made

This follow-up moves both facts to their owners. The WebSocket transport retains authoritative terminal `response.completed.response.output`, and the embedded session factory intrinsically preserves durable provider resources. Duplicate implementation-level tests were removed only where stronger production-boundary or lifecycle-owner coverage remains.

Production LOC: +20/-39 (net -19) | Tests/support: +32/-120 (net -88)

## User Impact

No intended user-visible behavior or new latency claim. The existing latency path is smaller and easier to maintain without weakening strict continuation replay checks, terminal incomplete/failed handling, abort and post-dispatch fallback behavior, or provider-session teardown ownership.

## Evidence

- Rebased onto current `origin/main` (`32894a3ba50`) before publication.
- 212 focused tests passed on the final exact head across OpenAI WebSocket/client continuation, agent-session loop correctness, embedded attempt/compaction lifecycle, SDK ownership, and OpenAI transport policy (5 Vitest shards, 64.15s).
- Plugin SDK API baseline passed on both pristine `origin/main` and the final branch, confirming no exported/transitive contract drift.
- OpenAI Node 6.49.0 source/types confirm `response.completed.response.output` is the authoritative ordered terminal output; incomplete and failed responses remain excluded from successful continuation seeding.
- Targeted Oxlint: 0 warnings and 0 errors across all 11 changed files.
- `oxfmt --check`: all 11 changed files correctly formatted.
- Dead-export scan: production, full-tree, and script scans passed with 0 entries.
- `git diff --check`: passed.
- Independent high-reasoning review: no high-confidence correctness, lifecycle, API, replay, abort, or coverage blocker.
- The structured Codex autoreview helper could not start because the `codex` executable is unavailable in this orb; exact-head GitHub CI supplies the broad typecheck/check fan-out.
