### PR TITLE
test(agents): remove duplicate restart progress case

### DIFF
--- a/src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.test.ts
@@ -29,16 +29,6 @@ function progressMessage(text: string, itemId: string): Record<string, unknown> 
 }
 
 describe("resolveMainSessionResumePolicy progress tails", () => {
-  it("resumes when keyed progress messages arrive after the recovery mark", () => {
-    expect(
-      resolveMainSessionResumePolicy([
-        { role: "user", content: "finish the interrupted work" },
-        progressMessage("Checking the owner boundary.", "progress-1"),
-        progressMessage("Still tracing the restart lifecycle.", "progress-2"),
-      ]),
-    ).toEqual({ action: "resume", forceRestartSafeTools: false });
-  });
-
   it("resumes explicit commentary without making completed answers resumable", () => {
     expect(
       resolveMainSessionResumePolicy([


### PR DESCRIPTION
## What Problem This Solves

The focused restart-resume policy suite repeated the keyed progress-message case already covered through the full persisted-session recovery boundary. Both tests were introduced for the same regression; the focused copy asserted only the policy return value.

## Why This Change Was Made

This deletes the strict-subset case while retaining the stronger recovery test. That boundary proof:

- creates and marks a real persisted session;
- appends two keyed durable progress messages after the recovery mark;
- runs the recovery store/runtime path;
- observes Gateway dispatch;
- verifies durable session state settlement; and
- verifies both progress records remain in the transcript.

All distinct focused policy cases remain, including explicit commentary, signed commentary, restart-abort artifacts, replay restrictions, unkeyed fallbacks, and final-answer precedence.

AI-assisted: yes. The deletion was manually inspected and passed repository autoreview.

## User Impact

No user-visible behavior change. The same restart recovery regression remains covered at the stronger owner boundary with less duplicate maintenance.

## Evidence

- `node scripts/run-vitest.mjs src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.test.ts src/agents/main-session-recovery/main-session-restart-recovery.test.ts` — 163 tests passed.
- `node scripts/check-changed.mjs -- src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.test.ts` — passed all selected test/type/lint/dead-export/boundary gates using the trusted local fallback because Blacksmith Testbox is unavailable on this host.
- Targeted oxlint, oxfmt, and `git diff --check` — passed.
- Fresh autoreview and secret scan — clean.

## Scope and LOC

- Production: unchanged.
- Tests: `-10` lines.

No runtime, config, protocol, schema, dependency, lockfile, generated baseline, release, docs, or changelog change.
