### PR TITLE
fix(agents): stop orphan delivery polling and delayed yield wakes

### DIFF
--- a/src/agents/subagents/completion/subagent-completion-admission.store.test.ts
+++ b/src/agents/subagents/completion/subagent-completion-admission.store.test.ts
@@ -1,7 +1,11 @@
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
-import { prepareClaimedSessionDelivery } from "../../../infra/session-delivery-queue-storage.js";
+import {
+  prepareClaimedSessionDelivery,
+  SessionDeliveryDeadLetteredError,
+  SessionDeliveryDeferredError,
+} from "../../../infra/session-delivery-queue-storage.js";
 import { resolvePreferredOpenClawTmpDir } from "../../../infra/tmp-openclaw-dir.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -208,6 +212,28 @@ describe("atomic subagent completion admission store", () => {
     expect(rowCount("delivery_queue_entries")).toBe(0);
     expect(rowCount("subagent_runs")).toBe(0);
     expect(rowCount("task_runs")).toBe(0);
+  });
+
+  it("dead-letters expired orphan generations before resolving their logical owner", () => {
+    const { queueEntry } = records();
+    if (queueEntry.kind !== "agentTurn" || queueEntry.owner?.kind !== "subagent_completion") {
+      throw new Error("expected correlated subagent completion queue entry");
+    }
+    queueEntry.owner.deadlineAt = Date.now() - 1;
+
+    expect(() => resolveCorrelatedSubagentDelivery(queueEntry)).toThrow(
+      SessionDeliveryDeadLetteredError,
+    );
+  });
+
+  it("defers an unexpired generation whose logical owner has moved on", () => {
+    const { queueEntry, subagent } = records();
+    subagent.delivery!.generation = 2;
+    subagentRuns.set(subagent.runId, subagent);
+
+    expect(() => resolveCorrelatedSubagentDelivery(queueEntry)).toThrow(
+      SessionDeliveryDeferredError,
+    );
   });
 
   it("reloads a blocked text completion from SQLite before canonical owner redrive", async () => {

--- a/src/agents/subagents/completion/subagent-completion-delivery.ts
+++ b/src/agents/subagents/completion/subagent-completion-delivery.ts
@@ -156,6 +156,11 @@ export function resolveCorrelatedSubagentDelivery(
   if (queued.kind !== "agentTurn" || queued.owner?.kind !== "subagent_completion") {
     return queued;
   }
+  if (Date.now() >= queued.owner.deadlineAt) {
+    throw new SessionDeliveryDeadLetteredError(
+      "correlated subagent completion delivery deadline expired",
+    );
+  }
   const entry = subagentRuns.get(queued.owner.runId);
   if (
     !entry ||
@@ -164,11 +169,6 @@ export function resolveCorrelatedSubagentDelivery(
     entry.delivery.deadlineAt !== queued.owner.deadlineAt
   ) {
     throw new SessionDeliveryDeferredError("correlated subagent delivery owner mismatch");
-  }
-  if (Date.now() >= queued.owner.deadlineAt) {
-    throw new SessionDeliveryDeadLetteredError(
-      "correlated subagent completion delivery deadline expired",
-    );
   }
   return { ...queued, message: canonicalResultMessage(entry) };
 }

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-common.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-common.ts
@@ -48,8 +48,8 @@ export function createSubagentRegistryLifecycleCommon(
       clearTimeout(timer);
     }
     scheduledResumeTimers.clear();
-    for (const timer of scheduledRequesterSettleWakeTimers.values()) {
-      clearTimeout(timer);
+    for (const scheduled of scheduledRequesterSettleWakeTimers.values()) {
+      clearTimeout(scheduled.timer);
     }
     scheduledRequesterSettleWakeTimers.clear();
     pendingRequesterSettleWakeRearms.clear();

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-contracts.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-contracts.ts
@@ -57,7 +57,14 @@ export type SubagentRegistryLifecycleState = {
   scheduledResumeTimers: Set<ReturnType<typeof setTimeout>>;
   pendingRequesterSettleWakeRearms: Set<string>;
   scheduledRequesterSettleWakeRuns: Set<string>;
-  scheduledRequesterSettleWakeTimers: Map<string, ReturnType<typeof setTimeout>>;
+  scheduledRequesterSettleWakeTimers: Map<
+    string,
+    {
+      timer: ReturnType<typeof setTimeout>;
+      deadline: number;
+      rearmGeneration?: number;
+    }
+  >;
   terminalCompletionLocks: Map<string, Promise<void>>;
   terminalGenerations: WeakMap<SubagentRunRecord, number>;
   cleanupGenerations: WeakMap<SubagentRunRecord, number>;

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-requester-wake.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-requester-wake.ts
@@ -103,7 +103,7 @@ export function createSubagentRegistryLifecycleRequesterWake(
     for (const [runId, entry] of entries) {
       const retryTimer = scheduledRequesterSettleWakeTimers.get(runId);
       if (retryTimer) {
-        clearTimeout(retryTimer);
+        clearTimeout(retryTimer.timer);
         scheduledRequesterSettleWakeTimers.delete(runId);
       }
       if (entry.requesterSettleWake === undefined || !params.runs.has(runId)) {
@@ -183,17 +183,40 @@ export function createSubagentRegistryLifecycleRequesterWake(
   // cleanup parent reserves the root synchronously, so restart or suspend
   // cannot reach quiescence between scheduling and the wake's gateway turn.
   // Failures are logged only.
+  function retainScheduledRequesterSettleWakeTimer(
+    runId: string,
+    deadline: number,
+    rearmGeneration?: number,
+  ): boolean {
+    const scheduled = scheduledRequesterSettleWakeTimers.get(runId);
+    if (!scheduled) {
+      return false;
+    }
+    const hasNewerGeneration =
+      rearmGeneration !== undefined &&
+      (scheduled.rearmGeneration === undefined || rearmGeneration > scheduled.rearmGeneration);
+    if (!hasNewerGeneration && deadline >= scheduled.deadline) {
+      return true;
+    }
+    clearTimeout(scheduled.timer);
+    scheduledRequesterSettleWakeTimers.delete(runId);
+    return false;
+  }
+
   function scheduleRequesterSettleWakeRetry(runId: string, entry: SubagentRunRecord): void {
     const nextAttemptAt = entry.requesterSettleWake?.nextAttemptAt;
-    if (
-      nextAttemptAt === undefined ||
-      nextAttemptAt <= Date.now() ||
-      scheduledRequesterSettleWakeTimers.has(runId)
-    ) {
+    if (nextAttemptAt === undefined || nextAttemptAt <= Date.now()) {
+      return;
+    }
+    const rearmGeneration = entry.requesterSettleWake?.rearmGeneration;
+    if (retainScheduledRequesterSettleWakeTimer(runId, nextAttemptAt, rearmGeneration)) {
       return;
     }
     const timer = setTimeout(
       () => {
+        if (scheduledRequesterSettleWakeTimers.get(runId)?.timer !== timer) {
+          return;
+        }
         scheduledRequesterSettleWakeTimers.delete(runId);
         const current = params.runs.get(runId);
         if (current === entry && current.requesterSettleWake) {
@@ -203,7 +226,11 @@ export function createSubagentRegistryLifecycleRequesterWake(
       Math.max(0, nextAttemptAt - Date.now()),
     );
     timer.unref?.();
-    scheduledRequesterSettleWakeTimers.set(runId, timer);
+    scheduledRequesterSettleWakeTimers.set(runId, {
+      timer,
+      deadline: nextAttemptAt,
+      rearmGeneration,
+    });
   }
 
   function scheduleRequesterSettleWake(runId: string, entry: SubagentRunRecord): void {
@@ -216,12 +243,23 @@ export function createSubagentRegistryLifecycleRequesterWake(
       !hasSubagentRunEnded(entry) ||
       !requesterSessionKey ||
       (entry.requesterTurnRunId && entry.requesterTurnYielded === true) ||
-      scheduledRequesterSettleWakeRuns.has(runId) ||
-      scheduledRequesterSettleWakeTimers.has(runId)
+      scheduledRequesterSettleWakeRuns.has(runId)
     ) {
       return;
     }
-    if ((entry.requesterSettleWake?.nextAttemptAt ?? 0) > Date.now()) {
+    const now = Date.now();
+    const nextAttemptAt = entry.requesterSettleWake?.nextAttemptAt;
+    const deadline = nextAttemptAt !== undefined && nextAttemptAt > now ? nextAttemptAt : now;
+    if (
+      retainScheduledRequesterSettleWakeTimer(
+        runId,
+        deadline,
+        entry.requesterSettleWake?.rearmGeneration,
+      )
+    ) {
+      return;
+    }
+    if (nextAttemptAt !== undefined && nextAttemptAt > now) {
       scheduleRequesterSettleWakeRetry(runId, entry);
       return;
     }

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -4560,12 +4560,70 @@ describe("requester settle wake trigger", () => {
       });
       await vi.advanceTimersByTimeAsync(0);
       expect(settleWake).toHaveBeenCalledTimes(1);
+      controller.resumeRequesterSettleWake(entry.runId, entry);
+      controller.resumeRequesterSettleWake(entry.runId, entry);
+      expect(vi.getTimerCount()).toBe(1);
 
       await vi.advanceTimersByTimeAsync(29_999);
       expect(settleWake).toHaveBeenCalledTimes(1);
       await vi.advanceTimersByTimeAsync(1);
       expect(settleWake).toHaveBeenCalledTimes(2);
       expect(entry.requesterSettleWake).toBeUndefined();
+    } finally {
+      controller.clearScheduledResumeTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("lets a fresh yield wake preempt a stale retry timer", async () => {
+    const entry = createRunEntry({
+      endedAt: 4_000,
+      expectsCompletionMessage: true,
+      delivery: { status: "delivered" },
+      requesterSettleWake: {
+        status: "pending",
+        attemptCount: 1,
+        nextAttemptAt: 120_000,
+        rearmGeneration: 1,
+      },
+    });
+    const settleWake = vi.fn(
+      async (
+        params: Parameters<
+          LifecycleControllerParams["maybeWakeRequesterAfterAllChildrenSettled"]
+        >[0],
+      ) => {
+        params.completeBatch([entry.runId], entry.requesterSettleWake?.rearmGeneration);
+        return true;
+      },
+    );
+    const controller = createLifecycleController({
+      entry,
+      maybeWakeRequesterAfterAllChildrenSettled: settleWake,
+    });
+
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    try {
+      controller.resumeRequesterSettleWake(entry.runId, entry);
+      expect(vi.getTimerCount()).toBe(1);
+
+      entry.requesterTurnRunId = "run-requester";
+      entry.requesterTurnYielded = true;
+      expect(
+        controller.settleRequesterTurnAfterSessionSpawns({
+          requesterSessionKey: entry.requesterSessionKey,
+          requesterTurnRunId: "run-requester",
+          requesterYielded: true,
+          acceptedSessionSpawns: [{ runId: entry.runId, childSessionKey: entry.childSessionKey }],
+        }),
+      ).toBe(true);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(settleWake).toHaveBeenCalledOnce();
+      expect(vi.getTimerCount()).toBe(0);
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(settleWake).toHaveBeenCalledOnce();
     } finally {
       controller.clearScheduledResumeTimers();
       vi.useRealTimers();


### PR DESCRIPTION
## What Problem This Solves

Fixes two adjacent lifecycle timing defects from verification report findings F5 and F6. Orphaned subagent completion queue rows could defer forever after their physical deadline, and a freshly yielded requester wake could remain parked behind an older 30/120-second retry timer.

## Why This Change Was Made

The completion resolver now treats the queue generation's own deadline as authoritative before consulting its logical registry owner, preserving the settlement-side stale-generation guard. Requester-wake timer bookkeeping now retains each timer's deadline and rearm generation so an earlier deadline or newer yield generation preempts stale work while same-generation schedules remain single-flight.

## User Impact

Expired orphan completion deliveries now terminate through the existing dead-letter path instead of polling indefinitely. Fresh requester yields can synthesize promptly rather than waiting for a stale retry timer.

## Evidence

- Verification report F5: expired orphan generations dead-letter before logical-owner resolution; unexpired owner mismatches still defer.
- Verification report F6: a generation+1 immediate yield wake cancels the old 120-second timer; repeated same-generation scheduling keeps one timer.
- `node scripts/run-vitest.mjs src/agents/subagents/completion/subagent-completion-admission.store.test.ts src/agents/subagents/registry/subagent-registry-lifecycle.test.ts src/agents/subagents/registry/subagent-registry-requester-yield.test.ts` — 3 files, 162 tests passed.
- `pnpm build` — passed locally after Testbox launch was unavailable because the Blacksmith CLI was missing.
- `pnpm check:import-cycles` — 0 runtime value cycles.
- Final branch autoreview — clean, no accepted/actionable findings.
- Production LOC: +63/-18 (net +45), justified by lifecycle-owned timer identity/deadline/generation state. Tests: +85/-1.
