### PR TITLE
chore: give test helpers nameable exported types

### DIFF
--- a/extensions/copilot/src/attempt-transcript-journal.test-helpers.ts
+++ b/extensions/copilot/src/attempt-transcript-journal.test-helpers.ts
@@ -9,7 +9,7 @@ import type {
   TranscriptTurnAdmission,
 } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
-import { vi } from "vitest";
+import { vi, type Mock } from "vitest";
 import { createAttemptTranscriptJournal } from "./attempt-transcript-journal.js";
 import type { AttemptParamsLike } from "./attempt-types.js";
 import { attachEventBridge, type SessionLike } from "./event-bridge.js";
@@ -18,6 +18,26 @@ const tempDirs: string[] = [];
 
 export type FakeSession = SessionLike & {
   emit: (event: SessionEvent) => void;
+};
+
+type TranscriptRecorder = NonNullable<AttemptParamsLike["userTurnTranscriptRecorder"]> & {
+  markBlocked: Mock<NonNullable<AttemptParamsLike["userTurnTranscriptRecorder"]>["markBlocked"]>;
+  markRuntimePersisted: Mock<
+    NonNullable<AttemptParamsLike["userTurnTranscriptRecorder"]>["markRuntimePersisted"]
+  >;
+  resolveMessage: Mock<
+    NonNullable<AttemptParamsLike["userTurnTranscriptRecorder"]>["resolveMessage"]
+  >;
+};
+
+type AttemptTranscriptJournalFixture = {
+  attempt: AttemptParamsLike;
+  bridge: ReturnType<typeof attachEventBridge>;
+  journal: ReturnType<typeof createAttemptTranscriptJournal>;
+  recorder: TranscriptRecorder;
+  session: FakeSession;
+  target: SessionTranscriptTargetParams;
+  tempDir: string;
 };
 
 export function createFakeSession(): FakeSession {
@@ -58,7 +78,7 @@ export function event(
 export async function createFixture(
   trigger?: string,
   resultContentSourceByToolName?: ReadonlyMap<string, "network">,
-) {
+): Promise<AttemptTranscriptJournalFixture> {
   const tempDir = await fs.mkdtemp(
     path.join(resolvePreferredOpenClawTmpDir(), "openclaw-copilot-journal-"),
   );
@@ -106,7 +126,7 @@ export async function createFixture(
     persistApproved: vi.fn(async () => undefined),
     persistBlocked: vi.fn(async () => undefined),
     persistFallback: vi.fn(async () => undefined),
-  } satisfies NonNullable<AttemptParamsLike["userTurnTranscriptRecorder"]>;
+  } satisfies TranscriptRecorder;
   const attempt = {
     agentId: "main",
     prompt: "inspect both files",

--- a/extensions/line/src/auto-reply-delivery.test-helpers.ts
+++ b/extensions/line/src/auto-reply-delivery.test-helpers.ts
@@ -1,9 +1,20 @@
 // Shared fixtures for LINE auto-reply delivery tests.
-import { vi } from "vitest";
+import type { messagingApi } from "@line/bot-sdk";
+import { vi, type Mock } from "vitest";
 import { deliverLineAutoReply } from "./auto-reply-delivery.js";
 import { createLineSendReceipt } from "./send-receipt.js";
 
 export type LineAutoReplyDeps = Parameters<typeof deliverLineAutoReply>[0]["deps"];
+
+type LineAutoReplyTestDeps = {
+  deps: LineAutoReplyDeps;
+  replyMessageLine: Mock<LineAutoReplyDeps["replyMessageLine"]>;
+  createQuickReplyItems: Mock<(labels: string[]) => { items: string[] }>;
+  buildMediaMessage: (
+    ...args: Parameters<LineAutoReplyDeps["buildMediaMessage"]>
+  ) => Promise<messagingApi.Message>;
+  pushMessagesLine: Mock<LineAutoReplyDeps["pushMessagesLine"]>;
+};
 
 export const LINE_TEST_CFG = { channels: { line: { accounts: { acc: {} } } } };
 
@@ -36,7 +47,7 @@ const createLocationMessage: LineAutoReplyDeps["createLocationMessage"] = (locat
       }
     : null;
 
-export function createDeps(overrides?: Partial<LineAutoReplyDeps>) {
+export function createDeps(overrides?: Partial<LineAutoReplyDeps>): LineAutoReplyTestDeps {
   const replyMessageLine = vi.fn<LineAutoReplyDeps["replyMessageLine"]>(async () => ({}));
   const createQuickReplyItems = vi.fn((labels: string[]) => ({ items: labels }));
   const buildMediaMessage: LineAutoReplyDeps["buildMediaMessage"] = vi.fn(

--- a/extensions/onepassword/src/secret-ref-cli.ts
+++ b/extensions/onepassword/src/secret-ref-cli.ts
@@ -12,6 +12,7 @@ import { resolveTrustedOnePasswordCli } from "../onepassword-op-path.js";
 import { encodeOnePasswordSecretId } from "../onepassword-secret-id.js";
 
 const ONEPASSWORD_PROVIDER_ALIAS = "onepassword";
+type PluginSecretRefSetupCli = ReturnType<typeof createPluginSecretRefSetupCli>;
 
 function normalizeOnePasswordSecretId(label: string, value: string): string {
   try {
@@ -22,7 +23,7 @@ function normalizeOnePasswordSecretId(label: string, value: string): string {
   }
 }
 
-const onePasswordSecretRefSetupCli = createPluginSecretRefSetupCli({
+const onePasswordSecretRefSetupCli: PluginSecretRefSetupCli = createPluginSecretRefSetupCli({
   productName: "1Password",
   secretIdLabel: "1Password SecretRef id",
   secretIdPlaceholder: "1password-secret-id",

--- a/extensions/policy/src/doctor/register.gateway-data-and-approvals.test-utils.ts
+++ b/extensions/policy/src/doctor/register.gateway-data-and-approvals.test-utils.ts
@@ -101,7 +101,7 @@ describe("registerPolicyDoctorChecks", () => {
       ...cfgWithPolicy(),
       diagnostics: { otel: { enabled: true, captureContent: true } },
       session: { maintenance: { mode: "warn" } },
-      memory: { search: { rememberAcrossConversations: true } },
+      memory: { search: { rememberAcrossConversations: true, sources: ["sessions"] } },
     } as unknown as OpenClawConfig;
     const configPath = await writeDataHandlingPolicyFixture({
       sensitiveLogging: { requireRedaction: true },

--- a/extensions/policy/src/doctor/register.test-harness.ts
+++ b/extensions/policy/src/doctor/register.test-harness.ts
@@ -95,7 +95,9 @@ export async function runPolicyChecksFixture(
   return runPolicyChecks(ctx(await writePolicyFixture(policy), cfg));
 }
 
-export async function runPolicyDoctorLint(checkCtx: HealthCheckContext) {
+export async function runPolicyDoctorLint(
+  checkCtx: HealthCheckContext,
+): Promise<Awaited<ReturnType<typeof runDoctorLintChecks>>> {
   return runDoctorLintChecks(checkCtx, { checks: registerChecks() });
 }
 

--- a/extensions/vault/src/cli.ts
+++ b/extensions/vault/src/cli.ts
@@ -8,6 +8,7 @@ import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { parseVaultSecretId } from "../vault-secret-id.js";
 
 const VAULT_PROVIDER_ALIAS = "vault";
+type PluginSecretRefSetupCli = ReturnType<typeof createPluginSecretRefSetupCli>;
 
 function normalizeVaultSecretId(label: string, value: string): string {
   try {
@@ -18,7 +19,7 @@ function normalizeVaultSecretId(label: string, value: string): string {
   }
 }
 
-const vaultSecretRefSetupCli = createPluginSecretRefSetupCli({
+const vaultSecretRefSetupCli: PluginSecretRefSetupCli = createPluginSecretRefSetupCli({
   productName: "Vault",
   secretIdLabel: "Vault secret id",
   secretIdPlaceholder: "vault-secret-id",

--- a/src/agents/openai-transport-stream.test-harness.ts
+++ b/src/agents/openai-transport-stream.test-harness.ts
@@ -5,11 +5,12 @@ import { expect } from "vitest";
 import { buildOpenAICompletionsParams } from "./openai-transport-stream.js";
 import { testing } from "./openai-transport-stream.test-support.js";
 
-export const {
-  buildOpenAIResponsesParams,
-  parseTransportChunkUsage,
-  resolveAzureOpenAIApiVersion,
-} = testing;
+export const buildOpenAIResponsesParams: typeof testing.buildOpenAIResponsesParams =
+  testing.buildOpenAIResponsesParams;
+export const parseTransportChunkUsage: typeof testing.parseTransportChunkUsage =
+  testing.parseTransportChunkUsage;
+export const resolveAzureOpenAIApiVersion: typeof testing.resolveAzureOpenAIApiVersion =
+  testing.resolveAzureOpenAIApiVersion;
 
 export type OpenAICompletionsOutput = Parameters<typeof testing.processOpenAICompletionsStream>[1];
 

--- a/src/agents/openai-transport-stream.test-support.ts
+++ b/src/agents/openai-transport-stream.test-support.ts
@@ -7,7 +7,20 @@ if (!completionsTesting || !responsesTesting) {
   throw new Error("OpenAI transport test APIs are unavailable outside test mode");
 }
 
-export const testing = {
+type OpenAICompletionsTransportTestApi = NonNullable<
+  typeof globalThis.openclawOpenAICompletionsTransportTestApi
+>;
+type OpenAIResponsesTransportTestApi = NonNullable<
+  typeof globalThis.openclawOpenAIResponsesTransportTestApi
+>;
+type OpenAITransportTestApi = Omit<
+  OpenAIResponsesTransportTestApi,
+  keyof OpenAICompletionsTransportTestApi
+> &
+  OpenAICompletionsTransportTestApi;
+
+// Keep declaration emit on the public test-API names instead of transport internals.
+export const testing: OpenAITransportTestApi = {
   ...responsesTesting,
   ...completionsTesting,
 };

--- a/src/cli/completion-cli.test-support.ts
+++ b/src/cli/completion-cli.test-support.ts
@@ -4,7 +4,7 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import { createInterface, type Interface as ReadlineInterface } from "node:readline";
 import { Command } from "commander";
-import { expect, it } from "vitest";
+import { expect, it, type TestAPI } from "vitest";
 import { getCompletionScript } from "./completion-cli.js";
 import { quoteCliArg } from "./quote-cli-arg.js";
 
@@ -59,7 +59,7 @@ function findFish(): string | null {
 }
 
 const fishPath = findFish();
-export const itWithFish = fishPath ? it : it.skip;
+export const itWithFish: TestAPI["skip"] = fishPath ? it : it.skip;
 
 export function runGeneratedFishCompletion(program: Command, commandLine: string): string[] {
   if (!fishPath) {
@@ -102,7 +102,7 @@ function findPowerShell(): string | null {
 }
 
 const powerShellPath = findPowerShell();
-export const itWithPowerShell = powerShellPath ? it : it.skip;
+export const itWithPowerShell: TestAPI["skip"] = powerShellPath ? it : it.skip;
 
 type PowerShellCompletionResponse =
   | { version: 1; id: string; ok: true; completions: string[] }

--- a/ui/src/e2e/new-session-page.test-support.ts
+++ b/ui/src/e2e/new-session-page.test-support.ts
@@ -77,7 +77,9 @@ export const SESSION_LIST_DEFAULTS = {
   modelProvider: "openai",
 };
 
-export function pollLocatorText(locator: Locator) {
+type LocatorTextPoll = ReturnType<typeof expect.poll<Promise<string | null>>>;
+
+export function pollLocatorText(locator: Locator): LocatorTextPoll {
   return expect.poll(() => locator.textContent({ timeout: LOCATOR_TEXT_READ_TIMEOUT_MS }), {
     timeout: LOCATOR_TEXT_POLL_TIMEOUT_MS,
   });


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI reliability problem where the test-type projects appeared green with warm incremental caches but failed from a fresh build-info cache. Before this change, a cold run reported 29 declaration-naming errors in the core test project and 9 in the extensions test project.

## Why This Change Was Made

Exported test helpers now use explicit, portable type expressions at their existing ownership boundaries. External types come from public Vitest and LINE entries, while plugin SecretRef helpers reference the existing SDK factory return type so the Plugin SDK surface remains unchanged. A stale policy-doctor fixture discovered by focused validation now enables the session source required by the behavior it already intended to test.

## User Impact

No user-visible runtime behavior changes. Maintainers and contributors get deterministic test-type results when CI caches are cold or invalidated.

## Evidence

Before, using distinct fresh build-info paths:

- Core test project: 29 errors.
- Extensions test project: 9 errors.
- Root test project: 0 errors.

After, using distinct fresh build-info paths:

- `./node_modules/.bin/tsgo -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile <fresh>/core.tsbuildinfo` — 0 errors.
- `./node_modules/.bin/tsgo -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile <fresh>/extensions.tsbuildinfo` — 0 errors.
- `./node_modules/.bin/tsgo -p test/tsconfig/tsconfig.test.root.json --incremental --tsBuildInfoFile <fresh>/root.tsbuildinfo` — 0 errors.
- `pnpm plugin-sdk:surface:check` — passed; no SDK surface change.
- `pnpm plugin-sdk:api:check` — passed; no contract drift.
- `node scripts/check-changed.mjs -- <touched paths>` — passed via the approved local fallback after the remote Crabbox broker was unavailable.
- Focused Vitest proof: OpenAI transport 47 passed; completion CLI 48 passed (75 platform skips); Copilot journal 34 passed; LINE delivery 34 passed; 1Password 20 passed; Vault 18 passed; policy doctor 301 passed.
- `$HOME/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings.
- `git diff --check` — passed.
