### PR TITLE
fix(agents): restore configured runtimes for direct ingress

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -62,6 +62,7 @@ import { AGENT_LANE_SUBAGENT } from "./lanes.js";
 import type { MainSessionRecoveryPendingTarget } from "./main-session-recovery/main-session-recovery-store.js";
 import type { AgentRunSessionTarget } from "./run-session-target.js";
 import { createAgentRunRestartAbortError } from "./run-termination.js";
+import { withAgentPluginRegistry } from "./runtime-plugins.js";
 import { measureAgentStartup } from "./startup-timing.js";
 
 type AgentCommandAdmissionIngress = Parameters<typeof executionIdentity.record>[0]["ingress"];
@@ -651,13 +652,18 @@ async function agentCommandFromIngressInternal(
       prepare: async (preparedOpts) => await prepareAgentCommandExecution(preparedOpts, runtime),
       restoreAdmittedRecovery: recovery?.restoreAdmittedRecovery,
       run: async (prepared) =>
-        await agentCommandInternal(
-          prepared,
-          prepared.opts,
-          { kind: "api", boundary: "agent-command.from-ingress", state: "unknown" },
-          runtime,
-          deps,
-        ),
+        await withAgentPluginRegistry({
+          config: prepared.cfg,
+          workspaceDir: prepared.workspaceDir,
+          run: async () =>
+            await agentCommandInternal(
+              prepared,
+              prepared.opts,
+              { kind: "api", boundary: "agent-command.from-ingress", state: "unknown" },
+              runtime,
+              deps,
+            ),
+        }),
     });
 
     if (result) {

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -30,8 +30,14 @@ vi.mock("./harness/runtime-plugin-load-plan.js", () => ({
   resolveAgentRuntimePluginLoadPlan: hoisted.resolveAgentRuntimePluginLoadPlan,
 }));
 
-import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
-import { loadAgentRuntimePluginRegistryHandle } from "./runtime-plugins.js";
+import {
+  getPluginRuntimeGatewayRequestScope,
+  withPluginRuntimeRegistryScope,
+} from "../plugins/runtime/gateway-request-scope.js";
+import {
+  loadAgentRuntimePluginRegistryHandle,
+  withAgentPluginRegistry,
+} from "./runtime-plugins.js";
 
 describe("agent runtime plugin registries", () => {
   beforeEach(() => {
@@ -170,5 +176,43 @@ describe("agent runtime plugin registries", () => {
       basePluginIds: [],
       selections: [],
     });
+  });
+
+  it("owns a scoped registry for direct hosts", async () => {
+    const config = {} as never;
+    const pluginRegistry = { handle: true } as never;
+    hoisted.loadPluginRegistryHandle.mockReturnValue(pluginRegistry);
+
+    await expect(
+      withAgentPluginRegistry({
+        config,
+        workspaceDir: "/tmp/workspace",
+        run: async () => getPluginRuntimeGatewayRequestScope()?.pluginRegistry,
+      }),
+    ).resolves.toBe(pluginRegistry);
+
+    expect(getPluginRuntimeGatewayRequestScope()).toBeUndefined();
+    expect(hoisted.resolveAgentRuntimePluginLoadPlan).toHaveBeenCalledWith({
+      config,
+      workspaceDir: "/tmp/workspace",
+      basePluginIds: [],
+      selections: [],
+    });
+  });
+
+  it("reuses an existing gateway registry owner", async () => {
+    const gatewayRegistry = { gateway: true } as never;
+
+    await expect(
+      withPluginRuntimeRegistryScope(gatewayRegistry, () =>
+        withAgentPluginRegistry({
+          config: {} as never,
+          workspaceDir: "/tmp/workspace",
+          run: async () => getPluginRuntimeGatewayRequestScope()?.pluginRegistry,
+        }),
+      ),
+    ).resolves.toBe(gatewayRegistry);
+
+    expect(hoisted.loadPluginRegistryHandle).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -881,6 +881,113 @@ describe("agentCommand", () => {
     });
   });
 
+  it("runs direct ingress with a configured plugin-owned harness", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      const workspaceDir = path.join(home, "openclaw");
+      const pluginDir = path.join(home, "plugins", "ingress-proof");
+      fs.mkdirSync(pluginDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(pluginDir, "openclaw.plugin.json"),
+        JSON.stringify({
+          id: "ingress-proof",
+          name: "Ingress proof harness",
+          activation: { onStartup: false, onAgentHarnesses: ["ingress-proof"] },
+          configSchema: { type: "object", additionalProperties: false },
+        }),
+      );
+      fs.writeFileSync(
+        path.join(pluginDir, "package.json"),
+        JSON.stringify({
+          name: "ingress-proof",
+          version: "1.0.0",
+          type: "module",
+          openclaw: { extensions: ["./index.js"] },
+        }),
+      );
+      fs.writeFileSync(
+        path.join(pluginDir, "index.js"),
+        `export default {
+          id: "ingress-proof",
+          register(api) {
+            api.registerAgentHarness({
+              id: "ingress-proof",
+              label: "Ingress proof harness",
+              supports: () => ({ supported: true }),
+              async runAttempt() { throw new Error("unused"); },
+            });
+          },
+        };\n`,
+      );
+      const cfg = {
+        meta: { migrations: { modelPolicyAllowlist: true } },
+        plugins: {
+          allow: ["ingress-proof"],
+          entries: { "ingress-proof": { enabled: true } },
+          load: { paths: [pluginDir] },
+        },
+        models: {
+          providers: {
+            "ingress-proof": {
+              api: "openai-responses",
+              baseUrl: "https://example.invalid/v1",
+              models: [
+                {
+                  id: "proof-model",
+                  name: "Proof model",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 128_000,
+                  maxTokens: 4096,
+                  agentRuntime: { id: "ingress-proof" },
+                },
+              ],
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            model: { primary: "ingress-proof/proof-model" },
+            workspace: workspaceDir,
+          },
+        },
+        session: { store, mainKey: "main" },
+      } as OpenClawConfig;
+      configIoMocks.loadConfig.mockReturnValue(cfg);
+      const actualRuntimePlugins = await vi.importActual<
+        typeof import("../agents/runtime-plugins.js")
+      >("../agents/runtime-plugins.js");
+      const runtimePlugins = await import("../agents/runtime-plugins.js");
+      vi.spyOn(runtimePlugins, "withAgentPluginRegistry").mockImplementationOnce(
+        actualRuntimePlugins.withAgentPluginRegistry,
+      );
+      await agentCommandFromIngress(
+        {
+          message: "ping",
+          agentId: "main",
+          allowModelOverride: false,
+        },
+        runtime,
+      );
+
+      expect(agentHarnessPluginMocks.ensureSelectedAgentHarnessPlugin).toHaveBeenCalledTimes(2);
+      const harnessSelectionCalls = agentHarnessPluginMocks.ensureSelectedAgentHarnessPlugin.mock
+        .calls as unknown as Array<
+        [
+          Parameters<
+            typeof import("../agents/harness/runtime-plugin.js").ensureSelectedAgentHarnessPlugin
+          >[0],
+        ]
+      >;
+      for (const [{ pluginRegistry }] of harnessSelectionCalls) {
+        expect(
+          pluginRegistry?.agentHarnesses.some((entry) => entry.harness.id === "ingress-proof"),
+        ).toBe(true);
+      }
+    });
+  });
+
   it("persists local overrides", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");


### PR DESCRIPTION
Related: #119855

## What Problem This Solves

Fixes an issue where direct ingress callers using a configured plugin-owned runtime could fail before the turn started because that path did not bind an agent plugin registry.

## Why This Change Was Made

Direct ingress now runs through the existing agent plugin-registry owner after command preparation. The owner reuses a Gateway registry when one exists and otherwise loads only the configured runtime plugins, matching the already-shipped local command path without adopting the broader prepared-registry refactor.

Production LOC: +13/-7 (net +6) | Tests: +153/-2

The positive production delta establishes the missing runtime ownership boundary for direct ingress.

## User Impact

Forced Codex and other configured plugin-owned runtimes can start from direct ingress surfaces instead of failing before the first turn.

## Evidence

- `node scripts/run-vitest.mjs src/commands/agent.test.ts src/agents/runtime-plugins.test.ts` - 52 tests passed, including a real installed/configured plugin-owned harness through direct ingress
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs src/agents/agent-command.ts src/agents/runtime-plugins.test.ts src/commands/agent.test.ts` - passed
- `pnpm exec oxfmt --check src/agents/agent-command.ts src/agents/runtime-plugins.test.ts src/commands/agent.test.ts` - passed
- `node scripts/check-max-lines-ratchet.mts --base origin/main` - passed
- `git diff --check origin/main...HEAD` - passed
- Commit signature verified locally.

Upstream Codex contract checked at sibling Codex SHA `414782450952a196bbb64b1605a458c2531c47b6`: initialization and thread/turn method definitions in `codex-rs/app-server-protocol/src/protocol/common.rs:466-481,799-803`; initialization gate and thread/turn dispatch in `codex-rs/app-server/src/message_processor.rs:839-880,1090-1100,1320-1330`; connection RPC lifetime in `codex-rs/app-server/src/connection_rpc_gate.rs:6-49`.

Release-line provenance: signed-equivalent fix `c33fa6ee831776373f576ca8ba107cd599ea38af`.
