### PR TITLE
fix(models): local model no-auth and overflow handling

### DIFF
--- a/packages/ai/src/host.ts
+++ b/packages/ai/src/host.ts
@@ -319,6 +319,11 @@ export function resolveAiTransportHeaderSentinels(
   const host = getAiTransportHost();
   let resolvedHeaders: Record<string, string> | undefined;
   for (const [name, value] of Object.entries(headers)) {
+    if (value === null) {
+      // applyLocalNoAuthHeaderOverride marks no-auth local providers with a
+      // runtime null marker outside the public string-only Model contract.
+      continue;
+    }
     const resolved = host.resolveSecretSentinel(value);
     if (resolved !== value) {
       resolvedHeaders ??= { ...headers };

--- a/packages/ai/src/transports/simple-completion-transport.test.ts
+++ b/packages/ai/src/transports/simple-completion-transport.test.ts
@@ -239,7 +239,7 @@ describe("prepareModelForSimpleCompletion", () => {
     expect(result).toBe(model);
   });
 
-  it("aliases a provider-owned stream when its wire-format api is already registered", async () => {
+  it("aliases a provider-owned stream while preserving its null auth-header marker", async () => {
     const builtInStream = vi.fn(() => createAssistantMessageEventStream());
     apiRegistry.registerApiProvider(
       {
@@ -260,6 +260,7 @@ describe("prepareModelForSimpleCompletion", () => {
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       contextWindow: 32768,
       maxTokens: 2048,
+      headers: { Authorization: null } as never,
     };
 
     const result = prepareModelForSimpleCompletion({ model });

--- a/scripts/run-node-watch-paths.mts
+++ b/scripts/run-node-watch-paths.mts
@@ -10,9 +10,11 @@ const RUN_NODE_PACKAGE_SOURCE_ROOTS = [
   // Root runtime code imports these package sources through tsconfig aliases,
   // while pnpm dev/watch still runs the root dist entrypoint. Treat them like
   // src/ so edits restart the same process that consumes them.
+  "packages/ai/src",
   "packages/gateway-client/src",
   "packages/gateway-protocol/src",
   "packages/markdown-core/src",
+  "packages/llm-core/src",
   "packages/media-core/src",
   "packages/media-generation-core/src",
   "packages/media-understanding-common/src",

--- a/src/agents/failover/context-overflow.test.ts
+++ b/src/agents/failover/context-overflow.test.ts
@@ -9,4 +9,12 @@ describe("isLikelyContextOverflowError", () => {
       ),
     ).toBe(true);
   });
+
+  it("does not mistake LM Studio prompt-template override guidance for overflow", () => {
+    expect(
+      isLikelyContextOverflowError(
+        'Error rendering prompt with jinja template: "Cannot apply filter upper to type UndefinedValue". You can override the prompt template in model settings.',
+      ),
+    ).toBe(false);
+  });
 });

--- a/src/agents/failover/context-overflow.ts
+++ b/src/agents/failover/context-overflow.ts
@@ -133,6 +133,9 @@ export function isLikelyContextOverflowError(errorMessage?: string): boolean {
   if (isContextOverflowError(errorMessage)) {
     return true;
   }
+  if (normalizeLowercaseStringOrEmpty(errorMessage).includes("prompt template")) {
+    return false;
+  }
   if (RATE_LIMIT_HINT_RE.test(errorMessage)) {
     return false;
   }

--- a/test/scripts/bundled-plugin-assets.test.ts
+++ b/test/scripts/bundled-plugin-assets.test.ts
@@ -119,6 +119,14 @@ describe("bundled plugin assets", () => {
     expect(isRestartRelevantRunNodePath("extensions/discord/src/activities/http.ts")).toBe(true);
   });
 
+  it.each(["packages/ai/src/host.ts", "packages/llm-core/src/types.ts"])(
+    "rebuilds the root runtime for %s",
+    (source) => {
+      expect(isBuildRelevantRunNodePath(source)).toBe(true);
+      expect(isRestartRelevantRunNodePath(source)).toBe(true);
+    },
+  );
+
   it("refreshes generated output metadata without recreating the watcher", async () => {
     await withPluginAssetFixture(async (rootDir) => {
       const packagePath = path.join(rootDir, "extensions", "canvas", "package.json");


### PR DESCRIPTION
## What Problem This Solves

Fixes local OpenAI-compatible model runs where a no-auth provider could crash before any request reached the local server, LM Studio prompt-template errors could be mistaken for context overflow and trigger pointless compaction, and `pnpm openclaw` development runs could keep stale `packages/ai` or `packages/llm-core` code after edits.

## Why This Change Was Made

The transport sentinel resolver now preserves the internal null `Authorization` marker used for intentionally unauthenticated local providers instead of treating it as a string. Context-overflow classification now excludes prompt-template guidance before the broad overflow hint can match “override.” The dev watcher now treats the internal AI and LLM-core package source roots as root-runtime inputs.

## User Impact

Local no-auth models such as LM Studio and llama.cpp can complete requests without a pre-dispatch crash; prompt-template failures surface as real template errors instead of causing misleading compaction; developers see AI/LLM core changes reflected in dev runs without manual restarts.

## Evidence

- Reproduced pre-fix local LM Studio failure: `TypeError: Cannot read properties of null (reading 'includes')`; post-fix HTTP 200 with exact `pong` output and no cloud fallback.
- Reproduced LM Studio Jinja template error being classified as context overflow; post-fix classification remains non-overflow.
- Focused Vitest after rebase onto latest `origin/main`: 3 shards, 33 tests passed (`packages/ai/src/transports/simple-completion-transport.test.ts`, `src/agents/failover/context-overflow.test.ts`, `test/scripts/bundled-plugin-assets.test.ts`).
- Remote changed gate passed on Blacksmith Testbox `tbx_01kzpmjsw95cb4jdn7b2bykpce`, including Plugin SDK baseline, typechecks, lint, guards, and formatting.
- Codex autoreview on rebased commit `c075a6fb5bd7`: no accepted/actionable findings; patch is correct (0.99).
- Production LOC: +10/-0; tests/tooling tests: +18/-1.
