### PR TITLE
improve(ui): make warm session switches settle faster

### DIFF
--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -44,7 +44,7 @@ type SessionCatalogRenderSnapshot = {
   loadingMoreCatalogIds: ReadonlySet<string>;
   projectGrouping: CatalogProjectGrouping;
   liveRows: readonly GatewaySessionRow[];
-  sidebarRowsByKey: ReadonlyMap<string, SidebarRecentSession>;
+  toSidebarSession: (row: GatewaySessionRow) => SidebarRecentSession;
   creatorId: string | null;
   catalogOpenTarget: CatalogOpenTarget;
   terminalAvailable: boolean;
@@ -335,7 +335,7 @@ function renderSessionCatalog(params: {
       renderLiveRow: (row, display) =>
         renderRecentSession({
           host,
-          session: snapshot.sidebarRowsByKey.get(row.key)!,
+          session: snapshot.toSidebarSession(row),
           display,
         }),
       onToggleSection: (sectionId) => host.toggleSection(sectionId),

--- a/ui/src/components/app-sidebar-session-navigation-logic.test.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.test.ts
@@ -269,6 +269,6 @@ it("keeps a prepared worktree session in Coding before canonical metadata arrive
     resolveAgentStatusNote: () => undefined,
   });
 
-  expect(navigation.visibleSessions).toHaveLength(1);
-  expect(navigation.visibleSessions[0]?.workSession).toBe(true);
+  expect(navigation.visibleSessionRows).toHaveLength(1);
+  expect(navigation.toSidebarSession(navigation.visibleSessionRows[0]!).workSession).toBe(true);
 });

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -101,7 +101,8 @@ function isSidebarDraftOwnedBySelf(
 export type SidebarSessionNavigationState = {
   routeSessionKey: string;
   selectedAgentId: string;
-  visibleSessions: SidebarRecentSession[];
+  activeRowKey: string | null;
+  visibleSessionRows: GatewaySessionRow[];
   toSidebarSession: (row: SessionRow, isChild?: boolean) => SidebarRecentSession;
 };
 
@@ -230,7 +231,8 @@ export function buildSidebarSessionNavigationState(input: {
   return {
     routeSessionKey: navigation.currentSessionKey,
     selectedAgentId: navigation.selectedAgentId,
-    visibleSessions: navigation.visibleSessions.map((row) => toSidebarSession(row)),
+    activeRowKey: navigation.activeRowKey,
+    visibleSessionRows: navigation.visibleSessions,
     toSidebarSession,
   };
 }
@@ -459,11 +461,11 @@ export function findProjectedSidebarSession(input: {
   navigationState: SidebarSessionNavigationState;
   sessionRowsByAgent: Readonly<Record<string, SessionsListResult["sessions"]>>;
 }): SidebarRecentSession | undefined {
-  const active = input.navigationState.visibleSessions.find(
+  const active = input.navigationState.visibleSessionRows.find(
     (candidate) => candidate.key === input.sessionKey,
   );
   if (active) {
-    return active;
+    return input.navigationState.toSidebarSession(active);
   }
   for (const rows of Object.values(input.sessionRowsByAgent)) {
     const row = rows.find((candidate) => candidate.key === input.sessionKey);

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -604,7 +604,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     const rowsByKey = new Map(rows.map((row) => [row.key, row]));
     const rootRows =
       selected === routeAgentId && selected === loadedAgentId
-        ? navigationState.visibleSessions.flatMap((session) => {
+        ? navigationState.visibleSessionRows.flatMap((session) => {
             const row = rowsByKey.get(session.key);
             return row ? [row] : [];
           })
@@ -624,12 +624,12 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     const lineageAgentId = normalizeAgentId(
       parseAgentSessionKey(lineageRoot?.key ?? "")?.agentId ?? "",
     );
-    const selectedFallback =
-      selected === routeAgentId || lineageAgentId === selected
-        ? navigationState.visibleSessions.find(
-            (session) => session.active && !areUiSessionKeysEquivalent(session.key, mainSessionKey),
-          )
-        : undefined;
+    const selectedFallback = navigationState.visibleSessionRows.find(
+      (session) =>
+        (selected === routeAgentId || lineageAgentId === selected) &&
+        session.key === navigationState.activeRowKey &&
+        !areUiSessionKeysEquivalent(session.key, mainSessionKey),
+    );
     const mainSessionKeys = new Set<string>([mainSessionKey]);
     const scopedRootRows = rootRows.filter((row) => {
       if (areUiSessionKeysEquivalent(row.key, mainSessionKey)) {
@@ -706,7 +706,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
         }
       }
       if (!selectedAlreadyProjected) {
-        projected.unshift(selectedFallback);
+        projected.unshift(navigationState.toSidebarSession(selectedFallback));
       }
     }
     const creatorFacet =

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -37,6 +37,7 @@ import type {
   SidebarNarrationSyncInput,
   SidebarSessionNarrationController,
 } from "./app-sidebar-session-narration.ts";
+import type { SidebarSessionNavigationState } from "./app-sidebar-session-navigation-logic.ts";
 import { AppSidebarSessionNavigationElement } from "./app-sidebar-session-navigation.ts";
 import {
   renderSessionTree,
@@ -81,6 +82,8 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
   // dropped because the controller aligns from cumulative snapshots.
   private narration: SidebarSessionNarrationController | null = null;
   private narrationLoad: Promise<void> | null = null;
+  private sessionNavigationState: SidebarSessionNavigationState | undefined;
+  private projectedSessionRows: SidebarRecentSession[] | undefined;
   private readonly narrationSubscriptions = this.createNarrationSubscriptions();
   private readonly nativeGatewaysChanged = () => this.requestUpdate();
   private readonly hiddenSessionCatalogsChanged = () => {
@@ -166,6 +169,8 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
 
   protected override willUpdate(changed: PropertyValues<this>) {
     super.willUpdate(changed);
+    this.sessionNavigationState = super.getSessionNavigationState();
+    this.projectedSessionRows = super.selectedAgentSessionRows(this.sessionNavigationState);
     const chip = this.activeChipAgent();
     // An open switcher tracks roster/reconnect updates; otherwise only hydrate
     // the active card and avoid background RPCs for every configured agent.
@@ -192,15 +197,27 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
     }
   }
 
+  override getSessionNavigationState(): SidebarSessionNavigationState {
+    return this.sessionNavigationState ?? super.getSessionNavigationState();
+  }
+
+  protected override selectedAgentSessionRows(
+    navigationState: SidebarSessionNavigationState,
+  ): SidebarRecentSession[] {
+    return this.projectedSessionRows ?? super.selectedAgentSessionRows(navigationState);
+  }
+
   override updated(changedProperties: PropertyValues<this>) {
     super.updated(changedProperties);
     if (!this.narration) {
       if (this.sidebarLiveActivity) {
         this.ensureNarrationController();
       }
-      return;
+    } else {
+      this.narration.sync(this.narrationSyncInput());
     }
-    this.narration.sync(this.narrationSyncInput());
+    this.sessionNavigationState = undefined;
+    this.projectedSessionRows = undefined;
   }
 
   private visibleNarrationRowsInOrder(): SidebarRecentSession[] {
@@ -419,12 +436,6 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
       ...(this.sessionData.sessionsResult?.sessions ?? []),
       ...Object.values(this.sessionData.sessionRowsByAgent).flat(),
     ];
-    const sidebarRowsByKey = new Map<string, SidebarRecentSession>();
-    for (const row of liveRows) {
-      if (!sidebarRowsByKey.has(row.key)) {
-        sidebarRowsByKey.set(row.key, navigationState.toSidebarSession(row));
-      }
-    }
     const { sections: allSections } = this.zonedVisibleSections(visibleSessions);
     const catalogs = this.sessionData.sessionCatalogs.filter(
       (catalog) => !this.hiddenSessionCatalogIds.has(catalog.id),
@@ -458,7 +469,7 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
         loadingMoreCatalogIds: this.sessionData.loadingMoreSessionCatalogIds,
         projectGrouping: this.catalogProjectGrouping,
         liveRows,
-        sidebarRowsByKey,
+        toSidebarSession: navigationState.toSidebarSession,
         creatorId: this.activeSessionCreatorId,
         catalogOpenTarget: this.catalogOpenTarget,
         terminalAvailable: this.terminalAvailable,

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1295,6 +1295,7 @@ describe("chat transcript rendering", () => {
 
     renderWithReply(firstReply);
     renderWithReply(currentReply);
+    expect(renderMessageGroupMock).toHaveBeenCalledOnce();
     requireElement(
       container,
       '[aria-label="Reply to message"]',

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -207,7 +207,7 @@ const renderMessageGroupMock = vi.fn(
     return html`<div class="chat-group">${text}</div>`;
   },
 );
-const assistantAttachmentRenderVersionMock = { value: 0 };
+const chatMediaRenderVersionMock = { value: 0 };
 
 type ChatHeaderTestState = {
   basePath?: string;
@@ -296,8 +296,8 @@ beforeEach(() => {
   vi.spyOn(chatThread, "getExpandedToolCards").mockReturnValue(new Map<string, boolean>());
   vi.spyOn(chatThread, "getExpandedUserMessages").mockReturnValue(new Map<string, boolean>());
   vi.spyOn(chatThread, "syncToolCardExpansionState").mockImplementation(() => undefined);
-  vi.spyOn(chatMessage, "getAssistantAttachmentAvailabilityRenderVersion").mockImplementation(
-    () => assistantAttachmentRenderVersionMock.value,
+  vi.spyOn(chatMessage, "getChatMediaRenderVersion").mockImplementation(
+    () => chatMediaRenderVersionMock.value,
   );
   vi.spyOn(chatMessage, "renderMessageGroup").mockImplementation(renderMessageGroupMock);
   vi.spyOn(chatMessage, "renderStreamGroup").mockImplementation(renderStreamGroupMock);
@@ -1855,7 +1855,7 @@ afterEach(() => {
   vi.useRealTimers();
   buildChatItemsMock.mockClear();
   renderMessageGroupMock.mockClear();
-  assistantAttachmentRenderVersionMock.value = 0;
+  chatMediaRenderVersionMock.value = 0;
   resetChatViewState();
   replaceSlashCommands(buildFallbackSlashCommands());
   vi.unstubAllGlobals();
@@ -2086,7 +2086,7 @@ describe("chat transcript rendering cache", () => {
     expect(renderMessageGroupMock.mock.calls[1]?.[1]).toMatchObject({ userId: "profile-1" });
   });
 
-  it("rerenders transcript groups when assistant attachment availability changes", () => {
+  it("rerenders transcript groups when chat media changes", () => {
     const messages = [{ role: "assistant", content: "ready" }];
     const toolMessages: unknown[] = [];
     const streamSegments: Array<{ text: string; ts: number }> = [];
@@ -2094,7 +2094,7 @@ describe("chat transcript rendering cache", () => {
     const container = document.createElement("div");
 
     renderChatInto(container, { messages, toolMessages, streamSegments, queue });
-    assistantAttachmentRenderVersionMock.value += 1;
+    chatMediaRenderVersionMock.value += 1;
     renderChatInto(container, { messages, toolMessages, streamSegments, queue, draft: "h" });
 
     expect(renderMessageGroupMock).toHaveBeenCalledTimes(2);

--- a/ui/src/pages/chat/components/chat-message-attachment-availability.ts
+++ b/ui/src/pages/chat/components/chat-message-attachment-availability.ts
@@ -44,8 +44,6 @@ const ASSISTANT_ATTACHMENT_METADATA_FETCH_TIMEOUT_MS = 30_000;
 export const ASSISTANT_ATTACHMENT_MEDIA_TICKET_REFRESH_SKEW_MS = 30_000;
 export const ASSISTANT_ATTACHMENT_MEDIA_TICKET_MAX_REFRESH_RETRIES = 2;
 
-let assistantAttachmentAvailabilityRenderVersion = 0;
-
 export function resolveAssistantAttachmentAvailability(
   source: string,
   localMediaPreviewRoots: readonly string[],
@@ -89,7 +87,6 @@ export function resolveAssistantAttachmentAvailability(
     ) {
       resource.retryAttempted = true;
       resource.value = undefined;
-      bumpAssistantAttachmentAvailabilityRenderVersion();
     } else if (
       cached.status === "available" &&
       cached.mediaTicket &&
@@ -252,15 +249,6 @@ function createUnavailableAssistantAttachment(
   };
 }
 
-export function getAssistantAttachmentAvailabilityRenderVersion(): number {
-  return assistantAttachmentAvailabilityRenderVersion;
-}
-
-export function bumpAssistantAttachmentAvailabilityRenderVersion(): void {
-  assistantAttachmentAvailabilityRenderVersion =
-    (assistantAttachmentAvailabilityRenderVersion + 1) % Number.MAX_SAFE_INTEGER;
-}
-
 function buildAssistantAttachmentMetaUrl(source: string, basePath?: string): string {
   const attachmentUrl = buildAssistantAttachmentUrl(source, basePath);
   return `${attachmentUrl}${attachmentUrl.includes("?") ? "&" : "?"}meta=1`;
@@ -274,7 +262,6 @@ function setAssistantAttachmentAvailability(
     return;
   }
   resource.value = availability;
-  bumpAssistantAttachmentAvailabilityRenderVersion();
   scheduleAssistantAttachmentRefresh(resource, availability);
 }
 
@@ -298,13 +285,8 @@ function scheduleAssistantAttachmentRefresh(
     // Keep the failed generation until its retry can inherit the one-attempt
     // budget. A ticket refresh keeps the playable generation mounted while
     // its replacement is minted, otherwise the checking card resets playback.
-    if (availability.status === "available") {
-      // Virtual rows use this version as their media invalidation key. Notify
-      // alone updates the host but can leave the attachment row memoized.
-      bumpAssistantAttachmentAvailabilityRenderVersion();
-    } else if (availability.status !== "unavailable") {
+    if (availability.status === "checking") {
       resource.value = undefined;
-      bumpAssistantAttachmentAvailabilityRenderVersion();
     }
     notifyChatMediaResourceSubscribers(resource);
   });

--- a/ui/src/pages/chat/components/chat-message-attachments.ts
+++ b/ui/src/pages/chat/components/chat-message-attachments.ts
@@ -9,8 +9,6 @@ import {
   ASSISTANT_ATTACHMENT_MEDIA_TICKET_MAX_REFRESH_RETRIES,
   ASSISTANT_ATTACHMENT_MEDIA_TICKET_REFRESH_SKEW_MS,
   ASSISTANT_ATTACHMENT_UNAVAILABLE_RETRY_MS,
-  bumpAssistantAttachmentAvailabilityRenderVersion,
-  getAssistantAttachmentAvailabilityRenderVersion,
   isManagedOutgoingMediaSource,
   managedAttachmentRefreshDelayMs,
   resolveAssistantAttachmentAvailability,
@@ -38,8 +36,6 @@ import {
   type ChatMediaResource,
 } from "./chat-message-media.ts";
 
-export { getAssistantAttachmentAvailabilityRenderVersion };
-
 function retainManagedAttachmentUntilExpiry(
   resource: ChatMediaResource<ManagedAttachmentAvailability>,
   availability: Extract<ManagedAttachmentAvailability, { status: "available" }> | null,
@@ -66,7 +62,6 @@ function setManagedAttachmentAvailability(
     return;
   }
   resource.value = availability;
-  bumpAssistantAttachmentAvailabilityRenderVersion();
   const refreshAt =
     availability.status === "checking"
       ? availability.refreshAfter
@@ -86,7 +81,6 @@ function setManagedAttachmentAvailability(
       resource.retryAttempted = true;
       resource.value = undefined;
     }
-    bumpAssistantAttachmentAvailabilityRenderVersion();
     notifyChatMediaResourceSubscribers(resource);
   });
 }

--- a/ui/src/pages/chat/components/chat-message-media.ts
+++ b/ui/src/pages/chat/components/chat-message-media.ts
@@ -76,6 +76,7 @@ const chatMediaResources = new Map<string, ChatMediaResource<unknown>>();
 const chatMediaSubscribers = new Map<() => void, ChatMediaSubscriber>();
 const managedImageBlobUrls = new Map<string, ManagedImageBlobUrl>();
 const MANAGED_IMAGE_BLOB_URL_CACHE_MAX_ENTRIES = 64;
+let chatMediaRenderVersion = 0;
 
 function chatMediaResourceKey(kind: ChatMediaResourceKind, cacheKey: string): string {
   return `${kind}\0${cacheKey}`;
@@ -157,10 +158,15 @@ export function isChatMediaResourceCurrent<Value>(resource: ChatMediaResource<Va
   );
 }
 
+export function getChatMediaRenderVersion(): number {
+  return chatMediaRenderVersion;
+}
+
 export function notifyChatMediaResourceSubscribers<Value>(resource: ChatMediaResource<Value>) {
   if (!isChatMediaResourceCurrent(resource)) {
     return;
   }
+  chatMediaRenderVersion = (chatMediaRenderVersion + 1) % Number.MAX_SAFE_INTEGER;
   // A pane can change its subscription while another pane is being notified.
   // Snapshot the current generation so a replacement never receives stale work.
   for (const subscriber of Array.from(resource.subscribers)) {

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -9,9 +9,11 @@ import * as localStorageModule from "../../../local-storage.ts";
 import * as chatAvatar from "../chat-avatar.ts";
 import { renderChatNotice } from "./chat-divider.ts";
 import { isTextyDocumentAttachment } from "./chat-message-document-preview.ts";
-import { releaseChatMediaResourceSubscriber } from "./chat-message-media.ts";
 import {
-  getAssistantAttachmentAvailabilityRenderVersion,
+  getChatMediaRenderVersion,
+  releaseChatMediaResourceSubscriber,
+} from "./chat-message-media.ts";
+import {
   dismissConfirmedActionPopovers,
   renderActivityGroup,
   renderMessageGroup,
@@ -3988,12 +3990,12 @@ describe("grouped chat rendering", () => {
     expect(
       container.querySelector<HTMLImageElement>(".chat-message-image")?.getAttribute("src"),
     ).toContain("mediaTicket=ticket-old");
-    const renderVersionBeforeRefresh = getAssistantAttachmentAvailabilityRenderVersion();
+    const renderVersionBeforeRefresh = getChatMediaRenderVersion();
 
     await vi.advanceTimersByTimeAsync(1_001);
     await flushAssistantAttachmentAvailabilityChecks();
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(getAssistantAttachmentAvailabilityRenderVersion()).not.toBe(renderVersionBeforeRefresh);
+    expect(getChatMediaRenderVersion()).not.toBe(renderVersionBeforeRefresh);
     expect(
       container.querySelector<HTMLImageElement>(".chat-message-image")?.getAttribute("src"),
     ).toContain("mediaTicket=ticket-new");

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -1,7 +1,7 @@
 // Public facade for Control UI grouped chat message rendering.
 import "../../../components/tooltip.ts";
 
-export { getAssistantAttachmentAvailabilityRenderVersion } from "./chat-message-attachments.ts";
+export { getChatMediaRenderVersion } from "./chat-message-media.ts";
 export {
   dismissConfirmedActionPopovers,
   openChatRewindConfirmation,

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -107,7 +107,7 @@ type ChatThreadState = {
   searchQuery: string;
   pinnedExpanded: boolean;
   transcriptRenderDependencies: readonly unknown[];
-  transcriptRenderContext: object;
+  transcriptRenderContext: { onSetReply?: ChatThreadProps["onSetReply"] };
 };
 
 type ChatThreadProps = {
@@ -1573,7 +1573,9 @@ function renderChatThreadContents(
       userAvatar: props.userAvatar ?? null,
       showAvatarGutter: !isDirectThread,
       contextWindow: threadContextWindow,
-      onReply: props.onSetReply,
+      onReply: props.onSetReply
+        ? (target) => state.transcriptRenderContext.onSetReply?.(target)
+        : undefined,
       onRewind:
         rewindEntryId && props.onRewindMessage
           ? () => {
@@ -1787,9 +1789,10 @@ function renderChatThreadContents(
     props.embedSandboxMode ?? "scripts",
     props.allowExternalEmbedUrls ?? false,
     threadContextWindow,
-    props.onSetReply,
+    Boolean(props.onSetReply),
     turnRecap === null ? "" : `${turnRecap.runtimeMs}:${turnRecap.outputTokens ?? ""}`,
   ]);
+  state.transcriptRenderContext.onSetReply = props.onSetReply;
   const transcriptContents =
     showLoadingSkeleton || isEmpty
       ? html`

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -84,7 +84,7 @@ import { renderChatDivider, renderChatNotice } from "./chat-divider.ts";
 import type { ArtifactDownloadResolver } from "./chat-message-media.ts";
 import {
   dismissConfirmedActionPopovers,
-  getAssistantAttachmentAvailabilityRenderVersion,
+  getChatMediaRenderVersion,
   openChatRewindConfirmation,
   renderMessageGroup,
   renderActivityGroup,
@@ -1756,7 +1756,7 @@ function renderChatThreadContents(
     expandedUserMessages,
     getExpansionStateVersion(expandedUserMessages),
     assistantMessageExpansionSignature(expandedAssistantMessages),
-    getAssistantAttachmentAvailabilityRenderVersion(),
+    getChatMediaRenderVersion(),
     // The host minute poll requests an update; this key crosses row guard() memoization.
     Math.floor(Date.now() / 60_000),
     getToolTitlesVersion(),


### PR DESCRIPTION
Related: #121624

## What Problem This Solves

Warm session switches already reuse retained chat roots, but the surrounding UI still repeated expensive work on every activation. A representative 100-session / 100-message switch reached useful content in 12.6 ms but took 266 ms to settle.

## Why This Change Was Made

Project sidebar session rows once per Lit update and share that projection across consumers, while projecting catalog rows only when rendered. Keep the latest reply callback in the stable transcript render context so callback identity churn no longer invalidates otherwise unchanged message rows. Chat media notifications now own their one render-version bump, replacing attachment-specific counters and preserving async document/media/QR updates without broad incidental transcript rerenders.

This preserves the existing three-presentation retention limit, live hidden-pane streaming, accessibility isolation, pane ownership, and split-pane behavior.

Production LOC: +52/-54 (net -2) | Tests: +15/-12 (net +3). The owner-level media invalidation cleanup more than absorbs the update-scoped sidebar cache; no new helper layer or retained-session state was added.

## User Impact

Warm session switches become visibly immediate across short, long, Markdown-heavy, tool-heavy, and near-5 MiB histories. In the representative 100-session case, useful content appears in 1.9 ms and the switch settles in 52 ms.

## Evidence

Two isolated exact-head runs used the production Control UI bundle in Chromium with a deterministic in-browser mocked Gateway. Both destinations were warmed, followed by one second idle before repeated switching.

| Warm scenario | Baseline first useful | This PR | Baseline settled | This PR (two runs) |
|---|---:|---:|---:|---:|
| 10 short messages | 2.4 ms | 1.3 ms | 69.1 ms | 36.6–43.0 ms |
| 100 × ~1 KiB | 12.6 ms | 1.9 ms | 266.0 ms | 51.7–51.8 ms |
| 800 KiB Markdown | 5.5 ms | 3.3 ms | 175.7 ms | 79.9–82.2 ms |
| 100 tool-heavy | 3.6 ms | 1.5–1.9 ms | 107.8 ms | 49.3–51.3 ms |
| near-5 MiB history | 4.5 ms | 1.9 ms | 141.3 ms | 34.1–46.8 ms |

Across every warm sample:

- retained transcript roots were reused;
- `chat.history`, `chat.startup`, `chat.subscribe`, and `chat.unsubscribe` deltas were zero;
- the background-streamed message was visible after activation;
- retention remained capped at three presentations with inactive roots `inert` and `aria-hidden`;
- same-session split panes retained distinct roots and drafts.

Regression proof for explicit media invalidation:

- merged baseline `e5de0a84345`: document-preview E2E passes;
- optimized intermediate head `e7ba34a4253`: the same E2E fails because preview completion no longer gets an incidental callback-identity rerender;
- exact final head `803711015dc`: the same E2E passes through the media resource notification owner.

Checks:

- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts ui/src/components/app-sidebar-session-navigation-logic.test.ts ui/src/components/app-sidebar-session-catalogs.test.ts ui/src/pages/chat/chat-view.test.ts` — 505 passed
- `node scripts/run-vitest.mjs ui/src/e2e/chat-flow.document-preview.e2e.test.ts ui/src/pages/chat/chat-view.test.ts ui/src/pages/chat/components/chat-message.test.ts` — 415 passed across UI and UI-E2E shards
- `pnpm tsgo:test:ui`
- `pnpm tsgo:ui`
- type-aware oxlint on all 12 changed files
- targeted `pnpm format:check`
- `pnpm check:max-lines-ratchet --base HEAD`
- autoreview after the performance change and after the media-invalidation repair — both clean, no accepted/actionable findings
