### PR TITLE
test(ui): remove output-root wrapper seam

### DIFF
--- a/scripts/ui.mts
+++ b/scripts/ui.mts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Routes UI package commands through the repo's Node/pnpm wrappers.
-import { spawn, spawnSync, type ChildProcess, type SpawnOptions } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
@@ -19,11 +19,12 @@ const FORWARDED_SIGNAL_KILL_GRACE_MS = 250;
 type UiSpawnCall = {
   args: string[];
   command: string;
-  options: SpawnOptions & {
+  options: {
     cwd: string;
     env: NodeJS.ProcessEnv;
     shell: boolean;
     stdio: "inherit";
+    windowsVerbatimArguments?: boolean;
   };
 };
 
@@ -137,10 +138,11 @@ function runSpawnCall(spawnCall: UiSpawnCall, label: string): void {
     return;
   }
 
-  let forwardedSignal: NodeJS.Signals | null = null;
+  const forwardedSignals = ["SIGTERM", "SIGHUP"] as const;
+  let forwardedSignal: (typeof forwardedSignals)[number] | null = null;
   let forwardedSignalPids: number[] = [];
-  let forceKillTimer: NodeJS.Timeout | null = null;
-  let forwardedSignalDrainTimer: NodeJS.Timeout | null = null;
+  let forceKillTimer: ReturnType<typeof setTimeout> | null = null;
+  let forwardedSignalDrainTimer: ReturnType<typeof setInterval> | null = null;
   const clearForwardedSignalTimers = () => {
     if (forceKillTimer) {
       clearTimeout(forceKillTimer);
@@ -166,7 +168,6 @@ function runSpawnCall(spawnCall: UiSpawnCall, label: string): void {
   // Keep UI dev children in the foreground process group for native TTY
   // resize/job-control behavior. Forward wrapper shutdown signals to the
   // captured child tree instead of using a detached process group.
-  const forwardedSignals: NodeJS.Signals[] = ["SIGTERM", "SIGHUP"];
   const signalHandlers = new Map(
     forwardedSignals.map((signal) => [
       signal,
@@ -338,10 +339,6 @@ function resolveScriptAction(action: string): "dev" | "build" | "test" | null {
   return null;
 }
 
-export function assertUiBuildOutputRoot(params: { rootDir?: string; fs?: typeof fs } = {}): void {
-  assertRealOutputRoot(path.join(params.rootDir ?? repoRoot, "dist"), { fs: params.fs ?? fs });
-}
-
 function main(argv: string[] = process.argv.slice(2)): void {
   const [action, ...rest] = argv;
   if (!action) {
@@ -355,7 +352,7 @@ function main(argv: string[] = process.argv.slice(2)): void {
     process.exit(2);
   }
   if (action === "build") {
-    assertUiBuildOutputRoot();
+    assertRealOutputRoot(path.join(repoRoot, "dist"));
   }
 
   if (process.env.OPENCLAW_BUILD_ALL_NO_PNPM === "1" && action === "build") {

--- a/test/scripts/ui.test.ts
+++ b/test/scripts/ui.test.ts
@@ -3,18 +3,13 @@ import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
-  assertUiBuildOutputRoot,
   isDirectScriptExecution,
   resolvePnpmSpawnCall,
   resolveSpawnCall,
   shouldUseCmdExeForCommand,
 } from "../../scripts/ui.mts";
-import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
-
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-
 // writeFileSync creates the file before its content lands, so an existence
 // poll can observe an empty file on loaded runners; wait for bytes instead.
 function readNonEmpty(file: string): string | null {
@@ -59,18 +54,6 @@ async function waitForExit(
 }
 
 describe("scripts/ui windows spawn behavior", () => {
-  it("rejects a symlinked dist root before launching a UI build", () => {
-    const rootDir = tempDirs.make("openclaw-ui-output-root-");
-    const targetDir = path.join(rootDir, "live-gateway-dist");
-    fs.mkdirSync(targetDir);
-    fs.writeFileSync(path.join(targetDir, "sentinel.js"), "keep\n");
-    fs.symlinkSync(targetDir, path.join(rootDir, "dist"), "dir");
-
-    expect(() => assertUiBuildOutputRoot({ rootDir })).toThrow(/symbolic link/u);
-    expect(fs.readFileSync(path.join(targetDir, "sentinel.js"), "utf8")).toBe("keep\n");
-    expect(fs.readlinkSync(path.join(rootDir, "dist"))).toBe(targetDir);
-  });
-
   it("wraps Windows command launchers with cmd.exe without enabling shell mode", () => {
     expect(
       shouldUseCmdExeForCommand("C:\\Users\\dev\\AppData\\Local\\pnpm\\pnpm.CMD", "win32"),


### PR DESCRIPTION
## What Problem This Solves

The UI build script exported an injectable `assertUiBuildOutputRoot` wrapper solely for a test that called the wrapper directly. That test duplicated the shared output-root guard's symlink case and did not execute `main(["build"])`, so deleting the real build-branch guard would not make it fail.

## Why This Change Was Made

This inlines `assertRealOutputRoot(path.join(repoRoot, "dist"))` at the actual build branch and deletes the wrapper, direct test, and temp-fixture scaffolding. The shared guard suite remains the canonical security contract for missing roots, files, directories, symlinks, dangling links, errors, and Windows junctions.

Touching `scripts/ui.mts` exposed pre-existing oxlint failures from broad Node namespace/intersection types. The same change narrows `UiSpawnCall.options` to fields the script actually uses and derives signal/timer types from local values, keeping tsgo and the script lint lane green without suppressions.

AI-assisted: yes. The change was manually inspected and passed repository autoreview.

## User Impact

No user-visible behavior change. UI builds still fail closed on a symlinked `dist` root before running Vite; the script has less test-only surface and clearer internal types.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/ui.test.ts test/scripts/output-root-guard.test.ts` — 17 tests passed, 1 platform-specific test skipped.
- Script and test-root tsgo — passed.
- Script-lane oxlint, targeted oxfmt, and `git diff --check` — passed.
- `node scripts/check-changed.mjs -- scripts/ui.mts test/scripts/ui.test.ts` — passed all selected tooling/type/lint/boundary gates using the trusted local fallback because Blacksmith Testbox is unavailable on this host.
- Fresh autoreview and secret scan — clean.

## Scope and LOC

- Production/tooling: `+8/-11` (net `-3`).
- Tests: `+1/-18` (net `-17`).
- Overall: `+9/-29` (net `-20`).

No runtime product behavior, config, protocol, database schema, dependency, lockfile, generated baseline, release, docs, or changelog change.
