### PR TITLE
fix(cron): surface Code Mode tool failures in cron run history

### DIFF
--- a/src/agents/embedded-agent-runner/run-loop.ts
+++ b/src/agents/embedded-agent-runner/run-loop.ts
@@ -578,33 +578,21 @@ export async function runPreparedEmbeddedLoop(
         reportedModelRef,
         finalAssistantVisibleText,
         finalAssistantRawText,
-        payloads,
         payloadsWithToolMedia,
-        timedOutDuringPrompt,
         recoveredFinalAssistantPayloadsAfterPromptTimeout,
-        hasSuccessfulFinalAssistantAfterPromptTimeout,
-        hasPartialAssistantTextAfterPromptTimeout,
         attemptToolSummary,
         failureSignal,
+        terminalToolFailure,
       } = terminalPrepared;
 
       const terminalTimeoutResult = resolveEmbeddedRunTerminalTimeout({
-        timedOutDuringPrompt,
-        hasSuccessfulFinalAssistantAfterPromptTimeout,
+        terminalPrepared,
         shouldSurfaceCodexCompletionTimeout: recovery.shouldSurfaceCodexCompletionTimeout,
         attempt: terminalAttempt,
-        hasPartialAssistantTextAfterPromptTimeout,
-        payloads,
-        payloadsWithToolMedia,
         terminalState: resolvedTerminalState,
         resolveReplayInvalid: resolveReplayInvalidForAttempt,
         setTerminalLifecycleMeta,
         startedAtMs: started,
-        agentMeta,
-        finalAssistantVisibleText,
-        finalAssistantRawText,
-        attemptToolSummary,
-        failureSignal,
       });
       if (terminalTimeoutResult) {
         return terminalTimeoutResult;
@@ -631,6 +619,7 @@ export async function runPreparedEmbeddedLoop(
         agentMeta,
         attemptToolSummary,
         failureSignal,
+        terminalToolFailure,
         maxReasoningOnlyRetryAttempts,
         maxEmptyResponseRetryAttempts,
         attemptCompactionCount: terminalAttemptCompactionCount,

--- a/src/agents/embedded-agent-runner/run.terminal-timeout.test.ts
+++ b/src/agents/embedded-agent-runner/run.terminal-timeout.test.ts
@@ -24,18 +24,31 @@ function makeTimedOutAttempt(
   };
 }
 
+type TimeoutInput = Parameters<typeof resolveEmbeddedRunTerminalTimeout>[0];
+
 function makeTimeoutInput(
   attempt: EmbeddedRunAttemptResult,
-  overrides: Partial<Parameters<typeof resolveEmbeddedRunTerminalTimeout>[0]> = {},
-): Parameters<typeof resolveEmbeddedRunTerminalTimeout>[0] {
+  preparedOverrides: Partial<TimeoutInput["terminalPrepared"]> = {},
+  overrides: Partial<Omit<TimeoutInput, "terminalPrepared">> = {},
+): TimeoutInput {
   return {
-    timedOutDuringPrompt: true,
-    hasSuccessfulFinalAssistantAfterPromptTimeout: false,
+    terminalPrepared: {
+      timedOutDuringPrompt: true,
+      hasSuccessfulFinalAssistantAfterPromptTimeout: false,
+      hasPartialAssistantTextAfterPromptTimeout: false,
+      payloads: undefined,
+      payloadsWithToolMedia: undefined,
+      agentMeta: {
+        sessionId: "session-1",
+        provider: "openai",
+        model: "gpt-5.6-luna",
+      },
+      attemptToolSummary: undefined,
+      failureSignal: undefined,
+      ...preparedOverrides,
+    },
     shouldSurfaceCodexCompletionTimeout: false,
     attempt,
-    hasPartialAssistantTextAfterPromptTimeout: false,
-    payloads: undefined,
-    payloadsWithToolMedia: undefined,
     terminalState: resolveEmbeddedRunAttemptTerminalState({
       attempt,
       assistant: attempt.lastAssistant,
@@ -43,13 +56,6 @@ function makeTimeoutInput(
     resolveReplayInvalid: vi.fn(() => false),
     setTerminalLifecycleMeta: vi.fn(),
     startedAtMs: Date.now(),
-    agentMeta: {
-      sessionId: "session-1",
-      provider: "openai",
-      model: "gpt-5.6-luna",
-    },
-    attemptToolSummary: undefined,
-    failureSignal: undefined,
     ...overrides,
   };
 }
@@ -100,7 +106,7 @@ describe("resolveEmbeddedRunTerminalTimeout", () => {
     });
 
     const result = resolveEmbeddedRunTerminalTimeout(
-      makeTimeoutInput(attempt, { setTerminalLifecycleMeta }),
+      makeTimeoutInput(attempt, {}, { setTerminalLifecycleMeta }),
     );
 
     expect(result?.payloads).toEqual([

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
@@ -93,6 +93,7 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
     };
   }
   const settledFailureSignal = prepared.failureSignal;
+  const settledTerminalToolFailure = prepared.terminalToolFailure;
 
   const runParams = input.terminalBase.runParams;
   const errorContext = input.terminalBase.activeErrorContext;
@@ -139,7 +140,11 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
     // host-owned recovery output and must cross that source-reply suppression.
     finalizedPrepared.payloadsWithToolMedia?.forEach(markReplyPayloadForSourceSuppressionDelivery);
     // A failure-honest final answer cannot turn a settled cron denial into success.
-    prepared = { ...finalizedPrepared, failureSignal: settledFailureSignal };
+    prepared = {
+      ...finalizedPrepared,
+      failureSignal: settledFailureSignal,
+      terminalToolFailure: settledTerminalToolFailure,
+    };
     return {
       attempt,
       attemptAssistant: attempt.currentAttemptAssistant,

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
@@ -204,6 +204,55 @@ describe("prepareEmbeddedRunTerminal", () => {
     expect(prepared.agentMeta.lastCallUsage).toMatchObject({ input: 200, output: 20, total: 220 });
   });
 
+  it("projects a Code Mode cron tool failure into terminal metadata", async () => {
+    const { prepareEmbeddedRunTerminal } = await import("./terminal-preparation.js");
+    const assistant = assistantMessage("stop");
+    const prepared = prepareEmbeddedRunTerminal({
+      runParams: {
+        admittedRunContext: createTestAdmittedRunContext("run-1"),
+        sessionId: "session-1",
+        runId: "run-1",
+        workspaceDir: "/tmp/openclaw-test",
+        prompt: "hi",
+        trigger: "cron",
+        timeoutMs: 60_000,
+      },
+      attempt: attemptResult({
+        codeModeEngaged: true,
+        lastToolError: {
+          toolName: "exec",
+          errorCode: "invalid_input",
+          error:
+            "Unknown tool id: MCP.notes.read. Use openclaw.tools.search to find a tool, openclaw.tools.describe to inspect it, then openclaw.tools.call with the exact id or name.",
+        },
+        lastAssistant: assistant,
+        currentAttemptAssistant: assistant,
+        currentAttemptCompletedAssistant: assistant,
+      }),
+      currentAttemptCompletedAssistant: assistant,
+      provider: "openai",
+      model: "gpt-5.4",
+      activeErrorContext: { provider: "openai", model: "gpt-5.4" },
+      authProfileStore: { version: 1, profiles: {} },
+      sessionIdUsed: "session-1",
+      outerContextTokenMeta: {},
+      usageAccumulator: createUsageAccumulator(),
+      contextRecoveryState: createEmbeddedRunContextRecoveryState(),
+      resolvedToolResultFormat: "markdown",
+      terminalState: {
+        outcome: { reason: "completed", status: "ok", stopReason: "stop" },
+        signalOwnedInterruption: false,
+      },
+    });
+
+    expect(prepared.failureSignal).toBeUndefined();
+    expect(prepared.terminalToolFailure).toEqual({
+      source: "tool",
+      toolName: "exec",
+      code: "UNKNOWN_TOOL_ID",
+    });
+  });
+
   it("recovers current final text and tool media after a prompt-timeout race", async () => {
     const completedText = "Completed answer block before the timeout.";
     const partialText = "Partial final response before the timeout.";

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.ts
@@ -7,6 +7,7 @@ import type { AuthProfileStore } from "../../auth-profiles.js";
 import type { PreparedProviderFailoverOwner } from "../../failover/provider-patterns.js";
 import type { NormalizedUsage, UsageLike } from "../../usage.js";
 import { resolveEmbeddedRunFailureSignal } from "../failure-signal.js";
+import { resolveEmbeddedRunTerminalToolFailure } from "../terminal-tool-failure.js";
 import type { EmbeddedAgentMeta, EmbeddedAgentRunResult } from "../types.js";
 import type { UsageAccumulator } from "../usage-accumulator.js";
 import type { EmbeddedRunAttemptWithReceiptEvidence } from "./attempt-result.js";
@@ -58,6 +59,7 @@ export function prepareEmbeddedRunTerminal(input: {
   hasPartialAssistantTextAfterPromptTimeout: boolean;
   attemptToolSummary: ReturnType<typeof buildTraceToolSummary>;
   failureSignal: ReturnType<typeof resolveEmbeddedRunFailureSignal>;
+  terminalToolFailure: ReturnType<typeof resolveEmbeddedRunTerminalToolFailure>;
 } {
   const { runParams, attempt } = input;
   const { timedOutDuringCompaction, timedOutDuringToolExecution } = projectAgentRunAttemptTerminal(
@@ -271,6 +273,11 @@ export function prepareEmbeddedRunTerminal(input: {
     trigger: runParams.trigger,
     lastToolError: attempt.lastToolError,
   });
+  const terminalToolFailure = resolveEmbeddedRunTerminalToolFailure({
+    trigger: runParams.trigger,
+    codeModeEngaged: attempt.codeModeEngaged,
+    lastToolError: attempt.lastToolError,
+  });
   return {
     agentMeta,
     reportedModelRef,
@@ -284,6 +291,7 @@ export function prepareEmbeddedRunTerminal(input: {
     hasPartialAssistantTextAfterPromptTimeout,
     attemptToolSummary,
     failureSignal,
+    terminalToolFailure,
   };
 }
 

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -191,6 +191,7 @@ export async function resolveEmbeddedRunTerminal(input: {
   agentMeta: EmbeddedAgentMeta;
   attemptToolSummary: EmbeddedAgentRunResult["meta"]["toolSummary"];
   failureSignal?: EmbeddedRunFailureSignal;
+  terminalToolFailure?: EmbeddedAgentRunResult["meta"]["terminalToolFailure"];
   maxReasoningOnlyRetryAttempts: number;
   maxEmptyResponseRetryAttempts: number;
   attemptCompactionCount: number;
@@ -530,6 +531,7 @@ async function surfaceIncompleteTurn(
         },
         toolSummary: input.attemptToolSummary,
         ...(input.failureSignal ? { failureSignal: input.failureSignal } : {}),
+        ...(input.terminalToolFailure ? { terminalToolFailure: input.terminalToolFailure } : {}),
         agentHarnessResultClassification: input.attempt.agentHarnessResultClassification,
       },
       ...copyAttemptDeliveryState(input.attempt),
@@ -689,6 +691,7 @@ function completeEmbeddedRun(
         },
         toolSummary: input.attemptToolSummary,
         ...(input.failureSignal ? { failureSignal: input.failureSignal } : {}),
+        ...(input.terminalToolFailure ? { terminalToolFailure: input.terminalToolFailure } : {}),
         completion: {
           ...(stopReason ? { stopReason } : {}),
           ...(stopReason ? { finishReason: stopReason } : {}),

--- a/src/agents/embedded-agent-runner/run/terminal-timeout.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-timeout.ts
@@ -10,27 +10,34 @@ import {
 import { copyAttemptDeliveryState } from "./terminal-resolution.js";
 import type { EmbeddedRunAttemptResult } from "./types.js";
 
-export function resolveEmbeddedRunTerminalTimeout(input: {
+// Carries the prepared terminal facts forward as one bundle instead of
+// re-enumerating them at every caller (see run-loop's terminalPrepared).
+type EmbeddedRunTerminalPreparedFacts = {
   timedOutDuringPrompt: boolean;
   hasSuccessfulFinalAssistantAfterPromptTimeout: boolean;
-  shouldSurfaceCodexCompletionTimeout: boolean;
-  attempt: EmbeddedRunAttemptResult;
   hasPartialAssistantTextAfterPromptTimeout: boolean;
   payloads: EmbeddedAgentRunResult["payloads"];
   payloadsWithToolMedia: EmbeddedAgentRunResult["payloads"];
+  agentMeta: EmbeddedAgentMeta;
+  finalAssistantVisibleText?: string | undefined;
+  finalAssistantRawText?: string | undefined;
+  attemptToolSummary: EmbeddedAgentRunResult["meta"]["toolSummary"];
+  failureSignal: EmbeddedAgentRunResult["meta"]["failureSignal"];
+  terminalToolFailure?: EmbeddedAgentRunResult["meta"]["terminalToolFailure"];
+};
+
+export function resolveEmbeddedRunTerminalTimeout(input: {
+  terminalPrepared: EmbeddedRunTerminalPreparedFacts;
+  shouldSurfaceCodexCompletionTimeout: boolean;
+  attempt: EmbeddedRunAttemptResult;
   terminalState: EmbeddedRunTerminalState;
   resolveReplayInvalid: (incompleteTurnText?: string | null) => boolean;
   setTerminalLifecycleMeta: NonNullable<EmbeddedRunAttemptResult["setTerminalLifecycleMeta"]>;
   startedAtMs: number;
-  agentMeta: EmbeddedAgentMeta;
-  finalAssistantVisibleText?: string;
-  finalAssistantRawText?: string;
-  attemptToolSummary: EmbeddedAgentRunResult["meta"]["toolSummary"];
-  failureSignal: EmbeddedAgentRunResult["meta"]["failureSignal"];
 }): EmbeddedAgentRunResult | undefined {
   if (
-    !input.timedOutDuringPrompt ||
-    input.hasSuccessfulFinalAssistantAfterPromptTimeout ||
+    !input.terminalPrepared.timedOutDuringPrompt ||
+    input.terminalPrepared.hasSuccessfulFinalAssistantAfterPromptTimeout ||
     (!input.shouldSurfaceCodexCompletionTimeout && hasMessagingToolDeliveryEvidence(input.attempt))
   ) {
     return undefined;
@@ -50,9 +57,9 @@ export function resolveEmbeddedRunTerminalTimeout(input: {
   const livenessState =
     input.attempt.promptTimeoutOutcome?.livenessState ??
     resolveRunLivenessState({
-      payloadCount: input.hasPartialAssistantTextAfterPromptTimeout
+      payloadCount: input.terminalPrepared.hasPartialAssistantTextAfterPromptTimeout
         ? 0
-        : (input.payloads?.length ?? 0),
+        : (input.terminalPrepared.payloads?.length ?? 0),
       aborted: terminalAborted,
       timedOut: terminalTimedOut,
       attempt: input.attempt,
@@ -70,17 +77,19 @@ export function resolveEmbeddedRunTerminalTimeout(input: {
   input.setTerminalLifecycleMeta({ replayInvalid, livenessState, ...timeoutAttribution });
   return {
     payloads: [
-      ...(input.hasPartialAssistantTextAfterPromptTimeout ? [] : input.payloadsWithToolMedia || []),
+      ...(input.terminalPrepared.hasPartialAssistantTextAfterPromptTimeout
+        ? []
+        : input.terminalPrepared.payloadsWithToolMedia || []),
       { text: timeoutText, isError: true },
     ],
     meta: {
       durationMs: Date.now() - input.startedAtMs,
-      agentMeta: input.agentMeta,
+      agentMeta: input.terminalPrepared.agentMeta,
       aborted: terminalAborted,
       systemPromptReport: input.attempt.systemPromptReport,
       finalPromptText: input.attempt.finalPromptText,
-      finalAssistantVisibleText: input.finalAssistantVisibleText,
-      finalAssistantRawText: input.finalAssistantRawText,
+      finalAssistantVisibleText: input.terminalPrepared.finalAssistantVisibleText,
+      finalAssistantRawText: input.terminalPrepared.finalAssistantRawText,
       replayInvalid,
       livenessState,
       ...timeoutAttribution,
@@ -93,8 +102,13 @@ export function resolveEmbeddedRunTerminalTimeout(input: {
             },
           }
         : {}),
-      toolSummary: input.attemptToolSummary,
-      ...(input.failureSignal ? { failureSignal: input.failureSignal } : {}),
+      toolSummary: input.terminalPrepared.attemptToolSummary,
+      ...(input.terminalPrepared.failureSignal
+        ? { failureSignal: input.terminalPrepared.failureSignal }
+        : {}),
+      ...(input.terminalPrepared.terminalToolFailure
+        ? { terminalToolFailure: input.terminalPrepared.terminalToolFailure }
+        : {}),
       agentHarnessResultClassification: input.attempt.agentHarnessResultClassification,
     },
     ...copyAttemptDeliveryState(input.attempt),

--- a/src/agents/embedded-agent-runner/terminal-tool-failure.test.ts
+++ b/src/agents/embedded-agent-runner/terminal-tool-failure.test.ts
@@ -1,0 +1,133 @@
+// Coverage for bounded Code Mode failure projection into terminal metadata.
+import { describe, expect, it } from "vitest";
+import { resolveEmbeddedRunTerminalToolFailure } from "./terminal-tool-failure.js";
+
+describe("resolveEmbeddedRunTerminalToolFailure", () => {
+  it("projects a sanitized Code Mode cron failure", () => {
+    expect(
+      resolveEmbeddedRunTerminalToolFailure({
+        trigger: "cron",
+        codeModeEngaged: true,
+        lastToolError: {
+          toolName: "exec",
+          errorCode: "invalid_input",
+          error:
+            "Unknown tool id: MCP.notes.read. Use openclaw.tools.search to find a tool, openclaw.tools.describe to inspect it, then openclaw.tools.call with the exact id or name.",
+        },
+      }),
+    ).toEqual({
+      source: "tool",
+      toolName: "exec",
+      code: "UNKNOWN_TOOL_ID",
+    });
+  });
+
+  it("projects a failed resumed Code Mode run from the wait control", () => {
+    expect(
+      resolveEmbeddedRunTerminalToolFailure({
+        trigger: "cron",
+        codeModeEngaged: true,
+        lastToolError: {
+          toolName: "wait",
+          errorCode: "invalid_input",
+          error:
+            "Unknown tool id: MCP.notes.read. Did you mean: MCP.notes.list? Use openclaw.tools.search to find a tool, openclaw.tools.describe to inspect it, then openclaw.tools.call with the exact id or name.",
+        },
+      }),
+    ).toEqual({
+      source: "tool",
+      toolName: "wait",
+      code: "UNKNOWN_TOOL_ID",
+    });
+  });
+
+  it("recognizes the wrapped bridge error a live exec failure actually records", () => {
+    // Captured verbatim from a real cron run: the bridge throws, so the
+    // recorded text carries an Error: prefix, tools.* recovery phrasing, and a
+    // controller stack frame after the formatter line.
+    expect(
+      resolveEmbeddedRunTerminalToolFailure({
+        trigger: "cron",
+        codeModeEngaged: true,
+        lastToolError: {
+          toolName: "exec",
+          errorCode: "internal_error",
+          error:
+            "Error: Unknown tool id: MCP.notes.frobnicate. Did you mean: automations, browser? Use tools.search to find a tool, tools.describe to inspect it, then tools.call with the exact id or name.\n    at settle (openclaw-code-mode:controller.js:125:49)\n",
+        },
+      }),
+    ).toEqual({
+      source: "tool",
+      toolName: "exec",
+      code: "UNKNOWN_TOOL_ID",
+    });
+  });
+
+  it("rejects multi-line text whose later lines mimic the formatter", () => {
+    expect(
+      resolveEmbeddedRunTerminalToolFailure({
+        trigger: "cron",
+        codeModeEngaged: true,
+        lastToolError: {
+          toolName: "exec",
+          error:
+            "secret-ish output sk-live-4242\nUnknown tool id: MCP.notes.read. Use tools.search to find a tool, tools.describe to inspect it, then tools.call with the exact id or name.",
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps ordinary exec, structured denials, and arbitrary private errors on existing paths", () => {
+    const base = {
+      trigger: "cron",
+      lastToolError: { toolName: "exec", error: "command failed" },
+    } as const;
+
+    expect(resolveEmbeddedRunTerminalToolFailure(base)).toBeUndefined();
+    expect(
+      resolveEmbeddedRunTerminalToolFailure({
+        ...base,
+        codeModeEngaged: true,
+        lastToolError: { ...base.lastToolError, errorCode: "SYSTEM_RUN_DENIED" },
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveEmbeddedRunTerminalToolFailure({
+        ...base,
+        codeModeEngaged: true,
+        lastToolError: {
+          ...base.lastToolError,
+          error: "Unknown tool id: MCP.notes.read; private output: /home/operator/.config/token",
+        },
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveEmbeddedRunTerminalToolFailure({
+        ...base,
+        codeModeEngaged: true,
+        lastToolError: {
+          ...base.lastToolError,
+          error: "OPENAI_API_KEY=sk-test-abcdefghijklmnopqrstuvwxyz",
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not persist an identifier fragment that could be secret-shaped", () => {
+    const result = resolveEmbeddedRunTerminalToolFailure({
+      trigger: "cron",
+      codeModeEngaged: true,
+      lastToolError: {
+        toolName: "exec",
+        error:
+          "Unknown tool id: MCP.sk_test_abcdefghijklmnopqrstuvwxyz.read. Did you mean: MCP.notes.read? Use openclaw.tools.search to find a tool, openclaw.tools.describe to inspect it, then openclaw.tools.call with the exact id or name.",
+      },
+    });
+
+    expect(result).toEqual({
+      source: "tool",
+      toolName: "exec",
+      code: "UNKNOWN_TOOL_ID",
+    });
+  });
+});

--- a/src/agents/embedded-agent-runner/terminal-tool-failure.ts
+++ b/src/agents/embedded-agent-runner/terminal-tool-failure.ts
@@ -1,0 +1,65 @@
+import { asOptionalObjectRecord } from "@openclaw/normalization-core/record-coerce";
+/** Projects a safe Code Mode catalog miss into terminal metadata for operator diagnostics. */
+import { CODE_MODE_EXEC_TOOL_NAME, CODE_MODE_WAIT_TOOL_NAME } from "../code-mode-control-tools.js";
+import type { ToolErrorSummary } from "../tool-error-summary.js";
+import { normalizeToolPolicyName } from "../tool-policy.js";
+import type { EmbeddedRunTerminalToolFailure } from "./types.js";
+
+// Only persist the catalog-miss form emitted by the Code Mode bridge. Tool
+// error text otherwise can contain command output, private paths, or values
+// that known-secret redaction cannot establish as safe for durable history.
+// The bridge surfaces the miss to exec/wait as a thrown error, so the recorded
+// text is `Error: <formatter line>` plus a controller stack frame; recovery
+// phrasing is `tools.*` from the exec bridge and `openclaw.tools.*` from the
+// gated tool-search surface. Match the exact formatter line on the first line.
+const SAFE_MCP_CATALOG_MISS =
+  /^(?:Error: )?Unknown tool id: MCP\.[A-Za-z0-9][A-Za-z0-9._-]*\. (?:Did you mean: [^\r\n]+\? )?Use (?:openclaw\.tools\.search to find a tool, openclaw\.tools\.describe to inspect it, then openclaw\.tools\.call|tools\.search to find a tool, tools\.describe to inspect it, then tools\.call) with the exact id or name\.$/;
+export const CODE_MODE_MCP_CATALOG_MISS_MESSAGE =
+  "Code Mode could not resolve a configured MCP tool.";
+
+/** Validates the only terminal tool failure fact safe to persist in cron history. */
+export function isEmbeddedRunTerminalToolFailure(
+  value: unknown,
+): value is EmbeddedRunTerminalToolFailure {
+  const failure = asOptionalObjectRecord(value);
+  return (
+    failure?.source === "tool" &&
+    (failure.toolName === CODE_MODE_EXEC_TOOL_NAME ||
+      failure.toolName === CODE_MODE_WAIT_TOOL_NAME) &&
+    failure.code === "UNKNOWN_TOOL_ID"
+  );
+}
+
+/**
+ * Preserves one strictly allowlisted Code Mode catalog-miss fact for cron
+ * history. All other tool errors stay on the existing generic presentation
+ * path.
+ */
+export function resolveEmbeddedRunTerminalToolFailure(params: {
+  trigger?: string | undefined;
+  codeModeEngaged?: boolean | undefined;
+  lastToolError?: ToolErrorSummary | undefined;
+}): EmbeddedRunTerminalToolFailure | undefined {
+  const failure = params.lastToolError;
+  const normalizedToolName = normalizeToolPolicyName(failure?.toolName ?? "");
+  if (
+    params.trigger !== "cron" ||
+    params.codeModeEngaged !== true ||
+    !failure ||
+    (normalizedToolName !== CODE_MODE_EXEC_TOOL_NAME &&
+      normalizedToolName !== CODE_MODE_WAIT_TOOL_NAME)
+  ) {
+    return undefined;
+  }
+  const failureFirstLine =
+    typeof failure.error === "string" ? failure.error.split(/\r?\n/, 1)[0] : undefined;
+  const match = failureFirstLine ? SAFE_MCP_CATALOG_MISS.exec(failureFirstLine) : null;
+  if (!match) {
+    return undefined;
+  }
+  return {
+    source: "tool",
+    toolName: normalizedToolName,
+    code: "UNKNOWN_TOOL_ID",
+  };
+}

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -172,6 +172,12 @@ export type EmbeddedRunFailureSignal = {
   fatalForCron: true;
 };
 
+export type EmbeddedRunTerminalToolFailure = {
+  source: "tool";
+  toolName: "exec" | "wait";
+  code: "UNKNOWN_TOOL_ID";
+};
+
 export type EmbeddedAgentRunMeta = {
   durationMs: number;
   agentMeta?: EmbeddedAgentMeta;
@@ -208,6 +214,8 @@ export type EmbeddedAgentRunMeta = {
     terminalPresentation?: boolean;
   };
   failureSignal?: EmbeddedRunFailureSignal;
+  /** Bounded, sanitized unresolved Code Mode failure for operator diagnostics. */
+  terminalToolFailure?: EmbeddedRunTerminalToolFailure;
   /** Stop reason for the agent run (e.g., "completed", "tool_calls"). */
   stopReason?: string;
   /** Pending tool calls when stopReason is "tool_calls". */

--- a/src/cron/cron-execution-diagnostics.e2e.test.ts
+++ b/src/cron/cron-execution-diagnostics.e2e.test.ts
@@ -12,6 +12,7 @@ import { resetTaskRegistryForTests } from "../tasks/task-runtime.test-helpers.js
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
   loadRunCronIsolatedAgentTurn,
+  dispatchCronDeliveryMock,
   mockRunCronFallbackPassthrough,
   resetRunCronIsolatedAgentTurnHarness,
   resolveAllowedModelRefMock,
@@ -326,6 +327,57 @@ describe.sequential("cron execution diagnostics", () => {
               source: "tool",
               severity: "error",
               message: "SYSTEM_RUN_DENIED: approval required",
+            }),
+          ]),
+        },
+      });
+    }
+  });
+
+  it("persists and emits terminal tool detail while keeping the payload generic", async () => {
+    const modelRef = { provider: "openai", model: "gpt-5.4" };
+    resolveConfiguredModelRefMock.mockReturnValue(modelRef);
+    mockRunCronFallbackPassthrough();
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "⚠️ Exec failed", isError: true, toolName: "exec" }],
+      meta: {
+        agentMeta: {},
+        terminalToolFailure: {
+          source: "tool",
+          toolName: "exec",
+          code: "UNKNOWN_TOOL_ID",
+        },
+      },
+    });
+
+    const { finished, history } = await runPersistedDiagnosticCase({
+      cfg: configFor(modelRef),
+      modelRef,
+      name: "unknown tool id",
+    });
+
+    expect(dispatchCronDeliveryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deliveryPayloads: [{ text: "cron isolated run returned an error payload", isError: true }],
+        outputText: "cron isolated run returned an error payload",
+        summary: "Code Mode could not resolve a configured MCP tool.",
+      }),
+    );
+
+    for (const outcome of [finished, history]) {
+      expect(outcome).toMatchObject({
+        status: "error",
+        provider: "openai",
+        model: "gpt-5.4",
+        summary: "Code Mode could not resolve a configured MCP tool.",
+        diagnostics: {
+          summary: "Code Mode could not resolve a configured MCP tool.",
+          entries: expect.arrayContaining([
+            expect.objectContaining({
+              source: "tool",
+              severity: "error",
+              message: "Code Mode could not resolve a configured MCP tool.",
+              toolName: "exec",
             }),
           ]),
         },

--- a/src/cron/isolated-agent/run-finalize.ts
+++ b/src/cron/isolated-agent/run-finalize.ts
@@ -8,6 +8,10 @@ import { hasAcceptedSessionSpawn } from "../../agents/accepted-session-spawn.js"
 import { resolveAuthoredModelContextTokens } from "../../agents/context-resolution.js";
 import { hasCommittedMessagingToolDeliveryEvidence } from "../../agents/embedded-agent-runner/delivery-evidence.js";
 import { hasIntentionalTerminalCompletion } from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
+import {
+  CODE_MODE_MCP_CATALOG_MISS_MESSAGE,
+  isEmbeddedRunTerminalToolFailure,
+} from "../../agents/embedded-agent-runner/terminal-tool-failure.js";
 import { deriveContextPromptTokens } from "../../agents/usage.js";
 import { isSilentReplyPayloadText } from "../../auto-reply/tokens.js";
 import { SESSION_TOTAL_TOKENS_VERSION } from "../../config/sessions.js";
@@ -349,6 +353,11 @@ export async function finalizeCronRun(params: {
     hasFatalErrorPayload,
     embeddedRunError,
   } = cronPayloadOutcome;
+  const terminalToolFailure = finalRunResult.meta?.terminalToolFailure;
+  const hasTerminalToolFailure = isEmbeddedRunTerminalToolFailure(terminalToolFailure);
+  if (hasFatalErrorPayload && hasTerminalToolFailure) {
+    summary = CODE_MODE_MCP_CATALOG_MISS_MESSAGE;
+  }
   const agentDiagnostics = createCronRunDiagnosticsFromAgentResult(finalRunResult, {
     finalStatus: hasFatalErrorPayload ? "error" : "ok",
   });
@@ -372,7 +381,7 @@ export async function finalizeCronRun(params: {
       delivery: result?.delivery,
       diagnostics: mergeCronRunDiagnostics(
         runDiagnostics,
-        hasFatalErrorPayload
+        hasFatalErrorPayload && !hasTerminalToolFailure
           ? createCronRunDiagnosticsFromError(
               "agent-run",
               embeddedRunError ?? "cron isolated run returned an error payload",

--- a/src/cron/run-diagnostics.test.ts
+++ b/src/cron/run-diagnostics.test.ts
@@ -209,6 +209,97 @@ describe("cron run diagnostics", () => {
     });
   });
 
+  it("prefers a terminal tool failure over a generic failed-tool payload", () => {
+    const diagnostics = createCronRunDiagnosticsFromAgentResult(
+      {
+        payloads: [{ text: "⚠️ Exec failed", isError: true, toolName: "exec" }],
+        meta: {
+          terminalToolFailure: {
+            source: "tool",
+            toolName: "exec",
+            code: "UNKNOWN_TOOL_ID",
+          },
+        },
+      },
+      { nowMs: () => 123 },
+    );
+
+    expect(diagnostics?.summary).toBe("Code Mode could not resolve a configured MCP tool.");
+    expect(diagnostics?.entries).toEqual([
+      {
+        ts: 123,
+        source: "tool",
+        severity: "error",
+        message: "⚠️ Exec failed",
+        toolName: "exec",
+      },
+      {
+        ts: 123,
+        source: "tool",
+        severity: "error",
+        message: "Code Mode could not resolve a configured MCP tool.",
+        toolName: "exec",
+      },
+    ]);
+  });
+
+  it("downgrades a recovered terminal tool failure to a warning", () => {
+    const diagnostics = createCronRunDiagnosticsFromAgentResult(
+      {
+        meta: {
+          terminalToolFailure: {
+            source: "tool",
+            toolName: "exec",
+            code: "UNKNOWN_TOOL_ID",
+          },
+        },
+      },
+      { nowMs: () => 123, finalStatus: "ok" },
+    );
+
+    expect(diagnostics).toEqual({
+      summary: "Code Mode could not resolve a configured MCP tool.",
+      entries: [
+        {
+          ts: 123,
+          source: "tool",
+          severity: "warn",
+          message: "Code Mode could not resolve a configured MCP tool.",
+          toolName: "exec",
+        },
+      ],
+    });
+  });
+
+  it("reconstructs a safe diagnostic from terminal tool metadata", () => {
+    const diagnostics = createCronRunDiagnosticsFromAgentResult(
+      {
+        meta: {
+          terminalToolFailure: {
+            source: "tool",
+            toolName: "exec",
+            code: "UNKNOWN_TOOL_ID",
+            message: "private-path /home/operator/.config/token",
+          },
+        },
+      },
+      { nowMs: () => 123 },
+    );
+
+    expect(diagnostics).toEqual({
+      summary: "Code Mode could not resolve a configured MCP tool.",
+      entries: [
+        {
+          ts: 123,
+          source: "tool",
+          severity: "error",
+          message: "Code Mode could not resolve a configured MCP tool.",
+          toolName: "exec",
+        },
+      ],
+    });
+  });
+
   it("keeps failed exec output tails valid at UTF-16 boundaries", () => {
     const diagnostics = createCronRunDiagnosticsFromAgentResult(
       {

--- a/src/cron/run-diagnostics.ts
+++ b/src/cron/run-diagnostics.ts
@@ -1,6 +1,10 @@
 /** Builds bounded, redacted diagnostics for cron run logs and UI surfaces. */
 import { asOptionalObjectRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  CODE_MODE_MCP_CATALOG_MISS_MESSAGE,
+  isEmbeddedRunTerminalToolFailure,
+} from "../agents/embedded-agent-runner/terminal-tool-failure.js";
 import { isToolAllowedByPolicyName } from "../agents/tool-policy-match.js";
 import { normalizeToolPolicyName as normalizePolicyToolName } from "../agents/tool-policy.js";
 import { getReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
@@ -250,6 +254,16 @@ export function createCronRunDiagnosticsFromAgentResult(
       : undefined;
   if (typeof metaError?.message === "string") {
     diagnostics.push(createCronRunDiagnosticsFromError("agent-run", metaError.message, opts));
+  }
+  const terminalToolFailure = meta.terminalToolFailure;
+  if (isEmbeddedRunTerminalToolFailure(terminalToolFailure)) {
+    diagnostics.push(
+      createCronRunDiagnosticsFromError("tool", CODE_MODE_MCP_CATALOG_MISS_MESSAGE, {
+        ...opts,
+        severity: opts?.finalStatus === "ok" ? "warn" : "error",
+        toolName: terminalToolFailure.toolName,
+      }),
+    );
   }
   const failureSignal =
     meta.failureSignal && typeof meta.failureSignal === "object"


### PR DESCRIPTION
Related: #120385

## What Problem This Solves

Operators debugging a failed Code Mode cron run see only a generic `⚠️ 🛠️ Exec failed` in run history, even though OpenClaw already captured the specific bounded tool failure. The actionable cause — for example an unresolved tool id — is discarded before it reaches the history summary, so the run history says something broke without saying what.

## Why This Change Was Made

The embedded runner now projects unresolved Code Mode `exec`/`wait` failures into a separate bounded, redacted terminal diagnostic fact. Cron persists that fact as the actionable history summary while preserving the generic delivery payload unchanged. The existing fatal execution-denial signal and scheduler classification are untouched.

Diagnostics are restricted to genuine catalog misses, so ordinary tool errors are not reclassified.

**Security boundary:** MCP server names are operator-controlled and can be token-shaped. This change therefore persists only the fixed string `Code Mode could not resolve a configured MCP tool.` with **no identifier fragment**, and carries a regression that feeds a secret-shaped server name and asserts it never reaches persisted history.

This PR is AI-assisted. I reviewed the implementation and validation results and understand the shipped behavior.

## User Impact

A failed Code Mode cron run reports an actionable reason in run history instead of a bare `Exec failed`. No configured MCP identifier — and therefore no secret-shaped name — is written to persisted history.

## Scope Note

This is the first half of a deliberate split of #121488, which reviewers flagged as too large to defend at once (17 files, dual `merge-risk: security-boundary` + `compatibility`, 10 blocking items). This PR contains **only** the cron run-history diagnostic. The MCP allowlist suppression warning ships separately so each half can be reviewed on its own merits.

## Evidence

Branch rebases cleanly on `origin/main`; 13 files, +361/-2.

Targeted suites, run on this exact head:

```text
vitest --config test/vitest/vitest.cron.config.ts src/cron/run-diagnostics.test.ts
  Test Files  1 passed (1)
       Tests  17 passed (17)

vitest --config test/vitest/vitest.agents-embedded-agent.config.ts
  Test Files  1 passed (1)
       Tests  12 passed (12)

vitest --config test/vitest/vitest.agents-embedded-agent-run.config.ts \
  src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
  Test Files  1 passed (1)
       Tests  12 passed (12)
```

Coverage includes the secret-shaped-identifier regression, catalog-miss restriction, and terminal-preparation projection of the diagnostic fact.



## Follow-up — exact head `2dc91f528afa72c2a4a0ce171712ba2918e8a9cf`

Fixed the ClawSweeper P1 source-contract mismatch: terminal metadata now recognizes only the actual Code Mode unknown-MCP-ID formatter outputs (with or without its optional suggestion) and still persists only the fixed identifier-free message. Added the corresponding resolver and terminal-preparation regressions.

Validation on this exact head:

```text
terminal-tool-failure.test.ts: 4 passed
terminal-preparation.test.ts: 12 passed
run-diagnostics.test.ts: 17 passed
tsgo:core: passed
format check: passed
```

`lint` remains blocked before source linting by the pre-existing unrelated `packages/terminal-core/src/ansi.ts:194` / `string-width` signature error. A redacted real configured-MCP cron run is still required for the separate behavior-proof request.


## Real behavior proof — head `425238f7a47` (added 2026-08-17)

Redacted after-fix configured-MCP cron run from a real setup: this PR's head built (`pnpm build`) and run as a dist-backed Gateway with an isolated `OPENCLAW_STATE_DIR`, a real `streamable-http` MCP server from a live operator config (`mcp.servers.ibkr`, private host redacted; the server connected with its real auth token), per-agent `tools.codeMode: true`, and a real `deepseek/deepseek-v4-pro` model turn through the shipped `openclaw automations add/run/runs/show` flow — no mocks.

The cron message asked the model to exec `await tools.call('MCP.ibkr.frobnicate', {})` — a genuine catalog miss against a connected server. Persisted run history afterwards:

```json
{
  "status": "ok",
  "summary": "done",
  "diagnostics": {
    "summary": "Code Mode could not resolve a configured MCP tool.",
    "entries": [
      { "source": "tool", "severity": "warn", "toolName": "exec",
        "message": "Code Mode could not resolve a configured MCP tool." }
    ]
  }
}
```

`openclaw automations show <jobId>` (operator surface): `diagnostic: Code Mode could not resolve a configured MCP tool.`

**Identifier redaction proof:** grepping the full `automations runs --json` output for the configured server name and the requested tool fragment returns zero matches — no identifier reaches persisted history.

**Defect found by this live run and fixed in the recognizer commit (now `425238f7a47` after rebasing onto current main):** the previous recognizer never fired in production. The bridge surfaces the catalog miss to exec as a thrown error, so the recorded text is `Error: Unknown tool id: MCP.<id>. … Use tools.search …` plus a controller stack frame — the earlier anchored regex expected bare `openclaw.tools.*` phrasing with no prefix or stack, and matched none of it (live run persisted `diagnostics: null`). The recognizer now matches the exact formatter line on the first recorded line in either bridge phrasing; the persisted message remains the fixed identifier-free string. A regression covers the verbatim live-captured error and rejects multi-line mimicry. Focused suites on this head: `terminal-tool-failure` 6 passed, `terminal-preparation` 12 passed, `run-diagnostics` 17 passed.


**Rebase note (2026-08-17):** branch rebased onto current `main` (`914d8f69326`) to clear the merge conflict; `normalizeToolName` was renamed to `normalizeToolPolicyName` upstream and the recognizer follows. The configured-MCP cron proof above was re-executed on the rebased head build (`OpenClaw 2026.8.1 (425238f)`) with the same persisted result.


**Head `d09a0e5057e`:** restores three main-owned terminal-preparation tests dropped during rebase reconciliation and absorbs `run-loop.ts` max-lines growth by passing the prepared terminal facts to the timeout resolver as one bundle (net-negative production lines). The recognizer and persisted diagnostic are unchanged from the proven run; full `src/agents/embedded-agent-runner/` suite (8 shards) and `tsgo` pass on this head.



## Latest exact-head validation

Head `e84f917eb838727938baec5354c7bad206f547fa` closes the terminal metadata boundary: only the closed `UNKNOWN_TOOL_ID` fact reaches cron persistence, and both run summary and diagnostics reconstruct fixed identifier-free text. Arbitrary extra metadata is ignored.

Validation on this head:
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.terminal-timeout.test.ts src/agents/embedded-agent-runner/terminal-tool-failure.test.ts src/agents/embedded-agent-runner/run/terminal-preparation.test.ts src/cron/run-diagnostics.test.ts` (47 passed)
- `node scripts/run-vitest.mjs src/cron/cron-execution-diagnostics.e2e.test.ts` (9 passed)
- `node scripts/check-changed.mjs -- <changed files>` (ran; the original dead-export blocker was fixed; `node --import tsx scripts/check-deadcode-exports.mts` passed)
