### PR TITLE
fix: prevent macOS workshop collection test failures

### DIFF
--- a/src/skills/workshop/collection-reconcile.test.ts
+++ b/src/skills/workshop/collection-reconcile.test.ts
@@ -64,7 +64,7 @@ beforeEach(async () => {
     layout: "state-only",
     prefix: "openclaw-skill-collection-state-",
   });
-  workspaceDir = await tempDirs.make("openclaw-skill-collection-workspace-");
+  workspaceDir = await fs.realpath(await tempDirs.make("openclaw-skill-collection-workspace-"));
 });
 
 afterEach(async () => {
@@ -470,8 +470,7 @@ describe("skill collection reconciliation", () => {
         },
       ],
     });
-    const canonicalWorkspaceDir = await fs.realpath(workspaceDir);
-    const skillDir = path.join(canonicalWorkspaceDir, "skills", "procedure");
+    const skillDir = path.join(workspaceDir, "skills", "procedure");
     const skillFile = path.join(skillDir, "SKILL.md");
     const backupRoot = path.join(
       await fs.realpath(testState.stateDir),
@@ -521,7 +520,7 @@ describe("skill collection reconciliation", () => {
         },
       ],
     });
-    const skillDir = path.join(await fs.realpath(workspaceDir), "skills", "procedure");
+    const skillDir = path.join(workspaceDir, "skills", "procedure");
     const beforeVersion = getSkillsSnapshotVersion();
     copyDirectoryBefore.mockImplementation(async (source, destination) => {
       if (path.resolve(String(destination)) === path.resolve(skillDir)) {

--- a/src/skills/workshop/collection-review.test.ts
+++ b/src/skills/workshop/collection-review.test.ts
@@ -29,6 +29,11 @@ vi.mock("../../process/gateway-work-admission.js", () => ({
 }));
 
 const tempDirs = createTrackedTempDirs();
+
+async function makeWorkspaceDir(prefix: string): Promise<string> {
+  return await fs.realpath(await tempDirs.make(prefix));
+}
+
 let testState: OpenClawTestState;
 
 beforeEach(async () => {
@@ -48,7 +53,7 @@ afterEach(async () => {
 
 describe("skill collection review", () => {
   it("runs an incognito session with only collection read and reconcile", async () => {
-    const workspaceDir = await tempDirs.make("openclaw-collection-review-workspace-");
+    const workspaceDir = await makeWorkspaceDir("openclaw-collection-review-workspace-");
     await writeWorkspaceSkills(workspaceDir, [
       { name: "useful", description: "Useful reusable procedure" },
     ]);
@@ -110,7 +115,7 @@ describe("skill collection review", () => {
   });
 
   it("encodes hostile skill metadata as prompt data", async () => {
-    const workspaceDir = await tempDirs.make("openclaw-collection-review-hostile-metadata-");
+    const workspaceDir = await makeWorkspaceDir("openclaw-collection-review-hostile-metadata-");
     await writeWorkspaceSkills(workspaceDir, [
       {
         name: "hostile",
@@ -150,7 +155,7 @@ describe("skill collection review", () => {
   });
 
   it("persists the daily boundary per workspace", async () => {
-    const workspaceDir = await tempDirs.make("openclaw-collection-review-cadence-");
+    const workspaceDir = await makeWorkspaceDir("openclaw-collection-review-cadence-");
     const nowMs = Date.UTC(2026, 7, 10);
 
     expect(isSkillCollectionReviewDue(workspaceDir, nowMs, { env: testState.env })).toBe(true);
@@ -168,7 +173,7 @@ describe("skill collection review", () => {
   });
 
   it("leaves disabled and agent-filtered skills outside the editable collection", async () => {
-    const workspaceDir = await tempDirs.make("openclaw-collection-review-filtered-");
+    const workspaceDir = await makeWorkspaceDir("openclaw-collection-review-filtered-");
     await writeWorkspaceSkills(workspaceDir, [
       { name: "enabled", description: "Enabled procedure" },
       { name: "disabled", description: "Disabled procedure" },
@@ -223,7 +228,7 @@ describe("skill collection review", () => {
   });
 
   it("does not dispatch a second review when the runner fails after reconciliation", async () => {
-    const workspaceDir = await tempDirs.make("openclaw-collection-review-restart-");
+    const workspaceDir = await makeWorkspaceDir("openclaw-collection-review-restart-");
     await writeWorkspaceSkills(workspaceDir, [
       { name: "useful", description: "Useful reusable procedure" },
     ]);
@@ -256,7 +261,7 @@ describe("skill collection review", () => {
   });
 
   it("reviews a same-model shared workspace without hiding every agent's skills", async () => {
-    const workspaceDir = await tempDirs.make("openclaw-collection-review-shared-");
+    const workspaceDir = await makeWorkspaceDir("openclaw-collection-review-shared-");
     await writeWorkspaceSkills(workspaceDir, [
       { name: "alpha", description: "Alpha procedure" },
       { name: "beta", description: "Beta procedure" },
@@ -331,7 +336,7 @@ describe("skill collection review", () => {
   });
 
   it("skips same-model shared agents with different implicit auth profiles", async () => {
-    const workspaceDir = await tempDirs.make("openclaw-collection-review-shared-auth-");
+    const workspaceDir = await makeWorkspaceDir("openclaw-collection-review-shared-auth-");
     await writeWorkspaceSkills(workspaceDir, [
       { name: "alpha", description: "Alpha procedure" },
       { name: "beta", description: "Beta procedure" },
@@ -379,8 +384,7 @@ describe("skill collection review", () => {
   });
 
   it("groups symlink aliases before comparing shared-workspace identities", async () => {
-    const workspaceDir = await tempDirs.make("openclaw-collection-review-real-workspace-");
-    const canonicalWorkspaceDir = await fs.realpath(workspaceDir);
+    const workspaceDir = await makeWorkspaceDir("openclaw-collection-review-real-workspace-");
     const aliasParent = await tempDirs.make("openclaw-collection-review-alias-parent-");
     const workspaceAlias = path.join(aliasParent, "workspace-alias");
     await fs.symlink(
@@ -414,13 +418,13 @@ describe("skill collection review", () => {
       onError,
     });
 
-    expect(onError).toHaveBeenCalledWith(expect.any(Error), canonicalWorkspaceDir);
+    expect(onError).toHaveBeenCalledWith(expect.any(Error), workspaceDir);
     expect(runWithGatewayIndependentRootWorkAdmission).not.toHaveBeenCalled();
     expect(runEmbeddedAgent).not.toHaveBeenCalled();
   });
 
   it("claims a due workspace before dispatching the model", async () => {
-    const workspaceDir = await tempDirs.make("openclaw-collection-review-claim-");
+    const workspaceDir = await makeWorkspaceDir("openclaw-collection-review-claim-");
     await writeWorkspaceSkills(workspaceDir, [{ name: "useful", description: "Useful procedure" }]);
     let releaseReview: (() => void) | undefined;
     let markStarted: (() => void) | undefined;
@@ -463,9 +467,8 @@ describe("skill collection review", () => {
   });
 
   it("admits and reports each workspace independently", async () => {
-    const oversizedWorkspace = await tempDirs.make("openclaw-collection-review-failed-");
-    const canonicalOversizedWorkspace = await fs.realpath(oversizedWorkspace);
-    const healthyWorkspace = await tempDirs.make("openclaw-collection-review-healthy-");
+    const oversizedWorkspace = await makeWorkspaceDir("openclaw-collection-review-failed-");
+    const healthyWorkspace = await makeWorkspaceDir("openclaw-collection-review-healthy-");
     await writeWorkspaceSkills(oversizedWorkspace, [
       { name: "oversized", description: "Oversized", body: "x".repeat(240_001) },
     ]);
@@ -504,12 +507,12 @@ describe("skill collection review", () => {
     });
 
     expect(runWithGatewayIndependentRootWorkAdmission).toHaveBeenCalledTimes(2);
-    expect(onError).toHaveBeenCalledWith(expect.any(Error), canonicalOversizedWorkspace);
+    expect(onError).toHaveBeenCalledWith(expect.any(Error), oversizedWorkspace);
     expect(runEmbeddedAgent).toHaveBeenCalledTimes(1);
   });
 
   it("rejects an oversized collection before model dispatch", async () => {
-    const workspaceDir = await tempDirs.make("openclaw-collection-review-oversized-");
+    const workspaceDir = await makeWorkspaceDir("openclaw-collection-review-oversized-");
     await writeWorkspaceSkills(workspaceDir, [
       {
         name: "oversized",
@@ -530,7 +533,7 @@ describe("skill collection review", () => {
 
     expect(onError).toHaveBeenCalledWith(
       expect.objectContaining({ message: expect.stringContaining("review limit") }),
-      await fs.realpath(workspaceDir),
+      workspaceDir,
     );
     expect(runEmbeddedAgent).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

macOS test runs can miss `fs.cp` fault injection and compare aliased workspace paths because `mkdtemp` may return `/var` while production canonicalizes to `/private/var`.

## Why This Change Was Made

Canonicalize workspace fixture roots at creation with `fs.realpath`; keep alias-parent temp dirs and production behavior unchanged.

## User Impact

No production behavior changes; maintainers get reliable workshop collection tests on macOS.

## Evidence

- `node scripts/run-vitest.mjs src/skills/workshop/collection-reconcile.test.ts src/skills/workshop/collection-review.test.ts` — 2 files, 27 tests passed.
- `git diff --check` — passed.
- Automated autoreview — no accepted or actionable findings.

AI-assisted: Yes.
