### PR TITLE
fix(agents): retry subagent cleanup after transient failures

### DIFF
--- a/src/agents/subagents/registry/subagent-registry-lifecycle-cleanup-base.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-cleanup-base.ts
@@ -10,7 +10,11 @@ import {
   ensureDeliveryState,
   getDeliveryLastError,
 } from "./subagent-delivery-state.js";
-import { logAnnounceGiveUp, MIN_ANNOUNCE_RETRY_DELAY_MS } from "./subagent-registry-helpers.js";
+import {
+  logAnnounceGiveUp,
+  MIN_ANNOUNCE_RETRY_DELAY_MS,
+  resolveAnnounceRetryDelayMs,
+} from "./subagent-registry-helpers.js";
 import type { createSubagentRegistryLifecycleCommon } from "./subagent-registry-lifecycle-common.js";
 import type {
   SubagentRegistryLifecycleParams,
@@ -20,6 +24,8 @@ import type { createSubagentRegistryLifecycleDelivery } from "./subagent-registr
 import type { createSubagentRegistryLifecycleRequesterWake } from "./subagent-registry-lifecycle-requester-wake.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
+const MAX_DETACHED_CLEANUP_RETRIES = 3;
+
 export function createSubagentRegistryLifecycleCleanupBase(
   params: SubagentRegistryLifecycleParams,
   state: SubagentRegistryLifecycleState,
@@ -28,6 +34,9 @@ export function createSubagentRegistryLifecycleCleanupBase(
   requesterWake: ReturnType<typeof createSubagentRegistryLifecycleRequesterWake>,
 ) {
   const { scheduledResumeTimers, cleanupGenerations, terminalGenerations } = state;
+  // Exhaustion intentionally leaves the durable row unlocked; only a process
+  // restart gets a fresh retry budget after this process stops scheduling it.
+  const cleanupFailureCounts = new WeakMap<SubagentRunRecord, number>();
   const { buildSafeLifecycleErrorMeta, maskRunId, maskSessionKey, newerGenerationOwnsSession } =
     common;
   const {
@@ -36,6 +45,16 @@ export function createSubagentRegistryLifecycleCleanupBase(
     safeSetSubagentTaskDeliveryStatus,
   } = deliveryHelpers;
   const { markRequesterSettleWakePending, scheduleRequesterSettleWake } = requesterWake;
+
+  const isCleanupGenerationCurrent = (
+    runId: string,
+    entry: SubagentRunRecord,
+    generation: number,
+  ): boolean =>
+    params.runs.get(runId) === entry &&
+    entry.pauseReason !== "sessions_yield" &&
+    cleanupGenerations.get(entry) === generation &&
+    !newerGenerationOwnsSession(entry);
 
   const scheduleResumeSubagentRun = (
     runId: string,
@@ -50,11 +69,13 @@ export function createSubagentRegistryLifecycleCleanupBase(
           return;
         }
         if (cleanupGeneration !== undefined) {
-          if (!isCleanupAttemptCurrent(runId, entry, cleanupGeneration)) {
+          if (!isCleanupGenerationCurrent(runId, entry, cleanupGeneration)) {
             return;
           }
-          entry.cleanupHandled = false;
-          params.persist(runId);
+          if (entry.cleanupHandled) {
+            entry.cleanupHandled = false;
+            params.persist(runId);
+          }
         }
         params.resumedRuns.delete(runId);
         params.resumeSubagentRun(runId);
@@ -94,6 +115,7 @@ export function createSubagentRegistryLifecycleCleanupBase(
       void runWithGatewayIndependentRootWorkAdmission(async () => {
         try {
           await args.run();
+          cleanupFailureCounts.delete(args.entry);
         } catch (err) {
           defaultRuntime.log(
             `[warn] subagent cleanup finalize failed (${args.runId}): ${String(err)}`,
@@ -109,6 +131,16 @@ export function createSubagentRegistryLifecycleCleanupBase(
           current.cleanupHandled = false;
           params.resumedRuns.delete(args.runId);
           params.persist(args.runId);
+          const failureCount = (cleanupFailureCounts.get(current) ?? 0) + 1;
+          cleanupFailureCounts.set(current, failureCount);
+          if (failureCount <= MAX_DETACHED_CLEANUP_RETRIES) {
+            scheduleResumeSubagentRun(
+              args.runId,
+              current,
+              resolveAnnounceRetryDelayMs(failureCount),
+              args.cleanupGeneration,
+            );
+          }
         }
       }).catch((err: unknown) => {
         defaultRuntime.log(
@@ -193,11 +225,7 @@ export function createSubagentRegistryLifecycleCleanupBase(
     entry: SubagentRunRecord,
     generation: number,
   ): boolean =>
-    params.runs.get(runId) === entry &&
-    entry.cleanupHandled === true &&
-    entry.pauseReason !== "sessions_yield" &&
-    cleanupGenerations.get(entry) === generation &&
-    !newerGenerationOwnsSession(entry);
+    entry.cleanupHandled === true && isCleanupGenerationCurrent(runId, entry, generation);
 
   const retireSupersededCleanupIfNeeded = async (
     runId: string,

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -976,6 +976,110 @@ describe("subagent registry lifecycle hardening", () => {
     }
   });
 
+  it("retries a detached cleanup failure and completes on the next attempt", async () => {
+    vi.useFakeTimers();
+    const entry = createRunEntry({
+      endedAt: 4_000,
+      expectsCompletionMessage: false,
+      retainAttachmentsOnKeep: false,
+    });
+    helperMocks.safeRemoveAttachmentsDir.mockRejectedValueOnce(new Error("cleanup failed"));
+    const resumeSubagentRun = vi.fn((runId: string) => {
+      controller.startSubagentAnnounceCleanupFlow(runId, entry);
+    });
+    const controller = createLifecycleController({ entry, resumeSubagentRun });
+
+    try {
+      expect(controller.startSubagentAnnounceCleanupFlow(entry.runId, entry)).toBe(true);
+      await waitForLifecycleState(() => expect(entry.cleanupHandled).toBe(false));
+      expect(entry.cleanupCompletedAt).toBeUndefined();
+      expect(vi.getTimerCount()).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(resumeSubagentRun).toHaveBeenCalledExactlyOnceWith(entry.runId);
+      await waitForLifecycleState(() => expect(entry.cleanupCompletedAt).toBeTypeOf("number"));
+    } finally {
+      helperMocks.safeRemoveAttachmentsDir.mockReset().mockResolvedValue(undefined);
+      controller.clearScheduledResumeTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("drops a failed-cleanup retry after a newer cleanup generation starts", async () => {
+    vi.useFakeTimers();
+    const entry = createRunEntry({
+      endedAt: 4_000,
+      expectsCompletionMessage: false,
+      retainAttachmentsOnKeep: false,
+    });
+    let releaseNewCleanup: (() => void) | undefined;
+    helperMocks.safeRemoveAttachmentsDir
+      .mockRejectedValueOnce(new Error("cleanup failed"))
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseNewCleanup = resolve;
+          }),
+      );
+    const resumeSubagentRun = vi.fn();
+    const controller = createLifecycleController({ entry, resumeSubagentRun });
+
+    try {
+      expect(controller.startSubagentAnnounceCleanupFlow(entry.runId, entry)).toBe(true);
+      await waitForLifecycleState(() => expect(entry.cleanupHandled).toBe(false));
+      expect(vi.getTimerCount()).toBe(1);
+
+      expect(controller.startSubagentAnnounceCleanupFlow(entry.runId, entry)).toBe(true);
+      await waitForLifecycleState(() => expect(releaseNewCleanup).toBeTypeOf("function"));
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(resumeSubagentRun).not.toHaveBeenCalled();
+      releaseNewCleanup?.();
+      await waitForLifecycleState(() => expect(entry.cleanupCompletedAt).toBeTypeOf("number"));
+    } finally {
+      releaseNewCleanup?.();
+      controller.clearScheduledResumeTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops retrying detached cleanup failures and leaves the run durably unlocked", async () => {
+    vi.useFakeTimers();
+    const entry = createRunEntry({
+      endedAt: 4_000,
+      expectsCompletionMessage: false,
+      retainAttachmentsOnKeep: false,
+    });
+    const persist = vi.fn();
+    helperMocks.safeRemoveAttachmentsDir.mockRejectedValue(new Error("cleanup failed"));
+    const resumeSubagentRun = vi.fn((runId: string) => {
+      controller.startSubagentAnnounceCleanupFlow(runId, entry);
+    });
+    const controller = createLifecycleController({ entry, persist, resumeSubagentRun });
+
+    try {
+      expect(controller.startSubagentAnnounceCleanupFlow(entry.runId, entry)).toBe(true);
+      await waitForLifecycleState(() => expect(entry.cleanupHandled).toBe(false));
+      expect(vi.getTimerCount()).toBe(1);
+
+      for (let attempts = 0; attempts < 10 && vi.getTimerCount() > 0; attempts += 1) {
+        await vi.runOnlyPendingTimersAsync();
+      }
+
+      expect(helperMocks.safeRemoveAttachmentsDir.mock.calls.length).toBeGreaterThan(1);
+      expect(helperMocks.safeRemoveAttachmentsDir.mock.calls.length).toBeLessThan(10);
+      expect(entry.cleanupHandled).toBe(false);
+      expect(entry.cleanupCompletedAt).toBeUndefined();
+      expect(persist).toHaveBeenLastCalledWith(entry.runId);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      helperMocks.safeRemoveAttachmentsDir.mockReset().mockResolvedValue(undefined);
+      controller.clearScheduledResumeTimers();
+      vi.useRealTimers();
+    }
+  });
+
   it("does not reject completion when task finalization throws", async () => {
     const persist = vi.fn();
     const persistOrThrow = vi.fn();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a transient exception during detached subagent cleanup could leave a completed run durably unlocked but never retried. The run then remained stranded until restart or unrelated recovery work happened to revisit it.

## Why This Change Was Made

The detached cleanup failure path now owns a bounded retry through the existing resume timer and announce backoff policy. Each retry is fenced to the same registry row and cleanup generation; after three scheduled retries, the row remains durably unlocked for restart recovery rather than creating an infinite timer chain.

This is AI-assisted work reviewed with the repository autoreview workflow.

F2 is intentionally deferred to the lifecycle-fold PR, where atomic terminal discard will become a first-class lifecycle operation:

> Routing dismissal through the existing finalizer without that operation would split lifecycle persistence from correlated task settlement, creating a crash window where cleanup is finalized while the task remains blocked and can no longer be dismissed again.

## User Impact

Completed subagent runs recover automatically from transient cleanup failures without waiting for an opportunistic sweep or process restart. Stale timers cannot interfere with a newer cleanup generation, and persistent failures stop retrying in-process after a bounded budget.

## Evidence

Verification finding: **F1 — cleanup exception strands the run**.

- Pre-fix regression run: the three new lifecycle cases failed because the cleanup exception scheduled no timer.
- `node scripts/run-vitest.mjs` over lifecycle cleanup, registry/suspended-delivery, sweeper recovery, and completion-delivery storage: **326 passed**.
- Post-rebase rerun on the final patch: **326 passed**.
- `pnpm check:import-cycles`: **0 runtime value cycles**.
- `pnpm build`: **passed**; all build phases completed in 11m39s.
- Targeted formatting and oxlint: **passed**.
- Autoreview: **clean; no accepted/actionable findings**.

Production LOC: **+37/-9 (net +28)**. Tests: **+104/-0**. The production growth is the process-local bounded retry budget and the generation-only timer fence required after the row has been durably unlocked.

Remote proof note: Blacksmith Testbox was unavailable because its CLI is absent on this host. Direct AWS Crabbox lease `cbx_b972c3d22b0d` could not frozen-install current `origin/main` because `pnpm-lock.yaml` lacks `@oxc-parser/binding-android-arm-eabi@0.128.0`; the lease was released. The requested build and import-cycle gates were therefore run against the ready local dependency tree, with exact-head CI left to provide Linux confirmation.
