### PR TITLE
improve: speed up fresh changed checks

### DIFF
--- a/.github/workflows/ci-check-testbox.yml
+++ b/.github/workflows/ci-check-testbox.yml
@@ -45,7 +45,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          fetch-depth: ${{ github.event_name == 'pull_request' && '2' || '0' }}
+          # Dispatch hydrates the pinned workflow ref; changed-gate sync later
+          # reconstructs its exact base and final tree. PR validation keeps both commits.
+          fetch-depth: ${{ github.event_name == 'pull_request' && '2' || '1' }}
           persist-credentials: false
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
@@ -65,7 +67,7 @@ jobs:
       - name: Prepare Testbox shell
         uses: ./.github/actions/prepare-testbox-shell
         with:
-          base-ref: ${{ github.event.pull_request.base.sha || 'refs/remotes/origin/main' }}
+          base-ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || 'HEAD' }}
 
       - name: Hydrate Testbox provider env helper
         shell: bash

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -705,6 +705,8 @@ Docker, package lanes, E2E, live proof, and CI parity. Trusted maintainer heavy
 proof defaults to `blacksmith-testbox`, and `.crabbox.yaml` now defaults to it. Its configured
 workflow hydrates provider and agent credentials, so untrusted contributor or
 fork code must use secretless fork CI or sanitized direct AWS Crabbox instead.
+The check workflow hydrates its pinned dispatch commit with a depth-1 checkout;
+the changed gate later reconstructs the exact merge base and synced final tree.
 Sanitized AWS runs set `CRABBOX_ENV_ALLOW=CI`, pass
 `--no-hydrate`, and use a fresh temporary remote `HOME`; this prevents the repo
 `OPENCLAW_*` allowlist and existing auth profiles from reaching untrusted code.

--- a/scripts/run-oxlint-shards.mts
+++ b/scripts/run-oxlint-shards.mts
@@ -10,6 +10,7 @@ import {
   resolveRepoToolBinPath,
   shouldAcquireLocalHeavyCheckLockForOxlint,
 } from "./lib/local-heavy-check-runtime.mts";
+import { shouldPrepareExtensionPackageBoundaryArtifacts } from "./run-oxlint.mts";
 
 const DEFAULT_WINDOWS_EXTENSION_CHUNK_SIZE = 8;
 const DEFAULT_SHARD_HEARTBEAT_MS = 30_000;
@@ -283,23 +284,28 @@ export async function main(
     const selectedShards = filterOxlintShards(shards, shardArgs.only);
 
     ensureRepoToolNodeModulesLink(resolveRepoToolBinPath("oxlint"));
-    const prepareResult = spawnSync(
-      process.execPath,
-      [
-        "--import",
-        "tsx",
-        path.resolve("scripts", "prepare-extension-package-boundary-artifacts.mts"),
-      ],
-      {
-        stdio: "inherit",
-        env,
-      },
-    );
+    const prepareResult = shouldPrepareExtensionPackageBoundaryArtifactsForShards(
+      selectedShards,
+      shardArgs.oxlintArgs,
+    )
+      ? spawnSync(
+          process.execPath,
+          [
+            "--import",
+            "tsx",
+            path.resolve("scripts", "prepare-extension-package-boundary-artifacts.mts"),
+          ],
+          {
+            stdio: "inherit",
+            env,
+          },
+        )
+      : undefined;
 
-    if (prepareResult.error) {
+    if (prepareResult?.error) {
       throw prepareResult.error;
     }
-    if ((prepareResult.status ?? 1) !== 0) {
+    if (prepareResult && (prepareResult.status ?? 1) !== 0) {
       process.exitCode = prepareResult.status ?? 1;
     } else {
       const shardConcurrency = resolveOxlintShardConcurrency({
@@ -395,6 +401,15 @@ export function filterOxlintShards<T extends { name: string }>(shards: T[], only
 
   return shards.filter((shard) =>
     selectors.some((selector) => matchesShardSelector(shard, selector)),
+  );
+}
+
+export function shouldPrepareExtensionPackageBoundaryArtifactsForShards(
+  shards: readonly OxlintShard[],
+  extraArgs: readonly string[] = [],
+) {
+  return shards.some((shard) =>
+    shouldPrepareExtensionPackageBoundaryArtifacts([...shard.args, ...extraArgs]),
   );
 }
 

--- a/scripts/run-oxlint.mts
+++ b/scripts/run-oxlint.mts
@@ -43,13 +43,33 @@ const OXLINT_VALUE_FLAGS = new Set([
   "--tsconfig",
   "--warn",
 ]);
+const OXLINT_BOUNDARY_FREE_TS_CONFIGS = new Set([
+  "config/tsconfig/oxlint.core.json",
+  "config/tsconfig/oxlint.scripts.json",
+]);
 const OPENCLAW_FOCUSED_CONFIG_FLAG = "--openclaw-focused-config";
 
 /**
  * Returns whether oxlint args need package-boundary declaration artifacts first.
  */
 export function shouldPrepareExtensionPackageBoundaryArtifacts(args: string[]) {
-  return !args.some((arg) => OXLINT_PREPARE_SKIP_FLAGS.has(arg));
+  if (args.some((arg) => OXLINT_PREPARE_SKIP_FLAGS.has(arg))) {
+    return false;
+  }
+
+  const tsconfigs = args.flatMap((arg, index) => {
+    if (arg === "--tsconfig") {
+      const value = args[index + 1];
+      return value === undefined ? [] : [value];
+    }
+    return arg.startsWith("--tsconfig=") ? [arg.slice("--tsconfig=".length)] : [];
+  });
+  // Core and script lint resolve workspace sources through the root tsconfig;
+  // generated plugin package declarations are only an extension-lint input.
+  return (
+    tsconfigs.length === 0 ||
+    tsconfigs.some((tsconfig) => !OXLINT_BOUNDARY_FREE_TS_CONFIGS.has(tsconfig))
+  );
 }
 
 /**

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4320,28 +4320,48 @@ NODE
     }
   });
 
-  it("prepares all Testbox checkouts from one maintained owner", () => {
+  it("prepares Testbox checkouts with one maintained owner and scoped history", () => {
     const workflowPaths = [
-      ".github/workflows/ci-check-testbox.yml",
-      ".github/workflows/ci-check-arm-testbox.yml",
-      ".github/workflows/ci-build-artifacts-testbox.yml",
-    ];
+      [
+        ".github/workflows/ci-check-testbox.yml",
+        "1",
+        "${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || 'HEAD' }}",
+      ],
+      [
+        ".github/workflows/ci-check-arm-testbox.yml",
+        "0",
+        "${{ github.event.pull_request.base.sha || 'refs/remotes/origin/main' }}",
+      ],
+      [
+        ".github/workflows/ci-build-artifacts-testbox.yml",
+        "0",
+        "${{ github.event.pull_request.base.sha || 'refs/remotes/origin/main' }}",
+      ],
+    ] as const;
 
-    for (const workflowPath of workflowPaths) {
+    for (const [workflowPath, dispatchFetchDepth, baseRef] of workflowPaths) {
       const workflow = parse(readFileSync(workflowPath, "utf8"));
       const job = Object.values(workflow.jobs)[0] as { steps: WorkflowStep[] };
       const checkoutStep = job.steps.find((step) => step.name === "Checkout");
       const prepareStep = job.steps.find((step) => step.name === "Prepare Testbox shell");
 
       expect(checkoutStep?.uses, workflowPath).toBe(CHECKOUT_V6);
-      expect(checkoutStep?.with, workflowPath).toEqual({
-        "fetch-depth": "${{ github.event_name == 'pull_request' && '2' || '0' }}",
-        "persist-credentials": false,
-      });
+      expect(checkoutStep?.with?.["persist-credentials"], workflowPath).toBe(false);
+      for (const [eventName, expectedDepth] of [
+        ["pull_request", "2"],
+        ["workflow_dispatch", dispatchFetchDepth],
+      ] as const) {
+        expect(
+          evaluateWorkflowExpression(checkoutStep?.with?.["fetch-depth"], {
+            eventName,
+            repository: "openclaw/openclaw",
+            runAttempt: 1,
+          }),
+          `${workflowPath} ${eventName}`,
+        ).toBe(expectedDepth);
+      }
       expect(prepareStep?.uses, workflowPath).toBe("./.github/actions/prepare-testbox-shell");
-      expect(prepareStep?.with?.["base-ref"], workflowPath).toBe(
-        "${{ github.event.pull_request.base.sha || 'refs/remotes/origin/main' }}",
-      );
+      expect(prepareStep?.with?.["base-ref"], workflowPath).toBe(baseRef);
       const ensureBaseStep = job.steps.find(
         (step: WorkflowStep) => step.name === "Ensure Testbox base commit",
       );

--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -16,6 +16,7 @@ import {
   resolveOxlintShardConcurrency,
   resolveWindowsExtensionChunkSize,
   runShard,
+  shouldPrepareExtensionPackageBoundaryArtifactsForShards,
   shouldRunOxlintShardsSerial,
 } from "../../scripts/run-oxlint-shards.mts";
 import {
@@ -192,6 +193,27 @@ describe("run-oxlint", () => {
     expect(shouldPrepareExtensionPackageBoundaryArtifacts([])).toBe(true);
     expect(shouldPrepareExtensionPackageBoundaryArtifacts(["src/index.ts"])).toBe(true);
     expect(shouldPrepareExtensionPackageBoundaryArtifacts(["--type-aware"])).toBe(true);
+    expect(
+      shouldPrepareExtensionPackageBoundaryArtifacts([
+        "--tsconfig",
+        "config/tsconfig/oxlint.extensions.json",
+        "extensions/telegram/src/index.ts",
+      ]),
+    ).toBe(true);
+    expect(
+      shouldPrepareExtensionPackageBoundaryArtifacts([
+        "--tsconfig=config/tsconfig/oxlint.core.json",
+        "--tsconfig=config/tsconfig/oxlint.extensions.json",
+      ]),
+    ).toBe(true);
+  });
+
+  it.each([
+    ["--tsconfig", "config/tsconfig/oxlint.core.json", "src/index.ts"],
+    ["--tsconfig=config/tsconfig/oxlint.core.json", "src/index.ts"],
+    ["--tsconfig", "config/tsconfig/oxlint.scripts.json", "scripts/check-changed.mts"],
+  ])("skips extension artifacts for an exact source-backed config: %s", (...args) => {
+    expect(shouldPrepareExtensionPackageBoundaryArtifacts(args)).toBe(false);
   });
 
   it("skips artifact preparation for metadata-only oxlint commands", () => {
@@ -199,6 +221,15 @@ describe("run-oxlint", () => {
     expect(shouldPrepareExtensionPackageBoundaryArtifacts(["--version"])).toBe(false);
     expect(shouldPrepareExtensionPackageBoundaryArtifacts(["--print-config"])).toBe(false);
     expect(shouldPrepareExtensionPackageBoundaryArtifacts(["--rules"])).toBe(false);
+  });
+
+  it("prepares shard artifacts only when a selected config consumes them", () => {
+    const core = oxlintShard("core", "core", "src");
+    const scripts = oxlintShard("scripts", "scripts", "scripts");
+    const extensions = oxlintShard("extensions", "extensions", "extensions");
+
+    expect(shouldPrepareExtensionPackageBoundaryArtifactsForShards([core, scripts])).toBe(false);
+    expect(shouldPrepareExtensionPackageBoundaryArtifactsForShards([core, extensions])).toBe(true);
   });
 
   it("does not run package-boundary artifact prep twice in pnpm check", () => {


### PR DESCRIPTION
## What Problem This Solves

Fresh `check:changed` runs through Blacksmith Testbox spend substantial time before useful lint work: the dispatch workflow fetches the repository's full history, and exact core/scripts oxlint configs build extension package-boundary declarations they do not consume.

On the six-run baseline, median end-to-end time for one representative core path was 11m37s. Median checkout was 113.5s, and median targeted core lint was 144.8s even though oxlint itself took about 12s.

## Why This Change Was Made

This keeps the existing gate plan and serial failure behavior intact while removing two unrelated costs:

- workflow dispatch uses the pinned commit with a depth-1 checkout; PR validation remains depth 2, and the changed-gate bootstrap still reconstructs the exact merge base and synced final tree;
- core/scripts-only oxlint invocations skip extension package-boundary preparation, while missing, unknown, mixed, and extension configs remain conservative and still prepare.

No gate is removed or narrowed. There is no new scheduler, lease reuse, provider routing, hardware sizing, environment/config surface, or written-policy change.

## User Impact

Maintainers get materially faster fresh `check:changed` feedback on the existing Testbox workflow without changing what is checked. In the matched six-run sample, median end-to-end time fell from 11m37s to 6m30s (44.0%), and all six post-patch runs completed under 9 minutes.

## Evidence

### Benchmark design

- Baseline: `750d0dcd9e7838bf65105902806f6a22f7c1c5f8`
- Performance head: `fe1dc26bb0e3df8bc764509f6f73c331127e1999`
- Final head: `fb9b1df17101f5bcb56282fcbdfe8e4d852f85dc`
- Command: `pnpm check:changed --timed -- src/agents/agent-command.ts`
- Classification: `lanes=core, coreTests`, identical 27-command serial plan
- Six fresh one-shot Testboxes before and six after; strictly sequential; no lease reuse or overlap
- Provider/workflow/environment and Crabbox 0.40.0 held constant
- P90 uses nearest-rank; with n=6 it is the sample maximum

The final-head change from the performance head only makes an already-executed `--tsconfig` value check explicit for tsgo narrowing; it does not change runtime branching. The complete changed gate passed on the final head below.

| Metric | Baseline median | Post median | Change |
| --- | ---: | ---: | ---: |
| Wrapper total | 696,995 ms | 390,007 ms | -44.0% |
| Internal 27-check sum | 472,492 ms | 319,088 ms | -32.5% |
| Actions checkout | 113.5s | 19s | -83.3% |
| Targeted core lint | 144.845s | 11.845s | -91.8% |

| Metric | Baseline P90/max | Post P90/max | Change |
| --- | ---: | ---: | ---: |
| Wrapper total | 843,063 ms | 526,662 ms | -37.5% |
| Internal 27-check sum | 504,527 ms | 411,513 ms | -18.4% |
| Actions checkout | 117s | 21s | -82.1% |
| Targeted core lint | 155.770s | 12.740s | -91.8% |

Queue time improved in the post sample, but it is external provider load and is not credited to this patch. Post targeted sync was larger because it transported the six-file patch; it is reported, not hidden.

### Raw benchmark runs

Baseline:

| Row | Total | Lint | Run |
| --- | ---: | ---: | --- |
| B1 | 646,488 ms | 144.72s | [31443916658](https://github.com/openclaw/openclaw/actions/runs/31443916658) |
| B2 | 691,772 ms | 144.97s | [31445423721](https://github.com/openclaw/openclaw/actions/runs/31445423721) |
| B3 | 647,672 ms | 155.77s | [31446114529](https://github.com/openclaw/openclaw/actions/runs/31446114529) |
| B4 | 755,164 ms | 151.40s | [31446759223](https://github.com/openclaw/openclaw/actions/runs/31446759223) |
| B5 | 843,063 ms | 135.52s | [31447466479](https://github.com/openclaw/openclaw/actions/runs/31447466479) |
| B6 | 702,218 ms | 144.12s | [31448254153](https://github.com/openclaw/openclaw/actions/runs/31448254153) |

Post-patch:

| Row | Total | Lint | Run |
| --- | ---: | ---: | --- |
| P1 | 526,662 ms | 11.83s | [31449135080](https://github.com/openclaw/openclaw/actions/runs/31449135080) |
| P2 | 488,596 ms | 12.60s | [31449609233](https://github.com/openclaw/openclaw/actions/runs/31449609233) |
| P3 | 380,093 ms | 12.74s | [31450066983](https://github.com/openclaw/openclaw/actions/runs/31450066983) |
| P4 | 399,700 ms | 10.46s | [31450417467](https://github.com/openclaw/openclaw/actions/runs/31450417467) |
| P5 | 355,761 ms | 11.86s | [31450777490](https://github.com/openclaw/openclaw/actions/runs/31450777490) |
| P6 | 380,314 ms | 11.26s | [31451113650](https://github.com/openclaw/openclaw/actions/runs/31451113650) |

Two untimed baseline pilots and setup/cap cancellations were excluded before statistics and are intentionally disclosed: [31442101853](https://github.com/openclaw/openclaw/actions/runs/31442101853), [31442872088](https://github.com/openclaw/openclaw/actions/runs/31442872088), [31448893917](https://github.com/openclaw/openclaw/actions/runs/31448893917), and [31449061435](https://github.com/openclaw/openclaw/actions/runs/31449061435). No failed gate was excluded from either six-run sample.

### Correctness and safety proof

- Final exact-head changed gate passed on a fresh Testbox: [31451728492](https://github.com/openclaw/openclaw/actions/runs/31451728492) (`tsgo:scripts`, root-test tsgo, complete scripts lint).
- Cold artifact acceptance: complete core and scripts lint passed while both extension boundary directories remained absent; a separate extension lint regenerated both required boundary stamps and passed: [31444790803](https://github.com/openclaw/openclaw/actions/runs/31444790803), [31445143933](https://github.com/openclaw/openclaw/actions/runs/31445143933).
- Focused tests: 163 passed / 2 skipped across `test/scripts/run-oxlint.test.ts` and `test/scripts/ci-workflow-guards.test.ts`; after the final narrowing edit, 49/49 oxlint tests passed again.
- Workflow validation: `scripts/check-workflows.mts`, `actionlint`, docs listing, formatting, and `git diff --check` passed.
- Pinned `actions/checkout` source was inspected: depth 1 fetches the selected ref/commit rather than full history. The shared prepare action receives `HEAD`, avoiding dependence on a remote-tracking ref.
- Structured autoreview on the final head: clean, no accepted/actionable findings.

One acceptance attempt used the stale path `extensions/telegram/src/index.ts` and correctly failed with no files found; it is not represented as product failure or proof. The rerun used tracked `extensions/telegram/index.ts` and passed. One pre-final changed gate caught the tsgo narrowing error described above; the same complete gate passed after correction.

Production/tooling delta: +50/-15 (net +35). Workflow/docs: +6/-2 (net +4). Tests: +64/-13 (net +51).
