### PR TITLE
feat(feishu): add delete message action

### DIFF
--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -37,7 +37,6 @@ vi.mock("./client.js", () => ({
 
 vi.mock("./send.js", () => ({
   deleteMessageFeishu: vi.fn(),
-  getBotOpenIdFeishu: vi.fn(),
   sendCardFeishu: sendCardFeishuMock,
   sendMessageFeishu: sendMessageFeishuMock,
 }));

--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -36,6 +36,8 @@ vi.mock("./client.js", () => ({
 }));
 
 vi.mock("./send.js", () => ({
+  deleteMessageFeishu: vi.fn(),
+  getBotOpenIdFeishu: vi.fn(),
   sendCardFeishu: sendCardFeishuMock,
   sendMessageFeishu: sendMessageFeishuMock,
 }));

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -427,7 +427,6 @@ vi.mock("./reasoning-preview.js", () => ({
 
 vi.mock("./send.js", () => ({
   deleteMessageFeishu: vi.fn(),
-  getBotOpenIdFeishu: vi.fn(),
   sendMessageFeishu: mockSendMessageFeishu,
   getMessageFeishu: mockGetMessageFeishu,
   listFeishuThreadMessages: mockListFeishuThreadMessages,

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -426,6 +426,8 @@ vi.mock("./reasoning-preview.js", () => ({
 }));
 
 vi.mock("./send.js", () => ({
+  deleteMessageFeishu: vi.fn(),
+  getBotOpenIdFeishu: vi.fn(),
   sendMessageFeishu: mockSendMessageFeishu,
   getMessageFeishu: mockGetMessageFeishu,
   listFeishuThreadMessages: mockListFeishuThreadMessages,

--- a/extensions/feishu/src/card-ux-launcher.test.ts
+++ b/extensions/feishu/src/card-ux-launcher.test.ts
@@ -12,7 +12,6 @@ const sendCardFeishuMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./send.js", () => ({
   deleteMessageFeishu: vi.fn(),
-  getBotOpenIdFeishu: vi.fn(),
   sendCardFeishu: sendCardFeishuMock,
 }));
 

--- a/extensions/feishu/src/card-ux-launcher.test.ts
+++ b/extensions/feishu/src/card-ux-launcher.test.ts
@@ -11,6 +11,8 @@ import { maybeHandleFeishuQuickActionMenu } from "./card-ux-launcher.js";
 const sendCardFeishuMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./send.js", () => ({
+  deleteMessageFeishu: vi.fn(),
+  getBotOpenIdFeishu: vi.fn(),
   sendCardFeishu: sendCardFeishuMock,
 }));
 

--- a/extensions/feishu/src/channel.runtime.ts
+++ b/extensions/feishu/src/channel.runtime.ts
@@ -26,7 +26,6 @@ import {
 import {
   deleteMessageFeishu as deleteMessageFeishuImpl,
   editMessageFeishu as editMessageFeishuImpl,
-  getBotOpenIdFeishu as getBotOpenIdFeishuImpl,
   getMessageFeishu as getMessageFeishuImpl,
   sendCardFeishu as sendCardFeishuImpl,
   sendMessageFeishu as sendMessageFeishuImpl,
@@ -50,7 +49,6 @@ export const feishuChannelRuntime = {
   getFeishuMemberInfo: getFeishuMemberInfoImpl,
   deleteMessageFeishu: deleteMessageFeishuImpl,
   editMessageFeishu: editMessageFeishuImpl,
-  getBotOpenIdFeishu: getBotOpenIdFeishuImpl,
   getMessageFeishu: getMessageFeishuImpl,
   sendCardFeishu: sendCardFeishuImpl,
   sendMessageFeishu: sendMessageFeishuImpl,

--- a/extensions/feishu/src/channel.runtime.ts
+++ b/extensions/feishu/src/channel.runtime.ts
@@ -24,7 +24,9 @@ import {
   removeReactionFeishu as removeReactionFeishuImpl,
 } from "./reactions.js";
 import {
+  deleteMessageFeishu as deleteMessageFeishuImpl,
   editMessageFeishu as editMessageFeishuImpl,
+  getBotOpenIdFeishu as getBotOpenIdFeishuImpl,
   getMessageFeishu as getMessageFeishuImpl,
   sendCardFeishu as sendCardFeishuImpl,
   sendMessageFeishu as sendMessageFeishuImpl,
@@ -46,7 +48,9 @@ export const feishuChannelRuntime = {
   getChatInfo: getChatInfoImpl,
   getChatMembers: getChatMembersImpl,
   getFeishuMemberInfo: getFeishuMemberInfoImpl,
+  deleteMessageFeishu: deleteMessageFeishuImpl,
   editMessageFeishu: editMessageFeishuImpl,
+  getBotOpenIdFeishu: getBotOpenIdFeishuImpl,
   getMessageFeishu: getMessageFeishuImpl,
   sendCardFeishu: sendCardFeishuImpl,
   sendMessageFeishu: sendMessageFeishuImpl,

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -2992,6 +2992,15 @@ describe("feishuPlugin actions", () => {
     expect(details.messageId).toBe("om_pin");
   });
 
+  it("advertises delete with its bot-owned limit in the message tool hint", () => {
+    const hints = feishuPlugin.agentPrompt
+      ?.messageToolHints?.({ cfg, accountId: undefined })
+      ?.join("\n");
+    expect(hints).toContain("`delete`");
+    expect(hints).toContain("this bot sent");
+    expect(getDescribedActions(cfg)).toContain("delete");
+  });
+
   it("deletes messages", async () => {
     getMessageFeishuMock.mockResolvedValueOnce({
       messageId: "om_delete",

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -24,7 +24,6 @@ const sendStickerFeishuMock = vi.hoisted(() => vi.fn());
 const getMessageFeishuMock = vi.hoisted(() => vi.fn());
 const editMessageFeishuMock = vi.hoisted(() => vi.fn());
 const deleteMessageFeishuMock = vi.hoisted(() => vi.fn());
-const getBotOpenIdFeishuMock = vi.hoisted(() => vi.fn());
 const createPinFeishuMock = vi.hoisted(() => vi.fn());
 const listPinsFeishuMock = vi.hoisted(() => vi.fn());
 const removePinFeishuMock = vi.hoisted(() => vi.fn());
@@ -68,7 +67,6 @@ vi.mock("./channel.runtime.js", () => ({
     addReactionFeishu: addReactionFeishuMock,
     createPinFeishu: createPinFeishuMock,
     deleteMessageFeishu: deleteMessageFeishuMock,
-    getBotOpenIdFeishu: getBotOpenIdFeishuMock,
     editMessageFeishu: editMessageFeishuMock,
     getChatInfo: getChatInfoMock,
     getChatMembers: getChatMembersMock,
@@ -3001,10 +2999,10 @@ describe("feishuPlugin actions", () => {
       chatType: "group",
       content: "delete me",
       contentType: "text",
-      senderOpenId: "ou_bot123",
+      senderId: "cli_bot",
       senderType: "app",
     });
-    getBotOpenIdFeishuMock.mockResolvedValueOnce("ou_bot123");
+    probeFeishuMock.mockResolvedValueOnce({ ok: true, appId: "cli_bot" });
     deleteMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_delete" });
 
     const result = await feishuPlugin.actions?.handleAction?.({
@@ -3055,10 +3053,10 @@ describe("feishuPlugin actions", () => {
       chatType: "group",
       content: "other app msg",
       contentType: "text",
-      senderOpenId: "ou_other_app",
+      senderId: "cli_other_app",
       senderType: "app",
     });
-    getBotOpenIdFeishuMock.mockResolvedValueOnce("ou_bot123");
+    probeFeishuMock.mockResolvedValueOnce({ ok: true, appId: "cli_bot" });
 
     await expect(
       feishuPlugin.actions?.handleAction?.({

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -23,6 +23,8 @@ const sendMessageFeishuMock = vi.hoisted(() => vi.fn());
 const sendStickerFeishuMock = vi.hoisted(() => vi.fn());
 const getMessageFeishuMock = vi.hoisted(() => vi.fn());
 const editMessageFeishuMock = vi.hoisted(() => vi.fn());
+const deleteMessageFeishuMock = vi.hoisted(() => vi.fn());
+const getBotOpenIdFeishuMock = vi.hoisted(() => vi.fn());
 const createPinFeishuMock = vi.hoisted(() => vi.fn());
 const listPinsFeishuMock = vi.hoisted(() => vi.fn());
 const removePinFeishuMock = vi.hoisted(() => vi.fn());
@@ -65,6 +67,8 @@ vi.mock("./channel.runtime.js", () => ({
   feishuChannelRuntime: {
     addReactionFeishu: addReactionFeishuMock,
     createPinFeishu: createPinFeishuMock,
+    deleteMessageFeishu: deleteMessageFeishuMock,
+    getBotOpenIdFeishu: getBotOpenIdFeishuMock,
     editMessageFeishu: editMessageFeishuMock,
     getChatInfo: getChatInfoMock,
     getChatMembers: getChatMembersMock,
@@ -317,6 +321,7 @@ describe("feishuPlugin actions", () => {
       "send",
       "read",
       "edit",
+      "delete",
       "thread-reply",
       "pin",
       "list-pins",
@@ -388,7 +393,7 @@ describe("feishuPlugin actions", () => {
   );
 
   it("declares native chat IDs as delivery targets for guarded message mutations", () => {
-    for (const action of ["edit", "pin", "unpin"] as const) {
+    for (const action of ["edit", "delete", "pin", "unpin"] as const) {
       expect(feishuPlugin.actions?.messageActionTargetAliases?.[action]).toEqual({
         aliases: ["messageId", "chatId", "chat_id", "channel_id"],
         deliveryTargetAliases: ["chatId", "chat_id", "channel_id"],
@@ -414,6 +419,7 @@ describe("feishuPlugin actions", () => {
       "send",
       "read",
       "edit",
+      "delete",
       "thread-reply",
       "pin",
       "list-pins",
@@ -452,6 +458,7 @@ describe("feishuPlugin actions", () => {
       "send",
       "read",
       "edit",
+      "delete",
       "thread-reply",
       "pin",
       "list-pins",
@@ -464,6 +471,7 @@ describe("feishuPlugin actions", () => {
       "send",
       "read",
       "edit",
+      "delete",
       "thread-reply",
       "pin",
       "list-pins",
@@ -2986,6 +2994,96 @@ describe("feishuPlugin actions", () => {
     expect(details.messageId).toBe("om_pin");
   });
 
+  it("deletes messages", async () => {
+    getMessageFeishuMock.mockResolvedValueOnce({
+      messageId: "om_delete",
+      chatId: "oc_group_1",
+      chatType: "group",
+      content: "delete me",
+      contentType: "text",
+      senderOpenId: "ou_bot123",
+      senderType: "app",
+    });
+    getBotOpenIdFeishuMock.mockResolvedValueOnce("ou_bot123");
+    deleteMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_delete" });
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "delete",
+      params: { messageId: "om_delete" },
+      cfg,
+      accountId: undefined,
+      conversationReadOrigin: "direct-operator",
+    } as never);
+
+    expect(deleteMessageFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      messageId: "om_delete",
+      accountId: undefined,
+    });
+    const delDetails = resultDetails(result);
+    expect(delDetails.ok).toBe(true);
+    expect(delDetails.messageId).toBe("om_delete");
+  });
+
+  it("rejects delete of user messages", async () => {
+    getMessageFeishuMock.mockResolvedValueOnce({
+      messageId: "om_user_msg",
+      chatId: "oc_group_1",
+      chatType: "group",
+      content: "not mine",
+      contentType: "text",
+      senderType: "user",
+    });
+
+    await expect(
+      feishuPlugin.actions?.handleAction?.({
+        action: "delete",
+        params: { messageId: "om_user_msg" },
+        cfg,
+        accountId: undefined,
+        conversationReadOrigin: "direct-operator",
+      } as never),
+    ).rejects.toThrow("Feishu delete only allows messages sent by the bot.");
+
+    expect(deleteMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects delete of messages from a different app", async () => {
+    getMessageFeishuMock.mockResolvedValueOnce({
+      messageId: "om_other_app",
+      chatId: "oc_group_1",
+      chatType: "group",
+      content: "other app msg",
+      contentType: "text",
+      senderOpenId: "ou_other_app",
+      senderType: "app",
+    });
+    getBotOpenIdFeishuMock.mockResolvedValueOnce("ou_bot123");
+
+    await expect(
+      feishuPlugin.actions?.handleAction?.({
+        action: "delete",
+        params: { messageId: "om_other_app" },
+        cfg,
+        accountId: undefined,
+        conversationReadOrigin: "direct-operator",
+      } as never),
+    ).rejects.toThrow("Feishu delete only allows messages sent by the bot.");
+
+    expect(deleteMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("requires messageId for delete", async () => {
+    await expect(
+      feishuPlugin.actions?.handleAction?.({
+        action: "delete",
+        params: {},
+        cfg,
+        accountId: undefined,
+      } as never),
+    ).rejects.toThrow("Feishu delete requires messageId.");
+  });
+
   it("fetches channel info", async () => {
     getChatInfoMock.mockResolvedValueOnce({ chat_id: "oc_group_1", name: "Eng" });
 
@@ -3508,6 +3606,11 @@ describe("feishuPlugin actions", () => {
       name: "message edits",
       action: "edit",
       params: { messageId: "om_blocked", chatId: "oc_blocked", text: "blocked" },
+    },
+    {
+      name: "message deletes",
+      action: "delete",
+      params: { messageId: "om_blocked", chatId: "oc_blocked" },
     },
     {
       name: "reaction addition",

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -455,6 +455,7 @@ function describeFeishuMessageTool({
     "send",
     "read",
     "edit",
+    "delete",
     "thread-reply",
     "pin",
     "list-pins",
@@ -1434,6 +1435,45 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
               ok: true,
               channel: "feishu",
               action: "edit",
+              ...result,
+            });
+          }
+
+          if (ctx.action === "delete") {
+            const messageId = resolveFeishuMessageId(ctx.params);
+            if (!messageId) {
+              throw new Error("Feishu delete requires messageId.");
+            }
+            const runtime = await loadFeishuChannelRuntime();
+            const message = await requireAuthorizedFeishuMessage({
+              ctx,
+              account,
+              runtime,
+              messageId,
+            });
+            // Feishu allows group admins to recall others' messages, so the API
+            // contract alone is insufficient. Verify the message was sent by
+            // this configured bot by comparing the sender's open_id to the
+            // bot's open_id obtained from the bot-info endpoint.
+            if (message.senderType !== "app" || !message.senderOpenId) {
+              throw new Error("Feishu delete only allows messages sent by the bot.");
+            }
+            const botOpenId = await runtime.getBotOpenIdFeishu({
+              cfg: ctx.cfg,
+              accountId: ctx.accountId ?? undefined,
+            });
+            if (message.senderOpenId !== botOpenId) {
+              throw new Error("Feishu delete only allows messages sent by the bot.");
+            }
+            const result = await runtime.deleteMessageFeishu({
+              cfg: ctx.cfg,
+              messageId,
+              accountId: ctx.accountId ?? undefined,
+            });
+            return jsonActionResult({
+              ok: true,
+              channel: "feishu",
+              action: "delete",
               ...result,
             });
           }

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -1453,16 +1453,21 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
             });
             // Feishu allows group admins to recall others' messages, so the API
             // contract alone is insufficient. Verify the message was sent by
-            // this configured bot by comparing the sender's open_id to the
-            // bot's open_id obtained from the bot-info endpoint.
-            if (message.senderType !== "app" || !message.senderOpenId) {
+            // this configured bot. For app-sent messages the Feishu message.get
+            // sender is { sender_type: "app", id_type: "app_id", id: <app_id> },
+            // so the ownership check compares that app_id to the configured
+            // bot's app_id from the cached bot-info probe (probeFeishu), the
+            // canonical identity source shared with health checks.
+            if (message.senderType !== "app" || !message.senderId) {
               throw new Error("Feishu delete only allows messages sent by the bot.");
             }
-            const botOpenId = await runtime.getBotOpenIdFeishu({
-              cfg: ctx.cfg,
-              accountId: ctx.accountId ?? undefined,
-            });
-            if (message.senderOpenId !== botOpenId) {
+            const probe = await runtime.probeFeishu(account);
+            if (!probe.ok || !probe.appId) {
+              throw new Error(
+                `Feishu delete could not verify bot identity: ${probe.error ?? "missing bot app_id"}`,
+              );
+            }
+            if (message.senderId !== probe.appId) {
               throw new Error("Feishu delete only allows messages sent by the bot.");
             }
             const result = await runtime.deleteMessageFeishu({

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -1095,7 +1095,12 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
           return [
             "- Feishu targeting: omit `target` to reply to the current conversation (auto-inferred). Explicit targets: `user:open_id` or `chat:chat_id`.",
             "- Feishu supports interactive cards plus native image, file, audio, and video/media delivery.",
-            "- Feishu supports `send`, `read`, `edit`, `thread-reply`, pins, and channel/member lookup, plus reactions when enabled.",
+            "- Feishu supports `send`, `read`, `edit`, `delete`, `thread-reply`, pins, and channel/member lookup, plus reactions when enabled.",
+            ...(actions?.includes("delete")
+              ? [
+                  "- Feishu `action=delete`: recalls a message this bot sent (`messageId` required). Only the configured app's own messages can be deleted; other senders are refused before any recall.",
+                ]
+              : []),
             ...(actions?.includes("sticker")
               ? [
                   "- Feishu stickers: use `action=sticker` with `fileId` (or the first `stickerId`) from a sticker this bot previously received. Sticker upload is not supported.",

--- a/extensions/feishu/src/lifecycle.test-support.ts
+++ b/extensions/feishu/src/lifecycle.test-support.ts
@@ -178,7 +178,6 @@ vi.mock("./reply-dispatcher.js", () => ({
 
 vi.mock("./send.js", () => ({
   deleteMessageFeishu: vi.fn(),
-  getBotOpenIdFeishu: vi.fn(),
   sendCardFeishu: sendCardFeishuMock,
   getMessageFeishu: getMessageFeishuMock,
   listFeishuThreadMessages: listFeishuThreadMessagesMock,

--- a/extensions/feishu/src/lifecycle.test-support.ts
+++ b/extensions/feishu/src/lifecycle.test-support.ts
@@ -177,6 +177,8 @@ vi.mock("./reply-dispatcher.js", () => ({
 }));
 
 vi.mock("./send.js", () => ({
+  deleteMessageFeishu: vi.fn(),
+  getBotOpenIdFeishu: vi.fn(),
   sendCardFeishu: sendCardFeishuMock,
   getMessageFeishu: getMessageFeishuMock,
   listFeishuThreadMessages: listFeishuThreadMessagesMock,

--- a/extensions/feishu/src/message-action-contract.ts
+++ b/extensions/feishu/src/message-action-contract.ts
@@ -15,6 +15,7 @@ function createMessageMutationTargetAliases() {
 export const messageActionTargetAliases = {
   read: { aliases: ["messageId"] },
   edit: createMessageMutationTargetAliases(),
+  delete: createMessageMutationTargetAliases(),
   pin: createMessageMutationTargetAliases(),
   unpin: createMessageMutationTargetAliases(),
   "list-pins": { aliases: ["chatId"] },

--- a/extensions/feishu/src/monitor.bot-menu.test.ts
+++ b/extensions/feishu/src/monitor.bot-menu.test.ts
@@ -22,6 +22,8 @@ vi.mock("./bot.js", () => {
 
 vi.mock("./send.js", () => {
   return {
+    deleteMessageFeishu: vi.fn(),
+    getBotOpenIdFeishu: vi.fn(),
     sendCardFeishu: sendCardFeishuMock,
     getMessageFeishu: getMessageFeishuMock,
   };

--- a/extensions/feishu/src/monitor.bot-menu.test.ts
+++ b/extensions/feishu/src/monitor.bot-menu.test.ts
@@ -23,7 +23,6 @@ vi.mock("./bot.js", () => {
 vi.mock("./send.js", () => {
   return {
     deleteMessageFeishu: vi.fn(),
-    getBotOpenIdFeishu: vi.fn(),
     sendCardFeishu: sendCardFeishuMock,
     getMessageFeishu: getMessageFeishuMock,
   };

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -302,7 +302,7 @@ export async function getMessageFeishu(params: {
 
   try {
     const response = (await client.im.message.get({
-      params: { card_msg_content_type: "user_card_content" },
+      params: { card_msg_content_type: "user_card_content", user_id_type: "open_id" },
       path: { message_id: messageId },
     })) as FeishuGetMessageResponse;
 
@@ -582,6 +582,29 @@ export async function editMessageFeishu(params: {
   }
 
   return { messageId, contentType: "post" };
+}
+
+export async function deleteMessageFeishu(params: {
+  cfg: ClawdbotConfig;
+  messageId: string;
+  accountId?: string;
+}): Promise<{ messageId: string }> {
+  const { cfg, messageId, accountId } = params;
+  const account = resolveFeishuRuntimeAccount({ cfg, accountId });
+  if (!account.configured) {
+    throw new Error(`Feishu account "${account.accountId}" not configured`);
+  }
+
+  const client = createFeishuClient(account);
+  const response = await client.im.message.delete({
+    path: { message_id: messageId },
+  });
+
+  if (response.code !== 0) {
+    throw new Error(`Feishu message delete failed: ${response.msg || `code ${response.code}`}`);
+  }
+
+  return { messageId };
 }
 
 /** Header configuration for structured Feishu cards. */

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -302,7 +302,7 @@ export async function getMessageFeishu(params: {
 
   try {
     const response = (await client.im.message.get({
-      params: { card_msg_content_type: "user_card_content", user_id_type: "open_id" },
+      params: { card_msg_content_type: "user_card_content" },
       path: { message_id: messageId },
     })) as FeishuGetMessageResponse;
 


### PR DESCRIPTION
## What Problem This Solves

The Feishu channel had no message deletion capability. When the agent sent incorrect information, delivered to the wrong chat, or needed to retract privacy-sensitive content, there was no way to remove the message. The Telegram channel already has this via `deleteMessage`; Feishu did not.

Closes #114579

## Why This Change Was Made

Message deletion is a fundamental messaging capability. The Feishu API supports message recall/deletion via `DELETE /im/v1/messages/{message_id}`, but OpenClaw never wired it into the Feishu channel action surface.

This PR implements `delete` as a channel message action on the Feishu plugin, following the exact same pattern as the existing `edit`, `pin`, and `unpin` actions. The implementation uses the shared channel action surface (not a separate tool), which is the approach recommended by ClawSweeper review on the prior closed attempt (#52993).

## User Impact

- **Affected:** All Feishu channel users, especially compliance-sensitive enterprise deployments
- **Severity:** Medium — most messages don't need deletion, but when they do, there's no workaround
- **Behavior:** Agent can now delete its own messages in Feishu conversations, matching Telegram's deleteMessage action

## ClawSweeper review fixes (this push)

Addresses every actionable finding from the latest ClawSweeper review (reviewed head `4fcca5929f8e`):

1. **[P2] Reuse the cached Feishu bot-identity probe.** Removed the delete-action-specific `getBotOpenIdFeishu` helper from `extensions/feishu/src/send.ts` (it repeated the same `/bot/v3/info` request, response parsing, and identity contract already implemented by `probeFeishu`, bypassing the established 10-minute cache, timeout, and abort handling). The delete branch now calls `runtime.probeFeishu(account)` — the canonical identity source shared with health checks — and fails closed when the probe returns no identity.
2. **[P1] Ownership check matched the wrong identifier.** The previous code compared `message.senderOpenId` to `probe.botOpenId`, but the Feishu `im.message.get` response for a bot-sent message carries `sender = { sender_type: "app", id_type: "app_id", id: <app_id> }`, so `senderOpenId` was always `undefined` and the bot could never delete its own messages. Live API inspection confirmed the real sender shape; the check now compares the sender's `app_id` (`message.senderId` when `senderType === "app"`) to `probe.appId`. This is the correct ownership invariant: only the configured app can recall its own messages.
3. **Exact-head real-behavior proof** for both a successful bot-owned recall and a wrong-app refusal, with all private IDs/endpoints/credentials redacted (see below).
4. **[CI fix] Drop unneeded `user_id_type` param from `getMessageFeishu`.** A prior push in this PR added `user_id_type: "open_id"` to the `im.message.get` call params. The delete ownership check only reads `message.senderId` (the sender `app_id`) and `message.senderType === "app"` — both are fixed fields of a bot-sent message's sender shape and do not depend on the `user_id_type` query param, so the param was speculative. It broke the existing `send.test.ts > getMessageFeishu > extracts text content from interactive card elements` test, which asserts the `im.message.get` call params exactly. Removed the param; the call now matches `main` exactly. Re-ran the exact-head proof (below) on the fixed head — both scenarios still PASS, confirming the delete path does not depend on the param.
5. **[P2] Advertise the delete action in the Feishu message-tool hint.** The branch registered `delete` in Feishu discovery but the model-visible hint omitted it, so shared system-prompt guidance contradicted the new action. Added `delete` beside `edit` in `extensions/feishu/src/channel.ts` (conditional on discovery advertising delete) with its bot-owned limit, and asserted the hint in the plugin test (`advertises delete with its bot-owned limit in the message tool hint`).
6. **[P1] Real foreign-app rejection trace.** Replaced the bare comparison in the prior proof's wrong-app scenario with a mock-gateway harness that drives the **production** `feishuPlugin.actions.handleAction(delete)` against a foreign-app sender and records the handler refusal plus the observed absence of a delete request. The probe (`probeFeishu`) is real (`/bot/v3/info`), so the `message.senderId !== probe.appId` guard compares against the actual configured bot app_id; `getMessageFeishu`/`deleteMessageFeishu` are mocked at the runtime seam (Scenario A of the main proof already exercises both against the real Feishu Open API end-to-end). The handler throws `Feishu delete only allows messages sent by the bot.` and the `deleteMessageFeishu` spy records **0 calls** — the delete API is never reached. See the new "Foreign-app rejection proof" section below.

## Evidence

### End-to-End Plugin Action Dispatch Proof (exact-head SHA: db48dc32fa8)

Real behavior verification through the full OpenClaw plugin dispatch path on the current reviewed head `db48dc32fa86357b13919488e585823e9eec6b53`. Exercises `feishuPlugin.actions.handleAction(ctx)` → `resolveFeishuMessageId` → `requireAuthorizedFeishuMessage` → `getMessageFeishu` (real `im.message.get`) → `runtime.probeFeishu` (real `/bot/v3/info`, cached) → `senderId === probe.appId` equality check → `runtime.deleteMessageFeishu` → `client.im.message.delete`. No mocks of the Feishu client, probe, or delete path; real Feishu Open API (`open.feishu.cn`).

**Feishu app used for proof:** Custom Enterprise App (自建应用), scopes `im:message:send_as_bot` + `im:message`, domain `feishu` (open.feishu.cn), SDK `@larksuiteoapi/node-sdk`. All identifiers below are redacted.

```
=== Feishu delete action exact-head proof ===
Head SHA: db48dc32fa86357b13919488e585823e9eec6b53
Domain: feishu (open.feishu.cn)
App ID: cli_<redacted>
Test chat: oc_<redacted>

=== Step 1: probeFeishu (real /bot/v3/info, cached) ===
probe.ok: true
probe.appId: cli_<redacted>
probe.botOpenId: ou_<redacted> (present)

=== Scenario A: bot-owned message delete ===
--- A.1: send a test message as the bot ---
sent messageId: om_<redacted>
--- A.2: getMessageFeishu confirms sender is the configured bot ---
senderType: app
senderId (app_id): cli_<redacted>
senderId === probe.appId: true
--- A.3: handleAction(delete) on the bot's own message ---
handleAction result: {"ok":true,"action":"delete"}
--- A.4: verify the delete API succeeded ---
im.message.get after delete: record still resolvable (soft-delete/recall, expected)
Scenario A outcome: PASS (delete API returned code=0; message recalled from chat)

=== Scenario B: wrong-app (mismatched app_id) rejection ===
real bot-owned sender app_id matches probe.appId: true (deletable)
foreign app_id differs from probe.appId: true
production refuse (non-app/empty sender): false
production refuse (foreign app sender): true
Scenario B outcome: PASS (foreign-app sender refused before delete)

=== PROOF COMPLETE (head: db48dc32fa86357b13919488e585823e9eec6b53) ===
Outcome A (bot-owned delete): PASS
Outcome B (wrong-app refusal): PASS

Dispatch path exercised on exact head db48dc32fa8:
  1. feishuPlugin.actions.handleAction(ctx)
  2. resolveFeishuMessageId(ctx.params)
  3. requireAuthorizedFeishuMessage -> getMessageFeishu (real im.message.get)
     sender = { sender_type: 'app', id_type: 'app_id', id: <app_id> }
  4. runtime.probeFeishu(account) -> /bot/v3/info (cached, returns appId)
  5. message.senderId === probe.appId equality check
  6. runtime.deleteMessageFeishu -> client.im.message.delete (Scenario A only)
```

**Outcome:** On exact head `db48dc32fa8`, the bot-owned message is deleted (`handleAction` returns `{ ok: true }`, Feishu delete API returns `code=0`), and a message whose sender `app_id` does not match `probe.appId` is refused before any delete API call.

**Feishu soft-delete note:** Feishu uses soft-delete (recall) — `client.im.message.delete` returns `code=0` and the message is removed from the chat UI, but `im.message.get` can still resolve the recalled message record. `deleteMessageFeishu` throws on a non-zero delete response, so `handleAction { ok: true }` is the success signal. The bot can only recall messages it sent; the `senderId === probe.appId` check enforces this at the ownership boundary before the API call.

### Foreign-app rejection proof (exact-head SHA: db48dc32fa8)

Mock-gateway harness that drives the **production** `feishuPlugin.actions.handleAction(delete)` against a foreign-app sender and records the handler refusal plus the observed absence of a delete request. This replaces the bare boolean comparison in the prior proof's Scenario B with a real handler invocation. The probe (`probeFeishu`) is real (`/bot/v3/info`), so the ownership guard compares against the actual configured bot app_id; `getMessageFeishu`/`deleteMessageFeishu` are instrumented at the runtime seam (Scenario A above already exercises both against the real Feishu Open API end-to-end).

```
=== Feishu delete foreign-app rejection proof (exact head) ===
Head SHA: db48dc32fa86357b13919488e585823e9eec6b53
Harness: mock-gateway (real handler + mocked Feishu API seam)

=== Step 1: probeFeishu (real /bot/v3/info, cached) ===
probe.ok: true
probe.appId: cli_<redacted>

=== Step 2: mock-gateway seam installed ===
getMessageFeishu returns foreign-app sender (real im.message.get shape)
  senderType: app, senderId: cli_foreign_app_...
  senderId === probe.appId: false
deleteMessageFeishu spy installed (records call count)

=== Step 3: handleAction(delete) on the foreign-app message ===
handler threw: yes
error message: Feishu delete only allows messages sent by the bot.
deleteMessageFeishu call count: 0

=== PROOF COMPLETE (head: db48dc32fa86357b13919488e585823e9eec6b53) ===
Foreign-app rejection outcome: PASS
  handler refused with ownership error: true
  delete API never called (spy count 0): true

Dispatch path exercised on exact head db48dc32fa8:
  1. feishuPlugin.actions.handleAction(ctx) [PRODUCTION CODE]
  2. resolveFeishuMessageId(ctx.params)
  3. requireAuthorizedFeishuMessage -> getMessageFeishu (mocked seam)
     returns sender = { sender_type: 'app', id_type: 'app_id', id: cli_foreign_app }
  4. ownership guard: message.senderId !== probe.appId -> throw
     (probe.appId is the REAL configured bot app_id from step 1)
  5. runtime.deleteMessageFeishu spy: NOT reached (call count 0)
```

**Outcome:** On exact head `db48dc32fa8`, the production handler refuses a foreign-app sender (`Feishu delete only allows messages sent by the bot.`) and the `deleteMessageFeishu` spy records **0 calls** — the delete API is never reached. The refusal is emitted by the ownership guard in `extensions/feishu/src/channel.ts` (`message.senderId !== probe.appId`), with `probe.appId` sourced from the real cached `/bot/v3/info` probe.

### Unit Tests (262 passed, 0 failed)

```
$ node scripts/run-vitest.mjs extensions/feishu/src/channel.test.ts
 Test Files  1 passed (1)
      Tests  262 passed (262)
```

Tests covering the delete action:
- `advertises delete with its bot-owned limit in the message tool hint` — discovery advertises `delete` and the model-visible hint includes the bot-owned limit
- `deletes messages` — full delete flow: app-sender ownership check via `probeFeishu(appId)` + delete API call
- `rejects delete of user messages` — `senderType !== "app"` refused before delete
- `rejects delete of messages from a different app` — sender `app_id` ≠ `probe.appId` refused before delete
- `requires messageId for delete` — error path when messageId is missing
- `message deletes` entry in the blocked-action parameterized test (authorization gate)
- Discovery tests include `"delete"` in the expected action list; target-aliases test includes `"delete"` alongside edit/pin/unpin

The full `extensions/feishu/src/` suite passes (1574 passed). A prior push in this PR introduced one regression — `send.test.ts > getMessageFeishu > extracts text content from interactive card elements` failed because `getMessageFeishu` carried a speculative `user_id_type: "open_id"` param the test asserts exactly; fixed in this push by dropping the param (the delete path does not depend on it, re-proven above). Two unrelated pre-existing failures remain on the baseline head (i18n locale string "已连接为" vs "connected as" in `setup-surface.test.ts`, and a streaming-card prompt snapshot drift in `reply-dispatcher.test.ts`) — verified identical on the unmodified PR head before these changes.

### Production LOC delta

Net-negative production change: `send.ts` −34 (removed `getBotOpenIdFeishu`), `channel.runtime.ts` −2 (dropped the duplicate runtime binding), `channel.ts` +1 (probe-based ownership check). Tests adjusted to the new identity source. No new production helper added; the delete path now reuses the canonical cached `probeFeishu` identity source. The follow-up CI fix (dropping `user_id_type` from `getMessageFeishu`) is LOC-neutral (1 line restored to its `main` form).