### PR TITLE
refactor(qa): simplify gateway lifecycle state

### DIFF
--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -682,7 +682,6 @@ function createQaGatewayChildLogCollector() {
   };
   let recent = "";
   let end = 0;
-  let dropped = false;
 
   const readFrom = (mark: number) => {
     const start = end - recent.length;
@@ -697,7 +696,6 @@ function createQaGatewayChildLogCollector() {
       recent += text;
       if (recent.length > QA_GATEWAY_CHILD_RECENT_LOG_CHARS) {
         recent = sliceUtf16Safe(recent, -QA_GATEWAY_CHILD_RECENT_LOG_CHARS);
-        dropped = true;
       }
     },
     mark() {
@@ -707,7 +705,7 @@ function createQaGatewayChildLogCollector() {
       return readFrom(mark);
     },
     text() {
-      return `${dropped ? QA_GATEWAY_CHILD_LOG_TRUNCATION_MARKER : ""}${recent}`.trim();
+      return `${end > recent.length ? QA_GATEWAY_CHILD_LOG_TRUNCATION_MARKER : ""}${recent}`.trim();
     },
   };
 }

--- a/extensions/qa-lab/src/gateway-rpc-client.ts
+++ b/extensions/qa-lab/src/gateway-rpc-client.ts
@@ -18,10 +18,10 @@ type QaGatewayRpcClient = {
 };
 
 type QaGatewayConnectionGate = {
+  connected: boolean;
   promise: Promise<void>;
   resolve: () => void;
   reject: (error: Error) => void;
-  state: "pending" | "connected" | "failed";
 };
 
 const QA_GATEWAY_RPC_TIMEOUT_MS = 20_000;
@@ -29,30 +29,13 @@ const QA_GATEWAY_RPC_TIMEOUT_MS = 20_000;
 function createQaGatewayConnectionGate(): QaGatewayConnectionGate {
   let resolvePromise!: () => void;
   let rejectPromise!: (error: Error) => void;
-  const gate: QaGatewayConnectionGate = {
-    promise: new Promise<void>((resolve, reject) => {
-      resolvePromise = resolve;
-      rejectPromise = reject;
-    }),
-    resolve: () => {
-      if (gate.state !== "pending") {
-        return;
-      }
-      gate.state = "connected";
-      resolvePromise();
-    },
-    reject: (error) => {
-      if (gate.state !== "pending") {
-        return;
-      }
-      gate.state = "failed";
-      rejectPromise(error);
-    },
-    state: "pending",
-  };
+  const promise = new Promise<void>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
   // A terminal reconnect error can arrive without an active request waiter.
-  void gate.promise.catch(() => {});
-  return gate;
+  void promise.catch(() => {});
+  return { connected: false, promise, reject: rejectPromise, resolve: resolvePromise };
 }
 
 function formatQaGatewayRpcError(error: unknown, logs: () => string) {
@@ -110,9 +93,12 @@ export async function startQaGatewayRpcClient(params: {
     deviceIdentity: null,
     mode: "backend",
     scopes: ["operator.admin"],
-    onHelloOk: () => connection.resolve(),
+    onHelloOk: () => {
+      connection.connected = true;
+      connection.resolve();
+    },
     onClose: () => {
-      if (!stopped && connection.state === "connected") {
+      if (!stopped && connection.connected) {
         connection = createQaGatewayConnectionGate();
       }
     },
@@ -120,7 +106,7 @@ export async function startQaGatewayRpcClient(params: {
       const error = new Error(
         `gateway reconnect paused (${info.code}): ${info.reason}${info.detailCode ? ` [${info.detailCode}]` : ""}`,
       );
-      if (connection.state === "connected") {
+      if (connection.connected) {
         connection = createQaGatewayConnectionGate();
       }
       connection.reject(error);
@@ -175,7 +161,7 @@ export async function startQaGatewayRpcClient(params: {
             assertNotStopped();
             // A close can race between gate resolution and request dispatch. No frame was sent,
             // so waiting for the next hello and retrying is safe even for non-idempotent methods.
-            if (connection === requestConnection && connection.state === "connected") {
+            if (connection === requestConnection && connection.connected) {
               connection = createQaGatewayConnectionGate();
             }
           }


### PR DESCRIPTION
## What Problem This Solves

The QA Gateway lifecycle retained duplicate state for connection Promise settlement and whole-log truncation after the recent concurrency refactor. The duplicate flags made reconnect and diagnostics behavior harder to audit without changing what operators observe.

## Why This Change Was Made

Replace the three-state connection gate plus guarded Promise wrappers with a single `connected` lifecycle bit and native Promise settlement. Derive whole-log truncation directly from the collector's absolute end offset and retained suffix length. This removes 16 production lines while preserving reconnect generations, terminal pause behavior, request replay boundaries, deadlines, stopping, and bounded chronological logs.

## User Impact

No user-visible behavior changes. QA Gateway lifecycle code is smaller and easier to verify.

## Evidence

- Production LOC: +15/-31 (net -16); tests unchanged.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/gateway-rpc-client.test.ts extensions/qa-lab/src/gateway-child.test.ts` — 123/123 passed on Node 22.22.3.
- Extensions test TypeScript project check passed.
- `oxlint`, `oxfmt --check`, and `git diff --check` passed.
- Independent source review found no lifecycle or truncation regression, including terminal pause → close and late callback ordering.
- Deterministic no-credential fake-provider concurrency proof on canonical main passed: 16 RPC connections; custom/main/fanout max concurrency 16/9/11; 48/48 exact-once markers; 32 persisted-session checks; 96 exactly accounted provider requests; no forbidden warnings or log leaks. The disposable harness was removed after the run.
