### PR TITLE
test(gateway): remove webchat audio test wrapper

### DIFF
--- a/src/gateway/server-methods/chat-webchat-media.test.ts
+++ b/src/gateway/server-methods/chat-webchat-media.test.ts
@@ -7,11 +7,16 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getDefaultLocalRoots } from "../../media/local-media-access.js";
-import { __testing, buildWebchatAssistantMessageFromReplyPayloads } from "./chat-webchat-media.js";
+import { buildWebchatAssistantMessageFromReplyPayloads } from "./chat-webchat-media.js";
 
-const { buildWebchatAudioContentBlocksFromReplyPayloads } = __testing;
+async function buildWebchatAudioBlocks(
+  ...args: Parameters<typeof buildWebchatAssistantMessageFromReplyPayloads>
+): Promise<Array<Record<string, unknown>>> {
+  const message = await buildWebchatAssistantMessageFromReplyPayloads(...args);
+  return message?.content.filter((block) => block.type === "attachment") ?? [];
+}
 
-describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
+describe("webchat audio blocks through assistant messages", () => {
   let tmpDir: string | undefined;
 
   afterEach(() => {
@@ -31,7 +36,7 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
   it("exposes a local audio file as a media-ticketed attachment when it is under localRoots", async () => {
     const { audioPath, localRoot } = writeAudioFixture();
 
-    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
+    const blocks = await buildWebchatAudioBlocks(
       [{ mediaUrl: audioPath, trustedLocalMedia: true }],
       { localRoots: [localRoot] },
     );
@@ -53,7 +58,7 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
   it("exposes MPEG-2 audio files with their canonical MIME type", async () => {
     const { audioPath, localRoot } = writeAudioFixture([0xff, 0xfd, 0x80, 0x00], ".m2a");
 
-    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
+    const blocks = await buildWebchatAudioBlocks(
       [{ mediaUrl: audioPath, trustedLocalMedia: true }],
       { localRoots: [localRoot] },
     );
@@ -75,7 +80,7 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
         extension,
       );
 
-      const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
+      const blocks = await buildWebchatAudioBlocks(
         [{ mediaUrl: audioPath, trustedLocalMedia: true }],
         { localRoots: [localRoot] },
       );
@@ -89,7 +94,7 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
   it("preserves voice-note metadata on local audio attachments", async () => {
     const { audioPath, localRoot } = writeAudioFixture();
 
-    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
+    const blocks = await buildWebchatAudioBlocks(
       [{ mediaUrl: audioPath, trustedLocalMedia: true, audioAsVoice: true }],
       { localRoots: [localRoot] },
     );
@@ -106,7 +111,7 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
   it("suppresses reasoning payload audio", async () => {
     const { audioPath, localRoot } = writeAudioFixture();
 
-    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
+    const blocks = await buildWebchatAudioBlocks(
       [
         {
           text: "step",
@@ -122,7 +127,7 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
   });
 
   it("skips remote URLs", async () => {
-    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads([
+    const blocks = await buildWebchatAudioBlocks([
       { mediaUrl: "https://example.com/a.mp3", trustedLocalMedia: true },
     ]);
     expect(blocks).toHaveLength(0);
@@ -133,7 +138,7 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
     const imagePath = path.join(tmpDir, "clip.png");
     fs.writeFileSync(imagePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
 
-    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
+    const blocks = await buildWebchatAudioBlocks(
       [{ mediaUrl: imagePath, trustedLocalMedia: true }],
       { localRoots: [tmpDir] },
     );
@@ -144,7 +149,7 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
   it("dedupes repeated paths", async () => {
     const { audioPath, localRoot } = writeAudioFixture([0x00]);
 
-    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
+    const blocks = await buildWebchatAudioBlocks(
       [
         { mediaUrl: audioPath, trustedLocalMedia: true },
         { mediaUrl: audioPath, trustedLocalMedia: true },
@@ -158,12 +163,9 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
     const { audioPath, localRoot } = writeAudioFixture([0x01]);
 
     const fileUrl = pathToFileURL(audioPath).href;
-    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
-      [{ mediaUrl: fileUrl, trustedLocalMedia: true }],
-      {
-        localRoots: [localRoot],
-      },
-    );
+    const blocks = await buildWebchatAudioBlocks([{ mediaUrl: fileUrl, trustedLocalMedia: true }], {
+      localRoots: [localRoot],
+    });
 
     expect(blocks).toHaveLength(1);
     expect((blocks[0] as { type?: string }).type).toBe("attachment");
@@ -172,7 +174,7 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
   it("drops tool-result file:// URLs with remote hosts before touching the filesystem", async () => {
     const openSpy = vi.spyOn(fsPromises, "open");
 
-    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads([
+    const blocks = await buildWebchatAudioBlocks([
       {
         text: "MEDIA:file://attacker/share/probe.mp3",
         mediaUrl: "file://attacker/share/probe.mp3",
@@ -196,7 +198,7 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
     fs.writeFileSync(audioPath, Buffer.from([0x03]));
 
     const onLocalAudioAccessDenied = vi.fn();
-    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
+    const blocks = await buildWebchatAudioBlocks(
       [{ mediaUrl: audioPath, trustedLocalMedia: true }],
       {
         localRoots: [allowedRoot],
@@ -219,7 +221,7 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
     const audioPath = path.join(tmpDir, "clip.mp3");
     fs.writeFileSync(audioPath, Buffer.from([0x04]));
 
-    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads([
+    const blocks = await buildWebchatAudioBlocks([
       { mediaUrl: audioPath, trustedLocalMedia: true },
     ]);
 
@@ -231,7 +233,7 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
     const { audioPath, localRoot } = writeAudioFixture([0x02]);
     fs.truncateSync(audioPath, 16 * 1024 * 1024);
 
-    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
+    const blocks = await buildWebchatAudioBlocks(
       [{ mediaUrl: audioPath, trustedLocalMedia: true }],
       { localRoots: [localRoot] },
     );
@@ -242,10 +244,9 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
   it("rejects untrusted local audio paths", async () => {
     const { audioPath, localRoot } = writeAudioFixture();
 
-    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
-      [{ mediaUrl: audioPath }],
-      { localRoots: [localRoot] },
-    );
+    const blocks = await buildWebchatAudioBlocks([{ mediaUrl: audioPath }], {
+      localRoots: [localRoot],
+    });
 
     expect(blocks).toHaveLength(0);
   });

--- a/src/gateway/server-methods/chat-webchat-media.ts
+++ b/src/gateway/server-methods/chat-webchat-media.ts
@@ -211,32 +211,6 @@ function resolveReplyDirectivePrefix(payload: ReplyPayload): string {
   return "";
 }
 
-/**
- * Build Control UI / transcript `content` blocks for local TTS (or other) audio files
- * referenced by slash-command / agent replies when the webchat path only had text aggregation.
- */
-async function buildWebchatAudioContentBlocksFromReplyPayloads(
-  payloads: ReplyPayload[],
-  options?: WebchatAudioEmbeddingOptions,
-): Promise<Array<Record<string, unknown>>> {
-  const seen = new Set<string>();
-  const blocks: Array<Record<string, unknown>> = [];
-  for (const payload of payloads) {
-    if (payload.isReasoning === true) {
-      continue;
-    }
-    const parts = resolveSendableOutboundReplyParts(payload);
-    for (const raw of parts.mediaUrls) {
-      const media = await resolveReplyMediaAudioEmbedding(payload, raw, seen, options);
-      if (!media?.audioBlock) {
-        continue;
-      }
-      blocks.push(media.audioBlock);
-    }
-  }
-  return blocks;
-}
-
 export async function buildWebchatAssistantMessageFromReplyPayloads(
   payloads: ReplyPayload[],
   options?: WebchatAudioEmbeddingOptions,
@@ -315,6 +289,3 @@ export async function buildWebchatAssistantMessageFromReplyPayloads(
   }
   return { content, transcriptText };
 }
-
-const testing = { buildWebchatAudioContentBlocksFromReplyPayloads };
-export { testing as __testing };


### PR DESCRIPTION
## What Problem This Solves

Webchat retained an audio-only builder and `__testing` export after `buildWebchatAssistantMessageFromReplyPayloads` absorbed the same local-media traversal. The obsolete wrapper had no production caller and duplicated reasoning filtering, media resolution, audio detection, and deduplication solely for direct tests.

## Why This Change Was Made

This deletes the audio-only wrapper and test facade. The unique audio regressions now run through the live assistant-message owner, with a test-local helper selecting attachment blocks from the returned content.

All valuable coverage remains, including:

- configured/default local-root enforcement;
- remote-host `file:` rejection before filesystem access;
- opened-file size caps and trust gating;
- MP3, MPEG-2, AIFF/AIF/AIFC MIME mapping;
- voice-note metadata;
- reasoning suppression and path deduplication.

AI-assisted: yes. The change was manually inspected and passed repository autoreview.

## User Impact

No user-visible behavior change. The same production builder and security policies remain covered, while 29 lines of duplicate production/test-only surface are removed.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-methods/chat-webchat-media.test.ts src/gateway/server-methods/chat.directive-tags.test.ts` — 215 tests passed.
- `node scripts/check-changed.mjs -- src/gateway/server-methods/chat-webchat-media.ts src/gateway/server-methods/chat-webchat-media.test.ts` — passed core/type/lint/dead-export/import-cycle/boundary gates using the trusted local fallback because Blacksmith Testbox is unavailable on this host.
- Plugin SDK API baseline — unchanged and green.
- Targeted oxlint, oxfmt, and `git diff --check` — passed.
- Fresh autoreview and secret scan — clean.

## Scope and LOC

- Production: `-29` lines.
- Tests: `+26/-25` (owner-boundary migration).
- Overall: `+26/-54` (net `-28`).

No runtime behavior, config, protocol, database schema, dependency, lockfile, generated baseline, release, docs, or changelog change.
