### PR TITLE
improve(ui): format sidebar timestamps on demand

### DIFF
--- a/ui/src/components/app-sidebar-session-narration.test.ts
+++ b/ui/src/components/app-sidebar-session-narration.test.ts
@@ -14,7 +14,7 @@ function runningRow(key: string): SidebarRecentSession {
   return {
     key,
     label: "Run",
-    meta: "now",
+    updatedAt: Date.now(),
     href: "#",
     active: false,
     visuallyActive: false,

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -36,7 +36,6 @@ import {
 } from "../lib/sessions/session-key.ts";
 import { reconcileSidebarZone } from "../lib/sidebar-zone.ts";
 import { normalizeOptionalString } from "../lib/string-coerce.ts";
-import { formatSidebarTimestamp } from "./app-sidebar-session-catalogs.ts";
 import {
   limitSidebarSessionRows,
   SIDEBAR_SESSION_NO_ATTENTION,
@@ -161,7 +160,6 @@ export function buildSidebarSessionNavigationState(input: {
       // The sidebar's zone structure already says what forked from what;
       // a "Subagent:" prefix on named threads is noise (other surfaces keep it).
       label: resolveSessionDisplayName(row.key, row, { includeSubagentPrefix: false }),
-      meta: formatSidebarTimestamp(row.updatedAt),
       subtitle: resolveSessionWorkSubtitle(row),
       href: sessionNavigationTarget({
         face: resolveSessionPreferredFace(row),

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -18,6 +18,7 @@ import type {
   CatalogBackingSessionDisplay,
   CatalogSessionMenuRequest,
 } from "./app-sidebar-session-catalogs.ts";
+import { formatSidebarTimestamp } from "./app-sidebar-session-catalogs.ts";
 import {
   rowDemandsVisibility,
   sidebarSessionMetaId,
@@ -106,11 +107,7 @@ export interface SessionListHost {
   handleSessionRowClick(event: MouseEvent, session: SidebarRecentSession): void;
   toggleSessionChildren(session: SidebarRecentSession): void;
   toggleSessionPin(session: SidebarRecentSession): void;
-  toggleSessionMenu(
-    session: SidebarRecentSession,
-    menuSession: SidebarRecentSession,
-    trigger: HTMLElement,
-  ): void;
+  toggleSessionMenu(session: SidebarRecentSession, trigger: HTMLElement): void;
   showMoreChildren(sessionKey: string): void;
   sectionDragOver(event: DragEvent, sectionId: string, group?: string): void;
   sectionDragLeave(event: DragEvent, sectionId: string, group?: string): void;
@@ -192,19 +189,18 @@ export function renderRecentSession(params: {
   const trailingDescription = session.isChild
     ? ""
     : describeSessionTrailingState(session, pullRequestState);
-  const meta = display?.meta ?? session.meta;
+  const meta = display?.meta ?? formatSidebarTimestamp(session.updatedAt);
   const rowMeta = session.pinned ? "" : meta;
   const hasTrail = session.isChild && (session.runtimeMs != null || session.startedAt != null);
   const metaId = hasTrail ? sidebarSessionMetaId(session.key) : undefined;
   const stateId = trailingIndicator === nothing ? undefined : sidebarSessionStateId(session.key);
-  const menuSession = display ? { ...session, meta } : session;
   const openMenuFromEvent = session.isChild
     ? undefined
     : (event: MouseEvent | KeyboardEvent) =>
         handleContextMenuEvent(
           event,
           (event.currentTarget as HTMLElement).querySelector("[data-session-menu]"),
-          (trigger, x, y) => host.sidebarMenus.openSessionMenu(menuSession, x, y, trigger),
+          (trigger, x, y) => host.sidebarMenus.openSessionMenu(session, x, y, trigger),
         );
   const title = [
     display?.title ?? [label, narration, rowMeta].filter(Boolean).join(" · "),
@@ -405,7 +401,7 @@ export function renderRecentSession(params: {
                 @click=${(event: MouseEvent) => {
                   event.stopPropagation();
                   const trigger = event.currentTarget as HTMLElement;
-                  host.toggleSessionMenu(session, menuSession, trigger);
+                  host.toggleSessionMenu(session, trigger);
                 }}
               >
                 ${icons.moreHorizontal}

--- a/ui/src/components/app-sidebar-session-types.ts
+++ b/ui/src/components/app-sidebar-session-types.ts
@@ -59,7 +59,6 @@ export type SidebarRecentSession = {
   createdActor?: SessionCreatedActor;
   archivedBy?: SessionCreatedActor;
   label: string;
-  meta: string;
   /** Compact repo/branch/node line for work sessions. */
   subtitle?: string;
   href: string;

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -300,17 +300,13 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
     void this.sessionOrganizer.patchSession(session, { pinned: !session.pinned });
   }
 
-  toggleSessionMenu(
-    session: SidebarRecentSession,
-    menuSession: SidebarRecentSession,
-    trigger: HTMLElement,
-  ): void {
+  toggleSessionMenu(session: SidebarRecentSession, trigger: HTMLElement): void {
     if (this.sidebarMenus.sessionMenu?.session.key === session.key) {
       this.sidebarMenus.closeSessionMenu();
       return;
     }
     const rect = trigger.getBoundingClientRect();
-    this.sidebarMenus.openSessionMenu(menuSession, rect.right, rect.bottom + 4, trigger);
+    this.sidebarMenus.openSessionMenu(session, rect.right, rect.bottom + 4, trigger);
   }
 
   startSidebarSectionDrag(sectionId: string): void {

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -15,6 +15,7 @@ import {
 } from "../lib/sessions/session-key.ts";
 import { renderSidebarAgentMenu, renderSidebarIdentityMenu } from "./app-sidebar-agent-menu.ts";
 import { renderSidebarCustomizeMenu, renderSidebarMoreMenu } from "./app-sidebar-nav-menus.ts";
+import { formatSidebarTimestamp } from "./app-sidebar-session-catalogs.ts";
 import {
   renderSidebarCatalogViewMenu,
   renderSidebarSessionGroupMenu,
@@ -180,7 +181,7 @@ export function renderSidebarSessionMenuForController(controller: SidebarMenusCo
           category: batchRows ? sharedCategory : (session.category ?? null),
         }}
         .selectionCount=${rows.length}
-        .lastActive=${batchRows ? "" : session.meta}
+        .lastActive=${batchRows ? "" : formatSidebarTimestamp(session.updatedAt)}
         .anchor=${menu}
         .trigger=${controller.sessionMenuTrigger}
         .disabled=${!host.connected}


### PR DESCRIPTION
Related: #121624

## What Problem This Solves

Warm session switches still rebuilt relative timestamp text for every loaded session in the selected agent's sidebar projection, even though pagination and collapsed sections render only a bounded subset. With 100 loaded sessions, this left relative-time formatting as the largest remaining application self-time hotspot during switching.

## Why This Change Was Made

Keep each session's existing raw `updatedAt` value through projection and format it only at the two presentation boundaries that display it: a rendered sidebar row and an opened session menu. This removes the duplicate derived `meta` field and the display-only menu-row copy while preserving catalog overrides and timestamp behavior.

## User Impact

Session switching does less main-thread work as the loaded session count grows, while row titles, relative timestamps, menus, retained roots, accessibility, and background streaming behave the same. Production and test code together shrink by 10 lines.

AI-assisted; the implementation and benchmark evidence were reviewed before publication.

## Evidence

Production-bundle browser profiling used deterministic realistic transcripts, a mocked Gateway WebSocket, 100 loaded sidebar sessions, two warmed retained panes, and repeated alternating switches:

- Exact merged-main four-switch profile: `ui/src/lib/format.ts:29` self-time fell from **25.6 ms to 3.4 ms** (**87% less**); settled median fell from **67.3 ms to 46.8 ms**.
- Two full candidate runs (10 samples each for the representative 100-session / 100-message case): first-useful **1.8 ms / 1.7 ms** versus merged baseline **1.9 ms / 1.9 ms**; settled **49.8 ms / 35.4 ms** versus **51.7 ms / 51.8 ms**. No long task occurred.
- Every warm sample reused its transcript root and made zero `chat.history`, `chat.startup`, `chat.subscribe`, or `chat.unsubscribe` calls.
- Both runs preserved the three-pane capacity/eviction contract, hidden-pane `inert` and `aria-hidden` state, live background streaming, and same-session split-pane isolation.

Validation:

- `node scripts/run-vitest.mjs ui/src/components/app-sidebar-session-catalogs.test.ts ui/src/components/app-sidebar-session-navigation-logic.test.ts ui/src/components/app-sidebar-session-narration.test.ts ui/src/components/app-sidebar.test.ts` — **294 passed**.
- UI production and test typechecks passed under Node 24.
- Full changed-file gate passed: format, max-lines ratchet, dead exports, UI i18n, typechecks, and type-aware oxlint (0 warnings/errors). The orb had no Crabbox/Blacksmith binary, so the documented trusted-source local fallback was used.
- `autoreview --mode uncommitted` — clean, no accepted/actionable findings.
