### PR TITLE
test(macos): remove body-only view probes

### DIFF
--- a/apps/macos/Sources/OpenClaw/SettingsComponents.swift
+++ b/apps/macos/Sources/OpenClaw/SettingsComponents.swift
@@ -157,26 +157,3 @@ struct SettingsCardToggleRow: View {
         }
     }
 }
-
-struct SettingsToggleRow: View {
-    let title: SettingsTextValue
-    let subtitle: SettingsTextValue?
-    @Binding var binding: Bool
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Toggle(isOn: self.$binding) {
-                self.title.text
-                    .font(.body)
-            }
-            .toggleStyle(.checkbox)
-
-            if let subtitle {
-                subtitle.text
-                    .font(.footnote)
-                    .foregroundStyle(.tertiary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-        }
-    }
-}

--- a/apps/macos/Tests/OpenClawIPCTests/LowCoverageViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/LowCoverageViewSmokeTests.swift
@@ -1,5 +1,4 @@
 import AppKit
-import OpenClawProtocol
 import SwiftUI
 import Testing
 @testable import OpenClaw
@@ -7,51 +6,6 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct LowCoverageViewSmokeTests {
-    @Test func `context root menu label builds body`() {
-        let longStatus = "Gateway connection dropped; gateway likely restarted and needs a few seconds to reconnect."
-        _ = ContextRootMenuLabelView(subtitle: longStatus, width: 320).body
-    }
-
-    @Test func `settings toggle row builds body`() {
-        var flag = false
-        let binding = Binding(get: { flag }, set: { flag = $0 })
-        let view = SettingsToggleRow(title: "Enable", subtitle: "Detail", binding: binding)
-        _ = view.body
-    }
-
-    @Test func `voice wake test card builds body across states`() {
-        var state = VoiceWakeTestState.idle
-        var isTesting = false
-        let stateBinding = Binding(get: { state }, set: { state = $0 })
-        let testingBinding = Binding(get: { isTesting }, set: { isTesting = $0 })
-
-        _ = VoiceWakeTestCard(testState: stateBinding, isTesting: testingBinding, onToggle: {}).body
-
-        state = .hearing("hello")
-        _ = VoiceWakeTestCard(testState: stateBinding, isTesting: testingBinding, onToggle: {}).body
-
-        state = .detected("command")
-        isTesting = true
-        _ = VoiceWakeTestCard(testState: stateBinding, isTesting: testingBinding, onToggle: {}).body
-
-        state = .failed("No mic")
-        _ = VoiceWakeTestCard(testState: stateBinding, isTesting: testingBinding, onToggle: {}).body
-    }
-
-    @Test func `agent events window builds body with event`() {
-        AgentEventStore.shared.clear()
-        let sample = ControlAgentEvent(
-            runId: "run-1",
-            seq: 1,
-            stream: "tool",
-            ts: Date().timeIntervalSince1970 * 1000,
-            data: ["phase": AnyCodable("start"), "name": AnyCodable("test")],
-            summary: nil)
-        AgentEventStore.shared.append(sample)
-        _ = AgentEventsWindow().body
-        AgentEventStore.shared.clear()
-    }
-
     @Test func `notify overlay keeps replacement visible`() async {
         let controller = NotifyOverlayController()
         controller.present(title: "Hello", body: "World", autoDismissAfter: 0.05)

--- a/apps/macos/Tests/OpenClawIPCTests/SettingsViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/SettingsViewSmokeTests.swift
@@ -6,81 +6,6 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct SettingsViewSmokeTests {
-    @Test func `cron settings builds body`() {
-        let store = CronJobsStore(isPreview: true)
-        store.schedulerEnabled = false
-        store.schedulerStorePath = "/tmp/openclaw-cron-store.json"
-
-        let job1 = CronJob(
-            id: "job-1",
-            agentId: "ops",
-            name: "  Morning Check-in  ",
-            description: nil,
-            enabled: true,
-            deleteAfterRun: nil,
-            createdAtMs: 1_700_000_000_000,
-            updatedAtMs: 1_700_000_100_000,
-            schedule: .cron(expr: "0 8 * * *", tz: "UTC"),
-            sessionTarget: .main,
-            wakeMode: .now,
-            payload: .systemEvent(text: "ping"),
-            delivery: nil,
-            state: CronJobState(
-                nextRunAtMs: 1_700_000_200_000,
-                runningAtMs: nil,
-                lastRunAtMs: 1_700_000_050_000,
-                lastStatus: "ok",
-                lastError: nil,
-                lastDurationMs: 123))
-
-        let job2 = CronJob(
-            id: "job-2",
-            agentId: nil,
-            name: "",
-            description: nil,
-            enabled: false,
-            deleteAfterRun: nil,
-            createdAtMs: 1_700_000_000_000,
-            updatedAtMs: 1_700_000_100_000,
-            schedule: .every(everyMs: 30000, anchorMs: nil),
-            sessionTarget: .isolated,
-            wakeMode: .nextHeartbeat,
-            payload: .agentTurn(
-                message: "hello",
-                thinking: "low",
-                timeoutSeconds: 30,
-                deliver: nil,
-                channel: nil,
-                to: nil,
-                bestEffortDeliver: nil),
-            delivery: CronDelivery(mode: .announce, channel: "sms", to: "+15551234567", bestEffort: true),
-            state: CronJobState(
-                nextRunAtMs: nil,
-                runningAtMs: nil,
-                lastRunAtMs: nil,
-                lastStatus: nil,
-                lastError: nil,
-                lastDurationMs: nil))
-
-        store.jobs = [job1, job2]
-        store.selectedJobId = job1.id
-        store.runEntries = [
-            CronRunLogEntry(
-                ts: 1_700_000_050_000,
-                jobId: job1.id,
-                action: "finished",
-                status: "ok",
-                error: nil,
-                summary: "ok",
-                runAtMs: 1_700_000_050_000,
-                durationMs: 123,
-                nextRunAtMs: 1_700_000_200_000),
-        ]
-
-        let view = CronSettings(store: store)
-        _ = view.body
-    }
-
     @Test func `cron settings renders in hosting view`() {
         let store = CronJobsStore(isPreview: true)
         store.schedulerEnabled = false
@@ -142,12 +67,6 @@ struct SettingsViewSmokeTests {
 
     @Test func `debug settings builds body`() {
         let view = DebugSettings()
-        _ = view.body
-    }
-
-    @Test func `general settings builds body`() {
-        let state = AppState(preview: true)
-        let view = GeneralSettings(state: state)
         _ = view.body
     }
 

--- a/scripts/apple-app-i18n.ts
+++ b/scripts/apple-app-i18n.ts
@@ -166,7 +166,6 @@ const LOCALIZED_WRAPPER_CONTRACTS: Record<string, readonly string[]> = {
     "struct SettingsCardGroup<Content: View>: View {\n    let title: SettingsTextValue",
     "struct SettingsCardRow<Content: View>: View {\n    let title: SettingsTextValue\n    let subtitle: SettingsTextValue?",
     "struct SettingsCardToggleRow: View {\n    let title: SettingsTextValue\n    let subtitle: SettingsTextValue?",
-    "struct SettingsToggleRow: View {\n    let title: SettingsTextValue\n    let subtitle: SettingsTextValue?",
     "Text(verbatim: value)",
   ],
   "apps/ios/Sources/Design/OpenClawProComponents.swift": [


### PR DESCRIPTION
## What Problem This Solves

Several macOS tests only evaluated SwiftUI `View.body` without mounting, laying out, interacting with, or asserting anything about the resulting view tree. Two were strict subsets of stronger `NSHostingView` tests, and one was the sole caller keeping the unreachable `SettingsToggleRow` production view alive.

## Why This Change Was Made

This removes:

- four coverage-only probes from `LowCoverageViewSmokeTests`;
- the body-only Cron and General Settings tests, while retaining their hosting/layout tests;
- the dead `SettingsToggleRow` struct; and
- its retired Apple i18n wrapper-contract inventory entry.

Behavior-bearing overlay, hosting-view, dock-icon, settings routing, and remaining settings smoke tests stay intact.

AI-assisted: yes. The change was manually inspected and passed repository autoreview.

## User Impact

No user-visible behavior change. The macOS app has one fewer unreachable view and its smoke suites retain the tests that actually mount, lay out, or verify behavior.

## Evidence

- `swift test --package-path apps/macos --filter 'SettingsViewSmokeTests|LowCoverageViewSmokeTests'` — 21 retained tests passed.
- `swift build --package-path apps/macos` — passed.
- `node --import tsx scripts/native-app-i18n.ts verify` — passed after removing the deleted wrapper's contract entry.
- `node scripts/check-changed.mjs -- ...` for all four touched files — passed full Swift lint, native i18n, app checks, 295 macOS CI tests, native schema guard, and related tooling gates using the trusted local fallback because Blacksmith Testbox is unavailable on this host.
- Fresh autoreview and secret scan — clean.

## Scope and LOC

- Production/tooling: `-24` lines.
- Tests: `-127` lines.
- Overall: `-151` lines.

No runtime behavior, config, protocol, database schema, dependency, lockfile, generated baseline, release, docs, or changelog change.
