### PR TITLE
fix: report message-tool-only runs that never reply

### DIFF
--- a/src/agents/agent-run-terminal-reply.ts
+++ b/src/agents/agent-run-terminal-reply.ts
@@ -9,6 +9,15 @@ export type AgentRunTerminalReplySnapshot =
   | { disposition: "silent" }
   | { disposition: "empty" };
 
+function isMessageToolNotCalledTerminalReply(
+  reply: AgentRunTerminalReplySnapshot | undefined,
+): boolean {
+  return (
+    reply?.disposition === "empty" &&
+    (reply as { code?: unknown }).code === "message-tool-not-called"
+  );
+}
+
 /** Sanitizes and caps producer-owned text before it enters lifecycle or durable state. */
 export function sanitizeAgentRunTerminalReplyText(text: string): string {
   const sanitized = stripInternalMetadataForDisplay(text).trim();
@@ -42,7 +51,14 @@ export function normalizeAgentRunTerminalReplySnapshot(
     return undefined;
   }
   const disposition = (value as { disposition?: unknown }).disposition;
-  if (disposition === "silent" || disposition === "empty") {
+  if (disposition === "silent") {
+    return { disposition };
+  }
+  if (disposition === "empty") {
+    if ((value as { code?: unknown }).code === "message-tool-not-called") {
+      const reply = { disposition, code: "message-tool-not-called" } as const;
+      return reply;
+    }
     return { disposition };
   }
   if (disposition !== "visible") {
@@ -64,11 +80,17 @@ export function mergeAgentRunTerminalReplySnapshot(
   if (!incoming) {
     return existing;
   }
-  if (!existing || existing.disposition === "empty") {
+  if (!existing) {
     return incoming;
   }
-  if (incoming.disposition === "empty") {
+  if (isMessageToolNotCalledTerminalReply(existing)) {
     return existing;
   }
-  return incoming;
+  if (isMessageToolNotCalledTerminalReply(incoming)) {
+    return incoming;
+  }
+  if (existing.disposition === "empty") {
+    return incoming;
+  }
+  return incoming.disposition === "empty" ? existing : incoming;
 }

--- a/src/auto-reply/reply/agent-runner-fallback-settlement.ts
+++ b/src/auto-reply/reply/agent-runner-fallback-settlement.ts
@@ -14,6 +14,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { defaultRuntime } from "../../runtime.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import { buildContextOverflowRecoveryText } from "./agent-runner-context-recovery.js";
+import { resolveSourceReplyPolicy } from "./agent-runner-core.js";
 import { markAgentRunFailureReplyPayload } from "./agent-runner-failure-reply.js";
 import type { AgentFallbackCandidatesResult } from "./agent-runner-fallback-candidate.js";
 import type {
@@ -127,7 +128,16 @@ export async function settleAgentFallbackCycle(params: {
     };
   }
   const terminalMetadata = fallbackResult.terminal.metadata;
-  const sourceReplyDeliveryMode = turn.followupRun.run.sourceReplyDeliveryMode;
+  const sourceReplyPolicy = turn.sessionKey
+    ? resolveSourceReplyPolicy({
+        cfg: cycle.runtimeConfig,
+        sessionCtx: turn.sessionCtx,
+        sessionEntry: turn.getActiveSessionEntry(),
+        sessionKey: turn.sessionKey,
+        runtimePolicySessionKey: turn.runtimePolicySessionKey,
+        opts: turn.opts,
+      })
+    : undefined;
   const finalText = runResult.meta?.finalAssistantVisibleText?.trim() ?? "";
   const successfulSourceReplyDelivery = hasCompletedSourceReplyDeliveryEvidence(runResult);
   const hasPendingContinuation =
@@ -135,9 +145,11 @@ export async function settleAgentFallbackCycle(params: {
   const privateFinalTerminalReply =
     !hasPendingContinuation &&
     classifyPrivateMessageToolFinal({
-      sourceReplyDeliveryMode,
-      sendPolicyDenied: false,
+      sourceReplyDeliveryMode: sourceReplyPolicy?.sourceReplyDeliveryMode,
+      sendPolicyDenied: sourceReplyPolicy?.sendPolicyDenied === true,
       successfulSourceReplyDelivery,
+      isHeartbeat: turn.isHeartbeat,
+      isRoomEvent: turn.sessionCtx.InboundEventKind === "room_event",
       finalText,
     }) === "short"
       ? ({ disposition: "empty", code: "message-tool-not-called" } as const)

--- a/src/auto-reply/reply/agent-runner-fallback-settlement.ts
+++ b/src/auto-reply/reply/agent-runner-fallback-settlement.ts
@@ -1,4 +1,5 @@
 import { isContextOverflowError } from "../../agents/embedded-agent-helpers.js";
+import { hasCompletedSourceReplyDeliveryEvidence } from "../../agents/embedded-agent-runner/delivery-evidence.js";
 import {
   PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE,
   renderControlUiAgentFailureCopy,
@@ -20,6 +21,7 @@ import type {
   AgentFallbackCycleResult,
 } from "./agent-runner-fallback-cycle.types.js";
 import { drainPendingToolTasks } from "./pending-tool-task-drain.js";
+import { classifyPrivateMessageToolFinal } from "./private-message-tool-final.js";
 import {
   isReplyOperationRestartAbort,
   isReplyOperationUserAbort,
@@ -125,6 +127,21 @@ export async function settleAgentFallbackCycle(params: {
     };
   }
   const terminalMetadata = fallbackResult.terminal.metadata;
+  const sourceReplyDeliveryMode = turn.followupRun.run.sourceReplyDeliveryMode;
+  const finalText = runResult.meta?.finalAssistantVisibleText?.trim() ?? "";
+  const successfulSourceReplyDelivery = hasCompletedSourceReplyDeliveryEvidence(runResult);
+  const hasPendingContinuation =
+    runResult.meta?.yielded === true || (runResult.meta?.pendingToolCalls?.length ?? 0) > 0;
+  const privateFinalTerminalReply =
+    !hasPendingContinuation &&
+    classifyPrivateMessageToolFinal({
+      sourceReplyDeliveryMode,
+      sendPolicyDenied: false,
+      successfulSourceReplyDelivery,
+      finalText,
+    }) === "short"
+      ? ({ disposition: "empty", code: "message-tool-not-called" } as const)
+      : undefined;
   let terminalRunFailed = false;
   if (fallbackExhausted) {
     const exhaustionError = new Error(
@@ -148,7 +165,11 @@ export async function settleAgentFallbackCycle(params: {
     turn.replyOperation?.retainFailureUntilComplete();
     turn.replyOperation?.fail("run_failed", terminalError);
   } else {
-    settledLifecycleTerminal?.emit("end", runResult);
+    settledLifecycleTerminal?.emit(
+      "end",
+      runResult,
+      privateFinalTerminalReply ? { terminalReply: privateFinalTerminalReply } : undefined,
+    );
   }
   return {
     kind: "completed",

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -15,6 +15,10 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { loadSessionEntry, replaceSessionEntry } from "../../config/sessions/session-accessor.js";
 import {
+  onAgentEvent as subscribeAgentEvent,
+  type AgentEventPayload,
+} from "../../infra/agent-events.js";
+import {
   onInternalDiagnosticEvent,
   resetDiagnosticEventsForTest,
   type DiagnosticEventPayload,
@@ -3308,6 +3312,7 @@ describe("runReplyAgent private message_tool_only final warning (#85714)", () =>
     strandedReplyRetry?: boolean;
     sendPolicyDenied?: boolean;
     isHeartbeat?: boolean;
+    pendingContinuation?: boolean;
     onDeliberateSilentTerminalReply?: () => void;
     onObservedReplyDelivery?: () => Promise<void> | void;
     replyOperation?: ReturnType<typeof createReplyOperation>;
@@ -3335,6 +3340,7 @@ describe("runReplyAgent private message_tool_only final warning (#85714)", () =>
       meta: {
         agentMeta: {},
         finalAssistantVisibleText: finalAssistantText,
+        ...(params.pendingContinuation ? { yielded: true } : {}),
         ...(params.finalAssistantRawText
           ? { finalAssistantRawText: params.finalAssistantRawText }
           : {}),
@@ -3379,8 +3385,8 @@ describe("runReplyAgent private message_tool_only final warning (#85714)", () =>
         messageProvider: "whatsapp",
         sessionFile: "/tmp/session.jsonl",
         workspaceDir: tmp,
-        // Direct chat + visibleReplies=message_tool resolves to message_tool_only,
-        // so the final text is kept private (no automatic delivery).
+        // Carry the canonical tool-only run fact and keep downstream policy aligned,
+        // so the private final is never eligible for automatic source delivery.
         config: { messages: { visibleReplies: "message_tool" } },
         skillsSnapshot: {},
         provider: "anthropic",
@@ -3392,6 +3398,7 @@ describe("runReplyAgent private message_tool_only final warning (#85714)", () =>
         bashElevated: { enabled: false, allowed: false, defaultLevel: "off" },
         timeoutMs: 1_000,
         blockReplyBreak: "message_end",
+        sourceReplyDeliveryMode: "message_tool_only",
       },
     } as unknown as FollowupRun;
 
@@ -3401,48 +3408,57 @@ describe("runReplyAgent private message_tool_only final warning (#85714)", () =>
     // visibleReplies=message_tool config and mis-resolve delivery to automatic.
     clearRuntimeConfigSnapshot();
 
-    const result = await runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: sessionKey,
-      resolvedQueue: { mode: "interrupt" } as unknown as QueueSettings,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      typing: createMockTypingController(),
-      sessionCtx,
-      sessionEntry,
-      sessionStore: { [sessionKey]: sessionEntry },
-      sessionKey,
-      storePath,
-      defaultModel: "anthropic/claude-opus-4-6",
-      agentCfgContextTokens: 200_000,
-      resolvedVerboseLevel: params.resolvedVerboseLevel ?? "off",
-      isNewSession: params.isNewSession ?? false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-      ...(params.isHeartbeat ||
-      params.onDeliberateSilentTerminalReply ||
-      params.onObservedReplyDelivery
-        ? {
-            opts: {
-              ...(params.isHeartbeat ? { isHeartbeat: true } : {}),
-              ...(params.onDeliberateSilentTerminalReply
-                ? {
-                    onDeliberateSilentTerminalReply: params.onDeliberateSilentTerminalReply,
-                  }
-                : {}),
-              ...(params.onObservedReplyDelivery
-                ? { onObservedReplyDelivery: params.onObservedReplyDelivery }
-                : {}),
-            },
-          }
-        : {}),
-      ...(params.replyOperation ? { replyOperation: params.replyOperation } : {}),
+    const runId = `stranded-${path.basename(tmp)}`;
+    const agentEvents: AgentEventPayload[] = [];
+    const unsubscribe = subscribeAgentEvent((event) => {
+      if (event.runId === runId) {
+        agentEvents.push(event);
+      }
     });
-    return { storePath, tmp, sessionKey, result, finalAssistantText };
+    try {
+      const result = await runReplyAgent({
+        commandBody: "hello",
+        followupRun,
+        queueKey: sessionKey,
+        resolvedQueue: { mode: "interrupt" } as unknown as QueueSettings,
+        shouldSteer: false,
+        shouldFollowup: false,
+        isActive: false,
+        typing: createMockTypingController(),
+        sessionCtx,
+        sessionEntry,
+        sessionStore: { [sessionKey]: sessionEntry },
+        sessionKey,
+        storePath,
+        defaultModel: "anthropic/claude-opus-4-6",
+        agentCfgContextTokens: 200_000,
+        resolvedVerboseLevel: params.resolvedVerboseLevel ?? "off",
+        isNewSession: params.isNewSession ?? false,
+        blockStreamingEnabled: false,
+        resolvedBlockStreamingBreak: "message_end",
+        shouldInjectGroupIntro: false,
+        typingMode: "instant",
+        opts: {
+          runId,
+          ...(params.isHeartbeat ? { isHeartbeat: true } : {}),
+          ...(params.onDeliberateSilentTerminalReply
+            ? { onDeliberateSilentTerminalReply: params.onDeliberateSilentTerminalReply }
+            : {}),
+          ...(params.onObservedReplyDelivery
+            ? { onObservedReplyDelivery: params.onObservedReplyDelivery }
+            : {}),
+        },
+        ...(params.replyOperation ? { replyOperation: params.replyOperation } : {}),
+      });
+      const terminalEvent = agentEvents.find(
+        (event) =>
+          event.stream === "lifecycle" &&
+          (event.data.phase === "end" || event.data.phase === "error"),
+      );
+      return { storePath, tmp, sessionKey, result, finalAssistantText, terminalEvent };
+    } finally {
+      unsubscribe();
+    }
   }
 
   it("warns when a substantive private final reply never used the message tool", async () => {
@@ -3550,18 +3566,37 @@ describe("runReplyAgent private message_tool_only final warning (#85714)", () =>
     expect(vi.mocked(enqueueFollowupRun).mock.calls[0]?.[6]).toEqual({ position: "front" });
   });
 
-  it("does not warn or enqueue retry for a short private final reply", async () => {
-    await runPrivateFinalCase({ finalAssistantText: "Nothing to send here." });
+  it("records a short private final without a message call as non-delivery", async () => {
+    const { terminalEvent } = await runPrivateFinalCase({
+      finalAssistantText: "Nothing to send here.",
+    });
+    expect(terminalEvent?.data.terminalReply).toEqual({
+      disposition: "empty",
+      code: "message-tool-not-called",
+    });
     expect(warnPrivateFinalSpy).not.toHaveBeenCalled();
     expect(vi.mocked(enqueueFollowupRun)).not.toHaveBeenCalled();
   });
 
   it("does not warn or enqueue retry when the message tool delivered this turn", async () => {
-    await runPrivateFinalCase({
+    const { terminalEvent } = await runPrivateFinalCase({
       didDeliverSourceReplyViaMessageTool: true,
     });
+    expect((terminalEvent?.data.terminalReply as { code?: unknown } | undefined)?.code).not.toBe(
+      "message-tool-not-called",
+    );
     expect(warnPrivateFinalSpy).not.toHaveBeenCalled();
     expect(vi.mocked(enqueueFollowupRun)).not.toHaveBeenCalled();
+  });
+
+  it("does not record message-tool non-delivery while the run has a continuation", async () => {
+    const { terminalEvent } = await runPrivateFinalCase({
+      finalAssistantText: "Nothing to send here.",
+      pendingContinuation: true,
+    });
+    expect((terminalEvent?.data.terminalReply as { code?: unknown } | undefined)?.code).not.toBe(
+      "message-tool-not-called",
+    );
   });
 
   it("still recovers a private final after only a message-tool progress delivery", async () => {
@@ -3617,11 +3652,14 @@ describe("runReplyAgent private message_tool_only final warning (#85714)", () =>
     // survives in finalPayloads. The warn must key off the assistant text, not
     // the payload bundle, so no private-final warning should fire.
     const onDeliberateSilentTerminalReply = vi.fn();
-    await runPrivateFinalCase({
+    const { terminalEvent } = await runPrivateFinalCase({
       finalAssistantText: "no_reply",
       onDeliberateSilentTerminalReply,
       payloadText: "Auto-compaction complete (count 1).",
     });
+    expect((terminalEvent?.data.terminalReply as { code?: unknown } | undefined)?.code).not.toBe(
+      "message-tool-not-called",
+    );
     expect(onDeliberateSilentTerminalReply).toHaveBeenCalledOnce();
     expect(warnPrivateFinalSpy).not.toHaveBeenCalled();
     expect(vi.mocked(enqueueFollowupRun)).not.toHaveBeenCalled();

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -3666,13 +3666,19 @@ describe("runReplyAgent private message_tool_only final warning (#85714)", () =>
   });
 
   it("does not warn or enqueue retry for room_event turns", async () => {
-    await runPrivateFinalCase({ inboundEventKind: "room_event" });
+    const { terminalEvent } = await runPrivateFinalCase({ inboundEventKind: "room_event" });
+    expect((terminalEvent?.data.terminalReply as { code?: unknown } | undefined)?.code).not.toBe(
+      "message-tool-not-called",
+    );
     expect(warnPrivateFinalSpy).not.toHaveBeenCalled();
     expect(vi.mocked(enqueueFollowupRun)).not.toHaveBeenCalled();
   });
 
   it("does not warn, enqueue retry, or emit diagnostic for heartbeat runs", async () => {
-    const { result } = await runPrivateFinalCase({ isHeartbeat: true });
+    const { result, terminalEvent } = await runPrivateFinalCase({ isHeartbeat: true });
+    expect((terminalEvent?.data.terminalReply as { code?: unknown } | undefined)?.code).not.toBe(
+      "message-tool-not-called",
+    );
     expect(warnPrivateFinalSpy).not.toHaveBeenCalled();
     expect(vi.mocked(enqueueFollowupRun)).not.toHaveBeenCalled();
     const payloads = result === undefined ? [] : normalizeReplyPayloads(result);
@@ -3680,7 +3686,10 @@ describe("runReplyAgent private message_tool_only final warning (#85714)", () =>
   });
 
   it("does not warn or enqueue retry when send policy denied source delivery", async () => {
-    await runPrivateFinalCase({ sendPolicyDenied: true });
+    const { terminalEvent } = await runPrivateFinalCase({ sendPolicyDenied: true });
+    expect((terminalEvent?.data.terminalReply as { code?: unknown } | undefined)?.code).not.toBe(
+      "message-tool-not-called",
+    );
     expect(warnPrivateFinalSpy).not.toHaveBeenCalled();
     expect(vi.mocked(enqueueFollowupRun)).not.toHaveBeenCalled();
   });

--- a/src/auto-reply/reply/private-message-tool-final.test.ts
+++ b/src/auto-reply/reply/private-message-tool-final.test.ts
@@ -7,6 +7,8 @@ const base = {
   sourceReplyDeliveryMode: "message_tool_only" as const,
   sendPolicyDenied: false,
   successfulSourceReplyDelivery: false,
+  isHeartbeat: false,
+  isRoomEvent: false,
   finalText:
     "Here is the answer the user asked for. It includes enough detail to look like a visible response rather than an internal no-op note.",
 };
@@ -141,5 +143,10 @@ describe("shouldWarnAboutPrivateMessageToolFinal", () => {
 
   it("does not flag when delivery was intentionally denied by send policy", () => {
     expect(shouldWarnAboutPrivateMessageToolFinal({ ...base, sendPolicyDenied: true })).toBe(false);
+  });
+
+  it("does not flag heartbeat or room-event non-delivery", () => {
+    expect(shouldWarnAboutPrivateMessageToolFinal({ ...base, isHeartbeat: true })).toBe(false);
+    expect(shouldWarnAboutPrivateMessageToolFinal({ ...base, isRoomEvent: true })).toBe(false);
   });
 });

--- a/src/auto-reply/reply/private-message-tool-final.test.ts
+++ b/src/auto-reply/reply/private-message-tool-final.test.ts
@@ -1,7 +1,7 @@
 // Tests private message-tool final delivery and visibility suppression.
 import { describe, expect, it } from "vitest";
 import { estimateStringChars } from "../../utils/cjk-chars.js";
-import { shouldWarnAboutPrivateMessageToolFinal } from "./private-message-tool-final.js";
+import { classifyPrivateMessageToolFinal } from "./private-message-tool-final.js";
 
 const base = {
   sourceReplyDeliveryMode: "message_tool_only" as const,
@@ -12,6 +12,12 @@ const base = {
   finalText:
     "Here is the answer the user asked for. It includes enough detail to look like a visible response rather than an internal no-op note.",
 };
+
+function shouldWarnAboutPrivateMessageToolFinal(
+  params: Parameters<typeof classifyPrivateMessageToolFinal>[0],
+): boolean {
+  return classifyPrivateMessageToolFinal(params) === "substantive";
+}
 
 describe("shouldWarnAboutPrivateMessageToolFinal", () => {
   it("flags a multi-sentence private final that was never delivered via the message tool (#85714)", () => {

--- a/src/auto-reply/reply/private-message-tool-final.ts
+++ b/src/auto-reply/reply/private-message-tool-final.ts
@@ -55,13 +55,6 @@ export function classifyPrivateMessageToolFinal(
   return substantive ? "substantive" : "short";
 }
 
-/** Substantive private finals usually indicate a missed configured delivery tool. */
-export function shouldWarnAboutPrivateMessageToolFinal(
-  params: Parameters<typeof classifyPrivateMessageToolFinal>[0],
-): boolean {
-  return classifyPrivateMessageToolFinal(params) === "substantive";
-}
-
 /**
  * Emit metadata-only operator signal. The body is intentionally omitted:
  * `message_tool_only` keeps normal final text private by design.

--- a/src/auto-reply/reply/private-message-tool-final.ts
+++ b/src/auto-reply/reply/private-message-tool-final.ts
@@ -12,42 +12,38 @@ const MULTI_SENTENCE_TERMINATOR_MIN_COUNT = 2;
 // CJK sentence marks do not require following whitespace; keep ASCII's boundary rule.
 const SENTENCE_TERMINATOR_REGEX = /[.!?]+(?:\s|$)|[。！？．｡]+/gu;
 
-/**
- * `message_tool_only` allows the model to stay silent by simply not calling the
- * message tool, so short private final text is not evidence of message loss.
- * Warn only for unusually substantive private finals, which usually means the
- * model wrote a user-facing answer but missed the configured delivery tool.
- */
-export function shouldWarnAboutPrivateMessageToolFinal(params: {
+/** Classifies private final text after message-tool-only source delivery settles. */
+export function classifyPrivateMessageToolFinal(params: {
   sourceReplyDeliveryMode: SourceReplyDeliveryMode | undefined;
   sendPolicyDenied: boolean;
   successfulSourceReplyDelivery: boolean;
   finalText: string;
-}): boolean {
-  if (params.sourceReplyDeliveryMode !== "message_tool_only") {
-    return false;
-  }
-  // A send-policy denial is an intentional block, and a successful source-reply
-  // delivery means the contract was honored. Other side effects do not count.
-  if (params.sendPolicyDenied || params.successfulSourceReplyDelivery) {
-    return false;
+}): "none" | "short" | "substantive" {
+  if (
+    params.sourceReplyDeliveryMode !== "message_tool_only" ||
+    params.sendPolicyDenied ||
+    params.successfulSourceReplyDelivery
+  ) {
+    return "none";
   }
   const trimmed = params.finalText.trim();
   if (!trimmed || isSilentReplyText(trimmed)) {
-    return false;
+    return "none";
   }
-  // Both thresholds are substance proxies, so they must be compared against the
-  // shared CJK-aware estimate: raw UTF-16 length under-counts CJK about 4x, which
-  // kept substantive CJK finals below both branches and skipped stranded recovery.
+  // Both thresholds are substance proxies, so they must use the shared CJK-aware estimate.
   const estimatedChars = estimateStringChars(trimmed);
-  if (estimatedChars >= LONG_PRIVATE_FINAL_MIN_CHARS) {
-    return true;
-  }
-  const sentenceTerminatorCount = countSentenceLikeTerminators(trimmed);
-  return (
-    estimatedChars >= MULTI_SENTENCE_PRIVATE_FINAL_MIN_CHARS &&
-    sentenceTerminatorCount >= MULTI_SENTENCE_TERMINATOR_MIN_COUNT
-  );
+  const substantive =
+    estimatedChars >= LONG_PRIVATE_FINAL_MIN_CHARS ||
+    (estimatedChars >= MULTI_SENTENCE_PRIVATE_FINAL_MIN_CHARS &&
+      countSentenceLikeTerminators(trimmed) >= MULTI_SENTENCE_TERMINATOR_MIN_COUNT);
+  return substantive ? "substantive" : "short";
+}
+
+/** Substantive private finals usually indicate a missed configured delivery tool. */
+export function shouldWarnAboutPrivateMessageToolFinal(
+  params: Parameters<typeof classifyPrivateMessageToolFinal>[0],
+): boolean {
+  return classifyPrivateMessageToolFinal(params) === "substantive";
 }
 
 /**

--- a/src/auto-reply/reply/private-message-tool-final.ts
+++ b/src/auto-reply/reply/private-message-tool-final.ts
@@ -12,18 +12,34 @@ const MULTI_SENTENCE_TERMINATOR_MIN_COUNT = 2;
 // CJK sentence marks do not require following whitespace; keep ASCII's boundary rule.
 const SENTENCE_TERMINATOR_REGEX = /[.!?]+(?:\s|$)|[。！？．｡]+/gu;
 
-/** Classifies private final text after message-tool-only source delivery settles. */
-export function classifyPrivateMessageToolFinal(params: {
+type PrivateMessageToolFinalContext = {
   sourceReplyDeliveryMode: SourceReplyDeliveryMode | undefined;
   sendPolicyDenied: boolean;
   successfulSourceReplyDelivery: boolean;
-  finalText: string;
-}): "none" | "short" | "substantive" {
-  if (
+  isHeartbeat: boolean;
+  isRoomEvent: boolean;
+};
+
+/** Returns whether a private final can represent an expected source reply that was not delivered. */
+export function shouldClassifyPrivateMessageToolFinal(
+  params: PrivateMessageToolFinalContext,
+): boolean {
+  return !(
+    params.isHeartbeat ||
+    params.isRoomEvent ||
     params.sourceReplyDeliveryMode !== "message_tool_only" ||
     params.sendPolicyDenied ||
     params.successfulSourceReplyDelivery
-  ) {
+  );
+}
+
+/** Classifies private final text after message-tool-only source delivery settles. */
+export function classifyPrivateMessageToolFinal(
+  params: PrivateMessageToolFinalContext & {
+    finalText: string;
+  },
+): "none" | "short" | "substantive" {
+  if (!shouldClassifyPrivateMessageToolFinal(params)) {
     return "none";
   }
   const trimmed = params.finalText.trim();

--- a/src/auto-reply/reply/stranded-reply-recovery.ts
+++ b/src/auto-reply/reply/stranded-reply-recovery.ts
@@ -1,7 +1,10 @@
 import type { SourceReplyDeliveryMode } from "../get-reply-options.types.js";
 import { markReplyPayloadForSourceSuppressionDelivery } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
-import { shouldWarnAboutPrivateMessageToolFinal } from "./private-message-tool-final.js";
+import {
+  classifyPrivateMessageToolFinal,
+  shouldClassifyPrivateMessageToolFinal,
+} from "./private-message-tool-final.js";
 import type { FollowupRun } from "./queue/types.js";
 
 const STRANDED_REPLY_RETRY_MARKER = "stranded-reply-retry";
@@ -31,29 +34,18 @@ export function resolveStrandedReplyRecovery(params: {
   isHeartbeat: boolean;
   isRoomEvent: boolean;
 }): StrandedReplyRecovery {
-  if (
-    params.isHeartbeat ||
-    params.isRoomEvent ||
-    params.sourceReplyDeliveryMode !== "message_tool_only" ||
-    params.sendPolicyDenied ||
-    params.successfulSourceReplyDelivery
-  ) {
+  if (!shouldClassifyPrivateMessageToolFinal(params)) {
     return { kind: "none" };
   }
-  const shouldWarn = shouldWarnAboutPrivateMessageToolFinal({
-    sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-    sendPolicyDenied: params.sendPolicyDenied,
-    successfulSourceReplyDelivery: params.successfulSourceReplyDelivery,
-    finalText: params.finalText,
-  });
+  const classification = classifyPrivateMessageToolFinal(params);
   if (params.base.strandedReplyRetry === true) {
     return {
       kind: "diagnostic",
       payload: buildStrandedReplyDeliveryFailurePayload(),
-      warn: shouldWarn,
+      warn: classification === "substantive",
     };
   }
-  if (!shouldWarn) {
+  if (classification !== "substantive") {
     return { kind: "none" };
   }
   return {


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

Related: #85714

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where a message_tool_only run could finish without a source reply when the model returned a short private final instead of calling the message tool, while terminal observers could still treat that private text as visible. This made intentional silence indistinguishable from missing delivery.

## Why This Change Was Made

Classify private finals after current-source delivery and continuation state settle. Short non-silent misses emit a bounded `message-tool-not-called` empty terminal fact; private text is never copied or auto-sent. The canonical classifier excludes policy-denied, heartbeat, room-event, completed-delivery, and non-tool-only runs, while preserving substantive stranded-final retry and second-retry diagnostic behavior. Internal normalization keeps the fact sticky without changing the public Plugin SDK reply snapshot contract. Automatic-delivery intent and hosted web-search paths are out of scope and untouched.

## User Impact

Operators and subagent completion projections can now distinguish a run that produced no source delivery because the message tool was not called, without leaking private model output, duplicating delivered replies, or mislabeling intentional non-delivery.

## Evidence

- Pre-fix regression assertion failed because the typed non-delivery fact was absent.
- `node scripts/run-vitest.mjs src/auto-reply/reply/private-message-tool-final.test.ts src/auto-reply/reply/stranded-reply-recovery.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts src/agents/subagents/registry/subagent-registry-lifecycle.test.ts` — 3 shards, 250 tests passed on the final local head.
- `pnpm tsgo:core` and `pnpm tsgo:core:test` passed on the initial exact patch; final-head hosted CI reproves production and test types.
- `node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check` — passed on the final local head; the public Plugin SDK baseline is unchanged.
- Targeted oxfmt, core oxlint, and `git diff --check` — passed on the final local head.
- Initial `autoreview --mode local` was clean. Fresh runs after the ClawSweeper P1 repair and dead-code cleanup were also clean with no accepted/actionable findings.
- ClawSweeper's P1 intentional-suppression finding is fixed in `a8404482ae03`; policy-denied, heartbeat, and room-event cases now assert no terminal reason.
- Exact-head run https://github.com/openclaw/openclaw/actions/runs/31455309256 exposed one test-only production export; commit `6ef690fdff30` deletes that seam. New exact-head hosted CI and repository-native Testbox gates are required before merge.
- Production LOC: +101/-49 (net +52) across four production files. Tests: +111/-51 (net +60) across two test files. The production growth is the typed internal terminal fact, canonical private-final classifier/exclusions, and sticky normalization/persistence boundary; it does not widen the public Plugin SDK contract.
- [x] AI-assisted; the change is understood and reviewed. No transcript is attached.
