### PR TITLE
fix(agents): report best-effort delivery failures

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -3082,9 +3082,10 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(state.deliverAgentCommandResultMock).not.toHaveBeenCalled();
   });
 
-  it("downgrades a rejected best-effort target to session-only before the model run", async () => {
+  it("preserves rejected best-effort delivery intent through the model run", async () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
+    setupBareStoredSession();
     state.resolveAgentDeliveryPlanWithSessionRouteMock.mockResolvedValueOnce({
       baseDelivery: {},
       resolvedChannel: "discord",
@@ -3105,8 +3106,12 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
 
     expect(state.runAgentAttemptMock).toHaveBeenCalled();
     expect(state.deliverAgentCommandResultMock).toHaveBeenCalledWith(
-      expect.objectContaining({ opts: expect.objectContaining({ deliver: false }) }),
+      expect.objectContaining({ opts: expect.objectContaining({ deliver: true }) }),
     );
+    const pendingEntries = state.persistSessionEntryMock.mock.calls
+      .map((call) => (call[0] as { entry?: SessionEntry }).entry)
+      .filter((entry): entry is SessionEntry => entry?.pendingFinalDelivery !== undefined);
+    expect(pendingEntries).toEqual([]);
   });
 
   it("clears a pre-existing transport-only pending delivery after an empty delivered run", async () => {

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -292,11 +292,10 @@ async function agentCommandInternal(
             throw error;
           }
           log.warn(
-            `delivery preflight failed; continuing session-only because bestEffortDeliver is enabled: ${
+            `delivery preflight failed; continuing model run with requested delivery intent because bestEffortDeliver is enabled: ${
               error instanceof Error ? error.message : String(error)
             }`,
           );
-          opts = { ...opts, deliver: false };
         }
         assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
         if (preparedDelivery) {

--- a/src/agents/pending-final-delivery-marker.ts
+++ b/src/agents/pending-final-delivery-marker.ts
@@ -45,7 +45,8 @@ export async function persistPendingFinalDeliveryMarker(
     params.payloads.length === 0 ||
     isSubagentSessionKey(params.sessionKey) ||
     !recoverableText ||
-    !hasSendableFinalPayload
+    !hasSendableFinalPayload ||
+    !params.deliveryContext
   ) {
     return {
       sessionEntry: params.sessionEntry,
@@ -75,7 +76,7 @@ export async function persistPendingFinalDeliveryMarker(
         kind: "replayable",
         text: recoverableText,
         createdAt: now,
-        ...(params.deliveryContext ? { context: params.deliveryContext } : {}),
+        context: params.deliveryContext,
       },
       updatedAt: now,
     },

--- a/src/gateway/agent-turn/agent-delivery-phase.ts
+++ b/src/gateway/agent-turn/agent-delivery-phase.ts
@@ -99,7 +99,7 @@ export async function resolveAgentDeliveryPhase(params: {
   const resolvedAccountId = deliveryPlan.resolvedAccountId;
   let resolvedTo = deliveryPlan.resolvedTo;
   let effectivePlan = deliveryPlan;
-  let deliveryDowngradeReason: string | null = null;
+  let deliveryResolutionError: string | null = null;
   let deliveryTargetResolutionError: Error | undefined = deliveryPlan.targetResolutionError;
 
   if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL) {
@@ -127,25 +127,17 @@ export async function resolveAgentDeliveryPhase(params: {
         params.respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, formatForLog(err)));
         return undefined;
       }
-      deliveryDowngradeReason = String(err);
+      deliveryResolutionError = String(err);
     }
   }
 
-  if (wantsDelivery && deliveryTargetResolutionError) {
-    if (!params.bestEffortDeliver) {
-      params.respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, String(deliveryTargetResolutionError)),
-      );
-      return undefined;
-    }
-    deliveryDowngradeReason = String(deliveryTargetResolutionError);
-    resolvedChannel = INTERNAL_MESSAGE_CHANNEL;
-    deliveryTargetMode = undefined;
-    resolvedTo = undefined;
-    const { plugin: _plugin, ...pluginFreePlan } = deliveryPlan;
-    effectivePlan = { ...pluginFreePlan, resolvedChannel, resolvedTo, deliveryTargetMode };
+  if (wantsDelivery && deliveryTargetResolutionError && !params.bestEffortDeliver) {
+    params.respond(
+      false,
+      undefined,
+      errorShape(ErrorCodes.INVALID_REQUEST, String(deliveryTargetResolutionError)),
+    );
+    return undefined;
   }
 
   if (!resolvedTo && isDeliverableMessageChannel(resolvedChannel)) {
@@ -202,9 +194,9 @@ export async function resolveAgentDeliveryPhase(params: {
       return undefined;
     }
     params.context.logGateway.info(
-      deliveryDowngradeReason
-        ? `agent delivery downgraded to session-only (bestEffortDeliver): ${deliveryDowngradeReason}`
-        : "agent delivery downgraded to session-only (bestEffortDeliver): no deliverable channel",
+      deliveryResolutionError
+        ? `agent delivery unresolved (bestEffortDeliver); final delivery will report: ${deliveryResolutionError}`
+        : "agent delivery unresolved (bestEffortDeliver); final delivery will report: no deliverable channel",
     );
   }
 
@@ -227,7 +219,7 @@ export async function resolveAgentDeliveryPhase(params: {
       (params.client?.connect && params.isWebchatConnect(params.client.connect)
         ? INTERNAL_MESSAGE_CHANNEL
         : resolvedChannel),
-    deliver: wantsDelivery && resolvedChannel !== INTERNAL_MESSAGE_CHANNEL,
+    deliver: wantsDelivery,
     explicitThreadId,
   };
 }

--- a/src/gateway/server-methods/agent.events-and-subagents.test-utils.ts
+++ b/src/gateway/server-methods/agent.events-and-subagents.test-utils.ts
@@ -657,7 +657,7 @@ describe("gateway agent handler", () => {
     expectStringFieldContains(error, "message", "requires target");
   });
 
-  it("downgrades to session-only when bestEffortDeliver=true and no external channel is configured", async () => {
+  it("preserves requested delivery when best effort has no external channel", async () => {
     mocks.agentCommand.mockClear();
     primeMainAgentRun();
     const respond = vi.fn();
@@ -687,7 +687,7 @@ describe("gateway agent handler", () => {
       },
     );
 
-    await waitForAgentCommandCall();
+    const callArgs = await waitForAgentCommandCall<{ deliver?: boolean; channel?: string }>();
     const accepted = respond.mock.calls.find(
       (call: unknown[]) =>
         call[0] === true && (call[1] as Record<string, unknown>)?.status === "accepted",
@@ -697,9 +697,10 @@ describe("gateway agent handler", () => {
     });
     const rejected = respond.mock.calls.find((call: unknown[]) => call[0] === false);
     expect(rejected).toBeUndefined();
+    expect(callArgs).toMatchObject({ deliver: true, channel: "webchat" });
     expect(logInfo).toHaveBeenCalledTimes(1);
     expect(mockCallArg(logInfo)).toContain(
-      "agent delivery downgraded to session-only (bestEffortDeliver)",
+      "agent delivery unresolved (bestEffortDeliver); final delivery will report",
     );
   });
 

--- a/src/gateway/server.agent.gateway-server-agent-b.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-b.test.ts
@@ -372,7 +372,7 @@ describe("gateway server agent", () => {
     expect(res.error?.code).toBe("INVALID_REQUEST");
   });
 
-  test("agent downgrades to session-only when multiple channels are configured but no external target resolves", async () => {
+  test("agent preserves requested delivery when no external target resolves", async () => {
     const registry = createRegistry([
       {
         pluginId: "discord",
@@ -399,7 +399,7 @@ describe("gateway server agent", () => {
     expect(res.ok).toBe(true);
     await expectAgentRoutingCall({
       channel: "webchat",
-      deliver: false,
+      deliver: true,
       runId: "idem-agent-multi-configured-best-effort",
     });
   });

--- a/src/gateway/server.agent.rpc-contracts.test.ts
+++ b/src/gateway/server.agent.rpc-contracts.test.ts
@@ -15,6 +15,14 @@ type AgentResponse = {
   payload?: {
     runId?: string;
     status?: string;
+    result?: {
+      payloads?: Array<{ text?: string }>;
+      deliveryStatus?: {
+        requested?: boolean;
+        attempted?: boolean;
+        reason?: string;
+      };
+    };
   };
 };
 
@@ -55,10 +63,23 @@ function sendAgentRequest(params: {
 }
 
 describe("gateway agent RPC contracts", () => {
-  test("downgrades ambiguous delivery and replays one ordered run across reconnect", async () => {
+  test("preserves requested delivery status across ordered final response and replay", async () => {
     const runCompletion = createDeferred();
     vi.mocked(agentCommand).mockImplementationOnce(async () => {
       await runCompletion.promise;
+      return {
+        payloads: [{ text: "assistant reply" }],
+        meta: { durationMs: 1 },
+        deliverySucceeded: false,
+        deliveryStatus: {
+          requested: true,
+          attempted: false,
+          status: "failed",
+          succeeded: false,
+          error: true,
+          reason: "channel_resolved_to_internal",
+        },
+      };
     });
 
     const idempotencyKey = "gateway-agent-rpc-contract";
@@ -99,7 +120,7 @@ describe("gateway agent RPC contracts", () => {
       runId: idempotencyKey,
       channel: "webchat",
       messageChannel: "webchat",
-      deliver: false,
+      deliver: true,
       bestEffortDeliver: true,
     });
 
@@ -124,6 +145,14 @@ describe("gateway agent RPC contracts", () => {
       payload: {
         runId: idempotencyKey,
         status: "ok",
+        result: {
+          payloads: [{ text: "assistant reply" }],
+          deliveryStatus: {
+            requested: true,
+            attempted: false,
+            reason: "channel_resolved_to_internal",
+          },
+        },
       },
     });
 
@@ -148,6 +177,11 @@ describe("gateway agent RPC contracts", () => {
       const replay = await replayPromise;
       expect(replay.payload).toEqual(terminal.payload);
       expect(replay.payload?.status).toBe("ok");
+      expect(replay.payload?.result?.deliveryStatus).toMatchObject({
+        requested: true,
+        attempted: false,
+        reason: "channel_resolved_to_internal",
+      });
       expect(agentCommand).toHaveBeenCalledTimes(1);
     } finally {
       second.ws.close();


### PR DESCRIPTION
Closes #121804

## What Problem This Solves

Fixes an issue where an explicit best-effort `openclaw agent --deliver` request could finish with assistant text and `status: ok` while neither sending the reply nor returning a `deliveryStatus`. This occurred when the requested channel or target could not be resolved before the model run.

## Why This Change Was Made

Requested delivery intent now survives best-effort Gateway and agent preflight so the canonical final-delivery owner can either send or record the concrete failure. Strict preflight behavior is unchanged. Restart-recovery markers are persisted only when preflight prepared a concrete `DeliveryContext`, preventing an unresolved request from being replayed later through a session fallback.

## User Impact

Automation can reliably distinguish a generated reply from a delivered reply. Missing, invalid, or internally resolved targets now produce an authoritative non-delivery status instead of a successful-looking response with no send evidence.

## Evidence

- Before: a controlled external-channel delivery probe returned assistant text with `status: ok`, omitted `deliveryStatus`, and produced no matching outgoing channel row.
- Focused regression proof: 401 tests passed across agent command preflight, real Gateway WebSocket accepted/final ordering, idempotent replay, the aggregate Gateway agent suite, and the sibling multi-channel routing contract selected by CI.
- `git diff --check`: passed.
- Targeted `oxfmt --check`: passed.
- Structured autoreview: clean; no accepted/actionable findings.
- Blacksmith Testbox `tbx_01kzqbactezm26a4kmm2jss730`: packaged `pnpm build` plus changed-surface formatting, API contracts, boundary guards, dead-export scans, typechecks, lint, and import-cycle checks passed. [Run](https://github.com/openclaw/openclaw/actions/runs/31453287390)
- Production delta is net-negative: the old intent-erasing downgrade path was removed.
- Post-fix live channel proof is intentionally pending until the code is deployed; the prior outcome was not retried because its delivery result was uncertain.

AI-assisted implementation; the patch and tests were manually reviewed.