### PR TITLE
fix(ui): hide agent selectors for single-agent setups

### DIFF
--- a/ui/src/components/agent-scope-control.test.ts
+++ b/ui/src/components/agent-scope-control.test.ts
@@ -23,6 +23,31 @@ function createSelection(setScope: (agentId: string | null) => void) {
 }
 
 describe("renderAgentScopeControl", () => {
+  it("renders only when multiple configured agents are selectable", () => {
+    const container = document.createElement("div");
+    const renderAgents = (agents: Array<{ id: string; name: string }>) => {
+      render(
+        renderAgentScopeControl({
+          agents,
+          selection: createSelection(vi.fn()),
+        }),
+        container,
+      );
+    };
+
+    renderAgents([]);
+    expect(container.querySelector(".agent-scope-control")).toBeNull();
+
+    renderAgents([{ id: "main", name: "Main agent" }]);
+    expect(container.querySelector(".agent-scope-control")).toBeNull();
+
+    renderAgents([
+      { id: "main", name: "Main agent" },
+      { id: "writer", name: "Writer" },
+    ]);
+    expect(container.querySelector(".agent-scope-control")).not.toBeNull();
+  });
+
   it("does not wrap dropdown options in a label that reactivates the trigger", async () => {
     const container = document.createElement("div");
     document.body.append(container);
@@ -55,7 +80,10 @@ describe("renderAgentScopeControl", () => {
 
     render(
       renderAgentScopeControl({
-        agents: [{ id: "main", name: "Main agent", identity: { emoji: "🦞" } }],
+        agents: [
+          { id: "main", name: "Main agent", identity: { emoji: "🦞" } },
+          { id: "writer", name: "Writer" },
+        ],
         additionalAgentIds: ["retired"],
         selection: createSelection(setScope),
       }),
@@ -65,7 +93,12 @@ describe("renderAgentScopeControl", () => {
     const select = container.querySelector<AgentSelectElement>("openclaw-agent-select");
     expect(select).not.toBeNull();
     await select?.updateComplete;
-    expect(select?.options.map((option) => option.value)).toEqual(["", "main", "retired"]);
+    expect(select?.options.map((option) => option.value)).toEqual([
+      "",
+      "main",
+      "retired",
+      "writer",
+    ]);
     expect(select?.querySelector(".agent-select__avatar--text")?.getAttribute("data-avatar")).toBe(
       "🦞",
     );

--- a/ui/src/components/agent-scope-control.ts
+++ b/ui/src/components/agent-scope-control.ts
@@ -1,4 +1,4 @@
-import { html } from "lit";
+import { html, nothing } from "lit";
 import type { GatewayAgentRow } from "../api/types.ts";
 import type { AgentSelectionCapability } from "../app/agent-selection.ts";
 import { t } from "../i18n/index.ts";
@@ -26,6 +26,9 @@ export function renderAgentScopeControl(params: AgentScopeControlParams) {
       (agent) => agent.kind === "system" && normalizeAgentId(agent.id) === agentId,
     );
   const selectableAgents = listSelectableAgents(params.agents);
+  if (selectableAgents.length <= 1) {
+    return nothing;
+  }
   const agentsById = new Map(
     selectableAgents.map((agent) => {
       const agentId = normalizeAgentId(agent.id);

--- a/ui/src/e2e/agent-select-avatar-timeout.e2e.test.ts
+++ b/ui/src/e2e/agent-select-avatar-timeout.e2e.test.ts
@@ -60,10 +60,35 @@ suite.define(() => {
         const gateway = await installMockGateway(page, {
           methodResponses: {
             "agent.identity.get": {
-              agentId: "main",
-              avatar: "/avatar/main",
-              avatarStatus: "local",
-              name: "Main agent",
+              cases: [
+                {
+                  match: { agentId: "main" },
+                  response: {
+                    agentId: "main",
+                    avatar: "/avatar/main",
+                    avatarStatus: "local",
+                    name: "Main agent",
+                  },
+                },
+                {
+                  match: { agentId: "writer" },
+                  response: {
+                    agentId: "writer",
+                    avatar: "",
+                    avatarStatus: "none",
+                    name: "Writer",
+                  },
+                },
+              ],
+            },
+            "agents.list": {
+              agents: [
+                { id: "main", name: "OpenClaw" },
+                { id: "writer", name: "Writer" },
+              ],
+              defaultId: "main",
+              mainKey: "main",
+              scope: "agent",
             },
           },
         });

--- a/ui/src/e2e/usage-cost-analysis.e2e.test.ts
+++ b/ui/src/e2e/usage-cost-analysis.e2e.test.ts
@@ -164,6 +164,15 @@ suite.define(() => {
       async ({ page }) => {
         const gateway = await installMockGateway(page, {
           methodResponses: {
+            "agents.list": {
+              agents: [
+                { id: "main", name: "Main" },
+                { id: "writer", name: "Writer" },
+              ],
+              defaultId: "main",
+              mainKey: "main",
+              scope: "agent",
+            },
             "sessions.usage": {
               updatedAt: Date.now(),
               startDate: dayOffset(-89),

--- a/ui/src/pages/agents/view.agent-selector.test.ts
+++ b/ui/src/pages/agents/view.agent-selector.test.ts
@@ -1,0 +1,34 @@
+// Control UI tests cover agent-selector behavior.
+import { render } from "lit";
+import { describe, expect, it, vi } from "vitest";
+import { t } from "../../i18n/index.ts";
+import { createAgentViewTestProps as createProps } from "./agents-view.test-helpers.ts";
+import { renderAgents } from "./view.ts";
+
+describe("renderAgents agent selector", () => {
+  it("hides the selector for one agent and keeps agent creation available", () => {
+    const container = document.createElement("div");
+    const onCreateAgent = vi.fn();
+    render(
+      renderAgents(
+        createProps({
+          agentsList: {
+            defaultId: "alpha",
+            mainKey: "main",
+            scope: "per-sender",
+            agents: [{ id: "alpha", name: "Alpha" }],
+          },
+          selectedAgentId: "alpha",
+          onCreateAgent,
+        }),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".agents-control-select")).toBeNull();
+    const createButton = container.querySelector<HTMLButtonElement>(".agents-create-btn");
+    expect(createButton?.textContent?.trim()).toBe(t("custodian.newAgent"));
+    createButton?.click();
+    expect(onCreateAgent).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/src/pages/agents/view.test.ts
+++ b/ui/src/pages/agents/view.test.ts
@@ -304,6 +304,32 @@ describe("renderAgents", () => {
     }
   });
 
+  it("hides the agent selector for one agent and keeps agent creation available", () => {
+    const container = document.createElement("div");
+    const onCreateAgent = vi.fn();
+    render(
+      renderAgents(
+        createProps({
+          agentsList: {
+            defaultId: "alpha",
+            mainKey: "main",
+            scope: "per-sender",
+            agents: [{ id: "alpha", name: "Alpha" }],
+          },
+          selectedAgentId: "alpha",
+          onCreateAgent,
+        }),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".agents-control-select")).toBeNull();
+    const createButton = container.querySelector<HTMLButtonElement>(".agents-create-btn");
+    expect(createButton?.textContent?.trim()).toBe(t("custodian.newAgent"));
+    createButton?.click();
+    expect(onCreateAgent).toHaveBeenCalledOnce();
+  });
+
   it("selects the configured primary model on initial render", async () => {
     const container = document.createElement("div");
     const configForm = {

--- a/ui/src/pages/agents/view.test.ts
+++ b/ui/src/pages/agents/view.test.ts
@@ -304,32 +304,6 @@ describe("renderAgents", () => {
     }
   });
 
-  it("hides the agent selector for one agent and keeps agent creation available", () => {
-    const container = document.createElement("div");
-    const onCreateAgent = vi.fn();
-    render(
-      renderAgents(
-        createProps({
-          agentsList: {
-            defaultId: "alpha",
-            mainKey: "main",
-            scope: "per-sender",
-            agents: [{ id: "alpha", name: "Alpha" }],
-          },
-          selectedAgentId: "alpha",
-          onCreateAgent,
-        }),
-      ),
-      container,
-    );
-
-    expect(container.querySelector(".agents-control-select")).toBeNull();
-    const createButton = container.querySelector<HTMLButtonElement>(".agents-create-btn");
-    expect(createButton?.textContent?.trim()).toBe(t("custodian.newAgent"));
-    createButton?.click();
-    expect(onCreateAgent).toHaveBeenCalledOnce();
-  });
-
   it("selects the configured primary model on initial render", async () => {
     const container = document.createElement("div");
     const configForm = {

--- a/ui/src/pages/agents/view.ts
+++ b/ui/src/pages/agents/view.ts
@@ -195,19 +195,34 @@ export function renderAgents(props: AgentsProps) {
     <div class="agents-layout">
       <section class="agents-toolbar">
         <div class="agents-toolbar-row">
-          <div class="agents-control-select">
-            <openclaw-agent-select
-              .options=${agentOptions}
-              .value=${selectedId ?? ""}
-              .accessibleLabel=${t("usage.filters.agent")}
-              .identityById=${props.agentIdentityById}
-              .authToken=${props.authToken}
-              .disabled=${props.loading}
-              .onSelect=${props.onSelectAgent}
-              .onCreateAgent=${props.access.canCreateAgent ? props.onCreateAgent : null}
-            ></openclaw-agent-select>
-          </div>
+          ${agentOptions.length > 1
+            ? html`
+                <div class="agents-control-select">
+                  <openclaw-agent-select
+                    .options=${agentOptions}
+                    .value=${selectedId ?? ""}
+                    .accessibleLabel=${t("usage.filters.agent")}
+                    .identityById=${props.agentIdentityById}
+                    .authToken=${props.authToken}
+                    .disabled=${props.loading}
+                    .onSelect=${props.onSelectAgent}
+                    .onCreateAgent=${props.access.canCreateAgent ? props.onCreateAgent : null}
+                  ></openclaw-agent-select>
+                </div>
+              `
+            : nothing}
           <div class="agents-toolbar-actions">
+            ${agentOptions.length <= 1 && props.access.canCreateAgent
+              ? html`
+                  <button
+                    class="btn btn--sm btn--ghost agents-create-btn"
+                    ?disabled=${props.loading}
+                    @click=${props.onCreateAgent}
+                  >
+                    ${t("custodian.newAgent")}
+                  </button>
+                `
+              : nothing}
             ${selectedAgent
               ? html`
                   <button

--- a/ui/src/pages/config/memory.test.ts
+++ b/ui/src/pages/config/memory.test.ts
@@ -74,6 +74,22 @@ function renderInto(props: MemoryViewProps): HTMLElement {
 }
 
 describe("renderMemory", () => {
+  it("renders the agent scope only for multiple configured agents", () => {
+    const emptyRoster = renderInto(createProps({ activeTab: "overview", agents: [] }));
+    expect(emptyRoster.querySelector(".agent-scope-control")).toBeNull();
+
+    const singleAgent = renderInto(
+      createProps({
+        activeTab: "overview",
+        agents: [{ value: "main", label: "Main" }],
+      }),
+    );
+    expect(singleAgent.querySelector(".agent-scope-control")).toBeNull();
+
+    const multipleAgents = renderInto(createProps({ activeTab: "overview" }));
+    expect(multipleAgents.querySelector(".agent-scope-control")).not.toBeNull();
+  });
+
   it.each(["overview", "memories", "dreams"] as const)(
     "renders the shared header and agent scope on %s",
     (activeTab) => {

--- a/ui/src/pages/config/memory.ts
+++ b/ui/src/pages/config/memory.ts
@@ -419,7 +419,7 @@ export function renderMemory(props: MemoryViewProps) {
           })}
         </div>
         <div class="hub-page-header__actions">
-          ${props.activeTab === "settings"
+          ${props.activeTab === "settings" || props.agents.length <= 1
             ? nothing
             : html`
                 <div class="agent-scope-control">

--- a/ui/src/pages/memory-import/view.test.ts
+++ b/ui/src/pages/memory-import/view.test.ts
@@ -124,6 +124,14 @@ describe("renderMemoryImport", () => {
     expect(container.textContent).not.toContain("private memory body");
   });
 
+  it("hides the agent row when only one agent is configured", () => {
+    const container = document.createElement("div");
+    render(renderMemoryImport(createProps()), container);
+
+    expect(container.querySelector('openclaw-agent-select[name="memory-import-agent"]')).toBeNull();
+    expect(container.textContent).not.toContain("Destination agent");
+  });
+
   it("renders the avatar agent picker and routes agent changes", async () => {
     const onSelectAgent = vi.fn();
     const container = document.createElement("div");
@@ -275,6 +283,10 @@ describe("renderMemoryImport", () => {
     render(
       renderMemoryImport(
         createProps({
+          agents: [
+            { id: "research", name: "Research" },
+            { id: "writer", name: "Writer" },
+          ],
           pendingProviderId: "codex",
           applyingProviderId: "codex",
           onConfirmImport,

--- a/ui/src/pages/memory-import/view.ts
+++ b/ui/src/pages/memory-import/view.ts
@@ -436,24 +436,26 @@ function renderIntroSection(props: MemoryImportViewProps) {
       `,
     },
     html`
-      ${renderSettingsRow({
-        title: t("memoryImport.agent"),
-        control: html`
-          <openclaw-agent-select
-            class="agent-select--settings"
-            name="memory-import-agent"
-            .options=${props.agents.map((agent) => ({
-              value: agent.id,
-              label: normalizeAgentLabel(agent),
-              agent,
-            }))}
-            .value=${props.selectedAgentId ?? ""}
-            .accessibleLabel=${t("memoryImport.agent")}
-            .disabled=${busy}
-            .onSelect=${props.onSelectAgent}
-          ></openclaw-agent-select>
-        `,
-      })}
+      ${props.agents.length > 1
+        ? renderSettingsRow({
+            title: t("memoryImport.agent"),
+            control: html`
+              <openclaw-agent-select
+                class="agent-select--settings"
+                name="memory-import-agent"
+                .options=${props.agents.map((agent) => ({
+                  value: agent.id,
+                  label: normalizeAgentLabel(agent),
+                  agent,
+                }))}
+                .value=${props.selectedAgentId ?? ""}
+                .accessibleLabel=${t("memoryImport.agent")}
+                .disabled=${busy}
+                .onSelect=${props.onSelectAgent}
+              ></openclaw-agent-select>
+            `,
+          })
+        : nothing}
       ${renderSettingsToggleRow({
         title: t("memoryImport.replaceExisting"),
         description: t("memoryImport.replaceHint"),

--- a/ui/src/pages/skills/view.test.ts
+++ b/ui/src/pages/skills/view.test.ts
@@ -129,6 +129,27 @@ describe("renderSkills", () => {
     await i18n.setLocale("en");
   });
 
+  it("hides the agent selector when only one agent is configured", () => {
+    const container = document.createElement("div");
+    render(
+      renderSkills(
+        createProps({
+          agentsList: {
+            defaultId: "main",
+            mainKey: "main",
+            scope: "per-sender",
+            agents: [{ id: "main", name: "Main" }],
+          },
+          selectedAgentId: "main",
+        }),
+      ),
+      container,
+    );
+
+    expect(container.querySelector('openclaw-agent-select[name="skills-agent"]')).toBeNull();
+    expect(container.querySelector('input[name="skills-filter"]')).toBeInstanceOf(HTMLInputElement);
+  });
+
   it("renders the agent selector and routes agent changes", async () => {
     const container = document.createElement("div");
     document.body.append(container);

--- a/ui/src/pages/skills/view.ts
+++ b/ui/src/pages/skills/view.ts
@@ -335,7 +335,7 @@ function renderSkillsToolbar(
         })),
         onChange: (value) => props.onStatusFilterChange(value),
       })}
-      ${agents.length > 0
+      ${agents.length > 1
         ? html`
             <div class="plugins-field skills-toolbar__agent">
               <span>${t("usage.filters.agent")}</span>
@@ -355,7 +355,7 @@ function renderSkillsToolbar(
                 })}
                 .value=${selectedAgentId}
                 .accessibleLabel=${t("usage.filters.agent")}
-                .disabled=${skillControlsLocked(props) || !props.connected || agents.length < 2}
+                .disabled=${skillControlsLocked(props) || !props.connected}
                 .onSelect=${props.onAgentChange}
               ></openclaw-agent-select>
             </div>


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where single-agent Control UI setups showed agent pickers that could not select anything else, adding visual noise across settings pages.

## Why This Change Was Made

Agent selectors now render only when more than one configured selectable agent exists. The shared page-scope renderer owns the common case, while the Agents, Skills, Memory, and Memory Import settings surfaces apply the same rule at their local render boundaries. The Agents page keeps the authorized New agent action available outside the hidden picker.

Selectors with distinct non-agent semantics, such as defaults versus overrides or unassigned workboard items, are intentionally unchanged.

AI-assisted: yes. The implementation was manually inspected, behavior-tested, and independently autoreviewed.

## User Impact

Operators with zero or one configured agent get a simpler settings UI without disabled or redundant agent controls. Multi-agent setups keep the existing selectors and switching behavior.

## Evidence

Pre-fix regression proof: the five new boundary assertions failed against the original production code because every redundant selector was present; 82 existing focused assertions passed in the same run.

Post-fix proof:
- Focused UI suite: 87 tests passed across six files
- Mocked Chromium: one-agent Agents and Tasks selectors hidden; two-agent Agents picker visible and switchable; authorized New agent navigation preserved
- Initial exact-head CI exposed two existing picker-specific E2E fixtures whose mock rosters contained only one agent; both were reproduced locally and repaired to declare two agents
- Repaired E2E files: 3 tests passed across agent-select-avatar-timeout and usage-cost-analysis
- Final changed gate: passed on Blacksmith Testbox tbx_01kzqdtnrr9645b1khnrh1t80y, Actions run 31455495526
- Final combined branch autoreview: clean, no accepted/actionable findings
- Production LOC: +54/-34 (+20), primarily preserving the New agent action after removing its picker host; tests: +156/-6

### Agents settings

Before:

![Agents settings before](https://github.com/user-attachments/assets/895365d2-548a-48be-8283-87fd24beaf2c)

After:

![Agents settings after](https://github.com/user-attachments/assets/7599ac5b-0992-41bf-8291-ef7c2805256b)

### Shared page scope

Before:

![Tasks page before](https://github.com/user-attachments/assets/cfbcafa5-4579-45e3-9362-cf1ef9bfc5a3)

After:

![Tasks page after](https://github.com/user-attachments/assets/71134de4-8f3f-492e-a27b-5f8837092f4a)
