### PR TITLE
fix(gateway): serve Control UI assistant media for uppercase file URLs

### DIFF
--- a/src/gateway/control-ui-assistant-media.e2e.test.ts
+++ b/src/gateway/control-ui-assistant-media.e2e.test.ts
@@ -1,6 +1,7 @@
 // Control UI assistant media e2e tests verify scoped media-ticket access through gateway HTTP routes.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, expect, test } from "vitest";
 import { installGatewayTestHooks, testState, withGatewayServer } from "./test-helpers.js";
 
@@ -50,6 +51,26 @@ describe("Control UI assistant media e2e", () => {
           `attachment; filename="__ ticketed (final).txt"; filename*=UTF-8''%E6%B5%8B%E8%AF%95%20ticketed%20%28final%29.txt`,
         );
         expect(await ticketed.text()).toBe("ticketed control ui media\n");
+
+        const fileUrl = pathToFileURL(filePath).href;
+        for (const source of [
+          fileUrl,
+          fileUrl.replace(/^file:/u, "FILE:"),
+          fileUrl.replace(/^file:\/\//u, "file:"),
+          fileUrl.replace(/^file:\/\//u, "FILE:"),
+        ]) {
+          const equivalent = await fetch(
+            `${route}?source=${encodeURIComponent(source)}&mediaTicket=${encodeURIComponent(payload.mediaTicket ?? "")}`,
+          );
+          expect(equivalent.status, source).toBe(200);
+          expect(await equivalent.text()).toBe("ticketed control ui media\n");
+        }
+        for (const source of ["file://evil-host/etc/hostname", "FILE://evil-host/etc/hostname"]) {
+          const remoteHost = await fetch(`${route}?source=${encodeURIComponent(source)}`, {
+            headers: { Authorization: `Bearer ${CONTROL_UI_E2E_TOKEN}` },
+          });
+          expect(remoteHost.status, source).toBe(404);
+        }
 
         const ranged = await fetch(
           `${route}?source=${sourceParam}&mediaTicket=${encodeURIComponent(payload.mediaTicket ?? "")}`,

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -220,7 +220,7 @@ function normalizeAssistantMediaSource(source: string): string | null {
   if (!trimmed) {
     return null;
   }
-  if (trimmed.startsWith("file://")) {
+  if (/^file:/iu.test(trimmed)) {
     try {
       return safeFileURLToPath(trimmed);
     } catch {

--- a/src/gateway/server-methods/chat-webchat-media.test.ts
+++ b/src/gateway/server-methods/chat-webchat-media.test.ts
@@ -159,34 +159,43 @@ describe("webchat audio blocks through assistant messages", () => {
     expect(blocks).toHaveLength(1);
   });
 
-  it("embeds file:// URLs pointing at a local file within localRoots", async () => {
-    const { audioPath, localRoot } = writeAudioFixture([0x01]);
+  it.each(["file://", "FILE://", "FiLe://", "file:", "FILE:"])(
+    "embeds %s URLs pointing at a local file within localRoots",
+    async (scheme) => {
+      const { audioPath, localRoot } = writeAudioFixture([0x01]);
 
-    const fileUrl = pathToFileURL(audioPath).href;
-    const blocks = await buildWebchatAudioBlocks([{ mediaUrl: fileUrl, trustedLocalMedia: true }], {
-      localRoots: [localRoot],
-    });
+      const fileUrl = pathToFileURL(audioPath).href.replace(/^file:\/\/\//, `${scheme}/`);
+      const blocks = await buildWebchatAudioBlocks(
+        [{ mediaUrl: fileUrl, trustedLocalMedia: true }],
+        {
+          localRoots: [localRoot],
+        },
+      );
 
-    expect(blocks).toHaveLength(1);
-    expect((blocks[0] as { type?: string }).type).toBe("attachment");
-  });
+      expect(blocks).toHaveLength(1);
+      expect((blocks[0] as { type?: string }).type).toBe("attachment");
+    },
+  );
 
-  it("drops tool-result file:// URLs with remote hosts before touching the filesystem", async () => {
-    const openSpy = vi.spyOn(fsPromises, "open");
+  it.each(["file://attacker/share/probe.mp3", "FILE://attacker/share/probe.mp3"])(
+    "drops tool-result %s URLs with remote hosts before touching the filesystem",
+    async (source) => {
+      const openSpy = vi.spyOn(fsPromises, "open");
 
-    const blocks = await buildWebchatAudioBlocks([
-      {
-        text: "MEDIA:file://attacker/share/probe.mp3",
-        mediaUrl: "file://attacker/share/probe.mp3",
-        trustedLocalMedia: true,
-      },
-    ]);
+      const blocks = await buildWebchatAudioBlocks([
+        {
+          text: `MEDIA:${source}`,
+          mediaUrl: source,
+          trustedLocalMedia: true,
+        },
+      ]);
 
-    expect(blocks).toHaveLength(0);
-    expect(openSpy).not.toHaveBeenCalled();
+      expect(blocks).toHaveLength(0);
+      expect(openSpy).not.toHaveBeenCalled();
 
-    openSpy.mockRestore();
-  });
+      openSpy.mockRestore();
+    },
+  );
 
   it("rejects a local audio file outside configured localRoots", async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-webchat-audio-"));

--- a/src/gateway/server-methods/chat-webchat-media.ts
+++ b/src/gateway/server-methods/chat-webchat-media.ts
@@ -53,7 +53,7 @@ function resolveLocalMediaPathForEmbedding(raw: string): string | null {
   if (/^https?:/i.test(trimmed)) {
     return null;
   }
-  if (trimmed.startsWith("file:")) {
+  if (/^file:/iu.test(trimmed)) {
     try {
       const p = safeFileURLToPath(trimmed);
       if (!path.isAbsolute(p)) {

--- a/ui/src/e2e/chat-flow.media-files.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.media-files.e2e.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import {
@@ -85,9 +85,25 @@ suite.define(() => {
       source: "/home/node/.openclaw/media/outbound/bootstrap-image.png",
       ticket: "ticket-bootstrap-image",
     },
+    {
+      kind: "image",
+      source: "FILE:///home/node/.openclaw/media/outbound/bootstrap-uppercase-image.png",
+      ticket: "ticket-bootstrap-uppercase-image",
+    },
+    {
+      kind: "image",
+      source: "file:/home/node/.openclaw/media/outbound/bootstrap-authorityless-image.png",
+      ticket: "ticket-bootstrap-authorityless-image",
+    },
+    {
+      kind: "audio",
+      source: "FILE:/home/node/.openclaw/media/outbound/bootstrap-structured-audio.mp3",
+      ticket: "ticket-bootstrap-structured-audio",
+      structured: true,
+    },
   ] as const)(
     "renders local assistant $kind through server metadata before preview roots load",
-    async ({ kind, source, ticket }) => {
+    async ({ kind, source, ticket, ...options }) => {
       const context = await suite.newBrowserContext({
         locale: "en-US",
         serviceWorkers: "block",
@@ -120,10 +136,7 @@ suite.define(() => {
           kind === "image"
             ? {
                 contentType: "image/png",
-                body: Buffer.from(
-                  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Zl1sAAAAASUVORK5CYII=",
-                  "base64",
-                ),
+                body: await readFile(path.join(process.cwd(), "ui/public/apple-touch-icon.png")),
               }
             : {
                 contentType: "audio/mpeg",
@@ -144,7 +157,10 @@ suite.define(() => {
             : {
                 id: "assistant-bootstrap-local-audio",
                 role: "assistant",
-                content: [{ type: "text", text: `Your recording\nMEDIA:${source}` }],
+                content:
+                  "structured" in options
+                    ? [{ type: "audio", url: source, fileName: "bootstrap-structured-audio.mp3" }]
+                    : [{ type: "text", text: `Your recording\nMEDIA:${source}` }],
                 timestamp: Date.now(),
               },
         ],
@@ -172,7 +188,7 @@ suite.define(() => {
                 element instanceof HTMLImageElement && element.complete ? element.naturalWidth : 0,
               ),
             )
-            .toBe(1);
+            .toBe(180);
         }
 
         const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
@@ -180,7 +196,7 @@ suite.define(() => {
           await mkdir(artifactDir, { recursive: true });
           await page.screenshot({
             fullPage: true,
-            path: path.join(artifactDir, `bootstrap-local-${kind}.png`),
+            path: path.join(artifactDir, `bootstrap-local-${kind}-${ticket}.png`),
           });
         }
         if (process.env.OPENCLAW_BEHAVIOR_PROOF === "1") {

--- a/ui/src/e2e/chat-flow.media-files.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.media-files.e2e.test.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import {
+  buildLocalWebchatAudioMessage,
   captureUiProofEnabled,
   copiedViaExec,
   createChatFlowE2eSuite,
@@ -97,7 +98,7 @@ suite.define(() => {
     },
     {
       kind: "audio",
-      source: "FILE:/home/node/.openclaw/media/outbound/bootstrap-structured-audio.mp3",
+      source: `FILE:${path.join(managedImageCacheProofDir, "bootstrap-structured-audio.mp3")}`,
       ticket: "ticket-bootstrap-structured-audio",
       structured: true,
     },
@@ -111,12 +112,13 @@ suite.define(() => {
       });
       const page = await context.newPage();
       const requestedMediaUrls: URL[] = [];
+      const expectedSource = "structured" in options ? new URL(source).pathname : source;
 
       await page.route("**/__openclaw__/assistant-media?**", async (route) => {
         const request = route.request();
         const url = new URL(request.url());
         requestedMediaUrls.push(url);
-        expect(url.searchParams.get("source")).toBe(source);
+        expect(url.searchParams.get("source")).toBe(expectedSource);
         if (url.searchParams.get("meta") === "1") {
           expect(request.headers().authorization).toBe("Bearer e2e-device-token");
           await route.fulfill({
@@ -159,7 +161,7 @@ suite.define(() => {
                 role: "assistant",
                 content:
                   "structured" in options
-                    ? [{ type: "audio", url: source, fileName: "bootstrap-structured-audio.mp3" }]
+                    ? (await buildLocalWebchatAudioMessage(source)).content
                     : [{ type: "text", text: `Your recording\nMEDIA:${source}` }],
                 timestamp: Date.now(),
               },

--- a/ui/src/e2e/chat-flow.test-support.ts
+++ b/ui/src/e2e/chat-flow.test-support.ts
@@ -52,6 +52,22 @@ export function createChatFlowE2eSuite() {
   });
 }
 
+export async function buildLocalWebchatAudioMessage(source: string) {
+  const { buildWebchatAssistantMessageFromReplyPayloads } =
+    await import("../../../src/gateway/server-methods/chat-webchat-media.ts");
+  const audioPath = new URL(source).pathname;
+  const localRoot = path.dirname(audioPath);
+  await mkdir(localRoot, { recursive: true });
+  await writeFile(audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
+  return expectDefined(
+    await buildWebchatAssistantMessageFromReplyPayloads(
+      [{ mediaUrl: source, trustedLocalMedia: true }],
+      { localRoots: [localRoot] },
+    ),
+    "Gateway-produced WebChat audio message",
+  );
+}
+
 export const requireRecord = createRequireRecord("record", "expected-object-value");
 
 export function requireString(value: unknown, label: string): string {

--- a/ui/src/pages/chat/components/chat-message-local-media.ts
+++ b/ui/src/pages/chat/components/chat-message-local-media.ts
@@ -7,7 +7,7 @@ export function isLocalAssistantAttachmentSource(source: string): boolean {
   }
   return (
     isCanonicalInboundMediaSource(trimmed) ||
-    trimmed.startsWith("file://") ||
+    /^file:/iu.test(trimmed) ||
     trimmed.startsWith("~") ||
     trimmed.startsWith("/") ||
     /^[a-zA-Z]:[\\/]/.test(trimmed)
@@ -32,15 +32,15 @@ function isCanonicalInboundMediaSource(source: string): boolean {
 
 function normalizeLocalAttachmentPath(source: string): string | null {
   const trimmed = source.trim();
-  if (!isLocalAssistantAttachmentSource(trimmed)) {
+  if (!isLocalAssistantAttachmentSource(trimmed) || isCanonicalInboundMediaSource(trimmed)) {
     return null;
   }
-  if (isCanonicalInboundMediaSource(trimmed)) {
-    return null;
-  }
-  if (trimmed.startsWith("file://")) {
+  if (/^file:/iu.test(trimmed)) {
     try {
       const url = new URL(trimmed);
+      if (url.hostname || /%2f|%5c/iu.test(url.pathname)) {
+        return null;
+      }
       const pathname = decodeURIComponent(url.pathname);
       if (/^\/[a-zA-Z]:\//.test(pathname)) {
         return pathname.slice(1);


### PR DESCRIPTION
## What Problem This Solves

The Control UI can fail to display a local assistant attachment when its URI uses an uppercase or mixed-case `FILE:` scheme, or the authority-less `file:/path` spelling. The actual failure spans three owners: Gateway HTTP source normalization, WebChat assistant-audio production, and the UI's local-attachment classifier. Correcting only the HTTP route leaves raw image blocks unrecognized by the UI, while correcting only the UI leaves equivalent sources unnormalized at the route or WebChat producer.

This completes @masatohoshino's original Gateway repair across the full existing flow:

1. `src/gateway/control-ui.ts` recognizes all valid case-insensitive `file:` spellings and delegates conversion to the unchanged `safeFileURLToPath` owner before checking the existing media ticket and allowed root.
2. `src/gateway/server-methods/chat-webchat-media.ts` applies the same anchored recognition at the shared WebChat audio producer used by all three reply-finalization paths. Its existing `trustedLocalMedia`, absolute-path, safe-open, and allowed-root checks remain intact.
3. `ui/src/pages/chat/components/chat-message-local-media.ts` recognizes these same local attachment references and rejects remote-host file URLs and encoded path separators before attempting preview.

The existing managed display path can independently represent some replies, so this does not claim every producer-side miss makes an entire assistant response disappear. The observed broken behaviors are raw local image rendering and the affected WebChat audio attachment projection.

Production code is exactly **+8/-8, net zero**. No authentication, public API, protocol, configuration, storage, or file-access policy is loosened.

### Before

![Before: uppercase local assistant image remains broken](https://github.com/user-attachments/assets/98e37d96-f50d-454c-aca3-d44d0a7f8f53)

### After

![After: the local assistant image renders through authenticated metadata and a scoped ticket](https://github.com/user-attachments/assets/011c934a-59d9-4715-af64-ba0b8f4e56ec)

## Evidence

- Existing-owner regression written first: the real WebChat producer failed **3 of 31** cases for `FILE://`, `FiLe://`, and `FILE:/` against an actual local MP3. After the one-line owner repair, **31 of 31 pass**, including lowercase and authority-less URLs, trust/root controls, and uppercase remote-host rejection without opening the filesystem.
- Real isolated Gateway HTTP server: **1/1 passes**, using one issued scoped media ticket across equivalent lowercase, mixed-case, uppercase, and authority-less file URLs; remote-host requests remain **404**.
- Real Chromium/Vite Control UI: **5/5 pass**. Raw uppercase and authority-less local images decode to their actual **180px** width. Structured uppercase audio is produced by the actual Gateway `buildWebchatAssistantMessageFromReplyPayloads` owner from a real local MP3 with `trustedLocalMedia` and an allowed root; its genuine assistant content is delivered through Gateway history to the browser.
- Both browser paths verify that metadata requests carry the Gateway bearer token while the actual image/audio fetch carries only its scoped ticket.
- Independent exact-head hostile-input audit: **19 cases / 66 assertions pass**, covering remote, numeric, and IPv6 authorities; encoded slash and backslash; traversal; `localhost`; case and authority variants; Windows-style paths; and canonical inbound media.
- Focused lint and formatting pass on all seven changed files; independent source review inspected all three producer/caller boundaries. Browser test support loads Gateway code lazily so unrelated UI suites do not pay the server import cost.

Reproduction and focused verification:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/server-methods/chat-webchat-media.test.ts
OPENCLAW_E2E_SKIP_BUILD=1 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/control-ui-assistant-media.e2e.test.ts
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.media-files.e2e.test.ts -t 'renders local assistant'
```

### Earlier review finding

The earlier ClawSweeper review correctly identified that the original route-only change missed the actual Control UI classifier. Its additional claim that `MEDIA:FILE:/...` remains plain text is not reproducible on current `main`: the existing case-insensitive `FILE_URL_PREFIX_RE` in `src/media/parse.ts` already canonicalizes that directive, and running the real `normalizeMessage` on `FILE:///tmp/a.png`, `file:/tmp/a.png`, and `FiLe:/tmp/a.mp3` produces structured attachments with canonical `/tmp/...` paths. Changing the message normalizer would duplicate a working owner and would still miss raw image blocks, which bypass that normalizer.

Original contributor credit is preserved: `Co-authored-by: masatohoshino <g515hoshino@gmail.com>`.
