### PR TITLE
test: clean up owned temp directories

### DIFF
--- a/extensions/google/index.test.ts
+++ b/extensions/google/index.test.ts
@@ -1,6 +1,5 @@
 // Google tests cover index plugin behavior.
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
-import os from "node:os";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { Context, Model } from "openclaw/plugin-sdk/llm";
@@ -19,11 +18,14 @@ import type {
   RealtimeVoiceBridgeCreateRequest,
   RealtimeVoiceProviderPlugin,
 } from "openclaw/plugin-sdk/realtime-voice";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerGoogleGeminiCliProvider } from "./gemini-cli-provider.js";
 import googlePlugin from "./index.js";
 import googleProviderDiscovery from "./provider-discovery.js";
 import { registerGoogleProvider } from "./provider-registration.js";
+import { useAutoCleanupTempDirTracker } from "./temp-dir.test-support.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const { createRealtimeBridgeMock } = vi.hoisted(() => ({
   createRealtimeBridgeMock: vi.fn<(req: RealtimeVoiceBridgeCreateRequest) => RealtimeVoiceBridge>(),
@@ -266,7 +268,7 @@ describe("google provider plugin hooks", () => {
   });
 
   it("resolves Google Vertex ADC auth evidence to the config marker", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-config-key-"));
+    const tempDir = tempDirs.make("openclaw-google-vertex-config-key-");
     const credentialsPath = path.join(tempDir, "application_default_credentials.json");
     await writeFile(
       credentialsPath,
@@ -319,7 +321,7 @@ describe("google provider plugin hooks", () => {
   });
 
   it("prefers relocated Google Cloud SDK ADC over the home fallback", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-cloud-sdk-"));
+    const tempDir = tempDirs.make("openclaw-google-vertex-cloud-sdk-");
     const cloudSdkDir = path.join(tempDir, "cloud-sdk");
     const homeCredentialsDir = path.join(tempDir, "home", ".config", "gcloud");
     await Promise.all([

--- a/extensions/google/temp-dir.test-support.ts
+++ b/extensions/google/temp-dir.test-support.ts
@@ -1,24 +1,80 @@
-// Google test temp directories are owned by the Vitest lifecycle that creates them.
+// This package-local copy mirrors test/helpers/temp-dir.ts because extension tests cannot
+// import repo-only helpers; keep it aligned so a future shared test seam can replace it.
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
-import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 
+// Synchronous temporary directory helpers for tests.
+
+type TempDirCollection = string[] | Set<string>;
 type RegisterTempDirCleanup = (cleanup: () => void) => unknown;
 
-export function useAutoCleanupTempDirTracker(registerCleanup: RegisterTempDirCleanup) {
+const canonicalSystemTempRoots = new Map<string, string>();
+
+function resolveCanonicalSystemTempRoot(): string {
+  const rawRoot = os.tmpdir();
+  const cachedRoot = canonicalSystemTempRoots.get(rawRoot);
+  if (cachedRoot !== undefined) {
+    return cachedRoot;
+  }
+  const canonicalRoot = fs.realpathSync(rawRoot);
+  canonicalSystemTempRoots.set(rawRoot, canonicalRoot);
+  return canonicalRoot;
+}
+
+interface TestTempDirTracker {
+  readonly dirs: ReadonlySet<string>;
+  make(prefix: string, root?: string): string;
+  cleanup(): void;
+}
+
+interface AutoCleanupTempDirTracker {
+  readonly dirs: ReadonlySet<string>;
+  make(prefix: string, root?: string): string;
+}
+
+/** Create a temp dir and register it in an array or set for cleanup. */
+export function makeTempDir(tempDirs: TempDirCollection, prefix: string, root?: string): string {
+  const tempRoot = root ?? resolveCanonicalSystemTempRoot();
+  // openclaw-temp-dir: allow this package-local mirror registers every directory for cleanup.
+  const dir = fs.mkdtempSync(path.join(tempRoot, prefix));
+  if (Array.isArray(tempDirs)) {
+    tempDirs.push(dir);
+  } else {
+    tempDirs.add(dir);
+  }
+  return dir;
+}
+
+/** Remove all tracked temporary directories and clear the tracker. */
+export function cleanupTempDirs(tempDirs: TempDirCollection): void {
+  const dirs = Array.isArray(tempDirs) ? tempDirs.splice(0) : [...tempDirs];
+  for (const dir of dirs) {
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+  }
+  if (!Array.isArray(tempDirs)) {
+    tempDirs.clear();
+  }
+}
+
+export function createTempDirTracker(): TestTempDirTracker {
   const dirs = new Set<string>();
-  registerCleanup(() => {
-    for (const dir of dirs) {
-      fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
-    }
-    dirs.clear();
-  });
   return {
-    make(prefix: string): string {
-      // openclaw-temp-dir: allow package-local tracker registers cleanup before returning.
-      const dir = fs.mkdtempSync(path.join(resolvePreferredOpenClawTmpDir(), prefix));
-      dirs.add(dir);
-      return dir;
+    dirs,
+    make(prefix: string, root?: string): string {
+      return makeTempDir(dirs, prefix, root);
+    },
+    cleanup(): void {
+      cleanupTempDirs(dirs);
     },
   };
+}
+
+/** Create a temp dir tracker that Vitest cleans up after each test. */
+export function useAutoCleanupTempDirTracker(
+  registerCleanup: RegisterTempDirCleanup,
+): AutoCleanupTempDirTracker {
+  const tracker = createTempDirTracker();
+  registerCleanup(tracker.cleanup);
+  return tracker;
 }

--- a/extensions/google/temp-dir.test-support.ts
+++ b/extensions/google/temp-dir.test-support.ts
@@ -1,0 +1,24 @@
+// Google test temp directories are owned by the Vitest lifecycle that creates them.
+import fs from "node:fs";
+import path from "node:path";
+import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
+
+type RegisterTempDirCleanup = (cleanup: () => void) => unknown;
+
+export function useAutoCleanupTempDirTracker(registerCleanup: RegisterTempDirCleanup) {
+  const dirs = new Set<string>();
+  registerCleanup(() => {
+    for (const dir of dirs) {
+      fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+    }
+    dirs.clear();
+  });
+  return {
+    make(prefix: string): string {
+      // openclaw-temp-dir: allow package-local tracker registers cleanup before returning.
+      const dir = fs.mkdtempSync(path.join(resolvePreferredOpenClawTmpDir(), prefix));
+      dirs.add(dir);
+      return dir;
+    },
+  };
+}

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -1,12 +1,14 @@
 // Google tests cover transport stream plugin behavior.
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
-import os from "node:os";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { gzipSync } from "node:zlib";
 import { expectDefined } from "@openclaw/normalization-core";
 import type { Model } from "openclaw/plugin-sdk/llm";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetGoogleVertexAdcState } from "./google-oauth.test-support.js";
+import { useAutoCleanupTempDirTracker } from "./temp-dir.test-support.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const {
   buildGuardedModelFetchMock,
@@ -154,7 +156,7 @@ async function useGoogleAuthorizedUserCredentials(
   refreshToken: string,
   quotaProjectId?: string,
 ) {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), `openclaw-google-vertex-${label}-`));
+  const tempDir = tempDirs.make(`openclaw-google-vertex-${label}-`);
   const credentialsPath = path.join(tempDir, "application_default_credentials.json");
   await writeFile(
     credentialsPath,
@@ -172,7 +174,7 @@ async function useGoogleAuthorizedUserCredentials(
 }
 
 async function useGoogleAuthLibraryCredentials(label: string, token?: string): Promise<void> {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), `openclaw-google-vertex-${label}-`));
+  const tempDir = tempDirs.make(`openclaw-google-vertex-${label}-`);
   vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", "");
   vi.stubEnv("HOME", path.join(tempDir, "home"));
   vi.stubEnv("APPDATA", "");
@@ -1373,7 +1375,7 @@ describe("google transport stream", () => {
   ])(
     "routes the %s Vertex multi-region through the production stream",
     async (location, origin) => {
-      const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-region-"));
+      const tempDir = tempDirs.make("openclaw-google-vertex-region-");
       vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", "");
       vi.stubEnv("HOME", path.join(tempDir, "home"));
       vi.stubEnv("APPDATA", "");
@@ -1422,7 +1424,7 @@ describe("google transport stream", () => {
   });
 
   it("never refreshes stale home ADC when the selected Cloud SDK directory has no credentials", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-stale-home-"));
+    const tempDir = tempDirs.make("openclaw-google-vertex-stale-home-");
     const homeCredentialsDir = path.join(tempDir, "home", ".config", "gcloud");
     await mkdir(homeCredentialsDir, { recursive: true });
     await writeFile(
@@ -1453,7 +1455,7 @@ describe("google transport stream", () => {
   });
 
   it("bounds Google Vertex ADC files before google-auth-library reads them", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-adc-file-"));
+    const tempDir = tempDirs.make("openclaw-google-vertex-adc-file-");
     const credentialsPath = path.join(tempDir, "application_default_credentials.json");
     const credentials = {
       type: "service_account",
@@ -1594,9 +1596,7 @@ describe("google transport stream", () => {
           }),
         );
       } else if (credentialType === "service_account") {
-        const tempDir = await mkdtemp(
-          path.join(os.tmpdir(), "openclaw-google-vertex-quota-service-"),
-        );
+        const tempDir = tempDirs.make("openclaw-google-vertex-quota-service-");
         const credentialsPath = path.join(tempDir, "application_default_credentials.json");
         await writeFile(
           credentialsPath,
@@ -1610,9 +1610,7 @@ describe("google transport stream", () => {
         vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", credentialsPath);
         googleAuthGetAccessTokenMock.mockResolvedValueOnce("fixture-vertex-token");
       } else {
-        const tempDir = await mkdtemp(
-          path.join(os.tmpdir(), "openclaw-google-vertex-quota-metadata-"),
-        );
+        const tempDir = tempDirs.make("openclaw-google-vertex-quota-metadata-");
         vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", "");
         vi.stubEnv("HOME", path.join(tempDir, "home"));
         vi.stubEnv("APPDATA", "");
@@ -1637,7 +1635,7 @@ describe("google transport stream", () => {
   );
 
   it("strips redundant google provider prefixes from Google Vertex model paths", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-prefix-"));
+    const tempDir = tempDirs.make("openclaw-google-vertex-prefix-");
     vi.stubEnv("HOME", path.join(tempDir, "home"));
     vi.stubEnv("APPDATA", "");
     vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
@@ -1816,7 +1814,7 @@ describe("google transport stream", () => {
   });
 
   it("refreshes authorized_user ADC from the Windows APPDATA fallback for Google Vertex requests", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-appdata-adc-"));
+    const tempDir = tempDirs.make("openclaw-google-vertex-appdata-adc-");
     const homeDir = path.join(tempDir, "home");
     const appDataDir = path.join(tempDir, "AppData", "Roaming");
     const fallbackDir = path.join(appDataDir, "gcloud");

--- a/src/agents/embedded-agent-subscribe.handlers.compaction.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.compaction.test.ts
@@ -1,9 +1,8 @@
 // Compaction handler tests cover session-store reconciliation and lifecycle
 // logging for automatic and manual embedded run compactions.
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
   readCompactionCount,
   seedSessionStore,
@@ -17,6 +16,8 @@ import reconcileSessionStoreCompactionCountAfterSuccess from "./embedded-agent-s
 import type { EmbeddedAgentSubscribeContext } from "./embedded-agent-subscribe.handlers.types.js";
 import type { AgentMessage } from "./runtime/index.js";
 import { makeZeroUsageSnapshot, type AssistantUsageSnapshot } from "./usage.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function createCompactionContext(params: {
   storePath: string;
@@ -133,7 +134,7 @@ describe("reconcileSessionStoreCompactionCountAfterSuccess", () => {
   it("raises the stored compaction count to the observed value", async () => {
     // Store count can lag the in-memory count after async writes; reconciliation
     // moves it forward without double-counting.
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compaction-reconcile-"));
+    const tmp = tempDirs.make("openclaw-compaction-reconcile-");
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "main";
     await seedSessionStore({
@@ -155,7 +156,7 @@ describe("reconcileSessionStoreCompactionCountAfterSuccess", () => {
   });
 
   it("does not double count when the store is already at or above the observed value", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compaction-idempotent-"));
+    const tmp = tempDirs.make("openclaw-compaction-idempotent-");
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "main";
     await seedSessionStore({
@@ -179,7 +180,7 @@ describe("reconcileSessionStoreCompactionCountAfterSuccess", () => {
 
 describe("compaction lifecycle logging", () => {
   it("logs lifecycle events at info level for gateway watch visibility", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compaction-log-"));
+    const tmp = tempDirs.make("openclaw-compaction-log-");
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "main";
     await seedSessionStore({
@@ -229,7 +230,7 @@ describe("compaction lifecycle logging", () => {
   });
 
   it("logs manual compaction as incomplete when no result is produced", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compaction-incomplete-log-"));
+    const tmp = tempDirs.make("openclaw-compaction-incomplete-log-");
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "main";
     await seedSessionStore({
@@ -279,7 +280,7 @@ describe("compaction lifecycle logging", () => {
   });
 
   it("defaults legacy synthetic compaction events to threshold logs", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compaction-legacy-log-"));
+    const tmp = tempDirs.make("openclaw-compaction-legacy-log-");
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "main";
     await seedSessionStore({
@@ -329,7 +330,7 @@ describe("compaction lifecycle logging", () => {
 
 describe("handleCompactionEnd", () => {
   it("reconciles the session store after a successful compaction end event", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compaction-handler-"));
+    const tmp = tempDirs.make("openclaw-compaction-handler-");
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "main";
     await seedSessionStore({
@@ -379,7 +380,7 @@ describe("handleCompactionEnd", () => {
         usage: freshUsage,
       }),
     ] as AgentMessage[];
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compaction-usage-"));
+    const tmp = tempDirs.make("openclaw-compaction-usage-");
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "main";
     const ctx = createCompactionContext({
@@ -413,7 +414,7 @@ describe("handleCompactionEnd", () => {
           usage: liveUsage,
         }),
       ] as AgentMessage[];
-      const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compaction-usage-keep-"));
+      const tmp = tempDirs.make("openclaw-compaction-usage-keep-");
       const storePath = path.join(tmp, "sessions.json");
       const ctx = createCompactionContext({
         storePath,
@@ -452,7 +453,7 @@ describe("handleCompactionEnd", () => {
         usage: freshUsage,
       }),
     ] as AgentMessage[];
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compaction-summary-first-"));
+    const tmp = tempDirs.make("openclaw-compaction-summary-first-");
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "main";
     const ctx = createCompactionContext({
@@ -484,7 +485,7 @@ describe("handleCompactionEnd", () => {
         usage: freshUsage,
       }),
     ] as AgentMessage[];
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compaction-legacy-usage-"));
+    const tmp = tempDirs.make("openclaw-compaction-legacy-usage-");
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "main";
     const ctx = createCompactionContext({
@@ -516,7 +517,7 @@ describe("handleCompactionEnd", () => {
         usage: secondUsage,
       }),
     ] as AgentMessage[];
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compaction-no-summary-"));
+    const tmp = tempDirs.make("openclaw-compaction-no-summary-");
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "main";
     const ctx = createCompactionContext({
@@ -544,7 +545,7 @@ describe("handleCompactionEnd", () => {
       }),
       makeCompactionSummaryMessage(2_000),
     ] as AgentMessage[];
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compaction-timestamp-fresh-"));
+    const tmp = tempDirs.make("openclaw-compaction-timestamp-fresh-");
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "main";
     const ctx = createCompactionContext({

--- a/src/channels/plugins/contracts/test-helpers/channel-plugin-catalog-contract-suites.ts
+++ b/src/channels/plugins/contracts/test-helpers/channel-plugin-catalog-contract-suites.ts
@@ -5,9 +5,12 @@
  */
 import fs from "node:fs";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../../test/helpers/temp-dir.js";
 import { resolvePreferredOpenClawTmpDir } from "../../../../infra/tmp-openclaw-dir.js";
 import { listRawChannelPluginCatalogEntries } from "../../catalog.js";
+
+type MakeTempDir = (prefix: string, root?: string) => string;
 
 type CatalogQuery = {
   catalogPaths?: string[];
@@ -75,11 +78,12 @@ function writeCatalogFile(
 }
 
 function createTemporaryCatalogFile(
+  makeTempDir: MakeTempDir,
   prefix: string,
   entry: Record<string, unknown>,
   richManifest = false,
 ) {
-  const directory = fs.mkdtempSync(path.join(resolvePreferredOpenClawTmpDir(), prefix));
+  const directory = makeTempDir(prefix, resolvePreferredOpenClawTmpDir());
   const catalogPath = path.join(directory, "catalog.json");
   writeCatalogFile(catalogPath, entry, richManifest);
   return catalogPath;
@@ -122,12 +126,13 @@ function writeDiscoveredChannelPlugin(params: {
 
 function createRichExternalCatalogCase(
   fixture: RichExternalCatalogFixture,
+  makeTempDir: MakeTempDir,
 ): ChannelCatalogContractCase {
   return {
     name: fixture.name,
     setup: () => ({
       channelId: fixture.channelId,
-      catalogPaths: [createTemporaryCatalogFile(fixture.prefix, fixture.entry, true)],
+      catalogPaths: [createTemporaryCatalogFile(makeTempDir, fixture.prefix, fixture.entry, true)],
       expected: fixture.expected,
     }),
   };
@@ -300,6 +305,7 @@ const [richNpmCatalogFixture, clawhubCatalogFixture, yuanbaoCatalogFixture] = [
 
 /** Installs catalog entry tests shared by plugin registry and manifest suites. */
 export function describeChannelPluginCatalogEntriesContract() {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
   const cases: ChannelCatalogContractCase[] = [
     {
       name: "includes external catalog entries",
@@ -307,6 +313,7 @@ export function describeChannelPluginCatalogEntriesContract() {
         channelId: "demo-channel",
         catalogPaths: [
           createTemporaryCatalogFile(
+            tempDirs.make,
             "openclaw-catalog-",
             createCatalogEntry({
               packageName: "@openclaw/demo-channel",
@@ -323,8 +330,9 @@ export function describeChannelPluginCatalogEntriesContract() {
     {
       name: "preserves plugin ids when they differ from channel ids",
       setup: () => {
-        const stateDir = fs.mkdtempSync(
-          path.join(resolvePreferredOpenClawTmpDir(), "openclaw-channel-catalog-state-"),
+        const stateDir = tempDirs.make(
+          "openclaw-channel-catalog-state-",
+          resolvePreferredOpenClawTmpDir(),
         );
         writeDiscoveredChannelPlugin({
           stateDir,
@@ -347,9 +355,7 @@ export function describeChannelPluginCatalogEntriesContract() {
     {
       name: "keeps discovered plugins ahead of external catalog overrides",
       setup: () => {
-        const stateDir = fs.mkdtempSync(
-          path.join(resolvePreferredOpenClawTmpDir(), "openclaw-catalog-state-"),
-        );
+        const stateDir = tempDirs.make("openclaw-catalog-state-", resolvePreferredOpenClawTmpDir());
         const catalogPath = path.join(stateDir, "catalog.json");
         writeDiscoveredChannelPlugin({
           stateDir,
@@ -384,13 +390,13 @@ export function describeChannelPluginCatalogEntriesContract() {
         };
       },
     },
-    createRichExternalCatalogCase(richNpmCatalogFixture),
+    createRichExternalCatalogCase(richNpmCatalogFixture, tempDirs.make),
     {
       name: "pins bare external prerelease package specs to the entry version",
       setup: () => ({
         channelId: "prerelease-demo",
         catalogPaths: [
-          createTemporaryCatalogFile("openclaw-catalog-prerelease-", {
+          createTemporaryCatalogFile(tempDirs.make, "openclaw-catalog-prerelease-", {
             ...createCatalogEntry({
               packageName: "@openclaw/prerelease-demo-channel",
               channelId: "prerelease-demo",
@@ -414,8 +420,8 @@ export function describeChannelPluginCatalogEntriesContract() {
         },
       }),
     },
-    createRichExternalCatalogCase(clawhubCatalogFixture),
-    createRichExternalCatalogCase(yuanbaoCatalogFixture),
+    createRichExternalCatalogCase(clawhubCatalogFixture, tempDirs.make),
+    createRichExternalCatalogCase(yuanbaoCatalogFixture, tempDirs.make),
   ];
 
   describe("channel plugin catalog entries contract", () => {
@@ -430,14 +436,13 @@ export function describeChannelPluginCatalogEntriesContract() {
 
 /** Installs catalog path resolution tests that depend on env/home/state paths. */
 export function describeChannelPluginCatalogPathResolutionContract() {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
   describe("channel plugin catalog path resolution contract", () => {
     it.each([
       {
         name: "uses the provided env for external catalog path resolution",
         setup: () => {
-          const home = fs.mkdtempSync(
-            path.join(resolvePreferredOpenClawTmpDir(), "openclaw-catalog-home-"),
-          );
+          const home = tempDirs.make("openclaw-catalog-home-", resolvePreferredOpenClawTmpDir());
           writeCatalogFile(
             path.join(home, "catalog.json"),
             createCatalogEntry({
@@ -462,8 +467,9 @@ export function describeChannelPluginCatalogPathResolutionContract() {
       {
         name: "uses the provided env for default catalog paths",
         setup: () => {
-          const stateDir = fs.mkdtempSync(
-            path.join(resolvePreferredOpenClawTmpDir(), "openclaw-catalog-state-"),
+          const stateDir = tempDirs.make(
+            "openclaw-catalog-state-",
+            resolvePreferredOpenClawTmpDir(),
           );
           const catalogPath = path.join(stateDir, "plugins", "catalog.json");
           fs.mkdirSync(path.dirname(catalogPath), { recursive: true });

--- a/src/infra/dotenv-workspace-blocklist.test.ts
+++ b/src/infra/dotenv-workspace-blocklist.test.ts
@@ -1,8 +1,8 @@
 // Tests workspace dotenv blocklist completeness across shipped runtime controls.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { clearCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
@@ -11,6 +11,8 @@ import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot
 import { listKnownProviderAuthEnvVarNames } from "../secrets/provider-env-vars.js";
 import { captureFullEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { loadDotEnv, loadWorkspaceDotEnvFile } from "./dotenv.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 type DotEnvFixture = {
   base: string;
@@ -34,7 +36,7 @@ async function withIsolatedEnvAndCwd(run: () => Promise<void>) {
 }
 
 async function withDotEnvFixture(run: (fixture: DotEnvFixture) => Promise<void>) {
-  const base = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-dotenv-test-"));
+  const base = tempDirs.make("openclaw-dotenv-test-");
   const cwdDir = path.join(base, "cwd");
   const stateDir = path.join(base, "state");
   setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);

--- a/src/infra/state-migrations.config-machine-state.test.ts
+++ b/src/infra/state-migrations.config-machine-state.test.ts
@@ -1,7 +1,5 @@
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { readConfigMachineState, writeConfigMachineState } from "../state/config-machine-state.js";
 import {
   claimControlUiDeviceAuthMigration,
@@ -13,13 +11,17 @@ import {
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { migrateLegacyConfigMachineState } from "./state-migrations.config-machine-state.js";
 
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+// Vitest unwinds hooks in reverse registration order, so this closes the database
+// before the earlier tracker hook removes its directory.
 afterEach(() => {
   closeOpenClawStateDatabaseForTest();
 });
 
 describe("legacy config machine-state migration", () => {
   it("imports machine-owned values and keeps existing database state", () => {
-    const stateDir = mkdtempSync(join(tmpdir(), "openclaw-config-machine-state-"));
+    const stateDir = tempDirs.make("openclaw-config-machine-state-");
     const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
     writeConfigMachineState("config.lastTouchedAt", "canonical", { env });
 
@@ -46,7 +48,7 @@ describe("legacy config machine-state migration", () => {
   });
 
   it("merges legacy hook installs while canonical records win conflicts", () => {
-    const stateDir = mkdtempSync(join(tmpdir(), "openclaw-config-machine-state-"));
+    const stateDir = tempDirs.make("openclaw-config-machine-state-");
     const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
     writeConfigMachineState(
       "hooks.internal.installs",
@@ -76,7 +78,7 @@ describe("legacy config machine-state migration", () => {
   });
 
   it("conservatively preserves compatibility for an unstamped plugin allowlist", () => {
-    const stateDir = mkdtempSync(join(tmpdir(), "openclaw-config-machine-state-"));
+    const stateDir = tempDirs.make("openclaw-config-machine-state-");
     const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
 
     migrateLegacyConfigMachineState({ env, config: { plugins: { allow: ["telegram"] } } });
@@ -85,7 +87,7 @@ describe("legacy config machine-state migration", () => {
   });
 
   it("preserves compatibility discovery for a pre-cutover plugin allowlist", () => {
-    const stateDir = mkdtempSync(join(tmpdir(), "openclaw-config-machine-state-"));
+    const stateDir = tempDirs.make("openclaw-config-machine-state-");
     const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
 
     migrateLegacyConfigMachineState({
@@ -100,7 +102,7 @@ describe("legacy config machine-state migration", () => {
   });
 
   it("does not infer compatibility discovery after the fixed cutover release", () => {
-    const stateDir = mkdtempSync(join(tmpdir(), "openclaw-config-machine-state-"));
+    const stateDir = tempDirs.make("openclaw-config-machine-state-");
     const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
 
     migrateLegacyConfigMachineState({
@@ -115,7 +117,7 @@ describe("legacy config machine-state migration", () => {
   });
 
   it("preserves the shipped device-auth bypass as pending migration state", () => {
-    const stateDir = mkdtempSync(join(tmpdir(), "openclaw-config-machine-state-"));
+    const stateDir = tempDirs.make("openclaw-config-machine-state-");
     const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
 
     migrateLegacyConfigMachineState({
@@ -132,7 +134,7 @@ describe("legacy config machine-state migration", () => {
   });
 
   it("never reopens a completed migration from stale legacy config", () => {
-    const stateDir = mkdtempSync(join(tmpdir(), "openclaw-config-machine-state-"));
+    const stateDir = tempDirs.make("openclaw-config-machine-state-");
     const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
     completeControlUiDeviceAuthMigration("browser-1", { env });
 
@@ -150,7 +152,7 @@ describe("legacy config machine-state migration", () => {
   });
 
   it("allows one claim and recovers a released or interrupted claim", () => {
-    const stateDir = mkdtempSync(join(tmpdir(), "openclaw-config-machine-state-"));
+    const stateDir = tempDirs.make("openclaw-config-machine-state-");
     const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
     migrateLegacyConfigMachineState({
       env,
@@ -169,7 +171,7 @@ describe("legacy config machine-state migration", () => {
   });
 
   it("does not create migration state when the retired bypass was disabled", () => {
-    const stateDir = mkdtempSync(join(tmpdir(), "openclaw-config-machine-state-"));
+    const stateDir = tempDirs.make("openclaw-config-machine-state-");
     const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
 
     migrateLegacyConfigMachineState({
@@ -183,7 +185,7 @@ describe("legacy config machine-state migration", () => {
   });
 
   it("does not treat a newly written current config as upgrade input", () => {
-    const stateDir = mkdtempSync(join(tmpdir(), "openclaw-config-machine-state-"));
+    const stateDir = tempDirs.make("openclaw-config-machine-state-");
     const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
 
     migrateLegacyConfigMachineState({
@@ -198,7 +200,7 @@ describe("legacy config machine-state migration", () => {
   });
 
   it("does not re-report inferred bundledDiscovery on second pass with beta version", () => {
-    const stateDir = mkdtempSync(join(tmpdir(), "openclaw-config-machine-state-"));
+    const stateDir = tempDirs.make("openclaw-config-machine-state-");
     const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
 
     // First pass: infer compat and write to SQLite

--- a/src/plugins/plugin-sdk-native-resolver.test.ts
+++ b/src/plugins/plugin-sdk-native-resolver.test.ts
@@ -2,10 +2,10 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import { createRequire } from "node:module";
-import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import {
   installOpenClawInternalCorePackageNativeResolver,
@@ -18,6 +18,7 @@ type NativeEsmLazyImportProbe = {
   stdout: string;
 };
 let nativeEsmLazyImportProbe: NativeEsmLazyImportProbe;
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function writeJsonFile(targetPath: string, value: unknown): void {
   fs.mkdirSync(path.dirname(targetPath), { recursive: true });
@@ -112,7 +113,7 @@ function createInternalCoreAliasFixture(prefix: string): {
   root: string;
   sourcePath: string;
 } {
-  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+  const root = fs.realpathSync(tempDirs.make(prefix));
   const { loaderModulePath } = writeFakeOpenClawPackage(root);
   const sourcePath = writeInternalCorePackageSource(root, "markdown-core", "code-spans.ts");
   const coreSourceParent = path.join(root, "src", "host-probe.js");
@@ -244,9 +245,11 @@ describe("installOpenClawInternalCorePackageNativeResolver", () => {
 });
 
 describe("installOpenClawPluginSdkNativeResolver", () => {
+  const suiteTempDirs = useAutoCleanupTempDirTracker(afterAll);
+
   it("resolves installed plugin SDK imports to the dev source root", () => {
-    const stableRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-stable-"));
-    const devRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-dev-source-"));
+    const stableRoot = tempDirs.make("openclaw-sdk-native-stable-");
+    const devRoot = tempDirs.make("openclaw-sdk-native-dev-source-");
     const { loaderModulePath } = writeFakeOpenClawPackage(stableRoot);
     writeFakeOpenClawPackage(devRoot);
     fs.mkdirSync(path.join(devRoot, "src"), { recursive: true });
@@ -276,8 +279,8 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
   });
 
   it("resolves installed plugin SDK imports to an explicit dev source root", () => {
-    const stableRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-stable-"));
-    const devRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-dev-source-"));
+    const stableRoot = tempDirs.make("openclaw-sdk-native-stable-");
+    const devRoot = tempDirs.make("openclaw-sdk-native-dev-source-");
     const { loaderModulePath } = writeFakeOpenClawPackage(stableRoot);
     writeFakeOpenClawPackage(devRoot);
     fs.mkdirSync(path.join(devRoot, "src"), { recursive: true });
@@ -298,8 +301,8 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
   });
 
   it("updates native SDK aliases when the same plugin parent switches dev source roots", () => {
-    const stableRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-stable-"));
-    const devRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-dev-source-"));
+    const stableRoot = tempDirs.make("openclaw-sdk-native-stable-");
+    const devRoot = tempDirs.make("openclaw-sdk-native-dev-source-");
     const { loaderModulePath } = writeFakeOpenClawPackage(stableRoot);
     writeFakeOpenClawPackage(devRoot);
     fs.mkdirSync(path.join(devRoot, "src"), { recursive: true });
@@ -327,8 +330,8 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
   });
 
   it("removes stale native SDK aliases when a later dev root omits a subpath", () => {
-    const stableRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-stable-"));
-    const devRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-dev-source-"));
+    const stableRoot = tempDirs.make("openclaw-sdk-native-stable-");
+    const devRoot = tempDirs.make("openclaw-sdk-native-dev-source-");
     const { loaderModulePath } = writeFakeOpenClawPackage(stableRoot);
     writeFakeOpenClawPackage(devRoot);
     const stableExtraPath = addFakePluginSdkDistExport(stableRoot, "stable-extra");
@@ -355,7 +358,7 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
   });
 
   it("keeps native aliases on JS dist artifacts when source files exist", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-source-resolver-"));
+    const root = tempDirs.make("openclaw-sdk-native-source-resolver-");
     const { loaderModulePath } = writeFakeOpenClawPackage(root);
     const sourceChannelOutboundPath = path.join(root, "src", "plugin-sdk", "channel-outbound.ts");
     fs.mkdirSync(path.dirname(sourceChannelOutboundPath), { recursive: true });
@@ -376,7 +379,7 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
   });
 
   it("lets built external plugins resolve OpenClaw SDK subpaths with createRequire", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-resolver-"));
+    const root = tempDirs.make("openclaw-sdk-native-resolver-");
     const { distRoot, loaderModulePath } = writeFakeOpenClawPackage(root);
     const externalPluginEntry = writeExternalPluginEntry(path.join(root, "external-plugin"));
 
@@ -412,7 +415,7 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
   });
 
   beforeAll(() => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-esm-resolver-"));
+    const root = suiteTempDirs.make("openclaw-sdk-native-esm-resolver-");
     const probePath = path.join(root, "probe.mjs");
     const resolverModuleUrl = pathToFileURL(
       path.join(process.cwd(), "src", "plugins", "plugin-sdk-native-resolver.ts"),
@@ -490,10 +493,10 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
   });
 
   it("does not resolve SDK aliases for parents outside registered plugin roots", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-guard-"));
+    const root = tempDirs.make("openclaw-sdk-native-guard-");
     const { loaderModulePath } = writeFakeOpenClawPackage(root);
     const externalPluginEntry = writeExternalPluginEntry(path.join(root, "external-plugin"));
-    const unrelatedRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-outside-"));
+    const unrelatedRoot = tempDirs.make("openclaw-sdk-native-outside-");
     const unrelatedEntry = path.join(unrelatedRoot, "runtime-api.js");
     fs.mkdirSync(path.dirname(unrelatedEntry), { recursive: true });
     fs.writeFileSync(unrelatedEntry, "export default {};\n", "utf8");
@@ -511,7 +514,7 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
   });
 
   it("resolves internal core packages only for OpenClaw-owned source parents", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-core-internal-"));
+    const root = tempDirs.make("openclaw-sdk-native-core-internal-");
     const { loaderModulePath } = writeFakeOpenClawPackage(root);
     const normalizationSource = writeNormalizationCoreSource(root);
     const booleanCoercionSource = writeInternalCorePackageSource(
@@ -618,7 +621,7 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
   });
 
   it("does not register source-only SDK subpaths for native resolution", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-source-only-"));
+    const root = tempDirs.make("openclaw-sdk-native-source-only-");
     const { loaderModulePath } = writeFakeOpenClawPackage(root);
     const sourceOnlyPath = path.join(root, "src", "plugin-sdk", "source-only.ts");
     fs.mkdirSync(path.dirname(sourceOnlyPath), { recursive: true });
@@ -638,7 +641,7 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
   });
 
   it("scopes private SSRF SDK aliases to bundled local IPC native parents", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-ssrf-"));
+    const root = tempDirs.make("openclaw-sdk-native-ssrf-");
     const { loaderModulePath } = writeFakeOpenClawPackage(root);
     const internalPath = path.join(root, "dist", "plugin-sdk", "ssrf-runtime-internal.js");
     fs.writeFileSync(internalPath, "export const ssrfInternal = true;\n", "utf8");

--- a/src/state/user-profiles.test.ts
+++ b/src/state/user-profiles.test.ts
@@ -1,7 +1,7 @@
-import { mkdtempSync, readFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { tableExists } from "./openclaw-state-db-schema-helpers.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db.js";
 import {
@@ -23,12 +23,11 @@ import {
   setDisplayName,
 } from "./user-profiles.js";
 
-const statePaths: string[] = [];
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function stateOptions() {
-  const directory = mkdtempSync(join(tmpdir(), "openclaw-user-profiles-"));
+  const directory = tempDirs.make("openclaw-user-profiles-");
   const path = join(directory, "openclaw.sqlite");
-  statePaths.push(path);
   return { path };
 }
 
@@ -51,6 +50,8 @@ async function ensureTailscaleProfileWithAvatar(
   return await adoptTailscaleProfileAvatar(profile.id, identity.profilePic, options, fetchOptions);
 }
 
+// Vitest unwinds hooks in reverse registration order, so this closes the database
+// before the earlier tracker hook removes its directory.
 afterEach(() => {
   vi.restoreAllMocks();
   closeOpenClawStateDatabaseForTest();


### PR DESCRIPTION
## What Problem This Solves

Several test suites created temporary directories without removing them, leaving filesystem residue after successful runs and making the temp-directory reporter unsuitable as a future blocking guard.

## Why This Change Was Made

Migrate the first high-confidence leak batch to lifecycle-owned temp-directory trackers. Core tests use the shared tracker; Google plugin tests use a package-local tracker that mirrors `test/helpers/temp-dir.ts` because the extension boundary prohibits importing repo-only test helpers, keeping the shape aligned for future consolidation. Database teardown hooks are registered after tracker hooks because Vitest unwinds hooks in reverse registration order, ensuring handles close before directories are removed.

## User Impact

No production behavior changes. Test runs now clean up these owned directories, reducing local and CI residue and moving the repository closer to safely enforcing the temp-directory guard as an error.

## Evidence

- Focused Vitest coverage: 225 tests passed.
- Temp-directory reporter in fail mode: no findings for the changed code.
- `git diff --check`: passed.
- Changed-check reached the existing environment-budget ratchet and was blocked by the baseline mismatch (`503 < 507`), unrelated to this test-only patch.
- Test LOC: +188/-93 across 9 files; production LOC: +0/-0.
