### PR TITLE
test(ui): remove duplicate update confirmation cases

### DIFF
--- a/ui/src/app/update-confirmation.runtime.test.ts
+++ b/ui/src/app/update-confirmation.runtime.test.ts
@@ -67,58 +67,6 @@ afterEach(() => {
   }
 });
 
-it("states the target, restart impact, and both versions without starting the update", async () => {
-  const postMessage = installNativeBridge();
-  const { settled, startGatewayUpdate } = startUpdate();
-  const { modal, dialog } = await getRenderedModalDialog(document.body);
-
-  expect(dialog.getAttribute("aria-label")).toBe("Update Gateway");
-  expect(modal.textContent).toContain(
-    "Installs the available update on the connected Gateway and restarts it.",
-  );
-  expect(modal.textContent).toContain("this Control UI disconnects until the Gateway is back");
-  expect(modal.textContent).toContain("Installed v1.0.0 · Available v2.0.0");
-  // The confirm action names the operation; a generic "Yes" would not.
-  expect(findButton("Update and restart")).toBeInstanceOf(HTMLButtonElement);
-  expect(findButton("Cancel").hasAttribute("autofocus")).toBe(true);
-  expect(startGatewayUpdate).not.toHaveBeenCalled();
-  expect(postMessage).not.toHaveBeenCalled();
-
-  findButton("Cancel").click();
-  await settled;
-});
-
-it.each([
-  { dismiss: () => findButton("Cancel").click(), name: "Cancel" },
-  {
-    dismiss: () => {
-      const modal = document.body.querySelector("openclaw-modal-dialog");
-      modal?.dispatchEvent(new CustomEvent("modal-cancel", { bubbles: true, composed: true }));
-    },
-    name: "Escape or modal dismissal",
-  },
-])("sends nothing when the operator chooses $name", async ({ dismiss }) => {
-  const postMessage = installNativeBridge();
-  const { settled, startGatewayUpdate } = startUpdate({ viaNativeApp: true });
-  await getRenderedModalDialog(document.body);
-
-  dismiss();
-  await settled;
-
-  expect(startGatewayUpdate).not.toHaveBeenCalled();
-  expect(postMessage).not.toHaveBeenCalled();
-});
-
-it("starts exactly one Gateway update after an explicit confirmation", async () => {
-  const { settled, startGatewayUpdate } = startUpdate();
-  await getRenderedModalDialog(document.body);
-
-  findButton("Update and restart").click();
-  await settled;
-
-  expect(startGatewayUpdate).toHaveBeenCalledOnce();
-});
-
 it("hands a confirmed update to the Mac app instead of the Gateway", async () => {
   const postMessage = installNativeBridge();
   const { settled, startGatewayUpdate } = startUpdate({ viaNativeApp: true });


### PR DESCRIPTION
## What Problem This Solves

The update-confirmation unit suite repeated three cases that are covered more strongly by mandatory browser E2E introduced in the same fix:

- dialog target/version/restart copy before any update request;
- Cancel/Escape dismissal issuing no request; and
- explicit confirmation issuing exactly one Gateway update request.

The unit copies invoke the runtime directly, while the E2E drives the actual sidebar/config UI and mock Gateway boundary.

## Why This Change Was Made

This removes only those strict-subset unit cases. Unit-only coverage remains for:

- native Mac app bridge dispatch;
- bridge disappearance fallback to the Gateway;
- git update targets; and
- repeated-request confirmation/update coalescing.

AI-assisted: yes. The deletion was manually inspected and passed repository autoreview.

## User Impact

No user-visible behavior change. Confirmation safety remains covered at the real Control UI and Gateway request boundary with less duplicate test maintenance.

## Evidence

- `node scripts/run-vitest.mjs ui/src/app/update-confirmation.runtime.test.ts ui/src/e2e/update-confirmation.e2e.test.ts` — 4 retained unit tests and 7 browser E2E tests passed.
- `node scripts/check-changed.mjs -- ui/src/app/update-confirmation.runtime.test.ts` — passed UI i18n, type, lint, dead-export, and related changed-file gates using the trusted local fallback because Blacksmith Testbox is unavailable on this host.
- Targeted oxlint, oxfmt, and `git diff --check` — passed.
- Fresh autoreview and secret scan — clean.

## Scope and LOC

- Production: unchanged.
- Tests: `-52` lines.

No runtime behavior, config, protocol, database schema, dependency, lockfile, generated baseline, release, docs, or changelog change.
