### PR TITLE
fix(agents): stop reporting undelivered subagent results as delivered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Subagent delivery truth:** preserve intentional requester-yield and inactive-cron non-delivery as pending recorded outcomes, credit delivery only when requester-settle succeeds, and mark exhausted settle wakes blocked instead of delivered.
 - **Control UI staged attachments:** preserve unsent images, files, pasted images, and large pasted text across same-tab route and narrow split-pane remounts while keeping pane close, mismatched pane/session/Gateway remounts, application shutdown, and hard reload as cleanup boundaries. Fixes #121519. Thanks @shakkernerd.
 - **Control UI browser annotations:** keep marked screenshots and generated page context together in structured composer cards, preserve user-written drafts when annotations are removed or replaced, retain complete unsent annotation packages across same-tab route and active split-pane remounts, and offer bounded Undo without restoring removed context into another session. Fixes #120744. Thanks @shakkernerd.
 - **Control UI profile avatar refreshes:** carry canonical content revisions through mutation responses and live presence so rapid replacements refresh every connected browser without stale cache rollback. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Subagent delivery truth:** preserve intentional requester-yield and inactive-cron non-delivery as pending recorded outcomes, credit delivery only when requester-settle succeeds, and mark exhausted settle wakes blocked instead of delivered.
 - **Control UI staged attachments:** preserve unsent images, files, pasted images, and large pasted text across same-tab route and narrow split-pane remounts while keeping pane close, mismatched pane/session/Gateway remounts, application shutdown, and hard reload as cleanup boundaries. Fixes #121519. Thanks @shakkernerd.
 - **Control UI browser annotations:** keep marked screenshots and generated page context together in structured composer cards, preserve user-written drafts when annotations are removed or replaced, retain complete unsent annotation packages across same-tab route and active split-pane remounts, and offer bounded Undo without restoring removed context into another session. Fixes #120744. Thanks @shakkernerd.
 - **Control UI profile avatar refreshes:** carry canonical content revisions through mutation responses and live presence so rapid replacements refresh every connected browser without stale cache rollback. Thanks @shakkernerd.

--- a/scripts/bench-agent-concurrency-worker.ts
+++ b/scripts/bench-agent-concurrency-worker.ts
@@ -206,7 +206,7 @@ async function configureSpawnRuntime(
       return undefined;
     },
     cleanupBrowserSessionsForLifecycleEnd: async () => {},
-    runSubagentAnnounceFlow: async () => false,
+    runSubagentAnnounceFlow: async () => "retryable" as const,
     maybeWakeRequesterAfterAllChildrenSettled: async () => false,
     ensureContextEnginesInitialized: () => {},
     loadAgentRuntimePluginRegistryHandle: () => undefined,

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
@@ -319,12 +319,12 @@ describe("openclaw-tools: subagents (sessions_spawn lifecycle)", () => {
   });
 
   it("sessions_spawn retires bundle MCP runtime when run-mode cleanup completes", async () => {
-    let resumeAnnounceFlow: ((value: boolean) => void) | undefined;
+    let resumeAnnounceFlow: ((value: "delivered") => void) | undefined;
     let announceFlowStarted: (() => void) | undefined;
     const announceFlowStartedPromise = new Promise<void>((resolve) => {
       announceFlowStarted = resolve;
     });
-    const announceFlowGate = new Promise<boolean>((resolve) => {
+    const announceFlowGate = new Promise<"delivered">((resolve) => {
       resumeAnnounceFlow = resolve;
     });
     setSessionsSpawnAnnounceFlowOverride(async () => {
@@ -360,7 +360,7 @@ describe("openclaw-tools: subagents (sessions_spawn lifecycle)", () => {
     });
     expect(bundleMcpRuntimeTesting.getCachedSessionIds()).toContain("session:subagent:mcp-retire");
 
-    resumeAnnounceFlow?.(true);
+    resumeAnnounceFlow?.("delivered");
     await waitForRunCleanup(child.sessionKey);
     await waitForSessionsSpawnEvent(
       "bundle MCP runtime retirement",

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.test-harness.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.test-harness.ts
@@ -96,7 +96,7 @@ const hoisted = vi.hoisted(() => {
       });
     }
 
-    return true;
+    return "delivered";
   };
   const defaultCaptureSubagentCompletionReply: CaptureSubagentCompletionReply = async () =>
     undefined;

--- a/src/agents/subagent-orphan-recovery.restart-integration.test.ts
+++ b/src/agents/subagent-orphan-recovery.restart-integration.test.ts
@@ -115,7 +115,7 @@ describe("subagent orphan recovery — faithful restart path", () => {
     testing.setDepsForTest({
       ...createSubagentRegistryTestDeps(),
       getGatewayRecoveryRuntime: () => gatewayRuntime,
-      runSubagentAnnounceFlow: vi.fn(async () => true),
+      runSubagentAnnounceFlow: vi.fn(async () => "delivered" as const),
       onAgentEvent: vi.fn(() => () => undefined),
     });
     dispatchAgent.mockReset();
@@ -256,7 +256,7 @@ describe("subagent orphan recovery — faithful restart path", () => {
     testing.setDepsForTest({
       ...createSubagentRegistryTestDeps(),
       getGatewayRecoveryRuntime: () => gatewayRuntime,
-      runSubagentAnnounceFlow: vi.fn(async () => true),
+      runSubagentAnnounceFlow: vi.fn(async () => "delivered" as const),
       onAgentEvent: vi.fn(() => () => undefined),
       persistSubagentRunsToDiskOrThrow: (runs, changedRunIds) => {
         strictWriteCount += 1;
@@ -408,7 +408,7 @@ describe("subagent orphan recovery — faithful restart path", () => {
     testing.setDepsForTest({
       ...createSubagentRegistryTestDeps(),
       getGatewayRecoveryRuntime: () => gatewayRuntime,
-      runSubagentAnnounceFlow: vi.fn(async () => true),
+      runSubagentAnnounceFlow: vi.fn(async () => "delivered" as const),
       onAgentEvent: vi.fn(() => () => undefined),
       persistSubagentRunsToDiskOrThrow: (runs, changedRunIds) => {
         strictWriteCount += 1;
@@ -456,7 +456,7 @@ describe("subagent orphan recovery — faithful restart path", () => {
       ...createSubagentRegistryTestDeps(),
       callGateway,
       getGatewayRecoveryRuntime: () => gatewayRuntime,
-      runSubagentAnnounceFlow: vi.fn(async () => true),
+      runSubagentAnnounceFlow: vi.fn(async () => "delivered" as const),
       onAgentEvent: vi.fn(() => () => undefined),
     });
     initSubagentRegistry();
@@ -528,7 +528,7 @@ describe("subagent orphan recovery — faithful restart path", () => {
     testing.setDepsForTest({
       ...createSubagentRegistryTestDeps(),
       getGatewayRecoveryRuntime: () => gatewayRuntime,
-      runSubagentAnnounceFlow: vi.fn(async () => true),
+      runSubagentAnnounceFlow: vi.fn(async () => "delivered" as const),
       onAgentEvent: vi.fn(() => () => undefined),
     });
     initSubagentRegistry();
@@ -603,7 +603,7 @@ describe("subagent orphan recovery — faithful restart path", () => {
     testing.setDepsForTest({
       ...createSubagentRegistryTestDeps(),
       getGatewayRecoveryRuntime: () => gatewayRuntime,
-      runSubagentAnnounceFlow: vi.fn(async () => true),
+      runSubagentAnnounceFlow: vi.fn(async () => "delivered" as const),
       onAgentEvent: vi.fn(() => () => undefined),
       persistSubagentRunsToDiskOrThrow: (runs, changedRunIds) => {
         strictWriteCount += 1;

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -2816,7 +2816,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     );
   });
 
-  it("no-ops stale isolated cron run text completions", async () => {
+  it("records stale isolated cron run text completions as intentional non-delivery", async () => {
     const callGateway = createGatewayMock();
     const sendMessage = createSendMessageMock();
     const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeMock(true);
@@ -2832,9 +2832,20 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     });
 
     expectRecordFields(result, {
-      delivered: true,
+      delivered: false,
       path: "none",
-      phases: [{ phase: "direct-primary", delivered: true, path: "none", error: undefined }],
+      reason: "completion_handoff_pending",
+      terminal: true,
+      disposition: "intentional_non_delivery",
+      phases: [
+        {
+          phase: "direct-primary",
+          delivered: false,
+          path: "none",
+          reason: "completion_handoff_pending",
+          error: undefined,
+        },
+      ],
     });
     expect(queueEmbeddedAgentMessageWithOutcome).not.toHaveBeenCalled();
     expect(callGateway).not.toHaveBeenCalled();

--- a/src/agents/subagents/announce/subagent-announce-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.ts
@@ -1059,8 +1059,11 @@ async function sendSubagentAnnounceDirectly(params: {
       !agentMediatedCompletion
     ) {
       return {
-        delivered: true,
+        delivered: false,
         path: "none",
+        reason: "completion_handoff_pending",
+        terminal: true,
+        disposition: "intentional_non_delivery",
       };
     }
     if (params.signal?.aborted) {

--- a/src/agents/subagents/announce/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.format.e2e.test.ts
@@ -786,7 +786,7 @@ describe("subagent announce formatting", () => {
       expectsCompletionMessage: true,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sendSpy).not.toHaveBeenCalled();
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const call = getAgentCall() as { params?: Record<string, unknown> };
@@ -811,7 +811,7 @@ describe("subagent announce formatting", () => {
       expectsCompletionMessage: true,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sendSpy).not.toHaveBeenCalled();
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const call = getAgentCall() as { params?: Record<string, unknown> };
@@ -852,7 +852,7 @@ describe("subagent announce formatting", () => {
       expectsCompletionMessage: true,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sendSpy).not.toHaveBeenCalled();
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const call = getAgentCall() as { params?: Record<string, unknown> };
@@ -874,7 +874,7 @@ describe("subagent announce formatting", () => {
       roundOneReply: "ANNOUNCE_SKIP",
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sendSpy).not.toHaveBeenCalled();
     expect(agentSpy).not.toHaveBeenCalled();
   });
@@ -897,7 +897,7 @@ describe("subagent announce formatting", () => {
       roundOneReply: "  ANNOUNCE_SKIP  ",
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sendSpy).not.toHaveBeenCalled();
     expect(agentSpy).not.toHaveBeenCalled();
     expect(sessionsDeleteSpy).toHaveBeenCalledTimes(1);
@@ -915,7 +915,7 @@ describe("subagent announce formatting", () => {
       roundOneReply: " NO_REPLY ",
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sendSpy).not.toHaveBeenCalled();
     expect(agentSpy).toHaveBeenCalledTimes(1);
     expect(getAgentCall()?.params?.message).toContain("(no output)");
@@ -933,7 +933,7 @@ describe("subagent announce formatting", () => {
       roundOneReply: " NO_REPLY ",
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sendSpy).not.toHaveBeenCalled();
     expect(agentSpy).not.toHaveBeenCalled();
   });
@@ -971,7 +971,7 @@ describe("subagent announce formatting", () => {
         terminalReply,
       });
 
-      expect(didAnnounce).toBe(true);
+      expect(didAnnounce).toBe("delivered");
       expect(chatHistoryMock).not.toHaveBeenCalled();
       expect(readLatestAssistantReplyMock).not.toHaveBeenCalled();
       expect(agentSpy).toHaveBeenCalledTimes(expectedAgentCalls);
@@ -994,7 +994,7 @@ describe("subagent announce formatting", () => {
       fallbackReply: "final summary from prior completion",
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sendSpy).not.toHaveBeenCalled();
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const call = getAgentCall() as { params?: { message?: string } };
@@ -1018,7 +1018,7 @@ describe("subagent announce formatting", () => {
       roundOneReply: "final answer",
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(agentSpy).toHaveBeenCalledTimes(3);
     expect(sendSpy).not.toHaveBeenCalled();
   });
@@ -1037,7 +1037,7 @@ describe("subagent announce formatting", () => {
       roundOneReply: "final answer",
     });
 
-    expect(didAnnounce).toBe(false);
+    expect(didAnnounce).toBe("permanent_failure");
     expect(agentSpy).toHaveBeenCalledTimes(1);
     expect(sendSpy).not.toHaveBeenCalled();
   });
@@ -1058,7 +1058,7 @@ describe("subagent announce formatting", () => {
       roundOneReply: "worker result",
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(agentSpy).toHaveBeenCalledTimes(3);
     expect(sendSpy).not.toHaveBeenCalled();
   });
@@ -1095,7 +1095,7 @@ describe("subagent announce formatting", () => {
       roundOneReply: "worker result",
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(agentSpy).toHaveBeenCalledTimes(2);
     expect(sendSpy).not.toHaveBeenCalled();
   });
@@ -1127,7 +1127,7 @@ describe("subagent announce formatting", () => {
       expectsCompletionMessage: true,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sendSpy).not.toHaveBeenCalled();
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const call = getAgentCall() as { params?: Record<string, unknown> };
@@ -1191,7 +1191,7 @@ describe("subagent announce formatting", () => {
       spawnMode: "session",
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sendSpy).not.toHaveBeenCalled();
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const call = getAgentCall() as { params?: Record<string, unknown> };
@@ -1246,7 +1246,7 @@ describe("subagent announce formatting", () => {
       spawnMode: "session",
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sendSpy).not.toHaveBeenCalled();
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const call = getAgentCall() as { params?: Record<string, unknown> };
@@ -1407,7 +1407,7 @@ describe("subagent announce formatting", () => {
       spawnMode: "session",
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sendSpy).not.toHaveBeenCalled();
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const call = getAgentCall() as { params?: Record<string, unknown> };
@@ -1465,7 +1465,7 @@ describe("subagent announce formatting", () => {
         ...(testCase.spawnMode ? { spawnMode: testCase.spawnMode } : {}),
       });
 
-      expect(didAnnounce).toBe(true);
+      expect(didAnnounce).toBe("delivered");
       expect(sendSpy).not.toHaveBeenCalled();
       expect(agentSpy).toHaveBeenCalledTimes(1);
       const call = getAgentCall() as { params?: Record<string, unknown> };
@@ -1532,7 +1532,7 @@ describe("subagent announce formatting", () => {
         expectsCompletionMessage: true,
       });
 
-      expect(didAnnounce).toBe(true);
+      expect(didAnnounce).toBe("delivered");
       expect(sendSpy).not.toHaveBeenCalled();
       expect(agentSpy).toHaveBeenCalledTimes(1);
       const call = getAgentCall() as { params?: Record<string, unknown> };
@@ -1594,7 +1594,7 @@ describe("subagent announce formatting", () => {
       spawnMode: "session",
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sendSpy).not.toHaveBeenCalled();
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const call = getAgentCall() as { params?: Record<string, unknown> };
@@ -1657,7 +1657,7 @@ describe("subagent announce formatting", () => {
       spawnMode: "session",
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sendSpy).not.toHaveBeenCalled();
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const call = getAgentCall() as { params?: Record<string, unknown> };
@@ -1698,7 +1698,7 @@ describe("subagent announce formatting", () => {
       expectsCompletionMessage: true,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sendSpy).not.toHaveBeenCalled();
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const call = getAgentCall() as { params?: Record<string, unknown> };
@@ -1761,7 +1761,7 @@ describe("subagent announce formatting", () => {
         spawnMode: "session",
       });
 
-      expect(didAnnounce).toBe(true);
+      expect(didAnnounce).toBe("delivered");
       expect(subagentDeliveryTargetHookMock).toHaveBeenCalledWith(
         {
           childSessionKey: "agent:main:subagent:test",
@@ -1816,7 +1816,7 @@ describe("subagent announce formatting", () => {
       spawnMode: "session",
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sendSpy).not.toHaveBeenCalled();
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const call = getAgentCall() as { params?: Record<string, unknown> };
@@ -1861,7 +1861,7 @@ describe("subagent announce formatting", () => {
       spawnMode: "session",
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sendSpy).not.toHaveBeenCalled();
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const call = getAgentCall() as { params?: Record<string, unknown> };
@@ -2020,7 +2020,7 @@ describe("subagent announce formatting", () => {
       ...defaultOutcomeAnnounce,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sendSpy).toHaveBeenCalledTimes(0);
     expect(agentSpy).toHaveBeenCalledTimes(1);
     expectAgentCallFields(getAgentCall(), {
@@ -2047,7 +2047,7 @@ describe("subagent announce formatting", () => {
       ...defaultOutcomeAnnounce,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sendSpy).not.toHaveBeenCalled();
     expect(agentSpy).toHaveBeenCalledTimes(1);
     expectAgentCallFields(getAgentCall(), {
@@ -2080,7 +2080,7 @@ describe("subagent announce formatting", () => {
       ...defaultOutcomeAnnounce,
     });
 
-    expect(didAnnounce).toBe(false);
+    expect(didAnnounce).toBe("retryable");
     expect(sendSpy).not.toHaveBeenCalled();
     expect(agentSpy).toHaveBeenCalledTimes(1);
   });
@@ -2110,7 +2110,7 @@ describe("subagent announce formatting", () => {
       ...defaultOutcomeAnnounce,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sendSpy).not.toHaveBeenCalled();
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const call = getAgentCall() as { params?: { message?: string } };
@@ -2144,7 +2144,7 @@ describe("subagent announce formatting", () => {
       ...defaultOutcomeAnnounce,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sendSpy).not.toHaveBeenCalled();
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const call = getAgentCall() as { params?: { message?: string } };
@@ -2174,7 +2174,7 @@ describe("subagent announce formatting", () => {
       ...defaultOutcomeAnnounce,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sendSpy).not.toHaveBeenCalled();
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const call = getAgentCall() as { params?: { message?: string } };
@@ -2204,7 +2204,7 @@ describe("subagent announce formatting", () => {
       ...defaultOutcomeAnnounce,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(agentSpy).toHaveBeenCalledTimes(1);
 
     const call = getAgentCall() as { params?: Record<string, unknown> };
@@ -2308,7 +2308,7 @@ describe("subagent announce formatting", () => {
       ...defaultOutcomeAnnounce,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     const call = getAgentCall() as {
       params?: Record<string, unknown>;
       expectFinal?: boolean;
@@ -2331,7 +2331,7 @@ describe("subagent announce formatting", () => {
       ...defaultOutcomeAnnounce,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sendSpy).not.toHaveBeenCalled();
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const call = getAgentCall() as {
@@ -2358,7 +2358,7 @@ describe("subagent announce formatting", () => {
       ...defaultOutcomeAnnounce,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     const call = getAgentCall() as { params?: Record<string, unknown> };
     expect(call?.params?.sessionKey).toBe("agent:main:subagent:orchestrator");
     expect(call?.params?.deliver).toBe(false);
@@ -2382,7 +2382,7 @@ describe("subagent announce formatting", () => {
       ...defaultOutcomeAnnounce,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sendSpy).not.toHaveBeenCalled();
     const call = getAgentCall() as { params?: Record<string, unknown> };
     expect(call?.params?.sessionKey).toBe("agent:main:subagent:orchestrator");
@@ -2503,7 +2503,7 @@ describe("subagent announce formatting", () => {
         ...(testCase.roundOneReply ? { roundOneReply: testCase.roundOneReply } : {}),
       });
 
-      expect(didAnnounce).toBe(false);
+      expect(didAnnounce).toBe("retryable");
       expect(agentSpy).not.toHaveBeenCalled();
       expect(sendSpy).not.toHaveBeenCalled();
     }
@@ -2538,7 +2538,7 @@ describe("subagent announce formatting", () => {
       roundOneReply: "single leaf result",
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(agentSpy).toHaveBeenCalledTimes(1);
     expect(sendSpy).not.toHaveBeenCalled();
     const call = getAgentCall() as { params?: { message?: string } };
@@ -2611,7 +2611,7 @@ describe("subagent announce formatting", () => {
       roundOneReply: "placeholder waiting text that should be ignored",
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(subagentRegistryMock.listSubagentRunsForRequester).toHaveBeenCalledWith(
       "agent:main:subagent:parent",
       { requesterRunId: "run-parent-settled" },
@@ -2693,7 +2693,7 @@ describe("subagent announce formatting", () => {
       roundOneReply: "placeholder waiting text that should be ignored",
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     const call = getAgentCall() as { params?: { message?: string } };
     const msg = call?.params?.message ?? "";
     expect(msg).toContain("current result from child a");
@@ -2760,7 +2760,7 @@ describe("subagent announce formatting", () => {
       roundOneReply: "old parent fallback reply",
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const call = getAgentCall() as { params?: { message?: string } };
     const msg = call?.params?.message ?? "";
@@ -2830,7 +2830,7 @@ describe("subagent announce formatting", () => {
       roundOneReply: "waiting for children",
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const call = getAgentCall() as {
       params?: { sessionKey?: string; message?: string };
@@ -2894,7 +2894,7 @@ describe("subagent announce formatting", () => {
       roundOneReply: "waiting for children",
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(subagentRegistryMock.replaceSubagentRunAfterSteer).not.toHaveBeenCalled();
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const call = getAgentCall() as {
@@ -2964,7 +2964,7 @@ describe("subagent announce formatting", () => {
       ...defaultOutcomeAnnounce,
       expectsCompletionMessage: true,
     });
-    expect(parentDeferred).toBe(false);
+    expect(parentDeferred).toBe("retryable");
     expect(agentSpy).not.toHaveBeenCalled();
 
     const childAnnounced = await runSubagentAnnounceFlow({
@@ -2975,7 +2975,7 @@ describe("subagent announce formatting", () => {
       ...defaultOutcomeAnnounce,
       expectsCompletionMessage: true,
     });
-    expect(childAnnounced).toBe(true);
+    expect(childAnnounced).toBe("delivered");
 
     parentPending = 0;
     const parentAnnounced = await runSubagentAnnounceFlow({
@@ -2986,7 +2986,7 @@ describe("subagent announce formatting", () => {
       ...defaultOutcomeAnnounce,
       expectsCompletionMessage: true,
     });
-    expect(parentAnnounced).toBe(true);
+    expect(parentAnnounced).toBe("delivered");
     expect(agentSpy).toHaveBeenCalledTimes(2);
 
     const childCall = getAgentCall() as { params?: { message?: string } };
@@ -3015,7 +3015,7 @@ describe("subagent announce formatting", () => {
       ...defaultOutcomeAnnounce,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(agentSpy).not.toHaveBeenCalled();
     expect(sendSpy).not.toHaveBeenCalled();
     expect(subagentRegistryMock.countPendingDescendantRuns).not.toHaveBeenCalled();
@@ -3040,7 +3040,7 @@ describe("subagent announce formatting", () => {
       ...defaultOutcomeAnnounce,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     const call = getAgentCall() as { params?: Record<string, unknown> };
     expect(call?.params?.sessionKey).toBe("agent:main:main");
     expect(call?.params?.deliver).toBe(true);
@@ -3065,7 +3065,7 @@ describe("subagent announce formatting", () => {
       cleanup: "delete",
     });
 
-    expect(didAnnounce).toBe(false);
+    expect(didAnnounce).toBe("retryable");
     expect(subagentRegistryMock.resolveRequesterForChildSession).toHaveBeenCalledWith(
       "agent:main:subagent:orchestrator",
     );
@@ -3108,7 +3108,7 @@ describe("subagent announce formatting", () => {
         ...(testCase.expectsCompletionMessage ? { expectsCompletionMessage: true } : {}),
       });
 
-      expect(didAnnounce).toBe(false);
+      expect(didAnnounce).toBe("retryable");
       expect(agentSpy).not.toHaveBeenCalled();
       expect(sendSpy).not.toHaveBeenCalled();
     }
@@ -3136,7 +3136,7 @@ describe("subagent announce formatting", () => {
       ...defaultOutcomeAnnounce,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(agentSpy).toHaveBeenCalledTimes(1);
 
     const call = getAgentCall() as { params?: Record<string, unknown> };
@@ -3231,7 +3231,7 @@ describe("subagent announce formatting", () => {
         task: "QA task",
       });
 
-      expect(didAnnounce, testCase.name).toBe(true);
+      expect(didAnnounce, testCase.name).toBe("delivered");
       const call = getAgentCall() as { params?: Record<string, unknown> };
       expect(call?.params?.sessionKey, testCase.name).toBe(testCase.expectedSessionKey);
       expect(call?.params?.deliver, testCase.name).toBe(testCase.expectedDeliver);
@@ -3284,7 +3284,7 @@ describe("subagent announce formatting", () => {
         roundOneReply: "leaf says done",
       });
 
-      expect(didAnnounce).toBe(true);
+      expect(didAnnounce).toBe("delivered");
       expect(agentSpy).toHaveBeenCalledTimes(1);
       const call = getAgentCall() as { params?: { message?: string } };
       expect(call?.params?.message ?? "").toContain("leaf says done");
@@ -3318,7 +3318,7 @@ describe("subagent announce formatting", () => {
         roundOneReply: "placeholder waiting text",
       });
 
-      expect(didAnnounce).toBe(true);
+      expect(didAnnounce).toBe("delivered");
       const call = getAgentCall() as { params?: { message?: string } };
       const message = call?.params?.message ?? "";
       expect(message).toContain("Child completion results:");
@@ -3363,7 +3363,7 @@ describe("subagent announce formatting", () => {
         ...defaultOutcomeAnnounce,
         expectsCompletionMessage: true,
       });
-      expect(deferred).toBe(false);
+      expect(deferred).toBe("retryable");
       expect(agentSpy).not.toHaveBeenCalled();
 
       pending = 0;
@@ -3375,7 +3375,7 @@ describe("subagent announce formatting", () => {
         ...defaultOutcomeAnnounce,
         expectsCompletionMessage: true,
       });
-      expect(announced).toBe(true);
+      expect(announced).toBe("delivered");
       expect(agentSpy).toHaveBeenCalledTimes(1);
       const call = getAgentCall() as { params?: { message?: string } };
       const message = call?.params?.message ?? "";
@@ -3422,7 +3422,7 @@ describe("subagent announce formatting", () => {
         ...defaultOutcomeAnnounce,
         expectsCompletionMessage: true,
       });
-      expect(prematureAttempt).toBe(false);
+      expect(prematureAttempt).toBe("retryable");
       expect(agentSpy).not.toHaveBeenCalled();
 
       pendingSlowChild = 0;
@@ -3434,7 +3434,7 @@ describe("subagent announce formatting", () => {
         ...defaultOutcomeAnnounce,
         expectsCompletionMessage: true,
       });
-      expect(settledAttempt).toBe(true);
+      expect(settledAttempt).toBe("delivered");
       const call = getAgentCall() as { params?: { message?: string } };
       const message = call?.params?.message ?? "";
       expect(message).toContain("fast child result");
@@ -3495,7 +3495,7 @@ describe("subagent announce formatting", () => {
         ...defaultOutcomeAnnounce,
         expectsCompletionMessage: true,
       });
-      expect(middleDeferred).toBe(false);
+      expect(middleDeferred).toBe("retryable");
 
       middlePending = 0;
       const middleAnnounced = await runSubagentAnnounceFlow({
@@ -3506,7 +3506,7 @@ describe("subagent announce formatting", () => {
         ...defaultOutcomeAnnounce,
         expectsCompletionMessage: true,
       });
-      expect(middleAnnounced).toBe(true);
+      expect(middleAnnounced).toBe("delivered");
 
       const parentAnnounced = await runSubagentAnnounceFlow({
         childSessionKey: "agent:main:subagent:parent-nested",
@@ -3516,7 +3516,7 @@ describe("subagent announce formatting", () => {
         ...defaultOutcomeAnnounce,
         expectsCompletionMessage: true,
       });
-      expect(parentAnnounced).toBe(true);
+      expect(parentAnnounced).toBe("delivered");
       expect(agentSpy).toHaveBeenCalledTimes(2);
 
       const parentCall = getAgentCall(1);
@@ -3566,7 +3566,7 @@ describe("subagent announce formatting", () => {
         expectsCompletionMessage: true,
       });
 
-      expect(didAnnounce).toBe(true);
+      expect(didAnnounce).toBe("delivered");
       const call = getAgentCall() as { params?: { message?: string } };
       const message = call?.params?.message ?? "";
       const firstIndex = message.indexOf("result one");
@@ -3605,7 +3605,7 @@ describe("subagent announce formatting", () => {
         expectsCompletionMessage: true,
       });
 
-      expect(didAnnounce).toBe(true);
+      expect(didAnnounce).toBe("delivered");
       const call = getAgentCall() as { params?: { message?: string } };
       const message = call?.params?.message ?? "";
       expect(message).toContain("status: error: child exploded");
@@ -3641,7 +3641,7 @@ describe("subagent announce formatting", () => {
         ...defaultOutcomeAnnounce,
         expectsCompletionMessage: true,
       });
-      expect(first).toBe(false);
+      expect(first).toBe("retryable");
       expect(agentSpy).not.toHaveBeenCalled();
 
       pending = 0;
@@ -3653,7 +3653,7 @@ describe("subagent announce formatting", () => {
         ...defaultOutcomeAnnounce,
         expectsCompletionMessage: true,
       });
-      expect(second).toBe(true);
+      expect(second).toBe("delivered");
       expect(subagentRegistryMock.countPendingDescendantRuns).toHaveBeenCalledWith(
         "agent:main:subagent:parent-gated",
       );
@@ -3709,7 +3709,7 @@ describe("subagent announce formatting", () => {
         ...defaultOutcomeAnnounce,
         expectsCompletionMessage: true,
       });
-      expect(parentDeferred).toBe(false);
+      expect(parentDeferred).toBe("retryable");
 
       const childAnnounced = await runSubagentAnnounceFlow({
         childSessionKey,
@@ -3719,7 +3719,7 @@ describe("subagent announce formatting", () => {
         ...defaultOutcomeAnnounce,
         expectsCompletionMessage: true,
       });
-      expect(childAnnounced).toBe(true);
+      expect(childAnnounced).toBe("delivered");
 
       parentPending = 0;
       const parentAnnounced = await runSubagentAnnounceFlow({
@@ -3730,7 +3730,7 @@ describe("subagent announce formatting", () => {
         ...defaultOutcomeAnnounce,
         expectsCompletionMessage: true,
       });
-      expect(parentAnnounced).toBe(true);
+      expect(parentAnnounced).toBe("delivered");
       expect(agentSpy).toHaveBeenCalledTimes(2);
 
       const childCall = getAgentCall() as { params?: { message?: string } };

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
@@ -3,6 +3,7 @@
 // nested/cron/single-delivered paths.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SubagentRunRecord } from "../registry/subagent-registry.types.js";
+import type { SubagentAnnounceDeliveryResult } from "./subagent-announce-dispatch.js";
 
 const deliverSpy = vi.fn(
   async (
@@ -117,8 +118,14 @@ function transitionBatch(runIds: readonly string[], state: RequesterSettleWakeBa
   }
 }
 
-function completeBatch(runIds: readonly string[], rearmGeneration?: number): void {
-  if (rearmGeneration === undefined) {
+function completeBatch(
+  runIds: readonly string[],
+  rearmGeneration?: number,
+  outcome?: SubagentAnnounceDeliveryResult,
+): void {
+  if (outcome) {
+    completeBatchSpy(runIds, rearmGeneration, outcome);
+  } else if (rearmGeneration === undefined) {
     completeBatchSpy(runIds);
   } else {
     completeBatchSpy(runIds, rearmGeneration);
@@ -434,7 +441,10 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
     expect(deliveredCallArg().directIdempotencyKey).toBe(
       `announce:requester-settle:${REQUESTER}:run-b:yield-1`,
     );
-    expect(completeBatchSpy).toHaveBeenCalledWith(["run-b"], 1);
+    expect(completeBatchSpy).toHaveBeenCalledWith(["run-b"], 1, {
+      delivered: true,
+      path: "direct",
+    });
   });
 
   it.each([
@@ -491,7 +501,10 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
 
     expect(woke).toBe(true);
     expect(deliverSpy).toHaveBeenCalledOnce();
-    expect(completeBatchSpy).toHaveBeenCalledWith(["run-a"], 1);
+    expect(completeBatchSpy).toHaveBeenCalledWith(["run-a"], 1, {
+      delivered: true,
+      path: "direct",
+    });
   });
 
   it("wakes after a requester yields with one already-delivered completion", async () => {
@@ -522,7 +535,10 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
     expect(deliveredCallArg().directIdempotencyKey).toBe(
       `announce:requester-settle:${REQUESTER}:run-b:yield-1`,
     );
-    expect(completeBatchSpy).toHaveBeenCalledWith(["run-b"], 1);
+    expect(completeBatchSpy).toHaveBeenCalledWith(["run-b"], 1, {
+      delivered: true,
+      path: "direct",
+    });
   });
 
   it("wakes for a single required completion whose announce never delivered", async () => {
@@ -653,7 +669,10 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
         `announce:requester-settle:${REQUESTER}:run-b:yield-1`,
         `announce:requester-settle:${REQUESTER}:run-b:yield-1:retry-1`,
       ]);
-      expect(completeBatchSpy).toHaveBeenCalledWith(["run-b"], 1);
+      expect(completeBatchSpy).toHaveBeenCalledWith(["run-b"], 1, {
+        delivered: true,
+        path: "direct",
+      });
     } finally {
       vi.useRealTimers();
     }
@@ -742,6 +761,11 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
 
       expect(woke).toBe(false);
       expect(deliverSpy).toHaveBeenCalledTimes(3);
+      expect(completeBatchSpy).toHaveBeenLastCalledWith(["run-a", "run-b"], undefined, {
+        delivered: false,
+        path: "direct",
+        error: "undelivered",
+      });
     } finally {
       vi.useRealTimers();
       deliverSpy.mockReset().mockResolvedValue({ delivered: true, path: "direct" });
@@ -763,6 +787,11 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
 
     expect(woke).toBe(false);
     expect(deliverSpy).toHaveBeenCalledTimes(1);
+    expect(completeBatchSpy).toHaveBeenLastCalledWith(["run-a", "run-b"], undefined, {
+      delivered: false,
+      path: "direct",
+      disposition: "ambiguous",
+    });
   });
 
   it("does not consume retry budget when aborted before dispatch", async () => {
@@ -812,7 +841,10 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
       ).toBe(true);
       expect(String(deliveredCallArg().triggerMessage)).toContain("alpha findings");
       expect(String(deliveredCallArg().triggerMessage)).toContain("beta findings");
-      expect(completeBatchSpy).toHaveBeenLastCalledWith(["run-a", "run-b"]);
+      expect(completeBatchSpy).toHaveBeenLastCalledWith(["run-a", "run-b"], undefined, {
+        delivered: true,
+        path: "direct",
+      });
     });
 
     it("persists the frozen batch before dispatch", async () => {
@@ -983,7 +1015,10 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
       expect(
         await maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: mixed[1] })),
       ).toBe(true);
-      expect(completeBatchSpy).toHaveBeenLastCalledWith(["run-delete", "run-keep"]);
+      expect(completeBatchSpy).toHaveBeenLastCalledWith(["run-delete", "run-keep"], undefined, {
+        delivered: true,
+        path: "direct",
+      });
 
       deliverSpy.mockClear();
       completeBatchSpy.mockClear();

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
@@ -24,6 +24,7 @@ import {
   deliverSubagentAnnouncement,
   loadRequesterSessionEntry,
 } from "./subagent-announce-delivery.js";
+import type { SubagentAnnounceDeliveryResult } from "./subagent-announce-dispatch.js";
 import { resolveAnnounceOrigin } from "./subagent-announce-origin.js";
 import {
   buildChildCompletionFindings,
@@ -190,13 +191,18 @@ function deferRequesterSettleWakeBatch(params: {
 function completeRequesterSettleWakeBatch(params: {
   runIds: readonly string[];
   state: RequesterSettleWakeBatchState;
-  completeBatch(runIds: readonly string[], rearmGeneration?: number): void;
+  delivery?: SubagentAnnounceDeliveryResult;
+  completeBatch(
+    runIds: readonly string[],
+    rearmGeneration?: number,
+    delivery?: SubagentAnnounceDeliveryResult,
+  ): void;
 }): void {
   if (params.state.rearmGeneration === undefined) {
-    params.completeBatch(params.runIds);
+    params.completeBatch(params.runIds, undefined, params.delivery);
     return;
   }
-  params.completeBatch(params.runIds, params.state.rearmGeneration);
+  params.completeBatch(params.runIds, params.state.rearmGeneration, params.delivery);
 }
 
 /**
@@ -209,18 +215,26 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
   requesterOrigin?: DeliveryContext;
   settledEntry: SubagentRunRecord;
   transitionBatch: (runIds: readonly string[], state: RequesterSettleWakeBatchState) => void;
-  completeBatch(runIds: readonly string[], rearmGeneration?: number): void;
+  completeBatch(
+    runIds: readonly string[],
+    rearmGeneration?: number,
+    delivery?: SubagentAnnounceDeliveryResult,
+  ): void;
   signal?: AbortSignal;
 }): Promise<boolean> {
   if (params.signal?.aborted) {
     return false;
   }
-  const completeBatch = (runIds: readonly string[], rearmGeneration?: number): void => {
+  const completeBatch = (
+    runIds: readonly string[],
+    rearmGeneration?: number,
+    delivery?: SubagentAnnounceDeliveryResult,
+  ): void => {
     if (rearmGeneration === undefined) {
-      params.completeBatch(runIds);
+      params.completeBatch(runIds, undefined, delivery);
       return;
     }
-    params.completeBatch(runIds, rearmGeneration);
+    params.completeBatch(runIds, rearmGeneration, delivery);
   };
   const requesterSessionKey = params.requesterSessionKey.trim();
   const initialState = params.settledEntry.requesterSettleWake;
@@ -333,6 +347,7 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
       runIds: batchRunIds,
       state: selectedState,
       completeBatch,
+      delivery: { delivered: false, path: "none", error: "requester session unavailable" },
     });
     return false;
   }
@@ -400,6 +415,11 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
           runIds: batchRunIds,
           state,
           completeBatch,
+          delivery: {
+            delivered: false,
+            path: "none",
+            error: state.lastError ?? "requester settle wake attempts exhausted",
+          },
         });
         return false;
       }
@@ -452,6 +472,7 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
           runIds: batchRunIds,
           state,
           completeBatch,
+          delivery: { delivered: false, path: "none", error: lastError },
         });
         return false;
       }
@@ -478,6 +499,7 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
         runIds: batchRunIds,
         state,
         completeBatch,
+        delivery,
       });
       return true;
     }
@@ -491,21 +513,23 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
         runIds: batchRunIds,
         state,
         completeBatch,
+        delivery,
       });
       return false;
     }
 
     const attemptCount = attemptIndex + 1;
     const retryDelayMs = REQUESTER_SETTLE_WAKE_RETRY_DELAYS_MS[attemptIndex];
+    const lastError = delivery.error ?? delivery.reason ?? "undelivered";
     if (attemptCount >= REQUESTER_SETTLE_WAKE_MAX_ATTEMPTS || retryDelayMs === undefined) {
       completeRequesterSettleWakeBatch({
         runIds: batchRunIds,
         state,
         completeBatch,
+        delivery: { ...delivery, error: lastError },
       });
       return false;
     }
-    const lastError = delivery.error ?? delivery.reason ?? "undelivered";
     const nextAttemptAt = Date.now() + retryDelayMs;
     params.transitionBatch(batchRunIds, {
       status: "pending",

--- a/src/agents/subagents/announce/subagent-announce.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.test.ts
@@ -341,7 +341,7 @@ describe("subagent announce seam flow", () => {
       roundOneReply: "  ANNOUNCE_SKIP  ",
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(agentSpy).not.toHaveBeenCalled();
     expect(sessionsDeleteSpy).toHaveBeenCalledTimes(1);
     expect(sessionsDeleteSpy).toHaveBeenCalledWith({
@@ -372,7 +372,7 @@ describe("subagent announce seam flow", () => {
       onBeforeDeleteChildSession: () => false,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sessionsDeleteSpy).not.toHaveBeenCalled();
   });
 
@@ -393,7 +393,7 @@ describe("subagent announce seam flow", () => {
       isCompletionDeliveryAllowed: () => true,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(agentSpy).toHaveBeenCalledTimes(1);
     expect(sessionsDeleteSpy).not.toHaveBeenCalled();
   });
@@ -414,7 +414,7 @@ describe("subagent announce seam flow", () => {
       isCompletionDeliveryAllowed: () => false,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("intentional_non_delivery");
     expect(agentSpy).not.toHaveBeenCalled();
   });
 
@@ -436,7 +436,7 @@ describe("subagent announce seam flow", () => {
       roundOneReply: "ANNOUNCE_SKIP",
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(logSpy).toHaveBeenCalledWith(
       expect.stringContaining("cron job completion for session=agent:main:cron:daily-report"),
     );
@@ -463,7 +463,7 @@ describe("subagent announce seam flow", () => {
       fallbackReply: "an actual fallback result",
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(logSpy).not.toHaveBeenCalled();
     logSpy.mockRestore();
   });
@@ -492,7 +492,7 @@ describe("subagent announce seam flow", () => {
       expectsCompletionMessage: true,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(sessionsDeleteSpy).toHaveBeenCalledTimes(1);
     expect(sessionsDeleteSpy).toHaveBeenCalledWith({
       method: "sessions.delete",
@@ -551,7 +551,7 @@ describe("subagent announce seam flow", () => {
       outcome: { status: "ok" },
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     const queuedCall = requireQueuedMessageCall();
     expect(queuedCall?.[0]).toBe("session-origin-provider-steer");
     expect(queuedCall?.[1]).toContain("[Internal task completion event]");
@@ -583,7 +583,7 @@ describe("subagent announce seam flow", () => {
       bestEffortDeliver: true,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const agentCall = requireAgentCall();
     expect(agentCall.method).toBe("agent");
@@ -616,7 +616,7 @@ describe("subagent announce seam flow", () => {
       bestEffortDeliver: true,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const params = requireAgentCall().params ?? {};
     expect(params.sessionKey).toBe("agent:main:subagent:orchestrator");
@@ -660,7 +660,7 @@ describe("subagent announce seam flow", () => {
       expectsCompletionMessage: true,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const agentCall = requireAgentCall();
     expect(agentCall.params?.deliver).toBe(true);
@@ -693,7 +693,7 @@ describe("subagent announce seam flow", () => {
       expectsCompletionMessage: true,
     });
 
-    expect(didAnnounce).toBe(false);
+    expect(didAnnounce).toBe("retryable");
     expect(logSpy).toHaveBeenCalledWith(
       "[warn] Subagent completion direct announce failed for run run-direct-failure-log: Outbound not configured for slack",
     );
@@ -738,7 +738,7 @@ describe("subagent announce seam flow", () => {
       },
     });
 
-    expect(didAnnounce).toBe(false);
+    expect(didAnnounce).toBe("ambiguous");
     expect(deliveryResult).toMatchObject({
       delivered: false,
       path: "direct",

--- a/src/agents/subagents/announce/subagent-announce.timeout.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.timeout.test.ts
@@ -346,7 +346,7 @@ describe("subagent announce timeout config", () => {
         },
         expectsCompletionMessage: true,
       });
-      await expect(announcePromise).resolves.toBe(false);
+      await expect(announcePromise).resolves.toBe("retryable");
 
       const directAgentCalls = gatewayCalls.filter(
         (call) => call.method === "agent" && call.expectFinal === true,
@@ -366,7 +366,7 @@ describe("subagent announce timeout config", () => {
       requesterDisplayKey: "agent:main:subagent:parent",
     });
 
-    expect(didAnnounce).toBe(false);
+    expect(didAnnounce).toBe("retryable");
     expect(
       findGatewayCall((call) => call.method === "agent" && call.expectFinal === true),
     ).toBeUndefined();
@@ -379,7 +379,7 @@ describe("subagent announce timeout config", () => {
       requesterOrigin: { channel: "discord", to: "channel:cron" },
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe("delivered");
     const directAgentCall = findGatewayCall(
       (call) => call.method === "agent" && call.expectFinal === true,
     );
@@ -556,7 +556,7 @@ describe("subagent announce timeout config", () => {
       roundOneReply: undefined,
     });
 
-    expect(didAnnounce).toBe(false);
+    expect(didAnnounce).toBe("retryable");
     expect(findFinalDirectAgentCall()).toBeUndefined();
   });
 

--- a/src/agents/subagents/announce/subagent-announce.timeout.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.timeout.test.ts
@@ -244,7 +244,7 @@ function setConfiguredAnnounceTimeout(timeoutMs: number): void {
 async function runAnnounceFlowForTest(
   childRunId: string,
   overrides: Partial<AnnounceFlowParams> = {},
-): Promise<boolean> {
+): ReturnType<typeof runSubagentAnnounceFlow> {
   return await runSubagentAnnounceFlow({
     ...baseAnnounceFlowParams,
     childRunId,

--- a/src/agents/subagents/announce/subagent-announce.ts
+++ b/src/agents/subagents/announce/subagent-announce.ts
@@ -94,6 +94,9 @@ export { captureSubagentCompletionReply } from "./subagent-announce-output.js";
 export type { SubagentRunOutcome } from "./subagent-announce-output.js";
 
 export type SubagentAnnounceType = "subagent task" | "cron job";
+export type SubagentAnnounceFlowOutcome = NonNullable<
+  SubagentAnnounceDeliveryResult["disposition"]
+>;
 
 function buildAnnounceReplyInstruction(params: {
   requesterIsSubagent: boolean;
@@ -181,8 +184,8 @@ export async function runSubagentAnnounceFlow(params: {
   bestEffortDeliver?: boolean;
   onDeliveryResult?: (delivery: SubagentAnnounceDeliveryResult) => void;
   onBeforeDeleteChildSession?: () => boolean;
-}): Promise<boolean> {
-  let didAnnounce = false;
+}): Promise<SubagentAnnounceFlowOutcome> {
+  let announceOutcome: SubagentAnnounceFlowOutcome = "retryable";
   const expectsCompletionMessage = params.expectsCompletionMessage === true;
   const announceType = params.announceType ?? "subagent task";
   let shouldDeleteChildSession = params.cleanup === "delete";
@@ -217,7 +220,7 @@ export async function runSubagentAnnounceFlow(params: {
         shouldDeleteChildSession = false;
         // Keep delete cleanup retryable until the active child can be removed.
         if (outcome?.status !== "timeout" || params.cleanup === "delete") {
-          return false;
+          return "retryable";
         }
       }
     }
@@ -260,7 +263,7 @@ export async function runSubagentAnnounceFlow(params: {
           targetRequesterSessionKey,
         )
       ) {
-        return true;
+        return "delivered";
       }
 
       const pendingChildDescendantRuns = !childSessionEffectsAllowed()
@@ -268,7 +271,7 @@ export async function runSubagentAnnounceFlow(params: {
         : Math.max(0, subagentRegistryRuntime.countPendingDescendantRuns(params.childSessionKey));
       if (pendingChildDescendantRuns > 0 && announceType !== "cron job") {
         shouldDeleteChildSession = false;
-        return false;
+        return "retryable";
       }
 
       if (
@@ -325,7 +328,7 @@ export async function runSubagentAnnounceFlow(params: {
       });
       if (woke) {
         shouldDeleteChildSession = false;
-        return true;
+        return "delivered";
       }
     }
 
@@ -342,7 +345,7 @@ export async function runSubagentAnnounceFlow(params: {
     if (!childCompletionFindings) {
       if (params.terminalReply?.disposition === "silent") {
         if (!hasVisibleFallback && (isAnnounceSkip(fallbackReply) || !expectsCompletionMessage)) {
-          return true;
+          return "delivered";
         }
         reply = cleanedFallbackReply;
       }
@@ -415,14 +418,14 @@ export async function runSubagentAnnounceFlow(params: {
               !expectsCompletionMessage ||
               hasVisibleFallback
             ) {
-              return true;
+              return "delivered";
             }
             reply = undefined;
           }
         } else if (reply) {
           reply = stripAndClassifyReply(reply) ?? cleanedFallbackReply;
           if (!reply) {
-            return true;
+            return "delivered";
           }
         }
       }
@@ -470,7 +473,7 @@ export async function runSubagentAnnounceFlow(params: {
       } = subagentRegistryRuntime ?? (await loadSubagentRegistryRuntime());
       if (!isSubagentSessionRunActive(targetRequesterSessionKey)) {
         if (shouldIgnorePostCompletionAnnounceForSession(targetRequesterSessionKey)) {
-          return true;
+          return "delivered";
         }
         const parentSessionEntry = loadSessionEntryByKey(targetRequesterSessionKey);
         const parentSessionAlive = hasUsableSessionEntry(parentSessionEntry);
@@ -479,7 +482,7 @@ export async function runSubagentAnnounceFlow(params: {
           const fallback = resolveRequesterForChildSession(targetRequesterSessionKey);
           if (!fallback?.requesterSessionKey) {
             shouldDeleteChildSession = false;
-            return false;
+            return "retryable";
           }
           targetRequesterSessionKey = fallback.requesterSessionKey;
           targetRequesterOrigin =
@@ -581,7 +584,7 @@ export async function runSubagentAnnounceFlow(params: {
       signal: params.signal,
     });
     reportDeliveryResult(delivery);
-    didAnnounce = delivery.delivered || delivery.disposition === "intentional_non_delivery";
+    announceOutcome = delivery.disposition ?? (delivery.delivered ? "delivered" : "retryable");
     if (!delivery.delivered && delivery.path === "direct" && delivery.error) {
       defaultRuntime.log(
         `[warn] Subagent completion direct announce failed for run ${params.childRunId}: ${delivery.error}`,
@@ -607,7 +610,7 @@ export async function runSubagentAnnounceFlow(params: {
       });
     }
   }
-  return didAnnounce;
+  return announceOutcome;
 }
 
 export const testing = {

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-cleanup.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-cleanup.ts
@@ -33,6 +33,7 @@ import { loadSubagentSessionEntry } from "./subagent-session-reconciliation.js";
 
 type RunSubagentAnnounceFlow =
   (typeof import("../announce/subagent-announce.js"))["runSubagentAnnounceFlow"];
+type SubagentAnnounceFlowOutcome = Awaited<ReturnType<RunSubagentAnnounceFlow>>;
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 import { deleteSubagentSessionForCleanup } from "./subagent-session-cleanup.js";
 
@@ -199,7 +200,7 @@ export function createSubagentRegistryLifecycleCleanup(
   const finalizeSubagentCleanup = async (
     runId: string,
     cleanup: "delete" | "keep",
-    didAnnounce: boolean,
+    announceOutcome: SubagentAnnounceFlowOutcome,
     cleanupGeneration: number,
     options?: {
       skipAnnounce?: boolean;
@@ -247,12 +248,13 @@ export function createSubagentRegistryLifecycleCleanup(
       }
       return;
     }
-    if (didAnnounce) {
+    if (announceOutcome === "delivered" || announceOutcome === "intentional_non_delivery") {
       const delivery = ensureDeliveryState(entry);
       const shouldCreditDelivery =
-        !options?.skipAnnounce ||
-        delivery.status === "delivered" ||
-        typeof delivery.announcedAt === "number";
+        announceOutcome === "delivered" &&
+        (!options?.skipAnnounce ||
+          delivery.status === "delivered" ||
+          typeof delivery.announcedAt === "number");
       if (shouldCreditDelivery) {
         const deliveredAt = delivery.deliveredAt ?? delivery.announcedAt ?? Date.now();
         delivery.status = "delivered";
@@ -263,7 +265,18 @@ export function createSubagentRegistryLifecycleCleanup(
           params.persist(runId);
         }
       }
-      clearPendingFinalDelivery(entry);
+      if (announceOutcome === "delivered") {
+        clearPendingFinalDelivery(entry);
+      } else {
+        // The requester-settle batch owns the real delivery now. Retire the
+        // per-child retry obligation without converting the handoff into success.
+        delivery.status = "pending";
+        delivery.disposition = "intentional_non_delivery";
+        delivery.payload = undefined;
+        delivery.createdAt = undefined;
+        delivery.attemptCount = undefined;
+        delivery.nextAttemptAt = undefined;
+      }
       const finalDelivery = ensureDeliveryState(entry);
       if (shouldCreditDelivery) {
         finalDelivery.status = "delivered";
@@ -275,9 +288,13 @@ export function createSubagentRegistryLifecycleCleanup(
           entry,
           deliveryStatus: "delivered",
         });
+      } else if (announceOutcome === "intentional_non_delivery" && !options?.skipDeliveryStatus) {
+        safeSetSubagentTaskDeliveryStatus({ entry, deliveryStatus: "pending" });
       }
-      finalDelivery.lastError = undefined;
-      finalDelivery.lastDropReason = undefined;
+      if (announceOutcome === "delivered") {
+        finalDelivery.lastError = undefined;
+        finalDelivery.lastDropReason = undefined;
+      }
       entry.wakeOnDescendantSettle = undefined;
       const completion = ensureCompletionState(entry);
       completion.fallbackResultText = undefined;
@@ -311,7 +328,7 @@ export function createSubagentRegistryLifecycleCleanup(
       return;
     }
 
-    if (entry.delivery?.disposition === "session_queued") {
+    if (announceOutcome === "session_queued") {
       // The correlated queue owns transport now. Settlement, not admission,
       // decides delivered versus blocked and re-enters cleanup afterward.
       entry.cleanupHandled = false;
@@ -356,7 +373,7 @@ export function createSubagentRegistryLifecycleCleanup(
 
     markPendingFinalDelivery({
       entry,
-      error: didAnnounce ? undefined : "announce deferred or direct delivery failed",
+      error: "announce deferred or direct delivery failed",
     });
     const delivery = ensureDeliveryState(entry);
     delivery.windowStartedAt ??= entry.execution.endedAt ?? now;
@@ -389,7 +406,7 @@ export function createSubagentRegistryLifecycleCleanup(
         entry,
         cleanupGeneration,
         run: async () => {
-          await finalizeSubagentCleanup(runId, cleanup, true, cleanupGeneration, {
+          await finalizeSubagentCleanup(runId, cleanup, "delivered", cleanupGeneration, {
             skipAnnounce: true,
           });
         },
@@ -482,7 +499,7 @@ export function createSubagentRegistryLifecycleCleanup(
             await retireSupersededCleanupIfNeeded(runId, entry, cleanupGeneration);
             return;
           }
-          await finalizeSubagentCleanup(runId, cleanup, true, cleanupGeneration, {
+          await finalizeSubagentCleanup(runId, cleanup, "delivered", cleanupGeneration, {
             skipAnnounce: true,
             skipDeliveryStatus: true,
             skipRequesterDelivery,
@@ -494,13 +511,13 @@ export function createSubagentRegistryLifecycleCleanup(
     const pendingPayload = loadPendingFinalDeliveryPayload(entry);
     const requesterOrigin = normalizeDeliveryContext(pendingPayload.requesterOrigin);
     let latestDeliveryError = getDeliveryLastError(entry);
-    const finalizeAnnounceCleanup = async (didAnnounce: boolean) => {
+    const finalizeAnnounceCleanup = async (announceOutcome: SubagentAnnounceFlowOutcome) => {
       if (!isCleanupAttemptCurrent(runId, entry, cleanupGeneration)) {
         await retireSupersededCleanupIfNeeded(runId, entry, cleanupGeneration);
         return;
       }
       const shouldCreditPriorDelivery =
-        !didAnnounce && (await hasPriorRequesterDeliveryMirror(entry));
+        announceOutcome !== "delivered" && (await hasPriorRequesterDeliveryMirror(entry));
       if (!isCleanupAttemptCurrent(runId, entry, cleanupGeneration)) {
         await retireSupersededCleanupIfNeeded(runId, entry, cleanupGeneration);
         return;
@@ -508,13 +525,13 @@ export function createSubagentRegistryLifecycleCleanup(
       if (shouldCreditPriorDelivery) {
         latestDeliveryError = undefined;
       }
-      if (!didAnnounce && latestDeliveryError) {
+      if (announceOutcome !== "delivered" && latestDeliveryError) {
         ensureDeliveryState(entry).lastError = latestDeliveryError;
       }
       await finalizeSubagentCleanup(
         runId,
         cleanup,
-        didAnnounce || shouldCreditPriorDelivery,
+        shouldCreditPriorDelivery ? "delivered" : announceOutcome,
         cleanupGeneration,
       );
     };
@@ -578,7 +595,7 @@ export function createSubagentRegistryLifecycleCleanup(
           latestDeliveryError = undefined;
           return;
         }
-        if (delivery.path === "none") {
+        if (delivery.path === "none" && delivery.disposition !== "intentional_non_delivery") {
           ensureDeliveryState(entry).lastDropReason = "sink_unavailable";
         }
         latestDeliveryError = formatAnnounceDeliveryError(delivery);
@@ -593,15 +610,15 @@ export function createSubagentRegistryLifecycleCleanup(
       entry,
       cleanupGeneration,
       run: async () => {
-        let didAnnounce = false;
+        let announceOutcome: SubagentAnnounceFlowOutcome = "retryable";
         try {
-          didAnnounce = await params.runSubagentAnnounceFlow(announceParams);
+          announceOutcome = await params.runSubagentAnnounceFlow(announceParams);
         } catch (error) {
           defaultRuntime.log(
             `[warn] Subagent announce flow failed during cleanup for run ${runId}: ${String(error)}`,
           );
         }
-        await finalizeAnnounceCleanup(didAnnounce);
+        await finalizeAnnounceCleanup(announceOutcome);
       },
     });
     return true;

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-delivery.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-delivery.ts
@@ -14,6 +14,7 @@ import {
   setDetachedTaskDeliveryStatusByRunId,
 } from "../../../tasks/detached-task-runtime.js";
 import { resolveRequiredCompletionDeliveryFailureTerminalResult } from "../../../tasks/task-completion-contract.js";
+import type { TaskDeliveryStatus } from "../../../tasks/task-registry.types.js";
 import {
   buildAnnounceIdFromChildRun,
   buildAnnounceIdempotencyKey,
@@ -51,6 +52,7 @@ export function createSubagentRegistryLifecycleDelivery(
   const formatAnnounceDeliveryError = (delivery: SubagentAnnounceDeliveryResult): string => {
     const errors = [
       delivery.error,
+      delivery.reason,
       ...(delivery.phases ?? []).map((phase) =>
         phase.error ? `${phase.phase}: ${phase.error}` : undefined,
       ),
@@ -164,7 +166,7 @@ export function createSubagentRegistryLifecycleDelivery(
 
   const safeSetSubagentTaskDeliveryStatus = (args: {
     entry: SubagentRunRecord;
-    deliveryStatus: "delivered" | "failed";
+    deliveryStatus: Extract<TaskDeliveryStatus, "pending" | "delivered" | "failed">;
     deliveryError?: string;
   }) => {
     const target = resolveSubagentTaskTarget(args.entry);

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-requester-wake.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-requester-wake.ts
@@ -1,10 +1,13 @@
 import { runWithoutOwnedSessionTranscriptWrites } from "../../../config/sessions/transcript-write-context.js";
 import { runWithGatewayIndependentRootWorkContinuation } from "../../../process/gateway-work-admission.js";
+import type { SubagentAnnounceDeliveryResult } from "../announce/subagent-announce-dispatch.js";
+import { ensureDeliveryState } from "./subagent-delivery-state.js";
 import type { createSubagentRegistryLifecycleCommon } from "./subagent-registry-lifecycle-common.js";
 import type {
   SubagentRegistryLifecycleParams,
   SubagentRegistryLifecycleState,
 } from "./subagent-registry-lifecycle-contracts.js";
+import type { createSubagentRegistryLifecycleDelivery } from "./subagent-registry-lifecycle-delivery.js";
 import type { RequesterSettleWakeState, SubagentRunRecord } from "./subagent-registry.types.js";
 import { hasSubagentRunEnded } from "./subagent-run-liveness.js";
 
@@ -15,6 +18,7 @@ export function createSubagentRegistryLifecycleRequesterWake(
   params: SubagentRegistryLifecycleParams,
   lifecycleState: SubagentRegistryLifecycleState,
   common: ReturnType<typeof createSubagentRegistryLifecycleCommon>,
+  deliveryHelpers: ReturnType<typeof createSubagentRegistryLifecycleDelivery>,
 ) {
   const {
     pendingRequesterSettleWakeRearms,
@@ -22,6 +26,8 @@ export function createSubagentRegistryLifecycleRequesterWake(
     scheduledRequesterSettleWakeTimers,
   } = lifecycleState;
   const { buildSafeLifecycleErrorMeta, maskRunId, maskSessionKey } = common;
+  const { safeMarkRequiredCompletionDeliveryBlocked, safeSetSubagentTaskDeliveryStatus } =
+    deliveryHelpers;
 
   const transitionRequesterSettleWakeBatch = (
     runIds: readonly string[],
@@ -59,6 +65,7 @@ export function createSubagentRegistryLifecycleRequesterWake(
   const completeRequesterSettleWakeBatch = (
     runIds: readonly string[],
     rearmGeneration?: number,
+    outcome?: SubagentAnnounceDeliveryResult,
   ) => {
     const entries = runIds
       .map((runId) => [runId, params.runs.get(runId)] as const)
@@ -72,10 +79,35 @@ export function createSubagentRegistryLifecycleRequesterWake(
     }
     const requesterSessionKeys = new Set(entries.map(([, entry]) => entry.requesterSessionKey));
     const previousStates = entries.map(([, entry]) => ({
+      delivery: structuredClone(entry.delivery),
       requesterSettleWake: structuredClone(entry.requesterSettleWake),
       retireAfterRequesterTurn: entry.retireAfterRequesterTurn,
     }));
+    const settledDeliveries: SubagentRunRecord[] = [];
     for (const [runId, entry] of entries) {
+      if (
+        outcome &&
+        entry.expectsCompletionMessage === true &&
+        entry.delivery?.status !== "delivered"
+      ) {
+        const delivery = ensureDeliveryState(entry);
+        if (outcome.delivered) {
+          const deliveredAt = outcome.deliveredAt ?? Date.now();
+          delivery.status = "delivered";
+          delivery.disposition = "delivered";
+          delivery.deliveredAt = deliveredAt;
+          delivery.announcedAt = deliveredAt;
+          delivery.lastError = undefined;
+          delivery.lastDropReason = undefined;
+        } else {
+          delivery.status = "failed";
+          delivery.disposition = outcome.disposition ?? delivery.disposition;
+          delivery.lastError = outcome.error ?? outcome.reason ?? "requester settle wake failed";
+          delivery.deliveredAt = undefined;
+          delivery.announcedAt = undefined;
+        }
+        settledDeliveries.push(entry);
+      }
       if (entry.requesterTurnRunId) {
         entry.retireAfterRequesterTurn =
           entry.retireAfterRequesterTurn === true ||
@@ -95,10 +127,24 @@ export function createSubagentRegistryLifecycleRequesterWake(
       entries.forEach(([runId, entry], index) => {
         const previous = previousStates[index];
         params.runs.set(runId, entry);
+        entry.delivery = previous?.delivery;
         entry.requesterSettleWake = previous?.requesterSettleWake;
         entry.retireAfterRequesterTurn = previous?.retireAfterRequesterTurn;
       });
       throw error;
+    }
+    for (const entry of settledDeliveries) {
+      if (outcome?.delivered) {
+        safeSetSubagentTaskDeliveryStatus({ entry, deliveryStatus: "delivered" });
+      } else if (outcome) {
+        const error = outcome.error ?? outcome.reason ?? "requester settle wake failed";
+        safeSetSubagentTaskDeliveryStatus({
+          entry,
+          deliveryStatus: "failed",
+          deliveryError: error,
+        });
+        safeMarkRequiredCompletionDeliveryBlocked({ entry, reason: error });
+      }
     }
     for (const [runId, entry] of entries) {
       const retryTimer = scheduledRequesterSettleWakeTimers.get(runId);

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -36,6 +36,9 @@ import type { SubagentRunRecord } from "./subagent-registry.types.js";
 type LifecycleControllerParams = Parameters<typeof createSubagentRegistryLifecycleController>[0];
 type LifecycleController = ReturnType<typeof createSubagentRegistryLifecycleController>;
 type SubagentCompletionParams = Parameters<LifecycleController["completeSubagentRun"]>[0];
+type AnnounceFlowOutcome = Awaited<
+  ReturnType<LifecycleControllerParams["runSubagentAnnounceFlow"]>
+>;
 type RestartRecoveryReceipt = NonNullable<SubagentRunRecord["execution"]["restartRecovery"]>;
 
 describe("subagent recovery session-effect ownership", () => {
@@ -169,7 +172,7 @@ vi.mock("../../../utils/delivery-context.shared.js", () => ({
 
 vi.mock("../announce/subagent-announce.js", () => ({
   captureSubagentCompletionReply: vi.fn(async () => undefined),
-  runSubagentAnnounceFlow: vi.fn(async () => false),
+  runSubagentAnnounceFlow: vi.fn(async () => "retryable" as const),
 }));
 
 vi.mock("./subagent-registry-cleanup.js", () => ({
@@ -391,7 +394,7 @@ function createLifecycleController({
     callGateway: async <T = Record<string, unknown>>(opts: CallGatewayOptions): Promise<T> =>
       (await gatewayMocks.callGateway(opts)) as T,
     captureSubagentCompletionReply: vi.fn(async () => "final completion reply"),
-    runSubagentAnnounceFlow: vi.fn(async () => true),
+    runSubagentAnnounceFlow: vi.fn(async () => "delivered" as const),
     maybeWakeRequesterAfterAllChildrenSettled: vi.fn(
       async (wakeParams: {
         settledEntry: { runId: string };
@@ -442,7 +445,7 @@ async function runNoReplyMirrorScenario(params: {
         path: "direct",
         error: "completion agent did not produce a visible reply",
       });
-      return false;
+      return "retryable" as const;
     },
   );
   gatewayMocks.callGateway.mockResolvedValueOnce({
@@ -511,7 +514,7 @@ describe("subagent registry lifecycle hardening", () => {
     async ({ terminalReply, resultText }) => {
       const entry = createRunEntry({ expectsCompletionMessage: true });
       const captureSubagentCompletionReply = vi.fn(async () => "stale transcript reply");
-      const runSubagentAnnounceFlow = vi.fn(async () => true);
+      const runSubagentAnnounceFlow = vi.fn(async () => "delivered" as const);
       const controller = createLifecycleController({
         entry,
         captureSubagentCompletionReply,
@@ -576,7 +579,7 @@ describe("subagent registry lifecycle hardening", () => {
     const runSubagentAnnounceFlow = vi.fn(async () => {
       await cleanupReady;
       await runWithOwnedSessionTranscriptWrite({ sessionKey }, freshTranscriptWrite);
-      return true;
+      return "delivered" as const;
     });
     const controller = createLifecycleController({ entry, runSubagentAnnounceFlow });
 
@@ -872,7 +875,7 @@ describe("subagent registry lifecycle hardening", () => {
   it("keeps task finalization, resource retirement, and announce cleanup root-admitted", async () => {
     const entry = createRunEntry({ expectsCompletionMessage: true });
     let releaseBrowserCleanup: (() => void) | undefined;
-    let releaseAnnounce: ((didAnnounce: boolean) => void) | undefined;
+    let releaseAnnounce: ((outcome: AnnounceFlowOutcome) => void) | undefined;
     browserLifecycleCleanupMocks.cleanupBrowserSessionsForLifecycleEnd.mockImplementationOnce(
       () =>
         new Promise<void>((resolve) => {
@@ -881,7 +884,7 @@ describe("subagent registry lifecycle hardening", () => {
     );
     const runSubagentAnnounceFlow = vi.fn(
       () =>
-        new Promise<boolean>((resolve) => {
+        new Promise<AnnounceFlowOutcome>((resolve) => {
           releaseAnnounce = resolve;
         }),
     );
@@ -902,7 +905,7 @@ describe("subagent registry lifecycle hardening", () => {
     await completion;
     expect(getActiveGatewayRootWorkCount()).toBe(1);
 
-    releaseAnnounce?.(true);
+    releaseAnnounce?.("delivered");
     await waitForLifecycleState(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
     expect(entry.cleanupCompletedAt).toBeTypeOf("number");
   });
@@ -941,7 +944,7 @@ describe("subagent registry lifecycle hardening", () => {
             releaseBrowserCleanup = resolve;
           }),
       );
-      const runSubagentAnnounceFlow = vi.fn(async () => true);
+      const runSubagentAnnounceFlow = vi.fn(async () => "delivered" as const);
       const resumeSubagentRun = vi.fn((runId: string) => {
         controller.startSubagentAnnounceCleanupFlow(runId, entry);
       });
@@ -1464,7 +1467,7 @@ describe("subagent registry lifecycle hardening", () => {
     async (expectsCompletionMessage) => {
       const entry = createRunEntry({ expectsCompletionMessage });
       const emitSubagentEndedHookForRun = vi.fn(async () => {});
-      const runSubagentAnnounceFlow = vi.fn(async () => true);
+      const runSubagentAnnounceFlow = vi.fn(async () => "delivered" as const);
       const controller = createLifecycleController({
         entry,
         shouldEmitEndedHookForRun: () => true,
@@ -1735,10 +1738,10 @@ describe("subagent registry lifecycle hardening", () => {
         expectsCompletionMessage: true,
       });
       const runs = new Map([[entry.runId, entry]]);
-      let finishAnnounce: ((didAnnounce: boolean) => void) | undefined;
+      let finishAnnounce: ((outcome: AnnounceFlowOutcome) => void) | undefined;
       const runSubagentAnnounceFlow = vi.fn(
         () =>
-          new Promise<boolean>((resolve) => {
+          new Promise<AnnounceFlowOutcome>((resolve) => {
             finishAnnounce = resolve;
           }),
       );
@@ -1760,7 +1763,7 @@ describe("subagent registry lifecycle hardening", () => {
           endedAt: 4_001,
         }),
       ).toBe(true);
-      finishAnnounce?.(true);
+      finishAnnounce?.("delivered");
       await waitForLifecycleState(() => expect(entry.pauseReason).toBe("sessions_yield"));
 
       expect(runs.get(entry.runId)).toBe(entry);
@@ -1804,9 +1807,9 @@ describe("subagent registry lifecycle hardening", () => {
     let releaseAnnounce: (() => void) | undefined;
     const runSubagentAnnounceFlow: LifecycleControllerParams["runSubagentAnnounceFlow"] = vi.fn(
       (announceParams) =>
-        new Promise<boolean>((resolve) => {
+        new Promise<AnnounceFlowOutcome>((resolve) => {
           expect(announceParams.onBeforeDeleteChildSession?.()).toBe(true);
-          releaseAnnounce = () => resolve(true);
+          releaseAnnounce = () => resolve("delivered");
         }),
     );
     const controller = createLifecycleController({ entry, runs, runSubagentAnnounceFlow });
@@ -1864,7 +1867,9 @@ describe("subagent registry lifecycle hardening", () => {
           }),
       )
       .mockResolvedValueOnce(undefined);
-    const runSubagentAnnounceFlow = vi.fn<(_params: unknown) => Promise<boolean>>(async () => true);
+    const runSubagentAnnounceFlow = vi.fn<
+      (_params: unknown) => ReturnType<LifecycleControllerParams["runSubagentAnnounceFlow"]>
+    >(async () => "delivered");
     const controller = createLifecycleController({
       entry,
       runSubagentAnnounceFlow,
@@ -1906,7 +1911,9 @@ describe("subagent registry lifecycle hardening", () => {
         suppressTaskDelivery: true,
       },
     });
-    const runSubagentAnnounceFlow = vi.fn<(_params: unknown) => Promise<boolean>>(async () => true);
+    const runSubagentAnnounceFlow = vi.fn<
+      (_params: unknown) => ReturnType<LifecycleControllerParams["runSubagentAnnounceFlow"]>
+    >(async () => "delivered");
     const emitSubagentEndedHookForRun = vi.fn(async () => {});
     const controller = createLifecycleController({
       entry,
@@ -2302,7 +2309,9 @@ describe("subagent registry lifecycle hardening", () => {
       runs.delete(runId);
     });
     const emitSubagentEndedHookForRun = vi.fn(async () => {});
-    const runSubagentAnnounceFlow = vi.fn<(_params: unknown) => Promise<boolean>>(async () => true);
+    const runSubagentAnnounceFlow = vi.fn<
+      (_params: unknown) => ReturnType<LifecycleControllerParams["runSubagentAnnounceFlow"]>
+    >(async () => "delivered");
     const controller = createLifecycleController({
       entry,
       runs,
@@ -2627,7 +2636,7 @@ describe("subagent registry lifecycle hardening", () => {
     const entry = createRunEntry({
       expectsCompletionMessage: true,
     });
-    const runSubagentAnnounceFlow = vi.fn(async () => true);
+    const runSubagentAnnounceFlow = vi.fn(async () => "delivered" as const);
 
     const controller = createLifecycleController({ entry, persist, runSubagentAnnounceFlow });
 
@@ -2769,7 +2778,7 @@ describe("subagent registry lifecycle hardening", () => {
     const runSubagentAnnounceFlow: LifecycleControllerParams["runSubagentAnnounceFlow"] = vi.fn(
       async (announceParams) => {
         announceParams.onDeliveryResult?.(delivery);
-        return true;
+        return "delivered";
       },
     );
 
@@ -2809,7 +2818,7 @@ describe("subagent registry lifecycle hardening", () => {
           deliveredAt: 12_300,
         });
         await announcePending;
-        return true;
+        return "delivered";
       },
     );
     const controller = createLifecycleController({ entry, persist, runSubagentAnnounceFlow });
@@ -2846,7 +2855,7 @@ describe("subagent registry lifecycle hardening", () => {
     const runSubagentAnnounceFlow: LifecycleControllerParams["runSubagentAnnounceFlow"] = vi.fn(
       async (announceParams) => {
         onDeliveryResult = announceParams.onDeliveryResult;
-        return true;
+        return "delivered";
       },
     );
     let releaseRetirement = () => {};
@@ -2897,7 +2906,7 @@ describe("subagent registry lifecycle hardening", () => {
           error: "prompt lock failed after visible send",
           terminal: true,
         });
-        return true;
+        return "delivered";
       },
     );
 
@@ -2926,7 +2935,7 @@ describe("subagent registry lifecycle hardening", () => {
       collect: true,
       groupId: "swarm:test",
     });
-    const runSubagentAnnounceFlow = vi.fn(async () => true);
+    const runSubagentAnnounceFlow = vi.fn(async () => "delivered" as const);
 
     const controller = createLifecycleController({
       entry,
@@ -3084,7 +3093,7 @@ describe("subagent registry lifecycle hardening", () => {
       spawnMode: "session",
     });
     const runs = new Map([[entry.runId, entry]]);
-    const runSubagentAnnounceFlow = vi.fn(async () => true);
+    const runSubagentAnnounceFlow = vi.fn(async () => "delivered" as const);
 
     const controller = createLifecycleController({
       entry,
@@ -3208,7 +3217,7 @@ describe("subagent registry lifecycle hardening", () => {
 
   it("enriches registered-run outcomes with persisted timing before cleanup", async () => {
     const persist = vi.fn();
-    const runSubagentAnnounceFlow = vi.fn(async () => true);
+    const runSubagentAnnounceFlow = vi.fn(async () => "delivered" as const);
     const entry = createRunEntry({
       startedAt: 2_000,
       expectsCompletionMessage: true,
@@ -3258,7 +3267,7 @@ describe("subagent registry lifecycle hardening", () => {
     const controller = createLifecycleController({
       entry,
       captureSubagentCompletionReply,
-      runSubagentAnnounceFlow: vi.fn(async () => false),
+      runSubagentAnnounceFlow: vi.fn(async () => "retryable" as const),
     });
 
     await expect(completeRun(controller, entry)).resolves.toBeUndefined();
@@ -3295,7 +3304,7 @@ describe("subagent registry lifecycle hardening", () => {
       entry,
       captureSubagentCompletionReply,
       getRuntimeConfig: () => ({ session: { store: durableStorePath } }),
-      runSubagentAnnounceFlow: vi.fn(async () => false),
+      runSubagentAnnounceFlow: vi.fn(async () => "retryable" as const),
     });
 
     await controller.completeSubagentRun(makeSubagentCompletion(entry));
@@ -3354,7 +3363,7 @@ describe("subagent registry lifecycle hardening", () => {
       endedAt: 4_000,
     });
     const persist = vi.fn();
-    const runSubagentAnnounceFlow = vi.fn(async () => true);
+    const runSubagentAnnounceFlow = vi.fn(async () => "delivered" as const);
     const notifyContextEngineSubagentEnded = vi.fn(async () => {});
 
     const controller = createLifecycleController({
@@ -3659,7 +3668,7 @@ describe("subagent registry lifecycle hardening", () => {
             },
           ],
         });
-        return false;
+        return "retryable" as const;
       },
     );
 
@@ -3822,7 +3831,7 @@ describe("subagent registry lifecycle hardening", () => {
     const entry = createRunEntry({
       expectsCompletionMessage: false,
     });
-    const runSubagentAnnounceFlow = vi.fn(async () => true);
+    const runSubagentAnnounceFlow = vi.fn(async () => "delivered" as const);
 
     const controller = createLifecycleController({
       entry,
@@ -3847,7 +3856,7 @@ describe("subagent registry lifecycle hardening", () => {
     const entry = createRunEntry({
       expectsCompletionMessage: false,
     });
-    const runSubagentAnnounceFlow = vi.fn(async () => true);
+    const runSubagentAnnounceFlow = vi.fn(async () => "delivered" as const);
 
     const controller = createLifecycleController({
       entry,
@@ -3934,7 +3943,7 @@ describe("subagent registry lifecycle hardening", () => {
     const entry = createRunEntry({
       expectsCompletionMessage: true,
     });
-    const runSubagentAnnounceFlow = vi.fn(async () => true);
+    const runSubagentAnnounceFlow = vi.fn(async () => "delivered" as const);
     const controller = createLifecycleController({ entry, runSubagentAnnounceFlow });
 
     let releaseFirstCleanup: (() => void) | undefined;
@@ -3992,7 +4001,9 @@ describe("subagent registry lifecycle hardening", () => {
           releaseTiming = resolve;
         }),
     );
-    const runSubagentAnnounceFlow = vi.fn<(_params: unknown) => Promise<boolean>>(async () => true);
+    const runSubagentAnnounceFlow = vi.fn<
+      (_params: unknown) => ReturnType<LifecycleControllerParams["runSubagentAnnounceFlow"]>
+    >(async () => "delivered");
     const controller = createLifecycleController({ entry, runSubagentAnnounceFlow });
     const completeParams = {
       runId: entry.runId,
@@ -4387,6 +4398,135 @@ describe("requester settle wake trigger", () => {
     expect(entry.requesterSettleWake).toBeUndefined();
   });
 
+  it("credits a yielded intentional non-delivery only after requester-settle succeeds", async () => {
+    const entry = createRunEntry({
+      endedAt: 4_000,
+      expectsCompletionMessage: true,
+      requesterSettleWake: {
+        status: "pending",
+        attemptCount: 0,
+        requesterYieldBatch: true,
+        rearmGeneration: 1,
+      },
+    });
+    let settleParams:
+      | Parameters<LifecycleControllerParams["maybeWakeRequesterAfterAllChildrenSettled"]>[0]
+      | undefined;
+    const maybeWakeRequesterAfterAllChildrenSettled = vi.fn(async (params) => {
+      settleParams = params;
+      return false;
+    });
+    const runSubagentAnnounceFlow: LifecycleControllerParams["runSubagentAnnounceFlow"] = vi.fn(
+      async (announceParams) => {
+        announceParams.onDeliveryResult?.({
+          delivered: false,
+          path: "none",
+          reason: "completion_handoff_pending",
+          terminal: true,
+          disposition: "intentional_non_delivery",
+        });
+        return "intentional_non_delivery";
+      },
+    );
+    const controller = createLifecycleController({
+      entry,
+      maybeWakeRequesterAfterAllChildrenSettled,
+      runSubagentAnnounceFlow,
+    });
+
+    await completeRun(controller, entry, { triggerCleanup: true });
+    await waitForLifecycleState(() =>
+      expect(maybeWakeRequesterAfterAllChildrenSettled).toHaveBeenCalledOnce(),
+    );
+    expect(entry.delivery).toMatchObject({
+      status: "pending",
+      disposition: "intentional_non_delivery",
+      lastError: "completion_handoff_pending",
+    });
+    expect(entry.delivery?.deliveredAt).toBeUndefined();
+    expect(taskExecutorMocks.setDetachedTaskDeliveryStatusByRunId).toHaveBeenCalledWith(
+      expect.objectContaining({ deliveryStatus: "pending" }),
+    );
+
+    settleParams?.completeBatch([entry.runId], 1, {
+      delivered: true,
+      path: "direct",
+      deliveredAt: 8_000,
+    });
+
+    expect(entry.delivery).toMatchObject({
+      status: "delivered",
+      disposition: "delivered",
+      deliveredAt: 8_000,
+      announcedAt: 8_000,
+    });
+    expect(taskExecutorMocks.setDetachedTaskDeliveryStatusByRunId).toHaveBeenCalledWith(
+      expect.objectContaining({ deliveryStatus: "delivered" }),
+    );
+  });
+
+  it("marks yielded intentional non-delivery blocked after requester-settle exhaustion", async () => {
+    const entry = createRunEntry({
+      endedAt: 4_000,
+      expectsCompletionMessage: true,
+      requesterSettleWake: {
+        status: "pending",
+        attemptCount: 0,
+        requesterYieldBatch: true,
+        rearmGeneration: 1,
+      },
+    });
+    let settleParams:
+      | Parameters<LifecycleControllerParams["maybeWakeRequesterAfterAllChildrenSettled"]>[0]
+      | undefined;
+    const maybeWakeRequesterAfterAllChildrenSettled = vi.fn(async (params) => {
+      settleParams = params;
+      return false;
+    });
+    const runSubagentAnnounceFlow: LifecycleControllerParams["runSubagentAnnounceFlow"] = vi.fn(
+      async (announceParams) => {
+        announceParams.onDeliveryResult?.({
+          delivered: false,
+          path: "none",
+          reason: "completion_handoff_pending",
+          terminal: true,
+          disposition: "intentional_non_delivery",
+        });
+        return "intentional_non_delivery";
+      },
+    );
+    const controller = createLifecycleController({
+      entry,
+      maybeWakeRequesterAfterAllChildrenSettled,
+      runSubagentAnnounceFlow,
+    });
+
+    await completeRun(controller, entry, { triggerCleanup: true });
+    await waitForLifecycleState(() =>
+      expect(maybeWakeRequesterAfterAllChildrenSettled).toHaveBeenCalledOnce(),
+    );
+    settleParams?.completeBatch([entry.runId], 1, {
+      delivered: false,
+      path: "none",
+      error: "requester settle wake attempts exhausted",
+    });
+
+    expect(entry.delivery).toMatchObject({
+      status: "failed",
+      disposition: "intentional_non_delivery",
+      lastError: "requester settle wake attempts exhausted",
+    });
+    expect(taskExecutorMocks.setDetachedTaskDeliveryStatusByRunId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deliveryStatus: "failed",
+        error: "requester settle wake attempts exhausted",
+      }),
+    );
+    expect(taskExecutorMocks.completeTaskRunByRunId).toHaveBeenCalledWith(
+      expect.objectContaining({ terminalOutcome: "blocked" }),
+    );
+  });
+
   it("retains a delete-mode child after no-wake until its requester turn settles", async () => {
     const entry = createRunEntry({
       requesterTurnRunId: "run-requester",
@@ -4405,7 +4545,7 @@ describe("requester settle wake trigger", () => {
         return false;
       },
     );
-    const runSubagentAnnounceFlow = vi.fn(async () => true);
+    const runSubagentAnnounceFlow = vi.fn(async () => "delivered" as const);
     const controller = createLifecycleController({
       entry,
       runs,

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -2778,7 +2778,7 @@ describe("subagent registry lifecycle hardening", () => {
     const runSubagentAnnounceFlow: LifecycleControllerParams["runSubagentAnnounceFlow"] = vi.fn(
       async (announceParams) => {
         announceParams.onDeliveryResult?.(delivery);
-        return "delivered";
+        return "delivered" as const;
       },
     );
 
@@ -2818,7 +2818,7 @@ describe("subagent registry lifecycle hardening", () => {
           deliveredAt: 12_300,
         });
         await announcePending;
-        return "delivered";
+        return "delivered" as const;
       },
     );
     const controller = createLifecycleController({ entry, persist, runSubagentAnnounceFlow });
@@ -2855,7 +2855,7 @@ describe("subagent registry lifecycle hardening", () => {
     const runSubagentAnnounceFlow: LifecycleControllerParams["runSubagentAnnounceFlow"] = vi.fn(
       async (announceParams) => {
         onDeliveryResult = announceParams.onDeliveryResult;
-        return "delivered";
+        return "delivered" as const;
       },
     );
     let releaseRetirement = () => {};
@@ -2906,7 +2906,7 @@ describe("subagent registry lifecycle hardening", () => {
           error: "prompt lock failed after visible send",
           terminal: true,
         });
-        return "delivered";
+        return "delivered" as const;
       },
     );
 
@@ -4425,7 +4425,7 @@ describe("requester settle wake trigger", () => {
           terminal: true,
           disposition: "intentional_non_delivery",
         });
-        return "intentional_non_delivery";
+        return "intentional_non_delivery" as const;
       },
     );
     const controller = createLifecycleController({
@@ -4492,7 +4492,7 @@ describe("requester settle wake trigger", () => {
           terminal: true,
           disposition: "intentional_non_delivery",
         });
-        return "intentional_non_delivery";
+        return "intentional_non_delivery" as const;
       },
     );
     const controller = createLifecycleController({

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.ts
@@ -22,7 +22,12 @@ export function createSubagentRegistryLifecycleController(params: SubagentRegist
   const state = createSubagentRegistryLifecycleState();
   const common = createSubagentRegistryLifecycleCommon(params, state);
   const delivery = createSubagentRegistryLifecycleDelivery(params, state, common);
-  const requesterWake = createSubagentRegistryLifecycleRequesterWake(params, state, common);
+  const requesterWake = createSubagentRegistryLifecycleRequesterWake(
+    params,
+    state,
+    common,
+    delivery,
+  );
   const cleanupBase = createSubagentRegistryLifecycleCleanupBase(
     params,
     state,

--- a/src/agents/subagents/registry/subagent-registry.announce-loop-guard.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.announce-loop-guard.test.ts
@@ -18,7 +18,7 @@ const mocks = vi.hoisted(() => ({
   callGateway: vi.fn().mockResolvedValue({ status: "ok" }),
   onAgentEventStop: vi.fn(),
   onAgentEvent: vi.fn(),
-  runSubagentAnnounceFlow: vi.fn().mockResolvedValue(false),
+  runSubagentAnnounceFlow: vi.fn().mockResolvedValue("retryable"),
   captureSubagentCompletionReply: vi.fn(),
   loadSubagentRegistryFromSqlite: vi.fn(() => new Map()),
   saveSubagentRegistryChangesToSqlite: vi.fn(),
@@ -126,7 +126,7 @@ describe("announce loop guard (#18264)", () => {
     mocks.onAgentEvent.mockReturnValue(mocks.onAgentEventStop);
     mocks.resolveAgentTimeoutMs.mockClear();
     mocks.runSubagentAnnounceFlow.mockReset();
-    mocks.runSubagentAnnounceFlow.mockResolvedValue(false);
+    mocks.runSubagentAnnounceFlow.mockResolvedValue("retryable");
     mocks.saveSubagentRegistryChangesToSqlite.mockClear();
     mocks.saveSubagentRegistryToSqlite.mockClear();
     mocks.updateSessionStore.mockClear();
@@ -250,7 +250,7 @@ describe("announce loop guard (#18264)", () => {
 
   test("expired completion-message entries are still resumed for announce", async () => {
     mocks.runSubagentAnnounceFlow.mockReset();
-    mocks.runSubagentAnnounceFlow.mockResolvedValueOnce(true);
+    mocks.runSubagentAnnounceFlow.mockResolvedValueOnce("delivered");
     registry.resetSubagentRegistryForTests();
 
     const now = Date.now();

--- a/src/agents/subagents/registry/subagent-registry.archive.e2e.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.archive.e2e.test.ts
@@ -91,7 +91,7 @@ vi.mock("../../../config/config.js", async () => {
 });
 
 vi.mock("../announce/subagent-announce.js", () => ({
-  runSubagentAnnounceFlow: vi.fn(async () => true),
+  runSubagentAnnounceFlow: vi.fn(async () => "delivered" as const),
 }));
 
 vi.mock("../../../plugins/hook-runner-global.js", () => ({
@@ -244,7 +244,7 @@ describe("subagent registry archive behavior", () => {
     vi.mocked(getAgentRunContext).mockReturnValue({} as never);
     setRegistryTestDeps({
       captureSubagentCompletionReply: vi.fn(async () => "completed result"),
-      runSubagentAnnounceFlow: vi.fn(async () => false),
+      runSubagentAnnounceFlow: vi.fn(async () => "retryable" as const),
     });
 
     mod.registerSubagentRun({

--- a/src/agents/subagents/registry/subagent-registry.nested.e2e.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.nested.e2e.test.ts
@@ -18,7 +18,7 @@ vi.mock("../../../config/config.js", async () => {
 });
 
 vi.mock("../announce/subagent-announce.js", () => ({
-  runSubagentAnnounceFlow: vi.fn(async () => true),
+  runSubagentAnnounceFlow: vi.fn(async () => "delivered" as const),
   buildSubagentSystemPrompt: vi.fn(() => "test prompt"),
 }));
 

--- a/src/agents/subagents/registry/subagent-registry.persistence.resume.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.persistence.resume.test.ts
@@ -18,7 +18,7 @@ import {
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 const { announceSpy } = vi.hoisted(() => ({
-  announceSpy: vi.fn(async () => true),
+  announceSpy: vi.fn(async () => "delivered" as const),
 }));
 vi.mock("../announce/subagent-announce.js", () => ({
   runSubagentAnnounceFlow: announceSpy,

--- a/src/agents/subagents/registry/subagent-registry.persistence.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.persistence.test.ts
@@ -42,7 +42,7 @@ import {
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 const { announceSpy } = vi.hoisted(() => ({
-  announceSpy: vi.fn(async () => true),
+  announceSpy: vi.fn(async () => "delivered" as const),
 }));
 vi.mock("../announce/subagent-announce.js", () => ({
   runSubagentAnnounceFlow: announceSpy,
@@ -198,7 +198,7 @@ describe("subagent registry persistence", () => {
 
   beforeEach(() => {
     announceSpy.mockReset();
-    announceSpy.mockResolvedValue(true);
+    announceSpy.mockResolvedValue("delivered");
     testing.setDepsForTest({
       ...createSubagentRegistryTestDeps(),
       persistSubagentRunsToDisk: fastPersistSubagentRunsToDisk,
@@ -610,7 +610,7 @@ describe("subagent registry persistence", () => {
     });
     const registryPath = await writePersistedRegistry(persisted);
 
-    announceSpy.mockResolvedValueOnce(false);
+    announceSpy.mockResolvedValueOnce("retryable");
     restartRegistry();
     await waitForRegistryWork(async () => {
       const afterFirst = await readPersistedRun<{
@@ -632,7 +632,7 @@ describe("subagent registry persistence", () => {
     expect(afterFirst?.cleanupHandled).toBe(false);
     expect(afterFirst?.cleanupCompletedAt).toBeUndefined();
 
-    announceSpy.mockResolvedValueOnce(true);
+    announceSpy.mockResolvedValueOnce("delivered");
     const beforeRetry = Date.now();
     restartRegistry();
     await waitForRegistryWork(async () => {
@@ -684,7 +684,7 @@ describe("subagent registry persistence", () => {
         .cleanupCompletedAt,
     ).toBeUndefined();
 
-    announceSpy.mockResolvedValueOnce(true);
+    announceSpy.mockResolvedValueOnce("delivered");
     const beforeRetry = Date.now();
     restartRegistry();
     await waitForRegistryWork(async () => {
@@ -711,7 +711,7 @@ describe("subagent registry persistence", () => {
     });
     const registryPath = await writePersistedRegistry(persisted);
 
-    announceSpy.mockResolvedValueOnce(false);
+    announceSpy.mockResolvedValueOnce("retryable");
     restartRegistry();
     await waitForRegistryWork(async () => {
       const afterFirst = await readPersistedRun<{ cleanupHandled?: boolean }>(
@@ -725,7 +725,7 @@ describe("subagent registry persistence", () => {
     const afterFirst = await readPersistedRun<{ cleanupHandled?: boolean }>(registryPath, "run-4");
     expect(afterFirst?.cleanupHandled).toBe(false);
 
-    announceSpy.mockResolvedValueOnce(true);
+    announceSpy.mockResolvedValueOnce("delivered");
     restartRegistry();
     await waitForRegistryWork(async () => {
       const afterSecond = readPersistedRegistry();

--- a/src/agents/subagents/registry/subagent-registry.persistence.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.persistence.test.ts
@@ -42,7 +42,7 @@ import {
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 const { announceSpy } = vi.hoisted(() => ({
-  announceSpy: vi.fn(async () => "delivered" as const),
+  announceSpy: vi.fn(async (): Promise<"delivered" | "retryable"> => "delivered"),
 }));
 vi.mock("../announce/subagent-announce.js", () => ({
   runSubagentAnnounceFlow: announceSpy,

--- a/src/agents/subagents/registry/subagent-registry.steer-restart.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.steer-restart.test.ts
@@ -92,7 +92,9 @@ vi.mock("../../../config/sessions/session-accessor.js", async (importOriginal) =
   patchSessionEntry: async () => null,
 }));
 
-const announceSpy = vi.fn(async (_params: unknown) => "delivered" as const);
+const announceSpy = vi.fn(
+  async (_params: unknown): Promise<"delivered" | "retryable"> => "delivered",
+);
 const runSubagentEndedHookMock = vi.fn(async (_eventValue?: unknown, _ctx?: unknown) => {});
 const emitSessionLifecycleEventMock = vi.fn();
 const removeInternalSessionEffectsSessionMock = vi.fn(async (_target?: unknown) => {});
@@ -215,17 +217,17 @@ describe("subagent registry steer restarts", () => {
     await vi.waitFor(assertion, { interval: 1, timeout: 1_000 });
   };
 
-  const createDeferredAnnounceResolver = (): ((value: boolean) => void) => {
+  const createDeferredAnnounceResolver = (): ((value: "delivered" | "retryable") => void) => {
     // Deferred announce lets tests observe registry state while delivery is
     // still in flight, then release the promise deterministically.
-    let resolveAnnounce: ((value: boolean) => void) | undefined;
+    let resolveAnnounce: ((value: "delivered" | "retryable") => void) | undefined;
     announceSpy.mockImplementationOnce(
       () =>
-        new Promise<boolean>((resolve) => {
+        new Promise<"delivered" | "retryable">((resolve) => {
           resolveAnnounce = resolve;
         }),
     );
-    return (value: boolean) => {
+    return (value: "delivered" | "retryable") => {
       if (!resolveAnnounce) {
         throw new Error("Expected subagent announcement resolver to be initialized");
       }
@@ -444,7 +446,7 @@ describe("subagent registry steer restarts", () => {
       });
       expect(runSubagentEndedHookMock).not.toHaveBeenCalled();
 
-      resolveAnnounce(true);
+      resolveAnnounce("delivered");
       await waitForRegistrySideEffect(() => {
         expect(runSubagentEndedHookMock).toHaveBeenCalledTimes(1);
       });
@@ -472,7 +474,7 @@ describe("subagent registry steer restarts", () => {
       await flushAnnounce();
       expect(runSubagentEndedHookMock).not.toHaveBeenCalled();
 
-      resolveAnnounce(true);
+      resolveAnnounce("delivered");
       await flushAnnounce();
 
       expect(runSubagentEndedHookMock).not.toHaveBeenCalled();

--- a/src/agents/subagents/registry/subagent-registry.steer-restart.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.steer-restart.test.ts
@@ -92,7 +92,7 @@ vi.mock("../../../config/sessions/session-accessor.js", async (importOriginal) =
   patchSessionEntry: async () => null,
 }));
 
-const announceSpy = vi.fn(async (_params: unknown) => true);
+const announceSpy = vi.fn(async (_params: unknown) => "delivered" as const);
 const runSubagentEndedHookMock = vi.fn(async (_eventValue?: unknown, _ctx?: unknown) => {});
 const emitSessionLifecycleEventMock = vi.fn();
 const removeInternalSessionEffectsSessionMock = vi.fn(async (_target?: unknown) => {});
@@ -198,7 +198,7 @@ describe("subagent registry steer restarts", () => {
       resolveContextEngine: async () => noopContextEngine,
     });
     announceSpy.mockReset();
-    announceSpy.mockResolvedValue(true);
+    announceSpy.mockResolvedValue("delivered");
     runSubagentEndedHookMock.mockReset();
     runSubagentEndedHookMock.mockImplementation(async () => {});
     emitSessionLifecycleEventMock.mockReset();
@@ -335,7 +335,7 @@ describe("subagent registry steer restarts", () => {
     vi.useRealTimers();
     mod.testing.setDepsForTest();
     announceSpy.mockReset();
-    announceSpy.mockResolvedValue(true);
+    announceSpy.mockResolvedValue("delivered");
     runSubagentEndedHookMock.mockReset();
     runSubagentEndedHookMock.mockImplementation(async () => {});
     emitSessionLifecycleEventMock.mockReset();
@@ -1123,9 +1123,9 @@ describe("subagent registry steer restarts", () => {
       const typed = params as { childRunId?: string };
       if (typed.childRunId === "run-parent") {
         parentAttempts += 1;
-        return parentAttempts >= 2;
+        return parentAttempts >= 2 ? "delivered" : "retryable";
       }
-      return true;
+      return "delivered";
     });
 
     registerRun({
@@ -1169,7 +1169,7 @@ describe("subagent registry steer restarts", () => {
     {
       vi.useFakeTimers();
       try {
-        announceSpy.mockResolvedValue(false);
+        announceSpy.mockResolvedValue("retryable");
 
         registerCompletionModeRun(
           "run-completion-retry",
@@ -1206,7 +1206,7 @@ describe("subagent registry steer restarts", () => {
   });
 
   it("keeps completion cleanup pending while descendants are still active", async () => {
-    announceSpy.mockResolvedValue(false);
+    announceSpy.mockResolvedValue("retryable");
 
     registerCompletionModeRun(
       "run-parent-expiry",

--- a/src/agents/subagents/registry/subagent-registry.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.test.ts
@@ -176,7 +176,7 @@ const mocks = vi.hoisted(() => ({
   ),
   captureSubagentCompletionReply: vi.fn(async () => "final completion reply"),
   cleanupBrowserSessionsForLifecycleEnd: vi.fn(async () => {}),
-  runSubagentAnnounceFlow: vi.fn(async () => "delivered" as const),
+  runSubagentAnnounceFlow: vi.fn(async (): Promise<"delivered" | "retryable"> => "delivered"),
   maybeWakeRequesterAfterAllChildrenSettled: vi.fn(
     async (wakeParams: {
       settledEntry: { runId: string };

--- a/src/agents/subagents/registry/subagent-registry.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.test.ts
@@ -176,7 +176,7 @@ const mocks = vi.hoisted(() => ({
   ),
   captureSubagentCompletionReply: vi.fn(async () => "final completion reply"),
   cleanupBrowserSessionsForLifecycleEnd: vi.fn(async () => {}),
-  runSubagentAnnounceFlow: vi.fn(async () => true),
+  runSubagentAnnounceFlow: vi.fn(async () => "delivered" as const),
   maybeWakeRequesterAfterAllChildrenSettled: vi.fn(
     async (wakeParams: {
       settledEntry: { runId: string };
@@ -462,7 +462,7 @@ describe("subagent registry seam flow", () => {
     mocks.persistSubagentRunsToDisk.mockReset();
     mocks.persistSubagentRunsToDiskOrThrow.mockReset();
     mocks.restoreSubagentRunsFromDisk.mockReset().mockReturnValue(0);
-    mocks.runSubagentAnnounceFlow.mockReset().mockResolvedValue(true);
+    mocks.runSubagentAnnounceFlow.mockReset().mockResolvedValue("delivered");
     mocks.maybeWakeRequesterAfterAllChildrenSettled
       .mockReset()
       .mockImplementation(async (params) => {
@@ -2061,7 +2061,7 @@ describe("subagent registry seam flow", () => {
     });
     mocks.runSubagentAnnounceFlow.mockImplementation(async () => {
       await runWithOwnedSessionTranscriptWrite({ sessionKey }, freshTranscriptWrite);
-      return true;
+      return "delivered";
     });
 
     await withOwnedSessionTranscriptWrites(
@@ -2494,7 +2494,7 @@ describe("subagent registry seam flow", () => {
   it("refreshes unpublished timeout delivery payloads after lifecycle correction", async () => {
     const createdAt = Date.parse("2026-03-24T11:59:00Z");
     mockPendingAgentWait();
-    mocks.runSubagentAnnounceFlow.mockResolvedValueOnce(false);
+    mocks.runSubagentAnnounceFlow.mockResolvedValueOnce("retryable");
     mod.registerSubagentRun({
       runId: "run-refresh-pending-timeout-payload",
       task: "pending timeout payload should refresh",
@@ -5616,7 +5616,7 @@ describe("subagent registry seam flow", () => {
   });
 
   it("retains delete-mode successful completions through the delivery deadline", async () => {
-    mocks.runSubagentAnnounceFlow.mockResolvedValue(false);
+    mocks.runSubagentAnnounceFlow.mockResolvedValue("retryable");
     const endedAt = Date.parse("2026-03-24T12:00:00Z");
     mocks.callGateway.mockResolvedValueOnce({
       status: "ok",

--- a/src/agents/subagents/spawn/acp-spawn.test.ts
+++ b/src/agents/subagents/spawn/acp-spawn.test.ts
@@ -3035,7 +3035,7 @@ describe("spawnAcpDirect", () => {
         expect(waited.terminalReply).toEqual(expected);
         const entry = createRegisteredRunEntry(registration);
         const captureSubagentCompletionReply = vi.fn(async () => undefined);
-        const runSubagentAnnounceFlow = vi.fn(async () => true);
+        const runSubagentAnnounceFlow = vi.fn(async () => "delivered" as const);
         await createBoundaryLifecycleController({
           entry,
           captureSubagentCompletionReply,

--- a/src/agents/tools/swarm-tools.integration.test.ts
+++ b/src/agents/tools/swarm-tools.integration.test.ts
@@ -129,7 +129,7 @@ describe("swarm tools integration", () => {
         persistSubagentRunsToDiskOrThrow: vi.fn(),
         resolveAgentTimeoutMs: () => 1_000,
         restoreSubagentRunsFromDisk: vi.fn(() => 0),
-        runSubagentAnnounceFlow: vi.fn(async () => true),
+        runSubagentAnnounceFlow: vi.fn(async () => "delivered" as const),
         ensureContextEnginesInitialized: vi.fn(),
         loadAgentRuntimePluginRegistryHandle: vi.fn(),
         resolveContextEngine: vi.fn(async () => ({

--- a/src/cron/isolated-agent.test-setup.ts
+++ b/src/cron/isolated-agent.test-setup.ts
@@ -169,7 +169,7 @@ export function setupIsolatedAgentTurnMocks(params?: { fast?: boolean }): void {
   }
   vi.mocked(runEmbeddedAgent).mockReset();
   vi.mocked(loadPreparedModelCatalog).mockResolvedValue([]);
-  vi.mocked(runSubagentAnnounceFlow).mockReset().mockResolvedValue(true);
+  vi.mocked(runSubagentAnnounceFlow).mockReset().mockResolvedValue("delivered");
   vi.mocked(callGateway).mockReset().mockResolvedValue({ ok: true, deleted: true });
   setActivePluginRegistry(
     createTestRegistry([

--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -665,7 +665,7 @@ describe("session.message websocket events", () => {
       resumeSubagentRun: vi.fn(),
       callGateway: async <T = Record<string, unknown>>() => ({}) as T,
       captureSubagentCompletionReply: vi.fn(async () => undefined),
-      runSubagentAnnounceFlow: vi.fn(async () => false),
+      runSubagentAnnounceFlow: vi.fn(async () => "retryable" as const),
       maybeWakeRequesterAfterAllChildrenSettled: vi.fn(async () => false),
       warn: vi.fn(),
     });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where subagent results intentionally handed to requester-settle, or intentionally suppressed for an inactive isolated-cron run with no sink, were persisted as delivered even though no transport delivered them. That false state leaked into `/subagents` information, maintenance, steering, and sweeper decisions.

## Why This Change Was Made

The announce flow now returns the existing closed delivery disposition instead of collapsing it to a boolean. Intentional non-delivery remains pending with its reason and disposition recorded; requester-settle is the only edge that grants delivered credit, while terminal wake failure records failed/blocked. The inactive-cron guard now returns a terminal `intentional_non_delivery`, which preserves duplicate suppression without claiming a send.

The #121551 failover campaign continues to own disposition classification and the typed dispatch attempt records; this PR only consumes those dispositions.

## User Impact

Operators and agents now see truthful subagent delivery state. A yielded result stays handoff-pending until the requester actually receives the consolidated settle wake, and a sinkless inactive-cron completion is no longer reported as delivered.

## Evidence

- Verification report F19: `src/agents/subagents/registry/subagent-registry.types.ts:145-146` says disposition is the latest transport result and never delivery success. The regression proves intentional yield handoff → pending recorded outcome → requester-settle success marks delivered; exhaustion marks failed/blocked.
- Verification report F20: the inactive-cron regression asserts `delivered: false`, `completion_handoff_pending`, terminal `intentional_non_delivery`, then verifies queue, Gateway, and message sends were all untouched.
- Product Doctrine: `AGENTS.md:48-50` ranks silent false outcomes above crashes and requires facts to be recorded at their owning boundary.
- Direct AWS Crabbox `cbx_7705f94cd665`, focused suites: 52 files / 1,048 tests passed ([run](https://crabbox.openclaw.ai/portal/runs/run_139ad864651c)).
- Announce format E2E: 83 tests passed ([run](https://crabbox.openclaw.ai/portal/runs/run_87b52b281c29)).
- `pnpm build` passed ([run](https://crabbox.openclaw.ai/portal/runs/run_1f15cac33bbe)).
- `pnpm check:import-cycles`: 0 runtime value cycles ([run](https://crabbox.openclaw.ai/portal/runs/run_f779631545b7)).
- `pnpm plugin-sdk:surface:check`: all 151 public subpaths verified ([run](https://crabbox.openclaw.ai/portal/runs/run_18e8ac12d7b5)).
- Follow-up CI proof: `pnpm tsgo:prod` passed ([run](https://crabbox.openclaw.ai/portal/runs/run_d0ab07e1b093)); `pnpm check:test-types` passed ([run](https://crabbox.openclaw.ai/portal/runs/run_00dd75111217)); sessions-spawn lifecycle passed 8/8 locally.
- Exact-head CI run [31459487724](https://github.com/openclaw/openclaw/actions/runs/31459487724): 125 checks terminal, no pending or failing checks.
- Final autoreview: clean, no accepted/actionable findings.
- Production: +144/-44 (net +100); tests/tooling: +367/-179 (net +188). Production growth establishes the closed outcome and requester-settle ownership boundary; no config, protocol, schema, changelog, or dispatch-classification surface changed.
