### PR TITLE
fix(ci): run policy tests for watched source changes

### DIFF
--- a/scripts/lib/ci-changed-node-test-plan.mts
+++ b/scripts/lib/ci-changed-node-test-plan.mts
@@ -8,7 +8,11 @@ import {
   isTestFileTarget,
   resolveChangedTestTargetPlan,
 } from "../test-projects.test-support.mts";
-import { createNodeTestShards } from "./ci-node-test-plan.mts";
+import {
+  createNodeTestShards,
+  isPolicyTestOwnedPath,
+  resolvePolicyTestTargets,
+} from "./ci-node-test-plan.mts";
 import { buildPluginSdkEntrySources, publicPluginSdkEntrypoints } from "./plugin-sdk-entries.mts";
 
 type ChangedNodeTestShard = {
@@ -183,6 +187,11 @@ export function createChangedNodeTestShards(
     return null;
   }
 
+  const policyTargetsByPath = new Map(
+    livePaths.map((changedPath) => [changedPath, resolvePolicyTestTargets([changedPath])]),
+  );
+  const regularLivePaths = livePaths.filter((changedPath) => !isPolicyTestOwnedPath(changedPath));
+
   // Workspace package consumers often use package specifiers, which the
   // relative import graph cannot connect back to the changed package source.
   if (changedPaths.some((changedPath) => changedPath.startsWith("packages/"))) {
@@ -193,8 +202,8 @@ export function createChangedNodeTestShards(
   // Fail safe when a core change reaches a public SDK entrypoint indirectly.
   if (
     detectChangedLanes(changedPaths).extensionImpactFromCore ||
-    (livePaths.some((changedPath) => changedPath.startsWith("src/")) &&
-      hasImportGraphImpactOnTargets(livePaths, publicPluginSdkEntrySources, cwd))
+    (regularLivePaths.some((changedPath) => changedPath.startsWith("src/")) &&
+      hasImportGraphImpactOnTargets(regularLivePaths, publicPluginSdkEntrySources, cwd))
   ) {
     return null;
   }
@@ -208,11 +217,13 @@ export function createChangedNodeTestShards(
       includeExtensionImpact: false,
     });
   const plan =
-    livePaths.length > 0 ? resolveTargetPlan(livePaths) : { mode: "targets", targets: [] };
+    regularLivePaths.length > 0
+      ? resolveTargetPlan(regularLivePaths)
+      : { mode: "targets" as const, targets: [] };
   // Aggregate resolution must not let one precise path hide another path that
   // contributes no tests. Partial plans silently drop coverage.
   if (
-    livePaths.some((changedPath) => {
+    regularLivePaths.some((changedPath) => {
       const changedPathPlan = resolveTargetPlan([changedPath]);
       return changedPathPlan.mode !== "targets" || changedPathPlan.targets.length === 0;
     })
@@ -222,7 +233,7 @@ export function createChangedNodeTestShards(
   if (plan.mode !== "targets") {
     return null;
   }
-  const targets = [...new Set(plan.targets)];
+  const targets = [...new Set([...plan.targets, ...[...policyTargetsByPath.values()].flat()])];
   if (
     targets.length > MAX_CHANGED_NODE_TEST_TARGETS ||
     targets.some(

--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -1,5 +1,5 @@
 // Builds CI node/Vitest shard plans from the full suite configuration.
-import { relative } from "node:path";
+import { matchesGlob, relative } from "node:path";
 import {
   agentVitestProjectOwners,
   embeddedAgentVitestProjectOwners,
@@ -49,6 +49,66 @@ type NodeTestPlanOptions = {
   compactGroupCount?: number;
   compactWholeGroupCount?: number;
 };
+
+type PolicyTestWatch = {
+  ownerGlobs?: readonly string[];
+  testFile: string;
+  watchGlobs: readonly string[];
+};
+
+// These tests read source trees instead of importing every file whose policy
+// they enforce. Boundary and contract suites have dedicated always-on lanes;
+// this inventory covers the remaining tests that changed targeting cannot
+// discover from imports alone.
+export const policyTestWatches = [
+  {
+    testFile: "ui/src/components/web-awesome-migration.node.test.ts",
+    watchGlobs: ["ui/src/**/*.ts"],
+  },
+  {
+    testFile: "ui/src/styles/base-theme-tokens.node.test.ts",
+    ownerGlobs: ["ui/src/**/*.css"],
+    watchGlobs: ["ui/src/**/*.css", "ui/src/**/*.ts"],
+  },
+  {
+    testFile: "ui/src/styles/cursor-policy.node.test.ts",
+    ownerGlobs: ["ui/index.html", "ui/src/**/*.css"],
+    watchGlobs: ["ui/index.html", "ui/src/**/*.css", "ui/src/**/*.ts"],
+  },
+  ...[
+    "src/cron/service.stream-trigger.test.ts",
+    "src/cron/service.stream-validation.test.ts",
+    "src/cron/service/timer.timeout-watchdog.test.ts",
+  ].map((testFile) => ({
+    testFile,
+    ownerGlobs: ["src/cron/failure-notification-text.ts"],
+    watchGlobs: ["src/cron/failure-notification-text.ts"],
+  })),
+] satisfies readonly PolicyTestWatch[];
+
+function normalizeChangedPath(changedPath: string): string {
+  return changedPath.replaceAll("\\", "/").replace(/^\.\//u, "");
+}
+
+/** Resolve policy tests whose scanned source surface intersects this diff. */
+export function resolvePolicyTestTargets(changedPaths: readonly string[]): string[] {
+  const normalizedPaths = changedPaths.map(normalizeChangedPath);
+  return policyTestWatches
+    .filter(({ watchGlobs }) =>
+      normalizedPaths.some((changedPath) =>
+        watchGlobs.some((watchGlob) => matchesGlob(changedPath, watchGlob)),
+      ),
+    )
+    .map(({ testFile }) => testFile);
+}
+
+/** True when the policy tests are the complete bounded owner for this path. */
+export function isPolicyTestOwnedPath(changedPath: string): boolean {
+  const normalizedPath = normalizeChangedPath(changedPath);
+  return policyTestWatches.some(({ ownerGlobs }) =>
+    ownerGlobs?.some((ownerGlob) => matchesGlob(normalizedPath, ownerGlob)),
+  );
+}
 
 type CompactNodeTestShard = Omit<NodeTestShard, "configs" | "groups"> & {
   groups: NodeTestShardGroup[];

--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -60,7 +60,7 @@ type PolicyTestWatch = {
 // they enforce. Boundary and contract suites have dedicated always-on lanes;
 // this inventory covers the remaining tests that changed targeting cannot
 // discover from imports alone.
-export const policyTestWatches = [
+const policyTestWatches = [
   {
     testFile: "ui/src/components/web-awesome-migration.node.test.ts",
     watchGlobs: ["ui/src/**/*.ts"],

--- a/test/scripts/ci-changed-node-test-plan.test.ts
+++ b/test/scripts/ci-changed-node-test-plan.test.ts
@@ -13,6 +13,27 @@ import { listGitTrackedFiles } from "../../src/test-utils/repo-files.js";
 import { isGatewayServerTestFile } from "../vitest/vitest.gateway-server-paths.mjs";
 
 describe("CI changed Node test plan", () => {
+  it("routes Control UI style changes through source-scanning policy tests", () => {
+    const shards = createChangedNodeTestShards(["ui/src/styles/chat/layout.css"]);
+    const targets = shards?.flatMap((shard) => shard.targets ?? []) ?? [];
+
+    expect(targets).toEqual([
+      "ui/src/styles/base-theme-tokens.node.test.ts",
+      "ui/src/styles/cursor-policy.node.test.ts",
+    ]);
+  });
+
+  it("routes cron alert sanitization changes through alert policy suites", () => {
+    const shards = createChangedNodeTestShards(["src/cron/failure-notification-text.ts"]);
+    const targets = shards?.flatMap((shard) => shard.targets ?? []) ?? [];
+
+    expect(targets).toEqual([
+      "src/cron/service.stream-trigger.test.ts",
+      "src/cron/service.stream-validation.test.ts",
+      "src/cron/service/timer.timeout-watchdog.test.ts",
+    ]);
+  });
+
   it("routes a focused source change into one targeted job", () => {
     expect(createChangedNodeTestShards(["src/agents/live-model-filter.ts"])).toEqual([
       {

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -6,6 +6,7 @@ import {
   assignVitestFsCacheWriter,
   createNodeTestShardBundles,
   createNodeTestShards,
+  resolvePolicyTestTargets,
   type NodeTestShard,
 } from "../../scripts/lib/ci-node-test-plan.mts";
 import { expectNoNodeFsScans } from "../../src/test-utils/fs-scan-assertions.js";
@@ -91,6 +92,15 @@ function listAllToolingTestFiles(): string[] {
 }
 
 describe("scripts/lib/ci-node-test-plan.mts", () => {
+  it("inventories source-scanning Control UI policy tests", () => {
+    expect(resolvePolicyTestTargets(["ui/src/pages/chat/view.ts"])).toEqual([
+      "ui/src/components/web-awesome-migration.node.test.ts",
+      "ui/src/styles/base-theme-tokens.node.test.ts",
+      "ui/src/styles/cursor-policy.node.test.ts",
+    ]);
+    expect(resolvePolicyTestTargets(["docs/web/control-ui.md"])).toEqual([]);
+  });
+
   it("assigns one semantic Vitest cache writer without changing shard order", () => {
     const full = createNodeTestShardBundles({ includeReleaseOnlyPluginShards: false });
     const compact = createNodeTestShardBundles({


### PR DESCRIPTION
Related: #121600
Related: #77017

## What Problem This Solves

Resolves a CI routing gap where policy-style tests that inspect broad source trees could be skipped when a pull request changed a watched file outside the test's import lane. This allowed #121600 to break three cron alert suites and #77017 to break the Control UI cursor-policy suite only after landing on `main`.

## Why This Change Was Made

The Node test-plan owner now declares bounded watch globs for source-scanning policy tests. Changed-node planning adds only the matching tests, and uses explicit owner globs for paths whose normal import-graph resolution is either impossible (CSS) or unbounded (the shared cron alert text owner). Existing always-on boundary and contract lanes remain unchanged, and ordinary TypeScript targeting retains its prior fail-safe behavior.

## User Impact

There is no runtime behavior change. Contributors now get the relevant policy failures in pull-request CI before changes land, without turning every pull request into a full Node test run.

## Evidence

Pre-fix reproduction:

- `ui/src/styles/chat/layout.css` produced no changed Node test shard; the new regression selects `base-theme-tokens.node.test.ts` and `cursor-policy.node.test.ts`.
- `src/cron/failure-notification-text.ts` produced no changed Node test shard; the new regression selects `service.stream-trigger.test.ts`, `service.stream-validation.test.ts`, and `timer.timeout-watchdog.test.ts`.

Exact source-tree validation on AWS Crabbox (`run_c4531681a73a`, exit 0):

- Focused planner tests: 45 passed.
- Cron alert suites: 27 passed.
- Control UI policy suites: 9 passed.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- `pnpm lint:tmp:export-name-collisions`: passed.
- `pnpm check:wrapper-shadowing`: passed (70 current, 70 baselined).
- `pnpm plugin-sdk:surface:check`: passed.
- `node scripts/check-changed.mjs`: passed for the scripts/tooling and root-test lanes, including formatting, script and test-root typechecks, and changed-file lint.
- `pnpm format scripts/lib/ci-node-test-plan.mts scripts/lib/ci-changed-node-test-plan.mts test/scripts/ci-node-test-plan.test.ts test/scripts/ci-changed-node-test-plan.test.ts`: clean.
- `.agents/skills/autoreview/scripts/autoreview --mode local`: clean, no accepted/actionable findings.

LOC split against `origin/main` merge base:

- Production: +0/-0 (net 0).
- Tests: +31/-0 (net +31).
- Tooling: +78/-7 (net +71).
- Generated: +0/-0 (net 0).

`pnpm build` was not required because no module or lazy-loading boundary changed. No unrelated pathfinder bugs were found or included.
