### PR TITLE
fix(ui): hide screen-reader-only status text

### DIFF
--- a/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
@@ -146,14 +146,10 @@ suite.define(() => {
     await expect
       .poll(() => currentPage.locator(".chat-working-indicator__elapsed").textContent())
       .toBe("2m 57s");
-    const workingLabel = currentPage.locator(
-      ".chat-working-indicator__status > .agent-chat__sr-only",
-    );
+    const workingLabel = currentPage.locator(".chat-working-indicator__status > .sr-only");
     expect(await workingLabel.textContent()).toBe("Working…");
     expect(
-      await currentPage
-        .locator(".chat-working-indicator__status > span:not(.agent-chat__sr-only)")
-        .count(),
+      await currentPage.locator(".chat-working-indicator__status > span:not(.sr-only)").count(),
     ).toBe(0);
   });
 

--- a/ui/src/e2e/mantis-chat-proof.e2e.test.ts
+++ b/ui/src/e2e/mantis-chat-proof.e2e.test.ts
@@ -113,12 +113,10 @@ describeMantisWebUiChat("Mantis Control UI web chat proof", () => {
 
       await page.getByText("saved 875.3k tokens", { exact: true }).waitFor();
       await page.locator(".chat-working-indicator").waitFor();
-      const workingLabel = page.locator(".chat-working-indicator__status > .agent-chat__sr-only");
+      const workingLabel = page.locator(".chat-working-indicator__status > .sr-only");
       expect(await workingLabel.textContent()).toBe("Working…");
       expect(
-        await page
-          .locator(".chat-working-indicator__status > span:not(.agent-chat__sr-only)")
-          .count(),
+        await page.locator(".chat-working-indicator__status > span:not(.sr-only)").count(),
       ).toBe(0);
       await page.clock.fastForward(177_000);
       await expect

--- a/ui/src/pages/about/view.ts
+++ b/ui/src/pages/about/view.ts
@@ -147,9 +147,7 @@ function renderCommit(props: AboutProps) {
           <span aria-hidden="true">${props.copyState === "copied" ? icons.check : icons.copy}</span>
         </button>
       </openclaw-tooltip>
-      <span class="about-sr-only" role="status" aria-live="polite"
-        >${copyStatus(props.copyState)}</span
-      >
+      <span class="sr-only" role="status" aria-live="polite">${copyStatus(props.copyState)}</span>
     </span>
   `;
 }

--- a/ui/src/pages/chat/components/chat-background-tasks-status.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks-status.ts
@@ -125,7 +125,7 @@ export function renderBackgroundTasksStatusRow(
             <span class="chat-tasks-status__sep" aria-hidden="true">·</span>
           `
         : nothing}
-      <span class="agent-chat__sr-only" role="status">${label}</span>
+      <span class="sr-only" role="status">${label}</span>
       <openclaw-tooltip class="chat-tasks-status__preview">
         <button class="chat-tasks-status__link" type="button" @click=${openRail}>${label}</button>
         ${renderStatusPreview(backgroundTasks)}

--- a/ui/src/pages/chat/components/chat-composer-controls.ts
+++ b/ui/src/pages/chat/components/chat-composer-controls.ts
@@ -309,7 +309,7 @@ export function renderChatPrimaryActions(props: ChatRunControlsProps) {
             ? nothing
             : html`
                 <span
-                  class="agent-chat__sr-only agent-chat__voice-status"
+                  class="sr-only agent-chat__voice-status"
                   role="status"
                   aria-live="polite"
                   aria-atomic="true"

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -389,14 +389,14 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
                 ></textarea>
                 <span
                   id=${slashMenuAnnouncementId}
-                  class="agent-chat__sr-only"
+                  class="sr-only"
                   role="status"
                   aria-live="polite"
                   aria-atomic="true"
                   >${activeSlashMenuOptionLabel}</span
                 >
                 <span
-                  class="agent-chat__run-status-announcement agent-chat__sr-only"
+                  class="agent-chat__run-status-announcement sr-only"
                   role="status"
                   aria-live="polite"
                   aria-atomic="true"

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1549,14 +1549,11 @@ describe("grouped chat rendering", () => {
     expect(container.querySelectorAll(".chat-avatar.assistant")).toHaveLength(0);
     expect(container.querySelector(".chat-reading-indicator")).not.toBeNull();
     expect(container.querySelector(".chat-working-indicator__elapsed")).not.toBeNull();
+    expect(container.querySelector(".chat-working-indicator__status > .sr-only")?.textContent).toBe(
+      "Working…",
+    );
     expect(
-      container.querySelector(".chat-working-indicator__status > .agent-chat__sr-only")
-        ?.textContent,
-    ).toBe("Working…");
-    expect(
-      container.querySelectorAll(
-        ".chat-working-indicator__status > span:not(.agent-chat__sr-only)",
-      ),
+      container.querySelectorAll(".chat-working-indicator__status > span:not(.sr-only)"),
     ).toHaveLength(0);
     expect(container.querySelector(".chat-group-footer")).toBeNull();
   });
@@ -1613,9 +1610,7 @@ describe("grouped chat rendering", () => {
       label,
     );
     expect(container.querySelector(".chat-working-indicator__elapsed")).not.toBeNull();
-    expect(
-      container.querySelector(".chat-working-indicator__status > .agent-chat__sr-only"),
-    ).toBeNull();
+    expect(container.querySelector(".chat-working-indicator__status > .sr-only")).toBeNull();
   });
 
   it("formats terminal recap durations with full localized units", () => {
@@ -1765,8 +1760,8 @@ describe("grouped chat rendering", () => {
       );
       const status = container.querySelector(".chat-working-indicator__status");
       return {
-        hidden: status?.querySelector(".agent-chat__sr-only")?.textContent,
-        visibleLabels: status?.querySelectorAll("span:not(.agent-chat__sr-only)").length,
+        hidden: status?.querySelector(".sr-only")?.textContent,
+        visibleLabels: status?.querySelectorAll("span:not(.sr-only)").length,
         // The whimsical long-wait phrase rides in its own aria-hidden element,
         // never as a plain status span screen readers would announce.
         decorativePhrases: status?.querySelectorAll("openclaw-working-phrase[aria-hidden]").length,

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -1854,7 +1854,7 @@ function renderChatThreadContents(
       @pointerup=${(event: PointerEvent) => handleChatThreadSelectionPointerUp(event, props)}
     >
       <span
-        class="chat-transcript-announcement agent-chat__sr-only"
+        class="chat-transcript-announcement sr-only"
         role="status"
         aria-live=${props.announceTranscript !== false ? "polite" : "off"}
         aria-atomic="true"

--- a/ui/src/pages/chat/components/chat-working-indicator.ts
+++ b/ui/src/pages/chat/components/chat-working-indicator.ts
@@ -163,9 +163,7 @@ export function renderChatWorkingIndicator(
                 ${renderLiveOutputTokens(options.outputTokens)}
               `
             : html`
-                <span class=${continuation ? "" : "agent-chat__sr-only"}
-                  >${t("common.working")}</span
-                >
+                <span class=${continuation ? "" : "sr-only"}>${t("common.working")}</span>
                 <openclaw-elapsed-time
                   class="chat-working-indicator__elapsed"
                   .startMs=${part.startedAt}

--- a/ui/src/pages/new-session/composer.ts
+++ b/ui/src/pages/new-session/composer.ts
@@ -270,9 +270,7 @@ function renderNewSessionComposer(options: NewSessionComposerOptions) {
           </div>
         </div>
         ${options.pendingAttachmentReads > 0
-          ? html`<span class="agent-chat__sr-only" role="status"
-              >${t("newSession.readingAttachment")}</span
-            >`
+          ? html`<span class="sr-only" role="status">${t("newSession.readingAttachment")}</span>`
           : nothing}
       </div>
     </div>

--- a/ui/src/pages/sessions/view.browser.test.ts
+++ b/ui/src/pages/sessions/view.browser.test.ts
@@ -80,9 +80,7 @@ function sessionsTableHtml() {
                               : index === 6
                                 ? "session-actions-col"
                                 : ""
-                      }">${
-                        index === 6 ? `<span class="sessions-sr-only">${header}</span>` : header
-                      }</th>`,
+                      }">${index === 6 ? `<span class="sr-only">${header}</span>` : header}</th>`,
                   )
                   .join("")}
               </tr>

--- a/ui/src/pages/sessions/view.ts
+++ b/ui/src/pages/sessions/view.ts
@@ -1286,7 +1286,7 @@ function renderSessionsTable(props: SessionsProps, ctx: SessionsTableContext) {
             ${sortHeader("updated", t("sessionsView.updated"))}
             ${sortHeader("tokens", t("sessionsView.tokens"))}
             <th class="session-actions-col">
-              <span class="sessions-sr-only">${t("sessionsView.actions")}</span>
+              <span class="sr-only">${t("sessionsView.actions")}</span>
             </th>
           </tr>
         </thead>

--- a/ui/src/pages/workboard/view-card-details.ts
+++ b/ui/src/pages/workboard/view-card-details.ts
@@ -265,7 +265,7 @@ export function renderCardDetailsPanel(props: WorkboardProps) {
             <div>
               <span class="workboard-card__priority">${formatPriorityLabel(card.priority)}</span>
               <h2 id=${workboardCardDetailTitleId}>
-                <span class="workboard-sr-only">${t("workboard.detailTitle")}: </span>${card.title}
+                <span class="sr-only">${t("workboard.detailTitle")}: </span>${card.title}
               </h2>
             </div>
             <openclaw-tooltip .content=${t("common.cancel")}>

--- a/ui/src/styles/about.css
+++ b/ui/src/styles/about.css
@@ -293,16 +293,3 @@
   font-size: var(--control-ui-text-xs, 12px);
   white-space: nowrap;
 }
-
-/* Screen-reader-only live region for copy feedback (no shared utility yet). */
-.about-sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -600,6 +600,19 @@
   box-sizing: border-box;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 html,
 body {
   height: 100%;

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2385,18 +2385,6 @@ openclaw-chat-video-player {
   min-width: 0;
 }
 
-.agent-chat__sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
 .agent-chat__composer-combobox > :is(textarea, input) {
   width: 100%;
   min-height: 36px;

--- a/ui/src/styles/sessions.css
+++ b/ui/src/styles/sessions.css
@@ -410,19 +410,6 @@
   min-width: 760px;
 }
 
-.sessions-sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  padding: 0;
-  border: 0;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  clip-path: inset(50%);
-  white-space: nowrap;
-}
-
 .sessions-table tbody tr.session-data-row > td {
   white-space: nowrap;
 }

--- a/ui/src/styles/sr-only.browser.test.ts
+++ b/ui/src/styles/sr-only.browser.test.ts
@@ -1,0 +1,71 @@
+import { chromium, type Browser } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { readStyleSheet } from "../../../test/helpers/ui-style-fixtures.js";
+import {
+  canRunPlaywrightChromium,
+  resolvePlaywrightChromiumExecutablePath,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const describeSrOnly = canRunPlaywrightChromium(chromiumExecutablePath) ? describe : describe.skip;
+
+let browser: Browser;
+
+beforeAll(async () => {
+  if (!canRunPlaywrightChromium(chromiumExecutablePath)) {
+    return;
+  }
+  browser = await chromium.launch({ executablePath: chromiumExecutablePath, headless: true });
+});
+
+afterAll(async () => {
+  await browser?.close().catch(() => {});
+});
+
+describeSrOnly("screen-reader-only utility", () => {
+  it("visually hides content while preserving its accessible status", async () => {
+    const page = await browser.newPage();
+    try {
+      await page.setContent(`<!doctype html>
+        <html>
+          <head><style>${readStyleSheet("ui/src/styles/base.css")}</style></head>
+          <body><span class="sr-only" role="status">Background task active</span></body>
+        </html>`);
+
+      const status = page.getByRole("status");
+      await expect
+        .poll(async () => {
+          return await status.evaluate((element) => {
+            const style = getComputedStyle(element);
+            return {
+              borderWidth: style.borderWidth,
+              clip: style.clip,
+              clipPath: style.clipPath,
+              height: style.height,
+              margin: style.margin,
+              overflow: style.overflow,
+              padding: style.padding,
+              position: style.position,
+              whiteSpace: style.whiteSpace,
+              width: style.width,
+            };
+          });
+        })
+        .toEqual({
+          borderWidth: "0px",
+          clip: "rect(0px, 0px, 0px, 0px)",
+          clipPath: "inset(50%)",
+          height: "1px",
+          margin: "-1px",
+          overflow: "hidden",
+          padding: "0px",
+          position: "absolute",
+          whiteSpace: "nowrap",
+          width: "1px",
+        });
+      expect(await status.ariaSnapshot()).toContain("Background task active");
+    } finally {
+      await page.close().catch(() => {});
+    }
+  });
+});

--- a/ui/src/styles/workboard.css
+++ b/ui/src/styles/workboard.css
@@ -34,19 +34,6 @@
   min-height: 0;
 }
 
-.workboard-sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  padding: 0;
-  border: 0;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  clip-path: inset(50%);
-  white-space: nowrap;
-}
-
 .workboard-toolbar {
   display: flex;
   justify-content: space-between;

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -96,6 +96,7 @@ const nodeDrivenBrowserLayoutTests = [
   "src/pages/sessions/view.browser.test.ts",
   "src/styles/cursor-policy.browser.test.ts",
   "src/styles/chat-file-link-presentation.browser.test.ts",
+  "src/styles/sr-only.browser.test.ts",
 ] as const;
 const mockRegistryUnitTests = [
   ...uiIsolatedTestFiles.map((testFile) => testFile.slice("ui/".length)),


### PR DESCRIPTION
Closes #121838

## What Problem This Solves

This PR proposes a fix for an issue where users opening Ask OpenClaw would see the assistive status text “OpenClaw is thinking” beside the animated dots whenever a response was pending.

The same missing shared contract left other Control UI surfaces relying on four separate screen-reader-only class implementations.

## Why This Change Was Made

The proposed change defines the canonical `.sr-only` utility once in the global base stylesheet, using absolute 1 px clipping without `display: none`, and moves the About, Chat, New Session, Sessions, and Workboard consumers to that one spelling. The four local CSS copies are removed.

Each consumer was checked for an attribute-only alternative. The static session-companion prompt was appropriately moved to `aria-label` in #121652, but the remaining consumers are live status regions, accessible table text, or accessible heading context whose DOM text should remain available to assistive technology.

Production LOC is net −38 after discounting class-name substitutions and formatting-only movement: one 13-line shared utility replaces four local definitions totaling 51 lines.

## User Impact

With this change, Ask OpenClaw keeps the visual thinking indicator without leaking its assistive status into the layout. Screen readers still receive the status. Other affected Control UI surfaces use the same shared behavior, reducing the chance of another local class drifting or remaining undefined.

## Evidence

The captures use the real Custodian component and shipped styles with repository mock data at 1440×900. The before state removes the proposed rule from the loaded stylesheet to reproduce current `main`; the after state leaves the proposed shared rule active.

**Before — assistive status leaks visibly**

| Light | Dark |
| --- | --- |
| ![Before in light theme: OpenClaw is thinking is visible beside the dots](https://github.com/user-attachments/assets/b18b9d5f-e604-41c5-b8db-78cc0d138510) | ![Before in dark theme: OpenClaw is thinking is visible beside the dots](https://github.com/user-attachments/assets/58c2833c-770a-45fd-8e9f-6469209d987c) |

**After — only the visual thinking indicator remains**

| Light | Dark |
| --- | --- |
| ![After in light theme: only the mascot and thinking dots are visible](https://github.com/user-attachments/assets/11d49e10-bbe2-443c-a204-fdda2edd3c59) | ![After in dark theme: only the mascot and thinking dots are visible](https://github.com/user-attachments/assets/822424ba-2efd-4153-b190-ba5e4b37c242) |

Browser evidence across both themes:

- Before: `position: static`, `128.719px × 21.6875px`, `clip: auto`, `overflow: visible`.
- After: `position: absolute`, `1px × 1px`, `clip: rect(0px, 0px, 0px, 0px)`, `clip-path: inset(50%)`, `overflow: hidden`.
- Accessibility snapshot in both states: `status: OpenClaw is thinking`.

Focused browser test:

```text
node scripts/run-vitest.mjs ui/src/styles/sr-only.browser.test.ts
1 file passed, 1 test passed
```

Proof run: https://github.com/openclaw/openclaw/actions/runs/31456541637

Structured review: clean, with no accepted or actionable findings.
