### PR TITLE
fix(scripts): allow PR review with restricted GitHub tokens

### DIFF
--- a/scripts/pr-lib/worktree.sh
+++ b/scripts/pr-lib/worktree.sh
@@ -102,7 +102,7 @@ enter_worktree() {
 pr_meta_json() {
   local pr="$1"
   local metadata files expected_file_count actual_file_count head_before head_after
-  metadata=$(gh pr view "$pr" --json number,title,state,isDraft,author,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner,url,body,labels,assignees,reviewRequests,changedFiles,additions,deletions,statusCheckRollup,files)
+  metadata=$(gh pr view "$pr" --json number,title,state,isDraft,author,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner,url,body,labels,assignees,changedFiles,additions,deletions,statusCheckRollup,files)
   head_before=$(printf '%s\n' "$metadata" | jq -r .headRefOid)
   expected_file_count=$(printf '%s\n' "$metadata" | jq -r .changedFiles)
 

--- a/test/scripts/pr-metadata.test.ts
+++ b/test/scripts/pr-metadata.test.ts
@@ -17,6 +17,10 @@ set -euo pipefail
 
 if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
   if [[ "$*" == *changedFiles* ]]; then
+    if [ "\${FAKE_REJECT_REVIEW_REQUESTS:-0}" = "1" ] && [[ "$*" == *reviewRequests* ]]; then
+      echo "GraphQL: Resource not accessible by integration (repository.pullRequest.reviewRequests.nodes.0.requestedReviewer)" >&2
+      exit 1
+    fi
     jq -nc --argjson changedFiles "\${FAKE_CHANGED_FILES:-101}" --argjson fileCount "\${FAKE_GRAPHQL_FILE_COUNT:-100}" --argjson includeChangeType "\${FAKE_GRAPHQL_CHANGE_TYPE:-true}" '
       {
         number: 42,
@@ -73,6 +77,7 @@ function readPrMetadata(
     graphqlChangeType?: boolean;
     graphqlFileCount?: string;
     headAfter?: string;
+    rejectReviewRequests?: boolean;
     restFileCount?: string;
   } = {},
 ) {
@@ -91,6 +96,7 @@ function readPrMetadata(
         FAKE_GRAPHQL_CHANGE_TYPE: options.graphqlChangeType === false ? "false" : "true",
         FAKE_GRAPHQL_FILE_COUNT: options.graphqlFileCount ?? "100",
         FAKE_HEAD_AFTER: options.headAfter ?? "head-a",
+        FAKE_REJECT_REVIEW_REQUESTS: options.rejectReviewRequests ? "1" : "0",
         FAKE_REST_FILE_COUNT: options.restFileCount ?? "101",
         OPENCLAW_GH_BIN: join(fakeGhDir, "gh"),
         PATH: `${fakeGhDir}:${process.env.PATH}`,
@@ -107,6 +113,17 @@ afterEach(() => {
 });
 
 describe("PR metadata", () => {
+  it("does not request reviewer metadata that GitHub App tokens cannot read", () => {
+    const result = readPrMetadata(createFakeGh(), {
+      changedFiles: "2",
+      graphqlFileCount: "2",
+      rejectReviewRequests: true,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+  });
+
   it("uses cacheable GraphQL file metadata when the complete list fits", () => {
     const result = readPrMetadata(createFakeGh(), {
       changedFiles: "2",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers and agents using repository-scoped GitHub installation tokens could not initialize the native PR review workflow when a team review was requested. GitHub rejects the `reviewRequests.requestedReviewer` GraphQL field for those tokens, causing `scripts/pr review-init` to lose the PR head identity and stop.

## Why This Change Was Made

Removes the unused `reviewRequests` field from the canonical PR metadata query. All metadata consumed by review, prepare, and merge remains unchanged, while restricted installation tokens can collect the complete, exact-head file snapshot through the existing GraphQL/REST flow.

## User Impact

The native `scripts/pr` landing workflow now works with repository-scoped GitHub App tokens even when protected-team review requests are present. Review requests themselves remain untouched.

## Evidence

- Real blocked flow: `scripts/pr review-init 121846` failed with `Resource not accessible by integration` on `reviewRequests.nodes.0.requestedReviewer`.
- Same token after fix: `pr_meta_json 121846` returned the exact head `7ff4c10afa3f4294c76e4062b505d50f6dfb7991` and all 70/70 changed files.
- Regression suite: `node scripts/run-vitest.mjs test/scripts/pr-metadata.test.ts --reporter=dot` — 7/7 passed.
- Formatting and `git diff --check`: clean.
- Production LOC: +1/-1 (net 0); tests: +17/-0.
