### PR TITLE
feat(scripts): report aliasing re-exports

### DIFF
--- a/scripts/check-export-name-collisions.mts
+++ b/scripts/check-export-name-collisions.mts
@@ -10,6 +10,7 @@ import {
   isTestLikeTypeScriptFile,
   resolveSourceRoots,
   runAsScript,
+  toLine,
   unwrapExpression,
 } from "./lib/ts-guard-utils.mts";
 
@@ -37,12 +38,18 @@ export type NamedReExport = {
   moduleSpecifier: string;
 };
 
+export type AliasingReExport = NamedReExport & {
+  line: number;
+  path: string;
+};
+
 export type ExportedValueDefinition = {
   importedReferences: ImportedSymbolReference[];
   name: string;
 };
 
 export type ModuleExports = {
+  aliasingReExports: Array<Omit<AliasingReExport, "path">>;
   definitions: Set<string>;
   exportedNames: Set<string>;
   namedReExports: NamedReExport[];
@@ -330,6 +337,7 @@ export function collectModuleExportNames(content: string, fileName = "source.ts"
   const directlyExportedNames = new Set<string>();
   const locallyExportedNames = new Set<string>();
   const exportedNames = new Set<string>();
+  const aliasingReExports: Array<Omit<AliasingReExport, "path">> = [];
   const namedReExports: NamedReExport[] = [];
   const pendingLocalReExports: Array<{ exportedName: string; localName: string }> = [];
   const starExportSpecifiers: string[] = [];
@@ -442,15 +450,18 @@ export function collectModuleExportNames(content: string, fileName = "source.ts"
         }
         const localName = specifier.propertyName?.text ?? specifier.name.text;
         if (statement.moduleSpecifier && ts.isStringLiteral(statement.moduleSpecifier)) {
-          namedReExports.push({
+          const reExport = {
             exportedName: specifier.name.text,
             importedName: localName,
             moduleSpecifier: statement.moduleSpecifier.text,
-          });
+          };
+          namedReExports.push(reExport);
+          if (reExport.exportedName !== reExport.importedName) {
+            aliasingReExports.push({ ...reExport, line: toLine(sourceFile, specifier) });
+          }
         } else if (!statement.moduleSpecifier) {
           pendingLocalReExports.push({ exportedName: specifier.name.text, localName });
         }
-        // Renamed re-exports are deliberately outside this guard's first slice.
         if (specifier.name.text !== localName) {
           continue;
         }
@@ -544,6 +555,7 @@ export function collectModuleExportNames(content: string, fileName = "source.ts"
   }
 
   return {
+    aliasingReExports,
     definitions,
     exportedNames,
     namedReExports: namedReExports.toSorted((left, right) =>
@@ -612,8 +624,8 @@ function collectTransitiveExportNames(
 // exact module. Flagging them would push burn-down work to "fix" a deliberate idiom.
 const intentionalSameNameFamilies = new Set(["testing", "testApi"]);
 
-/** Finds duplicate exported function/const definitions across source modules. */
-export function findExportNameCollisions(modules: SourceModule[]): ExportNameCollision[] {
+function analyzeExportNames(modules: SourceModule[]) {
+  const aliasingReExports: AliasingReExport[] = [];
   const filesByName = new Map<string, Set<string>>();
   const sdkExportNames = new Set<string>();
   const modulesByPath = new Map<string, ModuleExports>();
@@ -623,6 +635,14 @@ export function findExportNameCollisions(modules: SourceModule[]): ExportNameCol
     const relativePath = normalizeRelativePath(sourceModule.path);
     const moduleExports = collectModuleExportNames(sourceModule.content, relativePath);
     modulesByPath.set(relativePath, moduleExports);
+    if (sourceModule.includeDefinitions !== false && !relativePath.startsWith("src/plugin-sdk/")) {
+      aliasingReExports.push(
+        ...moduleExports.aliasingReExports.map((reExport) => ({
+          ...reExport,
+          path: relativePath,
+        })),
+      );
+    }
     if (sourceModule.includeDefinitions !== false) {
       for (const name of moduleExports.definitions) {
         const files = filesByName.get(name) ?? new Set<string>();
@@ -654,7 +674,25 @@ export function findExportNameCollisions(modules: SourceModule[]): ExportNameCol
     }
     collisions.push(collision);
   }
-  return collisions.toSorted((left, right) => left.name.localeCompare(right.name));
+  return {
+    aliasingReExports: aliasingReExports.toSorted(
+      (left, right) =>
+        left.path.localeCompare(right.path) ||
+        left.line - right.line ||
+        left.exportedName.localeCompare(right.exportedName),
+    ),
+    collisions: collisions.toSorted((left, right) => left.name.localeCompare(right.name)),
+  };
+}
+
+/** Finds direct renamed re-exports outside the Plugin SDK boundary. */
+export function findAliasingReExports(modules: SourceModule[]) {
+  return analyzeExportNames(modules).aliasingReExports;
+}
+
+/** Finds duplicate exported function/const definitions across source modules. */
+export function findExportNameCollisions(modules: SourceModule[]): ExportNameCollision[] {
+  return analyzeExportNames(modules).collisions;
 }
 
 type CollisionChange = {
@@ -702,7 +740,7 @@ function resolveBaselinePath(repoRoot: string) {
   return path.join(repoRoot, ...baselineRelativePath.split("/"));
 }
 
-export async function collectRepositoryCollisions(repoRoot: string) {
+async function collectRepositoryModules(repoRoot: string) {
   const sourceCollectOptions = {
     fileExtensions: [".ts", ".mts", ".js", ".mjs"],
     includeTests: true,
@@ -735,7 +773,15 @@ export async function collectRepositoryCollisions(repoRoot: string) {
       path: normalizeRelativePath(path.relative(repoRoot, filePath)),
     })),
   );
-  return findExportNameCollisions(modules);
+  return modules;
+}
+
+async function collectRepositoryExportAnalysis(repoRoot: string) {
+  return analyzeExportNames(await collectRepositoryModules(repoRoot));
+}
+
+export async function collectRepositoryCollisions(repoRoot: string) {
+  return (await collectRepositoryExportAnalysis(repoRoot)).collisions;
 }
 
 async function readBaseline(repoRoot: string) {
@@ -751,8 +797,7 @@ async function readBaseline(repoRoot: string) {
   }
 }
 
-async function writeBaseline(repoRoot: string) {
-  const collisions = await collectRepositoryCollisions(repoRoot);
+async function writeBaseline(repoRoot: string, collisions: ExportNameCollision[]) {
   await fs.writeFile(resolveBaselinePath(repoRoot), `${JSON.stringify(collisions, null, 2)}\n`);
   return collisions.length;
 }
@@ -761,11 +806,25 @@ function formatCollision(collision: ExportNameCollision | undefined) {
   return JSON.stringify(collision);
 }
 
+function printAliasingReExports(reExports: AliasingReExport[]) {
+  if (reExports.length === 0) {
+    return;
+  }
+  console.log("Aliasing re-exports outside src/plugin-sdk/ (informational):");
+  for (const reExport of reExports) {
+    console.log(
+      `- ${reExport.path}:${reExport.line}: ${reExport.importedName} as ${reExport.exportedName} from ${JSON.stringify(reExport.moduleSpecifier)}`,
+    );
+  }
+}
+
 export async function main() {
   const repoRoot = resolveRepoRoot(import.meta.url);
   if (process.argv.includes("--update-debt-baseline")) {
-    const count = await writeBaseline(repoRoot);
+    const analysis = await collectRepositoryExportAnalysis(repoRoot);
+    const count = await writeBaseline(repoRoot, analysis.collisions);
     console.log(`Wrote ${baselineRelativePath} (${count} entries)`);
+    printAliasingReExports(analysis.aliasingReExports);
     return 0;
   }
 
@@ -776,8 +835,9 @@ export async function main() {
     );
     return 1;
   }
-  const current = await collectRepositoryCollisions(repoRoot);
-  const debt = compareExportNameCollisionDebt(current, baseline);
+  const analysis = await collectRepositoryExportAnalysis(repoRoot);
+  const debt = compareExportNameCollisionDebt(analysis.collisions, baseline);
+  printAliasingReExports(analysis.aliasingReExports);
   if (debt.regressions.length === 0 && debt.improvements.length === 0) {
     console.log("export name collision guard passed.");
     return 0;

--- a/test/scripts/check-export-name-collisions.test.ts
+++ b/test/scripts/check-export-name-collisions.test.ts
@@ -5,6 +5,7 @@ import {
   collectModuleExportNames,
   collectRepositoryCollisions,
   compareExportNameCollisionDebt,
+  findAliasingReExports,
   findExportNameCollisions,
   isExcludedExportCollisionSource,
 } from "../../scripts/check-export-name-collisions.mts";
@@ -62,6 +63,45 @@ describe("export name collision guard", () => {
     `);
     expect([...result.definitions]).toEqual([]);
     expect([...result.exportedNames]).toEqual(["importedValue", "remoteValue"]);
+  });
+
+  it("reports direct aliasing re-exports only outside the Plugin SDK", () => {
+    expect(
+      findAliasingReExports([
+        {
+          path: "src/alias.ts",
+          content: `
+            export { original } from "./source.js";
+            export type { OriginalType as RenamedType } from "./source.js";
+            export { original as renamed } from "./source.js";
+          `,
+        },
+        {
+          path: "src/local-alias.ts",
+          content: `
+            import { original } from "./source.js";
+            export { original as locallyRenamed };
+          `,
+        },
+        {
+          path: "src/plugin-sdk/alias.ts",
+          content: 'export { original as sanctioned } from "../source.js";',
+        },
+        {
+          path: "packages/support.ts",
+          content: 'export { original as packageAlias } from "./source.js";',
+          includeDefinitions: false,
+        },
+      ]),
+    ).toEqual([
+      {
+        exportedName: "renamed",
+        importedName: "original",
+        line: 4,
+        moduleSpecifier: "./source.js",
+        path: "src/alias.ts",
+      },
+    ]);
   });
 
   it("exempts exact function and const same-name forwarders", () => {


### PR DESCRIPTION
Related: #121304

## What Problem This Solves

Aliasing re-exports such as `export { a as b } from` make grep-based navigation ambiguous in the same way duplicate exported definitions do. PR #121304 identified that visibility gap when it was closed in favor of the canonical export-name collision checker, but the informational alias report was the one capability not already present on `main`.

## Why This Change Was Made

The canonical `scripts/check-export-name-collisions.mts` now records direct value aliasing re-exports during its existing AST pass and prints them in a separate informational section. Type-only exports, local import/export aliases, resolution-only package modules, and sanctioned `src/plugin-sdk/**` boundary mappings are excluded. Alias findings never enter the debt baseline and do not affect the check's return value.

This change is AI-assisted and was reviewed with the repository autoreview workflow. No unrelated bugs or Pathfinder follow-ups were discovered.

## User Impact

There is no runtime behavior change. Developers running the collision guard now get a grep-friendly inventory of aliased re-exports outside the Plugin SDK boundary while the existing collision enforcement and baseline ratchet behave exactly as before.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/check-export-name-collisions.test.ts`
  - Pre-fix regression failed because `findAliasingReExports` did not exist.
  - Final: 1 file passed, 26 tests passed.
- `pnpm lint:tmp:export-name-collisions`
  - Printed the informational alias section, then `export name collision guard passed.`
- `pnpm check:wrapper-shadowing`
  - Passed: 70 current, 70 baselined.
- `pnpm plugin-sdk:surface:check`
  - Passed: 337 total entrypoints, 7,748 exports, 0 package-exported forbidden subpaths.
- `pnpm check:import-cycles`
  - Passed: 0 runtime value cycles.
- `pnpm format scripts/check-export-name-collisions.mts test/scripts/check-export-name-collisions.test.ts`
  - Passed; `git diff --check` is clean.
- `node scripts/check-changed.mjs`
  - Classified `scripts`, `testRoot`, and `tooling`. Remote routing did not yield usable proof; the documented trusted-source local fallback, `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs`, passed the complete plan, including both typechecks and script lint.
- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - Clean: no accepted/actionable findings.
- `git diff --numstat origin/main...HEAD` split:
  - Production runtime: +0/-0.
  - Tooling: +73/-13.
  - Tests: +40/-0.
  - Generated/baseline: +0/-0.
- `pnpm build` was not run because no module, lazy-loading, package, or published boundary changed.
