### PR TITLE
fix: handle legacy version before startup progress

### DIFF
--- a/src/index.entrypoint.test.ts
+++ b/src/index.entrypoint.test.ts
@@ -1,0 +1,80 @@
+// Tests executable behavior for the legacy package entrypoint.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { tryHandleRootVersionFastPath } from "./entry.version-fast-path.js";
+import { isMainModule } from "./infra/is-main.js";
+
+type IndexModule = typeof import("./index.js");
+
+vi.mock("./cli/run-main.js", () => ({
+  runCli: vi.fn(async () => undefined),
+}));
+
+vi.mock("./cli/one-shot-exit.js", () => ({
+  runCliWithExitFinalization: vi.fn(({ run }: { run: () => Promise<void> }) => {
+    void run();
+  }),
+}));
+
+vi.mock("./entry.version-fast-path.js", () => ({
+  tryHandleRootVersionFastPath: vi.fn(() => false),
+}));
+
+vi.mock("./infra/is-main.js", () => ({
+  isMainModule: vi.fn(() => true),
+}));
+
+vi.mock("./infra/unhandled-rejections.js", () => ({
+  installUnhandledRejectionHandler: vi.fn(),
+  isBenignUncaughtExceptionError: vi.fn(() => false),
+  isUncaughtExceptionHandled: vi.fn(() => false),
+}));
+
+vi.mock("./runtime.js", () => ({
+  restoreRuntimeTerminalState: vi.fn(),
+}));
+
+const originalArgv = process.argv;
+const originalExit = process.exit;
+
+describe("legacy package executable entrypoint", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.mocked(isMainModule).mockReturnValue(true);
+    vi.mocked(tryHandleRootVersionFastPath).mockReturnValue(false);
+    process.argv = ["node", "dist/index.js", "status"];
+    process.exit = vi.fn() as unknown as typeof process.exit;
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    process.exit = originalExit;
+    vi.restoreAllMocks();
+  });
+
+  it("handles root --version before loading runtime startup", async () => {
+    process.argv = ["node", "dist/index.js", "--version"];
+    vi.mocked(tryHandleRootVersionFastPath).mockReturnValue(true);
+
+    (await import("./index.js?legacy-version-fast-path" as "./index.js")) as IndexModule;
+
+    const runMain = await import("./cli/run-main.js");
+    const runtime = await import("./runtime.js");
+    const exitFinalization = await import("./cli/one-shot-exit.js");
+    expect(tryHandleRootVersionFastPath).toHaveBeenCalledWith(process.argv);
+    expect(runMain.runCli).not.toHaveBeenCalled();
+    expect(exitFinalization.runCliWithExitFinalization).not.toHaveBeenCalled();
+    expect(runtime.restoreRuntimeTerminalState).not.toHaveBeenCalled();
+  });
+
+  it("keeps normal legacy CLI execution when version fast path does not match", async () => {
+    (await import("./index.js?legacy-normal-exec" as "./index.js")) as IndexModule;
+
+    const runMain = await import("./cli/run-main.js");
+    const exitFinalization = await import("./cli/one-shot-exit.js");
+    expect(tryHandleRootVersionFastPath).toHaveBeenCalledWith(process.argv);
+    expect(exitFinalization.runCliWithExitFinalization).toHaveBeenCalledTimes(1);
+    expect(runMain.runCli).toHaveBeenCalledWith(process.argv, {
+      retainConsoleRoutingUntilProcessExit: true,
+    });
+  });
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,6 +3,18 @@ import fs from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 import { applyTemplate, runLegacyCliEntry } from "./index.js";
 
+vi.mock("./entry.version-fast-path.js", () => ({
+  tryHandleRootVersionFastPath: vi.fn(() => false),
+}));
+
+vi.mock("./runtime.js", () => ({
+  restoreRuntimeTerminalState: vi.fn(),
+}));
+
+vi.mock("./infra/is-main.js", () => ({
+  isMainModule: vi.fn(() => false),
+}));
+
 describe("legacy root entry", () => {
   it("routes the package root export to the pure library entry", () => {
     const packageJson = JSON.parse(

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { formatCliFailureLines } from "./cli/failure-output.js";
 import { runCliWithExitFinalization } from "./cli/one-shot-exit.js";
+import { tryHandleRootVersionFastPath } from "./entry.version-fast-path.js";
 import { formatUncaughtError } from "./infra/errors.js";
 import { runFatalErrorHooks } from "./infra/fatal-error-hooks.js";
 import { isMainModule } from "./infra/is-main.js";
@@ -97,56 +98,62 @@ if (!isMain) {
 }
 
 if (isMain) {
-  const { restoreRuntimeTerminalState } = await import("./runtime.js");
+  if (tryHandleRootVersionFastPath(process.argv)) {
+    // Match the primary launcher: root --version must exit before startup
+    // progress is created, otherwise the legacy package entry can leak the
+    // active spinner's process-exit cancellation output to TTY stderr.
+  } else {
+    const { restoreRuntimeTerminalState } = await import("./runtime.js");
 
-  // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
-  // These log the error and exit gracefully instead of crashing without trace.
-  installUnhandledRejectionHandler();
+    // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
+    // These log the error and exit gracefully instead of crashing without trace.
+    installUnhandledRejectionHandler();
 
-  process.on("uncaughtException", (error) => {
-    if (isUncaughtExceptionHandled(error)) {
-      return;
-    }
-    if (isBenignUncaughtExceptionError(error)) {
-      console.warn(
-        "[openclaw] Non-fatal uncaught exception (continuing):",
-        formatUncaughtError(error),
-      );
-      return;
-    }
-    for (const line of formatCliFailureLines({
-      title: "OpenClaw hit an unexpected runtime error.",
-      error,
-      argv: process.argv,
-    })) {
-      console.error(line);
-    }
-    for (const message of runFatalErrorHooks({ reason: "uncaught_exception", error })) {
-      console.error("[openclaw]", message);
-    }
-    restoreRuntimeTerminalState("uncaught exception", { resumeStdinIfPaused: false });
-    process.exit(1);
-  });
-
-  void runCliWithExitFinalization({
-    run: async () =>
-      await runLegacyCliEntry(process.argv, undefined, {
-        // Finalizers and process-exit hooks can still emit diagnostics after runCli settles.
-        retainConsoleRoutingUntilProcessExit: true,
-      }),
-    onError: (err) => {
+    process.on("uncaughtException", (error) => {
+      if (isUncaughtExceptionHandled(error)) {
+        return;
+      }
+      if (isBenignUncaughtExceptionError(error)) {
+        console.warn(
+          "[openclaw] Non-fatal uncaught exception (continuing):",
+          formatUncaughtError(error),
+        );
+        return;
+      }
       for (const line of formatCliFailureLines({
-        title: "The CLI command failed.",
-        error: err,
+        title: "OpenClaw hit an unexpected runtime error.",
+        error,
         argv: process.argv,
       })) {
         console.error(line);
       }
-      for (const message of runFatalErrorHooks({ reason: "legacy_cli_failure", error: err })) {
+      for (const message of runFatalErrorHooks({ reason: "uncaught_exception", error })) {
         console.error("[openclaw]", message);
       }
-      restoreRuntimeTerminalState("legacy cli failure", { resumeStdinIfPaused: false });
-      process.exitCode = 1;
-    },
-  });
+      restoreRuntimeTerminalState("uncaught exception", { resumeStdinIfPaused: false });
+      process.exit(1);
+    });
+
+    void runCliWithExitFinalization({
+      run: async () =>
+        await runLegacyCliEntry(process.argv, undefined, {
+          // Finalizers and process-exit hooks can still emit diagnostics after runCli settles.
+          retainConsoleRoutingUntilProcessExit: true,
+        }),
+      onError: (err) => {
+        for (const line of formatCliFailureLines({
+          title: "The CLI command failed.",
+          error: err,
+          argv: process.argv,
+        })) {
+          console.error(line);
+        }
+        for (const message of runFatalErrorHooks({ reason: "legacy_cli_failure", error: err })) {
+          console.error("[openclaw]", message);
+        }
+        restoreRuntimeTerminalState("legacy cli failure", { resumeStdinIfPaused: false });
+        process.exitCode = 1;
+      },
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- route the legacy package executable entry through the existing root `--version` fast path before CLI startup
- avoid creating startup progress for direct `dist/index.js --version`, matching the primary launcher behavior
- add executable-entry tests covering the fast path and normal legacy CLI fallback

Fixes #121604.

## What Problem This Solves
The normal `openclaw` launcher already handles root `--version` before startup progress is created, but executing the package entry directly (`node dist/index.js --version`) went through the legacy CLI path. That path could create TTY startup progress before the version handler exited, letting the active spinner print a misleading cancellation line to stderr for a successful version command.

This change makes the legacy package executable follow the same pre-startup version fast path as the primary launcher, while leaving normal non-version legacy CLI execution unchanged.

## Evidence
- Added `src/index.entrypoint.test.ts` to prove root `--version` is handled before `runCliWithExitFinalization`, runtime startup, or `runCli` are loaded/called.
- Added a normal-execution test to prove non-version legacy entry invocations still call `runCli` with `retainConsoleRoutingUntilProcessExit: true`.
- Ran targeted Vitest successfully:
  - `node --import tsx scripts/run-vitest.mts src/index.test.ts src/index.entrypoint.test.ts src/entry.version-fast-path.test.ts`
- Ran targeted lint successfully:
  - `pnpm exec oxlint src/index.ts src/index.test.ts src/index.entrypoint.test.ts`

## Notes
- `pnpm install --offline --ignore-scripts` initially failed because `@openclaw/fs-safe@0.5.4` was missing from the local store; a normal `pnpm install --ignore-scripts` completed and tests passed afterward.
- Full `tsc --noEmit --project tsconfig.json` was attempted with default and 8GB heap, but this checkout OOMed before producing type diagnostics.
