### PR TITLE
improve(test): speed up session list performance proofs

### DIFF
--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -2,12 +2,14 @@
 // session lists with repeated provider/model tuples.
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { describe, test, expect, vi } from "vitest";
+import { afterAll, describe, test, expect, vi } from "vitest";
 import {
   readAcpSessionMetaBatch,
   readAcpSessionMetaForEntry,
   writeAcpSessionMetaForMigration,
 } from "../acp/runtime/session-meta.js";
+import { buildSubagentRunReadIndexFromRuns } from "../agents/subagents/registry/subagent-registry-queries.js";
+import * as subagentRegistryRead from "../agents/subagents/registry/subagent-registry-read.js";
 import * as thinking from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
@@ -23,11 +25,13 @@ import { resolveGatewaySessionThinkingProjectionInternal } from "./session-utils
 import { buildSessionListRowMetadataContext } from "./session-utils-projection.js";
 import { listSessionsFromStore, listSessionsFromStoreAsync } from "./session-utils.js";
 
-// Runtime selection is outside these cache, metadata, and transcript batching
-// contracts. Keep its cold plugin/provider discovery off this focused file.
-vi.mock("../agents/harness/policy.js", () => ({
-  resolveAgentHarnessPolicy: () => ({ runtime: "openclaw", runtimeSource: "implicit" }),
-}));
+// Persisted subagent state is outside these cache, metadata, and transcript
+// batching contracts. Keep its state-database startup off this focused file.
+const subagentIndexSpy = vi
+  .spyOn(subagentRegistryRead, "buildSubagentSessionListReadIndex")
+  .mockImplementation((now) => buildSubagentRunReadIndexFromRuns({ runs: new Map(), now }));
+
+afterAll(() => subagentIndexSpy.mockRestore());
 
 /**
  * Regression smoke for the per-list rowContext resolver cache. The bug we are

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -2,14 +2,12 @@
 // session lists with repeated provider/model tuples.
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterAll, describe, test, expect, vi } from "vitest";
+import { describe, test, expect, vi } from "vitest";
 import {
   readAcpSessionMetaBatch,
   readAcpSessionMetaForEntry,
   writeAcpSessionMetaForMigration,
 } from "../acp/runtime/session-meta.js";
-import { buildSubagentRunReadIndexFromRuns } from "../agents/subagents/registry/subagent-registry-queries.js";
-import * as subagentRegistryRead from "../agents/subagents/registry/subagent-registry-read.js";
 import * as thinking from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
@@ -24,14 +22,6 @@ import { resolveEstimatedSessionCostUsd } from "./session-utils-core.js";
 import { resolveGatewaySessionThinkingProjectionInternal } from "./session-utils-model.js";
 import { buildSessionListRowMetadataContext } from "./session-utils-projection.js";
 import { listSessionsFromStore, listSessionsFromStoreAsync } from "./session-utils.js";
-
-// Persisted subagent state is outside these cache, metadata, and transcript
-// batching contracts. Keep its state-database startup off this focused file.
-const subagentIndexSpy = vi
-  .spyOn(subagentRegistryRead, "buildSubagentSessionListReadIndex")
-  .mockImplementation((now) => buildSubagentRunReadIndexFromRuns({ runs: new Map(), now }));
-
-afterAll(() => subagentIndexSpy.mockRestore());
 
 /**
  * Regression smoke for the per-list rowContext resolver cache. The bug we are
@@ -48,7 +38,10 @@ describe("listSessionsFromStore resolver cache", () => {
   test("collapses request-local resolver work to O(unique provider/model tuples)", () => {
     const cfg: OpenClawConfig = {
       agents: {
-        defaults: { model: { primary: "google-vertex/gemini-3-flash-preview" } },
+        defaults: {
+          model: { primary: "google-vertex/gemini-3-flash-preview" },
+          thinkingDefault: "off",
+        },
       },
     } as OpenClawConfig;
     const tuples: Array<{ modelProvider: string; model: string }> = [
@@ -128,7 +121,7 @@ describe("listSessionsFromStore resolver cache", () => {
       resetPluginRuntimeStateForTest();
       setActivePluginRegistry(createEmptyPluginRegistry());
       const cfg = {
-        agents: { defaults: { model: { primary: "openai/gpt-5" } } },
+        agents: { defaults: { model: { primary: "openai/gpt-5" }, thinkingDefault: "off" } },
       } as OpenClawConfig;
       resetConfigRuntimeState();
       setRuntimeConfigSnapshot(cfg);
@@ -256,7 +249,7 @@ describe("listSessionsFromStore resolver cache", () => {
       resetPluginRuntimeStateForTest();
       setActivePluginRegistry(createEmptyPluginRegistry());
       const cfg = {
-        agents: { defaults: { model: { primary: "openai/gpt-5" } } },
+        agents: { defaults: { model: { primary: "openai/gpt-5" }, thinkingDefault: "off" } },
       } as OpenClawConfig;
       resetConfigRuntimeState();
       setRuntimeConfigSnapshot(cfg);

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -95,9 +95,10 @@ describe("listSessionsFromStore resolver cache", () => {
         expect(result.sessions.length).toBe(rowCount);
 
         // The cache keys on rowContext are (provider, model) or
-        // (agentId, provider, model). With K=5 unique tuples we must see K
-        // resolver calls, not O(N=30).
-        expect(thinkingSpy).toHaveBeenCalledTimes(tuples.length);
+        // (agentId, provider, model). Thinking resolves one request default
+        // plus K=5 cached row tuples; cost resolves only the K row tuples.
+        // Both stay O(K), not O(N=30).
+        expect(thinkingSpy).toHaveBeenCalledTimes(tuples.length + 1);
         expect(costSpy).toHaveBeenCalledTimes(tuples.length);
       } finally {
         thinkingSpy.mockRestore();

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -23,6 +23,12 @@ import { resolveGatewaySessionThinkingProjectionInternal } from "./session-utils
 import { buildSessionListRowMetadataContext } from "./session-utils-projection.js";
 import { listSessionsFromStore, listSessionsFromStoreAsync } from "./session-utils.js";
 
+// Runtime selection is outside these cache, metadata, and transcript batching
+// contracts. Keep its cold plugin/provider discovery off this focused file.
+vi.mock("../agents/harness/policy.js", () => ({
+  resolveAgentHarnessPolicy: () => ({ runtime: "openclaw", runtimeSource: "implicit" }),
+}));
+
 /**
  * Regression smoke for the per-list rowContext resolver cache. The bug we are
  * guarding against is O(rows) scaling of deterministic resolvers whose results

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -2,7 +2,7 @@
 // session lists with repeated provider/model tuples.
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { beforeAll, describe, test, expect, vi } from "vitest";
+import { describe, test, expect, vi } from "vitest";
 import {
   readAcpSessionMetaBatch,
   readAcpSessionMetaForEntry,
@@ -32,49 +32,6 @@ import { listSessionsFromStore, listSessionsFromStoreAsync } from "./session-uti
  * are the actual scaling failure mode we care about.
  */
 describe("listSessionsFromStore resolver cache", () => {
-  beforeAll(async () => {
-    await withStateDirEnv("openclaw-perf-warm-", async ({ stateDir }) => {
-      resetPluginRuntimeStateForTest();
-      setActivePluginRegistry(createEmptyPluginRegistry());
-      const cfg = {
-        agents: { defaults: { model: { primary: "google-vertex/gemini-3-flash-preview" } } },
-      } as OpenClawConfig;
-      resetConfigRuntimeState();
-      setRuntimeConfigSnapshot(cfg);
-      listSessionsFromStore({
-        cfg,
-        storePath: path.join(stateDir, "sessions.json"),
-        store: {
-          google: {
-            sessionId: "google",
-            updatedAt: 1,
-            modelProvider: "google-vertex",
-            model: "gemini-3-flash-preview",
-          },
-          openai: {
-            sessionId: "openai",
-            updatedAt: 1,
-            modelProvider: "openai",
-            model: "gpt-5",
-          },
-          anthropic: {
-            sessionId: "anthropic",
-            updatedAt: 1,
-            modelProvider: "anthropic",
-            model: "claude-opus-4-7",
-          },
-          openrouter: {
-            sessionId: "openrouter",
-            updatedAt: 1,
-            modelProvider: "openrouter",
-            model: "z-ai/glm-5",
-          },
-        },
-        opts: {},
-      });
-    });
-  });
-
   test("collapses non-lightweight per-row resolver work to O(unique provider/model tuples)", async () => {
     await withStateDirEnv("openclaw-perf-", async ({ stateDir }) => {
       resetPluginRuntimeStateForTest();
@@ -112,8 +69,18 @@ describe("listSessionsFromStore resolver cache", () => {
         } as SessionEntry;
       }
 
-      const thinkingSpy = vi.spyOn(thinking, "listThinkingLevelOptions");
-      const costSpy = vi.spyOn(usageFormat, "resolveModelCostConfig");
+      // Keep this proof on the request-local cache boundary. Calling the real
+      // resolvers here pays unrelated cold provider startup before measuring
+      // the cache and previously required a duplicate broad warm-up list.
+      const thinkingSpy = vi
+        .spyOn(thinking, "listThinkingLevelOptions")
+        .mockReturnValue([{ id: "off", label: "Off" }]);
+      const costSpy = vi.spyOn(usageFormat, "resolveModelCostConfig").mockReturnValue({
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+      });
       try {
         const result = listSessionsFromStore({
           cfg,
@@ -128,13 +95,10 @@ describe("listSessionsFromStore resolver cache", () => {
         expect(result.sessions.length).toBe(rowCount);
 
         // The cache keys on rowContext are (provider, model) or
-        // (agentId, provider, model). With K=5 unique tuples we must see at
-        // most a small constant number of resolver calls, not O(N=30). A
-        // pre-cache regression would scale linearly and easily exceed the
-        // threshold below.
-        const cacheCallCeiling = tuples.length * 4;
-        expect(thinkingSpy.mock.calls.length).toBeLessThanOrEqual(cacheCallCeiling);
-        expect(costSpy.mock.calls.length).toBeLessThanOrEqual(cacheCallCeiling);
+        // (agentId, provider, model). With K=5 unique tuples we must see K
+        // resolver calls, not O(N=30).
+        expect(thinkingSpy).toHaveBeenCalledTimes(tuples.length);
+        expect(costSpy).toHaveBeenCalledTimes(tuples.length);
       } finally {
         thinkingSpy.mockRestore();
         costSpy.mockRestore();

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -2,7 +2,7 @@
 // session lists with repeated provider/model tuples.
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { beforeAll, describe, test, expect, vi } from "vitest";
+import { describe, test, expect, vi } from "vitest";
 import {
   readAcpSessionMetaBatch,
   readAcpSessionMetaForEntry,
@@ -18,6 +18,9 @@ import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import * as usageFormat from "../utils/usage-format.js";
 import * as titleReader from "./session-transcript-title-reader.js";
+import { resolveEstimatedSessionCostUsd } from "./session-utils-core.js";
+import { resolveGatewaySessionThinkingProjectionInternal } from "./session-utils-model.js";
+import { buildSessionListRowMetadataContext } from "./session-utils-projection.js";
 import { listSessionsFromStore, listSessionsFromStoreAsync } from "./session-utils.js";
 
 /**
@@ -32,114 +35,82 @@ import { listSessionsFromStore, listSessionsFromStoreAsync } from "./session-uti
  * are the actual scaling failure mode we care about.
  */
 describe("listSessionsFromStore resolver cache", () => {
-  beforeAll(async () => {
-    await withStateDirEnv("openclaw-perf-warm-", async ({ stateDir }) => {
-      resetPluginRuntimeStateForTest();
-      setActivePluginRegistry(createEmptyPluginRegistry());
-      const cfg = {
-        agents: { defaults: { model: { primary: "google-vertex/gemini-3-flash-preview" } } },
-      } as OpenClawConfig;
-      resetConfigRuntimeState();
-      setRuntimeConfigSnapshot(cfg);
-      listSessionsFromStore({
-        cfg,
-        storePath: path.join(stateDir, "sessions.json"),
-        store: {
-          google: {
-            sessionId: "google",
-            updatedAt: 1,
-            modelProvider: "google-vertex",
-            model: "gemini-3-flash-preview",
-          },
-          openai: {
-            sessionId: "openai",
-            updatedAt: 1,
-            modelProvider: "openai",
-            model: "gpt-5",
-          },
-          anthropic: {
-            sessionId: "anthropic",
-            updatedAt: 1,
-            modelProvider: "anthropic",
-            model: "claude-opus-4-7",
-          },
-          openrouter: {
-            sessionId: "openrouter",
-            updatedAt: 1,
-            modelProvider: "openrouter",
-            model: "z-ai/glm-5",
-          },
-        },
-        opts: {},
-      });
+  test("collapses request-local resolver work to O(unique provider/model tuples)", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { model: { primary: "google-vertex/gemini-3-flash-preview" } },
+      },
+    } as OpenClawConfig;
+    const tuples: Array<{ modelProvider: string; model: string }> = [
+      { modelProvider: "google-vertex", model: "gemini-3-flash-preview" },
+      { modelProvider: "openai", model: "gpt-5" },
+      { modelProvider: "anthropic", model: "claude-opus-4-7" },
+      { modelProvider: "openrouter", model: "z-ai/glm-5" },
+      { modelProvider: "google", model: "gemini-2.5-pro" },
+    ];
+    const now = Date.now();
+    const rowCount = 30;
+    const rowContext = buildSessionListRowMetadataContext({ now });
+    const thinkingSpy = vi
+      .spyOn(thinking, "listThinkingLevelOptions")
+      .mockReturnValue([{ id: "off", label: "Off" }]);
+    const costSpy = vi.spyOn(usageFormat, "resolveModelCostConfig").mockReturnValue({
+      input: 1,
+      output: 1,
+      cacheRead: 0,
+      cacheWrite: 0,
     });
-  });
-
-  test("collapses non-lightweight per-row resolver work to O(unique provider/model tuples)", async () => {
-    await withStateDirEnv("openclaw-perf-", async ({ stateDir }) => {
-      resetPluginRuntimeStateForTest();
-      setActivePluginRegistry(createEmptyPluginRegistry());
-      const cfg: OpenClawConfig = {
-        agents: {
-          defaults: { model: { primary: "google-vertex/gemini-3-flash-preview" } },
-        },
-      } as OpenClawConfig;
-      resetConfigRuntimeState();
-      setRuntimeConfigSnapshot(cfg);
-
-      const tuples: Array<{ modelProvider: string; model: string }> = [
-        { modelProvider: "google-vertex", model: "gemini-3-flash-preview" },
-        { modelProvider: "openai", model: "gpt-5" },
-        { modelProvider: "anthropic", model: "claude-opus-4-7" },
-        { modelProvider: "openrouter", model: "z-ai/glm-5" },
-        { modelProvider: "google", model: "gemini-2.5-pro" },
-      ];
-
-      const store: Record<string, SessionEntry> = {};
-      const now = Date.now();
-      const rowCount = 30;
-      for (let i = 0; i < rowCount; i++) {
+    try {
+      for (let index = 0; index < rowCount; index += 1) {
         const tuple = expectDefined(
-          tuples[i % tuples.length],
-          "tuples[i % tuples.length] test invariant",
+          tuples[index % tuples.length],
+          "tuples[index % tuples.length] test invariant",
         );
-        store[`agent:default:webchat:dm:${i}`] = {
-          updatedAt: now - i,
+        const sessionKey = `agent:default:webchat:dm:${index}`;
+        const entry: SessionEntry = {
+          updatedAt: now - index,
           modelProvider: tuple.modelProvider,
           model: tuple.model,
           inputTokens: 100,
           outputTokens: 50,
-        } as SessionEntry;
+          acp: {
+            backend: "acpx",
+            agent: "codex",
+            runtimeSessionName: sessionKey,
+            mode: "oneshot",
+            state: "idle",
+            lastActivityAt: now,
+          },
+        };
+        expect(
+          resolveGatewaySessionThinkingProjectionInternal({
+            cfg,
+            agentId: "default",
+            provider: tuple.modelProvider,
+            model: tuple.model,
+            sessionKey,
+            entry,
+            rowContext,
+          }).thinkingOptions,
+        ).toEqual(["Off"]);
+        expect(
+          resolveEstimatedSessionCostUsd({
+            cfg,
+            provider: tuple.modelProvider,
+            model: tuple.model,
+            entry,
+            rowContext,
+          }),
+        ).toBeDefined();
       }
 
-      const thinkingSpy = vi.spyOn(thinking, "listThinkingLevelOptions");
-      const costSpy = vi.spyOn(usageFormat, "resolveModelCostConfig");
-      try {
-        const result = listSessionsFromStore({
-          cfg,
-          storePath: path.join(stateDir, "sessions.json"),
-          store,
-          // sessions.list bounds responses to 100 rows by default; the perf
-          // smoke explicitly opts into the full set so the non-lightweight
-          // row builder exercises the display-identity, thinking-default, and
-          // model-cost caches at scale.
-          opts: { limit: rowCount },
-        });
-        expect(result.sessions.length).toBe(rowCount);
-
-        // The cache keys on rowContext are (provider, model) or
-        // (agentId, provider, model). With K=5 unique tuples we must see at
-        // most a small constant number of resolver calls, not O(N=30). A
-        // pre-cache regression would scale linearly and easily exceed the
-        // threshold below.
-        const cacheCallCeiling = tuples.length * 4;
-        expect(thinkingSpy.mock.calls.length).toBeLessThanOrEqual(cacheCallCeiling);
-        expect(costSpy.mock.calls.length).toBeLessThanOrEqual(cacheCallCeiling);
-      } finally {
-        thinkingSpy.mockRestore();
-        costSpy.mockRestore();
-      }
-    });
+      // Both caches key on the five unique tuples, not all 30 rows.
+      expect(thinkingSpy).toHaveBeenCalledTimes(tuples.length);
+      expect(costSpy).toHaveBeenCalledTimes(tuples.length);
+    } finally {
+      thinkingSpy.mockRestore();
+      costSpy.mockRestore();
+    }
   });
 
   test("batches ACP metadata reads once per list without changing row results", async () => {
@@ -259,6 +230,7 @@ describe("listSessionsFromStore resolver cache", () => {
             [missingKey]: missingEntry,
             [markerKey]: markerEntry,
           },
+          lightweightListRows: true,
           opts: { limit: 3 },
         });
         expect(result.sessions).toHaveLength(3);
@@ -300,6 +272,7 @@ describe("listSessionsFromStore resolver cache", () => {
           cfg,
           storePath,
           store,
+          lightweightListRows: true,
           opts: { includeDerivedTitles: true, includeLastMessage: true, limit: 30 },
         });
 
@@ -321,6 +294,7 @@ describe("listSessionsFromStore resolver cache", () => {
           cfg,
           storePath,
           store,
+          lightweightListRows: true,
           opts: { includeDerivedTitles: false, includeLastMessage: false, limit: 30 },
         });
         expect(titleBatchSpy).toHaveBeenCalledOnce();

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -225,18 +225,6 @@ describe("listSessionsFromStore resolver cache", () => {
         ]),
       );
 
-      const aboveSqliteVariableLimit = Array.from({ length: 33_000 }, (_, index) => ({
-        sessionKey: `agent:default:webchat:dm:missing-${index}`,
-        entry: {
-          sessionId: `missing-session-${index}`,
-          updatedAt: index,
-        } satisfies SessionEntry,
-      }));
-      const largeBatch = readAcpSessionMetaBatch({ entries: aboveSqliteVariableLimit });
-      expect(largeBatch.size).toBe(aboveSqliteVariableLimit.length);
-      expect(largeBatch.get(aboveSqliteVariableLimit[0]!.entry)).toBeUndefined();
-      expect(largeBatch.get(aboveSqliteVariableLimit.at(-1)!.entry)).toBeUndefined();
-
       const database = openOpenClawStateDatabase();
       const originalPrepare = database.db.prepare.bind(database.db);
       let acpSelects = 0;
@@ -247,6 +235,22 @@ describe("listSessionsFromStore resolver cache", () => {
         return originalPrepare(sql);
       });
       try {
+        // Cross the production 500-key chunk boundary without materializing
+        // tens of thousands of rows just to prove the same batching behavior.
+        const aboveBatchChunkSize = Array.from({ length: 501 }, (_, index) => ({
+          sessionKey: `agent:default:webchat:dm:missing-${index}`,
+          entry: {
+            sessionId: `missing-session-${index}`,
+            updatedAt: index,
+          } satisfies SessionEntry,
+        }));
+        const chunkedBatch = readAcpSessionMetaBatch({ entries: aboveBatchChunkSize });
+        expect(chunkedBatch.size).toBe(aboveBatchChunkSize.length);
+        expect(chunkedBatch.get(aboveBatchChunkSize[0]!.entry)).toBeUndefined();
+        expect(chunkedBatch.get(aboveBatchChunkSize.at(-1)!.entry)).toBeUndefined();
+        expect(acpSelects).toBe(2);
+
+        acpSelects = 0;
         const result = listSessionsFromStore({
           cfg,
           storePath: path.join(stateDir, "agents", "default", "sessions", "sessions.json"),

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -95,10 +95,9 @@ describe("listSessionsFromStore resolver cache", () => {
         expect(result.sessions.length).toBe(rowCount);
 
         // The cache keys on rowContext are (provider, model) or
-        // (agentId, provider, model). Thinking resolves one request default
-        // plus K=5 cached row tuples; cost resolves only the K row tuples.
-        // Both stay O(K), not O(N=30).
-        expect(thinkingSpy).toHaveBeenCalledTimes(tuples.length + 1);
+        // (agentId, provider, model). With K=5 unique tuples we must see K
+        // resolver calls, not O(N=30).
+        expect(thinkingSpy).toHaveBeenCalledTimes(tuples.length);
         expect(costSpy).toHaveBeenCalledTimes(tuples.length);
       } finally {
         thinkingSpy.mockRestore();

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -71,6 +71,7 @@ describe("listSessionsFromStore resolver cache", () => {
         );
         const sessionKey = `agent:default:webchat:dm:${index}`;
         const entry: SessionEntry = {
+          sessionId: `cache-proof-${index}`,
           updatedAt: now - index,
           modelProvider: tuple.modelProvider,
           model: tuple.model,

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -2,7 +2,7 @@
 // session lists with repeated provider/model tuples.
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { describe, test, expect, vi } from "vitest";
+import { beforeAll, describe, test, expect, vi } from "vitest";
 import {
   readAcpSessionMetaBatch,
   readAcpSessionMetaForEntry,
@@ -32,6 +32,49 @@ import { listSessionsFromStore, listSessionsFromStoreAsync } from "./session-uti
  * are the actual scaling failure mode we care about.
  */
 describe("listSessionsFromStore resolver cache", () => {
+  beforeAll(async () => {
+    await withStateDirEnv("openclaw-perf-warm-", async ({ stateDir }) => {
+      resetPluginRuntimeStateForTest();
+      setActivePluginRegistry(createEmptyPluginRegistry());
+      const cfg = {
+        agents: { defaults: { model: { primary: "google-vertex/gemini-3-flash-preview" } } },
+      } as OpenClawConfig;
+      resetConfigRuntimeState();
+      setRuntimeConfigSnapshot(cfg);
+      listSessionsFromStore({
+        cfg,
+        storePath: path.join(stateDir, "sessions.json"),
+        store: {
+          google: {
+            sessionId: "google",
+            updatedAt: 1,
+            modelProvider: "google-vertex",
+            model: "gemini-3-flash-preview",
+          },
+          openai: {
+            sessionId: "openai",
+            updatedAt: 1,
+            modelProvider: "openai",
+            model: "gpt-5",
+          },
+          anthropic: {
+            sessionId: "anthropic",
+            updatedAt: 1,
+            modelProvider: "anthropic",
+            model: "claude-opus-4-7",
+          },
+          openrouter: {
+            sessionId: "openrouter",
+            updatedAt: 1,
+            modelProvider: "openrouter",
+            model: "z-ai/glm-5",
+          },
+        },
+        opts: {},
+      });
+    });
+  });
+
   test("collapses non-lightweight per-row resolver work to O(unique provider/model tuples)", async () => {
     await withStateDirEnv("openclaw-perf-", async ({ stateDir }) => {
       resetPluginRuntimeStateForTest();
@@ -69,18 +112,8 @@ describe("listSessionsFromStore resolver cache", () => {
         } as SessionEntry;
       }
 
-      // Keep this proof on the request-local cache boundary. Calling the real
-      // resolvers here pays unrelated cold provider startup before measuring
-      // the cache and previously required a duplicate broad warm-up list.
-      const thinkingSpy = vi
-        .spyOn(thinking, "listThinkingLevelOptions")
-        .mockReturnValue([{ id: "off", label: "Off" }]);
-      const costSpy = vi.spyOn(usageFormat, "resolveModelCostConfig").mockReturnValue({
-        input: 1,
-        output: 1,
-        cacheRead: 0,
-        cacheWrite: 0,
-      });
+      const thinkingSpy = vi.spyOn(thinking, "listThinkingLevelOptions");
+      const costSpy = vi.spyOn(usageFormat, "resolveModelCostConfig");
       try {
         const result = listSessionsFromStore({
           cfg,
@@ -95,10 +128,13 @@ describe("listSessionsFromStore resolver cache", () => {
         expect(result.sessions.length).toBe(rowCount);
 
         // The cache keys on rowContext are (provider, model) or
-        // (agentId, provider, model). With K=5 unique tuples we must see K
-        // resolver calls, not O(N=30).
-        expect(thinkingSpy).toHaveBeenCalledTimes(tuples.length);
-        expect(costSpy).toHaveBeenCalledTimes(tuples.length);
+        // (agentId, provider, model). With K=5 unique tuples we must see at
+        // most a small constant number of resolver calls, not O(N=30). A
+        // pre-cache regression would scale linearly and easily exceed the
+        // threshold below.
+        const cacheCallCeiling = tuples.length * 4;
+        expect(thinkingSpy.mock.calls.length).toBeLessThanOrEqual(cacheCallCeiling);
+        expect(costSpy.mock.calls.length).toBeLessThanOrEqual(cacheCallCeiling);
       } finally {
         thinkingSpy.mockRestore();
         costSpy.mockRestore();

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -66,16 +66,6 @@ describe("listSessionsFromStore resolver cache", () => {
           model: tuple.model,
           inputTokens: 100,
           outputTokens: 50,
-          // Keep runtime selection outside this cache proof. ACP metadata gives
-          // the row a concrete runtime without cold-loading provider plugins.
-          acp: {
-            backend: "acpx",
-            agent: "codex",
-            runtimeSessionName: `cache-proof-${i}`,
-            mode: "oneshot",
-            state: "idle",
-            lastActivityAt: now,
-          },
         } as SessionEntry;
       }
 

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -66,6 +66,16 @@ describe("listSessionsFromStore resolver cache", () => {
           model: tuple.model,
           inputTokens: 100,
           outputTokens: 50,
+          // Keep runtime selection outside this cache proof. ACP metadata gives
+          // the row a concrete runtime without cold-loading provider plugins.
+          acp: {
+            backend: "acpx",
+            agent: "codex",
+            runtimeSessionName: `cache-proof-${i}`,
+            mode: "oneshot",
+            state: "idle",
+            lastActivityAt: now,
+          },
         } as SessionEntry;
       }
 


### PR DESCRIPTION
## What Problem This Solves

`src/gateway/session-utils.perf.test.ts` spent most of its time on behavior outside the three performance contracts it protects: cold provider thinking-default discovery, a broad warm-up list, and 33,000 missing ACP rows even though the production batch boundary is 500 keys.

## What Changed

- Replaced the broad list warm-up/cache probe with direct request-context coverage over 30 rows and five provider/model tuples.
- Pinned the synthetic configs' thinking default so the tests do not cold-discover unrelated provider policy.
- Kept the ACP and transcript-title integration proofs on the production lightweight list path, which still owns row-context, metadata, and transcript batching.
- Replaced 33,000 missing ACP entries with 501 and asserted exactly two 500-key chunk selects.
- Net test change: 19 fewer lines; no production code and no CI workers added.

## Coverage Retained

The exact-head test still proves:

- thinking and cost resolvers execute once per five unique provider/model tuples, not once per 30 rows;
- 501 ACP entries cross the 500-key boundary, preserve first/last missing results, and execute exactly two selects;
- a three-session gateway list executes one ACP select;
- 30 transcript title/preview requests hydrate in one batch and preserve first/last row results;
- disabling title/preview projection issues one empty batch call.

## Measured Result

Exact precise PR CI, same runner path:

| Metric | Before | After | Gain |
| --- | ---: | ---: | ---: |
| Test execution | 22.688s | 3.187s | **86.0% faster** |
| Full Vitest duration | 28.35s | 8.87s | **68.7% faster** |

The original compact-suite baseline was 32.577s of test execution, making the final test execution **90.2% faster** versus that baseline.

Evidence:

- Before: https://github.com/openclaw/openclaw/actions/runs/31460869648/job/93684262777
- Exact final head: https://github.com/openclaw/openclaw/actions/runs/31461356629/job/93685667977
- Original compact baseline: https://github.com/openclaw/openclaw/actions/runs/31450296338/job/93653908089

Static verification:

- `oxfmt --check src/gateway/session-utils.perf.test.ts`
- `git diff --check`
