### PR TITLE
refactor(agents): centralize exec process cancellation

### DIFF
--- a/src/agents/bash-process-references.test.ts
+++ b/src/agents/bash-process-references.test.ts
@@ -11,6 +11,7 @@ describe("bash-process-references truncation", () => {
       command,
       backgrounded: true,
       startedAt: 1,
+      pid: 4242,
     });
     session.scopeKey = "scope-a";
     addSession(session);
@@ -18,6 +19,7 @@ describe("bash-process-references truncation", () => {
     try {
       const [reference] = listActiveProcessSessionReferences({ scopeKey: "scope-a", now: 2 });
       expect(reference?.name).toBe(`${"a".repeat(136)}...`);
+      expect(reference?.pid).toBe(4242);
     } finally {
       deleteSession("emoji-proc-scoped");
     }

--- a/src/agents/bash-process-references.ts
+++ b/src/agents/bash-process-references.ts
@@ -57,7 +57,7 @@ export function listActiveProcessSessionReferences(params: {
     .map((session) => ({
       sessionId: session.id,
       status: "running" as const,
-      pid: session.pid ?? session.child?.pid,
+      pid: session.pid,
       startedAt: session.startedAt,
       runtimeMs: Math.max(0, now - session.startedAt),
       cwd: session.cwd,

--- a/src/agents/bash-process-registry.test-helpers.ts
+++ b/src/agents/bash-process-registry.test-helpers.ts
@@ -3,7 +3,6 @@
  * Provides complete session objects so tests can focus on the field under
  * inspection without repeating registry defaults.
  */
-import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import type { ProcessSession } from "./bash-process-registry.js";
 
 /** Build a process-session fixture with safe defaults for registry tests. */
@@ -16,7 +15,6 @@ export function createProcessSessionFixture(params: {
   pendingMaxOutputChars?: number;
   backgrounded?: boolean;
   pid?: number;
-  child?: ChildProcessWithoutNullStreams;
   cursorKeyMode?: ProcessSession["cursorKeyMode"];
 }): ProcessSession {
   const session: ProcessSession = {
@@ -43,9 +41,6 @@ export function createProcessSessionFixture(params: {
   };
   if (params.pid !== undefined) {
     session.pid = params.pid;
-  }
-  if (params.child) {
-    session.child = params.child;
   }
   return session;
 }

--- a/src/agents/bash-process-registry.test.ts
+++ b/src/agents/bash-process-registry.test.ts
@@ -3,7 +3,6 @@
  * Covers output caps, finished-session retention, cleanup, and PTY cursor mode
  * state for background exec sessions.
  */
-import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProcessSession } from "./bash-process-registry.js";
 import {
@@ -48,7 +47,6 @@ describe("bash process registry", () => {
     return createProcessSessionFixture({
       id: params.id ?? "sess",
       command: "echo test",
-      child: { pid: 123, removeAllListeners: vi.fn() } as unknown as ChildProcessWithoutNullStreams,
       maxOutputChars: params.maxOutputChars,
       pendingMaxOutputChars: params.pendingMaxOutputChars,
       backgrounded: params.backgrounded,
@@ -433,7 +431,6 @@ describe("cursorKeyMode", () => {
     return createProcessSessionFixture({
       id: params.id ?? "sess",
       command: "echo test",
-      child: { pid: 123, removeAllListeners: vi.fn() } as unknown as ChildProcessWithoutNullStreams,
       maxOutputChars: params.maxOutputChars,
       pendingMaxOutputChars: params.pendingMaxOutputChars,
       backgrounded: params.backgrounded,

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -29,11 +29,11 @@ let jobTtlMs = clampTtl(readEnvInt("OPENCLAW_BASH_JOB_TTL_MS", "PI_BASH_JOB_TTL_
 /** Lifecycle status recorded for background process sessions. */
 type ProcessStatus = "running" | "completed" | "failed" | "killed";
 
-/** Writable stdin surface shared by child-process and PTY-backed sessions. */
+/** Writable stdin surface prepared by the supervisor for child and PTY sessions. */
 type SessionStdin = {
   write: (data: string, cb?: (err?: Error | null) => void) => void;
   end: () => void;
-  // When backed by a real Node stream (child.stdin), this exists; for PTY wrappers it may not.
+  // Child and PTY wrappers both expose destroy today; keep it optional for alternate backends.
   destroy?: () => void;
   destroyed?: boolean;
   writable?: boolean;
@@ -70,6 +70,9 @@ export interface ProcessSession {
   /** Set when process poll observed the terminal result before notification. */
   terminalPollObserved?: boolean;
   notifyOnExitRemoval?: NotifyOnExitRemoval;
+  // Deprecated declaration-closure compatibility only; runtime never uses this.
+  // ProcessSupervisor owns raw processes. Remove when the public Plugin SDK closure no
+  // longer reaches registry types, or at the next compatible boundary change.
   child?: ChildProcessWithoutNullStreams;
   stdin?: SessionStdin;
   pid?: number;
@@ -326,33 +329,14 @@ export function getActiveBackgroundExecSessionCount(): number {
 function moveToFinished(session: ProcessSession, status: ProcessStatus) {
   runningSessions.delete(session.id);
 
-  // Clean up child process stdio streams to prevent FD leaks
-  if (session.child) {
-    // Destroy stdio streams to release file descriptors
-    session.child.stdin?.destroy?.();
-    session.child.stdout?.destroy?.();
-    session.child.stderr?.destroy?.();
-
-    // Remove all event listeners to prevent memory leaks
-    session.child.removeAllListeners();
-
-    // Clear the reference
-    delete session.child;
-  }
-
-  // Clean up stdin wrapper - call destroy if available, otherwise just remove reference
-  if (session.stdin) {
-    // Try to call destroy/end method if exists
-    if (typeof session.stdin.destroy === "function") {
-      session.stdin.destroy();
-    } else if (typeof session.stdin.end === "function") {
-      session.stdin.end();
-    }
-    // Only set flag if writable
-    try {
-      (session.stdin as { destroyed?: boolean }).destroyed = true;
-    } catch {
-      // Ignore if read-only
+  // The supervisor owns the raw process. The registry releases only the
+  // prepared stdin wrapper retained for process-tool input.
+  const stdin = session.stdin;
+  if (stdin) {
+    if (typeof stdin.destroy === "function") {
+      stdin.destroy();
+    } else if (typeof stdin.end === "function") {
+      stdin.end();
     }
     delete session.stdin;
   }

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -661,7 +661,6 @@ export async function runExecProcess(opts: {
     notifyOnExit: opts.notifyOnExit,
     notifyOnExitEmptySuccess: opts.notifyOnExitEmptySuccess === true,
     exitNotified: false,
-    child: undefined,
     stdin: undefined,
     pid: undefined,
     startedAt,

--- a/src/agents/bash-tools.process.e2e.test.ts
+++ b/src/agents/bash-tools.process.e2e.test.ts
@@ -227,7 +227,7 @@ test.skipIf(process.platform === "win32")(
 );
 
 test.skipIf(process.platform === "win32")(
-  "controls one real interactive background child through exec and process tools",
+  "controls and cancels one real interactive background child through process tools",
   async () => {
     const scopeKey = "agent:main:process-control-roundtrip";
     const execTool = createExecTool({
@@ -252,7 +252,6 @@ test.skipIf(process.platform === "win32")(
         "  for (const char of chunk) {",
         '    if (char === "\\u0003") {',
         "      process.stdout.write(`CONTROL:CTRL-C:${lineCount}\\n`);",
-        "      setTimeout(() => process.exit(lineCount === 2 ? 0 : 3), 10);",
         "      continue;",
         "    }",
         '    if (char !== "\\r" && char !== "\\n") {',
@@ -389,6 +388,24 @@ test.skipIf(process.platform === "win32")(
         keys: ["C-c"],
       });
       expect(interrupt.details).toMatchObject({ status: "running", sessionId });
+      await expect
+        .poll(
+          async () => {
+            const log = await processTool.execute("process-control-interrupt-log", {
+              action: "log",
+              sessionId,
+            });
+            return textContent(log);
+          },
+          { timeout: 5_000, interval: 25 },
+        )
+        .toContain("CONTROL:CTRL-C:2");
+
+      const killed = await processTool.execute("process-control-kill", {
+        action: "kill",
+        sessionId,
+      });
+      expect(textContent(killed)).toBe(`Termination requested for session ${sessionId}.`);
 
       await expect
         .poll(
@@ -400,20 +417,20 @@ test.skipIf(process.platform === "win32")(
             });
             const details = poll.details as {
               status?: string;
-              exitCode?: number;
+              exitReason?: string;
               aggregated?: string;
             };
             return {
               status: details.status,
-              exitCode: details.exitCode,
+              exitReason: details.exitReason,
               aggregated: details.aggregated ?? "",
             };
           },
           { timeout: 5_000, interval: 25 },
         )
         .toEqual({
-          status: "completed",
-          exitCode: 0,
+          status: "failed",
+          exitReason: "manual-cancel",
           aggregated: expect.stringContaining("CONTROL:CTRL-C:2"),
         });
 
@@ -421,7 +438,7 @@ test.skipIf(process.platform === "win32")(
         action: "log",
         sessionId,
       });
-      expect(completedLog.details).toMatchObject({ status: "completed", sessionId });
+      expect(completedLog.details).toMatchObject({ status: "failed", sessionId });
       expect(textContent(completedLog)).toContain("LINE:alpha");
       expect(textContent(completedLog)).toContain("LINE:beta");
       expect(textContent(completedLog)).toContain("CONTROL:CTRL-C:2");

--- a/src/agents/bash-tools.process.supervisor.test.ts
+++ b/src/agents/bash-tools.process.supervisor.test.ts
@@ -1,6 +1,6 @@
 /**
  * Regression coverage for process-tool supervisor cancellation.
- * Verifies managed session cancellation, process-tree fallback, and registry state.
+ * Verifies canonical cancellation admission and lifecycle-owned registry state.
  */
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -31,17 +31,21 @@ let getActiveBackgroundExecSessionCount: typeof import("./bash-process-registry.
 let getFinishedSession: typeof import("./bash-process-registry.js").getFinishedSession;
 let getSession: typeof import("./bash-process-registry.js").getSession;
 let markBackgrounded: typeof import("./bash-process-registry.js").markBackgrounded;
+let markExited: typeof import("./bash-process-registry.js").markExited;
 let resetProcessRegistryForTests: typeof import("./bash-process-registry.test-support.js").resetProcessRegistryForTests;
 let createProcessSessionFixture: typeof import("./bash-process-registry.test-helpers.js").createProcessSessionFixture;
 let createProcessTool: typeof import("./bash-tools.process.js").createProcessTool;
 
 function createBackgroundSession(id: string, pid?: number) {
-  return createProcessSessionFixture({
+  const session = createProcessSessionFixture({
     id,
     command: "sleep 999",
-    backgrounded: true,
+    backgrounded: false,
     ...(pid === undefined ? {} : { pid }),
   });
+  addSession(session);
+  markBackgrounded(session);
+  return session;
 }
 
 const requireRecord = createRequireRecord("object", "expected-label");
@@ -50,19 +54,6 @@ function expectSessionState(sessionId: string, expected: { exited?: boolean }) {
   const session = requireRecord(getSession(sessionId), sessionId);
   if ("exited" in expected) {
     expect(session.exited).toBe(expected.exited);
-  }
-}
-
-function expectFinishedSessionState(
-  sessionId: string,
-  expected: { status?: string; exitSignal?: string | null },
-) {
-  const session = requireRecord(getFinishedSession(sessionId), sessionId);
-  if ("status" in expected) {
-    expect(session.status).toBe(expected.status);
-  }
-  if ("exitSignal" in expected) {
-    expect(session.exitSignal).toBe(expected.exitSignal);
   }
 }
 
@@ -80,6 +71,7 @@ describe("process tool supervisor cancellation", () => {
       getFinishedSession,
       getSession,
       markBackgrounded,
+      markExited,
     } = await import("./bash-process-registry.js"));
     ({ resetProcessRegistryForTests } = await import("./bash-process-registry.test-support.js"));
     ({ createProcessSessionFixture } = await import("./bash-process-registry.test-helpers.js"));
@@ -103,7 +95,7 @@ describe("process tool supervisor cancellation", () => {
       runId: "sess",
       state: "running",
     });
-    addSession(createBackgroundSession("sess"));
+    createBackgroundSession("sess");
     const processTool = createProcessTool();
 
     const result = await processTool.execute("toolcall", {
@@ -113,6 +105,7 @@ describe("process tool supervisor cancellation", () => {
 
     expect(supervisorMock.cancel).toHaveBeenCalledWith("sess", "manual-cancel");
     expectSessionState("sess", { exited: false });
+    expect(getActiveBackgroundExecSessionCount()).toBe(1);
     expectTextContent(result.content[0], "Termination requested for session sess.");
   });
 
@@ -121,7 +114,7 @@ describe("process tool supervisor cancellation", () => {
       runId: "sess",
       state: "running",
     });
-    addSession(createBackgroundSession("sess"));
+    const session = createBackgroundSession("sess");
     const processTool = createProcessTool();
 
     const result = await processTool.execute("toolcall", {
@@ -132,23 +125,41 @@ describe("process tool supervisor cancellation", () => {
     expect(supervisorMock.cancel).toHaveBeenCalledWith("sess", "manual-cancel");
     expect(getSession("sess")).toBeUndefined();
     expect(getFinishedSession("sess")).toBeUndefined();
+    expect(getActiveBackgroundExecSessionCount()).toBe(1);
     expectTextContent(result.content[0], "Removed session sess (termination requested).");
+
+    markExited(session, null, "SIGTERM", "failed", "manual-cancel");
+    expect(getActiveBackgroundExecSessionCount()).toBe(0);
+    expect(getFinishedSession("sess")).toBeUndefined();
   });
 
-  it("falls back to process-tree kill when supervisor record is missing", async () => {
+  it.each([
+    {
+      action: "kill" as const,
+      expected:
+        "Unable to terminate session sess-unmanaged: no active supervisor cancellation handle. Use process poll to check whether it is already exiting.",
+    },
+    {
+      action: "remove" as const,
+      expected:
+        "Unable to remove session sess-unmanaged: no active supervisor cancellation handle. Use process poll to check whether it is already exiting.",
+    },
+  ])("refuses $action without a live supervisor record", async ({ action, expected }) => {
     supervisorMock.getRecord.mockReturnValue(undefined);
-    addSession(createBackgroundSession("sess-fallback", 4242));
+    createBackgroundSession("sess-unmanaged", 4242);
     const processTool = createProcessTool();
 
     const result = await processTool.execute("toolcall", {
-      action: "kill",
-      sessionId: "sess-fallback",
+      action,
+      sessionId: "sess-unmanaged",
     });
 
-    expect(killProcessTreeMock).toHaveBeenCalledWith(4242);
-    expect(getSession("sess-fallback")).toBeUndefined();
-    expectFinishedSessionState("sess-fallback", { status: "failed", exitSignal: "SIGKILL" });
-    expectTextContent(result.content[0], "Killed session sess-fallback.");
+    expect(supervisorMock.cancel).not.toHaveBeenCalled();
+    expect(killProcessTreeMock).not.toHaveBeenCalled();
+    expectSessionState("sess-unmanaged", { exited: false });
+    expect(getFinishedSession("sess-unmanaged")).toBeUndefined();
+    expect(getActiveBackgroundExecSessionCount()).toBe(1);
+    expectTextContent(result.content[0], expected);
   });
 
   it.each(["kill", "remove"] as const)(
@@ -157,8 +168,6 @@ describe("process tool supervisor cancellation", () => {
       supervisorMock.getRecord.mockReturnValue({ runId: "sess-finalizing", state: "exited" });
       const session = createBackgroundSession("sess-finalizing", 4242);
       session.finalizing = true;
-      addSession(session);
-      markBackgrounded(session);
       const processTool = createProcessTool();
 
       const result = await processTool.execute("toolcall", {
@@ -173,23 +182,4 @@ describe("process tool supervisor cancellation", () => {
       expectTextContent(result.content[0], "Session sess-finalizing is finalizing.");
     },
   );
-
-  it("fails remove when no supervisor record and no pid is available", async () => {
-    supervisorMock.getRecord.mockReturnValue(undefined);
-    addSession(createBackgroundSession("sess-no-pid"));
-    const processTool = createProcessTool();
-
-    const result = await processTool.execute("toolcall", {
-      action: "remove",
-      sessionId: "sess-no-pid",
-    });
-
-    expect(killProcessTreeMock).not.toHaveBeenCalled();
-    expectSessionState("sess-no-pid", { exited: false });
-    expect(requireRecord(result.details, "result details").status).toBe("failed");
-    expectTextContent(
-      result.content[0],
-      "Unable to remove session sess-no-pid: no active supervisor run or process id.",
-    );
-  });
 });

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -6,8 +6,8 @@
 import { createAbortError as createNamedAbortError } from "../infra/abort-signal.js";
 import { formatDurationCompact } from "../infra/format-time/format-duration.ts";
 import { getDiagnosticSessionState } from "../logging/diagnostic-session-state.js";
-import { killProcessTree } from "../process/kill-tree.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
+import { cancelBackgroundExecSession } from "./bash-process-control.js";
 import {
   acknowledgeNotifyOnExit,
   type ProcessSession,
@@ -20,7 +20,6 @@ import {
   listFinishedSessions,
   listRunningSessions,
   markTerminalPollObserved,
-  markExited,
   setJobTtlMs,
 } from "./bash-process-registry.js";
 import { describeProcessTool } from "./bash-tools.descriptions.js";
@@ -92,7 +91,7 @@ type RunningSessionRuntime = {
 };
 
 function resolveSessionStdin(session: ProcessSession): WritableStdin | undefined {
-  return (session.stdin ?? session.child?.stdin) as WritableStdin | undefined;
+  return session.stdin as WritableStdin | undefined;
 }
 
 function isWritableStdin(stdin: WritableStdin | undefined): stdin is WritableStdin {
@@ -280,24 +279,6 @@ export function createProcessTool(
     }
     const idle = formatDurationCompact(runtime.idleMs) ?? `${runtime.idleMs}ms`;
     return `\n\nNo new output for ${idle}; this session may be waiting for input. Use process write, send-keys, submit, or paste to provide input.`;
-  };
-
-  const cancelManagedSession = (sessionId: string) => {
-    const record = supervisor.getRecord(sessionId);
-    if (!record || record.state === "exited") {
-      return false;
-    }
-    supervisor.cancel(sessionId, "manual-cancel");
-    return true;
-  };
-
-  const terminateSessionFallback = (session: ProcessSession) => {
-    const pid = session.pid ?? session.child?.pid;
-    if (typeof pid !== "number" || !Number.isFinite(pid) || pid <= 0) {
-      return false;
-    }
-    killProcessTree(pid);
-    return true;
   };
 
   return {
@@ -676,24 +657,17 @@ export function createProcessTool(
           if (scopedSession.finalizing) {
             return failText(`Session ${params.sessionId} is finalizing.`);
           }
-          const canceled = cancelManagedSession(scopedSession.id);
-          if (!canceled) {
-            const terminated = terminateSessionFallback(scopedSession);
-            if (!terminated) {
-              return failText(
-                `Unable to terminate session ${params.sessionId}: no active supervisor run or process id.`,
-              );
-            }
-            markExited(scopedSession, null, "SIGKILL", "failed");
+          if (!cancelBackgroundExecSession(scopedSession.id)) {
+            return failText(
+              `Unable to terminate session ${params.sessionId}: no active supervisor cancellation handle. Use process poll to check whether it is already exiting.`,
+            );
           }
           resetPollRetrySuggestion(params.sessionId);
           return {
             content: [
               {
                 type: "text",
-                text: canceled
-                  ? `Termination requested for session ${params.sessionId}.`
-                  : `Killed session ${params.sessionId}.`,
+                text: `Termination requested for session ${params.sessionId}.`,
               },
             ],
             details: {
@@ -725,32 +699,26 @@ export function createProcessTool(
 
         case "remove": {
           if (scopedSession) {
+            if (!scopedSession.backgrounded) {
+              return failText(`Session ${params.sessionId} is not backgrounded.`);
+            }
             if (scopedSession.finalizing) {
               return failText(`Session ${params.sessionId} is finalizing.`);
             }
-            const canceled = cancelManagedSession(scopedSession.id);
-            if (canceled) {
-              // Keep remove semantics deterministic: drop from process registry now.
-              scopedSession.backgrounded = false;
-              deleteSession(params.sessionId);
-            } else {
-              const terminated = terminateSessionFallback(scopedSession);
-              if (!terminated) {
-                return failText(
-                  `Unable to remove session ${params.sessionId}: no active supervisor run or process id.`,
-                );
-              }
-              markExited(scopedSession, null, "SIGKILL", "failed");
-              deleteSession(params.sessionId);
+            if (!cancelBackgroundExecSession(scopedSession.id)) {
+              return failText(
+                `Unable to remove session ${params.sessionId}: no active supervisor cancellation handle. Use process poll to check whether it is already exiting.`,
+              );
             }
+            // Keep remove semantics deterministic: drop from process registry now.
+            scopedSession.backgrounded = false;
+            deleteSession(params.sessionId);
             resetPollRetrySuggestion(params.sessionId);
             return {
               content: [
                 {
                   type: "text",
-                  text: canceled
-                    ? `Removed session ${params.sessionId} (termination requested).`
-                    : `Removed session ${params.sessionId}.`,
+                  text: `Removed session ${params.sessionId} (termination requested).`,
                 },
               ],
               details: {

--- a/src/auto-reply/reply/bash-command.stop.test.ts
+++ b/src/auto-reply/reply/bash-command.stop.test.ts
@@ -3,20 +3,29 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { MsgContext } from "../templating.js";
 
-const { getSessionMock, getFinishedSessionMock, killProcessTreeMock } = vi.hoisted(() => ({
+const {
+  cancelBackgroundExecSessionMock,
+  createExecToolMock,
+  getFinishedSessionMock,
+  getSessionMock,
+} = vi.hoisted(() => ({
+  cancelBackgroundExecSessionMock: vi.fn(),
+  createExecToolMock: vi.fn(),
   getSessionMock: vi.fn(),
   getFinishedSessionMock: vi.fn(),
-  killProcessTreeMock: vi.fn(),
+}));
+
+vi.mock("../../agents/bash-process-control.js", () => ({
+  cancelBackgroundExecSession: cancelBackgroundExecSessionMock,
 }));
 
 vi.mock("../../agents/bash-process-registry.js", () => ({
   getSession: getSessionMock,
   getFinishedSession: getFinishedSessionMock,
-  markExited: vi.fn(),
 }));
 
-vi.mock("../../process/kill-tree.js", () => ({
-  killProcessTree: killProcessTreeMock,
+vi.mock("../../agents/bash-tools.js", () => ({
+  createExecTool: createExecToolMock,
 }));
 
 const { handleBashChatCommand } = await import("./bash-command.js");
@@ -76,14 +85,23 @@ function buildRunningSession(overrides?: Record<string, unknown>) {
   };
 }
 
+function backgroundExecResult(sessionId: string) {
+  return {
+    content: [],
+    details: { status: "running", sessionId, startedAt: Date.now() },
+  };
+}
+
 describe("handleBashChatCommand stop", () => {
   beforeEach(() => {
     getSessionMock.mockReset();
     getFinishedSessionMock.mockReset();
-    killProcessTreeMock.mockReset();
+    cancelBackgroundExecSessionMock.mockReset();
+    cancelBackgroundExecSessionMock.mockReturnValue(true);
+    createExecToolMock.mockReset();
   });
 
-  it("returns immediately with a stopping message and fires killProcessTree", async () => {
+  it("returns immediately after canonical cancellation is admitted", async () => {
     const session = buildRunningSession();
     getSessionMock.mockReturnValue(session);
     getFinishedSessionMock.mockReturnValue(undefined);
@@ -92,7 +110,8 @@ describe("handleBashChatCommand stop", () => {
 
     expect(result.text).toContain("bash stopping");
     expect(result.text).toContain("!poll session-1");
-    expect(killProcessTreeMock).toHaveBeenCalledWith(4242);
+    expect(cancelBackgroundExecSessionMock).toHaveBeenCalledWith("session-1");
+    expect(session.exited).toBe(false);
   });
 
   it("includes the full session ID so the user can poll after starting a new job", async () => {
@@ -105,16 +124,6 @@ describe("handleBashChatCommand stop", () => {
     expect(result.text).toContain("!poll deep-forest-42");
   });
 
-  it("does not call markExited synchronously (defers to supervisor lifecycle)", async () => {
-    const session = buildRunningSession();
-    getSessionMock.mockReturnValue(session);
-    getFinishedSessionMock.mockReturnValue(undefined);
-
-    await handleBashChatCommand(buildParams("/bash stop session-1"));
-
-    expect(session.exited).toBe(false);
-  });
-
   it("returns no-running-job when session is not found", async () => {
     getSessionMock.mockReturnValue(undefined);
     getFinishedSessionMock.mockReturnValue(undefined);
@@ -122,7 +131,7 @@ describe("handleBashChatCommand stop", () => {
     const result = await handleBashChatCommand(buildParams("/bash stop session-1"));
 
     expect(result.text).toContain("No running bash job found");
-    expect(killProcessTreeMock).not.toHaveBeenCalled();
+    expect(cancelBackgroundExecSessionMock).not.toHaveBeenCalled();
   });
 
   it("does not split boundary emoji in missing session snippets", async () => {
@@ -134,16 +143,47 @@ describe("handleBashChatCommand stop", () => {
     expect(result.text).toBe("⚙️ No running bash job found for 1234567….");
   });
 
-  it("fails stop when session has no pid", async () => {
-    const session = buildRunningSession({ pid: undefined, child: undefined });
+  it("returns actionable guidance when canonical cancellation is not admitted", async () => {
+    const session = buildRunningSession();
     getSessionMock.mockReturnValue(session);
     getFinishedSessionMock.mockReturnValue(undefined);
+    cancelBackgroundExecSessionMock.mockReturnValue(false);
 
     const result = await handleBashChatCommand(buildParams("/bash stop session-1"));
 
     expect(result.text).toContain("Unable to stop bash session");
     expect(result.text).toContain("!poll session-1");
-    expect(killProcessTreeMock).not.toHaveBeenCalled();
+    expect(result.text).toContain("no active cancellation handle");
+    expect(cancelBackgroundExecSessionMock).toHaveBeenCalledWith("session-1");
+  });
+
+  it("clears active job state from registry lifecycle without a child watcher", async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce(backgroundExecResult("session-first"))
+      .mockResolvedValueOnce(backgroundExecResult("session-second"));
+    createExecToolMock.mockReturnValue({ execute });
+    getSessionMock.mockReturnValue(undefined);
+    getFinishedSessionMock.mockReturnValue(undefined);
+
+    await handleBashChatCommand(buildParams("/bash first"));
+    const firstSession = buildRunningSession({ id: "session-first" });
+    getSessionMock.mockReturnValue(firstSession);
+    await handleBashChatCommand(buildParams("/bash stop"));
+    expect(cancelBackgroundExecSessionMock).toHaveBeenCalledWith("session-first");
+
+    getSessionMock.mockReturnValue(undefined);
+    getFinishedSessionMock.mockReturnValue({
+      id: "session-first",
+      scopeKey: "chat:bash",
+      status: "failed",
+    });
+    const restarted = await handleBashChatCommand(buildParams("/bash second"));
+    expect(restarted.text).toContain("session-second");
+    expect(execute).toHaveBeenCalledTimes(2);
+
+    getFinishedSessionMock.mockReturnValue(undefined);
+    await handleBashChatCommand(buildParams("/bash help"));
   });
 
   it("uses the canonical target session for elevated sandbox explanation", async () => {

--- a/src/auto-reply/reply/bash-command.ts
+++ b/src/auto-reply/reply/bash-command.ts
@@ -5,6 +5,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { cancelBackgroundExecSession } from "../../agents/bash-process-control.js";
 import { getFinishedSession, getSession } from "../../agents/bash-process-registry.js";
 import { createExecTool } from "../../agents/bash-tools.js";
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
@@ -37,7 +38,6 @@ type ActiveBashJob =
       sessionId: string;
       startedAt: number;
       command: string;
-      watcherAttached: boolean;
     };
 
 let activeJob: ActiveBashJob | null = null;
@@ -148,29 +148,6 @@ function ensureActiveJobState() {
   return null;
 }
 
-function attachActiveWatcher(sessionId: string) {
-  if (!activeJob || activeJob.state !== "running") {
-    return;
-  }
-  if (activeJob.sessionId !== sessionId) {
-    return;
-  }
-  if (activeJob.watcherAttached) {
-    return;
-  }
-  const { running } = getScopedSession(sessionId);
-  const child = running?.child;
-  if (!child) {
-    return;
-  }
-  activeJob.watcherAttached = true;
-  child.once("close", () => {
-    if (activeJob?.state === "running" && activeJob.sessionId === sessionId) {
-      activeJob = null;
-    }
-  });
-}
-
 function buildUsageReply(): ReplyPayload {
   return {
     text: [
@@ -255,7 +232,6 @@ export async function handleBashChatCommand(params: {
     }
     const { running, finished } = getScopedSession(sessionId);
     if (running) {
-      attachActiveWatcher(sessionId);
       const runtimeSec = Math.max(0, Math.floor((Date.now() - running.startedAt) / 1000));
       const tail = running.tail || "(no output yet)";
       return {
@@ -311,14 +287,11 @@ export async function handleBashChatCommand(params: {
         text: `⚠️ Session ${formatSessionSnippet(sessionId)} is not backgrounded.`,
       };
     }
-    const pid = running.pid ?? running.child?.pid;
-    if (!pid) {
+    if (!cancelBackgroundExecSession(sessionId)) {
       return {
-        text: `⚠️ Unable to stop bash session ${formatSessionSnippet(sessionId)} because no process ID is available. Use !poll ${sessionId} to check whether it exits on its own.`,
+        text: `⚠️ Unable to stop bash session ${formatSessionSnippet(sessionId)} because no active cancellation handle is available. Use !poll ${sessionId} to check whether it is already exiting.`,
       };
     }
-    const { killProcessTree } = await import("../../process/kill-tree.js");
-    killProcessTree(pid);
     return {
       text: `⚙️ bash stopping (session ${formatSessionSnippet(sessionId)}). Use !poll ${sessionId} to confirm exit.`,
     };
@@ -380,9 +353,7 @@ export async function handleBashChatCommand(params: {
         sessionId,
         startedAt: result.details.startedAt,
         command: commandText,
-        watcherAttached: false,
       };
-      attachActiveWatcher(sessionId);
       const snippet = formatSessionSnippet(sessionId);
       logVerbose(`Started bash session ${snippet}: ${commandText}`);
       return {


### PR DESCRIPTION
## What Problem This Solves

Process sessions retained a second raw-child ownership path beside `ProcessSupervisor`. That let process-tool and `/stop` cancellation fall back to direct process handling, duplicating lifecycle policy and making terminal state ownership ambiguous.

## Why This Change Was Made

This deletes all runtime and test ownership of `ProcessSession.child`. Process-tool kill/remove and `/stop` now use the canonical supervisor cancellation handle, while registry cleanup owns only its prepared stdin wrapper and lifecycle owners record terminal state.

The existing optional `child` type member remains solely as a deprecated declaration-closure compatibility shell because the current public Plugin SDK closure still reaches the internal registry interface. Runtime has zero reads, writes, initializers, cleanup, watchers, PID/stdin fallbacks, direct kills, or synthetic exit handling for it. Remove it only when the public Plugin SDK closure no longer reaches internal registry types, or at the next compatible boundary change.

## User Impact

Background exec cancellation has one owner and one visible outcome. This does not change config, protocol, storage, or output-capture behavior. #117080 is untouched. No changelog entry is needed for this internal ownership refactor.

## Evidence

- Base `6dbea69515a9c7059becf1decb1db28e4c1af18e`; head `dcc07325ed34f88472c3d5c49ba414e177a60553`.
- Canonical JSONL rendered independently from clean base and task snapshots is byte-identical; both SHA-256 `b1989863f1bfff28858d96171eda1f2cf3533cf56fb7e764121e66c10f7babc9`.
- `pnpm plugin-sdk:api:check` and `pnpm plugin-sdk:surface:check` pass with no generated baseline diff or commit.
- Eight-file focused run: 8 files, 58 tests passed. Standalone real-process manual-cancel proof: 1 E2E file, 8 tests passed.
- Blacksmith Testbox changed gate passed: `tbx_01kzqgqbjbvbc12tbv4ekst600`, https://github.com/openclaw/openclaw/actions/runs/31458099444.
- Fresh Codex-backed autoreview: clean, no accepted/actionable findings; it explicitly accepted the deprecated declaration-only compatibility contract.
- LOC: production `+35/-113` (net `-78`); tests/test support `+125/-84` (net `+41`); total `+160/-197` (net `-37`).
