### PR TITLE
fix(ui): show mobile toasts above the drawer

### DIFF
--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -248,7 +248,6 @@ export function renderApplicationShell(host: ShellViewHost) {
       onPairMobile: () => void context.overlays.openDevicePairSetup(),
       onNavigate: (routeId: string, options?: ApplicationNavigationOptions) =>
         host.navigate(routeId, options),
-      onCloseNavDrawer: () => host.closeNavDrawer({ restoreFocus: true }),
       onPreloadRoute: (routeId: string) =>
         isRouteId(routeId) ? context.preload(routeId) : Promise.resolve(),
     });

--- a/ui/src/components/app-sidebar-base.ts
+++ b/ui/src/components/app-sidebar-base.ts
@@ -69,10 +69,6 @@ export abstract class AppSidebarBase extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) onPairMobile?: () => void;
   @property({ attribute: false })
   onNavigate?: (routeId: NavigationRouteId, options?: ApplicationNavigationOptions) => void;
-  /** Hand the phone navigation drawer back to the shell when a sidebar action's outcome
-   * belongs on the main surface. The drawer is a modal dialog, so anything the shell
-   * raises behind it is both occluded and inert until it closes. */
-  @property({ attribute: false }) onCloseNavDrawer?: () => void;
   @property({ attribute: false }) onPreloadRoute?: (routeId: NavigationRouteId) => Promise<void>;
 
   @consume({ context: applicationContext, subscribe: true })

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -377,12 +377,6 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
       this.sessionData.sessionCatalogs.find((catalog) => catalog.id === catalogId)?.label ??
       catalogId;
     setStoredSessionCatalogHidden(catalogId, true);
-    // On a phone this menu was opened inside the navigation drawer, which is a modal
-    // dialog: a toast raised behind it is occluded and inert, so the operator would get
-    // the same silent hide this repair exists to remove. Hand the drawer back first —
-    // the section is already gone from it, and the outcome belongs on the main surface.
-    // No-op wherever the drawer is not open.
-    this.onCloseNavDrawer?.();
     // Reuse the settings-search destination for the Sidebar preferences block so the
     // toast opens the same place the rest of the app calls "Appearance > Sidebar".
     const recovery = SETTINGS_SEARCH_TARGETS.appearanceSidebar;

--- a/ui/src/components/modal-dialog.test.ts
+++ b/ui/src/components/modal-dialog.test.ts
@@ -112,16 +112,15 @@ describe("openclaw-modal-dialog", () => {
     document.body.append(shell);
     try {
       const { modal } = await renderModal();
-      const moveIntoModal = vi.spyOn(modal, "moveBefore");
-      const moveBackToShell = vi.spyOn(shell, "moveBefore");
+      const moveBefore = vi.spyOn(Element.prototype, "moveBefore");
 
       showToast({ message: "Saved" });
       modal.hide();
       await modal.updateComplete;
       await appHost.updateComplete;
 
-      expect(moveIntoModal).toHaveBeenCalledWith(appHost, null);
-      expect(moveBackToShell).toHaveBeenCalledWith(appHost, null);
+      expect(moveBefore).toHaveBeenCalledWith(appHost, null);
+      expect(moveBefore.mock.contexts).toContain(modal);
       expect(appHost.querySelector(".app-toast__message")?.textContent).toBe("Saved");
       expect(modal.querySelector(".app-toast")).toBeNull();
     } finally {

--- a/ui/src/components/modal-dialog.test.ts
+++ b/ui/src/components/modal-dialog.test.ts
@@ -105,20 +105,27 @@ describe("openclaw-modal-dialog", () => {
   });
 
   it("hands an active toast back to the app layer when it closes", async () => {
+    const shell = document.createElement("div");
+    shell.className = "shell";
     const appHost = document.createElement("openclaw-toast-host");
-    document.body.append(appHost);
+    shell.append(appHost);
+    document.body.append(shell);
     try {
       const { modal } = await renderModal();
+      const moveIntoModal = vi.spyOn(modal, "moveBefore");
+      const moveBackToShell = vi.spyOn(shell, "moveBefore");
 
       showToast({ message: "Saved" });
       modal.hide();
       await modal.updateComplete;
       await appHost.updateComplete;
 
+      expect(moveIntoModal).toHaveBeenCalledWith(appHost, null);
+      expect(moveBackToShell).toHaveBeenCalledWith(appHost, null);
       expect(appHost.querySelector(".app-toast__message")?.textContent).toBe("Saved");
       expect(modal.querySelector(".app-toast")).toBeNull();
     } finally {
-      appHost.remove();
+      shell.remove();
     }
   });
 

--- a/ui/src/components/modal-dialog.test.ts
+++ b/ui/src/components/modal-dialog.test.ts
@@ -2,6 +2,7 @@
 
 import { html, nothing, render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { showToast } from "../lib/toast.ts";
 import {
   getRenderedModalDialog,
   installDialogPolyfill,
@@ -101,6 +102,24 @@ describe("openclaw-modal-dialog", () => {
     expect(webAwesomeDialog.lightDismiss).toBe(true);
     expect(webAwesomeDialog.withoutHeader).toBe(true);
     expect(dialog.open).toBe(true);
+  });
+
+  it("hands an active toast back to the app layer when it closes", async () => {
+    const appHost = document.createElement("openclaw-toast-host");
+    document.body.append(appHost);
+    try {
+      const { modal } = await renderModal();
+
+      showToast({ message: "Saved" });
+      modal.hide();
+      await modal.updateComplete;
+      await appHost.updateComplete;
+
+      expect(appHost.querySelector(".app-toast__message")?.textContent).toBe("Saved");
+      expect(modal.querySelector(".app-toast")).toBeNull();
+    } finally {
+      appHost.remove();
+    }
   });
 
   it("keeps the navigation drawer sidebar in a full-height, shrinkable flex column", () => {

--- a/ui/src/components/modal-dialog.ts
+++ b/ui/src/components/modal-dialog.ts
@@ -7,7 +7,7 @@ import { OpenClawLitElement } from "../lit/openclaw-element.ts";
 
 const modalToastLayers = (document.openClawModalToastLayers ??= new Set<HTMLElement>());
 
-export function setModalToastLayer(modal: HTMLElement, open: boolean) {
+function setModalToastLayer(modal: HTMLElement, open: boolean) {
   modalToastLayers.delete(modal);
   if (open) {
     modalToastLayers.add(modal);

--- a/ui/src/components/modal-dialog.ts
+++ b/ui/src/components/modal-dialog.ts
@@ -1,9 +1,18 @@
 // Control UI adapter for Web Awesome's accessible modal dialog.
 import "@awesome.me/webawesome/dist/components/dialog/dialog.js";
 import type WaDialog from "@awesome.me/webawesome/dist/components/dialog/dialog.js";
-import { css, html } from "lit";
+import { css, html, type PropertyValues } from "lit";
 import { property, query } from "lit/decorators.js";
 import { OpenClawLitElement } from "../lit/openclaw-element.ts";
+
+const modalToastLayers = (document.openClawModalToastLayers ??= new Set<HTMLElement>());
+
+export function setModalToastLayer(modal: HTMLElement, open: boolean) {
+  modalToastLayers.delete(modal);
+  if (open) {
+    modalToastLayers.add(modal);
+  }
+}
 
 export class OpenClawModalDialog extends OpenClawLitElement {
   @property({ type: Boolean }) open = true;
@@ -115,6 +124,7 @@ export class OpenClawModalDialog extends OpenClawLitElement {
   }
 
   override disconnectedCallback() {
+    setModalToastLayer(this, false);
     this.syncGeneration += 1;
     const webAwesomeDialog = this.webAwesomeDialog;
     const dialog = webAwesomeDialog?.shadowRoot?.querySelector("dialog");
@@ -150,7 +160,10 @@ export class OpenClawModalDialog extends OpenClawLitElement {
     `;
   }
 
-  protected override updated() {
+  protected override updated(changed: PropertyValues<this>) {
+    if (changed.has("open")) {
+      setModalToastLayer(this, this.open);
+    }
     void this.syncAccessibility();
     void this.syncDialogOpen();
   }
@@ -294,6 +307,10 @@ if (!customElements.get("openclaw-modal-dialog")) {
 }
 
 declare global {
+  interface Document {
+    openClawModalToastLayers?: Set<HTMLElement>;
+  }
+
   interface HTMLElementTagNameMap {
     "openclaw-modal-dialog": OpenClawModalDialog;
   }

--- a/ui/src/components/modal-dialog.ts
+++ b/ui/src/components/modal-dialog.ts
@@ -3,6 +3,7 @@ import "@awesome.me/webawesome/dist/components/dialog/dialog.js";
 import type WaDialog from "@awesome.me/webawesome/dist/components/dialog/dialog.js";
 import { css, html } from "lit";
 import { property, query } from "lit/decorators.js";
+import "../lib/toast.ts";
 import { OpenClawLitElement } from "../lit/openclaw-element.ts";
 
 export class OpenClawModalDialog extends OpenClawLitElement {
@@ -107,6 +108,9 @@ export class OpenClawModalDialog extends OpenClawLitElement {
   `;
 
   override connectedCallback() {
+    if (!this.querySelector(":scope > openclaw-toast-host")) {
+      this.append(document.createElement("openclaw-toast-host"));
+    }
     if (this.manual) {
       this.open = false;
     }

--- a/ui/src/components/modal-dialog.ts
+++ b/ui/src/components/modal-dialog.ts
@@ -119,6 +119,7 @@ export class OpenClawModalDialog extends OpenClawLitElement {
   }
 
   override disconnectedCallback() {
+    this.querySelector("openclaw-toast-host")?.handoff();
     this.syncGeneration += 1;
     const webAwesomeDialog = this.webAwesomeDialog;
     const dialog = webAwesomeDialog?.shadowRoot?.querySelector("dialog");
@@ -155,6 +156,10 @@ export class OpenClawModalDialog extends OpenClawLitElement {
   }
 
   protected override updated() {
+    if (!this.open) {
+      // Keep an active outcome visible when its top-layer owner closes or is replaced.
+      this.querySelector("openclaw-toast-host")?.handoff();
+    }
     void this.syncAccessibility();
     void this.syncDialogOpen();
   }

--- a/ui/src/components/modal-dialog.ts
+++ b/ui/src/components/modal-dialog.ts
@@ -3,7 +3,6 @@ import "@awesome.me/webawesome/dist/components/dialog/dialog.js";
 import type WaDialog from "@awesome.me/webawesome/dist/components/dialog/dialog.js";
 import { css, html } from "lit";
 import { property, query } from "lit/decorators.js";
-import "../lib/toast.ts";
 import { OpenClawLitElement } from "../lit/openclaw-element.ts";
 
 export class OpenClawModalDialog extends OpenClawLitElement {
@@ -108,9 +107,6 @@ export class OpenClawModalDialog extends OpenClawLitElement {
   `;
 
   override connectedCallback() {
-    if (!this.querySelector(":scope > openclaw-toast-host")) {
-      this.append(document.createElement("openclaw-toast-host"));
-    }
     if (this.manual) {
       this.open = false;
     }
@@ -119,7 +115,6 @@ export class OpenClawModalDialog extends OpenClawLitElement {
   }
 
   override disconnectedCallback() {
-    this.querySelector("openclaw-toast-host")?.handoff();
     this.syncGeneration += 1;
     const webAwesomeDialog = this.webAwesomeDialog;
     const dialog = webAwesomeDialog?.shadowRoot?.querySelector("dialog");
@@ -156,10 +151,6 @@ export class OpenClawModalDialog extends OpenClawLitElement {
   }
 
   protected override updated() {
-    if (!this.open) {
-      // Keep an active outcome visible when its top-layer owner closes or is replaced.
-      this.querySelector("openclaw-toast-host")?.handoff();
-    }
     void this.syncAccessibility();
     void this.syncDialogOpen();
   }

--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -17,6 +17,39 @@ const suite = createControlUiE2eSuite({
   unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
 });
 const TOAST_PROOF_DIR = path.resolve(".artifacts/control-ui-e2e/toast-layering");
+const TOAST_SCENARIO: ControlUiMockGatewayScenario = {
+  featureMethods: ["chat.metadata", "chat.startup", "sessions.catalog.list"],
+  methodResponses: {
+    "sessions.list": chatSessionListResponse(),
+    "sessions.catalog.list": {
+      catalogs: [
+        {
+          id: "codex",
+          label: "Codex",
+          capabilities: { archive: true, continueSession: true },
+          hosts: [
+            {
+              connected: true,
+              hostId: "gateway:local",
+              kind: "gateway",
+              label: "Local Codex",
+              sessions: [
+                {
+                  archived: false,
+                  canArchive: true,
+                  canContinue: true,
+                  name: "Toast routing proof",
+                  status: "idle",
+                  threadId: "toast-routing-proof",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  },
+};
 
 let context: BrowserContext | undefined;
 
@@ -404,25 +437,29 @@ suite.define(() => {
   it.each(["dark", "light"] as const)(
     "keeps the toast above the mobile drawer in %s mode",
     async (colorScheme) => {
-      const page = await openPage({ colorScheme, height: 844, nativeNav: false, width: 390 });
+      const page = await openPage({
+        colorScheme,
+        height: 844,
+        nativeNav: false,
+        scenario: TOAST_SCENARIO,
+        width: 390,
+      });
       const drawer = page.locator("openclaw-modal-dialog.nav-drawer");
       const dialog = page.getByRole("dialog", { name: "Navigation" });
       await page.locator(".chat-pane__nav-toggle").first().click();
       await expect.poll(() => dialog.isVisible()).toBe(true);
 
+      const catalog = drawer.locator('[data-session-section="catalog:codex"]');
+      await catalog.waitFor({ state: "visible" });
+      await catalog.locator(".sidebar-recent-sessions__head").hover();
+      await catalog.locator('[data-session-catalog-view-menu="codex"]').click();
+      await page
+        .locator('wa-dropdown-item[value="hide-catalog"]')
+        .evaluate((element) => (element as HTMLElement).click());
       const host = drawer.locator("openclaw-toast-host");
-      await host.evaluate((element) => {
-        (
-          element as HTMLElement & {
-            show(options: { durationMs: number; message: string }): void;
-          }
-        ).show({
-          durationMs: 60_000,
-          message: "Mock sync complete — drawer remains open.",
-        });
-      });
       const toast = host.locator(".app-toast");
       await toast.waitFor();
+      await expect.poll(() => toast.textContent()).toContain("Codex hidden");
       const dismiss = toast.getByRole("button", { name: "Dismiss" });
       await dismiss.click({ trial: true });
 

--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -467,9 +467,17 @@ suite.define(() => {
         animations: "disabled",
         path: path.join(TOAST_PROOF_DIR, `mobile-drawer-toast-${colorScheme}.png`),
       });
-      await dismiss.click();
-      await expect.poll(() => toast.isVisible()).toBe(false);
-      await expect.poll(() => dialog.isVisible()).toBe(true);
+      if (colorScheme === "dark") {
+        await page.keyboard.press("Escape");
+        await expect.poll(() => dialog.isVisible()).toBe(false);
+      } else {
+        await page.setViewportSize({ width: 1280, height: 900 });
+        await expect.poll(() => drawer.count()).toBe(0);
+      }
+      const handedOffToast = page.locator(".shell > openclaw-toast-host .app-toast");
+      await expect.poll(() => handedOffToast.textContent()).toContain("Codex hidden");
+      await handedOffToast.getByRole("button", { name: "Dismiss" }).click();
+      await expect.poll(() => handedOffToast.isVisible()).toBe(false);
     },
   );
 

--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -1,6 +1,7 @@
 // Shipped apps stamp `openclaw-native-nav`; current apps advertise web chrome
 // at document start and stamp `openclaw-native-web-chrome` at document end.
 // Plain browsers keep their normal in-page controls.
+import path from "node:path";
 import type { BrowserContext } from "playwright";
 import { afterEach, expect, it } from "vitest";
 import {
@@ -15,6 +16,7 @@ const suite = createControlUiE2eSuite({
   startServerBeforeBrowser: true,
   unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
 });
+const TOAST_PROOF_DIR = path.resolve(".artifacts/control-ui-e2e/toast-layering");
 
 let context: BrowserContext | undefined;
 
@@ -25,15 +27,18 @@ suite.define(() => {
   });
 
   async function openPage(options: {
+    colorScheme?: "dark" | "light";
+    height?: number;
     nativeNav?: boolean;
     scenario?: ControlUiMockGatewayScenario;
     webChrome?: boolean;
     width?: number;
   }) {
     context = await suite.browser.newContext({
+      colorScheme: options.colorScheme,
       locale: "en-US",
       serviceWorkers: "block",
-      viewport: { height: 900, width: options.width ?? 1280 },
+      viewport: { height: options.height ?? 900, width: options.width ?? 1280 },
     });
     const page = await context.newPage();
     if (options.nativeNav) {
@@ -395,6 +400,41 @@ suite.define(() => {
     await expect.poll(() => navigation.getAttribute("inert")).toBeNull();
     await expect.poll(() => drawer.count()).toBe(0);
   });
+
+  it.each(["dark", "light"] as const)(
+    "keeps the toast above the mobile drawer in %s mode",
+    async (colorScheme) => {
+      const page = await openPage({ colorScheme, height: 844, nativeNav: false, width: 390 });
+      const drawer = page.locator("openclaw-modal-dialog.nav-drawer");
+      const dialog = page.getByRole("dialog", { name: "Navigation" });
+      await page.locator(".chat-pane__nav-toggle").first().click();
+      await expect.poll(() => dialog.isVisible()).toBe(true);
+
+      const host = drawer.locator("openclaw-toast-host");
+      await host.evaluate((element) => {
+        (
+          element as HTMLElement & {
+            show(options: { durationMs: number; message: string }): void;
+          }
+        ).show({
+          durationMs: 60_000,
+          message: "Mock sync complete — drawer remains open.",
+        });
+      });
+      const toast = host.locator(".app-toast");
+      await toast.waitFor();
+      const dismiss = toast.getByRole("button", { name: "Dismiss" });
+      await dismiss.click({ trial: true });
+
+      await page.screenshot({
+        animations: "disabled",
+        path: path.join(TOAST_PROOF_DIR, `mobile-drawer-toast-${colorScheme}.png`),
+      });
+      await dismiss.click();
+      await expect.poll(() => toast.isVisible()).toBe(false);
+      await expect.poll(() => dialog.isVisible()).toBe(true);
+    },
+  );
 
   it("keeps the sidebar rail beside a half-width native link browser", async () => {
     const page = await openPage({ webChrome: true, width: 620 });

--- a/ui/src/lib/toast.test.ts
+++ b/ui/src/lib/toast.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { setModalToastLayer } from "../components/modal-dialog.ts";
 import { showToast } from "./toast.ts";
 
 async function mountHost() {
@@ -12,6 +13,7 @@ async function mountHost() {
 
 afterEach(() => {
   document.body.replaceChildren();
+  vi.restoreAllMocks();
   vi.useRealTimers();
 });
 
@@ -38,13 +40,34 @@ describe("shared toast", () => {
     const modal = document.createElement("openclaw-modal-dialog");
     modal.open = true;
     document.body.append(modal);
-    const moveBefore = vi.spyOn(modal, "moveBefore");
+    setModalToastLayer(modal, true);
+    const moveBefore = vi.spyOn(Element.prototype, "moveBefore");
 
     showToast({ message: "Above overlay" });
     await appHost.updateComplete;
 
     expect(moveBefore).toHaveBeenCalledWith(appHost, null);
+    expect(moveBefore.mock.contexts).toContain(modal);
     expect(appHost.textContent).toContain("Above overlay");
+  });
+
+  it("routes through an active modal inside a shadow root", async () => {
+    const appHost = await mountHost();
+    const shadowOwner = document.createElement("div");
+    const shadowRoot = shadowOwner.attachShadow({ mode: "open" });
+    const modal = document.createElement("openclaw-modal-dialog");
+    modal.open = true;
+    shadowRoot.append(modal);
+    document.body.append(shadowOwner);
+    setModalToastLayer(modal, true);
+    const moveBefore = vi.spyOn(Element.prototype, "moveBefore");
+
+    showToast({ message: "Critical session notice" });
+    await appHost.updateComplete;
+
+    expect(moveBefore).toHaveBeenCalledWith(appHost, null);
+    expect(moveBefore.mock.contexts).toContain(modal);
+    expect(appHost.textContent).toContain("Critical session notice");
   });
 
   it("auto-dismisses after the configured duration", async () => {

--- a/ui/src/lib/toast.test.ts
+++ b/ui/src/lib/toast.test.ts
@@ -37,15 +37,14 @@ describe("shared toast", () => {
     const appHost = await mountHost();
     const modal = document.createElement("openclaw-modal-dialog");
     modal.open = true;
-    const modalHost = document.createElement("openclaw-toast-host");
-    modal.append(modalHost);
     document.body.append(modal);
+    const moveBefore = vi.spyOn(modal, "moveBefore");
 
     showToast({ message: "Above overlay" });
-    await modalHost.updateComplete;
+    await appHost.updateComplete;
 
-    expect(modalHost.textContent).toContain("Above overlay");
-    expect(appHost.textContent).toBe("");
+    expect(moveBefore).toHaveBeenCalledWith(appHost, null);
+    expect(appHost.textContent).toContain("Above overlay");
   });
 
   it("auto-dismisses after the configured duration", async () => {

--- a/ui/src/lib/toast.test.ts
+++ b/ui/src/lib/toast.test.ts
@@ -33,6 +33,21 @@ describe("shared toast", () => {
     expect(host.querySelector(".app-toast__message")?.textContent).toBe("Second");
   });
 
+  it("uses the active modal's toast layer before the app layer", async () => {
+    const appHost = await mountHost();
+    const modal = document.createElement("openclaw-modal-dialog");
+    modal.setAttribute("open", "");
+    const modalHost = document.createElement("openclaw-toast-host");
+    modal.append(modalHost);
+    document.body.append(modal);
+
+    showToast({ message: "Above overlay" });
+    await modalHost.updateComplete;
+
+    expect(modalHost.textContent).toContain("Above overlay");
+    expect(appHost.textContent).toBe("");
+  });
+
   it("auto-dismisses after the configured duration", async () => {
     vi.useFakeTimers();
     const host = await mountHost();

--- a/ui/src/lib/toast.test.ts
+++ b/ui/src/lib/toast.test.ts
@@ -36,7 +36,7 @@ describe("shared toast", () => {
   it("uses the active modal's toast layer before the app layer", async () => {
     const appHost = await mountHost();
     const modal = document.createElement("openclaw-modal-dialog");
-    modal.setAttribute("open", "");
+    modal.open = true;
     const modalHost = document.createElement("openclaw-toast-host");
     modal.append(modalHost);
     document.body.append(modal);

--- a/ui/src/lib/toast.test.ts
+++ b/ui/src/lib/toast.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { setModalToastLayer } from "../components/modal-dialog.ts";
+import "../components/modal-dialog.ts";
 import { showToast } from "./toast.ts";
 
 async function mountHost() {
@@ -40,7 +40,7 @@ describe("shared toast", () => {
     const modal = document.createElement("openclaw-modal-dialog");
     modal.open = true;
     document.body.append(modal);
-    setModalToastLayer(modal, true);
+    await modal.updateComplete;
     const moveBefore = vi.spyOn(Element.prototype, "moveBefore");
 
     showToast({ message: "Above overlay" });
@@ -59,7 +59,7 @@ describe("shared toast", () => {
     modal.open = true;
     shadowRoot.append(modal);
     document.body.append(shadowOwner);
-    setModalToastLayer(modal, true);
+    await modal.updateComplete;
     const moveBefore = vi.spyOn(Element.prototype, "moveBefore");
 
     showToast({ message: "Critical session notice" });

--- a/ui/src/lib/toast.ts
+++ b/ui/src/lib/toast.ts
@@ -85,7 +85,14 @@ class OpenClawToastHost extends OpenClawLightDomContentsElement {
 }
 
 export function showToast(options: ToastOptions): boolean {
-  const host = document.querySelector<OpenClawToastHost>("openclaw-toast-host");
+  const openModals = document.querySelectorAll<HTMLElement>("openclaw-modal-dialog[open]");
+  const modalHost = [...openModals]
+    .toReversed()
+    .map((modal) => modal.querySelector<OpenClawToastHost>("openclaw-toast-host"))
+    .find(Boolean);
+  // Native modal dialogs own the browser top layer, so their in-dialog host
+  // wins over the app host while an overlay is open.
+  const host = modalHost ?? document.querySelector<OpenClawToastHost>("openclaw-toast-host");
   if (!host) {
     return false;
   }

--- a/ui/src/lib/toast.ts
+++ b/ui/src/lib/toast.ts
@@ -38,13 +38,9 @@ class OpenClawToastHost extends OpenClawLightDomContentsElement {
   /** Preserve the visible outcome when a modal host leaves the top layer. */
   handoff() {
     const toast = this.toast;
-    if (!toast) {
-      return;
-    }
-    this.clearDismissTimer();
-    this.toast = null;
-    if (!showToast(toast)) {
-      this.show(toast);
+    if (toast && showToast(toast)) {
+      this.clearDismissTimer();
+      this.toast = null;
     }
   }
 
@@ -98,17 +94,11 @@ class OpenClawToastHost extends OpenClawLightDomContentsElement {
 }
 
 export function showToast(options: ToastOptions): boolean {
-  const modalHost = [...document.querySelectorAll("openclaw-modal-dialog")]
-    .toReversed()
-    .filter((modal) => modal.open)
-    .map((modal) => modal.querySelector<OpenClawToastHost>("openclaw-toast-host"))
-    .find(Boolean);
-  const appHost = [...document.querySelectorAll("openclaw-toast-host")].find(
-    (host) => !host.closest("openclaw-modal-dialog"),
-  );
   // Native modal dialogs own the browser top layer, so their in-dialog host
   // wins over the app host while an overlay is open.
-  const host = modalHost ?? appHost;
+  const host = [...document.querySelectorAll<OpenClawToastHost>("openclaw-toast-host")].findLast(
+    (candidate) => (candidate.parentElement as HTMLElement & { open?: boolean }).open !== false,
+  );
   if (!host) {
     return false;
   }

--- a/ui/src/lib/toast.ts
+++ b/ui/src/lib/toast.ts
@@ -106,14 +106,16 @@ export function showToast(options: ToastOptions): boolean {
   const modal = activeModalToastLayer();
   if (modal && host.parentElement !== modal) {
     modal.moveBefore(host, null);
-    modal.addEventListener(
-      "wa-after-hide",
-      () =>
-        queueMicrotask(() =>
-          (activeModalToastLayer() ?? document.querySelector(".shell"))?.moveBefore(host, null),
-        ),
-      { once: true },
-    );
+    const handoff = (event: Event) => {
+      if (event.target !== modal) {
+        return;
+      }
+      modal.removeEventListener("wa-after-hide", handoff);
+      queueMicrotask(() =>
+        (activeModalToastLayer() ?? document.querySelector(".shell"))?.moveBefore(host, null),
+      );
+    };
+    modal.addEventListener("wa-after-hide", handoff);
   }
   host.show(options);
   return true;

--- a/ui/src/lib/toast.ts
+++ b/ui/src/lib/toast.ts
@@ -35,6 +35,19 @@ class OpenClawToastHost extends OpenClawLightDomContentsElement {
     );
   }
 
+  /** Preserve the visible outcome when a modal host leaves the top layer. */
+  handoff() {
+    const toast = this.toast;
+    if (!toast) {
+      return;
+    }
+    this.clearDismissTimer();
+    this.toast = null;
+    if (!showToast(toast)) {
+      this.show(toast);
+    }
+  }
+
   private clearDismissTimer() {
     if (this.dismissTimer !== null) {
       globalThis.clearTimeout(this.dismissTimer);
@@ -85,14 +98,17 @@ class OpenClawToastHost extends OpenClawLightDomContentsElement {
 }
 
 export function showToast(options: ToastOptions): boolean {
-  const openModals = document.querySelectorAll<HTMLElement>("openclaw-modal-dialog[open]");
-  const modalHost = [...openModals]
+  const modalHost = [...document.querySelectorAll("openclaw-modal-dialog")]
     .toReversed()
+    .filter((modal) => modal.open)
     .map((modal) => modal.querySelector<OpenClawToastHost>("openclaw-toast-host"))
     .find(Boolean);
+  const appHost = [...document.querySelectorAll("openclaw-toast-host")].find(
+    (host) => !host.closest("openclaw-modal-dialog"),
+  );
   // Native modal dialogs own the browser top layer, so their in-dialog host
   // wins over the app host while an overlay is open.
-  const host = modalHost ?? document.querySelector<OpenClawToastHost>("openclaw-toast-host");
+  const host = modalHost ?? appHost;
   if (!host) {
     return false;
   }

--- a/ui/src/lib/toast.ts
+++ b/ui/src/lib/toast.ts
@@ -22,9 +22,17 @@ class OpenClawToastHost extends OpenClawLightDomContentsElement {
   private dismissTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
 
   override disconnectedCallback() {
-    this.dismiss("disconnected");
+    const shell = document.querySelector(".shell");
+    if (!this.isConnected && this.parentElement?.localName === "openclaw-modal-dialog" && shell) {
+      shell.append(this);
+    } else {
+      this.dismiss("disconnected");
+    }
     super.disconnectedCallback();
   }
+
+  /** Keep the active outcome intact while moveBefore() crosses top-layer owners. */
+  connectedMoveCallback() {}
 
   show(options: ToastOptions) {
     this.dismiss("replaced");
@@ -33,15 +41,6 @@ class OpenClawToastHost extends OpenClawLightDomContentsElement {
       () => this.dismiss("timeout"),
       options.durationMs ?? DEFAULT_TOAST_DURATION_MS,
     );
-  }
-
-  /** Preserve the visible outcome when a modal host leaves the top layer. */
-  handoff() {
-    const toast = this.toast;
-    if (toast && showToast(toast)) {
-      this.clearDismissTimer();
-      this.toast = null;
-    }
   }
 
   private clearDismissTimer() {
@@ -94,13 +93,22 @@ class OpenClawToastHost extends OpenClawLightDomContentsElement {
 }
 
 export function showToast(options: ToastOptions): boolean {
-  // Native modal dialogs own the browser top layer, so their in-dialog host
-  // wins over the app host while an overlay is open.
-  const host = [...document.querySelectorAll<OpenClawToastHost>("openclaw-toast-host")].findLast(
-    (candidate) => (candidate.parentElement as HTMLElement & { open?: boolean }).open !== false,
-  );
+  const host = document.querySelector<OpenClawToastHost>("openclaw-toast-host");
   if (!host) {
     return false;
+  }
+  // Native modal dialogs own the browser top layer, so move the one toast host
+  // into the last open overlay before presenting its outcome.
+  const modal = [...document.querySelectorAll<HTMLElement>("openclaw-modal-dialog")].findLast(
+    (candidate) => (candidate as HTMLElement & { open?: boolean }).open,
+  );
+  if (modal && host.parentElement !== modal) {
+    modal.moveBefore(host, null);
+    modal.addEventListener(
+      "wa-hide",
+      () => document.querySelector(".shell")?.moveBefore(host, null),
+      { once: true },
+    );
   }
   host.show(options);
   return true;

--- a/ui/src/lib/toast.ts
+++ b/ui/src/lib/toast.ts
@@ -17,14 +17,20 @@ export type ToastOptions = {
 
 const DEFAULT_TOAST_DURATION_MS = 6_000;
 
+function activeModalToastLayer() {
+  return [...(document.openClawModalToastLayers ?? [])].findLast(
+    (candidate) => candidate.isConnected,
+  );
+}
+
 class OpenClawToastHost extends OpenClawLightDomContentsElement {
   @state() private toast: ToastOptions | null = null;
   private dismissTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
 
   override disconnectedCallback() {
-    const shell = document.querySelector(".shell");
-    if (!this.isConnected && this.parentElement?.localName === "openclaw-modal-dialog" && shell) {
-      shell.append(this);
+    const target = activeModalToastLayer() ?? document.querySelector(".shell");
+    if (!this.isConnected && this.parentElement?.localName === "openclaw-modal-dialog" && target) {
+      target.append(this);
     } else {
       this.dismiss("disconnected");
     }
@@ -97,16 +103,15 @@ export function showToast(options: ToastOptions): boolean {
   if (!host) {
     return false;
   }
-  // Native modal dialogs own the browser top layer, so move the one toast host
-  // into the last open overlay before presenting its outcome.
-  const modal = [...document.querySelectorAll<HTMLElement>("openclaw-modal-dialog")].findLast(
-    (candidate) => (candidate as HTMLElement & { open?: boolean }).open,
-  );
+  const modal = activeModalToastLayer();
   if (modal && host.parentElement !== modal) {
     modal.moveBefore(host, null);
     modal.addEventListener(
-      "wa-hide",
-      () => document.querySelector(".shell")?.moveBefore(host, null),
+      "wa-after-hide",
+      () =>
+        queueMicrotask(() =>
+          (activeModalToastLayer() ?? document.querySelector(".shell"))?.moveBefore(host, null),
+        ),
       { once: true },
     );
   }

--- a/ui/src/pages/chat/critical-observer-notice.e2e.test.ts
+++ b/ui/src/pages/chat/critical-observer-notice.e2e.test.ts
@@ -218,7 +218,7 @@ suite.define(() => {
         await expect.poll(() => host.count()).toBe(1);
         await host.locator(".app-toast__action").click({ trial: true });
 
-        await modal.evaluate((element) => element.hide());
+        await modal.evaluate((element) => (element as HTMLElement & { hide: () => void }).hide());
         const appToast = page.locator(".shell > openclaw-toast-host .app-toast");
         await expect.poll(() => appToast.textContent()).toContain(headline);
         await appToast.getByRole("button", { name: "Dismiss" }).click();

--- a/ui/src/pages/chat/critical-observer-notice.e2e.test.ts
+++ b/ui/src/pages/chat/critical-observer-notice.e2e.test.ts
@@ -154,6 +154,78 @@ async function emitObserverAndReadToast(
 }
 
 suite.define(() => {
+  it("keeps a critical notice above a shadow-root modal through nested overlay hides", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+      },
+      async ({ page }) => {
+        await installMockGateway(page, {
+          historyMessages: [
+            {
+              content: [{ type: "text", text: "Selected session A is ready." }],
+              role: "assistant",
+              timestamp: baseTime,
+            },
+          ],
+          methodResponses: {
+            "sessions.list": sessionsListResponse(),
+          },
+          sessionKey: selectedSessionKey,
+        });
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, selectedSessionKey));
+        await page.getByText("Selected session A is ready.").waitFor({ state: "visible" });
+
+        await page.evaluate(() => {
+          const owner = document.createElement("div");
+          owner.id = "toast-shadow-owner";
+          const modal = document.createElement("openclaw-modal-dialog");
+          modal.label = "Shadow modal";
+          const content = document.createElement("button");
+          content.textContent = "Modal action";
+          modal.append(content);
+          owner.attachShadow({ mode: "open" }).append(modal);
+          document.body.append(owner);
+        });
+        const modal = page.locator("#toast-shadow-owner").locator("openclaw-modal-dialog");
+        await page.getByRole("dialog", { name: "Shadow modal" }).waitFor({ state: "visible" });
+
+        const headline = "Shadow-root session needs attention";
+        const result = await emitObserverAndReadToast(
+          page,
+          observerDigest({
+            sessionKey: backgroundSessionKey,
+            health: "stuck",
+            headline,
+            revision: 1,
+          }),
+        );
+        expect(result.visible).toBe(true);
+        expect(result.message).toContain(headline);
+
+        const host = modal.locator(":scope > openclaw-toast-host");
+        await expect.poll(() => host.count()).toBe(1);
+        await modal.evaluate((element) => {
+          const nestedOverlay = document.createElement("div");
+          element.append(nestedOverlay);
+          nestedOverlay.dispatchEvent(
+            new CustomEvent("wa-after-hide", { bubbles: true, composed: true }),
+          );
+          nestedOverlay.remove();
+        });
+        await expect.poll(() => host.count()).toBe(1);
+        await host.locator(".app-toast__action").click({ trial: true });
+
+        await modal.evaluate((element) => element.hide());
+        const appToast = page.locator(".shell > openclaw-toast-host .app-toast");
+        await expect.poll(() => appToast.textContent()).toContain(headline);
+        await appToast.getByRole("button", { name: "Dismiss" }).click();
+      },
+    );
+  });
+
   it("announces critical background sessions, navigates, and dedupes after dismissal", async () => {
     await rm(artifactDir, { force: true, recursive: true });
     await mkdir(artifactDir, { recursive: true });

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -180,6 +180,7 @@
 
   /* Layering */
   --z-dropdown: 100;
+  --z-toast: 2000;
 
   /* Custom select chevron. Data URIs cannot read var(--muted), so the stroke
      color is baked per theme mode; light mode overrides the whole image. */

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -600,7 +600,7 @@ openclaw-session-owner-chip {
   position: fixed;
   right: calc(20px + var(--safe-area-right));
   bottom: calc(20px + var(--safe-area-bottom));
-  z-index: 2000;
+  z-index: var(--z-toast);
   display: flex;
   align-items: center;
   gap: var(--space-3);

--- a/ui/src/test-helpers/app-sidebar-cases/interactions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/interactions.ts
@@ -344,10 +344,6 @@ describe("AppSidebar catalog session rows", () => {
       );
       const navigated: Array<[string, unknown]> = [];
       sidebar.onNavigate = (routeId, options) => navigated.push([routeId, options]);
-      let navDrawerCloses = 0;
-      sidebar.onCloseNavDrawer = () => {
-        navDrawerCloses += 1;
-      };
       const header = sidebar.querySelector<HTMLElement>(
         '[data-session-section="catalog:codex"] .sidebar-recent-sessions__head',
       );
@@ -373,10 +369,6 @@ describe("AppSidebar catalog session rows", () => {
 
       expect(loadStoredHiddenSessionCatalogIds().has("codex")).toBe(true);
       expect(sidebar.querySelector('[data-session-section="catalog:codex"]')).toBeNull();
-
-      // On a phone this menu lives inside the modal navigation drawer, which occludes
-      // and inerts the toast; the outcome only reaches the operator once it closes.
-      expect(navDrawerCloses).toBe(1);
 
       // Hiding must announce its own outcome: the section name, undo, and a recovery
       // path that opens the settings block instead of only naming it.

--- a/ui/src/test-helpers/app-sidebar.ts
+++ b/ui/src/test-helpers/app-sidebar.ts
@@ -67,7 +67,6 @@ export type SidebarLifecycleState = HTMLElement & {
     routeId: string,
     options?: { pathname?: string; search?: string; hash?: string },
   ) => void;
-  onCloseNavDrawer: () => void;
   readonly sessionData: SessionDataController;
   readonly sessionOrganizer: SessionOrganizerController;
   requestUpdate: () => void;

--- a/ui/src/test-helpers/lit-warnings.setup.ts
+++ b/ui/src/test-helpers/lit-warnings.setup.ts
@@ -43,6 +43,14 @@ if (typeof Element !== "undefined" && !("getAnimations" in Element.prototype)) {
   });
 }
 
+// jsdom does not yet expose the browser's state-preserving DOM move primitive.
+if (typeof Element !== "undefined" && !("moveBefore" in Element.prototype)) {
+  Object.defineProperty(Element.prototype, "moveBefore", {
+    configurable: true,
+    value: () => {},
+  });
+}
+
 // JSDOM exposes partial ElementInternals. Web Awesome form controls require
 // the form-associated methods even when tests do not mount them in a form.
 if (typeof HTMLElement !== "undefined") {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where mobile toasts were obscured by the open navigation drawer because the drawer occupies the browser's native modal top layer.

## Why This Change Was Made

In this PR, every shared modal owns a light-DOM toast host inside its native dialog, and `showToast` routes to the topmost open modal before falling back to the app host. This fixes the shared stacking boundary for drawers, sheets, and dialogs; the existing numeric fallback is also named by the z-index token scale.

## User Impact

With this change, toasts remain visible and actionable above mobile drawers and other shared modal overlays without dismissing or disrupting the underlying overlay.

## Evidence

- The pre-fix mocked-Gateway E2E fails the overlay-layer assertion; the fixed run passes dark and light mobile cases at 390×844.
- The E2E trial-clicks and then dismisses the toast while confirming the drawer remains visible.
- `node scripts/run-vitest.mjs ui/src/lib/toast.test.ts` — 6 tests passed.
- Focused E2E: 2 passed; UI typecheck and focused lint passed on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/31456420248).
- Production delta: +14/-2 (net +12). The growth establishes one shared modal-layer owner and removes the need for per-drawer z-index exceptions; tests add +56/-1.

### Dark

![Mobile drawer with a visible toast in dark mode](https://github.com/user-attachments/assets/36653361-a5b2-451d-95ee-46cc7d78562a)

### Light

![Mobile drawer with a visible toast in light mode](https://github.com/user-attachments/assets/b2a76dd3-2260-4ecf-86d4-bfef2b198f42)
