### PR TITLE
refactor: consolidate promise-like guards

### DIFF
--- a/packages/normalization-core/package.json
+++ b/packages/normalization-core/package.json
@@ -54,6 +54,11 @@
       "import": "./dist/phone-presentation.mjs",
       "default": "./dist/phone-presentation.mjs"
     },
+    "./promise-like": {
+      "types": "./dist/promise-like.d.mts",
+      "import": "./dist/promise-like.mjs",
+      "default": "./dist/promise-like.mjs"
+    },
     "./record-coerce": {
       "types": "./dist/record-coerce.d.mts",
       "import": "./dist/record-coerce.mjs",
@@ -91,7 +96,7 @@
     }
   },
   "scripts": {
-    "build": "tsdown src/index.ts src/agent-id.ts src/boolean-coercion.ts src/cjk-chars.ts src/error-coercion.ts src/expect.ts src/json-schema.ts src/number-coercion.ts src/phone-presentation.ts src/record-coerce.ts src/result.ts src/stable-node-path.ts src/stable-stringify.ts src/string-coerce.ts src/string-normalization.ts src/utf16-slice.ts --no-config --platform node --format esm --dts --out-dir dist --clean"
+    "build": "tsdown src/index.ts src/agent-id.ts src/boolean-coercion.ts src/cjk-chars.ts src/error-coercion.ts src/expect.ts src/json-schema.ts src/number-coercion.ts src/phone-presentation.ts src/promise-like.ts src/record-coerce.ts src/result.ts src/stable-node-path.ts src/stable-stringify.ts src/string-coerce.ts src/string-normalization.ts src/utf16-slice.ts --no-config --platform node --format esm --dts --out-dir dist --clean"
   },
   "dependencies": {
     "libphonenumber-js": "1.13.9",

--- a/packages/normalization-core/src/promise-like.test.ts
+++ b/packages/normalization-core/src/promise-like.test.ts
@@ -18,6 +18,7 @@ describe("isPromiseLike", () => {
 });
 
 it("classifies objects with throwing then getters as non-thenable", () => {
+  // oxlint-disable-next-line unicorn/no-thenable -- intentionally hostile thenable fixture
   const hostile = Object.defineProperty({}, "then", {
     get() {
       throw new Error("trap");

--- a/packages/normalization-core/src/promise-like.test.ts
+++ b/packages/normalization-core/src/promise-like.test.ts
@@ -16,3 +16,12 @@ describe("isPromiseLike", () => {
     expect(isPromiseLike(null)).toBe(false);
   });
 });
+
+it("classifies objects with throwing then getters as non-thenable", () => {
+  const hostile = Object.defineProperty({}, "then", {
+    get() {
+      throw new Error("trap");
+    },
+  });
+  expect(isPromiseLike(hostile)).toBe(false);
+});

--- a/packages/normalization-core/src/promise-like.test.ts
+++ b/packages/normalization-core/src/promise-like.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { isPromiseLike } from "./promise-like.js";
+
+describe("isPromiseLike", () => {
+  it("accepts thenables and rejects values without a callable then", () => {
+    const thenable = {};
+    // oxlint-disable-next-line unicorn/no-thenable -- An explicit thenable is the contract under test.
+    Reflect.defineProperty(thenable, "then", { value: () => {} });
+    const nonCallableThen = {};
+    // oxlint-disable-next-line unicorn/no-thenable -- The guard must reject a non-callable then field.
+    Reflect.defineProperty(nonCallableThen, "then", { value: true });
+
+    expect(isPromiseLike(Promise.resolve())).toBe(true);
+    expect(isPromiseLike(thenable)).toBe(true);
+    expect(isPromiseLike(nonCallableThen)).toBe(false);
+    expect(isPromiseLike(null)).toBe(false);
+  });
+});

--- a/packages/normalization-core/src/promise-like.ts
+++ b/packages/normalization-core/src/promise-like.ts
@@ -1,4 +1,13 @@
 /** Canonical thenable guard; use instead of local isPromiseLike copies. */
 export function isPromiseLike<T = unknown>(value: unknown): value is PromiseLike<T> {
-  return typeof (value as { then?: unknown } | null | undefined)?.then === "function";
+  if (value === null || (typeof value !== "object" && typeof value !== "function")) {
+    return false;
+  }
+  // A hostile/exotic object can throw from its `then` getter; a guard must
+  // classify, never throw (diagnostics streams rely on this).
+  try {
+    return typeof (value as { then?: unknown }).then === "function";
+  } catch {
+    return false;
+  }
 }

--- a/packages/normalization-core/src/promise-like.ts
+++ b/packages/normalization-core/src/promise-like.ts
@@ -1,0 +1,4 @@
+/** Canonical thenable guard; use instead of local isPromiseLike copies. */
+export function isPromiseLike<T = unknown>(value: unknown): value is PromiseLike<T> {
+  return typeof (value as { then?: unknown } | null | undefined)?.then === "function";
+}

--- a/src/agents/agent-tools.ring-zero-context.ts
+++ b/src/agents/agent-tools.ring-zero-context.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import type { AnyAgentTool } from "./tools/common.js";
 
 type AgentRingZeroToolScope = {
@@ -7,13 +8,6 @@ type AgentRingZeroToolScope = {
 };
 
 const activeRingZeroTools = new AsyncLocalStorage<AgentRingZeroToolScope>();
-
-function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
-  if ((typeof value !== "object" || value === null) && typeof value !== "function") {
-    return false;
-  }
-  return "then" in value && typeof value.then === "function";
-}
 
 class HostScopedAgentToolAuthorizationError extends Error {
   readonly status = 403;

--- a/src/agents/cron-creator-authority-context.ts
+++ b/src/agents/cron-creator-authority-context.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import {
   createCronCreatorAuthorityRunScope,
   mintCronCreatorAuthorityGrant,
@@ -20,13 +21,6 @@ type CronCreatorAuthorityResolverScope = {
 const activeCronCreatorAuthority = new AsyncLocalStorage<CronCreatorAuthorityRunScope>();
 const activeCronCreatorAuthorityResolver =
   new AsyncLocalStorage<CronCreatorAuthorityResolverScope>();
-
-function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
-  if ((typeof value !== "object" || value === null) && typeof value !== "function") {
-    return false;
-  }
-  return "then" in value && typeof value.then === "function";
-}
 
 /** Keeps fresh cron reauthorization within one admitted Gateway agent run. */
 export function runWithCronCreatorAuthority<T>(

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -1,3 +1,4 @@
+import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 /**
@@ -415,17 +416,6 @@ function modelCallSizeTimingFields(state: ModelCallObservationState): ModelCallS
       ? { timeToFirstByteMs: state.timeToFirstByteMs }
       : {}),
   };
-}
-
-function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
-  if (value === null || (typeof value !== "object" && typeof value !== "function")) {
-    return false;
-  }
-  try {
-    return typeof (value as { then?: unknown }).then === "function";
-  } catch {
-    return false;
-  }
 }
 
 function asyncIteratorFactory(value: unknown): (() => AsyncIterator<unknown>) | undefined {

--- a/src/agents/embedded-agent-subscribe.callback.ts
+++ b/src/agents/embedded-agent-subscribe.callback.ts
@@ -1,4 +1,4 @@
-import { isPromiseLike } from "./embedded-agent-subscribe.promise.js";
+import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 
 type CallbackLogger = {
   warn(message: string): void;
@@ -12,7 +12,7 @@ export function runBestEffortCallback(params: {
 }): void {
   try {
     const result = params.callback();
-    if (isPromiseLike<unknown>(result)) {
+    if (isPromiseLike(result)) {
       void Promise.resolve(result).catch((error: unknown) => {
         params.log.warn(`${params.label} callback failed: ${String(error)}`);
       });

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -1,6 +1,7 @@
 /**
  * Handles lifecycle and compaction events from subscribed embedded-agent sessions.
  */
+import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import { createInlineCodeState } from "../../packages/markdown-core/src/code-spans.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { hasAcceptedSessionSpawn } from "./accepted-session-spawn.js";
@@ -26,7 +27,6 @@ import {
   hasAssistantVisibleReply,
 } from "./embedded-agent-subscribe.handlers.messages.js";
 import type { EmbeddedAgentSubscribeContext } from "./embedded-agent-subscribe.handlers.types.js";
-import { isPromiseLike } from "./embedded-agent-subscribe.promise.js";
 import { isAssistantMessage } from "./embedded-agent-utils.js";
 import type { AgentSessionEvent } from "./sessions/index.js";
 import { summarizeToolValidationError } from "./tool-error-summary.js";

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -1,3 +1,4 @@
+import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 /**
  * Handles embedded-agent assistant message events, block replies, reasoning
  * streams, reply directives, and pending tool media attachment handoff.
@@ -34,7 +35,6 @@ import type {
   EmbeddedAgentSubscribeContext,
   EmbeddedAgentSubscribeState,
 } from "./embedded-agent-subscribe.handlers.types.js";
-import { isPromiseLike } from "./embedded-agent-subscribe.promise.js";
 import { appendRawStream } from "./embedded-agent-subscribe.raw-stream.js";
 import { warnIfAssistantEmittedSuspiciousText } from "./embedded-agent-subscribe.tool-text-diagnostics.js";
 import {

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -1,3 +1,4 @@
+import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 /**
  * Handles embedded-agent tool execution events and turns them into channel UI,
  * replay state, hook calls, approval prompts, media queues, and agent-event
@@ -69,7 +70,6 @@ import type {
   ToolCallSummary,
   ToolHandlerContext,
 } from "./embedded-agent-subscribe.handlers.types.js";
-import { isPromiseLike } from "./embedded-agent-subscribe.promise.js";
 import {
   collectMessagingMediaUrlsFromRecord,
   collectMessagingMediaUrlsFromToolResult,

--- a/src/agents/embedded-agent-subscribe.handlers.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.ts
@@ -1,6 +1,7 @@
 /**
  * Dispatches serialized embedded-agent subscription events to specific handlers.
  */
+import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import {
   handleAgentEnd,
   handleAgentStart,
@@ -24,7 +25,6 @@ import type {
   EmbeddedAgentSubscribeContext,
   EmbeddedAgentSubscribeEvent,
 } from "./embedded-agent-subscribe.handlers.types.js";
-import { isPromiseLike } from "./embedded-agent-subscribe.promise.js";
 import type { AgentMessage } from "./runtime/index.js";
 
 /** Create the serialized event dispatcher for subscribed embedded-agent sessions. */

--- a/src/agents/embedded-agent-subscribe.promise.ts
+++ b/src/agents/embedded-agent-subscribe.promise.ts
@@ -1,9 +1,0 @@
-/** Narrow unknown values to PromiseLike without requiring a concrete Promise. */
-export function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
-  return Boolean(
-    value &&
-    (typeof value === "object" || typeof value === "function") &&
-    "then" in value &&
-    typeof (value as { then?: unknown }).then === "function",
-  );
-}

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -1,6 +1,7 @@
 /**
  * Subscribes to embedded-agent sessions and streams formatted replies/events.
  */
+import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { InlineCodeState } from "../../packages/markdown-core/src/code-spans.js";
@@ -51,7 +52,6 @@ import type {
   EmbeddedAgentSubscribeContext,
   EmbeddedAgentSubscribeState,
 } from "./embedded-agent-subscribe.handlers.types.js";
-import { isPromiseLike } from "./embedded-agent-subscribe.promise.js";
 import {
   buildToolLifecycleErrorResult,
   extractToolResultMediaArtifact,

--- a/src/channels/inbound-event/context.ts
+++ b/src/channels/inbound-event/context.ts
@@ -3,6 +3,7 @@
  *
  * Converts route, sender, command, media, and supplemental facts into finalized message context.
  */
+import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import {
   commandTurnKindToSource,
   createCommandTurnContext,
@@ -249,10 +250,6 @@ function definedFields<T extends Record<string, unknown>>(fields: T): Partial<T>
       (entry): entry is [string, Exclude<unknown, undefined>] => entry[1] !== undefined,
     ),
   ) as Partial<T>;
-}
-
-function isPromiseLike<T>(value: MaybePromise<T>): value is Promise<T> {
-  return Boolean(value) && typeof (value as { then?: unknown }).then === "function";
 }
 
 function stripQuoteRuntimeFields(

--- a/src/gateway/server-methods/approval-shared.ts
+++ b/src/gateway/server-methods/approval-shared.ts
@@ -1,5 +1,6 @@
 // Approval shared helpers normalize pending exec/plugin approval lookups,
 // decision payloads, turn-source routing, and gateway error responses.
+import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
 import type {
@@ -75,10 +76,6 @@ type ApprovalResolveParamsValidator<TParams extends ApprovalResolveParams> = ((
 ) => params is TParams) & {
   errors?: ValidationError[] | null;
 };
-
-function isPromiseLike<T>(value: T | Promise<T>): value is Promise<T> {
-  return typeof value === "object" && value !== null && "then" in value;
-}
 
 function isApprovalDecision(value: string): value is ExecApprovalDecision {
   return value === "allow-once" || value === "allow-always" || value === "deny";

--- a/src/infra/sqlite-transaction.ts
+++ b/src/infra/sqlite-transaction.ts
@@ -1,5 +1,6 @@
 // Provides SQLite transaction helpers with nested savepoints.
 import type { DatabaseSync } from "node:sqlite";
+import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import { createSubsystemLogger, type SubsystemLogger } from "../logging/subsystem.js";
 // The cache-state module keeps this lifecycle edge off the kysely value graph
 // so cold control-plane paths using transactions do not load kysely.
@@ -35,10 +36,6 @@ type SqliteTransactionMode = "deferred" | "immediate";
 function nextSavepointName(): string {
   nextSavepointId += 1;
   return `openclaw_tx_${nextSavepointId}`;
-}
-
-function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
-  return Boolean(value && typeof (value as { then?: unknown }).then === "function");
 }
 
 function assertSyncTransactionResult(value: unknown): void {

--- a/src/llm/providers/stream-wrappers/openai.ts
+++ b/src/llm/providers/stream-wrappers/openai.ts
@@ -15,6 +15,7 @@ import {
   applyOpenAIResponsesPayloadPolicy,
   resolveOpenAIResponsesPayloadPolicy,
 } from "@openclaw/ai/transports";
+import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 // OpenAI stream wrapper normalizes OpenAI-compatible streamed tool and text events.
 import {
@@ -131,14 +132,6 @@ function isCodeModeEnabled(config?: OpenClawConfig): boolean {
     codeMode &&
     typeof codeMode === "object" &&
     (codeMode as { enabled?: unknown }).enabled === true,
-  );
-}
-
-function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
-  return (
-    value !== null &&
-    (typeof value === "object" || typeof value === "function") &&
-    typeof (value as { then?: unknown }).then === "function"
   );
 }
 

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -1,6 +1,7 @@
 // Model-backed image understanding runtime for providers without a native media
 // provider hook.
 import { clampPositiveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
+import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { isMinimaxVlmModel, minimaxUnderstandImage } from "../agents/minimax-vlm.js";
 import { requireApiKey, resolveApiKeyForProvider } from "../agents/model-auth.js";
@@ -91,10 +92,6 @@ function disableReasoningForImageRetryPayload(payload: unknown, model: Model): u
 
 function isImageModelNoTextError(err: unknown): boolean {
   return err instanceof Error && /^Image model returned no text\b/.test(err.message);
-}
-
-function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
-  return Boolean(value) && typeof (value as { then?: unknown }).then === "function";
 }
 
 function composeImageDescriptionPayloadHandlers(

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -7,6 +7,7 @@
 
 import { AsyncLocalStorage } from "node:async_hooks";
 import { clampPositiveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
+import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import { isToolAllowedByPolicyName } from "../agents/tool-policy-match.js";
 import {
   attachToolAllowlistIntersection,
@@ -614,13 +615,6 @@ export function createHookRunner(
 
   const getPluginPackageVersion = (pluginId: string): string | undefined =>
     registry.plugins.find((plugin) => plugin.id === pluginId)?.packageVersion;
-
-  const isPromiseLike = (value: unknown): value is PromiseLike<unknown> => {
-    if ((typeof value !== "object" && typeof value !== "function") || value === null) {
-      return false;
-    }
-    return typeof (value as { then?: unknown }).then === "function";
-  };
 
   const normalizePositiveTimeoutMs = (timeoutMs: number | undefined): number | undefined => {
     return clampPositiveTimerTimeoutMs(timeoutMs);

--- a/src/plugins/host-hook-state.ts
+++ b/src/plugins/host-hook-state.ts
@@ -1,5 +1,6 @@
 // Tracks host hook state and scheduled turn identifiers.
 import { randomUUID } from "node:crypto";
+import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { SessionEntry } from "../config/sessions.js";
 import {
@@ -462,10 +463,6 @@ function collectPluginSessionExtensionProjections(params: {
     }
   }
   return projections;
-}
-
-function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
-  return Boolean(value && typeof (value as { then?: unknown }).then === "function");
 }
 
 function discardUnexpectedPromiseProjection(value: PromiseLike<unknown>): void {

--- a/src/plugins/loader-module-runtime.ts
+++ b/src/plugins/loader-module-runtime.ts
@@ -1,3 +1,4 @@
+import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import { toSafeImportPath } from "../shared/import-specifier.js";
 import { attachPluginApiFacades } from "./api-facades.js";
 import { isLateCallablePluginApiMethod } from "./api-lifecycle.js";
@@ -40,14 +41,6 @@ const LAZY_RUNTIME_REFLECTION_KEYS = [
   "musicGeneration",
   "llm",
 ] as const satisfies readonly (keyof PluginRuntime)[];
-
-function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
-  return (
-    (typeof value === "object" || typeof value === "function") &&
-    value !== null &&
-    typeof (value as { then?: unknown }).then === "function"
-  );
-}
 
 function createGuardedPluginRegistrationApi(api: OpenClawPluginApi): {
   api: OpenClawPluginApi;

--- a/src/test-utils/vitest-spies.ts
+++ b/src/test-utils/vitest-spies.ts
@@ -12,6 +12,7 @@ function restoreMocks(mocks: readonly RestorableMock[]): void {
   }
 }
 
+// This guard requires concrete Promise.finally narrowing for synchronous cleanup overloads.
 function isPromiseLike<T>(value: T | Promise<T>): value is Promise<T> {
   return (
     typeof value === "object" &&

--- a/test/vitest/vitest.shared.config.ts
+++ b/test/vitest/vitest.shared.config.ts
@@ -483,6 +483,16 @@ export const sharedVitestConfig = {
         ),
       },
       {
+        find: "@openclaw/normalization-core/promise-like",
+        replacement: path.join(
+          repoRoot,
+          "packages",
+          "normalization-core",
+          "src",
+          "promise-like.ts",
+        ),
+      },
+      {
         find: "@openclaw/normalization-core/record-coerce",
         replacement: path.join(
           repoRoot,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -164,6 +164,9 @@
       "@openclaw/normalization-core/phone-presentation": [
         "./packages/normalization-core/src/phone-presentation.ts"
       ],
+      "@openclaw/normalization-core/promise-like": [
+        "./packages/normalization-core/src/promise-like.ts"
+      ],
       "@openclaw/normalization-core/record-coerce": [
         "./packages/normalization-core/src/record-coerce.ts"
       ],


### PR DESCRIPTION
## What Problem This Solves

Removes duplicated promise-like guards whose small semantic and typing differences made thenable handling easy to drift across core runtime paths.

## Why This Change Was Made

Adds one canonical `@openclaw/normalization-core/promise-like` helper and migrates every compatible core caller to it. The concrete-`Promise.finally` Vitest cleanup guard remains local with an explanatory comment; plugins under `extensions/**` stay outside this core-only seam.

Production code is net-negative: `+28/-85` (net `-57`). The complete PR is `+60/-85` (net `-25`) after the new contract test, test resolver alias, and TypeScript path metadata.

## User Impact

None. This is an internal simplification with unchanged user-visible behavior.

## Evidence

- Focused owner tests in one routed Vitest invocation: 11 shards covering normalization-core, agents, channels, gateway, infra, media understanding, plugins, and stream wrappers. One unrelated gateway audio-persistence assertion flaked; its single allowed rerun passed all 189 tests.
- `pnpm tsgo:core`, `pnpm tsgo:core:test`, and `pnpm tsgo:test:root` passed.
- `pnpm check:import-cycles` passed with 0 runtime value cycles.
- `pnpm plugin-sdk:surface:check` passed.
- Targeted Oxc lint passed for every touched TypeScript file.
- `pnpm build` passed, with the captured log checked for no `INEFFECTIVE_DYNAMIC_IMPORT` warning.
- Structured autoreview passed twice with no accepted/actionable findings.
