### PR TITLE
test(ui): remove duplicate dark contrast case

### DIFF
--- a/ui/src/styles/theme-contrast.test.ts
+++ b/ui/src/styles/theme-contrast.test.ts
@@ -100,27 +100,6 @@ describe("Control UI theme contrast", () => {
   const chatLayoutCss = readFileSync(path.join(here, "chat", "layout.css"), "utf8");
   const layoutCss = readFileSync(path.join(here, "layout.css"), "utf8");
 
-  it("keeps default dark muted text tokens at WCAG AA on declared surfaces", () => {
-    const dark = readCssVarBlock(baseCss, ":root");
-    const backgrounds = [
-      requireCssColor(dark, "bg"),
-      requireCssColor(dark, "bg-elevated"),
-      requireCssColor(dark, "bg-muted"),
-      requireCssColor(dark, "card"),
-    ];
-    const foregrounds = [
-      requireCssColor(dark, "muted"),
-      requireCssColor(dark, "muted-strong"),
-      requireCssColor(dark, "muted-foreground"),
-    ];
-
-    for (const foreground of foregrounds) {
-      for (const background of backgrounds) {
-        expect(contrastRatio(foreground, background)).toBeGreaterThanOrEqual(4.5);
-      }
-    }
-  });
-
   it("keeps chat timestamps and slash-arg hints AA without opacity dimming", () => {
     const dark = readCssVarBlock(baseCss, ":root");
     const muted = requireCssColor(dark, "muted");


### PR DESCRIPTION
## What Problem This Solves

The Control UI contrast suite repeated a narrow default-dark assertion for three muted tokens on four surfaces. The same invariant is covered more strongly by:

- the all-theme static matrix, which checks six text tokens on five surfaces across all six selectable themes; and
- browser E2E, which verifies resolved colors and a rendered muted description for every appearance selection.

## Why This Change Was Made

This deletes only the strict-subset default-dark case. Selector-specific tests for timestamp/slash-arg opacity, sidebar token wiring, and markdown code-chip separation remain intact.

AI-assisted: yes. The deletion was manually inspected and passed repository autoreview.

## User Impact

No user-visible behavior change. WCAG AA contrast remains covered statically and through browser-rendered theme behavior with less duplicate maintenance.

## Evidence

- `node scripts/run-vitest.mjs ui/src/styles/theme-contrast.test.ts ui/src/styles/base-theme-contrast.node.test.ts ui/src/e2e/theme-muted-contrast.e2e.test.ts` — 4 retained static tests and 7 browser E2E tests passed.
- `node scripts/check-changed.mjs -- ui/src/styles/theme-contrast.test.ts` — passed UI i18n, type, lint, dead-export, and related changed-file gates using the trusted local fallback because Blacksmith Testbox is unavailable on this host.
- Targeted oxlint, oxfmt, and `git diff --check` — passed.
- Fresh autoreview and secret scan — clean.

## Scope and LOC

- Production: unchanged.
- Tests: `-21` lines.

No runtime behavior, config, protocol, database schema, dependency, lockfile, generated baseline, release, docs, or changelog change.
