### PR TITLE
fix(release): scope iOS version checks to native releases

### DIFF
--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -738,7 +738,6 @@ export function createChangedCheckPlan(
         : ["--base", options.base ?? "origin/main", "--head", options.head ?? "HEAD"]),
     ]);
     add("Android version sync", ["android:version:check"]);
-    add("iOS version sync", ["ios:version:check"]);
     add("config schema baseline", ["config:schema:check"]);
     add("config docs baseline", ["config:docs:check"]);
     add("root dependency ownership", ["deps:root-ownership:check"]);

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -1592,7 +1592,8 @@ describe("scripts/changed-lanes", () => {
       docs: true,
       releaseMetadata: true,
     });
-    expect(plan.commands.map((command) => command.args[0])).toEqual([
+    const commands = plan.commands.map((command) => command.args[0]);
+    expect(commands).toEqual([
       "check:no-conflict-markers",
       "check:changelog-attributions",
       "check:doctor-deprecation-registry",
@@ -1608,11 +1609,11 @@ describe("scripts/changed-lanes", () => {
       "deps:patches:check",
       "release-metadata:check",
       "android:version:check",
-      "ios:version:check",
       "config:schema:check",
       "config:docs:check",
       "deps:root-ownership:check",
     ]);
+    expect(commands).not.toContain("ios:version:check");
     expect(
       plan.commands.find((command) => command.args[0] === "release-metadata:check")?.args,
     ).toEqual(["release-metadata:check", "--staged"]);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where generic release-metadata checks for an npm beta invoked the iOS App Store changelog validator. For `2026.8.1-beta.2`, the bare iOS check normalized the package version to `2026.8.1` and required native App Store notes that are outside npm beta scope, blocking Full Release Validation for unchanged Code SHA `a652994a7c685500f3f1f0c75b6e6c68555c906f`.

## Why This Change Was Made

The generic release-metadata plan no longer schedules iOS version sync. Explicit native iOS release paths remain strict and continue to pass their selected version and App Store revision; Android version sync and every other generic release-metadata check remain unchanged.

## User Impact

There is no user runtime behavior change. Maintainers can validate npm beta metadata without adding unrelated iOS App Store changelog notes.

## Evidence

- Before the fix, `node scripts/check-changed.mjs --dry-run -- package.json CHANGELOG.md` listed `pnpm ios:version:check`; after the fix it does not, while the other release-metadata checks remain present.
- `node scripts/run-vitest.mjs test/scripts/changed-lanes.test.ts test/scripts/ios-version.test.ts` — 2 files, 172 tests passed.
- `node --import tsx scripts/ios-sync-versioning.ts --check --version 2026.8.1 --revision 0` — passed, preserving strict explicit App Store validation.
- `git diff --check` — passed.
- Isolated Codex autoreview — clean, with no accepted or actionable findings.
