### PR TITLE
fix(openai): show all GPT-5.6 Sol thinking levels

### DIFF
--- a/extensions/codex/src/app-server/reasoning-effort.ts
+++ b/extensions/codex/src/app-server/reasoning-effort.ts
@@ -11,21 +11,9 @@ const CODEX_REASONING_EFFORTS = [
 ] as const;
 export type CodexReasoningEffort = (typeof CODEX_REASONING_EFFORTS)[number];
 
-const GPT_56_MAX_REASONING_EFFORTS = ["low", "medium", "high", "xhigh", "max"] as const;
-const GPT_56_ULTRA_REASONING_EFFORTS = [...GPT_56_MAX_REASONING_EFFORTS, "ultra"] as const;
-const GPT_5_PRO_REASONING_EFFORTS = ["medium", "high", "xhigh"] as const;
-const GPT_56_ULTRA_MODEL_IDS = new Set(["gpt-5.6-sol", "gpt-5.6-terra"]);
-const GPT_56_MAX_MODEL_IDS = new Set([...GPT_56_ULTRA_MODEL_IDS, "gpt-5.6-luna"]);
-const MODERN_CODEX_MODEL_IDS = new Set([
-  ...GPT_56_MAX_MODEL_IDS,
-  "gpt-5.6",
-  "gpt-5.5",
-  "gpt-5.5-pro",
-  "gpt-5.4",
-  "gpt-5.4-pro",
-  "gpt-5.4-mini",
-  "gpt-5.3-codex-spark",
-]);
+const LEGACY_PRO_REASONING_EFFORTS = ["medium", "high", "xhigh"] as const;
+const LEGACY_PRO_MODEL_ID_RE = /^gpt-5\.[45]-pro$/u;
+const MODERN_GPT_5_MODEL_ID_RE = /^gpt-5\.(?:[3-9]|[1-9]\d)(?:$|-)/u;
 
 function normalizeCodexReasoningEfforts(
   efforts: readonly string[] | null | undefined,
@@ -68,23 +56,7 @@ function resolveSupportedReasoningEffort(params: {
   );
 }
 
-function resolveFallbackReasoningEfforts(
-  modelId: string,
-): readonly CodexReasoningEffort[] | undefined {
-  const normalized = modelId.trim().toLowerCase();
-  if (GPT_56_ULTRA_MODEL_IDS.has(normalized)) {
-    return GPT_56_ULTRA_REASONING_EFFORTS;
-  }
-  if (normalized === "gpt-5.6-luna") {
-    return GPT_56_MAX_REASONING_EFFORTS;
-  }
-  if (normalized === "gpt-5.5-pro" || normalized === "gpt-5.4-pro") {
-    return GPT_5_PRO_REASONING_EFFORTS;
-  }
-  return undefined;
-}
-
-/** Resolve a turn effort from app-server metadata, with exact-name offline fallbacks. */
+/** Resolve a turn effort from the selected model's provider-owned metadata. */
 export function resolveCodexAppServerReasoningEffort(params: {
   thinkLevel: EmbeddedRunAttemptParams["thinkLevel"] | "ultra";
   modelId: string;
@@ -93,21 +65,30 @@ export function resolveCodexAppServerReasoningEffort(params: {
   if (params.thinkLevel === "off" || params.thinkLevel === "adaptive") {
     return null;
   }
-  const supportedReasoningEfforts =
-    params.supportedReasoningEfforts ?? resolveFallbackReasoningEfforts(params.modelId);
-  if (supportedReasoningEfforts) {
+  if (params.supportedReasoningEfforts) {
     return (
       resolveSupportedReasoningEffort({
         requested: params.thinkLevel,
-        supportedReasoningEfforts,
+        supportedReasoningEfforts: params.supportedReasoningEfforts,
       }) ?? null
     );
   }
-  const normalizedModelId = params.modelId.trim().toLowerCase();
-  if (params.thinkLevel === "minimal") {
-    return MODERN_CODEX_MODEL_IDS.has(normalizedModelId) ? "low" : "minimal";
+  const modelId = params.modelId.trim().toLowerCase();
+  // Preserve compatibility for deprecated Pro catalog rows that predate effort
+  // metadata. New model capabilities must come from the provider catalog.
+  if (LEGACY_PRO_MODEL_ID_RE.test(modelId)) {
+    return (
+      resolveSupportedReasoningEffort({
+        requested: params.thinkLevel,
+        supportedReasoningEfforts: LEGACY_PRO_REASONING_EFFORTS,
+      }) ?? null
+    );
+  }
+  if (params.thinkLevel === "minimal" && MODERN_GPT_5_MODEL_ID_RE.test(modelId)) {
+    return "low";
   }
   if (
+    params.thinkLevel === "minimal" ||
     params.thinkLevel === "low" ||
     params.thinkLevel === "medium" ||
     params.thinkLevel === "high" ||
@@ -115,5 +96,5 @@ export function resolveCodexAppServerReasoningEffort(params: {
   ) {
     return params.thinkLevel;
   }
-  return params.thinkLevel === "max" && GPT_56_MAX_MODEL_IDS.has(normalizedModelId) ? "max" : null;
+  return null;
 }

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -4504,113 +4504,41 @@ describe("Codex app-server thread lifecycle timing", () => {
 });
 
 describe("resolveReasoningEffort (#71946)", () => {
-  describe("modern Codex models (none/low/medium/high/xhigh enum)", () => {
-    it.each([
-      "gpt-5.6",
-      "gpt-5.6-sol",
-      "gpt-5.6-terra",
-      "gpt-5.6-luna",
-      "gpt-5.5",
-      "gpt-5.4",
-      "gpt-5.4-mini",
-      "gpt-5.3-codex-spark",
-    ] as const)(
-      "translates 'minimal' -> 'low' for %s so the first request is accepted",
-      (modelId) => {
-        expect(resolveReasoningEffort("minimal", modelId)).toBe("low");
-      },
-    );
+  const standardEfforts = ["low", "medium", "high", "xhigh"];
+  const maxEfforts = [...standardEfforts, "max"];
+  const ultraEfforts = [...maxEfforts, "ultra"];
 
-    it.each([
-      "gpt-5.6",
-      "gpt-5.6-sol",
-      "gpt-5.6-terra",
-      "gpt-5.6-luna",
-      "gpt-5.5",
-      "gpt-5.4",
-      "gpt-5.4-mini",
-      "gpt-5.3-codex-spark",
-    ] as const)(
-      "passes 'low' / 'medium' / 'high' / 'xhigh' through unchanged for %s",
-      (modelId) => {
-        expect(resolveReasoningEffort("low", modelId)).toBe("low");
-        expect(resolveReasoningEffort("medium", modelId)).toBe("medium");
-        expect(resolveReasoningEffort("high", modelId)).toBe("high");
-        expect(resolveReasoningEffort("xhigh", modelId)).toBe("xhigh");
-      },
-    );
+  it.each([
+    { requested: "minimal", supported: standardEfforts, expected: "low" },
+    { requested: "low", supported: standardEfforts, expected: "low" },
+    { requested: "medium", supported: standardEfforts, expected: "medium" },
+    { requested: "high", supported: standardEfforts, expected: "high" },
+    { requested: "xhigh", supported: standardEfforts, expected: "xhigh" },
+    { requested: "minimal", supported: ["medium", "high", "xhigh"], expected: "medium" },
+    { requested: "low", supported: ["medium", "high", "xhigh"], expected: "medium" },
+    { requested: "max", supported: ["medium", "high", "xhigh"], expected: "xhigh" },
+    { requested: "max", supported: maxEfforts, expected: "max" },
+    { requested: "ultra", supported: maxEfforts, expected: "max" },
+    { requested: "ultra", supported: ultraEfforts, expected: "ultra" },
+  ] as const)(
+    "maps $requested to $expected using provider-supported efforts",
+    ({ requested, supported, expected }) => {
+      expect(resolveReasoningEffort(requested, "catalog-model", supported)).toBe(expected);
+    },
+  );
 
-    it("normalizes case-variant model ids", () => {
-      expect(resolveReasoningEffort("minimal", "GPT-5.5")).toBe("low");
-      expect(resolveReasoningEffort("minimal", " gpt-5.4-mini ")).toBe("low");
-    });
-
-    it.each(["gpt-5.5-pro", "gpt-5.4-pro"] as const)(
-      "uses the %s minimum effort when metadata is unavailable",
-      (modelId) => {
-        expect(resolveReasoningEffort("minimal", modelId)).toBe("medium");
-        expect(resolveReasoningEffort("low", modelId)).toBe("medium");
-        expect(resolveReasoningEffort("medium", modelId)).toBe("medium");
-        expect(resolveReasoningEffort("max", modelId)).toBe("xhigh");
-      },
-    );
-
-    it("honors stricter app-server reasoning metadata", () => {
-      const supported = ["medium", "high", "xhigh"];
-
-      expect(resolveReasoningEffort("minimal", "gpt-5.5-pro", supported)).toBe("medium");
-      expect(resolveReasoningEffort("low", "gpt-5.5-pro", supported)).toBe("medium");
-      expect(resolveReasoningEffort("medium", "gpt-5.5-pro", supported)).toBe("medium");
-      expect(resolveReasoningEffort("max", "gpt-5.5-pro", supported)).toBe("xhigh");
-    });
+  it("preserves legacy compatibility when metadata is unavailable", () => {
+    expect(resolveReasoningEffort("minimal", "gpt-5.5")).toBe("low");
+    expect(resolveReasoningEffort("minimal", "gpt-4o")).toBe("minimal");
+    expect(resolveReasoningEffort("low", "gpt-5.5-pro")).toBe("medium");
+    expect(resolveReasoningEffort("max", "gpt-5.5-pro")).toBe("xhigh");
+    expect(resolveReasoningEffort("max", "gpt-5.6-sol")).toBeNull();
+    expect(resolveReasoningEffort("ultra", "gpt-5.6-sol")).toBeNull();
   });
 
-  describe("legacy / non-modern Codex models", () => {
-    it.each(["gpt-5", "gpt-4o", "o3-mini", "codex-mini-latest"] as const)(
-      "preserves 'minimal' for %s — pre-modern enum still supports it",
-      (modelId) => {
-        expect(resolveReasoningEffort("minimal", modelId)).toBe("minimal");
-      },
-    );
-
-    it("preserves 'minimal' for empty / unknown model ids (conservative default)", () => {
-      expect(resolveReasoningEffort("minimal", "")).toBe("minimal");
-      expect(resolveReasoningEffort("minimal", "unknown-model-xyz")).toBe("minimal");
-    });
-  });
-
-  describe("non-effort thinkLevel values", () => {
-    it("returns null for 'off'", () => {
-      expect(resolveReasoningEffort("off", "gpt-5.5")).toBeNull();
-      expect(resolveReasoningEffort("off", "gpt-4o")).toBeNull();
-    });
-
-    it("returns null for 'adaptive' (non-effort enum value)", () => {
-      expect(resolveReasoningEffort("adaptive", "gpt-5.5")).toBeNull();
-      expect(resolveReasoningEffort("adaptive", "gpt-4o")).toBeNull();
-    });
-
-    it("passes max only for known native GPT-5.6 models", () => {
-      expect(resolveReasoningEffort("max", "gpt-5.6-sol")).toBe("max");
-      expect(resolveReasoningEffort("max", "gpt-5.6-terra")).toBe("max");
-      expect(resolveReasoningEffort("max", "gpt-5.6-luna")).toBe("max");
-      expect(resolveReasoningEffort("max", "gpt-5.6")).toBeNull();
-      expect(resolveReasoningEffort("max", "gpt-5.6-sol-oai")).toBeNull();
-      expect(resolveReasoningEffort("max", "gpt-5.5")).toBeNull();
-      expect(resolveReasoningEffort("max", "gpt-4o")).toBeNull();
-    });
-
-    it("uses known GPT-5.6 fallbacks when app-server metadata is unavailable", () => {
-      const ultraEfforts = ["low", "medium", "high", "xhigh", "max", "ultra"];
-      const maxEfforts = ["low", "medium", "high", "xhigh", "max"];
-
-      expect(resolveReasoningEffort("ultra", "gpt-5.6-sol", ultraEfforts)).toBe("ultra");
-      expect(resolveReasoningEffort("ultra", "gpt-5.6-terra", ultraEfforts)).toBe("ultra");
-      expect(resolveReasoningEffort("ultra", "gpt-5.6-luna", maxEfforts)).toBe("max");
-      expect(resolveReasoningEffort("ultra", "gpt-5.6-sol")).toBe("ultra");
-      expect(resolveReasoningEffort("ultra", "gpt-5.6-terra")).toBe("ultra");
-      expect(resolveReasoningEffort("ultra", "gpt-5.6-luna")).toBe("max");
-    });
+  it("omits non-effort think levels", () => {
+    expect(resolveReasoningEffort("off", "catalog-model", ultraEfforts)).toBeNull();
+    expect(resolveReasoningEffort("adaptive", "catalog-model", ultraEfforts)).toBeNull();
   });
 });
 

--- a/extensions/codex/src/app-server/thread-model-selection.ts
+++ b/extensions/codex/src/app-server/thread-model-selection.ts
@@ -134,11 +134,8 @@ export function resolveCodexAppServerModelProvider(params: {
   return normalizedLower === "openai" ? "openai" : normalized;
 }
 
-// Modern Codex models reject the legacy CLI `minimal` default. Prefer
-// app-server metadata, then use the app-server-owned fallback effort contract
-// for Pro models whose minimum supported effort is `medium`.
-// Other modern models translate `minimal` to `low`. (#71946)
-// Exported for unit-test coverage of the model-aware translation path.
+// Provider catalog metadata owns model-specific effort support. Keeping this
+// bridge model-agnostic prevents the picker and native runtime from drifting.
 export function resolveReasoningEffort(
   thinkLevel: EmbeddedRunAttemptParams["thinkLevel"] | "ultra",
   modelId: string,

--- a/extensions/openai/model-route-contract.ts
+++ b/extensions/openai/model-route-contract.ts
@@ -20,6 +20,25 @@ export const OPENAI_GPT_56_VARIANT_MODEL_IDS = [
   OPENAI_GPT_56_LUNA_MODEL_ID,
 ] as const;
 
+const OPENAI_CODEX_REASONING_EFFORT_ORDER = [
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+  "ultra",
+] as const;
+type OpenAICodexReasoningEffort = (typeof OPENAI_CODEX_REASONING_EFFORT_ORDER)[number];
+
+const OPENAI_CODEX_REASONING_EFFORTS_BY_MODEL = new Map<
+  string,
+  readonly OpenAICodexReasoningEffort[]
+>([
+  [OPENAI_GPT_56_SOL_MODEL_ID, OPENAI_CODEX_REASONING_EFFORT_ORDER],
+  [OPENAI_GPT_56_TERRA_MODEL_ID, OPENAI_CODEX_REASONING_EFFORT_ORDER],
+  [OPENAI_GPT_56_LUNA_MODEL_ID, OPENAI_CODEX_REASONING_EFFORT_ORDER.slice(0, -1)],
+]);
+
 /** Models with known first-party Platform and ChatGPT transports. */
 const OPENAI_DUAL_ROUTE_MODEL_IDS = [
   ...OPENAI_GPT_56_VARIANT_MODEL_IDS,
@@ -71,6 +90,38 @@ export function normalizeOpenAIModelRouteId(value: string | undefined): string {
 function normalizeOpenAIRouteMembershipId(value: string | undefined): string {
   // Static first-party membership is case-insensitive without changing catalog keys.
   return normalizeOpenAIModelRouteId(value).toLowerCase();
+}
+
+/**
+ * Merge live Codex observations with first-party model capabilities.
+ * An explicit empty list remains authoritative; partial non-empty observations
+ * cannot erase capabilities known by every other OpenAI model surface.
+ */
+export function resolveOpenAICodexReasoningEfforts(
+  modelId: string | undefined,
+  observed: readonly string[] | undefined,
+): string[] | undefined {
+  const known = OPENAI_CODEX_REASONING_EFFORTS_BY_MODEL.get(
+    normalizeOpenAIRouteMembershipId(modelId),
+  );
+  if (!known) {
+    return observed ? [...observed] : undefined;
+  }
+  if (observed === undefined || observed.length === 0) {
+    return observed ? [] : [...known];
+  }
+  const normalizedObserved = observed.map((effort) => effort.trim().toLowerCase()).filter(Boolean);
+  const supported = new Set([...known, ...normalizedObserved]);
+  const knownSet = new Set(known);
+  for (const effort of OPENAI_CODEX_REASONING_EFFORT_ORDER) {
+    if (!knownSet.has(effort)) {
+      supported.delete(effort);
+    }
+  }
+  return [
+    ...OPENAI_CODEX_REASONING_EFFORT_ORDER.filter((effort) => supported.delete(effort)),
+    ...supported,
+  ];
 }
 
 export function isOpenAIDualRouteModelId(value: string | undefined): boolean {

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -816,7 +816,7 @@ describe("buildOpenAIProvider", () => {
       expect(openai?.models.find((model) => model.id === "gpt-5.6-sol")).toMatchObject({
         contextWindow: 372_000,
         compat: {
-          supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
+          supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
         },
         thinkingLevelMap: { off: null, xhigh: "xhigh", max: "max" },
       });
@@ -829,7 +829,7 @@ describe("buildOpenAIProvider", () => {
           api: "openai-chatgpt-responses",
           compat: liveSol?.compat,
         } as never)?.levels,
-      ).not.toContainEqual({ id: "ultra" });
+      ).toContainEqual({ id: "ultra" });
       expect(openai?.models.find((model) => model.id === "gpt-5.6-terra")).toMatchObject({
         contextWindow: 372_000,
         contextTokens: 272_000,
@@ -1016,6 +1016,7 @@ describe("buildOpenAIProvider", () => {
             supported_reasoning_levels: [
               { effort: "low", description: "low" },
               { effort: "high", description: "high" },
+              ...(tier === "luna" ? [{ effort: "ultra", description: "ultra" }] : []),
             ],
           })),
         ],
@@ -1035,12 +1036,20 @@ describe("buildOpenAIProvider", () => {
       contextWindow: 1_050_000,
       contextTokens: 272_000,
     });
-    for (const tier of ["sol", "terra", "luna"]) {
+    for (const tier of ["sol", "terra"] as const) {
       expect(provider.models.find((model) => model.id === `gpt-5.6-${tier}`)).toMatchObject({
         reasoning: true,
-        compat: { supportedReasoningEfforts: ["low", "high"] },
+        compat: {
+          supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
+        },
       });
     }
+    expect(provider.models.find((model) => model.id === "gpt-5.6-luna")).toMatchObject({
+      reasoning: true,
+      compat: {
+        supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
+      },
+    });
   });
 
   it("keeps an explicit empty Codex reasoning catalog authoritative", async () => {

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -52,6 +52,7 @@ import {
   isOpenAIPlatformOnlyRouteModelId,
   isOpenAISubscriptionOnlyRouteModelId,
   normalizeOpenAIModelRouteId,
+  resolveOpenAICodexReasoningEfforts,
 } from "./model-route-contract.js";
 import {
   buildOpenAIChatGPTAuthMethods,
@@ -436,16 +437,10 @@ function normalizeOpenAICodexCatalogModel(model: ModelDefinitionConfig): ModelDe
     modelId === OPENAI_GPT_56_TERRA_MODEL_ID ||
     modelId === OPENAI_GPT_56_LUNA_MODEL_ID
   ) {
-    const supportsNativeUltra =
-      modelId === OPENAI_GPT_56_SOL_MODEL_ID || modelId === OPENAI_GPT_56_TERRA_MODEL_ID;
-    const supportedReasoningEfforts = model.compat?.supportedReasoningEfforts
-      ? [
-          ...new Set([
-            ...model.compat.supportedReasoningEfforts.filter((effort) => effort !== "none"),
-            ...(supportsNativeUltra ? (["ultra"] as const) : []),
-          ]),
-        ]
-      : undefined;
+    const supportedReasoningEfforts = resolveOpenAICodexReasoningEfforts(
+      modelId,
+      model.compat?.supportedReasoningEfforts?.filter((effort) => effort !== "none"),
+    );
     return {
       ...model,
       contextWindow: OPENAI_CODEX_GPT_56_CONTEXT_WINDOW,
@@ -526,7 +521,7 @@ function buildOpenAICodexModelFromLiveRow(row: unknown): ModelDefinitionConfig |
     ...(reasoningLevels?.includes("max") ? { max: "max" as const } : {}),
   };
 
-  return {
+  return normalizeOpenAICodexCatalogModel({
     id: modelId,
     name: readCodexModelString(row, "display_name") ?? fallback?.name ?? modelId,
     api: "openai-chatgpt-responses",
@@ -542,7 +537,7 @@ function buildOpenAICodexModelFromLiveRow(row: unknown): ModelDefinitionConfig |
     ...(fallback?.mediaInput ? { mediaInput: fallback.mediaInput } : {}),
     ...(compat ? { compat } : {}),
     ...(Object.keys(thinkingLevelMap).length > 0 ? { thinkingLevelMap } : {}),
-  };
+  });
 }
 
 function buildOpenAICodexStaticProviderConfig(): ModelProviderConfig {

--- a/extensions/openai/provider-policy-api.test.ts
+++ b/extensions/openai/provider-policy-api.test.ts
@@ -164,13 +164,13 @@ describe("OpenAI provider policy artifact", () => {
     }
   });
 
-  it("lets authoritative Codex model/list metadata override native fallbacks", () => {
+  it("merges partial Codex model/list metadata with known native capabilities", () => {
     const solLevels = resolveThinkingProfile({
       provider: "openai",
       modelId: "gpt-5.6-sol",
       agentRuntime: "codex",
       api: "openai-chatgpt-responses",
-      compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"] },
+      compat: { supportedReasoningEfforts: ["low", "high"] },
     })?.levels.map((level) => level.id);
     const terraLevels = resolveThinkingProfile({
       provider: "openai",
@@ -182,39 +182,45 @@ describe("OpenAI provider policy artifact", () => {
       },
     })?.levels.map((level) => level.id);
 
-    expect(solLevels).not.toContain("ultra");
-    expect(terraLevels).toContain("ultra");
+    expect(solLevels).toEqual(["off", "low", "medium", "high", "xhigh", "max", "ultra"]);
+    expect(terraLevels).toEqual(["off", "low", "medium", "high", "xhigh", "max", "ultra"]);
   });
 
   it.each([
-    { efforts: [], expected: ["off"] },
-    { efforts: ["high"], expected: ["off", "high"] },
-  ])("uses the complete authoritative Codex effort list for $efforts", ({ efforts, expected }) => {
-    const profile = resolveThinkingProfile({
-      provider: "openai",
-      modelId: "gpt-5.6-sol",
-      agentRuntime: "codex",
-      api: "openai-chatgpt-responses",
-      compat: { supportedReasoningEfforts: efforts },
-    });
+    { efforts: [], expected: ["off"], defaultLevel: undefined },
+    {
+      efforts: ["high"],
+      expected: ["off", "low", "medium", "high", "xhigh", "max", "ultra"],
+      defaultLevel: "medium",
+    },
+  ])(
+    "distinguishes an explicit empty Codex effort list from an incomplete one",
+    ({ efforts, expected, defaultLevel }) => {
+      const profile = resolveThinkingProfile({
+        provider: "openai",
+        modelId: "gpt-5.6-sol",
+        agentRuntime: "codex",
+        api: "openai-chatgpt-responses",
+        compat: { supportedReasoningEfforts: efforts },
+      });
 
-    expect(profile?.levels.map((level) => level.id)).toEqual(expected);
-    expect(profile?.defaultLevel).toBeUndefined();
-  });
+      expect(profile?.levels.map((level) => level.id)).toEqual(expected);
+      expect(profile?.defaultLevel).toBe(defaultLevel);
+    },
+  );
 
-  it("keeps Codex Luna capped at Max without authoritative Ultra metadata", () => {
+  it("keeps Codex Luna capped at Max when live metadata advertises Ultra", () => {
     const levels = resolveThinkingProfile({
       provider: "openai",
       modelId: "gpt-5.6-luna",
       agentRuntime: "codex",
-      api: "openai-responses",
+      api: "openai-chatgpt-responses",
       compat: {
-        supportedReasoningEfforts: ["none", "low", "medium", "high", "xhigh", "max"],
+        supportedReasoningEfforts: ["low", "ultra"],
       },
     })?.levels.map((level) => level.id);
 
-    expect(levels).toContain("max");
-    expect(levels).not.toContain("ultra");
+    expect(levels).toEqual(["off", "low", "medium", "high", "xhigh", "max"]);
   });
   it("orders Platform before ChatGPT for unconfigured routable models", () => {
     const expected = {

--- a/extensions/openai/thinking-policy.test.ts
+++ b/extensions/openai/thinking-policy.test.ts
@@ -23,12 +23,12 @@ describe("OpenAI thinking route provenance", () => {
     ).toContain("ultra");
   });
 
-  it("uses ChatGPT model/list metadata as authoritative", () => {
+  it("retains known native capabilities when ChatGPT metadata is incomplete", () => {
     expect(
       levelIds({
         api: "openai-chatgpt-responses",
-        efforts: ["low", "medium", "high", "xhigh", "max"],
+        efforts: ["low", "high"],
       }),
-    ).not.toContain("ultra");
+    ).toEqual(["off", "low", "medium", "high", "xhigh", "max", "ultra"]);
   });
 });

--- a/extensions/openai/thinking-policy.ts
+++ b/extensions/openai/thinking-policy.ts
@@ -3,6 +3,17 @@ import type {
   ProviderDefaultThinkingPolicyContext,
   ProviderThinkingProfile,
 } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  OPENAI_GPT_53_CODEX_SPARK_MODEL_ID,
+  OPENAI_GPT_54_MINI_MODEL_ID,
+  OPENAI_GPT_54_MODEL_ID,
+  OPENAI_GPT_54_NANO_MODEL_ID,
+  OPENAI_GPT_54_PRO_MODEL_ID,
+  OPENAI_GPT_55_MODEL_ID,
+  OPENAI_GPT_55_PRO_MODEL_ID,
+  OPENAI_GPT_56_MODEL_ID,
+  resolveOpenAICodexReasoningEfforts,
+} from "./model-route-contract.js";
 
 type OpenAIThinkingCompat = ProviderDefaultThinkingPolicyContext["compat"];
 type OpenAIThinkingApi = ProviderDefaultThinkingPolicyContext["api"];
@@ -28,18 +39,18 @@ const OPENAI_THINKING_LEVEL_ORDER = [
 type OpenAIThinkingLevelId = (typeof OPENAI_THINKING_LEVEL_ORDER)[number];
 
 const OPENAI_CODEX_XHIGH_MODEL_IDS = [
-  "gpt-5.6",
-  "gpt-5.5",
-  "gpt-5.5-pro",
-  "gpt-5.4",
-  "gpt-5.4-pro",
-  "gpt-5.3-codex-spark",
+  OPENAI_GPT_56_MODEL_ID,
+  OPENAI_GPT_55_MODEL_ID,
+  OPENAI_GPT_55_PRO_MODEL_ID,
+  OPENAI_GPT_54_MODEL_ID,
+  OPENAI_GPT_54_PRO_MODEL_ID,
+  OPENAI_GPT_53_CODEX_SPARK_MODEL_ID,
 ] as const;
 
 const OPENAI_UNIFIED_XHIGH_MODEL_IDS = [
   ...OPENAI_CODEX_XHIGH_MODEL_IDS,
-  "gpt-5.4-mini",
-  "gpt-5.4-nano",
+  OPENAI_GPT_54_MINI_MODEL_ID,
+  OPENAI_GPT_54_NANO_MODEL_ID,
 ] as const;
 
 function normalizeModelId(value: string): string {
@@ -62,9 +73,7 @@ function normalizeCodexReasoningEffort(value: string): OpenAIThinkingLevelId | u
   return OPENAI_THINKING_LEVEL_ORDER.find((level) => level === normalized);
 }
 
-function buildAuthoritativeCodexLevels(
-  efforts: readonly string[],
-): ProviderThinkingProfile["levels"] {
+function buildCodexLevels(efforts: readonly string[]): ProviderThinkingProfile["levels"] {
   // Omitting an effort remains a valid Codex choice even when model/list has
   // no reasoning presets. Every other picker stop must come from that list.
   const supported = new Set<OpenAIThinkingLevelId>(["off"]);
@@ -86,31 +95,25 @@ function buildOpenAIThinkingProfile(params: {
 }): ProviderThinkingProfile {
   const modelId = normalizeModelId(params.modelId);
   const agentRuntime = normalizeModelId(params.agentRuntime ?? "");
-  const isBare = modelId === "gpt-5.6";
-  const isSol = modelId === "gpt-5.6-sol";
-  const isTerra = modelId === "gpt-5.6-terra";
-  const isLuna = modelId === "gpt-5.6-luna";
   const codexEfforts = params.compat?.supportedReasoningEfforts?.map(normalizeModelId);
-  const authoritativeCodexEfforts =
-    params.api === "openai-chatgpt-responses" ? codexEfforts : undefined;
-  const fallbackCodexMax = isSol || isTerra || isLuna;
-  const codexSupportsMax = authoritativeCodexEfforts
-    ? authoritativeCodexEfforts.includes("max")
-    : fallbackCodexMax;
+  const resolvedCodexEfforts =
+    params.api === "openai-chatgpt-responses"
+      ? resolveOpenAICodexReasoningEfforts(modelId, codexEfforts)
+      : undefined;
+  const knownCodexEfforts = resolveOpenAICodexReasoningEfforts(modelId, undefined);
+  const isGpt56Variant = knownCodexEfforts !== undefined;
+  const codexSupportsMax = (resolvedCodexEfforts ?? knownCodexEfforts)?.includes("max");
   const supportsMax =
     modelId.startsWith("gpt-5.6") && (agentRuntime !== "codex" || codexSupportsMax);
-  const fallbackCodexUltra = isSol || isTerra;
-  const codexSupportsUltra = authoritativeCodexEfforts
-    ? authoritativeCodexEfforts.includes("ultra")
-    : fallbackCodexUltra;
+  const codexSupportsUltra = (resolvedCodexEfforts ?? knownCodexEfforts)?.includes("ultra");
   // OpenClaw owns its logical Ultra orchestration. Native Codex capabilities
   // come only from the selected ChatGPT route's catalog metadata.
   const supportsUltra =
-    (isBare || isSol || isTerra || isLuna) &&
+    (modelId === OPENAI_GPT_56_MODEL_ID || isGpt56Variant) &&
     (agentRuntime === "openclaw" ||
       agentRuntime === "auto" ||
       (agentRuntime === "codex" && codexSupportsUltra));
-  const defaultLevel = isSol || isTerra || isLuna ? "medium" : undefined;
+  const defaultLevel = isGpt56Variant ? "medium" : undefined;
   const fallbackLevels: ProviderThinkingProfile["levels"] = [
     ...OPENAI_THINKING_BASE_LEVELS,
     ...(matchesExactOrPrefix(params.modelId, params.xhighModelIds)
@@ -120,8 +123,8 @@ function buildOpenAIThinkingProfile(params: {
     ...(supportsUltra ? [{ id: "ultra" as const }] : []),
   ];
   const levels =
-    agentRuntime === "codex" && authoritativeCodexEfforts !== undefined
-      ? buildAuthoritativeCodexLevels(authoritativeCodexEfforts)
+    agentRuntime === "codex" && resolvedCodexEfforts !== undefined
+      ? buildCodexLevels(resolvedCodexEfforts)
       : fallbackLevels;
   const supportedDefault = defaultLevel && levels.some((level) => level.id === defaultLevel);
   return {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users selecting GPT-5.6 Sol with the native Codex runtime could see only a partial thinking picker when ChatGPT model discovery returned an incomplete non-empty effort list. Sol supports `low`, `medium`, `high`, `xhigh`, `max`, and `ultra`, but a partial observation could hide valid levels from the Control UI.

## Why This Change Was Made

OpenAI model capability facts had drifted across the provider catalog, thinking policy, and Codex runtime. This change makes the OpenAI route contract the canonical owner for GPT-5.6 variant capabilities, merges partial live observations without letting them erase known levels, preserves explicit empty catalogs, and enforces each variant's ceiling (Luna remains capped at Max).

The Codex app-server bridge now validates against the selected model's provider-owned `supportedReasoningEfforts` instead of maintaining a second Sol/Terra/Luna capability table. Route behavior remains unchanged: direct OpenAI paths clamp logical Ultra to Max, while native Codex paths preserve literal Ultra only when model metadata advertises it.

Upstream contract: OpenAI Codex lists Sol's six efforts in [`models.json`](https://github.com/openai/codex/blob/2cc9dbb9846b2dc03948414df6712adb967c70eb/codex-rs/models-manager/models.json#L36-L60).

**Provenance:** The split capability ownership was introduced during #98021 (code and PR author @anyech / JC; squash merged by @steipete on 2026-07-10). Later provider refactoring carried forward the assumption that any non-empty live list was complete.

## User Impact

GPT-5.6 Sol users now see the complete picker in canonical order:

`Off → Low → Medium → High → Extra high → Maximum → Ultra`

Partial live catalog responses no longer silently remove valid options. Terra receives the same protection, while Luna cannot be widened beyond Max by a bad observation.

## Evidence

<table>
  <tr>
    <th width="50%">Before — picker ends at Maximum</th>
    <th width="50%">After — Ultra is available</th>
  </tr>
  <tr>
    <td width="50%"><img src="https://ampcode.com/user-content/artifacts/828831bf578ca96f74b3219b02dee0f8107e5e399eef108c46b2a490ce1907b2-file.png" width="390" alt="Before: GPT-5.6 Sol effort picker ending at Maximum"></td>
    <td width="50%"><img src="https://ampcode.com/user-content/artifacts/4a2b8e4c7b48c7f5e24ee6c2d1dbd4e4790da35831f3b0ef0947377ef786dd64-file.png" width="390" alt="After: GPT-5.6 Sol effort picker with Ultra selected"></td>
  </tr>
</table>

Focused verification on commit `1908802ce38`:

- OpenAI provider/policy regression suites: **134 passed**
- Codex reasoning and route mapping cases: **17 passed**
- Deterministic Control UI screenshot flow: **1 passed**
- `pnpm tsgo:extensions`: passed
- `pnpm tsgo:extensions:test`: passed
- Targeted `oxlint`: 0 warnings, 0 errors
- Changed-file formatting and `git diff --check`: passed
- Independent final review: approved with no blocking findings

The complete Codex lifecycle file also ran all affected tests successfully; its aggregate remains 138/140 because two unrelated existing copy assertions for Skill Workshop/message guidance fail on current `main` (the received text differs only in wording/capitalization).

