### PR TITLE
test(macos): remove stale Canvas helper probes

### DIFF
--- a/apps/macos/Sources/OpenClaw/CanvasWindowController+Helpers.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController+Helpers.swift
@@ -17,11 +17,6 @@ extension CanvasWindowController {
         return data.flatMap { String(data: $0, encoding: .utf8) } ?? "\"\""
     }
 
-    static func jsOptionalStringLiteral(_ value: String?) -> String {
-        guard let value else { return "null" }
-        return Self.jsStringLiteral(value)
-    }
-
     static func storedFrameDefaultsKey(sessionKey: String) -> String {
         "openclaw.canvas.frame.\(self.sanitizeSessionKey(sessionKey))"
     }

--- a/apps/macos/Sources/OpenClaw/CanvasWindowController+Testing.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController+Testing.swift
@@ -3,14 +3,6 @@ import AppKit
 import Foundation
 
 extension CanvasWindowController {
-    static func _testSanitizeSessionKey(_ key: String) -> String {
-        self.sanitizeSessionKey(key)
-    }
-
-    static func _testJSOptionalStringLiteral(_ value: String?) -> String {
-        self.jsOptionalStringLiteral(value)
-    }
-
     static func _testStoredFrameKey(sessionKey: String) -> String {
         self.storedFrameDefaultsKey(sessionKey: sessionKey)
     }

--- a/apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift
@@ -403,10 +403,6 @@ struct LowCoverageHelperTests {
     }
 
     @Test @MainActor func `canvas window helper functions`() throws {
-        #expect(CanvasWindowController._testSanitizeSessionKey("  main ") == "main")
-        #expect(CanvasWindowController._testSanitizeSessionKey("bad/..") == "bad___")
-        #expect(CanvasWindowController._testJSOptionalStringLiteral(nil) == "null")
-
         let rect = NSRect(x: 10, y: 12, width: 400, height: 420)
         let key = CanvasWindowController._testStoredFrameKey(sessionKey: "test")
         let loaded = CanvasWindowController._testStoreAndLoadFrame(sessionKey: "test", frame: rect)


### PR DESCRIPTION
## What Problem This Solves

Canvas retained two DEBUG-only test bridges for exact session-key sanitization spelling and a JavaScript optional-string helper. The controller smoke test already proves sanitized safe-directory construction through the real initializer, while `jsOptionalStringLiteral` has no production caller.

## Why This Change Was Made

This removes:

- `_testSanitizeSessionKey`;
- `_testJSOptionalStringLiteral`;
- the dead `jsOptionalStringLiteral` implementation; and
- their three private-helper assertions.

The mixed helper test retains frame persistence and trusted A2UI source checks. The controller smoke suite retains real directory sanitization, window lifecycle, polling, and navigation coverage.

AI-assisted: yes. The change was manually inspected and passed repository autoreview.

## User Impact

No user-visible behavior change. Canvas uses the same production session-key sanitizer and JavaScript string encoder, with less test-only and dead helper surface.

## Evidence

- `swift test --package-path apps/macos --filter 'CanvasWindowSmokeTests|LowCoverageHelperTests'` — 25 retained tests passed.
- `swift build --package-path apps/macos` — passed.
- `node scripts/check-changed.mjs -- ...` for the three touched macOS files — passed full Swift lint, app checks, 295 macOS CI tests, native schema guard, and related tooling gates using the trusted local fallback because Blacksmith Testbox is unavailable on this host.
- Fresh autoreview and secret scan — clean.

## Scope and LOC

- Production/test support: `-13` lines.
- Tests: `-4` lines.
- Overall: `-17` lines.

No runtime behavior, config, protocol, database schema, dependency, lockfile, generated baseline, release, docs, or changelog change.
