### PR TITLE
improve(test): reuse Vitest for doctor contract parity

### DIFF
--- a/src/plugins/doctor-contract-declarations.test.ts
+++ b/src/plugins/doctor-contract-declarations.test.ts
@@ -1,12 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { resolvePluginDoctorContractArtifactPath } from "./doctor-contract-artifact.js";
 import { coercePluginDoctorContractModule } from "./doctor-contract-module.js";
 import { loadBundledPluginManifestRegistry } from "./manifest-registry.js";
 import type { PluginManifestDoctorContract } from "./manifest-types.js";
-import {
-  createPluginModuleLoaderCache,
-  getCachedPluginModuleLoader,
-} from "./plugin-module-loader-cache.js";
 
 const DOCTOR_CONTRACT_SURFACES = [
   "configRepair",
@@ -16,41 +12,48 @@ const DOCTOR_CONTRACT_SURFACES = [
 ] as const satisfies readonly (keyof PluginManifestDoctorContract)[];
 
 describe("bundled plugin doctor contract declarations", () => {
-  it("matches every resolvable artifact's coerced doctor surfaces", () => {
-    const moduleLoaders = createPluginModuleLoaderCache();
-    const mismatches: string[] = [];
-
-    for (const record of loadBundledPluginManifestRegistry().plugins) {
-      const artifactPath = resolvePluginDoctorContractArtifactPath(record.rootDir);
-      if (!artifactPath) {
-        continue;
-      }
-      const declaration = record.doctorContract;
-      if (!declaration) {
-        mismatches.push(`${record.id}: missing doctorContract declaration`);
-        continue;
-      }
-      const mod = getCachedPluginModuleLoader({
-        cache: moduleLoaders,
-        modulePath: artifactPath,
-        importerUrl: import.meta.url,
-      })(artifactPath) as Parameters<typeof coercePluginDoctorContractModule>[0];
-      const { summary } = coercePluginDoctorContractModule(mod);
-      for (const surface of DOCTOR_CONTRACT_SURFACES) {
-        if (surface === "sessionRouteStateOwners" && record.sessionRouteStateOwners !== undefined) {
-          if (summary.sessionRouteStateOwners) {
-            mismatches.push(`${record.id}: bundled owner metadata must use the manifest`);
+  it("matches every resolvable artifact's coerced doctor surfaces", async () => {
+    const mismatches = (
+      await Promise.all(
+        loadBundledPluginManifestRegistry().plugins.map(async (record) => {
+          const pluginMismatches: string[] = [];
+          const artifactPath = resolvePluginDoctorContractArtifactPath(record.rootDir);
+          if (!artifactPath) {
+            return pluginMismatches;
           }
-          continue;
-        }
-        const declared = declaration[surface] === true;
-        if (declared !== summary[surface]) {
-          mismatches.push(
-            `${record.id}:${surface} declared=${String(declared)} actual=${String(summary[surface])}`,
-          );
-        }
-      }
-    }
+          const declaration = record.doctorContract;
+          if (!declaration) {
+            pluginMismatches.push(`${record.id}: missing doctorContract declaration`);
+            return pluginMismatches;
+          }
+          // This test owns declaration parity, not plugin-loader behavior. Let
+          // Vitest transform each real artifact once instead of creating a Jiti
+          // loader per plugin; dedicated loader tests cover production loading.
+          const mod = (await vi.importActual(artifactPath)) as Parameters<
+            typeof coercePluginDoctorContractModule
+          >[0];
+          const { summary } = coercePluginDoctorContractModule(mod);
+          for (const surface of DOCTOR_CONTRACT_SURFACES) {
+            if (
+              surface === "sessionRouteStateOwners" &&
+              record.sessionRouteStateOwners !== undefined
+            ) {
+              if (summary.sessionRouteStateOwners) {
+                pluginMismatches.push(`${record.id}: bundled owner metadata must use the manifest`);
+              }
+              continue;
+            }
+            const declared = declaration[surface] === true;
+            if (declared !== summary[surface]) {
+              pluginMismatches.push(
+                `${record.id}:${surface} declared=${String(declared)} actual=${String(summary[surface])}`,
+              );
+            }
+          }
+          return pluginMismatches;
+        }),
+      )
+    ).flat();
 
     expect(mismatches).toStrictEqual([]);
   }, 600_000);


### PR DESCRIPTION
## What Problem This Solves

`src/plugins/doctor-contract-declarations.test.ts` takes 36–38 seconds because it creates production Jiti loader state across 42 bundled doctor artifacts, even though this test only owns exhaustive manifest-to-export parity.

## What Changed

- Load every real doctor artifact through Vitest's existing transform/module cache.
- Resolve independent plugin artifacts concurrently while preserving manifest order in mismatch output.
- Keep actual module execution and `coercePluginDoctorContractModule` validation for every resolvable bundled plugin.
- Remove duplicate production-loader setup from this test; dedicated plugin-module-loader and doctor-registry fixture tests retain production loading coverage.
- No production code and no CI workers added.

## Coverage Retained

The test still fails when:

- a bundled doctor artifact lacks a manifest `doctorContract` declaration;
- `configRepair`, `resolveSessionStoreAgentIds`, `sessionRouteStateOwners`, or `stateMigrations` declaration booleans disagree with coerced exports;
- bundled session-route ownership is incorrectly exported from the module instead of manifest metadata;
- any real doctor artifact or its static imports fail to execute.

## Measured Result

- Baseline test: 38.457s ([exact compact job](https://github.com/openclaw/openclaw/actions/runs/31455822921/job/93669690205))
- PR exact-head test: 2.499s ([run 31462022442, job 93688866245](https://github.com/openclaw/openclaw/actions/runs/31462022442/job/93688866245))
- Improvement: **93.5% faster**
- Focused Vitest lane: 1/1 test passed in 4.21s total; changed-boundary and test-type checks also passed.

Static verification:

- `oxfmt --check src/plugins/doctor-contract-declarations.test.ts`
- `git diff --check`
