### PR TITLE
test(core): remove orphan internal test aliases

### DIFF
--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -178,8 +178,3 @@ export const tasksHandlers: GatewayRequestHandlers = {
     });
   },
 };
-
-export const testApi = {
-  mapTaskSummary,
-};
-export { testApi as __test };

--- a/src/gateway/server-methods/tools-effective.ts
+++ b/src/gateway/server-methods/tools-effective.ts
@@ -681,4 +681,3 @@ export const testing = {
     nowForToolsEffectiveCache = () => Date.now();
   },
 } as const;
-export { testing as __testing };

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -1140,7 +1140,6 @@ export const testApi = {
   sessionsUsageCache,
   sessionsUsageCacheKey,
 };
-export { testApi as __test };
 
 export type { SessionUsageEntry, SessionsUsageAggregates, SessionsUsageResult };
 

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -1459,5 +1459,4 @@ export const testing = {
   shouldSkipStartupModelPrewarm,
   stopPostReadySidecarsAfterCloseStarted,
 };
-export { testing as __testing };
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/secrets/apply.ts
+++ b/src/secrets/apply.ts
@@ -989,5 +989,4 @@ export const testing = {
     return projected.nextConfig;
   },
 };
-export { testing as __testing };
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

Several internal modules still exported compatibility aliases created during a 2026 lint rename, even though no tracked caller uses them. The tasks method also retained a `testApi` object whose only member is already owned by `task-summary.ts` and exercised through real task handlers.

## Why This Change Was Made

This removes:

- the unused task `testApi` and `__test` alias;
- the unused usage `__test` alias;
- the unused tools-effective `__testing` alias;
- the unused startup post-attach `__testing` alias; and
- the unused secrets apply `__testing` alias.

The primary `testing`/`testApi` objects with active test consumers remain unchanged. No public package, Plugin SDK, protocol, config, database, migration, or runtime behavior changes.

AI-assisted: yes. Every alias and caller was manually verified against current source, tests, history, and dead-export checks; fresh structured review found no actionable issue.

## User Impact

No user-visible behavior change. Internal test surface is smaller and no longer carries unconsumed compatibility names.

## Evidence

- Affected Gateway/startup/secrets suites — 9 files and 175 tests passed.
- `node scripts/check-changed.mjs -- ...` for the five touched files — passed all classified format, type, lint, Plugin SDK baseline, dead-export, boundary, architecture, and safety gates through trusted local fallback because Blacksmith Testbox is unavailable on this host.
- Fresh structured autoreview and secret scan — clean.
- `git diff --check` — clean.

Production/test-support delta: −9 lines. Tests: 0.
