### PR TITLE
refactor(outbound): consolidate message action test fixtures

### DIFF
--- a/src/infra/outbound/message-action-execution.media-policy.test.ts
+++ b/src/infra/outbound/message-action-execution.media-policy.test.ts
@@ -3,20 +3,16 @@
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { jsonResult } from "../../agents/tools/common.js";
-import { dispatchChannelMessageAction } from "../../channels/plugins/message-action-dispatch.js";
-import type {
-  ChannelMessageActionContext,
-  ChannelPlugin,
-} from "../../channels/plugins/types.public.js";
+import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import {
-  normalizeMessagePresentation,
-  renderMessagePresentationFallbackText,
-} from "../../interactive/payload.js";
-import { extractToolPayload } from "../../plugin-sdk/tool-payload.js";
-import { getActivePluginRegistry, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
-import { runMessageAction } from "./message-action-runner.js";
+import {
+  createAlwaysConfiguredPluginConfig,
+  resetMessageActionRunnerMocks,
+  runMessageAction,
+  setMessageActionTestPlugin as setTestPlugin,
+} from "./message-action-runner.test-helpers.js";
 
 const requireRecord = createRequireRecord("record", "expected-non-array-record");
 
@@ -30,202 +26,9 @@ function readMediaAccess(call: Record<string, unknown>): Record<string, unknown>
   return requireRecord(call.mediaAccess);
 }
 
-const mocks = vi.hoisted(() => ({
-  resolveOutboundChannelPlugin: vi.fn(),
-  executeSendAction: vi.fn(),
-  executePollAction: vi.fn(),
-  hasCorePresentationDelivery: vi.fn(),
-  materializeMessagePresentationFallback: vi.fn(),
-  callGateway: vi.fn(),
-  callGatewayLeastPrivilege: vi.fn(),
-  isGatewayTransportError: vi.fn(),
-  randomIdempotencyKey: vi.fn(() => "idem-gateway-action"),
-  maybeApplyTtsToPayload: vi.fn(async (params: { payload: unknown }) => params.payload),
-  prepareOutboundMirrorRoute: vi.fn(),
-  beginTerminalSourceReplyDelivery: vi.fn(),
-  cancelTerminalSourceReplyDelivery: vi.fn(),
-  isCurrentSourceReplyActionName: vi.fn(() => false),
-  isDeliveredCurrentSourceReply: vi.fn(() => false),
-  isDeliveredCurrentSourceReplyAction: vi.fn(() => false),
-  reconcileTerminalSourceReplyDelivery: vi.fn(),
-}));
-
-vi.mock("./channel-resolution.js", () => ({
-  normalizeDeliverableOutboundChannel: (value?: string | null) =>
-    typeof value === "string" ? value.trim().toLowerCase() || undefined : undefined,
-  resolveOutboundChannelPlugin: mocks.resolveOutboundChannelPlugin,
-  resetOutboundChannelResolutionStateForTest: vi.fn(),
-}));
-
-vi.mock("./outbound-send-service.js", () => ({
-  executeSendAction: mocks.executeSendAction,
-  executePollAction: mocks.executePollAction,
-  hasCorePresentationDelivery: mocks.hasCorePresentationDelivery,
-  materializeMessagePresentationFallback: mocks.materializeMessagePresentationFallback,
-}));
-
-vi.mock("./message.gateway.runtime.js", () => ({
-  callGateway: mocks.callGateway,
-  callGatewayLeastPrivilege: mocks.callGatewayLeastPrivilege,
-  isGatewayTransportError: mocks.isGatewayTransportError,
-  randomIdempotencyKey: mocks.randomIdempotencyKey,
-}));
-
-vi.mock("./source-reply-mirror.js", () => ({
-  beginTerminalSourceReplyDelivery: mocks.beginTerminalSourceReplyDelivery,
-  cancelTerminalSourceReplyDelivery: mocks.cancelTerminalSourceReplyDelivery,
-  isCurrentSourceReplyActionName: mocks.isCurrentSourceReplyActionName,
-  isDeliveredCurrentSourceReply: mocks.isDeliveredCurrentSourceReply,
-  isDeliveredCurrentSourceReplyAction: mocks.isDeliveredCurrentSourceReplyAction,
-  reconcileTerminalSourceReplyDelivery: mocks.reconcileTerminalSourceReplyDelivery,
-}));
-
-vi.mock("../../tts/tts.runtime.js", () => ({
-  maybeApplyTtsToPayload: mocks.maybeApplyTtsToPayload,
-}));
-
-vi.mock("./outbound-session.js", () => ({
-  ensureOutboundSessionEntry: vi.fn(async () => undefined),
-  resolveOutboundSessionRoute: vi.fn(async () => null),
-}));
-
-vi.mock("../../channels/plugins/bootstrap-registry.js", () => ({
-  getBootstrapChannelPlugin: (id: string) =>
-    id === "actionhub"
-      ? {
-          actions: {
-            messageActionTargetAliases: {
-              pin: { aliases: ["messageId"] },
-              unpin: { aliases: ["messageId"] },
-              "list-pins": { aliases: ["chatId"] },
-            },
-          },
-        }
-      : undefined,
-}));
-
-vi.mock("./message-action-threading.js", async () => {
-  const { createOutboundThreadingMock } =
-    await import("./message-action-threading.test-helpers.js");
-  const threading = createOutboundThreadingMock();
-  mocks.prepareOutboundMirrorRoute.mockImplementation(threading.prepareOutboundMirrorRoute);
-  return {
-    ...threading,
-    prepareOutboundMirrorRoute: mocks.prepareOutboundMirrorRoute,
-  };
-});
-
-function setTestPlugin(plugin: unknown, pluginId: string, origin?: "bundled") {
-  setActivePluginRegistry(
-    createTestRegistry([{ pluginId, source: "test", ...(origin ? { origin } : {}), plugin }]),
-  );
-}
-
-function createAlwaysConfiguredPluginConfig(account: Record<string, unknown> = { enabled: true }) {
-  return {
-    listAccountIds: () => ["default"],
-    resolveAccount: () => account,
-    isConfigured: () => true,
-  };
-}
-
-async function executePluginAction(params: {
-  action: "send" | "poll";
-  ctx: Pick<
-    ChannelMessageActionContext,
-    | "channel"
-    | "cfg"
-    | "params"
-    | "mediaAccess"
-    | "accountId"
-    | "gateway"
-    | "toolContext"
-    | "inboundEventKind"
-  > & {
-    dryRun: boolean;
-    agentId?: string;
-  };
-}) {
-  const handled = await dispatchChannelMessageAction({
-    channel: params.ctx.channel,
-    action: params.action,
-    cfg: params.ctx.cfg,
-    params: params.ctx.params,
-    mediaAccess: params.ctx.mediaAccess,
-    mediaLocalRoots: params.ctx.mediaAccess?.localRoots ?? [],
-    mediaReadFile:
-      typeof params.ctx.mediaAccess?.readFile === "function"
-        ? params.ctx.mediaAccess.readFile
-        : undefined,
-    accountId: params.ctx.accountId ?? undefined,
-    gateway: params.ctx.gateway,
-    toolContext: params.ctx.toolContext,
-    inboundEventKind: params.ctx.inboundEventKind,
-    dryRun: params.ctx.dryRun,
-    agentId: params.ctx.agentId,
-  });
-  if (!handled) {
-    throw new Error(`expected plugin to handle ${params.action}`);
-  }
-  return {
-    handledBy: "plugin" as const,
-    payload: extractToolPayload(handled),
-    toolResult: handled,
-  };
-}
-
 describe("runMessageAction plugin dispatch", () => {
   beforeEach(() => {
-    mocks.resolveOutboundChannelPlugin.mockReset();
-    mocks.resolveOutboundChannelPlugin.mockImplementation(
-      ({ channel }: { channel: string }) =>
-        getActivePluginRegistry()?.channels.find((entry) => entry?.plugin?.id === channel)?.plugin,
-    );
-    mocks.executeSendAction.mockReset();
-    mocks.executeSendAction.mockImplementation(
-      async ({ ctx }: { ctx: Parameters<typeof executePluginAction>[0]["ctx"] }) =>
-        await executePluginAction({ action: "send", ctx }),
-    );
-    mocks.executePollAction.mockReset();
-    mocks.executePollAction.mockImplementation(
-      async ({ ctx }: { ctx: Parameters<typeof executePluginAction>[0]["ctx"] }) =>
-        await executePluginAction({ action: "poll", ctx }),
-    );
-    mocks.hasCorePresentationDelivery.mockReset();
-    mocks.hasCorePresentationDelivery.mockImplementation(
-      (outbound?: { sendPayload?: unknown; sendText?: unknown; sendFormattedText?: unknown }) =>
-        Boolean(outbound?.sendPayload || outbound?.sendText || outbound?.sendFormattedText),
-    );
-    mocks.materializeMessagePresentationFallback.mockReset();
-    mocks.materializeMessagePresentationFallback.mockImplementation(
-      (params: { payload: { presentation?: unknown; text?: string }; text?: string }) => {
-        const presentation = normalizeMessagePresentation(params.payload.presentation);
-        const text = (params.text ?? params.payload.text ?? "").trim();
-        if (!presentation) {
-          return text;
-        }
-        const fallback = renderMessagePresentationFallbackText({ presentation });
-        return !fallback || text.includes(fallback)
-          ? text
-          : [text, fallback].filter(Boolean).join("\n\n");
-      },
-    );
-    mocks.callGateway.mockReset();
-    mocks.callGatewayLeastPrivilege.mockReset();
-    mocks.isGatewayTransportError.mockReset();
-    mocks.isGatewayTransportError.mockImplementation(
-      (value: unknown) =>
-        value instanceof Error && (value as { kind?: unknown }).kind === "timeout",
-    );
-    mocks.randomIdempotencyKey.mockClear();
-    mocks.maybeApplyTtsToPayload.mockReset();
-    mocks.maybeApplyTtsToPayload.mockImplementation(
-      async (params: { payload: unknown }) => params.payload,
-    );
-    mocks.prepareOutboundMirrorRoute.mockClear();
-    mocks.beginTerminalSourceReplyDelivery.mockReset();
-    mocks.cancelTerminalSourceReplyDelivery.mockReset();
-    mocks.reconcileTerminalSourceReplyDelivery.mockReset();
+    resetMessageActionRunnerMocks();
   });
   describe("alias-based plugin action dispatch", () => {
     const handleAction = vi.fn(async ({ params }: { params: Record<string, unknown> }) =>

--- a/src/infra/outbound/message-action-execution.poll.test.ts
+++ b/src/infra/outbound/message-action-execution.poll.test.ts
@@ -1,167 +1,22 @@
 // Covers message-action poll handling through plugin dispatch and core gateway
 // poll fallback.
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
-import type { OpenClawConfig } from "../../config/config.js";
-import { getActivePluginRegistry, setActivePluginRegistry } from "../../plugins/runtime.js";
-import { createTestRegistry } from "../../test-utils/channel-plugins.js";
-import { runMessageAction } from "./message-action-runner.js";
-
-const mocks = vi.hoisted(() => ({
-  executePollAction: vi.fn(),
-  resolveOutboundChannelPlugin: vi.fn(),
-}));
-
-function firstMockArg(
-  mock: { mock: { calls: readonly unknown[][] } },
-  label: string,
-): Record<string, unknown> {
-  const [call] = mock.mock.calls;
-  if (!call) {
-    throw new Error(`expected ${label} call`);
-  }
-  const [arg] = call;
-  if (typeof arg !== "object" || arg === null || Array.isArray(arg)) {
-    throw new Error(`expected ${label} params to be an object`);
-  }
-  return arg as Record<string, unknown>;
-}
-
-vi.mock("./channel-resolution.js", () => ({
-  normalizeDeliverableOutboundChannel: (value?: string | null) =>
-    typeof value === "string" ? value.trim().toLowerCase() || undefined : undefined,
-  resolveOutboundChannelPlugin: mocks.resolveOutboundChannelPlugin,
-  resetOutboundChannelResolutionStateForTest: vi.fn(),
-}));
-
-vi.mock("./outbound-send-service.js", () => ({
-  executeSendAction: vi.fn(async () => {
-    throw new Error("executeSendAction should not run in poll tests");
-  }),
-  executePollAction: mocks.executePollAction,
-}));
-
-vi.mock("./outbound-session.js", () => ({
-  ensureOutboundSessionEntry: vi.fn(async () => undefined),
-  resolveOutboundSessionRoute: vi.fn(async () => null),
-}));
-
-vi.mock("./message-action-threading.js", async () => {
-  const { createOutboundThreadingMock } =
-    await import("./message-action-threading.test-helpers.js");
-  return createOutboundThreadingMock();
-});
-const pollerConfig = {
-  channels: {
-    poller: {
-      botToken: "poller-test",
-    },
-  },
-} as OpenClawConfig;
-
-const pollerTestPlugin: ChannelPlugin = {
-  id: "poller",
-  meta: {
-    id: "poller",
-    label: "Poller",
-    selectionLabel: "Poller",
-    docsPath: "/channels/poller",
-    blurb: "Poller test plugin.",
-  },
-  capabilities: { chatTypes: ["direct", "group"] },
-  config: {
-    listAccountIds: () => ["default"],
-    resolveAccount: () => ({ botToken: "poller-test" }),
-    isConfigured: () => true,
-  },
-  outbound: {
-    deliveryMode: "gateway",
-    sendPoll: async () => ({
-      messageId: "poll-test",
-    }),
-  },
-  messaging: {
-    targetResolver: {
-      looksLikeId: () => true,
-      resolveTarget: async ({ normalized }) => ({
-        to: normalized,
-        kind: "user",
-        source: "normalized",
-      }),
-    },
-  },
-  threading: {
-    resolveAutoThreadId: ({ toolContext, to, replyToId }) => {
-      if (replyToId) {
-        return undefined;
-      }
-      if (toolContext?.currentChannelId !== to) {
-        return undefined;
-      }
-      return toolContext.currentThreadTs;
-    },
-  },
-};
-
-async function runPollAction(params: {
-  cfg: OpenClawConfig;
-  actionParams: Record<string, unknown>;
-  toolContext?: Record<string, unknown>;
-  inboundEventKind?: "user_request" | "room_event";
-}) {
-  await runMessageAction({
-    cfg: params.cfg,
-    action: "poll",
-    params: params.actionParams as never,
-    toolContext: params.toolContext as never,
-    inboundEventKind: params.inboundEventKind,
-  });
-  const call = firstMockArg(mocks.executePollAction, "executePollAction") as {
-    resolveCorePoll?: () => {
-      durationHours?: number;
-      maxSelections?: number;
-      threadId?: string;
-    };
-    ctx?: {
-      plugin?: ChannelPlugin;
-      inboundEventKind?: string;
-      idempotencyKey?: string;
-      params?: Record<string, unknown>;
-    };
-  };
-  return {
-    ...call.resolveCorePoll?.(),
-    ctx: call.ctx,
-  };
-}
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearMessageActionPollMocks,
+  messageActionRunnerMocks as mocks,
+  pollerConfig,
+  pollerTestPlugin,
+  resetMessageActionPollMocks,
+  runPollAction,
+} from "./message-action-runner.test-helpers.js";
 
 describe("runMessageAction poll handling", () => {
   beforeEach(() => {
-    setActivePluginRegistry(
-      createTestRegistry([
-        {
-          pluginId: "poller",
-          source: "test",
-          plugin: pollerTestPlugin,
-        },
-      ]),
-    );
-    mocks.resolveOutboundChannelPlugin.mockReset();
-    mocks.resolveOutboundChannelPlugin.mockImplementation(
-      ({ channel }: { channel: string }) =>
-        getActivePluginRegistry()?.channels.find((entry) => entry?.plugin?.id === channel)?.plugin,
-    );
-    mocks.executePollAction.mockReset();
-    mocks.executePollAction.mockImplementation(async (input) => ({
-      handledBy: "core",
-      payload: { ok: true, corePoll: input.resolveCorePoll() },
-      pollResult: { ok: true },
-    }));
+    resetMessageActionPollMocks();
   });
 
   afterEach(() => {
-    setActivePluginRegistry(createTestRegistry([]));
-    mocks.executePollAction.mockReset();
+    clearMessageActionPollMocks();
   });
   it("passes shared poll fields and auto threadId to executePollAction", async () => {
     const call = await runPollAction({

--- a/src/infra/outbound/message-action-execution.reply-action.test.ts
+++ b/src/infra/outbound/message-action-execution.reply-action.test.ts
@@ -1,120 +1,13 @@
 // Covers reply-type plugin actions: outbound text hygiene (citation control
 // markers) and current-source delivery marking for implicit reply routes.
-import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
-import type { OpenClawConfig } from "../../config/config.js";
+import { afterEach, describe, expect, it } from "vitest";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
-import { runMessageAction } from "./message-action-runner.js";
-
-type ChannelActionHandler = NonNullable<NonNullable<ChannelPlugin["actions"]>["handleAction"]>;
-
-const testchatConfig = {
-  channels: {
-    testchat: {
-      enabled: true,
-    },
-  },
-} as OpenClawConfig;
-
-function createReplyActionPlugin(handleAction: ChannelActionHandler): ChannelPlugin {
-  return {
-    id: "testchat",
-    meta: {
-      id: "testchat",
-      label: "Test Chat",
-      selectionLabel: "Test Chat",
-      docsPath: "/channels/testchat",
-      blurb: "Reply action test plugin.",
-    },
-    capabilities: { chatTypes: ["direct"] },
-    config: {
-      listAccountIds: () => ["default"],
-      resolveAccount: () => ({ enabled: true }),
-      isConfigured: () => true,
-    },
-    outbound: {
-      deliveryMode: "direct",
-      sendText: async () => ({ channel: "testchat", messageId: "m-send-1" }),
-    },
-    messaging: {
-      targetResolver: {
-        looksLikeId: () => true,
-      },
-    },
-    actions: {
-      describeMessageTool: () => ({ actions: ["reply", "poll"] }),
-      supportsAction: ({ action }) => action === "reply" || action === "poll",
-      handleAction,
-    },
-  };
-}
-
-function registerReplyPlugin() {
-  const payload = { ok: true, messageId: "m-reply-1", repliedTo: "platform-guid-1" };
-  const handleAction = vi.fn(async () => ({
-    content: [{ type: "text" as const, text: JSON.stringify(payload) }],
-    details: payload,
-  }));
-  setActivePluginRegistry(
-    createTestRegistry([
-      { pluginId: "testchat", source: "test", plugin: createReplyActionPlugin(handleAction) },
-    ]),
-  );
-  return handleAction;
-}
-
-async function runReplyAction(params: {
-  actionParams: Record<string, unknown>;
-  currentMessageId?: string | number;
-}) {
-  const toolContext = {
-    currentChannelProvider: "testchat" as const,
-    currentChannelId: "direct:user-1",
-    ...(params.currentMessageId !== undefined ? { currentMessageId: params.currentMessageId } : {}),
-  };
-  return await runMessageAction({
-    cfg: testchatConfig,
-    action: "reply",
-    params: { channel: "testchat", ...params.actionParams },
-    toolContext,
-    messageActionAuthorization: {
-      requesterAccountId: "default",
-      toolContext,
-    },
-    sessionKey: "agent:main:testchat:direct:user-1",
-    defaultAccountId: "default",
-    sourceReplyDeliveryMode: "message_tool_only",
-    dryRun: false,
-  });
-}
-
-async function runPollAction(params: { to: string }) {
-  const toolContext = {
-    currentChannelProvider: "testchat" as const,
-    currentChannelId: "direct:user-1",
-    currentMessageId: "1783",
-  };
-  return await runMessageAction({
-    cfg: testchatConfig,
-    action: "poll",
-    params: {
-      channel: "testchat",
-      to: params.to,
-      pollQuestion: "Preferred default?",
-      pollOption: ["Tell me right away", "Only important"],
-    },
-    toolContext,
-    messageActionAuthorization: {
-      requesterAccountId: "default",
-      toolContext,
-    },
-    sessionKey: "agent:main:testchat:direct:user-1",
-    defaultAccountId: "default",
-    sourceReplyDeliveryMode: "message_tool_only",
-    dryRun: false,
-  });
-}
+import {
+  registerReplyPlugin,
+  runCurrentConversationPollAction as runPollAction,
+  runReplyAction,
+} from "./message-action-test-fixtures.js";
 
 describe("runMessageAction reply-type plugin actions", () => {
   afterEach(() => {

--- a/src/infra/outbound/message-action-execution.test.ts
+++ b/src/infra/outbound/message-action-execution.test.ts
@@ -4,24 +4,20 @@ import path from "node:path";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { jsonResult } from "../../agents/tools/common.js";
-import { dispatchChannelMessageAction } from "../../channels/plugins/message-action-dispatch.js";
-import type {
-  ChannelMessageActionContext,
-  ChannelMessageActionName,
-  ChannelPlugin,
-} from "../../channels/plugins/types.public.js";
+import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import {
-  normalizeMessagePresentation,
-  renderMessagePresentationFallbackText,
-} from "../../interactive/payload.js";
-import { extractToolPayload } from "../../plugin-sdk/tool-payload.js";
-import { getActivePluginRegistry, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { withEnvAsync } from "../../test-utils/env.js";
-import { runMessageAction } from "./message-action-runner.js";
-
-type ChannelActionHandler = NonNullable<NonNullable<ChannelPlugin["actions"]>["handleAction"]>;
+import {
+  createAlwaysConfiguredPluginConfig,
+  createGatewayActionPlugin,
+  createPollForwardingPlugin,
+  messageActionRunnerMocks as mocks,
+  resetMessageActionRunnerMocks,
+  runMessageAction,
+  setMessageActionTestPlugin as setTestPlugin,
+} from "./message-action-runner.test-helpers.js";
 
 const requireRecord = createRequireRecord("record", "expected-non-array-record");
 const requireLabeledRecord = createRequireRecord("record", "expected-label");
@@ -71,267 +67,9 @@ function expectRecordFields(
   }
 }
 
-const mocks = vi.hoisted(() => ({
-  resolveOutboundChannelPlugin: vi.fn(),
-  executeSendAction: vi.fn(),
-  executePollAction: vi.fn(),
-  hasCorePresentationDelivery: vi.fn(),
-  materializeMessagePresentationFallback: vi.fn(),
-  callGateway: vi.fn(),
-  callGatewayLeastPrivilege: vi.fn(),
-  isGatewayTransportError: vi.fn(),
-  randomIdempotencyKey: vi.fn(() => "idem-gateway-action"),
-  maybeApplyTtsToPayload: vi.fn(async (params: { payload: unknown }) => params.payload),
-  prepareOutboundMirrorRoute: vi.fn(),
-  beginTerminalSourceReplyDelivery: vi.fn(),
-  cancelTerminalSourceReplyDelivery: vi.fn(),
-  isCurrentSourceReplyActionName: vi.fn(() => false),
-  isDeliveredCurrentSourceReply: vi.fn(() => false),
-  isDeliveredCurrentSourceReplyAction: vi.fn(() => false),
-  reconcileTerminalSourceReplyDelivery: vi.fn(),
-}));
-
-vi.mock("./channel-resolution.js", () => ({
-  normalizeDeliverableOutboundChannel: (value?: string | null) =>
-    typeof value === "string" ? value.trim().toLowerCase() || undefined : undefined,
-  resolveOutboundChannelPlugin: mocks.resolveOutboundChannelPlugin,
-  resetOutboundChannelResolutionStateForTest: vi.fn(),
-}));
-
-vi.mock("./outbound-send-service.js", () => ({
-  executeSendAction: mocks.executeSendAction,
-  executePollAction: mocks.executePollAction,
-  hasCorePresentationDelivery: mocks.hasCorePresentationDelivery,
-  materializeMessagePresentationFallback: mocks.materializeMessagePresentationFallback,
-}));
-
-vi.mock("./message.gateway.runtime.js", () => ({
-  callGateway: mocks.callGateway,
-  callGatewayLeastPrivilege: mocks.callGatewayLeastPrivilege,
-  isGatewayTransportError: mocks.isGatewayTransportError,
-  randomIdempotencyKey: mocks.randomIdempotencyKey,
-}));
-
-vi.mock("./source-reply-mirror.js", () => ({
-  beginTerminalSourceReplyDelivery: mocks.beginTerminalSourceReplyDelivery,
-  cancelTerminalSourceReplyDelivery: mocks.cancelTerminalSourceReplyDelivery,
-  isCurrentSourceReplyActionName: mocks.isCurrentSourceReplyActionName,
-  isDeliveredCurrentSourceReply: mocks.isDeliveredCurrentSourceReply,
-  isDeliveredCurrentSourceReplyAction: mocks.isDeliveredCurrentSourceReplyAction,
-  reconcileTerminalSourceReplyDelivery: mocks.reconcileTerminalSourceReplyDelivery,
-}));
-
-vi.mock("../../tts/tts.runtime.js", () => ({
-  maybeApplyTtsToPayload: mocks.maybeApplyTtsToPayload,
-}));
-
-vi.mock("./outbound-session.js", () => ({
-  ensureOutboundSessionEntry: vi.fn(async () => undefined),
-  resolveOutboundSessionRoute: vi.fn(async () => null),
-}));
-
-vi.mock("../../channels/plugins/bootstrap-registry.js", () => ({
-  getBootstrapChannelPlugin: (id: string) =>
-    id === "actionhub"
-      ? {
-          actions: {
-            messageActionTargetAliases: {
-              pin: { aliases: ["messageId"] },
-              unpin: { aliases: ["messageId"] },
-              "list-pins": { aliases: ["chatId"] },
-            },
-          },
-        }
-      : undefined,
-}));
-
-vi.mock("./message-action-threading.js", async () => {
-  const { createOutboundThreadingMock } =
-    await import("./message-action-threading.test-helpers.js");
-  const threading = createOutboundThreadingMock();
-  mocks.prepareOutboundMirrorRoute.mockImplementation(threading.prepareOutboundMirrorRoute);
-  return {
-    ...threading,
-    prepareOutboundMirrorRoute: mocks.prepareOutboundMirrorRoute,
-  };
-});
-
-function setTestPlugin(plugin: unknown, pluginId: string, origin?: "bundled") {
-  setActivePluginRegistry(
-    createTestRegistry([{ pluginId, source: "test", ...(origin ? { origin } : {}), plugin }]),
-  );
-}
-
-function createAlwaysConfiguredPluginConfig(account: Record<string, unknown> = { enabled: true }) {
-  return {
-    listAccountIds: () => ["default"],
-    resolveAccount: () => account,
-    isConfigured: () => true,
-  };
-}
-
-function createPollForwardingPlugin(params: {
-  pluginId: string;
-  label: string;
-  blurb: string;
-  handleAction: ChannelActionHandler;
-}): ChannelPlugin {
-  return {
-    id: params.pluginId,
-    meta: {
-      id: params.pluginId,
-      label: params.label,
-      selectionLabel: params.label,
-      docsPath: `/channels/${params.pluginId}`,
-      blurb: params.blurb,
-    },
-    capabilities: { chatTypes: ["direct"] },
-    config: createAlwaysConfiguredPluginConfig(),
-    messaging: {
-      targetResolver: {
-        looksLikeId: () => true,
-      },
-    },
-    actions: {
-      describeMessageTool: () => ({ actions: ["poll"] }),
-      supportsAction: ({ action }) => action === "poll",
-      handleAction: params.handleAction,
-    },
-  };
-}
-
-function createGatewayActionPlugin(params: {
-  pluginId: string;
-  label: string;
-  blurb: string;
-  actions: ChannelMessageActionName[];
-  gatewayActions?: ChannelMessageActionName[];
-  capabilities?: ChannelPlugin["capabilities"];
-  messaging?: ChannelPlugin["messaging"];
-  threading?: ChannelPlugin["threading"];
-  handleAction: ChannelActionHandler;
-}): ChannelPlugin {
-  const actions = new Set(params.actions);
-  const gatewayActions = new Set(params.gatewayActions ?? params.actions);
-  return {
-    id: params.pluginId,
-    meta: {
-      id: params.pluginId,
-      label: params.label,
-      selectionLabel: params.label,
-      docsPath: `/channels/${params.pluginId}`,
-      blurb: params.blurb,
-    },
-    capabilities: params.capabilities ?? { chatTypes: ["direct"] },
-    config: createAlwaysConfiguredPluginConfig(),
-    messaging: params.messaging,
-    threading: params.threading,
-    actions: {
-      describeMessageTool: () => ({ actions: params.actions }),
-      supportsAction: ({ action }) => actions.has(action),
-      resolveExecutionMode: ({ action }) => (gatewayActions.has(action) ? "gateway" : "local"),
-      handleAction: params.handleAction,
-    },
-  };
-}
-
-async function executePluginAction(params: {
-  action: "send" | "poll";
-  ctx: Pick<
-    ChannelMessageActionContext,
-    | "channel"
-    | "cfg"
-    | "params"
-    | "mediaAccess"
-    | "accountId"
-    | "gateway"
-    | "toolContext"
-    | "inboundEventKind"
-  > & {
-    dryRun: boolean;
-    agentId?: string;
-  };
-}) {
-  const handled = await dispatchChannelMessageAction({
-    channel: params.ctx.channel,
-    action: params.action,
-    cfg: params.ctx.cfg,
-    params: params.ctx.params,
-    mediaAccess: params.ctx.mediaAccess,
-    mediaLocalRoots: params.ctx.mediaAccess?.localRoots ?? [],
-    mediaReadFile:
-      typeof params.ctx.mediaAccess?.readFile === "function"
-        ? params.ctx.mediaAccess.readFile
-        : undefined,
-    accountId: params.ctx.accountId ?? undefined,
-    gateway: params.ctx.gateway,
-    toolContext: params.ctx.toolContext,
-    inboundEventKind: params.ctx.inboundEventKind,
-    dryRun: params.ctx.dryRun,
-    agentId: params.ctx.agentId,
-  });
-  if (!handled) {
-    throw new Error(`expected plugin to handle ${params.action}`);
-  }
-  return {
-    handledBy: "plugin" as const,
-    payload: extractToolPayload(handled),
-    toolResult: handled,
-  };
-}
-
 describe("runMessageAction plugin dispatch", () => {
   beforeEach(() => {
-    mocks.resolveOutboundChannelPlugin.mockReset();
-    mocks.resolveOutboundChannelPlugin.mockImplementation(
-      ({ channel }: { channel: string }) =>
-        getActivePluginRegistry()?.channels.find((entry) => entry?.plugin?.id === channel)?.plugin,
-    );
-    mocks.executeSendAction.mockReset();
-    mocks.executeSendAction.mockImplementation(
-      async ({ ctx }: { ctx: Parameters<typeof executePluginAction>[0]["ctx"] }) =>
-        await executePluginAction({ action: "send", ctx }),
-    );
-    mocks.executePollAction.mockReset();
-    mocks.executePollAction.mockImplementation(
-      async ({ ctx }: { ctx: Parameters<typeof executePluginAction>[0]["ctx"] }) =>
-        await executePluginAction({ action: "poll", ctx }),
-    );
-    mocks.hasCorePresentationDelivery.mockReset();
-    mocks.hasCorePresentationDelivery.mockImplementation(
-      (outbound?: { sendPayload?: unknown; sendText?: unknown; sendFormattedText?: unknown }) =>
-        Boolean(outbound?.sendPayload || outbound?.sendText || outbound?.sendFormattedText),
-    );
-    mocks.materializeMessagePresentationFallback.mockReset();
-    mocks.materializeMessagePresentationFallback.mockImplementation(
-      (params: { payload: { presentation?: unknown; text?: string }; text?: string }) => {
-        const presentation = normalizeMessagePresentation(params.payload.presentation);
-        const text = (params.text ?? params.payload.text ?? "").trim();
-        if (!presentation) {
-          return text;
-        }
-        const fallback = renderMessagePresentationFallbackText({ presentation });
-        return !fallback || text.includes(fallback)
-          ? text
-          : [text, fallback].filter(Boolean).join("\n\n");
-      },
-    );
-    mocks.callGateway.mockReset();
-    mocks.callGatewayLeastPrivilege.mockReset();
-    mocks.isGatewayTransportError.mockReset();
-    mocks.isGatewayTransportError.mockImplementation(
-      (value: unknown) =>
-        value instanceof Error && (value as { kind?: unknown }).kind === "timeout",
-    );
-    mocks.randomIdempotencyKey.mockClear();
-    mocks.maybeApplyTtsToPayload.mockReset();
-    mocks.maybeApplyTtsToPayload.mockImplementation(
-      async (params: { payload: unknown }) => params.payload,
-    );
-    mocks.prepareOutboundMirrorRoute.mockClear();
-    mocks.beginTerminalSourceReplyDelivery.mockReset();
-    mocks.cancelTerminalSourceReplyDelivery.mockReset();
-    mocks.reconcileTerminalSourceReplyDelivery.mockReset();
+    resetMessageActionRunnerMocks();
   });
   describe("alias-based plugin action dispatch", () => {
     const handleAction = vi.fn(async ({ params }: { params: Record<string, unknown> }) =>

--- a/src/infra/outbound/message-action-gateway-reconciliation.test.ts
+++ b/src/infra/outbound/message-action-gateway-reconciliation.test.ts
@@ -3,24 +3,19 @@
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { jsonResult } from "../../agents/tools/common.js";
-import { dispatchChannelMessageAction } from "../../channels/plugins/message-action-dispatch.js";
-import type {
-  ChannelMessageActionContext,
-  ChannelMessageActionName,
-  ChannelPlugin,
-} from "../../channels/plugins/types.public.js";
+import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import {
-  normalizeMessagePresentation,
-  renderMessagePresentationFallbackText,
-} from "../../interactive/payload.js";
-import { extractToolPayload } from "../../plugin-sdk/tool-payload.js";
-import { getActivePluginRegistry, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
-import { runMessageAction } from "./message-action-runner.js";
-
-type ChannelActionHandler = NonNullable<NonNullable<ChannelPlugin["actions"]>["handleAction"]>;
+import {
+  createAlwaysConfiguredPluginConfig,
+  createGatewayActionPlugin,
+  messageActionRunnerMocks as mocks,
+  resetMessageActionRunnerMocks,
+  runMessageAction,
+  setMessageActionTestPlugin as setTestPlugin,
+} from "./message-action-runner.test-helpers.js";
 
 const requireLabeledRecord = createRequireRecord("record", "expected-label");
 
@@ -50,237 +45,9 @@ function expectRecordFields(
   }
 }
 
-const mocks = vi.hoisted(() => ({
-  resolveOutboundChannelPlugin: vi.fn(),
-  executeSendAction: vi.fn(),
-  executePollAction: vi.fn(),
-  hasCorePresentationDelivery: vi.fn(),
-  materializeMessagePresentationFallback: vi.fn(),
-  callGateway: vi.fn(),
-  callGatewayLeastPrivilege: vi.fn(),
-  isGatewayTransportError: vi.fn(),
-  randomIdempotencyKey: vi.fn(() => "idem-gateway-action"),
-  maybeApplyTtsToPayload: vi.fn(async (params: { payload: unknown }) => params.payload),
-  prepareOutboundMirrorRoute: vi.fn(),
-  beginTerminalSourceReplyDelivery: vi.fn(),
-  cancelTerminalSourceReplyDelivery: vi.fn(),
-  isCurrentSourceReplyActionName: vi.fn(() => false),
-  isDeliveredCurrentSourceReply: vi.fn(() => false),
-  isDeliveredCurrentSourceReplyAction: vi.fn(() => false),
-  reconcileTerminalSourceReplyDelivery: vi.fn(),
-}));
-
-vi.mock("./channel-resolution.js", () => ({
-  normalizeDeliverableOutboundChannel: (value?: string | null) =>
-    typeof value === "string" ? value.trim().toLowerCase() || undefined : undefined,
-  resolveOutboundChannelPlugin: mocks.resolveOutboundChannelPlugin,
-  resetOutboundChannelResolutionStateForTest: vi.fn(),
-}));
-
-vi.mock("./outbound-send-service.js", () => ({
-  executeSendAction: mocks.executeSendAction,
-  executePollAction: mocks.executePollAction,
-  hasCorePresentationDelivery: mocks.hasCorePresentationDelivery,
-  materializeMessagePresentationFallback: mocks.materializeMessagePresentationFallback,
-}));
-
-vi.mock("./message.gateway.runtime.js", () => ({
-  callGateway: mocks.callGateway,
-  callGatewayLeastPrivilege: mocks.callGatewayLeastPrivilege,
-  isGatewayTransportError: mocks.isGatewayTransportError,
-  randomIdempotencyKey: mocks.randomIdempotencyKey,
-}));
-
-vi.mock("./source-reply-mirror.js", () => ({
-  beginTerminalSourceReplyDelivery: mocks.beginTerminalSourceReplyDelivery,
-  cancelTerminalSourceReplyDelivery: mocks.cancelTerminalSourceReplyDelivery,
-  isCurrentSourceReplyActionName: mocks.isCurrentSourceReplyActionName,
-  isDeliveredCurrentSourceReply: mocks.isDeliveredCurrentSourceReply,
-  isDeliveredCurrentSourceReplyAction: mocks.isDeliveredCurrentSourceReplyAction,
-  reconcileTerminalSourceReplyDelivery: mocks.reconcileTerminalSourceReplyDelivery,
-}));
-
-vi.mock("../../tts/tts.runtime.js", () => ({
-  maybeApplyTtsToPayload: mocks.maybeApplyTtsToPayload,
-}));
-
-vi.mock("./outbound-session.js", () => ({
-  ensureOutboundSessionEntry: vi.fn(async () => undefined),
-  resolveOutboundSessionRoute: vi.fn(async () => null),
-}));
-
-vi.mock("../../channels/plugins/bootstrap-registry.js", () => ({
-  getBootstrapChannelPlugin: (id: string) =>
-    id === "actionhub"
-      ? {
-          actions: {
-            messageActionTargetAliases: {
-              pin: { aliases: ["messageId"] },
-              unpin: { aliases: ["messageId"] },
-              "list-pins": { aliases: ["chatId"] },
-            },
-          },
-        }
-      : undefined,
-}));
-
-vi.mock("./message-action-threading.js", async () => {
-  const { createOutboundThreadingMock } =
-    await import("./message-action-threading.test-helpers.js");
-  const threading = createOutboundThreadingMock();
-  mocks.prepareOutboundMirrorRoute.mockImplementation(threading.prepareOutboundMirrorRoute);
-  return {
-    ...threading,
-    prepareOutboundMirrorRoute: mocks.prepareOutboundMirrorRoute,
-  };
-});
-
-function setTestPlugin(plugin: unknown, pluginId: string, origin?: "bundled") {
-  setActivePluginRegistry(
-    createTestRegistry([{ pluginId, source: "test", ...(origin ? { origin } : {}), plugin }]),
-  );
-}
-
-function createAlwaysConfiguredPluginConfig(account: Record<string, unknown> = { enabled: true }) {
-  return {
-    listAccountIds: () => ["default"],
-    resolveAccount: () => account,
-    isConfigured: () => true,
-  };
-}
-
-function createGatewayActionPlugin(params: {
-  pluginId: string;
-  label: string;
-  blurb: string;
-  actions: ChannelMessageActionName[];
-  gatewayActions?: ChannelMessageActionName[];
-  capabilities?: ChannelPlugin["capabilities"];
-  messaging?: ChannelPlugin["messaging"];
-  threading?: ChannelPlugin["threading"];
-  handleAction: ChannelActionHandler;
-}): ChannelPlugin {
-  const actions = new Set(params.actions);
-  const gatewayActions = new Set(params.gatewayActions ?? params.actions);
-  return {
-    id: params.pluginId,
-    meta: {
-      id: params.pluginId,
-      label: params.label,
-      selectionLabel: params.label,
-      docsPath: `/channels/${params.pluginId}`,
-      blurb: params.blurb,
-    },
-    capabilities: params.capabilities ?? { chatTypes: ["direct"] },
-    config: createAlwaysConfiguredPluginConfig(),
-    messaging: params.messaging,
-    threading: params.threading,
-    actions: {
-      describeMessageTool: () => ({ actions: params.actions }),
-      supportsAction: ({ action }) => actions.has(action),
-      resolveExecutionMode: ({ action }) => (gatewayActions.has(action) ? "gateway" : "local"),
-      handleAction: params.handleAction,
-    },
-  };
-}
-
-async function executePluginAction(params: {
-  action: "send" | "poll";
-  ctx: Pick<
-    ChannelMessageActionContext,
-    | "channel"
-    | "cfg"
-    | "params"
-    | "mediaAccess"
-    | "accountId"
-    | "gateway"
-    | "toolContext"
-    | "inboundEventKind"
-  > & {
-    dryRun: boolean;
-    agentId?: string;
-  };
-}) {
-  const handled = await dispatchChannelMessageAction({
-    channel: params.ctx.channel,
-    action: params.action,
-    cfg: params.ctx.cfg,
-    params: params.ctx.params,
-    mediaAccess: params.ctx.mediaAccess,
-    mediaLocalRoots: params.ctx.mediaAccess?.localRoots ?? [],
-    mediaReadFile:
-      typeof params.ctx.mediaAccess?.readFile === "function"
-        ? params.ctx.mediaAccess.readFile
-        : undefined,
-    accountId: params.ctx.accountId ?? undefined,
-    gateway: params.ctx.gateway,
-    toolContext: params.ctx.toolContext,
-    inboundEventKind: params.ctx.inboundEventKind,
-    dryRun: params.ctx.dryRun,
-    agentId: params.ctx.agentId,
-  });
-  if (!handled) {
-    throw new Error(`expected plugin to handle ${params.action}`);
-  }
-  return {
-    handledBy: "plugin" as const,
-    payload: extractToolPayload(handled),
-    toolResult: handled,
-  };
-}
-
 describe("runMessageAction plugin dispatch", () => {
   beforeEach(() => {
-    mocks.resolveOutboundChannelPlugin.mockReset();
-    mocks.resolveOutboundChannelPlugin.mockImplementation(
-      ({ channel }: { channel: string }) =>
-        getActivePluginRegistry()?.channels.find((entry) => entry?.plugin?.id === channel)?.plugin,
-    );
-    mocks.executeSendAction.mockReset();
-    mocks.executeSendAction.mockImplementation(
-      async ({ ctx }: { ctx: Parameters<typeof executePluginAction>[0]["ctx"] }) =>
-        await executePluginAction({ action: "send", ctx }),
-    );
-    mocks.executePollAction.mockReset();
-    mocks.executePollAction.mockImplementation(
-      async ({ ctx }: { ctx: Parameters<typeof executePluginAction>[0]["ctx"] }) =>
-        await executePluginAction({ action: "poll", ctx }),
-    );
-    mocks.hasCorePresentationDelivery.mockReset();
-    mocks.hasCorePresentationDelivery.mockImplementation(
-      (outbound?: { sendPayload?: unknown; sendText?: unknown; sendFormattedText?: unknown }) =>
-        Boolean(outbound?.sendPayload || outbound?.sendText || outbound?.sendFormattedText),
-    );
-    mocks.materializeMessagePresentationFallback.mockReset();
-    mocks.materializeMessagePresentationFallback.mockImplementation(
-      (params: { payload: { presentation?: unknown; text?: string }; text?: string }) => {
-        const presentation = normalizeMessagePresentation(params.payload.presentation);
-        const text = (params.text ?? params.payload.text ?? "").trim();
-        if (!presentation) {
-          return text;
-        }
-        const fallback = renderMessagePresentationFallbackText({ presentation });
-        return !fallback || text.includes(fallback)
-          ? text
-          : [text, fallback].filter(Boolean).join("\n\n");
-      },
-    );
-    mocks.callGateway.mockReset();
-    mocks.callGatewayLeastPrivilege.mockReset();
-    mocks.isGatewayTransportError.mockReset();
-    mocks.isGatewayTransportError.mockImplementation(
-      (value: unknown) =>
-        value instanceof Error && (value as { kind?: unknown }).kind === "timeout",
-    );
-    mocks.randomIdempotencyKey.mockClear();
-    mocks.maybeApplyTtsToPayload.mockReset();
-    mocks.maybeApplyTtsToPayload.mockImplementation(
-      async (params: { payload: unknown }) => params.payload,
-    );
-    mocks.prepareOutboundMirrorRoute.mockClear();
-    mocks.beginTerminalSourceReplyDelivery.mockReset();
-    mocks.cancelTerminalSourceReplyDelivery.mockReset();
-    mocks.reconcileTerminalSourceReplyDelivery.mockReset();
+    resetMessageActionRunnerMocks();
   });
   describe("alias-based plugin action dispatch", () => {
     const handleAction = vi.fn(async ({ params }: { params: Record<string, unknown> }) =>

--- a/src/infra/outbound/message-action-gateway.test.ts
+++ b/src/infra/outbound/message-action-gateway.test.ts
@@ -3,24 +3,20 @@
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { jsonResult } from "../../agents/tools/common.js";
-import { dispatchChannelMessageAction } from "../../channels/plugins/message-action-dispatch.js";
-import type {
-  ChannelMessageActionContext,
-  ChannelMessageActionName,
-  ChannelPlugin,
-} from "../../channels/plugins/types.public.js";
+import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import {
-  normalizeMessagePresentation,
-  renderMessagePresentationFallbackText,
-} from "../../interactive/payload.js";
-import { extractToolPayload } from "../../plugin-sdk/tool-payload.js";
-import { getActivePluginRegistry, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
-import { runMessageAction } from "./message-action-runner.js";
-
-type ChannelActionHandler = NonNullable<NonNullable<ChannelPlugin["actions"]>["handleAction"]>;
+import {
+  createAlwaysConfiguredPluginConfig,
+  createGatewayActionPlugin,
+  createPollForwardingPlugin,
+  messageActionRunnerMocks as mocks,
+  resetMessageActionRunnerMocks,
+  runMessageAction,
+  setMessageActionTestPlugin as setTestPlugin,
+} from "./message-action-runner.test-helpers.js";
 
 const requireLabeledRecord = createRequireRecord("record", "expected-label");
 
@@ -50,267 +46,9 @@ function expectRecordFields(
   }
 }
 
-const mocks = vi.hoisted(() => ({
-  resolveOutboundChannelPlugin: vi.fn(),
-  executeSendAction: vi.fn(),
-  executePollAction: vi.fn(),
-  hasCorePresentationDelivery: vi.fn(),
-  materializeMessagePresentationFallback: vi.fn(),
-  callGateway: vi.fn(),
-  callGatewayLeastPrivilege: vi.fn(),
-  isGatewayTransportError: vi.fn(),
-  randomIdempotencyKey: vi.fn(() => "idem-gateway-action"),
-  maybeApplyTtsToPayload: vi.fn(async (params: { payload: unknown }) => params.payload),
-  prepareOutboundMirrorRoute: vi.fn(),
-  beginTerminalSourceReplyDelivery: vi.fn(),
-  cancelTerminalSourceReplyDelivery: vi.fn(),
-  isCurrentSourceReplyActionName: vi.fn(() => false),
-  isDeliveredCurrentSourceReply: vi.fn(() => false),
-  isDeliveredCurrentSourceReplyAction: vi.fn(() => false),
-  reconcileTerminalSourceReplyDelivery: vi.fn(),
-}));
-
-vi.mock("./channel-resolution.js", () => ({
-  normalizeDeliverableOutboundChannel: (value?: string | null) =>
-    typeof value === "string" ? value.trim().toLowerCase() || undefined : undefined,
-  resolveOutboundChannelPlugin: mocks.resolveOutboundChannelPlugin,
-  resetOutboundChannelResolutionStateForTest: vi.fn(),
-}));
-
-vi.mock("./outbound-send-service.js", () => ({
-  executeSendAction: mocks.executeSendAction,
-  executePollAction: mocks.executePollAction,
-  hasCorePresentationDelivery: mocks.hasCorePresentationDelivery,
-  materializeMessagePresentationFallback: mocks.materializeMessagePresentationFallback,
-}));
-
-vi.mock("./message.gateway.runtime.js", () => ({
-  callGateway: mocks.callGateway,
-  callGatewayLeastPrivilege: mocks.callGatewayLeastPrivilege,
-  isGatewayTransportError: mocks.isGatewayTransportError,
-  randomIdempotencyKey: mocks.randomIdempotencyKey,
-}));
-
-vi.mock("./source-reply-mirror.js", () => ({
-  beginTerminalSourceReplyDelivery: mocks.beginTerminalSourceReplyDelivery,
-  cancelTerminalSourceReplyDelivery: mocks.cancelTerminalSourceReplyDelivery,
-  isCurrentSourceReplyActionName: mocks.isCurrentSourceReplyActionName,
-  isDeliveredCurrentSourceReply: mocks.isDeliveredCurrentSourceReply,
-  isDeliveredCurrentSourceReplyAction: mocks.isDeliveredCurrentSourceReplyAction,
-  reconcileTerminalSourceReplyDelivery: mocks.reconcileTerminalSourceReplyDelivery,
-}));
-
-vi.mock("../../tts/tts.runtime.js", () => ({
-  maybeApplyTtsToPayload: mocks.maybeApplyTtsToPayload,
-}));
-
-vi.mock("./outbound-session.js", () => ({
-  ensureOutboundSessionEntry: vi.fn(async () => undefined),
-  resolveOutboundSessionRoute: vi.fn(async () => null),
-}));
-
-vi.mock("../../channels/plugins/bootstrap-registry.js", () => ({
-  getBootstrapChannelPlugin: (id: string) =>
-    id === "actionhub"
-      ? {
-          actions: {
-            messageActionTargetAliases: {
-              pin: { aliases: ["messageId"] },
-              unpin: { aliases: ["messageId"] },
-              "list-pins": { aliases: ["chatId"] },
-            },
-          },
-        }
-      : undefined,
-}));
-
-vi.mock("./message-action-threading.js", async () => {
-  const { createOutboundThreadingMock } =
-    await import("./message-action-threading.test-helpers.js");
-  const threading = createOutboundThreadingMock();
-  mocks.prepareOutboundMirrorRoute.mockImplementation(threading.prepareOutboundMirrorRoute);
-  return {
-    ...threading,
-    prepareOutboundMirrorRoute: mocks.prepareOutboundMirrorRoute,
-  };
-});
-
-function setTestPlugin(plugin: unknown, pluginId: string, origin?: "bundled") {
-  setActivePluginRegistry(
-    createTestRegistry([{ pluginId, source: "test", ...(origin ? { origin } : {}), plugin }]),
-  );
-}
-
-function createAlwaysConfiguredPluginConfig(account: Record<string, unknown> = { enabled: true }) {
-  return {
-    listAccountIds: () => ["default"],
-    resolveAccount: () => account,
-    isConfigured: () => true,
-  };
-}
-
-function createPollForwardingPlugin(params: {
-  pluginId: string;
-  label: string;
-  blurb: string;
-  handleAction: ChannelActionHandler;
-}): ChannelPlugin {
-  return {
-    id: params.pluginId,
-    meta: {
-      id: params.pluginId,
-      label: params.label,
-      selectionLabel: params.label,
-      docsPath: `/channels/${params.pluginId}`,
-      blurb: params.blurb,
-    },
-    capabilities: { chatTypes: ["direct"] },
-    config: createAlwaysConfiguredPluginConfig(),
-    messaging: {
-      targetResolver: {
-        looksLikeId: () => true,
-      },
-    },
-    actions: {
-      describeMessageTool: () => ({ actions: ["poll"] }),
-      supportsAction: ({ action }) => action === "poll",
-      handleAction: params.handleAction,
-    },
-  };
-}
-
-function createGatewayActionPlugin(params: {
-  pluginId: string;
-  label: string;
-  blurb: string;
-  actions: ChannelMessageActionName[];
-  gatewayActions?: ChannelMessageActionName[];
-  capabilities?: ChannelPlugin["capabilities"];
-  messaging?: ChannelPlugin["messaging"];
-  threading?: ChannelPlugin["threading"];
-  handleAction: ChannelActionHandler;
-}): ChannelPlugin {
-  const actions = new Set(params.actions);
-  const gatewayActions = new Set(params.gatewayActions ?? params.actions);
-  return {
-    id: params.pluginId,
-    meta: {
-      id: params.pluginId,
-      label: params.label,
-      selectionLabel: params.label,
-      docsPath: `/channels/${params.pluginId}`,
-      blurb: params.blurb,
-    },
-    capabilities: params.capabilities ?? { chatTypes: ["direct"] },
-    config: createAlwaysConfiguredPluginConfig(),
-    messaging: params.messaging,
-    threading: params.threading,
-    actions: {
-      describeMessageTool: () => ({ actions: params.actions }),
-      supportsAction: ({ action }) => actions.has(action),
-      resolveExecutionMode: ({ action }) => (gatewayActions.has(action) ? "gateway" : "local"),
-      handleAction: params.handleAction,
-    },
-  };
-}
-
-async function executePluginAction(params: {
-  action: "send" | "poll";
-  ctx: Pick<
-    ChannelMessageActionContext,
-    | "channel"
-    | "cfg"
-    | "params"
-    | "mediaAccess"
-    | "accountId"
-    | "gateway"
-    | "toolContext"
-    | "inboundEventKind"
-  > & {
-    dryRun: boolean;
-    agentId?: string;
-  };
-}) {
-  const handled = await dispatchChannelMessageAction({
-    channel: params.ctx.channel,
-    action: params.action,
-    cfg: params.ctx.cfg,
-    params: params.ctx.params,
-    mediaAccess: params.ctx.mediaAccess,
-    mediaLocalRoots: params.ctx.mediaAccess?.localRoots ?? [],
-    mediaReadFile:
-      typeof params.ctx.mediaAccess?.readFile === "function"
-        ? params.ctx.mediaAccess.readFile
-        : undefined,
-    accountId: params.ctx.accountId ?? undefined,
-    gateway: params.ctx.gateway,
-    toolContext: params.ctx.toolContext,
-    inboundEventKind: params.ctx.inboundEventKind,
-    dryRun: params.ctx.dryRun,
-    agentId: params.ctx.agentId,
-  });
-  if (!handled) {
-    throw new Error(`expected plugin to handle ${params.action}`);
-  }
-  return {
-    handledBy: "plugin" as const,
-    payload: extractToolPayload(handled),
-    toolResult: handled,
-  };
-}
-
 describe("runMessageAction plugin dispatch", () => {
   beforeEach(() => {
-    mocks.resolveOutboundChannelPlugin.mockReset();
-    mocks.resolveOutboundChannelPlugin.mockImplementation(
-      ({ channel }: { channel: string }) =>
-        getActivePluginRegistry()?.channels.find((entry) => entry?.plugin?.id === channel)?.plugin,
-    );
-    mocks.executeSendAction.mockReset();
-    mocks.executeSendAction.mockImplementation(
-      async ({ ctx }: { ctx: Parameters<typeof executePluginAction>[0]["ctx"] }) =>
-        await executePluginAction({ action: "send", ctx }),
-    );
-    mocks.executePollAction.mockReset();
-    mocks.executePollAction.mockImplementation(
-      async ({ ctx }: { ctx: Parameters<typeof executePluginAction>[0]["ctx"] }) =>
-        await executePluginAction({ action: "poll", ctx }),
-    );
-    mocks.hasCorePresentationDelivery.mockReset();
-    mocks.hasCorePresentationDelivery.mockImplementation(
-      (outbound?: { sendPayload?: unknown; sendText?: unknown; sendFormattedText?: unknown }) =>
-        Boolean(outbound?.sendPayload || outbound?.sendText || outbound?.sendFormattedText),
-    );
-    mocks.materializeMessagePresentationFallback.mockReset();
-    mocks.materializeMessagePresentationFallback.mockImplementation(
-      (params: { payload: { presentation?: unknown; text?: string }; text?: string }) => {
-        const presentation = normalizeMessagePresentation(params.payload.presentation);
-        const text = (params.text ?? params.payload.text ?? "").trim();
-        if (!presentation) {
-          return text;
-        }
-        const fallback = renderMessagePresentationFallbackText({ presentation });
-        return !fallback || text.includes(fallback)
-          ? text
-          : [text, fallback].filter(Boolean).join("\n\n");
-      },
-    );
-    mocks.callGateway.mockReset();
-    mocks.callGatewayLeastPrivilege.mockReset();
-    mocks.isGatewayTransportError.mockReset();
-    mocks.isGatewayTransportError.mockImplementation(
-      (value: unknown) =>
-        value instanceof Error && (value as { kind?: unknown }).kind === "timeout",
-    );
-    mocks.randomIdempotencyKey.mockClear();
-    mocks.maybeApplyTtsToPayload.mockReset();
-    mocks.maybeApplyTtsToPayload.mockImplementation(
-      async (params: { payload: unknown }) => params.payload,
-    );
-    mocks.prepareOutboundMirrorRoute.mockClear();
-    mocks.beginTerminalSourceReplyDelivery.mockReset();
-    mocks.cancelTerminalSourceReplyDelivery.mockReset();
-    mocks.reconcileTerminalSourceReplyDelivery.mockReset();
+    resetMessageActionRunnerMocks();
   });
   describe("alias-based plugin action dispatch", () => {
     const handleAction = vi.fn(async ({ params }: { params: Record<string, unknown> }) =>

--- a/src/infra/outbound/message-action-params.attachments.test.ts
+++ b/src/infra/outbound/message-action-params.attachments.test.ts
@@ -8,58 +8,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { jsonResult } from "../../agents/tools/common.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import { loadWebMedia } from "../../media/web-media.js";
-import { getActivePluginRegistry, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
-import { runMessageAction } from "./message-action-runner.js";
+import {
+  messageActionRunnerMocks,
+  resetMessageActionMediaMocks,
+  runMessageAction,
+  setMessageActionTestPlugin as setTestPlugin,
+} from "./message-action-runner.test-helpers.js";
+
+const loadWebMedia = messageActionRunnerMocks.loadWebMedia;
 
 const onePixelPng = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5m8gAAAABJRU5ErkJggg==",
   "base64",
 );
-
-const channelResolutionMocks = vi.hoisted(() => ({
-  resolveOutboundChannelPlugin: vi.fn(),
-  executeSendAction: vi.fn(),
-  executePollAction: vi.fn(),
-}));
-
-vi.mock("./channel-resolution.js", () => ({
-  normalizeDeliverableOutboundChannel: (value?: string | null) =>
-    typeof value === "string" ? value.trim().toLowerCase() || undefined : undefined,
-  resolveOutboundChannelPlugin: channelResolutionMocks.resolveOutboundChannelPlugin,
-  resetOutboundChannelResolutionStateForTest: vi.fn(),
-}));
-
-vi.mock("./outbound-send-service.js", () => ({
-  executeSendAction: channelResolutionMocks.executeSendAction,
-  executePollAction: channelResolutionMocks.executePollAction,
-}));
-
-vi.mock("./outbound-session.js", () => ({
-  ensureOutboundSessionEntry: vi.fn(async () => undefined),
-  resolveOutboundSessionRoute: vi.fn(async () => null),
-}));
-
-vi.mock("./message-action-threading.js", async () => {
-  const { createOutboundThreadingMock } =
-    await import("./message-action-threading.test-helpers.js");
-  return createOutboundThreadingMock();
-});
-
-vi.mock("../../media/web-media.js", async () => {
-  const actual = await vi.importActual<typeof import("../../media/web-media.js")>(
-    "../../media/web-media.js",
-  );
-  return {
-    ...actual,
-    loadWebMedia: vi.fn(actual.loadWebMedia),
-  };
-});
-
-function setTestPlugin(plugin: ChannelPlugin, pluginId: string) {
-  setActivePluginRegistry(createTestRegistry([{ pluginId, source: "test", plugin }]));
-}
 
 function firstMockArg(
   mock: { mock: { calls: readonly unknown[][] } },
@@ -132,58 +95,9 @@ function expectAttachmentRemoteMediaPayload(result: Awaited<ReturnType<typeof ru
   expect(payload.buffer).toBe(Buffer.from("hello").toString("base64"));
 }
 
-let actualLoadWebMedia: typeof loadWebMedia;
-
 describe("runMessageAction media behavior", () => {
   beforeEach(async () => {
-    actualLoadWebMedia ??= (
-      await vi.importActual<typeof import("../../media/web-media.js")>("../../media/web-media.js")
-    ).loadWebMedia;
-    vi.restoreAllMocks();
-    vi.clearAllMocks();
-    channelResolutionMocks.resolveOutboundChannelPlugin.mockReset();
-    channelResolutionMocks.resolveOutboundChannelPlugin.mockImplementation(
-      ({ channel }: { channel: string }) =>
-        getActivePluginRegistry()?.channels.find((entry) => entry?.plugin?.id === channel)?.plugin,
-    );
-    channelResolutionMocks.executeSendAction.mockReset();
-    channelResolutionMocks.executeSendAction.mockImplementation(
-      async ({
-        ctx,
-        to,
-        message,
-        mediaUrl,
-        mediaUrls,
-      }: {
-        ctx: { channel: string; dryRun: boolean };
-        to: string;
-        message: string;
-        mediaUrl?: string;
-        mediaUrls?: string[];
-      }) => ({
-        handledBy: "core" as const,
-        payload: {
-          channel: ctx.channel,
-          to,
-          message,
-          mediaUrl,
-          mediaUrls,
-          dryRun: ctx.dryRun,
-        },
-        sendResult: {
-          channel: ctx.channel,
-          messageId: "msg-test",
-          ...(mediaUrl ? { mediaUrl } : {}),
-          ...(mediaUrls ? { mediaUrls } : {}),
-        },
-      }),
-    );
-    channelResolutionMocks.executePollAction.mockReset();
-    channelResolutionMocks.executePollAction.mockImplementation(async () => {
-      throw new Error("executePollAction should not run in media tests");
-    });
-    vi.mocked(loadWebMedia).mockReset();
-    vi.mocked(loadWebMedia).mockImplementation(actualLoadWebMedia);
+    await resetMessageActionMediaMocks();
   });
   describe("sendAttachment hydration", () => {
     const cfg = {

--- a/src/infra/outbound/message-action-params.media-access.test.ts
+++ b/src/infra/outbound/message-action-params.media-access.test.ts
@@ -5,62 +5,26 @@ import path from "node:path";
 // attachments, and channel/plugin media source aliases.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { Type } from "typebox";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { jsonResult } from "../../agents/tools/common.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import { loadWebMedia } from "../../media/web-media.js";
-import { getActivePluginRegistry, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import {
   createChannelTestPluginBase,
   createTestRegistry,
 } from "../../test-utils/channel-plugins.js";
 import { resolvePreferredOpenClawTmpDir } from "../tmp-openclaw-dir.js";
-import { runMessageAction } from "./message-action-runner.js";
+import {
+  resetMessageActionMediaMocks,
+  runMessageAction,
+  setMessageActionTestPlugin as setTestPlugin,
+} from "./message-action-runner.test-helpers.js";
 
 const onePixelPng = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5m8gAAAABJRU5ErkJggg==",
   "base64",
 );
-
-const channelResolutionMocks = vi.hoisted(() => ({
-  resolveOutboundChannelPlugin: vi.fn(),
-  executeSendAction: vi.fn(),
-  executePollAction: vi.fn(),
-}));
-
-vi.mock("./channel-resolution.js", () => ({
-  normalizeDeliverableOutboundChannel: (value?: string | null) =>
-    typeof value === "string" ? value.trim().toLowerCase() || undefined : undefined,
-  resolveOutboundChannelPlugin: channelResolutionMocks.resolveOutboundChannelPlugin,
-  resetOutboundChannelResolutionStateForTest: vi.fn(),
-}));
-
-vi.mock("./outbound-send-service.js", () => ({
-  executeSendAction: channelResolutionMocks.executeSendAction,
-  executePollAction: channelResolutionMocks.executePollAction,
-}));
-
-vi.mock("./outbound-session.js", () => ({
-  ensureOutboundSessionEntry: vi.fn(async () => undefined),
-  resolveOutboundSessionRoute: vi.fn(async () => null),
-}));
-
-vi.mock("./message-action-threading.js", async () => {
-  const { createOutboundThreadingMock } =
-    await import("./message-action-threading.test-helpers.js");
-  return createOutboundThreadingMock();
-});
-
-vi.mock("../../media/web-media.js", async () => {
-  const actual = await vi.importActual<typeof import("../../media/web-media.js")>(
-    "../../media/web-media.js",
-  );
-  return {
-    ...actual,
-    loadWebMedia: vi.fn(actual.loadWebMedia),
-  };
-});
 
 const workspaceConfig = {
   channels: {
@@ -70,10 +34,6 @@ const workspaceConfig = {
     },
   },
 } as OpenClawConfig;
-
-function setTestPlugin(plugin: ChannelPlugin, pluginId: string) {
-  setActivePluginRegistry(createTestRegistry([{ pluginId, source: "test", plugin }]));
-}
 
 async function withSandbox(test: (sandboxDir: string) => Promise<void>) {
   const sandboxDir = await fs.mkdtemp(path.join(os.tmpdir(), "msg-sandbox-"));
@@ -140,8 +100,6 @@ async function expectSandboxMediaRewrite(params: {
   );
 }
 
-let actualLoadWebMedia: typeof loadWebMedia;
-
 const workspacePlugin: ChannelPlugin = {
   ...createChannelTestPluginBase({
     id: "workspace",
@@ -175,54 +133,7 @@ const workspacePlugin: ChannelPlugin = {
 
 describe("runMessageAction media behavior", () => {
   beforeEach(async () => {
-    actualLoadWebMedia ??= (
-      await vi.importActual<typeof import("../../media/web-media.js")>("../../media/web-media.js")
-    ).loadWebMedia;
-    vi.restoreAllMocks();
-    vi.clearAllMocks();
-    channelResolutionMocks.resolveOutboundChannelPlugin.mockReset();
-    channelResolutionMocks.resolveOutboundChannelPlugin.mockImplementation(
-      ({ channel }: { channel: string }) =>
-        getActivePluginRegistry()?.channels.find((entry) => entry?.plugin?.id === channel)?.plugin,
-    );
-    channelResolutionMocks.executeSendAction.mockReset();
-    channelResolutionMocks.executeSendAction.mockImplementation(
-      async ({
-        ctx,
-        to,
-        message,
-        mediaUrl,
-        mediaUrls,
-      }: {
-        ctx: { channel: string; dryRun: boolean };
-        to: string;
-        message: string;
-        mediaUrl?: string;
-        mediaUrls?: string[];
-      }) => ({
-        handledBy: "core" as const,
-        payload: {
-          channel: ctx.channel,
-          to,
-          message,
-          mediaUrl,
-          mediaUrls,
-          dryRun: ctx.dryRun,
-        },
-        sendResult: {
-          channel: ctx.channel,
-          messageId: "msg-test",
-          ...(mediaUrl ? { mediaUrl } : {}),
-          ...(mediaUrls ? { mediaUrls } : {}),
-        },
-      }),
-    );
-    channelResolutionMocks.executePollAction.mockReset();
-    channelResolutionMocks.executePollAction.mockImplementation(async () => {
-      throw new Error("executePollAction should not run in media tests");
-    });
-    vi.mocked(loadWebMedia).mockReset();
-    vi.mocked(loadWebMedia).mockImplementation(actualLoadWebMedia);
+    await resetMessageActionMediaMocks();
   });
   describe("plugin-owned media-source discovery routing", () => {
     const profilePlugin: ChannelPlugin = {

--- a/src/infra/outbound/message-action-routing.accounts.test.ts
+++ b/src/infra/outbound/message-action-routing.accounts.test.ts
@@ -3,20 +3,15 @@
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { jsonResult } from "../../agents/tools/common.js";
-import { dispatchChannelMessageAction } from "../../channels/plugins/message-action-dispatch.js";
-import type {
-  ChannelMessageActionContext,
-  ChannelPlugin,
-} from "../../channels/plugins/types.public.js";
+import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import {
-  normalizeMessagePresentation,
-  renderMessagePresentationFallbackText,
-} from "../../interactive/payload.js";
-import { extractToolPayload } from "../../plugin-sdk/tool-payload.js";
-import { getActivePluginRegistry, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
-import { runMessageAction } from "./message-action-runner.js";
+import {
+  resetMessageActionRunnerMocks,
+  runMessageAction,
+  setMessageActionTestPlugin as setTestPlugin,
+} from "./message-action-runner.test-helpers.js";
 
 const requireRecord = createRequireRecord("record", "expected-non-array-record");
 
@@ -26,194 +21,9 @@ function readFirstPluginCall(mock: { mock: { calls: unknown[][] } }): Record<str
   return requireRecord(call);
 }
 
-const mocks = vi.hoisted(() => ({
-  resolveOutboundChannelPlugin: vi.fn(),
-  executeSendAction: vi.fn(),
-  executePollAction: vi.fn(),
-  hasCorePresentationDelivery: vi.fn(),
-  materializeMessagePresentationFallback: vi.fn(),
-  callGateway: vi.fn(),
-  callGatewayLeastPrivilege: vi.fn(),
-  isGatewayTransportError: vi.fn(),
-  randomIdempotencyKey: vi.fn(() => "idem-gateway-action"),
-  maybeApplyTtsToPayload: vi.fn(async (params: { payload: unknown }) => params.payload),
-  prepareOutboundMirrorRoute: vi.fn(),
-  beginTerminalSourceReplyDelivery: vi.fn(),
-  cancelTerminalSourceReplyDelivery: vi.fn(),
-  isCurrentSourceReplyActionName: vi.fn(() => false),
-  isDeliveredCurrentSourceReply: vi.fn(() => false),
-  isDeliveredCurrentSourceReplyAction: vi.fn(() => false),
-  reconcileTerminalSourceReplyDelivery: vi.fn(),
-}));
-
-vi.mock("./channel-resolution.js", () => ({
-  normalizeDeliverableOutboundChannel: (value?: string | null) =>
-    typeof value === "string" ? value.trim().toLowerCase() || undefined : undefined,
-  resolveOutboundChannelPlugin: mocks.resolveOutboundChannelPlugin,
-  resetOutboundChannelResolutionStateForTest: vi.fn(),
-}));
-
-vi.mock("./outbound-send-service.js", () => ({
-  executeSendAction: mocks.executeSendAction,
-  executePollAction: mocks.executePollAction,
-  hasCorePresentationDelivery: mocks.hasCorePresentationDelivery,
-  materializeMessagePresentationFallback: mocks.materializeMessagePresentationFallback,
-}));
-
-vi.mock("./message.gateway.runtime.js", () => ({
-  callGateway: mocks.callGateway,
-  callGatewayLeastPrivilege: mocks.callGatewayLeastPrivilege,
-  isGatewayTransportError: mocks.isGatewayTransportError,
-  randomIdempotencyKey: mocks.randomIdempotencyKey,
-}));
-
-vi.mock("./source-reply-mirror.js", () => ({
-  beginTerminalSourceReplyDelivery: mocks.beginTerminalSourceReplyDelivery,
-  cancelTerminalSourceReplyDelivery: mocks.cancelTerminalSourceReplyDelivery,
-  isCurrentSourceReplyActionName: mocks.isCurrentSourceReplyActionName,
-  isDeliveredCurrentSourceReply: mocks.isDeliveredCurrentSourceReply,
-  isDeliveredCurrentSourceReplyAction: mocks.isDeliveredCurrentSourceReplyAction,
-  reconcileTerminalSourceReplyDelivery: mocks.reconcileTerminalSourceReplyDelivery,
-}));
-
-vi.mock("../../tts/tts.runtime.js", () => ({
-  maybeApplyTtsToPayload: mocks.maybeApplyTtsToPayload,
-}));
-
-vi.mock("./outbound-session.js", () => ({
-  ensureOutboundSessionEntry: vi.fn(async () => undefined),
-  resolveOutboundSessionRoute: vi.fn(async () => null),
-}));
-
-vi.mock("../../channels/plugins/bootstrap-registry.js", () => ({
-  getBootstrapChannelPlugin: (id: string) =>
-    id === "actionhub"
-      ? {
-          actions: {
-            messageActionTargetAliases: {
-              pin: { aliases: ["messageId"] },
-              unpin: { aliases: ["messageId"] },
-              "list-pins": { aliases: ["chatId"] },
-            },
-          },
-        }
-      : undefined,
-}));
-
-vi.mock("./message-action-threading.js", async () => {
-  const { createOutboundThreadingMock } =
-    await import("./message-action-threading.test-helpers.js");
-  const threading = createOutboundThreadingMock();
-  mocks.prepareOutboundMirrorRoute.mockImplementation(threading.prepareOutboundMirrorRoute);
-  return {
-    ...threading,
-    prepareOutboundMirrorRoute: mocks.prepareOutboundMirrorRoute,
-  };
-});
-
-function setTestPlugin(plugin: unknown, pluginId: string, origin?: "bundled") {
-  setActivePluginRegistry(
-    createTestRegistry([{ pluginId, source: "test", ...(origin ? { origin } : {}), plugin }]),
-  );
-}
-
-async function executePluginAction(params: {
-  action: "send" | "poll";
-  ctx: Pick<
-    ChannelMessageActionContext,
-    | "channel"
-    | "cfg"
-    | "params"
-    | "mediaAccess"
-    | "accountId"
-    | "gateway"
-    | "toolContext"
-    | "inboundEventKind"
-  > & {
-    dryRun: boolean;
-    agentId?: string;
-  };
-}) {
-  const handled = await dispatchChannelMessageAction({
-    channel: params.ctx.channel,
-    action: params.action,
-    cfg: params.ctx.cfg,
-    params: params.ctx.params,
-    mediaAccess: params.ctx.mediaAccess,
-    mediaLocalRoots: params.ctx.mediaAccess?.localRoots ?? [],
-    mediaReadFile:
-      typeof params.ctx.mediaAccess?.readFile === "function"
-        ? params.ctx.mediaAccess.readFile
-        : undefined,
-    accountId: params.ctx.accountId ?? undefined,
-    gateway: params.ctx.gateway,
-    toolContext: params.ctx.toolContext,
-    inboundEventKind: params.ctx.inboundEventKind,
-    dryRun: params.ctx.dryRun,
-    agentId: params.ctx.agentId,
-  });
-  if (!handled) {
-    throw new Error(`expected plugin to handle ${params.action}`);
-  }
-  return {
-    handledBy: "plugin" as const,
-    payload: extractToolPayload(handled),
-    toolResult: handled,
-  };
-}
-
 describe("runMessageAction plugin dispatch", () => {
   beforeEach(() => {
-    mocks.resolveOutboundChannelPlugin.mockReset();
-    mocks.resolveOutboundChannelPlugin.mockImplementation(
-      ({ channel }: { channel: string }) =>
-        getActivePluginRegistry()?.channels.find((entry) => entry?.plugin?.id === channel)?.plugin,
-    );
-    mocks.executeSendAction.mockReset();
-    mocks.executeSendAction.mockImplementation(
-      async ({ ctx }: { ctx: Parameters<typeof executePluginAction>[0]["ctx"] }) =>
-        await executePluginAction({ action: "send", ctx }),
-    );
-    mocks.executePollAction.mockReset();
-    mocks.executePollAction.mockImplementation(
-      async ({ ctx }: { ctx: Parameters<typeof executePluginAction>[0]["ctx"] }) =>
-        await executePluginAction({ action: "poll", ctx }),
-    );
-    mocks.hasCorePresentationDelivery.mockReset();
-    mocks.hasCorePresentationDelivery.mockImplementation(
-      (outbound?: { sendPayload?: unknown; sendText?: unknown; sendFormattedText?: unknown }) =>
-        Boolean(outbound?.sendPayload || outbound?.sendText || outbound?.sendFormattedText),
-    );
-    mocks.materializeMessagePresentationFallback.mockReset();
-    mocks.materializeMessagePresentationFallback.mockImplementation(
-      (params: { payload: { presentation?: unknown; text?: string }; text?: string }) => {
-        const presentation = normalizeMessagePresentation(params.payload.presentation);
-        const text = (params.text ?? params.payload.text ?? "").trim();
-        if (!presentation) {
-          return text;
-        }
-        const fallback = renderMessagePresentationFallbackText({ presentation });
-        return !fallback || text.includes(fallback)
-          ? text
-          : [text, fallback].filter(Boolean).join("\n\n");
-      },
-    );
-    mocks.callGateway.mockReset();
-    mocks.callGatewayLeastPrivilege.mockReset();
-    mocks.isGatewayTransportError.mockReset();
-    mocks.isGatewayTransportError.mockImplementation(
-      (value: unknown) =>
-        value instanceof Error && (value as { kind?: unknown }).kind === "timeout",
-    );
-    mocks.randomIdempotencyKey.mockClear();
-    mocks.maybeApplyTtsToPayload.mockReset();
-    mocks.maybeApplyTtsToPayload.mockImplementation(
-      async (params: { payload: unknown }) => params.payload,
-    );
-    mocks.prepareOutboundMirrorRoute.mockClear();
-    mocks.beginTerminalSourceReplyDelivery.mockReset();
-    mocks.cancelTerminalSourceReplyDelivery.mockReset();
-    mocks.reconcileTerminalSourceReplyDelivery.mockReset();
+    resetMessageActionRunnerMocks();
   });
   describe("accountId defaults", () => {
     const handleAction = vi.fn(async () => jsonResult({ ok: true }));

--- a/src/infra/outbound/message-action-routing.context.test.ts
+++ b/src/infra/outbound/message-action-routing.context.test.ts
@@ -22,7 +22,7 @@ import {
   runDrySend,
   workspaceConfig,
   workspaceTestPlugin,
-} from "./message-action-runner.test-helpers.js";
+} from "./message-action-test-fixtures.js";
 
 const handleWorkspaceAction = vi.fn(async (_ctx: ChannelMessageActionContext) =>
   jsonResult({ ok: true }),

--- a/src/infra/outbound/message-action-routing.test.ts
+++ b/src/infra/outbound/message-action-routing.test.ts
@@ -3,24 +3,22 @@
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { jsonResult } from "../../agents/tools/common.js";
-import { dispatchChannelMessageAction } from "../../channels/plugins/message-action-dispatch.js";
 import type {
   ChannelMessageActionContext,
-  ChannelMessageActionName,
   ChannelPlugin,
 } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import {
-  normalizeMessagePresentation,
-  renderMessagePresentationFallbackText,
-} from "../../interactive/payload.js";
-import { extractToolPayload } from "../../plugin-sdk/tool-payload.js";
-import { getActivePluginRegistry, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
-import { runMessageAction } from "./message-action-runner.js";
-
-type ChannelActionHandler = NonNullable<NonNullable<ChannelPlugin["actions"]>["handleAction"]>;
+import {
+  createAlwaysConfiguredPluginConfig,
+  createGatewayActionPlugin,
+  messageActionRunnerMocks as mocks,
+  resetMessageActionRunnerMocks,
+  runMessageAction,
+  setMessageActionTestPlugin as setTestPlugin,
+} from "./message-action-runner.test-helpers.js";
 
 const requireRecord = createRequireRecord("record", "expected-non-array-record");
 const requireLabeledRecord = createRequireRecord("record", "expected-label");
@@ -59,237 +57,9 @@ function expectRecordFields(
   }
 }
 
-const mocks = vi.hoisted(() => ({
-  resolveOutboundChannelPlugin: vi.fn(),
-  executeSendAction: vi.fn(),
-  executePollAction: vi.fn(),
-  hasCorePresentationDelivery: vi.fn(),
-  materializeMessagePresentationFallback: vi.fn(),
-  callGateway: vi.fn(),
-  callGatewayLeastPrivilege: vi.fn(),
-  isGatewayTransportError: vi.fn(),
-  randomIdempotencyKey: vi.fn(() => "idem-gateway-action"),
-  maybeApplyTtsToPayload: vi.fn(async (params: { payload: unknown }) => params.payload),
-  prepareOutboundMirrorRoute: vi.fn(),
-  beginTerminalSourceReplyDelivery: vi.fn(),
-  cancelTerminalSourceReplyDelivery: vi.fn(),
-  isCurrentSourceReplyActionName: vi.fn(() => false),
-  isDeliveredCurrentSourceReply: vi.fn(() => false),
-  isDeliveredCurrentSourceReplyAction: vi.fn(() => false),
-  reconcileTerminalSourceReplyDelivery: vi.fn(),
-}));
-
-vi.mock("./channel-resolution.js", () => ({
-  normalizeDeliverableOutboundChannel: (value?: string | null) =>
-    typeof value === "string" ? value.trim().toLowerCase() || undefined : undefined,
-  resolveOutboundChannelPlugin: mocks.resolveOutboundChannelPlugin,
-  resetOutboundChannelResolutionStateForTest: vi.fn(),
-}));
-
-vi.mock("./outbound-send-service.js", () => ({
-  executeSendAction: mocks.executeSendAction,
-  executePollAction: mocks.executePollAction,
-  hasCorePresentationDelivery: mocks.hasCorePresentationDelivery,
-  materializeMessagePresentationFallback: mocks.materializeMessagePresentationFallback,
-}));
-
-vi.mock("./message.gateway.runtime.js", () => ({
-  callGateway: mocks.callGateway,
-  callGatewayLeastPrivilege: mocks.callGatewayLeastPrivilege,
-  isGatewayTransportError: mocks.isGatewayTransportError,
-  randomIdempotencyKey: mocks.randomIdempotencyKey,
-}));
-
-vi.mock("./source-reply-mirror.js", () => ({
-  beginTerminalSourceReplyDelivery: mocks.beginTerminalSourceReplyDelivery,
-  cancelTerminalSourceReplyDelivery: mocks.cancelTerminalSourceReplyDelivery,
-  isCurrentSourceReplyActionName: mocks.isCurrentSourceReplyActionName,
-  isDeliveredCurrentSourceReply: mocks.isDeliveredCurrentSourceReply,
-  isDeliveredCurrentSourceReplyAction: mocks.isDeliveredCurrentSourceReplyAction,
-  reconcileTerminalSourceReplyDelivery: mocks.reconcileTerminalSourceReplyDelivery,
-}));
-
-vi.mock("../../tts/tts.runtime.js", () => ({
-  maybeApplyTtsToPayload: mocks.maybeApplyTtsToPayload,
-}));
-
-vi.mock("./outbound-session.js", () => ({
-  ensureOutboundSessionEntry: vi.fn(async () => undefined),
-  resolveOutboundSessionRoute: vi.fn(async () => null),
-}));
-
-vi.mock("../../channels/plugins/bootstrap-registry.js", () => ({
-  getBootstrapChannelPlugin: (id: string) =>
-    id === "actionhub"
-      ? {
-          actions: {
-            messageActionTargetAliases: {
-              pin: { aliases: ["messageId"] },
-              unpin: { aliases: ["messageId"] },
-              "list-pins": { aliases: ["chatId"] },
-            },
-          },
-        }
-      : undefined,
-}));
-
-vi.mock("./message-action-threading.js", async () => {
-  const { createOutboundThreadingMock } =
-    await import("./message-action-threading.test-helpers.js");
-  const threading = createOutboundThreadingMock();
-  mocks.prepareOutboundMirrorRoute.mockImplementation(threading.prepareOutboundMirrorRoute);
-  return {
-    ...threading,
-    prepareOutboundMirrorRoute: mocks.prepareOutboundMirrorRoute,
-  };
-});
-
-function setTestPlugin(plugin: unknown, pluginId: string, origin?: "bundled") {
-  setActivePluginRegistry(
-    createTestRegistry([{ pluginId, source: "test", ...(origin ? { origin } : {}), plugin }]),
-  );
-}
-
-function createAlwaysConfiguredPluginConfig(account: Record<string, unknown> = { enabled: true }) {
-  return {
-    listAccountIds: () => ["default"],
-    resolveAccount: () => account,
-    isConfigured: () => true,
-  };
-}
-
-function createGatewayActionPlugin(params: {
-  pluginId: string;
-  label: string;
-  blurb: string;
-  actions: ChannelMessageActionName[];
-  gatewayActions?: ChannelMessageActionName[];
-  capabilities?: ChannelPlugin["capabilities"];
-  messaging?: ChannelPlugin["messaging"];
-  threading?: ChannelPlugin["threading"];
-  handleAction: ChannelActionHandler;
-}): ChannelPlugin {
-  const actions = new Set(params.actions);
-  const gatewayActions = new Set(params.gatewayActions ?? params.actions);
-  return {
-    id: params.pluginId,
-    meta: {
-      id: params.pluginId,
-      label: params.label,
-      selectionLabel: params.label,
-      docsPath: `/channels/${params.pluginId}`,
-      blurb: params.blurb,
-    },
-    capabilities: params.capabilities ?? { chatTypes: ["direct"] },
-    config: createAlwaysConfiguredPluginConfig(),
-    messaging: params.messaging,
-    threading: params.threading,
-    actions: {
-      describeMessageTool: () => ({ actions: params.actions }),
-      supportsAction: ({ action }) => actions.has(action),
-      resolveExecutionMode: ({ action }) => (gatewayActions.has(action) ? "gateway" : "local"),
-      handleAction: params.handleAction,
-    },
-  };
-}
-
-async function executePluginAction(params: {
-  action: "send" | "poll";
-  ctx: Pick<
-    ChannelMessageActionContext,
-    | "channel"
-    | "cfg"
-    | "params"
-    | "mediaAccess"
-    | "accountId"
-    | "gateway"
-    | "toolContext"
-    | "inboundEventKind"
-  > & {
-    dryRun: boolean;
-    agentId?: string;
-  };
-}) {
-  const handled = await dispatchChannelMessageAction({
-    channel: params.ctx.channel,
-    action: params.action,
-    cfg: params.ctx.cfg,
-    params: params.ctx.params,
-    mediaAccess: params.ctx.mediaAccess,
-    mediaLocalRoots: params.ctx.mediaAccess?.localRoots ?? [],
-    mediaReadFile:
-      typeof params.ctx.mediaAccess?.readFile === "function"
-        ? params.ctx.mediaAccess.readFile
-        : undefined,
-    accountId: params.ctx.accountId ?? undefined,
-    gateway: params.ctx.gateway,
-    toolContext: params.ctx.toolContext,
-    inboundEventKind: params.ctx.inboundEventKind,
-    dryRun: params.ctx.dryRun,
-    agentId: params.ctx.agentId,
-  });
-  if (!handled) {
-    throw new Error(`expected plugin to handle ${params.action}`);
-  }
-  return {
-    handledBy: "plugin" as const,
-    payload: extractToolPayload(handled),
-    toolResult: handled,
-  };
-}
-
 describe("runMessageAction plugin dispatch", () => {
   beforeEach(() => {
-    mocks.resolveOutboundChannelPlugin.mockReset();
-    mocks.resolveOutboundChannelPlugin.mockImplementation(
-      ({ channel }: { channel: string }) =>
-        getActivePluginRegistry()?.channels.find((entry) => entry?.plugin?.id === channel)?.plugin,
-    );
-    mocks.executeSendAction.mockReset();
-    mocks.executeSendAction.mockImplementation(
-      async ({ ctx }: { ctx: Parameters<typeof executePluginAction>[0]["ctx"] }) =>
-        await executePluginAction({ action: "send", ctx }),
-    );
-    mocks.executePollAction.mockReset();
-    mocks.executePollAction.mockImplementation(
-      async ({ ctx }: { ctx: Parameters<typeof executePluginAction>[0]["ctx"] }) =>
-        await executePluginAction({ action: "poll", ctx }),
-    );
-    mocks.hasCorePresentationDelivery.mockReset();
-    mocks.hasCorePresentationDelivery.mockImplementation(
-      (outbound?: { sendPayload?: unknown; sendText?: unknown; sendFormattedText?: unknown }) =>
-        Boolean(outbound?.sendPayload || outbound?.sendText || outbound?.sendFormattedText),
-    );
-    mocks.materializeMessagePresentationFallback.mockReset();
-    mocks.materializeMessagePresentationFallback.mockImplementation(
-      (params: { payload: { presentation?: unknown; text?: string }; text?: string }) => {
-        const presentation = normalizeMessagePresentation(params.payload.presentation);
-        const text = (params.text ?? params.payload.text ?? "").trim();
-        if (!presentation) {
-          return text;
-        }
-        const fallback = renderMessagePresentationFallbackText({ presentation });
-        return !fallback || text.includes(fallback)
-          ? text
-          : [text, fallback].filter(Boolean).join("\n\n");
-      },
-    );
-    mocks.callGateway.mockReset();
-    mocks.callGatewayLeastPrivilege.mockReset();
-    mocks.isGatewayTransportError.mockReset();
-    mocks.isGatewayTransportError.mockImplementation(
-      (value: unknown) =>
-        value instanceof Error && (value as { kind?: unknown }).kind === "timeout",
-    );
-    mocks.randomIdempotencyKey.mockClear();
-    mocks.maybeApplyTtsToPayload.mockReset();
-    mocks.maybeApplyTtsToPayload.mockImplementation(
-      async (params: { payload: unknown }) => params.payload,
-    );
-    mocks.prepareOutboundMirrorRoute.mockClear();
-    mocks.beginTerminalSourceReplyDelivery.mockReset();
-    mocks.cancelTerminalSourceReplyDelivery.mockReset();
-    mocks.reconcileTerminalSourceReplyDelivery.mockReset();
+    resetMessageActionRunnerMocks();
   });
   describe("alias-based plugin action dispatch", () => {
     const handleAction = vi.fn(async ({ params }: { params: Record<string, unknown> }) =>

--- a/src/infra/outbound/message-action-runner.context.test.ts
+++ b/src/infra/outbound/message-action-runner.context.test.ts
@@ -20,7 +20,7 @@ import {
   runDrySend,
   workspaceConfig,
   workspaceTestPlugin,
-} from "./message-action-runner.test-helpers.js";
+} from "./message-action-test-fixtures.js";
 
 const handleWorkspaceAction = vi.fn(async (_ctx: ChannelMessageActionContext) =>
   jsonResult({ ok: true }),

--- a/src/infra/outbound/message-action-runner.media.test.ts
+++ b/src/infra/outbound/message-action-runner.media.test.ts
@@ -6,53 +6,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { jsonResult } from "../../agents/tools/common.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import { loadWebMedia } from "../../media/web-media.js";
-import { getActivePluginRegistry, setActivePluginRegistry } from "../../plugins/runtime.js";
-import {
-  createChannelTestPluginBase,
-  createTestRegistry,
-} from "../../test-utils/channel-plugins.js";
+import { createChannelTestPluginBase } from "../../test-utils/channel-plugins.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
-import { runMessageAction } from "./message-action-runner.js";
+import {
+  messageActionRunnerMocks as channelResolutionMocks,
+  resetMessageActionMediaMocks,
+  runMessageAction,
+  setMessageActionTestPlugin as setTestPlugin,
+} from "./message-action-runner.test-helpers.js";
 
-const channelResolutionMocks = vi.hoisted(() => ({
-  resolveOutboundChannelPlugin: vi.fn(),
-  executeSendAction: vi.fn(),
-  executePollAction: vi.fn(),
-}));
-
-vi.mock("./channel-resolution.js", () => ({
-  normalizeDeliverableOutboundChannel: (value?: string | null) =>
-    typeof value === "string" ? value.trim().toLowerCase() || undefined : undefined,
-  resolveOutboundChannelPlugin: channelResolutionMocks.resolveOutboundChannelPlugin,
-  resetOutboundChannelResolutionStateForTest: vi.fn(),
-}));
-
-vi.mock("./outbound-send-service.js", () => ({
-  executeSendAction: channelResolutionMocks.executeSendAction,
-  executePollAction: channelResolutionMocks.executePollAction,
-}));
-
-vi.mock("./outbound-session.js", () => ({
-  ensureOutboundSessionEntry: vi.fn(async () => undefined),
-  resolveOutboundSessionRoute: vi.fn(async () => null),
-}));
-
-vi.mock("./message-action-threading.js", async () => {
-  const { createOutboundThreadingMock } =
-    await import("./message-action-threading.test-helpers.js");
-  return createOutboundThreadingMock();
-});
-
-vi.mock("../../media/web-media.js", async () => {
-  const actual = await vi.importActual<typeof import("../../media/web-media.js")>(
-    "../../media/web-media.js",
-  );
-  return {
-    ...actual,
-    loadWebMedia: vi.fn(actual.loadWebMedia),
-  };
-});
+const loadWebMedia = channelResolutionMocks.loadWebMedia;
 
 const workspaceConfig = {
   channels: {
@@ -63,18 +26,12 @@ const workspaceConfig = {
   },
 } as OpenClawConfig;
 
-function setTestPlugin(plugin: ChannelPlugin, pluginId: string) {
-  setActivePluginRegistry(createTestRegistry([{ pluginId, source: "test", plugin }]));
-}
-
 async function withTempOpenClawStateDir<T>(test: (stateDir: string) => Promise<T>): Promise<T> {
   return await withOpenClawTestState(
     { layout: "state-only", prefix: "msg-runner-state-" },
     (state) => test(state.stateDir),
   );
 }
-
-let actualLoadWebMedia: typeof loadWebMedia;
 
 const workspacePlugin: ChannelPlugin = {
   ...createChannelTestPluginBase({
@@ -109,54 +66,7 @@ const workspacePlugin: ChannelPlugin = {
 
 describe("runMessageAction media behavior", () => {
   beforeEach(async () => {
-    actualLoadWebMedia ??= (
-      await vi.importActual<typeof import("../../media/web-media.js")>("../../media/web-media.js")
-    ).loadWebMedia;
-    vi.restoreAllMocks();
-    vi.clearAllMocks();
-    channelResolutionMocks.resolveOutboundChannelPlugin.mockReset();
-    channelResolutionMocks.resolveOutboundChannelPlugin.mockImplementation(
-      ({ channel }: { channel: string }) =>
-        getActivePluginRegistry()?.channels.find((entry) => entry?.plugin?.id === channel)?.plugin,
-    );
-    channelResolutionMocks.executeSendAction.mockReset();
-    channelResolutionMocks.executeSendAction.mockImplementation(
-      async ({
-        ctx,
-        to,
-        message,
-        mediaUrl,
-        mediaUrls,
-      }: {
-        ctx: { channel: string; dryRun: boolean };
-        to: string;
-        message: string;
-        mediaUrl?: string;
-        mediaUrls?: string[];
-      }) => ({
-        handledBy: "core" as const,
-        payload: {
-          channel: ctx.channel,
-          to,
-          message,
-          mediaUrl,
-          mediaUrls,
-          dryRun: ctx.dryRun,
-        },
-        sendResult: {
-          channel: ctx.channel,
-          messageId: "msg-test",
-          ...(mediaUrl ? { mediaUrl } : {}),
-          ...(mediaUrls ? { mediaUrls } : {}),
-        },
-      }),
-    );
-    channelResolutionMocks.executePollAction.mockReset();
-    channelResolutionMocks.executePollAction.mockImplementation(async () => {
-      throw new Error("executePollAction should not run in media tests");
-    });
-    vi.mocked(loadWebMedia).mockReset();
-    vi.mocked(loadWebMedia).mockImplementation(actualLoadWebMedia);
+    await resetMessageActionMediaMocks();
   });
   it("rejects plugin-declined attachment actions before loading media", async () => {
     const handleAction = vi.fn(async () => jsonResult({ ok: true }));

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -3,24 +3,19 @@
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { jsonResult } from "../../agents/tools/common.js";
-import { dispatchChannelMessageAction } from "../../channels/plugins/message-action-dispatch.js";
-import type {
-  ChannelMessageActionContext,
-  ChannelMessageActionName,
-  ChannelPlugin,
-} from "../../channels/plugins/types.public.js";
+import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import {
-  normalizeMessagePresentation,
-  renderMessagePresentationFallbackText,
-} from "../../interactive/payload.js";
-import { extractToolPayload } from "../../plugin-sdk/tool-payload.js";
-import { getActivePluginRegistry, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
-import { runMessageAction } from "./message-action-runner.js";
-
-type ChannelActionHandler = NonNullable<NonNullable<ChannelPlugin["actions"]>["handleAction"]>;
+import {
+  createAlwaysConfiguredPluginConfig,
+  createGatewayActionPlugin,
+  messageActionRunnerMocks as mocks,
+  resetMessageActionRunnerMocks,
+  runMessageAction,
+  setMessageActionTestPlugin as setTestPlugin,
+} from "./message-action-runner.test-helpers.js";
 
 const requireLabeledRecord = createRequireRecord("record", "expected-label");
 
@@ -39,237 +34,9 @@ function expectRecordFields(
   }
 }
 
-const mocks = vi.hoisted(() => ({
-  resolveOutboundChannelPlugin: vi.fn(),
-  executeSendAction: vi.fn(),
-  executePollAction: vi.fn(),
-  hasCorePresentationDelivery: vi.fn(),
-  materializeMessagePresentationFallback: vi.fn(),
-  callGateway: vi.fn(),
-  callGatewayLeastPrivilege: vi.fn(),
-  isGatewayTransportError: vi.fn(),
-  randomIdempotencyKey: vi.fn(() => "idem-gateway-action"),
-  maybeApplyTtsToPayload: vi.fn(async (params: { payload: unknown }) => params.payload),
-  prepareOutboundMirrorRoute: vi.fn(),
-  beginTerminalSourceReplyDelivery: vi.fn(),
-  cancelTerminalSourceReplyDelivery: vi.fn(),
-  isCurrentSourceReplyActionName: vi.fn(() => false),
-  isDeliveredCurrentSourceReply: vi.fn(() => false),
-  isDeliveredCurrentSourceReplyAction: vi.fn(() => false),
-  reconcileTerminalSourceReplyDelivery: vi.fn(),
-}));
-
-vi.mock("./channel-resolution.js", () => ({
-  normalizeDeliverableOutboundChannel: (value?: string | null) =>
-    typeof value === "string" ? value.trim().toLowerCase() || undefined : undefined,
-  resolveOutboundChannelPlugin: mocks.resolveOutboundChannelPlugin,
-  resetOutboundChannelResolutionStateForTest: vi.fn(),
-}));
-
-vi.mock("./outbound-send-service.js", () => ({
-  executeSendAction: mocks.executeSendAction,
-  executePollAction: mocks.executePollAction,
-  hasCorePresentationDelivery: mocks.hasCorePresentationDelivery,
-  materializeMessagePresentationFallback: mocks.materializeMessagePresentationFallback,
-}));
-
-vi.mock("./message.gateway.runtime.js", () => ({
-  callGateway: mocks.callGateway,
-  callGatewayLeastPrivilege: mocks.callGatewayLeastPrivilege,
-  isGatewayTransportError: mocks.isGatewayTransportError,
-  randomIdempotencyKey: mocks.randomIdempotencyKey,
-}));
-
-vi.mock("./source-reply-mirror.js", () => ({
-  beginTerminalSourceReplyDelivery: mocks.beginTerminalSourceReplyDelivery,
-  cancelTerminalSourceReplyDelivery: mocks.cancelTerminalSourceReplyDelivery,
-  isCurrentSourceReplyActionName: mocks.isCurrentSourceReplyActionName,
-  isDeliveredCurrentSourceReply: mocks.isDeliveredCurrentSourceReply,
-  isDeliveredCurrentSourceReplyAction: mocks.isDeliveredCurrentSourceReplyAction,
-  reconcileTerminalSourceReplyDelivery: mocks.reconcileTerminalSourceReplyDelivery,
-}));
-
-vi.mock("../../tts/tts.runtime.js", () => ({
-  maybeApplyTtsToPayload: mocks.maybeApplyTtsToPayload,
-}));
-
-vi.mock("./outbound-session.js", () => ({
-  ensureOutboundSessionEntry: vi.fn(async () => undefined),
-  resolveOutboundSessionRoute: vi.fn(async () => null),
-}));
-
-vi.mock("../../channels/plugins/bootstrap-registry.js", () => ({
-  getBootstrapChannelPlugin: (id: string) =>
-    id === "actionhub"
-      ? {
-          actions: {
-            messageActionTargetAliases: {
-              pin: { aliases: ["messageId"] },
-              unpin: { aliases: ["messageId"] },
-              "list-pins": { aliases: ["chatId"] },
-            },
-          },
-        }
-      : undefined,
-}));
-
-vi.mock("./message-action-threading.js", async () => {
-  const { createOutboundThreadingMock } =
-    await import("./message-action-threading.test-helpers.js");
-  const threading = createOutboundThreadingMock();
-  mocks.prepareOutboundMirrorRoute.mockImplementation(threading.prepareOutboundMirrorRoute);
-  return {
-    ...threading,
-    prepareOutboundMirrorRoute: mocks.prepareOutboundMirrorRoute,
-  };
-});
-
-function setTestPlugin(plugin: unknown, pluginId: string, origin?: "bundled") {
-  setActivePluginRegistry(
-    createTestRegistry([{ pluginId, source: "test", ...(origin ? { origin } : {}), plugin }]),
-  );
-}
-
-function createAlwaysConfiguredPluginConfig(account: Record<string, unknown> = { enabled: true }) {
-  return {
-    listAccountIds: () => ["default"],
-    resolveAccount: () => account,
-    isConfigured: () => true,
-  };
-}
-
-function createGatewayActionPlugin(params: {
-  pluginId: string;
-  label: string;
-  blurb: string;
-  actions: ChannelMessageActionName[];
-  gatewayActions?: ChannelMessageActionName[];
-  capabilities?: ChannelPlugin["capabilities"];
-  messaging?: ChannelPlugin["messaging"];
-  threading?: ChannelPlugin["threading"];
-  handleAction: ChannelActionHandler;
-}): ChannelPlugin {
-  const actions = new Set(params.actions);
-  const gatewayActions = new Set(params.gatewayActions ?? params.actions);
-  return {
-    id: params.pluginId,
-    meta: {
-      id: params.pluginId,
-      label: params.label,
-      selectionLabel: params.label,
-      docsPath: `/channels/${params.pluginId}`,
-      blurb: params.blurb,
-    },
-    capabilities: params.capabilities ?? { chatTypes: ["direct"] },
-    config: createAlwaysConfiguredPluginConfig(),
-    messaging: params.messaging,
-    threading: params.threading,
-    actions: {
-      describeMessageTool: () => ({ actions: params.actions }),
-      supportsAction: ({ action }) => actions.has(action),
-      resolveExecutionMode: ({ action }) => (gatewayActions.has(action) ? "gateway" : "local"),
-      handleAction: params.handleAction,
-    },
-  };
-}
-
-async function executePluginAction(params: {
-  action: "send" | "poll";
-  ctx: Pick<
-    ChannelMessageActionContext,
-    | "channel"
-    | "cfg"
-    | "params"
-    | "mediaAccess"
-    | "accountId"
-    | "gateway"
-    | "toolContext"
-    | "inboundEventKind"
-  > & {
-    dryRun: boolean;
-    agentId?: string;
-  };
-}) {
-  const handled = await dispatchChannelMessageAction({
-    channel: params.ctx.channel,
-    action: params.action,
-    cfg: params.ctx.cfg,
-    params: params.ctx.params,
-    mediaAccess: params.ctx.mediaAccess,
-    mediaLocalRoots: params.ctx.mediaAccess?.localRoots ?? [],
-    mediaReadFile:
-      typeof params.ctx.mediaAccess?.readFile === "function"
-        ? params.ctx.mediaAccess.readFile
-        : undefined,
-    accountId: params.ctx.accountId ?? undefined,
-    gateway: params.ctx.gateway,
-    toolContext: params.ctx.toolContext,
-    inboundEventKind: params.ctx.inboundEventKind,
-    dryRun: params.ctx.dryRun,
-    agentId: params.ctx.agentId,
-  });
-  if (!handled) {
-    throw new Error(`expected plugin to handle ${params.action}`);
-  }
-  return {
-    handledBy: "plugin" as const,
-    payload: extractToolPayload(handled),
-    toolResult: handled,
-  };
-}
-
 describe("runMessageAction plugin dispatch", () => {
   beforeEach(() => {
-    mocks.resolveOutboundChannelPlugin.mockReset();
-    mocks.resolveOutboundChannelPlugin.mockImplementation(
-      ({ channel }: { channel: string }) =>
-        getActivePluginRegistry()?.channels.find((entry) => entry?.plugin?.id === channel)?.plugin,
-    );
-    mocks.executeSendAction.mockReset();
-    mocks.executeSendAction.mockImplementation(
-      async ({ ctx }: { ctx: Parameters<typeof executePluginAction>[0]["ctx"] }) =>
-        await executePluginAction({ action: "send", ctx }),
-    );
-    mocks.executePollAction.mockReset();
-    mocks.executePollAction.mockImplementation(
-      async ({ ctx }: { ctx: Parameters<typeof executePluginAction>[0]["ctx"] }) =>
-        await executePluginAction({ action: "poll", ctx }),
-    );
-    mocks.hasCorePresentationDelivery.mockReset();
-    mocks.hasCorePresentationDelivery.mockImplementation(
-      (outbound?: { sendPayload?: unknown; sendText?: unknown; sendFormattedText?: unknown }) =>
-        Boolean(outbound?.sendPayload || outbound?.sendText || outbound?.sendFormattedText),
-    );
-    mocks.materializeMessagePresentationFallback.mockReset();
-    mocks.materializeMessagePresentationFallback.mockImplementation(
-      (params: { payload: { presentation?: unknown; text?: string }; text?: string }) => {
-        const presentation = normalizeMessagePresentation(params.payload.presentation);
-        const text = (params.text ?? params.payload.text ?? "").trim();
-        if (!presentation) {
-          return text;
-        }
-        const fallback = renderMessagePresentationFallbackText({ presentation });
-        return !fallback || text.includes(fallback)
-          ? text
-          : [text, fallback].filter(Boolean).join("\n\n");
-      },
-    );
-    mocks.callGateway.mockReset();
-    mocks.callGatewayLeastPrivilege.mockReset();
-    mocks.isGatewayTransportError.mockReset();
-    mocks.isGatewayTransportError.mockImplementation(
-      (value: unknown) =>
-        value instanceof Error && (value as { kind?: unknown }).kind === "timeout",
-    );
-    mocks.randomIdempotencyKey.mockClear();
-    mocks.maybeApplyTtsToPayload.mockReset();
-    mocks.maybeApplyTtsToPayload.mockImplementation(
-      async (params: { payload: unknown }) => params.payload,
-    );
-    mocks.prepareOutboundMirrorRoute.mockClear();
-    mocks.beginTerminalSourceReplyDelivery.mockReset();
-    mocks.cancelTerminalSourceReplyDelivery.mockReset();
-    mocks.reconcileTerminalSourceReplyDelivery.mockReset();
+    resetMessageActionRunnerMocks();
   });
   describe("alias-based plugin action dispatch", () => {
     const handleAction = vi.fn(async ({ params }: { params: Record<string, unknown> }) =>

--- a/src/infra/outbound/message-action-runner.poll.test.ts
+++ b/src/infra/outbound/message-action-runner.poll.test.ts
@@ -1,167 +1,21 @@
 // Covers message-action poll handling through plugin dispatch and core gateway
 // poll fallback.
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
-import type { OpenClawConfig } from "../../config/config.js";
-import { getActivePluginRegistry, setActivePluginRegistry } from "../../plugins/runtime.js";
-import { createTestRegistry } from "../../test-utils/channel-plugins.js";
-import { runMessageAction } from "./message-action-runner.js";
-
-const mocks = vi.hoisted(() => ({
-  executePollAction: vi.fn(),
-  resolveOutboundChannelPlugin: vi.fn(),
-}));
-
-function firstMockArg(
-  mock: { mock: { calls: readonly unknown[][] } },
-  label: string,
-): Record<string, unknown> {
-  const [call] = mock.mock.calls;
-  if (!call) {
-    throw new Error(`expected ${label} call`);
-  }
-  const [arg] = call;
-  if (typeof arg !== "object" || arg === null || Array.isArray(arg)) {
-    throw new Error(`expected ${label} params to be an object`);
-  }
-  return arg as Record<string, unknown>;
-}
-
-vi.mock("./channel-resolution.js", () => ({
-  normalizeDeliverableOutboundChannel: (value?: string | null) =>
-    typeof value === "string" ? value.trim().toLowerCase() || undefined : undefined,
-  resolveOutboundChannelPlugin: mocks.resolveOutboundChannelPlugin,
-  resetOutboundChannelResolutionStateForTest: vi.fn(),
-}));
-
-vi.mock("./outbound-send-service.js", () => ({
-  executeSendAction: vi.fn(async () => {
-    throw new Error("executeSendAction should not run in poll tests");
-  }),
-  executePollAction: mocks.executePollAction,
-}));
-
-vi.mock("./outbound-session.js", () => ({
-  ensureOutboundSessionEntry: vi.fn(async () => undefined),
-  resolveOutboundSessionRoute: vi.fn(async () => null),
-}));
-
-vi.mock("./message-action-threading.js", async () => {
-  const { createOutboundThreadingMock } =
-    await import("./message-action-threading.test-helpers.js");
-  return createOutboundThreadingMock();
-});
-const pollerConfig = {
-  channels: {
-    poller: {
-      botToken: "poller-test",
-    },
-  },
-} as OpenClawConfig;
-
-const pollerTestPlugin: ChannelPlugin = {
-  id: "poller",
-  meta: {
-    id: "poller",
-    label: "Poller",
-    selectionLabel: "Poller",
-    docsPath: "/channels/poller",
-    blurb: "Poller test plugin.",
-  },
-  capabilities: { chatTypes: ["direct", "group"] },
-  config: {
-    listAccountIds: () => ["default"],
-    resolveAccount: () => ({ botToken: "poller-test" }),
-    isConfigured: () => true,
-  },
-  outbound: {
-    deliveryMode: "gateway",
-    sendPoll: async () => ({
-      messageId: "poll-test",
-    }),
-  },
-  messaging: {
-    targetResolver: {
-      looksLikeId: () => true,
-      resolveTarget: async ({ normalized }) => ({
-        to: normalized,
-        kind: "user",
-        source: "normalized",
-      }),
-    },
-  },
-  threading: {
-    resolveAutoThreadId: ({ toolContext, to, replyToId }) => {
-      if (replyToId) {
-        return undefined;
-      }
-      if (toolContext?.currentChannelId !== to) {
-        return undefined;
-      }
-      return toolContext.currentThreadTs;
-    },
-  },
-};
-
-async function runPollAction(params: {
-  cfg: OpenClawConfig;
-  actionParams: Record<string, unknown>;
-  toolContext?: Record<string, unknown>;
-  inboundEventKind?: "user_request" | "room_event";
-}) {
-  await runMessageAction({
-    cfg: params.cfg,
-    action: "poll",
-    params: params.actionParams as never,
-    toolContext: params.toolContext as never,
-    inboundEventKind: params.inboundEventKind,
-  });
-  const call = firstMockArg(mocks.executePollAction, "executePollAction") as {
-    resolveCorePoll?: () => {
-      durationHours?: number;
-      maxSelections?: number;
-      threadId?: string;
-    };
-    ctx?: {
-      plugin?: ChannelPlugin;
-      inboundEventKind?: string;
-      idempotencyKey?: string;
-      params?: Record<string, unknown>;
-    };
-  };
-  return {
-    ...call.resolveCorePoll?.(),
-    ctx: call.ctx,
-  };
-}
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearMessageActionPollMocks,
+  messageActionRunnerMocks as mocks,
+  pollerConfig,
+  resetMessageActionPollMocks,
+  runPollAction,
+} from "./message-action-runner.test-helpers.js";
 
 describe("runMessageAction poll handling", () => {
   beforeEach(() => {
-    setActivePluginRegistry(
-      createTestRegistry([
-        {
-          pluginId: "poller",
-          source: "test",
-          plugin: pollerTestPlugin,
-        },
-      ]),
-    );
-    mocks.resolveOutboundChannelPlugin.mockReset();
-    mocks.resolveOutboundChannelPlugin.mockImplementation(
-      ({ channel }: { channel: string }) =>
-        getActivePluginRegistry()?.channels.find((entry) => entry?.plugin?.id === channel)?.plugin,
-    );
-    mocks.executePollAction.mockReset();
-    mocks.executePollAction.mockImplementation(async (input) => ({
-      handledBy: "core",
-      payload: { ok: true, corePoll: input.resolveCorePoll() },
-      pollResult: { ok: true },
-    }));
+    resetMessageActionPollMocks();
   });
 
   afterEach(() => {
-    setActivePluginRegistry(createTestRegistry([]));
-    mocks.executePollAction.mockReset();
+    clearMessageActionPollMocks();
   });
   it("requires at least two poll options", async () => {
     await expect(

--- a/src/infra/outbound/message-action-runner.reply-action.test.ts
+++ b/src/infra/outbound/message-action-runner.reply-action.test.ts
@@ -1,70 +1,11 @@
 // Covers reply-type plugin actions: outbound text hygiene (citation control
 // markers) and current-source delivery marking for implicit reply routes.
-import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
-import type { OpenClawConfig } from "../../config/config.js";
+import { afterEach, describe, expect, it } from "vitest";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
-import { runMessageAction } from "./message-action-runner.js";
-
-type ChannelActionHandler = NonNullable<NonNullable<ChannelPlugin["actions"]>["handleAction"]>;
-
-const testchatConfig = {
-  channels: {
-    testchat: {
-      enabled: true,
-    },
-  },
-} as OpenClawConfig;
+import { registerReplyPlugin, runReplyAction } from "./message-action-test-fixtures.js";
 
 const CITATION_MARKED_MESSAGE = "Ayutthaya Thai is my pick. citeturn2search9turn2search6";
-
-function createReplyActionPlugin(handleAction: ChannelActionHandler): ChannelPlugin {
-  return {
-    id: "testchat",
-    meta: {
-      id: "testchat",
-      label: "Test Chat",
-      selectionLabel: "Test Chat",
-      docsPath: "/channels/testchat",
-      blurb: "Reply action test plugin.",
-    },
-    capabilities: { chatTypes: ["direct"] },
-    config: {
-      listAccountIds: () => ["default"],
-      resolveAccount: () => ({ enabled: true }),
-      isConfigured: () => true,
-    },
-    outbound: {
-      deliveryMode: "direct",
-      sendText: async () => ({ channel: "testchat", messageId: "m-send-1" }),
-    },
-    messaging: {
-      targetResolver: {
-        looksLikeId: () => true,
-      },
-    },
-    actions: {
-      describeMessageTool: () => ({ actions: ["reply", "poll"] }),
-      supportsAction: ({ action }) => action === "reply" || action === "poll",
-      handleAction,
-    },
-  };
-}
-
-function registerReplyPlugin() {
-  const payload = { ok: true, messageId: "m-reply-1", repliedTo: "platform-guid-1" };
-  const handleAction = vi.fn(async () => ({
-    content: [{ type: "text" as const, text: JSON.stringify(payload) }],
-    details: payload,
-  }));
-  setActivePluginRegistry(
-    createTestRegistry([
-      { pluginId: "testchat", source: "test", plugin: createReplyActionPlugin(handleAction) },
-    ]),
-  );
-  return handleAction;
-}
 
 function readHandledParams(handleAction: {
   mock: { calls: readonly unknown[][] };
@@ -79,31 +20,6 @@ function readHandledParams(handleAction: {
     throw new Error("expected plugin handleAction params");
   }
   return params as Record<string, unknown>;
-}
-
-async function runReplyAction(params: {
-  actionParams: Record<string, unknown>;
-  currentMessageId?: string | number;
-}) {
-  const toolContext = {
-    currentChannelProvider: "testchat" as const,
-    currentChannelId: "direct:user-1",
-    ...(params.currentMessageId !== undefined ? { currentMessageId: params.currentMessageId } : {}),
-  };
-  return await runMessageAction({
-    cfg: testchatConfig,
-    action: "reply",
-    params: { channel: "testchat", ...params.actionParams },
-    toolContext,
-    messageActionAuthorization: {
-      requesterAccountId: "default",
-      toolContext,
-    },
-    sessionKey: "agent:main:testchat:direct:user-1",
-    defaultAccountId: "default",
-    sourceReplyDeliveryMode: "message_tool_only",
-    dryRun: false,
-  });
 }
 
 describe("runMessageAction reply-type plugin actions", () => {

--- a/src/infra/outbound/message-action-runner.send-validation.test.ts
+++ b/src/infra/outbound/message-action-runner.send-validation.test.ts
@@ -9,7 +9,7 @@ import {
   forumTestPlugin,
   workspaceConfig,
   workspaceTestPlugin,
-} from "./message-action-runner.test-helpers.js";
+} from "./message-action-test-fixtures.js";
 
 const emptyConfig = {} as OpenClawConfig;
 describe("runMessageAction send validation", () => {

--- a/src/infra/outbound/message-action-runner.test-helpers.ts
+++ b/src/infra/outbound/message-action-runner.test-helpers.ts
@@ -1,183 +1,467 @@
-// Message-action runner test helpers define reusable plugin fixtures, target
-// parsers, and dry-run wrappers.
+// Shared runner-facade test harness. These mocks isolate message-action routing,
+// execution, and send coordination from real channel and gateway runtimes.
+import { vi } from "vitest";
+import { dispatchChannelMessageAction } from "../../channels/plugins/message-action-dispatch.js";
 import type {
-  ChannelDirectoryEntryKind,
+  ChannelMessageActionContext,
   ChannelMessageActionName,
-  ChannelMessagingAdapter,
-  ChannelOutboundAdapter,
   ChannelPlugin,
 } from "../../channels/plugins/types.public.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { createChannelTestPluginBase } from "../../test-utils/channel-plugins.js";
-import { runMessageAction } from "./message-action-runner.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import {
+  normalizeMessagePresentation,
+  renderMessagePresentationFallbackText,
+} from "../../interactive/payload.js";
+import { extractToolPayload } from "../../plugin-sdk/tool-payload.js";
+import { getActivePluginRegistry, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 
-/** Workspace-style config fixture used by message action runner tests. */
-export const workspaceConfig = {
-  channels: {
-    workspace: {
-      botToken: "workspace-test",
-      appToken: "workspace-app-test",
-    },
-  },
-} as OpenClawConfig;
+type ChannelActionHandler = NonNullable<NonNullable<ChannelPlugin["actions"]>["handleAction"]>;
 
-/** Direct-chat config fixture that allows any sender. */
-export const directChatConfig = {
-  channels: {
-    directchat: {
-      allowFrom: ["*"],
-    },
-  },
-} as OpenClawConfig;
-
-export const directOutbound: ChannelOutboundAdapter = {
-  deliveryMode: "direct",
-  sendText: async () => ({ channel: "test", messageId: "test" }),
+export const messageActionRunnerMocks = {
+  resolveOutboundChannelPlugin: vi.fn(),
+  executeSendAction: vi.fn(),
+  executePollAction: vi.fn(),
+  hasCorePresentationDelivery: vi.fn(),
+  materializeMessagePresentationFallback: vi.fn(),
+  callGateway: vi.fn(),
+  callGatewayLeastPrivilege: vi.fn(),
+  isGatewayTransportError: vi.fn(),
+  randomIdempotencyKey: vi.fn(() => "idem-gateway-action"),
+  maybeApplyTtsToPayload: vi.fn(async (params: { payload: unknown }) => params.payload),
+  prepareOutboundMirrorRoute: vi.fn(),
+  beginTerminalSourceReplyDelivery: vi.fn(),
+  cancelTerminalSourceReplyDelivery: vi.fn(),
+  isCurrentSourceReplyActionName: vi.fn(() => false),
+  isDeliveredCurrentSourceReply: vi.fn(() => false),
+  isDeliveredCurrentSourceReplyAction: vi.fn(() => false),
+  reconcileTerminalSourceReplyDelivery: vi.fn(),
+  loadWebMedia: vi.fn<typeof import("../../media/web-media.js").loadWebMedia>(),
 };
 
-// Test plugins model token-gated workspace sends without booting real channel runtimes.
-function hasChannelBotToken(channelConfig: unknown): boolean {
-  if (channelConfig == null || typeof channelConfig !== "object" || Array.isArray(channelConfig)) {
-    return false;
-  }
-  const token = (channelConfig as Record<string, unknown>).botToken;
-  return typeof token === "string" && Boolean(token.trim());
+vi.mock("./channel-resolution.js", () => ({
+  normalizeDeliverableOutboundChannel: (value?: string | null) =>
+    typeof value === "string" ? value.trim().toLowerCase() || undefined : undefined,
+  resolveOutboundChannelPlugin: messageActionRunnerMocks.resolveOutboundChannelPlugin,
+  resetOutboundChannelResolutionStateForTest: vi.fn(),
+}));
+
+vi.mock("./outbound-send-service.js", () => ({
+  executeSendAction: messageActionRunnerMocks.executeSendAction,
+  executePollAction: messageActionRunnerMocks.executePollAction,
+  hasCorePresentationDelivery: messageActionRunnerMocks.hasCorePresentationDelivery,
+  materializeMessagePresentationFallback:
+    messageActionRunnerMocks.materializeMessagePresentationFallback,
+}));
+
+vi.mock("./message.gateway.runtime.js", () => ({
+  callGateway: messageActionRunnerMocks.callGateway,
+  callGatewayLeastPrivilege: messageActionRunnerMocks.callGatewayLeastPrivilege,
+  isGatewayTransportError: messageActionRunnerMocks.isGatewayTransportError,
+  randomIdempotencyKey: messageActionRunnerMocks.randomIdempotencyKey,
+}));
+
+vi.mock("./source-reply-mirror.js", () => ({
+  beginTerminalSourceReplyDelivery: messageActionRunnerMocks.beginTerminalSourceReplyDelivery,
+  cancelTerminalSourceReplyDelivery: messageActionRunnerMocks.cancelTerminalSourceReplyDelivery,
+  isCurrentSourceReplyActionName: messageActionRunnerMocks.isCurrentSourceReplyActionName,
+  isDeliveredCurrentSourceReply: messageActionRunnerMocks.isDeliveredCurrentSourceReply,
+  isDeliveredCurrentSourceReplyAction: messageActionRunnerMocks.isDeliveredCurrentSourceReplyAction,
+  reconcileTerminalSourceReplyDelivery:
+    messageActionRunnerMocks.reconcileTerminalSourceReplyDelivery,
+}));
+
+vi.mock("../../tts/tts.runtime.js", () => ({
+  maybeApplyTtsToPayload: messageActionRunnerMocks.maybeApplyTtsToPayload,
+}));
+
+vi.mock("./outbound-session.js", () => ({
+  ensureOutboundSessionEntry: vi.fn(async () => undefined),
+  resolveOutboundSessionRoute: vi.fn(async () => null),
+}));
+
+vi.mock("../../channels/plugins/bootstrap-registry.js", () => ({
+  getBootstrapChannelPlugin: (id: string) =>
+    id === "actionhub"
+      ? {
+          actions: {
+            messageActionTargetAliases: {
+              pin: { aliases: ["messageId"] },
+              unpin: { aliases: ["messageId"] },
+              "list-pins": { aliases: ["chatId"] },
+            },
+          },
+        }
+      : undefined,
+}));
+
+vi.mock("./message-action-threading.js", async () => {
+  const { createOutboundThreadingMock } =
+    await import("./message-action-threading.test-helpers.js");
+  const threading = createOutboundThreadingMock();
+  messageActionRunnerMocks.prepareOutboundMirrorRoute.mockImplementation(
+    threading.prepareOutboundMirrorRoute,
+  );
+  return {
+    ...threading,
+    prepareOutboundMirrorRoute: messageActionRunnerMocks.prepareOutboundMirrorRoute,
+  };
+});
+
+vi.mock("../../media/web-media.js", () => ({
+  loadWebMedia: messageActionRunnerMocks.loadWebMedia,
+}));
+
+type RunMessageAction = typeof import("./message-action-runner.js").runMessageAction;
+
+export const runMessageAction: RunMessageAction = async (...args) =>
+  (await import("./message-action-runner.js")).runMessageAction(...args);
+
+export function setMessageActionTestPlugin(plugin: unknown, pluginId: string, origin?: "bundled") {
+  setActivePluginRegistry(
+    createTestRegistry([{ pluginId, source: "test", ...(origin ? { origin } : {}), plugin }]),
+  );
 }
 
-export const runDryAction = (params: {
-  cfg: OpenClawConfig;
-  action: ChannelMessageActionName;
-  actionParams: Record<string, unknown>;
-  toolContext?: Record<string, unknown>;
-  abortSignal?: AbortSignal;
-  sandboxRoot?: string;
-  agentId?: string;
-}) =>
-  runMessageAction({
-    cfg: params.cfg,
-    action: params.action,
-    params: params.actionParams as never,
-    toolContext: params.toolContext as never,
-    dryRun: true,
-    abortSignal: params.abortSignal,
-    sandboxRoot: params.sandboxRoot,
-    agentId: params.agentId,
-  });
-
-export const runDrySend = (params: {
-  cfg: OpenClawConfig;
-  actionParams: Record<string, unknown>;
-  toolContext?: Record<string, unknown>;
-  abortSignal?: AbortSignal;
-  sandboxRoot?: string;
-  agentId?: string;
-}) =>
-  runDryAction({
-    ...params,
-    action: "send",
-  });
-
-type ResolvedTestTarget = { to: string; kind: ChannelDirectoryEntryKind };
-
-function normalizeWorkspaceTarget(raw: string): string {
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return trimmed;
-  }
-  if (trimmed.startsWith("#")) {
-    return trimmed.slice(1).trim();
-  }
-  if (/^channel:/i.test(trimmed)) {
-    return trimmed.replace(/^channel:/i, "").trim();
-  }
-  if (/^user:/i.test(trimmed)) {
-    return trimmed.replace(/^user:/i, "").trim();
-  }
-  const mention = trimmed.match(/^<@([A-Z0-9]+)>$/i);
-  if (mention?.[1]) {
-    return mention[1];
-  }
-  return trimmed;
+export function createAlwaysConfiguredPluginConfig(
+  account: Record<string, unknown> = { enabled: true },
+) {
+  return {
+    listAccountIds: () => ["default"],
+    resolveAccount: () => account,
+    isConfigured: () => true,
+  };
 }
 
-function createConfiguredTestPlugin(params: {
-  id: string;
-  isConfigured: (cfg: OpenClawConfig) => boolean;
-  normalizeTarget: (raw: string) => string | undefined;
-  resolveTarget: (input: string) => ResolvedTestTarget | null;
+export function createGatewayActionPlugin(params: {
+  pluginId: string;
+  label: string;
+  blurb: string;
+  actions: ChannelMessageActionName[];
+  gatewayActions?: ChannelMessageActionName[];
+  capabilities?: ChannelPlugin["capabilities"];
+  messaging?: ChannelPlugin["messaging"];
+  threading?: ChannelPlugin["threading"];
+  handleAction: ChannelActionHandler;
 }): ChannelPlugin {
-  const messaging: ChannelMessagingAdapter = {
-    normalizeTarget: params.normalizeTarget,
-    targetResolver: {
-      looksLikeId: (raw) => Boolean(params.resolveTarget(raw.trim())),
-      hint: "<id>",
-      resolveTarget: async (resolverParams) => {
-        const resolved = params.resolveTarget(resolverParams.input);
-        return resolved ? { ...resolved, source: "normalized" } : null;
+  const actions = new Set(params.actions);
+  const gatewayActions = new Set(params.gatewayActions ?? params.actions);
+  return {
+    id: params.pluginId,
+    meta: {
+      id: params.pluginId,
+      label: params.label,
+      selectionLabel: params.label,
+      docsPath: `/channels/${params.pluginId}`,
+      blurb: params.blurb,
+    },
+    capabilities: params.capabilities ?? { chatTypes: ["direct"] },
+    config: createAlwaysConfiguredPluginConfig(),
+    messaging: params.messaging,
+    threading: params.threading,
+    actions: {
+      describeMessageTool: () => ({ actions: params.actions }),
+      supportsAction: ({ action }) => actions.has(action),
+      resolveExecutionMode: ({ action }) => (gatewayActions.has(action) ? "gateway" : "local"),
+      handleAction: params.handleAction,
+    },
+  };
+}
+
+export function createPollForwardingPlugin(params: {
+  pluginId: string;
+  label: string;
+  blurb: string;
+  handleAction: ChannelActionHandler;
+}): ChannelPlugin {
+  return {
+    id: params.pluginId,
+    meta: {
+      id: params.pluginId,
+      label: params.label,
+      selectionLabel: params.label,
+      docsPath: `/channels/${params.pluginId}`,
+      blurb: params.blurb,
+    },
+    capabilities: { chatTypes: ["direct"] },
+    config: createAlwaysConfiguredPluginConfig(),
+    messaging: {
+      targetResolver: {
+        looksLikeId: () => true,
       },
     },
-    inferTargetChatType: (inferParams) =>
-      params.resolveTarget(inferParams.to)?.kind === "user" ? "direct" : "group",
-  };
-  return {
-    ...createChannelTestPluginBase({
-      id: params.id,
-      config: {
-        listAccountIds: () => ["default"],
-        resolveAccount: () => ({ enabled: true }),
-        isConfigured: (_account, cfg) => params.isConfigured(cfg),
-      },
-    }),
-    outbound: directOutbound,
-    messaging,
+    actions: {
+      describeMessageTool: () => ({ actions: ["poll"] }),
+      supportsAction: ({ action }) => action === "poll",
+      handleAction: params.handleAction,
+    },
   };
 }
 
-export const workspaceTestPlugin = createConfiguredTestPlugin({
-  id: "workspace",
-  isConfigured: (cfg) => hasChannelBotToken(cfg.channels?.workspace),
-  normalizeTarget: (raw) => normalizeWorkspaceTarget(raw) || undefined,
-  resolveTarget: (input) => {
-    const normalized = normalizeWorkspaceTarget(input);
-    if (!normalized) {
-      return null;
-    }
-    if (/^[A-Z0-9]+$/i.test(normalized)) {
-      const kind = /^U/i.test(normalized) ? "user" : "group";
-      return { to: normalized, kind };
-    }
-    return null;
-  },
-});
+async function executePluginAction(params: {
+  action: "send" | "poll";
+  ctx: Pick<
+    ChannelMessageActionContext,
+    | "channel"
+    | "cfg"
+    | "params"
+    | "mediaAccess"
+    | "accountId"
+    | "gateway"
+    | "toolContext"
+    | "inboundEventKind"
+  > & {
+    dryRun: boolean;
+    agentId?: string;
+  };
+}) {
+  const handled = await dispatchChannelMessageAction({
+    channel: params.ctx.channel,
+    action: params.action,
+    cfg: params.ctx.cfg,
+    params: params.ctx.params,
+    mediaAccess: params.ctx.mediaAccess,
+    mediaLocalRoots: params.ctx.mediaAccess?.localRoots ?? [],
+    mediaReadFile:
+      typeof params.ctx.mediaAccess?.readFile === "function"
+        ? params.ctx.mediaAccess.readFile
+        : undefined,
+    accountId: params.ctx.accountId ?? undefined,
+    gateway: params.ctx.gateway,
+    toolContext: params.ctx.toolContext,
+    inboundEventKind: params.ctx.inboundEventKind,
+    dryRun: params.ctx.dryRun,
+    agentId: params.ctx.agentId,
+  });
+  if (!handled) {
+    throw new Error(`expected plugin to handle ${params.action}`);
+  }
+  return {
+    handledBy: "plugin" as const,
+    payload: extractToolPayload(handled),
+    toolResult: handled,
+  };
+}
 
-export const forumTestPlugin = createConfiguredTestPlugin({
-  id: "forum",
-  isConfigured: (cfg) => hasChannelBotToken(cfg.channels?.forum),
-  normalizeTarget: (raw) => raw.trim() || undefined,
-  resolveTarget: (input) => {
-    const normalized = input.trim();
-    if (!normalized) {
-      return null;
-    }
-    return {
-      to: normalized.replace(/^forum:/i, ""),
-      kind: normalized.startsWith("@") ? "user" : "group",
-    };
-  },
-});
+export function resetMessageActionRunnerMocks() {
+  const mocks = messageActionRunnerMocks;
+  mocks.resolveOutboundChannelPlugin.mockReset();
+  mocks.resolveOutboundChannelPlugin.mockImplementation(
+    ({ channel }: { channel: string }) =>
+      getActivePluginRegistry()?.channels.find((entry) => entry?.plugin?.id === channel)?.plugin,
+  );
+  mocks.executeSendAction.mockReset();
+  mocks.executeSendAction.mockImplementation(
+    async ({ ctx }: { ctx: Parameters<typeof executePluginAction>[0]["ctx"] }) =>
+      await executePluginAction({ action: "send", ctx }),
+  );
+  mocks.executePollAction.mockReset();
+  mocks.executePollAction.mockImplementation(
+    async ({ ctx }: { ctx: Parameters<typeof executePluginAction>[0]["ctx"] }) =>
+      await executePluginAction({ action: "poll", ctx }),
+  );
+  mocks.hasCorePresentationDelivery.mockReset();
+  mocks.hasCorePresentationDelivery.mockImplementation(
+    (outbound?: { sendPayload?: unknown; sendText?: unknown; sendFormattedText?: unknown }) =>
+      Boolean(outbound?.sendPayload || outbound?.sendText || outbound?.sendFormattedText),
+  );
+  mocks.materializeMessagePresentationFallback.mockReset();
+  mocks.materializeMessagePresentationFallback.mockImplementation(
+    (params: { payload: { presentation?: unknown; text?: string }; text?: string }) => {
+      const presentation = normalizeMessagePresentation(params.payload.presentation);
+      const text = (params.text ?? params.payload.text ?? "").trim();
+      if (!presentation) {
+        return text;
+      }
+      const fallback = renderMessagePresentationFallbackText({ presentation });
+      return !fallback || text.includes(fallback)
+        ? text
+        : [text, fallback].filter(Boolean).join("\n\n");
+    },
+  );
+  mocks.callGateway.mockReset();
+  mocks.callGatewayLeastPrivilege.mockReset();
+  mocks.isGatewayTransportError.mockReset();
+  mocks.isGatewayTransportError.mockImplementation(
+    (value: unknown) => value instanceof Error && (value as { kind?: unknown }).kind === "timeout",
+  );
+  mocks.randomIdempotencyKey.mockClear();
+  mocks.maybeApplyTtsToPayload.mockReset();
+  mocks.maybeApplyTtsToPayload.mockImplementation(
+    async (params: { payload: unknown }) => params.payload,
+  );
+  mocks.prepareOutboundMirrorRoute.mockClear();
+  mocks.beginTerminalSourceReplyDelivery.mockReset();
+  mocks.cancelTerminalSourceReplyDelivery.mockReset();
+  mocks.reconcileTerminalSourceReplyDelivery.mockReset();
+}
 
-export const directChatTestPlugin = createConfiguredTestPlugin({
-  id: "directchat",
-  isConfigured: (cfg) => Boolean(cfg.channels?.directchat),
-  normalizeTarget: (raw) => raw.trim() || undefined,
-  resolveTarget: (input) => {
-    const normalized = input.trim();
-    if (!normalized) {
-      return null;
-    }
-    return {
-      to: normalized,
-      kind: normalized.endsWith("@g.us") ? "group" : "user",
-    };
+let actualLoadWebMedia: typeof import("../../media/web-media.js").loadWebMedia | undefined;
+
+export async function resetMessageActionMediaMocks() {
+  actualLoadWebMedia ??= (
+    await vi.importActual<typeof import("../../media/web-media.js")>("../../media/web-media.js")
+  ).loadWebMedia;
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  const mocks = messageActionRunnerMocks;
+  mocks.resolveOutboundChannelPlugin.mockReset();
+  mocks.resolveOutboundChannelPlugin.mockImplementation(
+    ({ channel }: { channel: string }) =>
+      getActivePluginRegistry()?.channels.find((entry) => entry?.plugin?.id === channel)?.plugin,
+  );
+  mocks.executeSendAction.mockReset();
+  mocks.executeSendAction.mockImplementation(
+    async ({
+      ctx,
+      to,
+      message,
+      mediaUrl,
+      mediaUrls,
+    }: {
+      ctx: { channel: string; dryRun: boolean };
+      to: string;
+      message: string;
+      mediaUrl?: string;
+      mediaUrls?: string[];
+    }) => ({
+      handledBy: "core" as const,
+      payload: {
+        channel: ctx.channel,
+        to,
+        message,
+        mediaUrl,
+        mediaUrls,
+        dryRun: ctx.dryRun,
+      },
+      sendResult: {
+        channel: ctx.channel,
+        messageId: "msg-test",
+        ...(mediaUrl ? { mediaUrl } : {}),
+        ...(mediaUrls ? { mediaUrls } : {}),
+      },
+    }),
+  );
+  mocks.executePollAction.mockReset();
+  mocks.executePollAction.mockImplementation(async () => {
+    throw new Error("executePollAction should not run in media tests");
+  });
+  mocks.loadWebMedia.mockReset();
+  mocks.loadWebMedia.mockImplementation(actualLoadWebMedia);
+}
+
+export const pollerConfig = {
+  channels: {
+    poller: {
+      botToken: "poller-test",
+    },
   },
-});
+} as OpenClawConfig;
+
+export const pollerTestPlugin: ChannelPlugin = {
+  id: "poller",
+  meta: {
+    id: "poller",
+    label: "Poller",
+    selectionLabel: "Poller",
+    docsPath: "/channels/poller",
+    blurb: "Poller test plugin.",
+  },
+  capabilities: { chatTypes: ["direct", "group"] },
+  config: {
+    listAccountIds: () => ["default"],
+    resolveAccount: () => ({ botToken: "poller-test" }),
+    isConfigured: () => true,
+  },
+  outbound: {
+    deliveryMode: "gateway",
+    sendPoll: async () => ({
+      messageId: "poll-test",
+    }),
+  },
+  messaging: {
+    targetResolver: {
+      looksLikeId: () => true,
+      resolveTarget: async ({ normalized }) => ({
+        to: normalized,
+        kind: "user",
+        source: "normalized",
+      }),
+    },
+  },
+  threading: {
+    resolveAutoThreadId: ({ toolContext, to, replyToId }) => {
+      if (replyToId) {
+        return undefined;
+      }
+      if (toolContext?.currentChannelId !== to) {
+        return undefined;
+      }
+      return toolContext.currentThreadTs;
+    },
+  },
+};
+
+export async function runPollAction(params: {
+  cfg: OpenClawConfig;
+  actionParams: Record<string, unknown>;
+  toolContext?: Record<string, unknown>;
+  inboundEventKind?: "user_request" | "room_event";
+}) {
+  await runMessageAction({
+    cfg: params.cfg,
+    action: "poll",
+    params: params.actionParams as never,
+    toolContext: params.toolContext as never,
+    inboundEventKind: params.inboundEventKind,
+  });
+  const call = messageActionRunnerMocks.executePollAction.mock.calls[0]?.[0] as
+    | {
+        resolveCorePoll?: () => {
+          durationHours?: number;
+          maxSelections?: number;
+          threadId?: string;
+        };
+        ctx?: {
+          plugin?: ChannelPlugin;
+          inboundEventKind?: string;
+          idempotencyKey?: string;
+          params?: Record<string, unknown>;
+        };
+      }
+    | undefined;
+  if (!call) {
+    throw new Error("expected executePollAction call");
+  }
+  return {
+    ...call.resolveCorePoll?.(),
+    ctx: call.ctx,
+  };
+}
+
+export function resetMessageActionPollMocks() {
+  setActivePluginRegistry(
+    createTestRegistry([{ pluginId: "poller", source: "test", plugin: pollerTestPlugin }]),
+  );
+  const mocks = messageActionRunnerMocks;
+  mocks.resolveOutboundChannelPlugin.mockReset();
+  mocks.resolveOutboundChannelPlugin.mockImplementation(
+    ({ channel }: { channel: string }) =>
+      getActivePluginRegistry()?.channels.find((entry) => entry?.plugin?.id === channel)?.plugin,
+  );
+  mocks.executeSendAction.mockReset();
+  mocks.executeSendAction.mockImplementation(async () => {
+    throw new Error("executeSendAction should not run in poll tests");
+  });
+  mocks.executePollAction.mockReset();
+  mocks.executePollAction.mockImplementation(async (input) => ({
+    handledBy: "core",
+    payload: { ok: true, corePoll: input.resolveCorePoll() },
+    pollResult: { ok: true },
+  }));
+}
+
+export function clearMessageActionPollMocks() {
+  setActivePluginRegistry(createTestRegistry([]));
+  messageActionRunnerMocks.executePollAction.mockReset();
+}

--- a/src/infra/outbound/message-action-send.media.test.ts
+++ b/src/infra/outbound/message-action-send.media.test.ts
@@ -4,57 +4,18 @@ import path from "node:path";
 // Covers message-action media hydration, sandbox path normalization,
 // attachments, and channel/plugin media source aliases.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { MEDIA_MAX_BYTES } from "../../media/store.js";
-import { loadWebMedia } from "../../media/web-media.js";
-import { getActivePluginRegistry, setActivePluginRegistry } from "../../plugins/runtime.js";
-import {
-  createChannelTestPluginBase,
-  createTestRegistry,
-} from "../../test-utils/channel-plugins.js";
+import { createChannelTestPluginBase } from "../../test-utils/channel-plugins.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
-import { runMessageAction } from "./message-action-runner.js";
-
-const channelResolutionMocks = vi.hoisted(() => ({
-  resolveOutboundChannelPlugin: vi.fn(),
-  executeSendAction: vi.fn(),
-  executePollAction: vi.fn(),
-}));
-
-vi.mock("./channel-resolution.js", () => ({
-  normalizeDeliverableOutboundChannel: (value?: string | null) =>
-    typeof value === "string" ? value.trim().toLowerCase() || undefined : undefined,
-  resolveOutboundChannelPlugin: channelResolutionMocks.resolveOutboundChannelPlugin,
-  resetOutboundChannelResolutionStateForTest: vi.fn(),
-}));
-
-vi.mock("./outbound-send-service.js", () => ({
-  executeSendAction: channelResolutionMocks.executeSendAction,
-  executePollAction: channelResolutionMocks.executePollAction,
-}));
-
-vi.mock("./outbound-session.js", () => ({
-  ensureOutboundSessionEntry: vi.fn(async () => undefined),
-  resolveOutboundSessionRoute: vi.fn(async () => null),
-}));
-
-vi.mock("./message-action-threading.js", async () => {
-  const { createOutboundThreadingMock } =
-    await import("./message-action-threading.test-helpers.js");
-  return createOutboundThreadingMock();
-});
-
-vi.mock("../../media/web-media.js", async () => {
-  const actual = await vi.importActual<typeof import("../../media/web-media.js")>(
-    "../../media/web-media.js",
-  );
-  return {
-    ...actual,
-    loadWebMedia: vi.fn(actual.loadWebMedia),
-  };
-});
+import {
+  messageActionRunnerMocks as channelResolutionMocks,
+  resetMessageActionMediaMocks,
+  runMessageAction,
+  setMessageActionTestPlugin as setTestPlugin,
+} from "./message-action-runner.test-helpers.js";
 
 const workspaceConfig = {
   channels: {
@@ -64,10 +25,6 @@ const workspaceConfig = {
     },
   },
 } as OpenClawConfig;
-
-function setTestPlugin(plugin: ChannelPlugin, pluginId: string) {
-  setActivePluginRegistry(createTestRegistry([{ pluginId, source: "test", plugin }]));
-}
 
 function firstMockArg(
   mock: { mock: { calls: readonly unknown[][] } },
@@ -112,8 +69,6 @@ const runDrySend = (params: {
 
 const requireRecord = createRequireRecord("record", "expected-non-array-record");
 
-let actualLoadWebMedia: typeof loadWebMedia;
-
 const workspacePlugin: ChannelPlugin = {
   ...createChannelTestPluginBase({
     id: "workspace",
@@ -147,54 +102,7 @@ const workspacePlugin: ChannelPlugin = {
 
 describe("runMessageAction media behavior", () => {
   beforeEach(async () => {
-    actualLoadWebMedia ??= (
-      await vi.importActual<typeof import("../../media/web-media.js")>("../../media/web-media.js")
-    ).loadWebMedia;
-    vi.restoreAllMocks();
-    vi.clearAllMocks();
-    channelResolutionMocks.resolveOutboundChannelPlugin.mockReset();
-    channelResolutionMocks.resolveOutboundChannelPlugin.mockImplementation(
-      ({ channel }: { channel: string }) =>
-        getActivePluginRegistry()?.channels.find((entry) => entry?.plugin?.id === channel)?.plugin,
-    );
-    channelResolutionMocks.executeSendAction.mockReset();
-    channelResolutionMocks.executeSendAction.mockImplementation(
-      async ({
-        ctx,
-        to,
-        message,
-        mediaUrl,
-        mediaUrls,
-      }: {
-        ctx: { channel: string; dryRun: boolean };
-        to: string;
-        message: string;
-        mediaUrl?: string;
-        mediaUrls?: string[];
-      }) => ({
-        handledBy: "core" as const,
-        payload: {
-          channel: ctx.channel,
-          to,
-          message,
-          mediaUrl,
-          mediaUrls,
-          dryRun: ctx.dryRun,
-        },
-        sendResult: {
-          channel: ctx.channel,
-          messageId: "msg-test",
-          ...(mediaUrl ? { mediaUrl } : {}),
-          ...(mediaUrls ? { mediaUrls } : {}),
-        },
-      }),
-    );
-    channelResolutionMocks.executePollAction.mockReset();
-    channelResolutionMocks.executePollAction.mockImplementation(async () => {
-      throw new Error("executePollAction should not run in media tests");
-    });
-    vi.mocked(loadWebMedia).mockReset();
-    vi.mocked(loadWebMedia).mockImplementation(actualLoadWebMedia);
+    await resetMessageActionMediaMocks();
   });
   it("forwards asVoice from send actions into core delivery", async () => {
     setTestPlugin(workspacePlugin, "workspace");

--- a/src/infra/outbound/message-action-send.test.ts
+++ b/src/infra/outbound/message-action-send.test.ts
@@ -4,23 +4,18 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { jsonResult } from "../../agents/tools/common.js";
-import { dispatchChannelMessageAction } from "../../channels/plugins/message-action-dispatch.js";
-import type {
-  ChannelMessageActionContext,
-  ChannelMessageActionName,
-  ChannelPlugin,
-} from "../../channels/plugins/types.public.js";
+import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import {
-  normalizeMessagePresentation,
-  renderMessagePresentationFallbackText,
-} from "../../interactive/payload.js";
-import { extractToolPayload } from "../../plugin-sdk/tool-payload.js";
-import { getActivePluginRegistry, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
-import { runMessageAction } from "./message-action-runner.js";
-
-type ChannelActionHandler = NonNullable<NonNullable<ChannelPlugin["actions"]>["handleAction"]>;
+import {
+  createAlwaysConfiguredPluginConfig,
+  createGatewayActionPlugin,
+  messageActionRunnerMocks as mocks,
+  resetMessageActionRunnerMocks,
+  runMessageAction,
+  setMessageActionTestPlugin as setTestPlugin,
+} from "./message-action-runner.test-helpers.js";
 
 const requireRecord = createRequireRecord("record", "expected-non-array-record");
 const requireLabeledRecord = createRequireRecord("record", "expected-label");
@@ -57,237 +52,9 @@ function expectRecordFields(
   }
 }
 
-const mocks = vi.hoisted(() => ({
-  resolveOutboundChannelPlugin: vi.fn(),
-  executeSendAction: vi.fn(),
-  executePollAction: vi.fn(),
-  hasCorePresentationDelivery: vi.fn(),
-  materializeMessagePresentationFallback: vi.fn(),
-  callGateway: vi.fn(),
-  callGatewayLeastPrivilege: vi.fn(),
-  isGatewayTransportError: vi.fn(),
-  randomIdempotencyKey: vi.fn(() => "idem-gateway-action"),
-  maybeApplyTtsToPayload: vi.fn(async (params: { payload: unknown }) => params.payload),
-  prepareOutboundMirrorRoute: vi.fn(),
-  beginTerminalSourceReplyDelivery: vi.fn(),
-  cancelTerminalSourceReplyDelivery: vi.fn(),
-  isCurrentSourceReplyActionName: vi.fn(() => false),
-  isDeliveredCurrentSourceReply: vi.fn(() => false),
-  isDeliveredCurrentSourceReplyAction: vi.fn(() => false),
-  reconcileTerminalSourceReplyDelivery: vi.fn(),
-}));
-
-vi.mock("./channel-resolution.js", () => ({
-  normalizeDeliverableOutboundChannel: (value?: string | null) =>
-    typeof value === "string" ? value.trim().toLowerCase() || undefined : undefined,
-  resolveOutboundChannelPlugin: mocks.resolveOutboundChannelPlugin,
-  resetOutboundChannelResolutionStateForTest: vi.fn(),
-}));
-
-vi.mock("./outbound-send-service.js", () => ({
-  executeSendAction: mocks.executeSendAction,
-  executePollAction: mocks.executePollAction,
-  hasCorePresentationDelivery: mocks.hasCorePresentationDelivery,
-  materializeMessagePresentationFallback: mocks.materializeMessagePresentationFallback,
-}));
-
-vi.mock("./message.gateway.runtime.js", () => ({
-  callGateway: mocks.callGateway,
-  callGatewayLeastPrivilege: mocks.callGatewayLeastPrivilege,
-  isGatewayTransportError: mocks.isGatewayTransportError,
-  randomIdempotencyKey: mocks.randomIdempotencyKey,
-}));
-
-vi.mock("./source-reply-mirror.js", () => ({
-  beginTerminalSourceReplyDelivery: mocks.beginTerminalSourceReplyDelivery,
-  cancelTerminalSourceReplyDelivery: mocks.cancelTerminalSourceReplyDelivery,
-  isCurrentSourceReplyActionName: mocks.isCurrentSourceReplyActionName,
-  isDeliveredCurrentSourceReply: mocks.isDeliveredCurrentSourceReply,
-  isDeliveredCurrentSourceReplyAction: mocks.isDeliveredCurrentSourceReplyAction,
-  reconcileTerminalSourceReplyDelivery: mocks.reconcileTerminalSourceReplyDelivery,
-}));
-
-vi.mock("../../tts/tts.runtime.js", () => ({
-  maybeApplyTtsToPayload: mocks.maybeApplyTtsToPayload,
-}));
-
-vi.mock("./outbound-session.js", () => ({
-  ensureOutboundSessionEntry: vi.fn(async () => undefined),
-  resolveOutboundSessionRoute: vi.fn(async () => null),
-}));
-
-vi.mock("../../channels/plugins/bootstrap-registry.js", () => ({
-  getBootstrapChannelPlugin: (id: string) =>
-    id === "actionhub"
-      ? {
-          actions: {
-            messageActionTargetAliases: {
-              pin: { aliases: ["messageId"] },
-              unpin: { aliases: ["messageId"] },
-              "list-pins": { aliases: ["chatId"] },
-            },
-          },
-        }
-      : undefined,
-}));
-
-vi.mock("./message-action-threading.js", async () => {
-  const { createOutboundThreadingMock } =
-    await import("./message-action-threading.test-helpers.js");
-  const threading = createOutboundThreadingMock();
-  mocks.prepareOutboundMirrorRoute.mockImplementation(threading.prepareOutboundMirrorRoute);
-  return {
-    ...threading,
-    prepareOutboundMirrorRoute: mocks.prepareOutboundMirrorRoute,
-  };
-});
-
-function setTestPlugin(plugin: unknown, pluginId: string, origin?: "bundled") {
-  setActivePluginRegistry(
-    createTestRegistry([{ pluginId, source: "test", ...(origin ? { origin } : {}), plugin }]),
-  );
-}
-
-function createAlwaysConfiguredPluginConfig(account: Record<string, unknown> = { enabled: true }) {
-  return {
-    listAccountIds: () => ["default"],
-    resolveAccount: () => account,
-    isConfigured: () => true,
-  };
-}
-
-function createGatewayActionPlugin(params: {
-  pluginId: string;
-  label: string;
-  blurb: string;
-  actions: ChannelMessageActionName[];
-  gatewayActions?: ChannelMessageActionName[];
-  capabilities?: ChannelPlugin["capabilities"];
-  messaging?: ChannelPlugin["messaging"];
-  threading?: ChannelPlugin["threading"];
-  handleAction: ChannelActionHandler;
-}): ChannelPlugin {
-  const actions = new Set(params.actions);
-  const gatewayActions = new Set(params.gatewayActions ?? params.actions);
-  return {
-    id: params.pluginId,
-    meta: {
-      id: params.pluginId,
-      label: params.label,
-      selectionLabel: params.label,
-      docsPath: `/channels/${params.pluginId}`,
-      blurb: params.blurb,
-    },
-    capabilities: params.capabilities ?? { chatTypes: ["direct"] },
-    config: createAlwaysConfiguredPluginConfig(),
-    messaging: params.messaging,
-    threading: params.threading,
-    actions: {
-      describeMessageTool: () => ({ actions: params.actions }),
-      supportsAction: ({ action }) => actions.has(action),
-      resolveExecutionMode: ({ action }) => (gatewayActions.has(action) ? "gateway" : "local"),
-      handleAction: params.handleAction,
-    },
-  };
-}
-
-async function executePluginAction(params: {
-  action: "send" | "poll";
-  ctx: Pick<
-    ChannelMessageActionContext,
-    | "channel"
-    | "cfg"
-    | "params"
-    | "mediaAccess"
-    | "accountId"
-    | "gateway"
-    | "toolContext"
-    | "inboundEventKind"
-  > & {
-    dryRun: boolean;
-    agentId?: string;
-  };
-}) {
-  const handled = await dispatchChannelMessageAction({
-    channel: params.ctx.channel,
-    action: params.action,
-    cfg: params.ctx.cfg,
-    params: params.ctx.params,
-    mediaAccess: params.ctx.mediaAccess,
-    mediaLocalRoots: params.ctx.mediaAccess?.localRoots ?? [],
-    mediaReadFile:
-      typeof params.ctx.mediaAccess?.readFile === "function"
-        ? params.ctx.mediaAccess.readFile
-        : undefined,
-    accountId: params.ctx.accountId ?? undefined,
-    gateway: params.ctx.gateway,
-    toolContext: params.ctx.toolContext,
-    inboundEventKind: params.ctx.inboundEventKind,
-    dryRun: params.ctx.dryRun,
-    agentId: params.ctx.agentId,
-  });
-  if (!handled) {
-    throw new Error(`expected plugin to handle ${params.action}`);
-  }
-  return {
-    handledBy: "plugin" as const,
-    payload: extractToolPayload(handled),
-    toolResult: handled,
-  };
-}
-
 describe("runMessageAction plugin dispatch", () => {
   beforeEach(() => {
-    mocks.resolveOutboundChannelPlugin.mockReset();
-    mocks.resolveOutboundChannelPlugin.mockImplementation(
-      ({ channel }: { channel: string }) =>
-        getActivePluginRegistry()?.channels.find((entry) => entry?.plugin?.id === channel)?.plugin,
-    );
-    mocks.executeSendAction.mockReset();
-    mocks.executeSendAction.mockImplementation(
-      async ({ ctx }: { ctx: Parameters<typeof executePluginAction>[0]["ctx"] }) =>
-        await executePluginAction({ action: "send", ctx }),
-    );
-    mocks.executePollAction.mockReset();
-    mocks.executePollAction.mockImplementation(
-      async ({ ctx }: { ctx: Parameters<typeof executePluginAction>[0]["ctx"] }) =>
-        await executePluginAction({ action: "poll", ctx }),
-    );
-    mocks.hasCorePresentationDelivery.mockReset();
-    mocks.hasCorePresentationDelivery.mockImplementation(
-      (outbound?: { sendPayload?: unknown; sendText?: unknown; sendFormattedText?: unknown }) =>
-        Boolean(outbound?.sendPayload || outbound?.sendText || outbound?.sendFormattedText),
-    );
-    mocks.materializeMessagePresentationFallback.mockReset();
-    mocks.materializeMessagePresentationFallback.mockImplementation(
-      (params: { payload: { presentation?: unknown; text?: string }; text?: string }) => {
-        const presentation = normalizeMessagePresentation(params.payload.presentation);
-        const text = (params.text ?? params.payload.text ?? "").trim();
-        if (!presentation) {
-          return text;
-        }
-        const fallback = renderMessagePresentationFallbackText({ presentation });
-        return !fallback || text.includes(fallback)
-          ? text
-          : [text, fallback].filter(Boolean).join("\n\n");
-      },
-    );
-    mocks.callGateway.mockReset();
-    mocks.callGatewayLeastPrivilege.mockReset();
-    mocks.isGatewayTransportError.mockReset();
-    mocks.isGatewayTransportError.mockImplementation(
-      (value: unknown) =>
-        value instanceof Error && (value as { kind?: unknown }).kind === "timeout",
-    );
-    mocks.randomIdempotencyKey.mockClear();
-    mocks.maybeApplyTtsToPayload.mockReset();
-    mocks.maybeApplyTtsToPayload.mockImplementation(
-      async (params: { payload: unknown }) => params.payload,
-    );
-    mocks.prepareOutboundMirrorRoute.mockClear();
-    mocks.beginTerminalSourceReplyDelivery.mockReset();
-    mocks.cancelTerminalSourceReplyDelivery.mockReset();
-    mocks.reconcileTerminalSourceReplyDelivery.mockReset();
+    resetMessageActionRunnerMocks();
   });
   describe("alias-based plugin action dispatch", () => {
     const handleAction = vi.fn(async ({ params }: { params: Record<string, unknown> }) =>

--- a/src/infra/outbound/message-action-send.validation.test.ts
+++ b/src/infra/outbound/message-action-send.validation.test.ts
@@ -10,7 +10,7 @@ import {
   runDrySend,
   workspaceConfig,
   workspaceTestPlugin,
-} from "./message-action-runner.test-helpers.js";
+} from "./message-action-test-fixtures.js";
 
 const emptyConfig = {} as OpenClawConfig;
 const portableLocation = { latitude: 48.858844, longitude: 2.294351 };

--- a/src/infra/outbound/message-action-test-fixtures.ts
+++ b/src/infra/outbound/message-action-test-fixtures.ts
@@ -10,7 +10,11 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createChannelTestPluginBase } from "../../test-utils/channel-plugins.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
-import { runMessageAction } from "./message-action-runner.js";
+
+type RunMessageAction = typeof import("./message-action-runner.js").runMessageAction;
+
+const runFixtureMessageAction: RunMessageAction = async (...args) =>
+  (await import("./message-action-runner.js")).runMessageAction(...args);
 
 /** Workspace-style config fixture used by message action runner tests. */
 export const workspaceConfig = {
@@ -45,7 +49,7 @@ export const runDryAction = (params: {
   sandboxRoot?: string;
   agentId?: string;
 }) =>
-  runMessageAction({
+  runFixtureMessageAction({
     cfg: params.cfg,
     action: params.action,
     params: params.actionParams as never,
@@ -249,7 +253,7 @@ export async function runReplyAction(params: {
     currentChannelId: "direct:user-1",
     ...(params.currentMessageId !== undefined ? { currentMessageId: params.currentMessageId } : {}),
   };
-  return await runMessageAction({
+  return await runFixtureMessageAction({
     cfg: testchatConfig,
     action: "reply",
     params: { channel: "testchat", ...params.actionParams },
@@ -271,7 +275,7 @@ export async function runCurrentConversationPollAction(params: { to: string }) {
     currentChannelId: "direct:user-1",
     currentMessageId: "1783",
   };
-  return await runMessageAction({
+  return await runFixtureMessageAction({
     cfg: testchatConfig,
     action: "poll",
     params: {

--- a/src/infra/outbound/message-action-test-fixtures.ts
+++ b/src/infra/outbound/message-action-test-fixtures.ts
@@ -1,3 +1,297 @@
+import { vi } from "vitest";
+import type {
+  ChannelDirectoryEntryKind,
+  ChannelMessageActionName,
+  ChannelMessagingAdapter,
+  ChannelOutboundAdapter,
+  ChannelPlugin,
+} from "../../channels/plugins/types.public.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createChannelTestPluginBase } from "../../test-utils/channel-plugins.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { runMessageAction } from "./message-action-runner.js";
+
+/** Workspace-style config fixture used by message action runner tests. */
+export const workspaceConfig = {
+  channels: {
+    workspace: {
+      botToken: "workspace-test",
+      appToken: "workspace-app-test",
+    },
+  },
+} as OpenClawConfig;
+
+/** Direct-chat config fixture that allows any sender. */
+export const directChatConfig = {
+  channels: {
+    directchat: {
+      allowFrom: ["*"],
+    },
+  },
+} as OpenClawConfig;
+
+export const directOutbound: ChannelOutboundAdapter = {
+  deliveryMode: "direct",
+  sendText: async () => ({ channel: "test", messageId: "test" }),
+};
+
+export const runDryAction = (params: {
+  cfg: OpenClawConfig;
+  action: ChannelMessageActionName;
+  actionParams: Record<string, unknown>;
+  toolContext?: Record<string, unknown>;
+  abortSignal?: AbortSignal;
+  sandboxRoot?: string;
+  agentId?: string;
+}) =>
+  runMessageAction({
+    cfg: params.cfg,
+    action: params.action,
+    params: params.actionParams as never,
+    toolContext: params.toolContext as never,
+    dryRun: true,
+    abortSignal: params.abortSignal,
+    sandboxRoot: params.sandboxRoot,
+    agentId: params.agentId,
+  });
+
+export const runDrySend = (params: {
+  cfg: OpenClawConfig;
+  actionParams: Record<string, unknown>;
+  toolContext?: Record<string, unknown>;
+  abortSignal?: AbortSignal;
+  sandboxRoot?: string;
+  agentId?: string;
+}) =>
+  runDryAction({
+    ...params,
+    action: "send",
+  });
+
+type ResolvedTestTarget = { to: string; kind: ChannelDirectoryEntryKind };
+
+function normalizeWorkspaceTarget(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+  if (trimmed.startsWith("#")) {
+    return trimmed.slice(1).trim();
+  }
+  if (/^channel:/i.test(trimmed)) {
+    return trimmed.replace(/^channel:/i, "").trim();
+  }
+  if (/^user:/i.test(trimmed)) {
+    return trimmed.replace(/^user:/i, "").trim();
+  }
+  const mention = trimmed.match(/^<@([A-Z0-9]+)>$/i);
+  if (mention?.[1]) {
+    return mention[1];
+  }
+  return trimmed;
+}
+
+// Test plugins model token-gated workspace sends without booting real channel runtimes.
+function hasChannelBotToken(channelConfig: unknown): boolean {
+  if (channelConfig == null || typeof channelConfig !== "object" || Array.isArray(channelConfig)) {
+    return false;
+  }
+  const token = (channelConfig as Record<string, unknown>).botToken;
+  return typeof token === "string" && Boolean(token.trim());
+}
+
+function createConfiguredTestPlugin(params: {
+  id: string;
+  isConfigured: (cfg: OpenClawConfig) => boolean;
+  normalizeTarget: (raw: string) => string | undefined;
+  resolveTarget: (input: string) => ResolvedTestTarget | null;
+}): ChannelPlugin {
+  const messaging: ChannelMessagingAdapter = {
+    normalizeTarget: params.normalizeTarget,
+    targetResolver: {
+      looksLikeId: (raw) => Boolean(params.resolveTarget(raw.trim())),
+      hint: "<id>",
+      resolveTarget: async (resolverParams) => {
+        const resolved = params.resolveTarget(resolverParams.input);
+        return resolved ? { ...resolved, source: "normalized" } : null;
+      },
+    },
+    inferTargetChatType: (inferParams) =>
+      params.resolveTarget(inferParams.to)?.kind === "user" ? "direct" : "group",
+  };
+  return {
+    ...createChannelTestPluginBase({
+      id: params.id,
+      config: {
+        listAccountIds: () => ["default"],
+        resolveAccount: () => ({ enabled: true }),
+        isConfigured: (_account, cfg) => params.isConfigured(cfg),
+      },
+    }),
+    outbound: directOutbound,
+    messaging,
+  };
+}
+
+export const workspaceTestPlugin = createConfiguredTestPlugin({
+  id: "workspace",
+  isConfigured: (cfg) => hasChannelBotToken(cfg.channels?.workspace),
+  normalizeTarget: (raw) => normalizeWorkspaceTarget(raw) || undefined,
+  resolveTarget: (input) => {
+    const normalized = normalizeWorkspaceTarget(input);
+    if (!normalized) {
+      return null;
+    }
+    if (/^[A-Z0-9]+$/i.test(normalized)) {
+      const kind = /^U/i.test(normalized) ? "user" : "group";
+      return { to: normalized, kind };
+    }
+    return null;
+  },
+});
+
+export const forumTestPlugin = createConfiguredTestPlugin({
+  id: "forum",
+  isConfigured: (cfg) => hasChannelBotToken(cfg.channels?.forum),
+  normalizeTarget: (raw) => raw.trim() || undefined,
+  resolveTarget: (input) => {
+    const normalized = input.trim();
+    if (!normalized) {
+      return null;
+    }
+    return {
+      to: normalized.replace(/^forum:/i, ""),
+      kind: normalized.startsWith("@") ? "user" : "group",
+    };
+  },
+});
+
+export const directChatTestPlugin = createConfiguredTestPlugin({
+  id: "directchat",
+  isConfigured: (cfg) => Boolean(cfg.channels?.directchat),
+  normalizeTarget: (raw) => raw.trim() || undefined,
+  resolveTarget: (input) => {
+    const normalized = input.trim();
+    if (!normalized) {
+      return null;
+    }
+    return {
+      to: normalized,
+      kind: normalized.endsWith("@g.us") ? "group" : "user",
+    };
+  },
+});
+
+type ChannelActionHandler = NonNullable<NonNullable<ChannelPlugin["actions"]>["handleAction"]>;
+
+const testchatConfig = {
+  channels: {
+    testchat: {
+      enabled: true,
+    },
+  },
+} as OpenClawConfig;
+
+function createReplyActionPlugin(handleAction: ChannelActionHandler): ChannelPlugin {
+  return {
+    id: "testchat",
+    meta: {
+      id: "testchat",
+      label: "Test Chat",
+      selectionLabel: "Test Chat",
+      docsPath: "/channels/testchat",
+      blurb: "Reply action test plugin.",
+    },
+    capabilities: { chatTypes: ["direct"] },
+    config: {
+      listAccountIds: () => ["default"],
+      resolveAccount: () => ({ enabled: true }),
+      isConfigured: () => true,
+    },
+    outbound: {
+      deliveryMode: "direct",
+      sendText: async () => ({ channel: "testchat", messageId: "m-send-1" }),
+    },
+    messaging: {
+      targetResolver: {
+        looksLikeId: () => true,
+      },
+    },
+    actions: {
+      describeMessageTool: () => ({ actions: ["reply", "poll"] }),
+      supportsAction: ({ action }) => action === "reply" || action === "poll",
+      handleAction,
+    },
+  };
+}
+
+export function registerReplyPlugin() {
+  const payload = { ok: true, messageId: "m-reply-1", repliedTo: "platform-guid-1" };
+  const handleAction = vi.fn(async () => ({
+    content: [{ type: "text" as const, text: JSON.stringify(payload) }],
+    details: payload,
+  }));
+  setActivePluginRegistry(
+    createTestRegistry([
+      { pluginId: "testchat", source: "test", plugin: createReplyActionPlugin(handleAction) },
+    ]),
+  );
+  return handleAction;
+}
+
+export async function runReplyAction(params: {
+  actionParams: Record<string, unknown>;
+  currentMessageId?: string | number;
+}) {
+  const toolContext = {
+    currentChannelProvider: "testchat" as const,
+    currentChannelId: "direct:user-1",
+    ...(params.currentMessageId !== undefined ? { currentMessageId: params.currentMessageId } : {}),
+  };
+  return await runMessageAction({
+    cfg: testchatConfig,
+    action: "reply",
+    params: { channel: "testchat", ...params.actionParams },
+    toolContext,
+    messageActionAuthorization: {
+      requesterAccountId: "default",
+      toolContext,
+    },
+    sessionKey: "agent:main:testchat:direct:user-1",
+    defaultAccountId: "default",
+    sourceReplyDeliveryMode: "message_tool_only",
+    dryRun: false,
+  });
+}
+
+export async function runCurrentConversationPollAction(params: { to: string }) {
+  const toolContext = {
+    currentChannelProvider: "testchat" as const,
+    currentChannelId: "direct:user-1",
+    currentMessageId: "1783",
+  };
+  return await runMessageAction({
+    cfg: testchatConfig,
+    action: "poll",
+    params: {
+      channel: "testchat",
+      to: params.to,
+      pollQuestion: "Preferred default?",
+      pollOption: ["Tell me right away", "Only important"],
+    },
+    toolContext,
+    messageActionAuthorization: {
+      requesterAccountId: "default",
+      toolContext,
+    },
+    sessionKey: "agent:main:testchat:direct:user-1",
+    defaultAccountId: "default",
+    sourceReplyDeliveryMode: "message_tool_only",
+    dryRun: false,
+  });
+}
+
 /** Returns a bootstrap registry mock for message-action alias tests. */
 export function createPinboardMessageActionBootstrapRegistryMock() {
   const resolveIMessageTarget = ({ args }: { args: Record<string, unknown> }) => {


### PR DESCRIPTION
Related: #121434

## What Problem This Solves

PR #121434 split the message-action runner tests into ownership-focused files while preserving their coverage, but each split file retained large copies of the same runner mock factories, plugin builders, media setup, poll setup, and reset policy. That left roughly 3.4k lines of duplicated test scaffolding and made fixture changes easy to apply inconsistently.

## Why This Change Was Made

This consolidates the shared runner-facade mocks and reusable action fixtures into the existing message-action test-support seam. The explicit mock factories enumerate every production binding they replace, the web-media mock exposes only the binding under test, and real-runner fixture calls stay lazy so hoisted spec mocks cannot form an import cycle. Each owned test file now retains only its distinctive fixtures and assertions.

AI-assisted: implemented and reviewed with Codex.

## User Impact

No user-visible behavior changes. Developers keep the same message-action coverage with a substantially smaller, single-owner test harness.

## Evidence

Behavior and coverage:

- `node scripts/run-vitest.mjs src/infra/outbound test/scripts/ci-node-test-plan.test.ts`: 71 infra files / 1,149 tests, 19 unit-fast files / 184 tests, and 1 tooling file / 21 tests passed (1,354 total).
- Zero-context diff checks found no changed `expect(...)` assertion lines and no changed `it(...)`, `it.each(...)`, or `test(...)` declarations. The 924 cases redistributed by #121434 remain unchanged.
- Focused post-fix fixture-consumer run: 8 files / 144 tests passed.
- Focused changed-family runs: 2 files / 14 tests, 10 files / 116 tests, and 5 files / 43 tests passed.

Static validation:

- `node scripts/check-changed.mjs`: passed via the documented high-capacity local fallback after remote execution backends failed before running checks; core/core-test typechecks, changed-file lint, Knip scans, formatting, and all selected guards passed.
- `pnpm lint:tmp:export-name-collisions`: passed.
- `pnpm check:wrapper-shadowing`: passed (70 current / 70 baselined).
- `pnpm plugin-sdk:surface:check`: passed (152 public entrypoints, 0 forbidden subpaths).
- `pnpm check:import-cycles`: passed (0 runtime value cycles).
- `pnpm format <touched paths>` and `git diff --check`: passed.
- Structured Codex autoreview: clean before each commit; no accepted/actionable findings.
- `pnpm build` was not run because no production, package, or lazy-runtime boundary changed.

LOC against the merge base with current `origin/main`:

- Production: +0/-0 (net 0).
- Tests and test support: +891/-2,988 (net -2,097).
- Tooling/generated: +0/-0 (net 0).
