### PR TITLE
[AI-Assisted] fix(sqlite): cast updated_at to Number for strict equality check

### DIFF
--- a/src/config/sessions/session-entry-json.ts
+++ b/src/config/sessions/session-entry-json.ts
@@ -25,7 +25,7 @@ export function parseSqliteSessionEntryRecord(row: {
     }
     if (
       (row.current_session_id !== undefined && row.current_session_id !== record.sessionId) ||
-      (row.updated_at !== undefined && row.updated_at !== record.updatedAt)
+      (row.updated_at !== undefined && Number(row.updated_at) !== record.updatedAt)
     ) {
       return null;
     }


### PR DESCRIPTION
### What Problem This Solves
The CLI crashes during initialization with the error `invalid persisted session row requires repair` because `row.updated_at` (a BigInt or Number depending on the SQLite driver/environment) fails strict equality against `record.updatedAt` (a Number) in `parseSqliteSessionEntryRecord`. This falsely invalidates a valid row, preventing the gateway from starting.

### Why This Change Was Made
By casting `row.updated_at` using `Number(row.updated_at)` before comparison, we ensure that strict equality works properly regardless of whether the SQLite driver returns a Number or a BigInt for timestamps.

## Evidence
Unit tests pass successfully.

### Real Behavior Proof
Before fix:
```
[openclaw] Reason: invalid persisted session row requires repair for agent:main:cron:63c47ea8-1b00-48a0-bc3a-3cbc0c73f6e7:run:afd80450-cdef-45bb-863e-49926c64ed77; stop the Gateway and run openclaw doctor --fix
```

After fix:
```
$ openclaw status
...
│ age │ cron │ 8h ago  │ deepseek-v4- │ OpenClaw     │ unknown/200k (?%)       │
│ nt: │      │         │ flash        │ Default      │                         │
│ mai │      │         │              │              │                         │
...
```

## AI-Assisted Contribution
- [x] Mark as AI-assisted in the PR title or description
- [x] Include a concise Evidence section with the most useful validation
- [x] Confirm you understand what the code does
