### PR TITLE
test(llama-cpp): remove duplicate progress bridge

### DIFF
--- a/extensions/llama-cpp/src/setup.test.ts
+++ b/extensions/llama-cpp/src/setup.test.ts
@@ -30,16 +30,6 @@ vi.mock("node-llama-cpp", () => ({
 
 import { detectLlamaCppSetup, prepareLlamaCppSetup, runLlamaCppSetup } from "./setup.js";
 
-const { formatLlamaCppDownloadProgress } = (globalThis as Record<PropertyKey, unknown>)[
-  Symbol.for("openclaw.llamaCppSetupTestApi")
-] as {
-  formatLlamaCppDownloadProgress: (params: {
-    downloadedSize: number;
-    totalSize: number;
-    bytesPerSecond: number;
-  }) => string;
-};
-
 const GIB = 1024 ** 3;
 
 let tempRoot: string;
@@ -104,16 +94,6 @@ describe("llama.cpp setup", () => {
   it("requires 16 GiB for the bundled default offer", () => {
     expect(meetsLlamaCppDefaultModelRamFloor(16 * GIB - 1)).toBe(false);
     expect(meetsLlamaCppDefaultModelRamFloor(16 * GIB)).toBe(true);
-  });
-
-  it("formats percent, decimal GB, and transfer rate", () => {
-    expect(
-      formatLlamaCppDownloadProgress({
-        downloadedSize: 2_100_000_000,
-        totalSize: 5_000_000_000,
-        bytesPerSecond: 38_000_000,
-      }),
-    ).toBe("Downloading Gemma 4 E4B… 42% (2.1/5.0 GB, 38 MB/s)");
   });
 
   it("returns null when the configured model is not cached", async () => {

--- a/extensions/llama-cpp/src/setup.ts
+++ b/extensions/llama-cpp/src/setup.ts
@@ -211,9 +211,3 @@ export async function runLlamaCppSetup(ctx: ProviderAuthContext): Promise<Provid
   }
   return buildSetupResult(ctx.config);
 }
-
-if (process.env.VITEST || process.env.NODE_ENV === "test") {
-  (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.llamaCppSetupTestApi")] = {
-    formatLlamaCppDownloadProgress,
-  };
-}


### PR DESCRIPTION
## What Problem This Solves

Llama.cpp setup retained a process-global test bridge solely so one unit test could call the private download-progress formatter directly. A later setup-level regression already proves the same percent, decimal-GB, and transfer-rate formatting while also exercising resumed-byte handling and rolling-rate calculation through `runLlamaCppSetup`.

## Why This Change Was Made

This deletes:

- the `openclaw.llamaCppSetupTestApi` global Symbol bridge;
- the test-side global cast; and
- the strict-subset direct formatter assertion.

The stronger setup-level progress test remains unchanged. No setup behavior, model defaults, download policy, public plugin surface, config, dependency, or manifest changes.

AI-assisted: yes. Current callers, overlap, extension boundaries, and history were manually verified; fresh structured review found no actionable issue.

## User Impact

No user-visible behavior change. Llama.cpp setup keeps the same progress output with less production test surface.

## Evidence

- `node scripts/run-vitest.mjs extensions/llama-cpp/src/setup.test.ts` — 11 tests passed.
- Doctor-contract declaration/closure shards — 5 tests passed.
- `node scripts/check-changed.mjs -- extensions/llama-cpp/src/setup.ts extensions/llama-cpp/src/setup.test.ts` — passed all classified format, doctor-contract, Plugin SDK baseline, type, lint, dead-export, boundary, architecture, and safety gates through trusted local fallback because Blacksmith Testbox is unavailable on this host.
- The first local changed-gate attempt exposed stale untracked `packages/ai/dist` bytes after a fast-moving main update; `node --import tsx scripts/tsdown-build.mts --config tsdown.ai.config.ts` refreshed the package artifact, and the exact gate then passed without source changes.
- Fresh structured autoreview and secret scan — clean.
- `git diff --check` — clean.

Production/test-support delta: −6 lines. Tests: −20 lines.
