### PR TITLE
test(sqlite): avoid duplicate reliability proof run

### DIFF
--- a/test/scripts/bench-sqlite-reliability.test.ts
+++ b/test/scripts/bench-sqlite-reliability.test.ts
@@ -188,6 +188,8 @@ describe("scripts/bench-sqlite-reliability", () => {
     expect(result.stdout).toContain("SQLITE_RELIABILITY_TARGET=global");
     expect(result.stdout).not.toContain("=missing");
     const firstReport = JSON.parse(fs.readFileSync(output, "utf8")) as ReliabilityReport;
+    expect(firstReport.concurrentRestoresVerified).toBe(4);
+    expect(firstReport.restoresVerified).toBe(7);
     expect(
       firstReport.crashRecoveryProof.exit.code !== null ||
         firstReport.crashRecoveryProof.exit.signal !== null,

--- a/test/scripts/bench-sqlite-reliability.test.ts
+++ b/test/scripts/bench-sqlite-reliability.test.ts
@@ -4,17 +4,24 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { parseSqliteReliabilityCli } from "../../scripts/lib/sqlite-reliability-cli.js";
-import type { ReliabilityReport } from "../../scripts/lib/sqlite-reliability-contract.js";
+import {
+  STRESS_TABLE_SQL,
+  type ReliabilityReport,
+} from "../../scripts/lib/sqlite-reliability-contract.js";
 import { monitorSqliteWalDuring } from "../../scripts/lib/sqlite-reliability-wal-monitor.js";
 import {
   canonicalPathWithExistingParent,
   isPendingPathInRepository,
 } from "../../scripts/lib/sqlite-reliability-worker-paths.js";
 import { openNodeSqliteDatabase } from "../../src/infra/node-sqlite.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../src/state/openclaw-state-db.js";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-// Windows repeats ACL checks and >64 MiB crash/restore copies across two full runs.
+// Windows repeats ACL checks and >64 MiB crash/restore copies throughout the full proof.
 const RELIABILITY_PROOF_TIMEOUT_MS = process.platform === "win32" ? 480_000 : 240_000;
 const RELIABILITY_SMOKE_TEST_TIMEOUT_MS = process.platform === "win32" ? 1_200_000 : 300_000;
 
@@ -147,36 +154,40 @@ describe("scripts/bench-sqlite-reliability", () => {
     });
   });
 
-  reliabilitySmokeTest("reuses a state directory without stale rows or restore collisions", () => {
+  reliabilitySmokeTest("proves snapshot reliability while safely reusing state", () => {
     const stateDir = tempDirs.make("openclaw-sqlite-reliability-test-");
-    const firstOutput = path.join(stateDir, "report-first.json");
-    const firstResult = runProof([
-      "--profile",
-      "smoke",
-      "--state-dir",
+    const previousSyncedRepository = path.join(
       stateDir,
-      "--output",
-      firstOutput,
-    ]);
+      "sqlite-reliability-runs",
+      "previous-run",
+      "synced-snapshots",
+    );
+    const previousArtifact = path.join(previousSyncedRepository, "previous-artifact");
+    fs.mkdirSync(previousSyncedRepository, { recursive: true });
+    fs.writeFileSync(previousArtifact, "retained");
 
-    expect(firstResult.status, firstResult.stderr).toBe(0);
-    expect(firstResult.stderr).toBe("");
-    expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_TARGET=global");
-    expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_RESTORES_VERIFIED=7");
-    expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_CRASH_RECOVERY=verified");
-    expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_PUBLICATION_INTERRUPTION=verified");
-    expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_RESTORE_INTERRUPTION=verified");
-    expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_REPOSITORY_INTERRUPTION=verified");
-    expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_INDEX_REPAIR_INTERRUPTION=verified");
-    expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_VACUUM_INTERRUPTION=verified");
-    expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_POST_COMPACT_RESTORE=verified");
-    const firstReport = JSON.parse(fs.readFileSync(firstOutput, "utf8")) as ReliabilityReport;
-    expect(firstReport.concurrentRestoresVerified).toBe(4);
-    expect(firstReport.restoresVerified).toBe(7);
-    expect(firstReport.crashRecoveryProof.sourceRecovered).toBe(true);
-    expect(firstReport.crashRecoveryProof.committedStatePreserved).toBe(true);
-    expect(firstReport.crashRecoveryProof.partialVisibleAfterRecovery).toBe(false);
-    expect(firstReport.crashRecoveryProof.writerRestarted).toBe(true);
+    const existingDatabase = openOpenClawStateDatabase({
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+    });
+    try {
+      existingDatabase.db.exec(STRESS_TABLE_SQL);
+      existingDatabase.db
+        .prepare(
+          "INSERT INTO openclaw_reliability_entries (batch, ordinal, payload) VALUES (?, ?, ?)",
+        )
+        .run(999_999, 0, "stale-profile-row");
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+    }
+
+    const output = path.join(stateDir, "report.json");
+    const result = runProof(["--profile", "smoke", "--state-dir", stateDir, "--output", output]);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("SQLITE_RELIABILITY_TARGET=global");
+    expect(result.stdout).not.toContain("=missing");
+    const firstReport = JSON.parse(fs.readFileSync(output, "utf8")) as ReliabilityReport;
     expect(
       firstReport.crashRecoveryProof.exit.code !== null ||
         firstReport.crashRecoveryProof.exit.signal !== null,
@@ -375,33 +386,18 @@ describe("scripts/bench-sqlite-reliability", () => {
     expect(firstReport.walBytes.peak).toBeGreaterThan(0);
     expect(firstReport.walBytes.peak).toBeLessThanOrEqual(firstReport.walBytes.limit);
 
-    const database = openNodeSqliteDatabase(firstReport.paths.sourceDatabase);
+    expect(firstReport.paths.syncedRepository).not.toBe(previousSyncedRepository);
+    expect(fs.readFileSync(previousArtifact, "utf8")).toBe("retained");
+
+    const database = openNodeSqliteDatabase(firstReport.paths.sourceDatabase, { readOnly: true });
     try {
-      database
-        .prepare(
-          "INSERT INTO openclaw_reliability_entries (batch, ordinal, payload) VALUES (?, ?, ?)",
-        )
-        .run(999_999, 0, "stale-profile-row");
+      const staleRows = database
+        .prepare("SELECT COUNT(*) AS rows FROM openclaw_reliability_entries WHERE batch = ?")
+        .get(999_999) as { rows?: unknown };
+      expect(Number(staleRows.rows)).toBe(0);
     } finally {
       database.close();
     }
-
-    const secondOutput = path.join(stateDir, "report-second.json");
-    const secondResult = runProof([
-      "--profile",
-      "smoke",
-      "--state-dir",
-      stateDir,
-      "--output",
-      secondOutput,
-    ]);
-    expect(secondResult.status, secondResult.stderr).toBe(0);
-    const secondReport = JSON.parse(fs.readFileSync(secondOutput, "utf8")) as {
-      paths: { syncedRepository: string };
-      restoresVerified: number;
-    };
-    expect(secondReport.restoresVerified).toBe(7);
-    expect(secondReport.paths.syncedRepository).not.toBe(firstReport.paths.syncedRepository);
   });
 
   it("matches crash barriers across filesystem path aliases", () => {

--- a/test/scripts/bench-sqlite-reliability.test.ts
+++ b/test/scripts/bench-sqlite-reliability.test.ts
@@ -186,6 +186,14 @@ describe("scripts/bench-sqlite-reliability", () => {
     expect(result.status, result.stderr).toBe(0);
     expect(result.stderr).toBe("");
     expect(result.stdout).toContain("SQLITE_RELIABILITY_TARGET=global");
+    expect(result.stdout).toContain("SQLITE_RELIABILITY_RESTORES_VERIFIED=7");
+    expect(result.stdout).toContain("SQLITE_RELIABILITY_CRASH_RECOVERY=verified");
+    expect(result.stdout).toContain("SQLITE_RELIABILITY_PUBLICATION_INTERRUPTION=verified");
+    expect(result.stdout).toContain("SQLITE_RELIABILITY_RESTORE_INTERRUPTION=verified");
+    expect(result.stdout).toContain("SQLITE_RELIABILITY_REPOSITORY_INTERRUPTION=verified");
+    expect(result.stdout).toContain("SQLITE_RELIABILITY_INDEX_REPAIR_INTERRUPTION=verified");
+    expect(result.stdout).toContain("SQLITE_RELIABILITY_VACUUM_INTERRUPTION=verified");
+    expect(result.stdout).toContain("SQLITE_RELIABILITY_POST_COMPACT_RESTORE=verified");
     expect(result.stdout).not.toContain("=missing");
     const firstReport = JSON.parse(fs.readFileSync(output, "utf8")) as ReliabilityReport;
     expect(firstReport.concurrentRestoresVerified).toBe(4);

--- a/test/vitest-unit-fast-config.test.ts
+++ b/test/vitest-unit-fast-config.test.ts
@@ -261,8 +261,6 @@ describe("unit-fast vitest lane", () => {
     const files = [
       "src/agents/auth-profiles/oauth-refresh-error.test.ts",
       "src/auto-reply/reply/agent-runner-execution-runtime.test.ts",
-      "src/infra/outbound/message-action-execution.poll.test.ts",
-      "src/infra/outbound/message-action-runner.poll.test.ts",
     ];
     for (const file of files) {
       const analysis = unitFastAnalysis.find((entry) => entry.file === file);


### PR DESCRIPTION
## What Problem This Solves

The compact tooling lane ran the complete SQLite reliability benchmark twice inside one Vitest case. Each smoke proof performs the full writer crash/restart sequence, four concurrent snapshot/restore iterations, publication and repository interruption checks, two index-repair interruption modes, a >64 MiB restore interruption, interrupted VACUUM, compaction, and post-compaction restore. The second execution added roughly half the file's 59-67 second cost but only checked that a reused state directory did not collide with prior artifacts.

## Why This Change Was Made

Seed a real initialized state database with a stale reliability row and a retained prior-run artifact before the one full proof. The retained proof now directly verifies that startup removes stale profile data, chooses an isolated sync repository, preserves prior artifacts, and still passes every crash/durability contract.

This removes the duplicate full benchmark execution rather than weakening the smoke profile or adding a test-only production mode. The retained run still asserts four concurrent restores, seven total restores, every exact machine-readable CLI proof marker, and all detailed state, atomicity, recovery, and payload invariants.

While verifying the final head, compact CI exposed a deterministic failure already present on `main`: #121923 removed an outbound stateful-helper import and deleted its duplicate poll test, but the unit-fast lane inventory still required both stale paths. This PR removes those two obsolete expectations. No production code or CI worker count changes. All five SQLite test cases remain.

## User Impact

The core-tooling compact lane should spend about half as long in `bench-sqlite-reliability.test.ts`, reducing the slow shard without reducing crash, restore, publication, repository, index-repair, VACUUM, compaction, WAL-limit, path-alias, or writer-disconnect coverage.

## Evidence

Baseline from exact `main` head before this change:

- Actions run: https://github.com/openclaw/openclaw/actions/runs/31464051869
- Job: https://github.com/openclaw/openclaw/actions/runs/31464051869/job/93693336976
- `test/scripts/bench-sqlite-reliability.test.ts`: **59.249s**, 5/5 tests passed
- Two prior comparable samples: **58.344s** and **67.157s**

Exact-head result:

- Actions run: https://github.com/openclaw/openclaw/actions/runs/31465283782
- Job: https://github.com/openclaw/openclaw/actions/runs/31465283782/job/93697316076
- `test/scripts/bench-sqlite-reliability.test.ts`: **33.299s**, 5/5 tests passed
- **43.8% faster** than the exact 59.249s baseline (42.9-50.4% faster across the three baseline samples)
- Containing `core-tooling-3` shard: **209.08s → 179.97s**
- Job totals: 100/100 files passed; 2,496 tests passed, 2 skipped

Final rebased exact-head confirmation:

- Actions run: https://github.com/openclaw/openclaw/actions/runs/31467663640
- Timing job: https://github.com/openclaw/openclaw/actions/runs/31467663640/job/93704095331
- `test/scripts/bench-sqlite-reliability.test.ts`: **36.929s**, 5/5 tests passed
- **37.7% faster** than the exact 59.249s baseline
- `core-tooling-3`: 100/100 files passed; 2,496 tests passed, 2 skipped

Final exact-head result after review follow-ups:

- Actions run: https://github.com/openclaw/openclaw/actions/runs/31468631905
- Timing job: https://github.com/openclaw/openclaw/actions/runs/31468631905/job/93707194780
- `test/scripts/bench-sqlite-reliability.test.ts`: **34.088s**, 5/5 tests passed
- **42.5% faster** than the exact 59.249s baseline
- `core-tooling-3`: 100/100 files passed; 2,496 tests passed, 2 skipped

Review follow-ups:

- ClawSweeper's late P2 finding is addressed by restoring exact `concurrentRestoresVerified === 4` and `restoresVerified === 7` assertions.
- Independent review confirmed the CLI marker strings are a unique contract, so the single run again asserts the exact restore marker plus every `...=verified` proof marker.
- Final exact-head CI for rebased head `1a58bf67567774d99f489d1dd628db30a5962a10` measured the file at **34.860s**, **41.2% faster** than the exact baseline. The containing shard passed 100/100 files and 2,496 tests with 2 skipped: https://github.com/openclaw/openclaw/actions/runs/31470451927/job/93712581434
- Final head `1ac040c4ddb0b96d8ec6936b8eac13a9976f0ede`: `bench-sqlite-reliability.test.ts` passed 5/5 in **35.204s**, **40.6% faster** than the exact baseline; `core-tooling-3` passed 100 files and 2,496 tests with 2 skipped: https://github.com/openclaw/openclaw/actions/runs/31471155906/job/93714926632
- The repaired `core-tooling-4` shard passed 101 files and 1,497 tests with 13 skipped; `test/vitest-unit-fast-config.test.ts` passed 11/11: https://github.com/openclaw/openclaw/actions/runs/31471155906/job/93714926698

Local validation after the final rebase:

- Node 24.15.0: `node scripts/run-vitest.mjs test/scripts/bench-sqlite-reliability.test.ts` — 5/5 passed
- Node 24.15.0: `node scripts/run-vitest.mjs test/vitest-unit-fast-config.test.ts` — 11/11 passed
- `oxfmt --check test/scripts/bench-sqlite-reliability.test.ts`
- `oxfmt --check test/vitest-unit-fast-config.test.ts`
- `git diff --check`
- TruffleHog filesystem scan: 0 verified or unverified secrets

Structured autoreview binaries (`codex`, `claude`, `pi`) are unavailable in this orb. Independent Oracle review was completed; its one finding was addressed before the final rebase.
