### PR TITLE
fix(tasks): stream Codex subagent activity

### DIFF
--- a/extensions/codex/src/app-server/event-projector-events.ts
+++ b/extensions/codex/src/app-server/event-projector-events.ts
@@ -1,4 +1,7 @@
-import type { EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
+import type {
+  EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
+  ToolProgressDetailMode,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   asFiniteNumber,
   readStringField as readString,
@@ -27,6 +30,55 @@ import { readHookOutputEntries, readNullableString } from "./event-projector-val
 import { isJsonObject, type CodexThreadItem, type JsonObject } from "./protocol.js";
 
 type AgentEvent = Parameters<NonNullable<EmbeddedRunAttemptParams["onAgentEvent"]>>[0];
+
+type NormalizedToolItemProjection = {
+  name: string;
+  status: ReturnType<typeof itemStatus>;
+  args: Record<string, unknown> | undefined;
+  meta: string | undefined;
+  event: AgentEvent | undefined;
+};
+
+export function projectNormalizedToolItem(params: {
+  phase: "start" | "result";
+  item: CodexThreadItem | undefined;
+  detailMode?: ToolProgressDetailMode;
+}): NormalizedToolItemProjection | undefined {
+  const { item } = params;
+  if (!item || !shouldSynthesizeToolProgressForItem(item)) {
+    return undefined;
+  }
+  const name = itemName(item);
+  if (!name) {
+    return undefined;
+  }
+  const status = params.phase === "result" ? itemStatus(item) : "running";
+  const args = itemToolArgs(item);
+  const commandBearing = isCommandBearingToolItem(item, args);
+  const meta = itemMeta(item, params.detailMode);
+  const event = shouldEmitTranscriptToolProgress(name, args)
+    ? {
+        stream: "tool",
+        data: {
+          phase: params.phase,
+          name,
+          itemId: item.id,
+          toolCallId: item.id,
+          ...(meta ? { meta } : {}),
+          ...(commandBearing ? { commandBearing: true as const } : {}),
+          ...(params.phase === "start" && args ? { args } : {}),
+          ...(params.phase === "result"
+            ? {
+                status,
+                isError: isNonSuccessItemStatus(status),
+                ...itemToolResult(item),
+              }
+            : {}),
+        },
+      }
+    : undefined;
+  return { name, status, args, meta, event };
+}
 
 export class CodexEventProjection {
   private reviewCount = 0;
@@ -138,48 +190,27 @@ export class CodexEventProjection {
     phase: "start" | "result";
     item: CodexThreadItem | undefined;
   }): Promise<void> {
+    const projection = projectNormalizedToolItem({
+      ...params,
+      detailMode: this.toolProgress.toolProgressDetailMode(),
+    });
+    if (!projection || !params.item) {
+      return;
+    }
     const { item } = params;
-    if (!item || !shouldSynthesizeToolProgressForItem(item)) {
-      return;
-    }
-    const name = itemName(item);
-    if (!name) {
-      return;
-    }
-    const status = params.phase === "result" ? itemStatus(item) : "running";
-    const args = itemToolArgs(item);
-    const commandBearing = isCommandBearingToolItem(item, args);
-    const meta = itemMeta(item, this.toolProgress.toolProgressDetailMode());
+    const { name, status, args, meta, event } = projection;
     this.toolTranscript.recordTrajectoryEvent({ phase: params.phase, item, name, args, status });
     if (params.phase === "result") {
       this.toolProgress.recordNativeToolError({ item, name, meta, status });
     }
-    if (!shouldEmitTranscriptToolProgress(name, args)) {
+    if (!event) {
       if (params.phase === "result") {
         this.toolTranscript.emitAfterToolCallObservation(item);
         await this.onNativeToolResultRecorded?.();
       }
       return;
     }
-    this.emitAgentEvent({
-      stream: "tool",
-      data: {
-        phase: params.phase,
-        name,
-        itemId: item.id,
-        toolCallId: item.id,
-        ...(meta ? { meta } : {}),
-        ...(commandBearing ? { commandBearing: true } : {}),
-        ...(params.phase === "start" && args ? { args } : {}),
-        ...(params.phase === "result"
-          ? {
-              status,
-              isError: isNonSuccessItemStatus(status),
-              ...itemToolResult(item),
-            }
-          : {}),
-      },
-    });
+    this.emitAgentEvent(event);
     if (params.phase === "result") {
       this.toolTranscript.emitAfterToolCallObservation(item);
       await this.onNativeToolResultRecorded?.();

--- a/extensions/codex/src/app-server/native-subagent-monitor.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.test.ts
@@ -1,3 +1,4 @@
+import { onAgentEvent } from "openclaw/plugin-sdk/agent-harness-runtime";
 // Codex tests cover native subagent monitor plugin behavior.
 import type {
   AgentHarnessScopedSetDeliveryStatusParams,
@@ -713,6 +714,78 @@ describe("CodexNativeSubagentMonitor", () => {
     );
     expect(client.request).not.toHaveBeenCalled();
     client.close();
+  });
+
+  it("publishes child assistant and tool activity under the mirrored thread run id", async () => {
+    const events: Array<{ runId: string; stream: string; data: Record<string, unknown> }> = [];
+    const unsubscribe = onAgentEvent((event) => events.push(event));
+    const client = createClient();
+    const runtime = createRuntime();
+    const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
+    try {
+      registerParent(monitor);
+      await notifyChildStarted(client);
+      await client.notify({
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: "child-thread",
+          turnId: "child-turn",
+          itemId: "assistant-1",
+          delta: "Inspecting the registry",
+        },
+      });
+      await client.notify({
+        method: "item/reasoning/summaryTextDelta",
+        params: {
+          threadId: "child-thread",
+          turnId: "child-turn",
+          itemId: "reasoning-1",
+          summaryIndex: 0,
+          delta: "Planning the fix",
+        },
+      });
+      await client.notify({
+        method: "item/started",
+        params: {
+          threadId: "child-thread",
+          turnId: "child-turn",
+          item: {
+            type: "commandExecution",
+            id: "command-1",
+            command: "pnpm test",
+            cwd: "/workspace",
+            status: "inProgress",
+          },
+        },
+      });
+
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            runId: "codex-thread:child-thread",
+            stream: "assistant",
+            data: expect.objectContaining({ delta: "Inspecting the registry" }),
+          }),
+          expect.objectContaining({
+            runId: "codex-thread:child-thread",
+            stream: "thinking",
+            data: expect.objectContaining({ delta: "Planning the fix" }),
+          }),
+          expect.objectContaining({
+            runId: "codex-thread:child-thread",
+            stream: "tool",
+            data: expect.objectContaining({
+              phase: "start",
+              name: "bash",
+              toolCallId: "command-1",
+            }),
+          }),
+        ]),
+      );
+    } finally {
+      unsubscribe();
+      client.close();
+    }
   });
 
   it("delivers a completed child turn from its terminal snapshot", async () => {

--- a/extensions/codex/src/app-server/native-subagent-monitor.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.ts
@@ -2,7 +2,11 @@
  * Mirrors Codex native subagent lifecycle and completion into OpenClaw task
  * runtime records, with app-server history as the recovery source.
  */
-import { embeddedAgentLog, formatErrorMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  embeddedAgentLog,
+  emitAgentEvent,
+  formatErrorMessage,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   createAgentHarnessTaskRuntime,
   deliverAgentHarnessTaskCompletion,
@@ -24,6 +28,8 @@ import {
   type CodexAppServerLiveThreadOwnership,
 } from "./client-runtime.js";
 import type { CodexAppServerClient } from "./client.js";
+import { projectNormalizedToolItem } from "./event-projector-events.js";
+import { readItem } from "./event-projector-values.js";
 import {
   codexNativeSubagentNotifications as nativeSubagentNotifications,
   type CodexNativeSubagentCompletion,
@@ -140,6 +146,7 @@ const NATIVE_SUBAGENT_NOTIFICATION_METHODS = new Set([
   "turn/started",
   "turn/completed",
   "item/agentMessage/delta",
+  "item/reasoning/summaryTextDelta",
   "item/started",
   "item/completed",
   // App-server exposes no typed terminal subagent result. Keep this one raw
@@ -470,6 +477,9 @@ class Monitor {
     if (notification.method === "turn/started" && childState) {
       this.resumeChild(childState);
     }
+    if (childState && !childState.terminal) {
+      this.emitChildTaskActivity(notification, childState.childThreadId);
+    }
     this.captureChildAssistantMessage(notification);
     await this.handleChildTurnCompletion(notification);
     if (notification.method === "thread/status/changed" && threadId && threadStatus) {
@@ -499,6 +509,45 @@ class Monitor {
       }
     }
     await this.handleCompletionNotification(notification);
+  }
+
+  private emitChildTaskActivity(
+    notification: CodexServerNotification,
+    childThreadId: string,
+  ): void {
+    const params = isJsonObject(notification.params) ? notification.params : undefined;
+    if (!params) {
+      return;
+    }
+    const runId = codexNativeSubagentRunId(childThreadId);
+    if (notification.method === "item/agentMessage/delta") {
+      const delta = readString(params, "delta");
+      if (delta) {
+        emitAgentEvent({ runId, stream: "assistant", data: { delta } });
+      }
+      return;
+    }
+    if (notification.method === "item/reasoning/summaryTextDelta") {
+      const delta = readString(params, "delta");
+      if (delta) {
+        emitAgentEvent({ runId, stream: "thinking", data: { delta } });
+      }
+      return;
+    }
+    if (notification.method !== "item/started" && notification.method !== "item/completed") {
+      return;
+    }
+    const item = readItem(params.item);
+    if (item?.type === "agentMessage" && notification.method === "item/completed" && item.text) {
+      emitAgentEvent({ runId, stream: "assistant", data: { text: item.text } });
+    }
+    const projection = projectNormalizedToolItem({
+      phase: notification.method === "item/started" ? "start" : "result",
+      item,
+    });
+    if (projection?.event) {
+      emitAgentEvent({ runId, ...projection.event });
+    }
   }
 
   private resumeChild(childState: ChildState, options: { scheduleRecovery?: boolean } = {}): void {

--- a/src/gateway/agent-turn/agent-run-admission-phase.ts
+++ b/src/gateway/agent-turn/agent-run-admission-phase.ts
@@ -328,6 +328,7 @@ export async function prepareAgentRunDispatch(params: {
       logGateway: params.context.logGateway,
     }),
     modelRun: params.isOneShotModelRun,
+    runId: params.runId,
   });
   const dispatchTaskTrackingMode: PreparedAgentRunDispatch["dispatchTaskTrackingMode"] =
     taskTrackingMode === "cli" ? "cli" : "none";

--- a/src/gateway/server-methods/agent-task-tracking.ts
+++ b/src/gateway/server-methods/agent-task-tracking.ts
@@ -14,7 +14,7 @@ import {
   parseThreadSessionSuffix,
 } from "../../sessions/session-key-utils.js";
 import { finalizeTaskRunByRunId } from "../../tasks/detached-task-runtime.js";
-import { findTaskByRunId } from "../../tasks/task-registry.js";
+import { findTaskByRunId } from "../../tasks/runtime-internal.js";
 import type { TaskStatus } from "../../tasks/task-registry.types.js";
 import { formatForLog } from "../ws-log.js";
 import type { GatewayRequestContext, GatewayRequestHandlerOptions } from "./types.js";

--- a/src/gateway/server-methods/agent-task-tracking.ts
+++ b/src/gateway/server-methods/agent-task-tracking.ts
@@ -14,6 +14,7 @@ import {
   parseThreadSessionSuffix,
 } from "../../sessions/session-key-utils.js";
 import { finalizeTaskRunByRunId } from "../../tasks/detached-task-runtime.js";
+import { findTaskByRunId } from "../../tasks/task-registry.js";
 import type { TaskStatus } from "../../tasks/task-registry.types.js";
 import { formatForLog } from "../ws-log.js";
 import type { GatewayRequestContext, GatewayRequestHandlerOptions } from "./types.js";
@@ -88,6 +89,7 @@ export function resolveGatewayAgentTaskTrackingMode(params: {
   inputProvenance?: InputProvenance;
   confirmedAcpManualSpawn?: boolean;
   modelRun?: boolean;
+  runId?: string;
 }): GatewayAgentTaskTrackingMode {
   // Model probes are stateless one-shot work. A terminal CLI task row would
   // outlive the probe even when its session/transcript effects are internal.
@@ -99,6 +101,15 @@ export function resolveGatewayAgentTaskTrackingMode(params: {
   }
   if (params.client?.internal?.agentRunTracking === "plugin_subagent") {
     return "plugin_subagent";
+  }
+  // The subagent registry created the authoritative row before its host-owned
+  // gateway dispatch. A CLI row here would represent the same run twice.
+  const existingTask = params.runId ? findTaskByRunId(params.runId) : undefined;
+  if (
+    existingTask?.runtime === "subagent" &&
+    existingTask.childSessionKey === params.sessionKey?.trim()
+  ) {
+    return "none";
   }
   // A confirmed ACP manual-spawn child turn already owns its requester-visible
   // `acp` task row from the spawn control plane (src/agents/subagents/spawn/acp-spawn.ts). The

--- a/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
+++ b/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
@@ -2572,6 +2572,38 @@ describe("gateway agent handler", () => {
       });
     });
 
+    it("keeps a host-owned subagent run to its pre-registered task row", async () => {
+      await withTempDir({ prefix: "openclaw-gateway-subagent-owner-" }, async (root) => {
+        useTestStateDir(root);
+        resetAgentTaskRegistryForTests();
+        const childSessionKey = "agent:main:subagent:owned";
+        const runId = "host-owned-subagent-run";
+        mockAcpChildSessionEntry(childSessionKey);
+        getDetachedTaskLifecycleRuntime().createRunningTaskRun({
+          runtime: "subagent",
+          requesterSessionKey: "agent:main:main",
+          ownerKey: "agent:main:main",
+          scopeKind: "session",
+          childSessionKey,
+          runId,
+          task: "Run one owned subagent",
+          deliveryStatus: "pending",
+        });
+        const createRunningTaskRunSpy = spyDetachedCreateRunningTaskRun();
+
+        await invokeAgent(
+          { message: "host-owned child turn", sessionKey: childSessionKey, idempotencyKey: runId },
+          { reqId: runId, client: backendGatewayClient() },
+        );
+        await waitForAgentCommandCall();
+
+        expect(createRunningTaskRunSpy).not.toHaveBeenCalled();
+        expect(listTaskRecords().filter((task) => task.runId === runId)).toEqual([
+          expect.objectContaining({ runtime: "subagent", childSessionKey }),
+        ]);
+      });
+    });
+
     it("keeps CLI tracking when a non-backend operator-write caller sets acpTurnSource", async () => {
       await withTempDir({ prefix: "openclaw-gateway-acp-operator-write-" }, async (root) => {
         useTestStateDir(root);

--- a/src/gateway/server-runtime-subscriptions.test.ts
+++ b/src/gateway/server-runtime-subscriptions.test.ts
@@ -22,6 +22,7 @@ import {
   createTaskRecord,
   markTaskLostById,
   markTaskTerminalById,
+  recordTaskProgressByRunId,
 } from "../tasks/task-registry.js";
 import { getTaskRegistryObservers } from "../tasks/task-registry.store.js";
 import { resetTaskRegistryForTests } from "../tasks/task-runtime.test-helpers.js";
@@ -525,6 +526,50 @@ describe("startGatewayEventSubscriptions", () => {
     broadcast.mockClear();
     await vi.advanceTimersByTimeAsync(1_000);
     expect(broadcast).not.toHaveBeenCalled();
+  });
+
+  it("suppresses identical task summaries without delaying status transitions", async () => {
+    const broadcast = vi.fn<SubscriptionParams["broadcast"]>();
+    unsubs = startGatewayEventSubscriptions({ ...createParams(), broadcast });
+    await waitForFast(() => expect(getTaskRegistryObservers()).not.toBeNull());
+    const runId = "run-identical-task-summary";
+    const task = createTaskRecord({
+      runtime: "subagent",
+      requesterSessionKey: "agent:main:main",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      childSessionKey: "agent:main:subagent:summary",
+      runId,
+      task: "Avoid duplicate broadcasts",
+      status: "running",
+      deliveryStatus: "not_applicable",
+      notifyPolicy: "silent",
+      startedAt: 100,
+      lastEventAt: 100,
+    });
+    if (!task) {
+      throw new Error("expected task record");
+    }
+    broadcast.mockClear();
+
+    for (let index = 0; index < 2; index += 1) {
+      recordTaskProgressByRunId({
+        runId,
+        runtime: "subagent",
+        lastEventAt: 200,
+        progressSummary: "Working",
+      });
+    }
+    markTaskTerminalById({ taskId: task.taskId, status: "succeeded", endedAt: 300 });
+
+    const taskEvents = broadcast.mock.calls
+      .filter(([event]) => event === "task")
+      .map(([, payload]) => payload as TaskEventPayload)
+      .filter(
+        (payload): payload is Extract<TaskEventPayload, { action: "upserted" }> =>
+          payload.action === "upserted",
+      );
+    expect(taskEvents.map((event) => event.task.status)).toEqual(["running", "completed"]);
   });
 
   it.each(["succeeded", "failed", "cancelled", "timed_out", "lost"] as const)(

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -378,17 +378,27 @@ export function startGatewayEventSubscriptions(params: {
   });
 
   let taskObserverDisposed = false;
+  const lastTaskSummaryById = new Map<string, string>();
   const taskObservers = {
     onEvent: (event: TaskRegistryObserverEvent) => {
       let payload: TaskEventPayload;
       switch (event.kind) {
-        case "upserted":
-          payload = { action: "upserted", task: mapTaskSummary(event.task) };
+        case "upserted": {
+          const task = mapTaskSummary(event.task);
+          const summary = JSON.stringify(task);
+          if (lastTaskSummaryById.get(task.id) === summary) {
+            return;
+          }
+          lastTaskSummaryById.set(task.id, summary);
+          payload = { action: "upserted", task };
           break;
+        }
         case "deleted":
+          lastTaskSummaryById.delete(event.taskId);
           payload = { action: "deleted", taskId: event.taskId };
           break;
         case "restored":
+          lastTaskSummaryById.clear();
           payload = { action: "restored" };
           break;
       }

--- a/src/tasks/task-registry-activity.ts
+++ b/src/tasks/task-registry-activity.ts
@@ -117,7 +117,27 @@ function readEditPairs(args: Record<string, unknown>): EditPair[] {
 
 function readPatchDelta(args: Record<string, unknown>): DiffDelta | undefined {
   if (typeof args.input !== "string") {
-    return undefined;
+    let added = 0;
+    let removed = 0;
+    const files: string[] = [];
+    for (const candidate of Array.isArray(args.changes) ? args.changes : []) {
+      const change = asOptionalObjectRecord(candidate);
+      const target = change ? readTarget(change) : undefined;
+      if (!change || !target) {
+        continue;
+      }
+      files.push(target);
+      const stat = asOptionalObjectRecord(change.stat);
+      added +=
+        typeof stat?.added === "number" && Number.isFinite(stat.added)
+          ? Math.max(0, stat.added)
+          : 0;
+      removed +=
+        typeof stat?.removed === "number" && Number.isFinite(stat.removed)
+          ? Math.max(0, stat.removed)
+          : 0;
+    }
+    return files.length > 0 ? { files, added, removed } : undefined;
   }
   const files = extractApplyPatchTargetPaths(args);
   if (files.length === 0) {

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -33,6 +33,7 @@ import {
   requestFlowCancel,
 } from "./task-flow-registry.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
+import { getTaskActivitySnapshot } from "./task-registry-activity.js";
 import {
   cancelTaskById,
   deleteTaskRecordById,
@@ -788,6 +789,67 @@ describe("task-registry", () => {
       expectRecordFields(requireTaskByRunId("run-tools"), {
         toolUseCount: 2,
         lastToolName: "exec",
+      });
+    });
+  });
+
+  it("folds Codex native child activity under its canonical thread run id", async () => {
+    await withTaskRegistryTempDir(async () => {
+      resetTaskRegistryMemoryForTest();
+      const runId = "codex-thread:019fef4-native-child";
+      const task = createTaskFixture("subagent", {
+        childSessionKey: runId,
+        runId,
+        task: "Inspect the ACP runtime",
+        startedAt: 100,
+      });
+
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { delta: "Editing the native child path" },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "tool",
+        data: { phase: "start", name: "bash", toolCallId: "cmd-1" },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "tool",
+        data: {
+          phase: "start",
+          name: "apply_patch",
+          toolCallId: "patch-1",
+          args: {
+            changes: [
+              {
+                path: "src/tasks/task-registry.ts",
+                kind: "update",
+                stat: { added: 5, removed: 2 },
+              },
+              {
+                path: "src/tasks/task-registry.test.ts",
+                kind: "update",
+                stat: { added: 8, removed: 0 },
+              },
+            ],
+          },
+        },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "tool",
+        data: { phase: "result", name: "apply_patch", toolCallId: "patch-1", isError: false },
+      });
+
+      expectRecordFields(requireTaskByRunId(runId), {
+        toolUseCount: 2,
+        lastToolName: "apply_patch",
+      });
+      expect(getTaskActivitySnapshot(task.taskId)).toEqual({
+        lastActivity: "Editing the native child path",
+        diffStat: { files: 2, added: 13, removed: 2 },
       });
     });
   });


### PR DESCRIPTION
Related: #121549

## What Problem This Solves

Fixes an issue where task rows for Codex/ACP native subagents stayed at bare lifecycle status while the child was actively producing assistant text and tool calls. The task registry keyed those rows as `codex-thread:<childThreadId>`, but the child activity never reached the global agent-event fold under that identity, so `lastActivity`, `diffStat`, `toolUseCount`, and `lastToolName` remained empty.

The same live probe also exposed two adjacent task-stream defects: identical summaries could be broadcast repeatedly during one burst, and an ordinary host-owned subagent run could receive both its authoritative `subagent` row and a redundant gateway `cli` row for the same run.

## Why This Change Was Made

The Codex native-subagent monitor is the gateway boundary that observes child-thread app-server notifications. It now projects child assistant, reasoning-summary, and normalized tool events onto the existing global agent bus using the task's canonical `codex-thread:<childThreadId>` run ID. The existing task-registry activity fold remains the only overlay owner; it additionally accepts Codex's normalized `fileChange` change/stat arguments while preserving the existing success-gated pending/result accounting, one-second throttle, overlay-only storage, and terminal flush/clear semantics.

Task broadcasts now suppress only identical consecutive mapped summaries per task. Status changes remain immediate because status is part of the mapped summary. Gateway task tracking also consults the already-recorded run fact before creating a CLI row: when the same run ID and child session already own a `subagent` task, the redundant CLI producer stays off. Standalone CLI, ACP manual-spawn, and plugin-subagent tracking remain unchanged.

No protocol, UI, SQLite schema, or persistence shape changed.

### Codex dependency contract checked

Personally inspected sibling `openai/codex` at `c2bcb9a26b5bdbdc66c48cf3bc3bb382568e800c`:

- `codex-rs/app-server-protocol/src/protocol/v2/item.rs:1242-1252,1316-1346` defines `item/started`, `item/completed`, and `item/agentMessage/delta` with the authoritative `thread_id`.
- `codex-rs/app-server-protocol/src/protocol/event_mapping.rs:362-418,428-463` preserves that thread ID while mapping assistant deltas, generic item lifecycle, command starts, and command completions into app-server notifications.
- On the OpenClaw side, the ordinary per-attempt projector filters to one exact thread/turn and stamps the outer harness run ID, while the client-wide native-subagent monitor is the component that receives child-thread notifications. That proves the monitor is the producer boundary for the missing child activity; there is no alternate child run ID to adopt or dual-index.

### Sibling coverage

- Cron task rows pass their task-run ID into agent execution, so embedded and Codex harness events already share the same fold key.
- Detached media and background-exec rows represent one non-agent operation and do not emit nested agent tool streams under their task IDs; `toolUseCount` is not an equivalent contract for those records.

## User Impact

Clients receive one enriched task row for Codex native subagents, with live activity text, file-change totals, and tool metadata matching embedded subagents. Rapid no-op updates no longer produce identical task-event bursts, and ordinary subagent runs no longer appear twice as `subagent` plus `cli`.

## ClawSweeper rank-up moves

- No moves published. The latest exact-head ClawSweeper comment remains the `review started` placeholder for `5616934f857a22151bcc40d9b78a0b631d38fee3`, with no findings or `Rank-up moves:` list. There is therefore nothing to apply or skip; the maintainer approved this landing, and the queued review publisher is non-blocking under repository policy.

## Evidence

- Maintainer live pre-fix evidence: a dev gateway emitted `running -> completed` for a `codex-thread:*` task with no activity/tool enrichment; rapid tool bursts produced roughly 14 identical task summaries in one second; each ordinary subagent run produced matching `subagent` and `cli` rows.
- Negative control: removing the new native-monitor handoff makes `publishes child assistant and tool activity under the mirrored thread run id` fail with an empty event list; restoring it passes.
- Exact rebased subagent head: `node scripts/run-vitest.mjs src/tasks/task-registry.test.ts src/gateway/server-runtime-subscriptions.test.ts src/gateway/server-methods/agent.test.ts extensions/codex/src/app-server/native-subagent-monitor.test.ts --testNamePattern "folds Codex native child activity|publishes child assistant and tool activity|suppresses identical task summaries|keeps a host-owned subagent run"` — 4 files passed, 4 selected tests passed.
- Final rebased-head sanity covered the four task regressions, the task access boundary, and main's repaired poll suites: 7 files passed, 16 selected tests passed.
- Additional focused proof covered the existing one-minute durable-liveness bound, existing tool counting, task activity throttle/terminal flush, and streamed native-child completion paths.
- `node scripts/check-changed.mjs` — passed the complete core/extension plan locally after configured remote providers reported unavailable: formatting, Plugin SDK closure, dead exports, production/test typechecks, lint, database-first, sidecar, import-cycle, webhook, and pairing guards.
- Codex-backed autoreview — clean, no accepted/actionable findings.

Production LOC: +157/-35 (net +122) | Tests: +212/-0

The production growth establishes the missing native-child event producer, reuses the canonical Codex tool normalization, adds normalized file-change folding, suppresses identical wire summaries, and removes redundant CLI bookkeeping. Live post-change verification on a dev gateway remains the maintainer follow-up for this investigation.
