### PR TITLE
fix(telegram): preserve finalized preview on late media failure

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch-delivery.ts
+++ b/extensions/telegram/src/bot-message-dispatch-delivery.ts
@@ -35,6 +35,7 @@ import { deliverReplies, emitTelegramMessageSentHooks } from "./bot/delivery.js"
 import { resolveTelegramReplyId, type TelegramThreadSpec } from "./bot/helpers.js";
 import type { TelegramNativeQuoteCandidateByMessageId } from "./bot/native-quote.js";
 import type { TelegramInlineButtons } from "./button-types.js";
+import { mergeTelegramPartialDeliveryError } from "./chunk-delivery.js";
 import { canonicalizeTelegramPresentationPayload } from "./interactive-fallback.js";
 import {
   createLaneDeliveryStateTracker,
@@ -341,7 +342,10 @@ export function createTelegramDeliveryController(params: {
   };
 
   const emitPreviewFinalizedHook = async (result: LaneDeliveryResult) => {
-    if (params.isDispatchSuperseded() || result.kind !== "preview-finalized") {
+    if (
+      params.isDispatchSuperseded() ||
+      (result.kind !== "preview-finalized" && result.kind !== "preview-finalized-partial")
+    ) {
       return;
     }
     // A finalized preview is the durable Telegram message. Emit the composite
@@ -532,8 +536,16 @@ export function createTelegramDeliveryController(params: {
         params.progress.markFinalDelivered();
       }
     }
-    if (result.kind === "preview-finalized") {
+    if (result.kind === "preview-finalized" || result.kind === "preview-finalized-partial") {
       await emitPreviewFinalizedHook(result);
+    }
+    if (result.kind === "preview-finalized-partial") {
+      throw mergeTelegramPartialDeliveryError(result.error, {
+        receipt: result.delivery.receipt,
+        content: result.delivery.content,
+        messageIds: result.delivery.receipt.platformMessageIds,
+        visibleReplySent: true,
+      });
     }
     return result;
   };

--- a/extensions/telegram/src/bot-message-dispatch.delivery-transcript.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.delivery-transcript.test.ts
@@ -80,7 +80,10 @@ describeTelegramDispatch("dispatchTelegramMessage delivery-transcript", () => {
 
     await dispatchWithContext({ context });
 
-    expect(answerDraftStream.update).toHaveBeenCalledWith("Final answer");
+    expect(answerDraftStream.update).toHaveBeenCalledWith(
+      "Final answer",
+      expect.objectContaining({ onPlatformSendDispatch: expect.any(Function) }),
+    );
     expect(answerDraftStream.stop).toHaveBeenCalled();
     expect(deliverReplies).not.toHaveBeenCalled();
     expect(editMessageTelegram).not.toHaveBeenCalled();
@@ -318,7 +321,10 @@ describeTelegramDispatch("dispatchTelegramMessage delivery-transcript", () => {
     await dispatchWithContext({ context: createContext() });
 
     expect(answerDraftStream.update).toHaveBeenCalledTimes(1);
-    expect(answerDraftStream.update).toHaveBeenCalledWith("Final answer");
+    expect(answerDraftStream.update).toHaveBeenCalledWith(
+      "Final answer",
+      expect.objectContaining({ onPlatformSendDispatch: expect.any(Function) }),
+    );
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
@@ -351,6 +357,7 @@ describeTelegramDispatch("dispatchTelegramMessage delivery-transcript", () => {
 
     expect(answerDraftStream.update).toHaveBeenCalledWith(
       "FY25 outlook\n\nRevenue mix (pie chart)\n- Product: 60\n- Services: 40",
+      expect.objectContaining({ onPlatformSendDispatch: expect.any(Function) }),
     );
     expect(deliverReplies).not.toHaveBeenCalled();
     expect(deliverInboundReplyWithMessageSendContext).not.toHaveBeenCalled();
@@ -385,6 +392,7 @@ describeTelegramDispatch("dispatchTelegramMessage delivery-transcript", () => {
 
     expect(answerDraftStream.update).toHaveBeenCalledWith(
       "FY25 outlook\n\nPipeline (table)\n- Account: Acme; Stage: Won; ARR: 125000\n- Account: Globex; Stage: Review; ARR: 82000",
+      expect.objectContaining({ onPlatformSendDispatch: expect.any(Function) }),
     );
     expect(deliverReplies).not.toHaveBeenCalled();
     expect(deliverInboundReplyWithMessageSendContext).not.toHaveBeenCalled();
@@ -419,6 +427,7 @@ describeTelegramDispatch("dispatchTelegramMessage delivery-transcript", () => {
 
     expect(answerDraftStream.update).toHaveBeenCalledWith(
       "Quarterly results\n\nFY25 outlook\n\nDo not duplicate this block\n\nRevenue (bar chart)\n- USD: Q1: 12; Q2: 18",
+      expect.objectContaining({ onPlatformSendDispatch: expect.any(Function) }),
     );
     expect(deliverReplies).not.toHaveBeenCalled();
     expect(deliverInboundReplyWithMessageSendContext).not.toHaveBeenCalled();

--- a/extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts
@@ -153,6 +153,7 @@ describeTelegramDispatch("dispatchTelegramMessage draft-failures-progress", () =
         expect.stringMatching(
           /^partial answer\n\n.*Something went wrong while processing your request\. Please try again, or use \/new to start a fresh session\.$/,
         ),
+        expect.objectContaining({ onPlatformSendDispatch: expect.any(Function) }),
       );
       expect(answerDraftStream.clear).not.toHaveBeenCalled();
       expect(deliverReplies).not.toHaveBeenCalled();
@@ -267,7 +268,10 @@ describeTelegramDispatch("dispatchTelegramMessage draft-failures-progress", () =
 
     await dispatchWithContext({ context: createContext() });
 
-    expect(answerDraftStream.update.mock.calls).toEqual([["Site A shows X."], ["Final answer"]]);
+    expect(answerDraftStream.update.mock.calls).toEqual([
+      ["Site A shows X."],
+      ["Final answer", expect.objectContaining({ onPlatformSendDispatch: expect.any(Function) })],
+    ]);
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
       expect.objectContaining({ text: expect.stringMatching(/🛠️ Exec<\/b>$/) }),
     );
@@ -320,7 +324,11 @@ describeTelegramDispatch("dispatchTelegramMessage draft-failures-progress", () =
       expect.objectContaining({ text: expect.stringMatching(/🛠️ Exec<\/b>$/) }),
     );
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Site B shows Y.");
-    expect(answerDraftStream.update).toHaveBeenNthCalledWith(3, "Final answer");
+    expect(answerDraftStream.update).toHaveBeenNthCalledWith(
+      3,
+      "Final answer",
+      expect.objectContaining({ onPlatformSendDispatch: expect.any(Function) }),
+    );
     // The tool-progress window repositions (deferred delete) rather than an
     // immediate clear when the following text block takes over the lane.
     expect(answerDraftStream.rotateToNewMessageDeferringDelete).toHaveBeenCalledTimes(1);
@@ -356,7 +364,11 @@ describeTelegramDispatch("dispatchTelegramMessage draft-failures-progress", () =
 
     expect(answerDraftStream.forceNewMessage).not.toHaveBeenCalled();
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Partial before compaction");
-    expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Final after compaction");
+    expect(answerDraftStream.update).toHaveBeenNthCalledWith(
+      2,
+      "Final after compaction",
+      expect.objectContaining({ onPlatformSendDispatch: expect.any(Function) }),
+    );
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
@@ -375,7 +387,11 @@ describeTelegramDispatch("dispatchTelegramMessage draft-failures-progress", () =
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
       expect.objectContaining({ text: expect.stringMatching(/🛠️ Exec<\/b>$/) }),
     );
-    expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Branch is up to date");
+    expect(answerDraftStream.update).toHaveBeenNthCalledWith(
+      1,
+      "Branch is up to date",
+      expect.objectContaining({ onPlatformSendDispatch: expect.any(Function) }),
+    );
     // Reposition, not delete-then-repost: the tool-progress window is rewound
     // for a new message and its delete deferred until after the replacement
     // lands. clear() (immediate delete) must NOT run — that scroll-jumps.
@@ -422,7 +438,11 @@ describeTelegramDispatch("dispatchTelegramMessage draft-failures-progress", () =
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
       expect.objectContaining({ text: expect.stringMatching(/🛠️ Exec<\/b>$/) }),
     );
-    expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Branch is up to date");
+    expect(answerDraftStream.update).toHaveBeenNthCalledWith(
+      1,
+      "Branch is up to date",
+      expect.objectContaining({ onPlatformSendDispatch: expect.any(Function) }),
+    );
     // Across an assistant boundary the tool-progress window still repositions
     // (new message first, deferred delete) rather than deleting immediately.
     expect(answerDraftStream.rotateToNewMessageDeferringDelete).toHaveBeenCalledTimes(1);
@@ -463,7 +483,11 @@ describeTelegramDispatch("dispatchTelegramMessage draft-failures-progress", () =
     await dispatchWithContext({ context: createContext() });
 
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "🛠️ Exec: pnpm test");
-    expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Tests passed");
+    expect(answerDraftStream.update).toHaveBeenNthCalledWith(
+      2,
+      "Tests passed",
+      expect.objectContaining({ onPlatformSendDispatch: expect.any(Function) }),
+    );
     // Verbose tool result window repositions before the final: new message
     // first, superseded delete deferred (no immediate clear/delete).
     expect(answerDraftStream.rotateToNewMessageDeferringDelete).toHaveBeenCalledTimes(1);

--- a/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
@@ -1,5 +1,10 @@
+import {
+  createChannelPartialDeliveryError,
+  isChannelPartialDeliveryError,
+} from "openclaw/plugin-sdk/channel-inbound";
 import { expect, it } from "vitest";
 import {
+  appendAssistantMirrorMessageByIdentity,
   type DispatchReplyWithBufferedBlockDispatcherArgs,
   describeTelegramDispatch,
   createContext,
@@ -15,12 +20,14 @@ import {
   expectDeliverRepliesParams,
   expectRecordFields,
   expectWindowCollapsedTo,
+  loadSessionStore,
   mockCallArg,
   mockDefaultSessionEntry,
   readLatestAssistantTextByIdentity,
   recordOutboundMessageForPromptContext,
   setupDraftStreams,
   telegramProgressPreview,
+  type TelegramMessageContext,
 } from "./bot-message-dispatch.test-harness.js";
 
 describeTelegramDispatch("dispatchTelegramMessage progress-updates", () => {
@@ -196,6 +203,102 @@ describeTelegramDispatch("dispatchTelegramMessage progress-updates", () => {
       messageId: 2001,
     });
   });
+
+  it.each([
+    {
+      label: "direct chat",
+      sessionKey: "agent:test:telegram:direct:123",
+      createMessageContext: () =>
+        createContext({
+          ctxPayload: {
+            SessionKey: "agent:test:telegram:direct:123",
+            ChatType: "direct",
+          } as TelegramMessageContext["ctxPayload"],
+        }),
+    },
+    {
+      label: "group chat",
+      sessionKey: "agent:test:telegram:group:-100123",
+      createMessageContext: () =>
+        createContext({
+          chatId: -100123,
+          isGroup: true,
+          ctxPayload: {
+            SessionKey: "agent:test:telegram:group:-100123",
+            ChatType: "group",
+          } as TelegramMessageContext["ctxPayload"],
+          primaryCtx: {
+            message: { chat: { id: -100123, type: "supergroup", title: "Test group" } },
+          } as TelegramMessageContext["primaryCtx"],
+          msg: {
+            chat: { id: -100123, type: "supergroup", title: "Test group" },
+            message_id: 456,
+          } as TelegramMessageContext["msg"],
+          threadSpec: { id: undefined, scope: "none" },
+          replyThreadId: undefined,
+        }),
+    },
+  ])(
+    "keeps a finalized preview authoritative when late media fails in a $label",
+    async ({ createMessageContext, sessionKey }) => {
+      const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+      loadSessionStore.mockReturnValue({ [sessionKey]: { sessionId: "s1", updatedAt: 1 } });
+      const mediaFailure = createChannelPartialDeliveryError(new Error("media rejected"), {
+        messageIds: ["2002"],
+        visibleReplySent: true,
+      });
+      deliverReplies.mockRejectedValueOnce(mediaFailure);
+      let observedError: unknown;
+      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+        async ({ dispatcherOptions, replyOptions }) => {
+          await replyOptions?.onPartialReply?.({ text: "Photo" });
+          try {
+            await dispatcherOptions.deliver(
+              { text: "Photo", mediaUrl: "https://example.com/a.png" },
+              { kind: "final" },
+            );
+          } catch (error) {
+            observedError = error;
+            await dispatcherOptions.onError?.(error, { kind: "final" });
+          }
+          return {
+            queuedFinal: false,
+            counts: { block: 0, final: 1, tool: 0 },
+          };
+        },
+      );
+
+      await dispatchWithContext({ context: createMessageContext() });
+
+      expect(isChannelPartialDeliveryError(observedError)).toBe(true);
+      if (!isChannelPartialDeliveryError(observedError)) {
+        throw new Error("expected structured partial delivery error");
+      }
+      expect(observedError.deliveryResult).toMatchObject({
+        content: "Photo",
+        messageIds: ["2001", "2002"],
+        receipt: { primaryPlatformMessageId: "2001" },
+        visibleReplySent: true,
+      });
+      // onError records a non-silent failure. Avoiding a second delivery proves
+      // the finalized answer was committed before that failure was surfaced.
+      expect(deliverReplies).toHaveBeenCalledTimes(1);
+      expectDeliveredReply(0, { text: undefined, mediaUrl: "https://example.com/a.png" });
+      expect(answerDraftStream.stop).toHaveBeenCalled();
+      expect(answerDraftStream.clear).not.toHaveBeenCalled();
+      expect(emitTelegramMessageSentHooks).toHaveBeenCalledTimes(1);
+      expectRecordFields(mockCallArg(emitTelegramMessageSentHooks), {
+        content: "Photo",
+        messageId: 2001,
+        success: true,
+      });
+      expect(appendAssistantMirrorMessageByIdentity).toHaveBeenCalledTimes(1);
+      expectRecordFields(mockCallArg(appendAssistantMirrorMessageByIdentity), {
+        sessionKey,
+        text: "Photo",
+      });
+    },
+  );
 
   it("sends standalone MEDIA directive final replies as media", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });

--- a/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
@@ -163,7 +163,10 @@ describeTelegramDispatch("dispatchTelegramMessage progress-updates", () => {
 
     await dispatchWithContext({ context: createContext(), textLimit: 80 });
 
-    expect(answerDraftStream.update).toHaveBeenLastCalledWith(longText.trimEnd());
+    expect(answerDraftStream.update).toHaveBeenLastCalledWith(
+      longText.trimEnd(),
+      expect.objectContaining({ onPlatformSendDispatch: expect.any(Function) }),
+    );
     expectRecordFields(mockCallArg(recordOutboundMessageForPromptContext), {
       messageId: 2001,
       text: longText.trimEnd(),

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -43,6 +43,7 @@ export type LaneDeliveryResult =
       kind: "preview-finalized";
       delivery: LanePreviewFinalizedDelivery;
     }
+  | { kind: "preview-finalized-partial"; delivery: LanePreviewFinalizedDelivery; error: unknown }
   | { kind: "preview-retained" | "preview-updated" | "sent" | "skipped" };
 
 type CreateLaneTextDelivererParams = {
@@ -93,7 +94,7 @@ type DeliverLaneTextParams = {
 };
 
 function result(
-  kind: LaneDeliveryResult["kind"],
+  kind: Exclude<LaneDeliveryResult["kind"], "preview-finalized-partial">,
   delivery?: LanePreviewFinalizedDeliveryInput,
 ): LaneDeliveryResult {
   if (kind === "preview-finalized") {
@@ -474,19 +475,26 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           finalizedPreview.delivery.buttonsAttached === true;
         const mediaText =
           finalizedPreview.kind === "preview-finalized" ? finalizedPreview.delivery.content : text;
-        await params.sendPayload(
-          mediaOnlyPayload(payload, mediaText, {
-            stripButtons,
-            fallbackButtons: stripButtons ? undefined : buttons,
-          }),
-          {
-            afterAcceptedDraft: true,
-            durable,
-            promptContextSequence,
-            onPlatformSendDispatch,
-            bindPendingFinalDelivery,
-          },
-        );
+        try {
+          await params.sendPayload(
+            mediaOnlyPayload(payload, mediaText, {
+              stripButtons,
+              fallbackButtons: stripButtons ? undefined : buttons,
+            }),
+            {
+              afterAcceptedDraft: true,
+              durable,
+              promptContextSequence,
+              onPlatformSendDispatch,
+              bindPendingFinalDelivery,
+            },
+          );
+        } catch (error) {
+          if (durable && finalizedPreview.kind === "preview-finalized") {
+            return { ...finalizedPreview, kind: "preview-finalized-partial", error };
+          }
+          throw error;
+        }
         return finalizedPreview;
       }
     }

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -641,6 +641,51 @@ describe("createLaneTextDeliverer", () => {
     );
   });
 
+  it("preserves a finalized preview when the late media send fails", async () => {
+    const harness = createHarness({ answerMessageId: 999 });
+    const mediaError = new Error("media rejected");
+    harness.lanes.answer.hasStreamedMessage = true;
+    harness.sendPayload.mockRejectedValueOnce(mediaError);
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "photo",
+      payload: { text: "photo", mediaUrl: "https://example.com/a.png" },
+      infoKind: "final",
+    });
+
+    expect(result).toMatchObject({
+      kind: "preview-finalized-partial",
+      delivery: {
+        content: "photo",
+        messageId: 999,
+        receipt: { primaryPlatformMessageId: "999" },
+      },
+      error: mediaError,
+    });
+    expect(harness.markDelivered).toHaveBeenCalledTimes(1);
+    expect(harness.answer?.clear).not.toHaveBeenCalled();
+  });
+
+  it("keeps throwing late media failures without a concrete preview receipt", async () => {
+    const answer = createTestDraftStream();
+    const harness = createHarness({ answerStream: answer });
+    const mediaError = new Error("media rejected");
+    answer.sendMayHaveLanded.mockReturnValue(true);
+    harness.lanes.answer.hasStreamedMessage = true;
+    harness.sendPayload.mockRejectedValueOnce(mediaError);
+
+    await expect(
+      harness.deliverLaneText({
+        laneName: "answer",
+        text: "photo",
+        payload: { text: "photo", mediaUrl: "https://example.com/a.png" },
+        infoKind: "final",
+      }),
+    ).rejects.toBe(mediaError);
+    expect(harness.markDelivered).toHaveBeenCalledTimes(1);
+  });
+
   it("uses normal media final delivery when no preview has streamed", async () => {
     const harness = createHarness({ answerMessageId: 999 });
 


### PR DESCRIPTION
Related: #120626

## What Problem This Solves

Fixes an issue where Telegram users could receive a contradictory fallback or replay after the streamed text preview had already been finalized successfully but the supplemental media send failed afterward. The failure order is text preview accepted and finalized first, then the separate media delivery rejects; treating the whole final as undelivered loses the authoritative text receipt.

## Why This Change Was Made

The Telegram delivery lane now returns a closed `preview-finalized-partial` outcome only when it has a concrete finalized preview receipt and the supplemental media send fails. The controller records that finalized message once, emits one success hook and transcript entry, and then throws the existing merged `ChannelPartialDeliveryError` with the receipt, content, and combined text/media message IDs. The ambiguous no-receipt path still throws normally, and no fallback predicate changed.

The rebase preserves #121908's pending-final custody contract. `onPlatformSendDispatch` and `bindPendingFinalDelivery` remain threaded through preview finalization and the supplemental media send in main's original order; the late-media catch encloses that unchanged send and does not invoke either callback itself. The test-only poll-isolation commit was dropped because #121923 is now the canonical main implementation.

## User Impact

Users keep exactly one finalized Telegram answer when late media delivery fails. The media failure remains structured and observable for retry/diagnostics, while Telegram does not send a second fallback or replay that contradicts the answer already visible in the chat.

There is no config, protocol, storage, public Plugin SDK, or changelog change.

## Evidence

- Rebased product commit `790162bb1af47d5f2d1a82544414b7232692371f` onto `origin/main` `465aad50a7fa3f27dcf15e244de8d75a2fe3ef6b`; rebased product commit `98fb6f1b45528b10bcf2b6fd7c37c31b8c1ac0a3`, exact head `2f668d5315f41809d144c769f3f62619d21a42d8`.
- Range-diff: the product patch is unchanged except for carrying #121908's `onPlatformSendDispatch` and `bindPendingFinalDelivery` options through the supplemental send. A separate test-only commit refreshes exact-main assertions to require the custody callback on final preview updates.
- Pre-fix reproduction remains the original three late-media regressions: the lane throws the raw media error and the controller error lacks the finalized preview receipt/content/text message ID.
- Late-media selection: 5/5 passed across concrete receipt, ambiguous no-receipt, direct/group controller behavior, and #121908 equal-preview custody ordering.
- Requested Telegram files: 152/153 passed. The sole failure is the unchanged `keeps progress updates in a draft and sends the final answer normally` content assertion; it is unrelated to this patch and was not weakened. The three relevant #120626 recovery cases pass 3/3.
- #121908 pending-final/custody coverage: 268/268 passed across the selected core files; the callback-specific selection passed 3/3.
- Targeted `oxfmt --check` and `git diff --check origin/main...HEAD` pass.
- Blacksmith Testbox changed gate: `tbx_01kzqx6aynn68bnsxqkhfpwpyt`, exit 0, https://github.com/openclaw/openclaw/actions/runs/31471086534. It passed extension production/test types, lint, format, dependency/API/plugin boundaries, dead exports, database-first policy, and import cycles.
- Fresh exact-branch Codex autoreview: no findings; patch correct (0.98 confidence).
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/31472359736
- Mock boundary: unit-level Telegram lane/controller proof covers direct and group chats, exactly one finalized text message, no fallback/replay, one success hook/transcript, and a structured supplemental failure carrying the text receipt plus media ID.
- Production LOC: +36/-16 (net +20). Tests: +193/-9.

### Live Telegram proof

Exact live proof is not claimed. The protected bot-to-bot adapter is group-only and its existing failure fixture injects a provider-stream failure rather than a late media rejection. The real-user DM/group runner cannot configure `streaming.mode=partial`, has no controlled media/Bot API fault injection, and does not expose the structured receipt/content/message IDs in diagnostics. Adding honest support requires broader QA/Crabline fault-injection plumbing, so this narrowly scoped PR does not add a misleading scenario or a test-only production seam.

The maintainer explicitly accepted this documented harness limitation for the bounded repair: https://github.com/openclaw/openclaw/pull/121903#issuecomment-5250371062.
