### PR TITLE
test(plugins): remove cache resize test knob

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.jsonl
+++ b/docs/.generated/plugin-sdk-api-baseline.jsonl
@@ -3,7 +3,7 @@
 {"contentHash":"0d6827cdd7180482c49dc67aacc2b512e587d3453536081c15d3febaea2f1492","entrypoint":"account-id","importSpecifier":"openclaw/plugin-sdk/account-id"}
 {"contentHash":"0b4930a77ab3e63bed21a9651a23fb7130f623baf6ce153166cb80a965b0a004","entrypoint":"account-resolution","importSpecifier":"openclaw/plugin-sdk/account-resolution"}
 {"contentHash":"0349da0a93dadbdcff03ae8064b5066c5f2e1c28ee298bfa9ab3f1f8563300eb","entrypoint":"agent-config-primitives","importSpecifier":"openclaw/plugin-sdk/agent-config-primitives"}
-{"contentHash":"01d5984723e919a0b30a413c69daf0ccb4a0d2f58fdc8f12e177571760216964","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
+{"contentHash":"f53fd79e49341efdb7bd36238086046421aaaf4d30207ef87d0f25458900346c","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
 {"contentHash":"5ca2313d2fc0861f057bdebe44b6ef0b7f381acbc29554c206b2a996446745c0","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}
 {"contentHash":"4387e74b1261f632a0e140276c0f8cbbbe848a11f7ad287325538ebbee3b09da","entrypoint":"agent-media-payload","importSpecifier":"openclaw/plugin-sdk/agent-media-payload"}
 {"contentHash":"2782e8bae7ec62400f52caf45a6e58f61abb403bc0db28cdbfbc7833cd880ef8","entrypoint":"agent-runtime","importSpecifier":"openclaw/plugin-sdk/agent-runtime"}
@@ -104,7 +104,7 @@
 {"contentHash":"5a0848b02e24fa578448caa1ae877c6999af173e6a385015b4d4fa8316bf91b9","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}
 {"contentHash":"28b6ad49a305b579922ef3d1f199002787d05760c513d0b9f5847184d3547f69","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}
 {"contentHash":"d5d21f2a0883eac72d6642d93306c36e2de0f3851286eb3edbe3a2d9d6122dcc","entrypoint":"provider-auth","importSpecifier":"openclaw/plugin-sdk/provider-auth"}
-{"contentHash":"167605e024a3a1e9b94f5cc38deca1f26b8084e32959b144cd115585ed77976c","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
+{"contentHash":"0b89249790e2f201f4a6264d6ba7c9892f5f0bb564f540c8d5547e0d150e38a4","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
 {"contentHash":"aee2a235e7218ed4ba36e80e0a6d67ceb3b5de448f25ebc10d6f70552dc35b8a","entrypoint":"proxy-capture","importSpecifier":"openclaw/plugin-sdk/proxy-capture"}
 {"contentHash":"55bc0be5ce1d700d8b671efccb69ec14a3c942535c2f77d3ed7ca87809dc1ad9","entrypoint":"question-gateway-runtime","importSpecifier":"openclaw/plugin-sdk/question-gateway-runtime"}
 {"contentHash":"5263836c817c9391fd5a0efdda50552330dd01e4d6bc9cb4ebba58627c48f098","entrypoint":"reply-chunking","importSpecifier":"openclaw/plugin-sdk/reply-chunking"}

--- a/src/plugins/loader-cache-state.ts
+++ b/src/plugins/loader-cache-state.ts
@@ -22,14 +22,6 @@ export class PluginLoaderCacheState<T> {
     this.#registryCache = new PluginLruCache<T>(defaultMaxEntries);
   }
 
-  get maxEntries(): number {
-    return this.#registryCache.maxEntries;
-  }
-
-  setMaxEntriesForTest(value?: number): void {
-    this.#registryCache.setMaxEntriesForTest(value);
-  }
-
   clear(): void {
     this.#registryCache.clear();
     this.#inFlightLoads.clear();

--- a/src/plugins/plugin-cache-primitives.test.ts
+++ b/src/plugins/plugin-cache-primitives.test.ts
@@ -32,20 +32,6 @@ describe("PluginLruCache", () => {
     expect(cache.getResult("missing")).toEqual({ hit: true, value: null });
     expect(cache.getResult("unknown")).toEqual({ hit: false });
   });
-
-  it("resizes and falls back to the default max entry count", () => {
-    const cache = new PluginLruCache<string>(2);
-
-    cache.setMaxEntriesForTest(1.9);
-    cache.set("a", "alpha");
-    cache.set("b", "bravo");
-    expect(cache.maxEntries).toBe(1);
-    expect(cache.size).toBe(1);
-    expect(cache.get("a")).toBeUndefined();
-
-    cache.setMaxEntriesForTest();
-    expect(cache.maxEntries).toBe(2);
-  });
 });
 
 describe("resolveConfigScopedRuntimeCacheValue", () => {

--- a/src/plugins/plugin-cache-primitives.ts
+++ b/src/plugins/plugin-cache-primitives.ts
@@ -7,29 +7,15 @@ type PluginLruCacheResult<T> = { hit: true; value: T } | { hit: false };
 
 /** Small process-local LRU cache used for stable plugin metadata and loader artifacts. */
 export class PluginLruCache<T> {
-  readonly #defaultMaxEntries: number;
-  #maxEntries: number;
+  readonly #maxEntries: number;
   readonly #entries = new Map<string, T>();
 
-  constructor(defaultMaxEntries: number) {
-    this.#defaultMaxEntries = normalizeMaxEntries(defaultMaxEntries, 1);
-    this.#maxEntries = this.#defaultMaxEntries;
-  }
-
-  get maxEntries(): number {
-    return this.#maxEntries;
+  constructor(maxEntries: number) {
+    this.#maxEntries = normalizeMaxEntries(maxEntries, 1);
   }
 
   get size(): number {
     return this.#entries.size;
-  }
-
-  setMaxEntriesForTest(value?: number): void {
-    this.#maxEntries =
-      typeof value === "number"
-        ? normalizeMaxEntries(value, this.#defaultMaxEntries)
-        : this.#defaultMaxEntries;
-    pruneMapToMaxSize(this.#entries, this.#maxEntries);
   }
 
   clear(): void {


### PR DESCRIPTION
## What Problem This Solves

Plugin LRU caches retained mutable capacity state, `maxEntries` accessors, and `setMaxEntriesForTest` forwarding even though production always fixes capacity in the constructor. The only resize caller was a test of the test knob itself; loader-cache forwarding accessors had no caller at all.

## Why This Change Was Made

This removes:

- mutable/default capacity bookkeeping from `PluginLruCache`;
- primitive and loader-state `maxEntries` accessors;
- primitive and loader-state resize mutators; and
- the resize-only test.

Constructor normalization, observable cache size, LRU promotion/eviction, cache clearing, in-flight guards, and warning state remain unchanged and directly tested.

Because these primitives are in the transitive implementation closure of Plugin SDK exports, the generated API contract updates five closure hashes. Public declarations and exported names are unchanged.

AI-assisted: yes. Callers, history, owner tests, generated closure impact, and current main were manually verified; fresh structured review found no actionable issue.

## User Impact

No user-visible behavior change. Plugin caches keep the same fixed bounds and eviction policy with less test-only mutation surface.

## Evidence

- Plugin cache primitive, loader-state, and module-loader cache suites — 3 files and 31 tests passed after rebase.
- `pnpm plugin-sdk:api:check` — passed with the regenerated five-hash contract update.
- `node scripts/check-changed.mjs -- ...` — passed all classified format, Plugin SDK API, type, lint, dead-export, boundary, architecture, and safety gates through trusted local fallback because Blacksmith Testbox is unavailable on this host.
- Fresh structured reviews of the source cleanup, generated contract, and complete branch — clean.
- `git diff --check` — clean.

Production delta: −22 lines. Tests: −14 lines. Generated contract: 5 hash replacements, no declaration changes.
