### PR TITLE
fix(telegram): preserve reply and quote context from batched messages

### DIFF
--- a/extensions/telegram/src/bot-handlers.inbound-buffer.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-buffer.ts
@@ -205,7 +205,7 @@ export function createTelegramInboundBuffers({
               ),
               receivedAtMs: first.receivedAtMs,
               ingressBuffer: "inbound-debounce",
-              inboundDebounceMessages: entries.map((entry) => entry.msg),
+              bufferedMessages: entries.map((entry) => entry.msg),
               ...promptContextBoundaryOptions(
                 latestPromptContextMinTimestampMs(
                   ...entries.map((entry) => entry.promptContextMinTimestampMs),
@@ -287,6 +287,7 @@ export function createTelegramInboundBuffers({
   const flushTextFragments = async (entry: TextFragmentEntry) => {
     try {
       entry.messages.sort((a, b) => a.msg.message_id - b.msg.message_id);
+      const bufferedMessages = entry.messages.map((bufferedMessage) => bufferedMessage.msg);
       const first = entry.messages[0];
       const last = entry.messages.at(-1);
       if (!first || !last) {
@@ -294,10 +295,7 @@ export function createTelegramInboundBuffers({
         settleSpooledReplayParticipants(entry.spooledReplayParticipants, { kind: "skipped" });
         return;
       }
-      const combinedTextParts = joinTelegramTextParts(
-        entry.messages.map((bufferedMessage) => bufferedMessage.msg),
-        "",
-      );
+      const combinedTextParts = joinTelegramTextParts(bufferedMessages, "");
       const combinedText = combinedTextParts.text;
       if (!combinedText.trim()) {
         releaseDispatchDedupeClaims(entry.dispatchDedupeClaims);
@@ -317,11 +315,10 @@ export function createTelegramInboundBuffers({
         storeAllowFrom: entry.storeAllowFrom,
         options: {
           messageIdOverride: String(last.msg.message_id),
-          ambientTranscriptBody: formatTelegramAmbientTranscriptBody(
-            entry.messages.map((bufferedMessage) => bufferedMessage.msg),
-          ),
+          ambientTranscriptBody: formatTelegramAmbientTranscriptBody(bufferedMessages),
           receivedAtMs: first.receivedAtMs,
           ingressBuffer: "text-fragment",
+          bufferedMessages,
           ...promptContextBoundaryOptions(
             entry.promptContextMinTimestampMs,
             entry.promptContextAmbientWatermark,

--- a/extensions/telegram/src/bot-message-context.forwarded-batch.test.ts
+++ b/extensions/telegram/src/bot-message-context.forwarded-batch.test.ts
@@ -18,7 +18,7 @@ describe("buildTelegramMessageContext forwarded debounce batches", () => {
         ],
       },
       options: {
-        inboundDebounceMessages: [
+        bufferedMessages: [
           {
             message_id: 1,
             date: 1_700_000_000,
@@ -64,7 +64,7 @@ describe("buildTelegramMessageContext forwarded debounce batches", () => {
         },
       },
       options: {
-        inboundDebounceMessages: [
+        bufferedMessages: [
           {
             message_id: 1,
             date: 1_700_000_000,
@@ -122,7 +122,7 @@ describe("buildTelegramMessageContext forwarded debounce batches", () => {
         topicConfig: undefined,
       }),
       options: {
-        inboundDebounceMessages: [
+        bufferedMessages: [
           {
             message_id: 1,
             date: 1_700_000_000,
@@ -171,7 +171,7 @@ describe("buildTelegramMessageContext forwarded debounce batches", () => {
       },
       allMedia: [{ path: "/tmp/photo-1.jpg", contentType: "image/jpeg", kind: "image" }],
       options: {
-        inboundDebounceMessages: [
+        bufferedMessages: [
           {
             message_id: 1,
             date: 1_700_000_000,

--- a/extensions/telegram/src/bot-message-context.reply-batch.test.ts
+++ b/extensions/telegram/src/bot-message-context.reply-batch.test.ts
@@ -60,7 +60,7 @@ describe("buildTelegramMessageContext reply/quote debounce batches", () => {
     const context = await buildTelegramMessageContextForTest({
       message: plainMessage(2, "plain note\nquoting note"),
       options: {
-        inboundDebounceMessages: [plainMessage(1, "plain note"), quotingMessage(2, "quoting note")],
+        bufferedMessages: [plainMessage(1, "plain note"), quotingMessage(2, "quoting note")],
       },
     });
 
@@ -82,7 +82,7 @@ describe("buildTelegramMessageContext reply/quote debounce batches", () => {
         },
       ],
       options: {
-        inboundDebounceMessages: [
+        bufferedMessages: [
           first,
           {
             ...plainMessage(2, "follow-up"),
@@ -108,7 +108,7 @@ describe("buildTelegramMessageContext reply/quote debounce batches", () => {
     const context = await buildTelegramMessageContextForTest({
       message: plainMessage(3, "first ask\nsecond ask"),
       options: {
-        inboundDebounceMessages: [quotingMessage(1, "first ask"), quotingMessage(2, "second ask")],
+        bufferedMessages: [quotingMessage(1, "first ask"), quotingMessage(2, "second ask")],
       },
     });
 
@@ -129,7 +129,7 @@ describe("buildTelegramMessageContext reply/quote debounce batches", () => {
       message: plainMessage(2, "plain note\nquoting note"),
       replyChain: ancestry,
       options: {
-        inboundDebounceMessages: [plainMessage(1, "plain note"), quotingMessage(2, "quoting note")],
+        bufferedMessages: [plainMessage(1, "plain note"), quotingMessage(2, "quoting note")],
       },
     });
 
@@ -146,7 +146,7 @@ describe("buildTelegramMessageContext reply/quote debounce batches", () => {
     );
     const context = await buildTelegramMessageContextForTest({
       message: plainMessage(99, burst.map((entry) => entry.text).join("\n")),
-      options: { inboundDebounceMessages: burst },
+      options: { bufferedMessages: burst },
     });
 
     const body = context?.ctxPayload.Body ?? "";

--- a/extensions/telegram/src/bot-message-context.reply-batch.test.ts
+++ b/extensions/telegram/src/bot-message-context.reply-batch.test.ts
@@ -1,107 +1,71 @@
 import { describe, expect, it } from "vitest";
 import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
 
+const CHAT = { id: 999, type: "private" as const, first_name: "Alice" };
+const SENDER = { id: 42, first_name: "Alice", is_bot: false as const };
+const QUOTED_LINE = "the quoted source line";
+// `ReplyMessage` is a Message pinned to `reply_to_message: undefined`, so the
+// embedded reply target cannot itself nest another one.
+const REPLY_TARGET = {
+  message_id: 90,
+  date: 1_699_999_000,
+  chat: CHAT,
+  text: QUOTED_LINE,
+  from: { id: 7, first_name: "Bob", is_bot: false as const },
+  reply_to_message: undefined,
+};
+
+function quotingMessage(messageId: number, text: string) {
+  return {
+    message_id: messageId,
+    date: 1_700_000_000 + messageId,
+    chat: CHAT,
+    from: SENDER,
+    text,
+    reply_to_message: REPLY_TARGET,
+    quote: { text: QUOTED_LINE, position: 0 },
+  };
+}
+
+function plainMessage(messageId: number, text: string) {
+  return { message_id: messageId, date: 1_700_000_000 + messageId, chat: CHAT, from: SENDER, text };
+}
+
 describe("buildTelegramMessageContext reply/quote debounce batches", () => {
   it("preserves a quote carried by a non-first buffered message", async () => {
-    const chat = { id: 999, type: "private" as const, first_name: "Alice" };
-    const sender = { id: 42, first_name: "Alice", is_bot: false };
     const context = await buildTelegramMessageContextForTest({
-      message: {
-        message_id: 2,
-        chat,
-        from: sender,
-        text: "plain note\nquoting note",
-      },
+      message: plainMessage(2, "plain note\nquoting note"),
       options: {
-        inboundDebounceMessages: [
-          {
-            message_id: 1,
-            date: 1_700_000_000,
-            chat,
-            from: sender,
-            text: "plain note",
-          },
-          {
-            message_id: 2,
-            date: 1_700_000_001,
-            chat,
-            from: sender,
-            text: "quoting note",
-            reply_to_message: {
-              message_id: 90,
-              date: 1_699_999_000,
-              chat,
-              from: { id: 7, first_name: "Bob", is_bot: false },
-              text: "the quoted source line",
-            },
-            quote: { text: "the quoted source line", position: 0 },
-          },
-        ],
+        inboundDebounceMessages: [plainMessage(1, "plain note"), quotingMessage(2, "quoting note")],
       },
     });
 
-    expect(context?.ctxPayload.Body).toContain("the quoted source line");
+    expect(context?.ctxPayload.Body).toContain(QUOTED_LINE);
   });
 
   // Control: the identical quote on the FIRST buffered entry must be visible.
   // Without this, a failure above could just mean "quotes never reach Body".
   it("CONTROL: preserves the same quote when it is on the first buffered message", async () => {
-    const chat = { id: 999, type: "private" as const, first_name: "Alice" };
-    const sender = { id: 42, first_name: "Alice", is_bot: false };
-    const quoting = {
-      message_id: 1,
-      date: 1_700_000_000,
-      chat,
-      from: sender,
-      text: "quoting note",
-      reply_to_message: {
-        message_id: 90,
-        date: 1_699_999_000,
-        chat,
-        from: { id: 7, first_name: "Bob", is_bot: false },
-        text: "the quoted source line",
-      },
-      quote: { text: "the quoted source line", position: 0 },
-    };
     const context = await buildTelegramMessageContextForTest({
-      message: { ...quoting, message_id: 2, text: "quoting note\nplain note" },
+      message: quotingMessage(2, "quoting note\nplain note"),
       options: {
-        inboundDebounceMessages: [
-          quoting,
-          { message_id: 2, date: 1_700_000_001, chat, from: sender, text: "plain note" },
-        ],
+        inboundDebounceMessages: [quotingMessage(1, "quoting note"), plainMessage(2, "plain note")],
       },
     });
 
-    expect(context?.ctxPayload.Body).toContain("the quoted source line");
+    expect(context?.ctxPayload.Body).toContain(QUOTED_LINE);
   });
 
   it("lists a source re-quoted by two buffered messages only once", async () => {
-    const chat = { id: 999, type: "private" as const, first_name: "Alice" };
-    const sender = { id: 42, first_name: "Alice", is_bot: false };
-    const source = {
-      message_id: 90,
-      date: 1_699_999_000,
-      chat,
-      from: { id: 7, first_name: "Bob", is_bot: false },
-      text: "the quoted source line",
-    };
-    const quoting = (messageId: number, text: string) => ({
-      message_id: messageId,
-      date: 1_700_000_000 + messageId,
-      chat,
-      from: sender,
-      text,
-      reply_to_message: source,
-      quote: { text: "the quoted source line", position: 0 },
-    });
     const context = await buildTelegramMessageContextForTest({
-      message: { message_id: 3, chat, from: sender, text: "first ask\nsecond ask" },
-      options: { inboundDebounceMessages: [quoting(1, "first ask"), quoting(2, "second ask")] },
+      message: plainMessage(3, "first ask\nsecond ask"),
+      options: {
+        inboundDebounceMessages: [quotingMessage(1, "first ask"), quotingMessage(2, "second ask")],
+      },
     });
 
     const body = context?.ctxPayload.Body ?? "";
-    expect(body).toContain("the quoted source line");
-    expect(body.split("the quoted source line").length - 1).toBe(1);
+    expect(body).toContain(QUOTED_LINE);
+    expect(body.split(QUOTED_LINE).length - 1).toBe(1);
   });
 });

--- a/extensions/telegram/src/bot-message-context.reply-batch.test.ts
+++ b/extensions/telegram/src/bot-message-context.reply-batch.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
+import { TELEGRAM_REPLY_CHAIN_MAX_DEPTH } from "./message-cache.js";
 
 const CHAT = { id: 999, type: "private" as const, first_name: "Alice" };
 const SENDER = { id: 42, first_name: "Alice", is_bot: false as const };
@@ -25,6 +26,29 @@ function quotingMessage(messageId: number, text: string) {
     reply_to_message: REPLY_TARGET,
     quote: { text: QUOTED_LINE, position: 0 },
   };
+}
+
+/** A quoting message whose reply target is unique, so none of them dedupe away. */
+function quotingDistinctSource(messageId: number) {
+  const sourceText = `distinct source ${messageId}`;
+  return {
+    message_id: messageId,
+    date: 1_700_000_000 + messageId,
+    chat: CHAT,
+    from: SENDER,
+    text: `ask ${messageId}`,
+    reply_to_message: { ...REPLY_TARGET, message_id: 500 + messageId, text: sourceText },
+    quote: { text: sourceText, position: 0 },
+  };
+}
+
+function countReplyChainEntries(body: string): number {
+  const block = body.match(/\[Reply chain - nearest first\]\n([\s\S]*?)\n\[\/Reply chain\]/)?.[1];
+  if (!block) {
+    return 0;
+  }
+  // Entries render as `[1. Bob id:501]` followed by their body lines.
+  return block.split("\n").filter((line) => /^\[\d+\. /.test(line)).length;
 }
 
 function plainMessage(messageId: number, text: string) {
@@ -67,5 +91,21 @@ describe("buildTelegramMessageContext reply/quote debounce batches", () => {
     const body = context?.ctxPayload.Body ?? "";
     expect(body).toContain(QUOTED_LINE);
     expect(body.split(QUOTED_LINE).length - 1).toBe(1);
+  });
+
+  // A debounce window has no per-item cap of its own, so without a bound here a
+  // burst of distinct quote-replies would grow model-visible context without limit.
+  it("caps batch-derived reply targets at the canonical chain depth", async () => {
+    const burst = Array.from({ length: TELEGRAM_REPLY_CHAIN_MAX_DEPTH * 2 + 2 }, (_, i) =>
+      quotingDistinctSource(i + 1),
+    );
+    const context = await buildTelegramMessageContextForTest({
+      message: plainMessage(99, burst.map((entry) => entry.text).join("\n")),
+      options: { inboundDebounceMessages: burst },
+    });
+
+    const entries = countReplyChainEntries(context?.ctxPayload.Body ?? "");
+    expect(entries).toBeGreaterThan(0);
+    expect(entries).toBeLessThanOrEqual(TELEGRAM_REPLY_CHAIN_MAX_DEPTH);
   });
 });

--- a/extensions/telegram/src/bot-message-context.reply-batch.test.ts
+++ b/extensions/telegram/src/bot-message-context.reply-batch.test.ts
@@ -93,6 +93,27 @@ describe("buildTelegramMessageContext reply/quote debounce batches", () => {
     expect(body.split(QUOTED_LINE).length - 1).toBe(1);
   });
 
+  // The cap must not spend all its slots on the first message's inherited
+  // ancestry, or it suppresses exactly the later quote this path recovers.
+  it("keeps a later quote when the first message already has a full reply ancestry", async () => {
+    const ancestry = Array.from({ length: TELEGRAM_REPLY_CHAIN_MAX_DEPTH }, (_, i) => ({
+      messageId: String(900 + i),
+      sender: "Bob",
+      body: `ancestor ${i}`,
+    }));
+    const context = await buildTelegramMessageContextForTest({
+      message: plainMessage(2, "plain note\nquoting note"),
+      replyChain: ancestry,
+      options: {
+        inboundDebounceMessages: [plainMessage(1, "plain note"), quotingMessage(2, "quoting note")],
+      },
+    });
+
+    const body = context?.ctxPayload.Body ?? "";
+    expect(body).toContain(QUOTED_LINE);
+    expect(countReplyChainEntries(body)).toBeLessThanOrEqual(TELEGRAM_REPLY_CHAIN_MAX_DEPTH);
+  });
+
   // A debounce window has no per-item cap of its own, so without a bound here a
   // burst of distinct quote-replies would grow model-visible context without limit.
   it("caps batch-derived reply targets at the canonical chain depth", async () => {

--- a/extensions/telegram/src/bot-message-context.reply-batch.test.ts
+++ b/extensions/telegram/src/bot-message-context.reply-batch.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
+
+describe("buildTelegramMessageContext reply/quote debounce batches", () => {
+  it("preserves a quote carried by a non-first buffered message", async () => {
+    const chat = { id: 999, type: "private" as const, first_name: "Alice" };
+    const sender = { id: 42, first_name: "Alice", is_bot: false };
+    const context = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 2,
+        chat,
+        from: sender,
+        text: "plain note\nquoting note",
+      },
+      options: {
+        inboundDebounceMessages: [
+          {
+            message_id: 1,
+            date: 1_700_000_000,
+            chat,
+            from: sender,
+            text: "plain note",
+          },
+          {
+            message_id: 2,
+            date: 1_700_000_001,
+            chat,
+            from: sender,
+            text: "quoting note",
+            reply_to_message: {
+              message_id: 90,
+              date: 1_699_999_000,
+              chat,
+              from: { id: 7, first_name: "Bob", is_bot: false },
+              text: "the quoted source line",
+            },
+            quote: { text: "the quoted source line", position: 0 },
+          },
+        ],
+      },
+    });
+
+    expect(context?.ctxPayload.Body).toContain("the quoted source line");
+  });
+
+  // Control: the identical quote on the FIRST buffered entry must be visible.
+  // Without this, a failure above could just mean "quotes never reach Body".
+  it("CONTROL: preserves the same quote when it is on the first buffered message", async () => {
+    const chat = { id: 999, type: "private" as const, first_name: "Alice" };
+    const sender = { id: 42, first_name: "Alice", is_bot: false };
+    const quoting = {
+      message_id: 1,
+      date: 1_700_000_000,
+      chat,
+      from: sender,
+      text: "quoting note",
+      reply_to_message: {
+        message_id: 90,
+        date: 1_699_999_000,
+        chat,
+        from: { id: 7, first_name: "Bob", is_bot: false },
+        text: "the quoted source line",
+      },
+      quote: { text: "the quoted source line", position: 0 },
+    };
+    const context = await buildTelegramMessageContextForTest({
+      message: { ...quoting, message_id: 2, text: "quoting note\nplain note" },
+      options: {
+        inboundDebounceMessages: [
+          quoting,
+          { message_id: 2, date: 1_700_000_001, chat, from: sender, text: "plain note" },
+        ],
+      },
+    });
+
+    expect(context?.ctxPayload.Body).toContain("the quoted source line");
+  });
+
+  it("lists a source re-quoted by two buffered messages only once", async () => {
+    const chat = { id: 999, type: "private" as const, first_name: "Alice" };
+    const sender = { id: 42, first_name: "Alice", is_bot: false };
+    const source = {
+      message_id: 90,
+      date: 1_699_999_000,
+      chat,
+      from: { id: 7, first_name: "Bob", is_bot: false },
+      text: "the quoted source line",
+    };
+    const quoting = (messageId: number, text: string) => ({
+      message_id: messageId,
+      date: 1_700_000_000 + messageId,
+      chat,
+      from: sender,
+      text,
+      reply_to_message: source,
+      quote: { text: "the quoted source line", position: 0 },
+    });
+    const context = await buildTelegramMessageContextForTest({
+      message: { message_id: 3, chat, from: sender, text: "first ask\nsecond ask" },
+      options: { inboundDebounceMessages: [quoting(1, "first ask"), quoting(2, "second ask")] },
+    });
+
+    const body = context?.ctxPayload.Body ?? "";
+    expect(body).toContain("the quoted source line");
+    expect(body.split("the quoted source line").length - 1).toBe(1);
+  });
+});

--- a/extensions/telegram/src/bot-message-context.reply-batch.test.ts
+++ b/extensions/telegram/src/bot-message-context.reply-batch.test.ts
@@ -67,17 +67,41 @@ describe("buildTelegramMessageContext reply/quote debounce batches", () => {
     expect(context?.ctxPayload.Body).toContain(QUOTED_LINE);
   });
 
-  // Control: the identical quote on the FIRST buffered entry must be visible.
-  // Without this, a failure above could just mean "quotes never reach Body".
-  it("CONTROL: preserves the same quote when it is on the first buffered message", async () => {
+  it("keeps cached first-message ancestry after a quote-only follow-up", async () => {
+    const first = quotingMessage(1, "first ask");
     const context = await buildTelegramMessageContextForTest({
-      message: quotingMessage(2, "quoting note\nplain note"),
+      message: { ...first, text: "first ask\nfollow-up" },
+      replyChain: [
+        {
+          messageId: "90",
+          replyToId: "89",
+          sender: "Cached Bob",
+          senderId: "7",
+          body: QUOTED_LINE,
+          timestamp: 1_699_999_000_000,
+        },
+      ],
       options: {
-        inboundDebounceMessages: [quotingMessage(1, "quoting note"), plainMessage(2, "plain note")],
+        inboundDebounceMessages: [
+          first,
+          {
+            ...plainMessage(2, "follow-up"),
+            quote: { text: "quote-only follow-up", position: 0 },
+          },
+        ],
       },
     });
 
-    expect(context?.ctxPayload.Body).toContain(QUOTED_LINE);
+    expect(context?.ctxPayload.ReplyChain).toMatchObject([
+      { sender: "unknown sender", body: "quote-only follow-up", isQuote: true },
+      {
+        messageId: "90",
+        replyToId: "89",
+        sender: "Cached Bob",
+        senderId: "7",
+        timestamp: 1_699_999_000_000,
+      },
+    ]);
   });
 
   it("lists a source re-quoted by two buffered messages only once", async () => {
@@ -114,9 +138,9 @@ describe("buildTelegramMessageContext reply/quote debounce batches", () => {
     expect(countReplyChainEntries(body)).toBeLessThanOrEqual(TELEGRAM_REPLY_CHAIN_MAX_DEPTH);
   });
 
-  // A debounce window has no per-item cap of its own, so without a bound here a
-  // burst of distinct quote-replies would grow model-visible context without limit.
-  it("caps batch-derived reply targets at the canonical chain depth", async () => {
+  // A debounce window has no per-item cap of its own. Keep the nearest targets,
+  // not the oldest messages that happened to enter the window first.
+  it("keeps the newest batch reply targets in nearest-first order", async () => {
     const burst = Array.from({ length: TELEGRAM_REPLY_CHAIN_MAX_DEPTH * 2 + 2 }, (_, i) =>
       quotingDistinctSource(i + 1),
     );
@@ -125,8 +149,12 @@ describe("buildTelegramMessageContext reply/quote debounce batches", () => {
       options: { inboundDebounceMessages: burst },
     });
 
-    const entries = countReplyChainEntries(context?.ctxPayload.Body ?? "");
-    expect(entries).toBeGreaterThan(0);
-    expect(entries).toBeLessThanOrEqual(TELEGRAM_REPLY_CHAIN_MAX_DEPTH);
+    const body = context?.ctxPayload.Body ?? "";
+    expect(Array.from(body.matchAll(/"distinct source \d+"/g), ([source]) => source)).toEqual([
+      '"distinct source 10"',
+      '"distinct source 9"',
+      '"distinct source 8"',
+      '"distinct source 7"',
+    ]);
   });
 });

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -65,7 +65,7 @@ import {
   recordTelegramGroupHistoryEntry,
   selectTelegramGroupHistoryAfterLastSelf,
 } from "./group-history-window.js";
-import type { TelegramReplyChainEntry } from "./message-cache.js";
+import { TELEGRAM_REPLY_CHAIN_MAX_DEPTH, type TelegramReplyChainEntry } from "./message-cache.js";
 
 type TelegramInboundContextPayload = BuiltChannelInboundEventContext & {
   From: string;
@@ -383,11 +383,16 @@ export async function buildTelegramInboundContextPayload(params: {
   ];
   // A batch carries one reply target per buffered message, but the synthetic
   // message inherits only the first one. Append the targets the merge dropped,
-  // keyed by id so a re-quoted source is not listed twice.
+  // keyed by id so a re-quoted source is not listed twice, and stop at the
+  // canonical chain depth -- a debounce window has no item cap of its own, so
+  // an unbounded append here would grow model-visible context without limit.
   const seenReplyMessageIds = new Set(rawReplyChain.map((entry) => entry.messageId));
   for (const debouncedMessage of hasMultiMessageDebounceBatch
     ? (options?.inboundDebounceMessages ?? [])
     : []) {
+    if (rawReplyChain.length >= TELEGRAM_REPLY_CHAIN_MAX_DEPTH) {
+      break;
+    }
     const visible = resolveVisibleReplyTarget(describeReplyTarget(debouncedMessage));
     const entry = visible ? replyTargetToChainEntry(visible) : undefined;
     if (entry?.messageId === undefined || seenReplyMessageIds.has(entry.messageId)) {

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -334,13 +334,33 @@ export async function buildTelegramInboundContextPayload(params: {
       senderAllowed,
     }).include;
   };
-  const includeReplyTarget = replyTarget
-    ? shouldIncludeGroupSupplementalContext({
+  // Single owner for reply-target visibility so every buffered message in a
+  // debounce batch is gated identically to the lone-message case. Without one
+  // owner, only the synthetic (first) message's reply/quote survived the merge.
+  const resolveVisibleReplyTarget = (
+    target: TelegramReplyTarget | null,
+  ): TelegramReplyTarget | null => {
+    if (
+      !target ||
+      !shouldIncludeGroupSupplementalContext({
         kind: "quote",
-        senderId: replyTarget.senderId,
-        senderUsername: replyTarget.senderUsername,
+        senderId: target.senderId,
+        senderUsername: target.senderUsername,
       })
-    : false;
+    ) {
+      return null;
+    }
+    const forwardedFrom =
+      target.forwardedFrom &&
+      shouldIncludeGroupSupplementalContext({
+        kind: "forwarded",
+        senderId: target.forwardedFrom.fromId,
+        senderUsername: target.forwardedFrom.fromUsername,
+      })
+        ? target.forwardedFrom
+        : undefined;
+    return { ...target, forwardedFrom };
+  };
   const includeForwardOrigin = forwardOrigin
     ? shouldIncludeGroupSupplementalContext({
         kind: "forwarded",
@@ -348,28 +368,34 @@ export async function buildTelegramInboundContextPayload(params: {
         senderUsername: forwardOrigin.fromUsername,
       })
     : false;
-  const visibleReplyForwardedFrom =
-    includeReplyTarget && replyTarget?.forwardedFrom
-      ? shouldIncludeGroupSupplementalContext({
-          kind: "forwarded",
-          senderId: replyTarget.forwardedFrom.fromId,
-          senderUsername: replyTarget.forwardedFrom.fromUsername,
-        })
-        ? replyTarget.forwardedFrom
-        : undefined
-      : undefined;
-  const visibleReplyTarget: TelegramReplyTarget | null =
-    includeReplyTarget && replyTarget
-      ? {
-          ...replyTarget,
-          forwardedFrom: visibleReplyForwardedFrom,
-        }
-      : null;
+  const visibleReplyTarget = resolveVisibleReplyTarget(replyTarget);
   const visibleReplyTargetEntry = visibleReplyTarget
     ? replyTargetToChainEntry(visibleReplyTarget)
     : undefined;
-  const rawReplyChain =
-    replyChain.length > 0 ? replyChain : visibleReplyTargetEntry ? [visibleReplyTargetEntry] : [];
+  // Copied, not aliased: the batch append below must not mutate the caller's
+  // resolved reply chain.
+  const rawReplyChain = [
+    ...(replyChain.length > 0
+      ? replyChain
+      : visibleReplyTargetEntry
+        ? [visibleReplyTargetEntry]
+        : []),
+  ];
+  // A batch carries one reply target per buffered message, but the synthetic
+  // message inherits only the first one. Append the targets the merge dropped,
+  // keyed by id so a re-quoted source is not listed twice.
+  const seenReplyMessageIds = new Set(rawReplyChain.map((entry) => entry.messageId));
+  for (const debouncedMessage of hasMultiMessageDebounceBatch
+    ? (options?.inboundDebounceMessages ?? [])
+    : []) {
+    const visible = resolveVisibleReplyTarget(describeReplyTarget(debouncedMessage));
+    const entry = visible ? replyTargetToChainEntry(visible) : undefined;
+    if (entry?.messageId === undefined || seenReplyMessageIds.has(entry.messageId)) {
+      continue;
+    }
+    seenReplyMessageIds.add(entry.messageId);
+    rawReplyChain.push(entry);
+  }
   const visibleReplyChain = rawReplyChain.flatMap((entry) => {
     const selectedReplyEntry =
       entry.messageId === visibleReplyTargetEntry?.messageId ? visibleReplyTargetEntry : undefined;

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -306,8 +306,11 @@ export async function buildTelegramInboundContextPayload(params: {
     sessionRuntime: sessionRuntimeOverride,
   } = params;
   const replyTarget = describeReplyTarget(msg);
-  const hasMultiMessageDebounceBatch = (options?.inboundDebounceMessages?.length ?? 0) > 1;
-  const forwardOrigin = hasMultiMessageDebounceBatch ? null : normalizeForwardedContext(msg);
+  const bufferedMessages = options?.bufferedMessages ?? [];
+  const hasMultiMessageBatch = bufferedMessages.length > 1;
+  const shouldRenderBufferedBody =
+    hasMultiMessageBatch && options?.ingressBuffer !== "text-fragment";
+  const forwardOrigin = shouldRenderBufferedBody ? null : normalizeForwardedContext(msg);
   const contextVisibilityMode = resolveChannelContextVisibilityMode({
     cfg,
     channel: "telegram",
@@ -335,8 +338,8 @@ export async function buildTelegramInboundContextPayload(params: {
     }).include;
   };
   // Single owner for reply-target visibility so every buffered message in a
-  // debounce batch is gated identically to the lone-message case. Without one
-  // owner, only the synthetic (first) message's reply/quote survived the merge.
+  // synthetic batch is gated identically to the lone-message case. Without one
+  // owner, only the synthetic (first) message's reply/quote survives the merge.
   const resolveVisibleReplyTarget = (
     target: TelegramReplyTarget | null,
   ): TelegramReplyTarget | null => {
@@ -388,19 +391,18 @@ export async function buildTelegramInboundContextPayload(params: {
     }
     rawReplyChain.push(entry);
   };
-  const debouncedMessages = options?.inboundDebounceMessages ?? [];
   // The synthetic message already owns the first entry's cached ancestry.
   // Recover only its erased tail; newest direct targets outrank older ancestry.
   for (
-    let index = debouncedMessages.length - 1;
+    let index = bufferedMessages.length - 1;
     index >= 1 && rawReplyChain.length < TELEGRAM_REPLY_CHAIN_MAX_DEPTH;
     index -= 1
   ) {
-    const debouncedMessage = debouncedMessages[index];
-    if (!debouncedMessage) {
+    const bufferedMessage = bufferedMessages[index];
+    if (!bufferedMessage) {
       continue;
     }
-    const visible = resolveVisibleReplyTarget(describeReplyTarget(debouncedMessage));
+    const visible = resolveVisibleReplyTarget(describeReplyTarget(bufferedMessage));
     appendReplyChainEntry(visible ? replyTargetToChainEntry(visible) : undefined);
   }
   for (const entry of inheritedReplyChain) {
@@ -439,39 +441,39 @@ export async function buildTelegramInboundContextPayload(params: {
     return [includeForwarded ? visibleEntry : stripReplyChainForwarded(visibleEntry)];
   });
   const visibleForwardOrigin = includeForwardOrigin ? forwardOrigin : null;
-  const inboundDebounceBodySegments = hasMultiMessageDebounceBatch
-    ? options?.inboundDebounceMessages?.flatMap((debouncedMessage) => {
-        const debouncedMedia = resolveTelegramPrimaryMedia(debouncedMessage);
-        const textParts = getTelegramTextParts(debouncedMessage);
+  const bufferedBodySegments = shouldRenderBufferedBody
+    ? bufferedMessages.flatMap((bufferedMessage) => {
+        const bufferedMedia = resolveTelegramPrimaryMedia(bufferedMessage);
+        const textParts = getTelegramTextParts(bufferedMessage);
         const segmentBody =
           renderTelegramTextEntities(textParts.text, textParts.entities) ||
-          formatMediaPlaceholderText(debouncedMedia ? [{ kind: debouncedMedia.kind }] : []);
+          formatMediaPlaceholderText(bufferedMedia ? [{ kind: bufferedMedia.kind }] : []);
         if (!segmentBody) {
           return [];
         }
-        const debouncedForwardOrigin = normalizeForwardedContext(debouncedMessage);
-        const visibleDebouncedForwardOrigin =
-          debouncedForwardOrigin &&
+        const bufferedForwardOrigin = normalizeForwardedContext(bufferedMessage);
+        const visibleBufferedForwardOrigin =
+          bufferedForwardOrigin &&
           shouldIncludeGroupSupplementalContext({
             kind: "forwarded",
-            senderId: debouncedForwardOrigin.fromId,
-            senderUsername: debouncedForwardOrigin.fromUsername,
+            senderId: bufferedForwardOrigin.fromId,
+            senderUsername: bufferedForwardOrigin.fromUsername,
           })
-            ? debouncedForwardOrigin
+            ? bufferedForwardOrigin
             : null;
         return [
           formatTelegramForwardedMessageBody({
             body: segmentBody,
-            forwardedFrom: visibleDebouncedForwardOrigin?.from,
-            forwardedDate: visibleDebouncedForwardOrigin?.date
-              ? visibleDebouncedForwardOrigin.date * 1000
+            forwardedFrom: visibleBufferedForwardOrigin?.from,
+            forwardedDate: visibleBufferedForwardOrigin?.date
+              ? visibleBufferedForwardOrigin.date * 1000
               : undefined,
           }),
         ];
       })
     : undefined;
-  const visibleBodyText = inboundDebounceBodySegments?.length
-    ? inboundDebounceBodySegments.join("\n")
+  const visibleBodyText = bufferedBodySegments?.length
+    ? bufferedBodySegments.join("\n")
     : formatTelegramForwardedMessageBody({
         body: bodyText,
         forwardedFrom: visibleForwardOrigin?.from,
@@ -677,7 +679,7 @@ export async function buildTelegramInboundContextPayload(params: {
       inboundEventKind,
       body,
       rawBody,
-      bodyForAgent: hasMultiMessageDebounceBatch ? visibleBodyText : bodyText,
+      bodyForAgent: shouldRenderBufferedBody ? visibleBodyText : bodyText,
       commandBody,
       inboundHistory,
       sourceModality: msg.voice ? "voice" : undefined,

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -372,37 +372,42 @@ export async function buildTelegramInboundContextPayload(params: {
   const visibleReplyTargetEntry = visibleReplyTarget
     ? replyTargetToChainEntry(visibleReplyTarget)
     : undefined;
-  // A batch carries one reply target per buffered message, but the synthetic
-  // message inherits only the first one, so collect each buffered message's own
-  // target here.
-  const directBatchReplyEntries = hasMultiMessageDebounceBatch
-    ? (options?.inboundDebounceMessages ?? []).flatMap((debouncedMessage) => {
-        const visible = resolveVisibleReplyTarget(describeReplyTarget(debouncedMessage));
-        const entry = visible ? replyTargetToChainEntry(visible) : undefined;
-        // Needs an id to dedupe against the inherited chain below.
-        return entry?.messageId === undefined ? [] : [entry];
-      })
-    : [];
   const inheritedReplyChain =
     replyChain.length > 0 ? replyChain : visibleReplyTargetEntry ? [visibleReplyTargetEntry] : [];
-  // One bounded pass owns the whole chain. Direct targets from this batch are
-  // nearer than the first message's inherited ancestry, so they claim slots
-  // first: otherwise a deep ancestry on the first message would fill the cap and
-  // suppress exactly the later quote this path exists to recover. The cap itself
-  // is required because a debounce window has no per-item limit of its own.
   const seenReplyMessageIds = new Set<string>();
   const rawReplyChain: TelegramReplyChainEntry[] = [];
-  for (const entry of [...directBatchReplyEntries, ...inheritedReplyChain]) {
-    if (rawReplyChain.length >= TELEGRAM_REPLY_CHAIN_MAX_DEPTH) {
-      break;
+  const appendReplyChainEntry = (entry: TelegramReplyChainEntry | undefined) => {
+    if (!entry || rawReplyChain.length >= TELEGRAM_REPLY_CHAIN_MAX_DEPTH) {
+      return;
     }
     if (entry.messageId !== undefined) {
       if (seenReplyMessageIds.has(entry.messageId)) {
-        continue;
+        return;
       }
       seenReplyMessageIds.add(entry.messageId);
     }
     rawReplyChain.push(entry);
+  };
+  const debouncedMessages = options?.inboundDebounceMessages ?? [];
+  // The synthetic message already owns the first entry's cached ancestry.
+  // Recover only its erased tail; newest direct targets outrank older ancestry.
+  for (
+    let index = debouncedMessages.length - 1;
+    index >= 1 && rawReplyChain.length < TELEGRAM_REPLY_CHAIN_MAX_DEPTH;
+    index -= 1
+  ) {
+    const debouncedMessage = debouncedMessages[index];
+    if (!debouncedMessage) {
+      continue;
+    }
+    const visible = resolveVisibleReplyTarget(describeReplyTarget(debouncedMessage));
+    appendReplyChainEntry(visible ? replyTargetToChainEntry(visible) : undefined);
+  }
+  for (const entry of inheritedReplyChain) {
+    if (rawReplyChain.length >= TELEGRAM_REPLY_CHAIN_MAX_DEPTH) {
+      break;
+    }
+    appendReplyChainEntry(entry);
   }
   const visibleReplyChain = rawReplyChain.flatMap((entry) => {
     const selectedReplyEntry =

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -372,33 +372,36 @@ export async function buildTelegramInboundContextPayload(params: {
   const visibleReplyTargetEntry = visibleReplyTarget
     ? replyTargetToChainEntry(visibleReplyTarget)
     : undefined;
-  // Copied, not aliased: the batch append below must not mutate the caller's
-  // resolved reply chain.
-  const rawReplyChain = [
-    ...(replyChain.length > 0
-      ? replyChain
-      : visibleReplyTargetEntry
-        ? [visibleReplyTargetEntry]
-        : []),
-  ];
   // A batch carries one reply target per buffered message, but the synthetic
-  // message inherits only the first one. Append the targets the merge dropped,
-  // keyed by id so a re-quoted source is not listed twice, and stop at the
-  // canonical chain depth -- a debounce window has no item cap of its own, so
-  // an unbounded append here would grow model-visible context without limit.
-  const seenReplyMessageIds = new Set(rawReplyChain.map((entry) => entry.messageId));
-  for (const debouncedMessage of hasMultiMessageDebounceBatch
-    ? (options?.inboundDebounceMessages ?? [])
-    : []) {
+  // message inherits only the first one, so collect each buffered message's own
+  // target here.
+  const directBatchReplyEntries = hasMultiMessageDebounceBatch
+    ? (options?.inboundDebounceMessages ?? []).flatMap((debouncedMessage) => {
+        const visible = resolveVisibleReplyTarget(describeReplyTarget(debouncedMessage));
+        const entry = visible ? replyTargetToChainEntry(visible) : undefined;
+        // Needs an id to dedupe against the inherited chain below.
+        return entry?.messageId === undefined ? [] : [entry];
+      })
+    : [];
+  const inheritedReplyChain =
+    replyChain.length > 0 ? replyChain : visibleReplyTargetEntry ? [visibleReplyTargetEntry] : [];
+  // One bounded pass owns the whole chain. Direct targets from this batch are
+  // nearer than the first message's inherited ancestry, so they claim slots
+  // first: otherwise a deep ancestry on the first message would fill the cap and
+  // suppress exactly the later quote this path exists to recover. The cap itself
+  // is required because a debounce window has no per-item limit of its own.
+  const seenReplyMessageIds = new Set<string>();
+  const rawReplyChain: TelegramReplyChainEntry[] = [];
+  for (const entry of [...directBatchReplyEntries, ...inheritedReplyChain]) {
     if (rawReplyChain.length >= TELEGRAM_REPLY_CHAIN_MAX_DEPTH) {
       break;
     }
-    const visible = resolveVisibleReplyTarget(describeReplyTarget(debouncedMessage));
-    const entry = visible ? replyTargetToChainEntry(visible) : undefined;
-    if (entry?.messageId === undefined || seenReplyMessageIds.has(entry.messageId)) {
-      continue;
+    if (entry.messageId !== undefined) {
+      if (seenReplyMessageIds.has(entry.messageId)) {
+        continue;
+      }
+      seenReplyMessageIds.add(entry.messageId);
     }
-    seenReplyMessageIds.add(entry.messageId);
     rawReplyChain.push(entry);
   }
   const visibleReplyChain = rawReplyChain.flatMap((entry) => {

--- a/extensions/telegram/src/bot-message-context.types.ts
+++ b/extensions/telegram/src/bot-message-context.types.ts
@@ -32,7 +32,7 @@ export type TelegramMessageContextOptions = {
   promptContextMinTimestampMs?: number;
   promptContextAmbientWatermark?: TelegramAmbientTranscriptWatermark;
   ambientTranscriptBody?: string;
-  inboundDebounceMessages?: readonly Message[];
+  bufferedMessages?: readonly Message[];
   spooledReplay?: boolean;
   /** Use an attempt-local participant so an outer retry loop owns final spool settlement. */
   isolateSpooledReplaySettlement?: boolean;

--- a/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
@@ -286,20 +286,22 @@ describe("telegram text fragments", () => {
     "buffers near-limit text and processes sequential parts as one message",
     async () => {
       const { handler, replySpy } = await createBotHandlerWithOptions({});
-      const part1 = "A".repeat(4050);
+      const quote = "FRAGMENT_REPLY_QUOTE";
+      const part1 = `${"A".repeat(4050)} ${quote}`;
       const part2 = "B".repeat(50);
+      const firstMessage = {
+        chat: { id: 42, type: "private" as const },
+        from: { id: 777, is_bot: false as const, first_name: "Ada" },
+        message_id: 10,
+        date: 1736380800,
+        text: part1,
+      };
       const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
       const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
 
       try {
         await handler({
-          message: {
-            chat: { id: 42, type: "private" },
-            from: { id: 777, is_bot: false, first_name: "Ada" },
-            message_id: 10,
-            date: 1736380800,
-            text: part1,
-          },
+          message: firstMessage,
           me: { username: "openclaw_bot" },
           getFile: async () => ({}),
         });
@@ -311,6 +313,8 @@ describe("telegram text fragments", () => {
             message_id: 11,
             date: 1736380801,
             text: part2,
+            reply_to_message: { ...firstMessage, reply_to_message: undefined },
+            quote: { text: quote, position: 4051 },
           },
           me: { username: "openclaw_bot" },
           getFile: async () => ({}),
@@ -324,9 +328,10 @@ describe("telegram text fragments", () => {
         );
 
         await vi.waitFor(() => expect(replySpy).toHaveBeenCalledTimes(1));
-        const payload = replySpy.mock.calls.at(0)?.[0] as { RawBody?: string };
+        const payload = replySpy.mock.calls.at(0)?.[0] as { Body?: string; RawBody?: string };
         expect(payload.RawBody).toContain(part1.slice(0, 32));
         expect(payload.RawBody).toContain(part2.slice(0, 32));
+        expect(payload.Body).toContain(`[1. Ada id:10]\n"${quote}"`);
       } finally {
         setTimeoutSpy.mockRestore();
         clearTimeoutSpy.mockRestore();

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -886,6 +886,13 @@ async function resolveSessionBoundaryNode(params: {
   );
 }
 
+/**
+ * Hard cap on reply-chain nodes rendered into the prompt. Model-visible context
+ * must be bounded; every producer that appends chain entries shares this ceiling
+ * so a busy chat cannot grow the turn past its budget.
+ */
+export const TELEGRAM_REPLY_CHAIN_MAX_DEPTH = 4;
+
 export async function buildTelegramReplyChain(params: {
   cache: TelegramMessageCache;
   accountId: string;
@@ -897,7 +904,7 @@ export async function buildTelegramReplyChain(params: {
   if (!replyMessage?.message_id) {
     return [];
   }
-  const maxDepth = params.maxDepth ?? 4;
+  const maxDepth = params.maxDepth ?? TELEGRAM_REPLY_CHAIN_MAX_DEPTH;
   const visited = new Set<string>();
   const chain: TelegramCachedMessageNode[] = [];
   let current: TelegramCachedMessageNode | null =


### PR DESCRIPTION
Closes #121765

## What Problem This Solves

Telegram has two paths that combine several inbound messages into one synthetic message: normal inbound debounce and long-text fragment recovery. Both synthetic messages inherit reply metadata only from their first message. A reply or selected quote attached to a later buffered message was silently absent from agent-visible context while its text still arrived.

## Root Cause

Both buffers retain their ordered raw Telegram messages, but the context builder previously derived reply context only from the synthetic first message. One Telegram Message cannot represent several reply targets, so this information must cross the buffer-to-context owner boundary explicitly.

## Fix

Both buffers now pass one neutral ordered bufferedMessages contract to the context builder. That owner:

- recovers reply targets only from the synthetic message tail;
- traverses newest first and stops at the shared four-entry reply-chain cap;
- applies the existing visibility policy;
- deduplicates targets with message IDs while retaining ID-less selected quotes;
- fills remaining capacity from cached first-message ancestry;
- preserves each buffer body-join semantics and avoids rerendering long fragment bodies.

No provider, config, or compatibility path changed.

## Evidence

### Reproduction and owner regressions

Before the repair:

- a real Telegram selected-quote follow-up produced one debounced provider request, but current-main-equivalent source omitted the rendered reply marker;
- the newest-first regression received oldest targets 1, 2, 3, 4 instead of 10, 9, 8, 7;
- the long-text fragment handler test received only combined text and no reply-chain entry for the later selected quote.

After the repair:

- context suite: 19 files, 192 tests passed;
- long-text fragment handler boundary: 1 passed, with five unselected;
- the fragment assertion observes [1. Ada id:10] followed by the selected quote body;
- pnpm tsgo, pnpm tsgo:extensions, and pnpm check:test-types passed;
- targeted Oxfmt, Oxlint, and git diff --check passed;
- Distill: pass;
- Greybeard: pass, bounded traversal and no redundant fragment render.

### Redacted exact-head Telegram userbot artifact

Exact head: 8dd4c51bc1162d1fac3463f611e504b31fee83f0

Telegram proof captured on patch-identical pre-rebase head 0b92921589e4da1fee9e0132369225c218e944fb.

```json
{
  "doctorOk": true,
  "inboundDebounceMs": 10000,
  "sequenceDelayMs": 100,
  "replyBoundToFirstMessage": true,
  "selectedQuote": "PR121907_FINAL2_QUOTE",
  "providerRequests": 1,
  "agentInput": {
    "hasSource": true,
    "hasFollowup": true,
    "hasRenderedReplyMarker": true
  },
  "telegramTimeline": [
    {"kind": "typing", "elapsedMs": 13895},
    {"kind": "typing", "elapsedMs": 14951},
    {"kind": "message", "text": "OPENCLAW_E2E_OK", "elapsedMs": 14951}
  ],
  "sideEffects": {"edits": 0, "deletions": 0, "reactions": 0},
  "scratchRemovedAfterExit": true
}
```

Identifiers, usernames, endpoints, credentials, and raw runtime metadata are redacted. The event stream, summary, gateway log, and mock-provider request log remain preserved together.

## Scope

Production delta: +45 net lines. Test delta: +165 lines. The sibling fragment repair itself is production net -1: it generalizes the existing owner contract instead of adding a second recovery path.