### PR TITLE
chore(memory): remove retired QMD glossary entry

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -676,10 +676,6 @@
     "target": "记忆概览"
   },
   {
-    "source": "QMD memory backend removal",
-    "target": "QMD 记忆后端移除"
-  },
-  {
     "source": "Active memory",
     "target": "主动记忆"
   },


### PR DESCRIPTION
Related: #120936

## What Problem This Solves

The QMD backend removal left a Chinese documentation glossary entry for the retired QMD removal page. That stale i18n term remained discoverable after the runtime, configuration, CI, UI, and package surfaces were removed.

## Why This Change Was Made

Remove the obsolete glossary entry as the only actionable non-doc-lane residual found by an exhaustive current-main audit. The dedicated memory documentation page and its generated maturity-doc link remain unchanged because a sibling docs lane owns those content changes.

This PR is AI-assisted.

## User Impact

The documentation translation glossary no longer carries a term for the retired QMD backend. There is no runtime or configuration behavior change.

## Evidence

- `CI=true pnpm install`
- Case-insensitive QMD audit across `src`, `extensions`, `packages`, `ui`, `scripts`, `test`, `.github`, `config`, `docs`, `taxonomy.yaml`, `package.json`, and `pnpm-workspace.yaml`, excluding release history, the changelog, lockfile, dependencies, and build output
- Explicit clean probes for package exports/files, Plugin SDK entrypoint/private-subpath inventories, all Control UI locale files, config help snapshots, workflows and CodeQL configs, `taxonomy.yaml`, and Settings search
- `pnpm docs:check-i18n-glossary`
- `pnpm docs:list`
- `git diff --check`
- Codex autoreview: clean, no accepted/actionable findings

Docs handoff: `docs/concepts/memory-qmd.md` still contains the retired-backend removal content, and generated `docs/maturity/taxonomy.md` still links it. Those files are intentionally not changed here.
