### PR TITLE
fix(ui): Ctrl/Cmd+F search renders at normal size and restores focus

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -662,6 +662,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
 
       const searchBar = await getBoundingBox(page, ".agent-chat__search-bar");
       const icons = await page.locator(".agent-chat__search-bar svg").all();
+      const input = page.locator(".agent-chat__search-bar input");
 
       expect(searchBar.height).toBeLessThan(64);
       expect(icons).toHaveLength(2);
@@ -670,6 +671,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         expect(box?.width).toBe(16);
         expect(box?.height).toBe(16);
       }
+      await input.focus();
+      const outline = await input.evaluate((element) => getComputedStyle(element).outline);
+      expect(outline).toContain("2px solid");
     } finally {
       await closeBrowserPage(page);
     }

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -643,6 +643,38 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     sharedBrowser = null;
   });
 
+  it("keeps transcript search icons compact", async () => {
+    const page = await openBrowserPage(1024, 768);
+    try {
+      await page.setContent(`<!doctype html>
+        <html>
+          <head><style>${readUiCss()}</style></head>
+          <body>
+            <section class="chat">
+              <div class="agent-chat__search-bar">
+                ${iconSvg()}
+                <input type="text" placeholder="Search messages" />
+                <button class="btn btn--ghost" type="button">${iconSvg()}</button>
+              </div>
+            </section>
+          </body>
+        </html>`);
+
+      const searchBar = await getBoundingBox(page, ".agent-chat__search-bar");
+      const icons = await page.locator(".agent-chat__search-bar svg").all();
+
+      expect(searchBar.height).toBeLessThan(64);
+      expect(icons).toHaveLength(2);
+      for (const icon of icons) {
+        const box = await icon.boundingBox();
+        expect(box?.width).toBe(16);
+        expect(box?.height).toBe(16);
+      }
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
   it(
     "does not replay a consumed session rail open generation after round trips or remounts",
     FULL_APP_TEST_OPTIONS,

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -672,8 +672,11 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         expect(box?.height).toBe(16);
       }
       await input.focus();
-      const outline = await input.evaluate((element) => getComputedStyle(element).outline);
-      expect(outline).toContain("2px solid");
+      const outline = await input.evaluate((element) => {
+        const style = getComputedStyle(element);
+        return { style: style.outlineStyle, width: style.outlineWidth };
+      });
+      expect(outline).toEqual({ style: "solid", width: "2px" });
     } finally {
       await closeBrowserPage(page);
     }

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1994,22 +1994,92 @@ describe("session rail pane commands", () => {
 });
 
 describe("per-pane chat presentation state", () => {
-  it("opens thread search from the physical shortcut on a non-Latin layout", () => {
-    const onRequestUpdate = vi.fn();
-    const container = renderChatView({ onRequestUpdate });
-    const chat = requireElement(container, "section.card.chat", "chat view");
-    const event = new KeyboardEvent("keydown", {
-      key: "а",
-      code: "KeyF",
-      ctrlKey: true,
-      bubbles: true,
-      cancelable: true,
-    });
+  it("moves focus into and back out of thread search for the physical shortcut", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const onRequestUpdate = vi.fn(() => renderChatInto(container, { onRequestUpdate }));
+    try {
+      renderChatInto(container, { onRequestUpdate });
+      const composer = getComposerTextarea(container);
+      composer.focus();
+      const event = new KeyboardEvent("keydown", {
+        key: "а",
+        code: "KeyF",
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
 
-    chat.dispatchEvent(event);
+      composer.dispatchEvent(event);
+      await Promise.resolve();
 
-    expect(event.defaultPrevented).toBe(true);
-    expect(onRequestUpdate).toHaveBeenCalledOnce();
+      expect(event.defaultPrevented).toBe(true);
+      expect(onRequestUpdate).toHaveBeenCalledOnce();
+      expect(document.activeElement).toBe(
+        container.querySelector<HTMLInputElement>('.agent-chat__search-bar input[type="text"]'),
+      );
+
+      const closeEvent = new KeyboardEvent("keydown", {
+        key: "а",
+        code: "KeyF",
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      document.activeElement?.dispatchEvent(closeEvent);
+      await Promise.resolve();
+
+      expect(closeEvent.defaultPrevented).toBe(true);
+      expect(onRequestUpdate).toHaveBeenCalledTimes(2);
+      expect(document.activeElement).toBe(composer);
+      expect(container.querySelector(".agent-chat__search-bar")).toBeNull();
+    } finally {
+      container.remove();
+    }
+  });
+
+  it("returns focus to the composer when the original target disappears", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const onRequestUpdate = vi.fn(() => renderChatInto(container, { onRequestUpdate }));
+    try {
+      renderChatInto(container, { onRequestUpdate });
+      const composer = getComposerTextarea(container);
+      const transientTarget = document.createElement("button");
+      const chat = container.querySelector<HTMLElement>(".card.chat");
+      if (!chat) {
+        throw new Error("expected chat section");
+      }
+      chat.append(transientTarget);
+      transientTarget.focus();
+
+      transientTarget.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "f",
+          code: "KeyF",
+          ctrlKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      await Promise.resolve();
+
+      transientTarget.remove();
+      document.activeElement?.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "f",
+          code: "KeyF",
+          ctrlKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      await Promise.resolve();
+
+      expect(document.activeElement).toBe(composer);
+    } finally {
+      container.remove();
+    }
   });
 
   it("keeps slash menus independent and resets only the targeted pane", () => {

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -585,7 +585,12 @@ export function renderChat(props: ChatProps) {
           resolveAsciiShortcutKey(event) === "f"
         ) {
           event.preventDefault();
-          toggleChatThreadSearch(props.paneId, requestUpdate);
+          toggleChatThreadSearch(
+            props.paneId,
+            requestUpdate,
+            event.target instanceof HTMLElement ? event.target : undefined,
+            event.currentTarget instanceof HTMLElement ? event.currentTarget : undefined,
+          );
         }
       }}
     >

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -585,12 +585,7 @@ export function renderChat(props: ChatProps) {
           resolveAsciiShortcutKey(event) === "f"
         ) {
           event.preventDefault();
-          toggleChatThreadSearch(
-            props.paneId,
-            requestUpdate,
-            event.target instanceof HTMLElement ? event.target : undefined,
-            event.currentTarget instanceof HTMLElement ? event.currentTarget : undefined,
-          );
+          toggleChatThreadSearch(props.paneId, requestUpdate, event);
         }
       }}
     >

--- a/ui/src/pages/chat/components/chat-thread.measure.test.ts
+++ b/ui/src/pages/chat/components/chat-thread.measure.test.ts
@@ -419,6 +419,68 @@ describe("chat transcript row measurement", () => {
     transcript.hostDisconnected();
   });
 
+  it.each([
+    { label: "end-pinned", distanceFromEnd: 0, expectedCalls: 1 },
+    { label: "scrolled away", distanceFromEnd: 100, expectedCalls: 0 },
+  ])(
+    "$label transcript preserves its resize anchor",
+    async ({ distanceFromEnd, expectedCalls }) => {
+      measuredRowHeight = 240;
+      const transcript = createTestTranscript();
+      const container = document.body.appendChild(document.createElement("div"));
+      const messages = Array.from({ length: 12 }, (_, index) => ({
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: `message ${index}`,
+        timestamp: index + 1,
+      }));
+      const props = threadProps(
+        `pane-height-resize-${distanceFromEnd}`,
+        "agent:main:resize",
+        messages,
+      );
+      render(renderChatThread(props, transcript), container);
+      transcript.hostConnected();
+      transcript.hostUpdated();
+      await flushDeferredRowPrune();
+
+      const scrollElement = container.querySelector<HTMLElement>(".chat-thread");
+      expect(scrollElement).not.toBeNull();
+      const virtualizer = (
+        transcript as unknown as {
+          sessionVirtualizer: {
+            virtualizerController: {
+              getVirtualizer: () => {
+                scrollOffset: number | null;
+                getTotalSize: () => number;
+                scrollToEnd: (options?: { behavior?: ScrollBehavior }) => void;
+              };
+            };
+          };
+        }
+      ).sessionVirtualizer.virtualizerController.getVirtualizer();
+      const scrollToEnd = vi.spyOn(virtualizer, "scrollToEnd");
+      const emitViewportResize = (height: number) => {
+        for (const observer of resizeObservers) {
+          if (scrollElement && observer.observes(scrollElement)) {
+            observer.emit(800, height);
+          }
+        }
+      };
+
+      emitViewportResize(600);
+      scrollToEnd.mockClear();
+      expect(virtualizer.getTotalSize()).toBeGreaterThan(700);
+      virtualizer.scrollOffset = Math.max(0, virtualizer.getTotalSize() - 600 - distanceFromEnd);
+      emitViewportResize(560);
+
+      expect(scrollToEnd).toHaveBeenCalledTimes(expectedCalls);
+      if (expectedCalls > 0) {
+        expect(scrollToEnd).toHaveBeenCalledWith({ behavior: "auto" });
+      }
+      transcript.hostDisconnected();
+    },
+  );
+
   it("rebinds guarded transcript images when the gateway rotates its auth token", async () => {
     const NativeUrl = URL;
     const blobUrl = `blob:transcript-media-${crypto.randomUUID()}`;

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -922,11 +922,11 @@ function closeChatThreadSearch(state: ChatThreadState, requestUpdate: () => void
   });
 }
 
+/** Toggles transcript search and retains the shortcut origin for focus restoration. */
 export function toggleChatThreadSearch(
   paneId: string,
   requestUpdate: () => void,
-  returnFocusTarget?: HTMLElement,
-  returnFocusOwner?: HTMLElement,
+  triggerEvent?: Event,
 ): void {
   const state = getChatThreadState(paneId);
   if (state.searchOpen) {
@@ -936,8 +936,16 @@ export function toggleChatThreadSearch(
 
   state.searchOpen = true;
   state.searchFocusPending = true;
-  state.searchReturnFocusTarget = returnFocusTarget?.isConnected ? returnFocusTarget : null;
-  state.searchReturnFocusOwner = returnFocusOwner?.isConnected ? returnFocusOwner : null;
+  const returnFocusTarget = triggerEvent?.target;
+  const returnFocusOwner = triggerEvent?.currentTarget;
+  state.searchReturnFocusTarget =
+    returnFocusTarget instanceof HTMLElement && returnFocusTarget.isConnected
+      ? returnFocusTarget
+      : null;
+  state.searchReturnFocusOwner =
+    returnFocusOwner instanceof HTMLElement && returnFocusOwner.isConnected
+      ? returnFocusOwner
+      : null;
   requestUpdate();
 }
 

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -105,6 +105,9 @@ const pinnedMessagesMap = new Map<string, PinnedMessages>();
 type ChatThreadState = {
   searchOpen: boolean;
   searchQuery: string;
+  searchFocusPending: boolean;
+  searchReturnFocusTarget: HTMLElement | null;
+  searchReturnFocusOwner: HTMLElement | null;
   pinnedExpanded: boolean;
   transcriptRenderDependencies: readonly unknown[];
   transcriptRenderContext: { onSetReply?: ChatThreadProps["onSetReply"] };
@@ -240,6 +243,7 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
   private threadInnerElement: HTMLDivElement | null = null;
   private connected = false;
   private observedWidth: number | null = null;
+  private observedHeight: number | null = null;
   private contentReady = false;
   private pendingScrollOffset: {
     offset: number;
@@ -336,10 +340,23 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
       followOnAppend: false,
       observeElementRect: (instance, callback) =>
         observeElementRect(instance, (rect) => {
+          const previousHeight = this.observedHeight;
           const widthChanged = this.observedWidth !== null && this.observedWidth !== rect.width;
+          const heightChanged = previousHeight !== null && previousHeight !== rect.height;
+          const scrollOffset = instance.scrollOffset;
+          const wasAtEndBeforeResize =
+            heightChanged &&
+            this.pendingScrollOffset === null &&
+            scrollOffset !== null &&
+            instance.getTotalSize() - previousHeight - scrollOffset <=
+              CHAT_TRANSCRIPT_END_THRESHOLD_PX;
           this.observedWidth = rect.width;
+          this.observedHeight = rect.height;
           this.syncScrollMargin(instance.scrollElement);
           callback(rect);
+          if (wasAtEndBeforeResize) {
+            instance.scrollToEnd({ behavior: "auto" });
+          }
           if (widthChanged) {
             // Cached offscreen sizes belong to the old wrapping width. Reset
             // them, seed current rows, then repeat after any same-commit
@@ -772,6 +789,9 @@ function createChatThreadState(): ChatThreadState {
   return {
     searchOpen: false,
     searchQuery: "",
+    searchFocusPending: false,
+    searchReturnFocusTarget: null,
+    searchReturnFocusOwner: null,
     pinnedExpanded: false,
     transcriptRenderDependencies: [],
     transcriptRenderContext: {},
@@ -820,6 +840,9 @@ export function resetChatThreadSessionPresentationState(paneId: string, owner?: 
     // preferences or dependency memos and invalidate themselves on new props.
     state.searchOpen = false;
     state.searchQuery = "";
+    state.searchFocusPending = false;
+    state.searchReturnFocusTarget = null;
+    state.searchReturnFocusOwner = null;
   }
 }
 
@@ -850,6 +873,18 @@ export function renderChatSearchBar(
         placeholder=${t("chat.thread.searchPlaceholder")}
         aria-label=${t("chat.thread.search")}
         .value=${state.searchQuery}
+        ${state.searchFocusPending
+          ? ref((element) => {
+              if (element instanceof HTMLInputElement) {
+                state.searchFocusPending = false;
+                queueMicrotask(() => {
+                  if (element.isConnected) {
+                    element.focus({ preventScroll: true });
+                  }
+                });
+              }
+            })
+          : nothing}
         @input=${(event: Event) => {
           state.searchQuery = (event.target as HTMLInputElement).value;
           requestUpdate();
@@ -859,11 +894,7 @@ export function renderChatSearchBar(
         <button
           class="btn btn--ghost"
           aria-label=${t("chat.thread.closeSearch")}
-          @click=${() => {
-            state.searchOpen = false;
-            state.searchQuery = "";
-            requestUpdate();
-          }}
+          @click=${() => closeChatThreadSearch(state, requestUpdate)}
         >
           ${icons.x}
         </button>
@@ -872,12 +903,41 @@ export function renderChatSearchBar(
   `;
 }
 
-export function toggleChatThreadSearch(paneId: string, requestUpdate: () => void): void {
+function closeChatThreadSearch(state: ChatThreadState, requestUpdate: () => void): void {
+  const returnFocusTarget = state.searchReturnFocusTarget;
+  const returnFocusOwner = state.searchReturnFocusOwner;
+  state.searchOpen = false;
+  state.searchQuery = "";
+  state.searchFocusPending = false;
+  state.searchReturnFocusTarget = null;
+  state.searchReturnFocusOwner = null;
+  requestUpdate();
+  queueMicrotask(() => {
+    const target = returnFocusTarget?.isConnected
+      ? returnFocusTarget
+      : returnFocusOwner?.querySelector<HTMLTextAreaElement>(
+          ".agent-chat__composer-combobox > textarea",
+        );
+    target?.focus({ preventScroll: true });
+  });
+}
+
+export function toggleChatThreadSearch(
+  paneId: string,
+  requestUpdate: () => void,
+  returnFocusTarget?: HTMLElement,
+  returnFocusOwner?: HTMLElement,
+): void {
   const state = getChatThreadState(paneId);
-  state.searchOpen = !state.searchOpen;
-  if (!state.searchOpen) {
-    state.searchQuery = "";
+  if (state.searchOpen) {
+    closeChatThreadSearch(state, requestUpdate);
+    return;
   }
+
+  state.searchOpen = true;
+  state.searchFocusPending = true;
+  state.searchReturnFocusTarget = returnFocusTarget?.isConnected ? returnFocusTarget : null;
+  state.searchReturnFocusOwner = returnFocusOwner?.isConnected ? returnFocusOwner : null;
   requestUpdate();
 }
 

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -144,6 +144,37 @@ openclaw-chat-page {
   opacity: 0.5;
 }
 
+/* Transcript search sits above the workbench. Keep the shared SVG icon from
+   taking its intrinsic flex width and size the controls as compact chrome. */
+.agent-chat__search-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--card);
+}
+
+.agent-chat__search-bar svg {
+  width: 16px;
+  height: 16px;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+.agent-chat__search-bar input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 0.88rem;
+  outline: none;
+}
+
+.agent-chat__search-bar input::placeholder {
+  color: var(--muted);
+}
+
 .chat-workspace-conflict-notice {
   flex: 0 0 auto;
   margin: 12px 16px 0;

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -168,7 +168,6 @@ openclaw-chat-page {
   background: transparent;
   color: var(--text);
   font-size: 0.88rem;
-  outline: none;
 }
 
 .agent-chat__search-bar input::placeholder {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening transcript search with `Ctrl/Cmd+F` could see oversized search icons, leave keyboard focus in the composer, and notice the latest message shift when the search bar changed the transcript height.

## Why This Change Was Made

This restores the missing search bar styles, focuses the search input when it appears, and records the original chat focus so closing search can return to it with a composer fallback. The virtualizer determines whether the transcript was end-pinned from the pre-resize viewport, then reanchors pinned transcripts while preserving the position of transcripts that users scrolled away from the end.

## User Impact

`Ctrl/Cmd+F` opens a compact search field that is ready for typing. Closing search returns keyboard control to the chat, and toggling search keeps the latest message stationary without moving a transcript that the user has scrolled upward.

## Evidence

- Live reproduction before the fix showed the magnifying-glass SVG expanding across the chat because the search bar had no sizing styles.
- Live verification through the worktree gateway confirmed compact icons, focus transfer into and back out of search, and a stationary latest message while toggling search.
- `pnpm exec vitest run ui/src/pages/chat/chat-view.test.ts`: 234 passed.
- `pnpm exec vitest run ui/src/pages/chat/chat-responsive.browser.test.ts -t "keeps transcript search icons compact"`: 1 passed.
- `pnpm exec vitest run --config test/vitest/vitest.ui-isolated.config.ts ui/src/pages/chat/components/chat-thread.measure.test.ts`: 14 passed.
- `pnpm tsgo:ui`, `pnpm tsgo:test:ui`, changed-file formatting and style checks, and `pnpm ui:build` passed.
- AI-assisted with Codex. The implementation and tests were reviewed for focus restoration, disconnected-target fallback, and virtualizer resize anchoring behavior.
