### PR TITLE
fix(gateway): prevent wizard cleanup leaks after setup lock failures

### DIFF
--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -1,6 +1,8 @@
 // Wizard server-method tests cover stable lifecycle errors for process-local sessions.
+import fs from "node:fs/promises";
+import { __setFsSafeTestHooksForTest } from "@openclaw/fs-safe/test-hooks";
 import { expectDefined } from "@openclaw/normalization-core";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import {
   getActiveGatewayRootWorkCount,
@@ -17,6 +19,10 @@ import {
 import { systemAgentHandlers } from "./system-agent.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 import { type SetupWizardRunner, wizardHandlers } from "./wizard.js";
+
+afterEach(() => {
+  __setFsSafeTestHooksForTest(undefined);
+});
 
 function createWizardContext(
   wizardRunner: NonNullable<GatewayRequestHandlerOptions["context"]>["wizardRunner"],
@@ -280,6 +286,75 @@ describe("wizard setup ownership", () => {
     } finally {
       runnerSettled.resolve();
       resetGatewayWorkAdmission();
+    }
+  });
+
+  it("cleans up detached wizard owners when setup lock release fails", async () => {
+    resetGatewayWorkAdmission();
+    const runnerSettled = createDeferred();
+    const tracker = createWizardSessionTracker();
+    const context = {
+      ...tracker,
+      wizardRunner: async (_opts: unknown, _runtime: RuntimeEnv, prompter: WizardPrompter) => {
+        prompter.progress("working");
+        await runnerSettled.promise;
+      },
+    };
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandledRejection);
+    let lockPath: string | undefined;
+
+    try {
+      let sessionId = "";
+      await runWithGatewayIndependentRootWorkAdmission(async () => {
+        const respond = vi.fn();
+        await expectDefined(
+          wizardHandlers["wizard.start"],
+          "wizard.start test invariant",
+        )({ params: { mode: "local" }, respond, context } as never);
+        sessionId = String(respond.mock.calls[0]?.[1]?.sessionId ?? "");
+      });
+      expect(sessionId).not.toBe("");
+      expect(getActiveGatewayRootWorkCount()).toBe(1);
+
+      const cancelRespond = vi.fn();
+      await expectDefined(
+        wizardHandlers["wizard.cancel"],
+        "wizard.cancel test invariant",
+      )({ params: { sessionId }, respond: cancelRespond, context } as never);
+      expect(cancelRespond.mock.calls[0]?.[1]).toMatchObject({ status: "cancelled" });
+
+      const releaseError = new Error("setup lock release failed");
+      __setFsSafeTestHooksForTest({
+        beforeSidecarLockSnapshotOpen: (candidate) => {
+          lockPath = candidate;
+          throw releaseError;
+        },
+      });
+      runnerSettled.resolve();
+      const session = expectDefined(
+        tracker.wizardSessions.get(sessionId),
+        "cancelled setup session",
+      );
+      await expect(whenAdmittedWizardSessionSettled(session)).rejects.toBe(releaseError);
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+
+      expect.soft(unhandledRejections).toEqual([]);
+      expect.soft(getActiveGatewayRootWorkCount()).toBe(0);
+      expect.soft(tracker.wizardSessions.has(sessionId)).toBe(false);
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+      __setFsSafeTestHooksForTest(undefined);
+      runnerSettled.resolve();
+      resetGatewayWorkAdmission();
+      if (lockPath) {
+        await fs.rm(lockPath, { force: true });
+      }
     }
   });
 

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -84,7 +84,7 @@ function retainGatewayWorkUntilSettled(session: WizardSession): void {
   // active between steps or a config reload can erase the process-local session.
   const release = retainGatewayRootWorkAdmissionContinuation();
   if (release) {
-    void whenAdmittedWizardSessionSettled(session).then(release);
+    void whenAdmittedWizardSessionSettled(session).then(release, release);
   }
 }
 
@@ -219,9 +219,8 @@ export const wizardHandlers: GatewayRequestHandlers = {
     const cancelled = session.cancel();
     const status = readWizardStatus(session);
     if (cancelled) {
-      void whenAdmittedWizardSessionSettled(session).then(() =>
-        context.purgeWizardSession(sessionId),
-      );
+      const purge = () => context.purgeWizardSession(sessionId);
+      void whenAdmittedWizardSessionSettled(session).then(purge, purge);
     } else {
       context.purgeWizardSession(sessionId);
     }


### PR DESCRIPTION
<!--
Optional linked context:
No linked issue; this is a bounded setup lifecycle bug fix.
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where a rare setup-lock release failure could leave Gateway restart/suspend admission active, retain a cancelled setup wizard in the process-local session tracker, and emit unhandled promise rejections.

## Why This Change Was Made

The detached Gateway admission and cancelled-session cleanup owners now run on either settlement outcome. The original setup settlement error remains observable to awaited callers; there are no retries or sleeps, and the normal terminal-response ordering that permits an immediate replacement wizard remains unchanged.

## User Impact

The Gateway no longer remains artificially busy or stuck after a setup-lock cleanup failure, and cancelled wizard state is not retained.

## Evidence

- Deterministic regression using the public fs-safe test hook to fail sidecar snapshot open during lock release. Before the fix it observed two unhandled rejections, one retained Gateway root-work admission, and one retained cancelled wizard session; after the fix all three are clean.
- `node scripts/run-vitest.mjs src/gateway/server-methods/wizard.test.ts src/gateway/server-methods/setup-admission.test.ts src/gateway/server-wizard-sessions.test.ts` — 27 tests passed.
- Targeted `oxfmt --check`, `oxlint`, and `git diff --check origin/main...HEAD` passed.
- Changed-lane dry run selected core production and core test checks.
- Fresh post-rebase autoreview through P2 reported no accepted/actionable findings.
- Exact-head hosted CI and Testbox evidence will be recorded by the repository-native landing flow before merge.

AI-assisted: yes. I reviewed the implementation and validation evidence; no agent transcript is attached.
