### PR TITLE
refactor(ui): simplify terminal replay lifecycle

### DIFF
--- a/ui/src/components/terminal/terminal-connection.test.ts
+++ b/ui/src/components/terminal/terminal-connection.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.ts";
 import {
   TerminalConnection,
   type TerminalGatewayClient,
@@ -35,16 +36,6 @@ function sessionResult(overrides: Partial<TestSessionResult> = {}): TestSessionR
     confined: false,
     ...overrides,
   };
-}
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((next, fail) => {
-    resolve = next;
-    reject = fail;
-  });
-  return { promise, resolve, reject };
 }
 
 /** Fake gateway client that records requests and lets tests push events. */
@@ -99,7 +90,13 @@ function makeHarness() {
 }
 
 function testSink(overrides: Partial<TerminalSink> = {}): TerminalSink {
-  return { onData: () => {}, onExit: () => {}, ...overrides };
+  const onData = overrides.onData ?? (() => {});
+  return {
+    onData,
+    onReplay: ({ data }) => onData(data),
+    onExit: () => {},
+    ...overrides,
+  };
 }
 
 function openSession(
@@ -125,7 +122,7 @@ function emitExit(
 function deferRequest<T>(
   client: FakeClient,
   method: string,
-  pending: ReturnType<typeof deferred<T>>,
+  pending: ReturnType<typeof createDeferred<T>>,
 ): void {
   const baseRequest = client.request.bind(client);
   client.request = (<R>(
@@ -225,10 +222,10 @@ describe("TerminalConnection", () => {
     const data: string[] = [];
     const replays: string[] = [];
     const exits: unknown[] = [];
-    const recovery = deferred<TestSessionResult>();
+    const recovery = createDeferred<TestSessionResult>();
     await openSession(conn, {
       onData: (chunk) => data.push(chunk),
-      onReplay: (snapshot) => {
+      onReplay: ({ data: snapshot }) => {
         replays.push(snapshot);
       },
       onExit: (info) => exits.push(info),
@@ -253,10 +250,10 @@ describe("TerminalConnection", () => {
     const { client, conn } = makeHarness();
     const data: string[] = [];
     const replays: Array<{ snapshot: string; newlyObservedFrom: number }> = [];
-    const recovery = deferred<TestSessionResult>();
+    const recovery = createDeferred<TestSessionResult>();
     await openSession(conn, {
       onData: (chunk) => data.push(chunk),
-      onReplay: (snapshot, newlyObservedFrom) => {
+      onReplay: ({ data: snapshot, newlyObservedFrom }) => {
         replays.push({ snapshot, newlyObservedFrom });
       },
     });
@@ -284,13 +281,13 @@ describe("TerminalConnection", () => {
 
   it("does not let a superseded recovery drain the replacement stream queue", async () => {
     const { client, conn } = makeHarness();
-    const oldReplay = deferred<void>();
+    const oldReplay = createDeferred();
     const oldReplayEvents: string[] = [];
-    let oldReplayIsCurrent: (() => boolean) | undefined;
+    let oldReplaySignal: AbortSignal | undefined;
     await openSession(conn, {
       onData: () => {},
-      onReplay: async (_snapshot, _newlyObservedFrom, _mode, isCurrent) => {
-        oldReplayIsCurrent = isCurrent;
+      onReplay: async ({ signal }) => {
+        oldReplaySignal = signal;
         oldReplayEvents.push("start");
         await oldReplay.promise;
         oldReplayEvents.push("done");
@@ -300,9 +297,9 @@ describe("TerminalConnection", () => {
     emitData(client, 5, "hello");
     emitData(client, 12, "world");
     await vi.waitFor(() => expect(oldReplayEvents).toEqual(["start"]));
-    expect(oldReplayIsCurrent?.()).toBe(true);
+    expect(oldReplaySignal?.aborted).toBe(false);
 
-    const newReplay = deferred<void>();
+    const newReplay = createDeferred();
     const newReplayEvents: string[] = [];
     const newData: string[] = [];
     client.nextResponse = sessionResult({ buffer: "new snapshot", seq: 20 });
@@ -316,7 +313,7 @@ describe("TerminalConnection", () => {
       onExit: () => {},
     });
     await vi.waitFor(() => expect(newReplayEvents).toEqual(["start"]));
-    expect(oldReplayIsCurrent?.()).toBe(false);
+    expect(oldReplaySignal?.aborted).toBe(true);
     emitData(client, 21, "!");
 
     oldReplay.resolve();
@@ -329,30 +326,15 @@ describe("TerminalConnection", () => {
     expect(newData).toEqual(["!"]);
   });
 
-  it("never appends a recovery snapshot when the sink cannot reset", async () => {
-    const { client, conn } = makeHarness();
-    const data: string[] = [];
-    await openSession(conn, { onData: (chunk) => data.push(chunk) });
-    client.nextResponse = sessionResult({ buffer: "authoritative snapshot", seq: 12 });
-
-    emitData(client, 5, "hello");
-    emitData(client, 12, "world");
-
-    await vi.waitFor(() =>
-      expect(client.forceReconnects).toEqual(["terminal replay reset unavailable"]),
-    );
-    expect(data).toEqual(["hello"]);
-  });
-
   it("serializes a terminal exit behind an in-flight gap replay", async () => {
     const { client, conn } = makeHarness();
     const data: string[] = [];
     const replays: string[] = [];
     const exits: unknown[] = [];
-    const recovery = deferred<TestSessionResult>();
+    const recovery = createDeferred<TestSessionResult>();
     await openSession(conn, {
       onData: (chunk) => data.push(chunk),
-      onReplay: (snapshot) => {
+      onReplay: ({ data: snapshot }) => {
         replays.push(snapshot);
       },
       onExit: (info) => exits.push(info),
@@ -376,10 +358,10 @@ describe("TerminalConnection", () => {
     const data: string[] = [];
     const replays: string[] = [];
     const exits: unknown[] = [];
-    const recovery = deferred<TestSessionResult>();
+    const recovery = createDeferred<TestSessionResult>();
     await openSession(conn, {
       onData: (chunk) => data.push(chunk),
-      onReplay: (snapshot) => {
+      onReplay: ({ data: snapshot }) => {
         replays.push(snapshot);
       },
       onExit: (info) => exits.push(info),
@@ -402,7 +384,7 @@ describe("TerminalConnection", () => {
     const { client, conn } = makeHarness();
     const data: string[] = [];
     const exits: unknown[] = [];
-    const recovery = deferred<never>();
+    const recovery = createDeferred<never>();
     await openSession(conn, {
       onData: (chunk) => data.push(chunk),
       onReplay: () => {},
@@ -424,8 +406,8 @@ describe("TerminalConnection", () => {
 
   it("keeps a queued exit behind recovery started while flushing early events", async () => {
     const { client, conn } = makeHarness();
-    const openResult = deferred<TestSessionResult>();
-    const recovery = deferred<TestSessionResult>();
+    const openResult = createDeferred<TestSessionResult>();
+    const recovery = createDeferred<TestSessionResult>();
     client.request = ((method: string, params: unknown) => {
       client.requests.push({ method, params });
       return method === "terminal.open" ? openResult.promise : recovery.promise;
@@ -435,7 +417,7 @@ describe("TerminalConnection", () => {
 
     const opening = openSession(conn, {
       onData: () => {},
-      onReplay: (snapshot) => {
+      onReplay: ({ data: snapshot }) => {
         replays.push(snapshot);
       },
       onExit: (info) => exits.push(info),
@@ -546,7 +528,7 @@ describe("TerminalConnection", () => {
     const { client, conn } = makeHarness();
     const data: string[] = [];
     // Hold the open response so data can arrive before the sink registers.
-    const opening = deferred<TestSessionResult>();
+    const opening = createDeferred<TestSessionResult>();
     deferRequest(client, "terminal.open", opening);
     const openPromise = openSession(conn, { onData: (chunk) => data.push(chunk) });
     // Server streams the shell prompt before the client has a sink for s1.
@@ -563,7 +545,7 @@ describe("TerminalConnection", () => {
     const { client, conn } = makeHarness();
     const data: string[] = [];
     let exit: unknown;
-    const opening = deferred<TestSessionResult>();
+    const opening = createDeferred<TestSessionResult>();
     deferRequest(client, "terminal.open", opening);
     const openPromise = openSession(conn, {
       onData: (chunk) => data.push(chunk),
@@ -612,7 +594,7 @@ describe("TerminalConnection", () => {
     await openSession(conn);
 
     // Second open held in flight while the only registered session closes.
-    const opening = deferred<TestSessionResult>();
+    const opening = createDeferred<TestSessionResult>();
     deferRequest(client, "terminal.open", opening);
     const data: string[] = [];
     const openPromise = openSession(conn, { onData: (chunk) => data.push(chunk) });
@@ -662,7 +644,7 @@ describe("TerminalConnection", () => {
   it("attach replays the buffer before events that raced ahead, then resumes live", async () => {
     const { client, conn } = makeHarness();
     const data: string[] = [];
-    const attached = deferred<TestSessionResult>();
+    const attached = createDeferred<TestSessionResult>();
     deferRequest(client, "terminal.attach", attached);
 
     const attachPromise = conn.attach("s1", testSink({ onData: (chunk) => data.push(chunk) }));
@@ -684,13 +666,13 @@ describe("TerminalConnection", () => {
 
   it("awaits asynchronous initial replay before flushing live output", async () => {
     const { client, conn } = makeHarness();
-    const replay = deferred<void>();
+    const replay = createDeferred();
     const order: string[] = [];
     client.nextResponse = sessionResult({ buffer: "snapshot", seq: 8 });
 
     const attachPromise = conn.attach("s1", {
       onData: (chunk) => order.push(`data:${chunk}`),
-      onReplay: async (snapshot, _newlyObservedFrom, mode) => {
+      onReplay: async ({ data: snapshot, mode }) => {
         order.push(`${mode}:${snapshot}`);
         await replay.promise;
         order.push("replay:done");
@@ -711,30 +693,65 @@ describe("TerminalConnection", () => {
     const { client, conn } = makeHarness();
     client.nextResponse = sessionResult({ buffer: "snapshot", seq: 8 });
 
+    let replaySignal: AbortSignal | undefined;
     await expect(
       conn.attach("s1", {
         onData: () => {},
-        onReplay: async () => {
+        onReplay: async ({ signal }) => {
+          replaySignal = signal;
           throw new Error("replay failed");
         },
         onExit: () => {},
       }),
     ).rejects.toThrow("replay failed");
+    expect(replaySignal?.aborted).toBe(true);
     expect(conn.size).toBe(0);
     expect(client.listenerCount()).toBe(0);
   });
+
+  it.each(["close", "exit", "dispose"] as const)(
+    "aborts the replay lifetime when a stream ends via %s",
+    async (ending) => {
+      const { client, conn } = makeHarness();
+      client.nextResponse = sessionResult({ buffer: "snapshot", seq: 8 });
+      let replaySignal: AbortSignal | undefined;
+      let abortedAtExit: boolean | undefined;
+      await conn.attach("s1", {
+        onData: () => {},
+        onReplay: ({ signal }) => {
+          replaySignal = signal;
+        },
+        onExit: () => {
+          abortedAtExit = replaySignal?.aborted;
+        },
+      });
+
+      if (ending === "close") {
+        await conn.close("s1");
+      } else if (ending === "exit") {
+        emitExit(client, { exitCode: 0, signal: null });
+      } else {
+        conn.dispose();
+      }
+
+      expect(replaySignal?.aborted).toBe(true);
+      if (ending === "exit") {
+        expect(abortedAtExit).toBe(true);
+      }
+    },
+  );
 
   it("discards a detached exit that predates successful session adoption", async () => {
     const { client, conn } = makeHarness();
     const replays: string[] = [];
     const data: string[] = [];
     const exits: unknown[] = [];
-    const attached = deferred<TestSessionResult>();
+    const attached = createDeferred<TestSessionResult>();
     deferRequest(client, "terminal.attach", attached);
 
     const attachPromise = conn.attach("s1", {
       onData: (chunk) => data.push(chunk),
-      onReplay: (snapshot) => {
+      onReplay: ({ data: snapshot }) => {
         replays.push(snapshot);
       },
       onExit: (info) => exits.push(info),
@@ -753,7 +770,7 @@ describe("TerminalConnection", () => {
   it("preserves output that races an older gateway replay with no offset", async () => {
     const { client, conn } = makeHarness();
     const data: string[] = [];
-    const attached = deferred<TestSessionResult>();
+    const attached = createDeferred<TestSessionResult>();
     deferRequest(client, "terminal.attach", attached);
 
     const attachPromise = conn.attach("s1", testSink({ onData: (chunk) => data.push(chunk) }));

--- a/ui/src/components/terminal/terminal-connection.ts
+++ b/ui/src/components/terminal/terminal-connection.ts
@@ -57,19 +57,22 @@ type TerminalExitInfo = {
   error?: string;
 };
 
+type TerminalReplay = {
+  data: string;
+  newlyObservedFrom: number;
+  mode: "initial" | "recovery";
+  signal: AbortSignal;
+};
+
 type SessionSink = {
   onData: (data: string) => void;
   /** Replays a ring snapshot into a fresh sink or replaces a gapped live sink. */
-  onReplay?: (
-    data: string,
-    newlyObservedFrom: number,
-    mode: "initial" | "recovery",
-    isCurrent: () => boolean,
-  ) => void | Promise<void>;
+  onReplay: (replay: TerminalReplay) => void | Promise<void>;
   onExit: (info: TerminalExitInfo) => void;
 };
 
 type StreamState = {
+  abort: AbortController;
   sink: SessionSink;
   seqMode: "unknown" | "offset" | "counter";
   expectedSeq: number | null;
@@ -180,7 +183,7 @@ export class TerminalConnection {
             if (stream.recovering) {
               this.bufferEarly(payload.sessionId, { kind: "exit", info });
             } else {
-              this.deliverExit(payload.sessionId, stream.sink, info);
+              this.deliverExit(payload.sessionId, stream, info);
             }
           } else {
             this.bufferEarly(payload.sessionId, { kind: "exit", info });
@@ -213,7 +216,13 @@ export class TerminalConnection {
       }
       throw new TerminalOpenTimeoutError(error);
     }
-    await this.adoptSession(result.sessionId, sink, { seqMode: "unknown", expectedSeq: 0 });
+    const stream = this.setStream(result.sessionId, sink, {
+      seqMode: "unknown",
+      expectedSeq: 0,
+      recovering: false,
+    });
+    this.flushPending(result.sessionId, stream);
+    this.scheduleLivenessCheck();
     return result;
   }
 
@@ -224,17 +233,35 @@ export class TerminalConnection {
     );
     const offset =
       typeof result.seq === "number" && Number.isSafeInteger(result.seq) ? result.seq : null;
-    await this.adoptSession(
-      sessionId,
-      sink,
-      offset !== null
-        ? { seqMode: "offset", expectedSeq: offset }
-        : { seqMode: "counter", expectedSeq: null },
-      result.buffer,
-      // Old protocol-4 replies have no snapshot high-water. Preserve raced
-      // counter frames because they may have been emitted after the snapshot.
-      offset ?? undefined,
-    );
+    const stream = this.setStream(sessionId, sink, {
+      seqMode: offset === null ? "counter" : "offset",
+      expectedSeq: offset,
+      recovering: true,
+    });
+    const signal = stream.abort.signal;
+    try {
+      await sink.onReplay({
+        data: result.buffer,
+        newlyObservedFrom: result.buffer.length,
+        mode: "initial",
+        signal,
+      });
+    } catch (error) {
+      if (!signal.aborted) {
+        this.removeStream(sessionId);
+        this.pending.delete(sessionId);
+        this.maybeUnsubscribe();
+      }
+      throw error;
+    }
+    if (signal.aborted) {
+      return result;
+    }
+    stream.recovering = false;
+    // Old protocol-4 replies have no snapshot high-water. Preserve raced
+    // counter frames because they may have been emitted after the snapshot.
+    this.flushPending(sessionId, stream, offset ?? undefined, true);
+    this.scheduleLivenessCheck();
     return result;
   }
 
@@ -255,46 +282,6 @@ export class TerminalConnection {
       this.maybeUnsubscribe();
       throw err;
     }
-  }
-
-  /** Registers a sink, applies authoritative replay, then flushes raced events. */
-  private async adoptSession(
-    sessionId: string,
-    sink: SessionSink,
-    baseline: Pick<StreamState, "seqMode" | "expectedSeq">,
-    replay?: string,
-    coveredThroughSeq?: number,
-  ): Promise<void> {
-    const stream: StreamState = { sink, ...baseline, recovering: replay !== undefined };
-    this.streams.set(sessionId, stream);
-    this.lastTerminalActivityAtMs = Date.now();
-    try {
-      if (replay !== undefined) {
-        if (sink.onReplay) {
-          await sink.onReplay(
-            replay,
-            replay.length,
-            "initial",
-            () => this.streams.get(sessionId) === stream,
-          );
-        } else {
-          sink.onData(replay);
-        }
-      }
-    } catch (error) {
-      if (this.streams.get(sessionId) === stream) {
-        this.streams.delete(sessionId);
-        this.pending.delete(sessionId);
-        this.maybeUnsubscribe();
-      }
-      throw error;
-    }
-    if (this.streams.get(sessionId) !== stream) {
-      return;
-    }
-    stream.recovering = false;
-    this.flushPending(sessionId, stream, coveredThroughSeq, replay !== undefined);
-    this.scheduleLivenessCheck();
   }
 
   /** Validates one frame's arithmetic continuity before exposing its bytes. */
@@ -347,10 +334,11 @@ export class TerminalConnection {
       return;
     }
     stream.recovering = true;
+    const signal = stream.abort.signal;
     void this.client
       .request<TerminalAttachResult>("terminal.attach", { sessionId })
       .then(async (result) => {
-        if (this.streams.get(sessionId) !== stream) {
+        if (signal.aborted) {
           return;
         }
         const offset =
@@ -368,14 +356,6 @@ export class TerminalConnection {
         const previouslyObservedThrough = stream.expectedSeq;
         stream.seqMode = "offset";
         stream.expectedSeq = offset;
-        if (!stream.sink.onReplay) {
-          // Recovery must replace emulator state. Appending a full ring replay
-          // would duplicate bytes already rendered before the detected gap.
-          stream.recovering = false;
-          this.pending.delete(sessionId);
-          this.forceReconnect("terminal replay reset unavailable");
-          return;
-        }
         // The ring may include both bytes already delivered and the gap's
         // missing suffix. Preserve that boundary so response-producing
         // emulators do not answer historical control queries twice.
@@ -384,20 +364,20 @@ export class TerminalConnection {
           typeof previouslyObservedThrough === "number"
             ? Math.max(0, Math.min(result.buffer.length, previouslyObservedThrough - replayStart))
             : 0;
-        await stream.sink.onReplay(
-          result.buffer,
+        await stream.sink.onReplay({
+          data: result.buffer,
           newlyObservedFrom,
-          "recovery",
-          () => this.streams.get(sessionId) === stream,
-        );
-        if (this.streams.get(sessionId) !== stream) {
+          mode: "recovery",
+          signal,
+        });
+        if (signal.aborted) {
           return;
         }
         stream.recovering = false;
         this.flushPending(sessionId, stream, offset, true);
       })
       .catch(() => {
-        if (this.streams.get(sessionId) !== stream) {
+        if (signal.aborted) {
           return;
         }
         const queued = this.pending.get(sessionId)?.drain();
@@ -411,7 +391,7 @@ export class TerminalConnection {
             if (event.kind === "data") {
               stream.sink.onData(event.data);
             } else {
-              this.deliverExit(sessionId, stream.sink, event.info);
+              this.deliverExit(sessionId, stream, event.info);
               break;
             }
           }
@@ -459,17 +439,34 @@ export class TerminalConnection {
       } else if (stream.recovering) {
         this.bufferEarly(sessionId, event);
       } else {
-        this.deliverExit(sessionId, stream.sink, event.info);
+        this.deliverExit(sessionId, stream, event.info);
       }
     }
   }
 
   /** Own cleanup: replayed exits can arrive before the caller records the session id. */
-  private deliverExit(sessionId: string, sink: SessionSink, info: TerminalExitInfo): void {
-    sink.onExit(info);
-    this.streams.delete(sessionId);
+  private deliverExit(sessionId: string, stream: StreamState, info: TerminalExitInfo): void {
+    this.removeStream(sessionId);
+    stream.sink.onExit(info);
     this.pending.delete(sessionId);
     this.maybeUnsubscribe();
+  }
+
+  private setStream(
+    sessionId: string,
+    sink: SessionSink,
+    state: Pick<StreamState, "seqMode" | "expectedSeq" | "recovering">,
+  ): StreamState {
+    this.removeStream(sessionId);
+    const stream = { abort: new AbortController(), sink, ...state };
+    this.streams.set(sessionId, stream);
+    this.lastTerminalActivityAtMs = Date.now();
+    return stream;
+  }
+
+  private removeStream(sessionId: string): void {
+    this.streams.get(sessionId)?.abort.abort();
+    this.streams.delete(sessionId);
   }
 
   private bufferEarly(sessionId: string, event: PendingEvent): void {
@@ -581,7 +578,7 @@ export class TerminalConnection {
 
   /** Closes a session server-side and drops its local stream state. */
   async close(sessionId: string): Promise<void> {
-    this.streams.delete(sessionId);
+    this.removeStream(sessionId);
     this.pending.delete(sessionId);
     await this.client.request("terminal.close", { sessionId }).catch(() => undefined);
     // terminal.exit precedes the close response and can otherwise be buffered.
@@ -594,6 +591,9 @@ export class TerminalConnection {
   }
 
   dispose(): void {
+    for (const stream of this.streams.values()) {
+      stream.abort.abort();
+    }
     this.streams.clear();
     this.pending.clear();
     this.stopLiveness();

--- a/ui/src/components/terminal/terminal-controller-lifecycle.test.ts
+++ b/ui/src/components/terminal/terminal-controller-lifecycle.test.ts
@@ -1,50 +1,164 @@
 /* @vitest-environment jsdom */
 
 import type { GhosttyTerminalController } from "@openclaw/libterminal/browser";
-import { afterEach, describe, expect, it } from "vitest";
-import { replaceTerminalControllerForReplay } from "./terminal-controller-lifecycle.ts";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.ts";
+import {
+  disposeTerminalController,
+  replaceTerminalController,
+} from "./terminal-controller-lifecycle.ts";
 import { createTerminalController } from "./terminal-panel.test-support.ts";
+import { createIsolatedGhosttyTerminal } from "./terminal-runtime.ts";
 
-describe("replaceTerminalControllerForReplay", () => {
+const runtimeMocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  load: vi.fn(),
+}));
+
+vi.mock("@openclaw/libterminal/browser", () => ({
+  createGhosttyTerminal: runtimeMocks.create,
+  loadGhosttyRuntime: runtimeMocks.load,
+}));
+vi.mock("ghostty-web", () => ({ mockedGhosttyModule: true }));
+
+function terminalController(
+  dispose: () => void = vi.fn(),
+): GhosttyTerminalController & ReturnType<typeof createTerminalController> {
+  return createTerminalController(dispose) as unknown as GhosttyTerminalController &
+    ReturnType<typeof createTerminalController>;
+}
+
+function terminalRoot() {
+  const shell = document.body.appendChild(document.createElement("div"));
+  const root = shell.attachShadow({ mode: "open" });
+  const external = root.appendChild(document.createElement("input"));
+  const previousHost = root.appendChild(document.createElement("div"));
+  previousHost.tabIndex = 0;
+  return { external, previousHost, root };
+}
+
+describe("terminal controller lifecycle", () => {
   afterEach(() => {
     document.body.replaceChildren();
+    runtimeMocks.create.mockReset();
+    runtimeMocks.load.mockReset();
   });
 
-  it("restores focus after a superseding replacement detaches the previous host", async () => {
-    const shell = document.body.appendChild(document.createElement("div"));
-    const root = shell.attachShadow({ mode: "open" });
-    const externalInput = root.appendChild(document.createElement("input"));
-    const previousHost = root.appendChild(document.createElement("div"));
-    const previousControllerMock = createTerminalController();
-    const replacementControllerMock = createTerminalController();
-    const previousController = previousControllerMock as unknown as GhosttyTerminalController;
-    const replacementController = replacementControllerMock as unknown as GhosttyTerminalController;
-    const target = { controller: previousController, host: previousHost };
-    let current = true;
-    externalInput.focus();
-
-    const replaced = await replaceTerminalControllerForReplay({
-      target,
-      createController: async (parent, options) => {
-        expect(options).toEqual({ readOnly: true });
-        expect(parent.style.display).toBe("block");
-        expect(parent.style.visibility).toBe("hidden");
-        expect(parent.inert).toBe(true);
-        parent.tabIndex = 0;
-        parent.focus();
-        previousHost.remove();
-        current = false;
-        return replacementController;
-      },
-      replay: new Uint8Array(),
-      isCurrent: () => current,
+  it("owns pinned Ghostty listener cleanup before idempotent generic disposal", async () => {
+    const underlyingDispose = vi.fn(() => {
+      throw new Error("dispose failed");
     });
+    const underlying = terminalController(underlyingDispose);
+    const handleMouseUp = vi.fn();
+    (underlying.terminal as unknown as { handleMouseUp: EventListener }).handleMouseUp =
+      handleMouseUp;
+    const runtime = { isolated: true };
+    runtimeMocks.load.mockResolvedValue(runtime);
+    runtimeMocks.create.mockResolvedValue(underlying);
+    const removeEventListener = vi.spyOn(document, "removeEventListener");
+    const host = document.body.appendChild(document.createElement("div"));
 
-    expect(replaced).toBe(false);
-    expect(root.activeElement).toBe(externalInput);
-    expect(target).toEqual({ controller: previousController, host: previousHost });
-    expect(previousControllerMock.dispose).not.toHaveBeenCalled();
-    expect(replacementControllerMock.dispose).toHaveBeenCalledOnce();
-    expect(root.querySelectorAll("div")).toHaveLength(0);
+    const controller = await createIsolatedGhosttyTerminal({ parent: host });
+    expect(() => disposeTerminalController(controller, host)).not.toThrow();
+    expect(() => disposeTerminalController(controller, host)).not.toThrow();
+
+    expect(runtimeMocks.create).toHaveBeenCalledWith(
+      expect.objectContaining({ parent: host, runtime }),
+    );
+    expect(removeEventListener).toHaveBeenCalledTimes(1);
+    expect(removeEventListener).toHaveBeenCalledWith("mouseup", handleMouseUp);
+    expect(removeEventListener.mock.invocationCallOrder[0]).toBeLessThan(
+      underlyingDispose.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+    expect(underlyingDispose).toHaveBeenCalledOnce();
+    expect(host.isConnected).toBe(false);
+  });
+
+  it.each([
+    { focusBefore: "terminal", focusAfter: "replacement" },
+    { focusBefore: "external", focusAfter: "external" },
+    { focusBefore: "external", focusAfter: "newer" },
+  ] as const)(
+    "publishes a measurable writable replacement without losing $focusAfter focus",
+    async ({ focusBefore, focusAfter }) => {
+      const { external, previousHost, root } = terminalRoot();
+      const newer = root.appendChild(document.createElement("input"));
+      const previous = terminalController();
+      const replacement = terminalController();
+      const target = { controller: previous, host: previousHost };
+      previousHost.style.display = "none";
+      previousHost.style.visibility = "visible";
+      (focusBefore === "terminal" ? previousHost : external).focus();
+
+      const replaced = await replaceTerminalController(
+        target,
+        async (host, options) => {
+          expect(options).toEqual({ readOnly: true });
+          expect(host.style.display).toBe("block");
+          expect(host.style.visibility).toBe("hidden");
+          expect(host.inert).toBe(true);
+          host.tabIndex = 0;
+          host.focus();
+          setTimeout(() => host.focus(), 0);
+          if (focusAfter === "newer") {
+            setTimeout(() => newer.focus(), 0);
+          }
+          return replacement;
+        },
+        "authoritative replay",
+        new AbortController().signal,
+      );
+
+      expect(replaced).toBe(true);
+      expect(target.controller).toBe(replacement);
+      expect(target.host).not.toBe(previousHost);
+      expect(target.host.isConnected).toBe(true);
+      expect(new TextDecoder().decode(replacement.write.mock.calls[0]?.[0])).toBe(
+        "authoritative replay",
+      );
+      expect(replacement.setReadOnly).toHaveBeenCalledWith(false);
+      expect(target.host.style.display).toBe("none");
+      expect(target.host.style.visibility).toBe("visible");
+      expect(target.host.inert).toBe(false);
+      expect(previous.dispose).toHaveBeenCalledOnce();
+      expect(root.activeElement).toBe(
+        focusAfter === "replacement" ? target.host : focusAfter === "external" ? external : newer,
+      );
+    },
+  );
+
+  it("disposes an aborted unpublished replacement and restores focus it stole", async () => {
+    const { external, previousHost, root } = terminalRoot();
+    const previous = terminalController();
+    const replacement = terminalController();
+    const target = { controller: previous, host: previousHost };
+    const created = createDeferred<GhosttyTerminalController>();
+    const abort = new AbortController();
+    let stagedHost: HTMLElement | undefined;
+    external.focus();
+
+    const replacing = replaceTerminalController(
+      target,
+      async (host) => {
+        stagedHost = host;
+        host.tabIndex = 0;
+        host.focus();
+        previousHost.remove();
+        return created.promise;
+      },
+      "must not publish",
+      abort.signal,
+    );
+    await vi.waitFor(() => expect(stagedHost).toBeDefined());
+    abort.abort();
+    created.resolve(replacement);
+
+    await expect(replacing).resolves.toBe(false);
+    expect(target).toEqual({ controller: previous, host: previousHost });
+    expect(previous.dispose).not.toHaveBeenCalled();
+    expect(replacement.write).not.toHaveBeenCalled();
+    expect(replacement.dispose).toHaveBeenCalledOnce();
+    expect(stagedHost?.isConnected).toBe(false);
+    expect(root.activeElement).toBe(external);
   });
 });

--- a/ui/src/components/terminal/terminal-controller-lifecycle.ts
+++ b/ui/src/components/terminal/terminal-controller-lifecycle.ts
@@ -1,16 +1,32 @@
 import type { GhosttyTerminalController } from "@openclaw/libterminal/browser";
-import type { TerminalControllerFactory } from "./terminal-panel-session-types.ts";
 
 type TerminalControllerSlot = {
   controller: GhosttyTerminalController;
   host: HTMLDivElement;
 };
 
-function getActiveElementForHost(host: HTMLElement): Element | null {
+type TerminalControllerFactory = (
+  parent: HTMLElement,
+  options?: { readOnly?: boolean },
+) => Promise<GhosttyTerminalController>;
+
+const terminalOutputEncoder = new TextEncoder();
+
+function activeElementFor(host: HTMLElement): Element | null {
   const root = host.getRootNode();
   return root instanceof ShadowRoot
     ? (root.activeElement ?? document.activeElement)
     : document.activeElement;
+}
+
+function hostOwnsFocus(host: HTMLElement, focused: Element | null): boolean {
+  return focused === host || host.contains(focused);
+}
+
+function focusIfConnected(target: Element | null): void {
+  if (target instanceof HTMLElement && target.isConnected) {
+    target.focus();
+  }
 }
 
 export function disposeTerminalController(
@@ -18,41 +34,29 @@ export function disposeTerminalController(
   host: HTMLDivElement,
 ): void {
   try {
-    const terminal = controller.terminal as unknown as { handleMouseUp?: unknown };
-    if (typeof document !== "undefined" && typeof terminal.handleMouseUp === "function") {
-      // ghostty-web 0.4.0 clears isOpen before cleanup, skipping this listener removal.
-      document.removeEventListener("mouseup", terminal.handleMouseUp as EventListener);
-    }
-  } catch {
-    // A partially initialized dependency terminal may not expose its internals.
-  }
-  try {
     controller.dispose();
   } catch {
-    // Best-effort teardown; a partially initialized controller may throw.
+    // A partially initialized controller may fail during best-effort teardown.
   } finally {
-    // DOM ownership is independent of controller cleanup; never strand a
-    // Ghostty canvas when dependency disposal fails partway through.
     host.remove();
   }
 }
 
 /** Replays recovery output into a hidden replacement, then atomically swaps it in. */
-export async function replaceTerminalControllerForReplay(params: {
-  target: TerminalControllerSlot;
-  createController: TerminalControllerFactory;
-  replay: Uint8Array;
-  isCurrent: () => boolean;
-}): Promise<boolean> {
-  if (!params.isCurrent()) {
+export async function replaceTerminalController(
+  target: TerminalControllerSlot,
+  createController: TerminalControllerFactory,
+  replay: string,
+  signal: AbortSignal,
+): Promise<boolean> {
+  if (signal.aborted) {
     return false;
   }
 
-  const previousController = params.target.controller;
-  const previousHost = params.target.host;
-  const previouslyFocused = getActiveElementForHost(previousHost);
-  const previousTerminalOwnedFocus =
-    previouslyFocused === previousHost || previousHost.contains(previouslyFocused);
+  const previousController = target.controller;
+  const previousHost = target.host;
+  const previouslyFocused = activeElementFor(previousHost);
+  const previousTerminalOwnedFocus = hostOwnsFocus(previousHost, previouslyFocused);
   const replacementHost = previousHost.cloneNode() as HTMLDivElement;
   // The host is absolutely inset in the viewport. Keep it measurable while
   // hidden so Ghostty fits the authoritative replay to the real terminal grid.
@@ -63,13 +67,8 @@ export async function replaceTerminalControllerForReplay(params: {
 
   let replacement: GhosttyTerminalController | undefined;
   const disposeUnpublishedReplacement = () => {
-    const focused = getActiveElementForHost(replacementHost);
-    if (
-      (focused === replacementHost || replacementHost.contains(focused)) &&
-      previouslyFocused instanceof HTMLElement &&
-      previouslyFocused.isConnected
-    ) {
-      previouslyFocused.focus();
+    if (hostOwnsFocus(replacementHost, activeElementFor(replacementHost))) {
+      focusIfConnected(previouslyFocused);
     }
     if (replacement) {
       disposeTerminalController(replacement, replacementHost);
@@ -80,19 +79,19 @@ export async function replaceTerminalControllerForReplay(params: {
   try {
     // Ghostty autofocuses during open. Stage read-only so hidden focus can
     // never forward keyboard input before the replacement is published.
-    replacement = await params.createController(replacementHost, { readOnly: true });
-    if (!params.isCurrent()) {
+    replacement = await createController(replacementHost, { readOnly: true });
+    if (signal.aborted) {
       disposeUnpublishedReplacement();
       return false;
     }
-    if (params.replay.length > 0) {
-      replacement.write(params.replay);
+    if (replay) {
+      replacement.write(terminalOutputEncoder.encode(replay));
     }
     // ghostty-web 0.4.0 focuses during open and again in a zero-delay task.
     await new Promise<void>((resolve) => {
       setTimeout(resolve, 0);
     });
-    if (!params.isCurrent()) {
+    if (signal.aborted) {
       disposeUnpublishedReplacement();
       return false;
     }
@@ -101,29 +100,20 @@ export async function replaceTerminalControllerForReplay(params: {
     throw error;
   }
 
-  const currentlyFocused = getActiveElementForHost(previousHost);
-  const previousTerminalOwnsCurrentFocus =
-    currentlyFocused === previousHost || previousHost.contains(currentlyFocused);
-  const replacementOwnsCurrentFocus =
-    currentlyFocused === replacementHost || replacementHost.contains(currentlyFocused);
-  const shouldFocusReplacement =
-    previousTerminalOwnsCurrentFocus || (previousTerminalOwnedFocus && replacementOwnsCurrentFocus);
-  const shouldRestorePreviousFocus = !previousTerminalOwnedFocus && replacementOwnsCurrentFocus;
+  const currentlyFocused = activeElementFor(previousHost);
+  let focusTarget: Element | null = null;
+  if (hostOwnsFocus(previousHost, currentlyFocused)) {
+    focusTarget = replacementHost;
+  } else if (hostOwnsFocus(replacementHost, currentlyFocused)) {
+    focusTarget = previousTerminalOwnedFocus ? replacementHost : previouslyFocused;
+  }
   replacementHost.inert = false;
   replacement.setReadOnly(previousController.readOnly);
   replacementHost.style.display = previousHost.style.display;
   replacementHost.style.visibility = previousHost.style.visibility;
-  params.target.controller = replacement;
-  params.target.host = replacementHost;
+  target.controller = replacement;
+  target.host = replacementHost;
   disposeTerminalController(previousController, previousHost);
-  if (shouldFocusReplacement) {
-    replacementHost.focus();
-  } else if (
-    shouldRestorePreviousFocus &&
-    previouslyFocused instanceof HTMLElement &&
-    previouslyFocused.isConnected
-  ) {
-    previouslyFocused.focus();
-  }
+  focusIfConnected(focusTarget);
   return true;
 }

--- a/ui/src/components/terminal/terminal-panel-readiness.test.ts
+++ b/ui/src/components/terminal/terminal-panel-readiness.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.ts";
 import { i18n } from "../../i18n/index.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
@@ -38,14 +39,6 @@ class ReadinessTestTerminalPanel extends OpenClawTerminalPanel {
 
 const TERMINAL_PANEL_ELEMENT_NAME = `test-terminal-panel-readiness-${crypto.randomUUID()}`;
 customElements.define(TERMINAL_PANEL_ELEMENT_NAME, ReadinessTestTerminalPanel);
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((next) => {
-    resolve = next;
-  });
-  return { promise, resolve };
-}
 
 function terminalOpenResult(sessionId: string) {
   return {
@@ -121,7 +114,7 @@ describe("terminal panel readiness", () => {
   });
 
   it("shows a connecting animation while a terminal open is in flight", async () => {
-    const open = deferred<{
+    const open = createDeferred<{
       sessionId: string;
       agentId: string;
       shell: string;

--- a/ui/src/components/terminal/terminal-panel-reconnect.test.ts
+++ b/ui/src/components/terminal/terminal-panel-reconnect.test.ts
@@ -109,9 +109,6 @@ describe("OpenClawTerminalPanel reconnect", () => {
       ...panel.renderRoot.querySelectorAll<HTMLButtonElement>(".tp-session"),
     ].find((button) => button.textContent?.includes("detached-agent"));
     detachedRow?.click();
-    await (
-      panel as unknown as { attachPickedSession: (sessionId: string) => Promise<void> }
-    ).attachPickedSession("detached-1");
 
     await waitForFast(() => {
       expect(requests).toContainEqual({
@@ -132,40 +129,15 @@ describe("OpenClawTerminalPanel reconnect", () => {
       createTerminalController(),
       createTerminalController(),
       createTerminalController(),
-      createTerminalController(),
     ] as const;
-    let controllerIndex = 0;
-    let resolveFirstReplacement: (() => void) | undefined;
-    const firstReplacement = new Promise<void>((resolve) => {
-      resolveFirstReplacement = resolve;
-    });
-    let resolveSecondReplacement: (() => void) | undefined;
-    const secondReplacement = new Promise<void>((resolve) => {
-      resolveSecondReplacement = resolve;
-    });
     const controllerParents: HTMLElement[] = [];
-    const replacementFocusVisibilities: string[] = [];
     createGhosttyTerminalMock.mockImplementation(async (options) => {
-      const currentIndex = controllerIndex++;
+      const currentIndex = createGhosttyTerminalMock.mock.calls.length - 1;
       const controller = controllers[currentIndex];
       if (!controller) {
         throw new Error("unexpected terminal controller creation");
       }
       controllerParents[currentIndex] = options.parent;
-      options.parent.tabIndex = 0;
-      const focusParent = () => {
-        if (currentIndex >= 2) {
-          replacementFocusVisibilities.push(options.parent.style.visibility);
-        }
-        options.parent.focus();
-      };
-      focusParent();
-      setTimeout(focusParent, 0);
-      if (currentIndex === 2) {
-        await firstReplacement;
-      } else if (currentIndex === 3) {
-        await secondReplacement;
-      }
       return controller;
     });
 
@@ -173,8 +145,7 @@ describe("OpenClawTerminalPanel reconnect", () => {
     let listener: ((event: { event: string; payload: unknown }) => void) | undefined;
     const replay = "reconnected shell\r\n$ ";
     const recoveredReplay = `${replay}?gap`;
-    const secondRecoveredReplay = `${recoveredReplay}!?next`;
-    const attachReplays = [replay, recoveredReplay, secondRecoveredReplay] as const;
+    const attachReplays = [replay, recoveredReplay] as const;
     let attachCount = 0;
     const client: TerminalGatewayClient = {
       forceReconnect: () => {},
@@ -240,10 +211,12 @@ describe("OpenClawTerminalPanel reconnect", () => {
     expect(controllers[0].dispose).toHaveBeenCalledOnce();
     expect(new TextDecoder().decode(controllers[1].write.mock.calls[0]?.[0])).toBe(replay);
 
-    const externalInput = document.createElement("input");
-    panel.renderRoot.append(externalInput);
-    externalInput.focus();
-    expect(panel.shadowRoot?.activeElement).toBe(externalInput);
+    const previousHost = controllerParents[1];
+    if (!previousHost) {
+      throw new Error("missing reconnected terminal host");
+    }
+    previousHost.style.display = "none";
+    previousHost.style.visibility = "collapse";
 
     listener?.({
       event: "terminal.data",
@@ -251,28 +224,12 @@ describe("OpenClawTerminalPanel reconnect", () => {
     });
     await waitForFast(() => expect(createGhosttyTerminalMock).toHaveBeenCalledTimes(3));
     expect(requests.filter((request) => request.method === "terminal.attach")).toHaveLength(2);
-    await waitForFast(() => expect(replacementFocusVisibilities).toEqual(["hidden", "hidden"]));
-
-    const newerExternalInput = document.createElement("input");
-    panel.renderRoot.append(newerExternalInput);
-    newerExternalInput.focus();
-    expect(panel.shadowRoot?.activeElement).toBe(newerExternalInput);
-    const previousHost = controllerParents[1];
-    if (!previousHost) {
-      throw new Error("missing previous terminal host");
-    }
-    previousHost.style.display = "none";
-    const finishFirstReplacement = resolveFirstReplacement;
-    if (!finishFirstReplacement) {
-      throw new Error("first replacement controller creation did not start");
-    }
-    finishFirstReplacement();
 
     await waitForFast(() => expect(controllers[1].dispose).toHaveBeenCalledOnce());
     expect(new TextDecoder().decode(controllers[2].write.mock.calls[0]?.[0])).toBe(recoveredReplay);
     expect(controllers[2].setReadOnly).toHaveBeenCalledWith(false);
-    expect(panel.shadowRoot?.activeElement).toBe(newerExternalInput);
     expect(controllerParents[2]?.style.display).toBe("none");
+    expect(controllerParents[2]?.style.visibility).toBe("collapse");
     expect(controllerParents[2]?.inert).toBe(false);
 
     listener?.({
@@ -283,39 +240,5 @@ describe("OpenClawTerminalPanel reconnect", () => {
     expect(new TextDecoder().decode(controllers[2].write.mock.calls[1]?.[0])).toBe("!");
     expect(requests.filter((request) => request.method === "terminal.attach")).toHaveLength(2);
     expect(controllers[1].dispose).toHaveBeenCalledOnce();
-
-    listener?.({
-      event: "terminal.data",
-      payload: {
-        sessionId: "surviving-session",
-        seq: recoveredReplay.length + 6,
-        data: "next",
-      },
-    });
-    await waitForFast(() => expect(createGhosttyTerminalMock).toHaveBeenCalledTimes(4));
-    await waitForFast(() => expect(replacementFocusVisibilities).toHaveLength(4));
-    const currentHost = controllerParents[2];
-    if (!currentHost) {
-      throw new Error("missing current terminal host");
-    }
-    currentHost.style.display = "block";
-    currentHost.focus();
-    expect(panel.shadowRoot?.activeElement).toBe(currentHost);
-    const finishSecondReplacement = resolveSecondReplacement;
-    if (!finishSecondReplacement) {
-      throw new Error("second replacement controller creation did not start");
-    }
-    finishSecondReplacement();
-
-    await waitForFast(() => expect(controllers[2].dispose).toHaveBeenCalledOnce());
-    expect(new TextDecoder().decode(controllers[3].write.mock.calls[0]?.[0])).toBe(
-      secondRecoveredReplay,
-    );
-    expect(controllers[3].setReadOnly).toHaveBeenCalledWith(false);
-    expect(panel.shadowRoot?.activeElement).toBe(controllerParents[3]);
-    expect(controllers[3].terminal.focus).not.toHaveBeenCalled();
-    expect(controllerParents[3]?.style.display).toBe("block");
-    expect(controllerParents[3]?.inert).toBe(false);
-    expect(requests.filter((request) => request.method === "terminal.attach")).toHaveLength(3);
   });
 });

--- a/ui/src/components/terminal/terminal-panel-session-controller.ts
+++ b/ui/src/components/terminal/terminal-panel-session-controller.ts
@@ -9,7 +9,7 @@ import {
 } from "./terminal-connection.ts";
 import {
   disposeTerminalController,
-  replaceTerminalControllerForReplay,
+  replaceTerminalController,
 } from "./terminal-controller-lifecycle.ts";
 import {
   forceTerminalRender,
@@ -17,7 +17,6 @@ import {
   shellBasename,
   TERMINAL_FONT_FAMILY,
   TERMINAL_OUTPUT_ENCODER,
-  type TerminalControllerFactory,
   type TerminalOperation,
   type TerminalPanelCatalogReference,
   type TerminalPanelSessionControllerHost,
@@ -29,6 +28,8 @@ import { createTerminalStartupInput } from "./terminal-startup-input.ts";
 import { TerminalTabReadinessController } from "./terminal-tab-readiness.ts";
 import { TerminalTaskQueue } from "./terminal-task-queue.ts";
 import { terminalDynamicColors, terminalTheme } from "./terminal-theme.ts";
+
+type TerminalSessionSink = Parameters<TerminalConnection["open"]>[1];
 
 /** Owns gateway PTY sessions and the Ghostty controllers bound to them. */
 export class TerminalPanelSessionController
@@ -253,12 +254,7 @@ export class TerminalPanelSessionController
   private async bootTab(
     operation: TerminalOperation,
     options: { awaitFirstOutput?: boolean } = {},
-  ): Promise<{
-    tab: TerminalPanelSessionTab;
-    connection: TerminalConnection;
-    cols: number;
-    rows: number;
-  }> {
+  ) {
     const connection = this.connectionFor(operation);
     // Preserve the connection so cancelled-open cleanup still closes the in-flight session.
     const host = document.createElement("div");
@@ -286,7 +282,7 @@ export class TerminalPanelSessionController
       getColors: () => terminalDynamicColors(this.host.themeMode),
       reply: (data) => startupInput.onData(TERMINAL_OUTPUT_ENCODER.encode(data)),
     });
-    const createController: TerminalControllerFactory = (parent, controllerOptions) =>
+    const createController = (parent: HTMLElement, controllerOptions?: { readOnly?: boolean }) =>
       this.host.createTerminalController({
         parent,
         readOnly: controllerOptions?.readOnly ?? false,
@@ -319,7 +315,6 @@ export class TerminalPanelSessionController
       gatewaySessionId: "",
       pendingInput: startupInput.buffer,
       defaultColorQueries,
-      createController,
       shellName: null,
       shell: "",
       agentId: null,
@@ -332,15 +327,7 @@ export class TerminalPanelSessionController
       readyTimer: null,
     };
     tabReference.current = tab;
-    this.updateControllerState("tabs", [...this.tabs, tab]);
-    this.updateControllerState("activeId", id);
-    const { terminal } = controller;
-    return { tab, connection, cols: terminal.cols || 80, rows: terminal.rows || 24 };
-  }
-
-  /** Output/exit sink for one tab, shared by open and attach. */
-  private tabSink(tab: TerminalPanelSessionTab) {
-    return {
+    const sink: TerminalSessionSink = {
       // The cancelled guard also protects the buffered-event replay inside
       // connection.open/attach from writing to an already-disposed terminal.
       onData: (data: string) => {
@@ -352,13 +339,8 @@ export class TerminalPanelSessionController
           }
         }
       },
-      onReplay: (
-        data: string,
-        newlyObservedFrom: number,
-        mode: "initial" | "recovery",
-        isReplayCurrent: () => boolean,
-      ) => {
-        if (tab.cancelled) {
+      onReplay: ({ data, newlyObservedFrom, mode, signal }) => {
+        if (tab.cancelled || signal.aborted) {
           return undefined;
         }
         // Suppress complete historical queries, then answer only the suffix
@@ -366,12 +348,7 @@ export class TerminalPanelSessionController
         tab.defaultColorQueries.primeFromReplay(data.slice(0, newlyObservedFrom));
         tab.defaultColorQueries.observe(data.slice(newlyObservedFrom));
         if (mode === "recovery") {
-          return replaceTerminalControllerForReplay({
-            target: tab,
-            createController: tab.createController,
-            replay: TERMINAL_OUTPUT_ENCODER.encode(data),
-            isCurrent: () => isReplayCurrent() && !tab.cancelled && this.tabs.includes(tab),
-          }).then((replaced) => {
+          return replaceTerminalController(tab, createController, data, signal).then((replaced) => {
             if (replaced && data) {
               this.readiness.markReady(tab);
             }
@@ -385,6 +362,16 @@ export class TerminalPanelSessionController
       },
       onExit: (info: { reason?: string; exitCode: number | null; error?: string }) =>
         this.handleExit(tab.id, info),
+    };
+    this.updateControllerState("tabs", [...this.tabs, tab]);
+    this.updateControllerState("activeId", id);
+    const { terminal } = controller;
+    return {
+      tab,
+      connection,
+      cols: terminal.cols || 80,
+      rows: terminal.rows || 24,
+      sink,
     };
   }
 
@@ -450,7 +437,7 @@ export class TerminalPanelSessionController
       createdTab = boot.tab;
       const result = await boot.connection.open(
         { agentId, cols: boot.cols, rows: boot.rows, ...(catalog ? { catalog } : {}) },
-        this.tabSink(boot.tab),
+        boot.sink,
       );
       if (!this.isTerminalOperationCurrent(operation) || boot.tab.cancelled) {
         // The tab's close button was clicked while the open RPC was in flight.
@@ -501,7 +488,7 @@ export class TerminalPanelSessionController
       const boot = await this.bootTab(operation);
       createdTab = boot.tab;
       createdConnection = boot.connection;
-      const result = await boot.connection.attach(sessionId, this.tabSink(boot.tab));
+      const result = await boot.connection.attach(sessionId, boot.sink);
       if (!this.isTerminalOperationCurrent(operation) || boot.tab.cancelled) {
         // A user close is deliberate; lifecycle cancellation leaves the existing
         // server session available for the next reconnect to reattach.

--- a/ui/src/components/terminal/terminal-panel-session-types.ts
+++ b/ui/src/components/terminal/terminal-panel-session-types.ts
@@ -11,17 +11,11 @@ import { persistTerminalSessionIds } from "./terminal-session-storage.ts";
 import type { StartupInputBuffer } from "./terminal-startup-input.ts";
 import type { TerminalTabReadinessState } from "./terminal-tab-readiness.ts";
 
-export type TerminalControllerFactory = (
-  parent: HTMLElement,
-  options?: { readOnly?: boolean },
-) => Promise<GhosttyTerminalController>;
-
 export type TerminalPanelSessionTab = TerminalPanelTab &
   TerminalTabReadinessState & {
     gatewaySessionId: string;
     pendingInput: StartupInputBuffer;
     defaultColorQueries: ReturnType<typeof createTerminalDefaultColorQueryResponder>;
-    createController: TerminalControllerFactory;
     controller: GhosttyTerminalController;
     shell: string;
     host: HTMLDivElement;

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.ts";
 import { i18n } from "../../i18n/index.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
@@ -16,16 +17,6 @@ import { OpenClawTerminalPanel } from "./terminal-panel.ts";
 
 const createGhosttyTerminalMock: CreateGhosttyTerminalMock = vi.fn();
 
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((next, fail) => {
-    resolve = next;
-    reject = fail;
-  });
-  return { promise, resolve, reject };
-}
-
 const TERMINAL_PANEL_ELEMENT_NAME = defineTestTerminalPanelElement(createGhosttyTerminalMock);
 
 async function startPanelWithPendingOpen() {
@@ -34,7 +25,7 @@ async function startPanelWithPendingOpen() {
     createOptions = options;
     return createTerminalController();
   });
-  const open = deferred<ReturnType<typeof terminalOpenResult>>();
+  const open = createDeferred<ReturnType<typeof terminalOpenResult>>();
   const requests: Array<{ method: string; params: unknown }> = [];
   const client: TerminalGatewayClient = {
     forceReconnect: () => {},
@@ -522,8 +513,8 @@ describe("OpenClawTerminalPanel", () => {
       attached: boolean;
       createdAtMs: number;
     };
-    const firstList = deferred<{ sessions: ListedSession[] }>();
-    const secondList = deferred<{ sessions: ListedSession[] }>();
+    const firstList = createDeferred<{ sessions: ListedSession[] }>();
+    const secondList = createDeferred<{ sessions: ListedSession[] }>();
     let listCount = 0;
     const client: TerminalGatewayClient = {
       forceReconnect: () => {},
@@ -627,7 +618,7 @@ describe("OpenClawTerminalPanel", () => {
   });
 
   it("queues a catalog toggle that arrives during another terminal boot", async () => {
-    const firstBoot = deferred<ReturnType<typeof createTerminalController>>();
+    const firstBoot = createDeferred<ReturnType<typeof createTerminalController>>();
     createGhosttyTerminalMock
       .mockReturnValueOnce(firstBoot.promise)
       .mockResolvedValueOnce(createTerminalController());
@@ -833,7 +824,7 @@ describe("OpenClawTerminalPanel", () => {
   it("discards an async boot that finishes after disconnect and reconnect", async () => {
     const staleController = createTerminalController();
     const currentController = createTerminalController();
-    const staleBoot = deferred<typeof staleController>();
+    const staleBoot = createDeferred<typeof staleController>();
     createGhosttyTerminalMock
       .mockImplementationOnce(async () => staleBoot.promise)
       .mockResolvedValueOnce(currentController);
@@ -905,43 +896,6 @@ describe("OpenClawTerminalPanel", () => {
     expect(document.documentElement.style.getPropertyValue("--oc-terminal-reserve-right")).toBe(
       "0px",
     );
-  });
-
-  it("removes leaked terminal listeners and the tab host when controller disposal throws", () => {
-    const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
-    const host = document.createElement("div");
-    document.body.append(host);
-    const dispose = vi.fn(() => {
-      throw new Error("dispose failed");
-    });
-    const controller = createTerminalController(dispose);
-    const handleMouseUp = vi.fn();
-    (
-      controller.terminal as typeof controller.terminal & {
-        handleMouseUp: (event: MouseEvent) => void;
-      }
-    ).handleMouseUp = handleMouseUp;
-    const removeEventListener = vi.spyOn(document, "removeEventListener");
-    const terminalSessions = (
-      panel as unknown as {
-        terminalSessions: {
-          disposeTab(tab: { controller: typeof controller; host: HTMLDivElement }): void;
-        };
-      }
-    ).terminalSessions;
-    const disposeTab = terminalSessions.disposeTab.bind(terminalSessions);
-
-    try {
-      expect(() => disposeTab({ controller, host })).not.toThrow();
-      expect(removeEventListener).toHaveBeenCalledWith("mouseup", handleMouseUp);
-      expect(removeEventListener.mock.invocationCallOrder.at(-1)).toBeLessThan(
-        dispose.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
-      );
-      expect(dispose).toHaveBeenCalledOnce();
-      expect(host.isConnected).toBe(false);
-    } finally {
-      removeEventListener.mockRestore();
-    }
   });
 
   it("retranslates cached exit state when the locale changes", async () => {

--- a/ui/src/components/terminal/terminal-runtime.ts
+++ b/ui/src/components/terminal/terminal-runtime.ts
@@ -1,12 +1,7 @@
-import type {
-  CreateGhosttyTerminalOptions,
-  GhosttyTerminalController,
-} from "@openclaw/libterminal/browser";
+import type { CreateGhosttyTerminalOptions } from "@openclaw/libterminal/browser";
 
 /** Creates a terminal whose WASM memory is never reused by another tab. */
-export async function createIsolatedGhosttyTerminal(
-  options: CreateGhosttyTerminalOptions,
-): Promise<GhosttyTerminalController> {
+export async function createIsolatedGhosttyTerminal(options: CreateGhosttyTerminalOptions) {
   const [{ createGhosttyTerminal, loadGhosttyRuntime }, ghosttyModule] = await Promise.all([
     import("@openclaw/libterminal/browser"),
     import("ghostty-web"),
@@ -14,5 +9,25 @@ export async function createIsolatedGhosttyTerminal(
   // ghostty-web 0.4.0 reuses freed WASM pages, exposing stale cells and corrupting
   // later terminals (coder/ghostty-web#142). Per-tab runtimes confine disposal.
   const runtime = await loadGhosttyRuntime({ module: ghosttyModule });
-  return createGhosttyTerminal({ ...options, runtime });
+  const controller = await createGhosttyTerminal({ ...options, runtime });
+  const dispose = controller.dispose.bind(controller);
+  const terminal = controller.terminal as unknown as { handleMouseUp?: unknown };
+  let handleMouseUp =
+    typeof terminal.handleMouseUp === "function"
+      ? (terminal.handleMouseUp as EventListener)
+      : undefined;
+  let disposed = false;
+  controller.dispose = () => {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    // ghostty-web 0.4.0 clears isOpen before cleanup, skipping this listener removal.
+    if (handleMouseUp) {
+      document.removeEventListener("mouseup", handleMouseUp);
+      handleMouseUp = undefined;
+    }
+    dispose();
+  };
+  return controller;
 }


### PR DESCRIPTION
Related: #121637
Related: #121636

## What Problem This Solves

The recently landed terminal reconnect repair is correct, but its implementation still carries optional replay handling, exported controller-factory state, and nested currentness callbacks across lifecycle layers. This follow-up removes that maintenance complexity without changing terminal behavior.

## Why This Change Was Made

Replay is now one required structured contract whose lifetime is owned by `TerminalConnection` through a per-stream `AbortSignal`. `TerminalPanelSessionController` privately owns controller creation, while the generic lifecycle helper performs one staged, hidden, measurable, inert, read-only replacement transaction before atomically publishing the controller and transferring visibility and focus.

Pinned `ghostty-web@0.4.0` cleanup stays in the runtime adapter: the public controller's `dispose()` is wrapped idempotently to remove the leaked document `mouseup` listener before dependency disposal. The generic replacement lifecycle no longer knows dependency internals.

No behavior, API, protocol, config, schema, dependency, release, or publish surface changes.

Production LOC: +172/-186 (net -14) | Tests: +239/-238 (net +1). The exported factory type, optional replay fallback, factory-on-tab state, and cross-layer currentness callbacks are deleted.

AI-assisted; implementation and review findings were verified against current source, pinned dependency source, focused tests, browser behavior, and exact-head remote proof.

## User Impact

None. Terminal reconnect, authoritative replay, queued live continuation, focus, visibility, read-only staging, and cleanup behavior remain the same, with a smaller and more maintainable implementation.

## Evidence

- Rebased head: `d042df2b1a4fc26322ab6abd44bb98aa69713da1` on `origin/main` `8e54d696ebcef399157494ebab8c36d040602569`.
- `node scripts/run-vitest.mjs` over `terminal-connection`, `terminal-controller-lifecycle`, `terminal-panel-readiness`, `terminal-panel-reconnect`, `terminal-panel-suppression`, and `terminal-panel`: 6 files, 77/77 tests passed locally and on Blacksmith Testbox.
- Targeted `oxfmt --check`, `pnpm tsgo:ui`, targeted oxlint with `config/tsconfig/oxlint.core.json`, `pnpm deadcode:exports`, and `git diff --check origin/main...HEAD`: passed locally and on Testbox.
- Real Chromium: `terminal-runtime.e2e.test.ts` and `terminal-repaint.e2e.test.ts`: 2/2 passed on Testbox.
- Blacksmith Testbox lease `tbx_01kzqv8ds5rxymvvwn9dywgsf0`, run https://github.com/openclaw/openclaw/actions/runs/31468734928; one-shot lease stopped after success.
- Fresh branch-mode Codex-backed P0-P2 autoreview: clean, no accepted/actionable findings; overall correctness 0.93.
- Dependency proof: `ghostty-web@0.4.0` `open()` installs the document listener and autofocuses, `focus()` schedules a second zero-delay focus, `reset()` recreates the terminal in the same runtime, and `dispose()` clears `isOpen` before guarded listener cleanup (`dist/ghostty-web.js:2323-2375,2438-2450,2625-2667`). `@openclaw/libterminal@0.3.2` exposes idempotent controller disposal and forwards terminal disposal (`dist/browser.js:349-433`).
- Test audit: retained owner-boundary ordering, cancellation, focus/visibility, and runtime-cleanup coverage; no test-only production seam.
