### PR TITLE
fix(macos): make the whole AI candidate row clickable and clear stale exhausted verdicts

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -35171,7 +35171,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 390,
+      "line": 394,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "No key-based providers are available",
       "surface": "apple",
@@ -35179,7 +35179,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 391,
+      "line": 395,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
       "surface": "apple",
@@ -35187,7 +35187,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 393,
+      "line": 397,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Check again",
       "surface": "apple",
@@ -35195,7 +35195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 407,
+      "line": 411,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Set up a local model",
       "surface": "apple",
@@ -35203,7 +35203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 409,
+      "line": 413,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Connect a local model service, or prepare a model on this Gateway.",
       "surface": "apple",
@@ -35211,7 +35211,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 433,
+      "line": 437,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Connect / Set up",
       "surface": "apple",
@@ -35219,7 +35219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 453,
+      "line": 457,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Sign in with a provider",
       "surface": "apple",
@@ -35227,7 +35227,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 455,
+      "line": 459,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
       "surface": "apple",
@@ -35235,7 +35235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 470,
+      "line": 474,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "More sign-in options",
       "surface": "apple",
@@ -35243,7 +35243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 499,
+      "line": 503,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "API Keys",
       "surface": "apple",
@@ -35251,7 +35251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 539,
+      "line": 543,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Pair",
       "surface": "apple",
@@ -35259,7 +35259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 539,
+      "line": 543,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Sign in",
       "surface": "apple",
@@ -35267,7 +35267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 556,
+      "line": 560,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "OpenClaw will detect and verify the prepared model before using it.",
       "surface": "apple",
@@ -35275,7 +35275,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 557,
+      "line": 561,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
       "surface": "apple",
@@ -35283,7 +35283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 586,
+      "line": 590,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Open sign-in page…",
       "surface": "apple",
@@ -35291,7 +35291,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 594,
+      "line": 598,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Starting local model setup…",
       "surface": "apple",
@@ -35299,7 +35299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 595,
+      "line": 599,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Starting secure sign-in…",
       "surface": "apple",
@@ -35307,7 +35307,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 602,
+      "line": 606,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Model setup didn’t complete",
       "surface": "apple",
@@ -35315,7 +35315,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 603,
+      "line": 607,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Sign-in didn’t complete",
       "surface": "apple",
@@ -35323,7 +35323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 613,
+      "line": 617,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -35331,7 +35331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 636,
+      "line": 640,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Finish in your browser",
       "surface": "apple",
@@ -35339,7 +35339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 652,
+      "line": 656,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Copy",
       "surface": "apple",
@@ -35347,7 +35347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 661,
+      "line": 665,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Expires in \\(minutes) minutes",
       "surface": "apple",
@@ -35355,7 +35355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 668,
+      "line": 672,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Open sign-in page",
       "surface": "apple",
@@ -35363,7 +35363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 696,
+      "line": 700,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Option",
       "surface": "apple",
@@ -35371,7 +35371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 702,
+      "line": 706,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Confirm",
       "surface": "apple",
@@ -35379,7 +35379,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 711,
+      "line": 715,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "I've signed in",
       "surface": "apple",
@@ -35387,7 +35387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 713,
+      "line": 717,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Continue",
       "surface": "apple",
@@ -35395,7 +35395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 713,
+      "line": 717,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Submit",
       "surface": "apple",
@@ -35403,7 +35403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 718,
+      "line": 722,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Connect with an API key or token",
       "surface": "apple",
@@ -35411,7 +35411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 727,
+      "line": 731,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Provider",
       "surface": "apple",
@@ -35419,7 +35419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 735,
+      "line": 739,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "API key or token",
       "surface": "apple",
@@ -35427,7 +35427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 747,
+      "line": 751,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Connect",
       "surface": "apple",
@@ -35435,7 +35435,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 763,
+      "line": 767,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "That key didn’t work",
       "surface": "apple",
@@ -35443,7 +35443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 845,
+      "line": 849,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Open help…",
       "surface": "apple",
@@ -35451,7 +35451,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 884,
+      "line": 888,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Hide details",
       "surface": "apple",
@@ -35459,7 +35459,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 884,
+      "line": 888,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Show details",
       "surface": "apple",
@@ -35467,7 +35467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 907,
+      "line": 911,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Copy error",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -782,6 +782,10 @@ extension OnboardingAISetupModel {
         guard let context = beginAttemptContext(
             supersededAttemptDeadline: supersededAttemptDeadline)
         else { return }
+        // A fresh user-picked attempt owns the verdict; keeping the stale
+        // "none of the found options worked" card up during its test would
+        // contradict the visible Testing state.
+        self.exhaustedAutoCandidates = false
         if let supersededKind {
             self.statuses[supersededKind] = .untried
             self.selectedKind = kind

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift
@@ -312,6 +312,10 @@ struct OnboardingAISetupView: View {
                     Spacer(minLength: 0)
                     self.trailingIndicator(status: status, selected: selected)
                 }
+                // Plain buttons hit-test only opaque label pixels; without this the
+                // row's blank stretch (between texts, over the Spacer) ignores clicks
+                // and a mid-testing candidate pick silently does nothing.
+                .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .disabled(!self.model.canSelectCandidate(kind: candidate.kind))

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -2988,6 +2988,42 @@ struct OnboardingAISetupTests {
         await automatic.value
     }
 
+    @Test func `user pick after exhausted auto candidates clears the stale verdict`() async throws {
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingExhaustedRetryTests"))
+        let attempts = AISetupSocketGeneration()
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let harness = AISetupHarness(url: url) { _, request, _ in
+            switch request.method {
+            case "openclaw.setup.detect":
+                return selectableCandidatesDetectedSetupResponse(id: request.id)
+            case "openclaw.setup.activate" where attempts.claim() < 2:
+                return failedActivationResponse(id: request.id)
+            case "openclaw.setup.activate":
+                return successfulActivationResponse(
+                    id: request.id,
+                    modelRef: "openai/gpt-5.5",
+                    latencyMs: 120)
+            default:
+                return nil
+            }
+        }
+        let model = harness.model(defaults: defaults)
+
+        await model.detectAndAutoConnect()
+        #expect(model.exhaustedAutoCandidates)
+        #expect(!model.connected)
+
+        model.userSelect(kind: "codex-cli")
+        // The retest owns the verdict from the moment it starts; the stale
+        // "none of the found options worked" card must not outlive the pick.
+        #expect(!model.exhaustedAutoCandidates)
+        for _ in 0..<400 where !model.connected {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        #expect(model.connected)
+        #expect(model.selectedKind == "codex-cli")
+    }
+
     @Test func `candidate click after connection is ignored`() async throws {
         let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingConnectedCandidateClickTests"))
         let url = try #require(URL(string: "ws://example.invalid"))

--- a/test/vitest-unit-fast-config.test.ts
+++ b/test/vitest-unit-fast-config.test.ts
@@ -258,11 +258,11 @@ describe("unit-fast vitest lane", () => {
   });
 
   it("isolates tests that import stateful test helpers", () => {
+    // Fixture files must genuinely import a stateful test helper; #121923
+    // rewrote the outbound poll tests to be stateless, so they left this list.
     const files = [
       "src/agents/auth-profiles/oauth-refresh-error.test.ts",
       "src/auto-reply/reply/agent-runner-execution-runtime.test.ts",
-      "src/infra/outbound/message-action-execution.poll.test.ts",
-      "src/infra/outbound/message-action-runner.poll.test.ts",
     ];
     for (const file of files) {
       const analysis = unitFastAnalysis.find((entry) => entry.file === file);


### PR DESCRIPTION
## What Problem This Solves

Live stress-testing of macOS onboarding (2026-08-11, fresh `OPENCLAW_PROFILE` runs on current main) showed that clicking an AI candidate row during auto-testing frequently does nothing. The row renders as one large selectable card (it even carries the selection ring), but the plain-style SwiftUI button only hit-tests opaque label pixels — clicks landing on the blank stretch between the title and subtitle texts, or anywhere over the trailing spacer, are silently dropped. This makes the pick-during-testing flow shipped in #121613 hard to hit in practice: the user clicks the visibly highlighted row and gets no visible outcome (the worst bug class per repo doctrine).

Secondarily: after all auto-candidates fail, picking a candidate again for a retest left the stale "None of the found options worked" card on screen while the new test visibly ran — a claim contradicting the live Testing state next to it.

## Why This Change Was Made

`.contentShape(Rectangle())` on the button label makes the entire row hit-test, matching what the selection-ring chrome already promises visually. `userSelect` now clears `exhaustedAutoCandidates` the moment a fresh user-picked attempt begins, because that attempt owns the verdict from then on. Both fixes live at the owner (the candidate row view and the pick entry point); no consumer-side workarounds.

## User Impact

Clicking anywhere on a candidate row now selects it — including the mid-test supersede pick from #121613, which was live-verified working end-to-end once clicks land (supersede → busy-admission backoff → picked candidate tests → honest failure reporting → re-pick recovery). The stale exhausted-verdict card no longer contradicts a running retest.

## Evidence

- Live repro: cliclick/CGEvent clicks at the row's vertical midpoint (between title and subtitle) produced no `userSelect` (no supersede, no second `openclaw.setup.activate` in the gateway log); the same click on the title text immediately superseded and drove the full #121613 flow (6× UNAVAILABLE busy-admission rejections with backoff, then the picked candidate's activate succeeded).
- `swift test --package-path apps/macos --filter OnboardingAISetupTests`: 95/95 passed (Xcode 26.6), including the new regression `user pick after exhausted auto candidates clears the stale verdict`.
- `./scripts/format-swift.sh macos` and `./scripts/lint-swift.sh macos`: clean. `native-app-i18n` baseline regenerated (line-shift only) and `verify` passes.
- Autoreview (uncommitted mode): clean, "patch is correct" at 0.99 confidence.

## Red-main fix folded in

`main` went red at 465aad50a7f (#121923): it rewrote the outbound poll tests to be order-independent and deleted `src/infra/outbound/message-action-runner.poll.test.ts` plus the stateful helper file, but `test/vitest-unit-fast-config.test.ts` hardcoded both poll files as stateful-helper classification fixtures. Verified failing on clean `origin/main` and passing on the parent commit. Smallest fix (dropping the now-stateless fixtures) folded into this PR per the red-main landing policy; the two remaining fixture files still prove the classification behavior.
