### PR TITLE
docs(browser): point multi-step flows at the Code Mode loop in the tool description

### DIFF
--- a/extensions/browser/src/browser-tool-description.ts
+++ b/extensions/browser/src/browser-tool-description.ts
@@ -18,6 +18,7 @@ export function describeBrowserTool(opts: {
     "Use snapshot+act for UI automation. Avoid act:wait by default; use only in exceptional cases when no reliable UI state exists.",
     "For page text, use a selector-scoped snapshot or act:evaluate that returns only relevant text or structured data, then reason over that bounded result with the active model. Use efficient snapshots for controls and action discovery; they omit most non-interactive prose.",
     "For file chooser uploads, pass the trigger ref with paths in the same upload call when available; use paths-only arming only when a later trigger is intentional. Use inputRef or element to set a file input directly.",
+    "Multi-step flows (3+ dependent actions, any loop or aggregation): when a Code Mode exec tool is available, drive this tool from one exec cell — see the browser-automation skill's Code Mode Loop — instead of issuing one action per call.",
     `target selects browser location (sandbox|host|node). Default: ${opts.targetDefault}.`,
     opts.hostHint,
   ].join(" ");


### PR DESCRIPTION
Follow-up to #121902/#121924: the code-grain browser path already exists — Code Mode exec cells calling the browser tool (browser-automation skill, "Code Mode Loop") — but the browser tool's own prompt surface never mentions it, so models drive primitive-by-primitive even when the loop is available. Capability the description doesn't mention doesn't exist for the model.

One sentence added to the tool description directing multi-step flows (3+ dependent actions, loops, aggregation) to a single exec cell when a Code Mode exec tool is present. Worded to be self-verifying: the model can see whether it has an exec tool, so the hint is truthful under `tools.codeMode: "auto"` per-model activation without build-time conditionals.

Proof: `git diff --check` clean, extensions typecheck + oxlint green on the changed file; no focused test covers description text.