### PR TITLE
fix(ci): drop retired poll routing fixtures

### DIFF
--- a/test/vitest-unit-fast-config.test.ts
+++ b/test/vitest-unit-fast-config.test.ts
@@ -261,8 +261,6 @@ describe("unit-fast vitest lane", () => {
     const files = [
       "src/agents/auth-profiles/oauth-refresh-error.test.ts",
       "src/auto-reply/reply/agent-runner-execution-runtime.test.ts",
-      "src/infra/outbound/message-action-execution.poll.test.ts",
-      "src/infra/outbound/message-action-runner.poll.test.ts",
     ];
     for (const file of files) {
       const analysis = unitFastAnalysis.find((entry) => entry.file === file);


### PR DESCRIPTION
Related: #121923

## What Problem This Solves

Resolves a problem where the unit-fast routing contract still named two poll test fixtures after the order-independent poll rewrite removed one file and stopped the other from importing the shared stateful helper. The compact tooling shard therefore failed while classifying a retired routing shape.

## Why This Change Was Made

Remove both stale poll entries from the narrow assertion that enumerates tests importing stateful helpers. The general classifier still routes the surviving poll test from its actual contents; this change only deletes obsolete inventory after #121923 moved poll coverage to its direct provider boundary.

## User Impact

No user-visible runtime behavior changes. CI can validate the new owner-local poll coverage without failing on retired fixture names.

## Evidence

- Exact-main reproduction at `465aad50a7fa`: [Blacksmith Testbox run 31470804413](https://github.com/openclaw/openclaw/actions/runs/31470804413) failed `test/vitest-unit-fast-config.test.ts` because the old poll entries no longer had the `stateful-test-helper` reason.
- Patched focused proof: [Blacksmith Testbox run 31471140936](https://github.com/openclaw/openclaw/actions/runs/31471140936) passed `test/vitest-unit-fast-config.test.ts` (11/11) and `message-action-execution.poll.test.ts` (9/9).
- `git diff --check`: clean.
- Structured autoreview: clean, no accepted/actionable findings.
- Production LOC: +0/-0; tests: +0/-2.
