### PR TITLE
test(sqlite): avoid duplicate reliability proof run

### DIFF
--- a/test/scripts/bench-sqlite-reliability.test.ts
+++ b/test/scripts/bench-sqlite-reliability.test.ts
@@ -188,6 +188,8 @@ describe("scripts/bench-sqlite-reliability", () => {
     expect(result.stdout).toContain("SQLITE_RELIABILITY_TARGET=global");
     expect(result.stdout).not.toContain("=missing");
     const firstReport = JSON.parse(fs.readFileSync(output, "utf8")) as ReliabilityReport;
+    expect(firstReport.concurrentRestoresVerified).toBe(4);
+    expect(firstReport.restoresVerified).toBe(7);
     expect(
       firstReport.crashRecoveryProof.exit.code !== null ||
         firstReport.crashRecoveryProof.exit.signal !== null,

--- a/test/scripts/bench-sqlite-reliability.test.ts
+++ b/test/scripts/bench-sqlite-reliability.test.ts
@@ -4,17 +4,24 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { parseSqliteReliabilityCli } from "../../scripts/lib/sqlite-reliability-cli.js";
-import type { ReliabilityReport } from "../../scripts/lib/sqlite-reliability-contract.js";
+import {
+  STRESS_TABLE_SQL,
+  type ReliabilityReport,
+} from "../../scripts/lib/sqlite-reliability-contract.js";
 import { monitorSqliteWalDuring } from "../../scripts/lib/sqlite-reliability-wal-monitor.js";
 import {
   canonicalPathWithExistingParent,
   isPendingPathInRepository,
 } from "../../scripts/lib/sqlite-reliability-worker-paths.js";
 import { openNodeSqliteDatabase } from "../../src/infra/node-sqlite.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../src/state/openclaw-state-db.js";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-// Windows repeats ACL checks and >64 MiB crash/restore copies across two full runs.
+// Windows repeats ACL checks and >64 MiB crash/restore copies throughout the full proof.
 const RELIABILITY_PROOF_TIMEOUT_MS = process.platform === "win32" ? 480_000 : 240_000;
 const RELIABILITY_SMOKE_TEST_TIMEOUT_MS = process.platform === "win32" ? 1_200_000 : 300_000;
 
@@ -147,36 +154,40 @@ describe("scripts/bench-sqlite-reliability", () => {
     });
   });
 
-  reliabilitySmokeTest("reuses a state directory without stale rows or restore collisions", () => {
+  reliabilitySmokeTest("proves snapshot reliability while safely reusing state", () => {
     const stateDir = tempDirs.make("openclaw-sqlite-reliability-test-");
-    const firstOutput = path.join(stateDir, "report-first.json");
-    const firstResult = runProof([
-      "--profile",
-      "smoke",
-      "--state-dir",
+    const previousSyncedRepository = path.join(
       stateDir,
-      "--output",
-      firstOutput,
-    ]);
+      "sqlite-reliability-runs",
+      "previous-run",
+      "synced-snapshots",
+    );
+    const previousArtifact = path.join(previousSyncedRepository, "previous-artifact");
+    fs.mkdirSync(previousSyncedRepository, { recursive: true });
+    fs.writeFileSync(previousArtifact, "retained");
 
-    expect(firstResult.status, firstResult.stderr).toBe(0);
-    expect(firstResult.stderr).toBe("");
-    expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_TARGET=global");
-    expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_RESTORES_VERIFIED=7");
-    expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_CRASH_RECOVERY=verified");
-    expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_PUBLICATION_INTERRUPTION=verified");
-    expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_RESTORE_INTERRUPTION=verified");
-    expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_REPOSITORY_INTERRUPTION=verified");
-    expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_INDEX_REPAIR_INTERRUPTION=verified");
-    expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_VACUUM_INTERRUPTION=verified");
-    expect(firstResult.stdout).toContain("SQLITE_RELIABILITY_POST_COMPACT_RESTORE=verified");
-    const firstReport = JSON.parse(fs.readFileSync(firstOutput, "utf8")) as ReliabilityReport;
-    expect(firstReport.concurrentRestoresVerified).toBe(4);
-    expect(firstReport.restoresVerified).toBe(7);
-    expect(firstReport.crashRecoveryProof.sourceRecovered).toBe(true);
-    expect(firstReport.crashRecoveryProof.committedStatePreserved).toBe(true);
-    expect(firstReport.crashRecoveryProof.partialVisibleAfterRecovery).toBe(false);
-    expect(firstReport.crashRecoveryProof.writerRestarted).toBe(true);
+    const existingDatabase = openOpenClawStateDatabase({
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+    });
+    try {
+      existingDatabase.db.exec(STRESS_TABLE_SQL);
+      existingDatabase.db
+        .prepare(
+          "INSERT INTO openclaw_reliability_entries (batch, ordinal, payload) VALUES (?, ?, ?)",
+        )
+        .run(999_999, 0, "stale-profile-row");
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+    }
+
+    const output = path.join(stateDir, "report.json");
+    const result = runProof(["--profile", "smoke", "--state-dir", stateDir, "--output", output]);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("SQLITE_RELIABILITY_TARGET=global");
+    expect(result.stdout).not.toContain("=missing");
+    const firstReport = JSON.parse(fs.readFileSync(output, "utf8")) as ReliabilityReport;
     expect(
       firstReport.crashRecoveryProof.exit.code !== null ||
         firstReport.crashRecoveryProof.exit.signal !== null,
@@ -375,33 +386,18 @@ describe("scripts/bench-sqlite-reliability", () => {
     expect(firstReport.walBytes.peak).toBeGreaterThan(0);
     expect(firstReport.walBytes.peak).toBeLessThanOrEqual(firstReport.walBytes.limit);
 
-    const database = openNodeSqliteDatabase(firstReport.paths.sourceDatabase);
+    expect(firstReport.paths.syncedRepository).not.toBe(previousSyncedRepository);
+    expect(fs.readFileSync(previousArtifact, "utf8")).toBe("retained");
+
+    const database = openNodeSqliteDatabase(firstReport.paths.sourceDatabase, { readOnly: true });
     try {
-      database
-        .prepare(
-          "INSERT INTO openclaw_reliability_entries (batch, ordinal, payload) VALUES (?, ?, ?)",
-        )
-        .run(999_999, 0, "stale-profile-row");
+      const staleRows = database
+        .prepare("SELECT COUNT(*) AS rows FROM openclaw_reliability_entries WHERE batch = ?")
+        .get(999_999) as { rows?: unknown };
+      expect(Number(staleRows.rows)).toBe(0);
     } finally {
       database.close();
     }
-
-    const secondOutput = path.join(stateDir, "report-second.json");
-    const secondResult = runProof([
-      "--profile",
-      "smoke",
-      "--state-dir",
-      stateDir,
-      "--output",
-      secondOutput,
-    ]);
-    expect(secondResult.status, secondResult.stderr).toBe(0);
-    const secondReport = JSON.parse(fs.readFileSync(secondOutput, "utf8")) as {
-      paths: { syncedRepository: string };
-      restoresVerified: number;
-    };
-    expect(secondReport.restoresVerified).toBe(7);
-    expect(secondReport.paths.syncedRepository).not.toBe(firstReport.paths.syncedRepository);
   });
 
   it("matches crash barriers across filesystem path aliases", () => {

--- a/test/scripts/bench-sqlite-reliability.test.ts
+++ b/test/scripts/bench-sqlite-reliability.test.ts
@@ -186,6 +186,14 @@ describe("scripts/bench-sqlite-reliability", () => {
     expect(result.status, result.stderr).toBe(0);
     expect(result.stderr).toBe("");
     expect(result.stdout).toContain("SQLITE_RELIABILITY_TARGET=global");
+    expect(result.stdout).toContain("SQLITE_RELIABILITY_RESTORES_VERIFIED=7");
+    expect(result.stdout).toContain("SQLITE_RELIABILITY_CRASH_RECOVERY=verified");
+    expect(result.stdout).toContain("SQLITE_RELIABILITY_PUBLICATION_INTERRUPTION=verified");
+    expect(result.stdout).toContain("SQLITE_RELIABILITY_RESTORE_INTERRUPTION=verified");
+    expect(result.stdout).toContain("SQLITE_RELIABILITY_REPOSITORY_INTERRUPTION=verified");
+    expect(result.stdout).toContain("SQLITE_RELIABILITY_INDEX_REPAIR_INTERRUPTION=verified");
+    expect(result.stdout).toContain("SQLITE_RELIABILITY_VACUUM_INTERRUPTION=verified");
+    expect(result.stdout).toContain("SQLITE_RELIABILITY_POST_COMPACT_RESTORE=verified");
     expect(result.stdout).not.toContain("=missing");
     const firstReport = JSON.parse(fs.readFileSync(output, "utf8")) as ReliabilityReport;
     expect(firstReport.concurrentRestoresVerified).toBe(4);


### PR DESCRIPTION
## What Problem This Solves

The compact tooling lane ran the complete SQLite reliability benchmark twice inside one Vitest case. Each smoke proof performs the full writer crash/restart sequence, four concurrent snapshot/restore iterations, publication and repository interruption checks, two index-repair interruption modes, a >64 MiB restore interruption, interrupted VACUUM, compaction, and post-compaction restore. The second execution added roughly half the file's 59-67 second cost but only checked reused-state artifact isolation.

## Why This Change Was Made

Seed a real initialized state database with a stale reliability row and a retained prior-run artifact before one complete reliability proof. The retained run directly verifies stale-row cleanup, isolated sync repository selection, prior-artifact preservation, four concurrent restores, seven total restores, and every exact machine-readable CLI proof marker.

This removes duplicate expensive execution rather than weakening the smoke profile or adding a test-only production mode. Crash, restore, publication, repository, index-repair, VACUUM, compaction, WAL-limit, path-alias, and writer-disconnect contracts remain covered. No production code or CI worker count changes; all five tests remain.

## User Impact

Across repeated hosted runs, the median `bench-sqlite-reliability.test.ts` time falls from **59.249s to 35.032s (40.9% faster)**, lowering the compact tooling lane cost without reducing unique reliability coverage.

## Evidence

Baseline:

- Actions run: https://github.com/openclaw/openclaw/actions/runs/31464051869
- Timing job: https://github.com/openclaw/openclaw/actions/runs/31464051869/job/93693336976
- `bench-sqlite-reliability.test.ts`: **59.249s**, 5/5 passed
- Other comparable baseline samples: **58.344s** and **67.157s**

Patch-identical exact-head proof from superseded #121895:

- Actions run: https://github.com/openclaw/openclaw/actions/runs/31471155906
- Timing job: https://github.com/openclaw/openclaw/actions/runs/31471155906/job/93714926632
- `bench-sqlite-reliability.test.ts`: **35.204s**, 5/5 passed — **40.6% faster**
- `core-tooling-3`: 100/100 files passed; 2,496 tests passed, 2 skipped
- Entire exact-head CI run: green

Additional changed samples were **33.299s**, **34.088s**, **34.860s**, and **36.929s**, all at least 37.7% faster than the exact baseline.

Current PR exact-head confirmation:

- Actions run: https://github.com/openclaw/openclaw/actions/runs/31472577384
- Timing job: https://github.com/openclaw/openclaw/actions/runs/31472577384/job/93719914861
- `bench-sqlite-reliability.test.ts`: **42.775s**, 5/5 passed
- `core-tooling-3`: 100/100 files passed; 2,496 tests passed, 2 skipped
- This was the noisiest changed sample; the unrelated `test-projects.test.ts` in the same shard also ran at **27.877s** versus its recent **22.943-25.570s** range. The six changed hosted samples have a stable **35.032s median**, **40.9% faster** than the three-sample baseline median.

Focused/local proof on Node 24.15.0:

- `node scripts/run-vitest.mjs test/scripts/bench-sqlite-reliability.test.ts` — 5/5 passed
- `oxfmt --check test/scripts/bench-sqlite-reliability.test.ts`
- `git diff --check`
- TruffleHog: 0 verified or unverified secrets

Independent review required preserving exact 4/7 restore counts and every CLI proof marker; both were restored before the green exact-head run.
