### PR TITLE
fix(doctor): surface warning-only channel results

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -2150,6 +2150,40 @@ describe("doctor config flow", () => {
     });
   });
 
+  it("emits warning-only stale channel cleanup without changing config", async () => {
+    const input = {
+      agents: { entries: { ops: { default: true } } },
+      channels: { matrix: { enabled: true } },
+    };
+    const channelDoctor = await import("./doctor/shared/channel-doctor.js");
+    vi.mocked(channelDoctor.collectChannelDoctorStaleConfigMutations).mockResolvedValueOnce([
+      {
+        config: { ...input, channels: { matrix: { enabled: false } } },
+        changes: [],
+        warnings: ["- matrix stale cleanup warning"],
+      },
+    ]);
+    runDoctorRepairSequenceMock.mockImplementation(async (params: { state: unknown }) => ({
+      state: params.state,
+      changeNotes: [],
+      warningNotes: [],
+      authProfilesRepaired: false,
+    }));
+
+    const result = await runDoctorConfigWithInput({
+      config: input,
+      repair: true,
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+
+    expect(terminalNoteMock).toHaveBeenCalledWith(
+      "- matrix stale cleanup warning",
+      "Doctor warnings",
+    );
+    expect(result.cfg).toEqual(input);
+    expect(result.shouldWriteConfig).toBe(false);
+  });
+
   it("previews and repairs hooks token reuse of gateway auth", async () => {
     const config = {
       gateway: {

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -425,6 +425,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
       applyConfigMutation(staleCleanup, {
         fixHint: `Run "${doctorFixCommand}" to remove stale channel plugin references.`,
         sanitize: true,
+        emitWarnings: true,
       });
     }
   }

--- a/src/commands/doctor/shared/channel-doctor.test.ts
+++ b/src/commands/doctor/shared/channel-doctor.test.ts
@@ -185,6 +185,44 @@ describe("channel doctor compatibility mutations", () => {
     expect(discordCleanup).not.toHaveBeenCalled();
   });
 
+  it("retains warning-only stale results without advancing config", async () => {
+    const cfg = {
+      channels: {
+        matrix: { enabled: true },
+        discord: { enabled: true },
+      },
+    };
+    const alternateConfig = {
+      ...cfg,
+      channels: { ...cfg.channels, matrix: { enabled: false } },
+    };
+    const matrixCleanup = vi.fn(() => ({
+      config: alternateConfig,
+      changes: [],
+      warnings: ["matrix warning"],
+    }));
+    const discordCleanup = vi.fn(({ cfg }: { cfg: unknown }) => ({
+      config: cfg,
+      changes: ["discord cleanup"],
+    }));
+    mocks.getBundledChannelSetupPlugin.mockImplementation((id: string) => ({
+      id,
+      doctor: {
+        cleanStaleConfig: id === "matrix" ? matrixCleanup : discordCleanup,
+      },
+    }));
+
+    const result = await collectChannelDoctorStaleConfigMutations(cfg as never, {
+      channelIds: ["matrix", "discord"],
+    });
+
+    expect(result).toEqual([
+      { config: cfg, changes: [], warnings: ["matrix warning"] },
+      { config: cfg, changes: ["discord cleanup"] },
+    ]);
+    expect(discordCleanup).toHaveBeenCalledWith({ cfg });
+  });
+
   it("skips plugin discovery for explicitly disabled channels", () => {
     const result = collectChannelDoctorCompatibilityMutations({
       channels: {

--- a/src/commands/doctor/shared/channel-doctor.test.ts
+++ b/src/commands/doctor/shared/channel-doctor.test.ts
@@ -201,8 +201,8 @@ describe("channel doctor compatibility mutations", () => {
       changes: [],
       warnings: ["matrix warning"],
     }));
-    const discordCleanup = vi.fn(({ cfg }: { cfg: unknown }) => ({
-      config: cfg,
+    const discordCleanup = vi.fn(({ cfg: currentCfg }: { cfg: unknown }) => ({
+      config: currentCfg,
       changes: ["discord cleanup"],
     }));
     mocks.getBundledChannelSetupPlugin.mockImplementation((id: string) => ({

--- a/src/commands/doctor/shared/channel-doctor.ts
+++ b/src/commands/doctor/shared/channel-doctor.ts
@@ -245,6 +245,21 @@ function shouldSkipDefaultEmptyGroupAllowlistWarningForEntries(
   );
 }
 
+function appendChannelDoctorMutation(
+  mutations: ChannelDoctorConfigMutation[],
+  currentCfg: OpenClawConfig,
+  mutation: ChannelDoctorConfigMutation | undefined,
+): OpenClawConfig {
+  if (mutation?.changes.length) {
+    mutations.push(mutation);
+    return mutation.config;
+  }
+  if (mutation?.warnings?.length) {
+    mutations.push({ config: currentCfg, changes: [], warnings: mutation.warnings });
+  }
+  return currentCfg;
+}
+
 /** Build cached empty-allowlist hooks backed by channel doctor adapters. */
 export function createChannelDoctorEmptyAllowlistPolicyHooks(
   context: ChannelDoctorLookupContext,
@@ -299,18 +314,11 @@ export function collectChannelDoctorCompatibilityMutations(
   options: { env?: NodeJS.ProcessEnv } = {},
 ): ChannelDoctorConfigMutation[] {
   const channelIds = collectConfiguredChannelIds(cfg);
-  if (channelIds.length === 0) {
-    return [];
-  }
   const mutations: ChannelDoctorConfigMutation[] = [];
   let nextCfg = cfg;
   for (const entry of listChannelDoctorEntries(channelIds, { cfg, env: options.env })) {
     const mutation = entry.doctor.normalizeCompatibilityConfig?.({ cfg: nextCfg });
-    if (!mutation || mutation.changes.length === 0) {
-      continue;
-    }
-    mutations.push(mutation);
-    nextCfg = mutation.config;
+    nextCfg = appendChannelDoctorMutation(mutations, nextCfg, mutation);
   }
   return mutations;
 }
@@ -328,11 +336,7 @@ export async function collectChannelDoctorStaleConfigMutations(
     env: options.env,
   })) {
     const mutation = await entry.doctor.cleanStaleConfig?.({ cfg: nextCfg });
-    if (!mutation || mutation.changes.length === 0) {
-      continue;
-    }
-    mutations.push(mutation);
-    nextCfg = mutation.config;
+    nextCfg = appendChannelDoctorMutation(mutations, nextCfg, mutation);
   }
   return mutations;
 }
@@ -402,14 +406,7 @@ export async function collectChannelDoctorRepairMutations(params: {
       doctorFixCommand: params.doctorFixCommand,
       ...(params.env ? { env: params.env } : {}),
     });
-    if (!mutation || mutation.changes.length === 0) {
-      if (mutation?.warnings?.length) {
-        mutations.push({ config: nextCfg, changes: [], warnings: mutation.warnings });
-      }
-      continue;
-    }
-    mutations.push(mutation);
-    nextCfg = mutation.config;
+    nextCfg = appendChannelDoctorMutation(mutations, nextCfg, mutation);
   }
   return mutations;
 }


### PR DESCRIPTION
Closes #121948

## What Problem This Solves

Fixes a silent Doctor outcome where channel plugins returned actionable warning-only compatibility or stale-config results, but core aggregation discarded them because `changes` was empty. Signal could explain why a legacy transport was unsafe to migrate, while `openclaw doctor --fix` printed no matching warning and left the operator to repeat the same command.

## Why This Change Was Made

A single channel-Doctor mutation policy now preserves warnings independently from changes. Config advances only when `changes` is non-empty; warning-only results are retained against the current config. The stale-cleanup caller enables the existing sanitized warning emitter. Signal producers, public types, schema, migration behavior, and `applyDoctorConfigMutation` semantics are unchanged.

## User Impact

Operators now see the channel-specific remediation warning when Doctor intentionally leaves configuration unchanged. Warning-only results remain non-mutating and do not cause a config write.

## Evidence

- Pre-fix focused regression: two intended failures, 76 passing.
- Post-fix: `node scripts/run-vitest.mjs src/commands/doctor/shared/channel-doctor.test.ts src/commands/doctor-config-flow.test.ts` — 78 passed.
- Regression proves warning-only stale results are retained without advancing config or setting `shouldWriteConfig`.
- Targeted formatting and `git diff --check` passed.
- Changed-gate classification is limited to core/coreTests.
- Mandatory autoreview and TruffleHog were clean.
- Production delta: +19/-21 (net -2); tests: +72/-0.
- No plugin SDK, schema, migration, persistent-state, or Signal producer change.

AI-assisted implementation; no agent transcript attached.