### PR TITLE
fix(ui): confirm destructive session actions in an owned dialog

### DIFF
--- a/ui/src/components/confirm-dialog.ts
+++ b/ui/src/components/confirm-dialog.ts
@@ -85,3 +85,11 @@ export function showConfirmDialog(options: ConfirmDialogOptions): Promise<boolea
     confirmationActive = false;
   });
 }
+
+/** Danger-styled confirm for destructive session mutations (no browser chrome). */
+export function confirmDangerous(
+  message: string,
+  confirmLabel: string = t("common.delete"),
+): Promise<boolean> {
+  return showConfirmDialog({ message, confirmLabel, danger: true });
+}

--- a/ui/src/components/session-organizer-operations.runtime.ts
+++ b/ui/src/components/session-organizer-operations.runtime.ts
@@ -15,7 +15,7 @@ import type {
   SidebarSessionPatch,
 } from "./app-sidebar-session-types.ts";
 import { requestCloudWorkerStop } from "./cloud-worker-stop.ts";
-import { showConfirmDialog } from "./confirm-dialog.ts";
+import { confirmDangerous, showConfirmDialog } from "./confirm-dialog.ts";
 import type { SessionMenuAction } from "./session-menu.ts";
 import {
   patchSessionRows,
@@ -246,7 +246,11 @@ export async function deleteSessionsBatch(
   if (rows.length === 0) {
     return;
   }
-  if (!window.confirm(t("sessionsView.deleteSessionsConfirm", { count: String(rows.length) }))) {
+  if (
+    !(await confirmDangerous(
+      t("sessionsView.deleteSessionsConfirm", { count: String(rows.length) }),
+    ))
+  ) {
     return;
   }
   if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
@@ -610,7 +614,10 @@ export async function stopCloudWorker(
   if (
     !stopAction ||
     (stopAction.method === "sessions.reclaim" && session.hasActiveRun) ||
-    !window.confirm(t("sessionsView.stopCloudWorkerConfirm", { session: session.label }))
+    !(await confirmDangerous(
+      t("sessionsView.stopCloudWorkerConfirm", { session: session.label }),
+      t("sessionsView.stopCloudWorkerConfirmAction"),
+    ))
   ) {
     return;
   }
@@ -648,7 +655,9 @@ export async function deleteSession(
   session: SessionActionRow,
   scope: SidebarSessionMutationScope,
 ) {
-  if (!window.confirm(t("sessionsView.deleteSessionConfirm", { session: session.label }))) {
+  if (
+    !(await confirmDangerous(t("sessionsView.deleteSessionConfirm", { session: session.label })))
+  ) {
     return;
   }
   if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
@@ -696,11 +705,14 @@ export async function deleteSession(
         if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
           return;
         }
-      } else if (
-        window.confirm(
-          t("sessionsView.deletePreservedWorktreeConfirm", { branch: preserved.branch }),
-        )
-      ) {
+      } else {
+        if (
+          !(await confirmDangerous(
+            t("sessionsView.deletePreservedWorktreeConfirm", { branch: preserved.branch }),
+          ))
+        ) {
+          return;
+        }
         if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
           return;
         }

--- a/ui/src/test-helpers/app-sidebar-cases/interactions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/interactions.ts
@@ -9,6 +9,7 @@ import {
   loadStoredHiddenSessionCatalogIds,
   setStoredSessionCatalogHidden,
 } from "../../components/app-sidebar-session-types.ts";
+import { confirmDangerous } from "../../components/confirm-dialog.ts";
 import { TERMINAL_PANEL_TOGGLE_EVENT } from "../../components/panel-toggle-contract.ts";
 import { CATALOG_SESSION_CONTINUED_EVENT } from "../../lib/sessions/catalog-key.ts";
 import {
@@ -239,29 +240,25 @@ describe("AppSidebar multi-select", () => {
   });
 
   it("deletes the selection in one batch after a single confirm", async () => {
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    try {
-      const { sidebar, harness } = await mountMultiSelect();
+    vi.mocked(confirmDangerous).mockResolvedValueOnce(true);
+    const { sidebar, harness } = await mountMultiSelect();
 
-      click(rowLink(sidebar, "agent:main:a"), { metaKey: true });
-      click(rowLink(sidebar, "agent:main:b"), { metaKey: true });
-      await sidebar.updateComplete;
-      openContextMenu(sidebar, "agent:main:b");
-      await sidebar.updateComplete;
+    click(rowLink(sidebar, "agent:main:a"), { metaKey: true });
+    click(rowLink(sidebar, "agent:main:b"), { metaKey: true });
+    await sidebar.updateComplete;
+    openContextMenu(sidebar, "agent:main:b");
+    await sidebar.updateComplete;
 
-      const menu = await sessionMenu(sidebar);
-      menu.querySelector<HTMLButtonElement>('[data-shortcut="d"]')?.click();
+    const menu = await sessionMenu(sidebar);
+    menu.querySelector<HTMLButtonElement>('[data-shortcut="d"]')?.click();
 
-      await waitForFast(() => expect(harness.deleteMany).toHaveBeenCalledOnce());
-      expect(confirmSpy).toHaveBeenCalledOnce();
-      expect(confirmSpy.mock.calls[0]?.[0]).toContain("2");
-      expect(harness.deleteMany).toHaveBeenCalledWith([
-        { key: "agent:main:a", agentId: "main", deleteTranscript: true },
-        { key: "agent:main:b", agentId: "main", deleteTranscript: true },
-      ]);
-    } finally {
-      confirmSpy.mockRestore();
-    }
+    await waitForFast(() => expect(harness.deleteMany).toHaveBeenCalledOnce());
+    expect(confirmDangerous).toHaveBeenCalledOnce();
+    expect(vi.mocked(confirmDangerous).mock.calls[0]?.[0]).toContain("2");
+    expect(harness.deleteMany).toHaveBeenCalledWith([
+      { key: "agent:main:a", agentId: "main", deleteTranscript: true },
+      { key: "agent:main:b", agentId: "main", deleteTranscript: true },
+    ]);
   });
 
   it("retargets the menu to an unselected row and drops the selection", async () => {

--- a/ui/src/test-helpers/app-sidebar-cases/session-delete-access.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-delete-access.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { confirmDangerous } from "../../components/confirm-dialog.ts";
 import {
   createGatewayHarness,
   createSessionsHarness,
@@ -59,7 +60,7 @@ describe("AppSidebar session delete access", () => {
       deleted: true,
       worktreePreserved: { id: "wt-1", branch: "feature", path: "/tmp/worktree" },
     });
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(confirmDangerous).mockResolvedValueOnce(true);
     const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => undefined);
     try {
       const menu = await openSessionMenu(sidebar, archived.key);
@@ -67,10 +68,9 @@ describe("AppSidebar session delete access", () => {
       await waitForFast(() => expect(harness.deleteSession).toHaveBeenCalledOnce());
       await waitForFast(() => expect(alertSpy).toHaveBeenCalledOnce());
 
-      expect(confirmSpy).toHaveBeenCalledOnce();
+      expect(confirmDangerous).toHaveBeenCalledOnce();
       expect(request).not.toHaveBeenCalledWith("worktrees.remove", expect.anything());
     } finally {
-      confirmSpy.mockRestore();
       alertSpy.mockRestore();
     }
   });

--- a/ui/src/test-helpers/app-sidebar-cases/sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/sessions.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { confirmDangerous } from "../../components/confirm-dialog.ts";
 import {
   createContext,
   createGateway,
@@ -488,13 +489,13 @@ describe("AppSidebar session mutation feedback", () => {
     };
     harness.publishList({ result: state.result, agentId: state.agentId });
     await sidebar.updateComplete;
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(confirmDangerous).mockResolvedValueOnce(true);
 
     const menu = await openSessionMenu(sidebar, row.key);
     menu.querySelector<HTMLElement>('[value="stop-cloud-worker"]')?.click();
 
     await waitForFast(() => expect(request).toHaveBeenCalledOnce());
-    expect(confirm).toHaveBeenCalledWith('Stop the cloud worker for "a"?');
+    expect(vi.mocked(confirmDangerous).mock.calls[0]?.[0]).toBe('Stop the cloud worker for "a"?');
     expect(request).toHaveBeenCalledWith(
       "sessions.reclaim",
       { key: "agent:main:a", agentId: "main" },
@@ -532,13 +533,13 @@ describe("AppSidebar session mutation feedback", () => {
     harness.publishList({ result: state.result, agentId: state.agentId });
     const toast = await mountToastHost();
     await sidebar.updateComplete;
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(confirmDangerous).mockResolvedValueOnce(true);
 
     const menu = await openSessionMenu(sidebar, row.key);
     menu.querySelector<HTMLElement>('[value="stop-cloud-worker"]')?.click();
 
     await waitForFast(() => expect(request).toHaveBeenCalledOnce());
-    expect(confirm).toHaveBeenCalledWith('Stop the cloud worker for "a"?');
+    expect(vi.mocked(confirmDangerous).mock.calls[0]?.[0]).toBe('Stop the cloud worker for "a"?');
     expect(request).toHaveBeenCalledWith("environments.destroy", {
       environmentId: "environment-1",
     });
@@ -582,26 +583,22 @@ describe("AppSidebar session mutation feedback", () => {
       errors: ["agent:main:b: permission denied"],
       preservedWorktrees: [],
     });
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    try {
-      selectSession(sidebar, "agent:main:a");
-      selectSession(sidebar, "agent:main:b");
-      await sidebar.updateComplete;
-      const row = sidebar.querySelector('[data-session-key="agent:main:b"]');
-      row?.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
-      await sidebar.updateComplete;
-      const menu = sidebar.querySelector<TestSessionMenu>("openclaw-session-menu");
-      await menu?.updateComplete;
-      menu?.querySelector<HTMLButtonElement>('[data-shortcut="d"]')?.click();
+    vi.mocked(confirmDangerous).mockResolvedValueOnce(true);
+    selectSession(sidebar, "agent:main:a");
+    selectSession(sidebar, "agent:main:b");
+    await sidebar.updateComplete;
+    const row = sidebar.querySelector('[data-session-key="agent:main:b"]');
+    row?.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    await sidebar.updateComplete;
+    const menu = sidebar.querySelector<TestSessionMenu>("openclaw-session-menu");
+    await menu?.updateComplete;
+    menu?.querySelector<HTMLButtonElement>('[data-shortcut="d"]')?.click();
 
-      await waitForFast(() => {
-        expect(sidebar.querySelector("[data-sidebar-session-error]")?.textContent).toContain(
-          "agent:main:b: permission denied",
-        );
-      });
-    } finally {
-      confirmSpy.mockRestore();
-    }
+    await waitForFast(() => {
+      expect(sidebar.querySelector("[data-sidebar-session-error]")?.textContent).toContain(
+        "agent:main:b: permission denied",
+      );
+    });
   });
 
   it("surfaces ordered partial batch-archive errors", async () => {
@@ -734,22 +731,21 @@ describe("AppSidebar session mutation feedback", () => {
       worktreePreserved: { id: "wt-1", branch: "feature", path: "/tmp/worktree" },
     });
     let confirmations = 0;
-    const confirmSpy = vi.spyOn(window, "confirm").mockImplementation(() => {
-      confirmations += 1;
-      if (confirmations === 2) {
+    vi.mocked(confirmDangerous)
+      .mockImplementationOnce(async () => {
+        confirmations += 1;
+        return true;
+      })
+      .mockImplementationOnce(async () => {
+        confirmations += 1;
         gateway.publish({ phase: "reconnecting" });
         gateway.publish({ phase: "connected" });
-      }
-      return true;
-    });
-    try {
-      const menu = await openSessionMenu(sidebar, "agent:main:a");
-      menu.querySelector<HTMLButtonElement>('[data-shortcut="d"]')?.click();
-      await waitForFast(() => expect(confirmations).toBe(2));
+        return true;
+      });
+    const menu = await openSessionMenu(sidebar, "agent:main:a");
+    menu.querySelector<HTMLButtonElement>('[data-shortcut="d"]')?.click();
+    await waitForFast(() => expect(confirmations).toBe(2));
 
-      expect(request).not.toHaveBeenCalled();
-    } finally {
-      confirmSpy.mockRestore();
-    }
+    expect(request).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/test-helpers/app-sidebar-suite.ts
+++ b/ui/src/test-helpers/app-sidebar-suite.ts
@@ -1,3 +1,18 @@
+import { beforeEach, vi } from "vitest";
+import { confirmDangerous } from "../components/confirm-dialog.ts";
 import { setupSidebarTest } from "./app-sidebar.ts";
+
+// The sidebar session mutations confirm in-page through confirmDangerous.
+// Group-delete cases drive the real dialog DOM, while session delete/stop
+// cases override it per call; default to the real implementation so both
+// shapes keep working in this shared suite.
+vi.mock("../components/confirm-dialog.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../components/confirm-dialog.ts")>();
+  return { ...actual, confirmDangerous: vi.fn(actual.confirmDangerous) };
+});
+
+beforeEach(() => {
+  vi.mocked(confirmDangerous).mockClear();
+});
 
 setupSidebarTest();


### PR DESCRIPTION
## What Problem

Fixes #121702. In the Control UI sidebar, "Delete..." on a session (single, batch, or archived with preserved worktree) and "Stop cloud worker" had no visible effect on the macOS desktop app: no confirmation appeared and the action never ran. The same report's rename path was already repaired on main with an in-app dialog; the delete/stop paths were the remaining defect.

## Why

The sidebar mutation operations confirmed through `window.confirm`. The Control UI also ships in webviews (macOS desktop app) where the native confirm answers silently (`false`) with no visible feedback, so the reported action produced no outcome — the operator clicked Delete and nothing happened, with no error. The sibling group-delete path (#121738) already moved off browser chrome onto the owned in-app confirm dialog; these four paths were the last `window.confirm` stragglers in the session organizer.

## User Impact

Delete (single and batch), stop-cloud-worker, and preserved-worktree removal now show the themed in-app confirmation dialog (danger-styled, Cancel focused, no opt-out) instead of a native prompt that silently no-ops in desktop webviews. Cancelling returns to the prior state; confirming performs the mutation with the mutation scope reproven after the dialog settles, matching the group-delete behavior. No i18n changes needed — existing keys (`deleteSessionConfirm`, `deleteSessionsConfirm`, `stopCloudWorkerConfirm`, `deletePreservedWorktreeConfirm`, `common.delete`) are reused.

## Evidence

`pnpm vitest run --config vitest.config.ts src/components/app-sidebar.test.ts` — full sidebar suite, 252 passed (delete/stop/confirm-cancel/reconnect-stale cases included):

```text
Test Files  1 passed (1)
     Tests  252 passed (252)
 Start at  16:29:23
 Duration  21.30s (transform 2.66s, setup 2.94s, tests 17.08s, environment 905ms)
```

Lint and format on all touched files:

```text
$ npx oxlint src/components/session-organizer-operations.runtime.ts src/components/confirm-dialog.ts src/test-helpers/app-sidebar-suite.ts src/test-helpers/app-sidebar-cases/interactions.ts src/test-helpers/app-sidebar-cases/session-delete-access.ts src/test-helpers/app-sidebar-cases/sessions.ts
Found 0 warnings and 0 errors.

$ npx oxfmt --check <same files>
All matched files use the correct format.
```

The suite now drives the owned dialog: `app-sidebar-suite.ts` mocks `confirmDangerous` (the new shared helper in `confirm-dialog.ts`), and the delete/stop cases assert the confirm is shown once with the right copy before the mutation request fires.

[AI-assisted] — implemented and verified with automated tooling; human review requested for merge.
