### PR TITLE
test(ios): remove preview source mirrors

### DIFF
--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -527,21 +527,6 @@ struct RootTabsSourceGuardTests {
         #expect(source.contains("content.scrollEdgeEffectStyle(.soft, for: .vertical)"))
         #expect(!source.contains(".background(Color(uiColor: .systemBackground))"))
     }
-
-    @Test func `shared chat preview matrix covers connection states`() throws {
-        let source = try String(contentsOf: Self.sharedChatPreviewSourceURL(), encoding: .utf8)
-
-        #expect(source.contains("#Preview(\"Chat connected\")"))
-        #expect(source.contains("#Preview(\"Chat empty\")"))
-        #expect(source.contains("#Preview(\"Chat loading\")"))
-        #expect(source.contains("#Preview(\"Chat gateway error\")"))
-        #expect(source.contains("enum Scenario"))
-        #expect(source.contains("case connected"))
-        #expect(source.contains("case empty"))
-        #expect(source.contains("case loading"))
-        #expect(source.contains("case error"))
-        #expect(source.contains("Gateway not connected. Check Tailscale and retry."))
-    }
 }
 
 extension RootTabsSourceGuardTests {
@@ -657,7 +642,6 @@ extension RootTabsSourceGuardTests {
 
     @Test func `skill workshop uses kanban lanes on wide I pad`() throws {
         let source = try String(contentsOf: Self.iPadSkillWorkshopScreenSourceURL(), encoding: .utf8)
-        let previewSource = try String(contentsOf: Self.iPadSidebarFeaturePreviewsSourceURL(), encoding: .utf8)
         let content = try Self.extract(
             source,
             from: "private var proposalContent: some View",
@@ -676,61 +660,6 @@ extension RootTabsSourceGuardTests {
         #expect(source.contains("private struct IPadSkillProposalKanbanCard"))
         #expect(source.contains("static let defaultProposalStatusBoardLanes"))
         #expect(source.contains("private func proposals(forLaneStatus status: String)"))
-        #expect(previewSource.contains("#Preview(\n    \"Skill Workshop iPad kanban lanes\""))
-        #expect(previewSource.contains("private struct IPadSkillWorkshopKanbanPreview"))
-        #expect(previewSource.contains("IPadSkillProposalKanbanColumn("))
-        #expect(previewSource.contains("status: \"needs-review\""))
-        #expect(previewSource.contains("status: \"manual_QA\""))
-    }
-
-    @Test func `compact task rows have populated phone previews`() throws {
-        let source = try String(contentsOf: Self.iPadSidebarFeaturePreviewsSourceURL(), encoding: .utf8)
-
-        #expect(source.contains("#Preview(\"Workboard phone queue rows\")"))
-        #expect(source.contains("#Preview(\"Skill Workshop phone queue rows\")"))
-        #expect(source.contains("private struct IPadWorkboardCompactRowsPreview"))
-        #expect(source.contains("private struct IPadSkillWorkshopCompactRowsPreview"))
-        #expect(source.contains("IPadWorkboardPreviewFixtures.cards"))
-        #expect(source.contains("IPadSkillWorkshopPreviewFixtures.proposals"))
-    }
-
-    @Test func `task screen preview matrices cover primary states`() throws {
-        let source = try String(contentsOf: Self.iPadSidebarFeaturePreviewsSourceURL(), encoding: .utf8)
-
-        #expect(source.contains("#Preview(\"Workboard states\")"))
-        #expect(source.contains("private struct IPadWorkboardStatesPreview"))
-        #expect(source.contains("self.previewHeader(\"Connected\")"))
-        #expect(source.contains("self.previewHeader(\"Empty\")"))
-        #expect(source.contains("self.previewHeader(\"Loading\")"))
-        #expect(source.contains("self.previewHeader(\"Error\")"))
-        #expect(source.contains("title: \"Loading cards\""))
-        #expect(source.contains("title: \"Cards unavailable\""))
-        #expect(source.contains("IPadWorkboardKanbanColumn("))
-
-        #expect(source.contains("#Preview(\"Skill Workshop states\")"))
-        #expect(source.contains("private struct IPadSkillWorkshopStatesPreview"))
-        #expect(source.contains("self.previewHeader(\"Offline / Error\")"))
-        #expect(source.contains("title: \"No proposals\""))
-        #expect(source.contains("title: \"Workshop offline\""))
-        #expect(source.contains("title: \"Proposal unavailable\""))
-        #expect(source.contains("#Preview(\n    \"Skill Workshop iPad kanban lanes\""))
-        #expect(source.contains("private struct IPadSkillWorkshopKanbanPreview"))
-        #expect(source.contains("\"needs-review\""))
-        #expect(source.contains("\"manual_QA\""))
-    }
-
-    @Test func `activity preview matrix covers connection states`() throws {
-        let source = try String(contentsOf: Self.iPadSidebarFeaturePreviewsSourceURL(), encoding: .utf8)
-
-        #expect(source.contains("#Preview(\"Activity states\")"))
-        #expect(source.contains("private struct IPadActivityStatesPreview"))
-        #expect(source.contains("self.previewHeader(\"Connected\")"))
-        #expect(source.contains("self.previewHeader(\"Loading\")"))
-        #expect(source.contains("self.previewHeader(\"Empty\")"))
-        #expect(source.contains("self.previewHeader(\"Error\")"))
-        #expect(source.contains("title: \"Sessions unavailable\""))
-        #expect(source.contains("title: \"No recent sessions\""))
-        #expect(source.contains("title: \"Loading sessions\""))
     }
 
     @Test func `routed feature screens reuse shared pro components`() throws {
@@ -1323,22 +1252,6 @@ extension RootTabsSourceGuardTests {
             .contains("self.gatewayController.requestLocalNetworkAccess(reason: \"settings_preflight\")"))
     }
 
-    @Test func `gateway settings preview matrix covers primary states`() throws {
-        let supportSource = try String(contentsOf: Self.settingsProTabSupportSourceURL(), encoding: .utf8)
-
-        #expect(supportSource.contains("#Preview(\"Gateway settings states\")"))
-        #expect(supportSource.contains("private struct SettingsGatewayStatesPreview"))
-        #expect(supportSource.contains("self.stateSection(\"Connected\")"))
-        #expect(supportSource.contains("self.stateSection(\"Loading\")"))
-        #expect(supportSource.contains("self.stateSection(\"Empty\")"))
-        #expect(supportSource.contains("self.stateSection(\"Error\")"))
-        #expect(supportSource.contains("Tailscale is off on this device. Turn it on, then try again."))
-        #expect(supportSource.contains("self.previewButton(\"Scan QR\""))
-        #expect(supportSource.contains("self.previewButton(\"Connect\""))
-        #expect(supportSource.contains("self.previewButton(\"Reconnect\""))
-        #expect(supportSource.contains("self.previewButton(\"Diagnose\""))
-    }
-
     @Test func `native chat uses gateway transport`() throws {
         let chatSource = try String(contentsOf: Self.chatProTabSourceURL(), encoding: .utf8)
         let channelsSource = try String(contentsOf: Self.channelsSourceURL(), encoding: .utf8)
@@ -1713,13 +1626,6 @@ extension RootTabsSourceGuardTests {
             .appendingPathComponent("Sources/Design/IPadSkillWorkshopScreen.swift")
     }
 
-    private static func iPadSidebarFeaturePreviewsSourceURL() -> URL {
-        URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .appendingPathComponent("Sources/Design/IPadSidebarFeaturePreviews.swift")
-    }
-
     private static func iPadActivityScreenSourceURL() -> URL {
         URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
@@ -1877,14 +1783,6 @@ extension RootTabsSourceGuardTests {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .appendingPathComponent("Sources/Design/SettingsSkillsDestination.swift")
-    }
-
-    private static func sharedChatPreviewSourceURL() -> URL {
-        URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .appendingPathComponent("shared/OpenClawKit/Sources/OpenClawChatUI/ChatView+Previews.swift")
     }
 
     private static func sharedChatComposerSourceURL() -> URL {


### PR DESCRIPTION
## What Problem This Solves

`RootTabsSourceGuardTests` contained five tests that only mirrored exact `#Preview` names, private preview host types, fixture strings, and preview copy. They never rendered or instantiated a view and failed under harmless preview reorganization. A mixed kanban test also combined valuable production compact/wide wiring assertions with preview-only inventory checks.

## Why This Change Was Made

This change:

- deletes the shared-chat, compact-task-row, task-state, activity-state, and gateway-settings preview source inventories;
- narrows the kanban test to its production compact-list versus wide-board wiring, lane policy, and horizontal board construction;
- removes the two preview source URL helpers that become unused; and
- leaves all production previews untouched and compiled.

Behavior-bearing presentation and render coverage remains in `RootTabsPresentationTests` and `SwiftUIRenderSmokeTests`, while the retained source guard still independently checks the production kanban wiring.

AI-assisted: yes. The complete test file, preview owners, retained presentation/render coverage, history, and iOS CI routing were inspected; fresh structured review found no actionable issue.

## User Impact

No user-visible behavior change. Preview sources remain available to developers, with less exact-string inventory maintenance in the test suite.

## Evidence

- `./scripts/format-swift.sh ios` — 363 Swift files checked; clean.
- `./scripts/lint-swift.sh ios` — 363 Swift files linted; 0 violations.
- `node scripts/check-changed.mjs -- apps/ios/Tests/RootTabsSourceGuardTests.swift` — passed app static gates through trusted local fallback because Blacksmith Testbox is unavailable on this host.
- Fresh structured autoreview and secret scan — clean.
- `git diff --check` — clean.
- Local simulator test was attempted after confirming no real iOS device was connected, but project generation is unavailable on this host because `xcodegen` is not installed. Hosted `ios-build` remains the authoritative build and selected `RootTabsSourceGuardTests` proof.

Production delta: 0. Tests: −102 lines.
