### PR TITLE
refactor(gateway): centralize kernel dispatch gate ownership

### DIFF
--- a/src/gateway/server-core-runtime.ts
+++ b/src/gateway/server-core-runtime.ts
@@ -112,6 +112,7 @@ export async function startGatewayCoreRuntime(input: {
     agentRunSeq,
     nodeSendToSession,
     runtimeState,
+    kernel,
     startupTrace,
     activeTaskCount,
     channelManager,
@@ -361,11 +362,7 @@ export async function startGatewayCoreRuntime(input: {
     methods.push(...listStartupChannelGatewayMethods());
     return uniqueStrings(methods);
   };
-  runtimeState.gatewayMethods.splice(
-    0,
-    runtimeState.gatewayMethods.length,
-    ...listAttachedGatewayMethods(),
-  );
+  kernel.publishMethodSurface(listAttachedGatewayMethods());
   const replaceAttachedPluginRuntime = (loaded: {
     pluginRegistry: typeof pluginRuntime.registry;
     gatewayMethods: string[];
@@ -378,11 +375,7 @@ export async function startGatewayCoreRuntime(input: {
     Object.assign(attachedGatewayExtraHandlers, pluginRuntime.registry.gatewayHandlers);
     attachedPluginGatewayHandlerKeys = new Set(Object.keys(pluginRuntime.registry.gatewayHandlers));
     attachedGatewayMethodRegistry = buildAttachedGatewayMethodRegistry(pluginRuntime.registry);
-    runtimeState.gatewayMethods.splice(
-      0,
-      runtimeState.gatewayMethods.length,
-      ...listAttachedGatewayMethods(),
-    );
+    kernel.publishMethodSurface(listAttachedGatewayMethods());
     nodeRegistry.refreshNodePluginTools();
   };
   const refreshAttachedGatewayDiscovery = async (

--- a/src/gateway/server-lifecycle.ts
+++ b/src/gateway/server-lifecycle.ts
@@ -21,6 +21,7 @@ import {
 } from "../skills/runtime/remote.js";
 import type { RestartRecoveryCandidate } from "./chat-abort.js";
 import { createControlUiSessionPullRequestSubscriptions } from "./control-ui-session-pr-subscriptions.js";
+import { STARTUP_UNAVAILABLE_GATEWAY_METHODS } from "./methods/core-descriptors.js";
 import { disposeNodeConnectionNotifications } from "./node-connection-notifications.js";
 import { clearNodeWakeState } from "./node-wake-state.js";
 import { createLazyGatewayCronState } from "./server-cron-lazy.js";
@@ -65,6 +66,7 @@ export async function prepareGatewayLifecycle(params: {
     stopTaskRegistryMaintenanceOnDemand,
   } = params;
   const {
+    minimalTestGateway,
     controlUiDeviceAuthMigration,
     completeControlUiDeviceAuthMigration,
     workerGatewayEndpoint,
@@ -245,6 +247,27 @@ export async function prepareGatewayLifecycle(params: {
     gatewayMethods: listActiveGatewayMethods(pluginRuntime.baseGatewayMethods),
   });
   const runtimeState = runtimeStateRef.current;
+  const unavailableGatewayMethods = new Set<string>(
+    minimalTestGateway ? [] : STARTUP_UNAVAILABLE_GATEWAY_METHODS,
+  );
+  // Kernel methods are the only writers for readiness and advertised-method state.
+  // Residents use this surface so later ownership splits cannot mutate shared state directly.
+  const kernel = {
+    setDispatchReady: (ready: boolean) => {
+      startupState.dispatchReady = ready;
+    },
+    markSidecarsReady: () => {
+      startupState.sidecarsReady = true;
+    },
+    unlockStartupMethods: () => {
+      for (const method of STARTUP_UNAVAILABLE_GATEWAY_METHODS) {
+        unavailableGatewayMethods.delete(method);
+      }
+    },
+    publishMethodSurface: (methods: readonly string[]) => {
+      runtimeState.gatewayMethods.splice(0, runtimeState.gatewayMethods.length, ...methods);
+    },
+  };
   runtimeState.controlUiSessionPullRequests = createControlUiSessionPullRequestSubscriptions({
     broadcastToConnIds,
   });
@@ -317,7 +340,7 @@ export async function prepareGatewayLifecycle(params: {
     runtimeState.controlUiSessionPullRequests?.stop();
     runtimeState.sessionViewerPresence?.stop();
     unsubscribeEffectiveOperatorPairing();
-    startupState.dispatchReady = false;
+    kernel.setDispatchReady(false);
     gatewayInstanceRuntimeRef.current?.close();
     cronReconciliation.invalidate();
     clearPostReadyMaintenanceTimer();
@@ -519,6 +542,8 @@ export async function prepareGatewayLifecycle(params: {
     watchNodeHttpRuntime,
     terminalSessions,
     runtimeState,
+    unavailableGatewayMethods,
+    kernel,
     pluginHostServices,
     lifecycle,
     postReadyState,

--- a/src/gateway/server-startup-finish.ts
+++ b/src/gateway/server-startup-finish.ts
@@ -12,7 +12,6 @@ import type { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginHookGatewayCronService } from "../plugins/hook-types.js";
 import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
 import { createLazyPromise } from "../shared/lazy-runtime.js";
-import { STARTUP_UNAVAILABLE_GATEWAY_METHODS } from "./methods/core-descriptors.js";
 import { collectGatewayProcessMemoryUsageMb, finishGatewayRestartTrace } from "./restart-trace.js";
 import { createGatewayChatMetadataLifecycle } from "./server-chat-metadata-lifecycle.js";
 import type { startGatewayCoreRuntime } from "./server-core-runtime.js";
@@ -70,6 +69,8 @@ export async function finishGatewayStartup(params: {
     minimalTestGateway,
     deps,
     runtimeState,
+    unavailableGatewayMethods,
+    kernel,
     sessionCompanion,
     sessionObserver,
     getMcpAppSandboxPort,
@@ -195,9 +196,6 @@ export async function finishGatewayStartup(params: {
     stopRegisteredPostReadySidecars,
     clearFallbackGatewayContextForServer,
   } = runtime;
-  const unavailableGatewayMethods = new Set<string>(
-    minimalTestGateway ? [] : STARTUP_UNAVAILABLE_GATEWAY_METHODS,
-  );
   const chatMetadataLifecycle = await createGatewayChatMetadataLifecycle({
     getConfig: getRuntimeConfig,
     minimalTestGateway,
@@ -369,7 +367,7 @@ export async function finishGatewayStartup(params: {
     }),
   );
   await startupTrace.measure("http.listen", () => startListening());
-  startupState.dispatchReady = true;
+  kernel.setDispatchReady(true);
   startupTrace.mark("http.bound");
   const sessionDeliveryRecoveryMaxEnqueuedAt = Date.now();
   let postAttachRuntimeReturned = false;
@@ -447,7 +445,7 @@ export async function finishGatewayStartup(params: {
           recoveryRuntime: gatewayInstanceRuntimeLocal.recovery,
           logHooks,
           logChannels,
-          unavailableGatewayMethods,
+          unlockStartupMethods: kernel.unlockStartupMethods,
           refreshChatMetadata: chatMetadataLifecycle.refresh,
           loadStartupPlugins: async () => {
             const { loadGatewayStartupPluginRuntime } = await loadStartupPluginsModule();
@@ -516,7 +514,7 @@ export async function finishGatewayStartup(params: {
               }
             : {}),
           onSidecarsReady: () => {
-            startupState.sidecarsReady = true;
+            kernel.markSidecarsReady();
             activateScheduledServicesWhenReady();
           },
           isClosing: () => lifecycle.closePreludeStarted,

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -404,6 +404,14 @@ function firstStartupLog(): { loadedPluginIds?: string[] } {
   return mockCallArg(hoisted.logGatewayStartup) as { loadedPluginIds?: string[] };
 }
 
+function createStartupMethodUnlocker(unavailableGatewayMethods: Set<string>): () => void {
+  return () => {
+    for (const method of STARTUP_UNAVAILABLE_GATEWAY_METHODS) {
+      unavailableGatewayMethods.delete(method);
+    }
+  };
+}
+
 function createStartupTraceRecorder() {
   const details: Array<{
     name: string;
@@ -561,7 +569,7 @@ describe("startGatewayPostAttachRuntime", () => {
       ...createPostAttachParams(),
       getConfig: () => currentConfig,
       log,
-      unavailableGatewayMethods,
+      unlockStartupMethods: createStartupMethodUnlocker(unavailableGatewayMethods),
       onSidecarsReady,
     });
 
@@ -2584,7 +2592,7 @@ describe("startGatewayPostAttachRuntime", () => {
     await startGatewayPostAttachRuntime(
       {
         ...createPostAttachParams(),
-        unavailableGatewayMethods,
+        unlockStartupMethods: createStartupMethodUnlocker(unavailableGatewayMethods),
         sidecarStartup: "defer",
       },
       createPostAttachRuntimeDeps({ startGatewaySidecars: startGatewaySidecarsValue }),
@@ -2646,7 +2654,7 @@ describe("startGatewayPostAttachRuntime", () => {
     const runtimePromise = startGatewayPostAttachRuntime(
       {
         ...createPostAttachParams(),
-        unavailableGatewayMethods,
+        unlockStartupMethods: createStartupMethodUnlocker(unavailableGatewayMethods),
         sidecarStartup: "defer",
         startWorkerEnvironmentRuntime,
         onGatewayLifetimeSidecars,
@@ -3115,7 +3123,7 @@ function createPostAttachParams(overrides: Partial<PostAttachParams> = {}): Post
       info: vi.fn(),
       error: vi.fn(),
     },
-    unavailableGatewayMethods: new Set<string>(),
+    unlockStartupMethods: vi.fn(),
     providerAuthPrewarm: { enabled: false },
     ...overrides,
   };

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -27,7 +27,6 @@ import {
   projectUpdateAvailable,
   type GatewayUpdateAvailableEventPayload,
 } from "./events.js";
-import { STARTUP_UNAVAILABLE_GATEWAY_METHODS } from "./methods/core-descriptors.js";
 import type { GatewayBroadcastToConnIdsFn } from "./server-broadcast-types.js";
 import type { GatewayControlUiRootLifecycle } from "./server-control-ui-root.js";
 import type { GatewayRecoveryRuntime } from "./server-instance-runtime.types.js";
@@ -1076,7 +1075,7 @@ export async function startGatewayPostAttachRuntime(
       error: (msg: string) => void;
     };
     logChannels: { info: (msg: string) => void; error: (msg: string) => void };
-    unavailableGatewayMethods: Set<string>;
+    unlockStartupMethods: () => void;
     loadStartupPlugins?: () => Awaitable<{
       pluginRegistry: PluginRegistry;
       gatewayMethods: string[];
@@ -1318,9 +1317,7 @@ export async function startGatewayPostAttachRuntime(
         }
         // Capture the orphan-recovery cutoff before new startup-gated agent
         // work can create sessions that the recovery scan must leave alone.
-        for (const method of STARTUP_UNAVAILABLE_GATEWAY_METHODS) {
-          params.unavailableGatewayMethods.delete(method);
-        }
+        params.unlockStartupMethods();
         if (!pluginServicesReported) {
           reportPluginServices(result.pluginServices);
         }


### PR DESCRIPTION
## What Problem This Solves

Phase-2 PR 3 of the Gateway kernel split gives dispatch readiness, sidecar readiness, startup method availability, and the advertised method surface an explicit kernel owner. PR 2 landed as #121931 after the design-verified resident inventory and ownership-facet PR #121706.

## Why This Change Was Made

`prepareGatewayLifecycle` now creates one `kernel` control surface with `setDispatchReady`, `markSidecarsReady`, `unlockStartupMethods`, and `publishMethodSurface`. Existing startup, shutdown, sidecar, and plugin-replacement call sites invoke those methods in exactly their prior order instead of mutating `startupState`, `unavailableGatewayMethods`, or `runtimeState.gatewayMethods` directly.

The in-place method-array update is preserved so attached WebSocket consumers retain the same array identity. Dispatch still opens immediately after HTTP bind and closes synchronously before awaited teardown. Startup methods still unlock only after the orphan-recovery cutoff is captured, and scheduled services still activate only after post-attach return plus sidecar readiness.

There are no config, protocol, default, or user-visible behavior changes. Per the frozen sequence, stop after this PR lands: PRs 4-7 require a fresh coordinator review of the landed PR 2/3 seams before continuing.

## User Impact

No user-visible change. This behavior-neutral refactor makes kernel state ownership explicit for the later socket-free Gateway kernel extraction.

## Evidence

- `server-methods-list.test.ts`, `server-methods.suspension-admission.test.ts`, `server-startup-minimal-boot.test.ts`, `server-restart-deferral.test.ts`, and `server-startup-post-attach.test.ts` — 5 files, 105 passed
- `node scripts/check-changed.mjs -- <touched>` — core/core-test tsgo, lint, guards, import cycles, and runtime architecture lanes passed
- `pnpm build` — passed
- Codex autoreview — clean, no accepted/actionable findings

ClawSweeper review metrics: production `+36/-23` (net `+13`) for the explicit kernel ownership boundary; tests `+12/-4`. The added production surface replaces four resident/direct mutation paths with one canonical writer and preserves array identity and lifecycle ordering. AI-assisted; implementation and evidence were reviewed directly.
