### PR TITLE
fix(cli): execute mjs launcher fallback

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -34,6 +34,7 @@ import { defaultRuntime } from "./runtime.js";
 
 const ENTRY_WRAPPER_PAIRS = [
   { wrapperBasename: "openclaw.mjs", entryBasename: "entry.js" },
+  { wrapperBasename: "openclaw.mjs", entryBasename: "entry.mjs" },
   { wrapperBasename: "openclaw.js", entryBasename: "entry.js" },
 ] as const;
 

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -4,6 +4,7 @@ import { once } from "node:events";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { build } from "esbuild";
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "./helpers/temp-dir.js";
 
@@ -15,6 +16,29 @@ async function makeLauncherFixture(fixtureRoots: string[]): Promise<string> {
   );
   await fs.mkdir(path.join(fixtureRoot, "dist"), { recursive: true });
   return fixtureRoot;
+}
+
+async function addCompiledMjsEntryFixture(fixtureRoot: string): Promise<void> {
+  const sourceRoot = path.resolve(process.cwd(), "src");
+  await build({
+    bundle: true,
+    entryPoints: [path.join(sourceRoot, "entry.ts")],
+    format: "esm",
+    outfile: path.join(fixtureRoot, "dist", "entry.mjs"),
+    platform: "node",
+    plugins: [
+      {
+        name: "external-source-imports",
+        setup(build) {
+          build.onResolve({ filter: /^\./ }, ({ path: specifier, resolveDir }) => ({
+            external: true,
+            path: path.resolve(resolveDir, specifier.replace(/\.js$/u, ".ts")),
+          }));
+        },
+      },
+    ],
+    target: "node22",
+  });
 }
 
 async function makeLauncherProbeFixture(
@@ -327,6 +351,25 @@ describe("openclaw launcher", () => {
 
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain("missing dist/entry.(m)js");
+  });
+
+  it("executes an entry.mjs-only compiled entry through the root launcher", async () => {
+    const fixtureRoot = await makeLauncherFixture(fixtureRoots);
+    await addCompiledMjsEntryFixture(fixtureRoot);
+
+    const result = spawnSync(
+      process.execPath,
+      ["--import", import.meta.resolve("tsx"), path.join(fixtureRoot, "openclaw.mjs"), "--profile"],
+      {
+        cwd: process.cwd(),
+        env: launcherEnv({ OPENCLAW_NO_RESPAWN: "1" }),
+        encoding: "utf8",
+      },
+    );
+
+    expect(result.status, result.stderr).toBe(2);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("--profile requires a value");
   });
 
   it("treats Bun direct optional import misses as direct launcher misses", async () => {


### PR DESCRIPTION
Closes #121949

## What Problem This Solves

Fixes a silent launcher failure where `openclaw.mjs` accepted the supported packaged fallback `dist/entry.mjs`, but the compiled entrypoint's main-module guard recognized only `entry.js`. An `.mjs`-only artifact could therefore import successfully, skip every CLI side effect, and exit 0 without running the command.

## Why This Change Was Made

The entry bootstrap now maps the root `openclaw.mjs` wrapper to both currently supported entry candidates. A process-level regression builds the real compiled entry as `.mjs`, omits `.js`, and proves the root launcher reaches normal CLI argument handling. The fix does not add an artifact, fallback stack, public API, or test-only production export.

## User Impact

Packaged/source-archive variants containing only the supported `dist/entry.mjs` artifact now execute commands instead of reporting silent success.

## Evidence

- Pre-fix regression failed for the intended reason: expected CLI exit 2, received silent exit 0 with empty output.
- Post-fix focused regression passed.
- `node scripts/run-vitest.mjs src/infra/is-main.test.ts` — 9 passed.
- Testbox `tbx_01kzqyn0btdb7csvnww38gz2mc`: launcher E2E suite — 41 passed, 1 skipped. The outer delegated Actions wrapper was cancelled during/after lease cleanup; the completed Testbox result is the claimed proof.
- Targeted formatting and `git diff --check` passed.
- Mandatory autoreview and TruffleHog were clean.
- Production delta: +1/-0; tests: +43/-0.

AI-assisted implementation; no agent transcript attached.