### PR TITLE
fix(gateway): clear orphan execHost when unbinding execNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Gateway worker session unbinding:** clear node-only execution hosting together with its worker and workspace when sessions are unbound, while preserving explicit Gateway, sandbox, and automatic execution targets. Fixes #121965. (#121966) Thanks @zyw02.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Gateway worker session unbinding:** clear node-only execution hosting together with its worker and workspace when sessions are unbound, while preserving explicit Gateway, sandbox, and automatic execution targets. Fixes #121965. (#121966) Thanks @zyw02.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/src/gateway/server.sessions.exec-binding-rpc.test.ts
+++ b/src/gateway/server.sessions.exec-binding-rpc.test.ts
@@ -1,0 +1,44 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { expect, test } from "vitest";
+import { detectNodeClaudePlacement } from "../agents/cli-runner/prepare-claude.js";
+import { loadSessionEntry } from "../config/sessions/session-accessor.js";
+import { writeSessionStore } from "./test-helpers.js";
+import {
+  directSessionReq,
+  setupGatewaySessionsHandlerTestHarness,
+} from "./test/server-sessions.test-helpers.js";
+
+const { createSessionStoreDir } = setupGatewaySessionsHandlerTestHarness();
+
+test("sessions.patch clears the complete node binding before persisting an unbound session", async () => {
+  const { storePath } = await createSessionStoreDir();
+  await writeSessionStore({
+    entries: {
+      main: {
+        sessionId: "sess-exec-unbind",
+        updatedAt: Date.now(),
+        execHost: "node",
+        execNode: "worker-1",
+        execCwd: "/workspace/on-worker-1",
+      },
+    },
+  });
+
+  const unbound = await directSessionReq<{
+    entry: { execHost?: string; execNode?: string; execCwd?: string };
+  }>("sessions.patch", { key: "agent:main:main", execNode: null });
+
+  expect(unbound.ok).toBe(true);
+  expect(unbound.payload?.entry.execHost).toBeUndefined();
+  expect(unbound.payload?.entry.execNode).toBeUndefined();
+  expect(unbound.payload?.entry.execCwd).toBeUndefined();
+
+  const persisted = expectDefined(
+    loadSessionEntry({ sessionKey: "agent:main:main", storePath }),
+    "persisted session after removing its node binding",
+  );
+  expect(persisted.execHost).toBeUndefined();
+  expect(persisted.execNode).toBeUndefined();
+  expect(persisted.execCwd).toBeUndefined();
+  expect(detectNodeClaudePlacement({ backendId: "claude-cli", ...persisted })).toBe(false);
+});

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -1666,6 +1666,7 @@ describe("gateway sessions patch", () => {
     );
     expect(changed.execNode).toBe("worker-2");
     expect(changed.execCwd).toBeUndefined();
+    expect(changed.execHost).toBe("node");
 
     const cleared = expectPatchOk(
       await runPatch({
@@ -1679,7 +1680,28 @@ describe("gateway sessions patch", () => {
     );
     expect(cleared.execNode).toBeUndefined();
     expect(cleared.execCwd).toBeUndefined();
+    expect(cleared.execHost).toBeUndefined();
   });
+
+  test.each(["auto", "gateway", "sandbox"] as const)(
+    "preserves explicit %s exec hosting when clearing a stale node binding",
+    async (execHost) => {
+      const cleared = expectPatchOk(
+        await runPatch({
+          store: mainStoreEntry({
+            execHost,
+            execNode: "worker-1",
+            execCwd: "/workspace/on-worker-1",
+          }),
+          patch: { key: MAIN_SESSION_KEY, execNode: null },
+        }),
+      );
+
+      expect(cleared.execHost).toBe(execHost);
+      expect(cleared.execNode).toBeUndefined();
+      expect(cleared.execCwd).toBeUndefined();
+    },
+  );
 
   test("rejects invalid execHost values", async () => {
     const result = await runPatch({

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -122,18 +122,16 @@ export function resolveSessionPatchModelSelection(params: {
 
 function normalizeExecSecurity(raw: string): "deny" | "allowlist" | "full" | undefined {
   const normalized = normalizeOptionalLowercaseString(raw);
-  if (normalized === "deny" || normalized === "allowlist" || normalized === "full") {
-    return normalized;
-  }
-  return undefined;
+  return normalized === "deny" || normalized === "allowlist" || normalized === "full"
+    ? normalized
+    : undefined;
 }
 
 function normalizeExecAsk(raw: string): "off" | "on-miss" | "always" | undefined {
   const normalized = normalizeOptionalLowercaseString(raw);
-  if (normalized === "off" || normalized === "on-miss" || normalized === "always") {
-    return normalized;
-  }
-  return undefined;
+  return normalized === "off" || normalized === "on-miss" || normalized === "always"
+    ? normalized
+    : undefined;
 }
 
 function normalizeSessionToolOverrides(
@@ -554,12 +552,14 @@ export async function projectSessionsPatchEntry(params: {
   }
 
   if ("execNode" in patch) {
-    const raw = patch.execNode;
-    if (raw === null) {
+    if (patch.execNode === null) {
       delete next.execNode;
       delete next.execCwd;
-    } else if (raw !== undefined) {
-      const trimmed = normalizeOptionalString(raw) ?? "";
+      if (next.execHost === "node") {
+        delete next.execHost;
+      }
+    } else if (patch.execNode !== undefined) {
+      const trimmed = normalizeOptionalString(patch.execNode) ?? "";
       if (!trimmed) {
         return invalid("invalid execNode: empty");
       }


### PR DESCRIPTION
Closes #121965

## What Problem This Solves

Patching a session with `execNode: null` removed its node and node-local working directory while leaving `execHost: "node"` behind. The next Claude CLI turn then failed with `node-placed Claude CLI session is missing execNode`; other execution paths also retained an invalid node-only target after the operator had explicitly unbound the worker.

## Why This Change Was Made

The session-patch producer now clears node-only execution hosting whenever it removes the corresponding node binding. Explicit `auto`, `gateway`, and `sandbox` targets remain untouched, and changing one node for another still preserves `execHost: "node"`.

The existing execution-policy normalization was simplified in the same owner so the complete production change is net zero lines and remains within the enforced 700-line module limit. There is no protocol, schema, migration, compatibility, or new configuration change.

## User Impact

Unbinding a cloud or paired-worker session returns it to a valid non-node execution state immediately. The Gateway response, persisted session record, and downstream Claude CLI placement all agree; operators can continue the same session without resetting it or manually repairing session state.

## Evidence

Exact refreshed head: `0008ba2f3838581095700db6223bbed9cac3b3fd`.

Before the owner fix, the focused regression command failed independently at both boundaries:

```text
src/gateway/sessions-patch.test.ts
  AssertionError: expected 'node' to be undefined

src/gateway/server.sessions.exec-binding-rpc.test.ts
  AssertionError: expected 'node' to be undefined

Test Files  2 failed (2)
Tests       2 failed | 90 passed (92)
```

After the repair:

```text
node scripts/run-vitest.mjs \
  src/gateway/sessions-patch.test.ts \
  src/gateway/server.sessions.exec-binding-rpc.test.ts \
  src/agents/cli-runner/prepare.test.ts

Gateway owner and real session handler: 92 passed
Downstream Claude/CLI placement siblings: 112 passed
Total: 204 passed
```

The session-handler regression invokes the production `sessions.patch` handler, checks the response, reloads the SQLite-backed session record, and verifies that the actual Claude placement detector returns `false`. Owner-boundary cases additionally preserve replacement-node hosting plus explicit `auto`, `gateway`, and `sandbox` targets.

- Changed-file formatting, direct core lint, production core typecheck, assertion-safety ratchet, dependency pins, plugin boundaries, dead exports, and `git diff --check` passed.
- The complete local changed-file gate reached core-test typechecking and exposed an unrelated existing checkout dependency gap: unchanged `ui/vite.config.ts` cannot find declarations for `pako`. No unrelated dependency or UI source was changed; exact-head hosted CI provides the authoritative clean-install test-typecheck.
- Fresh independent autoreview found no accepted or actionable findings.
- Production: `+12/-12` (net zero). Tests: `+66/-0`. Release-note context remains in this PR body; changelog generation is release-owned.
- Preserves the original contributor credit for @zyw02.

AI-assisted: yes; the original contributor patch was reviewed and refreshed against current main.
