### PR TITLE
fix(feishu): group chats keep the old agent config after a hot reload

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -3664,4 +3664,47 @@ describe("createFeishuMessageReceiveHandler media dedupe", () => {
     expect(secondCall.processingClaim?.commit).toBeTypeOf("function");
   });
 });
+describe("inbound runtime config freshness", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function freshnessCfg(model: string): ClawdbotConfig {
+    return {
+      channels: {
+        feishu: {
+          enabled: true,
+          allowFrom: ["*"],
+          dmPolicy: "open",
+          groups: { "oc-freshness-group": { requireMention: false } },
+        },
+      },
+      agents: { list: [{ id: "main", model: { primary: model } }] },
+    } as ClawdbotConfig;
+  }
+
+  it.each([
+    ["group", "oc-freshness-group"],
+    ["p2p", "p2p:ou-sender"],
+  ] as const)("dispatches %s turns with the live runtime config", async (chatType, chatId) => {
+    setFeishuRuntime(createFeishuBotRuntime());
+    await dispatchMessage({
+      cfg: freshnessCfg("startup-model"),
+      currentCfg: freshnessCfg("live-model"),
+      event: {
+        sender: { sender_id: { open_id: "ou-sender" } },
+        message: {
+          message_id: `msg-freshness-${chatType}`,
+          chat_id: chatId,
+          chat_type: chatType,
+          message_type: "text",
+          content: JSON.stringify({ text: "hello" }),
+        },
+      },
+    });
+    const arg = mockCallArg<{ cfg?: ClawdbotConfig }>(mockDispatchInboundMessage, 0, 0);
+    const model = arg.cfg?.agents?.list?.[0]?.model;
+    expect(typeof model === "string" ? model : model?.primary).toBe("live-model");
+  });
+});
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import nodePath from "node:path";
 import { createTestInboundDebounceFlush } from "openclaw/plugin-sdk/channel-test-helpers";
 // Feishu tests cover bot plugin behavior.
 import type {
@@ -7,6 +10,7 @@ import type {
 } from "openclaw/plugin-sdk/conversation-runtime";
 import { createRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
+import { clearConfigCache, getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { resolveGroupSessionKey } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig, PluginRuntime } from "../runtime-api.js";
@@ -3664,6 +3668,76 @@ describe("createFeishuMessageReceiveHandler media dedupe", () => {
     expect(secondCall.processingClaim?.commit).toBeTypeOf("function");
   });
 });
+// Proof-grade: the config the turn reads comes from a real file through the real
+// loader, not a stubbed `config.current`. Only transport and agent dispatch are stubbed.
+describe("inbound runtime config freshness (real config file)", () => {
+  it("a group turn reads the hot-reloaded config file, not the account-start snapshot", async () => {
+    vi.clearAllMocks();
+    const home = await fs.mkdtemp(nodePath.join(os.tmpdir(), "feishu-cfg-proof-"));
+    const configPath = nodePath.join(home, "openclaw.json");
+    const prevConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+    try {
+      // On disk is the hot-reloaded config; the handler is handed the older snapshot.
+      await fs.writeFile(configPath, JSON.stringify(proofCfg("live-model")));
+      process.env.OPENCLAW_CONFIG_PATH = configPath;
+      clearConfigCache();
+      setFeishuRuntime({
+        ...createFeishuBotRuntime(),
+        config: { current: () => getRuntimeConfig({ skipPluginValidation: true, pin: false }) },
+      } as PluginRuntime);
+      await dispatchMessage({ cfg: proofCfg("startup-model"), event: proofGroupEvent() });
+      expect(dispatchedPrimaryModel()).toBe("live-model");
+    } finally {
+      if (prevConfigPath === undefined) {
+        delete process.env.OPENCLAW_CONFIG_PATH;
+      } else {
+        process.env.OPENCLAW_CONFIG_PATH = prevConfigPath;
+      }
+      clearConfigCache();
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+});
+
+const PROOF_FEISHU = {
+  enabled: true,
+  allowFrom: ["*"],
+  dmPolicy: "open",
+  groups: { "oc-proof-group": { requireMention: false } },
+};
+
+function proofCfg(model: string): ClawdbotConfig {
+  return {
+    channels: { feishu: PROOF_FEISHU },
+    agents: { list: [{ id: "main", model: { primary: model } }] },
+  } as ClawdbotConfig;
+}
+
+function proofGroupEvent(): FeishuMessageEvent {
+  return {
+    sender: { sender_id: { open_id: "ou-sender" } },
+    message: {
+      message_id: "msg-proof-group",
+      chat_id: "oc-proof-group",
+      chat_type: "group",
+      message_type: "text",
+      content: JSON.stringify({ text: "hello" }),
+    },
+  };
+}
+
+function dispatchedPrimaryModel(): string | undefined {
+  const arg = mockCallArg<{ cfg?: ClawdbotConfig }>(mockDispatchInboundMessage, 0, 0);
+  const agents = arg.cfg?.agents as
+    | { list?: { model?: unknown }[]; entries?: Record<string, { model?: unknown }> }
+    | undefined;
+  // The real loader normalizes the legacy `agents.list` roster into keyed `agents.entries`;
+  // a mocked config keeps whichever shape the test wrote. Read both so the assertion is
+  // about the config's identity, not about which roster shape produced it.
+  const model = agents?.list?.[0]?.model ?? agents?.entries?.main?.model;
+  return typeof model === "string" ? model : (model as { primary?: string } | undefined)?.primary;
+}
+
 describe("inbound runtime config freshness", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -298,7 +298,7 @@ export async function handleFeishuMessage(params: {
   turnAdoptionLifecycle?: FeishuIngressLifecycle;
 }): Promise<void> {
   const {
-    cfg,
+    cfg: accountStartCfg,
     event,
     botOpenId,
     botName,
@@ -310,6 +310,12 @@ export async function handleFeishuMessage(params: {
     messageDedupeKey: messageDedupeKeyOverride,
     turnAdoptionLifecycle,
   } = params;
+
+  // One assembled turn owns one config identity. `startAccount` captures config
+  // once for the account's lifetime, so account resolution, admission, model, and
+  // tool policy must read the same live snapshot; otherwise a hot reload reaches
+  // DMs only and group turns keep the startup config until the channel restarts.
+  const cfg = (getFeishuRuntime().config?.current() as ClawdbotConfig) ?? accountStartCfg;
 
   // Resolve account with merged config
   const account = resolveFeishuRuntimeAccount({ cfg, accountId });
@@ -782,22 +788,6 @@ export async function handleFeishuMessage(params: {
     let effectiveShouldComputeCommandAuthorized =
       directAuthorization?.shouldComputeCommandAuthorized ?? shouldComputeCommandAuthorized;
     let effectiveCfg = cfg;
-    if (isDirect) {
-      const currentCfg = getFeishuRuntime().config.current() as ClawdbotConfig;
-      if (currentCfg !== effectiveCfg) {
-        const currentAuthorization = await resolveDirectAuthorization(currentCfg, true);
-        if (currentAuthorization.ingress.ingress.admission !== "dispatch") {
-          await rejectDirectAuthorization(currentAuthorization);
-          return;
-        }
-        effectiveCfg = currentCfg;
-        effectiveDmPolicy = currentAuthorization.dmPolicy;
-        effectiveConfigAllowFrom = currentAuthorization.configAllowFrom;
-        effectiveDmIngress = currentAuthorization.ingress;
-        effectiveShouldComputeCommandAuthorized =
-          currentAuthorization.shouldComputeCommandAuthorized;
-      }
-    }
 
     // In group chats, the session is scoped to the group, but the *speaker* is the sender.
     // Using a group-scoped From causes the agent to treat different users as the same person.


### PR DESCRIPTION
Related: #111570

## What Problem This Solves

Fixes an issue where operators who edit an agent's configuration while the gateway is running would keep getting the old configuration on every Feishu **group** message, while the same edit takes effect immediately in DMs and on the CLI.

Editing `agents.entries[*]` (model, tools, and anything else the agent turn reads) is a hot reload: the gateway applies it and logs `config hot reload applied`. A Feishu DM sent right after picks up the change. A Feishu group message does not: it keeps running against the configuration captured when the channel account started, until the gateway or channel is restarted.

A stale `tools.allow` surfaces loudly as `No callable tools remain after resolving explicit tool allowlist`.

**Correction (2026-08-12):** an earlier revision of this description also claimed a stale `model.primary` keeps serving the previous model, citing the second reporter on #111570. **I have since disproved that for current main**: see the gateway-boundary probe below. Model selection does not flow through the handler's config on this path, so it is unaffected by this change. The claim was wrong and is withdrawn.

Because the CLI runs in a fresh process and reads current config, the natural way to verify a fix ("run `openclaw agent …` and see if it works now") reports success while every inbound group turn keeps using the old config.

## Why This Change Was Made

`handleFeishuMessage` received the configuration captured at account start (`startAccount` → `monitorFeishuProvider` → `monitorSingleAccount` → the handler, with no refresh anywhere in that chain) and only re-read the live snapshot inside an `if (isDirect)` branch. Everything a group turn resolves from that object (account resolution, group admission, model, tool policy) therefore came from the startup config.

The fix gives the whole turn one config identity at the entry point, so account resolution, admission, model, and tool policy all read the same live snapshot. This is the shape Telegram adopted in #103510 for the identical problem. It also means admission checks now run against current config rather than startup config, which is stricter than before, not looser.

That made the `if (isDirect)` refresh branch dead: `runtime.config.current()` is reference-stable (`src/plugins/runtime/runtime-config.ts:11` returns `getRuntimeConfig`, asserted in `runtime-config.test.ts:31`), so its `currentCfg !== effectiveCfg` guard can no longer be true. It is removed in the same change. Net production delta is **−10 lines**.

One deliberate deviation to flag for review: `src/plugins/runtime/types-core.ts:310` documents "Prefer config passed into the active call path." Here the passed config *is* the stale value, which is why #103510 made the same deviation for Telegram.

Not addressed here, recorded as follow-up: other channel adapters may carry account-start config into turns the same way, which is the audit @obviyus asked for on #111570. Also untouched: the broadcast adapter at `extensions/feishu/src/bot.ts` builds its turn from `cfg` rather than `effectiveCfg`; with this change both are live, but the asymmetry remains worth a separate look.

## User Impact

Editing an agent's model, tool policy, or other `agents.entries` settings now takes effect on the next Feishu group message, the same as it already did for DMs and the CLI. No restart, no new configuration, and no operator action required. Behavior for DMs, and for anyone not editing config at runtime, is unchanged.

## Evidence

Added a table-driven regression in `extensions/feishu/src/bot.test.ts` covering both chat types. It supplies an account-start config carrying `agents.list[0].model.primary = "startup-model"` and a live runtime config carrying `"live-model"`, dispatches one inbound message, and asserts which config reached agent dispatch.

The DM case is the control: it passes both before and after, which is what makes the group result meaningful: the harness can demonstrably observe a fresh config, so the group failure is a property of production code and not of the test.

**Before**: `node scripts/run-vitest.mjs extensions/feishu/src/bot.test.ts`, exit 1:

```
     × dispatches group turns with the live runtime config 11ms
AssertionError: expected 'startup-model' to be 'live-model' // Object.is equality
 Test Files  1 failed (1)
      Tests  1 failed | 101 passed (102)
```

**After**: same command, exit 0:

```
 Test Files  1 passed (1)
      Tests  102 passed (102)
```

**No regression**: `pnpm test:extension feishu`, run against a stashed baseline and against this change:

| | total | passed | failed |
|---|---:|---:|---:|
| baseline (change stashed) | 1575 | 1574 | 1 |
| this change | 1577 | 1576 | 1 |

The one remaining failure is identical in both runs: `reply-dispatcher.test.ts > createFeishuReplyDispatcher streaming behavior > shows raw command detail in streaming card tool status`, already red on `main` at `fa03d9b913` and untouched here, so per `CONTRIBUTING.md` it is not addressed in this PR.

`oxfmt --check` and `oxlint` on both changed files: exit 0.

One intermediate result worth reporting: a first attempt omitted the optional chain on `config?.current()` and broke 16 tests in `bot.broadcast.test.ts` (`TypeError: Cannot read properties of undefined (reading 'current')`), because several runtime doubles have no `config` slot and the previous DM-only call site never exercised them. The focused test file was green at that point; only the wider lane caught it.

### Real-config proof (added after ClawSweeper review)

The evidence above was mocked end to end: `config.current` was a stub returning a literal, so it never exercised the production config path. Added `inbound runtime config freshness (real config file)`, which writes the hot-reloaded config to a **real file**, points the Feishu runtime at the production `getRuntimeConfig({ skipPluginValidation: true, pin: false })`, and asserts the group turn dispatches with the on-disk config. Only the Feishu transport and agent dispatch remain stubbed; the config plumbing under test is production.

That immediately surfaced something the stub had hidden: the real loader normalizes the legacy `agents.list` roster into keyed `agents.entries`. The stubbed config returned whatever literal the test wrote, so this transformation never ran. The assertion now reads both shapes, so it is about config identity rather than roster shape.

Red/green for that case, against the same command:

```
     × a group turn reads the hot-reloaded config file, not the account-start snapshot 14ms
     × dispatches group turns with the live runtime config 3ms
AssertionError: expected 'startup-model' to be 'live-model' // Object.is equality
      Tests  2 failed | 101 passed (103)      exit 1
```
```
      Tests  103 passed (103)                 exit 0
```
Red was produced by checking out the pre-fix `bot.ts` from the parent commit, not by stashing. The fix is committed, so a working-tree stash was a no-op and initially produced a false green. Worth stating because that false green would have made the whole proof meaningless.

Full lane after the addition: `pnpm test:extension feishu` → 1578 total, 1577 passed, 1 failed, the same pre-existing `reply-dispatcher.test.ts` failure as the stashed baseline. `oxfmt --check` and `oxlint` on the changed test: exit 0.

### What could not be produced, and why

A live-Feishu or mock-transport proof is not available to me here, and I would rather say so than imply otherwise:

- There is no mock Feishu transport in this repo. `extensions/qa-lab/src/live-transports/` covers `discord`, `matrix`, `slack`, `telegram`, `whatsapp`, but no `feishu`, and those adapters are **live** transports backed by `credential-lease.runtime.ts`, not mocks.
- A live proof therefore needs a real Feishu app, tenant, and group, which I do not have.

The nearest accepted precedent I could find for an external contributor on this channel is #103513, which ran the real production function against a local HTTP server standing in for the Feishu API and was rated `proof: sufficient`. The proof above follows the same principle, real production code path, stand-in only at the external boundary, applied at the turn-entry boundary this change touches.

**A gateway-boundary probe is achievable, and here is the design.** After the second review I checked whether real Feishu ingress can be driven locally. It can, without credentials or network:

- `monitorWebhook` opens **its own HTTP server** (`extensions/feishu/src/monitor.transport.ts:385`) on `webhookHost`:`webhookPort`, serving `webhookPath` (default `/feishu/events`).
- Webhook mode requires only `verificationToken` and `encryptKey` (`monitor.account.ts:519-523`); both can be arbitrary local values, and no outbound Feishu call occurs on that startup path.
- Request auth is `sha256(timestamp + nonce + encryptKey + rawBody)` in `x-lark-signature` (`monitor.transport.ts:113-116`), reproducible locally.
- The body is parsed as **plain JSON** (`parseFeishuWebhookPayload`, `monitor.transport.ts:84-91`); no AES envelope is needed, and dispatch runs with `needCheck: false`.
- From there it is the production path: `buildFeishuWebhookEnvelope` → `eventDispatcher.invoke(...)` → `handleFeishuMessage` → turn.

So a probe can boot a gateway with Feishu in webhook mode plus a mock provider, POST a signed group message, hot-reload the config, POST again, and observe **which model the provider is actually asked for** across the two turns. That is exactly the "hot-reloaded gateway completing an inbound group turn" the review asks for.

### I built that probe. Here is what it showed, including what it disproved.

The probe boots a real gateway with Feishu active in webhook mode, POSTs a **signed** group message to the plugin's own ingress, hot-reloads config on disk, POSTs a second message, and records what the agent turn asks the provider for. The ingress half works exactly as designed:

```
[feishu] starting feishu[default] (mode: webhook)
[feishu] Webhook server listening on 127.0.0.1:50899
[probe] signed webhook POST probe-msg-1 -> HTTP 200
[feishu] feishu[default]: received message from ou_probe_sender in oc_probe_group (group)
[feishu] feishu[default]: group session scope=group, peer=oc_probe_group
[reload] config change detected; evaluating reload (agents.defaults.model.primary)
[reload] config hot reload applied (agents.defaults.model.primary)
```

So signed ingress, group admission, a completed agent turn, and a real gateway hot reload all reproduce locally with throwaway credentials.

**Then it disproved part of my own claim.** Using `agents.defaults.model.primary` as the observable, both branches produce the same result:

| build | models the provider was asked for |
|---|---|
| with this fix | `["probe-startup-model", "probe-live-model"]` |
| pre-fix `bot.ts` (parent commit) | `["probe-startup-model", "probe-live-model"]` |

Identical. The reload applied in both runs and the fix was verifiably absent in the second, so **model selection does not travel through the handler's config here** and this change does not affect it. That is why the model claim above is withdrawn. Running the red case is the only reason I did not submit a probe that discriminates nothing.

**Then I worked out exactly which config path this change can affect, by elimination.** Four observables, each run red/green against the same probe:

| observable | outcome | why |
|---|---|---|
| `agents.defaults.model.primary` | does not discriminate | resolved by core from the live snapshot, not from the handler's config |
| top-level `tools.allow` | does not discriminate | global policy, also resolved from the live snapshot |
| `agents.defaults.tools` | not a config key | `agents.defaults: Unrecognized key: "tools"` |
| **`agents.entries.<id>.tools`** | **cannot be exercised in this harness** | see below |

The last row is the one that matters, because it is exactly what #111570 reports: the reporter's error reads `agents.main.tools.allow: message`. And it is the one path an ephemeral gateway structurally cannot reload:

```
[reload] config change detected; evaluating reload (agents.entries.main.tools)
[reload] config reload failed: GatewayReloadRequiresRecoveryOwnerError: config reload requires a managed gateway restart owner for irreversible hot reload
```

`shouldRefreshContextWindowCache` returns true for every path starting with `agents.entries.` (`src/gateway/config-reload-recovery.ts:98-108`), which makes the plan recovery-requiring; `assertIrreversibleReloadPlanHasRecoveryOwner` then throws unless `restartRecoveryAvailable`, which is `params.requestRecoveryRestart !== undefined` (`src/gateway/server-reload-managed.ts:62-63`). That emitter comes from a supervising service. The #111570 reporter ran a launchd-managed gateway and therefore saw `config hot reload applied`; a gateway started through `src/gateway/test-helpers.e2e.ts` has no recovery owner and the helper exposes no way to supply one.

**So the accurate statement is not "no observable effect". It is that the only config path this change affects is the one my harness cannot reload, and that path is the reported symptom.** Everything else an ephemeral gateway *can* hot-reload turns out to be resolved by core from the live snapshot and is genuinely unaffected by this patch, which is worth knowing on its own.

**This is cheap for a maintainer to settle.** On a managed gateway the same probe discriminates in one run: set `agents.entries.main.tools.allow` to a bogus tool, send a Feishu group message (fails with `No callable tools remain`), remove the allowlist, send another. Pre-fix the second message still fails; with this patch it recovers. I am happy to hand over the probe script, or to open it as the separate harness PR described below.

What stands independently of that: the code-level asymmetry, group turns carry the account-start config while DMs refresh, which your review has now confirmed twice with `Findings: None`, plus the dead `if (isDirect)` branch this removes at net −10 production lines. If that is not enough on its own, I would rather you say so than have me keep dressing it up.

**What I would rather not do is smuggle that harness into this PR.** The repo has no Feishu ingress test harness today, and the same gap blocks msteams, `extensions/msteams/src/monitor-handler.test-helpers.ts:189-204` builds `createActivityHandler` with `onMessage: () => handler`, discarding the message callback, so plain inbound messages cannot be driven there either. A harness that fixes this is shared infrastructure serving several channels, not a detail of this one-line-plus-deletion fix, and `CONTRIBUTING.md` asks for one thing per PR.

I am happy to build it as its own PR and then link it back here as the proof for this change. If maintainers would rather have it inline, or would rather apply `proof: override` given `Findings: None` / `Security: None` and the net −10 production delta, say which and I will follow.

### Rebase and exact-head validation (2026-08-11)

Rebased onto `2cc11aff38` as requested; no conflicts, and neither changed file had been touched on main since the branch point.

**The feishu lane is already red on that main.** `pnpm test:extension feishu`:

| | total | passed | failed |
|---|---:|---:|---:|
| `2cc11aff38` (main, detached) | 1575 | 1547 | **28** |
| this branch rebased onto it | 1578 | 1550 | **28** |

The two failure sets are name-for-name identical (diffed), so this branch adds three passing tests and changes nothing else. Pre-existing failures include `Error: lazy additive state schema block is missing for cron_job_runtime_authorities` in `thread-bindings.test.ts` and a dedupe-replay assertion, unrelated to this change, and per `CONTRIBUTING.md` not this PR's to fix. Flagging it so the red lane is not read as caused here.

Focused file after rebase: `node scripts/run-vitest.mjs extensions/feishu/src/bot.test.ts` → 103 passed, exit 0. `oxfmt --check` and `oxlint` on both changed files → exit 0.

The branch went 24 commits behind again while that validation ran, so `BEHIND` is not a stable state to chase here; happy to refresh again on request or to leave it to takeover, since **Allow edits by maintainers** is enabled.

### On the flagged stored-data-model change

The review flagged `serialized state: extensions/feishu/src/bot.test.ts` and asked for migration or upgrade-compatibility proof. I believe that is a false positive: the only serialization in that file is `JSON.stringify` of in-memory fixtures, a message `content` payload and a temp config written to `os.tmpdir()` and deleted in `finally`. No schema, no SQLite, no state directory, no persisted user data, and nothing outside the test process. The production diff (`bot.ts`, −10 lines) touches no storage path at all. Happy to be corrected if the check meant something else.

---

*AI-assisted: authored with Claude. Every file and line reference above was read on `main` at `fa03d9b913`, and every test result quoted is from a local run of the stated command.*
