### PR TITLE
fix(meetings): classify Teams probe mode errors

### DIFF
--- a/extensions/teams-meetings/index.test.ts
+++ b/extensions/teams-meetings/index.test.ts
@@ -255,6 +255,23 @@ describe("Microsoft Teams meetings plugin surface", () => {
     });
   });
 
+  it.each([
+    ["teamsmeetings.testSpeech", "transcribe", "test_speech requires mode: agent or bidi"],
+    ["teamsmeetings.testListen", "agent", "test_listen requires mode: transcribe"],
+  ])(
+    "classifies invalid probe mode for %s as an invalid request",
+    async (method, mode, message) => {
+      const { invoke } = authorizationHarness();
+      const response = await invoke(method, { mode, timeoutMs: 1, url: MEETING_URL });
+
+      expect(response).toMatchObject({
+        error: { code: ErrorCodes.INVALID_REQUEST },
+        ok: false,
+        payload: { error: message },
+      });
+    },
+  );
+
   it("classifies browser failures as unavailable, not invalid requests", async () => {
     const { invoke } = authorizationHarness({ browserError: new Error("browser unavailable") });
     const response = await invoke("teamsmeetings.join", {

--- a/extensions/teams-meetings/index.ts
+++ b/extensions/teams-meetings/index.ts
@@ -2,18 +2,17 @@ import { MeetingPlatformAdapter } from "openclaw/plugin-sdk/meeting-runtime";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { Type } from "typebox";
 import { teamsMeetingsConfig } from "./src/config.js";
+import { TeamsMeetingsInvalidRequestError, teamsMeetingsInvalidRequest } from "./src/errors.js";
 import { handleTeamsMeetingsNodeHostCommand } from "./src/node-host.js";
 import { createTeamsMeetingsNodeInvokePolicy } from "./src/node-invoke-policy.js";
 import { TeamsMeetingsRuntime } from "./src/runtime.js";
 import { TEAMS_MEETINGS_PLATFORM_ADAPTER } from "./src/transports/teams-meetings-platform-adapter.js";
 
-class TeamsMeetingsInvalidRequestError extends Error {}
-
 export default MeetingPlatformAdapter.createPluginShellEntry({
   platform: TEAMS_MEETINGS_PLATFORM_ADAPTER,
   browserGuestLabel: "Microsoft Teams meeting",
   configSchema: teamsMeetingsConfig.configSchema,
-  invalidRequest: (message) => new TeamsMeetingsInvalidRequestError(message),
+  invalidRequest: teamsMeetingsInvalidRequest,
   isInvalidRequest: (error) => error instanceof TeamsMeetingsInvalidRequestError,
   toolParameters: Type.Object({
     action: Type.String({ enum: ["join", "leave", "status", "transcript", "speak"] }),

--- a/extensions/teams-meetings/src/errors.ts
+++ b/extensions/teams-meetings/src/errors.ts
@@ -1,0 +1,5 @@
+export class TeamsMeetingsInvalidRequestError extends Error {}
+
+export function teamsMeetingsInvalidRequest(message: string): TeamsMeetingsInvalidRequestError {
+  return new TeamsMeetingsInvalidRequestError(message);
+}

--- a/extensions/teams-meetings/src/runtime-probes.test.ts
+++ b/extensions/teams-meetings/src/runtime-probes.test.ts
@@ -1,151 +1,29 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { teamsMeetingsConfig } from "./config.js";
-import { testTeamsMeetingListening, testTeamsMeetingSpeech } from "./runtime-probes.js";
+import { testTeamsMeetingListening } from "./runtime-probes.js";
 import type { TeamsMeetingsSession } from "./transports/types.js";
 
-const resolveTeamsMeetingsConfig = teamsMeetingsConfig.resolveConfig;
-type TeamsMeetingsProbeContext = Parameters<typeof testTeamsMeetingSpeech>[0];
-
 const URL = "https://teams.microsoft.com/l/meetup-join/19%3ameeting_probe%40thread.v2/0";
-
-afterEach(() => {
-  vi.useRealTimers();
-});
+type TeamsMeetingsProbeContext = Parameters<typeof testTeamsMeetingListening>[0];
 
 describe("Microsoft Teams meeting runtime probes", () => {
-  it("uses the per-request speech verification timeout", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(0);
-    const session = {
-      agentId: "main",
-      chrome: { health: { inCall: true, lastOutputBytes: 0 } },
-      id: "teams-1",
-      mode: "agent",
-      transport: "chrome",
-    } as TeamsMeetingsSession;
-    const refreshHealth = vi.fn();
-    const context = {
-      config: resolveTeamsMeetingsConfig({ chrome: { joinTimeoutMs: 30_000 } }),
-      hasHealthHandle: () => true,
-      isReusable: () => false,
-      join: vi.fn(async () => ({ session, spoken: true })),
-      list: () => [],
-      refreshCaptionHealth: async () => {},
-      refreshHealth,
-      resolveAgentId: () => "main",
-    } satisfies TeamsMeetingsProbeContext;
-
-    const pending = testTeamsMeetingSpeech(context, {
-      mode: "agent",
-      timeoutMs: 150,
-      url: URL,
-    });
-    await vi.advanceTimersByTimeAsync(200);
-    const result = await pending;
-
-    expect(result.speechOutputTimedOut).toBe(true);
-    expect(refreshHealth).toHaveBeenCalledTimes(2);
-    expect(Date.now()).toBe(200);
-  });
-
-  it("requires fresh non-silent loopback capture as well as output bytes", async () => {
-    for (const [outputLoopbackSignalBytes, expected] of [
-      [0, false],
-      [4, true],
-    ] as const) {
-      const session = {
-        agentId: "main",
-        chrome: {
-          health: {
-            inCall: true,
-            lastOutputBytes: 4,
-            outputGeneration: 1,
-            outputLoopbackSignalBytes,
-            verifiedOutputGeneration: expected ? 1 : undefined,
-          },
-        },
-        id: `teams-speech-${outputLoopbackSignalBytes}`,
-        mode: "agent",
-        transport: "chrome",
-      } as TeamsMeetingsSession;
-      const context = {
-        config: resolveTeamsMeetingsConfig({}),
-        hasHealthHandle: () => false,
-        isReusable: () => false,
-        join: vi.fn(async () => ({ session, spoken: true })),
-        list: () => [],
-        refreshCaptionHealth: async () => {},
-        refreshHealth: () => {},
-        resolveAgentId: () => "main",
-      } satisfies TeamsMeetingsProbeContext;
-
-      const result = await testTeamsMeetingSpeech(context, { mode: "agent", url: URL });
-
-      expect(result.speechOutputVerified).toBe(expected);
-    }
-  });
-
-  it("bounds a blocked caption refresh by the per-request listening timeout", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(0);
+  it("waits for listening when Chrome launched without a tracked target", async () => {
     const session = {
       agentId: "main",
       chrome: { health: { inCall: true }, launched: true },
-      id: "teams-listen-1",
+      id: "teams-listen",
       mode: "transcribe",
       transport: "chrome",
     } as TeamsMeetingsSession;
-    const refreshCaptionHealth = vi.fn(
-      (_session: TeamsMeetingsSession, _timeoutMs: number) => new Promise<void>(() => {}),
-    );
-    const context = {
-      config: resolveTeamsMeetingsConfig({ chrome: { joinTimeoutMs: 30_000 } }),
-      hasHealthHandle: () => true,
-      isReusable: () => false,
-      join: vi.fn(async () => ({ session, spoken: false })),
-      list: () => [],
-      refreshCaptionHealth,
-      refreshHealth: () => {},
-      resolveAgentId: () => "main",
-    } satisfies TeamsMeetingsProbeContext;
-
-    const pending = testTeamsMeetingListening(context, {
-      mode: "transcribe",
-      timeoutMs: 300,
-      url: URL,
+    const refreshCaptionHealth = vi.fn(async () => {
+      session.chrome!.health = {
+        ...session.chrome!.health,
+        manualAction: { reason: "teams-admission-required", message: "Waiting" },
+      };
     });
-    await vi.advanceTimersByTimeAsync(350);
-    const result = await pending;
-
-    expect(result.listenTimedOut).toBe(true);
-    expect(refreshCaptionHealth).toHaveBeenCalledWith(session, 300);
-    expect(Date.now()).toBe(350);
-    expect(vi.getTimerCount()).toBe(0);
-  });
-
-  it("refreshes captions before a short listening timeout expires", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(0);
-    const session = {
-      agentId: "main",
-      chrome: { health: { inCall: true }, launched: true },
-      id: "teams-listen-2",
-      mode: "transcribe",
-      transport: "chrome",
-    } as TeamsMeetingsSession;
-    const refreshCaptionHealth = vi.fn(
-      async (_session: TeamsMeetingsSession, _timeoutMs: number) => {
-        session.chrome!.health = {
-          ...session.chrome!.health,
-          lastCaptionText: "Caption already waiting",
-          manualAction: { reason: "teams-admission-required", message: "Waiting" },
-          transcriptLines: 1,
-        };
-      },
-    );
     const context = {
-      config: resolveTeamsMeetingsConfig({ chrome: { joinTimeoutMs: 30_000 } }),
-      hasHealthHandle: () => true,
+      config: teamsMeetingsConfig.resolveConfig({}),
+      hasHealthHandle: () => false,
       isReusable: () => false,
       join: vi.fn(async () => ({ session, spoken: false })),
       list: () => [],
@@ -160,56 +38,10 @@ describe("Microsoft Teams meeting runtime probes", () => {
       url: URL,
     });
 
-    expect(result.listenVerified).toBe(true);
+    expect(refreshCaptionHealth).toHaveBeenCalledOnce();
     expect(result.manualAction).toEqual({
       reason: "teams-admission-required",
       message: "Waiting",
-    });
-    expect(refreshCaptionHealth).toHaveBeenCalledTimes(1);
-    expect(Date.now()).toBe(0);
-    expect(vi.getTimerCount()).toBe(0);
-  });
-
-  it("does not accept caption progress that arrives after the listening deadline", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(0);
-    const session = {
-      agentId: "main",
-      chrome: { health: { inCall: true }, launched: true },
-      id: "teams-listen-late",
-      mode: "transcribe",
-      transport: "chrome",
-    } as TeamsMeetingsSession;
-    const context = {
-      config: resolveTeamsMeetingsConfig({ chrome: { joinTimeoutMs: 30_000 } }),
-      hasHealthHandle: () => true,
-      isReusable: () => false,
-      join: vi.fn(async () => ({ session, spoken: false })),
-      list: () => [],
-      refreshCaptionHealth: async (_session: TeamsMeetingsSession, timeoutMs: number) => {
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, timeoutMs + 50);
-        });
-        session.chrome!.health = {
-          ...session.chrome!.health,
-          lastCaptionText: "Too late",
-          transcriptLines: 1,
-        };
-      },
-      refreshHealth: () => {},
-      resolveAgentId: () => "main",
-    } satisfies TeamsMeetingsProbeContext;
-
-    const pending = testTeamsMeetingListening(context, {
-      mode: "transcribe",
-      timeoutMs: 300,
-      url: URL,
-    });
-    await vi.advanceTimersByTimeAsync(400);
-
-    await expect(pending).resolves.toMatchObject({
-      listenTimedOut: true,
-      listenVerified: false,
     });
   });
 });

--- a/extensions/teams-meetings/src/runtime-probes.ts
+++ b/extensions/teams-meetings/src/runtime-probes.ts
@@ -1,5 +1,6 @@
 import { MeetingPlatformAdapter } from "openclaw/plugin-sdk/meeting-runtime";
 import type { TeamsMeetingsConfig, TeamsMeetingsMode, TeamsMeetingsTransport } from "./config.js";
+import { teamsMeetingsInvalidRequest } from "./errors.js";
 import type {
   TeamsMeetingsChromeHealth,
   TeamsMeetingsJoinRequest,
@@ -15,8 +16,9 @@ const probes = MeetingPlatformAdapter.createRuntimeProbes<
   TeamsMeetingsJoinRequest
 >({
   defaultSpeechMessage: "Say exactly: Microsoft Teams speech test complete.",
-  invalidRequest: (message) => new Error(message),
-  resolveTimeoutMs: MeetingPlatformAdapter.resolveProbeTimeoutMs,
+  invalidRequest: teamsMeetingsInvalidRequest,
+  resolveTimeoutMs: (input, fallback) =>
+    MeetingPlatformAdapter.resolveProbeTimeoutMs(input, fallback, teamsMeetingsInvalidRequest),
   shouldWaitForListening: (session) => Boolean(session.chrome?.launched),
   talkBackMode: MeetingPlatformAdapter.isTalkBackMode,
 });

--- a/extensions/zoom-meetings/src/runtime-probes.test.ts
+++ b/extensions/zoom-meetings/src/runtime-probes.test.ts
@@ -1,227 +1,61 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { zoomMeetingsConfig } from "./config.js";
-import { testZoomMeetingListening, testZoomMeetingSpeech } from "./runtime-probes.js";
+import { testZoomMeetingListening } from "./runtime-probes.js";
 import type { ZoomMeetingsSession } from "./transports/types.js";
 
-const resolveZoomMeetingsConfig = zoomMeetingsConfig.resolveConfig;
-type ZoomMeetingsProbeContext = Parameters<typeof testZoomMeetingSpeech>[0];
-
 const URL = "https://zoom.us/j/12345678902?pwd=probe";
-
-afterEach(() => {
-  vi.useRealTimers();
-});
+type ZoomMeetingsProbeContext = Parameters<typeof testZoomMeetingListening>[0];
 
 describe("Zoom meeting runtime probes", () => {
-  it("uses the per-request speech verification timeout", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(0);
-    const session = {
-      agentId: "main",
-      chrome: { health: { inCall: true, lastOutputBytes: 0 } },
-      id: "zoom-1",
-      mode: "agent",
-      transport: "chrome",
-    } as ZoomMeetingsSession;
-    const refreshHealth = vi.fn();
-    const context = {
-      config: resolveZoomMeetingsConfig({ chrome: { joinTimeoutMs: 30_000 } }),
-      hasHealthHandle: () => true,
-      isReusable: () => false,
-      join: vi.fn(async () => ({ session, spoken: true })),
-      list: () => [],
-      refreshCaptionHealth: async () => {},
-      refreshHealth,
-      resolveAgentId: () => "main",
-    } satisfies ZoomMeetingsProbeContext;
-
-    const pending = testZoomMeetingSpeech(context, {
-      mode: "agent",
-      timeoutMs: 150,
-      url: URL,
-    });
-    await vi.advanceTimersByTimeAsync(200);
-    const result = await pending;
-
-    expect(result.speechOutputTimedOut).toBe(true);
-    expect(refreshHealth).toHaveBeenCalledTimes(2);
-    expect(Date.now()).toBe(200);
-  });
-
-  it("requires fresh non-silent loopback capture as well as output bytes", async () => {
-    for (const [outputLoopbackSignalBytes, expected] of [
-      [0, false],
-      [4, true],
-    ] as const) {
+  it.each([
+    { launched: true, targetId: undefined, shouldWait: false },
+    { launched: false, targetId: "manual-zoom-tab", shouldWait: true },
+  ])(
+    "uses tracked target ownership when launched=$launched and targetId=$targetId",
+    async ({ launched, targetId, shouldWait }) => {
       const session = {
         agentId: "main",
         chrome: {
-          health: {
-            inCall: true,
-            lastOutputBytes: 4,
-            outputGeneration: 1,
-            outputLoopbackSignalBytes,
-            verifiedOutputGeneration: expected ? 1 : undefined,
-          },
+          ...(targetId ? { browserTab: { openedByPlugin: false, targetId } } : {}),
+          health: { inCall: true },
+          launched,
         },
-        id: `zoom-speech-${outputLoopbackSignalBytes}`,
-        mode: "agent",
+        id: "zoom-listen",
+        mode: "transcribe",
         transport: "chrome",
       } as ZoomMeetingsSession;
+      const refreshCaptionHealth = vi.fn(async () => {
+        session.chrome!.health = {
+          ...session.chrome!.health,
+          manualAction: { reason: "zoom-admission-required", message: "Waiting" },
+        };
+      });
       const context = {
-        config: resolveZoomMeetingsConfig({}),
+        config: zoomMeetingsConfig.resolveConfig({}),
         hasHealthHandle: () => false,
         isReusable: () => false,
-        join: vi.fn(async () => ({ session, spoken: true })),
+        join: vi.fn(async () => ({ session, spoken: false })),
         list: () => [],
-        refreshCaptionHealth: async () => {},
+        refreshCaptionHealth,
         refreshHealth: () => {},
         resolveAgentId: () => "main",
       } satisfies ZoomMeetingsProbeContext;
 
-      const result = await testZoomMeetingSpeech(context, { mode: "agent", url: URL });
+      const result = await testZoomMeetingListening(context, {
+        mode: "transcribe",
+        timeoutMs: 100,
+        url: URL,
+      });
 
-      expect(result.speechOutputVerified).toBe(expected);
-    }
-  });
-
-  it("bounds a blocked caption refresh by the per-request listening timeout", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(0);
-    const session = {
-      agentId: "main",
-      chrome: {
-        browserTab: { openedByPlugin: false, targetId: "manual-zoom-tab" },
-        health: { inCall: true },
-        launched: false,
-      },
-      id: "zoom-listen-1",
-      mode: "transcribe",
-      transport: "chrome",
-    } as ZoomMeetingsSession;
-    const refreshCaptionHealth = vi.fn(
-      (_session: ZoomMeetingsSession, _timeoutMs: number) => new Promise<void>(() => {}),
-    );
-    const context = {
-      config: resolveZoomMeetingsConfig({ chrome: { joinTimeoutMs: 30_000 } }),
-      hasHealthHandle: () => true,
-      isReusable: () => false,
-      join: vi.fn(async () => ({ session, spoken: false })),
-      list: () => [],
-      refreshCaptionHealth,
-      refreshHealth: () => {},
-      resolveAgentId: () => "main",
-    } satisfies ZoomMeetingsProbeContext;
-
-    const pending = testZoomMeetingListening(context, {
-      mode: "transcribe",
-      timeoutMs: 300,
-      url: URL,
-    });
-    await vi.advanceTimersByTimeAsync(350);
-    const result = await pending;
-
-    expect(result.listenTimedOut).toBe(true);
-    expect(refreshCaptionHealth).toHaveBeenCalledWith(session, 300);
-    expect(Date.now()).toBe(350);
-    expect(vi.getTimerCount()).toBe(0);
-  });
-
-  it("refreshes captions before a short listening timeout expires", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(0);
-    const session = {
-      agentId: "main",
-      chrome: {
-        browserTab: { openedByPlugin: false, targetId: "manual-zoom-tab" },
-        health: { inCall: true },
-        launched: false,
-      },
-      id: "zoom-listen-2",
-      mode: "transcribe",
-      transport: "chrome",
-    } as ZoomMeetingsSession;
-    const refreshCaptionHealth = vi.fn(
-      async (_session: ZoomMeetingsSession, _timeoutMs: number) => {
-        session.chrome!.health = {
-          ...session.chrome!.health,
-          lastCaptionText: "Caption already waiting",
-          manualAction: { reason: "zoom-admission-required", message: "Waiting" },
-          transcriptLines: 1,
-        };
-      },
-    );
-    const context = {
-      config: resolveZoomMeetingsConfig({ chrome: { joinTimeoutMs: 30_000 } }),
-      hasHealthHandle: () => true,
-      isReusable: () => false,
-      join: vi.fn(async () => ({ session, spoken: false })),
-      list: () => [],
-      refreshCaptionHealth,
-      refreshHealth: () => {},
-      resolveAgentId: () => "main",
-    } satisfies ZoomMeetingsProbeContext;
-
-    const result = await testZoomMeetingListening(context, {
-      mode: "transcribe",
-      timeoutMs: 100,
-      url: URL,
-    });
-
-    expect(result.listenVerified).toBe(true);
-    expect(result.manualAction).toEqual({
-      reason: "zoom-admission-required",
-      message: "Waiting",
-    });
-    expect(refreshCaptionHealth).toHaveBeenCalledTimes(1);
-    expect(Date.now()).toBe(0);
-    expect(vi.getTimerCount()).toBe(0);
-  });
-
-  it("does not accept caption progress that arrives after the listening deadline", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(0);
-    const session = {
-      agentId: "main",
-      chrome: {
-        browserTab: { openedByPlugin: true, targetId: "zoom-tab" },
-        health: { inCall: true },
-        launched: true,
-      },
-      id: "zoom-listen-late",
-      mode: "transcribe",
-      transport: "chrome",
-    } as ZoomMeetingsSession;
-    const context = {
-      config: resolveZoomMeetingsConfig({ chrome: { joinTimeoutMs: 30_000 } }),
-      hasHealthHandle: () => true,
-      isReusable: () => false,
-      join: vi.fn(async () => ({ session, spoken: false })),
-      list: () => [],
-      refreshCaptionHealth: async (_session: ZoomMeetingsSession, timeoutMs: number) => {
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, timeoutMs + 50);
+      if (shouldWait) {
+        expect(refreshCaptionHealth).toHaveBeenCalledOnce();
+        expect(result.manualAction).toEqual({
+          reason: "zoom-admission-required",
+          message: "Waiting",
         });
-        session.chrome!.health = {
-          ...session.chrome!.health,
-          lastCaptionText: "Too late",
-          transcriptLines: 1,
-        };
-      },
-      refreshHealth: () => {},
-      resolveAgentId: () => "main",
-    } satisfies ZoomMeetingsProbeContext;
-
-    const pending = testZoomMeetingListening(context, {
-      mode: "transcribe",
-      timeoutMs: 300,
-      url: URL,
-    });
-    await vi.advanceTimersByTimeAsync(400);
-
-    await expect(pending).resolves.toMatchObject({
-      listenTimedOut: true,
-      listenVerified: false,
-    });
-  });
+      } else {
+        expect(refreshCaptionHealth).not.toHaveBeenCalled();
+      }
+    },
+  );
 });

--- a/src/meeting-bot/runtime-probes.test.ts
+++ b/src/meeting-bot/runtime-probes.test.ts
@@ -1,15 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { MeetingPlatformAdapter } from "./platform-adapter.js";
-import { createMeetingRuntimeProbes } from "./runtime-probes.js";
-import type { MeetingBrowserHealth } from "./session-types.js";
+import { createMeetingRuntimeProbes, resolveMeetingProbeTimeoutMs } from "./runtime-probes.js";
+import type { MeetingPluginProbeHealth } from "./session-types.js";
 
 type Mode = "agent" | "bidi" | "transcribe";
 type Transport = "chrome" | "chrome-node";
-type Health = MeetingBrowserHealth & {
-  transcriptLines?: number;
-  lastCaptionAt?: string;
-  lastCaptionText?: string;
-};
+type Health = MeetingPluginProbeHealth;
 type Session = {
   id: string;
   chrome?: {
@@ -32,90 +28,218 @@ type Config = {
   chromeNode: { node?: string };
 };
 
-const cases = [
-  {
-    name: "Google Meet",
-    invalidRequestName: "Error",
-    session: { id: "google", chrome: { launched: true } } satisfies Session,
-    shouldWaitForListening: (session: Session) => Boolean(session.chrome?.launched),
-    waitsForListening: true,
-  },
-  {
-    name: "Teams",
-    invalidRequestName: "Error",
-    session: { id: "teams", chrome: { launched: true } } satisfies Session,
-    shouldWaitForListening: (session: Session) => Boolean(session.chrome?.launched),
-    waitsForListening: true,
-  },
-  {
-    name: "Zoom",
-    invalidRequestName: "ZoomInvalidRequest",
-    session: { id: "zoom", chrome: { launched: true } } satisfies Session,
-    shouldWaitForListening: (session: Session) => Boolean(session.chrome?.browserTab?.targetId),
-    waitsForListening: false,
-  },
-] as const;
+type CreateProbeOptions = {
+  invalidRequest?: (message: string) => Error;
+  shouldWaitForListening?: (session: Session) => boolean;
+};
 
-describe.each(cases)("$name meeting runtime probe parity", (testCase) => {
-  const createProbes = () =>
-    createMeetingRuntimeProbes<Config, Mode, Transport, Health, Session, Request>({
-      defaultSpeechMessage: `Say exactly: ${testCase.name} speech test complete.`,
-      invalidRequest: (message) => {
-        const error = new Error(message);
-        error.name = testCase.invalidRequestName;
-        return error;
-      },
-      resolveTimeoutMs: () => 5,
-      shouldWaitForListening: testCase.shouldWaitForListening,
-      talkBackMode: MeetingPlatformAdapter.isTalkBackMode,
+const URL = "https://example.test/meeting";
+const config: Config = {
+  defaultMode: "agent",
+  chrome: { joinTimeoutMs: 30_000 },
+  chromeNode: {},
+};
+
+function createProbes(options: CreateProbeOptions = {}) {
+  return createMeetingRuntimeProbes<Config, Mode, Transport, Health, Session, Request>({
+    defaultSpeechMessage: "Say exactly: meeting speech test complete.",
+    invalidRequest: options.invalidRequest ?? ((message) => new Error(message)),
+    resolveTimeoutMs: resolveMeetingProbeTimeoutMs,
+    shouldWaitForListening: options.shouldWaitForListening ?? (() => true),
+    talkBackMode: MeetingPlatformAdapter.isTalkBackMode,
+  });
+}
+
+type ProbeContext = Parameters<ReturnType<typeof createProbes>["testSpeech"]>[0];
+
+function createContext(params: {
+  session: Session;
+  spoken?: boolean;
+  existing?: Session[];
+  hasHealthHandle?: boolean;
+  refreshHealth?: () => void;
+  refreshCaptionHealth?: (session: Session, timeoutMs?: number) => Promise<void>;
+}): ProbeContext {
+  return {
+    config,
+    resolveAgentId: () => "main",
+    list: () => params.existing ?? [],
+    join: vi.fn(async () => ({ session: params.session, spoken: params.spoken })),
+    isReusable: () => false,
+    hasHealthHandle: () => params.hasHealthHandle ?? false,
+    refreshHealth: params.refreshHealth ?? vi.fn(),
+    refreshCaptionHealth: params.refreshCaptionHealth ?? vi.fn(async () => undefined),
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("meeting runtime probes", () => {
+  it("uses the supplied invalid-request factory", async () => {
+    const probes = createProbes({
+      invalidRequest: (message) =>
+        Object.assign(new Error(message), { name: "ProbeInvalidRequest" }),
     });
 
-  it("preserves the platform invalid-request contract", async () => {
-    const probes = createProbes();
     await expect(
-      probes.testSpeech(
-        {
-          config: { defaultMode: "agent", chrome: { joinTimeoutMs: 5 }, chromeNode: {} },
-          resolveAgentId: () => "main",
-          list: () => [],
-          join: vi.fn(),
-          isReusable: () => false,
-          hasHealthHandle: () => false,
-          refreshHealth: vi.fn(),
-          refreshCaptionHealth: vi.fn(),
-        },
-        { url: "https://example.test/meeting", mode: "transcribe" },
-      ),
+      probes.testSpeech(createContext({ session: { id: "unused" } }), {
+        url: URL,
+        mode: "transcribe",
+      }),
     ).rejects.toMatchObject({
-      name: testCase.invalidRequestName,
+      name: "ProbeInvalidRequest",
       message: "test_speech requires mode: agent or bidi",
     });
   });
 
-  it("preserves the platform listening wait ownership", async () => {
-    const probes = createProbes();
-    const refreshCaptionHealth = vi.fn(async () => undefined);
-    const context = {
-      config: { defaultMode: "agent" as const, chrome: { joinTimeoutMs: 5 }, chromeNode: {} },
-      resolveAgentId: () => "main",
-      list: () => [],
-      join: vi.fn(async () => ({ session: testCase.session })),
-      isReusable: () => false,
-      hasHealthHandle: () => false,
-      refreshHealth: vi.fn(),
-      refreshCaptionHealth,
-    };
+  it.each([false, true])("honors shouldWaitForListening when it returns %s", async (shouldWait) => {
+    const session: Session = { id: "listen-policy", chrome: { launched: true, health: {} } };
+    const refreshCaptionHealth = vi.fn(async () => {
+      session.chrome!.health = {
+        ...session.chrome!.health,
+        manualAction: { reason: "admission-required", message: "Waiting" },
+      };
+    });
+    const probes = createProbes({ shouldWaitForListening: () => shouldWait });
 
-    await probes.testListening(context, {
-      url: "https://example.test/meeting",
+    await probes.testListening(createContext({ session, refreshCaptionHealth }), {
+      url: URL,
       mode: "transcribe",
-      timeoutMs: 5,
+      timeoutMs: 100,
     });
 
-    if (testCase.waitsForListening) {
-      expect(refreshCaptionHealth).toHaveBeenCalled();
+    if (shouldWait) {
+      expect(refreshCaptionHealth).toHaveBeenCalledOnce();
     } else {
       expect(refreshCaptionHealth).not.toHaveBeenCalled();
     }
+  });
+
+  it("uses the per-request speech verification timeout", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const session: Session = {
+      id: "speech-timeout",
+      chrome: { launched: true, health: { inCall: true, lastOutputBytes: 0 } },
+    };
+    const refreshHealth = vi.fn();
+    const probes = createProbes();
+
+    const pending = probes.testSpeech(
+      createContext({ session, spoken: true, hasHealthHandle: true, refreshHealth }),
+      { url: URL, mode: "agent", timeoutMs: 150 },
+    );
+    await vi.advanceTimersByTimeAsync(200);
+
+    await expect(pending).resolves.toMatchObject({ speechOutputTimedOut: true });
+    expect(refreshHealth).toHaveBeenCalled();
+  });
+
+  it("requires a fresh verified output generation", async () => {
+    const probes = createProbes();
+    for (const [verifiedOutputGeneration, expected] of [
+      [undefined, false],
+      [1, true],
+    ] as const) {
+      const session: Session = {
+        id: `speech-generation-${String(verifiedOutputGeneration)}`,
+        chrome: {
+          launched: true,
+          health: {
+            inCall: true,
+            lastOutputBytes: 4,
+            outputGeneration: 1,
+            verifiedOutputGeneration,
+          },
+        },
+      };
+
+      const result = await probes.testSpeech(createContext({ session, spoken: true }), {
+        url: URL,
+        mode: "agent",
+      });
+
+      expect(result.speechOutputVerified).toBe(expected);
+    }
+  });
+
+  it("bounds a blocked caption refresh by the listening timeout", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const session: Session = { id: "listen-blocked", chrome: { launched: true, health: {} } };
+    const refreshCaptionHealth = vi.fn(
+      (_session: Session, _timeoutMs?: number) => new Promise<void>(() => {}),
+    );
+    const probes = createProbes();
+
+    const pending = probes.testListening(createContext({ session, refreshCaptionHealth }), {
+      url: URL,
+      mode: "transcribe",
+      timeoutMs: 300,
+    });
+    await vi.advanceTimersByTimeAsync(350);
+
+    await expect(pending).resolves.toMatchObject({ listenTimedOut: true });
+    expect(refreshCaptionHealth).toHaveBeenCalledWith(session, 300);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("returns caption progress and manual action before the deadline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const session: Session = { id: "listen-progress", chrome: { launched: true, health: {} } };
+    const refreshCaptionHealth = vi.fn(async () => {
+      session.chrome!.health = {
+        ...session.chrome!.health,
+        lastCaptionText: "Caption already waiting",
+        manualAction: { reason: "admission-required", message: "Waiting" },
+        transcriptLines: 1,
+      };
+    });
+    const probes = createProbes();
+
+    const result = await probes.testListening(createContext({ session, refreshCaptionHealth }), {
+      url: URL,
+      mode: "transcribe",
+      timeoutMs: 100,
+    });
+
+    expect(result).toMatchObject({
+      listenVerified: true,
+      manualAction: { reason: "admission-required", message: "Waiting" },
+    });
+    expect(refreshCaptionHealth).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("rejects caption progress that arrives after the deadline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const session: Session = { id: "listen-late", chrome: { launched: true, health: {} } };
+    const probes = createProbes();
+    const refreshCaptionHealth = async (_session: Session, timeoutMs?: number) => {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, (timeoutMs ?? 0) + 50);
+      });
+      session.chrome!.health = {
+        ...session.chrome!.health,
+        lastCaptionText: "Too late",
+        transcriptLines: 1,
+      };
+    };
+
+    const pending = probes.testListening(createContext({ session, refreshCaptionHealth }), {
+      url: URL,
+      mode: "transcribe",
+      timeoutMs: 300,
+    });
+    await vi.advanceTimersByTimeAsync(400);
+
+    await expect(pending).resolves.toMatchObject({
+      listenTimedOut: true,
+      listenVerified: false,
+    });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Microsoft Teams meeting probe validation threw plain `Error`, while the plugin shell classified only `TeamsMeetingsInvalidRequestError` as an invalid request. As a result, incompatible `testSpeech`/`testListen` modes returned `UNAVAILABLE` instead of `INVALID_REQUEST`.

The same five runtime-probe mechanics were also duplicated in both Teams and Zoom plugin suites even though `src/meeting-bot/runtime-probes.ts` owns them. Shared implementation changes therefore churned two plugin-local copies, and core changes were not guaranteed to select those extension tests.

## Why This Change Was Made

This change:

- adds a Teams-owned invalid-request error factory and uses it consistently in the plugin shell, runtime probe mode validation, and timeout validation;
- adds the missing Teams gateway-boundary regression for incompatible speech/listening modes while retaining browser failure as the `UNAVAILABLE` negative control;
- consolidates request deadlines, verified output generation, blocked refresh bounds, pre-deadline progress, and late-progress rejection in the shared meeting-bot owner suite; and
- reduces Teams and Zoom probe tests to their genuinely different listening-wait policies.

The fix follows Zoom's existing typed-error ownership and leaves Google Meet's provider-specific probe behavior unchanged.

AI-assisted: yes. The complete shared owner, Teams/Zoom/Google wiring, gateway shell classification, history, and CI routing were inspected; fresh structured review found no actionable issue.

## User Impact

Teams probe calls with incompatible modes now report `INVALID_REQUEST`, giving callers the correct actionable error class instead of a misleading availability failure. Normal browser/runtime failures remain `UNAVAILABLE`.

## Evidence

- Pre-fix regression: `extensions/teams-meetings/index.test.ts -t "classifies invalid probe mode"` failed both rows because the actual code was `UNAVAILABLE` instead of `INVALID_REQUEST`.
- Post-fix focused owner and plugin proof: 51 tests passed across shared runtime probes, output loopback, Teams, Zoom, and Google sibling probe paths.
- `node scripts/check-changed.mjs -- ...` for the seven changed/new files — passed format, Plugin SDK API, type, lint, dead-export, boundary, architecture, and safety gates through trusted local fallback because Blacksmith Testbox is unavailable on this host.
- Fresh structured autoreviews before and after rebase plus secret scans — clean.
- `git diff --check` — clean.

Production delta: +6 lines for the typed Teams error owner and wiring. Tests: −189 lines. Overall: −183 lines.
