### PR TITLE
test(tooling): decouple MinGit curl assertion

### DIFF
--- a/test/scripts/parallels-windows-git.test.ts
+++ b/test/scripts/parallels-windows-git.test.ts
@@ -31,8 +31,7 @@ describe("Parallels Windows MinGit preparation", () => {
     }));
 
     await expect(prepareMinGitZip(targetDir)).resolves.toBe(targetPath);
-    expect(runMock).toHaveBeenNthCalledWith(
-      2,
+    expect(runMock).toHaveBeenCalledWith(
       "curl",
       [
         "--retry",


### PR DESCRIPTION
## What Problem This Solves

The MinGit download regression test asserted that curl must be the second mocked process invocation. That absolute call position is not observable behavior: adding an unrelated preparation command would break the test while preserving every download bound.

## Why This Change Was Made

This change replaces `toHaveBeenNthCalledWith(2, ...)` with `toHaveBeenCalledWith(...)` and leaves the complete curl command contract unchanged:

- connection timeout;
- transfer timeout;
- retry count and retry window; and
- the outer 270-second process timeout that bounds a final transfer started near the retry-window edge.

AI-assisted: yes. The production owner, callers, history, curl timing contract, and CI routing were inspected; fresh structured review found no actionable issue.

## User Impact

No runtime behavior change. The focused test still protects bounded MinGit downloads without coupling to unrelated process ordering.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/parallels-windows-git.test.ts` — 1 test passed.
- `node scripts/check-changed.mjs -- test/scripts/parallels-windows-git.test.ts` — passed format, type, lint, tooling, and safety gates through trusted local fallback because Blacksmith Testbox is unavailable on this host.
- Fresh structured autoreview and secret scan — clean.
- `git diff --check` — clean.

Production delta: 0. Tests: −1 line net.
