### PR TITLE
refactor(gateway): extract socket-free kernel factory

### DIFF
--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -707,8 +707,8 @@ export function createGatewayCloseHandler(
       socket: { close: (code: number, reason: string) => void };
     }>;
     configReloader: { stop: () => Promise<void> };
-    wss: WebSocketServer;
-    httpServer: HttpServer;
+    wss?: WebSocketServer;
+    httpServer?: HttpServer;
     httpServers?: HttpServer[];
     drainActiveSessionsForShutdown?: (params: {
       reason: "shutdown" | "restart";
@@ -996,92 +996,102 @@ export function createGatewayCloseHandler(
         recordShutdownWarning(warnings, "ws-clients");
       }
       params.clients.clear();
-      await measureCloseStep("websocket-server", async () => {
-        const wsClients = params.wss.clients ?? new Set();
-        const closePromise = new Promise<void>((resolve) => {
-          params.wss.close(() => resolve());
-        });
-        const websocketGraceTimeout = createTimeoutRace(
-          WEBSOCKET_CLOSE_GRACE_MS,
-          () => false as const,
-        );
-        const closedWithinGrace = await Promise.race([
-          closePromise.then(() => true),
-          websocketGraceTimeout.promise,
-        ]);
-        websocketGraceTimeout.clear();
-        if (!closedWithinGrace) {
-          shutdownLog.warn(
-            `websocket server close exceeded ${WEBSOCKET_CLOSE_GRACE_MS}ms; forcing shutdown continuation with ${wsClients.size} tracked client(s)`,
+      if (params.wss) {
+        await measureCloseStep("websocket-server", async () => {
+          const wsClients = params.wss?.clients ?? new Set();
+          const closePromise = new Promise<void>((resolve) => {
+            params.wss?.close(() => resolve());
+          });
+          const websocketGraceTimeout = createTimeoutRace(
+            WEBSOCKET_CLOSE_GRACE_MS,
+            () => false as const,
           );
-          recordShutdownWarning(warnings, "websocket-server");
-          for (const client of wsClients) {
-            try {
-              client.terminate();
-            } catch {
-              /* ignore */
-            }
-          }
-          const websocketForceTimeout = createTimeoutRace(WEBSOCKET_CLOSE_FORCE_CONTINUE_MS, () => {
-            shutdownLog.warn(
-              `websocket server close still pending after ${WEBSOCKET_CLOSE_FORCE_CONTINUE_MS}ms force window; continuing shutdown`,
-            );
-          });
-          await Promise.race([closePromise, websocketForceTimeout.promise]);
-          websocketForceTimeout.clear();
-        }
-        clearSessionTypingState();
-      });
-      await measureCloseStep("http-server", async () => {
-        const servers =
-          params.httpServers && params.httpServers.length > 0
-            ? params.httpServers
-            : [params.httpServer];
-        for (let i = 0; i < servers.length; i++) {
-          const httpServer = servers[i] as HttpServer & {
-            closeAllConnections?: () => void;
-            closeIdleConnections?: () => void;
-          };
-          const label = servers.length > 1 ? `http-server[${i}]` : "http-server";
-          if (typeof httpServer.closeIdleConnections === "function") {
-            httpServer.closeIdleConnections();
-          }
-          const closePromise = new Promise<void>((resolve, reject) => {
-            httpServer.close((err) => {
-              if (!err || isServerNotRunningError(err)) {
-                resolve();
-                return;
-              }
-              reject(err);
-            });
-          });
-          void closePromise.catch(() => undefined);
-          const closedWithinGrace = await waitForHttpClose({
-            closePromise,
-            timeoutMs: HTTP_CLOSE_GRACE_MS,
-            label,
-            warnings,
-          });
+          const closedWithinGrace = await Promise.race([
+            closePromise.then(() => true),
+            websocketGraceTimeout.promise,
+          ]);
+          websocketGraceTimeout.clear();
           if (!closedWithinGrace) {
             shutdownLog.warn(
-              `${label} close exceeded ${HTTP_CLOSE_GRACE_MS}ms; forcing connection shutdown and waiting for close`,
+              `websocket server close exceeded ${WEBSOCKET_CLOSE_GRACE_MS}ms; forcing shutdown continuation with ${wsClients.size} tracked client(s)`,
             );
-            recordShutdownWarning(warnings, label);
-            httpServer.closeAllConnections?.();
-            const closedAfterForce = await waitForHttpClose({
+            recordShutdownWarning(warnings, "websocket-server");
+            for (const client of wsClients) {
+              try {
+                client.terminate();
+              } catch {
+                /* ignore */
+              }
+            }
+            const websocketForceTimeout = createTimeoutRace(
+              WEBSOCKET_CLOSE_FORCE_CONTINUE_MS,
+              () => {
+                shutdownLog.warn(
+                  `websocket server close still pending after ${WEBSOCKET_CLOSE_FORCE_CONTINUE_MS}ms force window; continuing shutdown`,
+                );
+              },
+            );
+            await Promise.race([closePromise, websocketForceTimeout.promise]);
+            websocketForceTimeout.clear();
+          }
+        });
+      }
+      clearSessionTypingState();
+      const transportServers =
+        params.httpServers && params.httpServers.length > 0
+          ? params.httpServers
+          : params.httpServer
+            ? [params.httpServer]
+            : [];
+      if (transportServers.length > 0) {
+        await measureCloseStep("http-server", async () => {
+          const servers = transportServers;
+          for (let i = 0; i < servers.length; i++) {
+            const httpServer = servers[i] as HttpServer & {
+              closeAllConnections?: () => void;
+              closeIdleConnections?: () => void;
+            };
+            const label = servers.length > 1 ? `http-server[${i}]` : "http-server";
+            if (typeof httpServer.closeIdleConnections === "function") {
+              httpServer.closeIdleConnections();
+            }
+            const closePromise = new Promise<void>((resolve, reject) => {
+              httpServer.close((err) => {
+                if (!err || isServerNotRunningError(err)) {
+                  resolve();
+                  return;
+                }
+                reject(err);
+              });
+            });
+            void closePromise.catch(() => undefined);
+            const closedWithinGrace = await waitForHttpClose({
               closePromise,
-              timeoutMs: HTTP_CLOSE_FORCE_WAIT_MS,
+              timeoutMs: HTTP_CLOSE_GRACE_MS,
               label,
               warnings,
             });
-            if (!closedAfterForce) {
-              throw new Error(
-                `${label} close still pending after forced connection shutdown (${HTTP_CLOSE_FORCE_WAIT_MS}ms)`,
+            if (!closedWithinGrace) {
+              shutdownLog.warn(
+                `${label} close exceeded ${HTTP_CLOSE_GRACE_MS}ms; forcing connection shutdown and waiting for close`,
               );
+              recordShutdownWarning(warnings, label);
+              httpServer.closeAllConnections?.();
+              const closedAfterForce = await waitForHttpClose({
+                closePromise,
+                timeoutMs: HTTP_CLOSE_FORCE_WAIT_MS,
+                label,
+                warnings,
+              });
+              if (!closedAfterForce) {
+                throw new Error(
+                  `${label} close still pending after forced connection shutdown (${HTTP_CLOSE_FORCE_WAIT_MS}ms)`,
+                );
+              }
             }
           }
-        }
-      });
+        });
+      }
       await disposeRuntimeWithShutdownGrace({
         label: "embedding-providers",
         dispose: drainRetainedEmbeddingProvidersOnDemand,

--- a/src/gateway/server-kernel-request-runtime.ts
+++ b/src/gateway/server-kernel-request-runtime.ts
@@ -1,0 +1,231 @@
+import { getRuntimeConfig } from "../config/io.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { createSubsystemLogger } from "../logging/subsystem.js";
+import { createGatewayChatMetadataLifecycle } from "./server-chat-metadata-lifecycle.js";
+import type { startGatewayCoreRuntime } from "./server-core-runtime.js";
+import { attachInitialGatewayLifetimeSidecars } from "./server-lifetime-sidecars.js";
+import { setFallbackGatewayContextResolver } from "./server-plugins.js";
+import { enforceSharedGatewaySessionGenerationForConfigWrite } from "./server-shared-auth-generation.js";
+import {
+  getHealthCache,
+  getHealthVersion,
+  incrementPresenceVersion,
+} from "./server/health-state.js";
+
+type GatewayCoreRuntime = Awaited<ReturnType<typeof startGatewayCoreRuntime>>;
+type GatewayLogger = ReturnType<typeof createSubsystemLogger>;
+
+/** Completes the socket-free request and internal-dispatch half of Gateway startup. */
+export async function prepareGatewayKernelRequestRuntime(params: {
+  coreRuntime: GatewayCoreRuntime;
+  log: GatewayLogger;
+  logHealth: GatewayLogger;
+}) {
+  const { coreRuntime: runtime, log, logHealth } = params;
+  const {
+    minimalTestGateway,
+    deps,
+    runtimeState,
+    unavailableGatewayMethods,
+    sessionCompanion,
+    sessionObserver,
+    getMcpAppSandboxPort,
+    ensureSandboxHostPort,
+    terminalLaunchPolicy,
+    execApprovalManager,
+    cancelRunBoundApprovals,
+    forwardPluginApprovalRequest,
+    pluginApprovalIosPushDelivery,
+    pluginApprovalManager,
+    systemAgentApprovalManager,
+    bindApprovalPublicationContext,
+    validateAgentRuntimeApprovalAuthority,
+    approvalSessionEvents,
+    startupTrace,
+    loadGatewayModelCatalog,
+    loadGatewayModelCatalogSnapshot,
+    readPreparedGatewayModelCatalog,
+    refreshGatewayHealthSnapshotWithRuntime,
+    getRuntimeSnapshot,
+    broadcast,
+    broadcastToConnIds,
+    nodeSendToSession,
+    nodeSendToAllSubscribed,
+    nodeSubscribe,
+    nodeUnsubscribe,
+    nodeUnsubscribeAll,
+    hasTalkNodeConnected,
+    clients,
+    watchNodeHttpRuntime,
+    sharedGatewaySessionGenerationState,
+    resolveSharedGatewaySessionGenerationForRuntimeSnapshot,
+    completeControlUiDeviceAuthMigrationForEffectiveOperator,
+    claimControlUiDeviceAuthMigration,
+    releaseControlUiDeviceAuthMigrationClaim,
+    nodeRegistry,
+    workerEnvironmentService,
+    workerEnvironmentStartup,
+    workerPlacementControlAvailable,
+    terminalSessions,
+    agentRunSeq,
+    chatAbortControllers,
+    chatQueuedTurns,
+    chatRunState,
+    addChatRun,
+    removeChatRun,
+    subscribeSessionMessageEvents,
+    unsubscribeSessionMessageEvents,
+    sessionEventSubscribers,
+    sessionMessageSubscribers,
+    toolEventRecipients,
+    dedupe,
+    wizardSessions,
+    systemAgentSessions,
+    findRunningWizard,
+    purgeWizardSession,
+    readinessEventLoopHealth,
+    startChannel,
+    stopChannel,
+    markChannelLoggedOut,
+    wizardRunner,
+    channelWizardRunner,
+    broadcastVoiceWakeChanged,
+    broadcastVoiceWakeRoutingChanged,
+    pluginGatewayContext,
+    getAttachedGatewayMethodRegistry,
+    gatewayInstanceRuntimeRef,
+    lifecycle,
+    startupState,
+    clearFallbackGatewayContextForServer,
+  } = runtime;
+  const chatMetadataLifecycle = await createGatewayChatMetadataLifecycle({
+    getConfig: getRuntimeConfig,
+    minimalTestGateway,
+    log,
+  });
+  const gatewayRequestContext = await startupTrace.measure("gateway.request-context", async () => {
+    const { createGatewayRequestContext } = await import("./server-request-context.js");
+    return createGatewayRequestContext({
+      deps,
+      runtimeState,
+      sessionCompanion,
+      getRuntimeConfig,
+      sessionObserver,
+      getMcpAppSandboxPort,
+      ensureSandboxHostPort,
+      resolveTerminalLaunchPolicy: terminalLaunchPolicy.resolve,
+      isTerminalEnabled: terminalLaunchPolicy.isEnabled,
+      execApprovalManager,
+      cancelRunBoundApprovals,
+      forwardPluginApprovalRequest,
+      pluginApprovalIosPushDelivery,
+      pluginApprovalManager,
+      systemAgentApprovalManager,
+      listSessionPendingApprovals: approvalSessionEvents.replay,
+      loadGatewayModelCatalog,
+      loadGatewayModelCatalogSnapshot,
+      readPreparedGatewayModelCatalog,
+      readChatMetadata: chatMetadataLifecycle.read,
+      readChatStartupProjection: chatMetadataLifecycle.readStartup,
+      getHealthCache,
+      refreshHealthSnapshot: refreshGatewayHealthSnapshotWithRuntime,
+      logHealth,
+      logGateway: log,
+      incrementPresenceVersion,
+      getHealthVersion,
+      broadcast,
+      broadcastToConnIds,
+      nodeSendToSession,
+      nodeSendToAllSubscribed,
+      nodeSubscribe,
+      nodeUnsubscribe,
+      nodeUnsubscribeAll,
+      hasConnectedTalkNode: hasTalkNodeConnected,
+      clients,
+      invalidateDeviceTransports: watchNodeHttpRuntime.invalidateSessionsForDevice,
+      disconnectDeviceTransports: watchNodeHttpRuntime.disconnectSessionsForDevice,
+      enforceSharedGatewayAuthGenerationForConfigWrite: (nextConfig: OpenClawConfig) => {
+        enforceSharedGatewaySessionGenerationForConfigWrite({
+          state: sharedGatewaySessionGenerationState,
+          nextConfig,
+          resolveRuntimeSnapshotGeneration: resolveSharedGatewaySessionGenerationForRuntimeSnapshot,
+          clients,
+        });
+      },
+      completeControlUiDeviceAuthMigration:
+        completeControlUiDeviceAuthMigrationForEffectiveOperator,
+      claimControlUiDeviceAuthMigration: (deviceId: string) =>
+        claimControlUiDeviceAuthMigration(deviceId, { env: process.env }),
+      releaseControlUiDeviceAuthMigrationClaim: (deviceId: string) =>
+        releaseControlUiDeviceAuthMigrationClaim(deviceId, { env: process.env }),
+      nodeRegistry,
+      ...(workerEnvironmentService ? { workerEnvironmentService } : {}),
+      ...(workerEnvironmentStartup
+        ? { workerSessionPlacementService: workerEnvironmentStartup.placementStore }
+        : {}),
+      ...(workerPlacementControlAvailable
+        ? { workerPlacementDispatchService: workerPlacementControlAvailable }
+        : {}),
+      validateAgentRuntimeApprovalAuthority,
+      terminalSessions,
+      agentRunSeq,
+      chatAbortControllers,
+      chatQueuedTurns,
+      chatRunState,
+      addChatRun,
+      removeChatRun,
+      subscribeSessionEvents: sessionEventSubscribers.subscribe,
+      unsubscribeSessionEvents: sessionEventSubscribers.unsubscribe,
+      subscribeSessionMessageEvents,
+      unsubscribeSessionMessageEvents,
+      unsubscribeAllSessionEvents: (connId: string) => {
+        sessionEventSubscribers.unsubscribe(connId);
+        sessionMessageSubscribers.unsubscribeAll(connId);
+        sessionObserver.removeConnection(connId);
+      },
+      getSessionEventSubscriberConnIds: sessionEventSubscribers.getAll,
+      registerToolEventRecipient: toolEventRecipients.add,
+      dedupe,
+      wizardSessions,
+      systemAgentSessions,
+      findRunningWizard,
+      purgeWizardSession,
+      getRuntimeSnapshot,
+      getEventLoopHealth: readinessEventLoopHealth.snapshot,
+      startChannel,
+      stopChannel,
+      markChannelLoggedOut,
+      wizardRunner,
+      channelWizardRunner,
+      broadcastVoiceWakeChanged,
+      unavailableGatewayMethods,
+      broadcastVoiceWakeRoutingChanged,
+    });
+  });
+  bindApprovalPublicationContext(gatewayRequestContext);
+  await attachInitialGatewayLifetimeSidecars({
+    chatMetadataLifecycle,
+    gatewayRequestContext,
+    sidecars: runtimeState.gatewayLifetimeSidecars,
+  });
+  pluginGatewayContext.current = gatewayRequestContext;
+  const { createGatewayInstanceRuntime } = await import("./server-instance-runtime.js");
+  const gatewayInstanceRuntime = createGatewayInstanceRuntime({
+    getContext: () => gatewayRequestContext,
+    getMethodRegistry: () => getAttachedGatewayMethodRegistry(),
+    isDispatchAvailable: () => startupState.dispatchReady && !lifecycle.closePreludeStarted,
+    logError: (message) => log.error(message),
+  });
+  gatewayInstanceRuntimeRef.current = gatewayInstanceRuntime;
+  gatewayRequestContext.approvalEvents = gatewayInstanceRuntime.approvalEvents;
+  gatewayRequestContext.recoveryRuntime = gatewayInstanceRuntime.recovery;
+  const clearFallbackContext: unknown = setFallbackGatewayContextResolver(
+    () => gatewayRequestContext,
+  );
+  clearFallbackGatewayContextForServer.set(
+    typeof clearFallbackContext === "function" ? () => clearFallbackContext() : () => {},
+  );
+  return { ...runtime, chatMetadataLifecycle, gatewayRequestContext, gatewayInstanceRuntime };
+}
+
+export type GatewayKernelRuntime = Awaited<ReturnType<typeof prepareGatewayKernelRequestRuntime>>;

--- a/src/gateway/server-kernel.test.ts
+++ b/src/gateway/server-kernel.test.ts
@@ -1,0 +1,190 @@
+import fs from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
+import { getActiveSecretsRuntimeConfigSnapshot } from "../secrets/runtime-state.js";
+import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { getFreePort } from "../test-utils/ports.js";
+import { CLI_DEFAULT_OPERATOR_SCOPES } from "./method-scopes.js";
+import { dispatchGatewayRequestInProcess } from "./server-in-process-dispatch.js";
+import { createSyntheticPluginRuntimeClient } from "./server-plugin-runtime-client.js";
+import { createGatewayKernel } from "./server-start.js";
+
+describe("createGatewayKernel", () => {
+  it("dispatches health and an agent turn without creating a transport", async () => {
+    const port = await getFreePort();
+    const state = await createOpenClawTestState({
+      label: "gateway-kernel-no-transport",
+      layout: "home",
+      env: {
+        OPENCLAW_DIAGNOSTICS: "1",
+        OPENCLAW_DIAGNOSTICS_TIMELINE_PATH: undefined,
+        OPENCLAW_GATEWAY_PASSWORD: undefined,
+        OPENCLAW_GATEWAY_TOKEN: undefined,
+        OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+        OPENCLAW_SKIP_CANVAS_HOST: "1",
+        OPENCLAW_SKIP_CHANNELS: "1",
+        OPENCLAW_SKIP_CRON: "1",
+        OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+        OPENCLAW_SKIP_PROVIDERS: "1",
+        OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+        VITEST: "1",
+      },
+    });
+    const timelinePath = state.path("kernel-startup.jsonl");
+    state.envVars.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH = timelinePath;
+    const token = "gateway-kernel-no-transport-token";
+    await state.writeConfig({
+      gateway: {
+        auth: { mode: "token", token },
+        controlUi: { enabled: false },
+        port,
+      },
+    });
+    state.applyEnv();
+
+    const kernel = await createGatewayKernel(port, {
+      auth: { mode: "token", token },
+      bind: "loopback",
+      controlUiEnabled: false,
+      sidecarStartup: "defer",
+    });
+    try {
+      expect(kernel.transportBridge.current()).toBeUndefined();
+      await expect(kernel.ensureSandboxHostPort()).rejects.toThrow(
+        "Gateway listener must start before the sandbox host",
+      );
+
+      kernel.kernel.setDispatchReady(true);
+      const client = createSyntheticPluginRuntimeClient({
+        scopes: [...CLI_DEFAULT_OPERATOR_SCOPES],
+      });
+      await expect(
+        dispatchGatewayRequestInProcess(
+          "health",
+          {},
+          {
+            client,
+            context: kernel.gatewayRequestContext,
+            methodRegistry: kernel.getAttachedGatewayMethodRegistry(),
+          },
+        ),
+      ).resolves.toEqual(expect.objectContaining({ ok: true }));
+
+      const idempotencyKey = "kernel-factory-agent";
+      kernel.dedupe.set(`agent:${idempotencyKey}`, {
+        ts: Date.now(),
+        ok: true,
+        payload: { runId: "kernel-run", status: "ok", summary: "cached" },
+      });
+      await expect(
+        kernel.gatewayInstanceRuntime.recovery.dispatchAgent({
+          message: "kernel factory proof",
+          idempotencyKey,
+        }),
+      ).resolves.toEqual({ runId: "kernel-run", status: "ok", summary: "cached" });
+      expect(getActiveGatewayRootWorkCount()).toBe(0);
+
+      const timeline = (await fs.readFile(timelinePath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as Record<string, unknown>);
+      const measureNames = timeline
+        .filter((event) => event.type === "span.start" && event.phase === "startup")
+        .map((event) => {
+          const attributes = event.attributes as { traceName?: string } | undefined;
+          return attributes?.traceName ?? event.name;
+        });
+      expect(measureNames).toEqual([
+        "config.snapshot",
+        "config.snapshot.read",
+        "config.snapshot.read.file",
+        "config.snapshot.read.hash",
+        "config.snapshot.read.parse",
+        "config.snapshot.read.includes",
+        "config.snapshot.read.env",
+        "config.snapshot.read.validate",
+        "plugins.metadata.scan",
+        "plugins.metadata.freeze",
+        "config.snapshot.read.materialize",
+        "config.snapshot.read.observe",
+        "config.auth",
+        "config.auth.snapshot-validate",
+        "config.auth.runtime-overrides",
+        "config.auth.startup-overrides",
+        "config.auth.secret-surface",
+        "config.auth.secret-preflight",
+        "config.auth.preflight-override",
+        "config.auth.ensure",
+        "config.auth.runtime-startup-overrides",
+        "config.auth.secrets-activate",
+        "startup.maintenance",
+        "plugins.bootstrap",
+        "plugins.metadata.scan",
+        "plugins.metadata.freeze",
+        "runtime.config",
+        "control-ui.root",
+        "tls.runtime",
+        "runtime.state",
+        "runtime.early",
+        "runtime.early.discovery",
+        "runtime.post-early-imports",
+        "runtime.subscriptions",
+        "runtime.services",
+        "gateway.handlers",
+        "gateway.request-context",
+      ]);
+    } finally {
+      await kernel.closeOnStartupFailure();
+      await state.cleanup();
+    }
+  });
+
+  it("runs kernel teardown when required TLS material is unavailable", async () => {
+    const port = await getFreePort();
+    const state = await createOpenClawTestState({
+      label: "gateway-kernel-tls-failure",
+      layout: "home",
+      env: {
+        OPENCLAW_GATEWAY_PASSWORD: undefined,
+        OPENCLAW_GATEWAY_TOKEN: undefined,
+        OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+        OPENCLAW_SKIP_CANVAS_HOST: "1",
+        OPENCLAW_SKIP_CHANNELS: "1",
+        OPENCLAW_SKIP_CRON: "1",
+        OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+        OPENCLAW_SKIP_PROVIDERS: "1",
+        OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+        VITEST: "1",
+      },
+    });
+    const token = "gateway-kernel-tls-failure-token";
+    await state.writeConfig({
+      gateway: {
+        auth: { mode: "token", token },
+        controlUi: { enabled: false },
+        port,
+        tls: {
+          enabled: true,
+          autoGenerate: false,
+          certPath: state.path("missing-cert.pem"),
+          keyPath: state.path("missing-key.pem"),
+        },
+      },
+    });
+    state.applyEnv();
+    try {
+      await expect(
+        createGatewayKernel(port, {
+          auth: { mode: "token", token },
+          bind: "loopback",
+          controlUiEnabled: false,
+          sidecarStartup: "defer",
+        }),
+      ).rejects.toThrow("gateway tls: cert/key missing");
+      expect(getActiveSecretsRuntimeConfigSnapshot()).toBeNull();
+      expect(getActiveGatewayRootWorkCount()).toBe(0);
+    } finally {
+      await state.cleanup();
+    }
+  });
+});

--- a/src/gateway/server-lifecycle.ts
+++ b/src/gateway/server-lifecycle.ts
@@ -33,7 +33,7 @@ import {
   type GatewayCloseOptions,
   shouldRetainControlUiDeviceAuthMigrationSession,
 } from "./server-public.js";
-import type { prepareGatewayRuntimeState } from "./server-runtime-state-prepare.js";
+import type { prepareGatewayKernelState } from "./server-runtime-state-prepare.js";
 import {
   getHealthVersion,
   incrementPresenceVersion,
@@ -42,7 +42,7 @@ import {
 import { broadcastPresenceSnapshot } from "./server/presence-events.js";
 import { createSessionViewerPresenceDeclarations } from "./session-viewer-presence.js";
 
-type GatewayRuntimePreparation = Awaited<ReturnType<typeof prepareGatewayRuntimeState>>;
+type GatewayRuntimePreparation = Awaited<ReturnType<typeof prepareGatewayKernelState>>;
 type GatewayLogger = ReturnType<typeof createSubsystemLogger>;
 
 export async function prepareGatewayLifecycle(params: {
@@ -70,7 +70,7 @@ export async function prepareGatewayLifecycle(params: {
     controlUiDeviceAuthMigration,
     completeControlUiDeviceAuthMigration,
     workerGatewayEndpoint,
-    getWorkerIngressEndpoint,
+    transportBridge,
     sessionMessageSubscribers,
     clients,
     broadcast,
@@ -87,9 +87,6 @@ export async function prepareGatewayLifecycle(params: {
     startupState,
     readinessEventLoopHealth,
     browserAuthRateLimiter,
-    wss,
-    httpServer,
-    httpServers,
     chatRunState,
     chatAbortControllers,
     chatQueuedTurns,
@@ -147,7 +144,7 @@ export async function prepareGatewayLifecycle(params: {
   const unsubscribeEffectiveOperatorPairing = onEffectiveOperatorDevicePaired(
     completeControlUiDeviceAuthMigrationForEffectiveOperator,
   );
-  workerGatewayEndpoint.resolve = getWorkerIngressEndpoint;
+  workerGatewayEndpoint.resolve = transportBridge.getWorkerIngressEndpoint;
   const subscribeSessionMessageEvents: GatewayRequestContext["subscribeSessionMessageEvents"] = (
     connId,
     sessionKey,
@@ -422,6 +419,7 @@ export async function prepareGatewayLifecycle(params: {
     const channelIds = listLoadedChannelPlugins().map((plugin) => plugin.id as ChannelId);
     const { createGatewayCloseHandler, drainActiveSessionsForShutdown } =
       await loadGatewayCloseModule();
+    const transport = transportBridge.current();
     await createGatewayCloseHandler({
       bonjourStop: runtimeState.bonjourStop,
       tailscaleCleanup: runtimeState.tailscaleCleanup,
@@ -479,9 +477,13 @@ export async function prepareGatewayLifecycle(params: {
       getPendingReplyCount: getTotalPendingReplies,
       clients,
       configReloader: { stop: stopConfigReloaderForClose },
-      wss,
-      httpServer,
-      httpServers,
+      ...(transport
+        ? {
+            wss: transport.wss,
+            httpServer: transport.httpServer,
+            httpServers: transport.httpServers,
+          }
+        : {}),
       drainActiveSessionsForShutdown,
     })(optsValue);
   };

--- a/src/gateway/server-runtime-state-prepare.ts
+++ b/src/gateway/server-runtime-state-prepare.ts
@@ -24,6 +24,7 @@ import type { GatewayRequestContext } from "./server-methods/types.js";
 import { createGatewayHttpTransport } from "./server-runtime-state.js";
 import type { SharedGatewaySessionGenerationState } from "./server-shared-auth-generation.js";
 import type { prepareGatewayServerBootstrap } from "./server-startup-bootstrap.js";
+import { createGatewayTransportBridge } from "./server-transport-bridge.js";
 import { createWizardSessionTracker } from "./server-wizard-sessions.js";
 import { createGatewayEventLoopHealthMonitor } from "./server/event-loop-health.js";
 import { resolveHookClientIpConfig } from "./server/hook-client-ip-config.js";
@@ -61,7 +62,7 @@ function listGatewayStartupChannelPlugins(): GatewayStartupChannelPlugin[] {
   return listLoadedChannelPlugins() as GatewayStartupChannelPlugin[];
 }
 
-export async function prepareGatewayRuntimeState(params: {
+export async function prepareGatewayKernelState(params: {
   bootstrap: GatewayBootstrap;
   port: number;
   opts: GatewayBootstrap["opts"];
@@ -298,9 +299,6 @@ export async function prepareGatewayRuntimeState(params: {
   const gatewayTls = await startupTrace.measure("tls.runtime", () =>
     loadGatewayTlsRuntime(cfgAtStart.gateway?.tls, log.child("tls")),
   );
-  if (cfgAtStart.gateway?.tls?.enabled && !gatewayTls.enabled) {
-    throw new Error(gatewayTls.error ?? "gateway tls: failed to enable");
-  }
   const serverStartedAt = Date.now();
   const readinessEventLoopHealth = createGatewayEventLoopHealthMonitor();
   const startupState = {
@@ -352,59 +350,61 @@ export async function prepareGatewayRuntimeState(params: {
       isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||
       isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS),
   });
-  log.info("starting HTTP server...");
   const pluginGatewayContext: { current: GatewayRequestContext | undefined } = {
     current: undefined,
   };
   const watchNodeRequestHandler: {
     current?: (req: IncomingMessage, res: ServerResponse) => Promise<boolean>;
   } = {};
-  const { connectionState, httpTransport } = await startupTrace.measure(
-    "runtime.state",
-    async () => {
-      const createdConnectionState = createGatewayConnectionState({
-        cfg: cfgAtStart,
-        getRuntimeConfig,
-      });
-      const createdHttpTransport = await createGatewayHttpTransport({
-        cfg: cfgAtStart,
-        getRuntimeConfig,
-        bindHost,
-        port,
-        controlUiEnabled,
-        controlUiBasePath,
-        controlUiRoot: controlUiRootLifecycle.state,
-        openAiChatCompletionsEnabled,
-        openAiChatCompletionsConfig,
-        openResponsesEnabled,
-        openResponsesConfig,
-        strictTransportSecurityHeader,
-        resolvedAuth,
-        rateLimiter: authRateLimiter,
-        isTerminalEnabled: terminalLaunchPolicy.isEnabled,
-        gatewayTls,
-        getResolvedAuth,
-        hooksConfig: () => runtimeStateRef.current?.hooksConfig ?? initialHooksConfig,
-        getHookClientIpConfig: () =>
-          runtimeStateRef.current?.hookClientIpConfig ?? initialHookClientIpConfig,
-        pluginRegistry: pluginRuntime.registry,
-        getPluginRouteRegistry: () => pluginRuntime.registry,
-        isStartupPluginRuntimeReady: () => startupState.sidecarsReady,
-        getGatewayRequestContext: () => pluginGatewayContext.current,
-        deps,
-        log,
-        logHooks,
-        logPlugins,
-        getReadiness,
-        handleWatchNodeRequest: async (req, res) =>
-          (await watchNodeRequestHandler.current?.(req, res)) ?? false,
-        workerIngressEnabled: Boolean(workerEnvironmentService),
-        workerDesktopTunnels: workerTunnelManager?.desktop,
-        clients: createdConnectionState.clients,
-      });
-      return { connectionState: createdConnectionState, httpTransport: createdHttpTransport };
-    },
+  // Preserve the operator-visible startup log order even though transport binds later.
+  log.info("starting HTTP server...");
+  const connectionState = await startupTrace.measure("runtime.state", () =>
+    createGatewayConnectionState({
+      cfg: cfgAtStart,
+      getRuntimeConfig,
+    }),
   );
+  const transportBridge = createGatewayTransportBridge();
+  const createHttpTransport = async () => {
+    const transport = await createGatewayHttpTransport({
+      cfg: cfgAtStart,
+      getRuntimeConfig,
+      bindHost,
+      port,
+      controlUiEnabled,
+      controlUiBasePath,
+      controlUiRoot: controlUiRootLifecycle.state,
+      openAiChatCompletionsEnabled,
+      openAiChatCompletionsConfig,
+      openResponsesEnabled,
+      openResponsesConfig,
+      strictTransportSecurityHeader,
+      resolvedAuth,
+      rateLimiter: authRateLimiter,
+      isTerminalEnabled: terminalLaunchPolicy.isEnabled,
+      gatewayTls,
+      getResolvedAuth,
+      hooksConfig: () => runtimeStateRef.current?.hooksConfig ?? initialHooksConfig,
+      getHookClientIpConfig: () =>
+        runtimeStateRef.current?.hookClientIpConfig ?? initialHookClientIpConfig,
+      pluginRegistry: pluginRuntime.registry,
+      getPluginRouteRegistry: () => pluginRuntime.registry,
+      isStartupPluginRuntimeReady: () => startupState.sidecarsReady,
+      getGatewayRequestContext: () => pluginGatewayContext.current,
+      deps,
+      log,
+      logHooks,
+      logPlugins,
+      getReadiness,
+      handleWatchNodeRequest: async (req, res) =>
+        (await watchNodeRequestHandler.current?.(req, res)) ?? false,
+      workerIngressEnabled: Boolean(workerEnvironmentService),
+      workerDesktopTunnels: workerTunnelManager?.desktop,
+      clients: connectionState.clients,
+    });
+    transportBridge.attach(transport);
+    return transport;
+  };
   const {
     clients,
     broadcast,
@@ -422,17 +422,6 @@ export async function prepareGatewayRuntimeState(params: {
     sessionEventSubscribers,
     sessionMessageSubscribers,
   } = connectionState;
-  const {
-    httpServer,
-    httpServers,
-    httpBindHosts,
-    startListening,
-    wss,
-    preauthConnectionBudget,
-    getWorkerIngressEndpoint,
-    getMcpAppSandboxPort,
-    ensureSandboxHostPort,
-  } = httpTransport;
 
   return {
     ...bootstrap,
@@ -491,12 +480,8 @@ export async function prepareGatewayRuntimeState(params: {
     isGatewayStartupPending,
     pluginGatewayContext,
     watchNodeRequestHandler,
-    httpServer,
-    httpServers,
-    httpBindHosts,
-    startListening,
-    wss,
-    preauthConnectionBudget,
+    createHttpTransport,
+    transportBridge,
     clients,
     broadcast,
     broadcastToConnIds,
@@ -512,9 +497,9 @@ export async function prepareGatewayRuntimeState(params: {
     toolEventRecipients,
     sessionEventSubscribers,
     sessionMessageSubscribers,
-    getWorkerIngressEndpoint,
-    getMcpAppSandboxPort,
-    ensureSandboxHostPort,
+    getWorkerIngressEndpoint: transportBridge.getWorkerIngressEndpoint,
+    getMcpAppSandboxPort: transportBridge.getMcpAppSandboxPort,
+    ensureSandboxHostPort: transportBridge.ensureSandboxHostPort,
     workerGatewayEndpoint,
   };
 }

--- a/src/gateway/server-start.ts
+++ b/src/gateway/server-start.ts
@@ -1,11 +1,14 @@
 import { isNixMode } from "../config/paths.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import { createSubsystemLogger, runtimeForLogger } from "../logging/subsystem.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { clearSecretsRuntimeSnapshot } from "../secrets/runtime-state.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { startGatewayCoreRuntime } from "./server-core-runtime.js";
+import { prepareGatewayKernelRequestRuntime } from "./server-kernel-request-runtime.js";
 import { prepareGatewayLifecycle } from "./server-lifecycle.js";
 import type { GatewayServer, GatewayServerOptions } from "./server-public.js";
-import { prepareGatewayRuntimeState } from "./server-runtime-state-prepare.js";
+import { prepareGatewayKernelState } from "./server-runtime-state-prepare.js";
 import { prepareGatewayServerBootstrap } from "./server-startup-bootstrap.js";
 import { finishGatewayStartup } from "./server-startup-finish.js";
 type LoadGatewayModelCatalog = typeof import("./server-model-catalog.js").loadGatewayModelCatalog;
@@ -105,42 +108,11 @@ export async function startGatewayServerCore(
   port = 18789,
   opts: GatewayServerOptions = {},
 ): Promise<GatewayServer> {
-  ensureOpenClawCliOnPath();
   let releasePostReadyWork: () => void = () => {};
   const postReadyWorkBarrier = new Promise<void>((resolve) => {
     releasePostReadyWork = resolve;
   });
-  const bootstrap = await prepareGatewayServerBootstrap({
-    port,
-    opts,
-    log,
-    logSecrets,
-    loadWorkerEnvironmentStartupModule,
-    formatRuntimeGatewayAuthTokenWarning,
-  });
-  const runtime = await prepareGatewayRuntimeState({
-    bootstrap,
-    port,
-    opts,
-    log,
-    logChannels,
-    logHooks,
-    logPlugins,
-    gatewayRuntime,
-    resolveChannelRuntime: getChannelRuntime,
-    loadWorkerEnvironmentStartupModule,
-    loadWorkerPlacementStartupModule,
-  });
-  const lifecycleRuntime = await prepareGatewayLifecycle({
-    runtime,
-    port,
-    log,
-    logCron,
-    diagnosticsEnabled: bootstrap.diagnosticsEnabled,
-    loadGatewayCloseModule,
-    closeMcpLoopbackServerOnDemand,
-    stopTaskRegistryMaintenanceOnDemand,
-  });
+  const gatewayKernel = await createGatewayKernel(port, opts);
   const {
     beginClosePrelude,
     clearFallbackGatewayContextForServer,
@@ -150,23 +122,11 @@ export async function startGatewayServerCore(
     stopRegisteredGatewayLifetimeSidecars,
     stopRegisteredPostReadySidecars,
     terminalSessions,
-  } = lifecycleRuntime;
+  } = gatewayKernel;
   try {
-    const coreRuntime = await startGatewayCoreRuntime({
-      lifecycleRuntime,
-      port,
-      log,
-      logDiscovery,
-      logHealth,
-      logChannels,
-      loadGatewayStartupEarlyModule,
-      loadGatewayPluginBootstrapModule,
-      loadGatewayModelCatalog,
-      loadGatewayModelCatalogSnapshot,
-      readPreparedGatewayModelCatalog,
-    });
+    const transport = await gatewayKernel.createHttpTransport();
     await finishGatewayStartup({
-      coreRuntime,
+      kernelRuntime: { ...gatewayKernel, ...transport },
       port,
       opts,
       log,
@@ -213,4 +173,68 @@ export async function startGatewayServerCore(
       }
     },
   };
+}
+
+/** Builds the Gateway kernel and internal dispatch surface without creating HTTP servers. */
+export async function createGatewayKernel(port = 18789, opts: GatewayServerOptions = {}) {
+  ensureOpenClawCliOnPath();
+  let lifecycleRuntime: Awaited<ReturnType<typeof prepareGatewayLifecycle>> | undefined;
+  try {
+    const bootstrap = await prepareGatewayServerBootstrap({
+      port,
+      opts,
+      log,
+      logSecrets,
+      loadWorkerEnvironmentStartupModule,
+      formatRuntimeGatewayAuthTokenWarning,
+    });
+    const runtime = await prepareGatewayKernelState({
+      bootstrap,
+      port,
+      opts,
+      log,
+      logChannels,
+      logHooks,
+      logPlugins,
+      gatewayRuntime,
+      resolveChannelRuntime: getChannelRuntime,
+      loadWorkerEnvironmentStartupModule,
+      loadWorkerPlacementStartupModule,
+    });
+    lifecycleRuntime = await prepareGatewayLifecycle({
+      runtime,
+      port,
+      log,
+      logCron,
+      diagnosticsEnabled: bootstrap.diagnosticsEnabled,
+      loadGatewayCloseModule,
+      closeMcpLoopbackServerOnDemand,
+      stopTaskRegistryMaintenanceOnDemand,
+    });
+    if (bootstrap.cfgAtStart.gateway?.tls?.enabled && !runtime.gatewayTls.enabled) {
+      throw new Error(runtime.gatewayTls.error ?? "gateway tls: failed to enable");
+    }
+    const coreRuntime = await startGatewayCoreRuntime({
+      lifecycleRuntime,
+      port,
+      log,
+      logDiscovery,
+      logHealth,
+      logChannels,
+      loadGatewayStartupEarlyModule,
+      loadGatewayPluginBootstrapModule,
+      loadGatewayModelCatalog,
+      loadGatewayModelCatalogSnapshot,
+      readPreparedGatewayModelCatalog,
+    });
+    return await prepareGatewayKernelRequestRuntime({ coreRuntime, log, logHealth });
+  } catch (error) {
+    if (lifecycleRuntime) {
+      await lifecycleRuntime.closeOnStartupFailure();
+    } else {
+      clearSecretsRuntimeSnapshot();
+      clearPluginMetadataLifecycleCaches();
+    }
+    throw error;
+  }
 }

--- a/src/gateway/server-startup-finish.ts
+++ b/src/gateway/server-startup-finish.ts
@@ -7,37 +7,26 @@ import {
   registerConfigWriteListener,
 } from "../config/io.js";
 import { isNixMode } from "../config/paths.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginHookGatewayCronService } from "../plugins/hook-types.js";
 import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
 import { createLazyPromise } from "../shared/lazy-runtime.js";
 import { collectGatewayProcessMemoryUsageMb, finishGatewayRestartTrace } from "./restart-trace.js";
-import { createGatewayChatMetadataLifecycle } from "./server-chat-metadata-lifecycle.js";
-import type { startGatewayCoreRuntime } from "./server-core-runtime.js";
-import {
-  attachInitialGatewayLifetimeSidecars,
-  publishGatewayLifetimeSidecars,
-} from "./server-lifetime-sidecars.js";
+import type { GatewayKernelRuntime } from "./server-kernel-request-runtime.js";
+import { publishGatewayLifetimeSidecars } from "./server-lifetime-sidecars.js";
 import { GATEWAY_EVENTS } from "./server-methods-list.js";
-import { setFallbackGatewayContextResolver } from "./server-plugins.js";
-import {
-  enforceSharedGatewaySessionGenerationForConfigWrite,
-  getRequiredSharedGatewaySessionGeneration,
-} from "./server-shared-auth-generation.js";
-import {
-  getHealthCache,
-  getHealthVersion,
-  incrementPresenceVersion,
-} from "./server/health-state.js";
+import { getRequiredSharedGatewaySessionGeneration } from "./server-shared-auth-generation.js";
+import type { GatewayHttpTransport } from "./server-transport-bridge.js";
 
-type GatewayCoreRuntime = Awaited<ReturnType<typeof startGatewayCoreRuntime>>;
 type GatewayLogger = ReturnType<typeof createSubsystemLogger>;
 const [POST_READY_MAINTENANCE_DELAY_MS, RETAINED_PLUGIN_CLEANUP_DELAY_MS] = [250, 30_000];
+
+type GatewayStartedRuntime = GatewayKernelRuntime & GatewayHttpTransport;
+
 export async function finishGatewayStartup(params: {
-  coreRuntime: GatewayCoreRuntime;
+  kernelRuntime: GatewayStartedRuntime;
   port: number;
-  opts: GatewayCoreRuntime["opts"];
+  opts: GatewayStartedRuntime["opts"];
   log: GatewayLogger;
   logHealth: GatewayLogger;
   logWsControl: GatewayLogger;
@@ -52,7 +41,7 @@ export async function finishGatewayStartup(params: {
   waitForPostReadyWork: () => Promise<void>;
 }) {
   const {
-    coreRuntime: runtime,
+    kernelRuntime: runtime,
     port,
     opts,
     log,
@@ -69,76 +58,20 @@ export async function finishGatewayStartup(params: {
     minimalTestGateway,
     deps,
     runtimeState,
-    unavailableGatewayMethods,
     kernel,
-    sessionCompanion,
-    sessionObserver,
-    getMcpAppSandboxPort,
-    ensureSandboxHostPort,
-    terminalLaunchPolicy,
-    execApprovalManager,
-    cancelRunBoundApprovals,
-    forwardPluginApprovalRequest,
-    pluginApprovalIosPushDelivery,
-    pluginApprovalManager,
-    systemAgentApprovalManager,
-    bindApprovalPublicationContext,
-    validateAgentRuntimeApprovalAuthority,
-    approvalSessionEvents,
     startupTrace,
-    loadGatewayModelCatalog,
-    loadGatewayModelCatalogSnapshot,
-    readPreparedGatewayModelCatalog,
-    refreshGatewayHealthSnapshotWithRuntime,
-    getRuntimeSnapshot,
     broadcast,
     broadcastToConnIds,
-    nodeSendToSession,
-    nodeSendToAllSubscribed,
-    nodeSubscribe,
-    nodeUnsubscribe,
-    nodeUnsubscribeAll,
-    hasTalkNodeConnected,
     clients,
-    watchNodeHttpRuntime,
     sharedGatewaySessionGenerationState,
-    resolveSharedGatewaySessionGenerationForRuntimeSnapshot,
-    completeControlUiDeviceAuthMigrationForEffectiveOperator,
-    claimControlUiDeviceAuthMigration,
-    releaseControlUiDeviceAuthMigrationClaim,
     controlUiDeviceAuthMigration,
-    nodeRegistry,
     workerEnvironmentService,
-    workerEnvironmentStartup,
     workerPlacementRuntime,
-    workerPlacementControlAvailable,
+    terminalLaunchPolicy,
     terminalSessions,
-    agentRunSeq,
-    chatAbortControllers,
-    chatQueuedTurns,
-    chatRunState,
-    addChatRun,
-    removeChatRun,
-    subscribeSessionMessageEvents,
-    unsubscribeSessionMessageEvents,
-    sessionEventSubscribers,
-    sessionMessageSubscribers,
-    toolEventRecipients,
-    dedupe,
-    wizardSessions,
-    systemAgentSessions,
-    findRunningWizard,
-    purgeWizardSession,
     startChannel,
     stopChannel,
-    markChannelLoggedOut,
-    wizardRunner,
-    channelWizardRunner,
-    broadcastVoiceWakeChanged,
-    broadcastVoiceWakeRoutingChanged,
-    pluginGatewayContext,
     getAttachedGatewayMethodRegistry,
-    gatewayInstanceRuntimeRef,
     lifecycle,
     startupState,
     pluginRuntime,
@@ -192,137 +125,11 @@ export async function finishGatewayStartup(params: {
     applyFixedGatewayOverlays,
     resolveSharedGatewaySessionGenerationForConfig,
     reloadAttachedGatewayPlugins,
-    readinessEventLoopHealth,
     stopRegisteredPostReadySidecars,
-    clearFallbackGatewayContextForServer,
-  } = runtime;
-  const chatMetadataLifecycle = await createGatewayChatMetadataLifecycle({
-    getConfig: getRuntimeConfig,
-    minimalTestGateway,
-    log,
-  });
-  const gatewayRequestContext = await startupTrace.measure("gateway.request-context", async () => {
-    const { createGatewayRequestContext } = await import("./server-request-context.js");
-    return createGatewayRequestContext({
-      deps,
-      runtimeState,
-      sessionCompanion,
-      getRuntimeConfig,
-      sessionObserver,
-      getMcpAppSandboxPort,
-      ensureSandboxHostPort,
-      resolveTerminalLaunchPolicy: terminalLaunchPolicy.resolve,
-      isTerminalEnabled: terminalLaunchPolicy.isEnabled,
-      execApprovalManager,
-      cancelRunBoundApprovals,
-      forwardPluginApprovalRequest,
-      pluginApprovalIosPushDelivery,
-      pluginApprovalManager,
-      systemAgentApprovalManager,
-      listSessionPendingApprovals: approvalSessionEvents.replay,
-      loadGatewayModelCatalog,
-      loadGatewayModelCatalogSnapshot,
-      readPreparedGatewayModelCatalog,
-      readChatMetadata: chatMetadataLifecycle.read,
-      readChatStartupProjection: chatMetadataLifecycle.readStartup,
-      getHealthCache,
-      refreshHealthSnapshot: refreshGatewayHealthSnapshotWithRuntime,
-      logHealth,
-      logGateway: log,
-      incrementPresenceVersion,
-      getHealthVersion,
-      broadcast,
-      broadcastToConnIds,
-      nodeSendToSession,
-      nodeSendToAllSubscribed,
-      nodeSubscribe,
-      nodeUnsubscribe,
-      nodeUnsubscribeAll,
-      hasConnectedTalkNode: hasTalkNodeConnected,
-      clients,
-      invalidateDeviceTransports: watchNodeHttpRuntime.invalidateSessionsForDevice,
-      disconnectDeviceTransports: watchNodeHttpRuntime.disconnectSessionsForDevice,
-      enforceSharedGatewayAuthGenerationForConfigWrite: (nextConfig: OpenClawConfig) => {
-        enforceSharedGatewaySessionGenerationForConfigWrite({
-          state: sharedGatewaySessionGenerationState,
-          nextConfig,
-          resolveRuntimeSnapshotGeneration: resolveSharedGatewaySessionGenerationForRuntimeSnapshot,
-          clients,
-        });
-      },
-      completeControlUiDeviceAuthMigration:
-        completeControlUiDeviceAuthMigrationForEffectiveOperator,
-      claimControlUiDeviceAuthMigration: (deviceId: string) =>
-        claimControlUiDeviceAuthMigration(deviceId, { env: process.env }),
-      releaseControlUiDeviceAuthMigrationClaim: (deviceId: string) =>
-        releaseControlUiDeviceAuthMigrationClaim(deviceId, { env: process.env }),
-      nodeRegistry,
-      ...(workerEnvironmentService ? { workerEnvironmentService } : {}),
-      ...(workerEnvironmentStartup
-        ? { workerSessionPlacementService: workerEnvironmentStartup.placementStore }
-        : {}),
-      ...(workerPlacementControlAvailable
-        ? { workerPlacementDispatchService: workerPlacementControlAvailable }
-        : {}),
-      validateAgentRuntimeApprovalAuthority,
-      terminalSessions,
-      agentRunSeq,
-      chatAbortControllers,
-      chatQueuedTurns,
-      chatRunState,
-      addChatRun,
-      removeChatRun,
-      subscribeSessionEvents: sessionEventSubscribers.subscribe,
-      unsubscribeSessionEvents: sessionEventSubscribers.unsubscribe,
-      subscribeSessionMessageEvents,
-      unsubscribeSessionMessageEvents,
-      unsubscribeAllSessionEvents: (connId: string) => {
-        sessionEventSubscribers.unsubscribe(connId);
-        sessionMessageSubscribers.unsubscribeAll(connId);
-        sessionObserver.removeConnection(connId);
-      },
-      getSessionEventSubscriberConnIds: sessionEventSubscribers.getAll,
-      registerToolEventRecipient: toolEventRecipients.add,
-      dedupe,
-      wizardSessions,
-      systemAgentSessions,
-      findRunningWizard,
-      purgeWizardSession,
-      getRuntimeSnapshot,
-      getEventLoopHealth: readinessEventLoopHealth.snapshot,
-      startChannel,
-      stopChannel,
-      markChannelLoggedOut,
-      wizardRunner,
-      channelWizardRunner,
-      broadcastVoiceWakeChanged,
-      unavailableGatewayMethods,
-      broadcastVoiceWakeRoutingChanged,
-    });
-  });
-  bindApprovalPublicationContext(gatewayRequestContext);
-  await attachInitialGatewayLifetimeSidecars({
     chatMetadataLifecycle,
     gatewayRequestContext,
-    sidecars: runtimeState.gatewayLifetimeSidecars,
-  });
-  pluginGatewayContext.current = gatewayRequestContext;
-  const { createGatewayInstanceRuntime } = await import("./server-instance-runtime.js");
-  const gatewayInstanceRuntimeLocal = createGatewayInstanceRuntime({
-    getContext: () => gatewayRequestContext,
-    getMethodRegistry: () => getAttachedGatewayMethodRegistry(),
-    isDispatchAvailable: () => startupState.dispatchReady && !lifecycle.closePreludeStarted,
-    logError: (message) => log.error(message),
-  });
-  gatewayInstanceRuntimeRef.current = gatewayInstanceRuntimeLocal;
-  gatewayRequestContext.approvalEvents = gatewayInstanceRuntimeLocal.approvalEvents;
-  gatewayRequestContext.recoveryRuntime = gatewayInstanceRuntimeLocal.recovery;
-  const clearFallbackContext: unknown = setFallbackGatewayContextResolver(
-    () => gatewayRequestContext,
-  );
-  clearFallbackGatewayContextForServer.set(
-    typeof clearFallbackContext === "function" ? () => clearFallbackContext() : () => {},
-  );
+    gatewayInstanceRuntime,
+  } = runtime;
   const [{ attachGatewayWsHandlers }, { listPluginNodeCapabilities }] = await startupTrace.measure(
     "gateway.ws-imports",
     () =>
@@ -442,7 +249,7 @@ export async function finishGatewayStartup(params: {
           defaultWorkspaceDir,
           deps,
           startChannels,
-          recoveryRuntime: gatewayInstanceRuntimeLocal.recovery,
+          recoveryRuntime: gatewayInstanceRuntime.recovery,
           logHooks,
           logChannels,
           unlockStartupMethods: kernel.unlockStartupMethods,

--- a/src/gateway/server-transport-bridge.ts
+++ b/src/gateway/server-transport-bridge.ts
@@ -1,0 +1,23 @@
+import type { createGatewayHttpTransport } from "./server-runtime-state.js";
+
+export type GatewayHttpTransport = Awaited<ReturnType<typeof createGatewayHttpTransport>>;
+
+/** Late-bound transport facts consumed by the socket-free Gateway kernel. */
+export function createGatewayTransportBridge() {
+  let current: GatewayHttpTransport | undefined;
+
+  return {
+    attach: (transport: GatewayHttpTransport) => {
+      current = transport;
+    },
+    current: () => current,
+    getWorkerIngressEndpoint: () => current?.getWorkerIngressEndpoint(),
+    getMcpAppSandboxPort: () => current?.getMcpAppSandboxPort(),
+    ensureSandboxHostPort: async () => {
+      if (!current) {
+        throw new Error("Gateway listener must start before the sandbox host");
+      }
+      return await current.ensureSandboxHostPort();
+    },
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

Phase-2 PR 4 extracts the socket-free Gateway kernel factory after the landed connection/transport split (#121931) and dispatch ownership seam (#121961).

## Why This Change Was Made

`createGatewayKernel()` now owns bootstrap, kernel-state preparation, lifecycle/live state, subscriptions and approval managers, the method registry, request-context construction, instance-runtime/facade wiring, and fallback context publication. `startGatewayServerCore()` composes that kernel with the HTTP transport and then starts transport-bound residents.

A late-bound transport bridge supplies worker ingress and sandbox accessors to the kernel. Before attachment it preserves the existing fail-closed sandbox error and undefined post-bind endpoints. Normal shutdown retains the same WebSocket/HTTP order; kernel-construction failures can run the full non-transport teardown, including the previously pre-lifecycle TLS failure surface.

The original startup log order, `minimalTestGateway` short-circuits, startup measure names, request-envelope/root-admission path, and 500ms post-ready barrier remain unchanged. There are no config, protocol, default, or user-visible behavior changes.

Next is phase-2 PR 5: the ordered resident registry and named kernel setters for resident-owned live-state slots.

## User Impact

No user-visible change. The Gateway kernel can now be constructed and used for internal dispatch without creating or listening on HTTP/WebSocket servers.

## Evidence

- new `server-kernel.test.ts`: constructs `createGatewayKernel()` without transport/listen, verifies the exact startup measure sequence, fail-closed sandbox access, in-process `health`, and a cached agent turn through the internal facade; also proves TLS construction failure performs teardown with the unchanged error — 2 passed
- full `server.agent.*` + `server.chat.*` suites — 7 files, 200 passed
- PR 2/3 regression suites, transport/network E2E, startup/close proof — 16 files, 239 passed with expected platform skip
- `node scripts/check-changed.mjs -- <touched>` — core/core-test tsgo, lint, guards, import cycles, and runtime architecture lanes passed
- `pnpm build` — passed
- Codex autoreview — clean, no accepted/actionable findings

ClawSweeper review metrics: production `+493/-411` (net `+82`) for the factory, late-bound transport boundary, and transport-optional teardown; tests `+190/-0`. AI-assisted; implementation and evidence were reviewed directly.
