### PR TITLE
refactor(telegram): unify formatted-to-plain send degradation in one orchestrator

### DIFF
--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -4,7 +4,6 @@ import type { Message } from "grammy/types";
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
 import { createChannelApiRetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
-import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { withTelegramApiErrorLogging } from "../api-logging.js";
 import { markdownToTelegramHtml } from "../format.js";
 import { isSafeToRetrySendError, isTelegramRateLimitError } from "../network-errors.js";
@@ -24,9 +23,9 @@ import {
   type TelegramInputRichMessage,
 } from "../rich-message.js";
 import {
-  buildTelegramPlainFallbackPlan,
   isTelegramEmptyContentError,
   isTelegramHtmlParseError,
+  withTelegramPlainFallback,
   warnTelegramRichBlocksDegradations,
 } from "../rich-plain-fallback.js";
 import { withTelegramNativeQuoteFallback } from "../send-context.js";
@@ -164,36 +163,31 @@ export async function sendTelegramText(
       runtime.log?.("telegram sendRichMessage rendered empty; falling back to plain text");
       return await sendPlainFallback();
     }
-    let res: Message;
-    try {
-      res = await sendTelegramWithThreadFallback({
-        operation: "sendRichMessage",
-        runtime,
-        requestParams: toTelegramRichMessageContextParams(baseParams),
-        removeNativeQuoteParam: removeTelegramRichNativeQuoteParam,
-        send: (effectiveParams) =>
-          getTelegramRichRawApi(bot.api).sendRichMessage({
-            chat_id: chatId,
-            rich_message: richPlan.richMessage,
-            ...(opts.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
-            ...effectiveParams,
-          }),
-      });
-    } catch (err) {
-      const fallbackPlan = buildTelegramPlainFallbackPlan({
-        plainText: richPlan.plainText || fallbackText,
-        err,
-        context: "sendRichMessage",
-        warn: (message) => runtime.log?.(message),
-      });
-      if (!fallbackPlan || !hasFallbackText) {
-        throw err;
-      }
-      return await sendPlainFallback(fallbackPlan.plainText);
-    }
-    const messageId = await acceptProviderMessage(res);
-    runtime.log?.(`telegram sendRichMessage ok chat=${chatId} message=${messageId}`);
-    return messageId;
+    return await withTelegramPlainFallback({
+      kind: "rich",
+      context: "sendRichMessage",
+      plainText: richPlan.plainText || fallbackText,
+      warn: (message) => runtime.log?.(message),
+      sendFormatted: async () => {
+        const res = await sendTelegramWithThreadFallback({
+          operation: "sendRichMessage",
+          runtime,
+          requestParams: toTelegramRichMessageContextParams(baseParams),
+          removeNativeQuoteParam: removeTelegramRichNativeQuoteParam,
+          send: (effectiveParams) =>
+            getTelegramRichRawApi(bot.api).sendRichMessage({
+              chat_id: chatId,
+              rich_message: richPlan.richMessage,
+              ...(opts.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
+              ...effectiveParams,
+            }),
+        });
+        const messageId = await acceptProviderMessage(res);
+        runtime.log?.(`telegram sendRichMessage ok chat=${chatId} message=${messageId}`);
+        return messageId;
+      },
+      sendPlain: (plan) => sendPlainFallback(plan.plainText),
+    });
   }
 
   // Markdown can render to empty HTML for syntax-only chunks; recover with plain text.
@@ -205,32 +199,29 @@ export async function sendTelegramText(
     }
     return await sendPlainFallback();
   }
-  try {
-    const res = await sendTelegramWithThreadFallback({
-      operation: "sendMessage",
-      runtime,
-      requestParams: baseParams,
-      shouldLog: (err) => !isTelegramHtmlParseError(err) && !isTelegramEmptyContentError(err),
-      send: (effectiveParams) =>
-        bot.api.sendMessage(chatId, htmlText, {
-          parse_mode: "HTML",
-          ...(linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : {}),
-          ...(opts?.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
-          ...effectiveParams,
-        }),
-    });
-    const messageId = await acceptProviderMessage(res);
-    runtime.log?.(`telegram sendMessage ok chat=${chatId} message=${messageId}`);
-    return messageId;
-  } catch (err) {
-    const errText = formatErrorMessage(err);
-    if (isTelegramHtmlParseError(err) || isTelegramEmptyContentError(err)) {
-      if (!hasFallbackText) {
-        throw err;
-      }
-      runtime.log?.(`telegram formatted send failed; retrying without formatting: ${errText}`);
-      return await sendPlainFallback();
-    }
-    throw err;
-  }
+  return await withTelegramPlainFallback({
+    kind: "html",
+    context: "sendMessage",
+    plainText: fallbackText,
+    warn: (message) => runtime.log?.(message),
+    sendFormatted: async () => {
+      const res = await sendTelegramWithThreadFallback({
+        operation: "sendMessage",
+        runtime,
+        requestParams: baseParams,
+        shouldLog: (err) => !isTelegramHtmlParseError(err) && !isTelegramEmptyContentError(err),
+        send: (effectiveParams) =>
+          bot.api.sendMessage(chatId, htmlText, {
+            parse_mode: "HTML",
+            ...(linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : {}),
+            ...(opts?.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
+            ...effectiveParams,
+          }),
+      });
+      const messageId = await acceptProviderMessage(res);
+      runtime.log?.(`telegram sendMessage ok chat=${chatId} message=${messageId}`);
+      return messageId;
+    },
+    sendPlain: (plan) => sendPlainFallback(plan.plainText),
+  });
 }

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -2147,7 +2147,7 @@ describe("deliverReplies", () => {
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(firstMockCallArg(sendMessage, 1)).toBe("Rank | Model | Score\n4 | Claude Opus | 78.16%");
     expect(runtime.log).toHaveBeenCalledWith(
-      expect.stringContaining("rich-degrade=plain-fallback:rich-entity-invalid"),
+      "telegram sendRichMessage degrade=plain-fallback:rich-entity-invalid: GrammyError: Call to 'sendRichMessage' failed! (400: Bad Request: RICH_MESSAGE_URL_INVALID)",
     );
   });
 

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -1320,6 +1320,34 @@ describe("createTelegramDraftStream", () => {
     });
   });
 
+  it("falls back to plain preview text when an HTML edit renders empty", async () => {
+    const api = createMockDraftApi();
+    const warn = vi.fn();
+    const stream = createDraftStream(api, { warn });
+
+    stream.updatePreview({ text: "<b>Working</b>", parseMode: "HTML" });
+    await stream.flush();
+
+    api.editMessageText
+      .mockRejectedValueOnce(new Error("400: Bad Request: message text is empty"))
+      .mockResolvedValueOnce(true);
+    stream.updatePreview({ text: "<b>Done &lt;&amp;&gt;</b>", parseMode: "HTML" });
+    await stream.flush();
+
+    expect(api.editMessageText).toHaveBeenNthCalledWith(1, 123, 17, "<b>Done &lt;&amp;&gt;</b>", {
+      parse_mode: "HTML",
+    });
+    expect(api.editMessageText).toHaveBeenNthCalledWith(2, 123, 17, "Done <&>");
+    expect(stream.currentMessageSnapshot?.()).toEqual({
+      text: "Done <&>",
+      sourceText: "Done &lt;&amp;&gt;",
+      sourceTextMode: "html",
+    });
+    expect(warn).toHaveBeenCalledWith(
+      "telegram stream preview edit degrade=plain-fallback:empty-content: 400: Bad Request: message text is empty",
+    );
+  });
+
   it("uses rich send and edit for previews when explicitly enabled", async () => {
     const api = createMockDraftApi();
     const stream = createDraftStream(api, { richMessages: true });
@@ -1362,7 +1390,7 @@ describe("createTelegramDraftStream", () => {
     expect(plain).toContain("Rank");
     expect(plain).toContain("Claude Opus");
     expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining("rich-degrade=plain-fallback:rich-entity-invalid"),
+      "telegram stream preview degrade=plain-fallback:rich-entity-invalid: 400: Bad Request: RICH_MESSAGE_URL_INVALID",
     );
   });
 

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -38,9 +38,8 @@ import {
   type TelegramInputRichMessage,
 } from "./rich-message.js";
 import {
-  buildTelegramPlainFallbackPlan,
-  isTelegramHtmlParseError,
   splitTelegramPlainTextChunks,
+  withTelegramPlainFallback,
   warnTelegramRichBlocksDegradations,
 } from "./rich-plain-fallback.js";
 
@@ -383,38 +382,36 @@ export function createTelegramDraftStream(params: {
     sendMessageParams: ReturnType<typeof reserveReplyTargetForSend>,
   ) => {
     if (page.richMessage) {
+      const richMessage = page.richMessage;
       warnTelegramRichBlocksDegradations({
         context: "stream preview",
         reasons: page.degradationReasons ?? [],
         warn: (message) => params.warn?.(message),
       });
-      try {
-        return {
+      return await withTelegramPlainFallback<{
+        message: Message;
+        snapshot: TelegramDraftMessageSnapshot;
+      }>({
+        kind: "rich",
+        context: "stream preview",
+        plainText: page.text,
+        warn: (message) => params.warn?.(message),
+        sendFormatted: async () => ({
           message: await getTelegramRichRawApi(params.api).sendRichMessage({
             chat_id: chatId,
-            rich_message: page.richMessage,
+            rich_message: richMessage,
             ...sendMessageParams,
           }),
           snapshot: page,
-        };
-      } catch (err) {
-        const fallbackPlan = buildTelegramPlainFallbackPlan({
-          plainText: page.text,
-          err,
-          context: "stream preview",
-          warn: (message) => params.warn?.(message),
-        });
-        if (!fallbackPlan) {
-          throw err;
-        }
-        return {
-          message: await params.api.sendMessage(chatId, fallbackPlan.plainText, {
+        }),
+        sendPlain: async (plan) => ({
+          message: await params.api.sendMessage(chatId, plan.plainText, {
             ...sendMessageParams,
             ...linkPreviewParams,
           }),
-          snapshot: fallbackSnapshot(fallbackPlan.plainText),
-        };
-      }
+          snapshot: fallbackSnapshot(plan.plainText),
+        }),
+      });
     }
     if (page.sourceTextMode !== "html") {
       return {
@@ -425,27 +422,30 @@ export function createTelegramDraftStream(params: {
         snapshot: page,
       };
     }
-    try {
-      return {
+    return await withTelegramPlainFallback<{
+      message: Message;
+      snapshot: TelegramDraftMessageSnapshot;
+    }>({
+      kind: "html",
+      context: "stream preview",
+      plainText: page.text,
+      warn: (message) => params.warn?.(message),
+      sendFormatted: async () => ({
         message: await params.api.sendMessage(chatId, page.sourceText, {
           parse_mode: "HTML" as const,
           ...sendMessageParams,
           ...linkPreviewParams,
         }),
         snapshot: page,
-      };
-    } catch (err) {
-      if (!isTelegramHtmlParseError(err)) {
-        throw err;
-      }
-      return {
-        message: await params.api.sendMessage(chatId, page.text, {
+      }),
+      sendPlain: async (plan) => ({
+        message: await params.api.sendMessage(chatId, plan.plainText, {
           ...sendMessageParams,
           ...linkPreviewParams,
         }),
-        snapshot: fallbackSnapshot(page.text),
-      };
-    }
+        snapshot: fallbackSnapshot(plan.plainText),
+      }),
+    });
   };
   const sendMessageTransportPreview = async (
     page: PlannedTelegramDraftPage,
@@ -460,42 +460,47 @@ export function createTelegramDraftStream(params: {
       streamVisibleSinceMs ??= Date.now();
       let acceptedSnapshot: TelegramDraftMessageSnapshot = page;
       if (page.richMessage) {
+        const richMessage = page.richMessage;
         warnTelegramRichBlocksDegradations({
           context: "stream preview edit",
           reasons: page.degradationReasons ?? [],
           warn: (message) => params.warn?.(message),
         });
-        try {
-          await getTelegramRichRawApi(params.api).editMessageText({
-            chat_id: chatId,
-            message_id: targetMessageId,
-            rich_message: page.richMessage,
-          });
-        } catch (err) {
-          const fallbackPlan = buildTelegramPlainFallbackPlan({
-            plainText: page.text,
-            err,
-            context: "stream preview edit",
-            warn: (message) => params.warn?.(message),
-          });
-          if (!fallbackPlan) {
-            throw err;
-          }
-          await editMessageTextWithPreview(targetMessageId, fallbackPlan.plainText);
-          acceptedSnapshot = fallbackSnapshot(fallbackPlan.plainText);
-        }
+        acceptedSnapshot = await withTelegramPlainFallback<TelegramDraftMessageSnapshot>({
+          kind: "rich",
+          context: "stream preview edit",
+          plainText: page.text,
+          warn: (message) => params.warn?.(message),
+          sendFormatted: async () => {
+            await getTelegramRichRawApi(params.api).editMessageText({
+              chat_id: chatId,
+              message_id: targetMessageId,
+              rich_message: richMessage,
+            });
+            return page;
+          },
+          sendPlain: async (plan) => {
+            await editMessageTextWithPreview(targetMessageId, plan.plainText);
+            return fallbackSnapshot(plan.plainText);
+          },
+        });
       } else if (page.sourceTextMode === "html") {
-        try {
-          await editMessageTextWithPreview(targetMessageId, page.sourceText, {
-            parse_mode: "HTML" as const,
-          });
-        } catch (err) {
-          if (!isTelegramHtmlParseError(err)) {
-            throw err;
-          }
-          await editMessageTextWithPreview(targetMessageId, page.text);
-          acceptedSnapshot = fallbackSnapshot(page.text);
-        }
+        acceptedSnapshot = await withTelegramPlainFallback<TelegramDraftMessageSnapshot>({
+          kind: "html",
+          context: "stream preview edit",
+          plainText: page.text,
+          warn: (message) => params.warn?.(message),
+          sendFormatted: async () => {
+            await editMessageTextWithPreview(targetMessageId, page.sourceText, {
+              parse_mode: "HTML" as const,
+            });
+            return page;
+          },
+          sendPlain: async (plan) => {
+            await editMessageTextWithPreview(targetMessageId, plan.plainText);
+            return fallbackSnapshot(plan.plainText);
+          },
+        });
       } else {
         await editMessageTextWithPreview(targetMessageId, page.sourceText);
       }

--- a/extensions/telegram/src/rich-plain-fallback.test.ts
+++ b/extensions/telegram/src/rich-plain-fallback.test.ts
@@ -1,40 +1,115 @@
-import { describe, expect, it } from "vitest";
-import {
-  buildTelegramPlainFallbackPlan,
-  isTelegramEmptyContentError,
-} from "./rich-plain-fallback.js";
+import { describe, expect, it, vi } from "vitest";
+import { isTelegramEmptyContentError, withTelegramPlainFallback } from "./rich-plain-fallback.js";
 
-function planFor(message: string) {
-  return buildTelegramPlainFallbackPlan({
-    plainText: "fallback body",
-    err: new Error(message),
-    context: "test",
-    warn: () => {},
+const fallbackCases = [
+  {
+    name: "rich-entity-invalid",
+    message: "Bad Request: RICH_MESSAGE_URL_INVALID",
+    richTrigger: "rich-entity-invalid",
+  },
+  {
+    name: "rich-structure-invalid",
+    message: "Bad Request: RICH_MESSAGE_BLOCKS_TOO_MANY",
+    richTrigger: "rich-structure-invalid",
+  },
+  {
+    name: "rich-content-required",
+    message: "Bad Request: RICH_MESSAGE_CONTENT_REQUIRED",
+    richTrigger: "rich-content-required",
+    htmlTrigger: "empty-content",
+  },
+  {
+    name: "html-parse",
+    message: "Bad Request: can't parse entities: unsupported tag",
+    richTrigger: "html-parse",
+    htmlTrigger: "html-parse",
+  },
+  {
+    name: "empty-content",
+    message: "Bad Request: message text is empty",
+    htmlTrigger: "empty-content",
+  },
+  {
+    name: "network error",
+    message: "read ECONNRESET",
+  },
+] as const;
+
+describe("withTelegramPlainFallback", () => {
+  it.each(
+    (["rich", "html"] as const).flatMap((kind) =>
+      fallbackCases.map((testCase) => Object.assign({ kind }, testCase)),
+    ),
+  )("classifies $kind $name consistently", async (testCase) => {
+    const error = new Error(testCase.message);
+    const warn = vi.fn();
+    const sendFormatted = vi.fn(async () => {
+      throw error;
+    });
+    const sendPlain = vi.fn(async () => "plain");
+    const trigger =
+      testCase.kind === "rich"
+        ? "richTrigger" in testCase
+          ? testCase.richTrigger
+          : undefined
+        : "htmlTrigger" in testCase
+          ? testCase.htmlTrigger
+          : undefined;
+    const run = withTelegramPlainFallback({
+      kind: testCase.kind,
+      context: "test send",
+      plainText: "fallback body",
+      warn,
+      limit: 8,
+      chunkCount: 3,
+      sendFormatted,
+      sendPlain,
+    });
+    expect(sendFormatted).toHaveBeenCalledTimes(1);
+
+    if (!trigger) {
+      await expect(run).rejects.toBe(error);
+      expect(sendPlain).not.toHaveBeenCalled();
+      expect(warn).not.toHaveBeenCalled();
+      return;
+    }
+
+    await expect(run).resolves.toBe("plain");
+    expect(sendPlain).toHaveBeenCalledWith(
+      {
+        plainText: "fallback body",
+        chunks: ["fallb", "ack ", "body"],
+      },
+      "test send-plain",
+    );
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      `telegram test send degrade=plain-fallback:${trigger}: ${testCase.message}`,
+    );
   });
-}
 
-describe("buildTelegramPlainFallbackPlan", () => {
-  // Live-verified Bot API 10.2 structural rejections (2026-07-15).
   it.each([
-    "Bad Request: RICH_MESSAGE_BLOCKS_TOO_MANY",
-    "Bad Request: RICH_MESSAGE_DEPTH_INVALID",
-    "Bad Request: RICH_MESSAGE_TEXT_TOO_LONG",
-    "Bad Request: RICH_MESSAGE_MEDIA_TOO_MANY",
-    "Bad Request: RICH_MESSAGE_TABLE_COLS_TOO_MANY",
-  ])("degrades structural rejection %s to plain text", (message) => {
-    expect(planFor(message)?.chunks).toEqual(["fallback body"]);
-  });
+    { kind: "rich" as const, message: "Bad Request: RICH_MESSAGE_URL_INVALID" },
+    { kind: "html" as const, message: "Bad Request: message text is empty" },
+  ])("rethrows $kind failures when plain text is empty", async ({ kind, message }) => {
+    const error = new Error(message);
+    const warn = vi.fn();
+    const sendPlain = vi.fn(async () => "plain");
 
-  it("degrades wire-shape parse rejections to plain text", () => {
-    expect(
-      planFor(
-        'Bad Request: can\'t parse InputRichBlock: Field "custom_emoji_id" must be a valid Number',
-      )?.chunks,
-    ).toEqual(["fallback body"]);
-  });
-
-  it("rethrows unrelated errors", () => {
-    expect(planFor("Bad Request: chat not found")).toBeUndefined();
+    await expect(
+      withTelegramPlainFallback({
+        kind,
+        context: "test send",
+        plainText: " \n",
+        warn,
+        sendFormatted: async () => {
+          throw error;
+        },
+        sendPlain,
+      }),
+    ).rejects.toBe(error);
+    expect(sendPlain).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/telegram/src/rich-plain-fallback.ts
+++ b/extensions/telegram/src/rich-plain-fallback.ts
@@ -1,5 +1,5 @@
-// Telegram rich/plain fallback policy is shared by durable sends, final replies,
-// and draft previews. A second copy reintroduces silent drift in parse failures.
+// withTelegramPlainFallback owns formatted-to-plain recovery for durable sends,
+// final replies, and draft previews. A second orchestrator reintroduces silent drift.
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { TelegramRichBlocksDegradationReason } from "./rich-block-model.js";
 
@@ -16,11 +16,13 @@ const RICH_STRUCTURE_INVALID_RE =
 const PARSE_ERR_RE =
   /can't parse entities|parse entities|find end of the entity|can't parse InputRichBlock/i;
 
-type TelegramPlainFallbackTrigger =
+type TelegramRichPlainFallbackTrigger =
   | "rich-entity-invalid"
   | "rich-structure-invalid"
   | "html-parse"
   | "rich-content-required";
+
+type TelegramPlainFallbackTrigger = TelegramRichPlainFallbackTrigger | "empty-content";
 
 type TelegramPlainFallbackPlan = {
   plainText: string;
@@ -40,7 +42,9 @@ export function isTelegramEmptyContentError(err: unknown): boolean {
   return EMPTY_TEXT_RE.test(message) || RICH_CONTENT_REQUIRED_RE.test(message);
 }
 
-function getTelegramPlainFallbackTrigger(err: unknown): TelegramPlainFallbackTrigger | undefined {
+function getTelegramPlainFallbackTrigger(
+  err: unknown,
+): TelegramRichPlainFallbackTrigger | undefined {
   if (isTelegramRichEntityInvalidError(err)) {
     return "rich-entity-invalid";
   }
@@ -107,33 +111,46 @@ function splitTelegramPlainTextFallback(text: string, chunkCount: number, limit:
   return chunks;
 }
 
-export function buildTelegramPlainFallbackPlan(params: {
-  plainText: string;
-  err: unknown;
+export async function withTelegramPlainFallback<T>(params: {
+  kind: "rich" | "html";
   context: string;
+  plainText: string;
   warn: (message: string) => void;
   limit?: number;
   chunkCount?: number;
-}): TelegramPlainFallbackPlan | undefined {
-  const trigger = getTelegramPlainFallbackTrigger(params.err);
-  if (!trigger) {
-    return undefined;
+  sendFormatted: () => Promise<T>;
+  sendPlain: (plan: TelegramPlainFallbackPlan, label: string) => Promise<T>;
+}): Promise<T> {
+  try {
+    return await params.sendFormatted();
+  } catch (err) {
+    const trigger: TelegramPlainFallbackTrigger | undefined =
+      params.kind === "rich"
+        ? getTelegramPlainFallbackTrigger(err)
+        : isTelegramHtmlParseError(err)
+          ? "html-parse"
+          : isTelegramEmptyContentError(err)
+            ? "empty-content"
+            : undefined;
+    if (!trigger || !params.plainText.trim()) {
+      throw err;
+    }
+    params.warn(
+      `telegram ${params.context} degrade=plain-fallback:${trigger}: ${formatErrorMessage(err)}`,
+    );
+    const limit = params.limit ?? 4000;
+    const chunks =
+      params.chunkCount === undefined
+        ? splitTelegramPlainTextChunks(params.plainText, limit)
+        : splitTelegramPlainTextFallback(params.plainText, params.chunkCount, limit);
+    return await params.sendPlain(
+      {
+        plainText: params.plainText,
+        chunks,
+      },
+      `${params.context}-plain`,
+    );
   }
-  const plainText = params.plainText;
-  const limit = params.limit ?? 4000;
-  const chunks =
-    params.chunkCount === undefined
-      ? splitTelegramPlainTextChunks(plainText, limit)
-      : splitTelegramPlainTextFallback(plainText, params.chunkCount, limit);
-  params.warn(
-    `telegram ${params.context} rich-degrade=plain-fallback:${trigger}: ${formatErrorMessage(
-      params.err,
-    )}`,
-  );
-  return {
-    plainText,
-    chunks,
-  };
 }
 
 export function warnTelegramRichBlocksDegradations(params: {

--- a/extensions/telegram/src/send-context.ts
+++ b/extensions/telegram/src/send-context.ts
@@ -23,7 +23,6 @@ import {
 } from "./reply-parameters.js";
 import { TELEGRAM_OUTBOUND_RETRY_AFTER_CAP_MS } from "./retry-after.js";
 import type { TelegramRichMessageContextParams } from "./rich-message.js";
-import { isTelegramHtmlParseError } from "./rich-plain-fallback.js";
 import { requireRuntimeConfig, type OpenClawConfig } from "./send.runtime.js";
 import { maybePersistResolvedTelegramTarget } from "./target-writeback.js";
 import { normalizeTelegramChatId, normalizeTelegramLookupTarget } from "./targets.js";
@@ -388,29 +387,6 @@ export function isTelegramMessageHasNoTextError(err: unknown): boolean {
 
 export function isTelegramMessageDeleteNoopError(err: unknown): boolean {
   return MESSAGE_DELETE_NOOP_RE.test(formatErrorMessage(err));
-}
-
-export async function withTelegramHtmlParseFallback<T>(params: {
-  label: string;
-  verbose?: boolean;
-  requestHtml: (label: string) => Promise<T>;
-  requestPlain: (label: string) => Promise<T>;
-}): Promise<T> {
-  try {
-    return await params.requestHtml(params.label);
-  } catch (err) {
-    if (!isTelegramHtmlParseError(err)) {
-      throw err;
-    }
-    if (params.verbose) {
-      sendLogger.warn(
-        `telegram ${params.label} failed with HTML parse error, retrying as plain text: ${formatErrorMessage(
-          err,
-        )}`,
-      );
-    }
-    return await params.requestPlain(`${params.label}-plain`);
-  }
 }
 
 export async function withTelegramNativeQuoteFallback<T>(params: {

--- a/extensions/telegram/src/send-edit.ts
+++ b/extensions/telegram/src/send-edit.ts
@@ -15,7 +15,7 @@ import {
   type TelegramEditRichMessageTextParams,
 } from "./rich-message.js";
 import {
-  buildTelegramPlainFallbackPlan,
+  withTelegramPlainFallback,
   warnTelegramRichBlocksDegradations,
 } from "./rich-plain-fallback.js";
 import {
@@ -24,7 +24,6 @@ import {
   resolveTelegramApiContext,
   sendLogger,
   withTelegramApiContextLease,
-  withTelegramHtmlParseFallback,
   type TelegramApiContext,
 } from "./send-context.js";
 import type { TelegramApiCallOpts, TelegramSendOpts } from "./send-message-types.js";
@@ -189,6 +188,16 @@ async function editMessageTelegramWithContext(
     plainCaptionParams.reply_markup = replyMarkup;
   }
 
+  const editPlainText = (plan: { plainText: string }, label: string) =>
+    requestWithEditShouldLog(
+      () =>
+        Object.keys(plainTextParams).length > 0
+          ? api.editMessageText(chatId, messageId, plan.plainText, plainTextParams)
+          : api.editMessageText(chatId, messageId, plan.plainText),
+      label,
+      (plainErr) => !isTelegramMessageNotModifiedError(plainErr),
+    );
+
   const performTextEdit = () => {
     if (richRawApi && richMessagePlan) {
       const richEditParams: Pick<
@@ -203,71 +212,57 @@ async function editMessageTelegramWithContext(
         reasons: richMessagePlan.degradationReasons,
         warn: (message) => sendLogger.warn(message),
       });
-      return requestWithEditShouldLog(
-        () =>
-          richRawApi.editMessageText({
-            chat_id: chatId,
-            message_id: messageId,
-            rich_message: richMessagePlan.richMessage,
-            ...richEditParams,
-          }),
-        "editMessage",
-        (err) => !isTelegramMessageNotModifiedError(err),
-      ).catch((err: unknown) => {
-        const fallbackPlan = buildTelegramPlainFallbackPlan({
-          plainText: richMessagePlan.plainText,
-          err,
-          context: "editMessage",
-          warn: (message) => sendLogger.warn(message),
-        });
-        if (!fallbackPlan) {
-          throw err;
-        }
-        return requestWithEditShouldLog(
-          () =>
-            Object.keys(plainTextParams).length > 0
-              ? api.editMessageText(chatId, messageId, fallbackPlan.plainText, plainTextParams)
-              : api.editMessageText(chatId, messageId, fallbackPlan.plainText),
-          "editMessage-plain",
-          (plainErr) => !isTelegramMessageNotModifiedError(plainErr),
-        );
+      return withTelegramPlainFallback({
+        kind: "rich",
+        context: "editMessage",
+        plainText: richMessagePlan.plainText,
+        warn: (message) => sendLogger.warn(message),
+        sendFormatted: () =>
+          requestWithEditShouldLog(
+            () =>
+              richRawApi.editMessageText({
+                chat_id: chatId,
+                message_id: messageId,
+                rich_message: richMessagePlan.richMessage,
+                ...richEditParams,
+              }),
+            "editMessage",
+            (err) => !isTelegramMessageNotModifiedError(err),
+          ),
+        sendPlain: editPlainText,
       });
     }
-    return withTelegramHtmlParseFallback({
-      label: "editMessage",
-      verbose: opts.verbose,
-      requestHtml: (retryLabel) =>
+    return withTelegramPlainFallback({
+      kind: "html",
+      context: "editMessage",
+      plainText,
+      warn: (message) => sendLogger.warn(message),
+      sendFormatted: () =>
         requestWithEditShouldLog(
           () => api.editMessageText(chatId, messageId, htmlText, textEditParams),
-          retryLabel,
+          "editMessage",
           (err) => !isTelegramMessageNotModifiedError(err),
         ),
-      requestPlain: (retryLabel) =>
-        requestWithEditShouldLog(
-          () =>
-            Object.keys(plainTextParams).length > 0
-              ? api.editMessageText(chatId, messageId, plainText, plainTextParams)
-              : api.editMessageText(chatId, messageId, plainText),
-          retryLabel,
-          (plainErr) => !isTelegramMessageNotModifiedError(plainErr),
-        ),
+      sendPlain: editPlainText,
     });
   };
 
   const performCaptionEdit = () =>
-    withTelegramHtmlParseFallback({
-      label: "editMessageCaption",
-      verbose: opts.verbose,
-      requestHtml: (retryLabel) =>
+    withTelegramPlainFallback({
+      kind: "html",
+      context: "editMessageCaption",
+      plainText,
+      warn: (message) => sendLogger.warn(message),
+      sendFormatted: () =>
         requestWithEditShouldLog(
           () => api.editMessageCaption(chatId, messageId, captionEditParams),
-          retryLabel,
+          "editMessageCaption",
           (err) => !isTelegramMessageNotModifiedError(err),
         ),
-      requestPlain: (retryLabel) =>
+      sendPlain: (_plan, label) =>
         requestWithEditShouldLog(
           () => api.editMessageCaption(chatId, messageId, plainCaptionParams),
-          retryLabel,
+          label,
           (plainErr) => !isTelegramMessageNotModifiedError(plainErr),
         ),
     });

--- a/extensions/telegram/src/send-message-text.ts
+++ b/extensions/telegram/src/send-message-text.ts
@@ -24,9 +24,9 @@ import {
   type TelegramRichTextChunk,
 } from "./rich-message.js";
 import {
-  buildTelegramPlainFallbackPlan,
   isTelegramEmptyContentError,
   splitTelegramPlainTextChunks,
+  withTelegramPlainFallback,
   warnTelegramRichBlocksDegradations,
 } from "./rich-plain-fallback.js";
 import {
@@ -35,7 +35,6 @@ import {
   resolveTelegramMessageIdOrThrow,
   sendLogger,
   toAcceptedThreadScopedParams,
-  withTelegramHtmlParseFallback,
   withTelegramNativeQuoteFallback,
   type TelegramApi,
   type TelegramThreadScopedParams,
@@ -166,23 +165,18 @@ export function createTelegramTextSender(config: {
     if (!chunk.htmlText) {
       result = await requestPlain("message");
     } else {
-      try {
-        result = await withTelegramHtmlParseFallback({
-          label: "message",
-          verbose: opts.verbose,
-          requestHtml: (label) =>
-            requestSendMessage(label, chunk.htmlText ?? chunk.plainText, {
-              parse_mode: "HTML" as const,
-              ...plainParams,
-            }),
-          requestPlain,
-        });
-      } catch (error) {
-        if (!isTelegramEmptyContentError(error) || !chunk.plainText.trim()) {
-          throw error;
-        }
-        result = await requestPlain("message-empty-fallback");
-      }
+      result = await withTelegramPlainFallback({
+        kind: "html",
+        context: "message",
+        plainText: chunk.plainText,
+        warn: (message) => sendLogger.warn(message),
+        sendFormatted: () =>
+          requestSendMessage("message", chunk.htmlText ?? chunk.plainText, {
+            parse_mode: "HTML" as const,
+            ...plainParams,
+          }),
+        sendPlain: (_plan, label) => requestPlain(label),
+      });
     }
     return {
       result: result.result,
@@ -547,11 +541,6 @@ export function createTelegramTextSender(config: {
           index === chunks.length - 1,
           options.replyToAlreadyUsed === true,
         );
-        let result: TelegramMessageLike;
-        let recordedParams:
-          | TelegramThreadScopedParams
-          | TelegramRichMessageContextParams
-          | undefined;
         if (isEmptyTelegramRichMessage(chunk.richMessage)) {
           if (!chunk.plainText.trim()) {
             sendLogger.warn(
@@ -581,80 +570,78 @@ export function createTelegramTextSender(config: {
           );
           continue;
         }
+        warnTelegramRichBlocksDegradations({
+          context: "richMessage",
+          reasons: chunk.degradationReasons,
+          warn: (message) => sendLogger.warn(message),
+        });
         try {
-          warnTelegramRichBlocksDegradations({
+          await withTelegramPlainFallback({
+            kind: "rich",
             context: "richMessage",
-            reasons: chunk.degradationReasons,
-            warn: (message) => sendLogger.warn(message),
-          });
-          const richResult = await withTelegramNativeQuoteFallback<TelegramMessageLike>({
-            label: "richMessage",
-            requestParams: acceptedParams ?? {},
-            removeNativeQuoteParam: removeTelegramRichNativeQuoteParam,
-            request: (effectiveParams, retryLabel) =>
-              requestWithChatNotFound(
-                () =>
-                  richRawApi.sendRichMessage({
-                    chat_id: chatId,
-                    rich_message: chunk.richMessage,
-                    ...effectiveParams,
-                    ...(opts.silent === true ? { disable_notification: true } : {}),
-                  }),
-                retryLabel,
-              ),
-          });
-          result = richResult.result;
-          recordedParams = toTelegramRichMessageContextParams(richResult.acceptedParams);
-        } catch (err) {
-          const fallbackPlan = buildTelegramPlainFallbackPlan({
             plainText: chunk.plainText,
-            err,
-            context: "richMessage",
             warn: (message) => sendLogger.warn(message),
-          });
-          if (!fallbackPlan) {
-            tracker.reject(err);
-            continue;
-          }
-          const fallbackChunks = fallbackPlan.chunks;
-          if (fallbackChunks.length === 0) {
-            tracker.reject(err);
-            continue;
-          }
-          const fallbackReplyChunkCount = Math.max(chunks.length, fallbackChunks.length);
-          for (let fallbackIndex = 0; fallbackIndex < fallbackChunks.length; fallbackIndex += 1) {
-            const fallbackText = fallbackChunks[fallbackIndex] ?? "";
-            const fallbackReplyIndex = chunks.length === 1 ? fallbackIndex : index;
-            const fallbackParams = buildTextParams(
-              fallbackReplyIndex,
-              fallbackReplyChunkCount,
-              index === chunks.length - 1 && fallbackIndex === fallbackChunks.length - 1,
-              options.replyToAlreadyUsed === true,
-            );
-            const finalPart =
-              index === chunks.length - 1 && fallbackIndex === fallbackChunks.length - 1;
-            await tracker.attempt(
-              () => sendTelegramTextChunk({ plainText: fallbackText }, fallbackParams),
-              ({ result: fallbackResult, acceptedParams: fallbackAcceptedParams }) =>
+            sendFormatted: async () => {
+              const richResult = await withTelegramNativeQuoteFallback<TelegramMessageLike>({
+                label: "richMessage",
+                requestParams: acceptedParams ?? {},
+                removeNativeQuoteParam: removeTelegramRichNativeQuoteParam,
+                request: (effectiveParams, retryLabel) =>
+                  requestWithChatNotFound(
+                    () =>
+                      richRawApi.sendRichMessage({
+                        chat_id: chatId,
+                        rich_message: chunk.richMessage,
+                        ...effectiveParams,
+                        ...(opts.silent === true ? { disable_notification: true } : {}),
+                      }),
+                    retryLabel,
+                  ),
+              });
+              const finalPart = index === chunks.length - 1;
+              await tracker.recordAccepted(richResult.result, (acceptedResult) =>
                 delivery.record({
-                  result: fallbackResult,
-                  acceptedParams: fallbackAcceptedParams,
-                  plainText: fallbackText,
+                  result: acceptedResult,
+                  acceptedParams: toTelegramRichMessageContextParams(richResult.acceptedParams),
+                  plainText: chunk.plainText,
                   hasInlineKeyboard: finalPart && Boolean(replyMarkup),
                 }),
-            );
-          }
-          continue;
+              );
+            },
+            sendPlain: async ({ chunks: fallbackChunks }) => {
+              const fallbackReplyChunkCount = Math.max(chunks.length, fallbackChunks.length);
+              for (
+                let fallbackIndex = 0;
+                fallbackIndex < fallbackChunks.length;
+                fallbackIndex += 1
+              ) {
+                const fallbackText = fallbackChunks[fallbackIndex] ?? "";
+                const fallbackReplyIndex = chunks.length === 1 ? fallbackIndex : index;
+                const fallbackParams = buildTextParams(
+                  fallbackReplyIndex,
+                  fallbackReplyChunkCount,
+                  index === chunks.length - 1 && fallbackIndex === fallbackChunks.length - 1,
+                  options.replyToAlreadyUsed === true,
+                );
+                const finalPart =
+                  index === chunks.length - 1 && fallbackIndex === fallbackChunks.length - 1;
+                await tracker.attempt(
+                  () => sendTelegramTextChunk({ plainText: fallbackText }, fallbackParams),
+                  ({ result: fallbackResult, acceptedParams: fallbackAcceptedParams }) =>
+                    delivery.record({
+                      result: fallbackResult,
+                      acceptedParams: fallbackAcceptedParams,
+                      plainText: fallbackText,
+                      hasInlineKeyboard: finalPart && Boolean(replyMarkup),
+                    }),
+                );
+              }
+            },
+          });
+        } catch (err) {
+          tracker.reject(err);
         }
-        const finalPart = index === chunks.length - 1;
-        await tracker.recordAccepted(result, (acceptedResult) =>
-          delivery.record({
-            result: acceptedResult,
-            acceptedParams: recordedParams,
-            plainText: chunk.plainText,
-            hasInlineKeyboard: finalPart && Boolean(replyMarkup),
-          }),
-        );
+        continue;
       }
       tracker.finish();
       return await delivery.finish("sendRichMessage");

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -5317,6 +5317,23 @@ describe("editMessageTelegram", () => {
     expect(botApi.editMessageText).toHaveBeenCalledTimes(1);
   });
 
+  it("falls back to plain text when an HTML edit renders empty", async () => {
+    botApi.editMessageText
+      .mockRejectedValueOnce(new Error("400: Bad Request: message text is empty"))
+      .mockResolvedValueOnce({ message_id: 1, chat: { id: "123" } });
+
+    await editMessageTelegram("123", 1, "<b>visible</b>", {
+      token: "tok",
+      cfg: {},
+      textMode: "html",
+    });
+
+    expect(botApi.editMessageText).toHaveBeenNthCalledWith(1, "123", 1, "<b>visible</b>", {
+      parse_mode: "HTML",
+    });
+    expect(botApi.editMessageText).toHaveBeenNthCalledWith(2, "123", 1, "visible");
+  });
+
   it("uses editMessageCaption when requested for media captions", async () => {
     botApi.editMessageCaption.mockResolvedValue({ message_id: 1, chat: { id: "123" } });
 


### PR DESCRIPTION
## What Problem This Solves

The Telegram plugin's "send funnel parity" invariant (`extensions/telegram/AGENTS.md`: the durable funnel and the streaming funnel must degrade identically on formatted-send 400s) was enforced only by prose and review. The formatted→plain recovery was hand-rolled at 11 call sites across `send-message-text.ts`, `send-edit.ts`, `bot/delivery.send.ts`, and `draft-stream.ts`, and had already drifted: draft previews and message edits degraded only on HTML-parse errors, not on empty-content 400s, so the same model output that recovered gracefully as a final message threw mid-preview.

## Why This Change Was Made

One orchestrator, `withTelegramPlainFallback` (in `rich-plain-fallback.ts`, the file that already owns the shared classification), now owns error classification (`rich` vs `html` trigger sets), the empty-fallback-text guard, the unified degrade log line, and plain-chunk planning. All 11 sites supply only their transport primitives (`sendFormatted` / `sendPlain`). `withTelegramHtmlParseFallback` and `buildTelegramPlainFallbackPlan` are deleted; a new degradation physically cannot land in one funnel only.

Intentional behavior changes (the drift this PR kills):
- Draft preview sends/edits and `editMessageTelegram` now degrade to plain text on empty-content 400s, matching the durable funnel.
- Degrade log lines unify to `telegram <context> degrade=plain-fallback:<trigger>: <error>` (previously `rich-degrade=plain-fallback:` plus per-site wordings).

Named follow-up: the voice-caption too-long recovery in `bot/delivery.replies.ts` remains a separate hand-rolled ladder (different recovery shape: resend captionless + separate text); unifying it belongs with the media ladder (`sendTelegramCaptionedMediaWithFallback`), not this text-send change.

## User Impact

Streaming previews no longer die mid-stream on model output that renders empty after formatting; users get the plain-text preview instead of a stalled draft. No config changes, no API surface changes outside the plugin.

## Evidence

- Production LOC net −29 (+285/−314); tests +155/−35.
- Table-driven parity test (`rich-plain-fallback.test.ts`): kind × {rich-entity-invalid, rich-structure-invalid, rich-content-required, html-parse, empty-content, non-degradable} → degrade vs rethrow.
- Regression tests verified to fail on pre-fix code for the intended reason (plain retry never issued): `draft-stream.test.ts` "falls back to plain preview text when an HTML edit renders empty", `send.test.ts` "falls back to plain text when an HTML edit renders empty" — ran the new tests against the pre-change production sources: 3 failed there, all pass after.
- Focused proof on head: `node scripts/run-vitest.mjs` over `send*`, `rich-plain-fallback*`, `draft-stream*`, `bot/delivery*` — 9 files, 526 tests passed (87s). `pnpm tsgo:extensions` clean, `scripts/run-oxlint.mjs` + telegram boundary dts clean, `git diff --check` clean.
- Telegram E2E userbot proof on the final head to follow as a PR comment before merge.
