### PR TITLE
refactor(gateway): register resident lifecycles

### DIFF
--- a/src/gateway/server-core-runtime.ts
+++ b/src/gateway/server-core-runtime.ts
@@ -114,7 +114,6 @@ export async function startGatewayCoreRuntime(input: {
     runtimeState,
     kernel,
     startupTrace,
-    activeTaskCount,
     channelManager,
     workerDispatchAuthority,
     clients,
@@ -141,9 +140,13 @@ export async function startGatewayCoreRuntime(input: {
     workerEnvironmentStartup,
     broadcastPluginEvent,
     activateRuntimeSecrets,
+    residentRegistry,
   } = runtime;
-  const earlyRuntime = await startupTrace.measure("runtime.early", () =>
-    loadGatewayStartupEarlyModule().then(({ startGatewayEarlyRuntime }) =>
+  let earlyRuntimePromise: ReturnType<
+    Awaited<ReturnType<typeof loadGatewayStartupEarlyModule>>["startGatewayEarlyRuntime"]
+  > | null = null;
+  const startEarlyRuntime = () => {
+    earlyRuntimePromise ??= loadGatewayStartupEarlyModule().then(({ startGatewayEarlyRuntime }) =>
       startGatewayEarlyRuntime({
         minimalTestGateway,
         cfgAtStart,
@@ -180,11 +183,31 @@ export async function startGatewayCoreRuntime(input: {
         getRuntimeConfig,
         startupTrace,
       }),
-    ),
+    );
+    return earlyRuntimePromise;
+  };
+  const discoveryResident = residentRegistry.register({
+    name: "bonjour-discovery",
+    start: startEarlyRuntime,
+    stop: async () => {
+      const earlyRuntime = await startEarlyRuntime();
+      await earlyRuntime.bonjourStop?.();
+    },
+  });
+  const taskAndSkillsResident = residentRegistry.register({
+    name: "task-and-skills-runtime",
+    start: async () => await discoveryResident.start(),
+    stop: async () => {
+      const earlyRuntime = await startEarlyRuntime();
+      earlyRuntime.skillsChangeUnsub();
+      const { stopTaskRegistryMaintenance } = await import("../tasks/task-registry.maintenance.js");
+      stopTaskRegistryMaintenance();
+    },
+  });
+  const earlyRuntime = await startupTrace.measure("runtime.early", () =>
+    taskAndSkillsResident.start(),
   );
-  runtimeState.bonjourStop = earlyRuntime.bonjourStop;
-  activeTaskCount.get = earlyRuntime.getActiveTaskCount;
-  runtimeState.skillsChangeUnsub = earlyRuntime.skillsChangeUnsub;
+  kernel.setEarlyRuntimeHandles(earlyRuntime);
 
   const [{ startGatewayEventSubscriptions }, { startGatewayRuntimeServices }] =
     await startupTrace.measure("runtime.post-early-imports", () =>
@@ -193,8 +216,9 @@ export async function startGatewayCoreRuntime(input: {
         import("./server-runtime-startup-services.js"),
       ]),
     );
-  const { sessionCompanion, sessionObserver, ...runtimeSubscriptionUnsubs } =
-    await startupTrace.measure("runtime.subscriptions", () =>
+  const eventSubscriptionsResident = residentRegistry.register({
+    name: "event-subscriptions",
+    start: () =>
       startGatewayEventSubscriptions({
         log,
         broadcast,
@@ -209,7 +233,16 @@ export async function startGatewayCoreRuntime(input: {
         restartRecoveryCandidates,
         terminalSessions,
       }),
-    );
+    stop: async () => {
+      await runtimeState.agentUnsub?.();
+      runtimeState.heartbeatUnsub?.();
+      runtimeState.transcriptUnsub?.();
+      runtimeState.lifecycleUnsub?.();
+      runtimeState.taskUnsub?.();
+    },
+  });
+  const { sessionCompanion, sessionObserver, ...runtimeSubscriptionUnsubs } =
+    await startupTrace.measure("runtime.subscriptions", () => eventSubscriptionsResident.start());
   Object.assign(runtimeState, runtimeSubscriptionUnsubs);
 
   const runtimeServices = await startupTrace.measure("runtime.services", () =>
@@ -289,7 +322,7 @@ export async function startGatewayCoreRuntime(input: {
       coreGatewayHandlers: coreGatewayHandlersLocal,
     };
   });
-  runtimeState.gatewayLifetimeSidecars.push({
+  kernel.addGatewayLifetimeSidecar({
     stop: async () => {
       unregisterApprovalAuthorityObserver();
     },
@@ -385,8 +418,7 @@ export async function startGatewayCoreRuntime(input: {
       return;
     }
     try {
-      const stopPreviousDiscovery = runtimeState.bonjourStop;
-      runtimeState.bonjourStop = null;
+      const stopPreviousDiscovery = kernel.swapBonjourStop(null);
       if (stopPreviousDiscovery) {
         try {
           await stopPreviousDiscovery();
@@ -395,16 +427,18 @@ export async function startGatewayCoreRuntime(input: {
         }
       }
       const { startGatewayPluginDiscovery } = await loadGatewayStartupEarlyModule();
-      runtimeState.bonjourStop = await startGatewayPluginDiscovery({
-        minimalTestGateway,
-        cfgAtStart,
-        port,
-        gatewayTls,
-        gatewayDirectReachable: !isLoopbackHost(bindHost),
-        tailscaleMode,
-        logDiscovery,
-        pluginRegistry: nextPluginRegistry,
-      });
+      kernel.swapBonjourStop(
+        await startGatewayPluginDiscovery({
+          minimalTestGateway,
+          cfgAtStart,
+          port,
+          gatewayTls,
+          gatewayDirectReachable: !isLoopbackHost(bindHost),
+          tailscaleMode,
+          logDiscovery,
+          pluginRegistry: nextPluginRegistry,
+        }),
+      );
     } catch (err) {
       logDiscovery.warn(`gateway discovery refresh failed after plugin load: ${String(err)}`);
     }

--- a/src/gateway/server-lifecycle.ts
+++ b/src/gateway/server-lifecycle.ts
@@ -98,6 +98,8 @@ export async function prepareGatewayLifecycle(params: {
     sessionEventSubscribers,
     watchNodeRequestHandler,
     defaultWorkspaceDir,
+    activeTaskCount,
+    residentRegistry,
   } = runtime;
   const completeControlUiDeviceAuthMigrationForEffectiveOperator = (
     device: EffectiveOperatorDeviceIdentity,
@@ -263,6 +265,66 @@ export async function prepareGatewayLifecycle(params: {
     },
     publishMethodSurface: (methods: readonly string[]) => {
       runtimeState.gatewayMethods.splice(0, runtimeState.gatewayMethods.length, ...methods);
+    },
+    setEarlyRuntimeHandles: (handles: {
+      bonjourStop: typeof runtimeState.bonjourStop;
+      getActiveTaskCount: () => number;
+      skillsChangeUnsub: typeof runtimeState.skillsChangeUnsub;
+    }) => {
+      runtimeState.bonjourStop = handles.bonjourStop;
+      activeTaskCount.get = handles.getActiveTaskCount;
+      runtimeState.skillsChangeUnsub = handles.skillsChangeUnsub;
+    },
+    swapBonjourStop: (next: typeof runtimeState.bonjourStop) => {
+      const previous = runtimeState.bonjourStop;
+      runtimeState.bonjourStop = next;
+      return previous;
+    },
+    setScheduledServiceHandles: (handles: {
+      heartbeatRunner: typeof runtimeState.heartbeatRunner;
+      stopOutboundDeliveryRecovery: typeof runtimeState.stopOutboundDeliveryRecovery;
+    }) => {
+      runtimeState.heartbeatRunner = handles.heartbeatRunner;
+      runtimeState.stopOutboundDeliveryRecovery = handles.stopOutboundDeliveryRecovery;
+    },
+    setPostAttachHandles: (handles: {
+      stopGatewayUpdateCheck: typeof runtimeState.stopGatewayUpdateCheck;
+      tailscaleCleanup: typeof runtimeState.tailscaleCleanup;
+      pluginServices: typeof runtimeState.pluginServices;
+    }) => {
+      runtimeState.stopGatewayUpdateCheck = handles.stopGatewayUpdateCheck;
+      runtimeState.tailscaleCleanup = handles.tailscaleCleanup;
+      runtimeState.pluginServices = handles.pluginServices;
+    },
+    setPluginServices: (pluginServices: typeof runtimeState.pluginServices) => {
+      runtimeState.pluginServices = pluginServices;
+    },
+    setConfigReloaderHandle: (configReloader: typeof runtimeState.configReloader) => {
+      runtimeState.configReloader = configReloader;
+    },
+    setPostReadySidecars: (sidecars: typeof runtimeState.postReadySidecars) => {
+      runtimeState.postReadySidecars = sidecars;
+    },
+    setGatewayLifetimeSidecars: (sidecars: typeof runtimeState.gatewayLifetimeSidecars) => {
+      runtimeState.gatewayLifetimeSidecars = sidecars;
+    },
+    addGatewayLifetimeSidecar: (sidecar: (typeof runtimeState.gatewayLifetimeSidecars)[number]) => {
+      runtimeState.gatewayLifetimeSidecars.push(sidecar);
+    },
+    setMaintenanceHandles: (handles: {
+      tickInterval: typeof runtimeState.tickInterval;
+      healthInterval: typeof runtimeState.healthInterval;
+      dedupeCleanup: typeof runtimeState.dedupeCleanup;
+      stopMediaCleanup: typeof runtimeState.stopMediaCleanup;
+      worktreeCleanup: typeof runtimeState.worktreeCleanup;
+      skillCuratorCleanup: typeof runtimeState.skillCuratorCleanup;
+    }) => {
+      runtimeState.tickInterval = handles.tickInterval;
+      runtimeState.healthInterval = handles.healthInterval;
+      runtimeState.dedupeCleanup = handles.dedupeCleanup;
+      runtimeState.stopMediaCleanup = handles.stopMediaCleanup;
+      runtimeState.worktreeCleanup = handles.worktreeCleanup;
+      runtimeState.skillCuratorCleanup = handles.skillCuratorCleanup;
     },
   };
   runtimeState.controlUiSessionPullRequests = createControlUiSessionPullRequestSubscriptions({
@@ -500,28 +562,35 @@ export async function prepareGatewayLifecycle(params: {
     }
   };
 
+  const diagnosticHeartbeatResident = residentRegistry.register({
+    name: "diagnostic-heartbeat",
+    start: () => {
+      // Gateway lifecycle owns both this existing heartbeat timer and the monitor
+      // it samples, so startup failure and normal close tear them down together.
+      startDiagnosticHeartbeat(undefined, {
+        getConfig: getRuntimeConfig,
+        startupGraceMs: 60_000,
+        sampleLiveness: () => {
+          const sample = readinessEventLoopHealth.persistentDegradationSnapshot();
+          if (!sample || sample.degradedSinceMs == null) {
+            return null;
+          }
+          return {
+            reasons: sample.reasons,
+            intervalMs: sample.intervalMs,
+            degradedSinceMs: sample.degradedSinceMs,
+            eventLoopDelayP99Ms: sample.delayP99Ms,
+            eventLoopDelayMaxMs: sample.delayMaxMs,
+            eventLoopUtilization: sample.utilization,
+            cpuCoreRatio: sample.cpuCoreRatio,
+          };
+        },
+      });
+    },
+    stop: () => stopDiagnosticHeartbeat(),
+  });
   if (diagnosticsEnabled) {
-    // Gateway lifecycle owns both this existing heartbeat timer and the monitor
-    // it samples, so startup failure and normal close tear them down together.
-    startDiagnosticHeartbeat(undefined, {
-      getConfig: getRuntimeConfig,
-      startupGraceMs: 60_000,
-      sampleLiveness: () => {
-        const sample = readinessEventLoopHealth.persistentDegradationSnapshot();
-        if (!sample || sample.degradedSinceMs == null) {
-          return null;
-        }
-        return {
-          reasons: sample.reasons,
-          intervalMs: sample.intervalMs,
-          degradedSinceMs: sample.degradedSinceMs,
-          eventLoopDelayP99Ms: sample.delayP99Ms,
-          eventLoopDelayMaxMs: sample.delayMaxMs,
-          eventLoopUtilization: sample.utilization,
-          cpuCoreRatio: sample.cpuCoreRatio,
-        };
-      },
-    });
+    diagnosticHeartbeatResident.start();
   }
 
   return {

--- a/src/gateway/server-resident-registry.ts
+++ b/src/gateway/server-resident-registry.ts
@@ -1,0 +1,35 @@
+type GatewayResident<
+  TStart extends () => unknown = () => unknown,
+  TStop extends () => unknown = () => unknown,
+> = {
+  name: string;
+  start: TStart;
+  stop: TStop;
+};
+
+export type GatewayResidentRegistry = {
+  register: <TStart extends () => unknown, TStop extends () => unknown>(
+    resident: GatewayResident<TStart, TStop>,
+  ) => GatewayResident<TStart, TStop>;
+  list: () => readonly GatewayResident[];
+};
+
+/** Records resident lifecycle owners without changing when callers start or stop them. */
+export function createGatewayResidentRegistry(): GatewayResidentRegistry {
+  const residents: GatewayResident[] = [];
+  const names = new Set<string>();
+
+  return {
+    register: <TStart extends () => unknown, TStop extends () => unknown>(
+      resident: GatewayResident<TStart, TStop>,
+    ) => {
+      if (names.has(resident.name)) {
+        throw new Error(`Gateway resident already registered: ${resident.name}`);
+      }
+      names.add(resident.name);
+      residents.push(resident as GatewayResident);
+      return resident;
+    },
+    list: () => residents,
+  };
+}

--- a/src/gateway/server-runtime-state-prepare.ts
+++ b/src/gateway/server-runtime-state-prepare.ts
@@ -21,6 +21,7 @@ import { createGatewayControlUiRootLifecycle } from "./server-control-ui-root.js
 import type { GatewayInstanceRuntime } from "./server-instance-runtime.types.js";
 import type { GatewayServerLiveState } from "./server-live-state.js";
 import type { GatewayRequestContext } from "./server-methods/types.js";
+import { createGatewayResidentRegistry } from "./server-resident-registry.js";
 import { createGatewayHttpTransport } from "./server-runtime-state.js";
 import type { SharedGatewaySessionGenerationState } from "./server-shared-auth-generation.js";
 import type { prepareGatewayServerBootstrap } from "./server-startup-bootstrap.js";
@@ -294,13 +295,25 @@ export async function prepareGatewayKernelState(params: {
   const systemAgentSessions: GatewayRequestContext["systemAgentSessions"] = new Map();
 
   const deps = createDefaultDeps();
+  const residentRegistry = createGatewayResidentRegistry();
   const runtimeStateRef: { current: GatewayServerLiveState | null } = { current: null };
   const cronStartState = { handled: false };
   const gatewayTls = await startupTrace.measure("tls.runtime", () =>
     loadGatewayTlsRuntime(cfgAtStart.gateway?.tls, log.child("tls")),
   );
   const serverStartedAt = Date.now();
-  const readinessEventLoopHealth = createGatewayEventLoopHealthMonitor();
+  const eventLoopHealthState: {
+    current?: ReturnType<typeof createGatewayEventLoopHealthMonitor>;
+  } = {};
+  const eventLoopHealthResident = residentRegistry.register({
+    name: "event-loop-health",
+    start: () => {
+      eventLoopHealthState.current ??= createGatewayEventLoopHealthMonitor();
+      return eventLoopHealthState.current;
+    },
+    stop: () => eventLoopHealthState.current?.stop(),
+  });
+  const readinessEventLoopHealth = eventLoopHealthResident.start();
   const startupState = {
     sidecarsReady: minimalTestGateway,
     pendingReason: "startup-sidecars",
@@ -468,6 +481,7 @@ export async function prepareGatewayKernelState(params: {
     purgeWizardSession,
     systemAgentSessions,
     deps,
+    residentRegistry,
     runtimeStateRef,
     cronStartState,
     gatewayTls,

--- a/src/gateway/server-startup-finish.ts
+++ b/src/gateway/server-startup-finish.ts
@@ -129,6 +129,7 @@ export async function finishGatewayStartup(params: {
     chatMetadataLifecycle,
     gatewayRequestContext,
     gatewayInstanceRuntime,
+    residentRegistry,
   } = runtime;
   const [{ attachGatewayWsHandlers }, { listPluginNodeCapabilities }] = await startupTrace.measure(
     "gateway.ws-imports",
@@ -176,6 +177,20 @@ export async function finishGatewayStartup(params: {
   await startupTrace.measure("http.listen", () => startListening());
   kernel.setDispatchReady(true);
   startupTrace.mark("http.bound");
+  let databaseVerifierHandle: { stop: () => void | Promise<void> } | null = null;
+  const databaseIntegrityResident = residentRegistry.register({
+    name: "database-integrity-verifier",
+    start: async () => {
+      if (minimalTestGateway) {
+        return;
+      }
+      const { startOpenClawDatabaseIntegrityVerifier } =
+        await import("../state/openclaw-database-verify.js");
+      databaseVerifierHandle = startOpenClawDatabaseIntegrityVerifier({ env: process.env });
+      kernel.addGatewayLifetimeSidecar(databaseVerifierHandle);
+    },
+    stop: async () => await databaseVerifierHandle?.stop(),
+  });
   const sessionDeliveryRecoveryMaxEnqueuedAt = Date.now();
   let postAttachRuntimeReturned = false;
   let scheduledServicesActivated = false;
@@ -183,41 +198,44 @@ export async function finishGatewayStartup(params: {
     () => import("./server-runtime-services.js"),
     { cacheRejections: true },
   );
-  const activateScheduledServicesWhenReady = () => {
-    if (
-      lifecycle.closePreludeStarted ||
-      !postAttachRuntimeReturned ||
-      !startupState.sidecarsReady ||
-      scheduledServicesActivated
-    ) {
-      return;
-    }
-    scheduledServicesActivated = true;
-    void loadScheduledServicesModule().then((gatewayRuntimeServices) => {
-      if (lifecycle.closePreludeStarted) {
+  const scheduledServicesResident = residentRegistry.register({
+    name: "scheduled-services",
+    start: () => {
+      if (
+        lifecycle.closePreludeStarted ||
+        !postAttachRuntimeReturned ||
+        !startupState.sidecarsReady ||
+        scheduledServicesActivated
+      ) {
         return;
       }
-      const activated = gatewayRuntimeServices.activateGatewayScheduledServices({
-        minimalTestGateway,
-        cfgAtStart,
-        deps,
-        sessionDeliveryRecoveryMaxEnqueuedAt,
-        cronState: runtimeState.cronState,
-        cronReconciliation,
-        startCron: false,
-        logCron,
-        log,
+      scheduledServicesActivated = true;
+      void loadScheduledServicesModule().then((gatewayRuntimeServices) => {
+        if (lifecycle.closePreludeStarted) {
+          return;
+        }
+        const activated = gatewayRuntimeServices.activateGatewayScheduledServices({
+          minimalTestGateway,
+          cfgAtStart,
+          deps,
+          sessionDeliveryRecoveryMaxEnqueuedAt,
+          cronState: runtimeState.cronState,
+          cronReconciliation,
+          startCron: false,
+          logCron,
+          log,
+        });
+        kernel.setScheduledServiceHandles(activated);
       });
-      runtimeState.heartbeatRunner = activated.heartbeatRunner;
-      runtimeState.stopOutboundDeliveryRecovery = activated.stopOutboundDeliveryRecovery;
-    });
-  };
+    },
+    stop: async () => {
+      await runtimeState.stopOutboundDeliveryRecovery();
+      runtimeState.heartbeatRunner.stop();
+    },
+  });
+  const activateScheduledServicesWhenReady = scheduledServicesResident.start;
   const { createGatewayServerActiveWorkInspectors } = await import("./server-active-work.js");
-  ({
-    stopGatewayUpdateCheck: runtimeState.stopGatewayUpdateCheck,
-    tailscaleCleanup: runtimeState.tailscaleCleanup,
-    pluginServices: runtimeState.pluginServices,
-  } = await startupTrace.measure("runtime.post-attach", () =>
+  const postAttachHandles = await startupTrace.measure("runtime.post-attach", () =>
     loadGatewayStartupPostAttachModule().then(
       ({ startGatewayPostAttachRuntime, stopPostReadySidecarsAfterCloseStarted }) =>
         startGatewayPostAttachRuntime({
@@ -284,25 +302,27 @@ export async function finishGatewayStartup(params: {
             releaseStartupAccountStarts();
           },
           onPluginServices: (pluginServices) => {
-            runtimeState.pluginServices = pluginServices;
+            kernel.setPluginServices(pluginServices);
           },
           onPostReadySidecars: (postReadySidecars) => {
-            runtimeState.postReadySidecars = postReadySidecars;
+            kernel.setPostReadySidecars(postReadySidecars);
             stopPostReadySidecarsAfterCloseStarted({
               postReadySidecars,
               closeStarted: lifecycle.closePreludeStarted,
             });
             if (lifecycle.closePreludeStarted) {
-              runtimeState.postReadySidecars = [];
+              kernel.setPostReadySidecars([]);
             }
           },
           onGatewayLifetimeSidecars: (gatewayLifetimeSidecars) => {
-            runtimeState.gatewayLifetimeSidecars = publishGatewayLifetimeSidecars({
-              registered: runtimeState.gatewayLifetimeSidecars,
-              published: gatewayLifetimeSidecars,
-              closeStarted: lifecycle.closePreludeStarted,
-              stopAfterCloseStarted: stopPostReadySidecarsAfterCloseStarted,
-            });
+            kernel.setGatewayLifetimeSidecars(
+              publishGatewayLifetimeSidecars({
+                registered: runtimeState.gatewayLifetimeSidecars,
+                published: gatewayLifetimeSidecars,
+                closeStarted: lifecycle.closePreludeStarted,
+                stopAfterCloseStarted: stopPostReadySidecarsAfterCloseStarted,
+              }),
+            );
           },
           ...(workerPlacementRuntime
             ? {
@@ -314,7 +334,7 @@ export async function finishGatewayStartup(params: {
                     isClosePreludeStarted: () => lifecycle.closePreludeStarted,
                     // Close must see the drain handle before reconciliation can yield.
                     registerSidecar: (sidecar) => {
-                      runtimeState.gatewayLifetimeSidecars.push(sidecar);
+                      kernel.addGatewayLifetimeSidecar(sidecar);
                     },
                   });
                 },
@@ -329,12 +349,14 @@ export async function finishGatewayStartup(params: {
           sidecarStartup,
           waitForPostReadyWork: params.waitForPostReadyWork,
           activeWorkInspectors: createGatewayServerActiveWorkInspectors(gatewayRequestContext),
+          residentRegistry,
           providerAuthPrewarm: {
             getConfig: getRuntimeConfig,
           },
         }),
     ),
-  ));
+  );
+  kernel.setPostAttachHandles(postAttachHandles);
   startupTrace.detail("memory.ready", collectGatewayProcessMemoryUsageMb());
   startupTrace.mark("ready");
   if (sidecarStartup === "defer") {
@@ -342,17 +364,13 @@ export async function finishGatewayStartup(params: {
   }
   finishGatewayRestartTrace("restart.ready", collectGatewayProcessMemoryUsageMb());
   if (!minimalTestGateway) {
-    const { startOpenClawDatabaseIntegrityVerifier } =
-      await import("../state/openclaw-database-verify.js");
-    runtimeState.gatewayLifetimeSidecars.push(
-      startOpenClawDatabaseIntegrityVerifier({ env: process.env }),
-    );
+    await databaseIntegrityResident.start();
   }
   postAttachRuntimeReturned = true;
   activateScheduledServicesWhenReady();
 
   const { startManagedGatewayConfigReloader } = await import("./server-reload-handlers.js");
-  runtimeState.configReloader = startManagedGatewayConfigReloader({
+  const configReloaderParams: Parameters<typeof startManagedGatewayConfigReloader>[0] = {
     minimalTestGateway,
     initialConfig: cfgAtStart,
     initialCompareConfig: startupLastGoodSnapshot.sourceConfig,
@@ -438,73 +456,99 @@ export async function finishGatewayStartup(params: {
     clients,
     ...(opts.hotReloadRecovery ? { requestRecoveryRestart: opts.hotReloadRecovery } : {}),
     restartRecoveryAvailable: opts.hotReloadRecovery !== undefined,
+  };
+  const configReloaderResident = residentRegistry.register({
+    name: "config-reloader",
+    start: () => startManagedGatewayConfigReloader(configReloaderParams),
+    stop: async () => await runtimeState.configReloader.stop(),
   });
+  kernel.setConfigReloaderHandle(configReloaderResident.start());
   await promoteConfigSnapshotToLastKnownGood(startupLastGoodSnapshot).catch((err: unknown) => {
     log.warn(`gateway: failed to promote config last-known-good backup: ${String(err)}`);
   });
   if (!minimalTestGateway) {
     const gatewayRuntimeServices = await loadScheduledServicesModule();
-    postReadyState.maintenanceTimer = gatewayRuntimeServices.scheduleGatewayPostReadyMaintenance({
-      delayMs: POST_READY_MAINTENANCE_DELAY_MS,
-      isClosing: () => lifecycle.closePreludeStarted,
-      onStarted: () => {
-        postReadyState.maintenanceTimer = null;
+    const maintenanceResident = residentRegistry.register({
+      name: "post-ready-maintenance",
+      start: () => {
+        postReadyState.maintenanceTimer =
+          gatewayRuntimeServices.scheduleGatewayPostReadyMaintenance({
+            delayMs: POST_READY_MAINTENANCE_DELAY_MS,
+            isClosing: () => lifecycle.closePreludeStarted,
+            onStarted: () => {
+              postReadyState.maintenanceTimer = null;
+            },
+            startMaintenance: async () => {
+              if (lifecycle.closePreludeStarted) {
+                return null;
+              }
+              return earlyRuntime.startMaintenance();
+            },
+            applyMaintenance: async (maintenance) => {
+              if (lifecycle.closePreludeStarted) {
+                clearInterval(maintenance.tickInterval);
+                clearInterval(maintenance.healthInterval);
+                clearInterval(maintenance.dedupeCleanup);
+                await maintenance.stopMediaCleanup();
+                clearInterval(maintenance.worktreeCleanup);
+                maintenance.skillCuratorCleanup();
+                return;
+              }
+              // Publish the stop owner before cleanup can touch SQLite or state paths;
+              // shutdown may begin immediately after this synchronous handoff.
+              kernel.setMaintenanceHandles(maintenance);
+              maintenance.startMediaCleanup();
+            },
+            shouldStartCron: () => !lifecycle.closePreludeStarted && !cronStartState.handled,
+            markCronStartHandled: () => {
+              cronStartState.handled = true;
+            },
+            cronState: runtimeState.cronState,
+            cronReconciliation,
+            cronConfig: cfgAtStart,
+            logCron,
+            log,
+            recordPostReadyMemory: () => {
+              startupTrace.detail("memory.post-ready", collectGatewayProcessMemoryUsageMb());
+            },
+          });
       },
-      startMaintenance: async () => {
-        if (lifecycle.closePreludeStarted) {
-          return null;
+      stop: () => {
+        if (postReadyState.maintenanceTimer) {
+          clearTimeout(postReadyState.maintenanceTimer);
+          postReadyState.maintenanceTimer = null;
         }
-        return earlyRuntime.startMaintenance();
-      },
-      applyMaintenance: async (maintenance) => {
-        if (lifecycle.closePreludeStarted) {
-          clearInterval(maintenance.tickInterval);
-          clearInterval(maintenance.healthInterval);
-          clearInterval(maintenance.dedupeCleanup);
-          await maintenance.stopMediaCleanup();
-          clearInterval(maintenance.worktreeCleanup);
-          maintenance.skillCuratorCleanup();
-          return;
-        }
-        runtimeState.tickInterval = maintenance.tickInterval;
-        runtimeState.healthInterval = maintenance.healthInterval;
-        runtimeState.dedupeCleanup = maintenance.dedupeCleanup;
-        // Publish the stop owner before cleanup can touch SQLite or state paths;
-        // shutdown may begin immediately after this synchronous handoff.
-        runtimeState.stopMediaCleanup = maintenance.stopMediaCleanup;
-        runtimeState.worktreeCleanup = maintenance.worktreeCleanup;
-        runtimeState.skillCuratorCleanup = maintenance.skillCuratorCleanup;
-        maintenance.startMediaCleanup();
-      },
-      shouldStartCron: () => !lifecycle.closePreludeStarted && !cronStartState.handled,
-      markCronStartHandled: () => {
-        cronStartState.handled = true;
-      },
-      cronState: runtimeState.cronState,
-      cronReconciliation,
-      cronConfig: cfgAtStart,
-      logCron,
-      log,
-      recordPostReadyMemory: () => {
-        startupTrace.detail("memory.post-ready", collectGatewayProcessMemoryUsageMb());
       },
     });
+    maintenanceResident.start();
     // The loop closes the previous server before this generation starts, so retired
     // plugin installs are safe to remove. Wait for an idle window and resolve current
     // install paths at execution time so cleanup cannot remove active code or delay a turn.
-    postReadyState.retainedPluginCleanupHandle = gatewayRuntimeServices.scheduleGatewayIdleTask({
-      delayMs: RETAINED_PLUGIN_CLEANUP_DELAY_MS,
-      retryDelayMs: RETAINED_PLUGIN_CLEANUP_DELAY_MS,
-      isClosing: () => lifecycle.closePreludeStarted,
-      isBusy: () => getActiveGatewayRootWorkCount({ excludeCurrent: true }) > 0,
-      run: async () => {
-        const { cleanupRetainedPluginInstallGenerations } =
-          await import("./server-retained-plugin-cleanup.js");
-        await cleanupRetainedPluginInstallGenerations({ log });
+    const retainedPluginCleanupResident = residentRegistry.register({
+      name: "retained-plugin-cleanup",
+      start: () => {
+        postReadyState.retainedPluginCleanupHandle = gatewayRuntimeServices.scheduleGatewayIdleTask(
+          {
+            delayMs: RETAINED_PLUGIN_CLEANUP_DELAY_MS,
+            retryDelayMs: RETAINED_PLUGIN_CLEANUP_DELAY_MS,
+            isClosing: () => lifecycle.closePreludeStarted,
+            isBusy: () => getActiveGatewayRootWorkCount({ excludeCurrent: true }) > 0,
+            run: async () => {
+              const { cleanupRetainedPluginInstallGenerations } =
+                await import("./server-retained-plugin-cleanup.js");
+              await cleanupRetainedPluginInstallGenerations({ log });
+            },
+            log,
+            errorMessage: "retained npm generation cleanup failed",
+          },
+        );
       },
-      log,
-      errorMessage: "retained npm generation cleanup failed",
+      stop: () => {
+        postReadyState.retainedPluginCleanupHandle?.stop();
+        postReadyState.retainedPluginCleanupHandle = null;
+      },
     });
+    retainedPluginCleanupResident.start();
   } else {
     startupTrace.detail("memory.post-ready", collectGatewayProcessMemoryUsageMb());
   }

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../process/gateway-work-admission.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withEnvAsync } from "../test-utils/env.js";
+import { createGatewayResidentRegistry } from "./server-resident-registry.js";
 import "./server-startup-outcomes.test-support.js";
 
 const hoisted = vi.hoisted(() => {
@@ -3124,6 +3125,7 @@ function createPostAttachParams(overrides: Partial<PostAttachParams> = {}): Post
       error: vi.fn(),
     },
     unlockStartupMethods: vi.fn(),
+    residentRegistry: createGatewayResidentRegistry(),
     providerAuthPrewarm: { enabled: false },
     ...overrides,
   };

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -31,6 +31,7 @@ import type { GatewayBroadcastToConnIdsFn } from "./server-broadcast-types.js";
 import type { GatewayControlUiRootLifecycle } from "./server-control-ui-root.js";
 import type { GatewayRecoveryRuntime } from "./server-instance-runtime.types.js";
 import type { GatewayClient } from "./server-methods/shared-types.js";
+import type { GatewayResidentRegistry } from "./server-resident-registry.js";
 import type { refreshLatestUpdateRestartSentinel } from "./server-restart-sentinel.js";
 import type { GatewaySidecarStartupMode } from "./server-sidecar-startup-mode.js";
 import { scheduleContextCachePrewarm } from "./server-startup-context-cache-prewarm.js";
@@ -1102,25 +1103,35 @@ export async function startGatewayPostAttachRuntime(
     };
     waitForPostReadyWork?: () => Promise<void>;
     activeWorkInspectors?: Partial<GatewayActiveWorkInspectors>;
+    residentRegistry: GatewayResidentRegistry;
   },
   runtimeDeps: GatewayPostAttachRuntimeDeps = defaultGatewayPostAttachRuntimeDeps,
 ) {
   const controlUiRootLifecycle = params.controlUiRootLifecycle;
-  const controlUiAssetsSidecar =
-    !params.minimalTestGateway && controlUiRootLifecycle?.state?.kind === "preparing"
-      ? schedulePostReadySidecarTask({
-          name: "sidecars.control-ui-assets",
-          startupTrace: params.startupTrace,
-          log: params.log,
-          run: controlUiRootLifecycle.start,
-          stop: controlUiRootLifecycle.stop,
-        })
-      : undefined;
-  if (controlUiAssetsSidecar) {
-    // Publish before the first await: slow CA/plugin startup must not strand
-    // the dashboard or hide its running builder from Gateway shutdown.
-    params.onGatewayLifetimeSidecars?.([controlUiAssetsSidecar]);
-  }
+  let controlUiAssetsSidecar: GatewayPostReadySidecarHandle | undefined;
+  const controlUiAssetsResident = params.residentRegistry.register({
+    name: "control-ui-assets",
+    start: () => {
+      controlUiAssetsSidecar =
+        !params.minimalTestGateway && controlUiRootLifecycle?.state?.kind === "preparing"
+          ? schedulePostReadySidecarTask({
+              name: "sidecars.control-ui-assets",
+              startupTrace: params.startupTrace,
+              log: params.log,
+              run: controlUiRootLifecycle.start,
+              stop: controlUiRootLifecycle.stop,
+            })
+          : undefined;
+      if (controlUiAssetsSidecar) {
+        // Publish before the first await: slow CA/plugin startup must not strand
+        // the dashboard or hide its running builder from Gateway shutdown.
+        params.onGatewayLifetimeSidecars?.([controlUiAssetsSidecar]);
+      }
+      return controlUiAssetsSidecar;
+    },
+    stop: async () => await controlUiAssetsSidecar?.stop(),
+  });
+  controlUiAssetsResident.start();
 
   if (!params.minimalTestGateway) {
     // The HTTP server is already attached, so keep health probes responsive while the worker
@@ -1162,7 +1173,12 @@ export async function startGatewayPostAttachRuntime(
     })();
     return await startupPluginsLoadPromise;
   };
-  await loadStartupPluginsIfNeeded();
+  const startupPluginsResident = params.residentRegistry.register({
+    name: "startup-plugin-load",
+    start: loadStartupPluginsIfNeeded,
+    stop: () => {},
+  });
+  await startupPluginsResident.start();
 
   const startupOutcomes = createGatewayStartupOutcomeRecorder({
     cfg: params.gatewayPluginConfigAtStart,
@@ -1203,21 +1219,37 @@ export async function startGatewayPostAttachRuntime(
         activeWorkInspectors: params.activeWorkInspectors,
       });
 
-  const tailscaleCleanupPromise = params.minimalTestGateway
-    ? Promise.resolve(null)
-    : params.tailscaleMode === "off" && !params.resetOnExit
-      ? Promise.resolve(null)
-      : measureStartup(params.startupTrace, "post-attach.tailscale", () =>
-          runtimeDeps.startGatewayTailscaleExposure({
-            tailscaleMode: params.tailscaleMode,
-            resetOnExit: params.resetOnExit,
-            serviceName: params.serviceName,
-            preserveFunnel: params.preserveFunnel,
-            port: params.port,
-            controlUiBasePath: params.controlUiBasePath,
-            logTailscale: params.logTailscale,
-          }),
-        );
+  const updateCheckResident = params.residentRegistry.register({
+    name: "update-check",
+    start: updateCheck.start,
+    stop: updateCheck.stop,
+  });
+  let tailscaleCleanupPromise!: Promise<Awaited<
+    ReturnType<typeof runtimeDeps.startGatewayTailscaleExposure>
+  > | null>;
+  const tailscaleResident = params.residentRegistry.register({
+    name: "tailscale-exposure",
+    start: () => {
+      tailscaleCleanupPromise = params.minimalTestGateway
+        ? Promise.resolve(null)
+        : params.tailscaleMode === "off" && !params.resetOnExit
+          ? Promise.resolve(null)
+          : measureStartup(params.startupTrace, "post-attach.tailscale", () =>
+              runtimeDeps.startGatewayTailscaleExposure({
+                tailscaleMode: params.tailscaleMode,
+                resetOnExit: params.resetOnExit,
+                serviceName: params.serviceName,
+                preserveFunnel: params.preserveFunnel,
+                port: params.port,
+                controlUiBasePath: params.controlUiBasePath,
+                logTailscale: params.logTailscale,
+              }),
+            );
+      return tailscaleCleanupPromise;
+    },
+    stop: async () => await (await tailscaleCleanupPromise)?.(),
+  });
+  void tailscaleResident.start();
 
   let pluginServicesReported = false;
   let reportedPluginServices: PluginServicesHandle | null = null;
@@ -1238,136 +1270,168 @@ export async function startGatewayPostAttachRuntime(
       setImmediate(resolve);
     });
 
-  const sidecarsPromise = params.minimalTestGateway
-    ? Promise.resolve({ pluginServices: null, pluginRegistry, postReadySidecars: [] })
-    : waitForSidecarStartTurn().then(async () => {
-        await loadStartupPluginsIfNeeded();
-        const workerEnvironmentSidecar = params.isClosing?.()
-          ? null
-          : ((await params.startWorkerEnvironmentRuntime?.()) ?? null);
-        params.log.info("starting channels and sidecars...");
-        const loaderStatsBefore = getPluginModuleLoaderStats();
-        const result = await (async () => {
+  const startSidecars = () =>
+    params.minimalTestGateway
+      ? Promise.resolve({
+          pluginServices: null,
+          pluginRegistry,
+          postReadySidecars: [],
+          gatewayLifetimeSidecars: [],
+        })
+      : waitForSidecarStartTurn().then(async () => {
+          await startupPluginsResident.start();
+          const workerEnvironmentSidecar = params.isClosing?.()
+            ? null
+            : ((await params.startWorkerEnvironmentRuntime?.()) ?? null);
+          params.log.info("starting channels and sidecars...");
+          const loaderStatsBefore = getPluginModuleLoaderStats();
+          const result = await (async () => {
+            try {
+              return await measureStartup(params.startupTrace, "sidecars.total", () =>
+                runtimeDeps.startGatewaySidecars({
+                  cfg: params.gatewayPluginConfigAtStart,
+                  pluginRegistry,
+                  defaultWorkspaceDir: params.defaultWorkspaceDir,
+                  deps: params.deps,
+                  startChannels: params.startChannels,
+                  refreshChatMetadata: params.refreshChatMetadata,
+                  log: params.log,
+                  logHooks: params.logHooks,
+                  logChannels: params.logChannels,
+                  startupTrace: params.startupTrace,
+                  onChannelsStarted: params.onChannelsStarted,
+                  onPluginServices: reportPluginServices,
+                  shouldStartPluginServices: () => params.isClosing?.() !== true,
+                  broadcastPluginEvent: params.broadcastPluginEvent,
+                  startupOutcomes,
+                  waitForPostReadyWork: params.waitForPostReadyWork,
+                }),
+              );
+            } catch (error) {
+              await workerEnvironmentSidecar?.stop();
+              throw error;
+            }
+          })();
+          const loaderStatsAfter = getPluginModuleLoaderStats();
+          params.startupTrace?.detail("sidecars.plugin-loader", [
+            ["callsCount", loaderStatsAfter.calls - loaderStatsBefore.calls],
+            ["nativeHitsCount", loaderStatsAfter.nativeHits - loaderStatsBefore.nativeHits],
+            ["nativeMissesCount", loaderStatsAfter.nativeMisses - loaderStatsBefore.nativeMisses],
+            [
+              "sourceTransformForcedCount",
+              loaderStatsAfter.sourceTransformForced - loaderStatsBefore.sourceTransformForced,
+            ],
+            [
+              "sourceTransformFallbacksCount",
+              loaderStatsAfter.sourceTransformFallbacks -
+                loaderStatsBefore.sourceTransformFallbacks,
+            ],
+          ]);
+          let mainSessionRecoverySidecar: GatewayPostReadySidecarHandle | undefined;
           try {
-            return await measureStartup(params.startupTrace, "sidecars.total", () =>
-              runtimeDeps.startGatewaySidecars({
-                cfg: params.gatewayPluginConfigAtStart,
-                pluginRegistry,
-                defaultWorkspaceDir: params.defaultWorkspaceDir,
-                deps: params.deps,
-                startChannels: params.startChannels,
-                refreshChatMetadata: params.refreshChatMetadata,
+            if (params.isClosing?.() !== true) {
+              const { scheduleRestartAbortedMainSessionRecovery } =
+                await loadMainSessionRestartRecoveryModule();
+              // Closing can begin while the runtime module is loading; a late owner
+              // would miss lifetime registration and race the replacement gateway.
+              if (params.isClosing?.() !== true) {
+                mainSessionRecoverySidecar = scheduleRestartAbortedMainSessionRecovery({
+                  delayMs: 0,
+                  getConfig: params.getConfig,
+                  shouldContinue: () => params.isClosing?.() !== true,
+                  waitForStart: params.waitForPostReadyWork,
+                  gatewayRuntime: params.recoveryRuntime,
+                });
+              }
+            }
+          } catch (err) {
+            params.log.warn(`main-session restart recovery failed to schedule: ${String(err)}`);
+          }
+          try {
+            const { scheduleSubagentRegistrySweep } =
+              await import("../agents/subagents/registry/subagent-registry.js");
+            scheduleSubagentRegistrySweep();
+          } catch (err) {
+            params.log.warn(`subagent restart recovery failed to schedule: ${String(err)}`);
+          }
+          // Capture the orphan-recovery cutoff before new startup-gated agent
+          // work can create sessions that the recovery scan must leave alone.
+          params.unlockStartupMethods();
+          if (!pluginServicesReported) {
+            reportPluginServices(result.pluginServices);
+          }
+          const postReadySidecars = [...result.postReadySidecars];
+          const gatewayLifetimeSidecars = [
+            ...(controlUiAssetsSidecar ? [controlUiAssetsSidecar] : []),
+            scheduleContextCachePrewarm(params),
+            scheduleGatewayHandlerPrewarm(params),
+            ...(mainSessionRecoverySidecar ? [mainSessionRecoverySidecar] : []),
+          ];
+          if (workerEnvironmentSidecar) {
+            gatewayLifetimeSidecars.push(workerEnvironmentSidecar);
+          }
+          if (params.providerAuthPrewarm && params.providerAuthPrewarm.enabled !== false) {
+            gatewayLifetimeSidecars.push(
+              scheduleProviderAuthStatePrewarm({
+                getConfig: params.providerAuthPrewarm.getConfig ?? (() => params.cfgAtStart),
                 log: params.log,
-                logHooks: params.logHooks,
-                logChannels: params.logChannels,
+                delayMs: params.providerAuthPrewarm.delayMs,
+                startupWarmEnabled: params.providerAuthPrewarm.enabled === true,
+              }),
+            );
+          }
+          if (params.gatewayPluginConfigAtStart.transcripts?.autoStart?.length) {
+            gatewayLifetimeSidecars.push(
+              scheduleTranscriptsAutoStartSidecar({
+                cfg: params.gatewayPluginConfigAtStart,
                 startupTrace: params.startupTrace,
-                onChannelsStarted: params.onChannelsStarted,
-                onPluginServices: reportPluginServices,
-                shouldStartPluginServices: () => params.isClosing?.() !== true,
-                broadcastPluginEvent: params.broadcastPluginEvent,
-                startupOutcomes,
+                log: params.log,
                 waitForPostReadyWork: params.waitForPostReadyWork,
               }),
             );
-          } catch (error) {
-            await workerEnvironmentSidecar?.stop();
-            throw error;
           }
-        })();
-        const loaderStatsAfter = getPluginModuleLoaderStats();
-        params.startupTrace?.detail("sidecars.plugin-loader", [
-          ["callsCount", loaderStatsAfter.calls - loaderStatsBefore.calls],
-          ["nativeHitsCount", loaderStatsAfter.nativeHits - loaderStatsBefore.nativeHits],
-          ["nativeMissesCount", loaderStatsAfter.nativeMisses - loaderStatsBefore.nativeMisses],
-          [
-            "sourceTransformForcedCount",
-            loaderStatsAfter.sourceTransformForced - loaderStatsBefore.sourceTransformForced,
-          ],
-          [
-            "sourceTransformFallbacksCount",
-            loaderStatsAfter.sourceTransformFallbacks - loaderStatsBefore.sourceTransformFallbacks,
-          ],
-        ]);
-        let mainSessionRecoverySidecar: GatewayPostReadySidecarHandle | undefined;
-        try {
-          if (params.isClosing?.() !== true) {
-            const { scheduleRestartAbortedMainSessionRecovery } =
-              await loadMainSessionRestartRecoveryModule();
-            // Closing can begin while the runtime module is loading; a late owner
-            // would miss lifetime registration and race the replacement gateway.
-            if (params.isClosing?.() !== true) {
-              mainSessionRecoverySidecar = scheduleRestartAbortedMainSessionRecovery({
-                delayMs: 0,
-                getConfig: params.getConfig,
-                shouldContinue: () => params.isClosing?.() !== true,
-                waitForStart: params.waitForPostReadyWork,
-                gatewayRuntime: params.recoveryRuntime,
-              });
-            }
+          params.onPostReadySidecars?.(postReadySidecars);
+          params.onGatewayLifetimeSidecars?.(gatewayLifetimeSidecars);
+          params.log.info(formatGatewayStartupOutcomes(startupOutcomes.snapshot()));
+          params.onSidecarsReady?.();
+          params.startupTrace?.detail("sidecars.ready", [
+            [
+              "loadedPluginCount",
+              pluginRegistry.plugins.filter((plugin) => plugin.status === "loaded").length,
+            ],
+            ["postReadySidecarCount", postReadySidecars.length + gatewayLifetimeSidecars.length],
+          ]);
+          params.startupTrace?.mark("sidecars.ready");
+          if (params.sidecarStartup !== "defer") {
+            params.log.info("gateway ready");
           }
-        } catch (err) {
-          params.log.warn(`main-session restart recovery failed to schedule: ${String(err)}`);
-        }
-        try {
-          const { scheduleSubagentRegistrySweep } =
-            await import("../agents/subagents/registry/subagent-registry.js");
-          scheduleSubagentRegistrySweep();
-        } catch (err) {
-          params.log.warn(`subagent restart recovery failed to schedule: ${String(err)}`);
-        }
-        // Capture the orphan-recovery cutoff before new startup-gated agent
-        // work can create sessions that the recovery scan must leave alone.
-        params.unlockStartupMethods();
-        if (!pluginServicesReported) {
-          reportPluginServices(result.pluginServices);
-        }
-        const postReadySidecars = [...result.postReadySidecars];
-        const gatewayLifetimeSidecars = [
-          ...(controlUiAssetsSidecar ? [controlUiAssetsSidecar] : []),
-          scheduleContextCachePrewarm(params),
-          scheduleGatewayHandlerPrewarm(params),
-          ...(mainSessionRecoverySidecar ? [mainSessionRecoverySidecar] : []),
-        ];
-        if (workerEnvironmentSidecar) {
-          gatewayLifetimeSidecars.push(workerEnvironmentSidecar);
-        }
-        if (params.providerAuthPrewarm && params.providerAuthPrewarm.enabled !== false) {
-          gatewayLifetimeSidecars.push(
-            scheduleProviderAuthStatePrewarm({
-              getConfig: params.providerAuthPrewarm.getConfig ?? (() => params.cfgAtStart),
-              log: params.log,
-              delayMs: params.providerAuthPrewarm.delayMs,
-              startupWarmEnabled: params.providerAuthPrewarm.enabled === true,
-            }),
-          );
-        }
-        if (params.gatewayPluginConfigAtStart.transcripts?.autoStart?.length) {
-          gatewayLifetimeSidecars.push(
-            scheduleTranscriptsAutoStartSidecar({
-              cfg: params.gatewayPluginConfigAtStart,
-              startupTrace: params.startupTrace,
-              log: params.log,
-              waitForPostReadyWork: params.waitForPostReadyWork,
-            }),
-          );
-        }
-        params.onPostReadySidecars?.(postReadySidecars);
-        params.onGatewayLifetimeSidecars?.(gatewayLifetimeSidecars);
-        params.log.info(formatGatewayStartupOutcomes(startupOutcomes.snapshot()));
-        params.onSidecarsReady?.();
-        params.startupTrace?.detail("sidecars.ready", [
-          [
-            "loadedPluginCount",
-            pluginRegistry.plugins.filter((plugin) => plugin.status === "loaded").length,
-          ],
-          ["postReadySidecarCount", postReadySidecars.length + gatewayLifetimeSidecars.length],
-        ]);
-        params.startupTrace?.mark("sidecars.ready");
-        if (params.sidecarStartup !== "defer") {
-          params.log.info("gateway ready");
-        }
-        return { ...result, postReadySidecars, gatewayLifetimeSidecars, pluginRegistry };
-      });
+          return { ...result, postReadySidecars, gatewayLifetimeSidecars, pluginRegistry };
+        });
+  let startedSidecars: ReturnType<typeof startSidecars> | undefined;
+  const sidecarSequenceResident = params.residentRegistry.register({
+    name: "sidecar-sequence",
+    start: () => {
+      startedSidecars ??= startSidecars();
+      return startedSidecars;
+    },
+    stop: async () => {
+      const result = await startedSidecars;
+      for (const sidecar of result?.postReadySidecars ?? []) {
+        await sidecar.stop();
+      }
+    },
+  });
+  const perConfigSidecarsResident = params.residentRegistry.register({
+    name: "per-config-sidecars",
+    start: sidecarSequenceResident.start,
+    stop: async () => {
+      const result = await startedSidecars;
+      for (const sidecar of result?.gatewayLifetimeSidecars ?? []) {
+        await sidecar.stop();
+      }
+    },
+  });
+  const sidecarsPromise = perConfigSidecarsResident.start();
 
   void sidecarsPromise
     .then(async (sidecarsResult) => {
@@ -1425,19 +1489,19 @@ export async function startGatewayPostAttachRuntime(
       tailscaleCleanupPromise,
       sidecarsPromise,
     ]);
-    updateCheck.start();
+    updateCheckResident.start();
     return {
-      stopGatewayUpdateCheck: updateCheck.stop,
+      stopGatewayUpdateCheck: updateCheckResident.stop,
       tailscaleCleanup,
       pluginServices: sidecarsResult.pluginServices,
     };
   }
 
   const [, tailscaleCleanup] = await Promise.all([startupLogPromise, tailscaleCleanupPromise]);
-  updateCheck.start();
+  updateCheckResident.start();
 
   return {
-    stopGatewayUpdateCheck: updateCheck.stop,
+    stopGatewayUpdateCheck: updateCheckResident.stop,
     tailscaleCleanup,
     pluginServices: reportedPluginServices,
   };


### PR DESCRIPTION
## What Problem This Solves

Phase-2 PR 5 gives every Gateway resident from the design-verified R6-R21 inventory a uniform lifecycle owner after the landed socket-free kernel factory (#121981).

## Why This Change Was Made

The new resident registry records `{ name, start, stop }` owners for discovery, task/skills maintenance, event subscriptions, diagnostics, event-loop health, control-UI assets, Tailscale, update checks, post-bind plugin loading, sidecars, database verification, scheduled services, config reload, post-ready maintenance, and retained-plugin cleanup. Existing call sites still start and stop them at the same points, so listener attachment, sidecar sequencing, close trace order, and the post-ready barrier do not move.

Resident publications now go through named kernel setters for early-runtime handles, discovery replacement, scheduled services, post-attach handles, plugin services, config reload, lifetime/post-ready sidecars, and maintenance handles. No config, protocol, default, log ordering, or user-visible behavior changes.

This is phase-2 PR 5 of the Gateway kernel split. The design-verified resident inventory preceded the implementation; next is PR 6, the config-reloader inversion through `kernel.swapCronState()`, `kernel.swapHeartbeatRunner()`, and `kernel.reloadPlugins()`.

## User Impact

No user-visible change. Gateway resident ownership is now explicit and enumerable, preparing final kernel/transport/resident composition without altering startup or shutdown behavior.

## Evidence

- `server-close`, `server-startup-post-attach`, `server-lifetime-sidecars`, and both restart-sentinel suites: 5 files, 204 passed; existing restart-trace step assertions preserve shutdown order
- socket-free kernel + minimal boot regression: 2 files, 3 passed
- core and core-test tsgo lanes: passed
- `node scripts/check-changed.mjs -- <touched>`: formatting, dead exports, lint, plugin boundaries, schema/runtime/import-cycle/auth guards passed locally after remote backend fallback
- `pnpm build`: passed
- Codex autoreview: clean, no accepted/actionable findings

The default local multi-project Gateway runner currently reproduces an unrelated current-main stale state-schema inlining failure for `cron_job_runtime_authorities`; the same untouched restart-sentinel suite and the full required group pass with `OPENCLAW_GATEWAY_PROJECT_SHARDS=0`. This is recorded as heal-check provenance, not hidden by retries or weaker assertions.

ClawSweeper review metrics: production `+562/-302` (net `+260`) for the explicit 16-resident lifecycle table and kernel-owned live-state setter boundary; test support `+2/-0`. AI-assisted; implementation and evidence were reviewed directly.
