### PR TITLE
improve: speed up package tarball tests

### DIFF
--- a/test/scripts/check-openclaw-package-tarball.test.ts
+++ b/test/scripts/check-openclaw-package-tarball.test.ts
@@ -17,7 +17,8 @@ import { LOCAL_BUILD_METADATA_DIST_PATHS } from "../../scripts/lib/local-build-m
 import { PACKAGE_INSTALL_GUARD_RELATIVE_PATH } from "../../scripts/lib/package-dist-inventory.ts";
 import { WORKSPACE_TEMPLATE_PACK_PATHS } from "../../scripts/lib/workspace-bootstrap-smoke.mts";
 
-const CHECK_SCRIPT = "scripts/check-openclaw-package-tarball.mjs";
+const CHECK_SCRIPT = "scripts/check-openclaw-package-tarball.mts";
+const PUBLIC_CHECK_SCRIPT = "scripts/check-openclaw-package-tarball.mjs";
 const NODE_DEFAULT_SPAWN_MAX_BUFFER_BYTES = 1024 * 1024;
 const CODE_MODE_WORKER_PATH = "dist/agents/code-mode.worker.js";
 const FIRST_CODE_MODE_WORKER_VERSION = "2026.5.14-beta.2";
@@ -149,7 +150,7 @@ function withTarball(
 
 describe("check-openclaw-package-tarball", () => {
   it("prints help before touching tarball state", () => {
-    const result = spawnSync("node", [CHECK_SCRIPT, "--help"], { encoding: "utf8" });
+    const result = spawnSync("node", [PUBLIC_CHECK_SCRIPT, "--help"], { encoding: "utf8" });
 
     expect(result.status, result.stderr).toBe(0);
     expect(result.stdout).toContain(
@@ -280,19 +281,6 @@ describe("check-openclaw-package-tarball", () => {
     );
   });
 
-  it("still rejects non-legacy missing inventory entries", () => {
-    withTarball(
-      ["dist/index.js", "dist/cli.js"],
-      { "dist/index.js": "export {};\n" },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain("inventory references missing tar entry dist/cli.js");
-      },
-    );
-  });
-
   it("requires an install guard omitted from the dist inventory", () => {
     withTarball(
       ["dist/index.js"],
@@ -351,19 +339,6 @@ describe("check-openclaw-package-tarball", () => {
     );
   });
 
-  it("accepts flat plugin SDK declaration inventory without the old deep tree", () => {
-    withTarball(
-      [FLAT_PLUGIN_SDK_DECLARATION],
-      { [FLAT_PLUGIN_SDK_DECLARATION]: "export {};\n" },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status, result.stderr).toBe(0);
-        expect(result.stdout).toContain("OpenClaw package tarball integrity passed.");
-      },
-    );
-  });
-
   it("accepts historical packages published before the Code Mode worker existed", () => {
     withTarball(
       ["dist/index.js"],
@@ -408,20 +383,6 @@ describe("check-openclaw-package-tarball", () => {
     );
   });
 
-  it("accepts Code Mode packages whose worker survives postinstall", () => {
-    withTarball(
-      ["dist/index.js"],
-      { "dist/index.js": "export {};\n" },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status, result.stderr).toBe(0);
-        expect(result.stdout).toContain("OpenClaw package tarball integrity passed.");
-      },
-      FIRST_CODE_MODE_WORKER_VERSION,
-    );
-  });
-
   it("rejects dist files that import missing relative chunks", () => {
     withTarball(
       ["dist/cli/run-main.js"],
@@ -454,47 +415,6 @@ describe("check-openclaw-package-tarball", () => {
           "dist/docker-runtime-BVdgRgxA.js imports missing dist/qa-runtime-Bi1S3plf.js",
         );
       },
-    );
-  });
-
-  it.each([
-    {
-      name: "named imports",
-      source: 'import { value } from "./missing.js";\n',
-    },
-    {
-      name: "multiline named imports",
-      source: 'import {\n  value,\n} from "./missing.js";\n',
-    },
-    {
-      name: "named re-exports",
-      source: 'export { value } from "./missing.js";\n',
-    },
-  ])("rejects missing packaged chunks in $name", ({ source }) => {
-    withTarball(
-      ["dist/index.js"],
-      { "dist/index.js": source },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain("dist/index.js imports missing dist/missing.js");
-      },
-      "2026.4.27",
-    );
-  });
-
-  it("does not reject import-like text inside packaged template literals", () => {
-    withTarball(
-      ["dist/index.js"],
-      { "dist/index.js": 'const example = `\nimport "./phantom.js"\n`;\n' },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status, result.stderr).toBe(0);
-        expect(result.stdout).toContain("OpenClaw package tarball integrity passed.");
-      },
-      "2026.4.27",
     );
   });
 
@@ -625,27 +545,6 @@ describe("check-openclaw-package-tarball", () => {
     withTarball(
       ["dist/index.js"],
       { "dist/index.js": 'const root = new URL("../..", import.meta.url);\n' },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status, result.stderr).toBe(0);
-        expect(result.stdout).toContain("OpenClaw package tarball integrity passed.");
-      },
-      "2026.4.27",
-    );
-  });
-
-  it.each([
-    "../../openclaw.mjs",
-    "../../scripts/run-node.mjs",
-    "../../dist/entry.js",
-    "../../dist/entry.mjs",
-  ])("allows import.meta.url JavaScript probes outside packaged dist (%s)", (specifier) => {
-    withTarball(
-      ["dist/index.js"],
-      {
-        "dist/index.js": `const candidate = new URL(${JSON.stringify(specifier)}, import.meta.url);\n`,
-      },
       (tarball) => {
         const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
 


### PR DESCRIPTION
## What Problem This Solves

The package-tarball tooling suite repeatedly paid the TypeScript CLI shim startup cost for 40+ subprocess fixtures and duplicated the package import parser's owner-boundary matrix. Locally, 51 checks took 34.55s of test-body time and 36.27s wall.

## Why This Change Was Made

Fixture checks now invoke the Node 24-compatible `.mts` implementation directly while one explicit help smoke continues to exercise the shipped `.mjs` public wrapper. The audit also removes 11 low-value tarball cases: eight exact parser-fixture replays already owned by `check-package-dist-imports.test.ts`, plus three generic positive/inventory cases subsumed by stronger remaining checks.

No production code or CI worker count changes.

## User Impact

CI spends less time in package-tarball tooling checks while retaining the public wrapper, large-tarball, cleanup, compatibility-boundary, package-content, import-closure, postinstall-inventory, bundled-runtime, and metadata contracts.

## Evidence

Same orb, Node 24.15.0, same command:

`pnpm exec vitest run --config test/vitest/vitest.tooling.config.ts test/scripts/check-openclaw-package-tarball.test.ts --reporter=verbose`

| Metric | Before | After | Gain |
| --- | ---: | ---: | ---: |
| Test body | 34.55s | 16.97s | 50.9% faster |
| Vitest | 34.83s | 17.29s | 50.4% faster |
| Wrapper wall | 36.27s | 18.72s | 48.4% faster |
| Tests | 51 | 40 | 11 duplicate/low-value checks removed |

Exact hosted same-shard proof:

| Metric | Baseline run 31481650408 | Exact-head run 31483391210 | Gain |
| --- | ---: | ---: | ---: |
| Tarball test file | 19.909s | 6.987s | 64.9% faster |

Both runs used `checks-node-compact-small-12 / core-tooling-3`; the exact-head job passed all 100 shard files (job 93753416884).

Focused proof:

- Tarball suite: 40/40 passed.
- Import-parser owner suite: 13/13 passed.
- `oxfmt --check`: passed.
- type-aware `oxlint`: 0 warnings/errors.
- `git diff --check`: passed.
- Production LOC: +0/-0; tests: +3/-104.

Bundled autoreview's TruffleHog scan was clean; the external Codex executable is unavailable in this orb.
