### PR TITLE
refactor(gateway): invert config reloader ownership

### DIFF
--- a/src/gateway/server-core-runtime.ts
+++ b/src/gateway/server-core-runtime.ts
@@ -571,17 +571,19 @@ export async function startGatewayCoreRuntime(input: {
       workspaceDir: defaultWorkspaceDir,
     });
     replaceAttachedPluginRuntime(loaded);
-    runtimeState.pluginServices = null;
+    kernel.setPluginServices(null);
     if (previousPluginServices) {
       await previousPluginServices.stop();
     }
     await refreshAttachedGatewayDiscovery(loaded.pluginRegistry);
-    runtimeState.pluginServices = await startPluginServices({
-      registry: loaded.pluginRegistry,
-      config: params.nextConfig,
-      workspaceDir: defaultWorkspaceDir,
-      broadcastPluginEvent,
-    });
+    kernel.setPluginServices(
+      await startPluginServices({
+        registry: loaded.pluginRegistry,
+        config: params.nextConfig,
+        workspaceDir: defaultWorkspaceDir,
+        broadcastPluginEvent,
+      }),
+    );
     const afterChannelTargets = listAttachedChannelConfigTargets();
     const afterChannelIds = new Set(afterChannelTargets.keys());
     const restartChannels = new Set<ChannelId>();
@@ -606,6 +608,10 @@ export async function startGatewayCoreRuntime(input: {
 
   return {
     ...runtime,
+    kernel: {
+      ...kernel,
+      reloadPlugins: reloadAttachedGatewayPlugins,
+    },
     earlyRuntime,
     sessionCompanion,
     sessionObserver,
@@ -622,7 +628,6 @@ export async function startGatewayCoreRuntime(input: {
     getAttachedGatewayMethodRegistry: () => attachedGatewayMethodRegistry,
     replaceAttachedPluginRuntime,
     refreshAttachedGatewayDiscovery,
-    reloadAttachedGatewayPlugins,
     loadGatewayModelCatalog,
     loadGatewayModelCatalogSnapshot,
     readPreparedGatewayModelCatalog,

--- a/src/gateway/server-kernel-request-runtime.ts
+++ b/src/gateway/server-kernel-request-runtime.ts
@@ -97,6 +97,7 @@ export async function prepareGatewayKernelRequestRuntime(params: {
     lifecycle,
     startupState,
     clearFallbackGatewayContextForServer,
+    kernel,
   } = runtime;
   const chatMetadataLifecycle = await createGatewayChatMetadataLifecycle({
     getConfig: getRuntimeConfig,
@@ -200,6 +201,8 @@ export async function prepareGatewayKernelRequestRuntime(params: {
       broadcastVoiceWakeChanged,
       unavailableGatewayMethods,
       broadcastVoiceWakeRoutingChanged,
+      notifyPluginMetadataChanged: kernel.notifyPluginMetadataChanged,
+      getConfigReloaderHotReloadStatus: kernel.getConfigReloaderHotReloadStatus,
     });
   });
   bindApprovalPublicationContext(gatewayRequestContext);

--- a/src/gateway/server-lifecycle.ts
+++ b/src/gateway/server-lifecycle.ts
@@ -302,6 +302,38 @@ export async function prepareGatewayLifecycle(params: {
     setConfigReloaderHandle: (configReloader: typeof runtimeState.configReloader) => {
       runtimeState.configReloader = configReloader;
     },
+    getReloadState: () => ({
+      hooksConfig: runtimeState.hooksConfig,
+      hookClientIpConfig: runtimeState.hookClientIpConfig,
+      heartbeatRunner: runtimeState.heartbeatRunner,
+      cronState: runtimeState.cronState,
+      channelHealthMonitor: runtimeState.channelHealthMonitor,
+    }),
+    setReloadHookState: (next: {
+      hooksConfig: typeof runtimeState.hooksConfig;
+      hookClientIpConfig: typeof runtimeState.hookClientIpConfig;
+    }) => {
+      runtimeState.hooksConfig = next.hooksConfig;
+      runtimeState.hookClientIpConfig = next.hookClientIpConfig;
+    },
+    swapHeartbeatRunner: (next: typeof runtimeState.heartbeatRunner) => {
+      const previous = runtimeState.heartbeatRunner;
+      runtimeState.heartbeatRunner = next;
+      return previous;
+    },
+    swapCronState: (next: typeof runtimeState.cronState) => {
+      const previous = runtimeState.cronState;
+      runtimeState.cronState = next;
+      deps.cron = next.cron;
+      return previous;
+    },
+    setChannelHealthMonitor: (next: typeof runtimeState.channelHealthMonitor) => {
+      runtimeState.channelHealthMonitor = next;
+    },
+    notifyPluginMetadataChanged: () => {
+      runtimeState.configReloader.notifyPluginMetadataChanged();
+    },
+    getConfigReloaderHotReloadStatus: () => runtimeState.configReloader.hotReloadStatus?.(),
     setPostReadySidecars: (sidecars: typeof runtimeState.postReadySidecars) => {
       runtimeState.postReadySidecars = sidecars;
     },
@@ -461,7 +493,7 @@ export async function prepareGatewayLifecycle(params: {
       ...optsResult,
       getRuntimeSnapshot,
       getEventLoopHealth: readinessEventLoopHealth.snapshot,
-      getConfigReloaderHotReloadStatus: () => runtimeState?.configReloader.hotReloadStatus?.(),
+      getConfigReloaderHotReloadStatus: kernel.getConfigReloaderHotReloadStatus,
     });
   const stopRegisteredPostReadySidecars = async () => {
     const postReadySidecars = runtimeState.postReadySidecars;

--- a/src/gateway/server-request-context.test.ts
+++ b/src/gateway/server-request-context.test.ts
@@ -24,15 +24,11 @@ function makeContextParams(
   overrides: Partial<GatewayRequestContextParams> = {},
 ): GatewayRequestContextParams {
   const config = {} as never;
-  const runtimeState: Pick<GatewayServerLiveState, "cronState" | "configReloader"> = {
+  const runtimeState: Pick<GatewayServerLiveState, "cronState"> = {
     cronState: {
       cron: { start: vi.fn(), stop: vi.fn() } as never,
       storePath: "/tmp/cron",
       cronEnabled: true,
-    },
-    configReloader: {
-      stop: vi.fn(async () => {}),
-      notifyPluginMetadataChanged: vi.fn(),
     },
   };
   return {
@@ -103,6 +99,8 @@ function makeContextParams(
     channelWizardRunner: vi.fn(async () => undefined),
     broadcastVoiceWakeChanged: vi.fn(),
     broadcastVoiceWakeRoutingChanged: vi.fn(),
+    notifyPluginMetadataChanged: vi.fn(),
+    getConfigReloaderHotReloadStatus: vi.fn(() => undefined),
     unavailableGatewayMethods: new Set(),
     ...overrides,
   };
@@ -161,15 +159,11 @@ describe("createGatewayRequestContext", () => {
   it("reads cron state live from runtime state", () => {
     const cronA = { start: vi.fn(), stop: vi.fn() } as never;
     const cronB = { start: vi.fn(), stop: vi.fn() } as never;
-    const runtimeState: Pick<GatewayServerLiveState, "cronState" | "configReloader"> = {
+    const runtimeState: Pick<GatewayServerLiveState, "cronState"> = {
       cronState: {
         cron: cronA,
         storePath: "/tmp/cron-a",
         cronEnabled: true,
-      },
-      configReloader: {
-        stop: vi.fn(async () => {}),
-        notifyPluginMetadataChanged: vi.fn(),
       },
     };
 
@@ -188,36 +182,28 @@ describe("createGatewayRequestContext", () => {
     expect(context.cronStorePath).toBe("/tmp/cron-b");
   });
 
-  it("reads config hot-reload status live from runtime state", () => {
-    const runtimeState: Pick<GatewayServerLiveState, "cronState" | "configReloader"> = {
-      cronState: {
-        cron: { start: vi.fn(), stop: vi.fn() } as never,
-        storePath: "/tmp/cron",
-        cronEnabled: true,
-      },
-      configReloader: {
-        stop: vi.fn(async () => {}),
-        notifyPluginMetadataChanged: vi.fn(),
-      },
-    };
-
-    const context = createGatewayRequestContext(makeContextParams({ runtimeState }));
+  it("reads config hot-reload status through the live kernel bridge", () => {
+    let status: "active" | "disabled" | undefined;
+    const context = createGatewayRequestContext(
+      makeContextParams({ getConfigReloaderHotReloadStatus: () => status }),
+    );
 
     expect(context.getConfigReloaderHotReloadStatus?.()).toBeUndefined();
 
-    runtimeState.configReloader = {
-      stop: vi.fn(async () => {}),
-      hotReloadStatus: () => "active",
-      notifyPluginMetadataChanged: vi.fn(),
-    };
+    status = "active";
     expect(context.getConfigReloaderHotReloadStatus?.()).toBe("active");
 
-    runtimeState.configReloader = {
-      stop: vi.fn(async () => {}),
-      hotReloadStatus: () => "disabled",
-      notifyPluginMetadataChanged: vi.fn(),
-    };
+    status = "disabled";
     expect(context.getConfigReloaderHotReloadStatus?.()).toBe("disabled");
+  });
+
+  it("routes plugin metadata changes through the kernel bridge", () => {
+    const notifyPluginMetadataChanged = vi.fn();
+    const context = createGatewayRequestContext(makeContextParams({ notifyPluginMetadataChanged }));
+
+    context.notifyPluginMetadataChanged();
+
+    expect(notifyPluginMetadataChanged).toHaveBeenCalledOnce();
   });
 
   it("does not treat scoped CLI or backend callers as approval delivery routes", () => {

--- a/src/gateway/server-request-context.ts
+++ b/src/gateway/server-request-context.ts
@@ -28,7 +28,7 @@ type GatewayRequestContextParams = {
   deps: GatewayRequestContext["deps"];
   runtimeState: Pick<
     GatewayServerLiveState,
-    "cronState" | "configReloader" | "controlUiSessionPullRequests" | "sessionViewerPresence"
+    "cronState" | "controlUiSessionPullRequests" | "sessionViewerPresence"
   >;
   getRuntimeConfig: GatewayRequestContext["getRuntimeConfig"];
   sessionCompanion: SessionCompanionService;
@@ -110,6 +110,8 @@ type GatewayRequestContextParams = {
   channelWizardRunner: GatewayRequestContext["channelWizardRunner"];
   broadcastVoiceWakeChanged: GatewayRequestContext["broadcastVoiceWakeChanged"];
   broadcastVoiceWakeRoutingChanged: GatewayRequestContext["broadcastVoiceWakeRoutingChanged"];
+  notifyPluginMetadataChanged: GatewayRequestContext["notifyPluginMetadataChanged"];
+  getConfigReloaderHotReloadStatus: GatewayRequestContext["getConfigReloaderHotReloadStatus"];
   unavailableGatewayMethods: ReadonlySet<string>;
 };
 
@@ -175,8 +177,7 @@ export function createGatewayRequestContext(
     sessionViewerPresence: params.runtimeState.sessionViewerPresence,
     sessionCompanion: params.sessionCompanion,
     sessionObserver: params.sessionObserver,
-    notifyPluginMetadataChanged: () =>
-      params.runtimeState.configReloader.notifyPluginMetadataChanged(),
+    notifyPluginMetadataChanged: params.notifyPluginMetadataChanged,
     getMcpAppSandboxPort: params.getMcpAppSandboxPort,
     ensureSandboxHostPort: params.ensureSandboxHostPort,
     resolveTerminalLaunchPolicy: params.resolveTerminalLaunchPolicy,
@@ -397,7 +398,7 @@ export function createGatewayRequestContext(
     purgeWizardSession: params.purgeWizardSession,
     getRuntimeSnapshot: params.getRuntimeSnapshot,
     getEventLoopHealth: params.getEventLoopHealth,
-    getConfigReloaderHotReloadStatus: () => params.runtimeState.configReloader.hotReloadStatus?.(),
+    getConfigReloaderHotReloadStatus: params.getConfigReloaderHotReloadStatus,
     startChannel: params.startChannel,
     stopChannel: params.stopChannel,
     markChannelLoggedOut: params.markChannelLoggedOut,

--- a/src/gateway/server-startup-finish.ts
+++ b/src/gateway/server-startup-finish.ts
@@ -124,7 +124,6 @@ export async function finishGatewayStartup(params: {
     activateRuntimeSecrets,
     applyFixedGatewayOverlays,
     resolveSharedGatewaySessionGenerationForConfig,
-    reloadAttachedGatewayPlugins,
     stopRegisteredPostReadySidecars,
     chatMetadataLifecycle,
     gatewayRequestContext,
@@ -404,22 +403,13 @@ export async function finishGatewayStartup(params: {
       }),
     deps,
     broadcast,
-    getState: () => ({
-      hooksConfig: runtimeState.hooksConfig,
-      hookClientIpConfig: runtimeState.hookClientIpConfig,
-      heartbeatRunner: runtimeState.heartbeatRunner,
-      cronState: runtimeState.cronState,
-      channelHealthMonitor: runtimeState.channelHealthMonitor,
-    }),
+    getState: kernel.getReloadState,
     setState: (nextState) => {
-      const cronStateChanged = nextState.cronState !== runtimeState.cronState;
-      runtimeState.hooksConfig = nextState.hooksConfig;
-      runtimeState.hookClientIpConfig = nextState.hookClientIpConfig;
-      runtimeState.heartbeatRunner = nextState.heartbeatRunner;
-      runtimeState.cronState = nextState.cronState;
-      deps.cron = runtimeState.cronState.cron;
-      runtimeState.channelHealthMonitor = nextState.channelHealthMonitor;
-      if (cronStateChanged) {
+      kernel.setReloadHookState(nextState);
+      kernel.swapHeartbeatRunner(nextState.heartbeatRunner);
+      const previousCronState = kernel.swapCronState(nextState.cronState);
+      kernel.setChannelHealthMonitor(nextState.channelHealthMonitor);
+      if (previousCronState !== nextState.cronState) {
         cronStartState.handled = true;
       }
     },
@@ -427,7 +417,7 @@ export async function finishGatewayStartup(params: {
     stopChannel,
     getChannelAutostartSuppression: channelManager.getAutostartSuppression,
     stopPostReadySidecars: stopRegisteredPostReadySidecars,
-    reloadPlugins: reloadAttachedGatewayPlugins,
+    reloadPlugins: kernel.reloadPlugins,
     logHooks,
     logChannels,
     logCron,


### PR DESCRIPTION
## What Problem This Solves

Phase-2 PR 6 removes the config reloader’s reverse dependency on raw Gateway kernel state after the resident registry landed in #121996.

## Why This Change Was Made

The kernel now owns reload snapshots and the named `swapHeartbeatRunner()` and `swapCronState()` operations, including the live `deps.cron` publication. The reloader calls those methods in the same synchronous order as the prior field assignments. Plugin replacement is exposed only as `kernel.reloadPlugins()`, while plugin-service publication also stays behind the kernel setter.

Request-context plugin metadata notifications and hot-reload status no longer reach into `runtimeState.configReloader`. They call kernel bridges that resolve the current `GatewayConfigReloaderHandle`, whose pre-start inert implementation remains unchanged. There are no config, protocol, default, ordering, or user-visible behavior changes.

This is phase-2 PR 6 of the Gateway kernel split. The next and final authorized step is PR 7: final composition plus the kernel import-boundary invariant.

## User Impact

No user-visible change. Config reload, cron/heartbeat swaps, plugin reload, and metadata refresh keep their existing behavior behind an explicit kernel ownership boundary.

## Evidence

- reload handlers, hot-reload status, restart, all startup-config suites, request-context bridge, and socket-free kernel: 8 files, 291 passed
- core and core-test tsgo lanes: passed
- `node scripts/check-changed.mjs -- <touched>`: formatting, dead exports, lint, plugin boundaries, schema/runtime/import-cycle/auth guards passed locally after remote backend fallback
- `pnpm build`: passed
- Codex autoreview: clean, no accepted/actionable findings

The default local multi-project Gateway runner still reproduces the current-main stale state-schema inlining issue recorded on PR 5; the focused proof uses `OPENCLAW_GATEWAY_PROJECT_SHARDS=0` without changing assertions. Exact-head hosted CI remains the heal-check.

ClawSweeper review metrics: production `+61/-30` (net `+31`) for kernel-owned reload state, plugin reload, and resident-handle bridges; tests `+20/-34` (net `-14`). AI-assisted; implementation and evidence were reviewed directly.
