### PR TITLE
fix: avoid repeated agent database checks at gateway startup

### DIFF
--- a/src/config/sessions/startup-migration.ts
+++ b/src/config/sessions/startup-migration.ts
@@ -1,11 +1,7 @@
 import { resolveAgentSessionDirs } from "../../agents/session-dirs.js";
 import { migrateOrphanedSessionKeys } from "../../infra/state-migrations.session-store.js";
 import type { PreparedLegacySessionSurfaces } from "../../plugins/legacy-session-surfaces.types.js";
-import {
-  closeOpenClawAgentDatabaseByPath,
-  isOpenClawAgentDatabaseOpen,
-  openOpenClawAgentDatabase,
-} from "../../state/openclaw-agent-db.js";
+import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { resolveStateDir } from "../paths.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { setCanonicalSqliteSessionMainKey } from "./session-canonical-key.js";
@@ -86,12 +82,8 @@ export async function runSessionStartupMigration(params: {
         agentId: target.agentId,
         env: params.env,
       }).path;
-      const alreadyOpen = isOpenClawAgentDatabaseOpen(path);
       const database = openOpenClawAgentDatabase({ agentId: target.agentId, path });
       setCanonicalSqliteSessionMainKey(database, params.cfg.session?.mainKey);
-      if (!alreadyOpen) {
-        closeOpenClawAgentDatabaseByPath(path);
-      }
       removedFiles += await sweepTemps({ storePath: target.storePath });
     }
     if (removedFiles > 0) {

--- a/src/config/sessions/startup-migration.ts
+++ b/src/config/sessions/startup-migration.ts
@@ -3,11 +3,7 @@ import { resolveAgentSessionDirs } from "../../agents/session-dirs.js";
 import { migrateOrphanedSessionKeys } from "../../infra/state-migrations.session-store.js";
 import type { PreparedLegacySessionSurfaces } from "../../plugins/legacy-session-surfaces.types.js";
 import { listOpenClawRegisteredAgentDatabases } from "../../state/openclaw-agent-db-registry.js";
-import {
-  closeOpenClawAgentDatabaseByPath,
-  isOpenClawAgentDatabaseOpen,
-  openOpenClawAgentDatabase,
-} from "../../state/openclaw-agent-db.js";
+import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { resolveStateDir } from "../paths.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { migrateLegacyMainSessionKeys } from "./legacy-main-session-migration.js";
@@ -152,7 +148,6 @@ export async function runSessionStartupMigration(params: {
         removedFiles += await sweepTemps({ storePath: target.storePath });
         continue;
       }
-      const alreadyOpen = isOpenClawAgentDatabaseOpen(path);
       const isRegistered = registeredDatabases.has(`${target.agentId}\0${path}`);
       if (
         !isRegistered ||
@@ -178,9 +173,6 @@ export async function runSessionStartupMigration(params: {
         params.log.warn(
           `session: managed-worktree workspace migration failed for ${target.agentId}; continuing: ${String(error)}`,
         );
-      }
-      if (!alreadyOpen && isOpenClawAgentDatabaseOpen(path)) {
-        closeOpenClawAgentDatabaseByPath(path);
       }
       removedFiles += await sweepTemps({ storePath: target.storePath });
     }

--- a/src/gateway/server-startup-session-migration.test-support.ts
+++ b/src/gateway/server-startup-session-migration.test-support.ts
@@ -3,7 +3,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import { EMPTY_LEGACY_SESSION_SURFACES } from "../plugins/legacy-session-surfaces.types.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  isOpenClawAgentDatabaseOpen,
+} from "../state/openclaw-agent-db.js";
 import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
 import { runStartupSessionMigration } from "./server-startup-session-migration.js";
 
@@ -130,6 +135,35 @@ describe("runStartupSessionMigration", () => {
 
     expect(migrate).toHaveBeenCalledOnce();
     expect(deps.runDoctorSessionSqlite).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the startup-opened agent database warm for transcript reconciliation", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-startup-warm-"));
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const storePath = path.join(stateDir, "agents", "main", "sessions.json");
+    const databasePath = resolveSqliteTargetFromSessionStorePath(storePath, {
+      agentId: "main",
+      env,
+    }).path;
+    const migrate = vi.fn<MigrateSessionKeys>().mockResolvedValue({ changes: [], warnings: [] });
+    // Startup must hand the already-open handle to reconciliation. Closing it here forced a second
+    // open plus a second integrity check of the same file on every gateway start.
+    const reconcile = vi.fn<ReconcileSessionTranscriptIndexes>().mockImplementation(async () => {
+      expect(isOpenClawAgentDatabaseOpen(databasePath)).toBe(true);
+      return { reconciledSessions: 0 };
+    });
+    const deps = makeDeps(migrate, 0, makeSessionSqliteImport(), reconcile);
+    deps.resolveAllAgentSessionStoreTargetsSync.mockReturnValue([{ agentId: "main", storePath }]);
+    deps.sessionSqliteDatabaseExists.mockReturnValue(true);
+
+    try {
+      await runStartupSessionMigration({ cfg: makeCfg(), env, log: makeLog(), deps });
+    } finally {
+      closeOpenClawAgentDatabasesForTest();
+      fs.rmSync(stateDir, { force: true, recursive: true });
+    }
+
+    expect(reconcile).toHaveBeenCalledOnce();
   });
 
   it("logs changes when orphaned keys are canonicalized", async () => {

--- a/src/gateway/server-startup-session-migration.test-support.ts
+++ b/src/gateway/server-startup-session-migration.test-support.ts
@@ -2,8 +2,13 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import { EMPTY_LEGACY_SESSION_SURFACES } from "../plugins/legacy-session-surfaces.types.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  isOpenClawAgentDatabaseOpen,
+} from "../state/openclaw-agent-db.js";
 import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
 import { runStartupSessionMigration } from "./server-startup-session-migration.js";
 
@@ -97,6 +102,8 @@ function makeSessionSqliteImport(
   });
 }
 
+afterEach(() => closeOpenClawAgentDatabasesForTest());
+
 describe("runStartupSessionMigration", () => {
   it("skips legacy migration imports when no session stores exist", async () => {
     const log = makeLog();
@@ -128,6 +135,32 @@ describe("runStartupSessionMigration", () => {
 
     expect(migrate).toHaveBeenCalledOnce();
     expect(deps.runDoctorSessionSqlite).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the startup-opened agent database warm for transcript reconciliation", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-startup-warm-"));
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const storePath = path.join(stateDir, "agents", "main", "sessions.json");
+    const databasePath = resolveSqliteTargetFromSessionStorePath(storePath, {
+      agentId: "main",
+      env,
+    }).path;
+    const migrate = vi.fn<MigrateSessionKeys>().mockResolvedValue({ changes: [], warnings: [] });
+    const reconcile = vi.fn<ReconcileSessionTranscriptIndexes>().mockImplementation(async () => {
+      expect(isOpenClawAgentDatabaseOpen(databasePath)).toBe(true);
+      return { reconciledSessions: 0 };
+    });
+    const deps = makeDeps(migrate, 0, makeSessionSqliteImport(), reconcile);
+    deps.resolveAllAgentSessionStoreTargetsSync.mockReturnValue([{ agentId: "main", storePath }]);
+
+    try {
+      await runStartupSessionMigration({ cfg: makeCfg(), env, log: makeLog(), deps });
+    } finally {
+      closeOpenClawAgentDatabasesForTest();
+      fs.rmSync(stateDir, { force: true, recursive: true });
+    }
+
+    expect(reconcile).toHaveBeenCalledOnce();
   });
 
   it("logs changes when orphaned keys are canonicalized", async () => {


### PR DESCRIPTION
Closes #121985

## What Problem This Solves

Fixes an issue where operators starting the Gateway with an existing SQLite agent database would pay for a full physical database open and integrity check twice during startup. The duplicate work is especially visible on large agent databases.

## Why This Change Was Made

The session startup migration now leaves its agent database handle in the existing bounded cache so transcript reconciliation can reuse it. The per-physical-open integrity policy is unchanged, and a lifecycle regression test verifies that the handle remains warm across the migration-to-reconciliation boundary.

## User Impact

Gateway startup avoids one redundant database open and integrity check per affected agent within the existing cache capacity. Database validation and repair behavior are otherwise unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-startup-session-migration.test-support.ts` — 28 tests passed.
- `node scripts/check-changed.mjs --dry-run -- src/config/sessions/startup-migration.ts src/gateway/server-startup-session-migration.test-support.ts` — classified as focused core production + core test changes.
- `node_modules/oxfmt/bin/oxfmt --check src/config/sessions/startup-migration.ts src/gateway/server-startup-session-migration.test-support.ts` — both files formatted.
- `git diff --check origin/main...fix/gateway-agent-db-double-open` — clean.
- Live diagnosis on an approximately 765 MiB agent database measured a full integrity check at about 1.0 second, making the redundant physical open directly observable.

AI-assisted: yes. I reviewed and understand the lifecycle change and its test coverage.


### Real behavior proof (added 2026-08-17)

After-fix gateway startup runtime trace demonstrating removal of the second physical open, on a real dataset: a 1.5 GiB `agents/main/agent/openclaw-agent.sqlite` plus its real `agents/main/sessions` store (operator state copies), isolated `OPENCLAW_STATE_DIR`, dist-backed `node dist/index.js gateway`, cold process, run to `[gateway] ready`. Physical opens were observed two independent ways: the product's own `[state/agent-db] slow OpenClaw agent database open` warning (fires per physical open slower than 1s; this database's integrity check takes ~2s) and `strace -f -e trace=openat` filtered to the exact database path.

**Before — current `main` without this fix (baseline `c98ae0f99cb`, the fix's rebase parent):**

```text
[state/agent-db] slow OpenClaw agent database open   (17:54:26)
[state/agent-db] slow OpenClaw agent database open   (17:54:37)
```

```text
openat(... "agents/main/agent/openclaw-agent.sqlite", O_RDONLY|...)          # owner probe
openat(... "agents/main/agent/openclaw-agent.sqlite", O_RDONLY|...)          # integrity read
openat(... "agents/main/agent/openclaw-agent.sqlite", O_RDONLY|...)          # integrity read
openat(... "agents/main/agent/openclaw-agent.sqlite", O_RDWR|O_CREAT|...)    # t+6.0s  migration open
openat(... "agents/main/agent/openclaw-agent.sqlite", O_RDWR|O_CREAT|...)    # t+16.1s reopen for reconciliation
```

**After — exact PR head `b79d9047e68`:**

```text
[state/agent-db] slow OpenClaw agent database open   (17:56:01)   # exactly one
```

```text
openat(... "agents/main/agent/openclaw-agent.sqlite", O_RDONLY|...)
openat(... "agents/main/agent/openclaw-agent.sqlite", O_RDONLY|...)
openat(... "agents/main/agent/openclaw-agent.sqlite", O_RDONLY|...)
openat(... "agents/main/agent/openclaw-agent.sqlite", O_RDWR|O_CREAT|...)    # single physical open, kept warm through reconciliation
```

The three read-only probe/verification opens are identical across both runs; the delta is exactly the redundant close→reopen pair between canonical-key migration and transcript reconciliation described in #121985 (which also predicted the two slow-open warnings — reproduced verbatim in the baseline run).
