### PR TITLE
fix(state): keep agent media floor stable across schema upgrades

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"f17fda486bebaafacc259619d94b63f6b19420ef47a9740c7b35b954c9ee018e","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}
+{"contentHash":"1e0832034f59d87a31bc1cfe56b8e3fc5795349705dd6d8df424f4c6f5891f55","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
@@ -1,1 +1,1 @@
-{"contentHash":"c017cdb95283e766f3455b2e5a1c828a7227db87ec82e5f346d94682292cbbf7","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
+{"contentHash":"da4d17548d4c7f6fb0d72386f0b297788e3b855bd638b7baf4b49fd412309d34","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-core.json
@@ -1,1 +1,1 @@
-{"contentHash":"f04ae840aa03ecffd6a5c617a206aeb468ab7e2663f146dee15e82a859ab94ea","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}
+{"contentHash":"2385e4f8fbdadfc5c418f0a5b5a860c2e179fa933b5ae52ac71ff98d7fdd7738","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
@@ -1,1 +1,1 @@
-{"contentHash":"da5462c33495c854121e954fe007c8bca17e3fd625f8fed130954705c62e1818","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}
+{"contentHash":"df5224962c4fddbdb17b2c3c21e2e7e51adccd2c25c923727e29819c35d439c5","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-inbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-inbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"71e2548711edb5372870a7afcef25547aae3d2484578c88610749e90ebe5f244","entrypoint":"channel-inbound","importSpecifier":"openclaw/plugin-sdk/channel-inbound"}
+{"contentHash":"ed4993ad2b9c3254b982b27a82f7948ecb79f4ffe03cd3c4b82b87d9a633e048","entrypoint":"channel-inbound","importSpecifier":"openclaw/plugin-sdk/channel-inbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-message.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-message.json
@@ -1,1 +1,1 @@
-{"contentHash":"20a70ea7ba78d5c618d82338e5901b73389313867458f67dbd95b3f6f91f4cbc","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}
+{"contentHash":"a578f67dfee05299597ab22937cab1244b0f454712f94fc45f99b7e486e09622","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"736070b02d2196ce75af349e9e71edcf464c8d43a01bdfd70c1b61abfac3e85f","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}
+{"contentHash":"883725e631aa012269fd6ce76d2603d02ba2880df58d917d29819376bb7e3d5d","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
@@ -1,1 +1,1 @@
-{"contentHash":"1770f99bd46d2ce7525fcd10cf143163efd1a01ef8a0a5cf22b097200477c762","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}
+{"contentHash":"bfac3008ae512011dfbe560b61c014281bcf6474fa54fa9e0207a7a1b3a20ca9","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}

--- a/docs/.generated/plugin-sdk-api-baseline/core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/core.json
@@ -1,1 +1,1 @@
-{"contentHash":"511e572af05c931e92680e1a154c5705a3ef54b822db8990605403d9d5697e3f","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}
+{"contentHash":"ca0ca33ba6a08bae28f0725a13c2d2faa3f2e5ed15068414384c6a095181b40f","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}

--- a/docs/.generated/plugin-sdk-api-baseline/discord.json
+++ b/docs/.generated/plugin-sdk-api-baseline/discord.json
@@ -1,1 +1,1 @@
-{"contentHash":"9ea9ae4e9fd1c35de0578f6c68722dd9c037430c8b5bb526d0f6266fdf7edb2c","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}
+{"contentHash":"62ec387aa5d7125a1838363ed63c3b0a1e33f032cb34cacdfc514da8b0bbe06b","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}

--- a/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
+++ b/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
@@ -1,1 +1,1 @@
-{"contentHash":"bf1a5368e13eb0bdef48b175dfa26222272499e31e0bd13bc87dcef79708a869","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}
+{"contentHash":"cd6d7648c7e1c73baaa6268d8484d4f1fdaf7bddf912be0f49b1d89ed4ae832b","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}

--- a/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"f62643baa25a9c3102e2173269ea301024a844e32dbfb7c39d122eca47a562dc","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}
+{"contentHash":"ad7a2e4350d2fadc32e3a95f8238d099eb493b586adda3abf9daaa051c59cdd3","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
@@ -1,1 +1,1 @@
-{"contentHash":"ecf8ac0427d503d3c2f5c174cee58d8aa47192e66bdda123f34546d02e5146b2","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}
+{"contentHash":"2d9c3ff8b49717c977ab4d888c5175036ffb7fedc3ee5855ec8d10cabf845c6c","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"9ee8b93b462bd6869a15ad42fa97aab32bd0a5e012b61f2e75355b898f85dc5b","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}
+{"contentHash":"0a8bd76ef85383941ab9fade76ebd2a0f7e5d3cb81864dd4a1fcca9fc75093b6","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"9bcfbbe5a2ddf62272fd953b0687d4e6d34cb80aa5de23e485c468182b79d8e4","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
+{"contentHash":"a1d0d3986f77637628e270449a6192a7eb8a80c629a95dbb941527ed571dc37f","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
+++ b/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
@@ -1,1 +1,1 @@
-{"contentHash":"5bb57a7c8f5f158c973540af418c5ea7df019622ad890e9f8741737e550c4109","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}
+{"contentHash":"dccb9fe000ad7744f3a4c0d88275b67f9a52f3674972af4c8ab3a014d4f927fc","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}

--- a/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
+++ b/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
@@ -1,1 +1,1 @@
-{"contentHash":"8f23b9a7a62f9587e1a7da7adfcc9c2b17f59c3f86e8c8da342797172d16f504","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}
+{"contentHash":"51d690a7c4b4a7a26b61ae6c257ee8f5603733061f2832df4eded0c0625790ac","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}

--- a/src/infra/state-migrations.media-persistence-targets.test.ts
+++ b/src/infra/state-migrations.media-persistence-targets.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   closeOpenClawAgentDatabasesForTest,
   listOpenClawRegisteredAgentDatabases,
+  OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION,
   OPENCLAW_AGENT_SCHEMA_VERSION,
   openOpenClawAgentDatabase,
 } from "../state/openclaw-agent-db.js";
@@ -22,7 +23,7 @@ import { requireNodeSqlite } from "./node-sqlite.js";
 import { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
 
 const tempDirs: string[] = [];
-const PREVIOUS_VERSION = OPENCLAW_AGENT_SCHEMA_VERSION - 1;
+const PREVIOUS_VERSION = OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION - 1;
 
 function createLegacyAgentDatabase(params: {
   agentId?: string;

--- a/src/infra/state-migrations.media-persistence.test.ts
+++ b/src/infra/state-migrations.media-persistence.test.ts
@@ -13,6 +13,7 @@ import { registerOpenClawAgentDatabase } from "../state/openclaw-agent-db-regist
 import {
   closeOpenClawAgentDatabasesForTest,
   listOpenClawRegisteredAgentDatabases,
+  OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION,
   OPENCLAW_AGENT_SCHEMA_VERSION,
   openOpenClawAgentDatabase,
   runOpenClawAgentWriteTransaction,
@@ -22,7 +23,7 @@ import { requireNodeSqlite } from "./node-sqlite.js";
 import { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
 
 const tempDirs: string[] = [];
-const PREVIOUS_VERSION = OPENCLAW_AGENT_SCHEMA_VERSION - 1;
+const PREVIOUS_VERSION = OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION - 1;
 
 type FixtureEvent = Record<string, unknown>;
 
@@ -447,6 +448,86 @@ describe("legacy media persistence doctor migration", () => {
     expect(openOpenClawAgentDatabase({ agentId: "main", env }).db.isOpen).toBe(true);
     closeOpenClawAgentDatabasesForTest();
     expect(migrateLegacyMediaPersistence({ env })).toEqual({ changes: [], warnings: [] });
+  });
+
+  it("runs the v16 media cutover before converging Doctor state through v17", () => {
+    expect(OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION).toBe(16);
+    expect(OPENCLAW_AGENT_SCHEMA_VERSION).toBe(17);
+    const stateDir = makeTempDir(tempDirs, "media-persistence-version-fences-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = createLegacyDatabaseFixture({
+      env,
+      eventsBySession: {
+        legacy: [
+          createEvent({
+            id: "event-1",
+            parentId: null,
+            timestamp: 1000,
+            message: { role: "user", content: "legacy", MediaPath: "/media/a.png" },
+          }),
+        ],
+      },
+    });
+    const { DatabaseSync } = requireNodeSqlite();
+    const legacy = new DatabaseSync(databasePath);
+    legacy.exec(`
+      CREATE TABLE state_leases (
+        scope TEXT NOT NULL,
+        lease_key TEXT NOT NULL,
+        owner TEXT NOT NULL,
+        expires_at INTEGER,
+        heartbeat_at INTEGER,
+        payload_json TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        PRIMARY KEY (scope, lease_key)
+      ) STRICT;
+      CREATE INDEX idx_agent_state_leases_expiry
+        ON state_leases(expires_at, scope, lease_key)
+        WHERE expires_at IS NOT NULL;
+      CREATE INDEX idx_agent_state_leases_owner
+        ON state_leases(owner, updated_at DESC);
+      INSERT INTO state_leases (
+        scope, lease_key, owner, expires_at, heartbeat_at, payload_json, created_at, updated_at
+      ) VALUES ('retired', 'orphan', 'nobody', NULL, NULL, NULL, 1, 1);
+    `);
+    legacy.close();
+
+    let versionBeforeMediaTransaction: number | undefined;
+    const migration = migrateLegacyMediaPersistence({
+      env,
+      hooks: {
+        beforeDatabaseTransaction: (pathname) => {
+          const beforeMedia = new DatabaseSync(pathname, { readOnly: true });
+          versionBeforeMediaTransaction = (
+            beforeMedia.prepare("PRAGMA user_version").get() as { user_version: number }
+          ).user_version;
+          beforeMedia.close();
+        },
+      },
+    });
+    expect(migration.warnings).toEqual([]);
+    expect(versionBeforeMediaTransaction).toBe(
+      OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION - 1,
+    );
+    const afterDoctor = new DatabaseSync(databasePath, { readOnly: true });
+    expect(afterDoctor.prepare("PRAGMA user_version").get()).toEqual({
+      user_version: OPENCLAW_AGENT_SCHEMA_VERSION,
+    });
+    expect(
+      afterDoctor
+        .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'state_leases'")
+        .get(),
+    ).toBeUndefined();
+    const migratedRow = afterDoctor
+      .prepare("SELECT event_json FROM transcript_events WHERE session_id = ? AND seq = 0")
+      .get("legacy") as { event_json: string };
+    expect(
+      (JSON.parse(migratedRow.event_json) as { message: Record<string, unknown> }).message,
+    ).toMatchObject({
+      __openclaw: { media: [expect.objectContaining({ path: "/media/a.png" })] },
+    });
+    afterDoctor.close();
   });
 
   it("upgrades the existing v14 structural schema before the media cutover", () => {

--- a/src/infra/state-migrations.media-persistence.test.ts
+++ b/src/infra/state-migrations.media-persistence.test.ts
@@ -366,9 +366,22 @@ describe("legacy media persistence doctor migration", () => {
     writeArchive(compressedArchive, [conflict], true);
 
     const before = readDatabaseSnapshot(databasePath);
-    const result = migrateLegacyMediaPersistence({ env });
+    let versionBeforeMediaTransaction: number | undefined;
+    const result = migrateLegacyMediaPersistence({
+      env,
+      hooks: {
+        beforeDatabaseTransaction: (pathname) => {
+          const database = new DatabaseSync(pathname, { readOnly: true });
+          versionBeforeMediaTransaction = (
+            database.prepare("PRAGMA user_version").get() as { user_version: number }
+          ).user_version;
+          database.close();
+        },
+      },
+    });
     expect(result.warnings).toEqual([]);
     expect(result.changes).toHaveLength(3);
+    expect(versionBeforeMediaTransaction).toBe(OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION - 1);
 
     const after = readDatabaseSnapshot(databasePath);
     expect(after.version.user_version).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
@@ -448,86 +461,6 @@ describe("legacy media persistence doctor migration", () => {
     expect(openOpenClawAgentDatabase({ agentId: "main", env }).db.isOpen).toBe(true);
     closeOpenClawAgentDatabasesForTest();
     expect(migrateLegacyMediaPersistence({ env })).toEqual({ changes: [], warnings: [] });
-  });
-
-  it("runs the v16 media cutover before converging Doctor state through v17", () => {
-    expect(OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION).toBe(16);
-    expect(OPENCLAW_AGENT_SCHEMA_VERSION).toBe(17);
-    const stateDir = makeTempDir(tempDirs, "media-persistence-version-fences-");
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    const databasePath = createLegacyDatabaseFixture({
-      env,
-      eventsBySession: {
-        legacy: [
-          createEvent({
-            id: "event-1",
-            parentId: null,
-            timestamp: 1000,
-            message: { role: "user", content: "legacy", MediaPath: "/media/a.png" },
-          }),
-        ],
-      },
-    });
-    const { DatabaseSync } = requireNodeSqlite();
-    const legacy = new DatabaseSync(databasePath);
-    legacy.exec(`
-      CREATE TABLE state_leases (
-        scope TEXT NOT NULL,
-        lease_key TEXT NOT NULL,
-        owner TEXT NOT NULL,
-        expires_at INTEGER,
-        heartbeat_at INTEGER,
-        payload_json TEXT,
-        created_at INTEGER NOT NULL,
-        updated_at INTEGER NOT NULL,
-        PRIMARY KEY (scope, lease_key)
-      ) STRICT;
-      CREATE INDEX idx_agent_state_leases_expiry
-        ON state_leases(expires_at, scope, lease_key)
-        WHERE expires_at IS NOT NULL;
-      CREATE INDEX idx_agent_state_leases_owner
-        ON state_leases(owner, updated_at DESC);
-      INSERT INTO state_leases (
-        scope, lease_key, owner, expires_at, heartbeat_at, payload_json, created_at, updated_at
-      ) VALUES ('retired', 'orphan', 'nobody', NULL, NULL, NULL, 1, 1);
-    `);
-    legacy.close();
-
-    let versionBeforeMediaTransaction: number | undefined;
-    const migration = migrateLegacyMediaPersistence({
-      env,
-      hooks: {
-        beforeDatabaseTransaction: (pathname) => {
-          const beforeMedia = new DatabaseSync(pathname, { readOnly: true });
-          versionBeforeMediaTransaction = (
-            beforeMedia.prepare("PRAGMA user_version").get() as { user_version: number }
-          ).user_version;
-          beforeMedia.close();
-        },
-      },
-    });
-    expect(migration.warnings).toEqual([]);
-    expect(versionBeforeMediaTransaction).toBe(
-      OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION - 1,
-    );
-    const afterDoctor = new DatabaseSync(databasePath, { readOnly: true });
-    expect(afterDoctor.prepare("PRAGMA user_version").get()).toEqual({
-      user_version: OPENCLAW_AGENT_SCHEMA_VERSION,
-    });
-    expect(
-      afterDoctor
-        .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'state_leases'")
-        .get(),
-    ).toBeUndefined();
-    const migratedRow = afterDoctor
-      .prepare("SELECT event_json FROM transcript_events WHERE session_id = ? AND seq = 0")
-      .get("legacy") as { event_json: string };
-    expect(
-      (JSON.parse(migratedRow.event_json) as { message: Record<string, unknown> }).message,
-    ).toMatchObject({
-      __openclaw: { media: [expect.objectContaining({ path: "/media/a.png" })] },
-    });
-    afterDoctor.close();
   });
 
   it("upgrades the existing v14 structural schema before the media cutover", () => {

--- a/src/infra/state-migrations.media-persistence.test.ts
+++ b/src/infra/state-migrations.media-persistence.test.ts
@@ -199,6 +199,34 @@ afterEach(() => {
 });
 
 describe("legacy media persistence doctor migration", () => {
+  it("refreshes a registry-owned v16 database after structural convergence", () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-registry-v16-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const opened = openOpenClawAgentDatabase({ agentId: "main", env });
+    const databasePath = opened.path;
+    closeOpenClawAgentDatabasesForTest();
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(databasePath);
+    database.exec(`PRAGMA user_version = ${OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION};`);
+    database
+      .prepare("UPDATE schema_meta SET schema_version = ? WHERE meta_key = 'primary'")
+      .run(OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION);
+    database.close();
+    registerOpenClawAgentDatabase({
+      agentId: "main",
+      env,
+      path: databasePath,
+      schemaVersion: OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION,
+    });
+
+    expect(migrateLegacyMediaPersistence({ env }).warnings).toEqual([]);
+    expect(listOpenClawRegisteredAgentDatabases({ env })).toEqual([
+      expect.objectContaining({
+        schemaVersion: OPENCLAW_AGENT_SCHEMA_VERSION,
+      }),
+    ]);
+  });
+
   it("canonicalizes assistant media at the generic transcript append owner", () => {
     const stateDir = makeTempDir(tempDirs, "media-persistence-append-");
     const env = { OPENCLAW_STATE_DIR: stateDir };

--- a/src/infra/state-migrations.media-persistence.ts
+++ b/src/infra/state-migrations.media-persistence.ts
@@ -26,6 +26,7 @@ import {
 } from "../state/openclaw-agent-db-schema.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
 import {
+  OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION,
   OPENCLAW_AGENT_SCHEMA_VERSION,
   type OpenClawAgentDatabase,
 } from "../state/openclaw-agent-db.js";
@@ -46,7 +47,7 @@ import { readSqliteUserVersion } from "./sqlite-user-version.js";
 import { resolveAgentDatabaseMediaMigrationTargets } from "./state-migrations.media-persistence-targets.js";
 import type { MigrationMessages } from "./state-migrations.types.js";
 
-const PREVIOUS_MEDIA_SCHEMA_VERSION = OPENCLAW_AGENT_SCHEMA_VERSION - 1;
+const PREVIOUS_MEDIA_SCHEMA_VERSION = OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION - 1;
 const ARCHIVE_TEMP_MARKER = ".media-retirement";
 
 type MediaMigrationDatabase = Pick<
@@ -304,11 +305,32 @@ function createMigrationDatabaseHandle(
   };
 }
 
+function convergeCurrentAgentSchema(params: {
+  agentId: string;
+  database: DatabaseSync;
+  pathname: string;
+}): number {
+  if (readSqliteUserVersion(params.database) < OPENCLAW_AGENT_SCHEMA_VERSION) {
+    // Media rows must cross their durable v16 fence before unrelated structural
+    // migrations run, so a failed second phase remains safely resumable by Doctor.
+    ensureOpenClawAgentDatabaseSchema(params.database, {
+      agentId: params.agentId,
+      path: params.pathname,
+    });
+  }
+  return readSqliteUserVersion(params.database);
+}
+
 function migrateAgentDatabase(params: {
   agentId: string;
   beforeTransaction?: () => void;
   pathname: string;
-}): { rewrittenSessions: number; rewrittenTrajectoryRows: number; versionAdvanced: boolean } {
+}): {
+  rewrittenSessions: number;
+  rewrittenTrajectoryRows: number;
+  schemaVersion: number;
+  versionAdvanced: boolean;
+} {
   const database = openNodeSqliteDatabase(params.pathname);
   try {
     database.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
@@ -329,11 +351,11 @@ function migrateAgentDatabase(params: {
       userVersion = readSqliteUserVersion(database);
     }
     if (
-      userVersion !== PREVIOUS_MEDIA_SCHEMA_VERSION &&
-      userVersion !== OPENCLAW_AGENT_SCHEMA_VERSION
+      userVersion < PREVIOUS_MEDIA_SCHEMA_VERSION ||
+      userVersion > OPENCLAW_AGENT_SCHEMA_VERSION
     ) {
       throw new Error(
-        `${params.pathname} uses schema version ${userVersion}; expected ${PREVIOUS_MEDIA_SCHEMA_VERSION} or ${OPENCLAW_AGENT_SCHEMA_VERSION}`,
+        `${params.pathname} uses schema version ${userVersion}; expected ${PREVIOUS_MEDIA_SCHEMA_VERSION} through ${OPENCLAW_AGENT_SCHEMA_VERSION}`,
       );
     }
     if (metadata.schemaVersion !== userVersion) {
@@ -380,7 +402,16 @@ function migrateAgentDatabase(params: {
     const changedSessions = planned.filter((session) => session.changed);
     const versionAdvanced = userVersion === PREVIOUS_MEDIA_SCHEMA_VERSION;
     if (!versionAdvanced && changedSessions.length === 0 && changedTrajectoryRows.length === 0) {
-      return { rewrittenSessions: 0, rewrittenTrajectoryRows: 0, versionAdvanced: false };
+      return {
+        rewrittenSessions: 0,
+        rewrittenTrajectoryRows: 0,
+        schemaVersion: convergeCurrentAgentSchema({
+          agentId: params.agentId,
+          database,
+          pathname: params.pathname,
+        }),
+        versionAdvanced: false,
+      };
     }
 
     params.beforeTransaction?.();
@@ -420,14 +451,16 @@ function migrateAgentDatabase(params: {
           );
         }
         if (versionAdvanced) {
-          database.exec(`PRAGMA user_version = ${OPENCLAW_AGENT_SCHEMA_VERSION};`);
+          database.exec(
+            `PRAGMA user_version = ${OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION};`,
+          );
           executeSqliteQuerySync(
             database,
             db
               .updateTable("schema_meta")
               .set({
                 app_version: VERSION,
-                schema_version: OPENCLAW_AGENT_SCHEMA_VERSION,
+                schema_version: OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION,
                 updated_at: Date.now(),
               })
               .where("meta_key", "=", "primary"),
@@ -440,9 +473,15 @@ function migrateAgentDatabase(params: {
         operationLabel: "media-persistence-retirement",
       },
     );
+    const schemaVersion = convergeCurrentAgentSchema({
+      agentId: params.agentId,
+      database,
+      pathname: params.pathname,
+    });
     return {
       rewrittenSessions: changedSessions.length,
       rewrittenTrajectoryRows: changedTrajectoryRows.length,
+      schemaVersion,
       versionAdvanced,
     };
   } finally {
@@ -631,7 +670,12 @@ export function migrateLegacyMediaPersistence(
         pathname,
       });
       if (entry.source !== "registry" || result.versionAdvanced) {
-        registerOpenClawAgentDatabase({ agentId: entry.agentId, env, path: pathname });
+        registerOpenClawAgentDatabase({
+          agentId: entry.agentId,
+          env,
+          path: pathname,
+          schemaVersion: result.schemaVersion,
+        });
       }
       if (
         result.versionAdvanced ||
@@ -639,7 +683,7 @@ export function migrateLegacyMediaPersistence(
         result.rewrittenTrajectoryRows > 0
       ) {
         changes.push(
-          `Migrated media persistence in ${pathname}: ${result.rewrittenSessions} transcript session(s), ${result.rewrittenTrajectoryRows} trajectory row(s), schema v${OPENCLAW_AGENT_SCHEMA_VERSION}.`,
+          `Migrated media persistence in ${pathname}: ${result.rewrittenSessions} transcript session(s), ${result.rewrittenTrajectoryRows} trajectory row(s), media floor v${OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION}.`,
         );
       }
     } catch (error) {

--- a/src/infra/state-migrations.media-persistence.ts
+++ b/src/infra/state-migrations.media-persistence.ts
@@ -402,14 +402,15 @@ function migrateAgentDatabase(params: {
     const changedSessions = planned.filter((session) => session.changed);
     const versionAdvanced = userVersion === PREVIOUS_MEDIA_SCHEMA_VERSION;
     if (!versionAdvanced && changedSessions.length === 0 && changedTrajectoryRows.length === 0) {
+      const schemaVersion = convergeCurrentAgentSchema({
+        agentId: params.agentId,
+        database,
+        pathname: params.pathname,
+      });
       return {
         rewrittenSessions: 0,
         rewrittenTrajectoryRows: 0,
-        schemaVersion: convergeCurrentAgentSchema({
-          agentId: params.agentId,
-          database,
-          pathname: params.pathname,
-        }),
+        schemaVersion,
         versionAdvanced: false,
       };
     }
@@ -669,14 +670,12 @@ export function migrateLegacyMediaPersistence(
           : undefined,
         pathname,
       });
-      if (entry.source !== "registry" || result.versionAdvanced) {
-        registerOpenClawAgentDatabase({
-          agentId: entry.agentId,
-          env,
-          path: pathname,
-          schemaVersion: result.schemaVersion,
-        });
-      }
+      registerOpenClawAgentDatabase({
+        agentId: entry.agentId,
+        env,
+        path: pathname,
+        schemaVersion: result.schemaVersion,
+      });
       if (
         result.versionAdvanced ||
         result.rewrittenSessions > 0 ||

--- a/src/state/openclaw-agent-db-contract.ts
+++ b/src/state/openclaw-agent-db-contract.ts
@@ -20,6 +20,9 @@ import type { OpenClawStateDatabaseOptions } from "./openclaw-state-db.js";
 // change is folded in structure-gated migrations, so v2 main DBs and
 // pre-merge v4 flip DBs both converge on this schema.
 export const OPENCLAW_AGENT_SCHEMA_VERSION = 17;
+// The Doctor-owned v15-to-v16 media rewrite is a durable data fence, not the
+// predecessor of whichever structural schema version happens to be current.
+export const OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION = 16;
 
 /** Open per-agent SQLite database handle plus lifecycle maintenance. */
 export type OpenClawAgentDatabase = {

--- a/src/state/openclaw-agent-db-schema-helpers.ts
+++ b/src/state/openclaw-agent-db-schema-helpers.ts
@@ -22,7 +22,10 @@ import {
   ensureOpenClawAgentBoardSchemaInTransaction,
 } from "./openclaw-agent-board-schema.js";
 import { CONTEXT_ENGINE_TURN_OUTBOX_TABLE } from "./openclaw-agent-context-engine-turn-outbox-schema.js";
-import { OPENCLAW_AGENT_SCHEMA_VERSION } from "./openclaw-agent-db-contract.js";
+import {
+  OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION,
+  OPENCLAW_AGENT_SCHEMA_VERSION,
+} from "./openclaw-agent-db-contract.js";
 import { OpenClawAgentDatabaseMediaMigrationRequiredError } from "./openclaw-agent-db-migration-required.js";
 import { ensureSessionEntryValidityProjection } from "./openclaw-agent-db-session-migrations.js";
 import { OPENCLAW_AGENT_SCHEMA_SQL } from "./openclaw-agent-schema.js";
@@ -214,7 +217,7 @@ export function assertCanonicalAgentMediaPersistenceVersion(
     .get();
   const isNewUnownedDatabase =
     userVersion === 0 && readExistingAgentSchemaMeta(db) === null && !hasApplicationSchema;
-  if (userVersion < OPENCLAW_AGENT_SCHEMA_VERSION && !isNewUnownedDatabase) {
+  if (userVersion < OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION && !isNewUnownedDatabase) {
     throw new OpenClawAgentDatabaseMediaMigrationRequiredError(pathname, userVersion);
   }
 }

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -24,6 +24,7 @@ import { normalizeAgentId } from "../routing/session-key.js";
 import { VERSION } from "../version.js";
 import { ensureOpenClawAgentBoardSchemaInTransaction } from "./openclaw-agent-board-schema.js";
 import {
+  OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION,
   OPENCLAW_AGENT_SCHEMA_VERSION,
   type OpenClawAgentDatabaseOptions,
 } from "./openclaw-agent-db-contract.js";
@@ -747,7 +748,7 @@ export function migrateOpenClawAgentDatabaseToMediaPrerequisiteSchema(
   db: DatabaseSync,
   options: OpenClawAgentDatabaseOptions,
 ): void {
-  const targetVersion = OPENCLAW_AGENT_SCHEMA_VERSION - 1;
+  const targetVersion = OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION - 1;
   const userVersion = readSqliteUserVersion(db);
   if (userVersion > targetVersion) {
     return;

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -45,6 +45,7 @@ import {
   inspectOpenClawAgentDatabaseOwner,
   listOpenClawRegisteredAgentDatabases,
   migrateOpenClawAgentDatabaseForMaintenance,
+  OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION,
   OPENCLAW_AGENT_SCHEMA_VERSION,
   openOpenClawAgentDatabase as openOpenClawAgentDatabaseRuntime,
   resolveOpenClawAgentSqlitePath,
@@ -1624,7 +1625,7 @@ describe("openclaw agent database", () => {
     `);
     legacy.close();
 
-    const migrated = migrateAndOpenLegacyAgentDatabaseForTest({ agentId: "worker-1", env });
+    const migrated = openOpenClawAgentDatabase({ agentId: "worker-1", env });
     expect(readSqliteNumberPragma(migrated.db, "user_version")).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
     expect(
       migrated.db
@@ -4201,7 +4202,7 @@ describe("openclaw agent database", () => {
     );
   });
 
-  it.each([0, OPENCLAW_AGENT_SCHEMA_VERSION - 1])(
+  it.each([0, OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION - 1])(
     "rechecks the media version guard at v%d after a validated handle is physically reopened",
     (version) => {
       const stateDir = createTempStateDir();

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -63,6 +63,7 @@ import {
 } from "./openclaw-state-db.js";
 
 export {
+  OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION,
   OPENCLAW_AGENT_SCHEMA_VERSION,
   type OpenClawAgentDatabase,
   type OpenClawAgentDatabaseOptions,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Gateway with an already-migrated v16 agent database could park during an upgrade to schema v17 and incorrectly require `openclaw doctor --fix`. The media guard treated every version below the current structural schema as pre-media state, so it blocked the online v16-to-v17 lease-table retirement before that migration could run.

## Why This Change Was Made

The completed media rewrite is now represented by its own durable schema floor: v16, with v15 as the Doctor-owned predecessor. Normal runtime opens accept v16 and converge it through the canonical v17 structural migration. Doctor first crosses the real v15-to-v16 media fence, then independently converges the database to the current structural schema and records the actual final registry version.

True pre-media databases remain fail-closed behind Doctor. No SQLite schema version is added or changed by this repair.

## User Impact

Operators upgrading from an already-migrated v16 agent database to v17 no longer see the Gateway park for an offline migration that has already completed. Legacy v15 media state still requires and receives the existing Doctor rewrite.

## Evidence

- Direct runtime regression: normal open accepts v16, migrates to v17, and removes the retired `state_leases` table.
- Doctor regression: v15 media data rewrites to the fixed v16 floor, then converges to v17 with the retired lease table removed.
- Blacksmith Testbox: 121 tests passed, 6 skipped across agent DB, media migration, and target discovery ([run](https://github.com/openclaw/openclaw/actions/runs/31485329716)).
- Autoreview and changelog review: clean, no accepted/actionable findings.
- `git diff --check`: clean.

Provenance: the latent current-version coupling was made visible when #121943 advanced the structural schema from v16 to v17.
