### PR TITLE
fix(update): avoid duplicate configured plugin installs

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -2501,7 +2501,7 @@ describe("update-cli", () => {
   });
 
   it("post-core resume mode skips the core update and only runs post-update tasks", async () => {
-    await runPostCoreCommand({ restart: false });
+    await runPostCoreCommand({ restart: false }, { OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1" });
 
     expect(runGatewayUpdate).not.toHaveBeenCalled();
     const installCall = (
@@ -2524,6 +2524,21 @@ describe("update-cli", () => {
         ([, args]) => args[0] === FRESH_POST_UPDATE_ENTRYPOINT && args[1] === "doctor",
       );
     expect(freshDoctorCall).toBeDefined();
+    expect(freshDoctorCall?.[2]).toMatchObject({
+      env: {
+        OPENCLAW_UPDATE_IN_PROGRESS: "1",
+        OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR: "1",
+        OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: "1",
+      },
+    });
+    expect(
+      (freshDoctorCall?.[2] as { env?: NodeJS.ProcessEnv } | undefined)?.env
+        ?.OPENCLAW_UPDATE_POST_CORE_CONVERGENCE,
+    ).toBeUndefined();
+    expect(
+      (freshDoctorCall?.[2] as { baseEnv?: NodeJS.ProcessEnv } | undefined)?.baseEnv
+        ?.OPENCLAW_UPDATE_POST_CORE_CONVERGENCE,
+    ).toBeUndefined();
     expect(vi.mocked(runExec).mock.invocationCallOrder[0] ?? 0).toBeLessThan(
       syncPluginsForUpdateChannel.mock.invocationCallOrder[0] ?? 0,
     );
@@ -7247,13 +7262,13 @@ describe("update-cli", () => {
     });
   });
 
-  it("updateFinalizeCommand runs doctor and plugin convergence with full update env", async () => {
+  it("updateFinalizeCommand defers plugin installation during pre-plugin doctor", async () => {
     await withEnvAsync(
       {
         OPENCLAW_UPDATE_IN_PROGRESS: undefined,
         OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR: undefined,
         OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: undefined,
-        OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: undefined,
+        OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1",
       },
       async () => {
         let doctorEnv: NodeJS.ProcessEnv | undefined;
@@ -7273,11 +7288,11 @@ describe("update-cli", () => {
         expect(doctorEnv?.OPENCLAW_UPDATE_IN_PROGRESS).toBe("1");
         expect(doctorEnv?.OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR).toBe("1");
         expect(doctorEnv?.OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE).toBe("1");
-        expect(doctorEnv?.OPENCLAW_UPDATE_POST_CORE_CONVERGENCE).toBe("1");
+        expect(doctorEnv?.OPENCLAW_UPDATE_POST_CORE_CONVERGENCE).toBeUndefined();
         expect(process.env.OPENCLAW_UPDATE_IN_PROGRESS).toBeUndefined();
         expect(process.env.OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR).toBeUndefined();
         expect(process.env.OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE).toBeUndefined();
-        expect(process.env.OPENCLAW_UPDATE_POST_CORE_CONVERGENCE).toBeUndefined();
+        expect(process.env.OPENCLAW_UPDATE_POST_CORE_CONVERGENCE).toBe("1");
         expect(doctorCommand).toHaveBeenCalledWith(defaultRuntime, {
           nonInteractive: true,
           repair: true,

--- a/src/cli/update-cli/update-command-fresh-doctor.ts
+++ b/src/cli/update-cli/update-command-fresh-doctor.ts
@@ -20,41 +20,36 @@ import {
   stripGatewayServiceMarkerEnv,
 } from "./update-command-service.js";
 
-export function withUpdateFinalizationEnv<T>(run: () => Promise<T>): Promise<T> {
-  const previousUpdateInProgress = process.env.OPENCLAW_UPDATE_IN_PROGRESS;
-  const previousDeferConfiguredPluginInstallRepair =
-    process.env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV];
-  const previousParentSupportsDoctorConfigWrite =
-    process.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV];
-  const previousPostCoreConvergence = process.env[UPDATE_POST_CORE_CONVERGENCE_ENV];
-  process.env.OPENCLAW_UPDATE_IN_PROGRESS = "1";
-  process.env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV] = "1";
-  process.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV] = "1";
-  process.env[UPDATE_POST_CORE_CONVERGENCE_ENV] = "1";
-  return run().finally(() => {
-    if (previousUpdateInProgress === undefined) {
-      delete process.env.OPENCLAW_UPDATE_IN_PROGRESS;
+type UpdateDoctorPhase = "pre-plugin" | "post-plugin";
+
+export async function withPrePluginUpdateDoctorEnv<T>(run: () => Promise<T>): Promise<T> {
+  const phaseEnv: NodeJS.ProcessEnv = {
+    OPENCLAW_UPDATE_IN_PROGRESS: "1",
+    [UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV]: "1",
+    [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
+    [UPDATE_POST_CORE_CONVERGENCE_ENV]: undefined,
+  };
+  const previousEnv = Object.fromEntries(
+    Object.keys(phaseEnv).map((key) => [key, process.env[key]]),
+  );
+  for (const [key, value] of Object.entries(phaseEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
     } else {
-      process.env.OPENCLAW_UPDATE_IN_PROGRESS = previousUpdateInProgress;
+      process.env[key] = value;
     }
-    if (previousDeferConfiguredPluginInstallRepair === undefined) {
-      delete process.env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV];
-    } else {
-      process.env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV] =
-        previousDeferConfiguredPluginInstallRepair;
+  }
+  try {
+    return await run();
+  } finally {
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
     }
-    if (previousParentSupportsDoctorConfigWrite === undefined) {
-      delete process.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV];
-    } else {
-      process.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV] =
-        previousParentSupportsDoctorConfigWrite;
-    }
-    if (previousPostCoreConvergence === undefined) {
-      delete process.env[UPDATE_POST_CORE_CONVERGENCE_ENV];
-    } else {
-      process.env[UPDATE_POST_CORE_CONVERGENCE_ENV] = previousPostCoreConvergence;
-    }
-  });
+  }
 }
 
 async function withNormalConfigValidation<T>(run: () => Promise<T>): Promise<T> {
@@ -91,6 +86,7 @@ function createPostPluginDoctorExecutionFailure(
 }
 
 export async function runUpdateFinalizationDoctorInFreshProcess(params: {
+  phase: UpdateDoctorPhase;
   root: string;
   yes: boolean;
   json: boolean;
@@ -110,17 +106,19 @@ export async function runUpdateFinalizationDoctorInFreshProcess(params: {
     "--no-workspace-suggestions",
     ...(params.yes ? ["--yes"] : []),
   ];
+  const baseEnv = stripGatewayServiceMarkerEnv(disableUpdatedPackageCompileCacheEnv(process.env));
+  delete baseEnv[UPDATE_POST_CORE_CONVERGENCE_ENV];
   const result = await runExec(params.nodeRunner ?? resolveNodeRunner(), args, {
     cwd: params.root,
     timeoutMs: params.timeoutMs,
     maxBuffer: 4 * 1024 * 1024,
     logOutput: false,
-    baseEnv: stripGatewayServiceMarkerEnv(disableUpdatedPackageCompileCacheEnv(process.env)),
+    baseEnv,
     env: {
       OPENCLAW_UPDATE_IN_PROGRESS: "1",
       [UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV]: "1",
       [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
-      [UPDATE_POST_CORE_CONVERGENCE_ENV]: "1",
+      ...(params.phase === "post-plugin" ? { [UPDATE_POST_CORE_CONVERGENCE_ENV]: "1" } : {}),
     },
   });
   if (!params.json) {
@@ -186,7 +184,11 @@ async function applyFreshPostPluginDoctor(params: {
   }
   let pluginUpdate = params.pluginUpdate;
   try {
-    await runUpdateFinalizationDoctorInFreshProcess({ ...params, entryPath });
+    await runUpdateFinalizationDoctorInFreshProcess({
+      ...params,
+      entryPath,
+      phase: "post-plugin",
+    });
   } catch (err) {
     pluginUpdate = createPostPluginDoctorExecutionFailure(params.pluginUpdate, String(err));
   }

--- a/src/cli/update-cli/update-command-fresh-doctor.ts
+++ b/src/cli/update-cli/update-command-fresh-doctor.ts
@@ -23,31 +23,41 @@ import {
 type UpdateDoctorPhase = "pre-plugin" | "post-plugin";
 
 export async function withPrePluginUpdateDoctorEnv<T>(run: () => Promise<T>): Promise<T> {
-  const phaseEnv: NodeJS.ProcessEnv = {
-    OPENCLAW_UPDATE_IN_PROGRESS: "1",
-    [UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV]: "1",
-    [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
-    [UPDATE_POST_CORE_CONVERGENCE_ENV]: undefined,
-  };
-  const previousEnv = Object.fromEntries(
-    Object.keys(phaseEnv).map((key) => [key, process.env[key]]),
-  );
-  for (const [key, value] of Object.entries(phaseEnv)) {
-    if (value === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = value;
-    }
-  }
+  const previousUpdateInProgress = process.env.OPENCLAW_UPDATE_IN_PROGRESS;
+  const previousDeferConfiguredPluginInstallRepair =
+    process.env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV];
+  const previousParentSupportsDoctorConfigWrite =
+    process.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV];
+  const previousPostCoreConvergence = process.env[UPDATE_POST_CORE_CONVERGENCE_ENV];
+
+  process.env.OPENCLAW_UPDATE_IN_PROGRESS = "1";
+  process.env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV] = "1";
+  process.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV] = "1";
+  delete process.env[UPDATE_POST_CORE_CONVERGENCE_ENV];
   try {
     return await run();
   } finally {
-    for (const [key, value] of Object.entries(previousEnv)) {
-      if (value === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = value;
-      }
+    if (previousUpdateInProgress === undefined) {
+      delete process.env.OPENCLAW_UPDATE_IN_PROGRESS;
+    } else {
+      process.env.OPENCLAW_UPDATE_IN_PROGRESS = previousUpdateInProgress;
+    }
+    if (previousDeferConfiguredPluginInstallRepair === undefined) {
+      delete process.env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV];
+    } else {
+      process.env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV] =
+        previousDeferConfiguredPluginInstallRepair;
+    }
+    if (previousParentSupportsDoctorConfigWrite === undefined) {
+      delete process.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV];
+    } else {
+      process.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV] =
+        previousParentSupportsDoctorConfigWrite;
+    }
+    if (previousPostCoreConvergence === undefined) {
+      delete process.env[UPDATE_POST_CORE_CONVERGENCE_ENV];
+    } else {
+      process.env[UPDATE_POST_CORE_CONVERGENCE_ENV] = previousPostCoreConvergence;
     }
   }
 }

--- a/src/cli/update-cli/update-command-post-core.ts
+++ b/src/cli/update-cli/update-command-post-core.ts
@@ -76,7 +76,7 @@ import {
 } from "./update-command-config.js";
 import {
   completePostCorePluginUpdate,
-  withUpdateFinalizationEnv,
+  withPrePluginUpdateDoctorEnv,
 } from "./update-command-fresh-doctor.js";
 import {
   updatePluginsAfterCoreUpdate,
@@ -207,7 +207,7 @@ export async function updateFinalizeCommand(opts: UpdateFinalizeOptions): Promis
   }
 
   const completedPluginUpdate = await withPluginLifecycleLease({}, async () => {
-    const initialPluginUpdate = await withUpdateFinalizationEnv(async () => {
+    const initialPluginUpdate = await withPrePluginUpdateDoctorEnv(async () => {
       await createUpdateConfigSnapshot();
       await doctorCommand(defaultRuntime, {
         nonInteractive: true,

--- a/src/cli/update-cli/update-command-resume.ts
+++ b/src/cli/update-cli/update-command-resume.ts
@@ -77,6 +77,7 @@ async function resumePostCoreUpdateUnlocked(params: ResumePostCoreUpdateParams):
   });
   await createUpdateConfigSnapshot();
   await runUpdateFinalizationDoctorInFreshProcess({
+    phase: "pre-plugin",
     root: params.root,
     yes: params.opts.yes === true,
     json: params.opts.json === true,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release-package upgrade lanes could run two identical ClawHub install transactions for `@openclaw/whatsapp` during one update. The strict package fixture requires exactly one configured-plugin installation transaction, so four lanes failed:

- [published-upgrade-survivor](https://github.com/openclaw/openclaw/actions/runs/31482499280/job/93752262555)
- [upgrade-survivor](https://github.com/openclaw/openclaw/actions/runs/31482499280/job/93752262558)
- [root-managed-vps-upgrade](https://github.com/openclaw/openclaw/actions/runs/31482499280/job/93752262561)
- [update-restart-auth](https://github.com/openclaw/openclaw/actions/runs/31482499280/job/93752262562)

The failed [Full Release Validation parent](https://github.com/openclaw/openclaw/actions/runs/31481515189) dispatched the failed [Release Checks child](https://github.com/openclaw/openclaw/actions/runs/31482499280).

## Why This Change Was Made

Both finalization paths marked the pre-plugin doctor as post-core convergence. Doctor therefore installed the missing configured plugin before the updater's plugin sweep immediately installed or updated it again.

This separates pre-plugin doctor deferral from post-plugin convergence: the updater remains the configured-plugin installation owner, and only the final post-plugin doctor receives the convergence marker needed for updated-plugin migrations. Ambient convergence state is also removed from the fresh child environment and restored after in-process execution.

## User Impact

Package upgrades now perform one configured-plugin installation transaction per update while retaining the final migration pass after plugins are updated.

## Evidence

- Pre-fix `src/cli/update-cli.test.ts`: 234 passed / 2 intended failures; both failures observed convergence `"1"` where the pre-plugin phase required `undefined`.
- Post-fix focused proof: update CLI 236/236; update-command 49/49; update-phase 7/7; missing-configured-plugin repair 86/86.
- Base-pinned changed-surface checks passed on Testbox `tbx_01kzr8b06zn7c9ekrgmk2d0ae2`, including core and core-test tsgo, oxlint with zero warnings/errors, dead exports, format, import cycles, architecture guards, and `git diff --check`. The lease was stopped after success.
- Fresh autoreview and candidate secret scan: clean.
- Production LOC: +40/-37 (net +3). Tests: +20/-5 (net +15).
