### PR TITLE
fix: keep schema 16 agent databases online during upgrade

### DIFF
--- a/src/infra/state-migrations.media-persistence-targets.test.ts
+++ b/src/infra/state-migrations.media-persistence-targets.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   closeOpenClawAgentDatabasesForTest,
   listOpenClawRegisteredAgentDatabases,
+  OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION,
   OPENCLAW_AGENT_SCHEMA_VERSION,
   openOpenClawAgentDatabase,
 } from "../state/openclaw-agent-db.js";
@@ -22,7 +23,7 @@ import { requireNodeSqlite } from "./node-sqlite.js";
 import { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
 
 const tempDirs: string[] = [];
-const PREVIOUS_VERSION = OPENCLAW_AGENT_SCHEMA_VERSION - 1;
+const PREVIOUS_VERSION = OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION - 1;
 
 function createLegacyAgentDatabase(params: {
   agentId?: string;

--- a/src/infra/state-migrations.media-persistence.test.ts
+++ b/src/infra/state-migrations.media-persistence.test.ts
@@ -13,6 +13,7 @@ import { registerOpenClawAgentDatabase } from "../state/openclaw-agent-db-regist
 import {
   closeOpenClawAgentDatabasesForTest,
   listOpenClawRegisteredAgentDatabases,
+  OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION,
   OPENCLAW_AGENT_SCHEMA_VERSION,
   openOpenClawAgentDatabase,
   runOpenClawAgentWriteTransaction,
@@ -22,7 +23,7 @@ import { requireNodeSqlite } from "./node-sqlite.js";
 import { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
 
 const tempDirs: string[] = [];
-const PREVIOUS_VERSION = OPENCLAW_AGENT_SCHEMA_VERSION - 1;
+const PREVIOUS_VERSION = OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION - 1;
 
 type FixtureEvent = Record<string, unknown>;
 

--- a/src/infra/state-migrations.media-persistence.ts
+++ b/src/infra/state-migrations.media-persistence.ts
@@ -26,6 +26,7 @@ import {
 } from "../state/openclaw-agent-db-schema.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
 import {
+  OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION,
   OPENCLAW_AGENT_SCHEMA_VERSION,
   type OpenClawAgentDatabase,
 } from "../state/openclaw-agent-db.js";
@@ -46,7 +47,7 @@ import { readSqliteUserVersion } from "./sqlite-user-version.js";
 import { resolveAgentDatabaseMediaMigrationTargets } from "./state-migrations.media-persistence-targets.js";
 import type { MigrationMessages } from "./state-migrations.types.js";
 
-const PREVIOUS_MEDIA_SCHEMA_VERSION = OPENCLAW_AGENT_SCHEMA_VERSION - 1;
+const PREVIOUS_MEDIA_SCHEMA_VERSION = OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION - 1;
 const ARCHIVE_TEMP_MARKER = ".media-retirement";
 
 type MediaMigrationDatabase = Pick<
@@ -330,10 +331,11 @@ function migrateAgentDatabase(params: {
     }
     if (
       userVersion !== PREVIOUS_MEDIA_SCHEMA_VERSION &&
+      userVersion !== OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION &&
       userVersion !== OPENCLAW_AGENT_SCHEMA_VERSION
     ) {
       throw new Error(
-        `${params.pathname} uses schema version ${userVersion}; expected ${PREVIOUS_MEDIA_SCHEMA_VERSION} or ${OPENCLAW_AGENT_SCHEMA_VERSION}`,
+        `${params.pathname} uses schema version ${userVersion}; expected ${PREVIOUS_MEDIA_SCHEMA_VERSION}, ${OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION}, or ${OPENCLAW_AGENT_SCHEMA_VERSION}`,
       );
     }
     if (metadata.schemaVersion !== userVersion) {
@@ -341,13 +343,18 @@ function migrateAgentDatabase(params: {
         `${params.pathname} metadata schema version ${metadata.schemaVersion ?? "invalid"} does not match ${userVersion}`,
       );
     }
-    if (userVersion === OPENCLAW_AGENT_SCHEMA_VERSION) {
+    if (userVersion >= OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION) {
       // Doctor can encounter a current-version database before newly additive schema exists.
       // Converge it through the canonical agent-schema owner before media validation.
       ensureOpenClawAgentDatabaseSchema(database, {
         agentId: params.agentId,
         path: params.pathname,
       });
+      metadata = assertOpenClawAgentDatabaseOwner(database, {
+        agentId: params.agentId,
+        pathname: params.pathname,
+      });
+      userVersion = readSqliteUserVersion(database);
     }
     // Remove after 2026-10-12: drop the v15-to-v16 media cutover once schema 16 is the support floor.
     if (userVersion === PREVIOUS_MEDIA_SCHEMA_VERSION) {
@@ -420,14 +427,16 @@ function migrateAgentDatabase(params: {
           );
         }
         if (versionAdvanced) {
-          database.exec(`PRAGMA user_version = ${OPENCLAW_AGENT_SCHEMA_VERSION};`);
+          database.exec(
+            `PRAGMA user_version = ${OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION};`,
+          );
           executeSqliteQuerySync(
             database,
             db
               .updateTable("schema_meta")
               .set({
                 app_version: VERSION,
-                schema_version: OPENCLAW_AGENT_SCHEMA_VERSION,
+                schema_version: OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION,
                 updated_at: Date.now(),
               })
               .where("meta_key", "=", "primary"),
@@ -440,6 +449,12 @@ function migrateAgentDatabase(params: {
         operationLabel: "media-persistence-retirement",
       },
     );
+    if (versionAdvanced) {
+      ensureOpenClawAgentDatabaseSchema(database, {
+        agentId: params.agentId,
+        path: params.pathname,
+      });
+    }
     return {
       rewrittenSessions: changedSessions.length,
       rewrittenTrajectoryRows: changedTrajectoryRows.length,

--- a/src/state/openclaw-agent-db-contract.ts
+++ b/src/state/openclaw-agent-db-contract.ts
@@ -20,6 +20,8 @@ import type { OpenClawStateDatabaseOptions } from "./openclaw-state-db.js";
 // change is folded in structure-gated migrations, so v2 main DBs and
 // pre-merge v4 flip DBs both converge on this schema.
 export const OPENCLAW_AGENT_SCHEMA_VERSION = 17;
+/** Oldest schema whose persisted transcript media is canonical for steady-state reads. */
+export const OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION = 16;
 
 /** Open per-agent SQLite database handle plus lifecycle maintenance. */
 export type OpenClawAgentDatabase = {

--- a/src/state/openclaw-agent-db-schema-helpers.ts
+++ b/src/state/openclaw-agent-db-schema-helpers.ts
@@ -22,7 +22,10 @@ import {
   ensureOpenClawAgentBoardSchemaInTransaction,
 } from "./openclaw-agent-board-schema.js";
 import { CONTEXT_ENGINE_TURN_OUTBOX_TABLE } from "./openclaw-agent-context-engine-turn-outbox-schema.js";
-import { OPENCLAW_AGENT_SCHEMA_VERSION } from "./openclaw-agent-db-contract.js";
+import {
+  OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION,
+  OPENCLAW_AGENT_SCHEMA_VERSION,
+} from "./openclaw-agent-db-contract.js";
 import { OpenClawAgentDatabaseMediaMigrationRequiredError } from "./openclaw-agent-db-migration-required.js";
 import { ensureSessionEntryValidityProjection } from "./openclaw-agent-db-session-migrations.js";
 import { OPENCLAW_AGENT_SCHEMA_SQL } from "./openclaw-agent-schema.js";
@@ -203,7 +206,7 @@ export function assertCanonicalAgentMediaPersistenceVersion(
     .get();
   const isNewUnownedDatabase =
     userVersion === 0 && readExistingAgentSchemaMeta(db) === null && !hasApplicationSchema;
-  if (userVersion < OPENCLAW_AGENT_SCHEMA_VERSION && !isNewUnownedDatabase) {
+  if (userVersion < OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION && !isNewUnownedDatabase) {
     throw new OpenClawAgentDatabaseMediaMigrationRequiredError(pathname, userVersion);
   }
 }

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -23,6 +23,7 @@ import { normalizeAgentId } from "../routing/session-key.js";
 import { VERSION } from "../version.js";
 import { ensureOpenClawAgentBoardSchemaInTransaction } from "./openclaw-agent-board-schema.js";
 import {
+  OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION,
   OPENCLAW_AGENT_SCHEMA_VERSION,
   type OpenClawAgentDatabaseOptions,
 } from "./openclaw-agent-db-contract.js";
@@ -726,7 +727,7 @@ export function migrateOpenClawAgentDatabaseToMediaPrerequisiteSchema(
   db: DatabaseSync,
   options: OpenClawAgentDatabaseOptions,
 ): void {
-  const targetVersion = OPENCLAW_AGENT_SCHEMA_VERSION - 1;
+  const targetVersion = OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION - 1;
   const userVersion = readSqliteUserVersion(db);
   if (userVersion > targetVersion) {
     return;

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -45,6 +45,7 @@ import {
   inspectOpenClawAgentDatabaseOwner,
   listOpenClawRegisteredAgentDatabases,
   migrateOpenClawAgentDatabaseForMaintenance,
+  OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION,
   OPENCLAW_AGENT_SCHEMA_VERSION,
   openOpenClawAgentDatabase as openOpenClawAgentDatabaseRuntime,
   resolveOpenClawAgentSqlitePath,
@@ -1624,7 +1625,7 @@ describe("openclaw agent database", () => {
     `);
     legacy.close();
 
-    const migrated = migrateAndOpenLegacyAgentDatabaseForTest({ agentId: "worker-1", env });
+    const migrated = openOpenClawAgentDatabase({ agentId: "worker-1", env });
     expect(readSqliteNumberPragma(migrated.db, "user_version")).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
     expect(
       migrated.db
@@ -4201,7 +4202,7 @@ describe("openclaw agent database", () => {
     );
   });
 
-  it.each([0, OPENCLAW_AGENT_SCHEMA_VERSION - 1])(
+  it.each([0, OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION - 1])(
     "rechecks the media version guard at v%d after a validated handle is physically reopened",
     (version) => {
       const stateDir = createTempStateDir();

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -63,6 +63,7 @@ import {
 } from "./openclaw-state-db.js";
 
 export {
+  OPENCLAW_AGENT_MEDIA_PERSISTENCE_SCHEMA_VERSION,
   OPENCLAW_AGENT_SCHEMA_VERSION,
   type OpenClawAgentDatabase,
   type OpenClawAgentDatabaseOptions,


### PR DESCRIPTION
## What Problem This Solves

Fixes a Gateway startup failure where a media-canonical agent database at schema v16 was misclassified as requiring an offline Doctor migration after schema v17 retired per-agent `state_leases`.

## Why This Change Was Made

Media persistence completion is now a fixed v16 data floor, independent of the moving structural schema version. Runtime opens can migrate v16 to v17 online. Doctor still commits legacy media rewrites at v16 first, then separately converges structure to v17, preserving crash safety and lease retirement.

## User Impact

Gateways with healthy v16 agent databases upgrade normally instead of parking their service. Genuine v15-and-older media states remain fail-closed with Doctor guidance.

## Evidence

- Blacksmith Testbox `tbx_01kzr9qyhmw30z6ksq14yzsn1d`: https://github.com/openclaw/openclaw/actions/runs/31487371137
- Direct v16 runtime-open and v15 media-guard regressions: 3 passed.
- Media migration/target suites: 21 passed.
- Formatting passed on all eight changed files.
- Final Codex autoreview clean; no actionable findings (0.96 confidence).

AI-assisted: yes. ClawSweeper is waived for this production incident repair.
