### PR TITLE
fix(ci): restore complete Kova performance evidence

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -394,19 +394,13 @@ jobs:
         run: |
           set -euo pipefail
           npm_wrapper="$PERFORMANCE_HELPER_DIR/scripts/ocm-npm-workspace-deps.mts"
-          npm_adapter="${RUNNER_TEMP}/openclaw-ocm-npm"
           workspace_dependency_dirs=""
           if [[ -f "${GITHUB_WORKSPACE}/packages/ai/package.json" ]]; then
             workspace_dependency_dirs="${GITHUB_WORKSPACE}/packages/ai"
           fi
-          cat > "$npm_adapter" <<'EOF'
-          #!/usr/bin/env bash
-          exec node --import tsx "$OPENCLAW_OCM_NPM_WRAPPER" "$@"
-          EOF
-          chmod 0755 "$npm_adapter"
+          chmod 0755 "$npm_wrapper"
           {
-            echo "OCM_INTERNAL_NPM_BIN=$npm_adapter"
-            echo "OPENCLAW_OCM_NPM_WRAPPER=$npm_wrapper"
+            echo "OCM_INTERNAL_NPM_BIN=$npm_wrapper"
             echo "OPENCLAW_OCM_REAL_NPM_BIN=$(command -v npm)"
             echo "OPENCLAW_OCM_WORKSPACE_DEPENDENCY_DIRS=$workspace_dependency_dirs"
           } >> "$GITHUB_ENV"

--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -396,7 +396,11 @@ jobs:
           npm_wrapper="$PERFORMANCE_HELPER_DIR/scripts/ocm-npm-workspace-deps.mts"
           workspace_dependency_dirs=""
           if [[ -f "${GITHUB_WORKSPACE}/packages/ai/package.json" ]]; then
-            workspace_dependency_dirs="${GITHUB_WORKSPACE}/packages/ai"
+            workspace_dependency_dirs="$(
+              pnpm --dir "$GITHUB_WORKSPACE" --filter '@openclaw/ai...' --fail-if-no-match \
+                list --depth -1 --json |
+                node -e 'const fs = require("node:fs"); const path = require("node:path"); const projects = JSON.parse(fs.readFileSync(0, "utf8")); process.stdout.write(projects.map((project) => project.path).join(path.delimiter));'
+            )"
           fi
           chmod 0755 "$npm_wrapper"
           {

--- a/scripts/ocm-npm-workspace-deps.mts
+++ b/scripts/ocm-npm-workspace-deps.mts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --import tsx
+#!/usr/bin/env node
 
 import { spawnSync, type SpawnSyncOptions } from "node:child_process";
 import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";

--- a/test/scripts/ocm-npm-workspace-deps.test.ts
+++ b/test/scripts/ocm-npm-workspace-deps.test.ts
@@ -323,32 +323,31 @@ describe("OCM npm workspace dependency adapter", () => {
       writeFileSync(join(transitiveWorkspaceDir, "index.js"), "export const normalized = true;\n");
       execFileSync("tar", ["-czf", rootArchive, "-C", archiveRoot, "package"]);
 
-      execFileSync(
-        process.execPath,
-        [
-          adapterPath,
-          "install",
-          "--prefix",
-          installDir,
-          "--omit=dev",
-          "--no-save",
-          "--package-lock=false",
-          rootArchive,
-        ],
-        {
-          env: {
-            ...process.env,
-            OPENCLAW_OCM_REAL_NPM_BIN: process.platform === "win32" ? "npm.cmd" : "npm",
-            OPENCLAW_OCM_WORKSPACE_DEPENDENCY_DIRS: [workspaceDir, transitiveWorkspaceDir].join(
-              delimiter,
-            ),
-            npm_config_audit: "false",
-            npm_config_cache: join(root, "npm-cache"),
-            npm_config_fund: "false",
-          },
-          stdio: "pipe",
+      const command = process.platform === "win32" ? process.execPath : adapterPath;
+      const args = [
+        ...(process.platform === "win32" ? [adapterPath] : []),
+        "install",
+        "--prefix",
+        installDir,
+        "--omit=dev",
+        "--no-save",
+        "--package-lock=false",
+        rootArchive,
+      ];
+      execFileSync(command, args, {
+        cwd: root,
+        env: {
+          ...process.env,
+          OPENCLAW_OCM_REAL_NPM_BIN: process.platform === "win32" ? "npm.cmd" : "npm",
+          OPENCLAW_OCM_WORKSPACE_DEPENDENCY_DIRS: [workspaceDir, transitiveWorkspaceDir].join(
+            delimiter,
+          ),
+          npm_config_audit: "false",
+          npm_config_cache: join(root, "npm-cache"),
+          npm_config_fund: "false",
         },
-      );
+        stdio: "pipe",
+      });
 
       expect(
         JSON.parse(readFileSync(join(installDir, "node_modules/openclaw/package.json"), "utf8"))

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -1084,8 +1084,11 @@ esac
     expect(configure.run).toContain(
       'npm_wrapper="$PERFORMANCE_HELPER_DIR/scripts/ocm-npm-workspace-deps.mts"',
     );
-    expect(configure.run).toContain("OCM_INTERNAL_NPM_BIN=$npm_adapter");
-    expect(configure.run).toContain("OPENCLAW_OCM_NPM_WRAPPER=$npm_wrapper");
+    expect(configure.run).toContain("OCM_INTERNAL_NPM_BIN=$npm_wrapper");
+    expect(configure.run).toContain('chmod 0755 "$npm_wrapper"');
+    expect(configure.run).not.toContain("npm_adapter=");
+    expect(configure.run).not.toContain("OPENCLAW_OCM_NPM_WRAPPER");
+    expect(configure.run).not.toContain("node --import tsx");
     expect(configure.run).toContain(
       'if [[ -f "${GITHUB_WORKSPACE}/packages/ai/package.json" ]]; then',
     );

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -1093,6 +1093,11 @@ esac
       'if [[ -f "${GITHUB_WORKSPACE}/packages/ai/package.json" ]]; then',
     );
     expect(configure.run).toContain(
+      "pnpm --dir \"$GITHUB_WORKSPACE\" --filter '@openclaw/ai...' --fail-if-no-match",
+    );
+    expect(configure.run).toContain("list --depth -1 --json");
+    expect(configure.run).toContain("projects.map((project) => project.path)");
+    expect(configure.run).toContain(
       "OPENCLAW_OCM_WORKSPACE_DEPENDENCY_DIRS=$workspace_dependency_dirs",
     );
   });


### PR DESCRIPTION
## What

Restore complete Kova performance evidence by giving OCM a directly executable npm adapter and the full `@openclaw/ai` workspace dependency closure. Node runs the adapter's erasable TypeScript natively, while pnpm supplies the current transitive workspace graph used to build the local runtime.

## Why

Full Release Validation run 31871527419 dispatched Product Performance run 31871544450. Job 94980872829 planned five scenario/state pairs with three repeats, but every record was `BLOCKED` before measurement. OpenClaw's workflow forced the adapter through `tsx`, which failed to parse it under Node 24.19.0. After removing that launcher, exact-head run 31893158252 exposed a second setup defect: the workflow configured only `packages/ai`, although its manifest now depends on `@openclaw/model-catalog-core` and `@openclaw/normalization-core`.

OpenClaw owns both failing inputs. OCM v0.2.29 executes `OCM_INTERNAL_NPM_BIN` as supplied, and pinned Kova correctly maps runtime-provisioning failures to `BLOCKED`. The repair keeps those fail-closed semantics and leaves incomplete-evidence and regression gates unchanged.

Provenance: `c70aee247e83` migrated the adapter to TypeScript and added the forced-`tsx` launcher. `c3887db7c17` later added the model-catalog workspace dependency that made the workflow's one-directory plan incomplete.

## Changes

- Execute the `.mts` adapter with native Node
- Pass the adapter path directly to OCM
- Resolve the complete AI workspace graph
- Exercise direct execution from another cwd
- Guard launcher and closure workflow contracts

Production/tooling LOC: +8/-10 (net -2). Tests: +34/-27 (net +7).

## Testing

- Original failure: `mise exec -- node --import tsx scripts/ocm-npm-workspace-deps.mts --version`
  - Reproduced `Parse error ...:2:113` with `idx: 148` on Node 24.19.0.
- Direct boundary: `(cd /tmp && mise exec -- /absolute/path/scripts/ocm-npm-workspace-deps.mts --version)`
  - Exited 0 and reported npm 11.17.0.
- Workspace closure: `pnpm --dir <repo> --filter '@openclaw/ai...' --fail-if-no-match list --depth -1 --json`
  - Resolved `ai`, `model-catalog-core`, and `normalization-core`.
- Focused Testbox: `pnpm test test/scripts/ocm-npm-workspace-deps.test.ts test/scripts/openclaw-performance-workflow.test.ts`
  - 49/49 tests passed on run 31893789783.
- Changed Testbox gate: `pnpm check:changed`
  - Formatting, type checks, lint, and repository guards passed.
- Strict exact-head Product Performance: https://github.com/openclaw/openclaw/actions/runs/31893653310
  - Tested `8b99a7a328ec668a3001d394c435a77b8626e4d7`, release profile, repeat 3, regression gate enabled, report publishing disabled.
  - Produced all 15 records across five scenario/state pairs and three repeats: 3 `PASS`, 12 measured `FAIL`, 0 `BLOCKED`.
  - Evidence validation and upload passed. The run remains red because measured RSS values exceed existing thresholds.
- Evidence-acceptance Product Performance: https://github.com/openclaw/openclaw/actions/runs/31894073760
  - Same head, profile, repeats, and scenarios with the existing diagnostic `fail_on_regression=false` input.
  - The complete workflow passed, including Kova execution, evidence validation, artifact upload, source-performance probes, and artifact-only report verification.
- Autoreview: clean, no accepted or actionable findings, confidence 0.99.

## Owner and remaining risk

The owner-level repair removes the duplicate launcher and derives the package plan from pnpm's workspace graph. Updating Kova would misclassify a real provisioning failure; relaxing OpenClaw's evidence gate would accept missing measurements; updating `tsx` would retain a cwd-sensitive duplicate launcher and change a dependency unnecessarily.

Evidence generation is complete. The strict run revealed a separate measured product regression: 12 records exceed existing RSS thresholds. This PR does not change those thresholds or performance behavior.

Directly checked contracts: `.github/workflows/openclaw-performance.yml`, `scripts/ocm-npm-workspace-deps.mts`, `scripts/openclaw-prepack.ts`, `scripts/lib/kova-workflow-evidence.mts`, pnpm 11.15.1 CLI help and workspace output, pinned Kova setup/BLOCKED handling, OCM v0.2.29 adapter invocation, Node 24 TypeScript execution, and the focused workflow/adapter tests.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"codex","entries":3,"user":1,"assistant":1,"toolCalls":6,"toolOutputsDropped":6,"web":0,"redactions":3,"omittedUnsafe":0,"rawEntries":27}

[user]
[instructions recap omitted; policy/config text, not task dialogue]

[assistant]
I’ll own the repair through a pushed PR. I’m starting with the required release-CI/testing/test-audit investigation workflow, then Pebbles planning before any code changes; later I’ll use autoreview, prepare-PR, agent-transcript, and the technical-writing guide for ship readiness. I’ll preserve unrelated worktree state and keep Pebbles strictly local.

The worktree is clean but detached, so I’ll first anchor it to the current remote default-branch SHA and only create the task branch after the investigation and Pebbles plan. The repository’s repair doctrine calls for independent evidence lanes here, so I’m splitting log/artifact retrieval, OpenClaw owner tracing, and upstream Kova contract inspection while I reproduce and verify the decisive evidence myself.

The artifact narrows the failure: all 15 cases were blocked before scenario execution because the shared runtime-build phase could not pack OpenClaw. OCM invoked the repository’s npm adapter, and its `tsx` trampoline failed to parse the adapter on Node 24.19.0; the gate correctly rejected the incomplete report. I also found an open, unmerged PR aimed at the same boundary, so I’m treating it as prior art and independently checking whether it is complete and whether current main still reproduces before deciding the patch shape.

The pre-fix reproduction now matches the Actions failure byte-for-byte at the important boundary: Node 24.19.0 plus the repository’s `tsx` reports the same adapter parse location (`2:113`, `idx: 148`). I’ve completed the investigation document and am moving through the required Pebbles gate now; implementation remains paused until the epic, tasks, and dependencies exist.

Pebbles was not initialized in this app-provisioned worktree. The Pebbles skill requires local initialization before planning can continue, so I’m initializing only `.pebbles/` here; it will remain untracked and will never be staged, synced, committed, or pushed.

The focused test harness cannot run in this linked worktree because dependencies are intentionally absent; the direct post-fix boundary probe is green. Following the testing policy, I’m switching focused and changed-scope proof to a fresh Blacksmith Testbox through the Crabbox workflow, rather than reconciling dependencies in this worktree.

The repair now passes the owner-boundary regression on Blacksmith Testbox: 49/49 focused tests are green, including direct execution from a separate working directory and workflow assertions that forbid the forced-`tsx` trampoline. I’m closing the implementation subtask, committing only the four source/test paths, then moving to exact-head Product Performance proof.

The exact repair commit is now on the remote branch, and the remote SHA matches locally. I’m dispatching the full release-profile Product Performance workflow against that immutable SHA with repeat 3 and regression gating enabled; success requires the mock lane to execute all 15 cases and the workflow’s own evidence validators to accept the report.

While the GitHub performance lane runs, I’m applying the autoreview skill to the frozen branch diff. Its scope is the single violated invariant: OpenClaw must hand OCM a cwd-independent executable adapter, while Kova’s BLOCKED/incomplete-evidence semantics remain unchanged. Any finding outside that owner boundary will be classified rather than folded into this release repair.

Autoreview is clean with no actionable findings. The exact-head mock lane is now running past the setup point that previously failed. While it finishes, I’m using the PR-maintainer and technical-writing guidance to prepare a concise PR that records the duplicate prior PR, the exact failure-before/fixed-after evidence, and the remaining evidence status without weakening the gate.

The exact-head workflow has cleared checkout, dependency setup, OCM/Kova installation, adapter configuration, and plan validation. It is now inside Kova execution rather than failing immediately in `target-setup`; the source-performance sibling is also still running. I’m waiting for terminal artifact validation before updating the existing canonical PR.

The first exact-head run removed the `tsx` parse failure, but Kova still blocked all 15 cases on a later setup failure. The strict gate again rejected the partial report, which is the intended behavior. I’m retrieving that new artifact now; this is a second root cause in the same runtime-build owner boundary, so I’m keeping the PR unpublished until the complete evidence requirement is actually met.

I’m continuing from the exact-head proof rather than treating the first repair as complete. The remaining failure is now narrowed to the workspace-dependency closure used by the local OCM runtime build; I’ll repair that owner boundary, preserve the strict BLOCKED gate, and rerun the full 15-case workflow before publication.

I’m using the required testing, test-audit, release-CI, Pebbles, autoreview, prepare-PR, transcript, and technical-writing workflows. Their key effect here is that the new closure regression must fail against the prior commit for the observed packaging reason, and the final proof must be the real Product Performance workflow—not a unit test that merely mirrors its YAML.

The second failure is not a reason to relax Kova’s verdict. The adapter already knows how to package a transitive workspace graph, but the workflow supplied only `@openclaw/ai`; after `@openclaw/model-catalog-core` became part of that graph, the plan was incomplete. I’m keeping the adapter’s fail-closed check and adding a workflow contract that tracks the actual `@openclaw/ai` workspace closure so future manifest changes cannot silently recreate this release blocker.

The pre-fix workflow contract now fails exactly where expected: it has no workspace-closure selection, while the amended workflow resolves `@openclaw/ai...` to all three current projects. The same command was verified against the pinned pnpm 11.15.1 CLI and returned `ai`, `model-catalog-core`, and `normalization-core`; focused remote tests are running on the existing Testbox lease.

The existing Testbox lease no longer has its hydrated dependency tree. Its one allowed reinstall attempt failed closed because the branch’s workspace override settings no longer match its lockfile, so I’m not changing dependencies or bypassing the frozen lock. I’m checking whether `main` advanced since this branch was created; if so, I’ll incorporate the current default branch before rerunning proof, which is also required for a current-main release repair.

The branch is now rebased onto the latest `origin/main` and the exact-head Product Performance run is live: [run [REDACTED_PHONE]](https://github.com/openclaw/openclaw/actions/runs/[REDACTED_PHONE]). It uses the release profile, three repeats, strict regression failure, no live-provider lane, and no report publication. Success requires the workflow’s existing completeness gate to accept all 15 mock records.

The refreshed Testbox lease is healthy and the focused boundary suite is green: 2 files, 49/49 tests. This includes direct POSIX execution of the `.mts` adapter, transitive workspace tarball installation, and the workflow’s dependency-closure contract. The real performance run has also passed configuration and plan sanity and is now executing Kova measurements.

The changed gate is also green on the exact rebased head: formatting, both TypeScript projects, lint, dependency pins, coercion guards, and repository checks all passed. Production/tooling remains net negative overall (+8/−10); tests are +34/−27. I’m running the mandatory final branch review while Kova finishes.

The infrastructure repair worked: configuration, plan sanity, evidence validation, and artifact upload all passed. Kova itself exited nonzero after 7m49s, so I’m inspecting the complete report before deciding whether this is a measured regression or another evidence-generation defect. I will not relabel it as success merely because all records exist.

The report is now complete: all 15 planned records ran, with 3 PASS and 12 measured FAIL results. The failures are real RSS threshold violations (not BLOCKED setup records), and the strict regression-enabled run correctly remains red. To prove the workflow’s evidence-acceptance path without changing any gate or threshold, I’m running the same exact head/profile/repeats with the existing diagnostic `fail_on_regression=false` dispatch input; the release-gated run remains recorded as a measured product regression.

The final autoreview is clean at 0.99 confidence. I’m now applying the prepare-PR workflow to the existing canonical PR #122030, preserving its author and using its exact current head as the push lease. This creates an isolated PR preparation worktree; it will not merge or alter `main`.

The acceptance lane is green end to end: Kova ran all scenarios, evidence validation passed, and artifacts uploaded with `fail_on_regression=false`. The only remaining job in that workflow is the independent source-performance sibling. I’m publishing the proven repair to the existing author-owned PR now, then I’ll verify its remote head and keep monitoring the workflow to terminal status.

The acceptance workflow is fully green, including the independent source-performance job and artifact-only report verification: [run [REDACTED_PHONE]](https://github.com/openclaw/openclaw/actions/runs/[REDACTED_PHONE]). The strict run remains correctly red with complete measured evidence. PR #122030 is updated, ready for review, and its remote head is verified at `8b99a7a328ec668a3001d394c435a77b8626e4d7`.

[tool summary]
1 read, 5 other; raw tool outputs dropped: 6
````

</details>
<!-- agent-transcript:end -->
