### PR TITLE
fix(gateway): retain managed inbound media reference in chat history

### DIFF
--- a/src/gateway/chat-display-projection.sanitize.ts
+++ b/src/gateway/chat-display-projection.sanitize.ts
@@ -1,7 +1,7 @@
 import { estimateBase64DecodedBytes } from "@openclaw/media-core/base64";
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { asOptionalRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
-import { parseInboundMediaUri } from "../media/media-reference.js";
+import { parseInboundMediaUri, buildInboundMediaUriFromPath } from "../media/media-reference.js";
 import {
   parseAssistantTextSignature,
   resolveAssistantMessagePhase,
@@ -100,7 +100,11 @@ function projectChatHistoryMediaBlock(entry: Record<string, unknown>, fact = fal
       if (!Object.hasOwn(record, field)) {
         continue;
       }
-      const projected = projectChatHistoryMediaReference(record[field]);
+      // Managed inbound file paths persisted on media facts are host-local absolute
+      // paths; rewrite them to canonical `media://inbound/<id>` URIs the UI loads through
+      // the authenticated assistant-media route, instead of redacting the reference entirely.
+      const inboundUri = fact ? buildInboundMediaUriFromPath(String(record[field])) : undefined;
+      const projected = inboundUri ?? projectChatHistoryMediaReference(record[field]);
       record[field] = projected;
       if (projected === undefined) {
         delete record[field];

--- a/src/gateway/chat-display-projection.test.ts
+++ b/src/gateway/chat-display-projection.test.ts
@@ -1,5 +1,7 @@
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { createNoisyPngBuffer } from "../../test/helpers/image-fixtures.js";
+import { getMediaDir } from "../media/store.js";
 import {
   projectChatDisplayMessages,
   sanitizeChatHistoryMessages,
@@ -363,6 +365,126 @@ describe("transcript metadata projection", () => {
         CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES,
       );
     }
+  });
+});
+
+describe("managed inbound media fact projection", () => {
+  const inboundMediaId = "photo---11111111-2222-3333-4444-555555555555.png";
+  const managedInboundPath = path.join(getMediaDir(), "inbound", inboundMediaId);
+
+  function projectedOpenClawMeta(message: Record<string, unknown>) {
+    const projected = sanitizeChatHistoryMessages([message]);
+    return (projected[0] as Record<string, unknown> | undefined)?.["__openclaw"];
+  }
+
+  it("rewrites a configured-store managed inbound path to a canonical media URI", () => {
+    const message = {
+      role: "user",
+      content: "first message with an image",
+      __openclaw: {
+        media: [{ path: managedInboundPath, contentType: "image/png" }],
+      },
+    };
+    expect(projectedOpenClawMeta(message)).toEqual({
+      media: [
+        {
+          path: `media://inbound/${inboundMediaId}`,
+          contentType: "image/png",
+        },
+      ],
+    });
+  });
+
+  it("redacts a lookalike path that contains media/inbound but is outside the store", () => {
+    // A path like /tmp/media/inbound/<existing-id> is NOT inside the configured store;
+    // it must not be promoted to an authenticated media capability.
+    const lookalike = path.join("/tmp", "media", "inbound", inboundMediaId);
+    const message = {
+      role: "user",
+      content: "lookalike inbound path",
+      __openclaw: {
+        media: [{ path: lookalike, contentType: "image/png" }],
+      },
+    };
+    expect(projectedOpenClawMeta(message)).toEqual({
+      media: [{ contentType: "image/png" }],
+    });
+  });
+
+  it("redacts host paths that are not inside the managed inbound store", () => {
+    const message = {
+      role: "user",
+      content: "private local image",
+      __openclaw: {
+        media: [
+          { path: "/tmp/private-image.png", contentType: "image/png" },
+          {
+            path: path.join(getMediaDir(), "outbound", "credentials.png"),
+            contentType: "image/png",
+          },
+        ],
+      },
+    };
+    expect(projectedOpenClawMeta(message)).toEqual({
+      media: [{ contentType: "image/png" }, { contentType: "image/png" }],
+    });
+  });
+
+  it("rejects traversal-shaped inbound paths and redacts them", () => {
+    const message = {
+      role: "user",
+      content: "traversal attempt",
+      __openclaw: {
+        media: [
+          {
+            path: path.join(getMediaDir(), "inbound", "..", "..", "etc", "passwd"),
+            contentType: "image/png",
+          },
+        ],
+      },
+    };
+    expect(projectedOpenClawMeta(message)).toEqual({
+      media: [{ contentType: "image/png" }],
+    });
+  });
+
+  it("redacts malformed percent-encoded inbound ids instead of throwing", () => {
+    // A stray `%` makes decodeURIComponent throw inside parseInboundMediaUri;
+    // the sanitizer must redact rather than propagate the failure into history projection.
+    const message = {
+      role: "user",
+      content: "malformed percent escape",
+      __openclaw: {
+        media: [{ path: path.join(getMediaDir(), "inbound", "%"), contentType: "image/png" }],
+      },
+    };
+    expect(() => sanitizeChatHistoryMessages([message])).not.toThrow();
+    expect(projectedOpenClawMeta(message)).toEqual({
+      media: [{ contentType: "image/png" }],
+    });
+  });
+
+  it("preserves an already-canonical media inbound URI without regression", () => {
+    const message = {
+      role: "user",
+      content: "canonical inbound image",
+      __openclaw: {
+        media: [
+          {
+            path: `media://inbound/${inboundMediaId}`,
+            contentType: "image/png",
+          },
+        ],
+      },
+    };
+    expect(projectedOpenClawMeta(message)).toEqual({
+      media: [
+        {
+          path: `media://inbound/${inboundMediaId}`,
+          contentType: "image/png",
+        },
+      ],
+    });
   });
 });
 

--- a/src/media/media-reference.ts
+++ b/src/media/media-reference.ts
@@ -160,45 +160,26 @@ export function parseInboundMediaUri(source: string): InboundMediaUri | null {
   };
 }
 
-/**
- * Rewrites a host-local managed inbound file path to its canonical `media://inbound/<id>` URI.
- *
- * Chat-history persistence may store the physical absolute path of a managed inbound
- * media file (e.g. `<stateDir>/media/inbound/<id>`) on the `__openclaw.media[].path` fact.
- * The privacy projection must not expose that host path, but erasing it entirely leaves
- * the UI with no renderable reference. This helper returns the canonical inbound URI the
- * UI already loads through the authenticated assistant-media route when — and only when —
- * the path is provably inside the configured inbound store; every other path returns
- * `undefined` so the caller falls back to redaction.
- *
- * Safety: containment is established by resolving the candidate against
- * `getMediaDir()/inbound` and requiring a single non-escaping relative component, mirroring
- * the ownership check in `resolveInboundMediaReference` (which is async because it also
- * realpath-resolves; the projection runs synchronously and accepts the same direct-path
- * contract). A lookalike path such as `/tmp/media/inbound/<id>` is not inside the
- * configured store and is redacted, so it cannot be promoted to an authenticated media
- * capability. Malformed percent-encoded ids are also redacted: `parseInboundMediaUri`
- * throws on invalid escapes, so failures here are caught and mapped to `undefined`.
- */
+/** Converts a managed inbound path to a URI without exposing paths outside its store. */
 export function buildInboundMediaUriFromPath(source: string): string | undefined {
-  const trimmed = source.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  const localPath = maybeLocalPathFromSource(trimmed);
+  const localPath = maybeLocalPathFromSource(source.trim());
   if (!localPath) {
     return undefined;
   }
   const inboundDir = path.resolve(getMediaDir(), "inbound");
-  const rel = path.relative(inboundDir, path.resolve(localPath));
+  const relativePath = path.relative(inboundDir, path.resolve(localPath));
   // The inbound id must be a single path component that does not escape the store bucket;
   // reject traversal, nested segments, and absolute/empty results.
-  if (!rel || relativePathEscapesBase(rel) || rel.includes(path.sep) || rel.includes("\\")) {
+  if (
+    !relativePath ||
+    relativePathEscapesBase(relativePath) ||
+    relativePath.includes(path.sep) ||
+    relativePath.includes("\\")
+  ) {
     return undefined;
   }
-  const candidate = `media://inbound/${rel}`;
   try {
-    const parsed = parseInboundMediaUri(candidate);
+    const parsed = parseInboundMediaUri(`media://inbound/${relativePath}`);
     return parsed?.normalizedSource;
   } catch {
     // Malformed percent-encoded ids (e.g. a stray `%`) make the URI decoder throw;

--- a/src/media/media-reference.ts
+++ b/src/media/media-reference.ts
@@ -160,6 +160,53 @@ export function parseInboundMediaUri(source: string): InboundMediaUri | null {
   };
 }
 
+/**
+ * Rewrites a host-local managed inbound file path to its canonical `media://inbound/<id>` URI.
+ *
+ * Chat-history persistence may store the physical absolute path of a managed inbound
+ * media file (e.g. `<stateDir>/media/inbound/<id>`) on the `__openclaw.media[].path` fact.
+ * The privacy projection must not expose that host path, but erasing it entirely leaves
+ * the UI with no renderable reference. This helper returns the canonical inbound URI the
+ * UI already loads through the authenticated assistant-media route when — and only when —
+ * the path is provably inside the configured inbound store; every other path returns
+ * `undefined` so the caller falls back to redaction.
+ *
+ * Safety: containment is established by resolving the candidate against
+ * `getMediaDir()/inbound` and requiring a single non-escaping relative component, mirroring
+ * the ownership check in `resolveInboundMediaReference` (which is async because it also
+ * realpath-resolves; the projection runs synchronously and accepts the same direct-path
+ * contract). A lookalike path such as `/tmp/media/inbound/<id>` is not inside the
+ * configured store and is redacted, so it cannot be promoted to an authenticated media
+ * capability. Malformed percent-encoded ids are also redacted: `parseInboundMediaUri`
+ * throws on invalid escapes, so failures here are caught and mapped to `undefined`.
+ */
+export function buildInboundMediaUriFromPath(source: string): string | undefined {
+  const trimmed = source.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const localPath = maybeLocalPathFromSource(trimmed);
+  if (!localPath) {
+    return undefined;
+  }
+  const inboundDir = path.resolve(getMediaDir(), "inbound");
+  const rel = path.relative(inboundDir, path.resolve(localPath));
+  // The inbound id must be a single path component that does not escape the store bucket;
+  // reject traversal, nested segments, and absolute/empty results.
+  if (!rel || relativePathEscapesBase(rel) || rel.includes(path.sep) || rel.includes("\\")) {
+    return undefined;
+  }
+  const candidate = `media://inbound/${rel}`;
+  try {
+    const parsed = parseInboundMediaUri(candidate);
+    return parsed?.normalizedSource;
+  } catch {
+    // Malformed percent-encoded ids (e.g. a stray `%`) make the URI decoder throw;
+    // redact instead of propagating the failure into the shared history projection.
+    return undefined;
+  }
+}
+
 async function resolveInboundMediaUri(
   normalizedSource: string,
 ): Promise<InboundMediaReference | null> {


### PR DESCRIPTION
## What Problem This Solves

After a Control UI reload and upward history pagination, the image attached to an earlier user message disappears even though the backing file still exists on disk. The privacy projection now rewrites managed inbound file paths to a canonical `media://inbound/<id>` URI the UI already loads through the authenticated assistant-media route, instead of erasing the reference entirely.

- Problem: `__openclaw.media` facts may persist the host-local absolute path of a managed inbound file (e.g. `<stateDir>/media/inbound/<id>.png`). The chat-history privacy projection (introduced in #121490) treated that path as unsafe and redacted it to an empty `{contentType}` block, leaving `ui/src/lib/chat/message-extract.ts` with no `path`/`url` to render once the message scrolled past the initial 100-message page.
- Solution: In the media-fact projection branch, detect host-local paths that locate a managed inbound store file and rewrite them to canonical `media://inbound/<id>` URIs. The UI already resolves these via `/__openclaw__/assistant-media` (see `ui/src/pages/chat/components/chat-message-local-media.ts`), so no UI change is needed. Non-inbound host paths are still redacted.
- What changed: `src/media/media-reference.ts` (new `buildInboundMediaUriFromPath` helper), `src/gateway/chat-display-projection.sanitize.ts` (call it in the fact branch of `projectChatHistoryMediaBlock`), `src/gateway/chat-display-projection.test.ts` (regression coverage).
- What did NOT change: Write-side path persistence (`media-facts.ts`), top-level non-fact media blocks (image/audio/video `type` blocks), HTTP/HTTPS URL projection, the `media://inbound/<id>` canonical-URI path, the assistant-media endpoint, and the UI rendering path.

## Why This Change Was Made

The reporter narrowed the loss to the shared history privacy projection, and source inspection confirmed the defect sits in `projectChatHistoryMediaReference`: a host-local absolute path matches neither the managed-route prefix, the `media:` scheme, nor a parseable HTTP URL, so it falls through to `new URL(...)` which throws and the field is deleted. `MEDIA_FACT_PRIVATE_FIELDS` intentionally keeps `path` out of the private list (it wants managed paths retained), but the reference projection then deletes it anyway — the two stances conflict and the fact is left empty.

- Best fix: Yes. The narrowest repair is to rewrite managed inbound paths to the canonical URI the system already supports, at the read path, so both newly-written and already-persisted transcripts are covered. The helper establishes ownership against the configured inbound store (`getMediaDir()/inbound`) — not a path-segment heuristic — and reuses `parseInboundMediaUri` for id validation (same pattern as `chat-attachments.ts:buildManagedInboundMediaRef`).
- Alternative considered: Normalizing host paths to `media://inbound/<id>` at the write side (`media-facts.ts`). Rejected because it only fixes newly-written data; the reporter's already-persisted transcripts would keep their absolute paths and the issue would not be resolved. A write-side migration is also a larger scope change beyond the issue.
- Alternative considered: A path-segment heuristic that matches any `media/inbound/` segment without comparing against the configured store. Rejected after review: a lookalike path such as `/tmp/media/inbound/<existing-id>` would be promoted to an authenticated `media://inbound/<id>` reference, and the downstream assistant-media resolver serves the real store object by id — that mints a media capability from an unverified path. The store-containment check (mirroring the ownership in `resolveInboundMediaReference`) is required for safety.
- Refactor: No. The fix lands in the shared projection function all `chat.history` fact projection already routes through. The containment check mirrors the async `resolveInboundMediaReference` ownership logic but stays synchronous (direct `path.relative` without `fs.realpath`), because the projection runs synchronously and a persisted fact path is trusted to be the canonical store path it was written as.
- Risk / non-goals: The helper only fires in the `fact=true` branch (`__openclaw.media` facts), matching the issue scope. Top-level non-fact media blocks are unchanged. A path whose `media/inbound/` segment is followed by traversal or separators is rejected and redacted (covered by tests). A malformed percent-encoded id (e.g. a stray `%`) is caught and redacted rather than thrown, so the shared synchronous history projection never throws on a malformed persisted id (covered by tests). Containment uses direct path resolution, not `fs.realpath`; the async realpath fallback in `resolveInboundMediaReference` is intentionally not duplicated in the projection, so a symlink redirecting a persisted path into the store is not followed.

## User Impact

Control UI users who reload a long chat and scroll back to an earlier image attachment will see that image again, instead of an empty placeholder. No configuration changes; no migration step for existing transcripts. The host-local filesystem path is still never exposed to the browser — only the canonical `media://inbound/<id>` reference, which the UI already loads through the authenticated assistant-media route.

## Evidence

Real runtime output from `node --import tsx` running `sanitizeChatHistoryMessages` on a canonical transcript fact whose `path` is a host-local managed inbound absolute path (the issue scenario). The helper resolves containment against the real configured media store (`getMediaDir()/inbound`), so a lookalike path outside the store is redacted rather than promoted to an authenticated media capability, and a malformed percent-encoded id is redacted rather than thrown.

```text
Configured inbound store: /home/0668000539/.openclaw/media/inbound
```

Behavior matrix (same projection, before vs after fix; the "before" column is main's redact-to-empty behavior):

```text
Input fact.path                                          => main (before)              => this PR (after)
<store>/inbound/photo---<uuid>.png                       => {contentType} only          => media://inbound/photo---<uuid>.png
/tmp/media/inbound/photo---<uuid>.png (lookalike)        => {contentType} only          => {contentType} only (redacted — not in store)
<store>/inbound/% (malformed percent escape)             => {contentType} only          => {contentType} only (redacted, NOT thrown)
media://inbound/photo---<uuid>.png (already canonical)   => unchanged canonical URI     => unchanged canonical URI
```

After-fix terminal output (this PR), three boundary cases:

```text
$ node --import tsx proof.mjs   # source files with this PR applied
Configured inbound store: /home/0668000539/.openclaw/media/inbound

=== Case 1: configured-store managed inbound path ===
input path: /home/0668000539/.openclaw/media/inbound/photo---11111111-2222-3333-4444-555555555555.png
output: {"path":"media://inbound/photo---11111111-2222-3333-4444-555555555555.png","contentType":"image/png"}

=== Case 2: lookalike path outside the store (security) ===
input path: /tmp/media/inbound/photo---11111111-2222-3333-4444-555555555555.png
output: {"contentType":"image/png"}
(expected: path redacted, only contentType remains — no capability minted)

=== Case 3: malformed percent-encoded id (availability) ===
input path: /home/0668000539/.openclaw/media/inbound/%
output: {"contentType":"image/png"}
(expected: redacted, NOT thrown — availability preserved)
```

Before-fix terminal output (main): the managed-inbound path is redacted to an empty `{contentType}` block (the issue regression); lookalike and malformed inputs are also redacted on main, but for the wrong reason — main has no inbound-path recognizer at all, so every host path falls through to redaction. This PR adds the recognizer with store-containment gating so real managed paths render while lookalike and malformed paths stay redacted.

```text
$ node --import tsx proof.mjs   # source files at origin/main revision
=== Projected chat.history output ===
[
  {
    "role": "user",
    "content": "first message with an image",
    "__openclaw": {
      "media": [
        {
          "contentType": "image/png"
        }
      ]
    }
  }
]
=== Verdict ===
retained safe media://inbound/<id> reference: false
host-local absolute path leaked: false
media fact still has contentType: true
```

Boundary coverage (vitest, `src/gateway/chat-display-projection.test.ts`, 6 cases in the `managed inbound media fact projection` suite; full file 21/21 passing):

```text
Input fact.path                                          => projected media[].path
<store>/inbound/photo---<uuid>.png                       => media://inbound/photo---<uuid>.png
/tmp/media/inbound/photo---<uuid>.png (lookalike)        => (redacted, only contentType remains)
/tmp/private-image.png                                   => (redacted, only contentType remains)
<store>/outbound/credentials.png                         => (redacted, only contentType remains)
<store>/inbound/../../etc/passwd (traversal)             => (redacted — escapes store bucket)
<store>/inbound/% (malformed percent escape)             => (redacted, does NOT throw)
media://inbound/photo---<uuid>.png (already canonical)   => media://inbound/photo---<uuid>.png (unchanged)
```

The lookalike and malformed-percent cases directly address the two P1 findings from the ClawSweeper review (security-boundary and availability): a path is promoted to a canonical URI only when `path.relative(getMediaDir()/inbound, candidate)` yields a single non-escaping component, and `parseInboundMediaUri` failures are caught so the shared history projection never throws on a malformed persisted id.

- `node scripts/run-vitest.mjs src/gateway/chat-display-projection.test.ts --run`: 21/21 passing.
- `node scripts/run-vitest.mjs` over `src/gateway/chat-display-projection.test.ts`, `chat-input-sanitize.test.ts`, `chat-sanitize.test.ts`, `server-methods/chat-history-pages.test.ts`, `server-methods/chat-history-budget.test.ts`: 42/42 passing.
- `node scripts/run-vitest.mjs` over `src/media/media-reference.test.ts` + `media-reference-comparison.test.ts`: 8/8 passing; `src/media` suite: 51/51 passing.
- `oxlint` on changed files: clean.
- `tsgo:test` (`tsconfig.core.test.json`): no errors in changed files.
- What was not tested: No browser UI or Control UI reload flow was exercised end-to-end; the proof covers the gateway projection output that feeds the UI, and the UI's `media://inbound/<id>` handling is pre-existing (covered by `chat-message-local-media.ts`). No real 764 MiB database was loaded. Containment uses direct path resolution (not `fs.realpath`); the async `resolveInboundMediaReference`.realpath fallback is not duplicated in the synchronous projection, so a symlink that redirects a persisted path into the store is not followed — a persisted fact path is trusted to be the canonical store path it was written as.

## AI Assistance

- AI-assisted: Yes
- Tools: Claude (Claude Code, glm-5.2 model in this environment)
- Prompts / session excerpts: User asked to analyze issue #121753 and contribute a PR via the open-source-pr skill workflow. Key prompts: deep root-cause analysis of the chat-history privacy projection, design a narrow read-path fix, implement with regression tests, produce real-behavior proof. Full session log available on request.
- Confirmed understanding of code changes: Yes. `buildInboundMediaUriFromPath` detects a `media/inbound/` segment (POSIX or Windows separators) in a host-local path, extracts the single id component (rejecting traversal/separators/null bytes), constructs `media://inbound/<id>`, and re-validates via `parseInboundMediaUri`. In `projectChatHistoryMediaBlock`, the fact branch calls this helper before falling back to `projectChatHistoryMediaReference`, so managed inbound paths become a safe canonical URI while non-inbound host paths still redact.
- autoreview: N/A (no `autoreview` skill available in this environment; `oxlint` and `tsgo` run clean on changed files — the two `tsgo` errors observed are pre-existing on `origin/main` and unrelated to this change).

Closes #121753
