### PR TITLE
fix(agents): replace stale timeout payloads precisely

### DIFF
--- a/src/agents/embedded-agent-helpers/error-text.test.ts
+++ b/src/agents/embedded-agent-helpers/error-text.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../../shared/assistant-error-format.js";
 import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
-import { formatAssistantErrorText } from "./error-text.js";
+import { formatAssistantErrorText, formatUserFacingAssistantErrorText } from "./error-text.js";
 
 const { toolPolicyAuditInfo } = vi.hoisted(() => ({
   toolPolicyAuditInfo: vi.fn(),
@@ -47,6 +47,15 @@ describe("formatAssistantErrorText streaming JSON parse classification", () => {
       "Expected ',' or '}' after property value in JSON at position 334 (line 1 column 335)",
     );
   });
+
+  it.each(["request timed out", "LLM request timed out."])(
+    "preserves safe user-facing timeout copy for provider error %j",
+    (errorMessage) => {
+      expect(formatUserFacingAssistantErrorText(makeAssistantError(errorMessage))).toBe(
+        "LLM request timed out.",
+      );
+    },
+  );
 
   it("keeps non-streaming provider request-validation syntax diagnostics", () => {
     const msg = makeAssistantError(

--- a/src/agents/embedded-agent-helpers/error-text.ts
+++ b/src/agents/embedded-agent-helpers/error-text.ts
@@ -35,6 +35,7 @@ import { classifyProviderRuntimeFailureKind } from "./provider-runtime-failure.j
 const log = createSubsystemLogger("errors");
 const sandboxToolPolicyAuditMessages = new WeakSet<AssistantMessage>();
 export const GENERIC_ASSISTANT_ERROR_TEXT = "LLM request failed.";
+export const SYNTHESIZED_TIMEOUT_ERROR_TEXT = "LLM request timed out.";
 const PROVIDER_SCHEMA_REJECTION_USER_TEXT =
   "LLM request failed: provider rejected the request schema or tool payload.";
 const MODEL_NOT_FOUND_USER_TEXT =
@@ -241,7 +242,7 @@ export function formatAssistantErrorText(
   }
 
   if (isTimeoutErrorMessage(raw)) {
-    return "LLM request timed out.";
+    return SYNTHESIZED_TIMEOUT_ERROR_TEXT;
   }
 
   if (isBillingErrorMessage(raw)) {
@@ -283,7 +284,7 @@ function isRawAssistantErrorPassthrough(params: {
     friendlyError.startsWith("LLM error") ||
     friendlyError.startsWith("HTTP ");
   return (
-    friendlyError === rawError ||
+    (friendlyError === rawError && friendlyError !== SYNTHESIZED_TIMEOUT_ERROR_TEXT) ||
     (rawError.length > 600 && friendlyError === `${truncateUtf16Safe(rawError, 600)}…`) ||
     Boolean(parsedMessage && hasRawDerivedProviderPrefix) ||
     Boolean(leadingStatusRest && friendlyError.startsWith("HTTP "))

--- a/src/agents/embedded-agent-runner/run.terminal-timeout-delivery.integration.test.ts
+++ b/src/agents/embedded-agent-runner/run.terminal-timeout-delivery.integration.test.ts
@@ -1,0 +1,128 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { settleReplyDispatcher } from "../../auto-reply/dispatch-dispatcher.js";
+import type { ReplyDispatchRuntimeInfo } from "../../auto-reply/reply/reply-dispatcher.types.js";
+import type { ReplyPayload } from "../../auto-reply/types.js";
+import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
+import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
+import {
+  mockedBuildEmbeddedRunPayloads,
+  mockedRunEmbeddedAttempt,
+  overflowBaseRunParams,
+  resetSharedRunIntegrationHarnessMocks,
+  useOpenAIPlatformAuthFixture,
+} from "./run.overflow-compaction.harness.js";
+import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
+
+const GENERIC_TIMEOUT = "LLM request timed out.";
+const AUTHORITATIVE_TIMEOUT =
+  "Provider timed out after the request started. Retry the turn, or increase its configured timeout.";
+const TOOL_MEDIA_URL = "https://example.test/tool-output.png";
+
+let runEmbeddedAgent: Awaited<ReturnType<typeof loadSharedRunIntegrationHarness>>;
+let buildEmbeddedRunPayloads: typeof import("./run/payloads.js").buildEmbeddedRunPayloads;
+let createReplyDispatcher: typeof import("../../auto-reply/reply/reply-dispatcher.js").createReplyDispatcher;
+
+beforeAll(async () => {
+  runEmbeddedAgent = await loadSharedRunIntegrationHarness();
+  ({ buildEmbeddedRunPayloads } =
+    await vi.importActual<typeof import("./run/payloads.js")>("./run/payloads.js"));
+  ({ createReplyDispatcher } = await import("../../auto-reply/reply/reply-dispatcher.js"));
+});
+
+beforeEach(() => {
+  resetSharedRunIntegrationHarnessMocks();
+});
+
+describe("provider timeout final delivery", () => {
+  it.each([
+    {
+      label: "one final timeout",
+      rawError: "request timed out",
+      preserveIndependentErrorAndMedia: false,
+    },
+    {
+      label: "one final timeout when the provider already uses canonical timeout copy",
+      rawError: GENERIC_TIMEOUT,
+      preserveIndependentErrorAndMedia: false,
+    },
+    {
+      label: "an independent same-text error and tool media",
+      rawError: "request timed out",
+      preserveIndependentErrorAndMedia: true,
+    },
+  ])(
+    "delivers $label without duplicating the provider timeout",
+    async ({ rawError, preserveIndependentErrorAndMedia }) => {
+      const assistant = makeAssistantMessageFixture({
+        stopReason: "aborted",
+        errorMessage: rawError,
+        content: [],
+      });
+      const independentError: ReplyPayload = { text: GENERIC_TIMEOUT, isError: true };
+      mockedBuildEmbeddedRunPayloads.mockImplementation((params) => [
+        ...buildEmbeddedRunPayloads(params),
+        ...(preserveIndependentErrorAndMedia ? [independentError] : []),
+      ]);
+      mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+        makeAttemptResult({
+          assistantTexts: [],
+          lastAssistant: assistant,
+          currentAttemptAssistant: assistant,
+          currentAttemptCompletedAssistant: assistant,
+          terminal: { kind: "timeout", phase: "prompt", source: "idle", aborted: true },
+          promptTimeoutOutcome: {
+            message: AUTHORITATIVE_TIMEOUT,
+            replayInvalid: false,
+            livenessState: "abandoned",
+            timeoutPhase: "provider",
+            providerStarted: true,
+          },
+          ...(preserveIndependentErrorAndMedia ? { toolMediaUrls: [TOOL_MEDIA_URL] } : {}),
+        }),
+      );
+      useOpenAIPlatformAuthFixture();
+
+      const result = await runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        provider: "openai",
+        model: "gpt-5.4",
+        runId: "provider-idle-timeout-single-final-delivery",
+      });
+      const finalPayloads = result.payloads ?? [];
+      const physicalSends: Array<{ payload: ReplyPayload; info: ReplyDispatchRuntimeInfo }> = [];
+      const mockChannelApi = vi.fn(
+        async (payload: ReplyPayload, info: ReplyDispatchRuntimeInfo) => {
+          physicalSends.push({ payload, info });
+          return { visibleReplySent: true, messageId: `mock-send-${physicalSends.length}` };
+        },
+      );
+      const dispatcher = createReplyDispatcher({ deliver: mockChannelApi });
+
+      for (const payload of finalPayloads) {
+        expect(dispatcher.sendFinalReply(payload)).toBe(true);
+      }
+      await settleReplyDispatcher({ dispatcher });
+
+      const independentSend = {
+        payload: expect.objectContaining({
+          text: GENERIC_TIMEOUT,
+          isError: true,
+          mediaUrl: TOOL_MEDIA_URL,
+          mediaUrls: [TOOL_MEDIA_URL],
+        }),
+        info: expect.objectContaining({ kind: "final" }),
+      };
+      const authoritativeSend = {
+        payload: { text: AUTHORITATIVE_TIMEOUT, isError: true },
+        info: expect.objectContaining({ kind: "final" }),
+      };
+
+      expect(physicalSends).toEqual(
+        preserveIndependentErrorAndMedia
+          ? [independentSend, authoritativeSend]
+          : [authoritativeSend],
+      );
+      expect(dispatcher.getFailedCounts()).toEqual({ tool: 0, block: 0, final: 0 });
+    },
+  );
+});

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -353,6 +353,59 @@ describe("buildEmbeddedRunPayloads", () => {
     expectNoPayloadTextContaining(payloads, "[[reply_to_current]]");
   });
 
+  it.each(["request timed out", "LLM request timed out."])(
+    "defers assistant timeout %j to its terminal owner without changing tool-warning policy",
+    (errorMessage) => {
+      const payloads = buildPayloads({
+        deferAssistantTimeoutError: true,
+        runAborted: true,
+        assistantTexts: [],
+        lastAssistant: makeAssistant({
+          stopReason: "aborted",
+          errorMessage,
+          content: [],
+        }),
+        lastToolError: {
+          toolName: "exec",
+          error: "command exited with code 1",
+          middlewareError: true,
+        },
+      });
+
+      expect(payloads).toEqual([]);
+    },
+  );
+
+  it.each([
+    {
+      label: "connection failures",
+      rawError: "connect ECONNREFUSED 127.0.0.1:443",
+      visibleError: "connection refused",
+    },
+    {
+      label: "authentication refresh timeouts",
+      rawError:
+        'OAuth refresh call "refreshProviderOAuthCredentialWithPlugin(openai)" exceeded hard timeout (120000ms)',
+      visibleError: "Authentication refresh timed out",
+    },
+  ])(
+    "preserves $label while terminal timeout handling is deferred",
+    ({ rawError, visibleError }) => {
+      const payloads = buildPayloads({
+        deferAssistantTimeoutError: true,
+        runAborted: true,
+        assistantTexts: [],
+        lastAssistant: makeAssistant({
+          stopReason: "aborted",
+          errorMessage: rawError,
+          content: [],
+        }),
+      });
+
+      expect(payloads).toEqual([{ text: expect.stringContaining(visibleError), isError: true }]);
+    },
+  );
+
   it("suppresses raw aborted assistant error messages in user-facing reply payloads", () => {
     const payloads = buildPayloads({
       runAborted: true,

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -42,6 +42,7 @@ import {
   isRawApiErrorPayload,
   normalizeTextForComparison,
 } from "../../embedded-agent-helpers.js";
+import { SYNTHESIZED_TIMEOUT_ERROR_TEXT } from "../../embedded-agent-helpers/error-text.js";
 import type {
   MessagingToolSend,
   MessagingToolSourceReplyPayload,
@@ -52,6 +53,7 @@ import {
   extractAssistantVisibleText,
   sanitizeAssistantVisibleStreamText,
 } from "../../embedded-agent-utils.js";
+import { isTimeoutErrorMessage } from "../../failover/classify.js";
 import type { PreparedProviderFailoverOwner } from "../../failover/provider-patterns.js";
 import type { ToolErrorSummary } from "../../tool-error-summary.js";
 import { buildSourceReplyPayloadState } from "./source-reply-payloads.js";
@@ -156,6 +158,7 @@ export function buildEmbeddedRunPayloads(params: {
   agentId?: string;
   runId?: string;
   runAborted?: boolean;
+  deferAssistantTimeoutError?: boolean;
   didSendDeterministicApprovalPrompt?: boolean;
   heartbeatToolResponse?: HeartbeatToolResponse;
 }): ReplyPayload[] {
@@ -253,7 +256,12 @@ export function buildEmbeddedRunPayloads(params: {
   const normalizedErrorText = errorText ? normalizeTextForComparison(errorText) : null;
   const normalizedGenericBillingErrorText = normalizeTextForComparison(BILLING_ERROR_USER_MESSAGE);
   const genericErrorText = "The AI service returned an error. Please try again.";
-  if (errorText) {
+  const deferAssistantTimeoutError =
+    params.deferAssistantTimeoutError === true &&
+    rawErrorMessage !== undefined &&
+    isTimeoutErrorMessage(rawErrorMessage) &&
+    errorText === SYNTHESIZED_TIMEOUT_ERROR_TEXT;
+  if (errorText && !deferAssistantTimeoutError) {
     replyItems.push({ text: errorText, isError: true });
   }
   const reasoningText =

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.ts
@@ -6,6 +6,7 @@ import type { AgentRunTerminalReceipt } from "../../agent-run-terminal-receipt.j
 import type { AuthProfileStore } from "../../auth-profiles.js";
 import type { PreparedProviderFailoverOwner } from "../../failover/provider-patterns.js";
 import type { NormalizedUsage, UsageLike } from "../../usage.js";
+import { hasMessagingToolDeliveryEvidence } from "../delivery-evidence.js";
 import { resolveEmbeddedRunFailureSignal } from "../failure-signal.js";
 import { resolveEmbeddedRunTerminalToolFailure } from "../terminal-tool-failure.js";
 import type { EmbeddedAgentMeta, EmbeddedAgentRunResult } from "../types.js";
@@ -215,6 +216,10 @@ export function prepareEmbeddedRunTerminal(input: {
     agentId: runParams.agentId,
     runId: runParams.runId,
     runAborted: isEmbeddedRunTerminalInterrupted(input.terminalState.outcome),
+    deferAssistantTimeoutError:
+      timedOutDuringPrompt &&
+      (!hasMessagingToolDeliveryEvidence(attempt) ||
+        attempt.codexAppServerFailure?.kind === "turn_completion_idle_timeout"),
     didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
     heartbeatToolResponse: attempt.heartbeatToolResponse,
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users waiting for a model response could receive two final error messages after a provider idle timeout instead of one clear, actionable failure. The duplication also occurred when a provider already used OpenClaw's canonical timeout wording.

## Why This Change Was Made

The embedded-run payload producer emitted a generic assistant timeout before the terminal lifecycle owner appended the authoritative provider-timeout result. Independently, the user-facing error formatter mistook its own known-safe timeout text for an unsafe raw-provider passthrough and downgraded it to a generic failure.

The formatter now recognizes only its exact internally synthesized timeout text as safe. Terminal preparation carries the already-known timeout ownership to payload construction, which defers only a canonically classified, formatter-owned generic timeout when the terminal owner will deliver the authoritative result. This removes the contributor branch's downstream identity-marker/media-merge approach entirely; independent identical-text errors, tool media, meaningful authentication/transport errors, warning policy, arbitrary raw-error redaction, already-delivered messaging runs, and replay-unsafe Codex completion timeouts retain their existing behavior. No public API, configuration, default, protocol, persistence, or security contract changes.

## User Impact

Operators receive exactly one authoritative, actionable final error for a provider timeout, including when the provider's raw error already reads `LLM request timed out.`. Legitimate independent errors and tool-generated media remain visible, and interrupted Codex turns remain explicitly unsafe to retry or fall back automatically.

## Evidence

Exact reviewed head: `07b19fff980894cb30377ab3faf968c7491c368b`.

- Before the formatter-owner repair, the exact existing provider error `LLM request timed out.` was rewritten to `LLM request failed.` and the actual production reply dispatcher physically sent two final messages; the new producer and channel-boundary regressions both failed for that reason.
- The final rebased head passes **84/84 focused tests** across four Vitest shards, including the exact previously failing plugin SDK source-count assertion:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/plugin-sdk-surface-report.test.ts src/agents/embedded-agent-helpers/error-text.test.ts src/agents/embedded-agent-runner/run/payloads.errors.test.ts src/agents/embedded-agent-runner/run.terminal-timeout-delivery.integration.test.ts src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
```

- Production-boundary integration covers actual `runEmbeddedAgent`, payload construction, terminal preparation/finalization, tool-media merge, and the shared reply dispatcher. Both provider timeout spellings send **one authoritative final message**; an independently produced identical-text error with tool media correctly sends **two distinct final messages**, preserving media and arbitrary raw-error redaction.
- The original targeted Codex recovery proof passed: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.shared-integration.test.ts -t 'does not hand Codex app-server idle timeouts to model fallback'`. Result: **1/1**, preserving already-delivered turns, `replayInvalid`, `incomplete_turn`, and `fallbackSafe: false` without another provider attempt.
- Personally inspected the upstream Codex protocol and runtime terminal contracts in `codex-rs/protocol/src/protocol.rs:1437`, `codex-rs/protocol/src/protocol.rs:3981`, `codex-rs/core/src/session/mod.rs:1975`, and `codex-rs/core/src/session/tests.rs:10474`.
- Fresh full-branch structured review returned **no actionable findings**; the exact frozen head additionally received independent read-only source review and independent maintainer challenge.
- Production: **+17/-3 (net +14)**; tests: **+191/-1**. The production growth carries one essential terminal-ownership fact to its actual producer and fixes formatter-owned safe-text provenance, replacing the earlier downstream marker and media-object-identity machinery.

## Real behavior proof

- Behavior addressed: One real provider idle timeout **after an actual tool execution** must produce exactly one actionable physical channel delivery, not the original two final errors.
- Real environment tested: An isolated ephemeral OpenClaw Gateway child, a real loopback HTTP `mock-openai` provider server, and the actual HTTP-backed `qa-channel` transport/bus. No operator Gateway, credentials, or external account were touched.
- Exact setup: The zero-edit harness invoked `node --import tsx --input-type=module -e` and imported `createQaBusState`, `createQaChannelTransport`, `startQaBusServer`, `startQaGatewayChild`, and `startQaMockOpenAiServer` from `extensions/qa-lab/api.ts`. It set the existing `models.providers.mock-openai.timeoutSeconds=2` configuration, disabled model fallbacks, injected the existing `Provider HTTP 503 after tool QA check: read QA_KICKOFF_TASK.md, then reply.` fixture through the real channel bus, and used a local HTTP proxy to forward the first provider request while holding the second `function_call_output` request until the actual idle watchdog closed its connection.
- Evidence after fix: The provider planned and executed **one real read**, received **two provider requests**, had its post-tool HTTP request closed by the real timeout owner, and the actual `qa-channel` bus recorded **exactly one** authoritative timeout reply. An additional **3.5-second quiet window** confirmed no duplicate delivery.
- Observed result after fix: The delivered message explained that the model exceeded its idle timeout and included the existing actionable provider/agent-timeout guidance.
- What was not tested: No external authenticated provider or live third-party channel was contacted. The proof uses the repository-approved actual ephemeral Gateway + mock provider + mock channel API path, not an external-service claim.

```json
{
  "schema": "openclaw.pr-real-behavior-proof/v1",
  "result": "pass",
  "target": {
    "repository": "openclaw/openclaw",
    "pullRequest": 122036,
    "immutableHead": "07b19fff980894cb30377ab3faf968c7491c368b"
  },
  "environment": {
    "gateway": "isolated-ephemeral-child",
    "provider": "real-loopback-http-mock-openai-with-post-tool-stall",
    "channel": "real-qa-channel-http-bus"
  },
  "productionBoundary": [
    "physical qa-channel inbound HTTP bus",
    "isolated real Gateway child",
    "real loopback mock OpenAI provider HTTP request",
    "actual read tool execution",
    "real post-tool provider HTTP request and idle watchdog abort",
    "assistant error formatter and payload producer",
    "terminal preparation and timeout finalization",
    "shared reply dispatcher",
    "physical qa-channel outbound HTTP bus"
  ],
  "observed": {
    "providerRequestCount": 2,
    "plannedReadCount": 1,
    "postToolRequestsHeld": 1,
    "postToolClientClosed": 1,
    "visibleFinalCount": 1,
    "quietWindowMs": 3500,
    "providerTimeoutSeconds": 2,
    "nonCanonicalRawTimeoutPhysicalSends": 1,
    "canonicalRawTimeoutPhysicalSends": 1,
    "independentSameTextAndMediaPhysicalSends": 2,
    "toolMediaPreserved": true,
    "codexIncompleteTurnFallbackSafe": false,
    "failedSends": { "tool": 0, "block": 0, "final": 0 }
  },
  "redaction": {
    "containsCredentials": false,
    "containsLocalPaths": false,
    "containsSessionIdentifiers": false
  }
}
```

Fixes #119715. Original contributor and primary commit author: @Alix-007.
