### PR TITLE
fix(agents): fall back from tool search code under Electron

### DIFF
--- a/src/agents/tool-search-config.ts
+++ b/src/agents/tool-search-config.ts
@@ -37,7 +37,12 @@ export function isToolSearchCodeModeSupported(): boolean {
   if (toolSearchCodeModeSupportedForTest !== undefined) {
     return toolSearchCodeModeSupportedForTest;
   }
-  return process.allowedNodeEnvironmentFlags.has("--permission");
+  // Electron advertises Node flags but process.execPath remains the host binary,
+  // so the isolated code child cannot be launched as a plain Node process.
+  return (
+    typeof process.versions.electron !== "string" &&
+    process.allowedNodeEnvironmentFlags.has("--permission")
+  );
 }
 
 function resolveMinCodeTimeoutMs(): number {

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -1127,6 +1127,25 @@ describe("Tool Search", () => {
     }
   });
 
+  it("falls back to structured controls under Electron without changing Node mode", () => {
+    const electronDescriptor = Object.getOwnPropertyDescriptor(process.versions, "electron");
+    Object.defineProperty(process.versions, "electron", {
+      configurable: true,
+      value: "99.0.0",
+    });
+    try {
+      expect(resolveToolSearchConfig({ tools: { toolSearch: true } } as never).mode).toBe("tools");
+    } finally {
+      if (electronDescriptor) {
+        Object.defineProperty(process.versions, "electron", electronDescriptor);
+      } else {
+        delete (process.versions as NodeJS.ProcessVersions & { electron?: string }).electron;
+      }
+    }
+
+    expect(resolveToolSearchConfig({ tools: { toolSearch: true } } as never).mode).toBe("code");
+  });
+
   it("guides structured control tools toward compact catalog calls", () => {
     const tools = createToolSearchTools({ config: {} as never });
     const byName = new Map(tools.map((tool) => [tool.name, tool]));


### PR DESCRIPTION
## Summary

- detect Electron-hosted runtimes before selecting tool-search code mode
- use the existing structured-tools fallback under Electron
- preserve code mode for ordinary Node runtimes that support permission flags

## What Problem This Solves

The capability check treated support for Node's `--permission` flag as sufficient for launching the isolated tool-search code child. The launcher uses `process.execPath`, however, so an Electron-hosted process attempts to launch the Electron executable rather than a plain Node child.

This is fixed at the existing tool-search configuration owner. Electron exposes `process.versions.electron`, and Node defines `process.execPath` as the executable that started the process. The normal structured-tools fallback already exists, so no alternate child-launch path, environment override, config, or compatibility shim is added.

Dependency contracts:

- https://www.electronjs.org/docs/latest/api/process#processversionselectron-readonly
- https://nodejs.org/api/process.html#processexecpath

## Evidence

- Exact head: `5a6a5359a5a2cbef45b42c6a8b72ea3aedb83f3a`.
- Sanitized AWS focused proof: [run `run_73140575c15c`](https://crabbox.openclaw.ai/portal/runs/run_73140575c15c) passed `src/agents/tool-search.test.ts` (131/131) and `src/agents/tool-surface-plan.test.ts` (25/25), 156/156 total.
- Sanitized AWS actual-host proof: [run `run_46cba0f22c03`](https://crabbox.openclaw.ai/portal/runs/run_46cba0f22c03) checked out the exact head, installed Electron 43.3.0, cleared `DISPLAY`, `WAYLAND_DISPLAY`, and `ELECTRON_RUN_AS_NODE`, and executed the production resolution, catalog, structured-search, and structured-call path from an Electron browser process.
- The actual-host artifact contains the verdict, runtime log, and `SHA256SUMS`. Archive SHA-256: `b352019a2d04b15f1949213a2a4c2b62570871f03b882abb710b404504b27ba5`; verdict SHA-256: `804e14273ee83fb49d4c70f959e14f621b80edaa975bb5c70c325de8cd7c4674`; log SHA-256: `d299c6c104e8afe4246db0c7b7ec2d8efa7a1bcbdd69674cabf9782aa061a606`.
- Exact-head GitHub CI passed, including `openclaw/ci-gate`.
- Local autoreview found no actionable issues.

Machine-readable verdict:

```json
{"schemaVersion":1,"verdict":"pass","targetSha":"5a6a5359a5a2cbef45b42c6a8b72ea3aedb83f3a","boundary":["actual-electron-main-process","production-tool-search-config-resolution","production-tool-search-catalog-compaction","production-structured-search-control","production-structured-call-control"],"runtime":{"electron":"43.3.0","node":"24.18.1","processType":"browser","defaultApp":true,"execPathSha256":"d3f141ac6c8aed896065c6a87b4952b2fa9c0520c84063499babfc7b464929aa"},"assertions":{"actualElectronRuntime":true,"actualElectronBrowserProcess":true,"defaultCodeRequestFellBackToTools":true,"codeControlHidden":true,"structuredSearchVisible":true,"structuredDescribeVisible":true,"structuredCallVisible":true,"structuredSearchReturnedAuthorizedTarget":true,"structuredCallExecutedAuthorizedTargetOnce":true,"structuredCallResultObserved":true},"observations":{"resolvedMode":"tools","visibleControls":["tool_call","tool_describe","tool_search"],"catalogToolCount":1,"targetCalls":1},"redaction":{"credentialsIncluded":false,"filesystemPathsIncluded":false,"toolPayloadIncluded":false}}
```

Production delta: +6/-1. Test delta: +19/-0. The production growth is the platform/runtime capability invariant and its inline rationale.

Punchcard-Session: ember-cedar-willow-tp

Fixes #121927
