### PR TITLE
fix(acp): avoid resending described images

### DIFF
--- a/src/auto-reply/reply/agent-turn-attachments.ts
+++ b/src/auto-reply/reply/agent-turn-attachments.ts
@@ -41,6 +41,15 @@ function hasInboundHistoryMedia(ctx: MsgContext): boolean {
   );
 }
 
+/** Current-turn image indexes already represented by media-understanding text. */
+export function collectDescribedImageAttachmentIndexes(ctx: MsgContext): Set<number> {
+  return new Set(
+    ctx.MediaUnderstanding?.filter((output) => output.kind === "image.description").map(
+      (output) => output.attachmentIndex,
+    ) ?? [],
+  );
+}
+
 /** Resolves image attachments for the current agent turn and recent image history. */
 export async function resolveAgentTurnAttachments(params: {
   ctx: MsgContext;
@@ -141,16 +150,21 @@ export async function resolveAgentTurnAttachments(params: {
     }
   };
 
+  const describedImageIndexes = collectDescribedImageAttachmentIndexes(params.ctx);
   let currentImageResolved = false;
-  const hasCurrentMedia = currentAttachments.length > 0;
   const hasCurrentImageCandidate = currentAttachments.some(runtime.isImageAttachment);
   for (const attachment of currentAttachments) {
+    if (describedImageIndexes.has(attachment.index) && runtime.isImageAttachment(attachment)) {
+      // A described image satisfies this turn without rehydrating it or reviving image history.
+      currentImageResolved = true;
+      continue;
+    }
     currentImageResolved = (await resolveImageAttachment(attachment)) || currentImageResolved;
   }
   if (
     includeRecentHistoryImages &&
     !currentImageResolved &&
-    (!hasCurrentMedia || hasCurrentImageCandidate)
+    (currentAttachments.length === 0 || hasCurrentImageCandidate)
   ) {
     // History images are only used when the current turn did not already provide an image.
     for (const attachment of historyAttachments) {

--- a/src/auto-reply/reply/current-turn-images.test.ts
+++ b/src/auto-reply/reply/current-turn-images.test.ts
@@ -397,7 +397,7 @@ describe("resolveCurrentTurnImages", () => {
     const imageData = Buffer.from("second image").toString("base64");
     vi.mocked(resolveAgentTurnAttachments).mockResolvedValueOnce({
       attachments: [{ data: imageData, mediaType: "image/png" }],
-      attachmentIndexes: [0],
+      attachmentIndexes: [1],
       recentHistoryImages: [],
     });
 
@@ -407,9 +407,7 @@ describe("resolveCurrentTurnImages", () => {
     });
 
     expect(resolveAgentTurnAttachments).toHaveBeenCalledWith({
-      ctx: expect.objectContaining({
-        media: [expect.objectContaining({ path: "/tmp/second.png", kind: "image" })],
-      }),
+      ctx: createDescribedImageContext([0]),
       cfg: {},
       includeRecentHistoryImages: false,
       includeAttachmentIndexes: true,
@@ -499,7 +497,7 @@ describe("resolveCurrentTurnImages", () => {
     });
   });
 
-  it("retains resolved native images when current media partially resolves", async () => {
+  it("retains undescribed native images when a described sibling and missing sibling coexist", async () => {
     await withTestDir({ prefix: "openclaw-current-turn-partial-" }, async (base) => {
       const imagePath = path.join(base, "present.png");
       const imageBytes = Buffer.from("present-image");
@@ -509,11 +507,24 @@ describe("resolveCurrentTurnImages", () => {
         ctx: {
           Body: "compare these images",
           media: [
+            {
+              path: path.join(base, "described.png"),
+              contentType: "image/png",
+              workspaceDir: base,
+            },
             { path: imagePath, contentType: "image/png", workspaceDir: base },
             {
               path: path.join(base, "missing.png"),
               contentType: "image/png",
               workspaceDir: base,
+            },
+          ],
+          MediaUnderstanding: [
+            {
+              kind: "image.description",
+              attachmentIndex: 0,
+              provider: "imageModel",
+              text: "an already described image",
             },
           ],
         } satisfies MsgContext,
@@ -528,8 +539,8 @@ describe("resolveCurrentTurnImages", () => {
         },
       ]);
       expect(result.imageOrder).toEqual(["inline"]);
-      expect(result.imageSourceIndexes).toEqual([0]);
-      expect(result.unresolvedSourceIndexes).toEqual([1]);
+      expect(result.imageSourceIndexes).toEqual([1]);
+      expect(result.unresolvedSourceIndexes).toEqual([2]);
     });
   });
 

--- a/src/auto-reply/reply/current-turn-images.ts
+++ b/src/auto-reply/reply/current-turn-images.ts
@@ -16,7 +16,10 @@ import {
 import type { MediaAttachment } from "../../media-understanding/types.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import type { RuntimeMsgContext as MsgContext } from "../templating.js";
-import { resolveAgentTurnAttachments } from "./agent-turn-attachments.js";
+import {
+  collectDescribedImageAttachmentIndexes,
+  resolveAgentTurnAttachments,
+} from "./agent-turn-attachments.js";
 
 type CurrentImageAttachment = MediaAttachment & { path: string };
 
@@ -41,30 +44,6 @@ function collectCurrentImageAttachments(ctx: MsgContext): CurrentImageAttachment
     const mediaPath = normalizeOptionalString(attachment.path);
     return mediaPath && isImageAttachment(attachment) ? [{ ...attachment, path: mediaPath }] : [];
   });
-}
-
-function collectDescribedImageAttachmentIndexes(ctx: MsgContext): Set<number> {
-  return new Set(
-    ctx.MediaUnderstanding?.filter((output) => output.kind === "image.description").map(
-      (output) => output.attachmentIndex,
-    ) ?? [],
-  );
-}
-
-function createUndescribedImageContext(
-  ctx: MsgContext,
-  undescribedAttachments: CurrentImageAttachment[],
-): MsgContext {
-  const media = undescribedAttachments.map((attachment) => ({
-    path: attachment.path,
-    contentType: attachment.mime,
-    kind: attachment.kind,
-    workspaceDir: attachment.workspaceDir,
-  }));
-  return {
-    ...ctx,
-    media,
-  };
 }
 
 function appendOrderedImages(params: {
@@ -117,9 +96,6 @@ function resolveMergedTurnImages(entries: OrderedTurnImage[]): {
     if (left.sourceIndex !== undefined && right.sourceIndex !== undefined) {
       return left.sourceIndex - right.sourceIndex || left.sequence - right.sequence;
     }
-    if (left.sourceIndex !== undefined || right.sourceIndex !== undefined) {
-      return left.sequence - right.sequence;
-    }
     return left.sequence - right.sequence;
   });
   const images = merged.flatMap((entry) => (entry.image ? [entry.image] : []));
@@ -170,7 +146,7 @@ export async function resolveCurrentTurnImages(params: {
   try {
     // Only send undescribed current images natively; described images already exist as text context.
     const resolved = await resolveAgentTurnAttachments({
-      ctx: createUndescribedImageContext(params.ctx, undescribedImageAttachments),
+      ctx: params.ctx,
       cfg: params.cfg,
       includeRecentHistoryImages: false,
       includeAttachmentIndexes: true,
@@ -192,8 +168,8 @@ export async function resolveCurrentTurnImages(params: {
       resolvedIndexes.map((resolvedIndex, imageIndex) => [resolvedIndex, images[imageIndex]]),
     );
     const unresolvedSourceIndexes: number[] = [];
-    for (const [subsetIndex, attachment] of undescribedImageAttachments.entries()) {
-      const image = imageByResolvedIndex.get(subsetIndex);
+    for (const attachment of undescribedImageAttachments) {
+      const image = imageByResolvedIndex.get(attachment.index);
       if (image) {
         appendOrderedImages({
           entries,

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -1888,7 +1888,10 @@ describe("tryDispatchAcpReplyCore", () => {
     expect(normalizeAttachments).not.toHaveBeenCalled();
   });
 
-  it("does not inject recent history images when the current turn already has an image", async () => {
+  it.each([
+    { name: "resolved", described: false, expectedAttachments: 1 },
+    { name: "already described", described: true, expectedAttachments: 0 },
+  ])("does not inject recent image history when the current image is $name", async (testCase) => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "dispatch-acp-current-"));
     const currentPath = path.join(tempDir, "current.png");
     const historyPath = path.join(tempDir, "history.png");
@@ -1901,6 +1904,18 @@ describe("tryDispatchAcpReplyCore", () => {
           Provider: "discord",
           Surface: "discord",
           media: [{ path: currentPath, contentType: "image/png" }],
+          ...(testCase.described
+            ? {
+                MediaUnderstanding: [
+                  {
+                    kind: "image.description",
+                    attachmentIndex: 0,
+                    text: "An already described current image.",
+                    provider: "imageModel",
+                  },
+                ],
+              }
+            : {}),
           Timestamp: 1_700_000_000_000,
           InboundHistory: [
             {
@@ -1932,7 +1947,7 @@ describe("tryDispatchAcpReplyCore", () => {
         },
       });
 
-      expect(result.attachments).toHaveLength(1);
+      expect(result.attachments).toHaveLength(testCase.expectedAttachments);
       expect(result.recentHistoryImages).toEqual([]);
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
@@ -2547,6 +2562,111 @@ describe("tryDispatchAcpReplyCore", () => {
         data: pdfPage.data,
       },
     ]);
+  });
+
+  it("omits described images while retaining first-read undescribed attachment bytes", async () => {
+    setReadyAcpResolution();
+    const describedPath = "/tmp/openclaw-described-current.png";
+    const undescribedPath = "/tmp/openclaw-undescribed-current.jpg";
+    const pdfPage = {
+      type: "image" as const,
+      mimeType: "image/png",
+      data: Buffer.from("pdf-page").toString("base64"),
+      attachmentIndex: 2,
+    };
+    acpAttachmentBuffers.set(describedPath, ACP_PNG_IMAGE_BYTES);
+    acpAttachmentBuffers.set(undescribedPath, ACP_JPEG_IMAGE_BYTES);
+    mediaUnderstandingMocks.applyMediaUnderstanding.mockImplementationOnce(async (params) => {
+      const ctx = (params as { ctx: { MediaUnderstanding?: unknown[] } }).ctx;
+      const description = {
+        kind: "image.description" as const,
+        attachmentIndex: 0,
+        text: "A described image.",
+        provider: "imageModel",
+      };
+      ctx.MediaUnderstanding = [description];
+      acpAttachmentBuffers.delete(undescribedPath);
+      return {
+        outputs: [description],
+        decisions: [],
+        extractedFileImages: [pdfPage],
+        appliedImage: true,
+        appliedAudio: false,
+        appliedVideo: false,
+        appliedFile: true,
+      };
+    });
+
+    await runDispatch({
+      bodyForAgent: "compare described, undescribed, and extracted images",
+      ctxOverrides: {
+        media: [
+          { path: describedPath, contentType: "image/png", kind: "image" },
+          { path: undescribedPath, contentType: "image/jpeg", kind: "image" },
+        ],
+      },
+    });
+
+    expect(runTurnCall().attachments).toEqual([
+      { mediaType: "image/jpeg", data: ACP_JPEG_IMAGE_BYTES.toString("base64") },
+      { mediaType: "image/png", data: pdfPage.data },
+    ]);
+  });
+
+  it.each([
+    { name: "resolved", currentBytes: ACP_PNG_IMAGE_BYTES, deliveredIndexes: [0] },
+    { name: "unreadable", currentBytes: undefined, deliveredIndexes: [1] },
+  ])("drops recent image history after a $name current image is described", async (testCase) => {
+    setReadyAcpResolution();
+    const currentPath = "/tmp/openclaw-described-history-current.png";
+    const historyPath = "/tmp/openclaw-described-history-previous.jpg";
+    if (testCase.currentBytes) {
+      acpAttachmentBuffers.set(currentPath, testCase.currentBytes);
+    }
+    acpAttachmentBuffers.set(historyPath, ACP_JPEG_IMAGE_BYTES);
+    mediaUnderstandingMocks.applyMediaUnderstanding.mockImplementationOnce(async (params) => {
+      const ctx = (params as { ctx: { MediaUnderstanding?: unknown[]; agentText: string } }).ctx;
+      const description = {
+        kind: "image.description" as const,
+        attachmentIndex: 0,
+        text: "The current image was already described.",
+        provider: "imageModel",
+      };
+      ctx.MediaUnderstanding = [description];
+      ctx.agentText = `${ctx.agentText}\n\n[Image 1]\n${description.text}`;
+      return {
+        outputs: [description],
+        decisions: [],
+        extractedFileImages: [],
+        appliedImage: true,
+        appliedAudio: false,
+        appliedVideo: false,
+        appliedFile: false,
+      };
+    });
+
+    await runDispatch({
+      bodyForAgent: "describe the current image",
+      ctxOverrides: {
+        Timestamp: 1_700_000_060_000,
+        media: [{ path: currentPath, contentType: "image/png", kind: "image" }],
+        InboundHistory: [
+          {
+            sender: "@alice",
+            body: "<media:image>",
+            timestamp: 1_700_000_000_000,
+            media: [{ path: historyPath, contentType: "image/jpeg", kind: "image" }],
+          },
+        ],
+      },
+    });
+
+    expect(mediaUnderstandingMocks.applyMediaUnderstanding).toHaveBeenCalledWith(
+      expect.objectContaining({ deliveredImageIndexes: new Set(testCase.deliveredIndexes) }),
+    );
+    expect(runTurnCall().text).toContain("The current image was already described.");
+    expect(runTurnCall().text).not.toContain("Recent image 1");
+    expect(runTurnCall().attachments).toBeUndefined();
   });
 
   it("preserves chat.send inline image attachments over recent history images", async () => {

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -53,6 +53,7 @@ import type { FinalizedRuntimeMsgContext } from "../templating.js";
 import { createLazyAcpElicitationHandler } from "./acp-elicitation-handler-lazy.js";
 import { createAcpReplyProjector } from "./acp-projector.js";
 import {
+  collectDescribedImageAttachmentIndexes,
   loadAgentTurnMediaRuntime,
   resolveAgentTurnAttachments,
   resolveInlineAgentImageAttachments,
@@ -99,9 +100,6 @@ function resolveMergedAcpAttachments(entries: OrderedAcpAttachment[]): AcpTurnAt
     .toSorted((left, right) => {
       if (left.sourceIndex !== undefined && right.sourceIndex !== undefined) {
         return left.sourceIndex - right.sourceIndex || left.sequence - right.sequence;
-      }
-      if (left.sourceIndex !== undefined || right.sourceIndex !== undefined) {
-        return left.sequence - right.sequence;
       }
       return left.sequence - right.sequence;
     })
@@ -764,8 +762,7 @@ export async function tryDispatchAcpReplyCore(params: {
       auditTerminalOutcome = "blocked";
       throw agentPolicyError;
     }
-    // Resolve turn attachments before media understanding so marker rendering
-    // suppresses exactly the image indexes ACP will deliver with the turn.
+    // Resolve bytes once before understanding so marker accounting shares the same snapshot.
     const resolvedTurnAttachments = await resolveAgentTurnAttachments({
       ctx: params.ctx,
       cfg: params.cfg,
@@ -794,18 +791,31 @@ export async function tryDispatchAcpReplyCore(params: {
     }
 
     const promptText = resolveAcpPromptText(params.ctx);
-    const mediaAttachments = resolvedTurnAttachments.attachments;
+    const describedImageIndexes = collectDescribedImageAttachmentIndexes(params.ctx);
+    const recentHistoryStart =
+      resolvedTurnAttachments.attachments.length -
+      resolvedTurnAttachments.recentHistoryImages.length;
+    const mediaAttachmentEntries = resolvedTurnAttachments.attachments.flatMap(
+      (attachment, index) => {
+        const sourceIndex = resolvedTurnAttachments.attachmentIndexes?.[index];
+        return sourceIndex !== undefined &&
+          !describedImageIndexes.has(sourceIndex) &&
+          (describedImageIndexes.size === 0 || index < recentHistoryStart)
+          ? [{ attachment, sourceIndex }]
+          : [];
+      },
+    );
+    const mediaAttachments = mediaAttachmentEntries.map((entry) => entry.attachment);
+    const recentHistoryImages =
+      describedImageIndexes.size === 0 ? resolvedTurnAttachments.recentHistoryImages : [];
     const inlineAttachments = resolveInlineAgentImageAttachments(params.images);
     const extractedAttachments = resolveInlineAgentImageAttachments(
       extractedFileImages.map(stripExtractedFileImageMetadata),
     );
-    const mediaAttachmentsAreOnlyRecentHistory =
-      mediaAttachments.length > 0 &&
-      mediaAttachments.length === resolvedTurnAttachments.recentHistoryImages.length;
     const useMediaAttachments =
       mediaAttachments.length > 0 &&
       !(
-        mediaAttachmentsAreOnlyRecentHistory &&
+        mediaAttachments.length === recentHistoryImages.length &&
         (inlineAttachments.length > 0 || extractedAttachments.length > 0)
       );
     const attachmentEntries: OrderedAcpAttachment[] = [];
@@ -813,7 +823,7 @@ export async function tryDispatchAcpReplyCore(params: {
       appendOrderedAcpAttachments({
         entries: attachmentEntries,
         attachments: mediaAttachments,
-        sourceIndexes: resolvedTurnAttachments.attachmentIndexes,
+        sourceIndexes: mediaAttachmentEntries.map((entry) => entry.sourceIndex),
       });
     } else {
       appendOrderedAcpAttachments({
@@ -830,7 +840,7 @@ export async function tryDispatchAcpReplyCore(params: {
     const turnPromptText = useMediaAttachments
       ? appendRecentHistoryImageContext({
           promptText,
-          images: resolvedTurnAttachments.recentHistoryImages,
+          images: recentHistoryImages,
         })
       : promptText;
     transcriptPromptText = turnPromptText;

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -1123,7 +1123,7 @@ describe("applyMediaUnderstanding", () => {
     expect(markerCount - 1).toBe(1);
   });
 
-  it("uses CLI image understanding and preserves caption for commands", async () => {
+  it("describes ACP-delivered images and preserves their captions for commands", async () => {
     const imagePath = await createTempMediaFile({
       fileName: "photo.jpg",
       content: "image-bytes",
@@ -1159,6 +1159,7 @@ describe("applyMediaUnderstanding", () => {
     const result = await applyMediaUnderstanding({
       ctx,
       cfg,
+      deliveredImageIndexes: new Set([0]),
     });
 
     expect(result.appliedImage).toBe(true);


### PR DESCRIPTION
## Summary

- move described-current-image filtering into the shared attachment resolver
- resolve ACP attachment bytes exactly once before media understanding, then retain that indexed payload snapshot through dispatch
- zip the retained payloads with their source indexes and filter only described current images after understanding
- drop the retained recent-history suffix whenever understanding describes a current image, so history fallback cannot be revived
- remove the duplicate current-image filtering path

## What Problem This Solves

ACP must resolve current attachments before media understanding so marker rendering knows which image indexes were actually delivered. Re-resolving after understanding is not safe: a second source read can fail and silently lose an undescribed image that the first read already resolved. It can also select recent-history images after all current images become text descriptions.

`dispatch-acp` now retains the first resolver result as the authoritative byte snapshot. After media understanding updates the context, it zips each payload with the resolver's aligned source index and filters described current indexes from that retained snapshot. The resolver appends successful current-turn payloads before history payloads and reports one `recentHistoryImages` entry for each successful history payload, so that count authoritatively identifies the snapshot's history suffix. If any current image is described, both the suffix and its history context are removed.

This preserves first-read bytes, marker accounting, payload/index ordering, and the existing no-history-fallback rule in one ACP owner flow. There is no second source read and no downstream image-content retry.

The branch incorporates current `main` at `84c7d45f15cd2ba093797ac1c4c9fd198a7cf6e3`.

## Evidence

- first-read snapshot retention: an undescribed image source is removed during media understanding, yet ACP dispatch still receives the original resolved bytes
- sole described current image plus recent history: the description remains in the prompt, while both attachment payloads and recent-history context are omitted
- first current-image read fails and history resolves, then media understanding describes the current image: the retained history fallback is removed rather than dispatched
- mixed described PNG, undescribed JPEG, and extracted PDF page: only the JPEG and PDF page are dispatched, in original order
- successful image understanding still preserves `deliveredImageIndexes` for marker accounting

Exact-head focused verification on `1fb50b9d809bf3ba9832ff5ede3a5bb1160ef80d`:

```text
media-understanding shard: 68 passed
auto-reply shard (dispatch-acp + current-turn-images): 131 passed
total: 199 passed
git diff --check: clean
```

Two full reviews were clean: the frozen P1 repair review found no actionable issue (`correct 0.91`), and the post-main-merge full-branch exact-head autoreview found no accepted/actionable finding (`correct 0.87`).

## Real ACP text-only proof

Exact source head: `1fb50b9d809bf3ba9832ff5ede3a5bb1160ef80d`.

An isolated proof exercised the real repaired boundary in order:

```text
tryDispatchAcpReplyCore -> acpManager.runTurn -> AcpxRuntime
```

It supplied one synthetic PNG and one successful indexed media-understanding description. The dispatch-produced prompt and attachment field were passed directly to ACPX with OpenCode using the text-only `opencode/ling-3.0-tiny-free` model.

Redacted terminal/runtime trace:

```json
{
  "head": "1fb50b9d809bf3ba9832ff5ede3a5bb1160ef80d",
  "path": "tryDispatchAcpReplyCore -> acpManager.runTurn -> AcpxRuntime",
  "syntheticInput": {
    "currentImages": 1,
    "successfulImageDescriptions": 1
  },
  "dispatchInput": {
    "promptContainsDescription": true,
    "attachmentsField": "omitted"
  },
  "runtime": {
    "backend": "acpx",
    "agent": "opencode",
    "model": "opencode/ling-3.0-tiny-free"
  },
  "output": {
    "text": "ACP_SNAPSHOT_DESC_7319",
    "terminal": {
      "type": "done",
      "stopReason": "end_turn"
    }
  },
  "redaction": "synthetic fixture only; no credentials, paths, or provider payload logged"
}
```

Proof command result: 1 passed, 106 skipped; proof test runtime 52.927s, total 108.67s. The temporary ACP session/state was closed and deleted, and the proof-only test was removed before the clean commit. This demonstrates that the description reaches the text-only model through `dispatch-acp`, the described image is not resent as image content, and the model turn completes normally.

## Patch Shape and CI

- production: +58/-38 (net +20)
- tests: +216/-1 (net +215)

The production growth carries the owner-boundary snapshot provenance and performs one aligned source-index/history-suffix filter. The old duplicate current-image policy was removed; no new config, fallback, compatibility path, or public surface was added.

The exact-head changed gate completed with exit 0, including core tsgo, core-test tsgo, formatting, type-aware lint, Plugin SDK API baseline, Knip, import-cycle, media, schema, sidecar, database-first, and boundary guards. The remote Crabbox backend was unavailable, so the trusted-source wrapper used its documented local fallback. GitHub CI for this pushed head is pending and is not claimed as green yet.

Fixes #102135
