### PR TITLE
fix(update): migrate plugin config before final validation

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -2410,6 +2410,32 @@ describe("update-cli", () => {
     expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
   });
 
+  it("runs the final fresh doctor for convergence-only current-process changes", async () => {
+    mockGitUpdateAfterMutation();
+    vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(FRESH_POST_UPDATE_ENTRYPOINT);
+    runPostCorePluginConvergenceSpy.mockResolvedValueOnce({
+      changes: ["Repaired configured plugin install records."],
+      warnings: [],
+      errored: false,
+      smokeFailures: [],
+      installRecords: {},
+    });
+
+    await updateCommand({ yes: true, restart: false });
+
+    expect(spawn).not.toHaveBeenCalled();
+    const doctorCall = vi.mocked(runExec).mock.calls.find(([, args]) => args[1] === "doctor");
+    expect(doctorCall?.[2]).toMatchObject({
+      env: { OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1" },
+    });
+    const strictValidationCall = vi
+      .mocked(runExec)
+      .mock.calls.find(([, args]) => args[1] === "config" && args[2] === "validate");
+    expect(strictValidationCall?.[2]).toMatchObject({
+      env: { OPENCLAW_UPDATE_IN_PROGRESS: "0" },
+    });
+  });
+
   it("runs the fresh plugin doctor with the selected Node runner", async () => {
     vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(
       "/tmp/openclaw-updated-entry.mjs",

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -2547,6 +2547,39 @@ describe("update-cli", () => {
     expect(spawn).not.toHaveBeenCalled();
   });
 
+  it("stages plugin-changing post-core config before updated plugin migrations run", async () => {
+    syncPluginsForUpdateChannel.mockImplementationOnce(async ({ config }) =>
+      pluginSyncResult(config, true),
+    );
+
+    await runPostCoreCommand({ restart: false });
+
+    expect(lastReplaceConfigCall()).toMatchObject({
+      writeOptions: { skipPluginValidation: true },
+    });
+  });
+
+  it("runs the final fresh doctor for convergence-only post-core changes", async () => {
+    vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(FRESH_POST_UPDATE_ENTRYPOINT);
+    runPostCorePluginConvergenceSpy.mockResolvedValueOnce({
+      changes: ["Repaired configured plugin install records."],
+      warnings: [],
+      errored: false,
+      smokeFailures: [],
+      installRecords: {},
+    });
+
+    await runPostCoreCommand({ restart: false });
+
+    expect(syncPluginCall()?.config).toBeDefined();
+    expect(updateNpmInstalledPlugins).toHaveBeenCalledTimes(1);
+    const doctorCalls = vi.mocked(runExec).mock.calls.filter(([, args]) => args[1] === "doctor");
+    expect(doctorCalls).toHaveLength(2);
+    expect(doctorCalls[1]?.[2]).toMatchObject({
+      env: { OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1" },
+    });
+  });
+
   it("keeps fresh doctor output off stdout during json post-core resume", async () => {
     vi.mocked(runExec).mockResolvedValueOnce({
       stdout: "doctor ui output",

--- a/src/cli/update-cli/update-command-plugins.ts
+++ b/src/cli/update-cli/update-command-plugins.ts
@@ -476,11 +476,14 @@ export async function updatePluginsAfterCoreUpdate(params: {
         channels: structuredClone(params.restoredAuthoredChannels) as OpenClawConfig["channels"],
       };
     }
+    // Installed plugin metadata can own migrations that this process has not loaded yet.
+    // Finalization runs fresh doctor plus strict validation before the update can complete.
     await commitPluginInstallRecordsWithConfig({
       previousInstallRecords: pluginInstallRecords,
       nextInstallRecords,
       nextConfig,
       baseHash: params.configSnapshot.hash,
+      writeOptions: { skipPluginValidation: true },
     });
     await refreshPluginRegistryAfterConfigMutation({
       config: nextConfig,

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -288,12 +288,9 @@ export async function finishUpdate(params: {
           const completedPluginUpdate = await completePostCorePluginUpdate({
             root: postUpdateRoot,
             pluginUpdate: initialPluginUpdate,
-            // A plugin-only update can replace its migration owner without replacing core.
-            // Downgrades and resume fallbacks can also leave an updated core on disk in this process.
+            // Aggregate plugin changes and core install changes independently require fresh doctor.
             freshDoctorRequired:
-              didCoreUpdateChangeInstall(params.result) ||
-              initialPluginUpdate.sync.changed ||
-              initialPluginUpdate.npm.changed,
+              didCoreUpdateChangeInstall(params.result) || initialPluginUpdate.changed,
             yes: params.opts.yes === true,
             json: params.opts.json === true,
             timeoutMs: params.updateStepTimeoutMs,

--- a/src/cli/update-cli/update-command-resume.ts
+++ b/src/cli/update-cli/update-command-resume.ts
@@ -127,8 +127,7 @@ async function resumePostCoreUpdateUnlocked(params: ResumePostCoreUpdateParams):
   const { pluginUpdate } = await completePostCorePluginUpdate({
     root: params.root,
     pluginUpdate: initialPluginUpdate,
-    // Only package/channel sync can replace the migration owner loaded by this process.
-    freshDoctorRequired: initialPluginUpdate.sync.changed || initialPluginUpdate.npm.changed,
+    freshDoctorRequired: initialPluginUpdate.changed,
     yes: params.opts.yes === true,
     json: params.opts.json === true,
     timeoutMs: params.timeoutMs,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a release upgrade that installs an updated configured plugin could fail before that plugin's fresh doctor migration had a chance to update legacy configuration. The first package-validation attempt exposed a duplicate plugin-install transaction; after the prior signed repair removed that collision, the rerun exposed this second boundary: plugin convergence installed the new schema owner, then an intermediate config write rejected stale plugin-owned fields before final doctor could migrate them.

Resume also treated only package updates as a reason to run the final doctor, so convergence-only install-record or config changes could skip the required final migration and validation pass.

## Why This Change Was Made

Plugin sync now installs updated schema owners once, then persists its intermediate install records and configuration through the established staged-write seam without plugin-schema validation. That write is deliberately temporary: update completion and restart remain gated on a mandatory fresh doctor that loads the installed plugin, runs its migration, and strictly validates the resulting configuration.

Resume now uses the aggregate plugin-update `changed` result, matching finalization, so convergence-only changes also trigger that fresh final doctor. The repair keeps validation strict at the completion boundary and does not add a fallback or relax the final gate.

## User Impact

Operators can complete upgrades across configured-plugin schema changes without the updater rejecting legacy plugin configuration before the owning plugin can migrate it. If migration or strict validation still fails, the update remains failed and does not complete or restart.

## Evidence

- Failed package boundary: parent run 31489405069 / child run 31490445357. The first observed failure was the duplicate plugin-install transaction fixed by the prior signed candidate; its rerun advanced to and exposed the stale-config intermediate-write failure repaired here.
- Two focused regression tests fail on signed base `5fe03188cc42e6696c86c66e5839b40f1b7a051a` for the intended reasons and pass with this repair: the staged config write requires plugin-validation deferral, and a convergence-only change requires both pre- and post-plugin doctor passes.
- 385 focused tests pass across updater, update phase, missing-configured-plugin, install-record, and config-writer coverage, including the existing final strict-validation failure case.
- Blacksmith Testbox `tbx_01kzre65tg3n9xj2fv20ty2p0a`: path-scoped `check:changed`, core/core-test tsgo, targeted oxlint, formatting, and guards passed; the Testbox was stopped and confirmed completed.
- OpenGrep: 108 rules against the exact three-file repair, zero findings.
- Manual Docker `upgrade-survivor` scenario passes the stale-config barrier and reaches the mandatory final doctor. It then fails closed because unpublished `@openclaw/discord@2026.8.1-beta.2` is unavailable outside the signed prepublish fixture, so the plugin-owned migration cannot run and strict validation remains fatal.
- Repair delta: production +4/-2; tests +33/-0. Total train delta from integration ancestor `f658c09a0591fa308f16a945e2850dff669dea99`: production +26/-11; tests +53/-5.
- Autoreview and secret scan are clean. No changelog, release metadata, workflow, or harness changes are included.

The remaining package-boundary proof is an exact signed-SHA rerun with the candidate external plugin artifacts available in the prepublish registry.
