### PR TITLE
fix(ci): isolate gateway kernel plugin registry state

### DIFF
--- a/src/gateway/server-kernel.test.ts
+++ b/src/gateway/server-kernel.test.ts
@@ -1,10 +1,11 @@
 import fs from "node:fs/promises";
 import { describe, expect, it, vi } from "vitest";
+import { createPluginRecord } from "../plugins/loader-records.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import {
   captureActivePluginRegistrySnapshot,
   restoreActivePluginRegistrySnapshot,
-  setActivePluginRegistry,
+  stageActivePluginRegistry,
 } from "../plugins/runtime.js";
 import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
 import { getActiveSecretsRuntimeConfigSnapshot } from "../secrets/runtime-state.js";
@@ -37,23 +38,46 @@ describe("createGatewayKernel", () => {
         VITEST: "1",
       },
     });
-    const activePluginRegistry = captureActivePluginRegistrySnapshot();
+    const originalPluginRegistry = captureActivePluginRegistrySnapshot();
     const inspectAccount = vi.fn(() => ({ enabled: true, configured: true }));
+    const capturedRegistryCleanup = vi.fn();
     const ambientPlugin = createChannelTestPluginBase({
       id: "telegram",
       config: { inspectAccount },
     });
+    const ambientRegistry = createTestRegistry([
+      {
+        pluginId: ambientPlugin.id,
+        plugin: ambientPlugin,
+        source: "gateway-kernel-test",
+      },
+    ]);
+    ambientRegistry.plugins.push(
+      createPluginRecord({
+        id: ambientPlugin.id,
+        source: "gateway-kernel-test",
+        origin: "bundled",
+        enabled: true,
+        configSchema: false,
+      }),
+    );
+    ambientRegistry.runtimeLifecycles.push({
+      pluginId: ambientPlugin.id,
+      pluginName: ambientPlugin.meta.label,
+      lifecycle: {
+        id: "gateway-kernel-test-cleanup",
+        cleanup: capturedRegistryCleanup,
+      },
+      source: "gateway-kernel-test",
+    });
+    let capturedLoadedPluginRegistry:
+      | ReturnType<typeof captureActivePluginRegistrySnapshot>
+      | undefined;
+    let prematureCleanupCalls: number | undefined;
     let kernel: Awaited<ReturnType<typeof createGatewayKernel>> | undefined;
     try {
-      setActivePluginRegistry(
-        createTestRegistry([
-          {
-            pluginId: ambientPlugin.id,
-            plugin: ambientPlugin,
-            source: "gateway-kernel-test",
-          },
-        ]),
-      );
+      stageActivePluginRegistry(ambientRegistry, null, "default");
+      capturedLoadedPluginRegistry = captureActivePluginRegistrySnapshot();
       const timelinePath = state.path("kernel-startup.jsonl");
       state.envVars.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH = timelinePath;
       const token = "gateway-kernel-no-transport-token";
@@ -65,7 +89,7 @@ describe("createGatewayKernel", () => {
         },
       });
       state.applyEnv();
-      setActivePluginRegistry(createEmptyPluginRegistry());
+      stageActivePluginRegistry(createEmptyPluginRegistry(), null, "default");
 
       kernel = await createGatewayKernel(port, {
         auth: { mode: "token", token },
@@ -164,10 +188,16 @@ describe("createGatewayKernel", () => {
         try {
           await state.cleanup();
         } finally {
-          restoreActivePluginRegistrySnapshot(activePluginRegistry);
+          if (capturedLoadedPluginRegistry) {
+            restoreActivePluginRegistrySnapshot(capturedLoadedPluginRegistry);
+          }
+          prematureCleanupCalls = capturedRegistryCleanup.mock.calls.length;
+          restoreActivePluginRegistrySnapshot(originalPluginRegistry);
         }
       }
     }
+    expect(prematureCleanupCalls).toBe(0);
+    await vi.waitFor(() => expect(capturedRegistryCleanup).toHaveBeenCalledOnce());
     expect(inspectAccount).not.toHaveBeenCalled();
   });
 

--- a/src/gateway/server-kernel.test.ts
+++ b/src/gateway/server-kernel.test.ts
@@ -1,7 +1,14 @@
 import fs from "node:fs/promises";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import {
+  captureActivePluginRegistrySnapshot,
+  restoreActivePluginRegistrySnapshot,
+  setActivePluginRegistry,
+} from "../plugins/runtime.js";
 import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
 import { getActiveSecretsRuntimeConfigSnapshot } from "../secrets/runtime-state.js";
+import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { getFreePort } from "../test-utils/ports.js";
 import { CLI_DEFAULT_OPERATOR_SCOPES } from "./method-scopes.js";
@@ -30,25 +37,42 @@ describe("createGatewayKernel", () => {
         VITEST: "1",
       },
     });
-    const timelinePath = state.path("kernel-startup.jsonl");
-    state.envVars.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH = timelinePath;
-    const token = "gateway-kernel-no-transport-token";
-    await state.writeConfig({
-      gateway: {
-        auth: { mode: "token", token },
-        controlUi: { enabled: false },
-        port,
-      },
+    const activePluginRegistry = captureActivePluginRegistrySnapshot();
+    const inspectAccount = vi.fn(() => ({ enabled: true, configured: true }));
+    const ambientPlugin = createChannelTestPluginBase({
+      id: "telegram",
+      config: { inspectAccount },
     });
-    state.applyEnv();
-
-    const kernel = await createGatewayKernel(port, {
-      auth: { mode: "token", token },
-      bind: "loopback",
-      controlUiEnabled: false,
-      sidecarStartup: "defer",
-    });
+    let kernel: Awaited<ReturnType<typeof createGatewayKernel>> | undefined;
     try {
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: ambientPlugin.id,
+            plugin: ambientPlugin,
+            source: "gateway-kernel-test",
+          },
+        ]),
+      );
+      const timelinePath = state.path("kernel-startup.jsonl");
+      state.envVars.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH = timelinePath;
+      const token = "gateway-kernel-no-transport-token";
+      await state.writeConfig({
+        gateway: {
+          auth: { mode: "token", token },
+          controlUi: { enabled: false },
+          port,
+        },
+      });
+      state.applyEnv();
+      setActivePluginRegistry(createEmptyPluginRegistry());
+
+      kernel = await createGatewayKernel(port, {
+        auth: { mode: "token", token },
+        bind: "loopback",
+        controlUiEnabled: false,
+        sidecarStartup: "defer",
+      });
       expect(kernel.transportBridge.current()).toBeUndefined();
       await expect(kernel.ensureSandboxHostPort()).rejects.toThrow(
         "Gateway listener must start before the sandbox host",
@@ -134,9 +158,17 @@ describe("createGatewayKernel", () => {
         "gateway.request-context",
       ]);
     } finally {
-      await kernel.closeOnStartupFailure();
-      await state.cleanup();
+      try {
+        await kernel?.closeOnStartupFailure();
+      } finally {
+        try {
+          await state.cleanup();
+        } finally {
+          restoreActivePluginRegistrySnapshot(activePluginRegistry);
+        }
+      }
     }
+    expect(inspectAccount).not.toHaveBeenCalled();
   });
 
   it("runs kernel teardown when required TLS material is unavailable", async () => {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/actions/runs/31480944303/job/93745715605

## What Problem This Solves

Fixes an issue where the shared Gateway runtime-server CI shard could time out while the socket-free kernel health test inspected ambient plugin registry state left by neighboring tests.

## Why This Change Was Made

The kernel test snapshots the process registry, stages its temporary loaded and empty registries through the canonical no-retire path, closes the kernel before state cleanup, and restores the original snapshot last. The loaded fixture includes account-inspection and lifecycle-cleanup spies, proving kernel startup neither inspects nor prematurely cleans captured neighboring plugin state.

## User Impact

No user-visible runtime change. CI keeps the Gateway kernel regression coverage without loading unrelated plugin account inspectors, cleaning neighboring plugin state, or timing out under shared-process execution.

## Evidence

- Incident: `server-kernel.test.ts` timed out after 120 seconds in `checks-node-agentic-control-plane-runtime-server`.
- Focused exact-head test: `node scripts/run-vitest.mjs src/gateway/server-kernel.test.ts` passed 2 tests.
- Exact-head serialized Blacksmith Testbox: `tbx_01kzrk072h6spbcymcqedh3n2r`, https://github.com/openclaw/openclaw/actions/runs/31500795747
- Exact CI shard result: 35 test files passed, 716 tests passed in 43.06 seconds.
- Target file result: 2 tests passed in 9.58 seconds; the formerly timed-out case completed in 9.40 seconds.
- Scope: test-only change, 81 additions and 19 deletions; production LOC delta is zero.
