### PR TITLE
fix(ui): prioritize active session quota provider

### DIFF
--- a/ui/src/pages/chat/chat-composer-context.test.ts
+++ b/ui/src/pages/chat/chat-composer-context.test.ts
@@ -208,8 +208,17 @@ describe("renderChatComposer context usage", () => {
     expect(container.textContent).not.toContain("Est. cost");
   });
 
-  it("falls back from an unmatched session provider to the response quota group", () => {
-    const container = renderComposer({
+  it("uses response provenance only when the session provider is absent", () => {
+    const session = {
+      key: "main",
+      kind: "direct",
+      updatedAt: null,
+      totalTokens: 1_000,
+      contextTokens: 200_000,
+      model: "gateway-injected",
+      modelProvider: "openclaw" as string | undefined,
+    };
+    const composerProps = {
       messages: [
         { role: "user", content: "hi" },
         {
@@ -221,19 +230,9 @@ describe("renderChatComposer context usage", () => {
         },
       ],
       sessions: {
-        sessions: [
-          {
-            key: "main",
-            kind: "direct",
-            updatedAt: null,
-            totalTokens: 1_000,
-            contextTokens: 200_000,
-            model: "gateway-injected",
-            modelProvider: "openclaw",
-          },
-        ],
+        sessions: [session],
         defaults: { contextTokens: 200_000 },
-      } as never,
+      },
       providerUsage: {
         modelAuthStatusResult: {
           ts: Date.now(),
@@ -261,16 +260,23 @@ describe("renderChatComposer context usage", () => {
           ],
         },
       },
-    });
-
-    expect(
+    };
+    const providerNames = (container: HTMLElement) =>
       [...container.querySelectorAll("[data-chat-usage-provider='true']")].map((row) =>
         row.textContent?.replace(/\s+/g, " ").trim(),
-      ),
-    ).toEqual(["Provider: OpenAI", "Provider: Claude"]);
-    expect(container.textContent).not.toContain("Est. cost");
-    expect(container.textContent).not.toContain("Cost by Type");
+      );
+
+    const container = renderComposer(composerProps as never);
+
+    expect(providerNames(container)).toEqual(["Provider: Claude", "Provider: OpenAI"]);
+    expect(container.textContent).toContain("Cost by Type");
     expect(container.textContent).not.toContain("Model:");
+
+    session.modelProvider = undefined;
+    expect(providerNames(renderComposer(composerProps as never))).toEqual([
+      "Provider: OpenAI",
+      "Provider: Claude",
+    ]);
   });
 
   it("omits the cost-by-type section when every recorded cost is zero", () => {

--- a/ui/src/pages/chat/components/chat-composer-context.ts
+++ b/ui/src/pages/chat/components/chat-composer-context.ts
@@ -120,7 +120,6 @@ function getContextNoticeViewModel(
   input: number | null;
   output: number | null;
   cost: number | null;
-  provider: string | null;
   detail: string;
   color: string;
   bg: string;
@@ -154,7 +153,6 @@ function getContextNoticeViewModel(
     input,
     output,
     cost,
-    provider: session?.modelProvider?.trim() || null,
   };
   if (!warning) {
     return {
@@ -350,7 +348,7 @@ export function renderContextNotice(
         )
       : undefined;
   };
-  const currentGroup = findQuotaGroup(model?.provider) ?? findQuotaGroup(providerCosts?.provider);
+  const currentGroup = findQuotaGroup(session?.modelProvider?.trim() || providerCosts?.provider);
   const planGroups = currentGroup
     ? [currentGroup, ...quotaGroups.filter((group) => group !== currentGroup)]
     : quotaGroups;


### PR DESCRIPTION
## What Problem This Solves

The compact session-status widget could promote quota data from a historical response provider even when the active Gateway session already named a different provider. The fallback used `??` on the result of quota-group lookup, so an authoritative-but-unmatched session provider was treated the same as an absent provider. The duplicated provider field also disappeared whenever context-token metrics were unavailable.

The session row is the owner of the active model provider. This change reads `session.modelProvider` directly and falls back to response provenance only when that field is absent. Existing provider alias matching and quota ordering remain unchanged.

Closes #120557.

## Evidence

- Exact PR head: `9a40272255bfe66f14f23a56524072e8838f1610`.
- Parent red: the focused regression failed 1 of 7 tests because historical OpenAI quota was promoted ahead of an authoritative unmatched active-session provider.
- Node 24.18.1 focused unit proof: `ui/src/pages/chat/chat-composer-context.test.ts` passed 7/7.
- Node 24.18.1 mocked-Gateway Chromium proof: `ui/src/e2e/chat-quota-pill-93041.e2e.test.ts` passed 4/4.
- Immutable real-behavior proof: [run 31520488930](https://github.com/Alix-007/openclaw/actions/runs/31520488930) succeeded against the exact PR head with proof harness `1ff8ab49b51da480b6929b1b26e5b6a735d22fa2`.
- Artifact `9113091092`, `openclaw-chat-quota-runtime-9a40272255bfe66f14f23a56524072e8838f1610`, digest `sha256:764db51ba713764278a61cd2d8ab158c30775a5472cbae088af43f9b85112ecd`.
- The proof used the production Gateway child, real Gateway WebSocket, production session/history/auth-status stores, a controlled loopback model provider, the production-built Control UI, and system Chromium.
- Focused oxlint, oxfmt check, `git diff --check`, and pre-commit autoreview passed; autoreview found no P0/P1 issue.

```json
{
  "schemaVersion": 1,
  "verdict": "pass",
  "targetSha": "9a40272255bfe66f14f23a56524072e8838f1610",
  "runId": 31520488930,
  "artifactId": 9113091092,
  "assertions": {
    "exactHeadVerified": true,
    "realGatewayHealthRpcPassed": true,
    "historicalOpenAiTurnCompleted": true,
    "historicalAssistantProviderObserved": true,
    "activeSessionProviderWasUnmatched": true,
    "realModelsAuthStatusReturnedTwoQuotaGroups": true,
    "browserConnectedOverRealGatewayWebSocket": true,
    "browserPreservedNaturalQuotaOrder": true,
    "historicalProviderWasNotPromoted": true
  },
  "observations": {
    "activeSessionProvider": "proof-active",
    "historicalAssistantProvider": "openai",
    "browserProviderOrder": ["Claude", "openai"],
    "providerUsageFetches": 4
  },
  "redaction": {
    "credentialsIncluded": false,
    "messageContentsIncluded": false,
    "filesystemPathsIncluded": false
  }
}
```## Scope And Risk

- Production: `+1/-3` lines, net `-2`.
- Tests: `+27/-21` lines.
- No config, protocol, dependency, migration, persistence, or public API changes.
- No compatibility path was added; the duplicated provider projection was removed.