### PR TITLE
fix: allow replacement setup after terminal wizard status

### DIFF
--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -10,6 +10,35 @@ import {
 import type { RuntimeEnv } from "../../runtime.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
 import { createWizardSessionTracker } from "../server-wizard-sessions.js";
+
+const setupTargetLock = vi.hoisted(() => ({
+  beforeRelease: undefined as Promise<void> | undefined,
+  releaseReached: undefined as (() => void) | undefined,
+}));
+
+vi.mock("../../infra/file-lock.js", async () => {
+  const actual = await vi.importActual<typeof import("../../infra/file-lock.js")>(
+    "../../infra/file-lock.js",
+  );
+  return {
+    ...actual,
+    withFileLock: async <T>(
+      filePath: string,
+      options: Parameters<typeof actual.acquireFileLock>[1],
+      run: () => Promise<T>,
+    ): Promise<T> => {
+      const lock = await actual.acquireFileLock(filePath, options);
+      try {
+        return await run();
+      } finally {
+        setupTargetLock.releaseReached?.();
+        await setupTargetLock.beforeRelease;
+        await lock.release();
+      }
+    },
+  };
+});
+
 import {
   runExclusiveSystemAgentSetupActivation,
   whenAdmittedWizardSessionSettled,
@@ -353,6 +382,87 @@ describe("wizard setup ownership", () => {
     expect(replacementRespond.mock.calls[0]?.[1]).toMatchObject({ status: "running" });
 
     await cancelWizardSessions(tracker.wizardSessions);
+  });
+
+  it("settles setup admission before returning a terminal wizard status", async () => {
+    const runnerSettled = createDeferred();
+    const releaseSetupTargetLock = createDeferred();
+    const setupTargetLockReleaseReached = createDeferred();
+    setupTargetLock.beforeRelease = releaseSetupTargetLock.promise;
+    setupTargetLock.releaseReached = setupTargetLockReleaseReached.resolve;
+    const tracker = createWizardSessionTracker();
+    const context = {
+      ...tracker,
+      wizardRunner: async (_opts: unknown, _runtime: RuntimeEnv, prompter: WizardPrompter) => {
+        prompter.progress("working");
+        await runnerSettled.promise;
+      },
+    };
+    let admittedSession: import("../../wizard/session.js").WizardSession | undefined;
+
+    try {
+      const startRespond = vi.fn();
+      await expectDefined(
+        wizardHandlers["wizard.start"],
+        "wizard.start test invariant",
+      )({ params: { mode: "local" }, respond: startRespond, context } as never);
+      const [, start] = startRespond.mock.calls[0] ?? [];
+      expect(start).toMatchObject({ status: "running" });
+      admittedSession = expectDefined(
+        tracker.wizardSessions.get(start.sessionId),
+        "admitted classic setup session",
+      );
+
+      runnerSettled.resolve();
+      await setupTargetLockReleaseReached.promise;
+      expect(admittedSession.getStatus()).toBe("done");
+      await expect(runExclusiveSystemAgentSetupActivation(async () => undefined)).rejects.toThrow(
+        "setup is already in progress",
+      );
+
+      const replacementRespond = vi.fn();
+      let replacementStart: Promise<void> | undefined;
+      const statusRespond = vi.fn(() => {
+        replacementStart = Promise.resolve(
+          expectDefined(
+            wizardHandlers["wizard.start"],
+            "wizard.start test invariant",
+          )({ params: { mode: "local" }, respond: replacementRespond, context } as never),
+        );
+      });
+      const statusTask = Promise.resolve(
+        expectDefined(
+          wizardHandlers["wizard.status"],
+          "wizard.status test invariant",
+        )({ params: { sessionId: start.sessionId }, respond: statusRespond, context } as never),
+      );
+
+      await Promise.resolve();
+      releaseSetupTargetLock.resolve();
+      await statusTask;
+      await vi.waitFor(() => expect(replacementStart).toBeDefined());
+      await replacementStart;
+
+      expect(statusRespond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({ status: "done" }),
+        undefined,
+      );
+      expect(replacementRespond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({ status: "running" }),
+        undefined,
+      );
+    } finally {
+      runnerSettled.resolve();
+      releaseSetupTargetLock.resolve();
+      if (admittedSession) {
+        await whenAdmittedWizardSessionSettled(admittedSession);
+      }
+      await cancelWizardSessions(tracker.wizardSessions);
+      setupTargetLock.beforeRelease = undefined;
+      setupTargetLock.releaseReached = undefined;
+    }
   });
 
   it.each([

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -227,7 +227,7 @@ export const wizardHandlers: GatewayRequestHandlers = {
     }
     respond(true, status, undefined);
   },
-  "wizard.status": ({ params, respond, context }) => {
+  "wizard.status": async ({ params, respond, context }) => {
     if (!assertValidParams(params, validateWizardStatusParams, "wizard.status", respond)) {
       return;
     }
@@ -237,6 +237,9 @@ export const wizardHandlers: GatewayRequestHandlers = {
       return;
     }
     const status = readWizardStatus(session);
+    if (status.status !== "running") {
+      await whenAdmittedWizardSessionSettled(session);
+    }
     context.purgeWizardSession(sessionId);
     respond(true, status, undefined);
   },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where clients polling a completed setup wizard could immediately start a replacement and receive a retryable busy response. The terminal status was visible before the setup admission and onboarding target lock had necessarily been released.

## Why This Change Was Made

Terminal `wizard.status` responses now consume the same authoritative admitted-session settlement used by terminal `wizard.start`, `wizard.next`, and cancellation cleanup. Running status polls remain immediate; only terminal status waits for the owning setup admission and filesystem lock to settle.

The regression holds the real setup-target lock release boundary open, observes the session becoming terminal, and starts a replacement directly from the status response callback.

## User Impact

Clients can treat a terminal wizard status as an authoritative signal that a replacement setup wizard may start immediately, without a transient retryable busy failure.

## Evidence

- Regression without the production fix: the replacement `wizard.start` returned `UNAVAILABLE` with `retryable: true`.
- `node scripts/run-vitest.mjs src/gateway/server-methods/wizard.test.ts` — 17/17 passed.
- `node scripts/run-vitest.mjs src/gateway/server-methods/setup-admission.test.ts` — 7/7 passed.
- `node scripts/check-changed.mjs -- src/gateway/server-methods/wizard.ts src/gateway/server-methods/wizard.test.ts` — passed all selected core production/test gates. The remote backend was unavailable, and the repository wrapper explicitly completed the fallback locally.
- `git diff --check` and targeted formatting checks passed.
- Fresh autoreview reported no accepted/actionable findings.

AI-assisted: yes. The lifecycle path, lock ownership, test behavior, and final diff were manually inspected and understood.
