### PR TITLE
fix(agents): preserve skills for wildcard tool policy

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.ts
@@ -37,6 +37,7 @@ import type { SandboxContext } from "../../sandbox/types.js";
 import { detectRuntimeShell } from "../../shell-utils.js";
 import { buildSystemPromptParams } from "../../system-prompt-params.js";
 import { buildSystemPromptReport } from "../../system-prompt-report.js";
+import { toolPolicyRestrictsTools } from "../../tool-policy.js";
 import type { ToolSearchCatalogRef } from "../../tool-search.js";
 import { buildToolSchemaDirectoryPrompt } from "../../tool-search.js";
 import { prepareWatchedSessionsPrompt } from "../../watched-sessions-prompt.js";
@@ -201,8 +202,9 @@ export async function prepareEmbeddedAttemptSystemPrompt(params: {
     attempt.promptMode ??
     (params.isRawModelRun ? "none" : resolvePromptModeForSession(attempt.sessionKey));
   const promptSurface = resolveAgentPromptSurfaceForSessionKey(attempt.sessionKey);
-  const effectivePromptMode = attempt.toolsAllow?.length ? ("minimal" as const) : promptMode;
-  const effectiveSkillsPrompt = attempt.toolsAllow?.length ? undefined : params.skillsPrompt;
+  const toolPolicyRestricted = toolPolicyRestrictsTools({ allow: attempt.toolsAllow });
+  const effectivePromptMode = toolPolicyRestricted ? ("minimal" as const) : promptMode;
+  const effectiveSkillsPrompt = toolPolicyRestricted ? undefined : params.skillsPrompt;
   const openClawReferences = await resolveOpenClawReferencePaths({
     workspaceDir: params.effectiveWorkspace,
     argv1: process.argv[1],

--- a/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
@@ -18,6 +18,7 @@ import {
 import { resolveModelAuthMode } from "../../model-auth.js";
 import { supportsModelTools } from "../../model-tool-support.js";
 import type { SandboxContext } from "../../sandbox/types.js";
+import { toolPolicyRestrictsTools } from "../../tool-policy.js";
 import { isAgentToolRestartSafe } from "../../tool-replay-safety.js";
 import {
   createToolSearchCatalogRef,
@@ -115,7 +116,9 @@ export function prepareEmbeddedAttemptToolBase(params: {
       ? createToolSearchCatalogRef()
       : undefined;
   const toolSearchTargetTranscriptProjections: ToolSearchTargetTranscriptProjection[] = [];
-  const codeModeSkills = attempt.toolsAllow?.length ? [] : params.codeModeSkills;
+  const codeModeSkills = toolPolicyRestrictsTools({ allow: attempt.toolsAllow })
+    ? []
+    : params.codeModeSkills;
   const cronCreatorToolAllowlist: CronCreatorToolAllowlistEntry[] = [];
   const cronCreatorToolAllowlistCaptureRef: CronToolsAllowCaptureRef = {};
   const inheritedToolAllowlist: string[] = [];

--- a/src/agents/embedded-agent-runner/run/attempt.skills-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.skills-policy.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createFixtureSkillEntry } from "../../../skills/test-support/test-helpers.js";
+import type { AnyAgentTool } from "../../tools/common.js";
+import {
+  cleanupTempPaths,
+  createContextEngineAttemptRunner,
+  createContextEngineBootstrapAndAssemble,
+  getHoisted,
+  preloadRunEmbeddedAttemptForTests,
+  resetEmbeddedAttemptHarness,
+} from "./attempt-spawn-workspace.test-support.js";
+
+const hoisted = getHoisted();
+const tempPaths: string[] = [];
+const skillsPrompt = [
+  "<available_skills>",
+  "  <skill>",
+  "    <name>demo</name>",
+  "    <description>demo description</description>",
+  "    <location>/skills/demo/SKILL.md</location>",
+  "  </skill>",
+  "</available_skills>",
+].join("\n");
+
+beforeAll(async () => {
+  await preloadRunEmbeddedAttemptForTests();
+});
+
+beforeEach(() => {
+  resetEmbeddedAttemptHarness();
+});
+
+afterEach(async () => {
+  await cleanupTempPaths(tempPaths);
+  vi.restoreAllMocks();
+});
+
+describe("runEmbeddedAttempt skill policy projections", () => {
+  it("keeps wildcard allowlists equivalent to an unrestricted attempt", async () => {
+    const observed: Array<{
+      label: string;
+      skillsPrompt?: string;
+      skillsListAvailable: boolean;
+    }> = [];
+
+    for (const testCase of [
+      { label: "undefined", toolsAllow: undefined },
+      { label: "wildcard", toolsAllow: ["*"] },
+      { label: "mixed wildcard", toolsAllow: ["message", "*"] },
+      { label: "finite", toolsAllow: ["message"] },
+    ]) {
+      resetEmbeddedAttemptHarness();
+      hoisted.resolveEmbeddedRunSkillEntriesMock.mockReturnValue({
+        shouldLoadSkillEntries: true,
+        skillEntries: [createFixtureSkillEntry("demo")],
+      });
+      hoisted.resolveSkillsPromptForRunMock.mockReturnValue(skillsPrompt);
+
+      await createContextEngineAttemptRunner({
+        contextEngine: createContextEngineBootstrapAndAssemble(),
+        sessionKey: `agent:main:${testCase.label.replace(" ", "-")}`,
+        tempPaths,
+        attemptOverrides: {
+          disableTools: false,
+          toolsAllow: testCase.toolsAllow,
+          config: { tools: { codeMode: true } },
+        },
+      });
+
+      const sessionOptions = hoisted.createAgentSessionMock.mock.calls.at(-1)?.[0] as
+        | { customTools?: AnyAgentTool[] }
+        | undefined;
+      const execTool = sessionOptions?.customTools?.find((tool) => tool.name === "exec");
+      if (!execTool) {
+        throw new Error("expected Code Mode exec tool");
+      }
+      const promptInput = hoisted.embeddedSystemPromptInputs.at(-1) as
+        | { skillsPrompt?: string }
+        | undefined;
+      observed.push({
+        label: testCase.label,
+        skillsPrompt: promptInput?.skillsPrompt,
+        skillsListAvailable: execTool.description.includes("await skills.list()"),
+      });
+    }
+
+    expect(observed).toEqual([
+      { label: "undefined", skillsPrompt, skillsListAvailable: true },
+      { label: "wildcard", skillsPrompt, skillsListAvailable: true },
+      { label: "mixed wildcard", skillsPrompt, skillsListAvailable: true },
+      { label: "finite", skillsPrompt: undefined, skillsListAvailable: false },
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #121950

## What Problem This Solves

Fixes a silent capability loss in embedded Code Mode runs using `toolsAllow: ["*"]` or another allowlist containing `"*"`. Concrete tool filtering correctly treated wildcard as unrestricted, but two independent raw-array checks erased the system-prompt skills catalog and the Code Mode skills bridge.

## Why This Change Was Made

Both projections now reuse the canonical semantic policy predicate, `toolPolicyRestrictsTools`. Undefined and wildcard-containing policies remain unrestricted; finite allowlists remain restrictive. Existing deny layers and concrete tool filtering are unchanged.

The regression drives a real embedded attempt and compares undefined, wildcard, mixed-wildcard, and finite allowlists. It verifies both rendered skills guidance and Code Mode `skills.list()` availability at the owning boundary.

## User Impact

Code Mode agents using an explicit wildcard tool cap can discover and read skills just like an unrestricted run. Finite per-run tool caps continue to suppress skill access as before.

## Evidence

- Pre-fix regression failed for wildcard and mixed-wildcard cases: skills prompt absent and Code Mode skills unavailable.
- Post-fix `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.skills-policy.test.ts` — 1 passed.
- `node scripts/run-vitest.mjs src/agents/code-mode.skills.test.ts` — 3 passed.
- Targeted oxfmt and `git diff --check` passed after rebase onto current main.
- Mandatory Codex autoreview and TruffleHog were clean.
- Production delta: +8/-3 (net +5); tests: +94/-0.
- No public API, config, protocol, authority, or changelog change.

AI-assisted implementation; no agent transcript attached.