### PR TITLE
fix(ci): budget expanded survivor groups

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -1538,6 +1538,7 @@ jobs:
           LANES: ${{ inputs.docker_lanes }}
           GROUP_SIZE: ${{ inputs.targeted_docker_lane_group_size }}
           OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPECS: ${{ inputs.published_upgrade_survivor_baselines }}
+          OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS: ${{ inputs.published_upgrade_survivor_scenarios }}
         run: |
           set -euo pipefail
           groups_json="$(node scripts/plan-targeted-docker-lane-groups.mjs)"
@@ -1555,7 +1556,7 @@ jobs:
     name: Docker E2E targeted lanes (${{ matrix.group.label }})
     continue-on-error: ${{ inputs.advisory }}
     runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-32vcpu-ubuntu-2404' }}
-    timeout-minutes: 60
+    timeout-minutes: ${{ matrix.group.timeout_minutes || 60 }}
     strategy:
       fail-fast: false
       matrix:

--- a/scripts/plan-targeted-docker-lane-groups.mjs
+++ b/scripts/plan-targeted-docker-lane-groups.mjs
@@ -31,17 +31,20 @@ function sanitizeLabel(value) {
  *   groupSize?: number | string;
  *   lanes?: string;
  *   upgradeSurvivorBaselines?: string;
+ *   upgradeSurvivorScenarios?: string;
  * }} [options]
  * @returns {{
  *   docker_lanes: string;
  *   label: string;
  *   published_upgrade_survivor_baselines?: string;
+ *   timeout_minutes?: number;
  * }[]}
  */
 export function planTargetedDockerLaneGroups({
   groupSize = 1,
   lanes,
   upgradeSurvivorBaselines = "",
+  upgradeSurvivorScenarios = "",
 } = {}) {
   const selectedLanes = splitTokens(lanes);
   if (selectedLanes.length === 0) {
@@ -50,8 +53,20 @@ export function planTargetedDockerLaneGroups({
 
   const parsedGroupSize = parsePositiveInt(groupSize, "groupSize");
   const baselineSpecs = splitTokens(upgradeSurvivorBaselines);
+  const hasExpandedSurvivorScenarios = splitTokens(upgradeSurvivorScenarios).length > 0;
   const groups = [];
   let pendingLanes = [];
+
+  const addGroup = (group) => {
+    const groupLanes = splitTokens(group.docker_lanes);
+    if (
+      hasExpandedSurvivorScenarios &&
+      groupLanes.some((lane) => BASELINE_SHARDED_LANES.has(lane))
+    ) {
+      group.timeout_minutes = 90;
+    }
+    groups.push(group);
+  };
 
   const flushPending = () => {
     if (pendingLanes.length === 0) {
@@ -60,7 +75,7 @@ export function planTargetedDockerLaneGroups({
     const first = sanitizeLabel(pendingLanes[0]);
     const last = sanitizeLabel(pendingLanes[pendingLanes.length - 1]);
     const label = pendingLanes.length === 1 ? first : `${first}--${last}`;
-    groups.push({ docker_lanes: pendingLanes.join(" "), label });
+    addGroup({ docker_lanes: pendingLanes.join(" "), label });
     pendingLanes = [];
   };
 
@@ -68,7 +83,7 @@ export function planTargetedDockerLaneGroups({
     if (BASELINE_SHARDED_LANES.has(lane) && baselineSpecs.length > 1) {
       flushPending();
       for (const baselineSpec of baselineSpecs) {
-        groups.push({
+        addGroup({
           docker_lanes: lane,
           label: `${sanitizeLabel(lane)}-${sanitizeLabel(baselineSpec)}`,
           published_upgrade_survivor_baselines: baselineSpec,
@@ -96,6 +111,7 @@ if (isMain) {
         groupSize: process.env.GROUP_SIZE,
         lanes: process.env.LANES,
         upgradeSurvivorBaselines: process.env.OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPECS,
+        upgradeSurvivorScenarios: process.env.OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS,
       }),
     ),
   );

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -3127,6 +3127,15 @@ NODE
       OPENCLAW_BUILD_PRIVATE_QA: "1",
       OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1",
     });
+    const targetedGroupStep = releaseChecks.jobs.plan_docker_lane_groups.steps.find(
+      (step: WorkflowStep) => step.name === "Build targeted Docker lane groups",
+    );
+    expect(targetedGroupStep.env.OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS).toBe(
+      "${{ inputs.published_upgrade_survivor_scenarios }}",
+    );
+    expect(releaseChecks.jobs.validate_docker_lanes["timeout-minutes"]).toBe(
+      "${{ matrix.group.timeout_minutes || 60 }}",
+    );
   });
 
   it("persists Node 22 declarations through trusted bounded artifacts", () => {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -219,6 +219,9 @@ function timeoutForProfile(
   if (typeof timeout === "number") {
     return timeout;
   }
+  if (timeout === "${{ matrix.group.timeout_minutes || 60 }}") {
+    return 60;
+  }
   const match = timeout?.match(
     /^\$\{\{ inputs\.(?:release_profile|release_test_profile) == 'full' && ([0-9]+) \|\| ([0-9]+) \}\}$/u,
   );
@@ -237,6 +240,9 @@ function evaluatedJobTimeouts(path: string, jobName: string, job: WorkflowJob): 
     return (["beta", "stable", "full"] as const).map((profile) =>
       timeoutForProfile(timeout, profile),
     );
+  }
+  if (timeout === "${{ matrix.group.timeout_minutes || 60 }}") {
+    return [60, 90];
   }
   if (timeout !== "${{ matrix.timeout_minutes }}") {
     throw new Error(`Unsupported timeout for ${path}:${jobName}: ${String(timeout)}`);
@@ -6342,16 +6348,22 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
           timeoutForProfile(liveE2e.jobs?.validate_selected_ref?.["timeout-minutes"], profile),
           timeoutForProfile(liveE2e.jobs?.prepare_docker_e2e_image?.["timeout-minutes"], profile),
           timeoutForProfile(liveE2e.jobs?.docker_e2e_image_ready?.["timeout-minutes"], profile),
-          timeoutForProfile(liveE2e.jobs?.validate_docker_lanes?.["timeout-minutes"], profile),
+          Math.max(
+            ...evaluatedJobTimeouts(
+              LIVE_E2E_WORKFLOW,
+              "validate_docker_lanes",
+              workflowJob(LIVE_E2E_WORKFLOW, "validate_docker_lanes"),
+            ),
+          ),
           timeoutForProfile(packageAcceptance.jobs?.summary?.["timeout-minutes"], profile),
           timeoutForProfile(releaseChecks.jobs?.summary?.["timeout-minutes"], profile),
         ],
       ]),
     ) as Record<(typeof profiles)[number], number[]>;
     expect(releasePackagePaths).toEqual({
-      beta: [30, 15, 60, 10, 30, 60, 5, 60, 5, 5],
-      stable: [30, 15, 60, 10, 30, 60, 5, 60, 5, 5],
-      full: [30, 15, 60, 10, 30, 90, 5, 60, 5, 5],
+      beta: [30, 15, 60, 10, 30, 60, 5, 90, 5, 5],
+      stable: [30, 15, 60, 10, 30, 60, 5, 90, 5, 5],
+      full: [30, 15, 60, 10, 30, 90, 5, 90, 5, 5],
     });
     const releaseChecksParent = workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "release_checks");
     expect(releaseChecksParent["runs-on"]).toBe("blacksmith-4vcpu-ubuntu-2404");
@@ -6361,7 +6373,7 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
       stable: releasePackagePaths.stable.reduce((total, timeout) => total + timeout, 0),
       full: releasePackagePaths.full.reduce((total, timeout) => total + timeout, 0),
     };
-    expect(releasePackageTimeouts).toEqual({ beta: 280, stable: 280, full: 310 });
+    expect(releasePackageTimeouts).toEqual({ beta: 310, stable: 310, full: 340 });
     for (const [profile, childTimeout] of Object.entries(releasePackageTimeouts)) {
       expect(childTimeout, `release-package:${profile}`).toBeLessThanOrEqual(420);
       expect(420 - childTimeout, `release-package:${profile}`).toBeGreaterThanOrEqual(60);

--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -53,6 +53,9 @@ function timeoutForProfile(
   if (typeof timeout === "number") {
     return timeout;
   }
+  if (timeout === "${{ matrix.group.timeout_minutes || 60 }}") {
+    return 60;
+  }
   const match = timeout?.match(
     /^\$\{\{ inputs\.(?:release_profile|release_test_profile) == 'full' && ([0-9]+) \|\| ([0-9]+) \}\}$/u,
   );

--- a/test/scripts/targeted-docker-lane-groups.test.ts
+++ b/test/scripts/targeted-docker-lane-groups.test.ts
@@ -67,6 +67,29 @@ describe("scripts/plan-targeted-docker-lane-groups", () => {
     ]);
   });
 
+  it("extends only groups containing expanded survivor lanes", () => {
+    expect(
+      planTargetedDockerLaneGroups({
+        groupSize: 2,
+        lanes:
+          "doctor-switch published-upgrade-survivor plugins-offline update-migration plugin-update",
+        upgradeSurvivorScenarios: "base plugin-deps-cleanup",
+      }),
+    ).toEqual([
+      {
+        docker_lanes: "doctor-switch published-upgrade-survivor",
+        label: "doctor-switch--published-upgrade-survivor",
+        timeout_minutes: 90,
+      },
+      {
+        docker_lanes: "plugins-offline update-migration",
+        label: "plugins-offline--update-migration",
+        timeout_minutes: 90,
+      },
+      { docker_lanes: "plugin-update", label: "plugin-update" },
+    ]);
+  });
+
   it("rejects malformed group size values", () => {
     expect(() =>
       planTargetedDockerLaneGroups({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where expanded published-upgrade-survivor and update-migration validation groups could be cancelled at the generic 60-minute targeted Docker job limit.

Related validation: https://github.com/openclaw/openclaw/actions/runs/31481965147

## Why This Change Was Made

The targeted lane-group planner now receives the configured survivor scenarios and assigns a 90-minute budget only to groups containing published-upgrade-survivor or update-migration when scenario expansion is active. All other targeted groups retain the existing 60-minute workflow fallback.

The planner remains the canonical owner of per-group matrix metadata; no Docker lane, retry, product, package, or release behavior changes.

The first exact-head PR run exposed two release test-plan helpers that only understood literal and profile-dependent timeout expressions. They now evaluate the bounded matrix timeout as 60 minutes for the default path and 90 minutes for worst-case package-acceptance accounting.

## User Impact

Release operators can complete expanded survivor coverage without the slowest supported baseline being cancelled at exactly 60 minutes. Ordinary targeted Docker validation keeps its current limit.

## Evidence

- Beta 2 r8 failure: `published-upgrade-survivor-2026.4.15` ran from 10:30:47Z to 11:31:06Z and was cancelled by the 60-minute job cap: https://github.com/openclaw/openclaw/actions/runs/31481965147/job/93750517768
- The initial four-file head correctly failed existing timeout-accounting guards, proving the additional test-only compatibility update was required:
  - https://github.com/openclaw/openclaw/actions/runs/31499268107/job/93805182903
  - https://github.com/openclaw/openclaw/actions/runs/31499268107/job/93805182994
- Focused planner, workflow guard, plugin prerelease, and package acceptance tests: green; package acceptance 190/190 passed.
- `node scripts/check-changed.mjs -- <six changed files>`: green on Testbox `tbx_01kzrjjyx7dp8ffs24v5rx91rp`: https://github.com/openclaw/openclaw/actions/runs/31500150248
- `git diff --check`: clean.
- Production/workflow LOC: +20/-3. Tests: +52/-5.

AI-assisted: yes.
