### PR TITLE
improve(test): speed up doctor preflight process coverage

### DIFF
--- a/src/commands/doctor-config-preflight.process.test.ts
+++ b/src/commands/doctor-config-preflight.process.test.ts
@@ -716,11 +716,11 @@ describe("gateway startup-migration refusal", () => {
       });
       expect(params.fixture.configFlowScanCount).toBeGreaterThan(0);
       expect(params.fixture.configFlowScanCount).toBeLessThanOrEqual(
-        params.mode === "preview" ? 9 : 6,
+        params.mode === "preview" ? 8 : 5,
       );
       expect(params.fixture.doctorScanCount).toBeGreaterThan(0);
       expect(params.fixture.doctorScanCount).toBeLessThanOrEqual(
-        params.mode === "preview" ? 9 : 15,
+        params.mode === "preview" ? 8 : 14,
       );
     };
 

--- a/src/commands/doctor-config-preflight.process.test.ts
+++ b/src/commands/doctor-config-preflight.process.test.ts
@@ -6,7 +6,6 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
-import pLimit from "p-limit";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -695,100 +694,37 @@ describe("gateway startup-migration refusal", () => {
       return metadata;
     };
 
-    // Each fixture needs a fresh process for environment and module-cache isolation. Bound the
-    // process fanout to the CI lane's worker budget instead of paying eight serial imports.
-    const runLimited = pLimit(3);
+    // Each mode gets a representative multi-plugin, multi-agent, configured-channel fixture in a
+    // fresh process for environment and module-cache isolation. The aggregate scan ceilings prove
+    // the flow stays bounded without paying for a redundant cross-product of single-factor cases.
     const fixtureRuns = [
-      runLimited(() => runDoctorConfigFlow(1, 1, "repair")),
-      runLimited(() => runDoctorConfigFlow(12, 1, "repair")),
-      runLimited(() => runDoctorConfigFlow(1, 12, "repair")),
-      runLimited(() =>
-        runDoctorConfigFlow(1, 1, "repair", {
-          configuredChannel: true,
-        }),
-      ),
-      runLimited(() => runDoctorConfigFlow(1, 1, "preview")),
-      runLimited(() => runDoctorConfigFlow(12, 1, "preview")),
-      runLimited(() => runDoctorConfigFlow(1, 12, "preview")),
-      runLimited(() =>
-        runDoctorConfigFlow(1, 1, "preview", {
-          configuredChannel: true,
-        }),
-      ),
+      runDoctorConfigFlow(3, 3, "repair", { configuredChannel: true }),
+      runDoctorConfigFlow(3, 3, "preview", { configuredChannel: true }),
     ] as const;
-    const [
-      repairBaseline,
-      repairManyPlugins,
-      repairManyAgents,
-      repairConfiguredChannel,
-      previewBaseline,
-      previewManyPlugins,
-      previewManyAgents,
-      previewConfiguredChannel,
-    ] = await Promise.all(fixtureRuns).catch(async (error: unknown) => {
+    const [repair, preview] = await Promise.all(fixtureRuns).catch(async (error: unknown) => {
       // A failed child must not let afterEach remove roots that queued siblings still use.
       await Promise.allSettled(fixtureRuns);
       throw error;
     });
 
-    const expectBoundedScans = (params: {
-      baseline: typeof repairBaseline;
-      manyPlugins: typeof repairManyPlugins;
-      manyAgents: typeof repairManyAgents;
-    }) => {
-      expect(params.baseline).toMatchObject({ manifestPluginCount: 1, scoped: false });
-      expect(params.manyPlugins).toMatchObject({ manifestPluginCount: 12, scoped: false });
-      expect(params.manyAgents).toMatchObject({ manifestPluginCount: 1, scoped: false });
-      expect(params.baseline.configFlowScanCount).toBeGreaterThan(0);
-      expect(params.baseline.configFlowScanCount).toBeLessThanOrEqual(12);
-      expect(params.manyPlugins.configFlowScanCount).toBe(params.baseline.configFlowScanCount);
-      expect(params.manyAgents.configFlowScanCount).toBe(
-        params.baseline.configFlowScanCount + (params.baseline.mode === "preview" ? 11 : 0),
-      );
-      expect(params.baseline.doctorScanCount).toBeLessThanOrEqual(20);
-      expect(params.manyPlugins.doctorScanCount).toBe(params.baseline.doctorScanCount);
-      expect(params.manyAgents.doctorScanCount).toBe(params.baseline.doctorScanCount + 11);
-    };
-    const expectConfiguredChannelScans = (params: {
-      baseline: typeof repairBaseline;
-      configuredChannel: typeof repairConfiguredChannel;
-    }) => {
-      expect(params.configuredChannel).toMatchObject({
+    const expectBoundedScans = (params: { fixture: typeof repair; mode: "preview" | "repair" }) => {
+      expect(params.fixture).toMatchObject({
+        mode: params.mode,
         configuredChannel: true,
-        manifestPluginCount: 1,
+        manifestPluginCount: 3,
         scoped: false,
       });
-      expect(params.configuredChannel.configFlowScanCount).toBeGreaterThanOrEqual(
-        params.baseline.configFlowScanCount,
+      expect(params.fixture.configFlowScanCount).toBeGreaterThan(0);
+      expect(params.fixture.configFlowScanCount).toBeLessThanOrEqual(
+        params.mode === "preview" ? 9 : 6,
       );
-      expect(params.configuredChannel.configFlowScanCount).toBeLessThanOrEqual(
-        params.baseline.configFlowScanCount + (params.baseline.mode === "preview" ? 3 : 0),
-      );
-      expect(params.configuredChannel.doctorScanCount).toBeGreaterThanOrEqual(
-        params.baseline.doctorScanCount,
-      );
-      expect(params.configuredChannel.doctorScanCount).toBeLessThanOrEqual(
-        params.baseline.doctorScanCount + (params.baseline.mode === "preview" ? 3 : 2),
+      expect(params.fixture.doctorScanCount).toBeGreaterThan(0);
+      expect(params.fixture.doctorScanCount).toBeLessThanOrEqual(
+        params.mode === "preview" ? 9 : 15,
       );
     };
 
-    expectBoundedScans({
-      baseline: repairBaseline,
-      manyPlugins: repairManyPlugins,
-      manyAgents: repairManyAgents,
-    });
-    expectBoundedScans({
-      baseline: previewBaseline,
-      manyPlugins: previewManyPlugins,
-      manyAgents: previewManyAgents,
-    });
-    expectConfiguredChannelScans({
-      baseline: repairBaseline,
-      configuredChannel: repairConfiguredChannel,
-    });
-    expectConfiguredChannelScans({
-      baseline: previewBaseline,
-      configuredChannel: previewConfiguredChannel,
-    });
+    expectBoundedScans({ fixture: repair, mode: "repair" });
+    expectBoundedScans({ fixture: preview, mode: "preview" });
   }, 300_000);
 });

--- a/src/commands/doctor-config-preflight.process.test.ts
+++ b/src/commands/doctor-config-preflight.process.test.ts
@@ -1,10 +1,12 @@
 // Process regression for typed gateway startup-migration refusal and lease cleanup.
-import { spawnSync } from "node:child_process";
+import { execFile, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+import pLimit from "p-limit";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -20,6 +22,7 @@ const STARTUP_REFUSAL =
 const STARTUP_RECOVERY =
   'Run "openclaw doctor --fix" against the same state/config, then restart the gateway.';
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const execFileAsync = promisify(execFile);
 
 function runIsolatedModuleScript(
   env: NodeJS.ProcessEnv,
@@ -630,9 +633,14 @@ describe("gateway startup-migration refusal", () => {
         nonInteractive: true,
         ...(mode === "repair" ? { repair: true } : {}),
       };
-      const result = runIsolatedModuleScript(
-        env,
-        `
+      await execFileAsync(
+        process.execPath,
+        [
+          "--import",
+          "tsx",
+          "--input-type=module",
+          "--eval",
+          `
           const { loadAndMaybeMigrateDoctorConfig } = await import(${JSON.stringify(configFlowUrl)});
           const result = await loadAndMaybeMigrateDoctorConfig({
             options: ${JSON.stringify(doctorOptions)},
@@ -666,11 +674,15 @@ describe("gateway startup-migration refusal", () => {
             doctorScanCount: countMetadataScans() - configFlowScanCount,
           }));
         `,
-        { timeoutMs: 60_000 },
+        ],
+        {
+          cwd: path.resolve("."),
+          encoding: "utf8",
+          env,
+          maxBuffer: 4 * 1024 * 1024,
+          timeout: 60_000,
+        },
       );
-      expect(result.error, `${result.stderr}\n${result.stdout}`).toBeUndefined();
-      expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(0);
-      expect(result.signal, `${result.stderr}\n${result.stdout}`).toBeNull();
 
       const metadata = JSON.parse(fs.readFileSync(resultPath, "utf8")) as {
         mode: "preview" | "repair";
@@ -683,17 +695,40 @@ describe("gateway startup-migration refusal", () => {
       return metadata;
     };
 
-    const repairBaseline = await runDoctorConfigFlow(1, 1, "repair");
-    const repairManyPlugins = await runDoctorConfigFlow(12, 1, "repair");
-    const repairManyAgents = await runDoctorConfigFlow(1, 12, "repair");
-    const repairConfiguredChannel = await runDoctorConfigFlow(1, 1, "repair", {
-      configuredChannel: true,
-    });
-    const previewBaseline = await runDoctorConfigFlow(1, 1, "preview");
-    const previewManyPlugins = await runDoctorConfigFlow(12, 1, "preview");
-    const previewManyAgents = await runDoctorConfigFlow(1, 12, "preview");
-    const previewConfiguredChannel = await runDoctorConfigFlow(1, 1, "preview", {
-      configuredChannel: true,
+    // Each fixture needs a fresh process for environment and module-cache isolation. Bound the
+    // process fanout to the CI lane's worker budget instead of paying eight serial imports.
+    const runLimited = pLimit(3);
+    const fixtureRuns = [
+      runLimited(() => runDoctorConfigFlow(1, 1, "repair")),
+      runLimited(() => runDoctorConfigFlow(12, 1, "repair")),
+      runLimited(() => runDoctorConfigFlow(1, 12, "repair")),
+      runLimited(() =>
+        runDoctorConfigFlow(1, 1, "repair", {
+          configuredChannel: true,
+        }),
+      ),
+      runLimited(() => runDoctorConfigFlow(1, 1, "preview")),
+      runLimited(() => runDoctorConfigFlow(12, 1, "preview")),
+      runLimited(() => runDoctorConfigFlow(1, 12, "preview")),
+      runLimited(() =>
+        runDoctorConfigFlow(1, 1, "preview", {
+          configuredChannel: true,
+        }),
+      ),
+    ] as const;
+    const [
+      repairBaseline,
+      repairManyPlugins,
+      repairManyAgents,
+      repairConfiguredChannel,
+      previewBaseline,
+      previewManyPlugins,
+      previewManyAgents,
+      previewConfiguredChannel,
+    ] = await Promise.all(fixtureRuns).catch(async (error: unknown) => {
+      // A failed child must not let afterEach remove roots that queued siblings still use.
+      await Promise.allSettled(fixtureRuns);
+      throw error;
     });
 
     const expectBoundedScans = (params: {


### PR DESCRIPTION
## Summary

- replace eight single-factor Doctor metadata-scan subprocess fixtures with one representative multi-plugin, multi-agent, configured-channel fixture per preview/repair mode
- retain the observable integration contract with tight aggregate scan ceilings while deleting implementation-coupled differential cases
- run the two isolated mode fixtures concurrently and drain both before teardown on failure
- retain all five process-level tests; add no CI workers and change no production code

## Measurements

Hosted current-`main` baseline (`checks-node-compact-small-6`, run `31498590989`):

- `src/commands/doctor-config-preflight.process.test.ts`: **88.108s**

Fresh-cache local, one Vitest worker:

| | Before | After | Improvement |
|---|---:|---:|---:|
| Vitest duration | 192.39s | 56.41–59.38s | **69.1–70.7% faster** |
| Wrapper wall time | 198.18s | 62.30–65.55s | **66.9–68.6% faster** |
| Metadata-scan test | 158.549s | 24.485–26.326s | **83.4–84.6% faster** |

Hosted exact head (`14d021eb9d0`, run `31502888134`): **53.49s**, or **39.3% faster**. A second hosted run of the same execution shape measured **57.70s** (**34.5% faster**), so both hosted samples clear the target.

## Test-value audit

The deleted fixtures separately attributed scan deltas to plugin count, agent count, and configured-channel discovery. Those scan-count decompositions are internal implementation details. The retained fixtures exercise all three dimensions together through the real config and Doctor health flows in both modes, verify complete unscoped metadata, and enforce measured scan ceilings with one scan of headroom, so a per-extra-agent or per-extra-plugin fanout regression cannot hide inside the allowance. A redundant metadata scan still fails the retained contract without eight cold process imports.

## Validation

- focused fresh-cache run: 5/5 passed
- `pnpm tsgo:core:test`
- focused type-aware oxlint: 0 warnings, 0 errors
- `oxfmt --check src/commands/doctor-config-preflight.process.test.ts`
- `git diff --check`
