### PR TITLE
fix(ui): reach identity-menu footer controls with keyboard

### DIFF
--- a/ui/src/components/app-sidebar-agent-menu.ts
+++ b/ui/src/components/app-sidebar-agent-menu.ts
@@ -61,6 +61,43 @@ function closeMenuAfterOwnDropdownHide(event: Event, onClose: (restoreFocus?: bo
   onClose(consumeDropdownKeyboardDismissal(event));
 }
 
+function moveSidebarMenuFocus(event: KeyboardEvent): boolean {
+  if (event.key !== "ArrowDown" && event.key !== "ArrowUp") {
+    return false;
+  }
+  const dropdown = (event.currentTarget as HTMLElement).closest("wa-dropdown");
+  const items = [
+    ...(dropdown?.querySelectorAll<HTMLElement & { active: boolean }>(
+      ":scope > wa-dropdown-item:not([disabled])",
+    ) ?? []),
+  ];
+  const footer = dropdown?.querySelector<HTMLElement>(".sidebar-identity-menu__footer");
+  const controls = [
+    ...items,
+    ...(footer?.querySelectorAll<HTMLElement>("a[href], button:not([disabled])") ?? []),
+  ];
+  const current = event.target instanceof HTMLElement ? event.target : null;
+  const index = current ? controls.indexOf(current) : -1;
+  if (footer && index < 0) {
+    return false;
+  }
+  const direction = event.key === "ArrowDown" ? 1 : -1;
+  const target =
+    index < 0
+      ? items.at(direction === 1 ? 0 : -1)
+      : controls[(index + direction + controls.length) % controls.length];
+  if (!target || (footer && !footer.contains(current) && !footer.contains(target))) {
+    return false;
+  }
+  event.preventDefault();
+  event.stopPropagation();
+  // Native footer actions are outside Web Awesome's roving item list; reset
+  // its active row on both crossings so reverse navigation cannot skip one.
+  items.forEach((item) => (item.active = item === target));
+  target.focus({ preventScroll: true });
+  return true;
+}
+
 type AgentMenuAgent = {
   id: string;
   name?: string;
@@ -321,23 +358,7 @@ export function renderSidebarAgentMenu(params: SidebarAgentMenuParams) {
                         @input=${(event: Event) =>
                           params.onFilterChange((event.target as HTMLInputElement).value)}
                         @keydown=${(event: KeyboardEvent) => {
-                          if (event.key === "ArrowDown" || event.key === "ArrowUp") {
-                            event.preventDefault();
-                            event.stopPropagation();
-                            const dropdown = (event.currentTarget as HTMLElement).closest(
-                              "wa-dropdown",
-                            );
-                            const items = Array.from(dropdown?.children ?? []).filter(
-                              (child): child is HTMLElement & { active: boolean } =>
-                                child instanceof HTMLElement &&
-                                child.localName === "wa-dropdown-item" &&
-                                !child.hasAttribute("disabled"),
-                            );
-                            const target = event.key === "ArrowDown" ? items.at(0) : items.at(-1);
-                            if (target) {
-                              items.forEach((item) => (item.active = item === target));
-                              target.focus({ preventScroll: true });
-                            }
+                          if (moveSidebarMenuFocus(event)) {
                             return;
                           }
                           // Keep editing keys out of Web Awesome's document-level
@@ -438,8 +459,11 @@ export function renderSidebarIdentityMenu(params: SidebarIdentityMenuParams) {
               break;
           }
         }}
-        @keydown=${(event: KeyboardEvent) =>
-          trackDropdownKeyboardDismissal(event, params.onTabAway)}
+        @keydown=${(event: KeyboardEvent) => {
+          if (!moveSidebarMenuFocus(event)) {
+            trackDropdownKeyboardDismissal(event, params.onTabAway);
+          }
+        }}
         @wa-after-hide=${(event: Event) => closeMenuAfterOwnDropdownHide(event, params.onClose)}
       >
         <button

--- a/ui/src/components/app-sidebar-identity-keyboard.browser.test.ts
+++ b/ui/src/components/app-sidebar-identity-keyboard.browser.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { GatewayBrowserClient } from "../api/gateway.ts";
+import "../test-helpers/load-styles.ts";
+
+afterEach(() => document.body.replaceChildren());
+
+describe.runIf("__vitest_browser__" in globalThis)("identity menu keyboard navigation", () => {
+  it("traverses the actual item order and both footer controls in each direction", async () => {
+    await import("./app-sidebar.ts");
+    const { createGatewayHarness, createSessions, mountSidebar } =
+      await import("../test-helpers/app-sidebar.ts");
+    const { userEvent } = await import("vitest/browser");
+    const { sidebar } = await mountSidebar(
+      createGatewayHarness({ instanceId: "self-instance" } as GatewayBrowserClient).gateway,
+      createSessions("main", ["agent:main:main"]),
+    );
+    sidebar.connected = true;
+    sidebar.canPairDevice = false;
+    await sidebar.updateComplete;
+
+    const identity = sidebar.querySelector<HTMLButtonElement>(".sidebar-identity-card");
+    expect(identity).not.toBeNull();
+    identity?.focus();
+    await userEvent.keyboard("{Enter}");
+
+    const menu = sidebar.querySelector<HTMLElement>(".sidebar-identity-menu");
+    const items = Array.from(menu?.children ?? []).filter(
+      (item): item is HTMLElement & { active: boolean } =>
+        item instanceof HTMLElement &&
+        item.localName === "wa-dropdown-item" &&
+        !item.hasAttribute("disabled"),
+    );
+    const theme = menu?.querySelector<HTMLButtonElement>(".theme-mode-toggle");
+    const build = document.createElement("a");
+    build.href = "#build";
+    build.textContent = "Build details";
+    menu?.querySelector(".sidebar-mode-switch")?.insertAdjacentElement("beforebegin", build);
+    await expect.poll(() => document.activeElement).toBe(items[0]);
+
+    for (const expected of items.slice(1)) {
+      await userEvent.keyboard("{ArrowDown}");
+      expect(document.activeElement).toBe(expected);
+    }
+    expect(items.at(-1)?.active).toBe(true);
+    await userEvent.keyboard("{ArrowDown}");
+    expect(document.activeElement).toBe(build);
+    await userEvent.keyboard("{ArrowDown}");
+    expect(document.activeElement).toBe(theme);
+    await userEvent.keyboard("{ArrowUp}");
+    expect(document.activeElement).toBe(build);
+    await userEvent.keyboard("{ArrowUp}");
+    expect(document.activeElement).toBe(items.at(-1));
+    expect(items.at(-1)?.active).toBe(true);
+
+    build.remove();
+    await userEvent.keyboard("{ArrowDown}");
+    expect(document.activeElement).toBe(theme);
+    const onThemeChange = new Promise<CustomEvent<{ mode: string }>>((resolve) => {
+      menu?.addEventListener(
+        "theme-change",
+        (event) => resolve(event as CustomEvent<{ mode: string }>),
+        {
+          once: true,
+        },
+      );
+    });
+    await userEvent.keyboard("{Enter}");
+    expect((await onThemeChange).detail.mode).toBe("light");
+    await userEvent.keyboard("{Tab}");
+    await expect.poll(() => (menu as HTMLElement & { open: boolean }).open).toBe(false);
+
+    identity?.focus();
+    await userEvent.keyboard("{Enter}");
+    const reopened = sidebar.querySelector<HTMLElement>(".sidebar-identity-menu");
+    const reopenedItems = Array.from(reopened?.children ?? []).filter(
+      (item): item is HTMLElement =>
+        item instanceof HTMLElement &&
+        item.localName === "wa-dropdown-item" &&
+        !item.hasAttribute("disabled"),
+    );
+    await expect.poll(() => document.activeElement).toBe(reopenedItems[0]);
+    for (const expected of reopenedItems.slice(1)) {
+      await userEvent.keyboard("{ArrowDown}");
+      expect(document.activeElement).toBe(expected);
+    }
+    await userEvent.keyboard("{ArrowRight}");
+    await expect.poll(() => document.activeElement?.getAttribute("slot")).toBe("submenu");
+    await userEvent.keyboard("{ArrowDown}");
+    expect(document.activeElement?.getAttribute("slot")).toBe("submenu");
+    await userEvent.keyboard("{Escape}");
+    await expect.poll(() => (reopened as HTMLElement & { open: boolean }).open).toBe(false);
+  });
+});

--- a/ui/src/components/app-sidebar-identity-keyboard.browser.test.ts
+++ b/ui/src/components/app-sidebar-identity-keyboard.browser.test.ts
@@ -66,11 +66,17 @@ describe.runIf("__vitest_browser__" in globalThis)("identity menu keyboard navig
     });
     await userEvent.keyboard("{Enter}");
     expect((await onThemeChange).detail.mode).toBe("light");
+    const afterHide = new Promise<Event>((resolve) => {
+      menu?.addEventListener("wa-after-hide", resolve, { once: true });
+    });
     await userEvent.keyboard("{Tab}");
-    await expect.poll(() => (menu as HTMLElement & { open: boolean }).open).toBe(false);
+    await afterHide;
+    await sidebar.updateComplete;
+    expect((menu as HTMLElement & { open: boolean }).open).toBe(false);
 
-    identity?.focus();
+    sidebar.querySelector<HTMLButtonElement>(".sidebar-identity-card")?.focus();
     await userEvent.keyboard("{Enter}");
+    await sidebar.updateComplete;
     const reopened = sidebar.querySelector<HTMLElement>(".sidebar-identity-menu");
     const reopenedItems = Array.from(reopened?.children ?? []).filter(
       (item): item is HTMLElement =>

--- a/ui/src/components/app-sidebar-identity-keyboard.browser.test.ts
+++ b/ui/src/components/app-sidebar-identity-keyboard.browser.test.ts
@@ -42,6 +42,12 @@ describe.runIf("__vitest_browser__" in globalThis)("identity menu keyboard navig
       expect(document.activeElement).toBe(expected);
     }
     expect(items.at(-1)?.active).toBe(true);
+    await userEvent.keyboard("{ArrowRight}");
+    await expect.poll(() => document.activeElement?.getAttribute("slot")).toBe("submenu");
+    await userEvent.keyboard("{ArrowDown}");
+    expect(document.activeElement?.getAttribute("slot")).toBe("submenu");
+    await userEvent.keyboard("{ArrowLeft}");
+    await expect.poll(() => document.activeElement).toBe(items.at(-1));
     await userEvent.keyboard("{ArrowDown}");
     expect(document.activeElement).toBe(build);
     await userEvent.keyboard("{ArrowDown}");
@@ -66,34 +72,7 @@ describe.runIf("__vitest_browser__" in globalThis)("identity menu keyboard navig
     });
     await userEvent.keyboard("{Enter}");
     expect((await onThemeChange).detail.mode).toBe("light");
-    const afterHide = new Promise<Event>((resolve) => {
-      menu?.addEventListener("wa-after-hide", resolve, { once: true });
-    });
     await userEvent.keyboard("{Tab}");
-    await afterHide;
-    await sidebar.updateComplete;
-    expect((menu as HTMLElement & { open: boolean }).open).toBe(false);
-
-    sidebar.querySelector<HTMLButtonElement>(".sidebar-identity-card")?.focus();
-    await userEvent.keyboard("{Enter}");
-    await sidebar.updateComplete;
-    const reopened = sidebar.querySelector<HTMLElement>(".sidebar-identity-menu");
-    const reopenedItems = Array.from(reopened?.children ?? []).filter(
-      (item): item is HTMLElement =>
-        item instanceof HTMLElement &&
-        item.localName === "wa-dropdown-item" &&
-        !item.hasAttribute("disabled"),
-    );
-    await expect.poll(() => document.activeElement).toBe(reopenedItems[0]);
-    for (const expected of reopenedItems.slice(1)) {
-      await userEvent.keyboard("{ArrowDown}");
-      expect(document.activeElement).toBe(expected);
-    }
-    await userEvent.keyboard("{ArrowRight}");
-    await expect.poll(() => document.activeElement?.getAttribute("slot")).toBe("submenu");
-    await userEvent.keyboard("{ArrowDown}");
-    expect(document.activeElement?.getAttribute("slot")).toBe("submenu");
-    await userEvent.keyboard("{Escape}");
-    await expect.poll(() => (reopened as HTMLElement & { open: boolean }).open).toBe(false);
+    await expect.poll(() => (menu as HTMLElement & { open: boolean }).open).toBe(false);
   });
 });

--- a/ui/src/test-helpers/app-sidebar-cases/identity-menu.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/identity-menu.ts
@@ -99,4 +99,65 @@ describe("AppSidebar footer identity menu", () => {
     expect(onNavigate).toHaveBeenCalledWith("profile", { hash: "#settings-profile-identity" });
     expect(sidebar.querySelector(".sidebar-identity-menu")).toBeNull();
   });
+
+  it.each([false, true])(
+    "traverses footer controls without losing the active menu item (offline: %s)",
+    async (offline) => {
+      const { sidebar } = await mountSidebar(
+        createGatewayHarness({ instanceId: "self-instance" } as GatewayBrowserClient).gateway,
+        createSessions("main", ["agent:main:main"]),
+      );
+      sidebar.connected = true;
+      sidebar.canPairDevice = false;
+      sidebar.offline = offline;
+      await sidebar.updateComplete;
+
+      const identity = sidebar.querySelector<HTMLButtonElement>(".sidebar-identity-card");
+      identity?.click();
+      await sidebar.updateComplete;
+
+      const menu = sidebar.querySelector<HTMLElement>(".sidebar-identity-menu");
+      const items = Array.from(menu?.children ?? []).filter(
+        (item): item is HTMLElement & { active: boolean } =>
+          item instanceof HTMLElement &&
+          item.localName === "wa-dropdown-item" &&
+          !item.hasAttribute("disabled"),
+      );
+      const lastItem = items.at(-1);
+      const theme = menu?.querySelector<HTMLButtonElement>(".theme-mode-toggle");
+      const build = document.createElement("a");
+      build.href = "#build";
+      menu?.querySelector(".sidebar-mode-switch")?.insertAdjacentElement("beforebegin", build);
+
+      const arrow = (target: HTMLElement | undefined, key: "ArrowDown" | "ArrowUp") => {
+        target?.dispatchEvent(
+          new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }),
+        );
+      };
+      items.forEach((item) => (item.active = item === lastItem));
+      lastItem?.focus();
+      arrow(lastItem, "ArrowDown");
+      expect(document.activeElement).toBe(build);
+      arrow(build, "ArrowDown");
+      expect(document.activeElement).toBe(theme);
+      arrow(theme ?? undefined, "ArrowUp");
+      expect(document.activeElement).toBe(build);
+      arrow(build, "ArrowUp");
+      expect(document.activeElement).toBe(lastItem);
+      expect(lastItem?.active).toBe(true);
+
+      build.remove();
+      arrow(lastItem, "ArrowDown");
+      expect(document.activeElement).toBe(theme);
+      arrow(theme ?? undefined, "ArrowUp");
+      expect(document.activeElement).toBe(lastItem);
+
+      items[0]?.focus();
+      items.forEach((item) => (item.active = item === items[0]));
+      arrow(items[0], "ArrowUp");
+      expect(document.activeElement).toBe(theme);
+      arrow(theme ?? undefined, "ArrowDown");
+      expect(document.activeElement).toBe(items[0]);
+    },
+  );
 });


### PR DESCRIPTION
## What Problem This Solves

Keyboard-only Control UI users can open the sidebar identity menu but cannot reach its build link or theme toggle: Web Awesome navigates only top-level `wa-dropdown-item` elements, while those native controls live in the menu footer and Tab intentionally closes the transient menu.

Closes #121987

## Why This Change Was Made

The identity-menu owner now shares the existing agent-search keyboard-focus helper instead of adding a separate traversal implementation. It bridges ArrowUp/ArrowDown between enabled top-level menu items and native footer actions, synchronizing Web Awesome's roving `active` state in both directions. That synchronization is essential: after genuine sequential ArrowDown traversal, delegating footer ArrowUp back to Web Awesome skips the final menu item because the dependency still considers that item active.

The helper leaves ordinary item-to-item navigation and nested help submenus to Web Awesome, preserves disabled-item filtering and optional build-link behavior, and keeps the existing native theme-button Enter action plus Tab/Escape dismissal. Wrapping footer actions in `wa-dropdown-item` was rejected because it changes native link/button selection semantics. No shared adapter, dependency internals, public configuration, or theme component changes are required.

Production: **+43/-19 (net +24)**; owner and real-browser regression tests: **+139**. The original proposal required net +86 production lines; reusing the existing agent-search owner logic removes that duplication.

## User Impact

ArrowDown now progresses through every enabled identity-menu row, then the optional build link and theme toggle. ArrowUp returns through those same controls to the actual final menu row; Enter still activates the native theme toggle. Disabled rows and nested submenus remain isolated, and Tab/Escape retain their existing close behavior.

## Evidence

Before the fix, a real isolated Control UI and Chromium session cycled through `settings -> usage -> pair-mobile -> apps -> debug-overlay -> help -> settings` and never reached the visible build/theme footer controls. The new focused owner regression also failed on clean main because focus remained on the final `wa-dropdown-item` instead of advancing into the footer.

After the fix, real Chromium keyboard events traverse the entire rendered item sequence and prove:

| Starting focus | Key | Result |
| --- | --- | --- |
| Each enabled menu row | ArrowDown | Next actual menu row |
| Final menu row | ArrowDown | Build-link-position native anchor |
| Build-link-position anchor | ArrowDown | Theme toggle |
| Theme toggle | ArrowUp | Build-link-position anchor |
| Build-link-position anchor | ArrowUp | Actual final menu row, with its roving `active` state restored |
| Final menu row, without build link | ArrowDown | Theme toggle directly |
| Theme toggle | Enter | Native `theme-change` event; mode advances from system to light |
| Theme toggle | Tab | Transient menu closes |
| Help submenu | ArrowRight, ArrowDown, ArrowLeft | Nested navigation remains isolated and returns to the actual final parent row |

The focused browser lane lacks compile-time build metadata, so it inserts a test-local anchor at the real build-link position without modifying global metadata or shared browser state.

```text
Focused genuine Chromium browser regression: 1 passed (1), 1.67s
Exact hosted three-worker UI command, sidebar/Chromium/Web Awesome/theme: 294 passed (294)
Full Control UI typecheck: passed
Scoped oxlint, formatting, and git diff --check: passed
Independent source-only Codex autoreview: clean; no actionable findings
```

Owner regressions cover online/offline menus, disabled rows, forward and reverse footer transitions, optional missing build links, and wraparound. Hosted CI exposed a brittle browser-test reopen under the full non-isolated suite; the final test instead proves nested help navigation inline during the same genuine menu traversal, then closes exactly once with Tab. Existing Web Awesome owner tests independently cover Escape. The screenshot is retained locally because no approved sanitized public upload destination was established; no screen-reader session was run.

## AI Assistance

- AI-assisted: Yes, with Codex.
- Original contributor implementation and issue analysis are preserved through commit co-authorship.
- The final owner-level refactor and genuine keyboard regression were independently reviewed and exercised against the actual Web Awesome dependency contract.
