### PR TITLE
chore(deadcode): remove stale Knip config scaffolding

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -190,10 +190,6 @@ const rootEntries = [
   "src/plugins/contracts/rootdir-boundary-canary.ts!",
   // Mintlify executes every JavaScript file in the docs content directory on each page.
   "docs/nav-tabs-underline.js!",
-  // Knip loads these audit configurations by command-line path.
-  "config/knip.config.ts!",
-  "config/knip.all-exports.config.ts!",
-  "config/knip.scripts-exports.config.ts!",
   // Native applications load these JavaScript assets directly rather than through Node imports.
   "apps/android/app/src/main/assets/katex/katex.min.js!",
   "apps/android/app/src/main/assets/katex/renderer.js!",
@@ -419,8 +415,6 @@ const config = {
     // Focused media tests consume these explicit seams; production uses the helpers in-module.
     "src/agents/embedded-agent-subscribe.handlers.lifecycle.ts": ["exports"],
     "src/gateway/server-methods/chat-webchat-media.ts": ["exports"],
-    // Collection reconcile behavior is asserted by the focused review tests;
-    // production wires only the scheduled review loop.
     // Greeting cache/fact contracts (hash, alert text, store shapes) are
     // asserted by the focused greeting unit tests, not by another prod module.
     "src/system-agent/greeting.ts": ["exports", "types"],


### PR DESCRIPTION
## What Problem This Solves

Removes stale Knip configuration scaffolding that duplicated three already-registered audit entrypoints and left two comments describing an export suppression that no longer exists.

## Why This Change Was Made

The audit entrypoints were first registered by #108648 (`906c7332d20`) and then accidentally repeated by #108717 (`7e1d93d36d7`). The collection-review suppression was added in `db879e73fa9`; #121751 (`9175530fc1a`) localized that helper and removed the suppression key but left its comments behind. This change removes only those redundant lines and leaves the canonical entries and current suppressions unchanged.

AI-assisted cleanup. No agent transcript is included.

## User Impact

No runtime or user-visible behavior changes. The dead-code scanner configuration is smaller and has one canonical declaration for each affected entrypoint.

Production LOC: +0/-0 (net 0) | Tests: +0/-0 | Configuration: +0/-6

## Evidence

- `pnpm deadcode:exports` — production, full-tree, and script unused-export scans all passed with 0 findings.
- `pnpm deadcode:full` — passed with 0 findings.
- `node scripts/check-changed.mjs` — passed the tooling lane; remote providers were unavailable, so the repository wrapper used its documented local fallback.
- `git diff --check` — passed.
- Structured autoreview — clean; no accepted/actionable findings.

