### PR TITLE
fix: Slack agent RPC messages use configured identity

### DIFF
--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -7,7 +7,6 @@ import type {
 } from "../../channels/plugins/types.public.js";
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import type { OutboundIdentity } from "../../infra/outbound/identity.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
@@ -181,7 +180,6 @@ function latestOutboundDeliveryArgs(): {
   payloads: ReplyPayload[];
   bestEffort?: boolean;
   queuePolicy?: string;
-  identity?: OutboundIdentity;
   replyPayloadSendingHook?: ReplyPayloadSendingHookArgs;
 } {
   const args = lastMockArg(deliverOutboundPayloadsMock, "outbound delivery arguments");
@@ -197,7 +195,6 @@ function latestOutboundDeliveryArgs(): {
     payloads: ReplyPayload[];
     bestEffort?: boolean;
     queuePolicy?: string;
-    identity?: OutboundIdentity;
     replyPayloadSendingHook?: ReplyPayloadSendingHookArgs;
   };
 }
@@ -443,28 +440,29 @@ describe("deliverAgentCommandResult payload normalization", () => {
     });
   });
 
-  it("passes the active agent identity through durable delivery", async () => {
+  it.each([
+    { source: "outbound agent", outboundSession: { agentId: "worker" }, name: "Worker" },
+    { source: "session key", sessionKey: "agent:worker:slack:channel:c123", name: "Worker" },
+    { source: "sole agent", name: "Default" },
+  ])("carries the $source identity through durable final delivery", async (testCase) => {
     await deliverAgentCommandResultForTest({
       cfg: {
         agents: {
-          list: [
-            {
-              id: "tester",
-              identity: { name: "  Pulse  ", emoji: "  📟  " },
-            },
-          ],
+          entries: {
+            main: { identity: { name: " Default ", emoji: " :robot_face: " } },
+            ...(testCase.name === "Worker"
+              ? { worker: { identity: { name: " Worker ", emoji: " :robot_face: " } } }
+              : {}),
+          },
         },
-      } as OpenClawConfig,
-      outboundSession: {
-        key: "agent:tester:slack:direct:alice",
-        agentId: "tester",
-      } as never,
+      },
+      outboundSession: testCase.outboundSession,
+      opts: { sessionKey: testCase.sessionKey },
       payloads: [{ text: "final answer" }],
     });
 
-    expect(latestOutboundDeliveryArgs().identity).toMatchObject({
-      name: "Pulse",
-      emoji: "📟",
+    expect(latestOutboundDeliveryArgs()).toMatchObject({
+      identity: { name: testCase.name, emoji: ":robot_face:" },
     });
   });
 

--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -7,6 +7,7 @@ import type {
 } from "../../channels/plugins/types.public.js";
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { OutboundIdentity } from "../../infra/outbound/identity.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
@@ -180,6 +181,7 @@ function latestOutboundDeliveryArgs(): {
   payloads: ReplyPayload[];
   bestEffort?: boolean;
   queuePolicy?: string;
+  identity?: OutboundIdentity;
   replyPayloadSendingHook?: ReplyPayloadSendingHookArgs;
 } {
   const args = lastMockArg(deliverOutboundPayloadsMock, "outbound delivery arguments");
@@ -195,6 +197,7 @@ function latestOutboundDeliveryArgs(): {
     payloads: ReplyPayload[];
     bestEffort?: boolean;
     queuePolicy?: string;
+    identity?: OutboundIdentity;
     replyPayloadSendingHook?: ReplyPayloadSendingHookArgs;
   };
 }
@@ -437,6 +440,31 @@ describe("deliverAgentCommandResult payload normalization", () => {
         sessionKey: "agent:tester:slack:direct:alice",
         runId: "run-1",
       },
+    });
+  });
+
+  it("passes the active agent identity through durable delivery", async () => {
+    await deliverAgentCommandResultForTest({
+      cfg: {
+        agents: {
+          list: [
+            {
+              id: "tester",
+              identity: { name: "  Pulse  ", emoji: "  📟  " },
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      outboundSession: {
+        key: "agent:tester:slack:direct:alice",
+        agentId: "tester",
+      } as never,
+      payloads: [{ text: "final answer" }],
+    });
+
+    expect(latestOutboundDeliveryArgs().identity).toMatchObject({
+      name: "Pulse",
+      emoji: "📟",
     });
   });
 

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -929,7 +929,6 @@ export async function deliverAgentCommandResult(
     if (deliveryTarget && !deliveryStatus) {
       params.assertDeliveryCurrent?.();
       const restartAbort = createRestartOnlyAbortSignal(opts.abortSignal);
-      const outboundIdentity = resolveAgentOutboundIdentity(cfg, deliveryAgentId);
       let send: DurableSendResult;
       try {
         send = await sendDurableMessageBatch({
@@ -939,7 +938,7 @@ export async function deliverAgentCommandResult(
           accountId: resolvedAccountId,
           payloads: deliveryPayloads,
           session: outboundSession,
-          identity: outboundIdentity,
+          identity: resolveAgentOutboundIdentity(cfg, deliveryAgentId),
           replyPayloadSendingHook: {
             kind: "final",
             channel: deliveryChannel,

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -36,6 +36,7 @@ import {
 } from "../../infra/outbound/agent-delivery.js";
 import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
 import { buildOutboundResultEnvelope } from "../../infra/outbound/envelope.js";
+import { resolveAgentOutboundIdentity } from "../../infra/outbound/identity.js";
 import {
   createOutboundPayloadPlan,
   formatOutboundPayloadLog,
@@ -928,6 +929,7 @@ export async function deliverAgentCommandResult(
     if (deliveryTarget && !deliveryStatus) {
       params.assertDeliveryCurrent?.();
       const restartAbort = createRestartOnlyAbortSignal(opts.abortSignal);
+      const outboundIdentity = resolveAgentOutboundIdentity(cfg, deliveryAgentId);
       let send: DurableSendResult;
       try {
         send = await sendDurableMessageBatch({
@@ -937,6 +939,7 @@ export async function deliverAgentCommandResult(
           accountId: resolvedAccountId,
           payloads: deliveryPayloads,
           session: outboundSession,
+          identity: outboundIdentity,
           replyPayloadSendingHook: {
             kind: "final",
             channel: deliveryChannel,


### PR DESCRIPTION
Reviewed head: `aad120619df52308a96480f84c796e73f2ef067e`.

## What Problem This Solves

Agent RPC delivery selected the correct agent but omitted its configured display identity from durable outbound delivery. Pass the existing canonical identity resolver's result at that producer boundary, so Slack receives the configured name and emoji. The repair adds two production lines and preserves the existing channel-independent delivery contract and Slack customization fallback. Thanks @Iskam31.

## Evidence

Three regression cases cover explicit outbound ownership, session-key selection, and the sole configured agent. They failed before the fix; 103 owner/sibling tests and full static gates passed during development. A fresh standalone checkout was then installed from the frozen lockfile, built, and tested through a real Gateway against the auditable current-main merge candidate.

The server's main ref was resolved to `f085148cf5178a94b7e27d47780e944fe11c28bd`. This command produces `5ea24365044041828e0331181afcba89d20f834d`, which matches the **entire tracked source tree** used by the successful fresh build and Gateway run:

```sh
git merge-tree --write-tree f085148cf5178a94b7e27d47780e944fe11c28bd aad120619df52308a96480f84c796e73f2ef067e
```

The Gateway received an `agent` RPC for synthetic agent `qa`, made one request to the mock model provider, and emitted this accepted Slack HTTP request:

```json
{
  "method": "POST",
  "path": "/api/chat.postMessage",
  "accepted": true,
  "body": {
    "channel": "CIDENTITY",
    "text": "RPC-IDENTITY-OK",
    "unfurl_links": "false",
    "username": "Synthetic Worker",
    "icon_emoji": ":robot_face:"
  },
  "modelRequests": 1,
  "gatewayFinalResponseReceived": true,
  "gatewayTemporaryStateRemoved": true
}
```

This is a real ephemeral Gateway and synthetic Slack HTTP service, not an authenticated Slack workspace. The full source-tree comparison covers the changed delivery owner and its current Gateway, durable-send, Slack, and mock-provider callers and dependencies. The delivery owner SHA256 is `a704e12b369e259bb09d678a61d8199b550b4e8f04561f5108d3bdb490ce4775`; its regression test SHA256 is `68196897ff62fb0f99d41b746b290d51a36f0eb7c2c96b54c2c763d6ca41fa00`.

Latest review disposition: the literal external-branch runtime rank-up is skipped in favor of the requested auditable current-main merge trace above. This fresh complete-merge proof supersedes the earlier patch-equivalent handoff proof. Exact published-head CI [CI run 33498173374](https://github.com/openclaw/openclaw/actions/runs/33498173374) passed on attempt 2 at the unchanged head. Attempt 1 failed only while downloading the Matrix crypto binary: GitHub returned HTTP 429 and the dependency's error handler referenced an undefined variable; the check itself had not run. No source change or unrelated main merge was needed for the successful retry.
