### PR TITLE
fix(gateway): report all-failed Web Push tests

### DIFF
--- a/src/gateway/server-methods/push.test.ts
+++ b/src/gateway/server-methods/push.test.ts
@@ -1,5 +1,5 @@
-// Push method tests cover APNs direct/relay registrations, alert delivery,
-// stale registration cleanup, config resolution, and error mapping.
+// Push method tests cover APNs direct/relay registrations, Web Push delivery
+// outcomes, stale registration cleanup, config resolution, and error mapping.
 
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -24,6 +24,13 @@ vi.mock("../../infra/push-apns.js", () => ({
   shouldClearStoredApnsRegistration: vi.fn(),
 }));
 
+vi.mock("../../infra/push-web.js", () => ({
+  broadcastWebPush: vi.fn(),
+  clearWebPushSubscriptionByEndpoint: vi.fn(),
+  registerWebPushSubscription: vi.fn(),
+  resolveVapidKeys: vi.fn(),
+}));
+
 import {
   type ApnsRegistration,
   clearApnsRegistrationIfCurrent,
@@ -34,10 +41,12 @@ import {
   sendApnsAlert,
   shouldClearStoredApnsRegistration,
 } from "../../infra/push-apns.js";
+import { broadcastWebPush } from "../../infra/push-web.js";
 
 type ApnsPushResult = Awaited<ReturnType<typeof sendApnsAlert>>;
+type WebPushResults = Awaited<ReturnType<typeof broadcastWebPush>>;
 
-type RespondCall = [boolean, unknown?, { code: number; message: string }?];
+type RespondCall = [boolean, unknown?, { code: string; message: string; details?: unknown }?];
 
 const DEFAULT_DIRECT_REGISTRATION = {
   nodeId: "ios-node-1",
@@ -110,6 +119,25 @@ function createInvokeParams(params: Record<string, unknown>) {
         context: { getRuntimeConfig: () => mocks.getRuntimeConfig() } as never,
         client: null,
         req: { type: "req", id: "req-1", method: "push.test" },
+        isWebchatConnect: () => false,
+      }),
+  };
+}
+
+function createWebPushTestInvokeParams(params: Record<string, unknown> = {}) {
+  const respond = vi.fn();
+  return {
+    respond,
+    invoke: async () =>
+      await expectDefined(
+        pushHandlers["push.web.test"],
+        'pushHandlers["push.web.test"] test invariant',
+      )({
+        params,
+        respond: respond as never,
+        context: {} as never,
+        client: null,
+        req: { type: "req", id: "req-1", method: "push.web.test" },
         isWebchatConnect: () => false,
       }),
   };
@@ -332,5 +360,71 @@ describe("push.test handler", () => {
       overrideEnvironment: "production",
     });
     expect(clearApnsRegistrationIfCurrent).not.toHaveBeenCalled();
+  });
+});
+
+describe("push.web.test handler", () => {
+  beforeEach(() => {
+    vi.mocked(broadcastWebPush).mockReset();
+  });
+
+  it("returns unavailable with delivery results when every attempt fails", async () => {
+    const results: WebPushResults = [
+      {
+        ok: false,
+        subscriptionId: "expired-subscription",
+        statusCode: 410,
+        error: "Gone",
+      },
+      {
+        ok: false,
+        subscriptionId: "rejected-subscription",
+        statusCode: 503,
+        error: "Service Unavailable",
+      },
+    ];
+    vi.mocked(broadcastWebPush).mockResolvedValue(results);
+
+    const { respond, invoke } = createWebPushTestInvokeParams();
+    await invoke();
+
+    expect(respond).toHaveBeenCalledTimes(1);
+    const call = firstRespondCall(respond);
+    expect(call?.[0]).toBe(false);
+    expect(call?.[1]).toBeUndefined();
+    expect(call?.[2]?.code).toBe(ErrorCodes.UNAVAILABLE);
+    expect(call?.[2]?.details).toEqual({ results });
+  });
+
+  it("returns all delivery results when at least one attempt succeeds", async () => {
+    const results: WebPushResults = [
+      {
+        ok: true,
+        subscriptionId: "active-subscription",
+        statusCode: 201,
+      },
+      {
+        ok: false,
+        subscriptionId: "expired-subscription",
+        statusCode: 410,
+        error: "Gone",
+      },
+    ];
+    vi.mocked(broadcastWebPush).mockResolvedValue(results);
+
+    const { respond, invoke } = createWebPushTestInvokeParams();
+    await invoke();
+
+    expect(respond).toHaveBeenCalledTimes(1);
+    expect(firstRespondCall(respond)).toEqual([true, { results }, undefined]);
+  });
+
+  it("returns invalid request when no subscriptions are registered", async () => {
+    vi.mocked(broadcastWebPush).mockResolvedValue([]);
+
+    const { respond, invoke } = createWebPushTestInvokeParams();
+    await invoke();
+
+    expectInvalidRequestResponse(respond, "no web push subscriptions registered");
   });
 });

--- a/src/gateway/server-methods/push.ts
+++ b/src/gateway/server-methods/push.ts
@@ -200,6 +200,16 @@ export const pushHandlers: GatewayRequestHandlers = {
         );
         return;
       }
+      if (!results.some((result) => result.ok)) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.UNAVAILABLE, "all web push deliveries failed", {
+            details: { results },
+          }),
+        );
+        return;
+      }
       respond(true, { results }, undefined);
     });
   },


### PR DESCRIPTION
Closes #122062

## What Problem This Solves

Fixes `push.web.test` reporting RPC success when every registered browser delivery failed. The delivery layer correctly preserved one `ok: false` result per subscription, but the Gateway rejected only the zero-subscription case. The Control UI therefore showed neither a notification nor an error.

## Why This Change Was Made

The Gateway fan-out owner now distinguishes three outcomes:

- no subscriptions: existing `INVALID_REQUEST` behavior;
- every attempted delivery failed: `UNAVAILABLE` with the original `{ results }` in error details;
- at least one delivery succeeded: unchanged successful `{ results }`, including failed entries.

No retries, protocol schema/version, UI state, copy, or partial-success policy were added.

## User Impact

The Web Push test action now displays a real error when no browser received the test. Partial delivery remains successful and preserves per-subscription diagnostics.

## Evidence

- Pre-fix handler regression: 1 intended failure, 9 passing; all-failed received success instead of failure.
- `node scripts/run-vitest.mjs src/gateway/server-methods/push.test.ts` — 10 passed after fix/rebase.
- `node scripts/run-vitest.mjs src/infra/push-web.test.ts` — 16 passed.
- Targeted oxfmt, oxlint, and `git diff --check` passed.
- Mandatory autoreview and TruffleHog were clean.
- Testbox Actions run 31502383148 completed the focused proof; retained lease was stopped.
- Production delta: +10/-0; tests: +97/-3.
- No UI, retry, protocol, config, schema, docs, or changelog change.

AI-assisted implementation; no agent transcript attached.