### PR TITLE
test(macos): remove private helper mirrors

### DIFF
--- a/apps/macos/Sources/OpenClaw/PresenceReporter.swift
+++ b/apps/macos/Sources/OpenClaw/PresenceReporter.swift
@@ -96,18 +96,6 @@ extension PresenceReporter {
         self.composePresenceSummary(mode: mode, reason: reason)
     }
 
-    static func _testAppVersionString() -> String {
-        self.appVersionString()
-    }
-
-    static func _testPlatformString() -> String {
-        self.platformString()
-    }
-
-    static func _testPrimaryIPv4Address() -> String? {
-        SystemPresenceInfo.primaryIPv4Address()
-    }
-
     static func _testActivityPrivacyParameters() -> [String: AnyHashable] {
         [
             "lastInputSeconds": AnyHashable(self.legacyClearedLastInputSeconds),

--- a/apps/macos/Sources/OpenClaw/VoicePushToTalk.swift
+++ b/apps/macos/Sources/OpenClaw/VoicePushToTalk.swift
@@ -391,19 +391,6 @@ actor VoicePushToTalk {
             sendChime: state.voiceWakeSendChime)
     }
 
-    // MARK: - Test helpers
-
-    static func _testDelta(committed: String, current: String) -> String {
-        VoiceOverlayTextFormatting.delta(after: committed, current: current)
-    }
-
-    static func _testAttributedColors(isFinal: Bool) -> (NSColor, NSColor) {
-        let sample = VoiceOverlayTextFormatting.makeAttributed(committed: "a", volatile: "b", isFinal: isFinal)
-        let committedColor = sample.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor ?? .clear
-        let volatileColor = sample.attribute(.foregroundColor, at: 1, effectiveRange: nil) as? NSColor ?? .clear
-        return (committedColor, volatileColor)
-    }
-
     private static func join(_ prefix: String, _ suffix: String) -> String {
         if prefix.isEmpty { return suffix }
         if suffix.isEmpty { return prefix }

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -969,26 +969,7 @@ private struct MacChatSurface: View {
             title: String(localized: "Catch me up"),
             prompt: String(localized: "Summarize what happened in my threads since yesterday.")),
     ]
-
-    #if DEBUG
-    var _testCapabilities: MacChatSurfaceCapabilities {
-        MacChatSurfaceCapabilities(
-            hasTalkControl: true,
-            hasSpeech: true,
-            hasVoiceNoteControl: true,
-            displayOptions: self.displayOptions)
-    }
-    #endif
 }
-
-#if DEBUG
-struct MacChatSurfaceCapabilities: Equatable {
-    let hasTalkControl: Bool
-    let hasSpeech: Bool
-    let hasVoiceNoteControl: Bool
-    let displayOptions: OpenClawChatDisplayOptions
-}
-#endif
 
 /// Bridges the view model's session switches out of the controller. The view
 /// model is constructed before `self`, so the closure targets this box and the
@@ -1317,15 +1298,6 @@ final class WebChatSwiftUIWindowController: NSObject, NSWindowDelegate {
 
     var _testSceneBridgingOptions: NSHostingSceneBridgingOptions? {
         (self.contentController as? NSHostingController<MacChatSurface>)?.sceneBridgingOptions
-    }
-
-    var _testChatCapabilities: MacChatSurfaceCapabilities? {
-        if let hosting = contentController as? NSHostingController<MacChatSurface> {
-            return hosting.rootView._testCapabilities
-        }
-        return self.contentController.children
-            .compactMap { $0 as? NSHostingController<MacChatSurface> }
-            .first?.rootView._testCapabilities
     }
 
     var _testActiveAgentID: String? {

--- a/apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift
@@ -114,13 +114,10 @@ struct LowCoverageHelperTests {
         #expect(decoded.isConnected == false)
     }
 
-    @Test @MainActor func `presence reporter helpers`() {
+    @Test @MainActor func `presence reporter summary and privacy parameters`() {
         let summary = PresenceReporter._testComposePresenceSummary(mode: "local", reason: "test")
         #expect(summary.contains("mode local"))
         #expect(!summary.contains("last input"))
-        #expect(!PresenceReporter._testAppVersionString().isEmpty)
-        #expect(!PresenceReporter._testPlatformString().isEmpty)
-        _ = PresenceReporter._testPrimaryIPv4Address()
         let privacyParameters = PresenceReporter._testActivityPrivacyParameters()
         #expect(privacyParameters["lastInputSeconds"]?.base as? Int == 2_592_000)
         #expect(

--- a/apps/macos/Tests/OpenClawIPCTests/VoicePushToTalkTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/VoicePushToTalkTests.swift
@@ -46,22 +46,12 @@ struct VoicePushToTalkTests {
     }
 
     @Test func `delta trims committed prefix`() {
-        let delta = VoicePushToTalk._testDelta(committed: "hello ", current: "hello world again")
+        let delta = VoiceOverlayTextFormatting.delta(after: "hello ", current: "hello world again")
         #expect(delta == "world again")
     }
 
     @Test func `delta falls back when prefix differs`() {
-        let delta = VoicePushToTalk._testDelta(committed: "goodbye", current: "hello world")
+        let delta = VoiceOverlayTextFormatting.delta(after: "goodbye", current: "hello world")
         #expect(delta == "hello world")
-    }
-
-    @Test func `attributed colors differ when not final`() {
-        let colors = VoicePushToTalk._testAttributedColors(isFinal: false)
-        #expect(colors.0 != colors.1)
-    }
-
-    @Test func `attributed colors match when final`() {
-        let colors = VoicePushToTalk._testAttributedColors(isFinal: true)
-        #expect(colors.0 == colors.1)
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/VoicePushToTalkTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/VoicePushToTalkTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import AVFoundation
 import Testing
 @testable import OpenClaw
@@ -53,5 +54,19 @@ struct VoicePushToTalkTests {
     @Test func `delta falls back when prefix differs`() {
         let delta = VoiceOverlayTextFormatting.delta(after: "goodbye", current: "hello world")
         #expect(delta == "hello world")
+    }
+
+    @Test func `partial transcript distinguishes volatile text`() throws {
+        let text = VoiceOverlayTextFormatting.makeAttributed(committed: "a", volatile: "b", isFinal: false)
+        let committed = try #require(text.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor)
+        let volatile = try #require(text.attribute(.foregroundColor, at: 1, effectiveRange: nil) as? NSColor)
+        #expect(committed != volatile)
+    }
+
+    @Test func `final transcript uses one text color`() throws {
+        let text = VoiceOverlayTextFormatting.makeAttributed(committed: "a", volatile: "b", isFinal: true)
+        let committed = try #require(text.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor)
+        let volatile = try #require(text.attribute(.foregroundColor, at: 1, effectiveRange: nil) as? NSColor)
+        #expect(committed == volatile)
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/WebChatSwiftUISmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/WebChatSwiftUISmokeTests.swift
@@ -125,28 +125,11 @@ struct WebChatSwiftUISmokeTests {
     }
 
     @Test func `window controller merges titlebar and keeps toolbar controls`() throws {
-        let traceKeys = [
-            OpenClawChatWindowShell.assistantTraceDefaultsKey,
-            OpenClawChatWindowShell.assistantReasoningDefaultsKey,
-            OpenClawChatWindowShell.assistantToolActivityDefaultsKey,
-        ]
-        let previousTraceValues = traceKeys.map { ($0, UserDefaults.standard.object(forKey: $0)) }
-        traceKeys.forEach { UserDefaults.standard.removeObject(forKey: $0) }
-        defer {
-            for (key, value) in previousTraceValues {
-                if let value {
-                    UserDefaults.standard.set(value, forKey: key)
-                } else {
-                    UserDefaults.standard.removeObject(forKey: key)
-                }
-            }
-        }
         let controller = WebChatSwiftUIWindowController(
             sessionKey: "main",
             transport: TestTransport(),
             windowTitle: "Studio — OpenClaw")
         let window = try #require(controller._testWindow)
-        let capabilities = try #require(controller._testChatCapabilities)
 
         #expect(window.styleMask.contains(.fullSizeContentView))
         #expect(window.titleVisibility == .hidden)
@@ -160,10 +143,6 @@ struct WebChatSwiftUISmokeTests {
         #expect(window.title == "Studio — OpenClaw")
         #expect(controller._testSceneBridgingOptions?.contains(.toolbars) == true)
         #expect(controller._testSceneBridgingOptions?.contains(.title) == false)
-        #expect(capabilities.hasTalkControl)
-        #expect(capabilities.hasSpeech)
-        #expect(capabilities.hasVoiceNoteControl)
-        #expect(capabilities.displayOptions == .assistantTrace)
 
         controller.show()
         #expect(window.titleVisibility == .hidden)


### PR DESCRIPTION
## What Problem This Solves

Several macOS tests still depended on DEBUG-only mirrors that did not independently observe the production UI or behavior: native-chat capability booleans hardcoded to true, a push-to-talk adapter plus synthetic color probe, and trivial PresenceReporter app/platform/IP accessors. These seams added maintenance whenever implementation structure changed without catching credible regressions.

## Why This Change Was Made

This removes the native-chat capability structs/accessors and their defaults-mutating assertions, moves the two useful delta cases directly to `VoiceOverlayTextFormatting`, deletes private attributed-color probes, and removes trivial PresenceReporter accessors while retaining summary and privacy compatibility checks.

## User Impact

No intended user-visible change. The chat window titlebar/toolbar, voice delta behavior, and presence privacy contract remain covered; only implementation mirrors and vacuous probes are removed.

## Evidence

- WebChatSwiftUISmokeTests, VoicePushToTalkTests, VoiceWakeRuntimeTests, and LowCoverageHelperTests: 59 tests passed.
- `swift build --package-path apps/macos --target OpenClaw`: passed.
- macOS SwiftFormat source lint and `git diff --check`: passed.
- Full changed-file gate and structured review: clean; SwiftLint, macOS packaging/service test lanes, native schema guard, and repository safety checks passed through trusted local fallback because Blacksmith/Testbox is unavailable on this host.

Production delta: -53 lines. Tests: -19 lines. Overall: -72 lines.

AI-assisted maintenance cleanup; the diff and behavior evidence were reviewed directly.
