### PR TITLE
fix(ci): bound hosted Android build memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3686,14 +3686,29 @@ jobs:
               ./gradlew --no-daemon --build-cache :wear:testDebugUnitTest
               ;;
             build-play)
-              ./gradlew --no-daemon --build-cache \
-                :app:assemblePlayDebug \
-                :app:assembleThirdPartyDebug \
-                :app:lintPlayDebug \
-                :app:lintThirdPartyDebug \
-                :benchmark:assembleDebug \
-                :wear-shared:assembleDebug \
-                :wear-shared:lintDebug
+              if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+                # GitHub-hosted runners have less memory headroom. Separate Gradle
+                # processes release each variant's build state before the next starts.
+                ./gradlew --no-daemon --build-cache \
+                  :app:assemblePlayDebug \
+                  :app:lintPlayDebug
+                ./gradlew --no-daemon --build-cache \
+                  :app:assembleThirdPartyDebug \
+                  :app:lintThirdPartyDebug
+                ./gradlew --no-daemon --build-cache \
+                  :benchmark:assembleDebug \
+                  :wear-shared:assembleDebug \
+                  :wear-shared:lintDebug
+              else
+                ./gradlew --no-daemon --build-cache \
+                  :app:assemblePlayDebug \
+                  :app:assembleThirdPartyDebug \
+                  :app:lintPlayDebug \
+                  :app:lintThirdPartyDebug \
+                  :benchmark:assembleDebug \
+                  :wear-shared:assembleDebug \
+                  :wear-shared:lintDebug
+              fi
               ;;
             build-wear)
               ./gradlew --no-daemon --build-cache \

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2690,29 +2690,67 @@ NODE
   it("covers Android app variants, lint, and benchmark compilation", () => {
     const workflow = readCiWorkflow();
     const source = readFileSync(".github/workflows/ci.yml", "utf8");
-    const runStep = workflow.jobs.android.steps.find(
-      (step: WorkflowStep) => step.name === "Run Android ${{ matrix.task }}",
+    const androidJob = workflow.jobs.android;
+    const runStep = expectDefined(
+      androidJob.steps.find((step: WorkflowStep) => step.name === "Run Android ${{ matrix.task }}"),
+      "Android task runner",
     );
     const nativeResourcesSetup = expectDefined(
-      workflow.jobs.android.steps.find(
+      androidJob.steps.find(
         (step: WorkflowStep) => step.name === "Setup Node environment for native resources",
       ),
       "Android native resources Node setup",
     );
+    const buildPlayCase = expectDefined(
+      runStep.run?.match(/^\s*build-play\)\n([\s\S]*?)^\s*;;$/mu)?.[1],
+      "Android build-play case",
+    );
+    const buildPlayBranches = expectDefined(
+      buildPlayCase.match(
+        /if \[ "\$GITHUB_EVENT_NAME" = "workflow_dispatch" \]; then\n([\s\S]*?)\n\s*else\n([\s\S]*?)\n\s*fi/u,
+      ),
+      "Android build-play event branches",
+    );
+    const dispatchBuild = expectDefined(buildPlayBranches[1], "hosted dispatch build branch");
+    const blacksmithBuild = expectDefined(buildPlayBranches[2], "Blacksmith build branch");
+    const readTasks = (script: string) =>
+      [...script.matchAll(/^\s+(:[a-z][A-Za-z0-9:-]*)\s*\\?$/gmu)].map((match) => match[1]);
+    const dispatchTasks = readTasks(dispatchBuild);
+    const blacksmithTasks = readTasks(blacksmithBuild);
 
     expect(source).toContain('task: useCompatibleAndroidCi ? "test-play-compat" : "test-play"');
     expect(source).toContain(
       '{ check_name: "android-test-third-party", task: "test-third-party" }',
     );
-    expect(source).toContain('check_name: "android-build-play"');
+    expect(source.match(/check_name: "android-build-play"/gu)).toHaveLength(1);
     expect(source).toContain('task: useCompatibleAndroidCi ? "build-play-compat" : "build-play"');
+    expect(androidJob.name).toBe("${{ matrix.check_name }}");
+    expect(androidJob["runs-on"]).toBe(
+      "${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-8vcpu-ubuntu-2404' || 'ubuntu-24.04') }}",
+    );
     expect(runStep.run).toContain(":app:testPlayDebugUnitTest");
     expect(runStep.run).toContain(":app:testThirdPartyDebugUnitTest");
-    expect(runStep.run).toContain(":app:assemblePlayDebug");
-    expect(runStep.run).toContain(":app:assembleThirdPartyDebug");
-    expect(runStep.run).toContain(":app:lintPlayDebug");
-    expect(runStep.run).toContain(":app:lintThirdPartyDebug");
-    expect(runStep.run).toContain(":benchmark:assembleDebug");
+    expect(dispatchBuild.match(/^\s*\.\/gradlew\b/gmu)).toHaveLength(3);
+    expect(dispatchTasks).toEqual([
+      ":app:assemblePlayDebug",
+      ":app:lintPlayDebug",
+      ":app:assembleThirdPartyDebug",
+      ":app:lintThirdPartyDebug",
+      ":benchmark:assembleDebug",
+      ":wear-shared:assembleDebug",
+      ":wear-shared:lintDebug",
+    ]);
+    expect(new Set(dispatchTasks).size).toBe(dispatchTasks.length);
+    expect(blacksmithBuild.match(/^\s*\.\/gradlew\b/gmu)).toHaveLength(1);
+    expect(blacksmithTasks).toEqual([
+      ":app:assemblePlayDebug",
+      ":app:assembleThirdPartyDebug",
+      ":app:lintPlayDebug",
+      ":app:lintThirdPartyDebug",
+      ":benchmark:assembleDebug",
+      ":wear-shared:assembleDebug",
+      ":wear-shared:lintDebug",
+    ]);
     expect(nativeResourcesSetup.uses).toBe("./.github/actions/setup-node-env");
     expect(nativeResourcesSetup.if).toBe(
       "needs.preflight.outputs.use_compatible_android_ci != 'true'",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the manual Android CI build could exhaust memory on GitHub-hosted runners because Play, ThirdParty, benchmark, and Wear shared compilation and lint all ran in one Gradle process.

## Why This Change Was Made

For `workflow_dispatch` only, the existing `android-build-play` lane now runs three sequential Gradle invocations: Play assemble and lint, ThirdParty assemble and lint, then benchmark plus Wear shared assemble and lint. Pull request and push CI keep the existing combined Blacksmith invocation, check names, compatibility lane, and global 3 GiB Gradle heap.

## User Impact

Maintainers can run the Android manual CI lane with bounded process memory while preserving the same task coverage and normal Blacksmith CI behavior.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts -t "covers Android app variants, lint, and benchmark compilation"`
- `./node_modules/.bin/oxfmt --check .github/workflows/ci.yml test/scripts/ci-workflow-guards.test.ts`
- `git diff origin/main...HEAD --check`
- Cold exact-head hosted dispatch: https://github.com/openclaw/openclaw/actions/runs/31504449666
- Hosted `android-build-play` job: https://github.com/openclaw/openclaw/actions/runs/31504449666/job/93822629275
  - Play assemble + lint: successful in 5m31s
  - ThirdParty assemble + lint: successful in 4m23s
  - Benchmark + Wear shared assemble/lint: successful in 37s
