### PR TITLE
fix(android): keep completed subagent activity visible for sixty seconds

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -5907,7 +5907,8 @@ class ChatController internal constructor(
       if (activity.isWorking) {
         subagentActivityExpiryJobs.remove(taskId)?.cancel()
       } else if (terminal && existing?.isWorking != false) {
-        // Local receipt starts retention; remote endedAt may be old, and duplicate terminal updates must not extend it.
+        // Local receipt starts retention; remote endedAt may be old.
+        // Duplicate terminal updates must not extend that retention window.
         subagentActivityExpiryJobs[taskId] =
           scope.launch {
             delay(SUBAGENT_ACTIVITY_RETENTION_MS)

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -5904,17 +5904,16 @@ class ChatController internal constructor(
               ?: existing?.childSessionKey,
         )
       _subagentActivities.value = _subagentActivities.value + (taskId to activity)
-      subagentActivityExpiryJobs.remove(taskId)?.cancel()
-      if (!activity.isWorking) {
-        val expiresAt = (activity.endedAtMs ?: now) + SUBAGENT_ACTIVITY_RETENTION_MS
-        val expiryDelayMs = (expiresAt - now).coerceAtLeast(0L)
+      if (activity.isWorking) {
+        subagentActivityExpiryJobs.remove(taskId)?.cancel()
+      } else if (terminal && existing?.isWorking != false) {
+        // Local receipt starts retention; remote endedAt may be old, and duplicate terminal updates must not extend it.
         subagentActivityExpiryJobs[taskId] =
           scope.launch {
-            delay(expiryDelayMs)
+            delay(SUBAGENT_ACTIVITY_RETENTION_MS)
             synchronized(subagentActivityLock) {
-              if (_subagentActivities.value[taskId] == activity) {
-                _subagentActivities.value = _subagentActivities.value - taskId
-              }
+              if (subagentActivityExpiryJobs[taskId] !== coroutineContext[Job]) return@synchronized
+              _subagentActivities.value = _subagentActivities.value - taskId
               subagentActivityExpiryJobs.remove(taskId)
             }
           }

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerSubagentActivityTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerSubagentActivityTest.kt
@@ -81,6 +81,44 @@ class ChatControllerSubagentActivityTest {
     }
 
   @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun terminalRetentionUsesFirstLocalObservation() =
+    runTest {
+      val controller = newController()
+      controller.handleGatewayEvent(
+        "task",
+        taskPayload(id = "task-1", status = "completed", endedAt = 1),
+      )
+
+      advanceTimeBy(30_000)
+      runCurrent()
+      assertTrue("task-1" in controller.subagentActivities.value)
+
+      controller.handleGatewayEvent(
+        "task",
+        taskPayload(
+          id = "task-1",
+          status = "completed",
+          terminalSummary = "Updated terminal detail",
+          endedAt = 1,
+        ),
+      )
+      assertEquals(
+        "Updated terminal detail",
+        controller.subagentActivities.value
+          .getValue("task-1")
+          .terminalSummary,
+      )
+      advanceTimeBy(29_999)
+      runCurrent()
+      assertTrue("task-1" in controller.subagentActivities.value)
+
+      advanceTimeBy(1)
+      runCurrent()
+      assertTrue(controller.subagentActivities.value.isEmpty())
+    }
+
+  @Test
   fun sessionSwitchClearsActivityButParentRunCleanupDoesNot() =
     runTest {
       val controller = newController()
@@ -139,6 +177,7 @@ class ChatControllerSubagentActivityTest {
     terminalSummary: String? = null,
     error: String? = null,
     diffStat: Triple<Int, Int, Int>? = null,
+    endedAt: Long? = null,
   ): String =
     buildString {
       append("{\"action\":\"upserted\",\"task\":{")
@@ -148,6 +187,7 @@ class ChatControllerSubagentActivityTest {
       append("\"childSessionKey\":\"agent:worker:subagent:").append(id).append("\",")
       append("\"status\":\"").append(status).append("\",")
       append("\"startedAt\":1000")
+      endedAt?.let { append(",\"endedAt\":").append(it) }
       lastActivity?.let { append(",\"lastActivity\":\"").append(it).append("\"") }
       progressSummary?.let { append(",\"progressSummary\":\"").append(it).append("\"") }
       lastToolName?.let { append(",\"lastToolName\":\"").append(it).append("\"") }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android chat users could see completed subagent activity disappear before the promised 60-second retention window when Gateway timestamps were delayed or clock-skewed. Main now computes its coroutine delay from one clock sample (#122198), but still treats remote `endedAt` as the retention owner and restarts expiry on duplicate terminal updates; this PR closes those remaining user-visible lifecycle gaps.

## Why This Change Was Made

Android retention now starts on the first local working-to-terminal observation, matching the Apple and Web clients. Remote task timestamps remain presentation data, duplicate terminal updates preserve the original deadline, working transitions cancel expiry, and only the authoritative scheduled job may clean up the row.

The focused repair is production net-zero (+8/-8) relative to current main. It carries no generated locale or UI files; the second commit only preserves the source line positions recorded by the native-i18n inventory.

## User Impact

Completed subagent rows remain visible for a full 60 seconds after Android first observes completion, even when the Gateway terminal timestamp is old. Later terminal detail updates no longer extend that window.

## Evidence

- Regression covers an old remote terminal timestamp, a terminal-detail update at +30 seconds, presence through +59,999 ms, and removal at exactly +60,000 ms.
- Original failure: https://github.com/openclaw/openclaw/actions/runs/31499825221/job/93806968500 (`ChatControllerSubagentActivityTest.terminalActivityExpiresAfterSixtySeconds`, 1 failure among 2,227 tests).
- Patch-equivalent head `80bac63fd553584a78dd23c31ce060d95c55cada`: all six Android jobs passed in https://github.com/openclaw/openclaw/actions/runs/31505347510.
- Patch-equivalent focused head `d9d3130ebb2c92d529e0ac7119976fbb8695fb78`: all six Android jobs passed in https://github.com/openclaw/openclaw/actions/runs/31514662871.
- Patch-equivalent focused head `c78d37f1879dde2059ae67d99425756c0532a7ea`: every selected job passed in https://github.com/openclaw/openclaw/actions/runs/31521311816.
- Final focused head: `677583ebf9c52e1005115468a71c05c1d6f205d3`, resolving the overlap with main #122198.
- `:app:ktlintCheck` passed on the final head.
- Codex autoreview reported no accepted/actionable findings on the runtime conflict resolution or the inventory-preserving comment split.
