### PR TITLE
refactor(telegram): merge dispatch controllers into one turn module

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch-delivery.ts
+++ b/extensions/telegram/src/bot-message-dispatch-delivery.ts
@@ -1,5 +1,3 @@
-// Telegram plugin module owns final payload projection and Telegram delivery.
-import type { Bot } from "grammy";
 import type { Message } from "grammy/types";
 import {
   createOutboundPayloadPlan,
@@ -7,40 +5,46 @@ import {
   projectOutboundPayloadPlanForDelivery,
   resolveTranscriptBackedChannelFinalText,
 } from "openclaw/plugin-sdk/channel-outbound";
-import type {
-  OpenClawConfig,
-  ReplyToMode,
-  TelegramAccountConfig,
-} from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-payload";
 import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
-import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import type { TelegramBotDeps } from "./bot-deps.js";
-import type { TelegramMessageContext } from "./bot-message-context.js";
-import type { TelegramDraftController } from "./bot-message-dispatch-draft.js";
-import type { TelegramProgressController } from "./bot-message-dispatch-progress.js";
 import {
-  mirrorTelegramAssistantReplyToTranscript,
+  flushDraftLane,
+  prepareAnswerLaneForText,
+  rotateAnswerLaneAfterQueuedBlocksSettle,
+  rotateAnswerLaneAfterToolProgress,
+} from "./bot-message-dispatch-draft.js";
+import {
+  applyCollapseSummary,
+  markFinalDelivered,
+  markFinalStarted,
+  resetAnswerLaneAfterCollapse,
+  resolveCollapseSummaryLine,
+  teardownProgressWindow,
+} from "./bot-message-dispatch-progress.js";
+import {
   createCurrentTurnTranscriptFinalResolver,
+  mirrorTelegramAssistantReplyToTranscript,
 } from "./bot-message-dispatch-session.js";
 import type {
+  TelegramDispatchTurn as Turn,
+  TelegramDispatchTurnConfig as TurnConfig,
   CurrentTurnTranscriptFinal,
-  FreshTelegramSessionEntryLoader,
+  TelegramDeliveryStateSlice,
   TelegramTranscriptMirrorPayload,
 } from "./bot-message-dispatch.types.js";
-import type { TelegramBotOptions } from "./bot.types.js";
 import { deliverReplies, emitTelegramMessageSentHooks } from "./bot/delivery.js";
-import { resolveTelegramReplyId, type TelegramThreadSpec } from "./bot/helpers.js";
-import type { TelegramNativeQuoteCandidateByMessageId } from "./bot/native-quote.js";
+import { resolveTelegramReplyId } from "./bot/helpers.js";
 import type { TelegramInlineButtons } from "./button-types.js";
 import { mergeTelegramPartialDeliveryError } from "./chunk-delivery.js";
 import { canonicalizeTelegramPresentationPayload } from "./interactive-fallback.js";
 import {
   createLaneDeliveryStateTracker,
   createLaneTextDeliverer,
+  type DraftLaneState,
   type LaneDeliveryResult,
+  type LaneName,
 } from "./lane-delivery.js";
 import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
 import {
@@ -54,569 +58,594 @@ import {
 import { editMessageTelegram } from "./send.js";
 import { resolveTelegramTargetChatType } from "./targets.js";
 
-export function createTelegramDeliveryController(params: {
-  bot: Bot;
-  cfg: OpenClawConfig;
-  chunkMode: ReturnType<typeof import("./bot-message-dispatch.runtime.js").resolveChunkMode>;
-  context: TelegramMessageContext;
-  dispatchStartedAt: number;
-  draft: TelegramDraftController;
-  isDispatchSuperseded: () => boolean;
-  loadFreshSessionEntry: FreshTelegramSessionEntryLoader;
-  mediaLocalRoots: readonly string[];
-  opts: Pick<TelegramBotOptions, "token" | "mediaMaxMb">;
-  progress: TelegramProgressController;
-  draftReplyToMessageId?: number;
-  replyQuoteByMessageId: TelegramNativeQuoteCandidateByMessageId;
-  replyQuoteEntities?: Message["entities"];
-  replyQuoteMessageId?: number;
-  replyQuotePosition?: number;
-  replyQuoteText?: string;
-  replyToMode: ReplyToMode;
-  runtime: RuntimeEnv;
-  streamMode: import("./bot/types.js").TelegramStreamMode;
-  tableMode: Parameters<typeof deliverReplies>[0]["tableMode"];
-  telegramCfg: TelegramAccountConfig;
-  telegramDeps: TelegramBotDeps;
-  textLimit: number;
-  threadSpec: TelegramThreadSpec;
-}) {
-  const { context } = params;
-  const sessionKey = context.ctxPayload.SessionKey;
-  const deliveryState = createLaneDeliveryStateTracker();
-  const resolveCurrentTurnTranscriptFinal = createCurrentTurnTranscriptFinalResolver({
-    agentId: context.route.agentId,
-    dispatchStartedAt: params.dispatchStartedAt,
-    loadFreshSessionEntry: params.loadFreshSessionEntry,
-    sessionKey,
-  });
-  let transcriptMirrorSequence = 0;
-  const transcriptMirrorTurnId = `${context.chatId}:${context.ctxPayload.MessageSid ?? context.msg.message_id ?? params.dispatchStartedAt}`;
-  const implicitQuoteReplyTargetId =
-    context.ctxPayload.ReplyToIsQuote &&
-    !context.msg.reply_to_message?.from?.is_bot &&
-    params.replyQuoteMessageId != null
-      ? String(params.replyQuoteMessageId)
-      : undefined;
-  const currentMessageIdForQuoteReply =
-    implicitQuoteReplyTargetId && context.ctxPayload.MessageSid
-      ? context.ctxPayload.MessageSid
-      : undefined;
+type TelegramDeliveryConfig = TurnConfig & {
+  lanes: Record<LaneName, DraftLaneState>;
+};
 
-  const projectPayloadForDelivery = (payload: ReplyPayload): ReplyPayload | undefined =>
-    projectOutboundPayloadPlanForDelivery(
-      createOutboundPayloadPlan([payload], {
-        cfg: params.cfg,
-        sessionKey,
-        surface: "telegram",
-      }),
-    )[0];
-  const promptContextDeliverySignature = (payload: ReplyPayload): string | undefined => {
-    const projected = projectPayloadForDelivery(payload);
-    return projected ? resolveTelegramPromptContextDeliverySignature(projected) : undefined;
-  };
-  const resolvePromptContextSource = (
-    final: CurrentTurnTranscriptFinal | undefined,
-    ...payloads: ReplyPayload[]
-  ): TelegramPromptContextSource | undefined => {
-    const finalSignature = final ? promptContextDeliverySignature({ text: final.text }) : undefined;
-    if (!final?.messageId || !finalSignature) {
-      return undefined;
-    }
-    return payloads.some((payload) => promptContextDeliverySignature(payload) === finalSignature)
-      ? { transcriptMessageId: final.messageId }
-      : undefined;
-  };
-  const recordPromptContextMessage = (record: {
+type TelegramSendPayloadOptions = {
+  afterAcceptedDraft?: boolean;
+  durable?: boolean;
+  silent?: boolean;
+  mirrorTranscript?: boolean;
+  promptContextSequence?: TelegramPromptContextProjectionSequence;
+  textMode?: "html";
+  onPlatformSendDispatch?: () => Promise<void>;
+  bindPendingFinalDelivery?: <T extends ReplyPayload>(payload: T) => T;
+};
+
+const projectPayloadForDelivery = (turn: Turn, payload: ReplyPayload): ReplyPayload | undefined =>
+  projectOutboundPayloadPlanForDelivery(
+    createOutboundPayloadPlan([payload], {
+      cfg: turn.cfg,
+      sessionKey: turn.context.ctxPayload.SessionKey,
+      surface: "telegram",
+    }),
+  )[0];
+
+const promptContextDeliverySignature = (turn: Turn, payload: ReplyPayload): string | undefined => {
+  const projected = projectPayloadForDelivery(turn, payload);
+  return projected ? resolveTelegramPromptContextDeliverySignature(projected) : undefined;
+};
+
+function resolvePromptContextSource(
+  turn: Turn,
+  final: CurrentTurnTranscriptFinal | undefined,
+  ...payloads: ReplyPayload[]
+): TelegramPromptContextSource | undefined {
+  const finalSignature = final
+    ? promptContextDeliverySignature(turn, { text: final.text })
+    : undefined;
+  if (!final?.messageId || !finalSignature) {
+    return undefined;
+  }
+  return payloads.some(
+    (payload) => promptContextDeliverySignature(turn, payload) === finalSignature,
+  )
+    ? { transcriptMessageId: final.messageId }
+    : undefined;
+}
+
+async function recordPromptContextMessage(
+  turn: Turn,
+  record: {
     messageId: number;
     message?: Message;
     text?: string;
     projection?: TelegramPromptContextProjection;
-  }): Promise<boolean> =>
-    (
-      params.telegramDeps.recordOutboundMessageForPromptContext ??
-      recordOutboundMessageForPromptContext
-    )({
-      cfg: params.cfg,
-      account: {
-        accountId: context.route.accountId,
-        ...(params.telegramCfg.name !== undefined ? { name: params.telegramCfg.name } : {}),
-        ...(context.primaryCtx.me ? { bot: context.primaryCtx.me } : {}),
-      },
-      ...(context.primaryCtx.me?.id !== undefined ? { botUserId: context.primaryCtx.me.id } : {}),
-      chatId: String(context.chatId),
-      message: record.message ?? { message_id: record.messageId },
-      messageId: record.messageId,
-      ...(record.text ? { text: record.text } : {}),
-      ...(record.projection ? { promptContextProjection: record.projection } : {}),
-      ...(params.threadSpec.id !== undefined ? { messageThreadId: params.threadSpec.id } : {}),
-      successfulSendThread: params.threadSpec,
-    });
-  const createPromptContextSequence = (source?: TelegramPromptContextSource) =>
-    createTelegramPromptContextProjectionSequence({
-      ...(source ? { source } : {}),
-      record: recordPromptContextMessage,
-    });
-  const transcriptMirror = sessionKey
+  },
+): Promise<boolean> {
+  const { context } = turn;
+  return await (
+    turn.telegramDeps.recordOutboundMessageForPromptContext ?? recordOutboundMessageForPromptContext
+  )({
+    cfg: turn.cfg,
+    account: {
+      accountId: context.route.accountId,
+      ...(turn.telegramCfg.name !== undefined ? { name: turn.telegramCfg.name } : {}),
+      ...(context.primaryCtx.me ? { bot: context.primaryCtx.me } : {}),
+    },
+    ...(context.primaryCtx.me?.id !== undefined ? { botUserId: context.primaryCtx.me.id } : {}),
+    chatId: String(context.chatId),
+    message: record.message ?? { message_id: record.messageId },
+    messageId: record.messageId,
+    ...(record.text ? { text: record.text } : {}),
+    ...(record.projection ? { promptContextProjection: record.projection } : {}),
+    ...(turn.context.threadSpec.id !== undefined
+      ? { messageThreadId: turn.context.threadSpec.id }
+      : {}),
+    successfulSendThread: turn.context.threadSpec,
+  });
+}
+
+const createPromptContextSequence = (
+  turn: Turn,
+  source?: TelegramPromptContextSource,
+): TelegramPromptContextProjectionSequence =>
+  createTelegramPromptContextProjectionSequence({
+    ...(source ? { source } : {}),
+    record: async (record) => await recordPromptContextMessage(turn, record),
+  });
+
+function createTranscriptMirror(turn: Turn) {
+  const sessionKey = turn.context.ctxPayload.SessionKey;
+  return sessionKey
     ? async (payload: TelegramTranscriptMirrorPayload) => {
-        const idempotencyKey = `telegram-final:${sessionKey}:${transcriptMirrorTurnId}:${transcriptMirrorSequence++}`;
+        const idempotencyKey = `telegram-final:${sessionKey}:${turn.transcriptMirrorTurnId}:${turn.transcriptMirrorSequence++}`;
         await mirrorTelegramAssistantReplyToTranscript({
-          cfg: params.cfg,
+          cfg: turn.cfg,
           idempotencyKey,
-          loadFreshSessionEntry: params.loadFreshSessionEntry,
-          route: context.route,
+          loadFreshSessionEntry: turn.loadFreshSessionEntry,
+          route: turn.context.route,
           sessionKey,
           payload,
         });
       }
     : undefined;
-  const deliveryBaseOptions = {
-    cfg: params.cfg,
+}
+
+function createDeliveryBaseOptions(turn: Turn) {
+  const { context } = turn;
+  return {
+    cfg: turn.cfg,
     chatId: String(context.chatId),
     accountId: context.route.accountId,
-    sessionKeyForInternalHooks: sessionKey,
+    sessionKeyForInternalHooks: context.ctxPayload.SessionKey,
     mirrorIsGroup: context.isGroup,
     mirrorGroupId: context.isGroup ? String(context.chatId) : undefined,
-    token: params.opts.token,
-    runtime: params.runtime,
-    bot: params.bot,
-    mediaLocalRoots: params.mediaLocalRoots,
-    mediaMaxBytes: (params.opts.mediaMaxMb ?? params.telegramCfg.mediaMaxMb ?? 100) * 1024 * 1024,
-    replyToMode: params.replyToMode,
-    textLimit: params.textLimit,
-    thread: params.threadSpec,
-    tableMode: params.tableMode,
-    chunkMode: params.chunkMode,
-    richMessages: params.telegramCfg.richMessages,
-    linkPreview: params.telegramCfg.linkPreview,
-    replyQuoteMessageId: params.replyQuoteMessageId,
-    replyQuoteText: params.replyQuoteText,
-    replyQuotePosition: params.replyQuotePosition,
-    replyQuoteEntities: params.replyQuoteEntities,
-    replyQuoteByMessageId: params.replyQuoteByMessageId,
-    transcriptMirror,
+    token: turn.opts.token,
+    runtime: turn.runtime,
+    bot: turn.bot,
+    mediaLocalRoots: turn.mediaLocalRoots,
+    mediaMaxBytes: (turn.opts.mediaMaxMb ?? turn.telegramCfg.mediaMaxMb ?? 100) * 1024 * 1024,
+    replyToMode: turn.replyToMode,
+    textLimit: turn.textLimit,
+    thread: turn.context.threadSpec,
+    tableMode: turn.tableMode,
+    chunkMode: turn.chunkMode,
+    richMessages: turn.telegramCfg.richMessages,
+    linkPreview: turn.telegramCfg.linkPreview,
+    replyQuoteMessageId: turn.replyQuoteMessageId,
+    replyQuoteText: turn.replyQuoteText,
+    replyQuotePosition: turn.replyQuotePosition,
+    replyQuoteEntities: turn.replyQuoteEntities,
+    replyQuoteByMessageId: turn.replyQuoteByMessageId,
+    transcriptMirror: createTranscriptMirror(turn),
   };
+}
 
-  const applyTextToPayload = (payload: ReplyPayload, text: string): ReplyPayload =>
-    payload.text === text ? payload : { ...payload, text };
-  const applyQuoteReplyTarget = (payload: ReplyPayload): ReplyPayload => {
-    if (
-      !implicitQuoteReplyTargetId ||
-      !currentMessageIdForQuoteReply ||
-      payload.replyToId !== currentMessageIdForQuoteReply ||
-      payload.replyToTag ||
-      payload.replyToCurrent
-    ) {
-      return payload;
+export const applyTextToPayload = (payload: ReplyPayload, text: string): ReplyPayload =>
+  payload.text === text ? payload : { ...payload, text };
+
+function applyQuoteReplyTarget(turn: Turn, payload: ReplyPayload): ReplyPayload {
+  if (
+    !turn.implicitQuoteReplyTargetId ||
+    !turn.currentMessageIdForQuoteReply ||
+    payload.replyToId !== turn.currentMessageIdForQuoteReply ||
+    payload.replyToTag ||
+    payload.replyToCurrent
+  ) {
+    return payload;
+  }
+  return { ...payload, replyToId: turn.implicitQuoteReplyTargetId };
+}
+
+const usesNativeTelegramQuote = (turn: Turn, payload: ReplyPayload): boolean =>
+  turn.replyQuoteText != null ||
+  (payload.replyToId != null && turn.replyQuoteByMessageId[payload.replyToId] != null);
+
+export async function sendPayload(
+  turn: Turn,
+  payload: ReplyPayload,
+  options?: TelegramSendPayloadOptions,
+): Promise<boolean> {
+  if (turn.isSuperseded()) {
+    await options?.promptContextSequence?.fail();
+    return false;
+  }
+  const targetedPayload = applyQuoteReplyTarget(turn, payload);
+  const finalReplyTargetId = resolveTelegramReplyId(targetedPayload.replyToId);
+  const targetsDifferentMessage =
+    finalReplyTargetId != null && finalReplyTargetId !== turn.draftReplyToMessageId;
+  const consumedSingleUseReply =
+    options?.afterAcceptedDraft === true &&
+    isSingleUseReplyToMode(turn.replyToMode) &&
+    !targetsDifferentMessage;
+  const deliverablePayload = consumedSingleUseReply
+    ? (({ replyToId: _, replyToTag: _tag, replyToCurrent: _current, ...rest }) => rest)(
+        targetedPayload,
+      )
+    : targetedPayload;
+  const effectiveReplyToMode = consumedSingleUseReply ? "off" : turn.replyToMode;
+  const projectionSequence =
+    options?.promptContextSequence ??
+    createPromptContextSequence(
+      turn,
+      options?.durable
+        ? resolvePromptContextSource(
+            turn,
+            await turn.resolveCurrentTurnTranscriptFinal(),
+            deliverablePayload,
+          )
+        : undefined,
+    );
+  const projectedPayload = withTelegramPromptContextSource(
+    deliverablePayload,
+    projectionSequence.source,
+  );
+  const effectivePayload = options?.bindPendingFinalDelivery
+    ? options.bindPendingFinalDelivery(projectedPayload)
+    : projectedPayload;
+  const silent =
+    options?.silent ?? (turn.telegramCfg.silentErrorReplies === true && payload.isError === true);
+  const durableDelivery = turn.telegramDeps.deliverInboundReplyWithMessageSendContext;
+  if (options?.durable && durableDelivery && projectionSequence.isFresh()) {
+    const durable = await durableDelivery({
+      cfg: turn.cfg,
+      channel: "telegram",
+      to:
+        turn.context.ctxPayload.OriginatingTo ??
+        turn.context.ctxPayload.To ??
+        `telegram:${turn.context.chatId}`,
+      accountId: turn.context.route.accountId,
+      agentId: turn.context.route.agentId,
+      ctxPayload: turn.context.ctxPayload,
+      payload: effectivePayload,
+      info: { kind: "final" },
+      replyToMode: effectiveReplyToMode,
+      threadId: turn.context.threadSpec.id,
+      formatting: {
+        textLimit: turn.textLimit,
+        tableMode: turn.tableMode,
+        chunkMode: turn.chunkMode,
+        ...(options?.textMode === "html" ? { parseMode: "HTML" as const } : {}),
+      },
+      silent,
+      requiredCapabilities: deriveDurableFinalDeliveryRequirements({
+        payload: effectivePayload,
+        replyToId: effectivePayload.replyToId,
+        threadId: turn.context.threadSpec.id,
+        silent,
+        payloadTransport: true,
+        extraCapabilities: {
+          nativeQuote: !consumedSingleUseReply && usesNativeTelegramQuote(turn, effectivePayload),
+        },
+      }),
+    });
+    if (durable.status === "failed") {
+      await projectionSequence.fail();
+      throw durable.error;
     }
-    return {
-      ...payload,
-      replyToId: implicitQuoteReplyTargetId,
-    };
-  };
-  const usesNativeTelegramQuote = (payload: ReplyPayload): boolean =>
-    params.replyQuoteText != null ||
-    (payload.replyToId != null && params.replyQuoteByMessageId[payload.replyToId] != null);
-
-  const sendPayload = async (
-    payload: ReplyPayload,
-    options?: {
-      afterAcceptedDraft?: boolean;
-      durable?: boolean;
-      silent?: boolean;
-      mirrorTranscript?: boolean;
-      promptContextSequence?: TelegramPromptContextProjectionSequence;
-      textMode?: "html";
-      onPlatformSendDispatch?: () => Promise<void>;
-      bindPendingFinalDelivery?: <T extends ReplyPayload>(payload: T) => T;
-    },
-  ) => {
-    if (params.isDispatchSuperseded()) {
-      await options?.promptContextSequence?.fail();
+    if (durable.status === "handled_visible") {
+      turn.deliveryState.markDelivered();
+      return true;
+    }
+    if (durable.status === "handled_no_send") {
+      await projectionSequence.fail();
       return false;
     }
-    const targetedPayload = applyQuoteReplyTarget(payload);
-    const finalReplyTargetId = resolveTelegramReplyId(targetedPayload.replyToId);
-    const targetsDifferentMessage =
-      finalReplyTargetId != null && finalReplyTargetId !== params.draftReplyToMessageId;
-    const consumedSingleUseReply =
-      options?.afterAcceptedDraft === true &&
-      isSingleUseReplyToMode(params.replyToMode) &&
-      !targetsDifferentMessage;
-    const deliverablePayload = consumedSingleUseReply
-      ? (({ replyToId: _, replyToTag: _tag, replyToCurrent: _current, ...rest }) => rest)(
-          targetedPayload,
-        )
-      : targetedPayload;
-    const effectiveReplyToMode = consumedSingleUseReply ? "off" : params.replyToMode;
-    const projectionSequence =
-      options?.promptContextSequence ??
-      createPromptContextSequence(
-        options?.durable
-          ? resolvePromptContextSource(
-              await resolveCurrentTurnTranscriptFinal(),
-              deliverablePayload,
-            )
-          : undefined,
-      );
-    const projectedPayload = withTelegramPromptContextSource(
-      deliverablePayload,
-      projectionSequence.source,
-    );
-    const effectivePayload = options?.bindPendingFinalDelivery
-      ? options.bindPendingFinalDelivery(projectedPayload)
-      : projectedPayload;
-    const silent =
-      options?.silent ??
-      (params.telegramCfg.silentErrorReplies === true && payload.isError === true);
-    const durableDelivery = params.telegramDeps.deliverInboundReplyWithMessageSendContext;
-    if (options?.durable && durableDelivery && projectionSequence.isFresh()) {
-      const durable = await durableDelivery({
-        cfg: params.cfg,
-        channel: "telegram",
-        to:
-          context.ctxPayload.OriginatingTo ?? context.ctxPayload.To ?? `telegram:${context.chatId}`,
-        accountId: context.route.accountId,
-        agentId: context.route.agentId,
-        ctxPayload: context.ctxPayload,
-        payload: effectivePayload,
-        info: { kind: "final" },
-        replyToMode: effectiveReplyToMode,
-        threadId: params.threadSpec.id,
-        formatting: {
-          textLimit: params.textLimit,
-          tableMode: params.tableMode,
-          chunkMode: params.chunkMode,
-          ...(options?.textMode === "html" ? { parseMode: "HTML" as const } : {}),
-        },
-        silent,
-        requiredCapabilities: deriveDurableFinalDeliveryRequirements({
-          payload: effectivePayload,
-          replyToId: effectivePayload.replyToId,
-          threadId: params.threadSpec.id,
-          silent,
-          payloadTransport: true,
-          extraCapabilities: {
-            nativeQuote: !consumedSingleUseReply && usesNativeTelegramQuote(effectivePayload),
-          },
-        }),
-      });
-      if (durable.status === "failed") {
-        await projectionSequence.fail();
-        throw durable.error;
-      }
-      if (durable.status === "handled_visible") {
-        deliveryState.markDelivered();
-        return true;
-      }
-      if (durable.status === "handled_no_send") {
-        await projectionSequence.fail();
-        return false;
-      }
-    }
-    try {
-      const result = await (params.telegramDeps.deliverReplies ?? deliverReplies)({
-        ...deliveryBaseOptions,
-        replyToMode: effectiveReplyToMode,
-        transcriptMirror:
-          options?.durable && options?.mirrorTranscript !== false ? transcriptMirror : undefined,
-        replies: [effectivePayload],
-        onVoiceRecording: context.sendRecordVoice,
-        silent,
-        mediaLoader: params.telegramDeps.loadWebMedia,
-        promptContextSequence: projectionSequence,
-        onPlatformSendDispatch: options?.onPlatformSendDispatch,
-        ...(options?.textMode ? { textMode: options.textMode } : {}),
-      });
-      if (!result.delivered) {
-        await projectionSequence.fail();
-        return false;
-      }
-      await projectionSequence.finish();
-      deliveryState.markDelivered();
-      return true;
-    } catch (error) {
+  }
+  try {
+    const transcriptMirror = createTranscriptMirror(turn);
+    const result = await (turn.telegramDeps.deliverReplies ?? deliverReplies)({
+      ...createDeliveryBaseOptions(turn),
+      replyToMode: effectiveReplyToMode,
+      transcriptMirror:
+        options?.durable && options?.mirrorTranscript !== false ? transcriptMirror : undefined,
+      replies: [effectivePayload],
+      onVoiceRecording: turn.context.sendRecordVoice,
+      silent,
+      mediaLoader: turn.telegramDeps.loadWebMedia,
+      promptContextSequence: projectionSequence,
+      onPlatformSendDispatch: options?.onPlatformSendDispatch,
+      ...(options?.textMode ? { textMode: options.textMode } : {}),
+    });
+    if (!result.delivered) {
       await projectionSequence.fail();
-      throw error;
+      return false;
     }
-  };
+    await projectionSequence.finish();
+    turn.deliveryState.markDelivered();
+    return true;
+  } catch (error) {
+    await projectionSequence.fail();
+    throw error;
+  }
+}
 
-  const emitPreviewFinalizedHook = async (result: LaneDeliveryResult) => {
-    if (
-      params.isDispatchSuperseded() ||
-      (result.kind !== "preview-finalized" && result.kind !== "preview-finalized-partial")
-    ) {
-      return;
-    }
-    // A finalized preview is the durable Telegram message. Emit the composite
-    // terminal here so plugin and internal observers see that one provider result.
-    (params.telegramDeps.emitTelegramMessageSentHooks ?? emitTelegramMessageSentHooks)({
-      sessionKeyForInternalHooks: sessionKey,
-      chatId: String(context.chatId),
-      accountId: context.route.accountId,
-      content: result.delivery.content,
-      success: true,
-      messageId: result.delivery.messageId,
-      isGroup: context.isGroup,
-      groupId: context.isGroup ? String(context.chatId) : undefined,
-    });
-    if (transcriptMirror && result.delivery.content) {
-      void transcriptMirror({ text: result.delivery.content }).catch((err: unknown) => {
-        logVerbose(
-          `telegram preview-finalized transcriptMirror failed: ${formatErrorMessage(err)}`,
-        );
-      });
-    }
-  };
-  const deliverLaneText = createLaneTextDeliverer({
-    lanes: params.draft.lanes,
-    applyTextToPayload,
-    sendPayload,
-    flushDraftLane: params.draft.flushLane,
-    stopDraftLane: async (lane) => await lane.stream?.stop(),
-    clearDraftLane: async (lane) => await lane.stream?.clear(),
-    editStreamMessage: async ({ messageId, text, textMode, buttons }) => {
-      if (!params.isDispatchSuperseded()) {
-        await (params.telegramDeps.editMessageTelegram ?? editMessageTelegram)(
-          context.chatId,
-          messageId,
-          text,
-          {
-            api: params.bot.api,
-            cfg: params.cfg,
-            accountId: context.route.accountId,
-            linkPreview: params.telegramCfg.linkPreview,
-            textMode,
-            buttons,
-          },
-        );
-      }
-    },
-    createPromptContextSequence,
-    resolveFinalTextCandidate: async () => (await resolveCurrentTurnTranscriptFinal())?.text,
-    log: logVerbose,
-    markDelivered: deliveryState.markDelivered,
+export async function emitPreviewFinalizedHook(
+  turn: Turn,
+  result: LaneDeliveryResult,
+): Promise<void> {
+  if (
+    turn.isSuperseded() ||
+    (result.kind !== "preview-finalized" && result.kind !== "preview-finalized-partial")
+  ) {
+    return;
+  }
+  // A finalized preview is the durable Telegram message. Emit the composite
+  // terminal here so plugin and internal observers see that one provider result.
+  (turn.telegramDeps.emitTelegramMessageSentHooks ?? emitTelegramMessageSentHooks)({
+    sessionKeyForInternalHooks: turn.context.ctxPayload.SessionKey,
+    chatId: String(turn.context.chatId),
+    accountId: turn.context.route.accountId,
+    content: result.delivery.content,
+    success: true,
+    messageId: result.delivery.messageId,
+    isGroup: turn.context.isGroup,
+    groupId: turn.context.isGroup ? String(turn.context.chatId) : undefined,
   });
-
-  const materializeAnswerLaneBeforeRotation = async () => {
-    const block = params.draft.activeAnswerBlockDelivery();
-    const lane = params.draft.answerLane;
-    if (
-      !block ||
-      !lane.stream ||
-      !lane.hasStreamedMessage ||
-      lane.finalized ||
-      params.draft.isAnswerToolProgressOnly()
-    ) {
-      return;
-    }
-    const text = lane.lastPartialText || params.draft.lastAnswerPartialText() || block.text;
-    if (!text?.trim()) {
-      return;
-    }
-    const result = await deliverLaneText({
-      laneName: "answer",
-      text,
-      payload: block.payload,
-      infoKind: "block",
-      buttons: block.buttons,
-      finalizePreview: true,
-      durable: false,
+  const transcriptMirror = createTranscriptMirror(turn);
+  if (transcriptMirror && result.delivery.content) {
+    void transcriptMirror({ text: result.delivery.content }).catch((err: unknown) => {
+      logVerbose(`telegram preview-finalized transcriptMirror failed: ${formatErrorMessage(err)}`);
     });
-    params.draft.setActiveAnswerBlockDelivery();
-    await emitPreviewFinalizedHook(result);
-  };
-  params.draft.setMaterializeBeforeRotation(materializeAnswerLaneBeforeRotation);
+  }
+}
 
-  const postCosmeticSummaryBar = async (line: string) => {
-    try {
-      await sendPayload({ text: line }, { durable: true, mirrorTranscript: false });
-    } catch (err) {
-      logVerbose(`telegram: collapse summary bar send failed: ${formatErrorMessage(err)}`);
-    }
-  };
-  const deliverProgressCollapseSummary = async () => {
-    const line = params.progress.resolveCollapseSummaryLine();
-    if (line) {
-      await postCosmeticSummaryBar(line);
-    }
-  };
-  const deliverProgressModeFinalAnswer = async (
-    payload: ReplyPayload,
-    text: string,
-    promptContextSequence: TelegramPromptContextProjectionSequence,
-    onPlatformSendDispatch?: () => Promise<void>,
-    bindPendingFinalDelivery?: <T extends ReplyPayload>(payload: T) => T,
-  ): Promise<LaneDeliveryResult> => {
-    const afterAcceptedDraft = params.draft.answerLane.stream?.hasConsumedReplyTarget?.() === true;
-    if (payload.isError === true) {
-      params.progress.setSummaryDelivered();
-      await params.progress.teardownWindow();
-      const delivered = await sendPayload(applyTextToPayload(payload, text), {
-        afterAcceptedDraft,
-        durable: true,
-        promptContextSequence,
-        onPlatformSendDispatch,
-        bindPendingFinalDelivery,
-      });
-      if (!delivered) {
-        return { kind: "skipped" };
-      }
-      params.draft.answerLane.finalized = true;
-      params.progress.markFinalDelivered();
-      return { kind: "sent" };
-    }
-    const barLine = params.progress.resolveCollapseSummaryLine();
-    const delivered = await sendPayload(applyTextToPayload(payload, text), {
+async function materializeAnswerLaneBeforeRotation(turn: Turn): Promise<void> {
+  const block = turn.activeAnswerBlockDelivery;
+  const lane = turn.answerLane;
+  if (
+    !block ||
+    !lane.stream ||
+    !lane.hasStreamedMessage ||
+    lane.finalized ||
+    turn.activeAnswerDraftIsToolProgressOnly
+  ) {
+    return;
+  }
+  const text = lane.lastPartialText || turn.lastAnswerPartialText || block.text;
+  if (!text?.trim()) {
+    return;
+  }
+  const result = await turn.deliverLaneText({
+    laneName: "answer",
+    text,
+    payload: block.payload,
+    infoKind: "block",
+    buttons: block.buttons,
+    finalizePreview: true,
+    durable: false,
+  });
+  turn.activeAnswerBlockDelivery = undefined;
+  await emitPreviewFinalizedHook(turn, result);
+}
+
+async function postTelegramCosmeticSummaryBar(turn: Turn, line: string): Promise<void> {
+  try {
+    await sendPayload(turn, { text: line }, { durable: true, mirrorTranscript: false });
+  } catch (err) {
+    logVerbose(`telegram: collapse summary bar send failed: ${formatErrorMessage(err)}`);
+  }
+}
+
+export async function deliverProgressCollapseSummary(turn: Turn): Promise<void> {
+  const line = resolveCollapseSummaryLine(turn);
+  turn.summaryDelivered = true;
+  if (line) {
+    await postTelegramCosmeticSummaryBar(turn, line);
+  }
+}
+
+async function deliverTelegramProgressModeFinalAnswer(
+  turn: Turn,
+  payload: ReplyPayload,
+  text: string,
+  promptContextSequence: TelegramPromptContextProjectionSequence,
+  onPlatformSendDispatch?: () => Promise<void>,
+  bindPendingFinalDelivery?: <T extends ReplyPayload>(payload: T) => T,
+): Promise<LaneDeliveryResult> {
+  const afterAcceptedDraft = turn.answerLane.stream?.hasConsumedReplyTarget?.() === true;
+  if (payload.isError === true) {
+    turn.summaryDelivered = true;
+    await teardownProgressWindow(turn);
+    const delivered = await sendPayload(turn, applyTextToPayload(payload, text), {
       afterAcceptedDraft,
       durable: true,
       promptContextSequence,
       onPlatformSendDispatch,
       bindPendingFinalDelivery,
     });
-    if (barLine) {
-      await params.progress.applyCollapseSummary(barLine, postCosmeticSummaryBar);
-      params.progress.resetAnswerLaneAfterCollapse();
-    } else {
-      await params.progress.teardownWindow();
-    }
     if (!delivered) {
       return { kind: "skipped" };
     }
-    params.draft.answerLane.finalized = true;
-    params.progress.markFinalDelivered();
+    turn.answerLane.finalized = true;
+    markFinalDelivered(turn);
     return { kind: "sent" };
-  };
-  const deliverFinalAnswerText = async (
-    answerPayload: ReplyPayload,
-    text: string,
-    buttons?: TelegramInlineButtons,
-    onPlatformSendDispatch?: () => Promise<void>,
-    bindPendingFinalDelivery?: <T extends ReplyPayload>(payload: T) => T,
-  ): Promise<LaneDeliveryResult> => {
-    const transcriptFinal = await resolveCurrentTurnTranscriptFinal();
-    const finalText = await resolveTranscriptBackedChannelFinalText({
-      finalText: text,
-      resolveCandidateText: async () => transcriptFinal?.text,
+  }
+  const barLine = resolveCollapseSummaryLine(turn);
+  turn.summaryDelivered = true;
+  const delivered = await sendPayload(turn, applyTextToPayload(payload, text), {
+    afterAcceptedDraft,
+    durable: true,
+    promptContextSequence,
+    onPlatformSendDispatch,
+    bindPendingFinalDelivery,
+  });
+  // The final must dispatch before collapse mutates the preview. Collapse then
+  // retires the activity window before the answer lane can accept follow-ups.
+  if (barLine) {
+    await applyCollapseSummary(turn, barLine, async (line) => {
+      await postTelegramCosmeticSummaryBar(turn, line);
     });
-    const source = resolvePromptContextSource(
-      transcriptFinal,
-      answerPayload,
-      applyTextToPayload(answerPayload, finalText),
-    );
-    const promptContextSequence = createPromptContextSequence(source);
-    const isFollowUp = params.progress.finalAnswerDelivered();
-    let result: LaneDeliveryResult;
-    if (!isFollowUp && params.streamMode === "progress") {
-      result = await deliverProgressModeFinalAnswer(
-        answerPayload,
-        finalText,
-        promptContextSequence,
-        onPlatformSendDispatch,
-        bindPendingFinalDelivery,
-      );
-    } else {
-      if (isFollowUp) {
-        await params.draft.prepareAnswerLaneForText();
-      } else if (!(await params.draft.rotateAnswerLaneAfterToolProgress())) {
-        await params.draft.rotateAnswerLaneAfterQueuedBlocksSettle();
-      }
-      result = await deliverLaneText({
-        laneName: "answer",
-        text: finalText,
-        payload: answerPayload,
-        infoKind: "final",
-        buttons,
-        allowStream: !usesNativeTelegramQuote(answerPayload),
-        promptContextSequence,
-        onPlatformSendDispatch,
-        bindPendingFinalDelivery,
-      });
-      if (!isFollowUp && result.kind !== "skipped") {
-        params.progress.markFinalDelivered();
-      }
-    }
-    if (result.kind === "preview-finalized" || result.kind === "preview-finalized-partial") {
-      await emitPreviewFinalizedHook(result);
-    }
-    if (result.kind === "preview-finalized-partial") {
-      throw mergeTelegramPartialDeliveryError(result.error, {
-        receipt: result.delivery.receipt,
-        content: result.delivery.content,
-        messageIds: result.delivery.receipt.platformMessageIds,
-        visibleReplySent: true,
-      });
-    }
-    return result;
-  };
-  const finalizePendingAnswerBlockDraft = async (final: {
-    queuedFinal: boolean;
-    dispatchError?: unknown;
-  }) => {
-    const block = params.draft.activeAnswerBlockDelivery();
-    if (
-      !block ||
-      final.queuedFinal ||
-      final.dispatchError ||
-      params.isDispatchSuperseded() ||
-      params.draft.answerLane.finalized
-    ) {
-      return;
-    }
-    const content = block.text.trimEnd();
-    if (!content) {
-      return;
-    }
-    params.progress.markFinalStarted();
-    await deliverFinalAnswerText(block.payload, content, block.buttons);
-    params.draft.setActiveAnswerBlockDelivery();
-  };
-
-  return {
-    applyTextToPayload,
-    createPromptContextSequence,
-    deliverFallback: async (replies: ReplyPayload[], silent: boolean) =>
-      await (params.telegramDeps.deliverReplies ?? deliverReplies)({
-        replies,
-        ...deliveryBaseOptions,
-        silent,
-        mediaLoader: params.telegramDeps.loadWebMedia,
-      }),
-    deliverFinalAnswerText,
-    deliverLaneText,
-    deliverProgressCollapseSummary,
-    emitPreviewFinalizedHook,
-    finalizePendingAnswerBlockDraft,
-    markDelivered: deliveryState.markDelivered,
-    markNonSilentFailure: deliveryState.markNonSilentFailure,
-    markNonSilentSkip: deliveryState.markNonSilentSkip,
-    normalizeDeliveryPayload: (payload: ReplyPayload): ReplyPayload | undefined => {
-      const keepReasoningLane =
-        payload.isReasoning === true && params.draft.durableReasoningPayloadsEnabled;
-      const payloadForPlan = keepReasoningLane ? { ...payload } : payload;
-      if (keepReasoningLane) {
-        delete payloadForPlan.isReasoning;
-      }
-      const normalized = projectPayloadForDelivery(payloadForPlan);
-      if (!normalized) {
-        return undefined;
-      }
-      // Retained finals can still select HTML at send time, and HTML bypasses
-      // rich blocks. Converting a presentation here would strip it while the
-      // final funnel is still undecided, so rich accounts defer canonicalization
-      // to the sender (deliverReplies / the outbound adapter) which knows the
-      // text mode. Plain accounts always flatten, so deciding early is safe.
-      if (params.telegramCfg.richMessages === true && normalized.presentation) {
-        return normalized;
-      }
-      return canonicalizeTelegramPresentationPayload(normalized, {
-        allowWebAppButtons: resolveTelegramTargetChatType(String(context.chatId)) === "direct",
-        richTables: false,
-      });
-    },
-    sendPayload,
-    snapshot: deliveryState.snapshot,
-  };
+    resetAnswerLaneAfterCollapse(turn);
+  } else {
+    await teardownProgressWindow(turn);
+  }
+  if (!delivered) {
+    return { kind: "skipped" };
+  }
+  turn.answerLane.finalized = true;
+  markFinalDelivered(turn);
+  return { kind: "sent" };
 }
 
-export type TelegramDeliveryController = ReturnType<typeof createTelegramDeliveryController>;
+export async function deliverFinalAnswerText(
+  turn: Turn,
+  answerPayload: ReplyPayload,
+  text: string,
+  buttons?: TelegramInlineButtons,
+  onPlatformSendDispatch?: () => Promise<void>,
+  bindPendingFinalDelivery?: <T extends ReplyPayload>(payload: T) => T,
+): Promise<LaneDeliveryResult> {
+  const transcriptFinal = await turn.resolveCurrentTurnTranscriptFinal();
+  const finalText = await resolveTranscriptBackedChannelFinalText({
+    finalText: text,
+    resolveCandidateText: async () => transcriptFinal?.text,
+  });
+  const source = resolvePromptContextSource(
+    turn,
+    transcriptFinal,
+    answerPayload,
+    applyTextToPayload(answerPayload, finalText),
+  );
+  const promptContextSequence = createPromptContextSequence(turn, source);
+  const isFollowUp = turn.finalAnswerDelivered;
+  let result: LaneDeliveryResult;
+  if (!isFollowUp && turn.streamMode === "progress") {
+    result = await deliverTelegramProgressModeFinalAnswer(
+      turn,
+      answerPayload,
+      finalText,
+      promptContextSequence,
+      onPlatformSendDispatch,
+      bindPendingFinalDelivery,
+    );
+  } else {
+    if (isFollowUp) {
+      await prepareAnswerLaneForText(turn);
+    } else if (!(await rotateAnswerLaneAfterToolProgress(turn))) {
+      await rotateAnswerLaneAfterQueuedBlocksSettle(turn);
+    }
+    result = await turn.deliverLaneText({
+      laneName: "answer",
+      text: finalText,
+      payload: answerPayload,
+      infoKind: "final",
+      buttons,
+      allowStream: !usesNativeTelegramQuote(turn, answerPayload),
+      promptContextSequence,
+      onPlatformSendDispatch,
+      bindPendingFinalDelivery,
+    });
+    if (!isFollowUp && result.kind !== "skipped") {
+      markFinalDelivered(turn);
+    }
+  }
+  if (result.kind === "preview-finalized" || result.kind === "preview-finalized-partial") {
+    await emitPreviewFinalizedHook(turn, result);
+  }
+  if (result.kind === "preview-finalized-partial") {
+    throw mergeTelegramPartialDeliveryError(result.error, {
+      receipt: result.delivery.receipt,
+      content: result.delivery.content,
+      messageIds: result.delivery.receipt.platformMessageIds,
+      visibleReplySent: true,
+    });
+  }
+  return result;
+}
+
+export async function finalizePendingAnswerBlockDraft(turn: Turn): Promise<void> {
+  const block = turn.activeAnswerBlockDelivery;
+  if (
+    !block ||
+    turn.queuedFinal ||
+    turn.dispatchError ||
+    turn.isSuperseded() ||
+    turn.answerLane.finalized
+  ) {
+    return;
+  }
+  const content = block.text.trimEnd();
+  if (!content) {
+    return;
+  }
+  markFinalStarted(turn);
+  await deliverFinalAnswerText(turn, block.payload, content, block.buttons);
+  turn.activeAnswerBlockDelivery = undefined;
+}
+
+export async function deliverFallback(turn: Turn, replies: ReplyPayload[], silent: boolean) {
+  return await (turn.telegramDeps.deliverReplies ?? deliverReplies)({
+    replies,
+    ...createDeliveryBaseOptions(turn),
+    silent,
+    mediaLoader: turn.telegramDeps.loadWebMedia,
+  });
+}
+
+export function normalizeDeliveryPayload(
+  turn: Turn,
+  payload: ReplyPayload,
+): ReplyPayload | undefined {
+  const keepReasoningLane = payload.isReasoning === true && turn.durableReasoningPayloadsEnabled;
+  const payloadForPlan = keepReasoningLane ? { ...payload } : payload;
+  if (keepReasoningLane) {
+    delete payloadForPlan.isReasoning;
+  }
+  const normalized = projectPayloadForDelivery(turn, payloadForPlan);
+  if (!normalized) {
+    return undefined;
+  }
+  // Retained finals can still select HTML at send time, and HTML bypasses
+  // rich blocks. Converting a presentation here would strip it while the
+  // final funnel is still undecided, so rich accounts defer canonicalization
+  // to the sender which knows the text mode.
+  if (turn.telegramCfg.richMessages === true && normalized.presentation) {
+    return normalized;
+  }
+  return canonicalizeTelegramPresentationPayload(normalized, {
+    allowWebAppButtons: resolveTelegramTargetChatType(String(turn.context.chatId)) === "direct",
+    richTables: false,
+  });
+}
+
+export function createDeliveryState(
+  config: TelegramDeliveryConfig,
+  getTurn: () => Turn,
+): TelegramDeliveryStateSlice {
+  const { context } = config;
+  const sessionKey = context.ctxPayload.SessionKey;
+  const implicitQuoteReplyTargetId =
+    context.ctxPayload.ReplyToIsQuote &&
+    !context.msg.reply_to_message?.from?.is_bot &&
+    config.replyQuoteMessageId != null
+      ? String(config.replyQuoteMessageId)
+      : undefined;
+  const currentMessageIdForQuoteReply =
+    implicitQuoteReplyTargetId && context.ctxPayload.MessageSid
+      ? context.ctxPayload.MessageSid
+      : undefined;
+  const deliveryState = createLaneDeliveryStateTracker();
+  const deliverLaneText = createLaneTextDeliverer({
+    lanes: config.lanes,
+    applyTextToPayload,
+    sendPayload: async (payload, options) => await sendPayload(getTurn(), payload, options),
+    flushDraftLane: async (lane) => await flushDraftLane(getTurn(), lane),
+    stopDraftLane: async (lane) => await lane.stream?.stop(),
+    clearDraftLane: async (lane) => await lane.stream?.clear(),
+    editStreamMessage: async ({ messageId, text, textMode, buttons }) => {
+      const turn = getTurn();
+      if (!turn.isSuperseded()) {
+        await (turn.telegramDeps.editMessageTelegram ?? editMessageTelegram)(
+          turn.context.chatId,
+          messageId,
+          text,
+          {
+            api: turn.bot.api,
+            cfg: turn.cfg,
+            accountId: turn.context.route.accountId,
+            linkPreview: turn.telegramCfg.linkPreview,
+            textMode,
+            buttons,
+          },
+        );
+      }
+    },
+    createPromptContextSequence: () => createPromptContextSequence(getTurn()),
+    resolveFinalTextCandidate: async () =>
+      (await getTurn().resolveCurrentTurnTranscriptFinal())?.text,
+    log: logVerbose,
+    markDelivered: deliveryState.markDelivered,
+  });
+
+  return {
+    deliveryState,
+    deliverLaneText,
+    // Draft's rotate path calls this through the turn record: a direct import
+    // from draft.ts would recreate the draft<->delivery runtime import cycle.
+    materializeAnswerLaneBeforeRotation: async () =>
+      await materializeAnswerLaneBeforeRotation(getTurn()),
+    resolveCurrentTurnTranscriptFinal: createCurrentTurnTranscriptFinalResolver({
+      agentId: context.route.agentId,
+      dispatchStartedAt: config.dispatchStartedAt,
+      loadFreshSessionEntry: config.loadFreshSessionEntry,
+      sessionKey,
+    }),
+    transcriptMirrorSequence: 0,
+    transcriptMirrorTurnId: `${context.chatId}:${context.ctxPayload.MessageSid ?? context.msg.message_id ?? config.dispatchStartedAt}`,
+    implicitQuoteReplyTargetId,
+    currentMessageIdForQuoteReply,
+  };
+}

--- a/extensions/telegram/src/bot-message-dispatch-draft.ts
+++ b/extensions/telegram/src/bot-message-dispatch-draft.ts
@@ -1,22 +1,16 @@
-// Telegram plugin module owns answer/reasoning draft lanes and rotation state.
-import type { Bot } from "grammy";
 import { resolveChannelStreamingBlockEnabled } from "openclaw/plugin-sdk/channel-outbound";
-import type {
-  OpenClawConfig,
-  ReplyToMode,
-  TelegramAccountConfig,
-} from "openclaw/plugin-sdk/config-contracts";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-payload";
 import type { BlockReplyContext } from "openclaw/plugin-sdk/reply-runtime";
 import { createSubsystemLogger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import type { TelegramBotDeps } from "./bot-deps.js";
-import { resolveMarkdownTableMode } from "./bot-message-dispatch.runtime.js";
 import type {
-  TelegramReasoningLevel,
+  TelegramDispatchTurn as Turn,
+  TelegramDispatchTurnConfig as TurnConfig,
+  TelegramDraftPartialTextUpdate,
+  TelegramDraftStateSlice,
+  TelegramQueuedAnswerBlockRotation,
+  TelegramSplitLaneSegmentsResult,
   TelegramAnswerBlockDelivery,
 } from "./bot-message-dispatch.types.js";
-import type { TelegramThreadSpec } from "./bot/helpers.js";
-import type { TelegramStreamMode } from "./bot/types.js";
 import { resolveTelegramDraftStreamingChunking } from "./draft-chunking.js";
 import { createTelegramDraftStream, type TelegramDraftPreview } from "./draft-stream.js";
 import { renderTelegramHtmlText } from "./format.js";
@@ -29,31 +23,11 @@ import { reportTelegramProviderDelivery } from "./send-outbound.js";
 import { recordSentMessage } from "./sent-message-cache.js";
 
 const draftLogger = createSubsystemLogger("telegram/draft-stream");
-
 const DRAFT_MIN_INITIAL_CHARS = 30;
-
-type DraftPartialTextUpdate = {
-  text: string;
-  delta?: string;
-  replace?: true;
-  isReasoningSnapshot?: boolean;
-};
-
-type SplitLaneSegment = { lane: LaneName; update: DraftPartialTextUpdate };
-type SplitLaneSegmentsResult = {
-  segments: SplitLaneSegment[];
-  suppressedReasoningOnly: boolean;
-};
-
-type QueuedAnswerBlockRotation = {
-  assistantMessageIndex?: number;
-  text?: string;
-  shouldRotateBeforeDelivery: boolean;
-};
 
 function resolveDraftPartialText(
   previous: string,
-  update: DraftPartialTextUpdate,
+  update: TelegramDraftPartialTextUpdate,
 ): string | undefined {
   const nextText =
     update.replace || update.isReasoningSnapshot || update.delta === undefined
@@ -62,32 +36,35 @@ function resolveDraftPartialText(
   return nextText === previous ? undefined : nextText;
 }
 
-export function createTelegramDraftController(params: {
-  accountId: string;
-  allowProviderPreview: boolean;
-  bot: Bot;
-  cfg: OpenClawConfig;
-  chatId: number;
-  draftReplyToMessageId?: number;
-  forceBlockStreamingForReasoning: boolean;
-  hasTelegramQuoteReply: boolean;
-  isDispatchSuperseded: () => boolean;
-  isRoomEvent: boolean;
-  replyToMode: ReplyToMode;
-  resolvedReasoningLevel: TelegramReasoningLevel;
-  streamMode: TelegramStreamMode;
-  tableMode: ReturnType<typeof resolveMarkdownTableMode>;
-  telegramCfg: TelegramAccountConfig;
-  telegramDeps: TelegramBotDeps;
-  textLimit: number;
-  threadSpec: TelegramThreadSpec;
-}) {
-  const streamDeliveryEnabled = !params.isRoomEvent && params.streamMode !== "off";
+export function renderStreamText(
+  turn: Pick<Turn, "tableMode" | "telegramCfg">,
+  text: string,
+): TelegramDraftPreview {
+  return turn.telegramCfg.richMessages === true
+    ? {
+        text,
+        richMessage: buildTelegramRichMarkdown(text, {
+          tableMode: turn.tableMode,
+          skipEntityDetection: turn.telegramCfg.linkPreview === false,
+        }),
+      }
+    : {
+        text: renderTelegramHtmlText(text, { tableMode: turn.tableMode }),
+        parseMode: "HTML",
+        markdownSource: { text, tableMode: turn.tableMode },
+      };
+}
+
+export function createDraftState(params: TurnConfig): TelegramDraftStateSlice {
+  const isRoomEvent = params.context.ctxPayload.InboundEventKind === "room_event";
+  const forceBlockStreamingForReasoning =
+    params.resolvedReasoningLevel === "on" && params.streamMode !== "progress";
+  const streamDeliveryEnabled = !isRoomEvent && params.streamMode !== "off";
   const previewAvailable =
     params.allowProviderPreview &&
     streamDeliveryEnabled &&
-    !params.hasTelegramQuoteReply &&
-    !params.forceBlockStreamingForReasoning;
+    !(params.replyToMode !== "off" && params.replyQuoteText != null) &&
+    !forceBlockStreamingForReasoning;
   const accountBlockStreamingEnabled = resolveChannelStreamingBlockEnabled(params.telegramCfg, {
     previewAvailable,
     blockStreamingDefault: params.cfg.agents?.defaults?.blockStreamingDefault,
@@ -98,13 +75,14 @@ export function createTelegramDraftController(params: {
     streamReasoningDraft && params.streamMode === "progress" && canStreamAnswerDraft;
   const canStreamReasoningDraft =
     params.allowProviderPreview &&
-    !params.isRoomEvent &&
+    !isRoomEvent &&
     streamReasoningDraft &&
     !streamReasoningInProgressDraft;
   const draftMaxChars =
     params.streamMode === "block"
       ? Math.min(
-          resolveTelegramDraftStreamingChunking(params.cfg, params.accountId).maxChars,
+          resolveTelegramDraftStreamingChunking(params.cfg, params.context.route.accountId)
+            .maxChars,
           params.textLimit,
         )
       : Math.min(
@@ -113,70 +91,57 @@ export function createTelegramDraftController(params: {
             ? TELEGRAM_RICH_TEXT_LIMIT
             : TELEGRAM_TEXT_CHUNK_LIMIT,
         );
-  const renderStreamText = (text: string): TelegramDraftPreview =>
-    params.telegramCfg.richMessages === true
-      ? {
-          text,
-          richMessage: buildTelegramRichMarkdown(text, {
-            tableMode: params.tableMode,
-            skipEntityDetection: params.telegramCfg.linkPreview === false,
-          }),
-        }
-      : {
-          text: renderTelegramHtmlText(text, { tableMode: params.tableMode }),
-          parseMode: "HTML",
-          markdownSource: { text, tableMode: params.tableMode },
-        };
+  const renderDraftText = (text: string): TelegramDraftPreview => renderStreamText(params, text);
 
   const createDraftLane = (laneName: LaneName, enabled: boolean): DraftLaneState => {
     const stream = enabled
       ? (params.telegramDeps.createTelegramDraftStream ?? createTelegramDraftStream)({
           api: params.bot.api,
-          chatId: params.chatId,
+          chatId: params.context.chatId,
           maxChars: draftMaxChars,
-          thread: params.threadSpec,
+          thread: params.context.threadSpec,
           replyToMessageId: params.draftReplyToMessageId,
           replyToMode: params.replyToMode,
           richMessages: params.telegramCfg.richMessages,
           linkPreview: params.telegramCfg.linkPreview,
           minInitialChars: params.streamMode === "progress" ? 0 : DRAFT_MIN_INITIAL_CHARS,
-          renderText: renderStreamText,
+          renderText: renderDraftText,
           onRetainedPage: (page) => {
             lanes[laneName].retainedPromptContextPages.push({
               messageId: page.messageId,
               text: page.textSnapshot,
             });
           },
-          ...(params.threadSpec.id !== undefined
+          ...(params.context.threadSpec.id !== undefined
             ? {
                 validateProviderMessage: async (message) => {
                   await reportTelegramProviderDelivery({
                     message,
                     messageId: message.message_id,
-                    fallbackChatId: params.chatId,
-                    successfulSendThread: params.threadSpec,
+                    fallbackChatId: params.context.chatId,
+                    successfulSendThread: params.context.threadSpec,
                   });
                 },
               }
             : {}),
           onProviderMessage: async (message) => {
-            recordSentMessage(params.chatId, message.message_id, params.cfg);
+            recordSentMessage(params.context.chatId, message.message_id, params.cfg);
             await (
               params.telegramDeps.recordOutboundMessageForPromptContext ??
               recordOutboundMessageForPromptContext
             )({
               cfg: params.cfg,
               account: {
-                accountId: params.accountId,
+                accountId: params.context.route.accountId,
                 ...(params.telegramCfg.name !== undefined ? { name: params.telegramCfg.name } : {}),
               },
-              chatId: params.chatId,
+              chatId: params.context.chatId,
               message,
               messageId: message.message_id,
-              ...(params.threadSpec.id !== undefined
-                ? { messageThreadId: params.threadSpec.id }
+              ...(params.context.threadSpec.id !== undefined
+                ? { messageThreadId: params.context.threadSpec.id }
                 : {}),
-              successfulSendThread: params.threadSpec,
+              successfulSendThread: params.context.threadSpec,
             });
           },
           log: logVerbose,
@@ -186,8 +151,8 @@ export function createTelegramDraftController(params: {
           warn: (message) =>
             draftLogger.warn(message, {
               lane: laneName,
-              chatId: params.chatId,
-              threadId: params.threadSpec.id,
+              chatId: params.context.chatId,
+              threadId: params.context.threadSpec.id,
             }),
         })
       : undefined;
@@ -203,326 +168,10 @@ export function createTelegramDraftController(params: {
     answer: createDraftLane("answer", canStreamAnswerDraft),
     reasoning: createDraftLane("reasoning", canStreamReasoningDraft),
   };
-  const answerLane = lanes.answer;
-  const reasoningLane = lanes.reasoning;
-  let lastAnswerPartialText = "";
-  let activeAnswerDraftIsToolProgressOnly = false;
-  let activeAnswerBlockAssistantMessageIndex: number | undefined;
-  let activeAnswerBlockDelivery: TelegramAnswerBlockDelivery | undefined;
-  let materializeAnswerLaneBeforeRotation: (() => Promise<void>) | undefined;
-  const queuedAnswerBlockRotations: QueuedAnswerBlockRotation[] = [];
-  let queuedAnswerBlockAssistantMessageIndex: number | undefined;
-  let pendingAnswerBlockAssistantMessageIndex: number | undefined;
-  let rotateAnswerLaneWhenQueuedBlocksSettle = false;
-  let eventQueue = Promise.resolve();
-  let resetProgress = () => {};
-  let suppressProgress = () => {};
-  let noteReasoningHint = () => {};
-  let noteReasoningDelivered = () => {};
-
-  const resetAnswerToolProgressDraft = () => {
-    activeAnswerDraftIsToolProgressOnly = false;
-  };
-  const resetLaneState = (lane: DraftLaneState) => {
-    lane.lastPartialText = "";
-    if (lane === answerLane) {
-      lastAnswerPartialText = "";
-    }
-    lane.hasStreamedMessage = false;
-    lane.finalized = false;
-    lane.retainedPromptContextPages = [];
-    if (lane === answerLane) {
-      resetAnswerToolProgressDraft();
-      pendingAnswerBlockAssistantMessageIndex = undefined;
-      activeAnswerBlockDelivery = undefined;
-    }
-  };
-  const repositionLaneForNewMessage = (lane: DraftLaneState) => {
-    // Reposition instead of delete-then-repost: the replacement must land
-    // before deferred cleanup or Telegram can jump and retain a stale preview.
-    lane.stream?.rotateToNewMessageDeferringDelete();
-    resetLaneState(lane);
-  };
-  const rotateLaneForNewMessage = async (lane: DraftLaneState) => {
-    if (!lane.hasStreamedMessage && typeof lane.stream?.messageId() !== "number") {
-      resetLaneState(lane);
-      return;
-    }
-    await lane.stream?.stop();
-    lane.stream?.forceNewMessage();
-    resetLaneState(lane);
-  };
-  const rotateAnswerLaneForNewMessage = async () => {
-    await materializeAnswerLaneBeforeRotation?.();
-    await rotateLaneForNewMessage(answerLane);
-  };
-  const rotateAnswerLaneAfterToolProgress = async () => {
-    if (!activeAnswerDraftIsToolProgressOnly) {
-      return false;
-    }
-    repositionLaneForNewMessage(answerLane);
-    suppressProgress();
-    rotateAnswerLaneWhenQueuedBlocksSettle = false;
-    return true;
-  };
-  const rotateAnswerLaneAfterQueuedBlocksSettle = async () => {
-    if (!rotateAnswerLaneWhenQueuedBlocksSettle || queuedAnswerBlockRotations.length > 0) {
-      return false;
-    }
-    rotateAnswerLaneWhenQueuedBlocksSettle = false;
-    if (!answerLane.hasStreamedMessage || activeAnswerDraftIsToolProgressOnly) {
-      return false;
-    }
-    await rotateAnswerLaneForNewMessage();
-    return true;
-  };
-  const prepareAnswerLaneForText = async (): Promise<boolean> => {
-    // Progress mode owns one stationary activity window; answer text never rotates it.
-    if (params.streamMode === "progress") {
-      return false;
-    }
-    if (await rotateAnswerLaneAfterToolProgress()) {
-      return true;
-    }
-    if (await rotateAnswerLaneAfterQueuedBlocksSettle()) {
-      return true;
-    }
-    if (!answerLane.finalized) {
-      return false;
-    }
-    answerLane.stream?.forceNewMessage();
-    resetLaneState(answerLane);
-    rotateAnswerLaneWhenQueuedBlocksSettle = false;
-    return true;
-  };
-  const prepareAnswerLaneForToolProgress = async () => {
-    if (answerLane.finalized) {
-      answerLane.stream?.forceNewMessage();
-      resetLaneState(answerLane);
-    }
-    if (activeAnswerDraftIsToolProgressOnly) {
-      return;
-    }
-    if (params.streamMode !== "progress" && answerLane.hasStreamedMessage) {
-      await rotateAnswerLaneForNewMessage();
-    }
-    activeAnswerDraftIsToolProgressOnly = true;
-  };
-
-  const splitTextIntoLaneSegments = (
-    update: { text?: string; delta?: string; replace?: true; isReasoningSnapshot?: boolean },
-    isReasoning?: boolean,
-  ): SplitLaneSegmentsResult => {
-    const split = splitTelegramReasoningText(update.text, isReasoning);
-    const splitSegments: Array<{ lane: LaneName; text: string }> = [];
-    const useDelta =
-      !update.replace && update.isReasoningSnapshot !== true && update.delta !== undefined;
-    const suppressReasoning = params.resolvedReasoningLevel === "off";
-    if (split.reasoningText && !suppressReasoning) {
-      splitSegments.push({ lane: "reasoning", text: split.reasoningText });
-    }
-    if (split.answerText) {
-      splitSegments.push({ lane: "answer", text: split.answerText });
-    }
-    return {
-      segments: splitSegments.map((segment) => ({
-        lane: segment.lane,
-        update: {
-          text: segment.text,
-          ...(!useDelta || splitSegments.length !== 1 ? {} : { delta: update.delta }),
-          ...(update.replace ? { replace: true as const } : {}),
-          ...(update.isReasoningSnapshot ? { isReasoningSnapshot: true } : {}),
-        },
-      })),
-      suppressedReasoningOnly:
-        Boolean(split.reasoningText) && suppressReasoning && !split.answerText,
-    };
-  };
-  const updateDraftFromPartial = (
-    lane: DraftLaneState,
-    update: DraftPartialTextUpdate,
-    schedule = true,
-  ): string | undefined => {
-    if (!lane.stream || !update.text) {
-      return undefined;
-    }
-    const previousText = lane === answerLane ? lastAnswerPartialText : lane.lastPartialText;
-    const nextText = resolveDraftPartialText(previousText, update);
-    if (!nextText || (lane === answerLane && params.streamMode === "progress")) {
-      return undefined;
-    }
-    if (lane === answerLane) {
-      resetAnswerToolProgressDraft();
-      suppressProgress();
-      lastAnswerPartialText = nextText;
-    }
-    lane.hasStreamedMessage = true;
-    lane.finalized = false;
-    lane.lastPartialText = nextText;
-    if (schedule) {
-      lane.stream.update(nextText);
-    }
-    return nextText;
-  };
-  const ingestDraftLaneSegments = async (
-    update: { text?: string; delta?: string; replace?: true; isReasoningSnapshot?: boolean },
-    isReasoning?: boolean,
-  ) => {
-    if (isReasoning !== true) {
-      const stream = answerLane.stream;
-      if (!stream) {
-        return;
-      }
-      const rotationPending =
-        params.streamMode !== "progress" &&
-        (activeAnswerDraftIsToolProgressOnly ||
-          answerLane.finalized ||
-          (rotateAnswerLaneWhenQueuedBlocksSettle &&
-            queuedAnswerBlockRotations.length === 0 &&
-            answerLane.hasStreamedMessage));
-      if (rotationPending) {
-        const text = update.text;
-        if (!text) {
-          return;
-        }
-        await prepareAnswerLaneForText();
-        updateDraftFromPartial(answerLane, { text, replace: true });
-        return;
-      }
-      let didMaterialize = false;
-      let materialized: string | undefined;
-      stream.updateLazy(() => {
-        if (!didMaterialize) {
-          const text = update.text;
-          // Partial text is cumulative, so the newest snapshot remains authoritative when
-          // intermediate delta-bearing payloads are coalesced before this flush.
-          materialized = text
-            ? updateDraftFromPartial(answerLane, { text, replace: true }, false)
-            : undefined;
-          didMaterialize = true;
-        }
-        return materialized;
-      });
-      return;
-    }
-    const split = splitTextIntoLaneSegments(update, isReasoning);
-    for (const segment of split.segments) {
-      if (segment.lane === "answer") {
-        await prepareAnswerLaneForText();
-      }
-      if (segment.lane === "reasoning") {
-        noteReasoningHint();
-        noteReasoningDelivered();
-      }
-      updateDraftFromPartial(lanes[segment.lane], segment.update);
-    }
-  };
-  const enqueueEvent = (task: () => Promise<void>): Promise<void> => {
-    const next = eventQueue.then(async () => {
-      if (!params.isDispatchSuperseded()) {
-        await task();
-      }
-    });
-    eventQueue = next.catch((err: unknown) => {
-      logVerbose(`telegram: draft lane callback failed: ${String(err)}`);
-    });
-    return eventQueue;
-  };
-
-  const recomputeQueuedAnswerBlockRotations = () => {
-    let previous =
-      activeAnswerBlockAssistantMessageIndex ?? pendingAnswerBlockAssistantMessageIndex;
-    queuedAnswerBlockAssistantMessageIndex = undefined;
-    for (const entry of queuedAnswerBlockRotations) {
-      if (entry.assistantMessageIndex === undefined) {
-        continue;
-      }
-      entry.shouldRotateBeforeDelivery =
-        previous !== undefined && entry.assistantMessageIndex !== previous;
-      previous = entry.assistantMessageIndex;
-      queuedAnswerBlockAssistantMessageIndex = entry.assistantMessageIndex;
-    }
-  };
-  const rotationMatches = (
-    entry: QueuedAnswerBlockRotation,
-    payload: ReplyPayload,
-    assistantMessageIndex?: number,
-  ) =>
-    assistantMessageIndex !== undefined && entry.assistantMessageIndex !== undefined
-      ? assistantMessageIndex === entry.assistantMessageIndex
-      : entry.text !== undefined && payload.text !== undefined && entry.text === payload.text;
-  const prepareQueuedAnswerBlock = async (
-    payload: ReplyPayload,
-    blockContext?: BlockReplyContext,
-  ) => {
-    if (
-      !splitTextIntoLaneSegments({ text: payload.text }, payload.isReasoning).segments.some(
-        (segment) => segment.lane === "answer",
-      )
-    ) {
-      return;
-    }
-    resetProgress();
-    const assistantMessageIndex = blockContext?.assistantMessageIndex;
-    if (assistantMessageIndex === undefined) {
-      queuedAnswerBlockRotations.push({ text: payload.text, shouldRotateBeforeDelivery: false });
-      return;
-    }
-    const previous =
-      queuedAnswerBlockAssistantMessageIndex ??
-      activeAnswerBlockAssistantMessageIndex ??
-      pendingAnswerBlockAssistantMessageIndex;
-    queuedAnswerBlockRotations.push({
-      assistantMessageIndex,
-      text: payload.text,
-      shouldRotateBeforeDelivery: previous !== undefined && assistantMessageIndex !== previous,
-    });
-    queuedAnswerBlockAssistantMessageIndex = assistantMessageIndex;
-  };
-  const takeQueuedAnswerBlockRotation = (payload: ReplyPayload, index?: number): boolean => {
-    if (queuedAnswerBlockRotations.length === 0) {
-      return false;
-    }
-    const matchIndex = queuedAnswerBlockRotations.findIndex((entry) =>
-      rotationMatches(entry, payload, index),
-    );
-    const matched = queuedAnswerBlockRotations.splice(0, Math.max(matchIndex, 0) + 1).at(-1);
-    if (matched?.assistantMessageIndex !== undefined) {
-      activeAnswerBlockAssistantMessageIndex = matched.assistantMessageIndex;
-      pendingAnswerBlockAssistantMessageIndex = undefined;
-    }
-    recomputeQueuedAnswerBlockRotations();
-    return matched?.shouldRotateBeforeDelivery ?? false;
-  };
-  const dropQueuedAnswerBlockRotation = (payload: ReplyPayload, index?: number) => {
-    let matchIndex = queuedAnswerBlockRotations.findIndex((entry) =>
-      rotationMatches(entry, payload, index),
-    );
-    if (matchIndex < 0 && index === undefined) {
-      matchIndex = queuedAnswerBlockRotations.findIndex(
-        (entry) => entry.assistantMessageIndex === undefined,
-      );
-    }
-    if (matchIndex < 0) {
-      return;
-    }
-    const [matched] = queuedAnswerBlockRotations.splice(matchIndex, 1);
-    if (
-      matchIndex === 0 &&
-      matched?.assistantMessageIndex !== undefined &&
-      rotateAnswerLaneWhenQueuedBlocksSettle &&
-      activeAnswerBlockAssistantMessageIndex === undefined &&
-      answerLane.hasStreamedMessage
-    ) {
-      pendingAnswerBlockAssistantMessageIndex = matched.assistantMessageIndex;
-    }
-    recomputeQueuedAnswerBlockRotations();
-  };
-
   const resolvedBlockStreamingEnabled = resolveChannelStreamingBlockEnabled(params.telegramCfg);
   const disableBlockStreaming = !streamDeliveryEnabled
     ? true
-    : params.forceBlockStreamingForReasoning
+    : forceBlockStreamingForReasoning
       ? false
       : typeof resolvedBlockStreamingEnabled === "boolean"
         ? !resolvedBlockStreamingEnabled
@@ -531,80 +180,392 @@ export function createTelegramDraftController(params: {
           : undefined;
 
   return {
-    answerLane,
-    reasoningLane,
+    answerLane: lanes.answer,
+    reasoningLane: lanes.reasoning,
     lanes,
-    beginQueuedFollowup: () => {
-      for (const lane of [answerLane, reasoningLane]) {
-        if (!lane.stream) {
-          continue;
-        }
-        lane.stream.forceNewMessage();
-        resetLaneState(lane);
-      }
-    },
-    canPushAnswerDraft: () => Boolean(answerLane.stream),
-    cleanup: async (superseded: boolean) => {
-      for (const lane of [answerLane, reasoningLane]) {
-        const stream = lane.stream;
-        if (!stream) {
-          continue;
-        }
-        if (superseded) {
-          await (typeof stream.discard === "function" ? stream.discard() : stream.stop());
-        } else if (lane.finalized) {
-          await stream.stop();
-        } else {
-          await stream.clear();
-        }
-      }
-    },
-    disableBlockStreaming,
-    durableReasoningPayloadsEnabled:
-      params.resolvedReasoningLevel === "on" || Boolean(reasoningLane.stream),
-    enqueueEvent,
-    ingestDraftLaneSegments,
-    isAnswerToolProgressOnly: () => activeAnswerDraftIsToolProgressOnly,
-    isQueuedAnswerBlock: (payload: ReplyPayload, index?: number) =>
-      queuedAnswerBlockRotations.some((entry) => rotationMatches(entry, payload, index)),
-    lastAnswerPartialText: () => lastAnswerPartialText,
-    prepareAnswerLaneForText,
-    prepareAnswerLaneForToolProgress,
-    prepareQueuedAnswerBlock,
-    dropQueuedAnswerBlockRotation,
-    takeQueuedAnswerBlockRotation,
-    renderStreamText,
-    repositionLaneForNewMessage,
-    resetAnswerToolProgressDraft,
-    resetLaneState,
-    rotateAnswerLaneAfterQueuedBlocksSettle,
-    rotateAnswerLaneAfterToolProgress,
-    rotateAnswerLaneForNewMessage,
-    rotateLaneForNewMessage,
-    setActiveAnswerBlockDelivery: (delivery?: TelegramAnswerBlockDelivery) => {
-      activeAnswerBlockDelivery = delivery;
-    },
-    activeAnswerBlockDelivery: () => activeAnswerBlockDelivery,
-    setMaterializeBeforeRotation: (materialize: () => Promise<void>) => {
-      materializeAnswerLaneBeforeRotation = materialize;
-    },
-    setProgressLifecycle: (lifecycle: { reset: () => void; suppress: () => void }) => {
-      resetProgress = lifecycle.reset;
-      suppressProgress = lifecycle.suppress;
-    },
-    setReasoningStepCallbacks: (callbacks: { noteHint: () => void; noteDelivered: () => void }) => {
-      noteReasoningHint = callbacks.noteHint;
-      noteReasoningDelivered = callbacks.noteDelivered;
-    },
-    setRotateWhenQueuedBlocksSettle: (value: boolean) => {
-      rotateAnswerLaneWhenQueuedBlocksSettle = value;
-    },
-    splitTextIntoLaneSegments,
     streamDeliveryEnabled,
     streamReasoningInProgressDraft,
-    waitForEvents: async () => await eventQueue,
-    flushLane: async (lane: DraftLaneState) => await lane.stream?.flush(),
+    disableBlockStreaming,
+    durableReasoningPayloadsEnabled:
+      params.resolvedReasoningLevel === "on" || Boolean(lanes.reasoning.stream),
+    lastAnswerPartialText: "",
+    activeAnswerDraftIsToolProgressOnly: false,
+    activeAnswerBlockAssistantMessageIndex: undefined as number | undefined,
+    activeAnswerBlockDelivery: undefined as TelegramAnswerBlockDelivery | undefined,
+    queuedAnswerBlockRotations: [] as TelegramQueuedAnswerBlockRotation[],
+    queuedAnswerBlockAssistantMessageIndex: undefined as number | undefined,
+    pendingAnswerBlockAssistantMessageIndex: undefined as number | undefined,
+    rotateAnswerLaneWhenQueuedBlocksSettle: false,
+    draftEventQueue: Promise.resolve(),
   };
 }
 
-export type TelegramDraftController = ReturnType<typeof createTelegramDraftController>;
+export function resetLaneState(turn: Turn, lane: DraftLaneState): void {
+  lane.lastPartialText = "";
+  if (lane === turn.answerLane) {
+    turn.lastAnswerPartialText = "";
+  }
+  lane.hasStreamedMessage = false;
+  lane.finalized = false;
+  lane.retainedPromptContextPages = [];
+  if (lane === turn.answerLane) {
+    turn.activeAnswerDraftIsToolProgressOnly = false;
+    turn.pendingAnswerBlockAssistantMessageIndex = undefined;
+    turn.activeAnswerBlockDelivery = undefined;
+  }
+}
+
+export function repositionLaneForNewMessage(turn: Turn, lane: DraftLaneState): void {
+  // Reposition instead of delete-then-repost: the replacement must land
+  // before deferred cleanup or Telegram can jump and retain a stale preview.
+  lane.stream?.rotateToNewMessageDeferringDelete();
+  resetLaneState(turn, lane);
+}
+
+export async function rotateLaneForNewMessage(turn: Turn, lane: DraftLaneState): Promise<void> {
+  if (!lane.hasStreamedMessage && typeof lane.stream?.messageId() !== "number") {
+    resetLaneState(turn, lane);
+    return;
+  }
+  // Settle pending edits before changing stream identity; reset only after the
+  // new Telegram message is selected or delivery state can describe the old one.
+  await lane.stream?.stop();
+  lane.stream?.forceNewMessage();
+  resetLaneState(turn, lane);
+}
+
+export async function rotateAnswerLaneForNewMessage(turn: Turn) {
+  // An accepted block must become durable before rotation; otherwise cleanup
+  // can discard its only visible preview.
+  await turn.materializeAnswerLaneBeforeRotation();
+  await rotateLaneForNewMessage(turn, turn.answerLane);
+}
+
+export async function rotateAnswerLaneAfterToolProgress(turn: Turn): Promise<boolean> {
+  if (!turn.activeAnswerDraftIsToolProgressOnly) {
+    return false;
+  }
+  repositionLaneForNewMessage(turn, turn.answerLane);
+  turn.progressCompositor.suppress();
+  turn.rotateAnswerLaneWhenQueuedBlocksSettle = false;
+  return true;
+}
+
+export async function rotateAnswerLaneAfterQueuedBlocksSettle(turn: Turn): Promise<boolean> {
+  if (!turn.rotateAnswerLaneWhenQueuedBlocksSettle || turn.queuedAnswerBlockRotations.length > 0) {
+    return false;
+  }
+  turn.rotateAnswerLaneWhenQueuedBlocksSettle = false;
+  if (!turn.answerLane.hasStreamedMessage || turn.activeAnswerDraftIsToolProgressOnly) {
+    return false;
+  }
+  await rotateAnswerLaneForNewMessage(turn);
+  return true;
+}
+
+export async function prepareAnswerLaneForText(turn: Turn): Promise<boolean> {
+  if (turn.streamMode === "progress") {
+    return false;
+  }
+  if (await rotateAnswerLaneAfterToolProgress(turn)) {
+    return true;
+  }
+  if (await rotateAnswerLaneAfterQueuedBlocksSettle(turn)) {
+    return true;
+  }
+  if (!turn.answerLane.finalized) {
+    return false;
+  }
+  turn.answerLane.stream?.forceNewMessage();
+  resetLaneState(turn, turn.answerLane);
+  turn.rotateAnswerLaneWhenQueuedBlocksSettle = false;
+  return true;
+}
+
+export async function prepareAnswerLaneForToolProgress(turn: Turn): Promise<void> {
+  if (turn.answerLane.finalized) {
+    turn.answerLane.stream?.forceNewMessage();
+    resetLaneState(turn, turn.answerLane);
+  }
+  if (turn.activeAnswerDraftIsToolProgressOnly) {
+    return;
+  }
+  if (turn.streamMode !== "progress" && turn.answerLane.hasStreamedMessage) {
+    await rotateAnswerLaneForNewMessage(turn);
+  }
+  turn.activeAnswerDraftIsToolProgressOnly = true;
+}
+
+export function splitTextIntoLaneSegments(
+  turn: Turn,
+  update: { text?: string; delta?: string; replace?: true; isReasoningSnapshot?: boolean },
+  isReasoning?: boolean,
+): TelegramSplitLaneSegmentsResult {
+  const split = splitTelegramReasoningText(update.text, isReasoning);
+  const splitSegments: Array<{ lane: LaneName; text: string }> = [];
+  const useDelta =
+    !update.replace && update.isReasoningSnapshot !== true && update.delta !== undefined;
+  const suppressReasoning = turn.resolvedReasoningLevel === "off";
+  if (split.reasoningText && !suppressReasoning) {
+    splitSegments.push({ lane: "reasoning", text: split.reasoningText });
+  }
+  if (split.answerText) {
+    splitSegments.push({ lane: "answer", text: split.answerText });
+  }
+  return {
+    segments: splitSegments.map((segment) => ({
+      lane: segment.lane,
+      update: {
+        text: segment.text,
+        ...(!useDelta || splitSegments.length !== 1 ? {} : { delta: update.delta }),
+        ...(update.replace ? { replace: true as const } : {}),
+        ...(update.isReasoningSnapshot ? { isReasoningSnapshot: true } : {}),
+      },
+    })),
+    suppressedReasoningOnly: Boolean(split.reasoningText) && suppressReasoning && !split.answerText,
+  };
+}
+
+function updateTelegramDraftFromPartial(
+  turn: Turn,
+  lane: DraftLaneState,
+  update: TelegramDraftPartialTextUpdate,
+  schedule = true,
+): string | undefined {
+  if (!lane.stream || !update.text) {
+    return undefined;
+  }
+  const previousText = lane === turn.answerLane ? turn.lastAnswerPartialText : lane.lastPartialText;
+  const nextText = resolveDraftPartialText(previousText, update);
+  if (!nextText || (lane === turn.answerLane && turn.streamMode === "progress")) {
+    return undefined;
+  }
+  if (lane === turn.answerLane) {
+    turn.activeAnswerDraftIsToolProgressOnly = false;
+    turn.progressCompositor.suppress();
+    turn.lastAnswerPartialText = nextText;
+  }
+  lane.hasStreamedMessage = true;
+  lane.finalized = false;
+  lane.lastPartialText = nextText;
+  if (schedule) {
+    lane.stream.update(nextText);
+  }
+  return nextText;
+}
+
+export async function ingestDraftLaneSegments(
+  turn: Turn,
+  update: { text?: string; delta?: string; replace?: true; isReasoningSnapshot?: boolean },
+  isReasoning?: boolean,
+): Promise<void> {
+  if (isReasoning !== true) {
+    const stream = turn.answerLane.stream;
+    if (!stream) {
+      return;
+    }
+    const rotationPending =
+      turn.streamMode !== "progress" &&
+      (turn.activeAnswerDraftIsToolProgressOnly ||
+        turn.answerLane.finalized ||
+        (turn.rotateAnswerLaneWhenQueuedBlocksSettle &&
+          turn.queuedAnswerBlockRotations.length === 0 &&
+          turn.answerLane.hasStreamedMessage));
+    if (rotationPending) {
+      const text = update.text;
+      if (!text) {
+        return;
+      }
+      await prepareAnswerLaneForText(turn);
+      updateTelegramDraftFromPartial(turn, turn.answerLane, { text, replace: true });
+      return;
+    }
+    let didMaterialize = false;
+    let materialized: string | undefined;
+    stream.updateLazy(() => {
+      if (!didMaterialize) {
+        const text = update.text;
+        // Partial text is cumulative, so the newest snapshot remains authoritative when
+        // intermediate delta-bearing payloads are coalesced before this flush.
+        materialized = text
+          ? updateTelegramDraftFromPartial(turn, turn.answerLane, { text, replace: true }, false)
+          : undefined;
+        didMaterialize = true;
+      }
+      return materialized;
+    });
+    return;
+  }
+  const split = splitTextIntoLaneSegments(turn, update, isReasoning);
+  for (const segment of split.segments) {
+    if (segment.lane === "answer") {
+      await prepareAnswerLaneForText(turn);
+    }
+    if (segment.lane === "reasoning") {
+      turn.reasoningStepState.noteReasoningHint();
+      turn.reasoningStepState.noteReasoningDelivered();
+    }
+    updateTelegramDraftFromPartial(turn, turn.lanes[segment.lane], segment.update);
+  }
+}
+
+export function enqueueDraftEvent(turn: Turn, task: () => Promise<void>): Promise<void> {
+  // Ownership can change while this serialized mutation waits. Re-check at
+  // execution time so superseded work cannot update or rotate visible drafts.
+  const next = turn.draftEventQueue.then(async () => {
+    if (!turn.isSuperseded()) {
+      await task();
+    }
+  });
+  turn.draftEventQueue = next.catch((err: unknown) => {
+    logVerbose(`telegram: draft lane callback failed: ${String(err)}`);
+  });
+  return turn.draftEventQueue;
+}
+
+function recomputeTelegramQueuedAnswerBlockRotations(turn: Turn): void {
+  let previous =
+    turn.activeAnswerBlockAssistantMessageIndex ?? turn.pendingAnswerBlockAssistantMessageIndex;
+  turn.queuedAnswerBlockAssistantMessageIndex = undefined;
+  for (const entry of turn.queuedAnswerBlockRotations) {
+    if (entry.assistantMessageIndex === undefined) {
+      continue;
+    }
+    entry.shouldRotateBeforeDelivery =
+      previous !== undefined && entry.assistantMessageIndex !== previous;
+    previous = entry.assistantMessageIndex;
+    turn.queuedAnswerBlockAssistantMessageIndex = entry.assistantMessageIndex;
+  }
+}
+
+function telegramQueuedRotationMatches(
+  entry: TelegramQueuedAnswerBlockRotation,
+  payload: ReplyPayload,
+  assistantMessageIndex?: number,
+): boolean {
+  return assistantMessageIndex !== undefined && entry.assistantMessageIndex !== undefined
+    ? assistantMessageIndex === entry.assistantMessageIndex
+    : entry.text !== undefined && payload.text !== undefined && entry.text === payload.text;
+}
+
+export async function prepareQueuedAnswerBlock(
+  turn: Turn,
+  payload: ReplyPayload,
+  blockContext?: BlockReplyContext,
+): Promise<void> {
+  if (
+    !splitTextIntoLaneSegments(turn, { text: payload.text }, payload.isReasoning).segments.some(
+      (segment) => segment.lane === "answer",
+    )
+  ) {
+    return;
+  }
+  turn.progressCompositor.reset();
+  const assistantMessageIndex = blockContext?.assistantMessageIndex;
+  if (assistantMessageIndex === undefined) {
+    turn.queuedAnswerBlockRotations.push({
+      text: payload.text,
+      shouldRotateBeforeDelivery: false,
+    });
+    return;
+  }
+  const previous =
+    turn.queuedAnswerBlockAssistantMessageIndex ??
+    turn.activeAnswerBlockAssistantMessageIndex ??
+    turn.pendingAnswerBlockAssistantMessageIndex;
+  turn.queuedAnswerBlockRotations.push({
+    assistantMessageIndex,
+    text: payload.text,
+    shouldRotateBeforeDelivery: previous !== undefined && assistantMessageIndex !== previous,
+  });
+  turn.queuedAnswerBlockAssistantMessageIndex = assistantMessageIndex;
+}
+
+export function takeQueuedAnswerBlockRotation(
+  turn: Turn,
+  payload: ReplyPayload,
+  assistantMessageIndex?: number,
+): boolean {
+  if (turn.queuedAnswerBlockRotations.length === 0) {
+    return false;
+  }
+  const matchIndex = turn.queuedAnswerBlockRotations.findIndex((entry) =>
+    telegramQueuedRotationMatches(entry, payload, assistantMessageIndex),
+  );
+  const matched = turn.queuedAnswerBlockRotations.splice(0, Math.max(matchIndex, 0) + 1).at(-1);
+  if (matched?.assistantMessageIndex !== undefined) {
+    turn.activeAnswerBlockAssistantMessageIndex = matched.assistantMessageIndex;
+    turn.pendingAnswerBlockAssistantMessageIndex = undefined;
+  }
+  recomputeTelegramQueuedAnswerBlockRotations(turn);
+  return matched?.shouldRotateBeforeDelivery ?? false;
+}
+
+export function dropQueuedAnswerBlockRotation(
+  turn: Turn,
+  payload: ReplyPayload,
+  assistantMessageIndex?: number,
+): void {
+  let matchIndex = turn.queuedAnswerBlockRotations.findIndex((entry) =>
+    telegramQueuedRotationMatches(entry, payload, assistantMessageIndex),
+  );
+  if (matchIndex < 0 && assistantMessageIndex === undefined) {
+    matchIndex = turn.queuedAnswerBlockRotations.findIndex(
+      (entry) => entry.assistantMessageIndex === undefined,
+    );
+  }
+  if (matchIndex < 0) {
+    return;
+  }
+  const [matched] = turn.queuedAnswerBlockRotations.splice(matchIndex, 1);
+  if (
+    matchIndex === 0 &&
+    matched?.assistantMessageIndex !== undefined &&
+    turn.rotateAnswerLaneWhenQueuedBlocksSettle &&
+    turn.activeAnswerBlockAssistantMessageIndex === undefined &&
+    turn.answerLane.hasStreamedMessage
+  ) {
+    turn.pendingAnswerBlockAssistantMessageIndex = matched.assistantMessageIndex;
+  }
+  recomputeTelegramQueuedAnswerBlockRotations(turn);
+}
+
+export function isQueuedAnswerBlock(
+  turn: Turn,
+  payload: ReplyPayload,
+  assistantMessageIndex?: number,
+): boolean {
+  return turn.queuedAnswerBlockRotations.some((entry) =>
+    telegramQueuedRotationMatches(entry, payload, assistantMessageIndex),
+  );
+}
+
+export function beginDraftQueuedFollowup(turn: Turn): void {
+  for (const lane of [turn.answerLane, turn.reasoningLane]) {
+    if (!lane.stream) {
+      continue;
+    }
+    lane.stream.forceNewMessage();
+    resetLaneState(turn, lane);
+  }
+}
+
+export async function cleanupDrafts(turn: Turn, superseded: boolean): Promise<void> {
+  for (const lane of [turn.answerLane, turn.reasoningLane]) {
+    const stream = lane.stream;
+    if (!stream) {
+      continue;
+    }
+    if (superseded) {
+      await (typeof stream.discard === "function" ? stream.discard() : stream.stop());
+    } else if (lane.finalized) {
+      await stream.stop();
+    } else {
+      await stream.clear();
+    }
+  }
+}
+
+export const waitForDraftEvents = (turn: Turn) => turn.draftEventQueue;
+
+export const flushDraftLane = (_turn: Turn, lane: DraftLaneState) => lane.stream?.flush();

--- a/extensions/telegram/src/bot-message-dispatch-progress.ts
+++ b/extensions/telegram/src/bot-message-dispatch-progress.ts
@@ -4,11 +4,18 @@ import {
   resolveChannelStreamingPreviewToolProgress,
   type ChannelProgressDraftLine,
 } from "openclaw/plugin-sdk/channel-outbound";
-import type { TelegramAccountConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { TelegramBotDeps } from "./bot-deps.js";
-import type { TelegramMessageContext } from "./bot-message-context.js";
-import type { TelegramDraftController } from "./bot-message-dispatch-draft.js";
-import type { TelegramStreamMode } from "./bot/types.js";
+import {
+  renderStreamText,
+  resetLaneState,
+  rotateAnswerLaneAfterToolProgress,
+} from "./bot-message-dispatch-draft.js";
+import type {
+  TelegramDispatchTurn as Turn,
+  TelegramDispatchTurnConfig as TurnConfig,
+  TelegramProgressStateSlice,
+} from "./bot-message-dispatch.types.js";
+import type { DraftLaneState } from "./lane-delivery.js";
 import {
   formatTelegramProgressLine,
   renderTelegramProgressDraftPreview,
@@ -46,36 +53,37 @@ function buildTelegramTextToolProgressLine(text: string): ChannelProgressDraftLi
   };
 }
 
-export function createTelegramProgressController(params: {
-  accountId: string;
-  chatId: TelegramMessageContext["chatId"];
-  draft: TelegramDraftController;
-  statusReactionController: TelegramMessageContext["statusReactionController"];
-  streamMode: TelegramStreamMode;
+type TelegramProgressDraftState = {
+  answerLane: DraftLaneState;
   streamReasoningInProgressDraft: boolean;
-  telegramCfg: TelegramAccountConfig;
-  threadId?: number;
-}) {
-  const { answerLane } = params.draft;
-  const summaryStartedAt = Date.now();
-  const summary = createTelegramProgressSummaryTracker();
-  let summaryDelivered = false;
-  let draftEverRendered = false;
-  let finalAnswerDeliveryStarted = false;
-  let finalAnswerDelivered = false;
-  let sawProgressFinal = false;
-  let verboseProgressActive: () => boolean = () => false;
+};
 
-  const compositor = createChannelProgressDraftCompositor({
-    entry: params.telegramCfg,
-    mode: params.streamMode,
-    active: Boolean(answerLane.stream),
-    seed: `${params.accountId}:${params.chatId}:${params.threadId ?? ""}`,
+export function createProgressState(
+  config: TurnConfig,
+  draftState: TelegramProgressDraftState,
+  getTurn: () => Turn,
+  prepareAnswerLaneForToolProgress: () => Promise<void>,
+): TelegramProgressStateSlice {
+  const progressState = {
+    progressSummary: createTelegramProgressSummaryTracker(),
+    progressSummaryStartedAt: Date.now(),
+    summaryDelivered: false,
+    draftEverRendered: false,
+    finalAnswerDeliveryStarted: false,
+    finalAnswerDelivered: false,
+    sawProgressFinal: false,
+    verboseProgressActive: () => false,
+  };
+  const progressCompositor = createChannelProgressDraftCompositor({
+    entry: config.telegramCfg,
+    mode: config.streamMode,
+    active: Boolean(draftState.answerLane.stream),
+    seed: `${config.context.route.accountId}:${config.context.chatId}:${config.context.threadSpec.id ?? ""}`,
     formatLine: (text) =>
-      compositor.hasStatusHeadline || compositor.hasPlanProgress
+      progressCompositor.hasStatusHeadline || progressCompositor.hasPlanProgress
         ? text
         : formatTelegramProgressLine(text),
-    reasoningGate: params.streamReasoningInProgressDraft,
+    reasoningGate: draftState.streamReasoningInProgressDraft,
     reasoningLinePrefix: "🧠 ",
     commentaryLinePrefix: "💬 ",
     commentaryItalics: false,
@@ -85,226 +93,224 @@ export function createTelegramProgressController(params: {
     // headline/checklist mode, so they must not also arrive inside the text.
     rendersRollingLinesNatively: true,
     update: async (streamText, options) => {
-      draftEverRendered = true;
-      await params.draft.prepareAnswerLaneForToolProgress();
-      answerLane.lastPartialText = streamText;
-      answerLane.hasStreamedMessage = true;
-      answerLane.finalized = false;
-      answerLane.stream?.updatePreview(
+      getTurn().draftEverRendered = true;
+      await prepareAnswerLaneForToolProgress();
+      draftState.answerLane.lastPartialText = streamText;
+      draftState.answerLane.hasStreamedMessage = true;
+      draftState.answerLane.finalized = false;
+      draftState.answerLane.stream?.updatePreview(
         renderTelegramProgressDraftPreview(
           streamText,
           options?.lines ?? [],
-          params.telegramCfg.richMessages === true,
-          compositor.hasStatusHeadline || compositor.hasPlanProgress,
+          config.telegramCfg.richMessages === true,
+          progressCompositor.hasStatusHeadline || progressCompositor.hasPlanProgress,
         ),
       );
       if (options?.flush) {
-        await answerLane.stream?.flush();
+        await draftState.answerLane.stream?.flush();
       }
     },
   });
-
-  params.draft.setProgressLifecycle({
-    reset: () => compositor.reset(),
-    suppress: () => compositor.suppress(),
-  });
-
-  const canPushToolProgress = () =>
-    Boolean(
-      answerLane.stream &&
-      !verboseProgressActive() &&
-      !answerLane.finalized &&
-      !finalAnswerDeliveryStarted &&
-      !finalAnswerDelivered,
-    );
-  const pushEvent = async (fn: () => Promise<boolean>) =>
-    canPushToolProgress() ? await fn() : false;
-  const pushToolProgress = async (
-    line?: string | ChannelProgressDraftLine,
-    options?: { toolName?: string; startImmediately?: boolean },
-  ) => {
-    if (!canPushToolProgress()) {
-      return false;
-    }
-    return await compositor.pushToolProgress(
-      typeof line === "string" ? buildTelegramTextToolProgressLine(line) : line,
-      options,
-    );
-  };
-  const pushReasoningProgress = async (payload: {
-    text?: string;
-    isReasoningSnapshot?: boolean;
-  }) => {
-    if (params.streamReasoningInProgressDraft && payload.text) {
-      summary.noteReasoningActivity();
-    }
-    return await compositor.pushReasoningProgress(payload.text, {
-      snapshot: payload.isReasoningSnapshot === true,
-    });
-  };
-  const pushThinkingTokenProgress = async (progressTokens: number) => {
-    const rendered = await pushToolProgress(buildTelegramThinkingProgressLine(progressTokens), {
-      startImmediately: true,
-    });
-    if (rendered) {
-      summary.noteReasoningActivity();
-    }
-    return rendered;
-  };
-
-  const markFinalStarted = () => {
-    finalAnswerDeliveryStarted = true;
-    compositor.markFinalReplyStarted();
-  };
-  const markFinalDelivered = () => {
-    finalAnswerDelivered = true;
-    sawProgressFinal = true;
-    compositor.markFinalReplyDelivered();
-  };
-  const resolveCollapseSummaryLine = (): string | undefined => {
-    if (summaryDelivered) {
-      return undefined;
-    }
-    summaryDelivered = true;
-    if (!draftEverRendered) {
-      return undefined;
-    }
-    return (
-      formatTelegramProgressSummaryLine(summary.counts(), Date.now() - summaryStartedAt) ||
-      undefined
-    );
-  };
-  const applyCollapseSummary = async (
-    line: string,
-    postCosmeticSummary: (line: string) => Promise<void>,
-  ) => {
-    const messageId = await answerLane.stream?.finalizeToPreview(
-      params.draft.renderStreamText(line),
-    );
-    if (typeof messageId !== "number") {
-      await postCosmeticSummary(line);
-    }
-  };
-  const resetAnswerLaneAfterCollapse = () => {
-    if (params.draft.isAnswerToolProgressOnly()) {
-      params.draft.resetAnswerToolProgressDraft();
-      compositor.suppress();
-      params.draft.setRotateWhenQueuedBlocksSettle(false);
-    }
-    answerLane.stream?.forceNewMessage();
-    params.draft.resetLaneState(answerLane);
-  };
-  const teardownWindow = async () => {
-    if (params.draft.isAnswerToolProgressOnly()) {
-      await params.draft.rotateAnswerLaneAfterToolProgress();
-      return;
-    }
-    await answerLane.stream?.clear();
-    params.draft.resetLaneState(answerLane);
-  };
-
-  const handleToolStart = async (payload: CallbackPayload<"onToolStart">) => {
-    const toolName = payload.name?.trim();
-    if (payload.phase === "start") {
-      const windowRendersTool =
-        canPushToolProgress() &&
-        resolveChannelStreamingPreviewToolProgress(params.telegramCfg, true, params.streamMode) &&
-        isChannelProgressDraftWorkToolName(toolName);
-      if (windowRendersTool) {
-        summary.noteToolCall();
-      } else {
-        summary.closeReasoningBurst();
-        summary.closeCommentaryBurst();
-      }
-    }
-    const progressPromise = pushEvent(() => compositor.pushToolEvent(payload));
-    if (params.statusReactionController && toolName) {
-      await params.statusReactionController.setTool(toolName);
-    }
-    return await progressPromise;
-  };
-  const handleItemEvent = async (payload: CallbackPayload<"onItemEvent">) => {
-    if (payload.kind === "preamble") {
-      if (verboseProgressActive()) {
-        return false;
-      }
-      let rendered = false;
-      if (params.streamMode === "progress") {
-        rendered = await compositor.pushPreambleHeadline(payload.progressText, {
-          itemId: payload.itemId,
-        });
-      }
-      if (params.streamMode === "progress" && compositor.commentaryProgressEnabled) {
-        const accepted = await compositor.pushCommentaryProgress(payload.progressText, {
-          itemId: payload.itemId,
-        });
-        if (accepted) {
-          summary.noteCommentary(payload.itemId, payload.progressText);
-        }
-        rendered ||= accepted;
-      }
-      return rendered;
-    }
-    return await pushEvent(() => compositor.pushItemEvent(payload));
-  };
-  const handlePlanUpdate = async (payload: CallbackPayload<"onPlanUpdate">) => {
-    if (payload.phase === "update" && canPushToolProgress()) {
-      return await compositor.pushPlanProgress(payload.steps, {
-        explanation: payload.explanation,
-      });
-    }
-    return false;
-  };
-  return {
-    applyCollapseSummary,
-    beginQueuedFollowup: () => {
-      finalAnswerDeliveryStarted = false;
-      finalAnswerDelivered = false;
-      sawProgressFinal = false;
-      compositor.beginNewTurn({ force: true });
-    },
-    canPushToolProgress,
-    cancel: () => compositor.cancel(),
-    closeReasoningBurst: () => summary.closeReasoningBurst(),
-    commentaryProgressEnabled: compositor.commentaryProgressEnabled,
-    finalAnswerDelivered: () => finalAnswerDelivered,
-    finalAnswerDeliveryStarted: () => finalAnswerDeliveryStarted,
-    handleApprovalEvent: (payload: CallbackPayload<"onApprovalEvent">) =>
-      pushEvent(() => compositor.pushApprovalEvent(payload)),
-    handleCommandOutput: (payload: CallbackPayload<"onCommandOutput">) =>
-      pushEvent(() => compositor.pushCommandOutputEvent(payload)),
-    handleItemEvent,
-    handlePatchSummary: (payload: CallbackPayload<"onPatchSummary">) =>
-      pushEvent(() => compositor.pushPatchEvent(payload)),
-    handlePlanUpdate,
-    handleToolStart,
-    markFinalDelivered,
-    markFinalStarted,
-    markSawFinal: () => {
-      sawProgressFinal = true;
-    },
+  return Object.assign(progressState, {
+    progressCompositor,
+    commentaryProgressEnabled: progressCompositor.commentaryProgressEnabled,
     progressPreambleEnabled:
-      params.streamMode === "progress" && answerLane.stream ? true : undefined,
-    pushReasoningProgress,
-    pushThinkingTokenProgress,
-    pushToolProgress,
-    reset: () => compositor.reset(),
-    resetAnswerLaneAfterCollapse,
-    resolveCollapseSummaryLine,
-    sawProgressFinal: () => sawProgressFinal,
-    setFinalAnswerDelivered: (value: boolean) => {
-      finalAnswerDelivered = value;
-    },
-    setSummaryDelivered: () => {
-      summaryDelivered = true;
-    },
-    setVerboseProgressActive: (isActive: () => boolean) => {
-      verboseProgressActive = isActive;
-    },
-    suppress: () => compositor.suppress(),
-    teardownWindow,
-    verboseProgressActive: () => verboseProgressActive(),
-  };
+      config.streamMode === "progress" && draftState.answerLane.stream ? true : undefined,
+  });
 }
 
-export type TelegramProgressController = ReturnType<typeof createTelegramProgressController>;
+export function canPushToolProgress(turn: Turn): boolean {
+  return Boolean(
+    turn.answerLane.stream &&
+    !turn.verboseProgressActive() &&
+    !turn.answerLane.finalized &&
+    !turn.finalAnswerDeliveryStarted &&
+    !turn.finalAnswerDelivered,
+  );
+}
+
+async function pushProgressEvent(turn: Turn, event: () => Promise<boolean>): Promise<boolean> {
+  return canPushToolProgress(turn) ? await event() : false;
+}
+
+export async function pushToolProgress(
+  turn: Turn,
+  line?: string | ChannelProgressDraftLine,
+  options?: { toolName?: string; startImmediately?: boolean },
+): Promise<boolean> {
+  if (!canPushToolProgress(turn)) {
+    return false;
+  }
+  return await turn.progressCompositor.pushToolProgress(
+    typeof line === "string" ? buildTelegramTextToolProgressLine(line) : line,
+    options,
+  );
+}
+
+export async function pushReasoningProgress(
+  turn: Turn,
+  payload: { text?: string; isReasoningSnapshot?: boolean },
+): Promise<boolean> {
+  if (turn.streamReasoningInProgressDraft && payload.text) {
+    turn.progressSummary.noteReasoningActivity();
+  }
+  return await turn.progressCompositor.pushReasoningProgress(payload.text, {
+    snapshot: payload.isReasoningSnapshot === true,
+  });
+}
+
+export async function pushThinkingTokenProgress(
+  turn: Turn,
+  progressTokens: number,
+): Promise<boolean> {
+  const rendered = await pushToolProgress(turn, buildTelegramThinkingProgressLine(progressTokens), {
+    startImmediately: true,
+  });
+  if (rendered) {
+    turn.progressSummary.noteReasoningActivity();
+  }
+  return rendered;
+}
+
+export function markFinalStarted(turn: Turn): void {
+  turn.finalAnswerDeliveryStarted = true;
+  turn.progressCompositor.markFinalReplyStarted();
+}
+
+export function markFinalDelivered(turn: Turn): void {
+  turn.finalAnswerDelivered = true;
+  turn.sawProgressFinal = true;
+  turn.progressCompositor.markFinalReplyDelivered();
+}
+
+export function resolveCollapseSummaryLine(turn: Turn): string | undefined {
+  if (turn.summaryDelivered || !turn.draftEverRendered) {
+    return undefined;
+  }
+  return (
+    formatTelegramProgressSummaryLine(
+      turn.progressSummary.counts(),
+      Date.now() - turn.progressSummaryStartedAt,
+    ) || undefined
+  );
+}
+
+export async function applyCollapseSummary(
+  turn: Turn,
+  line: string,
+  postCosmeticSummary: (line: string) => Promise<void>,
+): Promise<void> {
+  const messageId = await turn.answerLane.stream?.finalizeToPreview(renderStreamText(turn, line));
+  if (typeof messageId !== "number") {
+    await postCosmeticSummary(line);
+  }
+}
+
+export function resetAnswerLaneAfterCollapse(turn: Turn): void {
+  if (turn.activeAnswerDraftIsToolProgressOnly) {
+    turn.activeAnswerDraftIsToolProgressOnly = false;
+    turn.progressCompositor.suppress();
+    turn.rotateAnswerLaneWhenQueuedBlocksSettle = false;
+  }
+  // Collapse must consume the active message before reset drops its identity.
+  // Reversing this order strands the summary or deletes the visible window.
+  turn.answerLane.stream?.forceNewMessage();
+  resetLaneState(turn, turn.answerLane);
+}
+
+export async function teardownProgressWindow(turn: Turn): Promise<void> {
+  if (turn.activeAnswerDraftIsToolProgressOnly) {
+    await rotateAnswerLaneAfterToolProgress(turn);
+    return;
+  }
+  await turn.answerLane.stream?.clear();
+  resetLaneState(turn, turn.answerLane);
+}
+
+export async function handleToolStart(
+  turn: Turn,
+  payload: CallbackPayload<"onToolStart">,
+): Promise<boolean> {
+  const toolName = payload.name?.trim();
+  if (payload.phase === "start") {
+    const windowRendersTool =
+      canPushToolProgress(turn) &&
+      resolveChannelStreamingPreviewToolProgress(turn.telegramCfg, true, turn.streamMode) &&
+      isChannelProgressDraftWorkToolName(toolName);
+    if (windowRendersTool) {
+      turn.progressSummary.noteToolCall();
+    } else {
+      turn.progressSummary.closeReasoningBurst();
+      turn.progressSummary.closeCommentaryBurst();
+    }
+  }
+  const progressPromise = pushProgressEvent(turn, () =>
+    turn.progressCompositor.pushToolEvent(payload),
+  );
+  if (turn.statusReactionController && toolName) {
+    await turn.statusReactionController.setTool(toolName);
+  }
+  return await progressPromise;
+}
+
+export async function handleItemEvent(
+  turn: Turn,
+  payload: CallbackPayload<"onItemEvent">,
+): Promise<boolean> {
+  if (payload.kind === "preamble") {
+    if (turn.verboseProgressActive()) {
+      return false;
+    }
+    let rendered = false;
+    if (turn.streamMode === "progress") {
+      rendered = await turn.progressCompositor.pushPreambleHeadline(payload.progressText, {
+        itemId: payload.itemId,
+      });
+    }
+    if (turn.streamMode === "progress" && turn.progressCompositor.commentaryProgressEnabled) {
+      const accepted = await turn.progressCompositor.pushCommentaryProgress(payload.progressText, {
+        itemId: payload.itemId,
+      });
+      if (accepted) {
+        turn.progressSummary.noteCommentary(payload.itemId, payload.progressText);
+      }
+      rendered ||= accepted;
+    }
+    return rendered;
+  }
+  return await pushProgressEvent(turn, () => turn.progressCompositor.pushItemEvent(payload));
+}
+
+export async function handlePlanUpdate(
+  turn: Turn,
+  payload: CallbackPayload<"onPlanUpdate">,
+): Promise<boolean> {
+  return payload.phase === "update" && canPushToolProgress(turn)
+    ? await turn.progressCompositor.pushPlanProgress(payload.steps, {
+        explanation: payload.explanation,
+      })
+    : false;
+}
+
+export async function handleApprovalEvent(
+  turn: Turn,
+  payload: CallbackPayload<"onApprovalEvent">,
+): Promise<boolean> {
+  return await pushProgressEvent(turn, () => turn.progressCompositor.pushApprovalEvent(payload));
+}
+
+export async function handleCommandOutput(
+  turn: Turn,
+  payload: CallbackPayload<"onCommandOutput">,
+): Promise<boolean> {
+  return await pushProgressEvent(turn, () =>
+    turn.progressCompositor.pushCommandOutputEvent(payload),
+  );
+}
+
+export async function handlePatchSummary(
+  turn: Turn,
+  payload: CallbackPayload<"onPatchSummary">,
+): Promise<boolean> {
+  return await pushProgressEvent(turn, () => turn.progressCompositor.pushPatchEvent(payload));
+}

--- a/extensions/telegram/src/bot-message-dispatch-reply.ts
+++ b/extensions/telegram/src/bot-message-dispatch-reply.ts
@@ -1,9 +1,7 @@
-// Telegram plugin module owns buffered reply payload delivery decisions.
 import {
   createChannelPartialDeliveryError,
   isChannelPartialDeliveryError,
 } from "openclaw/plugin-sdk/channel-inbound";
-import type { OpenClawConfig, TelegramAccountConfig } from "openclaw/plugin-sdk/config-contracts";
 import { normalizeMessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
 import {
   isFastModeAutoProgressPayload,
@@ -11,16 +9,37 @@ import {
   resolveSendableOutboundReplyParts,
   type ReplyPayload,
 } from "openclaw/plugin-sdk/reply-payload";
-import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
 import type { TelegramBotDeps } from "./bot-deps.js";
-import type { TelegramMessageContext } from "./bot-message-context.js";
-import type { TelegramDeliveryController } from "./bot-message-dispatch-delivery.js";
-import type { TelegramDraftController } from "./bot-message-dispatch-draft.js";
-import type { TelegramProgressController } from "./bot-message-dispatch-progress.js";
+import {
+  applyTextToPayload,
+  deliverFinalAnswerText,
+  emitPreviewFinalizedHook,
+  normalizeDeliveryPayload,
+  sendPayload,
+} from "./bot-message-dispatch-delivery.js";
+import {
+  dropQueuedAnswerBlockRotation,
+  enqueueDraftEvent,
+  isQueuedAnswerBlock,
+  prepareAnswerLaneForText,
+  prepareAnswerLaneForToolProgress,
+  rotateAnswerLaneAfterToolProgress,
+  rotateAnswerLaneForNewMessage,
+  splitTextIntoLaneSegments,
+  takeQueuedAnswerBlockRotation,
+} from "./bot-message-dispatch-draft.js";
+import {
+  markFinalDelivered,
+  markFinalStarted,
+  pushToolProgress,
+} from "./bot-message-dispatch-progress.js";
 import { deduplicateBlockSentMedia } from "./bot-message-dispatch.media-dedup.js";
-import type { TelegramDispatchTurnState } from "./bot-message-dispatch.types.js";
-import type { TelegramStreamMode } from "./bot/types.js";
+import type {
+  TelegramBufferedFinalSettlement,
+  TelegramDispatchTurn as Turn,
+  TelegramReplyStateSlice,
+} from "./bot-message-dispatch.types.js";
 import {
   resolveTelegramInlineButtons,
   resolveTelegramQuestionOptionIndices,
@@ -88,458 +107,443 @@ function hasExecApprovalPayload(payload: ReplyPayload): boolean {
   return payload.channelData?.execApproval !== undefined;
 }
 
-export function createTelegramReplyDelivery(params: {
-  cfg: OpenClawConfig;
-  context: TelegramMessageContext;
-  delivery: TelegramDeliveryController;
-  draft: TelegramDraftController;
-  fence: { generation: () => number; isSuperseded: () => boolean };
-  progress: TelegramProgressController;
-  runtime: RuntimeEnv;
-  state: TelegramDispatchTurnState;
-  streamMode: TelegramStreamMode;
-  telegramCfg: TelegramAccountConfig;
-}) {
-  const reasoningStepState = createTelegramReasoningStepState();
-  let bufferedFinalSettlement:
-    | {
-        promise: Promise<{ visibleReplySent: boolean }>;
-        visibleReplySent: boolean;
-        onPlatformSendDispatch?: () => Promise<void>;
-        bindPendingFinalDelivery?: <T extends ReplyPayload>(payload: T) => T;
-        resolve: (result: { visibleReplySent: boolean }) => void;
-        reject: (error: unknown) => void;
-      }
-    | undefined;
-  const sentBlockMediaUrls = new Set<string>();
-  params.draft.setReasoningStepCallbacks({
-    noteHint: () => reasoningStepState.noteReasoningHint(),
-    noteDelivered: () => reasoningStepState.noteReasoningDelivered(),
-  });
-
-  const settleBufferedFinalAsNotVisible = () => {
-    if (bufferedFinalSettlement) {
-      bufferedFinalSettlement.resolve({
-        visibleReplySent: bufferedFinalSettlement.visibleReplySent,
-      });
-    }
-    bufferedFinalSettlement = undefined;
-  };
-  const resetReasoningStepState = () => {
-    settleBufferedFinalAsNotVisible();
-    reasoningStepState.resetForNextStep();
-  };
-  const flushBufferedFinalAnswer = async (currentPayloadVisible = false): Promise<void> => {
-    const settlement = bufferedFinalSettlement;
-    const buffered = reasoningStepState.takeBufferedFinalAnswer(params.fence.generation());
-    if (!buffered) {
-      // A stale fence can discard the buffered text after another segment became visible.
-      // Preserve that partial visibility so core does not reconcile an actual send away.
-      settlement?.resolve({ visibleReplySent: settlement.visibleReplySent });
-      bufferedFinalSettlement = undefined;
-      resetReasoningStepState();
-      return;
-    }
-    bufferedFinalSettlement = undefined;
-    try {
-      const result = await params.delivery.deliverFinalAnswerText(
-        buffered.payload,
-        buffered.text,
-        resolvePayloadTelegramInlineButtons(buffered.payload),
-        settlement?.onPlatformSendDispatch,
-        settlement?.bindPendingFinalDelivery,
-      );
-      if (settlement) {
-        settlement.resolve({
-          visibleReplySent: settlement.visibleReplySent || result.kind !== "skipped",
-        });
-      }
-      resetReasoningStepState();
-    } catch (error: unknown) {
-      if (settlement) {
-        settlement.reject(
-          settlement.visibleReplySent ? toTelegramVisiblePartialDeliveryError(error) : error,
-        );
-      }
-      throw currentPayloadVisible ? toTelegramVisiblePartialDeliveryError(error) : error;
-    }
-  };
-  const settleTerminalNoVisibleDelivery = async (
-    info: Parameters<NonNullable<Deliver>>[1],
-    options?: { abandonBufferedFinal?: boolean },
-  ): Promise<TelegramReplyDeliveryResult> => {
-    if (options?.abandonBufferedFinal) {
-      resetReasoningStepState();
-    } else if (info.kind === "final") {
-      await flushBufferedFinalAnswer();
-    }
-    return toTelegramReplyDeliveryResult(false);
-  };
-  const trackBlockMedia = (delivered: boolean, kind: string, payload: ReplyPayload) => {
-    if (delivered && kind === "block" && payload.mediaUrls?.length) {
-      for (const url of payload.mediaUrls) {
-        sentBlockMediaUrls.add(url);
-      }
-    }
-  };
-
-  const deliver = (async (
-    payload: Parameters<Deliver>[0],
-    info: Parameters<Deliver>[1],
-  ): Promise<TelegramReplyDeliveryResult> => {
-    if (params.fence.isSuperseded()) {
-      return await settleTerminalNoVisibleDelivery(info, { abandonBufferedFinal: true });
-    }
-    const normalizedPayload = params.delivery.normalizeDeliveryPayload(payload);
-    if (!normalizedPayload) {
-      return await settleTerminalNoVisibleDelivery(info);
-    }
-    const deduped =
-      info.kind === "final"
-        ? deduplicateBlockSentMedia(normalizedPayload, sentBlockMediaUrls)
-        : normalizedPayload;
-    if (!deduped) {
-      return await settleTerminalNoVisibleDelivery(info);
-    }
-    const effectivePayload = deduped;
-    if (
-      shouldSuppressLocalTelegramExecApprovalPrompt({
-        cfg: params.cfg,
-        accountId: params.context.route.accountId,
-        payload: effectivePayload,
-      })
-    ) {
-      params.state.queuedFinal = true;
-      return await settleTerminalNoVisibleDelivery(info);
-    }
-    const telegramButtons = resolvePayloadTelegramInlineButtons(effectivePayload);
-    const lanePayload =
-      info.kind === "block" &&
-      typeof payload.text === "string" &&
-      typeof effectivePayload.text === "string" &&
-      payload.text !== effectivePayload.text &&
-      payload.text.trimEnd() === effectivePayload.text &&
-      !effectivePayload.mediaUrl &&
-      !effectivePayload.mediaUrls?.length
-        ? { ...effectivePayload, text: payload.text }
-        : effectivePayload;
-    const split = params.draft.splitTextIntoLaneSegments(
-      { text: lanePayload.text },
-      payload.isReasoning,
-    );
-    const segments = split.segments;
-    const reply = resolveSendableOutboundReplyParts(effectivePayload);
-    if (info.kind === "final" && (reply.text.length > 0 || reply.hasMedia)) {
-      params.progress.markFinalStarted();
-    }
-    if (info.kind === "final") {
-      await params.draft.enqueueEvent(async () => {});
-    }
-    const isToolPayloadAfterFinal =
-      info.kind === "tool" &&
-      (params.progress.finalAnswerDeliveryStarted() || params.progress.finalAnswerDelivered());
-    const isNonTerminalWarningAfterDeliveredFinal =
-      isReplyPayloadNonTerminalToolErrorWarning(payload) && params.progress.finalAnswerDelivered();
-    if (
-      (isToolPayloadAfterFinal || isNonTerminalWarningAfterDeliveredFinal) &&
-      !reply.hasMedia &&
-      !hasExecApprovalPayload(effectivePayload)
-    ) {
-      return await settleTerminalNoVisibleDelivery(info);
-    }
-    if (payload.isError === true) {
-      params.state.hadErrorReplyFailureOrSkip = true;
-    }
-
-    let blockDelivered = false;
-    let finalization: Promise<{ visibleReplySent: boolean }> | undefined;
-    const hasAnswerSegment = segments.some((segment) => segment.lane === "answer");
-    if (info.kind === "block" && !hasAnswerSegment) {
-      params.draft.dropQueuedAnswerBlockRotation(effectivePayload, info.assistantMessageIndex);
-    }
-    for (const segment of segments) {
-      if (
-        segment.lane === "answer" &&
-        info.kind === "final" &&
-        reasoningStepState.shouldBufferFinalAnswer()
-      ) {
-        let resolveFinalization!: (result: { visibleReplySent: boolean }) => void;
-        let rejectFinalization!: (error: unknown) => void;
-        finalization = new Promise((resolve, reject) => {
-          resolveFinalization = resolve;
-          rejectFinalization = reject;
-        });
-        // The coordinator admits only one buffered answer. Settle defensively before replacing
-        // its paired promise so an unexpected rebuffer can never orphan turn finalization.
-        settleBufferedFinalAsNotVisible();
-        bufferedFinalSettlement = {
-          promise: finalization,
-          visibleReplySent: blockDelivered,
-          onPlatformSendDispatch: info.onPlatformSendDispatch,
-          bindPendingFinalDelivery: info.bindPendingFinalDelivery,
-          resolve: resolveFinalization,
-          reject: rejectFinalization,
-        };
-        reasoningStepState.bufferFinalAnswer({
-          payload: effectivePayload,
-          text: segment.update.text,
-          bufferedGeneration: params.fence.generation(),
-        });
-        continue;
-      }
-      if (segment.lane === "reasoning") {
-        reasoningStepState.noteReasoningHint();
-      }
-      if (segment.lane === "answer" && info.kind === "tool") {
-        if (params.progress.verboseProgressActive()) {
-          if (
-            await params.delivery.sendPayload(
-              params.delivery.applyTextToPayload(effectivePayload, segment.update.text),
-            )
-          ) {
-            blockDelivered = true;
-          }
-          continue;
-        }
-        const canRepresentAsTransientProgress =
-          !reply.hasMedia &&
-          telegramButtons === undefined &&
-          !hasExecApprovalPayload(effectivePayload);
-        const isFastModeProgressPayload = isFastModeAutoProgressPayload(effectivePayload);
-        if (params.streamMode === "progress") {
-          if (
-            canRepresentAsTransientProgress &&
-            params.draft.answerLane.stream &&
-            !isFastModeProgressPayload
-          ) {
-            continue;
-          }
-          if (
-            (canRepresentAsTransientProgress || isFastModeProgressPayload) &&
-            (await params.progress.pushToolProgress(segment.update.text, {
-              startImmediately: true,
-            }))
-          ) {
-            blockDelivered = true;
-            continue;
-          }
-        }
-        await params.draft.prepareAnswerLaneForToolProgress();
-      }
-
-      const ownedByQueuedRotation = params.draft.isQueuedAnswerBlock(
-        lanePayload,
-        info.assistantMessageIndex,
-      );
-      const skipTextOnlyBlock =
-        params.streamMode === "partial" &&
-        info.kind === "block" &&
-        segment.lane === "answer" &&
-        !reply.hasMedia &&
-        !hasExecApprovalPayload(effectivePayload) &&
-        telegramButtons === undefined &&
-        params.draft.answerLane.hasStreamedMessage &&
-        !params.draft.isAnswerToolProgressOnly() &&
-        !ownedByQueuedRotation &&
-        segment.update.text.trimEnd() === params.draft.answerLane.lastPartialText.trimEnd();
-      const isDurableProgressCommentary =
-        params.streamMode === "progress" &&
-        info.kind === "block" &&
-        effectivePayload.isCommentary === true;
-      // CLI finals exclude separately classified commentary. Send that block outside
-      // the disposable progress stream or its collapse summary erases the text.
-      const suppressProgressAnswerBlock =
-        params.streamMode === "progress" &&
-        info.kind === "block" &&
-        segment.lane === "answer" &&
-        !isDurableProgressCommentary &&
-        !reply.hasMedia &&
-        !hasExecApprovalPayload(effectivePayload) &&
-        telegramButtons === undefined;
-      if (skipTextOnlyBlock || suppressProgressAnswerBlock) {
-        params.draft.setActiveAnswerBlockDelivery({
-          payload: effectivePayload,
-          text: segment.update.text,
-          buttons: telegramButtons,
-        });
-        params.draft.resetAnswerToolProgressDraft();
-        params.progress.reset();
-        blockDelivered = true;
-        continue;
-      }
-
-      if (segment.lane === "answer" && info.kind === "block") {
-        const prepared = await params.draft.prepareAnswerLaneForText();
-        const shouldRotate = params.draft.takeQueuedAnswerBlockRotation(
-          lanePayload,
-          info.assistantMessageIndex,
-        );
-        if (params.streamMode !== "progress" && shouldRotate && !prepared) {
-          await params.draft.rotateAnswerLaneForNewMessage();
-          params.draft.setRotateWhenQueuedBlocksSettle(false);
-        }
-        params.draft.resetAnswerToolProgressDraft();
-        params.progress.reset();
-      }
-      const result =
-        segment.lane === "answer" && info.kind === "final"
-          ? await params.delivery.deliverFinalAnswerText(
-              effectivePayload,
-              segment.update.text,
-              telegramButtons,
-              info.onPlatformSendDispatch,
-              info.bindPendingFinalDelivery,
-            )
-          : await params.delivery.deliverLaneText({
-              laneName: segment.lane,
-              text: segment.update.text,
-              payload: lanePayload,
-              infoKind: info.kind,
-              buttons: telegramButtons,
-              allowStream: !isDurableProgressCommentary,
-              onPlatformSendDispatch: info.onPlatformSendDispatch,
-              bindPendingFinalDelivery: info.bindPendingFinalDelivery,
-            });
-      if (
-        segment.lane === "answer" &&
-        info.kind !== "final" &&
-        result.kind === "preview-finalized"
-      ) {
-        await params.delivery.emitPreviewFinalizedHook(result);
-      }
-      if (segment.lane === "answer" && info.kind === "block" && result.kind === "preview-updated") {
-        params.draft.setActiveAnswerBlockDelivery({
-          payload: lanePayload,
-          text: segment.update.text,
-          buttons: telegramButtons,
-        });
-      }
-      blockDelivered ||= result.kind !== "skipped";
-      if (segment.lane === "reasoning") {
-        if (result.kind !== "skipped") {
-          reasoningStepState.noteReasoningDelivered();
-          if (finalization && bufferedFinalSettlement) {
-            bufferedFinalSettlement.visibleReplySent ||= blockDelivered;
-          }
-          await flushBufferedFinalAnswer(blockDelivered);
-        }
-      } else if (info.kind === "final") {
-        resetReasoningStepState();
-      }
-    }
-    if (segments.length > 0) {
-      if (finalization && bufferedFinalSettlement) {
-        bufferedFinalSettlement.visibleReplySent ||= blockDelivered;
-      }
-      trackBlockMedia(blockDelivered, info.kind, effectivePayload);
-      return toTelegramReplyDeliveryResult(blockDelivered, finalization);
-    }
-
-    if (split.suppressedReasoningOnly) {
-      let delivered = false;
-      if (info.kind === "final") {
-        await params.draft.rotateAnswerLaneAfterToolProgress();
-        await params.draft.answerLane.stream?.stop();
-        await params.draft.reasoningLane.stream?.stop();
-        await flushBufferedFinalAnswer();
-      }
-      if (reply.hasMedia) {
-        const payloadWithoutReasoning =
-          typeof effectivePayload.text === "string"
-            ? { ...effectivePayload, text: "" }
-            : effectivePayload;
-        delivered = await params.delivery.sendPayload(payloadWithoutReasoning, {
-          durable: info.kind === "final",
-          onPlatformSendDispatch: info.onPlatformSendDispatch,
-          bindPendingFinalDelivery: info.bindPendingFinalDelivery,
-        });
-      }
-      if (info.kind === "final" && delivered) {
-        params.progress.markFinalDelivered();
-      }
-      trackBlockMedia(delivered, info.kind, effectivePayload);
-      return toTelegramReplyDeliveryResult(delivered);
-    }
-
-    if (info.kind === "final") {
-      await params.draft.rotateAnswerLaneAfterToolProgress();
-      await params.draft.answerLane.stream?.stop();
-      await params.draft.reasoningLane.stream?.stop();
-      await flushBufferedFinalAnswer();
-    }
-    if (!reply.hasMedia && reply.text.length === 0) {
-      if (info.kind === "final") {
-        await flushBufferedFinalAnswer();
-      }
-      return toTelegramReplyDeliveryResult(false);
-    }
-    const delivered = await params.delivery.sendPayload(effectivePayload, {
-      durable: info.kind === "final",
-      onPlatformSendDispatch: info.onPlatformSendDispatch,
-      bindPendingFinalDelivery: info.bindPendingFinalDelivery,
-    });
-    if (info.kind === "final" && delivered) {
-      params.progress.markFinalDelivered();
-    }
-    trackBlockMedia(delivered, info.kind, effectivePayload);
-    return toTelegramReplyDeliveryResult(delivered);
-  }) satisfies Deliver;
-
-  const onSkip: Skip = (payload, info) => {
-    if (info.kind === "block") {
-      void params.draft.enqueueEvent(async () => {
-        params.draft.dropQueuedAnswerBlockRotation(payload, info.assistantMessageIndex);
-      });
-    }
-    if (payload.isError === true) {
-      params.state.hadErrorReplyFailureOrSkip = true;
-    }
-    if (info.reason !== "silent") {
-      params.delivery.markNonSilentSkip();
-    }
-  };
-
-  const onError: ErrorCallback = (err, info) => {
-    const errorPolicy = resolveTelegramErrorPolicy({
-      accountConfig: params.telegramCfg,
-      groupConfig: params.context.groupConfig,
-      topicConfig: params.context.topicConfig,
-    });
-    if (isSilentErrorPolicy(errorPolicy.policy)) {
-      return;
-    }
-    if (
-      errorPolicy.policy === "once" &&
-      shouldSuppressTelegramError({
-        scopeKey: buildTelegramErrorScopeKey({
-          accountId: params.context.route.accountId,
-          chatId: params.context.chatId,
-          threadId: params.context.threadSpec.id,
-        }),
-        cooldownMs: errorPolicy.cooldownMs,
-        errorMessage: String(err),
-      })
-    ) {
-      return;
-    }
-    params.delivery.markNonSilentFailure();
-    params.runtime.error?.(danger(`telegram ${info.kind} reply failed: ${String(err)}`));
-  };
-
+export function createReplyState(): TelegramReplyStateSlice {
   return {
-    deliver,
-    onBeforeDeliverCancelled: (payload: Parameters<Cancel>[0], info: Parameters<Cancel>[1]) => {
-      if (info.kind === "block") {
-        return params.draft.enqueueEvent(async () => {
-          params.draft.dropQueuedAnswerBlockRotation(payload, info.assistantMessageIndex);
-        });
-      }
-      return undefined;
-    },
-    onError,
-    onSkip,
-    reasoningStepState: { ...reasoningStepState, resetForNextStep: resetReasoningStepState },
+    reasoningStepState: createTelegramReasoningStepState(),
+    bufferedFinalSettlement: undefined as TelegramBufferedFinalSettlement | undefined,
+    sentBlockMediaUrls: new Set<string>(),
+    splitReasoningOnNextStream: false,
   };
 }
 
-export type TelegramReplyDelivery = ReturnType<typeof createTelegramReplyDelivery>;
+function settleBufferedFinalAsNotVisible(turn: Turn): void {
+  if (turn.bufferedFinalSettlement) {
+    turn.bufferedFinalSettlement.resolve({
+      visibleReplySent: turn.bufferedFinalSettlement.visibleReplySent,
+    });
+  }
+  turn.bufferedFinalSettlement = undefined;
+}
+
+export function resetReasoningStepState(turn: Turn): void {
+  settleBufferedFinalAsNotVisible(turn);
+  turn.reasoningStepState.resetForNextStep();
+}
+
+async function flushBufferedFinalAnswer(turn: Turn, currentPayloadVisible = false): Promise<void> {
+  const settlement = turn.bufferedFinalSettlement;
+  const buffered = turn.reasoningStepState.takeBufferedFinalAnswer();
+  turn.bufferedFinalSettlement = undefined;
+  if (!buffered) {
+    settlement?.resolve({ visibleReplySent: settlement.visibleReplySent });
+    turn.reasoningStepState.resetForNextStep();
+    return;
+  }
+  try {
+    const result = await deliverFinalAnswerText(
+      turn,
+      buffered.payload,
+      buffered.text,
+      resolvePayloadTelegramInlineButtons(buffered.payload),
+      settlement?.onPlatformSendDispatch,
+      settlement?.bindPendingFinalDelivery,
+    );
+    if (settlement) {
+      settlement.resolve({
+        visibleReplySent: settlement.visibleReplySent || result.kind !== "skipped",
+      });
+    }
+    resetReasoningStepState(turn);
+  } catch (error: unknown) {
+    if (settlement) {
+      settlement.reject(
+        settlement.visibleReplySent ? toTelegramVisiblePartialDeliveryError(error) : error,
+      );
+    }
+    throw currentPayloadVisible ? toTelegramVisiblePartialDeliveryError(error) : error;
+  }
+}
+
+async function stopTelegramReplyLanesAndFlushBufferedFinal(turn: Turn): Promise<void> {
+  await rotateAnswerLaneAfterToolProgress(turn);
+  await turn.answerLane.stream?.stop();
+  await turn.reasoningLane.stream?.stop();
+  // Both lanes must stop before the buffered flush, keeping the final answer the last visible send.
+  await flushBufferedFinalAnswer(turn);
+}
+
+async function settleTerminalNoVisibleDelivery(
+  turn: Turn,
+  info: Parameters<NonNullable<Deliver>>[1],
+  options?: { abandonBufferedFinal?: boolean },
+): Promise<TelegramReplyDeliveryResult> {
+  if (options?.abandonBufferedFinal) {
+    resetReasoningStepState(turn);
+  } else if (info.kind === "final") {
+    // A terminal callback must drain the buffered answer before the next step can reset it.
+    await flushBufferedFinalAnswer(turn);
+  }
+  return toTelegramReplyDeliveryResult(false);
+}
+
+function trackBlockMedia(
+  turn: Turn,
+  delivered: boolean,
+  kind: string,
+  payload: ReplyPayload,
+): void {
+  if (delivered && kind === "block" && payload.mediaUrls?.length) {
+    for (const url of payload.mediaUrls) {
+      turn.sentBlockMediaUrls.add(url);
+    }
+  }
+}
+
+export async function deliverReply(
+  turn: Turn,
+  payload: Parameters<NonNullable<Deliver>>[0],
+  info: Parameters<NonNullable<Deliver>>[1],
+): Promise<TelegramReplyDeliveryResult> {
+  if (turn.isSuperseded()) {
+    return await settleTerminalNoVisibleDelivery(turn, info, { abandonBufferedFinal: true });
+  }
+  const normalizedPayload = normalizeDeliveryPayload(turn, payload);
+  if (!normalizedPayload) {
+    return await settleTerminalNoVisibleDelivery(turn, info);
+  }
+  const deduped =
+    info.kind === "final"
+      ? deduplicateBlockSentMedia(normalizedPayload, turn.sentBlockMediaUrls)
+      : normalizedPayload;
+  if (!deduped) {
+    return await settleTerminalNoVisibleDelivery(turn, info);
+  }
+  const effectivePayload = deduped;
+  if (
+    shouldSuppressLocalTelegramExecApprovalPrompt({
+      cfg: turn.cfg,
+      accountId: turn.context.route.accountId,
+      payload: effectivePayload,
+    })
+  ) {
+    turn.queuedFinal = true;
+    return await settleTerminalNoVisibleDelivery(turn, info);
+  }
+  const telegramButtons = resolvePayloadTelegramInlineButtons(effectivePayload);
+  const lanePayload =
+    info.kind === "block" &&
+    typeof payload.text === "string" &&
+    typeof effectivePayload.text === "string" &&
+    payload.text !== effectivePayload.text &&
+    payload.text.trimEnd() === effectivePayload.text &&
+    !effectivePayload.mediaUrl &&
+    !effectivePayload.mediaUrls?.length
+      ? { ...effectivePayload, text: payload.text }
+      : effectivePayload;
+  const split = splitTextIntoLaneSegments(turn, { text: lanePayload.text }, payload.isReasoning);
+  const segments = split.segments;
+  const reply = resolveSendableOutboundReplyParts(effectivePayload);
+  if (info.kind === "final" && (reply.text.length > 0 || reply.hasMedia)) {
+    // Mark final delivery before any queued draft drain; late tool progress must stay suppressed.
+    markFinalStarted(turn);
+  }
+  if (info.kind === "final") {
+    // Final delivery drains queued draft work so an earlier block cannot overtake it.
+    await enqueueDraftEvent(turn, async () => {});
+  }
+  const isToolPayloadAfterFinal =
+    info.kind === "tool" && (turn.finalAnswerDeliveryStarted || turn.finalAnswerDelivered);
+  const isNonTerminalWarningAfterDeliveredFinal =
+    isReplyPayloadNonTerminalToolErrorWarning(payload) && turn.finalAnswerDelivered;
+  if (
+    (isToolPayloadAfterFinal || isNonTerminalWarningAfterDeliveredFinal) &&
+    !reply.hasMedia &&
+    !hasExecApprovalPayload(effectivePayload)
+  ) {
+    return await settleTerminalNoVisibleDelivery(turn, info);
+  }
+  if (payload.isError === true) {
+    turn.hadErrorReplyFailureOrSkip = true;
+  }
+
+  let blockDelivered = false;
+  let finalization: Promise<{ visibleReplySent: boolean }> | undefined;
+  const hasAnswerSegment = segments.some((segment) => segment.lane === "answer");
+  if (info.kind === "block" && !hasAnswerSegment) {
+    dropQueuedAnswerBlockRotation(turn, effectivePayload, info.assistantMessageIndex);
+  }
+  for (const segment of segments) {
+    if (
+      segment.lane === "answer" &&
+      info.kind === "final" &&
+      turn.reasoningStepState.shouldBufferFinalAnswer()
+    ) {
+      let resolveFinalization!: (result: { visibleReplySent: boolean }) => void;
+      let rejectFinalization!: (error: unknown) => void;
+      finalization = new Promise((resolve, reject) => {
+        resolveFinalization = resolve;
+        rejectFinalization = reject;
+      });
+      // The coordinator admits only one buffered answer. Settle defensively before replacing
+      // its paired promise so an unexpected rebuffer can never orphan turn finalization.
+      settleBufferedFinalAsNotVisible(turn);
+      turn.bufferedFinalSettlement = {
+        visibleReplySent: blockDelivered,
+        onPlatformSendDispatch: info.onPlatformSendDispatch,
+        bindPendingFinalDelivery: info.bindPendingFinalDelivery,
+        resolve: resolveFinalization,
+        reject: rejectFinalization,
+      };
+      turn.reasoningStepState.bufferFinalAnswer({
+        payload: effectivePayload,
+        text: segment.update.text,
+      });
+      continue;
+    }
+    if (segment.lane === "reasoning") {
+      turn.reasoningStepState.noteReasoningHint();
+    }
+    if (segment.lane === "answer" && info.kind === "tool") {
+      if (turn.verboseProgressActive()) {
+        if (await sendPayload(turn, applyTextToPayload(effectivePayload, segment.update.text))) {
+          blockDelivered = true;
+        }
+        continue;
+      }
+      const canRepresentAsTransientProgress =
+        !reply.hasMedia &&
+        telegramButtons === undefined &&
+        !hasExecApprovalPayload(effectivePayload);
+      const isFastModeProgressPayload = isFastModeAutoProgressPayload(effectivePayload);
+      if (turn.streamMode === "progress") {
+        if (
+          canRepresentAsTransientProgress &&
+          turn.answerLane.stream &&
+          !isFastModeProgressPayload
+        ) {
+          continue;
+        }
+        if (
+          (canRepresentAsTransientProgress || isFastModeProgressPayload) &&
+          (await pushToolProgress(turn, segment.update.text, {
+            startImmediately: true,
+          }))
+        ) {
+          blockDelivered = true;
+          continue;
+        }
+      }
+      await prepareAnswerLaneForToolProgress(turn);
+    }
+
+    const ownedByQueuedRotation = isQueuedAnswerBlock(
+      turn,
+      lanePayload,
+      info.assistantMessageIndex,
+    );
+    const skipTextOnlyBlock =
+      turn.streamMode === "partial" &&
+      info.kind === "block" &&
+      segment.lane === "answer" &&
+      !reply.hasMedia &&
+      !hasExecApprovalPayload(effectivePayload) &&
+      telegramButtons === undefined &&
+      turn.answerLane.hasStreamedMessage &&
+      !turn.activeAnswerDraftIsToolProgressOnly &&
+      !ownedByQueuedRotation &&
+      segment.update.text.trimEnd() === turn.answerLane.lastPartialText.trimEnd();
+    const isDurableProgressCommentary =
+      turn.streamMode === "progress" &&
+      info.kind === "block" &&
+      effectivePayload.isCommentary === true;
+    // CLI finals exclude separately classified commentary. Send that block outside
+    // the disposable progress stream or its collapse summary erases the text.
+    const suppressProgressAnswerBlock =
+      turn.streamMode === "progress" &&
+      info.kind === "block" &&
+      segment.lane === "answer" &&
+      !isDurableProgressCommentary &&
+      !reply.hasMedia &&
+      !hasExecApprovalPayload(effectivePayload) &&
+      telegramButtons === undefined;
+    if (skipTextOnlyBlock || suppressProgressAnswerBlock) {
+      turn.activeAnswerBlockDelivery = {
+        payload: effectivePayload,
+        text: segment.update.text,
+        buttons: telegramButtons,
+      };
+      turn.activeAnswerDraftIsToolProgressOnly = false;
+      turn.progressCompositor.reset();
+      blockDelivered = true;
+      continue;
+    }
+
+    if (segment.lane === "answer" && info.kind === "block") {
+      const prepared = await prepareAnswerLaneForText(turn);
+      const shouldRotate = takeQueuedAnswerBlockRotation(
+        turn,
+        lanePayload,
+        info.assistantMessageIndex,
+      );
+      if (turn.streamMode !== "progress" && shouldRotate && !prepared) {
+        await rotateAnswerLaneForNewMessage(turn);
+        turn.rotateAnswerLaneWhenQueuedBlocksSettle = false;
+      }
+      turn.activeAnswerDraftIsToolProgressOnly = false;
+      turn.progressCompositor.reset();
+    }
+    const result =
+      segment.lane === "answer" && info.kind === "final"
+        ? await deliverFinalAnswerText(
+            turn,
+            effectivePayload,
+            segment.update.text,
+            telegramButtons,
+            info.onPlatformSendDispatch,
+            info.bindPendingFinalDelivery,
+          )
+        : await turn.deliverLaneText({
+            laneName: segment.lane,
+            text: segment.update.text,
+            payload: lanePayload,
+            infoKind: info.kind,
+            buttons: telegramButtons,
+            allowStream: !isDurableProgressCommentary,
+            onPlatformSendDispatch: info.onPlatformSendDispatch,
+            bindPendingFinalDelivery: info.bindPendingFinalDelivery,
+          });
+    if (segment.lane === "answer" && info.kind !== "final" && result.kind === "preview-finalized") {
+      await emitPreviewFinalizedHook(turn, result);
+    }
+    if (segment.lane === "answer" && info.kind === "block" && result.kind === "preview-updated") {
+      turn.activeAnswerBlockDelivery = {
+        payload: lanePayload,
+        text: segment.update.text,
+        buttons: telegramButtons,
+      };
+    }
+    blockDelivered ||= result.kind !== "skipped";
+    if (segment.lane === "reasoning") {
+      if (result.kind !== "skipped") {
+        turn.reasoningStepState.noteReasoningDelivered();
+        if (finalization && turn.bufferedFinalSettlement) {
+          turn.bufferedFinalSettlement.visibleReplySent ||= blockDelivered;
+        }
+        await flushBufferedFinalAnswer(turn, blockDelivered);
+      }
+    } else if (info.kind === "final") {
+      resetReasoningStepState(turn);
+    }
+  }
+  if (segments.length > 0) {
+    if (finalization && turn.bufferedFinalSettlement) {
+      turn.bufferedFinalSettlement.visibleReplySent ||= blockDelivered;
+    }
+    trackBlockMedia(turn, blockDelivered, info.kind, effectivePayload);
+    return toTelegramReplyDeliveryResult(blockDelivered, finalization);
+  }
+
+  if (split.suppressedReasoningOnly) {
+    let delivered = false;
+    if (info.kind === "final") {
+      await stopTelegramReplyLanesAndFlushBufferedFinal(turn);
+    }
+    if (reply.hasMedia) {
+      const payloadWithoutReasoning =
+        typeof effectivePayload.text === "string"
+          ? { ...effectivePayload, text: "" }
+          : effectivePayload;
+      delivered = await sendPayload(turn, payloadWithoutReasoning, {
+        durable: info.kind === "final",
+        onPlatformSendDispatch: info.onPlatformSendDispatch,
+        bindPendingFinalDelivery: info.bindPendingFinalDelivery,
+      });
+    }
+    if (info.kind === "final" && delivered) {
+      markFinalDelivered(turn);
+    }
+    trackBlockMedia(turn, delivered, info.kind, effectivePayload);
+    return toTelegramReplyDeliveryResult(delivered);
+  }
+
+  if (info.kind === "final") {
+    await stopTelegramReplyLanesAndFlushBufferedFinal(turn);
+  }
+  if (!reply.hasMedia && reply.text.length === 0) {
+    if (info.kind === "final") {
+      await flushBufferedFinalAnswer(turn);
+    }
+    return toTelegramReplyDeliveryResult(false);
+  }
+  const delivered = await sendPayload(turn, effectivePayload, {
+    durable: info.kind === "final",
+    onPlatformSendDispatch: info.onPlatformSendDispatch,
+    bindPendingFinalDelivery: info.bindPendingFinalDelivery,
+  });
+  if (info.kind === "final" && delivered) {
+    markFinalDelivered(turn);
+  }
+  trackBlockMedia(turn, delivered, info.kind, effectivePayload);
+  return toTelegramReplyDeliveryResult(delivered);
+}
+
+export function handleReplySkip(
+  turn: Turn,
+  payload: Parameters<Skip>[0],
+  info: Parameters<Skip>[1],
+): void {
+  if (info.kind === "block") {
+    void enqueueDraftEvent(turn, async () => {
+      dropQueuedAnswerBlockRotation(turn, payload, info.assistantMessageIndex);
+    });
+  }
+  if (payload.isError === true) {
+    turn.hadErrorReplyFailureOrSkip = true;
+  }
+  if (info.reason !== "silent") {
+    turn.deliveryState.markNonSilentSkip();
+  }
+}
+
+export function handleReplyError(
+  turn: Turn,
+  err: Parameters<ErrorCallback>[0],
+  info: Parameters<ErrorCallback>[1],
+): void {
+  const errorPolicy = resolveTelegramErrorPolicy({
+    accountConfig: turn.telegramCfg,
+    groupConfig: turn.context.groupConfig,
+    topicConfig: turn.context.topicConfig,
+  });
+  if (isSilentErrorPolicy(errorPolicy.policy)) {
+    return;
+  }
+  if (
+    errorPolicy.policy === "once" &&
+    shouldSuppressTelegramError({
+      scopeKey: buildTelegramErrorScopeKey({
+        accountId: turn.context.route.accountId,
+        chatId: turn.context.chatId,
+        threadId: turn.context.threadSpec.id,
+      }),
+      cooldownMs: errorPolicy.cooldownMs,
+      errorMessage: String(err),
+    })
+  ) {
+    return;
+  }
+  turn.deliveryState.markNonSilentFailure();
+  turn.runtime.error?.(danger(`telegram ${info.kind} reply failed: ${String(err)}`));
+}
+
+export function handleBeforeDeliverCancelled(
+  turn: Turn,
+  payload: Parameters<Cancel>[0],
+  info: Parameters<Cancel>[1],
+): ReturnType<Cancel> {
+  return info.kind === "block"
+    ? enqueueDraftEvent(turn, async () => {
+        dropQueuedAnswerBlockRotation(turn, payload, info.assistantMessageIndex);
+      })
+    : undefined;
+}

--- a/extensions/telegram/src/bot-message-dispatch-turn.ts
+++ b/extensions/telegram/src/bot-message-dispatch-turn.ts
@@ -3,72 +3,71 @@ import {
   runChannelInboundEvent,
   type ChannelInboundTurnPlan,
 } from "openclaw/plugin-sdk/channel-inbound";
-// Telegram plugin module wires inbound turn execution to Telegram delivery controllers.
 import {
   createChannelMessageReplyPipeline,
   resolveChannelStreamingPreviewToolProgress,
 } from "openclaw/plugin-sdk/channel-outbound";
-import type { OpenClawConfig, TelegramAccountConfig } from "openclaw/plugin-sdk/config-contracts";
 import { isFastModeAutoProgressPayload } from "openclaw/plugin-sdk/reply-payload";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import type { TelegramBotDeps } from "./bot-deps.js";
-import type { TelegramMessageContext } from "./bot-message-context.js";
-import type { TelegramDeliveryController } from "./bot-message-dispatch-delivery.js";
-import type { TelegramDraftController } from "./bot-message-dispatch-draft.js";
-import type { TelegramProgressController } from "./bot-message-dispatch-progress.js";
-import type { TelegramReplyDelivery } from "./bot-message-dispatch-reply.js";
-import type { TelegramDispatchTurnState } from "./bot-message-dispatch.types.js";
-import type { TelegramStreamMode } from "./bot/types.js";
+import { sendPayload } from "./bot-message-dispatch-delivery.js";
+import {
+  beginDraftQueuedFollowup,
+  cleanupDrafts,
+  enqueueDraftEvent,
+  ingestDraftLaneSegments,
+  prepareQueuedAnswerBlock,
+  repositionLaneForNewMessage,
+  rotateLaneForNewMessage,
+  waitForDraftEvents,
+} from "./bot-message-dispatch-draft.js";
+import {
+  canPushToolProgress,
+  handleApprovalEvent,
+  handleCommandOutput,
+  handleItemEvent,
+  handlePatchSummary,
+  handlePlanUpdate,
+  handleToolStart,
+  pushReasoningProgress,
+  pushThinkingTokenProgress,
+  pushToolProgress,
+} from "./bot-message-dispatch-progress.js";
+import {
+  deliverReply,
+  handleBeforeDeliverCancelled,
+  handleReplyError,
+  handleReplySkip,
+  resetReasoningStepState,
+} from "./bot-message-dispatch-reply.js";
+import type { TelegramDispatchTurn as Turn } from "./bot-message-dispatch.types.js";
 import { TELEGRAM_CHAT_ACTION_INTERVAL_MS } from "./chat-action-timing.js";
 import { telegramInboundEventDelivery } from "./inbound-event-delivery.js";
 
 const TELEGRAM_MAX_CONSECUTIVE_TYPING_FAILURES = 5;
 
-export async function runTelegramDispatchTurn(params: {
-  cfg: OpenClawConfig;
-  context: TelegramMessageContext;
-  delivery: TelegramDeliveryController;
-  draft: TelegramDraftController;
-  /** Pre-adoption abort + lifecycle from durable ingress (optional for non-spooled). */
-  turnAdoptionLifecycle?: {
-    admission?: "exclusive" | "cancel-only";
-    onAdopted: () => void | Promise<void>;
-    onDeferred?: () => void;
-    onAbandoned?: () => void;
-    abortSignal?: AbortSignal;
-  };
-  isSuperseded: () => boolean;
-  progress: TelegramProgressController;
-  reply: TelegramReplyDelivery;
-  state: TelegramDispatchTurnState;
-  statusReactionController: TelegramMessageContext["statusReactionController"];
-  streamMode: TelegramStreamMode;
-  telegramCfg: TelegramAccountConfig;
-  telegramDeps: TelegramBotDeps;
-}) {
-  const { context } = params;
+export async function runTelegramDispatchTurn(turn: Turn) {
+  const { context } = turn;
   const isRoomEvent = context.ctxPayload.InboundEventKind === "room_event";
   const toolProgressEnabled =
-    params.streamMode !== "off" &&
-    resolveChannelStreamingPreviewToolProgress(params.telegramCfg, true, params.streamMode);
+    turn.streamMode !== "off" &&
+    resolveChannelStreamingPreviewToolProgress(turn.telegramCfg, true, turn.streamMode);
   const beginDeliveryCorrelation = () =>
     telegramInboundEventDelivery.begin(
       context.ctxPayload.SessionKey,
       {
         outboundTo: context.historyKey || String(context.chatId),
         outboundAccountId: context.route.accountId,
-        markInboundEventDelivered: params.delivery.markDelivered,
+        markInboundEventDelivered: turn.deliveryState.markDelivered,
       },
       { inboundEventKind: context.ctxPayload.InboundEventKind },
     );
   const endDeliveryCorrelation = beginDeliveryCorrelation();
-  let splitReasoningOnNextStream = false;
 
   try {
     const { onModelSelected, ...replyPipeline } = (
-      params.telegramDeps.createChannelMessageReplyPipeline ?? createChannelMessageReplyPipeline
+      turn.telegramDeps.createChannelMessageReplyPipeline ?? createChannelMessageReplyPipeline
     )({
-      cfg: params.cfg,
+      cfg: turn.cfg,
       agentId: context.route.agentId,
       channel: "telegram",
       accountId: context.route.accountId,
@@ -91,7 +90,7 @@ export async function runTelegramDispatchTurn(params: {
     });
     const handleDeliveryError = async (err: unknown, info: { kind: string }) => {
       await Promise.resolve(
-        params.reply.onError(err, info as Parameters<typeof params.reply.onError>[1]),
+        handleReplyError(turn, err, info as Parameters<typeof handleReplyError>[2]),
       ).catch((callbackError: unknown) => {
         logVerbose(`telegram reply error callback failed: ${String(callbackError)}`);
       });
@@ -113,7 +112,7 @@ export async function runTelegramDispatchTurn(params: {
           raw: context,
         }),
         resolveTurn: (): ChannelInboundTurnPlan<"provider_message_sending"> => ({
-          cfg: params.cfg,
+          cfg: turn.cfg,
           channel: "telegram",
           accountId: context.route.accountId,
           route: {
@@ -123,9 +122,8 @@ export async function runTelegramDispatchTurn(params: {
           ctxPayload: context.ctxPayload,
           record: context.turn.record,
           delivery: {
-            deliverWithProviderMessageSending: async (payload, info) => {
-              return await params.reply.deliver(payload, info);
-            },
+            deliverWithProviderMessageSending: async (payload, info) =>
+              await deliverReply(turn, payload, info),
             // The shipped SDK declaration stays void; core still awaits the runtime promise.
             onError: handleDeliveryError as NonNullable<
               ChannelInboundTurnPlan["delivery"]["onError"]
@@ -134,20 +132,21 @@ export async function runTelegramDispatchTurn(params: {
           dispatcherOptions: {
             ...replyPipeline,
             beforeDeliver: async (payload) => payload,
-            onBeforeDeliverCancelled: params.reply.onBeforeDeliverCancelled,
-            onSkip: params.reply.onSkip,
+            onBeforeDeliverCancelled: (payload, info) =>
+              handleBeforeDeliverCancelled(turn, payload, info),
+            onSkip: (payload, info) => handleReplySkip(turn, payload, info),
           },
           replyOptions: {
             skillFilter: context.skillFilter,
-            disableBlockStreaming: params.draft.disableBlockStreaming,
-            abortSignal: params.turnAdoptionLifecycle?.abortSignal,
-            turnAdoptionLifecycle: params.turnAdoptionLifecycle
+            disableBlockStreaming: turn.disableBlockStreaming,
+            abortSignal: turn.turnAdoptionLifecycle?.abortSignal,
+            turnAdoptionLifecycle: turn.turnAdoptionLifecycle
               ? {
-                  admission: params.turnAdoptionLifecycle.admission ?? "exclusive",
-                  onAdopted: params.turnAdoptionLifecycle.onAdopted,
-                  onDeferred: params.turnAdoptionLifecycle.onDeferred,
-                  onAbandoned: params.turnAdoptionLifecycle.onAbandoned,
-                  abortSignal: params.turnAdoptionLifecycle.abortSignal,
+                  admission: turn.turnAdoptionLifecycle.admission ?? "exclusive",
+                  onAdopted: turn.turnAdoptionLifecycle.onAdopted,
+                  onDeferred: turn.turnAdoptionLifecycle.onDeferred,
+                  onAbandoned: turn.turnAdoptionLifecycle.onAbandoned,
+                  abortSignal: turn.turnAdoptionLifecycle.abortSignal,
                 }
               : undefined,
             sourceReplyDeliveryMode: isRoomEvent ? "message_tool_only" : undefined,
@@ -156,15 +155,15 @@ export async function runTelegramDispatchTurn(params: {
               : undefined,
             suppressTyping: isRoomEvent,
             onPartialReply:
-              params.draft.answerLane.stream || params.draft.reasoningLane.stream
+              turn.answerLane.stream || turn.reasoningLane.stream
                 ? (payload) => {
-                    const queued = params.draft.enqueueEvent(async () => {
-                      await params.draft.ingestDraftLaneSegments(payload);
+                    const queued = enqueueDraftEvent(turn, async () => {
+                      await ingestDraftLaneSegments(turn, payload);
                     });
                     // Queue settlement records draft intent; a numeric provider message ID
                     // proves operator visibility for terminal recovery.
                     return queued.then(async () => {
-                      const answerStream = params.draft.answerLane.stream;
+                      const answerStream = turn.answerLane.stream;
                       await answerStream?.waitForInFlight();
                       const providerMessageId = answerStream?.messageId();
                       return (
@@ -173,137 +172,135 @@ export async function runTelegramDispatchTurn(params: {
                     });
                   }
                 : undefined,
-            onBlockReplyQueued: params.draft.answerLane.stream
+            onBlockReplyQueued: turn.answerLane.stream
               ? (payload, blockContext) => {
-                  const queued = params.draft.enqueueEvent(async () => {
-                    await params.draft.prepareQueuedAnswerBlock(payload, blockContext);
+                  const queued = enqueueDraftEvent(turn, async () => {
+                    await prepareQueuedAnswerBlock(turn, payload, blockContext);
                   });
                   return queued.then(() => false);
                 }
               : undefined,
-            onReasoningStream: params.draft.reasoningLane.stream
+            onReasoningStream: turn.reasoningLane.stream
               ? (payload) => {
-                  const queued = params.draft.enqueueEvent(async () => {
-                    if (splitReasoningOnNextStream) {
-                      params.draft.repositionLaneForNewMessage(params.draft.reasoningLane);
-                      splitReasoningOnNextStream = false;
+                  const queued = enqueueDraftEvent(turn, async () => {
+                    if (turn.splitReasoningOnNextStream) {
+                      repositionLaneForNewMessage(turn, turn.reasoningLane);
+                      turn.splitReasoningOnNextStream = false;
                     }
-                    await params.draft.ingestDraftLaneSegments(payload, true);
+                    await ingestDraftLaneSegments(turn, payload, true);
                   });
                   return queued.then(() => false);
                 }
-              : params.draft.streamReasoningInProgressDraft
+              : turn.streamReasoningInProgressDraft
                 ? (payload) => {
-                    const queued = params.draft.enqueueEvent(async () => {
-                      await params.progress.pushReasoningProgress(payload);
+                    const queued = enqueueDraftEvent(turn, async () => {
+                      await pushReasoningProgress(turn, payload);
                     });
                     return queued.then(() => false);
                   }
                 : undefined,
-            onReasoningProgress: params.draft.answerLane.stream
+            onReasoningProgress: turn.answerLane.stream
               ? (payload) =>
-                  params.draft.enqueueEvent(async () => {
-                    await params.progress.pushThinkingTokenProgress(payload.progressTokens);
+                  enqueueDraftEvent(turn, async () => {
+                    await pushThinkingTokenProgress(turn, payload.progressTokens);
                   })
               : undefined,
-            onAssistantMessageStart: params.draft.answerLane.stream
+            onAssistantMessageStart: turn.answerLane.stream
               ? () => {
-                  const queued = params.draft.enqueueEvent(async () => {
-                    params.reply.reasoningStepState.resetForNextStep();
-                    params.progress.setFinalAnswerDelivered(false);
-                    if (params.streamMode !== "progress") {
-                      params.progress.reset();
+                  const queued = enqueueDraftEvent(turn, async () => {
+                    resetReasoningStepState(turn);
+                    turn.finalAnswerDelivered = false;
+                    if (turn.streamMode !== "progress") {
+                      turn.progressCompositor.reset();
                     }
-                    if (params.draft.answerLane.finalized) {
-                      await params.draft.rotateLaneForNewMessage(params.draft.answerLane);
-                      params.draft.setRotateWhenQueuedBlocksSettle(false);
+                    if (turn.answerLane.finalized) {
+                      await rotateLaneForNewMessage(turn, turn.answerLane);
+                      turn.rotateAnswerLaneWhenQueuedBlocksSettle = false;
                     } else if (
-                      params.draft.answerLane.hasStreamedMessage &&
-                      !params.draft.isAnswerToolProgressOnly()
+                      turn.answerLane.hasStreamedMessage &&
+                      !turn.activeAnswerDraftIsToolProgressOnly
                     ) {
-                      params.draft.setRotateWhenQueuedBlocksSettle(true);
+                      turn.rotateAnswerLaneWhenQueuedBlocksSettle = true;
                     }
                   });
                   return queued.then(() => false);
                 }
               : undefined,
-            onReasoningEnd: params.draft.reasoningLane.stream
+            onReasoningEnd: turn.reasoningLane.stream
               ? () => {
-                  const queued = params.draft.enqueueEvent(async () => {
-                    params.progress.closeReasoningBurst();
-                    splitReasoningOnNextStream = params.draft.reasoningLane.hasStreamedMessage;
-                    params.progress.reset();
+                  const queued = enqueueDraftEvent(turn, async () => {
+                    turn.progressSummary.closeReasoningBurst();
+                    turn.splitReasoningOnNextStream = turn.reasoningLane.hasStreamedMessage;
+                    turn.progressCompositor.reset();
                   });
                   return queued.then(() => false);
                 }
               : () => {
-                  params.progress.closeReasoningBurst();
+                  turn.progressSummary.closeReasoningBurst();
                   return false;
                 },
             onQueuedFollowupAdmitted: () => {
-              params.draft.beginQueuedFollowup();
-              params.progress.beginQueuedFollowup();
+              beginDraftQueuedFollowup(turn);
+              turn.finalAnswerDeliveryStarted = false;
+              turn.finalAnswerDelivered = false;
+              turn.sawProgressFinal = false;
+              turn.progressCompositor.beginNewTurn({ force: true });
             },
             onQueuedFollowupSettled: async () => {
-              params.progress.cancel();
-              await params.draft.waitForEvents();
-              await params.draft.cleanup(params.isSuperseded());
+              turn.progressCompositor.cancel();
+              await waitForDraftEvents(turn);
+              await cleanupDrafts(turn, turn.isSuperseded());
             },
             suppressDefaultToolProgressMessages:
-              !params.draft.streamDeliveryEnabled || Boolean(params.draft.answerLane.stream),
+              !turn.streamDeliveryEnabled || Boolean(turn.answerLane.stream),
             suppressToolProgressMessages: !toolProgressEnabled,
             forceToolResultProgress:
-              Boolean(params.draft.answerLane.stream) &&
-              params.streamMode === "progress" &&
+              Boolean(turn.answerLane.stream) &&
+              turn.streamMode === "progress" &&
               toolProgressEnabled,
             allowProgressCallbacksWhenSourceDeliverySuppressed:
-              !isRoomEvent && Boolean(params.draft.answerLane.stream),
+              !isRoomEvent && Boolean(turn.answerLane.stream),
             onVerboseProgressVisibility: (isActive) => {
-              params.progress.setVerboseProgressActive(isActive);
+              turn.verboseProgressActive = isActive;
             },
             commentaryProgressEnabled:
-              params.streamMode === "progress"
-                ? params.progress.commentaryProgressEnabled
-                : undefined,
-            progressPreambleEnabled: params.progress.progressPreambleEnabled,
-            commentaryPayloadsEnabled: params.progress.progressPreambleEnabled,
-            reasoningPayloadsEnabled: params.draft.durableReasoningPayloadsEnabled,
-            onToolStart: params.progress.handleToolStart,
-            onItemEvent: params.progress.handleItemEvent,
-            onPlanUpdate: params.progress.handlePlanUpdate,
-            onApprovalEvent: params.progress.handleApprovalEvent,
+              turn.streamMode === "progress" ? turn.commentaryProgressEnabled : undefined,
+            progressPreambleEnabled: turn.progressPreambleEnabled,
+            commentaryPayloadsEnabled: turn.progressPreambleEnabled,
+            reasoningPayloadsEnabled: turn.durableReasoningPayloadsEnabled,
+            onToolStart: (payload) => handleToolStart(turn, payload),
+            onItemEvent: (payload) => handleItemEvent(turn, payload),
+            onPlanUpdate: (payload) => handlePlanUpdate(turn, payload),
+            onApprovalEvent: (payload) => handleApprovalEvent(turn, payload),
             onToolResult: async (payload) => {
               const text = payload.text?.trim();
               if (!text) {
                 return false;
               }
-              const updatedDraft = await params.progress.pushToolProgress(text, {
+              const updatedDraft = await pushToolProgress(turn, text, {
                 startImmediately: true,
               });
               if (updatedDraft) {
                 return true;
               }
-              if (
-                isFastModeAutoProgressPayload(payload) &&
-                !params.progress.canPushToolProgress()
-              ) {
-                await params.delivery.sendPayload(payload);
+              if (isFastModeAutoProgressPayload(payload) && !canPushToolProgress(turn)) {
+                await sendPayload(turn, payload);
                 return true;
               }
               return false;
             },
-            onCommandOutput: params.progress.handleCommandOutput,
-            onPatchSummary: params.progress.handlePatchSummary,
-            onCompactionStart: params.statusReactionController
+            onCommandOutput: (payload) => handleCommandOutput(turn, payload),
+            onPatchSummary: (payload) => handlePatchSummary(turn, payload),
+            onCompactionStart: turn.statusReactionController
               ? async () => {
-                  await params.statusReactionController?.setCompacting();
+                  await turn.statusReactionController?.setCompacting();
                   return false;
                 }
               : undefined,
-            onCompactionEnd: params.statusReactionController
+            onCompactionEnd: turn.statusReactionController
               ? async () => {
-                  params.statusReactionController?.cancelPending();
-                  await params.statusReactionController?.setThinking();
+                  turn.statusReactionController?.cancelPending();
+                  await turn.statusReactionController?.setThinking();
                   return false;
                 }
               : undefined,
@@ -315,13 +312,13 @@ export async function runTelegramDispatchTurn(params: {
     if (!turnResult.dispatched) {
       return false;
     }
-    params.state.queuedFinal = turnResult.dispatchResult.queuedFinal;
-    params.state.noVisibleReplyFallbackEligible =
+    turn.queuedFinal ||= turnResult.dispatchResult.queuedFinal;
+    turn.noVisibleReplyFallbackEligible =
       turnResult.dispatchResult.noVisibleReplyFallbackEligible === true;
     if ((turnResult.dispatchResult.counts?.final ?? 0) > 0) {
-      params.progress.markSawFinal();
+      turn.sawProgressFinal = true;
     }
-    params.state.suppressSilentReplyFallback =
+    turn.suppressSilentReplyFallback =
       turnResult.dispatchResult.sourceReplyDeliveryMode === "message_tool_only";
     return true;
   } finally {

--- a/extensions/telegram/src/bot-message-dispatch.runtime.ts
+++ b/extensions/telegram/src/bot-message-dispatch.runtime.ts
@@ -1,5 +1,5 @@
 // Telegram plugin module implements bot message dispatch behavior.
-export { getSessionEntry, type SessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+export { getSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 export { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 export { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
 export { resolveChunkMode } from "openclaw/plugin-sdk/reply-dispatch-runtime";

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1,12 +1,21 @@
-// Telegram plugin module coordinates one inbound message dispatch lifecycle.
 import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import { createSubsystemLogger, danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveDispatchTelegramContext } from "./bot-message-dispatch-context.js";
-import { createTelegramDeliveryController } from "./bot-message-dispatch-delivery.js";
-import { createTelegramDraftController } from "./bot-message-dispatch-draft.js";
-import { createTelegramProgressController } from "./bot-message-dispatch-progress.js";
-import { createTelegramReplyDelivery } from "./bot-message-dispatch-reply.js";
+import {
+  createDeliveryState,
+  deliverFallback,
+  deliverProgressCollapseSummary,
+  finalizePendingAnswerBlockDraft,
+} from "./bot-message-dispatch-delivery.js";
+import {
+  cleanupDrafts,
+  createDraftState,
+  prepareAnswerLaneForToolProgress,
+  waitForDraftEvents,
+} from "./bot-message-dispatch-draft.js";
+import { createProgressState } from "./bot-message-dispatch-progress.js";
+import { createReplyState } from "./bot-message-dispatch-reply.js";
 import {
   createFreshTelegramSessionEntryLoader,
   resolveTelegramReasoningLevel,
@@ -29,8 +38,8 @@ import {
 } from "./bot-message-dispatch.runtime.js";
 import type {
   DispatchTelegramMessageParams,
+  TelegramDispatchTurn,
   TelegramDispatchResult,
-  TelegramDispatchTurnState,
 } from "./bot-message-dispatch.types.js";
 import { getTelegramTextParts, resolveTelegramReplyId } from "./bot/helpers.js";
 import {
@@ -73,8 +82,6 @@ function includeStickerDescription(params: {
   if (!current) {
     return params.formattedDescription;
   }
-  // Cached descriptions can already be present from inbound context construction.
-  // Keep that body intact so captions, forwarded text, and supplemental context survive.
   if (params.body.includes(params.formattedDescription)) {
     return params.body;
   }
@@ -142,7 +149,6 @@ function resolveTelegramQuoteContext(params: {
       : undefined;
   return {
     draftReplyToMessageId,
-    hasTelegramQuoteReply: replyToMode !== "off" && replyQuoteText != null,
     replyQuoteByMessageId,
     replyQuoteEntities: Array.isArray(context.ctxPayload.ReplyToQuoteEntities)
       ? context.ctxPayload.ReplyToQuoteEntities
@@ -274,21 +280,22 @@ function scheduleDmTopicLabel(params: {
   })();
 }
 
-export const dispatchTelegramMessage = async ({
-  context,
-  bot,
-  cfg,
-  runtime,
-  replyToMode,
-  streamMode,
-  textLimit,
-  telegramCfg,
-  telegramDeps: injectedTelegramDeps,
-  opts,
-  retryDispatchErrors = false,
-  suppressFailureFallback = false,
-  turnAdoptionLifecycle,
-}: DispatchTelegramMessageParams): Promise<TelegramDispatchResult> => {
+export const dispatchTelegramMessage = async (
+  dispatchParams: DispatchTelegramMessageParams,
+): Promise<TelegramDispatchResult> => {
+  const {
+    context,
+    bot,
+    cfg,
+    runtime,
+    replyToMode,
+    streamMode,
+    telegramCfg,
+    telegramDeps: injectedTelegramDeps,
+    retryDispatchErrors = false,
+    suppressFailureFallback = false,
+    turnAdoptionLifecycle,
+  } = dispatchParams;
   const dispatchStartedAt = Date.now();
   const dispatchContext = resolveDispatchTelegramContext({ context });
   const telegramDeps =
@@ -308,8 +315,6 @@ export const dispatchTelegramMessage = async ({
     agentId: dispatchContext.route.agentId,
     loadFreshSessionEntry,
   });
-  const forceBlockStreamingForReasoning =
-    resolvedReasoningLevel === "on" && streamMode !== "progress";
   const quote = resolveTelegramQuoteContext({ context: dispatchContext, replyToMode });
   // Draft messages are provider-visible before final modifiers run. Suppress them when a hook
   // can rewrite or cancel, or the original payload can flash before the normal delivery gate.
@@ -318,87 +323,46 @@ export const dispatchTelegramMessage = async ({
     (hookRunner?.hasHooks("reply_payload_sending") ?? false) ||
     (hookRunner?.hasHooks("message_sending") ?? false)
   );
-  // Pre-adoption abort is drain-owned via turnAdoptionLifecycle.abortSignal.
   const isDispatchSuperseded = () => turnAdoptionLifecycle?.abortSignal?.aborted === true;
-  const dispatchGeneration = 0;
-  const draft = createTelegramDraftController({
-    accountId: dispatchContext.route.accountId,
+  const turnConfig = {
+    ...dispatchParams,
     allowProviderPreview,
-    bot,
-    cfg,
-    chatId: dispatchContext.chatId,
-    draftReplyToMessageId: quote.draftReplyToMessageId,
-    forceBlockStreamingForReasoning,
-    hasTelegramQuoteReply: quote.hasTelegramQuoteReply,
-    isDispatchSuperseded,
-    isRoomEvent,
-    replyToMode,
-    resolvedReasoningLevel,
-    streamMode,
-    tableMode,
-    telegramCfg,
-    telegramDeps,
-    textLimit,
-    threadSpec: dispatchContext.threadSpec,
-  });
-  const progress = createTelegramProgressController({
-    accountId: dispatchContext.route.accountId,
-    chatId: dispatchContext.chatId,
-    draft,
-    statusReactionController: status.controller,
-    streamMode,
-    streamReasoningInProgressDraft: draft.streamReasoningInProgressDraft,
-    telegramCfg,
-    threadId: dispatchContext.threadSpec.id,
-  });
-  const delivery = createTelegramDeliveryController({
-    bot,
-    cfg,
     chunkMode: resolveChunkMode(cfg, "telegram", dispatchContext.route.accountId),
     context: dispatchContext,
     dispatchStartedAt,
-    draft,
     draftReplyToMessageId: quote.draftReplyToMessageId,
-    isDispatchSuperseded,
+    isSuperseded: isDispatchSuperseded,
     loadFreshSessionEntry,
     mediaLocalRoots: getAgentScopedMediaLocalRoots(cfg, dispatchContext.route.agentId),
-    opts,
-    progress,
     replyQuoteByMessageId: quote.replyQuoteByMessageId,
     replyQuoteEntities: quote.replyQuoteEntities,
     replyQuoteMessageId: quote.replyQuoteMessageId,
     replyQuotePosition: quote.replyQuotePosition,
     replyQuoteText: quote.replyQuoteText,
-    replyToMode,
-    runtime,
-    streamMode,
+    resolvedReasoningLevel,
+    statusReactionController: status.controller,
     tableMode,
-    telegramCfg,
     telegramDeps,
-    textLimit,
-    threadSpec: dispatchContext.threadSpec,
-  });
-  const state: TelegramDispatchTurnState = {
+  };
+  const draftState = createDraftState(turnConfig);
+  const progressState = createProgressState(
+    turnConfig,
+    draftState,
+    () => turn,
+    async () => await prepareAnswerLaneForToolProgress(turn),
+  );
+  const deliveryState = createDeliveryState({ ...turnConfig, lanes: draftState.lanes }, () => turn);
+  const turn: TelegramDispatchTurn = {
+    ...turnConfig,
+    ...draftState,
+    ...progressState,
+    ...deliveryState,
+    ...createReplyState(),
     queuedFinal: false,
     noVisibleReplyFallbackEligible: false,
     suppressSilentReplyFallback: false,
     hadErrorReplyFailureOrSkip: false,
   };
-  const reply = createTelegramReplyDelivery({
-    cfg,
-    context: dispatchContext,
-    delivery,
-    draft,
-    fence: {
-      generation: () => dispatchGeneration,
-      isSuperseded: isDispatchSuperseded,
-    },
-    progress,
-    runtime,
-    state,
-    streamMode,
-    telegramCfg,
-  });
 
   let isFirstTurnInSession = false;
   let dispatchWasSuperseded: boolean;
@@ -427,42 +391,30 @@ export const dispatchTelegramMessage = async ({
       void status.controller.setThinking();
     }
     try {
-      turnDispatched = await runTelegramDispatchTurn({
-        cfg,
-        context: dispatchContext,
-        delivery,
-        draft,
-        turnAdoptionLifecycle,
-        isSuperseded: isDispatchSuperseded,
-        progress,
-        reply,
-        state,
-        statusReactionController: status.controller,
-        streamMode,
-        telegramCfg,
-        telegramDeps,
-      });
+      turnDispatched = await runTelegramDispatchTurn(turn);
     } catch (err) {
-      state.dispatchError = err;
+      turn.dispatchError = err;
       runtime.error?.(danger(`telegram dispatch failed: ${String(err)}`));
     } finally {
-      progress.cancel();
-      await draft.waitForEvents();
+      // Terminal order: stop producers, drain queued drafts, materialize accepted text,
+      // clean previews, then collapse the progress window.
+      turn.progressCompositor.cancel();
+      await waitForDraftEvents(turn);
       try {
-        await delivery.finalizePendingAnswerBlockDraft(state);
+        await finalizePendingAnswerBlockDraft(turn);
       } catch (err) {
-        state.dispatchError ??= err;
+        turn.dispatchError ??= err;
         runtime.error?.(danger(`telegram terminal block delivery failed: ${String(err)}`));
       }
-      await draft.cleanup(isDispatchSuperseded());
+      await cleanupDrafts(turn, isDispatchSuperseded());
       if (
         streamMode === "progress" &&
-        progress.sawProgressFinal() &&
-        !state.dispatchError &&
-        !state.hadErrorReplyFailureOrSkip &&
+        turn.sawProgressFinal &&
+        !turn.dispatchError &&
+        !turn.hadErrorReplyFailureOrSkip &&
         !isDispatchSuperseded()
       ) {
-        await delivery.deliverProgressCollapseSummary();
+        await deliverProgressCollapseSummary(turn);
       }
     }
   } finally {
@@ -479,60 +431,61 @@ export const dispatchTelegramMessage = async ({
     return { kind: "completed" };
   }
 
-  const deliverySummary = delivery.snapshot();
+  const deliverySummary = turn.deliveryState.snapshot();
   let sentFallback = false;
   const shouldSendFailureFallback =
     !isRoomEvent &&
     !suppressFailureFallback &&
-    !progress.finalAnswerDelivered() &&
-    (state.dispatchError ||
+    !turn.finalAnswerDelivered &&
+    (turn.dispatchError ||
       deliverySummary.failedNonSilent > 0 ||
-      (deliverySummary.skippedNonSilent > 0 && !state.suppressSilentReplyFallback));
+      (deliverySummary.skippedNonSilent > 0 && !turn.suppressSilentReplyFallback));
   if (shouldSendFailureFallback) {
-    const fallbackText = state.dispatchError
+    const fallbackText = turn.dispatchError
       ? "Something went wrong while processing your request. Please try again."
       : EMPTY_RESPONSE_FALLBACK;
-    const result = await delivery.deliverFallback(
+    const result = await deliverFallback(
+      turn,
       [{ text: fallbackText }],
       telegramCfg.silentErrorReplies === true &&
-        (state.dispatchError != null || state.hadErrorReplyFailureOrSkip),
+        (turn.dispatchError != null || turn.hadErrorReplyFailureOrSkip),
     );
     sentFallback = result.delivered;
   }
 
   if (
     !sentFallback &&
-    !state.dispatchError &&
+    !turn.dispatchError &&
     !deliverySummary.delivered &&
-    !state.suppressSilentReplyFallback &&
-    !state.queuedFinal &&
-    state.noVisibleReplyFallbackEligible
+    !turn.suppressSilentReplyFallback &&
+    !turn.queuedFinal &&
+    turn.noVisibleReplyFallbackEligible
   ) {
-    sentFallback = (await delivery.deliverFallback([{ text: EMPTY_RESPONSE_FALLBACK }], false))
+    sentFallback = (await deliverFallback(turn, [{ text: EMPTY_RESPONSE_FALLBACK }], false))
       .delivered;
     silentReplyDispatchLogger.debug("telegram recovered eligible turn without visible response", {
       hasSessionKey: Boolean(dispatchContext.ctxPayload.SessionKey),
       hasChatId: dispatchContext.chatId != null,
-      queuedFinal: state.queuedFinal,
+      queuedFinal: turn.queuedFinal,
       sentFallback,
     });
   }
 
   const hasFinalResponse =
-    progress.finalAnswerDelivered() ||
+    turn.finalAnswerDelivered ||
     sentFallback ||
-    state.suppressSilentReplyFallback ||
-    state.queuedFinal;
+    turn.suppressSilentReplyFallback ||
+    turn.queuedFinal;
   const hasVisibleResponse =
     deliverySummary.delivered ||
     sentFallback ||
-    state.suppressSilentReplyFallback ||
-    state.queuedFinal;
+    turn.suppressSilentReplyFallback ||
+    turn.queuedFinal;
   const deliveryFailureWithoutFinalResponse =
-    !progress.finalAnswerDelivered() &&
+    !turn.finalAnswerDelivered &&
     (deliverySummary.skippedNonSilent > 0 || deliverySummary.failedNonSilent > 0);
   const retryableDispatchFailure =
-    state.dispatchError ??
+    turn.dispatchError ??
     (deliveryFailureWithoutFinalResponse
       ? new Error(
           `Telegram reply delivery failed without a final response (failed=${deliverySummary.failedNonSilent}, skipped=${deliverySummary.skippedNonSilent})`,
@@ -544,8 +497,8 @@ export const dispatchTelegramMessage = async ({
   }
   const shouldReturnRetryableDispatchFailure =
     retryDispatchErrors &&
-    ((state.dispatchError != null && !hasFinalResponse) ||
-      (state.dispatchError == null && deliveryFailureWithoutFinalResponse && !hasVisibleResponse));
+    ((turn.dispatchError != null && !hasFinalResponse) ||
+      (turn.dispatchError == null && deliveryFailureWithoutFinalResponse && !hasVisibleResponse));
   if (retryableDispatchFailure && shouldReturnRetryableDispatchFailure) {
     return { kind: "failed-retryable", error: retryableDispatchFailure };
   }
@@ -564,7 +517,7 @@ export const dispatchTelegramMessage = async ({
     status.finalizeInBackground(
       {
         outcome:
-          !progress.finalAnswerDelivered() && (state.dispatchError != null || sentFallback)
+          !turn.finalAnswerDelivered && (turn.dispatchError != null || sentFallback)
             ? "error"
             : "done",
       },

--- a/extensions/telegram/src/bot-message-dispatch.types.ts
+++ b/extensions/telegram/src/bot-message-dispatch.types.ts
@@ -1,5 +1,10 @@
-// Telegram plugin module defines message-dispatch contracts.
 import type { Bot } from "grammy";
+import type { Message } from "grammy/types";
+import type {
+  AgentPlanStep,
+  ChannelProgressDraftLine,
+  TextChunkMode,
+} from "openclaw/plugin-sdk/channel-outbound";
 import type {
   OpenClawConfig,
   ReplyToMode,
@@ -7,11 +12,18 @@ import type {
 } from "openclaw/plugin-sdk/config-contracts";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-payload";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import type { SessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import type { TelegramBotDeps } from "./bot-deps.js";
 import type { TelegramMessageContext } from "./bot-message-context.js";
-import type { SessionEntry } from "./bot-message-dispatch.runtime.js";
 import type { TelegramBotOptions } from "./bot.types.js";
+import type { TelegramNativeQuoteCandidateByMessageId } from "./bot/native-quote.js";
 import type { TelegramStreamMode } from "./bot/types.js";
+import type {
+  DraftLaneState,
+  LaneDeliveryStateTracker,
+  LaneName,
+  LaneTextDeliverer,
+} from "./lane-delivery.js";
 
 export type DispatchTelegramMessageParams = {
   context: TelegramMessageContext;
@@ -64,10 +76,178 @@ export type TelegramAnswerBlockDelivery = {
   buttons: import("./button-types.js").TelegramInlineButtons | undefined;
 };
 
-export type TelegramDispatchTurnState = {
-  queuedFinal: boolean;
-  noVisibleReplyFallbackEligible: boolean;
-  suppressSilentReplyFallback: boolean;
-  hadErrorReplyFailureOrSkip: boolean;
-  dispatchError?: unknown;
+export type TelegramDispatchTurnConfig = Omit<
+  DispatchTelegramMessageParams,
+  "context" | "telegramDeps"
+> & {
+  allowProviderPreview: boolean;
+  chunkMode: TextChunkMode;
+  context: TelegramMessageContext;
+  dispatchStartedAt: number;
+  draftReplyToMessageId?: number;
+  isSuperseded: () => boolean;
+  loadFreshSessionEntry: FreshTelegramSessionEntryLoader;
+  mediaLocalRoots: readonly string[];
+  replyQuoteByMessageId: TelegramNativeQuoteCandidateByMessageId;
+  replyQuoteEntities?: Message["entities"];
+  replyQuoteMessageId?: number;
+  replyQuotePosition?: number;
+  replyQuoteText?: string;
+  resolvedReasoningLevel: TelegramReasoningLevel;
+  statusReactionController: TelegramMessageContext["statusReactionController"];
+  tableMode: Parameters<
+    NonNullable<import("./bot-deps.js").TelegramBotDeps["deliverReplies"]>
+  >[0]["tableMode"];
+  telegramDeps: import("./bot-deps.js").TelegramBotDeps;
 };
+
+export type TelegramDraftPartialTextUpdate = {
+  text: string;
+  delta?: string;
+  replace?: true;
+  isReasoningSnapshot?: boolean;
+};
+export type TelegramSplitLaneSegmentsResult = {
+  segments: Array<{ lane: LaneName; update: TelegramDraftPartialTextUpdate }>;
+  suppressedReasoningOnly: boolean;
+};
+export type TelegramQueuedAnswerBlockRotation = {
+  assistantMessageIndex?: number;
+  text?: string;
+  shouldRotateBeforeDelivery: boolean;
+};
+export type TelegramBufferedFinalSettlement = {
+  visibleReplySent: boolean;
+  onPlatformSendDispatch?: () => Promise<void>;
+  bindPendingFinalDelivery?: <T extends ReplyPayload>(payload: T) => T;
+  resolve: (result: { visibleReplySent: boolean }) => void;
+  reject: (error: unknown) => void;
+};
+
+type BufferedDispatchParams = Parameters<
+  TelegramBotDeps["dispatchReplyWithBufferedBlockDispatcher"]
+>[0];
+type ReplyOptions = NonNullable<BufferedDispatchParams["replyOptions"]>;
+type CallbackPayload<K extends keyof ReplyOptions> =
+  NonNullable<ReplyOptions[K]> extends (...args: infer Args) => unknown ? Args[0] : never;
+
+export type TelegramProgressSummaryCounters = {
+  reasoningSteps: number;
+  commentaryNotes: number;
+  toolCalls: number;
+};
+
+export type TelegramProgressSummaryTracker = {
+  noteReasoningActivity: () => void;
+  closeReasoningBurst: () => void;
+  noteToolCall: () => void;
+  noteCommentary: (itemId?: string, text?: string) => void;
+  closeCommentaryBurst: () => void;
+  counts: () => TelegramProgressSummaryCounters;
+  hasActivity: () => boolean;
+};
+
+type TelegramProgressCompositor = {
+  readonly commentaryProgressEnabled: boolean;
+  readonly hasStatusHeadline: boolean;
+  readonly hasPlanProgress: boolean;
+  markFinalReplyStarted: () => void;
+  markFinalReplyDelivered: () => void;
+  beginNewTurn: (options?: { force?: boolean }) => boolean;
+  reset: () => void;
+  suppress: () => void;
+  cancel: () => void;
+  pushToolProgress: (
+    line?: string | ChannelProgressDraftLine,
+    options?: { toolName?: string; startImmediately?: boolean },
+  ) => Promise<boolean>;
+  pushReasoningProgress: (text?: string, options?: { snapshot?: boolean }) => Promise<boolean>;
+  pushCommentaryProgress: (text?: string, options?: { itemId?: string }) => Promise<boolean>;
+  pushPlanProgress: (
+    steps?: AgentPlanStep[],
+    options?: { explanation?: string },
+  ) => Promise<boolean>;
+  pushPreambleHeadline: (text?: string, options?: { itemId?: string }) => Promise<boolean>;
+  pushToolEvent: (payload: CallbackPayload<"onToolStart">) => Promise<boolean>;
+  pushItemEvent: (payload: CallbackPayload<"onItemEvent">) => Promise<boolean>;
+  pushApprovalEvent: (payload: CallbackPayload<"onApprovalEvent">) => Promise<boolean>;
+  pushCommandOutputEvent: (payload: CallbackPayload<"onCommandOutput">) => Promise<boolean>;
+  pushPatchEvent: (payload: CallbackPayload<"onPatchSummary">) => Promise<boolean>;
+};
+
+export type TelegramBufferedFinalAnswer = {
+  payload: ReplyPayload;
+  text: string;
+};
+
+export type TelegramReasoningStepState = {
+  noteReasoningHint: () => void;
+  noteReasoningDelivered: () => void;
+  shouldBufferFinalAnswer: () => boolean;
+  bufferFinalAnswer: (value: TelegramBufferedFinalAnswer) => void;
+  takeBufferedFinalAnswer: () => TelegramBufferedFinalAnswer | undefined;
+  resetForNextStep: () => void;
+};
+
+export type TelegramDraftStateSlice = {
+  answerLane: DraftLaneState;
+  reasoningLane: DraftLaneState;
+  lanes: Record<LaneName, DraftLaneState>;
+  streamDeliveryEnabled: boolean;
+  streamReasoningInProgressDraft: boolean;
+  disableBlockStreaming: boolean | undefined;
+  durableReasoningPayloadsEnabled: boolean;
+  lastAnswerPartialText: string;
+  activeAnswerDraftIsToolProgressOnly: boolean;
+  activeAnswerBlockAssistantMessageIndex: number | undefined;
+  activeAnswerBlockDelivery: TelegramAnswerBlockDelivery | undefined;
+  queuedAnswerBlockRotations: TelegramQueuedAnswerBlockRotation[];
+  queuedAnswerBlockAssistantMessageIndex: number | undefined;
+  pendingAnswerBlockAssistantMessageIndex: number | undefined;
+  rotateAnswerLaneWhenQueuedBlocksSettle: boolean;
+  draftEventQueue: Promise<void>;
+};
+
+export type TelegramProgressStateSlice = {
+  progressSummary: TelegramProgressSummaryTracker;
+  progressSummaryStartedAt: number;
+  summaryDelivered: boolean;
+  draftEverRendered: boolean;
+  finalAnswerDeliveryStarted: boolean;
+  finalAnswerDelivered: boolean;
+  sawProgressFinal: boolean;
+  verboseProgressActive: () => boolean;
+  progressCompositor: TelegramProgressCompositor;
+  commentaryProgressEnabled: boolean;
+  progressPreambleEnabled: boolean | undefined;
+};
+
+export type TelegramDeliveryStateSlice = {
+  deliveryState: LaneDeliveryStateTracker;
+  deliverLaneText: LaneTextDeliverer;
+  materializeAnswerLaneBeforeRotation: () => Promise<void>;
+  resolveCurrentTurnTranscriptFinal: () => Promise<CurrentTurnTranscriptFinal | undefined>;
+  transcriptMirrorSequence: number;
+  transcriptMirrorTurnId: string;
+  implicitQuoteReplyTargetId: string | undefined;
+  currentMessageIdForQuoteReply: string | undefined;
+};
+
+export type TelegramReplyStateSlice = {
+  reasoningStepState: TelegramReasoningStepState;
+  bufferedFinalSettlement: TelegramBufferedFinalSettlement | undefined;
+  sentBlockMediaUrls: Set<string>;
+  splitReasoningOnNextStream: boolean;
+};
+
+export type TelegramDispatchTurn = TelegramDispatchTurnConfig &
+  TelegramDraftStateSlice &
+  TelegramProgressStateSlice &
+  TelegramDeliveryStateSlice &
+  TelegramReplyStateSlice & {
+    queuedFinal: boolean;
+    noVisibleReplyFallbackEligible: boolean;
+    suppressSilentReplyFallback: boolean;
+    hadErrorReplyFailureOrSkip: boolean;
+    dispatchError?: unknown;
+  };

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -687,175 +687,230 @@ function systemEventOptions(index = 0) {
   );
 }
 
-describe("createTelegramReplyDelivery", () => {
-  const runtime = createNonExitingRuntimeEnv();
+type TelegramDispatch = typeof import("./bot-message-dispatch.js").dispatchTelegramMessage;
+type TelegramDispatchParams = Parameters<TelegramDispatch>[0];
 
+function createDirectDispatchContext(cfg: OpenClawConfig): TelegramDispatchParams["context"] {
+  const msg = {
+    chat: { id: 123, type: "private" },
+    date: 1_736_380_800,
+    from: { id: 9, is_bot: false, first_name: "Ada" },
+    message_id: 456,
+    text: "test turn",
+  } as TelegramDispatchParams["context"]["msg"];
+  return {
+    cfg,
+    ctxPayload: {
+      Body: "test turn",
+      BodyForAgent: "test turn",
+      ChatType: "direct",
+      CommandBody: "test turn",
+      MessageSid: "456",
+      RawBody: "test turn",
+      SessionKey: "agent:default:telegram:direct:123",
+    } as TelegramDispatchParams["context"]["ctxPayload"],
+    turn: {
+      storePath: "/tmp/openclaw/telegram-sessions.json",
+      recordInboundSession: vi.fn(async () => undefined),
+      record: { onRecordError: vi.fn() },
+    } as TelegramDispatchParams["context"]["turn"],
+    primaryCtx: { message: msg } as TelegramDispatchParams["context"]["primaryCtx"],
+    msg,
+    chatId: 123,
+    isGroup: false,
+    threadSpec: { scope: "none" },
+    isForum: false,
+    historyLimit: 0,
+    groupHistories: new Map(),
+    skillFilter: undefined,
+    route: {
+      accountId: "default",
+      agentId: "default",
+      sessionKey: "agent:default:telegram:direct:123",
+    } as TelegramDispatchParams["context"]["route"],
+    sendTyping: vi.fn(async () => undefined),
+    sendRecordVoice: vi.fn(async () => undefined),
+    sendChatActionHandler: {
+      sendChatAction: vi.fn(async () => undefined),
+      isSuspended: () => false,
+      reset: vi.fn(),
+    },
+    ackReactionPromise: null,
+    reactionApi: null,
+    statusReactionController: null,
+    accountId: "default",
+  };
+}
+
+async function dispatchDirectTelegramTurn(params: {
+  cfg?: OpenClawConfig;
+  deliverReplies: NonNullable<TelegramBotDeps["deliverReplies"]>;
+  telegramCfg?: TelegramDispatchParams["telegramCfg"];
+}) {
+  const cfg = params.cfg ?? {};
+  const { dispatchTelegramMessage } = await import("./bot-message-dispatch.js");
+  const { Bot } = await import("./bot.runtime.js");
+  const bot = new Bot("tok", { botInfo: telegramBotInfoForTest });
+  return await dispatchTelegramMessage({
+    context: createDirectDispatchContext(cfg),
+    bot,
+    cfg,
+    runtime: createNonExitingRuntimeEnv(),
+    replyToMode: "first",
+    streamMode: "off",
+    textLimit: 4096,
+    telegramCfg: params.telegramCfg ?? {},
+    telegramDeps: { ...telegramBotDepsForTest, deliverReplies: params.deliverReplies },
+    opts: { token: "tok" },
+  });
+}
+
+function requireFinalization(result: unknown): Promise<unknown> {
+  const record = requireRecord(result, "buffered Telegram delivery result");
+  if (!(record.finalization instanceof Promise)) {
+    throw new Error("Expected buffered Telegram finalization promise");
+  }
+  return record.finalization;
+}
+
+describe("dispatchTelegramMessage reply settlement", () => {
   it("reports each payload independently when a later provider-hook send is cancelled", async () => {
-    const { createTelegramReplyDelivery } = await import("./bot-message-dispatch-reply.js");
-    const sendPayload = vi.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(false);
-    const reply = createTelegramReplyDelivery({
-      cfg: {} as never,
-      context: { route: { accountId: "default" } } as never,
-      delivery: {
-        normalizeDeliveryPayload: (payload: unknown) => payload,
-        sendPayload,
-      } as never,
-      draft: {
-        answerLane: { stream: undefined },
-        reasoningLane: { stream: undefined },
-        setReasoningStepCallbacks: vi.fn(),
-        splitTextIntoLaneSegments: () => ({ segments: [], suppressedReasoningOnly: false }),
-        enqueueEvent: async (callback: () => Promise<void>) => await callback(),
-        rotateAnswerLaneAfterToolProgress: async () => false,
-      } as never,
-      fence: { generation: () => 1, isSuperseded: () => false },
-      progress: {
-        markFinalStarted: vi.fn(),
-        finalAnswerDeliveryStarted: () => false,
-        finalAnswerDelivered: () => false,
-        markFinalDelivered: vi.fn(),
-      } as never,
-      runtime,
-      state: {} as never,
-      streamMode: "off",
-      telegramCfg: {},
+    const deliverReplies = vi
+      .fn<NonNullable<TelegramBotDeps["deliverReplies"]>>()
+      .mockResolvedValueOnce({ delivered: true })
+      .mockResolvedValueOnce({ delivered: false });
+    const results: unknown[] = [];
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      const deliver = dispatcherOptions.deliver;
+      if (!deliver) {
+        throw new Error("Expected Telegram reply deliverer");
+      }
+      results.push(await deliver({ text: "visible first" }, { kind: "final" }));
+      results.push(await deliver({ text: "cancelled second" }, { kind: "final" }));
+      return { queuedFinal: true, counts: { block: 0, final: 2, tool: 0 } };
     });
 
-    await expect(reply.deliver({ text: "visible first" }, { kind: "final" })).resolves.toEqual({
-      visibleReplySent: true,
-    });
-    await expect(reply.deliver({ text: "cancelled second" }, { kind: "final" })).resolves.toEqual({
-      visibleReplySent: false,
-      suppression: { reason: "no_visible_result" },
-    });
-    expect(sendPayload).toHaveBeenCalledTimes(2);
+    await dispatchDirectTelegramTurn({ deliverReplies });
+
+    expect(results).toEqual([
+      { visibleReplySent: true },
+      { visibleReplySent: false, suppression: { reason: "no_visible_result" } },
+    ]);
+    expect(deliverReplies).toHaveBeenCalledTimes(2);
   });
 
   it("settles a buffered final before a later empty final resets reasoning state", async () => {
-    const { createTelegramReplyDelivery } = await import("./bot-message-dispatch-reply.js");
-    const deliverFinalAnswerText = vi.fn(async () => ({ kind: "sent" as const }));
-    const reply = createTelegramReplyDelivery({
-      cfg: {} as never,
-      context: { route: { accountId: "default" } } as never,
-      delivery: {
-        normalizeDeliveryPayload: (payload: { text?: string }) =>
-          payload.text === "drop terminal" ? undefined : payload,
-        deliverFinalAnswerText,
-      } as never,
-      draft: {
-        answerLane: { stream: undefined },
-        reasoningLane: { stream: undefined },
-        setReasoningStepCallbacks: vi.fn(),
-        splitTextIntoLaneSegments: (
-          input: { text?: string },
-          isReasoning: boolean | undefined,
-        ) => ({
-          segments: input.text
-            ? [
-                {
-                  lane: isReasoning ? ("reasoning" as const) : ("answer" as const),
-                  update: { text: input.text },
-                },
-              ]
-            : [],
-          suppressedReasoningOnly: false,
-        }),
-        enqueueEvent: async (callback: () => Promise<void>) => await callback(),
-        dropQueuedAnswerBlockRotation: vi.fn(),
-        isQueuedAnswerBlock: () => false,
-      } as never,
-      fence: { generation: () => 1, isSuperseded: () => false },
-      progress: {
-        markFinalStarted: vi.fn(),
-        finalAnswerDeliveryStarted: () => false,
-        finalAnswerDelivered: () => false,
-      } as never,
-      runtime,
-      state: {} as never,
-      streamMode: "off",
-      telegramCfg: {},
+    const cfg: OpenClawConfig = { agents: { defaults: { reasoningDefault: "on" } } };
+    const deliverReplies = vi
+      .fn<NonNullable<TelegramBotDeps["deliverReplies"]>>()
+      .mockResolvedValueOnce({ delivered: false })
+      .mockResolvedValueOnce({ delivered: true });
+    let bufferedFinalization: Promise<unknown> | undefined;
+    let emptyFinalResult: unknown;
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      const deliver = dispatcherOptions.deliver;
+      if (!deliver) {
+        throw new Error("Expected Telegram reply deliverer");
+      }
+      await deliver({ text: "<think>first attempt</think>", isReasoning: true }, { kind: "block" });
+      bufferedFinalization = requireFinalization(
+        await deliver({ text: "buffered answer" }, { kind: "final" }),
+      );
+      emptyFinalResult = await deliver({}, { kind: "final" });
+      return { queuedFinal: true, counts: { block: 1, final: 2, tool: 0 } };
     });
-    reply.reasoningStepState.noteReasoningHint();
 
-    const buffered = (await reply.deliver({ text: "buffered answer" }, { kind: "final" })) as {
-      visibleReplySent: boolean;
-      finalization: Promise<unknown>;
-    };
-    expect(buffered).toMatchObject({ visibleReplySent: false });
-    expect(buffered.finalization).toBeInstanceOf(Promise);
+    await dispatchDirectTelegramTurn({ cfg, deliverReplies });
 
-    await expect(reply.deliver({ text: "drop terminal" }, { kind: "final" })).resolves.toEqual({
+    expect(emptyFinalResult).toEqual({
       visibleReplySent: false,
       suppression: { reason: "no_visible_result" },
     });
-    await expect(buffered.finalization).resolves.toEqual({ visibleReplySent: true });
-    expect(deliverFinalAnswerText).toHaveBeenCalledWith(
-      expect.objectContaining({ text: "buffered answer" }),
-      "buffered answer",
-      undefined,
+    await expect(bufferedFinalization).resolves.toEqual({ visibleReplySent: true });
+    expect(deliverReplies).toHaveBeenLastCalledWith(
+      expect.objectContaining({ replies: [expect.objectContaining({ text: "buffered answer" })] }),
     );
   });
 
   it("keeps buffered-final failure separate from a visible reasoning payload", async () => {
-    const { createTelegramReplyDelivery } = await import("./bot-message-dispatch-reply.js");
+    const cfg: OpenClawConfig = { agents: { defaults: { reasoningDefault: "on" } } };
     const error = new Error("buffered final failed");
-    const reply = createTelegramReplyDelivery({
-      cfg: {} as never,
-      context: { route: { accountId: "default" } } as never,
-      delivery: {
-        normalizeDeliveryPayload: (payload: unknown) => payload,
-        deliverFinalAnswerText: async () => {
-          throw error;
-        },
-        deliverLaneText: async () => ({ kind: "sent" as const }),
-      } as never,
-      draft: {
-        answerLane: { stream: undefined },
-        reasoningLane: { stream: undefined },
-        setReasoningStepCallbacks: vi.fn(),
-        splitTextIntoLaneSegments: (
-          input: { text?: string },
-          isReasoning: boolean | undefined,
-        ) => ({
-          segments: [
-            {
-              lane: isReasoning ? ("reasoning" as const) : ("answer" as const),
-              update: { text: input.text ?? "" },
-            },
-          ],
-          suppressedReasoningOnly: false,
-        }),
-        enqueueEvent: async (callback: () => Promise<void>) => await callback(),
-        dropQueuedAnswerBlockRotation: vi.fn(),
-        isQueuedAnswerBlock: () => false,
-      } as never,
-      fence: { generation: () => 1, isSuperseded: () => false },
-      progress: {
-        markFinalStarted: vi.fn(),
-        finalAnswerDeliveryStarted: () => false,
-        finalAnswerDelivered: () => false,
-      } as never,
-      runtime,
-      state: {} as never,
-      streamMode: "off",
-      telegramCfg: {},
+    const deliverReplies = vi
+      .fn<NonNullable<TelegramBotDeps["deliverReplies"]>>()
+      .mockResolvedValueOnce({ delivered: false })
+      .mockResolvedValueOnce({ delivered: true })
+      .mockRejectedValueOnce(error);
+    let bufferedSettlement: Promise<unknown> | undefined;
+    let visibleReasoningError: unknown;
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      const deliver = dispatcherOptions.deliver;
+      if (!deliver) {
+        throw new Error("Expected Telegram reply deliverer");
+      }
+      await deliver({ text: "<think>first attempt</think>", isReasoning: true }, { kind: "block" });
+      const finalization = requireFinalization(
+        await deliver({ text: "buffered answer" }, { kind: "final" }),
+      );
+      bufferedSettlement = finalization.then(
+        () => ({ status: "resolved" as const }),
+        (settlementError: unknown) => ({ status: "rejected" as const, error: settlementError }),
+      );
+      try {
+        await deliver(
+          { text: "<think>visible reasoning</think>", isReasoning: true },
+          { kind: "block" },
+        );
+      } catch (deliveryError) {
+        visibleReasoningError = deliveryError;
+      }
+      return { queuedFinal: true, counts: { block: 2, final: 1, tool: 0 } };
     });
-    reply.reasoningStepState.noteReasoningHint();
-    const buffered = (await reply.deliver({ text: "buffered answer" }, { kind: "final" })) as {
-      finalization: Promise<unknown>;
-    };
-    const bufferedSettlement = buffered.finalization.then(
-      () => ({ status: "resolved" as const }),
-      (settlementError: unknown) => ({ status: "rejected" as const, error: settlementError }),
-    );
 
-    await expect(
-      reply.deliver({ text: "visible reasoning", isReasoning: true }, { kind: "block" }),
-    ).rejects.toMatchObject({
+    await dispatchDirectTelegramTurn({ cfg, deliverReplies });
+
+    expect(visibleReasoningError).toMatchObject({
       code: "CHANNEL_PARTIAL_DELIVERY",
       deliveryResult: { visibleReplySent: true },
     });
     await expect(bufferedSettlement).resolves.toEqual({ status: "rejected", error });
+  });
+
+  it("keeps a suppressed exec-approval final in the fallback ledger", async () => {
+    const telegramCfg = {
+      execApprovals: { enabled: true, approvers: ["123"], target: "dm" as const },
+    };
+    const cfg: OpenClawConfig = { channels: { telegram: telegramCfg } };
+    const deliverReplies = vi
+      .fn<NonNullable<TelegramBotDeps["deliverReplies"]>>()
+      .mockResolvedValue({ delivered: true });
+    let suppressedResult: unknown;
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      const deliver = dispatcherOptions.deliver;
+      if (!deliver) {
+        throw new Error("Expected Telegram reply deliverer");
+      }
+      suppressedResult = await deliver(
+        {
+          channelData: {
+            execApproval: { approvalId: "req-1", approvalSlug: "req-1" },
+          },
+        },
+        { kind: "final" },
+      );
+      return {
+        queuedFinal: false,
+        noVisibleReplyFallbackEligible: true,
+        counts: { block: 0, final: 1, tool: 0 },
+      };
+    });
+
+    await dispatchDirectTelegramTurn({ cfg, deliverReplies, telegramCfg });
+
+    expect(suppressedResult).toEqual({
+      visibleReplySent: false,
+      suppression: { reason: "no_visible_result" },
+    });
+    expect(deliverReplies).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/telegram/src/lane-delivery-state.ts
+++ b/extensions/telegram/src/lane-delivery-state.ts
@@ -5,7 +5,7 @@ type LaneDeliverySnapshot = {
   failedNonSilent: number;
 };
 
-type LaneDeliveryStateTracker = {
+export type LaneDeliveryStateTracker = {
   markDelivered: () => void;
   markNonSilentSkip: () => void;
   markNonSilentFailure: () => void;

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -93,6 +93,8 @@ type DeliverLaneTextParams = {
   bindPendingFinalDelivery?: <T extends ReplyPayload>(payload: T) => T;
 };
 
+export type LaneTextDeliverer = (params: DeliverLaneTextParams) => Promise<LaneDeliveryResult>;
+
 function result(
   kind: Exclude<LaneDeliveryResult["kind"], "preview-finalized-partial">,
   delivery?: LanePreviewFinalizedDeliveryInput,
@@ -110,7 +112,7 @@ function result(
   return { kind };
 }
 
-export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
+export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams): LaneTextDeliverer {
   const textOnlyPayload = (payload: ReplyPayload): ReplyPayload => {
     const {
       mediaUrl: _mediaUrl,

--- a/extensions/telegram/src/lane-delivery.ts
+++ b/extensions/telegram/src/lane-delivery.ts
@@ -1,8 +1,12 @@
 // Telegram plugin module implements lane delivery behavior.
 export {
   createLaneTextDeliverer,
+  type LaneTextDeliverer,
   type DraftLaneState,
   type LaneDeliveryResult,
   type LaneName,
 } from "./lane-delivery-text-deliverer.js";
-export { createLaneDeliveryStateTracker } from "./lane-delivery-state.js";
+export {
+  createLaneDeliveryStateTracker,
+  type LaneDeliveryStateTracker,
+} from "./lane-delivery-state.js";

--- a/extensions/telegram/src/progress-summary.ts
+++ b/extensions/telegram/src/progress-summary.ts
@@ -1,3 +1,8 @@
+import type {
+  TelegramProgressSummaryCounters,
+  TelegramProgressSummaryTracker,
+} from "./bot-message-dispatch.types.js";
+
 // Post-turn collapse summary for the Telegram progress window.
 //
 // Mirrors Discord's collapse-summary line (extensions/discord/src/monitor/
@@ -11,12 +16,6 @@
 // prefix: Discord wraps the line in its `-#` small-text syntax, which Telegram
 // markdown has no analog for, so the Telegram line is emitted plain.
 
-type TelegramProgressSummaryCounters = {
-  reasoningSteps: number;
-  commentaryNotes: number;
-  toolCalls: number;
-};
-
 // Tracks turn activity for the collapse summary. The summary reflects ONLY what
 // actually streamed to the progress window — never durable-delivered items
 // (per the user's spec: "only summarize messages that ACTUALLY streamed").
@@ -27,38 +26,6 @@ type TelegramProgressSummaryCounters = {
 // the next tool call, or the summary flush — because some models (e.g. deepseek)
 // do not emit a reliable thinking_end per burst, so counting on the end event
 // alone undercounts.
-type TelegramProgressSummaryTracker = {
-  /** A reasoning delta arrived; opens (or keeps open) the current burst. */
-  noteReasoningActivity(): void;
-  /** Reasoning-end fired; close and count the current burst if one is open. */
-  closeReasoningBurst(): void;
-  /**
-   * A window-rendered tool call started: it is the boundary for any open
-   * reasoning/commentary burst, so close+count those first, then count one tool.
-   * Callers count the tool only when it is suppressed (window-rendered); under
-   * verbose the tool persists durably and they close the bursts directly instead
-   * (closeReasoningBurst/closeCommentaryBurst) without calling this.
-   */
-  noteToolCall(): void;
-  /**
-   * A commentary/preamble note arrived for the window. Opens (or keeps open) a
-   * commentary burst — it is NOT counted here. The burst is counted once when it
-   * closes at the next boundary (tool start, reasoning-end, a different note, or
-   * the summary flush). Counting per-burst rather than per-id is deliberate: the
-   * anthropic core tags every note in a turn with the SAME turn-local id
-   * ("commentary-0"), so an id-Set dedup collapsed a multi-tool turn's notes to
-   * one (D3). A tool follows each note in a tool-using turn, closing its burst
-   * before the next note opens => N notes.
-   */
-  noteCommentary(itemId?: string, text?: string): void;
-  /** Close and count the current commentary burst if one is open. */
-  closeCommentaryBurst(): void;
-  /** Snapshot of the current counters (closes any open bursts into the tally). */
-  counts(): TelegramProgressSummaryCounters;
-  /** True when there is at least one thought, note, or tool call to summarize. */
-  hasActivity(): boolean;
-};
-
 export function createTelegramProgressSummaryTracker(): TelegramProgressSummaryTracker {
   let reasoningSteps = 0;
   let commentaryNotes = 0;

--- a/extensions/telegram/src/reasoning-lane-coordinator.ts
+++ b/extensions/telegram/src/reasoning-lane-coordinator.ts
@@ -1,9 +1,12 @@
 // Telegram plugin module implements reasoning lane coordinator behavior.
 import { formatReasoningMessage } from "openclaw/plugin-sdk/agent-runtime";
-import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { findCodeRegions, isInsideCode } from "openclaw/plugin-sdk/text-chunking";
 import { stripReasoningTagsFromText } from "openclaw/plugin-sdk/text-chunking";
+import type {
+  TelegramBufferedFinalAnswer,
+  TelegramReasoningStepState,
+} from "./bot-message-dispatch.types.js";
 
 // A durable reasoning message already marked channel-side: 🧠 + italic body
 // (see markReasoningMessage). Detect it so a re-split passes it through
@@ -121,15 +124,9 @@ export function splitTelegramReasoningText(
   };
 }
 
-type BufferedFinalAnswer = {
-  payload: ReplyPayload;
-  text: string;
-  bufferedGeneration?: number;
-};
-
-export function createTelegramReasoningStepState() {
+export function createTelegramReasoningStepState(): TelegramReasoningStepState {
   let reasoningStatus: "none" | "hinted" | "delivered" = "none";
-  let bufferedFinalAnswer: BufferedFinalAnswer | undefined;
+  let bufferedFinalAnswer: TelegramBufferedFinalAnswer | undefined;
 
   const noteReasoningHint = () => {
     if (reasoningStatus === "none") {
@@ -145,18 +142,11 @@ export function createTelegramReasoningStepState() {
     return reasoningStatus === "hinted" && !bufferedFinalAnswer;
   };
 
-  const bufferFinalAnswer = (value: BufferedFinalAnswer) => {
+  const bufferFinalAnswer = (value: TelegramBufferedFinalAnswer) => {
     bufferedFinalAnswer = value;
   };
 
-  const takeBufferedFinalAnswer = (currentGeneration?: number): BufferedFinalAnswer | undefined => {
-    if (
-      currentGeneration !== undefined &&
-      bufferedFinalAnswer?.bufferedGeneration !== undefined &&
-      bufferedFinalAnswer.bufferedGeneration !== currentGeneration
-    ) {
-      return undefined;
-    }
+  const takeBufferedFinalAnswer = (): TelegramBufferedFinalAnswer | undefined => {
     const value = bufferedFinalAnswer;
     bufferedFinalAnswer = undefined;
     return value;


### PR DESCRIPTION
## What Problem This Solves

The four Telegram dispatch "controllers" (`bot-message-dispatch-{draft,progress,delivery,reply}`) were partitions of one closure pretending to be modules: ~75 parameter slots across five factory signatures, ~12 config fields copied into multiple constructors, a shared mutable `TelegramDispatchTurnState`, and seven post-construction back-edge setters whose only reason to exist was the module boundary. Construction order was load-bearing (draft's no-op defaults silently absorbed misordering) with nothing asserting it. `dispatchTelegramMessage` was already the only production entry point; the internal shape just didn't match that fact.

## Why This Change Was Made

One `turn` record now carries the once-resolved config and all turn state; the four files remain as implementation of that single module (plain functions over the turn record), with the factories, option bags, and every setter deleted. Three latent hazards found during the mapping are fixed in the same change:

- **H1**: the generation fence was dead code — `dispatchGeneration` was introduced as a constant `0` (verified via history), so the buffered-final generation guard could never reject; the whole fence is deleted.
- **H2**: `runTelegramDispatchTurn` unconditionally overwrote `state.queuedFinal`, clobbering the reply-side write for suppressed exec-approval prompts; now `||=`, with a regression test proven to fail on the pre-fix code (one unwanted fallback delivery).
- **H3**: `resolveCollapseSummaryLine` mutated `summaryDelivered` as a side effect of a resolver; split into a pure resolver plus explicit marks at both consumption sites.

## User Impact

None intended: behavior-neutral restructure. The acceptance gate makes that checkable — all 17 `bot-message-dispatch*` test files and the 745-line test harness are byte-identical to main and pass unchanged (247/247). H2 is the one deliberate behavior fix (suppressed exec-approval turns no longer trigger a spurious "no response" fallback).

## Evidence

- Dispatch suite + `bot.test.ts`: 18 files, 387 tests green on the exact head; dispatch tests/harness zero-diff vs main.
- `bot.test.ts`'s three reply-controller tests rewritten through the `dispatchTelegramMessage` front door (the deleted factory was their only consumer).
- H2 negative control: reverting `||=` to assignment fails exactly the new regression.
- `pnpm tsgo:extensions`, `pnpm check:test-types`, oxlint (all touched files incl. tests), `git diff --check`: clean.
- Production LOC net +93 (+2076/−1983); tests +55. Named tradeoff, accepted deliberately: ~100 of those lines are the hand-written turn contract — four explicit state-slice types (`TelegramDraftStateSlice` 16 members, progress 11, delivery 8, reply 4) in `bot-message-dispatch.types.ts`, now a leaf module with zero imports from implementations (repo madge leaf-contract rule). This replaces `ReturnType<typeof create*>` derived types — the exact interface-is-whatever-the-implementation-returns anti-pattern this refactor exists to kill. What got deleted is interface, not lines: 4 factories, ~75 parameter slots, 7 back-edge setters, the shared mutable state bag, and the dead generation fence.
- Rebased over #117327; `bot-message-dispatch-progress.ts` keeps main's centralized text-delivery behavior with the turn-record structure re-applied.

