### PR TITLE
refactor(plugins): centralize bundled tree detection

### DIFF
--- a/src/plugins/bundled-dir.ts
+++ b/src/plugins/bundled-dir.ts
@@ -48,7 +48,7 @@ function shouldTrustTestBundledPluginsDirOverride(env: NodeJS.ProcessEnv): boole
   );
 }
 
-function hasUsableBundledPluginTree(pluginsDir: string): boolean {
+export function hasUsableBundledPluginTree(pluginsDir: string): boolean {
   if (!fs.existsSync(pluginsDir)) {
     return false;
   }

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -12,7 +12,10 @@ import { tryReadJsonSync } from "../infra/json-files.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
 import { detectBundleManifestFormat, loadBundleManifest } from "./bundle-manifest.js";
-import { resolveSourceCheckoutDependencyDiagnostic } from "./bundled-dir.js";
+import {
+  hasUsableBundledPluginTree,
+  resolveSourceCheckoutDependencyDiagnostic,
+} from "./bundled-dir.js";
 import { buildLegacyBundledRootPath } from "./bundled-load-path-aliases.js";
 import { listBundledSourceOverlayDirs } from "./bundled-source-overlays.js";
 import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
@@ -1214,31 +1217,13 @@ function discoverInDirectory(params: {
   }
 }
 
-function hasDiscoverablePluginTree(pluginsDir: string): boolean {
-  try {
-    return fs.readdirSync(pluginsDir, { withFileTypes: true }).some((entry) => {
-      if (!entry.isDirectory()) {
-        return false;
-      }
-      const pluginDir = path.join(pluginsDir, entry.name);
-      return (
-        fs.existsSync(path.join(pluginDir, "package.json")) ||
-        fs.existsSync(path.join(pluginDir, "openclaw.plugin.json"))
-      );
-    });
-  } catch {
-    return false;
-  }
-}
-
 function isSourceCheckoutExtensionsDir(extensionsDir: string): boolean {
   const packageRoot = path.dirname(extensionsDir);
   return (
     fs.existsSync(path.join(packageRoot, ".git")) &&
     fs.existsSync(path.join(packageRoot, "pnpm-workspace.yaml")) &&
     fs.existsSync(path.join(packageRoot, "src")) &&
-    fs.existsSync(extensionsDir) &&
-    hasDiscoverablePluginTree(extensionsDir)
+    hasUsableBundledPluginTree(extensionsDir)
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Plugin discovery maintained a second copy of the bundled plugin tree usability check. The copies encoded the same filesystem policy in different owners, so future changes could drift and make source-checkout discovery disagree with bundled directory resolution.

## Why This Change Was Made

`src/plugins/bundled-dir.ts` now exports its existing `hasUsableBundledPluginTree` owner helper, and `src/plugins/discovery.ts` reuses it for source-checkout detection. This removes the duplicate reader and the redundant pre-check without changing trust, precedence, source-checkout, configuration, or fallback behavior.

Non-goals: no helper rename, new module, new tests, public API change, documentation, changelog, or discovery-policy change.

## User Impact

No user-visible behavior change. Bundled directory resolution and plugin discovery now share one canonical filesystem predicate instead of maintaining duplicate policy.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/bundled-dir.test.ts src/plugins/discovery.test.ts` - 126 tests passed.
- `node scripts/check-changed.mjs -- src/plugins/bundled-dir.ts src/plugins/discovery.ts` - passed on Blacksmith Testbox `tbx_01kzrnm6nat14kz536a1y43j36`; Actions receipt: https://github.com/openclaw/openclaw/actions/runs/31505014242
- `pnpm test src/plugins/bundled-dir.test.ts src/plugins/discovery.test.ts && pnpm test:contracts:plugins` - exact-head Blacksmith Testbox `tbx_01kzrp587zrkwkm5temt343wn4`; 126 focused tests and 1,057 plugin-contract tests passed. Actions receipt: https://github.com/openclaw/openclaw/actions/runs/31505841930
- `pnpm openclaw plugins list --json` - direct AWS Crabbox `cbx_c6395e117264`, run `run_59be81ad1119`; clean exit with 150 bundled plugins, 83 enabled plugins, and 0 diagnostics. Final timing: sync 85.474s, command 16.711s, total 252.071s; lease released.
- Exact-head CI run https://github.com/openclaw/openclaw/actions/runs/31507083553 - green. One unrelated gateway test intermittently redacted a generated sender UUID; the exact 28-test file passed on Testbox `tbx_01kzrqcchm0tn29p3zr7b45ws1` (https://github.com/openclaw/openclaw/actions/runs/31507793527), then only failed CI job `93831705296` was rerun as `93834573526` and passed.
- ClawSweeper exact-head review: no blocking findings, no rank-up moves, and no before-merge actions: https://github.com/openclaw/openclaw/pull/122093#issuecomment-5255540615
- `.agents/skills/autoreview/scripts/autoreview --mode local` - clean, no accepted/actionable findings.
- `git diff --check` - passed.
- Production LOC: `+6/-21` (net `-15`). Tests: `+0/-0`.
