### PR TITLE
fix(gateway): return UNAVAILABLE when all web push deliveries fail

### DIFF
--- a/src/gateway/server-methods/push.ts
+++ b/src/gateway/server-methods/push.ts
@@ -200,8 +200,14 @@ export const pushHandlers: GatewayRequestHandlers = {
         );
         return;
       }
-      // If every delivery failed (`ok: false`), return UNAVAILABLE with the full result list.
-      const allFailed = results.every((r) => !(r as any).ok);
+      // If every delivery failed (`ok: false`), return `UNAVAILABLE` with the full result list.
+      interface ResultLike {
+        ok: boolean;
+      }
+      const allFailed = results.every((r) => {
+        const rec = r as ResultLike;
+        return typeof rec.ok === "boolean" && !rec.ok;
+      });
       if (allFailed) {
         respond(
           false,

--- a/src/gateway/server-methods/push.ts
+++ b/src/gateway/server-methods/push.ts
@@ -200,6 +200,17 @@ export const pushHandlers: GatewayRequestHandlers = {
         );
         return;
       }
+      // If every delivery failed (`ok: false`), return UNAVAILABLE with the full result list.
+      const allFailed = results.every((r) => !(r as any).ok);
+      if (allFailed) {
+        respond(
+          false,
+          { results },
+          errorShape(ErrorCodes.UNAVAILABLE, "all web push deliveries failed"),
+        );
+        return;
+      }
+      // Otherwise at least one delivery succeeded – treat as a successful test.
       respond(true, { results }, undefined);
     });
   },


### PR DESCRIPTION
## What Problem This Solves
`push.web.test` could silently report success when every Web Push delivery failed. The Gateway treated any non-empty fan-out result array as success, so the UI showed no notification and no error, giving operators false confidence in broken push infrastructure.

## Why This Change Was Made
The handler previously responded with success whenever `broadcastWebPush` returned a non-empty result list. When every subscription delivery failed, the result list was still non-empty, so the Gateway returned success instead of an error. This masks real delivery failures and wastes operator diagnosis time.

## User Impact
- A test notification that fails for every registered browser subscription now surfaces as an explicit `UNAVAILABLE` error in the Control UI.
- Partial success and fully successful fan-outs remain unchanged.
- Operators get immediate visible feedback instead of silent false positives.

## Evidence
### Before
`push.web.test` returned success with `{ results }` even when every result had `ok: false`.

### After
The handler detects when all deliveries failed and returns `UNAVAILABLE` with the full `{ results }` payload. Partial success continues to return success.

### Test Output
```
Test Files  1 passed (1)
Tests       7 passed (7)
Duration    4.11s
```
All existing tests pass against the updated handler.

## AI-assisted contribution
This PR was authored with **Claude Code**.

Closes #122062