### PR TITLE
fix(macos): verify configured gateway inference live before onboarding handoff

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -35571,7 +35571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 381,
+      "line": 432,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift",
       "source": "Back",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -765,6 +765,18 @@ extension GatewayConnection {
 
     func supportsServerMethod(
         _ method: String,
+        ifCurrentRoute route: Route) async -> Bool?
+    {
+        guard let endpoint = try? await currentEndpoint() else { return nil }
+        guard self.routeMatchesCurrentState(route, endpoint: endpoint),
+              let snapshot = lastSnapshot
+        else { return nil }
+        let methods = snapshot.features["methods"]?.value as? [AnyCodable] ?? []
+        return methods.contains { ($0.value as? String) == method }
+    }
+
+    func supportsServerMethod(
+        _ method: String,
         ifCurrentServerLease lease: ServerLease) async -> Bool?
     {
         guard await self.isCurrentServerLease(lease),

--- a/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
@@ -30,8 +30,17 @@ final class OnboardingConfiguredGatewayProbe {
         }
     }
 
+    enum LiveVerification: Equatable {
+        case verified
+        case failed(status: String?, error: String?)
+        case unsupported
+        case unavailable
+        case superseded
+    }
+
     private let gateway: GatewayConnection
     private let timeoutMs: Double
+    private let verificationTimeoutMs: Double
     private var generation: UInt64 = 0
     private var activeProbeCount = 0
     private var reconnectPending = false
@@ -41,10 +50,12 @@ final class OnboardingConfiguredGatewayProbe {
 
     init(
         gateway: GatewayConnection = .shared,
-        timeoutMs: Double = 15000)
+        timeoutMs: Double = 15000,
+        verificationTimeoutMs: Double = 150_000)
     {
         self.gateway = gateway
         self.timeoutMs = timeoutMs
+        self.verificationTimeoutMs = verificationTimeoutMs
     }
 
     /// Allocate before queuing async work so user-event order, not Task start
@@ -155,6 +166,44 @@ final class OnboardingConfiguredGatewayProbe {
 
     func isCurrent(_ route: BoundRoute) async -> Bool {
         await self.gateway.isCurrentRoute(route.route)
+    }
+
+    /// A configured model string only proves config exists, not that the route
+    /// can complete a turn: a migrated OAuth profile can be permanently
+    /// expired. Prove inference on the bound route before onboarding hands off
+    /// to the dashboard. Gateways too old to advertise the verification RPC
+    /// keep the config-only handoff.
+    func verifyConfiguredRoute(
+        _ route: BoundRoute,
+        attempt: Attempt) async -> LiveVerification
+    {
+        guard self.isCurrent(attempt) else { return .superseded }
+        guard let supported = await self.gateway.supportsServerMethod(
+            "openclaw.setup.verify",
+            ifCurrentRoute: route.route)
+        else { return .superseded }
+        guard supported else { return .unsupported }
+        do {
+            let data = try await gateway.request(
+                method: "openclaw.setup.verify",
+                params: [:],
+                timeoutMs: self.verificationTimeoutMs,
+                ifCurrentRoute: route.route)
+            guard await self.gateway.isCurrentRoute(route.route),
+                  self.isCurrent(attempt)
+            else { return .superseded }
+            let result = try JSONDecoder().decode(OnboardingAISetupModel.ActivateResult.self, from: data)
+            return result.ok
+                ? .verified
+                : .failed(status: result.status, error: result.error)
+        } catch is CancellationError {
+            return .superseded
+        } catch {
+            guard await self.gateway.isCurrentRoute(route.route),
+                  self.isCurrent(attempt)
+            else { return .superseded }
+            return .unavailable
+        }
     }
 
     func consumeReconnects(onReconnect: @escaping @MainActor () -> Void) async {

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
@@ -184,7 +184,7 @@ extension OnboardingView {
             self.schedulePendingActivationRecheckIfNeeded(pendingState)
 
             switch outcome {
-            case let .configured(modelRef, _):
+            case let .configured(modelRef, route):
                 switch pendingState {
                 case .activating, .activationExpired, .completed:
                     // A live setup/verification already owns this marker. A
@@ -208,17 +208,18 @@ extension OnboardingView {
                     }
                 }
                 guard Self.shouldOpenConfiguredGatewayDashboard(
-                    onboardingVisible: self.onboardingVisible,
+                    onboardingVisible: knownVisible || self.onboardingVisible,
                     expectedMode: expectedMode,
                     currentMode: self.state.connectionMode,
                     systemAgentResumePending: systemAgentResumePending,
                     setupOwnsInferenceTransition: self.aiSetup.ownsInferenceTransition)
                 else { return }
-                self.onboardingVisible = false
-                self.configuredGatewayProbe.invalidate()
-                OnboardingController.markComplete()
-                OnboardingController.shared.close()
-                AppNavigationActions.openDashboard()
+                await self.verifyAndCompleteConfiguredGatewayHandoff(
+                    route: route,
+                    attempt: probeAttempt,
+                    expectedMode: expectedMode,
+                    expectedRouteIdentity: expectedRouteIdentity,
+                    knownVisible: knownVisible)
             case .missing:
                 // A route-bound activation/verification can complete while the
                 // earlier agents.list request is suspended. Never let that
@@ -256,6 +257,56 @@ extension OnboardingView {
                 break
             }
         }
+    }
+
+    /// A configured model string is not proof that the route can complete a
+    /// turn: a migrated OAuth profile can be permanently expired. Prove
+    /// inference live before the dashboard handoff.
+    private func verifyAndCompleteConfiguredGatewayHandoff(
+        route: OnboardingConfiguredGatewayProbe.BoundRoute,
+        attempt: OnboardingConfiguredGatewayProbe.Attempt,
+        expectedMode: AppState.ConnectionMode,
+        expectedRouteIdentity: String?,
+        knownVisible: Bool) async
+    {
+        let verification = await self.configuredGatewayProbe.verifyConfiguredRoute(
+            route,
+            attempt: attempt)
+        guard self.configuredGatewayProbe.isCurrent(attempt),
+              await self.configuredGatewayProbe.isCurrent(route),
+              self.aiSetupRouteIdentityProvider() == expectedRouteIdentity
+        else { return }
+        switch verification {
+        case .verified, .unsupported:
+            // Gateways too old for the verification RPC keep the config-only handoff.
+            break
+        case .failed:
+            // The route answered but cannot complete a turn. Stay in
+            // onboarding and enter the standard AI setup recovery flow.
+            self.resumePendingInferenceSetup()
+            return
+        case .unavailable:
+            self.showConfiguredGatewayProbeBlocker(.unavailable)
+            return
+        case .superseded:
+            return
+        }
+        // The verification round-trip can overlap a user-started setup or a
+        // fresh activation marker; re-gate before the handoff.
+        guard Self.shouldOpenConfiguredGatewayDashboard(
+            onboardingVisible: knownVisible || self.onboardingVisible,
+            expectedMode: expectedMode,
+            currentMode: self.state.connectionMode,
+            systemAgentResumePending: OnboardingSystemAgentResumeStore.pendingState(
+                for: expectedRouteIdentity,
+                defaults: self.systemAgentDefaults) != .none,
+            setupOwnsInferenceTransition: self.aiSetup.ownsInferenceTransition)
+        else { return }
+        self.onboardingVisible = false
+        self.configuredGatewayProbe.invalidate()
+        OnboardingController.markComplete()
+        OnboardingController.shared.close()
+        AppNavigationActions.openDashboard()
     }
 
     private func showConfiguredGatewayProbeBlocker(

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -2344,6 +2344,94 @@ struct OnboardingAISetupTests {
         #expect(isPending(defaults))
     }
 
+    @Test func `failed configured route verification enters AI setup recovery instead of handing off`() async throws {
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingConfiguredVerifyRecoveryTests"))
+        let url = try #require(URL(string: "ws://localhost:18789"))
+        let harness = AISetupHarness(
+            url: url,
+            handler: { _, request, _ in
+                switch request.method {
+                case "agents.list":
+                    return configuredModelResponse(id: request.id)
+                case "openclaw.setup.verify":
+                    return rejectedSetupVerificationResponse(id: request.id)
+                case "openclaw.setup.detect":
+                    return detectedSetupResponse(id: request.id)
+                case "openclaw.setup.activate":
+                    return failedActivationResponse(id: request.id)
+                default:
+                    return nil
+                }
+            },
+            receiveHook: { task, receiveIndex in
+                if receiveIndex == 0 {
+                    return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                }
+                return .data(GatewayWebSocketTestSupport.connectOkData(
+                    id: task.snapshotConnectRequestID() ?? "connect",
+                    methods: ["openclaw.setup.verify"]))
+            })
+        let appState = AppState(preview: true)
+        appState.connectionMode = .local
+        let view = harness.view(state: appState, defaults: defaults, routeIdentityProvider: { "local" })
+        view.onboardingVisible = true
+
+        let probe = try #require(view.probeConfiguredGatewayForDashboard(knownVisible: true))
+        await probe.value
+        let requests = await waitForAISetupRequests(harness.recorder, count: 3)
+        await settleQueuedAISetupTasks()
+
+        #expect(Array(requests.methods.prefix(3)) == [
+            "agents.list",
+            "openclaw.setup.verify",
+            "openclaw.setup.detect",
+        ])
+        // The failed route must not hand off; it enters AI setup recovery.
+        // (View @State does not read back on uninstalled views, so assert on
+        // the model and the recorded request sequence instead.)
+        #expect(view.aiSetup.phase != .idle)
+        #expect(!view.aiSetup.connected)
+        #expect(!view.aiSetup.configuredGatewayProbeUnavailable)
+    }
+
+    @Test func `configured route verification failure keeps onboarding on the probe blocker`() async throws {
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingConfiguredVerifyUnavailableTests"))
+        let url = try #require(URL(string: "ws://localhost:18789"))
+        let harness = AISetupHarness(
+            url: url,
+            handler: { _, request, _ in
+                switch request.method {
+                case "agents.list":
+                    return configuredModelResponse(id: request.id)
+                case "openclaw.setup.verify":
+                    return unavailableGatewayResponse(id: request.id)
+                default:
+                    return nil
+                }
+            },
+            receiveHook: { task, receiveIndex in
+                if receiveIndex == 0 {
+                    return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                }
+                return .data(GatewayWebSocketTestSupport.connectOkData(
+                    id: task.snapshotConnectRequestID() ?? "connect",
+                    methods: ["openclaw.setup.verify"]))
+            })
+        let appState = AppState(preview: true)
+        appState.connectionMode = .local
+        let view = harness.view(state: appState, defaults: defaults, routeIdentityProvider: { "local" })
+        view.onboardingVisible = true
+
+        let probe = try #require(view.probeConfiguredGatewayForDashboard(knownVisible: true))
+        await probe.value
+        await settleQueuedAISetupTasks()
+
+        #expect(await (harness.recorder.snapshot()).methods == ["agents.list", "openclaw.setup.verify"])
+        #expect(view.aiSetup.configuredGatewayProbeUnavailable)
+        #expect(view.aiSetup.detectError != nil)
+        #expect(!view.aiSetup.connected)
+    }
+
     @Test func `verified configured model stays read only until pending deadline`() async throws {
         let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingPendingConfiguredVerificationTests"))
         let url = try #require(URL(string: "ws://localhost:18789"))

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
@@ -201,6 +201,78 @@ private func onboardingProbeAuthFailureTaskFactory() -> GatewayTestWebSocketSess
     }
 }
 
+private func onboardingProbeRequest(
+    from message: URLSessionWebSocketTask.Message) -> (id: String, method: String)?
+{
+    let data: Data? = switch message {
+    case let .data(data): data
+    case let .string(string): string.data(using: .utf8)
+    @unknown default: nil
+    }
+    guard let data,
+          let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let id = object["id"] as? String,
+          let method = object["method"] as? String
+    else { return nil }
+    return (id: id, method: method)
+}
+
+private func onboardingVerifyOkResponse(id: String) -> Data {
+    Data(
+        #"{"type":"res","id":"\#(id)","ok":true,"payload":{"ok":true,"modelRef":"openai/gpt-5.5","latencyMs":42}}"#
+            .utf8)
+}
+
+private func onboardingVerifyRejectedResponse(id: String) -> Data {
+    Data(
+        #"{"type":"res","id":"\#(id)","ok":true,"payload":{"ok":false,"status":"auth","error":"expired login"}}"#
+            .utf8)
+}
+
+private enum OnboardingVerifyReply: Sendable {
+    case verified
+    case rejected
+    case transportFailure
+}
+
+/// Answers `agents.list` with a configured model and dispatches the live
+/// verification request by method, advertising it in the hello when asked.
+private func onboardingVerifyTaskFactory(
+    reply: OnboardingVerifyReply,
+    advertiseVerifyMethod: Bool = true,
+    beforeVerifyReply: (@Sendable () async -> Void)? = nil) -> GatewayTestWebSocketSession.TaskFactory
+{
+    {
+        GatewayTestWebSocketTask(
+            sendHook: { task, message, sendIndex in
+                guard sendIndex > 0,
+                      let request = onboardingProbeRequest(from: message)
+                else { return }
+                guard request.method == "openclaw.setup.verify" else {
+                    task.emitReceiveSuccess(.data(onboardingAgentsResponse(id: request.id)))
+                    return
+                }
+                await beforeVerifyReply?()
+                switch reply {
+                case .verified:
+                    task.emitReceiveSuccess(.data(onboardingVerifyOkResponse(id: request.id)))
+                case .rejected:
+                    task.emitReceiveSuccess(.data(onboardingVerifyRejectedResponse(id: request.id)))
+                case .transportFailure:
+                    task.emitReceiveFailure()
+                }
+            },
+            receiveHook: { task, receiveIndex in
+                if receiveIndex == 0 {
+                    return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                }
+                return .data(GatewayWebSocketTestSupport.connectOkData(
+                    id: task.snapshotConnectRequestID() ?? "connect",
+                    methods: advertiseVerifyMethod ? ["openclaw.setup.verify"] : []))
+            })
+    }
+}
+
 @MainActor
 private struct OnboardingProbeFixture {
     let session: GatewayTestWebSocketSession
@@ -562,5 +634,109 @@ struct OnboardingConfiguredGatewayProbeTests {
         probe.invalidate()
 
         #expect(await probe.probe(connectionMode: .remote, attempt: attempt) == .superseded)
+    }
+
+    @Test func `configured route passes live verification on the bound route`() async throws {
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let fixture = onboardingProbeFixture(
+            url: url,
+            taskFactory: onboardingVerifyTaskFactory(reply: .verified))
+        let probe = fixture.probe
+
+        let attempt = probe.beginProbe()
+        let outcome = await probe.probe(connectionMode: .remote, attempt: attempt)
+        let route = try #require(outcome.boundRoute)
+
+        #expect(await probe.verifyConfiguredRoute(route, attempt: attempt) == .verified)
+        #expect(fixture.session.latestTask()?.snapshotSendCount() == 3)
+    }
+
+    @Test func `failed live verification reports the gateway failure status`() async throws {
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let fixture = onboardingProbeFixture(
+            url: url,
+            taskFactory: onboardingVerifyTaskFactory(reply: .rejected))
+        let probe = fixture.probe
+
+        let attempt = probe.beginProbe()
+        let outcome = await probe.probe(connectionMode: .remote, attempt: attempt)
+        let route = try #require(outcome.boundRoute)
+
+        #expect(await probe.verifyConfiguredRoute(route, attempt: attempt) ==
+            .failed(status: "auth", error: "expired login"))
+    }
+
+    @Test func `gateway without the verification method keeps the config-only result`() async throws {
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let fixture = onboardingProbeFixture(
+            url: url,
+            taskFactory: onboardingVerifyTaskFactory(
+                reply: .verified,
+                advertiseVerifyMethod: false))
+        let probe = fixture.probe
+
+        let attempt = probe.beginProbe()
+        let outcome = await probe.probe(connectionMode: .remote, attempt: attempt)
+        let route = try #require(outcome.boundRoute)
+
+        #expect(await probe.verifyConfiguredRoute(route, attempt: attempt) == .unsupported)
+        #expect(fixture.session.latestTask()?.snapshotSendCount() == 2)
+    }
+
+    @Test func `verification transport failure is unavailable`() async throws {
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let fixture = onboardingProbeFixture(
+            url: url,
+            taskFactory: onboardingVerifyTaskFactory(reply: .transportFailure))
+        let probe = fixture.probe
+
+        let attempt = probe.beginProbe()
+        let outcome = await probe.probe(connectionMode: .remote, attempt: attempt)
+        let route = try #require(outcome.boundRoute)
+
+        #expect(await probe.verifyConfiguredRoute(route, attempt: attempt) == .unavailable)
+    }
+
+    @Test func `route replacement supersedes an in-flight verification`() async throws {
+        let config = OnboardingProbeGatewayConfig()
+        let gate = OnboardingProbeGate()
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let probe = onboardingProbeFixture(
+            url: url,
+            tokenProvider: { await config.snapshotToken() },
+            taskFactory: onboardingVerifyTaskFactory(
+                reply: .verified,
+                beforeVerifyReply: { await gate.wait() })).probe
+
+        let attempt = probe.beginProbe()
+        let outcome = await probe.probe(connectionMode: .remote, attempt: attempt)
+        let route = try #require(outcome.boundRoute)
+        let result = Task { await probe.verifyConfiguredRoute(route, attempt: attempt) }
+        await gate.waitUntilStarted()
+        await config.setToken("route-b")
+        await gate.release()
+
+        #expect(await result.value == .superseded)
+    }
+
+    @Test func `invalidation during live verification supersedes the result`() async throws {
+        let gate = OnboardingProbeGate()
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let fixture = onboardingProbeFixture(
+            url: url,
+            taskFactory: onboardingVerifyTaskFactory(
+                reply: .verified,
+                beforeVerifyReply: { await gate.wait() }))
+        let probe = fixture.probe
+
+        let attempt = probe.beginProbe()
+        let outcome = await probe.probe(connectionMode: .remote, attempt: attempt)
+        let route = try #require(outcome.boundRoute)
+        let result = Task { await probe.verifyConfiguredRoute(route, attempt: attempt) }
+        await gate.waitUntilStarted()
+        probe.invalidate()
+        await gate.release()
+
+        #expect(await result.value == .superseded)
     }
 }

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -46,10 +46,13 @@ has no macOS app asset, use the newest one that does, or build from source with
    macOS permissions any time from **Settings → Permissions**.
 
 If the app reaches an existing Gateway whose default agent has a configured
-model, it treats that Gateway as already set up, skips provider onboarding and
-OpenClaw, and opens the dashboard. If the Gateway cannot connect or its
-default agent has no model, inference onboarding remains available for
-recovery.
+model, it proves that route with a live model check before treating the
+Gateway as already set up: a passing check skips provider onboarding and
+opens the dashboard, while a failed check (for example an expired sign-in)
+keeps onboarding open on the AI setup recovery flow. Gateways too old to run
+the live check keep the previous config-only handoff. If the Gateway cannot
+connect or its default agent has no model, inference onboarding remains
+available for recovery.
 
 For the CLI/Gateway setup path, use [Getting started](/start/getting-started).
 For permission recovery, use [macOS permissions](/platforms/mac/permissions).


### PR DESCRIPTION
## What Problem This Solves

Fixes #121825.

On first launch over an existing OpenClaw state directory, macOS onboarding reported OpenAI authentication as healthy and green even when the only migrated OAuth profile could no longer refresh. The false success surfaced only when the first chat message failed with HTTP 401 `refresh_token_reused` — every chat turn failed until the user forced reauthentication.

Root cause: the configured-Gateway probe (`OnboardingConfiguredGatewayProbe.probe`) reads only the default agent's configured model string via `agents.list`. A non-empty string completed onboarding and opened the dashboard without ever exercising the credential. The owner-level live verifier already existed — the `openclaw.setup.verify` RPC runs a tool-free completion through the exact configured route and converts terminal auth failures (expired/reused OAuth refresh token) into a structured `{ ok: false, status: "auth" }` result — but the configured-model handoff never called it.

## Why This Change Was Made

The repair reuses the existing verifier at the handoff instead of adding an OAuth-specific heuristic, per the issue's reviewed fix shape:

- `OnboardingConfiguredGatewayProbe.verifyConfiguredRoute(_:attempt:)` runs `openclaw.setup.verify` bound to the probed route, returning a closed `LiveVerification` result (`verified` / `failed(status,error)` / `unsupported` / `unavailable` / `superseded`).
- The dashboard handoff in `probeConfiguredGatewayForDashboard` now proves inference live before completing onboarding. A failed verification keeps onboarding open and enters the existing AI setup recovery flow (`resumePendingInferenceSetup`, the same path used for expired activation markers), where the auth failure surfaces with reauthentication guidance. A verification transport failure shows the existing probe blocker with retry.
- Gateways that do not advertise `openclaw.setup.verify` (pre-2026.7) keep the previous config-only handoff, detected via a new route-bound `supportsServerMethod(_:ifCurrentRoute:)` mirroring the existing capability variant.
- Pending-activation resume paths already ran this same verification and are unchanged; the verification timeout (150s) matches the existing pending-verification client bound against the 90s server probe limit.

## User Impact

A migrated or expired OAuth profile no longer produces a false-green onboarding: the user is kept in onboarding and routed into AI setup recovery with a visible reauthentication path instead of discovering the failure on the first chat message. Healthy configured gateways gain one bounded, tool-free model round-trip (32 max tokens) before the dashboard opens. Older Gateways are unaffected.

## Evidence

Regression coverage (new tests fail on pre-fix code because the verification request is never sent and the handoff completes immediately):

- `OnboardingConfiguredGatewayProbeTests`: live verification succeeds on the bound route; failed verification reports the gateway status; gateways without the advertised method keep the config-only result (no verification request sent); transport failure is `unavailable`; route replacement and probe invalidation supersede an in-flight verification.
- `OnboardingAISetupTests`: a failed configured-route verification keeps onboarding visible and enters AI setup recovery (agents.list → verify → detect request order asserted); a verification RPC failure lands on the existing probe blocker without starting setup.

Acceptance-criteria suites: `swift test --package-path apps/macos --filter OnboardingConfiguredGatewayProbeTests`, `--filter OnboardingAISetupTests`, and `node scripts/run-vitest.mjs src/system-agent/setup-inference.test.ts` (server side unchanged; the RPC contract is reused as-is).

Proof note: authored on Linux, so the Swift suites could not be executed locally; the macOS CI Swift test lane on this PR is the execution proof. Pre-PR structured review (`autoreview --mode local --engine claude`, after the Codex engine failed twice in this environment): clean, no accepted/actionable findings.
