### PR TITLE
fix(browser): let attached workers exit after CDP use

### DIFF
--- a/extensions/browser/src/attached-browser-tool-runtime.test.ts
+++ b/extensions/browser/src/attached-browser-tool-runtime.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   createBrowserTool: vi.fn(),
   startBrowserBridgeServer: vi.fn(),
   stopBrowserBridgeServer: vi.fn(),
+  retirePlaywrightBrowserConnectionExact: vi.fn(),
 }));
 
 vi.mock("./browser-tool.js", () => ({
@@ -18,17 +19,31 @@ vi.mock("./browser/bridge-server.js", () => ({
   stopBrowserBridgeServer: mocks.stopBrowserBridgeServer,
 }));
 
+vi.mock("./browser/pw-session.js", () => ({
+  retirePlaywrightBrowserConnectionExact: mocks.retirePlaywrightBrowserConnectionExact,
+}));
+
 import { createAttachedBrowserToolRuntime } from "./attached-browser-tool-runtime.js";
 
 describe("attached Browser tool runtime", () => {
+  const closeRetirement = vi.fn();
+  const refreshRetirement = vi.fn();
+
   beforeEach(() => {
     vi.clearAllMocks();
+    closeRetirement.mockResolvedValue(undefined);
+    refreshRetirement.mockReturnValue(true);
     mocks.createBrowserTool.mockReturnValue({ name: "browser" });
     mocks.startBrowserBridgeServer.mockResolvedValue({
       baseUrl: "http://127.0.0.1:18443",
       server: { marker: "bridge-server" },
     });
     mocks.stopBrowserBridgeServer.mockResolvedValue(undefined);
+    mocks.retirePlaywrightBrowserConnectionExact.mockReturnValue({
+      retired: true,
+      close: closeRetirement,
+      refresh: refreshRetirement,
+    });
   });
 
   it("exposes only one raw attach-only CDP profile through an authenticated loopback bridge", async () => {
@@ -80,11 +95,13 @@ describe("attached Browser tool runtime", () => {
     const sourcePath = path.join(workspaceDir, "source.png");
     await fs.writeFile(sourcePath, "screenshot-bytes");
     const artifactPath = await toolParams.persistScreenshot({ sourcePath, type: "png" });
-    expect(artifactPath).toMatch(
+    expect(artifactPath.replaceAll("\\", "/")).toMatch(
       /\.artifacts\/cloud-worker-browser\/screenshot-[a-f0-9]{16}\.png$/u,
     );
     expect(await fs.readFile(artifactPath, "utf8")).toBe("screenshot-bytes");
-    expect((await fs.stat(artifactPath)).mode & 0o777).toBe(0o600);
+    if (process.platform !== "win32") {
+      expect((await fs.stat(artifactPath)).mode & 0o777).toBe(0o600);
+    }
     const filesBeforeFailure = await fs.readdir(path.dirname(artifactPath));
     await expect(
       toolParams.persistScreenshot({
@@ -97,7 +114,34 @@ describe("attached Browser tool runtime", () => {
 
     await runtime.dispose();
     expect(mocks.stopBrowserBridgeServer).toHaveBeenCalledWith({ marker: "bridge-server" });
+    expect(mocks.retirePlaywrightBrowserConnectionExact).toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:9222",
+    });
+    expect(closeRetirement).toHaveBeenCalledOnce();
     expect(ensureAttachTarget).toHaveBeenCalledOnce();
+    await fs.rm(workspaceDir, { recursive: true, force: true });
+  });
+
+  it("retires the exact Playwright CDP adapter upon disposal and supports repeated retries", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "attached-browser-workspace-"));
+    const runtime = await createAttachedBrowserToolRuntime({
+      cdpUrl: "http://127.0.0.1:9222",
+      ensureAttachTarget: async () => {},
+      workspaceDir,
+    });
+
+    await runtime.dispose();
+    expect(mocks.stopBrowserBridgeServer).toHaveBeenCalledOnce();
+    expect(mocks.retirePlaywrightBrowserConnectionExact).toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:9222",
+    });
+    expect(closeRetirement).toHaveBeenCalledOnce();
+
+    // Repeated disposal should refresh the retirement and retry close
+    await runtime.dispose();
+    expect(refreshRetirement).toHaveBeenCalledOnce();
+    expect(closeRetirement).toHaveBeenCalledTimes(2);
+
     await fs.rm(workspaceDir, { recursive: true, force: true });
   });
 

--- a/extensions/browser/src/attached-browser-tool-runtime.test.ts
+++ b/extensions/browser/src/attached-browser-tool-runtime.test.ts
@@ -7,7 +7,7 @@ const mocks = vi.hoisted(() => ({
   createBrowserTool: vi.fn(),
   startBrowserBridgeServer: vi.fn(),
   stopBrowserBridgeServer: vi.fn(),
-  retirePlaywrightBrowserConnectionExact: vi.fn(),
+  closePlaywrightBrowserConnection: vi.fn(),
 }));
 
 vi.mock("./browser-tool.js", () => ({
@@ -20,30 +20,21 @@ vi.mock("./browser/bridge-server.js", () => ({
 }));
 
 vi.mock("./browser/pw-session.js", () => ({
-  retirePlaywrightBrowserConnectionExact: mocks.retirePlaywrightBrowserConnectionExact,
+  closePlaywrightBrowserConnection: mocks.closePlaywrightBrowserConnection,
 }));
 
 import { createAttachedBrowserToolRuntime } from "./attached-browser-tool-runtime.js";
 
 describe("attached Browser tool runtime", () => {
-  const closeRetirement = vi.fn();
-  const refreshRetirement = vi.fn();
-
   beforeEach(() => {
     vi.clearAllMocks();
-    closeRetirement.mockResolvedValue(undefined);
-    refreshRetirement.mockReturnValue(true);
+    mocks.closePlaywrightBrowserConnection.mockResolvedValue(undefined);
     mocks.createBrowserTool.mockReturnValue({ name: "browser" });
     mocks.startBrowserBridgeServer.mockResolvedValue({
       baseUrl: "http://127.0.0.1:18443",
       server: { marker: "bridge-server" },
     });
     mocks.stopBrowserBridgeServer.mockResolvedValue(undefined);
-    mocks.retirePlaywrightBrowserConnectionExact.mockReturnValue({
-      retired: true,
-      close: closeRetirement,
-      refresh: refreshRetirement,
-    });
   });
 
   it("exposes only one raw attach-only CDP profile through an authenticated loopback bridge", async () => {
@@ -114,33 +105,35 @@ describe("attached Browser tool runtime", () => {
 
     await runtime.dispose();
     expect(mocks.stopBrowserBridgeServer).toHaveBeenCalledWith({ marker: "bridge-server" });
-    expect(mocks.retirePlaywrightBrowserConnectionExact).toHaveBeenCalledWith({
+    expect(mocks.closePlaywrightBrowserConnection).toHaveBeenCalledWith({
       cdpUrl: "http://127.0.0.1:9222",
     });
-    expect(closeRetirement).toHaveBeenCalledOnce();
     expect(ensureAttachTarget).toHaveBeenCalledOnce();
     await fs.rm(workspaceDir, { recursive: true, force: true });
   });
 
-  it("retires the exact Playwright CDP adapter upon disposal and supports repeated retries", async () => {
+  it("retries exact Playwright CDP adapter disposal after a failed disconnect", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "attached-browser-workspace-"));
     const runtime = await createAttachedBrowserToolRuntime({
       cdpUrl: "http://127.0.0.1:9222",
       ensureAttachTarget: async () => {},
       workspaceDir,
     });
+    mocks.closePlaywrightBrowserConnection
+      .mockRejectedValueOnce(new Error("disconnect failed"))
+      .mockResolvedValueOnce(undefined);
 
-    await runtime.dispose();
-    expect(mocks.stopBrowserBridgeServer).toHaveBeenCalledOnce();
-    expect(mocks.retirePlaywrightBrowserConnectionExact).toHaveBeenCalledWith({
+    await expect(runtime.dispose()).rejects.toThrow("disconnect failed");
+    await expect(runtime.dispose()).resolves.toBeUndefined();
+
+    expect(mocks.stopBrowserBridgeServer).toHaveBeenCalledTimes(2);
+    expect(mocks.closePlaywrightBrowserConnection).toHaveBeenCalledTimes(2);
+    expect(mocks.closePlaywrightBrowserConnection).toHaveBeenNthCalledWith(1, {
       cdpUrl: "http://127.0.0.1:9222",
     });
-    expect(closeRetirement).toHaveBeenCalledOnce();
-
-    // Repeated disposal should refresh the retirement and retry close
-    await runtime.dispose();
-    expect(refreshRetirement).toHaveBeenCalledOnce();
-    expect(closeRetirement).toHaveBeenCalledTimes(2);
+    expect(mocks.closePlaywrightBrowserConnection).toHaveBeenNthCalledWith(2, {
+      cdpUrl: "http://127.0.0.1:9222",
+    });
 
     await fs.rm(workspaceDir, { recursive: true, force: true });
   });

--- a/extensions/browser/src/attached-browser-tool-runtime.ts
+++ b/extensions/browser/src/attached-browser-tool-runtime.ts
@@ -11,6 +11,10 @@ import { createBrowserTool } from "./browser-tool.js";
 import type { AnyAgentTool } from "./browser-tool.runtime.js";
 import { startBrowserBridgeServer, stopBrowserBridgeServer } from "./browser/bridge-server.js";
 import { resolveBrowserConfig } from "./browser/config.js";
+import {
+  retirePlaywrightBrowserConnectionExact,
+  type PlaywrightConnectionRetirement,
+} from "./browser/pw-session.js";
 import { writeExternalFileWithinRoot } from "./sdk-security-runtime.js";
 
 const ATTACHED_PROFILE_NAME = "worker";
@@ -113,6 +117,21 @@ export async function createAttachedBrowserToolRuntime(
     authToken: randomBytes(32).toString("base64url"),
     onEnsureAttachTarget: async () => await params.ensureAttachTarget(),
   });
+  let adapterRetirement: PlaywrightConnectionRetirement | undefined;
+  const dispose = async () => {
+    try {
+      await stopBrowserBridgeServer(bridge.server);
+    } finally {
+      if (!adapterRetirement) {
+        adapterRetirement = retirePlaywrightBrowserConnectionExact({ cdpUrl });
+      } else {
+        adapterRetirement.refresh();
+      }
+      if (adapterRetirement.retired) {
+        await adapterRetirement.close();
+      }
+    }
+  };
   try {
     const tool = createBrowserTool({
       sandboxBridgeUrl: bridge.baseUrl,
@@ -132,10 +151,10 @@ export async function createAttachedBrowserToolRuntime(
     });
     return {
       tool,
-      dispose: async () => await stopBrowserBridgeServer(bridge.server),
+      dispose,
     };
   } catch (error) {
-    await stopBrowserBridgeServer(bridge.server);
+    await dispose();
     throw error;
   }
 }

--- a/extensions/browser/src/attached-browser-tool-runtime.ts
+++ b/extensions/browser/src/attached-browser-tool-runtime.ts
@@ -11,10 +11,7 @@ import { createBrowserTool } from "./browser-tool.js";
 import type { AnyAgentTool } from "./browser-tool.runtime.js";
 import { startBrowserBridgeServer, stopBrowserBridgeServer } from "./browser/bridge-server.js";
 import { resolveBrowserConfig } from "./browser/config.js";
-import {
-  retirePlaywrightBrowserConnectionExact,
-  type PlaywrightConnectionRetirement,
-} from "./browser/pw-session.js";
+import { closePlaywrightBrowserConnection } from "./browser/pw-session.js";
 import { writeExternalFileWithinRoot } from "./sdk-security-runtime.js";
 
 const ATTACHED_PROFILE_NAME = "worker";
@@ -117,19 +114,11 @@ export async function createAttachedBrowserToolRuntime(
     authToken: randomBytes(32).toString("base64url"),
     onEnsureAttachTarget: async () => await params.ensureAttachTarget(),
   });
-  let adapterRetirement: PlaywrightConnectionRetirement | undefined;
   const dispose = async () => {
     try {
       await stopBrowserBridgeServer(bridge.server);
     } finally {
-      if (!adapterRetirement) {
-        adapterRetirement = retirePlaywrightBrowserConnectionExact({ cdpUrl });
-      } else {
-        adapterRetirement.refresh?.();
-      }
-      if (adapterRetirement.retired) {
-        await adapterRetirement.close();
-      }
+      await closePlaywrightBrowserConnection({ cdpUrl });
     }
   };
   try {

--- a/extensions/browser/src/attached-browser-tool-runtime.ts
+++ b/extensions/browser/src/attached-browser-tool-runtime.ts
@@ -125,7 +125,7 @@ export async function createAttachedBrowserToolRuntime(
       if (!adapterRetirement) {
         adapterRetirement = retirePlaywrightBrowserConnectionExact({ cdpUrl });
       } else {
-        adapterRetirement.refresh();
+        adapterRetirement.refresh?.();
       }
       if (adapterRetirement.retired) {
         await adapterRetirement.close();


### PR DESCRIPTION
Closes #122065

## What Problem This Solves

Fixes an issue where a completed one-shot worker could remain alive after Browser/CDP use because attached-runtime disposal stopped the HTTP bridge but retained the Playwright WebSocket adapter in process-global state.

## Why This Change Was Made

The attached Browser runtime owns one exact CDP adapter but does not own caller Chrome. Its disposer now stops bridge ingress and drains admitted work first, then uses the existing exact scoped close facade for that canonical `cdpUrl`.

Every disposal attempt creates a fresh exact retirement. If disconnect fails, the existing retained-closing map keeps the handle available and a later `dispose()` retries it. Generic bridge shutdown continues preserving shared adapters, and no global cleanup or forced process exit is added.

## User Impact

One-shot workers can finish naturally after Browser actions without leaking a Playwright transport, while caller-owned Chrome remains running and reusable.

## Evidence

- Current-main source reproduction: attached-runtime disposal called only `stopBrowserBridgeServer`; generic bridge shutdown deliberately uses `closeSharedAdapters: false`, while worker terminal cleanup awaits that disposer and relies on natural event-loop exit.
- Installed Playwright `1.62.0` types document that `browser.close()` for a connected browser clears client-created contexts and disconnects from the browser server rather than terminating the existing browser.
- Existing exact-retirement coverage proves scoped close waits for in-flight connection attempts and a fresh second close retries a failed disconnect.
- Maintainer follow-up `9fc22f34663f9576147dfe612b52a5954e9161b6` removes retained local retirement state and changes the runtime retry test to fail once, then succeed on the next disposal.
- Canonical oxfmt, `git diff --check`, direct Playwright source/type inspection, mandatory Codex autoreview, and TruffleHog are clean on the combined branch.
- Production delta: +10/-2 (net +8); tests: +39/-2 (net +37).
- Real worker/CDP proof passed on sanitized direct AWS Crabbox: provider `aws`, lease `cbx_6b415a755e55`, run https://crabbox.openclaw.ai/portal/runs/run_5adbef33943b. A fresh checkout of patch-identical pre-rebase head `a2d21b2c1a34faca7aba512d1e9aa6ff3ffa88fd` used a disposable Chrome and the actual attached Browser tool. Observed: `tabActionCompleted`, original adapter disconnected, fresh adapter created, caller Chrome alive, and `NATURAL_NODE_EXIT=1`. The public/no-Tailscale/no-instance-profile lease was stopped after proof; rebased head `9fc22f34663f9576147dfe612b52a5954e9161b6` preserves the same two-file patch.
- Current exact-head CI is pending and remains the final merge gate.

AI-assisted maintainer follow-up; no agent transcript attached.
