### PR TITLE
fix(slack): retry member events after transient lookup failures

### DIFF
--- a/extensions/slack/src/monitor/events/members.test.ts
+++ b/extensions/slack/src/monitor/events/members.test.ts
@@ -145,6 +145,31 @@ describe("registerSlackMemberEvents", () => {
     expect(trackEvent).toHaveBeenCalledTimes(1);
   });
 
+  it("logs and rejects transient member lookup failures", async () => {
+    const lookupError = new Error("users.info temporarily unavailable");
+    const harness = initSlackHarness();
+    const runtimeError = vi.fn();
+    harness.ctx.runtime.error = runtimeError;
+    harness.ctx.resolveUserName = vi.fn().mockRejectedValue(lookupError);
+    registerSlackMemberEvents({ ctx: harness.ctx });
+    const handler = harness.getHandler("member_joined_channel");
+    if (!handler) {
+      throw new Error("expected Slack member joined handler");
+    }
+
+    await expect(
+      handler({
+        event: makeMemberEvent(),
+        body: { event_id: "Ev-member-failure" },
+      }),
+    ).rejects.toBe(lookupError);
+
+    expect(runtimeError).toHaveBeenCalledWith(
+      expect.stringContaining("users.info temporarily unavailable"),
+    );
+    expect(memberMocks.enqueue).not.toHaveBeenCalled();
+  });
+
   it("keys each queued event by the envelope occurrence", async () => {
     await runMemberCase({ body: { event_id: "Ev-member-2" } });
 

--- a/extensions/slack/src/monitor/events/members.ts
+++ b/extensions/slack/src/monitor/events/members.ts
@@ -66,6 +66,7 @@ export function registerSlackMemberEvents(params: {
       ctx.runtime.error?.(
         danger(`slack ${paramsLocal.verb} handler failed: ${formatErrorMessage(err)}`),
       );
+      throw err;
     }
   };
 


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/actions/runs/31481855862/job/93748583213

## What Problem This Solves

Fixes an issue where Slack member join or leave events could disappear permanently when a transient member lookup failed after durable admission. The handler logged the failure but returned success, so durable ingress completed and deleted the event instead of retaining it for retry.

## Why This Change Was Made

The Slack member-event owner now logs and rethrows lookup failures. Bolt propagates the rejection to durable ingress, which keeps the event pending for its existing retry and restart recovery flow. The production change is exactly one line; the existing durable ingress regression remains the end-to-end proof, with a direct handler rejection test added.

## User Impact

Slack member join and leave events survive transient Slack API failures and are retried after restart instead of being silently lost.

## Evidence

- Qualification failure: the prerelease Slack shard expected `Ev-member-retry` to remain pending, but the queue was empty because the handler swallowed the lookup rejection.
- Exact-head local focused proof on `102b67ec9bb41900def65bdf7464fac208a979a9`: `node scripts/run-vitest.mjs extensions/slack/src/monitor/events/members.test.ts extensions/slack/src/monitor/ingress.test.ts` passed 23/23 tests.
- Exact-head aggregate CI run https://github.com/openclaw/openclaw/actions/runs/31510322849 failed only `extensions/slack/src/monitor/provider.allowlist.test.ts:147`; the one narrow retry reproduced that unrelated failure locally.
- A clean current-main GWT at `b45ddf2754f2092f37df438155148b1e39235680` reproduced the same provider test failure, and current main has no later Slack changes, so rebasing does not resolve it.
- Patch-identical predecessor Blacksmith Testbox proof on `ab1e7635ebb64e5c0de27b3a768b9630e38215c8`: provider `blacksmith-testbox`, lease `tbx_01kzrp0s1agny37x1p5htegkmn`, run https://github.com/openclaw/openclaw/actions/runs/31505626400.
- Path-scoped `pnpm check:changed -- CHANGELOG.md extensions/slack/src/monitor/events/members.ts extensions/slack/src/monitor/events/members.test.ts` passed on that Testbox. The current head preserves its Slack source and test patch byte-for-byte; it only removes the release-owned changelog entry per repository policy.
- Local autoreview: clean, no accepted/actionable findings.
- LOC: production `+1/-0`; tests `+25/-0`.
