### PR TITLE
fix(tlon): surface unavailable inbound images

### DIFF
--- a/extensions/tlon/src/monitor/index.ts
+++ b/extensions/tlon/src/monitor/index.ts
@@ -342,6 +342,7 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
           runtime.log?.(`[tlon] Downloaded ${attachments.length} image(s) from message`);
         }
       } catch (error: unknown) {
+        unavailableMediaCount = 1;
         runtime.log?.(`[tlon] Failed to download images: ${formatErrorMessage(error)}`);
       }
     }
@@ -500,7 +501,9 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
       }
     }
 
-    const promptMedia = buildTlonInboundMediaPrompt(messageText, attachments);
+    const promptMedia = buildTlonInboundMediaPrompt(messageText, attachments, {
+      unavailableCount: unavailableMediaCount,
+    });
 
     const body = createChannelInboundEnvelopeBuilder({ cfg, route })({
       channel: "Tlon",

--- a/extensions/tlon/src/monitor/media.test.ts
+++ b/extensions/tlon/src/monitor/media.test.ts
@@ -66,6 +66,29 @@ describe("tlon monitor media", () => {
     });
   });
 
+  it("appends an unavailable image notice beside the shipped media prompt", () => {
+    expect(
+      buildTlonInboundMediaPrompt("caption", [{ path: "/tmp/a.png", contentType: "image/png" }], {
+        unavailableCount: 2,
+      }),
+    ).toEqual({
+      body: [
+        "[media attached: /tmp/a.png (image/png) | /tmp/a.png]",
+        "caption",
+        "",
+        "[tlon 2 attachments unavailable]",
+      ].join("\n"),
+      media: [{ path: "/tmp/a.png", contentType: "image/png" }],
+    });
+  });
+
+  it("uses the unavailable image notice as the body when no image downloads succeeded", () => {
+    expect(buildTlonInboundMediaPrompt("", [], { unavailableCount: 1 })).toEqual({
+      body: "[tlon attachment unavailable]",
+      media: [],
+    });
+  });
+
   it("stores fetched media through the shared inbound media store with the image cap", async () => {
     saveRemoteMediaMock.mockResolvedValue({
       id: "photo---uuid.png",

--- a/extensions/tlon/src/monitor/media.ts
+++ b/extensions/tlon/src/monitor/media.ts
@@ -2,6 +2,7 @@
 import { randomUUID } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
 import * as path from "node:path";
+import { formatInboundMediaUnavailableText } from "openclaw/plugin-sdk/channel-inbound";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import {
@@ -23,18 +24,32 @@ type TlonInboundMediaDownload = { attachments: TlonInboundMedia[]; unavailableCo
 export function buildTlonInboundMediaPrompt(
   messageText: string,
   attachments: readonly TlonInboundMedia[],
+  options: { unavailableCount?: number } = {},
 ): { body: string; media: TlonInboundMedia[] } {
   const media = attachments.map((attachment) => ({ ...attachment }));
+  const unavailableCount = options.unavailableCount ?? 0;
+  const body =
+    media.length === 0
+      ? messageText
+      : `${media
+          .map(
+            (attachment) =>
+              `[media attached: ${attachment.path} (${attachment.contentType}) | ${attachment.path}]`,
+          )
+          .join("\n")}\n${messageText}`;
+  if (unavailableCount > 0) {
+    return {
+      body: formatInboundMediaUnavailableText({
+        body,
+        notice: `[tlon ${unavailableCount > 1 ? `${unavailableCount} attachments` : "attachment"} unavailable]`,
+      }),
+      media,
+    };
+  }
   if (media.length === 0) {
     return { body: messageText, media };
   }
-  const mediaLines = media
-    .map(
-      (attachment) =>
-        `[media attached: ${attachment.path} (${attachment.contentType}) | ${attachment.path}]`,
-    )
-    .join("\n");
-  return { body: `${mediaLines}\n${messageText}`, media };
+  return { body, media };
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Tlon's media-aware inbound prompt could lose the unavailable-attachment notice even after the media owner counted unavailable images. The message still arrived, but the prompt/envelope text could omit the fact that an attachment was skipped or rejected.

## Why This Change Was Made

Tlon now threads the media owner's `unavailableCount` into the prompt builder while keeping the current main behavior that adds the same notice to `BodyForAgent` without changing raw command text. Unexpected media extraction failures also surface one unavailable attachment instead of only logging the failure.

## User Impact

Agents and reviewers can see when Tlon attachments were unavailable, while command parsing still receives the original message text.

## Evidence

- Real dispatch-boundary proof: `pnpm exec tsx proof-live.ts` ran `extensions/tlon/src/monitor/index.ts` `monitorTlonProvider` against a localhost Urbit login/channel/SSE fixture at exact head `d79b98c5210b0a988e575cc162a2b2f2515b3e3b`.
- Real-path negative control: the same dispatch output shows `CommandBody` stayed byte-identical to the original message and did not receive the unavailable-attachment notice.
- Canonical precedent: shared `formatInboundMediaUnavailableText` channel pattern used by sibling inbound media surfaces.
- Conflict-focused validation: `node scripts/run-vitest.mjs extensions/tlon/src/monitor/media.test.ts extensions/tlon/src/monitor/index.test.ts` passed 2 files / 15 tests; `git diff --check 2dffeae12692f6524a1b624ae49108f6832486bc...HEAD -- extensions/tlon/src/monitor/index.test.ts extensions/tlon/src/monitor/index.ts extensions/tlon/src/monitor/media.test.ts extensions/tlon/src/monitor/media.ts` passed.

```text
$ pnpm exec tsx proof-live.ts
[tlon-media] Rejected non-http(s) URL: file:///tmp/not-remote.png
head: d79b98c5210b0a988e575cc162a2b2f2515b3e3b
entrypoint: extensions/tlon/src/monitor/index.ts monitorTlonProvider
dependency-boundary: localhost Urbit login/channel/SSE fixture
Body: "[Tlon ~nec (owner) Wed 1970-01-21 07:10:00 GMT+8] caption\n\nfile:///tmp/not-remote.png\n\n[tlon attachment unavailable]"
BodyForAgent: "caption\n\nfile:///tmp/not-remote.png\n\n[tlon attachment unavailable]"
CommandBody: "caption\n\nfile:///tmp/not-remote.png"
body-notice-visible: yes
agent-notice-visible: yes
command-notice-control: raw-command-only
```

<details>
<summary>proof-live.ts</summary>

```ts
import { createServer, type ServerResponse } from "node:http";
import { tmpdir } from "node:os";
import { mkdtemp, rm } from "node:fs/promises";
import { join } from "node:path";
import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
import { createChannelIngressQueue } from "./src/channels/message/ingress-queue.js";
import { setTlonRuntime } from "./extensions/tlon/src/runtime.js";
import { monitorTlonProvider } from "./extensions/tlon/src/monitor/index.js";

type CapturedContext = {
  Body?: string;
  BodyForAgent?: string;
  CommandBody?: string;
  RawBody?: string;
};

const head = "d79b98c5210b0a988e575cc162a2b2f2515b3e3b";
const stateDir = await mkdtemp(join(tmpdir(), "openclaw-tlon-proof-"));
process.env.OPENCLAW_HOME = stateDir;
process.env.OPENCLAW_STATE_DIR = stateDir;
let streamResponse: ServerResponse | undefined;

const server = createServer((req, res) => {
  const pathname = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
  if (req.method === "POST" && pathname === "/~/login") {
    res.writeHead(200, {
      "Content-Type": "text/plain",
      "Set-Cookie": "urbauth-~zod=redacted; Path=/",
    });
    res.end("ok");
    return;
  }
  if (req.method === "GET" && pathname.startsWith("/~/scry/")) {
    res.writeHead(200, { "Content-Type": "application/json" });
    res.end("{}");
    return;
  }
  if (req.method === "PUT" && pathname.startsWith("/~/channel/")) {
    req.resume();
    res.writeHead(204);
    res.end();
    return;
  }
  if (req.method === "GET" && pathname.startsWith("/~/channel/")) {
    streamResponse = res;
    res.writeHead(200, {
      "Cache-Control": "no-cache",
      "Content-Type": "text/event-stream",
    });
    res.write(": connected\n\n");
    return;
  }
  res.writeHead(404);
  res.end();
});

await new Promise<void>((resolve, reject) => {
  server.once("error", reject);
  server.listen(0, "127.0.0.1", resolve);
});

const address = server.address();
if (!address || typeof address === "string") {
  throw new Error("localhost proof server did not bind to a TCP port");
}

let capturedContext: CapturedContext | undefined;
let resolveCaptured!: () => void;
const captured = new Promise<void>((resolve) => {
  resolveCaptured = resolve;
});

const cfg = {
  channels: {
    tlon: {
      code: "redacted-code",
      ship: "~zod",
      url: `http://127.0.0.1:${address.port}`,
      network: { dangerouslyAllowPrivateNetwork: true },
      ownerShip: "~nec",
    },
  },
} satisfies OpenClawConfig;

setTlonRuntime({
  config: { current: () => cfg },
  logging: { getChildLogger: () => ({}) },
  state: {
    openChannelIngressQueue: ({ accountId }: { accountId: string }) =>
      createChannelIngressQueue({ channelId: "tlon", accountId, stateDir }),
  },
  channel: {
    commands: { shouldComputeCommandAuthorized: () => false },
    inbound: {
      buildContext: buildChannelInboundEventContext,
      dispatch: async ({ ctxPayload }: { ctxPayload: CapturedContext }) => {
        capturedContext = ctxPayload;
        resolveCaptured();
      },
    },
    reply: { resolveEffectiveMessagesConfig: () => ({ responsePrefix: undefined }) },
    routing: {
      resolveAgentRoute: () => ({
        agentId: "main",
        accountId: "default",
        dmScope: "shared",
        sessionKey: "agent:main:tlon:direct:~nec",
      }),
    },
  },
} as never);

const controller = new AbortController();
const monitor = monitorTlonProvider({
  abortSignal: controller.signal,
  runtime: {
    log: () => undefined,
    error: (message) => console.error(String(message)),
    exit: () => undefined,
  },
});

await new Promise<void>((resolve) => {
  const wait = () => (streamResponse ? resolve() : setTimeout(wait, 10));
  wait();
});

const chatEvent = {
  id: "msg-1",
  whom: "~nec",
  response: {
    add: {
      essay: {
        author: "~nec",
        sent: 1_725_000_000,
        content: [
          { inline: ["caption"] },
          { block: { image: { src: "file:///tmp/not-remote.png" } } },
        ],
      },
    },
  },
};

streamResponse?.write(`id: 1\ndata: ${JSON.stringify({ id: 2, json: chatEvent })}\n\n`);

await Promise.race([
  captured,
  new Promise<never>((_, reject) =>
    setTimeout(() => reject(new Error("timed out waiting for Tlon dispatch")), 5_000),
  ),
]);

controller.abort();
await monitor;
await new Promise<void>((resolve) => server.close(() => resolve()));
await rm(stateDir, { recursive: true, force: true });

console.log(`head: ${head}`);
console.log("entrypoint: extensions/tlon/src/monitor/index.ts monitorTlonProvider");
console.log("dependency-boundary: localhost Urbit login/channel/SSE fixture");
console.log(`Body: ${JSON.stringify(capturedContext?.Body)}`);
console.log(`BodyForAgent: ${JSON.stringify(capturedContext?.BodyForAgent)}`);
console.log(`CommandBody: ${JSON.stringify(capturedContext?.CommandBody)}`);
console.log(
  `body-notice-visible: ${capturedContext?.Body?.includes("[tlon attachment unavailable]") ? "yes" : "no"}`,
);
console.log(
  `agent-notice-visible: ${capturedContext?.BodyForAgent?.includes("[tlon attachment unavailable]") ? "yes" : "no"}`,
);
console.log(
  `command-notice-control: ${capturedContext?.CommandBody?.includes("[tlon attachment unavailable]") ? "unexpected-notice" : "raw-command-only"}`,
);
```

</details>

AI-assisted: built with Codex
