### PR TITLE
refactor(mcp): single OAuth identity owner + resumable authorization session

### DIFF
--- a/src/agents/mcp-auth-profile.test.ts
+++ b/src/agents/mcp-auth-profile.test.ts
@@ -68,8 +68,10 @@ describe("mcp auth profile bearer projection", () => {
     );
     expect(authMocks.resolveMcpOAuthAccessToken).toHaveBeenCalledWith(
       expect.objectContaining({
-        serverName: "docs",
-        serverUrl: "https://mcp.example.com/mcp",
+        identity: expect.objectContaining({
+          serverName: "docs",
+          serverUrl: "https://mcp.example.com/mcp",
+        }),
         config: { scope: "docs.read" },
         fetchFn: expect.any(Function),
       }),

--- a/src/agents/mcp-auth-profile.ts
+++ b/src/agents/mcp-auth-profile.ts
@@ -13,6 +13,7 @@ import {
   withoutMcpAuthorizationHeader,
   withSameOriginMcpHttpHeaders,
 } from "./mcp-http-fetch.js";
+import { operatorMcpOAuthIdentity } from "./mcp-oauth-identity.js";
 import { resolveMcpOAuthAccessToken, type McpOAuthConfig } from "./mcp-oauth.js";
 import { resolveMcpTransportConfig } from "./mcp-transport-config.js";
 
@@ -131,8 +132,7 @@ async function resolveMcpBearerToken(params: {
     resourceUrl: resolved.url,
   });
   return await resolveMcpOAuthAccessToken({
-    serverName: params.serverName,
-    serverUrl: resolved.url,
+    identity: operatorMcpOAuthIdentity(params.serverName, resolved.url),
     config: resolved.oauth as McpOAuthConfig | undefined,
     fetchFn,
   });

--- a/src/agents/mcp-http-fetch.test.ts
+++ b/src/agents/mcp-http-fetch.test.ts
@@ -13,6 +13,7 @@ import {
   withSameOriginMcpHttpHeaders,
 } from "./mcp-http-fetch.js";
 import { withMcpOAuthBearer } from "./mcp-oauth-fetch.js";
+import { operatorMcpOAuthIdentity } from "./mcp-oauth-identity.js";
 
 const testGlobal = globalThis as Record<string, unknown>;
 const TEST_UNDICI_RUNTIME_DEPS_KEY = "__OPENCLAW_TEST_UNDICI_RUNTIME_DEPS__";
@@ -321,8 +322,7 @@ describe("MCP HTTP fetch helpers", () => {
     const fetch = withMcpOAuthBearer({
       fetchFn: buildMcpHttpFetch({ resourceUrl }),
       authFetchFn: buildMcpHttpFetch({ resourceUrl }),
-      serverName: "docs",
-      resourceUrl,
+      identity: operatorMcpOAuthIdentity("docs", resourceUrl),
     });
 
     const response = await fetch(resourceUrl, {

--- a/src/agents/mcp-oauth-fetch.test.ts
+++ b/src/agents/mcp-oauth-fetch.test.ts
@@ -1,11 +1,13 @@
 import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { withMcpOAuthBearer } from "./mcp-oauth-fetch.js";
+import { operatorMcpOAuthIdentity } from "./mcp-oauth-identity.js";
 
 const oauthMocks = vi.hoisted(() => ({
   recordAuthorizationRequired: vi.fn(),
   resolve: vi.fn(),
 }));
+const IDENTITY = operatorMcpOAuthIdentity("docs", "https://mcp.example.com/mcp");
 
 vi.mock("./mcp-oauth.js", () =>
   Object.fromEntries([
@@ -36,8 +38,7 @@ describe("MCP OAuth bearer fetch", () => {
     const wrapped = withMcpOAuthBearer({
       fetchFn,
       authFetchFn: fetchFn,
-      serverName: "docs",
-      resourceUrl: "https://mcp.example.com/mcp",
+      identity: IDENTITY,
     });
 
     await wrapped("https://mcp.example.com/mcp", { headers: { "x-tenant": "docs" } });
@@ -68,8 +69,7 @@ describe("MCP OAuth bearer fetch", () => {
     const wrapped = withMcpOAuthBearer({
       fetchFn,
       authFetchFn: fetchFn,
-      serverName: "docs",
-      resourceUrl: "https://mcp.example.com/mcp",
+      identity: IDENTITY,
       config: { scope: "fallback" },
     });
     const controller = new AbortController();
@@ -108,8 +108,7 @@ describe("MCP OAuth bearer fetch", () => {
     const wrapped = withMcpOAuthBearer({
       fetchFn,
       authFetchFn: fetchFn,
-      serverName: "docs",
-      resourceUrl: "https://mcp.example.com/mcp",
+      identity: IDENTITY,
     });
 
     await expect(wrapped("https://mcp.example.com/mcp")).resolves.toMatchObject({ status: 200 });
@@ -138,8 +137,7 @@ describe("MCP OAuth bearer fetch", () => {
     const wrapped = withMcpOAuthBearer({
       fetchFn,
       authFetchFn: fetchFn,
-      serverName: "docs",
-      resourceUrl: "https://mcp.example.com/mcp",
+      identity: IDENTITY,
     });
 
     const response = await wrapped(
@@ -173,8 +171,7 @@ describe("MCP OAuth bearer fetch", () => {
     const wrapped = withMcpOAuthBearer({
       fetchFn,
       authFetchFn: fetchFn,
-      serverName: "docs",
-      resourceUrl: "https://mcp.example.com/mcp",
+      identity: IDENTITY,
     });
 
     await expect(wrapped("https://mcp.example.com/mcp")).rejects.toBe(loginRequired);
@@ -199,8 +196,7 @@ describe("MCP OAuth bearer fetch", () => {
     const wrapped = withMcpOAuthBearer({
       fetchFn,
       authFetchFn: fetchFn,
-      serverName: "docs",
-      resourceUrl: "https://mcp.example.com/mcp",
+      identity: IDENTITY,
     });
 
     await expect(wrapped("https://mcp.example.com/mcp")).resolves.toMatchObject({ status: 401 });
@@ -208,9 +204,8 @@ describe("MCP OAuth bearer fetch", () => {
     expect(oauthMocks.resolve).toHaveBeenCalledTimes(2);
     expect(oauthMocks.recordAuthorizationRequired).toHaveBeenCalledWith(
       expect.objectContaining({
+        identity: IDENTITY,
         rejectedAccessToken: "test-auth-token",
-        serverName: "docs",
-        serverUrl: "https://mcp.example.com/mcp",
       }),
     );
   });

--- a/src/agents/mcp-oauth-fetch.ts
+++ b/src/agents/mcp-oauth-fetch.ts
@@ -1,5 +1,6 @@
 import { extractWWWAuthenticateParams } from "@modelcontextprotocol/sdk/client/auth.js";
 import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { McpOAuthIdentity } from "./mcp-oauth-identity.js";
 import {
   recordMcpOAuthAuthorizationRequired,
   resolveMcpOAuthAccessToken,
@@ -47,11 +48,10 @@ async function dispatchRequest(fetchFn: FetchLike, request: Request): Promise<Re
 export function withMcpOAuthBearer(params: {
   fetchFn: FetchLike;
   authFetchFn: FetchLike;
-  serverName: string;
-  resourceUrl: string;
+  identity: McpOAuthIdentity;
   config?: McpOAuthConfig;
 }): McpOAuthFetch {
-  const resourceOrigin = new URL(params.resourceUrl).origin;
+  const resourceOrigin = new URL(params.identity.serverUrl).origin;
   return async (input, init) => {
     const source = input instanceof Request ? input.clone() : input;
     const request = new Request(source, init);
@@ -60,8 +60,7 @@ export function withMcpOAuthBearer(params: {
     }
 
     const accessToken = await resolveMcpOAuthAccessToken({
-      serverName: params.serverName,
-      serverUrl: params.resourceUrl,
+      identity: params.identity,
       config: params.config,
       fetchFn: params.authFetchFn,
       // Resource feedback can reject an unknown-expiry token. Avoid rotating it
@@ -84,8 +83,7 @@ export function withMcpOAuthBearer(params: {
     // first request's dispatcher lease across discovery/refresh.
     await response.body?.cancel().catch(() => undefined);
     const nextAccessToken = await resolveMcpOAuthAccessToken({
-      serverName: params.serverName,
-      serverUrl: params.resourceUrl,
+      identity: params.identity,
       config: params.config,
       fetchFn: params.authFetchFn,
       acceptUnknownExpiry: true,
@@ -104,8 +102,7 @@ export function withMcpOAuthBearer(params: {
     if (retryResponse.status === 401 || retryInsufficientScope) {
       const rejectedAccessToken = nextAccessToken;
       await recordMcpOAuthAuthorizationRequired({
-        serverName: params.serverName,
-        serverUrl: params.resourceUrl,
+        identity: params.identity,
         rejectedAccessToken,
         resourceMetadataUrl: retryChallenge.resourceMetadataUrl ?? challenge.resourceMetadataUrl,
         scope: retryChallenge.scope ?? challenge.scope,

--- a/src/agents/mcp-oauth-identity.ts
+++ b/src/agents/mcp-oauth-identity.ts
@@ -1,0 +1,27 @@
+import { createHash } from "node:crypto";
+import { sanitizeServerName } from "./agent-bundle-mcp-names.js";
+
+/** Identity of one principal's OAuth state for one MCP server. */
+export type McpOAuthIdentity = {
+  storeKey: string;
+  principal: "operator";
+  serverName: string;
+  serverUrl: string;
+};
+
+export function operatorMcpOAuthIdentity(serverName: string, serverUrl: string): McpOAuthIdentity {
+  const safeServerName = sanitizeServerName(serverName, new Set<string>());
+  const hash = createHash("sha256").update(serverName).update("\0").update(serverUrl).digest("hex");
+  return {
+    storeKey: `${safeServerName}-${hash.slice(0, 16)}`,
+    principal: "operator",
+    serverName,
+    serverUrl,
+  };
+}
+
+export function mcpOAuthStoreKeyFromLegacyFileName(fileName: string): string | null {
+  return /^[A-Za-z][A-Za-z0-9_-]{0,29}-[0-9a-f]{16}\.json$/u.test(fileName)
+    ? fileName.slice(0, -".json".length)
+    : null;
+}

--- a/src/agents/mcp-oauth-provider.ts
+++ b/src/agents/mcp-oauth-provider.ts
@@ -6,12 +6,8 @@ import type { OAuthClientMetadata, OAuthTokens } from "@modelcontextprotocol/sdk
 import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawStateLeaseContext } from "../state/openclaw-state-lease.js";
-import {
-  readMcpOAuthStore,
-  resolveMcpOAuthStoreKey,
-  updateMcpOAuthStore,
-  type McpOAuthStore,
-} from "./mcp-oauth-store.js";
+import type { McpOAuthIdentity } from "./mcp-oauth-identity.js";
+import { readMcpOAuthStore, updateMcpOAuthStore, type McpOAuthStore } from "./mcp-oauth-store.js";
 
 export type McpOAuthConfig = {
   scope?: unknown;
@@ -82,25 +78,21 @@ function beginMcpOAuthAuthorization(store: McpOAuthStore): McpOAuthStore {
 
 /** Creates the MCP SDK OAuth provider backed by canonical shared SQLite state. */
 export function createMcpOAuthClientProvider(params: {
-  serverName: string;
-  serverUrl: string;
+  identity: McpOAuthIdentity;
   config?: McpOAuthConfig;
-  onAuthorizationUrl?: (url: URL) => void | Promise<void>;
   allowAuthorizationRedirect?: boolean;
   suppressStoredTokens?: boolean;
   lease?: OpenClawStateLeaseContext;
 }): OAuthClientProvider {
   const config = params.config ?? {};
-  const storeKey = resolveMcpOAuthStoreKey(params.serverName, params.serverUrl);
+  const storeKey = params.identity.storeKey;
   const assertOwnedInTransaction = bindMcpOAuthLeaseAssertion(params.lease);
   const updateStore = (update: (store: McpOAuthStore) => McpOAuthStore) =>
     updateMcpOAuthStore(storeKey, update, assertOwnedInTransaction);
-  const allowAuthorizationRedirect =
-    params.allowAuthorizationRedirect ?? Boolean(params.onAuthorizationUrl);
   const assertAuthorizationRedirectAllowed = () => {
-    if (!allowAuthorizationRedirect) {
+    if (params.allowAuthorizationRedirect !== true) {
       throw new Error(
-        `MCP server "${params.serverName}" requires OAuth authorization. Run openclaw mcp login ${params.serverName}.`,
+        `MCP server "${params.identity.serverName}" requires OAuth authorization. Run openclaw mcp login ${params.identity.serverName}.`,
       );
     }
   };
@@ -162,8 +154,8 @@ export function createMcpOAuthClientProvider(params: {
       updateStore((store) => ({
         ...beginMcpOAuthAuthorization(store),
         lastAuthorizationUrl: authorizationUrl.toString(),
+        redirectUrl: resolveOAuthRedirectUrl(config, store),
       }));
-      await params.onAuthorizationUrl?.(authorizationUrl);
     },
     saveCodeVerifier(codeVerifier) {
       assertAuthorizationRedirectAllowed();

--- a/src/agents/mcp-oauth-refresh-issuer.test.ts
+++ b/src/agents/mcp-oauth-refresh-issuer.test.ts
@@ -4,8 +4,9 @@ import { withTempHome as withBaseTempHome } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withMcpOAuthBearer } from "./mcp-oauth-fetch.js";
+import { operatorMcpOAuthIdentity } from "./mcp-oauth-identity.js";
 import { createMcpOAuthClientProvider } from "./mcp-oauth-provider.js";
-import { readMcpOAuthStore, resolveMcpOAuthStoreKey } from "./mcp-oauth-store.js";
+import { readMcpOAuthStore } from "./mcp-oauth-store.js";
 
 const SERVER_NAME = "Remote Docs";
 const SERVER_URL = "https://mcp.example.com/mcp";
@@ -15,6 +16,7 @@ const ORIGINAL_ISSUER = "https://auth-old.example";
 const REPLACEMENT_ISSUER = "https://auth-new.example";
 const STORED_ACCESS = "stored-access";
 const STORED_REFRESH = "stored-refresh-secret";
+const IDENTITY = operatorMcpOAuthIdentity(SERVER_NAME, SERVER_URL);
 
 async function withTempHome<T>(
   run: () => T | Promise<T>,
@@ -98,8 +100,7 @@ async function seedAuthorizedStore(
   expiresIn = 3600,
 ) {
   const provider = createMcpOAuthClientProvider({
-    serverName: SERVER_NAME,
-    serverUrl: SERVER_URL,
+    identity: IDENTITY,
   });
   const discoveryState = {
     authorizationServerUrl: ORIGINAL_ISSUER,
@@ -125,13 +126,12 @@ function buildOAuthFetch(fetchFn: FetchLike) {
   return withMcpOAuthBearer({
     fetchFn,
     authFetchFn: fetchFn,
-    serverName: SERVER_NAME,
-    resourceUrl: SERVER_URL,
+    identity: IDENTITY,
   });
 }
 
 function readStore() {
-  return readMcpOAuthStore(resolveMcpOAuthStoreKey(SERVER_NAME, SERVER_URL));
+  return readMcpOAuthStore(IDENTITY.storeKey);
 }
 
 const TEMP_HOME_OPTIONS = {
@@ -212,8 +212,7 @@ describe("MCP OAuth refresh issuer binding", () => {
         async () => {
           await seedAuthorizedStore("discovery-then-tokens");
           const provider = createMcpOAuthClientProvider({
-            serverName: SERVER_NAME,
-            serverUrl: SERVER_URL,
+            identity: IDENTITY,
           });
           await provider.saveDiscoveryState?.({
             authorizationServerUrl: issuer,
@@ -315,8 +314,7 @@ describe("MCP OAuth refresh issuer binding", () => {
     await withTempHome(
       async () => {
         const provider = createMcpOAuthClientProvider({
-          serverName: SERVER_NAME,
-          serverUrl: SERVER_URL,
+          identity: IDENTITY,
         });
         await provider.saveClientInformation?.({ client_id: "stored-client-id" });
         await provider.saveTokens({

--- a/src/agents/mcp-oauth-refresh.test.ts
+++ b/src/agents/mcp-oauth-refresh.test.ts
@@ -7,13 +7,15 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
+import { operatorMcpOAuthIdentity } from "./mcp-oauth-identity.js";
 import { createMcpOAuthClientProvider, withMcpOAuthLeaseSignal } from "./mcp-oauth-provider.js";
-import { readMcpOAuthStore, resolveMcpOAuthStoreKey } from "./mcp-oauth-store.js";
+import { readMcpOAuthStore } from "./mcp-oauth-store.js";
 import { clearMcpOAuthCredentials, resolveMcpOAuthAccessToken } from "./mcp-oauth.js";
 
 const authMock = vi.hoisted(() => vi.fn());
 const FRESH_ACCESS = "test-token-placeholder";
 const ROTATED_ACCESS = "gateway-token";
+const IDENTITY = operatorMcpOAuthIdentity("Remote Docs", "https://mcp.example.com/mcp");
 
 vi.mock("@modelcontextprotocol/sdk/client/auth.js", () => ({
   auth: authMock,
@@ -77,8 +79,7 @@ describe("MCP OAuth provider", () => {
     await withTempHome(
       async () => {
         const provider = createMcpOAuthClientProvider({
-          serverName: "Remote Docs",
-          serverUrl: "https://mcp.example.com/mcp",
+          identity: IDENTITY,
         });
         await provider.saveTokens({
           access_token: "test-token-placeholder",
@@ -89,8 +90,7 @@ describe("MCP OAuth provider", () => {
 
         await expect(
           resolveMcpOAuthAccessToken({
-            serverName: "Remote Docs",
-            serverUrl: "https://mcp.example.com/mcp",
+            identity: IDENTITY,
           }),
         ).resolves.toBe(FRESH_ACCESS);
         expect(authMock).not.toHaveBeenCalled();
@@ -109,9 +109,7 @@ describe("MCP OAuth provider", () => {
   it("aborts an in-flight refresh, preserves tokens, and releases its lease", async () => {
     await withTempHome(
       async () => {
-        const serverName = "Remote Docs";
-        const serverUrl = "https://mcp.example.com/mcp";
-        const provider = createMcpOAuthClientProvider({ serverName, serverUrl });
+        const provider = createMcpOAuthClientProvider({ identity: IDENTITY });
         await provider.saveTokens({
           access_token: "decoy-token",
           refresh_token: "test-auth-token",
@@ -146,8 +144,7 @@ describe("MCP OAuth provider", () => {
         const controller = new AbortController();
 
         const refresh = resolveMcpOAuthAccessToken({
-          serverName,
-          serverUrl,
+          identity: IDENTITY,
           fetchFn,
           signal: controller.signal,
         });
@@ -177,8 +174,7 @@ describe("MCP OAuth provider", () => {
     await withTempHome(
       async () => {
         const provider = createMcpOAuthClientProvider({
-          serverName: "Remote Docs",
-          serverUrl: "https://mcp.example.com/mcp",
+          identity: IDENTITY,
         });
         await provider.saveTokens({
           access_token: "decoy-token",
@@ -198,8 +194,7 @@ describe("MCP OAuth provider", () => {
 
         await expect(
           resolveMcpOAuthAccessToken({
-            serverName: "Remote Docs",
-            serverUrl: "https://mcp.example.com/mcp",
+            identity: IDENTITY,
             config: { scope: "docs.read" },
           }),
         ).resolves.toBe(ROTATED_ACCESS);
@@ -224,8 +219,7 @@ describe("MCP OAuth provider", () => {
     await withTempHome(
       async () => {
         const provider = createMcpOAuthClientProvider({
-          serverName: "Remote Docs",
-          serverUrl: "https://mcp.example.com/mcp",
+          identity: IDENTITY,
         });
         await provider.saveTokens({
           access_token: "decoy-token",
@@ -255,13 +249,11 @@ describe("MCP OAuth provider", () => {
         });
 
         const first = resolveMcpOAuthAccessToken({
-          serverName: "Remote Docs",
-          serverUrl: "https://mcp.example.com/mcp",
+          identity: IDENTITY,
         });
         await refreshStarted;
         const second = resolveMcpOAuthAccessToken({
-          serverName: "Remote Docs",
-          serverUrl: "https://mcp.example.com/mcp",
+          identity: IDENTITY,
         });
         releaseRefresh?.();
 
@@ -286,8 +278,7 @@ describe("MCP OAuth provider", () => {
     await withTempHome(
       async () => {
         const provider = createMcpOAuthClientProvider({
-          serverName: "Remote Docs",
-          serverUrl: "https://mcp.example.com/mcp",
+          identity: IDENTITY,
         });
         await provider.saveTokens({
           access_token: "decoy-token",
@@ -317,16 +308,14 @@ describe("MCP OAuth provider", () => {
         });
 
         const first = resolveMcpOAuthAccessToken({
-          serverName: "Remote Docs",
-          serverUrl: "https://mcp.example.com/mcp",
+          identity: IDENTITY,
           authorizationChallenge: true,
           rejectedAccessToken: "decoy-token",
           scope: "docs.read",
         });
         await refreshStarted;
         const second = resolveMcpOAuthAccessToken({
-          serverName: "Remote Docs",
-          serverUrl: "https://mcp.example.com/mcp",
+          identity: IDENTITY,
           authorizationChallenge: true,
           rejectedAccessToken: "decoy-token",
           scope: "stale.scope",
@@ -338,10 +327,7 @@ describe("MCP OAuth provider", () => {
           ROTATED_ACCESS,
         ]);
         expect(authMock).toHaveBeenCalledOnce();
-        expect(
-          readMcpOAuthStore(resolveMcpOAuthStoreKey("Remote Docs", "https://mcp.example.com/mcp"))
-            .pendingAuthorizationChallenge,
-        ).toBeUndefined();
+        expect(readMcpOAuthStore(IDENTITY.storeKey).pendingAuthorizationChallenge).toBeUndefined();
       },
       {
         prefix: "openclaw-mcp-oauth-concurrent-challenge-",
@@ -355,8 +341,7 @@ describe("MCP OAuth provider", () => {
     await withTempHome(
       async () => {
         const provider = createMcpOAuthClientProvider({
-          serverName: "Remote Docs",
-          serverUrl: "https://mcp.example.com/mcp",
+          identity: IDENTITY,
         });
         await provider.saveTokens({
           access_token: "decoy-token",
@@ -385,14 +370,10 @@ describe("MCP OAuth provider", () => {
         });
 
         const refresh = resolveMcpOAuthAccessToken({
-          serverName: "Remote Docs",
-          serverUrl: "https://mcp.example.com/mcp",
+          identity: IDENTITY,
         });
         await started;
-        const logout = clearMcpOAuthCredentials({
-          serverName: "Remote Docs",
-          serverUrl: "https://mcp.example.com/mcp",
-        });
+        const logout = clearMcpOAuthCredentials(IDENTITY);
         releaseRefresh?.();
 
         await expect(refresh).resolves.toBe(ROTATED_ACCESS);
@@ -411,8 +392,7 @@ describe("MCP OAuth provider", () => {
     await withTempHome(
       async () => {
         const provider = createMcpOAuthClientProvider({
-          serverName: "Remote Docs",
-          serverUrl: "https://mcp.example.com/mcp",
+          identity: IDENTITY,
         });
         await provider.saveTokens({
           access_token: "decoy-token",
@@ -432,8 +412,7 @@ describe("MCP OAuth provider", () => {
 
         await expect(
           resolveMcpOAuthAccessToken({
-            serverName: "Remote Docs",
-            serverUrl: "https://mcp.example.com/mcp",
+            identity: IDENTITY,
             authorizationChallenge: true,
             rejectedAccessToken: "decoy-token",
             resourceMetadataUrl: new URL(
@@ -443,10 +422,7 @@ describe("MCP OAuth provider", () => {
           }),
         ).resolves.toBe(ROTATED_ACCESS);
         expect(authMock).toHaveBeenCalledOnce();
-        expect(
-          readMcpOAuthStore(resolveMcpOAuthStoreKey("Remote Docs", "https://mcp.example.com/mcp"))
-            .pendingAuthorizationChallenge,
-        ).toBeUndefined();
+        expect(readMcpOAuthStore(IDENTITY.storeKey).pendingAuthorizationChallenge).toBeUndefined();
       },
       {
         prefix: "openclaw-mcp-oauth-rejected-token-",

--- a/src/agents/mcp-oauth-store.ts
+++ b/src/agents/mcp-oauth-store.ts
@@ -1,5 +1,4 @@
 // Canonical MCP OAuth session state. Legacy JSON import belongs to doctor only.
-import { createHash } from "node:crypto";
 import fs from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
 import type { OAuthDiscoveryState } from "@modelcontextprotocol/sdk/client/auth.js";
@@ -26,7 +25,6 @@ import {
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
-import { sanitizeServerName } from "./agent-bundle-mcp-names.js";
 
 type McpOAuthDatabase = Pick<OpenClawStateKyselyDatabase, "mcp_oauth_stores">;
 
@@ -206,12 +204,6 @@ export function parseMcpOAuthStoreJson(storeKey: string, raw: string): McpOAuthS
   assertDiscoveryState(storeKey, value.discoveryState);
   assertAuthorizationChallenge(storeKey, value.pendingAuthorizationChallenge);
   return value as McpOAuthStore;
-}
-
-export function resolveMcpOAuthStoreKey(serverName: string, serverUrl: string): string {
-  const safeServerName = sanitizeServerName(serverName, new Set<string>());
-  const hash = createHash("sha256").update(serverName).update("\0").update(serverUrl).digest("hex");
-  return `${safeServerName}-${hash.slice(0, 16)}`;
 }
 
 function storeFromRow(

--- a/src/agents/mcp-oauth.test.ts
+++ b/src/agents/mcp-oauth.test.ts
@@ -121,7 +121,10 @@ async function startAuthorizationServer(port: number) {
   });
   return {
     issuer,
-    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
   };
 }
 

--- a/src/agents/mcp-oauth.test.ts
+++ b/src/agents/mcp-oauth.test.ts
@@ -1,5 +1,7 @@
 // Covers MCP OAuth token persistence, isolation, and noninteractive behavior.
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import path from "node:path";
 import { withTempHome as withBaseTempHome } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -9,23 +11,127 @@ import {
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { getFreePort } from "../test-utils/ports.js";
+import { operatorMcpOAuthIdentity, type McpOAuthIdentity } from "./mcp-oauth-identity.js";
 import { createMcpOAuthClientProvider } from "./mcp-oauth-provider.js";
-import {
-  readMcpOAuthStore,
-  resolveMcpOAuthStoreKey,
-  updateMcpOAuthStore,
-} from "./mcp-oauth-store.js";
+import { readMcpOAuthStore, updateMcpOAuthStore } from "./mcp-oauth-store.js";
 import {
   clearMcpOAuthCredentials,
+  completeMcpOAuthAuthorization,
   readMcpOAuthCredentialsStatus,
   recordMcpOAuthAuthorizationRequired,
   resolveMcpOAuthAccessToken,
-  runMcpOAuthLogin,
+  startMcpOAuthAuthorization,
 } from "./mcp-oauth.js";
 
 const authMock = vi.hoisted(() => vi.fn());
 const ROTATED_ACCESS = "gateway-token";
 const LEGACY_ACCESS = "example";
+const REMOTE_IDENTITY = operatorMcpOAuthIdentity("Remote Docs", "https://mcp.example.com/mcp");
+const CALENDLY_IDENTITY = operatorMcpOAuthIdentity("Calendly", "https://mcp.calendly.com/");
+
+function resolvedOAuthConfig(identity: McpOAuthIdentity) {
+  return {
+    kind: "http" as const,
+    transportType: "streamable-http" as const,
+    url: identity.serverUrl,
+    auth: "oauth" as const,
+    description: identity.serverUrl,
+    connectionTimeoutMs: 30_000,
+    requestTimeoutMs: 60_000,
+    supportsParallelToolCalls: false,
+  };
+}
+
+async function persistRedirect(provider: ReturnType<typeof createMcpOAuthClientProvider>) {
+  await provider.saveCodeVerifier("verifier");
+  const authorizationUrl = new URL("https://auth.example.com/authorize");
+  authorizationUrl.searchParams.set("redirect_uri", String(provider.redirectUrl));
+  authorizationUrl.searchParams.set("state", "state-1234567890");
+  await provider.redirectToAuthorization(authorizationUrl);
+  return "REDIRECT" as const;
+}
+
+function sendOAuthJson(response: ServerResponse, body: unknown, status = 200): void {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+}
+
+async function readOAuthBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function startAuthorizationServer(port: number) {
+  const issuer = `http://127.0.0.1:${port}`;
+  const handleRequest = async (request: IncomingMessage, response: ServerResponse) => {
+    const url = new URL(request.url ?? "/", issuer);
+    if (url.pathname.startsWith("/.well-known/oauth-protected-resource")) {
+      sendOAuthJson(response, { resource: `${issuer}/mcp`, authorization_servers: [issuer] });
+      return;
+    }
+    if (url.pathname === "/.well-known/oauth-authorization-server") {
+      sendOAuthJson(response, {
+        issuer,
+        authorization_endpoint: `${issuer}/authorize`,
+        token_endpoint: `${issuer}/token`,
+        registration_endpoint: `${issuer}/register`,
+        response_types_supported: ["code"],
+        grant_types_supported: ["authorization_code", "refresh_token"],
+        token_endpoint_auth_methods_supported: ["none"],
+        code_challenge_methods_supported: ["S256"],
+      });
+      return;
+    }
+    if (url.pathname === "/register" && request.method === "POST") {
+      const metadata = JSON.parse(await readOAuthBody(request)) as Record<string, unknown>;
+      sendOAuthJson(response, { ...metadata, client_id: "fixture-client" }, 201);
+      return;
+    }
+    if (url.pathname === "/token" && request.method === "POST") {
+      const form = new URLSearchParams(await readOAuthBody(request));
+      const challenge = createHash("sha256")
+        .update(form.get("code_verifier") ?? "")
+        .digest("base64url");
+      if (form.get("code") !== challenge) {
+        sendOAuthJson(response, { error: "invalid_grant" }, 400);
+        return;
+      }
+      sendOAuthJson(response, {
+        access_token: `access-${challenge.slice(0, 8)}`,
+        refresh_token: "fixture-refresh",
+        token_type: "Bearer",
+        expires_in: 3600,
+      });
+      return;
+    }
+    response.writeHead(404).end();
+  };
+  const server = createServer((request, response) => {
+    void handleRequest(request, response).catch((error: unknown) => {
+      response.destroy(error instanceof Error ? error : new Error("OAuth fixture failed"));
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", resolve);
+  });
+  return {
+    issuer,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+function authorizationCode(authorizationUrl: string): string {
+  const code = new URL(authorizationUrl).searchParams.get("code_challenge");
+  if (!code) {
+    throw new Error("authorization URL omitted the PKCE challenge");
+  }
+  return code;
+}
 
 vi.mock("@modelcontextprotocol/sdk/client/auth.js", () => ({
   auth: authMock,
@@ -64,8 +170,7 @@ describe("MCP OAuth provider", () => {
     await withTempHome(
       async () => {
         const provider = createMcpOAuthClientProvider({
-          serverName: "Remote Docs",
-          serverUrl: "https://mcp.example.com/mcp",
+          identity: REMOTE_IDENTITY,
         });
         await provider.saveTokens({
           access_token: "decoy-token",
@@ -76,8 +181,7 @@ describe("MCP OAuth provider", () => {
 
         await expect(
           resolveMcpOAuthAccessToken({
-            serverName: "Remote Docs",
-            serverUrl: "https://mcp.example.com/mcp",
+            identity: REMOTE_IDENTITY,
             authorizationChallenge: true,
             interactiveAuthorizationRequired: true,
             rejectedAccessToken: "decoy-token",
@@ -91,26 +195,20 @@ describe("MCP OAuth provider", () => {
           access_token: "decoy-token",
           refresh_token: "test-auth-token",
         });
-        expect(
-          readMcpOAuthStore(resolveMcpOAuthStoreKey("Remote Docs", "https://mcp.example.com/mcp"))
-            .pendingAuthorizationChallenge,
-        ).toEqual({
+        expect(readMcpOAuthStore(REMOTE_IDENTITY.storeKey).pendingAuthorizationChallenge).toEqual({
           requiresAuthorization: true,
           scope: "docs.write",
         });
-        await expect(
-          readMcpOAuthCredentialsStatus({
-            serverName: "Remote Docs",
-            serverUrl: "https://mcp.example.com/mcp",
-          }),
-        ).resolves.toMatchObject({ hasTokens: true, requiresAuthorization: true });
+        await expect(readMcpOAuthCredentialsStatus(REMOTE_IDENTITY)).resolves.toMatchObject({
+          hasTokens: true,
+          requiresAuthorization: true,
+        });
 
-        const storeKey = resolveMcpOAuthStoreKey("Remote Docs", "https://mcp.example.com/mcp");
+        const storeKey = REMOTE_IDENTITY.storeKey;
         updateMcpOAuthStore(storeKey, (store) => ({ ...store, tokenExpiresAt: 0 }));
         await expect(
           resolveMcpOAuthAccessToken({
-            serverName: "Remote Docs",
-            serverUrl: "https://mcp.example.com/mcp",
+            identity: REMOTE_IDENTITY,
           }),
         ).rejects.toThrow("requires additional OAuth authorization");
         expect(authMock).not.toHaveBeenCalled();
@@ -126,26 +224,20 @@ describe("MCP OAuth provider", () => {
         authMock.mockImplementationOnce(async (loginProvider, options) => {
           expect(await loginProvider.tokens()).toBeUndefined();
           expect(options.scope).toBe("docs.write");
-          return "REDIRECT";
+          return await persistRedirect(loginProvider);
         });
         await expect(
-          runMcpOAuthLogin({
-            serverName: "Remote Docs",
-            serverUrl: "https://mcp.example.com/mcp",
-          }),
-        ).resolves.toBe("redirect");
+          startMcpOAuthAuthorization(REMOTE_IDENTITY, resolvedOAuthConfig(REMOTE_IDENTITY), {}),
+        ).resolves.toMatchObject({ state: "state-1234567890" });
         expect(provider.tokens()).toMatchObject({ access_token: "decoy-token" });
 
         authMock.mockImplementationOnce(async (loginProvider) => {
           await loginProvider.invalidateCredentials?.("tokens");
-          await loginProvider.invalidateCredentials?.("all");
           throw new Error("replacement authorization failed");
         });
         await expect(
-          runMcpOAuthLogin({
-            serverName: "Remote Docs",
-            serverUrl: "https://mcp.example.com/mcp",
-            authorizationCode: "expired-code",
+          completeMcpOAuthAuthorization(REMOTE_IDENTITY, resolvedOAuthConfig(REMOTE_IDENTITY), {
+            code: "expired-code",
           }),
         ).rejects.toThrow("replacement authorization failed");
         expect(readMcpOAuthStore(storeKey)).toMatchObject({
@@ -164,10 +256,8 @@ describe("MCP OAuth provider", () => {
           return "AUTHORIZED";
         });
         await expect(
-          runMcpOAuthLogin({
-            serverName: "Remote Docs",
-            serverUrl: "https://mcp.example.com/mcp",
-            authorizationCode: "valid-code",
+          completeMcpOAuthAuthorization(REMOTE_IDENTITY, resolvedOAuthConfig(REMOTE_IDENTITY), {
+            code: "valid-code",
           }),
         ).resolves.toBe("authorized");
         expect(readMcpOAuthStore(storeKey)).toMatchObject({
@@ -186,9 +276,7 @@ describe("MCP OAuth provider", () => {
   it("stops refreshing after a replacement token is rejected twice", async () => {
     await withTempHome(
       async () => {
-        const serverName = "Remote Docs";
-        const serverUrl = "https://mcp.example.com/mcp";
-        const provider = createMcpOAuthClientProvider({ serverName, serverUrl });
+        const provider = createMcpOAuthClientProvider({ identity: REMOTE_IDENTITY });
         await provider.saveTokens({
           access_token: "replacement-token",
           refresh_token: "replacement-refresh",
@@ -198,13 +286,12 @@ describe("MCP OAuth provider", () => {
 
         await expect(
           recordMcpOAuthAuthorizationRequired({
-            serverName,
-            serverUrl,
+            identity: REMOTE_IDENTITY,
             rejectedAccessToken: "replacement-token",
             scope: "docs.read",
           }),
         ).resolves.toBe(true);
-        await expect(resolveMcpOAuthAccessToken({ serverName, serverUrl })).rejects.toThrow(
+        await expect(resolveMcpOAuthAccessToken({ identity: REMOTE_IDENTITY })).rejects.toThrow(
           "requires additional OAuth authorization",
         );
         expect(authMock).not.toHaveBeenCalled();
@@ -218,8 +305,7 @@ describe("MCP OAuth provider", () => {
         });
         await expect(
           recordMcpOAuthAuthorizationRequired({
-            serverName,
-            serverUrl,
+            identity: REMOTE_IDENTITY,
             rejectedAccessToken: "replacement-token",
           }),
         ).resolves.toBe(false);
@@ -237,8 +323,7 @@ describe("MCP OAuth provider", () => {
     await withTempHome(
       async () => {
         const provider = createMcpOAuthClientProvider({
-          serverName: "Remote Docs",
-          serverUrl: "https://mcp.example.com/mcp",
+          identity: REMOTE_IDENTITY,
         });
         await provider.saveTokens({
           access_token: "decoy-token",
@@ -257,34 +342,25 @@ describe("MCP OAuth provider", () => {
 
         await expect(
           resolveMcpOAuthAccessToken({
-            serverName: "Remote Docs",
-            serverUrl: "https://mcp.example.com/mcp",
+            identity: REMOTE_IDENTITY,
             authorizationChallenge: true,
             rejectedAccessToken: "decoy-token",
             resourceMetadataUrl,
             scope: "docs.write",
           }),
         ).rejects.toThrow("scope refresh rejected");
-        expect(
-          readMcpOAuthStore(resolveMcpOAuthStoreKey("Remote Docs", "https://mcp.example.com/mcp")),
-        ).toMatchObject({
+        expect(readMcpOAuthStore(REMOTE_IDENTITY.storeKey)).toMatchObject({
           pendingAuthorizationChallenge: {
             resourceMetadataUrl: resourceMetadataUrl.toString(),
             scope: "docs.write",
           },
         });
-        expect(
-          readMcpOAuthStore(resolveMcpOAuthStoreKey("Remote Docs", "https://mcp.example.com/mcp"))
-            .discoveryState,
-        ).toBeUndefined();
+        expect(readMcpOAuthStore(REMOTE_IDENTITY.storeKey).discoveryState).toBeUndefined();
 
-        authMock.mockResolvedValueOnce("REDIRECT");
+        authMock.mockImplementationOnce(persistRedirect);
         await expect(
-          runMcpOAuthLogin({
-            serverName: "Remote Docs",
-            serverUrl: "https://mcp.example.com/mcp",
-          }),
-        ).resolves.toBe("redirect");
+          startMcpOAuthAuthorization(REMOTE_IDENTITY, resolvedOAuthConfig(REMOTE_IDENTITY), {}),
+        ).resolves.toMatchObject({ state: "state-1234567890" });
         expect(authMock.mock.calls[1]?.[1]).toMatchObject({
           resourceMetadataUrl,
           scope: "docs.write",
@@ -301,13 +377,11 @@ describe("MCP OAuth provider", () => {
   it("uses a persisted challenge when refreshing after Doctor credential import", async () => {
     await withTempHome(
       async () => {
-        const serverName = "Remote Docs";
-        const serverUrl = "https://mcp.example.com/mcp";
-        const storeKey = resolveMcpOAuthStoreKey(serverName, serverUrl);
+        const storeKey = REMOTE_IDENTITY.storeKey;
         const resourceMetadataUrl = new URL(
           "https://mcp.example.com/.well-known/oauth-protected-resource",
         );
-        const provider = createMcpOAuthClientProvider({ serverName, serverUrl });
+        const provider = createMcpOAuthClientProvider({ identity: REMOTE_IDENTITY });
         await provider.saveTokens({
           access_token: "legacy-access",
           refresh_token: "legacy-refresh",
@@ -333,7 +407,7 @@ describe("MCP OAuth provider", () => {
           return "AUTHORIZED";
         });
 
-        await expect(resolveMcpOAuthAccessToken({ serverName, serverUrl })).resolves.toBe(
+        await expect(resolveMcpOAuthAccessToken({ identity: REMOTE_IDENTITY })).resolves.toBe(
           ROTATED_ACCESS,
         );
         expect(readMcpOAuthStore(storeKey).pendingAuthorizationChallenge).toBeUndefined();
@@ -350,8 +424,7 @@ describe("MCP OAuth provider", () => {
     await withTempHome(
       async () => {
         const provider = createMcpOAuthClientProvider({
-          serverName: "Remote Docs",
-          serverUrl: "https://mcp.example.com/mcp",
+          identity: REMOTE_IDENTITY,
         });
         await provider.saveTokens({
           access_token: "example",
@@ -359,7 +432,7 @@ describe("MCP OAuth provider", () => {
           token_type: "Bearer",
           expires_in: 3600,
         });
-        const storeKey = resolveMcpOAuthStoreKey("Remote Docs", "https://mcp.example.com/mcp");
+        const storeKey = REMOTE_IDENTITY.storeKey;
         updateMcpOAuthStore(storeKey, (store) => {
           const next = { ...store };
           delete next.tokenExpiresAt;
@@ -368,8 +441,7 @@ describe("MCP OAuth provider", () => {
 
         await expect(
           resolveMcpOAuthAccessToken({
-            serverName: "Remote Docs",
-            serverUrl: "https://mcp.example.com/mcp",
+            identity: REMOTE_IDENTITY,
             acceptUnknownExpiry: true,
           }),
         ).resolves.toBe(LEGACY_ACCESS);
@@ -387,8 +459,7 @@ describe("MCP OAuth provider", () => {
 
         await expect(
           resolveMcpOAuthAccessToken({
-            serverName: "Remote Docs",
-            serverUrl: "https://mcp.example.com/mcp",
+            identity: REMOTE_IDENTITY,
           }),
         ).resolves.toBe(ROTATED_ACCESS);
         expect(authMock).toHaveBeenCalledOnce();
@@ -409,8 +480,7 @@ describe("MCP OAuth provider", () => {
       async () => {
         await expect(
           resolveMcpOAuthAccessToken({
-            serverName: "Remote Docs",
-            serverUrl: "https://mcp.example.com/mcp",
+            identity: REMOTE_IDENTITY,
           }),
         ).rejects.toThrow("Run openclaw mcp login Remote Docs.");
         expect(authMock).not.toHaveBeenCalled();
@@ -431,15 +501,12 @@ describe("MCP OAuth provider", () => {
       async () => {
         await expect(
           resolveMcpOAuthAccessToken({
-            serverName: "Remote Docs",
-            serverUrl: "https://mcp.example.com/mcp",
+            identity: REMOTE_IDENTITY,
             authorizationChallenge: true,
             scope: "docs.read",
           }),
         ).rejects.toThrow("Run openclaw mcp login Remote Docs.");
-        expect(
-          readMcpOAuthStore(resolveMcpOAuthStoreKey("Remote Docs", "https://mcp.example.com/mcp")),
-        ).toMatchObject({
+        expect(readMcpOAuthStore(REMOTE_IDENTITY.storeKey)).toMatchObject({
           credentialState: "uninitialized",
           pendingAuthorizationChallenge: { scope: "docs.read" },
         });
@@ -459,25 +526,21 @@ describe("MCP OAuth provider", () => {
           "https://mcp.example.com/.well-known/oauth-protected-resource",
         );
         const provider = createMcpOAuthClientProvider({
-          serverName: "Remote Docs",
-          serverUrl: "https://mcp.example.com/mcp",
-          onAuthorizationUrl: () => {},
+          identity: REMOTE_IDENTITY,
+          allowAuthorizationRedirect: true,
         });
         await provider.saveCodeVerifier("existing-verifier");
 
         await expect(
           resolveMcpOAuthAccessToken({
-            serverName: "Remote Docs",
-            serverUrl: "https://mcp.example.com/mcp",
+            identity: REMOTE_IDENTITY,
             authorizationChallenge: true,
             resourceMetadataUrl,
             scope: "docs.read",
           }),
         ).rejects.toThrow("Run openclaw mcp login Remote Docs.");
         expect(authMock).not.toHaveBeenCalled();
-        expect(
-          readMcpOAuthStore(resolveMcpOAuthStoreKey("Remote Docs", "https://mcp.example.com/mcp")),
-        ).toMatchObject({
+        expect(readMcpOAuthStore(REMOTE_IDENTITY.storeKey)).toMatchObject({
           codeVerifier: "existing-verifier",
           pendingAuthorizationChallenge: {
             resourceMetadataUrl: resourceMetadataUrl.toString(),
@@ -485,13 +548,10 @@ describe("MCP OAuth provider", () => {
           },
         });
 
-        authMock.mockResolvedValueOnce("REDIRECT");
+        authMock.mockImplementationOnce(persistRedirect);
         await expect(
-          runMcpOAuthLogin({
-            serverName: "Remote Docs",
-            serverUrl: "https://mcp.example.com/mcp",
-          }),
-        ).resolves.toBe("redirect");
+          startMcpOAuthAuthorization(REMOTE_IDENTITY, resolvedOAuthConfig(REMOTE_IDENTITY), {}),
+        ).resolves.toMatchObject({ state: "state-1234567890" });
         expect(authMock.mock.calls[0]?.[1]).toMatchObject({
           resourceMetadataUrl,
           scope: "docs.read",
@@ -509,8 +569,7 @@ describe("MCP OAuth provider", () => {
     await withTempHome(
       async (home) => {
         const provider = createMcpOAuthClientProvider({
-          serverName: "Remote Docs",
-          serverUrl: "https://mcp.example.com/mcp",
+          identity: REMOTE_IDENTITY,
         });
         await provider.saveTokens({ access_token: "access", token_type: "Bearer" });
 
@@ -546,12 +605,7 @@ describe("MCP OAuth provider", () => {
   it("does not create shared state for a read-only credential status check", async () => {
     await withTempHome(
       async () => {
-        await expect(
-          readMcpOAuthCredentialsStatus({
-            serverName: "Remote Docs",
-            serverUrl: "https://mcp.example.com/mcp",
-          }),
-        ).resolves.toEqual({
+        await expect(readMcpOAuthCredentialsStatus(REMOTE_IDENTITY)).resolves.toEqual({
           hasTokens: false,
           requiresAuthorization: false,
           hasClientInformation: false,
@@ -575,9 +629,8 @@ describe("MCP OAuth provider", () => {
     await withTempHome(
       async () => {
         const provider = createMcpOAuthClientProvider({
-          serverName: "Remote Docs",
-          serverUrl: "https://mcp.example.com/mcp",
-          onAuthorizationUrl: () => {},
+          identity: REMOTE_IDENTITY,
+          allowAuthorizationRedirect: true,
         });
         await provider.saveClientInformation?.({ client_id: "client-id" });
         await provider.saveTokens({
@@ -589,9 +642,7 @@ describe("MCP OAuth provider", () => {
         await provider.saveCodeVerifier("verifier");
         await provider.invalidateCredentials?.("tokens");
 
-        const store = readMcpOAuthStore(
-          resolveMcpOAuthStoreKey("Remote Docs", "https://mcp.example.com/mcp"),
-        );
+        const store = readMcpOAuthStore(REMOTE_IDENTITY.storeKey);
         expect(store.clientInformation).toEqual({ client_id: "client-id" });
         expect(store.codeVerifier).toBe("verifier");
         expect(store.tokens).toBeUndefined();
@@ -610,11 +661,10 @@ describe("MCP OAuth provider", () => {
     await withTempHome(
       async () => {
         const provider = createMcpOAuthClientProvider({
-          serverName: "Remote Docs",
-          serverUrl: "https://mcp.example.com/mcp",
+          identity: REMOTE_IDENTITY,
         });
         await provider.saveTokens({ access_token: "access", token_type: "Bearer" });
-        const storeKey = resolveMcpOAuthStoreKey("Remote Docs", "https://mcp.example.com/mcp");
+        const storeKey = REMOTE_IDENTITY.storeKey;
         openOpenClawStateDatabase()
           .db.prepare("UPDATE mcp_oauth_stores SET store_json = ? WHERE store_key = ?")
           .run("{", storeKey);
@@ -633,11 +683,10 @@ describe("MCP OAuth provider", () => {
     await withTempHome(
       async () => {
         const provider = createMcpOAuthClientProvider({
-          serverName: "Remote Docs",
-          serverUrl: "https://mcp.example.com/mcp",
+          identity: REMOTE_IDENTITY,
         });
         await provider.saveTokens({ access_token: "access", token_type: "Bearer" });
-        const storeKey = resolveMcpOAuthStoreKey("Remote Docs", "https://mcp.example.com/mcp");
+        const storeKey = REMOTE_IDENTITY.storeKey;
         openOpenClawStateDatabase()
           .db.prepare("UPDATE mcp_oauth_stores SET store_json = ? WHERE store_key = ?")
           .run(JSON.stringify({ tokenExpiresAt: 10_000 }), storeKey);
@@ -656,12 +705,10 @@ describe("MCP OAuth provider", () => {
     await withTempHome(
       async () => {
         const first = createMcpOAuthClientProvider({
-          serverName: "Remote Docs",
-          serverUrl: "https://mcp.example.com/mcp",
+          identity: REMOTE_IDENTITY,
         });
         const second = createMcpOAuthClientProvider({
-          serverName: "Remote Docs",
-          serverUrl: "https://other.example.com/mcp",
+          identity: operatorMcpOAuthIdentity("Remote Docs", "https://other.example.com/mcp"),
         });
         await first.saveTokens({ access_token: "access", token_type: "Bearer" });
 
@@ -680,46 +727,85 @@ describe("MCP OAuth provider", () => {
 
   it("keeps the legacy loopback redirect as the default for upgrade compatibility", () => {
     const provider = createMcpOAuthClientProvider({
-      serverName: "Calendly",
-      serverUrl: "https://mcp.calendly.com/",
+      identity: CALENDLY_IDENTITY,
     });
 
     expect(provider.clientMetadata.redirect_uris).toEqual(["http://127.0.0.1:8989/oauth/callback"]);
     expect(provider.redirectUrl).toBe("http://127.0.0.1:8989/oauth/callback");
   });
 
-  it("retries MCP OAuth login with localhost after redirect registration rejection", async () => {
-    authMock.mockReset();
-    authMock
-      .mockRejectedValueOnce(new Error("invalid_client_metadata: redirect_uri rejected"))
-      .mockResolvedValueOnce("AUTHORIZED");
+  it("persists the localhost retry for completion and then clears the session", async () => {
+    await withTempHome(
+      async () => {
+        authMock
+          .mockRejectedValueOnce(new Error("invalid_client_metadata: redirect_uri rejected"))
+          .mockImplementationOnce(persistRedirect);
 
-    await expect(
-      runMcpOAuthLogin({
-        serverName: "Calendly",
-        serverUrl: "https://mcp.calendly.com/",
-      }),
-    ).resolves.toBe("authorized");
+        const session = await startMcpOAuthAuthorization(
+          CALENDLY_IDENTITY,
+          resolvedOAuthConfig(CALENDLY_IDENTITY),
+          {},
+        );
 
-    expect(authMock).toHaveBeenCalledTimes(2);
-    expect(authMock.mock.calls[1]?.[0]?.clientMetadata.redirect_uris).toEqual([
-      "http://localhost:8989/oauth/callback",
-    ]);
+        expect(session.redirectUrl).toBe("http://localhost:8989/oauth/callback");
+        expect(authMock.mock.calls[1]?.[0]?.clientMetadata.redirect_uris).toEqual([
+          "http://localhost:8989/oauth/callback",
+        ]);
+        expect(readMcpOAuthStore(CALENDLY_IDENTITY.storeKey)).toMatchObject({
+          codeVerifier: "verifier",
+          redirectUrl: "http://localhost:8989/oauth/callback",
+        });
+
+        authMock.mockReset();
+        authMock.mockImplementationOnce(async (provider, options) => {
+          expect(options.authorizationCode).toBe("code-123");
+          expect(provider.redirectUrl).toBe("http://localhost:8989/oauth/callback");
+          expect(await provider.codeVerifier()).toBe("verifier");
+          return "AUTHORIZED";
+        });
+        await expect(
+          completeMcpOAuthAuthorization(CALENDLY_IDENTITY, resolvedOAuthConfig(CALENDLY_IDENTITY), {
+            code: "code-123",
+          }),
+        ).resolves.toBe("authorized");
+        expect(readMcpOAuthStore(CALENDLY_IDENTITY.storeKey)).not.toMatchObject({
+          codeVerifier: expect.anything(),
+          redirectUrl: expect.anything(),
+        });
+      },
+      {
+        prefix: "openclaw-mcp-oauth-localhost-persist-",
+        skipSessionCleanup: true,
+        env: { OPENCLAW_CONFIG_PATH: undefined, OPENCLAW_STATE_DIR: undefined },
+      },
+    );
   });
 
   it("does not retry a code exchange redirect mismatch", async () => {
-    authMock.mockReset();
-    authMock.mockRejectedValueOnce(new Error("invalid_grant: redirect_uri mismatch"));
+    await withTempHome(
+      async () => {
+        authMock.mockImplementationOnce(persistRedirect);
+        await startMcpOAuthAuthorization(
+          CALENDLY_IDENTITY,
+          resolvedOAuthConfig(CALENDLY_IDENTITY),
+          {},
+        );
+        authMock.mockReset();
+        authMock.mockRejectedValueOnce(new Error("invalid_grant: redirect_uri mismatch"));
 
-    await expect(
-      runMcpOAuthLogin({
-        serverName: "Calendly",
-        serverUrl: "https://mcp.calendly.com/",
-        authorizationCode: "code-123",
-      }),
-    ).rejects.toThrow("redirect_uri mismatch");
-
-    expect(authMock).toHaveBeenCalledOnce();
+        await expect(
+          completeMcpOAuthAuthorization(CALENDLY_IDENTITY, resolvedOAuthConfig(CALENDLY_IDENTITY), {
+            code: "code-123",
+          }),
+        ).rejects.toThrow("redirect_uri mismatch");
+        expect(authMock).toHaveBeenCalledOnce();
+      },
+      {
+        prefix: "openclaw-mcp-oauth-code-mismatch-",
+        skipSessionCleanup: true,
+        env: { OPENCLAW_CONFIG_PATH: undefined, OPENCLAW_STATE_DIR: undefined },
+      },
+    );
   });
 
   it("does not persist localhost when the fallback attempt fails", async () => {
@@ -731,148 +817,13 @@ describe("MCP OAuth provider", () => {
           .mockRejectedValueOnce(new Error("localhost redirect also rejected"));
 
         await expect(
-          runMcpOAuthLogin({
-            serverName: "Calendly",
-            serverUrl: "https://mcp.calendly.com/",
-          }),
+          startMcpOAuthAuthorization(CALENDLY_IDENTITY, resolvedOAuthConfig(CALENDLY_IDENTITY), {}),
         ).rejects.toThrow("localhost redirect also rejected");
 
-        const storeKey = resolveMcpOAuthStoreKey("Calendly", "https://mcp.calendly.com/");
-        expect(readMcpOAuthStore(storeKey)).toEqual({});
+        expect(readMcpOAuthStore(CALENDLY_IDENTITY.storeKey)).toEqual({});
       },
       {
         prefix: "openclaw-mcp-oauth-localhost-failure-",
-        skipSessionCleanup: true,
-        env: {
-          OPENCLAW_CONFIG_PATH: undefined,
-          OPENCLAW_STATE_DIR: undefined,
-        },
-      },
-    );
-  });
-
-  it("persists localhost redirect for a later code exchange login", async () => {
-    await withTempHome(
-      async () => {
-        let finalAuthorizationUrl: URL | undefined;
-        authMock.mockReset();
-        authMock
-          .mockRejectedValueOnce(new Error("invalid_client_metadata: redirect_uri rejected"))
-          .mockImplementationOnce(async (provider) => {
-            await provider.saveCodeVerifier?.("verifier");
-            const authorizationUrl = new URL("https://auth.example.com/authorize");
-            authorizationUrl.searchParams.set("redirect_uri", String(provider.redirectUrl));
-            authorizationUrl.searchParams.set("state", "state-1234567890");
-            await provider.redirectToAuthorization?.(authorizationUrl);
-            return "REDIRECT";
-          });
-
-        await expect(
-          runMcpOAuthLogin({
-            serverName: "Calendly",
-            serverUrl: "https://mcp.calendly.com/",
-            onAuthorizationUrl: (url) => {
-              finalAuthorizationUrl = url;
-            },
-          }),
-        ).resolves.toBe("redirect");
-
-        expect(finalAuthorizationUrl?.searchParams.get("redirect_uri")).toBe(
-          "http://localhost:8989/oauth/callback",
-        );
-
-        const store = readMcpOAuthStore(
-          resolveMcpOAuthStoreKey("Calendly", "https://mcp.calendly.com/"),
-        );
-        expect(store.redirectUrl).toBe("http://localhost:8989/oauth/callback");
-        expect(store.codeVerifier).toBe("verifier");
-
-        authMock.mockReset();
-        authMock.mockImplementationOnce(async (provider, options) => {
-          expect(options.authorizationCode).toBe("code-123");
-          expect(provider.redirectUrl).toBe("http://localhost:8989/oauth/callback");
-          expect(await provider.codeVerifier?.()).toBe("verifier");
-          return "AUTHORIZED";
-        });
-        await runMcpOAuthLogin({
-          serverName: "Calendly",
-          serverUrl: "https://mcp.calendly.com/",
-          authorizationCode: "code-123",
-        });
-        expect(authMock.mock.calls[0]?.[0]?.clientMetadata.redirect_uris).toEqual([
-          "http://localhost:8989/oauth/callback",
-        ]);
-      },
-      {
-        prefix: "openclaw-mcp-oauth-localhost-persist-",
-        skipSessionCleanup: true,
-        env: {
-          OPENCLAW_CONFIG_PATH: undefined,
-          OPENCLAW_STATE_DIR: undefined,
-        },
-      },
-    );
-  });
-
-  it("keeps a captured verifier bound to its login when another login overlaps", async () => {
-    await withTempHome(
-      async () => {
-        let firstSession: { codeVerifier: string; redirectUrl: string } | undefined;
-        authMock.mockReset();
-        authMock.mockImplementationOnce(async (provider) => {
-          await provider.saveCodeVerifier?.("verifier-first");
-          return "REDIRECT";
-        });
-
-        await runMcpOAuthLogin({
-          serverName: "Calendly",
-          serverUrl: "https://mcp.calendly.com/",
-          onAuthorizationUrl: () => {},
-          onAuthorizationSession: (session) => {
-            firstSession = session;
-          },
-        });
-        expect(firstSession).toEqual({
-          codeVerifier: "verifier-first",
-          redirectUrl: "http://127.0.0.1:8989/oauth/callback",
-        });
-
-        authMock.mockImplementationOnce(async (provider) => {
-          await provider.saveCodeVerifier?.("verifier-second");
-          return "REDIRECT";
-        });
-        await runMcpOAuthLogin({
-          serverName: "Calendly",
-          serverUrl: "https://mcp.calendly.com/",
-          onAuthorizationUrl: () => {},
-        });
-        expect(
-          readMcpOAuthStore(resolveMcpOAuthStoreKey("Calendly", "https://mcp.calendly.com/"))
-            .codeVerifier,
-        ).toBe("verifier-second");
-
-        const captured = firstSession;
-        if (!captured) {
-          throw new Error("first login did not capture its authorization session");
-        }
-        authMock.mockImplementationOnce(async (provider, options) => {
-          expect(options.authorizationCode).toBe("code-first");
-          expect(await provider.codeVerifier()).toBe("verifier-first");
-          expect(provider.redirectUrl).toBe("http://127.0.0.1:8989/oauth/callback");
-          return "AUTHORIZED";
-        });
-        await expect(
-          runMcpOAuthLogin({
-            serverName: "Calendly",
-            serverUrl: "https://mcp.calendly.com/",
-            config: { redirectUrl: captured.redirectUrl },
-            authorizationCode: "code-first",
-            codeVerifier: captured.codeVerifier,
-          }),
-        ).resolves.toBe("authorized");
-      },
-      {
-        prefix: "openclaw-mcp-oauth-overlap-",
         skipSessionCleanup: true,
         env: {
           OPENCLAW_CONFIG_PATH: undefined,
@@ -888,8 +839,7 @@ describe("MCP OAuth provider", () => {
     await withTempHome(
       async () => {
         const provider = createMcpOAuthClientProvider({
-          serverName: "Remote Docs",
-          serverUrl: "https://mcp.example.com/mcp",
+          identity: REMOTE_IDENTITY,
         });
 
         expect(() => provider.state?.()).toThrow("Run openclaw mcp login Remote Docs.");
@@ -915,21 +865,14 @@ describe("MCP OAuth provider", () => {
     await withTempHome(
       async () => {
         const provider = createMcpOAuthClientProvider({
-          serverName: "Remote Docs",
-          serverUrl: "https://mcp.example.com/mcp",
+          identity: REMOTE_IDENTITY,
         });
         await provider.saveTokens({ access_token: "access", token_type: "Bearer" });
 
-        await clearMcpOAuthCredentials({
-          serverName: "Remote Docs",
-          serverUrl: "https://mcp.example.com/mcp",
-        });
+        await clearMcpOAuthCredentials(REMOTE_IDENTITY);
 
         expect(provider.tokens()).toBeUndefined();
-        expect(
-          readMcpOAuthStore(resolveMcpOAuthStoreKey("Remote Docs", "https://mcp.example.com/mcp"))
-            .credentialState,
-        ).toBe("cleared");
+        expect(readMcpOAuthStore(REMOTE_IDENTITY.storeKey).credentialState).toBe("cleared");
       },
       {
         prefix: "openclaw-mcp-oauth-clear-",
@@ -938,6 +881,72 @@ describe("MCP OAuth provider", () => {
           OPENCLAW_CONFIG_PATH: undefined,
           OPENCLAW_STATE_DIR: undefined,
         },
+      },
+    );
+  });
+
+  it("resumes authorization after restart, retains failures, and supersedes older starts", async () => {
+    await withTempHome(
+      async () => {
+        const { auth: realAuth } = await vi.importActual<
+          typeof import("@modelcontextprotocol/sdk/client/auth.js")
+        >("@modelcontextprotocol/sdk/client/auth.js");
+        authMock.mockImplementation(realAuth);
+        const fixture = await startAuthorizationServer(await getFreePort());
+        const identity = operatorMcpOAuthIdentity("fixture", `${fixture.issuer}/mcp`);
+        const config = {
+          ...resolvedOAuthConfig(identity),
+          oauth: { redirectUrl: "http://127.0.0.1:8989/oauth/callback" },
+        };
+        try {
+          const first = await startMcpOAuthAuthorization(identity, config, {});
+          expect(readMcpOAuthStore(identity.storeKey)).toMatchObject({
+            codeVerifier: expect.any(String),
+            lastAuthorizationUrl: first.authorizationUrl,
+            redirectUrl: first.redirectUrl,
+          });
+
+          closeOpenClawStateDatabaseForTest();
+          await expect(
+            completeMcpOAuthAuthorization(identity, config, {
+              code: authorizationCode(first.authorizationUrl),
+            }),
+          ).resolves.toBe("authorized");
+          expect(readMcpOAuthStore(identity.storeKey)).not.toHaveProperty("codeVerifier");
+
+          const second = await startMcpOAuthAuthorization(identity, config, {});
+          await expect(
+            completeMcpOAuthAuthorization(identity, config, { code: "wrong-code" }),
+          ).rejects.toThrow();
+          expect(readMcpOAuthStore(identity.storeKey)).toMatchObject({
+            lastAuthorizationUrl: second.authorizationUrl,
+            redirectUrl: second.redirectUrl,
+            codeVerifier: expect.any(String),
+          });
+
+          const third = await startMcpOAuthAuthorization(identity, config, {});
+          expect(third.authorizationUrl).not.toBe(second.authorizationUrl);
+          await expect(
+            completeMcpOAuthAuthorization(identity, config, {
+              code: authorizationCode(second.authorizationUrl),
+            }),
+          ).rejects.toThrow();
+          expect(readMcpOAuthStore(identity.storeKey).lastAuthorizationUrl).toBe(
+            third.authorizationUrl,
+          );
+          await expect(
+            completeMcpOAuthAuthorization(identity, config, {
+              code: authorizationCode(third.authorizationUrl),
+            }),
+          ).resolves.toBe("authorized");
+        } finally {
+          await fixture.close();
+        }
+      },
+      {
+        prefix: "openclaw-mcp-oauth-session-",
+        skipSessionCleanup: true,
+        env: { OPENCLAW_CONFIG_PATH: undefined, OPENCLAW_STATE_DIR: undefined },
       },
     );
   });

--- a/src/agents/mcp-oauth.ts
+++ b/src/agents/mcp-oauth.ts
@@ -7,6 +7,12 @@ import {
   withOpenClawStateLease,
 } from "../state/openclaw-state-lease.js";
 import {
+  buildMcpHttpFetch,
+  withoutMcpAuthorizationHeader,
+  withSameOriginMcpHttpHeaders,
+} from "./mcp-http-fetch.js";
+import type { McpOAuthIdentity } from "./mcp-oauth-identity.js";
+import {
   bindMcpOAuthLeaseAssertion,
   createMcpOAuthClientProvider,
   type McpOAuthConfig,
@@ -16,12 +22,17 @@ import {
   clearMcpOAuthStore,
   readMcpOAuthStore,
   readMcpOAuthStoreReadOnly,
-  resolveMcpOAuthStoreKey,
   updateMcpOAuthStore,
   type McpOAuthStore,
 } from "./mcp-oauth-store.js";
+import type { resolveMcpTransportConfig } from "./mcp-transport-config.js";
 
 export type { McpOAuthConfig } from "./mcp-oauth-provider.js";
+
+type ResolvedHttpMcpTransportConfig = Extract<
+  NonNullable<ReturnType<typeof resolveMcpTransportConfig>>,
+  { kind: "http" }
+>;
 
 /** Persisted OAuth credential presence and authorization state for one MCP server. */
 export type McpOAuthCredentialsStatus = {
@@ -31,12 +42,6 @@ export type McpOAuthCredentialsStatus = {
   hasCodeVerifier: boolean;
   hasDiscoveryState: boolean;
   hasLastAuthorizationUrl: boolean;
-};
-
-/** Attempt-scoped PKCE facts captured before the login lease is released. */
-export type McpOAuthAuthorizationSession = {
-  codeVerifier: string;
-  redirectUrl: string;
 };
 
 const LOCALHOST_REDIRECT_URL = "http://localhost:8989/oauth/callback";
@@ -124,8 +129,7 @@ function applyMcpOAuthAuthorizationChallenge(
 }
 
 type ResolveMcpOAuthAccessTokenParams = {
-  serverName: string;
-  serverUrl: string;
+  identity: McpOAuthIdentity;
   config?: McpOAuthConfig;
   fetchFn?: FetchLike;
   acceptUnknownExpiry?: boolean;
@@ -148,7 +152,7 @@ export function resolveMcpOAuthAccessToken(
 export async function resolveMcpOAuthAccessToken(
   params: ResolveMcpOAuthAccessTokenParams,
 ): Promise<string | undefined> {
-  const storeKey = resolveMcpOAuthStoreKey(params.serverName, params.serverUrl);
+  const storeKey = params.identity.storeKey;
   return await withMcpOAuthLease(
     storeKey,
     async (lease) => {
@@ -179,17 +183,17 @@ export async function resolveMcpOAuthAccessToken(
         params.interactiveAuthorizationRequired === true &&
         challengeAppliesToCurrentState
       ) {
-        throw mcpOAuthAdditionalAuthorizationError(params.serverName);
+        throw mcpOAuthAdditionalAuthorizationError(params.identity.serverName);
       }
       if (store.pendingAuthorizationChallenge?.requiresAuthorization === true) {
-        throw mcpOAuthAdditionalAuthorizationError(params.serverName);
+        throw mcpOAuthAdditionalAuthorizationError(params.identity.serverName);
       }
       if (!tokens?.access_token) {
         if (params.allowMissingToken === true) {
           return undefined;
         }
         throw new Error(
-          `MCP server "${params.serverName}" requires OAuth authorization. Run openclaw mcp login ${params.serverName}.`,
+          `MCP server "${params.identity.serverName}" requires OAuth authorization. Run openclaw mcp login ${params.identity.serverName}.`,
         );
       }
 
@@ -206,15 +210,19 @@ export async function resolveMcpOAuthAccessToken(
       }
       if (!tokens.refresh_token) {
         throw new Error(
-          `MCP server "${params.serverName}" has expired OAuth credentials. Run openclaw mcp login ${params.serverName}.`,
+          `MCP server "${params.identity.serverName}" has expired OAuth credentials. Run openclaw mcp login ${params.identity.serverName}.`,
         );
       }
 
       const pendingChallenge = store.pendingAuthorizationChallenge;
       updateMcpOAuthStore(storeKey, bindMcpOAuthTokensIssuer, bindMcpOAuthLeaseAssertion(lease));
-      const provider = createMcpOAuthClientProvider({ ...params, lease });
+      const provider = createMcpOAuthClientProvider({
+        identity: params.identity,
+        config: params.config,
+        lease,
+      });
       const result = await auth(provider, {
-        serverUrl: params.serverUrl,
+        serverUrl: params.identity.serverUrl,
         resourceMetadataUrl:
           params.resourceMetadataUrl ??
           (pendingChallenge?.resourceMetadataUrl
@@ -230,7 +238,7 @@ export async function resolveMcpOAuthAccessToken(
       const refreshedTokens = await provider.tokens();
       if (result !== "AUTHORIZED" || !refreshedTokens?.access_token) {
         throw new Error(
-          `MCP server "${params.serverName}" could not refresh OAuth credentials. Run openclaw mcp login ${params.serverName}.`,
+          `MCP server "${params.identity.serverName}" could not refresh OAuth credentials. Run openclaw mcp login ${params.identity.serverName}.`,
         );
       }
       return refreshedTokens.access_token;
@@ -241,14 +249,13 @@ export async function resolveMcpOAuthAccessToken(
 
 /** Persist a terminal resource rejection without overwriting newer credentials. */
 export async function recordMcpOAuthAuthorizationRequired(params: {
-  serverName: string;
-  serverUrl: string;
+  identity: McpOAuthIdentity;
   rejectedAccessToken: string;
   resourceMetadataUrl?: URL;
   scope?: string;
   signal?: AbortSignal;
 }): Promise<boolean> {
-  const storeKey = resolveMcpOAuthStoreKey(params.serverName, params.serverUrl);
+  const storeKey = params.identity.storeKey;
   return await withMcpOAuthLease(
     storeKey,
     async (lease) => {
@@ -279,24 +286,17 @@ export async function recordMcpOAuthAuthorizationRequired(params: {
 }
 
 /** Deletes one OAuth session without racing an in-flight refresh or login. */
-export async function clearMcpOAuthCredentials(params: {
-  serverName: string;
-  serverUrl: string;
-}): Promise<void> {
-  const storeKey = resolveMcpOAuthStoreKey(params.serverName, params.serverUrl);
-  await withMcpOAuthLease(storeKey, async (lease) => {
-    clearMcpOAuthStore(storeKey, bindMcpOAuthLeaseAssertion(lease));
+export async function clearMcpOAuthCredentials(identity: McpOAuthIdentity): Promise<void> {
+  await withMcpOAuthLease(identity.storeKey, async (lease) => {
+    clearMcpOAuthStore(identity.storeKey, bindMcpOAuthLeaseAssertion(lease));
   });
 }
 
 /** Reads stored OAuth credential presence without exposing values or creating state. */
-export async function readMcpOAuthCredentialsStatus(params: {
-  serverName: string;
-  serverUrl: string;
-}): Promise<McpOAuthCredentialsStatus> {
-  const store = readMcpOAuthStoreReadOnly(
-    resolveMcpOAuthStoreKey(params.serverName, params.serverUrl),
-  );
+export async function readMcpOAuthCredentialsStatus(
+  identity: McpOAuthIdentity,
+): Promise<McpOAuthCredentialsStatus> {
+  const store = readMcpOAuthStoreReadOnly(identity.storeKey);
   return {
     hasTokens: Boolean(store.tokens),
     requiresAuthorization: store.pendingAuthorizationChallenge?.requiresAuthorization === true,
@@ -307,103 +307,143 @@ export async function readMcpOAuthCredentialsStatus(params: {
   };
 }
 
-async function runMcpOAuthLoginAttempt(
+function buildMcpOAuthAuthorizationFetch(config: ResolvedHttpMcpTransportConfig): FetchLike {
+  const fetchFn = buildMcpHttpFetch({
+    sslVerify: config.sslVerify,
+    clientCert: config.clientCert,
+    clientKey: config.clientKey,
+    resourceUrl: config.url,
+    timeoutMs: config.requestTimeoutMs,
+  });
+  return withSameOriginMcpHttpHeaders({
+    fetchFn,
+    headers: withoutMcpAuthorizationHeader(config.headers),
+    resourceUrl: config.url,
+  });
+}
+
+async function runMcpOAuthAuthorizationAttempt(
   params: {
-    serverName: string;
-    serverUrl: string;
-    config?: McpOAuthConfig;
+    identity: McpOAuthIdentity;
+    config: McpOAuthConfig;
+    fetchFn: FetchLike;
     authorizationCode?: string;
-    codeVerifier?: string;
-    fetchFn?: FetchLike;
-    onAuthorizationUrl?: (url: URL) => void | Promise<void>;
-    onAuthorizationSession?: (session: McpOAuthAuthorizationSession) => void;
     resourceMetadataUrl?: URL;
     scope?: string;
-    forceAuthorization?: boolean;
+    suppressStoredTokens?: boolean;
   },
   lease: OpenClawStateLeaseContext,
-): Promise<"authorized" | "redirect"> {
+): Promise<void> {
   const provider = createMcpOAuthClientProvider({
-    ...params,
+    identity: params.identity,
+    config: params.config,
     allowAuthorizationRedirect: true,
-    suppressStoredTokens: params.forceAuthorization,
+    suppressStoredTokens: params.suppressStoredTokens,
     lease,
   });
-  if (params.codeVerifier) {
-    const codeVerifier = params.codeVerifier;
-    provider.codeVerifier = () => codeVerifier;
-  }
-  const result = await auth(provider, {
-    serverUrl: params.serverUrl,
+  await auth(provider, {
+    serverUrl: params.identity.serverUrl,
     authorizationCode: normalizeOptionalString(params.authorizationCode),
     resourceMetadataUrl: params.resourceMetadataUrl,
     scope: normalizeOptionalString(params.scope) ?? normalizeOptionalString(params.config?.scope),
     fetchFn: withMcpOAuthLeaseSignal(params.fetchFn, lease.signal),
   });
   lease.assertOwned();
-  if (result === "REDIRECT" && params.onAuthorizationSession) {
-    const redirectUrl = provider.redirectUrl;
-    if (!redirectUrl) {
-      throw new Error("Missing MCP OAuth redirect URL after authorization started.");
-    }
-    params.onAuthorizationSession({
-      codeVerifier: await provider.codeVerifier(),
-      redirectUrl: String(redirectUrl),
-    });
-  }
-  return result === "AUTHORIZED" ? "authorized" : "redirect";
 }
 
-/** Runs both redirect-registration attempts under one OAuth session lease. */
-export async function runMcpOAuthLogin(params: {
-  serverName: string;
-  serverUrl: string;
-  config?: McpOAuthConfig;
-  authorizationCode?: string;
-  codeVerifier?: string;
-  fetchFn?: FetchLike;
-  onAuthorizationUrl?: (url: URL) => void | Promise<void>;
-  onAuthorizationSession?: (session: McpOAuthAuthorizationSession) => void;
-}): Promise<"authorized" | "redirect"> {
-  const storeKey = resolveMcpOAuthStoreKey(params.serverName, params.serverUrl);
+export async function startMcpOAuthAuthorization(
+  identity: McpOAuthIdentity,
+  config: ResolvedHttpMcpTransportConfig,
+  opts: { redirectUrl?: string },
+): Promise<{ authorizationUrl: string; redirectUrl: string; state: string }> {
+  const storeKey = identity.storeKey;
   return await withMcpOAuthLease(storeKey, async (lease) => {
     const store = readMcpOAuthStore(storeKey);
     const pendingChallenge = store.pendingAuthorizationChallenge;
-    const loginParams = {
-      ...params,
-      config: {
-        ...params.config,
-        redirectUrl: normalizeOptionalString(params.config?.redirectUrl) ?? store.redirectUrl,
-      },
+    const configuredRedirectUrl =
+      normalizeOptionalString(opts.redirectUrl) ??
+      normalizeOptionalString(config.oauth?.redirectUrl) ??
+      store.redirectUrl;
+    const oauthConfig: McpOAuthConfig = {
+      ...config.oauth,
+      ...(configuredRedirectUrl ? { redirectUrl: configuredRedirectUrl } : {}),
+    };
+    const attempt = {
+      identity,
+      config: oauthConfig,
+      fetchFn: buildMcpOAuthAuthorizationFetch(config),
       resourceMetadataUrl: pendingChallenge?.resourceMetadataUrl
         ? new URL(pendingChallenge.resourceMetadataUrl)
         : undefined,
       scope: normalizeOptionalString(pendingChallenge?.scope),
-      forceAuthorization: pendingChallenge?.requiresAuthorization === true,
+      suppressStoredTokens: true,
     };
     try {
-      return await runMcpOAuthLoginAttempt(loginParams, lease);
+      await runMcpOAuthAuthorizationAttempt(attempt, lease);
     } catch (error) {
       if (
-        !normalizeOptionalString(params.authorizationCode) &&
-        !normalizeOptionalString(params.config?.redirectUrl) &&
+        !normalizeOptionalString(opts.redirectUrl) &&
+        !normalizeOptionalString(config.oauth?.redirectUrl) &&
         isMcpOAuthRedirectRegistrationError(error)
       ) {
-        const result = await runMcpOAuthLoginAttempt(
+        await runMcpOAuthAuthorizationAttempt(
           {
-            ...loginParams,
-            config: { ...params.config, redirectUrl: LOCALHOST_REDIRECT_URL },
+            ...attempt,
+            config: { ...config.oauth, redirectUrl: LOCALHOST_REDIRECT_URL },
           },
           lease,
         );
-        updateMcpOAuthStore(
-          storeKey,
-          (current) => ({ ...current, redirectUrl: LOCALHOST_REDIRECT_URL }),
-          bindMcpOAuthLeaseAssertion(lease),
-        );
-        return result;
+      } else {
+        throw error;
       }
-      throw error;
     }
+    const pending = readMcpOAuthStore(storeKey);
+    const authorizationUrl = pending.lastAuthorizationUrl;
+    const state = authorizationUrl ? new URL(authorizationUrl).searchParams.get("state") : null;
+    if (!authorizationUrl || !pending.codeVerifier || !pending.redirectUrl || !state) {
+      throw new Error("MCP OAuth authorization session was not persisted.");
+    }
+    return { authorizationUrl, redirectUrl: pending.redirectUrl, state };
+  });
+}
+
+export async function completeMcpOAuthAuthorization(
+  identity: McpOAuthIdentity,
+  config: ResolvedHttpMcpTransportConfig,
+  input: { code: string },
+): Promise<"authorized"> {
+  const storeKey = identity.storeKey;
+  return await withMcpOAuthLease<"authorized">(storeKey, async (lease) => {
+    const store = readMcpOAuthStore(storeKey);
+    if (!store.codeVerifier || !store.redirectUrl) {
+      throw new Error("Missing MCP OAuth authorization session. Run the login flow again.");
+    }
+    const pendingChallenge = store.pendingAuthorizationChallenge;
+    await runMcpOAuthAuthorizationAttempt(
+      {
+        identity,
+        config: { ...config.oauth, redirectUrl: store.redirectUrl },
+        fetchFn: buildMcpOAuthAuthorizationFetch(config),
+        authorizationCode: input.code,
+        resourceMetadataUrl: pendingChallenge?.resourceMetadataUrl
+          ? new URL(pendingChallenge.resourceMetadataUrl)
+          : undefined,
+        scope: normalizeOptionalString(pendingChallenge?.scope),
+        suppressStoredTokens: pendingChallenge?.requiresAuthorization === true,
+      },
+      lease,
+    );
+    updateMcpOAuthStore(
+      storeKey,
+      (current) => {
+        const next = { ...current };
+        delete next.codeVerifier;
+        delete next.lastAuthorizationUrl;
+        delete next.redirectUrl;
+        return next;
+      },
+      bindMcpOAuthLeaseAssertion(lease),
+    );
+    return "authorized";
   });
 }

--- a/src/agents/mcp-transport.test.ts
+++ b/src/agents/mcp-transport.test.ts
@@ -320,8 +320,10 @@ describe("resolveMcpTransport", () => {
     expect(options.requestInit).toBeUndefined();
     expect(oauthBearerMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        serverName: "probe",
-        resourceUrl: "https://mcp.example.com/mcp",
+        identity: expect.objectContaining({
+          serverName: "probe",
+          serverUrl: "https://mcp.example.com/mcp",
+        }),
       }),
     );
   });

--- a/src/agents/mcp-transport.ts
+++ b/src/agents/mcp-transport.ts
@@ -20,6 +20,7 @@ import {
   withSameOriginMcpHttpHeaders,
 } from "./mcp-http-fetch.js";
 import { withMcpOAuthBearer } from "./mcp-oauth-fetch.js";
+import { operatorMcpOAuthIdentity } from "./mcp-oauth-identity.js";
 import { OpenClawStdioClientTransport } from "./mcp-stdio-transport.js";
 import { resolveMcpTransportConfig } from "./mcp-transport-config.js";
 
@@ -117,6 +118,7 @@ export function resolveMcpTransport(
     };
   }
   const authProfileId = resolveMcpAuthProfileId(rawServer);
+  const oauthIdentity = operatorMcpOAuthIdentity(serverName, resolved.url);
   // The SDK reuses one fetch for OAuth and long-lived SSE/streamable bodies.
   // Per-RPC deadlines belong to client calls, not this transport fetch.
   const baseFetch = buildMcpHttpFetch({
@@ -150,8 +152,7 @@ export function resolveMcpTransport(
           // Protected-resource discovery lives at the resource origin and may
           // require the same routing headers. Cross-origin auth calls stay scrubbed.
           authFetchFn: resourceFetch,
-          serverName,
-          resourceUrl: resolved.url,
+          identity: oauthIdentity,
           config: resolved.oauth,
         })
       : baseFetch;

--- a/src/cli/mcp-cli.login-loopback.test.ts
+++ b/src/cli/mcp-cli.login-loopback.test.ts
@@ -22,7 +22,8 @@ const mocks = vi.hoisted(() => {
   };
   return {
     runtime,
-    runMcpOAuthLogin: vi.fn(),
+    completeMcpOAuthAuthorization: vi.fn(),
+    startMcpOAuthAuthorization: vi.fn(),
     readMcpOAuthCredentialsStatus: vi.fn(),
     createSessionMcpRuntimeOverride: undefined as CreateSessionMcpRuntime | undefined,
   };
@@ -32,8 +33,9 @@ vi.mock("../runtime.js", () => ({ defaultRuntime: mocks.runtime }));
 vi.mock("../mcp/channel-server.js", () => ({ serveOpenClawChannelMcp: vi.fn() }));
 vi.mock("../agents/mcp-oauth.js", () => ({
   clearMcpOAuthCredentials: vi.fn(),
+  completeMcpOAuthAuthorization: mocks.completeMcpOAuthAuthorization,
   readMcpOAuthCredentialsStatus: mocks.readMcpOAuthCredentialsStatus,
-  runMcpOAuthLogin: mocks.runMcpOAuthLogin,
+  startMcpOAuthAuthorization: mocks.startMcpOAuthAuthorization,
 }));
 vi.mock("../agents/agent-bundle-mcp-runtime.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../agents/agent-bundle-mcp-runtime.js")>();
@@ -74,23 +76,15 @@ async function configureServer(): Promise<void> {
 }
 
 function mockRedirectFlow(redirectUrl: string): void {
-  mocks.runMcpOAuthLogin.mockImplementation(
-    async (params: {
-      authorizationCode?: string;
-      onAuthorizationUrl?: (url: URL) => void | Promise<void>;
-      onAuthorizationSession?: (session: { codeVerifier: string; redirectUrl: string }) => void;
-    }) => {
-      if (params.authorizationCode) {
-        return "authorized";
-      }
-      const authorizationUrl = new URL("https://auth.example.com/authorize");
-      authorizationUrl.searchParams.set("redirect_uri", redirectUrl);
-      authorizationUrl.searchParams.set("state", "state-1234567890");
-      await params.onAuthorizationUrl?.(authorizationUrl);
-      params.onAuthorizationSession?.({ codeVerifier: "verifier-123", redirectUrl });
-      return "redirect";
-    },
-  );
+  const authorizationUrl = new URL("https://auth.example.com/authorize");
+  authorizationUrl.searchParams.set("redirect_uri", redirectUrl);
+  authorizationUrl.searchParams.set("state", "state-1234567890");
+  mocks.startMcpOAuthAuthorization.mockResolvedValue({
+    authorizationUrl: authorizationUrl.toString(),
+    redirectUrl,
+    state: "state-1234567890",
+  });
+  mocks.completeMcpOAuthAuthorization.mockResolvedValue("authorized");
 }
 
 describe("mcp login loopback callback", () => {
@@ -131,17 +125,17 @@ describe("mcp login loopback callback", () => {
 
       const wrong = await fetch(`${redirectUrl}?code=wrong&state=wrong`);
       expect(wrong.status).toBe(400);
-      expect(mocks.runMcpOAuthLogin).toHaveBeenCalledOnce();
+      expect(mocks.startMcpOAuthAuthorization).toHaveBeenCalledOnce();
+      expect(mocks.completeMcpOAuthAuthorization).not.toHaveBeenCalled();
 
       const response = await fetch(`${redirectUrl}?code=right&state=state-1234567890`);
       expect(response.status).toBe(200);
       await expect(response.text()).resolves.toContain("Authorization received");
       await login;
 
-      expect(mocks.runMcpOAuthLogin).toHaveBeenCalledTimes(2);
-      expect(mocks.runMcpOAuthLogin).toHaveBeenLastCalledWith(
-        expect.objectContaining({ authorizationCode: "right" }),
-      );
+      expect(mocks.startMcpOAuthAuthorization).toHaveBeenCalledOnce();
+      expect(mocks.completeMcpOAuthAuthorization).toHaveBeenCalledOnce();
+      expect(mocks.completeMcpOAuthAuthorization.mock.calls[0]?.[2]).toEqual({ code: "right" });
       expect(mocks.runtime.log).toHaveBeenCalledWith('MCP OAuth credentials saved for "docs".');
     });
   });
@@ -164,7 +158,8 @@ describe("mcp login loopback callback", () => {
       expect(mocks.runtime.log.mock.calls.some(([line]) => String(line).includes("--code"))).toBe(
         true,
       );
-      expect(mocks.runMcpOAuthLogin).toHaveBeenCalledOnce();
+      expect(mocks.startMcpOAuthAuthorization).toHaveBeenCalledOnce();
+      expect(mocks.completeMcpOAuthAuthorization).not.toHaveBeenCalled();
       await new Promise<void>((resolve) => {
         blocker.close(() => resolve());
       });

--- a/src/cli/mcp-cli.oauth-integration.test.ts
+++ b/src/cli/mcp-cli.oauth-integration.test.ts
@@ -3,6 +3,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { createServer } from "node:http";
 import { Command } from "commander";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { operatorMcpOAuthIdentity } from "../agents/mcp-oauth-identity.js";
 import { readMcpOAuthCredentialsStatus } from "../agents/mcp-oauth.js";
 import { withTempHome } from "../config/home-env.test-harness.js";
 import { defaultRuntime } from "../runtime.js";
@@ -162,11 +163,14 @@ describe("mcp login OAuth integration", () => {
         await login;
 
         await expect(
-          readMcpOAuthCredentialsStatus({
-            serverName: "fixture",
-            serverUrl: `${fixture.issuer}/mcp`,
-          }),
-        ).resolves.toMatchObject({ hasTokens: true, hasCodeVerifier: true });
+          readMcpOAuthCredentialsStatus(
+            operatorMcpOAuthIdentity("fixture", `${fixture.issuer}/mcp`),
+          ),
+        ).resolves.toMatchObject({
+          hasTokens: true,
+          hasCodeVerifier: false,
+          hasLastAuthorizationUrl: false,
+        });
         expect(fixture.exchange()).toMatchObject({
           tokenRedirectUri: redirectUrl,
           tokenVerifier: expect.any(String),

--- a/src/cli/mcp-cli.oauth.test.ts
+++ b/src/cli/mcp-cli.oauth.test.ts
@@ -1,17 +1,16 @@
 // MCP CLI OAuth tests cover credential status, login callbacks, and logout behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import * as mcpHttpFetch from "../agents/mcp-http-fetch.js";
 import { withTempHome } from "../config/home-env.test-harness.js";
 import {
   cleanupMcpCliTestState,
   clearMcpOAuthCredentials,
+  completeMcpOAuthAuthorization,
   createWorkspace,
   lastLogLine,
   mockLog,
   readMcpOAuthCredentialsStatus,
   resetMcpCliTestState,
   runMcpCommand,
-  runMcpOAuthLogin,
 } from "./mcp-cli.test-harness.js";
 
 describe("mcp cli OAuth", () => {
@@ -114,8 +113,7 @@ describe("mcp cli OAuth", () => {
     await withTempHome("openclaw-cli-mcp-home-", async () => {
       const workspaceDir = await createWorkspace();
       vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
-      const buildMcpHttpFetch = vi.spyOn(mcpHttpFetch, "buildMcpHttpFetch");
-      runMcpOAuthLogin.mockResolvedValueOnce("authorized");
+      completeMcpOAuthAuthorization.mockResolvedValueOnce("authorized");
 
       await runMcpCommand([
         "mcp",
@@ -135,19 +133,14 @@ describe("mcp cli OAuth", () => {
       ]);
       await runMcpCommand(["mcp", "login", "docs", "--code", "abc123"]);
 
-      expect(buildMcpHttpFetch).toHaveBeenCalledWith(
+      expect(completeMcpOAuthAuthorization).toHaveBeenCalledWith(
         expect.objectContaining({
-          resourceUrl: "https://mcp.example.com",
-          timeoutMs: 9_000,
+          serverName: "docs",
+          serverUrl: "https://mcp.example.com",
         }),
+        expect.objectContaining({ url: "https://mcp.example.com" }),
+        { code: "abc123" },
       );
-      expect(runMcpOAuthLogin).toHaveBeenCalledWith({
-        serverName: "docs",
-        serverUrl: "https://mcp.example.com",
-        config: undefined,
-        fetchFn: expect.any(Function),
-        authorizationCode: "abc123",
-      });
 
       mockLog.mockClear();
       await runMcpCommand(["mcp", "status", "--json"]);
@@ -175,10 +168,12 @@ describe("mcp cli OAuth", () => {
       clearMcpOAuthCredentials.mockClear();
       await runMcpCommand(["mcp", "logout", "docs"]);
 
-      expect(clearMcpOAuthCredentials).toHaveBeenCalledWith({
-        serverName: "docs",
-        serverUrl: "https://mcp.example.com",
-      });
+      expect(clearMcpOAuthCredentials).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serverName: "docs",
+          serverUrl: "https://mcp.example.com",
+        }),
+      );
       expect(lastLogLine()).toBe('MCP OAuth credentials cleared for "docs".');
     });
   });
@@ -197,10 +192,12 @@ describe("mcp cli OAuth", () => {
       clearMcpOAuthCredentials.mockClear();
       await runMcpCommand(["mcp", "logout", "docs"]);
 
-      expect(clearMcpOAuthCredentials).toHaveBeenCalledWith({
-        serverName: "docs",
-        serverUrl: "https://mcp.example.com",
-      });
+      expect(clearMcpOAuthCredentials).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serverName: "docs",
+          serverUrl: "https://mcp.example.com",
+        }),
+      );
     });
   });
 });

--- a/src/cli/mcp-cli.test-harness.ts
+++ b/src/cli/mcp-cli.test-harness.ts
@@ -23,8 +23,9 @@ const mocks = vi.hoisted(() => {
     runtime,
     serveOpenClawChannelMcp: vi.fn(),
     clearMcpOAuthCredentials: vi.fn(),
+    completeMcpOAuthAuthorization: vi.fn(),
     readMcpOAuthCredentialsStatus: vi.fn(),
-    runMcpOAuthLogin: vi.fn(),
+    startMcpOAuthAuthorization: vi.fn(),
     createSessionMcpRuntimeOverride: undefined as CreateSessionMcpRuntime | undefined,
   };
 });
@@ -33,8 +34,9 @@ export const mockLog = mocks.runtime.log;
 export const mockError = mocks.runtime.error;
 export const serveOpenClawChannelMcp = mocks.serveOpenClawChannelMcp;
 export const clearMcpOAuthCredentials = mocks.clearMcpOAuthCredentials;
+export const completeMcpOAuthAuthorization = mocks.completeMcpOAuthAuthorization;
 export const readMcpOAuthCredentialsStatus = mocks.readMcpOAuthCredentialsStatus;
-export const runMcpOAuthLogin = mocks.runMcpOAuthLogin;
+export const startMcpOAuthAuthorization = mocks.startMcpOAuthAuthorization;
 
 vi.mock("../runtime.js", () => ({
   defaultRuntime: mocks.runtime,
@@ -46,8 +48,9 @@ vi.mock("../mcp/channel-server.js", () => ({
 
 vi.mock("../agents/mcp-oauth.js", () => ({
   clearMcpOAuthCredentials: mocks.clearMcpOAuthCredentials,
+  completeMcpOAuthAuthorization: mocks.completeMcpOAuthAuthorization,
   readMcpOAuthCredentialsStatus: mocks.readMcpOAuthCredentialsStatus,
-  runMcpOAuthLogin: mocks.runMcpOAuthLogin,
+  startMcpOAuthAuthorization: mocks.startMcpOAuthAuthorization,
 }));
 
 vi.mock("../agents/agent-bundle-mcp-runtime.js", async (importOriginal) => {

--- a/src/cli/mcp-cli.test-harness.ts
+++ b/src/cli/mcp-cli.test-harness.ts
@@ -36,7 +36,6 @@ export const serveOpenClawChannelMcp = mocks.serveOpenClawChannelMcp;
 export const clearMcpOAuthCredentials = mocks.clearMcpOAuthCredentials;
 export const completeMcpOAuthAuthorization = mocks.completeMcpOAuthAuthorization;
 export const readMcpOAuthCredentialsStatus = mocks.readMcpOAuthCredentialsStatus;
-export const startMcpOAuthAuthorization = mocks.startMcpOAuthAuthorization;
 
 vi.mock("../runtime.js", () => ({
   defaultRuntime: mocks.runtime,

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -646,10 +646,12 @@ describe("mcp cli", () => {
       ]);
       await runMcpCommand(["mcp", "configure", "docs", "--clear-auth"]);
 
-      expect(clearMcpOAuthCredentials).toHaveBeenCalledWith({
-        serverName: "docs",
-        serverUrl: "https://mcp.example.com",
-      });
+      expect(clearMcpOAuthCredentials).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serverName: "docs",
+          serverUrl: "https://mcp.example.com",
+        }),
+      );
 
       mockLog.mockClear();
       await runMcpCommand(["mcp", "show", "docs", "--json"]);
@@ -670,10 +672,12 @@ describe("mcp cli", () => {
       ]);
       await runMcpCommand(["mcp", "unset", "docs"]);
 
-      expect(clearMcpOAuthCredentials).toHaveBeenCalledWith({
-        serverName: "docs",
-        serverUrl: "https://mcp.example.com",
-      });
+      expect(clearMcpOAuthCredentials).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serverName: "docs",
+          serverUrl: "https://mcp.example.com",
+        }),
+      );
     });
   });
 
@@ -691,10 +695,12 @@ describe("mcp cli", () => {
       clearMcpOAuthCredentials.mockClear();
       await runMcpCommand(["mcp", "set", "docs", '{"command":"uvx","args":["docs-mcp"]}']);
 
-      expect(clearMcpOAuthCredentials).toHaveBeenCalledWith({
-        serverName: "docs",
-        serverUrl: "https://mcp.example.com",
-      });
+      expect(clearMcpOAuthCredentials).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serverName: "docs",
+          serverUrl: "https://mcp.example.com",
+        }),
+      );
     });
   });
 
@@ -723,10 +729,12 @@ describe("mcp cli", () => {
         "--no-probe",
       ]);
 
-      expect(clearMcpOAuthCredentials).toHaveBeenCalledWith({
-        serverName: "docs",
-        serverUrl: "https://mcp.example.com",
-      });
+      expect(clearMcpOAuthCredentials).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serverName: "docs",
+          serverUrl: "https://mcp.example.com",
+        }),
+      );
     });
   });
 

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -12,16 +12,12 @@ import {
 import { Command } from "commander";
 import { buildBundleMcpToolsFromCatalog } from "../agents/agent-bundle-mcp-materialize.js";
 import { createSessionMcpRuntime } from "../agents/agent-bundle-mcp-runtime.js";
-import {
-  buildMcpHttpFetch,
-  withoutMcpAuthorizationHeader,
-  withSameOriginMcpHttpHeaders,
-} from "../agents/mcp-http-fetch.js";
+import { operatorMcpOAuthIdentity } from "../agents/mcp-oauth-identity.js";
 import {
   clearMcpOAuthCredentials,
+  completeMcpOAuthAuthorization,
   readMcpOAuthCredentialsStatus,
-  runMcpOAuthLogin,
-  type McpOAuthAuthorizationSession,
+  startMcpOAuthAuthorization,
   type McpOAuthCredentialsStatus,
 } from "../agents/mcp-oauth.js";
 import { resolveMcpTransportConfig } from "../agents/mcp-transport-config.js";
@@ -126,7 +122,7 @@ async function clearMcpOAuthCredentialsForConfiguredServer(
 ): Promise<void> {
   const resolved = resolveMcpTransportConfig(name, server);
   if (resolved?.kind === "http") {
-    await clearMcpOAuthCredentials({ serverName: name, serverUrl: resolved.url });
+    await clearMcpOAuthCredentials(operatorMcpOAuthIdentity(name, resolved.url));
   }
 }
 
@@ -155,10 +151,7 @@ async function clearStaleMcpOAuthCredentialsForReplacement(params: {
   if (nextResolved?.kind === "http" && nextResolved.url === previousResolved.url) {
     return;
   }
-  await clearMcpOAuthCredentials({
-    serverName: params.name,
-    serverUrl: previousResolved.url,
-  });
+  await clearMcpOAuthCredentials(operatorMcpOAuthIdentity(params.name, previousResolved.url));
 }
 
 function setOptionalField(target: Record<string, unknown>, key: string, value: unknown): void {
@@ -326,10 +319,9 @@ async function collectMcpDoctorIssues(params: {
     }
     if (resolved?.kind === "http") {
       if (server.auth === "oauth") {
-        const authStatus = await readMcpOAuthCredentialsStatus({
-          serverName: name,
-          serverUrl: resolved.url,
-        });
+        const authStatus = await readMcpOAuthCredentialsStatus(
+          operatorMcpOAuthIdentity(name, resolved.url),
+        );
         if (authStatus.requiresAuthorization) {
           issues.push(
             issue(
@@ -463,10 +455,9 @@ async function buildMcpStatusEntries(
         entry.auth = server.auth;
       }
       if (server.auth === "oauth" && resolved?.kind === "http") {
-        entry.authStatus = await readMcpOAuthCredentialsStatus({
-          serverName: name,
-          serverUrl: resolved.url,
-        });
+        entry.authStatus = await readMcpOAuthCredentialsStatus(
+          operatorMcpOAuthIdentity(name, resolved.url),
+        );
       }
       return entry;
     }),
@@ -1329,73 +1320,39 @@ export function registerMcpCli(program: Command) {
       if (!resolved || resolved.kind !== "http") {
         fail(`MCP server "${name}" needs a valid HTTP transport for OAuth login.`);
       }
-      const loginParams = {
-        serverName: name,
-        serverUrl: resolved.url,
-        config: server.oauth as Record<string, string> | undefined,
-        fetchFn: withSameOriginMcpHttpHeaders({
-          fetchFn: buildMcpHttpFetch({
-            sslVerify: resolved.sslVerify,
-            clientCert: resolved.clientCert,
-            clientKey: resolved.clientKey,
-            resourceUrl: resolved.url,
-            timeoutMs: resolved.requestTimeoutMs,
-          }),
-          headers: withoutMcpAuthorizationHeader(resolved.headers),
-          resourceUrl: resolved.url,
-        }),
-      };
+      const identity = operatorMcpOAuthIdentity(name, resolved.url);
       if (opts.code) {
-        const result = await runMcpOAuthLogin({
-          ...loginParams,
-          authorizationCode: opts.code,
+        await completeMcpOAuthAuthorization(identity, resolved, {
+          code: opts.code,
         });
-        if (result === "authorized") {
-          defaultRuntime.log(`MCP OAuth credentials saved for "${name}".`);
-        }
+        defaultRuntime.log(`MCP OAuth credentials saved for "${name}".`);
         return;
       }
 
       let callbackServer: OAuthLoopbackCallbackServer | undefined;
-      let authorizationSession: McpOAuthAuthorizationSession | undefined;
       const manualCommand = formatCliCommand(`openclaw mcp login ${name} --code <code>`);
       try {
-        const result = await runMcpOAuthLogin({
-          ...loginParams,
-          onAuthorizationSession: (session) => {
-            authorizationSession = session;
-          },
-          onAuthorizationUrl: async (url) => {
-            const redirectValue = url.searchParams.get("redirect_uri");
-            const expectedState = url.searchParams.get("state");
-            if (redirectValue && expectedState && expectedState.length >= 16) {
-              try {
-                callbackServer = await startOAuthLoopbackCallbackServer({
-                  redirectUrl: redirectValue,
-                  expectedState,
-                  timeoutMs: MCP_OAUTH_CALLBACK_TIMEOUT_MS,
-                });
-              } catch (error) {
-                defaultRuntime.log(
-                  `Could not start the local OAuth callback (${formatErrorMessage(error)}).`,
-                );
-              }
-            }
-            defaultRuntime.log(`Open this URL to authorize "${name}":`);
-            defaultRuntime.log(url.toString());
-            if (callbackServer) {
-              defaultRuntime.log("Waiting for the browser to return to OpenClaw...");
-              defaultRuntime.log(
-                `If the callback cannot reach this terminal, run ${manualCommand}.`,
-              );
-            } else {
-              defaultRuntime.log(`After approval, run ${manualCommand}.`);
-            }
-          },
-        });
-        if (result === "authorized") {
-          defaultRuntime.log(`MCP OAuth credentials saved for "${name}".`);
-          return;
+        const session = await startMcpOAuthAuthorization(identity, resolved, {});
+        if (session.state.length >= 16) {
+          try {
+            callbackServer = await startOAuthLoopbackCallbackServer({
+              redirectUrl: session.redirectUrl,
+              expectedState: session.state,
+              timeoutMs: MCP_OAUTH_CALLBACK_TIMEOUT_MS,
+            });
+          } catch (error) {
+            defaultRuntime.log(
+              `Could not start the local OAuth callback (${formatErrorMessage(error)}).`,
+            );
+          }
+        }
+        defaultRuntime.log(`Open this URL to authorize "${name}":`);
+        defaultRuntime.log(session.authorizationUrl);
+        if (callbackServer) {
+          defaultRuntime.log("Waiting for the browser to return to OpenClaw...");
+          defaultRuntime.log(`If the callback cannot reach this terminal, run ${manualCommand}.`);
+        } else {
+          defaultRuntime.log(`After approval, run ${manualCommand}.`);
         }
         if (!callbackServer) {
           return;
@@ -1410,19 +1367,9 @@ export function registerMcpCli(program: Command) {
         if (callback.type === "oauth_error") {
           fail(`OAuth authorization did not complete. Retry login or use ${manualCommand}.`);
         }
-        const session = authorizationSession;
-        if (!session) {
-          fail(`OAuth login state was not preserved. Retry login or use ${manualCommand}.`);
-        }
-        const exchangeResult = await runMcpOAuthLogin({
-          ...loginParams,
-          config: { ...loginParams.config, redirectUrl: session.redirectUrl },
-          authorizationCode: callback.code,
-          codeVerifier: session.codeVerifier,
+        await completeMcpOAuthAuthorization(identity, resolved, {
+          code: callback.code,
         });
-        if (exchangeResult !== "authorized") {
-          fail(`OAuth login did not complete. Retry login or use ${manualCommand}.`);
-        }
         defaultRuntime.log(`MCP OAuth credentials saved for "${name}".`);
       } finally {
         await callbackServer?.close();
@@ -1448,10 +1395,7 @@ export function registerMcpCli(program: Command) {
       if (!resolved || resolved.kind !== "http") {
         fail(`MCP server "${name}" needs a valid HTTP transport for OAuth logout.`);
       }
-      await clearMcpOAuthCredentials({
-        serverName: name,
-        serverUrl: resolved.url,
-      });
+      await clearMcpOAuthCredentials(operatorMcpOAuthIdentity(name, resolved.url));
       defaultRuntime.log(`MCP OAuth credentials cleared for "${name}".`);
     });
 

--- a/src/infra/state-migrations.mcp-oauth.test.ts
+++ b/src/infra/state-migrations.mcp-oauth.test.ts
@@ -5,8 +5,8 @@ import fsp from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { operatorMcpOAuthIdentity } from "../agents/mcp-oauth-identity.js";
 import { createMcpOAuthClientProvider } from "../agents/mcp-oauth-provider.js";
-import { resolveMcpOAuthStoreKey } from "../agents/mcp-oauth-store.js";
 import { clearMcpOAuthCredentials, resolveMcpOAuthAccessToken } from "../agents/mcp-oauth.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
@@ -297,20 +297,19 @@ describe("legacy MCP OAuth Doctor migration", () => {
     const { env, stateDir } = useStateDir();
     const serverName = "Remote Docs";
     const serverUrl = "https://mcp.example.com/mcp";
-    const storeKey = resolveMcpOAuthStoreKey(serverName, serverUrl);
+    const identity = operatorMcpOAuthIdentity(serverName, serverUrl);
+    const storeKey = identity.storeKey;
     vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
     await expect(
       resolveMcpOAuthAccessToken({
-        serverName,
-        serverUrl,
+        identity,
         authorizationChallenge: true,
         scope: "docs.read",
       }),
     ).rejects.toThrow("Run openclaw mcp login Remote Docs.");
     const provider = createMcpOAuthClientProvider({
-      serverName,
-      serverUrl,
-      onAuthorizationUrl: () => {},
+      identity,
+      allowAuthorizationRedirect: true,
     });
     await provider.saveCodeVerifier("new-login-verifier");
     const sourcePath = await writeLegacy({
@@ -343,14 +342,15 @@ describe("legacy MCP OAuth Doctor migration", () => {
     const { env, stateDir } = useStateDir();
     const serverName = "Remote Docs";
     const serverUrl = "https://mcp.example.com/mcp";
-    const storeKey = resolveMcpOAuthStoreKey(serverName, serverUrl);
+    const identity = operatorMcpOAuthIdentity(serverName, serverUrl);
+    const storeKey = identity.storeKey;
     const sourcePath = await writeLegacy({
       stateDir,
       fileName: `${storeKey}.json`,
     });
     vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
 
-    await clearMcpOAuthCredentials({ serverName, serverUrl });
+    await clearMcpOAuthCredentials(identity);
     expect(JSON.parse(storeRow(env, storeKey)?.store_json ?? "null")).toEqual({
       credentialState: "cleared",
     });

--- a/src/infra/state-migrations.mcp-oauth.ts
+++ b/src/infra/state-migrations.mcp-oauth.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { root, type Root } from "@openclaw/fs-safe";
+import { mcpOAuthStoreKeyFromLegacyFileName } from "../agents/mcp-oauth-identity.js";
 import { parseMcpOAuthStoreJson } from "../agents/mcp-oauth-store.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
@@ -36,7 +37,6 @@ const LEGACY_MCP_OAUTH_DIR = "mcp-oauth";
 const DOCTOR_CLAIM_SUFFIX = ".doctor-importing";
 const MIGRATION_KIND = "legacy-mcp-oauth-json";
 const MAX_LEGACY_STORE_BYTES = 4 * 1024 * 1024;
-const LEGACY_STORE_NAME_RE = /^[A-Za-z][A-Za-z0-9_-]{0,29}-[0-9a-f]{16}\.json$/u;
 const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
 
 type McpOAuthMigrationDatabase = Pick<OpenClawStateKyselyDatabase, "mcp_oauth_stores">;
@@ -55,7 +55,7 @@ function exactLegacyBaseName(name: string): string | null {
   const baseName = name.endsWith(DOCTOR_CLAIM_SUFFIX)
     ? name.slice(0, -DOCTOR_CLAIM_SUFFIX.length)
     : name;
-  return LEGACY_STORE_NAME_RE.test(baseName) ? baseName : null;
+  return mcpOAuthStoreKeyFromLegacyFileName(baseName) ? baseName : null;
 }
 
 function exactLegacyBaseNames(entries: Iterable<{ name: string }>): string[] {
@@ -130,11 +130,11 @@ async function readLegacySourceSnapshot(
 }
 
 function storeKeyForSource(sourcePath: string): string {
-  const fileName = path.basename(sourcePath);
-  if (!LEGACY_STORE_NAME_RE.test(fileName)) {
+  const storeKey = mcpOAuthStoreKeyFromLegacyFileName(path.basename(sourcePath));
+  if (!storeKey) {
     throw new Error("legacy MCP OAuth filename is invalid");
   }
-  return fileName.slice(0, -".json".length);
+  return storeKey;
 }
 
 function importAndRecordReceipt(params: {


### PR DESCRIPTION
## What Problem This Solves

The MCP OAuth cluster hardwires "whose tokens" to the operator: three modules independently derive the store key from (serverName, serverUrl), the key silently doubles as the refresh-lease key, and the interactive authorize → capture → exchange dance lives as ~125 lines inside a Commander action with its contract proven only against a whole-module mock. Per-requester OAuth (multiplayer tool identity, #122034) cannot be built on that shape without smearing a principal parameter across five signatures and copy-pasting the login dance for a second driver.

## Why This Change Was Made

Prep refactor for #122034, behavior-neutral for operators. Part A: `McpOAuthIdentity` (src/agents/mcp-oauth-identity.ts) becomes the single owner of the store-key grammar — operator keys are byte-identical to today's, so existing rows keep working with zero migration; provider, coordinator, fetch wrapper, transport, CLI, auth-profile projection, and doctor all receive an identity instead of re-deriving keys (`resolveMcpOAuthStoreKey` deleted, zero references remain). Part B: the authorization dance moves into the coordinator as a resumable session — `startMcpOAuthAuthorization` persists the pending verifier/authorize URL in the existing store-row slots and releases the lease; `completeMcpOAuthAuthorization` reacquires it and exchanges the code — leaving the CLI loopback as a pure capture adapter and giving the future gateway callback route (multiplayer) a real seam with an executable contract.

## User Impact

None intended: `openclaw mcp login` flow, manual `--code` path, doctor migrations, and #112032's issuer-binding security behavior are preserved (its test scenarios migrated mechanically to the identity interface with assertions semantically unchanged).

## Evidence

- Grouped focused run green (exit 0): `node scripts/run-vitest.mjs src/agents/mcp-oauth src/agents/mcp-transport src/agents/mcp-auth-profile src/cli/mcp-cli src/infra/state-migrations.mcp-oauth`
- New coordinator boundary tests drive start → pending-persisted → simulated restart → complete against the real SQLite store; wrong code fails without clearing pending; a second start supersedes the first.
- Production LOC net −7 (+224/−231); tests net −8, with mock-heavy CLI dance tests replaced by interface-level coordinator tests.
- `git diff --check`, oxfmt, tsgo lanes clean on the patch.
