### PR TITLE
refactor(state): centralize keyed audit record mutations

### DIFF
--- a/src/infra/sqlite-audit-record-store.test.ts
+++ b/src/infra/sqlite-audit-record-store.test.ts
@@ -98,7 +98,7 @@ describe("SQLite audit record store", () => {
     });
   });
 
-  it("updates a retained key without consuming another bounded entry", async () => {
+  it("keeps keyed mutations atomic without changing insertion age", async () => {
     await withTempDir({ prefix: "openclaw-audit-store-upsert-" }, async (stateDir) => {
       const store = createSqliteAuditRecordStore<{ value: number }>({
         scope: "upsert-test",
@@ -109,11 +109,39 @@ describe("SQLite audit record store", () => {
       store.register("one", { value: 1 }, 1);
       store.register("two", { value: 2 }, 2);
       store.upsert("one", { value: 3 }, 3);
+      expect(store.latest({ limit: 2 })).toEqual([
+        { key: "two", value: { value: 2 }, createdAt: 2, sequence: 2 },
+        { key: "one", value: { value: 3 }, createdAt: 3, sequence: 1 },
+      ]);
 
-      expect(store.size()).toBe(2);
-      expect(store.entries()).toEqual([
-        { key: "one", value: { value: 3 }, createdAt: 3 },
-        { key: "two", value: { value: 2 }, createdAt: 2 },
+      expect(store.compareAndSet("one", { value: 3 }, { value: 4 }, 4)).toBe(true);
+      expect(store.latest({ limit: 2 })).toEqual([
+        { key: "two", value: { value: 2 }, createdAt: 2, sequence: 2 },
+        { key: "one", value: { value: 4 }, createdAt: 4, sequence: 1 },
+      ]);
+
+      expect(store.compareAndSet("one", { value: 999 }, null)).toBe(false);
+      expect(store.latest({ limit: 2 })).toEqual([
+        { key: "two", value: { value: 2 }, createdAt: 2, sequence: 2 },
+        { key: "one", value: { value: 4 }, createdAt: 4, sequence: 1 },
+      ]);
+
+      expect(store.compareAndSet("one", { value: 4 }, null)).toBe(true);
+      expect(store.compareAndSet("three", null, { value: 5 }, 5)).toBe(true);
+      expect(store.latest({ limit: 2 })).toEqual([
+        { key: "three", value: { value: 5 }, createdAt: 5, sequence: 3 },
+        { key: "two", value: { value: 2 }, createdAt: 2, sequence: 2 },
+      ]);
+
+      expect(store.compareAndSet("four", null, { value: 6 }, 6)).toBe(true);
+      expect(store.latest({ limit: 2 })).toEqual([
+        { key: "four", value: { value: 6 }, createdAt: 6, sequence: 4 },
+        { key: "three", value: { value: 5 }, createdAt: 5, sequence: 3 },
+      ]);
+
+      store.delete("four");
+      expect(store.latest({ limit: 2 })).toEqual([
+        { key: "three", value: { value: 5 }, createdAt: 5, sequence: 3 },
       ]);
     });
   });

--- a/src/infra/sqlite-audit-record-store.ts
+++ b/src/infra/sqlite-audit-record-store.ts
@@ -1,4 +1,4 @@
-// Shared SQLite storage for append-only diagnostic audit records.
+// Shared SQLite storage for bounded diagnostic audit records.
 import type { DatabaseSync } from "node:sqlite";
 import type { Selectable } from "kysely";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
@@ -112,7 +112,7 @@ function pruneAuditRecords(params: {
   }
 }
 
-/** Opens one bounded append-only audit scope in the shared state database. */
+/** Opens one bounded audit-record scope in the shared state database. */
 export function createSqliteAuditRecordStore<T>(
   options: OpenClawStateDatabaseOptions & { scope: string; maxEntries: number },
 ) {
@@ -146,6 +146,39 @@ export function createSqliteAuditRecordStore<T>(
     );
   }
 
+  function upsertPreparedRecord(database: DatabaseSync, record: PreparedDiagnosticEventRow): void {
+    executeSqliteQuerySync(
+      database,
+      getAuditRecordKysely(database)
+        .insertInto("diagnostic_events")
+        .values({
+          scope,
+          event_key: record.event_key,
+          payload_json: record.payload_json,
+          created_at: record.created_at,
+          sequence: nextAuditSequence({ database, scope, legacy: false }),
+        })
+        .onConflict((conflict) =>
+          conflict.columns(["scope", "event_key"]).doUpdateSet({
+            payload_json: record.payload_json,
+            created_at: record.created_at,
+            // Updates retain their sequence because reordering keyed state changes retention age.
+          }),
+        ),
+    );
+    pruneAuditRecords({ database, scope, maxEntries, protectedKey: record.event_key });
+  }
+
+  function deleteRecord(database: DatabaseSync, key: string): void {
+    executeSqliteQuerySync(
+      database,
+      getAuditRecordKysely(database)
+        .deleteFrom("diagnostic_events")
+        .where("scope", "=", scope)
+        .where("event_key", "=", key),
+    );
+  }
+
   return {
     register(key: string, value: T, createdAt = Date.now()): void {
       const record = prepareRecord({ key, value, createdAt });
@@ -167,41 +200,12 @@ export function createSqliteAuditRecordStore<T>(
     upsert(key: string, value: T, createdAt = Date.now()): void {
       const record = prepareRecord({ key, value, createdAt });
       runOpenClawStateWriteTransaction((database) => {
-        executeSqliteQuerySync(
-          database.db,
-          getAuditRecordKysely(database.db)
-            .insertInto("diagnostic_events")
-            .values({
-              scope,
-              event_key: record.event_key,
-              payload_json: record.payload_json,
-              created_at: record.created_at,
-              sequence: nextAuditSequence({ database: database.db, scope, legacy: false }),
-            })
-            .onConflict((conflict) =>
-              conflict.columns(["scope", "event_key"]).doUpdateSet({
-                payload_json: record.payload_json,
-                created_at: record.created_at,
-              }),
-            ),
-        );
-        pruneAuditRecords({
-          database: database.db,
-          scope,
-          maxEntries,
-          protectedKey: key,
-        });
+        upsertPreparedRecord(database.db, record);
       }, options);
     },
     delete(key: string): void {
       runOpenClawStateWriteTransaction((database) => {
-        executeSqliteQuerySync(
-          database.db,
-          getAuditRecordKysely(database.db)
-            .deleteFrom("diagnostic_events")
-            .where("scope", "=", scope)
-            .where("event_key", "=", key),
-        );
+        deleteRecord(database.db, key);
       }, options);
     },
     compareAndSet(
@@ -226,33 +230,9 @@ export function createSqliteAuditRecordStore<T>(
           return;
         }
         if (record) {
-          executeSqliteQuerySync(
-            database.db,
-            getAuditRecordKysely(database.db)
-              .insertInto("diagnostic_events")
-              .values({
-                scope,
-                event_key: record.event_key,
-                payload_json: record.payload_json,
-                created_at: record.created_at,
-                sequence: nextAuditSequence({ database: database.db, scope, legacy: false }),
-              })
-              .onConflict((conflict) =>
-                conflict.columns(["scope", "event_key"]).doUpdateSet({
-                  payload_json: record.payload_json,
-                  created_at: record.created_at,
-                }),
-              ),
-          );
-          pruneAuditRecords({ database: database.db, scope, maxEntries, protectedKey: key });
+          upsertPreparedRecord(database.db, record);
         } else {
-          executeSqliteQuerySync(
-            database.db,
-            getAuditRecordKysely(database.db)
-              .deleteFrom("diagnostic_events")
-              .where("scope", "=", scope)
-              .where("event_key", "=", key),
-          );
+          deleteRecord(database.db, key);
         }
         updated = true;
       }, options);


### PR DESCRIPTION
## What Problem This Solves

The bounded SQLite audit record store maintained duplicate keyed upsert and delete SQL in its public mutation methods and compare-and-set path. That duplicated retention and sequence policy could drift between ordinary writes and atomic state transitions.

## Why This Change Was Made

Centralize keyed writes in nested synchronous `upsertPreparedRecord` and `deleteRecord` helpers owned by the audit store. Compare-and-set still reads, compares exact serialized JSON, and mutates within one immediate transaction. Updates retain their original sequence; inserts allocate sequence inside the transaction; deletes allocate none.

Removed duplicate mutation paths without changing schema, migrations, public API, callers, legacy registration, or storage format.

## User Impact

No user-visible behavior change. Keyed audit state now has one mutation policy, reducing the risk that config snapshot and system-agent CAS behavior diverges from normal upserts or deletes.

## Evidence

- Head: `1ec20bc2b3d70aa3553d0a7cfc57613872f29539`; reviewed base: `f798f9999b4d25e468a0bd521f004bdd7b87bb2e`. Both target files remained unchanged on newer `main`.
- Graph-backed inspection confirmed the store is the owner boundary with 12 callers; CAS callers include config snapshot and system-agent greeting state.
- `node scripts/run-vitest.mjs src/infra/sqlite-audit-record-store.test.ts` — 7 tests passed.
- `node scripts/run-vitest.mjs src/config/config-journal-snapshot.test.ts` — 4 tests passed.
- `git diff --check` — passed.
- Local autoreview on the complete patch — clean, no accepted/actionable findings.
- Exact-head Blacksmith focused proof: Testbox `tbx_01kzrqqczt6kydxhtxyjt1s4bt`, wrapper exit `0`, 230 tests passed across the audit store, config snapshot, greeting, migrations, backup, and system-changes suites in 56.633s.
- Exact-head Blacksmith changed gate: Testbox `tbx_01kzrvrk3fdqjfj8810x2pbdat`, wrapper exit `0`, 7m06.246s. The command asserted head `1ec20bc2b3d70aa3553d0a7cfc57613872f29539` and compared against reviewed base `f798f9999b4d25e468a0bd521f004bdd7b87bb2e`.
- Exact-head Blacksmith workflow receipt: https://github.com/openclaw/openclaw/actions/runs/31515795326 — `SUCCESS`.
- Literal AWS Crabbox operator smoke: lease `cbx_5141bfc3d986`, run `run_640d8a63b92f`, wrapper exit `0`. In an isolated `OPENCLAW_STATE_DIR`, real `openclaw config set/get` calls observed port `19002`, one config snapshot row, and retained snapshot sequence `1`.
- Production LOC: `+39/-59` (net `-20`). Tests: `+33/-5`.
