### PR TITLE
fix: keep browser tab selection aligned with the displayed page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI browser tab identity:** keep selected tab styling, accessibility, focus, address, and page snapshot aligned across in-place navigation and tab reordering. Fixes #120745. Thanks @shakkernerd.
 - **Control UI staged attachments:** preserve unsent images, files, pasted images, and large pasted text across same-tab route and narrow split-pane remounts while keeping pane close, mismatched pane/session/Gateway remounts, application shutdown, and hard reload as cleanup boundaries. Fixes #121519. Thanks @shakkernerd.
 - **Control UI browser annotations:** keep marked screenshots and generated page context together in structured composer cards, preserve user-written drafts when annotations are removed or replaced, retain complete unsent annotation packages across same-tab route and active split-pane remounts, and offer bounded Undo without restoring removed context into another session. Fixes #120744. Thanks @shakkernerd.
 - **Control UI profile avatar refreshes:** carry canonical content revisions through mutation responses and live presence so rapid replacements refresh every connected browser without stale cache rollback. Thanks @shakkernerd.

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -423,6 +423,8 @@ The terminal is also available as a [full-screen terminal document](/web/urls#sp
 
 The Control UI ships a dockable browser panel that renders the Gateway-controlled browser (the same one agents drive through the [browser tool](/tools/browser-control)) in any regular web browser - no native webview required. It appears when the connected Gateway advertises `browser.request` to an `operator.admin` connection; the globe button in the thread workspace rail toggles it. The panel shows a live page snapshot with tabs, an editable URL bar, back/forward/reload, and open-in-your-browser, docks right or bottom, and forwards clicks, wheel scrolling, and basic typing to the remote page.
 
+Each tab keeps one stable identity across in-place navigation and target replacement, so its selected state, keyboard focus, URL, page snapshot, and browser actions stay aligned even when the Gateway returns tabs in a different order.
+
 Two capture modes package page context for the agent:
 
 - **Annotate (pencil)**: draw freehand markup over the page. **Send to chat** composites the strokes into the screenshot and adds one structured annotation card to the active chat composer. The card keeps its generated page and region context with the image instead of inserting it into your editable draft.

--- a/ui/src/components/browser/browser-client.ts
+++ b/ui/src/components/browser/browser-client.ts
@@ -71,10 +71,6 @@ function stringOrEmpty(value: unknown): string {
   return readStringValue(value) ?? "";
 }
 
-export function errorDetail(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
 function asNullableFiniteNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }

--- a/ui/src/components/browser/browser-client.ts
+++ b/ui/src/components/browser/browser-client.ts
@@ -71,6 +71,10 @@ function stringOrEmpty(value: unknown): string {
   return readStringValue(value) ?? "";
 }
 
+export function errorDetail(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 function asNullableFiniteNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }

--- a/ui/src/components/browser/browser-panel-controller-input.test.ts
+++ b/ui/src/components/browser/browser-panel-controller-input.test.ts
@@ -378,6 +378,76 @@ describe("BrowserPanelController capture and input ownership", () => {
     expect(controller.loading).toBe(false);
   });
 
+  it("reconciles a committed background navigation without stealing the selected view", async () => {
+    stubScreenshotMedia();
+    const navigation = createDeferred<{ ok: boolean }>();
+    const initialUrl = "https://example.test/initial";
+    const destinationUrl = "https://example.test/destination";
+    const selectedUrl = "https://example.test/selected";
+    let backgroundUrl = initialUrl;
+    const { client, request } = createBrowserClient(async (envelope) => {
+      if (envelope.path === "/navigate") {
+        const result = await navigation.promise;
+        backgroundUrl = destinationUrl;
+        return result;
+      }
+      if (envelope.path === "/tabs/focus") {
+        return { ok: true };
+      }
+      if (envelope.path === "/tabs") {
+        return {
+          running: true,
+          tabs: [
+            {
+              tabId: "tab-a",
+              targetId: "raw-a",
+              title: backgroundUrl === destinationUrl ? "Destination" : "Initial",
+              url: backgroundUrl,
+            },
+            {
+              tabId: "tab-b",
+              targetId: "raw-b",
+              title: "Selected",
+              url: selectedUrl,
+            },
+          ],
+        };
+      }
+      if (envelope.path === "/screenshot") {
+        return { path: "/selected.png", targetId: "raw-b", url: selectedUrl };
+      }
+      if (envelope.path === "/act") {
+        return createBrowserPanelTestMetrics(selectedUrl, "Selected");
+      }
+      throw new Error(`Unexpected browser route: ${envelope.path}`);
+    });
+    const controller = createBrowserPanelTestController(client, "tab-a", initialUrl);
+    controller.tabs = [
+      { id: "tab-a", targetId: "raw-a", title: "Initial", url: initialUrl },
+      { id: "tab-b", targetId: "raw-b", title: "Selected", url: selectedUrl },
+    ];
+
+    const pendingNavigation = controller.openUrl(destinationUrl, { newTab: false });
+    await flushBrowserResponses();
+    await controller.selectTab("tab-b");
+    navigation.resolve({ ok: true });
+    await pendingNavigation;
+
+    expect(controller.activeTargetId).toBe("tab-b");
+    expect(controller.view?.targetId).toBe("tab-b");
+    expect(controller.view?.url).toBe(selectedUrl);
+    expect(controller.tabs.find((tab) => tab.id === "tab-a")).toMatchObject({
+      title: "Destination",
+      url: destinationUrl,
+    });
+    expect(
+      request.mock.calls.filter(([, envelope]) => {
+        const browserRequest = envelope as BrowserRequestEnvelope;
+        return browserRequest.path === "/screenshot" && browserRequest.body?.targetId === "tab-a";
+      }),
+    ).toEqual([]);
+  });
+
   it("selects a new tab after a passive refresh overtakes its creation", async () => {
     stubScreenshotMedia();
     const initialUrl = "https://example.test/initial";

--- a/ui/src/components/browser/browser-panel-controller-input.test.ts
+++ b/ui/src/components/browser/browser-panel-controller-input.test.ts
@@ -663,7 +663,7 @@ describe("BrowserPanelController capture and input ownership", () => {
     const previousUrl = "https://example.test/previous";
     const { client, request } = createBrowserClient(async (envelope) => {
       if (envelope.path === "/act") {
-        const fn = String(envelope.body?.fn ?? "");
+        const fn = typeof envelope.body?.fn === "string" ? envelope.body.fn : "";
         return fn.includes("history.go")
           ? { result: true }
           : createBrowserPanelTestMetrics(previousUrl, "Previous");

--- a/ui/src/components/browser/browser-panel-controller-input.test.ts
+++ b/ui/src/components/browser/browser-panel-controller-input.test.ts
@@ -55,49 +55,59 @@ describe("BrowserPanelController capture and input ownership", () => {
     expect(controller.loading).toBe(false);
   });
 
-  it("does not restore a stale view when a background navigation commits before selection fails", async () => {
-    const navigation = createDeferred<{ ok: boolean }>();
-    const focus = createDeferred<{ ok: boolean }>();
-    const initialUrl = "https://example.test/initial";
-    const destinationUrl = "https://example.test/destination";
-    const { client, request } = createBrowserClient(async (envelope) => {
-      if (envelope.path === "/navigate") {
-        return await navigation.promise;
-      }
-      if (envelope.path === "/tabs/focus") {
-        return await focus.promise;
-      }
-      throw new Error(`Unexpected browser route: ${envelope.path}`);
-    });
-    const controller = createBrowserPanelTestController(client, "tab-a", initialUrl);
-    controller.tabs = [
-      { id: "tab-a", targetId: "raw-a", title: "Initial", url: initialUrl },
-      {
-        id: "tab-b",
-        targetId: "raw-b",
-        title: "Selected",
-        url: "https://example.test/selected",
-      },
-    ];
+  it.each(["navigation", "focus rejection"] as const)(
+    "does not restore a stale view when %s settles first",
+    async (first) => {
+      const navigation = createDeferred<{ ok: boolean }>();
+      const focus = createDeferred<{ ok: boolean }>();
+      const initialUrl = "https://example.test/initial";
+      const destinationUrl = "https://example.test/destination";
+      const { client, request } = createBrowserClient(async (envelope) => {
+        if (envelope.path === "/navigate") {
+          return await navigation.promise;
+        }
+        if (envelope.path === "/tabs/focus") {
+          return await focus.promise;
+        }
+        throw new Error(`Unexpected browser route: ${envelope.path}`);
+      });
+      const controller = createBrowserPanelTestController(client, "tab-a", initialUrl);
+      controller.tabs = [
+        { id: "tab-a", targetId: "raw-a", title: "Initial", url: initialUrl },
+        {
+          id: "tab-b",
+          targetId: "raw-b",
+          title: "Selected",
+          url: "https://example.test/selected",
+        },
+      ];
 
-    const pendingNavigation = controller.openUrl(destinationUrl, { newTab: false });
-    await flushBrowserResponses();
-    const pendingSelection = controller.selectTab("tab-b");
-    navigation.resolve({ ok: true });
-    await pendingNavigation;
-    focus.reject(new Error("Tab focus rejected"));
-    await pendingSelection;
+      const pendingNavigation = controller.openUrl(destinationUrl, { newTab: false });
+      await flushBrowserResponses();
+      const pendingSelection = controller.selectTab("tab-b");
+      if (first === "navigation") {
+        navigation.resolve({ ok: true });
+        await pendingNavigation;
+        focus.reject(new Error("Tab focus rejected"));
+        await pendingSelection;
+      } else {
+        focus.reject(new Error("Tab focus rejected"));
+        await pendingSelection;
+        navigation.resolve({ ok: true });
+        await pendingNavigation;
+      }
 
-    expect(controller.activeTargetId).toBeNull();
-    expect(controller.view).toBeNull();
-    expect(controller.urlDraft).toBe("");
-    expect(controller.errorText).toBe("Browser request failed: Tab focus rejected");
-    expect(
-      request.mock.calls.filter(([, envelope]) => {
-        return (envelope as BrowserRequestEnvelope).path === "/tabs";
-      }),
-    ).toEqual([]);
-  });
+      expect(controller.activeTargetId).toBeNull();
+      expect(controller.view).toBeNull();
+      expect(controller.urlDraft).toBe("");
+      expect(controller.errorText).toBe("Browser request failed: Tab focus rejected");
+      expect(
+        request.mock.calls.filter(([, envelope]) => {
+          return (envelope as BrowserRequestEnvelope).path === "/tabs";
+        }),
+      ).toEqual([]);
+    },
+  );
 
   it("retains a newly opened tab after its original active tab closes", async () => {
     stubScreenshotMedia();

--- a/ui/src/components/browser/browser-panel-controller-input.test.ts
+++ b/ui/src/components/browser/browser-panel-controller-input.test.ts
@@ -55,6 +55,50 @@ describe("BrowserPanelController capture and input ownership", () => {
     expect(controller.loading).toBe(false);
   });
 
+  it("does not restore a stale view when a background navigation commits before selection fails", async () => {
+    const navigation = createDeferred<{ ok: boolean }>();
+    const focus = createDeferred<{ ok: boolean }>();
+    const initialUrl = "https://example.test/initial";
+    const destinationUrl = "https://example.test/destination";
+    const { client, request } = createBrowserClient(async (envelope) => {
+      if (envelope.path === "/navigate") {
+        return await navigation.promise;
+      }
+      if (envelope.path === "/tabs/focus") {
+        return await focus.promise;
+      }
+      throw new Error(`Unexpected browser route: ${envelope.path}`);
+    });
+    const controller = createBrowserPanelTestController(client, "tab-a", initialUrl);
+    controller.tabs = [
+      { id: "tab-a", targetId: "raw-a", title: "Initial", url: initialUrl },
+      {
+        id: "tab-b",
+        targetId: "raw-b",
+        title: "Selected",
+        url: "https://example.test/selected",
+      },
+    ];
+
+    const pendingNavigation = controller.openUrl(destinationUrl, { newTab: false });
+    await flushBrowserResponses();
+    const pendingSelection = controller.selectTab("tab-b");
+    navigation.resolve({ ok: true });
+    await pendingNavigation;
+    focus.reject(new Error("Tab focus rejected"));
+    await pendingSelection;
+
+    expect(controller.activeTargetId).toBeNull();
+    expect(controller.view).toBeNull();
+    expect(controller.urlDraft).toBe("");
+    expect(controller.errorText).toBe("Browser request failed: Tab focus rejected");
+    expect(
+      request.mock.calls.filter(([, envelope]) => {
+        return (envelope as BrowserRequestEnvelope).path === "/tabs";
+      }),
+    ).toEqual([]);
+  });
+
   it("retains a newly opened tab after its original active tab closes", async () => {
     stubScreenshotMedia();
     const newUrl = "https://example.test/new";
@@ -378,40 +422,18 @@ describe("BrowserPanelController capture and input ownership", () => {
     expect(controller.loading).toBe(false);
   });
 
-  it("reconciles a committed background navigation without stealing the selected view", async () => {
+  it("does not poll tab metadata after a committed background navigation", async () => {
     stubScreenshotMedia();
     const navigation = createDeferred<{ ok: boolean }>();
     const initialUrl = "https://example.test/initial";
     const destinationUrl = "https://example.test/destination";
     const selectedUrl = "https://example.test/selected";
-    let backgroundUrl = initialUrl;
     const { client, request } = createBrowserClient(async (envelope) => {
       if (envelope.path === "/navigate") {
-        const result = await navigation.promise;
-        backgroundUrl = destinationUrl;
-        return result;
+        return await navigation.promise;
       }
       if (envelope.path === "/tabs/focus") {
         return { ok: true };
-      }
-      if (envelope.path === "/tabs") {
-        return {
-          running: true,
-          tabs: [
-            {
-              tabId: "tab-a",
-              targetId: "raw-a",
-              title: backgroundUrl === destinationUrl ? "Destination" : "Initial",
-              url: backgroundUrl,
-            },
-            {
-              tabId: "tab-b",
-              targetId: "raw-b",
-              title: "Selected",
-              url: selectedUrl,
-            },
-          ],
-        };
       }
       if (envelope.path === "/screenshot") {
         return { path: "/selected.png", targetId: "raw-b", url: selectedUrl };
@@ -437,9 +459,14 @@ describe("BrowserPanelController capture and input ownership", () => {
     expect(controller.view?.targetId).toBe("tab-b");
     expect(controller.view?.url).toBe(selectedUrl);
     expect(controller.tabs.find((tab) => tab.id === "tab-a")).toMatchObject({
-      title: "Destination",
-      url: destinationUrl,
+      title: "Initial",
+      url: initialUrl,
     });
+    expect(
+      request.mock.calls.filter(([, envelope]) => {
+        return (envelope as BrowserRequestEnvelope).path === "/tabs";
+      }),
+    ).toEqual([]);
     expect(
       request.mock.calls.filter(([, envelope]) => {
         const browserRequest = envelope as BrowserRequestEnvelope;

--- a/ui/src/components/browser/browser-panel-controller-input.test.ts
+++ b/ui/src/components/browser/browser-panel-controller-input.test.ts
@@ -656,6 +656,58 @@ describe("BrowserPanelController capture and input ownership", () => {
     expect(inspections[0]?.[1]).toMatchObject({ body: { targetId: "tab-a" } });
   });
 
+  it("reconciles selected tab metadata from the captured history document", async () => {
+    vi.useFakeTimers();
+    stubScreenshotMedia();
+    const currentUrl = "https://example.test/current";
+    const previousUrl = "https://example.test/previous";
+    const { client, request } = createBrowserClient(async (envelope) => {
+      if (envelope.path === "/act") {
+        const fn = String(envelope.body?.fn ?? "");
+        return fn.includes("history.go")
+          ? { result: true }
+          : createBrowserPanelTestMetrics(previousUrl, "Previous");
+      }
+      if (envelope.path === "/screenshot") {
+        return { path: "/fresh.png", targetId: "raw-a", url: previousUrl };
+      }
+      throw new Error(`Unexpected browser route: ${envelope.path}`);
+    });
+    const controller = createBrowserPanelTestController(client, "tab-a", currentUrl);
+    controller.tabs = [
+      { id: "tab-a", targetId: "raw-a", title: "Current", url: currentUrl },
+      {
+        id: "tab-b",
+        targetId: "raw-b",
+        title: "Background",
+        url: "https://example.test/background",
+      },
+    ];
+
+    controller.goHistory(-1);
+    await flushBrowserResponses();
+    await vi.advanceTimersByTimeAsync(350);
+    await flushBrowserResponses();
+    await vi.runAllTimersAsync();
+    await flushBrowserResponses();
+
+    expect(controller.tabs).toEqual([
+      { id: "tab-a", targetId: "raw-a", title: "Previous", url: previousUrl },
+      {
+        id: "tab-b",
+        targetId: "raw-b",
+        title: "Background",
+        url: "https://example.test/background",
+      },
+    ]);
+    expect(controller.urlDraft).toBe(previousUrl);
+    expect(
+      request.mock.calls.filter(([, envelope]) => {
+        return (envelope as BrowserRequestEnvelope).path === "/tabs";
+      }),
+    ).toEqual([]);
+  });
+
   it("never forwards a queued wheel action to a newly selected tab", async () => {
     vi.useFakeTimers();
     const { client, request } = createBrowserClient(async (envelope) => {

--- a/ui/src/components/browser/browser-panel-controller.test.ts
+++ b/ui/src/components/browser/browser-panel-controller.test.ts
@@ -341,6 +341,9 @@ describe("BrowserPanelController tab and lifecycle ownership", () => {
       committedNavigation.resolve({ targetId: "raw-stable", url: committedUrl });
       await expect(Promise.all([previous, latest])).resolves.toEqual([undefined, undefined]);
 
+      expect(controller.activeTargetId).toBeNull();
+      expect(controller.view).toBeNull();
+      expect(controller.urlDraft).toBe("");
       expect(controller.errorText).toBe("Browser request failed: Original navigation rejected");
       expect(controller.loading).toBe(false);
     },

--- a/ui/src/components/browser/browser-panel-controller.ts
+++ b/ui/src/components/browser/browser-panel-controller.ts
@@ -37,6 +37,7 @@ import {
   paintBrowserPanelOverlay,
   type BrowserPanelView,
 } from "./browser-panel-surface.ts";
+import { reconcileCapturedTab } from "./browser-panel-tabs.ts";
 import { normalizeBrowserUrlDraft } from "./browser-url.ts";
 
 const INSPECT_THROTTLE_MS = 120;
@@ -223,19 +224,9 @@ export class BrowserPanelController implements ReactiveController {
         shot.url && observedMetrics?.url && shot.url !== observedMetrics.url
           ? null
           : observedMetrics;
-      const tabIndex = this.tabs.findIndex((tab) => tab.id === targetId);
-      const tab = this.tabs[tabIndex];
-      if (tab) {
-        // Tab snapshots can lag history and in-page navigation. Keep the active
-        // tab's stable identity aligned with the document this capture owns.
-        const url = metrics?.url || shot.url || tab.url;
-        const title = metrics ? metrics.title : tab.title;
-        if (url !== tab.url || title !== tab.title) {
-          const tabs = [...this.tabs];
-          tabs[tabIndex] = { ...tab, title, url };
-          this.setState("tabs", tabs);
-        }
-      }
+      // Tab snapshots can lag history and in-page navigation. Keep the stable
+      // identity aligned with the document this capture owns.
+      this.setState("tabs", reconcileCapturedTab(this.tabs, targetId, metrics, shot.url));
       this.setState("view", { targetId, dataUrl, image, url: shot.url, metrics });
       if (!this.urlDraftEditing && shot.url) {
         this.setState("urlDraft", shot.url);

--- a/ui/src/components/browser/browser-panel-controller.ts
+++ b/ui/src/components/browser/browser-panel-controller.ts
@@ -7,7 +7,6 @@ import {
   captureBrowserScreenshot,
   clickBrowserCoords,
   closeBrowserTab,
-  errorDetail,
   fetchBrowserScreenshotDataUrl,
   focusBrowserTab,
   goBrowserHistory,
@@ -37,7 +36,6 @@ import {
   paintBrowserPanelOverlay,
   type BrowserPanelView,
 } from "./browser-panel-surface.ts";
-import { reconcileCapturedTab } from "./browser-panel-tabs.ts";
 import { normalizeBrowserUrlDraft } from "./browser-url.ts";
 
 const INSPECT_THROTTLE_MS = 120;
@@ -128,7 +126,8 @@ export class BrowserPanelController implements ReactiveController {
   }
 
   private reportError(error: unknown): void {
-    this.setState("errorText", t("browser.errors.requestFailed", { error: errorDetail(error) }));
+    const detail = error instanceof Error ? error.message : String(error);
+    this.setState("errorText", t("browser.errors.requestFailed", { error: detail }));
   }
 
   async refreshAll(): Promise<void> {
@@ -147,7 +146,7 @@ export class BrowserPanelController implements ReactiveController {
         return;
       }
       this.setState("running", snapshot.running);
-      this.setState("tabs", snapshot.tabs);
+      this.setState("tabs", this.operations.retainTabSnapshot(client, snapshot.tabs));
       // A mutation may adopt the same tab while this snapshot is pending.
       // Reconcile its tab strip, but never let it own document or loading state.
       if (!this.operations.canCaptureSnapshot(invocation)) {
@@ -225,7 +224,7 @@ export class BrowserPanelController implements ReactiveController {
           : observedMetrics;
       // Tab snapshots can lag history and in-page navigation. Keep the stable
       // identity aligned with the document this capture owns.
-      this.setState("tabs", reconcileCapturedTab(this.tabs, targetId, metrics, shot.url));
+      this.setState("tabs", this.operations.capturedTabs(this.tabs, targetId, metrics, shot.url));
       this.setState("view", { targetId, dataUrl, image, url: shot.url, metrics });
       if (!this.urlDraftEditing && shot.url) {
         this.setState("urlDraft", shot.url);
@@ -398,7 +397,7 @@ export class BrowserPanelController implements ReactiveController {
         this.operations.acceptSnapshot(invocation, this.activeTargetId, this.activeTargetId)
       ) {
         this.setState("running", snapshot.running);
-        this.setState("tabs", snapshot.tabs);
+        this.setState("tabs", this.operations.retainTabSnapshot(client, snapshot.tabs));
         return "accepted";
       }
       return "rejected";
@@ -446,6 +445,7 @@ export class BrowserPanelController implements ReactiveController {
     await this.runAction(async (client) => {
       const epoch = this.operations.epoch;
       await closeBrowserTab(client, targetId);
+      this.operations.forgetNavigation(client, targetId);
       if (!this.operations.isLive(epoch, client)) {
         if (this.operations.isLive(this.operations.epoch, client)) {
           await this.refreshAll();

--- a/ui/src/components/browser/browser-panel-controller.ts
+++ b/ui/src/components/browser/browser-panel-controller.ts
@@ -335,6 +335,14 @@ export class BrowserPanelController implements ReactiveController {
           }
         });
         if (!invocation.isCurrent()) {
+          // The remote document can commit just before a tab switch supersedes
+          // this mutation. Reconcile its tab label without owning the new view.
+          if (this.operations.hasUnreconciledNavigation(client, targetId)) {
+            await this.refreshTabsOnly(
+              client,
+              this.operations.survivingInvocation(invocation, client),
+            );
+          }
           return;
         }
         this.setState("view", null);
@@ -419,6 +427,9 @@ export class BrowserPanelController implements ReactiveController {
     const focused = await this.runAction(async (client) => {
       await focusBrowserTab(client, targetId);
       await this.refreshView(targetId);
+      if (this.activeTargetId === targetId && this.view?.targetId === targetId) {
+        this.operations.markNavigationReconciled(client, targetId);
+      }
     }, false);
     if (!focused && this.operations.isLive(epoch) && this.activeTargetId === targetId) {
       this.setState("activeTargetId", previous.targetId);

--- a/ui/src/components/browser/browser-panel-controller.ts
+++ b/ui/src/components/browser/browser-panel-controller.ts
@@ -339,14 +339,6 @@ export class BrowserPanelController implements ReactiveController {
           }
         });
         if (!invocation.isCurrent()) {
-          // The remote document can commit just before a tab switch supersedes
-          // this mutation. Reconcile its tab label without owning the new view.
-          if (this.operations.hasUnreconciledNavigation(client, targetId)) {
-            await this.refreshTabsOnly(
-              client,
-              this.operations.survivingInvocation(invocation, client),
-            );
-          }
           return;
         }
         this.setState("view", null);
@@ -422,20 +414,30 @@ export class BrowserPanelController implements ReactiveController {
     if (targetId === this.activeTargetId) {
       return;
     }
+    const client = this.operations.captureClient();
     const previous = { targetId: this.activeTargetId, view: this.view };
     this.invalidateViewOperations();
     const epoch = this.operations.epoch;
     this.setState("activeTargetId", targetId);
     this.setState("view", null);
     this.exitCaptureModes();
-    const focused = await this.runAction(async (client) => {
-      await focusBrowserTab(client, targetId);
+    const focused = await this.runAction(async (actionClient) => {
+      await focusBrowserTab(actionClient, targetId);
       await this.refreshView(targetId);
       if (this.activeTargetId === targetId && this.view?.targetId === targetId) {
-        this.operations.markNavigationReconciled(client, targetId);
+        this.operations.markNavigationReconciled(actionClient, targetId);
       }
     }, false);
     if (!focused && this.operations.isLive(epoch) && this.activeTargetId === targetId) {
+      if (this.operations.hasUnreconciledNavigation(client, previous.targetId)) {
+        // The prior remote document changed while selection failed. Expose an
+        // unavailable state instead of restoring a screenshot that no longer owns it.
+        this.setState("activeTargetId", null);
+        if (!this.urlDraftEditing) {
+          this.setState("urlDraft", "");
+        }
+        return;
+      }
       this.setState("activeTargetId", previous.targetId);
       this.setState("view", previous.view);
     }

--- a/ui/src/components/browser/browser-panel-controller.ts
+++ b/ui/src/components/browser/browser-panel-controller.ts
@@ -2,10 +2,12 @@ import type { ReactiveController } from "lit";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { t } from "../../i18n/index.ts";
 import type { AnnotationStroke } from "./browser-annotation.ts";
+import type { BrowserInspectedNode, BrowserPanelTab } from "./browser-client.ts";
 import {
   captureBrowserScreenshot,
   clickBrowserCoords,
   closeBrowserTab,
+  errorDetail,
   fetchBrowserScreenshotDataUrl,
   focusBrowserTab,
   goBrowserHistory,
@@ -17,8 +19,6 @@ import {
   pressBrowserKey,
   scrollBrowserBy,
   startBrowser,
-  type BrowserInspectedNode,
-  type BrowserPanelTab,
 } from "./browser-client.ts";
 import {
   BrowserPanelOperationOwnership,
@@ -128,8 +128,7 @@ export class BrowserPanelController implements ReactiveController {
   }
 
   private reportError(error: unknown): void {
-    const detail = error instanceof Error ? error.message : String(error);
-    this.setState("errorText", t("browser.errors.requestFailed", { error: detail }));
+    this.setState("errorText", t("browser.errors.requestFailed", { error: errorDetail(error) }));
   }
 
   async refreshAll(): Promise<void> {
@@ -482,6 +481,7 @@ export class BrowserPanelController implements ReactiveController {
         this.setState("loading", false);
       }
     }, false);
+    await this.host.updateComplete;
   }
 
   /** Real page reload: re-navigate to the current URL, then re-capture. A bare

--- a/ui/src/components/browser/browser-panel-controller.ts
+++ b/ui/src/components/browser/browser-panel-controller.ts
@@ -351,32 +351,31 @@ export class BrowserPanelController implements ReactiveController {
       }
     } catch (error) {
       if (invocation.isCurrent()) {
-        this.reportError(error);
         if (previousNavigationQueued && this.activeTargetId) {
           const targetId = this.activeTargetId;
-          const navigationErrorText = this.errorText;
           // An earlier queued navigation may already have committed remotely.
           // Recover its actual document without replacing an unchanged view.
-          try {
-            const refreshed = await this.refreshTabsOnly(client, () => invocation.isCurrent());
-            const active = this.tabs.find((tab) => tab.id === targetId);
-            if (refreshed === "accepted" && invocation.isCurrent() && active) {
-              await this.refreshView(targetId, invocation.epoch);
-              if (
-                invocation.isCurrent() &&
-                this.view?.targetId === targetId &&
-                this.errorText === navigationErrorText
-              ) {
-                this.operations.markNavigationReconciled(client, targetId);
-              }
+          const refreshed = await this.refreshTabsOnly(client, () => invocation.isCurrent());
+          const active = this.tabs.find((tab) => tab.id === targetId);
+          if (refreshed === "accepted" && invocation.isCurrent() && active) {
+            this.setState("view", null);
+            await this.refreshView(targetId, invocation.epoch);
+            if (invocation.isCurrent() && this.view?.targetId === targetId) {
+              this.operations.markNavigationReconciled(client, targetId);
             }
-          } catch {
-            // Recovery is best-effort; retain the original navigation failure.
           }
-          if (invocation.isCurrent()) {
-            this.reportError(error);
+          if (
+            invocation.isCurrent() &&
+            this.operations.hasUnreconciledNavigation(client, targetId)
+          ) {
+            this.setState("activeTargetId", null);
+            this.setState("view", null);
+            if (!this.urlDraftEditing) {
+              this.setState("urlDraft", "");
+            }
           }
         }
+        this.reportError(error);
       }
     } finally {
       if (invocation.isCurrent()) {

--- a/ui/src/components/browser/browser-panel-controller.ts
+++ b/ui/src/components/browser/browser-panel-controller.ts
@@ -223,6 +223,19 @@ export class BrowserPanelController implements ReactiveController {
         shot.url && observedMetrics?.url && shot.url !== observedMetrics.url
           ? null
           : observedMetrics;
+      const tabIndex = this.tabs.findIndex((tab) => tab.id === targetId);
+      const tab = this.tabs[tabIndex];
+      if (tab) {
+        // Tab snapshots can lag history and in-page navigation. Keep the active
+        // tab's stable identity aligned with the document this capture owns.
+        const url = metrics?.url || shot.url || tab.url;
+        const title = metrics ? metrics.title : tab.title;
+        if (url !== tab.url || title !== tab.title) {
+          const tabs = [...this.tabs];
+          tabs[tabIndex] = { ...tab, title, url };
+          this.setState("tabs", tabs);
+        }
+      }
       this.setState("view", { targetId, dataUrl, image, url: shot.url, metrics });
       if (!this.urlDraftEditing && shot.url) {
         this.setState("urlDraft", shot.url);

--- a/ui/src/components/browser/browser-panel-controller.ts
+++ b/ui/src/components/browser/browser-panel-controller.ts
@@ -427,7 +427,7 @@ export class BrowserPanelController implements ReactiveController {
       }
     }, false);
     if (!focused && this.operations.isLive(epoch) && this.activeTargetId === targetId) {
-      if (this.operations.hasUnreconciledNavigation(client, previous.targetId)) {
+      if (this.operations.hasPendingNavigation(client, previous.targetId)) {
         // The prior remote document changed while selection failed. Expose an
         // unavailable state instead of restoring a screenshot that no longer owns it.
         this.setState("activeTargetId", null);

--- a/ui/src/components/browser/browser-panel-operation-ownership.test.ts
+++ b/ui/src/components/browser/browser-panel-operation-ownership.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  createBrowserClient,
+  createBrowserPanelTestMetrics,
+  TestBrowserPanelHost,
+} from "./browser-panel-controller-test-support.ts";
+import { BrowserPanelOperationOwnership } from "./browser-panel-operation-ownership.ts";
+
+describe("BrowserPanelOperationOwnership", () => {
+  it("releases navigation commits when tabs reconcile, close, or leave an accepted snapshot", () => {
+    const { client } = createBrowserClient(async () => ({}));
+    const ownership = new BrowserPanelOperationOwnership(new TestBrowserPanelHost(client));
+    ownership.markNavigationCommitted(client, "tab-a");
+    ownership.markNavigationCommitted(client, "tab-b");
+
+    ownership.retainTabSnapshot(client, [
+      { id: "tab-a", targetId: "raw-a", title: "A", url: "https://a.example" },
+    ]);
+    expect(ownership.hasUnreconciledNavigation(client, "tab-a")).toBe(true);
+    expect(ownership.hasUnreconciledNavigation(client, "tab-b")).toBe(false);
+
+    ownership.forgetNavigation(client, "tab-a");
+    expect(ownership.hasUnreconciledNavigation(client, "tab-a")).toBe(false);
+
+    ownership.markNavigationCommitted(client, "tab-a");
+    ownership.markNavigationReconciled(client, "tab-a");
+    expect(ownership.hasUnreconciledNavigation(client, "tab-a")).toBe(false);
+  });
+
+  it("reconciles captured metadata without replacing an unchanged tab list", () => {
+    const { client } = createBrowserClient(async () => ({}));
+    const ownership = new BrowserPanelOperationOwnership(new TestBrowserPanelHost(client));
+    const tabs = [{ id: "tab-a", targetId: "raw-a", title: "A", url: "https://a.example" }];
+    const metrics = createBrowserPanelTestMetrics("https://b.example", "B").result;
+
+    const reconciled = ownership.capturedTabs(tabs, "tab-a", metrics, metrics.url);
+    expect(reconciled).toEqual([
+      { id: "tab-a", targetId: "raw-a", title: "B", url: "https://b.example" },
+    ]);
+    expect(ownership.capturedTabs(reconciled, "tab-a", metrics, metrics.url)).toBe(reconciled);
+  });
+});

--- a/ui/src/components/browser/browser-panel-operation-ownership.ts
+++ b/ui/src/components/browser/browser-panel-operation-ownership.ts
@@ -26,11 +26,6 @@ type BrowserPanelInvocation = {
   isCurrent(): boolean;
 };
 
-type BrowserNavigationCommit = {
-  committed: number;
-  reconciled: number;
-};
-
 export type BrowserPanelSnapshotOutcome = "accepted" | "rejected" | "failed";
 
 /** Owns the panel lifecycle, tab snapshots, captures, and pointer operations. */
@@ -46,10 +41,7 @@ export class BrowserPanelOperationOwnership {
     GatewayBrowserClient,
     Map<string, Promise<unknown>>
   >();
-  private readonly navigationCommits = new WeakMap<
-    GatewayBrowserClient,
-    Map<string, BrowserNavigationCommit>
-  >();
+  private readonly navigationCommits = new WeakMap<GatewayBrowserClient, Set<string>>();
 
   constructor(private readonly host: BrowserPanelControllerHost) {}
 
@@ -110,19 +102,16 @@ export class BrowserPanelOperationOwnership {
     if (!client || !targetId) {
       return false;
     }
-    const state = this.navigationCommits.get(client)?.get(targetId);
-    return state !== undefined && state.committed !== state.reconciled;
+    return this.navigationCommits.get(client)?.has(targetId) ?? false;
   }
 
   markNavigationCommitted(client: GatewayBrowserClient, targetId: string): void {
     let commits = this.navigationCommits.get(client);
     if (!commits) {
-      commits = new Map();
+      commits = new Set();
       this.navigationCommits.set(client, commits);
     }
-    const state = commits.get(targetId) ?? { committed: 0, reconciled: 0 };
-    state.committed += 1;
-    commits.set(targetId, state);
+    commits.add(targetId);
   }
 
   markNavigationReconciled(client: GatewayBrowserClient, targetId: string): void {

--- a/ui/src/components/browser/browser-panel-operation-ownership.ts
+++ b/ui/src/components/browser/browser-panel-operation-ownership.ts
@@ -4,6 +4,7 @@ import {
   isBrowserEvaluateDisabledError,
   readBrowserPageMetrics,
   type BrowserPageMetrics,
+  type BrowserPanelTab,
 } from "./browser-client.ts";
 
 export interface BrowserPanelControllerHost extends ReactiveControllerHost {
@@ -125,10 +126,49 @@ export class BrowserPanelOperationOwnership {
   }
 
   markNavigationReconciled(client: GatewayBrowserClient, targetId: string): void {
-    const state = this.navigationCommits.get(client)?.get(targetId);
-    if (state) {
-      state.reconciled = state.committed;
+    this.forgetNavigation(client, targetId);
+  }
+
+  forgetNavigation(client: GatewayBrowserClient, targetId: string): void {
+    const commits = this.navigationCommits.get(client);
+    commits?.delete(targetId);
+    if (commits?.size === 0) {
+      this.navigationCommits.delete(client);
     }
+  }
+
+  retainTabSnapshot(client: GatewayBrowserClient, tabs: BrowserPanelTab[]): BrowserPanelTab[] {
+    const commits = this.navigationCommits.get(client);
+    if (!commits) {
+      return tabs;
+    }
+    const liveTargetIds = new Set(tabs.map((tab) => tab.id));
+    for (const targetId of commits.keys()) {
+      if (!liveTargetIds.has(targetId)) {
+        commits.delete(targetId);
+      }
+    }
+    if (commits.size === 0) {
+      this.navigationCommits.delete(client);
+    }
+    return tabs;
+  }
+
+  capturedTabs(
+    tabs: BrowserPanelTab[],
+    targetId: string,
+    metrics: BrowserPageMetrics | null,
+    screenshotUrl: string,
+  ): BrowserPanelTab[] {
+    const tab = tabs.find((entry) => entry.id === targetId);
+    if (!tab) {
+      return tabs;
+    }
+    const title = metrics?.title ?? tab.title;
+    const url = metrics?.url || screenshotUrl || tab.url;
+    return title === tab.title && url === tab.url
+      ? tabs
+      : tabs.map((entry) => (entry.id === targetId ? { ...entry, title, url } : entry));
   }
 
   /** Remote navigations for one gateway tab must commit in user-intent order. */

--- a/ui/src/components/browser/browser-panel-operation-ownership.ts
+++ b/ui/src/components/browser/browser-panel-operation-ownership.ts
@@ -105,6 +105,15 @@ export class BrowserPanelOperationOwnership {
     return this.navigationCommits.get(client)?.has(targetId) ?? false;
   }
 
+  hasPendingNavigation(client: GatewayBrowserClient | null, targetId: string | null): boolean {
+    return Boolean(
+      client &&
+      targetId &&
+      (this.hasQueuedNavigation(client, targetId) ||
+        this.hasUnreconciledNavigation(client, targetId)),
+    );
+  }
+
   markNavigationCommitted(client: GatewayBrowserClient, targetId: string): void {
     let commits = this.navigationCommits.get(client);
     if (!commits) {

--- a/ui/src/components/browser/browser-panel-operation-ownership.ts
+++ b/ui/src/components/browser/browser-panel-operation-ownership.ts
@@ -105,7 +105,10 @@ export class BrowserPanelOperationOwnership {
   }
 
   /** A committed document still needs its first owner-authoritative screenshot. */
-  hasUnreconciledNavigation(client: GatewayBrowserClient, targetId: string): boolean {
+  hasUnreconciledNavigation(client: GatewayBrowserClient | null, targetId: string | null): boolean {
+    if (!client || !targetId) {
+      return false;
+    }
     const state = this.navigationCommits.get(client)?.get(targetId);
     return state !== undefined && state.committed !== state.reconciled;
   }

--- a/ui/src/components/browser/browser-panel-render.ts
+++ b/ui/src/components/browser/browser-panel-render.ts
@@ -21,7 +21,7 @@ function renderTabStrip(controller: BrowserPanelController) {
     tabs: controller.tabs,
     activeTargetId: controller.activeTargetId,
     onSelect: (targetId) => void controller.selectTab(targetId),
-    onClose: (targetId) => void controller.closeTab(targetId),
+    onClose: (targetId) => controller.closeTab(targetId),
     onNew: () => controller.beginNewTab(),
   });
 }

--- a/ui/src/components/browser/browser-panel-tabs.ts
+++ b/ui/src/components/browser/browser-panel-tabs.ts
@@ -35,7 +35,7 @@ export function renderBrowserPanelTabs(params: {
   tabs: BrowserPanelTab[];
   activeTargetId: string | null;
   onSelect: (targetId: string) => void;
-  onClose: (targetId: string) => void;
+  onClose: (targetId: string) => void | Promise<void>;
   onNew: () => void;
 }) {
   const tabs: PanelTabStripTab[] = params.tabs.map((tab) => {

--- a/ui/src/components/browser/browser-panel-tabs.ts
+++ b/ui/src/components/browser/browser-panel-tabs.ts
@@ -1,6 +1,24 @@
 import { t } from "../../i18n/index.ts";
 import { renderPanelTabStrip, type PanelTabStripTab } from "../panel-tab-strip.ts";
-import type { BrowserPanelTab } from "./browser-client.ts";
+import type { BrowserPageMetrics, BrowserPanelTab } from "./browser-client.ts";
+
+export function reconcileCapturedTab(
+  tabs: BrowserPanelTab[],
+  targetId: string,
+  metrics: BrowserPageMetrics | null,
+  screenshotUrl: string,
+): BrowserPanelTab[] {
+  const tab = tabs.find((entry) => entry.id === targetId);
+  if (!tab) {
+    return tabs;
+  }
+  const title = metrics?.title ?? tab.title;
+  const url = metrics?.url || screenshotUrl || tab.url;
+  if (title === tab.title && url === tab.url) {
+    return tabs;
+  }
+  return tabs.map((entry) => (entry.id === targetId ? { ...entry, title, url } : entry));
+}
 
 function tabLabel(tab: BrowserPanelTab): string {
   if (tab.title.trim()) {

--- a/ui/src/components/browser/browser-panel-tabs.ts
+++ b/ui/src/components/browser/browser-panel-tabs.ts
@@ -1,24 +1,6 @@
 import { t } from "../../i18n/index.ts";
 import { renderPanelTabStrip, type PanelTabStripTab } from "../panel-tab-strip.ts";
-import type { BrowserPageMetrics, BrowserPanelTab } from "./browser-client.ts";
-
-export function reconcileCapturedTab(
-  tabs: BrowserPanelTab[],
-  targetId: string,
-  metrics: BrowserPageMetrics | null,
-  screenshotUrl: string,
-): BrowserPanelTab[] {
-  const tab = tabs.find((entry) => entry.id === targetId);
-  if (!tab) {
-    return tabs;
-  }
-  const title = metrics?.title ?? tab.title;
-  const url = metrics?.url || screenshotUrl || tab.url;
-  if (title === tab.title && url === tab.url) {
-    return tabs;
-  }
-  return tabs.map((entry) => (entry.id === targetId ? { ...entry, title, url } : entry));
-}
+import type { BrowserPanelTab } from "./browser-client.ts";
 
 function tabLabel(tab: BrowserPanelTab): string {
   if (tab.title.trim()) {

--- a/ui/src/components/panel-tab-strip.browser.test.ts
+++ b/ui/src/components/panel-tab-strip.browser.test.ts
@@ -105,6 +105,16 @@ describe.skipIf(!hasBrowserLayout)("panel tab strip browser lifecycle", () => {
 
     expect(reorderedActive).toBe(initialActive);
     await vi.waitFor(() => expect(container.activeElement).toBe(initialActive));
+
+    renderControlledStrip({
+      container,
+      tabs: [tabs[2]!, tab("d"), tabs[1]!, tabs[0]!],
+      activeId: "b",
+      onSelect: vi.fn(),
+    });
+    const insertedActive = await expectControlledSelection(container, "b");
+    expect(insertedActive).toBe(initialActive);
+    expect(container.activeElement).toBe(initialActive);
   });
 
   it("keeps arrow and mouse activation controlled and the selected overflow tab visible", async () => {

--- a/ui/src/components/panel-tab-strip.browser.test.ts
+++ b/ui/src/components/panel-tab-strip.browser.test.ts
@@ -1,5 +1,6 @@
 import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import {
   panelTabStripStyles,
   renderPanelTabStrip,
@@ -152,13 +153,17 @@ describe.skipIf(!hasBrowserLayout)("panel tab strip browser lifecycle", () => {
   it("moves focus to the selected fallback when the focused tab is closed", async () => {
     const container = document.createElement("div");
     document.body.append(container);
+    const close = createDeferred();
     let tabs = [tab("a"), tab("b")];
     let activeId = "a";
     const onSelect = vi.fn();
     const onClose = vi.fn((closedId: string) => {
-      tabs = tabs.filter((entry) => entry.id !== closedId);
-      activeId = tabs[0]?.id ?? "";
-      renderControlledStrip({ container, tabs, activeId, onSelect, onClose });
+      void close.promise.then(() => {
+        (document.activeElement as HTMLElement | null)?.blur();
+        tabs = tabs.filter((entry) => entry.id !== closedId);
+        activeId = tabs[0]?.id ?? "";
+        renderControlledStrip({ container, tabs, activeId, onSelect, onClose });
+      });
     });
     renderControlledStrip({ container, tabs, activeId, onSelect, onClose });
     await expectControlledSelection(container, activeId);
@@ -167,6 +172,10 @@ describe.skipIf(!hasBrowserLayout)("panel tab strip browser lifecycle", () => {
     expect(document.activeElement).toBe(closeButton);
 
     closeButton?.click();
+    expect(document.activeElement).toBe(closeButton);
+    close.resolve();
+    await close.promise;
+    await Promise.resolve();
 
     const fallback = await expectControlledSelection(container, activeId);
     await vi.waitFor(() => expect(document.activeElement).toBe(fallback));

--- a/ui/src/components/panel-tab-strip.browser.test.ts
+++ b/ui/src/components/panel-tab-strip.browser.test.ts
@@ -174,8 +174,9 @@ describe.skipIf(!hasBrowserLayout)("panel tab strip browser lifecycle", () => {
     closeButton?.focus();
     expect(document.activeElement).toBe(closeButton);
 
+    closeButton?.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    closeButton?.blur();
     closeButton?.click();
-    expect(document.activeElement).toBe(closeButton);
     close.resolve();
     await close.promise;
     await Promise.resolve();

--- a/ui/src/components/panel-tab-strip.browser.test.ts
+++ b/ui/src/components/panel-tab-strip.browser.test.ts
@@ -1,4 +1,4 @@
-import { render } from "lit";
+import { nothing, render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import {
@@ -162,6 +162,7 @@ describe.skipIf(!hasBrowserLayout)("panel tab strip browser lifecycle", () => {
         (document.activeElement as HTMLElement | null)?.blur();
         tabs = tabs.filter((entry) => entry.id !== closedId);
         activeId = tabs[0]?.id ?? "";
+        render(nothing, container);
         renderControlledStrip({ container, tabs, activeId, onSelect, onClose });
       });
     });
@@ -178,6 +179,11 @@ describe.skipIf(!hasBrowserLayout)("panel tab strip browser lifecycle", () => {
     await Promise.resolve();
 
     const fallback = await expectControlledSelection(container, activeId);
-    await vi.waitFor(() => expect(document.activeElement).toBe(fallback));
+    const group = container.querySelector<RenderedTabGroup & { updateComplete: Promise<boolean> }>(
+      "wa-tab-group",
+    );
+    await group?.updateComplete;
+    await new Promise(requestAnimationFrame);
+    expect(document.activeElement).toBe(fallback);
   });
 });

--- a/ui/src/components/panel-tab-strip.browser.test.ts
+++ b/ui/src/components/panel-tab-strip.browser.test.ts
@@ -31,6 +31,7 @@ function renderControlledStrip(params: {
   tabs: PanelTabStripTab[];
   activeId: string;
   onSelect: (id: string) => void;
+  onClose?: (id: string) => void;
 }) {
   render(
     renderPanelTabStrip({
@@ -38,7 +39,7 @@ function renderControlledStrip(params: {
       activeId: params.activeId,
       ariaControls: "browser-test-panel",
       onSelect: params.onSelect,
-      onClose: vi.fn(),
+      onClose: params.onClose ?? vi.fn(),
       onNew: vi.fn(),
       newLabel: "New tab",
     }),
@@ -146,5 +147,28 @@ describe.skipIf(!hasBrowserLayout)("panel tab strip browser lifecycle", () => {
     expect(nav.scrollWidth).toBeGreaterThan(nav.clientWidth);
     expect(activeRect.left).toBeGreaterThanOrEqual(navRect.left - 1);
     expect(activeRect.right).toBeLessThanOrEqual(navRect.right + 1);
+  });
+
+  it("moves focus to the selected fallback when the focused tab is closed", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    let tabs = [tab("a"), tab("b")];
+    let activeId = "a";
+    const onSelect = vi.fn();
+    const onClose = vi.fn((closedId: string) => {
+      tabs = tabs.filter((entry) => entry.id !== closedId);
+      activeId = tabs[0]?.id ?? "";
+      renderControlledStrip({ container, tabs, activeId, onSelect, onClose });
+    });
+    renderControlledStrip({ container, tabs, activeId, onSelect, onClose });
+    await expectControlledSelection(container, activeId);
+    const closeButton = container.querySelector<HTMLButtonElement>(".tabstrip-tab__close");
+    closeButton?.focus();
+    expect(document.activeElement).toBe(closeButton);
+
+    closeButton?.click();
+
+    const fallback = await expectControlledSelection(container, activeId);
+    await vi.waitFor(() => expect(document.activeElement).toBe(fallback));
   });
 });

--- a/ui/src/components/panel-tab-strip.browser.test.ts
+++ b/ui/src/components/panel-tab-strip.browser.test.ts
@@ -28,7 +28,7 @@ function tab(id: string): PanelTabStripTab {
 }
 
 function renderControlledStrip(params: {
-  container: HTMLElement;
+  container: HTMLElement | DocumentFragment;
   tabs: PanelTabStripTab[];
   activeId: string;
   onSelect: (id: string) => void;
@@ -84,14 +84,17 @@ afterEach(() => {
 
 describe.skipIf(!hasBrowserLayout)("panel tab strip browser lifecycle", () => {
   it("preserves the focused active element when tabs reorder", async () => {
-    const container = document.createElement("div");
-    document.body.append(container);
+    const host = document.createElement("div");
+    const container = host.attachShadow({ mode: "open" });
+    document.body.append(host);
     const tabs = [tab("a"), tab("b"), tab("c")];
     renderControlledStrip({ container, tabs, activeId: "b", onSelect: vi.fn() });
     const initialActive = await expectControlledSelection(container, "b");
     initialActive.focus();
-    expect(document.activeElement).toBe(initialActive);
+    expect(document.activeElement).toBe(host);
+    expect(container.activeElement).toBe(initialActive);
 
+    queueMicrotask(() => initialActive.blur());
     renderControlledStrip({
       container,
       tabs: [tabs[2]!, { ...tabs[1]!, label: "Tab B navigated" }, tabs[0]!],
@@ -101,7 +104,7 @@ describe.skipIf(!hasBrowserLayout)("panel tab strip browser lifecycle", () => {
     const reorderedActive = await expectControlledSelection(container, "b");
 
     expect(reorderedActive).toBe(initialActive);
-    expect(document.activeElement).toBe(initialActive);
+    await vi.waitFor(() => expect(container.activeElement).toBe(initialActive));
   });
 
   it("keeps arrow and mouse activation controlled and the selected overflow tab visible", async () => {

--- a/ui/src/components/panel-tab-strip.browser.test.ts
+++ b/ui/src/components/panel-tab-strip.browser.test.ts
@@ -1,0 +1,150 @@
+import { render } from "lit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  panelTabStripStyles,
+  renderPanelTabStrip,
+  type PanelTabStripTab,
+} from "./panel-tab-strip.ts";
+
+type RenderedTab = HTMLElement & {
+  active: boolean;
+  panel: string;
+};
+
+type RenderedTabGroup = HTMLElement & {
+  active: string;
+};
+
+const hasBrowserLayout = !navigator.userAgent.toLowerCase().includes("jsdom");
+
+function tab(id: string): PanelTabStripTab {
+  return {
+    id,
+    domId: `browser-test-tab-${id}`,
+    label: `Tab ${id.toUpperCase()}`,
+    closeLabel: `Close tab ${id.toUpperCase()}`,
+  };
+}
+
+function renderControlledStrip(params: {
+  container: HTMLElement;
+  tabs: PanelTabStripTab[];
+  activeId: string;
+  onSelect: (id: string) => void;
+}) {
+  render(
+    renderPanelTabStrip({
+      tabs: params.tabs,
+      activeId: params.activeId,
+      ariaControls: "browser-test-panel",
+      onSelect: params.onSelect,
+      onClose: vi.fn(),
+      onNew: vi.fn(),
+      newLabel: "New tab",
+    }),
+    params.container,
+  );
+}
+
+function renderedTabs(container: ParentNode): RenderedTab[] {
+  return [...container.querySelectorAll<RenderedTab>("wa-tab")];
+}
+
+async function expectControlledSelection(
+  container: ParentNode,
+  activeId: string,
+): Promise<RenderedTab> {
+  let active: RenderedTab | undefined;
+  await vi.waitFor(() => {
+    const tabs = renderedTabs(container);
+    const selected = tabs.filter(
+      (candidate) =>
+        candidate.active ||
+        candidate.hasAttribute("active") ||
+        candidate.getAttribute("aria-selected") === "true",
+    );
+    active = tabs.find((candidate) => candidate.panel === activeId);
+    expect(selected).toEqual([active]);
+    expect(active?.tabIndex).toBe(0);
+    expect(
+      tabs
+        .filter((candidate) => candidate.panel !== activeId)
+        .every((candidate) => candidate.tabIndex === -1),
+    ).toBe(true);
+  });
+  return active!;
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+  document.querySelector("#panel-tab-strip-browser-test-styles")?.remove();
+});
+
+describe.skipIf(!hasBrowserLayout)("panel tab strip browser lifecycle", () => {
+  it("preserves the focused active element when tabs reorder", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const tabs = [tab("a"), tab("b"), tab("c")];
+    renderControlledStrip({ container, tabs, activeId: "b", onSelect: vi.fn() });
+    const initialActive = await expectControlledSelection(container, "b");
+    initialActive.focus();
+    expect(document.activeElement).toBe(initialActive);
+
+    renderControlledStrip({
+      container,
+      tabs: [tabs[2]!, { ...tabs[1]!, label: "Tab B navigated" }, tabs[0]!],
+      activeId: "b",
+      onSelect: vi.fn(),
+    });
+    const reorderedActive = await expectControlledSelection(container, "b");
+
+    expect(reorderedActive).toBe(initialActive);
+    expect(document.activeElement).toBe(initialActive);
+  });
+
+  it("keeps arrow and mouse activation controlled and the selected overflow tab visible", async () => {
+    const style = document.createElement("style");
+    style.id = "panel-tab-strip-browser-test-styles";
+    style.textContent = panelTabStripStyles.cssText;
+    document.head.append(style);
+    const container = document.createElement("div");
+    container.style.width = "220px";
+    document.body.append(container);
+    const tabs = Array.from({ length: 8 }, (_, index) => tab(String(index + 1)));
+    let activeId = "4";
+    const onSelect = vi.fn((nextId: string) => {
+      activeId = nextId;
+      renderControlledStrip({ container, tabs, activeId, onSelect });
+    });
+    renderControlledStrip({ container, tabs, activeId, onSelect });
+    const initialActive = await expectControlledSelection(container, activeId);
+    initialActive.focus();
+    initialActive.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "ArrowRight",
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    await vi.waitFor(() => expect(activeId).toBe("5"));
+    const arrowActive = await expectControlledSelection(container, activeId);
+    expect(document.activeElement).toBe(arrowActive);
+
+    const last = renderedTabs(container).find((candidate) => candidate.panel === "8");
+    last?.click();
+    await vi.waitFor(() => expect(activeId).toBe("8"));
+    const lastActive = await expectControlledSelection(container, activeId);
+    const group = container.querySelector<RenderedTabGroup>("wa-tab-group");
+    const nav = group?.shadowRoot?.querySelector<HTMLElement>(".nav");
+    if (!group || !nav) {
+      throw new Error("expected rendered tab group navigation");
+    }
+    await new Promise(requestAnimationFrame);
+    const navRect = nav.getBoundingClientRect();
+    const activeRect = lastActive.getBoundingClientRect();
+
+    expect(nav.scrollWidth).toBeGreaterThan(nav.clientWidth);
+    expect(activeRect.left).toBeGreaterThanOrEqual(navRect.left - 1);
+    expect(activeRect.right).toBeLessThanOrEqual(navRect.right + 1);
+  });
+});

--- a/ui/src/components/panel-tab-strip.browser.test.ts
+++ b/ui/src/components/panel-tab-strip.browser.test.ts
@@ -1,4 +1,4 @@
-import { nothing, render } from "lit";
+import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import {
@@ -151,7 +151,7 @@ describe.skipIf(!hasBrowserLayout)("panel tab strip browser lifecycle", () => {
   });
 
   it("moves focus to the selected fallback when the focused tab is closed", async () => {
-    const container = document.createElement("div");
+    let container = document.createElement("div");
     document.body.append(container);
     const close = createDeferred();
     let tabs = [tab("a"), tab("b")];
@@ -162,7 +162,9 @@ describe.skipIf(!hasBrowserLayout)("panel tab strip browser lifecycle", () => {
         (document.activeElement as HTMLElement | null)?.blur();
         tabs = tabs.filter((entry) => entry.id !== closedId);
         activeId = tabs[0]?.id ?? "";
-        render(nothing, container);
+        const replacement = document.createElement("div");
+        container.replaceWith(replacement);
+        container = replacement;
         renderControlledStrip({ container, tabs, activeId, onSelect, onClose });
       }),
     );

--- a/ui/src/components/panel-tab-strip.browser.test.ts
+++ b/ui/src/components/panel-tab-strip.browser.test.ts
@@ -32,7 +32,7 @@ function renderControlledStrip(params: {
   tabs: PanelTabStripTab[];
   activeId: string;
   onSelect: (id: string) => void;
-  onClose?: (id: string) => void;
+  onClose?: (id: string) => void | Promise<void>;
 }) {
   render(
     renderPanelTabStrip({
@@ -157,15 +157,15 @@ describe.skipIf(!hasBrowserLayout)("panel tab strip browser lifecycle", () => {
     let tabs = [tab("a"), tab("b")];
     let activeId = "a";
     const onSelect = vi.fn();
-    const onClose = vi.fn((closedId: string) => {
-      void close.promise.then(() => {
+    const onClose = vi.fn((closedId: string) =>
+      close.promise.then(() => {
         (document.activeElement as HTMLElement | null)?.blur();
         tabs = tabs.filter((entry) => entry.id !== closedId);
         activeId = tabs[0]?.id ?? "";
         render(nothing, container);
         renderControlledStrip({ container, tabs, activeId, onSelect, onClose });
-      });
-    });
+      }),
+    );
     renderControlledStrip({ container, tabs, activeId, onSelect, onClose });
     await expectControlledSelection(container, activeId);
     const closeButton = container.querySelector<HTMLButtonElement>(".tabstrip-tab__close");

--- a/ui/src/components/panel-tab-strip.test.ts
+++ b/ui/src/components/panel-tab-strip.test.ts
@@ -15,15 +15,6 @@ const TAB: PanelTabStripTab = {
   closeLabel: "Close tab: First tab",
 };
 
-type RenderedTab = HTMLElement & {
-  active: boolean;
-  panel: string;
-};
-
-type RenderedTabGroup = HTMLElement & {
-  active: string;
-};
-
 function renderStrip(options: {
   tabs?: PanelTabStripTab[];
   activeId?: string | null;
@@ -46,18 +37,6 @@ function renderStrip(options: {
     container,
   );
   return container;
-}
-
-function readTabStrip(container: ParentNode): {
-  group: RenderedTabGroup;
-  tabs: RenderedTab[];
-} {
-  const group = container.querySelector<RenderedTabGroup>("wa-tab-group");
-  if (!group) {
-    throw new Error("expected rendered tab group");
-  }
-  const tabs = [...container.querySelectorAll<RenderedTab>("wa-tab")];
-  return { group, tabs };
 }
 
 afterEach(() => {
@@ -103,66 +82,5 @@ describe("renderPanelTabStrip", () => {
 
     container.querySelector("wa-tab")?.dispatchEvent(new MouseEvent("auxclick", { button: 1 }));
     expect(onClose).toHaveBeenCalledWith(TAB.id);
-  });
-
-  it("keeps the controlled active tab coherent when stateful tab elements reorder", async () => {
-    const first: PanelTabStripTab = {
-      ...TAB,
-      id: "a",
-      domId: "test-tab-a",
-      label: "Alpha",
-      title: "https://example.com/a",
-    };
-    const second: PanelTabStripTab = {
-      ...TAB,
-      id: "b",
-      domId: "test-tab-b",
-      label: "Beta",
-      title: "https://example.com/b",
-    };
-    const container = renderStrip({ tabs: [first, second], activeId: first.id });
-    document.body.append(container);
-    const initial = readTabStrip(container);
-    const firstElement = initial.tabs.find((tab) => tab.panel === first.id);
-    const secondElement = initial.tabs.find((tab) => tab.panel === second.id);
-    if (!firstElement || !secondElement) {
-      throw new Error("expected initial active tab");
-    }
-    firstElement.active = true;
-    firstElement.setAttribute("active", "");
-    firstElement.setAttribute("aria-selected", "true");
-    firstElement.tabIndex = 0;
-    secondElement.active = false;
-    secondElement.removeAttribute("active");
-    secondElement.setAttribute("aria-selected", "false");
-    secondElement.tabIndex = -1;
-
-    renderStrip({
-      container,
-      tabs: [
-        { ...second, label: "Beta navigated", title: "https://example.com/b/next" },
-        { ...first, label: "Alpha navigated", title: "https://example.com/a/next" },
-      ],
-      activeId: first.id,
-    });
-
-    await vi.waitFor(() => {
-      const reordered = readTabStrip(container);
-      const active = reordered.tabs.filter(
-        (tab) =>
-          tab.active || tab.hasAttribute("active") || tab.getAttribute("aria-selected") === "true",
-      );
-      const reorderedFirst = reordered.tabs.find((tab) => tab.panel === first.id);
-
-      expect(reorderedFirst).toBe(firstElement);
-      expect(reordered.group.active).toBe(first.id);
-      expect(active).toEqual([firstElement]);
-      expect(firstElement.getAttribute("aria-selected")).toBe("true");
-      expect(firstElement.tabIndex).toBe(0);
-      expect(reordered.tabs.find((tab) => tab.panel === second.id)).toMatchObject({
-        active: false,
-        tabIndex: -1,
-      });
-    });
   });
 });

--- a/ui/src/components/panel-tab-strip.test.ts
+++ b/ui/src/components/panel-tab-strip.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { render } from "lit";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   panelTabStripStyles,
   renderPanelTabStrip,
@@ -15,18 +15,30 @@ const TAB: PanelTabStripTab = {
   closeLabel: "Close tab: First tab",
 };
 
+type RenderedTab = HTMLElement & {
+  active: boolean;
+  panel: string;
+};
+
+type RenderedTabGroup = HTMLElement & {
+  active: string;
+};
+
 function renderStrip(options: {
   tabs?: PanelTabStripTab[];
+  activeId?: string | null;
   onClose?: (id: string) => void;
   onNew?: () => void;
+  onSelect?: (id: string) => void;
+  container?: HTMLDivElement;
 }) {
-  const container = document.createElement("div");
+  const container = options.container ?? document.createElement("div");
   render(
     renderPanelTabStrip({
       tabs: options.tabs ?? [],
-      activeId: options.tabs?.[0]?.id ?? null,
+      activeId: options.activeId ?? options.tabs?.[0]?.id ?? null,
       ariaControls: "test-tab-panel",
-      onSelect: vi.fn(),
+      onSelect: options.onSelect ?? vi.fn(),
       onClose: options.onClose ?? vi.fn(),
       onNew: options.onNew ?? vi.fn(),
       newLabel: "New tab",
@@ -35,6 +47,22 @@ function renderStrip(options: {
   );
   return container;
 }
+
+function readTabStrip(container: ParentNode): {
+  group: RenderedTabGroup;
+  tabs: RenderedTab[];
+} {
+  const group = container.querySelector<RenderedTabGroup>("wa-tab-group");
+  if (!group) {
+    throw new Error("expected rendered tab group");
+  }
+  const tabs = [...container.querySelectorAll<RenderedTab>("wa-tab")];
+  return { group, tabs };
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
 
 describe("renderPanelTabStrip", () => {
   it("keeps the new-tab control from shrinking when the strip overflows", () => {
@@ -75,5 +103,66 @@ describe("renderPanelTabStrip", () => {
 
     container.querySelector("wa-tab")?.dispatchEvent(new MouseEvent("auxclick", { button: 1 }));
     expect(onClose).toHaveBeenCalledWith(TAB.id);
+  });
+
+  it("keeps the controlled active tab coherent when stateful tab elements reorder", async () => {
+    const first: PanelTabStripTab = {
+      ...TAB,
+      id: "a",
+      domId: "test-tab-a",
+      label: "Alpha",
+      title: "https://example.com/a",
+    };
+    const second: PanelTabStripTab = {
+      ...TAB,
+      id: "b",
+      domId: "test-tab-b",
+      label: "Beta",
+      title: "https://example.com/b",
+    };
+    const container = renderStrip({ tabs: [first, second], activeId: first.id });
+    document.body.append(container);
+    const initial = readTabStrip(container);
+    const firstElement = initial.tabs.find((tab) => tab.panel === first.id);
+    const secondElement = initial.tabs.find((tab) => tab.panel === second.id);
+    if (!firstElement || !secondElement) {
+      throw new Error("expected initial active tab");
+    }
+    firstElement.active = true;
+    firstElement.setAttribute("active", "");
+    firstElement.setAttribute("aria-selected", "true");
+    firstElement.tabIndex = 0;
+    secondElement.active = false;
+    secondElement.removeAttribute("active");
+    secondElement.setAttribute("aria-selected", "false");
+    secondElement.tabIndex = -1;
+
+    renderStrip({
+      container,
+      tabs: [
+        { ...second, label: "Beta navigated", title: "https://example.com/b/next" },
+        { ...first, label: "Alpha navigated", title: "https://example.com/a/next" },
+      ],
+      activeId: first.id,
+    });
+
+    await vi.waitFor(() => {
+      const reordered = readTabStrip(container);
+      const active = reordered.tabs.filter(
+        (tab) =>
+          tab.active || tab.hasAttribute("active") || tab.getAttribute("aria-selected") === "true",
+      );
+      const reorderedFirst = reordered.tabs.find((tab) => tab.panel === first.id);
+
+      expect(reorderedFirst).toBe(firstElement);
+      expect(reordered.group.active).toBe(first.id);
+      expect(active).toEqual([firstElement]);
+      expect(firstElement.getAttribute("aria-selected")).toBe("true");
+      expect(firstElement.tabIndex).toBe(0);
+      expect(reordered.tabs.find((tab) => tab.panel === second.id)).toMatchObject({
+        active: false,
+        tabIndex: -1,
+      });
+    });
   });
 });

--- a/ui/src/components/panel-tab-strip.ts
+++ b/ui/src/components/panel-tab-strip.ts
@@ -20,11 +20,12 @@ const CLOSE_GLYPH = svg`<svg viewBox="0 0 16 16" width="14" height="14" fill="no
 const PLUS_GLYPH = svg`<svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><path d="M8 3v10M3 8h10" /></svg>`;
 
 const reconciledTabOrders = new WeakMap<Element, string>();
-const pendingCloseFocus = new WeakMap<Element, string>();
+const pendingCloseFocus = new Map<string, string>();
 
 function reconcileSelectedTabElement(
   element: Element | undefined,
   tabOrder: string,
+  focusScope: string,
   restoreFocus: boolean,
 ): void {
   if (!(element instanceof HTMLElement)) {
@@ -32,8 +33,7 @@ function reconcileSelectedTabElement(
   }
   const orderChanged = reconciledTabOrders.get(element) !== tabOrder;
   reconciledTabOrders.set(element, tabOrder);
-  const group = element.closest("wa-tab-group");
-  if (!orderChanged && !restoreFocus && !(group && pendingCloseFocus.has(group))) {
+  if (!orderChanged && !restoreFocus && !pendingCloseFocus.has(focusScope)) {
     return;
   }
   // Keyed movement can make the browser briefly focus the document or move the
@@ -43,23 +43,32 @@ function reconcileSelectedTabElement(
       return;
     }
     const currentGroup = element.closest("wa-tab-group");
-    const closedTabId = currentGroup ? pendingCloseFocus.get(currentGroup) : undefined;
+    const closedTabId = pendingCloseFocus.get(focusScope);
     const focusAfterClose =
+      currentGroup !== null &&
       closedTabId !== undefined &&
       ![...currentGroup!.querySelectorAll<HTMLElement>("wa-tab")].some(
         (tab) => tab.getAttribute("panel") === closedTabId,
       );
-    if (currentGroup && closedTabId !== undefined) {
-      pendingCloseFocus.delete(currentGroup);
+    if (closedTabId !== undefined) {
+      pendingCloseFocus.delete(focusScope);
     }
-    element.scrollIntoView?.({ block: "nearest", inline: "nearest" });
-    const current = document.activeElement;
-    if (
-      (restoreFocus || focusAfterClose) &&
-      (current === document.body || current === document.documentElement)
-    ) {
-      element.focus({ preventScroll: true });
-    }
+    const updateComplete =
+      (currentGroup as (HTMLElement & { updateComplete?: Promise<unknown> }) | null)
+        ?.updateComplete ?? Promise.resolve();
+    void updateComplete.then(() => {
+      if (!element.isConnected) {
+        return;
+      }
+      element.scrollIntoView?.({ block: "nearest", inline: "nearest" });
+      const current = document.activeElement;
+      if (
+        (restoreFocus || focusAfterClose) &&
+        (current === document.body || current === document.documentElement)
+      ) {
+        element.focus({ preventScroll: true });
+      }
+    });
   });
 }
 
@@ -87,6 +96,7 @@ export function renderPanelTabStrip(params: {
     </button>
   `;
   if (params.tabs.length === 0) {
+    pendingCloseFocus.delete(params.ariaControls);
     // Web Awesome 3.10 dereferences its first tab when an empty group becomes
     // visible. Keep the new-session control outside the group until one exists.
     return newButton(false);
@@ -123,7 +133,12 @@ export function renderPanelTabStrip(params: {
               .tabIndex=${selected ? 0 : -1}
               ${selected
                 ? ref((element) =>
-                    reconcileSelectedTabElement(element, tabOrder, focusedTabDomId === tab.domId),
+                    reconcileSelectedTabElement(
+                      element,
+                      tabOrder,
+                      params.ariaControls,
+                      focusedTabDomId === tab.domId,
+                    ),
                   )
                 : nothing}
               @auxclick=${(event: MouseEvent) => {
@@ -150,9 +165,8 @@ export function renderPanelTabStrip(params: {
               aria-label=${tab.closeLabel}
               @click=${(event: MouseEvent) => {
                 const button = event.currentTarget;
-                const group = button instanceof HTMLElement ? button.closest("wa-tab-group") : null;
-                if (group && document.activeElement === button) {
-                  pendingCloseFocus.set(group, tab.id);
+                if (button instanceof HTMLElement && document.activeElement === button) {
+                  pendingCloseFocus.set(params.ariaControls, tab.id);
                 }
                 params.onClose(tab.id);
               }}

--- a/ui/src/components/panel-tab-strip.ts
+++ b/ui/src/components/panel-tab-strip.ts
@@ -82,6 +82,12 @@ export function renderPanelTabStrip(params: {
     params.tabs.some((tab) => tab.domId === activeElement.id)
       ? activeElement.id
       : null;
+  const focusedCloseTabId =
+    activeElement instanceof HTMLElement && activeElement.classList.contains("tabstrip-tab__close")
+      ? (activeElement.dataset.tabId ?? null)
+      : null;
+  const focusedTabWasRemoved =
+    focusedCloseTabId !== null && !params.tabs.some((tab) => tab.id === focusedCloseTabId);
   const tabOrder = params.tabs.map((tab) => tab.id).join("\u0000");
   return html`
     <wa-tab-group
@@ -108,7 +114,11 @@ export function renderPanelTabStrip(params: {
               .tabIndex=${selected ? 0 : -1}
               ${selected
                 ? ref((element) =>
-                    reconcileSelectedTabElement(element, tabOrder, focusedTabDomId === tab.domId),
+                    reconcileSelectedTabElement(
+                      element,
+                      tabOrder,
+                      focusedTabDomId === tab.domId || focusedTabWasRemoved,
+                    ),
                   )
                 : nothing}
               @auxclick=${(event: MouseEvent) => {
@@ -131,6 +141,7 @@ export function renderPanelTabStrip(params: {
               slot="nav"
               class="tabstrip-tab__close"
               type="button"
+              data-tab-id=${tab.id}
               title=${tab.closeLabel}
               aria-label=${tab.closeLabel}
               @click=${() => params.onClose(tab.id)}

--- a/ui/src/components/panel-tab-strip.ts
+++ b/ui/src/components/panel-tab-strip.ts
@@ -144,16 +144,23 @@ export function renderPanelTabStrip(params: {
               aria-label=${tab.closeLabel}
               @click=${async (event: MouseEvent) => {
                 const button = event.currentTarget;
-                const group = button instanceof HTMLElement ? button.closest("wa-tab-group") : null;
-                const groupOwner = group?.parentNode as ParentNode | null;
+                const renderRoot =
+                  button instanceof Node ? (button.getRootNode() as ParentNode) : null;
                 const restoreFocus = document.activeElement === button;
                 await params.onClose(tab.id);
                 if (!restoreFocus) {
                   return;
                 }
-                const settledGroup = groupOwner?.querySelector<
-                  HTMLElement & { updateComplete?: Promise<unknown> }
-                >("wa-tab-group");
+                const settledGroup = [
+                  ...(renderRoot?.querySelectorAll<
+                    HTMLElement & { updateComplete?: Promise<unknown> }
+                  >("wa-tab-group") ?? []),
+                ].find((candidate) =>
+                  [...candidate.querySelectorAll<HTMLElement>("wa-tab")].some(
+                    (renderedTab) =>
+                      renderedTab.getAttribute("aria-controls") === params.ariaControls,
+                  ),
+                );
                 await settledGroup?.updateComplete;
                 const closingTab = [
                   ...(settledGroup?.querySelectorAll<HTMLElement>("wa-tab") ?? []),

--- a/ui/src/components/panel-tab-strip.ts
+++ b/ui/src/components/panel-tab-strip.ts
@@ -20,6 +20,7 @@ const CLOSE_GLYPH = svg`<svg viewBox="0 0 16 16" width="14" height="14" fill="no
 const PLUS_GLYPH = svg`<svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><path d="M8 3v10M3 8h10" /></svg>`;
 
 const reconciledTabOrders = new WeakMap<Element, string>();
+const keyboardCloseActivations = new WeakSet<Element>();
 
 function reconcileSelectedTabElement(
   element: Element | undefined,
@@ -142,6 +143,14 @@ export function renderPanelTabStrip(params: {
               type="button"
               title=${tab.closeLabel}
               aria-label=${tab.closeLabel}
+              @keydown=${(event: KeyboardEvent) => {
+                if (
+                  (event.key === "Enter" || event.key === " ") &&
+                  event.currentTarget instanceof Element
+                ) {
+                  keyboardCloseActivations.add(event.currentTarget);
+                }
+              }}
               @click=${async (event: MouseEvent) => {
                 const button = event.currentTarget;
                 const renderRoot =
@@ -150,7 +159,9 @@ export function renderPanelTabStrip(params: {
                   renderRoot instanceof ShadowRoot
                     ? (renderRoot.host as HTMLElement & { updateComplete?: Promise<unknown> })
                     : null;
-                const restoreFocus = document.activeElement === button;
+                const restoreFocus =
+                  button instanceof Element &&
+                  (keyboardCloseActivations.delete(button) || document.activeElement === button);
                 await params.onClose(tab.id);
                 if (!restoreFocus) {
                   return;

--- a/ui/src/components/panel-tab-strip.ts
+++ b/ui/src/components/panel-tab-strip.ts
@@ -1,4 +1,5 @@
 import { css, html, nothing, svg, type TemplateResult } from "lit";
+import { ref } from "lit/directives/ref.js";
 import { repeat } from "lit/directives/repeat.js";
 import "./web-awesome-tabs.ts";
 
@@ -17,6 +18,35 @@ export type PanelTabStripTab = {
 
 const CLOSE_GLYPH = svg`<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"><path d="M4 4l8 8M12 4l-8 8" /></svg>`;
 const PLUS_GLYPH = svg`<svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><path d="M8 3v10M3 8h10" /></svg>`;
+
+const reconciledTabOrders = new WeakMap<Element, string>();
+
+function reconcileSelectedTabElement(
+  element: Element | undefined,
+  tabOrder: string,
+  restoreFocus: boolean,
+): void {
+  if (!(element instanceof HTMLElement)) {
+    return;
+  }
+  const orderChanged = reconciledTabOrders.get(element) !== tabOrder;
+  reconciledTabOrders.set(element, tabOrder);
+  if (!orderChanged && !restoreFocus) {
+    return;
+  }
+  // Keyed movement can make the browser briefly focus the document or move the
+  // selected tab outside the overflow viewport. Reconcile only those changes.
+  queueMicrotask(() => {
+    if (!element.isConnected) {
+      return;
+    }
+    element.scrollIntoView?.({ block: "nearest", inline: "nearest" });
+    const current = document.activeElement;
+    if (restoreFocus && (current === document.body || current === document.documentElement)) {
+      element.focus({ preventScroll: true });
+    }
+  });
+}
 
 export function renderPanelTabStrip(params: {
   tabs: PanelTabStripTab[];
@@ -46,6 +76,12 @@ export function renderPanelTabStrip(params: {
     // visible. Keep the new-session control outside the group until one exists.
     return newButton(false);
   }
+  const focusedTabDomId =
+    document.activeElement instanceof HTMLElement &&
+    params.tabs.some((tab) => tab.domId === document.activeElement.id)
+      ? document.activeElement.id
+      : null;
+  const tabOrder = params.tabs.map((tab) => tab.id).join("\u0000");
   return html`
     <wa-tab-group
       class="tabstrip"
@@ -69,6 +105,11 @@ export function renderPanelTabStrip(params: {
               title=${tab.title || nothing}
               ?active=${selected}
               .tabIndex=${selected ? 0 : -1}
+              ${selected
+                ? ref((element) =>
+                    reconcileSelectedTabElement(element, tabOrder, focusedTabDomId === tab.domId),
+                  )
+                : nothing}
               @auxclick=${(event: MouseEvent) => {
                 if (event.button === 1) {
                   event.preventDefault();

--- a/ui/src/components/panel-tab-strip.ts
+++ b/ui/src/components/panel-tab-strip.ts
@@ -146,11 +146,16 @@ export function renderPanelTabStrip(params: {
                 const button = event.currentTarget;
                 const renderRoot =
                   button instanceof Node ? (button.getRootNode() as ParentNode) : null;
+                const renderHost =
+                  renderRoot instanceof ShadowRoot
+                    ? (renderRoot.host as HTMLElement & { updateComplete?: Promise<unknown> })
+                    : null;
                 const restoreFocus = document.activeElement === button;
                 await params.onClose(tab.id);
                 if (!restoreFocus) {
                   return;
                 }
+                await renderHost?.updateComplete;
                 const settledGroup = [
                   ...(renderRoot?.querySelectorAll<
                     HTMLElement & { updateComplete?: Promise<unknown> }

--- a/ui/src/components/panel-tab-strip.ts
+++ b/ui/src/components/panel-tab-strip.ts
@@ -22,6 +22,30 @@ const PLUS_GLYPH = svg`<svg viewBox="0 0 16 16" width="13" height="13" fill="non
 const reconciledTabOrders = new WeakMap<Element, string>();
 const keyboardCloseActivations = new WeakSet<Element>();
 
+function activeElementFor(element: Element): Element | null {
+  const root = element.getRootNode();
+  return root instanceof ShadowRoot
+    ? (root.activeElement ?? document.activeElement)
+    : document.activeElement;
+}
+
+function deepestActiveElement(): Element | null {
+  let active = document.activeElement;
+  while (active instanceof HTMLElement && active.shadowRoot?.activeElement) {
+    active = active.shadowRoot.activeElement;
+  }
+  return active;
+}
+
+function focusNeedsRecovery(element: Element, current: Element | null): boolean {
+  const root = element.getRootNode();
+  return (
+    current === document.body ||
+    current === document.documentElement ||
+    (root instanceof ShadowRoot && current === root.host)
+  );
+}
+
 function reconcileSelectedTabElement(
   element: Element | undefined,
   tabOrder: string,
@@ -50,8 +74,8 @@ function reconcileSelectedTabElement(
         return;
       }
       element.scrollIntoView?.({ block: "nearest", inline: "nearest" });
-      const current = document.activeElement;
-      if (restoreFocus && (current === document.body || current === document.documentElement)) {
+      const current = activeElementFor(element);
+      if (restoreFocus && focusNeedsRecovery(element, current)) {
         element.focus({ preventScroll: true });
       }
     });
@@ -86,7 +110,7 @@ export function renderPanelTabStrip(params: {
     // visible. Keep the new-session control outside the group until one exists.
     return newButton(false);
   }
-  const activeElement = document.activeElement;
+  const activeElement = deepestActiveElement();
   const focusedTabDomId =
     activeElement instanceof HTMLElement &&
     params.tabs.some((tab) => tab.domId === activeElement.id)
@@ -161,7 +185,7 @@ export function renderPanelTabStrip(params: {
                     : null;
                 const restoreFocus =
                   button instanceof Element &&
-                  (keyboardCloseActivations.delete(button) || document.activeElement === button);
+                  (keyboardCloseActivations.delete(button) || activeElementFor(button) === button);
                 await params.onClose(tab.id);
                 if (!restoreFocus) {
                   return;
@@ -182,12 +206,8 @@ export function renderPanelTabStrip(params: {
                   ...(settledGroup?.querySelectorAll<HTMLElement>("wa-tab") ?? []),
                 ].find((candidate) => candidate.getAttribute("panel") === tab.id);
                 const fallback = settledGroup?.querySelector<HTMLElement>("wa-tab[active]");
-                const current = document.activeElement;
-                if (
-                  !closingTab &&
-                  fallback &&
-                  (current === document.body || current === document.documentElement)
-                ) {
+                const current = fallback ? activeElementFor(fallback) : null;
+                if (!closingTab && fallback && focusNeedsRecovery(fallback, current)) {
                   fallback.focus({ preventScroll: true });
                 }
               }}

--- a/ui/src/components/panel-tab-strip.ts
+++ b/ui/src/components/panel-tab-strip.ts
@@ -20,12 +20,10 @@ const CLOSE_GLYPH = svg`<svg viewBox="0 0 16 16" width="14" height="14" fill="no
 const PLUS_GLYPH = svg`<svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><path d="M8 3v10M3 8h10" /></svg>`;
 
 const reconciledTabOrders = new WeakMap<Element, string>();
-const pendingCloseFocus = new Map<string, string>();
 
 function reconcileSelectedTabElement(
   element: Element | undefined,
   tabOrder: string,
-  focusScope: string,
   restoreFocus: boolean,
 ): void {
   if (!(element instanceof HTMLElement)) {
@@ -33,7 +31,7 @@ function reconcileSelectedTabElement(
   }
   const orderChanged = reconciledTabOrders.get(element) !== tabOrder;
   reconciledTabOrders.set(element, tabOrder);
-  if (!orderChanged && !restoreFocus && !pendingCloseFocus.has(focusScope)) {
+  if (!orderChanged && !restoreFocus) {
     return;
   }
   // Keyed movement can make the browser briefly focus the document or move the
@@ -43,16 +41,6 @@ function reconcileSelectedTabElement(
       return;
     }
     const currentGroup = element.closest("wa-tab-group");
-    const closedTabId = pendingCloseFocus.get(focusScope);
-    const focusAfterClose =
-      currentGroup !== null &&
-      closedTabId !== undefined &&
-      ![...currentGroup!.querySelectorAll<HTMLElement>("wa-tab")].some(
-        (tab) => tab.getAttribute("panel") === closedTabId,
-      );
-    if (closedTabId !== undefined) {
-      pendingCloseFocus.delete(focusScope);
-    }
     const updateComplete =
       (currentGroup as (HTMLElement & { updateComplete?: Promise<unknown> }) | null)
         ?.updateComplete ?? Promise.resolve();
@@ -62,10 +50,7 @@ function reconcileSelectedTabElement(
       }
       element.scrollIntoView?.({ block: "nearest", inline: "nearest" });
       const current = document.activeElement;
-      if (
-        (restoreFocus || focusAfterClose) &&
-        (current === document.body || current === document.documentElement)
-      ) {
+      if (restoreFocus && (current === document.body || current === document.documentElement)) {
         element.focus({ preventScroll: true });
       }
     });
@@ -77,7 +62,7 @@ export function renderPanelTabStrip(params: {
   activeId: string | null;
   ariaControls: string;
   onSelect: (id: string) => void;
-  onClose: (id: string) => void;
+  onClose: (id: string) => void | Promise<void>;
   onNew: () => void;
   newLabel: string;
   newDisabled?: boolean;
@@ -96,7 +81,6 @@ export function renderPanelTabStrip(params: {
     </button>
   `;
   if (params.tabs.length === 0) {
-    pendingCloseFocus.delete(params.ariaControls);
     // Web Awesome 3.10 dereferences its first tab when an empty group becomes
     // visible. Keep the new-session control outside the group until one exists.
     return newButton(false);
@@ -133,18 +117,13 @@ export function renderPanelTabStrip(params: {
               .tabIndex=${selected ? 0 : -1}
               ${selected
                 ? ref((element) =>
-                    reconcileSelectedTabElement(
-                      element,
-                      tabOrder,
-                      params.ariaControls,
-                      focusedTabDomId === tab.domId,
-                    ),
+                    reconcileSelectedTabElement(element, tabOrder, focusedTabDomId === tab.domId),
                   )
                 : nothing}
               @auxclick=${(event: MouseEvent) => {
                 if (event.button === 1) {
                   event.preventDefault();
-                  params.onClose(tab.id);
+                  void params.onClose(tab.id);
                 }
               }}
             >
@@ -163,12 +142,31 @@ export function renderPanelTabStrip(params: {
               type="button"
               title=${tab.closeLabel}
               aria-label=${tab.closeLabel}
-              @click=${(event: MouseEvent) => {
+              @click=${async (event: MouseEvent) => {
                 const button = event.currentTarget;
-                if (button instanceof HTMLElement && document.activeElement === button) {
-                  pendingCloseFocus.set(params.ariaControls, tab.id);
+                const group = button instanceof HTMLElement ? button.closest("wa-tab-group") : null;
+                const groupOwner = group?.parentNode as ParentNode | null;
+                const restoreFocus = document.activeElement === button;
+                await params.onClose(tab.id);
+                if (!restoreFocus) {
+                  return;
                 }
-                params.onClose(tab.id);
+                const settledGroup = groupOwner?.querySelector<
+                  HTMLElement & { updateComplete?: Promise<unknown> }
+                >("wa-tab-group");
+                await settledGroup?.updateComplete;
+                const closingTab = [
+                  ...(settledGroup?.querySelectorAll<HTMLElement>("wa-tab") ?? []),
+                ].find((candidate) => candidate.getAttribute("panel") === tab.id);
+                const fallback = settledGroup?.querySelector<HTMLElement>("wa-tab[active]");
+                const current = document.activeElement;
+                if (
+                  !closingTab &&
+                  fallback &&
+                  (current === document.body || current === document.documentElement)
+                ) {
+                  fallback.focus({ preventScroll: true });
+                }
               }}
             >
               <span class="tabstrip-tab__close-box">${CLOSE_GLYPH}</span>

--- a/ui/src/components/panel-tab-strip.ts
+++ b/ui/src/components/panel-tab-strip.ts
@@ -76,10 +76,11 @@ export function renderPanelTabStrip(params: {
     // visible. Keep the new-session control outside the group until one exists.
     return newButton(false);
   }
+  const activeElement = document.activeElement;
   const focusedTabDomId =
-    document.activeElement instanceof HTMLElement &&
-    params.tabs.some((tab) => tab.domId === document.activeElement.id)
-      ? document.activeElement.id
+    activeElement instanceof HTMLElement &&
+    params.tabs.some((tab) => tab.domId === activeElement.id)
+      ? activeElement.id
       : null;
   const tabOrder = params.tabs.map((tab) => tab.id).join("\u0000");
   return html`

--- a/ui/src/components/panel-tab-strip.ts
+++ b/ui/src/components/panel-tab-strip.ts
@@ -20,6 +20,7 @@ const CLOSE_GLYPH = svg`<svg viewBox="0 0 16 16" width="14" height="14" fill="no
 const PLUS_GLYPH = svg`<svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><path d="M8 3v10M3 8h10" /></svg>`;
 
 const reconciledTabOrders = new WeakMap<Element, string>();
+const pendingCloseFocus = new WeakMap<Element, string>();
 
 function reconcileSelectedTabElement(
   element: Element | undefined,
@@ -31,7 +32,8 @@ function reconcileSelectedTabElement(
   }
   const orderChanged = reconciledTabOrders.get(element) !== tabOrder;
   reconciledTabOrders.set(element, tabOrder);
-  if (!orderChanged && !restoreFocus) {
+  const group = element.closest("wa-tab-group");
+  if (!orderChanged && !restoreFocus && !(group && pendingCloseFocus.has(group))) {
     return;
   }
   // Keyed movement can make the browser briefly focus the document or move the
@@ -40,9 +42,22 @@ function reconcileSelectedTabElement(
     if (!element.isConnected) {
       return;
     }
+    const currentGroup = element.closest("wa-tab-group");
+    const closedTabId = currentGroup ? pendingCloseFocus.get(currentGroup) : undefined;
+    const focusAfterClose =
+      closedTabId !== undefined &&
+      ![...currentGroup!.querySelectorAll<HTMLElement>("wa-tab")].some(
+        (tab) => tab.getAttribute("panel") === closedTabId,
+      );
+    if (currentGroup && closedTabId !== undefined) {
+      pendingCloseFocus.delete(currentGroup);
+    }
     element.scrollIntoView?.({ block: "nearest", inline: "nearest" });
     const current = document.activeElement;
-    if (restoreFocus && (current === document.body || current === document.documentElement)) {
+    if (
+      (restoreFocus || focusAfterClose) &&
+      (current === document.body || current === document.documentElement)
+    ) {
       element.focus({ preventScroll: true });
     }
   });
@@ -82,12 +97,6 @@ export function renderPanelTabStrip(params: {
     params.tabs.some((tab) => tab.domId === activeElement.id)
       ? activeElement.id
       : null;
-  const focusedCloseTabId =
-    activeElement instanceof HTMLElement && activeElement.classList.contains("tabstrip-tab__close")
-      ? (activeElement.dataset.tabId ?? null)
-      : null;
-  const focusedTabWasRemoved =
-    focusedCloseTabId !== null && !params.tabs.some((tab) => tab.id === focusedCloseTabId);
   const tabOrder = params.tabs.map((tab) => tab.id).join("\u0000");
   return html`
     <wa-tab-group
@@ -114,11 +123,7 @@ export function renderPanelTabStrip(params: {
               .tabIndex=${selected ? 0 : -1}
               ${selected
                 ? ref((element) =>
-                    reconcileSelectedTabElement(
-                      element,
-                      tabOrder,
-                      focusedTabDomId === tab.domId || focusedTabWasRemoved,
-                    ),
+                    reconcileSelectedTabElement(element, tabOrder, focusedTabDomId === tab.domId),
                   )
                 : nothing}
               @auxclick=${(event: MouseEvent) => {
@@ -141,10 +146,16 @@ export function renderPanelTabStrip(params: {
               slot="nav"
               class="tabstrip-tab__close"
               type="button"
-              data-tab-id=${tab.id}
               title=${tab.closeLabel}
               aria-label=${tab.closeLabel}
-              @click=${() => params.onClose(tab.id)}
+              @click=${(event: MouseEvent) => {
+                const button = event.currentTarget;
+                const group = button instanceof HTMLElement ? button.closest("wa-tab-group") : null;
+                if (group && document.activeElement === button) {
+                  pendingCloseFocus.set(group, tab.id);
+                }
+                params.onClose(tab.id);
+              }}
             >
               <span class="tabstrip-tab__close-box">${CLOSE_GLYPH}</span>
             </button>

--- a/ui/src/components/panel-tab-strip.ts
+++ b/ui/src/components/panel-tab-strip.ts
@@ -1,4 +1,5 @@
 import { css, html, nothing, svg, type TemplateResult } from "lit";
+import { repeat } from "lit/directives/repeat.js";
 import "./web-awesome-tabs.ts";
 
 export type PanelTabStripTab = {
@@ -53,41 +54,49 @@ export function renderPanelTabStrip(params: {
       without-scroll-controls
       @wa-tab-show=${(event: CustomEvent<{ name: string }>) => params.onSelect(event.detail.name)}
     >
-      ${params.tabs.map(
-        (tab) => html`
-          <wa-tab
-            id=${tab.domId}
-            class=${`tabstrip-tab ${tab.className ?? ""}`}
-            panel=${tab.id}
-            aria-controls=${params.ariaControls}
-            title=${tab.title || nothing}
-            @auxclick=${(event: MouseEvent) => {
-              if (event.button === 1) {
-                event.preventDefault();
-                params.onClose(tab.id);
-              }
-            }}
-          >
-            ${tab.icon == null || tab.icon === nothing
-              ? nothing
-              : html`<span class="tabstrip-tab__icon" aria-hidden="true">${tab.icon}</span>`}
-            <span class="tabstrip-tab__label">${tab.label}</span>
-            ${tab.badge ? html`<span class="tabstrip-tab__badge">${tab.badge}</span>` : nothing}
-            ${tab.statusLabel
-              ? html`<span class="tabstrip-tab__status">${tab.statusLabel}</span>`
-              : nothing}
-          </wa-tab>
-          <button
-            slot="nav"
-            class="tabstrip-tab__close"
-            type="button"
-            title=${tab.closeLabel}
-            aria-label=${tab.closeLabel}
-            @click=${() => params.onClose(tab.id)}
-          >
-            <span class="tabstrip-tab__close-box">${CLOSE_GLYPH}</span>
-          </button>
-        `,
+      ${repeat(
+        params.tabs,
+        (tab) => tab.id,
+        (tab) => {
+          const selected = tab.id === params.activeId;
+          return html`
+            <wa-tab
+              id=${tab.domId}
+              class=${`tabstrip-tab ${tab.className ?? ""}`}
+              panel=${tab.id}
+              aria-controls=${params.ariaControls}
+              aria-selected=${selected ? "true" : "false"}
+              title=${tab.title || nothing}
+              ?active=${selected}
+              .tabIndex=${selected ? 0 : -1}
+              @auxclick=${(event: MouseEvent) => {
+                if (event.button === 1) {
+                  event.preventDefault();
+                  params.onClose(tab.id);
+                }
+              }}
+            >
+              ${tab.icon == null || tab.icon === nothing
+                ? nothing
+                : html`<span class="tabstrip-tab__icon" aria-hidden="true">${tab.icon}</span>`}
+              <span class="tabstrip-tab__label">${tab.label}</span>
+              ${tab.badge ? html`<span class="tabstrip-tab__badge">${tab.badge}</span>` : nothing}
+              ${tab.statusLabel
+                ? html`<span class="tabstrip-tab__status">${tab.statusLabel}</span>`
+                : nothing}
+            </wa-tab>
+            <button
+              slot="nav"
+              class="tabstrip-tab__close"
+              type="button"
+              title=${tab.closeLabel}
+              aria-label=${tab.closeLabel}
+              @click=${() => params.onClose(tab.id)}
+            >
+              <span class="tabstrip-tab__close-box">${CLOSE_GLYPH}</span>
+            </button>
+          `;
+        },
       )}
       ${newButton(true)}
     </wa-tab-group>

--- a/ui/src/components/terminal/terminal-panel-chrome.ts
+++ b/ui/src/components/terminal/terminal-panel-chrome.ts
@@ -37,7 +37,7 @@ export function renderTerminalPanelHeader(
   booting: boolean,
   toolbar: TemplateResult,
   selectTab: (id: string) => void,
-  closeTab: (id: string) => void,
+  closeTab: (id: string) => void | Promise<void>,
   openSession: () => void,
 ): TemplateResult {
   return html`<header class="tp-header">

--- a/ui/src/components/terminal/terminal-panel-tabs.ts
+++ b/ui/src/components/terminal/terminal-panel-tabs.ts
@@ -47,7 +47,7 @@ export function renderTerminalPanelTabs(params: {
   activeId: string | null;
   booting: boolean;
   onSelect: (id: string) => void;
-  onClose: (id: string) => void;
+  onClose: (id: string) => void | Promise<void>;
   onNew: () => void;
 }) {
   const tabs: PanelTabStripTab[] = params.tabs.map((tab) => {

--- a/ui/src/components/terminal/terminal-panel.ts
+++ b/ui/src/components/terminal/terminal-panel.ts
@@ -384,7 +384,10 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
           this.terminalSessions.booting,
           toolbar,
           (id) => this.terminalSessions.switchTo(id),
-          (id) => this.terminalSessions.closeTab(id),
+          (id) => {
+            this.terminalSessions.closeTab(id);
+            return this.updateComplete.then(() => undefined);
+          },
           () => void this.terminalSessions.openSession(),
         )}
         ${renderTerminalPanelViewport(


### PR DESCRIPTION
Fixes #120745

## What changed

- Preserve each shared Browser and Terminal tab element by logical tab ID and explicitly control active, accessibility, and keyboard state.
- Keep browser tab metadata, address, document, and toolbar ownership aligned across navigation, history, background completion, close, and stale-operation races.
- Preserve focus through reorder, insertion, overflow, and asynchronous close inside Lit shadow roots.
- Bound per-client navigation ownership to live unreconciled tabs.

## Why

In-place browser navigation can replace a raw target and change upstream tab order while the stable tab alias remains active. Positional rendering let Web Awesome's selected DOM element become associated with a different logical tab, splitting the tab strip from the displayed page.

## Verification

- Repeated live in-place navigation, background selection, Back, Forward, Reload, visible failure recovery, Inspect, Annotate, close, restart, desktop, and narrow layouts.
- Focused UI unit tests and real Chromium lifecycle coverage for reorder, insertion, overflow, keyboard activation, asynchronous close, and shadow-root focus.
- Changed-surface typecheck and lint, production Control UI build, precompressed assets, and performance budgets.
