### PR TITLE
fix(logging): publish diagnostics ZIP through staged atomic overwrite

### DIFF
--- a/src/logging/diagnostic-support-bundle.test.ts
+++ b/src/logging/diagnostic-support-bundle.test.ts
@@ -104,9 +104,11 @@ describe("diagnostic support bundle helpers", () => {
     });
     const priorBytes = fs.readFileSync(outputPath);
 
-    const writeFileSpy = vi
-      .spyOn(fsp, "writeFile")
-      .mockRejectedValueOnce(new Error("injected write failure"));
+    const writeFileSpy = vi.spyOn(fsp, "writeFile").mockImplementationOnce(async (file) => {
+      expect(typeof file).toBe("string");
+      fs.writeFileSync(file as string, "partial replacement");
+      throw new Error("injected write failure");
+    });
     try {
       await expect(
         writeSupportBundleZip({

--- a/src/logging/diagnostic-support-bundle.test.ts
+++ b/src/logging/diagnostic-support-bundle.test.ts
@@ -1,9 +1,10 @@
 // Diagnostic support bundle tests cover collected files and redaction in bundles.
 import fs from "node:fs";
+import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import JSZip from "jszip";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   jsonSupportBundleFile,
   textSupportBundleFile,
@@ -62,15 +63,62 @@ describe("diagnostic support bundle helpers", () => {
 
   it("writes zip bundles through the same file model", async () => {
     const outputPath = path.join(tempDir, "bundle.zip");
-    const bytes = await writeSupportBundleZip({
+    const published = await writeSupportBundleZip({
       outputPath,
       files: [jsonSupportBundleFile("manifest.json", { ok: true })],
     });
 
-    expect(bytes).toBeGreaterThan(0);
+    expect(published.path).toBe(outputPath);
+    expect(published.bytes).toBeGreaterThan(0);
     expect(fs.statSync(outputPath).mode & 0o777).toBe(0o600);
 
     const zip = await JSZip.loadAsync(fs.readFileSync(outputPath));
     expect(await zip.file("manifest.json")?.async("string")).toBe('{\n  "ok": true\n}\n');
+    expect(fs.readdirSync(tempDir)).toEqual(["bundle.zip"]);
+  });
+
+  it("replaces an existing export with restrictive permissions", async () => {
+    const outputPath = path.join(tempDir, "bundle.zip");
+    fs.writeFileSync(outputPath, "previous export");
+    fs.chmodSync(outputPath, 0o644);
+
+    const published = await writeSupportBundleZip({
+      outputPath,
+      files: [jsonSupportBundleFile("manifest.json", { ok: true })],
+    });
+
+    expect(published.path).toBe(outputPath);
+    // The staged replacement installs a fresh file instead of truncating in
+    // place, so a permissive pre-existing mode cannot survive the overwrite.
+    expect(fs.statSync(outputPath).mode & 0o777).toBe(0o600);
+    const zip = await JSZip.loadAsync(fs.readFileSync(outputPath));
+    expect(await zip.file("manifest.json")?.async("string")).toBe('{\n  "ok": true\n}\n');
+    expect(fs.readdirSync(tempDir)).toEqual(["bundle.zip"]);
+  });
+
+  it("keeps the previous export when publication fails", async () => {
+    const outputPath = path.join(tempDir, "bundle.zip");
+    await writeSupportBundleZip({
+      outputPath,
+      files: [jsonSupportBundleFile("manifest.json", { ok: true })],
+    });
+    const priorBytes = fs.readFileSync(outputPath);
+
+    const writeFileSpy = vi
+      .spyOn(fsp, "writeFile")
+      .mockRejectedValueOnce(new Error("injected write failure"));
+    try {
+      await expect(
+        writeSupportBundleZip({
+          outputPath,
+          files: [jsonSupportBundleFile("manifest.json", { ok: false })],
+        }),
+      ).rejects.toThrow("injected write failure");
+    } finally {
+      writeFileSpy.mockRestore();
+    }
+
+    expect(fs.readFileSync(outputPath)).toEqual(priorBytes);
+    expect(fs.readdirSync(tempDir)).toEqual(["bundle.zip"]);
   });
 });

--- a/src/logging/diagnostic-support-bundle.ts
+++ b/src/logging/diagnostic-support-bundle.ts
@@ -1,6 +1,7 @@
 // Diagnostic support bundle helpers collect logs and metadata for support exports.
 import fsp from "node:fs/promises";
 import path from "node:path";
+import { writeExternalFileWithinRoot } from "../infra/fs-safe.js";
 import { isPathInside } from "../infra/path-guards.js";
 
 // File builders and writers for redacted diagnostic support bundles.
@@ -121,12 +122,12 @@ export async function writeSupportBundleDirectory(params: {
   return supportBundleContents(params.files);
 }
 
-/** Writes support-bundle files to a private zip archive and returns its byte size. */
+/** Writes support-bundle files to a private zip archive and returns the published path and byte size. */
 export async function writeSupportBundleZip(params: {
   outputPath: string;
   files: readonly DiagnosticSupportBundleFile[];
   compressionLevel?: number;
-}): Promise<number> {
+}): Promise<{ path: string; bytes: number }> {
   const { default: JSZip } = await import("jszip");
   const zip = new JSZip();
   for (const file of params.files) {
@@ -137,7 +138,18 @@ export async function writeSupportBundleZip(params: {
     compression: "DEFLATE",
     compressionOptions: { level: params.compressionLevel ?? 6 },
   });
-  await fsp.mkdir(path.dirname(params.outputPath), { recursive: true, mode: 0o700 });
-  await fsp.writeFile(params.outputPath, buffer, { mode: 0o600 });
-  return buffer.length;
+  const outputPath = path.resolve(params.outputPath);
+  await fsp.mkdir(path.dirname(outputPath), { recursive: true, mode: 0o700 });
+  // Publish through the staged sibling writer: a failed or interrupted write
+  // must never truncate a previously exported archive at the final path, and
+  // the atomic rename also replaces an overly permissive pre-existing mode.
+  const published = await writeExternalFileWithinRoot({
+    rootDir: path.dirname(outputPath),
+    path: path.basename(outputPath),
+    fallbackFileName: "openclaw-support.zip",
+    write: async (tempPath) => {
+      await fsp.writeFile(tempPath, buffer, { mode: 0o600 });
+    },
+  });
+  return { path: published.path, bytes: buffer.length };
 }

--- a/src/logging/diagnostic-support-export.ts
+++ b/src/logging/diagnostic-support-export.ts
@@ -805,14 +805,14 @@ export async function writeDiagnosticSupportExport(
     now,
   });
   const artifact = await buildDiagnosticSupportExport({ ...options, env, stateDir, now });
-  const bytes = await writeSupportBundleZip({
+  const published = await writeSupportBundleZip({
     outputPath,
     files: artifact.files,
     compressionLevel: 6,
   });
   return {
-    path: outputPath,
-    bytes,
+    path: published.path,
+    bytes: published.bytes,
     manifest: artifact.manifest,
   };
 }

--- a/test/scripts/bench-sqlite-reliability.test.ts
+++ b/test/scripts/bench-sqlite-reliability.test.ts
@@ -164,7 +164,7 @@ describe("scripts/bench-sqlite-reliability", () => {
       "synced-snapshots",
     );
     const previousArtifact = path.join(previousSyncedRepository, "previous-artifact");
-    fs.mkdirSync(previousSyncedRepository, { recursive: true });
+    fs.mkdirSync(previousSyncedRepository, { recursive: true, mode: 0o700 });
     fs.writeFileSync(previousArtifact, "retained");
 
     const existingDatabase = openOpenClawStateDatabase({


### PR DESCRIPTION
## What Problem This Solves

Fixes #122064.

`openclaw` diagnostics support export builds the complete ZIP in memory and writes it directly to the final output path. Replacing an existing named export truncates that file before the new bytes are safely published: a write failure or process termination mid-overwrite destroys the previously valid archive and can leave an empty/partial ZIP at the final path. Additionally, `writeFile`'s `mode: 0o600` only applies on file creation, so overwriting a pre-existing export preserved its old (potentially permissive) mode.

## Why This Change Was Made

The issue prescribes the repair shape: route publication through the existing staged external-file owner instead of adding ad-hoc staging. `writeSupportBundleZip` (`src/logging/diagnostic-support-bundle.ts`) now publishes via `writeExternalFileWithinRoot` (`src/infra/fs-safe.ts`), which writes the buffer to a private sibling staging file, fsyncs it, and atomically renames it over the final path:

- A failed or interrupted publication leaves the previous ZIP untouched; the staging file is cleaned up (verified in `@openclaw/fs-safe` `output-sibling.js`: identity-pinned staging, rename-before-publish, best-effort cleanup plus exit registration when the rename never happened).
- The atomic rename always installs the staged file's `0o600` mode, fixing the permissive-mode-on-overwrite case as a consequence.
- Arbitrary output paths keep working: the export resolves the output path first, and publication uses `rootDir: dirname, path: basename`, which is trivially in-root. The dependency's `root()` requires the parent to exist, so the pre-existing recursive `mkdir (0o700)` stays ahead of publication.
- The command now returns the actual published path (the dependency may adjust a non-portable basename), per the issue's contract.

Trajectory directory publication is out of scope per the issue.

## User Impact

Operators re-exporting a diagnostics ZIP to the same path no longer lose the prior archive when the write fails or the process dies; exports consistently land with owner-only permissions. No CLI surface changes.

## Evidence

- New boundary regressions in `src/logging/diagnostic-support-bundle.test.ts`:
  - overwriting an existing `0o644` export installs the new archive with `0o600` (rename replaces instead of truncating in place) — fails on pre-fix code;
  - the injected publisher writes partial bytes to the path it receives, then throws; the old direct writer corrupts the final ZIP while the staged writer preserves it byte-identical and cleans `.part` residue;
  - success leaves only the target file.
- Prior head: `node scripts/run-vitest.mjs src/logging/diagnostic-support-bundle.test.ts` — 5 passed, and `node scripts/run-vitest.mjs src/logging/diagnostic-support-export` — 12 passed.
- Maintainer follow-up `6c82d97c5cdc09d667f3506c8eae407d437e7503` strengthened the atomicity regression so it fails against the old direct-write path for the intended corruption reason.
- Testbox baseline repair `2ec2a76bd2e375fc20a59cdd27b359e011b84412` makes the reused snapshot fixture private under permissive runner umasks. Clean-main run https://github.com/openclaw/openclaw/actions/runs/31532901008 failed the focused case; after the one-line `0700` fixture fix, run https://github.com/openclaw/openclaw/actions/runs/31534199721 passed all 5 tests.
- `oxfmt --check` on the four touched files — clean.
- Mandatory Codex autoreview and TruffleHog are clean on the combined branch.
- Current exact-head CI is running and remains the final merge gate.

Production LOC: +20/-8 (net +12) | Tests: +54/-4 (net +50).


### Real-behavior proof (real filesystem, failure injection via `ulimit -f 4` = 4096-byte file cap)

Drove the real `writeDiagnosticSupportExport` against an isolated `OPENCLAW_STATE_DIR` (no mocks): seed a valid export, then re-export to the same path with writes dying mid-publication (`EFBIG` at 4096 bytes, ~92% through the 4460-byte archive).

Pre-fix (`fsp.writeFile` direct to final path), the previous archive is destroyed:

```
seeded: bytes=4460 sha256=0526dbc7c4af0ab5...
Error: EFBIG: file too large, write
    at async writeSupportBundleZip (src/logging/diagnostic-support-bundle.ts:141:3)
support.zip: mode=600 bytes=4096 sha256=9da60bbbd84e44b8... ZIP CORRUPT
```

Post-fix (this branch), the previous archive survives byte-identical and valid; the error propagates from the sibling staging write and no staging residue remains:

```
seeded: bytes=4460 sha256=87d895b578ab6a28...
Error: EFBIG: file too large, write
    at async writeExternalFileWithinRoot (src/infra/fs-safe.ts:119:18)
support.zip: mode=600 bytes=4460 sha256=87d895b578ab6a28... ZIP VALID
$ ls <stateDir>   # only support.zip — staging temp cleaned up
```

Also verified on the real filesystem (no failure injection): first export lands `mode=600`; `chmod 644` on the file then re-exporting to the same path restores `mode=600` with a valid ZIP (atomic replace, not in-place truncate).

