### PR TITLE
fix(matrix): preserve inbound events when sends start before monitoring

### DIFF
--- a/extensions/matrix/src/matrix/actions/client.ts
+++ b/extensions/matrix/src/matrix/actions/client.ts
@@ -1,5 +1,8 @@
 // Matrix plugin module implements client behavior.
-import { withResolvedRuntimeMatrixClient } from "../client-bootstrap.js";
+import {
+  type MatrixRuntimeClientTask,
+  withResolvedRuntimeMatrixClient,
+} from "../client-bootstrap.js";
 import { resolveMatrixRoomId } from "../send.js";
 import type { MatrixActionClient, MatrixActionClientOpts } from "./types.js";
 
@@ -7,7 +10,7 @@ type MatrixActionClientStopMode = "stop" | "persist" | "discard";
 
 export async function withResolvedActionClient<T>(
   opts: MatrixActionClientOpts,
-  run: (client: MatrixActionClient["client"], abortSignal?: AbortSignal) => Promise<T>,
+  run: MatrixRuntimeClientTask<T>,
   mode: MatrixActionClientStopMode = "stop",
 ): Promise<T> {
   return await withResolvedRuntimeMatrixClient(opts, run, mode);
@@ -15,7 +18,7 @@ export async function withResolvedActionClient<T>(
 
 export async function withStartedActionClient<T>(
   opts: MatrixActionClientOpts,
-  run: (client: MatrixActionClient["client"], abortSignal?: AbortSignal) => Promise<T>,
+  run: MatrixRuntimeClientTask<T>,
 ): Promise<T> {
   return await withResolvedActionClient({ ...opts, readiness: "started" }, run, "persist");
 }

--- a/extensions/matrix/src/matrix/actions/verification.test.ts
+++ b/extensions/matrix/src/matrix/actions/verification.test.ts
@@ -269,6 +269,36 @@ describe("matrix verification actions", () => {
     expect(withStartedActionClientMock).not.toHaveBeenCalled();
   });
 
+  it("starts authoritative verification status through the shared lease", async () => {
+    const leaseStart = vi.fn(async () => undefined);
+    const directStart = vi.fn(async () => undefined);
+    const prepareForOneOff = vi.fn(async () => undefined);
+    const getOwnDeviceVerificationStatus = vi.fn(async () => ({
+      ...mockVerifiedOwnerStatus(),
+      serverDeviceKnown: true,
+    }));
+    withResolvedActionClientMock.mockImplementation(async (_opts, run) => {
+      return await run(
+        {
+          crypto: { listVerifications: vi.fn(async () => []) },
+          getOwnDeviceVerificationStatus,
+          prepareForOneOff,
+          start: directStart,
+        },
+        undefined,
+        leaseStart,
+      );
+    });
+
+    const status = await getMatrixVerificationStatus({ readiness: "started" });
+
+    expect(status.verified).toBe(true);
+    expect(leaseStart).toHaveBeenCalledTimes(1);
+    expect(directStart).not.toHaveBeenCalled();
+    expect(prepareForOneOff).not.toHaveBeenCalled();
+    expect(getOwnDeviceVerificationStatus).toHaveBeenCalledTimes(2);
+  });
+
   it("fails closed before local Matrix prep when the current device is gone", async () => {
     const prepareForOneOff = vi.fn(async () => undefined);
     const getOwnDeviceVerificationStatus = vi.fn(async () => ({
@@ -354,13 +384,13 @@ describe("matrix verification actions", () => {
     expect(withStartedActionClientMock).not.toHaveBeenCalled();
   });
 
-  it("restores room-key backup without startup crypto auto-repair", async () => {
+  it("restores room-key backup through a started shared lease", async () => {
     const restoreRoomKeyBackup = vi.fn(async () => ({
       success: true,
       imported: 1,
       total: 1,
     }));
-    withResolvedActionClientMock.mockImplementation(async (_opts, run) => {
+    withStartedActionClientMock.mockImplementation(async (_opts, run) => {
       return await run({ restoreRoomKeyBackup });
     });
 
@@ -368,8 +398,8 @@ describe("matrix verification actions", () => {
 
     expect(restored.success).toBe(true);
     expect(restoreRoomKeyBackup).toHaveBeenCalledWith({ recoveryKey: "key" });
-    expect(withResolvedActionClientMock).toHaveBeenCalledTimes(1);
-    expect(withStartedActionClientMock).not.toHaveBeenCalled();
+    expect(withStartedActionClientMock).toHaveBeenCalledTimes(1);
+    expect(withResolvedActionClientMock).not.toHaveBeenCalled();
   });
 
   it("rehydrates DM verification requests before follow-up actions", async () => {

--- a/extensions/matrix/src/matrix/actions/verification.ts
+++ b/extensions/matrix/src/matrix/actions/verification.ts
@@ -495,13 +495,13 @@ export async function getMatrixVerificationStatus(
   const readiness = opts.readiness ?? "prepared";
   return await withResolvedActionClient(
     { ...opts, readiness: "none" },
-    async (client) => {
+    async (client, _abortSignal, start) => {
       const preflight = await readMatrixVerificationStatus(client, opts);
       if (readiness === "none" || preflight.serverDeviceKnown === false) {
         return preflight;
       }
       if (readiness === "started") {
-        await client.start();
+        await start();
       } else {
         await client.prepareForOneOff();
       }
@@ -552,7 +552,7 @@ export async function restoreMatrixRoomKeyBackup(
     recoveryKey?: string;
   } = {},
 ) {
-  return await withResolvedActionClient(
+  return await withStartedActionClient(
     opts,
     async (client) =>
       await client.restoreRoomKeyBackup({

--- a/extensions/matrix/src/matrix/client-bootstrap.test.ts
+++ b/extensions/matrix/src/matrix/client-bootstrap.test.ts
@@ -11,6 +11,7 @@ const {
   getMatrixRuntimeMock,
   acquireSharedMatrixClientMock,
   sharedLeaseReleaseMock,
+  sharedLeaseStartMock,
   isBunRuntimeMock,
   resolveMatrixAuthContextMock,
 } = matrixClientResolverMocks;
@@ -114,6 +115,20 @@ describe("client bootstrap", () => {
         expect(abortSignal).toBe(lease.abortSignal);
       },
     );
+  });
+
+  it("exposes deferred startup through the shared lease owner", async () => {
+    const sharedClient = createMockMatrixClient();
+    setAcquiredMatrixClient(sharedClient);
+    sharedLeaseStartMock.mockResolvedValue(undefined);
+
+    await withResolvedRuntimeMatrixClient(
+      { cfg: TEST_CFG, accountId: "default", readiness: "none" },
+      async (_client, _abortSignal, start) => await start(),
+    );
+
+    expect(sharedLeaseStartMock).toHaveBeenCalledTimes(1);
+    expect(sharedClient.start).not.toHaveBeenCalled();
   });
 
   it("does not borrow or stop an explicitly injected client", async () => {

--- a/extensions/matrix/src/matrix/client-bootstrap.test.ts
+++ b/extensions/matrix/src/matrix/client-bootstrap.test.ts
@@ -118,7 +118,8 @@ describe("client bootstrap", () => {
   });
 
   it("exposes deferred startup through the shared lease owner", async () => {
-    const sharedClient = createMockMatrixClient();
+    const clientStart = vi.fn(async () => undefined);
+    const sharedClient = Object.assign(createMockMatrixClient(), { start: clientStart });
     setAcquiredMatrixClient(sharedClient);
     sharedLeaseStartMock.mockResolvedValue(undefined);
 
@@ -128,7 +129,7 @@ describe("client bootstrap", () => {
     );
 
     expect(sharedLeaseStartMock).toHaveBeenCalledTimes(1);
-    expect(sharedClient.start).not.toHaveBeenCalled();
+    expect(clientStart).not.toHaveBeenCalled();
   });
 
   it("does not borrow or stop an explicitly injected client", async () => {

--- a/extensions/matrix/src/matrix/client-bootstrap.ts
+++ b/extensions/matrix/src/matrix/client-bootstrap.ts
@@ -13,6 +13,11 @@ type ResolvedRuntimeMatrixClient = {
 
 type MatrixRuntimeClientReadiness = "none" | "prepared" | "started";
 type ResolvedRuntimeMatrixClientStopMode = "stop" | "persist" | "discard";
+export type MatrixRuntimeClientTask<T> = (
+  client: MatrixClient,
+  abortSignal: AbortSignal | undefined,
+  start: () => Promise<void>,
+) => Promise<T>;
 
 const loadMatrixSharedClientRuntimeDeps = createLazyRuntimeModule(() =>
   import("./client.js").then((clientModule) => ({
@@ -107,13 +112,18 @@ export async function withResolvedRuntimeMatrixClient<T>(
     accountId?: string | null;
     readiness?: MatrixRuntimeClientReadiness;
   },
-  run: (client: MatrixClient, abortSignal?: AbortSignal) => Promise<T>,
+  run: MatrixRuntimeClientTask<T>,
   stopMode: ResolvedRuntimeMatrixClientStopMode = "stop",
 ): Promise<T> {
   const resolved = await resolveRuntimeMatrixClientWithReadiness(opts);
+  const lease = resolved.lease;
   try {
-    return await run(resolved.client, resolved.lease?.abortSignal);
+    return await run(
+      resolved.client,
+      lease?.abortSignal,
+      lease ? () => lease.start() : () => resolved.client.start(),
+    );
   } finally {
-    await resolved.lease?.release({ mode: stopMode });
+    await lease?.release({ mode: stopMode });
   }
 }

--- a/extensions/matrix/src/matrix/client/shared.real-sdk.test.ts
+++ b/extensions/matrix/src/matrix/client/shared.real-sdk.test.ts
@@ -117,7 +117,10 @@ describe("shared Matrix lifecycle with the real SDK", () => {
     let savedFilter: unknown = {};
     let burstSyncCount = 0;
 
-    const server = http.createServer(async (request, response) => {
+    const handleRequest = async (
+      request: http.IncomingMessage,
+      response: http.ServerResponse,
+    ): Promise<void> => {
       try {
         const method = request.method ?? "GET";
         const url = new URL(request.url ?? "/", "http://127.0.0.1");
@@ -185,29 +188,38 @@ describe("shared Matrix lifecycle with the real SDK", () => {
           response.destroy(error instanceof Error ? error : new Error(String(error)));
         }
       }
+    };
+    const server = http.createServer((request, response) => {
+      void handleRequest(request, response);
     });
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
     const address = server.address();
     if (!address || typeof address === "string") {
       throw new Error("Matrix test server did not bind a TCP port");
     }
     const homeserver = `http://127.0.0.1:${address.port}`;
-    let auth: Awaited<ReturnType<typeof resolveMatrixAuth>> | undefined;
+    const cleanupState: {
+      auth?: Awaited<ReturnType<typeof resolveMatrixAuth>>;
+      monitorTask?: Promise<unknown>;
+      outboundPromise?: Promise<unknown>;
+    } = {};
     let monitorLease: SharedMatrixClientLease | undefined;
-    let monitorTask: Promise<unknown> | undefined;
-    let outboundPromise: Promise<unknown> | undefined;
     cleanup = async () => {
       allowSend.resolve();
       for (const response of pendingSyncResponses) {
         response.destroy();
       }
-      const serverClosed = new Promise<void>((resolve) => server.close(() => resolve()));
+      const serverClosed = new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
       server.closeAllConnections();
       await monitorLease?.release({ mode: "persist" }).catch(() => undefined);
-      if (auth) {
-        await stopSharedClientForAccount(auth).catch(() => undefined);
+      if (cleanupState.auth) {
+        await stopSharedClientForAccount(cleanupState.auth).catch(() => undefined);
       }
-      await Promise.allSettled([outboundPromise, monitorTask]);
+      await Promise.allSettled([cleanupState.outboundPromise, cleanupState.monitorTask]);
       await serverClosed;
       resetPluginStateStoreForTests();
       fs.rmSync(stateDir, { recursive: true, force: true });
@@ -233,7 +245,8 @@ describe("shared Matrix lifecycle with the real SDK", () => {
         },
       } as unknown as PluginRuntime["channel"],
     });
-    auth = await resolveMatrixAuth({ cfg });
+    const auth = await resolveMatrixAuth({ cfg });
+    cleanupState.auth = auth;
     const storagePaths = resolveMatrixStoragePaths({
       homeserver: auth.homeserver,
       userId: auth.userId,
@@ -246,12 +259,13 @@ describe("shared Matrix lifecycle with the real SDK", () => {
     seedStore.markCleanShutdown();
     await seedStore.flush();
 
-    outboundPromise = matrixOutbound.sendText!({
+    const outboundPromise = matrixOutbound.sendText!({
       cfg,
       to: `room:${ROOM_ID}`,
       text: "outbound proof",
       accountId: "default",
     });
+    cleanupState.outboundPromise = outboundPromise;
     await Promise.race([
       sendRequested.promise,
       outboundPromise.then(() => {
@@ -306,9 +320,11 @@ describe("shared Matrix lifecycle with the real SDK", () => {
       lease.client.off("sync.state", onSyncState);
       return { disposeEvents, lease };
     });
-    monitorTask = monitorPromise;
+    cleanupState.monitorTask = monitorPromise;
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
     allowSend.resolve();
     const outbound = await outboundPromise;
     outboundCompleted = true;

--- a/extensions/matrix/src/matrix/client/shared.real-sdk.test.ts
+++ b/extensions/matrix/src/matrix/client/shared.real-sdk.test.ts
@@ -1,0 +1,337 @@
+// Matrix tests cover the shared lifecycle with the real SDK, HTTP, and SQLite store.
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, describe, expect, it } from "vitest";
+import { matrixOutbound } from "../../outbound.js";
+import type { PluginRuntime } from "../../runtime-api.js";
+import { installMatrixTestRuntime } from "../../test-runtime.js";
+import type { CoreConfig } from "../../types.js";
+import { registerMatrixMonitorEvents } from "../monitor/events.js";
+import { resolveMatrixAuth } from "./config.js";
+import { SqliteBackedMatrixSyncStore } from "./file-sync-store.js";
+import {
+  acquireSharedMatrixClient,
+  stopSharedClientForAccount,
+  type SharedMatrixClientLease,
+} from "./shared.js";
+import { resolveMatrixStoragePaths } from "./storage.js";
+
+const ROOM_ID = "!room:localhost";
+const BOT_USER_ID = "@bot:localhost";
+const REMOTE_USER_ID = "@alice:localhost";
+const OUTBOUND_EVENT_ID = "$outbound";
+const INBOUND_EVENT_IDS = Array.from({ length: 60 }, (_, index) => `$inbound-${index}`);
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+function respondJson(response: http.ServerResponse, status: number, body: unknown): void {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+}
+
+async function readRequestJson(request: http.IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  const text = Buffer.concat(chunks).toString("utf8");
+  return text ? JSON.parse(text) : undefined;
+}
+
+function buildSync(nextBatch: string, eventIds: string[]) {
+  const now = Date.now();
+  const member = (userId: string) => ({
+    event_id: `$member-${userId}`,
+    type: "m.room.member",
+    state_key: userId,
+    sender: userId,
+    origin_server_ts: now,
+    content: { membership: "join" },
+  });
+  return {
+    next_batch: nextBatch,
+    presence: { events: [] },
+    account_data: { events: [] },
+    to_device: { events: [] },
+    device_lists: { changed: [], left: [] },
+    device_one_time_keys_count: {},
+    rooms: {
+      invite: {},
+      leave: {},
+      knock: {},
+      join: {
+        [ROOM_ID]: {
+          summary: {
+            "m.heroes": [REMOTE_USER_ID],
+            "m.joined_member_count": 2,
+            "m.invited_member_count": 0,
+          },
+          state: { events: [member(BOT_USER_ID), member(REMOTE_USER_ID)] },
+          timeline: {
+            limited: false,
+            prev_batch: "p0",
+            events: eventIds.map((eventId, index) => ({
+              event_id: eventId,
+              type: "m.room.message",
+              sender: REMOTE_USER_ID,
+              origin_server_ts: now + index,
+              content: { msgtype: "m.text", body: `inbound before monitor ${index}` },
+            })),
+          },
+          ephemeral: { events: [] },
+          account_data: { events: [] },
+          unread_notifications: { highlight_count: 0, notification_count: 0 },
+        },
+      },
+    },
+  };
+}
+
+describe("shared Matrix lifecycle with the real SDK", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    await cleanup?.();
+    cleanup = undefined;
+  });
+
+  it("recovers a transient-first burst from the authoritative cursor after monitor admission", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-matrix-shared-real-"));
+    const sendRequested = createDeferred<void>();
+    const allowSend = createDeferred<void>();
+    const pendingSyncResponses = new Set<http.ServerResponse>();
+    const unexpectedRequests: string[] = [];
+    const syncSinceValues: Array<string | null> = [];
+    const sentBodies: unknown[] = [];
+    let savedFilter: unknown = {};
+    let burstSyncCount = 0;
+
+    const server = http.createServer(async (request, response) => {
+      try {
+        const method = request.method ?? "GET";
+        const url = new URL(request.url ?? "/", "http://127.0.0.1");
+        const requestLabel = `${method} ${url.pathname}`;
+        if (url.pathname === "/_matrix/client/versions") {
+          respondJson(response, 200, { versions: ["v1.11"], unstable_features: {} });
+          return;
+        }
+        if (url.pathname.endsWith("/pushrules/")) {
+          respondJson(response, 200, {
+            global: { override: [], content: [], room: [], sender: [], underride: [] },
+          });
+          return;
+        }
+        if (method === "POST" && url.pathname.endsWith("/filter")) {
+          savedFilter = await readRequestJson(request);
+          respondJson(response, 200, { filter_id: "0" });
+          return;
+        }
+        if (method === "GET" && url.pathname.endsWith("/filter/0")) {
+          respondJson(response, 200, savedFilter);
+          return;
+        }
+        if (url.pathname.endsWith("/capabilities")) {
+          respondJson(response, 200, { capabilities: {} });
+          return;
+        }
+        if (url.pathname.endsWith("/account_data/m.direct")) {
+          respondJson(response, 200, {});
+          return;
+        }
+        if (url.pathname.endsWith("/state/m.room.encryption/")) {
+          respondJson(response, 404, { errcode: "M_NOT_FOUND", error: "not encrypted" });
+          return;
+        }
+        if (method === "GET" && url.pathname.endsWith("/sync")) {
+          const since = url.searchParams.get("since");
+          syncSinceValues.push(since);
+          if (since === "s0") {
+            burstSyncCount += 1;
+            respondJson(
+              response,
+              200,
+              buildSync(burstSyncCount === 1 ? "s1" : "s2", INBOUND_EVENT_IDS),
+            );
+            return;
+          }
+          pendingSyncResponses.add(response);
+          response.once("close", () => pendingSyncResponses.delete(response));
+          return;
+        }
+        if (method === "PUT" && url.pathname.includes("/send/m.room.message/")) {
+          sentBodies.push(await readRequestJson(request));
+          sendRequested.resolve();
+          await allowSend.promise;
+          respondJson(response, 200, { event_id: OUTBOUND_EVENT_ID });
+          return;
+        }
+        unexpectedRequests.push(requestLabel);
+        respondJson(response, 404, { errcode: "M_UNRECOGNIZED", error: requestLabel });
+      } catch (error) {
+        if (!response.headersSent) {
+          respondJson(response, 500, { error: String(error) });
+        } else {
+          response.destroy(error instanceof Error ? error : new Error(String(error)));
+        }
+      }
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Matrix test server did not bind a TCP port");
+    }
+    const homeserver = `http://127.0.0.1:${address.port}`;
+    let auth: Awaited<ReturnType<typeof resolveMatrixAuth>> | undefined;
+    let monitorLease: SharedMatrixClientLease | undefined;
+    let monitorTask: Promise<unknown> | undefined;
+    let outboundPromise: Promise<unknown> | undefined;
+    cleanup = async () => {
+      allowSend.resolve();
+      for (const response of pendingSyncResponses) {
+        response.destroy();
+      }
+      const serverClosed = new Promise<void>((resolve) => server.close(() => resolve()));
+      server.closeAllConnections();
+      await monitorLease?.release({ mode: "persist" }).catch(() => undefined);
+      if (auth) {
+        await stopSharedClientForAccount(auth).catch(() => undefined);
+      }
+      await Promise.allSettled([outboundPromise, monitorTask]);
+      await serverClosed;
+      resetPluginStateStoreForTests();
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    };
+    const cfg = {
+      channels: {
+        matrix: {
+          homeserver,
+          userId: BOT_USER_ID,
+          accessToken: "test-access-token",
+          encryption: false,
+          network: { dangerouslyAllowPrivateNetwork: true },
+        },
+      },
+    } as CoreConfig;
+    installMatrixTestRuntime({
+      cfg,
+      stateDir,
+      channel: {
+        text: {
+          resolveMarkdownTableMode: () => "code",
+          resolveTextChunkLimit: () => 4_000,
+        },
+      } as unknown as PluginRuntime["channel"],
+    });
+    auth = await resolveMatrixAuth({ cfg });
+    const storagePaths = resolveMatrixStoragePaths({
+      homeserver: auth.homeserver,
+      userId: auth.userId,
+      accessToken: auth.accessToken,
+      deviceId: auth.deviceId,
+      accountId: auth.accountId,
+    });
+    const seedStore = new SqliteBackedMatrixSyncStore(storagePaths.rootDir);
+    await seedStore.setSyncData(buildSync("s0", []));
+    seedStore.markCleanShutdown();
+    await seedStore.flush();
+
+    outboundPromise = matrixOutbound.sendText!({
+      cfg,
+      to: `room:${ROOM_ID}`,
+      text: "outbound proof",
+      accountId: "default",
+    });
+    await Promise.race([
+      sendRequested.promise,
+      outboundPromise.then(() => {
+        throw new Error("Matrix outbound completed before its HTTP send was observed");
+      }),
+    ]);
+    const afterTransientSync = new SqliteBackedMatrixSyncStore(storagePaths.rootDir);
+    expect(afterTransientSync.hasSavedSyncFromCleanShutdown()).toBe(true);
+    expect(await afterTransientSync.getSavedSyncToken()).toBe("s0");
+
+    const receivedEventIds: string[] = [];
+    let acquiredBeforeOutboundCompleted = false;
+    let outboundCompleted = false;
+    const monitorPromise = acquireSharedMatrixClient({
+      auth,
+      role: "monitor",
+      startClient: false,
+    }).then(async (lease) => {
+      monitorLease = lease;
+      acquiredBeforeOutboundCompleted = !outboundCompleted;
+      const monitorNetworkSync = createDeferred<void>();
+      const onSyncState = (state: string) => {
+        if (state === "SYNCING") {
+          monitorNetworkSync.resolve();
+        }
+      };
+      lease.client.on("sync.state", onSyncState);
+      const disposeEvents = registerMatrixMonitorEvents({
+        cfg,
+        client: lease.client,
+        auth,
+        allowFrom: [],
+        dmEnabled: true,
+        dmPolicy: "open",
+        readStoreAllowFrom: async () => [],
+        logVerboseMessage: () => {},
+        warnedEncryptedRooms: new Set(),
+        warnedCryptoMissingRooms: new Set(),
+        logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+        formatNativeDependencyHint: () => "",
+        onRoomMessage: (_roomId, event) => {
+          if (event.type === "m.room.message") {
+            receivedEventIds.push(event.event_id);
+          }
+        },
+        runDetachedTask: async (_label, task) => await task(),
+      });
+      await lease.start();
+      if (!acquiredBeforeOutboundCompleted) {
+        await monitorNetworkSync.promise;
+      }
+      lease.client.off("sync.state", onSyncState);
+      return { disposeEvents, lease };
+    });
+    monitorTask = monitorPromise;
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    allowSend.resolve();
+    const outbound = await outboundPromise;
+    outboundCompleted = true;
+    const monitor = await monitorPromise;
+
+    expect(outbound).toMatchObject({
+      channel: "matrix",
+      messageId: OUTBOUND_EVENT_ID,
+      roomId: ROOM_ID,
+    });
+    expect(sentBodies).toEqual([
+      expect.objectContaining({ msgtype: "m.text", body: "outbound proof" }),
+    ]);
+    expect(receivedEventIds).toEqual(INBOUND_EVENT_IDS);
+    expect(acquiredBeforeOutboundCompleted).toBe(false);
+    expect(syncSinceValues.filter((since) => since === "s0")).toEqual(["s0", "s0"]);
+    expect(unexpectedRequests).toEqual([]);
+
+    monitor.disposeEvents();
+    await monitor.lease.release({ mode: "persist" });
+    monitorLease = undefined;
+    const reloadedStore = new SqliteBackedMatrixSyncStore(storagePaths.rootDir);
+    expect(reloadedStore.hasSavedSyncFromCleanShutdown()).toBe(true);
+    expect(await reloadedStore.getSavedSyncToken()).toBe("s2");
+  });
+});

--- a/extensions/matrix/src/matrix/client/shared.test.ts
+++ b/extensions/matrix/src/matrix/client/shared.test.ts
@@ -341,7 +341,9 @@ describe("shared Matrix client generations", () => {
       return lease;
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
     expect(monitor).toBeUndefined();
 
     await transient.release({ mode: "persist" });
@@ -428,7 +430,9 @@ describe("shared Matrix client generations", () => {
       },
     );
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
     expect(transient).toBeUndefined();
     expect(client.start).not.toHaveBeenCalled();
 

--- a/extensions/matrix/src/matrix/client/shared.test.ts
+++ b/extensions/matrix/src/matrix/client/shared.test.ts
@@ -38,6 +38,9 @@ function authFor(accountId: string): MatrixAuth {
 function createMockClient(name: string, callOrder: string[] = []) {
   return {
     name,
+    freezeSyncCursorPersistence: vi.fn(async () => {
+      callOrder.push("freeze-sync-persistence");
+    }),
     start: vi.fn(async (_params?: { abortSignal?: AbortSignal }) => {
       callOrder.push("start");
     }),
@@ -318,6 +321,129 @@ describe("shared Matrix client generations", () => {
     ]);
   });
 
+  it("does not admit a monitor to a generation already started by transient work", async () => {
+    const auth = authFor("main");
+    const transientClient = createMockClient("transient");
+    const monitorClient = createMockClient("monitor");
+    createMatrixClientMock
+      .mockResolvedValueOnce(transientClient)
+      .mockResolvedValueOnce(monitorClient);
+
+    const transient = await acquireSharedMatrixClient({ auth, role: "transient" });
+    expect(transientClient.freezeSyncCursorPersistence).toHaveBeenCalledTimes(1);
+    let monitor: Awaited<ReturnType<typeof acquireSharedMatrixClient>> | undefined;
+    const monitorPending = acquireSharedMatrixClient({
+      auth,
+      role: "monitor",
+      startClient: false,
+    }).then((lease) => {
+      monitor = lease;
+      return lease;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(monitor).toBeUndefined();
+
+    await transient.release({ mode: "persist" });
+    monitor = await monitorPending;
+    expect(monitor.client).toBe(monitorClient);
+    expect(transientClient.stopAndPersist).toHaveBeenCalledTimes(1);
+    await monitor.release({ mode: "persist" });
+  });
+
+  it("does not retire transient work for an already-aborted monitor acquisition", async () => {
+    const auth = authFor("main");
+    const client = createMockClient("main");
+    createMatrixClientMock.mockResolvedValue(client);
+    const transient = await acquireSharedMatrixClient({ auth, role: "transient" });
+    const abortController = new AbortController();
+    abortController.abort();
+
+    await expectMatrixStartupAbort(
+      acquireSharedMatrixClient({
+        auth,
+        role: "monitor",
+        startClient: false,
+        abortSignal: abortController.signal,
+      }),
+    );
+
+    expect(transient.abortSignal.aborted).toBe(false);
+    expect(client.quiesceSync).not.toHaveBeenCalled();
+    expect(createMatrixClientMock).toHaveBeenCalledTimes(1);
+    await transient.release({ mode: "persist" });
+  });
+
+  it("does not start a replacement when monitor acquisition aborts after handoff commits", async () => {
+    const auth = authFor("main");
+    const quiesce = createDeferred<void>();
+    const transientClient = createMockClient("transient");
+    transientClient.quiesceSync.mockReturnValue(quiesce.promise);
+    const replacementClient = createMockClient("replacement");
+    createMatrixClientMock
+      .mockResolvedValueOnce(transientClient)
+      .mockResolvedValueOnce(replacementClient);
+    const transient = await acquireSharedMatrixClient({ auth, role: "transient" });
+    const abortController = new AbortController();
+    const monitor = acquireSharedMatrixClient({
+      auth,
+      role: "monitor",
+      startClient: false,
+      abortSignal: abortController.signal,
+    });
+    await vi.waitFor(() => {
+      expect(transientClient.quiesceSync).toHaveBeenCalledTimes(1);
+    });
+
+    abortController.abort();
+    await expectMatrixStartupAbort(monitor);
+    expect(createMatrixClientMock).toHaveBeenCalledTimes(1);
+    expect(replacementClient.start).not.toHaveBeenCalled();
+
+    quiesce.resolve();
+    await transient.release({ mode: "persist" });
+    const replacement = await acquireSharedMatrixClient({
+      auth,
+      role: "monitor",
+      startClient: false,
+    });
+    expect(replacement.client).toBe(replacementClient);
+    await replacement.release({ mode: "persist" });
+  });
+
+  it("waits for monitor admission before a transient lease can start sync", async () => {
+    const auth = authFor("main");
+    const client = createMockClient("main");
+    createMatrixClientMock.mockResolvedValue(client);
+    const monitor = await acquireSharedMatrixClient({
+      auth,
+      role: "monitor",
+      startClient: false,
+    });
+    let transient: Awaited<ReturnType<typeof acquireSharedMatrixClient>> | undefined;
+    const transientPending = acquireSharedMatrixClient({ auth, role: "transient" }).then(
+      (lease) => {
+        transient = lease;
+        return lease;
+      },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(transient).toBeUndefined();
+    expect(client.start).not.toHaveBeenCalled();
+
+    monitor.registerMonitorRetirement(createMonitorRetirement([]));
+    await monitor.start();
+    transient = await transientPending;
+    expect(transient.client).toBe(client);
+    expect(client.start).toHaveBeenCalledTimes(1);
+    expect(client.freezeSyncCursorPersistence).not.toHaveBeenCalled();
+
+    await transient.release({ mode: "persist" });
+    await monitor.release({ mode: "persist" });
+    expect(client.stopAndPersist).toHaveBeenCalledTimes(1);
+  });
+
   it("signals cooperative transient work and persists after it drains", async () => {
     const callOrder: string[] = [];
     const client = createMockClient("main", callOrder);
@@ -458,6 +584,9 @@ describe("shared Matrix client generations", () => {
     const firstRetirement = createMonitorRetirement(callOrder);
     first.registerMonitorRetirement(firstRetirement);
     final.registerMonitorRetirement(createMonitorRetirement(callOrder));
+    await first.start();
+    await final.start();
+    callOrder.length = 0;
 
     const firstRelease = first.release({ mode: "persist" });
     expect(first.release({ mode: "discard" })).toBe(firstRelease);
@@ -493,6 +622,147 @@ describe("shared Matrix client generations", () => {
     expect(client.stopAndPersist).toHaveBeenCalledTimes(1);
   });
 
+  it("retires when the last admitted monitor leaves before an acquired sibling starts", async () => {
+    const firstClient = createMockClient("first");
+    const replacementClient = createMockClient("replacement");
+    createMatrixClientMock
+      .mockResolvedValueOnce(firstClient)
+      .mockResolvedValueOnce(replacementClient);
+    const auth = authFor("main");
+    const admitted = await acquireSharedMatrixClient({
+      auth,
+      role: "monitor",
+      startClient: false,
+    });
+    const waiting = await acquireSharedMatrixClient({
+      auth,
+      role: "monitor",
+      startClient: false,
+    });
+    const admittedRetirement = createMonitorRetirement([]);
+    const waitingRetirement = createMonitorRetirement([]);
+    admitted.registerMonitorRetirement(admittedRetirement);
+    waiting.registerMonitorRetirement(waitingRetirement);
+    await admitted.start();
+
+    const admittedRelease = admitted.release({ mode: "persist" });
+    expect(waiting.abortSignal.aborted).toBe(true);
+    await Promise.all([admittedRelease, waiting.release({ mode: "persist" })]);
+
+    for (const retirement of [admittedRetirement, waitingRetirement]) {
+      expect(retirement.detachListeners).toHaveBeenCalledTimes(1);
+      expect(retirement.cleanup).toHaveBeenCalledTimes(1);
+    }
+    expect(firstClient.quiesceSync).toHaveBeenCalledTimes(1);
+    expect(firstClient.stopAndPersist).toHaveBeenCalledTimes(1);
+
+    const replacement = await acquireSharedMatrixClient({
+      auth,
+      role: "monitor",
+      startClient: false,
+    });
+    expect(replacement.client).toBe(replacementClient);
+    await replacement.release({ mode: "persist" });
+  });
+
+  it("detaches a slow transient-first generation without stopping its operation", async () => {
+    vi.useFakeTimers();
+    const firstClient = createMockClient("transient");
+    const monitorClient = createMockClient("monitor");
+    createMatrixClientMock.mockResolvedValueOnce(firstClient).mockResolvedValueOnce(monitorClient);
+    const auth = authFor("main");
+    const transient = await acquireSharedMatrixClient({ auth, role: "transient" });
+    let monitor: Awaited<ReturnType<typeof acquireSharedMatrixClient>> | undefined;
+    const monitorPending = acquireSharedMatrixClient({
+      auth,
+      role: "monitor",
+      startClient: false,
+    }).then((lease) => {
+      monitor = lease;
+      return lease;
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(firstClient.quiesceSync).toHaveBeenCalledTimes(1);
+    expect(transient.abortSignal.aborted).toBe(true);
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(monitor).toBeUndefined();
+    expect(firstClient.stopWithoutPersist).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    monitor = await monitorPending;
+
+    expect(monitor.client).toBe(monitorClient);
+    expect(firstClient.stopWithoutPersist).not.toHaveBeenCalled();
+    expect(firstClient.stopAndPersist).not.toHaveBeenCalled();
+    await transient.release({ mode: "persist" });
+    expect(firstClient.stopAndPersist).toHaveBeenCalledWith({ persistSyncCursor: false });
+    expect(firstClient.stopWithoutPersist).not.toHaveBeenCalled();
+    await monitor.release({ mode: "persist" });
+  });
+
+  it("stops both detached work and the active monitor generation for an account", async () => {
+    vi.useFakeTimers();
+    const firstClient = createMockClient("transient");
+    const monitorClient = createMockClient("monitor");
+    createMatrixClientMock.mockResolvedValueOnce(firstClient).mockResolvedValueOnce(monitorClient);
+    const auth = authFor("main");
+    const transient = await acquireSharedMatrixClient({ auth, role: "transient" });
+    const monitorPending = acquireSharedMatrixClient({
+      auth,
+      role: "monitor",
+      startClient: false,
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(5_000);
+    const monitor = await monitorPending;
+    const retirement = createMonitorRetirement([]);
+    monitor.registerMonitorRetirement(retirement);
+
+    await stopSharedClientForAccount(auth);
+
+    expect(firstClient.stopAndPersist).toHaveBeenCalledWith({ persistSyncCursor: false });
+    expect(monitorClient.stopAndPersist).toHaveBeenCalledTimes(1);
+    expect(retirement.detachListeners).toHaveBeenCalledTimes(1);
+    await Promise.all([
+      transient.release({ mode: "persist" }),
+      monitor.release({ mode: "persist" }),
+    ]);
+  });
+
+  it("does not publish an in-flight replacement generation across account stop", async () => {
+    vi.useFakeTimers();
+    const transientClient = createMockClient("transient");
+    const laterClient = createMockClient("later");
+    createMatrixClientMock
+      .mockResolvedValueOnce(transientClient)
+      .mockResolvedValueOnce(laterClient);
+    const auth = authFor("main");
+    const transient = await acquireSharedMatrixClient({ auth, role: "transient" });
+    const monitor = acquireSharedMatrixClient({
+      auth,
+      role: "monitor",
+      startClient: false,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(transientClient.quiesceSync).toHaveBeenCalledTimes(1);
+
+    const accountStop = stopSharedClientForAccount(auth);
+    await expect(monitor).rejects.toThrow("Matrix shared client account is stopping");
+    await accountStop;
+    await transient.release({ mode: "persist" });
+    expect(createMatrixClientMock).toHaveBeenCalledTimes(1);
+
+    const later = await acquireSharedMatrixClient({
+      auth,
+      role: "monitor",
+      startClient: false,
+    });
+    expect(later.client).toBe(laterClient);
+    await later.release({ mode: "persist" });
+  });
+
   it("uses the same quiesce-before-persist path for a transient-only started generation", async () => {
     const callOrder: string[] = [];
     const client = createMockClient("main", callOrder);
@@ -504,7 +774,14 @@ describe("shared Matrix client generations", () => {
     });
     await transient.release({ mode: "persist" });
 
-    expect(callOrder).toEqual(["start", "quiesce", "drain-quiesce", "drain-final", "persist"]);
+    expect(callOrder).toEqual([
+      "freeze-sync-persistence",
+      "start",
+      "quiesce",
+      "drain-quiesce",
+      "drain-final",
+      "persist",
+    ]);
   });
 
   it("memoizes one release promise for duplicate release calls", async () => {
@@ -558,7 +835,7 @@ describe("shared Matrix client generations", () => {
     await replacement.release();
   });
 
-  it("poisons a timed-out generation, discards final state, and never reopens it automatically", async () => {
+  it("discards a poisoned generation and allows a fresh generation", async () => {
     const cause = new Error("Matrix classic sync did not reach STOPPED within 5000ms");
     const callOrder: string[] = [];
     const client = createMockClient("main", callOrder);
@@ -566,7 +843,8 @@ describe("shared Matrix client generations", () => {
       callOrder.push("quiesce");
       throw cause;
     });
-    createMatrixClientMock.mockResolvedValue(client);
+    const replacementClient = createMockClient("replacement");
+    createMatrixClientMock.mockResolvedValueOnce(client).mockResolvedValueOnce(replacementClient);
     const auth = authFor("main");
     const monitor = await acquireSharedMatrixClient({
       auth,
@@ -588,14 +866,13 @@ describe("shared Matrix client generations", () => {
     await vi.waitFor(() => {
       expect(callOrder).toContain("monitor-cleanup");
     });
-    await expect(acquireSharedMatrixClient({ auth })).rejects.toBe(cause);
-
     await expect(transient.release()).rejects.toBe(cause);
     expect(await releaseError).toBe(cause);
     expect(client.stopWithoutPersist).toHaveBeenCalledTimes(1);
     expect(client.stopAndPersist).not.toHaveBeenCalled();
-    await expect(acquireSharedMatrixClient({ auth })).rejects.toBe(cause);
-    expect(createMatrixClientMock).toHaveBeenCalledTimes(1);
+    const replacement = await acquireSharedMatrixClient({ auth, startClient: false });
+    expect(replacement.client).toBe(replacementClient);
+    await replacement.release({ mode: "discard" });
   });
 
   it("preserves an earlier stop requirement when the final lease requests discard", async () => {

--- a/extensions/matrix/src/matrix/client/shared.ts
+++ b/extensions/matrix/src/matrix/client/shared.ts
@@ -5,7 +5,7 @@ import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { CoreConfig } from "../../types.js";
 import type { MatrixClient } from "../sdk.js";
 import { LogService } from "../sdk/logger.js";
-import { awaitMatrixStartupWithAbort } from "../startup-abort.js";
+import { awaitMatrixStartupWithAbort, throwIfMatrixStartupAborted } from "../startup-abort.js";
 import { resolveMatrixAuth, resolveMatrixAuthContext } from "./config.js";
 import type { MatrixAuth } from "./types.js";
 
@@ -39,6 +39,7 @@ type SharedMatrixClientPhase = "open" | "quiescing" | "closing";
 
 type SharedMatrixClientLeaseState = {
   abortController: AbortController;
+  monitorAdmitted: boolean;
   monitorRetirement: MatrixMonitorRetirement | null;
   monitorRetirementPromise: Promise<void> | null;
   role: MatrixClientLeaseRole;
@@ -52,10 +53,13 @@ type SharedMatrixClientState = {
   started: boolean;
   cryptoReady: boolean;
   startPromise: Promise<void> | null;
+  monitorAdmission: { promise: Promise<void>; resolve: () => void };
+  monitorlessSyncClaim: Promise<void> | null;
   phase: SharedMatrixClientPhase;
   leases: Set<SharedMatrixClientLeaseState>;
   monitorRetirementPromises: Set<Promise<void>>;
   noLeases: { promise: Promise<void>; resolve: () => void };
+  replacementReady: { promise: Promise<void>; resolve: () => void };
   retirementPromise: Promise<void> | null;
   poisonError: Error | null;
   releaseMode: MatrixClientReleaseMode;
@@ -74,6 +78,8 @@ type SharedMatrixClientParams = {
 
 const sharedClientStates = new Map<string, SharedMatrixClientState>();
 const sharedClientPromises = new Map<string, Promise<SharedMatrixClientState>>();
+const retiringClientStates = new Set<SharedMatrixClientState>();
+const sharedClientStopPromises = new Map<string, Promise<void>>();
 
 function buildSharedClientKey(auth: MatrixAuth): string {
   // Serialize the tuple as a whole: Matrix URLs and credentials may contain `|`,
@@ -87,6 +93,12 @@ function buildSharedClientKey(auth: MatrixAuth): string {
     auth.dispatcherPolicy ?? null,
     auth.accountId,
   ]);
+}
+
+function assertSharedClientAccountOpen(key: string): void {
+  if (sharedClientStopPromises.has(key)) {
+    throw new Error("Matrix shared client account is stopping");
+  }
 }
 
 async function createSharedMatrixClient(params: {
@@ -115,21 +127,33 @@ async function createSharedMatrixClient(params: {
     started: false,
     cryptoReady: false,
     startPromise: null,
+    monitorAdmission: createDeferred<void>(),
+    monitorlessSyncClaim: null,
     phase: "open",
     leases: new Set(),
     monitorRetirementPromises: new Set(),
     noLeases: createDeferred<void>(),
+    replacementReady: createDeferred<void>(),
     retirementPromise: null,
     poisonError: null,
     releaseMode: "discard",
   };
 }
 
+function detachSharedClientState(state: SharedMatrixClientState): void {
+  if (sharedClientStates.get(state.key) === state) {
+    sharedClientStates.delete(state.key);
+  }
+  retiringClientStates.add(state);
+  state.replacementReady.resolve();
+}
+
 function deleteSharedClientState(state: SharedMatrixClientState): void {
   if (sharedClientStates.get(state.key) === state) {
     sharedClientStates.delete(state.key);
   }
-  sharedClientPromises.delete(state.key);
+  retiringClientStates.delete(state);
+  state.replacementReady.resolve();
 }
 
 async function ensureSharedClientStarted(
@@ -203,6 +227,7 @@ async function resolveOpenSharedMatrixClientState(
   const key = buildSharedClientKey(auth);
 
   while (true) {
+    assertSharedClientAccountOpen(key);
     const existing = sharedClientStates.get(key);
     if (existing?.poisonError) {
       throw existing.poisonError;
@@ -211,7 +236,7 @@ async function resolveOpenSharedMatrixClientState(
       return existing;
     }
     if (existing?.retirementPromise) {
-      await awaitMatrixStartupWithAbort(existing.retirementPromise, params.abortSignal);
+      await awaitMatrixStartupWithAbort(existing.replacementReady.promise, params.abortSignal);
       continue;
     }
 
@@ -229,6 +254,7 @@ async function resolveOpenSharedMatrixClientState(
     try {
       const created = await creationPromise;
       sharedClientStates.set(key, created);
+      assertSharedClientAccountOpen(key);
       return created;
     } finally {
       sharedClientPromises.delete(key);
@@ -292,11 +318,9 @@ function mergeReleaseMode(
   return "discard";
 }
 
-function abortTransientLeases(state: SharedMatrixClientState): void {
+function abortGenerationLeases(state: SharedMatrixClientState): void {
   for (const lease of state.leases) {
-    if (lease.role === "transient") {
-      lease.abortController.abort();
-    }
+    lease.abortController.abort();
   }
 }
 
@@ -341,6 +365,7 @@ async function waitForLeaseDrain(state: SharedMatrixClientState): Promise<void> 
 function beginGenerationRetirement(params: {
   state: SharedMatrixClientState;
   monitorLeases?: SharedMatrixClientLeaseState[];
+  detachOnTimeout?: boolean;
 }): Promise<void> {
   const { state } = params;
   if (state.retirementPromise) {
@@ -366,15 +391,26 @@ function beginGenerationRetirement(params: {
     try {
       await waitForLeaseDrain(state);
     } catch (error) {
-      state.poisonError ??= toRetirementError(error);
-      forceReleaseLeases(state);
+      if (params.detachOnTimeout) {
+        // Sync is already quiesced and its cursor frozen. Detach this generation
+        // so a monitor can start while legitimate slow work finishes naturally.
+        detachSharedClientState(state);
+        await state.noLeases.promise;
+      } else {
+        state.poisonError ??= toRetirementError(error);
+        forceReleaseLeases(state);
+      }
     }
 
     if (state.poisonError) {
       await state.client
         .drainPendingDecryptions("matrix poisoned client shutdown")
         .catch(() => undefined);
-      state.client.stopWithoutPersist();
+      try {
+        state.client.stopWithoutPersist();
+      } finally {
+        deleteSharedClientState(state);
+      }
       throw state.poisonError;
     }
 
@@ -390,18 +426,22 @@ function beginGenerationRetirement(params: {
       throw state.poisonError;
     }
     try {
+      const persist = () =>
+        retiringClientStates.has(state)
+          ? state.client.stopAndPersist({ persistSyncCursor: false })
+          : state.client.stopAndPersist();
       if (state.releaseMode === "persist") {
-        await state.client.stopAndPersist();
+        await persist();
       } else if (state.releaseMode === "discard") {
         state.client.stopWithoutPersist();
       } else {
-        await state.client.stopAndPersist().catch(() => state.client.stopWithoutPersist());
+        await persist().catch(() => state.client.stopWithoutPersist());
       }
     } finally {
       deleteSharedClientState(state);
     }
   });
-  abortTransientLeases(state);
+  abortGenerationLeases(state);
   return state.retirementPromise;
 }
 
@@ -411,6 +451,7 @@ function createSharedMatrixClientLease(
 ): SharedMatrixClientLease {
   const leaseState: SharedMatrixClientLeaseState = {
     abortController: new AbortController(),
+    monitorAdmitted: false,
     monitorRetirement: null,
     monitorRetirementPromise: null,
     role,
@@ -444,6 +485,25 @@ function createSharedMatrixClientLease(
       const startupSignal = abortSignal
         ? AbortSignal.any([abortSignal, leaseState.abortController.signal])
         : leaseState.abortController.signal;
+      throwIfMatrixStartupAborted(startupSignal);
+      const monitorAttached = [...state.leases].some((candidate) => candidate.role === "monitor");
+      if (role === "transient" && monitorAttached) {
+        await awaitMatrixStartupWithAbort(state.monitorAdmission.promise, startupSignal);
+      } else if (role === "transient") {
+        // Transient sync may initialize crypto, but only the monitor may advance the
+        // durable inbound cursor; otherwise a later monitor can silently skip events.
+        state.monitorlessSyncClaim ??= state.client.freezeSyncCursorPersistence();
+        await awaitMatrixStartupWithAbort(state.monitorlessSyncClaim, startupSignal);
+      }
+      throwIfMatrixStartupAborted(startupSignal);
+      if (state.phase !== "open") {
+        throw new Error("Matrix client generation is retiring");
+      }
+      if (role === "monitor") {
+        // Monitor listeners are attached before lease.start() opens sync admission.
+        leaseState.monitorAdmitted = true;
+        state.monitorAdmission.resolve();
+      }
       await ensureSharedClientStarted(state, startupSignal);
     },
     release: (releaseParams = {}) => {
@@ -456,20 +516,24 @@ function createSharedMatrixClientLease(
         state.noLeases.resolve();
       }
 
-      const finalMonitor =
-        role === "monitor" && !Array.from(state.leases).some((lease) => lease.role === "monitor");
-      if (role === "monitor" && !finalMonitor) {
+      const remainingMonitors = [...state.leases].filter((lease) => lease.role === "monitor");
+      const finalMonitor = role === "monitor" && remainingMonitors.length === 0;
+      const finalAdmittedMonitor =
+        role === "monitor" &&
+        leaseState.monitorAdmitted &&
+        !remainingMonitors.some((lease) => lease.monitorAdmitted);
+      if (role === "monitor" && !finalMonitor && !finalAdmittedMonitor) {
         leaseState.releasePromise = retireMonitorLease(state, leaseState);
         return leaseState.releasePromise;
       }
-      const shouldRetire = finalMonitor || state.leases.size === 0;
+      const shouldRetire = finalMonitor || finalAdmittedMonitor || state.leases.size === 0;
       if (!shouldRetire) {
         leaseState.releasePromise = Promise.resolve();
         return leaseState.releasePromise;
       }
       leaseState.releasePromise = beginGenerationRetirement({
         state,
-        monitorLeases: role === "monitor" ? [leaseState] : undefined,
+        monitorLeases: role === "monitor" ? [leaseState, ...remainingMonitors] : undefined,
       });
       return leaseState.releasePromise;
     },
@@ -479,8 +543,25 @@ function createSharedMatrixClientLease(
 export async function acquireSharedMatrixClient(
   params: SharedMatrixClientParams = {},
 ): Promise<SharedMatrixClientLease> {
-  const state = await resolveOpenSharedMatrixClientState(params);
-  const lease = createSharedMatrixClientLease(state, params.role ?? "transient");
+  const role = params.role ?? "transient";
+  let state: SharedMatrixClientState;
+  while (true) {
+    state = await resolveOpenSharedMatrixClientState(params);
+    assertSharedClientAccountOpen(state.key);
+    if (role === "monitor" && state.monitorlessSyncClaim) {
+      // Rotate a transient-first generation so the monitor resumes from the
+      // homeserver cursor that transient sync was forbidden to persist.
+      throwIfMatrixStartupAborted(params.abortSignal);
+      const retirement = beginGenerationRetirement({ state, detachOnTimeout: true });
+      void retirement.catch((error: unknown) => {
+        LogService.warn("MatrixClientLite", "Failed to retire transient-first generation:", error);
+      });
+      await awaitMatrixStartupWithAbort(state.replacementReady.promise, params.abortSignal);
+      continue;
+    }
+    break;
+  }
+  const lease = createSharedMatrixClientLease(state, role);
   if (params.startClient !== false) {
     try {
       await lease.start(params.abortSignal);
@@ -494,9 +575,10 @@ export async function acquireSharedMatrixClient(
 
 async function forceRetireState(state: SharedMatrixClientState): Promise<void> {
   state.releaseMode = mergeReleaseMode(state.releaseMode, "stop");
+  const monitorLeases = Array.from(state.leases).filter((lease) => lease.role === "monitor");
   const retirementPromise = beginGenerationRetirement({
     state,
-    monitorLeases: Array.from(state.leases).filter((lease) => lease.role === "monitor"),
+    monitorLeases,
   });
   forceReleaseLeases(state, retirementPromise);
   if (state.poisonError) {
@@ -515,9 +597,36 @@ async function forceRetireState(state: SharedMatrixClientState): Promise<void> {
 }
 
 export async function stopSharedClientForAccount(auth: MatrixAuth): Promise<void> {
-  const state = sharedClientStates.get(buildSharedClientKey(auth));
-  if (!state) {
+  const key = buildSharedClientKey(auth);
+  const pendingStop = sharedClientStopPromises.get(key);
+  if (pendingStop) {
+    await pendingStop;
     return;
   }
-  await forceRetireState(state);
+  const stopPromise = Promise.resolve().then(async () => {
+    while (true) {
+      await sharedClientPromises.get(key)?.catch(() => undefined);
+      const states = Array.from(retiringClientStates).filter((state) => state.key === key);
+      const active = sharedClientStates.get(key);
+      if (active) {
+        states.push(active);
+      }
+      if (states.length === 0) {
+        return;
+      }
+      const results = await Promise.allSettled(states.map((state) => forceRetireState(state)));
+      const failure = results.find((result) => result.status === "rejected");
+      if (failure?.status === "rejected") {
+        throw failure.reason;
+      }
+    }
+  });
+  sharedClientStopPromises.set(key, stopPromise);
+  try {
+    await stopPromise;
+  } finally {
+    if (sharedClientStopPromises.get(key) === stopPromise) {
+      sharedClientStopPromises.delete(key);
+    }
+  }
 }

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -1389,6 +1389,39 @@ describe("MatrixClient request hardening", () => {
     }
   });
 
+  it("persists crypto without rewriting a detached generation's sync cursor", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-matrix-sdk-store-"));
+    clearMatrixSyncApiForNeverStartedClient();
+
+    try {
+      const client = new MatrixClient("https://matrix.example.org", "token", {
+        storageRootDir: tempDir,
+      });
+      const store = lastCreateClientOpts?.store as
+        | {
+            discardPendingSyncCursorPersistence: () => void;
+            flush: () => Promise<void>;
+            markCleanShutdown: () => void;
+          }
+        | undefined;
+      if (!store) {
+        throw new Error("expected Matrix sync store");
+      }
+      const discardSpy = vi.spyOn(store, "discardPendingSyncCursorPersistence");
+      const flushSpy = vi.spyOn(store, "flush");
+      const markCleanSpy = vi.spyOn(store, "markCleanShutdown");
+
+      await client.stopAndPersist({ persistSyncCursor: false });
+
+      expect(discardSpy).toHaveBeenCalledTimes(1);
+      expect(markCleanSpy).not.toHaveBeenCalled();
+      expect(flushSpy).not.toHaveBeenCalled();
+      expect(matrixJsClient.stopClient).toHaveBeenCalledTimes(1);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("persists crypto before marking and flushing the clean sync cursor", async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-matrix-sdk-store-"));
     clearMatrixSyncApiForNeverStartedClient();

--- a/extensions/matrix/src/matrix/sdk/client-base.ts
+++ b/extensions/matrix/src/matrix/sdk/client-base.ts
@@ -535,6 +535,10 @@ export abstract class MatrixClientBase {
     return this.syncStore?.hasSavedSyncFromCleanShutdown() === true;
   }
 
+  async freezeSyncCursorPersistence(): Promise<void> {
+    await this.syncStore?.freezeSyncCursorPersistence();
+  }
+
   protected async ensureStartedForCryptoControlPlane(): Promise<void> {
     if (this.started) {
       return;
@@ -579,7 +583,7 @@ export abstract class MatrixClientBase {
       .catch(noop);
   }
 
-  async stopAndPersist(): Promise<void> {
+  async stopAndPersist(options: { persistSyncCursor?: boolean } = {}): Promise<void> {
     if (this.stopPersistPromise) {
       await this.stopPersistPromise;
       return;
@@ -594,8 +598,12 @@ export abstract class MatrixClientBase {
         databasePrefix: this.cryptoDatabasePrefix,
         strict: true,
       });
-      this.syncStore?.markCleanShutdown();
-      await this.syncStore?.flush();
+      if (options.persistSyncCursor === false) {
+        this.syncStore?.discardPendingSyncCursorPersistence();
+      } else {
+        this.syncStore?.markCleanShutdown();
+        await this.syncStore?.flush();
+      }
     })();
     await this.stopPersistPromise;
   }


### PR DESCRIPTION
Closes #120275

AI-assisted: Yes — Codex. I reviewed and understand the change.

## What Problem This Solves

Fixes an issue where Matrix operators could silently miss inbound room messages or invites when a one-off outbound send started the shared Matrix client before monitoring registered its listeners.

## Why This Change Was Made

The shared Matrix lifecycle now keeps the inbound sync cursor under monitor ownership. If transient work starts synchronization first, it may initialize crypto and complete its outbound operation, but it cannot advance the durable inbound cursor; monitoring rotates to a fresh generation and resumes from the homeserver's authoritative cursor. Slow outbound work is allowed to finish naturally, while account shutdown still drains both active and retiring generations.

Deferred action startup also routes through the shared lease, so one-off CLI and verification paths follow the same lifecycle contract. Explicitly injected clients retain their direct startup behavior. This adds no config, environment variable, storage schema, migration, or retry path.

## User Impact

Matrix users should no longer lose messages or invites silently when outbound work wins the startup race. One-off outbound and CLI sends continue to work, and operators do not need to change configuration.

## Evidence

- **Before, exact base `5c308e0ebacfa92a9992d77f342facd0bbcef90e`:** the focused lifecycle regression reused the transient-started generation for the monitor. In the local real-SDK probe, inbound sync completed before monitor admission, the outbound HTTP `PUT` succeeded as `$outbound`, and the monitor observed no inbound event.
- **After, exact head `f3c00613f95db87ecdc856673487a053a82ca7ed`:** nine focused Matrix files passed, **281 tests total**, covering shared lifecycle, SQLite sync storage, monitor/outbound callers, action startup, and SDK shutdown/persistence.
- **Real behavior:** a macOS local integration used the actual `matrix-js-sdk@41.9.0`, real TCP HTTP Matrix `/sync` and send requests, and the plugin SQLite store. Starting from clean cursor `s0`, transient sync consumed a 60-event burst (greater than the SDK cache's 50-event cap) and completed the outbound `PUT` while SQLite remained at `s0`; the monitor replacement then requested `since=s0`, received all 60 events in order, and cleanly persisted `s2`. This is a local real-SDK integration, not a public Matrix homeserver run.
- **Race and cleanup coverage:** tests cover a send lasting beyond the five-second handoff bound, active plus retiring account shutdown, stop racing replacement creation, two admitted monitors, an acquired-but-unstarted sibling monitor, pre-aborted and mid-handoff acquisition, direct action startup, and crypto persistence without stale cursor persistence.
- **Review:** frozen-head autoreview and an independent read-only owner/dependency review both returned clean, with no actionable findings. A fresh autoreview of the later test-only lint cleanup also returned clean.
- **Checks:** target formatting, `git diff --check`, focused lint, type-aware lint, and the nine-file Matrix suite passed. The path-scoped changed-check fallback passed its local conflict, ratchet, dependency, format, and doctor-contract lanes. Its final global Plugin SDK manifest check reported an unrelated 982-line agent-harness closure-hash drift that was independently reproduced on the clean base; the remote Testbox backend was unavailable, so exact-head GitHub CI remains the Linux remote gate. The normal local extension-lint preparation is also blocked by unrelated borrowed-dependency Plugin SDK declaration drift; the same wrapper's focused and type-aware lint paths both passed for every touched test file.
- **CI boundary:** exact-head `checks-node-changed-4` failed an existing Matrix progress-text assertion in `monitor/handler.test.ts` (`Working / Exec` did not contain `install dependencies`). The identical focused assertion failed in a clean archived `upstream/main` snapshot at `6e9e56924326323b4649cffcfac99afa17cbf295`; the PR's current base `1383144b027a6b10c746636687182064d24b3bf9` has no Matrix changes from that snapshot, and this PR changes neither the handler test/implementation nor its relevant import closure. This is a reproduced baseline failure, not a lifecycle-patch regression.
- **LOC:** production `+166/-36` (lifecycle admission, retiring-generation ownership, monitor ownership, account-stop serialization, and deferred lease startup); tests `+724/-11`.
