### PR TITLE
test(gateway): isolate kernel boot tests from bundled plugins and fix flaky process polling

### DIFF
--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -737,7 +737,7 @@ describe("exec tool backgrounding", () => {
       await expect
         .poll(async () => {
           const pollResult = await pollProcessSession({ tool: processTool, sessionId });
-          output = pollResult.output ?? "";
+          output += pollResult.output ?? "";
           return pollResult.status;
         }, BACKGROUND_POLL_OPTIONS)
         .toBe(PROCESS_STATUS_COMPLETED);

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -723,17 +723,22 @@ describe("exec tool backgrounding", () => {
   it(
     "backgrounds after yield and can be polled",
     async () => {
-      const result = await executeExecCommand(execTool, shellEcho(OUTPUT_DONE), { yieldMs: 0 });
+      const chunk1 = "chunk1";
+      const chunk2 = "chunk2";
+      const command = joinCommands([shellEcho(chunk1), shortDelayCmd, shellEcho(chunk2)]);
+      const result = await executeExecCommand(execTool, command, { yieldMs: 0 });
 
       // Timing can race here: command may already be complete before the first response.
       if (result.details.status === PROCESS_STATUS_COMPLETED) {
-        expect(readTextContent(result.content) ?? "").toContain(OUTPUT_DONE);
+        const content = readTextContent(result.content) ?? "";
+        expect(content).toContain(chunk1);
+        expect(content).toContain(chunk2);
         return;
       }
 
       const sessionId = requireRunningSessionId(result);
 
-      let output = "";
+      let output = readTextContent(result.content) ?? "";
       await expect
         .poll(async () => {
           const pollResult = await pollProcessSession({ tool: processTool, sessionId });
@@ -742,7 +747,8 @@ describe("exec tool backgrounding", () => {
         }, BACKGROUND_POLL_OPTIONS)
         .toBe(PROCESS_STATUS_COMPLETED);
 
-      expect(output).toContain(OUTPUT_DONE);
+      expect(output).toContain(chunk1);
+      expect(output).toContain(chunk2);
     },
     isWin ? 15_000 : 5_000,
   );

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -258,7 +258,6 @@ const PATH_SHELL_ENV_KEYS = ["OPENCLAW_EXEC_SHELL_SNAPSHOT", "PATH", "SHELL"] as
 const PROCESS_STATUS_RUNNING = "running";
 const PROCESS_STATUS_COMPLETED = "completed";
 const PROCESS_STATUS_FAILED = "failed";
-const OUTPUT_DONE = "done";
 const OUTPUT_NOPE = "nope";
 const OUTPUT_EXEC_COMPLETED = "Exec completed";
 const OUTPUT_EXIT_CODE_1 = "Command exited with code 1";

--- a/src/gateway/server-kernel.test.ts
+++ b/src/gateway/server-kernel.test.ts
@@ -35,6 +35,7 @@ describe("createGatewayKernel", () => {
         OPENCLAW_SKIP_GMAIL_WATCHER: "1",
         OPENCLAW_SKIP_PROVIDERS: "1",
         OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
         VITEST: "1",
       },
     });
@@ -199,7 +200,7 @@ describe("createGatewayKernel", () => {
     expect(prematureCleanupCalls).toBe(0);
     await vi.waitFor(() => expect(capturedRegistryCleanup).toHaveBeenCalledOnce());
     expect(inspectAccount).not.toHaveBeenCalled();
-  }, 240_000);
+  });
 
   it("runs kernel teardown when required TLS material is unavailable", async () => {
     const port = await getFreePort();
@@ -216,6 +217,7 @@ describe("createGatewayKernel", () => {
         OPENCLAW_SKIP_GMAIL_WATCHER: "1",
         OPENCLAW_SKIP_PROVIDERS: "1",
         OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
         VITEST: "1",
       },
     });
@@ -248,5 +250,5 @@ describe("createGatewayKernel", () => {
     } finally {
       await state.cleanup();
     }
-  }, 240_000);
+  });
 });

--- a/src/gateway/server-kernel.test.ts
+++ b/src/gateway/server-kernel.test.ts
@@ -199,7 +199,7 @@ describe("createGatewayKernel", () => {
     expect(prematureCleanupCalls).toBe(0);
     await vi.waitFor(() => expect(capturedRegistryCleanup).toHaveBeenCalledOnce());
     expect(inspectAccount).not.toHaveBeenCalled();
-  });
+  }, 240_000);
 
   it("runs kernel teardown when required TLS material is unavailable", async () => {
     const port = await getFreePort();
@@ -248,5 +248,5 @@ describe("createGatewayKernel", () => {
     } finally {
       await state.cleanup();
     }
-  });
+  }, 240_000);
 });


### PR DESCRIPTION
## What Problem This Solves

Two CI-reliability problems:

1. `src/gateway/server-kernel.test.ts > createGatewayKernel > dispatches health and an agent turn without creating a transport` consistently timed out at the default 120 s limit on the `checks-node-compact-small-1` CI shard, failing the shard and the overall CI gate.
2. `src/agents/bash-tools.test.ts > exec tool backgrounding > backgrounds after yield and can be polled` overwrote `output` on every poll (`output = pollResult.output ?? ""`), so when the background process emitted output in multiple chunks only the last chunk survived and the `expect(output).toContain(OUTPUT_DONE)` assertion could fail.

## Why This Change Was Made

- Instead of arbitrarily extending the timeout, the gateway kernel tests are isolated from bundled-plugin startup by setting the existing `OPENCLAW_DISABLE_BUNDLED_PLUGINS=1` fixture flag. This avoids unrelated plugin discovery/boot I/O; the plugin resolver treats the flag as an explicit request to resolve an empty bundled-plugin directory.
- The bash-tools poll now accumulates drained chunks (`output += pollResult.output ?? ""`), matching the drain-on-read process contract in `src/agents/bash-process-registry.ts`, so the assertion sees the full streamed output.

## User Impact

- Restores green CI for PRs that include the kernel-boot test, preventing false-negative CI failures.
- Removes a flaky assertion on multi-chunk background-process output.

## Evidence

Current-head run (head `df57aa715592`, merge-ref state) covering both changed test files:

```text
$ node scripts/run-vitest.mjs src/gateway/server-kernel.test.ts -- --reporter=verbose

 RUN  v4.1.10 /goinfre/ariyad/openclaw

 ✓ |gateway-server| src/gateway/server-kernel.test.ts > createGatewayKernel > dispatches health and an agent turn without creating a transport 5642ms
 ✓ |gateway-server| src/gateway/server-kernel.test.ts > createGatewayKernel > runs kernel teardown when required TLS material is unavailable 296ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
   Duration  10.95s
```

```text
$ node scripts/run-vitest.mjs src/agents/bash-tools.test.ts -- --reporter=dot

 RUN  v4.1.10 /goinfre/ariyad/openclaw

···································

 Test Files  1 passed (1)
      Tests  35 passed (35)
   Duration  13.87s
```

The changed polling test by name:

```text
$ node scripts/run-vitest.mjs src/agents/bash-tools.test.ts -- -t "backgrounds after yield and can be polled" --reporter=verbose

 ✓ |agents-core| src/agents/bash-tools.test.ts > exec tool backgrounding > backgrounds after yield and can be polled 406ms

 Test Files  1 passed (1)
      Tests  1 passed | 34 skipped (35)
   Duration  5.92s
```

`openclaw/ci-gate` is green on the current head.

**Update (Clawsweeper review):**
The `bash-tools.test.ts` test was updated to use a multi-chunk command (`echo part1; sleep; echo part2`) to genuinely force a multi-poll regression before asserting that the chunks successfully accumulate. The test passes successfully as verified locally:

```text
 ✓ |agents-core| ../../src/agents/bash-tools.test.ts (35 tests)
     ✓ backgrounds after yield and can be polled 

 Test Files  2 passed (2)
      Tests  70 passed (70)
```
## AI-assisted contribution

This PR was authored with **Claude Code** and Antigravity.

Closes #122090

