### PR TITLE
feat(onboard): label CLI candidates with subscription vs API-key auth

### DIFF
--- a/src/commands/onboard-inference.test.ts
+++ b/src/commands/onboard-inference.test.ts
@@ -131,8 +131,48 @@ describe("detectInferenceBackends", () => {
       "anthropic-api-key",
       "claude-cli",
     ]);
-    expect(candidates[1]).toMatchObject({ credentials: true, detail: "logged in" });
+    expect(candidates[1]).toMatchObject({
+      credentials: true,
+      detail: "logged in · API key (usage-billed)",
+    });
   });
+
+  it("labels a Claude CLI environment key as usage-billed", async () => {
+    const candidates = await detectInferenceBackends({
+      env: { ANTHROPIC_API_KEY: "sk-y" },
+      platform: "linux",
+      deps: {
+        probeLocalCommand: probeDeps({ claude: true }),
+        readClaudeCliCredentials: () => null,
+      },
+    });
+
+    expect(candidates.find((candidate) => candidate.kind === "claude-cli")?.detail).toBe(
+      "logged in · API key (usage-billed)",
+    );
+  });
+
+  it.each(["oauth", "token"])(
+    "labels parsed Claude CLI %s credentials as a subscription",
+    async (type) => {
+      const candidates = await detectInferenceBackends({
+        env: {},
+        platform: "linux",
+        deps: {
+          probeLocalCommand: probeDeps({ claude: true }),
+          readClaudeCliCredentials: () => ({ type }),
+        },
+      });
+
+      expect(candidates).toMatchObject([
+        {
+          kind: "claude-cli",
+          credentials: true,
+          detail: "logged in · Claude subscription",
+        },
+      ]);
+    },
+  );
 
   it("keeps an Anthropic environment key ahead of unknown Claude credentials", async () => {
     const candidates = await detectInferenceBackends({
@@ -176,7 +216,7 @@ describe("detectInferenceBackends", () => {
         kind: "claude-cli",
         credentials: true,
         detail:
-          "logged in; Claude Code 2.1.206 is the first published build known to advertise msg_lifecycle_v1; found 2.1.205. OpenClaw verifies this capability at runtime. If this build is rejected, run `claude update`, restart OpenClaw, and retry.",
+          "logged in · Claude subscription; Claude Code 2.1.206 is the first published build known to advertise msg_lifecycle_v1; found 2.1.205. OpenClaw verifies this capability at runtime. If this build is rejected, run `claude update`, restart OpenClaw, and retry.",
       },
     ]);
   });
@@ -320,11 +360,19 @@ describe("detectInferenceBackends", () => {
     ).toBeUndefined();
   });
 
-  it("recognizes Codex login status across native credential stores", async () => {
+  it.each([
+    ["ChatGPT", "Logged in using ChatGPT", "logged in · ChatGPT subscription"],
+    [
+      "API key",
+      "Logged in using an API key - sk-proj-1***23456",
+      "logged in · API key (usage-billed)",
+    ],
+    ["unrecognized auth", "Logged in using access token", "logged in"],
+  ])("classifies Codex %s login status", async (_auth, loginOutput, expectedDetail) => {
     const probe = async (command: string, args: string[] = ["--version"]) => ({
       command,
       found: command === "codex",
-      ...(args[0] === "login" ? {} : { version: "codex 1.0" }),
+      version: args[0] === "login" ? loginOutput : "codex 1.0",
     });
     const candidates = await detectInferenceBackends({
       env: {},
@@ -335,7 +383,7 @@ describe("detectInferenceBackends", () => {
     });
 
     expect(candidates).toMatchObject([
-      { kind: "codex-cli", credentials: true, detail: "logged in" },
+      { kind: "codex-cli", credentials: true, detail: expectedDetail },
     ]);
   });
 

--- a/src/commands/onboard-inference.ts
+++ b/src/commands/onboard-inference.ts
@@ -83,14 +83,39 @@ function detectCliCredentialState(params: {
   return params.platform === "darwin" ? undefined : false;
 }
 
-function describeCliDetail(credentials: boolean | undefined, loginHint: string): string {
-  if (credentials === true) {
+type CliAuthKind = "api-key" | "chatgpt-subscription" | "claude-subscription";
+type CliLoginState = { credentials: boolean | undefined; authKind?: CliAuthKind };
+
+const CLI_AUTH_KIND_LABEL: Record<CliAuthKind, string> = {
+  "api-key": "API key (usage-billed)",
+  "chatgpt-subscription": "ChatGPT subscription",
+  "claude-subscription": "Claude subscription",
+};
+
+function describeCliDetail(state: CliLoginState, loginHint: string): string {
+  if (state.authKind) {
+    return `logged in · ${CLI_AUTH_KIND_LABEL[state.authKind]}`;
+  }
+  if (state.credentials === true) {
     return "logged in";
   }
-  if (credentials === false) {
+  if (state.credentials === false) {
     return `installed, not logged in — ${loginHint}, then check again`;
   }
   return "installed";
+}
+
+function classifyClaudeCliAuth(
+  credential: { type: string } | null,
+  env: NodeJS.ProcessEnv,
+): CliAuthKind | undefined {
+  if (env.ANTHROPIC_API_KEY?.trim() || credential?.type === "api_key_helper") {
+    return "api-key";
+  }
+  if (credential?.type === "oauth" || credential?.type === "token") {
+    return "claude-subscription";
+  }
+  return undefined;
 }
 
 function describeGeminiCliDetail(credentials: boolean | undefined): string {
@@ -99,17 +124,34 @@ function describeGeminiCliDetail(credentials: boolean | undefined): string {
     : "installed; login status unavailable";
 }
 
+async function classifyCodexLoginStatus(
+  probe: typeof probeLocalCommand,
+  command: string,
+): Promise<CliLoginState> {
+  const status = await probe(command, ["login", "status"], { timeoutMs: 3_000 });
+  if (status.error) {
+    // Codex login status covers its own auth store, not custom model-provider
+    // credentials. Keep failures indeterminate so the live probe decides usability.
+    return { credentials: undefined };
+  }
+  if (status.version === "Logged in using ChatGPT") {
+    return { credentials: true, authKind: "chatgpt-subscription" };
+  }
+  if (/^Logged in using an API key - .+$/u.test(status.version ?? "")) {
+    return { credentials: true, authKind: "api-key" };
+  }
+  return { credentials: true };
+}
+
+// Deliberately boolean-shaped: this signature is reachable from the exported
+// detectInferenceBackends options type and therefore part of the plugin-sdk
+// agent-harness API contract. Widening it would bump the contract hash — the
+// rich classification stays module-local in classifyCodexLoginStatus.
 async function detectCodexLoginState(
   probe: typeof probeLocalCommand,
   command: string,
 ): Promise<boolean | undefined> {
-  const status = await probe(command, ["login", "status"], { timeoutMs: 3_000 });
-  if (!status.error) {
-    return true;
-  }
-  // Codex login status covers its own auth store, not custom model-provider
-  // credentials. Keep failures indeterminate so the live probe decides usability.
-  return undefined;
+  return (await classifyCodexLoginStatus(probe, command)).credentials;
 }
 
 function randomizeClaudeCodexTie(
@@ -241,7 +283,10 @@ export async function detectInferenceBackends(
     if (credentials === true && claudeCredential?.type === "oauth") {
       subscriptionPromotionEligibleCliKinds.add("claude-cli");
     }
-    const detail = describeCliDetail(credentials, "run `claude auth login`");
+    const detail = describeCliDetail(
+      { credentials, authKind: classifyClaudeCliAuth(claudeCredential, env) },
+      "run `claude auth login`",
+    );
     // Only the live init record can prove capability support. Keep backports and
     // wrappers selectable here even when their version predates the known release.
     cliCandidates.push({
@@ -261,15 +306,21 @@ export async function detectInferenceBackends(
   }
   if (codexProbe.found && !codexProbe.timedOut) {
     const codexCredential = readCodex();
-    const credentials = options.deps?.detectCodexLoginState
-      ? await options.deps.detectCodexLoginState(probe, codexProbe.command)
+    const loginState: CliLoginState = options.deps?.detectCodexLoginState
+      ? { credentials: await options.deps.detectCodexLoginState(probe, codexProbe.command) }
       : options.deps?.readCodexCliCredentials
-        ? detectCliCredentialState({
-            probe: codexProbe,
-            hasStoredCredentials: codexCredential !== null,
-            platform,
-          })
-        : await detectCodexLoginState(probe, codexProbe.command);
+        ? {
+            credentials: detectCliCredentialState({
+              probe: codexProbe,
+              hasStoredCredentials: codexCredential !== null,
+              platform,
+            }),
+            ...(codexCredential?.type === "oauth"
+              ? { authKind: "chatgpt-subscription" as const }
+              : {}),
+          }
+        : await classifyCodexLoginStatus(probe, codexProbe.command);
+    const credentials = loginState.credentials;
     // Promote only prompt-free ChatGPT OAuth tokens. Status-only logins may be metered;
     // keychain-only ChatGPT users conservatively stay usable in the fallback tier.
     if (credentials === true && codexCredential?.type === "oauth") {
@@ -279,7 +330,7 @@ export async function detectInferenceBackends(
       kind: "codex-cli",
       modelRef: CODEX_APP_SERVER_DEFAULT_MODEL_REF,
       label: "Codex",
-      detail: describeCliDetail(credentials, "run `codex login`"),
+      detail: describeCliDetail(loginState, "run `codex login`"),
       ...(credentials === undefined ? {} : { credentials }),
     });
   }


### PR DESCRIPTION
## What Problem This Solves

Onboarding's pitch is "reuses what you already have — nothing new to sign up for." But a detected Codex or Claude Code CLI candidate can be backed by a flat-rate subscription login (ChatGPT Plus/Pro, Claude Pro/Max) or by a metered API key — and OpenClaw is an always-on workload (heartbeats, cron, channels) where a metered key compounds silently. The candidate row just said "logged in", hiding a real billing difference at the exact moment the user picks their inference route.

## Why This Change Was Made

Record the fact where it is detected and show it. The candidate `detail` string now carries the auth kind:

- `logged in · ChatGPT subscription`
- `logged in · Claude subscription`
- `logged in · API key (usage-billed)`
- unknown auth kind stays plain `logged in`; indeterminate login state stays `installed`. Honest unknowns are never guessed.

Codex classification parses `codex login status` output exactly per the Codex source (openai/codex @ 3b67b03a3f6): `codex-rs/cli/src/main.rs:1394-1407` dispatches `login status`; `codex-rs/cli/src/login.rs:439-484` prints `Logged in using ChatGPT` (subscription) or `Logged in using an API key - <masked>` (metered), both exit 0; access-token/PAT/Bedrock states intentionally stay unlabeled. Claude Code classification uses only prompt-free signals (credentials file type, `apiKeyHelper`, `ANTHROPIC_API_KEY`) — never the macOS keychain, preserving the existing no-prompt invariant.

Display-only by design: ranking, defaults, auto-selection, and gating are unchanged — the billing/quota tradeoff belongs to the operator.

**API-surface note:** the injectable `deps.detectCodexLoginState` seam deliberately keeps its boolean signature. That signature is reachable from the exported `detectInferenceBackends` options type and is therefore part of the plugin-sdk `agent-harness` API contract; the rich classification lives in a module-local helper so this PR does not bump the contract hash (a code comment records the constraint).

## User Impact

Picking an AI candidate during onboarding is now an informed billing decision. The `detail` strings flow unchanged through `openclaw.setup.detect` to the macOS onboarding rows and the CLI wizard — no protocol, Swift, or config changes.

## Evidence

- Live proof on a real install: `codex login status` → `Logged in using ChatGPT` (exit 0); real `detectInferenceBackends` path → `{"kind":"codex-cli","detail":"logged in · ChatGPT subscription","credentials":true}`.
- Focused suite `src/commands/onboard-inference.test.ts`: 34/34 locally and on Blacksmith Testbox (run 31511545507), including table-driven Codex classification (ChatGPT / API key / unrecognized), Claude credential-type and env-key labeling, and unchanged logged-out flows.
- `pnpm plugin-sdk:api:check` clean on this head (no contract drift by construction).
- Blacksmith core production typecheck (run 31511791468), test typecheck (run 31512065859), targeted oxlint (run 31512499852): all passed.
- Autoreview (branch mode): clean, "patch is correct" at 0.99.
