### PR TITLE
fix: keep subagent reconciliation case-sensitive

### DIFF
--- a/src/agents/subagents/registry/subagent-session-reconciliation.test.ts
+++ b/src/agents/subagents/registry/subagent-session-reconciliation.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import type { SessionEntry } from "../../../config/sessions.js";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import {
+  resolveSubagentSessionCompletion,
+  type SubagentSessionStoreCache,
+} from "./subagent-session-reconciliation.js";
+
+describe("subagent session reconciliation", () => {
+  it("does not complete from a case-colliding sibling session", () => {
+    const missingChildKey = "agent:main:matrix:group:!Room:server";
+    const collidingSiblingKey = "agent:main:matrix:group:!room:server";
+    const storePath = "/tmp/openclaw-subagent-session-reconciliation.sqlite";
+    const cfg = { session: { store: storePath } } satisfies OpenClawConfig;
+    const terminalSibling: SessionEntry = {
+      sessionId: "sibling-session",
+      status: "done",
+      startedAt: 1_000,
+      updatedAt: 2_000,
+      endedAt: 2_000,
+    };
+    const storeCache: SubagentSessionStoreCache = new Map([
+      [storePath, { [collidingSiblingKey]: terminalSibling }],
+    ]);
+
+    expect(
+      resolveSubagentSessionCompletion({
+        childSessionKey: missingChildKey,
+        fallbackEndedAt: 3_000,
+        notBeforeMs: 0,
+        storeCache,
+        cfg,
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/agents/subagents/registry/subagent-session-reconciliation.ts
+++ b/src/agents/subagents/registry/subagent-session-reconciliation.ts
@@ -69,20 +69,6 @@ function freshSessionStartedAt(
   return notBeforeMs === undefined || startedAt >= notBeforeMs ? startedAt : undefined;
 }
 
-function findSessionEntryByKey(store: Record<string, SessionEntry>, sessionKey: string) {
-  const direct = store[sessionKey];
-  if (direct) {
-    return direct;
-  }
-  const normalized = sessionKey.trim().toLowerCase();
-  for (const [key, entry] of Object.entries(store)) {
-    if (key.trim().toLowerCase() === normalized) {
-      return entry;
-    }
-  }
-  return undefined;
-}
-
 /** Load a child session entry using the agent-specific session store path. */
 export function loadSubagentSessionEntry(params: {
   childSessionKey: string;
@@ -106,7 +92,7 @@ export function loadSubagentSessionEntry(params: {
     );
     params.storeCache?.set(storePath, store);
   }
-  return findSessionEntryByKey(store, key);
+  return store[key];
 }
 
 /** Resolve a child session entry without depending on the file-backed store shape. */


### PR DESCRIPTION
Fixes #122047

## What Problem This Solves

Fixes an issue where a missing subagent session could be reconciled as completed from a different sibling session whose key differed only by letter case.

## Why This Change Was Made

Subagent reconciliation now requires an exact session-key match, preserving the opaque, case-sensitive identity already used by the canonical SQLite session store. The reconciliation-only case-folded fallback is removed so a sibling cannot supply another run's terminal state.

## User Impact

Parents no longer receive a false completion result when two subagent session keys collide under case folding and one exact child session is absent.

## Evidence

- Production-boundary SQLite trace on exact head `66e4ad147b312fbf4a43bb8dfee30e8ede2867d7` using Node 24.15.0. A temporary, uncommitted harness wrote both entries through production `replaceSessionEntry`, then queried production `resolveSubagentSessionCompletion`: a terminal case-colliding sibling could not complete the missing child, while a normal UUID child still reconciled successfully.

  ```text
  exact_head=66e4ad147b312fbf4a43bb8dfee30e8ede2867d7
  sqlite_store=sessions.json -> openclaw-agent.sqlite
  case_collision_missing_child=NOT_TERMINAL
  normal_uuid_child=RECONCILED_OK
  ```

- Focused exact-head contract validation passed:

  ```text
  pnpm dlx node@24.15.0 scripts/run-vitest.mjs \
    src/agents/subagents/registry/subagent-session-reconciliation.test.ts \
    src/sessions/session-key-case-preservation.test.ts

  Test Files  2 passed (2)
  Tests       43 passed (43)
  ```

- Exact-head GitHub CI passed with no failed or pending checks: https://github.com/openclaw/openclaw/actions/runs/31513647931
- `PATH="$PWD/node_modules/.bin:$PATH" oxfmt --check src/agents/subagents/registry/subagent-session-reconciliation.ts src/agents/subagents/registry/subagent-session-reconciliation.test.ts`
- `git diff --check upstream/main...HEAD`
- Fresh branch autoreview on `66e4ad147b312fbf4a43bb8dfee30e8ede2867d7`: clean, no accepted/actionable findings, correctness 0.99.
