### PR TITLE
fix(ui): hide Desktop panel for local sessions

### DIFF
--- a/ui/src/app/app-host.dock-suppression.test.ts
+++ b/ui/src/app/app-host.dock-suppression.test.ts
@@ -3,6 +3,7 @@
 import { render as renderLit, type TemplateResult } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
+import type { GatewaySessionRow } from "../api/types.ts";
 import type { RouteId } from "../app-routes.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import { resetAppHostTestGlobals } from "./app-host.test-support.ts";
@@ -12,6 +13,7 @@ import type { ApplicationContext } from "./context.ts";
 
 type ShellRenderState = {
   runtime: ApplicationRuntime;
+  activeSessionKey: string;
   routeState: { routeId: RouteId };
   render: () => TemplateResult;
 };
@@ -21,7 +23,7 @@ afterEach(() => {
 });
 
 describe("OpenClaw shell dock suppression", () => {
-  it("keeps Ask OpenClaw on settings pages and suppresses it only on its full page", () => {
+  it("applies route and session ownership to shell panels", () => {
     vi.stubGlobal("localStorage", createStorageMock());
     vi.stubGlobal(
       "matchMedia",
@@ -38,7 +40,14 @@ describe("OpenClaw shell dock suppression", () => {
           assistantAgentId: "main",
           hello: {
             auth: { role: "operator", scopes: ["operator.admin"] },
-            features: { methods: ["terminal.open", "browser.request", "openclaw.chat"] },
+            features: {
+              methods: [
+                "terminal.open",
+                "browser.request",
+                "openclaw.chat",
+                "worker.desktop.observe",
+              ],
+            },
           },
           lastError: null,
           offlineStable: false,
@@ -55,7 +64,20 @@ describe("OpenClaw shell dock suppression", () => {
       runtimeConfig: {
         state: { configSchema: null, configForm: null, configSnapshot: null, configUiHints: null },
       },
-      sessions: { state: { result: null } },
+      sessions: {
+        state: {
+          agentId: "main",
+          result: {
+            count: 1,
+            defaults: {},
+            path: "",
+            sessions: [
+              { key: "agent:main:main", kind: "direct", updatedAt: 0 } satisfies GatewaySessionRow,
+            ],
+            ts: 0,
+          },
+        },
+      },
       navigation: {
         snapshot: {
           navCollapsed: false,
@@ -90,7 +112,14 @@ describe("OpenClaw shell dock suppression", () => {
     } as unknown as ApplicationContext;
     const shell = document.createElement("openclaw-app-shell") as unknown as ShellRenderState;
     shell.runtime = { context, router: {} } as unknown as ApplicationRuntime;
+    shell.activeSessionKey = "agent:main:main";
     const container = document.createElement("div");
+    const desktopAvailable = () =>
+      (
+        container.querySelector("openclaw-desktop-panel") as HTMLElement & {
+          available: boolean;
+        }
+      ).available;
 
     shell.routeState = { routeId: "appearance" };
     renderLit(shell.render(), container);
@@ -128,5 +157,27 @@ describe("OpenClaw shell dock suppression", () => {
         }
       ).suppressed,
     ).toBe(false);
+    expect(desktopAvailable()).toBe(false);
+
+    context.sessions.state.result!.sessions = [
+      {
+        key: "agent:main:main",
+        kind: "direct",
+        placement: { state: "active" } as GatewaySessionRow["placement"],
+        updatedAt: 0,
+      },
+    ];
+    renderLit(shell.render(), container);
+    expect(desktopAvailable()).toBe(true);
+
+    context.sessions.state.result!.sessions = [
+      { key: "agent:main:main", kind: "direct", updatedAt: 0 },
+    ];
+    renderLit(shell.render(), container);
+    expect(desktopAvailable()).toBe(false);
+
+    context.sessions.state.result = null;
+    renderLit(shell.render(), container);
+    expect(desktopAvailable()).toBe(false);
   });
 });

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -28,6 +28,7 @@ import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
 import { createIdleImport } from "../lib/idle-import.ts";
 import { isWorkboardEnabledInConfigSnapshot } from "../lib/plugin-activation.ts";
 import { resolveSessionDisplayName } from "../lib/session-display.ts";
+import { findUiSessionRow } from "../lib/sessions/route-navigation.ts";
 import {
   isUiGlobalSessionKey,
   normalizeAgentId,
@@ -523,7 +524,8 @@ class OpenClawShell
     }
     const gatewaySnapshot = context.gateway?.snapshot;
     if (gatewaySnapshot) {
-      const desktopAvailable = isDesktopPanelAvailable(gatewaySnapshot);
+      const activeSessionRow = findUiSessionRow(context, this.activeSessionKey);
+      const desktopAvailable = isDesktopPanelAvailable(gatewaySnapshot, activeSessionRow);
       if (this.commandPalette) {
         this.commandPalette.desktopAvailable = desktopAvailable;
       }

--- a/ui/src/app/app-shell-chrome.ts
+++ b/ui/src/app/app-shell-chrome.ts
@@ -1,3 +1,5 @@
+import { isCloudWorkerPlacementState } from "../../../packages/gateway-protocol/src/schema/session-placement-state.js";
+import type { GatewaySessionRow } from "../api/types.ts";
 import { isSettingsNavigationRoute } from "../app-navigation.ts";
 import { routeIdFromPath, type RouteId } from "../app-route-paths.ts";
 import {
@@ -22,6 +24,7 @@ import type { BoardFace } from "../lib/board/settings.ts";
 import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
 import { resolveAsciiShortcutKey } from "../lib/keyboard-shortcuts.ts";
 import { readSessionMethodAccess } from "../lib/session-method-access.ts";
+import { findUiSessionRow } from "../lib/sessions/route-navigation.ts";
 import { isTerminalAvailable } from "../lib/terminal-availability.ts";
 import type { ShellRouteState } from "./app-host-route-state.ts";
 import type { ApplicationContext, ApplicationNavigationOptions } from "./context.ts";
@@ -55,8 +58,10 @@ export function isBrowserPanelAvailable(
 
 export function isDesktopPanelAvailable(
   snapshot: ApplicationContext["gateway"]["snapshot"],
+  session: GatewaySessionRow | undefined,
 ): boolean {
   return (
+    isCloudWorkerPlacementState(session?.placement?.state) &&
     snapshot.phase === "connected" &&
     hasOperatorAdminAccess(snapshot.hello?.auth ?? null) &&
     isGatewayMethodAdvertised(snapshot, "worker.desktop.observe") === true
@@ -65,6 +70,7 @@ export function isDesktopPanelAvailable(
 
 export interface ShellChromeHost extends HTMLElement {
   readonly context: ApplicationContext<RouteId> | undefined;
+  readonly activeSessionKey: string;
   readonly onboardingMode: boolean;
   readonly updateComplete: Promise<boolean>;
   readonly commandPaletteElement: OptionalCustomElement;
@@ -501,13 +507,16 @@ export class ShellChromeOwner {
 
   readonly handleDeferredDesktopToggle = (event: Event): void => {
     const host = this.host;
+    const context = host.context;
+    const session = context ? findUiSessionRow(context, host.activeSessionKey) : undefined;
+    if (!context || !isDesktopPanelAvailable(context.gateway.snapshot, session)) {
+      event.stopImmediatePropagation();
+      return;
+    }
     if (isOptionalElementDefined(host.desktopPanelElement)) {
       return;
     }
-    const snapshot = host.context?.gateway?.snapshot;
-    if (snapshot && isDesktopPanelAvailable(snapshot)) {
-      this.deliverPanelEventAfterLoad(host.desktopPanelElement, event);
-    }
+    this.deliverPanelEventAfterLoad(host.desktopPanelElement, event);
   };
 
   readonly handleDeferredCustodianToggle = (event: Event): void => {

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -12,6 +12,7 @@ import type { ThemeModeChangeDetail } from "../components/theme-mode-toggle.ts";
 import { t } from "../i18n/index.ts";
 import { canCallGatewayMethod, isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
 import { readSessionMethodAccess } from "../lib/session-method-access.ts";
+import { findUiSessionRow } from "../lib/sessions/route-navigation.ts";
 import { normalizeAgentId } from "../lib/sessions/session-key.ts";
 import { isTerminalAvailable } from "../lib/terminal-availability.ts";
 import { findSettingsSearchBlocks } from "../pages/config/settings-search.ts";
@@ -127,7 +128,8 @@ export function renderApplicationShell(host: ShellViewHost) {
     context.config.current.terminalEnabled ?? false,
   );
   const browserPanelAvailable = isBrowserPanelAvailable(gatewaySnapshot);
-  const desktopPanelAvailable = isDesktopPanelAvailable(gatewaySnapshot);
+  const activeSessionRow = findUiSessionRow(context, host.activeSessionKey);
+  const desktopPanelAvailable = isDesktopPanelAvailable(gatewaySnapshot, activeSessionRow);
   const custodianPanelAvailable =
     gatewayConnected && isGatewayMethodAdvertised(gatewaySnapshot, "openclaw.chat") === true;
   const activeRoute = host.routeState.routeId ?? "chat";

--- a/ui/src/e2e/desktop-panel.e2e.test.ts
+++ b/ui/src/e2e/desktop-panel.e2e.test.ts
@@ -9,6 +9,24 @@ const suite = createControlUiE2eSuite({
     `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`.`,
 });
 
+function sessionsList(placement: "local" | "active") {
+  return {
+    count: 1,
+    defaults: { contextTokens: null, model: "gpt-5.5", modelProvider: "openai" },
+    path: "",
+    sessions: [
+      {
+        key: "main",
+        kind: "direct",
+        label: "Main",
+        placement: { state: placement },
+        updatedAt: Date.now(),
+      },
+    ],
+    ts: Date.now(),
+  };
+}
+
 async function openPalette(page: import("playwright").Page) {
   await page.evaluate(() => {
     window.dispatchEvent(new CustomEvent("openclaw:command-palette-open"));
@@ -49,20 +67,47 @@ async function installDesktopClientFake(panel: import("playwright").Locator) {
 
 suite.define(() => {
   it("hides the desktop command without the method or operator.admin", async () => {
-    for (const scenario of [
-      { featureMethods: ["environments.list"] },
+    for (const testCase of [
+      {
+        featureMethods: ["environments.list"],
+        methodResponses: { "sessions.list": sessionsList("active") },
+      },
       {
         featureMethods: ["environments.list", "worker.desktop.observe"],
+        methodResponses: { "sessions.list": sessionsList("active") },
         operatorScopes: ["operator.read"],
       },
     ]) {
       await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
-        await installMockGateway(page, scenario);
+        await installMockGateway(page, testCase);
         await page.goto(`${suite.server.baseUrl}chat`);
         await openPalette(page);
         expect(await page.getByRole("option", { name: "Desktop", exact: true }).count()).toBe(0);
       });
     }
+  });
+
+  it("keeps the desktop command and panel unavailable for a local session", async () => {
+    await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: ["environments.list", "worker.desktop.observe"],
+        methodResponses: { "sessions.list": sessionsList("local") },
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await openPalette(page);
+      expect(await page.getByRole("option", { name: "Desktop", exact: true }).count()).toBe(0);
+
+      await page.evaluate(() => {
+        window.dispatchEvent(
+          new CustomEvent("openclaw:desktop-toggle", { detail: { open: true } }),
+        );
+      });
+      await page.waitForTimeout(250);
+      expect(
+        await page.locator("openclaw-desktop-panel section[aria-label='Desktop']").count(),
+      ).toBe(0);
+      expect(await gateway.getRequests("environments.list")).toHaveLength(0);
+    });
   });
 
   it("launches advertised desktop apps and keeps observe controls working", async () => {
@@ -71,6 +116,7 @@ suite.define(() => {
         deferredMethods: ["worker.desktop.launch"],
         featureMethods: ["environments.list", "worker.desktop.launch", "worker.desktop.observe"],
         methodResponses: {
+          "sessions.list": sessionsList("active"),
           "environments.list": {
             environments: [
               {
@@ -207,6 +253,7 @@ suite.define(() => {
       const gateway = await installMockGateway(page, {
         featureMethods: ["environments.list", "worker.desktop.launch", "worker.desktop.observe"],
         methodResponses: {
+          "sessions.list": sessionsList("active"),
           "environments.list": {
             environments: [
               {

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -178,7 +178,7 @@ export abstract class ChatPaneHeader extends ChatPaneSessionMenu {
           session: row,
         })
       : {};
-    const desktopPanelAvailable = isDesktopPanelAvailable(this.context.gateway.snapshot);
+    const desktopPanelAvailable = isDesktopPanelAvailable(this.context.gateway.snapshot, row);
     const openDesktopPanel = () =>
       window.dispatchEvent(
         new CustomEvent<DesktopPanelToggleDetail>(DESKTOP_PANEL_TOGGLE_EVENT, {

--- a/ui/src/pages/chat/chat-pane-terminal.test.ts
+++ b/ui/src/pages/chat/chat-pane-terminal.test.ts
@@ -66,16 +66,20 @@ describe("chat pane terminal action", () => {
     }
   });
 
-  it("renders the desktop launcher only when available and opens the panel", () => {
+  it("renders the desktop controls only for cloud sessions and opens the panel", () => {
     const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
     const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
-    const session = {
+    const localSession = {
       key: state.sessionKey,
       kind: "direct",
       updatedAt: 0,
     } satisfies GatewaySessionRow;
+    const cloudSession = {
+      ...localSession,
+      placement: { state: "active" } as GatewaySessionRow["placement"],
+    } satisfies GatewaySessionRow;
     const container = document.createElement("div");
-    const renderHeader = () =>
+    const renderHeader = (session: GatewaySessionRow) => {
       render(
         pane.renderPaneHeader(
           createSessionWorkspaceProps(state),
@@ -87,27 +91,39 @@ describe("chat pane terminal action", () => {
         ),
         container,
       );
+    };
+    const panelActionIds = () =>
+      container
+        .querySelector<HTMLElement & { panelActions: Array<{ id: string }> }>(
+          "openclaw-chat-header-session-menu",
+        )
+        ?.panelActions.map((action) => action.id) ?? [];
     const snapshot = pane.context.gateway.snapshot;
     snapshot.hello = desktopHello([], ["operator.admin"]);
-    renderHeader();
+    renderHeader(cloudSession);
     expect(container.querySelector('[aria-label="Toggle desktop panel"]')).toBeNull();
 
     snapshot.hello = desktopHello(["worker.desktop.observe"], ["operator.admin"]);
+    renderHeader(localSession);
+    expect(container.querySelector('[aria-label="Toggle desktop panel"]')).toBeNull();
+    expect(panelActionIds()).not.toContain("desktop");
+
     const events: CustomEvent<DesktopPanelToggleDetail>[] = [];
     const listener = (event: Event) => events.push(event as CustomEvent<DesktopPanelToggleDetail>);
     window.addEventListener(DESKTOP_PANEL_TOGGLE_EVENT, listener);
     try {
-      renderHeader();
+      renderHeader(cloudSession);
       const button = container.querySelector<HTMLButtonElement>(
         '[aria-label="Toggle desktop panel"]',
       );
       expect(button).not.toBeNull();
+      expect(panelActionIds()).toContain("desktop");
       button?.click();
       expect(events).toHaveLength(1);
       expect(events[0]?.detail).toEqual({ open: true });
 
       snapshot.hello = desktopHello(["worker.desktop.observe"], ["operator.read"]);
-      renderHeader();
+      renderHeader(cloudSession);
       expect(container.querySelector('[aria-label="Toggle desktop panel"]')).toBeNull();
     } finally {
       window.removeEventListener(DESKTOP_PANEL_TOGGLE_EVENT, listener);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing a local session could still see and invoke cloud-worker Desktop UI when the connected Gateway advertised Desktop support. The leak covered the chat-header button, session-menu action, command-palette item, panel loading/opening, and stale or synthetic toggle events.

The regression entered in stages: the cloud Desktop panel arrived in #120727 at 8fdf7570a17ffbbafe825bd379bab858f263b8ca, Gateway-wide launchers were restored in #121322 at 0ce757027ab0b55ade217bc0552d875b24bd245c, and the chat-header launcher followed in #121935 at 4841e4e6b96275d5c298de4fb71c2a9754c457c4. The Gateway-wide availability predicate never incorporated the selected session placement.

## Why This Change Was Made

The canonical availability owner, isDesktopPanelAvailable, now requires both Gateway method/admin access and a selected GatewaySessionRow whose placement is a cloud-worker state. Shell callers resolve the active row through findUiSessionRow, the chat header passes its already-selected row, and deferred toggle delivery revalidates the same predicate before lazy-loading the panel. Missing, local, or reclaimed rows therefore fail closed while active cloud-worker sessions retain the existing Desktop experience.

This is the best-fix owner boundary because it puts placement policy in the shared availability predicate used by every launcher and panel path. Per-button guards or a consumer-only panel check would duplicate policy and would still leave stale synthetic events capable of loading the panel.

Production LOC: +20/-7 (net +13) | Tests: +126/-12. The production growth carries the selected-row fact into the existing shared predicate and removes no supported path.

AI-assisted: yes. The resulting diff was reviewed and behavior-tested before publication.

## User Impact

Local sessions no longer expose any cloud-worker Desktop controls or accept stale/synthetic Desktop toggle events. Cloud-worker sessions keep the Desktop header button, session-menu action, command-palette item, and functioning panel.

## Evidence

Focused unit regression proof:

    OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs ui/src/app/app-host.dock-suppression.test.ts ui/src/pages/chat/chat-pane-terminal.test.ts

Result: 2 files and 3 tests passed.

Mock-Gateway Playwright proof:

    OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/desktop-panel.e2e.test.ts

Result: 1 file and 4 tests passed. It covers missing method/admin access, a local session rejecting the command and synthetic toggle without loading the panel, and active cloud-worker Desktop launch/observe behavior.

Changed-surface checks:

    node scripts/check-changed.mjs

Result: passed. Blacksmith CLI was missing and managed broker authentication was unavailable, so the wrapper used its documented trusted-source local fallback and passed UI/core typecheck, lint, deadcode, format, i18n, and guards.

Build proof:

    pnpm ui:build
    pnpm build

Both passed. The startup bundle remained below budget; the full build completed in 12m51.7s.

Fresh structured autoreview of the exact uncommitted diff completed cleanly with no accepted or actionable findings.

Before — local session incorrectly exposes Desktop:

![Before: local session incorrectly exposes Desktop](https://github.com/user-attachments/assets/1f415b42-9310-4b38-acab-2d1037144e42)

After — local session has no Desktop UI:

![After: local session has no Desktop UI](https://github.com/user-attachments/assets/63d38a13-ad18-4182-a483-828efd3f4253)

After — active cloud-worker session retains Desktop:

![After: active cloud-worker session retains Desktop](https://github.com/user-attachments/assets/5bbca878-dee2-431e-ae2e-f188ea34ce95)
