### PR TITLE
improve(ui): speed up large Markdown session switches

### DIFF
--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -503,6 +503,8 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
                     transform: `translateY(${
                       virtualRow.start - virtualizer.options.scrollMargin
                     }px)`,
+                    // Keep skipped overscan rows at the virtualizer's known size.
+                    containIntrinsicBlockSize: `auto ${virtualRow.size}px`,
                   })}
                   data-index=${String(virtualRow.index)}
                   data-virtual-row-key=${row.key}

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -402,6 +402,7 @@ openclaw-chat-page {
   left: 0;
   display: flow-root;
   width: 100%;
+  content-visibility: auto;
 }
 
 .chat-virtual-row--first > :first-child {


### PR DESCRIPTION
Related: #121625
Related: #121792

AI-assisted: Amp thread https://ampcode.com/threads/T-019fe957-0e49-707f-859f-9600ef536125

## What Problem This Solves

Retained session activation is immediately useful for ordinary chats, but a warm switch between sessions containing one 800 KiB Markdown message still took 82.9 ms median / 91.3 ms p95 to settle and produced a 73 ms long task. That made the largest Markdown transcripts visibly lag behind the otherwise-instant retained-session path.

## Why This Change Was Made

Chromium profiling and direct DOM mutation probes isolated the remaining cost to the paired `inert` handoff: each toggle forced style work across roughly 5,000 descendants in the tall Markdown row and cost 50–72 ms. Markdown parsing, history reconciliation, and unchanged message rendering were not on the hot path.

This lets Chromium skip rendering work for offscreen virtual rows with `content-visibility: auto`. Each skipped row receives `contain-intrinsic-block-size: auto <virtualRow.size>` so TanStack Virtual keeps the measured/estimated scroll geometry while the browser can remember the last rendered height. The retained-session cap, live background updates, route handoff, and accessibility ownership remain unchanged.

Production LOC: +3/-0 (net +3) | Tests: +0/-0. The added row-size hint and its invariant comment are the smallest expression of the browser/virtualizer contract; no extra state, cache, or lifecycle path is introduced.

## User Impact

Large Markdown sessions become useful in about 2 ms and settle about 49–53% faster when switching between retained sessions. The measured long task disappears, while ordinary, tool-heavy, and near-5 MiB multi-message histories stay within normal browser timing noise.

## Evidence

Production Control UI bundle, Chromium, 1440×900 viewport, deterministic in-browser mocked Gateway, both panes warmed and idled for one second:

| 800 KiB Markdown switch | Current main | Candidate run 1 | Candidate run 2 |
| --- | ---: | ---: | ---: |
| settled median | 82.9 ms | 42.6 ms | 39.0 ms |
| settled p95 | 91.3 ms | 56.9 ms | 47.0 ms |
| first useful median | 3.5 ms | 2.0 ms | 2.0 ms |
| longest task | 73 ms | 0 ms | 0 ms |

A separate 100-switch 800 KiB Markdown soak measured:

- dispatch: 1.4 ms median / 1.7 ms p95
- first useful: 1.9 ms median / 2.4 ms p95
- settled: 39.0 ms median / 50.8 ms p95
- longest task: 0 ms
- retained roots reused: 100/100
- warm `chat.history`, `chat.startup`, `chat.subscribe`, and `chat.unsubscribe`: all zero
- active/hidden `inert`, `aria-hidden`, and live-region ownership: correct throughout

The full benchmark also passed three-retained/fourth-session eviction, background-stream-then-activate, split same-session isolation, and zero warm-RPC invariants.

Focused tests:

```text
node scripts/run-vitest.mjs \
  ui/src/pages/chat/components/chat-thread.measure.test.ts \
  ui/src/pages/chat/chat-view.test.ts \
  ui/src/pages/chat/chat-page-retained-sessions.test.ts \
  ui/src/pages/chat/chat-pane-retained-presentation.test.ts \
  ui/src/components/markdown.test.ts
# 5 files, 350 tests passed

node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.ui-e2e.config.ts \
  --configLoader runner \
  ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts \
  ui/src/e2e/chat-panel-reflow.e2e.test.ts \
  ui/src/e2e/chat-flow.streaming.e2e.test.ts
# passed in Chromium, including navigation/scroll retention, reflow,
# streaming Markdown/media pinning, reconnect, and scroll-to-bottom coverage

pnpm tsgo:ui
pnpm lint:ui:styles
git diff --check
# passed
```

The normal changed-file gate attempted Crabbox/Testbox first, but this orb's installed Crabbox binary failed its basic sanity check. The repository-approved local fallback completed successfully: all 16 selected checks passed, including core-test/UI typechecks, UI i18n verification, formatting, dead-export scan, and full core/UI/package lint. Exact-head hosted CI remains required before merge.

Fresh structured autoreview of commit `3de2f0da500` reported no accepted/actionable findings.

Browser contract references:

- https://developer.mozilla.org/en-US/docs/Web/CSS/content-visibility
- https://developer.mozilla.org/en-US/docs/Web/CSS/contain-intrinsic-block-size

