### PR TITLE
refactor(mcp): centralize requester runtime materialization

### DIFF
--- a/src/agents/agent-bundle-mcp-manager.ts
+++ b/src/agents/agent-bundle-mcp-manager.ts
@@ -16,11 +16,7 @@ import {
   resolveSessionMcpRuntimeIdleTtlMs,
   type CreateSessionMcpRuntime,
 } from "./agent-bundle-mcp-runtime-shared.js";
-import type {
-  SessionMcpRequesterScope,
-  SessionMcpRuntime,
-  SessionMcpRuntimeManager,
-} from "./agent-bundle-mcp-types.js";
+import type { SessionMcpRuntime, SessionMcpRuntimeManager } from "./agent-bundle-mcp-types.js";
 import { revokeMcpAppModelContext } from "./mcp-app-model-context.js";
 import {
   buildMcpRequesterRuntimeCacheKey,
@@ -53,6 +49,49 @@ export function createSessionMcpRuntimeManager(
   );
   const lifecycle = createSessionMcpRuntimeManagerLifecycle(store);
   const install = createSessionMcpRuntimeManagerInstall(lifecycle);
+  const materializeRequesterScopedRuntime = async (
+    params: Parameters<SessionMcpRuntimeManager["getOrCreate"]>[0] & {
+      idleTtlMs: number;
+      requesterScopedServerNames: readonly string[];
+      scopedNameSet: ReadonlySet<string>;
+      safeServerNamesByServer: ReadonlyMap<string, string>;
+      requesterSenderId: string;
+    },
+  ) => {
+    const agentAccountId = normalizeOptionalString(params.agentAccountId);
+    const messageChannel = normalizeOptionalString(params.messageChannel);
+    const runtimeKey = buildMcpRequesterRuntimeCacheKey({
+      sessionId: params.sessionId,
+      messageChannel,
+      agentAccountId,
+      requesterSenderId: params.requesterSenderId,
+    });
+    const fullScopedFingerprint = loadSessionMcpConfig({
+      workspaceDir: params.workspaceDir,
+      cfg: params.cfg,
+      logDiagnostics: false,
+      manifestRegistry: params.manifestRegistry,
+      includeServerNames: params.scopedNameSet,
+      redactConnectionServerNames: params.scopedNameSet,
+      safeServerNamesByServer: params.safeServerNamesByServer,
+      toolOverrides: params.toolOverrides,
+    }).fingerprint;
+    const runtime = await lifecycle.runExclusiveOnRuntimeKey(runtimeKey, () =>
+      install.resolveAndInstallRequesterRuntime({
+        ...params,
+        runtimeKey,
+        fullScopedFingerprint,
+        agentAccountId,
+        messageChannel,
+        requesterScope: {
+          requesterSenderId: params.requesterSenderId,
+          ...(agentAccountId ? { agentAccountId } : {}),
+          ...(messageChannel ? { messageChannel } : {}),
+        },
+      }),
+    );
+    return { runtimeKey, runtime };
+  };
 
   const manager: SessionMcpRuntimeManager = {
     async getOrCreate(params) {
@@ -134,52 +173,14 @@ export function createSessionMcpRuntimeManager(
 
       const requesterSenderId = normalizeOptionalString(params.requesterSenderId);
       if (requesterSenderId) {
-        const requesterScope: SessionMcpRequesterScope = {
-          requesterSenderId,
-          ...(normalizeOptionalString(params.agentAccountId)
-            ? { agentAccountId: normalizeOptionalString(params.agentAccountId) }
-            : {}),
-          ...(normalizeOptionalString(params.messageChannel)
-            ? { messageChannel: normalizeOptionalString(params.messageChannel) }
-            : {}),
-        };
-        const runtimeKey = buildMcpRequesterRuntimeCacheKey({
-          sessionId: params.sessionId,
-          messageChannel: params.messageChannel,
-          agentAccountId: params.agentAccountId,
-          requesterSenderId,
-        });
-        const { fingerprint: fullScopedFingerprint } = loadSessionMcpConfig({
-          workspaceDir: params.workspaceDir,
-          cfg: params.cfg,
-          logDiagnostics: false,
-          manifestRegistry: params.manifestRegistry,
-          includeServerNames: scopedNameSet,
-          redactConnectionServerNames: scopedNameSet,
+        const { runtimeKey, runtime: scopedRuntime } = await materializeRequesterScopedRuntime({
+          ...params,
+          idleTtlMs,
+          requesterScopedServerNames,
+          scopedNameSet,
           safeServerNamesByServer,
-          toolOverrides: params.toolOverrides,
+          requesterSenderId,
         });
-        const scopedRuntime = await lifecycle.runExclusiveOnRuntimeKey(runtimeKey, () =>
-          install.resolveAndInstallRequesterRuntime({
-            runtimeKey,
-            sessionId: params.sessionId,
-            sessionKey: params.sessionKey,
-            workspaceDir: params.workspaceDir,
-            agentDir: params.agentDir,
-            cfg: params.cfg,
-            manifestRegistry: params.manifestRegistry,
-            idleTtlMs,
-            requesterScopedServerNames,
-            scopedNameSet,
-            safeServerNamesByServer,
-            fullScopedFingerprint,
-            requesterSenderId,
-            agentAccountId: params.agentAccountId,
-            messageChannel: params.messageChannel,
-            requesterScope,
-            toolOverrides: params.toolOverrides,
-          }),
-        );
         if (scopedRuntime) {
           parts.push(scopedRuntime);
         }
@@ -245,56 +246,18 @@ export function createSessionMcpRuntimeManager(
         Object.keys(fullConfig.loaded.mcpServers),
       );
       const scopedNameSet = new Set(requesterScopedServerNames);
-      const requesterScope: SessionMcpRequesterScope = {
-        requesterSenderId,
-        ...(normalizeOptionalString(params.agentAccountId)
-          ? { agentAccountId: normalizeOptionalString(params.agentAccountId) }
-          : {}),
-        ...(normalizeOptionalString(params.messageChannel)
-          ? { messageChannel: normalizeOptionalString(params.messageChannel) }
-          : {}),
-      };
-      const runtimeKey = buildMcpRequesterRuntimeCacheKey({
-        sessionId: params.sessionId,
-        messageChannel: params.messageChannel,
-        agentAccountId: params.agentAccountId,
-        requesterSenderId,
-      });
-      const { fingerprint: fullScopedFingerprint } = loadSessionMcpConfig({
-        workspaceDir: params.workspaceDir,
-        cfg: params.cfg,
-        logDiagnostics: false,
-        manifestRegistry: params.manifestRegistry,
-        includeServerNames: scopedNameSet,
-        redactConnectionServerNames: scopedNameSet,
+      const { runtimeKey, runtime } = await materializeRequesterScopedRuntime({
+        ...params,
+        idleTtlMs,
+        requesterScopedServerNames,
+        scopedNameSet,
         safeServerNamesByServer,
-        toolOverrides: params.toolOverrides,
+        requesterSenderId,
       });
-      const scopedRuntime = await lifecycle.runExclusiveOnRuntimeKey(runtimeKey, () =>
-        install.resolveAndInstallRequesterRuntime({
-          runtimeKey,
-          sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
-          workspaceDir: params.workspaceDir,
-          agentDir: params.agentDir,
-          cfg: params.cfg,
-          manifestRegistry: params.manifestRegistry,
-          idleTtlMs,
-          requesterScopedServerNames,
-          scopedNameSet,
-          safeServerNamesByServer,
-          fullScopedFingerprint,
-          requesterSenderId,
-          agentAccountId: params.agentAccountId,
-          messageChannel: params.messageChannel,
-          requesterScope,
-          toolOverrides: params.toolOverrides,
-        }),
-      );
-      if (scopedRuntime) {
+      if (runtime) {
         await lifecycle.enforceRequesterRuntimeCap(params.sessionId, runtimeKey);
       }
-      return scopedRuntime;
+      return runtime;
     },
     rememberAdvertisedScopedCatalog: lifecycle.rememberAdvertisedScopedCatalog,
     getAdvertisedScopedCatalog: lifecycle.getAdvertisedScopedCatalog,

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -3712,67 +3712,84 @@ describe("requester-scoped MCP connection resolution", () => {
     await manager.disposeAll();
   });
 
-  it("evicts LRU idle requester runtimes past the per-session cap", async () => {
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
-        serverName: "user-mail",
-        resolve: async (ctx) => ({ url: `https://mcp.example.test/${ctx.requesterSenderId}` }),
-      },
-    ]);
+  it.each([
+    ["full", 3],
+    ["requester-only", 2],
+  ] as const)(
+    "evicts LRU idle requester runtimes past the per-session cap via %s materialization",
+    async (entrypoint, expectedRuntimeCount) => {
+      const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
+      resolverTesting.setMcpServerConnectionResolversForTest([
+        {
+          serverName: "user-mail",
+          resolve: async (ctx) => ({ url: `https://mcp.example.test/${ctx.requesterSenderId}` }),
+        },
+      ]);
 
-    const disposedSenders: string[] = [];
-    let syntheticLastUsedAt = 100_000;
-    const createRuntime: RuntimeFactory = (params) => {
-      const sender = params.requesterScope?.requesterSenderId;
-      const base = makeRuntime([{ toolName: "probe", description: "probe" }]);
-      // Distinct ascending lastUsedAt per runtime so LRU ordering is deterministic.
-      const lastUsedAt = (syntheticLastUsedAt += 1_000);
-      return {
-        ...base,
-        sessionId: params.sessionId,
-        workspaceDir: params.workspaceDir,
-        configFingerprint: params.configFingerprint ?? "fingerprint",
-        requesterScope: params.requesterScope,
-        get lastUsedAt() {
-          return lastUsedAt;
-        },
-        markUsed: () => {},
-        dispose: async () => {
-          if (sender) {
-            disposedSenders.push(sender);
-          }
-        },
+      const disposedSenders: string[] = [];
+      let syntheticLastUsedAt = 100_000;
+      const createRuntime: RuntimeFactory = (params) => {
+        const sender = params.requesterScope?.requesterSenderId;
+        const base = makeRuntime([{ toolName: "probe", description: "probe" }]);
+        // Distinct ascending lastUsedAt per runtime so LRU ordering is deterministic.
+        const lastUsedAt = (syntheticLastUsedAt += 1_000);
+        return {
+          ...base,
+          sessionId: params.sessionId,
+          workspaceDir: params.workspaceDir,
+          configFingerprint: params.configFingerprint ?? "fingerprint",
+          requesterScope: params.requesterScope,
+          get lastUsedAt() {
+            return lastUsedAt;
+          },
+          markUsed: () => {},
+          dispose: async () => {
+            if (sender) {
+              disposedSenders.push(sender);
+            }
+          },
+        };
       };
-    };
-    const manager = testing.createSessionMcpRuntimeManager({
-      createRuntime,
-      // Pin the sweep clock near the synthetic lastUsedAt values so the idle
-      // TTL sweep never fires; this test exercises only the cap eviction.
-      now: () => 150_000,
-      maxIdleRequesterRuntimesPerSession: 2,
-    });
-    const cfg = {
-      mcp: { servers: { "user-mail": { transport: "streamable-http" } } },
-    };
-
-    for (const sender of ["sender-a", "sender-b", "sender-c"]) {
-      await manager.getOrCreate({
-        sessionId: "session-cap",
-        workspaceDir: "/workspace",
-        cfg: cfg as never,
-        requesterSenderId: sender,
-        messageChannel: "telegram",
+      const manager = testing.createSessionMcpRuntimeManager({
+        createRuntime,
+        // Pin the sweep clock near the synthetic lastUsedAt values so the idle
+        // TTL sweep never fires; this test exercises only the cap eviction.
+        now: () => 150_000,
+        maxIdleRequesterRuntimesPerSession: 2,
       });
-    }
+      const cfg = {
+        mcp: { servers: { "user-mail": { transport: "streamable-http" } } },
+      };
 
-    // sender-a is the least recently used zero-lease scoped runtime.
-    expect(disposedSenders).toEqual(["sender-a"]);
-    // Bare static reconcile key + two newest requester keys survive.
-    expect(manager.listRuntimeKeys()).toHaveLength(3);
+      for (const sender of ["sender-a", "sender-b", "sender-c"]) {
+        const runtimeParams = {
+          sessionId: "session-cap",
+          workspaceDir: "/workspace",
+          cfg: cfg as never,
+          requesterSenderId: sender,
+          messageChannel: "telegram",
+        };
+        if (entrypoint === "full") {
+          await manager.getOrCreate(runtimeParams);
+        } else {
+          await manager.getOrCreateRequesterScoped(runtimeParams);
+        }
+      }
 
-    await manager.disposeAll();
-  });
+      // sender-a is the least recently used zero-lease scoped runtime.
+      expect(disposedSenders).toEqual(["sender-a"]);
+      const runtimeKeys = manager.listRuntimeKeys();
+      expect(runtimeKeys).toHaveLength(expectedRuntimeCount);
+      expect(runtimeKeys.includes("session-cap")).toBe(entrypoint === "full");
+      expect(
+        runtimeKeys
+          .filter((key) => key.startsWith("{"))
+          .map((key) => (JSON.parse(key) as { requesterSenderId: string }).requesterSenderId),
+      ).toEqual(["sender-b", "sender-c"]);
+
+      await manager.disposeAll();
+    },
+  );
 
   it("re-merges the combined catalog after a part refreshes on tools/list_changed", async () => {
     const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
@@ -4635,7 +4652,7 @@ describe("requester-scoped MCP connection resolution", () => {
     await manager.disposeAll();
   });
 
-  it("reuses requester cache keys for getOrCreateRequesterScoped", async () => {
+  it("reuses one requester runtime across full and requester-only entrypoints", async () => {
     const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
     let resolveCount = 0;
     resolverTesting.setMcpServerConnectionResolversForTest([
@@ -4663,23 +4680,27 @@ describe("requester-scoped MCP connection resolution", () => {
       },
     };
 
-    const first = await manager.getOrCreateRequesterScoped({
+    const full = await manager.getOrCreate({
       sessionId: "session-reuse",
       workspaceDir: "/workspace",
       cfg: cfg as never,
       requesterSenderId: "sender-a",
       messageChannel: "telegram",
     });
-    const second = await manager.getOrCreateRequesterScoped({
+    const fullRuntimeKey = manager.listRuntimeKeys().find((key) => key.startsWith("{"));
+    const requesterOnly = await manager.getOrCreateRequesterScoped({
       sessionId: "session-reuse",
       workspaceDir: "/workspace",
       cfg: cfg as never,
       requesterSenderId: "sender-a",
       messageChannel: "telegram",
     });
-    expect(first).toBe(second);
+    const requesterOnlyRuntimeKey = manager.listRuntimeKeys().find((key) => key.startsWith("{"));
+    expect(requesterOnly).toBe(full);
     expect(resolveCount).toBe(1);
-    expect(manager.listRuntimeKeys()).toHaveLength(1);
+    expect(requesterOnlyRuntimeKey).toBe(fullRuntimeKey);
+    expect(requesterOnly?.configFingerprint).toBe(full.configFingerprint);
+    expect(manager.listRuntimeKeys()).toHaveLength(2);
 
     await manager.disposeAll();
   });


### PR DESCRIPTION
## What Problem This Solves

Requester-scoped MCP runtime materialization was duplicated across the full session runtime and requester-only harness entrypoints. That made cache identity, redacted fingerprints, and serialization vulnerable to drifting independently.

## Why This Change Was Made

Centralizes normalized requester scope, requester cache keys, redacted scoped fingerprints, exclusive key serialization, and requester runtime installation in one manager-local flow. Caller-owned preparation and composition remain unchanged, including the intentional cap difference: full materialization enforces the cap after every identified requester attempt, while requester-only materialization enforces it only after a runtime exists.

## User Impact

No user-visible behavior change. Maintainers get one canonical requester runtime materialization path with explicit parity coverage across both entrypoints.

## Evidence

Exact head: `a54cdb73b663654a3b4ee5902f8d4dc04fda2007`

- Focused runtime test: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime.test.ts` - 92 passed.
- Changed-file gate: `node scripts/check-changed.mjs -- src/agents/agent-bundle-mcp-manager.ts src/agents/agent-bundle-mcp-runtime.test.ts` - passed after the unavailable remote warmup fell back to local execution.
- Formatting and patch integrity: `pnpm format ...`; `git diff --check` - clean.
- Autoreview: clean, no accepted/actionable findings.
- Production LOC: `+58/-95` (net `-37`).
- Tests: `+82/-61` (net `+21`).

### Exact-head remote proof

- Blacksmith Testbox: lease `tbx_01kzryq2g8eag9dr42we6r23rf`, [Actions run 31518971930](https://github.com/openclaw/openclaw/actions/runs/31518971930), exact remote `HEAD` asserted as `a54cdb73b663654a3b4ee5902f8d4dc04fda2007`.
  - Focused runtime test: 92/92 passed; wrapper exit `0`, 18.459s.
  - `pnpm check:changed --base 82ba647673f90c7193c627b5de710980789eca85 --head HEAD`: core + coreTests lanes passed; wrapper exit `0`, 337.538s.
- AWS Crabbox: lease `cbx_9b78ca4fb1e8`, [run `run_c760ca4c7a40`](https://crabbox.openclaw.ai/portal/runs/run_c760ca4c7a40), exact head asserted before build.
  - `pnpm build qaRuntime` produced the packaged loader and MCP runtime entries.
  - A normally loaded ephemeral plugin registered the requester connection resolver.
  - Real stateful SDK Streamable HTTP MCP endpoints proved Alice/Bob isolation, full-to-requester-only cache reuse, anonymous no-op, null resolution, and clean DELETE disposal.
  - Wrapper exit `0`; command 37.830s, sync 89.310s, total 277.175s.

```json
{"status":"pass","exactHead":"a54cdb73b663654a3b4ee5902f8d4dc04fda2007","packagedDist":{"loader":"dist/plugins/build-smoke-entry.js","runtime":"dist/agents/agent-bundle-mcp-runtime.js"},"plugin":{"id":"requester-mcp-packaged-proof","loadStatus":"loaded","resolverRegistrations":1},"crossEntrypoint":{"sameRuntime":true,"sameFingerprint":true,"resolverCallsAfterReuse":1},"isolation":{"aliceToolResult":"alice","bobToolResult":"bob","distinctRuntime":true,"distinctRuntimeKeys":true},"failClosed":{"anonymousScopedNoOp":true,"anonymousResolverCalls":0,"deniedNullResolution":true},"disposal":{"cacheEmpty":true,"deleteRequests":{"alice":1,"bob":1}},"invalidHeaderCount":0}
```

AI-assisted: yes. The implementation, tests, and proof were reviewed directly before publication.
