### PR TITLE
fix(ui): hide session changes outside Git checkouts

### DIFF
--- a/ui/src/e2e/chat-session-diff.e2e.test.ts
+++ b/ui/src/e2e/chat-session-diff.e2e.test.ts
@@ -163,10 +163,10 @@ describeControlUiE2e("session diff panel", () => {
     await expect.poll(() => modified.locator(".chat-diff").count()).toBe(1);
   });
 
-  it("disables the diff toggle for a workspace outside a git checkout", async () => {
+  it("hides the diff toggle until the workspace becomes a git checkout", async () => {
     const context = await newBrowserContext();
     const page = await context.newPage();
-    await installMockGateway(page, {
+    const gateway = await installMockGateway(page, {
       featureMethods: ["chat.metadata", "chat.startup", "sessions.diff"],
       methodResponses: {
         "sessions.files.list": {
@@ -186,20 +186,28 @@ describeControlUiE2e("session diff panel", () => {
       },
     });
     await page.goto(`${server.baseUrl}chat`);
-
-    const toggle = page.locator(".chat-session-diff-toggle").first();
-    await expect.poll(() => toggle.isDisabled()).toBe(true);
-    await expect.poll(() => toggle.getAttribute("aria-label")).toBe("Show session changes");
     await expect
-      .poll(() =>
-        toggle.evaluate(
-          (element) =>
-            (element.closest("openclaw-tooltip") as (HTMLElement & { content?: string }) | null)
-              ?.content,
-        ),
-      )
-      .toBe("This session's workspace is not a git checkout.");
+      .poll(async () => (await gateway.getRequests("sessions.files.list")).length)
+      .toBe(1);
+
+    const toggles = page.locator(".chat-session-diff-toggle");
+    await expect.poll(() => toggles.count()).toBe(0);
     await expect.poll(() => page.locator(".session-diff").count()).toBe(0);
+
+    await gateway.setMethodResponse("sessions.files.list", {
+      sessionKey: "main",
+      root: "/tmp/plain-workspace",
+      gitCheckout: true,
+      files: [],
+      browser: { path: "", entries: [] },
+    });
+    await gateway.emitChatFinal({ runId: "git-init-run", text: "Initialized repository." });
+    await expect
+      .poll(async () => (await gateway.getRequests("sessions.files.list")).length)
+      .toBe(2);
+
+    await expect.poll(() => toggles.count()).toBe(1);
+    await expect.poll(() => toggles.first().isEnabled()).toBe(true);
   });
 
   it("keeps the panel fallback for gateways that omit checkout capability", async () => {

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -231,7 +231,6 @@ export abstract class ChatPaneHeader extends ChatPaneSessionMenu {
         id: "changes",
         label: t("chat.sessionDiff.show"),
         icon: icons.fileDiff,
-        disabledReason: sessionWorkspace.diffNotGit ? t("chat.sessionDiff.notGit") : undefined,
         onActivate: sessionWorkspace.onOpenDiff,
       });
     }

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -41,6 +41,7 @@ import type { ChatPageHost } from "./chat-state-host.ts";
 import { requestChatPageUpdate } from "./chat-state-render.ts";
 import { resolveChatAgentId, selectedChatSessionRow } from "./chat-state-route.ts";
 import { handleBackgroundTasksEvent } from "./components/chat-background-tasks.ts";
+import { refreshSessionWorkspace } from "./components/chat-session-workspace.ts";
 import { readChatSessionProjectionScope, reduceChatSessionProjection } from "./history-merge.ts";
 import {
   reconcileChatRunFromCurrentSessionRow,
@@ -473,6 +474,9 @@ export function handlePageGatewayEvent(state: ChatPageHost, event: GatewayEventF
     if (terminal) {
       removeDeliveredQueuedChatSendForRun(state, payload?.runId);
       void resumeStoredChatOutboxes(state);
+      if (chatScopedEventSessionMatches(state, payload?.sessionKey, payload?.agentId)) {
+        refreshSessionWorkspace(state);
+      }
     }
     requestChatPageUpdate(state, payload?.state === "delta" ? "animation-frame" : "immediate");
     return;

--- a/ui/src/pages/chat/components/chat-header-session-menu.test.ts
+++ b/ui/src/pages/chat/components/chat-header-session-menu.test.ts
@@ -190,7 +190,6 @@ describe("chat header session menu", () => {
           id: "changes",
           label: "Show session changes",
           icon: icons.fileDiff,
-          disabledReason: "This session's workspace is not a git checkout.",
           onActivate: showChanges,
         },
       ],
@@ -211,7 +210,6 @@ describe("chat header session menu", () => {
     expect(panelItems.map(itemLabel)).toEqual(["Show background tasks", "Show session changes"]);
     expect(panelItems[0]?.checked).toBe(false);
     expect(panelItems[0]?.querySelector('[slot="details"]')?.textContent?.trim()).toBe("2");
-    expect(panelItems[1]?.disabled).toBe(true);
     expect(
       Array.from(
         item(menu, "Layout").querySelectorAll<MenuItemElement>("wa-dropdown-item[slot='submenu']"),
@@ -222,7 +220,7 @@ describe("chat header session menu", () => {
     select(menu, "quick:panels:changes");
     select(menu, "quick:layout:split-right");
     expect(showTasks).toHaveBeenCalledOnce();
-    expect(showChanges).not.toHaveBeenCalled();
+    expect(showChanges).toHaveBeenCalledOnce();
     expect(splitRight).toHaveBeenCalledOnce();
   });
 

--- a/ui/src/pages/chat/components/chat-header-session-menu.ts
+++ b/ui/src/pages/chat/components/chat-header-session-menu.ts
@@ -22,7 +22,6 @@ export type HeaderMenuQuickAction = {
   icon: TemplateResult;
   active?: boolean;
   badge?: number;
-  disabledReason?: string;
   onActivate: () => void;
 };
 
@@ -65,7 +64,7 @@ class ChatHeaderSessionMenu extends OpenClawLightDomElement {
       const [, group, id] = value.split(":");
       const actions = group === "panels" ? this.panelActions : this.layoutActions;
       const action = actions.find((candidate) => candidate.id === id);
-      if (action && !action.disabledReason) {
+      if (action) {
         action.onActivate();
       }
       return;
@@ -134,8 +133,6 @@ class ChatHeaderSessionMenu extends OpenClawLightDomElement {
           value=${`quick:${group}:${action.id}`}
           type=${action.active === undefined ? nothing : "checkbox"}
           .checked=${action.active ?? false}
-          ?disabled=${Boolean(action.disabledReason)}
-          title=${action.disabledReason ?? nothing}
         >
           <span slot="icon" class="session-menu__icon" aria-hidden="true">${action.icon}</span>
           <span class="session-menu__text">${action.label}</span>

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -66,9 +66,8 @@ export type SessionWorkspaceProps = {
   onToggleTerminal?: () => void;
   onToggleBrowser?: () => void;
   onToggleCustodian?: () => void;
-  /** Opens the session diff panel; absent when the gateway lacks sessions.diff. */
+  /** Opens the session diff panel; absent until a usable checkout is known. */
   onOpenDiff?: () => void;
-  diffNotGit?: boolean;
 };
 
 type SessionWorkspaceState = {
@@ -375,12 +374,25 @@ function loadWorkspace(
         const reload = current.pendingReload;
         current.pendingReload = false;
         if (reload) {
-          loadWorkspace(state, current, true);
+          loadWorkspace(state, current);
         }
       }
       requestUpdate(state);
     }
   })();
+}
+
+/** Refresh workspace facts after a run, which may have created a git checkout. */
+export function refreshSessionWorkspace(state: SessionWorkspaceHost) {
+  const workspace = state.sessionWorkspaceState;
+  if (!workspace || workspace.sessionKey !== state.sessionKey) {
+    return;
+  }
+  if (workspace.loading) {
+    workspace.pendingReload = true;
+  } else {
+    loadWorkspace(state, workspace);
+  }
 }
 
 function beginOpenRequest(
@@ -755,6 +767,11 @@ export function createSessionWorkspaceProps(
   ) {
     loadWorkspace(state, workspace);
   }
+  const canOpenDiff =
+    isGatewayMethodAdvertised(state, "sessions.diff") === true &&
+    Boolean(state.client) &&
+    workspace.list?.sessionKey === state.sessionKey &&
+    workspace.list.gitCheckout !== false;
   return {
     collapsed: workspace.collapsed,
     sessionKey: state.sessionKey,
@@ -815,11 +832,9 @@ export function createSessionWorkspaceProps(
       state.connected && isGatewayMethodAdvertised(state, "openclaw.chat") === true
         ? () => window.dispatchEvent(new CustomEvent(CUSTODIAN_PANEL_TOGGLE_EVENT))
         : undefined,
-    diffNotGit: workspace.list?.gitCheckout === false,
-    onOpenDiff:
-      isGatewayMethodAdvertised(state, "sessions.diff") === true && state.client
-        ? () => state.handleOpenSidebar(buildSessionDiffSidebarContent(state))
-        : undefined,
+    onOpenDiff: canOpenDiff
+      ? () => state.handleOpenSidebar(buildSessionDiffSidebarContent(state))
+      : undefined,
   };
 }
 
@@ -913,8 +928,7 @@ export function renderSessionWorkspaceToggle(
   `;
 }
 
-/** Session diff button shown beside the workspace toggle; hidden when the
- * gateway does not advertise sessions.diff. */
+/** Session diff button shown beside the workspace toggle when available. */
 export function renderSessionDiffToggle(
   sessionWorkspace: SessionWorkspaceProps | undefined,
 ): TemplateResult | typeof nothing {
@@ -922,14 +936,12 @@ export function renderSessionDiffToggle(
     return nothing;
   }
   const label = t("chat.sessionDiff.show");
-  const tooltip = sessionWorkspace.diffNotGit ? t("chat.sessionDiff.notGit") : label;
   return html`
-    <openclaw-tooltip .content=${tooltip}>
+    <openclaw-tooltip .content=${label}>
       <button
         class="btn btn--ghost btn--icon chat-icon-btn chat-session-diff-toggle"
         type="button"
         aria-label=${label}
-        ?disabled=${sessionWorkspace.diffNotGit === true}
         @click=${sessionWorkspace.onOpenDiff}
       >
         ${icons.fileDiff}
@@ -993,16 +1005,11 @@ export function renderSessionWorkspaceRail(
     : nothing;
   const diffButton = sessionWorkspace.onOpenDiff
     ? html`
-        <openclaw-tooltip
-          .content=${sessionWorkspace.diffNotGit
-            ? t("chat.sessionDiff.notGit")
-            : t("chat.sessionDiff.show")}
-        >
+        <openclaw-tooltip .content=${t("chat.sessionDiff.show")}>
           <button
             type="button"
             class="chat-workspace-rail__terminal chat-session-diff-toggle"
             aria-label=${t("chat.sessionDiff.show")}
-            ?disabled=${sessionWorkspace.diffNotGit === true}
             @click=${sessionWorkspace.onOpenDiff}
           >
             ${icons.fileDiff}


### PR DESCRIPTION
Closes #122147

## What Problem This Solves

Fixes an issue where users opening a Control UI chat outside a Git checkout would see a disabled Session changes icon that could not provide a useful result.

## Why This Change Was Made

In this PR, the workspace capability owner omits every Session changes entry point when the live `sessions.files.list` result says `gitCheckout: false`. A terminal chat event refreshes that fact once per completed run, so an agent-created checkout such as `git init` makes the action appear without polling. Gateways that omit the newer field remain fail-open and keep the existing panel fallback.

This follows the existing header pattern: terminal, desktop, discussion, tasks, and split actions are conditionally present when their callbacks are available, and the header has no fixed-slot layout contract. It also removes the now-obsolete disabled quick-action seam.

## User Impact

Non-Git sessions no longer advertise an unusable diff action. If the same session becomes a Git checkout during a run, Session changes appears after that run completes.

## Evidence

### Before

The non-Git workspace shows a disabled diff glyph whose tooltip only explains that it cannot work.

![Before: disabled Session changes glyph in a non-Git workspace](https://github.com/user-attachments/assets/36f9c825-f603-40c7-a177-f618c97d0e65)

### After

In this PR, the unusable action is omitted while the rest of the header remains unchanged.

![After: Session changes glyph omitted in a non-Git workspace](https://github.com/user-attachments/assets/912b7382-3fbc-41e2-bd43-1d1bf86287d2)

### Validation

- Pre-fix browser regression: failed with one visible toggle where zero was expected.
- Focused Testbox proof: 3 session-diff E2E tests and 7 header-menu unit tests passed.
- The E2E proof covers `gitCheckout: false`, same-session transition to `true` after a terminal run, and the legacy `undefined` fallback.
- Path-scoped changed-file gate passed: formatting, i18n, dependency guards, dead exports, core/UI typechecks, and lint.
- Autoreview: clean, no actionable findings; TruffleHog clean.

Production delta is +7 lines. The net growth is the bounded terminal-run refresh needed to make the live Git capability reactive; connected disabled-state policy was removed. Tests are +6 net lines.
