### PR TITLE
fix(agents): treat observed CLI activity as replay-unsafe for whole-turn retries

### DIFF
--- a/src/auto-reply/reply/agent-runner-error-handler.ts
+++ b/src/auto-reply/reply/agent-runner-error-handler.ts
@@ -7,7 +7,7 @@ import {
 } from "../../agents/embedded-agent-helpers.js";
 import { sanitizeUserFacingText } from "../../agents/embedded-agent-helpers/sanitize-user-facing-text.js";
 import { renderUserFacingText } from "../../agents/embedded-agent-helpers/user-facing-text.js";
-import { isFailoverError } from "../../agents/failover-error.js";
+import { findCliTimeoutError, isFailoverError } from "../../agents/failover-error.js";
 import {
   GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
   HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT,
@@ -262,6 +262,11 @@ export async function handleAgentExecutionError(params: {
         }),
       }),
     };
+  }
+  // The CLI boundary records this fact even when phase callbacks do not arrive.
+  // Replaying an observed turn may duplicate already-started side effects.
+  if (findCliTimeoutError(err)?.cliTimeout.observedActivity === true) {
+    markOverloadRetryUnsafeToReplay(params.overloadRetryState);
   }
   if (
     isOverloaded &&

--- a/src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
@@ -529,9 +529,9 @@ describe("executeAgentTurn: provider failures", () => {
     },
   );
 
-  it("currently retries a CLI timeout whose recorded activity has no execution phase mark", async () => {
+  it("does not retry a CLI timeout whose recorded activity has no execution phase mark", async () => {
     vi.useFakeTimers();
-    // BUG(refactor-02b): replay guard ignores recorded cliTimeout.observedActivity; fixed in B2
+    // FIXED(refactor-02b): the typed CLI activity fact blocks whole-turn replay without a phase mark.
     const timeoutError = new FailoverError("CLI exceeded timeout (600s) and was terminated.", {
       reason: "timeout",
       provider: "claude-cli",
@@ -561,16 +561,16 @@ describe("executeAgentTurn: provider failures", () => {
     await vi.advanceTimersByTimeAsync(2_500);
     const result = await resultPromise;
 
-    expect(state.runCliAgentMock).toHaveBeenCalledTimes(2);
-    expect(state.runWithModelFallbackMock).toHaveBeenCalledTimes(2);
+    expect(state.runCliAgentMock).toHaveBeenCalledTimes(1);
+    expect(state.runWithModelFallbackMock).toHaveBeenCalledTimes(1);
     expect(state.runEmbeddedAgentMock).not.toHaveBeenCalled();
     const wholeTurnRetries = state.runCliAgentMock.mock.calls.length - 1;
-    expect(wholeTurnRetries).toBe(1);
+    expect(wholeTurnRetries).toBe(0);
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
       expect(result.payload.text).toContain("overall turn limit");
       expect(result.payload.text).toMatch(/effects may be partial/i);
-      expect(result.payload.text).not.toContain("did not replay this turn automatically");
+      expect(result.payload.text).toContain("did not replay this turn automatically");
     }
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a CLI-backed agent turn that timed out after observable activity could be replayed automatically when no execution phase mark arrived, potentially duplicating side effects.

## Why This Change Was Made

The reply layer now consumes the typed `cliTimeout.observedActivity` fact recorded at the CLI boundary and marks the shared whole-turn retry state unsafe. Both outer retry gates—overload recovery and the one-shot transient retry—already consume that state; active-tool and background-task counts remain diagnostic only.

The only phase-mark consumer for these whole-turn gates is the shared execution-phase callback. Model-candidate fallback uses a separate delivery-evidence decision and does not consult this phase-mark state, so it is not part of this frozen outer-retry behavior change.

## User Impact

CLI timeouts after observed activity now surface the existing partial-effects guidance without replaying the whole turn. Release-note context: prevents duplicate side effects after CLI timeouts.

## Evidence

- Red regression before the production change: scenario 9 expected one CLI invocation but observed two; the other 74 provider-failure cases passed.
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts` — 75 passed.
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution-terminal-failures.test.ts` — 20 passed.
- `node scripts/check-changed.mjs` — passed the `core` and `coreTests` lanes via its documented local fallback.
- Targeted `oxfmt --check` and `git diff --check` — passed.
- Autoreview — clean, no accepted/actionable findings.
- Exact-head CI for `092f1c35b2ad636c23cdc35a36b325a28f3f91b7` — green: https://github.com/openclaw/openclaw/actions/runs/31514961935
- Exact-head CodeQL — green on retry after an infrastructure-only certificate failure while downloading the CodeQL bundle: https://github.com/openclaw/openclaw/actions/runs/31514961908

The requested directory-wide `src/auto-reply` run was attempted locally, but the shared host produced unrelated multi-minute timeouts and cross-suite state fallout; that run was stopped after 30 minutes and is not claimed as proof. Exact-head PR CI is green and is the canonical isolated broad validation.
