### PR TITLE
fix(browser): shared tabs disappear after relay reconnect

### DIFF
--- a/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
@@ -561,6 +561,43 @@ describe("ExtensionRelayBridge", () => {
     });
   });
 
+  it("replaces an in-flight attach when the extension reconnects", async () => {
+    const bridge = new ExtensionRelayBridge();
+    const tabs = defaultTabs();
+    const firstSocket = new FakeSocket();
+    const first = bridge.attachExtensionSocket(firstSocket);
+    sendHello(first, tabs);
+
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+    cdp.onMessage(
+      JSON.stringify({ id: 1, method: "Target.setAutoAttach", params: { autoAttach: true } }),
+    );
+    await flush();
+    expect(firstSocket.frames().filter((frame) => frame.type === "attach")).toHaveLength(1);
+
+    first.onClose();
+    const replacement = wireExtension(bridge);
+    sendHello(replacement.handlers, tabs);
+    await flush();
+
+    expect(
+      replacement.socket
+        .frames()
+        .filter((frame) => frame.type === "attach")
+        .map((frame) => frame.tabId),
+    ).toEqual([1]);
+    expect(
+      client.frames().filter((frame) => frame.method === "Target.attachedToTarget"),
+    ).toHaveLength(1);
+
+    cdp.onMessage(JSON.stringify({ id: 2, method: "Target.getTargets" }));
+    await flush();
+    expect(client.frames().find((frame) => frame.id === 2)?.result).toMatchObject({
+      targetInfos: [{ targetId: "target-1" }],
+    });
+  });
+
   it("reports malformed CDP client JSON instead of leaving the client waiting", () => {
     const bridge = new ExtensionRelayBridge();
     const client = new FakeSocket();

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
@@ -511,6 +511,56 @@ describe("ExtensionRelayBridge", () => {
     expect(bridge.extensionConnected).toBe(false);
   });
 
+  it("reattaches unchanged accessible tabs after the extension reconnects", async () => {
+    const bridge = new ExtensionRelayBridge();
+    const tabs = defaultTabs();
+    const first = wireExtension(bridge);
+    sendHello(first.handlers, tabs);
+
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+    cdp.onMessage(
+      JSON.stringify({ id: 1, method: "Target.setAutoAttach", params: { autoAttach: true } }),
+    );
+    await flush();
+    expect(
+      client.frames().filter((frame) => frame.method === "Target.attachedToTarget"),
+    ).toHaveLength(1);
+
+    first.handlers.onClose();
+    expect(bridge.accessibleTabs()).toEqual(tabs);
+    expect(
+      client.frames().filter((frame) => frame.method === "Target.detachedFromTarget"),
+    ).toHaveLength(1);
+
+    const replacement = wireExtension(bridge);
+    sendHello(replacement.handlers, tabs);
+    await flush();
+
+    expect(
+      replacement.socket
+        .frames()
+        .filter((frame) => frame.type === "attach")
+        .map((frame) => frame.tabId),
+    ).toEqual([1]);
+    const attached = client.frames().filter((frame) => frame.method === "Target.attachedToTarget");
+    expect(attached).toHaveLength(2);
+    expect(
+      attached.map(
+        (frame) => (frame.params as { targetInfo: { targetId: string } }).targetInfo.targetId,
+      ),
+    ).toEqual(["target-1", "target-1"]);
+    expect(
+      new Set(attached.map((frame) => (frame.params as { sessionId: string }).sessionId)).size,
+    ).toBe(2);
+
+    cdp.onMessage(JSON.stringify({ id: 2, method: "Target.getTargets" }));
+    await flush();
+    expect(client.frames().find((frame) => frame.id === 2)?.result).toMatchObject({
+      targetInfos: [{ targetId: "target-1" }],
+    });
+  });
+
   it("reports malformed CDP client JSON instead of leaving the client waiting", () => {
     const bridge = new ExtensionRelayBridge();
     const client = new FakeSocket();

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -288,6 +288,7 @@ export class ExtensionRelayBridge {
     // Tell CDP clients their pages are gone; the tab list itself survives so a
     // reconnecting extension can re-expose the same tabs.
     for (const [tabId, tab] of this.tabs) {
+      tab.attaching = undefined;
       if (tab.attached) {
         this.emitDetachedFromTarget(tabId, tab.attached.sessionId, tab.attached.targetId);
         tab.attached = undefined;
@@ -419,7 +420,9 @@ export class ExtensionRelayBridge {
     try {
       return await attaching;
     } finally {
-      tab.attaching = undefined;
+      if (tab.attaching === attaching) {
+        tab.attaching = undefined;
+      }
     }
   }
 

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -370,17 +370,17 @@ export class ExtensionRelayBridge {
         existing.info = info;
       } else {
         this.tabs.set(info.tabId, { info });
-        // Newly accessible tabs must reach auto-attach clients immediately;
-        // an access-mode or pause change may happen mid-session.
-        if ([...this.clients].some((client) => client.autoAttach)) {
-          void this.ensureTabAttached(info.tabId)
-            .then(({ targetId, sessionId }) => {
-              this.announceAttachedTab(info.tabId, targetId, sessionId, { onlyAutoAttach: true });
-            })
-            .catch((err: unknown) => {
-              log.warn(`auto-attach of accessible tab ${info.tabId} failed: ${String(err)}`);
-            });
-        }
+      }
+      // Accessible tabs must reach auto-attach clients immediately, including
+      // unchanged tab ids reported after the extension reconnects.
+      if ([...this.clients].some((client) => client.autoAttach)) {
+        void this.ensureTabAttached(info.tabId)
+          .then(({ targetId, sessionId }) => {
+            this.announceAttachedTab(info.tabId, targetId, sessionId, { onlyAutoAttach: true });
+          })
+          .catch((err: unknown) => {
+            log.warn(`auto-attach of accessible tab ${info.tabId} failed: ${String(err)}`);
+          });
       }
     }
   }


### PR DESCRIPTION
Closes #122121

AI-assisted: yes.

## What Problem This Solves

Fixes an issue where users sharing an existing Chrome tab with OpenClaw could see that tab disappear from the controllable browser inventory when the extension relay reconnected without changing the tab ID. It also closes the race where a relay disconnect during an in-flight attach left the replacement connection waiting on a stale rejected promise.

## Why This Change Was Made

Every authoritative tab snapshot from the extension now passes through the existing coalesced attach path, including tabs whose IDs were already known before the reconnect. When the extension disconnects, the bridge invalidates the old in-flight attachment state. Each attach attempt clears only its own promise, so cleanup from the rejected old connection cannot erase a newer replacement attach.

This preserves the existing attachment lifecycle and intentionally does not add retries from detached state outside an authoritative extension snapshot.

## User Impact

Shared Chrome tabs can become controllable again automatically after an extension relay reconnect, including when the previous connection dropped while attachment was still pending. Users no longer need the tab ID to change or to reshare the tab to recover from this state.

## Evidence

- Current PR head: `228be20654bddce26527abb392c90adf8f3d9fb0`.
- Added a regression that disconnects the original extension socket while its attach request is pending, reconnects with the same accessible tab ID, and verifies that the replacement socket receives a fresh attach, emits `Target.attachedToTarget`, and exposes the tab through `Target.getTargets`. It failed before the lifecycle fix (`expected [1], received []`) and passes after it.
- Exact-head focused suite: `node scripts/run-vitest.mjs extensions/browser/src/browser/extension-relay/relay-bridge.test.ts` — 26/26 passed locally. The same 26 tests also passed in GitHub CI.
- Exact-head build provenance: a full `pnpm build` completed successfully; `dist/.buildstamp`, `dist/.runtime-postbuildstamp`, and `dist/build-info.json` all recorded `228be20654bddce26527abb392c90adf8f3d9fb0` (`OpenClaw 2026.8.1 (228be20)`).
- Exact-head real behavior proof on Windows with the actual paired Chrome extension:
  1. Launched the built candidate Gateway from `228be206` with isolated temporary state/config while preserving the installed operator Gateway.
  2. Opened only `https://example.com/`, set an in-page marker, and recorded a redacted SHA-256 target alias `07ac94817744`.
  3. Reloaded the real OpenClaw extension, producing a relay disconnect/reconnect against the still-running candidate Gateway.
  4. After reconnect, `cdpReady` returned `true`, exactly one `example.com` target reappeared, its alias remained `07ac94817744`, and evaluation on that target confirmed the marker was still present (`sameTarget=true`, `markerPreserved=true`).
  5. Stopped only the candidate process, restored the installed Gateway (`2026.7.1-2`) with healthy RPC/CDP, and closed the neutral test tab.
- Pre-commit review: TruffleHog found no verified or unknown credentials; repository autoreview reported no accepted/actionable findings and rated the patch correct at 0.99 confidence.

GitHub CI for exact PR head `228be20654bddce26527abb392c90adf8f3d9fb0`: [run 31702031172](https://github.com/openclaw/openclaw/actions/runs/31702031172) completed with 52 successful jobs, 16 skipped jobs, and two failures. The substantive failure is `checks-node-changed-extensions-config`; `openclaw/ci-gate` fails downstream because of it. That extension shard passed 2,506 tests, including all 26 relay-bridge tests, and failed 9 tests in three untouched files. Those three files are byte-identical on the PR head and the tested `upstream/main` base. Two failures are deterministic expectation drift: the tests expect `setFiles(paths)` while the current implementation calls `setFiles(paths, { timeout: 120000 })`. The remaining failures are likewise outside this two-file relay patch. No relay test failed.
