### PR TITLE
fix(ui): align selector menu checks to the right

### DIFF
--- a/ui/src/components/menu-check-alignment.browser.test.ts
+++ b/ui/src/components/menu-check-alignment.browser.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it } from "vitest";
+import "../styles.css";
+import "../styles/cron.css";
+import "../styles/usage.css";
+import "./web-awesome.ts";
+
+const hasBrowserLayout = !navigator.userAgent.toLowerCase().includes("jsdom");
+
+type DropdownItemElement = HTMLElement & {
+  checked: boolean;
+  type: "checkbox" | "normal";
+  updateComplete: Promise<boolean>;
+};
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+function createMenuItem(label: string, checkbox: boolean, checked = false) {
+  const item = document.createElement("wa-dropdown-item") as DropdownItemElement;
+  item.type = checkbox ? "checkbox" : "normal";
+  item.checked = checked;
+  item.setAttribute("checkbox-adjacent", "");
+  const icon = document.createElement("span");
+  icon.slot = "icon";
+  icon.textContent = "#";
+  item.append(icon, label);
+  return item;
+}
+
+function partBounds(item: DropdownItemElement, part: string): DOMRect {
+  const element = item.shadowRoot?.querySelector<HTMLElement>(`[part="${part}"]`);
+  expect(element, `${part} part should exist`).not.toBeNull();
+  return element!.getBoundingClientRect();
+}
+
+describe.skipIf(!hasBrowserLayout)("menu selection check alignment", () => {
+  it("keeps the icon column flush left and selection checks in the trailing rail", async () => {
+    const menu = document.createElement("div");
+    menu.style.width = "240px";
+    const selected = createMenuItem("Selected", true, true);
+    const unselected = createMenuItem("Unselected", true);
+    const command = createMenuItem("Command", false);
+    const usageSelected = createMenuItem("Usage selected", true, true);
+    selected.className = "cron-filter-dropdown__option";
+    unselected.className = "cron-filter-dropdown__option";
+    command.className = "cron-filter-dropdown__option";
+    usageSelected.className = "usage-filter-option";
+    menu.append(selected, unselected, command, usageSelected);
+    document.body.append(menu);
+    await Promise.all([
+      selected.updateComplete,
+      unselected.updateComplete,
+      command.updateComplete,
+      usageSelected.updateComplete,
+    ]);
+
+    expect(selected.hasAttribute("checkbox-adjacent")).toBe(true);
+    expect(unselected.hasAttribute("checkbox-adjacent")).toBe(true);
+    expect(command.hasAttribute("checkbox-adjacent")).toBe(true);
+
+    const selectedCheck = partBounds(selected, "checkmark");
+    const selectedLabel = partBounds(selected, "label");
+    expect(selectedCheck.width).toBeGreaterThan(0);
+    expect(selectedLabel.width).toBeGreaterThan(0);
+    expect(selectedCheck.left).toBeGreaterThanOrEqual(selectedLabel.right);
+    expect(Math.abs(selectedCheck.top - selectedLabel.top)).toBeLessThanOrEqual(2);
+
+    const unselectedCheck = partBounds(unselected, "checkmark");
+    const unselectedLabel = partBounds(unselected, "label");
+    expect(unselectedCheck.left).toBeGreaterThanOrEqual(unselectedLabel.right);
+
+    const usageCheck = partBounds(usageSelected, "checkmark");
+    const usageLabel = partBounds(usageSelected, "label");
+    expect(usageCheck.left).toBeGreaterThanOrEqual(usageLabel.right);
+
+    const iconStarts = [selected, unselected, command].map((item) => partBounds(item, "icon").left);
+    expect(Math.max(...iconStarts) - Math.min(...iconStarts)).toBeLessThanOrEqual(1);
+  });
+});

--- a/ui/src/pages/new-session/cloud-target.ts
+++ b/ui/src/pages/new-session/cloud-target.ts
@@ -37,14 +37,14 @@ export function renderSessionMenuItem(params: SessionMenuItemOptions, submitting
       ?disabled=${submitting || (params.disabled ?? false)}
       @click=${params.onSelect}
     >
-      <span class="session-menu__check" aria-hidden="true"
-        >${params.checked ? icons.check : nothing}</span
-      >
       ${params.icon
         ? html`<span class="session-menu__icon" aria-hidden="true">${params.icon}</span>`
         : nothing}
       <span class="session-menu__text">${params.label}</span>
       ${params.sub ? html`<span class="session-menu__sub">${params.sub}</span>` : nothing}
+      <span class="session-menu__check" aria-hidden="true"
+        >${params.checked ? icons.check : nothing}</span
+      >
     </button>
   `;
 }

--- a/ui/src/pages/new-session/place-picker.ts
+++ b/ui/src/pages/new-session/place-picker.ts
@@ -398,7 +398,6 @@ export function renderPlaceSelect(params: {
                 ?disabled=${params.submitting || params.pendingCloud || !params.browseAvailable}
                 @click=${() => params.onBrowse(browseTarget)}
               >
-                <span class="session-menu__check" aria-hidden="true"></span>
                 <span class="session-menu__text">${t("newSession.browse")}</span>
                 <span class="new-session-page__menu-chevron" aria-hidden="true"
                   >${icons.chevronRight}</span

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -799,6 +799,21 @@ wa-dropdown-item[disabled] {
   cursor: not-allowed;
 }
 
+/* Keep Web Awesome's checkbox rail trailing so it cannot shift menu icons and labels. */
+wa-dropdown-item[checkbox-adjacent] {
+  padding-inline-start: 1em;
+}
+
+wa-dropdown-item[type="checkbox"]::part(checkmark) {
+  order: 1;
+  margin-inline: 0.75em 0;
+}
+
+wa-dropdown-item[type="checkbox"] {
+  display: flex;
+  align-items: center;
+}
+
 button,
 input,
 textarea,

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2512,8 +2512,8 @@ wa-dropdown.sidebar-customize-menu::part(menu) {
 }
 
 .sidebar-customize-menu__group-title {
-  margin: 6px 4px 2px;
-  padding: 7px 6px 4px;
+  margin: 6px 0 2px;
+  padding: 7px 8px 4px;
   border-top: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
   color: var(--muted);
   font-size: calc(10px * var(--control-ui-text-scale));
@@ -2567,20 +2567,6 @@ wa-dropdown-item.sidebar-customize-menu__item {
   width: 100%;
   color: inherit;
   text-decoration: none;
-}
-
-/* Pin-editor rows: wa-dropdown flags every row [checkbox-adjacent] when the menu
-   holds checkbox items and tucks the shadow checkmark into a 2em start inset via
-   a -1.5em margin. Our compact `padding: 0 8px` above removes that inset, so
-   rebuild the check column here or the checkmark lands outside the row edge. */
-.sidebar-pin-editor-menu .sidebar-customize-menu__item[checkbox-adjacent] {
-  padding-inline-start: 30px; /* 8px edge + 14px check column + 8px gutter */
-}
-
-.sidebar-pin-editor-menu .sidebar-customize-menu__item::part(checkmark) {
-  width: 14px;
-  min-width: 14px;
-  margin-inline: -22px 8px; /* pull back into the padding; the end margin spaces the icon */
 }
 
 /* The agent switcher marks its selection in the trailing details rail


### PR DESCRIPTION
Closes #122156

## What Problem This Solves

Fixes an issue where users opening Control UI selector menus would see selected-row checks in a leading column before icons or labels. The leading rail also shifted mixed rows in **Edit pinned items**, leaving route icons, WorkBoard rows, section text, and **Reset pinned items** on inconsistent columns.

## Why This Change Was Made

This PR applies the trailing-affordance pattern established in #121383 at the shared Web Awesome dropdown-item boundary: checkbox rows use one flex row, the dependency's leading adjacency inset is neutralized, and the native check part moves after label/details. The custom New Session picker reuses the existing `.session-menu__check` trailing rail.

The pinned menu's duplicate leading-check workaround is removed. Its icon/label column now stays fixed across selected and unselected route rows, WorkBoard rows, **Default board**, and **Reset pinned items**; the WorkBoard section inset now matches the menu's shared 8px content edge.

Production LOC delta: **0** (`+20/-20`). Test coverage adds 80 lines.

## User Impact

In this PR, selection checks appear at the right edge across all 15 rendered selector menus. Icons and labels stay flush left regardless of selection, and the pinned-items menu presents one clean column system in light and dark themes.

## Evidence

All screenshots are light-theme, tight crops captured from the mocked-Gateway Control UI harness. The shared stylesheet rule also applies under dark theme tokens without color-specific overrides.

| Occurrence | Before | After |
| --- | --- | --- |
| Edit pinned items — routes + WorkBoard | ![Before: Edit pinned items](https://robust-unity-7v9k.here.now/before/pinned-items.png) | ![After: Edit pinned items](https://robust-unity-7v9k.here.now/after/pinned-items.png) |
| Agent selector | ![Before: Agent selector](https://robust-unity-7v9k.here.now/before/agent-select.png) | ![After: Agent selector](https://robust-unity-7v9k.here.now/after/agent-select.png) |
| Model-provider selector | ![Before: Model-provider selector](https://robust-unity-7v9k.here.now/before/model-provider.png) | ![After: Model-provider selector](https://robust-unity-7v9k.here.now/after/model-provider.png) |
| Board widget — Auto height | ![Before: Board widget](https://robust-unity-7v9k.here.now/before/board-widget.png) | ![After: Board widget](https://robust-unity-7v9k.here.now/after/board-widget.png) |
| Session board dock | ![Before: Board dock](https://robust-unity-7v9k.here.now/before/board-dock.png) | ![After: Board dock](https://robust-unity-7v9k.here.now/after/board-dock.png) |
| Usage — Channel | ![Before: Usage Channel](https://robust-unity-7v9k.here.now/before/usage-channel-filter.png) | ![After: Usage Channel](https://robust-unity-7v9k.here.now/after/usage-channel-filter.png) |
| Usage — Provider | ![Before: Usage Provider](https://robust-unity-7v9k.here.now/before/usage-provider-filter.png) | ![After: Usage Provider](https://robust-unity-7v9k.here.now/after/usage-provider-filter.png) |
| Usage — Model | ![Before: Usage Model](https://robust-unity-7v9k.here.now/before/usage-model-filter.png) | ![After: Usage Model](https://robust-unity-7v9k.here.now/after/usage-model-filter.png) |
| Usage — Tool | ![Before: Usage Tool](https://robust-unity-7v9k.here.now/before/usage-tool-filter.png) | ![After: Usage Tool](https://robust-unity-7v9k.here.now/after/usage-tool-filter.png) |
| Cron — Status | ![Before: Cron Status](https://robust-unity-7v9k.here.now/before/cron-status-filter.png) | ![After: Cron Status](https://robust-unity-7v9k.here.now/after/cron-status-filter.png) |
| Cron — Delivery | ![Before: Cron Delivery](https://robust-unity-7v9k.here.now/before/cron-delivery-filter.png) | ![After: Cron Delivery](https://robust-unity-7v9k.here.now/after/cron-delivery-filter.png) |
| Composer Plus — Web search | ![Before: Composer Web search](https://robust-unity-7v9k.here.now/before/composer-web-search.png) | ![After: Composer Web search](https://robust-unity-7v9k.here.now/after/composer-web-search.png) |
| Session header — Panels | ![Before: Session Panels](https://robust-unity-7v9k.here.now/before/session-panels.png) | ![After: Session Panels](https://robust-unity-7v9k.here.now/after/session-panels.png) |
| Session header — View | ![Before: Session View](https://robust-unity-7v9k.here.now/before/session-view.png) | ![After: Session View](https://robust-unity-7v9k.here.now/after/session-view.png) |
| New Session place picker | ![Before: New Session place](https://robust-unity-7v9k.here.now/before/new-session-place.png) | ![After: New Session place](https://robust-unity-7v9k.here.now/after/new-session-place.png) |

### Verification

- Chromium geometry regression: the added test fails on the old behavior (`check x=10`, label right edge `x=226`) and passes with the check trailing plus stable icon starts.
- `cd ui && node ../scripts/run-vitest.mjs run --config vitest.config.ts --project chromium src/components/menu-check-alignment.browser.test.ts`
- `node scripts/run-vitest.mjs ui/src/pages/new-session/cloud-target.test.ts ui/src/pages/chat/components/chat-header-session-menu.test.ts`
- Focused mocked-Gateway E2Es passed for pinned-route persistence, Cron history filters, and New Session place selection.
- `git diff --check origin/main...HEAD`

The shared owner covers native Web Awesome checkbox rows. Already-correct menus with custom trailing checks (session grouping/sort, agent switcher, model/reasoning pickers, microphone, gateway, sharing, and branch selectors) remain unchanged.
