### PR TITLE
fix(compaction): recover overflow from sparse assistant history

### DIFF
--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -243,6 +243,27 @@ describe("calculateContextTokens", () => {
     });
     expect(estimateContextTokens(messages).trailingTokens).toBeGreaterThan(0);
   });
+
+  it("scans past a sparse assistant row to retain older valid usage", () => {
+    const validUsage = createUsage(20);
+    const sparseAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "seeded without provider usage" }],
+      api: "test-api",
+      provider: "test-provider",
+      model: "test-model",
+      stopReason: "stop",
+      timestamp: 2,
+    } as AgentMessage;
+    const messages = [createAssistant("complete", validUsage, 1), sparseAssistant];
+
+    expect(getLastAssistantUsage(messages.map(createMessageEntry))).toBe(validUsage);
+    expect(estimateContextTokens(messages)).toMatchObject({
+      usageTokens: 20,
+      lastUsageIndex: 0,
+    });
+    expect(estimateContextTokens(messages).trailingTokens).toBeGreaterThan(0);
+  });
 });
 
 describe("session-entry compaction budgeting", () => {

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -128,13 +128,17 @@ function isUnavailableContextBarrier(message: AgentMessage): boolean {
   if (message.role !== "assistant") {
     return false;
   }
-  if (message.api === "cli" && message.usage.contextUsage === undefined) {
-    return true;
-  }
-  if (message.usage.contextUsage?.state !== "unavailable") {
+  const usage = "usage" in message ? message.usage : undefined;
+  if (!usage) {
     return false;
   }
-  return calculateContextTokens(message.usage) === 0;
+  if (message.api === "cli" && usage.contextUsage === undefined) {
+    return true;
+  }
+  if (usage.contextUsage?.state !== "unavailable") {
+    return false;
+  }
+  return calculateContextTokens(usage) === 0;
 }
 
 /** Return usage from the last valid assistant message in session entries. */


### PR DESCRIPTION
Related: #121867

## What Problem This Solves

Fixes an issue where overflow recovery could crash instead of compacting when persisted or seeded assistant history contained a row without provider usage metadata.

The failure was reproduced in the exact-SHA qualification for `1383144b027a6b10c746636687182064d24b3bf9`: candidate, baseline, and runtime-pair QA all failed `compaction-retry-mutating-tool` after auto-compaction threw `Cannot read properties of undefined (reading 'contextUsage')`.

Qualification: https://github.com/openclaw/openclaw/actions/runs/31512918029

## Why This Change Was Made

The compaction usage classifier now treats an assistant row with no usage block as sparse history and continues scanning for the preceding valid usage snapshot. Deliberate zero/unavailable context markers and legacy CLI barriers keep their existing invalidation behavior.

This is the focused mainline extraction of the compaction repair authored by @steipete in `4726adbc6339567679895a5d3d530b4ba6602eff`; the earlier combined release repair landed only on a release-integration branch in #121867.

## User Impact

Long-running agents can recover from context overflow when history contains sparse assistant rows instead of terminating the run with an internal compaction error.

## Evidence

- Current-main regression before the repair: focused test failed at `isUnavailableContextBarrier` with `undefined.contextUsage`.
- Focused AgentCore compaction test: 32/32 passed after the repair.
- AgentCore compaction sibling suite: 61/61 passed.
- Existing zero/unavailable and legacy CLI barrier tests remain green.
- Exact-head Blacksmith Testbox `pnpm check:changed`: passed.
- Prior product-equivalent head Blacksmith Testbox private-QA build: passed; the final head only removes the release-owned changelog entry.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/31521475716
- Exact-head `compaction-retry-mutating-tool` no longer crashes: auto-compaction succeeded, the retry performed one write, and the terminal reply completed. The scenario then reported a harness-only assertion failure because its current causal check also includes successful preflight `compaction-summary` requests that occur before the injected overflow; no QA harness changes are included in this focused product repair.
- Exact-head local ClawSweeper fallback: complete with high confidence; patch correct; no findings, security concerns, maintainer decision, or rank-up moves.
- `git diff --check`, privacy scan, and targeted `oxfmt`: passed.
- Production: +7/-3; tests: +21/-0.



