### PR TITLE
fix(test): keep CLI process suites in owner lane

### DIFF
--- a/test/vitest-scoped-config.test.ts
+++ b/test/vitest-scoped-config.test.ts
@@ -610,9 +610,13 @@ describe("scoped vitest configs", () => {
     expect(requireTestConfig(defaultCliConfig).exclude).toEqual(
       expect.arrayContaining(cliProcessTestFiles.map((file) => file.replace("src/cli/", ""))),
     );
-    expect(requireTestConfig(defaultCliProcessConfig).include).toEqual(cliProcessTestFiles);
-    expect(requireTestConfig(defaultCliProcessConfig).fileParallelism).toBe(false);
-    expect(requireTestConfig(defaultCliProcessConfig).env).toMatchObject({
+    const processTestConfig = requireTestConfig(defaultCliProcessConfig);
+    expect(processTestConfig.include).toEqual(cliProcessTestFiles);
+    for (const file of cliProcessTestFiles) {
+      expect(matchingExcludePatterns(processTestConfig.exclude ?? [], file), file).toEqual([]);
+    }
+    expect(processTestConfig.fileParallelism).toBe(false);
+    expect(processTestConfig.env).toMatchObject({
       ESBUILD_WORKER_THREADS: "0",
     });
   });

--- a/test/vitest-unit-fast-config.test.ts
+++ b/test/vitest-unit-fast-config.test.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { beforeAll, describe, expect, it } from "vitest";
 import { spawnNodeEvalSync } from "../src/test-utils/node-process.js";
+import { cliProcessTestFiles } from "./vitest/vitest.cli-process-paths.mjs";
 import { createCommandsLightVitestConfig } from "./vitest/vitest.commands-light.config.ts";
 import { createPluginSdkLightVitestConfig } from "./vitest/vitest.plugin-sdk-light.config.ts";
 import { createUnitFastFakeTimersVitestConfig } from "./vitest/vitest.unit-fast-fake-timers.config.ts";
@@ -215,6 +216,13 @@ describe("unit-fast vitest lane", () => {
       "vitest-mock-api",
       "dynamic-import",
     ]);
+  });
+
+  it("keeps process-launching CLI files in their owner lane", () => {
+    for (const file of cliProcessTestFiles) {
+      expect(isUnitFastTestFile(file), file).toBe(false);
+      expect(unitFastTestFiles, file).not.toContain(file);
+    }
   });
 
   it("routes unit-fast source files to their unit-fast sibling tests", () => {

--- a/test/vitest/vitest.unit-fast-paths.mjs
+++ b/test/vitest/vitest.unit-fast-paths.mjs
@@ -2,6 +2,7 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { cliProcessTestFiles } from "./vitest.cli-process-paths.mjs";
 import {
   commandsLightSourceFiles,
   commandsLightTestFiles,
@@ -165,6 +166,7 @@ const broadUnitFastCandidateGlobs = [
   "test/**/*.test.ts",
 ];
 const ownerRoutedUnitTestPatterns = [
+  ...cliProcessTestFiles,
   "src/agents/embedded-agent-runner/run/attempt.abort-race.test.ts",
   "src/agents/openai-transport-stream.*.test.ts",
   "src/agents/embedded-agent-runner/run.shared-integration.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where full release validation could run process-launching CLI tests in the shared unit-fast shard, causing ACP child startup to contend with hundreds of unrelated tests and hit its 30-second deadline.

Qualification evidence: https://github.com/openclaw/openclaw/actions/runs/31511770565/job/93847393957

## Why This Change Was Made

The dedicated `cli-process` project already owns these serial isolated tests, but content-based unit-fast discovery could reclaim them. This routes the canonical `cliProcessTestFiles` inventory through the existing owner-routed exclusion and adds invariants for both sides of the boundary.

No product behavior, planner behavior, or timeout values change.

## User Impact

Maintainers get deterministic ACP CLI process coverage in its intended isolated lane instead of release validation failures caused by shared-shard contention. There is no runtime user-facing change.

Production LOC: +0/-0 | Test and test infrastructure: +17/-3

## Evidence

- Regression proof before the fix: `test/vitest-unit-fast-config.test.ts` reported `src/cli/acp-cli-exit.process.test.ts` as unit-fast.
- `node scripts/run-vitest.mjs test/vitest-unit-fast-config.test.ts test/vitest-scoped-config.test.ts` - 111 tests passed.
- `node scripts/run-vitest.mjs src/cli/acp-cli-exit.process.test.ts` - 5 tests passed through `vitest.cli-process.config.ts`.
- Blacksmith Testbox changed gates passed: https://github.com/openclaw/openclaw/actions/runs/31515849625
- Exact-head PR CI passed at `63bd83dba35067f27365228b9d12186f3d6330a5`: https://github.com/openclaw/openclaw/actions/runs/31517308897
- `git diff --check` passed; targeted `oxfmt` passed.
