### PR TITLE
fix(update): avoid duplicate configured plugin installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Updater plugin convergence:** keep pre-plugin doctor passes from installing configured plugins before the updater's plugin sweep, while preserving the final post-plugin migration pass and preventing ambient update-phase state from leaking into fresh doctor processes.
 - **Control UI browser tab identity:** keep selected tab styling, accessibility, focus, address, and page snapshot aligned across in-place navigation and tab reordering. Fixes #120745. Thanks @shakkernerd.
 - **Control UI staged attachments:** preserve unsent images, files, pasted images, and large pasted text across same-tab route and narrow split-pane remounts while keeping pane close, mismatched pane/session/Gateway remounts, application shutdown, and hard reload as cleanup boundaries. Fixes #121519. Thanks @shakkernerd.
 - **Control UI browser annotations:** keep marked screenshots and generated page context together in structured composer cards, preserve user-written drafts when annotations are removed or replaced, retain complete unsent annotation packages across same-tab route and active split-pane remounts, and offer bounded Undo without restoring removed context into another session. Fixes #120744. Thanks @shakkernerd.

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -2500,7 +2500,7 @@ describe("update-cli", () => {
   });
 
   it("post-core resume mode skips the core update and only runs post-update tasks", async () => {
-    await runPostCoreCommand({ restart: false });
+    await runPostCoreCommand({ restart: false }, { OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1" });
 
     expect(runGatewayUpdate).not.toHaveBeenCalled();
     const installCall = (
@@ -2523,6 +2523,21 @@ describe("update-cli", () => {
         ([, args]) => args[0] === FRESH_POST_UPDATE_ENTRYPOINT && args[1] === "doctor",
       );
     expect(freshDoctorCall).toBeDefined();
+    expect(freshDoctorCall?.[2]).toMatchObject({
+      env: {
+        OPENCLAW_UPDATE_IN_PROGRESS: "1",
+        OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR: "1",
+        OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: "1",
+      },
+    });
+    expect(
+      (freshDoctorCall?.[2] as { env?: NodeJS.ProcessEnv } | undefined)?.env
+        ?.OPENCLAW_UPDATE_POST_CORE_CONVERGENCE,
+    ).toBeUndefined();
+    expect(
+      (freshDoctorCall?.[2] as { baseEnv?: NodeJS.ProcessEnv } | undefined)?.baseEnv
+        ?.OPENCLAW_UPDATE_POST_CORE_CONVERGENCE,
+    ).toBeUndefined();
     expect(vi.mocked(runExec).mock.invocationCallOrder[0] ?? 0).toBeLessThan(
       syncPluginsForUpdateChannel.mock.invocationCallOrder[0] ?? 0,
     );
@@ -7247,13 +7262,13 @@ describe("update-cli", () => {
     });
   });
 
-  it("updateFinalizeCommand runs doctor and plugin convergence with full update env", async () => {
+  it("updateFinalizeCommand defers plugin installation during pre-plugin doctor", async () => {
     await withEnvAsync(
       {
         OPENCLAW_UPDATE_IN_PROGRESS: undefined,
         OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR: undefined,
         OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: undefined,
-        OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: undefined,
+        OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1",
       },
       async () => {
         let doctorEnv: NodeJS.ProcessEnv | undefined;
@@ -7273,11 +7288,11 @@ describe("update-cli", () => {
         expect(doctorEnv?.OPENCLAW_UPDATE_IN_PROGRESS).toBe("1");
         expect(doctorEnv?.OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR).toBe("1");
         expect(doctorEnv?.OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE).toBe("1");
-        expect(doctorEnv?.OPENCLAW_UPDATE_POST_CORE_CONVERGENCE).toBe("1");
+        expect(doctorEnv?.OPENCLAW_UPDATE_POST_CORE_CONVERGENCE).toBeUndefined();
         expect(process.env.OPENCLAW_UPDATE_IN_PROGRESS).toBeUndefined();
         expect(process.env.OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR).toBeUndefined();
         expect(process.env.OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE).toBeUndefined();
-        expect(process.env.OPENCLAW_UPDATE_POST_CORE_CONVERGENCE).toBeUndefined();
+        expect(process.env.OPENCLAW_UPDATE_POST_CORE_CONVERGENCE).toBe("1");
         expect(doctorCommand).toHaveBeenCalledWith(defaultRuntime, {
           nonInteractive: true,
           repair: true,

--- a/src/cli/update-cli/update-command-fresh-doctor.ts
+++ b/src/cli/update-cli/update-command-fresh-doctor.ts
@@ -20,7 +20,9 @@ import {
   stripGatewayServiceMarkerEnv,
 } from "./update-command-service.js";
 
-export function withUpdateFinalizationEnv<T>(run: () => Promise<T>): Promise<T> {
+type UpdateDoctorPhase = "pre-plugin" | "post-plugin";
+
+export async function withPrePluginUpdateDoctorEnv<T>(run: () => Promise<T>): Promise<T> {
   const previousUpdateInProgress = process.env.OPENCLAW_UPDATE_IN_PROGRESS;
   const previousDeferConfiguredPluginInstallRepair =
     process.env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV];
@@ -30,8 +32,10 @@ export function withUpdateFinalizationEnv<T>(run: () => Promise<T>): Promise<T> 
   process.env.OPENCLAW_UPDATE_IN_PROGRESS = "1";
   process.env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV] = "1";
   process.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV] = "1";
-  process.env[UPDATE_POST_CORE_CONVERGENCE_ENV] = "1";
-  return run().finally(() => {
+  delete process.env[UPDATE_POST_CORE_CONVERGENCE_ENV];
+  try {
+    return await run();
+  } finally {
     if (previousUpdateInProgress === undefined) {
       delete process.env.OPENCLAW_UPDATE_IN_PROGRESS;
     } else {
@@ -54,7 +58,7 @@ export function withUpdateFinalizationEnv<T>(run: () => Promise<T>): Promise<T> 
     } else {
       process.env[UPDATE_POST_CORE_CONVERGENCE_ENV] = previousPostCoreConvergence;
     }
-  });
+  }
 }
 
 async function withNormalConfigValidation<T>(run: () => Promise<T>): Promise<T> {
@@ -91,6 +95,7 @@ function createPostPluginDoctorExecutionFailure(
 }
 
 export async function runUpdateFinalizationDoctorInFreshProcess(params: {
+  phase: UpdateDoctorPhase;
   root: string;
   yes: boolean;
   json: boolean;
@@ -110,17 +115,19 @@ export async function runUpdateFinalizationDoctorInFreshProcess(params: {
     "--no-workspace-suggestions",
     ...(params.yes ? ["--yes"] : []),
   ];
+  const baseEnv = stripGatewayServiceMarkerEnv(disableUpdatedPackageCompileCacheEnv(process.env));
+  delete baseEnv[UPDATE_POST_CORE_CONVERGENCE_ENV];
   const result = await runExec(params.nodeRunner ?? resolveNodeRunner(), args, {
     cwd: params.root,
     timeoutMs: params.timeoutMs,
     maxBuffer: 4 * 1024 * 1024,
     logOutput: false,
-    baseEnv: stripGatewayServiceMarkerEnv(disableUpdatedPackageCompileCacheEnv(process.env)),
+    baseEnv,
     env: {
       OPENCLAW_UPDATE_IN_PROGRESS: "1",
       [UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV]: "1",
       [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
-      [UPDATE_POST_CORE_CONVERGENCE_ENV]: "1",
+      ...(params.phase === "post-plugin" ? { [UPDATE_POST_CORE_CONVERGENCE_ENV]: "1" } : {}),
     },
   });
   if (!params.json) {
@@ -186,7 +193,11 @@ async function applyFreshPostPluginDoctor(params: {
   }
   let pluginUpdate = params.pluginUpdate;
   try {
-    await runUpdateFinalizationDoctorInFreshProcess({ ...params, entryPath });
+    await runUpdateFinalizationDoctorInFreshProcess({
+      ...params,
+      entryPath,
+      phase: "post-plugin",
+    });
   } catch (err) {
     pluginUpdate = createPostPluginDoctorExecutionFailure(params.pluginUpdate, String(err));
   }

--- a/src/cli/update-cli/update-command-post-core.ts
+++ b/src/cli/update-cli/update-command-post-core.ts
@@ -76,7 +76,7 @@ import {
 } from "./update-command-config.js";
 import {
   completePostCorePluginUpdate,
-  withUpdateFinalizationEnv,
+  withPrePluginUpdateDoctorEnv,
 } from "./update-command-fresh-doctor.js";
 import {
   updatePluginsAfterCoreUpdate,
@@ -207,7 +207,7 @@ export async function updateFinalizeCommand(opts: UpdateFinalizeOptions): Promis
   }
 
   const completedPluginUpdate = await withPluginLifecycleLease({}, async () => {
-    const initialPluginUpdate = await withUpdateFinalizationEnv(async () => {
+    const initialPluginUpdate = await withPrePluginUpdateDoctorEnv(async () => {
       await createUpdateConfigSnapshot();
       await doctorCommand(defaultRuntime, {
         nonInteractive: true,

--- a/src/cli/update-cli/update-command-resume.ts
+++ b/src/cli/update-cli/update-command-resume.ts
@@ -77,6 +77,7 @@ async function resumePostCoreUpdateUnlocked(params: ResumePostCoreUpdateParams):
   });
   await createUpdateConfigSnapshot();
   await runUpdateFinalizationDoctorInFreshProcess({
+    phase: "pre-plugin",
     root: params.root,
     yes: params.opts.yes === true,
     json: params.opts.json === true,


### PR DESCRIPTION
Related: #122011

## What Problem This Solves

Fixes an issue where package upgrades could install the same configured plugin twice during one update. The frozen qualification SHA `1383144b027a6b10c746636687182064d24b3bf9` failed all four upgrade-survivor lanes when the strict ClawHub fixture observed duplicate `@openclaw/whatsapp` artifact requests:

- [root-managed-vps-upgrade](https://github.com/openclaw/openclaw/actions/runs/31512918029/job/93853863101)
- [published-upgrade-survivor](https://github.com/openclaw/openclaw/actions/runs/31512918029/job/93853863133)
- [upgrade-survivor](https://github.com/openclaw/openclaw/actions/runs/31512918029/job/93853863174)
- [update-restart-auth](https://github.com/openclaw/openclaw/actions/runs/31512918029/job/93853863200)

## Why This Change Was Made

The pre-plugin doctor was marked as post-core convergence, so doctor installed the missing configured plugin before the updater's plugin sweep installed or updated it again. This makes update phase ownership explicit: pre-plugin doctor defers configured-plugin payload repair, while only the final post-plugin doctor receives the convergence marker. Fresh child environments also strip ambient convergence state before applying the requested phase.

This ports the canonical repair from release-integration PR [#122011](https://github.com/openclaw/openclaw/pull/122011) onto current `main`, preserving Peter Steinberger as commit author without cherry-picking unrelated release integration history.

## User Impact

Package upgrades perform one configured-plugin installation transaction while retaining the final updated-plugin migration pass before restart.

## Evidence

- Focused local proof: 374 tests passed across `src/cli/update-cli.test.ts`, post-core convergence, update-phase, and missing-configured-plugin repair.
- Changed-surface Testbox: `tbx_01kzrwvahx6mn675e8rk382xyv`, [Actions run](https://github.com/openclaw/openclaw/actions/runs/31516195797), passed core/core-test tsgo, oxlint, formatting, API/boundary guards, dead exports, import cycles, and `git diff --check`.
- Exact-head CI: [run 31517065896](https://github.com/openclaw/openclaw/actions/runs/31517065896) passed all required checks for `7a306e5e770b4b6f0a6f24da15c772c03da518cf`.
- Exact-head ClawSweeper: [run 31519416346](https://github.com/openclaw/clawsweeper/actions/runs/31519416346) found no actionable findings and marked proof sufficient. The first review attempt was throttled by the GitHub App API at 17:23 UTC; the classified retry entered the queue at 17:47 UTC and completed at 17:54 UTC.
- Targeted package acceptance: [run 31517562495](https://github.com/openclaw/openclaw/actions/runs/31517562495) passed `update-restart-auth`. The other three requested lanes stopped before updater convergence assertions on an independent retired Discord fixture shape (`channels.discord.dm.policy` / `allowFrom`), so the unchanged full graph was not retried.
- Branch autoreview: clean, no accepted/actionable findings; TruffleHog clean.
- Production LOC: +21/-9 (net +12). Maintainer decision: accept this growth because distinct pre-plugin and post-plugin process contracts require named phase ownership; a net-neutral helper would reintroduce ambient convergence-marker leakage. Tests: +20/-5. Changelog: +1.
- No publish, tag, or release action is included.
