### PR TITLE
refactor(agents): unify CLI spawn/live failure policy lanes

### DIFF
--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -841,6 +841,52 @@ describe("runCliAgent reliability", () => {
     expect(supervisorSpawnMock).toHaveBeenCalledTimes(2);
   });
 
+  it("does not treat unsupported-flag wording fragments as a Claude downgrade", async () => {
+    supervisorSpawnMock.mockClear();
+    supervisorSpawnMock.mockResolvedValueOnce(
+      makeManagedRun({
+        exitCode: 1,
+        durationMs: 25,
+        stderr: "Claude exited unexpectedly while using --resume-session-at",
+      }),
+    );
+    const clearBeforeRetry = vi.fn(async () => true);
+    const context = makeClaudePreparedContext({
+      sessionKey: "agent:main:resume-token-boundary",
+      runId: "run-resume-token-boundary",
+      cliSessionId: "existing-session",
+      openClawHistoryPrompt: CLI_RESEED_PROMPT,
+    });
+    context.preparedBackend.backend = {
+      ...context.preparedBackend.backend,
+      resumeArgs: ["--resume", "{sessionId}"],
+      forkArg: "--fork-session",
+      resumeAtArg: "--resume-session-at",
+    };
+    context.params.cliSessionBinding = {
+      sessionId: "existing-session",
+      resumeCheckpointId: "assistant-before-stall",
+      forkNextResume: true,
+    };
+
+    await expect(
+      runPreparedCliAgent({
+        ...context,
+        params: {
+          ...context.params,
+          forkCliSessionOnResume: true,
+          claimCliSessionFork: vi.fn(async () => true),
+          restoreCliSessionFork: vi.fn(async () => {}),
+          persistCliSessionForkSuccessor: vi.fn(async () => {}),
+          onBeforeFreshCliSessionRetry: clearBeforeRetry,
+        },
+      }),
+    ).rejects.toThrow("exited unexpectedly");
+
+    expect(clearBeforeRetry).not.toHaveBeenCalled();
+    expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
+  });
+
   it("preserves fresh retry for direct CLI callers without a pre-clear hook", async () => {
     supervisorSpawnMock.mockClear();
     supervisorSpawnMock.mockResolvedValueOnce(

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -47,6 +47,7 @@ import {
   attachCliMessagingDeliveryEvidence,
   getCliMessagingDeliveryEvidence,
 } from "./cli-runner/delivery-evidence.js";
+import { createCliFailoverError } from "./cli-runner/exit-error.js";
 import { cliBackendLog, formatCliBackendOutputDigest } from "./cli-runner/log.js";
 import { hashCliReseedPrompt } from "./cli-runner/reseed-envelope.js";
 import {
@@ -63,13 +64,12 @@ import type {
   RunCliAgentParams,
 } from "./cli-runner/types.js";
 import { claudeCliSessionTranscriptHasContent as claudeCliSessionTranscriptHasContentImpl } from "./command/attempt-execution.helpers.js";
-import { classifyFailoverReason, isFailoverErrorMessage } from "./embedded-agent-helpers.js";
 import type { EmbeddedAgentRunResult } from "./embedded-agent-runner.js";
 import { waitForDeferredTurnMaintenanceForSession } from "./embedded-agent-runner/context-engine-maintenance.js";
 import { resolveExplicitFinalSourceReplyDeliveryEvidence } from "./embedded-agent-runner/delivery-evidence.js";
 import { resolveAuthProfileFailureReason } from "./embedded-agent-runner/run/auth-profile-failure-policy.js";
 import { buildEmbeddedRunPayloads } from "./embedded-agent-runner/run/payloads.js";
-import { FailoverError, isFailoverError, resolveFailoverStatus } from "./failover-error.js";
+import { coerceToFailoverError, FailoverError, isFailoverError } from "./failover-error.js";
 import {
   awaitAgentEndSideEffects,
   runAgentEndSideEffects,
@@ -216,29 +216,8 @@ function isUnsupportedCliResumeAtError(error: unknown, resumeAtArg: string): boo
   const message = formatErrorMessage(error).toLowerCase();
   return (
     message.includes(resumeAtArg.toLowerCase()) &&
-    ["unknown", "unexpected", "unrecognized", "not recognized"].some((token) =>
-      message.includes(token),
-    )
+    /\b(?:unknown|unexpected|unrecognized)\b|\bnot\s+recognized\b/.test(message)
   );
-}
-
-function formatCliEmptyOutputDiagnostics(output: CliOutput): string | undefined {
-  const process = output.diagnostics?.process;
-  if (!process) {
-    return undefined;
-  }
-  return [
-    `backend=${process.backendId}`,
-    `reason=${process.processReason}`,
-    `exitCode=${process.exitCode ?? "null"}`,
-    `exitSignal=${process.exitSignal ?? "null"}`,
-    `durationMs=${process.durationMs}`,
-    `stdoutBytes=${process.stdoutBytes}`,
-    `stdoutHash=${process.stdoutHash}`,
-    `stderrBytes=${process.stderrBytes}`,
-    `stderrHash=${process.stderrHash}`,
-    `useResume=${process.useResume ? "true" : "false"}`,
-  ].join(" ");
 }
 
 /** Checks whether a Claude CLI session binding has reached its transcript file. */
@@ -802,6 +781,12 @@ export async function runPreparedCliAgent(
 ): Promise<EmbeddedAgentRunResult> {
   const { executePreparedCliRun } = await import("./cli-runner/execute.runtime.js");
   const { params } = context;
+  const cliFailoverContext = {
+    provider: params.provider,
+    model: context.modelId,
+    sessionId: params.sessionId,
+    lane: params.lane,
+  };
   const sessionBindingDisabled = context.preparedBackend.backend.sessionMode === "none";
   const preparedContextAgentMeta =
     isClaudeCliProvider(params.provider) && context.contextWindowInfo
@@ -1145,26 +1130,6 @@ export async function runPreparedCliAgent(
     }
   };
 
-  const toCliRunFailure = (error: unknown): never => {
-    if (isFailoverError(error)) {
-      throw error;
-    }
-    const message = formatErrorMessage(error);
-    if (isFailoverErrorMessage(message, { provider: params.provider })) {
-      const reason = classifyFailoverReason(message, { provider: params.provider }) ?? "unknown";
-      const status = resolveFailoverStatus(reason);
-      throw new FailoverError(message, {
-        reason,
-        provider: params.provider,
-        model: context.modelId,
-        sessionId: params.sessionId,
-        lane: params.lane,
-        status,
-      });
-    }
-    throw error;
-  };
-
   const executeCliAttempt = async (
     cliSessionIdToUse?: string,
     options?: {
@@ -1223,18 +1188,28 @@ export async function runPreparedCliAgent(
       !output.didSendViaMessagingTool &&
       params.allowEmptyAssistantReplyAsSilent !== true
     ) {
-      const emptyOutputDiagnostics = formatCliEmptyOutputDiagnostics(output);
-      if (emptyOutputDiagnostics) {
-        cliBackendLog.warn(`cli empty response diagnostics: ${emptyOutputDiagnostics}`);
+      const process = output.diagnostics?.process;
+      if (process) {
+        const diagnostics = [
+          `backend=${process.backendId}`,
+          `reason=${process.processReason}`,
+          `exitCode=${process.exitCode ?? "null"}`,
+          `exitSignal=${process.exitSignal ?? "null"}`,
+          `durationMs=${process.durationMs}`,
+          `stdoutBytes=${process.stdoutBytes}`,
+          `stdoutHash=${process.stdoutHash}`,
+          `stderrBytes=${process.stderrBytes}`,
+          `stderrHash=${process.stderrHash}`,
+          `useResume=${process.useResume ? "true" : "false"}`,
+        ].join(" ");
+        cliBackendLog.warn(`cli empty response diagnostics: ${diagnostics}`);
       }
       throw attachCliMessagingDeliveryEvidence(
-        new FailoverError("CLI backend returned an empty response.", {
-          reason: "empty_response",
-          provider: params.provider,
-          model: context.modelId,
-          sessionId: params.sessionId,
-          lane: params.lane,
-        }),
+        createCliFailoverError(
+          "CLI backend returned an empty response.",
+          "empty_response",
+          cliFailoverContext,
+        ),
         output,
       );
     }
@@ -1673,15 +1648,12 @@ export async function runPreparedCliAgent(
         context.preparedBackend.backend.resumeAtArg &&
         isUnsupportedCliResumeAtError(err, context.preparedBackend.backend.resumeAtArg)
       ) {
-        recoveryError = new FailoverError("CLI backend cannot resume from the stored checkpoint.", {
-          reason: "session_expired",
-          provider: params.provider,
-          model: context.modelId,
-          sessionId: params.sessionId,
-          lane: params.lane,
-          status: resolveFailoverStatus("session_expired"),
-          cause: err,
-        });
+        recoveryError = createCliFailoverError(
+          "CLI backend cannot resume from the stored checkpoint.",
+          "session_expired",
+          cliFailoverContext,
+          { cause: err },
+        );
       }
       if (isFailoverError(recoveryError)) {
         if (
@@ -1777,7 +1749,7 @@ export async function runPreparedCliAgent(
               ctx: hookContext,
               hookRunner,
             });
-            return toCliRunFailure(retryErr);
+            throw retryErr;
           }
         }
       }
@@ -1795,7 +1767,7 @@ export async function runPreparedCliAgent(
         ctx: hookContext,
         hookRunner,
       });
-      return toCliRunFailure(recoveryError);
+      throw recoveryError;
     }
   };
 
@@ -1825,7 +1797,7 @@ export async function runPreparedCliAgent(
     );
   }
   if (runFailed) {
-    throw runError;
+    throw coerceToFailoverError(runError, cliFailoverContext) ?? runError;
   }
   if (!runResult) {
     throw new Error("CLI run completed without a result");

--- a/src/agents/cli-runner/claude-live-process.test.ts
+++ b/src/agents/cli-runner/claude-live-process.test.ts
@@ -786,6 +786,17 @@ describe("Claude live process", () => {
       },
     },
     {
+      name: "marks quiet Claude live nonzero exits as retryable unknown failures",
+      exitCode: 1,
+      stderr: "",
+      events: [],
+      expected: {
+        name: "FailoverError",
+        reason: "unknown",
+        code: "cli_unknown_empty_failure",
+      },
+    },
+    {
       name: "preserves Claude live stderr classification on exit-zero failures",
       exitCode: 0,
       stderr: "Prompt is too long",

--- a/src/agents/cli-runner/claude-live-turn-timeouts.ts
+++ b/src/agents/cli-runner/claude-live-turn-timeouts.ts
@@ -1,5 +1,8 @@
 import { BLOCKED_TOOL_CALL_ABORT_FLOOR_MS } from "../../logging/diagnostic-run-activity.js";
-import { type CliTimeoutContext, FailoverError, resolveFailoverStatus } from "../failover-error.js";
+import {
+  createCliTimeoutError,
+  resolveCliNoOutputTimeoutDecision,
+} from "./no-output-timeout-policy.js";
 
 type ClaudeLiveTimeoutTurn = {
   startedAtMs: number;
@@ -23,22 +26,6 @@ type ClaudeLiveTimeoutHost = {
   close(reason: "idle" | "restart" | "abort" | "mcp-capture-rotation", error?: unknown): void;
 };
 
-function createClaudeTimeoutError(
-  host: ClaudeLiveTimeoutHost,
-  message: string,
-  code?: string,
-  cliTimeout?: CliTimeoutContext,
-): FailoverError {
-  return new FailoverError(message, {
-    reason: "timeout",
-    provider: host.providerId,
-    model: host.modelId,
-    status: resolveFailoverStatus("timeout"),
-    code,
-    cliTimeout,
-  });
-}
-
 function armNoOutputTimer(
   host: ClaudeLiveTimeoutHost,
   turn: ClaudeLiveTimeoutTurn,
@@ -49,41 +36,30 @@ function armNoOutputTimer(
   }
   turn.noOutputTimer = setTimeout(() => {
     const quietSinceMs = turn.lastOutputAtMs ?? turn.startedAtMs;
-    const hasOutstandingWork =
-      turn.activeTools.size > 0 || host.outstandingBackgroundTaskIds.size > 0;
-    if (hasOutstandingWork) {
-      const remainingMs =
-        quietSinceMs +
-        Math.max(host.noOutputTimeoutMs, BLOCKED_TOOL_CALL_ABORT_FLOOR_MS) -
-        Date.now();
-      if (remainingMs > 0) {
-        armNoOutputTimer(host, turn, remainingMs);
-        return;
-      }
+    const quietDurationMs = Date.now() - quietSinceMs;
+    const decision = resolveCliNoOutputTimeoutDecision({
+      context: { provider: host.providerId, model: host.modelId },
+      timeoutMs: host.noOutputTimeoutMs,
+      quietDurationMs,
+      cliTimeout: {
+        mode: "no-output",
+        timeoutSeconds: Math.round(quietDurationMs / 1000),
+        observedActivity:
+          turn.lastOutputAtMs !== null || turn.toolEventCount > 0 || turn.rawLines.length > 0,
+        activeToolCount: turn.activeTools.size,
+        backgroundTaskCount: host.outstandingBackgroundTaskIds.size,
+      },
+      hasOutputText: host.stdoutBuffer.pending.trim().length > 0,
+      useResume: turn.useResume,
+      hasReplayUnsafeActivity: turn.hasReplayUnsafeActivity,
+      allowResumeControlOnlyRetry: true,
+      outstandingWorkGraceMs: BLOCKED_TOOL_CALL_ABORT_FLOOR_MS,
+    });
+    if (decision.deferMs !== undefined) {
+      armNoOutputTimer(host, turn, decision.deferMs);
+      return;
     }
-    const retryableResumeStall =
-      turn.useResume &&
-      host.stdoutBuffer.pending.trim().length === 0 &&
-      !turn.hasReplayUnsafeActivity &&
-      turn.toolEventCount === 0 &&
-      turn.activeTools.size === 0 &&
-      host.outstandingBackgroundTaskIds.size === 0;
-    host.close(
-      "abort",
-      createClaudeTimeoutError(
-        host,
-        `CLI produced no output for ${Math.round((Date.now() - quietSinceMs) / 1000)}s and was terminated.`,
-        turn.lastOutputAtMs === null || retryableResumeStall ? "cli_no_output_timeout" : undefined,
-        {
-          mode: "no-output",
-          timeoutSeconds: Math.round((Date.now() - quietSinceMs) / 1000),
-          observedActivity:
-            turn.lastOutputAtMs !== null || turn.toolEventCount > 0 || turn.rawLines.length > 0,
-          activeToolCount: turn.activeTools.size,
-          backgroundTaskCount: host.outstandingBackgroundTaskIds.size,
-        },
-      ),
-    );
+    host.close("abort", decision.error);
   }, delayMs);
 }
 
@@ -116,20 +92,20 @@ export function armClaudeTurnTimers(
 ): void {
   armNoOutputTimer(host, turn, host.noOutputTimeoutMs);
   turn.timeoutTimer = setTimeout(() => {
+    const timeoutSeconds = Math.round(overallTimeoutMs / 1000);
     host.close(
       "abort",
-      createClaudeTimeoutError(
-        host,
-        `CLI exceeded timeout (${Math.round(overallTimeoutMs / 1000)}s) and was terminated.`,
-        "cli_overall_timeout",
+      createCliTimeoutError(
+        { provider: host.providerId, model: host.modelId },
         {
           mode: "overall",
-          timeoutSeconds: Math.round(overallTimeoutMs / 1000),
+          timeoutSeconds,
           observedActivity:
             turn.observedStdout || turn.rawLines.length > 0 || turn.toolEventCount > 0,
           activeToolCount: turn.activeTools.size,
           backgroundTaskCount: host.outstandingBackgroundTaskIds.size,
         },
+        "cli_overall_timeout",
       ),
     );
   }, overallTimeoutMs);

--- a/src/agents/cli-runner/claude-live-turn.ts
+++ b/src/agents/cli-runner/claude-live-turn.ts
@@ -27,15 +27,15 @@ import {
   frameBoundedCliJsonlChunk,
   normalizeClaudeCliStreamJsonRecord,
 } from "../cli-output-stream.js";
-import { extractCliErrorMessage, parseCliOutput } from "../cli-output.js";
-import { classifyFailoverReason } from "../embedded-agent-helpers.js";
-import { FailoverError, resolveFailoverStatus } from "../failover-error.js";
+import { parseCliOutput } from "../cli-output.js";
+import type { FailoverError } from "../failover-error.js";
 import { resolveCliToolTerminalReason } from "../run-termination.js";
 import {
   armClaudeTurnTimers,
   clearClaudeTurnTimers,
   resetClaudeNoOutputTimer,
 } from "./claude-live-turn-timeouts.js";
+import { createCliExitFailoverError, createCliFailoverError } from "./exit-error.js";
 import { cliBackendLog, formatCliBackendOutputDigest } from "./log.js";
 import { createCliOutputFailoverError } from "./output-error.js";
 import type { PreparedCliRunContext } from "./types.js";
@@ -150,11 +150,9 @@ export function createClaudeOutputLimitError(
   host: ClaudeLiveTurnHost,
   message: string,
 ): FailoverError {
-  return new FailoverError(message, {
-    reason: "format",
+  return createCliFailoverError(message, "format", {
     provider: host.providerId,
     model: host.modelId,
-    status: resolveFailoverStatus("format"),
   });
 }
 
@@ -522,36 +520,16 @@ export function acceptClaudeExit(host: ClaudeLiveTurnHost, exitCode: number | nu
     return;
   }
   const stderr = host.stderr.trim();
-  const message =
-    extractCliErrorMessage(stderr) ??
-    (stderr ||
-      (exitCode === 0 ? "Claude CLI exited before completing the turn." : "Claude CLI failed."));
-  if (exitCode === 0 && !stderr) {
-    const turn = host.currentTurn;
-    failClaudeTurn(
-      host,
-      new FailoverError(message, {
-        reason: "empty_response",
-        provider: host.providerId,
-        model: host.modelId,
-        status: resolveFailoverStatus("empty_response"),
-        code:
-          turn && !turn.observedStdout && turn.rawLines.length === 0
-            ? "cli_unknown_empty_failure"
-            : undefined,
-      }),
-    );
-    return;
-  }
-  const reason = classifyFailoverReason(message, { provider: host.providerId }) ?? "unknown";
+  const turn = host.currentTurn;
   failClaudeTurn(
     host,
-    new FailoverError(message, {
-      reason,
-      provider: host.providerId,
-      model: host.modelId,
-      status: resolveFailoverStatus(reason),
-      code: reason === "context_overflow" ? "cli_context_overflow" : undefined,
+    createCliExitFailoverError({
+      context: { provider: host.providerId, model: host.modelId },
+      candidates: [stderr],
+      fallbackMessage:
+        exitCode === 0 ? "Claude CLI exited before completing the turn." : "Claude CLI failed.",
+      emptyReason: exitCode === 0 ? "empty_response" : undefined,
+      retryEmptyFailure: !turn.observedStdout && turn.rawLines.length === 0,
     }),
   );
 }

--- a/src/agents/cli-runner/execute-process.ts
+++ b/src/agents/cli-runner/execute-process.ts
@@ -9,9 +9,7 @@ import type { CliBackendConfig } from "../../plugins/cli-backend.types.js";
 import type { RunExit } from "../../process/supervisor/types.js";
 import type { CliOutput } from "../cli-output-contracts.js";
 import { createCliJsonlStreamingParser } from "../cli-output-stream.js";
-import { extractCliErrorMessage, parseCliOutput } from "../cli-output.js";
-import { classifyFailoverReason } from "../embedded-agent-helpers.js";
-import { FailoverError, resolveFailoverStatus } from "../failover-error.js";
+import { parseCliOutput } from "../cli-output.js";
 import { applyPluginTextReplacements } from "../plugin-text-transforms.js";
 import { runClaudeTurn } from "./claude-live-session.js";
 import type { CliExecuteDeps } from "./execute-deps.js";
@@ -23,9 +21,14 @@ import {
 } from "./execute-node-claude.js";
 import { appendCliOutputTail } from "./execute-output-buffer.js";
 import type { CliToolTracking } from "./execute-tool-tracking.js";
+import { createCliExitFailoverError, createCliFailoverError } from "./exit-error.js";
 import { buildCliSupervisorScopeKey } from "./helpers.js";
 import { cliBackendLog, formatCliBackendOutputDigest } from "./log.js";
 import type { createClaudeCliModelCallDiagnostics } from "./model-call-diagnostics.js";
+import {
+  createCliTimeoutError,
+  resolveCliNoOutputTimeoutDecision,
+} from "./no-output-timeout-policy.js";
 import { createCliOutputFailoverError } from "./output-error.js";
 import type { PreparedCliRunContext } from "./types.js";
 
@@ -312,11 +315,7 @@ export async function executeCliProcess(params: {
   const streamingParserErrorText =
     params.outputMode === "jsonl" ? (streamingParser?.getErrorText() ?? null) : null;
   if (streamingParserErrorText) {
-    throw new FailoverError(streamingParserErrorText, {
-      reason: "format",
-      ...failoverContext,
-      status: resolveFailoverStatus("format"),
-    });
+    throw createCliFailoverError(streamingParserErrorText, "format", failoverContext);
   }
   // The node re-injects the terminal result after truncation. If even that is
   // missing, the turn outcome is unknowable and cannot pass as a clean exit.
@@ -326,13 +325,10 @@ export async function executeCliProcess(params: {
     !result.timedOut &&
     !streamingParser?.hasTerminalResult()
   ) {
-    throw new FailoverError(
+    throw createCliFailoverError(
       "paired node truncated the Claude CLI stream before the terminal result; refusing to accept partial output.",
-      {
-        reason: "format",
-        ...failoverContext,
-        status: resolveFailoverStatus("format"),
-      },
+      "format",
+      failoverContext,
     );
   }
 
@@ -401,8 +397,23 @@ export async function executeCliProcess(params: {
       cliBackendLog.warn(
         `cli watchdog timeout: provider=${runParams.provider} model=${context.modelId} session=${params.resolvedSessionId ?? runParams.sessionId} noOutputTimeoutMs=${params.noOutputTimeoutMs} pid=${managedRunPid ?? "node"}`,
       );
-      const retryable =
-        !params.events.hasObservedCliActivity() && !stdoutDiagnostic && !stderrDiagnostic;
+      const observedActivity = params.events.hasObservedCliActivity();
+      const timeoutDecision = resolveCliNoOutputTimeoutDecision({
+        context: failoverContext,
+        timeoutMs: params.noOutputTimeoutMs,
+        quietDurationMs: params.noOutputTimeoutMs,
+        cliTimeout: {
+          mode: "no-output",
+          timeoutSeconds,
+          observedActivity,
+          activeToolCount: params.events.activeParsedToolCount(),
+          backgroundTaskCount: 0,
+        },
+        hasOutputText: Boolean(stdoutDiagnostic || stderrDiagnostic),
+        useResume: params.useResume,
+        hasReplayUnsafeActivity: observedActivity,
+      });
+      const retryable = timeoutDecision.error.code === "cli_no_output_timeout";
       const deferNotice =
         retryable &&
         Boolean(params.cliSessionIdToUse) &&
@@ -435,79 +446,35 @@ export async function executeCliProcess(params: {
           ),
         );
       }
-      throw new FailoverError(`CLI produced no output for ${timeoutSeconds}s and was terminated.`, {
-        reason: "timeout",
-        ...failoverContext,
-        status: resolveFailoverStatus("timeout"),
-        code: retryable ? "cli_no_output_timeout" : undefined,
-        cliTimeout: {
-          mode: "no-output",
-          timeoutSeconds,
-          observedActivity: params.events.hasObservedCliActivity(),
-          activeToolCount: params.events.activeParsedToolCount(),
-          backgroundTaskCount: 0,
-        },
-      });
+      throw timeoutDecision.error;
     }
     if (result.reason === "overall-timeout") {
       const timeoutSeconds = Math.round(runParams.timeoutMs / 1000);
-      throw new FailoverError(`CLI exceeded timeout (${timeoutSeconds}s) and was terminated.`, {
-        reason: "timeout",
-        ...failoverContext,
-        status: resolveFailoverStatus("timeout"),
-        code: "cli_overall_timeout",
-        cliTimeout: {
+      throw createCliTimeoutError(
+        failoverContext,
+        {
           mode: "overall",
           timeoutSeconds,
           observedActivity: params.events.hasObservedCliActivity(),
           activeToolCount: params.events.activeParsedToolCount(),
           backgroundTaskCount: 0,
         },
-      });
+        "cli_overall_timeout",
+      );
     }
-    const errorCandidates = [stderr, stdout, stderrDiagnostic, stdoutDiagnostic].filter(Boolean);
-    const structuredError =
-      errorCandidates.map((candidate) => extractCliErrorMessage(candidate)).find(Boolean) ?? null;
-    let classifiedErrorText = structuredError;
-    let reason = structuredError
-      ? classifyFailoverReason(structuredError, { provider: runParams.provider })
-      : null;
-    if (!reason) {
-      for (const candidate of errorCandidates) {
-        reason = classifyFailoverReason(candidate, { provider: runParams.provider });
-        if (reason) {
-          classifiedErrorText = candidate;
-          break;
-        }
-      }
-    }
-    const errorText = structuredError || classifiedErrorText || errorCandidates[0] || "CLI failed.";
-    reason ??= "unknown";
-    const retryCode =
-      reason === "context_overflow"
-        ? "cli_context_overflow"
-        : reason === "unknown" &&
-            result.reason === "exit" &&
-            errorCandidates.length === 0 &&
-            !params.events.hasObservedCliActivity()
-          ? "cli_unknown_empty_failure"
-          : undefined;
-    throw new FailoverError(errorText, {
-      reason,
-      ...failoverContext,
-      status: resolveFailoverStatus(reason),
-      code: retryCode,
+    throw createCliExitFailoverError({
+      context: failoverContext,
+      candidates: [stderr, stdout, stderrDiagnostic, stdoutDiagnostic],
+      fallbackMessage: "CLI failed.",
+      retryEmptyFailure: result.reason === "exit" && !params.events.hasObservedCliActivity(),
     });
   }
 
   if (stdoutParseExceeded && !streamedJsonlOutput) {
-    throw new FailoverError(
+    throw createCliFailoverError(
       `CLI stdout exceeded ${CLI_RUNNER_OUTPUT_PARSE_BYTES} bytes; refusing to parse truncated output.`,
-      {
-        reason: "format",
-        ...failoverContext,
-        status: resolveFailoverStatus("format"),
-      },
+      "format",
+      failoverContext,
     );
   }
   const parsed =

--- a/src/agents/cli-runner/exit-error.ts
+++ b/src/agents/cli-runner/exit-error.ts
@@ -1,0 +1,45 @@
+import { extractCliErrorMessage } from "../cli-output.js";
+import { coerceToFailoverError, FailoverError, resolveFailoverStatus } from "../failover-error.js";
+
+type CliExitFailoverErrorParams = {
+  context: Pick<FailoverError, "provider" | "model" | "sessionId" | "lane">;
+  // Spawn supplies stderr/stdout windows; live stdout is already structured, so it supplies stderr.
+  candidates: readonly string[];
+  fallbackMessage: string;
+  // Only a clean premature live exit is protocol-level empty_response; other empty exits are unknown.
+  emptyReason?: FailoverError["reason"];
+  retryEmptyFailure: boolean;
+};
+
+export function createCliFailoverError(
+  message: string,
+  reason: FailoverError["reason"],
+  context: Pick<FailoverError, "provider" | "model" | "sessionId" | "lane">,
+  options?: { cause?: unknown; cliTimeout?: FailoverError["cliTimeout"]; code?: string },
+): FailoverError {
+  return new FailoverError(message, {
+    reason,
+    ...context,
+    status: resolveFailoverStatus(reason),
+    ...options,
+  });
+}
+
+export function createCliExitFailoverError(params: CliExitFailoverErrorParams): FailoverError {
+  const candidates = params.candidates.map((candidate) => candidate.trim()).filter(Boolean);
+  const structuredError =
+    candidates.map((candidate) => extractCliErrorMessage(candidate)).find(Boolean) ?? null;
+  const classified = [structuredError, ...candidates]
+    .flatMap((candidate) => (candidate ? [coerceToFailoverError(candidate, params.context)] : []))
+    .find((error) => error !== null);
+  const message = structuredError || classified?.message || candidates[0] || params.fallbackMessage;
+  const reason =
+    classified?.reason ?? (candidates.length === 0 ? params.emptyReason : undefined) ?? "unknown";
+  const code =
+    reason === "context_overflow"
+      ? "cli_context_overflow"
+      : candidates.length === 0 && params.retryEmptyFailure
+        ? "cli_unknown_empty_failure"
+        : undefined;
+  return createCliFailoverError(message, reason, params.context, { code });
+}

--- a/src/agents/cli-runner/no-output-timeout-policy.ts
+++ b/src/agents/cli-runner/no-output-timeout-policy.ts
@@ -1,0 +1,59 @@
+import { type CliTimeoutContext, FailoverError } from "../failover-error.js";
+import { createCliFailoverError } from "./exit-error.js";
+
+type CliNoOutputTimeoutPolicyParams = {
+  context: Pick<FailoverError, "provider" | "model" | "sessionId" | "lane">;
+  cliTimeout: CliTimeoutContext;
+  timeoutMs: number;
+  quietDurationMs: number;
+  hasOutputText: boolean;
+  useResume: boolean;
+  hasReplayUnsafeActivity: boolean;
+  allowResumeControlOnlyRetry?: boolean;
+  outstandingWorkGraceMs?: number;
+};
+
+export function resolveCliNoOutputTimeoutDecision(params: CliNoOutputTimeoutPolicyParams): {
+  deferMs?: number;
+  error: FailoverError;
+} {
+  const outstandingWork =
+    params.cliTimeout.activeToolCount > 0 || params.cliTimeout.backgroundTaskCount > 0;
+  // Live-only: tracked work may extend the watchdog; spawn has already terminated its child.
+  const deferMs =
+    outstandingWork && params.outstandingWorkGraceMs !== undefined
+      ? Math.max(params.timeoutMs, params.outstandingWorkGraceMs) - params.quietDurationMs
+      : undefined;
+  // Live-only: resume control traffic is distinguishable from replay-unsafe substantive output.
+  const retryableResumeStall =
+    params.allowResumeControlOnlyRetry === true &&
+    params.useResume &&
+    !params.hasOutputText &&
+    !params.hasReplayUnsafeActivity &&
+    !outstandingWork;
+  const retryable =
+    (!params.cliTimeout.observedActivity && !params.hasOutputText) || retryableResumeStall;
+  return {
+    ...(deferMs !== undefined && deferMs > 0 ? { deferMs } : {}),
+    error: createCliTimeoutError(
+      params.context,
+      params.cliTimeout,
+      retryable ? "cli_no_output_timeout" : undefined,
+    ),
+  };
+}
+
+export function createCliTimeoutError(
+  context: Pick<FailoverError, "provider" | "model" | "sessionId" | "lane">,
+  cliTimeout: CliTimeoutContext,
+  code?: string,
+): FailoverError {
+  return createCliFailoverError(
+    cliTimeout.mode === "no-output"
+      ? `CLI produced no output for ${cliTimeout.timeoutSeconds}s and was terminated.`
+      : `CLI exceeded timeout (${cliTimeout.timeoutSeconds}s) and was terminated.`,
+    "timeout",
+    context,
+    { code, cliTimeout },
+  );
+}

--- a/src/agents/embedded-agent-runner/run/failover-policy.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.ts
@@ -182,8 +182,8 @@ export function resolveRunFailoverDecision(params: RunFailoverDecisionParams): R
 
   if (params.stage === "prompt") {
     if (params.failoverCode === "cli_max_turns") {
-      // A CLI may have completed tool actions before reaching this terminal
-      // limit. Replaying against another profile/model could repeat effects.
+      // Plugin-harness errors can propagate arbitrary string codes through failover-error normalization;
+      // normal CLI paths are protected in model-fallback-runner instead.
       return {
         action: "surface_error",
         reason: params.failoverReason,


### PR DESCRIPTION
## What Problem This Solves

Resolves a maintenance and reliability problem where the CLI spawn and persistent-live lanes made the same watchdog and abnormal-exit decisions through duplicated, subtly different predicates. That divergence could make equivalent quiet failures recover differently depending on which CLI transport was selected.

## Why This Change Was Made

This change gives both lanes one CLI-owned no-output decision module and one exit-classification adapter backed by the shared failover substrate. It also routes final raw CLI errors through `coerceToFailoverError`, word-bounds unsupported checkpoint-flag detection, and documents why `cli_max_turns` remains reachable at the embedded failover boundary.

Predicate differences were adjudicated as follows:

- Initial no-output retry: unified on no observed activity and no stdout/stderr text. This replaces the live lane's unconditional `lastOutputAtMs === null` code assignment with the same replay-safety facts used by spawn.
- Resume control-only stalls: retained as the named live-only `allowResumeControlOnlyRetry` input. The persistent live parser can distinguish init/control traffic from replay-unsafe assistant/tool activity; spawn supervision cannot.
- Outstanding tools/background work: retained as the named live-only `outstandingWorkGraceMs` input. The persistent live lane still owns tracked work and may extend to the blocked-tool floor; the spawn child is already terminated when classification runs.
- Activity and timeout facts: retained as lane-owned inputs to the one decision. Spawn reports parser/event activity and the configured supervisor threshold; live reports process-output/tool/raw-line activity and measured quiet duration. The retry predicate and `CliTimeoutContext` construction are shared.
- Spawn stall notification routing: retained outside the decision module because it is an orchestration side effect, not retry authority. The shared decision still determines whether that notice may be deferred for an internal recovery.
- Exit candidates: retained as the named `candidates` input. Spawn can classify bounded stderr/stdout parse windows and diagnostic tails; live stdout is structured and consumed before exit, so live supplies stderr only.
- Empty exit reason: retained as the named `emptyReason` input. A clean live exit before a terminal record is a protocol-level `empty_response`; an output-free nonzero exit remains `unknown`.
- Empty failure retry code: unified. A normal process exit with no error candidate and no observed activity now receives `cli_unknown_empty_failure` in both lanes, including quiet nonzero live exits.
- Fallback copy and attribution: retained as lane-owned inputs. Live preserves its precise premature-clean-exit copy, while spawn preserves session/lane attribution; both use the same classifier and CLI code mapping.

The removed alternatives were a consumer-side guard, a lane-selecting wrapper over the old branches, and preserving the CLI-local text classifier. Each would have left duplicate retry authority or classification policy in place.

## User Impact

No new configuration or public API. Equivalent CLI failures now produce consistent structured failover behavior across spawn and persistent-live execution, while replay-unsafe tool/output activity remains protected from automatic recovery.

Production LOC: +229/-232 (net -3). Tests: +57/-0.

## Evidence

- `node scripts/run-vitest.mjs src/agents/cli-runner.fault-sequences.e2e.test.ts` — 10/10 passed.
- `node scripts/run-vitest.mjs src/agents/cli-runner.reliability.test.ts` — 86/86 passed; the new word-bound regression failed before the matcher fix and passes after it.
- `node scripts/run-vitest.mjs src/agents/cli-runner/execute.supervisor-capture.test.ts` — 52/52 passed.
- `node scripts/run-vitest.mjs src/agents/cli-runner/claude-live-process.test.ts src/agents/cli-runner/claude-live-turn.test.ts src/agents/cli-runner/claude-live-turn-diagnostics.test.ts` — 57/57 passed.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/failover-policy.test.ts` — 47/47 passed.
- `node scripts/check-changed.mjs --timed` — passed all changed gates after the remote backend was unavailable and the documented trusted-source local fallback ran.
- `pnpm check:import-cycles` and `pnpm check:madge-import-cycles` — 0 cycles.
- `pnpm build` — passed.
- `git diff --check` and changed-file formatting — passed.
- Fresh structured autoreview on the rebased branch — no actionable findings; secret scan clean.

Broad local aggregate notes: `src/agents/cli-runner` passed 1184/1196, with 12 order-sensitive target-normalization assertions in supervisor capture; that owning file passes 52/52 alone and the target-normalization surface is untouched here. The embedded `run/` aggregate passed 4724/4728; all four failures were the same hard-coded `/tmp/openclaw.sqlite` schema-16 artifact under four configs, unrelated to the two-line failover-policy comment.

AI-assisted implementation; reviewed and verified by the maintainer workflow.
