### PR TITLE
test: keep CLI loader failure injection deterministic

### DIFF
--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -103,11 +103,10 @@ registerHooks({
     `import { registerHooks } from "node:module";
 registerHooks({
   resolve(specifier, context, nextResolve) {
-    const resolved = nextResolve(specifier, context);
-    if (/\\/cli\\/run-main\\.(?:js|ts)$/.test(resolved.url)) {
+    if (/\\/cli\\/run-main\\.(?:js|ts)(?:[?#].*)?$/.test(specifier)) {
       throw new Error("forced run-main import failure");
     }
-    return resolved;
+    return nextResolve(specifier, context);
   },
 });
 `,
@@ -152,6 +151,10 @@ async function runCliProcess(params: {
   const child = spawn(
     process.execPath,
     [
+      "--import",
+      "tsx",
+      // Node runs later sync customization hooks first. Install test guards after
+      // TSX so they own the requested specifier instead of TSX's resolved result.
       ...(params.forbidTlsImport
         ? ["--import", pathToFileURL(fixture.tlsImportGuardPath).href]
         : []),
@@ -162,8 +165,6 @@ async function runCliProcess(params: {
       ...(params.unsupportedRuntime
         ? ["--import", pathToFileURL(fixture.unsupportedRuntimePath).href]
         : []),
-      "--import",
-      "tsx",
       "src/entry.ts",
       ...params.args,
     ],


### PR DESCRIPTION
Related: #121939

## What Problem This Solves

Resolves a problem where the CLI process suite could intermittently miss its injected `run-main` import failure, wait until the deadlock guard killed the child, and fail an otherwise healthy Node CI shard.

## Why This Change Was Made

The source-process harness now loads `tsx` before installing its synchronous test hooks, so the guards own the requested CLI specifier instead of sitting below `tsx` and inspecting its resolved URL. The failure hook rejects the `run-main` request before delegating; production CLI behavior is unchanged.

This PR is AI-assisted. I inspected the affected harness and CLI entry path, Node v24.15.0's preload/hook implementation, and `tsx` v4.23.1's synchronous hook composition before changing the injection boundary.

## User Impact

No user-visible product change. Maintainers get deterministic process-test coverage for dotenv-backed early CLI failure formatting without spurious 240-second shard failures.

## Evidence

- Original failure: [CI run 31504048537, attempt 1, checks-node-compact-small-1](https://github.com/openclaw/openclaw/actions/runs/31504048537/job/93821365421) (`code: null` after the child deadlock guard).
- Same-head flake confirmation: [attempt 2 passed](https://github.com/openclaw/openclaw/actions/runs/31504048537/job/93831066441).
- Blacksmith Testbox: targeted regression passed 10/10; the complete `src/cli/help-exit.process.test.ts` file passed 25/25. [Hydrated run](https://github.com/openclaw/openclaw/actions/runs/31513794006).
- `oxfmt --check src/cli/help-exit.process.test.ts`
- `oxlint src/cli/help-exit.process.test.ts` (0 warnings, 0 errors)
- Codex autoreview (`gpt-5.6-sol`, high): no accepted/actionable findings.
