### PR TITLE
refactor(state): retire commitments schema

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/PortGuardianRecordStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/PortGuardianRecordStoreTests.swift
@@ -532,7 +532,7 @@ struct PortGuardianRecordStoreTests {
         let fixture = try Self.fixture()
         defer { fixture.cleanup() }
 
-        for version in [4, 5, 6] {
+        for version in [4, 5, 6, 7] {
             let databaseURL = fixture.root.appendingPathComponent("supported-v\(version).sqlite")
             try Self.seedVersionedPortGuardianDatabase(databaseURL, schemaVersion: version)
             let store = try PortGuardianRecordStore(databaseURL: databaseURL)
@@ -544,7 +544,7 @@ struct PortGuardianRecordStoreTests {
             #expect(try store.records() == [record])
         }
 
-        for version in [7, 99] {
+        for version in [8, 99] {
             let databaseURL = fixture.root.appendingPathComponent("newer-v\(version).sqlite")
             try Self.seedVersionedPortGuardianDatabase(databaseURL, schemaVersion: version)
             #expect(throws: PortGuardianStoreError.self) {

--- a/apps/shared/OpenClawKit/Sources/OpenClawNativeState/OpenClawNativeStateSQLite.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawNativeState/OpenClawNativeStateSQLite.swift
@@ -37,7 +37,7 @@ public enum OpenClawNativeStateSQLiteValueType: Equatable, Sendable {
 /// One recursive connection lock serializes transactions and statement access.
 public final class OpenClawNativeStateSQLite: @unchecked Sendable {
     // Keep aligned with OPENCLAW_STATE_SCHEMA_VERSION. Native clients never upgrade this database.
-    private static let maximumSupportedSchemaVersion: Int64 = 6
+    private static let maximumSupportedSchemaVersion: Int64 = 7
     private static let defaultBusyTimeoutMilliseconds: Int32 = 5000
 
     private struct SchemaObject: Hashable {

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"4cbdbf71af85d9f128c7508ff8fc731e26d6534a005cf198ee65a29900c77340","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}
+{"contentHash":"e2a5ce75757e7a275312c91ce95bdb4f13091a3c613dd4c66fdda0b2e4d3bf83","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
@@ -1,1 +1,1 @@
-{"contentHash":"23d191b0194005162c3004d7094de2c2ab3130519cc1dd8e93b9fd3b7de1887a","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
+{"contentHash":"0e4494129d83b508c82788383f8dfead578976ed474be2cfbec557aa6caf88e7","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-core.json
@@ -1,1 +1,1 @@
-{"contentHash":"1a06845da584661ae0964b92fb78a6e30b5b49eb76e8607d7d27e22b9cea06e5","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}
+{"contentHash":"8643a3553553855a519e825fcaa483024ecd3538675c5a2d474af841fb5070d7","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
@@ -1,1 +1,1 @@
-{"contentHash":"3a12bd6e0a49b35124afb94210e13e08d009c3879f28e5d397f7c3155155ef8d","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}
+{"contentHash":"13ec7276e7c37ae4e7589e67302c2bf531674f2c439b70d4a8a44a4ee136f685","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-inbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-inbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"017a51cefc0713190d68e7ba9a7901d45342451ca3b05c4830072340fa86515e","entrypoint":"channel-inbound","importSpecifier":"openclaw/plugin-sdk/channel-inbound"}
+{"contentHash":"ed0a5bf19bbe6e9641c8de12ea94105865850343c319a58953a2dce21e6d3f49","entrypoint":"channel-inbound","importSpecifier":"openclaw/plugin-sdk/channel-inbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-message.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-message.json
@@ -1,1 +1,1 @@
-{"contentHash":"986d193f0ee65375bba05e796533e619ef5d5861d3cb4b76d3233ff94f60ae26","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}
+{"contentHash":"feb6187469b8f0e88c0445ba025cc557c94871db55f39075eb63044d8ba48cd7","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"f34d5a25428beca66e891f24c358befc2ffa900ae5efe66770039e95b6d554f8","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}
+{"contentHash":"97d39817d24eaf5b2808960770447188daa0b2959514efbd44db007797e40e3b","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
@@ -1,1 +1,1 @@
-{"contentHash":"c16c7681de92566c0c886aae20c229422185d65a6a1be627e97fe4152b9a0cd9","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}
+{"contentHash":"e824840c22ccade58891ad2952a6aea4aafa8c163adb4383e9a5aa8b47cce44b","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}

--- a/docs/.generated/plugin-sdk-api-baseline/core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/core.json
@@ -1,1 +1,1 @@
-{"contentHash":"c8683be7c78ece135932acd07c4b5c8e840177d1fe16f9da298202287dd4b305","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}
+{"contentHash":"08bba8059fb44659737936c0ef4c163cfff29872db3088b72d2fff82f4c4ac85","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}

--- a/docs/.generated/plugin-sdk-api-baseline/discord.json
+++ b/docs/.generated/plugin-sdk-api-baseline/discord.json
@@ -1,1 +1,1 @@
-{"contentHash":"cf626c5629096ad218de506f7e35d22806efcbd4eacccc3d84df13aa726f7f33","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}
+{"contentHash":"db6ac3119377920f375bdb1cd01082815022f2ad49de3dc5d7ac258a6a864ca6","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}

--- a/docs/.generated/plugin-sdk-api-baseline/gateway-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/gateway-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"6b238d77a12894d47525c52b8e564656292178054b6f7dfcba4c5f4ba721c124","entrypoint":"gateway-runtime","importSpecifier":"openclaw/plugin-sdk/gateway-runtime"}
+{"contentHash":"9f395b8d8bc7f59316cc969ab88242928e383241ddb5e4e30e43419823bb2724","entrypoint":"gateway-runtime","importSpecifier":"openclaw/plugin-sdk/gateway-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
+++ b/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
@@ -1,1 +1,1 @@
-{"contentHash":"449257831591673a7f5bb4a2664cf5931cdc7ba9baa380f4b25513fb11a66c13","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}
+{"contentHash":"7bb8bb13f101a7018aea253debd9c3611635541b8ad2d847e827300b9f94991f","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}

--- a/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"63740457d088b93b3f42f5f5991ca566c03c7024a471bfcee9f4bae3dd1f609e","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}
+{"contentHash":"e5c950c85caf1fe7edf4d672f95afc074e926e300981d96707ed904304e001b4","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
@@ -1,1 +1,1 @@
-{"contentHash":"73b7833128355b975c6084eeb195b2d2278982fb42e00253ad1d26249cb6bd51","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}
+{"contentHash":"f6867c932f2632409f933d8e158d01f303679950b4e6e3a01ba28b0ea8b4d7da","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"0b4f0f3996add880e30ae03f78f1ee8220d67eece0b85c89204e9e384f242d8f","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}
+{"contentHash":"53a44cf7b1b8866054e905dd7a34623e75dbf4be6da5b58e7d47fd638e2a92f5","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"1cd3f740a75bcc58e73253165e13bef74f7e4472d59d2cb0c5f3a14a5944a4e6","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
+{"contentHash":"03aeade34faf6a1c6bfee3e88f684ccb4abe657ea8f3475c96162698baeeb314","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
+++ b/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
@@ -1,1 +1,1 @@
-{"contentHash":"9f785c65c9d357a29d1449fe6ac3c4bbafe9cd638298485f209ba3547bf118ee","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}
+{"contentHash":"83795fac5e17a90840255de8446aaf23b988a14d19bc76a327b0b74ef5f9ee8a","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}

--- a/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
+++ b/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
@@ -1,1 +1,1 @@
-{"contentHash":"d99313fa91889a8eb69c5331f28dac834d133c7dadd2b6fafae69975afdeb56e","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}
+{"contentHash":"9511576a6c8d6631cbe81dc7aca200f670feaf7fc03d6b3308066b5caa3ab50c","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}

--- a/docs/refactor/database-first.md
+++ b/docs/refactor/database-first.md
@@ -202,7 +202,7 @@ without exceptions outside doctor/import/export/debug boundaries.
 - No active session files.
 - No fake JSONL test fixtures except doctor legacy migration tests.
 - No raw SQLite access where Kysely is expected.
-- No new file-era runtime stores. The current global schema is version `6`, and
+- No new file-era runtime stores. The current global schema is version `7`, and
   the current per-agent schema is version `17`; older supported databases move
   through the bounded forward migrations listed in
   [Database schemas](/reference/database-schemas).
@@ -309,7 +309,7 @@ The branch already has a real shared SQLite base:
 - Runtime stores derive selected and inserted row types from those generated
   Kysely `DB` interfaces instead of shadowing SQLite row shapes by hand. Raw SQL
   remains limited to schema application, pragmas, and migration-only DDL.
-- The global SQLite schema is at `user_version = 6`. The per-agent schema is at
+- The global SQLite schema is at `user_version = 7`. The per-agent schema is at
   version `17`; their openers apply bounded forward migrations from supported
   older schemas. File-to-database import remains in Doctor code.
 - Relational ownership is enforced where the ownership boundary is canonical:
@@ -320,7 +320,7 @@ The branch already has a real shared SQLite base:
   `auth_profile_stores`, `auth_profile_state`,
   `plugin_state_entries`, `plugin_blob_entries`, `media_blobs`,
   `skill_uploads`, `capture_sessions`, `capture_events`, `capture_blobs`,
-  `sandbox_registry_entries`, `cron_jobs`, `commitments`,
+  `sandbox_registry_entries`, `cron_jobs`,
   `delivery_queue_entries`, `model_capability_cache`,
   `workspace_setup_state`, `workspace_path_aliases`, `workspace_attestations`,
   `workspace_generated_bootstrap_hashes`, `native_hook_relay_bridges`,
@@ -348,7 +348,7 @@ The branch already has a real shared SQLite base:
   site.
 - Global and per-agent databases record a `schema_meta` row with database role,
   schema version, timestamps, and agent id for agent databases. The global DB
-  currently uses `user_version = 6`; per-agent DBs use version `17`.
+  currently uses `user_version = 7`; per-agent DBs use version `17`.
 - Per-agent session identity now has a canonical `sessions` root table keyed by
   `session_id`, with `session_key`, `session_scope`, `account_id`,
   `primary_conversation_id`, timestamps, display fields, model metadata,
@@ -1112,10 +1112,9 @@ sessionId})`; create, branch, continue, list, and fork flows live in their
   sharded JSON registry files and removes successful sources. Runtime reads use
   the typed row columns as source of truth; `entry_json` is only a replay/debug
   copy.
-- The retired `commitments` table remains in the shared schema only until an
-  approved schema-version migration can drop it. Runtime no longer reads or
-  writes commitment rows. Doctor leaves retained rows and the legacy
-  `commitments.json` source untouched.
+- Shared schema version 7 removes the retired `commitments` table and discards
+  its inert rows. Runtime no longer reads or writes commitment state. Doctor
+  leaves the legacy `commitments.json` source untouched.
 - Web Push subscriptions and the generated VAPID identity now use typed shared
   `web_push_subscriptions` and `web_push_vapid_keys` rows. Runtime registration,
   expiry cleanup, and first-use key generation use row-level SQLite
@@ -1536,7 +1535,6 @@ config_health_entries(config_path, last_known_good_json, last_promoted_good_json
 sandbox_registry_entries(registry_kind, container_name, session_key, backend_id, runtime_label, image, created_at_ms, last_used_at_ms, config_label_kind, config_hash, cdp_port, no_vnc_port, entry_json, updated_at)
 cron_jobs(store_key, job_id, name, description, enabled, delete_after_run, created_at_ms, agent_id, session_key, schedule_kind, schedule_expr, schedule_tz, every_ms, anchor_ms, at, stagger_ms, session_target, wake_mode, payload_kind, payload_message, payload_model, payload_fallbacks_json, payload_thinking, payload_timeout_seconds, payload_allow_unsafe_external_content, payload_external_content_source_json, payload_light_context, payload_tools_allow_json, delivery_mode, delivery_channel, delivery_to, delivery_thread_id, delivery_account_id, delivery_best_effort, failure_delivery_mode, failure_delivery_channel, failure_delivery_to, failure_delivery_account_id, failure_alert_disabled, failure_alert_after, failure_alert_channel, failure_alert_to, failure_alert_cooldown_ms, failure_alert_include_skipped, failure_alert_mode, failure_alert_account_id, next_run_at_ms, running_at_ms, last_run_at_ms, last_run_status, last_error, last_duration_ms, consecutive_errors, consecutive_skipped, schedule_error_count, last_delivery_status, last_delivery_error, last_delivered, last_failure_alert_at_ms, job_json, state_json, runtime_updated_at_ms, schedule_identity, sort_order, updated_at)
 delivery_queue_entries(queue_name, id, status, entry_kind, session_key, channel, target, account_id, retry_count, last_attempt_at, last_error, recovery_state, platform_send_started_at, entry_json, enqueued_at, updated_at, failed_at)
-commitments(id, agent_id, session_key, channel, account_id, recipient_id, thread_id, sender_id, kind, sensitivity, source, status, reason, suggested_text, dedupe_key, confidence, due_earliest_ms, due_latest_ms, due_timezone, source_message_id, source_run_id, created_at_ms, updated_at_ms, attempts, last_attempt_at_ms, sent_at_ms, dismissed_at_ms, snoozed_until_ms, expired_at_ms, record_json)
 migration_runs(id, started_at, finished_at, status, report_json)
 migration_sources(source_key, migration_kind, source_path, target_table, source_sha256, source_size_bytes, source_record_count, last_run_id, status, imported_at, removed_source, report_json)
 backup_runs(id, created_at, archive_path, status, manifest_json)
@@ -1638,8 +1636,8 @@ Move these into the global database:
 - Host and Apple device identity/auth, push, update check, OpenRouter model
   cache, installed plugin index, and app-server bindings. Android device auth
   remains app-local in `SecurePrefs`.
-- Retired commitment rows and the legacy `commitments.json` source stay inert
-  until an approved retention and schema-version migration removes them.
+- Shared schema version 7 discards retired commitment rows and removes their
+  table. The legacy `commitments.json` source stays inert and untouched.
 - Device/node pairing and bootstrap records now use typed SQLite tables
 - Device-pair notification subscribers and delivered-request markers now use the
   shared SQLite plugin-state table instead of `device-pair-notify.json`.
@@ -1895,7 +1893,7 @@ Backups remain one archive file:
   creation integrity check.
 - Restore copies snapshots back to their target paths without rewriting their
   recorded schema versions. The normal database open then applies bounded
-  forward migrations to the current global version `6` or per-agent version
+  forward migrations to the current global version `7` or per-agent version
   `17` when required.
 
 ### Phase 6: Worker Runtime
@@ -1949,7 +1947,7 @@ status.
 Restore should rebuild the global database and agent database files from the
 archive snapshots without rewriting their recorded schema versions. Normal
 database open applies bounded forward migrations to the current global version
-`6` or per-agent version `17`. Doctor remains the only owner of file-to-database
+`7` or per-agent version `17`. Doctor remains the only owner of file-to-database
 import. The restore command validates the archive first, then replaces each
 manifest asset from the verified extracted payload.
 
@@ -1957,7 +1955,7 @@ manifest asset from the verified extracted payload.
 
 1. Add database registry APIs.
    - Resolve global DB and per-agent DB paths.
-   - The global schema now uses `user_version = 6`; per-agent DBs use version
+   - The global schema now uses `user_version = 7`; per-agent DBs use version
      `17`, with bounded forward migrations from supported older versions.
    - Add close/checkpoint/integrity helpers used by tests, backup, and doctor.
 

--- a/docs/refactor/database-first.md
+++ b/docs/refactor/database-first.md
@@ -1112,9 +1112,10 @@ sessionId})`; create, branch, continue, list, and fork flows live in their
   sharded JSON registry files and removes successful sources. Runtime reads use
   the typed row columns as source of truth; `entry_json` is only a replay/debug
   copy.
-- Shared schema version 7 removes the retired `commitments` table and discards
-  its inert rows. Runtime no longer reads or writes commitment state. Doctor
-  leaves the legacy `commitments.json` source untouched.
+- Shared schema version 7 validates and removes the exact retired `commitments`
+  table and discards its inert rows. Unknown same-named tables or indexes are
+  preserved and the migration is refused. Runtime no longer reads or writes
+  commitment state. Doctor leaves the legacy `commitments.json` source untouched.
 - Web Push subscriptions and the generated VAPID identity now use typed shared
   `web_push_subscriptions` and `web_push_vapid_keys` rows. Runtime registration,
   expiry cleanup, and first-use key generation use row-level SQLite

--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -85,6 +85,7 @@ Version 3 was an unshipped development step folded into version 4.
 | 4       | Session watch provenance replaces encoded sentinel rows                                                                                                                                                                                          | Unreleased          |
 | 5       | Durable cloud-worker result references on pending workspace fences ([`7a7d6bb`](https://github.com/openclaw/openclaw/commit/7a7d6bb51f42bd896de2b8a4df2ee66f3dce0a21), [#110952](https://github.com/openclaw/openclaw/pull/110952))              | `v2026.7.2-beta.4`  |
 | 6       | Every committed shared-state table becomes part of the canonical runtime schema ([`509a5f0`](https://github.com/openclaw/openclaw/commit/509a5f03737642fec4a940e6d605887f7957ddc8), [#113473](https://github.com/openclaw/openclaw/pull/113473)) | `v2026.7.2-beta.5`  |
+| 7       | Retired inferred-commitment storage removed                                                                                                                                                                                                      | Unreleased          |
 
 ## Integrity checks
 
@@ -136,6 +137,74 @@ The general procedure is:
 2. In one transaction, drop every table, index, trigger, and column introduced after the target version.
 3. Set `PRAGMA user_version` and `schema_meta.schema_version` to the target version.
 4. Run the target release's full database verification before starting the Gateway.
+
+### Example: state schema 7 to 6
+
+Schema 7 removed the retired shared commitments table. A schema 6 build still requires that canonical table, so a manual downgrade must recreate its exact empty schema before lowering the version.
+
+Run equivalent SQL against the global state database after inspecting the exact schema that wrote it:
+
+```sql
+BEGIN IMMEDIATE;
+
+CREATE TABLE commitments (
+  id TEXT NOT NULL PRIMARY KEY,
+  agent_id TEXT NOT NULL,
+  session_key TEXT NOT NULL,
+  channel TEXT NOT NULL,
+  account_id TEXT,
+  recipient_id TEXT,
+  thread_id TEXT,
+  sender_id TEXT,
+  kind TEXT NOT NULL,
+  sensitivity TEXT NOT NULL,
+  source TEXT NOT NULL,
+  status TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  suggested_text TEXT NOT NULL,
+  dedupe_key TEXT NOT NULL,
+  confidence REAL NOT NULL,
+  due_earliest_ms INTEGER NOT NULL,
+  due_latest_ms INTEGER NOT NULL,
+  due_timezone TEXT NOT NULL,
+  source_message_id TEXT,
+  source_run_id TEXT,
+  created_at_ms INTEGER NOT NULL,
+  updated_at_ms INTEGER NOT NULL,
+  attempts INTEGER NOT NULL,
+  last_attempt_at_ms INTEGER,
+  sent_at_ms INTEGER,
+  dismissed_at_ms INTEGER,
+  snoozed_until_ms INTEGER,
+  expired_at_ms INTEGER,
+  record_json TEXT NOT NULL
+) STRICT;
+
+CREATE INDEX idx_commitments_scope_due
+  ON commitments(agent_id, session_key, status, due_earliest_ms, due_latest_ms);
+
+CREATE INDEX idx_commitments_status_due
+  ON commitments(status, due_earliest_ms, due_latest_ms);
+
+CREATE INDEX idx_commitments_scope_dedupe
+  ON commitments(agent_id, session_key, channel, dedupe_key, status);
+
+CREATE INDEX idx_commitments_agent_due
+  ON commitments(agent_id, status, due_earliest_ms, due_latest_ms, session_key);
+
+CREATE INDEX idx_commitments_agent_sent
+  ON commitments(agent_id, status, sent_at_ms, session_key);
+
+PRAGMA user_version = 6;
+UPDATE schema_meta
+SET schema_version = 6,
+    updated_at = unixepoch('now') * 1000
+WHERE meta_key = 'primary';
+
+COMMIT;
+```
+
+The recreated table starts empty because schema 7 discarded the retired rows. A botched downgrade means restore from the verified backup.
 
 ### Example: agent schema 17 to 16
 

--- a/extensions/voice-call/doctor-contract-api.ts
+++ b/extensions/voice-call/doctor-contract-api.ts
@@ -140,6 +140,8 @@ function describeVoiceCallSchemaMigration(migration: OpenClawStateDatabaseSchema
       return "agent database registry primary key -> agent_id,path";
     case "audit-events-v2":
       return "audit event ledger -> versioned message lifecycle schema";
+    case "commitments-retirement-v7":
+      return "retired commitments storage -> removed table and indexes";
     case "operator-approvals-system-agent":
       return "operator approvals -> OpenClaw system changes";
     case "session-watch-cursor-provenance-v4":

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2026.8.1",
   "openclaw": {
     "schemaVersions": {
-      "state": 6,
+      "state": 7,
       "agent": 17
     }
   },

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -1053,6 +1053,7 @@ describe("doctor legacy state migrations", () => {
     const result = await runLegacyStateMigrations({ detected });
     expect(result.warnings).toStrictEqual([]);
     expect(result.changes).toStrictEqual([
+      "Retired shared state commitments table and indexes",
       "Migrated shared state agent database registry primary key → agent_id,path",
     ]);
 

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -1053,7 +1053,6 @@ describe("doctor legacy state migrations", () => {
     const result = await runLegacyStateMigrations({ detected });
     expect(result.warnings).toStrictEqual([]);
     expect(result.changes).toStrictEqual([
-      "Retired shared state commitments table and indexes",
       "Migrated shared state agent database registry primary key → agent_id,path",
     ]);
 

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -180,6 +180,8 @@ function describeStateSchemaMigration(migration: OpenClawStateDatabaseSchemaMigr
       return "agent database registry primary key → agent_id,path";
     case "audit-events-v2":
       return "audit event ledger → versioned message lifecycle schema";
+    case "commitments-retirement-v7":
+      return "retired commitments storage → removed table and indexes";
     case "operator-approvals-system-agent":
       return "operator approvals → OpenClaw system changes";
     case "session-watch-cursor-provenance-v4":

--- a/src/secrets/store/secret-store.test.ts
+++ b/src/secrets/store/secret-store.test.ts
@@ -7,6 +7,7 @@ import { isSecretValueRegisteredForRedaction } from "../../logging/secret-redact
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
+  OPENCLAW_STATE_SCHEMA_VERSION,
 } from "../../state/openclaw-state-db.js";
 import {
   deleteSecretStoreEntry,
@@ -164,13 +165,15 @@ describe("secret store", () => {
     expect(stored.ok && stored.value).toBe("");
   });
 
-  it("treats a missing lazy table as empty and preserves schema version 6 on ensure", () => {
+  it("treats a missing lazy table as empty and preserves the current schema version", () => {
     const database = createDatabaseOptions();
     openOpenClawStateDatabase(database);
     closeOpenClawStateDatabaseForTest();
     const { DatabaseSync } = requireNodeSqlite();
     const before = new DatabaseSync(database.path);
-    expect(before.prepare("PRAGMA user_version").get()).toEqual({ user_version: 6 });
+    expect(before.prepare("PRAGMA user_version").get()).toEqual({
+      user_version: OPENCLAW_STATE_SCHEMA_VERSION,
+    });
     before.exec("DROP TABLE secret_store_entries;");
     before.close();
 
@@ -197,7 +200,9 @@ describe("secret store", () => {
     });
     closeOpenClawStateDatabaseForTest();
     const after = new DatabaseSync(database.path, { readOnly: true });
-    expect(after.prepare("PRAGMA user_version").get()).toEqual({ user_version: 6 });
+    expect(after.prepare("PRAGMA user_version").get()).toEqual({
+      user_version: OPENCLAW_STATE_SCHEMA_VERSION,
+    });
     expect(
       after
         .prepare("SELECT name FROM sqlite_schema WHERE type = 'index' AND name = ?")

--- a/src/state/openclaw-schema-retirements.json
+++ b/src/state/openclaw-schema-retirements.json
@@ -1,20 +1,6 @@
 {
   "retirements": [
     {
-      "database": "state",
-      "status": "planned",
-      "targetVersion": 7,
-      "table": "commitments",
-      "indexes": [
-        "idx_commitments_scope_due",
-        "idx_commitments_status_due",
-        "idx_commitments_scope_dedupe",
-        "idx_commitments_agent_due",
-        "idx_commitments_agent_sent"
-      ],
-      "note": "Remove the retired commitments feature in the next shared-state schema."
-    },
-    {
       "database": "agent",
       "status": "completed",
       "targetVersion": 17,

--- a/src/state/openclaw-state-db-contract.ts
+++ b/src/state/openclaw-state-db-contract.ts
@@ -1,9 +1,10 @@
 import type { DatabaseSync } from "node:sqlite";
 import type { SqliteWalMaintenance } from "../infra/sqlite-wal.js";
 
+// v7 retires the inert shared commitments table.
 // v6 makes every committed shared-state table part of the canonical runtime schema.
 // v5 records durable cloud-worker result refs on pending workspace fences.
-export const OPENCLAW_STATE_SCHEMA_VERSION = 6;
+export const OPENCLAW_STATE_SCHEMA_VERSION = 7;
 export const OPENCLAW_STATE_STRICT_SCHEMA_VERSION = 3;
 // Privacy-sensitive feature tables remain absent even in fresh databases until
 // their feature-local first write. The canonical SQL still owns their shape.

--- a/src/state/openclaw-state-db-contract.ts
+++ b/src/state/openclaw-state-db-contract.ts
@@ -64,6 +64,7 @@ export type OpenClawStateDatabaseSchemaMigration = {
   kind:
     | "agent-databases-composite-primary-key"
     | "audit-events-v2"
+    | "commitments-retirement-v7"
     | "operator-approvals-system-agent"
     | "session-watch-cursor-provenance-v4"
     | "strict-tables-v3";

--- a/src/state/openclaw-state-db-maintenance.ts
+++ b/src/state/openclaw-state-db-maintenance.ts
@@ -18,6 +18,11 @@ import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 import { OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY } from "./openclaw-state-schema-compatibility.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.js";
 
+const STATE_V6_ADDITIVE_TABLES = [
+  ...LAZY_ADDITIVE_STATE_TABLES,
+  "worker_session_tool_operations",
+  "worker_turn_tool_authorities",
+] as const;
 const STATE_V5_ADDITIVE_TABLES = [
   "agent_database_leases",
   "agent_deletion_journal",
@@ -35,7 +40,7 @@ const STATE_V5_ADDITIVE_TABLES = [
   "worker_environment_credentials",
   "worker_transcript_commit_heads",
   "worker_transcript_commits",
-  ...LAZY_ADDITIVE_STATE_TABLES,
+  ...STATE_V6_ADDITIVE_TABLES,
 ] as const;
 
 /** Open shared SQLite database handle plus WAL maintenance lifecycle. */
@@ -126,30 +131,53 @@ export function assertOpenClawStateDatabaseForMaintenance(
   );
 }
 
-/** Require every stable v5 table before the v6 additive migration can run. */
-export function assertOpenClawStateDatabaseV5ForMigration(
+function assertOpenClawStateDatabaseVersionForMigration(
   database: DatabaseSync,
-  options: { pathname: string },
+  options: { pathname: string; version: number; allowedMissingTables: readonly string[] },
 ): void {
   const userVersion = readSqliteUserVersion(database);
-  if (userVersion !== 5) {
+  if (userVersion !== options.version) {
     throw new Error(
-      `OpenClaw state database ${options.pathname} uses schema version ${userVersion}; expected 5 before migrating it.`,
+      `OpenClaw state database ${options.pathname} uses schema version ${userVersion}; expected ${options.version} before migrating it.`,
     );
   }
   assertOpenClawStateDatabaseOwner(database, options);
   const metadata = database
     .prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary' LIMIT 1")
     .get() as { schema_version?: unknown } | undefined;
-  if (metadata?.schema_version !== 5) {
+  if (metadata?.schema_version !== options.version) {
     const schemaVersion =
       typeof metadata?.schema_version === "number" ? metadata.schema_version : "invalid";
     throw new Error(
-      `OpenClaw state database ${options.pathname} metadata schema version ${schemaVersion} does not match 5; repair the ownership metadata before migrating it.`,
+      `OpenClaw state database ${options.pathname} metadata schema version ${schemaVersion} does not match ${options.version}; repair the ownership metadata before migrating it.`,
     );
   }
   assertSqliteSchemaTablesPresent(database, options.pathname, OPENCLAW_STATE_SCHEMA_SQL, {
+    allowedMissingTables: options.allowedMissingTables,
+  });
+}
+
+/** Require every stable v5 table before the v6 additive migration can run. */
+export function assertOpenClawStateDatabaseV5ForMigration(
+  database: DatabaseSync,
+  options: { pathname: string },
+): void {
+  assertOpenClawStateDatabaseVersionForMigration(database, {
+    ...options,
+    version: 5,
     allowedMissingTables: STATE_V5_ADDITIVE_TABLES,
+  });
+}
+
+/** Require every stable v6 table before the v7 retirement migration can run. */
+export function assertOpenClawStateDatabaseV6ForMigration(
+  database: DatabaseSync,
+  options: { pathname: string },
+): void {
+  assertOpenClawStateDatabaseVersionForMigration(database, {
+    ...options,
+    version: 6,
+    allowedMissingTables: STATE_V6_ADDITIVE_TABLES,
   });
 }
 

--- a/src/state/openclaw-state-db-restart-handoff-migration.test.ts
+++ b/src/state/openclaw-state-db-restart-handoff-migration.test.ts
@@ -91,6 +91,7 @@ describe("gateway restart handoff state migration", () => {
     ]);
     expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
       changes: [
+        "Retired shared state commitments table and indexes",
         "Migrated shared state session watch cursors → provenance column (0 ambient, 0 sentinels removed)",
         "Migrated shared state tables to SQLite STRICT typing (1)",
       ],

--- a/src/state/openclaw-state-db-restart-handoff-migration.test.ts
+++ b/src/state/openclaw-state-db-restart-handoff-migration.test.ts
@@ -91,7 +91,6 @@ describe("gateway restart handoff state migration", () => {
     ]);
     expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
       changes: [
-        "Retired shared state commitments table and indexes",
         "Migrated shared state session watch cursors → provenance column (0 ambient, 0 sentinels removed)",
         "Migrated shared state tables to SQLite STRICT typing (1)",
       ],

--- a/src/state/openclaw-state-db-schema-additive.ts
+++ b/src/state/openclaw-state-db-schema-additive.ts
@@ -354,27 +354,6 @@ export function ensureAdditiveStateColumns(db: DatabaseSync): void {
   ensureColumn(db, "delivery_queue_entries", "recovery_state TEXT");
   ensureColumn(db, "delivery_queue_entries", "platform_send_started_at INTEGER");
   backfillDeliveryQueueEntriesFromEntryJson(db);
-  ensureColumn(db, "commitments", "account_id TEXT");
-  ensureColumn(db, "commitments", "recipient_id TEXT");
-  ensureColumn(db, "commitments", "thread_id TEXT");
-  ensureColumn(db, "commitments", "sender_id TEXT");
-  ensureColumn(db, "commitments", "kind TEXT NOT NULL DEFAULT 'followup'");
-  ensureColumn(db, "commitments", "sensitivity TEXT NOT NULL DEFAULT 'normal'");
-  ensureColumn(db, "commitments", "source TEXT NOT NULL DEFAULT 'unknown'");
-  ensureColumn(db, "commitments", "reason TEXT NOT NULL DEFAULT ''");
-  ensureColumn(db, "commitments", "suggested_text TEXT NOT NULL DEFAULT ''");
-  ensureColumn(db, "commitments", "dedupe_key TEXT NOT NULL DEFAULT ''");
-  ensureColumn(db, "commitments", "confidence REAL NOT NULL DEFAULT 0");
-  ensureColumn(db, "commitments", "due_timezone TEXT NOT NULL DEFAULT 'UTC'");
-  ensureColumn(db, "commitments", "source_message_id TEXT");
-  ensureColumn(db, "commitments", "source_run_id TEXT");
-  ensureColumn(db, "commitments", "created_at_ms INTEGER NOT NULL DEFAULT 0");
-  ensureColumn(db, "commitments", "attempts INTEGER NOT NULL DEFAULT 0");
-  ensureColumn(db, "commitments", "last_attempt_at_ms INTEGER");
-  ensureColumn(db, "commitments", "sent_at_ms INTEGER");
-  ensureColumn(db, "commitments", "dismissed_at_ms INTEGER");
-  ensureColumn(db, "commitments", "snoozed_until_ms INTEGER");
-  ensureColumn(db, "commitments", "expired_at_ms INTEGER");
   // The shipped JSON runtime predeclared this table but never populated it.
   // The transitional default makes ADD COLUMN portable; schema-v2 tables are
   // rebuilt from canonical STRICT SQL immediately afterward, removing it.

--- a/src/state/openclaw-state-db-schema-repair.ts
+++ b/src/state/openclaw-state-db-schema-repair.ts
@@ -30,6 +30,22 @@ export function dropLegacyStateTables(db: DatabaseSync): void {
   db.exec("DROP TABLE IF EXISTS node_pairing_pending; DROP TABLE IF EXISTS node_pairing_paired;");
 }
 
+export function migrateRetiredCommitmentsSchema(db: DatabaseSync, previousVersion: number): void {
+  if (previousVersion >= 7) {
+    return;
+  }
+  // The commitments runtime was removed before v7; retained rows are inert
+  // migration debt and have no remaining product owner or export contract.
+  db.exec(`
+    DROP INDEX IF EXISTS idx_commitments_scope_due;
+    DROP INDEX IF EXISTS idx_commitments_status_due;
+    DROP INDEX IF EXISTS idx_commitments_scope_dedupe;
+    DROP INDEX IF EXISTS idx_commitments_agent_due;
+    DROP INDEX IF EXISTS idx_commitments_agent_sent;
+    DROP TABLE IF EXISTS commitments;
+  `);
+}
+
 function hasCanonicalAgentDatabasesPrimaryKey(db: DatabaseSync): boolean {
   if (!tableExists(db, "agent_databases")) {
     return true;

--- a/src/state/openclaw-state-db-schema-repair.ts
+++ b/src/state/openclaw-state-db-schema-repair.ts
@@ -30,9 +30,12 @@ export function dropLegacyStateTables(db: DatabaseSync): void {
   db.exec("DROP TABLE IF EXISTS node_pairing_pending; DROP TABLE IF EXISTS node_pairing_paired;");
 }
 
-export function migrateRetiredCommitmentsSchema(db: DatabaseSync, previousVersion: number): void {
+export function migrateRetiredCommitmentsSchema(
+  db: DatabaseSync,
+  previousVersion: number,
+): boolean {
   if (previousVersion >= 7) {
-    return;
+    return false;
   }
   // The commitments runtime was removed before v7; retained rows are inert
   // migration debt and have no remaining product owner or export contract.
@@ -44,6 +47,7 @@ export function migrateRetiredCommitmentsSchema(db: DatabaseSync, previousVersio
     DROP INDEX IF EXISTS idx_commitments_agent_sent;
     DROP TABLE IF EXISTS commitments;
   `);
+  return true;
 }
 
 function hasCanonicalAgentDatabasesPrimaryKey(db: DatabaseSync): boolean {

--- a/src/state/openclaw-state-db-schema-repair.ts
+++ b/src/state/openclaw-state-db-schema-repair.ts
@@ -6,6 +6,7 @@ import {
   collectSqliteSchemaIssues,
   type SqliteSchemaCompatibility,
 } from "../infra/sqlite-schema-contract.js";
+import { quoteSqliteIdentifier } from "../infra/sqlite-schema-sql.js";
 import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
 import {
   canRepairLegacyAuditEventsSchema,
@@ -92,6 +93,12 @@ CREATE TABLE commitments (
   updated_at_ms INTEGER NOT NULL,
   record_json TEXT NOT NULL
 );
+CREATE INDEX idx_commitments_scope_due
+  ON commitments(agent_id, session_key, status, due_earliest_ms, due_latest_ms);
+CREATE INDEX idx_commitments_status_due
+  ON commitments(status, due_earliest_ms, due_latest_ms);
+CREATE INDEX idx_commitments_agent_due
+  ON commitments(agent_id, status, due_earliest_ms, due_latest_ms, session_key);
 `;
 
 const RETIRED_COMMITMENTS_INDEX_NAMES = [
@@ -118,9 +125,20 @@ const RETIRED_COMMITMENTS_SCHEMA_COMPATIBILITY: SqliteSchemaCompatibility = {
     "commitments.source": ["source TEXT NOT NULL DEFAULT 'unknown'"],
     "commitments.suggested_text": ["suggested_text TEXT NOT NULL DEFAULT ''"],
   },
+  allowedMissingIndexes: RETIRED_COMMITMENTS_INDEX_NAMES,
 };
 
-function hasExactRetiredCommitmentsSchema(
+const EARLY_RETIRED_COMMITMENTS_INDEX_NAMES = [
+  "idx_commitments_agent_due",
+  "idx_commitments_scope_due",
+  "idx_commitments_status_due",
+] as const;
+
+const EARLY_RETIRED_COMMITMENTS_SCHEMA_COMPATIBILITY: SqliteSchemaCompatibility = {
+  allowedMissingIndexes: EARLY_RETIRED_COMMITMENTS_INDEX_NAMES,
+};
+
+function hasSupportedRetiredCommitmentsSchema(
   db: DatabaseSync,
   schemaSql: string,
   expectedIndexNames: readonly string[],
@@ -139,11 +157,9 @@ function hasExactRetiredCommitmentsSchema(
           ORDER BY type, name`,
     )
     .all() as Array<{ name: string; type: string }>;
-  return (
-    attachedObjects.length === expectedIndexNames.length &&
-    attachedObjects.every(
-      (object, index) => object.type === "index" && object.name === expectedIndexNames[index],
-    )
+  const expectedIndexes = new Set(expectedIndexNames);
+  return attachedObjects.every(
+    (object) => object.type === "index" && expectedIndexes.has(object.name),
   );
 }
 
@@ -155,6 +171,7 @@ function assertRecognizedRetiredCommitmentsSchema(db: DatabaseSync): void {
     db,
     "retired OpenClaw commitments schema",
     RETIRED_COMMITMENTS_SCHEMA_SQL,
+    RETIRED_COMMITMENTS_SCHEMA_COMPATIBILITY,
   );
   throw new Error(
     "Retired OpenClaw commitments schema has unsupported additional indexes; refusing destructive migration.",
@@ -163,13 +180,116 @@ function assertRecognizedRetiredCommitmentsSchema(db: DatabaseSync): void {
 
 function hasRecognizedRetiredCommitmentsSchema(db: DatabaseSync): boolean {
   return (
-    hasExactRetiredCommitmentsSchema(
+    hasSupportedRetiredCommitmentsSchema(
       db,
       RETIRED_COMMITMENTS_SCHEMA_SQL,
       RETIRED_COMMITMENTS_INDEX_NAMES,
       RETIRED_COMMITMENTS_SCHEMA_COMPATIBILITY,
-    ) || hasExactRetiredCommitmentsSchema(db, EARLY_RETIRED_COMMITMENTS_SCHEMA_SQL, [])
+    ) ||
+    hasSupportedRetiredCommitmentsSchema(
+      db,
+      EARLY_RETIRED_COMMITMENTS_SCHEMA_SQL,
+      EARLY_RETIRED_COMMITMENTS_INDEX_NAMES,
+      EARLY_RETIRED_COMMITMENTS_SCHEMA_COMPATIBILITY,
+    )
   );
+}
+
+function assertNoRetiredCommitmentsForeignKeys(db: DatabaseSync): void {
+  const tables = db
+    .prepare(
+      `SELECT name
+         FROM sqlite_schema
+        WHERE type = 'table' AND name <> 'commitments'
+        ORDER BY name`,
+    )
+    .all() as Array<{ name: string }>;
+  for (const table of tables) {
+    const foreignKeys = db
+      .prepare(`PRAGMA foreign_key_list(${quoteSqliteIdentifier(table.name)})`)
+      .all() as Array<{ table?: unknown }>;
+    if (
+      foreignKeys.some(
+        (foreignKey) =>
+          typeof foreignKey.table === "string" && foreignKey.table.toLowerCase() === "commitments",
+      )
+    ) {
+      throw new Error(
+        `Retired OpenClaw commitments schema is referenced by table ${table.name}; refusing destructive migration.`,
+      );
+    }
+  }
+}
+
+function collectRetainedSchemaSql(db: DatabaseSync): Map<string, string> {
+  return new Map(
+    (
+      db
+        .prepare(
+          `SELECT type, name, sql
+             FROM sqlite_schema
+            WHERE type IN ('trigger', 'view')
+              AND tbl_name <> 'commitments'
+              AND sql IS NOT NULL
+            ORDER BY type, name`,
+        )
+        .all() as Array<{ name: string; sql: string; type: string }>
+    ).map((object) => [`${object.type}:${object.name}`, object.sql]),
+  );
+}
+
+function assertNoRetiredCommitmentsSchemaDependencies(db: DatabaseSync): void {
+  const probeTable = "__openclaw_retired_commitments_probe";
+  if (tableExists(db, probeTable)) {
+    throw new Error(
+      `OpenClaw state database already contains ${probeTable}; refusing destructive migration.`,
+    );
+  }
+  const before = collectRetainedSchemaSql(db);
+  const savepoint = "openclaw_probe_commitments_dependencies";
+  db.exec(`SAVEPOINT ${savepoint};`);
+  let changedObject: string | undefined;
+  try {
+    db.exec(`ALTER TABLE commitments RENAME TO ${quoteSqliteIdentifier(probeTable)};`);
+    const after = collectRetainedSchemaSql(db);
+    changedObject = [...before].find(([object, sql]) => after.get(object) !== sql)?.[0];
+  } catch (error) {
+    db.exec(`ROLLBACK TO ${savepoint}; RELEASE ${savepoint};`);
+    // A broken retained object makes dependency resolution ambiguous. Refuse
+    // rather than discard rows that object may still own indirectly.
+    throw new Error(
+      "Could not prove retained SQLite views and triggers independent of commitments; refusing destructive migration.",
+      { cause: error },
+    );
+  }
+  db.exec(`ROLLBACK TO ${savepoint}; RELEASE ${savepoint};`);
+  if (changedObject) {
+    const [type, name] = changedObject.split(":", 2);
+    throw new Error(
+      `Retired OpenClaw commitments schema is referenced by ${type} ${name}; refusing destructive migration.`,
+    );
+  }
+}
+
+function assertVirtualTablesUsable(db: DatabaseSync, phase: "before" | "after"): void {
+  const virtualTables = db
+    .prepare(
+      `SELECT name
+         FROM sqlite_schema
+        WHERE type = 'table' AND lower(sql) LIKE 'create virtual table%'
+        ORDER BY name`,
+    )
+    .all() as Array<{ name: string }>;
+  for (const table of virtualTables) {
+    try {
+      db.prepare(`SELECT * FROM ${quoteSqliteIdentifier(table.name)} LIMIT 1`).all();
+    } catch (error) {
+      throw new Error(
+        `SQLite virtual table ${table.name} is unusable ${phase} commitments retirement.`,
+        { cause: error },
+      );
+    }
+  }
 }
 
 export function migrateRetiredCommitmentsSchema(
@@ -185,9 +305,21 @@ export function migrateRetiredCommitmentsSchema(
   // The commitments runtime was removed before v7; retained rows are inert
   // migration debt and have no remaining product owner or export contract.
   assertRecognizedRetiredCommitmentsSchema(db);
-  // DROP TABLE removes only the validated table's indexes and sqlite_stat rows.
-  db.exec("DROP TABLE commitments;");
-  return true;
+  assertNoRetiredCommitmentsForeignKeys(db);
+  assertNoRetiredCommitmentsSchemaDependencies(db);
+  assertVirtualTablesUsable(db, "before");
+  const savepoint = "openclaw_retire_commitments_v7";
+  db.exec(`SAVEPOINT ${savepoint};`);
+  try {
+    // DROP TABLE removes only the validated table's indexes and sqlite_stat rows.
+    db.exec("DROP TABLE commitments;");
+    assertVirtualTablesUsable(db, "after");
+    db.exec(`RELEASE ${savepoint};`);
+    return true;
+  } catch (error) {
+    db.exec(`ROLLBACK TO ${savepoint}; RELEASE ${savepoint};`);
+    throw error;
+  }
 }
 
 function hasCanonicalAgentDatabasesPrimaryKey(db: DatabaseSync): boolean {

--- a/src/state/openclaw-state-db-schema-repair.ts
+++ b/src/state/openclaw-state-db-schema-repair.ts
@@ -93,10 +93,46 @@ CREATE TABLE commitments (
 );
 `;
 
+const RETIRED_COMMITMENTS_INDEX_NAMES = [
+  "idx_commitments_agent_due",
+  "idx_commitments_agent_sent",
+  "idx_commitments_scope_dedupe",
+  "idx_commitments_scope_due",
+  "idx_commitments_status_due",
+] as const;
+
+function hasExactRetiredCommitmentsSchema(
+  db: DatabaseSync,
+  schemaSql: string,
+  expectedIndexNames: readonly string[],
+): boolean {
+  if (collectSqliteSchemaIssues(db, schemaSql).length > 0) {
+    return false;
+  }
+  const actualIndexNames = (
+    db
+      .prepare(
+        `SELECT name
+           FROM sqlite_schema
+          WHERE type = 'index' AND tbl_name = 'commitments' AND sql IS NOT NULL
+          ORDER BY name`,
+      )
+      .all() as Array<{ name: string }>
+  ).map((row) => row.name);
+  return (
+    actualIndexNames.length === expectedIndexNames.length &&
+    actualIndexNames.every((name, index) => name === expectedIndexNames[index])
+  );
+}
+
 function assertRecognizedRetiredCommitmentsSchema(db: DatabaseSync): void {
   if (
-    collectSqliteSchemaIssues(db, RETIRED_COMMITMENTS_SCHEMA_SQL).length === 0 ||
-    collectSqliteSchemaIssues(db, EARLY_RETIRED_COMMITMENTS_SCHEMA_SQL).length === 0
+    hasExactRetiredCommitmentsSchema(
+      db,
+      RETIRED_COMMITMENTS_SCHEMA_SQL,
+      RETIRED_COMMITMENTS_INDEX_NAMES,
+    ) ||
+    hasExactRetiredCommitmentsSchema(db, EARLY_RETIRED_COMMITMENTS_SCHEMA_SQL, [])
   ) {
     return;
   }

--- a/src/state/openclaw-state-db-schema-repair.ts
+++ b/src/state/openclaw-state-db-schema-repair.ts
@@ -37,6 +37,7 @@ export function migrateRetiredCommitmentsSchema(
   if (previousVersion >= 7) {
     return false;
   }
+  const hadCommitments = tableExists(db, "commitments");
   // The commitments runtime was removed before v7; retained rows are inert
   // migration debt and have no remaining product owner or export contract.
   db.exec(`
@@ -47,7 +48,7 @@ export function migrateRetiredCommitmentsSchema(
     DROP INDEX IF EXISTS idx_commitments_agent_sent;
     DROP TABLE IF EXISTS commitments;
   `);
-  return true;
+  return hadCommitments;
 }
 
 function hasCanonicalAgentDatabasesPrimaryKey(db: DatabaseSync): boolean {

--- a/src/state/openclaw-state-db-schema-repair.ts
+++ b/src/state/openclaw-state-db-schema-repair.ts
@@ -148,15 +148,7 @@ function hasExactRetiredCommitmentsSchema(
 }
 
 function assertRecognizedRetiredCommitmentsSchema(db: DatabaseSync): void {
-  if (
-    hasExactRetiredCommitmentsSchema(
-      db,
-      RETIRED_COMMITMENTS_SCHEMA_SQL,
-      RETIRED_COMMITMENTS_INDEX_NAMES,
-      RETIRED_COMMITMENTS_SCHEMA_COMPATIBILITY,
-    ) ||
-    hasExactRetiredCommitmentsSchema(db, EARLY_RETIRED_COMMITMENTS_SCHEMA_SQL, [])
-  ) {
+  if (hasRecognizedRetiredCommitmentsSchema(db)) {
     return;
   }
   assertSqliteSchemaContains(
@@ -166,6 +158,17 @@ function assertRecognizedRetiredCommitmentsSchema(db: DatabaseSync): void {
   );
   throw new Error(
     "Retired OpenClaw commitments schema has unsupported additional indexes; refusing destructive migration.",
+  );
+}
+
+function hasRecognizedRetiredCommitmentsSchema(db: DatabaseSync): boolean {
+  return (
+    hasExactRetiredCommitmentsSchema(
+      db,
+      RETIRED_COMMITMENTS_SCHEMA_SQL,
+      RETIRED_COMMITMENTS_INDEX_NAMES,
+      RETIRED_COMMITMENTS_SCHEMA_COMPATIBILITY,
+    ) || hasExactRetiredCommitmentsSchema(db, EARLY_RETIRED_COMMITMENTS_SCHEMA_SQL, [])
   );
 }
 
@@ -351,6 +354,13 @@ export function detectOpenClawStateDatabaseSchemaMigrationsFromDatabase(
 ): OpenClawStateDatabaseSchemaMigration[] {
   const migrations: OpenClawStateDatabaseSchemaMigration[] = [];
   const userVersion = readSqliteUserVersion(db);
+  if (
+    userVersion < OPENCLAW_STATE_SCHEMA_VERSION &&
+    tableExists(db, "commitments") &&
+    hasRecognizedRetiredCommitmentsSchema(db)
+  ) {
+    migrations.push({ kind: "commitments-retirement-v7", path: pathname });
+  }
   if (!hasCanonicalAgentDatabasesPrimaryKey(db)) {
     migrations.push({ kind: "agent-databases-composite-primary-key", path: pathname });
   }

--- a/src/state/openclaw-state-db-schema-repair.ts
+++ b/src/state/openclaw-state-db-schema-repair.ts
@@ -81,16 +81,37 @@ CREATE INDEX idx_commitments_agent_sent
   ON commitments(agent_id, status, sent_at_ms, session_key);
 `;
 
-const EARLY_RETIRED_COMMITMENTS_SCHEMA_SQL = `
+const ADDITIVE_RETIRED_COMMITMENTS_SCHEMA_SQL = `
 CREATE TABLE commitments (
   id TEXT NOT NULL PRIMARY KEY,
   agent_id TEXT NOT NULL,
   session_key TEXT NOT NULL,
   channel TEXT NOT NULL,
+  account_id TEXT,
+  recipient_id TEXT,
+  thread_id TEXT,
+  sender_id TEXT,
+  kind TEXT NOT NULL DEFAULT 'followup',
+  sensitivity TEXT NOT NULL DEFAULT 'normal',
+  source TEXT NOT NULL DEFAULT 'unknown',
   status TEXT NOT NULL,
+  reason TEXT NOT NULL DEFAULT '',
+  suggested_text TEXT NOT NULL DEFAULT '',
+  dedupe_key TEXT NOT NULL DEFAULT '',
+  confidence REAL NOT NULL DEFAULT 0,
   due_earliest_ms INTEGER NOT NULL,
   due_latest_ms INTEGER NOT NULL,
+  due_timezone TEXT NOT NULL DEFAULT 'UTC',
+  source_message_id TEXT,
+  source_run_id TEXT,
+  created_at_ms INTEGER NOT NULL DEFAULT 0,
   updated_at_ms INTEGER NOT NULL,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  last_attempt_at_ms INTEGER,
+  sent_at_ms INTEGER,
+  dismissed_at_ms INTEGER,
+  snoozed_until_ms INTEGER,
+  expired_at_ms INTEGER,
   record_json TEXT NOT NULL
 );
 CREATE INDEX idx_commitments_scope_due
@@ -99,6 +120,10 @@ CREATE INDEX idx_commitments_status_due
   ON commitments(status, due_earliest_ms, due_latest_ms);
 CREATE INDEX idx_commitments_agent_due
   ON commitments(agent_id, status, due_earliest_ms, due_latest_ms, session_key);
+CREATE INDEX idx_commitments_scope_dedupe
+  ON commitments(agent_id, session_key, channel, dedupe_key, status);
+CREATE INDEX idx_commitments_agent_sent
+  ON commitments(agent_id, status, sent_at_ms, session_key);
 `;
 
 const RETIRED_COMMITMENTS_INDEX_NAMES = [
@@ -107,6 +132,30 @@ const RETIRED_COMMITMENTS_INDEX_NAMES = [
   "idx_commitments_scope_dedupe",
   "idx_commitments_scope_due",
   "idx_commitments_status_due",
+] as const;
+
+const RETIRED_COMMITMENTS_ADDITIVE_COLUMNS = [
+  "commitments.account_id",
+  "commitments.recipient_id",
+  "commitments.thread_id",
+  "commitments.sender_id",
+  "commitments.kind",
+  "commitments.sensitivity",
+  "commitments.source",
+  "commitments.reason",
+  "commitments.suggested_text",
+  "commitments.dedupe_key",
+  "commitments.confidence",
+  "commitments.due_timezone",
+  "commitments.source_message_id",
+  "commitments.source_run_id",
+  "commitments.created_at_ms",
+  "commitments.attempts",
+  "commitments.last_attempt_at_ms",
+  "commitments.sent_at_ms",
+  "commitments.dismissed_at_ms",
+  "commitments.snoozed_until_ms",
+  "commitments.expired_at_ms",
 ] as const;
 
 const RETIRED_COMMITMENTS_SCHEMA_COMPATIBILITY: SqliteSchemaCompatibility = {
@@ -125,17 +174,13 @@ const RETIRED_COMMITMENTS_SCHEMA_COMPATIBILITY: SqliteSchemaCompatibility = {
     "commitments.source": ["source TEXT NOT NULL DEFAULT 'unknown'"],
     "commitments.suggested_text": ["suggested_text TEXT NOT NULL DEFAULT ''"],
   },
+  allowedMissingColumns: RETIRED_COMMITMENTS_ADDITIVE_COLUMNS,
   allowedMissingIndexes: RETIRED_COMMITMENTS_INDEX_NAMES,
 };
 
-const EARLY_RETIRED_COMMITMENTS_INDEX_NAMES = [
-  "idx_commitments_agent_due",
-  "idx_commitments_scope_due",
-  "idx_commitments_status_due",
-] as const;
-
-const EARLY_RETIRED_COMMITMENTS_SCHEMA_COMPATIBILITY: SqliteSchemaCompatibility = {
-  allowedMissingIndexes: EARLY_RETIRED_COMMITMENTS_INDEX_NAMES,
+const ADDITIVE_RETIRED_COMMITMENTS_SCHEMA_COMPATIBILITY: SqliteSchemaCompatibility = {
+  allowedMissingColumns: RETIRED_COMMITMENTS_ADDITIVE_COLUMNS,
+  allowedMissingIndexes: RETIRED_COMMITMENTS_INDEX_NAMES,
 };
 
 function hasSupportedRetiredCommitmentsSchema(
@@ -188,9 +233,9 @@ function hasRecognizedRetiredCommitmentsSchema(db: DatabaseSync): boolean {
     ) ||
     hasSupportedRetiredCommitmentsSchema(
       db,
-      EARLY_RETIRED_COMMITMENTS_SCHEMA_SQL,
-      EARLY_RETIRED_COMMITMENTS_INDEX_NAMES,
-      EARLY_RETIRED_COMMITMENTS_SCHEMA_COMPATIBILITY,
+      ADDITIVE_RETIRED_COMMITMENTS_SCHEMA_SQL,
+      RETIRED_COMMITMENTS_INDEX_NAMES,
+      ADDITIVE_RETIRED_COMMITMENTS_SCHEMA_COMPATIBILITY,
     )
   );
 }

--- a/src/state/openclaw-state-db-schema-repair.ts
+++ b/src/state/openclaw-state-db-schema-repair.ts
@@ -141,6 +141,9 @@ function assertRecognizedRetiredCommitmentsSchema(db: DatabaseSync): void {
     "retired OpenClaw commitments schema",
     RETIRED_COMMITMENTS_SCHEMA_SQL,
   );
+  throw new Error(
+    "Retired OpenClaw commitments schema has unsupported additional indexes; refusing destructive migration.",
+  );
 }
 
 export function migrateRetiredCommitmentsSchema(

--- a/src/state/openclaw-state-db-schema-repair.ts
+++ b/src/state/openclaw-state-db-schema-repair.ts
@@ -4,6 +4,7 @@ import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import {
   assertSqliteSchemaContains,
   collectSqliteSchemaIssues,
+  type SqliteSchemaCompatibility,
 } from "../infra/sqlite-schema-contract.js";
 import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
 import {
@@ -101,27 +102,48 @@ const RETIRED_COMMITMENTS_INDEX_NAMES = [
   "idx_commitments_status_due",
 ] as const;
 
+const RETIRED_COMMITMENTS_SCHEMA_COMPATIBILITY: SqliteSchemaCompatibility = {
+  // These defaults shipped as independent same-version additive repairs, so
+  // supported databases may mix canonical and defaulted definitions. The
+  // surrounding exact-object check still rejects every other schema change.
+  allowedColumnDefinitions: {
+    "commitments.attempts": ["attempts INTEGER NOT NULL DEFAULT 0"],
+    "commitments.confidence": ["confidence REAL NOT NULL DEFAULT 0"],
+    "commitments.created_at_ms": ["created_at_ms INTEGER NOT NULL DEFAULT 0"],
+    "commitments.dedupe_key": ["dedupe_key TEXT NOT NULL DEFAULT ''"],
+    "commitments.due_timezone": ["due_timezone TEXT NOT NULL DEFAULT 'UTC'"],
+    "commitments.kind": ["kind TEXT NOT NULL DEFAULT 'followup'"],
+    "commitments.reason": ["reason TEXT NOT NULL DEFAULT ''"],
+    "commitments.sensitivity": ["sensitivity TEXT NOT NULL DEFAULT 'normal'"],
+    "commitments.source": ["source TEXT NOT NULL DEFAULT 'unknown'"],
+    "commitments.suggested_text": ["suggested_text TEXT NOT NULL DEFAULT ''"],
+  },
+};
+
 function hasExactRetiredCommitmentsSchema(
   db: DatabaseSync,
   schemaSql: string,
   expectedIndexNames: readonly string[],
+  compatibility: SqliteSchemaCompatibility = {},
 ): boolean {
-  if (collectSqliteSchemaIssues(db, schemaSql).length > 0) {
+  if (collectSqliteSchemaIssues(db, schemaSql, compatibility).length > 0) {
     return false;
   }
-  const actualIndexNames = (
-    db
-      .prepare(
-        `SELECT name
+  const attachedObjects = db
+    .prepare(
+      `SELECT type, name
            FROM sqlite_schema
-          WHERE type = 'index' AND tbl_name = 'commitments' AND sql IS NOT NULL
-          ORDER BY name`,
-      )
-      .all() as Array<{ name: string }>
-  ).map((row) => row.name);
+          WHERE type IN ('index', 'trigger')
+            AND tbl_name = 'commitments'
+            AND sql IS NOT NULL
+          ORDER BY type, name`,
+    )
+    .all() as Array<{ name: string; type: string }>;
   return (
-    actualIndexNames.length === expectedIndexNames.length &&
-    actualIndexNames.every((name, index) => name === expectedIndexNames[index])
+    attachedObjects.length === expectedIndexNames.length &&
+    attachedObjects.every(
+      (object, index) => object.type === "index" && object.name === expectedIndexNames[index],
+    )
   );
 }
 
@@ -131,6 +153,7 @@ function assertRecognizedRetiredCommitmentsSchema(db: DatabaseSync): void {
       db,
       RETIRED_COMMITMENTS_SCHEMA_SQL,
       RETIRED_COMMITMENTS_INDEX_NAMES,
+      RETIRED_COMMITMENTS_SCHEMA_COMPATIBILITY,
     ) ||
     hasExactRetiredCommitmentsSchema(db, EARLY_RETIRED_COMMITMENTS_SCHEMA_SQL, [])
   ) {

--- a/src/state/openclaw-state-db-schema-repair.ts
+++ b/src/state/openclaw-state-db-schema-repair.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import { assertSqliteSchemaContains } from "../infra/sqlite-schema-contract.js";
 import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
 import {
   canRepairLegacyAuditEventsSchema,
@@ -30,6 +31,51 @@ export function dropLegacyStateTables(db: DatabaseSync): void {
   db.exec("DROP TABLE IF EXISTS node_pairing_pending; DROP TABLE IF EXISTS node_pairing_paired;");
 }
 
+const RETIRED_COMMITMENTS_SCHEMA_SQL = `
+CREATE TABLE commitments (
+  id TEXT NOT NULL PRIMARY KEY,
+  agent_id TEXT NOT NULL,
+  session_key TEXT NOT NULL,
+  channel TEXT NOT NULL,
+  account_id TEXT,
+  recipient_id TEXT,
+  thread_id TEXT,
+  sender_id TEXT,
+  kind TEXT NOT NULL,
+  sensitivity TEXT NOT NULL,
+  source TEXT NOT NULL,
+  status TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  suggested_text TEXT NOT NULL,
+  dedupe_key TEXT NOT NULL,
+  confidence REAL NOT NULL,
+  due_earliest_ms INTEGER NOT NULL,
+  due_latest_ms INTEGER NOT NULL,
+  due_timezone TEXT NOT NULL,
+  source_message_id TEXT,
+  source_run_id TEXT,
+  created_at_ms INTEGER NOT NULL,
+  updated_at_ms INTEGER NOT NULL,
+  attempts INTEGER NOT NULL,
+  last_attempt_at_ms INTEGER,
+  sent_at_ms INTEGER,
+  dismissed_at_ms INTEGER,
+  snoozed_until_ms INTEGER,
+  expired_at_ms INTEGER,
+  record_json TEXT NOT NULL
+) STRICT;
+CREATE INDEX idx_commitments_scope_due
+  ON commitments(agent_id, session_key, status, due_earliest_ms, due_latest_ms);
+CREATE INDEX idx_commitments_status_due
+  ON commitments(status, due_earliest_ms, due_latest_ms);
+CREATE INDEX idx_commitments_scope_dedupe
+  ON commitments(agent_id, session_key, channel, dedupe_key, status);
+CREATE INDEX idx_commitments_agent_due
+  ON commitments(agent_id, status, due_earliest_ms, due_latest_ms, session_key);
+CREATE INDEX idx_commitments_agent_sent
+  ON commitments(agent_id, status, sent_at_ms, session_key);
+`;
+
 export function migrateRetiredCommitmentsSchema(
   db: DatabaseSync,
   previousVersion: number,
@@ -37,18 +83,19 @@ export function migrateRetiredCommitmentsSchema(
   if (previousVersion >= 7) {
     return false;
   }
-  const hadCommitments = tableExists(db, "commitments");
+  if (!tableExists(db, "commitments")) {
+    return false;
+  }
   // The commitments runtime was removed before v7; retained rows are inert
   // migration debt and have no remaining product owner or export contract.
-  db.exec(`
-    DROP INDEX IF EXISTS idx_commitments_scope_due;
-    DROP INDEX IF EXISTS idx_commitments_status_due;
-    DROP INDEX IF EXISTS idx_commitments_scope_dedupe;
-    DROP INDEX IF EXISTS idx_commitments_agent_due;
-    DROP INDEX IF EXISTS idx_commitments_agent_sent;
-    DROP TABLE IF EXISTS commitments;
-  `);
-  return hadCommitments;
+  assertSqliteSchemaContains(
+    db,
+    "retired OpenClaw commitments schema",
+    RETIRED_COMMITMENTS_SCHEMA_SQL,
+  );
+  // DROP TABLE removes only the validated table's indexes and sqlite_stat rows.
+  db.exec("DROP TABLE commitments;");
+  return true;
 }
 
 function hasCanonicalAgentDatabasesPrimaryKey(db: DatabaseSync): boolean {

--- a/src/state/openclaw-state-db-schema-repair.ts
+++ b/src/state/openclaw-state-db-schema-repair.ts
@@ -1,7 +1,10 @@
 import { existsSync } from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
-import { assertSqliteSchemaContains } from "../infra/sqlite-schema-contract.js";
+import {
+  assertSqliteSchemaContains,
+  collectSqliteSchemaIssues,
+} from "../infra/sqlite-schema-contract.js";
 import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
 import {
   canRepairLegacyAuditEventsSchema,
@@ -76,6 +79,34 @@ CREATE INDEX idx_commitments_agent_sent
   ON commitments(agent_id, status, sent_at_ms, session_key);
 `;
 
+const EARLY_RETIRED_COMMITMENTS_SCHEMA_SQL = `
+CREATE TABLE commitments (
+  id TEXT NOT NULL PRIMARY KEY,
+  agent_id TEXT NOT NULL,
+  session_key TEXT NOT NULL,
+  channel TEXT NOT NULL,
+  status TEXT NOT NULL,
+  due_earliest_ms INTEGER NOT NULL,
+  due_latest_ms INTEGER NOT NULL,
+  updated_at_ms INTEGER NOT NULL,
+  record_json TEXT NOT NULL
+);
+`;
+
+function assertRecognizedRetiredCommitmentsSchema(db: DatabaseSync): void {
+  if (
+    collectSqliteSchemaIssues(db, RETIRED_COMMITMENTS_SCHEMA_SQL).length === 0 ||
+    collectSqliteSchemaIssues(db, EARLY_RETIRED_COMMITMENTS_SCHEMA_SQL).length === 0
+  ) {
+    return;
+  }
+  assertSqliteSchemaContains(
+    db,
+    "retired OpenClaw commitments schema",
+    RETIRED_COMMITMENTS_SCHEMA_SQL,
+  );
+}
+
 export function migrateRetiredCommitmentsSchema(
   db: DatabaseSync,
   previousVersion: number,
@@ -88,11 +119,7 @@ export function migrateRetiredCommitmentsSchema(
   }
   // The commitments runtime was removed before v7; retained rows are inert
   // migration debt and have no remaining product owner or export contract.
-  assertSqliteSchemaContains(
-    db,
-    "retired OpenClaw commitments schema",
-    RETIRED_COMMITMENTS_SCHEMA_SQL,
-  );
+  assertRecognizedRetiredCommitmentsSchema(db);
   // DROP TABLE removes only the validated table's indexes and sqlite_stat rows.
   db.exec("DROP TABLE commitments;");
   return true;

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -369,39 +369,6 @@ export interface CommandLogEntries {
   timestamp_ms: number;
 }
 
-export interface Commitments {
-  account_id: string | null;
-  agent_id: string;
-  attempts: number;
-  channel: string;
-  confidence: number;
-  created_at_ms: number;
-  dedupe_key: string;
-  dismissed_at_ms: number | null;
-  due_earliest_ms: number;
-  due_latest_ms: number;
-  due_timezone: string;
-  expired_at_ms: number | null;
-  id: string;
-  kind: string;
-  last_attempt_at_ms: number | null;
-  reason: string;
-  recipient_id: string | null;
-  record_json: string;
-  sender_id: string | null;
-  sensitivity: string;
-  sent_at_ms: number | null;
-  session_key: string;
-  snoozed_until_ms: number | null;
-  source: string;
-  source_message_id: string | null;
-  source_run_id: string | null;
-  status: string;
-  suggested_text: string;
-  thread_id: string | null;
-  updated_at_ms: number;
-}
-
 export interface ConfigHealthEntries {
   config_path: string;
   last_known_good_json: string | null;
@@ -1710,7 +1677,6 @@ export interface DB {
   clawhub_promotion_claims: ClawhubPromotionClaims;
   clawhub_promotions_feed_state: ClawhubPromotionsFeedState;
   command_log_entries: CommandLogEntries;
-  commitments: Commitments;
   config_health_entries: ConfigHealthEntries;
   config_machine_state: ConfigMachineState;
   cron_job_runtime_authorities: CronJobRuntimeAuthorities;

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -1340,6 +1340,17 @@ describe("openclaw state database", () => {
           changes: ["Retired shared state commitments table and indexes"],
           warnings: [],
         });
+        const repaired = new DatabaseSync(databasePath, { readOnly: true });
+        try {
+          expect(readSqliteNumberPragma(repaired, "user_version")).toBe(7);
+          expect(
+            repaired
+              .prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'")
+              .get(),
+          ).toEqual({ schema_version: 7 });
+        } finally {
+          repaired.close();
+        }
       }
       const migrated = openOpenClawStateDatabase(options);
 

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -1336,7 +1336,10 @@ describe("openclaw state database", () => {
       legacy.close();
 
       if (migrationPath === "doctor repair") {
-        expect(repairOpenClawStateDatabaseSchema(options).warnings).toEqual([]);
+        expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
+          changes: ["Retired shared state commitments table and indexes"],
+          warnings: [],
+        });
       }
       const migrated = openOpenClawStateDatabase(options);
 
@@ -1585,6 +1588,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     ]);
     expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
       changes: [
+        "Retired shared state commitments table and indexes",
         "Migrated shared state session watch cursors → provenance column (0 ambient, 0 sentinels removed)",
         "Migrated shared state tables to SQLite STRICT typing (1)",
       ],
@@ -1617,6 +1621,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     ]);
     expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
       changes: [
+        "Retired shared state commitments table and indexes",
         "Migrated shared state session watch cursors → provenance column (2 ambient, 5 sentinels removed)",
       ],
       warnings: [],
@@ -2357,32 +2362,45 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     }
   });
 
-  it("rejects a missing stable v5 table before the v6 migration", () => {
-    const stateDir = createTempStateDir();
-    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-    const databasePath = materializeCurrentStateDatabase(stateDir);
+  it.each(["runtime open", "doctor repair"] as const)(
+    "rejects a missing stable v5 table before the v7 migration through %s",
+    (migrationPath) => {
+      const stateDir = createTempStateDir();
+      const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+      const databasePath = materializeCurrentStateDatabase(stateDir);
 
-    const { DatabaseSync } = requireNodeSqlite();
-    const damaged = new DatabaseSync(databasePath);
-    damaged.exec("DROP TABLE auth_profile_stores;");
-    markStateDatabaseAsV5(damaged);
-    damaged.close();
+      const { DatabaseSync } = requireNodeSqlite();
+      const damaged = new DatabaseSync(databasePath);
+      damaged.exec("DROP TABLE auth_profile_stores;");
+      markStateDatabaseAsV5(damaged);
+      damaged.close();
 
-    expect(() => openOpenClawStateDatabase(options)).toThrow(/missing table auth_profile_stores/iu);
+      if (migrationPath === "runtime open") {
+        expect(() => openOpenClawStateDatabase(options)).toThrow(
+          /missing table auth_profile_stores/iu,
+        );
+      } else {
+        expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
+          changes: [],
+          warnings: [expect.stringContaining("missing table auth_profile_stores")],
+        });
+      }
 
-    const after = new DatabaseSync(databasePath, { readOnly: true });
-    try {
-      expect(
-        after
-          .prepare(
-            "SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'auth_profile_stores'",
-          )
-          .get(),
-      ).toBeUndefined();
-    } finally {
-      after.close();
-    }
-  });
+      const after = new DatabaseSync(databasePath, { readOnly: true });
+      try {
+        expect(
+          after
+            .prepare(
+              "SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'auth_profile_stores'",
+            )
+            .get(),
+        ).toBeUndefined();
+        expect(readSqliteNumberPragma(after, "user_version")).toBe(5);
+      } finally {
+        after.close();
+      }
+    },
+  );
 
   it("upgrades v5 databases that predate startup worker tool tables", () => {
     const stateDir = createTempStateDir();
@@ -2413,33 +2431,45 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     ]);
   });
 
-  it("rejects a missing stable v6 table before the v7 migration", () => {
-    const stateDir = createTempStateDir();
-    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-    const databasePath = materializeCurrentStateDatabase(stateDir);
+  it.each(["runtime open", "doctor repair"] as const)(
+    "rejects a missing stable v6 table before the v7 migration through %s",
+    (migrationPath) => {
+      const stateDir = createTempStateDir();
+      const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+      const databasePath = materializeCurrentStateDatabase(stateDir);
 
-    const { DatabaseSync } = requireNodeSqlite();
-    const damaged = new DatabaseSync(databasePath);
-    damaged.exec("DROP TABLE auth_profile_stores;");
-    markStateDatabaseAsV6(damaged);
-    damaged.close();
+      const { DatabaseSync } = requireNodeSqlite();
+      const damaged = new DatabaseSync(databasePath);
+      damaged.exec("DROP TABLE auth_profile_stores;");
+      markStateDatabaseAsV6(damaged);
+      damaged.close();
 
-    expect(() => openOpenClawStateDatabase(options)).toThrow(/missing table auth_profile_stores/iu);
+      if (migrationPath === "runtime open") {
+        expect(() => openOpenClawStateDatabase(options)).toThrow(
+          /missing table auth_profile_stores/iu,
+        );
+      } else {
+        expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
+          changes: [],
+          warnings: [expect.stringContaining("missing table auth_profile_stores")],
+        });
+      }
 
-    const after = new DatabaseSync(databasePath, { readOnly: true });
-    try {
-      expect(
-        after
-          .prepare(
-            "SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'auth_profile_stores'",
-          )
-          .get(),
-      ).toBeUndefined();
-      expect(readSqliteNumberPragma(after, "user_version")).toBe(6);
-    } finally {
-      after.close();
-    }
-  });
+      const after = new DatabaseSync(databasePath, { readOnly: true });
+      try {
+        expect(
+          after
+            .prepare(
+              "SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'auth_profile_stores'",
+            )
+            .get(),
+        ).toBeUndefined();
+        expect(readSqliteNumberPragma(after, "user_version")).toBe(6);
+      } finally {
+        after.close();
+      }
+    },
+  );
 
   it("rejects an inline unique constraint hidden behind a SQLite autoindex", () => {
     const stateDir = createTempStateDir();
@@ -2595,6 +2625,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
 
     expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
       changes: [
+        "Retired shared state commitments table and indexes",
         "Migrated shared state audit event ledger → versioned message lifecycle schema",
         "Migrated shared state tables to SQLite STRICT typing (3)",
       ],
@@ -2848,7 +2879,10 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     legacy.close();
 
     expect(detectOpenClawStateDatabaseSchemaMigrations(options)).toEqual([]);
-    expect(repairOpenClawStateDatabaseSchema(options)).toEqual({ changes: [], warnings: [] });
+    expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
+      changes: ["Retired shared state commitments table and indexes"],
+      warnings: [],
+    });
     const beforeOpen = new DatabaseSync(databasePath, { readOnly: true });
     expect(readSqliteNumberPragma(beforeOpen, "user_version")).toBe(1);
     beforeOpen.close();

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -1496,6 +1496,34 @@ describe("openclaw state database", () => {
     },
   );
 
+  it("preserves an extra index on the final v6 commitments layout", () => {
+    const stateDir = createTempStateDir();
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const databasePath = materializeCurrentStateDatabase(stateDir);
+    const { DatabaseSync } = requireNodeSqlite();
+    const customized = new DatabaseSync(databasePath);
+    seedV6CommitmentSchema(customized);
+    customized.exec("CREATE INDEX foreign_commitments_status ON commitments(status);");
+    customized.close();
+
+    expect(() => openOpenClawStateDatabase(options)).toThrow(/unsupported additional indexes/u);
+
+    const preserved = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(readSqliteNumberPragma(preserved, "user_version")).toBe(6);
+      expect(
+        preserved.prepare("SELECT name FROM sqlite_schema WHERE name = 'commitments'").get(),
+      ).toEqual({ name: "commitments" });
+      expect(
+        preserved
+          .prepare("SELECT tbl_name FROM sqlite_schema WHERE name = 'foreign_commitments_status'")
+          .get(),
+      ).toEqual({ tbl_name: "commitments" });
+    } finally {
+      preserved.close();
+    }
+  });
+
   it("keeps the additive worker SSH fallback table compatible with older v6 containment", () => {
     const database = openMaterializedCurrentStateDatabase();
     try {

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -1383,6 +1383,11 @@ describe("openclaw state database", () => {
       seedV6CommitmentSchema(legacy);
       legacy.close();
 
+      expect(detectOpenClawStateDatabaseSchemaMigrations(options)).toContainEqual({
+        kind: "commitments-retirement-v7",
+        path: databasePath,
+      });
+
       if (migrationPath === "doctor repair") {
         expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
           changes: ["Retired shared state commitments table and indexes"],
@@ -1431,6 +1436,10 @@ describe("openclaw state database", () => {
         payload_json: "{}",
         created_at: 1,
         updated_at: 2,
+      });
+      expect(detectOpenClawStateDatabaseSchemaMigrations(options)).not.toContainEqual({
+        kind: "commitments-retirement-v7",
+        path: databasePath,
       });
     },
   );

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -318,6 +318,38 @@ function seedAdditiveV6CommitmentSchema(database: DatabaseSync): void {
   markStateDatabaseAsV6(database);
 }
 
+function seedPartiallyAdditiveV6CommitmentSchema(database: DatabaseSync): void {
+  database.exec(`
+    CREATE TABLE commitments (
+      id TEXT NOT NULL PRIMARY KEY,
+      agent_id TEXT NOT NULL,
+      session_key TEXT NOT NULL,
+      channel TEXT NOT NULL,
+      account_id TEXT,
+      kind TEXT NOT NULL DEFAULT 'followup',
+      status TEXT NOT NULL,
+      dedupe_key TEXT NOT NULL DEFAULT '',
+      due_earliest_ms INTEGER NOT NULL,
+      due_latest_ms INTEGER NOT NULL,
+      updated_at_ms INTEGER NOT NULL,
+      last_attempt_at_ms INTEGER,
+      record_json TEXT NOT NULL
+    );
+    CREATE INDEX idx_commitments_scope_due
+      ON commitments(agent_id, session_key, status, due_earliest_ms, due_latest_ms);
+    CREATE INDEX idx_commitments_status_due
+      ON commitments(status, due_earliest_ms, due_latest_ms);
+    INSERT INTO commitments (
+      id, agent_id, session_key, channel, account_id, kind, status, dedupe_key,
+      due_earliest_ms, due_latest_ms, updated_at_ms, last_attempt_at_ms, record_json
+    ) VALUES (
+      'partial-commitment', 'main', 'agent:main:main', 'telegram', 'default',
+      'followup', 'pending', 'partial-dedupe', 10, 20, 1, 1, '{}'
+    );
+  `);
+  markStateDatabaseAsV6(database);
+}
+
 function seedLegacySessionWatchCursorSchema(stateDir: string): {
   ambientTarget: string;
   bomTarget: string;
@@ -1540,6 +1572,33 @@ describe("openclaw state database", () => {
         const result = repairOpenClawStateDatabaseSchema(options);
         expect(result.warnings).toEqual([]);
         expect(result.changes).toContain("Retired shared state commitments table and indexes");
+      }
+      const migrated = openOpenClawStateDatabase(options);
+      expect(readSqliteNumberPragma(migrated.db, "user_version")).toBe(
+        OPENCLAW_STATE_SCHEMA_VERSION,
+      );
+      expect(
+        migrated.db.prepare("SELECT name FROM sqlite_schema WHERE name = 'commitments'").get(),
+      ).toBeUndefined();
+    },
+  );
+
+  it.each(["runtime open", "doctor repair"] as const)(
+    "retires a partially additive v6 commitments layout through %s",
+    (migrationPath) => {
+      const stateDir = createTempStateDir();
+      const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+      const databasePath = materializeCurrentStateDatabase(stateDir);
+      const { DatabaseSync } = requireNodeSqlite();
+      const partial = new DatabaseSync(databasePath);
+      seedPartiallyAdditiveV6CommitmentSchema(partial);
+      partial.close();
+
+      if (migrationPath === "doctor repair") {
+        expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
+          changes: ["Retired shared state commitments table and indexes"],
+          warnings: [],
+        });
       }
       const migrated = openOpenClawStateDatabase(options);
       expect(readSqliteNumberPragma(migrated.db, "user_version")).toBe(

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -1599,7 +1599,6 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     ]);
     expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
       changes: [
-        "Retired shared state commitments table and indexes",
         "Migrated shared state session watch cursors → provenance column (0 ambient, 0 sentinels removed)",
         "Migrated shared state tables to SQLite STRICT typing (1)",
       ],
@@ -1632,7 +1631,6 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     ]);
     expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
       changes: [
-        "Retired shared state commitments table and indexes",
         "Migrated shared state session watch cursors → provenance column (2 ambient, 5 sentinels removed)",
       ],
       warnings: [],
@@ -2636,7 +2634,6 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
 
     expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
       changes: [
-        "Retired shared state commitments table and indexes",
         "Migrated shared state audit event ledger → versioned message lifecycle schema",
         "Migrated shared state tables to SQLite STRICT typing (3)",
       ],
@@ -2891,7 +2888,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
 
     expect(detectOpenClawStateDatabaseSchemaMigrations(options)).toEqual([]);
     expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
-      changes: ["Retired shared state commitments table and indexes"],
+      changes: [],
       warnings: [],
     });
     const beforeOpen = new DatabaseSync(databasePath, { readOnly: true });

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -1387,6 +1387,55 @@ describe("openclaw state database", () => {
     },
   );
 
+  it.each(["runtime open", "doctor repair"] as const)(
+    "preserves a foreign commitments table and colliding index through %s",
+    (migrationPath) => {
+      const stateDir = createTempStateDir();
+      const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+      const databasePath = materializeCurrentStateDatabase(stateDir);
+      const { DatabaseSync } = requireNodeSqlite();
+      const foreign = new DatabaseSync(databasePath);
+      foreign.exec(`
+        CREATE TABLE commitments (marker TEXT NOT NULL PRIMARY KEY) STRICT;
+        CREATE TABLE foreign_commitment_index_owner (marker TEXT NOT NULL) STRICT;
+        CREATE INDEX idx_commitments_scope_due
+          ON foreign_commitment_index_owner(marker);
+      `);
+      markStateDatabaseAsV6(foreign);
+      foreign.close();
+
+      if (migrationPath === "doctor repair") {
+        const result = repairOpenClawStateDatabaseSchema(options);
+        expect(result.changes).toEqual([]);
+        expect(result.warnings.join("\n")).toMatch(/commitments/u);
+      } else {
+        expect(() => openOpenClawStateDatabase(options)).toThrow(/commitments/u);
+      }
+
+      const preserved = new DatabaseSync(databasePath, { readOnly: true });
+      try {
+        expect(readSqliteNumberPragma(preserved, "user_version")).toBe(6);
+        expect(
+          preserved
+            .prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'")
+            .get(),
+        ).toEqual({ schema_version: 6 });
+        expect(
+          preserved.prepare("SELECT sql FROM sqlite_schema WHERE name = 'commitments'").get(),
+        ).toEqual({
+          sql: "CREATE TABLE commitments (marker TEXT NOT NULL PRIMARY KEY) STRICT",
+        });
+        expect(
+          preserved
+            .prepare("SELECT tbl_name FROM sqlite_schema WHERE name = 'idx_commitments_scope_due'")
+            .get(),
+        ).toEqual({ tbl_name: "foreign_commitment_index_owner" });
+      } finally {
+        preserved.close();
+      }
+    },
+  );
+
   it("keeps the additive worker SSH fallback table compatible with older v6 containment", () => {
     const database = openMaterializedCurrentStateDatabase();
     try {

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -1445,6 +1445,37 @@ describe("openclaw state database", () => {
   );
 
   it.each(["runtime open", "doctor repair"] as const)(
+    "retires a v6 commitments layout with missing canonical indexes through %s",
+    (migrationPath) => {
+      const stateDir = createTempStateDir();
+      const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+      const databasePath = materializeCurrentStateDatabase(stateDir);
+      const { DatabaseSync } = requireNodeSqlite();
+      const legacy = new DatabaseSync(databasePath);
+      seedV6CommitmentSchema(legacy);
+      legacy.exec(`
+        DROP INDEX idx_commitments_scope_dedupe;
+        DROP INDEX idx_commitments_agent_sent;
+      `);
+      legacy.close();
+
+      if (migrationPath === "doctor repair") {
+        expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
+          changes: ["Retired shared state commitments table and indexes"],
+          warnings: [],
+        });
+      }
+      const migrated = openOpenClawStateDatabase(options);
+      expect(readSqliteNumberPragma(migrated.db, "user_version")).toBe(
+        OPENCLAW_STATE_SCHEMA_VERSION,
+      );
+      expect(
+        migrated.db.prepare("SELECT name FROM sqlite_schema WHERE name = 'commitments'").get(),
+      ).toBeUndefined();
+    },
+  );
+
+  it.each(["runtime open", "doctor repair"] as const)(
     "retires the supported early commitments layout through %s",
     (migrationPath) => {
       const stateDir = createTempStateDir();
@@ -1465,6 +1496,10 @@ describe("openclaw state database", () => {
           updated_at_ms INTEGER NOT NULL,
           record_json TEXT NOT NULL
         );
+        CREATE INDEX idx_commitments_scope_due
+          ON commitments(agent_id, session_key, status, due_earliest_ms, due_latest_ms);
+        CREATE INDEX idx_commitments_status_due
+          ON commitments(status, due_earliest_ms, due_latest_ms);
         INSERT INTO commitments (
           id, agent_id, session_key, channel, status, due_earliest_ms,
           due_latest_ms, updated_at_ms, record_json
@@ -1614,6 +1649,186 @@ describe("openclaw state database", () => {
       expect(
         preserved.prepare("SELECT type, tbl_name FROM sqlite_schema WHERE name = ?").get(name),
       ).toEqual({ type, tbl_name: "commitments" });
+    } finally {
+      preserved.close();
+    }
+  });
+
+  it.each(["runtime open", "doctor repair"] as const)(
+    "preserves an inbound foreign-key dependency through %s",
+    (migrationPath) => {
+      const stateDir = createTempStateDir();
+      const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+      const databasePath = materializeCurrentStateDatabase(stateDir);
+      const { DatabaseSync } = requireNodeSqlite();
+      const dependent = new DatabaseSync(databasePath);
+      seedV6CommitmentSchema(dependent);
+      dependent.exec(`
+        CREATE TABLE sqliteX_dependents (
+          id TEXT NOT NULL PRIMARY KEY,
+          commitment_id TEXT NOT NULL REFERENCES commitments(id) ON DELETE CASCADE
+        ) STRICT;
+        INSERT INTO sqliteX_dependents (id, commitment_id)
+        VALUES ('dependent-row', 'retired-commitment');
+      `);
+      dependent.close();
+
+      if (migrationPath === "doctor repair") {
+        const result = repairOpenClawStateDatabaseSchema(options);
+        expect(result.changes).toEqual([]);
+        expect(result.warnings.join("\n")).toMatch(/referenced by table sqliteX_dependents/iu);
+      } else {
+        expect(() => openOpenClawStateDatabase(options)).toThrow(
+          /referenced by table sqliteX_dependents/iu,
+        );
+      }
+
+      const preserved = new DatabaseSync(databasePath, { readOnly: true });
+      try {
+        expect(readSqliteNumberPragma(preserved, "user_version")).toBe(6);
+        expect(preserved.prepare("SELECT id FROM commitments").all()).toEqual([
+          { id: "retired-commitment" },
+        ]);
+        expect(preserved.prepare("SELECT id, commitment_id FROM sqliteX_dependents").all()).toEqual(
+          [{ id: "dependent-row", commitment_id: "retired-commitment" }],
+        );
+      } finally {
+        preserved.close();
+      }
+    },
+  );
+
+  it.each([
+    {
+      name: "commitment_projection",
+      sql: "CREATE VIEW commitment_projection AS SELECT id FROM 'commitments';",
+      type: "view",
+    },
+    {
+      name: "lease_commitment_cleanup",
+      sql: `CREATE TRIGGER lease_commitment_cleanup
+              AFTER DELETE ON state_leases
+              BEGIN DELETE FROM [commitments] WHERE id = OLD.lease_key; END;`,
+      type: "trigger",
+    },
+    {
+      name: "lease_commitment_update",
+      sql: `CREATE TRIGGER lease_commitment_update
+              UPDATE OF owner ON state_leases
+              BEGIN DELETE FROM commitments WHERE id = OLD.lease_key; END;`,
+      type: "trigger",
+    },
+    {
+      name: "rowid_commitment_update",
+      sql: `CREATE TABLE rowid_dependency_owner (value TEXT) STRICT;
+            CREATE TRIGGER rowid_commitment_update
+              AFTER UPDATE OF rowid ON rowid_dependency_owner
+              BEGIN DELETE FROM commitments WHERE id = 'retired-commitment'; END;`,
+      type: "trigger",
+    },
+  ])("preserves a cross-object $type dependency on commitments", ({ name, sql, type }) => {
+    const stateDir = createTempStateDir();
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const databasePath = materializeCurrentStateDatabase(stateDir);
+    const { DatabaseSync } = requireNodeSqlite();
+    const dependent = new DatabaseSync(databasePath);
+    seedV6CommitmentSchema(dependent);
+    dependent.exec(sql);
+    dependent.close();
+
+    expect(() => openOpenClawStateDatabase(options)).toThrow(
+      new RegExp(`referenced by ${type} ${name}`, "iu"),
+    );
+
+    const preserved = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(readSqliteNumberPragma(preserved, "user_version")).toBe(6);
+      expect(preserved.prepare("SELECT name FROM sqlite_schema WHERE name = ?").get(name)).toEqual({
+        name,
+      });
+      expect(preserved.prepare("SELECT id FROM commitments").all()).toEqual([
+        { id: "retired-commitment" },
+      ]);
+    } finally {
+      preserved.close();
+    }
+  });
+
+  it("preserves an external-content virtual table dependency on commitments", () => {
+    const stateDir = createTempStateDir();
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const databasePath = materializeCurrentStateDatabase(stateDir);
+    const { DatabaseSync } = requireNodeSqlite();
+    const dependent = new DatabaseSync(databasePath);
+    seedV6CommitmentSchema(dependent);
+    dependent.exec(`
+      create virtual table commitment_search USING fts5(
+        suggested_text,
+        content='commitments',
+        content_rowid='rowid'
+      );
+    `);
+    dependent.close();
+
+    expect(() => openOpenClawStateDatabase(options)).toThrow(
+      /SQLite virtual table commitment_search is unusable/iu,
+    );
+
+    const preserved = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(readSqliteNumberPragma(preserved, "user_version")).toBe(6);
+      expect(
+        preserved.prepare("SELECT name FROM sqlite_schema WHERE name = 'commitment_search'").get(),
+      ).toEqual({ name: "commitment_search" });
+      expect(preserved.prepare("SELECT id FROM commitments").all()).toEqual([
+        { id: "retired-commitment" },
+      ]);
+    } finally {
+      preserved.close();
+    }
+  });
+
+  it("keeps unrelated schema identifiers named commitments usable", () => {
+    const stateDir = createTempStateDir();
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const databasePath = materializeCurrentStateDatabase(stateDir);
+    const { DatabaseSync } = requireNodeSqlite();
+    const unrelated = new DatabaseSync(databasePath);
+    seedV6CommitmentSchema(unrelated);
+    unrelated.exec("CREATE VIEW commitment_metrics AS SELECT 1 AS commitments;");
+    unrelated.close();
+
+    const migrated = openOpenClawStateDatabase(options);
+    expect(readSqliteNumberPragma(migrated.db, "user_version")).toBe(OPENCLAW_STATE_SCHEMA_VERSION);
+    expect(migrated.db.prepare("SELECT commitments FROM commitment_metrics").get()).toEqual({
+      commitments: 1,
+    });
+  });
+
+  it("refuses retirement when a broken retained view makes dependency resolution ambiguous", () => {
+    const stateDir = createTempStateDir();
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const databasePath = materializeCurrentStateDatabase(stateDir);
+    const { DatabaseSync } = requireNodeSqlite();
+    const legacy = new DatabaseSync(databasePath);
+    seedV6CommitmentSchema(legacy);
+    legacy.exec("CREATE VIEW unrelated_broken_view AS SELECT id FROM missing_unrelated_table;");
+    legacy.close();
+
+    expect(() => openOpenClawStateDatabase(options)).toThrow(
+      /Could not prove retained SQLite views and triggers independent of commitments/iu,
+    );
+    const preserved = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(readSqliteNumberPragma(preserved, "user_version")).toBe(6);
+      expect(
+        preserved
+          .prepare("SELECT name FROM sqlite_schema WHERE name = 'unrelated_broken_view'")
+          .get(),
+      ).toEqual({ name: "unrelated_broken_view" });
+      expect(preserved.prepare("SELECT id FROM commitments").all()).toEqual([
+        { id: "retired-commitment" },
+      ]);
     } finally {
       preserved.close();
     }

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -1388,6 +1388,52 @@ describe("openclaw state database", () => {
   );
 
   it.each(["runtime open", "doctor repair"] as const)(
+    "retires the supported early commitments layout through %s",
+    (migrationPath) => {
+      const stateDir = createTempStateDir();
+      const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+      const databasePath = path.join(stateDir, "state", "openclaw.sqlite");
+      fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+      const { DatabaseSync } = requireNodeSqlite();
+      const early = new DatabaseSync(databasePath);
+      early.exec(`
+        CREATE TABLE commitments (
+          id TEXT NOT NULL PRIMARY KEY,
+          agent_id TEXT NOT NULL,
+          session_key TEXT NOT NULL,
+          channel TEXT NOT NULL,
+          status TEXT NOT NULL,
+          due_earliest_ms INTEGER NOT NULL,
+          due_latest_ms INTEGER NOT NULL,
+          updated_at_ms INTEGER NOT NULL,
+          record_json TEXT NOT NULL
+        );
+        INSERT INTO commitments (
+          id, agent_id, session_key, channel, status, due_earliest_ms,
+          due_latest_ms, updated_at_ms, record_json
+        ) VALUES (
+          'early-commitment', 'main', 'agent:main:main', 'telegram', 'pending',
+          10, 20, 1, '{}'
+        );
+      `);
+      early.close();
+
+      if (migrationPath === "doctor repair") {
+        const result = repairOpenClawStateDatabaseSchema(options);
+        expect(result.warnings).toEqual([]);
+        expect(result.changes).toContain("Retired shared state commitments table and indexes");
+      }
+      const migrated = openOpenClawStateDatabase(options);
+      expect(readSqliteNumberPragma(migrated.db, "user_version")).toBe(
+        OPENCLAW_STATE_SCHEMA_VERSION,
+      );
+      expect(
+        migrated.db.prepare("SELECT name FROM sqlite_schema WHERE name = 'commitments'").get(),
+      ).toBeUndefined();
+    },
+  );
+
+  it.each(["runtime open", "doctor repair"] as const)(
     "preserves a foreign commitments table and colliding index through %s",
     (migrationPath) => {
       const stateDir = createTempStateDir();

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -194,6 +194,82 @@ function markStateDatabaseAsV5(database: DatabaseSync): void {
   `);
 }
 
+function markStateDatabaseAsV6(database: DatabaseSync): void {
+  database.exec(`
+    PRAGMA user_version = 6;
+    UPDATE schema_meta SET schema_version = 6 WHERE meta_key = 'primary';
+  `);
+}
+
+const RETIRED_COMMITMENT_SCHEMA_OBJECTS = [
+  "commitments",
+  "idx_commitments_scope_due",
+  "idx_commitments_status_due",
+  "idx_commitments_scope_dedupe",
+  "idx_commitments_agent_due",
+  "idx_commitments_agent_sent",
+] as const;
+
+function seedV6CommitmentSchema(database: DatabaseSync): void {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS commitments (
+      id TEXT NOT NULL PRIMARY KEY,
+      agent_id TEXT NOT NULL,
+      session_key TEXT NOT NULL,
+      channel TEXT NOT NULL,
+      account_id TEXT,
+      recipient_id TEXT,
+      thread_id TEXT,
+      sender_id TEXT,
+      kind TEXT NOT NULL,
+      sensitivity TEXT NOT NULL,
+      source TEXT NOT NULL,
+      status TEXT NOT NULL,
+      reason TEXT NOT NULL,
+      suggested_text TEXT NOT NULL,
+      dedupe_key TEXT NOT NULL,
+      confidence REAL NOT NULL,
+      due_earliest_ms INTEGER NOT NULL,
+      due_latest_ms INTEGER NOT NULL,
+      due_timezone TEXT NOT NULL,
+      source_message_id TEXT,
+      source_run_id TEXT,
+      created_at_ms INTEGER NOT NULL,
+      updated_at_ms INTEGER NOT NULL,
+      attempts INTEGER NOT NULL,
+      last_attempt_at_ms INTEGER,
+      sent_at_ms INTEGER,
+      dismissed_at_ms INTEGER,
+      snoozed_until_ms INTEGER,
+      expired_at_ms INTEGER,
+      record_json TEXT NOT NULL
+    ) STRICT;
+    CREATE INDEX IF NOT EXISTS idx_commitments_scope_due
+      ON commitments(agent_id, session_key, status, due_earliest_ms, due_latest_ms);
+    CREATE INDEX IF NOT EXISTS idx_commitments_status_due
+      ON commitments(status, due_earliest_ms, due_latest_ms);
+    CREATE INDEX IF NOT EXISTS idx_commitments_scope_dedupe
+      ON commitments(agent_id, session_key, channel, dedupe_key, status);
+    CREATE INDEX IF NOT EXISTS idx_commitments_agent_due
+      ON commitments(agent_id, status, due_earliest_ms, due_latest_ms, session_key);
+    CREATE INDEX IF NOT EXISTS idx_commitments_agent_sent
+      ON commitments(agent_id, status, sent_at_ms, session_key);
+    INSERT INTO commitments (
+      id, agent_id, session_key, channel, kind, sensitivity, source, status,
+      reason, suggested_text, dedupe_key, confidence, due_earliest_ms,
+      due_latest_ms, due_timezone, created_at_ms, updated_at_ms, attempts, record_json
+    ) VALUES (
+      'retired-commitment', 'main', 'agent:main:main', 'telegram', 'followup',
+      'normal', 'message', 'pending', 'inert', 'follow up', 'retired-dedupe',
+      1.0, 10, 20, 'UTC', 1, 1, 0, '{}'
+    );
+    INSERT INTO state_leases (
+      scope, lease_key, owner, expires_at, heartbeat_at, payload_json, created_at, updated_at
+    ) VALUES ('test', 'preserved-lease', 'migration-test', 100, 50, '{}', 1, 2);
+  `);
+  markStateDatabaseAsV6(database);
+}
+
 function seedLegacySessionWatchCursorSchema(stateDir: string): {
   ambientTarget: string;
   bomTarget: string;
@@ -1219,6 +1295,11 @@ describe("openclaw state database", () => {
         .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = ?")
         .get("execution_identity_contexts"),
     ).toBeUndefined();
+    expect(
+      database.db
+        .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = ?")
+        .get("commitments"),
+    ).toBeUndefined();
     expect(database.path).toBe(path.join(stateDir, "state", "openclaw.sqlite"));
     expect(
       database.db
@@ -1242,6 +1323,55 @@ describe("openclaw state database", () => {
         .run("not-an-integer"),
     ).toThrow();
   });
+
+  it.each(["runtime open", "doctor repair"] as const)(
+    "retires v6 commitments through %s while preserving shared leases",
+    (migrationPath) => {
+      const stateDir = createTempStateDir();
+      const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+      const databasePath = materializeCurrentStateDatabase(stateDir);
+      const { DatabaseSync } = requireNodeSqlite();
+      const legacy = new DatabaseSync(databasePath);
+      seedV6CommitmentSchema(legacy);
+      legacy.close();
+
+      if (migrationPath === "doctor repair") {
+        expect(repairOpenClawStateDatabaseSchema(options).warnings).toEqual([]);
+      }
+      const migrated = openOpenClawStateDatabase(options);
+
+      expect(readSqliteNumberPragma(migrated.db, "user_version")).toBe(7);
+      expect(
+        migrated.db
+          .prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'")
+          .get(),
+      ).toEqual({ schema_version: 7 });
+      for (const name of RETIRED_COMMITMENT_SCHEMA_OBJECTS) {
+        expect(
+          migrated.db.prepare("SELECT name FROM sqlite_schema WHERE name = ?").get(name),
+        ).toBeUndefined();
+      }
+      expect(
+        migrated.db
+          .prepare(
+            `SELECT scope, lease_key, owner, expires_at, heartbeat_at, payload_json,
+                    created_at, updated_at
+               FROM state_leases
+              WHERE scope = 'test' AND lease_key = 'preserved-lease'`,
+          )
+          .get(),
+      ).toEqual({
+        scope: "test",
+        lease_key: "preserved-lease",
+        owner: "migration-test",
+        expires_at: 100,
+        heartbeat_at: 50,
+        payload_json: "{}",
+        created_at: 1,
+        updated_at: 2,
+      });
+    },
+  );
 
   it("keeps the additive worker SSH fallback table compatible with older v6 containment", () => {
     const database = openMaterializedCurrentStateDatabase();
@@ -2249,6 +2379,63 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
           )
           .get(),
       ).toBeUndefined();
+    } finally {
+      after.close();
+    }
+  });
+
+  it("upgrades v5 databases that predate startup worker tool tables", () => {
+    const stateDir = createTempStateDir();
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const databasePath = materializeCurrentStateDatabase(stateDir);
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const legacy = new DatabaseSync(databasePath);
+    legacy.exec(`
+      DROP TABLE worker_session_tool_operations;
+      DROP TABLE worker_turn_tool_authorities;
+    `);
+    markStateDatabaseAsV5(legacy);
+    legacy.close();
+
+    const migrated = openOpenClawStateDatabase(options);
+    expect(readSqliteNumberPragma(migrated.db, "user_version")).toBe(OPENCLAW_STATE_SCHEMA_VERSION);
+    const tables = migrated.db
+      .prepare(
+        `SELECT name FROM sqlite_schema
+         WHERE type = 'table' AND name IN (?, ?)
+         ORDER BY name`,
+      )
+      .all("worker_session_tool_operations", "worker_turn_tool_authorities");
+    expect(tables).toEqual([
+      { name: "worker_session_tool_operations" },
+      { name: "worker_turn_tool_authorities" },
+    ]);
+  });
+
+  it("rejects a missing stable v6 table before the v7 migration", () => {
+    const stateDir = createTempStateDir();
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const databasePath = materializeCurrentStateDatabase(stateDir);
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const damaged = new DatabaseSync(databasePath);
+    damaged.exec("DROP TABLE auth_profile_stores;");
+    markStateDatabaseAsV6(damaged);
+    damaged.close();
+
+    expect(() => openOpenClawStateDatabase(options)).toThrow(/missing table auth_profile_stores/iu);
+
+    const after = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(
+        after
+          .prepare(
+            "SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'auth_profile_stores'",
+          )
+          .get(),
+      ).toBeUndefined();
+      expect(readSqliteNumberPragma(after, "user_version")).toBe(6);
     } finally {
       after.close();
     }
@@ -4305,7 +4492,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     ).toEqual([{ source_id: "legacy-job", ended_at: 12345 }]);
   });
 
-  it("opens databases with early queue and commitment tables before creating newer indexes", () => {
+  it("opens databases with early queue tables before creating newer indexes", () => {
     const stateDir = createTempStateDir();
     const databasePath = path.join(stateDir, "state", "openclaw.sqlite");
     fs.mkdirSync(path.dirname(databasePath), { recursive: true });
@@ -4328,17 +4515,6 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
         updated_at INTEGER NOT NULL,
         failed_at INTEGER,
         PRIMARY KEY (queue_name, id)
-      );
-      CREATE TABLE commitments (
-        id TEXT NOT NULL PRIMARY KEY,
-        agent_id TEXT NOT NULL,
-        session_key TEXT NOT NULL,
-        channel TEXT NOT NULL,
-        status TEXT NOT NULL,
-        due_earliest_ms INTEGER NOT NULL,
-        due_latest_ms INTEGER NOT NULL,
-        updated_at_ms INTEGER NOT NULL,
-        record_json TEXT NOT NULL
       );
     `);
     db.prepare(
@@ -4394,9 +4570,6 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
       session_key: "agent:main:main",
       target: "chat-1",
     });
-    expect(() =>
-      database.db.prepare("SELECT dedupe_key FROM commitments LIMIT 1").all(),
-    ).not.toThrow();
   });
 
   it("configures durable SQLite connection pragmas", () => {

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -3436,16 +3436,20 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     const databasePath = materializeCurrentStateDatabase(stateDir);
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
     const { DatabaseSync } = requireNodeSqlite();
-    const olderV6 = new DatabaseSync(databasePath);
+    const currentSchema = new DatabaseSync(databasePath);
     try {
-      olderV6.exec("DROP INDEX idx_operator_approvals_source_run_resolved;");
-      expect(olderV6.prepare("PRAGMA user_version").get()).toEqual({ user_version: 6 });
+      currentSchema.exec("DROP INDEX idx_operator_approvals_source_run_resolved;");
+      expect(currentSchema.prepare("PRAGMA user_version").get()).toEqual({
+        user_version: OPENCLAW_STATE_SCHEMA_VERSION,
+      });
     } finally {
-      olderV6.close();
+      currentSchema.close();
     }
 
     const beforeRepair = await openExistingOpenClawStateDatabaseReadOnly(options);
-    expect(beforeRepair?.db.prepare("PRAGMA user_version").get()).toEqual({ user_version: 6 });
+    expect(beforeRepair?.db.prepare("PRAGMA user_version").get()).toEqual({
+      user_version: OPENCLAW_STATE_SCHEMA_VERSION,
+    });
     beforeRepair?.walMaintenance.close();
 
     const writable = openOpenClawStateDatabase(options);
@@ -3454,11 +3458,15 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
         .prepare("SELECT name FROM sqlite_schema WHERE type = 'index' AND name = ?")
         .get("idx_operator_approvals_source_run_resolved"),
     ).toEqual({ name: "idx_operator_approvals_source_run_resolved" });
-    expect(writable.db.prepare("PRAGMA user_version").get()).toEqual({ user_version: 6 });
+    expect(writable.db.prepare("PRAGMA user_version").get()).toEqual({
+      user_version: OPENCLAW_STATE_SCHEMA_VERSION,
+    });
     closeOpenClawStateDatabaseForTest();
 
     const afterRepair = await openExistingOpenClawStateDatabaseReadOnly(options);
-    expect(afterRepair?.db.prepare("PRAGMA user_version").get()).toEqual({ user_version: 6 });
+    expect(afterRepair?.db.prepare("PRAGMA user_version").get()).toEqual({
+      user_version: OPENCLAW_STATE_SCHEMA_VERSION,
+    });
     afterRepair?.walMaintenance.close();
   });
 

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -270,6 +270,54 @@ function seedV6CommitmentSchema(database: DatabaseSync): void {
   markStateDatabaseAsV6(database);
 }
 
+function seedAdditiveV6CommitmentSchema(database: DatabaseSync): void {
+  database.exec(`
+    CREATE TABLE commitments (
+      id TEXT NOT NULL PRIMARY KEY,
+      agent_id TEXT NOT NULL,
+      session_key TEXT NOT NULL,
+      channel TEXT NOT NULL,
+      account_id TEXT,
+      recipient_id TEXT,
+      thread_id TEXT,
+      sender_id TEXT,
+      kind TEXT NOT NULL DEFAULT 'followup',
+      sensitivity TEXT NOT NULL DEFAULT 'normal',
+      source TEXT NOT NULL DEFAULT 'unknown',
+      status TEXT NOT NULL,
+      reason TEXT NOT NULL DEFAULT '',
+      suggested_text TEXT NOT NULL DEFAULT '',
+      dedupe_key TEXT NOT NULL DEFAULT '',
+      confidence REAL NOT NULL DEFAULT 0,
+      due_earliest_ms INTEGER NOT NULL,
+      due_latest_ms INTEGER NOT NULL,
+      due_timezone TEXT NOT NULL DEFAULT 'UTC',
+      source_message_id TEXT,
+      source_run_id TEXT,
+      created_at_ms INTEGER NOT NULL DEFAULT 0,
+      updated_at_ms INTEGER NOT NULL,
+      attempts INTEGER NOT NULL DEFAULT 0,
+      last_attempt_at_ms INTEGER,
+      sent_at_ms INTEGER,
+      dismissed_at_ms INTEGER,
+      snoozed_until_ms INTEGER,
+      expired_at_ms INTEGER,
+      record_json TEXT NOT NULL
+    ) STRICT;
+    CREATE INDEX idx_commitments_scope_due
+      ON commitments(agent_id, session_key, status, due_earliest_ms, due_latest_ms);
+    CREATE INDEX idx_commitments_status_due
+      ON commitments(status, due_earliest_ms, due_latest_ms);
+    CREATE INDEX idx_commitments_scope_dedupe
+      ON commitments(agent_id, session_key, channel, dedupe_key, status);
+    CREATE INDEX idx_commitments_agent_due
+      ON commitments(agent_id, status, due_earliest_ms, due_latest_ms, session_key);
+    CREATE INDEX idx_commitments_agent_sent
+      ON commitments(agent_id, status, sent_at_ms, session_key);
+  `);
+  markStateDatabaseAsV6(database);
+}
+
 function seedLegacySessionWatchCursorSchema(stateDir: string): {
   ambientTarget: string;
   bomTarget: string;
@@ -1434,6 +1482,32 @@ describe("openclaw state database", () => {
   );
 
   it.each(["runtime open", "doctor repair"] as const)(
+    "retires the supported additive v6 commitments layout through %s",
+    (migrationPath) => {
+      const stateDir = createTempStateDir();
+      const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+      const databasePath = materializeCurrentStateDatabase(stateDir);
+      const { DatabaseSync } = requireNodeSqlite();
+      const additive = new DatabaseSync(databasePath);
+      seedAdditiveV6CommitmentSchema(additive);
+      additive.close();
+
+      if (migrationPath === "doctor repair") {
+        const result = repairOpenClawStateDatabaseSchema(options);
+        expect(result.warnings).toEqual([]);
+        expect(result.changes).toContain("Retired shared state commitments table and indexes");
+      }
+      const migrated = openOpenClawStateDatabase(options);
+      expect(readSqliteNumberPragma(migrated.db, "user_version")).toBe(
+        OPENCLAW_STATE_SCHEMA_VERSION,
+      );
+      expect(
+        migrated.db.prepare("SELECT name FROM sqlite_schema WHERE name = 'commitments'").get(),
+      ).toBeUndefined();
+    },
+  );
+
+  it.each(["runtime open", "doctor repair"] as const)(
     "preserves a foreign commitments table and colliding index through %s",
     (migrationPath) => {
       const stateDir = createTempStateDir();
@@ -1496,17 +1570,31 @@ describe("openclaw state database", () => {
     },
   );
 
-  it("preserves an extra index on the final v6 commitments layout", () => {
+  it.each([
+    {
+      label: "extra index",
+      name: "foreign_commitments_status",
+      sql: "CREATE INDEX foreign_commitments_status ON commitments(status);",
+      type: "index",
+    },
+    {
+      label: "attached trigger",
+      name: "foreign_commitments_delete",
+      sql: `CREATE TRIGGER foreign_commitments_delete
+              AFTER DELETE ON commitments BEGIN SELECT 1; END;`,
+      type: "trigger",
+    },
+  ])("preserves an $label on the final v6 commitments layout", ({ name, sql, type }) => {
     const stateDir = createTempStateDir();
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
     const databasePath = materializeCurrentStateDatabase(stateDir);
     const { DatabaseSync } = requireNodeSqlite();
     const customized = new DatabaseSync(databasePath);
     seedV6CommitmentSchema(customized);
-    customized.exec("CREATE INDEX foreign_commitments_status ON commitments(status);");
+    customized.exec(sql);
     customized.close();
 
-    expect(() => openOpenClawStateDatabase(options)).toThrow(/unsupported additional indexes/u);
+    expect(() => openOpenClawStateDatabase(options)).toThrow(/commitments/u);
 
     const preserved = new DatabaseSync(databasePath, { readOnly: true });
     try {
@@ -1515,10 +1603,8 @@ describe("openclaw state database", () => {
         preserved.prepare("SELECT name FROM sqlite_schema WHERE name = 'commitments'").get(),
       ).toEqual({ name: "commitments" });
       expect(
-        preserved
-          .prepare("SELECT tbl_name FROM sqlite_schema WHERE name = 'foreign_commitments_status'")
-          .get(),
-      ).toEqual({ tbl_name: "commitments" });
+        preserved.prepare("SELECT type, tbl_name FROM sqlite_schema WHERE name = ?").get(name),
+      ).toEqual({ type, tbl_name: "commitments" });
     } finally {
       preserved.close();
     }

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -1442,7 +1442,18 @@ describe("openclaw state database", () => {
       const { DatabaseSync } = requireNodeSqlite();
       const foreign = new DatabaseSync(databasePath);
       foreign.exec(`
-        CREATE TABLE commitments (marker TEXT NOT NULL PRIMARY KEY) STRICT;
+        CREATE TABLE commitments (
+          id TEXT NOT NULL PRIMARY KEY,
+          agent_id TEXT NOT NULL,
+          session_key TEXT NOT NULL,
+          channel TEXT NOT NULL,
+          status TEXT NOT NULL,
+          due_earliest_ms INTEGER NOT NULL,
+          due_latest_ms INTEGER NOT NULL,
+          updated_at_ms INTEGER NOT NULL,
+          record_json TEXT NOT NULL
+        );
+        CREATE INDEX foreign_commitments_status ON commitments(status);
         CREATE TABLE foreign_commitment_index_owner (marker TEXT NOT NULL) STRICT;
         CREATE INDEX idx_commitments_scope_due
           ON foreign_commitment_index_owner(marker);
@@ -1467,10 +1478,13 @@ describe("openclaw state database", () => {
             .get(),
         ).toEqual({ schema_version: 6 });
         expect(
-          preserved.prepare("SELECT sql FROM sqlite_schema WHERE name = 'commitments'").get(),
-        ).toEqual({
-          sql: "CREATE TABLE commitments (marker TEXT NOT NULL PRIMARY KEY) STRICT",
-        });
+          preserved.prepare("SELECT name FROM sqlite_schema WHERE name = 'commitments'").get(),
+        ).toEqual({ name: "commitments" });
+        expect(
+          preserved
+            .prepare("SELECT tbl_name FROM sqlite_schema WHERE name = 'foreign_commitments_status'")
+            .get(),
+        ).toEqual({ tbl_name: "commitments" });
         expect(
           preserved
             .prepare("SELECT tbl_name FROM sqlite_schema WHERE name = 'idx_commitments_scope_due'")

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -174,12 +174,16 @@ function repairOpenClawStateDatabaseSchemaWithWriteAccess(
           });
         } else if (previousVersion === 6) {
           assertOpenClawStateDatabaseV6ForMigration(db, { pathname });
+        } else if (previousVersion === 5) {
+          assertOpenClawStateDatabaseV5ForMigration(db, { pathname });
         }
         if (rebuiltIndexNames.size === 0) {
           assertSqliteIntegrity(db, pathname);
         }
         dropLegacyStateTables(db);
-        migrateRetiredCommitmentsSchema(db, previousVersion);
+        if (migrateRetiredCommitmentsSchema(db, previousVersion)) {
+          applied.push("Retired shared state commitments table and indexes");
+        }
         if (repairAgentDatabasesCompositePrimaryKey(db)) {
           applied.push(`Migrated shared state agent database registry primary key → agent_id,path`);
         }

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -54,6 +54,7 @@ import {
 import {
   assertOpenClawStateDatabaseForMaintenance,
   assertOpenClawStateDatabaseV5ForMigration,
+  assertOpenClawStateDatabaseV6ForMigration,
   assertSupportedSchemaVersion,
   resolveDatabasePath,
 } from "./openclaw-state-db-maintenance.js";
@@ -66,6 +67,7 @@ import {
   detectOpenClawStateDatabaseSchemaMigrationsFromDatabase,
   dropLegacyStateTables,
   markCurrentStateSchemaVersion,
+  migrateRetiredCommitmentsSchema,
   repairAgentDatabasesCompositePrimaryKey,
   repairLegacyGatewayRestartHandoffsForStrictMigration,
 } from "./openclaw-state-db-schema-repair.js";
@@ -170,11 +172,14 @@ function repairOpenClawStateDatabaseSchemaWithWriteAccess(
           assertSqliteSchemaTablesPresent(db, pathname, OPENCLAW_STATE_SCHEMA_SQL, {
             allowedMissingTables: LAZY_ADDITIVE_STATE_TABLES,
           });
+        } else if (previousVersion === 6) {
+          assertOpenClawStateDatabaseV6ForMigration(db, { pathname });
         }
         if (rebuiltIndexNames.size === 0) {
           assertSqliteIntegrity(db, pathname);
         }
         dropLegacyStateTables(db);
+        migrateRetiredCommitmentsSchema(db, previousVersion);
         if (repairAgentDatabasesCompositePrimaryKey(db)) {
           applied.push(`Migrated shared state agent database registry primary key → agent_id,path`);
         }
@@ -353,10 +358,13 @@ function ensureSchema(db: DatabaseSync, pathname: string, env: NodeJS.ProcessEnv
           });
           ensureAdditiveStateColumns(db);
           assertCurrentStateRuntimeSchema(db, pathname);
+        } else if (previousVersion === 6) {
+          assertOpenClawStateDatabaseV6ForMigration(db, { pathname });
         } else if (previousVersion === 5) {
           assertOpenClawStateDatabaseV5ForMigration(db, { pathname });
         }
         dropLegacyStateTables(db);
+        migrateRetiredCommitmentsSchema(db, previousVersion);
         ensureAdditiveStateColumns(db);
         sessionWatchMigration.migrateSessionWatchCursorProvenance(db);
         assertCanonicalStateSchemaShape(db, pathname);

--- a/src/state/openclaw-state-schema-compatibility.ts
+++ b/src/state/openclaw-state-schema-compatibility.ts
@@ -82,16 +82,6 @@ export const STATE_PERSISTENT_SCHEMA_COMPATIBILITY: SqliteSchemaCompatibility = 
   allowCompatibleAdditiveColumns: true,
   allowedColumnDefinitions: {
     "diagnostic_events.sequence": ["sequence INTEGER NOT NULL DEFAULT 0"],
-    "commitments.attempts": ["attempts INTEGER NOT NULL DEFAULT 0"],
-    "commitments.confidence": ["confidence REAL NOT NULL DEFAULT 0"],
-    "commitments.created_at_ms": ["created_at_ms INTEGER NOT NULL DEFAULT 0"],
-    "commitments.dedupe_key": ["dedupe_key TEXT NOT NULL DEFAULT ''"],
-    "commitments.due_timezone": ["due_timezone TEXT NOT NULL DEFAULT 'UTC'"],
-    "commitments.kind": ["kind TEXT NOT NULL DEFAULT 'followup'"],
-    "commitments.reason": ["reason TEXT NOT NULL DEFAULT ''"],
-    "commitments.sensitivity": ["sensitivity TEXT NOT NULL DEFAULT 'normal'"],
-    "commitments.source": ["source TEXT NOT NULL DEFAULT 'unknown'"],
-    "commitments.suggested_text": ["suggested_text TEXT NOT NULL DEFAULT ''"],
     "claw_package_refs.package_integrity": [
       "package_integrity TEXT NOT NULL DEFAULT 'sha256:0000000000000000000000000000000000000000000000000000000000000000'",
     ],

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -1323,54 +1323,6 @@ CREATE INDEX IF NOT EXISTS idx_sandbox_registry_last_used
   ON sandbox_registry_entries(registry_kind, last_used_at_ms DESC, container_name)
   WHERE last_used_at_ms IS NOT NULL;
 
-CREATE TABLE IF NOT EXISTS commitments (
-  id TEXT NOT NULL PRIMARY KEY,
-  agent_id TEXT NOT NULL,
-  session_key TEXT NOT NULL,
-  channel TEXT NOT NULL,
-  account_id TEXT,
-  recipient_id TEXT,
-  thread_id TEXT,
-  sender_id TEXT,
-  kind TEXT NOT NULL,
-  sensitivity TEXT NOT NULL,
-  source TEXT NOT NULL,
-  status TEXT NOT NULL,
-  reason TEXT NOT NULL,
-  suggested_text TEXT NOT NULL,
-  dedupe_key TEXT NOT NULL,
-  confidence REAL NOT NULL,
-  due_earliest_ms INTEGER NOT NULL,
-  due_latest_ms INTEGER NOT NULL,
-  due_timezone TEXT NOT NULL,
-  source_message_id TEXT,
-  source_run_id TEXT,
-  created_at_ms INTEGER NOT NULL,
-  updated_at_ms INTEGER NOT NULL,
-  attempts INTEGER NOT NULL,
-  last_attempt_at_ms INTEGER,
-  sent_at_ms INTEGER,
-  dismissed_at_ms INTEGER,
-  snoozed_until_ms INTEGER,
-  expired_at_ms INTEGER,
-  record_json TEXT NOT NULL
-) STRICT;
-
-CREATE INDEX IF NOT EXISTS idx_commitments_scope_due
-  ON commitments(agent_id, session_key, status, due_earliest_ms, due_latest_ms);
-
-CREATE INDEX IF NOT EXISTS idx_commitments_status_due
-  ON commitments(status, due_earliest_ms, due_latest_ms);
-
-CREATE INDEX IF NOT EXISTS idx_commitments_scope_dedupe
-  ON commitments(agent_id, session_key, channel, dedupe_key, status);
-
-CREATE INDEX IF NOT EXISTS idx_commitments_agent_due
-  ON commitments(agent_id, status, due_earliest_ms, due_latest_ms, session_key);
-
-CREATE INDEX IF NOT EXISTS idx_commitments_agent_sent
-  ON commitments(agent_id, status, sent_at_ms, session_key);
-
 CREATE TABLE IF NOT EXISTS cron_jobs (
   store_key TEXT NOT NULL,
   job_id TEXT NOT NULL,

--- a/src/state/user-profiles.test.ts
+++ b/src/state/user-profiles.test.ts
@@ -74,7 +74,7 @@ describe("user profiles", () => {
     expect(
       openOpenClawStateDatabase(options).db.prepare("PRAGMA user_version").get()?.user_version,
     ).toBe(versionBefore);
-    expect(OPENCLAW_STATE_SCHEMA_VERSION).toBe(6);
+    expect(OPENCLAW_STATE_SCHEMA_VERSION).toBe(7);
     expect(second).toEqual(first);
     expect(ensureProfileForEmail("ADA@example.com", options)).toEqual(first);
     expect(listProfiles(options)).toEqual([

--- a/test/scripts/check-native-state-schema-version.test.ts
+++ b/test/scripts/check-native-state-schema-version.test.ts
@@ -6,15 +6,15 @@ import {
 
 describe("native state schema version guard", () => {
   it("keeps the checked-in Swift and TypeScript contracts aligned", () => {
-    expect(checkNativeStateSchemaVersion()).toBe(6);
+    expect(checkNativeStateSchemaVersion()).toBe(7);
   });
 
   it("fails when a deliberate Swift fixture drifts behind TypeScript", () => {
     expect(() =>
       compareNativeStateSchemaVersions({
         swiftSource: "private static let maximumSupportedSchemaVersion: Int64 = 5\n",
-        typescriptSource: "export const OPENCLAW_STATE_SCHEMA_VERSION = 6;\n",
+        typescriptSource: "export const OPENCLAW_STATE_SCHEMA_VERSION = 7;\n",
       }),
-    ).toThrow("Native state schema version drift: Swift supports 5, TypeScript owns 6");
+    ).toThrow("Native state schema version drift: Swift supports 5, TypeScript owns 7");
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The commitments runtime was removed by #121479, while #122143 kept its shared-state table in an explicit retirement ledger pending an approved schema migration. Existing shared databases could therefore retain inert commitment rows and five indexes with no remaining runtime owner.

## Why This Change Was Made

Shared-state schema version 7 removes only the retired `commitments` table and its five canonical indexes. The agent schema remains version 17.

Runtime open and Doctor use the same transactional migration. They validate the supported v5/v6 owner and stable-table shape, recognize exact early, partially additive, and final commitments layouts, reject unknown columns/definitions/indexes/triggers, and refuse inbound foreign keys or retained view/trigger/virtual-table dependencies before dropping data. The drop and dependency checks are savepoint-protected, then `PRAGMA user_version` and `schema_meta` advance together. Doctor reports the retirement only when it occurred.

Direct v5-to-v7 and v6-to-v7 upgrades remain supported. Missing unrelated stable v5/v6 tables are refused and never recreated empty. Shared `state_leases`, `agent_database_leases`, Teams poll/plugin state, ACPX leases, and all per-agent schemas remain untouched. Native clients accept shared schema v7 but do not migrate it.

The public database reference records state schema v7 and gives the exact backup-first manual v7-to-v6 procedure, which recreates the v6 commitments table empty before lowering both schema markers.

Recovery rebased the existing PR onto current main and dropped recovery-only Slack, approval, UI, browser, and stale generated-baseline repairs that had already landed independently. The final diff contains only schema v7, necessary native/generated/Doctor/docs surfaces, and focused tests.

## User Impact

Operators upgrading to schema v7 stop carrying storage for a fully retired feature. Only inert, unowned commitment rows are discarded. Foreign or dependent schema objects fail closed before any deletion, with the database left at its prior version.

There is no config, protocol, dependency, changelog, package-version, publication, or release change.

## Evidence

- Focused unique-cache Vitest: 8 files, 277 passed, 1 existing skip. Coverage includes runtime and Doctor retirement, exact/partial additive layouts, direct v5/v6 upgrades, missing-stable-table refusal, foreign/dependent schema preservation, restart handoff, native version alignment, profiles, secret store, retirement ledger, and package metadata.
- `node --import tsx scripts/generate-kysely-types.mts --verify`
- `node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check`
- `node scripts/check-native-state-schema-version.mjs` (`v7`)
- `pnpm docs:list`
- `pnpm docs:check-mdx` (771 files)
- `pnpm format:docs:check` (755 files)
- Targeted Oxfmt/Oxlint and `git diff --check`
- Patch-identical current schema diff: full changed classifier passed on Testbox `tbx_01kzvm0tay25a1w0qbsrscr0jt`, Actions run [31628259237](https://github.com/openclaw/openclaw/actions/runs/31628259237), exit 0. A later actual-conflict rebase changed only generated Plugin SDK hashes; those regenerated hashes passed their check and a separate P2 review.
- Full-branch Codex autoreview through P2 plus TruffleHog: clean, no accepted/actionable findings. Review findings about dependent objects, index subsets, virtual-table discovery, and partially additive historical layouts were fixed and re-reviewed.
- Exact pushed head: `785c39e7e3c49beb4267377c29718d47e25dfdcf`.
- Exact-head hosted CI: [31640137019](https://github.com/openclaw/openclaw/actions/runs/31640137019), success. Repo-native prepare accepted hosted exact-head gates and merge `b6548e509aac607530247127a5c98ec49d88b904` is on `main`.

LOC classification against the rebased base:

- Production/schema/native/metadata: +401/-104 (net +297). The growth is the validated destructive-migration boundary: exact historical-layout recognition plus foreign/view/trigger/virtual-table dependency refusal and rollback.
- Tests: +785/-51 (net +734)
- Docs: +82/-14 (net +68)
- Generated Kysely and Plugin SDK baselines: +18/-52 (net -34)

Known proof gap: no live operator database was mutated. The migration is deterministic SQLite ownership code exercised through both production entry paths against materialized historical databases.
