### PR TITLE
fix(browser): restore shared tabs after relay reconnect

### DIFF
--- a/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
@@ -511,6 +511,53 @@ describe("ExtensionRelayBridge", () => {
     expect(bridge.extensionConnected).toBe(false);
   });
 
+  it("repairs reconnect attach without undoing a later explicit detach", async () => {
+    const bridge = new ExtensionRelayBridge();
+    const initialSocket = new FakeSocket();
+    const initial = bridge.attachExtensionSocket(initialSocket);
+    sendHello(initial);
+
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+    cdp.onMessage(
+      JSON.stringify({ id: 1, method: "Target.setAutoAttach", params: { autoAttach: true } }),
+    );
+    expect(initialSocket.frames().filter((frame) => frame.type === "attach")).toHaveLength(1);
+
+    const replacement = wireExtension(bridge);
+    sendHello(replacement.handlers);
+    await flush();
+
+    expect(replacement.socket.frames().filter((frame) => frame.type === "attach")).toEqual([
+      expect.objectContaining({ tabId: 1 }),
+    ]);
+    cdp.onMessage(JSON.stringify({ id: 2, method: "Target.getTargets" }));
+    await flush();
+    expect(client.frames().find((frame) => frame.id === 2)?.result).toMatchObject({
+      targetInfos: [expect.objectContaining({ targetId: "target-1" })],
+    });
+
+    const attached = client
+      .frames()
+      .findLast((frame) => frame.method === "Target.attachedToTarget");
+    const sessionId = (attached?.params as { sessionId?: string } | undefined)?.sessionId;
+    expect(typeof sessionId).toBe("string");
+    cdp.onMessage(
+      JSON.stringify({ id: 3, method: "Target.detachFromTarget", params: { sessionId } }),
+    );
+    await flush();
+    const afterDetach = wireExtension(bridge);
+    sendHello(afterDetach.handlers, [
+      { tabId: 1, url: "https://example.com", title: "Updated", active: true },
+    ]);
+    await flush();
+
+    expect(afterDetach.socket.frames().filter((frame) => frame.type === "attach")).toHaveLength(0);
+    cdp.onMessage(JSON.stringify({ id: 4, method: "Target.getTargets" }));
+    await flush();
+    expect(client.frames().find((frame) => frame.id === 4)?.result).toEqual({ targetInfos: [] });
+  });
+
   it("reports malformed CDP client JSON instead of leaving the client waiting", () => {
     const bridge = new ExtensionRelayBridge();
     const client = new FakeSocket();

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -53,6 +53,8 @@ type TabState = {
   /** Set while chrome.debugger is attached: real CDP targetId + synthetic root sessionId. */
   attached?: { targetId: string; sessionId: string };
   attaching?: Promise<{ targetId: string; sessionId: string }>;
+  /** Extension loss invalidated attachment work that auto-attach clients still expect restored. */
+  restoreAttachment: boolean;
 };
 
 type CdpClientState = {
@@ -285,9 +287,11 @@ export class ExtensionRelayBridge {
       pending.reject(new Error("extension disconnected"));
     }
     this.pendingExtension.clear();
-    // Tell CDP clients their pages are gone; the tab list itself survives so a
-    // reconnecting extension can re-expose the same tabs.
+    // Retire attach work synchronously so a replacement snapshot cannot reuse
+    // a rejected promise. Keep the tab list so the same ids can be re-exposed.
     for (const [tabId, tab] of this.tabs) {
+      tab.restoreAttachment ||= tab.attached !== undefined || tab.attaching !== undefined;
+      tab.attaching = undefined;
       if (tab.attached) {
         this.emitDetachedFromTarget(tabId, tab.attached.sessionId, tab.attached.targetId);
         tab.attached = undefined;
@@ -356,6 +360,7 @@ export class ExtensionRelayBridge {
 
   private syncTabs(tabs: RelayTabInfo[]): void {
     const nextIds = new Set(tabs.map((tab) => tab.tabId));
+    const shouldAutoAttach = [...this.clients].some((client) => client.autoAttach);
     for (const [tabId, tab] of this.tabs) {
       if (!nextIds.has(tabId)) {
         if (tab.attached) {
@@ -366,21 +371,20 @@ export class ExtensionRelayBridge {
     }
     for (const info of tabs) {
       const existing = this.tabs.get(info.tabId);
+      const shouldAttach = !existing || existing.restoreAttachment;
       if (existing) {
         existing.info = info;
       } else {
-        this.tabs.set(info.tabId, { info });
-        // Newly accessible tabs must reach auto-attach clients immediately;
-        // an access-mode or pause change may happen mid-session.
-        if ([...this.clients].some((client) => client.autoAttach)) {
-          void this.ensureTabAttached(info.tabId)
-            .then(({ targetId, sessionId }) => {
-              this.announceAttachedTab(info.tabId, targetId, sessionId, { onlyAutoAttach: true });
-            })
-            .catch((err: unknown) => {
-              log.warn(`auto-attach of accessible tab ${info.tabId} failed: ${String(err)}`);
-            });
-        }
+        this.tabs.set(info.tabId, { info, restoreAttachment: false });
+      }
+      if (shouldAutoAttach && shouldAttach) {
+        void this.ensureTabAttached(info.tabId)
+          .then(({ targetId, sessionId }) => {
+            this.announceAttachedTab(info.tabId, targetId, sessionId, { onlyAutoAttach: true });
+          })
+          .catch((err: unknown) => {
+            log.warn(`auto-attach of accessible tab ${info.tabId} failed: ${String(err)}`);
+          });
       }
     }
   }
@@ -413,13 +417,17 @@ export class ExtensionRelayBridge {
         throw new Error(`tab ${tabId} closed during attach`);
       }
       current.attached = attached;
+      current.restoreAttachment = false;
       return attached;
     })();
     tab.attaching = attaching;
     try {
       return await attaching;
     } finally {
-      tab.attaching = undefined;
+      // A replacement extension may already have started a fresh attach for this tab.
+      if (tab.attaching === attaching) {
+        tab.attaching = undefined;
+      }
     }
   }
 
@@ -884,7 +892,10 @@ export class ExtensionRelayBridge {
         }
         const tabId = created.tabId;
         if (!this.tabs.has(tabId)) {
-          this.tabs.set(tabId, { info: { tabId, url, title: "", active: false } });
+          this.tabs.set(tabId, {
+            info: { tabId, url, title: "", active: false },
+            restoreAttachment: false,
+          });
         }
         const attached = await this.ensureTabAttached(tabId);
         // Announce before responding, mirroring Chrome's event-then-result order.


### PR DESCRIPTION
## What Problem This Solves

Fixes #122121.

The Chrome extension relay retained accessible tab ids across an extension disconnect, but only auto-attached newly discovered ids. When the extension reconnected with the same shared tabs, existing CDP clients could permanently lose those targets.

## Why This Change Was Made

- Record whether each retained tab was attached or attaching when the extension connection disappeared.
- Retire stale in-flight attach work before the replacement extension publishes its tab snapshot.
- Restore only tabs whose attachment was invalidated by the disconnect, preserving an explicit `Target.detachFromTarget` across later reconnects.
- Keep the existing new-tab auto-attach behavior for ordinary tab updates.

## User Impact

Shared Chrome tabs remain controllable after the OpenClaw extension reconnects. Tabs explicitly detached by a CDP client stay detached.

## Evidence

- Exact head tested: `de6e547435882638cec92d65d8fbbec8a85b65c0`.
- Real Chromium reconnect proof passed using the repository-pinned Playwright Chromium revision `1234`. A temporary, uncommitted extension of the repository's native Chromium harness loaded the real unpacked extension, paired through the extension's public pairing message, connected to the real relay and `/cdp` endpoint, and closed the actual extension WebSocket twice to exercise reconnect. The harness was removed after the run and is not part of this PR.
- `pnpm test:e2e:browser-extension` under Node `24.15.0` passed: 1 test file, 1 test, 155.57s. Redacted trace:

  ```text
  [browser-extension-e2e] launcher probe passed
  [browser-extension-reconnect-proof] exact_head=de6e547435882638cec92d65d8fbbec8a85b65c0
  [browser-extension-reconnect-proof] controlled_tab_id_preserved=true
  [browser-extension-reconnect-proof] relay_reconnect_restored_same_target=true
  [browser-extension-reconnect-proof] restored_session_rotated=true
  [browser-extension-reconnect-proof] explicit_detach_survived_next_reconnect=true
  [browser-extension-reconnect-proof] detached_target_absent=true
  ```

- `node scripts/run-vitest.mjs extensions/browser/src/browser/extension-relay/relay-bridge.test.ts` under Node `24.15.0` passed: 1 test file, 25 tests, 42.82s.
- Exact-head GitHub CI passed, including `openclaw/ci-gate`: https://github.com/openclaw/openclaw/actions/runs/31521077506
- `oxfmt --check extensions/browser/src/browser/extension-relay/relay-bridge.ts extensions/browser/src/browser/extension-relay/relay-bridge.test.ts` passed.
- `git diff --check upstream/main...HEAD` passed.
- Fresh autoreview passed with no accepted/actionable findings (`patch is correct`, confidence `0.91`).
