### PR TITLE
fix(macos): deliver provisional notifications

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardWindowController+Notifications.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController+Notifications.swift
@@ -30,9 +30,10 @@ extension DashboardWindowController {
     }
 
     static func notificationsPermissionLabel(for status: UNAuthorizationStatus) -> String {
+        if PermissionManager.isNotificationAuthorized(status: status) {
+            return "granted"
+        }
         switch status {
-        case .authorized, .provisional:
-            "granted"
         case .denied:
             "denied"
         case .notDetermined:

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController+Notifications.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController+Notifications.swift
@@ -35,14 +35,14 @@ extension DashboardWindowController {
         }
         switch status {
         case .denied:
-            "denied"
+            return "denied"
         case .notDetermined:
-            "notDetermined"
+            return "notDetermined"
         default:
             // .ephemeral is unavailable by name on macOS and cannot occur here;
             // map it and future cases to notDetermined so the UI offers the
             // permission request instead of claiming access.
-            "notDetermined"
+            return "notDetermined"
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController+Notifications.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController+Notifications.swift
@@ -30,19 +30,18 @@ extension DashboardWindowController {
     }
 
     static func notificationsPermissionLabel(for status: UNAuthorizationStatus) -> String {
-        if PermissionManager.isNotificationAuthorized(status: status) {
-            return "granted"
-        }
         switch status {
+        case .authorized, .provisional:
+            "granted"
         case .denied:
-            return "denied"
+            "denied"
         case .notDetermined:
-            return "notDetermined"
+            "notDetermined"
         default:
             // .ephemeral is unavailable by name on macOS and cannot occur here;
             // map it and future cases to notDetermined so the UI offers the
             // permission request instead of claiming access.
-            return "notDetermined"
+            "notDetermined"
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/NotificationManager.swift
+++ b/apps/macos/Sources/OpenClaw/NotificationManager.swift
@@ -23,7 +23,7 @@ struct NotificationManager {
                 self.logger.warning("notification permission denied (request)")
                 return false
             }
-        } else if status.authorizationStatus != .authorized {
+        } else if !PermissionManager.isNotificationAuthorized(status: status.authorizationStatus) {
             self.logger.warning("notification permission denied status=\(status.authorizationStatus.rawValue)")
             return false
         }

--- a/apps/macos/Sources/OpenClaw/PairingPromptSupport.swift
+++ b/apps/macos/Sources/OpenClaw/PairingPromptSupport.swift
@@ -82,7 +82,8 @@ enum PairingPromptSupport {
 
     static func notificationsAuthorized() async -> Bool {
         let settings = await UNUserNotificationCenter.current().notificationSettings()
-        return PermissionManager.isNotificationAuthorized(status: settings.authorizationStatus)
+        let status = settings.authorizationStatus
+        return PermissionManager.isNotificationAuthorized(status: status)
     }
 
     /// Decisions resolve the card optimistically before the RPC returns; when

--- a/apps/macos/Sources/OpenClaw/PairingPromptSupport.swift
+++ b/apps/macos/Sources/OpenClaw/PairingPromptSupport.swift
@@ -82,8 +82,7 @@ enum PairingPromptSupport {
 
     static func notificationsAuthorized() async -> Bool {
         let settings = await UNUserNotificationCenter.current().notificationSettings()
-        return settings.authorizationStatus == .authorized ||
-            settings.authorizationStatus == .provisional
+        return PermissionManager.isNotificationAuthorized(status: settings.authorizationStatus)
     }
 
     /// Decisions resolve the card optimistically before the RPC returns; when

--- a/apps/macos/Sources/OpenClaw/PermissionManager.swift
+++ b/apps/macos/Sources/OpenClaw/PermissionManager.swift
@@ -24,6 +24,10 @@ enum CapabilityAuthorizationStatus: Equatable, Sendable {
 }
 
 enum PermissionManager {
+    static func isNotificationAuthorized(status: UNAuthorizationStatus) -> Bool {
+        status == .authorized || status == .provisional
+    }
+
     static func isLocationAuthorized(status: CLAuthorizationStatus, requireAlways: Bool) -> Bool {
         if requireAlways { return status == .authorizedAlways }
         switch status {
@@ -73,24 +77,19 @@ enum PermissionManager {
     private static func ensureNotifications(interactive: Bool) async -> Bool {
         let center = UNUserNotificationCenter.current()
         let settings = await center.notificationSettings()
-
-        switch settings.authorizationStatus {
-        case .authorized, .provisional, .ephemeral:
+        if self.isNotificationAuthorized(status: settings.authorizationStatus) {
             return true
-        case .notDetermined:
+        }
+        if settings.authorizationStatus == .notDetermined {
             guard interactive else { return false }
             let granted = await (try? center.requestAuthorization(options: [.alert, .sound, .badge])) ?? false
             let updated = await center.notificationSettings()
-            return granted &&
-                (updated.authorizationStatus == .authorized || updated.authorizationStatus == .provisional)
-        case .denied:
-            if interactive {
-                NotificationPermissionHelper.openSettings()
-            }
-            return false
-        @unknown default:
-            return false
+            return granted && self.isNotificationAuthorized(status: updated.authorizationStatus)
         }
+        if settings.authorizationStatus == .denied, interactive {
+            NotificationPermissionHelper.openSettings()
+        }
+        return false
     }
 
     private static func ensureAppleScript(interactive: Bool) async -> Bool {
@@ -216,8 +215,8 @@ enum PermissionManager {
             case .notifications:
                 let center = UNUserNotificationCenter.current()
                 let settings = await center.notificationSettings()
-                results[cap] = settings.authorizationStatus == .authorized
-                    || settings.authorizationStatus == .provisional ? .granted : .notGranted
+                results[cap] = self.isNotificationAuthorized(status: settings.authorizationStatus)
+                    ? .granted : .notGranted
 
             case .appleScript:
                 results[cap] = await TerminalAutomationPermission.authorizationStatus()

--- a/apps/macos/Tests/OpenClawIPCTests/PermissionManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/PermissionManagerTests.swift
@@ -1,11 +1,21 @@
 import CoreLocation
 import OpenClawIPC
 import Testing
+import UserNotifications
 @testable import OpenClaw
 
 @Suite(.serialized)
 @MainActor
 struct PermissionManagerTests {
+    @Test func `notification authorization accepts provisional delivery`() throws {
+        #expect(PermissionManager.isNotificationAuthorized(status: .authorized))
+        #expect(PermissionManager.isNotificationAuthorized(status: .provisional))
+        #expect(!PermissionManager.isNotificationAuthorized(status: .notDetermined))
+        #expect(!PermissionManager.isNotificationAuthorized(status: .denied))
+        let ephemeral = try #require(UNAuthorizationStatus(rawValue: 4))
+        #expect(!PermissionManager.isNotificationAuthorized(status: ephemeral))
+    }
+
     @Test func `voice wake permission helpers match status`() async {
         let direct = PermissionManager.voiceWakePermissionsGranted()
         let ensured = await PermissionManager.ensureVoiceWakePermissions(interactive: false)


### PR DESCRIPTION
Closes #122063

## What Problem This Solves

Fixes an issue where macOS users with provisional notification authorization saw notifications reported as granted while every test, pairing, or system notification was rejected before enqueueing.

## Why This Change Was Made

One macOS-owned authorization predicate now defines usable notification status as `.authorized` or `.provisional`, matching Apple's UserNotifications contract. Permission checks, dashboard presentation, pairing preflight, and delivery all consume that owner instead of maintaining separate local comparisons.

The iOS-only `.ephemeral` status is intentionally rejected on macOS. The broader typed send-result and native bridge redesign remains out of scope.

## User Impact

Provisional macOS authorization now permits the non-interruptive notifications Apple documents, so the dashboard's Granted state and Send test action agree with actual delivery behavior.

## Evidence

- Pre-fix source reproduction: `PermissionManager`, dashboard status, and pairing preflight accepted `.provisional`, while `NotificationManager.send` rejected every status other than `.authorized` before calling `UNUserNotificationCenter.add`.
- Installed macOS 27.0 SDK contract: `UNAuthorizationStatusProvisional` means the app is authorized to post non-interruptive notifications and is available on macOS 10.14+; `UNAuthorizationStatusEphemeral` is unavailable on macOS.
- The canonical predicate has focused coverage for authorized, provisional, not-determined, denied, and raw ephemeral status.
- SwiftFormat lint, `swiftc -parse`, `git diff --check`, changed-lane classification, and `pnpm native:i18n:check` pass on the rebased branch.
- Initial exact-head CI exposed a missing Swift return after the dashboard refactor and native-i18n line-identity drift. The repaired branch leaves the already-correct dashboard mapping unchanged and preserves pairing source line identity; both fixes completed clean mandatory Codex autoreview and TruffleHog scans.
- Production delta: +17/-18 (net -1); tests: +10/-0.
- Local `swift test --package-path apps/macos --filter 'PermissionManagerTests|DashboardNotificationsBridgeTests'` did not reach compilation: the cold SwiftPM cache hit a GRDB HTTP/2 early EOF, then the one HTTP/1.1 retry stalled cloning Peekaboo after growing the mirror to roughly 500 MB. Fresh exact-head macOS CI remains required before merge.

AI-assisted implementation; no agent transcript attached.
