### PR TITLE
fix(state): recover agent databases left incomplete by v17 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Agent database repair:** let Doctor and writable opens remove retired v17 lease tables from databases stamped current before the structural migration, preserving auth, ownership, and schema metadata.
 - **Control UI browser tab identity:** keep selected tab styling, accessibility, focus, address, and page snapshot aligned across in-place navigation and tab reordering. Fixes #120745. Thanks @shakkernerd.
 - **Control UI staged attachments:** preserve unsent images, files, pasted images, and large pasted text across same-tab route and narrow split-pane remounts while keeping pane close, mismatched pane/session/Gateway remounts, application shutdown, and hard reload as cleanup boundaries. Fixes #121519. Thanks @shakkernerd.
 - **Control UI browser annotations:** keep marked screenshots and generated page context together in structured composer cards, preserve user-written drafts when annotations are removed or replaced, retain complete unsent annotation packages across same-tab route and active split-pane remounts, and offer bounded Undo without restoring removed context into another session. Fixes #120744. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Agent database repair:** let Doctor and writable opens remove retired v17 lease tables from databases stamped current before the structural migration, preserving auth, ownership, and schema metadata.
 - **Control UI browser tab identity:** keep selected tab styling, accessibility, focus, address, and page snapshot aligned across in-place navigation and tab reordering. Fixes #120745. Thanks @shakkernerd.
 - **Control UI staged attachments:** preserve unsent images, files, pasted images, and large pasted text across same-tab route and narrow split-pane remounts while keeping pane close, mismatched pane/session/Gateway remounts, application shutdown, and hard reload as cleanup boundaries. Fixes #121519. Thanks @shakkernerd.
 - **Control UI browser annotations:** keep marked screenshots and generated page context together in structured composer cards, preserve user-written drafts when annotations are removed or replaced, retain complete unsent annotation packages across same-tab route and active split-pane remounts, and offer bounded Undo without restoring removed context into another session. Fixes #120744. Thanks @shakkernerd.

--- a/src/infra/state-migrations.media-persistence.additive-schema.test.ts
+++ b/src/infra/state-migrations.media-persistence.additive-schema.test.ts
@@ -18,7 +18,7 @@ describe("legacy media persistence additive schema repair", () => {
     cleanupTempDirs(tempDirs);
   });
 
-  it("repairs same-version additive session schema before media validation", () => {
+  it("repairs same-version additive and retired structural schema before media validation", () => {
     const stateDir = makeTempDir(tempDirs, "media-persistence-current-additive-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const opened = openOpenClawAgentDatabase({ agentId: "main", env });
@@ -46,7 +46,43 @@ describe("legacy media persistence additive schema repair", () => {
       DROP INDEX idx_agent_session_nodes_entry_valid_pending;
       DROP TABLE session_key_contract;
       ALTER TABLE session_nodes DROP COLUMN entry_valid;
+      CREATE TABLE state_leases (
+        scope TEXT NOT NULL,
+        lease_key TEXT NOT NULL,
+        owner TEXT NOT NULL,
+        expires_at INTEGER,
+        heartbeat_at INTEGER,
+        payload_json TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        PRIMARY KEY (scope, lease_key)
+      ) STRICT;
+      CREATE INDEX idx_agent_state_leases_expiry
+        ON state_leases(expires_at, scope, lease_key)
+        WHERE expires_at IS NOT NULL;
+      CREATE INDEX idx_agent_state_leases_owner
+        ON state_leases(owner, updated_at DESC);
+      INSERT INTO state_leases (
+        scope, lease_key, owner, expires_at, heartbeat_at, payload_json, created_at, updated_at
+      ) VALUES ('retired', 'orphan', 'nobody', NULL, NULL, NULL, 1, 1);
+      INSERT INTO auth_profile_store (store_key, store_json, updated_at)
+      VALUES ('primary', '{"fixture":"store-present"}', 10);
+      INSERT INTO auth_profile_state (state_key, state_json, updated_at)
+      VALUES ('primary', '{"fixture":"state-present"}', 11);
     `);
+    const before = {
+      authState: database
+        .prepare("SELECT state_key, state_json, updated_at FROM auth_profile_state")
+        .get(),
+      authStore: database
+        .prepare("SELECT store_key, store_json, updated_at FROM auth_profile_store")
+        .get(),
+      metadata: database
+        .prepare(
+          "SELECT role, schema_version, agent_id, app_version, created_at, updated_at FROM schema_meta WHERE meta_key = 'primary'",
+        )
+        .get(),
+    };
     database.close();
 
     const result = migrateLegacyMediaPersistence({ env });
@@ -64,8 +100,31 @@ describe("legacy media persistence additive schema repair", () => {
       expect(
         repaired.prepare("SELECT main_key FROM session_key_contract WHERE id = 1").get(),
       ).toEqual({ main_key: "main" });
+      expect(
+        repaired
+          .prepare(
+            "SELECT name FROM sqlite_schema WHERE name IN ('state_leases', 'idx_agent_state_leases_expiry', 'idx_agent_state_leases_owner')",
+          )
+          .all(),
+      ).toEqual([]);
+      expect(
+        repaired.prepare("SELECT store_key, store_json, updated_at FROM auth_profile_store").get(),
+      ).toEqual(before.authStore);
+      expect(
+        repaired.prepare("SELECT state_key, state_json, updated_at FROM auth_profile_state").get(),
+      ).toEqual(before.authState);
+      expect(
+        repaired
+          .prepare(
+            "SELECT role, schema_version, agent_id, app_version, created_at, updated_at FROM schema_meta WHERE meta_key = 'primary'",
+          )
+          .get(),
+      ).toEqual(before.metadata);
+      expect(repaired.prepare("PRAGMA integrity_check").get()).toEqual({ integrity_check: "ok" });
+      expect(repaired.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
     } finally {
       repaired.close();
     }
+    expect(migrateLegacyMediaPersistence({ env })).toEqual({ changes: [], warnings: [] });
   });
 });

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -292,12 +292,8 @@ function migrateOpenClawAgentSchema(db: DatabaseSync): void {
   backfillTranscriptMutationWatermarks(db);
 }
 
-function migrateRetiredAgentStateLeaseSchema(
-  db: DatabaseSync,
-  previousVersion: number,
-  targetVersion: number,
-): void {
-  if (previousVersion >= 17 || targetVersion < 17) {
+function migrateRetiredAgentStateLeaseSchema(db: DatabaseSync, targetVersion: number): void {
+  if (targetVersion < 17) {
     return;
   }
   // The 2026-08-10 tenant audit found no agent-DB lease writers after #121113;
@@ -613,6 +609,9 @@ function ensureAgentSchema(
           `OpenClaw agent database ${pathname} uses schema version ${previousVersion}; expected at most ${targetVersion} for this migration.`,
         );
       }
+      // Early v17 media migrations stamped the version before this structural step.
+      // Keep the retirement before the same-version return so reruns converge safely.
+      migrateRetiredAgentStateLeaseSchema(db, targetVersion);
       if (previousVersion === targetVersion) {
         ensureSessionEntryValidityProjection(db);
         ensureSessionKeyContractSchemaInTransaction(db);
@@ -640,7 +639,6 @@ function ensureAgentSchema(
       dropLegacyRuntimeJournalSchemas(db);
       migrateMemoryIndexSourcesIdentity(db);
       migrateOpenClawAgentSchema(db);
-      migrateRetiredAgentStateLeaseSchema(db, previousVersion, targetVersion);
       migrateConversationDeliveryTargetColumn(db);
       backfillOpenClawAgentSchema(db, previousVersion);
       // Remove after 2026-10-01: drop the pre-v11 conversation backfill once schema 11 is the support floor.

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -1640,6 +1640,110 @@ describe("openclaw agent database", () => {
     ).toEqual([]);
   });
 
+  it.each([
+    { authState: true, label: "with auth rows" },
+    { authState: false, label: "without auth rows" },
+  ])("repairs residual version 17 lease storage $label", ({ authState }) => {
+    const stateDir = createTempStateDir();
+    const databasePath = materializeCurrentWorkerAgentDatabase(stateDir);
+    const { DatabaseSync } = requireNodeSqlite();
+    const writer = new DatabaseSync(databasePath);
+    writer.exec(`
+      PRAGMA journal_mode = WAL;
+      PRAGMA wal_autocheckpoint = 0;
+      PRAGMA wal_checkpoint(TRUNCATE);
+    `);
+    const snapshotReader = new DatabaseSync(databasePath, { readOnly: true });
+    snapshotReader.exec("BEGIN;");
+    snapshotReader
+      .prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'")
+      .get();
+    writer.exec(`
+      BEGIN IMMEDIATE;
+      CREATE TABLE state_leases (
+        scope TEXT NOT NULL,
+        lease_key TEXT NOT NULL,
+        owner TEXT NOT NULL,
+        expires_at INTEGER,
+        heartbeat_at INTEGER,
+        payload_json TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        PRIMARY KEY (scope, lease_key)
+      ) STRICT;
+      CREATE INDEX idx_agent_state_leases_expiry
+        ON state_leases(expires_at, scope, lease_key)
+        WHERE expires_at IS NOT NULL;
+      CREATE INDEX idx_agent_state_leases_owner
+        ON state_leases(owner, updated_at DESC);
+      INSERT INTO state_leases (
+        scope, lease_key, owner, expires_at, heartbeat_at, payload_json, created_at, updated_at
+      ) VALUES ('retired', 'orphan', 'nobody', NULL, NULL, NULL, 1, 1);
+      ${authState ? "INSERT INTO auth_profile_store (store_key, store_json, updated_at) VALUES ('primary', '{\"fixture\":\"store-present\"}', 10);" : ""}
+      ${authState ? "INSERT INTO auth_profile_state (state_key, state_json, updated_at) VALUES ('primary', '{\"fixture\":\"state-present\"}', 11);" : ""}
+      COMMIT;
+    `);
+    writer.close();
+    expect(fs.statSync(`${databasePath}-wal`).size).toBeGreaterThan(0);
+
+    const readPreservedState = () => {
+      const database = new DatabaseSync(databasePath, { readOnly: true });
+      try {
+        return {
+          authState: database
+            .prepare(
+              "SELECT state_key, state_json, updated_at FROM auth_profile_state ORDER BY state_key",
+            )
+            .all(),
+          authStore: database
+            .prepare(
+              "SELECT store_key, store_json, updated_at FROM auth_profile_store ORDER BY store_key",
+            )
+            .all(),
+          foreignKeys: database.prepare("PRAGMA foreign_key_check").all(),
+          integrity: database.prepare("PRAGMA integrity_check").get(),
+          journalMode: database.prepare("PRAGMA journal_mode").get(),
+          metadata: database
+            .prepare(
+              "SELECT role, schema_version, agent_id, app_version, created_at, updated_at FROM schema_meta WHERE meta_key = 'primary'",
+            )
+            .get(),
+          retiredObjects: database
+            .prepare(
+              "SELECT name FROM sqlite_schema WHERE name IN ('state_leases', 'idx_agent_state_leases_expiry', 'idx_agent_state_leases_owner') ORDER BY name",
+            )
+            .all(),
+          userVersion: database.prepare("PRAGMA user_version").get(),
+        };
+      } finally {
+        database.close();
+      }
+    };
+    const before = readPreservedState();
+
+    migrateOpenClawAgentDatabaseForMaintenance({
+      agentId: "worker-1",
+      pathname: databasePath,
+    });
+    snapshotReader.exec("ROLLBACK;");
+    snapshotReader.close();
+    const repaired = readPreservedState();
+    expect(repaired).toEqual({
+      ...before,
+      foreignKeys: [],
+      integrity: { integrity_check: "ok" },
+      journalMode: { journal_mode: "wal" },
+      retiredObjects: [],
+      userVersion: { user_version: OPENCLAW_AGENT_SCHEMA_VERSION },
+    });
+
+    migrateOpenClawAgentDatabaseForMaintenance({
+      agentId: "worker-1",
+      pathname: databasePath,
+    });
+    expect(readPreservedState()).toEqual(repaired);
+  });
+
   it("upgrades version 11 with agent state intact and adds ACP parent-stream storage", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an early v17 upgrade could mark an agent database as current before removing retired lease storage. Later Doctor runs and writable opens accepted that incomplete physical layout without converging it.

## Why This Change Was Made

The agent schema owner now retires the old lease table inside its existing immediate transaction before the same-version return. This complements the forward-migration fix by repairing databases that were already stamped v17, without lowering versions, adding runtime compatibility paths, or moving schema ownership into Doctor.

The defect became reachable when the v16 media fence from #113695 was followed by the independent v17 structural migration in #121943.

## User Impact

Doctor and normal writable agent-database opens now repair the incomplete v17 layout automatically. Stored authentication rows, agent ownership metadata, schema versions, WAL behavior, and unrelated agent state remain unchanged.

## Evidence

- Before the production change, the focused owner regression failed in both auth-present and auth-absent cases because `state_leases` and both indexes survived.
- Before the production change, the Doctor media-migration integration failed for the same residual objects.
- Exact-head focused and sibling proof: 117 passed, 6 platform skips across the agent database, Doctor media migration, and auth-profile SQLite suites.
- WAL-pinned fixture preserves committed auth state while the schema repair runs on a separate connection; integrity and foreign-key checks remain clean.
- Targeted formatting and lint passed.
- Codex autoreview: clean, no accepted/actionable findings.

Production LOC: +5/-7 (net -2) | Tests: +164/-1
