### PR TITLE
fix(macos): accept provisional notification authorization

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardWindowController+Notifications.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController+Notifications.swift
@@ -31,7 +31,7 @@ extension DashboardWindowController {
 
     static func notificationsPermissionLabel(for status: UNAuthorizationStatus) -> String {
         switch status {
-        case .authorized, .provisional:
+        case _ where PermissionManager.isNotificationAuthorized(status: status):
             "granted"
         case .denied:
             "denied"

--- a/apps/macos/Sources/OpenClaw/NotificationManager.swift
+++ b/apps/macos/Sources/OpenClaw/NotificationManager.swift
@@ -23,7 +23,7 @@ struct NotificationManager {
                 self.logger.warning("notification permission denied (request)")
                 return false
             }
-        } else if status.authorizationStatus != .authorized {
+        } else if !PermissionManager.isNotificationAuthorized(status: status.authorizationStatus) {
             self.logger.warning("notification permission denied status=\(status.authorizationStatus.rawValue)")
             return false
         }

--- a/apps/macos/Sources/OpenClaw/PairingPromptSupport.swift
+++ b/apps/macos/Sources/OpenClaw/PairingPromptSupport.swift
@@ -82,8 +82,8 @@ enum PairingPromptSupport {
 
     static func notificationsAuthorized() async -> Bool {
         let settings = await UNUserNotificationCenter.current().notificationSettings()
-        return settings.authorizationStatus == .authorized ||
-            settings.authorizationStatus == .provisional
+        return PermissionManager
+            .isNotificationAuthorized(status: settings.authorizationStatus)
     }
 
     /// Decisions resolve the card optimistically before the RPC returns; when

--- a/apps/macos/Sources/OpenClaw/PermissionManager.swift
+++ b/apps/macos/Sources/OpenClaw/PermissionManager.swift
@@ -82,7 +82,7 @@ enum PermissionManager {
             let granted = await (try? center.requestAuthorization(options: [.alert, .sound, .badge])) ?? false
             let updated = await center.notificationSettings()
             return granted &&
-                (updated.authorizationStatus == .authorized || updated.authorizationStatus == .provisional)
+                self.isNotificationAuthorized(status: updated.authorizationStatus)
         case .denied:
             if interactive {
                 NotificationPermissionHelper.openSettings()
@@ -216,8 +216,8 @@ enum PermissionManager {
             case .notifications:
                 let center = UNUserNotificationCenter.current()
                 let settings = await center.notificationSettings()
-                results[cap] = settings.authorizationStatus == .authorized
-                    || settings.authorizationStatus == .provisional ? .granted : .notGranted
+                results[cap] = self.isNotificationAuthorized(status: settings.authorizationStatus)
+                    ? .granted : .notGranted
 
             case .appleScript:
                 results[cap] = await TerminalAutomationPermission.authorizationStatus()
@@ -510,5 +510,11 @@ enum ScreenRecordingProbe {
         if #available(macOS 10.15, *) {
             _ = CGRequestScreenCaptureAccess()
         }
+    }
+}
+
+extension PermissionManager {
+    static func isNotificationAuthorized(status: UNAuthorizationStatus) -> Bool {
+        status == .authorized || status == .provisional
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/PermissionManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/PermissionManagerTests.swift
@@ -1,11 +1,19 @@
 import CoreLocation
 import OpenClawIPC
 import Testing
+import UserNotifications
 @testable import OpenClaw
 
 @Suite(.serialized)
 @MainActor
 struct PermissionManagerTests {
+    @Test func `notification authorization includes provisional access`() {
+        #expect(PermissionManager.isNotificationAuthorized(status: .authorized))
+        #expect(PermissionManager.isNotificationAuthorized(status: .provisional))
+        #expect(!PermissionManager.isNotificationAuthorized(status: .denied))
+        #expect(!PermissionManager.isNotificationAuthorized(status: .notDetermined))
+    }
+
     @Test func `voice wake permission helpers match status`() async {
         let direct = PermissionManager.voiceWakePermissionsGranted()
         let ensured = await PermissionManager.ensureVoiceWakePermissions(interactive: false)


### PR DESCRIPTION
## What Problem This Solves

Fixes #122063.

The macOS app reported provisional notification authorization as granted in permission status, the dashboard, and pairing preflight, but `NotificationManager.send` rejected the same status before enqueueing a notification.

## Why This Change Was Made

- Define one macOS notification authorization predicate in `PermissionManager` for authorized and provisional access.
- Reuse that predicate in permission reporting, post-request validation, dashboard presentation, pairing preflight, and delivery.
- Preserve the existing denied, not-determined, and macOS ephemeral UI behavior.

Apple documents provisional authorization as permission to post noninterruptive notifications: https://developer.apple.com/documentation/usernotifications/unauthorizationstatus/provisional

## User Impact

macOS users with provisional authorization can send test, pairing, and system notifications consistently with the Granted status shown by the app.

## Evidence

- Added a focused `PermissionManagerTests` regression for authorized, provisional, denied, and not-determined states.
- Existing `DashboardNotificationsBridgeTests` continues to cover the provisional-to-Granted UI mapping through the canonical predicate.
- `git diff --check upstream/main...HEAD` passed.
- Fresh autoreview passed with no accepted/actionable findings (`patch is correct`, confidence `0.98`).
- Local Swift/macOS execution was unavailable in this Linux checkout. Exact-head macOS GitHub CI is the executable test authority for this branch.
