### PR TITLE
fix(release): retire install E2E TOOLS assertion

### DIFF
--- a/scripts/docker/install-sh-e2e/run.sh
+++ b/scripts/docker/install-sh-e2e/run.sh
@@ -849,7 +849,6 @@ run_profile() {
   test -f "$workspace/IDENTITY.md"
   test -f "$workspace/USER.md"
   test -f "$workspace/SOUL.md"
-  test -f "$workspace/TOOLS.md"
   # The remaining checks are deterministic tool smokes, not the interactive
   # first-run identity ritual. Drop BOOTSTRAP.md so provider prompts stay focused
   # on the fixture task and do not spend turns following onboarding copy.


### PR DESCRIPTION
## What Problem This Solves

Fixes the extended-stable installer E2E run, which still requires a workspace `TOOLS.md` file after the current beta onboarding flow retired it.

## Why This Change Was Made

Remove only the obsolete `TOOLS.md` existence assertion. The remaining workspace identity-file checks are unchanged and match current main.

## User Impact

Release validation can exercise the current beta installer without failing on a retired workspace file. No installer or runtime behavior changes.

## Evidence

- `bash -n scripts/docker/install-sh-e2e/run.sh`
- `shellcheck -e SC1091 scripts/docker/install-sh-e2e/run.sh` (SC1091 is the existing dynamic source-path limitation)
- `git diff --check`
- Fresh autoreview: clean, no actionable findings.
- `node scripts/check-changed.mjs --dry-run -- scripts/docker/install-sh-e2e/run.sh` was not runnable because this isolated worktree has no installed `yaml` dependency; no dependency reconciliation was performed for this one-line shell-only release repair.