### PR TITLE
fix(cron): record exhausted stream failures before alerts

### DIFF
--- a/src/cron/service.stream-validation.test.ts
+++ b/src/cron/service.stream-validation.test.ts
@@ -2,7 +2,9 @@ import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coerc
 import { describe, expect, it, vi } from "vitest";
 import { CronService } from "./service.js";
 import { setupCronServiceSuite } from "./service.test-harness.js";
+import { cronStoreKey } from "./store/key.js";
 import { cronStreamScheduleKey } from "./stream-schedule.js";
+import { readCronTaskRunHistoryPage } from "./task-run-history.js";
 import type { CronJobCreate } from "./types.js";
 
 const { logger, makeStorePath } = setupCronServiceSuite({ prefix: "cron-stream-validation-" });
@@ -140,9 +142,18 @@ describe("cron stream schedule validation", () => {
     }
   });
 
-  it("routes restart exhaustion through normal failure alerts", async () => {
+  it("records restart exhaustion before routing its normal failure alert", async () => {
     const { storePath } = await makeStorePath();
-    const enqueueSystemEvent = vi.fn();
+    let jobId = "";
+    const historyAtAlert: unknown[][] = [];
+    const enqueueSystemEvent = vi.fn(() => {
+      historyAtAlert.push(
+        readCronTaskRunHistoryPage({
+          storeKey: cronStoreKey(storePath),
+          jobId,
+        }).entries,
+      );
+    });
     const cron = new CronService({
       storePath,
       cronEnabled: true,
@@ -158,6 +169,7 @@ describe("cron stream schedule validation", () => {
     await cron.start();
     try {
       const created = await cron.add(streamJob());
+      jobId = created.id;
       await cron.recordExternalFailure(created.id, "stream source exhausted restarts", {
         streamStatus: "error",
         streamRestartExhausted: true,
@@ -174,6 +186,16 @@ describe("cron stream schedule validation", () => {
         'Automation "stream" failed 5 times\nCheck automation history for details.',
         expect.any(Object),
       );
+      expect(historyAtAlert).toEqual([
+        [
+          expect.objectContaining({
+            jobId: created.id,
+            status: "error",
+            error: "stream source exhausted restarts",
+            durationMs: 0,
+          }),
+        ],
+      ]);
     } finally {
       cron.stop();
     }

--- a/src/cron/service/ops-read.ts
+++ b/src/cron/service/ops-read.ts
@@ -23,6 +23,7 @@ import type {
 import { locked } from "./locked.js";
 import { normalizeOptionalAgentId } from "./normalize.js";
 import { updateLoadedJob } from "./ops-mutations.js";
+import { emitCronRunFinished } from "./ops-run-preparation.js";
 import {
   ensureLoadedForRead,
   ownsStreamSource,
@@ -30,7 +31,6 @@ import {
   resolveEffectiveJobAgentId,
 } from "./ops-shared.js";
 import type { CronServiceState, DeferredCronNotifications } from "./state.js";
-import { emit } from "./state.js";
 import { ensureLoaded, persistOrRestore, snapshotStoreForRollback } from "./store.js";
 import { applyJobResult, armTimer } from "./timer.js";
 
@@ -146,7 +146,7 @@ export async function recordExternalFailure(
     // Stream schedules are event-driven; applyJobResult's generic recurring
     // backoff must never turn source failure into a time-due payload run.
     job.state.nextRunAtMs = undefined;
-    emit(state, {
+    emitCronRunFinished(state, {
       jobId: job.id,
       action: "finished",
       job,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators whose stream-source automation exhausted its restart budget would receive the generic failure alert before the terminal failure appeared in durable cron run history. Alert consumers could therefore observe an empty history even though the alert told operators to check it.

## Why This Change Was Made

The root cause was that `recordExternalFailure` called the raw event emitter directly, bypassing the canonical task-ledger finalization path. This change routes restart exhaustion through `emitCronRunFinished`, the owner boundary that persists and finalizes run history before event listeners and deferred generic alert delivery.

The existing generic alert text from commit `21e7f200aa84` is preserved. PR #121544 concerns plugin command identity and is intentionally separate and out of scope.

Alternatives rejected:

- Delaying only the alert callback would compensate downstream while leaving durable run history unfinalized for other listeners.
- Writing task history separately inside `recordExternalFailure` would duplicate canonical finalization policy and risk diverging from normal cron completion.
- Reworking stream watcher lifecycle was unnecessary because the violated invariant belongs to cron run finalization.

Production LOC: +2/-2 (net 0). Tests: +24/-2 (net +22).

Provenance: introduced by @steipete in #112387 (`98742bc2c7f2`, 2026-07-21), carried through #113830, and exposed by the deferred-alert ordering from #118200. Commit `21e7f200aa84` only aligned generic alert assertions and remains preserved.

## User Impact

When a stream source exhausts its restart budget, the terminal error is now present in automation run history before the existing generic failure alert is delivered. Operators can immediately inspect the history referenced by that alert.

## Evidence

- Pre-fix controlled boundary reproduction:
  - `node scripts/run-vitest.mjs src/cron/service.stream-validation.test.ts`
  - Result: 1 failed, 7 passed.
  - The alert callback observed empty history: `[[]]`.
- Post-fix same boundary test:
  - `node scripts/run-vitest.mjs src/cron/service.stream-validation.test.ts`
  - Result: 8/8 passed.
- Failure-alert/task-ledger sibling tests: 52/52 passed.
- Stream-watcher lifecycle tests: 31/31 passed.
- Formatting, path-scoped lint, and `git diff --check`: clean.
- An independent verifier reproduced the before/after behavior, found no findings, and restored the exact task-file hashes.
- Mandatory uncommitted autoreview exited clean with no accepted or actionable findings.
- Frozen committed file hashes:
  - `src/cron/service/ops-read.ts`: `771d5aa060b903488782a7afd7cd308dd6b5afc1b8a9798efdf48dd489ef1ad9`
  - `src/cron/service.stream-validation.test.ts`: `0fd1ee8358892172609f1bc16b365bc6dbba0021a98ad5db0743bb0ea2cbc8b6`