### PR TITLE
refactor(agents): centralize typed activity event emission

### DIFF
--- a/src/agents/embedded-agent-runner/run/progress-controller.ts
+++ b/src/agents/embedded-agent-runner/run/progress-controller.ts
@@ -2,7 +2,7 @@ import {
   FAST_MODE_AUTO_PROGRESS_KIND,
   type ReplyPayload,
 } from "../../../auto-reply/reply-payload.js";
-import { emitAgentItemEvent } from "../../../infra/agent-activity-events.js";
+import { emitAgentActivityEvent } from "../../../infra/agent-activity-events.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { resolveFastModeModelAutoOnSeconds } from "../../../shared/fast-mode.js";
 import {
@@ -54,9 +54,10 @@ export function createEmbeddedRunProgressController(params: {
   }) => {
     const summary = formatFastModeAutoProgressText(payload);
     try {
-      emitAgentItemEvent({
+      emitAgentActivityEvent({
         runId: params.attempt.runId,
         ...(params.attempt.sessionKey ? { sessionKey: params.attempt.sessionKey } : {}),
+        stream: "item",
         data: {
           itemId: `fast-mode-auto:${payload.enabled ? "on" : "off"}`,
           kind: "status",

--- a/src/agents/embedded-agent-subscribe.handlers.tools.completion.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.completion.ts
@@ -4,15 +4,11 @@ import {
   normalizeHeartbeatToolResponse,
 } from "../auto-reply/heartbeat-tool-response.js";
 import { parseSessionThreadInfoFast } from "../config/sessions/thread-info.js";
-import type {
-  AgentCommandOutputEventData,
-  AgentItemEventData,
-  AgentPatchSummaryEventData,
-} from "../infra/agent-activity-events.js";
 import {
-  emitAgentApprovalEvent,
-  emitAgentCommandOutputEvent,
-  emitAgentPatchSummaryEvent,
+  emitAgentActivityEvent,
+  type AgentCommandOutputEventData,
+  type AgentItemEventData,
+  type AgentPatchSummaryEventData,
 } from "../infra/agent-activity-events.js";
 import { emitAgentEvent, type AgentApprovalEventData } from "../infra/agent-events.js";
 import type { PluginHookAfterToolCallEvent } from "../plugins/types.js";
@@ -452,9 +448,10 @@ export async function handleToolExecutionEnd(
         ...(execDetails.status === "approval-unavailable" ? { reason: execDetails.reason } : {}),
         message: execDetails.warningText,
       };
-      emitAgentApprovalEvent({
+      emitAgentActivityEvent({
         runId: ctx.params.runId,
         ...(ctx.params.sessionKey ? { sessionKey: ctx.params.sessionKey } : {}),
+        stream: "approval",
         data: approvalData,
       });
       emitAgentEventCallbackBestEffort(ctx, {
@@ -519,9 +516,10 @@ export async function handleToolExecutionEnd(
           ? { cwd: execDetails.cwd }
           : {}),
       };
-      emitAgentCommandOutputEvent({
+      emitAgentActivityEvent({
         runId: ctx.params.runId,
         ...(ctx.params.sessionKey ? { sessionKey: ctx.params.sessionKey } : {}),
+        stream: "command_output",
         data: outputData,
       });
       emitAgentEventCallbackBestEffort(ctx, {
@@ -545,9 +543,10 @@ export async function handleToolExecutionEnd(
             toolCallId,
             message: parsedApprovalResult.body || parsedApprovalResult.raw,
           };
-          emitAgentApprovalEvent({
+          emitAgentActivityEvent({
             runId: ctx.params.runId,
             ...(ctx.params.sessionKey ? { sessionKey: ctx.params.sessionKey } : {}),
+            stream: "approval",
             data: approvalData,
           });
           emitAgentEventCallbackBestEffort(ctx, {
@@ -591,9 +590,10 @@ export async function handleToolExecutionEnd(
         deleted: patchSummary.deleted,
         summary: summaryText ?? buildPatchSummaryText(patchSummary),
       };
-      emitAgentPatchSummaryEvent({
+      emitAgentActivityEvent({
         runId: ctx.params.runId,
         ...(ctx.params.sessionKey ? { sessionKey: ctx.params.sessionKey } : {}),
+        stream: "patch",
         data: patchData,
       });
       emitAgentEventCallbackBestEffort(ctx, {

--- a/src/agents/embedded-agent-subscribe.handlers.tools.progress.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.progress.ts
@@ -3,11 +3,11 @@ import {
   asOptionalRecord as readRecordField,
 } from "@openclaw/normalization-core/record-coerce";
 import { readStringValue } from "@openclaw/normalization-core/string-coerce";
-import type {
-  AgentCommandOutputEventData,
-  AgentItemEventData,
+import {
+  emitAgentActivityEvent,
+  type AgentCommandOutputEventData,
+  type AgentItemEventData,
 } from "../infra/agent-activity-events.js";
-import { emitAgentCommandOutputEvent } from "../infra/agent-activity-events.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { extractLiveExecOutput } from "./embedded-agent-subscribe.handlers.tools.results.js";
 import {
@@ -146,9 +146,10 @@ export function handleToolExecutionUpdate(
         output,
         status: "running",
       };
-      emitAgentCommandOutputEvent({
+      emitAgentActivityEvent({
         runId: ctx.params.runId,
         ...(ctx.params.sessionKey ? { sessionKey: ctx.params.sessionKey } : {}),
+        stream: "command_output",
         data: outputData,
       });
       emitAgentEventCallbackBestEffort(ctx, {

--- a/src/agents/embedded-agent-subscribe.handlers.tools.start.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.start.ts
@@ -5,8 +5,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { parseSessionThreadInfoFast } from "../config/sessions/thread-info.js";
-import type { AgentItemEventData } from "../infra/agent-activity-events.js";
-import { emitAgentItemEvent } from "../infra/agent-activity-events.js";
+import { emitAgentActivityEvent, type AgentItemEventData } from "../infra/agent-activity-events.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { REQUIRED_PARAM_GROUPS, type RequiredParamGroup } from "./agent-tools.params.js";
 import { sanitizeForConsole } from "./console-sanitize.js";
@@ -255,9 +254,10 @@ export function emitTrackedItemEvent(ctx: ToolHandlerContext, itemData: AgentIte
     ctx.state.itemActiveIds.delete(itemData.itemId);
     ctx.state.itemCompletedCount += 1;
   }
-  emitAgentItemEvent({
+  emitAgentActivityEvent({
     runId: ctx.params.runId,
     ...(ctx.params.sessionKey ? { sessionKey: ctx.params.sessionKey } : {}),
+    stream: "item",
     data: itemData,
   });
   emitAgentEventCallbackBestEffort(ctx, {

--- a/src/infra/agent-activity-events.test.ts
+++ b/src/infra/agent-activity-events.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, expectTypeOf, test } from "vitest";
+import {
+  emitAgentActivityEvent,
+  type AgentCommandOutputEventData,
+  type AgentItemEventData,
+  type AgentPatchSummaryEventData,
+} from "./agent-activity-events.js";
+import {
+  type AgentApprovalEventData,
+  type AgentEventPayload,
+  onAgentEvent,
+  resetAgentEventsForTest,
+} from "./agent-events.js";
+
+describe("agent activity events", () => {
+  beforeEach(() => {
+    resetAgentEventsForTest();
+  });
+
+  test("emits every activity stream with shared sequencing and context", () => {
+    const itemData: AgentItemEventData = {
+      itemId: "item-1",
+      phase: "start",
+      kind: "tool",
+      title: "Read",
+      status: "running",
+    };
+    const approvalData: AgentApprovalEventData = {
+      phase: "requested",
+      kind: "exec",
+      status: "pending",
+      title: "Approve",
+    };
+    const commandData: AgentCommandOutputEventData = {
+      itemId: "command-1",
+      phase: "delta",
+      title: "Command",
+      toolCallId: "tool-1",
+      output: "working",
+    };
+    const patchData: AgentPatchSummaryEventData = {
+      itemId: "patch-1",
+      phase: "end",
+      title: "Patch",
+      toolCallId: "tool-2",
+      added: ["new.ts"],
+      modified: [],
+      deleted: [],
+      summary: "Added new.ts",
+    };
+    const events: AgentEventPayload[] = [];
+    const unsubscribe = onAgentEvent((event) => events.push(event));
+
+    emitAgentActivityEvent({
+      runId: "run-1",
+      sessionKey: "session-1",
+      stream: "item",
+      data: itemData,
+    });
+    emitAgentActivityEvent({
+      runId: "run-1",
+      sessionKey: "session-1",
+      stream: "approval",
+      data: approvalData,
+    });
+    emitAgentActivityEvent({
+      runId: "run-1",
+      sessionKey: "session-1",
+      stream: "command_output",
+      data: commandData,
+    });
+    emitAgentActivityEvent({
+      runId: "run-1",
+      sessionKey: "",
+      stream: "patch",
+      data: patchData,
+    });
+
+    expect(
+      events.map(({ runId, seq, stream, sessionKey }) => ({ runId, seq, stream, sessionKey })),
+    ).toEqual([
+      { runId: "run-1", seq: 1, stream: "item", sessionKey: "session-1" },
+      { runId: "run-1", seq: 2, stream: "approval", sessionKey: "session-1" },
+      { runId: "run-1", seq: 3, stream: "command_output", sessionKey: "session-1" },
+      { runId: "run-1", seq: 4, stream: "patch", sessionKey: undefined },
+    ]);
+    expect(events.map((event) => event.data)).toEqual([
+      itemData,
+      approvalData,
+      commandData,
+      patchData,
+    ]);
+    expect(events[0]?.data).toBe(itemData);
+    unsubscribe();
+  });
+
+  test("rejects mismatched stream and payload pairs", () => {
+    type ItemData = Extract<
+      Parameters<typeof emitAgentActivityEvent>[0],
+      { stream: "item" }
+    >["data"];
+
+    expectTypeOf<AgentApprovalEventData>().not.toMatchTypeOf<ItemData>();
+  });
+});

--- a/src/infra/agent-activity-events.ts
+++ b/src/infra/agent-activity-events.ts
@@ -58,57 +58,27 @@ export type AgentPatchSummaryEventData = {
   summary: string;
 };
 
-/** Emits an item activity event on the shared agent event bus. */
-export function emitAgentItemEvent(params: {
-  runId: string;
-  data: AgentItemEventData;
-  sessionKey?: string;
-}) {
-  emitAgentEvent({
-    runId: params.runId,
-    stream: "item",
-    data: params.data as unknown as Record<string, unknown>,
-    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-  });
-}
+type AgentActivityEventDataByStream = {
+  item: AgentItemEventData;
+  approval: AgentApprovalEventData;
+  command_output: AgentCommandOutputEventData;
+  patch: AgentPatchSummaryEventData;
+};
 
-/** Emits an approval event on the shared agent event bus. */
-export function emitAgentApprovalEvent(params: {
-  runId: string;
-  data: AgentApprovalEventData;
-  sessionKey?: string;
-}) {
-  emitAgentEvent({
-    runId: params.runId,
-    stream: "approval",
-    data: params.data as unknown as Record<string, unknown>,
-    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-  });
-}
+type AgentActivityEventParams = {
+  [Stream in keyof AgentActivityEventDataByStream]: {
+    runId: string;
+    sessionKey?: string;
+    stream: Stream;
+    data: AgentActivityEventDataByStream[Stream];
+  };
+}[keyof AgentActivityEventDataByStream];
 
-/** Emits command output for a running or completed item/tool call. */
-export function emitAgentCommandOutputEvent(params: {
-  runId: string;
-  data: AgentCommandOutputEventData;
-  sessionKey?: string;
-}) {
+/** Emits a typed activity event on the shared agent event bus. */
+export function emitAgentActivityEvent(params: AgentActivityEventParams): void {
   emitAgentEvent({
     runId: params.runId,
-    stream: "command_output",
-    data: params.data as unknown as Record<string, unknown>,
-    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-  });
-}
-
-/** Emits a patch summary for a completed file-editing item/tool call. */
-export function emitAgentPatchSummaryEvent(params: {
-  runId: string;
-  data: AgentPatchSummaryEventData;
-  sessionKey?: string;
-}) {
-  emitAgentEvent({
-    runId: params.runId,
-    stream: "patch",
+    stream: params.stream,
     data: params.data as unknown as Record<string, unknown>,
     ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
   });


### PR DESCRIPTION
## What Problem This Solves

Agent activity emission duplicated the same shared-bus plumbing across four semantic wrappers. That repeated run/session forwarding, payload casting, and bus dispatch while making stream/payload pairing depend on which wrapper a caller happened to choose.

## Why This Change Was Made

The agent activity owner now exposes one mapped-discriminated-union emitter. Its `stream` literal selects the exact allowed payload type, all existing callers use that canonical path, and the four duplicate wrappers are removed. Callback emissions remain separate because their best-effort failure semantics differ from the global bus.

Architectural closeout:

- Root cause: four wrappers duplicated one invariant and encoded type pairing indirectly.
- Owner: `src/infra/agent-activity-events.ts`.
- Canonical fix: `emitAgentActivityEvent({ runId, sessionKey?, stream, data })`.
- Removed paths: item, approval, command-output, and patch wrapper functions.
- Production LOC: +41/-69 (net -28).
- Tests: +105/-0.
- Contracts unchanged: stream strings, payload identity, truthy-only session omission, event sequencing/context enrichment, callback paths, config, protocol, SDK, and dependencies.

## User Impact

No user-visible behavior change. Agent item, approval, command-output, and patch events keep the same payloads, ordering, session routing, and operator-visible activity.

## Evidence

Exact head: `1a11c684cdd861fdfd5befbba1d7450aa756830e`

Local focused proof:

- Owner, handler, and fast-mode integration: 229 tests passed across 3 shards.
- `pnpm check:test-types`: core, extension, and root test programs passed.
- Touched-path formatting and `git diff --check`: passed.
- Autoreview: clean at 0.99 confidence with no actionable finding.

Remote proof:

- Changed gate: Blacksmith Testbox `tbx_01kzs162ctntwq15j2ygwx11zw`, Actions run `31522684684`, exit 0.
- Focused exact-head Testbox: lease `tbx_01kzs43kk7hqjwzrxmxsb5c3na`, Actions run `31527072635`, job `93897908795`; 229 focused tests and `pnpm check:test-types` passed, workflow conclusion success.
- AWS Crabbox: lease `cbx_cbff05a9e647`, run `run_5f1849151da8`, exit 0. The private-QA packaged build passed; the built `emitAgentActivityEvent` helper emitted ordered `item`, `approval`, `command_output`, and `patch` events with sequence 1-4, session omission, and payload identity preserved; built CLI and launcher version smoke passed.
- ClawSweeper exact-head review: run `31526043249`; no code findings. Its proof-only rank-up move is satisfied by the fresh green focused Testbox and AWS helper-level runtime proof above.
