### PR TITLE
fix(update): migrate plugin config before final validation

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -2410,6 +2410,32 @@ describe("update-cli", () => {
     expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
   });
 
+  it("runs the final fresh doctor for convergence-only current-process changes", async () => {
+    mockGitUpdateAfterMutation();
+    vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(FRESH_POST_UPDATE_ENTRYPOINT);
+    runPostCorePluginConvergenceSpy.mockResolvedValueOnce({
+      changes: ["Repaired configured plugin install records."],
+      warnings: [],
+      errored: false,
+      smokeFailures: [],
+      installRecords: {},
+    });
+
+    await updateCommand({ yes: true, restart: false });
+
+    expect(spawn).not.toHaveBeenCalled();
+    const doctorCall = vi.mocked(runExec).mock.calls.find(([, args]) => args[1] === "doctor");
+    expect(doctorCall?.[2]).toMatchObject({
+      env: { OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1" },
+    });
+    const strictValidationCall = vi
+      .mocked(runExec)
+      .mock.calls.find(([, args]) => args[1] === "config" && args[2] === "validate");
+    expect(strictValidationCall?.[2]).toMatchObject({
+      env: { OPENCLAW_UPDATE_IN_PROGRESS: "0" },
+    });
+  });
+
   it("runs the fresh plugin doctor with the selected Node runner", async () => {
     vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(
       "/tmp/openclaw-updated-entry.mjs",
@@ -2545,6 +2571,51 @@ describe("update-cli", () => {
     expect(syncPluginsForUpdateChannel).toHaveBeenCalledTimes(1);
     expect(updateNpmInstalledPlugins).toHaveBeenCalledTimes(1);
     expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("stages plugin-changing post-core config before updated plugin migrations run", async () => {
+    syncPluginsForUpdateChannel.mockImplementationOnce(async ({ config }) =>
+      pluginSyncResult(config, true),
+    );
+
+    await runPostCoreCommand({ restart: false });
+
+    expect(lastReplaceConfigCall()).toMatchObject({
+      writeOptions: { skipPluginValidation: true },
+    });
+  });
+
+  it("runs the final fresh doctor for convergence-only post-core changes", async () => {
+    vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(FRESH_POST_UPDATE_ENTRYPOINT);
+    runPostCorePluginConvergenceSpy.mockResolvedValueOnce({
+      changes: ["Repaired configured plugin install records."],
+      warnings: [],
+      errored: false,
+      smokeFailures: [],
+      installRecords: {},
+    });
+
+    await runPostCoreCommand({ restart: false });
+
+    expect(syncPluginCall()?.config).toBeDefined();
+    expect(updateNpmInstalledPlugins).toHaveBeenCalledTimes(1);
+    const doctorCalls = vi.mocked(runExec).mock.calls.filter(([, args]) => args[1] === "doctor");
+    expect(doctorCalls).toHaveLength(2);
+    expect(doctorCalls[1]?.[2]).toMatchObject({
+      env: { OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1" },
+    });
+    const strictValidationCall = vi
+      .mocked(runExec)
+      .mock.calls.find(
+        ([, args]) =>
+          args[0] === FRESH_POST_UPDATE_ENTRYPOINT &&
+          args[1] === "config" &&
+          args[2] === "validate" &&
+          args[3] === "--json",
+      );
+    expect(strictValidationCall?.[2]).toMatchObject({
+      env: { OPENCLAW_UPDATE_IN_PROGRESS: "0" },
+    });
   });
 
   it("keeps fresh doctor output off stdout during json post-core resume", async () => {

--- a/src/cli/update-cli/update-command-plugins.ts
+++ b/src/cli/update-cli/update-command-plugins.ts
@@ -476,11 +476,14 @@ export async function updatePluginsAfterCoreUpdate(params: {
         channels: structuredClone(params.restoredAuthoredChannels) as OpenClawConfig["channels"],
       };
     }
+    // Installed plugin metadata can own migrations that this process has not loaded yet.
+    // Finalization runs fresh doctor plus strict validation before the update can complete.
     await commitPluginInstallRecordsWithConfig({
       previousInstallRecords: pluginInstallRecords,
       nextInstallRecords,
       nextConfig,
       baseHash: params.configSnapshot.hash,
+      writeOptions: { skipPluginValidation: true },
     });
     await refreshPluginRegistryAfterConfigMutation({
       config: nextConfig,

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -288,12 +288,9 @@ export async function finishUpdate(params: {
           const completedPluginUpdate = await completePostCorePluginUpdate({
             root: postUpdateRoot,
             pluginUpdate: initialPluginUpdate,
-            // A plugin-only update can replace its migration owner without replacing core.
-            // Downgrades and resume fallbacks can also leave an updated core on disk in this process.
+            // Aggregate plugin changes and core install changes independently require fresh doctor.
             freshDoctorRequired:
-              didCoreUpdateChangeInstall(params.result) ||
-              initialPluginUpdate.sync.changed ||
-              initialPluginUpdate.npm.changed,
+              didCoreUpdateChangeInstall(params.result) || initialPluginUpdate.changed,
             yes: params.opts.yes === true,
             json: params.opts.json === true,
             timeoutMs: params.updateStepTimeoutMs,

--- a/src/cli/update-cli/update-command-resume.ts
+++ b/src/cli/update-cli/update-command-resume.ts
@@ -127,8 +127,7 @@ async function resumePostCoreUpdateUnlocked(params: ResumePostCoreUpdateParams):
   const { pluginUpdate } = await completePostCorePluginUpdate({
     root: params.root,
     pluginUpdate: initialPluginUpdate,
-    // Only package/channel sync can replace the migration owner loaded by this process.
-    freshDoctorRequired: initialPluginUpdate.sync.changed || initialPluginUpdate.npm.changed,
+    freshDoctorRequired: initialPluginUpdate.changed,
     yes: params.opts.yes === true,
     json: params.opts.json === true,
     timeoutMs: params.timeoutMs,


### PR DESCRIPTION
Related: #122048

## What Problem This Solves

Fixes an issue where package upgrades that install an updated configured plugin can fail before the plugin's fresh doctor migration updates legacy configuration. The updater installs the new schema owner, then an intermediate config write validates stale plugin-owned fields too early.

Resume also treated only package or channel synchronization as a reason to run the final doctor, so convergence-only install-record or config changes could skip the required final migration and strict validation pass.

## Why This Change Was Made

Plugin convergence now persists its transitional install records and configuration through the existing staged-write seam without plugin-schema validation. The write remains temporary: update completion and restart still require a fresh doctor that loads the installed plugin, runs its migration, and strictly validates the resulting configuration.

Direct and resume finalization now use the aggregate plugin-update `changed` result, so convergence-only changes receive the same final doctor and validation gate. This ports the narrow owner-boundary repair from #122048 onto current `main` while preserving Peter Steinberger as commit author.

## User Impact

Operators can complete upgrades across configured-plugin schema changes without the updater rejecting legacy plugin configuration before the owning plugin can migrate it. Failed migrations or strict validation still fail the update before completion or restart.

## Evidence

- Red proof on current `main`: three focused regressions failed at the intended boundaries: missing staged-write validation deferral, missing current-process convergence finalization, and missing resume convergence finalization.
- Green focused proof on exact head: `src/cli/update-cli.test.ts` passed 239/239.
- Adjacent owner proof: install-record commit tests passed 26/26; config writer `skipPluginValidation` contract passed; doctor repair sequencing passed 23/23.
- The resume convergence regression asserts the final `config validate --json` child runs with `OPENCLAW_UPDATE_IN_PROGRESS=0`.
- `git diff --check` and targeted `oxfmt` passed.
- Production LOC: +6/-7 (net -1). Tests: +71/-0.
- ClawSweeper rank-up move applied: removed the release-owned `CHANGELOG.md` edit required by root `AGENTS.md`.
- Exact-head CI passed: https://github.com/openclaw/openclaw/actions/runs/31524859991 (56 passed, zero failures, no retry).
- Exact-head Package Acceptance passed: https://github.com/openclaw/openclaw/actions/runs/31524904600. Candidate `openclaw@2026.8.1` was built from workflow/package/source ref `07febc2146a9cef6a749979d7c4933de1915a39f`, tarball SHA-256 `a40d2d99eac14618b274dbbabb80a6659596c6b91360edc43e7dca2d08f7cdc2`, artifact id `9114792280`, and artifact service digest `a5df6feace8953519dbb34120538be85b39a1cdac1e700c4d3a818b6784dba00`.
- Package Acceptance ran only `root-managed-vps-upgrade`, `published-upgrade-survivor`, and `upgrade-survivor`; all three passed with `OPENCLAW_DOCKER_E2E_SELECTED_SHA=07febc2146a9cef6a749979d7c4933de1915a39f` and baseline `openclaw@2026.7.1-2`.
- Exact-head local ClawSweeper review found no correctness or security findings. Its only rank-up move was completion of the now-green CI and Package Acceptance runs; hosted exact-head re-review is requested after those proofs.
- No publish, tag, or release action is included.
