### PR TITLE
fix(test): serialize default e2e runner

### DIFF
--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -781,10 +781,10 @@ Native dependency policy:
 - Files: `src/**/*.e2e.test.ts`, `test/**/*.e2e.test.ts`, and bundled-plugin E2E tests under `extensions/`
 - Runtime defaults:
   - Uses Vitest `threads` with `isolate: false`, matching the rest of the repo.
-  - Uses adaptive workers (CI: up to 2, local: 1 by default).
+  - Uses one worker by default to keep non-isolated gateway state deterministic.
   - Runs in silent mode by default to reduce console I/O overhead.
 - Useful overrides:
-  - `OPENCLAW_E2E_WORKERS=<n>` to force worker count (capped at 16).
+  - `OPENCLAW_E2E_WORKERS=<n>` to opt into parallel workers (capped at 16).
   - `OPENCLAW_E2E_VERBOSE=1` to re-enable verbose console output.
 - Scope:
   - Multi-instance gateway end-to-end behavior

--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -113,7 +113,7 @@ Test wrapper runs end with a short `[test] passed|failed|skipped ... in ...` sum
 
 - Gateway tests are included in the untargeted `pnpm test` full suite; run them alone with `pnpm test:gateway`.
 - `pnpm test:e2e`: repo E2E aggregate = `pnpm test:e2e:gateway && pnpm test:ui:e2e`.
-- `pnpm test:e2e:gateway`: gateway end-to-end smoke tests (multi-instance WS/HTTP/node pairing). Defaults to `threads` + `isolate: false` with adaptive workers in `vitest.e2e.config.ts`; tune with `OPENCLAW_E2E_WORKERS=<n>`, verbose logs with `OPENCLAW_E2E_VERBOSE=1`.
+- `pnpm test:e2e:gateway`: gateway end-to-end smoke tests (multi-instance WS/HTTP/node pairing). Defaults to `threads` + `isolate: false` with one worker in `vitest.e2e.config.ts`; opt into parallelism with `OPENCLAW_E2E_WORKERS=<n>` (capped at 16), and enable verbose logs with `OPENCLAW_E2E_VERBOSE=1`.
 - `pnpm test:live`: provider live tests (Claude/Minimax/DeepSeek/z.ai/etc, gated by `*.live.test.ts`). Requires API keys and `LIVE=1` (or `OPENCLAW_LIVE_TEST=1`) to unskip; verbose output with `OPENCLAW_LIVE_TEST_QUIET=0`.
 
 ## Full Docker suite (`pnpm test:docker:all`)

--- a/src/infra/vitest-e2e-config.test.ts
+++ b/src/infra/vitest-e2e-config.test.ts
@@ -5,7 +5,7 @@ import {
   normalizeConfigPaths,
 } from "../../test/helpers/vitest-config-paths.js";
 import { BUNDLED_PLUGIN_E2E_TEST_GLOB } from "../../test/vitest/vitest.bundled-plugin-paths.ts";
-import e2eConfig from "../../test/vitest/vitest.e2e.config.ts";
+import e2eConfig, { createE2EVitestConfig } from "../../test/vitest/vitest.e2e.config.ts";
 
 describe("e2e vitest config", () => {
   it("runs as a standalone config instead of inheriting unit projects", () => {
@@ -31,5 +31,13 @@ describe("e2e vitest config", () => {
       "test/setup.ts",
       "test/setup-openclaw-runtime.ts",
     ]);
+  });
+
+  it("serializes default e2e runs while preserving explicit worker overrides", () => {
+    expect(createE2EVitestConfig({}).test?.maxWorkers).toBe(1);
+    expect(createE2EVitestConfig({ OPENCLAW_E2E_WORKERS: "4" }).test?.maxWorkers).toBe(4);
+    expect(createE2EVitestConfig({ OPENCLAW_E2E_WORKERS: "99" }).test?.maxWorkers).toBe(16);
+    expect(createE2EVitestConfig({ OPENCLAW_E2E_WORKERS: "0" }).test?.maxWorkers).toBe(1);
+    expect(createE2EVitestConfig({ OPENCLAW_E2E_WORKERS: "invalid" }).test?.maxWorkers).toBe(1);
   });
 });

--- a/test/vitest/vitest.e2e.config.ts
+++ b/test/vitest/vitest.e2e.config.ts
@@ -1,22 +1,17 @@
 // Vitest e2e config wires the e2e test shard.
-import os from "node:os";
 import { defineConfig } from "vitest/config";
 import { BUNDLED_PLUGIN_E2E_TEST_GLOB } from "./vitest.bundled-plugin-paths.ts";
 import baseConfig from "./vitest.config.ts";
 import { resolveRepoRootPath } from "./vitest.shared.config.ts";
 
-const base = baseConfig as unknown as Record<string, unknown>;
-const isCI = process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true";
-const cpuCount = os.cpus().length;
-// Keep e2e runs cheap by default; callers can still override via OPENCLAW_E2E_WORKERS.
-const defaultWorkers = isCI ? Math.min(2, Math.max(1, Math.floor(cpuCount * 0.25))) : 1;
-const requestedWorkers = Number.parseInt(process.env.OPENCLAW_E2E_WORKERS ?? "", 10);
-const e2eWorkers =
-  Number.isFinite(requestedWorkers) && requestedWorkers > 0
+function resolveE2EWorkerCount(env: Record<string, string | undefined>): number {
+  const requestedWorkers = Number.parseInt(env.OPENCLAW_E2E_WORKERS ?? "", 10);
+  return Number.isFinite(requestedWorkers) && requestedWorkers > 0
     ? Math.min(16, requestedWorkers)
-    : defaultWorkers;
-const verboseE2E = process.env.OPENCLAW_E2E_VERBOSE === "1";
+    : 1;
+}
 
+const base = baseConfig as unknown as Record<string, unknown>;
 const baseTestWithProjects =
   (baseConfig as { test?: { exclude?: string[]; projects?: string[]; setupFiles?: string[] } })
     .test ?? {};
@@ -33,27 +28,37 @@ const exclude = [
   ...tuiPtyExcludes,
 ];
 
-export default defineConfig({
-  ...base,
-  test: {
-    ...baseTest,
-    maxWorkers: e2eWorkers,
-    silent: !verboseE2E,
-    globalSetup: [resolveRepoRootPath("test/vitest/vitest.e2e.global-setup.ts")],
-    setupFiles: [
-      ...new Set(
-        [...(baseTest.setupFiles ?? []), "test/setup-openclaw-runtime.ts"].map(resolveRepoRootPath),
-      ),
-    ],
-    include: [
-      "test/**/*.e2e.test.ts",
-      "src/**/*.e2e.test.ts",
-      "packages/**/*.e2e.test.ts",
-      "src/gateway/gateway.test.ts",
-      "src/gateway/server.startup-matrix-migration.integration.test.ts",
-      "src/gateway/sessions-history-http.test.ts",
-      BUNDLED_PLUGIN_E2E_TEST_GLOB,
-    ],
-    exclude,
-  },
-});
+export function createE2EVitestConfig(env: Record<string, string | undefined> = process.env) {
+  // Keep e2e runs deterministic by default; callers can still opt into parallelism.
+  const e2eWorkers = resolveE2EWorkerCount(env);
+  const verboseE2E = env.OPENCLAW_E2E_VERBOSE === "1";
+
+  return defineConfig({
+    ...base,
+    test: {
+      ...baseTest,
+      maxWorkers: e2eWorkers,
+      silent: !verboseE2E,
+      globalSetup: [resolveRepoRootPath("test/vitest/vitest.e2e.global-setup.ts")],
+      setupFiles: [
+        ...new Set(
+          [...(baseTest.setupFiles ?? []), "test/setup-openclaw-runtime.ts"].map(
+            resolveRepoRootPath,
+          ),
+        ),
+      ],
+      include: [
+        "test/**/*.e2e.test.ts",
+        "src/**/*.e2e.test.ts",
+        "packages/**/*.e2e.test.ts",
+        "src/gateway/gateway.test.ts",
+        "src/gateway/server.startup-matrix-migration.integration.test.ts",
+        "src/gateway/sessions-history-http.test.ts",
+        BUNDLED_PLUGIN_E2E_TEST_GLOB,
+      ],
+      exclude,
+    },
+  });
+}
+
+export default createE2EVitestConfig();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the full release E2E suite could run two non-isolated files concurrently by default, causing shared gateway and process state to collide and repeatedly time out during beta validation.

The regression is visible in two release-validation runs for the same frozen candidate:

- https://github.com/openclaw/openclaw/actions/runs/31504695772/job/93824252983
- https://github.com/openclaw/openclaw/actions/runs/31516030711/job/93862257476

## Why This Change Was Made

Restores the deterministic single-worker default introduced by `120eb342`, which was accidentally reverted by the unrelated canvas refactor in `330ba1`. Explicit positive `OPENCLAW_E2E_WORKERS` overrides remain supported and capped at 16; zero and invalid values fall back to one worker.

Current TUI exclusions and the rest of the E2E config shape are unchanged.

Scope expanded after exact-head ClawSweeper review found that two operator-facing testing pages still described the old adaptive-worker default. Those two references now document the single-worker default and explicit parallelism opt-in; no other docs were changed.

## User Impact

Release and CI E2E runs use one worker unless the caller explicitly opts into parallelism, avoiding cross-file shared-state collisions. This changes test infrastructure and its operator documentation only; production LOC is unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/infra/vitest-e2e-config.test.ts`
  - 1 test file passed
  - 3 tests passed
- `OPENCLAW_E2E_WORKERS=4 node scripts/run-vitest.mjs src/infra/vitest-e2e-config.test.ts`
  - 1 test file passed
  - 3 tests passed
- `pnpm docs:check-mdx`
  - passed for 769 files
- `node scripts/check-changed.mjs -- docs/help/testing.md docs/reference/test.md`
  - docs-only lane passed
- `pnpm format test/vitest/vitest.e2e.config.ts src/infra/vitest-e2e-config.test.ts`
- `pnpm format docs/help/testing.md docs/reference/test.md`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
  - clean, no accepted/actionable findings
- Signed head commit: `ba2ed6a1f205fac74038092b01eebecdf2034e1b`
- Production LOC: `+0/-0`
- Test and harness LOC: `+49/-36`
- Docs LOC: `+3/-3`

AI-assisted implementation; the exact diff and focused proof were reviewed before publication.
