### PR TITLE
test(cli): make help-exit process failures self-diagnosing

### DIFF
--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -17,6 +17,8 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 // to cold-load the CLI graph on shared hosted runners, while still exiting correctly.
 // Keep the default guard below the shared Vitest deadline so it always reports
 // captured child output before the framework can replace it with an opaque timeout.
+// Guard, signal, and wrong-code failures embed both output tails so CI shows the
+// child's last completed startup step.
 const DEFAULT_CHILD_PROCESS_TIMEOUT_MS = DEFAULT_VITEST_TEST_TIMEOUT_MS - 20_000;
 const SLOW_DOTENV_CHILD_PROCESS_TIMEOUT_MS = 240_000;
 const SLOW_DOTENV_TEST_TIMEOUT_MS = SLOW_DOTENV_CHILD_PROCESS_TIMEOUT_MS + 10_000;
@@ -33,6 +35,21 @@ const LAZY_GROUP_HELP_CASES = [
   { group: "security", usageCommand: "security", registry: "subcli" },
   { group: "update", usageCommand: "update", registry: "subcli" },
 ] as const;
+
+function formatCliProcessFailure(params: {
+  reason: string;
+  stdout: string;
+  stderr: string;
+}): string {
+  const tail = (stream: string) => {
+    const tailLength = 8_000;
+    const truncatedLength = stream.length - tailLength;
+    return truncatedLength > 0
+      ? `[... truncated ${truncatedLength} chars ...]\n${stream.slice(-tailLength)}`
+      : stream;
+  };
+  return `${params.reason}\n--- child stderr (tail) ---\n${tail(params.stderr)}\n--- child stdout (tail) ---\n${tail(params.stdout)}`;
+}
 
 async function createHelpProcessFixture(config?: Record<string, unknown>) {
   const root = tempDirs.make("openclaw-help-exit-");
@@ -93,6 +110,7 @@ async function runCliProcess(params: {
   allowRespawn?: boolean;
   stateEnv?: (stateDir: string) => Record<string, string>;
   timeoutMs?: number;
+  expectedExitCode?: number;
 }) {
   const fixture = await createHelpProcessFixture(params.config);
   if (params.stateEnv) {
@@ -155,6 +173,8 @@ async function runCliProcess(params: {
 
   const stdoutEnded = once(child.stdout, "end");
   const stderrEnded = once(child.stderr, "end");
+  const expectedExitCode = params.expectedExitCode ?? 0;
+  const timeoutMs = params.timeoutMs ?? DEFAULT_CHILD_PROCESS_TIMEOUT_MS;
   let timeout: NodeJS.Timeout | undefined;
   const exit = await Promise.race([
     Promise.all([once(child, "exit"), stdoutEnded, stderrEnded]).then(([[code, signal]]) => ({
@@ -165,14 +185,15 @@ async function runCliProcess(params: {
       timeout = setTimeout(() => {
         child.kill("SIGKILL");
         reject(
-          Object.assign(new Error("CLI process did not exit before the deadlock guard"), {
-            code: child.exitCode,
-            signal: child.signalCode,
-            stderr,
-            stdout,
-          }),
+          new Error(
+            formatCliProcessFailure({
+              reason: `CLI process did not exit before the ${timeoutMs}ms deadlock guard (SIGKILL sent; exitCode=${child.exitCode} signalCode=${child.signalCode})`,
+              stderr,
+              stdout,
+            }),
+          ),
         );
-      }, params.timeoutMs ?? DEFAULT_CHILD_PROCESS_TIMEOUT_MS);
+      }, timeoutMs);
       timeout.unref();
     }),
   ]).finally(() => {
@@ -180,12 +201,23 @@ async function runCliProcess(params: {
       clearTimeout(timeout);
     }
   });
-  if (exit.code !== 0) {
-    throw Object.assign(new Error(`CLI process exited with code ${exit.code}`), {
-      ...exit,
-      stderr,
-      stdout,
-    });
+  if (exit.signal) {
+    throw new Error(
+      formatCliProcessFailure({
+        reason: `CLI process was killed by signal ${exit.signal} (expected exit code ${expectedExitCode})`,
+        stderr,
+        stdout,
+      }),
+    );
+  }
+  if (exit.code !== expectedExitCode) {
+    throw new Error(
+      formatCliProcessFailure({
+        reason: `CLI process exited with code ${exit.code} (expected ${expectedExitCode})`,
+        stderr,
+        stdout,
+      }),
+    );
   }
   return { stderr, stdout };
 }
@@ -197,11 +229,33 @@ function parseJsonLines(stdout: string): Array<Record<string, unknown>> {
     .map((line) => JSON.parse(line) as Record<string, unknown>);
 }
 
-type CliProcessFailure = Error & {
-  code?: number | string;
-  stderr?: string;
-  stdout?: string;
-};
+describe("formatCliProcessFailure", () => {
+  it("includes the failure identity and both captured output tails", () => {
+    const reason =
+      "CLI process did not exit before the 240000ms deadlock guard (SIGKILL sent; exitCode=null signalCode=null)";
+    const message = formatCliProcessFailure({
+      reason,
+      stderr: "startup trace: entry.bootstrap",
+      stdout: "partial command output",
+    });
+
+    expect(message).toContain(reason);
+    expect(message).toContain("startup trace: entry.bootstrap");
+    expect(message).toContain("partial command output");
+  });
+
+  it("keeps the end of streams longer than the output tail cap", () => {
+    const message = formatCliProcessFailure({
+      reason: "wrong exit code",
+      stderr: "",
+      stdout: `${"x".repeat(8_005)}END`,
+    });
+
+    expect(message).toContain("[... truncated 8 chars ...]");
+    expect(message).toMatch(/xEND$/u);
+  });
+});
+
 describe("CLI help process exit", () => {
   it("disables esbuild worker IPC for source CLI children", () => {
     expect(process.env.ESBUILD_WORKER_THREADS).toBe("0");
@@ -328,26 +382,21 @@ describe("JSON console style process output", () => {
   it(
     "captures exact exit code 2 after loading dotenv for entry validation diagnostics",
     async () => {
-      let failure: CliProcessFailure | undefined;
-      try {
-        await runCliProcess({
-          args: ["--container"],
-          config: {
-            logging: {
-              consoleStyle: "${OPENCLAW_TEST_CONSOLE_STYLE}",
-              level: "silent",
-            },
+      const result = await runCliProcess({
+        args: ["--container"],
+        config: {
+          logging: {
+            consoleStyle: "${OPENCLAW_TEST_CONSOLE_STYLE}",
+            level: "silent",
           },
-          env: { OPENCLAW_TEST_CONSOLE_STYLE: undefined },
-          stateEnv: () => ({ OPENCLAW_TEST_CONSOLE_STYLE: "json" }),
-          timeoutMs: SLOW_DOTENV_CHILD_PROCESS_TIMEOUT_MS,
-        });
-      } catch (error) {
-        failure = error as CliProcessFailure;
-      }
+        },
+        env: { OPENCLAW_TEST_CONSOLE_STYLE: undefined },
+        stateEnv: () => ({ OPENCLAW_TEST_CONSOLE_STYLE: "json" }),
+        timeoutMs: SLOW_DOTENV_CHILD_PROCESS_TIMEOUT_MS,
+        expectedExitCode: 2,
+      });
 
-      expect(failure?.code).toBe(2);
-      expect(parseJsonLines(failure?.stderr ?? "")).toEqual([
+      expect(parseJsonLines(result.stderr)).toEqual([
         expect.objectContaining({
           level: "error",
           message: expect.stringContaining("--container requires a value"),
@@ -360,30 +409,25 @@ describe("JSON console style process output", () => {
   it(
     "loads eligible dotenv before formatting a run-main import failure",
     async () => {
-      let failure: CliProcessFailure | undefined;
-      try {
-        await runCliProcess({
-          args: ["gateway", "status"],
-          config: {
-            logging: {
-              consoleStyle: "${OPENCLAW_TEST_CONSOLE_STYLE}",
-              level: "silent",
-            },
+      const result = await runCliProcess({
+        args: ["gateway", "status"],
+        config: {
+          logging: {
+            consoleStyle: "${OPENCLAW_TEST_CONSOLE_STYLE}",
+            level: "silent",
           },
-          env: {
-            OPENCLAW_GATEWAY_STARTUP_TRACE: "1",
-            OPENCLAW_TEST_CONSOLE_STYLE: undefined,
-          },
-          failRunMainImport: true,
-          stateEnv: () => ({ OPENCLAW_TEST_CONSOLE_STYLE: "json" }),
-          timeoutMs: SLOW_DOTENV_CHILD_PROCESS_TIMEOUT_MS,
-        });
-      } catch (error) {
-        failure = error as CliProcessFailure;
-      }
+        },
+        env: {
+          OPENCLAW_GATEWAY_STARTUP_TRACE: "1",
+          OPENCLAW_TEST_CONSOLE_STYLE: undefined,
+        },
+        failRunMainImport: true,
+        stateEnv: () => ({ OPENCLAW_TEST_CONSOLE_STYLE: "json" }),
+        timeoutMs: SLOW_DOTENV_CHILD_PROCESS_TIMEOUT_MS,
+        expectedExitCode: 1,
+      });
 
-      expect(failure?.code).toBe(1);
-      expect(parseJsonLines(failure?.stderr ?? "")).toEqual(
+      expect(parseJsonLines(result.stderr)).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             level: "info",


### PR DESCRIPTION
## What Problem This Solves

CI run 31515400879 (shard `checks-node-compact-small-1`, PR #122144 head, 2026-08-11) failed `src/cli/help-exit.process.test.ts > loads eligible dotenv before formatting a run-main import failure` with an opaque `AssertionError: expected null to be 1` after exactly 240013ms, and passed on rerun.

What actually happened: the harness's 240s deadlock guard fired with the spawned CLI child still alive (`child.exitCode` is `null` until exit — the "null"). The guard was built in #115940 precisely so a hung child "always reports captured child output before the framework can replace it with an opaque timeout" — but its rejection carried the captured stderr/stdout only as hidden error properties, and the tests then asserted `expect(failure?.code).toBe(1)` with no message. Every diagnostic — including the child's `OPENCLAW_GATEWAY_STARTUP_TRACE` lines that pinpoint the last completed startup step — was silently discarded, so the one CI occurrence is unfalsifiable after the fact.

## Why This Change Was Made

`runCliProcess` now takes `expectedExitCode` (default 0) and has exactly two outcomes: the expected exit (returns `{stdout, stderr, fixture}`), or a thrown error whose message names the precise failure identity — deadlock guard fired (with the guard duration and `exitCode`/`signalCode` at kill time), child killed by a signal, or wrong exit code — with bounded 8000-char tails of the child's stderr and stdout embedded. The `CliProcessFailure` try/catch pattern is deleted file-wide; five failure-shaped tests now pass `expectedExitCode` and assert on the returned streams. Sibling process harnesses (`hooks-cli.process`, `claws-authoring-state.process`) already embed output in their failure paths; this file was the drifted copy.

The hang itself did not reproduce and no child-side defect was found (evidence below), so no speculative child-side guard was added; the repaired reporting contract makes any next occurrence self-diagnosing instead of another blind flake.

## User Impact

None at runtime — test-only change, zero production LOC. Maintainers triaging CI get the child's exit identity and output tails directly in the assertion failure.

## Evidence

- `node scripts/run-vitest.mjs src/cli/help-exit.process.test.ts`: 27/27 passed (25 existing + 2 new formatter regression tests protecting the diagnostic contract: identity + both tails present; truncation keeps the stream end).
- `node scripts/check-changed.mjs`: green (core-test typecheck + lint on the changed file). Remote Testbox backend unavailable this session (Blacksmith CLI absent, Crabbox broker 401), so trusted-source proof ran locally per the documented fallback.
- Fresh autoreview on the final diff: clean, no accepted/actionable findings.
- Hang reproduction campaign (all negative): ~1,300 exact-env child invocations (`node --import <throwing-resolve-hook> --import tsx src/entry.ts gateway status`, same env as the test) — 540 on macOS and 721 on Linux Node v24.19.0 (CI's exact version, `node:24.19.0-bookworm`), including 240 pinned to 2 CPUs with a busy-loop load to mimic the 2-core runner; plus 13 full vitest-file runs (warm and cold caches, 2-CPU pinned). Ruled out by direct inspection: respawn/grandchild paths (`OPENCLAW_NO_RESPAWN` + compile-cache guards), tsx loader-thread/Atomics deadlocks (tsx 4.23.1 registers sync `module.registerHooks` on Node >= 24.11.1), and esbuild worker IPC (strace shows a warm child performs zero external spawns; cold children spawn only synchronous esbuild one-shots via `execFileSync`).
- Cold-cache container runs surfaced only a container-specific artifact: vitest's own esbuild `--service --ping` children become unreaped zombies when PID 1 is a non-reaping `sleep`, tripping the run-vitest process-group leak check. Not applicable to CI runners with a real init.

AI-assisted change (investigation, implementation, and review tooling).
