### PR TITLE
fix: speed up streamed assistant output

### DIFF
--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -2309,7 +2309,7 @@ describe("buildOpenAIProvider", () => {
     });
 
     expectFields(extraParams, {
-      transport: "auto",
+      transport: "sse",
     });
     expect(result.payload.store).toBe(true);
     expect(result.payload.context_management).toEqual([
@@ -2616,7 +2616,7 @@ describe("buildOpenAIProvider", () => {
     expect(allowedHostedToolTypes).toEqual(new Set());
   });
 
-  it("preserves explicit OpenAI responses transport overrides", () => {
+  it("defaults direct OpenAI API-key traffic to SSE and preserves explicit WebSocket", () => {
     const provider = buildOpenAIProvider();
 
     const explicit = {
@@ -2628,12 +2628,38 @@ describe("buildOpenAIProvider", () => {
       provider.prepareExtraParams?.({
         provider: "openai",
         modelId: "gpt-5.4",
+        model: {
+          api: "openai-responses",
+          provider: "openai",
+          id: "gpt-5.4",
+          baseUrl: "https://api.openai.com/v1",
+        },
+        config: {
+          models: {
+            providers: {
+              openai: {
+                api: "openai-responses",
+                auth: "api-key",
+                baseUrl: "https://api.openai.com/v1",
+                models: [],
+              },
+            },
+          },
+        },
+        extraParams: { effort: "high" },
+      } as never),
+    ).toEqual({ effort: "high", transport: "sse" });
+
+    expect(
+      provider.prepareExtraParams?.({
+        provider: "openai",
+        modelId: "gpt-5.4",
         extraParams: explicit,
       } as never),
     ).toBe(explicit);
   });
 
-  it("does not infer Codex transport from an unselected OAuth profile", () => {
+  it("uses SSE for an unselected OAuth profile and native defaults for a Codex route", () => {
     const provider = buildOpenAIProvider();
 
     expect(
@@ -2654,7 +2680,7 @@ describe("buildOpenAIProvider", () => {
       } as never),
     ).toEqual({
       effort: "high",
-      transport: "auto",
+      transport: "sse",
     });
     expect(
       provider.prepareExtraParams?.({

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -1077,12 +1077,7 @@ export function buildOpenAIProvider(): ProviderPlugin {
         (normalizeProviderId(ctx.provider) === PROVIDER_ID &&
           (!providerConfig?.baseUrl || isOpenAIHttpsApiBaseUrl(providerConfig.baseUrl)) &&
           resolveConfiguredProviderAuthTransport(providerConfig) === "codex");
-      const responsesBaseUrl = ctx.model?.baseUrl ?? providerConfig?.baseUrl;
-      const useNativeResponsesTransport =
-        useCodexTransport || !responsesBaseUrl || isOpenAIHttpsApiBaseUrl(responsesBaseUrl);
-      return (
-        useNativeResponsesTransport ? nativeResponsesHooks : responsesHooks
-      ).prepareExtraParams?.(ctx);
+      return (useCodexTransport ? nativeResponsesHooks : responsesHooks).prepareExtraParams?.(ctx);
     },
     resolveUsageAuth: codexHooks.resolveUsageAuth,
     fetchUsageSnapshot: codexHooks.fetchUsageSnapshot,

--- a/src/gateway/server-chat-state.ts
+++ b/src/gateway/server-chat-state.ts
@@ -104,7 +104,7 @@ type ChatRunToolRecipientState = {
   finalizedAt?: number;
 };
 
-type PendingChatDeltaFlush = {
+type PendingLiveTextFlush = {
   timer: NodeJS.Timeout;
   flush: () => void;
 };
@@ -133,7 +133,7 @@ type ChatRunRecord = {
 
 type InternalChatRunRecord = ChatRunRecord & {
   /** Fixed-deadline trailing wake-up owned by this run's buffered state. */
-  pendingDeltaFlush?: PendingChatDeltaFlush;
+  pendingTextFlushes?: Partial<Record<"chat" | "agent", PendingLiveTextFlush>>;
 };
 
 type ChatRunRecordStore = {
@@ -167,13 +167,12 @@ function internalChatRunRecord(record: ChatRunRecord): InternalChatRunRecord {
   return record;
 }
 
-function clearPendingChatDeltaFlush(record: ChatRunRecord): void {
+function clearPendingLiveTextFlushes(record: ChatRunRecord): void {
   const internal = internalChatRunRecord(record);
-  if (!internal.pendingDeltaFlush) {
-    return;
+  for (const pending of Object.values(internal.pendingTextFlushes ?? {})) {
+    clearTimeout(pending.timer);
   }
-  clearTimeout(internal.pendingDeltaFlush.timer);
-  delete internal.pendingDeltaFlush;
+  delete internal.pendingTextFlushes;
 }
 
 export type ChatRunRegistry = {
@@ -297,14 +296,14 @@ export function createChatRunState(): ChatRunState {
     delete record.deltaSentAt;
     delete record.deltaLastBroadcastLen;
     delete record.deltaLastBroadcastText;
-    clearPendingChatDeltaFlush(record);
+    clearPendingLiveTextFlushes(record);
     delete record.agentText;
     store.releaseIfEmpty(runId);
   };
 
   const clear = () => {
     for (const record of store.runs.values()) {
-      clearPendingChatDeltaFlush(record);
+      clearPendingLiveTextFlushes(record);
     }
     store.runs.clear();
   };

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -720,14 +720,14 @@ describe("agent event handler", () => {
     expect(agentBroadcastCalls(broadcast)).toHaveLength(1);
   });
 
-  it("coalesces assistant agent events under the chat delta throttle", () => {
+  it("coalesces assistant agent events inside one live-text pacing window", () => {
     let now = 10_000;
     const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
     const { broadcast, nodeSendToSession, chatRunState, handler } = createHarness();
     registerNamedChatRun(chatRunState, "agent-throttle");
 
     for (let i = 0; i < 5; i += 1) {
-      now = 10_000 + i * 20;
+      now = 10_000 + i * 10;
       emitAgentEvent(
         handler,
         "run-agent-throttle",
@@ -752,6 +752,53 @@ describe("agent event handler", () => {
     nowSpy.mockRestore();
   });
 
+  it("flushes trailing assistant agent text at the fixed pacing deadline", () => {
+    vi.useFakeTimers();
+    let now = 15_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const { broadcast, chatRunState, handler } = createHarness();
+    registerNamedChatRun(chatRunState, "agent-trailing");
+
+    emitAgentEvent(handler, "run-agent-trailing", "assistant", {
+      text: "Hello",
+      delta: "Hello",
+    });
+    now = 15_020;
+    emitAgentEvent(
+      handler,
+      "run-agent-trailing",
+      "assistant",
+      { text: "Hello world", delta: " world" },
+      { seq: 2 },
+    );
+
+    expect(
+      agentBroadcastCalls(broadcast).map(([, payload]) => ({
+        seq: (payload as { seq?: number }).seq,
+        text: (payload as { data?: { text?: string } }).data?.text,
+      })),
+    ).toEqual([{ seq: 1, text: "Hello" }]);
+
+    now = 15_074;
+    vi.advanceTimersByTime(54);
+    expect(agentBroadcastCalls(broadcast)).toHaveLength(1);
+
+    now = 15_075;
+    vi.advanceTimersByTime(1);
+    expect(
+      agentBroadcastCalls(broadcast).map(([, payload]) => ({
+        seq: (payload as { seq?: number }).seq,
+        text: (payload as { data?: { text?: string } }).data?.text,
+        delta: (payload as { data?: { delta?: string } }).data?.delta,
+      })),
+    ).toEqual([
+      { seq: 1, text: "Hello", delta: "Hello" },
+      { seq: 2, text: "Hello world", delta: " world" },
+    ]);
+    expect(vi.getTimerCount()).toBe(0);
+    nowSpy.mockRestore();
+  });
+
   it("flushes coalesced assistant agent text before lifecycle end", () => {
     let now = 20_000;
     const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
@@ -759,7 +806,7 @@ describe("agent event handler", () => {
     registerNamedChatRun(chatRunState, "agent-flush");
 
     emitAgentEvent(handler, "run-agent-flush", "assistant", { text: "Hello", delta: "Hello" });
-    now = 20_050;
+    now = 20_020;
     emitAgentEvent(
       handler,
       "run-agent-flush",
@@ -767,7 +814,7 @@ describe("agent event handler", () => {
       { text: "Hello world", delta: " world" },
       { seq: 2 },
     );
-    now = 20_090;
+    now = 20_040;
     emitAgentEvent(
       handler,
       "run-agent-flush",
@@ -957,14 +1004,14 @@ describe("agent event handler", () => {
     nowSpy.mockRestore();
   });
 
-  it("coalesces thinking agent events under the chat delta throttle", () => {
+  it("coalesces thinking agent events inside one live-text pacing window", () => {
     let now = 27_000;
     const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
     const { broadcast, nodeSendToSession, chatRunState, handler } = createHarness();
     registerNamedChatRun(chatRunState, "agent-thinking");
 
     for (let i = 0; i < 5; i += 1) {
-      now = 27_000 + i * 20;
+      now = 27_000 + i * 10;
       emitAgentEvent(
         handler,
         "run-agent-thinking",
@@ -1459,8 +1506,12 @@ describe("agent event handler", () => {
     emitAgentEvent(handler, "run-trailing", "assistant", { text: "Hello world" });
 
     expect(chatDeltaTexts(broadcast)).toEqual(["Hello"]);
-    now = 12_150;
-    vi.advanceTimersByTime(130);
+    now = 12_074;
+    vi.advanceTimersByTime(54);
+    expect(chatDeltaTexts(broadcast)).toEqual(["Hello"]);
+
+    now = 12_075;
+    vi.advanceTimersByTime(1);
 
     expect(chatDeltaTexts(broadcast)).toEqual(["Hello", " world"]);
     expect(vi.getTimerCount()).toBe(0);
@@ -1474,12 +1525,21 @@ describe("agent event handler", () => {
     const { broadcast, chatRunState, handler } = createHarness();
     registerNamedChatRun(chatRunState, "terminal-trailing");
 
-    emitAgentEvent(handler, "run-terminal-trailing", "assistant", { text: "Hello" });
+    emitAgentEvent(handler, "run-terminal-trailing", "assistant", {
+      text: "Hello",
+      delta: "Hello",
+    });
     now = 13_020;
-    emitAgentEvent(handler, "run-terminal-trailing", "assistant", { text: "Hello world" });
-    expect(vi.getTimerCount()).toBe(1);
+    emitAgentEvent(
+      handler,
+      "run-terminal-trailing",
+      "assistant",
+      { text: "Hello world", delta: " world" },
+      { seq: 2 },
+    );
+    expect(vi.getTimerCount()).toBe(2);
 
-    emitLifecycleEnd(handler, "run-terminal-trailing");
+    emitLifecycleEnd(handler, "run-terminal-trailing", 3);
     expect(vi.getTimerCount()).toBe(0);
     const statesAtTerminal = chatBroadcastCalls(broadcast).map(
       ([, payload]) => (payload as { state?: string }).state,
@@ -1491,6 +1551,7 @@ describe("agent event handler", () => {
     expect(
       chatBroadcastCalls(broadcast).map(([, payload]) => (payload as { state?: string }).state),
     ).toEqual(statesAtTerminal);
+    expect(agentBroadcastCalls(broadcast)).toHaveLength(3);
     nowSpy.mockRestore();
   });
 
@@ -1501,16 +1562,26 @@ describe("agent event handler", () => {
     const { broadcast, chatRunState, handler } = createHarness();
     registerNamedChatRun(chatRunState, "shutdown-trailing");
 
-    emitAgentEvent(handler, "run-shutdown-trailing", "assistant", { text: "Hello" });
+    emitAgentEvent(handler, "run-shutdown-trailing", "assistant", {
+      text: "Hello",
+      delta: "Hello",
+    });
     now = 14_020;
-    emitAgentEvent(handler, "run-shutdown-trailing", "assistant", { text: "Hello world" });
-    expect(vi.getTimerCount()).toBe(1);
+    emitAgentEvent(
+      handler,
+      "run-shutdown-trailing",
+      "assistant",
+      { text: "Hello world", delta: " world" },
+      { seq: 2 },
+    );
+    expect(vi.getTimerCount()).toBe(2);
 
     chatRunState.clear();
     expect(vi.getTimerCount()).toBe(0);
     now = 14_500;
     vi.advanceTimersByTime(1_000);
     expect(chatDeltaTexts(broadcast)).toEqual(["Hello"]);
+    expect(agentBroadcastCalls(broadcast)).toHaveLength(1);
     nowSpy.mockRestore();
   });
 

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -226,7 +226,7 @@ function normalizeHeartbeatChatFinalText(params: {
  * do not finalize a run before fallback or retry reuses the same runId.
  */
 const AGENT_LIFECYCLE_ERROR_RETRY_GRACE_MS = 15_000;
-const CHAT_DELTA_THROTTLE_MS = 150;
+const LIVE_TEXT_PACING_MS = 75;
 
 export type ChatEventBroadcast = GatewayBroadcastFn;
 
@@ -384,14 +384,55 @@ type AgentEventHandler = ((event: AgentEventPayload) => void) & {
   dispose: () => void;
 };
 
+const AGENT_TEXT_THROTTLE_STREAMS = ["assistant", "thinking"] as const;
+
+type AgentTextThrottleStream = (typeof AGENT_TEXT_THROTTLE_STREAMS)[number];
+type LiveTextStream = "chat" | "agent";
+type PendingLiveTextFlush = { timer: NodeJS.Timeout; flush: () => void };
 type InternalChatRunRecord = ReturnType<ChatRunState["getOrCreate"]> & {
-  pendingDeltaFlush?: { timer: NodeJS.Timeout; flush: () => void };
+  pendingTextFlushes?: Partial<Record<LiveTextStream, PendingLiveTextFlush>>;
 };
 
 function internalChatRunRecord(
   record: ReturnType<ChatRunState["getOrCreate"]>,
 ): InternalChatRunRecord {
   return record;
+}
+
+function cancelPendingLiveTextFlush(run: InternalChatRunRecord, stream: LiveTextStream): void {
+  const pending = run.pendingTextFlushes?.[stream];
+  if (!pending) {
+    return;
+  }
+  clearTimeout(pending.timer);
+  delete run.pendingTextFlushes?.[stream];
+  if (run.pendingTextFlushes && Object.keys(run.pendingTextFlushes).length === 0) {
+    delete run.pendingTextFlushes;
+  }
+}
+
+function scheduleLiveTextFlush(
+  run: InternalChatRunRecord,
+  stream: LiveTextStream,
+  delayMs: number,
+  flush: () => void,
+): void {
+  const pendingFlushes = (run.pendingTextFlushes ??= {});
+  const existing = pendingFlushes[stream];
+  if (existing) {
+    existing.flush = flush;
+    return;
+  }
+  const timer = setSafeTimeout(() => {
+    const pending = run.pendingTextFlushes?.[stream];
+    if (!pending || pending.timer !== timer) {
+      return;
+    }
+    cancelPendingLiveTextFlush(run, stream);
+    pending.flush();
+  }, delayMs);
+  timer.unref?.();
+  pendingFlushes[stream] = { timer, flush };
 }
 
 function roundedChatSendTimingMs(value: number): number {
@@ -452,22 +493,11 @@ export function createAgentEventHandler({
 
   const pendingTerminalLifecycleErrors = new Map<string, PendingTerminalLifecycleError>();
 
-  type AgentTextThrottleStream = "assistant" | "thinking";
-
-  const agentTextThrottleStreams = ["assistant", "thinking"] as const;
-
   const cancelPendingChatDeltaFlush = (clientRunId: string) => {
     const record = chatRunState.runs.get(clientRunId);
-    const pending = record ? internalChatRunRecord(record).pendingDeltaFlush : undefined;
-    if (!pending || !record) {
-      return;
+    if (record) {
+      cancelPendingLiveTextFlush(internalChatRunRecord(record), "chat");
     }
-    clearTimeout(pending.timer);
-    delete internalChatRunRecord(record).pendingDeltaFlush;
-  };
-
-  const clearBufferedChatState = (clientRunId: string) => {
-    chatRunState.clearRun(clientRunId);
   };
 
   const clearPendingTerminalLifecycleError = (runId: string, lifecycleGeneration?: string) => {
@@ -824,16 +854,13 @@ export function createAgentEventHandler({
             },
           );
         }
-      } else {
-        clearBufferedChatState(clientRunId);
-        if (chatLink) {
-          chatRunState.registry.remove(evt.runId, clientRunId, sessionKey);
-        }
+      } else if (chatLink) {
+        chatRunState.registry.remove(evt.runId, clientRunId, sessionKey);
       }
     }
 
     toolEventRecipients.markFinal(evt.runId);
-    clearBufferedChatState(clientRunId);
+    chatRunState.clearRun(clientRunId);
     if (suppressRestartRecoveryProjection && chatLink) {
       chatRunState.registry.remove(evt.runId, clientRunId, sessionKey);
     }
@@ -989,21 +1016,7 @@ export function createAgentEventHandler({
         controlUiVisible,
       });
     };
-    const existing = run.pendingDeltaFlush;
-    if (existing) {
-      existing.flush = flush;
-      return;
-    }
-    const timer = setSafeTimeout(() => {
-      const pending = run.pendingDeltaFlush;
-      if (!pending || pending.timer !== timer) {
-        return;
-      }
-      cancelPendingChatDeltaFlush(clientRunId);
-      pending.flush();
-    }, delayMs);
-    timer.unref?.();
-    run.pendingDeltaFlush = { timer, flush };
+    scheduleLiveTextFlush(run, "chat", delayMs, flush);
   };
 
   const emitChatDelta = (
@@ -1030,14 +1043,14 @@ export function createAgentEventHandler({
     run.rawBuffer = mergedRawText;
     run.bufferUpdatedAt = now;
     const waitedMs = now - (run.deltaSentAt ?? 0);
-    if (waitedMs < CHAT_DELTA_THROTTLE_MS) {
+    if (waitedMs < LIVE_TEXT_PACING_MS) {
       scheduleChatDeltaFlush(
         sessionKey,
         agentId,
         clientRunId,
         sourceRunId,
         seq,
-        CHAT_DELTA_THROTTLE_MS - waitedMs,
+        LIVE_TEXT_PACING_MS - waitedMs,
         opts?.controlUiVisible,
       );
       return;
@@ -1138,9 +1151,8 @@ export function createAgentEventHandler({
     const { text, shouldSuppressSilent } = resolveBufferedChatTextState(clientRunId, sourceRunId, {
       suppressLeadFragments: false,
     });
-    // Flush any throttled delta so streaming clients receive the complete text
-    // before the final event. The 150 ms throttle in emitChatDelta may have
-    // suppressed the most recent chunk, leaving the client with stale text.
+    // Flush any paced delta so streaming clients receive the complete text
+    // before the final event.
     // Only flush if the buffered text differs from the last broadcast to avoid duplicates.
     flushBufferedChatDeltaIfNeeded(sessionKey, opts?.agentId, clientRunId, sourceRunId, seq, opts);
     chatRunState.clearRun(clientRunId);
@@ -1223,14 +1235,14 @@ export function createAgentEventHandler({
     }
   };
 
-  const flushBufferedAgentDeltaIfNeeded = (
-    clientRunId: string,
-    stream?: AgentTextThrottleStream,
-  ) => {
+  const flushBufferedAgentDeltaIfNeeded = (clientRunId: string) => {
     const run = chatRunState.runs.get(clientRunId);
-    const streams = stream ? [stream] : agentTextThrottleStreams;
-    const bufferedEntries = streams.flatMap((currentStream) => {
-      const buffered = run?.agentText?.[currentStream]?.bufferedEvent;
+    if (run) {
+      cancelPendingLiveTextFlush(internalChatRunRecord(run), "agent");
+    }
+    const bufferedEntries = AGENT_TEXT_THROTTLE_STREAMS.flatMap((currentStream) => {
+      const state = run?.agentText?.[currentStream];
+      const buffered = state?.bufferedEvent;
       if (!buffered) {
         return [];
       }
@@ -1245,42 +1257,22 @@ export function createAgentEventHandler({
         state.lastSentAt = Date.now();
       }
     }
-    return bufferedEntries.length > 0;
   };
 
   const resolveAgentTextThrottleStream = (
     evt: AgentEventPayload,
-  ): AgentTextThrottleStream | null => {
-    if (evt.stream === "assistant") {
-      return "assistant";
-    }
-    if (evt.stream === "thinking") {
-      return "thinking";
-    }
-    return null;
-  };
-
-  const isAgentTextThrottleEvent = (evt: AgentEventPayload) =>
-    resolveAgentTextThrottleStream(evt) !== null && typeof evt.data?.text === "string";
+  ): AgentTextThrottleStream | null =>
+    evt.stream === "assistant" ? "assistant" : evt.stream === "thinking" ? "thinking" : null;
 
   const shouldCoalesceAgentTextEvent = (evt: AgentEventPayload) =>
-    isAgentTextThrottleEvent(evt) &&
+    resolveAgentTextThrottleStream(evt) !== null &&
+    typeof evt.data?.text === "string" &&
     typeof evt.data.delta === "string" &&
     evt.data.delta.length > 0 &&
     !(Array.isArray(evt.data.mediaUrls) && evt.data.mediaUrls.length > 0) &&
     typeof evt.data.mediaUrl !== "string" &&
     evt.data.replace !== true &&
     (evt.stream !== "assistant" || !shouldSuppressAssistantEventForLiveChat(evt.data));
-
-  const shouldAdvanceAgentTextThrottle = (evt: AgentEventPayload) =>
-    isAgentTextThrottleEvent(evt) &&
-    (typeof evt.data.delta === "string" || evt.data.replace === true);
-
-  const buildBufferedAgentEvent = (
-    sessionKey: string | undefined,
-    agentId: string | undefined,
-    payload: AgentEventPayload & { spawnedBy?: string },
-  ): BufferedAgentEvent => (sessionKey ? { sessionKey, agentId, payload } : { agentId, payload });
 
   const mergeBufferedAgentPayload = (
     previous: BufferedAgentEvent,
@@ -1322,11 +1314,19 @@ export function createAgentEventHandler({
     const agentText = (run.agentText ??= {});
     const state = (agentText[stream] ??= {});
     const last = state.lastSentAt;
-    if (last !== undefined && now - last < 150) {
-      const nextBuffered = buildBufferedAgentEvent(sessionKey, agentId, payload);
+    if (last !== undefined && now - last < LIVE_TEXT_PACING_MS) {
+      const nextBuffered: BufferedAgentEvent = sessionKey
+        ? { sessionKey, agentId, payload }
+        : { agentId, payload };
       state.bufferedEvent = state.bufferedEvent
         ? mergeBufferedAgentPayload(state.bufferedEvent, nextBuffered)
         : nextBuffered;
+      scheduleLiveTextFlush(
+        internalChatRunRecord(run),
+        "agent",
+        LIVE_TEXT_PACING_MS - (now - last),
+        () => flushBufferedAgentDeltaIfNeeded(clientRunId),
+      );
       return;
     }
     flushBufferedAgentDeltaIfNeeded(clientRunId);
@@ -1640,7 +1640,10 @@ export function createAgentEventHandler({
             controlUiVisible: isControlUiVisible,
           });
           const textThrottleStream = resolveAgentTextThrottleStream(evt);
-          if (textThrottleStream && shouldAdvanceAgentTextThrottle(evt)) {
+          if (
+            textThrottleStream &&
+            (typeof evt.data.delta === "string" || evt.data.replace === true)
+          ) {
             const agentText = (chatRunState.getOrCreate(clientRunId).agentText ??= {});
             (agentText[textThrottleStream] ??= {}).lastSentAt = Date.now();
           }
@@ -1733,7 +1736,7 @@ export function createAgentEventHandler({
             },
           );
         }
-        clearBufferedChatState(clientRunId);
+        chatRunState.clearRun(clientRunId);
         scheduleTerminalLifecycleError(evt, { skipChatErrorFinal, restartRecoveryState });
       }
       return;

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -502,8 +502,9 @@ export function handlePageGatewayEvent(state: ChatPageHost, event: GatewayEventF
     return;
   }
   if (event.event === "agent" || event.event === "session.tool") {
-    handleAgentEvent(state as never, event.payload as never);
-    requestChatPageUpdate(state);
+    if (handleAgentEvent(state as never, event.payload as never)) {
+      requestChatPageUpdate(state);
+    }
     return;
   }
   if (event.event === "session.operation") {

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -788,6 +788,39 @@ describe("ChatStateController render lifecycle", () => {
     expect(state.waitingApprovalStatuses.size).toBe(0);
   });
 
+  it("skips no-op assistant invalidation while tool and plan changes render immediately", () => {
+    const requestUpdate = vi.fn();
+    const state = createStreamEventState({
+      requestUpdate,
+      chatStreamSegments: [],
+      chatToolMessages: [],
+      toolStreamById: new Map(),
+      toolStreamOrder: [],
+      toolStreamSyncTimer: null,
+      planStatus: null,
+      sessions: { setModelOverride: vi.fn() } as never,
+    });
+    const emitAgent = (seq: number, stream: string, data: Record<string, unknown>) =>
+      handlePageGatewayEvent(state, {
+        type: "event",
+        event: "agent",
+        payload: { runId: "run-1", seq, stream, ts: seq, sessionKey: "main", data },
+      });
+
+    emitAgent(1, "assistant", { text: "Hello", delta: "Hello" });
+    expect(requestUpdate).not.toHaveBeenCalled();
+
+    emitAgent(2, "plan", {
+      phase: "update",
+      steps: [{ step: "Measure the repair", status: "in_progress" }],
+    });
+    expect(requestUpdate).toHaveBeenCalledOnce();
+
+    requestUpdate.mockClear();
+    emitAgent(3, "tool", { phase: "start", name: "read", toolCallId: "tool-1" });
+    expect(requestUpdate).toHaveBeenCalledOnce();
+  });
+
   it("coalesces stream invalidations into one animation frame", () => {
     let nextFrame = 1;
     const frames = new Map<number, FrameRequestCallback>();

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -938,24 +938,24 @@ export function normalizePlanSnapshot(
   };
 }
 
-function handlePlanEvent(host: ToolStreamHost, payload: AgentEventPayload) {
+function handlePlanEvent(host: ToolStreamHost, payload: AgentEventPayload): boolean {
   // Plan snapshots are run-owned: a stale or spawned-run event in the same
   // session must not overwrite (or clear) the active run's checklist. Mirrors
   // the compaction/fallback acceptance policy (session-scoped when idle).
   if (!resolveAcceptedSession(host, payload, { allowSessionScopedWhenIdle: true }).accepted) {
-    return;
+    return false;
   }
   const data = payload.data ?? {};
   if (data.phase !== "update") {
-    return;
+    return false;
   }
   host.planStatus = normalizePlanSnapshot(data, payload.runId);
-  host.requestUpdate?.();
+  return true;
 }
 
-export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPayload) {
+export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPayload): boolean {
   if (!payload) {
-    return;
+    return false;
   }
 
   // Filter the shared activity stream by session first. Chat-linked events use
@@ -963,13 +963,13 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
   // active chat run; individual run-owned projections apply their own match.
   const sessionKey = typeof payload.sessionKey === "string" ? payload.sessionKey : undefined;
   if (sessionKey && !uiSessionEventMatches(host, sessionKey, toTrimmedString(payload.agentId))) {
-    return;
+    return false;
   }
   // History can replay an older active-run snapshot after newer live activity.
   // Fence each tool/preamble identity by Gateway sequence so restore fills gaps
   // without regressing a result or newer progress already rendered by this pane.
   if (!acceptActivityEvent(host, payload)) {
-    return;
+    return false;
   }
   if (payload.stream === "lifecycle" || payload.stream === "tool") {
     const runId = toTrimmedString(payload.runId);
@@ -979,13 +979,13 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
   }
 
   if (handleUsageEvent(host, payload)) {
-    return;
+    return true;
   }
 
   // Handle compaction events
   if (payload.stream === "compaction") {
     handleCompactionEvent(host as CompactionHost, payload);
-    return;
+    return true;
   }
 
   if (payload.stream === "lifecycle") {
@@ -999,35 +999,34 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
       host.chatRunUsageById = usageByRun;
     }
     if (handleLifecycleApprovalEvent(host, payload)) {
-      return;
+      return true;
     }
     handleLifecycleCompactionEvent(host as CompactionHost, payload);
     handleLifecycleFallbackEvent(host as CompactionHost, payload);
-    return;
+    return true;
   }
 
   if (payload.stream === "fallback") {
     handleLifecycleFallbackEvent(host as CompactionHost, payload);
-    return;
+    return true;
   }
 
   if (handlePreambleProgressEvent(host, payload)) {
-    return;
+    return true;
   }
 
   if (payload.stream === "plan") {
-    handlePlanEvent(host, payload);
-    return;
+    return handlePlanEvent(host, payload);
   }
 
   if (payload.stream !== "tool") {
-    return;
+    return false;
   }
 
   const data = payload.data ?? {};
   const toolCallId = typeof data.toolCallId === "string" ? data.toolCallId : "";
   if (!toolCallId) {
-    return;
+    return false;
   }
   const toolStreamIdentity = buildToolStreamIdentity(payload.runId, toolCallId);
   let entry = host.toolStreamById.get(toolStreamIdentity);
@@ -1119,5 +1118,6 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
   entry.message = buildToolStreamMessage(entry);
   trimToolStream(host);
   scheduleToolStreamSync(host, phase === "result");
+  return true;
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -950,7 +950,8 @@ function handlePlanEvent(host: ToolStreamHost, payload: AgentEventPayload): bool
     return false;
   }
   host.planStatus = normalizePlanSnapshot(data, payload.runId);
-  return true;
+  host.requestUpdate?.();
+  return false;
 }
 
 export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPayload): boolean {


### PR DESCRIPTION
Closes #122204

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users watching direct OpenAI Responses turns in the Control UI would see streamed assistant text arrive in small, widely spaced updates even when provider generation was healthy. The regression combined a slower default provider transport, duplicated Gateway pacing, a missing trailing agent-text wake-up, and redundant UI invalidations.

## Why This Change Was Made

Direct official OpenAI API-key traffic now defaults to measured-faster SSE while Codex-authenticated routes keep their native transport behavior and explicit WebSocket overrides remain honored. The Gateway now uses one run-owned 75 ms pacing policy for chat and agent text with fixed-deadline trailing cleanup, and the Control UI skips ordinary assistant/thinking invalidations when visible state is unchanged while plan/tool changes still invalidate exactly once.

The Cloud Worker preview ACK/persistence path is a separate follow-up and is intentionally not changed here.

## User Impact

Assistant text becomes visible sooner and advances more smoothly in the default Control UI path. Trailing agent text no longer waits for a later event or terminal lifecycle flush, and no-op mirror events do less rendering work.

## Evidence

![Before/after streaming latency evidence](https://github.com/user-attachments/assets/a5ad78ca-7b23-44e6-81e5-9ec3a5839862)

- Deployed baseline at `5c52666`: visible-update gap p50 196 ms, p95 466 ms, median 6 characters/update.
- Three interleaved live provider A/B runs: SSE 1,854 chars/s versus WebSocket 1,025 chars/s; median visible stream 3.24 s versus 5.87 s.
- Live GPT-5.6 Sol High response-shape comparison: SSE TTFT 5.58 s and 374.6 chars/s; WebSocket TTFT 10.0 s and 343.6 chars/s; SSE completed about 21% sooner.
- Rebased focused proof: OpenAI provider 74 tests, Gateway 143 tests, UI 50 tests; 267 total passed. The CI-discovered direct plan-stream contract also passes its 27-test node suite.
- Required red/green: both 75 ms cadence deadline regressions fail against the former 150 ms policy and pass with this repair.
- `git diff --check`, targeted `oxfmt`, and `node scripts/check-changed.mjs -- <eight files>` pass. The remote changed-gate backend was unavailable, so the repo wrapper used its documented trusted local fallback.
- Fresh Codex/high autoreview: TruffleHog clean; no accepted/actionable findings; patch correct 0.98.
- Exact-head CI: run [31523664465](https://github.com/openclaw/openclaw/actions/runs/31523664465), attempt 2, green at `1524e221b4a` after one unrelated ACP help-process timeout passed on retry.
- Actual merged production/UI LOC: +109/-110 (net -1). Tests: +149/-19 (net +130).

This PR was AI-assisted. The implementation and evidence were reviewed against the owner boundaries and focused tests above; no agent transcript is included.
