### PR TITLE
feat(agents): add isolated database rehearsal contract

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"6d42269794e0473fdae832d6c1af49854a822438f4b3b0943fb855846cbd5f64","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}
+{"contentHash":"832242378a62c543983b23dcb612dfae4467243f82107f6c9d14ff782d46f736","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
@@ -1,1 +1,1 @@
-{"contentHash":"d5a6edec36b8675110181c771b79fac5753d242ce8adc58022743eb0184c34f2","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
+{"contentHash":"2d2c7ff168ed21f0688a11b238d4610f5ee04408790131bd9e5d6a2ec5aea9d0","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-core.json
@@ -1,1 +1,1 @@
-{"contentHash":"74e044d5e8a93fd319609f0d130eea0c1e636111e7c2597cbc3c98b847515bd3","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}
+{"contentHash":"fda0b2d5b972d86836b886198f5b32b8310b218e9ddffd102e7dd6a500e20345","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
@@ -1,1 +1,1 @@
-{"contentHash":"176592119d65008bfa8d1b465670c9556b0275d432e738353ea5a25d0a61985d","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}
+{"contentHash":"735ca78faf887251da8085586f8b322c49ffd500165d365b32a88e49535c6272","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-inbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-inbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"39d7eea281be7a268c1878155930034027f73ae6404622ab09041300bda41991","entrypoint":"channel-inbound","importSpecifier":"openclaw/plugin-sdk/channel-inbound"}
+{"contentHash":"ee0ae6ca77c76bd48947bbfb1fdcee2a257fd6d5187ef16fd9b5c8c3590a4b6d","entrypoint":"channel-inbound","importSpecifier":"openclaw/plugin-sdk/channel-inbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-message.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-message.json
@@ -1,1 +1,1 @@
-{"contentHash":"d10f59babb0166e4db0a66e801ca674ad23b158737939d9213c3bc6258f2cc5c","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}
+{"contentHash":"d16ed1acced22118a5c0e1a7c6aeb0e275634302b122b2dfb10b84b5980a547d","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"dcbaf714f293fbe933587344f798c0d86bfd65dc74e05e552c08666695da5125","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}
+{"contentHash":"6916eb2a43c65fb222333d08897e0f17cf9c09b562162eae7a20041ddfa78e61","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
@@ -1,1 +1,1 @@
-{"contentHash":"5e92fe659c6fa93639b6e197bca678ec533c190208c65eee3ef4cb24f3929848","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}
+{"contentHash":"19406f1c233dee4b06a282b7a9f1b03f3c488426e716b0634901c485ffc4cee8","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}

--- a/docs/.generated/plugin-sdk-api-baseline/core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/core.json
@@ -1,1 +1,1 @@
-{"contentHash":"db4f872ae8ea2b1c36068c4fa4d0550e49550f34d31cbb4898533cdde9f4d103","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}
+{"contentHash":"4af1b7b532653deb52d1f8f35968d2c69a7df8a3bb09f4337b02787da00fa691","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}

--- a/docs/.generated/plugin-sdk-api-baseline/discord.json
+++ b/docs/.generated/plugin-sdk-api-baseline/discord.json
@@ -1,1 +1,1 @@
-{"contentHash":"9a9729aaa9a46400464a7c2b5240541a9f379271b863b25e1c4dd1c3b7508e73","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}
+{"contentHash":"2753bf321cf3fdb403b220584fa867ba4148c8e8943f40858cf19387346e22a9","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}

--- a/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
+++ b/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
@@ -1,1 +1,1 @@
-{"contentHash":"0006fe56489e1a95488e436e5b2d881c353003ba24163aa5620f8b52c87c0d99","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}
+{"contentHash":"092f99a3a47f3dc1e9d489ecce25a649cc3e913921d5071167abc9ed581cd36d","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}

--- a/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"4d4adfe9f53f025c8bb22ee1a1dff2e224dae6bb25158ac1ac991cf7ebad249b","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}
+{"contentHash":"c982a730f0da5ed626802bfffa582f9e4f63b31dd34141e9f179b14d90a33ba5","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
@@ -1,1 +1,1 @@
-{"contentHash":"61e6ba4e3564811059b3d27ecfee1df8b63f151a8a43bab7190336b02f76889d","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}
+{"contentHash":"cbefda03bb600982100b5404e4f3093e786dea7f4e7558494ebf9d1f379379f5","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"647420ef973a58b7078e974eba6ab85b6d2df96f28e07c3bce108c0da3f52c68","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}
+{"contentHash":"6c4816d6e435d20a57ae57ffa020e6890ac9dbb4459d9193f9529a8f05143062","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"61e41f87d2a11f6c85ff712b500fc2cf50b974ee2f701e9c69c1693dc206e15d","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
+{"contentHash":"035282d913110c215820cb4af4c2590d2282eac72da807daa3ec022489465271","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
+++ b/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
@@ -1,1 +1,1 @@
-{"contentHash":"d2d5d792a37398f060d0e069077d794d7e2d91a23fb0a4849ec66b8591f86daa","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}
+{"contentHash":"3464dac1c6160e4fbe2fa0a7b4ab16000a59e4cc29d1f0f82abcd46c53f1b873","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}

--- a/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
+++ b/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
@@ -1,1 +1,1 @@
-{"contentHash":"ae862c22e6d6f96239ea1666faa208c5445aef89b6f3bc4425e3a259c3c6cb2b","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}
+{"contentHash":"41a206b6e0a64dd56d2acdb0b6455257acc5aa0f5b6a9b528075c70987d1e97f","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}

--- a/src/cli/agents-output-mode.test.ts
+++ b/src/cli/agents-output-mode.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { isAgentsMachineOutput } from "./agents-output-mode.js";
+
+describe("agents machine output", () => {
+  it("classifies the hidden database rehearsal as machine output", () => {
+    expect(isAgentsMachineOutput(["node", "openclaw", "agents", "db-rehearsal"])).toBe(true);
+    expect(
+      isAgentsMachineOutput([
+        "node",
+        "openclaw",
+        "--profile",
+        "test",
+        "agents",
+        "db-rehearsal",
+        "--request",
+        "-",
+      ]),
+    ).toBe(true);
+  });
+
+  it("keeps ordinary agent management on human output", () => {
+    expect(isAgentsMachineOutput(["node", "openclaw", "agents", "list"])).toBe(false);
+    expect(isAgentsMachineOutput(["node", "openclaw", "agents"])).toBe(false);
+  });
+});

--- a/src/cli/agents-output-mode.ts
+++ b/src/cli/agents-output-mode.ts
@@ -1,0 +1,7 @@
+import { getMachineOutputCommandPath } from "./machine-output-argv.js";
+
+/** Agent database rehearsals always reserve stdout for the JSON contract. */
+export function isAgentsMachineOutput(argv: readonly string[]): boolean {
+  const [, command] = getMachineOutputCommandPath(argv, 2);
+  return command === "db-rehearsal";
+}

--- a/src/cli/program/core-command-descriptors.ts
+++ b/src/cli/program/core-command-descriptors.ts
@@ -1,5 +1,6 @@
 // Core root-command descriptor catalog used for help placeholders and lazy registration.
 import { isExperimentalClawsEnabled } from "../../claws/experimental.js";
+import { isAgentsMachineOutput } from "../agents-output-mode.js";
 import { isConfigMachineOutput } from "../config-output-mode.js";
 import { isDoctorMachineOutput } from "../doctor-output-mode.js";
 import { defineCommandDescriptorCatalog } from "./command-descriptor-utils.js";
@@ -105,6 +106,7 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
     name: "agents",
     description: "Manage isolated agents (workspaces + auth + routing)",
     hasSubcommands: true,
+    machineOutput: ({ argv }) => isAgentsMachineOutput(argv),
   },
   {
     name: "status",

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -58,7 +58,7 @@ vi.mock("../../commands/agents.commands.delete.js", () => ({
   agentsDeleteCommand: mocks.agentsDeleteCommandMock,
 }));
 
-vi.mock("../../commands/agents.db-rehearsal.js", () => ({
+vi.mock("../../commands/agents.db-rehearsal-cli.js", () => ({
   agentsDatabaseRehearsalCommand: mocks.agentsDatabaseRehearsalCommandMock,
 }));
 

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   agentsBindingsCommandMock: vi.fn(),
   agentsBindCommandMock: vi.fn(),
   agentsDeleteCommandMock: vi.fn(),
+  agentsDatabaseRehearsalCommandMock: vi.fn(),
   agentsListCommandMock: vi.fn(),
   agentsSetIdentityCommandMock: vi.fn(),
   agentsUnbindCommandMock: vi.fn(),
@@ -28,6 +29,7 @@ const agentsAddCommandMock = mocks.agentsAddCommandMock;
 const agentsBindingsCommandMock = mocks.agentsBindingsCommandMock;
 const agentsBindCommandMock = mocks.agentsBindCommandMock;
 const agentsDeleteCommandMock = mocks.agentsDeleteCommandMock;
+const agentsDatabaseRehearsalCommandMock = mocks.agentsDatabaseRehearsalCommandMock;
 const agentsListCommandMock = mocks.agentsListCommandMock;
 const agentsSetIdentityCommandMock = mocks.agentsSetIdentityCommandMock;
 const agentsUnbindCommandMock = mocks.agentsUnbindCommandMock;
@@ -54,6 +56,10 @@ vi.mock("../../commands/agents.commands.bind.js", () => ({
 
 vi.mock("../../commands/agents.commands.delete.js", () => ({
   agentsDeleteCommand: mocks.agentsDeleteCommandMock,
+}));
+
+vi.mock("../../commands/agents.db-rehearsal.js", () => ({
+  agentsDatabaseRehearsalCommand: mocks.agentsDatabaseRehearsalCommandMock,
 }));
 
 vi.mock("../../commands/agents.commands.identity.js", () => ({
@@ -89,6 +95,7 @@ describe("agent command registration", () => {
     agentsBindingsCommandMock.mockResolvedValue(undefined);
     agentsBindCommandMock.mockResolvedValue(undefined);
     agentsDeleteCommandMock.mockResolvedValue(undefined);
+    agentsDatabaseRehearsalCommandMock.mockResolvedValue(undefined);
     agentsListCommandMock.mockResolvedValue(undefined);
     agentsSetIdentityCommandMock.mockResolvedValue(undefined);
     agentsUnbindCommandMock.mockResolvedValue(undefined);
@@ -376,6 +383,22 @@ describe("agent command registration", () => {
     expect((options as { force?: boolean }).force).toBe(true);
     expect((options as { json?: boolean }).json).toBe(true);
     expect(callRuntime).toBe(runtime);
+  });
+
+  it("keeps the operator database rehearsal hidden and forwards its request source", async () => {
+    const program = new Command();
+    registerAgentsCommands(program);
+    const agents = program.commands.find((command) => command.name() === "agents");
+    const rehearsal = agents?.commands.find((command) => command.name() === "db-rehearsal");
+    expect(rehearsal).toBeDefined();
+    expect(agents?.helpInformation()).not.toContain("db-rehearsal");
+
+    await runCli(["agents", "db-rehearsal", "--request", "rehearsal.json"]);
+
+    expect(agentsDatabaseRehearsalCommandMock).toHaveBeenCalledWith(
+      { request: "rehearsal.json" },
+      runtime,
+    );
   });
 
   it("forwards set-identity options", async () => {

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -10,7 +10,7 @@ import { collectOption } from "./helpers.js";
 type AgentsAddModule = typeof import("../../commands/agents.commands.add.js");
 type AgentsBindModule = typeof import("../../commands/agents.commands.bind.js");
 type AgentsDeleteModule = typeof import("../../commands/agents.commands.delete.js");
-type AgentsDatabaseRehearsalModule = typeof import("../../commands/agents.db-rehearsal.js");
+type AgentsDatabaseRehearsalModule = typeof import("../../commands/agents.db-rehearsal-cli.js");
 type AgentsIdentityModule = typeof import("../../commands/agents.commands.identity.js");
 type AgentsListModule = typeof import("../../commands/agents.commands.list.js");
 type CliUtilsModule = typeof import("../cli-utils.js");
@@ -43,7 +43,7 @@ async function loadAgentsDeleteCommand(): Promise<AgentsDeleteModule["agentsDele
 async function loadAgentsDatabaseRehearsalCommand(): Promise<
   AgentsDatabaseRehearsalModule["agentsDatabaseRehearsalCommand"]
 > {
-  return (await import("../../commands/agents.db-rehearsal.js")).agentsDatabaseRehearsalCommand;
+  return (await import("../../commands/agents.db-rehearsal-cli.js")).agentsDatabaseRehearsalCommand;
 }
 
 async function loadAgentsSetIdentityCommand(): Promise<

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -10,6 +10,7 @@ import { collectOption } from "./helpers.js";
 type AgentsAddModule = typeof import("../../commands/agents.commands.add.js");
 type AgentsBindModule = typeof import("../../commands/agents.commands.bind.js");
 type AgentsDeleteModule = typeof import("../../commands/agents.commands.delete.js");
+type AgentsDatabaseRehearsalModule = typeof import("../../commands/agents.db-rehearsal.js");
 type AgentsIdentityModule = typeof import("../../commands/agents.commands.identity.js");
 type AgentsListModule = typeof import("../../commands/agents.commands.list.js");
 type CliUtilsModule = typeof import("../cli-utils.js");
@@ -37,6 +38,12 @@ async function loadAgentsUnbindCommand(): Promise<AgentsBindModule["agentsUnbind
 
 async function loadAgentsDeleteCommand(): Promise<AgentsDeleteModule["agentsDeleteCommand"]> {
   return (await import("../../commands/agents.commands.delete.js")).agentsDeleteCommand;
+}
+
+async function loadAgentsDatabaseRehearsalCommand(): Promise<
+  AgentsDatabaseRehearsalModule["agentsDatabaseRehearsalCommand"]
+> {
+  return (await import("../../commands/agents.db-rehearsal.js")).agentsDatabaseRehearsalCommand;
 }
 
 async function loadAgentsSetIdentityCommand(): Promise<
@@ -264,6 +271,15 @@ ${formatHelpExamples([
           runtime,
         );
       });
+    });
+
+  agents
+    .command("db-rehearsal", { hidden: true })
+    .requiredOption("--request <file|->", "Read the bounded rehearsal JSON request")
+    .action(async (opts): Promise<void> => {
+      const { defaultRuntime } = await loadAgentsActionRuntime();
+      const agentsDatabaseRehearsalCommand = await loadAgentsDatabaseRehearsalCommand();
+      await agentsDatabaseRehearsalCommand({ request: String(opts.request) }, defaultRuntime);
     });
 
   agents.action(async (): Promise<void> => {

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -6,6 +6,7 @@ import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
 import { hasExplicitOptions } from "../command-options.js";
 import { formatHelpExamples } from "../help-format.js";
 import { collectOption } from "./helpers.js";
+import { setCommandJsonMode } from "./json-mode.js";
 
 type AgentsAddModule = typeof import("../../commands/agents.commands.add.js");
 type AgentsBindModule = typeof import("../../commands/agents.commands.bind.js");
@@ -273,8 +274,8 @@ ${formatHelpExamples([
       });
     });
 
-  agents
-    .command("db-rehearsal", { hidden: true })
+  const dbRehearsal = agents.command("db-rehearsal", { hidden: true });
+  setCommandJsonMode(dbRehearsal, "output", () => true)
     .requiredOption("--request <file|->", "Read the bounded rehearsal JSON request")
     .action(async (opts): Promise<void> => {
       const { defaultRuntime } = await loadAgentsActionRuntime();

--- a/src/cli/program/root-command-descriptions.test.ts
+++ b/src/cli/program/root-command-descriptions.test.ts
@@ -223,7 +223,7 @@ const JSON_OUTPUT_INHERITED_FROM_PARENT = new Set([
 ]);
 
 // Route-first parsing accepts JSON before Commander registration is reached.
-const JSON_OUTPUT_ROUTE_FIRST = new Set(["agents"]);
+const JSON_OUTPUT_ROUTE_FIRST = new Set(["agents", "agents db-rehearsal"]);
 
 async function registerAllBuiltInCommands(): Promise<Command> {
   const program = new Command().name("openclaw");

--- a/src/commands/agents.db-rehearsal-cli.ts
+++ b/src/commands/agents.db-rehearsal-cli.ts
@@ -1,0 +1,81 @@
+// CLI adapter for the bounded agent-database rehearsal JSON contract.
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { readByteStreamWithLimit } from "@openclaw/media-core/read-byte-stream-with-limit";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { readFileDescriptorBounded } from "../infra/boundary-file-read.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { writeRuntimeJson } from "../runtime.js";
+import { AgentDatabaseRehearsalError, runAgentDatabaseRehearsal } from "./agents.db-rehearsal.js";
+
+const REHEARSAL_REQUEST_MAX_BYTES = 256 * 1024;
+type RehearsalMode = "inventory" | "migrate" | "read-only";
+
+function fail(code: string, message: string): never {
+  throw new AgentDatabaseRehearsalError(code, message);
+}
+
+async function readRequestSource(source: string, stdin: AsyncIterable<unknown>): Promise<unknown> {
+  let raw: Buffer;
+  if (source === "-") {
+    raw = await readByteStreamWithLimit(stdin, {
+      maxBytes: REHEARSAL_REQUEST_MAX_BYTES,
+      onOverflow: ({ maxBytes }) =>
+        new AgentDatabaseRehearsalError("request-too-large", `request exceeds ${maxBytes} bytes.`),
+    });
+  } else {
+    const file = await fsp.open(path.resolve(source), "r");
+    try {
+      const stat = await file.stat();
+      if (!stat.isFile()) {
+        fail("request-unavailable", "request source must be a regular file.");
+      }
+      if (stat.size > REHEARSAL_REQUEST_MAX_BYTES) {
+        fail("request-too-large", `request exceeds ${REHEARSAL_REQUEST_MAX_BYTES} bytes.`);
+      }
+      raw = await readFileDescriptorBounded(file.fd, REHEARSAL_REQUEST_MAX_BYTES);
+    } finally {
+      await file.close();
+    }
+  }
+  try {
+    return JSON.parse(raw.toString("utf8")) as unknown;
+  } catch {
+    return fail("invalid-json", "request source is not valid JSON.");
+  }
+}
+
+export async function agentsDatabaseRehearsalCommand(
+  options: { request: string },
+  runtime: RuntimeEnv,
+  deps: { stdin?: AsyncIterable<unknown> } = {},
+): Promise<void> {
+  let mode: RehearsalMode | undefined;
+  try {
+    const value = await readRequestSource(options.request, deps.stdin ?? process.stdin);
+    mode =
+      isRecord(value) && typeof value.mode === "string" ? (value.mode as RehearsalMode) : undefined;
+    writeRuntimeJson(runtime, await runAgentDatabaseRehearsal(value), 0);
+  } catch (error) {
+    const typed =
+      error instanceof AgentDatabaseRehearsalError
+        ? error
+        : new AgentDatabaseRehearsalError("rehearsal-failed", formatErrorMessage(error));
+    writeRuntimeJson(
+      runtime,
+      {
+        schemaVersion: 1,
+        ok: false,
+        ...(mode ? { mode } : {}),
+        code: typed.code,
+        message: typed.message,
+        ...(typed.unsupportedPluginPersistence
+          ? { unsupportedPluginPersistence: typed.unsupportedPluginPersistence }
+          : {}),
+      },
+      0,
+    );
+    runtime.exit(1, { resetStream: process.stderr });
+  }
+}

--- a/src/commands/agents.db-rehearsal.test.ts
+++ b/src/commands/agents.db-rehearsal.test.ts
@@ -161,6 +161,54 @@ describe("agents database rehearsal", () => {
     expect(result.complete).toBe(true);
   });
 
+  it("accepts exactly 2048 logical inventory references", async () => {
+    const stateRoot = await makeRoot();
+    const configPath = path.join(stateRoot, "openclaw.json");
+    const entries = Object.fromEntries(
+      Array.from({ length: 1024 }, (_, index) => [
+        `agent-${index}`,
+        index === 0 ? { default: true } : {},
+      ]),
+    );
+    await fsp.writeFile(
+      configPath,
+      JSON.stringify({ agents: { entries }, plugins: { enabled: false } }),
+    );
+
+    const result = (await runAgentDatabaseRehearsal({
+      schemaVersion: 1,
+      mode: "inventory",
+      stateRoot,
+      configPath,
+    })) as Extract<RehearsalSuccess, { mode: "inventory" }>;
+
+    expect(result.references).toHaveLength(2048);
+  });
+
+  it("rejects the 2049th logical inventory reference", async () => {
+    const stateRoot = await makeRoot();
+    const configPath = path.join(stateRoot, "openclaw.json");
+    const entries = Object.fromEntries(
+      Array.from({ length: 1025 }, (_, index) => [
+        `agent-${index}`,
+        index === 0 ? { default: true } : {},
+      ]),
+    );
+    await fsp.writeFile(
+      configPath,
+      JSON.stringify({ agents: { entries }, plugins: { enabled: false } }),
+    );
+
+    await expect(
+      runAgentDatabaseRehearsal({
+        schemaVersion: 1,
+        mode: "inventory",
+        stateRoot,
+        configPath,
+      }),
+    ).rejects.toMatchObject({ code: "inventory-limit-exceeded" });
+  });
+
   it("rejects unsupported plugin persistence before validating or opening any database", async () => {
     const root = await makeRoot();
     await expect(

--- a/src/commands/agents.db-rehearsal.test.ts
+++ b/src/commands/agents.db-rehearsal.test.ts
@@ -1,0 +1,318 @@
+// Agent DB rehearsal tests cover isolated inventory, migration, and compatibility probes.
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { listOpenClawRegisteredAgentDatabases } from "../state/openclaw-agent-db-registry.js";
+import {
+  closeOpenClawAgentDatabaseByPath,
+  closeOpenClawAgentDatabasesForTest,
+  OPENCLAW_AGENT_SCHEMA_VERSION,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  OPENCLAW_STATE_SCHEMA_VERSION,
+} from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
+import { runAgentDatabaseRehearsal } from "./agents.db-rehearsal.js";
+
+type RehearsalSuccess = Awaited<ReturnType<typeof runAgentDatabaseRehearsal>>;
+
+describe("agents database rehearsal", () => {
+  const tempRoots = createSuiteTempRootTracker({ prefix: "openclaw-agent-db-rehearsal-" });
+
+  beforeAll(async () => {
+    await tempRoots.setup();
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+  });
+
+  afterAll(async () => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    await tempRoots.cleanup();
+  });
+
+  async function makeRoot(): Promise<string> {
+    return await tempRoots.make();
+  }
+
+  function createAgentDatabase(params: {
+    root: string;
+    agentId: string;
+    relativePath: string;
+  }): string {
+    const env = { OPENCLAW_STATE_DIR: params.root };
+    const pathname = path.join(params.root, params.relativePath);
+    fs.mkdirSync(path.dirname(pathname), { recursive: true });
+    const database = openOpenClawAgentDatabase({
+      agentId: params.agentId,
+      env,
+      path: pathname,
+    });
+    database.db.exec("PRAGMA wal_checkpoint(TRUNCATE);");
+    closeOpenClawAgentDatabaseByPath(pathname);
+    return pathname;
+  }
+
+  function setAgentSchemaVersion(pathname: string, version: number): void {
+    const database = new DatabaseSync(pathname);
+    try {
+      database.exec(`PRAGMA user_version = ${version};`);
+      database
+        .prepare("UPDATE schema_meta SET schema_version = ? WHERE meta_key = 'primary'")
+        .run(version);
+    } finally {
+      database.close();
+    }
+  }
+
+  function readAgentSchemaVersion(pathname: string): number {
+    const database = new DatabaseSync(pathname, { readOnly: true });
+    try {
+      return (database.prepare("PRAGMA user_version").get() as { user_version: number })
+        .user_version;
+    } finally {
+      database.close();
+    }
+  }
+
+  it("inventories effective roster, agent-dir, and fixed session-store claims without a database open", async () => {
+    const stateRoot = await makeRoot();
+    const configuredAgentDir = path.join(stateRoot, "custom-auth", "main");
+    const fixedStore = path.join(stateRoot, "fixed-sessions", "sessions.json");
+    const configPath = path.join(stateRoot, "openclaw.json");
+    await fsp.writeFile(
+      configPath,
+      JSON.stringify({
+        agents: {
+          entries: {
+            main: { default: true, agentDir: configuredAgentDir },
+            ops: {},
+          },
+        },
+        session: { store: fixedStore },
+      }),
+    );
+
+    const result = (await runAgentDatabaseRehearsal({
+      schemaVersion: 1,
+      mode: "inventory",
+      stateRoot,
+      configPath,
+    })) as Extract<RehearsalSuccess, { mode: "inventory" }>;
+
+    expect(result.references).toEqual(
+      expect.arrayContaining([
+        {
+          agentId: "main",
+          path: path.join(configuredAgentDir, "openclaw-agent.sqlite"),
+          claimKind: "agent-dir-database",
+          ownerClaim: "configured-agent-dir",
+        },
+        {
+          agentId: "ops",
+          path: path.join(stateRoot, "agents", "ops", "agent", "openclaw-agent.sqlite"),
+          claimKind: "agent-dir-database",
+          ownerClaim: "default-agent-dir",
+        },
+        {
+          agentId: "main",
+          path: path.join(stateRoot, "fixed-sessions", "openclaw-agent.sqlite"),
+          claimKind: "session-store-fixed-family",
+          ownerClaim: "configured-session-store",
+        },
+        {
+          agentId: "ops",
+          path: path.join(stateRoot, "fixed-sessions", "openclaw-agent.sqlite"),
+          claimKind: "session-store-fixed-family",
+          ownerClaim: "configured-session-store",
+        },
+      ]),
+    );
+    expect(result.pluginPersistence).toEqual([
+      expect.objectContaining({ pluginId: "*", kind: "indeterminate", copiedPath: null }),
+    ]);
+    expect(result.complete).toBe(false);
+    expect(fs.existsSync(resolveOpenClawStateSqlitePath({ OPENCLAW_STATE_DIR: stateRoot }))).toBe(
+      false,
+    );
+  });
+
+  it("reports plugin inventory complete only when plugin loading is explicitly disabled", async () => {
+    const stateRoot = await makeRoot();
+    const configPath = path.join(stateRoot, "openclaw.json");
+    await fsp.writeFile(configPath, JSON.stringify({ plugins: { enabled: false } }));
+
+    const result = (await runAgentDatabaseRehearsal({
+      schemaVersion: 1,
+      mode: "inventory",
+      stateRoot,
+      configPath,
+    })) as Extract<RehearsalSuccess, { mode: "inventory" }>;
+
+    expect(result.pluginPersistence).toEqual([]);
+    expect(result.complete).toBe(true);
+  });
+
+  it("rejects unsupported plugin persistence before validating or opening any database", async () => {
+    const root = await makeRoot();
+    await expect(
+      runAgentDatabaseRehearsal({
+        schemaVersion: 1,
+        mode: "migrate",
+        privateStateRoot: root,
+        agents: [{ agentId: "main", copiedPath: path.join(root, "missing.sqlite") }],
+        pluginPersistence: [
+          { pluginId: "custom-store", kind: "sqlite", copiedPath: "/outside/plugin.sqlite" },
+        ],
+      }),
+    ).rejects.toMatchObject({ code: "unsupported-plugin-persistence" });
+    expect(fs.existsSync(resolveOpenClawStateSqlitePath({ OPENCLAW_STATE_DIR: root }))).toBe(false);
+  });
+
+  it("migrates every explicit composite row and replaces stale private registry rows", async () => {
+    const root = await makeRoot();
+    const first = createAgentDatabase({
+      root,
+      agentId: "main",
+      relativePath: "copies/first/openclaw-agent.sqlite",
+    });
+    const second = createAgentDatabase({
+      root,
+      agentId: "main",
+      relativePath: "copies/second/openclaw-agent.sqlite",
+    });
+    createAgentDatabase({
+      root,
+      agentId: "stale",
+      relativePath: "copies/stale/openclaw-agent.sqlite",
+    });
+    closeOpenClawStateDatabaseForTest();
+    setAgentSchemaVersion(first, OPENCLAW_AGENT_SCHEMA_VERSION - 1);
+    setAgentSchemaVersion(second, OPENCLAW_AGENT_SCHEMA_VERSION - 1);
+
+    const result = (await runAgentDatabaseRehearsal({
+      schemaVersion: 1,
+      mode: "migrate",
+      privateStateRoot: root,
+      agents: [
+        { agentId: "main", copiedPath: first },
+        { agentId: "main", copiedPath: second },
+      ],
+      pluginPersistence: [],
+    })) as Extract<RehearsalSuccess, { mode: "migrate" }>;
+
+    expect(result.sharedState).toMatchObject({
+      schemaVersionAfter: OPENCLAW_STATE_SCHEMA_VERSION,
+      role: "global",
+      readOnly: false,
+    });
+    expect(result.agents).toHaveLength(2);
+    expect(result.agents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          agentId: "main",
+          realPath: fs.realpathSync.native(first),
+          before: expect.objectContaining({ userVersion: OPENCLAW_AGENT_SCHEMA_VERSION - 1 }),
+          after: expect.objectContaining({ userVersion: OPENCLAW_AGENT_SCHEMA_VERSION }),
+          migrated: true,
+        }),
+        expect.objectContaining({
+          agentId: "main",
+          realPath: fs.realpathSync.native(second),
+          migrated: true,
+        }),
+      ]),
+    );
+    const registry = listOpenClawRegisteredAgentDatabases({
+      env: { OPENCLAW_STATE_DIR: root },
+      includeIncompatibleSchemaVersions: true,
+    });
+    expect(registry.map(({ agentId, path: pathname }) => ({ agentId, path: pathname }))).toEqual([
+      { agentId: "main", path: fs.realpathSync.native(first) },
+      { agentId: "main", path: fs.realpathSync.native(second) },
+    ]);
+  });
+
+  it("read-only compatibility verifies exact registry without migrating files", async () => {
+    const root = await makeRoot();
+    const databasePath = createAgentDatabase({
+      root,
+      agentId: "main",
+      relativePath: "copies/current/openclaw-agent.sqlite",
+    });
+    closeOpenClawStateDatabaseForTest();
+    const beforeVersion = readAgentSchemaVersion(databasePath);
+    const beforeMtime = fs.statSync(databasePath).mtimeMs;
+
+    const result = (await runAgentDatabaseRehearsal({
+      schemaVersion: 1,
+      mode: "read-only",
+      privateStateRoot: root,
+      agents: [{ agentId: "main", copiedPath: databasePath }],
+      pluginPersistence: [],
+    })) as Extract<RehearsalSuccess, { mode: "read-only" }>;
+
+    expect(result.sharedState.readOnly).toBe(true);
+    expect(result.agents[0]).toMatchObject({
+      migrated: false,
+      before: { userVersion: beforeVersion },
+      after: { userVersion: beforeVersion },
+    });
+    expect(readAgentSchemaVersion(databasePath)).toBe(beforeVersion);
+    expect(fs.statSync(databasePath).mtimeMs).toBe(beforeMtime);
+  });
+
+  it("rejects a hardlinked clone before writable shared state opens", async () => {
+    const outside = await makeRoot();
+    const root = await makeRoot();
+    const source = createAgentDatabase({
+      root: outside,
+      agentId: "main",
+      relativePath: "source/openclaw-agent.sqlite",
+    });
+    closeOpenClawStateDatabaseForTest();
+    const alias = path.join(root, "copy", "openclaw-agent.sqlite");
+    await fsp.mkdir(path.dirname(alias), { recursive: true });
+    await fsp.link(source, alias);
+
+    await expect(
+      runAgentDatabaseRehearsal({
+        schemaVersion: 1,
+        mode: "migrate",
+        privateStateRoot: root,
+        agents: [{ agentId: "main", copiedPath: alias }],
+        pluginPersistence: [],
+      }),
+    ).rejects.toMatchObject({ code: "path-not-private" });
+    expect(fs.existsSync(resolveOpenClawStateSqlitePath({ OPENCLAW_STATE_DIR: root }))).toBe(false);
+  });
+
+  it("rejects copied paths that escape the private root", async () => {
+    const outside = await makeRoot();
+    const root = await makeRoot();
+    const databasePath = createAgentDatabase({
+      root: outside,
+      agentId: "main",
+      relativePath: "outside/openclaw-agent.sqlite",
+    });
+    closeOpenClawStateDatabaseForTest();
+
+    await expect(
+      runAgentDatabaseRehearsal({
+        schemaVersion: 1,
+        mode: "read-only",
+        privateStateRoot: root,
+        agents: [{ agentId: "main", copiedPath: databasePath }],
+        pluginPersistence: [],
+      }),
+    ).rejects.toMatchObject({ code: "path-escape" });
+  });
+});

--- a/src/commands/agents.db-rehearsal.test.ts
+++ b/src/commands/agents.db-rehearsal.test.ts
@@ -168,7 +168,9 @@ describe("agents database rehearsal", () => {
         schemaVersion: 1,
         mode: "migrate",
         privateStateRoot: root,
-        agents: [{ agentId: "main", copiedPath: path.join(root, "missing.sqlite") }],
+        agents: [
+          { agentId: "main", copiedPath: path.join(root, "missing.sqlite"), creation: "existing" },
+        ],
         pluginPersistence: [
           { pluginId: "custom-store", kind: "sqlite", copiedPath: "/outside/plugin.sqlite" },
         ],
@@ -187,7 +189,7 @@ describe("agents database rehearsal", () => {
       schemaVersion: 1,
       mode: "migrate",
       privateStateRoot: root,
-      agents: [{ agentId: "main", copiedPath: databasePath }],
+      agents: [{ agentId: "main", copiedPath: databasePath, creation: "fresh" }],
       pluginPersistence: [],
     })) as Extract<RehearsalSuccess, { mode: "migrate" }>;
 
@@ -199,6 +201,63 @@ describe("agents database rehearsal", () => {
     });
     expect(result.privateStateRoot).toBe(root);
     expect(fs.existsSync(resolveOpenClawStateSqlitePath({ OPENCLAW_STATE_DIR: root }))).toBe(true);
+
+    const readback = (await runAgentDatabaseRehearsal({
+      schemaVersion: 1,
+      mode: "read-only",
+      privateStateRoot: root,
+      agents: [{ agentId: "main", copiedPath: databasePath, creation: "fresh" }],
+      pluginPersistence: [],
+    })) as Extract<RehearsalSuccess, { mode: "read-only" }>;
+    expect(readback.agents[0]).toMatchObject({
+      creation: "fresh",
+      migrated: false,
+      before: { role: "agent", ownerAgentId: "main" },
+      after: { role: "agent", ownerAgentId: "main" },
+    });
+  });
+
+  it("rejects fresh provenance for an already-owned database", async () => {
+    const sourceRoot = await makeRoot();
+    const source = createAgentDatabase({
+      root: sourceRoot,
+      agentId: "main",
+      relativePath: "source/openclaw-agent.sqlite",
+    });
+    closeOpenClawStateDatabaseForTest();
+    const root = await makeRoot();
+    const copiedPath = path.join(root, "copy", "openclaw-agent.sqlite");
+    await fsp.mkdir(path.dirname(copiedPath), { recursive: true });
+    await fsp.copyFile(source, copiedPath);
+
+    await expect(
+      runAgentDatabaseRehearsal({
+        schemaVersion: 1,
+        mode: "migrate",
+        privateStateRoot: root,
+        agents: [{ agentId: "main", copiedPath, creation: "fresh" }],
+        pluginPersistence: [],
+      }),
+    ).rejects.toMatchObject({ code: "fresh-database-not-empty" });
+    expect(fs.existsSync(resolveOpenClawStateSqlitePath({ OPENCLAW_STATE_DIR: root }))).toBe(false);
+  });
+
+  it("rejects existing provenance for an unowned database", async () => {
+    const root = await makeRoot();
+    const copiedPath = path.join(root, "copy", "openclaw-agent.sqlite");
+    await fsp.mkdir(path.dirname(copiedPath), { recursive: true });
+    new DatabaseSync(copiedPath).close();
+
+    await expect(
+      runAgentDatabaseRehearsal({
+        schemaVersion: 1,
+        mode: "migrate",
+        privateStateRoot: root,
+        agents: [{ agentId: "main", copiedPath, creation: "existing" }],
+        pluginPersistence: [],
+      }),
+    ).rejects.toMatchObject({ code: "agent-owner-mismatch" });
+    expect(fs.existsSync(resolveOpenClawStateSqlitePath({ OPENCLAW_STATE_DIR: root }))).toBe(false);
   });
 
   it("migrates every explicit composite row and replaces stale private registry rows", async () => {
@@ -227,8 +286,8 @@ describe("agents database rehearsal", () => {
       mode: "migrate",
       privateStateRoot: root,
       agents: [
-        { agentId: "main", copiedPath: first },
-        { agentId: "main", copiedPath: second },
+        { agentId: "main", copiedPath: first, creation: "existing" },
+        { agentId: "main", copiedPath: second, creation: "existing" },
       ],
       pluginPersistence: [],
     })) as Extract<RehearsalSuccess, { mode: "migrate" }>;
@@ -280,7 +339,7 @@ describe("agents database rehearsal", () => {
       schemaVersion: 1,
       mode: "read-only",
       privateStateRoot: root,
-      agents: [{ agentId: "main", copiedPath: databasePath }],
+      agents: [{ agentId: "main", copiedPath: databasePath, creation: "existing" }],
       pluginPersistence: [],
     })) as Extract<RehearsalSuccess, { mode: "read-only" }>;
 
@@ -313,7 +372,7 @@ describe("agents database rehearsal", () => {
         schemaVersion: 1,
         mode: "migrate",
         privateStateRoot: root,
-        agents: [{ agentId: "main", copiedPath: alias }],
+        agents: [{ agentId: "main", copiedPath: alias, creation: "existing" }],
         pluginPersistence: [],
       }),
     ).rejects.toMatchObject({ code: "path-not-private" });
@@ -335,7 +394,7 @@ describe("agents database rehearsal", () => {
         schemaVersion: 1,
         mode: "read-only",
         privateStateRoot: root,
-        agents: [{ agentId: "main", copiedPath: databasePath }],
+        agents: [{ agentId: "main", copiedPath: databasePath, creation: "existing" }],
         pluginPersistence: [],
       }),
     ).rejects.toMatchObject({ code: "path-escape" });

--- a/src/commands/agents.db-rehearsal.test.ts
+++ b/src/commands/agents.db-rehearsal.test.ts
@@ -177,6 +177,30 @@ describe("agents database rehearsal", () => {
     expect(fs.existsSync(resolveOpenClawStateSqlitePath({ OPENCLAW_STATE_DIR: root }))).toBe(false);
   });
 
+  it("creates the private shared database when its canonical state directory is missing", async () => {
+    const root = await makeRoot();
+    const databasePath = path.join(root, "copy", "openclaw-agent.sqlite");
+    await fsp.mkdir(path.dirname(databasePath), { recursive: true });
+    new DatabaseSync(databasePath).close();
+
+    const result = (await runAgentDatabaseRehearsal({
+      schemaVersion: 1,
+      mode: "migrate",
+      privateStateRoot: root,
+      agents: [{ agentId: "main", copiedPath: databasePath }],
+      pluginPersistence: [],
+    })) as Extract<RehearsalSuccess, { mode: "migrate" }>;
+
+    expect(result.sharedState).toMatchObject({
+      path: path.join(root, "state", "openclaw.sqlite"),
+      schemaVersionBefore: 0,
+      schemaVersionAfter: OPENCLAW_STATE_SCHEMA_VERSION,
+      role: "global",
+    });
+    expect(result.privateStateRoot).toBe(root);
+    expect(fs.existsSync(resolveOpenClawStateSqlitePath({ OPENCLAW_STATE_DIR: root }))).toBe(true);
+  });
+
   it("migrates every explicit composite row and replaces stale private registry rows", async () => {
     const root = await makeRoot();
     const first = createAgentDatabase({
@@ -261,6 +285,7 @@ describe("agents database rehearsal", () => {
     })) as Extract<RehearsalSuccess, { mode: "read-only" }>;
 
     expect(result.sharedState.readOnly).toBe(true);
+    expect(result.sharedState.schemaVersionBefore).toBe(result.sharedState.schemaVersionAfter);
     expect(result.agents[0]).toMatchObject({
       migrated: false,
       before: { userVersion: beforeVersion },

--- a/src/commands/agents.db-rehearsal.ts
+++ b/src/commands/agents.db-rehearsal.ts
@@ -58,6 +58,7 @@ type PluginPersistenceDeclaration = {
 type AgentDatabaseRequest = {
   agentId: string;
   copiedPath: string;
+  creation: "existing" | "fresh";
 };
 
 type InventoryRequest = {
@@ -87,6 +88,7 @@ type DatabaseSnapshot = {
 
 type PreparedAgentDatabase = {
   agentId: string;
+  creation: "existing" | "fresh";
   requestedPath: string;
   resolvedPath: string;
   realPath: string;
@@ -184,9 +186,14 @@ function parseRequest(value: unknown): ParsedRequest {
     if (!isRecord(entry)) {
       fail("invalid-request", `agents[${index}] must be an object.`);
     }
+    const creation = entry.creation;
+    if (creation !== "existing" && creation !== "fresh") {
+      fail("invalid-request", `agents[${index}].creation must be existing or fresh.`);
+    }
     return {
       agentId: normalizeAgentId(requiredString(entry, "agentId")),
       copiedPath: requiredString(entry, "copiedPath"),
+      creation,
     };
   });
   return {
@@ -321,6 +328,17 @@ function inspectDatabaseSnapshot(pathname: string): DatabaseSnapshot {
   }
 }
 
+function hasApplicationSchema(pathname: string): boolean {
+  const database = openNodeSqliteDatabase(pathname, { readOnly: true });
+  try {
+    return Boolean(
+      database.prepare("SELECT 1 FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' LIMIT 1").get(),
+    );
+  } finally {
+    database.close();
+  }
+}
+
 function prepareAgentDatabases(
   request: RehearsalRequest,
   root: { resolved: string; real: string },
@@ -346,12 +364,37 @@ function prepareAgentDatabases(
       );
     }
     seen.add(compositeKey);
+    const before = inspectDatabaseSnapshot(realPath);
+    const ownerMatches =
+      before.role === "agent" &&
+      before.ownerAgentId !== null &&
+      normalizeAgentId(before.ownerAgentId) === entry.agentId;
+    if (request.mode === "migrate" && entry.creation === "fresh") {
+      if (
+        before.userVersion !== 0 ||
+        before.metadataSchemaVersion !== null ||
+        before.role !== null ||
+        before.ownerAgentId !== null ||
+        hasApplicationSchema(realPath)
+      ) {
+        fail(
+          "fresh-database-not-empty",
+          `agents[${index}] is marked fresh but already contains application schema or ownership.`,
+        );
+      }
+    } else if (!ownerMatches) {
+      fail(
+        "agent-owner-mismatch",
+        `agents[${index}] must be owned by agent ${entry.agentId} for ${request.mode} mode.`,
+      );
+    }
     return {
       agentId: entry.agentId,
+      creation: entry.creation,
       requestedPath,
       resolvedPath: requestedPath,
       realPath,
-      before: inspectDatabaseSnapshot(realPath),
+      before,
     };
   });
 }

--- a/src/commands/agents.db-rehearsal.ts
+++ b/src/commands/agents.db-rehearsal.ts
@@ -68,13 +68,15 @@ type InventoryRequest = {
   configPath: string;
 };
 
-type RehearsalRequest = {
+type RehearsalRequestBase = {
   schemaVersion: 1;
-  mode: "migrate" | "read-only";
   privateStateRoot: string;
   agents: AgentDatabaseRequest[];
   pluginPersistence: PluginPersistenceDeclaration[];
 };
+
+type RehearsalRequest = RehearsalRequestBase &
+  ({ mode: "migrate" } | { mode: "read-only" });
 
 type ParsedRequest = InventoryRequest | RehearsalRequest;
 

--- a/src/commands/agents.db-rehearsal.ts
+++ b/src/commands/agents.db-rehearsal.ts
@@ -44,7 +44,7 @@ import { VERSION } from "../version.js";
 const REHEARSAL_SCHEMA_VERSION = 1;
 const REHEARSAL_REQUEST_MAX_BYTES = 256 * 1024;
 const REHEARSAL_MAX_AGENT_DATABASES = 256;
-const REHEARSAL_MAX_INVENTORY_REFERENCES = 256;
+const REHEARSAL_MAX_INVENTORY_REFERENCES = 2048;
 
 type RehearsalMode = "inventory" | "migrate" | "read-only";
 

--- a/src/commands/agents.db-rehearsal.ts
+++ b/src/commands/agents.db-rehearsal.ts
@@ -1,0 +1,688 @@
+// Hidden operator contract for isolated agent-database upgrade rehearsals.
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { readByteStreamWithLimit } from "@openclaw/media-core/read-byte-stream-with-limit";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { listAgentIds, resolveAgentConfig, resolveAgentDir } from "../agents/agent-scope.js";
+import { createConfigIO } from "../config/io.js";
+import { resolveStateDir } from "../config/paths.js";
+import { resolveStorePath } from "../config/sessions/paths.js";
+import { resolveUnsuffixedSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
+import {
+  isPerAgentSessionStoreConfig,
+  listConfiguredSessionStoreAgentIds,
+} from "../config/sessions/targets.js";
+import { readFileDescriptorBounded } from "../infra/boundary-file-read.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import { isPathInside } from "../infra/path-guards.js";
+import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
+import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { writeRuntimeJson } from "../runtime.js";
+import { findOpenClawAgentDatabaseMediaMigrationRequiredError } from "../state/openclaw-agent-db-migration-required.js";
+import { withOpenClawAgentDatabaseReadOnly } from "../state/openclaw-agent-db-readonly.js";
+import {
+  listOpenClawRegisteredAgentDatabases,
+  replaceOpenClawAgentDatabaseRegistryForRehearsal,
+} from "../state/openclaw-agent-db-registry.js";
+import { readExistingAgentSchemaMeta } from "../state/openclaw-agent-db-schema-helpers.js";
+import {
+  closeOpenClawAgentDatabaseByPath,
+  migrateOpenClawAgentDatabaseForMaintenance,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import {
+  closeOpenClawStateDatabaseByPath,
+  openExistingOpenClawStateDatabaseReadOnly,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { VERSION } from "../version.js";
+
+const REHEARSAL_SCHEMA_VERSION = 1;
+const REHEARSAL_REQUEST_MAX_BYTES = 256 * 1024;
+const REHEARSAL_MAX_AGENT_DATABASES = 256;
+const REHEARSAL_MAX_INVENTORY_REFERENCES = 256;
+
+type RehearsalMode = "inventory" | "migrate" | "read-only";
+
+type PluginPersistenceDeclaration = {
+  pluginId: string;
+  kind: string;
+  copiedPath: string | null;
+  reason?: string;
+};
+
+type AgentDatabaseRequest = {
+  agentId: string;
+  copiedPath: string;
+};
+
+type InventoryRequest = {
+  schemaVersion: 1;
+  mode: "inventory";
+  stateRoot: string;
+  configPath: string;
+};
+
+type RehearsalRequest = {
+  schemaVersion: 1;
+  mode: "migrate" | "read-only";
+  privateStateRoot: string;
+  agents: AgentDatabaseRequest[];
+  pluginPersistence: PluginPersistenceDeclaration[];
+};
+
+type ParsedRequest = InventoryRequest | RehearsalRequest;
+
+type DatabaseSnapshot = {
+  userVersion: number;
+  metadataSchemaVersion: number | null;
+  role: string | null;
+  ownerAgentId: string | null;
+};
+
+type PreparedAgentDatabase = {
+  agentId: string;
+  requestedPath: string;
+  resolvedPath: string;
+  realPath: string;
+  before: DatabaseSnapshot;
+};
+
+type InventoryReference = {
+  agentId: string;
+  path: string;
+  claimKind: "agent-dir-database" | "session-store-database" | "session-store-fixed-family";
+  ownerClaim:
+    | "configured-agent-dir"
+    | "default-agent-dir"
+    | "configured-session-store"
+    | "default-session-store";
+};
+
+class AgentDatabaseRehearsalError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+    readonly unsupportedPluginPersistence?: readonly PluginPersistenceDeclaration[],
+  ) {
+    super(message);
+    this.name = "AgentDatabaseRehearsalError";
+  }
+}
+
+function fail(code: string, message: string): never {
+  throw new AgentDatabaseRehearsalError(code, message);
+}
+
+function requiredString(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  if (typeof value !== "string" || !value.trim()) {
+    fail("invalid-request", `${key} must be a non-empty string.`);
+  }
+  return value.trim();
+}
+
+function parsePluginPersistence(value: unknown): PluginPersistenceDeclaration[] {
+  if (!Array.isArray(value)) {
+    fail("invalid-request", "pluginPersistence must be an array.");
+  }
+  return value.map((entry, index) => {
+    if (!isRecord(entry)) {
+      fail("invalid-request", `pluginPersistence[${index}] must be an object.`);
+    }
+    const copiedPath = entry.copiedPath;
+    if (copiedPath !== null && (typeof copiedPath !== "string" || !copiedPath.trim())) {
+      fail("invalid-request", `pluginPersistence[${index}].copiedPath must be a string or null.`);
+    }
+    const reason = entry.reason;
+    if (reason !== undefined && (typeof reason !== "string" || !reason.trim())) {
+      fail("invalid-request", `pluginPersistence[${index}].reason must be a non-empty string.`);
+    }
+    return {
+      pluginId: requiredString(entry, "pluginId"),
+      kind: requiredString(entry, "kind"),
+      copiedPath: copiedPath === null ? null : copiedPath.trim(),
+      ...(typeof reason === "string" ? { reason: reason.trim() } : {}),
+    };
+  });
+}
+
+function parseRequest(value: unknown): ParsedRequest {
+  if (!isRecord(value)) {
+    fail("invalid-request", "request must be a JSON object.");
+  }
+  if (value.schemaVersion !== REHEARSAL_SCHEMA_VERSION) {
+    fail("unsupported-request-version", "schemaVersion must be 1.");
+  }
+  const mode = value.mode;
+  if (mode === "inventory") {
+    return {
+      schemaVersion: 1,
+      mode,
+      stateRoot: requiredString(value, "stateRoot"),
+      configPath: requiredString(value, "configPath"),
+    };
+  }
+  if (mode !== "migrate" && mode !== "read-only") {
+    fail("invalid-request", "mode must be inventory, migrate, or read-only.");
+  }
+  if (!Array.isArray(value.agents)) {
+    fail("invalid-request", "agents must be an array.");
+  }
+  if (value.agents.length > REHEARSAL_MAX_AGENT_DATABASES) {
+    fail(
+      "agent-limit-exceeded",
+      `agents exceeds the ${REHEARSAL_MAX_AGENT_DATABASES}-entry limit.`,
+    );
+  }
+  const agents = value.agents.map((entry, index) => {
+    if (!isRecord(entry)) {
+      fail("invalid-request", `agents[${index}] must be an object.`);
+    }
+    return {
+      agentId: normalizeAgentId(requiredString(entry, "agentId")),
+      copiedPath: requiredString(entry, "copiedPath"),
+    };
+  });
+  return {
+    schemaVersion: 1,
+    mode,
+    privateStateRoot: requiredString(value, "privateStateRoot"),
+    agents,
+    pluginPersistence: parsePluginPersistence(value.pluginPersistence),
+  };
+}
+
+function requireAbsoluteDirectory(
+  rawPath: string,
+  field: string,
+): { resolved: string; real: string } {
+  if (!path.isAbsolute(rawPath)) {
+    fail("path-not-absolute", `${field} must be absolute.`);
+  }
+  const resolved = path.resolve(rawPath);
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(resolved);
+  } catch (error) {
+    fail("path-unavailable", `${field} is unavailable: ${formatErrorMessage(error)}`);
+  }
+  if (!stat.isDirectory()) {
+    fail("path-not-directory", `${field} must be an existing directory.`);
+  }
+  return { resolved, real: fs.realpathSync.native(resolved) };
+}
+
+function requireAbsoluteConfigPath(rawPath: string): string {
+  if (!path.isAbsolute(rawPath)) {
+    fail("path-not-absolute", "configPath must be absolute.");
+  }
+  const resolved = path.resolve(rawPath);
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(resolved);
+  } catch (error) {
+    fail("config-unavailable", `configPath is unavailable: ${formatErrorMessage(error)}`);
+  }
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    fail("config-unavailable", "configPath must be a regular non-symlink file.");
+  }
+  return resolved;
+}
+
+function assertPathInsideRoot(root: string, candidate: string, label: string): void {
+  if (candidate !== root && !isPathInside(root, candidate)) {
+    fail("path-escape", `${label} must remain inside the private state root.`);
+  }
+}
+
+function assertPrivateDatabaseFamily(params: {
+  root: string;
+  pathname: string;
+  requireMain: boolean;
+  label: string;
+}): string {
+  const resolved = path.resolve(params.pathname);
+  assertPathInsideRoot(params.root, resolved, params.label);
+  const parentReal = fs.realpathSync.native(path.dirname(resolved));
+  assertPathInsideRoot(params.root, parentReal, `${params.label} parent`);
+  let mainReal: string | undefined;
+  for (const candidate of resolveSqliteDatabaseFilePaths(resolved)) {
+    let stat: fs.Stats;
+    try {
+      stat = fs.lstatSync(candidate);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        continue;
+      }
+      fail("path-unavailable", `${params.label} is unavailable: ${formatErrorMessage(error)}`);
+    }
+    if (stat.isSymbolicLink() || !stat.isFile() || stat.nlink !== 1) {
+      fail(
+        "path-not-private",
+        `${params.label} and its SQLite sidecars must be private regular files without symlink or hardlink aliases.`,
+      );
+    }
+    const real = fs.realpathSync.native(candidate);
+    assertPathInsideRoot(params.root, real, params.label);
+    if (candidate === resolved) {
+      mainReal = real;
+    }
+  }
+  if (params.requireMain && !mainReal) {
+    fail("database-missing", `${params.label} must be an existing SQLite file.`);
+  }
+  return mainReal ?? resolved;
+}
+
+function inspectDatabaseSnapshot(pathname: string): DatabaseSnapshot {
+  if (!fs.existsSync(pathname)) {
+    return {
+      userVersion: 0,
+      metadataSchemaVersion: null,
+      role: null,
+      ownerAgentId: null,
+    };
+  }
+  const database = openNodeSqliteDatabase(pathname, { readOnly: true });
+  try {
+    const metadata = readExistingAgentSchemaMeta(database);
+    return {
+      userVersion: readSqliteUserVersion(database),
+      metadataSchemaVersion: metadata?.schemaVersion ?? null,
+      role: metadata?.role ?? null,
+      ownerAgentId: metadata?.agentId ?? null,
+    };
+  } finally {
+    database.close();
+  }
+}
+
+function prepareAgentDatabases(
+  request: RehearsalRequest,
+  root: { resolved: string; real: string },
+): PreparedAgentDatabase[] {
+  const seen = new Set<string>();
+  return request.agents.map((entry, index) => {
+    if (!path.isAbsolute(entry.copiedPath)) {
+      fail("path-not-absolute", `agents[${index}].copiedPath must be absolute.`);
+    }
+    const requestedPath = path.resolve(entry.copiedPath);
+    assertPathInsideRoot(root.resolved, requestedPath, `agents[${index}].copiedPath`);
+    const realPath = assertPrivateDatabaseFamily({
+      root: root.real,
+      pathname: fs.realpathSync.native(requestedPath),
+      requireMain: true,
+      label: `agents[${index}].copiedPath`,
+    });
+    const compositeKey = `${entry.agentId}\0${realPath}`;
+    if (seen.has(compositeKey)) {
+      fail(
+        "duplicate-agent-database",
+        `agents[${index}] duplicates ${entry.agentId} at ${realPath}.`,
+      );
+    }
+    seen.add(compositeKey);
+    return {
+      agentId: entry.agentId,
+      requestedPath,
+      resolvedPath: requestedPath,
+      realPath,
+      before: inspectDatabaseSnapshot(realPath),
+    };
+  });
+}
+
+function compareRegistryExact(
+  expected: readonly { agentId: string; path: string; schemaVersion: number }[],
+  actual: readonly { agentId: string; path: string; schemaVersion: number }[],
+): void {
+  const key = (entry: { agentId: string; path: string; schemaVersion: number }) =>
+    `${normalizeAgentId(entry.agentId)}\0${path.resolve(entry.path)}\0${entry.schemaVersion}`;
+  const expectedKeys = expected.map(key).toSorted();
+  const actualKeys = actual.map(key).toSorted();
+  if (
+    expectedKeys.length !== actualKeys.length ||
+    expectedKeys.some((entry, index) => entry !== actualKeys[index])
+  ) {
+    fail(
+      "registry-mismatch",
+      "private agent database registry does not exactly match the manifest.",
+    );
+  }
+}
+
+function referenceKey(reference: InventoryReference): string {
+  return [reference.agentId, reference.path, reference.claimKind, reference.ownerClaim].join("\0");
+}
+
+async function runInventory(request: InventoryRequest) {
+  const root = requireAbsoluteDirectory(request.stateRoot, "stateRoot");
+  const configPath = requireAbsoluteConfigPath(request.configPath);
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    OPENCLAW_STATE_DIR: root.real,
+    OPENCLAW_CONFIG_PATH: configPath,
+  };
+  const io = createConfigIO({
+    configPath,
+    env,
+    logger: { error: () => undefined, warn: () => undefined },
+    observe: false,
+    pluginValidation: "skip",
+    shellEnvFallback: "defer",
+  });
+  const snapshot = await io.readConfigFileSnapshot();
+  if (!snapshot.valid) {
+    fail("config-invalid", "configPath could not be resolved as a valid effective config.");
+  }
+  const config = snapshot.runtimeConfig;
+  const references = new Map<string, InventoryReference>();
+  const addReference = (reference: InventoryReference) => {
+    references.set(referenceKey(reference), reference);
+    if (references.size > REHEARSAL_MAX_INVENTORY_REFERENCES) {
+      fail(
+        "inventory-limit-exceeded",
+        `inventory exceeds the ${REHEARSAL_MAX_INVENTORY_REFERENCES}-reference limit.`,
+      );
+    }
+  };
+  for (const agentId of listAgentIds(config)) {
+    const normalizedAgentId = normalizeAgentId(agentId);
+    const configuredAgentDir = Boolean(
+      resolveAgentConfig(config, normalizedAgentId)?.agentDir?.trim(),
+    );
+    const agentDir = resolveAgentDir(config, normalizedAgentId, env);
+    addReference({
+      agentId: normalizedAgentId,
+      path: path.resolve(agentDir, "openclaw-agent.sqlite"),
+      claimKind: "agent-dir-database",
+      ownerClaim: configuredAgentDir ? "configured-agent-dir" : "default-agent-dir",
+    });
+  }
+  const storeConfig = config.session?.store;
+  const configuredSessionStore = Boolean(storeConfig?.trim());
+  for (const agentId of listConfiguredSessionStoreAgentIds(config)) {
+    const normalizedAgentId = normalizeAgentId(agentId);
+    const storePath = resolveStorePath(storeConfig, { agentId: normalizedAgentId, env });
+    const target = resolveUnsuffixedSqliteTargetFromSessionStorePath(storePath);
+    addReference({
+      agentId: normalizedAgentId,
+      path: path.resolve(target.path),
+      claimKind:
+        isPerAgentSessionStoreConfig(storeConfig) || path.resolve(storePath).endsWith(".sqlite")
+          ? "session-store-database"
+          : "session-store-fixed-family",
+      ownerClaim: configuredSessionStore ? "configured-session-store" : "default-session-store",
+    });
+  }
+  const pluginPersistence: PluginPersistenceDeclaration[] =
+    config.plugins?.enabled === false
+      ? []
+      : [
+          {
+            pluginId: "*",
+            kind: "indeterminate",
+            copiedPath: null,
+            reason: "enabled plugin persistence has no manifest declaration surface",
+          },
+        ];
+  return {
+    schemaVersion: 1 as const,
+    ok: true as const,
+    mode: "inventory" as const,
+    runtimeVersion: VERSION,
+    stateRoot: resolveStateDir(env),
+    configPath,
+    references: [...references.values()].toSorted(
+      (left, right) =>
+        left.agentId.localeCompare(right.agentId) ||
+        left.path.localeCompare(right.path) ||
+        left.claimKind.localeCompare(right.claimKind),
+    ),
+    pluginPersistence,
+    complete: pluginPersistence.length === 0,
+  };
+}
+
+async function runReadOnly(
+  request: RehearsalRequest & { mode: "read-only" },
+  root: { resolved: string; real: string },
+  agents: PreparedAgentDatabase[],
+  env: NodeJS.ProcessEnv,
+) {
+  const sharedPath = resolveOpenClawStateSqlitePath(env);
+  const stateBefore = inspectDatabaseSnapshot(sharedPath);
+  const state = await openExistingOpenClawStateDatabaseReadOnly({ env });
+  if (!state) {
+    fail("shared-state-missing", "private shared state database is missing.");
+  }
+  try {
+    const results = agents.map((agent) => {
+      const result = withOpenClawAgentDatabaseReadOnly(
+        (database) => inspectDatabaseSnapshot(database.path),
+        { agentId: agent.agentId, env, path: agent.realPath },
+      );
+      if (!result.found) {
+        fail(
+          "agent-database-unreadable",
+          `${agent.agentId} at ${agent.realPath} is unavailable (${result.reason}).`,
+        );
+      }
+      return {
+        ...agent,
+        after: result.value,
+        migrated: false,
+        registry: {
+          path: agent.realPath,
+          schemaVersion: result.value.userVersion,
+        },
+      };
+    });
+    const registry = listOpenClawRegisteredAgentDatabases({
+      env,
+      includeIncompatibleSchemaVersions: true,
+    });
+    compareRegistryExact(
+      results.map((result) => ({
+        agentId: result.agentId,
+        path: result.realPath,
+        schemaVersion: result.after.userVersion,
+      })),
+      registry,
+    );
+    const stateAfter = inspectDatabaseSnapshot(sharedPath);
+    return {
+      schemaVersion: 1 as const,
+      ok: true as const,
+      mode: request.mode,
+      runtimeVersion: VERSION,
+      privateStateRoot: root.real,
+      sharedState: {
+        path: sharedPath,
+        schemaVersionBefore: stateBefore.userVersion,
+        schemaVersionAfter: stateAfter.userVersion,
+        role: stateAfter.role,
+        readOnly: true,
+      },
+      agents: results,
+      pluginPersistence: request.pluginPersistence,
+    };
+  } finally {
+    state.walMaintenance.close();
+  }
+}
+
+function runMigrate(
+  request: RehearsalRequest & { mode: "migrate" },
+  root: { resolved: string; real: string },
+  agents: PreparedAgentDatabase[],
+  env: NodeJS.ProcessEnv,
+) {
+  const sharedPath = resolveOpenClawStateSqlitePath(env);
+  assertPrivateDatabaseFamily({
+    root: root.real,
+    pathname: sharedPath,
+    requireMain: false,
+    label: "private shared state database",
+  });
+  const stateBefore = inspectDatabaseSnapshot(sharedPath);
+  const openedPaths = new Set<string>();
+  const state = openOpenClawStateDatabase({ env });
+  try {
+    const results = agents.map((agent) => {
+      try {
+        try {
+          openOpenClawAgentDatabase({ agentId: agent.agentId, env, path: agent.realPath });
+        } catch (error) {
+          if (!findOpenClawAgentDatabaseMediaMigrationRequiredError(error)) {
+            throw error;
+          }
+          migrateOpenClawAgentDatabaseForMaintenance({
+            agentId: agent.agentId,
+            env,
+            pathname: agent.realPath,
+          });
+          openOpenClawAgentDatabase({ agentId: agent.agentId, env, path: agent.realPath });
+        }
+        openedPaths.add(agent.realPath);
+        const after = inspectDatabaseSnapshot(agent.realPath);
+        return {
+          ...agent,
+          after,
+          migrated:
+            agent.before.userVersion !== after.userVersion ||
+            agent.before.metadataSchemaVersion !== after.metadataSchemaVersion,
+          registry: { path: agent.realPath, schemaVersion: after.userVersion },
+        };
+      } finally {
+        closeOpenClawAgentDatabaseByPath(agent.realPath);
+        openedPaths.delete(agent.realPath);
+      }
+    });
+    const expectedRegistry = results.map((result) => ({
+      agentId: result.agentId,
+      path: result.realPath,
+      schemaVersion: result.after.userVersion,
+    }));
+    replaceOpenClawAgentDatabaseRegistryForRehearsal({ entries: expectedRegistry, env });
+    const registry = listOpenClawRegisteredAgentDatabases({
+      env,
+      includeIncompatibleSchemaVersions: true,
+    });
+    compareRegistryExact(expectedRegistry, registry);
+    const stateAfter = inspectDatabaseSnapshot(sharedPath);
+    return {
+      schemaVersion: 1 as const,
+      ok: true as const,
+      mode: request.mode,
+      runtimeVersion: VERSION,
+      privateStateRoot: root.real,
+      sharedState: {
+        path: sharedPath,
+        schemaVersionBefore: stateBefore.userVersion,
+        schemaVersionAfter: stateAfter.userVersion,
+        role: stateAfter.role,
+        readOnly: false,
+      },
+      agents: results,
+      pluginPersistence: request.pluginPersistence,
+    };
+  } finally {
+    for (const pathname of openedPaths) {
+      closeOpenClawAgentDatabaseByPath(pathname);
+    }
+    closeOpenClawStateDatabaseByPath(state.path);
+  }
+}
+
+export async function runAgentDatabaseRehearsal(requestValue: unknown) {
+  const request = parseRequest(requestValue);
+  if (request.mode === "inventory") {
+    return await runInventory(request);
+  }
+  // Unsupported plugin state must stop before any writable shared or agent open.
+  if (request.pluginPersistence.length > 0) {
+    throw new AgentDatabaseRehearsalError(
+      "unsupported-plugin-persistence",
+      "plugin-owned persistence is unsupported by rehearsal schema v1.",
+      request.pluginPersistence,
+    );
+  }
+  const root = requireAbsoluteDirectory(request.privateStateRoot, "privateStateRoot");
+  const agents = prepareAgentDatabases(request, root);
+  const env: NodeJS.ProcessEnv = { ...process.env, OPENCLAW_STATE_DIR: root.real };
+  if (request.mode === "read-only") {
+    return await runReadOnly(request, root, agents, env);
+  }
+  return runMigrate(request, root, agents, env);
+}
+
+async function readRequestSource(source: string, stdin: AsyncIterable<unknown>): Promise<unknown> {
+  let raw: Buffer;
+  if (source === "-") {
+    raw = await readByteStreamWithLimit(stdin, {
+      maxBytes: REHEARSAL_REQUEST_MAX_BYTES,
+      onOverflow: ({ maxBytes }) =>
+        new AgentDatabaseRehearsalError("request-too-large", `request exceeds ${maxBytes} bytes.`),
+    });
+  } else {
+    const file = await fsp.open(path.resolve(source), "r");
+    try {
+      const stat = await file.stat();
+      if (!stat.isFile()) {
+        fail("request-unavailable", "request source must be a regular file.");
+      }
+      if (stat.size > REHEARSAL_REQUEST_MAX_BYTES) {
+        fail("request-too-large", `request exceeds ${REHEARSAL_REQUEST_MAX_BYTES} bytes.`);
+      }
+      raw = await readFileDescriptorBounded(file.fd, REHEARSAL_REQUEST_MAX_BYTES);
+    } finally {
+      await file.close();
+    }
+  }
+  try {
+    return JSON.parse(raw.toString("utf8")) as unknown;
+  } catch {
+    return fail("invalid-json", "request source is not valid JSON.");
+  }
+}
+
+export async function agentsDatabaseRehearsalCommand(
+  options: { request: string },
+  runtime: RuntimeEnv,
+  deps: { stdin?: AsyncIterable<unknown> } = {},
+): Promise<void> {
+  let mode: RehearsalMode | undefined;
+  try {
+    const value = await readRequestSource(options.request, deps.stdin ?? process.stdin);
+    mode =
+      isRecord(value) && typeof value.mode === "string" ? (value.mode as RehearsalMode) : undefined;
+    writeRuntimeJson(runtime, await runAgentDatabaseRehearsal(value), 0);
+  } catch (error) {
+    const typed =
+      error instanceof AgentDatabaseRehearsalError
+        ? error
+        : new AgentDatabaseRehearsalError("rehearsal-failed", formatErrorMessage(error));
+    writeRuntimeJson(
+      runtime,
+      {
+        schemaVersion: 1,
+        ok: false,
+        ...(mode ? { mode } : {}),
+        code: typed.code,
+        message: typed.message,
+        ...(typed.unsupportedPluginPersistence
+          ? { unsupportedPluginPersistence: typed.unsupportedPluginPersistence }
+          : {}),
+      },
+      0,
+    );
+    runtime.exit(1, { resetStream: process.stderr });
+  }
+}

--- a/src/commands/agents.db-rehearsal.ts
+++ b/src/commands/agents.db-rehearsal.ts
@@ -6,7 +6,6 @@ import { readByteStreamWithLimit } from "@openclaw/media-core/read-byte-stream-w
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { listAgentIds, resolveAgentConfig, resolveAgentDir } from "../agents/agent-scope.js";
 import { createConfigIO } from "../config/io.js";
-import { resolveStateDir } from "../config/paths.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { resolveUnsuffixedSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import {
@@ -75,8 +74,7 @@ type RehearsalRequestBase = {
   pluginPersistence: PluginPersistenceDeclaration[];
 };
 
-type RehearsalRequest = RehearsalRequestBase &
-  ({ mode: "migrate" } | { mode: "read-only" });
+type RehearsalRequest = RehearsalRequestBase & ({ mode: "migrate" } | { mode: "read-only" });
 
 type ParsedRequest = InventoryRequest | RehearsalRequest;
 
@@ -243,6 +241,24 @@ function assertPathInsideRoot(root: string, candidate: string, label: string): v
   }
 }
 
+function realpathExistingAncestor(pathname: string, label: string): string {
+  let current = path.resolve(pathname);
+  while (true) {
+    try {
+      return fs.realpathSync.native(current);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        fail("path-unavailable", `${label} is unavailable: ${formatErrorMessage(error)}`);
+      }
+      const parent = path.dirname(current);
+      if (parent === current) {
+        fail("path-unavailable", `${label} has no existing ancestor.`);
+      }
+      current = parent;
+    }
+  }
+}
+
 function assertPrivateDatabaseFamily(params: {
   root: string;
   pathname: string;
@@ -251,7 +267,7 @@ function assertPrivateDatabaseFamily(params: {
 }): string {
   const resolved = path.resolve(params.pathname);
   assertPathInsideRoot(params.root, resolved, params.label);
-  const parentReal = fs.realpathSync.native(path.dirname(resolved));
+  const parentReal = realpathExistingAncestor(path.dirname(resolved), `${params.label} parent`);
   assertPathInsideRoot(params.root, parentReal, `${params.label} parent`);
   let mainReal: string | undefined;
   for (const candidate of resolveSqliteDatabaseFilePaths(resolved)) {
@@ -439,7 +455,7 @@ async function runInventory(request: InventoryRequest) {
     ok: true as const,
     mode: "inventory" as const,
     runtimeVersion: VERSION,
-    stateRoot: resolveStateDir(env),
+    stateRoot: root.resolved,
     configPath,
     references: [...references.values()].toSorted(
       (left, right) =>
@@ -504,9 +520,9 @@ async function runReadOnly(
       ok: true as const,
       mode: request.mode,
       runtimeVersion: VERSION,
-      privateStateRoot: root.real,
+      privateStateRoot: root.resolved,
       sharedState: {
-        path: sharedPath,
+        path: path.join(root.resolved, "state", "openclaw.sqlite"),
         schemaVersionBefore: stateBefore.userVersion,
         schemaVersionAfter: stateAfter.userVersion,
         role: stateAfter.role,
@@ -584,9 +600,9 @@ function runMigrate(
       ok: true as const,
       mode: request.mode,
       runtimeVersion: VERSION,
-      privateStateRoot: root.real,
+      privateStateRoot: root.resolved,
       sharedState: {
-        path: sharedPath,
+        path: path.join(root.resolved, "state", "openclaw.sqlite"),
         schemaVersionBefore: stateBefore.userVersion,
         schemaVersionAfter: stateAfter.userVersion,
         role: stateAfter.role,

--- a/src/commands/agents.db-rehearsal.ts
+++ b/src/commands/agents.db-rehearsal.ts
@@ -1,33 +1,31 @@
 // Hidden operator contract for isolated agent-database upgrade rehearsals.
 import fs from "node:fs";
-import fsp from "node:fs/promises";
 import path from "node:path";
-import { readByteStreamWithLimit } from "@openclaw/media-core/read-byte-stream-with-limit";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { listAgentIds, resolveAgentConfig, resolveAgentDir } from "../agents/agent-scope.js";
 import { createConfigIO } from "../config/io.js";
-import { resolveStorePath } from "../config/sessions/paths.js";
+import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
 import { resolveUnsuffixedSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import {
   isPerAgentSessionStoreConfig,
   listConfiguredSessionStoreAgentIds,
 } from "../config/sessions/targets.js";
-import { readFileDescriptorBounded } from "../infra/boundary-file-read.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
 import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
 import { normalizeAgentId } from "../routing/session-key.js";
-import type { RuntimeEnv } from "../runtime.js";
-import { writeRuntimeJson } from "../runtime.js";
 import { findOpenClawAgentDatabaseMediaMigrationRequiredError } from "../state/openclaw-agent-db-migration-required.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../state/openclaw-agent-db-readonly.js";
 import {
   listOpenClawRegisteredAgentDatabases,
   replaceOpenClawAgentDatabaseRegistryForRehearsal,
 } from "../state/openclaw-agent-db-registry.js";
-import { readExistingAgentSchemaMeta } from "../state/openclaw-agent-db-schema-helpers.js";
+import {
+  hasOpenClawAgentApplicationSchema,
+  readExistingAgentSchemaMeta,
+} from "../state/openclaw-agent-db-schema-helpers.js";
 import {
   closeOpenClawAgentDatabaseByPath,
   migrateOpenClawAgentDatabaseForMaintenance,
@@ -42,11 +40,8 @@ import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths
 import { VERSION } from "../version.js";
 
 const REHEARSAL_SCHEMA_VERSION = 1;
-const REHEARSAL_REQUEST_MAX_BYTES = 256 * 1024;
 const REHEARSAL_MAX_AGENT_DATABASES = 256;
 const REHEARSAL_MAX_INVENTORY_REFERENCES = 2048;
-
-type RehearsalMode = "inventory" | "migrate" | "read-only";
 
 type PluginPersistenceDeclaration = {
   pluginId: string;
@@ -106,7 +101,7 @@ type InventoryReference = {
     | "default-session-store";
 };
 
-class AgentDatabaseRehearsalError extends Error {
+export class AgentDatabaseRehearsalError extends Error {
   constructor(
     readonly code: string,
     message: string,
@@ -182,7 +177,7 @@ function parseRequest(value: unknown): ParsedRequest {
       `agents exceeds the ${REHEARSAL_MAX_AGENT_DATABASES}-entry limit.`,
     );
   }
-  const agents = value.agents.map((entry, index) => {
+  const agents: AgentDatabaseRequest[] = value.agents.map((entry, index) => {
     if (!isRecord(entry)) {
       fail("invalid-request", `agents[${index}] must be an object.`);
     }
@@ -331,9 +326,7 @@ function inspectDatabaseSnapshot(pathname: string): DatabaseSnapshot {
 function hasApplicationSchema(pathname: string): boolean {
   const database = openNodeSqliteDatabase(pathname, { readOnly: true });
   try {
-    return Boolean(
-      database.prepare("SELECT 1 FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' LIMIT 1").get(),
-    );
+    return hasOpenClawAgentApplicationSchema(database);
   } finally {
     database.close();
   }
@@ -470,7 +463,10 @@ async function runInventory(request: InventoryRequest) {
   const configuredSessionStore = Boolean(storeConfig?.trim());
   for (const agentId of listConfiguredSessionStoreAgentIds(config)) {
     const normalizedAgentId = normalizeAgentId(agentId);
-    const storePath = resolveStorePath(storeConfig, { agentId: normalizedAgentId, env });
+    const storePath = resolveSessionStorePathCore(storeConfig, {
+      agentId: normalizedAgentId,
+      env,
+    });
     const target = resolveUnsuffixedSqliteTargetFromSessionStorePath(storePath);
     addReference({
       agentId: normalizedAgentId,
@@ -682,68 +678,4 @@ export async function runAgentDatabaseRehearsal(requestValue: unknown) {
     return await runReadOnly(request, root, agents, env);
   }
   return runMigrate(request, root, agents, env);
-}
-
-async function readRequestSource(source: string, stdin: AsyncIterable<unknown>): Promise<unknown> {
-  let raw: Buffer;
-  if (source === "-") {
-    raw = await readByteStreamWithLimit(stdin, {
-      maxBytes: REHEARSAL_REQUEST_MAX_BYTES,
-      onOverflow: ({ maxBytes }) =>
-        new AgentDatabaseRehearsalError("request-too-large", `request exceeds ${maxBytes} bytes.`),
-    });
-  } else {
-    const file = await fsp.open(path.resolve(source), "r");
-    try {
-      const stat = await file.stat();
-      if (!stat.isFile()) {
-        fail("request-unavailable", "request source must be a regular file.");
-      }
-      if (stat.size > REHEARSAL_REQUEST_MAX_BYTES) {
-        fail("request-too-large", `request exceeds ${REHEARSAL_REQUEST_MAX_BYTES} bytes.`);
-      }
-      raw = await readFileDescriptorBounded(file.fd, REHEARSAL_REQUEST_MAX_BYTES);
-    } finally {
-      await file.close();
-    }
-  }
-  try {
-    return JSON.parse(raw.toString("utf8")) as unknown;
-  } catch {
-    return fail("invalid-json", "request source is not valid JSON.");
-  }
-}
-
-export async function agentsDatabaseRehearsalCommand(
-  options: { request: string },
-  runtime: RuntimeEnv,
-  deps: { stdin?: AsyncIterable<unknown> } = {},
-): Promise<void> {
-  let mode: RehearsalMode | undefined;
-  try {
-    const value = await readRequestSource(options.request, deps.stdin ?? process.stdin);
-    mode =
-      isRecord(value) && typeof value.mode === "string" ? (value.mode as RehearsalMode) : undefined;
-    writeRuntimeJson(runtime, await runAgentDatabaseRehearsal(value), 0);
-  } catch (error) {
-    const typed =
-      error instanceof AgentDatabaseRehearsalError
-        ? error
-        : new AgentDatabaseRehearsalError("rehearsal-failed", formatErrorMessage(error));
-    writeRuntimeJson(
-      runtime,
-      {
-        schemaVersion: 1,
-        ok: false,
-        ...(mode ? { mode } : {}),
-        code: typed.code,
-        message: typed.message,
-        ...(typed.unsupportedPluginPersistence
-          ? { unsupportedPluginPersistence: typed.unsupportedPluginPersistence }
-          : {}),
-      },
-      0,
-    );
-    runtime.exit(1, { resetStream: process.stderr });
-  }
 }

--- a/src/state/openclaw-agent-db-maintenance.ts
+++ b/src/state/openclaw-agent-db-maintenance.ts
@@ -70,6 +70,7 @@ export function assertOpenClawAgentDatabaseForMaintenance(
 /** Upgrade or repair a supported owned schema before strict offline maintenance. */
 export function migrateOpenClawAgentDatabaseForMaintenance(options: {
   agentId: string;
+  env?: NodeJS.ProcessEnv;
   pathname: string;
 }): void {
   const agentId = normalizeAgentId(options.agentId);
@@ -99,6 +100,7 @@ export function migrateOpenClawAgentDatabaseForMaintenance(options: {
     }
     ensureOpenClawAgentDatabaseSchema(database, {
       agentId,
+      ...(options.env ? { env: options.env } : {}),
       path: options.pathname,
     });
     assertOpenClawAgentDatabaseForMaintenance(database, {

--- a/src/state/openclaw-agent-db-registry.ts
+++ b/src/state/openclaw-agent-db-registry.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { isPathInside } from "../infra/path-guards.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import {
   assertAgentDeletionPathFence,
   prepareAgentDeletionPathFence,
@@ -638,6 +639,62 @@ export function registerOpenClawAgentDatabase(params: {
       );
     },
     { env: params.env },
+  );
+  invalidateRegisteredAgentDatabasesMemo({ env: params.env });
+}
+
+/** Atomically replace one state root's registry with an exact reviewed set. */
+export function replaceOpenClawAgentDatabaseRegistryForRehearsal(params: {
+  entries: readonly {
+    agentId: string;
+    path: string;
+    schemaVersion: number;
+  }[];
+  env?: NodeJS.ProcessEnv;
+}): void {
+  const prepared = params.entries.map((entry) => {
+    const agentId = normalizeAgentId(entry.agentId);
+    const pathname = path.resolve(entry.path);
+    const deletionFence = prepareAgentDeletionPathFence(
+      { agentId, path: pathname },
+      { env: params.env },
+    );
+    const sizeBytes = (() => {
+      try {
+        return statSync(pathname).size;
+      } catch {
+        return null;
+      }
+    })();
+    return {
+      agentId,
+      deletionFence,
+      path: pathname,
+      schemaVersion: entry.schemaVersion,
+      sizeBytes,
+    };
+  });
+  const lastSeenAt = Date.now();
+  runOpenClawStateWriteTransaction(
+    (database) => {
+      const db = getNodeSqliteKysely<OpenClawAgentRegistryDatabase>(database.db);
+      executeSqliteQuerySync(database.db, db.deleteFrom("agent_databases"));
+      for (const entry of prepared) {
+        assertAgentDeletionPathFence(database.db, entry.deletionFence);
+        executeSqliteQuerySync(
+          database.db,
+          db.insertInto("agent_databases").values({
+            agent_id: entry.agentId,
+            path: entry.path,
+            schema_version: entry.schemaVersion,
+            last_seen_at: lastSeenAt,
+            size_bytes: entry.sizeBytes,
+          }),
+        );
+      }
+    },
+    { env: params.env },
+    { operationLabel: "agent.registry.replace" },
   );
   invalidateRegisteredAgentDatabasesMemo({ env: params.env });
 }

--- a/src/state/openclaw-agent-db-schema-helpers.ts
+++ b/src/state/openclaw-agent-db-schema-helpers.ts
@@ -203,15 +203,20 @@ export function assertSupportedAgentSchemaVersion(db: DatabaseSync, pathname: st
   }
 }
 
+/** Whether a database contains any non-SQLite-owned schema object. */
+export function hasOpenClawAgentApplicationSchema(db: DatabaseSync): boolean {
+  return Boolean(
+    db.prepare("SELECT 1 FROM sqlite_master WHERE substr(name, 1, 7) <> 'sqlite_' LIMIT 1").get(),
+  );
+}
+
 /** Refuse steady-state reads until Doctor has completed the v16 media cutover. */
 export function assertCanonicalAgentMediaPersistenceVersion(
   db: DatabaseSync,
   pathname: string,
 ): void {
   const userVersion = readSqliteUserVersion(db);
-  const hasApplicationSchema = db
-    .prepare("SELECT 1 FROM sqlite_master WHERE substr(name, 1, 7) <> 'sqlite_' LIMIT 1")
-    .get();
+  const hasApplicationSchema = hasOpenClawAgentApplicationSchema(db);
   const isNewUnownedDatabase =
     userVersion === 0 && readExistingAgentSchemaMeta(db) === null && !hasApplicationSchema;
   if (userVersion < OPENCLAW_AGENT_SCHEMA_VERSION && !isNewUnownedDatabase) {

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -35,6 +35,7 @@ import {
   assertOpenClawAgentCurrentRuntimeSchema,
   assertSupportedAgentSchemaVersion,
   ensureSessionKeyContractSchemaInTransaction,
+  hasOpenClawAgentApplicationSchema,
   readExistingAgentSchemaMeta,
   repairAndAssertOpenClawAgentV14SchemaForMigration,
 } from "./openclaw-agent-db-schema-helpers.js";
@@ -553,9 +554,7 @@ export function assertAgentDatabaseIntegrityBeforeMutation(
 ): void {
   database.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
   const userVersion = readSqliteUserVersion(database);
-  const hasApplicationSchema = database
-    .prepare("SELECT 1 FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' LIMIT 1")
-    .get();
+  const hasApplicationSchema = hasOpenClawAgentApplicationSchema(database);
   const migrationPending =
     (userVersion === 0 && hasApplicationSchema) ||
     (userVersion > 0 && userVersion < OPENCLAW_AGENT_SCHEMA_VERSION);


### PR DESCRIPTION
## What Problem This Solves

Resolves an operational gap where release managers could not prove agent-database upgrade and rollback compatibility against private clones without reimplementing OpenClaw's config, path, ownership, migration, registry, and plugin-persistence rules.

## Why This Change Was Made

Adds a hidden, schema-versioned `openclaw agents db-rehearsal` operator contract with three modes: read-only effective-path inventory, isolated canonical migration, and prior-build readback. Explicit private-root fencing, composite `(agentId,path)` registry replacement, fresh-vs-existing provenance, and fail-closed plugin declarations keep the rehearsal deterministic without exposing a public configuration surface or touching live state.

## User Impact

Release automation can inventory every configured/default agent and session database family, migrate up to 256 explicit private clones through OpenClaw's canonical owners, then run a non-migrating compatibility read with the previous build. Enabled plugin persistence remains deliberately indeterminate until an operator supplies a complete audited declaration; v1 refuses every nonempty declaration.

## Evidence

- Blacksmith Testbox `tbx_01kzrzqsdg5vbq9w8qvb81dvmp` ([run](https://github.com/openclaw/openclaw/actions/runs/31520506500)):
  - focused Vitest: 25 CLI registration tests + 10 rehearsal contract tests passed
  - `pnpm tsgo:core` passed
  - `pnpm tsgo:core:test` passed after discriminated-union correction
  - targeted OXLint and formatting passed
  - full `pnpm build` passed, including all 152 Plugin SDK export checks
- Source-blind CLI behavior validation passed:
  - inventory returned four owner-produced references, an indeterminate plugin declaration, and created no database
  - two distinct private clone paths for one agent migrated and registered exactly
  - stdin read-only replay preserved SQLite main-file hashes and schema versions
  - plugin persistence and path escape failed before private shared-state creation
  - `creation:fresh` initialized an empty v0/unowned SQLite clone and read back current ownership; owned-as-fresh and unowned-as-existing both failed closed
- Autoreview: clean after each accepted change; latest pass reported no findings (confidence 0.98).

Proof note: the broad changed gate independently reports 17 generated Plugin SDK API baseline drifts on current main despite this PR touching no SDK exports. The full build's declaration/export gate passed; this PR does not regenerate unrelated baselines.
