### PR TITLE
refactor(gateway): unify terminal chat broadcasts

### DIFF
--- a/src/gateway/server-methods/chat-broadcast.test.ts
+++ b/src/gateway/server-methods/chat-broadcast.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vitest";
+import { broadcastChatError, broadcastChatFinal } from "./chat-broadcast.js";
+import type { GatewayRequestContext } from "./types.js";
+
+function createContext(seq = 0) {
+  const order: string[] = [];
+  const agentRunSeq = new Map<string, number>([["run-1", seq]]);
+  const broadcast = vi.fn<GatewayRequestContext["broadcast"]>(() => {
+    order.push("broadcast");
+  });
+  const nodeSendToSession = vi.fn<GatewayRequestContext["nodeSendToSession"]>(() => {
+    order.push("node");
+  });
+  const deleteSpy = vi.spyOn(agentRunSeq, "delete").mockImplementation((key) => {
+    order.push("delete");
+    return Map.prototype.delete.call(agentRunSeq, key);
+  });
+
+  return {
+    context: {
+      agentRunSeq,
+      broadcast,
+      nodeSendToSession,
+      getRuntimeConfig: () => ({ agents: { list: [{ id: "main", default: true }] } }),
+    },
+    order,
+    deleteSpy,
+  };
+}
+
+describe("chat terminal broadcasts", () => {
+  it("projects global final payloads and fans out one object to both delivery keys", () => {
+    const { context, order, deleteSpy } = createContext(7);
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "done" }],
+    };
+
+    broadcastChatFinal({
+      context,
+      runId: "run-1",
+      sessionKey: "global",
+      agentId: "main",
+      message,
+    });
+
+    const payload = context.broadcast.mock.calls[0]?.[1];
+    expect(payload).toEqual({
+      runId: "run-1",
+      sessionKey: "global",
+      agentId: "main",
+      seq: 8,
+      state: "final",
+      message,
+    });
+    expect(context.broadcast).toHaveBeenCalledWith("chat", payload, {
+      sessionKeys: ["agent:main:global", "global"],
+    });
+    expect(context.nodeSendToSession.mock.calls).toEqual([
+      ["agent:main:global", "chat", payload],
+      ["global", "chat", payload],
+    ]);
+    expect(context.nodeSendToSession.mock.calls[0]?.[2]).toBe(payload);
+    expect(context.nodeSendToSession.mock.calls[1]?.[2]).toBe(payload);
+    expect(order).toEqual(["broadcast", "node", "node", "delete"]);
+    expect(deleteSpy).toHaveBeenCalledWith("run-1");
+    expect(context.agentRunSeq.has("run-1")).toBe(false);
+  });
+
+  it("emits canonical error payloads without message or agentId", () => {
+    const { context } = createContext(2);
+
+    broadcastChatError({
+      context,
+      runId: "run-1",
+      sessionKey: "agent:main:main",
+      agentId: "main",
+      errorMessage: "provider unavailable",
+    });
+
+    const payload = context.broadcast.mock.calls[0]?.[1];
+    expect(payload).toEqual({
+      runId: "run-1",
+      sessionKey: "agent:main:main",
+      seq: 3,
+      state: "error",
+      errorMessage: "provider unavailable",
+    });
+    expect(payload).not.toHaveProperty("message");
+    expect(payload).not.toHaveProperty("agentId");
+    expect(context.broadcast).toHaveBeenCalledWith("chat", payload, {
+      sessionKeys: ["agent:main:main"],
+    });
+    expect(context.nodeSendToSession).toHaveBeenCalledWith("agent:main:main", "chat", payload);
+    expect(context.nodeSendToSession.mock.calls[0]?.[2]).toBe(payload);
+  });
+
+  it("retains the incremented sequence when websocket broadcast throws", () => {
+    const { context, deleteSpy } = createContext(4);
+    context.broadcast.mockImplementation(() => {
+      throw new Error("websocket failed");
+    });
+
+    expect(() =>
+      broadcastChatFinal({
+        context,
+        runId: "run-1",
+        sessionKey: "agent:main:main",
+      }),
+    ).toThrow("websocket failed");
+
+    expect(context.agentRunSeq.get("run-1")).toBe(5);
+    expect(context.nodeSendToSession).not.toHaveBeenCalled();
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it("retains the incremented sequence when node fanout throws", () => {
+    const { context, deleteSpy } = createContext(9);
+    context.nodeSendToSession.mockImplementation(() => {
+      throw new Error("node failed");
+    });
+
+    expect(() =>
+      broadcastChatError({
+        context,
+        runId: "run-1",
+        sessionKey: "agent:main:main",
+        errorMessage: "failed",
+      }),
+    ).toThrow("node failed");
+
+    expect(context.broadcast).toHaveBeenCalledOnce();
+    expect(context.agentRunSeq.get("run-1")).toBe(10);
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server-methods/chat-broadcast.ts
+++ b/src/gateway/server-methods/chat-broadcast.ts
@@ -65,22 +65,30 @@ export function sendGlobalAwareNodeChatPayload(params: {
   }
 }
 
-export function broadcastChatFinal(params: {
+type ChatBroadcastParams = {
   context: ChatBroadcastContext;
   runId: string;
   sessionKey: string;
   agentId?: string;
-  message?: Record<string, unknown>;
-}): void {
+};
+
+type ChatTerminal =
+  | { state: "final"; message?: Record<string, unknown> }
+  | { state: "error"; errorMessage?: string };
+
+function broadcastChatTerminal(params: ChatBroadcastParams & ChatTerminal): void {
   const seq = nextChatSeq(params.context, params.runId);
   const payloadAgentId = params.sessionKey === "global" ? params.agentId : undefined;
+  const terminal =
+    params.state === "final"
+      ? { state: params.state, message: projectChatDisplayMessage(params.message) }
+      : { state: params.state, errorMessage: params.errorMessage };
   const payload = {
     runId: params.runId,
     sessionKey: params.sessionKey,
     ...(payloadAgentId ? { agentId: payloadAgentId } : {}),
     seq,
-    state: "final" as const,
-    message: projectChatDisplayMessage(params.message),
+    ...terminal,
   };
   params.context.broadcast("chat", payload, {
     sessionKeys: resolveChatSessionKeys({
@@ -97,6 +105,12 @@ export function broadcastChatFinal(params: {
     payload,
   });
   params.context.agentRunSeq.delete(params.runId);
+}
+
+export function broadcastChatFinal(
+  params: ChatBroadcastParams & { message?: Record<string, unknown> },
+): void {
+  broadcastChatTerminal({ ...params, state: "final" });
 }
 
 export function isBtwReplyPayload(payload: ReplyPayload | undefined): payload is ReplyPayload & {
@@ -139,38 +153,8 @@ export function broadcastSideResult(params: {
   });
 }
 
-export function broadcastChatError(params: {
-  context: ChatBroadcastContext;
-  runId: string;
-  sessionKey: string;
-  agentId?: string;
-  errorMessage?: string;
-}): void {
-  const seq = nextChatSeq(params.context, params.runId);
-  const payloadAgentId = params.sessionKey === "global" ? params.agentId : undefined;
-  const payload = {
-    runId: params.runId,
-    sessionKey: params.sessionKey,
-    ...(payloadAgentId ? { agentId: payloadAgentId } : {}),
-    seq,
-    state: "error" as const,
-    errorMessage: params.errorMessage,
-  };
-  params.context.broadcast("chat", payload, {
-    sessionKeys: resolveChatSessionKeys({
-      context: params.context,
-      sessionKey: params.sessionKey,
-      agentId: payloadAgentId,
-    }),
-  });
-  sendGlobalAwareNodeChatPayload({
-    context: params.context,
-    sessionKey: params.sessionKey,
-    agentId: payloadAgentId,
-    event: "chat",
-    payload,
-  });
-  params.context.agentRunSeq.delete(params.runId);
+export function broadcastChatError(params: ChatBroadcastParams & { errorMessage?: string }): void {
+  broadcastChatTerminal({ ...params, state: "error" });
 }
 
 export function isSourceReplyTranscriptMirrorPayload(payload: ReplyPayload | undefined): boolean {

--- a/src/gateway/server.node-chat-subscriptions.test.ts
+++ b/src/gateway/server.node-chat-subscriptions.test.ts
@@ -7,7 +7,7 @@ import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-cha
 import { pairDeviceIdentity } from "./device-authz.test-helpers.js";
 import { describeWithGatewayServer } from "./server.node-pairing.test-support.js";
 import { connectGatewayClient } from "./test-helpers.e2e.js";
-import { installGatewayTestHooks } from "./test-helpers.js";
+import { dispatchInboundMessageMock, installGatewayTestHooks } from "./test-helpers.js";
 
 installGatewayTestHooks({ scope: "suite" });
 
@@ -127,6 +127,137 @@ describe("gateway node chat subscriptions", () => {
       } finally {
         await first?.stopAndWait();
         await reconnected?.stopAndWait();
+      }
+    });
+
+    test("delivers final and error terminals through one canonical node subscription", async () => {
+      const paired = await pairDeviceIdentity({
+        name: "canonical-chat-terminal-fanout",
+        role: "node",
+        scopes: [],
+        clientId: GATEWAY_CLIENT_NAMES.NODE_HOST,
+        clientMode: GATEWAY_CLIENT_MODES.NODE,
+      });
+      const pairing = await requestNodePairing({
+        nodeId: paired.identity.deviceId,
+        platform: "macos",
+        deviceFamily: "Mac",
+        commands: [],
+      });
+      await approveNodePairing(pairing.request.requestId, {
+        callerScopes: ["operator.pairing", "operator.write", "operator.admin"],
+      });
+
+      const events: ReceivedNodeEvent[] = [];
+      let node: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
+      let operator: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
+      const terminalPayloads = (runId: string) =>
+        events
+          .filter(
+            (event) =>
+              event.event === "chat" &&
+              (event.payload as { runId?: string } | undefined)?.runId === runId,
+          )
+          .map((event) => event.payload as Record<string, unknown>);
+
+      try {
+        node = await connectGatewayClient({
+          url: `ws://127.0.0.1:${getStarted().port}`,
+          token: "secret",
+          role: "node",
+          clientName: GATEWAY_CLIENT_NAMES.NODE_HOST,
+          clientDisplayName: "canonical terminal fanout node",
+          clientVersion: "1.0.0",
+          platform: "macos",
+          deviceFamily: "Mac",
+          mode: GATEWAY_CLIENT_MODES.NODE,
+          scopes: [],
+          commands: [],
+          deviceIdentity: paired.identity,
+          onEvent: (event) => events.push(event),
+        });
+        operator = await connectGatewayClient({
+          url: `ws://127.0.0.1:${getStarted().port}`,
+          token: "secret",
+          role: "operator",
+          scopes: ["operator.write"],
+        });
+        await node.request("node.event", {
+          event: "chat.subscribe",
+          payload: { sessionKey: " Main " },
+        });
+
+        dispatchInboundMessageMock.mockImplementationOnce(async (...args: unknown[]) => {
+          const [params] = args as [
+            {
+              dispatcher: {
+                sendFinalReply: (payload: { text: string }) => boolean;
+                markComplete: () => void;
+                waitForIdle: () => Promise<void>;
+                getQueuedCounts: () => { final: number; block: number; tool: number };
+              };
+            },
+          ];
+          params.dispatcher.sendFinalReply({ text: "node subscription final" });
+          params.dispatcher.markComplete();
+          await params.dispatcher.waitForIdle();
+          return { queuedFinal: true, counts: params.dispatcher.getQueuedCounts() };
+        });
+        const finalRunId = "canonical-node-terminal-final";
+        const finalStarted = await operator.request<{ runId: string; status: string }>(
+          "chat.send",
+          {
+            sessionKey: "main",
+            message: "deliver a final terminal",
+            idempotencyKey: finalRunId,
+          },
+        );
+        expect(finalStarted).toMatchObject({ runId: finalRunId, status: "started" });
+        await vi.waitFor(() => expect(terminalPayloads(finalRunId)).toHaveLength(1));
+        expect(terminalPayloads(finalRunId)[0]).toMatchObject({
+          runId: finalRunId,
+          sessionKey: "agent:main:main",
+          state: "final",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "node subscription final" }],
+          },
+        });
+
+        const errorRunId = "canonical-node-terminal-error";
+        dispatchInboundMessageMock.mockRejectedValueOnce(new Error("node dispatch rejected"));
+        const errorStarted = await operator.request<{ runId: string; status: string }>(
+          "chat.send",
+          {
+            sessionKey: "main",
+            message: "deliver an error terminal",
+            idempotencyKey: errorRunId,
+          },
+        );
+        expect(errorStarted).toMatchObject({ runId: errorRunId, status: "started" });
+        await vi.waitFor(() => expect(terminalPayloads(errorRunId)).toHaveLength(1));
+        await node.request("node.event", {
+          event: "chat.subscribe",
+          payload: { sessionKey: "main" },
+        });
+
+        expect(terminalPayloads(finalRunId)).toHaveLength(1);
+        expect(terminalPayloads(errorRunId)).toHaveLength(1);
+        const errorPayload = terminalPayloads(errorRunId)[0];
+        if (!errorPayload) {
+          throw new Error("expected the node error terminal");
+        }
+        expect(errorPayload).toMatchObject({
+          runId: errorRunId,
+          sessionKey: "agent:main:main",
+          state: "error",
+        });
+        expect(errorPayload.errorMessage).toContain("node dispatch rejected");
+        expect(errorPayload).not.toHaveProperty("message");
+      } finally {
+        dispatchInboundMessageMock.mockReset();
+        await operator?.stopAndWait();
+        await node?.stopAndWait();
       }
     });
   });


### PR DESCRIPTION
## What Problem This Solves

The final and error chat terminal paths independently implemented the same sequence, delivery, and cleanup pipeline. That duplication made it easy for websocket and node subscribers, global-session aliases, or run-sequence cleanup to drift between terminal outcomes.

## Why This Change Was Made

This introduces one private discriminated terminal broadcaster while preserving the public final and error entry points. Side-result delivery remains separate, and the existing throw-before-cleanup behavior is explicitly covered.

Production LOC: +21/-37 (net -16) | Tests: +268/-1 (net +267)

## User Impact

No intended user-visible behavior change. Terminal chat delivery now has one canonical implementation for payload identity, ordering, subscription fanout, and sequence cleanup.

## Evidence

- [x] AI-assisted; implementation and tests reviewed against the owner boundary.
- Exact head: `e8c2417ad5276699c229898f0fed081936316d1f`.
- Direct terminal-broadcast regression tests cover final/global/default-agent routing, final projection, both delivery keys, canonical error payload shape, object identity, sequence order, and throw/non-cleanup behavior.
- Real ephemeral-Gateway coverage observes one final and one dispatch-rejection error terminal through the same paired-node `chat.subscribe` subscription, including the projected final assistant message and error payload with no `message` field.
- Blacksmith Testbox workflow [31533568932](https://github.com/openclaw/openclaw/actions/runs/31533568932), job [93919179894](https://github.com/openclaw/openclaw/actions/runs/31533568932/job/93919179894): full success at the exact head. The six-file focused Gateway suite passed 210/210, `pnpm check:test-types` passed, and the exact-head changed gate across all three PR files passed. `Run Testbox`, SSH cleanup, post steps, runner completion, and job completion were all green.
- AWS Crabbox run `run_fc3e1a10dc1e`: exit 0 in 7m9.356s at the exact head. The private-QA build passed, `gateway-rpc-chat` passed 1/1, and built/launcher version and help smokes passed.
- `provider-http-503-visible-failure` was intentionally excluded from the final proof because its current-main harness is self-contradictory: `extensions/qa-lab/src/suite-runtime-transport.ts:29-31` throws on every classified failure reply before `qa/scenarios/channels/provider-http-503-visible-failure.yaml:76-83` can match the expected sanitized failure text. The harness files are unchanged by this PR.
- Follow-up: repair `provider-http-503-visible-failure` to await and inspect its expected classified failure reply without using the success-only `waitForOutboundMessage` helper.

## Scope

- Canonicalizes only final/error terminal chat broadcasts.
- Preserves final-only display projection, error payload shape, global/default-agent delivery keys, websocket-before-node ordering, payload object identity, sequence allocation/deletion, and throw/non-cleanup semantics.
- No protocol, UI, schema, lifecycle, abort, injection, side-result, docs, or changelog changes.
