### PR TITLE
fix(scripts): keep bundled channel smoke standalone

### DIFF
--- a/scripts/test-built-bundled-channel-entry-smoke.mts
+++ b/scripts/test-built-bundled-channel-entry-smoke.mts
@@ -6,9 +6,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { collectRootPackageExcludedExtensionDirs } from "./lib/bundled-plugin-build-entries.mjs";
 import { parsePackageRootArg } from "./lib/package-root-args.mts";
+// Keep this prepack smoke independent of workspace package links.
+import { isRecord } from "./lib/record-shared.mjs";
 import { installProcessWarningFilter } from "./process-warning-filter.mts";
 
 installProcessWarningFilter();

--- a/test/openclaw-prepack.test.ts
+++ b/test/openclaw-prepack.test.ts
@@ -24,6 +24,79 @@ import { useAutoCleanupTempDirTracker } from "./helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
+const standaloneBundledChannelSmokeFiles = [
+  "scripts/test-built-bundled-channel-entry-smoke.mts",
+  "scripts/lib/bundled-plugin-build-entries.mjs",
+  "scripts/lib/bundled-plugin-paths.mjs",
+  "scripts/lib/optional-bundled-clusters.mjs",
+  "scripts/lib/package-root-args.mts",
+  "scripts/lib/record-shared.mjs",
+  "scripts/process-warning-filter.mts",
+];
+
+function runStandaloneBundledChannelSmoke(entrySource: string) {
+  const rootDir = tempDirs.make("openclaw-prepack-standalone-smoke-");
+  for (const relativePath of standaloneBundledChannelSmokeFiles) {
+    const destination = path.join(rootDir, relativePath);
+    mkdirSync(path.dirname(destination), { recursive: true });
+    copyFileSync(path.join(process.cwd(), relativePath), destination);
+  }
+
+  const packageRoot = path.join(rootDir, "package");
+  const extensionRoot = path.join(packageRoot, "dist", "extensions", "fixture-channel");
+  mkdirSync(extensionRoot, { recursive: true });
+  writeFileSync(path.join(packageRoot, "package.json"), '{"files":[]}\n');
+  writeFileSync(
+    path.join(extensionRoot, "package.json"),
+    `${JSON.stringify({
+      name: "@openclaw/fixture-channel",
+      openclaw: { channel: true, extensions: ["./index.ts"] },
+    })}\n`,
+  );
+  writeFileSync(path.join(extensionRoot, "index.js"), entrySource);
+
+  return spawnSync(
+    process.execPath,
+    [
+      path.join(rootDir, "scripts", "test-built-bundled-channel-entry-smoke.mts"),
+      "--package-root",
+      packageRoot,
+    ],
+    {
+      cwd: rootDir,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        OPENCLAW_BUNDLED_CHANNEL_SMOKE_INSTALLED_LAYOUT: "1",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+}
+
+describe("standalone bundled channel smoke", () => {
+  it("runs without workspace packages linked at the root", () => {
+    const result = runStandaloneBundledChannelSmoke(`
+      export default {
+        kind: "bundled-channel-entry",
+        loadChannelPlugin() {
+          return { id: "fixture-channel" };
+        },
+      };
+    `);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("channel=1");
+  });
+
+  it("rejects a non-record channel entry default export", () => {
+    const result = runStandaloneBundledChannelSmoke("export default [];\n");
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("AssertionError");
+  });
+});
+
 describe("collectSourcePackWorkspaceDependencyErrors", () => {
   it("rejects the plain source pack that pnpm rewrites without bundling @openclaw/ai", () => {
     const rootDir = tempDirs.make("openclaw-source-pack-workspace-");


### PR DESCRIPTION
## Summary

- restore the bundled channel prepack smoke as a standalone script by using the checked-in dependency-free record helper
- add a real-process prepack regression that copies the script closure into an isolated root with no workspace packages linked
- retain the existing assertion and add a negative control for non-record channel entries

## Root cause

PR #121005 / `c70aee247e831d21895f5ea3dda7497c50af0721` converted the smoke from `.mjs` to TypeScript and replaced its local record guard with a static `@openclaw/normalization-core` import. The root package neither declares nor links that workspace package, so direct supported prepack execution fails during module loading before package-root inspection.

This uses `scripts/lib/record-shared.mjs`, which is dependency-free and already serves standalone/copied script boundaries. It deliberately does not add a published root dependency.

## Validation

- Node 24.15.0 focused prepack suite: 15/15 passed
- source-blind behavior contract: 4/4 passed, including the invalid-export negative control
- repository-routed changed-file checks: passed (typecheck, lint, formatting, dependency/coercion guards): https://github.com/openclaw/openclaw/actions/runs/31523994791
- real prepack + `npm pack` + transitive install with the current OCM transitive-pack patch: passed; installed manifests resolved `openclaw`, `@openclaw/ai`, and `@openclaw/normalization-core`: https://github.com/openclaw/openclaw/actions/runs/31523994868
- autoreview: clean, no actionable findings

Canonical base was re-fetched before commit and push; head contains `origin/main` at `5179e1235293bbd80c623cf3b6359414b1cb1e74`.
