### PR TITLE
fix(backup): prevent false archive stalls during active traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Backup archives:** count active tar traversal as writer progress so large backups do not false-timeout, and verify valid sparse archives with bounded decompression-ratio headroom.
 - **Updater plugin convergence:** keep pre-plugin doctor passes from installing configured plugins before the updater's plugin sweep, while preserving the final post-plugin migration pass and preventing ambient update-phase state from leaking into fresh doctor processes.
 - **Control UI browser tab identity:** keep selected tab styling, accessibility, focus, address, and page snapshot aligned across in-place navigation and tab reordering. Fixes #120745. Thanks @shakkernerd.
 - **Control UI staged attachments:** preserve unsent images, files, pasted images, and large pasted text across same-tab route and narrow split-pane remounts while keeping pane close, mismatched pane/session/Gateway remounts, application shutdown, and hard reload as cleanup boundaries. Fixes #121519. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Backup archives:** count active tar traversal as writer progress so large backups do not false-timeout, and verify valid sparse archives with bounded decompression-ratio headroom.
 - **Updater plugin convergence:** keep pre-plugin doctor passes from installing configured plugins before the updater's plugin sweep, while preserving the final post-plugin migration pass and preventing ambient update-phase state from leaking into fresh doctor processes.
 - **Control UI browser tab identity:** keep selected tab styling, accessibility, focus, address, and page snapshot aligned across in-place navigation and tab reordering. Fixes #120745. Thanks @shakkernerd.
 - **Control UI staged attachments:** preserve unsent images, files, pasted images, and large pasted text across same-tab route and narrow split-pane remounts while keeping pane close, mismatched pane/session/Gateway remounts, application shutdown, and hard reload as cleanup boundaries. Fixes #121519. Thanks @shakkernerd.

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -18,6 +18,9 @@ const WINDOWS_ABSOLUTE_ARCHIVE_PATH_RE = /^[A-Za-z]:[\\/]/;
 const MAX_MANIFEST_BYTES = 1024 * 1024;
 const MAX_SQLITE_SNAPSHOT_EXTRACT_BYTES = 64 * 1024 * 1024 * 1024;
 const SQLITE_SNAPSHOT_FREE_SPACE_RESERVE_BYTES = 256 * 1024 * 1024;
+// DEFLATE can legitimately encode zero-filled sparse ranges just over 1000:1.
+// Keep bounded headroom without disabling node-tar's decompression bomb guard.
+const BACKUP_MAX_DECOMPRESSION_RATIO = 1100;
 const SQLITE_SNAPSHOT_SIDECAR_SUFFIXES = ["-wal", "-shm", "-journal"] as const;
 
 type BackupManifestAsset = {
@@ -205,6 +208,7 @@ async function listArchiveEntries(archivePath: string): Promise<ArchiveEntry[]> 
   await tar.t({
     file: archivePath,
     gzip: true,
+    maxDecompressionRatio: BACKUP_MAX_DECOMPRESSION_RATIO,
     onReadEntry: (entry) => {
       entries.push({
         path: entry.path,
@@ -226,6 +230,7 @@ async function extractManifest(params: {
   await tar.t({
     file: params.archivePath,
     gzip: true,
+    maxDecompressionRatio: BACKUP_MAX_DECOMPRESSION_RATIO,
     filter: (entryPath) => entryPath === params.manifestEntryPath,
     onReadEntry: (entry) => {
       manifestContentPromise =
@@ -649,6 +654,7 @@ async function verifySqliteSnapshots(params: {
     await tar.x({
       file: params.archivePath,
       gzip: true,
+      maxDecompressionRatio: BACKUP_MAX_DECOMPRESSION_RATIO,
       cwd: tempDir,
       strict: true,
       preserveOwner: false,

--- a/src/infra/backup-archive-publication.test.ts
+++ b/src/infra/backup-archive-publication.test.ts
@@ -39,7 +39,7 @@ async function prepareArchive(
   const archiveStream = new PassThrough();
   const preparedPromise = writeArchiveStreamToFile({
     archivePath: plan.tempArchivePath,
-    archiveStream,
+    createArchiveStream: () => archiveStream,
   });
   archiveStream.end(content);
   return await preparedPromise;
@@ -297,7 +297,7 @@ describe("backup archive publication", () => {
     try {
       const writePromise = writeArchiveStreamToFile({
         archivePath: plan.tempArchivePath,
-        archiveStream,
+        createArchiveStream: () => archiveStream,
         onPartialArchive: (receipt) => {
           plan.pendingCleanupArchives.push(receipt);
         },

--- a/src/infra/backup-create-stream.ts
+++ b/src/infra/backup-create-stream.ts
@@ -42,7 +42,7 @@ export function removePreparedBackupArchive(prepared: PreparedBackupArchive): bo
 
 export async function writeArchiveStreamToFile(params: {
   archivePath: string;
-  archiveStream: DestroyableArchiveStream;
+  createArchiveStream: (reportProgress: () => void) => DestroyableArchiveStream;
   idleTimeoutMs?: number;
   onPartialArchive?: (receipt: BackupArchiveCleanupReceipt) => void;
 }): Promise<PreparedBackupArchive> {
@@ -51,18 +51,25 @@ export async function writeArchiveStreamToFile(params: {
   // refuses a pre-existing path instead of following a symlink.
   const idleTimeoutMs = params.idleTimeoutMs ?? BACKUP_ARCHIVE_IDLE_TIMEOUT_MS;
   const controller = new AbortController();
+  let archiveStream: DestroyableArchiveStream | undefined;
   let openedIdentity: Stats | undefined;
   let idleTimer: ReturnType<typeof setTimeout> | undefined;
   let idleTimeoutError: Error | undefined;
+  let settled = false;
   const armIdleTimer = () => {
+    // A destroyed producer may finish an in-flight filesystem callback later;
+    // never let that callback retain the process after cleanup has completed.
+    if (settled) {
+      return;
+    }
     if (idleTimer) {
       clearTimeout(idleTimer);
     }
     idleTimer = setTimeout(() => {
       idleTimeoutError = new Error(
-        `Backup archive write stalled: no data produced for ${idleTimeoutMs}ms`,
+        `Backup archive write stalled: no progress observed for ${idleTimeoutMs}ms`,
       );
-      params.archiveStream.destroy(idleTimeoutError);
+      archiveStream?.destroy(idleTimeoutError);
       controller.abort(idleTimeoutError);
     }, idleTimeoutMs);
   };
@@ -86,7 +93,8 @@ export async function writeArchiveStreamToFile(params: {
     }
   });
   try {
-    const pipelinePromise = pipeline(params.archiveStream, progress, archiveWriteStream, {
+    archiveStream = params.createArchiveStream(armIdleTimer);
+    const pipelinePromise = pipeline(archiveStream, progress, archiveWriteStream, {
       signal: controller.signal,
     });
     armIdleTimer();
@@ -148,6 +156,7 @@ export async function writeArchiveStreamToFile(params: {
     }
     throw idleTimeoutError ?? err;
   } finally {
+    settled = true;
     if (idleTimer) {
       clearTimeout(idleTimer);
     }

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -731,6 +731,34 @@ describe("createBackupArchive", () => {
     );
   });
 
+  it("creates a verifiable archive for highly compressible sparse state", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-sparse-state-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const outputDir = state.path("backups");
+        const sparsePath = state.statePath("sparse-state.bin");
+        await fs.mkdir(outputDir, { recursive: true });
+        await fs.writeFile(sparsePath, "");
+        await fs.truncate(sparsePath, 256 * 1024 * 1024);
+
+        const result = await createBackupArchive({
+          output: outputDir,
+          includeWorkspace: false,
+          nowMs: Date.UTC(2026, 4, 9, 8, 10, 0),
+        });
+        const runtime: RuntimeEnv = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+        await expect(
+          backupVerifyCommand(runtime, { archive: result.archivePath }),
+        ).resolves.toMatchObject({ ok: true });
+      },
+    );
+  });
+
   it("replaces legacy audit raw archives with sanitized restorable snapshots", async () => {
     await withOpenClawTestState(
       {

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -927,30 +927,35 @@ export async function createBackupArchive(
         unexpectedSqliteSourcePaths.length = 0;
         const prepared = await writeArchiveStreamToFile({
           archivePath: attemptTempArchivePath,
-          archiveStream: tar.c(
-            {
-              gzip: true,
-              portable: true,
-              preservePaths: true,
-              linkCache: createBackupLinkCache(),
-              statCache: createBackupVolatileStatCache(volatilePlan),
-              filter: tarFilter,
-              onWriteEntry: (entry) => {
-                entry.path = remapArchiveEntryPath({
-                  entryPath: entry.path,
-                  manifestPath,
-                  archiveRoot,
-                  sourcePathRemaps,
-                });
+          createArchiveStream: (reportProgress) =>
+            tar.c(
+              {
+                gzip: true,
+                portable: true,
+                preservePaths: true,
+                linkCache: createBackupLinkCache(),
+                statCache: createBackupVolatileStatCache(volatilePlan),
+                filter: (entryPath, entryStat) => {
+                  reportProgress();
+                  return tarFilter(entryPath, entryStat);
+                },
+                onWriteEntry: (entry) => {
+                  reportProgress();
+                  entry.path = remapArchiveEntryPath({
+                    entryPath: entry.path,
+                    manifestPath,
+                    archiveRoot,
+                    sourcePathRemaps,
+                  });
+                },
               },
-            },
-            [
-              manifestPath,
-              ...stateSqliteBackup.snapshots.map((snapshot) => snapshot.sourcePath),
-              ...legacyAuditSnapshots.map((snapshot) => snapshot.sourcePath),
-              ...result.assets.map((asset) => asset.sourcePath),
-            ],
-          ),
+              [
+                manifestPath,
+                ...stateSqliteBackup.snapshots.map((snapshot) => snapshot.sourcePath),
+                ...legacyAuditSnapshots.map((snapshot) => snapshot.sourcePath),
+                ...result.assets.map((asset) => asset.sourcePath),
+              ],
+            ),
           onPartialArchive: (partialArchive) => {
             publication.pendingCleanupArchives.push(partialArchive);
           },

--- a/src/infra/backup-create.windows.test.ts
+++ b/src/infra/backup-create.windows.test.ts
@@ -19,7 +19,7 @@ describe("writeArchiveStreamToFile", () => {
     try {
       const writePromise = writeArchiveStreamToFile({
         archivePath,
-        archiveStream,
+        createArchiveStream: () => archiveStream,
       });
       archiveStream.end("partial archive");
 
@@ -36,7 +36,7 @@ describe("writeArchiveStreamToFile", () => {
     const archiveStream = new PassThrough();
     const writePromise = writeArchiveStreamToFile({
       archivePath,
-      archiveStream,
+      createArchiveStream: () => archiveStream,
     });
     archiveStream.write("partial archive");
     archiveStream.destroy(new Error("injected tar read failure"));
@@ -53,13 +53,13 @@ describe("writeArchiveStreamToFile", () => {
       const archiveStream = new PassThrough();
       const writePromise = writeArchiveStreamToFile({
         archivePath,
-        archiveStream,
+        createArchiveStream: () => archiveStream,
         idleTimeoutMs: 50,
       });
       archiveStream.write("partial archive");
 
       const rejection = expect(writePromise).rejects.toThrow(
-        "Backup archive write stalled: no data produced for 50ms",
+        "Backup archive write stalled: no progress observed for 50ms",
       );
       await vi.advanceTimersByTimeAsync(60);
       await rejection;
@@ -78,7 +78,7 @@ describe("writeArchiveStreamToFile", () => {
       const archiveStream = new PassThrough();
       const writePromise = writeArchiveStreamToFile({
         archivePath,
-        archiveStream,
+        createArchiveStream: () => archiveStream,
         idleTimeoutMs: 50,
       });
 
@@ -90,6 +90,34 @@ describe("writeArchiveStreamToFile", () => {
 
       await expect(writePromise).resolves.toMatchObject({ archivePath });
       await expect(fs.readFile(archivePath, "utf8")).resolves.toBe("firstsecondthird");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the archive alive while the producer reports silent traversal progress", async () => {
+    vi.useFakeTimers();
+    try {
+      const tempDir = tempDirs.make("openclaw-backup-stream-traversal-progress-");
+      const archivePath = path.join(tempDir, "complete.tar.gz");
+      const archiveStream = new PassThrough();
+      let reportProgress: (() => void) | undefined;
+      const writePromise = writeArchiveStreamToFile({
+        archivePath,
+        createArchiveStream: (progress) => {
+          reportProgress = progress;
+          return archiveStream;
+        },
+      });
+
+      for (let elapsed = 0; elapsed < 360_000; elapsed += 60_000) {
+        await vi.advanceTimersByTimeAsync(60_000);
+        reportProgress?.();
+      }
+      archiveStream.end("archive after traversal");
+
+      await expect(writePromise).resolves.toMatchObject({ archivePath });
+      await expect(fs.readFile(archivePath, "utf8")).resolves.toBe("archive after traversal");
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users creating a large backup could receive a five-minute archive-stall failure even while tar was actively traversing source entries. It also fixes verification rejecting valid backups containing highly compressible sparse files.

## Why This Change Was Made

The archive writer now owns a producer-progress callback as well as compressed-output progress, so tar traversal and entry creation refresh the existing idle deadline without extending or disabling it. True silence still aborts and uses the existing identity-bound partial cleanup. Backup verification keeps node-tar's decompression-bomb defense enabled with bounded 1100:1 headroom for valid DEFLATE output.

## User Impact

Large active backups no longer false-timeout solely because gzip has not emitted another output chunk. Sparse backups created by OpenClaw can be verified normally, while corrupt archives and genuinely stalled writers continue to fail closed.

## Evidence

- Pre-fix fake-clock regression failed after the writer received no compressed bytes despite explicit producer progress.
- Post-fix regression simulates 360,000 ms of producer traversal before the first archive byte and passes without changing the 300,000 ms idle deadline.
- Focused Testbox proof: 129 passed, 1 skipped across backup creation, writer timeout and cleanup, atomic publication, command verification, and sparse create-to-verify behavior: https://github.com/openclaw/openclaw/actions/runs/31523396550
- `git diff --check` and targeted formatting passed.
- Autoreview: no accepted/actionable findings (`patch is correct`, confidence 0.98).

Production LOC: +47/-27 (net +20), justified by making producer progress an explicit writer-owned lifecycle contract and retaining bounded decompression-bomb protection. Tests: +63/-7.
