### PR TITLE
fix: connect open-tui to an already-running Gateway instead of forcing local mode

### DIFF
--- a/src/system-agent/operations-execute.ts
+++ b/src/system-agent/operations-execute.ts
@@ -509,8 +509,16 @@ export async function executeSystemAgentOperation(
       });
       const session = agentId ? buildAgentMainSessionKey({ agentId }) : undefined;
       const runTui = opts.deps?.runTui ?? (await import("../tui/tui.js")).runTui;
+      const readActiveGatewayLockIdentity =
+        opts.deps?.readActiveGatewayLockIdentity ??
+        (await import("../infra/gateway-lock.js")).readActiveGatewayLockIdentity;
+      // A Gateway already running for this state directory (for example, one
+      // that setup just started) refuses a second local TUI lock holder with
+      // GatewayLockError. Connect to it instead of forcing embedded local mode,
+      // mirroring the setup finalizer's own bound-vs-local handoff choice.
+      const activeGateway = await readActiveGatewayLockIdentity();
       const result = await runTui({
-        local: true,
+        local: activeGateway === undefined,
         session,
         deliver: false,
         historyLimit: 200,

--- a/src/system-agent/operations-parse.ts
+++ b/src/system-agent/operations-parse.ts
@@ -60,6 +60,7 @@ export type SystemAgentCommandDeps = {
     historyLimit?: number;
     message?: string;
   }) => Promise<TuiResult | void>;
+  readActiveGatewayLockIdentity?: typeof import("../infra/gateway-lock.js").readActiveGatewayLockIdentity;
   /** Where setup side effects run; the gateway surface never manages its own daemon. */
   setupSurface?: "cli" | "gateway";
   applySetup?: typeof import("./setup-apply.js").applySystemAgentSetup;

--- a/src/system-agent/operations.tui.test.ts
+++ b/src/system-agent/operations.tui.test.ts
@@ -77,6 +77,50 @@ describe("system-agent TUI operations", () => {
     });
   });
 
+  it("connects to an already-running Gateway instead of forcing a local TUI", async () => {
+    const { runtime } = createSystemAgentTestRuntime();
+    const runTui = vi.fn(async () => ({ exitReason: "exit" as const }));
+    const readActiveGatewayLockIdentity = vi.fn(async () => ({
+      pid: 4242,
+      createdAt: new Date().toISOString(),
+      port: 18789,
+    }));
+
+    await executeSystemAgentOperation(
+      { kind: "open-tui", agentId: "work", agentDraft: "hatch" },
+      runtime,
+      { deps: { runTui, readActiveGatewayLockIdentity } },
+    );
+
+    expect(readActiveGatewayLockIdentity).toHaveBeenCalled();
+    expect(runTui).toHaveBeenCalledWith({
+      local: false,
+      session: "agent:work:main",
+      deliver: false,
+      historyLimit: 200,
+      message: "Wake up, my friend!",
+    });
+  });
+
+  it("falls back to a local TUI when no Gateway owns this state directory", async () => {
+    const { runtime } = createSystemAgentTestRuntime();
+    const runTui = vi.fn(async () => ({ exitReason: "exit" as const }));
+    const readActiveGatewayLockIdentity = vi.fn(async () => undefined);
+
+    await executeSystemAgentOperation(
+      { kind: "open-tui", agentId: "work" },
+      runtime,
+      { deps: { runTui, readActiveGatewayLockIdentity } },
+    );
+
+    expect(runTui).toHaveBeenCalledWith({
+      local: true,
+      session: "agent:work:main",
+      deliver: false,
+      historyLimit: 200,
+    });
+  });
+
   it("re-enters the OpenClaw shell when the agent TUI returns without a request", async () => {
     const { runtime, lines } = createSystemAgentTestRuntime();
     const runTui = vi.fn(async () => ({


### PR DESCRIPTION
Closes #122170 
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where opening the TUI (including the agent-hatch flow triggered by the system-agent's `open-tui` operation) always forced a local TUI session. When a Gateway was already running for the same state directory (for example, one setup had just started), the local lock acquisition failed with `GatewayLockError` instead of attaching to the running Gateway.

## Why This Change Was Made

`open-tui` now calls `readActiveGatewayLockIdentity()` before deciding how to run the TUI. If a Gateway already owns the state directory, `runTui` is invoked with `local: false`, so `resolveGatewayConnection()` auto-detects and connects to that Gateway instead of forcing embedded local mode. This mirrors the same bound-vs-local handoff choice already used by the setup finalizer (`setup.finalize.ts`). When no Gateway is running, behavior is unchanged.

## User Impact

Users can now open the TUI (directly or via the hatch flow) while a Gateway is already running for their state directory without hitting a GatewayLockError. No visible change when no Gateway is active.

## Evidence

I could not run the full `pnpm build && pnpm check && pnpm test` in this environment, so I'm saying so plainly here. I verified the three changed files with TypeScript's `ts.transpileModule` (syntax-only, no type-checking or cross-file resolution) to confirm they parse cleanly, and added two new unit tests to `operations.tui.test.ts` covering both the "Gateway already running" and "no Gateway" branches, following the existing dependency-injection pattern used elsewhere in that file. Please confirm with the full CI suite.

---

This PR was drafted with AI assistance (Claude), operating autonomously to find and fix a well-scoped issue: reading the linked issue, tracing the existing `resolveGatewayConnection` auto-detect path and the precedent pattern in `setup.finalize.ts` to design a minimal fix, applying the diff, and writing the regression tests. I reviewed the diff before submitting.