### PR TITLE
improve(cli): speed up update dry-run process tests

### DIFF
--- a/src/cli/update-dry-run-state.process.test.ts
+++ b/src/cli/update-dry-run-state.process.test.ts
@@ -86,24 +86,6 @@ function runUpdateDryRun(root: string, args: string[]) {
 }
 
 describe("update dry-run process state", () => {
-  it.each([
-    ["root command", ["update", "--dry-run", "--no-restart", "--json"]],
-    ["root shorthand", ["--update", "--dry-run", "--no-restart", "--json"]],
-  ])("leaves isolated state unchanged for the %s", async (_name, args) => {
-    const root = tempDirs.make("openclaw-update-dry-run-");
-    await fs.mkdir(path.join(root, "config"), { recursive: true });
-    await fs.mkdir(path.join(root, "state"), { recursive: true });
-    await fs.writeFile(path.join(root, "config", "openclaw.json"), "{}\n");
-    const before = await snapshotTree(root);
-
-    const result = runUpdateDryRun(root, args);
-
-    expect(result.error).toBeUndefined();
-    expect(result.status, result.stderr).toBe(0);
-    expect(JSON.parse(result.stdout)).toMatchObject({ dryRun: true });
-    expect(await snapshotTree(root)).toEqual(before);
-  });
-
   it("keeps malformed config immutable while producing a best-effort preview", async () => {
     const root = tempDirs.make("openclaw-update-dry-run-malformed-");
     const configPath = path.join(root, "config", "openclaw.json");


### PR DESCRIPTION
## What Problem This Solves

The update dry-run process suite launched five full Node+tsx CLI processes and took 18.14 seconds of test execution on current `main`. Two basic empty-state cases duplicated stronger process scenarios using the same root command and shorthand entry paths.

## Why This Change Was Made

Deletes the basic root-command and root-shorthand process cases. The retained malformed-config root-command case and migration-pending shorthand case both prove successful dry-run output plus stricter filesystem immutability. The ownership-fence process case remains unchanged, as do focused update behavior and `--update` argv-rewrite owner suites.

No CI workers, shards, mocks, or production seams were added.

## User Impact

No runtime behavior changes. Contributors and CI execute two fewer full CLI processes while retaining the stronger state-safety contracts.

## Evidence

Same orb, exact current-main baseline (`98361489704`), same command:

```text
pnpm exec vitest run --config test/vitest/vitest.cli.config.ts src/cli/update-dry-run-state.process.test.ts
```

| metric | baseline | after | improvement |
| --- | ---: | ---: | ---: |
| Vitest duration | 19.15s | 11.66s | 39.1% |
| test body | 18.14s | 10.64s | 41.4% |
| timed wrapper | 20.67s | 13.18s | 36.2% |

- Process launches: 5 → 3 (40% fewer).
- Retained process scenarios: 3/3 passed.
- `src/cli/update-cli.test.ts`: 236/236 passed.
- `src/cli/run-main.test.ts`: 44/44 passed.
- `pnpm exec oxfmt --check src/cli/update-dry-run-state.process.test.ts`: pass.
- `git diff --check`: pass.
- Hosted exact-target A/B measurement will be added after both jobs complete.
