### PR TITLE
refactor(outbound): inline delivery diagnostics

### DIFF
--- a/src/infra/outbound/deliver-core.ts
+++ b/src/infra/outbound/deliver-core.ts
@@ -4,7 +4,11 @@ import { payloadRequiresDurablePayloadTransport } from "../../channels/message/c
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { OutboundMediaAccess } from "../../media/load-options.js";
 import { getOrCreatePromise } from "../../shared/lazy-promise.js";
-import type { DiagnosticMessageDeliveryKind } from "../diagnostic-events.js";
+import { diagnosticErrorCategory } from "../diagnostic-error-metadata.js";
+import {
+  emitInternalDiagnosticEvent as emitDiagnosticEvent,
+  type DiagnosticMessageDeliveryKind,
+} from "../diagnostic-events.js";
 import { formatErrorMessage } from "../errors.js";
 import { throwIfAborted } from "./abort.js";
 import { createChannelHandler } from "./deliver-channel.js";
@@ -13,15 +17,11 @@ import { suppressedPayloadOutcome, toOutboundDeliveryError } from "./deliver-hoo
 import {
   buildPayloadSummary,
   deliveryKindForPayload,
-  emitMessageDeliveryCompleted,
-  emitMessageDeliveryError,
-  emitMessageDeliveryStarted,
   maybeNotifyAfterDeliveredPayload,
   maybePinDeliveredMessage,
   normalizeEmptyPayloadForDelivery,
   renderPresentationForDelivery,
   resolveOutboundMediaAccessForSend,
-  sessionKeyForDeliveryDiagnostics,
   stripInternalRuntimeScaffoldingFromPayload,
 } from "./deliver-payload.js";
 import { createDeliveryResultRecorder } from "./deliver-results.js";
@@ -211,7 +211,9 @@ export async function deliverOutboundPayloadsCore(
       deliveredMirrorPayloads.push(payloadSummary);
     }
   };
-  const diagnosticSessionKey = sessionKeyForDeliveryDiagnostics(params);
+  // `policyKey` is a diagnostics-only fallback; never use it for hook correlation.
+  const diagnosticSessionKey =
+    params.mirror?.sessionKey ?? params.session?.key ?? params.session?.policyKey;
   for (const [deliveryPayloadIndex, preparedEntry] of acceptedEntries.entries()) {
     const payloadIndex = preparedEntry.sourceIndex;
     const payload = preparedEntry.payload;
@@ -237,10 +239,11 @@ export async function deliverOutboundPayloadsCore(
       deliveryStartedAt = Date.now();
       deliveryStarted = true;
       deliveryFinished = false;
-      emitMessageDeliveryStarted({
+      emitDiagnosticEvent({
+        type: "message.delivery.started",
         channel,
         deliveryKind,
-        sessionKey: diagnosticSessionKey,
+        ...(diagnosticSessionKey ? { sessionKey: diagnosticSessionKey } : {}),
       });
     };
     const completeDeliveryDiagnostics = (resultCount: number) => {
@@ -248,12 +251,13 @@ export async function deliverOutboundPayloadsCore(
         return;
       }
       deliveryFinished = true;
-      emitMessageDeliveryCompleted({
+      emitDiagnosticEvent({
+        type: "message.delivery.completed",
         channel,
         deliveryKind,
         durationMs: Date.now() - deliveryStartedAt,
         resultCount,
-        sessionKey: diagnosticSessionKey,
+        ...(diagnosticSessionKey ? { sessionKey: diagnosticSessionKey } : {}),
       });
     };
     const errorDeliveryDiagnostics = (err: unknown) => {
@@ -261,12 +265,13 @@ export async function deliverOutboundPayloadsCore(
         return;
       }
       deliveryFinished = true;
-      emitMessageDeliveryError({
+      emitDiagnosticEvent({
+        type: "message.delivery.error",
         channel,
         deliveryKind,
         durationMs: Date.now() - deliveryStartedAt,
-        error: err,
-        sessionKey: diagnosticSessionKey,
+        errorCategory: diagnosticErrorCategory(err),
+        ...(diagnosticSessionKey ? { sessionKey: diagnosticSessionKey } : {}),
       });
     };
     try {

--- a/src/infra/outbound/deliver-payload.ts
+++ b/src/infra/outbound/deliver-payload.ts
@@ -12,11 +12,6 @@ import {
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { OutboundMediaAccess } from "../../media/load-options.js";
 import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
-import { diagnosticErrorCategory } from "../diagnostic-error-metadata.js";
-import {
-  emitInternalDiagnosticEvent as emitDiagnosticEvent,
-  type DiagnosticMessageDeliveryKind,
-} from "../diagnostic-events.js";
 import { formatErrorMessage } from "../errors.js";
 import type {
   ChannelHandler,
@@ -25,23 +20,14 @@ import type {
 } from "./deliver-contracts.js";
 import type { OutboundDeliveryResult, OutboundPayloadDeliveryKind } from "./deliver-types.js";
 import { flattenMarkdownDetails } from "./markdown-details.js";
-import type { DeliveryMirror } from "./mirror.js";
 import {
   summarizeOutboundPayloadForTransport,
   type NormalizedOutboundPayload,
   type OutboundPayloadPlan,
 } from "./payloads.js";
 import { stripInternalRuntimeScaffolding } from "./protocol-scaffolding.js";
-import type { OutboundSessionContext } from "./session-context.js";
 
 const log = createSubsystemLogger("outbound/deliver");
-
-export function sessionKeyForDeliveryDiagnostics(params: {
-  mirror?: DeliveryMirror;
-  session?: OutboundSessionContext;
-}): string | undefined {
-  return params.mirror?.sessionKey ?? params.session?.key ?? params.session?.policyKey;
-}
 
 export function deliveryKindForPayload(
   payload: ReplyPayload,
@@ -54,53 +40,6 @@ export function deliveryKindForPayload(
     return "other";
   }
   return "text";
-}
-
-export function emitMessageDeliveryStarted(params: {
-  channel: string;
-  deliveryKind: DiagnosticMessageDeliveryKind;
-  sessionKey?: string;
-}): void {
-  emitDiagnosticEvent({
-    type: "message.delivery.started",
-    channel: params.channel,
-    deliveryKind: params.deliveryKind,
-    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-  });
-}
-
-export function emitMessageDeliveryCompleted(params: {
-  channel: string;
-  deliveryKind: DiagnosticMessageDeliveryKind;
-  durationMs: number;
-  resultCount: number;
-  sessionKey?: string;
-}): void {
-  emitDiagnosticEvent({
-    type: "message.delivery.completed",
-    channel: params.channel,
-    deliveryKind: params.deliveryKind,
-    durationMs: params.durationMs,
-    resultCount: params.resultCount,
-    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-  });
-}
-
-export function emitMessageDeliveryError(params: {
-  channel: string;
-  deliveryKind: DiagnosticMessageDeliveryKind;
-  durationMs: number;
-  error: unknown;
-  sessionKey?: string;
-}): void {
-  emitDiagnosticEvent({
-    type: "message.delivery.error",
-    channel: params.channel,
-    deliveryKind: params.deliveryKind,
-    durationMs: params.durationMs,
-    errorCategory: diagnosticErrorCategory(params.error),
-    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-  });
 }
 
 export function normalizeEmptyPayloadForDelivery(payload: ReplyPayload): ReplyPayload | null {

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -2411,18 +2411,19 @@ describe("deliverOutboundPayloads", () => {
       unsubscribe();
     }
 
-    const errorEvent = events.find((event) => event.type === "message.delivery.error") as
-      | Record<string, unknown>
-      | undefined;
+    const deliveryEvents = events.filter((event) => event.type.startsWith("message.delivery."));
+    expect(deliveryEvents.map((event) => event.type)).toEqual([
+      "message.delivery.started",
+      "message.delivery.error",
+    ]);
+    const errorEvent = deliveryEvents[1] as Record<string, unknown> | undefined;
     expect(errorEvent?.type).toBe("message.delivery.error");
     expect(errorEvent?.channel).toBe("matrix");
     expect(errorEvent?.deliveryKind).toBe("text");
     expect(typeof errorEvent?.durationMs).toBe("number");
     expect(errorEvent?.errorCategory).toBe("TypeError");
     expect(errorEvent?.sessionKey).toBe("session-1");
-    expect(
-      JSON.stringify(events.filter((event) => event.type.startsWith("message.delivery."))),
-    ).not.toContain("secret delivery body");
+    expect(JSON.stringify(deliveryEvents)).not.toContain("secret delivery body");
   });
 
   it("emits one metadata-only audit terminal for a successful logical payload", async () => {


### PR DESCRIPTION
## What Problem This Solves

Outbound delivery diagnostics were split across one lifecycle owner and four exported pass-through helpers. That duplicated the event contract, obscured terminal ordering, and left delivery-only policy inside the payload utility module.

## Why This Change Was Made

The delivery lifecycle now emits its typed internal diagnostic events directly where start, completion, and failure are owned. The redundant emitters and session-key helper are removed; the diagnostics-only `policyKey` fallback remains local and cannot be mistaken for hook correlation.

Production LOC: +18/-74 (net -56) | Tests: +7/-6

## User Impact

No user-visible behavior changes. Diagnostic event names, fields, ordering, duration, error categorization, session precedence, internal provenance, and zero-result completion semantics remain unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/infra/outbound/deliver.test.ts` - 176 tests passed.
- `pnpm format src/infra/outbound/deliver-core.ts src/infra/outbound/deliver-payload.ts src/infra/outbound/deliver.test.ts`
- `git diff --check`
- The failure regression now asserts the exact terminal sequence: `message.delivery.started`, then `message.delivery.error`.
- AWS Crabbox `run_b5f5022f0931` on `cbx_cd29ef5eef74`, exact head `d9915da1b85ef175173f8a7ef5ce490294c0f166`: 176 tests passed, private-QA build passed, `channel-chat-baseline` passed, and `qa-evidence.json` recorded one passing entry.
- Blacksmith Testbox `tbx_01kzs5hgm19e8p2476vaecm8y7`, workflow `31529179852`, job `93904803357`, exact head `d9915da1b85ef175173f8a7ef5ce490294c0f166`: outbound 176/176, diagnostics-otel 191/191, `check:test-types`, and `check:changed` passed; all workflow close and post steps completed successfully.
- Exact-head ClawSweeper review: no findings; best-fix verdict confirmed.
- Collision audit: #80396 overlaps only `src/infra/outbound/deliver.test.ts`; its production changes do not overlap this refactor. Recheck required before merge.
- Hosted CI: 79 checks passed, 42 intentionally skipped, zero pending or failing, including `openclaw/ci-gate`.

AI-assisted: yes.
