### PR TITLE
improve(ui): blend chat header into transcript

### DIFF
--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -183,6 +183,16 @@
   overflow: hidden;
 }
 
+.chat-main__conversation::before {
+  content: "";
+  position: absolute;
+  z-index: 2;
+  inset: 0 0 auto;
+  height: 24px;
+  pointer-events: none;
+  background: linear-gradient(to bottom, var(--chat-surface), transparent);
+}
+
 .chat-main--rail-docked {
   flex-direction: row;
 }

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -35,6 +35,8 @@ openclaw-chat-pane {
 /* One cell = pane header + pane; the header lives in-flow with its pane, so
    split geometry needs no mirrored toolbar layer. */
 .chat-split-view__cell {
+  --chat-surface: var(--bg-content, var(--bg));
+
   display: flex;
   flex-direction: column;
   min-width: 0;
@@ -154,8 +156,7 @@ openclaw-chat-pane {
      line up with the sidebar across the top of the shell. */
   min-height: 48px;
   padding: 0 6px 0 12px;
-  border-bottom: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
-  background: color-mix(in srgb, var(--panel) 62%, transparent);
+  background: var(--chat-surface);
   /* Chrome row, not content: a selectable title would fight the native
      window drag the macOS app starts from this row. */
   user-select: none;


### PR DESCRIPTION
Closes #122137

## What Problem This Solves

The Control UI chat header currently reads as separate window chrome: its translucent panel fill and bottom separator break the transcript surface, while scrolled messages clip abruptly at the header boundary.

## Why This Change Was Made

This change gives each chat pane one theme-aware surface, uses it for the pane header, removes the separator, and fades scrolled transcript content through a 24px pointer-transparent overlay. The transcript remains the scroll owner, the in-flow header remains fixed, and higher conversation overlays keep their existing stacking order.

## User Impact

The chat header, transcript, and composer now read as one continuous pane in light and dark themes without changing layout, scrolling, hit testing, mobile navigation, or native titlebar behavior.

## Evidence

All screenshots use the Control UI mock Gateway with realistic transcript content, a 1440×900 viewport, and the identical transcript position (`scrollTop = 3628`). Before is merge-base `7fe75acb5f46bc64a00efc88c350711f24f417b4`; after is PR head `12bc234039880cfd498572cb448f075849f810a4`.

### Full chat — light

| Before | After |
| --- | --- |
| ![Light theme full chat before: separated header, transcript, and composer](https://github.com/user-attachments/assets/98468d07-3754-4c21-8cec-1e7a36886064) | ![Light theme full chat after: continuous header, transcript, and composer surface](https://github.com/user-attachments/assets/d87b9457-e970-44e2-b946-8b0904776985) |

### Full chat — dark

| Before | After |
| --- | --- |
| ![Dark theme full chat before: separated header, transcript, and composer](https://github.com/user-attachments/assets/08fafab8-4261-4d3e-ba2f-3046aca72d45) | ![Dark theme full chat after: continuous header, transcript, and composer surface](https://github.com/user-attachments/assets/001de68a-2912-4608-aae9-30aeaabdfb95) |

### Header/transcript detail — light

| Before | After |
| --- | --- |
| ![Light theme boundary before: separator and hard-clipped transcript](https://github.com/user-attachments/assets/e3cde679-a43e-4d26-8995-1a5b4add0199) | ![Light theme boundary after: shared surface and soft transcript fade](https://github.com/user-attachments/assets/fecd243f-c959-4ab3-aed5-ef11b7076d70) |

### Header/transcript detail — dark

| Before | After |
| --- | --- |
| ![Dark theme boundary before: separator and hard-clipped transcript](https://github.com/user-attachments/assets/35d216ec-2654-48ae-b0a3-f61637b33f4b) | ![Dark theme boundary after: shared surface and soft transcript fade](https://github.com/user-attachments/assets/2ee231fe-8076-47a6-a8f3-0e9492ddeb35) |

Browser assertions on the PR head:

- Light: header and fade start resolve to `rgb(244, 241, 236)`.
- Dark: header and fade start resolve to `rgb(14, 16, 21)` through the `--bg` fallback; no hard light-theme edge appears.
- Header bottom and transcript top both remain at 48px while the transcript scrolls.
- Fade is 24px, `pointer-events: none`, and z-index 2; task suggestions remain above it at z-index 24.
- Mobile drawer opens at 390×844 in both themes, remains outside the chat-surface scope, and leaves the chat header surface intact.

Commands:

```text
nice -n 19 ./node_modules/.bin/stylelint ui/src/styles/chat/sidebar.css ui/src/styles/chat/split-view.css --config config/stylelint.config.mjs
nice -n 19 node scripts/run-vitest.mjs ui/src/pages/chat/chat-page.test.ts
node --import tsx scripts/control-ui-mock-dev.ts --port <port>
```

Results:

- Focused stylelint: pass.
- `ui/src/pages/chat/chat-page.test.ts`: 30/30 pass.
- Blacksmith Testbox run 31523365991: `pnpm check:changed` plus `ui/src/e2e/app-chrome-interaction.e2e.test.ts`, pass. The run used patch-identical pre-rebase head `8dd3e360aa13e4f3d4b7fb513a492137661a4421`; the final rebase changed no affected file or patch bytes.
- Exact-head PR CI: green — https://github.com/openclaw/openclaw/actions/runs/31525735750