### PR TITLE
refactor(gateway): unify terminal restriction tracking

### DIFF
--- a/src/gateway/terminal/launch.test.ts
+++ b/src/gateway/terminal/launch.test.ts
@@ -81,6 +81,40 @@ describe("createTerminalLaunchPolicy", () => {
     }
   });
 
+  it("keeps restart and commit restrictions isolated across agents", () => {
+    const baseConfig: OpenClawConfig = {
+      agents: { list: [{ id: "alpha" }, { id: "beta" }] },
+    };
+    const policy = createTerminalLaunchPolicy(baseConfig);
+
+    policy.prepareConfig(
+      {
+        agents: {
+          list: [{ id: "alpha", sandbox: { mode: "all" } }, { id: "beta" }],
+        },
+      },
+      { restartPending: true },
+    );
+    policy.prepareConfig(
+      {
+        agents: {
+          list: [{ id: "alpha" }, { id: "beta", sandbox: { mode: "all" } }],
+        },
+      },
+      { restartPending: false },
+    );
+
+    expect(policy.resolve("alpha").ok).toBe(false);
+    expect(policy.resolve("beta").ok).toBe(false);
+
+    policy.acceptConfig({ retireRejectedRestart: false });
+    expect(policy.resolve("alpha").ok).toBe(false);
+    expect(policy.resolve("beta").ok).toBe(true);
+
+    policy.acceptConfig({ retireRejectedRestart: true });
+    expect(policy.resolve("alpha").ok).toBe(true);
+  });
+
   it("keeps current launch details until a restart-bound change takes effect", () => {
     const workspace = tempDirs.make("term-policy-");
     const policy = createTerminalLaunchPolicy({

--- a/src/gateway/terminal/launch.ts
+++ b/src/gateway/terminal/launch.ts
@@ -120,12 +120,14 @@ function resolveTerminalLaunch(params: {
 export function createTerminalLaunchPolicy(initialConfig: OpenClawConfig): TerminalLaunchPolicy {
   let activeConfig = initialConfig;
   let hasPendingRestart = false;
-  let terminalDisabledUntilRestart = false;
   let preparedConfig: OpenClawConfig | null = null;
   let appliedConfigWhileRestartPending: OpenClawConfig | null = null;
-  let terminalDisabledUntilCommit = false;
-  const blockedAgentsUntilRestart = new Map<string, TerminalLaunchBlock>();
-  const blockedAgentsUntilCommit = new Map<string, TerminalLaunchBlock>();
+  const createRestrictions = () => ({
+    disabled: false,
+    blockedAgents: new Map<string, TerminalLaunchBlock>(),
+  });
+  const restartRestrictions = createRestrictions();
+  const commitRestrictions = createRestrictions();
   const preserveTerminalConfig = (config: OpenClawConfig, owner: OpenClawConfig) => {
     const { terminal: _ignored, ...gateway } = config.gateway ?? {};
     const terminal = owner.gateway?.terminal;
@@ -146,9 +148,12 @@ export function createTerminalLaunchPolicy(initialConfig: OpenClawConfig): Termi
       configuredShell: terminalConfig?.shell,
     });
   };
-  const accumulateRestartRestrictions = (config: OpenClawConfig) => {
+  const accumulateRestrictions = (
+    config: OpenClawConfig,
+    restrictions: ReturnType<typeof createRestrictions>,
+  ) => {
     if (!isTerminalConfigEnabled(config)) {
-      terminalDisabledUntilRestart = true;
+      restrictions.disabled = true;
       return;
     }
     const activeAgentIds = new Set([
@@ -158,25 +163,13 @@ export function createTerminalLaunchPolicy(initialConfig: OpenClawConfig): Termi
     for (const agentId of activeAgentIds) {
       const candidate = resolveForConfig(config, agentId);
       if (!candidate.ok) {
-        blockedAgentsUntilRestart.set(agentId, candidate.block);
+        restrictions.blockedAgents.set(agentId, candidate.block);
       }
     }
   };
-  const accumulateCommitRestrictions = (config: OpenClawConfig) => {
-    if (!isTerminalConfigEnabled(config)) {
-      terminalDisabledUntilCommit = true;
-      return;
-    }
-    const activeAgentIds = new Set([
-      ...listAgentIds(activeConfig),
-      resolveDefaultAgentId(activeConfig),
-    ]);
-    for (const agentId of activeAgentIds) {
-      const candidate = resolveForConfig(config, agentId);
-      if (!candidate.ok) {
-        blockedAgentsUntilCommit.set(agentId, candidate.block);
-      }
-    }
+  const clearRestrictions = (restrictions: ReturnType<typeof createRestrictions>) => {
+    restrictions.disabled = false;
+    restrictions.blockedAgents.clear();
   };
 
   return {
@@ -185,14 +178,14 @@ export function createTerminalLaunchPolicy(initialConfig: OpenClawConfig): Termi
       if (!active.ok) {
         return active;
       }
-      if (terminalDisabledUntilRestart) {
+      if (restartRestrictions.disabled) {
         return { ok: false, block: { kind: "disabled" } };
       }
-      const pendingBlock = blockedAgentsUntilRestart.get(active.plan.agentId);
+      const pendingBlock = restartRestrictions.blockedAgents.get(active.plan.agentId);
       if (pendingBlock) {
         return { ok: false, block: pendingBlock };
       }
-      const preparedBlock = blockedAgentsUntilCommit.get(active.plan.agentId);
+      const preparedBlock = commitRestrictions.blockedAgents.get(active.plan.agentId);
       if (preparedBlock) {
         return { ok: false, block: preparedBlock };
       }
@@ -207,8 +200,8 @@ export function createTerminalLaunchPolicy(initialConfig: OpenClawConfig): Termi
     },
     isEnabled: () =>
       isTerminalConfigEnabled(activeConfig) &&
-      !terminalDisabledUntilRestart &&
-      !terminalDisabledUntilCommit &&
+      !restartRestrictions.disabled &&
+      !commitRestrictions.disabled &&
       (preparedConfig === null || isTerminalConfigEnabled(preparedConfig)),
     prepareConfig: (config, options) => {
       if (options.restartPending) {
@@ -216,7 +209,7 @@ export function createTerminalLaunchPolicy(initialConfig: OpenClawConfig): Termi
         // Keep an older candidate fail-closed only until this transaction is
         // accepted; do not mix its restrictions into the restart-owned bucket.
         preparedConfig = null;
-        accumulateRestartRestrictions(config);
+        accumulateRestrictions(config, restartRestrictions);
         return;
       }
       // No-op/hot plans may arrive with restart-only terminal fields that an
@@ -224,11 +217,11 @@ export function createTerminalLaunchPolicy(initialConfig: OpenClawConfig): Termi
       // terminal subtree already owned by the active or pending process.
       if (hasPendingRestart) {
         preparedConfig = preserveTerminalConfig(config, activeConfig);
-        accumulateCommitRestrictions(preparedConfig);
+        accumulateRestrictions(preparedConfig, commitRestrictions);
         return;
       }
       preparedConfig = preserveTerminalConfig(config, activeConfig);
-      accumulateCommitRestrictions(preparedConfig);
+      accumulateRestrictions(preparedConfig, commitRestrictions);
     },
     commitConfig: () => {
       if (hasPendingRestart) {
@@ -238,10 +231,9 @@ export function createTerminalLaunchPolicy(initialConfig: OpenClawConfig): Termi
           appliedConfigWhileRestartPending = preparedConfig;
         }
         preparedConfig = null;
-        terminalDisabledUntilCommit = false;
-        blockedAgentsUntilCommit.clear();
+        clearRestrictions(commitRestrictions);
         if (appliedConfigWhileRestartPending) {
-          accumulateCommitRestrictions(appliedConfigWhileRestartPending);
+          accumulateRestrictions(appliedConfigWhileRestartPending, commitRestrictions);
         }
         return;
       }
@@ -249,20 +241,17 @@ export function createTerminalLaunchPolicy(initialConfig: OpenClawConfig): Termi
         activeConfig = preparedConfig;
       }
       preparedConfig = null;
-      terminalDisabledUntilCommit = false;
-      blockedAgentsUntilCommit.clear();
+      clearRestrictions(commitRestrictions);
     },
     acceptConfig: (options) => {
       // Baseline acceptance retires an un-published candidate, including config
       // intentionally skipped by reload policy. Only onConfigApplied may stage
       // runtime truth for promotion after a rejected restart.
       preparedConfig = null;
-      terminalDisabledUntilCommit = false;
-      blockedAgentsUntilCommit.clear();
+      clearRestrictions(commitRestrictions);
       if (options.retireRejectedRestart) {
         hasPendingRestart = false;
-        terminalDisabledUntilRestart = false;
-        blockedAgentsUntilRestart.clear();
+        clearRestrictions(restartRestrictions);
         if (appliedConfigWhileRestartPending) {
           activeConfig = appliedConfigWhileRestartPending;
         }
@@ -270,7 +259,7 @@ export function createTerminalLaunchPolicy(initialConfig: OpenClawConfig): Termi
         return;
       }
       if (appliedConfigWhileRestartPending) {
-        accumulateCommitRestrictions(appliedConfigWhileRestartPending);
+        accumulateRestrictions(appliedConfigWhileRestartPending, commitRestrictions);
       }
     },
   };


### PR DESCRIPTION
## What Problem This Solves

Terminal launch policy tracked restart-owned and commit-owned restrictions through duplicated booleans, maps, accumulation loops, and reset sequences. The duplicated lifecycle bookkeeping made it easier for the two fail-closed buckets to drift or be cleared together accidentally.

## Why This Change Was Made

This change gives both lifecycle buckets one internal representation and routes accumulation and clearing through shared private helpers. Restart and commit state remain separate, restart restrictions keep precedence, and the existing config-reload behavior is unchanged.

## User Impact

No user-visible behavior changes. The gateway terminal keeps the same default-on, sandbox, reload, restart, and PTY admission semantics with less duplicated policy code.

Production LOC: +29/-40 (net -11) | Tests: +34/-0

## Evidence

- Exact head: `95c37611ed8c7b171dd85515361ea9623e591887`
- `node scripts/run-vitest.mjs src/gateway/terminal/launch.test.ts` - 17/17 tests passed
- `./node_modules/.bin/oxfmt --write src/gateway/terminal/launch.ts src/gateway/terminal/launch.test.ts`
- `git diff --check`
- Autoreview: clean, no accepted/actionable findings
- Direct AWS Crabbox `run_bae8e1727669` at the exact head: 425/425 lifecycle tests passed across terminal launch, config reload, server reload handlers, and terminal server methods; private-QA/package build passed. Its later proof-script lookup expected `.js` instead of the emitted `.mjs`, so only that failed surface was retried.
- Corrected direct AWS Crabbox `run_097a93f67c75` at the exact head: deterministic `launch.mjs` import passed; the built two-agent runtime probe preserved restart-versus-commit restriction independence and retirement behavior; built CLI and launcher version/help smokes passed.
- AWS lease `cbx_d8bc359ec690` released.
- Blacksmith Testbox lease `tbx_01kzs9sdyst1xm234v1xafhhds`, workflow `31535458894`, job `93925384051`: full success through teardown at the exact head; 425/425 lifecycle tests, `pnpm check:test-types`, and `pnpm check:changed` passed. Payload receipt: exit 0, command 10m30.771s, total 10m30.838s.
- ClawSweeper exact-head review: no findings; proof sufficient; the only rank-up move is normal maintainer readiness and exact-head hosted CI.
- Hosted CI run `31538333635` at the exact head: 92 successful checks, zero pending or failed.
- Repo-native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 122228` and `scripts/pr merge-run 122228` passed.
- Landed squash commit: `642fe776244d09a99232daba8be20a34522f2fdf` (verified GitHub signature; ancestor of live `origin/main`).

AI-assisted: yes.
