### PR TITLE
improve: trim duplicate cold-command process checks

### DIFF
--- a/src/cli/cold-command-plugin-imports.process.test.ts
+++ b/src/cli/cold-command-plugin-imports.process.test.ts
@@ -1,11 +1,10 @@
 // Real CLI processes must keep unrelated plugin runtimes cold on read-only command paths.
 import { execFile } from "node:child_process";
 import fs from "node:fs";
-import { createServer, type Server } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
-import { afterAll, beforeAll, expect, it } from "vitest";
+import { afterAll, expect, it } from "vitest";
 import {
   createColdPluginFixture,
   isColdPluginRuntimeLoaded,
@@ -13,38 +12,13 @@ import {
 
 const execFileAsync = promisify(execFile);
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cold-commands-"));
-let clawHubServer: Server;
-let clawHubUrl: string;
 
-beforeAll(async () => {
-  clawHubServer = createServer((_request, response) => {
-    response.writeHead(200, { "content-type": "application/json" });
-    response.end('{"results":[]}');
-  });
-  await new Promise<void>((resolve) => {
-    clawHubServer.listen(0, "127.0.0.1", resolve);
-  });
-  const address = clawHubServer.address();
-  if (!address || typeof address === "string") {
-    throw new Error("failed to bind the ClawHub fixture server");
-  }
-  clawHubUrl = `http://127.0.0.1:${address.port}`;
-});
-
-afterAll(async () => {
-  await new Promise<void>((resolve, reject) => {
-    clawHubServer.close((error) => (error ? reject(error) : resolve()));
-  });
+afterAll(() => {
   fs.rmSync(tempRoot, { recursive: true, force: true });
 });
 
 const cases = [
   { label: "hooks", args: ["hooks", "--json"], needsMemoryOwner: false },
-  {
-    label: "skills-search",
-    args: ["skills", "search", "fixture", "--json"],
-    needsMemoryOwner: false,
-  },
   {
     label: "skills-info",
     args: ["skills", "info", "fixture-skill", "--json"],
@@ -53,11 +27,6 @@ const cases = [
   {
     label: "memory-status",
     args: ["memory", "status", "--agent", "main", "--json"],
-    needsMemoryOwner: true,
-  },
-  {
-    label: "memory-search",
-    args: ["memory", "search", "no-hit", "--agent", "main", "--json"],
     needsMemoryOwner: true,
   },
 ] as const;
@@ -116,7 +85,6 @@ it.each(cases)(
           "    api.registerCli(({ program }) => {",
           '      const memory = program.command("memory");',
           '      memory.command("status").option("--agent <id>").option("--json").action(() => console.log("[]"));',
-          '      memory.command("search").argument("<query>").option("--agent <id>").option("--json").action(() => console.log("{\\\"results\\\":[]}"));',
           '    }, { descriptors: [{ name: "memory", description: "Memory fixture", hasSubcommands: true }] });',
           "  },",
           "};",
@@ -151,7 +119,6 @@ it.each(cases)(
           NODE_DISABLE_COMPILE_CACHE: "1",
           NODE_ENV: undefined,
           VITEST: undefined,
-          OPENCLAW_CLAWHUB_URL: clawHubUrl,
           OPENCLAW_CONFIG_PATH: configPath,
           MEMORY_OWNER_MARKER: path.join(root, "memory-owner-loaded"),
           OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",


### PR DESCRIPTION
## What Problem This Solves

Resolves unnecessary CI time in the cold-command plugin boundary suite, which launched five full Node + TSX CLI processes even though two cases repeated the same command-owner and startup-policy boundaries.

## Why This Change Was Made

Keeps one real-process representative for each distinct ownership category: built-in `hooks`, local `skills info`, and scoped plugin-owner `memory status`. Removes `skills search`, which shares the same lazy skills registrar and `loadPlugins: never` policy, and `memory search`, which resolves the same root `memory` plugin owner as the retained status case.

Focused policy and command-owner matrices continue to cover both deleted subcommands. The now-unused ClawHub HTTP server and synthetic memory-search command are removed with the cases they supported.

## User Impact

No user-visible runtime behavior changes. Contributors get a faster CLI shard with fewer serial child-process launches and no loss of unique plugin cold-loading coverage.

## Evidence

- Focused test body: **16.982s → 10.833s (36.2% faster)**.
- Focused Vitest duration: **17.77s → 11.75s (33.9% faster)**.
- Full-process cases: **5 → 3**.
- Retained focused process cases: **3/3 passed**.
- Startup/path policy and skills owners: **107/107 passed**.
- Memory CLI owner: **77/77 passed**.
- `oxfmt --check` and `git diff --check` passed.
- Independent final review: approve, no blockers; it verified both deleted routes share the retained plugin-loading owners and that fixture cleanup is complete.
- The repository autoreview wrapper completed its secret scan; no supported external reviewer executable is installed in this orb, so the available read-only expert reviewer was used.

Production LOC: +0/-0 | Tests: +2/-35 (net -33)
