### PR TITLE
improve: trim duplicate gateway CLI process tests

### DIFF
--- a/src/cli/gateway-backed-exit.process.test.ts
+++ b/src/cli/gateway-backed-exit.process.test.ts
@@ -33,6 +33,7 @@ afterEach(async () => {
       }
     }),
   );
+  activeChildren.clear();
   await Promise.all(Array.from(activeServers, closeMinimalGatewayServer));
   activeServers.clear();
 });
@@ -264,54 +265,8 @@ describe("gateway-backed CLI process exit", () => {
     expect(JSON.parse(stdout)).toMatchObject({ jobs: [], total: 0 });
   }, 20_000);
 
-  it("keeps gateway auth failures machine-readable across CLI entry points", async () => {
+  it("keeps gateway auth failures machine-readable through the real health entry point", async () => {
     const root = tempDirs.make("openclaw-gateway-auth-json-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
-    const port = await getFreePort();
-    await fs.mkdir(stateDir, { recursive: true });
-
-    const cases: Array<{ label: string; args: string[]; env?: NodeJS.ProcessEnv }> = [
-      { label: "health", args: ["health", "--json", "--timeout", "250"] },
-      {
-        label: "health explicit URL",
-        args: ["health", "--json", "--timeout", "250"],
-        env: { OPENCLAW_GATEWAY_URL: `ws://127.0.0.1:${port}` },
-      },
-      {
-        label: "gateway health",
-        args: ["gateway", "health", "--json", "--port", String(port), "--timeout", "250"],
-      },
-      {
-        label: "gateway call",
-        args: ["gateway", "call", "health", "--json", "--timeout", "250"],
-      },
-    ];
-    for (const testCase of cases) {
-      const result = await runIsolatedGatewayCli({
-        args: testCase.args,
-        root,
-        stateDir,
-        configPath,
-        env: { OPENCLAW_GATEWAY_PORT: String(port), ...testCase.env },
-      });
-      expect(result, `${testCase.label}: ${result.stderr}`).toMatchObject({
-        code: 1,
-        signal: null,
-        stderr: "",
-      });
-      expect(JSON.parse(result.stdout)).toMatchObject({
-        ok: false,
-        error: {
-          type: "gateway_credentials_required",
-          message: expect.stringContaining("requires"),
-        },
-      });
-    }
-  }, 60_000);
-
-  it("preserves authenticated unreachable failures as transport errors", async () => {
-    const root = tempDirs.make("openclaw-gateway-transport-json-");
     const stateDir = path.join(root, "state");
     const configPath = path.join(stateDir, "openclaw.json");
     const port = await getFreePort();
@@ -322,17 +277,16 @@ describe("gateway-backed CLI process exit", () => {
       root,
       stateDir,
       configPath,
-      env: {
-        OPENCLAW_GATEWAY_PORT: String(port),
-        OPENCLAW_GATEWAY_TOKEN: "test-token",
-      },
+      env: { OPENCLAW_GATEWAY_PORT: String(port) },
     });
 
     expect(result, result.stderr).toMatchObject({ code: 1, signal: null, stderr: "" });
     expect(JSON.parse(result.stdout)).toMatchObject({
       ok: false,
-      error: { type: "gateway_transport_error" },
-      gateway: { url: `ws://127.0.0.1:${port}` },
+      error: {
+        type: "gateway_credentials_required",
+        message: expect.stringContaining("requires"),
+      },
     });
   }, 30_000);
 


### PR DESCRIPTION
## What Problem This Solves

The gateway-backed CLI process suite paid for seven serial Node + TSX process launches even though four of them replayed error classification and JSON-routing contracts already owned by focused command and formatter tests. The focused file took 18.936s in exact-ref hosted CI and was a recurring CLI-shard hotspot.

## Why This Change Was Made

Keep three distinct real boundaries: the system-CA one-shot shutdown regression, one missing-credential JSON/exit composition sentinel through the real health entry point, and the real pre-hello WebSocket rate-limit path. Remove the explicit-URL, routed gateway-health, generic gateway-call, and authenticated-unreachable process replays; their semantics remain covered at the health command, routed-health, gateway registration, and call/formatter owners.

Independent review also found that timeout cleanup killed a tracked child without clearing its stale object from `activeChildren`; teardown now clears that set after child cleanup.

## User Impact

No runtime behavior changes. Developers and CI run four fewer full CLI processes while retaining the process and transport regressions that cannot be proven by in-process tests.

## Evidence

- **Hosted exact-ref target:** 18.936s → 9.286s (**51.0% faster**); both CLI jobs passed. Retained cron and rate-limit controls stayed within 1%, so the A/B was stable.
  - [Baseline job](https://github.com/openclaw/openclaw/actions/runs/31531256892/job/93911811110) at `01cd9cc2a80d71d6adb697938fe01fafb2feeb00`
  - [Head job](https://github.com/openclaw/openclaw/actions/runs/31531407990/job/93912310266) at `6a9b650970bfb6dd2c97213f64e38fcd7143f2fd`
- Entire shared cli-process config: 77.47s → 69.01s (**10.9% faster**).
- Local focused Vitest duration: 25.21s → 10.71s (**57.5% faster**).
- Test body: 21.853s → 9.323s (**57.3% faster**).
- Wrapper wall time: 31.88s → 17.07s (**46.5% faster**).
- Final focused run after teardown cleanup: 3/3 passed in 10.06s.
- Owner suites: 298/298 passed across `src/gateway/call.test.ts`, `src/commands/health.test.ts`, `src/cli/gateway-cli/health-route.test.ts`, and `src/cli/gateway-cli.coverage.test.ts`.
- `oxfmt --check` and `git diff --check` passed.
- Independent expert review: approve; no blocking findings. Its only cleanup finding was fixed.
- Bundled autoreview secret scan passed twice, but the configured Codex executable is unavailable in this orb; no model review ran through that helper.
