### PR TITLE
fix(ui): keep new-session identity anchored as the composer grows

### DIFF
--- a/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
@@ -33,12 +33,26 @@ async function withNewSessionPage(run: (page: Page) => Promise<void>): Promise<v
 }
 
 suite.define(() => {
-  it("grows the first prompt through ten lines before using a narrow scrollbar", async () => {
+  it("grows the first prompt downward without moving the identity, then caps at ten lines", async () => {
     await withNewSessionPage(async (page) => {
       const gateway = await installMockGateway(page);
       await page.goto(`${suite.server.baseUrl}new`);
       const message = page.locator(".new-session-page__message");
       await message.waitFor();
+
+      const identity = page.locator(
+        ".agent-chat__welcome-clawd, .agent-chat__welcome-avatar, .agent-chat__avatar--text",
+      );
+      const triggers = page.locator(".new-session-page__triggers");
+      const composer = page.locator(".new-session-page__composer");
+      const [identityBox, triggersBox, composerBox] = await Promise.all([
+        identity.boundingBox(),
+        triggers.boundingBox(),
+        composer.boundingBox(),
+      ]);
+      expect(identityBox).not.toBeNull();
+      expect(triggersBox).not.toBeNull();
+      expect(composerBox).not.toBeNull();
 
       const initial = await message.evaluate((element) => ({
         height: element.clientHeight,
@@ -73,8 +87,16 @@ suite.define(() => {
         overflowY: getComputedStyle(element).overflowY,
         scrollHeight: element.scrollHeight,
       }));
+      const [expandedIdentityBox, expandedTriggersBox, expandedComposerBox] = await Promise.all([
+        identity.boundingBox(),
+        triggers.boundingBox(),
+        composer.boundingBox(),
+      ]);
       expect(capped.clientHeight).toBeLessThan(capped.scrollHeight);
       expect(capped.overflowY).toBe("auto");
+      expect(expandedIdentityBox?.y).toBeCloseTo(identityBox?.y ?? 0, 0);
+      expect(expandedTriggersBox?.y).toBeCloseTo(triggersBox?.y ?? 0, 0);
+      expect(expandedComposerBox?.y).toBeCloseTo(composerBox?.y ?? 0, 0);
       await captureUiProof(page, "new-session-composer-capped-scrollbar.png");
       const start = page.getByRole("button", { name: "Start session" });
       await expect(start.isVisible()).resolves.toBe(true);

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -1,7 +1,5 @@
-/* Full-page new-session draft: the start-screen welcome centers in the pane
-   with the draft block (clean target row + composer) between the hero and the
-   recent chats, so the draft reads as the start screen plus "where to start"
-   controls. */
+/* Full-page new-session draft: the welcome and draft form one top-anchored
+   composition, with the target row and composer between hero and recents. */
 openclaw-new-session-page {
   display: flex;
   flex: 1 1 0;
@@ -30,16 +28,15 @@ openclaw-new-session-page {
   padding: clamp(44px, 5vh, 52px) clamp(6px, 1vw, 12px) 6px;
 }
 
-/* The shared welcome stretches (flex: 1) and centers via justify-content,
-   which clips overflow above the scroll origin once the draft content is
-   taller than the pane (short window, open folder browser). Content-size it
-   here; its margin: auto still centers whenever there is spare room. */
+/* Content-size the shared welcome and top-anchor it inside the page scroll.
+   Auto vertical margins would re-center the identity as the textarea grows. */
 .new-session-page .agent-chat__welcome {
   flex: 0 0 auto;
   width: 100%;
   max-width: none;
   min-height: auto;
   box-sizing: border-box;
+  margin: 0 auto auto;
 }
 
 /* Draft block inside the centered welcome column; the welcome centers text,


### PR DESCRIPTION
Closes #122226

## What Problem This Solves

Fixes an issue where users drafting a new session would see the assistant identity and workspace picker jump upward when pasted or long text made the composer grow.

## Why This Change Was Made

The `/new` composition now uses upper-third gravity and stays top-anchored inside its existing scroll region. The identity, hint, workspace picker, and composer top remain fixed; the existing textarea grows downward to its ten-line cap and then scrolls internally.

Recent chats remain visible below the composer. Once growth is one-directional, they no longer move anything above the draft, and preserving them avoids removing useful navigation merely because the composer is non-empty.

## User Impact

Typing or pasting a long first prompt no longer repositions the new-session identity or target controls. The empty screen starts higher, long drafts remain bounded, and Recent chats stay available in both light and dark themes.

## Evidence

Captured with the real Control UI mock-Gateway surface in Chromium at 1440×900. Before ref: `32a43960c66bd1568712ca8d8c7e432932813271`. After ref: `f8e744af7d4c0517c1f129b24327bb6ca50493c8`.

### Light theme — before

| Empty composer | 18-line paste |
| --- | --- |
| ![Light theme before, empty composer: vertically centered new-session composition](https://github.com/user-attachments/assets/cdc2af24-4daf-48e5-9aad-ed9dc5c34fd5) | ![Light theme before, long composer: identity and workspace controls shifted upward](https://github.com/user-attachments/assets/512f887f-ab87-40c1-b431-087552f98a4e) |

### Light theme — after

| Empty composer | 18-line paste |
| --- | --- |
| ![Light theme after, empty composer: upper-third top-anchored composition](https://github.com/user-attachments/assets/6d3ef18c-d14e-4070-8523-8c60ec15d6c2) | ![Light theme after, long composer: identity stays fixed while the composer grows downward](https://github.com/user-attachments/assets/b064fb73-519a-4322-82c9-c6209465b1f7) |

### Dark theme — before

| Empty composer | 18-line paste |
| --- | --- |
| ![Dark theme before, empty composer: vertically centered new-session composition](https://github.com/user-attachments/assets/6d09fe82-1f28-4556-94ff-1b56549893c8) | ![Dark theme before, long composer: identity and workspace controls shifted upward](https://github.com/user-attachments/assets/c64ca613-0cfd-474d-a905-5143619e8ae6) |

### Dark theme — after

| Empty composer | 18-line paste |
| --- | --- |
| ![Dark theme after, empty composer: upper-third top-anchored composition](https://github.com/user-attachments/assets/18586ab6-e557-4a9f-8121-6f41df8ed7e6) | ![Dark theme after, long composer: identity stays fixed while the composer grows downward](https://github.com/user-attachments/assets/ecc4924b-d94c-45f6-8ee7-5ce5a50283a5) |

The browser geometry check measures the full growth sequence:

```text
before identity top: 161.046875px -> 81px      (-80.046875px)
after identity top:   81px -> 81px             (0px)
after picker top:     288.328125px -> 288.328125px (0px)
after composer top:   322.328125px -> 322.328125px (0px)
long textarea:        212px client / 369px scroll height
page scroll top:      0px
```

Focused red/green regression proof:

```text
# With the old auto-margin behavior
new-session-page.prompt-attachments.e2e.test.ts
expected 151.1875 to be close to 239.15625 (difference 87.96875)

# With this PR
Test Files  1 passed (1)
Tests       11 passed (11)
```

Commands:

```bash
nice -n 19 ./node_modules/.bin/stylelint ui/src/styles/new-session.css --config config/stylelint.config.mjs
nice -n 19 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
```

Testbox lease `tbx_01kzs5g8nzwafbdebvxzr7zk0k` / run https://github.com/openclaw/openclaw/actions/runs/31529124663 passed the full changed gate plus the focused Chromium suite on the patch-identical pre-rebase head. The final rebase adopted only unrelated main changes; the focused suite and all screenshots were rerun on the final head.

Production delta: `+5/-8` (net `-3`). Test delta: `+23/-1` (net `+22`). Exact-head PR CI is green: https://github.com/openclaw/openclaw/actions/runs/31532017749.