### PR TITLE
fix: stop process poll coverage from dropping earlier output

### DIFF
--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -733,16 +733,16 @@ describe("exec tool backgrounding", () => {
 
       const sessionId = requireRunningSessionId(result);
 
-      let output = "";
+      const outputs: string[] = [];
       await expect
         .poll(async () => {
           const pollResult = await pollProcessSession({ tool: processTool, sessionId });
-          output = pollResult.output ?? "";
+          outputs.push(pollResult.output ?? "");
           return pollResult.status;
         }, BACKGROUND_POLL_OPTIONS)
         .toBe(PROCESS_STATUS_COMPLETED);
 
-      expect(output).toContain(OUTPUT_DONE);
+      expect(outputs.join("\n")).toContain(OUTPUT_DONE);
     },
     isWin ? 15_000 : 5_000,
   );


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the main CI process-tool integration test could fail after successfully observing background command output, because a later terminal poll correctly returned only the exit receipt and the test discarded the earlier response.

## Why This Change Was Made

Process polling is intentionally incremental: each poll returns only newly available output, and terminal polls do not replay drained text. The integration test now retains every observed poll response before checking for the command output, matching that public contract without changing production behavior.

## User Impact

No user-visible behavior changes. This restores reliable CI coverage for background exec polling while preserving the no-replay process contract.

## Evidence

- Exact failure: [main CI run 31529006284](https://github.com/openclaw/openclaw/actions/runs/31529006284), `checks-node-compact-large-7`, where the terminal response was `(no new output)` after an earlier poll had consumed `done`.
- Focused Testbox proof: [run 31530902145](https://github.com/openclaw/openclaw/actions/runs/31530902145), `src/agents/bash-tools.test.ts`: 35/35 tests passed.
- Changed-file Testbox gate: [run 31532056896](https://github.com/openclaw/openclaw/actions/runs/31532056896): formatting, core test typecheck, lint, dead-code, boundary, and ratchet checks passed.
- Autoreview: clean, with no accepted or actionable findings.
- LOC: production `+0/-0`; tests `+3/-3` (net zero).
