### PR TITLE
fix(docker): stamp correction release image versions

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -171,6 +171,7 @@ jobs:
       contents: read
     outputs:
       built_at: ${{ steps.build_provenance.outputs.built_at }}
+      release_version: ${{ steps.build_provenance.outputs.release_version }}
       source_sha: ${{ steps.build_provenance.outputs.source_sha }}
     steps:
       - name: Checkout selected source
@@ -182,10 +183,13 @@ jobs:
       - name: Resolve shared build provenance
         id: build_provenance
         shell: bash
+        env:
+          RELEASE_VERSION: ${{ needs.resolve_release_policy.outputs.version }}
         run: |
           set -euo pipefail
           echo "source_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           echo "built_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+          echo "release_version=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
 
   # KEEP THIS WORKFLOW ON GITHUB-HOSTED RUNNERS.
   # DO NOT MOVE IT BACK TO BLACKSMITH WITHOUT RE-VALIDATING TAG BUILDS AND BACKFILLS.
@@ -323,6 +327,7 @@ jobs:
           build-args: |
             GIT_COMMIT=${{ needs.resolve_build_provenance.outputs.source_sha }}
             OPENCLAW_BUILD_TIMESTAMP=${{ needs.resolve_build_provenance.outputs.built_at }}
+            OPENCLAW_BUILD_VERSION=${{ needs.resolve_build_provenance.outputs.release_version }}
             OPENCLAW_EXTENSIONS=diagnostics-otel,codex
           tags: ${{ steps.tags.outputs.value }}
           labels: ${{ steps.labels.outputs.value }}
@@ -345,6 +350,7 @@ jobs:
           build-args: |
             GIT_COMMIT=${{ needs.resolve_build_provenance.outputs.source_sha }}
             OPENCLAW_BUILD_TIMESTAMP=${{ needs.resolve_build_provenance.outputs.built_at }}
+            OPENCLAW_BUILD_VERSION=${{ needs.resolve_build_provenance.outputs.release_version }}
             OPENCLAW_EXTENSIONS=diagnostics-otel,codex
             OPENCLAW_INSTALL_BROWSER=1
           tags: ${{ steps.tags.outputs.browser }}
@@ -356,6 +362,7 @@ jobs:
       - name: Smoke test amd64 runtime workspace templates
         shell: bash
         env:
+          EXPECTED_IMAGE_VERSION: ${{ needs.resolve_build_provenance.outputs.release_version }}
           IMAGE_REFS: ${{ steps.tags.outputs.value }}
         run: |
           set -euo pipefail
@@ -365,8 +372,12 @@ jobs:
             echo "::error::No amd64 image ref resolved for runtime template smoke"
             exit 1
           fi
-          docker run --rm --entrypoint /bin/sh "${image_ref}" -lc '
+          docker run --rm --entrypoint /bin/sh \
+            -e "EXPECTED_IMAGE_VERSION=${EXPECTED_IMAGE_VERSION}" \
+            "${image_ref}" -lc '
             set -eu
+            test "$(node -p "require(\"/app/package.json\").version")" = "$EXPECTED_IMAGE_VERSION"
+            test "$(node -p "require(\"/app/dist/build-info.json\").version")" = "$EXPECTED_IMAGE_VERSION"
             test -f /app/src/agents/templates/HEARTBEAT.md
             temp_root="$(mktemp -d)"
             trap "rm -rf \"${temp_root}\"" EXIT
@@ -531,6 +542,7 @@ jobs:
           build-args: |
             GIT_COMMIT=${{ needs.resolve_build_provenance.outputs.source_sha }}
             OPENCLAW_BUILD_TIMESTAMP=${{ needs.resolve_build_provenance.outputs.built_at }}
+            OPENCLAW_BUILD_VERSION=${{ needs.resolve_build_provenance.outputs.release_version }}
             OPENCLAW_EXTENSIONS=diagnostics-otel,codex
           tags: ${{ steps.tags.outputs.value }}
           labels: ${{ steps.labels.outputs.value }}
@@ -553,6 +565,7 @@ jobs:
           build-args: |
             GIT_COMMIT=${{ needs.resolve_build_provenance.outputs.source_sha }}
             OPENCLAW_BUILD_TIMESTAMP=${{ needs.resolve_build_provenance.outputs.built_at }}
+            OPENCLAW_BUILD_VERSION=${{ needs.resolve_build_provenance.outputs.release_version }}
             OPENCLAW_EXTENSIONS=diagnostics-otel,codex
             OPENCLAW_INSTALL_BROWSER=1
           tags: ${{ steps.tags.outputs.browser }}
@@ -564,6 +577,7 @@ jobs:
       - name: Smoke test arm64 runtime workspace templates
         shell: bash
         env:
+          EXPECTED_IMAGE_VERSION: ${{ needs.resolve_build_provenance.outputs.release_version }}
           IMAGE_REFS: ${{ steps.tags.outputs.value }}
         run: |
           set -euo pipefail
@@ -573,8 +587,12 @@ jobs:
             echo "::error::No arm64 image ref resolved for runtime template smoke"
             exit 1
           fi
-          docker run --rm --entrypoint /bin/sh "${image_ref}" -lc '
+          docker run --rm --entrypoint /bin/sh \
+            -e "EXPECTED_IMAGE_VERSION=${EXPECTED_IMAGE_VERSION}" \
+            "${image_ref}" -lc '
             set -eu
+            test "$(node -p "require(\"/app/package.json\").version")" = "$EXPECTED_IMAGE_VERSION"
+            test "$(node -p "require(\"/app/dist/build-info.json\").version")" = "$EXPECTED_IMAGE_VERSION"
             test -f /app/src/agents/templates/HEARTBEAT.md
             temp_root="$(mktemp -d)"
             trap "rm -rf \"${temp_root}\"" EXIT

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,6 +116,7 @@ RUN set -eux; \
 # these after the dependency layer so a new timestamp does not invalidate install.
 ARG GIT_COMMIT=""
 ARG OPENCLAW_BUILD_TIMESTAMP=""
+ARG OPENCLAW_BUILD_VERSION=""
 ENV GIT_COMMIT=${GIT_COMMIT} \
     OPENCLAW_BUILD_TIMESTAMP=${OPENCLAW_BUILD_TIMESTAMP}
 
@@ -145,8 +146,13 @@ RUN pnpm_config_verify_deps_before_run=false pnpm canvas:a2ui:bundle || \
      rm -rf vendor/a2ui apps/shared/OpenClawKit/Tools/CanvasA2UI)
 # Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
 ENV OPENCLAW_PREFER_PNPM=1
+# Correction-release source keeps the base package version, but official images
+# must report the complete release tag from the publish workflow.
 RUN set -eu; \
     selected_plugin_dirs="$(cat /tmp/openclaw-selected-plugin-dirs)"; \
+    if [ -n "$OPENCLAW_BUILD_VERSION" ]; then \
+      pnpm pkg set "version=$OPENCLAW_BUILD_VERSION"; \
+    fi; \
     if [ -z "$OPENCLAW_BUILD_TIMESTAMP" ]; then \
       OPENCLAW_BUILD_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
       export OPENCLAW_BUILD_TIMESTAMP; \

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -521,6 +521,9 @@ describe("Dockerfile", () => {
 
     expect(workflow).toContain("resolve_build_provenance:");
     expect(workflow).toContain("built_at: ${{ steps.build_provenance.outputs.built_at }}");
+    expect(workflow).toContain(
+      "release_version: ${{ steps.build_provenance.outputs.release_version }}",
+    );
     expect(workflow).toContain("source_sha: ${{ steps.build_provenance.outputs.source_sha }}");
     expect(workflow.match(/date -u \+%Y-%m-%dT%H:%M:%SZ/gu)).toHaveLength(1);
     expect(
@@ -539,6 +542,34 @@ describe("Dockerfile", () => {
         "OPENCLAW_BUILD_TIMESTAMP=${{ needs.resolve_build_provenance.outputs.built_at }}",
       ).length - 1,
     ).toBe(4);
+  });
+
+  it("stamps and verifies the full correction-release version in official images", async () => {
+    const [dockerfile, workflow] = await Promise.all([
+      readFile(dockerfilePath, "utf8"),
+      readFile(dockerReleaseWorkflowPath, "utf8"),
+    ]);
+    const versionArgIndex = dockerfile.indexOf('ARG OPENCLAW_BUILD_VERSION=""');
+    const versionStampIndex = dockerfile.indexOf('pnpm pkg set "version=$OPENCLAW_BUILD_VERSION"');
+    const buildIndex = dockerfile.indexOf("pnpm build:docker");
+
+    expect(versionArgIndex).toBeGreaterThan(-1);
+    expect(versionStampIndex).toBeGreaterThan(versionArgIndex);
+    expect(versionStampIndex).toBeLessThan(buildIndex);
+    expect(
+      workflow.split(
+        "OPENCLAW_BUILD_VERSION=${{ needs.resolve_build_provenance.outputs.release_version }}",
+      ).length - 1,
+    ).toBe(4);
+    expect(
+      workflow.split(
+        "EXPECTED_IMAGE_VERSION: ${{ needs.resolve_build_provenance.outputs.release_version }}",
+      ).length - 1,
+    ).toBe(2);
+    expect(workflow.split(String.raw`require(\"/app/package.json\").version`).length - 1).toBe(2);
+    expect(
+      workflow.split(String.raw`require(\"/app/dist/build-info.json\").version`).length - 1,
+    ).toBe(2);
   });
 
   it("publishes official Docker browser images with baked Chromium", async () => {


### PR DESCRIPTION
## What Problem This Solves

Correction-release tags intentionally keep the repository package version at the base release, but official Docker builds copied that base version into the image. A `2026.7.1-2` image therefore reported `2026.7.1` and could show a permanent update banner.

Fixes #121958.

## Why This Change Was Made

The Docker release workflow already validates and resolves the full immutable tag version. This change carries that prepared value with the shared build provenance and passes it to all four official image builds. The Docker build stamps only its copied root package metadata before backend, Control UI, and build-info generation, preserving the repository and native release base-version contract.

The amd64 and arm64 runtime smokes now verify that both `/app/package.json` and `/app/dist/build-info.json` match the resolved release version.

## User Impact

Correction-release container images report the same full version as their published tag, so the Control UI no longer treats a current correction image as permanently outdated. Normal source builds remain unchanged when the optional Docker build argument is absent. No config, migration, or runtime fallback is added.

## Evidence

- `git diff --check HEAD^..HEAD`
- Parsed `.github/workflows/docker-release.yml` with the repository-installed `yaml` parser
- Direct structural assertions verified the stamp precedes `pnpm build:docker`, all four official builds receive the resolved version, and both architecture smokes check package/build-info identity
- Executed the exact nested shell quoting used by the runtime version smoke
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD --stream-engine-output`: clean, no accepted/actionable findings, patch correct at 0.99 confidence
- `node scripts/run-vitest.mjs src/dockerfile.test.ts` was attempted, but the linked checkout's shared dependency state failed before test collection with `configureFsSafeNative is not a function`; exact-head CI is the authoritative Vitest proof
- Pinned actionlint was attempted twice, but the host's shared Go sumdb cache is read-only; YAML parsing passed and exact-head workflow sanity CI remains required
