### PR TITLE
improve: trim duplicate Claw authoring process tests

### DIFF
--- a/src/cli/claws-authoring-state.process.test.ts
+++ b/src/cli/claws-authoring-state.process.test.ts
@@ -74,38 +74,23 @@ function runClaws(root: string, args: string[]) {
 }
 
 describe("Claw authoring process state", () => {
-  it.each(["create", "validate", "build", "dev"] as const)(
-    "leaves migration-pending operator state unchanged for claws %s",
-    async (command) => {
-      const root = tempDirs.make(`openclaw-claws-${command}-state-`);
-      const external = tempDirs.make(`openclaw-claws-${command}-external-`);
-      const project = path.join(external, command === "create" ? "created-project" : "project");
-      const output = path.join(external, `${command}.tgz`);
-      const workspace = path.join(external, `${command}-workspace`);
-      await fs.mkdir(path.join(root, "config"), { recursive: true });
-      await fs.mkdir(path.join(root, "state", "tasks"), { recursive: true });
-      await fs.writeFile(path.join(root, "config", "openclaw.json"), "{}\n");
-      await fs.writeFile(path.join(root, "state", "tasks", "runs.sqlite"), "legacy state\n");
-      if (command !== "create") {
-        await writeProject(project);
-      }
-      const before = await snapshotTree(root);
-      const args =
-        command === "create"
-          ? ["create", project, "--json"]
-          : command === "validate"
-            ? ["validate", project, "--json"]
-            : command === "build"
-              ? ["build", project, "--out", output, "--json"]
-              : ["dev", project, "--workspace", workspace, "--json"];
+  it("leaves migration-pending operator state unchanged for claws dev", async () => {
+    const root = tempDirs.make("openclaw-claws-dev-state-");
+    const external = tempDirs.make("openclaw-claws-dev-external-");
+    const project = path.join(external, "project");
+    const workspace = path.join(external, "dev-workspace");
+    await fs.mkdir(path.join(root, "config"), { recursive: true });
+    await fs.mkdir(path.join(root, "state", "tasks"), { recursive: true });
+    await fs.writeFile(path.join(root, "config", "openclaw.json"), "{}\n");
+    await fs.writeFile(path.join(root, "state", "tasks", "runs.sqlite"), "legacy state\n");
+    await writeProject(project);
+    const before = await snapshotTree(root);
 
-      const result = runClaws(root, args);
+    const result = runClaws(root, ["dev", project, "--workspace", workspace, "--json"]);
 
-      expect(result.error).toBeUndefined();
-      expect(result.status, result.stderr).toBe(0);
-      expect(JSON.parse(result.stdout)).toBeTruthy();
-      expect(await snapshotTree(root)).toEqual(before);
-    },
-    120_000,
-  );
+    expect(result.error).toBeUndefined();
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toBeTruthy();
+    expect(await snapshotTree(root)).toEqual(before);
+  }, 120_000);
 });


### PR DESCRIPTION
## What Problem This Solves

The Claw authoring state suite launched four serial Node + TSX CLI processes to repeat one shared startup-policy invariant. The focused file took 12.65s locally even though policy ownership and command behavior are already exhaustively covered in-process.

## Why This Change Was Made

Retain `claws dev` as the single real-process representative because it exercises the same shared startup policy as create/validate/build and additionally reads an operator config snapshot. The startup-policy suite continues checking every authoring command path, while the project CLI suite continues invoking all four handlers and their command-specific outputs.

## User Impact

No runtime behavior changes. Developers and CI run three fewer full CLI processes while preserving the real boundary that migration-pending operator state remains byte-for-byte unchanged.

## Evidence

- Hosted exact-ref target-file time: 11.819s → 3.553s (**69.9% faster**), comparing baseline `01c1ebf803e24cb2e9cf40b2dcb850263379665c` with head `f629155fe0ed60da8cbd3f7093cf4889bc8100b7` in the same `checks-node-agentic-cli` workflow.
- Hosted baseline: [run 31533419865](https://github.com/openclaw/openclaw/actions/runs/31533419865), job 93918979975.
- Hosted head: [run 31533420410](https://github.com/openclaw/openclaw/actions/runs/31533420410), job 93918918123.
- Focused local Vitest duration: 12.65s → 3.75s (**70.4% faster**).
- Local test body: 10.741s → 2.893s (**73.1% faster**).
- Local wrapper wall time: 19.15s → 10.13s (**47.1% faster**).
- Retained process suite: 1/1 passed.
- Shared startup-policy and all-four-handler owner suites: 19/19 passed.
- Canonical project owner suite: 27 passed, 1 skipped.
- `oxfmt --check` and `git diff --check` passed.
- Independent expert review: approve; no blocking findings. It confirmed `dev` is the strongest retained process representative and the deleted rows have no distinct startup/state boundary.
- Bundled autoreview secret scan passed, but the configured Codex executable is unavailable in this orb; no model review ran through that helper.
