### PR TITLE
fix(backup): exclude transient state temp files

### DIFF
--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -110,7 +110,7 @@ SQLite databases under the state directory are captured with SQLite's online bac
 
 Installed plugin source and manifest files under the state directory's `extensions/` tree are included, but their nested `node_modules/` dependency trees are skipped as rebuildable install artifacts. After restoring an archive, use `openclaw plugins update <id>` or reinstall with `openclaw plugins install <spec> --force` if a restored plugin reports missing dependencies.
 
-Installer-managed and rebuildable runtime roots under the state directory are also skipped: `dev/`, `git/`, `npm/`, legacy `npm-runtime/`, and `tools/`. These contain managed checkouts, package trees, and downloaded runtimes rather than authoritative user state; reinstall or update the corresponding runtime or plugin after restore. An explicitly configured config file, credentials directory, or workspace inside one of these roots remains included.
+Installer-managed and rebuildable runtime roots under the state directory are also skipped: `dev/`, `git/`, `npm/`, legacy `npm-runtime/`, `tmp/`, and `tools/`. These contain managed checkouts, package trees, compiler caches, temporary files, and downloaded runtimes rather than authoritative user state; reinstall or update the corresponding runtime or plugin after restore. An explicitly configured config file, credentials directory, or workspace inside one of these roots remains included.
 
 Local edits inside a managed `dev/` checkout are developer source, not OpenClaw product state, and are not included. Commit and push those edits or copy the checkout separately before relying on a state backup.
 

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -726,7 +726,7 @@ describe("createBackupArchive", () => {
             suffix,
           ).toBe(false);
         }
-        expect(result.skippedVolatileCount).toBe(10);
+        expect(result.skippedVolatileCount).toBe(9);
       },
     );
   });
@@ -2524,7 +2524,9 @@ describe("createBackupArchive", () => {
         await fs.mkdir(path.join(stateDir, "dev", "openclaw", "dist"), { recursive: true });
         await fs.mkdir(path.join(stateDir, "developer"), { recursive: true });
         await fs.mkdir(path.join(stateDir, "dev-backup"), { recursive: true });
-        for (const managedRoot of ["dev", "git", "npm-runtime", "tools"]) {
+        await fs.mkdir(path.join(stateDir, "temporary"), { recursive: true });
+        await fs.mkdir(path.join(stateDir, "tmp-data"), { recursive: true });
+        for (const managedRoot of ["dev", "git", "npm-runtime", "tmp", "tools"]) {
           await fs.mkdir(path.join(stateDir, managedRoot, "runtime"), { recursive: true });
           await fs.writeFile(
             path.join(stateDir, managedRoot, "runtime", "fixture.sqlite"),
@@ -2589,6 +2591,8 @@ describe("createBackupArchive", () => {
         );
         await fs.writeFile(path.join(stateDir, "developer", "keep.txt"), "keep\n", "utf8");
         await fs.writeFile(path.join(stateDir, "dev-backup", "keep.txt"), "keep\n", "utf8");
+        await fs.writeFile(path.join(stateDir, "temporary", "keep.txt"), "keep\n", "utf8");
+        await fs.writeFile(path.join(stateDir, "tmp-data", "keep.txt"), "keep\n", "utf8");
         await fs.mkdir(outputDir, { recursive: true });
 
         const result = await createBackupArchive({
@@ -2603,7 +2607,7 @@ describe("createBackupArchive", () => {
         expect(entrySuffixes).toContain("/state/extensions/demo/src/index.js");
         expect(entrySuffixes).toContain("/state/node_modules/root-dep/index.js");
         expect(entrySuffixes).toContain("/state/node_modules/root-dep/fixture.sqlite");
-        for (const managedRoot of ["dev", "git", "npm", "npm-runtime", "tools"]) {
+        for (const managedRoot of ["dev", "git", "npm", "npm-runtime", "tmp", "tools"]) {
           expect(
             entrySuffixes.some(
               (entry) =>
@@ -2614,6 +2618,8 @@ describe("createBackupArchive", () => {
         }
         expect(entrySuffixes).toContain("/state/developer/keep.txt");
         expect(entrySuffixes).toContain("/state/dev-backup/keep.txt");
+        expect(entrySuffixes).toContain("/state/temporary/keep.txt");
+        expect(entrySuffixes).toContain("/state/tmp-data/keep.txt");
         const pluginNodeModuleEntries = entries.filter((entry) =>
           entry.includes("/state/extensions/demo/node_modules/"),
         );
@@ -2637,6 +2643,8 @@ describe("createBackupArchive", () => {
       async (state) => {
         const stateDir = state.stateDir;
         const workspaceDir = path.join(stateDir, "dev", "workspace");
+        const tmpWorkspaceDir = path.join(stateDir, "tmp", "workspace");
+        const externalTmpWorkspaceDir = state.path("tmp");
         const runtimeDir = path.join(stateDir, "dev", "openclaw");
         const configPath = path.join(stateDir, "git", "config", "openclaw.json");
         const oauthDir = path.join(stateDir, "tools", "oauth");
@@ -2647,6 +2655,9 @@ describe("createBackupArchive", () => {
         state.envVars.OPENCLAW_OAUTH_DIR = oauthDir;
         state.applyEnv();
         await fs.mkdir(workspaceDir, { recursive: true });
+        await fs.mkdir(tmpWorkspaceDir, { recursive: true });
+        await fs.mkdir(externalTmpWorkspaceDir, { recursive: true });
+        await fs.mkdir(path.join(stateDir, "tmp", "tsx-501"), { recursive: true });
         await fs.mkdir(runtimeDir, { recursive: true });
         await fs.mkdir(path.dirname(configPath), { recursive: true });
         await fs.mkdir(oauthDir, { recursive: true });
@@ -2655,13 +2666,32 @@ describe("createBackupArchive", () => {
           configPath,
           `${JSON.stringify({
             agents: {
-              entries: { main: { default: true, workspace: workspaceDir } },
+              entries: {
+                main: { default: true, workspace: workspaceDir },
+                external: { workspace: externalTmpWorkspaceDir },
+                worker: { workspace: tmpWorkspaceDir },
+              },
             },
           })}\n`,
           "utf8",
         );
         await fs.writeFile(path.join(oauthDir, "credentials.json"), "{}\n", "utf8");
         await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "durable workspace\n", "utf8");
+        await fs.writeFile(
+          path.join(tmpWorkspaceDir, "AGENTS.md"),
+          "durable tmp workspace\n",
+          "utf8",
+        );
+        await fs.writeFile(
+          path.join(externalTmpWorkspaceDir, "AGENTS.md"),
+          "durable external tmp workspace\n",
+          "utf8",
+        );
+        await fs.writeFile(
+          path.join(stateDir, "tmp", "tsx-501", "cache-entry"),
+          "rebuildable compiler cache\n",
+          "utf8",
+        );
         await fs.writeFile(path.join(runtimeDir, "package.json"), "{}\n", "utf8");
         await fs.writeFile(path.join(toolRuntimeDir, "tool.bin"), "runtime\n", "utf8");
         const sqlite = requireNodeSqlite();
@@ -2688,6 +2718,10 @@ describe("createBackupArchive", () => {
         expect(
           entries.some((entry) => entry.endsWith("/state/dev/workspace/workspace.sqlite")),
         ).toBe(true);
+        expect(entries.some((entry) => entry.endsWith("/state/tmp/workspace/AGENTS.md"))).toBe(
+          true,
+        );
+        expect(entries.some((entry) => entry.endsWith("/tmp/AGENTS.md"))).toBe(true);
         expect(entries.some((entry) => entry.endsWith("/state/git/config/openclaw.json"))).toBe(
           true,
         );
@@ -2695,6 +2729,7 @@ describe("createBackupArchive", () => {
           true,
         );
         expect(entries.some((entry) => entry.includes("/state/dev/openclaw/"))).toBe(false);
+        expect(entries.some((entry) => entry.includes("/state/tmp/tsx-501/"))).toBe(false);
         expect(entries.some((entry) => entry.includes("/state/tools/runtime/"))).toBe(false);
 
         const runtime: RuntimeEnv = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -331,7 +331,7 @@ function normalizeBackupFilterPath(value: string): string {
   return value.replaceAll("\\", "/").replace(/\/+$/u, "");
 }
 
-const REINSTALLABLE_STATE_ROOTS = new Set(["dev", "git", "npm", "npm-runtime", "tools"]);
+const NON_AUTHORITATIVE_STATE_ROOTS = new Set(["dev", "git", "npm", "npm-runtime", "tmp", "tools"]);
 
 function buildStateBackupFilter(
   stateDir: string,
@@ -348,7 +348,7 @@ function buildStateBackupFilter(
     }
 
     const segments = normalizedFilePath.slice(statePrefix.length).split("/");
-    if (REINSTALLABLE_STATE_ROOTS.has(segments[0] ?? "")) {
+    if (NON_AUTHORITATIVE_STATE_ROOTS.has(segments[0] ?? "")) {
       const resolvedFilePath = path.resolve(filePath);
       // Configured workspaces nested under a managed root remain authoritative
       // user state. Keep their ancestors traversable without admitting siblings.


### PR DESCRIPTION
Related: #122213
Related: #122235

## What Problem This Solves

Fixes an issue where backup archives included the macOS managed service's state-local temporary directory. That directory contains rebuildable compiler caches, locks, temporary database copies, and other scratch files rather than authoritative OpenClaw state.

## Why This Change Was Made

macOS services intentionally set `TMPDIR=<stateDir>/tmp`; TSX and other runtime dependencies therefore create cache files there. The exact top-level `tmp/` root now uses the same non-authoritative state filter as managed checkouts, package trees, and downloaded runtimes. Explicitly configured config, credential, or workspace paths nested under `tmp/` remain included through the existing preserved-path corridor. External workspaces named `tmp` are unaffected.

The change does not special-case TSX paths, alter the five-minute watchdog, or weaken the raw-byte diagnostics landed in #122235. The last-reported live entry was not proven causal; this PR repairs the independent backup-contract defect.

## User Impact

Backups skip service scratch that is recreated on startup or cache miss, while preserving durable configured paths. This reduces archive churn and prevents temporary SQLite-looking files from entering snapshot discovery.

## Evidence

- Focused create/verify proof: 100 passed, 1 skipped.
- Tests cover `tmp/tsx-501`, invalid SQLite-looking debris, exact-root exclusion, configured workspace preservation inside state `tmp`, external workspace `tmp` preservation, and near names `temporary`/`tmp-data`.
- Core production and test typechecks, targeted oxlint, and format checks passed on Testbox: https://github.com/openclaw/openclaw/actions/runs/31532719365
- Docs MDX check passed for 770 files; 6,442-link audit reported zero broken links.
- Autoreview: no accepted/actionable findings (`patch is correct`, confidence 0.99).

Production LOC: +2/-2 (net 0). Tests: +39/-4. Docs: +1/-1.
