### PR TITLE
fix(agents): preserve reply cleanup when cancellation throws

### DIFF
--- a/src/auto-reply/reply/reply-run-registry.operation.ts
+++ b/src/auto-reply/reply/reply-run-registry.operation.ts
@@ -195,6 +195,8 @@ export function createReplyOperation(params: {
     }
     phase = "aborted";
     abortInternally(abortReason);
+    // Cancellation may throw, but lifecycle cleanup still must run. Pre-backend
+    // non-retained owners release now; retained/running owners await terminal settle.
     try {
       getAttachedBackend(operation)?.cancel(reason);
     } finally {

--- a/src/auto-reply/reply/reply-run-registry.operation.ts
+++ b/src/auto-reply/reply/reply-run-registry.operation.ts
@@ -183,18 +183,30 @@ export function createReplyOperation(params: {
     terminalSettleTimer.scheduleOnce(REPLY_RUN_TERMINAL_SETTLE_TIMEOUT_MS);
   };
 
-  const abortWithReason = (
+  const abortOperation = (
     reason: ReplyBackendCancelReason,
     abortReason: unknown,
-    opts?: { abortedCode?: ReplyOperationAbortCode },
+    abortedCode: ReplyOperationAbortCode,
   ) => {
-    if (opts?.abortedCode && !result) {
-      setResult({ kind: "aborted", code: opts.abortedCode });
+    const phaseBeforeAbort = phase;
+    if (!result) {
+      setResult({ kind: "aborted", code: abortedCode });
       detachUpstreamAbort();
     }
     phase = "aborted";
     abortInternally(abortReason);
-    getAttachedBackend(operation)?.cancel(reason);
+    try {
+      getAttachedBackend(operation)?.cancel(reason);
+    } finally {
+      if (
+        isReplyOperationPreBackendPhase(phaseBeforeAbort) &&
+        !retainStateUntilCompleteOperations.has(operation)
+      ) {
+        clearState();
+      } else {
+        scheduleTerminalSettle();
+      }
+    }
   };
 
   const operation: ReplyOperation = {
@@ -463,36 +475,14 @@ export function createReplyOperation(params: {
       if (!isReplyOperationAbortable(operation)) {
         return false;
       }
-      const phaseBeforeAbort = phase;
-      abortWithReason("user_abort", createUserAbortError(), {
-        abortedCode: "aborted_by_user",
-      });
-      if (
-        isReplyOperationPreBackendPhase(phaseBeforeAbort) &&
-        !retainStateUntilCompleteOperations.has(operation)
-      ) {
-        clearState();
-      } else {
-        scheduleTerminalSettle();
-      }
+      abortOperation("user_abort", createUserAbortError(), "aborted_by_user");
       return true;
     },
     abortForRestart() {
       if (!isReplyOperationAbortable(operation)) {
         return false;
       }
-      const phaseBeforeAbort = phase;
-      abortWithReason("restart", createAgentRunRestartAbortError(), {
-        abortedCode: "aborted_for_restart",
-      });
-      if (
-        isReplyOperationPreBackendPhase(phaseBeforeAbort) &&
-        !retainStateUntilCompleteOperations.has(operation)
-      ) {
-        clearState();
-      } else {
-        scheduleTerminalSettle();
-      }
+      abortOperation("restart", createAgentRunRestartAbortError(), "aborted_for_restart");
       return true;
     },
   };
@@ -638,18 +628,11 @@ export function createReplyOperation(params: {
         return;
       }
       const restart = isAgentRunRestartAbortReason(upstreamAbortSignal.reason);
-      const phaseBeforeAbort = phase;
-      abortWithReason(restart ? "restart" : "user_abort", upstreamAbortSignal.reason, {
-        abortedCode: restart ? "aborted_for_restart" : "aborted_by_user",
-      });
-      if (
-        isReplyOperationPreBackendPhase(phaseBeforeAbort) &&
-        !retainStateUntilCompleteOperations.has(operation)
-      ) {
-        clearState();
-      } else {
-        scheduleTerminalSettle();
-      }
+      abortOperation(
+        restart ? "restart" : "user_abort",
+        upstreamAbortSignal.reason,
+        restart ? "aborted_for_restart" : "aborted_by_user",
+      );
     };
     if (upstreamAbortSignal.aborted) {
       abortFromUpstream();

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -1163,6 +1163,73 @@ describe("reply run registry", () => {
     operation.complete();
   });
 
+  it.each([
+    {
+      name: "user abort while queued",
+      abort: (operation: ReturnType<typeof createTestReplyOperation>) => operation.abortByUser(),
+      code: "aborted_by_user",
+      reason: "user_abort",
+      phase: "queued",
+    },
+    {
+      name: "restart abort while queued",
+      abort: (operation: ReturnType<typeof createTestReplyOperation>) =>
+        operation.abortForRestart(),
+      code: "aborted_for_restart",
+      reason: "restart",
+      phase: "queued",
+    },
+    {
+      name: "user abort while running",
+      abort: (operation: ReturnType<typeof createTestReplyOperation>) => operation.abortByUser(),
+      code: "aborted_by_user",
+      reason: "user_abort",
+      phase: "running",
+    },
+    {
+      name: "restart abort while running",
+      abort: (operation: ReturnType<typeof createTestReplyOperation>) =>
+        operation.abortForRestart(),
+      code: "aborted_for_restart",
+      reason: "restart",
+      phase: "running",
+    },
+  ] as const)("preserves cleanup when backend cancellation throws: $name", async (testCase) => {
+    await withFakeReplyTimers(async () => {
+      const cancelError = new Error("cancel failed");
+      const cancel = vi.fn(() => {
+        throw cancelError;
+      });
+      const operation = createTestReplyOperation({
+        sessionKey: `agent:main:${testCase.reason}-${testCase.phase}`,
+        sessionId: `session-${testCase.reason}-${testCase.phase}`,
+      });
+      operation.attachBackend({ kind: "embedded", cancel, isStreaming: () => true });
+      operation.setPhase(testCase.phase);
+      const afterClear = vi.fn();
+      runAfterReplyOperationClear(operation, afterClear);
+
+      expect(() => testCase.abort(operation)).toThrow(cancelError);
+      expect(operation.result).toEqual({ kind: "aborted", code: testCase.code });
+      expect(operation.phase).toBe("aborted");
+      expect(operation.abortSignal.aborted).toBe(true);
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(cancel).toHaveBeenCalledWith(testCase.reason);
+
+      const retained = testCase.phase === "running";
+      expect(replyRunRegistry.isActive(operation.key)).toBe(retained);
+      expect(afterClear).toHaveBeenCalledTimes(retained ? 0 : 1);
+      expect(vi.getTimerCount()).toBe(retained ? 1 : 0);
+
+      await vi.advanceTimersByTimeAsync(REPLY_RUN_TERMINAL_SETTLE_TIMEOUT_MS);
+      expect(replyRunRegistry.isActive(operation.key)).toBe(false);
+      expect(afterClear).toHaveBeenCalledOnce();
+      operation.complete();
+      expect(afterClear).toHaveBeenCalledOnce();
+      expect(cancel).toHaveBeenCalledOnce();
+    });
+  });
+
   it("force-releases a running aborted operation when the owner never returns", async () => {
     await withFakeReplyTimers(async () => {
       const cancel = vi.fn();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a reply backend whose cancellation callback throws could leave queued reply ownership active indefinitely or leave running ownership without its terminal-settle deadline.

## Why This Change Was Made

The reply-operation owner now uses one canonical abort path for direct user aborts, restart aborts, and upstream cancellation. It records the terminal result, detaches upstream cancellation, aborts the local signal, invokes backend cancellation, and guarantees the phase-appropriate cleanup in `finally`.

The change preserves public abortability guards, upstream settled-result handling, user/restart result codes, the Plugin SDK contract, and backend cancellation exception propagation.

## User Impact

Reply lanes no longer remain wedged when backend cancellation throws. Normal cancellation behavior is unchanged.

## Evidence

- Prepared head: `1cdc152df420ad323b02c6d07db9ab1233976d52`.
- Landed via squash: `f30e67298a59384295d120198b083bae2e925577`; GitHub reports a valid verified signature, and the commit is live on `origin/main`.
- Pre-fix regression on current `main`: all four queued/running x user/restart cases fail. Queued ownership remains active; running ownership has no terminal-settle timer.
- Focused local test: `node scripts/run-vitest.mjs src/auto-reply/reply/reply-run-registry.test.ts` -> 80 passed.
- Plugin SDK baseline check: `generate-plugin-sdk-api-baseline.ts --check` -> `OK docs/.generated/plugin-sdk-api-baseline`.
- Blacksmith Testbox: workflow `31540936563`, job `93942917774`, lease `tbx_01kzsds47j67jj8pn91wfrzpaj`; exact tree `169e267f3fdd8a872d317d8fc4753ed0f9284c5c`; four files / 151 tests, `check:test-types`, and the exact two-file changed gate passed. The full workflow, teardown, and post steps completed successfully.
- AWS Crabbox: run `run_3b1147852239`, lease `cbx_904d5b7bb03e`; exact head verified, 151/151 lifecycle tests passed, built CLI and launcher version/help smokes passed, and the lease was released.
- Hosted CI: workflow `31543742410` completed successfully with 70 jobs and zero failures.
- Exact-head ClawSweeper review: no findings.
- Production LOC: +26/-41 (net -15). Tests: +67/-0.

AI-assisted: yes.
