### PR TITLE
fix(control-ui): bundle chat stylesheet so file preview panel scrolls

### DIFF
--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -5,6 +5,7 @@
 @import "./styles/components.css";
 @import "./styles/approval-boot.css";
 @import "./styles/settings.css";
+@import "./styles/chat.css";
 
 /* Contract read by stale-chunk-reload.ts to detect a failed entry stylesheet load.
  * Removing it leaves a fully unstyled page undetected. */


### PR DESCRIPTION
## Problem

Reading a `.md` file via the read tool in chat opens a "Markdown Preview" detail panel. Long documents overflow the viewport with **no scrollbar** — the user can't reach the bottom of the document.

![preview-no-scroll](https://user-images.githubusercontent.com/...placeholder)

## Root cause

`ui/src/pages/chat/components/chat-sidebar.ts` renders a `<div class="sidebar-panel-host--fill">` wrapper around the `<div class="sidebar-panel">` when the panel content kind is `file` or `markdown` (see the `fillHost` flag and the comment: *"Markdown previews and file editors need a bounded host wrapper so their inner content can shrink and scroll"*).

The wrapper class is **defined** in `ui/src/styles/chat/sidebar.css:1384`:

```css
.sidebar-panel-host--fill {
  display: flex;
  flex: 1;
  flex-direction: column;
  min-height: 0;
}
```

But the entry stylesheet (`ui/src/styles.css`, imported from `main.ts`) does **not** transitively pull in `chat/sidebar.css`:

- `main.ts` imports `./styles.css`
- `styles.css` imports `base.css`, `layout.css`, `layout.mobile.css`, `components.css`, `approval-boot.css`, `settings.css`
- **`chat.css` is never imported**

`chat.css` itself does `@import "./chat/sidebar.css"` and is imported from `chat-page.ts:25` (`import "../../styles/chat.css"`), but the vite build for the standalone control UI drops the wrapper rule. I confirmed in the production bundle `dist/control-ui/assets/index-*.css`: `grep "sidebar-panel-host--fill"` returns zero matches while the JS still applies the class to the DOM.

Without the rule, the wrapper collapses and `.sidebar-panel { height: 100% }` finds no bounded parent, so the panel expands past the viewport with no overflow.

## Fix

Add `@import "./styles/chat.css";` to `ui/src/styles.css` so the chat stylesheet chain (which includes `chat/sidebar.css` via its own `@import`) is reachable from the entry stylesheet and ends up in the production bundle.

One-line change.

## Verification

Before: `dist/control-ui/assets/index-*.css` contains `.sidebar-panel` rules but **no** `.sidebar-panel-host--fill`.

After rebuild: `.sidebar-panel-host--fill { display: flex; flex: 1; flex-direction: column; min-height: 0 }` is present.

End-user effect: the file/markdown preview panel stays bounded to ~85vh, the inner `.sidebar-content` shows a working scrollbar, and the full document is reachable.

I am running this fix in production against v2026.7.1-2 by manually appending the rule to the bundled CSS as a workaround, and it works exactly as expected. This PR moves the fix upstream where it belongs.

## Notes

- Tested with `openclaw@2026.7.1-2`.
- The fix is minimal (single `@import`) — please confirm it does not collide with the existing chunking/perf budgets in `scripts/check-control-ui-performance.mts`. I expect the additional rules to be tiny (a handful of selectors), but the build budget check is the right place to catch any regression.
- I did not change `chat/sidebar.css` itself — the missing rule is already there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)