### PR TITLE
feat(models): repeat provider auth setup

### DIFF
--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -153,6 +153,7 @@ Manages `agents.defaults.model.fallbacks`. `openclaw models image-fallbacks list
 openclaw models auth add
 openclaw models auth list [--provider <id>] [--json]
 openclaw models auth login --provider <id> [--agent <agentId>]
+openclaw models auth login --repeat
 openclaw models auth login --provider openai --profile-id openai:work
 openclaw models auth login-github-copilot
 openclaw models auth logout <profileId> [--yes]
@@ -173,6 +174,8 @@ openclaw models auth order clear --provider <id>
 `models auth logout <profileId>` removes one saved auth profile from the selected agent auth store. Use the profile id shown by `models auth list`. It also drops that profile from `auth.profiles` and from every `auth.order` list in your config, so no stale reference is left behind, and it deletes an `auth.order.<provider>` entry that would otherwise be emptied (an authored empty order means "select no profiles" and would disable the provider). It prompts for confirmation on a TTY; pass `--yes` for scripts and agents. Logout refuses when the profile is not in the store, or when a `models.providers.<id>.apiKey` entry names it — change that config value first.
 
 `models auth login-github-copilot` is a shortcut for `models auth login --provider github-copilot --method device` (GitHub device flow); it accepts `--yes` to overwrite an existing profile without prompting.
+
+Use `models auth login --repeat` to add multiple provider credentials in one interactive session. Provider-scoped options such as `--method` and `--profile-id` are cleared between iterations.
 
 Use either `openclaw models auth --agent <id> <subcommand>` or `openclaw models auth <subcommand> --agent <id>` to target a specific configured agent store. Both forms are supported by `add`, `list`, `login`, `logout`, `paste-api-key`, `setup-token`, `paste-token`, `login-github-copilot`, and `order get`/`set`/`clear`.
 

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -381,6 +381,7 @@ export function registerModelsCli(program: Command) {
       "Remove existing profiles for the provider before logging in (use when a cached OAuth profile is stuck or you want to switch accounts)",
       false,
     )
+    .option("--repeat", "Keep adding provider credentials until you stop", false)
     .action(async (opts, command) => {
       if (opts.deviceCode && typeof opts.method === "string" && opts.method !== "device-code") {
         throw new Error(
@@ -397,6 +398,7 @@ export function registerModelsCli(program: Command) {
             profileId: opts.profileId as string | undefined,
             setDefault: Boolean(opts.setDefault),
             force: Boolean(opts.force),
+            repeat: Boolean(opts.repeat),
             agent,
           },
           defaultRuntime,

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -895,6 +895,7 @@ type LoginOptions = {
    * because credentials already exist on disk.
    */
   force?: boolean;
+  repeat?: boolean;
 };
 
 export type ModelsAuthLoginFlowResult = {
@@ -1100,10 +1101,26 @@ export async function modelsAuthLoginCommand(opts: LoginOptions, runtime: Runtim
     );
   }
 
-  await runModelsAuthLoginFlowCore({
-    ...opts,
-    runtime,
-    prompter: createClackPrompter(),
-  });
+  const prompter = createClackPrompter();
+  let provider = opts.provider;
+  let first = true;
+  do {
+    await runModelsAuthLoginFlowCore({
+      ...opts,
+      provider,
+      ...(first ? {} : { force: false, setDefault: false }),
+      runtime,
+      prompter,
+    });
+    if (!opts.repeat) break;
+    const addAnother = await clackConfirm({ message: "Add another provider API key?", initialValue: true });
+    if (!addAnother) break;
+    provider = undefined;
+    first = false;
+    // Provider method and profile ids are scoped to the first provider. Do not
+    // carry them into the next picker iteration where they can be invalid or
+    // overwrite a profile belonging to another provider.
+    opts = { ...opts, method: undefined, profileId: undefined };
+  } while (true);
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

Adding a second model provider currently requires leaving the auth flow and repeating a broader onboarding/configuration journey. This makes multi-provider setups unnecessarily slow and makes manual model switching harder to discover.

## Why This Change Was Made

Adds `openclaw models auth login --repeat`. After each provider auth flow, OpenClaw asks whether another provider credential should be added. Subsequent iterations return to the provider picker, while existing credentials and the current default model are preserved.

Provider-scoped options (`--method` and `--profile-id`) are honored only for the first iteration and cleared before the next provider is selected, preventing invalid auth-method reuse or profile overwrites.

## User Impact

Advanced users can register several provider keys in one session and then use the existing `/model` picker to switch between the models exposed by those authenticated providers. Default-model changes remain opt-in through `--set-default`.

## Evidence

- `pnpm test src/commands/models/auth.test.ts` — 40/40 passing
- `git diff --check`
- Public CLI reference updated in `docs/cli/models.md`
- Rebased on `origin/main`
- Head commit: `2a42df97d`

Refs #122247
