### PR TITLE
feat(agents): replay persisted native video

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-transcript-persistence.e2e.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-transcript-persistence.e2e.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import { readSessionTranscriptRawDelta } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { afterEach, describe, expect, it } from "vitest";
@@ -6,10 +7,15 @@ import {
   appendTranscriptMessage,
   upsertSessionEntryCore,
 } from "../../../config/sessions/session-accessor.js";
+import { buildPersistedUserTurnMessage } from "../../../sessions/user-turn-transcript.js";
+import { captureEnv, setTestEnvValue } from "../../../test-utils/env.js";
+import { convertToLlm } from "../../sessions/messages.js";
 import { SessionManager } from "../../sessions/session-manager.js";
 import { flushSessionManagerTranscript } from "./attempt-transcript-helpers.js";
+import { materializeProviderContext } from "./images.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const MP4 = Buffer.from("0000001c6674797069736f6d0000000069736f6d0000000000000000", "hex");
 
 function buildAssistantMessage(text: string) {
   return {
@@ -38,6 +44,70 @@ function buildAssistantMessage(text: string) {
 }
 
 describe("embedded attempt transcript persistence", () => {
+  it("replays native video after reopening the canonical transcript", async () => {
+    const stateDir = tempDirs.make("openclaw-video-transcript-replay-");
+    const inboundDir = path.join(stateDir, "media", "inbound");
+    await fs.mkdir(inboundDir, { recursive: true });
+    await fs.writeFile(path.join(inboundDir, "history.mp4"), MP4);
+    const env = captureEnv(["OPENCLAW_STATE_DIR"]);
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    const target = {
+      agentId: "main",
+      sessionId: "video-replay",
+      sessionKey: "agent:main:video-replay",
+      storePath: path.join(stateDir, "sessions.json"),
+    };
+    const persisted = buildPersistedUserTurnMessage({
+      text: "inspect historical video",
+      media: [
+        {
+          kind: "video",
+          contentType: "video/mp4",
+          sizeBytes: MP4.length,
+          url: "media://inbound/history.mp4",
+          hydrationSuppressed: true,
+        },
+      ],
+    });
+    const serialized = JSON.stringify(persisted);
+    expect(serialized).toContain("media://inbound/history.mp4");
+    expect(serialized).not.toContain(MP4.toString("base64"));
+    expect(serialized).not.toContain(stateDir);
+
+    try {
+      await upsertSessionEntryCore(target, {
+        sessionId: target.sessionId,
+        updatedAt: 1,
+      });
+      await appendTranscriptMessage(target, {
+        cwd: stateDir,
+        eventId: "historical-user",
+        message: persisted,
+        now: 1,
+      });
+
+      const reopened = SessionManager.open(target, stateDir).buildSessionContext();
+      const provider = await materializeProviderContext({
+        context: { systemPrompt: "system", messages: convertToLlm(reopened.messages), tools: [] },
+        workspaceDir: stateDir,
+      });
+      expect(provider.messages[0]?.content).toEqual([
+        { type: "text", text: "inspect historical video" },
+        { type: "video", data: MP4.toString("base64"), mimeType: "video/mp4" },
+      ]);
+
+      const raw = await readSessionTranscriptRawDelta({
+        ...target,
+        maxBytes: 100_000,
+        maxEvents: 100,
+      });
+      expect(JSON.stringify(raw)).toContain("media://inbound/history.mp4");
+      expect(JSON.stringify(raw)).not.toContain(MP4.toString("base64"));
+    } finally {
+      env.restore();
+    }
+  });
+
   it("resumes a raw cursor after append-only attempt settlement", async () => {
     const dir = tempDirs.make("openclaw-attempt-transcript-");
     const storePath = path.join(dir, "sessions.json");

--- a/src/agents/embedded-agent-runner/run/history-image-prune.test.ts
+++ b/src/agents/embedded-agent-runner/run/history-image-prune.test.ts
@@ -709,7 +709,9 @@ describe("installHistoryImagePruneContextTransform", () => {
   it("strips nested media metadata before old turns can rehydrate", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pruned-nested-media-"));
     const imagePath = path.join(workspaceDir, "old.png");
+    const videoPath = path.join(workspaceDir, "old.mp4");
     await fs.writeFile(imagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+    await fs.writeFile(videoPath, Buffer.from("0000001c6674797069736f6d", "hex"));
     const baseBridge = createHostSandboxFsBridge(workspaceDir);
     let hydrationReadCount = 0;
     const bridge = {
@@ -723,7 +725,10 @@ describe("installHistoryImagePruneContextTransform", () => {
       role: "user",
       content: "[media attached: ./old.png (image/png)]",
       __openclaw: {
-        media: [{ path: "./old.png", contentType: "image/png" }],
+        media: [
+          { path: "./old.png", contentType: "image/png" },
+          { path: "./old.mp4", contentType: "video/mp4" },
+        ],
         mediaImageBlockFactIndexes: [0],
         mediaImageLayout: { slots: [{ kind: "offloaded", factIndex: 0 }] },
       },

--- a/src/agents/embedded-agent-runner/run/images.ts
+++ b/src/agents/embedded-agent-runner/run/images.ts
@@ -492,7 +492,6 @@ type PromptMediaOptions = {
 
 const VIDEO_OMISSION = {
   unsupported: "(video omitted: provider does not support native video)",
-  historical: "(video omitted: native historical replay is not available yet)",
   unavailable: "(video omitted: source unavailable)",
   invalid: "(video omitted: invalid video MIME type)",
   limit: "(video omitted: native video byte limit exceeded)",
@@ -537,7 +536,6 @@ async function projectOrderedPromptMedia(params: {
   media: MediaFact[];
   images: ImageContent[];
   imageFactIndexes: ImageFactIndex[];
-  runtime: boolean;
   options: PromptMediaOptions;
   budget: { remaining: number };
 }): Promise<ModelInputContent[]> {
@@ -560,11 +558,9 @@ async function projectOrderedPromptMedia(params: {
       projected.push(...(imagesByFact.get(factIndex) ?? []));
     } else if (isVideoMediaFact(fact)) {
       projected.push(
-        !params.runtime
-          ? { type: "text", text: VIDEO_OMISSION.historical }
-          : params.options.provider
-            ? await materializeVideoFact(fact, params.budget, params.options)
-            : { type: "text", text: VIDEO_OMISSION.unsupported },
+        params.options.provider
+          ? await materializeVideoFact(fact, params.budget, params.options)
+          : { type: "text", text: VIDEO_OMISSION.unsupported },
       );
     }
   }
@@ -602,7 +598,6 @@ async function materializePromptMediaMessages(
       model: options.model,
       existingImages,
       existingImageFactIndexes: readPersistedImageBlockFactIndexes(message),
-      imageOrder: runtimeImageOrder,
       mediaImageLayout,
       maxBytes: options.maxBytes,
       maxDimensionPx: options.maxDimensionPx,
@@ -615,7 +610,6 @@ async function materializePromptMediaMessages(
       media: resolvedMedia,
       images: result.images,
       imageFactIndexes: result.imageFactIndexes,
-      runtime: runtimeMedia !== undefined,
       options,
       budget: videoBudget,
     });

--- a/src/agents/embedded-agent-runner/run/message-transform-stream-wrapper.test.ts
+++ b/src/agents/embedded-agent-runner/run/message-transform-stream-wrapper.test.ts
@@ -32,29 +32,40 @@ describe("direct provider context handoff", () => {
     );
   });
 
-  it("keeps canonical omissions while materializing only exact current runtime facts", async () => {
+  it("keeps canonical omissions while materializing persisted and current facts in order", async () => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-provider-video-"));
     tempDirs.push(stateDir);
     const env = captureEnv(["OPENCLAW_STATE_DIR"]);
     setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
     const inbound = path.join(stateDir, "media", "inbound");
     await fs.mkdir(inbound, { recursive: true });
+    await fs.writeFile(path.join(inbound, "old.mp4"), MP4);
     await fs.writeFile(path.join(inbound, "recent.mp4"), MP4);
     await fs.writeFile(path.join(inbound, "steer.mp4"), MP4);
 
     try {
       const historical = {
         role: "user" as const,
-        content: "historical",
+        content: [{ type: "text" as const, text: "historical" }, PNG, { ...PNG }],
         timestamp: 1,
         __openclaw: {
+          mediaImageBlockFactIndexes: [0, 2],
+          mediaImageLayout: {
+            slots: [
+              { kind: "inline" as const, factIndex: 0 },
+              { kind: "inline" as const, factIndex: 2 },
+            ],
+          },
           media: [
+            { kind: "image", contentType: "image/png" },
             {
               kind: "video",
-              contentType: "video/mp4",
+              contentType: "application/octet-stream",
+              sizeBytes: MP4.length,
               url: "media://inbound/old.mp4",
               hydrationSuppressed: true,
             },
+            { kind: "image", contentType: "image/png" },
           ],
         },
       };
@@ -102,10 +113,27 @@ describe("direct provider context handoff", () => {
           { kind: "image", contentType: "image/png" },
         ],
       );
-      const canonicalMessages = await hydratePromptMediaMessages([historical, recent, steer], {
-        workspaceDir: stateDir,
-        model: { input: ["text", "image"] },
-      });
+      const missingHistorical = {
+        role: "user" as const,
+        content: "missing historical",
+        timestamp: 2,
+        __openclaw: {
+          media: [
+            {
+              kind: "video",
+              contentType: "video/mp4",
+              url: "media://inbound/missing.mp4",
+            },
+          ],
+        },
+      };
+      const canonicalMessages = await hydratePromptMediaMessages(
+        [historical, missingHistorical, recent, steer],
+        {
+          workspaceDir: stateDir,
+          model: { input: ["text", "image"] },
+        },
+      );
       const context = {
         systemPrompt: "system",
         messages: canonicalMessages,
@@ -122,7 +150,7 @@ describe("direct provider context handoff", () => {
       const firstCandidate = vi.fn<StreamFn>((_model, firstContext, options) => {
         expect((options as ProviderStreamOptions)[PROVIDER_CONTEXT_HANDOFF]).toBeUndefined();
         expect(JSON.stringify(firstContext)).toContain("provider does not support native video");
-        expect(JSON.stringify(firstContext)).toContain("historical replay is not available yet");
+        expect(JSON.stringify(firstContext)).not.toContain("native historical replay");
         return createAssistantMessageEventStream();
       });
       void firstCandidate(model, context, {});
@@ -144,20 +172,26 @@ describe("direct provider context handoff", () => {
 
       expect(resolved?.messages[0]?.content).toEqual([
         { type: "text", text: "historical" },
-        { type: "text", text: "(video omitted: native historical replay is not available yet)" },
+        PNG,
+        { type: "video", data: MP4.toString("base64"), mimeType: "video/mp4" },
+        { ...PNG },
       ]);
       expect(resolved?.messages[1]?.content).toEqual([
+        { type: "text", text: "missing historical" },
+        { type: "text", text: "(video omitted: source unavailable)" },
+      ]);
+      expect(resolved?.messages[2]?.content).toEqual([
         { type: "text", text: "recent" },
         PNG,
         { type: "video", data: MP4.toString("base64"), mimeType: "video/mp4" },
         { ...PNG },
       ]);
-      expect(resolved?.messages[2]?.content).toEqual([
+      expect(resolved?.messages[3]?.content).toEqual([
         { type: "text", text: "steer" },
         { type: "video", data: MP4.toString("base64"), mimeType: "video/mp4" },
         { ...PNG },
       ]);
-      for (const message of resolved?.messages.slice(1) ?? []) {
+      for (const message of resolved?.messages.slice(2) ?? []) {
         expect(message).not.toHaveProperty("__openclaw");
         expect(Object.getOwnPropertySymbols(message)).toEqual([]);
       }
@@ -171,7 +205,7 @@ describe("direct provider context handoff", () => {
     }
   });
 
-  it("rejects abort after a bounded sandbox read instead of dispatching an omission", async () => {
+  it("rejects abort after a bounded sandbox read before later dispatch", async () => {
     let finishRead: ((value: Buffer) => void) | undefined;
     let markReadStarted: (() => void) | undefined;
     const readStarted = new Promise<void>((resolve) => {
@@ -190,24 +224,33 @@ describe("direct provider context handoff", () => {
       }),
     } as unknown as SandboxFsBridge;
     const controller = new AbortController();
-    const current = attachRuntimePromptMediaFacts(
-      { role: "user" as const, content: "inspect", timestamp: 1 },
-      [{ kind: "video", contentType: "video/mp4", path: "/workspace/clip.mp4" }],
-    );
+    const current = {
+      role: "user" as const,
+      content: "inspect",
+      timestamp: 1,
+      __openclaw: {
+        media: [{ kind: "video", contentType: "video/mp4", path: "/workspace/clip.mp4" }],
+      },
+    };
     const resolving = materializeProviderContext({
       context: { systemPrompt: "system", messages: [current], tools: [] },
       signal: controller.signal,
       workspaceDir: "/workspace",
       sandbox: { root: "/workspace", bridge },
     });
+    let dispatched = false;
+    const dispatching = resolving.then(() => {
+      dispatched = true;
+    });
     await readStarted;
     controller.abort(new Error("test abort"));
     finishRead?.(MP4);
-    await expect(resolving).rejects.toThrow("test abort");
+    await expect(dispatching).rejects.toThrow("test abort");
+    expect(dispatched).toBe(false);
   });
 
-  it("rejects a known over-budget current video before reading it", async () => {
-    const readFile = vi.fn();
+  it("applies one aggregate byte budget to persisted videos before reading", async () => {
+    const readFile = vi.fn(async () => MP4);
     const bridge = {
       resolvePath: ({ filePath }: { filePath: string }) => ({
         containerPath: filePath,
@@ -215,26 +258,87 @@ describe("direct provider context handoff", () => {
       }),
       readFile,
     } as unknown as SandboxFsBridge;
-    const current = attachRuntimePromptMediaFacts(
-      { role: "user" as const, content: "inspect", timestamp: 1 },
-      [
-        {
-          kind: "video",
-          contentType: "video/mp4",
-          path: "/workspace/clip.mp4",
-          sizeBytes: MAX_VIDEO_BYTES + 1,
-        },
-      ],
-    );
+    const current = {
+      role: "user" as const,
+      content: "inspect",
+      timestamp: 1,
+      __openclaw: {
+        media: [
+          {
+            kind: "video",
+            contentType: "video/mp4",
+            path: "/workspace/first.mp4",
+            sizeBytes: MP4.length,
+          },
+          {
+            kind: "video",
+            contentType: "video/mp4",
+            path: "/workspace/second.mp4",
+            sizeBytes: MAX_VIDEO_BYTES,
+          },
+        ],
+      },
+    };
     const resolved = await materializeProviderContext({
       context: { systemPrompt: "system", messages: [current], tools: [] },
       workspaceDir: "/workspace",
       sandbox: { root: "/workspace", bridge },
     });
-    expect(resolved.messages[0]?.content).toContainEqual({
-      type: "text",
-      text: "(video omitted: native video byte limit exceeded)",
-    });
+    expect(resolved.messages[0]?.content).toEqual([
+      { type: "text", text: "inspect" },
+      { type: "video", data: MP4.toString("base64"), mimeType: "video/mp4" },
+      { type: "text", text: "(video omitted: native video byte limit exceeded)" },
+    ]);
+    expect(readFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("does no I/O for a nonconsumer and reloads each opted-in physical call", async () => {
+    const readFile = vi.fn(async () => MP4);
+    const bridge = {
+      resolvePath: ({ filePath }: { filePath: string }) => ({
+        containerPath: filePath,
+        relativePath: filePath.replace(/^\//, ""),
+      }),
+      readFile,
+    } as unknown as SandboxFsBridge;
+    const historical = {
+      role: "user" as const,
+      content: "inspect",
+      timestamp: 1,
+      __openclaw: {
+        media: [{ kind: "video", contentType: "video/mp4", path: "/workspace/clip.mp4" }],
+      },
+    };
+    const context = { systemPrompt: "system", messages: [historical], tools: [] };
+    const model = { id: "test", provider: "test", api: "test", input: ["text", "image"] };
+    const nonconsumer = vi.fn<StreamFn>(() => createAssistantMessageEventStream());
+    void wrapStreamFnWithMessageTransform(nonconsumer, (messages) => messages)(
+      model as Parameters<StreamFn>[0],
+      context,
+      {},
+    );
     expect(readFile).not.toHaveBeenCalled();
+
+    const consume = async () => {
+      let resolved: Promise<ProviderContext> | undefined;
+      const consumer = vi.fn<StreamFn>((_model, canonical, options) => {
+        resolved = resolveProviderContext(canonical, options);
+        return createAssistantMessageEventStream();
+      });
+      void wrapStreamFnWithMessageTransform(
+        consumer,
+        (messages) => messages,
+        (input) =>
+          materializeProviderContext({
+            ...input,
+            workspaceDir: "/workspace",
+            sandbox: { root: "/workspace", bridge },
+          }),
+      )(model as Parameters<StreamFn>[0], context, {});
+      await resolved;
+    };
+    await consume();
+    await consume();
+    expect(readFile).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
Related: #120499
Related: #122074

## What Problem This Solves

Fixes an issue where native video worked for the active turn but a recent persisted video became a “historical replay deferred” marker after a session restart. The durable transcript already retained the safe managed media claim, but the provider handoff deliberately refused to rematerialize it.

## Why This Change Was Made

Persisted and runtime video facts now use the same existing ordered, bounded, abort-aware provider materializer. The change removes the runtime-only branch and stops forwarding a runtime positional image-order hint downstream; canonical `mediaImageLayout` and `mediaImageBlockFactIndexes` remain the ordering owners.

Unsupported/image-only providers still receive explicit omission text. Recent opted-in providers load only managed or validated local references under the existing root/sandbox rules. History pruning remains authoritative, so pruned video cannot be resurrected.

AI-assisted; implementation and review were performed with coding agents under maintainer supervision.

## User Impact

A recent video attachment can survive transcript persistence and session restart, then reach a compatible provider as native video in its original image/video order. Missing or unsafe historical sources produce a visible omission instead of disappearing. Raw video bytes are never written into the transcript.

## Evidence

- Pre-fix regression: an opted-in provider received the historical-deferred marker instead of `VideoContent`.
- Projector/prune suite: 136/136 passed.
- Restart E2E: 2/2 passed through canonical transcript persistence, `SessionManager` reopen, Agent Core conversion, and provider materialization.
- Coverage includes persisted image/video/image order, MIME validation, missing-source omission, aggregate byte budget, prune-before-read, abort-before-dispatch, nonconsumer zero-I/O, and fresh per-call loading.
- Blacksmith Testbox changed gate passed: `tbx_01kzs7dvshnx614x46bzwqav8a`.
- Fresh autoreview: no accepted/actionable findings.
- SDK baseline unchanged; `git diff --check` passed.
- Production LOC: `+3/-9`, net `-6`; tests: `+214/-35`; generated/docs/locks: zero.

No provider wire format, route policy, Plugin SDK/public type, worker/protocol/config, SQLite schema, dependency, or Codex/Copilot/CLI behavior changes.