### PR TITLE
fix(worker): stop Gateway RTT from pacing live previews

### DIFF
--- a/src/gateway/worker-environments/placement-store.test.ts
+++ b/src/gateway/worker-environments/placement-store.test.ts
@@ -695,6 +695,9 @@ describe("worker session placement store", () => {
         liveEvent: 8,
       }),
     ).toMatchObject({ lastTranscriptAckCursor: 4, lastLiveEventAckCursor: 9 });
+    expect(store.listPendingWorkspaceResults()).toMatchObject([
+      { sessionId: SESSION.sessionId, claimId: currentClaim.claimId },
+    ]);
   });
 
   it("advances the workspace manifest only under the exact worker turn claim", () => {

--- a/src/gateway/worker-environments/placement-turn-claims.ts
+++ b/src/gateway/worker-environments/placement-turn-claims.ts
@@ -431,6 +431,7 @@ export function createPlacementTurnClaimOps(runtime: PlacementStoreRuntime) {
       claim: WorkerSessionTurnClaim;
       transcript?: number;
       liveEvent?: number;
+      /** @deprecated Workspace result fencing is implied by a live event cursor. */
       workspaceResultPending?: boolean;
     }): WorkerSessionPlacementRecord {
       const sessionId = required(input.claim.sessionId, "session id");
@@ -499,7 +500,7 @@ export function createPlacementTurnClaimOps(runtime: PlacementStoreRuntime) {
         if (result.numAffectedRows !== 1n) {
           throw new Error(`Worker session placement ${sessionId} changed during ACK`);
         }
-        if (input.workspaceResultPending) {
+        if (input.liveEvent !== undefined) {
           // The terminal event is not ACKed until crash recovery has a durable
           // fence protecting remote workspace results from stale-claim teardown.
           insertWorkerWorkspacePendingResult(db, input.claim, now(), instanceId);

--- a/src/gateway/worker-environments/placement-worker-gate.test.ts
+++ b/src/gateway/worker-environments/placement-worker-gate.test.ts
@@ -103,7 +103,7 @@ describe("worker session placement gate", () => {
     expect(gate.validateWorkerTurn({ ...binding, ownerEpoch: OWNER_EPOCH + 1 })).toBe(false);
   });
 
-  it("updates exact-owner cursors and rejects stale descriptor replay", () => {
+  it("atomically retains the finishing cursor and workspace-result fence", () => {
     const runId = "run-worker-ack";
     const claim = preclaim(runId);
     const gate = createWorkerSessionPlacementGate(store);
@@ -114,13 +114,19 @@ describe("worker session placement gate", () => {
       runId,
     };
 
-    gate.updateAckCursors({ ...binding, transcriptSeq: 4, liveSeq: 9 });
+    gate.updateAckCursors({ ...binding, transcriptSeq: 4 });
+    expect(store.listPendingWorkspaceResults()).toEqual([]);
+    gate.updateAckCursors({ ...binding, liveSeq: 9 });
     expect(store.get(SESSION.sessionId)).toMatchObject({
       generation: claim.placementGeneration,
       lastTranscriptAckCursor: 4,
       lastLiveEventAckCursor: 9,
     });
-    store.releaseTurn(claim);
+    expect(store.listPendingWorkspaceResults()).toMatchObject([
+      { sessionId: SESSION.sessionId, runId },
+    ]);
+    store.acceptWorkspaceResult(claim);
+    store.completeWorkspaceResultAndReleaseTurn(claim);
     expect(store.get(SESSION.sessionId)?.turnClaim).toBeNull();
     expect(gate.validateWorkerTurn(binding)).toBe(false);
   });

--- a/src/gateway/worker-environments/placement-worker-gate.ts
+++ b/src/gateway/worker-environments/placement-worker-gate.ts
@@ -23,7 +23,6 @@ export type WorkerSessionPlacementGate = {
     binding: WorkerPlacementTurnBinding & {
       transcriptSeq?: number;
       liveSeq?: number;
-      workspaceResultPending?: boolean;
     },
   ): void;
 };
@@ -86,9 +85,6 @@ export function createWorkerSessionPlacementGate(
         claim,
         ...(binding.transcriptSeq === undefined ? {} : { transcript: binding.transcriptSeq }),
         ...(binding.liveSeq === undefined ? {} : { liveEvent: binding.liveSeq }),
-        ...(binding.workspaceResultPending === undefined
-          ? {}
-          : { workspaceResultPending: binding.workspaceResultPending }),
       });
     },
   };

--- a/src/gateway/worker-environments/worker-turn-launcher.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.test.ts
@@ -793,7 +793,7 @@ describe("worker turn launcher", () => {
           ownerEpoch: OWNER_EPOCH,
           runId: "run-worker-turn",
           transcriptSeq: 2,
-          workspaceResultPending: true,
+          liveSeq: 1,
         });
         return {
           stdout: JSON.stringify({
@@ -1027,7 +1027,7 @@ describe("worker turn launcher", () => {
           ownerEpoch: OWNER_EPOCH,
           runId: "run-persisted-user",
           transcriptSeq: 2,
-          workspaceResultPending: true,
+          liveSeq: 1,
         });
         return {
           stdout: JSON.stringify({
@@ -1161,7 +1161,7 @@ describe("worker turn launcher", () => {
           ownerEpoch: OWNER_EPOCH,
           runId: "run-reconcile-tunnel-loss",
           transcriptSeq: 2,
-          workspaceResultPending: true,
+          liveSeq: 1,
         });
         return {
           stdout: JSON.stringify({
@@ -1286,7 +1286,7 @@ describe("worker turn launcher", () => {
             ownerEpoch: OWNER_EPOCH,
             runId: "run-worker-usage",
             transcriptSeq: 2,
-            workspaceResultPending: true,
+            liveSeq: 1,
           });
           return {
             stdout: JSON.stringify({
@@ -1487,7 +1487,6 @@ describe("worker turn launcher", () => {
         ownerEpoch: OWNER_EPOCH,
         runId: "run-terminal-child-failure",
         liveSeq: 1,
-        workspaceResultPending: true,
       });
       return {
         stdout: "",
@@ -2011,7 +2010,7 @@ describe("worker turn launcher", () => {
       ownerEpoch: OWNER_EPOCH,
       runId: "run-overlap",
       transcriptSeq: 2,
-      workspaceResultPending: true,
+      liveSeq: 1,
     });
     const active = placements.get(SESSION_ID);
     if (active?.state !== "active") {
@@ -2089,7 +2088,7 @@ describe("worker turn launcher", () => {
               ownerEpoch: OWNER_EPOCH,
               runId: "run-model-failed",
               transcriptSeq: 2,
-              workspaceResultPending: true,
+              liveSeq: 1,
             });
             return {
               stdout: JSON.stringify({
@@ -2118,7 +2117,7 @@ describe("worker turn launcher", () => {
             ownerEpoch: OWNER_EPOCH,
             runId: "run-model-recovered",
             transcriptSeq: 2,
-            workspaceResultPending: true,
+            liveSeq: 1,
           });
           return {
             stdout: JSON.stringify({
@@ -2240,7 +2239,7 @@ describe("worker turn launcher", () => {
         ownerEpoch: OWNER_EPOCH,
         runId,
         transcriptSeq: 2,
-        workspaceResultPending: true,
+        liveSeq: 1,
       });
       return {
         stdout: JSON.stringify({

--- a/src/gateway/worker-environments/worker-turn-rpc.test.ts
+++ b/src/gateway/worker-environments/worker-turn-rpc.test.ts
@@ -149,7 +149,7 @@ describe("worker environment service", () => {
     expect(liveEvents.rotateCredential).not.toHaveBeenCalled();
   });
 
-  it("persists worker transcript and terminal live ACK cursors", async () => {
+  it("keeps preview ACKs in memory and persists only transcript and terminal cursors", async () => {
     const applyTranscriptCommit = support.successfulTranscriptCommit("entry-placement");
     const { liveEvents } = support.sequencedLiveEvents();
     const { identity, placementStore, workerService } = support.placementHarness(
@@ -174,15 +174,19 @@ describe("worker environment service", () => {
     });
 
     await expect(
-      workerService.pushLiveEvent(identity, support.terminalEvent(identity)),
-    ).resolves.toEqual({
-      ok: true,
-      result: { ackedSeq: 1 },
-    });
+      workerService.pushLiveEvent(identity, support.assistantEvent(identity, "preview")),
+    ).resolves.toEqual({ ok: true, result: { ackedSeq: 1 } });
+    expect(placementStore.updateAckCursors).toHaveBeenCalledOnce();
+
+    await expect(
+      workerService.pushLiveEvent(
+        identity,
+        support.terminalEvent(identity, { lastAckedSeq: 1, seq: 2 }),
+      ),
+    ).resolves.toEqual({ ok: true, result: { ackedSeq: 2 } });
     expect(placementStore.updateAckCursors).toHaveBeenLastCalledWith({
       ...binding,
-      liveSeq: 1,
-      workspaceResultPending: true,
+      liveSeq: 2,
     });
   });
 
@@ -209,7 +213,6 @@ describe("worker environment service", () => {
     expect(placementStore.updateAckCursors).toHaveBeenLastCalledWith({
       ...support.placementBinding(identity),
       liveSeq: 1,
-      workspaceResultPending: true,
     });
   });
 
@@ -288,15 +291,16 @@ describe("worker environment service", () => {
     await expect(
       workerService.pushLiveEvent(identity, support.terminalEvent(identity, { seq: 2 })),
     ).resolves.toEqual({ ok: true, result: { ackedSeq: 0 } });
-    expect(placementStore.updateAckCursors).toHaveBeenCalledWith({
-      ...support.placementBinding(identity),
-      liveSeq: 0,
-      workspaceResultPending: true,
-    });
+    expect(placementStore.updateAckCursors).not.toHaveBeenCalled();
 
     await expect(
       workerService.pushLiveEvent(identity, support.assistantEvent(identity, "fills gap")),
     ).resolves.toEqual({ ok: true, result: { ackedSeq: 2 } });
+    expect(placementStore.updateAckCursors).toHaveBeenCalledOnce();
+    expect(placementStore.updateAckCursors).toHaveBeenCalledWith({
+      ...support.placementBinding(identity),
+      liveSeq: 2,
+    });
     await expect(
       workerService.commitTranscript(
         identity,
@@ -352,7 +356,6 @@ describe("worker environment service", () => {
         {
           ...support.placementBinding(identity),
           liveSeq: 1,
-          workspaceResultPending: true,
         },
       ],
     ]);

--- a/src/gateway/worker-environments/worker-turn-rpc.ts
+++ b/src/gateway/worker-environments/worker-turn-rpc.ts
@@ -386,16 +386,10 @@ export function createWorkerTurnRpc(options: WorkerTurnRpcOptions) {
     // commits and the terminal mutation fence while this synchronous receiver runs.
     const result = options.liveEvents.apply({ identity, request });
     if (result.ok) {
-      const placement = placementBinding(identity);
       const processTurn = processTurnBinding(identity);
-      if (!placement || !processTurn) {
+      if (!processTurn) {
         return { ok: false, closeReason: "placement-mismatch" };
       }
-      options.placementStore?.updateAckCursors({
-        ...placement,
-        liveSeq: result.result.ackedSeq,
-        ...(isTerminalLiveEvent(request) ? { workspaceResultPending: true } : {}),
-      });
       recordAckCursor(processTurn, { liveSeq: result.result.ackedSeq });
     }
     return result;
@@ -430,6 +424,12 @@ export function createWorkerTurnRpc(options: WorkerTurnRpcOptions) {
         matchesTurnBinding(terminal, processTurn) &&
         result.result.ackedSeq >= terminal.terminalLiveSeq
       ) {
+        // Only finishing authority crosses the durable boundary. Its live cursor
+        // and workspace-result recovery fence commit in one placement transaction.
+        options.placementStore?.updateAckCursors({
+          ...placement,
+          liveSeq: result.result.ackedSeq,
+        });
         // A gap fill can ACK a previously buffered terminal event. Fence from
         // the observed high-water marks, not only from the request carrying it.
         terminalTurnFences.set(

--- a/src/worker/embedded-agent-live.runtime.test.ts
+++ b/src/worker/embedded-agent-live.runtime.test.ts
@@ -37,8 +37,6 @@ describe("createWorkerLiveRuntime", () => {
     for (const event of events) {
       runtime.handleSessionEvent(event);
     }
-    await runtime.flush();
-
     expect(JSON.stringify(emitted)).not.toContain("QUJDRA==");
     expect(JSON.stringify(emitted)).not.toMatch(/"[0-9]+":(?:[0-9]+|\{)/u);
     expect(emitted).toHaveLength(3);

--- a/src/worker/embedded-agent-live.runtime.ts
+++ b/src/worker/embedded-agent-live.runtime.ts
@@ -104,45 +104,6 @@ function boundLiveEvent(event: WorkerLiveEvent): WorkerLiveEvent {
   return bounded;
 }
 
-function coalescePendingLiveEvent(pending: WorkerLiveEvent[], event: WorkerLiveEvent): boolean {
-  const index = pending.length - 1;
-  const previous = pending[index];
-  if (!previous) {
-    return false;
-  }
-  if (previous.kind === "assistant" && event.kind === "assistant") {
-    pending[index] = boundLiveEvent({
-      kind: "assistant",
-      payload: { ...event.payload, delta: event.payload.text, replace: true },
-    });
-    return true;
-  }
-  if (previous.kind === "thinking" && event.kind === "thinking") {
-    if (event.payload.text === "" && event.payload.delta === "") {
-      return false;
-    }
-    pending[index] = boundLiveEvent({
-      kind: "thinking",
-      payload: {
-        text: event.payload.text,
-        delta: `${previous.payload.delta}${event.payload.delta}`,
-      },
-    });
-    return true;
-  }
-  if (
-    previous.kind === "tool" &&
-    previous.payload.phase === "update" &&
-    event.kind === "tool" &&
-    event.payload.phase === "update" &&
-    previous.payload.toolCallId === event.payload.toolCallId
-  ) {
-    pending[index] = boundLiveEvent(event);
-    return true;
-  }
-  return false;
-}
-
 function readAssistantText(message: AgentMessage): string {
   if (message.role !== "assistant") {
     return "";
@@ -170,57 +131,22 @@ type WorkerLiveClient = {
 type WorkerLiveRuntime = {
   handleSessionEvent: (event: AgentSessionEvent) => void;
   enqueueRunFailure: (failure: { aborted: boolean; error: Error }) => void;
-  flush: () => Promise<void>;
   emitTerminal: () => Promise<void>;
 };
 
 export function createWorkerLiveRuntime(client: WorkerLiveClient): WorkerLiveRuntime {
-  const pendingLiveEvents: WorkerLiveEvent[] = [];
-  let liveDrain: Promise<void> | undefined;
   let liveDegraded = false;
-  const startLiveDrain = () => {
-    if (liveDrain || liveDegraded || pendingLiveEvents.length === 0) {
-      return;
-    }
-    liveDrain = (async () => {
-      while (true) {
-        const event = pendingLiveEvents.shift();
-        if (!event) {
-          return;
-        }
-        await client.emit(event);
-      }
-    })()
-      .catch(() => {
-        // Live events are preview-only; transcript commits and inference stay authoritative.
-        liveDegraded = true;
-        pendingLiveEvents.length = 0;
-      })
-      .finally(() => {
-        liveDrain = undefined;
-        startLiveDrain();
-      });
-  };
   const enqueueLive = (event: WorkerLiveEvent) => {
     if (liveDegraded) {
       return;
     }
     try {
-      const bounded = boundLiveEvent(event);
-      if (!coalescePendingLiveEvent(pendingLiveEvents, bounded)) {
-        pendingLiveEvents.push(bounded);
-      }
-      startLiveDrain();
+      void client.emit(boundLiveEvent(event)).catch(() => {
+        // Preview loss must not block inference, transcript durability, or finishing.
+        liveDegraded = true;
+      });
     } catch {
       liveDegraded = true;
-      pendingLiveEvents.length = 0;
-    }
-  };
-  const flush = async () => {
-    let drain = liveDrain;
-    while (drain) {
-      await drain;
-      drain = liveDrain;
     }
   };
   const startedAt = Date.now();
@@ -358,5 +284,5 @@ export function createWorkerLiveRuntime(client: WorkerLiveClient): WorkerLiveRun
     }
     await client.emit(boundLiveEvent(terminalLiveEvent));
   };
-  return { handleSessionEvent, enqueueRunFailure, flush, emitTerminal };
+  return { handleSessionEvent, enqueueRunFailure, emitTerminal };
 }

--- a/src/worker/embedded-agent.runtime.ts
+++ b/src/worker/embedded-agent.runtime.ts
@@ -317,7 +317,6 @@ export async function runWorkerEmbeddedTurn(params: RunWorkerEmbeddedTurnParams)
     } catch (error) {
       finalTranscriptFailure = toWorkerAgentError(error, "Worker transcript flush failed.");
     }
-    await liveRuntime.flush();
     if (finalTranscriptFailure === undefined) {
       await liveRuntime.emitTerminal();
     }

--- a/src/worker/worker-fault-injection.test-support.ts
+++ b/src/worker/worker-fault-injection.test-support.ts
@@ -1,7 +1,6 @@
 import { once } from "node:events";
 import fs from "node:fs/promises";
 import { createServer, type Server } from "node:http";
-import os from "node:os";
 import path from "node:path";
 import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
@@ -185,10 +184,7 @@ export class ComposedGatewayHarness {
   private useReplacementExecutor = false;
   private unsubscribeLive: (() => void) | undefined;
 
-  static async create(): Promise<ComposedGatewayHarness> {
-    const root = await fs.mkdtemp(
-      path.join(await fs.realpath(os.tmpdir()), "openclaw-worker-fault-"),
-    );
+  static async create(root: string): Promise<ComposedGatewayHarness> {
     const sessionsDir = path.join(root, "agents", "main", "sessions");
     const storePath = path.join(sessionsDir, "sessions.json");
     await upsertSessionEntryCore(

--- a/src/worker/worker-fault-injection.test-support.ts
+++ b/src/worker/worker-fault-injection.test-support.ts
@@ -1,0 +1,733 @@
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
+import { WebSocket, WebSocketServer, type RawData } from "ws";
+import {
+  type WorkerLiveEventParams,
+  WORKER_PROTOCOL_FEATURES,
+  WORKER_RPC_SET_VERSION,
+} from "../../packages/gateway-protocol/src/schema/worker-admission.js";
+import type { WorkerInferenceTerminalOutcome } from "../../packages/gateway-protocol/src/schema/worker-inference.js";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { createOperationalRunInstanceRef } from "../agents/admitted-run-context.js";
+import {
+  resolveSessionTranscriptRuntimeTarget,
+  upsertSessionEntryCore,
+} from "../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import * as workerServer from "../gateway/server/ws-connection/worker-connection.js";
+import type { GatewayWsClient } from "../gateway/server/ws-types.js";
+import type { WorkerConnectionIdentity } from "../gateway/worker-environments/connection-identity.js";
+import { hashWorkerCredential } from "../gateway/worker-environments/credential.js";
+import { createWorkerInferenceStore } from "../gateway/worker-environments/inference-store.js";
+import * as liveEvents from "../gateway/worker-environments/live-events.js";
+import * as placements from "../gateway/worker-environments/placement-store.js";
+import {
+  createWorkerSessionPlacementGate,
+  type WorkerSessionPlacementGate,
+} from "../gateway/worker-environments/placement-worker-gate.js";
+import * as workerEnv from "../gateway/worker-environments/service.js";
+import * as envStore from "../gateway/worker-environments/store.js";
+import { createWorkerTranscriptCommitStore } from "../gateway/worker-environments/transcript-commit-store.js";
+import { createWorkerTranscriptCommitter } from "../gateway/worker-environments/transcript-commit.js";
+import { onAgentRuntimeEvent } from "../infra/agent-events.js";
+import type { WorkerProvider, WorkerSshEndpoint } from "../plugins/types.js";
+import * as stateDb from "../state/openclaw-state-db.js";
+import { buildWorkerConnectParams, type WorkerLaunchDescriptor } from "./launch-descriptor.js";
+import { createWorkerConnection, type WorkerConnection } from "./worker-connection.js";
+import * as workerRpc from "./worker-rpc-clients.js";
+
+export const SESSION_ID = "fault-session";
+export const SESSION_KEY = "agent:main:fault-session";
+export const ENVIRONMENT_ID = "fault-environment";
+export const RUN_ID = "fault-run";
+const BUNDLE_HASH = Array.from({ length: 64 }, () => "a").join("");
+const CREDENTIAL = ["worker", "fault", "fixture"].join("-");
+const MODEL_REF = { provider: "fake", model: "fault-model" } as const;
+const SSH_ENDPOINT: WorkerSshEndpoint = {
+  host: "worker.example.test",
+  port: 22,
+  user: "openclaw",
+  hostKey: [["ssh", "ed25519"].join("-"), "AAAA"].join(" "),
+  keyRef: { source: "file", provider: "worker-fixtures", id: "/development-key" },
+};
+const HANDSHAKE = {
+  bundleHash: BUNDLE_HASH,
+  openclawVersion: "fault-test",
+  protocolFeatures: [...WORKER_PROTOCOL_FEATURES],
+};
+const BUNDLE_ARTIFACT = {
+  install: "bundle" as const,
+  bundleHash: BUNDLE_HASH,
+  openclawVersion: HANDSHAKE.openclawVersion,
+  protocolFeatures: [...WORKER_PROTOCOL_FEATURES],
+  tarballSha256: Array.from({ length: 64 }, () => "b").join(""),
+  tarballPath: "/gateway/cache/worker-bundle.tgz",
+};
+const PROVIDER: WorkerProvider = {
+  id: "fake",
+  provision: async () => ({ leaseId: "lease-fault", ssh: SSH_ENDPOINT }),
+  inspect: async () => ({ status: "active" }),
+  destroy: async () => {},
+};
+
+type Deferred<T> = ReturnType<typeof createDeferred<T>>;
+
+type WorkerDoneMessage = Extract<WorkerInferenceTerminalOutcome, { type: "done" }>["message"];
+
+export function doneMessage(text: string): WorkerDoneMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "openai-responses",
+    provider: MODEL_REF.provider,
+    model: MODEL_REF.model,
+    usage: {
+      input: 1,
+      output: 1,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 2,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: 1,
+  };
+}
+
+export const doneOutcome = (text: string): WorkerInferenceTerminalOutcome => ({
+  type: "done",
+  message: doneMessage(text),
+});
+
+type FaultRule =
+  | { kind: "drop-response"; method: string; restart: boolean }
+  | { kind: "partition-after-inference-event"; seq: number };
+
+type TranscriptGate = {
+  phase: "before-apply" | "after-apply";
+  entered: Deferred<void>;
+  release: Deferred<void>;
+};
+
+type LiveEventGate = {
+  stage: "before-service" | "after-service";
+  target: "preview" | "finishing";
+  entered: Deferred<void>;
+  release: Deferred<void>;
+  claimed: boolean;
+};
+
+type ProviderPlan =
+  | { kind: "immediate"; text: string; outcome?: WorkerInferenceTerminalOutcome }
+  | {
+      kind: "live-preview";
+      nextRelease: Deferred<void>;
+      produced: Deferred<void>;
+      text: string;
+    }
+  | {
+      kind: "partitioned";
+      firstRelease: Deferred<void>;
+      secondRelease: Deferred<void>;
+      started: Deferred<void>;
+      text: string;
+    }
+  | { kind: "pending"; release: Deferred<WorkerInferenceTerminalOutcome>; started: Deferred<void> };
+
+export type WorkerClients = {
+  connection: WorkerConnection;
+  transcript: workerRpc.WorkerTranscriptCommitClient;
+  live: workerRpc.WorkerLiveEventClient;
+  inference: workerRpc.WorkerInferenceProxyClient;
+};
+
+type WorkerClientOptions = {
+  admissionProof?: string;
+  epoch?: number;
+  baseLeafId?: string | null;
+  initialSeq?: number;
+  initialAckedSeq?: number;
+  runId?: string;
+};
+
+export class ComposedGatewayHarness {
+  readonly socketPath: string;
+  readonly cfg: OpenClawConfig;
+  readonly database: stateDb.OpenClawStateDatabase;
+  readonly store: envStore.WorkerEnvironmentStore;
+  readonly placementStore: placements.WorkerSessionPlacementStore;
+  readonly requests: Array<{ method: string; params: unknown }> = [];
+  readonly admissions: WorkerConnectionIdentity[] = [];
+  readonly liveDeltas: string[] = [];
+  readonly abandonedServices: workerEnv.WorkerEnvironmentService[] = [];
+  readonly placementWrites: Array<Parameters<WorkerSessionPlacementGate["updateAckCursors"]>[0]> =
+    [];
+  providerCalls = 0;
+  replacementProviderCalls = 0;
+  connectionCount = 0;
+  transcriptGate: TranscriptGate | undefined;
+  providerPlan: ProviderPlan = { kind: "immediate", text: "done" };
+
+  private readonly httpServer: Server;
+  private readonly webSocketServer: WebSocketServer;
+  private readonly sockets = new Set<WebSocket>();
+  private readonly socketCleanups = new Set<() => void>();
+  private readonly requestMethods = new Map<string, string>();
+  private readonly faults: FaultRule[] = [];
+  private readonly liveEventGates: LiveEventGate[] = [];
+  private serviceValue!: workerEnv.WorkerEnvironmentService;
+  private liveEventsValue!: liveEvents.WorkerLiveEventReceiver;
+  private placementGateValue: WorkerSessionPlacementGate | undefined;
+  private useReplacementExecutor = false;
+  private unsubscribeLive: (() => void) | undefined;
+
+  static async create(): Promise<ComposedGatewayHarness> {
+    const root = await fs.mkdtemp(
+      path.join(await fs.realpath(os.tmpdir()), "openclaw-worker-fault-"),
+    );
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    const storePath = path.join(sessionsDir, "sessions.json");
+    await upsertSessionEntryCore(
+      { agentId: "main", sessionKey: SESSION_KEY, storePath },
+      { sessionId: SESSION_ID, updatedAt: 1 },
+    );
+    const sessionTarget = await resolveSessionTranscriptRuntimeTarget({
+      agentId: "main",
+      sessionId: SESSION_ID,
+      sessionKey: SESSION_KEY,
+      storePath,
+    });
+    return new ComposedGatewayHarness(root, sessionTarget);
+  }
+
+  private constructor(
+    readonly root: string,
+    readonly sessionTarget: Awaited<ReturnType<typeof resolveSessionTranscriptRuntimeTarget>>,
+  ) {
+    const stateDir = path.join(root, "state");
+    this.socketPath = path.join(root, "gateway.sock");
+    this.cfg = {
+      agents: { list: [{ id: "main", default: true }] },
+      session: {
+        mainKey: "main",
+        store: path.join(root, "agents", "{agentId}", "sessions", "sessions.json"),
+      },
+      cloudWorkers: {
+        profiles: { development: { provider: "fake", settings: { region: "test" } } },
+      },
+    };
+    this.database = stateDb.openOpenClawStateDatabase({
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+    this.store = envStore.createWorkerEnvironmentStore({ database: this.database });
+    this.placementStore = placements.createWorkerSessionPlacementStore({
+      database: this.database,
+    });
+    this.seedAttachedEnvironment();
+    this.liveEventsValue = this.createLiveEvents(true);
+    this.serviceValue = this.createService();
+    this.httpServer = createServer();
+    this.webSocketServer = new WebSocketServer({ server: this.httpServer });
+    this.webSocketServer.on("connection", (socket) => this.accept(socket));
+    this.unsubscribeLive = onAgentRuntimeEvent((event) => {
+      if (typeof event.data.delta === "string") {
+        this.liveDeltas.push(event.data.delta);
+      }
+    });
+  }
+
+  get epoch(): number {
+    const record = this.store.get(ENVIRONMENT_ID);
+    if (!record) {
+      throw new Error("fault environment missing");
+    }
+    return record.ownerEpoch;
+  }
+
+  async start(): Promise<void> {
+    const listening = once(this.httpServer, "listening");
+    this.httpServer.listen(this.socketPath);
+    await listening;
+  }
+
+  addFault(rule: FaultRule): void {
+    this.faults.push(rule);
+  }
+
+  addLiveEventGate(stage: LiveEventGate["stage"], target: LiveEventGate["target"]): LiveEventGate {
+    const gate = {
+      stage,
+      target,
+      entered: createDeferred(),
+      release: createDeferred(),
+      claimed: false,
+    };
+    this.liveEventGates.push(gate);
+    return gate;
+  }
+
+  enablePlacement(runId: string): void {
+    let placement = this.placementStore.startDispatch({
+      sessionId: SESSION_ID,
+      agentId: "main",
+      sessionKey: SESSION_KEY,
+    });
+    const transitions = [
+      { to: "provisioning", patch: { environmentId: ENVIRONMENT_ID } },
+      { to: "syncing", patch: { workerBundleHash: BUNDLE_HASH } },
+      {
+        to: "starting",
+        patch: {
+          workspaceBaseManifestRef: `sha256:${"c".repeat(64)}`,
+          remoteWorkspaceDir: "/workspace/fault-session",
+        },
+      },
+      { to: "active", patch: { activeOwnerEpoch: this.epoch } },
+    ] as const;
+    for (const transition of transitions) {
+      placement = this.placementStore.transition({
+        sessionId: SESSION_ID,
+        from: placement.state,
+        expectedGeneration: placement.generation,
+        ...transition,
+      });
+    }
+    this.placementStore.claimTurn({
+      sessionId: SESSION_ID,
+      agentId: "main",
+      sessionKey: SESSION_KEY,
+      claimId: `claim:${runId}`,
+      runId,
+      owner: { kind: "worker", environmentId: ENVIRONMENT_ID, ownerEpoch: this.epoch },
+    });
+    const placementGate = createWorkerSessionPlacementGate(this.placementStore);
+    this.placementGateValue = {
+      ...placementGate,
+      updateAckCursors: (binding) => {
+        this.placementWrites.push(structuredClone(binding));
+        placementGate.updateAckCursors(binding);
+      },
+    };
+    this.abandonedServices.push(this.serviceValue);
+    this.serviceValue = this.createService();
+  }
+
+  createDescriptor(params: WorkerClientOptions = {}): WorkerLaunchDescriptor {
+    const epoch = params.epoch ?? this.epoch;
+    const credential = params.admissionProof ?? CREDENTIAL;
+    return {
+      version: 2,
+      socketPath: this.socketPath,
+      admission: {
+        environmentId: ENVIRONMENT_ID,
+        credential,
+        sessionId: SESSION_ID,
+        ownerEpoch: epoch,
+        rpcSetVersion: WORKER_RPC_SET_VERSION,
+        handshake: HANDSHAKE,
+      },
+      assignment: {
+        agentId: "worker-agent",
+        runId: params.runId ?? RUN_ID,
+        operationalRunInstance: createOperationalRunInstanceRef(params.runId ?? RUN_ID),
+        agentRuntimeIdentityToken: "test-agent-runtime-token",
+        turnId: "fault-turn",
+        prompt: "fault injection",
+        workspaceDir: this.root,
+        modelRef: MODEL_REF,
+        inferenceOptions: {},
+        suppressPromptTranscript: false,
+        initialMessages: [],
+        transcript: { baseLeafId: params.baseLeafId ?? null, nextSeq: params.initialSeq ?? 1 },
+        liveEvents: {
+          ackedSeq: params.initialAckedSeq ?? 0,
+          nextSeq: (params.initialAckedSeq ?? 0) + 1,
+        },
+        toolAuthority: {
+          allowedToolNames: ["read", "write", "edit", "apply_patch", "exec", "process"],
+        },
+      },
+    };
+  }
+
+  createClients(params: WorkerClientOptions = {}): WorkerClients {
+    const descriptor = this.createDescriptor(params);
+    const epoch = descriptor.admission.ownerEpoch;
+    const connection = createWorkerConnection({
+      socketPath: this.socketPath,
+      connectParams: buildWorkerConnectParams(descriptor),
+      admissionTimeoutMs: 1_000,
+      admissionDeadlineMs: 5_000,
+      requestTimeoutMs: 2_000,
+      reconnectBackoff: { initialMs: 1, maxMs: 1, factor: 1, jitter: 0 },
+    });
+    return {
+      connection,
+      transcript: new workerRpc.WorkerTranscriptCommitClient(connection, {
+        runEpoch: epoch,
+        baseLeafId: params.baseLeafId ?? null,
+        initialSeq: params.initialSeq ?? 1,
+      }),
+      live: new workerRpc.WorkerLiveEventClient(connection, {
+        runEpoch: epoch,
+        initialAckedSeq: params.initialAckedSeq ?? 0,
+      }),
+      inference: new workerRpc.WorkerInferenceProxyClient(connection),
+    };
+  }
+
+  hardRestart(options: { corroborateLiveOwner: boolean }): void {
+    this.abandonedServices.push(this.serviceValue);
+    this.liveEventsValue.clear();
+    this.liveEventsValue = this.createLiveEvents(options.corroborateLiveOwner);
+    this.useReplacementExecutor = true;
+    this.serviceValue = this.createService();
+    this.terminateSockets();
+  }
+
+  partition(): void {
+    this.terminateSockets();
+  }
+
+  reclaimWithCredential(credential: string): number {
+    const attached = this.store.get(ENVIRONMENT_ID);
+    if (!attached || attached.state !== "attached") {
+      throw new Error("fault environment is not attached");
+    }
+    const idle = this.store.transition({
+      environmentId: ENVIRONMENT_ID,
+      from: "attached",
+      to: "idle",
+      expectedOwnerEpoch: attached.ownerEpoch,
+    });
+    const next = this.store.transition({
+      environmentId: ENVIRONMENT_ID,
+      from: "idle",
+      to: "attached",
+      expectedOwnerEpoch: idle.ownerEpoch,
+      patch: {
+        attachedSessionIds: [SESSION_ID],
+        credential: {
+          credentialHash: hashWorkerCredential(credential),
+          sessionId: SESSION_ID,
+          rpcSetVersion: WORKER_RPC_SET_VERSION,
+          expiresAtMs: Date.now() + 60_000,
+        },
+      },
+    });
+    this.liveEventsValue.clearEnvironment(ENVIRONMENT_ID);
+    if (
+      !this.liveEventsValue.bindSession({
+        environmentId: ENVIRONMENT_ID,
+        runEpoch: next.ownerEpoch,
+        sessionId: SESSION_ID,
+      })
+    ) {
+      throw new Error("replacement live-event binding failed");
+    }
+    return next.ownerEpoch;
+  }
+
+  requestParams(method: string): unknown[] {
+    return this.requests
+      .filter((request) => request.method === method)
+      .map((request) => structuredClone(request.params));
+  }
+
+  async close(): Promise<void> {
+    this.transcriptGate?.release.resolve();
+    for (const gate of this.liveEventGates) {
+      gate.release.resolve();
+    }
+    if (this.providerPlan.kind === "live-preview") {
+      this.providerPlan.nextRelease.resolve();
+    } else if (this.providerPlan.kind === "partitioned") {
+      this.providerPlan.firstRelease.resolve();
+      this.providerPlan.secondRelease.resolve();
+    } else if (this.providerPlan.kind === "pending") {
+      this.providerPlan.release.resolve({
+        type: "error",
+        reason: "provider-error",
+        message: "fixture released during cleanup",
+      });
+    }
+    this.terminateSockets();
+    for (const cleanup of this.socketCleanups) {
+      cleanup();
+    }
+    this.socketCleanups.clear();
+    await this.serviceValue.stop();
+    for (const service of this.abandonedServices) {
+      await service.stop();
+    }
+    this.liveEventsValue.clear();
+    this.unsubscribeLive?.();
+    this.unsubscribeLive = undefined;
+    await new Promise<void>((resolve) => {
+      this.webSocketServer.close(() => resolve());
+    });
+    await new Promise<void>((resolve) => {
+      this.httpServer.close(() => resolve());
+    });
+    stateDb.closeOpenClawStateDatabaseForTest();
+    await fs.rm(this.root, { recursive: true, force: true });
+  }
+
+  private seedAttachedEnvironment(): void {
+    let environment = this.store.createIntent({
+      environmentId: ENVIRONMENT_ID,
+      providerId: "fake",
+      profileId: "development",
+      profileSnapshot: { settings: { region: "test" } },
+      provisionOperationId: "provision:fault-environment",
+    });
+    const transitions = [
+      { to: "provisioning", patch: {} },
+      { to: "bootstrapping", patch: { leaseId: "lease-fault", sshEndpoint: SSH_ENDPOINT } },
+      {
+        to: "ready",
+        patch: {
+          bootstrapReceipt: HANDSHAKE,
+          credential: {
+            credentialHash: hashWorkerCredential([CREDENTIAL, "ready"].join("-")),
+            sessionId: null,
+            rpcSetVersion: WORKER_RPC_SET_VERSION,
+            expiresAtMs: Date.now() + 60_000,
+          },
+        },
+      },
+      {
+        to: "attached",
+        patch: {
+          attachedSessionIds: [SESSION_ID],
+          credential: {
+            credentialHash: hashWorkerCredential(CREDENTIAL),
+            sessionId: SESSION_ID,
+            rpcSetVersion: WORKER_RPC_SET_VERSION,
+            expiresAtMs: Date.now() + 60_000,
+          },
+        },
+      },
+    ] as const;
+    for (const transition of transitions) {
+      environment = this.store.transition({
+        environmentId: ENVIRONMENT_ID,
+        from: environment.state,
+        ...transition,
+      });
+    }
+  }
+
+  private createLiveEvents(corroborateOwner: boolean): liveEvents.WorkerLiveEventReceiver {
+    const binding = {
+      environmentId: ENVIRONMENT_ID,
+      runEpoch: this.epoch,
+      sessionId: SESSION_ID,
+    };
+    const receiver = liveEvents.createWorkerLiveEventReceiver({
+      getConfig: () => this.cfg,
+      startupBindings: corroborateOwner ? [binding] : [],
+      startupOwners: corroborateOwner
+        ? new Map([[ENVIRONMENT_ID, this.epoch]])
+        : new Map<string, number>(),
+    });
+    receiver.start();
+    if (!corroborateOwner && !receiver.bindSession(binding)) {
+      throw new Error("live-event restart binding failed");
+    }
+    return receiver;
+  }
+
+  private createService(): workerEnv.WorkerEnvironmentService {
+    const ledger = createWorkerTranscriptCommitStore({ database: this.database });
+    const committer = createWorkerTranscriptCommitter({
+      getConfig: () => this.cfg,
+      store: ledger,
+    });
+    const executeInference: Parameters<
+      typeof workerEnv.createWorkerEnvironmentService
+    >[0]["executeInference"] = async (params) => {
+      if (this.useReplacementExecutor) {
+        this.replacementProviderCalls += 1;
+      } else {
+        this.providerCalls += 1;
+      }
+      const plan = this.providerPlan;
+      if (plan.kind === "immediate") {
+        return structuredClone(plan.outcome ?? doneOutcome(plan.text));
+      }
+      if (plan.kind === "pending") {
+        plan.started.resolve();
+        return await plan.release.promise;
+      }
+      if (plan.kind === "live-preview") {
+        params.emit({
+          type: "start",
+          resolvedModel: { api: "openai-responses", ...MODEL_REF },
+          timestamp: Date.now(),
+        });
+        params.emit({ type: "text_start", contentIndex: 0 });
+        params.emit({ type: "text_delta", contentIndex: 0, delta: "preview " });
+        await plan.nextRelease.promise;
+        params.emit({ type: "text_delta", contentIndex: 0, delta: "reply" });
+        params.emit({ type: "text_end", contentIndex: 0 });
+        plan.produced.resolve();
+        return doneOutcome(plan.text);
+      }
+      plan.started.resolve();
+      params.emit({ type: "text_delta", contentIndex: 0, delta: "first" });
+      await plan.firstRelease.promise;
+      params.emit({ type: "text_delta", contentIndex: 0, delta: "second" });
+      await plan.secondRelease.promise;
+      return doneOutcome(plan.text);
+    };
+    return workerEnv.createWorkerEnvironmentService({
+      store: this.store,
+      getConfig: () => this.cfg,
+      resolveProvider: (providerId) => (providerId === PROVIDER.id ? PROVIDER : undefined),
+      prepareInstallation: async () => BUNDLE_ARTIFACT,
+      bootstrapWorker: async () => HANDSHAKE,
+      resolveSshIdentity: async () => ({ kind: "path", path: "/keys/worker" }),
+      applyTranscriptCommit: async (params) => {
+        const gate = this.transcriptGate;
+        if (gate?.phase === "before-apply") {
+          gate.entered.resolve();
+          await gate.release.promise;
+        }
+        const result = await committer.commit(params);
+        if (gate?.phase === "after-apply") {
+          gate.entered.resolve();
+          await gate.release.promise;
+        }
+        return result;
+      },
+      liveEvents: this.liveEventsValue,
+      executeInference,
+      inferenceStore: createWorkerInferenceStore({ database: this.database }),
+      ...(this.placementGateValue ? { placementStore: this.placementGateValue } : {}),
+    });
+  }
+
+  private matchesLiveEventGate(gate: LiveEventGate, request: WorkerLiveEventParams): boolean {
+    if (gate.target === "preview") {
+      return request.event.kind === "assistant" || request.event.kind === "thinking";
+    }
+    return request.event.kind === "lifecycle" && request.event.payload.phase === "finishing";
+  }
+
+  private accept(socket: WebSocket): void {
+    this.connectionCount += 1;
+    this.sockets.add(socket);
+    const connId = `fault-connection-${this.connectionCount}`;
+    let client: GatewayWsClient | null = null;
+    let closed = false;
+    const observe = (data: RawData) => {
+      const parsed = JSON.parse(rawDataToString(data)) as unknown;
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return;
+      }
+      const request = parsed as { id?: unknown; method?: unknown; params?: unknown };
+      if (typeof request.id !== "string" || typeof request.method !== "string") {
+        return;
+      }
+      this.requestMethods.set(request.id, request.method);
+      this.requests.push({ method: request.method, params: structuredClone(request.params) });
+    };
+    socket.on("message", observe);
+    const service = this.serviceValue;
+    const cleanup = workerServer.attachWorkerWsMessageHandler({
+      socket,
+      connId,
+      service: {
+        ...service,
+        pushLiveEvent: async (identity, request) => {
+          const gate = this.liveEventGates.find(
+            (candidate) => !candidate.claimed && this.matchesLiveEventGate(candidate, request),
+          );
+          if (gate) {
+            gate.claimed = true;
+            if (gate.stage === "before-service") {
+              gate.entered.resolve();
+              await gate.release.promise;
+            }
+          }
+          const result = await service.pushLiveEvent(identity, request);
+          if (gate?.stage === "after-service") {
+            gate.entered.resolve();
+            await gate.release.promise;
+          }
+          return result;
+        },
+      } as workerServer.WorkerConnectionService,
+      send: (frame) => this.send(socket, frame),
+      close: (code = 1000, reason = "") => socket.close(code, reason),
+      isClosed: () => closed || socket.readyState === WebSocket.CLOSED,
+      clearHandshakeTimer: () => {},
+      getClient: () => client,
+      setClient: (next) => {
+        client = next;
+        if (next.worker) {
+          this.admissions.push(next.worker);
+        }
+        return true;
+      },
+      setHandshakeState: () => {},
+      advanceHandshakePhase: () => {},
+      setCloseCause: () => {},
+      setLastFrameMeta: () => {},
+      logGateway: { warn: () => {} },
+      logWsControl: { warn: () => {} },
+    });
+    this.socketCleanups.add(cleanup);
+    socket.on("close", () => {
+      closed = true;
+      socket.off("message", observe);
+      cleanup();
+      this.socketCleanups.delete(cleanup);
+      this.sockets.delete(socket);
+    });
+  }
+
+  private send(socket: WebSocket, frame: unknown): void {
+    const response =
+      frame && typeof frame === "object" && !Array.isArray(frame)
+        ? (frame as { event?: unknown; id?: unknown; payload?: { seq?: unknown } })
+        : undefined;
+    const method =
+      typeof response?.id === "string" ? this.requestMethods.get(response.id) : undefined;
+    const faultIndex = this.faults.findIndex((fault) => {
+      if (fault.kind === "drop-response") {
+        return method === fault.method;
+      }
+      return response?.event === "worker.inference.event" && response.payload?.seq === fault.seq;
+    });
+    const fault = faultIndex >= 0 ? this.faults.splice(faultIndex, 1)[0] : undefined;
+    if (fault?.kind === "drop-response") {
+      if (fault.restart) {
+        this.hardRestart({ corroborateLiveOwner: false });
+      } else {
+        socket.terminate();
+      }
+      return;
+    }
+    if (socket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    const encoded = JSON.stringify(frame);
+    if (fault?.kind === "partition-after-inference-event") {
+      socket.send(encoded, () => socket.terminate());
+      return;
+    }
+    socket.send(encoded);
+  }
+
+  private terminateSockets(): void {
+    for (const socket of this.sockets) {
+      socket.terminate();
+    }
+  }
+}

--- a/src/worker/worker-rpc-clients.test.ts
+++ b/src/worker/worker-rpc-clients.test.ts
@@ -465,6 +465,56 @@ describe("worker live-event client", () => {
     client.dispose();
   });
 
+  it("recovers finishing emitted after an earlier preview rejection", async () => {
+    const harness = connectionHarness();
+    harness.requestLiveEvent
+      .mockResolvedValueOnce({
+        type: "res",
+        id: "live-response-preview",
+        ok: false,
+        error: {
+          code: "INVALID_REQUEST",
+          message: "Preview rejected",
+          details: { reason: "invalid-event" },
+        },
+      })
+      .mockResolvedValueOnce({
+        type: "res",
+        id: "live-response-resync",
+        ok: false,
+        error: {
+          code: "INVALID_REQUEST",
+          message: "Replay required",
+          details: { reason: "resync-required", ackedSeq: 0, expectedSeq: 1 },
+        },
+      })
+      .mockResolvedValueOnce({
+        type: "res",
+        id: "live-response-finishing",
+        ok: true,
+        payload: { ackedSeq: 1 },
+      });
+    const client = new WorkerLiveEventClient(harness.connection, { runEpoch: 3 });
+
+    await expect(client.emit("run-1", LIVE_EVENT)).rejects.toMatchObject({
+      name: "WorkerLiveEventError",
+      reason: "invalid-event",
+    });
+    await expect(
+      client.emit("run-1", {
+        kind: "lifecycle",
+        payload: { phase: "finishing", startedAt: 1, endedAt: 2 },
+      }),
+    ).resolves.toEqual({ ackedSeq: 1 });
+
+    expect(harness.requestLiveEvent.mock.calls.map((call) => call[0])).toEqual([
+      expect.objectContaining({ seq: 1, lastAckedSeq: 0, event: LIVE_EVENT }),
+      expect.objectContaining({ seq: 2, lastAckedSeq: 1 }),
+      expect.objectContaining({ seq: 1, lastAckedSeq: 0 }),
+    ]);
+    client.dispose();
+  });
+
   it("replays immutable sequence and payload after a resync response", async () => {
     const harness = connectionHarness();
     harness.requestLiveEvent

--- a/src/worker/worker-rpc-clients.test.ts
+++ b/src/worker/worker-rpc-clients.test.ts
@@ -401,6 +401,70 @@ describe("worker live-event client", () => {
     client.dispose();
   });
 
+  it("recovers finishing after a concurrent preview rejection wins the response race", async () => {
+    const harness = connectionHarness();
+    const previewResponse =
+      createDeferred<Awaited<ReturnType<WorkerConnection["requestLiveEvent"]>>>();
+    const firstTerminalResponse =
+      createDeferred<Awaited<ReturnType<WorkerConnection["requestLiveEvent"]>>>();
+    harness.requestLiveEvent
+      .mockImplementationOnce(async () => await previewResponse.promise)
+      .mockImplementationOnce(async () => await firstTerminalResponse.promise)
+      .mockResolvedValueOnce({
+        type: "res",
+        id: "live-response-resync",
+        ok: false,
+        error: {
+          code: "INVALID_REQUEST",
+          message: "Replay required",
+          details: { reason: "resync-required", ackedSeq: 0, expectedSeq: 1 },
+        },
+      })
+      .mockResolvedValueOnce({
+        type: "res",
+        id: "live-response-finishing",
+        ok: true,
+        payload: { ackedSeq: 1 },
+      });
+    const client = new WorkerLiveEventClient(harness.connection, { runEpoch: 3 });
+
+    const preview = client.emit("run-1", LIVE_EVENT);
+    const finishing = client.emit("run-1", {
+      kind: "lifecycle",
+      payload: { phase: "finishing", startedAt: 1, endedAt: 2 },
+    });
+    await vi.waitFor(() => expect(harness.requestLiveEvent).toHaveBeenCalledTimes(2));
+    previewResponse.resolve({
+      type: "res",
+      id: "live-response-preview",
+      ok: false,
+      error: {
+        code: "INVALID_REQUEST",
+        message: "Preview rejected",
+        details: { reason: "invalid-event" },
+      },
+    });
+    await expect(preview).rejects.toMatchObject({
+      name: "WorkerLiveEventError",
+      reason: "invalid-event",
+    });
+    firstTerminalResponse.resolve({
+      type: "res",
+      id: "live-response-stale-finishing",
+      ok: true,
+      payload: { ackedSeq: 0 },
+    });
+
+    await expect(finishing).resolves.toEqual({ ackedSeq: 1 });
+    expect(harness.requestLiveEvent.mock.calls.map((call) => call[0])).toEqual([
+      expect.objectContaining({ seq: 1, lastAckedSeq: 0, event: LIVE_EVENT }),
+      expect.objectContaining({ seq: 2, lastAckedSeq: 0 }),
+      expect.objectContaining({ seq: 2, lastAckedSeq: 2 }),
+      expect.objectContaining({ seq: 1, lastAckedSeq: 0 }),
+    ]);
+    client.dispose();
+  });
+
   it("replays immutable sequence and payload after a resync response", async () => {
     const harness = connectionHarness();
     harness.requestLiveEvent

--- a/src/worker/worker-rpc-clients.test.ts
+++ b/src/worker/worker-rpc-clients.test.ts
@@ -10,6 +10,7 @@ import type {
   WorkerInferenceTerminalFrame,
   WorkerInferenceTerminalOutcome,
 } from "../../packages/gateway-protocol/src/schema/worker-inference.js";
+import { createDeferred } from "../../test/helpers/promise.js";
 import type { WorkerConnection, WorkerConnectionState } from "./worker-connection.js";
 import {
   WorkerConnectionInterruptedError,
@@ -361,8 +362,42 @@ describe("worker live-event client", () => {
 
     await expect(Promise.all([first, second])).resolves.toEqual([{ ackedSeq: 1 }, { ackedSeq: 2 }]);
     expect(harness.requestLiveEvent).toHaveBeenCalledTimes(2);
-    expect(client.ackedSeq).toBe(2);
-    expect(client.unackedCount).toBe(0);
+    client.dispose();
+  });
+
+  it("accepts out-of-order cumulative ACKs while a no-progress response has peers in flight", async () => {
+    const harness = connectionHarness();
+    const firstResponse =
+      createDeferred<Awaited<ReturnType<WorkerConnection["requestLiveEvent"]>>>();
+    const secondResponse =
+      createDeferred<Awaited<ReturnType<WorkerConnection["requestLiveEvent"]>>>();
+    harness.requestLiveEvent.mockImplementation(async (request) => {
+      return await (request.seq === 1 ? firstResponse.promise : secondResponse.promise);
+    });
+    const client = new WorkerLiveEventClient(harness.connection, { runEpoch: 3 });
+
+    const first = client.emit("run-1", LIVE_EVENT);
+    const second = client.emit("run-1", {
+      kind: "thinking",
+      payload: { text: "second", delta: "second" },
+    });
+    await vi.waitFor(() => expect(harness.requestLiveEvent).toHaveBeenCalledTimes(2));
+    secondResponse.resolve({
+      type: "res",
+      id: "live-response-2",
+      ok: true,
+      payload: { ackedSeq: 0 },
+    });
+    await Promise.resolve();
+    expect(harness.requestLiveEvent).toHaveBeenCalledTimes(2);
+    firstResponse.resolve({
+      type: "res",
+      id: "live-response-1",
+      ok: true,
+      payload: { ackedSeq: 2 },
+    });
+
+    await expect(Promise.all([first, second])).resolves.toEqual([{ ackedSeq: 2 }, { ackedSeq: 2 }]);
     client.dispose();
   });
 
@@ -443,14 +478,13 @@ describe("worker live-event client", () => {
     };
     const second = client.emit("run-1", secondEvent);
 
-    await expect(Promise.all([first, second])).resolves.toEqual([{ ackedSeq: 1 }, { ackedSeq: 2 }]);
+    await expect(Promise.all([first, second])).resolves.toEqual([{ ackedSeq: 2 }, { ackedSeq: 2 }]);
     expect(harness.requestLiveEvent.mock.calls.map((call) => call[0])).toEqual([
       expect.objectContaining({ seq: 6, lastAckedSeq: 5, event: LIVE_EVENT }),
+      expect.objectContaining({ seq: 7, lastAckedSeq: 5, event: secondEvent }),
       expect.objectContaining({ seq: 1, lastAckedSeq: 0, event: LIVE_EVENT }),
-      expect.objectContaining({ seq: 2, lastAckedSeq: 1, event: secondEvent }),
+      expect.objectContaining({ seq: 2, lastAckedSeq: 0, event: secondEvent }),
     ]);
-    expect(client.ackedSeq).toBe(2);
-    expect(client.unackedCount).toBe(0);
     client.dispose();
   });
 

--- a/src/worker/worker-rpc-clients.test.ts
+++ b/src/worker/worker-rpc-clients.test.ts
@@ -410,16 +410,25 @@ describe("worker live-event client", () => {
     harness.requestLiveEvent
       .mockImplementationOnce(async () => await previewResponse.promise)
       .mockImplementationOnce(async () => await firstTerminalResponse.promise)
-      .mockResolvedValueOnce({
-        type: "res",
-        id: "live-response-resync",
-        ok: false,
-        error: {
-          code: "INVALID_REQUEST",
-          message: "Replay required",
-          details: { reason: "resync-required", ackedSeq: 0, expectedSeq: 1 },
-        },
-      })
+      .mockImplementationOnce(async (request) =>
+        request.lastAckedSeq > 0
+          ? {
+              type: "res",
+              id: "live-response-resync",
+              ok: false,
+              error: {
+                code: "INVALID_REQUEST",
+                message: "Replay required",
+                details: { reason: "resync-required", ackedSeq: 0, expectedSeq: 1 },
+              },
+            }
+          : {
+              type: "res",
+              id: "live-response-gap",
+              ok: true,
+              payload: { ackedSeq: 0 },
+            },
+      )
       .mockResolvedValueOnce({
         type: "res",
         id: "live-response-finishing",
@@ -478,16 +487,25 @@ describe("worker live-event client", () => {
           details: { reason: "invalid-event" },
         },
       })
-      .mockResolvedValueOnce({
-        type: "res",
-        id: "live-response-resync",
-        ok: false,
-        error: {
-          code: "INVALID_REQUEST",
-          message: "Replay required",
-          details: { reason: "resync-required", ackedSeq: 0, expectedSeq: 1 },
-        },
-      })
+      .mockImplementationOnce(async (request) =>
+        request.lastAckedSeq > 0
+          ? {
+              type: "res",
+              id: "live-response-resync",
+              ok: false,
+              error: {
+                code: "INVALID_REQUEST",
+                message: "Replay required",
+                details: { reason: "resync-required", ackedSeq: 0, expectedSeq: 1 },
+              },
+            }
+          : {
+              type: "res",
+              id: "live-response-gap",
+              ok: true,
+              payload: { ackedSeq: 0 },
+            },
+      )
       .mockResolvedValueOnce({
         type: "res",
         id: "live-response-finishing",

--- a/src/worker/worker-rpc-live-event-client.ts
+++ b/src/worker/worker-rpc-live-event-client.ts
@@ -62,6 +62,9 @@ export class WorkerLiveEventClient {
   private maxSentSeqValue: number;
   private replayGeneration = 0;
   private lastResync: { ackedSeq: number; expectedSeq: number } | undefined;
+  // A preview may fail before finishing is enqueued; retain its send high-water
+  // so that later terminal delivery still clears the resulting sequence gap.
+  private terminalResyncFromSeq: number | undefined;
   private disposed = false;
 
   constructor(
@@ -96,10 +99,15 @@ export class WorkerLiveEventClient {
       return Promise.reject(new Error("worker live-event buffer capacity exceeded"));
     }
     return new Promise((resolve, reject) => {
+      const terminalResyncFromSeq = isTerminalEvent(event) ? this.terminalResyncFromSeq : undefined;
+      if (terminalResyncFromSeq !== undefined) {
+        this.terminalResyncFromSeq = undefined;
+      }
       this.buffered.push({
         seq: this.nextSeqValue,
         runId,
         event: structuredClone(event),
+        ...(terminalResyncFromSeq === undefined ? {} : { resyncFromSeq: terminalResyncFromSeq }),
         resolve,
         reject,
       });
@@ -206,11 +214,8 @@ export class WorkerLiveEventClient {
         return;
       }
       const failure = error instanceof Error ? error : new Error(String(error));
-      if (
-        !isTerminalEvent(entry.event) &&
-        !isTerminalConnection(this.connection) &&
-        this.recoverTerminalAfterPreviewFailure(failure)
-      ) {
+      if (!isTerminalEvent(entry.event) && !isTerminalConnection(this.connection)) {
+        this.recoverTerminalAfterPreviewFailure(failure);
         return;
       }
       this.rejectAll(failure);
@@ -254,24 +259,23 @@ export class WorkerLiveEventClient {
     this.maxSentSeqValue = ackedSeq;
   }
 
-  private recoverTerminalAfterPreviewFailure(error: Error): boolean {
-    if (!this.buffered.some((entry) => isTerminalEvent(entry.event))) {
-      return false;
-    }
+  private recoverTerminalAfterPreviewFailure(error: Error): void {
     this.replayGeneration += 1;
     this.lastResync = undefined;
-    const resyncFromSeq = this.maxSentSeqValue;
+    const resyncFromSeq = Math.max(this.terminalResyncFromSeq ?? 0, this.maxSentSeqValue);
     const buffered = this.buffered.splice(0);
+    let terminalRetained = false;
     for (const entry of buffered) {
       if (isTerminalEvent(entry.event)) {
         delete entry.blockedAck;
         entry.resyncFromSeq = resyncFromSeq;
         this.buffered.push(entry);
+        terminalRetained = true;
       } else {
         entry.reject(error);
       }
     }
-    return true;
+    this.terminalResyncFromSeq = terminalRetained ? undefined : resyncFromSeq;
   }
 
   private rejectAll(error: Error): void {

--- a/src/worker/worker-rpc-live-event-client.ts
+++ b/src/worker/worker-rpc-live-event-client.ts
@@ -32,17 +32,33 @@ type BufferedLiveEvent = {
   seq: number;
   runId: string;
   event: WorkerLiveEvent;
-  lastResync?: { ackedSeq: number; expectedSeq: number };
+  blockedAck?: number;
   resolve: (result: WorkerLiveEventResult) => void;
   reject: (error: Error) => void;
 };
 
+// Keep worker requests below the Gateway's 16-frame ingress ceiling while allowing
+// preview delivery to advance independently of any one cumulative ACK.
+const MAX_IN_FLIGHT = 8;
+
+function isTerminalEvent(event: WorkerLiveEvent): boolean {
+  return (
+    event.kind === "lifecycle" &&
+    (event.payload.phase === "finishing" ||
+      event.payload.phase === "end" ||
+      event.payload.phase === "error")
+  );
+}
+
 export class WorkerLiveEventClient {
   private readonly buffered: BufferedLiveEvent[] = [];
+  private readonly inFlight = new Set<BufferedLiveEvent>();
   private readonly unsubscribers: Array<() => void>;
   private ackedSeqValue: number;
   private nextSeqValue: number;
-  private draining = false;
+  private maxSentSeqValue: number;
+  private replayGeneration = 0;
+  private lastResync: { ackedSeq: number; expectedSeq: number } | undefined;
   private disposed = false;
 
   constructor(
@@ -51,8 +67,9 @@ export class WorkerLiveEventClient {
   ) {
     this.ackedSeqValue = options.initialAckedSeq ?? 0;
     this.nextSeqValue = this.ackedSeqValue + 1;
+    this.maxSentSeqValue = this.ackedSeqValue;
     this.unsubscribers = [
-      connection.onReady(() => this.scheduleDrain()),
+      connection.onReady(() => this.pump()),
       connection.onStateChange((state) => {
         if (state.kind === "fenced") {
           this.rejectAll(new WorkerFencedError(state.reason));
@@ -65,19 +82,14 @@ export class WorkerLiveEventClient {
     ];
   }
 
-  get ackedSeq(): number {
-    return this.ackedSeqValue;
-  }
-
-  get unackedCount(): number {
-    return this.buffered.length;
-  }
-
   emit(runId: string, event: WorkerLiveEvent): Promise<WorkerLiveEventResult> {
     if (this.disposed) {
       return Promise.reject(new Error("worker live-event client disposed"));
     }
-    if (this.buffered.length >= (this.options.maxBufferedEvents ?? 1_024)) {
+    if (
+      !isTerminalEvent(event) &&
+      this.buffered.length >= (this.options.maxBufferedEvents ?? 1_024)
+    ) {
       return Promise.reject(new Error("worker live-event buffer capacity exceeded"));
     }
     return new Promise((resolve, reject) => {
@@ -89,7 +101,7 @@ export class WorkerLiveEventClient {
         reject,
       });
       this.nextSeqValue += 1;
-      this.scheduleDrain();
+      this.pump();
     });
   }
 
@@ -104,89 +116,95 @@ export class WorkerLiveEventClient {
     this.rejectAll(new Error("worker live-event client disposed"));
   }
 
-  private scheduleDrain(): void {
-    if (this.draining || this.disposed || this.buffered.length === 0) {
+  private pump(): void {
+    if (this.disposed || this.buffered.length === 0) {
       return;
     }
-    this.draining = true;
-    void this.drain()
-      .catch((error: unknown) => {
-        this.rejectAll(error instanceof Error ? error : new Error(String(error)));
-      })
-      .finally(() => {
-        this.draining = false;
-        if (!this.disposed && this.buffered.length > 0) {
-          this.scheduleDrain();
-        }
-      });
+    for (const entry of this.buffered) {
+      if (this.inFlight.size >= MAX_IN_FLIGHT) {
+        break;
+      }
+      if (this.inFlight.has(entry)) {
+        continue;
+      }
+      if (entry.blockedAck === this.ackedSeqValue) {
+        continue;
+      }
+      this.inFlight.add(entry);
+      void this.send(entry);
+    }
+    if (
+      this.inFlight.size === 0 &&
+      this.buffered.length > 0 &&
+      this.buffered.every((entry) => entry.blockedAck === this.ackedSeqValue)
+    ) {
+      const head = this.buffered[0]!;
+      this.rejectAll(
+        new Error(
+          `worker live-event acknowledgement did not advance (seq=${head.seq} runId=${head.runId} ackedSeq=${this.ackedSeqValue} buffered=${this.buffered.length} runEpoch=${this.options.runEpoch})`,
+        ),
+      );
+    }
   }
 
-  private async drain(): Promise<void> {
-    while (!this.disposed && this.buffered.length > 0) {
-      const current = this.buffered[0];
-      if (!current) {
+  private async send(entry: BufferedLiveEvent): Promise<void> {
+    const generation = this.replayGeneration;
+    const sentSeq = entry.seq;
+    this.maxSentSeqValue = Math.max(this.maxSentSeqValue, sentSeq);
+    try {
+      await this.connection.waitForReady();
+      const response = await this.connection.requestLiveEvent({
+        runEpoch: this.options.runEpoch,
+        lastAckedSeq: this.ackedSeqValue,
+        seq: sentSeq,
+        runId: entry.runId,
+        event: entry.event,
+      });
+      if (generation !== this.replayGeneration || !this.buffered.includes(entry)) {
         return;
       }
-      try {
-        await this.connection.waitForReady();
-        const response = await this.connection.requestLiveEvent({
-          runEpoch: this.options.runEpoch,
-          lastAckedSeq: this.ackedSeqValue,
-          seq: current.seq,
-          runId: current.runId,
-          event: current.event,
-        });
-        if (response.ok) {
-          if (
-            response.payload.ackedSeq < this.ackedSeqValue ||
-            response.payload.ackedSeq > current.seq
-          ) {
-            this.rejectAll(new Error("worker live-event acknowledgement is outside sent range"));
-            return;
-          }
-          const previousAck = this.ackedSeqValue;
+      if (response.ok) {
+        if (response.payload.ackedSeq > this.maxSentSeqValue) {
+          throw new Error("worker live-event acknowledgement is outside sent range");
+        }
+        if (response.payload.ackedSeq > this.ackedSeqValue) {
+          this.lastResync = undefined;
           this.ackThrough(response.payload.ackedSeq);
-          if (this.ackedSeqValue === previousAck && this.buffered[0] === current) {
-            this.rejectAll(
-              new Error(
-                `worker live-event acknowledgement did not advance (seq=${current.seq} runId=${current.runId} ackedSeq=${response.payload.ackedSeq} previousAck=${previousAck} buffered=${this.buffered.length} runEpoch=${this.options.runEpoch})`,
-              ),
-            );
-            return;
-          }
-          continue;
+        } else {
+          entry.blockedAck = response.payload.ackedSeq;
         }
-        if (response.error.details.reason === "resync-required") {
-          if (response.error.details.ackedSeq > current.seq) {
-            this.rejectAll(new Error("worker live-event resync acknowledged an unsent event"));
-            return;
-          }
-          const cursor = {
-            ackedSeq: response.error.details.ackedSeq,
-            expectedSeq: response.error.details.expectedSeq,
-          };
-          if (
-            current.lastResync?.ackedSeq === cursor.ackedSeq &&
-            current.lastResync.expectedSeq === cursor.expectedSeq
-          ) {
-            throw new Error("worker live-event resync did not advance");
-          }
-          current.lastResync = cursor;
-          this.resync(response.error.details.ackedSeq, response.error.details.expectedSeq);
-          continue;
-        }
-        fenceForOwnershipError(this.connection, response.error);
-        this.rejectAll(new WorkerLiveEventError(response.error));
         return;
-      } catch (error) {
-        if (
-          error instanceof WorkerConnectionInterruptedError &&
-          !isTerminalConnection(this.connection)
-        ) {
-          return;
-        }
-        throw error;
       }
+      if (response.error.details.reason === "resync-required") {
+        if (response.error.details.ackedSeq > this.maxSentSeqValue) {
+          throw new Error("worker live-event resync acknowledged an unsent event");
+        }
+        const cursor = {
+          ackedSeq: response.error.details.ackedSeq,
+          expectedSeq: response.error.details.expectedSeq,
+        };
+        if (
+          this.lastResync?.ackedSeq === cursor.ackedSeq &&
+          this.lastResync.expectedSeq === cursor.expectedSeq
+        ) {
+          throw new Error("worker live-event resync did not advance");
+        }
+        this.lastResync = cursor;
+        this.resync(cursor.ackedSeq, cursor.expectedSeq);
+        return;
+      }
+      fenceForOwnershipError(this.connection, response.error);
+      throw new WorkerLiveEventError(response.error);
+    } catch (error) {
+      if (
+        !(error instanceof WorkerConnectionInterruptedError) ||
+        isTerminalConnection(this.connection)
+      ) {
+        this.rejectAll(error instanceof Error ? error : new Error(String(error)));
+      }
+    } finally {
+      this.inFlight.delete(entry);
+      this.pump();
     }
   }
 
@@ -207,6 +225,7 @@ export class WorkerLiveEventClient {
       this.rejectAll(new Error("worker live-event resync cursor is inconsistent"));
       return;
     }
+    this.replayGeneration += 1;
     if (ackedSeq >= this.ackedSeqValue) {
       this.ackThrough(ackedSeq);
     } else {
@@ -215,9 +234,11 @@ export class WorkerLiveEventClient {
     let seq = expectedSeq;
     for (const entry of this.buffered) {
       entry.seq = seq;
+      delete entry.blockedAck;
       seq += 1;
     }
     this.nextSeqValue = seq;
+    this.maxSentSeqValue = ackedSeq;
   }
 
   private rejectAll(error: Error): void {

--- a/src/worker/worker-rpc-live-event-client.ts
+++ b/src/worker/worker-rpc-live-event-client.ts
@@ -33,6 +33,9 @@ type BufferedLiveEvent = {
   runId: string;
   event: WorkerLiveEvent;
   blockedAck?: number;
+  // Claim the old send high-water once so the Gateway clears speculative
+  // preview gaps before an authoritative terminal retry is renumbered.
+  resyncFromSeq?: number;
   resolve: (result: WorkerLiveEventResult) => void;
   reject: (error: Error) => void;
 };
@@ -155,7 +158,7 @@ export class WorkerLiveEventClient {
       await this.connection.waitForReady();
       const response = await this.connection.requestLiveEvent({
         runEpoch: this.options.runEpoch,
-        lastAckedSeq: this.ackedSeqValue,
+        lastAckedSeq: entry.resyncFromSeq ?? this.ackedSeqValue,
         seq: sentSeq,
         runId: entry.runId,
         event: entry.event,
@@ -197,11 +200,20 @@ export class WorkerLiveEventClient {
       throw new WorkerLiveEventError(response.error);
     } catch (error) {
       if (
-        !(error instanceof WorkerConnectionInterruptedError) ||
-        isTerminalConnection(this.connection)
+        error instanceof WorkerConnectionInterruptedError &&
+        !isTerminalConnection(this.connection)
       ) {
-        this.rejectAll(error instanceof Error ? error : new Error(String(error)));
+        return;
       }
+      const failure = error instanceof Error ? error : new Error(String(error));
+      if (
+        !isTerminalEvent(entry.event) &&
+        !isTerminalConnection(this.connection) &&
+        this.recoverTerminalAfterPreviewFailure(failure)
+      ) {
+        return;
+      }
+      this.rejectAll(failure);
     } finally {
       this.inFlight.delete(entry);
       this.pump();
@@ -235,10 +247,31 @@ export class WorkerLiveEventClient {
     for (const entry of this.buffered) {
       entry.seq = seq;
       delete entry.blockedAck;
+      delete entry.resyncFromSeq;
       seq += 1;
     }
     this.nextSeqValue = seq;
     this.maxSentSeqValue = ackedSeq;
+  }
+
+  private recoverTerminalAfterPreviewFailure(error: Error): boolean {
+    if (!this.buffered.some((entry) => isTerminalEvent(entry.event))) {
+      return false;
+    }
+    this.replayGeneration += 1;
+    this.lastResync = undefined;
+    const resyncFromSeq = this.maxSentSeqValue;
+    const buffered = this.buffered.splice(0);
+    for (const entry of buffered) {
+      if (isTerminalEvent(entry.event)) {
+        delete entry.blockedAck;
+        entry.resyncFromSeq = resyncFromSeq;
+        this.buffered.push(entry);
+      } else {
+        entry.reject(error);
+      }
+    }
+    return true;
   }
 
   private rejectAll(error: Error): void {

--- a/src/worker/worker.fault-injection.test.ts
+++ b/src/worker/worker.fault-injection.test.ts
@@ -1,146 +1,33 @@
-import fs from "node:fs/promises";
-import { createServer, type Server } from "node:http";
-import os from "node:os";
-import path from "node:path";
-import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { WebSocket, WebSocketServer, type RawData } from "ws";
-import {
-  type WorkerLiveEventParams,
-  WORKER_PROTOCOL_FEATURES,
-  WORKER_RPC_SET_VERSION,
-} from "../../packages/gateway-protocol/src/schema/worker-admission.js";
+import type { WorkerLiveEventParams } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
 import type {
   WorkerInferenceStartParams,
   WorkerInferenceTerminalOutcome,
 } from "../../packages/gateway-protocol/src/schema/worker-inference.js";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { runWorkerProviderReplayRoundTrip } from "../../test/helpers/worker-provider-replay-roundtrip.js";
-import { createOperationalRunInstanceRef } from "../agents/admitted-run-context.js";
 import { SessionManager } from "../agents/sessions/session-manager.js";
-import {
-  resolveSessionTranscriptRuntimeTarget,
-  upsertSessionEntryCore,
-} from "../config/sessions/session-accessor.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  attachWorkerWsMessageHandler,
-  type WorkerConnectionService,
-} from "../gateway/server/ws-connection/worker-connection.js";
-import type { GatewayWsClient } from "../gateway/server/ws-types.js";
-import type { WorkerConnectionIdentity } from "../gateway/worker-environments/connection-identity.js";
-import { hashWorkerCredential } from "../gateway/worker-environments/credential.js";
-import { createWorkerInferenceStore } from "../gateway/worker-environments/inference-store.js";
-import {
-  createWorkerLiveEventReceiver,
-  type WorkerLiveEventReceiver,
-} from "../gateway/worker-environments/live-events.js";
-import {
-  createWorkerEnvironmentService,
-  type WorkerEnvironmentService,
-} from "../gateway/worker-environments/service.js";
-import {
-  createWorkerEnvironmentStore,
-  type WorkerEnvironmentStore,
-} from "../gateway/worker-environments/store.js";
-import { createWorkerTranscriptCommitStore } from "../gateway/worker-environments/transcript-commit-store.js";
-import { createWorkerTranscriptCommitter } from "../gateway/worker-environments/transcript-commit.js";
-import { getAgentEventLifecycleGeneration, onAgentRuntimeEvent } from "../infra/agent-events.js";
+import { getAgentEventLifecycleGeneration } from "../infra/agent-events.js";
 import {
   claimAgentRunContext,
   clearAgentRunContext,
   getAgentRunContext,
 } from "../infra/agent-run-registry.js";
-import type { WorkerProvider, WorkerSshEndpoint } from "../plugins/types.js";
+import { WorkerConnectionStoppedError, WorkerFencedError } from "./worker-connection.js";
 import {
-  closeOpenClawStateDatabaseForTest,
-  openOpenClawStateDatabase,
-  type OpenClawStateDatabase,
-} from "../state/openclaw-state-db.js";
-import { buildWorkerConnectParams, type WorkerLaunchDescriptor } from "./launch-descriptor.js";
-import {
-  createWorkerConnection,
-  type WorkerConnection,
-  WorkerConnectionStoppedError,
-  WorkerFencedError,
-} from "./worker-connection.js";
-import {
-  WorkerInferenceProxyClient,
-  WorkerLiveEventClient,
-  WorkerTranscriptCommitClient,
-} from "./worker-rpc-clients.js";
+  ComposedGatewayHarness,
+  ENVIRONMENT_ID,
+  RUN_ID,
+  SESSION_ID,
+  SESSION_KEY,
+  doneMessage,
+  doneOutcome,
+  type WorkerClients,
+} from "./worker-fault-injection.test-support.js";
+import { runWorkerDescriptor } from "./worker.runtime.js";
 
-const SESSION_ID = "fault-session";
-const SESSION_KEY = "agent:main:fault-session";
-const ENVIRONMENT_ID = "fault-environment";
-const RUN_ID = "fault-run";
-const BUNDLE_HASH = Array.from({ length: 64 }, () => "a").join("");
-const CREDENTIAL = ["worker", "fault", "fixture"].join("-");
 const REPLACEMENT_CREDENTIAL = ["worker", "replacement", "fixture"].join("-");
 const MODEL_REF = { provider: "fake", model: "fault-model" } as const;
-const HOST_KEY = [["ssh", "ed25519"].join("-"), "AAAA"].join(" ");
-const SSH_ENDPOINT: WorkerSshEndpoint = {
-  host: "worker.example.test",
-  port: 22,
-  user: "openclaw",
-  hostKey: HOST_KEY,
-  keyRef: { source: "file", provider: "worker-fixtures", id: "/development-key" },
-};
-const HANDSHAKE = {
-  bundleHash: BUNDLE_HASH,
-  openclawVersion: "fault-test",
-  protocolFeatures: [...WORKER_PROTOCOL_FEATURES],
-};
-type WorkerEnvironmentServiceOptions = Parameters<typeof createWorkerEnvironmentService>[0];
-const BUNDLE_ARTIFACT = {
-  install: "bundle" as const,
-  bundleHash: BUNDLE_HASH,
-  openclawVersion: HANDSHAKE.openclawVersion,
-  protocolFeatures: [...WORKER_PROTOCOL_FEATURES],
-  tarballSha256: Array.from({ length: 64 }, () => "b").join(""),
-  tarballPath: "/gateway/cache/worker-bundle.tgz",
-};
-const PROVIDER: WorkerProvider = {
-  id: "fake",
-  provision: async () => ({ leaseId: "lease-fault", ssh: SSH_ENDPOINT }),
-  inspect: async () => ({ status: "active" }),
-  destroy: async () => {},
-};
-
-type Deferred<T> = {
-  promise: Promise<T>;
-  resolve(value: T): void;
-  reject(error: Error): void;
-};
-
-type WorkerDoneMessage = Extract<WorkerInferenceTerminalOutcome, { type: "done" }>["message"];
-
-function doneMessage(text: string): WorkerDoneMessage {
-  return {
-    role: "assistant",
-    content: [{ type: "text", text }],
-    api: "openai-responses",
-    provider: MODEL_REF.provider,
-    model: MODEL_REF.model,
-    usage: {
-      input: 1,
-      output: 1,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 2,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
-    stopReason: "stop",
-    timestamp: 1,
-  };
-}
-
-function doneOutcome(text: string): WorkerInferenceTerminalOutcome {
-  return {
-    type: "done",
-    message: doneMessage(text),
-  };
-}
 
 function transcriptMessage(text: string) {
   return {
@@ -160,535 +47,6 @@ function inferenceRequest(epoch: number, turnId: string): WorkerInferenceStartPa
     context: { messages: [] },
     options: {},
   };
-}
-
-type FaultRule =
-  | { kind: "drop-response"; method: string; restart: boolean }
-  | { kind: "partition-after-inference-event"; seq: number };
-
-type TranscriptGate = {
-  phase: "before-apply" | "after-apply";
-  entered: Deferred<void>;
-  release: Deferred<void>;
-};
-
-type ProviderPlan =
-  | { kind: "immediate"; text: string; outcome?: WorkerInferenceTerminalOutcome }
-  | {
-      kind: "partitioned";
-      firstRelease: Deferred<void>;
-      secondRelease: Deferred<void>;
-      started: Deferred<void>;
-      text: string;
-    }
-  | { kind: "pending"; release: Deferred<WorkerInferenceTerminalOutcome>; started: Deferred<void> };
-
-type WorkerClients = {
-  connection: WorkerConnection;
-  transcript: WorkerTranscriptCommitClient;
-  live: WorkerLiveEventClient;
-  inference: WorkerInferenceProxyClient;
-};
-
-type WorkerClientOptions = {
-  admissionProof?: string;
-  epoch?: number;
-  baseLeafId?: string | null;
-  initialSeq?: number;
-  initialAckedSeq?: number;
-  runId?: string;
-};
-
-class ComposedGatewayHarness {
-  readonly root: string;
-  readonly stateDir: string;
-  readonly sessionsDir: string;
-  readonly storePath: string;
-  readonly sessionTarget: Awaited<ReturnType<typeof resolveSessionTranscriptRuntimeTarget>>;
-  readonly socketPath: string;
-  readonly cfg: OpenClawConfig;
-  readonly database: OpenClawStateDatabase;
-  readonly store: WorkerEnvironmentStore;
-  readonly requests: Array<{ method: string; params: unknown }> = [];
-  readonly admissions: WorkerConnectionIdentity[] = [];
-  readonly liveDeltas: string[] = [];
-  readonly abandonedServices: WorkerEnvironmentService[] = [];
-  providerCalls = 0;
-  replacementProviderCalls = 0;
-  connectionCount = 0;
-  transcriptGate: TranscriptGate | undefined;
-  providerPlan: ProviderPlan = { kind: "immediate", text: "done" };
-
-  private readonly httpServer: Server;
-  private readonly webSocketServer: WebSocketServer;
-  private readonly sockets = new Set<WebSocket>();
-  private readonly socketCleanups = new Set<() => void>();
-  private readonly requestMethods = new Map<string, string>();
-  private readonly faults: FaultRule[] = [];
-  private serviceValue!: WorkerEnvironmentService;
-  private liveEventsValue!: WorkerLiveEventReceiver;
-  private useReplacementExecutor = false;
-  private unsubscribeLive: (() => void) | undefined;
-
-  static async create(): Promise<ComposedGatewayHarness> {
-    const root = await fs.mkdtemp(
-      path.join(await fs.realpath(os.tmpdir()), "openclaw-worker-fault-"),
-    );
-    const sessionsDir = path.join(root, "agents", "main", "sessions");
-    const storePath = path.join(sessionsDir, "sessions.json");
-    await upsertSessionEntryCore(
-      { agentId: "main", sessionKey: SESSION_KEY, storePath },
-      { sessionId: SESSION_ID, updatedAt: 1 },
-    );
-    const sessionTarget = await resolveSessionTranscriptRuntimeTarget({
-      agentId: "main",
-      sessionId: SESSION_ID,
-      sessionKey: SESSION_KEY,
-      storePath,
-    });
-    return new ComposedGatewayHarness({ root, sessionsDir, storePath, sessionTarget });
-  }
-
-  private constructor(params: {
-    root: string;
-    sessionsDir: string;
-    storePath: string;
-    sessionTarget: Awaited<ReturnType<typeof resolveSessionTranscriptRuntimeTarget>>;
-  }) {
-    this.root = params.root;
-    this.stateDir = path.join(params.root, "state");
-    this.sessionsDir = params.sessionsDir;
-    this.storePath = params.storePath;
-    this.sessionTarget = params.sessionTarget;
-    this.socketPath = path.join(params.root, "gateway.sock");
-    this.cfg = {
-      agents: { list: [{ id: "main", default: true }] },
-      session: {
-        mainKey: "main",
-        store: path.join(params.root, "agents", "{agentId}", "sessions", "sessions.json"),
-      },
-      cloudWorkers: {
-        profiles: { development: { provider: "fake", settings: { region: "test" } } },
-      },
-    };
-    this.database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: this.stateDir } });
-    this.store = createWorkerEnvironmentStore({ database: this.database });
-    this.seedAttachedEnvironment();
-    this.liveEventsValue = this.createLiveEvents(true);
-    this.serviceValue = this.createService();
-    this.httpServer = createServer();
-    this.webSocketServer = new WebSocketServer({ server: this.httpServer });
-    this.webSocketServer.on("connection", (socket) => this.accept(socket));
-    this.unsubscribeLive = onAgentRuntimeEvent((event) => {
-      if (typeof event.data.delta === "string") {
-        this.liveDeltas.push(event.data.delta);
-      }
-    });
-  }
-
-  get service(): WorkerEnvironmentService {
-    return this.serviceValue;
-  }
-
-  get epoch(): number {
-    const record = this.store.get(ENVIRONMENT_ID);
-    if (!record) {
-      throw new Error("fault environment missing");
-    }
-    return record.ownerEpoch;
-  }
-
-  async start(): Promise<void> {
-    await new Promise<void>((resolve, reject) => {
-      const onError = (error: Error) => {
-        this.httpServer.off("listening", onListening);
-        reject(error);
-      };
-      const onListening = () => {
-        this.httpServer.off("error", onError);
-        resolve();
-      };
-      this.httpServer.once("error", onError);
-      this.httpServer.once("listening", onListening);
-      this.httpServer.listen(this.socketPath);
-    });
-  }
-
-  addFault(rule: FaultRule): void {
-    this.faults.push(rule);
-  }
-
-  createDescriptor(params: WorkerClientOptions = {}): WorkerLaunchDescriptor {
-    const epoch = params.epoch ?? this.epoch;
-    const credential = params.admissionProof ?? CREDENTIAL;
-    return {
-      version: 2,
-      socketPath: this.socketPath,
-      admission: {
-        environmentId: ENVIRONMENT_ID,
-        credential,
-        sessionId: SESSION_ID,
-        ownerEpoch: epoch,
-        rpcSetVersion: WORKER_RPC_SET_VERSION,
-        handshake: HANDSHAKE,
-      },
-      assignment: {
-        agentId: "worker-agent",
-        runId: params.runId ?? RUN_ID,
-        operationalRunInstance: createOperationalRunInstanceRef(params.runId ?? RUN_ID),
-        agentRuntimeIdentityToken: "test-agent-runtime-token",
-        turnId: "fault-turn",
-        prompt: "fault injection",
-        workspaceDir: this.root,
-        modelRef: MODEL_REF,
-        inferenceOptions: {},
-        suppressPromptTranscript: false,
-        initialMessages: [],
-        transcript: { baseLeafId: params.baseLeafId ?? null, nextSeq: params.initialSeq ?? 1 },
-        liveEvents: {
-          ackedSeq: params.initialAckedSeq ?? 0,
-          nextSeq: (params.initialAckedSeq ?? 0) + 1,
-        },
-        toolAuthority: {
-          allowedToolNames: ["read", "write", "edit", "apply_patch", "exec", "process"],
-        },
-      },
-    };
-  }
-
-  createClients(params: WorkerClientOptions = {}): WorkerClients {
-    const descriptor = this.createDescriptor(params);
-    const epoch = descriptor.admission.ownerEpoch;
-    const connection = createWorkerConnection({
-      socketPath: this.socketPath,
-      connectParams: buildWorkerConnectParams(descriptor),
-      admissionTimeoutMs: 1_000,
-      admissionDeadlineMs: 5_000,
-      requestTimeoutMs: 2_000,
-      reconnectBackoff: { initialMs: 1, maxMs: 1, factor: 1, jitter: 0 },
-    });
-    return {
-      connection,
-      transcript: new WorkerTranscriptCommitClient(connection, {
-        runEpoch: epoch,
-        baseLeafId: params.baseLeafId ?? null,
-        initialSeq: params.initialSeq ?? 1,
-      }),
-      live: new WorkerLiveEventClient(connection, {
-        runEpoch: epoch,
-        initialAckedSeq: params.initialAckedSeq ?? 0,
-      }),
-      inference: new WorkerInferenceProxyClient(connection),
-    };
-  }
-
-  hardRestart(options: { corroborateLiveOwner: boolean }): void {
-    const previous = this.serviceValue;
-    this.abandonedServices.push(previous);
-    this.liveEventsValue.clear();
-    this.liveEventsValue = this.createLiveEvents(options.corroborateLiveOwner);
-    this.useReplacementExecutor = true;
-    this.serviceValue = this.createService();
-    this.terminateSockets();
-  }
-
-  partition(): void {
-    this.terminateSockets();
-  }
-
-  reclaimWithCredential(credential: string): number {
-    const attached = this.store.get(ENVIRONMENT_ID);
-    if (!attached || attached.state !== "attached") {
-      throw new Error("fault environment is not attached");
-    }
-    const idle = this.store.transition({
-      environmentId: ENVIRONMENT_ID,
-      from: "attached",
-      to: "idle",
-      expectedOwnerEpoch: attached.ownerEpoch,
-    });
-    const next = this.store.transition({
-      environmentId: ENVIRONMENT_ID,
-      from: "idle",
-      to: "attached",
-      expectedOwnerEpoch: idle.ownerEpoch,
-      patch: {
-        attachedSessionIds: [SESSION_ID],
-        credential: {
-          credentialHash: hashWorkerCredential(credential),
-          sessionId: SESSION_ID,
-          rpcSetVersion: WORKER_RPC_SET_VERSION,
-          expiresAtMs: Date.now() + 60_000,
-        },
-      },
-    });
-    this.liveEventsValue.clearEnvironment(ENVIRONMENT_ID);
-    if (
-      !this.liveEventsValue.bindSession({
-        environmentId: ENVIRONMENT_ID,
-        runEpoch: next.ownerEpoch,
-        sessionId: SESSION_ID,
-      })
-    ) {
-      throw new Error("replacement live-event binding failed");
-    }
-    return next.ownerEpoch;
-  }
-
-  requestParams(method: string): unknown[] {
-    return this.requests
-      .filter((request) => request.method === method)
-      .map((request) => structuredClone(request.params));
-  }
-
-  async close(): Promise<void> {
-    this.transcriptGate?.release.resolve();
-    if (this.providerPlan.kind === "partitioned") {
-      this.providerPlan.firstRelease.resolve();
-      this.providerPlan.secondRelease.resolve();
-    } else if (this.providerPlan.kind === "pending") {
-      this.providerPlan.release.resolve({
-        type: "error",
-        reason: "provider-error",
-        message: "fixture released during cleanup",
-      });
-    }
-    this.terminateSockets();
-    for (const cleanup of this.socketCleanups) {
-      cleanup();
-    }
-    this.socketCleanups.clear();
-    await this.serviceValue.stop();
-    for (const service of this.abandonedServices) {
-      await service.stop();
-    }
-    this.liveEventsValue.clear();
-    this.unsubscribeLive?.();
-    this.unsubscribeLive = undefined;
-    await new Promise<void>((resolve) => {
-      this.webSocketServer.close(() => resolve());
-    });
-    await new Promise<void>((resolve) => {
-      this.httpServer.close(() => resolve());
-    });
-    closeOpenClawStateDatabaseForTest();
-    await fs.rm(this.root, { recursive: true, force: true });
-  }
-
-  private seedAttachedEnvironment(): void {
-    const intent = this.store.createIntent({
-      environmentId: ENVIRONMENT_ID,
-      providerId: "fake",
-      profileId: "development",
-      profileSnapshot: { settings: { region: "test" } },
-      provisionOperationId: "provision:fault-environment",
-    });
-    const provisioning = this.store.transition({
-      environmentId: ENVIRONMENT_ID,
-      from: intent.state,
-      to: "provisioning",
-    });
-    const bootstrapping = this.store.transition({
-      environmentId: ENVIRONMENT_ID,
-      from: provisioning.state,
-      to: "bootstrapping",
-      patch: { leaseId: "lease-fault", sshEndpoint: SSH_ENDPOINT },
-    });
-    const ready = this.store.transition({
-      environmentId: ENVIRONMENT_ID,
-      from: bootstrapping.state,
-      to: "ready",
-      patch: {
-        bootstrapReceipt: HANDSHAKE,
-        credential: {
-          credentialHash: hashWorkerCredential([CREDENTIAL, "ready"].join("-")),
-          sessionId: null,
-          rpcSetVersion: WORKER_RPC_SET_VERSION,
-          expiresAtMs: Date.now() + 60_000,
-        },
-      },
-    });
-    this.store.transition({
-      environmentId: ENVIRONMENT_ID,
-      from: ready.state,
-      to: "attached",
-      patch: {
-        attachedSessionIds: [SESSION_ID],
-        credential: {
-          credentialHash: hashWorkerCredential(CREDENTIAL),
-          sessionId: SESSION_ID,
-          rpcSetVersion: WORKER_RPC_SET_VERSION,
-          expiresAtMs: Date.now() + 60_000,
-        },
-      },
-    });
-  }
-
-  private createLiveEvents(corroborateOwner: boolean): WorkerLiveEventReceiver {
-    const binding = {
-      environmentId: ENVIRONMENT_ID,
-      runEpoch: this.epoch,
-      sessionId: SESSION_ID,
-    };
-    const receiver = createWorkerLiveEventReceiver({
-      getConfig: () => this.cfg,
-      startupBindings: corroborateOwner ? [binding] : [],
-      startupOwners: corroborateOwner
-        ? new Map([[ENVIRONMENT_ID, this.epoch]])
-        : new Map<string, number>(),
-    });
-    receiver.start();
-    if (!corroborateOwner && !receiver.bindSession(binding)) {
-      throw new Error("live-event restart binding failed");
-    }
-    return receiver;
-  }
-
-  private createService(): WorkerEnvironmentService {
-    const ledger = createWorkerTranscriptCommitStore({ database: this.database });
-    const committer = createWorkerTranscriptCommitter({
-      getConfig: () => this.cfg,
-      store: ledger,
-    });
-    const executeInference: WorkerEnvironmentServiceOptions["executeInference"] = async (
-      params,
-    ) => {
-      if (this.useReplacementExecutor) {
-        this.replacementProviderCalls += 1;
-      } else {
-        this.providerCalls += 1;
-      }
-      const plan = this.providerPlan;
-      if (plan.kind === "immediate") {
-        return structuredClone(plan.outcome ?? doneOutcome(plan.text));
-      }
-      if (plan.kind === "pending") {
-        plan.started.resolve();
-        return await plan.release.promise;
-      }
-      plan.started.resolve();
-      params.emit({ type: "text_delta", contentIndex: 0, delta: "first" });
-      await plan.firstRelease.promise;
-      params.emit({ type: "text_delta", contentIndex: 0, delta: "second" });
-      await plan.secondRelease.promise;
-      return doneOutcome(plan.text);
-    };
-    return createWorkerEnvironmentService({
-      store: this.store,
-      getConfig: () => this.cfg,
-      resolveProvider: (providerId) => (providerId === PROVIDER.id ? PROVIDER : undefined),
-      prepareInstallation: async () => BUNDLE_ARTIFACT,
-      bootstrapWorker: async () => HANDSHAKE,
-      resolveSshIdentity: async () => ({ kind: "path", path: "/keys/worker" }),
-      applyTranscriptCommit: async (params) => {
-        const gate = this.transcriptGate;
-        if (gate?.phase === "before-apply") {
-          gate.entered.resolve();
-          await gate.release.promise;
-        }
-        const result = await committer.commit(params);
-        if (gate?.phase === "after-apply") {
-          gate.entered.resolve();
-          await gate.release.promise;
-        }
-        return result;
-      },
-      liveEvents: this.liveEventsValue,
-      executeInference,
-      inferenceStore: createWorkerInferenceStore({ database: this.database }),
-    });
-  }
-
-  private accept(socket: WebSocket): void {
-    this.connectionCount += 1;
-    this.sockets.add(socket);
-    const connId = `fault-connection-${this.connectionCount}`;
-    let client: GatewayWsClient | null = null;
-    let closed = false;
-    const observe = (data: RawData) => {
-      const parsed = JSON.parse(rawDataToString(data)) as unknown;
-      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-        return;
-      }
-      const request = parsed as { id?: unknown; method?: unknown; params?: unknown };
-      if (typeof request.id !== "string" || typeof request.method !== "string") {
-        return;
-      }
-      this.requestMethods.set(request.id, request.method);
-      this.requests.push({ method: request.method, params: structuredClone(request.params) });
-    };
-    socket.on("message", observe);
-    const cleanup = attachWorkerWsMessageHandler({
-      socket,
-      connId,
-      service: this.serviceValue as WorkerConnectionService,
-      send: (frame) => this.send(socket, frame),
-      close: (code = 1000, reason = "") => socket.close(code, reason),
-      isClosed: () => closed || socket.readyState === WebSocket.CLOSED,
-      clearHandshakeTimer: () => {},
-      getClient: () => client,
-      setClient: (next) => {
-        client = next;
-        if (next.worker) {
-          this.admissions.push(next.worker);
-        }
-        return true;
-      },
-      setHandshakeState: () => {},
-      advanceHandshakePhase: () => {},
-      setCloseCause: () => {},
-      setLastFrameMeta: () => {},
-      logGateway: { warn: () => {} },
-      logWsControl: { warn: () => {} },
-    });
-    this.socketCleanups.add(cleanup);
-    socket.on("close", () => {
-      closed = true;
-      socket.off("message", observe);
-      cleanup();
-      this.socketCleanups.delete(cleanup);
-      this.sockets.delete(socket);
-    });
-  }
-
-  private send(socket: WebSocket, frame: unknown): void {
-    const response =
-      frame && typeof frame === "object" && !Array.isArray(frame)
-        ? (frame as { event?: unknown; id?: unknown; payload?: { seq?: unknown } })
-        : undefined;
-    const method =
-      typeof response?.id === "string" ? this.requestMethods.get(response.id) : undefined;
-    const faultIndex = this.faults.findIndex((fault) => {
-      if (fault.kind === "drop-response") {
-        return method === fault.method;
-      }
-      return response?.event === "worker.inference.event" && response.payload?.seq === fault.seq;
-    });
-    const fault = faultIndex >= 0 ? this.faults.splice(faultIndex, 1)[0] : undefined;
-    if (fault?.kind === "drop-response") {
-      if (fault.restart) {
-        this.hardRestart({ corroborateLiveOwner: false });
-      } else {
-        socket.terminate();
-      }
-      return;
-    }
-    if (socket.readyState !== WebSocket.OPEN) {
-      return;
-    }
-    const encoded = JSON.stringify(frame);
-    if (fault?.kind === "partition-after-inference-event") {
-      socket.send(encoded, () => socket.terminate());
-      return;
-    }
-    socket.send(encoded);
-  }
-
-  private terminateSockets(): void {
-    for (const socket of this.sockets) {
-      socket.terminate();
-    }
-  }
 }
 
 async function stopClients(clients: WorkerClients | undefined): Promise<void> {
@@ -726,6 +84,64 @@ describe("cloud worker milestone 2 fault injection", () => {
       },
     });
   });
+
+  it.each([
+    ["before service handling", "before-service"],
+    ["after service handling", "after-service"],
+  ] as const)(
+    "does not pace provider preview production on a delayed first request %s",
+    async (_label, previewStage) => {
+      harness.enablePlacement(RUN_ID);
+      const nextProviderDelta = createDeferred();
+      const providerProduced = createDeferred();
+      const previewGate = harness.addLiveEventGate(previewStage, "preview");
+      const finishingGate = harness.addLiveEventGate("after-service", "finishing");
+      harness.providerPlan = {
+        kind: "live-preview",
+        nextRelease: nextProviderDelta,
+        produced: providerProduced,
+        text: "preview reply",
+      };
+      let settled = false;
+      const result = runWorkerDescriptor(harness.createDescriptor()).finally(() => {
+        settled = true;
+      });
+      void result.catch(() => undefined);
+
+      await previewGate.entered.promise;
+      nextProviderDelta.resolve();
+      await providerProduced.promise;
+      await vi.waitFor(() =>
+        expect(
+          harness.requestParams("worker.live-event").filter((params) => {
+            const request = params as WorkerLiveEventParams;
+            return request.event.kind === "assistant" || request.event.kind === "thinking";
+          }),
+        ).toHaveLength(2),
+      );
+      expect(settled).toBe(false);
+      expect(harness.placementWrites.filter((write) => write.liveSeq !== undefined)).toEqual([]);
+      expect(harness.placementStore.get(SESSION_ID)?.lastLiveEventAckCursor).toBeNull();
+
+      previewGate.release.resolve();
+      await finishingGate.entered.promise;
+      expect(settled).toBe(false);
+      expect(SessionManager.open(harness.sessionTarget).getEntries()).toHaveLength(2);
+      expect(harness.placementWrites.filter((write) => write.liveSeq !== undefined)).toHaveLength(
+        1,
+      );
+      expect(harness.placementStore.get(SESSION_ID)?.lastLiveEventAckCursor).toBeGreaterThan(0);
+      expect(harness.placementStore.listPendingWorkspaceResults()).toMatchObject([
+        { sessionId: SESSION_ID, environmentId: ENVIRONMENT_ID, runId: RUN_ID },
+      ]);
+
+      finishingGate.release.resolve();
+      await expect(result).resolves.toMatchObject({
+        transcriptLeafId: expect.any(String),
+        transcriptNextSeq: expect.any(Number),
+      });
+    },
+  );
 
   it("survives repeated tunnel partitions without transcript duplication, live replay, or rebilling", async () => {
     const current = harness.createClients();
@@ -780,7 +196,7 @@ describe("cloud worker milestone 2 fault injection", () => {
       harness
         .requestParams("worker.live-event")
         .map((request) => (request as WorkerLiveEventParams).seq),
-    ).toEqual([1, 1, 2, 3]);
+    ).toEqual([1, 2, 3, 1, 2, 3]);
     const transcript = SessionManager.open(harness.sessionTarget).getEntries();
     expect(transcript).toHaveLength(2);
     expect(new Set(transcript.map((entry) => entry.id)).size).toBe(2);
@@ -820,7 +236,9 @@ describe("cloud worker milestone 2 fault injection", () => {
     // The restart fault fires when the gated commit response drains; make sure the
     // pre-restart tail-a live request reached the gateway first or the lost-window
     // replay assertion below becomes timing-dependent.
-    await vi.waitFor(() => expect(harness.requestParams("worker.live-event")).toHaveLength(2));
+    await vi.waitFor(() =>
+      expect(harness.requestParams("worker.live-event").length).toBeGreaterThanOrEqual(3),
+    );
     commitRelease.resolve();
 
     await expect(commit).resolves.toMatchObject({ entryIds: [expect.any(String)] });
@@ -839,15 +257,16 @@ describe("cloud worker milestone 2 fault injection", () => {
       return [live.seq, live.lastAckedSeq];
     });
     // Pre-restart prefix is deterministic (the waitFor above pins tail-a's send).
-    expect(liveRequests.slice(0, 2)).toEqual([
+    expect(liveRequests.slice(0, 3)).toEqual([
       [1, 0],
       [2, 1],
+      [3, 1],
     ]);
     // Whether tail-a's ack beats the socket teardown is a legitimate race, so the
     // exact retry trace varies; what must hold is that the cleared window forced a
     // resync replay renumbered from the fresh ack state.
-    expect(liveRequests.length).toBeGreaterThanOrEqual(4);
-    expect(liveRequests.slice(2)).toContainEqual([1, 0]);
+    expect(liveRequests.length).toBeGreaterThanOrEqual(5);
+    expect(liveRequests.slice(3)).toContainEqual([1, 0]);
     expect(SessionManager.open(harness.sessionTarget).getEntries()).toHaveLength(1);
     providerRelease.resolve(doneOutcome("late stale provider result"));
   });

--- a/src/worker/worker.fault-injection.test.ts
+++ b/src/worker/worker.fault-injection.test.ts
@@ -5,6 +5,7 @@ import type {
   WorkerInferenceTerminalOutcome,
 } from "../../packages/gateway-protocol/src/schema/worker-inference.js";
 import { createDeferred } from "../../test/helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { runWorkerProviderReplayRoundTrip } from "../../test/helpers/worker-provider-replay-roundtrip.js";
 import { SessionManager } from "../agents/sessions/session-manager.js";
 import { getAgentEventLifecycleGeneration } from "../infra/agent-events.js";
@@ -26,6 +27,7 @@ import {
 } from "./worker-fault-injection.test-support.js";
 import { runWorkerDescriptor } from "./worker.runtime.js";
 
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const REPLACEMENT_CREDENTIAL = ["worker", "replacement", "fixture"].join("-");
 const MODEL_REF = { provider: "fake", model: "fault-model" } as const;
 
@@ -63,7 +65,7 @@ describe("cloud worker milestone 2 fault injection", () => {
   const clients: WorkerClients[] = [];
 
   beforeEach(async () => {
-    harness = await ComposedGatewayHarness.create();
+    harness = await ComposedGatewayHarness.create(tempDirs.make("openclaw-worker-fault-"));
     await harness.start();
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Cloud Worker assistant and thinking previews were paced by one Gateway RPC round trip and one synchronous SQLite cursor write for every delta. On higher-latency worker connections, provider output arrived in stop-and-wait bursts even though preview delivery is lossy and non-authoritative.

## Why This Change Was Made

The worker now has one bounded eight-request cumulative-ACK/replay window, and the embedded runtime no longer owns a second serial drain. Gateway preview high-water state stays in memory under `worker-turn-rpc`; only the ordered `finishing` crossing advances the durable live cursor and atomically creates the existing workspace-result fence. A preview rejection preserves concurrent finishing and forces the existing resync protocol to discard speculative preview gaps before terminal replay. Exact placement, credential, owner epoch, generation, run, and turn-claim validation remain unchanged. The deprecated store input remains source-compatible but no longer owns behavior.

## User Impact

Cloud Worker previews can flow at provider speed instead of Gateway RTT, while transcript ordering, reconnect/resync, terminal authority, and crash-safe workspace reconciliation remain durable.

## Evidence

- Exact pre-fix regression: with the first preview request held before service work or after service work/before ACK, the old code transmitted one preview and failed `expected ... length 2 but got 1`; the repaired two-case boundary regression passes.
- ClawSweeper response-order regressions: a preview rejection no longer rejects finishing already in flight or strands finishing emitted later; both old shared-rejection orderings failed with `Preview rejected`, and terminal-only resync recovery now passes.
- Authenticated live proof: a real `openai/gpt-5.6-luna` streaming response produced 599 assistant/thinking `worker.live-event` preview RPCs through the production worker client and Gateway receiver, with exactly one durable live-cursor write, one pending workspace-result fence, and a two-entry transcript.
- Focused exact-head proof: 215 tests passed across worker fault injection/runtime/RPC, Gateway live-event/worker-turn RPC, placement/recovery, WebSocket handling, and worker-turn launcher suites.
- `node scripts/check-changed.mjs --timed` passed all selected core/core-test lanes on the reviewed preview repair. The scoped follow-up rerun used the trusted-source local fallback and stopped only on stale-branch max-lines baseline entries already removed on current `main`; exact-head merge-ref CI covers the current baseline.
- `pnpm build` passed after the terminal-recovery repair; the private-QA build also passed while constructing the live setup.
- Final Codex-backed autoreview passed with no accepted/actionable findings.
- Production LOC: +155/-175 (net -20). Tests/test support: +1022/-697.
- Full static-SSH product setup was attempted, but current source-bundle bootstrap is independently blocked by npm rejecting existing `workspace:*` package metadata. The authenticated live proof therefore exercised the changed worker/Gateway streaming and durability boundary directly rather than claiming package-install proof.
