### PR TITLE
fix(ui): keep new-session drafts out of the sidebar

### DIFF
--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -585,9 +585,9 @@ class OpenClawShell
       : ROUTE_IDS_WITHOUT_WORKBOARD;
   }
 
-  /** Sidebar draft-row hint while the new-session page is open, keyed off its ?agent param. */
-  draftSessionAgentId(): string {
-    return this.shellNavigation.draftSessionAgentId();
+  /** Agent targeted by the open new-session route, keyed off its ?agent param. */
+  newSessionRouteAgentId(): string {
+    return this.shellNavigation.newSessionRouteAgentId();
   }
 
   ensureAgentsList(

--- a/ui/src/app/app-shell-navigation.ts
+++ b/ui/src/app/app-shell-navigation.ts
@@ -264,8 +264,8 @@ export class ShellNavigationOwner {
     }
   }
 
-  /** Sidebar draft-row hint while the new-session page is open, keyed off its ?agent param. */
-  draftSessionAgentId(): string {
+  /** Agent targeted by the open new-session route, keyed off its ?agent param. */
+  newSessionRouteAgentId(): string {
     if (this.host.routeState.routeId !== "new-session") {
       return "";
     }

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -66,7 +66,7 @@ export interface ShellViewHost {
   readonly sidebarWorkboardRenderers: SidebarWorkboardRenderers | undefined;
   readonly sidebarWorkboardSnapshot: SidebarWorkboardSnapshot;
   closeNavDrawer(options?: { restoreFocus?: boolean }): void;
-  draftSessionAgentId(): string;
+  newSessionRouteAgentId(): string;
   enabledRouteIds(): readonly RouteId[];
   exitSettings(): void;
   handleCommandPaletteSlashCommand(command: string): void;
@@ -198,10 +198,10 @@ export function renderApplicationShell(host: ShellViewHost) {
     mobileNavLayout,
   });
   const shellWidth = Math.max(globalThis.innerWidth || 0, NAV_WIDTH_MAX);
-  // Mirror the sidebar brand action: an open new-session draft wins over the
-  // persisted selection so the collapsed cluster "+" targets the same agent.
+  // Mirror the sidebar brand action: the open new-session route target wins
+  // over persisted selection so the collapsed cluster "+" uses the same agent.
   const selectedAgentId = normalizeAgentId(
-    host.draftSessionAgentId() ||
+    host.newSessionRouteAgentId() ||
       (context.agentSelection.state.selectedId ?? gatewaySnapshot.assistantAgentId),
   );
   const newSessionAccess = readSessionMethodAccess(gatewaySnapshot, {
@@ -270,7 +270,6 @@ export function renderApplicationShell(host: ShellViewHost) {
       onOpenApprovals: () => host.openApprovals(),
       onRetryConnect: () => context.gateway.connect(),
       onOpenNewSession: openNewSession,
-      draftSessionAgentId: host.draftSessionAgentId(),
       onUpdateSidebarEntries: (entries: string[]) =>
         context.navigation.update({ sidebarEntries: entries }),
       onPairMobile: () => void context.overlays.openDevicePairSetup(),

--- a/ui/src/components/app-sidebar-base.ts
+++ b/ui/src/components/app-sidebar-base.ts
@@ -69,8 +69,6 @@ export abstract class AppSidebarBase extends OpenClawLightDomContentsElement {
     agentId: string,
     target?: NewSessionTarget,
   ) => void;
-  /** Agent id of the in-flight new-session draft; renders the draft row. */
-  @property({ attribute: false }) draftSessionAgentId = "";
   @property({ attribute: false }) onUpdateSidebarEntries?: (entries: string[]) => void;
   @property({ attribute: false }) onPairMobile?: () => void;
   @property({ attribute: false })

--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -53,11 +53,9 @@ type SessionCatalogRenderSnapshot = {
 function renderSessionSection(params: {
   host: SidebarSessionListHost;
   section: RenderableSessionSection;
-  showDraft?: boolean;
   nativeSessionsHaveMore?: boolean;
 }) {
   const { host, section } = params;
-  const showDraft = params.showDraft ?? false;
   const totalRowCount = section.totalRowCount;
   const group = section.category;
   // zonedVisibleSections removes pinned rows; AppSidebar renders them through
@@ -229,9 +227,8 @@ function renderSessionSection(params: {
                   >${t("chat.sidebar.noSessionsForAgent")}</span
                 >`
               : nothing}
-            ${section.rows.length > 0 || showDraft
+            ${section.rows.length > 0
               ? html`<div class="sidebar-recent-sessions__list" role="list" aria-label=${label}>
-                  ${showDraft ? renderDraftSessionRow() : nothing}
                   ${section.rows.map((session) => renderSessionTree({ host, session }))}
                 </div>`
               : nothing}
@@ -241,19 +238,6 @@ function renderSessionSection(params: {
               nativeSessionsHaveMore: params.nativeSessionsHaveMore ?? false,
             })}
           `}
-    </div>
-  `;
-}
-
-function renderDraftSessionRow() {
-  return html`
-    <div class="sidebar-recent-session sidebar-recent-session--draft" role="listitem">
-      <span class="sidebar-recent-session__link">
-        <span class="sidebar-session-indicator"></span>
-        <span class="sidebar-recent-session__text">
-          <span class="sidebar-recent-session__name">${t("newSession.draftRow")}</span>
-        </span>
-      </span>
     </div>
   `;
 }
@@ -371,7 +355,6 @@ function renderSessionCatalog(params: {
 function renderSessionListBody(params: {
   host: SidebarSessionListHost;
   sections: RenderableSessionSection[];
-  showDraft: boolean;
   nativeSessionsHaveMore: boolean;
   catalogs: SessionCatalogRenderSnapshot;
   catalogRenderer: SessionCatalogGroupsRenderer | null;
@@ -398,7 +381,6 @@ function renderSessionListBody(params: {
   );
   return html`
     ${params.sections.map((section, index) => {
-      const showDraft = section.id === "ungrouped" && params.showDraft;
       if (section.id.startsWith("catalog:")) {
         const catalog = catalogsBySectionId.get(section.id);
         return html`${index === firstCatalogSectionIndex ? catalogStatus : nothing}${catalog
@@ -423,7 +405,6 @@ function renderSessionListBody(params: {
       if (
         section.id === "ungrouped" &&
         section.totalRowCount === 0 &&
-        !showDraft &&
         !params.nativeSessionsHaveMore &&
         !hasCategorizedThreads &&
         !host.sessionOwnershipVisible &&
@@ -435,7 +416,6 @@ function renderSessionListBody(params: {
       return renderSessionSection({
         host,
         section,
-        showDraft,
         nativeSessionsHaveMore: params.nativeSessionsHaveMore,
       });
     })}
@@ -447,7 +427,6 @@ export function renderSessionList(params: {
   host: SidebarSessionListHost;
   empty: boolean;
   sections: RenderableSessionSection[];
-  showDraft: boolean;
   nativeSessionsHaveMore: boolean;
   catalogs: SessionCatalogRenderSnapshot;
   catalogRenderer: SessionCatalogGroupsRenderer | null;
@@ -487,7 +466,6 @@ export function renderSessionList(params: {
         ${renderSessionListBody({
           host,
           sections: params.sections,
-          showDraft: params.showDraft,
           nativeSessionsHaveMore: params.nativeSessionsHaveMore,
           catalogs: params.catalogs,
           catalogRenderer: params.catalogRenderer,

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -16,7 +16,6 @@ import "./tooltip.ts";
 import { createIdleImport } from "../lib/idle-import.ts";
 import { shouldHandleNavigationClick } from "../lib/navigation-click.ts";
 import type { CatalogProjectGrouping } from "../lib/sessions/catalog-project-grouping.ts";
-import { normalizeAgentId } from "../lib/sessions/session-key.ts";
 import { showToast } from "../lib/toast.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import { SETTINGS_SEARCH_TARGETS } from "../pages/config/settings-targets.ts";
@@ -181,16 +180,6 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
         ? [chip.activeId]
         : chip.agents.map((agent) => agent.id);
     this.ensureAgentIdentities(identityIds);
-    // A fresh draft must be visible where it will live: genuinely expand a
-    // collapsed Threads section (persisted) instead of overriding at render
-    // time, so the header toggle keeps matching the visible state.
-    if (
-      changed.has("draftSessionAgentId") &&
-      this.draftSessionAgentId &&
-      this.collapsedSessionSections.has("ungrouped")
-    ) {
-      this.sessionOrganizer.toggleSection("ungrouped");
-    }
   }
 
   ensureAgentIdentities(agentIds: readonly string[]): void {
@@ -448,9 +437,6 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
       sections,
       nativeSessionsHaveMore: this.sessionData.sessionsResult?.hasMore === true,
       catalogRenderer: this.catalogRenderer,
-      showDraft:
-        Boolean(this.draftSessionAgentId) &&
-        normalizeAgentId(this.draftSessionAgentId) === expandedAgentId,
       catalogs: {
         catalogs,
         refreshStatus: this.sessionData.sessionCatalogRefreshStatus,

--- a/ui/src/e2e/new-session-page.places.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.places.e2e.test.ts
@@ -8,6 +8,7 @@ import {
   SESSION_LIST_DEFAULTS,
   WORKSPACE,
   captureProjectUiProof,
+  captureUiProof,
   captureUiProofEnabled,
   controlUiSessionPath,
   createNewSessionPageE2eSuite,
@@ -22,6 +23,46 @@ import {
 const suite = createNewSessionPageE2eSuite();
 
 suite.define(() => {
+  it("keeps the pre-creation draft on the composer surface", async () => {
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      methodResponses: {
+        "agents.list": {
+          agents: [
+            {
+              id: "main",
+              identity: { name: "Main" },
+              name: "Main",
+              workspace: WORKSPACE,
+              workspaceGit: true,
+            },
+          ],
+          defaultId: "main",
+          mainKey: "main",
+          scope: "agent",
+        },
+        "sessions.list": createdSessionListResult("agent:main:existing"),
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}new?agent=main`);
+      await page.getByRole("heading", { name: "Main" }).waitFor();
+      await page.locator(".new-session-page__message").waitFor();
+      await expect.poll(() => page.locator(".sidebar-recent-session--draft").count()).toBe(0);
+      await captureUiProof(page, "draft-row-after-light.png");
+      await page.evaluate(() => document.documentElement.setAttribute("data-theme-mode", "dark"));
+      await captureUiProof(page, "draft-row-after-dark.png");
+    } finally {
+      await context.close();
+    }
+  });
+
   it("drafts a session with a browsed folder and creates it on first message", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -693,7 +693,6 @@ export const en: TranslationMap = {
   newSession: {
     title: "New session",
     hint: "Pick where this session works, then say what to do.",
-    draftRow: "New session",
     agent: "Agent",
     where: "Where",
     gateway: "Gateway · local",

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -4048,14 +4048,3 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
     opacity: 1;
   }
 }
-
-.sidebar-recent-session--draft {
-  border: 1px dashed color-mix(in srgb, var(--accent) 55%, transparent);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--accent-subtle) 60%, transparent);
-}
-
-.sidebar-recent-session--draft .sidebar-recent-session__name {
-  color: var(--text-strong);
-  font-style: italic;
-}

--- a/ui/src/test-helpers/app-sidebar-cases/session-list-sections.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-list-sections.ts
@@ -5,81 +5,10 @@ import {
   createSessions,
   createSessionsHarness,
   mountSidebar,
-  type SidebarLifecycleState,
 } from "../app-sidebar.ts";
 import "../../components/app-sidebar.ts";
 
 describe("AppSidebar session section visibility", () => {
-  it("renders an active draft first inside an expanded empty Threads section", async () => {
-    localStorage.setItem(
-      "openclaw:sidebar:sessions:collapsed-sections",
-      JSON.stringify(["ungrouped"]),
-    );
-    const gateway = createGateway({} as GatewayBrowserClient);
-    const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
-    const draftSidebar = sidebar as SidebarLifecycleState & { draftSessionAgentId: string };
-    draftSidebar.draftSessionAgentId = "main";
-    draftSidebar.requestUpdate();
-    await draftSidebar.updateComplete;
-
-    const section = draftSidebar.querySelector('[data-session-section="ungrouped"]');
-    const list = section?.querySelector(".sidebar-recent-sessions__list");
-    expect(section).not.toBeNull();
-    expect(
-      section?.querySelector(".sidebar-session-group-toggle")?.getAttribute("aria-expanded"),
-    ).toBe("true");
-    expect(list?.firstElementChild?.classList.contains("sidebar-recent-session--draft")).toBe(true);
-    const draft = list?.querySelector(".sidebar-recent-session--draft");
-    expect(list?.getAttribute("role")).toBe("list");
-    expect(draft?.parentElement).toBe(list);
-    expect(draft?.getAttribute("role")).toBe("listitem");
-    expect(draft?.textContent?.trim()).toBe("New session");
-    const draftLead = list?.querySelector(
-      ".sidebar-recent-session--draft .sidebar-session-indicator",
-    );
-    expect(draftLead).not.toBeNull();
-    expect(draftLead?.childElementCount).toBe(0);
-    expect(
-      list?.querySelectorAll(".sidebar-recent-session:not(.sidebar-recent-session--draft)"),
-    ).toHaveLength(0);
-
-    // The draft expands the section for real, so the header toggle keeps
-    // working: collapsing during a draft hides it and persists honestly.
-    section?.querySelector<HTMLButtonElement>(".sidebar-session-group-toggle")?.click();
-    await draftSidebar.updateComplete;
-    expect(
-      draftSidebar
-        .querySelector('[data-session-section="ungrouped"] .sidebar-session-group-toggle')
-        ?.getAttribute("aria-expanded"),
-    ).toBe("false");
-    expect(draftSidebar.querySelector(".sidebar-recent-session--draft")).toBeNull();
-  });
-
-  it("keeps normal pagination when a draft overrides collapsed Threads", async () => {
-    localStorage.setItem(
-      "openclaw:sidebar:sessions:collapsed-sections",
-      JSON.stringify(["ungrouped"]),
-    );
-    const gateway = createGateway({} as GatewayBrowserClient);
-    const { sidebar } = await mountSidebar(
-      gateway,
-      createSessions("main", [
-        "agent:main:main",
-        ...Array.from({ length: 12 }, (_, index) => `agent:main:thread-${index}`),
-      ]),
-    );
-    const draftSidebar = sidebar as SidebarLifecycleState & { draftSessionAgentId: string };
-    draftSidebar.draftSessionAgentId = "main";
-    draftSidebar.requestUpdate();
-    await draftSidebar.updateComplete;
-
-    const section = draftSidebar.querySelector('[data-session-section="ungrouped"]');
-    expect(
-      section?.querySelectorAll(".sidebar-recent-session:not(.sidebar-recent-session--draft)"),
-    ).toHaveLength(10);
-    expect(draftSidebar.querySelector('[aria-label="Show more"]')).not.toBeNull();
-  });
-
   it("paginates each expanded section independently", async () => {
     const threadKeys = Array.from({ length: 12 }, (_, index) => `agent:main:thread-${index}`);
     const categoryKeys = Array.from({ length: 12 }, (_, index) => `agent:main:alpha-${index}`);


### PR DESCRIPTION
Closes #122231

## What Problem This Solves

Fixes an issue where users starting a new session would see a dashed “New session” entry in the sidebar before any session existed. The entry looked recoverable but had no navigation or action.

## Why This Change Was Made

In this PR, the sidebar lists created sessions only. The unsent draft remains on the new-session composer until the first message creates a real session, while the selected agent still carries through the new-session route and collapsed navigation controls.

## User Impact

With this change, starting a new session does not add a placeholder row to the Sessions group. Existing sessions remain available in the sidebar and on the new-session page’s Recent chats surface.

## Evidence

### Light theme

| Before | After |
| --- | --- |
| ![Before: a dashed New session row appears above the created session](https://crisp-dahlia-khvs.here.now/draft-row-before-light.png) | ![After: only the created session appears in the sidebar](https://crisp-dahlia-khvs.here.now/draft-row-after-light.png) |

### Dark theme

| Before | After |
| --- | --- |
| ![Before: a dashed New session row appears above the created session in dark theme](https://crisp-dahlia-khvs.here.now/draft-row-before-dark.png) | ![After: only the created session appears in the sidebar in dark theme](https://crisp-dahlia-khvs.here.now/draft-row-after-dark.png) |

### Regression proof

- Red: the new-session browser test failed on the previous behavior with `expected 0, received 1` draft rows.
- Green on the rebased head: the same browser test passes and confirms the composer remains visible while the sidebar has no draft row.
- Focused sidebar and shell coverage: 280 tests passed.
- Control UI i18n verification passed.
- Patch-identical Testbox changed-scope gate passed: [run 31529974828](https://github.com/openclaw/openclaw/actions/runs/31529974828), lease `tbx_01kzs62xdvfra9fxr0ctdk96wp`.
