### PR TITLE
test(cli): trim duplicate MCP probe process cases

### DIFF
--- a/src/cli/mcp-cli.probe-exit.process.test.ts
+++ b/src/cli/mcp-cli.probe-exit.process.test.ts
@@ -16,52 +16,6 @@ async function writeConfig(home: string, servers: Record<string, unknown>): Prom
   return configPath;
 }
 
-async function writeProbeServer(filePath: string): Promise<void> {
-  await fs.writeFile(
-    filePath,
-    `let buffer = "";
-function send(message) {
-  process.stdout.write(JSON.stringify(message) + "\\n");
-}
-function handle(message) {
-  if (message.method === "initialize") {
-    send({
-      jsonrpc: "2.0",
-      id: message.id,
-      result: {
-        protocolVersion: message.params?.protocolVersion ?? "2025-03-26",
-        capabilities: { tools: {} },
-        serverInfo: { name: "probe-process-test", version: "1.0.0" },
-      },
-    });
-    return;
-  }
-  if (message.method === "tools/list") {
-    send({
-      jsonrpc: "2.0",
-      id: message.id,
-      result: { tools: [{ name: "ping", inputSchema: { type: "object" } }] },
-    });
-  }
-}
-process.stdin.setEncoding("utf8");
-process.stdin.on("data", (chunk) => {
-  buffer += chunk;
-  while (true) {
-    const newline = buffer.indexOf("\\n");
-    if (newline < 0) return;
-    const line = buffer.slice(0, newline).replace(/\\r$/, "");
-    buffer = buffer.slice(newline + 1);
-    if (line.trim()) handle(JSON.parse(line));
-  }
-});
-process.stdin.on("end", () => process.exit(0));
-process.on("SIGTERM", () => process.exit(0));
-`,
-    "utf8",
-  );
-}
-
 function runProbe(home: string, args: string[]) {
   const env: NodeJS.ProcessEnv = {
     ...process.env,
@@ -117,53 +71,5 @@ describe("mcp probe process exit", () => {
     expect(output.servers).toEqual({});
     expect(output.diagnostics).toEqual([expect.objectContaining({ serverName: "broken" })]);
     expect(result.stderr).toContain(`MCP probe failed for "broken" in ${configPath}:`);
-  });
-
-  it("preserves mixed partial text output before exiting nonzero", async () => {
-    const home = await createTempHome();
-    const serverPath = path.join(home, "probe-server.mjs");
-    await writeProbeServer(serverPath);
-    await writeConfig(home, {
-      healthy: { command: process.execPath, args: [serverPath] },
-      broken: { command: path.join(home, "missing-mcp-server") },
-    });
-
-    const result = runProbe(home, ["mcp", "probe"]);
-
-    expect(result.error).toBeUndefined();
-    expect(result.status).toBe(1);
-    expect(result.stdout).toContain("- healthy: 1 tools");
-    expect(result.stdout).toContain("! broken:");
-  });
-
-  it("fails when an enabled server is omitted without a diagnostic", async () => {
-    const home = await createTempHome();
-    await writeConfig(home, { incomplete: {} });
-
-    const result = runProbe(home, ["mcp", "probe", "incomplete", "--json"]);
-
-    expect(result.error).toBeUndefined();
-    expect(result.status).toBe(1);
-    expect(JSON.parse(result.stdout)).toMatchObject({ servers: {}, diagnostics: [] });
-    expect(result.stderr).toContain('MCP probe did not connect to "incomplete"');
-  });
-
-  it("keeps healthy output successful and ignores disabled entries", async () => {
-    const home = await createTempHome();
-    const serverPath = path.join(home, "probe-server.mjs");
-    await writeProbeServer(serverPath);
-    await writeConfig(home, {
-      healthy: { command: process.execPath, args: [serverPath] },
-      disabled: { enabled: false },
-    });
-
-    const result = runProbe(home, ["mcp", "probe", "--json"]);
-
-    expect(result.error).toBeUndefined();
-    expect(result.status).toBe(0);
-    expect(JSON.parse(result.stdout)).toMatchObject({
-      diagnostics: [],
-      servers: { healthy: { tools: 1 } },
-    });
   });
 });

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -19,6 +19,7 @@ import {
   serveOpenClawChannelMcp,
 } from "./mcp-cli.test-harness.js";
 import { writeProbeMcpServer } from "./mcp-cli.test-support.js";
+import { runCliWithExitFinalization } from "./one-shot-exit.js";
 
 describe("mcp cli", () => {
   beforeEach(() => {
@@ -766,6 +767,84 @@ describe("mcp cli", () => {
       expect(lastErrorLine()).toBe(
         `MCP server "docs" is disabled in ${configPath}. Run openclaw mcp configure docs --enable before probing it.`,
       );
+    });
+  });
+
+  it("reports omitted enabled servers while accepting omitted disabled servers", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async (home) => {
+      const workspaceDir = await createWorkspace();
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      let catalogServers: Record<
+        string,
+        { serverName: string; launchSummary: string; toolCount: number }
+      > = {};
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        `${JSON.stringify({ mcp: { servers: { incomplete: { command: "node" } } } })}\n`,
+        "utf8",
+      );
+      setCreateSessionMcpRuntimeOverride((params) => ({
+        sessionId: params.sessionId,
+        workspaceDir: params.workspaceDir,
+        configFingerprint: "cli-probe-test",
+        createdAt: 0,
+        lastUsedAt: 0,
+        getCatalog: async () => ({
+          version: 1,
+          generatedAt: Date.now(),
+          servers: catalogServers,
+          tools: [],
+          diagnostics: [],
+        }),
+        peekCatalog: () => null,
+        markUsed: () => {},
+        callTool: async () => ({ content: [] }),
+        dispose: async () => {},
+      }));
+
+      mockError.mockClear();
+      await runCliWithExitFinalization({
+        run: () => runMcpCommand(["mcp", "probe", "--json"]),
+        onError: (error) => {
+          throw error;
+        },
+      });
+
+      expect(JSON.parse(lastLogLine())).toMatchObject({ servers: {}, diagnostics: [] });
+      expect(lastErrorLine()).toBe(`MCP probe did not connect to "incomplete" in ${configPath}.`);
+
+      await fs.writeFile(
+        configPath,
+        `${JSON.stringify({
+          mcp: {
+            servers: {
+              healthy: { command: "node" },
+              disabled: { enabled: false },
+            },
+          },
+        })}\n`,
+        "utf8",
+      );
+      catalogServers = {
+        healthy: { serverName: "healthy", launchSummary: "node", toolCount: 1 },
+      };
+      mockError.mockClear();
+      mockLog.mockClear();
+
+      await runCliWithExitFinalization({
+        run: () => runMcpCommand(["mcp", "probe", "--json"]),
+        onError: (error) => {
+          throw error;
+        },
+      });
+
+      expect(JSON.parse(lastLogLine())).toMatchObject({
+        servers: { healthy: { tools: 1 } },
+        diagnostics: [],
+      });
+      expect(lastErrorLine()).toBe("");
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

The MCP probe exit suite launched four serial Node + TSX CLI processes. Three replayed probe-result semantics or generic output-drain behavior already owned by cheaper MCP runtime, CLI, and one-shot-exit tests. The focused process file spent 17.14s in test bodies and 24.24s wrapper wall time locally.

## Why This Change Was Made

Retain the strongest real-process representative: a failed MCP spawn must still print parseable named JSON diagnostics and stderr before exiting 1 through the real Commander + one-shot-finalizer boundary.

Move the only distinct omitted-server rule into the MCP CLI owner suite. The owner test now proves both sides of the rule without spawning another CLI: an omitted enabled server is reported, while an omitted disabled server remains non-fatal when a healthy server is returned. Existing runtime tests retain mixed healthy/broken connection behavior, and one-shot-exit owner tests retain large piped-output draining.

## User Impact

No runtime behavior changes. Developers and CI run three fewer full CLI processes while preserving the actual process-exit contract and all unique probe acceptance semantics.

## Evidence

- Hosted exact-ref target-file time: 17.668s → 5.110s (**71.1% faster**), comparing baseline `a432e2a58653de0304063901fb18b445983dfef4` with head `2f084c640e12d58fe8e948e5d28126f4375dd558` in the same `checks-node-agentic-cli` workflow.
- Hosted baseline: [run 31535945397](https://github.com/openclaw/openclaw/actions/runs/31535945397), job 93927241941.
- Hosted head: [run 31535947552](https://github.com/openclaw/openclaw/actions/runs/31535947552), job 93927189629.
- Local focused process test bodies: 17.14s → 3.97s (**76.8% faster**).
- Local focused Vitest duration: 17.95s → 4.74s (**73.6% faster**).
- Local wrapper wall time: 24.24s → 11.22s (**53.7% faster**).
- Retained real-process test: 1/1 passed.
- MCP CLI, process, and one-shot owner suites: 49/49 passed.
- New omitted-enabled/disabled owner contract: 1/1 passed.
- `oxfmt --check`, `git diff --check`, and changed-gate classification passed.
- Independent exact-diff review: approve, no blockers after adding cheap healthy/disabled owner coverage.
- Bundled autoreview exact-diff secret scan passed; its configured Codex executable is unavailable in this orb, so the model phase could not run.
