### PR TITLE
fix(gateway): project canonical ACP model identity and lock model selection in session rows

### DIFF
--- a/src/gateway/session-utils-model.ts
+++ b/src/gateway/session-utils-model.ts
@@ -39,6 +39,7 @@ import {
   resolveSupportedThinkingLevel,
 } from "../auto-reply/thinking.js";
 import { resolveAgentMainSessionKey, type SessionEntry } from "../config/sessions.js";
+import type { SessionAcpMeta } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import type { GatewayModelCatalogSnapshot } from "./server-model-catalog.types.js";
@@ -172,6 +173,13 @@ type GatewaySessionThinkingProjectionParams = {
   entry?: SessionEntry;
   modelCatalog?: ModelCatalogEntry[];
   rowContext?: SessionListRowContext;
+  /**
+   * Pre-resolved persisted ACP runtime metadata for this session. When
+   * provided, the projection skips its own store/DB lookup; callers that
+   * already resolved the metadata (e.g. row builders that also project the
+   * ACP model overlay) avoid reading the same row twice.
+   */
+  acpMeta?: SessionAcpMeta;
 };
 
 export function resolveGatewaySessionThinkingProjectionInternal(
@@ -179,10 +187,12 @@ export function resolveGatewaySessionThinkingProjectionInternal(
 ) {
   const cachedAcpMeta = params.rowContext?.acpSessionMetaByEntry;
   const acpMeta =
-    params.entry?.acp ??
-    (params.entry && cachedAcpMeta?.has(params.entry)
-      ? cachedAcpMeta.get(params.entry)
-      : readAcpSessionMeta({ sessionKey: params.sessionKey }));
+    params.acpMeta !== undefined
+      ? params.acpMeta
+      : (params.entry?.acp ??
+        (params.entry && cachedAcpMeta?.has(params.entry)
+          ? cachedAcpMeta.get(params.entry)
+          : readAcpSessionMeta({ sessionKey: params.sessionKey })));
   const configuredAgentRuntime = resolveModelAgentRuntimeMetadata({
     cfg: params.cfg,
     agentId: params.agentId,

--- a/src/gateway/session-utils-row.ts
+++ b/src/gateway/session-utils-row.ts
@@ -1,5 +1,6 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { SessionCreatedActor } from "../../packages/gateway-protocol/src/index.js";
+import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveContextTokensForModel } from "../agents/context.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
@@ -29,6 +30,7 @@ import { projectPluginSessionExtensionsSync } from "../plugins/host-hook-state.j
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { classifySessionKind } from "../sessions/classify-session-kind.js";
 import { resolveActiveSessionAgentStatus } from "../sessions/session-agent-status.js";
+import { isAcpSessionKey } from "../sessions/session-key-utils.js";
 import { resolveNonNegativeNumber } from "../shared/number-coercion.js";
 import { projectSessionDeliveryFields } from "../utils/delivery-context.shared.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel-constants.js";
@@ -325,6 +327,16 @@ export function buildGatewaySessionRow(params: {
     agentId: sessionAgentId,
     sessionKey: key,
   });
+  // Persisted ACP runtime metadata gates both the ACP model overlay below and
+  // the thinking projection's runtime classification. Key shape alone is not
+  // sufficient: ACP bridge sessions (translator.ts) use ACP-shaped keys without
+  // ever writing `SessionAcpMeta` and still run the configured model.
+  const acpMeta =
+    entry?.acp ??
+    (entry && rowContext?.acpSessionMetaByEntry?.has(entry)
+      ? rowContext.acpSessionMetaByEntry.get(entry)
+      : readAcpSessionMeta({ sessionKey: acpSessionKey }));
+  const acpRuntime = acpMeta != null && isAcpSessionKey(key);
   const estimatedCostUsd = lightweight
     ? resolveNonNegativeNumber(entry?.estimatedCostUsd)
     : (resolveEstimatedSessionCostUsd({
@@ -382,6 +394,7 @@ export function buildGatewaySessionRow(params: {
     model: thinkingModel,
     sessionKey: acpSessionKey,
     entry,
+    acpMeta,
     modelCatalog: params.modelCatalog,
     rowContext,
   });
@@ -503,9 +516,14 @@ export function buildGatewaySessionRow(params: {
       channel: INTERNAL_MESSAGE_CHANNEL,
       sessionEntry: entry,
     }).mode,
-    modelProvider: rowModelProvider,
-    model: rowModel,
-    modelSelectionLocked: entry?.modelSelectionLocked,
+    // ACP runtime sessions are answered by the external harness, not the
+    // agent's configured model: report the canonical ACP display identity
+    // (mirroring `sessions list`'s sentinel overlay) and lock model selection
+    // so the composer footer cannot present or mutate an inapplicable model.
+    modelProvider: acpRuntime ? "acpx" : rowModelProvider,
+    model: acpRuntime ? `${sessionAgentId}-acp` : rowModel,
+    modelSelectionLocked:
+      entry?.modelSelectionLocked === true || acpRuntime ? true : entry?.modelSelectionLocked,
     agentRuntime: thinkingProjection.agentRuntime,
     contextTokens,
     contextBudgetStatus: entry?.contextBudgetStatus,

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -334,6 +334,81 @@ describe("gateway session utils", () => {
     expect(buildGatewaySessionEventFields({ sessionRow: row }).observerDigest).toBeNull();
   });
 
+  describe("ACP runtime session row projection", () => {
+    const ACP_KEY = "agent:cursor:acp:22222222-2222-4222-8222-222222222222";
+
+    test("overlays the canonical ACP display identity and locks model selection when persisted ACP metadata exists", () => {
+      const row = buildGatewaySessionRow({
+        cfg: createModelDefaultsConfig({ primary: "openai/gpt-5.4" }),
+        storePath: "",
+        store: {},
+        key: ACP_KEY,
+        entry: {
+          sessionId: "sess-acp",
+          updatedAt: 1,
+          modelProvider: "openrouter",
+          model: "z-ai/glm-5.2",
+          acp: {
+            backend: "acpx",
+            agent: "cursor",
+            runtimeSessionName: ACP_KEY,
+            mode: "oneshot",
+            state: "idle",
+            lastActivityAt: 1,
+          },
+        } as SessionEntry,
+      });
+
+      // The external harness answers in this session, so the row must report
+      // the canonical ACP identity (matching `sessions list`) instead of the
+      // owning agent's configured model, and lock the model selector.
+      expect(row.model).toBe("cursor-acp");
+      expect(row.modelProvider).toBe("acpx");
+      expect(row.modelSelectionLocked).toBe(true);
+      expect(row.agentRuntime?.id).toBe("acpx");
+    });
+
+    test("keeps the configured model for ACP-shaped bridge keys without persisted ACP metadata", () => {
+      const row = buildGatewaySessionRow({
+        cfg: createModelDefaultsConfig({ primary: "openai/gpt-5.4" }),
+        storePath: "",
+        store: {},
+        key: "agent:cursor:acp:configured-bridge-without-meta",
+        entry: {
+          sessionId: "sess-bridge",
+          updatedAt: 1,
+          modelProvider: "openrouter",
+          model: "z-ai/glm-5.2",
+        } as SessionEntry,
+      });
+
+      // ACP bridge sessions run the configured model; key shape alone must not
+      // trigger the sentinel overlay.
+      expect(row.model).toBe("z-ai/glm-5.2");
+      expect(row.modelProvider).toBe("openrouter");
+      expect(row.modelSelectionLocked).toBeUndefined();
+    });
+
+    test("leaves non-ACP sessions untouched", () => {
+      const row = buildGatewaySessionRow({
+        cfg: createModelDefaultsConfig({ primary: "openai/gpt-5.4" }),
+        storePath: "",
+        store: {},
+        key: "agent:main:main",
+        entry: {
+          sessionId: "sess-main",
+          updatedAt: 1,
+          modelProvider: "openai",
+          model: "gpt-5.4",
+        } as SessionEntry,
+      });
+
+      expect(row.model).toBe("gpt-5.4");
+      expect(row.modelProvider).toBe("openai");
+      expect(row.modelSelectionLocked).toBeUndefined();
+    });
+  });
+
   test("session lists apply a bounded default and expose truncation metadata", async () => {
     const cfg = createModelDefaultsConfig({ primary: "openai/gpt-5.4" });
     const store = Object.fromEntries(

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -891,6 +891,64 @@ describe("gateway sessions patch", () => {
     expect(store[MAIN_SESSION_KEY]).toEqual(before);
   });
 
+  test("rejects model patches for persisted-ACP sessions without the durable lock field", async () => {
+    const acpKey = "agent:main:acp:child";
+    const acpEntry = {
+      sessionId: "sess-acp-locked",
+      updatedAt: 1,
+      providerOverride: "openai",
+      modelOverride: OPENAI_GPT_ID,
+      acp: {
+        backend: "cursor",
+        agent: "main",
+        runtimeSessionName: acpKey,
+        mode: "persistent",
+        state: "idle",
+        lastActivityAt: 1,
+      },
+    } satisfies SessionEntry;
+    const store = { [acpKey]: acpEntry };
+    const before = { ...acpEntry };
+    const loadGatewayModelCatalog = vi.fn(loadCatalog(ANTHROPIC_SONNET_MODEL));
+
+    const result = await runPatch({
+      store,
+      storeKey: acpKey,
+      cfg: createAllowlistedAnthropicModelCfg(),
+      patch: { key: acpKey, model: ANTHROPIC_SONNET_MODEL },
+      loadGatewayModelCatalog,
+    });
+
+    expectPatchError(result, MODEL_SELECTION_LOCKED_MESSAGE);
+    expect(loadGatewayModelCatalog).not.toHaveBeenCalled();
+    expect(store[acpKey]).toEqual(before);
+  });
+
+  test("allows model patches for ACP-shaped keys without persisted ACP metadata", async () => {
+    acpSessionMetaMocks.readAcpSessionMetaForEntry.mockReturnValue(undefined);
+    const acpKey = "agent:main:acp:child";
+    const store = {
+      [acpKey]: {
+        sessionId: "sess-acp-bridge",
+        updatedAt: 1,
+        providerOverride: "openai",
+        modelOverride: OPENAI_GPT_ID,
+      } satisfies SessionEntry,
+    };
+
+    const result = await runPatch({
+      store,
+      storeKey: acpKey,
+      cfg: createAllowlistedAnthropicModelCfg(),
+      patch: { key: acpKey, model: ANTHROPIC_SONNET_MODEL },
+      loadGatewayModelCatalog: loadCatalog(OPENAI_GPT_MODEL, ANTHROPIC_SONNET_MODEL),
+      providerAuthMetadataSnapshot: EMPTY_PROVIDER_AUTH_METADATA_SNAPSHOT,
+    });
+
+    const entry = expectPatchOk(result);
+    expectModelSelection(entry, "anthropic", ANTHROPIC_SONNET_ID);
+  });
+
   test("allows non-model metadata patches for model-locked sessions", async () => {
     const entry = expectPatchOk(
       await runPatch({

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -65,6 +65,7 @@ import {
   sessionAgentStatusExpiresAt,
   SESSION_AGENT_STATUS_MAX_TTL_MINUTES,
 } from "../sessions/session-agent-status.js";
+import { isAcpSessionKey } from "../sessions/session-key-utils.js";
 import { parseSessionLabel, SESSION_LABEL_MAX_LENGTH } from "../sessions/session-label.js";
 import {
   isAgentSessionModelPatchOrigin,
@@ -180,8 +181,20 @@ export async function projectSessionsPatchEntry(params: {
   if (harnessSessionError) {
     return invalid(harnessSessionError);
   }
-  if ("model" in patch && isModelSelectionLocked(params.existingEntry)) {
-    return invalid(MODEL_SELECTION_LOCKED_MESSAGE);
+  if ("model" in patch) {
+    // The row projection can lock model selection for persisted-ACP sessions
+    // without writing the durable modelSelectionLocked field (ACP metadata is
+    // persisted separately). Apply the same metadata-and-key gate here so a
+    // direct Gateway model patch cannot mutate a session the UI reports as
+    // locked: reject when the durable lock is set OR the session has
+    // persisted ACP metadata on an ACP-shaped key.
+    const acpMeta =
+      params.existingEntry?.acp ??
+      readAcpSessionMetaForEntry({ sessionKey: storeKey, entry: params.existingEntry });
+    const acpRuntime = acpMeta != null && isAcpSessionKey(storeKey);
+    if (isModelSelectionLocked(params.existingEntry) || acpRuntime) {
+      return invalid(MODEL_SELECTION_LOCKED_MESSAGE);
+    }
   }
   const now = Date.now();
   const parsedAgent = parseAgentSessionKey(storeKey);


### PR DESCRIPTION
[AI-assisted]

Fixes #121993

## What Problem This Solves

Sessions driven by an external ACP harness (e.g. `/acp spawn cursor` with the `acpx` backend) showed the owning agent's configured model in the Control UI composer footer, even though the external harness answers in that session. The same session key is reported by `openclaw sessions list` as model `cursor-acp` / runtime `acpx`, so the two surfaces disagreed, and the footer presented an inapplicable model dropdown for a responder that is external.

## Why This Change Was Made

The gateway session-row projection (`buildGatewaySessionRow`) always reported the agent's configured model/provider, while the CLI already applies a metadata-gated ACP sentinel overlay: only when the session key is ACP-shaped AND persisted `SessionAcpMeta` exists does it emit `{ provider: "acpx", model: "<agentId>-acp" }`. Key shape alone is insufficient because ACP bridge sessions (translator.ts) use ACP-shaped keys without ever writing `SessionAcpMeta` and still run the configured model.

The gateway row builder now resolves the same persisted ACP metadata (entry `acp` field, the row-context batch cache, or a store read) and:

- overlays the canonical ACP display identity on `model` / `modelProvider` (`<agent>-acp` / `acpx`), mirroring the CLI listing;
- projects `modelSelectionLocked: true` so the Control UI locks the model selector for externally-answered sessions (the composer already renders the locked-session state);
- passes the pre-resolved metadata into the thinking projection to avoid a duplicate store/DB read per row.

Non-ACP sessions and ACP-shaped bridge sessions without metadata are untouched.

## User Impact

Control UI operators can no longer misattribute answers to the embedded agent or switch a model that the external harness owns. The composer footer now identifies the ACP responder and locks the selector, matching the CLI listing instead of contradicting it.

## Evidence

Focused regression tests (3 new): ACP session with persisted metadata overlays `cursor-acp`/`acpx` and locks selection; ACP-shaped bridge key without metadata keeps the configured model; non-ACP sessions unchanged:

```text
✓ gateway-client  ../../src/gateway/session-utils.test.ts (162 tests | 159 skipped)
   ✓ overlays the canonical ACP display identity and locks model selection when persisted ACP metadata exists
   ✓ keeps the configured model for ACP-shaped bridge keys without persisted ACP metadata
   ✓ leaves non-ACP sessions untouched

 Test Files  3 passed (3)
      Tests  9 passed | 477 skipped (486)
```

Full-file and related-suite regression run (session-utils, sessions-resolve, session-utils.search, stuck-session recovery runtime):

```text
 Test Files  3 failed | 7 passed (10)
      Tests  3 failed | 624 passed (627)
```

The 3 failures are the pre-existing `listAgentsForGateway reports whether each workspace is a git checkout` environmental test (git-checkout detection in this sandbox). Reproduced identically on clean `main` with this change stashed:

```text
# clean main, changes stashed
 Test Files  3 failed (3)
      Tests  3 failed | 474 skipped (477)
```

oxlint on the touched files: `Found 0 warnings and 0 errors.` (212 rules).

Production LOC: +35/-7 (net +28, projection-only: `session-utils-row.ts` +21/-3, `session-utils-model.ts` +14/-4); tests +75.


## ClawSweeper P1 repair (head `0e853045969`)

P1 "Enforce the ACP model lock at the patch boundary" fixed: `projectSessionsPatchEntry` now applies the same metadata-and-key gate the row projection uses before any model mutation - it rejects `sessions.patch { model }` when the durable lock is set OR the existing entry carries persisted ACP metadata on an ACP-shaped key (inline `entry.acp`, then the ACP session store). A direct Gateway client can no longer persist a model override for a session the Control UI reports as locked.

Regressions added: a persisted-ACP session without the durable `modelSelectionLocked` field rejects model patches before catalog loading; an ACP-shaped bridge key without persisted metadata stays patchable.

```text
node scripts/run-vitest.mjs src/gateway/sessions-patch.test.ts
 Test Files  1 passed (1)
      Tests  82 passed (82)

node scripts/run-vitest.mjs src/gateway/session-utils.test.ts
 Test Files  1 failed (1)
      Tests  161 passed | 1 failed (162)
# the 1 failure is the pre-existing listAgentsForGateway git-checkout env test, reproduced on clean main

oxlint: 0 warnings, 0 errors (212 rules)
```
