### PR TITLE
fix(recovery): reclaim proven-stale reply-only ownership with zero queued backlog

### DIFF
--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -487,6 +487,39 @@ describe("stuck session recovery", () => {
     ]);
   });
 
+  it.each(["preflight_compacting", "memory_flushing"])(
+    "keeps zero-backlog maintenance phase %s out of the stale reclaim path",
+    async (phase) => {
+      mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("maintenance-reply-session");
+      mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+      mocks.isEmbeddedAgentRunActive.mockReturnValue(true);
+      mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
+      mocks.resolveEmbeddedAgentReplyRunPhase.mockReturnValue(phase);
+      mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({
+        lastProgressAgeMs: 720_000,
+      });
+
+      const outcome = await recoverStuckDiagnosticSession({
+        sessionId: "maintenance-reply-session",
+        sessionKey: "agent:main:main",
+        ageMs: 720_000,
+        queueDepth: 0,
+      });
+
+      // Preflight compaction and memory flush are recognized maintenance
+      // phases that may legitimately outlive the stale threshold (they honor a
+      // configured compaction timeout). The zero-backlog exemption must not
+      // turn a running maintenance operation into a reclaim target.
+      expect(outcome).toMatchObject({
+        status: "skipped",
+        action: "keep_lane",
+        reason: "active_reply_work",
+        activeSessionId: "maintenance-reply-session",
+      });
+      expect(mocks.abortEmbeddedAgentRun).not.toHaveBeenCalled();
+    },
+  );
+
   it("keeps reply-only ownership with recent progress even with zero queued backlog", async () => {
     mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("live-reply-session");
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -452,6 +452,88 @@ describe("stuck session recovery", () => {
     expect(mocks.resetCommandLane).not.toHaveBeenCalled();
   });
 
+  it("reclaims proven-stale reply-only ownership even with zero queued backlog", async () => {
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("phantom-reply-session");
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedAgentRunActive.mockReturnValue(true);
+    mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
+    mocks.abortEmbeddedAgentRun.mockReturnValue(true);
+    mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "phantom-reply-session",
+      sessionKey: "agent:main:main",
+      ageMs: 720_000,
+      queueDepth: 0,
+    });
+
+    // Stale reply-only ownership must expire through the abort-and-drain owner
+    // path even when the queued backlog is empty; previously the zero-depth
+    // gate kept the lane forever (reason=active_reply_work).
+    expect(mocks.abortEmbeddedAgentRun).toHaveBeenCalledWith("phantom-reply-session");
+    expect(mocks.waitForEmbeddedAgentRunEnd).toHaveBeenCalledWith("phantom-reply-session", 15_000);
+    expect(outcome).toMatchObject({
+      status: "aborted",
+      action: "abort_embedded_run",
+      activeSessionId: "phantom-reply-session",
+      activeWorkKind: "embedded_run",
+      aborted: true,
+      drained: true,
+    });
+    expect(warnLogMessages()).toEqual([
+      "stuck session recovery reclaiming stale active reply work: sessionId=phantom-reply-session sessionKey=agent:main:main age=720s queueDepth=0 activeSessionId=phantom-reply-session",
+      "stuck session recovery: sessionId=phantom-reply-session sessionKey=agent:main:main age=720s action=abort_embedded_run aborted=true drained=true released=0",
+      "stuck session recovery outcome: status=aborted action=abort_embedded_run sessionId=phantom-reply-session sessionKey=agent:main:main activeSessionId=phantom-reply-session activeWorkKind=embedded_run lane=session:agent:main:main aborted=true drained=true forceCleared=false released=0",
+    ]);
+  });
+
+  it("keeps reply-only ownership with recent progress even with zero queued backlog", async () => {
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("live-reply-session");
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedAgentRunActive.mockReturnValue(true);
+    mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
+    mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({ lastProgressAgeMs: 1_000 });
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "live-reply-session",
+      sessionKey: "agent:main:main",
+      ageMs: 720_000,
+      queueDepth: 0,
+    });
+
+    // Recent progress means the reply is genuinely active; the zero-depth
+    // exemption must not turn live work into a reclaim target.
+    expect(outcome).toMatchObject({
+      status: "skipped",
+      action: "keep_lane",
+      reason: "active_reply_work",
+      activeSessionId: "live-reply-session",
+    });
+    expect(mocks.abortEmbeddedAgentRun).not.toHaveBeenCalled();
+  });
+
+  it("keeps the queue gate for active run handles with zero queued backlog", async () => {
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue("session-1");
+    mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(true);
+    mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({ lastProgressAgeMs: 720_000 });
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      ageMs: 720_000,
+      queueDepth: 0,
+    });
+
+    // Run-handle recovery keeps the queue gate: without a queued backlog the
+    // active run is presumed to be processing and must not be aborted.
+    expect(outcome).toMatchObject({
+      status: "skipped",
+      action: "observe_only",
+      reason: "active_embedded_run",
+    });
+    expect(mocks.abortEmbeddedAgentRun).not.toHaveBeenCalled();
+  });
+
   it("releases the session lane when abort+drain succeeds but queued messages remain (ghost run + queued messages)", async () => {
     mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("ghost-run-session");
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -260,8 +260,15 @@ export async function recoverStuckDiagnosticSession(
           // Reply-only ownership must expire when proven stale even with zero
           // queued backlog; the queue gate exists to protect run handles that
           // are actively draining queued turns, and there is no such backlog
-          // here to protect.
-          requireQueueBacklog: false,
+          // here to protect. Recognized maintenance phases are the exception:
+          // preflight compaction and memory flush are explicitly allowed to
+          // run longer than the stale threshold (they honor a configured
+          // compaction timeout), so they keep the queue-backlog guard and are
+          // never force-cleared early by this reclaim path.
+          requireQueueBacklog:
+            activeReplyPhase === "preflight_compacting" || activeReplyPhase === "memory_flushing"
+              ? undefined
+              : false,
         });
       if (params.allowActiveAbort === true || reclaimStaleReplyWork) {
         if (reclaimStaleReplyWork) {

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -62,8 +62,15 @@ function isActiveRunProgressStale(params: {
   sessionKey?: string;
   queueDepth?: number;
   staleAbortMs: number;
+  /**
+   * When false, staleness is evaluated even with a zero queued backlog.
+   * Run-handle recovery keeps the gate so an unqueued active run is not
+   * disturbed; reply-only ownership has no backlog to protect and must
+   * still expire when proven stale (phantom active reply work).
+   */
+  requireQueueBacklog?: boolean;
 }): boolean {
-  if ((params.queueDepth ?? 0) <= 0) {
+  if ((params.queueDepth ?? 0) <= 0 && params.requireQueueBacklog !== false) {
     return false;
   }
   const activity = getDiagnosticSessionActivitySnapshot({
@@ -250,6 +257,11 @@ export async function recoverStuckDiagnosticSession(
           sessionKey: params.sessionKey,
           queueDepth: params.queueDepth,
           staleAbortMs: staleActiveProgressAbortMs,
+          // Reply-only ownership must expire when proven stale even with zero
+          // queued backlog; the queue gate exists to protect run handles that
+          // are actively draining queued turns, and there is no such backlog
+          // here to protect.
+          requireQueueBacklog: false,
         });
       if (params.allowActiveAbort === true || reclaimStaleReplyWork) {
         if (reclaimStaleReplyWork) {


### PR DESCRIPTION
[AI-assisted]

Fixes #122227

## What Problem This Solves

A normal Telegram DM could be durably admitted but never reach `session.started`, model execution, or tool execution. Stuck-session diagnostics kept reporting `state=processing`, `queueDepth=0`, `activeWorkKind=embedded_run`, `reason=active_reply_work` and repeatedly chose `action=keep_lane` — even after the durable session became `killed` with `abortedLastRun=true`. The phantom reply ownership blocked the session indefinitely: later messages hit the five-minute ingress adoption timeout or failed with `restart recovery claim changed before agent adoption`.

## Why This Change Was Made

`isActiveRunProgressStale` short-circuits to `false` whenever `queueDepth <= 0`. That gate protects run-handle paths (an unqueued active run is presumed to be processing), but the reply-only branch — active reply work with no run handle (`!activeSessionId && activeWorkSessionId && isEmbeddedAgentRunActive(...)`) — has no queued backlog to protect, so its staleness was never evaluated and phantom reply ownership could never expire.

The reply-only branch now evaluates staleness with `requireQueueBacklog: false`: proven-stale reply work (no progress for the stale window, or orphan state older than the floor) is reclaimed through the existing `abortAndDrainEmbeddedAgentRun` owner path, exactly like the queued case. The `waiting_for_global_lane` and `waiting_for_deferred_maintenance` exemptions are checked before this branch and remain untouched, and reply work with recent progress is still kept.

## User Impact

Sessions whose only remaining claim is stale reply ownership are unblocked: the phantom lane is released through the abort-and-drain owner, later messages become processable again, and durable session state (`killed`) agrees with runtime activity instead of contradicting it every 30 seconds.

## Evidence

New regressions (3): stale reply-only ownership at `queueDepth: 0` is reclaimed (previously `keep_lane` forever); reply-only ownership with recent progress at `queueDepth: 0` is kept; run-handle paths keep the queue gate:

```text
 ✓  logging  ../../src/logging/diagnostic-stuck-session-recovery.runtime.test.ts (27 tests) 555ms
     ✓ reclaims proven-stale reply-only ownership even with zero queued backlog
     ✓ keeps reply-only ownership with recent progress even with zero queued backlog
     ✓ keeps the queue gate for active run handles with zero queued backlog

 Test Files  1 passed (1)
      Tests  27 passed (27)
```

Integration suite for the same module:

```text
 ✓  logging  ../../src/logging/diagnostic-stuck-session-recovery.integration.test.ts (9 tests) 620ms
     ✓ recovers repeated paid-call-shaped activity once without duplicate queued delivery

 Test Files  1 passed (1)
      Tests  9 passed (9)
```

oxlint on the touched files: `Found 0 warnings and 0 errors.` (212 rules).

Production LOC: +13/-1 (net +12, single recovery predicate option in `diagnostic-stuck-session-recovery.runtime.ts`); tests +82.


## ClawSweeper P1 repair (head `561fba14c8c`)

P1 "Preserve configured compaction timeouts" fixed: the zero-backlog reclaim path (`requireQueueBacklog: false`) no longer applies to the recognized maintenance phases `preflight_compacting` and `memory_flushing`. Those phases keep the queue-backlog guard, so an unqueued long-running compaction or memory flush honoring a configured timeout is never force-cleared early by this reclaim path; ordinary reply-only ownership keeps the zero-backlog expiry.

Regressions added for both maintenance phases (stale + zero queue depth - `keep_lane` / `active_reply_work`, no abort).

```text
node scripts/run-vitest.mjs src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
 Test Files  1 passed (1)
      Tests  29 passed (29)

oxlint: 0 warnings, 0 errors (212 rules)
```
