### PR TITLE
fix(media): make transcode pool saturation test deterministic

### DIFF
--- a/src/media/playback-transcode.test-support.ts
+++ b/src/media/playback-transcode.test-support.ts
@@ -11,6 +11,7 @@ type PlaybackPolicyEntry = {
 type PlaybackTranscodeTestApi = {
   PLAYBACK_TRANSCODE_POLICY: Record<PlaybackMediaKind, PlaybackPolicyEntry>;
   resolvePlaybackMode(mimeType: string, policy: PlaybackPolicyEntry): PlaybackMode | undefined;
+  getPlaybackTranscodeJobs(): Promise<void>[];
 };
 
 function getTestApi(): PlaybackTranscodeTestApi {
@@ -33,4 +34,13 @@ export function resolvePlaybackModeForTest(
 ): PlaybackMode | undefined {
   const api = getTestApi();
   return api.resolvePlaybackMode(mimeType, api.PLAYBACK_TRANSCODE_POLICY[kind]);
+}
+
+export async function waitForPlaybackTranscodeJobsForTest(mode: "next" | "all"): Promise<number> {
+  const jobs = getTestApi().getPlaybackTranscodeJobs();
+  if (jobs.length === 0) {
+    throw new Error("No active playback transcode jobs");
+  }
+  await (mode === "next" ? Promise.race(jobs) : Promise.all(jobs));
+  return jobs.length;
 }

--- a/src/media/playback-transcode.test.ts
+++ b/src/media/playback-transcode.test.ts
@@ -1,10 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
 import {
   getPlaybackTranscodePolicyForTest,
   resolvePlaybackModeForTest,
+  waitForPlaybackTranscodeJobsForTest,
 } from "./playback-transcode.test-support.js";
 
 const { probePlaybackMediaFileDescriptor, runFfmpeg } = vi.hoisted(() => ({
@@ -764,9 +766,11 @@ describe("resolvePlaybackTranscode", () => {
       createSource("pool-third.mkv"),
     ]);
     const finishers: Array<() => Promise<void>> = [];
+    const starts = [createDeferred(), createDeferred(), createDeferred()];
     runFfmpeg.mockImplementation(
       async (args: string[]) =>
         await new Promise<string>((resolve) => {
+          starts[finishers.length]?.resolve();
           finishers.push(async () => {
             await fs.writeFile(args.at(-1) ?? "", "normalized-video");
             resolve("");
@@ -786,29 +790,31 @@ describe("resolvePlaybackTranscode", () => {
     await expect(playback.resolvePlaybackTranscode(params[1]!)).resolves.toEqual({
       kind: "preparing",
     });
-    await vi.waitFor(() => expect(runFfmpeg).toHaveBeenCalledTimes(2));
+    await Promise.all(starts.slice(0, 2).map(async ({ promise }) => await promise));
+    expect(runFfmpeg).toHaveBeenCalledTimes(2);
     await expect(playback.resolvePlaybackTranscode(params[2]!)).resolves.toEqual({
       kind: "preparing",
     });
     expect(runFfmpeg).toHaveBeenCalledTimes(2);
 
+    const capacityAvailable = waitForPlaybackTranscodeJobsForTest("next");
     await finishers[0]?.();
-    await vi.waitFor(async () => {
-      await expect(playback.resolvePlaybackTranscode(params[2]!)).resolves.toEqual({
-        kind: "preparing",
-      });
-      expect(runFfmpeg).toHaveBeenCalledTimes(3);
+    await expect(capacityAvailable).resolves.toBe(2);
+    await expect(playback.resolvePlaybackTranscode(params[2]!)).resolves.toEqual({
+      kind: "preparing",
     });
+    await starts[2]!.promise;
+    expect(runFfmpeg).toHaveBeenCalledTimes(3);
+    const remainingJobs = waitForPlaybackTranscodeJobsForTest("all");
     await Promise.all(finishers.slice(1).map(async (finish) => await finish()));
-    await vi.waitFor(async () => {
-      await expect(
-        Promise.all(params.map(async (param) => await playback.resolvePlaybackTranscode(param))),
-      ).resolves.toEqual([
-        expect.objectContaining({ kind: "transcoded" }),
-        expect.objectContaining({ kind: "transcoded" }),
-        expect.objectContaining({ kind: "transcoded" }),
-      ]);
-    });
+    await expect(remainingJobs).resolves.toBe(2);
+    await expect(
+      Promise.all(params.map(async (param) => await playback.resolvePlaybackTranscode(param))),
+    ).resolves.toEqual([
+      expect.objectContaining({ kind: "transcoded" }),
+      expect.objectContaining({ kind: "transcoded" }),
+      expect.objectContaining({ kind: "transcoded" }),
+    ]);
   });
 
   it("passes already portable media through without invoking ffmpeg", async () => {

--- a/src/media/playback-transcode.ts
+++ b/src/media/playback-transcode.ts
@@ -135,7 +135,7 @@ const PLAYBACK_TRANSCODE_MAX_INPUT_PIXELS = 4096 * 4096;
 const PLAYBACK_TRANSCODE_THREADS = 2;
 const PLAYBACK_TRANSCODE_FAILURE_COOLDOWN_MS = 60_000;
 const MAX_PLAYBACK_ENTRIES = { failures: 32, inspections: 32, inspectionJobs: 2 } as const;
-const playbackJobs = new Map<string, true>();
+const playbackJobs = new Map<string, Promise<void>>();
 const playbackFailures = new Map<string, number>();
 const playbackInspections = new Map<string, PlaybackInspection>();
 const playbackInspectionJobs = new Map<string, Promise<PlaybackInspection>>();
@@ -203,6 +203,7 @@ if (process.env.VITEST || process.env.NODE_ENV === "test") {
     PLAYBACK_TRANSCODE_POLICY,
     readPlaybackSourceBounded,
     resolvePlaybackMode,
+    getPlaybackTranscodeJobs: (): Promise<void>[] => [...playbackJobs.values()],
   };
 }
 
@@ -667,8 +668,7 @@ export async function resolvePlaybackTranscode(
     return { kind: "preparing" };
   }
 
-  playbackJobs.set(operationKey, true);
-  void transcodePlaybackSource({
+  const job = transcodePlaybackSource({
     ...(inspection.audioStreamIndex !== undefined
       ? { audioStreamIndex: inspection.audioStreamIndex }
       : {}),
@@ -681,7 +681,10 @@ export async function resolvePlaybackTranscode(
     ...(inspection.videoStreamIndex !== undefined
       ? { videoStreamIndex: inspection.videoStreamIndex }
       : {}),
-  }).then(
+  });
+  // Pool admission and test synchronization must observe the same completion boundary.
+  playbackJobs.set(operationKey, job);
+  void job.then(
     () => {
       playbackJobs.delete(operationKey);
       playbackFailures.delete(operationKey);


### PR DESCRIPTION
## What Problem This Solves

Resolves a timing-dependent media test failure where the saturated playback transcode pool test could observe only two mocked `ffmpeg` calls after releasing one mock. Releasing `ffmpeg` does not release pool capacity: output validation and cache persistence still have to settle first.

## Why This Change Was Made

The pool now retains its authoritative job promises instead of boolean occupancy markers. Test support can observe the same settlement boundary used by pool admission, while deferred mock-start signals preserve the exact two-job capacity and three-job scheduling assertions without wall-clock polling.

The wait is order-independent because the two initial transcodes legitimately race; it observes the next pool completion and then all remaining jobs rather than assuming the first mock finisher belongs to a particular source.

## User Impact

No user-visible runtime behavior changes. CI no longer depends on output validation and cache persistence finishing inside Vitest's one-second polling window.

## Evidence

- Deterministic before/after proof: injecting a 1.25-second post-`ffmpeg` validation delay made the old test fail with `expected 3 calls, got 2`; the repaired test passed under the identical delay.
- `src/media/playback-transcode.test.ts`: 27/27 passed.
- Saturation test: 25 independent process runs passed after the final order-independent synchronization fix.
- Targeted Oxfmt, diff check, and Oxlint passed.
- Blacksmith Testbox changed gate passed on frozen base `2f071c9371bdf7b7163660fc58361edc42db6154`: https://github.com/openclaw/openclaw/actions/runs/31537040507
- Autoreview: clean, no accepted/actionable findings (confidence 0.98).

Production LOC: +7/-4 (net +3) | Tests/test support: +31/-15

Root cause and owner: `resolvePlaybackTranscode` owns capacity through the complete transcode promise, but the test synchronized only on the inner mocked `ffmpeg` promise. Recording the owner promise makes pool occupancy and test observation share one lifecycle fact.

Provenance: the original saturation test and pool behavior were introduced together in #115987 (`4229e96e0ec3394ab9d154d09992d825c64d8685`, authored and merged by @steipete on 2026-07-29). The timing gap became visible under loaded exact-head CI; no runtime regression was introduced by the Android PR whose gate exposed it.

Best-fix verdict: best. Increasing the timeout, retrying the test, or weakening the third-call assertion would retain the wrong synchronization boundary. Automatically queueing saturated requests would change runtime behavior unnecessarily.

ClawSweeper is waived for this repair per the standing deployment request.
