### PR TITLE
feat(control-model): add session catalog store

### DIFF
--- a/packages/control-model/README.md
+++ b/packages/control-model/README.md
@@ -18,7 +18,8 @@ const model = createControlModel({
   gateway: {
     getConnectionSnapshot: () => connectionSnapshot,
     subscribeConnection: (listener) => connectionStore.subscribe(listener),
-    subscribeEvents: (listener) => gatewayEvents.subscribe(listener),
+    subscribeSessionCatalogInvalidations: (listener) =>
+      sessionCatalogInvalidations.subscribe(listener),
     request: (method, params, options) => gateway.request(method, params, options),
   },
 });
@@ -33,11 +34,19 @@ The binding supplies monotonically increasing connection epochs. A response
 captured under a retired epoch never replaces state from the current
 connection.
 
+The invalidation binding owns the Gateway subscription boundary: it must
+activate `sessions.subscribe`, renew it for every replacement connection epoch,
+and invoke the listener for authorized `sessions.changed` events. This keeps a
+single subscription owner in the host instead of creating a second Gateway
+event lifecycle inside the model.
+
 ## Session snapshots
 
 `model.refreshSessions()` requests one bounded `sessions.list` result and
 publishes a deeply frozen snapshot. Live `sessions.changed` events schedule a
-canonical refresh; they do not mutate rows directly.
+canonical refresh; they do not mutate rows directly. Control Model exports the
+same bounded refresh coordinator used by Control UI, so both surfaces preserve
+one trailing refresh after an in-flight request succeeds or fails.
 
 Subscriber notifications run in a coalesced microtask. A slow or throwing
 subscriber cannot block the Gateway event callback or prevent other subscribers

--- a/packages/control-model/README.md
+++ b/packages/control-model/README.md
@@ -1,0 +1,46 @@
+# `@openclaw/control-model`
+
+Framework-neutral state and command projections above
+`@openclaw/gateway-client`.
+
+The first workspace-only slice owns connection lifecycle and immutable session
+catalog snapshots. It does not include conversation messages, UI artifacts,
+framework adapters, or npm publication.
+
+## Bind a Gateway client
+
+Hosts adapt their existing Gateway connection to `ControlModelGatewayBinding`:
+
+```ts
+import { createControlModel } from "@openclaw/control-model";
+
+const model = createControlModel({
+  gateway: {
+    getConnectionSnapshot: () => connectionSnapshot,
+    subscribeConnection: (listener) => connectionStore.subscribe(listener),
+    subscribeEvents: (listener) => gatewayEvents.subscribe(listener),
+    request: (method, params, options) => gateway.request(method, params, options),
+  },
+});
+
+model.start();
+const unsubscribe = model.subscribe(() => {
+  render(model.getSnapshot());
+});
+```
+
+The binding supplies monotonically increasing connection epochs. A response
+captured under a retired epoch never replaces state from the current
+connection.
+
+## Session snapshots
+
+`model.refreshSessions()` requests one bounded `sessions.list` result and
+publishes a deeply frozen snapshot. Live `sessions.changed` events schedule a
+canonical refresh; they do not mutate rows directly.
+
+Subscriber notifications run in a coalesced microtask. A slow or throwing
+subscriber cannot block the Gateway event callback or prevent other subscribers
+from observing the current snapshot.
+
+Call `model.dispose()` before releasing the host connection.

--- a/packages/control-model/package.json
+++ b/packages/control-model/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@openclaw/control-model",
+  "version": "0.0.0-private",
+  "private": true,
+  "description": "Framework-neutral OpenClaw state and command model",
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsdown src/index.ts --no-config --platform neutral --format esm --dts --out-dir dist --clean"
+  },
+  "dependencies": {
+    "@openclaw/gateway-protocol": "workspace:*"
+  }
+}

--- a/packages/control-model/src/index.ts
+++ b/packages/control-model/src/index.ts
@@ -1,0 +1,19 @@
+export {
+  ControlModelDisposedError,
+  ControlModelSubscriberLimitError,
+  createControlModel,
+} from "./model.js";
+export type {
+  ControlModel,
+  ControlModelBounds,
+  ControlModelConnectionSnapshot,
+  ControlModelConnectionStatus,
+  ControlModelError,
+  ControlModelGatewayBinding,
+  ControlModelGatewayEvent,
+  ControlModelOptions,
+  ControlModelRequestOptions,
+  ControlModelSessionCatalogSnapshot,
+  ControlModelSnapshot,
+  ControlModelSubscriber,
+} from "./model.js";

--- a/packages/control-model/src/index.ts
+++ b/packages/control-model/src/index.ts
@@ -10,10 +10,12 @@ export type {
   ControlModelConnectionStatus,
   ControlModelError,
   ControlModelGatewayBinding,
-  ControlModelGatewayEvent,
   ControlModelOptions,
   ControlModelRequestOptions,
   ControlModelSessionCatalogSnapshot,
   ControlModelSnapshot,
   ControlModelSubscriber,
+  DeepReadonly,
 } from "./model.js";
+export { createSessionEventRefreshCoordinator } from "./session-event-refresh.js";
+export type { SessionEventRefreshCoordinatorOptions } from "./session-event-refresh.js";

--- a/packages/control-model/src/model.test.ts
+++ b/packages/control-model/src/model.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ControlModelDisposedError,
   ControlModelSubscriberLimitError,
   createControlModel,
   type ControlModelConnectionSnapshot,
   type ControlModelGatewayBinding,
-  type ControlModelGatewayEvent,
+  type ControlModelRequestOptions,
 } from "./index.js";
 
 type SessionListResult = {
@@ -29,38 +29,54 @@ function createGatewayHarness(
 ) {
   let connection = initial;
   const connectionListeners = new Set<() => void>();
-  const eventListeners = new Set<(event: ControlModelGatewayEvent) => void>();
-  const requests: Array<ReturnType<typeof deferred<SessionListResult>>> = [];
-  const request = vi.fn(() => {
-    const pending = deferred<SessionListResult>();
-    requests.push(pending);
-    return pending.promise;
+  const invalidationListeners = new Set<() => void>();
+  const unsubscribeInvalidations = vi.fn();
+  const subscribeInvalidations = vi.fn((listener: () => void) => {
+    invalidationListeners.add(listener);
+    return () => {
+      invalidationListeners.delete(listener);
+      unsubscribeInvalidations();
+    };
   });
+  const requests: Array<ReturnType<typeof deferred<SessionListResult>>> = [];
+  const requestCalls: Array<{
+    method: string;
+    params: Record<string, unknown>;
+    options: ControlModelRequestOptions | undefined;
+  }> = [];
+  const request = vi.fn(
+    (method: string, params: Record<string, unknown>, options?: ControlModelRequestOptions) => {
+      requestCalls.push({ method, params, options });
+      const pending = deferred<SessionListResult>();
+      requests.push(pending);
+      return pending.promise;
+    },
+  );
   const gateway: ControlModelGatewayBinding = {
     getConnectionSnapshot: () => connection,
     subscribeConnection(listener) {
       connectionListeners.add(listener);
       return () => connectionListeners.delete(listener);
     },
-    subscribeEvents(listener) {
-      eventListeners.add(listener);
-      return () => eventListeners.delete(listener);
-    },
+    subscribeSessionCatalogInvalidations: subscribeInvalidations,
     request,
   };
   return {
     gateway,
     request,
     requests,
+    requestCalls,
+    subscribeInvalidations,
+    unsubscribeInvalidations,
     setConnection(next: ControlModelConnectionSnapshot) {
       connection = next;
       for (const listener of connectionListeners) {
         listener();
       }
     },
-    emit(event: ControlModelGatewayEvent) {
-      for (const listener of eventListeners) {
-        listener(event);
+    emitInvalidation() {
+      for (const listener of invalidationListeners) {
+        listener();
       }
     },
   };
@@ -71,7 +87,21 @@ async function flushMicrotasks() {
   await Promise.resolve();
 }
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe("Control Model session catalog", () => {
+  it("activates and disposes the host-owned invalidation subscription", () => {
+    const harness = createGatewayHarness({ status: "disconnected", epoch: 0 });
+    const model = createControlModel({ gateway: harness.gateway });
+    model.start();
+    model.start();
+    expect(harness.subscribeInvalidations).toHaveBeenCalledTimes(1);
+    model.dispose();
+    expect(harness.unsubscribeInvalidations).toHaveBeenCalledTimes(1);
+  });
+
   it("publishes deeply immutable bounded session snapshots", async () => {
     const harness = createGatewayHarness();
     const model = createControlModel({
@@ -80,7 +110,6 @@ describe("Control Model session catalog", () => {
       now: () => 42,
     });
     model.start();
-    const refresh = model.refreshSessions();
     harness.requests[0]?.resolve({
       sessions: [
         {
@@ -93,7 +122,9 @@ describe("Control Model session catalog", () => {
       totalCount: 2,
       hasMore: true,
     });
-    await refresh;
+    await vi.waitFor(() => {
+      expect(model.getSnapshot().sessionCatalog.status).toBe("ready");
+    });
 
     const snapshot = model.getSnapshot();
     expect(harness.request).toHaveBeenCalledWith("sessions.list", { limit: 1 }, undefined);
@@ -109,21 +140,24 @@ describe("Control Model session catalog", () => {
     expect(Object.isFrozen(snapshot.sessionCatalog.sessions[0]?.worktree)).toBe(true);
   });
 
-  it("coalesces live invalidations and rejects retired-epoch results", async () => {
+  it("coalesces invalidations and never publishes a retired-epoch result", async () => {
+    vi.useFakeTimers();
     const harness = createGatewayHarness();
     const model = createControlModel({ gateway: harness.gateway });
     model.start();
     await flushMicrotasks();
     expect(harness.requests).toHaveLength(1);
 
-    harness.emit({ event: "sessions.changed" });
-    harness.emit({ event: "sessions.changed" });
+    harness.emitInvalidation();
+    harness.emitInvalidation();
+    await vi.advanceTimersByTimeAsync(200);
     harness.setConnection({ status: "reconnecting", epoch: 2 });
     harness.setConnection({ status: "connected", epoch: 2 });
     harness.requests[0]?.resolve({
       sessions: [{ key: "agent:main:stale", kind: "direct" }],
     });
     await flushMicrotasks();
+    expect(model.getSnapshot().sessionCatalog.sessions).toEqual([]);
     expect(harness.requests).toHaveLength(2);
 
     harness.requests[1]?.resolve({
@@ -137,12 +171,31 @@ describe("Control Model session catalog", () => {
     ]);
   });
 
+  it("retires stale request failures without publishing them", async () => {
+    const harness = createGatewayHarness();
+    const model = createControlModel({ gateway: harness.gateway });
+    model.start();
+    await flushMicrotasks();
+    harness.setConnection({ status: "reconnecting", epoch: 2 });
+    harness.setConnection({ status: "connected", epoch: 2 });
+    harness.requests[0]?.reject(new Error("retired failure"));
+    await flushMicrotasks();
+    expect(harness.requests).toHaveLength(2);
+    expect(model.getSnapshot().sessionCatalog.error).toBeNull();
+    harness.requests[1]?.resolve({
+      sessions: [{ key: "agent:main:current", kind: "direct" }],
+    });
+    await vi.waitFor(() => {
+      expect(model.getSnapshot().sessionCatalog.status).toBe("ready");
+    });
+  });
+
   it("reconciles create, update, and delete through canonical refreshes", async () => {
+    vi.useFakeTimers();
     const harness = createGatewayHarness({ status: "disconnected", epoch: 0 });
     const model = createControlModel({ gateway: harness.gateway });
     model.start();
     harness.setConnection({ status: "connected", epoch: 1 });
-    await flushMicrotasks();
     harness.requests[0]?.resolve({
       sessions: [{ key: "agent:main:one", kind: "direct", label: "First" }],
     });
@@ -150,8 +203,8 @@ describe("Control Model session catalog", () => {
       expect(model.getSnapshot().sessionCatalog.status).toBe("ready");
     });
 
-    harness.emit({ event: "sessions.changed" });
-    await flushMicrotasks();
+    harness.emitInvalidation();
+    await vi.advanceTimersByTimeAsync(200);
     harness.requests[1]?.resolve({
       sessions: [
         { key: "agent:main:one", kind: "direct", label: "Updated" },
@@ -162,8 +215,8 @@ describe("Control Model session catalog", () => {
       expect(model.getSnapshot().sessionCatalog.sessions).toHaveLength(2);
     });
 
-    harness.emit({ event: "sessions.changed" });
-    await flushMicrotasks();
+    harness.emitInvalidation();
+    await vi.advanceTimersByTimeAsync(200);
     harness.requests[2]?.resolve({
       sessions: [{ key: "agent:main:two", kind: "direct" }],
     });
@@ -173,12 +226,56 @@ describe("Control Model session catalog", () => {
     expect(model.getSnapshot().sessionCatalog.sessions[0]?.key).toBe("agent:main:two");
   });
 
-  it("publishes structured request failures and preserves rejection", async () => {
+  it("runs a trailing invalidation refresh after an active refresh fails", async () => {
+    vi.useFakeTimers();
+    const backgroundErrors: unknown[] = [];
+    const harness = createGatewayHarness();
+    const model = createControlModel({
+      gateway: harness.gateway,
+      onBackgroundError: (error) => backgroundErrors.push(error),
+    });
+    model.start();
+    await flushMicrotasks();
+    harness.emitInvalidation();
+    await vi.advanceTimersByTimeAsync(200);
+    harness.requests[0]?.reject(new Error("first refresh failed"));
+    await vi.waitFor(() => {
+      expect(harness.requests).toHaveLength(2);
+    });
+    harness.requests[1]?.resolve({
+      sessions: [{ key: "agent:main:recovered", kind: "direct" }],
+    });
+    await vi.waitFor(() => {
+      expect(model.getSnapshot().sessionCatalog.status).toBe("ready");
+    });
+    expect(backgroundErrors).toHaveLength(1);
+  });
+
+  it("preserves explicit request options across background invalidations", async () => {
+    vi.useFakeTimers();
+    const harness = createGatewayHarness();
+    const model = createControlModel({ gateway: harness.gateway });
+    const controller = new AbortController();
+    model.start();
+    await flushMicrotasks();
+    const refresh = model.refreshSessions({ signal: controller.signal });
+    harness.emitInvalidation();
+    await vi.advanceTimersByTimeAsync(200);
+    harness.requests[0]?.resolve({ sessions: [] });
+    await flushMicrotasks();
+    expect(harness.requests).toHaveLength(2);
+    expect(harness.requestCalls[1]?.options?.signal).toBe(controller.signal);
+    harness.requests[1]?.resolve({ sessions: [] });
+    await refresh;
+    await flushMicrotasks();
+    harness.requests[2]?.resolve({ sessions: [] });
+  });
+
+  it("publishes structured request failures", async () => {
     const harness = createGatewayHarness({ status: "disconnected", epoch: 0 });
     const model = createControlModel({ gateway: harness.gateway });
     model.start();
     harness.setConnection({ status: "connected", epoch: 1 });
-    await flushMicrotasks();
     const error = Object.assign(new Error("temporarily unavailable"), {
       code: "UNAVAILABLE",
       retryable: true,
@@ -221,6 +318,37 @@ describe("Control Model session catalog", () => {
     slow.reject(new Error("slow subscriber failed"));
     await flushMicrotasks();
     expect(subscriberErrors).toHaveLength(2);
+  });
+
+  it("stops notifying copied subscribers when one disposes the model", async () => {
+    const harness = createGatewayHarness({ status: "disconnected", epoch: 0 });
+    const model = createControlModel({ gateway: harness.gateway });
+    const laterSubscriber = vi.fn();
+    model.subscribe(() => model.dispose());
+    model.subscribe(laterSubscriber);
+    model.start();
+    await flushMicrotasks();
+    expect(laterSubscriber).not.toHaveBeenCalled();
+  });
+
+  it("reports more rows when the response exceeds the local bound", async () => {
+    const harness = createGatewayHarness();
+    const model = createControlModel({
+      gateway: harness.gateway,
+      bounds: { maxSessions: 1 },
+    });
+    model.start();
+    harness.requests[0]?.resolve({
+      sessions: [
+        { key: "agent:main:one", kind: "direct" },
+        { key: "agent:main:two", kind: "direct" },
+      ],
+      hasMore: false,
+    });
+    await vi.waitFor(() => {
+      expect(model.getSnapshot().sessionCatalog.status).toBe("ready");
+    });
+    expect(model.getSnapshot().sessionCatalog.hasMore).toBe(true);
   });
 
   it("enforces subscriber bounds and disposal", () => {

--- a/packages/control-model/src/model.test.ts
+++ b/packages/control-model/src/model.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ControlModelDisposedError,
+  ControlModelSubscriberLimitError,
+  createControlModel,
+  type ControlModelConnectionSnapshot,
+  type ControlModelGatewayBinding,
+  type ControlModelGatewayEvent,
+} from "./index.js";
+
+type SessionListResult = {
+  sessions: Array<Record<string, unknown>>;
+  totalCount?: number;
+  hasMore?: boolean;
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function createGatewayHarness(
+  initial: ControlModelConnectionSnapshot = { status: "connected", epoch: 1 },
+) {
+  let connection = initial;
+  const connectionListeners = new Set<() => void>();
+  const eventListeners = new Set<(event: ControlModelGatewayEvent) => void>();
+  const requests: Array<ReturnType<typeof deferred<SessionListResult>>> = [];
+  const request = vi.fn(() => {
+    const pending = deferred<SessionListResult>();
+    requests.push(pending);
+    return pending.promise;
+  });
+  const gateway: ControlModelGatewayBinding = {
+    getConnectionSnapshot: () => connection,
+    subscribeConnection(listener) {
+      connectionListeners.add(listener);
+      return () => connectionListeners.delete(listener);
+    },
+    subscribeEvents(listener) {
+      eventListeners.add(listener);
+      return () => eventListeners.delete(listener);
+    },
+    request,
+  };
+  return {
+    gateway,
+    request,
+    requests,
+    setConnection(next: ControlModelConnectionSnapshot) {
+      connection = next;
+      for (const listener of connectionListeners) {
+        listener();
+      }
+    },
+    emit(event: ControlModelGatewayEvent) {
+      for (const listener of eventListeners) {
+        listener(event);
+      }
+    },
+  };
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("Control Model session catalog", () => {
+  it("publishes deeply immutable bounded session snapshots", async () => {
+    const harness = createGatewayHarness();
+    const model = createControlModel({
+      gateway: harness.gateway,
+      bounds: { maxSessions: 1 },
+      now: () => 42,
+    });
+    model.start();
+    const refresh = model.refreshSessions();
+    harness.requests[0]?.resolve({
+      sessions: [
+        {
+          key: "agent:main:one",
+          kind: "direct",
+          worktree: { id: "one", branch: "main", repoRoot: "C:\\repo" },
+        },
+        { key: "agent:main:two", kind: "direct" },
+      ],
+      totalCount: 2,
+      hasMore: true,
+    });
+    await refresh;
+
+    const snapshot = model.getSnapshot();
+    expect(harness.request).toHaveBeenCalledWith("sessions.list", { limit: 1 }, undefined);
+    expect(snapshot.sessionCatalog).toMatchObject({
+      status: "ready",
+      totalCount: 2,
+      hasMore: true,
+      refreshedAt: 42,
+    });
+    expect(snapshot.sessionCatalog.sessions).toHaveLength(1);
+    expect(Object.isFrozen(snapshot)).toBe(true);
+    expect(Object.isFrozen(snapshot.sessionCatalog.sessions)).toBe(true);
+    expect(Object.isFrozen(snapshot.sessionCatalog.sessions[0]?.worktree)).toBe(true);
+  });
+
+  it("coalesces live invalidations and rejects retired-epoch results", async () => {
+    const harness = createGatewayHarness();
+    const model = createControlModel({ gateway: harness.gateway });
+    model.start();
+    await flushMicrotasks();
+    expect(harness.requests).toHaveLength(1);
+
+    harness.emit({ event: "sessions.changed" });
+    harness.emit({ event: "sessions.changed" });
+    harness.setConnection({ status: "reconnecting", epoch: 2 });
+    harness.setConnection({ status: "connected", epoch: 2 });
+    harness.requests[0]?.resolve({
+      sessions: [{ key: "agent:main:stale", kind: "direct" }],
+    });
+    await flushMicrotasks();
+    expect(harness.requests).toHaveLength(2);
+
+    harness.requests[1]?.resolve({
+      sessions: [{ key: "agent:main:current", kind: "direct" }],
+    });
+    await vi.waitFor(() => {
+      expect(model.getSnapshot().sessionCatalog.status).toBe("ready");
+    });
+    expect(model.getSnapshot().sessionCatalog.sessions.map((session) => session.key)).toEqual([
+      "agent:main:current",
+    ]);
+  });
+
+  it("reconciles create, update, and delete through canonical refreshes", async () => {
+    const harness = createGatewayHarness({ status: "disconnected", epoch: 0 });
+    const model = createControlModel({ gateway: harness.gateway });
+    model.start();
+    harness.setConnection({ status: "connected", epoch: 1 });
+    await flushMicrotasks();
+    harness.requests[0]?.resolve({
+      sessions: [{ key: "agent:main:one", kind: "direct", label: "First" }],
+    });
+    await vi.waitFor(() => {
+      expect(model.getSnapshot().sessionCatalog.status).toBe("ready");
+    });
+
+    harness.emit({ event: "sessions.changed" });
+    await flushMicrotasks();
+    harness.requests[1]?.resolve({
+      sessions: [
+        { key: "agent:main:one", kind: "direct", label: "Updated" },
+        { key: "agent:main:two", kind: "direct" },
+      ],
+    });
+    await vi.waitFor(() => {
+      expect(model.getSnapshot().sessionCatalog.sessions).toHaveLength(2);
+    });
+
+    harness.emit({ event: "sessions.changed" });
+    await flushMicrotasks();
+    harness.requests[2]?.resolve({
+      sessions: [{ key: "agent:main:two", kind: "direct" }],
+    });
+    await vi.waitFor(() => {
+      expect(model.getSnapshot().sessionCatalog.sessions).toHaveLength(1);
+    });
+    expect(model.getSnapshot().sessionCatalog.sessions[0]?.key).toBe("agent:main:two");
+  });
+
+  it("publishes structured request failures and preserves rejection", async () => {
+    const harness = createGatewayHarness({ status: "disconnected", epoch: 0 });
+    const model = createControlModel({ gateway: harness.gateway });
+    model.start();
+    harness.setConnection({ status: "connected", epoch: 1 });
+    await flushMicrotasks();
+    const error = Object.assign(new Error("temporarily unavailable"), {
+      code: "UNAVAILABLE",
+      retryable: true,
+    });
+    harness.requests[0]?.reject(error);
+
+    await vi.waitFor(() => {
+      expect(model.getSnapshot().sessionCatalog.status).toBe("error");
+    });
+    expect(model.getSnapshot().sessionCatalog.error).toEqual({
+      code: "UNAVAILABLE",
+      message: "temporarily unavailable",
+      retryable: true,
+    });
+  });
+
+  it("isolates throwing and slow subscribers from event delivery", async () => {
+    const harness = createGatewayHarness({ status: "disconnected", epoch: 0 });
+    const subscriberErrors: unknown[] = [];
+    const model = createControlModel({
+      gateway: harness.gateway,
+      onSubscriberError: (error) => subscriberErrors.push(error),
+    });
+    const slow = deferred<void>();
+    const observed: number[] = [];
+    model.subscribe(() => {
+      throw new Error("subscriber failed");
+    });
+    model.subscribe(() => slow.promise);
+    model.subscribe(() => {
+      observed.push(model.getSnapshot().revision);
+    });
+    model.start();
+    harness.setConnection({ status: "connecting", epoch: 1 });
+    harness.setConnection({ status: "reconnecting", epoch: 1 });
+    await flushMicrotasks();
+
+    expect(observed).toHaveLength(1);
+    expect(subscriberErrors).toHaveLength(1);
+    slow.reject(new Error("slow subscriber failed"));
+    await flushMicrotasks();
+    expect(subscriberErrors).toHaveLength(2);
+  });
+
+  it("enforces subscriber bounds and disposal", () => {
+    const harness = createGatewayHarness({ status: "disconnected", epoch: 0 });
+    const model = createControlModel({
+      gateway: harness.gateway,
+      bounds: { maxSubscribers: 1 },
+    });
+    model.subscribe(() => {});
+    expect(() => model.subscribe(() => {})).toThrow(ControlModelSubscriberLimitError);
+    model.dispose();
+    expect(model.getSnapshot().lifecycle).toBe("disposed");
+    expect(() => model.start()).toThrow(ControlModelDisposedError);
+    expect(() => model.refreshSessions()).toThrow(ControlModelDisposedError);
+  });
+});

--- a/packages/control-model/src/model.ts
+++ b/packages/control-model/src/model.ts
@@ -1,4 +1,13 @@
 import type { SessionRow } from "@openclaw/gateway-protocol";
+import { createSessionEventRefreshCoordinator } from "./session-event-refresh.js";
+
+export type DeepReadonly<T> = T extends (...args: infer _Args) => infer _Result
+  ? T
+  : T extends readonly (infer Item)[]
+    ? readonly DeepReadonly<Item>[]
+    : T extends object
+      ? { readonly [Key in keyof T]: DeepReadonly<T[Key]> }
+      : T;
 
 export type ControlModelConnectionStatus =
   | "disconnected"
@@ -18,11 +27,6 @@ export type ControlModelConnectionSnapshot = Readonly<{
   error?: ControlModelError;
 }>;
 
-export type ControlModelGatewayEvent = Readonly<{
-  event: string;
-  payload?: unknown;
-}>;
-
 export type ControlModelRequestOptions = Readonly<{
   signal?: AbortSignal;
 }>;
@@ -30,7 +34,7 @@ export type ControlModelRequestOptions = Readonly<{
 export type ControlModelGatewayBinding = Readonly<{
   getConnectionSnapshot(): ControlModelConnectionSnapshot;
   subscribeConnection(listener: () => void): () => void;
-  subscribeEvents(listener: (event: ControlModelGatewayEvent) => void): () => void;
+  subscribeSessionCatalogInvalidations(listener: () => void): () => void;
   request<T>(
     method: string,
     params: Record<string, unknown>,
@@ -40,7 +44,7 @@ export type ControlModelGatewayBinding = Readonly<{
 
 export type ControlModelSessionCatalogSnapshot = Readonly<{
   status: "idle" | "loading" | "ready" | "error";
-  sessions: readonly Readonly<SessionRow>[];
+  sessions: readonly DeepReadonly<SessionRow>[];
   totalCount: number;
   hasMore: boolean;
   refreshedAt: number | null;
@@ -180,13 +184,12 @@ class ControlModelImpl implements ControlModel {
   readonly #subscribers = new Set<ControlModelSubscriber>();
   #snapshot: ControlModelSnapshot;
   #unsubscribeConnection: (() => void) | null = null;
-  #unsubscribeEvents: (() => void) | null = null;
+  #unsubscribeSessionCatalogInvalidations: (() => void) | null = null;
   #refreshLoop: Promise<void> | null = null;
   #refreshRequested = false;
   #refreshOptions: ControlModelRequestOptions | undefined;
   #notificationScheduled = false;
-  #backgroundRefreshScheduled = false;
-  #backgroundRefreshForced = false;
+  readonly #eventRefreshCoordinator: ReturnType<typeof createSessionEventRefreshCoordinator>;
 
   constructor(options: ControlModelOptions) {
     this.#gateway = options.gateway;
@@ -196,6 +199,19 @@ class ControlModelImpl implements ControlModel {
     this.#onSubscriberError = options.onSubscriberError;
     this.#onBackgroundError = options.onBackgroundError;
     this.#snapshot = initialSnapshot(this.#gateway.getConnectionSnapshot());
+    this.#eventRefreshCoordinator = createSessionEventRefreshCoordinator({
+      canRefresh: () =>
+        this.#snapshot.lifecycle === "running" &&
+        this.#gateway.getConnectionSnapshot().status === "connected",
+      refresh: async () => {
+        try {
+          await this.refreshSessions();
+        } catch (error) {
+          this.#reportBackgroundError(error);
+          throw error;
+        }
+      },
+    });
   }
 
   getSnapshot(): ControlModelSnapshot {
@@ -221,29 +237,36 @@ class ControlModelImpl implements ControlModel {
     this.#unsubscribeConnection = this.#gateway.subscribeConnection(() => {
       this.#readConnection();
     });
-    this.#unsubscribeEvents = this.#gateway.subscribeEvents((event) => {
-      if (event.event === "sessions.changed") {
-        this.#scheduleBackgroundRefresh(true);
-      }
-    });
+    this.#unsubscribeSessionCatalogInvalidations =
+      this.#gateway.subscribeSessionCatalogInvalidations(() => {
+        this.#eventRefreshCoordinator.schedule();
+      });
     this.#publish({
       ...this.#snapshot,
       lifecycle: "running",
       connection: freezeConnection(this.#gateway.getConnectionSnapshot()),
     });
     if (this.#snapshot.connection.status === "connected") {
-      this.#scheduleBackgroundRefresh();
+      this.#eventRefreshCoordinator.schedule();
+      this.#eventRefreshCoordinator.flush();
     }
   }
 
   refreshSessions(options?: ControlModelRequestOptions): Promise<void> {
     this.#assertActive();
     this.#refreshRequested = true;
-    this.#refreshOptions = options;
+    if (options !== undefined || this.#refreshOptions === undefined) {
+      this.#refreshOptions = options;
+    }
     if (!this.#refreshLoop) {
       const loop = this.#drainRefreshes().finally(() => {
         if (this.#refreshLoop === loop) {
           this.#refreshLoop = null;
+          if (this.#refreshRequested && this.#snapshot.lifecycle !== "disposed") {
+            void this.refreshSessions(this.#refreshOptions).catch((error: unknown) => {
+              this.#reportBackgroundError(error);
+            });
+          }
         }
       });
       this.#refreshLoop = loop;
@@ -256,10 +279,11 @@ class ControlModelImpl implements ControlModel {
       return;
     }
     this.#unsubscribeConnection?.();
-    this.#unsubscribeEvents?.();
+    this.#unsubscribeSessionCatalogInvalidations?.();
     this.#unsubscribeConnection = null;
-    this.#unsubscribeEvents = null;
+    this.#unsubscribeSessionCatalogInvalidations = null;
     this.#refreshRequested = false;
+    this.#eventRefreshCoordinator.dispose();
     this.#publish({
       ...this.#snapshot,
       lifecycle: "disposed",
@@ -268,11 +292,19 @@ class ControlModelImpl implements ControlModel {
   }
 
   async #drainRefreshes(): Promise<void> {
+    let firstError: unknown;
     while (this.#refreshRequested && this.#snapshot.lifecycle !== "disposed") {
       this.#refreshRequested = false;
       const options = this.#refreshOptions;
       this.#refreshOptions = undefined;
-      await this.#refreshOnce(options);
+      try {
+        await this.#refreshOnce(options);
+      } catch (error) {
+        firstError ??= error;
+      }
+    }
+    if (firstError !== undefined) {
+      throw firstError;
     }
   }
 
@@ -301,6 +333,7 @@ class ControlModelImpl implements ControlModel {
       if (!this.#isCurrentEpoch(epoch)) {
         return;
       }
+      const locallyTruncated = response.sessions.length > this.#maxSessions;
       const sessions = cloneAndFreeze(response.sessions.slice(0, this.#maxSessions));
       const totalCount = Math.max(
         sessions.length,
@@ -315,7 +348,7 @@ class ControlModelImpl implements ControlModel {
           status: "ready",
           sessions,
           totalCount,
-          hasMore: response.hasMore === true || totalCount > sessions.length,
+          hasMore: response.hasMore === true || locallyTruncated || totalCount > sessions.length,
           refreshedAt: this.#now(),
           error: null,
         }),
@@ -342,6 +375,9 @@ class ControlModelImpl implements ControlModel {
     }
     const connection = freezeConnection(this.#gateway.getConnectionSnapshot());
     const epochChanged = connection.epoch !== this.#snapshot.connection.epoch;
+    if (epochChanged || connection.status !== "connected") {
+      this.#eventRefreshCoordinator.reset();
+    }
     this.#publish({
       ...this.#snapshot,
       connection,
@@ -366,33 +402,9 @@ class ControlModelImpl implements ControlModel {
       connection.status === "connected" &&
       (epochChanged || this.#snapshot.sessionCatalog.status === "idle")
     ) {
-      this.#scheduleBackgroundRefresh(epochChanged);
+      this.#eventRefreshCoordinator.schedule();
+      this.#eventRefreshCoordinator.flush();
     }
-  }
-
-  #scheduleBackgroundRefresh(forceAfterActiveRefresh = false): void {
-    if (this.#snapshot.lifecycle === "disposed") {
-      return;
-    }
-    this.#backgroundRefreshForced ||= forceAfterActiveRefresh;
-    if (this.#backgroundRefreshScheduled) {
-      return;
-    }
-    this.#backgroundRefreshScheduled = true;
-    queueMicrotask(() => {
-      this.#backgroundRefreshScheduled = false;
-      const forced = this.#backgroundRefreshForced;
-      this.#backgroundRefreshForced = false;
-      if (this.#snapshot.lifecycle === "disposed") {
-        return;
-      }
-      if (!forced && this.#refreshLoop) {
-        return;
-      }
-      void this.refreshSessions().catch((error: unknown) => {
-        this.#reportBackgroundError(error);
-      });
-    });
   }
 
   #isCurrentEpoch(epoch: number): boolean {
@@ -424,6 +436,9 @@ class ControlModelImpl implements ControlModel {
         return;
       }
       for (const subscriber of [...this.#subscribers]) {
+        if (this.#snapshot.lifecycle === "disposed") {
+          break;
+        }
         try {
           const result = subscriber();
           if (result && typeof result.then === "function") {

--- a/packages/control-model/src/model.ts
+++ b/packages/control-model/src/model.ts
@@ -1,0 +1,466 @@
+import type { SessionRow } from "@openclaw/gateway-protocol";
+
+export type ControlModelConnectionStatus =
+  | "disconnected"
+  | "connecting"
+  | "connected"
+  | "reconnecting";
+
+export type ControlModelError = Readonly<{
+  code: string;
+  message: string;
+  retryable: boolean;
+}>;
+
+export type ControlModelConnectionSnapshot = Readonly<{
+  status: ControlModelConnectionStatus;
+  epoch: number;
+  error?: ControlModelError;
+}>;
+
+export type ControlModelGatewayEvent = Readonly<{
+  event: string;
+  payload?: unknown;
+}>;
+
+export type ControlModelRequestOptions = Readonly<{
+  signal?: AbortSignal;
+}>;
+
+export type ControlModelGatewayBinding = Readonly<{
+  getConnectionSnapshot(): ControlModelConnectionSnapshot;
+  subscribeConnection(listener: () => void): () => void;
+  subscribeEvents(listener: (event: ControlModelGatewayEvent) => void): () => void;
+  request<T>(
+    method: string,
+    params: Record<string, unknown>,
+    options?: ControlModelRequestOptions,
+  ): Promise<T>;
+}>;
+
+export type ControlModelSessionCatalogSnapshot = Readonly<{
+  status: "idle" | "loading" | "ready" | "error";
+  sessions: readonly Readonly<SessionRow>[];
+  totalCount: number;
+  hasMore: boolean;
+  refreshedAt: number | null;
+  error: ControlModelError | null;
+}>;
+
+export type ControlModelSnapshot = Readonly<{
+  revision: number;
+  lifecycle: "idle" | "running" | "disposed";
+  connection: ControlModelConnectionSnapshot;
+  sessionCatalog: ControlModelSessionCatalogSnapshot;
+}>;
+
+export type ControlModelSubscriber = () => void | Promise<void>;
+
+export type ControlModelBounds = Readonly<{
+  maxSessions?: number;
+  maxSubscribers?: number;
+}>;
+
+export type ControlModelOptions = Readonly<{
+  gateway: ControlModelGatewayBinding;
+  bounds?: ControlModelBounds;
+  now?: () => number;
+  onSubscriberError?: (error: unknown) => void;
+  onBackgroundError?: (error: unknown) => void;
+}>;
+
+export type ControlModel = Readonly<{
+  getSnapshot(): ControlModelSnapshot;
+  subscribe(subscriber: ControlModelSubscriber): () => void;
+  start(): void;
+  refreshSessions(options?: ControlModelRequestOptions): Promise<void>;
+  dispose(): void;
+}>;
+
+type SessionsListResponse = Readonly<{
+  sessions: readonly SessionRow[];
+  totalCount?: number;
+  hasMore?: boolean;
+}>;
+
+const DEFAULT_MAX_SESSIONS = 200;
+const DEFAULT_MAX_SUBSCRIBERS = 100;
+
+export class ControlModelDisposedError extends Error {
+  constructor() {
+    super("Control Model has been disposed");
+    this.name = "ControlModelDisposedError";
+  }
+}
+
+export class ControlModelSubscriberLimitError extends Error {
+  constructor(limit: number) {
+    super(`Control Model subscriber limit reached (${limit})`);
+    this.name = "ControlModelSubscriberLimitError";
+  }
+}
+
+function normalizeBound(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : fallback;
+}
+
+function normalizeError(error: unknown): ControlModelError {
+  const record =
+    error !== null && typeof error === "object" ? (error as Record<string, unknown>) : undefined;
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof record?.message === "string"
+        ? record.message
+        : String(error);
+  const candidateCode = record?.code ?? record?.gatewayCode;
+  return Object.freeze({
+    code:
+      typeof candidateCode === "string" && candidateCode.trim()
+        ? candidateCode.trim()
+        : "CONTROL_MODEL_REQUEST_FAILED",
+    message,
+    retryable: record?.retryable === true,
+  });
+}
+
+function cloneAndFreeze<T>(value: T, seen = new WeakMap<object, unknown>()): T {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  const existing = seen.get(value);
+  if (existing !== undefined) {
+    return existing as T;
+  }
+  if (Array.isArray(value)) {
+    const clone: unknown[] = [];
+    seen.set(value, clone);
+    for (const item of value) {
+      clone.push(cloneAndFreeze(item, seen));
+    }
+    return Object.freeze(clone) as T;
+  }
+  const clone: Record<string, unknown> = {};
+  seen.set(value, clone);
+  for (const [key, item] of Object.entries(value)) {
+    clone[key] = cloneAndFreeze(item, seen);
+  }
+  return Object.freeze(clone) as T;
+}
+
+function freezeConnection(
+  connection: ControlModelConnectionSnapshot,
+): ControlModelConnectionSnapshot {
+  return cloneAndFreeze(connection);
+}
+
+function initialSnapshot(connection: ControlModelConnectionSnapshot): ControlModelSnapshot {
+  return Object.freeze({
+    revision: 0,
+    lifecycle: "idle",
+    connection: freezeConnection(connection),
+    sessionCatalog: Object.freeze({
+      status: "idle",
+      sessions: Object.freeze([]),
+      totalCount: 0,
+      hasMore: false,
+      refreshedAt: null,
+      error: null,
+    }),
+  });
+}
+
+class ControlModelImpl implements ControlModel {
+  readonly #gateway: ControlModelGatewayBinding;
+  readonly #maxSessions: number;
+  readonly #maxSubscribers: number;
+  readonly #now: () => number;
+  readonly #onSubscriberError?: (error: unknown) => void;
+  readonly #onBackgroundError?: (error: unknown) => void;
+  readonly #subscribers = new Set<ControlModelSubscriber>();
+  #snapshot: ControlModelSnapshot;
+  #unsubscribeConnection: (() => void) | null = null;
+  #unsubscribeEvents: (() => void) | null = null;
+  #refreshLoop: Promise<void> | null = null;
+  #refreshRequested = false;
+  #refreshOptions: ControlModelRequestOptions | undefined;
+  #notificationScheduled = false;
+  #backgroundRefreshScheduled = false;
+  #backgroundRefreshForced = false;
+
+  constructor(options: ControlModelOptions) {
+    this.#gateway = options.gateway;
+    this.#maxSessions = normalizeBound(options.bounds?.maxSessions, DEFAULT_MAX_SESSIONS);
+    this.#maxSubscribers = normalizeBound(options.bounds?.maxSubscribers, DEFAULT_MAX_SUBSCRIBERS);
+    this.#now = options.now ?? Date.now;
+    this.#onSubscriberError = options.onSubscriberError;
+    this.#onBackgroundError = options.onBackgroundError;
+    this.#snapshot = initialSnapshot(this.#gateway.getConnectionSnapshot());
+  }
+
+  getSnapshot(): ControlModelSnapshot {
+    return this.#snapshot;
+  }
+
+  subscribe(subscriber: ControlModelSubscriber): () => void {
+    this.#assertActive();
+    if (this.#subscribers.size >= this.#maxSubscribers) {
+      throw new ControlModelSubscriberLimitError(this.#maxSubscribers);
+    }
+    this.#subscribers.add(subscriber);
+    return () => {
+      this.#subscribers.delete(subscriber);
+    };
+  }
+
+  start(): void {
+    this.#assertActive();
+    if (this.#snapshot.lifecycle === "running") {
+      return;
+    }
+    this.#unsubscribeConnection = this.#gateway.subscribeConnection(() => {
+      this.#readConnection();
+    });
+    this.#unsubscribeEvents = this.#gateway.subscribeEvents((event) => {
+      if (event.event === "sessions.changed") {
+        this.#scheduleBackgroundRefresh(true);
+      }
+    });
+    this.#publish({
+      ...this.#snapshot,
+      lifecycle: "running",
+      connection: freezeConnection(this.#gateway.getConnectionSnapshot()),
+    });
+    if (this.#snapshot.connection.status === "connected") {
+      this.#scheduleBackgroundRefresh();
+    }
+  }
+
+  refreshSessions(options?: ControlModelRequestOptions): Promise<void> {
+    this.#assertActive();
+    this.#refreshRequested = true;
+    this.#refreshOptions = options;
+    if (!this.#refreshLoop) {
+      const loop = this.#drainRefreshes().finally(() => {
+        if (this.#refreshLoop === loop) {
+          this.#refreshLoop = null;
+        }
+      });
+      this.#refreshLoop = loop;
+    }
+    return this.#refreshLoop;
+  }
+
+  dispose(): void {
+    if (this.#snapshot.lifecycle === "disposed") {
+      return;
+    }
+    this.#unsubscribeConnection?.();
+    this.#unsubscribeEvents?.();
+    this.#unsubscribeConnection = null;
+    this.#unsubscribeEvents = null;
+    this.#refreshRequested = false;
+    this.#publish({
+      ...this.#snapshot,
+      lifecycle: "disposed",
+    });
+    this.#subscribers.clear();
+  }
+
+  async #drainRefreshes(): Promise<void> {
+    while (this.#refreshRequested && this.#snapshot.lifecycle !== "disposed") {
+      this.#refreshRequested = false;
+      const options = this.#refreshOptions;
+      this.#refreshOptions = undefined;
+      await this.#refreshOnce(options);
+    }
+  }
+
+  async #refreshOnce(options?: ControlModelRequestOptions): Promise<void> {
+    const connection = this.#gateway.getConnectionSnapshot();
+    if (connection.status !== "connected") {
+      return;
+    }
+    const epoch = connection.epoch;
+    this.#publish({
+      ...this.#snapshot,
+      connection: freezeConnection(connection),
+      sessionCatalog: Object.freeze({
+        ...this.#snapshot.sessionCatalog,
+        status: "loading",
+        error: null,
+      }),
+    });
+
+    try {
+      const response = await this.#gateway.request<SessionsListResponse>(
+        "sessions.list",
+        { limit: this.#maxSessions },
+        options,
+      );
+      if (!this.#isCurrentEpoch(epoch)) {
+        return;
+      }
+      const sessions = cloneAndFreeze(response.sessions.slice(0, this.#maxSessions));
+      const totalCount = Math.max(
+        sessions.length,
+        typeof response.totalCount === "number" && Number.isFinite(response.totalCount)
+          ? Math.max(0, Math.floor(response.totalCount))
+          : sessions.length,
+      );
+      this.#publish({
+        ...this.#snapshot,
+        connection: freezeConnection(this.#gateway.getConnectionSnapshot()),
+        sessionCatalog: Object.freeze({
+          status: "ready",
+          sessions,
+          totalCount,
+          hasMore: response.hasMore === true || totalCount > sessions.length,
+          refreshedAt: this.#now(),
+          error: null,
+        }),
+      });
+    } catch (error) {
+      if (!this.#isCurrentEpoch(epoch)) {
+        return;
+      }
+      this.#publish({
+        ...this.#snapshot,
+        sessionCatalog: Object.freeze({
+          ...this.#snapshot.sessionCatalog,
+          status: "error",
+          error: normalizeError(error),
+        }),
+      });
+      throw error;
+    }
+  }
+
+  #readConnection(): void {
+    if (this.#snapshot.lifecycle === "disposed") {
+      return;
+    }
+    const connection = freezeConnection(this.#gateway.getConnectionSnapshot());
+    const epochChanged = connection.epoch !== this.#snapshot.connection.epoch;
+    this.#publish({
+      ...this.#snapshot,
+      connection,
+      sessionCatalog: epochChanged
+        ? Object.freeze({
+            status: "idle",
+            sessions: Object.freeze([]),
+            totalCount: 0,
+            hasMore: false,
+            refreshedAt: null,
+            error: null,
+          })
+        : connection.status !== "connected" && this.#snapshot.sessionCatalog.status === "loading"
+          ? Object.freeze({
+              ...this.#snapshot.sessionCatalog,
+              status: "idle",
+              error: null,
+            })
+          : this.#snapshot.sessionCatalog,
+    });
+    if (
+      connection.status === "connected" &&
+      (epochChanged || this.#snapshot.sessionCatalog.status === "idle")
+    ) {
+      this.#scheduleBackgroundRefresh(epochChanged);
+    }
+  }
+
+  #scheduleBackgroundRefresh(forceAfterActiveRefresh = false): void {
+    if (this.#snapshot.lifecycle === "disposed") {
+      return;
+    }
+    this.#backgroundRefreshForced ||= forceAfterActiveRefresh;
+    if (this.#backgroundRefreshScheduled) {
+      return;
+    }
+    this.#backgroundRefreshScheduled = true;
+    queueMicrotask(() => {
+      this.#backgroundRefreshScheduled = false;
+      const forced = this.#backgroundRefreshForced;
+      this.#backgroundRefreshForced = false;
+      if (this.#snapshot.lifecycle === "disposed") {
+        return;
+      }
+      if (!forced && this.#refreshLoop) {
+        return;
+      }
+      void this.refreshSessions().catch((error: unknown) => {
+        this.#reportBackgroundError(error);
+      });
+    });
+  }
+
+  #isCurrentEpoch(epoch: number): boolean {
+    const connection = this.#gateway.getConnectionSnapshot();
+    return (
+      this.#snapshot.lifecycle !== "disposed" &&
+      connection.status === "connected" &&
+      connection.epoch === epoch
+    );
+  }
+
+  #publish(next: Omit<ControlModelSnapshot, "revision"> & { revision?: number }): void {
+    const { revision: _ignored, ...rest } = next;
+    this.#snapshot = Object.freeze({
+      ...rest,
+      revision: this.#snapshot.revision + 1,
+    });
+    this.#scheduleNotification();
+  }
+
+  #scheduleNotification(): void {
+    if (this.#notificationScheduled || this.#snapshot.lifecycle === "disposed") {
+      return;
+    }
+    this.#notificationScheduled = true;
+    queueMicrotask(() => {
+      this.#notificationScheduled = false;
+      if (this.#snapshot.lifecycle === "disposed") {
+        return;
+      }
+      for (const subscriber of [...this.#subscribers]) {
+        try {
+          const result = subscriber();
+          if (result && typeof result.then === "function") {
+            void result.catch((error: unknown) => {
+              this.#reportSubscriberError(error);
+            });
+          }
+        } catch (error) {
+          this.#reportSubscriberError(error);
+        }
+      }
+    });
+  }
+
+  #reportSubscriberError(error: unknown): void {
+    try {
+      this.#onSubscriberError?.(error);
+    } catch {
+      // Error observers are terminal reporting hooks and cannot own model progress.
+    }
+  }
+
+  #reportBackgroundError(error: unknown): void {
+    try {
+      this.#onBackgroundError?.(error);
+    } catch {
+      // The structured catalog error remains observable when reporting fails.
+    }
+  }
+
+  #assertActive(): void {
+    if (this.#snapshot.lifecycle === "disposed") {
+      throw new ControlModelDisposedError();
+    }
+  }
+}
+
+export function createControlModel(options: ControlModelOptions): ControlModel {
+  return new ControlModelImpl(options);
+}

--- a/packages/control-model/src/session-event-refresh.test.ts
+++ b/packages/control-model/src/session-event-refresh.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSessionEventRefreshCoordinator } from "./session-event-refresh.js";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("session event refresh coordinator", () => {
+  it("coalesces bursts and runs one trailing refresh after failure", async () => {
+    vi.useFakeTimers();
+    const first = deferred<void>();
+    const refresh = vi.fn().mockReturnValueOnce(first.promise).mockResolvedValue(undefined);
+    const coordinator = createSessionEventRefreshCoordinator({
+      canRefresh: () => true,
+      refresh,
+    });
+
+    coordinator.schedule();
+    coordinator.schedule();
+    await vi.advanceTimersByTimeAsync(200);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    coordinator.schedule();
+    await vi.advanceTimersByTimeAsync(200);
+    first.reject(new Error("transient failure"));
+    await vi.waitFor(() => {
+      expect(refresh).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("retires pending work on reset", async () => {
+    vi.useFakeTimers();
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    const coordinator = createSessionEventRefreshCoordinator({
+      canRefresh: () => true,
+      refresh,
+    });
+    coordinator.schedule();
+    coordinator.reset();
+    await vi.runAllTimersAsync();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+});

--- a/packages/control-model/src/session-event-refresh.ts
+++ b/packages/control-model/src/session-event-refresh.ts
@@ -1,15 +1,24 @@
-const SESSION_EVENT_REFRESH_DEBOUNCE_MS = 200;
-const SESSION_EVENT_REFRESH_MAX_WAIT_MS = 1_000;
+const DEFAULT_DEBOUNCE_MS = 200;
+const DEFAULT_MAX_WAIT_MS = 1_000;
 
-type SessionEventRefreshCoordinatorOptions = {
+export type SessionEventRefreshCoordinatorOptions = Readonly<{
   canRefresh: () => boolean;
   refresh: () => Promise<void>;
-};
+  debounceMs?: number;
+  maxWaitMs?: number;
+  now?: () => number;
+}>;
 
-/** Canonical bounded event refresh policy shared by session-list owners. */
+/**
+ * Canonical bounded event-refresh policy shared by Control Model and Control UI.
+ * One in-flight refresh may acquire one trailing run, including after failure.
+ */
 export function createSessionEventRefreshCoordinator(
   options: SessionEventRefreshCoordinatorOptions,
 ) {
+  const debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+  const maxWaitMs = options.maxWaitMs ?? DEFAULT_MAX_WAIT_MS;
+  const now = options.now ?? Date.now;
   let timer: ReturnType<typeof globalThis.setTimeout> | null = null;
   let deadline: number | null = null;
   let inFlight: Promise<void> | null = null;
@@ -53,12 +62,12 @@ export function createSessionEventRefreshCoordinator(
       if (disposed || !options.canRefresh()) {
         return;
       }
-      const now = Date.now();
-      deadline ??= now + SESSION_EVENT_REFRESH_MAX_WAIT_MS;
+      const currentTime = now();
+      deadline ??= currentTime + maxWaitMs;
       if (timer !== null) {
         globalThis.clearTimeout(timer);
       }
-      const delay = Math.min(SESSION_EVENT_REFRESH_DEBOUNCE_MS, Math.max(0, deadline - now));
+      const delay = Math.min(debounceMs, Math.max(0, deadline - currentTime));
       timer = globalThis.setTimeout(() => {
         timer = null;
         deadline = null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2214,6 +2214,12 @@ importers:
         specifier: 1.3.6
         version: 1.3.6
 
+  packages/control-model:
+    dependencies:
+      '@openclaw/gateway-protocol':
+        specifier: workspace:*
+        version: link:../gateway-protocol
+
   packages/gateway-client:
     dependencies:
       '@openclaw/gateway-protocol':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2413,6 +2413,9 @@ importers:
       '@novnc/novnc':
         specifier: 1.7.0
         version: 1.7.0
+      '@openclaw/control-model':
+        specifier: workspace:*
+        version: link:../packages/control-model
       '@openclaw/gateway-client':
         specifier: workspace:*
         version: link:../packages/gateway-client

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,6 +40,8 @@
       "@openclaw/ai/internal/shared": ["./packages/ai/src/internal/shared.ts"],
       "@openclaw/agent-core": ["./packages/agent-core/src/index.ts"],
       "@openclaw/agent-core/*": ["./packages/agent-core/src/*"],
+      "@openclaw/control-model": ["./packages/control-model/src/index.ts"],
+      "@openclaw/control-model/*": ["./packages/control-model/src/*"],
       "@openclaw/llm-core": ["./packages/llm-core/src/index.ts"],
       "@openclaw/llm-core/diagnostics": ["./packages/llm-core/src/utils/diagnostics.ts"],
       "@openclaw/llm-core/event-stream": ["./packages/llm-core/src/utils/event-stream.ts"],

--- a/ui/package.json
+++ b/ui/package.json
@@ -22,6 +22,7 @@
     "@modelcontextprotocol/sdk": "1.30.0",
     "@noble/ed25519": "3.1.0",
     "@novnc/novnc": "1.7.0",
+    "@openclaw/control-model": "workspace:*",
     "@openclaw/gateway-client": "workspace:*",
     "@openclaw/gateway-protocol": "workspace:*",
     "@openclaw/libterminal": "0.3.2",

--- a/ui/src/app/vite-config.node.test.ts
+++ b/ui/src/app/vite-config.node.test.ts
@@ -345,6 +345,9 @@ describe("Control UI Vite config", () => {
     expect(findStringAlias("@openclaw/net-policy/ip")?.replacement).toBe(
       path.join(repoRoot, "packages/net-policy/src/ip.ts"),
     );
+    expect(findStringAlias("@openclaw/control-model")?.replacement).toBe(
+      path.join(repoRoot, "packages/control-model/src/index.ts"),
+    );
   });
 
   it("resolves Control UI dev-server source aliases for internal packages", () => {

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -1,5 +1,5 @@
+import { createSessionEventRefreshCoordinator } from "@openclaw/control-model";
 import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
-import { createSessionEventRefreshCoordinator } from "./event-refresh-coordinator.ts";
 import { appendSessionResults, reconcileRosterPresentationMetadata } from "./reconcile.ts";
 import type {
   SessionConnectionOwner,

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -17,6 +17,10 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "..");
 const workspaceSourceAliases = [
   {
+    find: "@openclaw/control-model",
+    replacement: path.resolve(repoRoot, "packages/control-model/src/index.ts"),
+  },
+  {
     find: "@openclaw/gateway-client/browser",
     replacement: path.resolve(repoRoot, "packages/gateway-client/src/browser.ts"),
   },


### PR DESCRIPTION
## Summary

- add the workspace-only `@openclaw/control-model` package
- expose immutable connection and bounded session-catalog snapshots behind a host-supplied Gateway binding
- coalesce `sessions.changed` invalidations into canonical `sessions.list` refreshes
- reject retired connection-epoch results and isolate slow or throwing subscribers from Gateway delivery
- keep conversation state, UI artifacts, framework adapters, and publication out of this first slice

## Why draft

This is **OC1** from the proposed Control Model series. It is opened early for implementation feedback while the fork-only RFC is under team review. It should not merge until the package boundary and ownership model are accepted.

RFC review: https://github.com/giodl73-repo/rfcs/pull/8
Lobster/M adoption design: https://github.com/gim-home/m/issues/5675

## Contract boundaries

- OpenClaw owns connection/session reconciliation and immutable snapshots.
- Hosts retain transport construction, authentication, and product presentation.
- The package imports no React, Lit, DOM component, Node built-in, or product code.
- Live events invalidate the catalog; authoritative Gateway results replace it.
- The package remains private and workspace-only until two consumers prove the contract.

## Verification

- `vitest run` for `packages/control-model/src/model.test.ts` — 6 tests
- `pnpm --filter @openclaw/control-model run build`
- neutral ESM plus declarations; no Node/browser/framework imports in the built graph

## Follow-up series

1. OC2: selected conversation model and typed commands
2. OC3: renderer-neutral UI artifacts, including inline and durable-surface projection
3. OC4: Control UI reference adoption
4. LM1-LM4: Lobster `SessionView` adapter, native artifact, actions/streaming, parity/cutover
5. OC5: publication only after two-consumer evidence and deletion of duplicate behavior