### PR TITLE
fix(ui): keep adjacent chat Markdown blocks on a consistent rhythm

### DIFF
--- a/ui/src/e2e/route-css.e2e.test.ts
+++ b/ui/src/e2e/route-css.e2e.test.ts
@@ -132,19 +132,41 @@ suite.define(() => {
           probe.className = "chat-text";
           probe.style.width = "900px";
           probe.innerHTML = `
+          <ol class="probe-list"><li>First</li></ol>
+          <blockquote class="probe-quote"><p>Quoted block</p></blockquote>
           <table>
             <thead><tr><th>Dimension</th><th>Sentiment signal</th></tr></thead>
             <tbody><tr><td>Demographics</td><td>Experience-dependent sentiment.</td></tr></tbody>
           </table>
-          <ol><li>One central pattern</li><li>Another central pattern</li></ol>
-          <p><strong>Overall characterization:</strong> Pragmatic adoption under suspicion.</p>
+          <p class="probe-table-copy"><strong>Overall characterization:</strong> Pragmatic adoption under suspicion.</p>
+          <ul class="probe-task-list"><li class="task-list-item"><input class="task-list-item-checkbox" type="checkbox" disabled /> Task</li></ul>
+          <details class="probe-details"><summary>More details</summary><p>Body</p></details>
+          <ul class="probe-unordered"><li>Unordered</li></ul>
+          <ol class="probe-ordered"><li>Ordered</li></ol>
         `;
           document.body.append(probe);
+          const list = probe.querySelector(".probe-list");
+          const quote = probe.querySelector(".probe-quote");
           const dimension = probe.querySelector("th:first-child");
           const demographics = probe.querySelector("td:first-child");
-          const list = probe.querySelector("ol");
-          const summary = probe.querySelector("ol + p");
-          if (!dimension || !demographics || !list || !summary) {
+          const table = probe.querySelector("table");
+          const tableCopy = probe.querySelector(".probe-table-copy");
+          const taskList = probe.querySelector(".probe-task-list");
+          const details = probe.querySelector(".probe-details");
+          const unordered = probe.querySelector(".probe-unordered");
+          const ordered = probe.querySelector(".probe-ordered");
+          if (
+            !dimension ||
+            !demographics ||
+            !list ||
+            !quote ||
+            !table ||
+            !tableCopy ||
+            !taskList ||
+            !details ||
+            !unordered ||
+            !ordered
+          ) {
             throw new Error("Chat Markdown style probe did not render");
           }
           const lineCount = (element: Element) => {
@@ -156,9 +178,18 @@ suite.define(() => {
             demographicsLineCount: lineCount(demographics),
             dimensionLineCount: lineCount(dimension),
             firstColumnWidth: dimension.getBoundingClientRect().width,
-            postListGap: summary.getBoundingClientRect().top - list.getBoundingClientRect().bottom,
-            postListMargin: Number.parseFloat(getComputedStyle(summary).marginTop),
-            summaryFontSize: Number.parseFloat(getComputedStyle(summary).fontSize),
+            listToQuoteGap: quote.getBoundingClientRect().top - list.getBoundingClientRect().bottom,
+            quoteMargin: Number.parseFloat(getComputedStyle(quote).marginTop),
+            tableToCopyGap:
+              tableCopy.getBoundingClientRect().top - table.getBoundingClientRect().bottom,
+            tableCopyMargin: Number.parseFloat(getComputedStyle(tableCopy).marginTop),
+            taskListToDetailsGap:
+              details.getBoundingClientRect().top - taskList.getBoundingClientRect().bottom,
+            detailsMargin: Number.parseFloat(getComputedStyle(details).marginTop),
+            unorderedToOrderedGap:
+              ordered.getBoundingClientRect().top - unordered.getBoundingClientRect().bottom,
+            orderedMargin: Number.parseFloat(getComputedStyle(ordered).marginTop),
+            blockFontSize: Number.parseFloat(getComputedStyle(tableCopy).fontSize),
           };
           probe.remove();
           return result;
@@ -166,8 +197,23 @@ suite.define(() => {
         expect(chatMarkdownStyles.dimensionLineCount).toBe(1);
         expect(chatMarkdownStyles.demographicsLineCount).toBe(1);
         expect(chatMarkdownStyles.firstColumnWidth).toBeGreaterThanOrEqual(128);
-        expect(chatMarkdownStyles.postListGap).toBeGreaterThan(0);
-        expect(chatMarkdownStyles.postListMargin / chatMarkdownStyles.summaryFontSize).toBeCloseTo(
+        expect(chatMarkdownStyles.listToQuoteGap).toBeGreaterThan(0);
+        expect(chatMarkdownStyles.tableToCopyGap).toBeGreaterThan(0);
+        expect(chatMarkdownStyles.taskListToDetailsGap).toBeGreaterThan(0);
+        expect(chatMarkdownStyles.unorderedToOrderedGap).toBeGreaterThan(0);
+        expect(chatMarkdownStyles.quoteMargin / chatMarkdownStyles.blockFontSize).toBeCloseTo(
+          0.75,
+          2,
+        );
+        expect(chatMarkdownStyles.tableCopyMargin / chatMarkdownStyles.blockFontSize).toBeCloseTo(
+          0.75,
+          2,
+        );
+        expect(chatMarkdownStyles.detailsMargin / chatMarkdownStyles.blockFontSize).toBeCloseTo(
+          0.75,
+          2,
+        );
+        expect(chatMarkdownStyles.orderedMargin / chatMarkdownStyles.blockFontSize).toBeCloseTo(
           0.75,
           2,
         );

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -57,12 +57,20 @@
   outline-offset: 2px;
 }
 
-.chat-text :where(p, ul, ol, pre, blockquote, table) {
+.chat-text :where(p, ul, ol, pre, blockquote, table, details) {
   margin: 0;
 }
 
-/* Tables always carry top margin (not just after paragraphs); see the sibling
-   :where(p + ...) spacing rule below which intentionally omits table. */
+/* Keep every adjacent top-level Markdown block on the same rhythm, including
+   special blocks that otherwise read as part of the preceding block. */
+.chat-text
+  :where(p, ul, ol, pre, blockquote, table, details)
+  + :where(p, ul, ol, pre, blockquote, table, details) {
+  margin-top: 0.75em;
+}
+
+/* Tables retain top margin even when first; the adjacent-block rule above gives
+   tables the same rhythm when they follow another Markdown block. */
 .chat-text :where(table) {
   margin-top: 0.75em;
   border: 1px solid color-mix(in srgb, var(--accent) 20%, var(--border));
@@ -377,12 +385,6 @@
 
 .chat-text :where(blockquote blockquote blockquote) {
   background: rgba(255, 255, 255, 0.04);
-}
-
-/* Order contract: stays below the nested-blockquote margin rule so a nested
-   quote that follows a paragraph gets paragraph rhythm, not the 8px gap. */
-.chat-text :where(p + p, p + ul, p + ol, p + pre, p + blockquote, ul + p, ol + p) {
-  margin-top: 0.75em;
 }
 
 :root[data-theme-mode="light"] .chat-text :where(blockquote) {


### PR DESCRIPTION
## What Problem This Solves
Adjacent Markdown blocks in the Control UI chat transcript could touch when the preceding or following block was a list, blockquote, table, or native details block. The affected cases were list → blockquote, table → prose, task-list → details, and unordered-list → ordered-list.

Fixes #122269

## Why This Change Was Made
The chat text stylesheet reset the relevant block margins and had a partial sibling-spacing rule. The missing combinations bypassed the existing `0.75em` rhythm. This patch replaces that partial list with one canonical adjacent-block rule covering the Markdown block types used by the transcript, while preserving the intentional table card styling and nested blockquote behavior.

The change is CSS-only in production. The existing route CSS E2E test gains focused browser assertions for all four gaps.

## User Impact
Markdown-rich assistant responses are easier to scan: adjacent special blocks now have consistent separation in both light and dark themes.

## Validation
- Current `origin/main`: `edb7a1692e58d78ff7e196db39ea8eff297b2e19`
- Pre-fix browser probe: 0px for all four affected gaps.
- Post-fix browser probe on this commit: 12px for all four affected gaps, matching `0.75em` at the fixture's 16px root size.
- `node scripts/run-vitest.mjs ui/src/e2e/route-css.e2e.test.ts` — passed.
- Stylelint for `ui/src/styles/chat/text.css` — passed.
- Diff check — passed.
- Final review — clean; no actionable findings.

## Before / After

### Light theme

Before:

![Before — light theme](https://github.com/user-attachments/assets/69925181-3008-4a24-8f30-8d3c219e0cac)

After:

![After — light theme](https://github.com/user-attachments/assets/d685c06e-1d67-46a5-9332-5ba70c59e19c)

### Dark theme

Before:

![Before — dark theme](https://github.com/user-attachments/assets/017f5f26-dc03-45f3-966a-dde35a723c5c)

After:

![After — dark theme](https://github.com/user-attachments/assets/6cd74cb6-a483-4366-908b-270cd993dc1a)
