### PR TITLE
fix(errors): detect HTML after HTTP reason phrases

### DIFF
--- a/src/agents/embedded-agent-helpers/provider-runtime-failure.test.ts
+++ b/src/agents/embedded-agent-helpers/provider-runtime-failure.test.ts
@@ -17,6 +17,12 @@ function expectNotFailoverSample(sample: string) {
 }
 
 describe("classifyProviderRuntimeFailureKind", () => {
+  it("classifies complete HTML after an HTTP reason phrase as upstream_html", () => {
+    const raw = "HTTP 502 Bad Gateway\n\n<!doctype html><html><body>down</body></html>";
+
+    expect(classifyProviderRuntimeFailureKind(raw)).toBe("upstream_html");
+  });
+
   it("classifies generic resource-exhausted codes as rate_limit", () => {
     expect(
       classifyProviderRuntimeFailureKind({

--- a/src/agents/embedded-agent-helpers/provider-runtime-failure.ts
+++ b/src/agents/embedded-agent-helpers/provider-runtime-failure.ts
@@ -1,5 +1,6 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { extractLeadingHttpStatus } from "../../shared/assistant-error-format.js";
+import { extractHttpResponseBody } from "../../shared/http-error-response.js";
 import { classifyOAuthRefreshFailure } from "../auth-profiles/oauth-refresh-failure.js";
 import { formatExecDeniedUserMessage } from "../exec-approval-result.js";
 import {
@@ -70,7 +71,7 @@ function isHtmlErrorResponse(raw: string, status?: number): boolean {
   if (typeof inferred !== "number" || inferred < 400) {
     return false;
   }
-  const rest = extractLeadingHttpStatus(candidate)?.rest ?? candidate;
+  const rest = extractHttpResponseBody(extractLeadingHttpStatus(candidate))?.body ?? candidate;
   return HTML_BODY_RE.test(rest) && HTML_CLOSE_RE.test(rest);
 }
 function isCloudflareChallengeResponse(message: string): boolean {

--- a/src/shared/assistant-error-format.html.test.ts
+++ b/src/shared/assistant-error-format.html.test.ts
@@ -17,6 +17,16 @@ describe("isCloudflareOrHtmlErrorPage", () => {
     expect(isCloudflareOrHtmlErrorPage(htmlError)).toBe(true);
   });
 
+  it("detects complete 5xx HTML pages after an HTTP reason phrase", () => {
+    const htmlError = "HTTP 502 Bad Gateway\n\n<!doctype html><html><body>down</body></html>";
+    expect(isCloudflareOrHtmlErrorPage(htmlError)).toBe(true);
+  });
+
+  it("does not flag partial HTML after an HTTP reason phrase", () => {
+    const partialHtml = "HTTP 502 Bad Gateway\n\n<!doctype html><html><body>down";
+    expect(isCloudflareOrHtmlErrorPage(partialHtml)).toBe(false);
+  });
+
   it("detects standalone Cloudflare challenge HTML pages", () => {
     // HTML challenge pages are provider transport failures, not model text.
     const htmlError = `<!DOCTYPE html>

--- a/src/shared/assistant-error-format.test.ts
+++ b/src/shared/assistant-error-format.test.ts
@@ -81,6 +81,18 @@ describe("extractErrorHttpStatus", () => {
 });
 
 describe("HTTP status consumers", () => {
+  it("does not return raw HTML after an HTTP reason phrase", () => {
+    const raw = [
+      "HTTP 502 Bad Gateway",
+      "",
+      "<!doctype html><html><body><h1>502</h1></body></html>",
+    ].join("\n");
+
+    expect(formatRawAssistantErrorForUi(raw)).toBe(
+      "The AI service is temporarily unavailable (HTTP 502). Please try again in a moment.",
+    );
+  });
+
   it("formats only status lines inside the HTTP range", () => {
     expect(formatRawAssistantErrorForUi("100 Continue")).toBe("HTTP 100: Continue");
     expect(formatRawAssistantErrorForUi("599 Provider Error")).toBe("HTTP 599: Provider Error");

--- a/src/shared/assistant-error-format.ts
+++ b/src/shared/assistant-error-format.ts
@@ -1,5 +1,6 @@
 // Assistant error formatting helpers normalize assistant-visible error payloads.
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { extractHttpResponseBody } from "./http-error-response.js";
 const ERROR_PAYLOAD_PREFIX_RE =
   /^(?:error|(?:[a-z][\w-]*\s+)?api\s*error|apierror|openai\s*error|anthropic\s*error|gateway\s*error|codex\s*error)(?:\s+\d{3})?[:\s-]+/i;
 const HTTP_STATUS_DELIMITER_RE = /(?:\s*:\s*|\s+)/;
@@ -160,7 +161,7 @@ export function isCloudflareOrHtmlErrorPage(raw: string): boolean {
     return true;
   }
 
-  const status = extractLeadingHttpStatus(trimmed);
+  const status = extractHttpResponseBody(extractLeadingHttpStatus(trimmed));
   if (!status || status.code < 500) {
     return false;
   }
@@ -170,7 +171,7 @@ export function isCloudflareOrHtmlErrorPage(raw: string): boolean {
   }
 
   return (
-    status.code < 600 && HTML_ERROR_PREFIX_RE.test(status.rest) && HTML_CLOSE_RE.test(status.rest)
+    status.code < 600 && HTML_ERROR_PREFIX_RE.test(status.body) && HTML_CLOSE_RE.test(status.body)
   );
 }
 

--- a/src/shared/http-error-response.test.ts
+++ b/src/shared/http-error-response.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { extractHttpResponseBody } from "./http-error-response.js";
+
+describe("extractHttpResponseBody", () => {
+  it.each([
+    {
+      name: "direct HTML body",
+      rest: "<html><body>down</body></html>",
+      expected: "<html><body>down</body></html>",
+    },
+    {
+      name: "HTTP reason phrase before HTML",
+      rest: "Bad Gateway\n\n<!doctype html><html><body>down</body></html>",
+      expected: "<!doctype html><html><body>down</body></html>",
+    },
+    {
+      name: "non-HTML status text",
+      rest: "Service Unavailable",
+      expected: "Service Unavailable",
+    },
+  ])("extracts $name", ({ rest, expected }) => {
+    expect(extractHttpResponseBody({ code: 502, rest })).toEqual({
+      code: 502,
+      body: expected,
+    });
+  });
+
+  it("preserves a missing status", () => {
+    expect(extractHttpResponseBody(null)).toBeNull();
+  });
+});

--- a/src/shared/http-error-response.ts
+++ b/src/shared/http-error-response.ts
@@ -1,0 +1,17 @@
+const HTML_ERROR_PREFIX_RE = /^\s*(?:<!doctype\s+html\b|<html\b)/i;
+
+export function extractHttpResponseBody(
+  status: { code: number; rest: string } | null,
+): { code: number; body: string } | null {
+  if (!status) {
+    return null;
+  }
+  if (HTML_ERROR_PREFIX_RE.test(status.rest)) {
+    return { code: status.code, body: status.rest };
+  }
+  const lineBreak = status.rest.indexOf("\n");
+  return {
+    code: status.code,
+    body: lineBreak === -1 ? status.rest : status.rest.slice(lineBreak + 1).trimStart(),
+  };
+}

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -12,10 +12,24 @@ import {
   isolateRtlRenderedLine,
   isTerminalSafeAutocompleteValue,
   isCommandMarkedMessage,
+  resolveFinalAssistantText,
   sanitizeMarkdownSource,
   sanitizeRenderableLine,
   sanitizeRenderableText,
 } from "./tui-formatters.js";
+
+describe("resolveFinalAssistantText", () => {
+  it("hides complete HTML error pages after an HTTP reason phrase", () => {
+    const raw = "HTTP 502 Bad Gateway\n\n<!doctype html><html><body>down</body></html>";
+
+    const rendered = resolveFinalAssistantText({ errorMessage: raw });
+
+    expect(rendered).toBe(
+      "The AI service is temporarily unavailable (HTTP 502). Please try again in a moment.",
+    );
+    expect(rendered).not.toContain("<html>");
+  });
+});
 
 describe("formatTuiFooter", () => {
   it("shows session modes and the process delivery mode in one compact summary", () => {


### PR DESCRIPTION
## What Problem This Solves

Provider and proxy 5xx errors can arrive as an HTTP status line with a reason phrase followed by a complete HTML error page, for example `HTTP 502 Bad Gateway` followed by a doctype. The formatter and runtime failure classifier previously interpreted the status remainder differently. Raw markup could reach TUI output while the sibling runtime classifier could misclassify the same upstream HTML failure as a timeout.

Fixes #122244.

## What Changed

- Add one shared HTTP status response-body extraction rule.
- Use that rule in both user-facing HTML-page detection and provider runtime failure classification.
- Keep existing status-only, direct-HTML, Cloudflare-code, auth HTML, and non-HTML behavior.
- Add classifier, runtime-classifier, and TUI consumer regressions for the reason-phrase-plus-HTML shape.
- Refresh the mechanically generated Plugin SDK closure hashes required by the repository API-baseline check.

## Evidence

### Repository-native verification

- Before the latest-main rebase, the final owner-boundary change passed 6 files and 222 focused tests.
- After rebasing onto current `main`, the same focused matrix passed 6 files and 182 tests; the count changed because upstream split the test shards.
- The runtime regression asserts that `HTTP 502 Bad Gateway` plus complete HTML classifies as `upstream_html` instead of `timeout`.
- The TUI consumer regression calls `resolveFinalAssistantText` with the same input and observes exactly: `The AI service is temporarily unavailable (HTTP 502). Please try again in a moment.`
- The TUI assertion also verifies that raw HTML is absent.
- `oxfmt --check` passed for the shared formatter, runtime classifier, and all focused tests.
- `pnpm plugin-sdk:api:check` passes after regenerating the required closure hashes.
- The final rebased-head CI run is pending.

### Real OpenClaw runtime proof

I ran the PR head through an isolated `openclaw agent --local` setup using a custom OpenAI Responses-compatible provider on `127.0.0.1`. The provider returned `502 Bad Gateway` with `Content-Type: text/html` and a complete HTML body on every request. OpenClaw made three provider attempts and surfaced concise user copy after the final failure.

Redacted after-fix output:

```text
[model-fetch] response provider=pprt-proof api=openai-responses
status=502 contentType=text/html; charset=utf-8

[agent/embedded] ... isError=true ...
error=The provider returned an HTML error page instead of an API response.
This usually means a CDN or gateway (e.g. Cloudflare) blocked the request.
Retry in a moment or check provider status.

FailoverError: The provider returned an HTML error page instead of an API response.
This usually means a CDN or gateway (e.g. Cloudflare) blocked the request.
Retry in a moment or check provider status.
```

The final user-facing error contains no HTML. Transport diagnostics still record the upstream response for debugging; the proof above is intentionally redacted. The live OpenAI-compatible adapter normalized the HTTP failure to `502 <html...>` without preserving the reason phrase, so the exact `HTTP 502 Bad Gateway\n\n<html...>` variant remains covered by the deterministic unit and TUI regressions.

## Scope

The production change is limited to the existing shared assistant error parser and its runtime classifier consumer. It does not alter transport retries, provider adapters, failover policy, TUI architecture, or unrelated error formatting. The additional generated files contain only repository-required API closure hash refreshes.
