### PR TITLE
fix(ui): let short Canvas previews fit their content

### DIFF
--- a/ui/src/pages/chat/components/widget-card.test.ts
+++ b/ui/src/pages/chat/components/widget-card.test.ts
@@ -58,7 +58,7 @@ describe("widget-card", () => {
     expect(host.querySelector("iframe")?.getAttribute("src")).toContain("/__openclaw__/cap/three/");
   });
 
-  it("keeps a reported frame height across a capability rotation", () => {
+  it("keeps a short reported frame height across a capability rotation", () => {
     const preview = {
       kind: "canvas",
       surface: "assistant_message",
@@ -79,11 +79,11 @@ describe("widget-card", () => {
     frame?.dispatchEvent(new Event("load"));
     window.dispatchEvent(
       new MessageEvent("message", {
-        data: { type: "openclaw:widget-size", height: 640 },
+        data: { type: "openclaw:widget-size", height: 48 },
         source: frame?.contentWindow,
       }),
     );
-    expect(frame?.style.height).toBe("640px");
+    expect(frame?.style.height).toBe("48px");
 
     // Re-render at the same URL so the style binding itself carries the
     // remembered height; only then can a later rotation clear it.
@@ -93,7 +93,7 @@ describe("widget-card", () => {
       }),
       host,
     );
-    expect(frame?.getAttribute("style")).toContain("640px");
+    expect(frame?.getAttribute("style")).toContain("48px");
 
     // The in-frame reporter only posts when its own height changes, so a
     // rotation that lost the remembered height would strand the frame at its
@@ -105,7 +105,7 @@ describe("widget-card", () => {
       host,
     );
     expect(host.querySelector("iframe")).toBe(frame);
-    expect(frame?.getAttribute("style")).toContain("640px");
+    expect(frame?.getAttribute("style")).toContain("48px");
     host.remove();
   });
 

--- a/ui/src/pages/chat/components/widget-card.ts
+++ b/ui/src/pages/chat/components/widget-card.ts
@@ -135,7 +135,7 @@ const WIDGET_SIZE_MESSAGE_TYPE = "openclaw:widget-size";
 const WIDGET_PROMPT_OFFER_MESSAGE_TYPE = "openclaw:widget-prompt-offer";
 const WIDGET_PROMPT_MESSAGE_TYPE = "openclaw:widget-prompt";
 const WIDGET_PROMPT_HOST_READY_MESSAGE_TYPE = "openclaw:widget-prompt-host-ready";
-const WIDGET_FRAME_MIN_HEIGHT = 160;
+const WIDGET_FRAME_MIN_HEIGHT = 48;
 const WIDGET_FRAME_MAX_HEIGHT = 1200;
 // Preview frames render inside lit shadow roots, so a document query cannot
 // find them; frames register themselves on load and are dropped once detached.


### PR DESCRIPTION
Closes #122272

## What Problem This Solves

Fixes an issue where short Canvas widgets in the Control UI transcript left a large empty area below their content because preview frames could not shrink below 160px.

## Why This Change Was Made

This PR lowers the existing measured-height floor to 48px. The frame still uses the widget document's reported height, preserves the 1200px safety ceiling, and retains its measured height when the Canvas capability URL rotates.

## User Impact

Compact Canvas widgets fit their content instead of reserving roughly 150px of blank space. Medium and tall widgets, dynamic resizing, multiple widgets, activity-group rendering, and narrow mobile layouts retain their existing behavior.

## Evidence

- Regression test: a widget reporting `48px` failed at `160px` before this change and passes at `48px` after it.
- Focused component suite: 8/8 passed.
- Canonical-render coverage: 1/1 passed, confirming the assistant widget remains a single render even when tool rows are visible.
- Stress matrix: 13/13 final Chromium scenarios passed against the production size reporter in populated transcripts. A single source-server readiness miss on the tall dark scenario did not reproduce: the focused scenario passed 5/5, then the complete matrix passed 13/13 without changing product code or timeouts.
- Theme-pair completion: 3/3 additional Chromium scenarios passed, adding dark coverage for medium and shrink plus light coverage for two independent widgets.
- Exact-head hosted CI: `openclaw/ci-gate` passed on `56d82382976a819799322b5cbc80dbd791d56868`.
- Final diff review and structured review completed without findings.

### Canvas fit stress matrix

Each context image shows the widget inside a populated chat transcript; each crop shows the measured card and relevant interaction state.

| Case | Expected | Observed | Screenshots |
| --- | --- | --- | --- |
| 1. Minimum (~48px) | The reported 48px document should no longer be floored to 160px. | Before: frame `160px`, card `233px`. In this PR: frame `48px`, card `121px`, in light and dark. | **Light**<br><a href="https://github.com/user-attachments/assets/9e4eadf9-7d99-436a-98c5-92324c214125"><img src="https://github.com/user-attachments/assets/9e4eadf9-7d99-436a-98c5-92324c214125" width="84" alt="Before light crop: minimum widget forced to 160 pixels"></a> <a href="https://github.com/user-attachments/assets/94b67e19-2e5c-49ba-97a6-8ac9c75cb5ba"><img src="https://github.com/user-attachments/assets/94b67e19-2e5c-49ba-97a6-8ac9c75cb5ba" width="120" alt="Before light context: minimum widget in populated chat"></a> <a href="https://github.com/user-attachments/assets/9bdb868b-3c7d-4125-9e4a-c80a4fe219f5"><img src="https://github.com/user-attachments/assets/9bdb868b-3c7d-4125-9e4a-c80a4fe219f5" width="84" alt="After light crop: minimum widget fitted to 48 pixels"></a> <a href="https://github.com/user-attachments/assets/7fb3015e-273d-4182-8105-ab08ada32efb"><img src="https://github.com/user-attachments/assets/7fb3015e-273d-4182-8105-ab08ada32efb" width="120" alt="After light context: fitted minimum widget in populated chat"></a><br>**Dark**<br><a href="https://github.com/user-attachments/assets/b4ac8f85-d62d-41a6-9258-d5c055d3ab0e"><img src="https://github.com/user-attachments/assets/b4ac8f85-d62d-41a6-9258-d5c055d3ab0e" width="84" alt="Before dark crop: minimum widget forced to 160 pixels"></a> <a href="https://github.com/user-attachments/assets/af1ec233-e870-45e4-836c-9f4c2a320c90"><img src="https://github.com/user-attachments/assets/af1ec233-e870-45e4-836c-9f4c2a320c90" width="120" alt="Before dark context: minimum widget in populated chat"></a> <a href="https://github.com/user-attachments/assets/f6c2e197-8559-4287-9a6d-23d7e3d191b3"><img src="https://github.com/user-attachments/assets/f6c2e197-8559-4287-9a6d-23d7e3d191b3" width="84" alt="After dark crop: minimum widget fitted to 48 pixels"></a> <a href="https://github.com/user-attachments/assets/be522793-c329-4ce4-8f86-67dfed5655b8"><img src="https://github.com/user-attachments/assets/be522793-c329-4ce4-8f86-67dfed5655b8" width="120" alt="After dark context: fitted minimum widget in populated chat"></a> |
| 2. Typical medium | A normal 320px report should keep its measured height. | Frame stayed exactly `320px`; content and surrounding transcript remained intact in light and dark. | **Light** <a href="https://github.com/user-attachments/assets/4d221256-4a53-499b-b85b-dbf25b6dd87d"><img src="https://github.com/user-attachments/assets/4d221256-4a53-499b-b85b-dbf25b6dd87d" width="110" alt="Light crop: typical 320 pixel Canvas widget"></a> <a href="https://github.com/user-attachments/assets/f9f91a79-288e-4f18-bf42-c75589d596c7"><img src="https://github.com/user-attachments/assets/f9f91a79-288e-4f18-bf42-c75589d596c7" width="150" alt="Light context: typical widget in populated chat"></a><br>**Dark** <a href="https://github.com/user-attachments/assets/6c0aa2de-9be5-4bc4-805d-6c625c816813"><img src="https://github.com/user-attachments/assets/6c0aa2de-9be5-4bc4-805d-6c625c816813" width="110" alt="Dark crop: typical 320 pixel Canvas widget"></a> <a href="https://github.com/user-attachments/assets/8ab54172-3eaf-457c-ae0b-c132bdb887db"><img src="https://github.com/user-attachments/assets/8ab54172-3eaf-457c-ae0b-c132bdb887db" width="150" alt="Dark context: typical widget in populated chat"></a> |
| 3. Tall / 1200px ceiling | A 1480px document should cap the host frame at 1200px and remain internally scrollable. | Outer frame was exactly `1200px`; inner viewport was `1198px` including the frame border, `scrollHeight > clientHeight`, and scrolling reached the final row. | **Light** <a href="https://github.com/user-attachments/assets/f825ae23-ccb6-4f9c-8a06-7e0784f44f72"><img src="https://github.com/user-attachments/assets/f825ae23-ccb6-4f9c-8a06-7e0784f44f72" width="84" alt="Light crop: bottom of tall internally scrolled widget"></a> <a href="https://github.com/user-attachments/assets/7b895a56-669a-489b-9442-ef03a323c29f"><img src="https://github.com/user-attachments/assets/7b895a56-669a-489b-9442-ef03a323c29f" width="120" alt="Light context: tall capped widget in chat"></a><br>**Dark** <a href="https://github.com/user-attachments/assets/4ab1cbec-f23f-46b1-8c13-a4abe447cbb4"><img src="https://github.com/user-attachments/assets/4ab1cbec-f23f-46b1-8c13-a4abe447cbb4" width="84" alt="Dark crop: bottom of tall internally scrolled widget"></a> <a href="https://github.com/user-attachments/assets/e50aa0d7-dfd8-42f4-93be-34d4c43b0de0"><img src="https://github.com/user-attachments/assets/e50aa0d7-dfd8-42f4-93be-34d4c43b0de0" width="120" alt="Dark context: tall capped widget in chat"></a> |
| 4. Dynamic growth after first render | A JS expansion should republish size and grow the same card from 80px to 360px without horizontal or transcript-coordinate drift. | Frame changed `80px -> 360px`; width and transcript coordinate stayed within `1px` in light and dark. | **Light** <a href="https://github.com/user-attachments/assets/3979eeea-ff98-475b-8add-0be14f04806d"><img src="https://github.com/user-attachments/assets/3979eeea-ff98-475b-8add-0be14f04806d" width="84" alt="Light crop: widget before dynamic growth"></a> <a href="https://github.com/user-attachments/assets/9dddd876-af54-4016-b6ac-4d5384bce0e6"><img src="https://github.com/user-attachments/assets/9dddd876-af54-4016-b6ac-4d5384bce0e6" width="84" alt="Light crop: widget after dynamic growth"></a> <a href="https://github.com/user-attachments/assets/ca990bcf-bc3f-4cc2-b4cc-ca382755a1ca"><img src="https://github.com/user-attachments/assets/ca990bcf-bc3f-4cc2-b4cc-ca382755a1ca" width="120" alt="Light context: dynamically expanded widget in chat"></a><br>**Dark** <a href="https://github.com/user-attachments/assets/65b91c38-d758-471d-a949-8c3e8e393f1a"><img src="https://github.com/user-attachments/assets/65b91c38-d758-471d-a949-8c3e8e393f1a" width="84" alt="Dark crop: widget before dynamic growth"></a> <a href="https://github.com/user-attachments/assets/d127be1d-0cc7-47af-881c-56427fd69fa2"><img src="https://github.com/user-attachments/assets/d127be1d-0cc7-47af-881c-56427fd69fa2" width="84" alt="Dark crop: widget after dynamic growth"></a> <a href="https://github.com/user-attachments/assets/cccf0525-eae6-4f7d-9702-08a15907eedb"><img src="https://github.com/user-attachments/assets/cccf0525-eae6-4f7d-9702-08a15907eedb" width="120" alt="Dark context: dynamically expanded widget in chat"></a> |
| 5. Dynamic shrink | A JS collapse should republish size and shrink the same card from 420px to 96px without coordinate drift. | Frame changed `420px -> 96px`; width and transcript coordinate stayed within `1px` in light and dark. | **Light** <a href="https://github.com/user-attachments/assets/f9368bc9-580a-4936-917f-96a655004bac"><img src="https://github.com/user-attachments/assets/f9368bc9-580a-4936-917f-96a655004bac" width="90" alt="Light crop: expanded widget before shrinking"></a> <a href="https://github.com/user-attachments/assets/539dce15-3a48-4a78-a890-b2fa1476742a"><img src="https://github.com/user-attachments/assets/539dce15-3a48-4a78-a890-b2fa1476742a" width="110" alt="Light crop: widget after shrinking"></a> <a href="https://github.com/user-attachments/assets/9048be15-6ea2-4910-804c-6e4b596f1962"><img src="https://github.com/user-attachments/assets/9048be15-6ea2-4910-804c-6e4b596f1962" width="150" alt="Light context: dynamically collapsed widget in populated chat"></a><br>**Dark** <a href="https://github.com/user-attachments/assets/457c29b0-4eb0-4606-933c-805e32b49e84"><img src="https://github.com/user-attachments/assets/457c29b0-4eb0-4606-933c-805e32b49e84" width="90" alt="Dark crop: expanded widget before shrinking"></a> <a href="https://github.com/user-attachments/assets/40d1ea8d-d8a9-4603-9cfb-9864ead86dfa"><img src="https://github.com/user-attachments/assets/40d1ea8d-d8a9-4603-9cfb-9864ead86dfa" width="110" alt="Dark crop: widget after shrinking"></a> <a href="https://github.com/user-attachments/assets/3318cd29-825a-4bbb-b7a3-03266c101d49"><img src="https://github.com/user-attachments/assets/3318cd29-825a-4bbb-b7a3-03266c101d49" width="150" alt="Dark context: dynamically collapsed widget in populated chat"></a> |
| 6. Two widgets / one transcript | Two documents with different reported heights should remain independent. | Exactly two frames rendered at `72px` and `280px`; neither height leaked into the other in light or dark. | **Light** <a href="https://github.com/user-attachments/assets/fa217a42-a1be-4008-8738-88bb1a2de73d"><img src="https://github.com/user-attachments/assets/fa217a42-a1be-4008-8738-88bb1a2de73d" width="110" alt="Light crop: two widgets with independent heights"></a> <a href="https://github.com/user-attachments/assets/3a92edde-7cb4-4b80-8497-7639e4a680b3"><img src="https://github.com/user-attachments/assets/3a92edde-7cb4-4b80-8497-7639e4a680b3" width="150" alt="Light context: two differently sized widgets in one transcript"></a><br>**Dark** <a href="https://github.com/user-attachments/assets/e6c6bbee-52a0-4209-8b7c-855a71941d9c"><img src="https://github.com/user-attachments/assets/e6c6bbee-52a0-4209-8b7c-855a71941d9c" width="110" alt="Dark crop: two widgets with independent heights"></a> <a href="https://github.com/user-attachments/assets/d81fb17d-b85b-4900-9189-dd71f835936e"><img src="https://github.com/user-attachments/assets/d81fb17d-b85b-4900-9189-dd71f835936e" width="150" alt="Dark context: two differently sized widgets in one transcript"></a> |
| 7. Expanded activity group / #110740 | Expanding the paired tool activity must not restore a `chat_tool` Canvas surface. | Exactly one iframe remained before and after expansion; the expanded activity body contained zero iframes, in light and dark. | **Light** <a href="https://github.com/user-attachments/assets/4c5c8a84-c7da-4136-9553-343e7d5fbf9a"><img src="https://github.com/user-attachments/assets/4c5c8a84-c7da-4136-9553-343e7d5fbf9a" width="130" alt="Light crop: single assistant widget next to expanded activity group"></a> <a href="https://github.com/user-attachments/assets/3a399035-1c09-4e0b-9277-a38a745ec6cb"><img src="https://github.com/user-attachments/assets/3a399035-1c09-4e0b-9277-a38a745ec6cb" width="150" alt="Light context: expanded activity group with one canonical widget"></a><br>**Dark** <a href="https://github.com/user-attachments/assets/9d0b0c16-85c0-439b-87cc-6872a5cbcab9"><img src="https://github.com/user-attachments/assets/9d0b0c16-85c0-439b-87cc-6872a5cbcab9" width="130" alt="Dark crop: single assistant widget next to expanded activity group"></a> <a href="https://github.com/user-attachments/assets/f8694353-7e47-43b8-90ec-be04dd26dea6"><img src="https://github.com/user-attachments/assets/f8694353-7e47-43b8-90ec-be04dd26dea6" width="150" alt="Dark context: expanded activity group with one canonical widget"></a> |
| 8. Narrow mobile viewport | At 390x844, the 180px widget should fit the lane with no document-level horizontal overflow. | Frame stayed `180px`, remained within the card width, and document `scrollWidth == clientWidth` in light and dark. | **Light** <a href="https://github.com/user-attachments/assets/a734b636-513b-4ff2-803d-ee796973b159"><img src="https://github.com/user-attachments/assets/a734b636-513b-4ff2-803d-ee796973b159" width="100" alt="Light crop: Canvas widget in narrow mobile lane"></a> <a href="https://github.com/user-attachments/assets/6dbca54b-f186-48a3-a0a9-d343ea494c86"><img src="https://github.com/user-attachments/assets/6dbca54b-f186-48a3-a0a9-d343ea494c86" width="100" alt="Light context: populated mobile chat with Canvas widget"></a><br>**Dark** <a href="https://github.com/user-attachments/assets/bd66b9ca-e0c3-4f4b-bbe4-c5c499e38d20"><img src="https://github.com/user-attachments/assets/bd66b9ca-e0c3-4f4b-bbe4-c5c499e38d20" width="100" alt="Dark crop: Canvas widget in narrow mobile lane"></a> <a href="https://github.com/user-attachments/assets/694e6f1c-a6ad-4ed7-9b2e-3eb4791c94d3"><img src="https://github.com/user-attachments/assets/694e6f1c-a6ad-4ed7-9b2e-3eb4791c94d3" width="100" alt="Dark context: populated mobile chat with Canvas widget"></a> |
