### PR TITLE
fix(ui): keep composer capability menus within the viewport

### DIFF
--- a/ui/src/e2e/chat-composer-capability-menu-height.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-capability-menu-height.e2e.test.ts
@@ -202,22 +202,70 @@ suite.define(() => {
       const layouts = [await inspectView("skills")];
 
       const back = dropdown.locator('[value="back"]');
-      await back.focus();
-      await back.press("End");
-      await expect
-        .poll(() =>
-          dropdown.evaluate((node) => {
-            const menu = node.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
-            const active = document.activeElement;
-            if (!menu || !(active instanceof HTMLElement)) {
-              return false;
-            }
-            const menuRect = menu.getBoundingClientRect();
-            const activeRect = active.getBoundingClientRect();
-            return activeRect.top >= menuRect.top && activeRect.bottom <= menuRect.bottom;
-          }),
-        )
-        .toBe(true);
+      const interactionTarget = dropdown.locator('[value="skill:19"]');
+      const captureInteraction = async (state: "focus" | "hover", theme: "dark" | "light") => {
+        await page.evaluate((mode) => {
+          document.documentElement.dataset.themeMode = mode;
+        }, theme);
+        await interactionTarget.scrollIntoViewIfNeeded();
+
+        if (state === "hover") {
+          await interactionTarget.hover();
+          await expect
+            .poll(() => interactionTarget.evaluate((node) => node.matches(":hover")))
+            .toBe(true);
+        } else {
+          await back.focus();
+          await page.keyboard.press("Home");
+          for (let index = 0; index < 20; index += 1) {
+            await page.keyboard.press("ArrowDown");
+          }
+          await page.mouse.move(900, 500);
+          await expect
+            .poll(() =>
+              interactionTarget.evaluate(
+                (node) => document.activeElement === node && node.matches(":focus-visible"),
+              ),
+            )
+            .toBe(true);
+        }
+
+        await expect
+          .poll(() =>
+            dropdown.evaluate((node, target) => {
+              const menu = node.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
+              const backRow = node.querySelector<HTMLElement>('[value="back"]');
+              const targetRow = node.querySelector<HTMLElement>(target);
+              if (!menu || !backRow || !targetRow) {
+                return false;
+              }
+              const menuRect = menu.getBoundingClientRect();
+              const backRect = backRow.getBoundingClientRect();
+              const targetRect = targetRow.getBoundingClientRect();
+              return (
+                menu.scrollTop > 0 &&
+                menu.scrollHeight > menu.clientHeight &&
+                backRect.top >= menuRect.top &&
+                backRect.bottom <= menuRect.bottom &&
+                targetRect.top >= menuRect.top &&
+                targetRect.bottom <= menuRect.bottom
+              );
+            }, '[value="skill:19"]'),
+          )
+          .toBe(true);
+
+        if (artifactDir && captureStage === "after") {
+          await page.waitForTimeout(50);
+          await page.screenshot({
+            path: path.join(artifactDir, `skill-20-${state}-${theme}-after.png`),
+          });
+        }
+      };
+
+      await captureInteraction("hover", "dark");
+      await captureInteraction("hover", "light");
+      await captureInteraction("focus", "dark");
+      await captureInteraction("focus", "light");
 
       await back.click();
       await dropdown.locator('[value="open-connectors"]').click();

--- a/ui/src/e2e/chat-composer-capability-menu-height.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-capability-menu-height.e2e.test.ts
@@ -254,6 +254,24 @@ suite.define(() => {
           )
           .toBe(true);
 
+        await expect
+          .poll(() =>
+            interactionTarget.evaluate((node) => {
+              const probe = document.createElement("div");
+              probe.style.backgroundColor = "var(--bg-hover)";
+              probe.style.color = "var(--text)";
+              document.body.append(probe);
+              const rowStyle = getComputedStyle(node);
+              const probeStyle = getComputedStyle(probe);
+              const matches =
+                rowStyle.backgroundColor === probeStyle.backgroundColor &&
+                rowStyle.color === probeStyle.color;
+              probe.remove();
+              return matches;
+            }),
+          )
+          .toBe(true);
+
         if (artifactDir && captureStage === "after") {
           await page.waitForTimeout(50);
           await page.screenshot({

--- a/ui/src/e2e/chat-composer-capability-menu-height.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-capability-menu-height.e2e.test.ts
@@ -1,0 +1,220 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  browserLaunchOptions: { ignoreDefaultArgs: ["--hide-scrollbars"] },
+  name: "Control UI composer capability menu height",
+});
+
+function skill(index: number) {
+  const name = `Skill ${String(index).padStart(2, "0")}`;
+  return {
+    name,
+    description: `${name} skill`,
+    source: "test",
+    filePath: `/tmp/openclaw-e2e/skills/${name}/SKILL.md`,
+    baseDir: `/tmp/openclaw-e2e/skills/${name}`,
+    skillKey: name.toLowerCase().replaceAll(" ", "-"),
+    always: false,
+    disabled: false,
+    blockedByAllowlist: false,
+    eligible: true,
+    requirements: { anyBins: [], bins: [], env: [], config: [], os: [] },
+    missing: { anyBins: [], bins: [], env: [], config: [], os: [] },
+    configChecks: [],
+    install: [],
+  };
+}
+
+function sessionsList() {
+  return {
+    count: 1,
+    defaults: { contextTokens: 200_000, model: "gpt-5.5", modelProvider: "openai" },
+    path: "",
+    sessions: [
+      {
+        key: "main",
+        kind: "direct",
+        model: "gpt-5.5",
+        modelProvider: "openai",
+        status: "done",
+        updatedAt: Date.now(),
+      },
+    ],
+    ts: Date.now(),
+  };
+}
+
+function configResponse() {
+  const servers = Object.fromEntries(
+    Array.from({ length: 24 }, (_, index) => [
+      `connector-${String(index).padStart(2, "0")}`,
+      { enabled: true, url: `https://connector-${index}.example.test` },
+    ]),
+  );
+  const config = { mcp: { servers }, tools: { web: { search: { enabled: false } } } };
+  return {
+    raw: JSON.stringify(config),
+    hash: "capability-menu-height-config",
+    sourceConfig: config,
+    runtimeConfig: config,
+    config,
+  };
+}
+
+suite.define(() => {
+  it("constrains long capability views and keeps keyboard focus visible", async () => {
+    await suite.withPage({ viewport: { width: 1280, height: 720 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "config.get": configResponse(),
+          "sessions.list": sessionsList(),
+          "skills.status": {
+            workspaceDir: "/tmp/openclaw-e2e/workspace",
+            managedSkillsDir: "/tmp/openclaw-e2e/skills",
+            skills: Array.from({ length: 36 }, (_, index) => skill(index + 1)),
+          },
+        },
+      });
+
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      const composer = page.locator(".agent-chat__input");
+      await expect.poll(() => composer.isVisible()).toBe(true);
+      const dropdown = composer.locator("wa-dropdown.agent-chat__capability-menu");
+      const attach = composer.locator("button.agent-chat__input-btn--attach");
+      await expect.poll(() => attach.isVisible()).toBe(true);
+      await attach.click();
+      await dropdown.locator('[value="open-skills"]').click();
+      await expect.poll(() => dropdown.getAttribute("data-view")).toBe("skills");
+
+      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const captureStage = process.env.OPENCLAW_UI_E2E_CAPTURE_STAGE?.trim();
+      const capture = async (theme: "dark" | "light") => {
+        if (!artifactDir) {
+          return;
+        }
+        await fs.mkdir(artifactDir, { recursive: true });
+        await page.evaluate((mode) => {
+          document.documentElement.dataset.themeMode = mode;
+        }, theme);
+        await page.waitForTimeout(50);
+        if (captureStage === "after") {
+          const menuCenter = await dropdown.evaluate((node) => {
+            const menu = node.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
+            if (!menu) {
+              throw new Error("expected capability menu bounds");
+            }
+            const rect = menu.getBoundingClientRect();
+            return { x: rect.right - 8, y: rect.top + rect.height / 2 };
+          });
+          await page.mouse.move(menuCenter.x, menuCenter.y);
+          await page.mouse.wheel(0, 1);
+        }
+        const clip = await dropdown.evaluate((node) => {
+          const menu = node.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
+          const composerElement = node.closest<HTMLElement>(".agent-chat__input");
+          if (!menu || !composerElement) {
+            throw new Error("expected capability menu and composer bounds");
+          }
+          const menuRect = menu.getBoundingClientRect();
+          const composerRect = composerElement.getBoundingClientRect();
+          return {
+            x: Math.max(0, Math.min(menuRect.left, composerRect.left) - 20),
+            y: Math.max(0, menuRect.top - 20),
+            width:
+              Math.max(menuRect.right, composerRect.right) -
+              Math.min(menuRect.left, composerRect.left) +
+              40,
+            height: Math.max(menuRect.bottom, composerRect.bottom) - menuRect.top + 40,
+          };
+        });
+        await page.screenshot({
+          path: path.join(artifactDir, `${theme}-${captureStage}.png`),
+          clip,
+        });
+      };
+
+      if (captureStage === "before") {
+        await capture("dark");
+        await capture("light");
+      }
+
+      const layout = await dropdown.evaluate((node) => {
+        const menu = node.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
+        const composerElement = node.closest<HTMLElement>(".agent-chat__input");
+        const back = node.querySelector<HTMLElement>('[value="back"]');
+        if (!menu || !composerElement || !back) {
+          throw new Error("expected capability menu layout");
+        }
+        menu.scrollTop = Math.floor((menu.scrollHeight - menu.clientHeight) / 2);
+        const menuRect = menu.getBoundingClientRect();
+        const backRect = back.getBoundingClientRect();
+        const style = getComputedStyle(menu);
+        return {
+          backOffset: backRect.top - menuRect.top,
+          clientHeight: menu.clientHeight,
+          maxHeight: Number.parseFloat(style.maxHeight),
+          overscrollY: style.overscrollBehaviorY,
+          scrollHeight: menu.scrollHeight,
+          scrollTop: menu.scrollTop,
+          token: Number.parseFloat(
+            getComputedStyle(composerElement).getPropertyValue(
+              "--chat-composer-popover-max-height",
+            ),
+          ),
+        };
+      });
+      expect(layout.scrollHeight).toBeGreaterThan(layout.clientHeight);
+      expect(layout.scrollTop).toBeGreaterThan(0);
+      expect(layout.maxHeight).toBeLessThanOrEqual(layout.token + 1);
+      expect(layout.overscrollY).toBe("contain");
+      expect(layout.backOffset).toBeGreaterThanOrEqual(0);
+      expect(layout.backOffset).toBeLessThanOrEqual(1);
+
+      const back = dropdown.locator('[value="back"]');
+      await back.focus();
+      await back.press("End");
+      await expect
+        .poll(() =>
+          dropdown.evaluate((node) => {
+            const menu = node.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
+            const active = document.activeElement;
+            if (!menu || !(active instanceof HTMLElement)) {
+              return false;
+            }
+            const menuRect = menu.getBoundingClientRect();
+            const activeRect = active.getBoundingClientRect();
+            return activeRect.top >= menuRect.top && activeRect.bottom <= menuRect.bottom;
+          }),
+        )
+        .toBe(true);
+
+      await back.click();
+      await dropdown.locator('[value="open-connectors"]').click();
+      await expect.poll(() => dropdown.getAttribute("data-view")).toBe("connectors");
+      expect(
+        await dropdown.evaluate((node) => {
+          const menu = node.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
+          return Boolean(menu && menu.scrollHeight > menu.clientHeight);
+        }),
+      ).toBe(true);
+
+      await dropdown.locator('[value="back"]').click();
+      await dropdown.locator('[value="open-skills"]').click();
+      await dropdown.evaluate((node) => {
+        const menu = node.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
+        if (menu) {
+          menu.scrollTop = Math.floor((menu.scrollHeight - menu.clientHeight) / 2);
+        }
+      });
+      if (captureStage === "after") {
+        await capture("dark");
+        await capture("light");
+      }
+    });
+  });
+});

--- a/ui/src/e2e/chat-composer-capability-menu-height.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-capability-menu-height.e2e.test.ts
@@ -65,10 +65,59 @@ function configResponse() {
   };
 }
 
+function toolsEffectiveResponse() {
+  return {
+    agentId: "main",
+    profile: "full",
+    groups: [
+      {
+        id: "mcp",
+        label: "MCP",
+        source: "mcp",
+        tools: Array.from({ length: 28 }, (_, index) => {
+          const number = String(index + 1).padStart(2, "0");
+          return {
+            id: `mcp_connector_00_tool_${number}`,
+            label: `Project tool ${number}`,
+            description: `Operate on project resource ${number}`,
+            rawDescription: `Operate on project resource ${number}`,
+            source: "mcp",
+            mcpServer: "connector-00",
+            mcpToolName: `project-tool-${number}`,
+          };
+        }),
+      },
+    ],
+  };
+}
+
 suite.define(() => {
-  it("constrains long capability views and keeps keyboard focus visible", async () => {
-    await suite.withPage({ viewport: { width: 1280, height: 720 } }, async ({ page }) => {
+  it("caps every long capability view at 420px and keeps keyboard focus visible", async () => {
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
       const gateway = await installMockGateway(page, {
+        featureMethods: ["chat.metadata", "chat.startup", "sessions.patch", "tools.effective"],
+        historyMessages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: "Review the release dashboard and flag anything that needs attention.",
+              },
+            ],
+            timestamp: Date.now() - 60_000,
+          },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "text",
+                text: "The rollout is healthy. I found two follow-ups:\n\n- Confirm the mobile smoke lane\n- Review the connector permission changes",
+              },
+            ],
+            timestamp: Date.now() - 30_000,
+          },
+        ],
         methodResponses: {
           "config.get": configResponse(),
           "sessions.list": sessionsList(),
@@ -77,6 +126,7 @@ suite.define(() => {
             managedSkillsDir: "/tmp/openclaw-e2e/skills",
             skills: Array.from({ length: 36 }, (_, index) => skill(index + 1)),
           },
+          "tools.effective": toolsEffectiveResponse(),
         },
       });
 
@@ -93,8 +143,8 @@ suite.define(() => {
 
       const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
       const captureStage = process.env.OPENCLAW_UI_E2E_CAPTURE_STAGE?.trim();
-      const capture = async (theme: "dark" | "light") => {
-        if (!artifactDir) {
+      const capture = async (view: string, theme: "dark" | "light") => {
+        if (!artifactDir || !captureStage) {
           return;
         }
         await fs.mkdir(artifactDir, { recursive: true });
@@ -102,60 +152,54 @@ suite.define(() => {
           document.documentElement.dataset.themeMode = mode;
         }, theme);
         await page.waitForTimeout(50);
-        if (captureStage === "after") {
-          const menuCenter = await dropdown.evaluate((node) => {
-            const menu = node.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
-            if (!menu) {
-              throw new Error("expected capability menu bounds");
-            }
-            const rect = menu.getBoundingClientRect();
-            return { x: rect.right - 8, y: rect.top + rect.height / 2 };
-          });
-          await page.mouse.move(menuCenter.x, menuCenter.y);
-          await page.mouse.wheel(0, 1);
-        }
-        await page.screenshot({ path: path.join(artifactDir, `${theme}-${captureStage}.png`) });
+        const menuCenter = await dropdown.evaluate((node) => {
+          const menu = node.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
+          if (!menu) {
+            throw new Error("expected capability menu bounds");
+          }
+          const rect = menu.getBoundingClientRect();
+          return { x: rect.right - 8, y: rect.top + rect.height / 2 };
+        });
+        await page.mouse.move(menuCenter.x, menuCenter.y);
+        await page.mouse.wheel(0, 1);
+        await page.screenshot({
+          path: path.join(artifactDir, `${view}-${theme}-${captureStage}.png`),
+        });
       };
 
-      if (captureStage === "before") {
-        await capture("dark");
-        await capture("light");
-      }
-
-      const layout = await dropdown.evaluate((node) => {
-        const menu = node.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
-        const composerElement = node.closest<HTMLElement>(".agent-chat__input");
-        const back = node.querySelector<HTMLElement>('[value="back"]');
-        if (!menu || !composerElement || !back) {
-          throw new Error("expected capability menu layout");
-        }
-        menu.scrollTop = Math.floor((menu.scrollHeight - menu.clientHeight) / 2);
-        const menuRect = menu.getBoundingClientRect();
-        const backRect = back.getBoundingClientRect();
-        const style = getComputedStyle(menu);
-        return {
-          backOffset: backRect.top - menuRect.top,
-          clientHeight: menu.clientHeight,
-          maxHeight: Number.parseFloat(style.maxHeight),
-          overscrollY: style.overscrollBehaviorY,
-          scrollHeight: menu.scrollHeight,
-          scrollTop: menu.scrollTop,
-          token: Number.parseFloat(
-            getComputedStyle(composerElement).getPropertyValue(
-              "--chat-composer-popover-max-height",
+      const inspectView = async (view: string) => {
+        const layout = await dropdown.evaluate((node) => {
+          const menu = node.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
+          const composerElement = node.closest<HTMLElement>(".agent-chat__input");
+          const back = node.querySelector<HTMLElement>('[value="back"]');
+          if (!menu || !composerElement || !back) {
+            throw new Error("expected capability menu layout");
+          }
+          menu.scrollTop = Math.floor((menu.scrollHeight - menu.clientHeight) / 2);
+          const menuRect = menu.getBoundingClientRect();
+          const backRect = back.getBoundingClientRect();
+          const style = getComputedStyle(menu);
+          return {
+            backOffset: backRect.top - menuRect.top,
+            clientHeight: menu.clientHeight,
+            maxHeight: Number.parseFloat(style.maxHeight),
+            overscrollY: style.overscrollBehaviorY,
+            scrollHeight: menu.scrollHeight,
+            scrollTop: menu.scrollTop,
+            token: Number.parseFloat(
+              getComputedStyle(composerElement).getPropertyValue(
+                "--chat-composer-popover-max-height",
+              ),
             ),
-          ),
-          viewportHeight: window.innerHeight,
-        };
-      });
-      const compactHeightCap = Math.min(layout.token, 420, layout.viewportHeight * 0.5);
-      expect(layout.scrollHeight).toBeGreaterThan(layout.clientHeight);
-      expect(layout.scrollTop).toBeGreaterThan(0);
-      expect(layout.maxHeight).toBeLessThanOrEqual(compactHeightCap + 1);
-      expect(layout.clientHeight).toBeLessThanOrEqual(compactHeightCap + 1);
-      expect(layout.overscrollY).toBe("contain");
-      expect(layout.backOffset).toBeGreaterThanOrEqual(0);
-      expect(layout.backOffset).toBeLessThanOrEqual(1);
+            viewportHeight: window.innerHeight,
+          };
+        });
+        await capture(view, "dark");
+        await capture(view, "light");
+        return { ...layout, view };
+      };
+
+      const layouts = [await inspectView("skills")];
 
       const back = dropdown.locator('[value="back"]');
       await back.focus();
@@ -178,24 +222,31 @@ suite.define(() => {
       await back.click();
       await dropdown.locator('[value="open-connectors"]').click();
       await expect.poll(() => dropdown.getAttribute("data-view")).toBe("connectors");
-      expect(
-        await dropdown.evaluate((node) => {
-          const menu = node.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
-          return Boolean(menu && menu.scrollHeight > menu.clientHeight);
-        }),
-      ).toBe(true);
+      layouts.push(await inspectView("connectors"));
 
-      await dropdown.locator('[value="back"]').click();
-      await dropdown.locator('[value="open-skills"]').click();
-      await dropdown.evaluate((node) => {
-        const menu = node.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
-        if (menu) {
-          menu.scrollTop = Math.floor((menu.scrollHeight - menu.clientHeight) / 2);
-        }
-      });
-      if (captureStage === "after") {
-        await capture("dark");
-        await capture("light");
+      await dropdown.locator('[value="tools:0"]').click();
+      await expect.poll(() => dropdown.getAttribute("data-view")).toBe("tools:connector-00");
+      await expect.poll(() => dropdown.getByText("28 of 28 tools on").isVisible()).toBe(true);
+      layouts.push(await inspectView("tool-access"));
+
+      if (artifactDir && captureStage) {
+        await fs.writeFile(
+          path.join(artifactDir, `${captureStage}-layout.json`),
+          `${JSON.stringify(layouts, null, 2)}\n`,
+        );
+      }
+
+      for (const layout of layouts) {
+        const compactHeightCap = Math.min(layout.token, 420, layout.viewportHeight * 0.5);
+        expect(compactHeightCap).toBe(420);
+        expect(layout.scrollHeight).toBeGreaterThan(layout.clientHeight);
+        expect(layout.scrollTop).toBeGreaterThan(0);
+        expect(layout.maxHeight).toBeGreaterThanOrEqual(compactHeightCap - 1);
+        expect(layout.maxHeight).toBeLessThanOrEqual(compactHeightCap + 1);
+        expect(layout.clientHeight).toBeLessThanOrEqual(compactHeightCap + 1);
+        expect(layout.overscrollY).toBe("contain");
+        expect(layout.backOffset).toBeGreaterThanOrEqual(0);
+        expect(layout.backOffset).toBeLessThanOrEqual(1);
       }
     });
   });

--- a/ui/src/e2e/chat-composer-capability-menu-height.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-capability-menu-height.e2e.test.ts
@@ -114,28 +114,7 @@ suite.define(() => {
           await page.mouse.move(menuCenter.x, menuCenter.y);
           await page.mouse.wheel(0, 1);
         }
-        const clip = await dropdown.evaluate((node) => {
-          const menu = node.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
-          const composerElement = node.closest<HTMLElement>(".agent-chat__input");
-          if (!menu || !composerElement) {
-            throw new Error("expected capability menu and composer bounds");
-          }
-          const menuRect = menu.getBoundingClientRect();
-          const composerRect = composerElement.getBoundingClientRect();
-          return {
-            x: Math.max(0, Math.min(menuRect.left, composerRect.left) - 20),
-            y: Math.max(0, menuRect.top - 20),
-            width:
-              Math.max(menuRect.right, composerRect.right) -
-              Math.min(menuRect.left, composerRect.left) +
-              40,
-            height: Math.max(menuRect.bottom, composerRect.bottom) - menuRect.top + 40,
-          };
-        });
-        await page.screenshot({
-          path: path.join(artifactDir, `${theme}-${captureStage}.png`),
-          clip,
-        });
+        await page.screenshot({ path: path.join(artifactDir, `${theme}-${captureStage}.png`) });
       };
 
       if (captureStage === "before") {
@@ -166,11 +145,14 @@ suite.define(() => {
               "--chat-composer-popover-max-height",
             ),
           ),
+          viewportHeight: window.innerHeight,
         };
       });
+      const compactHeightCap = Math.min(layout.token, 420, layout.viewportHeight * 0.5);
       expect(layout.scrollHeight).toBeGreaterThan(layout.clientHeight);
       expect(layout.scrollTop).toBeGreaterThan(0);
-      expect(layout.maxHeight).toBeLessThanOrEqual(layout.token + 1);
+      expect(layout.maxHeight).toBeLessThanOrEqual(compactHeightCap + 1);
+      expect(layout.clientHeight).toBeLessThanOrEqual(compactHeightCap + 1);
       expect(layout.overscrollY).toBe("contain");
       expect(layout.backOffset).toBeGreaterThanOrEqual(0);
       expect(layout.backOffset).toBeLessThanOrEqual(1);

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2769,6 +2769,11 @@ openclaw-chat-video-player {
   border-radius: 999px;
 }
 
+.agent-chat__capability-menu-item {
+  --wa-color-neutral-fill-normal: var(--bg-hover);
+  --wa-color-text-normal: var(--text);
+}
+
 .agent-chat__capability-menu-item,
 .agent-chat__capability-menu-state {
   color: var(--text);

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2736,9 +2736,33 @@ openclaw-chat-video-player {
 }
 
 .agent-chat__capability-menu::part(menu) {
+  /* Web Awesome owns this menu's important max-height rule. Feed that rule the
+     composer viewport budget so every nested view keeps the same top gutter. */
+  --auto-size-available-height: var(--chat-composer-popover-max-height, calc(100dvh - 116px));
   width: 292px;
   min-width: 292px;
   max-width: min(292px, calc(100vw - 24px));
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
+  scrollbar-color: var(--muted-strong) transparent;
+}
+
+.agent-chat__capability-menu-item[value="back"] {
+  position: sticky;
+  top: calc(-1 * var(--menu-padding));
+  z-index: 1;
+  background: var(--bg-elevated);
+}
+
+.agent-chat__capability-menu::part(menu)::-webkit-scrollbar {
+  width: 6px;
+}
+
+.agent-chat__capability-menu::part(menu)::-webkit-scrollbar-thumb {
+  background: var(--muted-strong);
+  border-radius: 999px;
 }
 
 .agent-chat__capability-menu-item,

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2736,9 +2736,13 @@ openclaw-chat-video-player {
 }
 
 .agent-chat__capability-menu::part(menu) {
-  /* Web Awesome owns this menu's important max-height rule. Feed that rule the
-     composer viewport budget so every nested view keeps the same top gutter. */
-  --auto-size-available-height: var(--chat-composer-popover-max-height, calc(100dvh - 116px));
+  /* Web Awesome owns this menu's important max-height rule. Keep capability
+     views compact while respecting the composer's live viewport budget. */
+  --auto-size-available-height: min(
+    420px,
+    50dvh,
+    var(--chat-composer-popover-max-height, calc(100dvh - 116px))
+  );
   width: 292px;
   min-width: 292px;
   max-width: min(292px, calc(100vw - 24px));


### PR DESCRIPTION
Closes #122262

## What Problem This Solves

Fixes an issue where users with many installed skills, configured connectors, or discovered connector tools could open a composer capability submenu that grew nearly to the full viewport and read like a page-sized panel instead of a dropdown.

## Why This Change Was Made

This PR gives the shared capability menu one compact height budget: the smallest of 420px, 50% of the viewport height, and the live space available above the composer. Overflow and overscroll stay inside the menu, while the Back row remains sticky. Skills, Connectors, and per-connector Tool access use the same owner-level behavior without per-view branches. Web Awesome's existing keyboard navigation and focused-item scrolling remain unchanged.

## User Impact

Long `+` menu subviews remain compact, expose an in-panel scrollbar, retain Back at the top, and keep pointer-hovered or keyboard-focused rows visible. At the 1280×900 evidence viewport, each rich state is capped at exactly 420px instead of growing to 787px. The short root menu is unchanged.

## Evidence

AWS Crabbox run [run_e6c2281caa81](https://crabbox.openclaw.ai/portal/runs/run_e6c2281caa81) used a clean merge of the production change against `origin/main@93f5e0f1f68a3af83c5fb53f68c39af495b98f38` for the red→green layout matrix. The final interaction-state and dark-contrast harness was rerun on AWS in [run_1abd4a7a2734](https://crabbox.openclaw.ai/portal/runs/run_1abd4a7a2734); its applied patch is now committed byte-for-byte as final PR head `676bb8e3c773cc71ed3a7e9301a8a6e939ae9925`. The same 1280×900 canvas and populated transcript were used throughout.

### Skills — 36 rows

| Theme | Before — 787px, Back scrolls away | Proposed in this PR — 420px, internal scroll + sticky Back |
| --- | --- | --- |
| Light | ![Light Skills menu before: the long list occupies nearly the full chat height and Back is outside the visible scrolled area](https://github.com/user-attachments/assets/2922cd97-f72e-4aaf-9c0a-7f8fafacef76) | ![Light Skills menu proposed: the list is capped at 420px with an internal scrollbar and sticky Back row](https://github.com/user-attachments/assets/90af9361-bbb8-4a29-9798-9430a420eb9c) |
| Dark | ![Dark Skills menu before: the long list occupies nearly the full chat height and Back is outside the visible scrolled area](https://github.com/user-attachments/assets/3268e8df-7e0e-4e79-b7f3-df4cd0067de0) | ![Dark Skills menu proposed: the list is capped at 420px with an internal scrollbar and sticky Back row](https://github.com/user-attachments/assets/cff859e4-4d4e-4fdd-833f-cd51ac10a7de) |

### Connectors — 24 rows

| Theme | Before — 787px, Back scrolls away | Proposed in this PR — 420px, internal scroll + sticky Back |
| --- | --- | --- |
| Light | ![Light Connectors menu before: the connector list expands through nearly the full chat height](https://github.com/user-attachments/assets/72c50614-0259-4308-be17-45f2d6fa539e) | ![Light Connectors menu proposed: the connector list is capped at 420px with visible transcript context and sticky Back](https://github.com/user-attachments/assets/5fa7b858-410a-471c-8b74-b0b85ff8a55b) |
| Dark | ![Dark Connectors menu before: the connector list expands through nearly the full chat height](https://github.com/user-attachments/assets/ae16f050-2570-4a45-8529-6abbeadb8f1e) | ![Dark Connectors menu proposed: the connector list is capped at 420px with visible transcript context and sticky Back](https://github.com/user-attachments/assets/79848bd6-e2ef-4698-8156-c14e53005527) |

### Tool access — 28 rows

| Theme | Before — 787px, Back scrolls away | Proposed in this PR — 420px, internal scroll + sticky Back |
| --- | --- | --- |
| Light | ![Light Tool access menu before: the discovered tool list grows through nearly the full chat height](https://github.com/user-attachments/assets/c34c3ad2-3744-4eec-8136-5244ce88ed42) | ![Light Tool access menu proposed: the tool list is capped at 420px with internal scrolling and sticky Back](https://github.com/user-attachments/assets/fb30432c-8dab-4d03-b220-faa56046ea99) |
| Dark | ![Dark Tool access menu before: the discovered tool list grows through nearly the full chat height](https://github.com/user-attachments/assets/1c6f61a8-6bb1-4182-857d-995478144fcd) | ![Dark Tool access menu proposed: the tool list is capped at 420px with internal scrolling and sticky Back](https://github.com/user-attachments/assets/b8297803-3070-49f5-a93b-9d935933cad3) |

### Hover and keyboard focus — the same Skill 20 row

| Theme | Pointer hover | Keyboard focus via Home + 20× ArrowDown |
| --- | --- | --- |
| Light | ![Light menu with Skill 20 visibly hovered, internal scrollbar active, and Back visible](https://github.com/user-attachments/assets/c9369bbf-04a1-4eb9-a6df-e15f22b7de1e) | ![Light menu with Skill 20 visibly keyboard-focused by a red focus ring, internal scrollbar active, and Back visible](https://github.com/user-attachments/assets/7b2b49f7-044a-43f0-9351-feaa6c32b825) |
| Dark | ![Dark menu with Skill 20 visibly hovered, internal scrollbar active, and Back visible](https://github.com/user-attachments/assets/590e7d91-6931-4c3b-9844-efb348704b33) | ![Dark menu with Skill 20 visibly keyboard-focused by a red focus ring, internal scrollbar active, and Back visible](https://github.com/user-attachments/assets/157a2bd1-f777-4523-bab9-633dddf6b6f5) |

The dedicated interaction proof asserts real `:hover` for the pointer state. For keyboard focus it sends Home followed by 20 ArrowDown key presses, then asserts that Skill 20 is both `document.activeElement` and `:focus-visible`. Every capture also requires internal overflow, nonzero scroll, visible Back, and a fully visible target row.

The dark-state contrast regression was reproduced on AWS in [run_e3f6a942674a](https://crabbox.openclaw.ai/portal/runs/run_e3f6a942674a): Web Awesome resolved the active fill to `rgba(228, 229, 233, 0.345)` while the Control UI dark hover surface was `rgb(31, 35, 48)`. This PR now scopes Web Awesome’s normal active-fill and text tokens to `--bg-hover` and `--text` for every capability-menu item. [run_1abd4a7a2734](https://crabbox.openclaw.ai/portal/runs/run_1abd4a7a2734) passed after waiting for the transition to settle and asserting both computed foreground and background against those owner tokens.

### Red → green measurements

| State | Before from current main CSS | Proposed in this PR |
| --- | --- | --- |
| Skills | max 787px; client 785px; overscroll `auto`; Back offset −181px | max 420px; client 418px; overscroll `contain`; Back offset 1px |
| Connectors | max 787px; client 785px; overscroll `auto`; Back offset −506px | max 420px; client 418px; overscroll `contain`; Back offset 1px |
| Tool access | max 787px; client 785px; overscroll `auto`; Back offset −251px | max 420px; client 418px; overscroll `contain`; Back offset 1px |

The baseline run failed the new `<=421px` observable-layout assertion in all three states. Restoring this PR's CSS made the same scenario pass, including internal overflow, contained overscroll, sticky Back, keyboard-focus visibility, and pointer-hover visibility.

Exact remote browser command:

```sh
OPENCLAW_UI_E2E_ARTIFACT_DIR=.artifacts/pr122296 \
OPENCLAW_UI_E2E_CAPTURE_STAGE=<before|after> \
node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.ui-e2e.config.ts \
  --configLoader runner \
  ui/src/e2e/chat-composer-capability-menu-height.e2e.test.ts
```

Remote validation also passed:

```sh
corepack pnpm exec oxfmt --check \
  ui/src/e2e/chat-composer-capability-menu-height.e2e.test.ts \
  ui/src/styles/chat/layout.css
corepack pnpm exec stylelint --config config/stylelint.config.mjs \
  ui/src/styles/chat/layout.css
```

Dependency contract checked directly against pinned `@awesome.me/webawesome@3.10.0`: its popup middleware writes `--auto-size-available-height`, its menu consumes that value as `max-height`, and its keyboard path scrolls focused items into view. This PR narrows that shared available-height token rather than replacing dependency behavior.

Production delta: +33 CSS lines. Tests: +319 E2E lines. The production change remains one shared viewport cap, contained internal scrolling, cross-browser scrollbar treatment, and sticky Back row; no new capability logic or per-submenu branches were added.