### PR TITLE
fix(ui): fit chat table cards to their columns

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -2056,6 +2056,47 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
   );
 
   it.each(["dark", "light"] as const)(
+    "fits short table cards to their columns in %s mode",
+    async (themeMode) => {
+      const page = await openBrowserPage(800, 400);
+      try {
+        await page.setContent(
+          `<!doctype html><html data-theme-mode="${themeMode}"><head><style>${readUiCss()}</style></head><body>
+            <div class="chat-text">
+              <div data-table-lane style="width: 680px">
+                <table data-short-table><thead><tr><th>Name</th><th>Status</th></tr></thead><tbody><tr><td>Gateway</td><td>Ready</td></tr></tbody></table>
+              </div>
+              <div data-narrow-table-lane style="width: 160px">
+                <table data-narrow-table><thead><tr><th>Name</th><th>Status</th></tr></thead><tbody><tr><td>Gateway</td><td>Ready</td></tr></tbody></table>
+              </div>
+            </div>
+          </body></html>`,
+        );
+
+        const geometry = await page.evaluate(() => {
+          const rectFor = (selector: string) =>
+            document.querySelector<HTMLElement>(selector)!.getBoundingClientRect();
+          const shortTable = rectFor("[data-short-table]");
+          const lastCell = rectFor("[data-short-table] tbody td:last-child");
+          return {
+            laneWidth: rectFor("[data-table-lane]").width,
+            narrowLaneWidth: rectFor("[data-narrow-table-lane]").width,
+            narrowTableWidth: rectFor("[data-narrow-table]").width,
+            shortTableWidth: shortTable.width,
+            trailingGap: shortTable.right - lastCell.right,
+          };
+        });
+
+        expect(geometry.shortTableWidth).toBeLessThan(geometry.laneWidth);
+        expect(geometry.trailingGap).toBeLessThanOrEqual(1);
+        expect(geometry.narrowTableWidth).toBeCloseTo(geometry.narrowLaneWidth, 0);
+      } finally {
+        await closeBrowserPage(page);
+      }
+    },
+  );
+
+  it.each(["dark", "light"] as const)(
     "keeps mobile controls inside the viewport with touch targets in %s mode",
     async (themeMode) => {
       const page = await openFixture(320, 568);

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -77,7 +77,7 @@
   border-radius: var(--radius-md);
   border-collapse: separate;
   border-spacing: 0;
-  width: 100%;
+  width: fit-content;
   max-width: 100%;
   background: color-mix(in srgb, var(--accent) 2%, var(--bg-elevated));
   box-shadow: 0 6px 20px color-mix(in srgb, var(--accent) 4%, transparent);


### PR DESCRIPTION
Closes #122293

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where short Markdown tables in Control UI chat transcripts would render as full-width cards with an empty strip after the final column.

## Why This Change Was Made

In this PR, table cards use content width while retaining the existing `max-width: 100%` cap and horizontal overflow behavior for narrow message lanes. The adjacent Markdown rhythm change in #122289 is a separate concern and does not alter table sizing.

## User Impact

Short table cards now end at the last column, while tables that need the full message width remain bounded by their chat lane in both light and dark themes.

## Evidence

| Theme | Before | In this PR |
| --- | --- | --- |
| Dark | ![Short chat table before in dark mode](https://github.com/user-attachments/assets/5934d8f9-abcb-4567-a711-9f28ec0cd512) | ![Short chat table after in dark mode](https://github.com/user-attachments/assets/d4e32674-a71b-4b62-a7f0-1470deff76df) |
| Light | ![Short chat table before in light mode](https://github.com/user-attachments/assets/6f20db41-ba14-46a3-97af-91e24dd820fe) | ![Short chat table after in light mode](https://github.com/user-attachments/assets/d0d7db22-b01a-48e7-b72f-508d6e093507) |

Browser geometry in a `680px` message lane:

- short card width: `680px` before → `194.265625px` in this PR
- blank strip after the last cell: `486.734375px` before → `1px` border in this PR
- the same table remains capped to `160px` in a `160px` lane

Focused validation:

```text
node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts -t "fits short table cards"
Test Files  1 passed (1)
Tests       2 passed | 79 skipped (81)
```

Formatting check passed for both changed files. Production delta is net-zero (`1+ / 1-`); test coverage adds `41` lines.
