### PR TITLE
fix(ui): show configured agent names in switcher

### DIFF
--- a/ui/src/components/app-sidebar-agent-menu.ts
+++ b/ui/src/components/app-sidebar-agent-menu.ts
@@ -135,9 +135,7 @@ function sidebarAgentMenuRows(params: {
       const agentId = normalizeAgentId(entry.id);
       return (
         agentId.toLowerCase().includes(query) ||
-        (params.identities.get(agentId)?.name?.trim() || normalizeAgentLabel(entry))
-          .toLowerCase()
-          .includes(query)
+        normalizeAgentLabel(entry, params.identities.get(agentId)).toLowerCase().includes(query)
       );
     });
     return { rows, showFilter: true };
@@ -164,7 +162,7 @@ function sidebarAgentMenuRows(params: {
 function renderAgentRow(agent: AgentMenuAgent, params: SidebarAgentMenuParams) {
   const agentId = normalizeAgentId(agent.id);
   const identity = params.identities.get(agentId) ?? null;
-  const label = identity?.name?.trim() || normalizeAgentLabel(agent);
+  const label = normalizeAgentLabel(agent, identity);
   const active = agentId === params.activeId;
   const unread = active ? 0 : params.agentUnreadCount(agentId);
   const approvals = params.agentApprovalCount(agentId);

--- a/ui/src/components/app-sidebar-render.ts
+++ b/ui/src/components/app-sidebar-render.ts
@@ -82,7 +82,7 @@ export function renderAppSidebarBrand(host: AppSidebarRenderHost) {
     const agentId = normalizeAgentId(entry.id);
     return agentId !== cardAgentId && host.agentUnreadCount(agentId) > 0;
   });
-  const cardName = cardAgent ? normalizeAgentLabel(cardAgent, cardIdentity) : cardAgentId;
+  const cardName = normalizeAgentLabel(cardAgent ?? { id: cardAgentId }, cardIdentity);
   const approvalCount = host.sessionData.approvalBadgeSnapshot().agentCounts.get(cardAgentId) ?? 0;
   const gateway = host.sessionDataContext?.gateway;
   const avatarAuthToken = gateway

--- a/ui/src/components/app-sidebar-render.ts
+++ b/ui/src/components/app-sidebar-render.ts
@@ -82,8 +82,7 @@ export function renderAppSidebarBrand(host: AppSidebarRenderHost) {
     const agentId = normalizeAgentId(entry.id);
     return agentId !== cardAgentId && host.agentUnreadCount(agentId) > 0;
   });
-  const cardName =
-    cardIdentity?.name?.trim() || (cardAgent ? normalizeAgentLabel(cardAgent) : cardAgentId);
+  const cardName = cardAgent ? normalizeAgentLabel(cardAgent, cardIdentity) : cardAgentId;
   const approvalCount = host.sessionData.approvalBadgeSnapshot().agentCounts.get(cardAgentId) ?? 0;
   const gateway = host.sessionDataContext?.gateway;
   const avatarAuthToken = gateway

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -83,7 +83,7 @@ export function renderSidebarAgentMenuForController(controller: SidebarMenusCont
     position,
     basePath: host.basePath,
     activeId,
-    activeName: identity?.name?.trim() || (agent ? normalizeAgentLabel(agent) : activeId),
+    activeName: agent ? normalizeAgentLabel(agent, identity) : activeId,
     agents,
     identities,
     filter: controller.agentMenuFilter,

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -83,7 +83,7 @@ export function renderSidebarAgentMenuForController(controller: SidebarMenusCont
     position,
     basePath: host.basePath,
     activeId,
-    activeName: agent ? normalizeAgentLabel(agent, identity) : activeId,
+    activeName: normalizeAgentLabel(agent ?? { id: activeId }, identity),
     agents,
     identities,
     filter: controller.agentMenuFilter,

--- a/ui/src/lib/agents/display.ts
+++ b/ui/src/lib/agents/display.ts
@@ -23,6 +23,8 @@ import { normalizeLowercaseStringOrEmpty, normalizeOptionalString } from "../str
 type AgentRosterEntry = {
   id: string;
   kind?: "agent" | "system";
+  name?: string;
+  identity?: { name?: string };
 };
 
 /** Ordinary agent targets; system rows remain available to diagnostic surfaces. */
@@ -319,13 +321,16 @@ type ConfigSnapshot = {
   };
 };
 
-export function normalizeAgentLabel(agent: {
-  id: string;
-  name?: string;
-  identity?: { name?: string };
-}) {
+export function normalizeAgentLabel(
+  agent: AgentRosterEntry,
+  hydratedIdentity?: { name?: string } | null,
+) {
+  // Roster labels own operator target identity; workspace identity only fills gaps.
   return (
-    normalizeOptionalString(agent.name) ?? normalizeOptionalString(agent.identity?.name) ?? agent.id
+    normalizeOptionalString(agent.name) ??
+    normalizeOptionalString(agent.identity?.name) ??
+    normalizeOptionalString(hydratedIdentity?.name) ??
+    agent.id
   );
 }
 

--- a/ui/src/test-helpers/app-sidebar-cases/agent-menu.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/agent-menu.ts
@@ -52,6 +52,41 @@ describe("AppSidebar agent chip", () => {
     expect(request).toHaveBeenCalledWith("agent.identity.get", { agentId: "main" });
   });
 
+  it("keeps the hydrated identity while the active roster row is unavailable", async () => {
+    const request = vi.fn().mockResolvedValue({
+      agentId: "main",
+      name: "Workspace Molty",
+      emoji: "🦞",
+    });
+    const gatewayHarness = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+    const agentIdentity = createAgentIdentityCapability(gatewayHarness.gateway);
+    const { sidebar } = await mountSidebar(
+      gatewayHarness.gateway,
+      createSessions("main", ["agent:main:main"]),
+      "panel",
+      null,
+      [],
+      agentIdentity,
+    );
+
+    sidebar.connected = true;
+    await vi.waitFor(() => {
+      expect(sidebar.querySelector(".sidebar-agent-card__name")?.textContent?.trim()).toBe(
+        "Workspace Molty",
+      );
+    });
+    sidebar.querySelector<HTMLButtonElement>(".sidebar-agent-card__main")?.click();
+    await vi.waitFor(() => {
+      expect(
+        sidebar
+          .querySelector<HTMLElement>(
+            'wa-dropdown-item[value="command:capabilities"] .sidebar-customize-menu__text',
+          )
+          ?.textContent?.trim(),
+      ).toBe("What can Workspace Molty do?");
+    });
+  });
+
   it("keeps the configured roster label when identity hydration returns a fallback", async () => {
     const request = vi.fn(async (_method: string, params: { agentId: string }) =>
       params.agentId === "main"

--- a/ui/src/test-helpers/app-sidebar-cases/agent-menu.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/agent-menu.ts
@@ -52,6 +52,52 @@ describe("AppSidebar agent chip", () => {
     expect(request).toHaveBeenCalledWith("agent.identity.get", { agentId: "main" });
   });
 
+  it("keeps the configured roster label when identity hydration returns a fallback", async () => {
+    const request = vi.fn(async (_method: string, params: { agentId: string }) =>
+      params.agentId === "main"
+        ? { agentId: "main", name: "Workspace Molty", avatar: "🦞" }
+        : { agentId: "rust-claw", name: "Assistant", avatar: "🦀" },
+    );
+    const gatewayHarness = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+    const agentIdentity = createAgentIdentityCapability(gatewayHarness.gateway);
+    const { sidebar } = await mountSidebar(
+      gatewayHarness.gateway,
+      createSessions("main", ["agent:main:main"]),
+      "panel",
+      {
+        defaultId: "main",
+        mainKey: "main",
+        scope: "per-sender",
+        agents: [{ id: "main" }, { id: "rust-claw", name: "rust-claw" }],
+      },
+      [],
+      agentIdentity,
+    );
+
+    sidebar.connected = true;
+    await vi.waitFor(() => {
+      expect(sidebar.querySelector(".sidebar-agent-card__name")?.textContent?.trim()).toBe(
+        "Workspace Molty",
+      );
+    });
+    sidebar.querySelector<HTMLButtonElement>(".sidebar-agent-card__main")?.click();
+    await vi.waitFor(() => {
+      expect(request).toHaveBeenCalledWith("agent.identity.get", { agentId: "rust-claw" });
+      const labels = [
+        ...sidebar.querySelectorAll(".sidebar-agent-menu .agent-select__option-label"),
+      ].map((element) => element.textContent?.trim());
+      expect(labels).toEqual(["Workspace Molty", "rust-claw"]);
+    });
+    await vi.waitFor(() => {
+      const rustRow = [
+        ...sidebar.querySelectorAll<HTMLElement>(".sidebar-agent-menu__agent-switch"),
+      ].find((row) => row.textContent?.includes("rust-claw"));
+      expect(
+        rustRow?.querySelector(".agent-select__avatar--text")?.getAttribute("data-avatar"),
+      ).toBe("🦀");
+    });
+  });
+
   it("hydrates agents added while the switcher remains open", async () => {
     const request = vi.fn(async (_method: string, params: { agentId: string }) => ({
       agentId: params.agentId,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with multiple configured agents could see a generic `Assistant` row in the Control UI agent switcher instead of the configured agent name. This happened when an agent had a stable roster name such as `rust-claw` but its effective workspace identity supplied only an avatar and therefore synthesized the default assistant name.

## Why This Change Was Made

The selectable agent roster remains the owner of operator-facing target names. Hydrated workspace identity continues to provide avatars and fills a label only when the roster has no configured name or identity name. The same precedence now drives the active card, switcher rows, filtering, and capability prompt text.

This restores the behavior before #114126 without changing Gateway protocol or special-casing the literal `Assistant` fallback.

## User Impact

Operators can distinguish and select configured agents by their expected names. Workspace avatars still hydrate normally.

## Evidence

- Real-Gateway isolated A/B browser proof on loopback-only temporary state:
  - parent `776c19eaaa4`: labels `Joshtimus Prime`, `Assistant`; rust agent avatar `🦀`
  - captured candidate `7d89787e042`: labels `Joshtimus Prime`, `rust-claw`; rust agent avatar `🦀`
  - selecting `rust-claw` navigated to `/chat/rust-claw`
  - no production state, external credentials, channels, or non-loopback listeners were used

### Screenshot proof

| Before: hydrated fallback hides the configured target | After: roster label remains visible |
|---|---|
| ![Before: the second agent is shown as Assistant](https://gist.githubusercontent.com/joshavant/0518bb8caf306c2705adcb53d6a3b643/raw/c20a2ca99921c558c58ee9e5c3bb53444d77d573/01-before-agent-menu.png) | ![After: the second agent is shown as rust-claw with its hydrated crab avatar](https://gist.githubusercontent.com/joshavant/0518bb8caf306c2705adcb53d6a3b643/raw/aa0fd752983c1981fbd6dbddd4e9326a2264ca21/02-after-agent-menu.png) |

After selection, the active card identifies the correct agent and retains the hydrated avatar:

![After selecting rust-claw: the active card shows rust-claw and the crab avatar](https://gist.githubusercontent.com/joshavant/0518bb8caf306c2705adcb53d6a3b643/raw/b9ecbd65cfed920c4172cc9ad03d5a0cfbcd3482/03-after-rust-claw-selected.png)

- Regression tests failed before the production edits for both defects: expected `rust-claw`, received `Assistant`; expected `Workspace Molty`, received `main` while the active roster row was unavailable.
- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts ui/src/lib/agents/display.test.ts` — 279 tests passed.
- Exact-head CI for `c97b9f2524a` — 73 jobs completed successfully.
- Local autoreview: clean, no accepted/actionable findings.
- Production LOC: +15/-13 (net +2). Tests: +81/-0. The small production increase centralizes label precedence in the existing display helper rather than duplicating policy across sidebar consumers.
