### PR TITLE
fix(google-meet): publish exports atomically

### DIFF
--- a/extensions/google-meet/src/cli-export.test.ts
+++ b/extensions/google-meet/src/cli-export.test.ts
@@ -1,0 +1,88 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import JSZip from "jszip";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { writeMeetExportBundle } from "./cli-export.js";
+import type { GoogleMeetArtifactsResult, GoogleMeetAttendanceResult } from "./meet-api.js";
+
+const emptyArtifacts: GoogleMeetArtifactsResult = {
+  conferenceRecords: [],
+  artifacts: [],
+};
+
+const emptyAttendance: GoogleMeetAttendanceResult = {
+  conferenceRecords: [],
+  attendance: [],
+};
+
+describe("Google Meet export publication", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(tmpdir(), "openclaw-google-meet-export-publication-"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("keeps an existing bundle member when replacement fails", async () => {
+    const outputDir = path.join(tempDir, "bundle");
+    const summaryPath = path.join(outputDir, "summary.md");
+    fs.mkdirSync(outputDir);
+    fs.writeFileSync(summaryPath, "previous summary\n");
+    const priorBytes = fs.readFileSync(summaryPath);
+
+    vi.spyOn(fsp, "writeFile").mockImplementationOnce(async (file) => {
+      expect(typeof file).toBe("string");
+      fs.writeFileSync(file as string, "partial replacement");
+      throw new Error("injected write failure");
+    });
+
+    await expect(
+      writeMeetExportBundle({
+        outputDir,
+        artifacts: emptyArtifacts,
+        attendance: emptyAttendance,
+      }),
+    ).rejects.toThrow("injected write failure");
+
+    expect(fs.readFileSync(summaryPath)).toEqual(priorBytes);
+    expect(fs.readdirSync(outputDir)).toEqual(["summary.md"]);
+  });
+
+  it("keeps an existing ZIP when replacement fails", async () => {
+    const outputDir = path.join(tempDir, "bundle");
+    const zipPath = `${outputDir}.zip`;
+    const priorZip = await new JSZip()
+      .file("previous.txt", "previous export")
+      .generateAsync({ type: "nodebuffer" });
+    fs.writeFileSync(zipPath, priorZip);
+    const realWriteFile = fsp.writeFile;
+
+    vi.spyOn(fsp, "writeFile").mockImplementation(async (...args) => {
+      const [file, data] = args;
+      if (Buffer.isBuffer(data)) {
+        expect(typeof file).toBe("string");
+        fs.writeFileSync(file as string, "partial replacement");
+        throw new Error("injected ZIP write failure");
+      }
+      await Reflect.apply(realWriteFile, fsp, args);
+    });
+
+    await expect(
+      writeMeetExportBundle({
+        outputDir,
+        artifacts: emptyArtifacts,
+        attendance: emptyAttendance,
+        zip: true,
+      }),
+    ).rejects.toThrow("injected ZIP write failure");
+
+    expect(fs.readFileSync(zipPath)).toEqual(priorZip);
+    expect(fs.readdirSync(tempDir).toSorted()).toEqual(["bundle", "bundle.zip"]);
+  });
+});

--- a/extensions/google-meet/src/cli-export.ts
+++ b/extensions/google-meet/src/cli-export.ts
@@ -1,6 +1,7 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import fsp from "node:fs/promises";
 import path from "node:path";
 import JSZip from "jszip";
+import { writeExternalFileWithinRoot } from "openclaw/plugin-sdk/security-runtime";
 import { listGoogleMeetCalendarEvents, type GoogleMeetCalendarLookupResult } from "./calendar.js";
 import {
   formatDuration,
@@ -522,6 +523,17 @@ function defaultExportDirectory(): string {
   return `google-meet-export-${new Date().toISOString().replace(/[:.]/g, "-")}`;
 }
 
+async function publishMeetExportFile(outputPath: string, content: string | Buffer): Promise<void> {
+  const absolutePath = path.resolve(outputPath);
+  await writeExternalFileWithinRoot({
+    rootDir: path.dirname(absolutePath),
+    path: path.basename(absolutePath),
+    write: async (tempPath) => {
+      await fsp.writeFile(tempPath, content);
+    },
+  });
+}
+
 export async function writeMeetExportBundle(params: {
   outputDir?: string;
   artifacts: GoogleMeetArtifactsResult;
@@ -532,7 +544,7 @@ export async function writeMeetExportBundle(params: {
   calendarEvent?: GoogleMeetCalendarLookupResult;
 }): Promise<{ outputDir: string; files: string[]; zipFile?: string }> {
   const outputDir = params.outputDir?.trim() || defaultExportDirectory();
-  await mkdir(outputDir, { recursive: true });
+  await fsp.mkdir(outputDir, { recursive: true });
   const zipFile = params.zip ? `${outputDir.replace(/\/$/, "")}.zip` : undefined;
   const fileNames = googleMeetExportFileNames();
   const files = [
@@ -562,7 +574,7 @@ export async function writeMeetExportBundle(params: {
     },
   ];
   for (const file of files) {
-    await writeFile(path.join(outputDir, file.name), file.content, "utf8");
+    await publishMeetExportFile(path.join(outputDir, file.name), file.content);
   }
   const result: { outputDir: string; files: string[]; zipFile?: string } = {
     outputDir,
@@ -573,7 +585,7 @@ export async function writeMeetExportBundle(params: {
     for (const file of files) {
       zip.file(file.name, file.content);
     }
-    await writeFile(zipFile, await zip.generateAsync({ type: "nodebuffer" }));
+    await publishMeetExportFile(zipFile, await zip.generateAsync({ type: "nodebuffer" }));
     result.zipFile = zipFile;
   }
   return result;


### PR DESCRIPTION
## What Problem This Solves

Closes #122276.

Google Meet export wrote every completed artifact directly to its final path. Re-exporting to an existing directory or ZIP therefore truncated the previous artifact before the replacement was safely published; a filesystem failure or process interruption could destroy the prior valid export and leave partial bytes at the final path.

## Why This Change Was Made

The Google Meet plugin now routes all six directory members and the optional ZIP through the existing `openclaw/plugin-sdk/security-runtime` `writeExternalFileWithinRoot` contract. That public plugin seam writes to a randomized sibling staging file, validates the staged regular-file identity, syncs it, atomically renames it over the final path, syncs the parent directory, and cleans failed staging files.

This keeps the repair at the plugin-owned export boundary without adding a dependency, SDK surface, compatibility path, or second publication implementation.

## User Impact

A failed Google Meet export replacement no longer corrupts the previous artifact at that path. Successful exports retain the same CLI and plugin result shape, while both folder members and ZIP archives become visible only after their complete bytes have been staged.

## Evidence

- Real filesystem reproduction before the fix, using a 2 KiB process file limit: the replacement failed with `EFBIG` and the previous 18-byte `summary.md` was replaced by a corrupt 2,048-byte partial file.
- The same reproduction after the fix: `EFBIG` still propagates, the previous file remains byte-identical at 18 bytes, and the export directory contains only `summary.md` with no staging residue.
- New owner-boundary regressions inject partial writes before throwing for both a directory member and the ZIP. Both tests failed against the direct-write implementation for the intended corruption reason, then passed after staged publication.
- `node scripts/run-vitest.mjs extensions/google-meet/src/cli-export.test.ts extensions/google-meet/src/cli-artifacts.test.ts` — 19 passed.
- `node scripts/run-vitest.mjs extensions/google-meet` — 25 files, 334 tests passed.
- `pnpm tsgo:extensions && pnpm tsgo:extensions:test` — passed.
- Targeted extension Oxlint and formatting checks — passed.
- Mandatory Codex autoreview and TruffleHog — clean, no accepted/actionable findings.
- Delegated changed-file gate Testbox run https://github.com/openclaw/openclaw/actions/runs/31537828610 timed out during checkout hydration before running repository checks. The trusted-source local fallback passed every lane through plugin boundaries, then stopped because the pre-existing Knip pnpm-store link remained missing after the required install/retry.
- Exact-head CI parent https://github.com/openclaw/openclaw/actions/runs/31541187794 completed successfully for `8fc2e1c44373ffab501c4d945fdc382a7c4e4df8`.
- Native review artifacts validated `READY FOR /prepare-pr` with zero findings, and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 122306` completed with hosted gates passed.

Production LOC: +16/-4 (net +12). Tests: +88/-0 (net +88).
