### PR TITLE
refactor(gateway): use resolved auth getter for WebSocket connections

### DIFF
--- a/src/gateway/server-startup-finish.ts
+++ b/src/gateway/server-startup-finish.ts
@@ -110,7 +110,6 @@ export async function finishGatewayStartup(params: {
     workerLiveEvents,
     earlyRuntime,
     cfgAtStart,
-    resolvedAuth,
     preauthConnectionBudget,
     releaseStartupAccountStarts,
     cronReconciliation,
@@ -151,7 +150,6 @@ export async function finishGatewayStartup(params: {
           listPluginNodeCapabilities(pluginRuntime.registry),
           isCoreCanvasHostEnabled(getRuntimeConfig()),
         ),
-      resolvedAuth,
       getResolvedAuth,
       getRequiredSharedGatewaySessionGeneration: () =>
         getRequiredSharedGatewaySessionGeneration(sharedGatewaySessionGenerationState),

--- a/src/gateway/server-ws-runtime.ts
+++ b/src/gateway/server-ws-runtime.ts
@@ -26,7 +26,6 @@ export function attachGatewayWsHandlers(params: GatewayWsRuntimeParams) {
     gatewayHost: params.gatewayHost,
     pluginSurfaceScheme: params.pluginSurfaceScheme,
     getPluginNodeCapabilities: params.getPluginNodeCapabilities,
-    resolvedAuth: params.resolvedAuth,
     getResolvedAuth: params.getResolvedAuth,
     getRequiredSharedGatewaySessionGeneration: params.getRequiredSharedGatewaySessionGeneration,
     rateLimiter: params.rateLimiter,

--- a/src/gateway/server/ws-connection.startup.test.ts
+++ b/src/gateway/server/ws-connection.startup.test.ts
@@ -37,7 +37,7 @@ describe("attachGatewayWsConnectionHandler startup readiness", () => {
       clients,
       socket,
       options: {
-        resolvedAuth: { mode: "token", allowTailscale: false, token: "test-token" },
+        getResolvedAuth: () => ({ mode: "token", allowTailscale: false, token: "test-token" }),
         buildRequestContext: () => createGatewayWsTestRequestContext() as never,
       },
     });
@@ -116,7 +116,7 @@ describe("attachGatewayWsConnectionHandler startup readiness", () => {
         attach: attachGatewayWsConnectionHandler,
         socket,
         options: {
-          resolvedAuth: { mode: "none", allowTailscale: false },
+          getResolvedAuth: () => ({ mode: "none", allowTailscale: false }),
           isStartupPending: () => true,
           logWsControl: logWsControl as never,
           buildRequestContext: () => createGatewayWsTestRequestContext() as never,

--- a/src/gateway/server/ws-connection.test-helpers.ts
+++ b/src/gateway/server/ws-connection.test-helpers.ts
@@ -106,7 +106,7 @@ export function attachGatewayWsForTest(params: {
     clients: clients as never,
     preauthConnectionBudget: { release: vi.fn() } as never,
     port: 19001,
-    resolvedAuth: createResolvedGatewayTokenAuth("token"),
+    getResolvedAuth: () => createResolvedGatewayTokenAuth("token"),
     preauthHandshakeTimeoutMs: 60_000,
     gatewayMethods: [],
     events: [],

--- a/src/gateway/server/ws-connection.test.ts
+++ b/src/gateway/server/ws-connection.test.ts
@@ -159,7 +159,6 @@ describe("attachGatewayWsConnectionHandler", () => {
 
     const { passed } = await connectTestWs({
       options: {
-        resolvedAuth: initialAuth,
         getResolvedAuth: () => currentAuth,
       },
     });

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -160,8 +160,12 @@ type GatewayWsSharedHandlerParams = {
   gatewayHost?: string;
   pluginSurfaceScheme?: "http" | "https";
   getPluginNodeCapabilities?: () => PluginNodeCapabilitySurface[];
-  resolvedAuth: ResolvedGatewayAuth;
-  getResolvedAuth?: () => ResolvedGatewayAuth;
+  /**
+   * Auth is read per connection, not per process: a reload can rotate it while
+   * this handler stays attached. One getter keeps that the only source, so no
+   * caller can hand over a snapshot that silently outlives the config it came from.
+   */
+  getResolvedAuth: () => ResolvedGatewayAuth;
   getRequiredSharedGatewaySessionGeneration?: () => string | undefined;
   /** Optional rate limiter for auth brute-force protection. */
   rateLimiter?: AuthRateLimiter;
@@ -240,8 +244,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
     port,
     pluginSurfaceScheme,
     getPluginNodeCapabilities,
-    resolvedAuth,
-    getResolvedAuth = () => resolvedAuth,
+    getResolvedAuth,
     getRequiredSharedGatewaySessionGeneration = () =>
       resolveSharedGatewaySessionGeneration(
         getResolvedAuth(),


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The WebSocket connection owner currently accepts both a resolved-auth snapshot and a getter for the current resolved auth. The snapshot is only a fallback for the getter, which creates two sources for a fact that can rotate during config reload.

## Why This Change Was Made

This PR proposes making the resolved-auth getter the only WebSocket connection input. Production wiring and tests now pass one current-value seam, so new connections cannot silently fall back to a process-start snapshot.

This extracts the refactor from #120825 so the pairing stack can stay focused on its core connectivity and setup-code contract.

## User Impact

No intended user-visible behavior change. Gateway maintainers get one canonical resolved-auth source at the connection boundary, aligned with config reload behavior.

## Evidence

Head: `40c587273885cae2aeaf6075f02f27e6fdee23a5`

- Source audit: all production callers already supplied `getResolvedAuth`; the removed snapshot only defaulted that getter.
- Diff check: clean.
- Production LOC: `+7/-7` (net 0); tests: `+3/-4` (net -1).
- Structured branch review: TruffleHog clean, no accepted/actionable findings, patch correct (0.99).
- Blacksmith Testbox: [`31541667324`](https://github.com/openclaw/openclaw/actions/runs/31541667324), lease `tbx_01kzseb7renxnnk3x1xpd2eq5q` completed and stopped. Exact-head `node scripts/check-changed.mjs --base d035dba6c768117c673a6326252f1e1bc9182a56 --head HEAD` passed all selected `core` and `coreTests` gates.
- Exact-head GitHub CI: [`31541542537`](https://github.com/openclaw/openclaw/actions/runs/31541542537) completed successfully.
