### PR TITLE
fix(ui): render disallowed markdown links as plain text

### DIFF
--- a/ui/src/components/markdown-parser.ts
+++ b/ui/src/components/markdown-parser.ts
@@ -19,6 +19,7 @@ import type { MarkdownRenderEnv } from "./markdown-render-options.ts";
 import { escapeMarkdownHtml } from "./markdown-text.ts";
 
 const INLINE_DATA_IMAGE_RE = /^data:image\/[a-z0-9.+-]+;base64,/i;
+const DISALLOWED_LINK_SCHEME_RE = /^(?!(?:https?|mailto):)[a-z][a-z0-9+.-]*:/i;
 // CJK character ranges for URL boundary detection (RFC 3986: CJK is not valid in raw URLs).
 // CJK Unified Ideographs, CJK Symbols/Punctuation, Fullwidth Forms, Hiragana, Katakana,
 // Hangul Syllables, and CJK Compatibility Ideographs.
@@ -220,17 +221,31 @@ export function createMarkdownParser(): MarkdownIt {
     },
   });
 
-  // Override default link validator to allow all URLs through to renderers.
-  // marked.js does not validate URLs at all — it generates <a>/<img> tags for
-  // everything and relies on DOMPurify to strip dangerous schemes.
-  //
-  // We match this behavior exactly:
-  // - All URLs pass validation, including javascript:, vbscript:, file:, data:
-  // - Images: renderer.rules.image shows alt text for non-data-image URLs
-  // - Links: DOMPurify strips dangerous href schemes, leaving safe anchor text
-  // - Blocking at validateLink would skip token generation entirely, causing raw
-  //   markdown source to appear instead of graceful fallbacks.
+  // Keep label tokens for invalid destinations; the rule below removes only the
+  // link wrapper so rejected Markdown stays readable without a false affordance.
   markdownParser.validateLink = () => true;
+
+  markdownParser.core.ruler.after("linkify", "disallowed-link-schemes", (state) => {
+    for (const blockToken of state.tokens) {
+      const children = blockToken.children;
+      if (blockToken.type !== "inline" || !children) {
+        continue;
+      }
+      let hideClose = false;
+      for (const token of children) {
+        if (
+          token.type === "link_open" &&
+          DISALLOWED_LINK_SCHEME_RE.test(token.attrGet("href") ?? "")
+        ) {
+          token.hidden = true;
+          hideClose = true;
+        } else if (token.type === "link_close" && hideClose) {
+          token.hidden = true;
+          hideClose = false;
+        }
+      }
+    }
+  });
 
   // Trim trailing CJK characters from auto-linked URLs (RFC 3986: raw CJK is
   // not valid in URLs). markdown-it's built-in linkify for https:// URLs may

--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -46,7 +46,7 @@ describe("toSanitizedMarkdownHtml", () => {
       ].join("\n"),
     );
     expect(html).toBe(
-      '&lt;script&gt;alert(1)&lt;/script&gt;\n\n<p><a>x</a></p>\n<p><a href="https://example.com" rel="noreferrer noopener" target="_blank">ok</a></p>\n',
+      '&lt;script&gt;alert(1)&lt;/script&gt;\n\n<p>x</p>\n<p><a href="https://example.com" rel="noreferrer noopener" target="_blank">ok</a></p>\n',
     );
   });
 
@@ -529,9 +529,16 @@ PY
   });
 
   describe("security", () => {
-    it("blocks javascript: in links via DOMPurify", () => {
-      const html = toSanitizedMarkdownHtml("[click me](javascript:alert(1))");
-      expect(html).toBe("<p><a>click me</a></p>\n");
+    it.each([
+      ["javascript:", "[JavaScript link](javascript:alert(1))", "JavaScript link"],
+      ["data:", "[Data link](data:text/html,test)", "Data link"],
+      ["vbscript:", "[VBScript link](vbscript:msgbox(1))", "VBScript link"],
+      ["file:", "[File link](file:///etc/passwd)", "File link"],
+    ])("renders disallowed %s links as plain text", (_scheme, markdown, label) => {
+      const fragment = htmlFragment(toSanitizedMarkdownHtml(markdown));
+
+      expect(fragment.querySelector("a")).toBeNull();
+      expect(fragment.querySelector("p")?.textContent).toBe(label);
     });
 
     it("shows alt text for javascript: images", () => {
@@ -547,19 +554,9 @@ PY
       expect(html2).toBe("<p>Alt2</p>\n");
     });
 
-    it("renders non-image data: URIs as inert links (marked.js compat)", () => {
-      const html = toSanitizedMarkdownHtml("[x](data:text/html,<script>alert(1)</script>)");
-      expect(html).toBe("<p><a>x</a></p>\n");
-    });
-
     it("does not auto-link bare file:// URIs", () => {
       const html = toSanitizedMarkdownHtml("Check file:///etc/passwd");
       expect(html).toBe("<p>Check file:///etc/passwd</p>\n");
-    });
-
-    it("strips href from explicit file:// links via DOMPurify", () => {
-      const html = toSanitizedMarkdownHtml("[click](file:///etc/passwd)");
-      expect(html).toBe("<p><a>click</a></p>\n");
     });
 
     it("strips href from host-local absolute file paths", () => {


### PR DESCRIPTION
Closes #122280

## What Problem This Solves

Fixes an issue where users reading chat Markdown would see `javascript:`, `data:`, `vbscript:`, and `file:` labels styled as normal links even after sanitization removed their destinations. The resulting affordance promised an interaction but clicking produced no outcome.

## Why This Change Was Made

The parser still admits every destination long enough to preserve a readable Markdown label, then removes the `link_open`/`link_close` wrappers for any explicit scheme outside HTTP(S) and mail. This keeps relative, mail, web, and workspace-file flows intact while making the sanitized result truthful at the semantic owner boundary; DOMPurify remains defense in depth.

Using the upstream validator directly was not sufficient because it exposes raw Markdown syntax when it rejects a destination. A CSS-only treatment was also rejected because it would leave misleading anchor markup in the document.

## User Impact

Disallowed destinations now read as ordinary text. Safe HTTPS links remain visually and semantically interactive, and inline `data:image/*;base64` images retain their existing image behavior.

## Evidence

Before ref: `edb7a1692e58d78ff7e196db39ea8eff297b2e19`  
After ref: `6032c05e3951ea273d0ffaa52cd03ff919a33c55`

| Theme | Before | In this PR |
| --- | --- | --- |
| Light | ![Before: scripting and data schemes retain red underlined link styling](https://github.com/user-attachments/assets/07981a18-e17a-4bfe-88bf-688e4cfadea0) | ![After: prohibited schemes are plain text while the safe HTTPS comparison remains a link](https://github.com/user-attachments/assets/67d583b9-762c-41c9-9a1f-a9146758ee5b) |
| Dark | ![Before in dark theme: prohibited schemes look clickable](https://github.com/user-attachments/assets/358e0c1a-279d-447a-8fa0-6276fa05a925) | ![After in dark theme: prohibited schemes are plain text and HTTPS remains linked](https://github.com/user-attachments/assets/466baf4a-0982-4d46-b2f2-09bfa188743f) |

Screenshots came from the same 1200×900 Chromium viewport and deterministic mocked-Gateway transcript in both refs. The proof-only harness populated a user prompt plus assistant Markdown containing the three reported schemes and one safe HTTPS comparison, switched the real UI between light/dark, and captured the rendered `.chat-text` surface:

```shell
OPENCLAW_SECJS_PROOF_DIR=<dir> node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner \
  ui/src/e2e/chat-secjs-proof.e2e.test.ts
```

Regression proof:

```shell
# Before implementation: 5 expected failures; each prohibited label remained inside <a>.
node scripts/run-vitest.mjs ui/src/components/markdown.test.ts

# Final focused coverage: 158/158 passed.
node scripts/run-vitest.mjs \
  ui/src/components/markdown.test.ts \
  ui/src/components/markdown-links.test.ts
```

Remote changed gate:

```shell
node scripts/check-changed.mjs -- \
  ui/src/components/markdown-parser.ts \
  ui/src/components/markdown.test.ts
```

Passed on Blacksmith Testbox run [31539101484](https://github.com/openclaw/openclaw/actions/runs/31539101484): formatting, guards, i18n verification, dead-export scan, UI/core-test typechecks, and lint all completed successfully.

Production LOC: `+25/-10` (net `+15`). Test LOC: `+11/-14` (net `-3`). The production addition is the parser pass needed to preserve label tokens while removing disallowed wrappers; the stale compatibility comment and redundant individual tests were removed.
