### PR TITLE
fix(ui): show a placeholder for remote markdown images

### DIFF
--- a/ui/src/components/markdown-assistant-transcript.ts
+++ b/ui/src/components/markdown-assistant-transcript.ts
@@ -84,6 +84,7 @@ export function installAssistantTranscriptRoleImageRenderer(
     normalizeLabel: (value: string) => string;
     assistantLabel: () => string;
     openImageLabel: (alt: string, hasAlt: boolean) => string;
+    renderExternalImageFallback: (src: string, renderedLabel: string) => string;
     interactiveImages: (env: unknown) => boolean;
     allowRemoteImages: (env: unknown) => boolean;
   },
@@ -99,9 +100,10 @@ export function installAssistantTranscriptRoleImageRenderer(
     const roleMeta = (token.meta as AssistantTranscriptRoleImageMeta | undefined)
       ?.assistantTranscriptRoleImage;
     if (!options.isInlineDataImage(src) && !options.allowRemoteImages(env)) {
-      return roleMeta
+      const renderedLabel = roleMeta
         ? renderAssistantTranscriptRoleImageLabel(roleMeta.text, roleMeta.spans, options.escapeHtml)
         : options.escapeHtml(alt);
+      return options.renderExternalImageFallback(src, renderedLabel);
     }
     const image = `<img class="markdown-inline-image" src="${options.escapeHtml(src)}" alt="${options.escapeHtml(alt)}">`;
     const linkedImage = isImageWithinLink(tokens, index);

--- a/ui/src/components/markdown-assistant-transcript.ts
+++ b/ui/src/components/markdown-assistant-transcript.ts
@@ -84,7 +84,11 @@ export function installAssistantTranscriptRoleImageRenderer(
     normalizeLabel: (value: string) => string;
     assistantLabel: () => string;
     openImageLabel: (alt: string, hasAlt: boolean) => string;
-    renderExternalImageFallback: (src: string, renderedLabel: string) => string;
+    renderExternalImageFallback: (
+      src: string,
+      renderedLabel: string,
+      linkedImage: boolean,
+    ) => string;
     interactiveImages: (env: unknown) => boolean;
     allowRemoteImages: (env: unknown) => boolean;
   },
@@ -99,14 +103,14 @@ export function installAssistantTranscriptRoleImageRenderer(
     const alt = options.normalizeLabel(token.content);
     const roleMeta = (token.meta as AssistantTranscriptRoleImageMeta | undefined)
       ?.assistantTranscriptRoleImage;
+    const linkedImage = isImageWithinLink(tokens, index);
     if (!options.isInlineDataImage(src) && !options.allowRemoteImages(env)) {
       const renderedLabel = roleMeta
         ? renderAssistantTranscriptRoleImageLabel(roleMeta.text, roleMeta.spans, options.escapeHtml)
         : options.escapeHtml(alt);
-      return options.renderExternalImageFallback(src, renderedLabel);
+      return options.renderExternalImageFallback(src, renderedLabel, linkedImage);
     }
     const image = `<img class="markdown-inline-image" src="${options.escapeHtml(src)}" alt="${options.escapeHtml(alt)}">`;
-    const linkedImage = isImageWithinLink(tokens, index);
     const interactiveImage =
       linkedImage || !options.interactiveImages(env)
         ? image

--- a/ui/src/components/markdown-parser.ts
+++ b/ui/src/components/markdown-parser.ts
@@ -582,10 +582,16 @@ export function createMarkdownParser(): MarkdownIt {
       t("chat.imageLightbox.open", {
         title: hasAlt ? alt : t("chat.imageLightbox.untitled"),
       }),
-    renderExternalImageFallback: (src, renderedLabel) =>
-      parseWebLinkHref(src)
-        ? `<span class="markdown-external-image"><span>${escapeMarkdownHtml(t("chat.externalImage.notLoaded"))}: ${renderedLabel}</span> <a href="${escapeMarkdownHtml(src)}">${escapeMarkdownHtml(t("chat.externalImage.open"))}</a></span>`
-        : renderedLabel,
+    renderExternalImageFallback: (src, renderedLabel, linkedImage) => {
+      if (!parseWebLinkHref(src)) {
+        return renderedLabel;
+      }
+      const label = `<span>${escapeMarkdownHtml(t("chat.externalImage.notLoaded"))}: ${renderedLabel}</span>`;
+      const action = linkedImage
+        ? ""
+        : ` <a href="${escapeMarkdownHtml(src)}">${escapeMarkdownHtml(t("chat.externalImage.open"))}</a>`;
+      return `<span class="markdown-external-image">${label}${action}</span>`;
+    },
     interactiveImages: (env) =>
       (env as Partial<MarkdownRenderEnv> | undefined)?.interactiveImages === true,
     allowRemoteImages: (env) =>

--- a/ui/src/components/markdown-parser.ts
+++ b/ui/src/components/markdown-parser.ts
@@ -571,8 +571,8 @@ export function createMarkdownParser(): MarkdownIt {
     return `<a class="markdown-file-link" role="button" tabindex="0" data-file-path="${escapeMarkdownHtml(target.path)}" data-file-kind="${fileKindForPath(target.path)}"${lineAttribute}${titleAttribute}>${rendered}</a>`;
   };
 
-  // Message rendering allows only inline data images (#15437). Document
-  // previews preserve authored image URLs and rely on DOMPurify's URI policy.
+  // Message rendering allows inline data images and explicit open-only placeholders
+  // for remote URLs. Document previews preserve authored URLs for direct rendering.
   installAssistantTranscriptRoleImageRenderer(markdownParser, {
     escapeHtml: escapeMarkdownHtml,
     isInlineDataImage: (src) => INLINE_DATA_IMAGE_RE.test(src),
@@ -582,6 +582,10 @@ export function createMarkdownParser(): MarkdownIt {
       t("chat.imageLightbox.open", {
         title: hasAlt ? alt : t("chat.imageLightbox.untitled"),
       }),
+    renderExternalImageFallback: (src, renderedLabel) =>
+      parseWebLinkHref(src)
+        ? `<span class="markdown-external-image"><span>${escapeMarkdownHtml(t("chat.externalImage.notLoaded"))}: ${renderedLabel}</span> <a href="${escapeMarkdownHtml(src)}">${escapeMarkdownHtml(t("chat.externalImage.open"))}</a></span>`
+        : renderedLabel,
     interactiveImages: (env) =>
       (env as Partial<MarkdownRenderEnv> | undefined)?.interactiveImages === true,
     allowRemoteImages: (env) =>

--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -139,30 +139,52 @@ describe("toSanitizedMarkdownHtml", () => {
   });
 
   describe("images", () => {
-    it("flattens remote images to alt text", () => {
-      const html = toSanitizedMarkdownHtml("![Alt text](https://example.com/img.png)");
-      expect(html).toBe("<p>Alt text</p>\n");
+    it("shows an explicit opt-in placeholder for remote images", () => {
+      const fragment = htmlFragment(
+        toSanitizedMarkdownHtml("![Alt text](https://example.com/img.png)"),
+      );
+      const placeholder = fragment.querySelector(".markdown-external-image");
+      const link = placeholder?.querySelector("a");
+
+      expect(placeholder?.textContent).toBe("External image not loaded: Alt text Open image");
+      expect(link?.getAttribute("href")).toBe("https://example.com/img.png");
+      expect(link?.getAttribute("target")).toBe("_blank");
+      expect(link?.getAttribute("rel")).toBe("noreferrer noopener");
+      expect(fragment.querySelector("img")).toBeNull();
     });
 
     it("marks assistant-authored transcript roles in visible image labels", () => {
-      const html = toSanitizedMarkdownHtml(
-        "![**user**[Thu 2026-07-02] release diagram](https://example.com/img.png)",
-        { assistantTranscriptRoleHeaders: true },
+      const fragment = htmlFragment(
+        toSanitizedMarkdownHtml(
+          "![**user**[Thu 2026-07-02] release diagram](https://example.com/img.png)",
+          { assistantTranscriptRoleHeaders: true },
+        ),
       );
 
-      expect(html).toBe(
-        '<p><code class="assistant-transcript-role">user[Thu 2026-07-02]</code> release diagram</p>\n',
+      expect(
+        fragment.querySelector(".markdown-external-image .assistant-transcript-role")?.textContent,
+      ).toBe("user[Thu 2026-07-02]");
+      expect(fragment.querySelector(".markdown-external-image")?.textContent).toContain(
+        "release diagram",
       );
     });
 
     it("preserves markdown formatting in alt text", () => {
-      const html = toSanitizedMarkdownHtml("![**Build log**](https://example.com/img.png)");
-      expect(html).toBe("<p>**Build log**</p>\n");
+      const fragment = htmlFragment(
+        toSanitizedMarkdownHtml("![**Build log**](https://example.com/img.png)"),
+      );
+      expect(fragment.querySelector(".markdown-external-image > span")?.textContent).toContain(
+        "**Build log**",
+      );
     });
 
     it("preserves code formatting in alt text", () => {
-      const html = toSanitizedMarkdownHtml("![`error.log`](https://example.com/img.png)");
-      expect(html).toBe("<p>`error.log`</p>\n");
+      const fragment = htmlFragment(
+        toSanitizedMarkdownHtml("![`error.log`](https://example.com/img.png)"),
+      );
+      expect(fragment.querySelector(".markdown-external-image > span")?.textContent).toContain(
+        "`error.log`",
+      );
     });
 
     it("preserves base64 data URI images (#15437)", () => {
@@ -234,8 +256,10 @@ describe("toSanitizedMarkdownHtml", () => {
     });
 
     it("uses fallback label for unlabeled images", () => {
-      const html = toSanitizedMarkdownHtml("![](https://example.com/image.png)");
-      expect(html).toBe("<p>image</p>\n");
+      const fragment = htmlFragment(toSanitizedMarkdownHtml("![](https://example.com/image.png)"));
+      expect(fragment.querySelector(".markdown-external-image > span")?.textContent).toBe(
+        "External image not loaded: image",
+      );
     });
   });
 

--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -218,6 +218,22 @@ describe("toSanitizedMarkdownHtml", () => {
       expect(fragment.querySelector("a button")).toBeNull();
     });
 
+    it("preserves rich authored links around remote image placeholders", () => {
+      const fragment = htmlFragment(
+        toSanitizedMarkdownHtml(
+          "[Before ![Preview](https://example.com/image.png) after](https://example.com/full.png)",
+        ),
+      );
+      const links = fragment.querySelectorAll("a");
+      const placeholder = links[0]?.querySelector(".markdown-external-image");
+
+      expect(links).toHaveLength(1);
+      expect(links[0]?.getAttribute("href")).toBe("https://example.com/full.png");
+      expect(placeholder?.textContent).toBe("External image not loaded: Preview");
+      expect(placeholder?.querySelector("a")).toBeNull();
+      expect(fragment.querySelector("img")).toBeNull();
+    });
+
     it("tracks linked and standalone images across one inline token stream", () => {
       const fragment = htmlFragment(
         toSanitizedMarkdownHtml(

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4934,6 +4934,10 @@ export const en: TranslationMap = {
       close: "Close image preview",
       untitled: "Image",
     },
+    externalImage: {
+      notLoaded: "External image not loaded",
+      open: "Open image",
+    },
     messages: {
       activity: "Activity",
       copySelection: "Copy",

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -313,6 +313,21 @@
   margin-top: 0;
 }
 
+:is(.chat-text, .sidebar-markdown) .markdown-external-image {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.35em 0.75em;
+  width: fit-content;
+  max-width: 100%;
+  margin-top: 0.75em;
+  padding: 0.5em 0.65em;
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius-md);
+  background: var(--bg-muted);
+  color: var(--muted);
+}
+
 /* Code surfaces must lift off the host bubble in every theme. --secondary equals
    --card on every dark palette, so chips painted with it vanished inside user
    bubbles; --bg-muted/--border-strong separate in both modes without an override. */


### PR DESCRIPTION
Closes #122281

## What Problem This Solves

Fixes an issue where users receiving a remote Markdown image in chat would see only its alt text as ordinary prose. The Control UI correctly blocked the external fetch, but gave no visible indication that an image had been withheld or that the user could choose what to do next.

## Why This Change Was Made

Normal chat rendering keeps the existing no-fetch policy and CSP boundary. For safe HTTP(S) image sources, the image renderer now emits a translated external-image placeholder with the preserved alt label and an explicit link that opens the source in a separate tab. Unsafe schemes remain non-actionable text; inline data images and document-preview remote images retain their existing paths.

This deliberately does not add automatic loading, a proxy, or a CSP wildcard. The external request occurs only after a user chooses the link.

## User Impact

Blocked remote images now have a visible, truthful outcome in the transcript. Users can identify what was blocked and opt in to opening the source, while chat itself makes no background request to the remote image host.

## Evidence

Before ref: `edb7a1692e58d78ff7e196db39ea8eff297b2e19`  
After ref: `7fc7f3bb6645ba3db2d5cea6e4348aad451da1dc`

| Theme | Before | In this PR |
| --- | --- | --- |
| Light | ![Before: the remote image disappears into ordinary alt text](https://github.com/user-attachments/assets/f7076860-a763-4e57-9670-fd55a175a010) | ![After: a light-theme external-image placeholder names the blocked image and offers Open image](https://github.com/user-attachments/assets/57ba5036-f055-442d-8664-f7eba62589a8) |
| Dark | ![Before in dark theme: only the image alt text remains](https://github.com/user-attachments/assets/94b5f1d5-fc6b-4d3f-9f37-a15286a5b2b3) | ![After in dark theme: the blocked-image placeholder and opt-in action are visible](https://github.com/user-attachments/assets/b0c5e341-229a-420d-b797-f2faf8e3db23) |

Screenshots came from the same 1200×900 Chromium viewport and deterministic mocked-Gateway transcript in both refs. The proof-only harness rendered the remote Markdown image through the real chat surface, switched light/dark theme state, and captured `.chat-text` without navigating to or fetching the external source:

```shell
OPENCLAW_SECJS_PROOF_DIR=<dir> node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner \
  ui/src/e2e/chat-secjs-proof.e2e.test.ts
```

Regression proof:

```shell
# Before implementation: failed because no placeholder or action existed.
node scripts/run-vitest.mjs ui/src/components/markdown.test.ts

# Final focused coverage: 90/90 passed.
node scripts/run-vitest.mjs \
  ui/src/components/markdown.test.ts \
  ui/src/components/markdown-document.test.ts
```

The assertions cover the placeholder label, HTTPS destination, `_blank`, `noreferrer noopener`, no `<img>` fetch in message mode, authored rich-link preservation without nested anchors, inline data images, unsafe image schemes, assistant-role labels, and the unchanged document-mode remote-image path.

Remote changed gate:

```shell
node scripts/check-changed.mjs -- \
  ui/src/components/markdown-assistant-transcript.ts \
  ui/src/components/markdown-parser.ts \
  ui/src/components/markdown.test.ts \
  ui/src/i18n/locales/en.ts \
  ui/src/styles/chat/text.css
```

Passed on Blacksmith Testbox run [31539510944](https://github.com/openclaw/openclaw/actions/runs/31539510944): formatting, guards, i18n verification, dead-export scan, UI/core-test typechecks, and lint all completed successfully.

Production LOC: `+39/-4` (net `+35`). Test LOC: `+54/-14` (net `+40`). The production addition is the complete visible outcome: one renderer callback, two canonical English strings, and theme-aware placeholder styling shared by transcript/sidebar Markdown.

