### PR TITLE
fix(ui): keep short JSON replies visible

### DIFF
--- a/ui/src/components/markdown-code-blocks.ts
+++ b/ui/src/components/markdown-code-blocks.ts
@@ -20,6 +20,8 @@ import { escapeMarkdownHtml, isMarkdownBlockArtText } from "./markdown-text.ts";
 
 const blockArtCopyPayloadPrefix = "openclaw:block-art-code:";
 const blockArtCodeBlockCopyPayloadEncoding = "block-art-json";
+// Keep typical replies visible; disclosure is reserved for JSON that dominates the transcript.
+const JSON_COLLAPSE_LINE_THRESHOLD = 40;
 const codeBlockCopyAttempts = new WeakMap<HTMLElement, number>();
 const codeBlockCopyResetTimers = new WeakMap<HTMLElement, ReturnType<typeof setTimeout>>();
 
@@ -175,12 +177,11 @@ export function renderMarkdownCodeBlock(
         (trimmed.startsWith("[") && trimmed.endsWith("]"))));
 
   if (isJson) {
-    const lineCount = text.split("\n").length;
-    const label =
-      lineCount > 1
-        ? escapeMarkdownHtml(t("chat.codeBlock.jsonLines", { count: String(lineCount) }))
-        : "JSON";
-    return `<details class="json-collapse"><summary>${label}</summary><div class="code-block-wrapper">${header}${codeBlock}</div></details>`;
+    const lineCount = markdownCodeBlockCopyText(text).split("\n").length;
+    if (lineCount > JSON_COLLAPSE_LINE_THRESHOLD) {
+      const label = escapeMarkdownHtml(t("chat.codeBlock.jsonLines", { count: String(lineCount) }));
+      return `<details class="json-collapse code-block-wrapper"><summary class="code-block-header"><span>${label}</span>${copyButton}</summary>${codeBlock}</details>`;
+    }
   }
 
   return `<div class="code-block-wrapper">${header}${codeBlock}</div>`;

--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -241,6 +241,11 @@ describe("toSanitizedMarkdownHtml", () => {
 
   describe("code blocks", () => {
     const blockArt = "  ▀▀▀▀  \n  ▄▄▄▄  \n  ████  ";
+    const jsonBlock = (lineCount: number) => {
+      const values = Array.from({ length: lineCount - 2 }, (_, index) => `  ${index},`);
+      values[values.length - 1] = values.at(-1)?.slice(0, -1) ?? "";
+      return `\`\`\`json\n[\n${values.join("\n")}\n]\n\`\`\``;
+    };
 
     it("renders raw block art as a whitespace-preserving code block", () => {
       const html = toSanitizedMarkdownHtml(blockArt);
@@ -343,15 +348,28 @@ PY
       );
     });
 
-    it("highlights collapsed JSON code blocks", () => {
-      const html = toSanitizedMarkdownHtml('```json\n{"ok": true}\n```');
+    it("keeps short JSON code blocks visible and highlighted", () => {
+      const html = toSanitizedMarkdownHtml(jsonBlock(6));
       const fragment = htmlFragment(html);
-      const details = fragment.querySelector("details.json-collapse");
-      const code = details?.querySelector("pre code");
+      const code = fragment.querySelector(".code-block-wrapper pre code");
 
-      expect(details?.querySelector("summary")?.textContent).toBe("JSON · 2 lines");
-      expect(code?.textContent).toBe('{"ok": true}\n');
+      expect(fragment.querySelector("details.json-collapse")).toBeNull();
+      expect(code?.textContent?.split("\n")).toHaveLength(7);
       expect(code?.innerHTML).toContain("hljs-");
+    });
+
+    it("collapses JSON only above 40 lines and uses one copyable header", () => {
+      const atLimit = htmlFragment(toSanitizedMarkdownHtml(jsonBlock(40)));
+      const overLimit = htmlFragment(toSanitizedMarkdownHtml(jsonBlock(41)));
+      const details = overLimit.querySelector("details.json-collapse");
+      const summary = details?.querySelector("summary");
+
+      expect(atLimit.querySelector("details.json-collapse")).toBeNull();
+      expect(summary?.textContent).toContain("JSON · 41 lines");
+      expect(summary?.querySelector(".code-block-copy")).toBeInstanceOf(HTMLButtonElement);
+      expect(details?.querySelectorAll(".code-block-header")).toHaveLength(1);
+      expect(summary?.classList.contains("code-block-header")).toBe(true);
+      expect(details?.querySelector("pre code")?.innerHTML).toContain("hljs-");
     });
 
     it("localizes collapsed JSON line counts", async () => {
@@ -364,8 +382,8 @@ PY
       });
       await i18n.setLocale("pt-BR");
       try {
-        const fragment = htmlFragment(toSanitizedMarkdownHtml('```json\n{"ok": true}\n```'));
-        expect(fragment.querySelector("summary")?.textContent).toBe("JSON · 2 linhas");
+        const fragment = htmlFragment(toSanitizedMarkdownHtml(jsonBlock(41)));
+        expect(fragment.querySelector("summary")?.textContent).toContain("JSON · 41 linhas");
       } finally {
         await i18n.setLocale("en");
       }

--- a/ui/src/e2e/chat-json-code-block.e2e.test.ts
+++ b/ui/src/e2e/chat-json-code-block.e2e.test.ts
@@ -1,0 +1,140 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { chromium, type Browser, type Page } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const proofStage = process.env.OPENCLAW_JSON_CODE_PROOF_STAGE ?? "after";
+const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/chat-json-code-block");
+
+function fencedJson(lineCount: number): string {
+  const values = Array.from({ length: lineCount - 2 }, (_, index) => `  ${index},`);
+  values[values.length - 1] = values.at(-1)?.slice(0, -1) ?? "";
+  return `\`\`\`json\n[\n${values.join("\n")}\n]\n\`\`\``;
+}
+
+const shortJson = `\`\`\`json
+{
+  "status": "ok",
+  "items": [
+    "alpha"
+  ]
+}
+\`\`\``;
+
+async function setThemeMode(page: Page, mode: "dark" | "light"): Promise<void> {
+  await page.emulateMedia({ colorScheme: mode });
+  await page.evaluate((nextMode) => {
+    const root = document.documentElement;
+    root.dataset.themeMode = nextMode;
+    root.dataset.themeResolved = nextMode;
+    root.classList.toggle("wa-light", nextMode === "light");
+    root.classList.toggle("wa-dark", nextMode === "dark");
+    root.style.colorScheme = nextMode;
+  }, mode);
+}
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+
+describeControlUiE2e("Control UI JSON code blocks", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
+    }
+    if (captureProof) {
+      await mkdir(artifactDir, { recursive: true });
+    }
+    server = await startControlUiE2eServer(undefined, { source: true });
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it.each(["dark", "light"] as const)(
+    "keeps short JSON visible and reserves one disclosure header for long JSON in %s mode",
+    async (theme) => {
+      const context = await browser.newContext({
+        colorScheme: theme,
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+      });
+      await context.grantPermissions(["clipboard-read", "clipboard-write"], {
+        origin: new URL(server.baseUrl).origin,
+      });
+      const page = await context.newPage();
+      await installMockGateway(page, {
+        historyMessages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Show the full diagnostic payload." }],
+            timestamp: Date.now(),
+            __openclaw: { id: "user-json-long", seq: 1 },
+          },
+          {
+            role: "assistant",
+            content: [{ type: "text", text: fencedJson(41) }],
+            timestamp: Date.now() + 1,
+            __openclaw: { id: "assistant-json-long", seq: 2 },
+          },
+          {
+            role: "user",
+            content: [{ type: "text", text: "Return the deployment receipt as JSON." }],
+            timestamp: Date.now() + 2,
+            __openclaw: { id: "user-json-short", seq: 3 },
+          },
+          {
+            role: "assistant",
+            content: [{ type: "text", text: shortJson }],
+            timestamp: Date.now() + 3,
+            __openclaw: { id: "assistant-json-short", seq: 4 },
+          },
+        ],
+      });
+
+      try {
+        await page.goto(`${server.baseUrl}chat`);
+        await setThemeMode(page, theme);
+        const shortBubble = page.locator('[data-entry-id="assistant-json-short"]');
+        const longBubble = page.locator('[data-entry-id="assistant-json-long"]');
+        await shortBubble.waitFor({ state: "visible" });
+        if (captureProof) {
+          await page.screenshot({
+            animations: "disabled",
+            path: path.join(artifactDir, `${proofStage}-${theme}.png`),
+          });
+        }
+
+        expect(await shortBubble.locator("details.json-collapse").count()).toBe(0);
+        expect(await shortBubble.locator("pre code").isVisible()).toBe(true);
+
+        const details = longBubble.locator("details.json-collapse");
+        const summary = details.locator("summary");
+        expect(await summary.textContent()).toContain("JSON · 41 lines");
+        expect(await summary.locator(".code-block-copy").count()).toBe(1);
+        expect(await details.locator(".code-block-header").count()).toBe(1);
+        await summary.click();
+        await expect.poll(() => details.getAttribute("open")).toBe("");
+        await summary.locator(".code-block-copy").click();
+        await expect.poll(() => details.getAttribute("open")).toBe("");
+      } finally {
+        await context.close();
+      }
+    },
+  );
+});

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2335,10 +2335,20 @@ openclaw-chat-session-rail {
 }
 
 .json-collapse summary {
+  display: list-item;
   font-size: 12px;
   color: var(--muted);
   padding: 4px 8px;
+  border-radius: var(--radius-sm);
   user-select: none;
+}
+
+.json-collapse summary .code-block-copy {
+  float: right;
+}
+
+.json-collapse[open] summary {
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
 }
 
 .json-collapse summary:hover {


### PR DESCRIPTION
Closes #122274

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users receiving a short assistant reply made entirely of fenced JSON would see an apparently empty message because the code block started collapsed.

## Why This Change Was Made

In this PR, JSON code blocks up to 40 lines use the existing visible code card. Larger JSON blocks retain a disclosure, with the line count and Copy action in one header so opening the block does not reveal a duplicated header.

## User Impact

Short JSON answers are readable immediately, while long payloads remain compact. Non-JSON code blocks and the separate pure-JSON message renderer are unchanged.

## Evidence

| Theme | Before | Proposed in this PR |
| --- | --- | --- |
| Dark | ![Before: short JSON reply collapsed in dark mode](https://github.com/user-attachments/assets/8dfafaf1-e78f-48e4-896e-60c12d19b4a2) | ![Proposed: short JSON visible and long JSON compact in dark mode](https://github.com/user-attachments/assets/c4545e64-510d-424f-b66f-cfc9b2f3af4b) |
| Light | ![Before: short JSON reply collapsed in light mode](https://github.com/user-attachments/assets/76b7c011-35bf-41d2-ba0d-8193cd454b44) | ![Proposed: short JSON visible and long JSON compact in light mode](https://github.com/user-attachments/assets/935db3bf-382d-4c95-8e36-a9c5d3fa2de3) |

- Focused Markdown suite: 88 passed.
- Control UI browser coverage: 2 passed (dark and light).
- Changed-surface checks: passed, including typechecks, formatting, i18n verification, dead-export scan, and lint.
- Production delta: +17/-6 lines (net +11); test delta: +166/-8 lines.
