### PR TITLE
fix(ui): make chat transcript prose easier to scan

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -1304,6 +1304,104 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
+  it("keeps transcript prose readable without narrowing structured blocks", async () => {
+    const page = await openBrowserPage(1600, 1000);
+    const prose =
+      "A reliable transcript should make the main idea easy to follow before the reader reaches the details. This paragraph carries realistic context about the change, the tradeoffs, the proof, and the next action so its line length exposes the reading measure rather than a short fixture.";
+    try {
+      await page.setContent(`<!doctype html><html><head><style>${readUiCss()}</style></head><body>
+        <section class="card chat" data-theme="dark">
+          <div class="chat-thread" role="log">
+            <div class="chat-thread-inner">
+              <div class="chat-group assistant">
+                <div class="chat-avatar assistant">A</div>
+                <div class="chat-group-messages">
+                  <div class="chat-bubble">
+                    <div class="chat-text">
+                      <h2>Decision and supporting context</h2>
+                      <p id="measure-prose">${prose}</p>
+                      <ul id="measure-list">
+                        <li>Preserve the operator's mental model across the whole response.</li>
+                        <li>Keep the proof visible next to the decision it supports.</li>
+                      </ul>
+                      <blockquote><p>Everything should remain readable when the transcript is scanned.</p></blockquote>
+                      <details id="measure-details" open>
+                        <summary>Implementation details</summary>
+                        <p>${prose}</p>
+                      </details>
+                      <pre id="measure-code"><code>const transcriptMeasure = 68;\nconsole.log(transcriptMeasure);</code></pre>
+                      <table id="measure-table">
+                        <thead><tr><th>Surface</th><th>Decision</th><th>Evidence</th></tr></thead>
+                        <tbody><tr><td>Prose</td><td>Cap measure</td><td>68ch target</td></tr></tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </body></html>`);
+
+      const metrics = await page.evaluate(() => {
+        const lineLengths = (selector: string) => {
+          const element = document.querySelector<HTMLElement>(selector);
+          const textNode = element?.firstChild;
+          if (!(textNode instanceof Text)) {
+            throw new Error(`Expected text fixture for ${selector}`);
+          }
+          const lines = new Map<number, number>();
+          const range = document.createRange();
+          for (let index = 0; index < textNode.length; index += 1) {
+            range.setStart(textNode, index);
+            range.setEnd(textNode, index + 1);
+            const top = Math.round(range.getBoundingClientRect().top * 100) / 100;
+            lines.set(top, (lines.get(top) ?? 0) + 1);
+          }
+          return [...lines.values()];
+        };
+        const rect = (selector: string) => {
+          const element = document.querySelector<HTMLElement>(selector);
+          if (!element) {
+            throw new Error(`Missing fixture element ${selector}`);
+          }
+          const bounds = element.getBoundingClientRect();
+          return { width: bounds.width, height: bounds.height };
+        };
+        const text = document.querySelector<HTMLElement>(".chat-text");
+        const prose = document.querySelector<HTMLElement>("#measure-prose");
+        if (!text || !prose) {
+          throw new Error("Missing transcript measure fixture");
+        }
+        const textStyle = getComputedStyle(text);
+        const proseStyle = getComputedStyle(prose);
+        return {
+          code: rect("#measure-code"),
+          details: rect("#measure-details"),
+          fontSize: Number.parseFloat(textStyle.fontSize),
+          lane: rect(".chat-group-messages"),
+          lineHeight: Number.parseFloat(textStyle.lineHeight),
+          list: rect("#measure-list"),
+          maxProseLineLength: Math.max(...lineLengths("#measure-prose")),
+          prose: rect("#measure-prose"),
+          proseMaxWidth: Number.parseFloat(proseStyle.maxWidth),
+          table: rect("#measure-table"),
+        };
+      });
+
+      expect(metrics.lineHeight / metrics.fontSize).toBeCloseTo(1.58, 2);
+      expect(metrics.proseMaxWidth).toBeCloseTo(metrics.prose.width, 0);
+      expect(metrics.maxProseLineLength).toBeLessThanOrEqual(100);
+      expect(metrics.prose.width).toBeLessThan(metrics.lane.width - 100);
+      expect(metrics.list.width).toBeCloseTo(metrics.prose.width, 0);
+      expect(metrics.details.width).toBeCloseTo(metrics.prose.width, 0);
+      expect(metrics.code.width).toBeCloseTo(metrics.lane.width, 0);
+      expect(metrics.table.width).toBeCloseTo(metrics.lane.width, 0);
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
   it("gives inline MCP Apps the full assistant message column", async () => {
     const page = await openBrowserPage(1366, 900);
     try {

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -608,6 +608,7 @@ img.chat-avatar.chat-avatar--logo {
 }
 
 .chat-group.assistant .chat-bubble {
+  width: 100%;
   padding: 4px 0;
   border: 0;
   background: transparent;

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -20,10 +20,17 @@
 
 .chat-text {
   font-size: var(--chat-text-size);
-  line-height: 1.5;
+  line-height: 1.58;
   color: var(--chat-text);
   overflow-wrap: anywhere;
   word-break: break-word;
+}
+
+/* Continuous prose is easier to scan at a character-based measure. Keep code,
+   tables, and widget-owned surfaces on the full message lane so structured
+   content does not inherit a narrow reading column. */
+.chat-text > :where(h1, h2, h3, h4, h5, h6, p, ul, ol, blockquote, details) {
+  max-width: 68ch;
 }
 
 .chat-message-disclosure__preview {


### PR DESCRIPTION
## Summary

This PR proposes a more readable default measure for long Control UI chat transcripts.

- Set chat text leading to 1.58 while keeping the existing 14px Inter-based body size.
- Cap direct prose blocks at 68ch: headings, paragraphs, lists, blockquotes, and details.
- Keep code blocks and tables on the full assistant message lane; the assistant bubble now fills that lane so the structured-content exception works consistently.
- Add a browser-layout regression covering the measure, line-height, prose/list/details widths, and full-width code/table behavior.

Closes #122305.

## Why

The current default path uses 14px text at 1.5 line-height, with no character-based prose cap. In the populated browser fixture, the assistant lane is 702px and prose lines reach 112 characters. The proposed 68ch measure resolves to about 600px in the same fixture, with measured line lengths at or below 100 while structured blocks remain 702px wide.

The source history shows that the 900px/980px values were introduced as message-column and responsive-width layout decisions, not as a prose reading measure. This PR keeps that layout behavior for structured content and adds the missing prose-specific constraint. The rationale follows the [W3C visual-presentation guidance](https://www.w3.org/WAI/WCAG22/Understanding/visual-presentation.html) and [Butterick's line-length guidance](https://practicaltypography.com/line-length.html).

## Screenshots

Rich populated transcript, before/after in both themes:

![Before — light](https://github.com/user-attachments/assets/1a50bd88-9980-4220-b2c7-e75ec6c0d188)

![After — light](https://github.com/user-attachments/assets/199c7b35-cd1f-4db9-8751-215cbd0992d1)

![Before — dark](https://github.com/user-attachments/assets/131f1f35-0291-4b00-be43-2302e66256c9)

![After — dark](https://github.com/user-attachments/assets/4623a7e6-50c2-44a1-9049-c8ad0729f744)

Side-by-side current vs prototype target:

![Current vs prototype target](https://github.com/user-attachments/assets/f0eaccd2-7ee5-45c0-87b7-f5509bae0d85)

## Validation

- Direct Chromium before/after probe: passed; 21px -> 22.12px line-height, 702px -> 599.6px prose, code/table remain 702px.
- Stylelint for the two changed CSS files: passed.
- `git diff --check`: passed.
- Focused Vitest could not start in this sparse worktree because the linked test runner/config dependencies are not present locally; no dependency installation was performed. The new test is intended for the remote UI/browser lane.

## Coordination

PR #122289 remains OPEN. Its text.css changes are adjacent block-spacing declarations; this patch does not touch those declarations. The branch was rebased onto the current origin/main before publication.

Review focus: default-path readability and the prose-versus-structured-content boundary. No merge requested; final review is by Vyctor.

