### PR TITLE
fix(ui): gate model shortcuts by search focus

### DIFF
--- a/ui/src/e2e/chat-composer-accessory-focus.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-accessory-focus.e2e.test.ts
@@ -9,7 +9,7 @@ const suite = createControlUiE2eSuite({
 });
 
 suite.define(() => {
-  it("keeps focus in place when pointer-opening passive composer popovers", async () => {
+  it("routes focus by composer accessory purpose", async () => {
     await suite.withPage({ viewport: { width: 1440, height: 900 } }, async ({ page }) => {
       const gateway = await installMockGateway(page, {
         models: [{ id: "gpt-5.6", name: "GPT-5.6", provider: "openai" }],
@@ -114,28 +114,30 @@ suite.define(() => {
         await trigger.press("Enter");
       }
 
-      for (const popover of [
-        {
-          focus: ".chat-controls__model-search",
-          trigger: ".chat-controls__model-picker > summary",
-        },
-        {
-          focus: ".agent-chat__attach-menu-option",
-          trigger: ".agent-chat__input-btn--attach",
-        },
-      ]) {
-        await outside.focus();
-        await composer.locator(popover.trigger).click();
-        await expect
-          .poll(() =>
-            page
-              .locator(popover.focus)
-              .first()
-              .evaluate((element) => document.activeElement === element),
-          )
-          .toBe(true);
-        await page.keyboard.press("Escape");
-      }
+      const modelTrigger = composer.locator(".chat-controls__model-picker > summary");
+      await outside.focus();
+      await modelTrigger.click();
+      expect(await modelTrigger.evaluate((element) => document.activeElement === element)).toBe(
+        true,
+      );
+      expect(
+        await page
+          .locator(".chat-controls__model-search")
+          .evaluate((element) => document.activeElement === element),
+      ).toBe(false);
+      await page.keyboard.press("Escape");
+
+      await outside.focus();
+      await composer.locator(".agent-chat__input-btn--attach").click();
+      await expect
+        .poll(() =>
+          page
+            .locator(".agent-chat__attach-menu-option")
+            .first()
+            .evaluate((element) => document.activeElement === element),
+        )
+        .toBe(true);
+      await page.keyboard.press("Escape");
     });
   });
 });

--- a/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
@@ -530,7 +530,8 @@ suite.define(() => {
       const search = main.locator('[data-chat-model-search="true"]');
       await expect
         .poll(() => search.evaluate((element) => element === document.activeElement))
-        .toBe(true);
+        .toBe(false);
+      await search.focus();
       await search.fill("anthropic");
       const anthropicModel = main.locator('[data-chat-model-option="anthropic/claude-fable-5"]');
       await expect.poll(() => anthropicModel.isVisible()).toBe(true);

--- a/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
@@ -248,21 +248,14 @@ suite.define(() => {
         .toBe(true);
       const secondShortcut = secondModel.locator('[data-chat-model-shortcut-number="2"]');
       await expect.poll(() => secondShortcut.count()).toBe(1);
-      await page.keyboard.press("2");
-      await expect.poll(() => picker.getAttribute("open")).toBe(null);
-      await expect.poll(() => modelSelect.textContent()).toContain("Claude Sonnet 4.6");
-
-      await modelSelect.click();
-      const firstShortcut = firstModel.locator('[data-chat-model-shortcut-number="1"]');
-      await expect.poll(() => firstShortcut.count()).toBe(1);
       const menuBoxBeforeFocus = await page.locator(".chat-controls__model-menu").boundingBox();
-      const actionBoxBeforeFocus = await firstModel
+      const actionBoxBeforeFocus = await secondModel
         .locator(".chat-controls__model-option-action")
         .boundingBox();
       expect(menuBoxBeforeFocus).not.toBeNull();
       expect(actionBoxBeforeFocus).not.toBeNull();
       await expect
-        .poll(() => firstShortcut.evaluate((element) => getComputedStyle(element).opacity))
+        .poll(() => secondShortcut.evaluate((element) => getComputedStyle(element).opacity))
         .toBe("1");
 
       await search.focus();
@@ -270,28 +263,29 @@ suite.define(() => {
         .poll(() => search.evaluate((element) => element === document.activeElement))
         .toBe(true);
       await expect
-        .poll(() => firstShortcut.evaluate((element) => getComputedStyle(element).opacity))
+        .poll(() => secondShortcut.evaluate((element) => getComputedStyle(element).opacity))
         .toBe("0");
       expect(await page.locator(".chat-controls__model-menu").boundingBox()).toEqual(
         menuBoxBeforeFocus,
       );
-      expect(await firstModel.locator(".chat-controls__model-option-action").boundingBox()).toEqual(
-        actionBoxBeforeFocus,
-      );
+      expect(
+        await secondModel.locator(".chat-controls__model-option-action").boundingBox(),
+      ).toEqual(actionBoxBeforeFocus);
       await search.press("1");
       await expect.poll(() => search.inputValue()).toBe("1");
       await expect.poll(() => picker.getAttribute("open")).toBe("");
 
-      await search.fill("openai");
-      await expect.poll(() => firstModel.isVisible()).toBe(true);
-      await expect.poll(() => secondModel.isVisible()).toBe(false);
+      await search.fill("anthropic");
+      await expect.poll(() => firstModel.isVisible()).toBe(false);
+      await expect.poll(() => secondModel.isVisible()).toBe(true);
       await modelSelect.focus();
+      const filteredShortcut = secondModel.locator('[data-chat-model-shortcut-number="1"]');
       await expect
-        .poll(() => firstShortcut.evaluate((element) => getComputedStyle(element).opacity))
+        .poll(() => filteredShortcut.evaluate((element) => getComputedStyle(element).opacity))
         .toBe("1");
       await page.keyboard.press("1");
       await expect.poll(() => picker.getAttribute("open")).toBe(null);
-      await expect.poll(() => modelSelect.textContent()).toContain("GPT 5.5");
+      await expect.poll(() => modelSelect.textContent()).toContain("Claude Sonnet 4.6");
     });
   });
 

--- a/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
@@ -230,6 +230,71 @@ suite.define(() => {
     });
   });
 
+  it("separates model shortcuts from numeric search input by focus", async () => {
+    await withNewSessionPage(DESKTOP_CONTEXT, async (page) => {
+      await installMockGateway(page, { models: MODELS });
+      await page.goto(`${suite.server.baseUrl}new`);
+
+      const modelSelect = page.locator('[data-chat-model-select="true"]');
+      const picker = page.locator(".chat-controls__model-picker");
+      const search = page.locator('[data-chat-model-search="true"]');
+      const firstModel = page.locator('[data-chat-model-option="openai/gpt-5.5"]');
+      const secondModel = page.locator('[data-chat-model-option="anthropic/claude-sonnet-4-6"]');
+
+      await modelSelect.click();
+      await expect.poll(() => picker.getAttribute("open")).toBe("");
+      await expect
+        .poll(() => modelSelect.evaluate((element) => element === document.activeElement))
+        .toBe(true);
+      const secondShortcut = secondModel.locator('[data-chat-model-shortcut-number="2"]');
+      await expect.poll(() => secondShortcut.count()).toBe(1);
+      await page.keyboard.press("2");
+      await expect.poll(() => picker.getAttribute("open")).toBe(null);
+      await expect.poll(() => modelSelect.textContent()).toContain("Claude Sonnet 4.6");
+
+      await modelSelect.click();
+      const firstShortcut = firstModel.locator('[data-chat-model-shortcut-number="1"]');
+      await expect.poll(() => firstShortcut.count()).toBe(1);
+      const menuBoxBeforeFocus = await page.locator(".chat-controls__model-menu").boundingBox();
+      const actionBoxBeforeFocus = await firstModel
+        .locator(".chat-controls__model-option-action")
+        .boundingBox();
+      expect(menuBoxBeforeFocus).not.toBeNull();
+      expect(actionBoxBeforeFocus).not.toBeNull();
+      await expect
+        .poll(() => firstShortcut.evaluate((element) => getComputedStyle(element).opacity))
+        .toBe("1");
+
+      await search.focus();
+      await expect
+        .poll(() => search.evaluate((element) => element === document.activeElement))
+        .toBe(true);
+      await expect
+        .poll(() => firstShortcut.evaluate((element) => getComputedStyle(element).opacity))
+        .toBe("0");
+      expect(await page.locator(".chat-controls__model-menu").boundingBox()).toEqual(
+        menuBoxBeforeFocus,
+      );
+      expect(await firstModel.locator(".chat-controls__model-option-action").boundingBox()).toEqual(
+        actionBoxBeforeFocus,
+      );
+      await search.press("1");
+      await expect.poll(() => search.inputValue()).toBe("1");
+      await expect.poll(() => picker.getAttribute("open")).toBe("");
+
+      await search.fill("openai");
+      await expect.poll(() => firstModel.isVisible()).toBe(true);
+      await expect.poll(() => secondModel.isVisible()).toBe(false);
+      await modelSelect.focus();
+      await expect
+        .poll(() => firstShortcut.evaluate((element) => getComputedStyle(element).opacity))
+        .toBe("1");
+      await page.keyboard.press("1");
+      await expect.poll(() => picker.getAttribute("open")).toBe(null);
+      await expect.poll(() => modelSelect.textContent()).toContain("GPT 5.5");
+    });
+  });
+
   it("keeps the effort label, slider stop, and create payload aligned after a model switch", async () => {
     await withNewSessionPage(DESKTOP_CONTEXT, async (page) => {
       const levels = (ids: string[]) => ids.map((id) => ({ id, label: id }));

--- a/ui/src/pages/chat/components/chat-model-picker.ts
+++ b/ui/src/pages/chat/components/chat-model-picker.ts
@@ -258,13 +258,9 @@ function handleModelPickerKeydown(event: KeyboardEvent): void {
   if (!details.open || event.target instanceof HTMLInputElement || !/^[1-9]$/u.test(event.key)) {
     return;
   }
-  const row = visibleModelRows(details).find(
-    (candidate) => candidate.dataset.chatModelIndex === String(Number(event.key) - 1),
-  );
-  if (row) {
-    event.preventDefault();
-    row.click();
-  }
+  const row = visibleModelRows(details)[Number(event.key) - 1];
+  event.preventDefault();
+  row?.click();
 }
 
 function renderCatalogState(state: ChatModelCatalogState | undefined, hasOptions: boolean) {
@@ -420,7 +416,9 @@ export function renderChatModelPicker(params: ChatModelPickerParams) {
         @click=${(event: MouseEvent) => {
           if (params.disabled) {
             event.preventDefault();
+            return;
           }
+          (event.currentTarget as HTMLElement).focus({ preventScroll: true });
         }}
       >
         ${modelToolsUnavailable

--- a/ui/src/pages/chat/components/chat-model-picker.ts
+++ b/ui/src/pages/chat/components/chat-model-picker.ts
@@ -91,8 +91,8 @@ function pickerMenu(target: EventTarget | null): HTMLElement | null {
     : null;
 }
 
-function visibleModelRows(menu: HTMLElement): HTMLButtonElement[] {
-  return [...menu.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]")]
+function visibleModelRows(root: HTMLElement): HTMLButtonElement[] {
+  return [...root.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]")]
     .filter((row) => !row.hidden)
     .toSorted(
       (left, right) =>
@@ -234,11 +234,6 @@ function handleModelSearchKeydown(event: KeyboardEvent): void {
   if (rows.length === 0) {
     return;
   }
-  if (/^[1-9]$/u.test(event.key) && input.value === "") {
-    event.preventDefault();
-    rows[Number(event.key) - 1]?.click();
-    return;
-  }
   if (event.key === "Enter") {
     const highlighted = rows.find((row) => row.hasAttribute("data-chat-model-highlighted"));
     if (highlighted) {
@@ -256,6 +251,20 @@ function handleModelSearchKeydown(event: KeyboardEvent): void {
   const nextIndex = currentIndex < 0 ? 0 : (currentIndex + offset) % rows.length;
   highlightModelRow(menu, rows[nextIndex]);
   rows[nextIndex]?.scrollIntoView?.({ block: "nearest" });
+}
+
+function handleModelPickerKeydown(event: KeyboardEvent): void {
+  const details = event.currentTarget as HTMLDetailsElement;
+  if (!details.open || event.target instanceof HTMLInputElement || !/^[1-9]$/u.test(event.key)) {
+    return;
+  }
+  const row = visibleModelRows(details).find(
+    (candidate) => candidate.dataset.chatModelIndex === String(Number(event.key) - 1),
+  );
+  if (row) {
+    event.preventDefault();
+    row.click();
+  }
 }
 
 function renderCatalogState(state: ChatModelCatalogState | undefined, hasOptions: boolean) {
@@ -382,6 +391,7 @@ export function renderChatModelPicker(params: ChatModelPickerParams) {
   return html`
     <details
       class="chat-controls__inline-select chat-controls__model-picker"
+      @keydown=${handleModelPickerKeydown}
       @toggle=${(event: Event) => {
         const details = event.currentTarget as HTMLDetailsElement;
         if (!details.open) {
@@ -392,7 +402,6 @@ export function renderChatModelPicker(params: ChatModelPickerParams) {
           const input = details.querySelector<HTMLInputElement>("[data-chat-model-search]");
           if (input) {
             updateModelSearch(input);
-            input.focus({ preventScroll: true });
           }
         });
       }}

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -4617,18 +4617,6 @@ button.chat-reply-preview--message:disabled {
   margin-left: auto;
 }
 
-.chat-controls__model-option-action kbd {
-  min-width: 18px;
-  padding: 1px 4px;
-  border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
-  border-radius: 4px;
-  color: var(--muted);
-  font-family: inherit;
-  font-size: 10px;
-  line-height: 1.35;
-  text-align: center;
-}
-
 .chat-controls__model-option-action kbd::before {
   content: attr(data-chat-model-shortcut-number);
 }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -4617,6 +4617,19 @@ button.chat-reply-preview--message:disabled {
   margin-left: auto;
 }
 
+@media (prefers-reduced-motion: no-preference) {
+  .chat-controls__model-option-action kbd {
+    transition: opacity var(--duration-fast) var(--ease-out);
+  }
+}
+
+.chat-controls__model-search-wrap:focus-within
+  ~ .chat-controls__model-options
+  .chat-controls__model-option-action
+  kbd {
+  opacity: 0;
+}
+
 .chat-controls__model-option-action kbd::before {
   content: attr(data-chat-model-shortcut-number);
 }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2789,7 +2789,8 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 /* Keycap hint, not content: the app's quiet mono shortcut idiom (see
    .chat-question-panel__option kbd), fixed-width so letters and digits share
    one rail beside the labels. */
-.session-menu__shortcut {
+.session-menu__shortcut,
+.chat-controls__model-option-action kbd {
   flex: 0 0 auto;
   min-width: 12px;
   color: var(--muted);


### PR DESCRIPTION
Closes #122292

## What Problem This Solves

#120495 deliberately introduced two fast paths together: `Search models` autofocus for type-and-Enter, and `1`–`9` shortcuts for visible model rows. With both active in the same focused empty text field, however, the first digit selects a model instead of behaving like search input, while the UI still looks like an editable field.

The model picker also renders those numbers as bordered keycaps, unlike the flat, muted shortcut labels already used by the sidebar session context menu.

## Why This Change Was Made

In this PR, the picker opens with its trigger retaining focus. In that state, flat numeric hints are visible and `1`–`9` select the row carrying the matching hint. Focusing `Search models` fades the hints out and lets digits enter the field normally. Returning focus to the picker restores both hints and shortcuts, including after filtering.

Opening unfocused is intentional: retaining #120495's autofocus under the new focus gate would make every shortcut hidden and inactive on open. Search remains one Tab or click away, preserving the original type-and-Enter path while giving the two input modes a clear focus boundary.

The hint treatment reuses the existing `.session-menu__shortcut` declarations. Opacity changes only the hint itself; the fixed action rail remains in layout throughout the transition.

## User Impact

- Open picker: numeric hints are visible, flat, and active.
- Search focused: hints fade out, digits type normally, and row geometry stays fixed.
- Focus returned: hints and shortcuts reactivate without layout shift.

## Evidence

### Picker states

| State | Light | Dark |
| --- | --- | --- |
| Before: search auto-focused, bordered hints still visible | ![Before in light theme: search is focused while bordered numeric hints remain visible](https://github.com/user-attachments/assets/db917953-1007-436f-87f8-7f751681df10) | ![Before in dark theme: search is focused while bordered numeric hints remain visible](https://github.com/user-attachments/assets/1b33fe97-e7c9-4152-9e74-dfa0a043b6c6) |
| Open, search unfocused | ![In this PR in light theme: picker opens with flat numeric hints visible](https://github.com/user-attachments/assets/aaaf0b19-744f-4a90-b1cc-c6bdc05edf3f) | ![In this PR in dark theme: picker opens with flat numeric hints visible](https://github.com/user-attachments/assets/15af6773-7293-43d9-826f-f6008919edbc) |
| Search focused | ![In this PR in light theme: focused search hides numeric hints](https://github.com/user-attachments/assets/d73ac6e5-1455-45fe-86d5-a5697bdef867) | ![In this PR in dark theme: focused search hides numeric hints](https://github.com/user-attachments/assets/737a4df9-30fd-4f0b-8297-e3fcd63271ee) |
| Return transition | ![In this PR in light theme: numeric hints fade back in](https://github.com/user-attachments/assets/70587eaf-f6b7-4914-b88c-e47da874075a) | ![In this PR in dark theme: numeric hints fade back in](https://github.com/user-attachments/assets/99851882-42d5-4152-890e-c265228d610c) |
| Returned, search unfocused | ![In this PR in light theme: flat numeric hints are visible again](https://github.com/user-attachments/assets/40bd30cb-0757-442f-b7da-81e00963d33e) | ![In this PR in dark theme: flat numeric hints are visible again](https://github.com/user-attachments/assets/53ddd428-6ef5-46bf-b5f6-92d1d47d2dff) |

<details>
<summary>Full-page context for every state</summary>

| State | Light | Dark |
| --- | --- | --- |
| Before | ![Before full-page context in light theme](https://github.com/user-attachments/assets/46d52888-137e-455a-b798-d95476e8c6bc) | ![Before full-page context in dark theme](https://github.com/user-attachments/assets/c7646f96-3831-47ba-8703-63f8dcccd086) |
| Open, search unfocused | ![Open and unfocused full-page context in light theme](https://github.com/user-attachments/assets/7ec8c25e-dea7-46d4-b5d1-87fa9c77fd59) | ![Open and unfocused full-page context in dark theme](https://github.com/user-attachments/assets/6a22aeed-af84-49ee-88dd-2667257a82ac) |
| Search focused | ![Search-focused full-page context in light theme](https://github.com/user-attachments/assets/25063861-bc6d-4bc1-875b-6fb787be95c9) | ![Search-focused full-page context in dark theme](https://github.com/user-attachments/assets/9ca4d2ba-bb45-4197-9aa5-7c23042237e2) |
| Return transition | ![Return-transition full-page context in light theme](https://github.com/user-attachments/assets/fc4766b7-fc5e-45e9-be19-10b96dfc776b) | ![Return-transition full-page context in dark theme](https://github.com/user-attachments/assets/c4f45a6d-1e1b-4f16-8f3c-09dd8da8ff28) |
| Returned, search unfocused | ![Returned and unfocused full-page context in light theme](https://github.com/user-attachments/assets/ee085bbf-71b5-4bed-bee2-94d3576c4aa4) | ![Returned and unfocused full-page context in dark theme](https://github.com/user-attachments/assets/80f57124-3ba9-428c-8eaf-fd2e82318032) |

</details>

### Verification

- Regression scenario: failed against the pre-change autofocus behavior, then passed on this branch.
- Focused Control UI E2E: 20 tests passed across composer focus, new-session, and model/reasoning flows.
- Visual state proof: light and dark themes; open, search-focused, transition, and returned states; stable menu and shortcut-rail geometry asserted.
- `OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 CI=1 pnpm check:changed`: passed.
- Focused E2E Testbox: `tbx_01kzssyczwkwb16qtasepm24b3` ([run](https://github.com/openclaw/openclaw/actions/runs/31554285280)).
- Check Testbox: `tbx_01kzspf1nf9v8b37c4as5zjy8r` ([run](https://github.com/openclaw/openclaw/actions/runs/31550863921)).
