### PR TITLE
fix(ui): show catalog labels in hidden section settings

### DIFF
--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -20,6 +20,7 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const catalogLabelProofVariant = process.env.OPENCLAW_CATALOG_LABEL_PROOF_VARIANT ?? "after";
 const hiddenSessionCatalogsStorageKey = "openclaw:sidebar:sessions:hidden-catalogs";
 const uiProofArtifactDir = path.join(
   process.cwd(),
@@ -94,6 +95,19 @@ async function holdUiProof(page: Page, durationMs = 600) {
   }
 }
 
+async function setThemeMode(page: Page, mode: "dark" | "light") {
+  await page.emulateMedia({ colorScheme: mode });
+  await page.evaluate((nextMode) => {
+    const root = document.documentElement;
+    root.dataset.themeMode = nextMode;
+    root.dataset.themeResolved = nextMode;
+    root.classList.toggle("wa-light", nextMode === "light");
+    root.classList.toggle("wa-dark", nextMode === "dark");
+    root.style.colorScheme = nextMode;
+  }, mode);
+  await expect.poll(() => page.locator("html").getAttribute("data-theme-mode")).toBe(mode);
+}
+
 async function openSidebarTestPage() {
   const context = await suite.browser.newContext({
     locale: "en-US",
@@ -112,7 +126,7 @@ suite.define(() => {
     const page = await suite.browser.newPage({ viewport: { height: 900, width: 1440 } });
     await page.addInitScript(
       ({ key, value }) => localStorage.setItem(key, JSON.stringify(value)),
-      { key: hiddenSessionCatalogsStorageKey, value: ["claude"] },
+      { key: hiddenSessionCatalogsStorageKey, value: ["claude", "offline-catalog"] },
     );
     const gateway = await installMockGateway(page, {
       featureMethods: ["sessions.catalog.list"],
@@ -132,19 +146,45 @@ suite.define(() => {
 
     try {
       await page.goto(`${suite.server.baseUrl}settings/appearance`);
-      await gateway.waitForRequest("sessions.catalog.list");
+      if (catalogLabelProofVariant !== "before") {
+        await gateway.waitForRequest("sessions.catalog.list");
+      }
       const recovery = page
         .getByRole("heading", { name: "Hidden session sections" })
         .locator("xpath=following-sibling::*[1]");
-      const row = recovery.locator(".settings-row", { hasText: "Claude Code" });
+      const expectedClaudeLabel = catalogLabelProofVariant === "before" ? "claude" : "Claude Code";
+      const row = recovery.locator(".settings-row", { hasText: expectedClaudeLabel });
+      const fallbackRow = recovery.locator(".settings-row", { hasText: "offline-catalog" });
       await expect.poll(() => row.isVisible()).toBe(true);
-      expect(await recovery.getByText("claude", { exact: true }).count()).toBe(0);
+      await expect.poll(() => fallbackRow.isVisible()).toBe(true);
+      expect(
+        await recovery.getByText(
+          catalogLabelProofVariant === "before" ? "Claude Code" : "claude",
+          { exact: true },
+        ).count(),
+      ).toBe(0);
+
+      if (captureUiProofEnabled) {
+        await mkdir(uiProofArtifactDir, { recursive: true });
+        await recovery.scrollIntoViewIfNeeded();
+        for (const theme of ["light", "dark"] as const) {
+          await setThemeMode(page, theme);
+          await page.screenshot({
+            animations: "disabled",
+            path: path.join(uiProofArtifactDir, `${catalogLabelProofVariant}-${theme}-context.png`),
+          });
+          await recovery.screenshot({
+            animations: "disabled",
+            path: path.join(uiProofArtifactDir, `${catalogLabelProofVariant}-${theme}-rows.png`),
+          });
+        }
+      }
 
       await row.getByRole("button", { name: "Show" }).click();
       await expect.poll(() => row.count()).toBe(0);
       expect(
         await page.evaluate((key) => localStorage.getItem(key), hiddenSessionCatalogsStorageKey),
-      ).toBe("[]");
+      ).toBe('["offline-catalog"]');
     } finally {
       await page.close();
     }

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -20,6 +20,7 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const hiddenSessionCatalogsStorageKey = "openclaw:sidebar:sessions:hidden-catalogs";
 const uiProofArtifactDir = path.join(
   process.cwd(),
   ".artifacts",
@@ -107,6 +108,48 @@ async function openSidebarTestPage() {
 }
 
 suite.define(() => {
+  it("uses catalog labels in the hidden-section recovery rows", async () => {
+    const page = await suite.browser.newPage({ viewport: { height: 900, width: 1440 } });
+    await page.addInitScript(
+      ({ key, value }) => localStorage.setItem(key, JSON.stringify(value)),
+      { key: hiddenSessionCatalogsStorageKey, value: ["claude"] },
+    );
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["sessions.catalog.list"],
+      methodResponses: {
+        "sessions.catalog.list": {
+          catalogs: [
+            {
+              id: "claude",
+              label: "Claude Code",
+              capabilities: { continueSession: true, archive: false },
+              hosts: [],
+            },
+          ],
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}settings/appearance`);
+      await gateway.waitForRequest("sessions.catalog.list");
+      const recovery = page
+        .getByRole("heading", { name: "Hidden session sections" })
+        .locator("xpath=following-sibling::*[1]");
+      const row = recovery.locator(".settings-row", { hasText: "Claude Code" });
+      await expect.poll(() => row.isVisible()).toBe(true);
+      expect(await recovery.getByText("claude", { exact: true }).count()).toBe(0);
+
+      await row.getByRole("button", { name: "Show" }).click();
+      await expect.poll(() => row.count()).toBe(0);
+      expect(
+        await page.evaluate((key) => localStorage.getItem(key), hiddenSessionCatalogsStorageKey),
+      ).toBe("[]");
+    } finally {
+      await page.close();
+    }
+  });
+
   it("pins routes, restores defaults, and persists navigation state across reloads", async () => {
     if (captureUiProofEnabled) {
       await mkdir(uiProofArtifactDir, { recursive: true });

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -20,7 +20,6 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const catalogLabelProofVariant = process.env.OPENCLAW_CATALOG_LABEL_PROOF_VARIANT ?? "after";
 const hiddenSessionCatalogsStorageKey = "openclaw:sidebar:sessions:hidden-catalogs";
 const uiProofArtifactDir = path.join(
   process.cwd(),
@@ -123,11 +122,16 @@ async function openSidebarTestPage() {
 
 suite.define(() => {
   it("uses catalog labels in the hidden-section recovery rows", async () => {
-    const page = await suite.browser.newPage({ viewport: { height: 900, width: 1440 } });
-    await page.addInitScript(
-      ({ key, value }) => localStorage.setItem(key, JSON.stringify(value)),
-      { key: hiddenSessionCatalogsStorageKey, value: ["claude", "offline-catalog"] },
-    );
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const page = await context.newPage();
+    await page.addInitScript(({ key, value }) => localStorage.setItem(key, JSON.stringify(value)), {
+      key: hiddenSessionCatalogsStorageKey,
+      value: ["claude", "offline-catalog"],
+    });
     const gateway = await installMockGateway(page, {
       featureMethods: ["sessions.catalog.list"],
       methodResponses: {
@@ -146,23 +150,15 @@ suite.define(() => {
 
     try {
       await page.goto(`${suite.server.baseUrl}settings/appearance`);
-      if (catalogLabelProofVariant !== "before") {
-        await gateway.waitForRequest("sessions.catalog.list");
-      }
-      const recovery = page
-        .getByRole("heading", { name: "Hidden session sections" })
-        .locator("xpath=following-sibling::*[1]");
-      const expectedClaudeLabel = catalogLabelProofVariant === "before" ? "claude" : "Claude Code";
-      const row = recovery.locator(".settings-row", { hasText: expectedClaudeLabel });
-      const fallbackRow = recovery.locator(".settings-row", { hasText: "offline-catalog" });
-      await expect.poll(() => row.isVisible()).toBe(true);
-      await expect.poll(() => fallbackRow.isVisible()).toBe(true);
-      expect(
-        await recovery.getByText(
-          catalogLabelProofVariant === "before" ? "Claude Code" : "claude",
-          { exact: true },
-        ).count(),
-      ).toBe(0);
+      await waitForControlUiSettingsTakeover(page);
+      await gateway.waitForRequest("sessions.catalog.list");
+      const sidebarSettings = page.locator("#settings-appearance-sidebar");
+      await sidebarSettings.getByRole("heading", { name: "Hidden session sections" }).waitFor();
+      const recovery = sidebarSettings.locator(".settings-group", { hasText: "offline-catalog" });
+      const row = recovery.locator(".settings-row", { hasText: "Claude Code" });
+      await expect.poll(() => recovery.textContent()).toContain("Claude Code");
+      await expect.poll(() => recovery.textContent()).toContain("offline-catalog");
+      expect(await recovery.getByText("claude", { exact: true }).count()).toBe(0);
 
       if (captureUiProofEnabled) {
         await mkdir(uiProofArtifactDir, { recursive: true });
@@ -171,11 +167,11 @@ suite.define(() => {
           await setThemeMode(page, theme);
           await page.screenshot({
             animations: "disabled",
-            path: path.join(uiProofArtifactDir, `${catalogLabelProofVariant}-${theme}-context.png`),
+            path: path.join(uiProofArtifactDir, `after-${theme}-context.png`),
           });
           await recovery.screenshot({
             animations: "disabled",
-            path: path.join(uiProofArtifactDir, `${catalogLabelProofVariant}-${theme}-rows.png`),
+            path: path.join(uiProofArtifactDir, `after-${theme}-rows.png`),
           });
         }
       }
@@ -186,7 +182,7 @@ suite.define(() => {
         await page.evaluate((key) => localStorage.getItem(key), hiddenSessionCatalogsStorageKey),
       ).toBe('["offline-catalog"]');
     } finally {
-      await page.close();
+      await context.close();
     }
   });
 

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -4,7 +4,10 @@ import { initialState, Task, TaskStatus } from "@lit/task";
 import { asNullableRecord as asConfigRecord } from "@openclaw/normalization-core/record-coerce";
 import { html, nothing, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
-import type { SystemInfoResult } from "../../../../packages/gateway-protocol/src/index.js";
+import type {
+  SessionsCatalogListResult,
+  SystemInfoResult,
+} from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ModelCatalogEntry } from "../../api/types.ts";
 import { titleForRoute } from "../../app-navigation.ts";
@@ -114,6 +117,7 @@ const MOVED_SECTION_ROUTES: Record<string, { routeId: RouteId; keepSection: bool
 };
 
 const SESSION_OBSERVER_STATUS_POLL_INTERVAL_MS = 10_000;
+const EMPTY_SESSION_CATALOG_LABELS: ReadonlyMap<string, string> = new Map();
 
 function defaultConfigSelection(pageId: ConfigPageId): ConfigSelection {
   switch (pageId) {
@@ -335,6 +339,42 @@ export class ConfigPage extends OpenClawLightDomElement {
         this.systemInfo = null;
         this.systemInfoUnavailable = true;
         this.systemInfoPolling.stop();
+      }
+    },
+  });
+  private readonly hiddenSessionCatalogLabelsTask = new Task(this, {
+    args: () => {
+      const gateway = this.context?.gateway.snapshot;
+      const hiddenCatalogIds = [...this.hiddenSessionCatalogIds].toSorted();
+      const client =
+        this.pageId === "appearance" &&
+        hiddenCatalogIds.length > 0 &&
+        canCallGatewayMethod(gateway, "sessions.catalog.list", "operator.read")
+          ? gateway?.client
+          : null;
+      return [
+        client,
+        this.context?.agentSelection.state.selectedId ?? null,
+        hiddenCatalogIds.join("\0"),
+      ] as const;
+    },
+    task: async ([client, agentId], { signal }) => {
+      if (!client) {
+        return EMPTY_SESSION_CATALOG_LABELS;
+      }
+      try {
+        const result = await client.request<SessionsCatalogListResult>(
+          "sessions.catalog.list",
+          {
+            ...(agentId ? { agentId } : {}),
+            limitPerHost: 1,
+          },
+          { signal },
+        );
+        return new Map(result.catalogs.map((catalog) => [catalog.id, catalog.label]));
+      } catch {
+        // Recovery must remain available when catalog discovery is unsupported or offline.
+        return EMPTY_SESSION_CATALOG_LABELS;
       }
     },
   });
@@ -1170,6 +1210,10 @@ export class ConfigPage extends OpenClawLightDomElement {
         this.settings.sidebarLiveActivity ?? UI_APPEARANCE_DEFAULTS.sidebarLiveActivity,
       setSidebarLiveActivity: (enabled) => this.setSetting("sidebarLiveActivity", enabled),
       hiddenSessionCatalogIds: this.hiddenSessionCatalogIds,
+      hiddenSessionCatalogLabels:
+        this.hiddenSessionCatalogLabelsTask.status === TaskStatus.COMPLETE
+          ? (this.hiddenSessionCatalogLabelsTask.value ?? EMPTY_SESSION_CATALOG_LABELS)
+          : EMPTY_SESSION_CATALOG_LABELS,
       setSessionCatalogHidden: setStoredSessionCatalogHidden,
       chatMessageMaxWidth: this.settings.chatMessageMaxWidth,
       setChatMessageMaxWidth: (value) => this.setSetting("chatMessageMaxWidth", value),

--- a/ui/src/pages/config/view-appearance-preferences.ts
+++ b/ui/src/pages/config/view-appearance-preferences.ts
@@ -486,7 +486,7 @@ export function renderSidebarPreferencesSection(props: ConfigProps) {
             <div class="settings-group">
               ${hiddenCatalogIds.map((catalogId) =>
                 renderSettingsRow({
-                  title: catalogId,
+                  title: props.hiddenSessionCatalogLabels.get(catalogId) ?? catalogId,
                   description: t("quickSettings.personal.browserOnly"),
                   control: html`<button
                     type="button"

--- a/ui/src/pages/config/view-types.ts
+++ b/ui/src/pages/config/view-types.ts
@@ -128,6 +128,7 @@ export type ConfigProps = {
   sidebarLiveActivity: boolean;
   setSidebarLiveActivity: (enabled: boolean) => void;
   hiddenSessionCatalogIds: ReadonlySet<string>;
+  hiddenSessionCatalogLabels: ReadonlyMap<string, string>;
   setSessionCatalogHidden: (catalogId: string, hidden: boolean) => void;
   chatMessageMaxWidth?: string;
   setChatMessageMaxWidth: (value: string | undefined) => void;

--- a/ui/src/pages/config/view.browser.test.ts
+++ b/ui/src/pages/config/view.browser.test.ts
@@ -2149,8 +2149,7 @@ describe("config view", () => {
     );
     const fallbackRow = Array.from(container.querySelectorAll<HTMLElement>(".settings-row")).find(
       (candidate) =>
-        candidate.querySelector(".settings-row__title")?.textContent?.trim() ===
-        "offline-catalog",
+        candidate.querySelector(".settings-row__title")?.textContent?.trim() === "offline-catalog",
     );
     expect(heading).toBeDefined();
     expect(labeledRow).toBeDefined();

--- a/ui/src/pages/config/view.browser.test.ts
+++ b/ui/src/pages/config/view.browser.test.ts
@@ -85,6 +85,7 @@ describe("config view", () => {
     sidebarLiveActivity: true,
     setSidebarLiveActivity: vi.fn(),
     hiddenSessionCatalogIds: new Set<string>(),
+    hiddenSessionCatalogLabels: new Map<string, string>(),
     setSessionCatalogHidden: vi.fn(),
     chatMessageMaxWidth: undefined,
     setChatMessageMaxWidth: vi.fn(),
@@ -2129,26 +2130,33 @@ describe("config view", () => {
     expect(setSidebarLiveActivity).toHaveBeenCalledWith(false);
   });
 
-  it("lists hidden session sections and offers to show them", () => {
+  it("labels hidden session sections from the catalog and keeps ids as the fallback", () => {
     const setSessionCatalogHidden = vi.fn();
     const { container } = renderConfigView({
       activeSection: "__appearance__",
       includeSections: ["__appearance__"],
-      hiddenSessionCatalogIds: new Set(["codex"]),
+      hiddenSessionCatalogIds: new Set(["claude", "offline-catalog"]),
+      hiddenSessionCatalogLabels: new Map([["claude", "Claude Code"]]),
       setSessionCatalogHidden,
     });
 
     const heading = Array.from(container.querySelectorAll("h3")).find(
       (candidate) => candidate.textContent?.trim() === "Hidden session sections",
     );
-    const row = Array.from(container.querySelectorAll<HTMLElement>(".settings-row")).find(
+    const labeledRow = Array.from(container.querySelectorAll<HTMLElement>(".settings-row")).find(
       (candidate) =>
-        candidate.querySelector(".settings-row__title")?.textContent?.trim() === "codex",
+        candidate.querySelector(".settings-row__title")?.textContent?.trim() === "Claude Code",
+    );
+    const fallbackRow = Array.from(container.querySelectorAll<HTMLElement>(".settings-row")).find(
+      (candidate) =>
+        candidate.querySelector(".settings-row__title")?.textContent?.trim() ===
+        "offline-catalog",
     );
     expect(heading).toBeDefined();
-    expect(row).toBeDefined();
-    row?.querySelector<HTMLButtonElement>("button")?.click();
-    expect(setSessionCatalogHidden).toHaveBeenCalledWith("codex", false);
+    expect(labeledRow).toBeDefined();
+    expect(fallbackRow).toBeDefined();
+    labeledRow?.querySelector<HTMLButtonElement>("button")?.click();
+    expect(setSessionCatalogHidden).toHaveBeenCalledWith("claude", false);
   });
 
   it("uses rich Lobsterdex lore tooltips and opens the full collection", () => {


### PR DESCRIPTION
## What Problem This Solves

Before, **Settings → Appearance → Hidden session sections** shows the internal catalog id `claude`. The sidebar calls the same section **Claude Code**, so an operator has to guess that both names refer to the same thing.

After this PR, the recovery row shows **Claude Code**, matching the sidebar. If catalog discovery is unavailable or a catalog is missing, the row still shows its raw id so the operator can recover it.

Closes #122317.

## Why This Change Was Made

The recovery UI should use the same operator-facing name as the sidebar. This PR reads the authoritative labels from the existing `sessions.catalog.list` response only when Appearance has hidden session sections.

Catalog ids remain the storage key and the target of **Show**. There is no preference migration or storage-shape change. A missing/offline catalog deliberately falls back to its id so recovery never disappears.

## User Impact

**Before:** the row shows the raw id `claude`.

**After:** the row shows **Claude Code**, equal to the sidebar label. Clicking **Show** still restores the `claude` section. An unavailable catalog remains visible as `offline-catalog`.

## Evidence

Rich scenario used in every image: two hidden sections together — `claude`, whose catalog label is **Claude Code**, and `offline-catalog`, which exercises the truthful id fallback.

### Light theme — full Settings context

<table>
<tr><th>Before: raw id</th><th>After: sidebar label</th></tr>
<tr>
<td><img width="1440" height="900" alt="Before in light theme: Settings Appearance shows claude and offline-catalog" src="https://github.com/user-attachments/assets/e8f358c1-d07d-4d2e-b94e-a22b793b581a" /></td>
<td><img width="1440" height="900" alt="After in light theme: Settings Appearance shows Claude Code and offline-catalog" src="https://github.com/user-attachments/assets/78522b2e-1110-4ad7-a7da-6f844af0cc75" /></td>
</tr>
</table>

### Light theme — tight row crop

<table>
<tr><th>Before: raw id</th><th>After: sidebar label</th></tr>
<tr>
<td><img width="728" height="128" alt="Before light row crop: claude and offline-catalog" src="https://github.com/user-attachments/assets/0a9fecbb-ba18-46ac-82dd-de5ea512812b" /></td>
<td><img width="728" height="128" alt="After light row crop: Claude Code and offline-catalog" src="https://github.com/user-attachments/assets/e81f25aa-5288-4b9b-9f0e-31dcd36b456d" /></td>
</tr>
</table>

### Dark theme — full Settings context

<table>
<tr><th>Before: raw id</th><th>After: sidebar label</th></tr>
<tr>
<td><img width="1440" height="900" alt="Before in dark theme: Settings Appearance shows claude and offline-catalog" src="https://github.com/user-attachments/assets/b1cdde64-7774-4d6a-b5ab-92c14398ee0f" /></td>
<td><img width="1440" height="900" alt="After in dark theme: Settings Appearance shows Claude Code and offline-catalog" src="https://github.com/user-attachments/assets/2afe90df-b99b-4888-a33d-1494b9121ee8" /></td>
</tr>
</table>

### Dark theme — tight row crop

<table>
<tr><th>Before: raw id</th><th>After: sidebar label</th></tr>
<tr>
<td><img width="728" height="128" alt="Before dark row crop: claude and offline-catalog" src="https://github.com/user-attachments/assets/3d677352-de94-4681-8392-eea1b785da99" /></td>
<td><img width="728" height="128" alt="After dark row crop: Claude Code and offline-catalog" src="https://github.com/user-attachments/assets/283a99f1-c791-4833-b136-0ae4dad018bc" /></td>
</tr>
</table>

### State matrix

| Recovery-row state | Light | Dark |
| --- | --- | --- |
| Catalog available (`claude`) | **Claude Code** | **Claude Code** |
| Catalog missing/offline (`offline-catalog`) | raw-id fallback | raw-id fallback |

### Verification

- Pre-fix reproduction failed at test-only commit `ad8a8e763747` because no row titled **Claude Code** existed.
- `node scripts/run-vitest.mjs ui/src/pages/config/view.browser.test.ts -t "labels hidden session sections"` — passed.
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/sidebar-customization.e2e.test.ts -t "uses catalog labels in the hidden-section recovery rows"` — passed against final head `f06c36cc5c6`.
- The E2E also verifies that **Show** removes only `claude` from the hidden-id preference, leaving `offline-catalog` intact.
- Autoreview: clean, no accepted/actionable findings.
