### PR TITLE
fix(ui): keep chat sharing menu compact

### DIFF
--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -468,7 +468,7 @@ suite.define(() => {
     expect(await gateway.getRequests("session.members.add")).toHaveLength(0);
   });
 
-  it("keeps high-volume member lists compact while visibility stays pinned", async () => {
+  it("scrolls high-volume sharing through one compact menu", async () => {
     const context = await suite.browser.newContext({ viewport: { height: 800, width: 1280 } });
     const currentPage = await context.newPage();
     page = currentPage;
@@ -529,26 +529,53 @@ suite.define(() => {
 
     const beforeScroll = await dropdown.evaluate((element) => {
       const menu = element.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
-      const visibility = element.querySelector<HTMLElement>(".chat-pane__sharing-visibility-item");
+      const visibilityTitle = element.querySelector<HTMLElement>(
+        ".chat-pane__sharing-visibility-title",
+      );
+      const visibilityItems = [
+        ...element.querySelectorAll<HTMLElement>(".chat-pane__sharing-visibility-item"),
+      ];
       const membersTitle = element.querySelector<HTMLElement>(".chat-pane__sharing-members-title");
       const firstMember = element.querySelector<HTMLElement>(".chat-pane__sharing-member");
+      const previousVisibilityRect = visibilityItems.at(-2)?.getBoundingClientRect();
+      const lastVisibilityRect = visibilityItems.at(-1)?.getBoundingClientRect();
+      const membersTitleRect = membersTitle?.getBoundingClientRect();
       return {
         menuHeight: menu?.getBoundingClientRect().height ?? 0,
+        menuTop: menu?.getBoundingClientRect().top ?? 0,
         scrollHeight: menu?.scrollHeight ?? 0,
         clientHeight: menu?.clientHeight ?? 0,
-        visibilityTop: visibility?.getBoundingClientRect().top ?? 0,
         firstMemberTop: firstMember?.getBoundingClientRect().top ?? 0,
+        groupGap:
+          membersTitleRect && lastVisibilityRect
+            ? membersTitleRect.top - lastVisibilityRect.bottom
+            : 0,
+        rowGap:
+          previousVisibilityRect && lastVisibilityRect
+            ? lastVisibilityRect.top - previousVisibilityRect.bottom
+            : 0,
         membersTitleInset: Number.parseFloat(
           membersTitle ? getComputedStyle(membersTitle).paddingInlineStart : "0",
         ),
         firstMemberInset: Number.parseFloat(
           firstMember ? getComputedStyle(firstMember).paddingInlineStart : "0",
         ),
+        visibilityTitlePosition: visibilityTitle ? getComputedStyle(visibilityTitle).position : "",
+        membersTitlePosition: membersTitle ? getComputedStyle(membersTitle).position : "",
+        nestedScrollers: [...element.children].filter((child) => {
+          const node = child as HTMLElement;
+          return (
+            node.scrollHeight > node.clientHeight &&
+            ["auto", "scroll"].includes(getComputedStyle(node).overflowY)
+          );
+        }).length,
       };
     });
     const afterScroll = await dropdown.evaluate(async (element) => {
       const menu = element.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
-      const visibility = element.querySelector<HTMLElement>(".chat-pane__sharing-visibility-item");
+      const visibilityTitle = element.querySelector<HTMLElement>(
+        ".chat-pane__sharing-visibility-title",
+      );
       const membersTitle = element.querySelector<HTMLElement>(".chat-pane__sharing-members-title");
       const firstMember = element.querySelector<HTMLElement>(".chat-pane__sharing-member");
       if (menu) {
@@ -559,7 +586,7 @@ suite.define(() => {
       });
       return {
         scrollTop: menu?.scrollTop ?? 0,
-        visibilityTop: visibility?.getBoundingClientRect().top ?? 0,
+        visibilityTitleBottom: visibilityTitle?.getBoundingClientRect().bottom ?? 0,
         membersTitleTop: membersTitle?.getBoundingClientRect().top ?? 0,
         firstMemberTop: firstMember?.getBoundingClientRect().top ?? 0,
       };
@@ -568,10 +595,14 @@ suite.define(() => {
     expect(beforeScroll.menuHeight).toBeLessThanOrEqual(421);
     expect(beforeScroll.scrollHeight).toBeGreaterThan(beforeScroll.clientHeight);
     expect(beforeScroll.membersTitleInset).toBe(beforeScroll.firstMemberInset);
+    expect(beforeScroll.groupGap).toBeGreaterThanOrEqual(8);
+    expect(beforeScroll.groupGap).toBeGreaterThan(beforeScroll.rowGap + 6);
+    expect(beforeScroll.visibilityTitlePosition).not.toBe("sticky");
+    expect(beforeScroll.membersTitlePosition).not.toBe("sticky");
+    expect(beforeScroll.nestedScrollers).toBe(0);
     expect(afterScroll.scrollTop).toBeGreaterThan(0);
-    expect(Math.abs(afterScroll.visibilityTop - beforeScroll.visibilityTop)).toBeLessThan(1);
-    expect(afterScroll.membersTitleTop).toBeGreaterThan(afterScroll.visibilityTop);
-    expect(afterScroll.membersTitleTop).toBeLessThan(beforeScroll.firstMemberTop);
+    expect(afterScroll.visibilityTitleBottom).toBeLessThan(beforeScroll.menuTop);
+    expect(afterScroll.membersTitleTop).toBeLessThan(beforeScroll.menuTop);
     expect(afterScroll.firstMemberTop).toBeLessThan(beforeScroll.firstMemberTop);
     await expectBrowser(
       dropdown.locator(".chat-pane__sharing-member openclaw-session-owner-chip"),

--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -468,6 +468,109 @@ suite.define(() => {
     expect(await gateway.getRequests("session.members.add")).toHaveLength(0);
   });
 
+  it("keeps long member lists compact while visibility stays pinned", async () => {
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1280 } });
+    const currentPage = await context.newPage();
+    page = currentPage;
+    const sessions = sessionsList(["profile-ada", "profile-bob"]);
+    const activeSession = sessions.sessions[0];
+    if (!activeSession) {
+      throw new Error("expected active session fixture");
+    }
+    Object.assign(activeSession, { visibility: "shared", sharingRole: "owner" });
+    sessions.count = 1;
+    sessions.creators = [{ id: "profile-ada", label: "Ada" }];
+    sessions.sessions = [activeSession];
+    const humanIdentities = Array.from({ length: 10 }, (_, index) => ({
+      type: "human" as const,
+      id: `profile-member-${index}`,
+      label: `Member ${index + 1}`,
+    }));
+    const channelIdentities = [
+      { type: "human" as const, id: "channel:chn_design", label: "Design" },
+      { type: "human" as const, id: "discord:channel:operations", label: "Operations" },
+    ];
+    const gateway = await installMockGateway(currentPage, {
+      sessionKey: "agent:main:ada",
+      hasMultipleSessionSharingIdentities: true,
+      featureMethods: [
+        "chat.metadata",
+        "chat.startup",
+        "session.members.list",
+        "session.members.add",
+        "session.members.remove",
+        "session.visibility.set",
+      ],
+      operatorScopes: ["operator.read", "operator.write"],
+      historyMessages: [{ role: "assistant", content: [{ type: "text", text: "Ready." }] }],
+      methodResponses: {
+        "sessions.list": sessions,
+        "session.members.list": {
+          sessionKey: "agent:main:ada",
+          members: [],
+          identities: [...humanIdentities, ...channelIdentities],
+          role: "owner",
+          allowedVisibilities: ["shared", "read-only", "suggest", "draft"],
+        },
+      },
+    });
+
+    await currentPage.goto(`${suite.server?.baseUrl ?? ""}chat`);
+    await currentPage.getByText("Ready.", { exact: true }).waitFor();
+    await currentPage.locator(".chat-pane__sharing-trigger").click();
+    await gateway.waitForRequest("session.members.list");
+    const dropdown = currentPage.locator(".chat-pane__sharing-menu");
+    await dropdown.locator('wa-dropdown-item[value="member:profile-member-0"]').waitFor();
+    await dropdown.evaluate(async (element) => {
+      const menu = element.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
+      const animations = [...element.getAnimations(), ...(menu?.getAnimations() ?? [])];
+      await Promise.all(animations.map((animation) => animation.finished.catch(() => {})));
+    });
+
+    const beforeScroll = await dropdown.evaluate((element) => {
+      const menu = element.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
+      const visibility = element.querySelector<HTMLElement>(".chat-pane__sharing-visibility-item");
+      const firstMember = element.querySelector<HTMLElement>(".chat-pane__sharing-member");
+      return {
+        menuHeight: menu?.getBoundingClientRect().height ?? 0,
+        scrollHeight: menu?.scrollHeight ?? 0,
+        clientHeight: menu?.clientHeight ?? 0,
+        visibilityTop: visibility?.getBoundingClientRect().top ?? 0,
+        firstMemberTop: firstMember?.getBoundingClientRect().top ?? 0,
+      };
+    });
+    const afterScroll = await dropdown.evaluate(async (element) => {
+      const menu = element.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
+      const visibility = element.querySelector<HTMLElement>(".chat-pane__sharing-visibility-item");
+      const membersTitle = element.querySelector<HTMLElement>(".chat-pane__sharing-members-title");
+      const firstMember = element.querySelector<HTMLElement>(".chat-pane__sharing-member");
+      if (menu) {
+        menu.scrollTop = menu.scrollHeight;
+      }
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => resolve());
+      });
+      return {
+        scrollTop: menu?.scrollTop ?? 0,
+        visibilityTop: visibility?.getBoundingClientRect().top ?? 0,
+        membersTitleTop: membersTitle?.getBoundingClientRect().top ?? 0,
+        firstMemberTop: firstMember?.getBoundingClientRect().top ?? 0,
+      };
+    });
+
+    expect(beforeScroll.menuHeight).toBeLessThanOrEqual(421);
+    expect(beforeScroll.scrollHeight).toBeGreaterThan(beforeScroll.clientHeight);
+    expect(afterScroll.scrollTop).toBeGreaterThan(0);
+    expect(Math.abs(afterScroll.visibilityTop - beforeScroll.visibilityTop)).toBeLessThan(1);
+    expect(afterScroll.membersTitleTop).toBeGreaterThan(afterScroll.visibilityTop);
+    expect(afterScroll.membersTitleTop).toBeLessThan(beforeScroll.firstMemberTop);
+    expect(afterScroll.firstMemberTop).toBeLessThan(beforeScroll.firstMemberTop);
+    await expectBrowser(
+      dropdown.locator(".chat-pane__sharing-member openclaw-session-owner-chip"),
+    ).toHaveCount(10);
+    await expectBrowser(dropdown.locator(".chat-pane__sharing-channel-icon")).toHaveCount(2);
+  });
+
   it("clears a selected draft mode when sharing policy becomes unavailable", async () => {
     const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();

--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -468,7 +468,7 @@ suite.define(() => {
     expect(await gateway.getRequests("session.members.add")).toHaveLength(0);
   });
 
-  it("keeps long member lists compact while visibility stays pinned", async () => {
+  it("keeps high-volume member lists compact while visibility stays pinned", async () => {
     const context = await suite.browser.newContext({ viewport: { height: 800, width: 1280 } });
     const currentPage = await context.newPage();
     page = currentPage;
@@ -481,7 +481,7 @@ suite.define(() => {
     sessions.count = 1;
     sessions.creators = [{ id: "profile-ada", label: "Ada" }];
     sessions.sessions = [activeSession];
-    const humanIdentities = Array.from({ length: 10 }, (_, index) => ({
+    const humanIdentities = Array.from({ length: 30 }, (_, index) => ({
       type: "human" as const,
       id: `profile-member-${index}`,
       label: `Member ${index + 1}`,
@@ -530,6 +530,7 @@ suite.define(() => {
     const beforeScroll = await dropdown.evaluate((element) => {
       const menu = element.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
       const visibility = element.querySelector<HTMLElement>(".chat-pane__sharing-visibility-item");
+      const membersTitle = element.querySelector<HTMLElement>(".chat-pane__sharing-members-title");
       const firstMember = element.querySelector<HTMLElement>(".chat-pane__sharing-member");
       return {
         menuHeight: menu?.getBoundingClientRect().height ?? 0,
@@ -537,6 +538,12 @@ suite.define(() => {
         clientHeight: menu?.clientHeight ?? 0,
         visibilityTop: visibility?.getBoundingClientRect().top ?? 0,
         firstMemberTop: firstMember?.getBoundingClientRect().top ?? 0,
+        membersTitleInset: Number.parseFloat(
+          membersTitle ? getComputedStyle(membersTitle).paddingInlineStart : "0",
+        ),
+        firstMemberInset: Number.parseFloat(
+          firstMember ? getComputedStyle(firstMember).paddingInlineStart : "0",
+        ),
       };
     });
     const afterScroll = await dropdown.evaluate(async (element) => {
@@ -560,6 +567,7 @@ suite.define(() => {
 
     expect(beforeScroll.menuHeight).toBeLessThanOrEqual(421);
     expect(beforeScroll.scrollHeight).toBeGreaterThan(beforeScroll.clientHeight);
+    expect(beforeScroll.membersTitleInset).toBe(beforeScroll.firstMemberInset);
     expect(afterScroll.scrollTop).toBeGreaterThan(0);
     expect(Math.abs(afterScroll.visibilityTop - beforeScroll.visibilityTop)).toBeLessThan(1);
     expect(afterScroll.membersTitleTop).toBeGreaterThan(afterScroll.visibilityTop);
@@ -567,7 +575,7 @@ suite.define(() => {
     expect(afterScroll.firstMemberTop).toBeLessThan(beforeScroll.firstMemberTop);
     await expectBrowser(
       dropdown.locator(".chat-pane__sharing-member openclaw-session-owner-chip"),
-    ).toHaveCount(10);
+    ).toHaveCount(30);
     await expectBrowser(dropdown.locator(".chat-pane__sharing-channel-icon")).toHaveCount(2);
   });
 

--- a/ui/src/pages/chat/components/chat-session-sharing.test.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.test.ts
@@ -70,6 +70,49 @@ describe("chat session sharing menu", () => {
     expect(onMemberChange).toHaveBeenCalledWith("alice", true);
   });
 
+  it("distinguishes people from channel-backed members", () => {
+    const root = mount(
+      renderChatSessionSharing({
+        session: {
+          key: "agent:main:main",
+          kind: "direct",
+          updatedAt: 1,
+          visibility: "shared",
+          sharingRole: "owner",
+        },
+        state: {
+          loading: false,
+          result: {
+            sessionKey: "agent:main:main",
+            members: [],
+            identities: [
+              { type: "human", id: "profile-vyctor", label: "Vyctor Brzezowski" },
+              { type: "human", id: "channel:chn_design", label: "Design" },
+              { type: "human", id: "discord:channel:operations", label: "Operations" },
+            ],
+            role: "owner",
+            allowedVisibilities: ["shared"],
+          },
+        },
+        onOpen: vi.fn(),
+        onVisibilityChange: vi.fn(),
+        onMemberChange: vi.fn(),
+      }),
+    );
+
+    const human = root.querySelector('wa-dropdown-item[value="member:profile-vyctor"]');
+    const channels = [
+      root.querySelector('wa-dropdown-item[value="member:channel:chn_design"]'),
+      root.querySelector('wa-dropdown-item[value="member:discord:channel:operations"]'),
+    ];
+
+    expect(human?.querySelector("openclaw-session-owner-chip")).not.toBeNull();
+    for (const channel of channels) {
+      expect(channel?.querySelector("openclaw-session-owner-chip")).toBeNull();
+      expect(channel?.querySelector(".chat-pane__sharing-channel-icon svg")).not.toBeNull();
+    }
+  });
+
   it("shows only the draft marker to a non-manager", () => {
     const root = mount(
       renderChatSessionSharing({

--- a/ui/src/pages/chat/components/chat-session-sharing.test.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.test.ts
@@ -55,6 +55,7 @@ describe("chat session sharing menu", () => {
     expect(root.textContent).not.toContain("Suggest");
     expect(root.textContent).toContain("Alice");
     expect(root.querySelector('wa-dropdown-item[value="member:owner"]')).toBeNull();
+    expect(root.querySelector(".session-menu__separator")).toBeNull();
 
     dropdown?.dispatchEvent(
       new CustomEvent("wa-select", {

--- a/ui/src/pages/chat/components/chat-session-sharing.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.ts
@@ -154,7 +154,6 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps) {
       )}
       ${membersAvailable
         ? html`
-            <div class="session-menu__separator" role="separator"></div>
             <div class="chat-pane__sharing-title chat-pane__sharing-members-title">
               ${t("chat.sessionSharing.members")}
             </div>

--- a/ui/src/pages/chat/components/chat-session-sharing.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.ts
@@ -81,7 +81,6 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps) {
   return html`
     <wa-dropdown
       class="chat-pane__sharing-menu ${shouldCapMembers ? "chat-pane__sharing-menu--capped" : ""}"
-      style=${`--sharing-visibility-count: ${visibilityOptions.length}`}
       placement="bottom-end"
       @wa-show=${() => {
         if (!props.openDisabledReason) {
@@ -137,10 +136,9 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps) {
         ${t("chat.sessionSharing.visibility")}
       </div>
       ${visibilityOptions.map(
-        (option, index) => html`
+        (option) => html`
           <wa-dropdown-item
             class="session-menu__item chat-pane__sharing-visibility-item"
-            style=${`--sharing-sticky-index: ${index}`}
             value=${`visibility:${option}`}
             ?disabled=${option === visibility || Boolean(props.visibilityDisabledReason)}
             title=${props.visibilityDisabledReason ?? nothing}

--- a/ui/src/pages/chat/components/chat-session-sharing.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.ts
@@ -5,6 +5,7 @@ import type {
   SessionVisibility,
 } from "../../../api/types.ts";
 import { icons } from "../../../components/icons.ts";
+import { renderSessionOwnerChip } from "../../../components/session-owner-chip.ts";
 import "../../../components/web-awesome.ts";
 import { t } from "../../../i18n/index.ts";
 
@@ -42,6 +43,10 @@ function sharingIcon(visibility: SessionVisibility): TemplateResult {
   return visibility === "shared" ? icons.users : icons.lock;
 }
 
+function isChannelIdentity(identityId: string): boolean {
+  return identityId.startsWith("channel:") || identityId.includes(":channel:");
+}
+
 export function canManageChatSessionSharing(
   session: Pick<GatewaySessionRow, "sharingRole">,
 ): boolean {
@@ -70,9 +75,13 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps) {
   const allowed = result?.allowedVisibilities ?? props.allowedVisibilities ?? [visibility];
   const canPublish = visibility === "draft" && allowed.includes("shared");
   const membersAvailable = props.membersAvailable !== false;
+  const visibilityOptions = allowed.filter((option) => !canPublish || option !== "shared");
+  const shouldCapMembers =
+    membersAvailable && visibilityOptions.length + identities.length + (canPublish ? 1 : 0) > 12;
   return html`
     <wa-dropdown
-      class="chat-pane__sharing-menu"
+      class="chat-pane__sharing-menu ${shouldCapMembers ? "chat-pane__sharing-menu--capped" : ""}"
+      style=${`--sharing-visibility-count: ${visibilityOptions.length}`}
       placement="bottom-end"
       @wa-show=${() => {
         if (!props.openDisabledReason) {
@@ -124,27 +133,31 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps) {
             </wa-dropdown-item>
             <div class="session-menu__separator" role="separator"></div>`
         : nothing}
-      <div class="chat-pane__sharing-title">${t("chat.sessionSharing.visibility")}</div>
-      ${allowed
-        .filter((option) => !canPublish || option !== "shared")
-        .map(
-          (option) => html`
-            <wa-dropdown-item
-              value=${`visibility:${option}`}
-              ?disabled=${option === visibility || Boolean(props.visibilityDisabledReason)}
-              title=${props.visibilityDisabledReason ?? nothing}
-            >
-              <span>${t(VISIBILITY_LABEL_KEYS[option])}</span>
-              ${option === visibility
-                ? html`<span slot="details" aria-hidden="true">${icons.check}</span>`
-                : nothing}
-            </wa-dropdown-item>
-          `,
-        )}
+      <div class="chat-pane__sharing-title chat-pane__sharing-visibility-title">
+        ${t("chat.sessionSharing.visibility")}
+      </div>
+      ${visibilityOptions.map(
+        (option, index) => html`
+          <wa-dropdown-item
+            class="session-menu__item chat-pane__sharing-visibility-item"
+            style=${`--sharing-sticky-index: ${index}`}
+            value=${`visibility:${option}`}
+            ?disabled=${option === visibility || Boolean(props.visibilityDisabledReason)}
+            title=${props.visibilityDisabledReason ?? nothing}
+          >
+            <span>${t(VISIBILITY_LABEL_KEYS[option])}</span>
+            ${option === visibility
+              ? html`<span slot="details" aria-hidden="true">${icons.check}</span>`
+              : nothing}
+          </wa-dropdown-item>
+        `,
+      )}
       ${membersAvailable
         ? html`
             <div class="session-menu__separator" role="separator"></div>
-            <div class="chat-pane__sharing-title">${t("chat.sessionSharing.members")}</div>
+            <div class="chat-pane__sharing-title chat-pane__sharing-members-title">
+              ${t("chat.sessionSharing.members")}
+            </div>
             ${props.state?.loading
               ? html`<div class="chat-pane__sharing-status">${t("common.loading")}</div>`
               : identities.length > 0
@@ -152,13 +165,30 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps) {
                     const disabledReason = members.has(identity.id)
                       ? props.memberRemoveDisabledReason
                       : props.memberAddDisabledReason;
+                    const channelIdentity = isChannelIdentity(identity.id);
                     return html`
                       <wa-dropdown-item
+                        class="session-menu__item chat-pane__sharing-member"
                         value=${`member:${identity.id}`}
                         ?disabled=${Boolean(disabledReason)}
                         title=${disabledReason ?? nothing}
                       >
-                        <span>${identity.label ?? identity.id}</span>
+                        <span
+                          slot="icon"
+                          class="chat-pane__sharing-member-icon ${channelIdentity
+                            ? "chat-pane__sharing-channel-icon"
+                            : ""}"
+                          aria-hidden="true"
+                        >
+                          ${channelIdentity
+                            ? icons.messageSquare
+                            : identity.type === "human"
+                              ? renderSessionOwnerChip(identity, "header")
+                              : icons.bot}
+                        </span>
+                        <span class="chat-pane__sharing-member-label"
+                          >${identity.label ?? identity.id}</span
+                        >
                         ${members.has(identity.id)
                           ? html`<span
                               slot="details"

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -505,7 +505,6 @@ openclaw-chat-pane {
 }
 
 .chat-pane__sharing-menu {
-  --sharing-title-height: 28px;
   flex: 0 0 auto;
 }
 
@@ -537,42 +536,13 @@ openclaw-chat-pane {
   padding: 6px 12px;
 }
 
-.chat-pane__sharing-visibility-title,
-.chat-pane__sharing-visibility-item {
-  position: sticky;
-  z-index: 2;
-  background: var(--bg-elevated);
-}
-
-.chat-pane__sharing-visibility-title {
-  top: 0;
-  box-sizing: border-box;
-  height: var(--sharing-title-height);
-}
-
-.chat-pane__sharing-visibility-item {
-  top: calc(var(--sharing-title-height) + var(--sharing-sticky-index) * var(--menu-item-height));
-}
-
-.chat-pane__sharing-visibility-item:hover:not([disabled]),
-.chat-pane__sharing-visibility-item:focus-visible {
-  background: var(--bg-hover);
-}
-
 .chat-pane__sharing-visibility-item[disabled] {
   opacity: 1;
   color: var(--muted);
 }
 
 .chat-pane__sharing-members-title {
-  position: sticky;
-  z-index: 2;
-  top: calc(
-    var(--sharing-title-height) + var(--sharing-visibility-count) * var(--menu-item-height)
-  );
-  box-sizing: border-box;
-  height: var(--sharing-title-height);
-  background: var(--bg-elevated);
+  margin-top: 8px;
 }
 
 .chat-pane__sharing-member {

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -505,7 +505,21 @@ openclaw-chat-pane {
 }
 
 .chat-pane__sharing-menu {
+  --sharing-title-height: 24px;
   flex: 0 0 auto;
+}
+
+.chat-pane__sharing-menu::part(menu) {
+  width: 260px;
+  min-width: min(260px, calc(100vw - 24px));
+  max-width: min(260px, calc(100vw - 24px));
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+}
+
+.chat-pane__sharing-menu--capped::part(menu) {
+  height: min(420px, 60vh);
 }
 
 .chat-pane__sharing-title,
@@ -514,6 +528,82 @@ openclaw-chat-pane {
   color: var(--muted);
   font-size: 11px;
   font-weight: 600;
+}
+
+.chat-pane__sharing-visibility-title,
+.chat-pane__sharing-visibility-item {
+  position: sticky;
+  z-index: 2;
+  background: var(--bg-elevated);
+}
+
+.chat-pane__sharing-visibility-title {
+  top: 0;
+  box-sizing: border-box;
+  height: var(--sharing-title-height);
+  padding-block: 5px;
+}
+
+.chat-pane__sharing-visibility-item {
+  top: calc(var(--sharing-title-height) + var(--sharing-sticky-index) * var(--menu-item-height));
+}
+
+.chat-pane__sharing-visibility-item:hover:not([disabled]),
+.chat-pane__sharing-visibility-item:focus-visible {
+  background: var(--bg-hover);
+}
+
+.chat-pane__sharing-visibility-item[disabled] {
+  opacity: 1;
+  color: var(--muted);
+}
+
+.chat-pane__sharing-members-title {
+  position: sticky;
+  z-index: 2;
+  top: calc(
+    var(--sharing-title-height) + var(--sharing-visibility-count) * var(--menu-item-height)
+  );
+  box-sizing: border-box;
+  height: var(--sharing-title-height);
+  padding-block: 5px;
+  background: var(--bg-elevated);
+  box-shadow: 0 8px 8px -10px color-mix(in srgb, var(--text) 32%, transparent);
+}
+
+.chat-pane__sharing-member {
+  gap: 0;
+  font-size: 12px;
+}
+
+.chat-pane__sharing-member::part(icon) {
+  display: flex;
+  align-items: center;
+}
+
+.chat-pane__sharing-member-icon {
+  display: inline-flex;
+  width: 20px;
+  height: 20px;
+  align-items: center;
+  justify-content: center;
+}
+
+.chat-pane__sharing-channel-icon {
+  border-radius: var(--radius-full);
+  background: var(--bg-muted);
+  color: var(--muted);
+}
+
+.chat-pane__sharing-channel-icon svg {
+  width: 13px;
+  height: 13px;
+}
+
+.chat-pane__sharing-member-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .chat-pane__sharing-status--error {

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -505,7 +505,7 @@ openclaw-chat-pane {
 }
 
 .chat-pane__sharing-menu {
-  --sharing-title-height: 24px;
+  --sharing-title-height: 28px;
   flex: 0 0 auto;
 }
 
@@ -524,10 +524,17 @@ openclaw-chat-pane {
 
 .chat-pane__sharing-title,
 .chat-pane__sharing-status {
-  padding: 6px 12px;
   color: var(--muted);
   font-size: 11px;
   font-weight: 600;
+}
+
+.chat-pane__sharing-title {
+  padding: 5px 8px 7px;
+}
+
+.chat-pane__sharing-status {
+  padding: 6px 12px;
 }
 
 .chat-pane__sharing-visibility-title,
@@ -541,7 +548,6 @@ openclaw-chat-pane {
   top: 0;
   box-sizing: border-box;
   height: var(--sharing-title-height);
-  padding-block: 5px;
 }
 
 .chat-pane__sharing-visibility-item {
@@ -566,9 +572,7 @@ openclaw-chat-pane {
   );
   box-sizing: border-box;
   height: var(--sharing-title-height);
-  padding-block: 5px;
   background: var(--bg-elevated);
-  box-shadow: 0 8px 8px -10px color-mix(in srgb, var(--text) 32%, transparent);
 }
 
 .chat-pane__sharing-member {


### PR DESCRIPTION
Closes #122266

## What Problem This Solves

Fixes an issue where owners of shared chats would see a nearly viewport-height sharing dropdown when many member identities were available. The unbounded, text-only list was difficult to scan and did not distinguish people from channel-backed members.

## Why This Change Was Made

Long menus are capped at `min(420px, 60vh)`. The dropdown itself is the single scroll container, so Visibility and Members move together and naturally leave the viewport as the full menu scrolls. There is no nested member-list scroller and no sticky heading behavior.

Human rows reuse the existing session-owner avatar treatment; identities shaped like `channel:...` or `...:channel:...` use the existing channel glyph instead of false initials. Section labels and rows share the same 8px left inset. Separators are removed, and Members receives an 8px group gap above its heading so the two sections read as distinct blocks. Selectable items remain direct dropdown children, preserving the component's keyboard navigation. The sharing RPC/state flow is unchanged.

## User Impact

The sharing menu remains compact with long identity lists, while using one predictable scroll surface. People and channels are visually distinct in both light and dark themes, and the larger inter-group gap makes Visibility and Members easier to scan.

## Evidence

All captures use the same 1280×800 viewport. The grouped state has 12 people and 2 channels at the top of the menu. The high-volume state has 30 people and 2 channels with the whole dropdown scrolled 187px; Visibility and the Members heading have both moved above the menu viewport.

| Theme | Before — 14 identities | Grouped top — 14 identities | High volume — 32 identities, whole menu scrolled |
| --- | --- | --- | --- |
| Light | ![Before: unbounded light sharing dropdown](https://github.com/user-attachments/assets/ae052f76-c1f4-4b5e-ab2e-baf2a6aa86f8) | ![After: compact light sharing dropdown with separated, aligned groups](https://github.com/user-attachments/assets/60d7957e-5d4e-4420-9ec6-b68dffdb9c7c) | ![High-volume light sharing dropdown with the whole menu scrolled and section headings out of view](https://github.com/user-attachments/assets/a7f4ed7d-7a4d-4f6c-845e-5287e43cf9fd) |
| Dark | ![Before: unbounded dark sharing dropdown](https://github.com/user-attachments/assets/84b148f1-8baf-4576-91d6-3553a92f16b1) | ![After: compact dark sharing dropdown with separated, aligned groups](https://github.com/user-attachments/assets/6effa714-3480-486f-884f-be5125bab1ea) | ![High-volume dark sharing dropdown with the whole menu scrolled and section headings out of view](https://github.com/user-attachments/assets/d158f7a2-51c9-4410-ac35-9631e1a80c64) |

- Component tests: 9 passed.
- Focused browser regression: passed with 30 human avatars and 2 channel glyphs; the dropdown remained capped, used one scroll container, and had no nested scroller or sticky headings.
- Changed-file validation: formatting, typechecks, lint, i18n, dependency/export guards passed.
- Production UI build and asset budgets: passed. Startup JS was 328,289 B gzip against the 328,285 B baseline plus 1,024 B tolerance; startup CSS was 40.1 KiB gzip against the 45 KiB limit.
