### PR TITLE
fix(plugins): keep startup convergence read-only

### DIFF
--- a/src/commands/doctor-config-preflight-plugin-verification.ts
+++ b/src/commands/doctor-config-preflight-plugin-verification.ts
@@ -97,7 +97,6 @@ export async function runStartupUpgradeConvergence(params: {
         cfg: params.cfg,
         env: params.env,
         compatibilityHostVersion: resolveCompatibilityHostVersion(params.env),
-        baselineInstallRecords: plan.installRecords,
       }),
     params.measure,
   );

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -647,7 +647,7 @@ describe("runDoctorConfigPreflight state migration", () => {
     expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
   });
 
-  it("pins startup plugin convergence to the explicit compatibility host version", async () => {
+  it("pins startup plugin convergence without re-persisting the installed record snapshot", async () => {
     needsStartupMigrationCheckpoint.mockReturnValue(true);
     const previousHostVersion = process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
     process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION = "2026.7.2-beta.7";
@@ -670,7 +670,6 @@ describe("runDoctorConfigPreflight state migration", () => {
       cfg: { gateway: { mode: "local", port: 19091 } },
       env: expect.any(Object),
       compatibilityHostVersion: "2026.7.2-beta.7",
-      baselineInstallRecords: {},
     });
   });
 


### PR DESCRIPTION
Startup verification passes persisted install records into post-core convergence as a baseline. That marks the baseline as unpersisted and rewrites the installed plugin index even when repair makes no changes. If discovery order differs from persistence order, the migration fingerprint changes during the same boot and the gateway refuses readiness on every restart.

This keeps gateway startup convergence read-only unless repair finds an actual change. The explicit update flow still passes and persists its in-memory baseline.

Validation:
- focused startup migration suite, 30 tests passed
- live gateway restart completed without changing the migration identity
- autoreview clean, confidence 0.99