### PR TITLE
fix(browser): publish snapshot output atomically

### DIFF
--- a/extensions/browser/src/cli/browser-cli-inspect.test.ts
+++ b/extensions/browser/src/cli/browser-cli-inspect.test.ts
@@ -1,4 +1,8 @@
 // Browser tests cover browser cli inspect plugin behavior.
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createCliRuntimeCapture } from "../../test-support.js";
@@ -240,5 +244,34 @@ describe("browser cli snapshot defaults", () => {
     const body = (params as { body?: Record<string, unknown> } | undefined)?.body;
     expect(body?.targetId).toBe("tab-1");
     expect(body?.labels).toBe(true);
+  });
+
+  it.each([
+    { label: "AI", args: [] },
+    { label: "ARIA", args: ["--format", "aria"] },
+  ])("keeps an existing $label snapshot when publication fails", async ({ args }) => {
+    const tempDir = fsSync.mkdtempSync(path.join(tmpdir(), "openclaw-browser-snapshot-"));
+    try {
+      const outputPath = path.join(tempDir, "snapshot.txt");
+      fsSync.writeFileSync(outputPath, "previous snapshot\n");
+      const priorBytes = fsSync.readFileSync(outputPath);
+
+      const writeSpy = vi.spyOn(fs, "writeFile").mockImplementationOnce(async (file) => {
+        expect(typeof file).toBe("string");
+        fsSync.writeFileSync(file as string, "partial replacement");
+        throw new Error("injected snapshot write failure");
+      });
+      try {
+        await expect(runSnapshot([...args, "--out", outputPath])).rejects.toThrow("__exit__:1");
+      } finally {
+        writeSpy.mockRestore();
+      }
+
+      expect(runtime.error.mock.calls.at(-1)?.[0]).toContain("injected snapshot write failure");
+      expect(fsSync.readFileSync(outputPath)).toEqual(priorBytes);
+      expect(fsSync.readdirSync(tempDir)).toEqual(["snapshot.txt"]);
+    } finally {
+      fsSync.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/extensions/browser/src/cli/browser-cli-inspect.ts
+++ b/extensions/browser/src/cli/browser-cli-inspect.ts
@@ -2,8 +2,10 @@
  * Browser CLI inspection commands for screenshots and snapshots.
  */
 import fs from "node:fs/promises";
+import path from "node:path";
 import type { Command } from "commander";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { writeExternalFileWithinOutputRoot } from "../browser/output-files.js";
 import {
   BROWSER_TAB_REFERENCE_HELP,
   callBrowserRequest,
@@ -179,12 +181,14 @@ export function registerBrowserInspectCommands(
         );
 
         if (opts.out) {
-          if (result.format === "ai") {
-            await fs.writeFile(opts.out, result.snapshot, "utf8");
-          } else {
-            const payload = JSON.stringify(result, null, 2);
-            await fs.writeFile(opts.out, payload, "utf8");
-          }
+          const payload =
+            result.format === "ai" ? result.snapshot : JSON.stringify(result, null, 2);
+          await writeExternalFileWithinOutputRoot({
+            path: path.resolve(opts.out),
+            write: async (tempPath) => {
+              await fs.writeFile(tempPath, payload, "utf8");
+            },
+          });
           if (parent?.json) {
             defaultRuntime.writeJson({
               ok: true,


### PR DESCRIPTION
## What Problem This Solves

Closes #122323.

`openclaw browser snapshot --out <path>` wrote AI text and ARIA JSON directly to the final user-selected path. Replacing an existing snapshot therefore truncated the previous artifact before the new bytes were complete; a filesystem failure or process interruption could destroy the prior valid snapshot and leave partial bytes visible.

## Why This Change Was Made

The Browser CLI now renders one snapshot payload and publishes it through the plugin's existing `writeExternalFileWithinOutputRoot` owner. That helper resolves the caller-selected output root and delegates to the public Plugin SDK sibling-staging contract, which validates the staged regular file, syncs it, atomically renames it, syncs the parent directory, and cleans failed staging files.

The path is resolved only for publication. Human and JSON CLI output retain the operator's original `--out` spelling. No dependency, SDK surface, configuration, protocol, or compatibility path was added.

## User Impact

A failed Browser snapshot replacement no longer corrupts the previous file at that path. Successful AI and ARIA snapshot bytes and command output remain unchanged.

## Evidence

- New table-driven owner-boundary coverage seeds a prior snapshot, writes partial replacement bytes to the writer-supplied path, then throws for both AI and ARIA formats.
- Both cases failed against the old direct-final-path implementation for the intended corruption reason, then passed after staged publication while leaving only the original final file and no staging residue.
- `node scripts/run-vitest.mjs extensions/browser/src/cli/browser-cli-inspect.test.ts extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts` — 2 files, 29 tests passed.
- `node scripts/run-vitest.mjs extensions/browser/src/cli` — 15 files, 145 tests passed.
- `pnpm tsgo:extensions && pnpm tsgo:extensions:test` — passed.
- Targeted extension Oxlint, formatting, and `git diff --check` — passed.
- Mandatory Codex autoreview and TruffleHog — clean, no accepted/actionable findings.
- Exact-head CI parent https://github.com/openclaw/openclaw/actions/runs/31543649755 completed successfully for `c99fd3791363b01029d3fabeb4636a10c1790511`.
- Native review artifacts validated `READY FOR /prepare-pr` with zero findings, and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 122327` completed with hosted gates passed.

Production LOC: +10/-6 (net +4). Tests: +33/-0 (net +33). The four production lines are the format-neutral payload plus staged-writer callback required to reuse the established Browser publication owner and delete the two duplicated direct-write branches.
