### PR TITLE
fix(ui): match chat transcript text rendering to prototype

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -3298,5 +3298,34 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       await closeBrowserPage(page);
     }
   });
+
+  it("matches the reading prototype's transcript letter spacing", async () => {
+    const page = await openBrowserPage(1366, 900);
+    try {
+      await page.setContent(`<!doctype html><html data-theme-mode="dark"><head><style>${readUiCss()}</style></head><body>
+        <div class="chat-thread chat-thread--direct" role="log">
+          <div class="chat-thread-inner">
+            <div class="chat-group assistant">
+              <div class="chat-group-messages">
+                <div class="chat-bubble">
+                  <div class="chat-text">
+                    <p>Aa Bb Cc — Smooth reading depends on the shape, spacing, and contrast of every glyph in a transcript.</p>
+                    <p>Keep this fixture about text rendering; width and block rhythm are intentionally not asserted here.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </body></html>`);
+
+      const letterSpacing = await page
+        .locator(".chat-text")
+        .evaluate((element) => getComputedStyle(element).letterSpacing);
+      expect(letterSpacing).toBe("0px");
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -3330,9 +3330,12 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       const cronLetterSpacing = await page
         .locator(".cron-run-entry__body.chat-text")
         .evaluate((element) => getComputedStyle(element).letterSpacing);
+      const bodyLetterSpacing = await page
+        .locator("body")
+        .evaluate((element) => getComputedStyle(element).letterSpacing);
       expect(transcriptLetterSpacing).toBe("normal");
-      expect(noticeLetterSpacing).toBe("-0.12px");
-      expect(cronLetterSpacing).toBe("-0.14px");
+      expect(noticeLetterSpacing).toBe(bodyLetterSpacing);
+      expect(cronLetterSpacing).toBe(bodyLetterSpacing);
     } finally {
       await closeBrowserPage(page);
     }

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -3317,12 +3317,18 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
             </div>
           </div>
         </div>
+        <section class="custodian-surface">
+          <div class="chat-bubble"><div class="chat-text">Custodian output</div></div>
+        </section>
         <div class="chat-notice"><div class="chat-text chat-notice__body">Compact notice</div></div>
         <div class="cron-run-entry__body chat-text">Cron output</div>
       </body></html>`);
 
       const transcriptLetterSpacing = await page
-        .locator(".chat-bubble .chat-text")
+        .locator(".chat-thread .chat-bubble .chat-text")
+        .evaluate((element) => getComputedStyle(element).letterSpacing);
+      const custodianLetterSpacing = await page
+        .locator(".custodian-surface .chat-bubble .chat-text")
         .evaluate((element) => getComputedStyle(element).letterSpacing);
       const noticeLetterSpacing = await page
         .locator(".chat-notice .chat-text")
@@ -3334,6 +3340,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         .locator("body")
         .evaluate((element) => getComputedStyle(element).letterSpacing);
       expect(transcriptLetterSpacing).toBe("normal");
+      expect(custodianLetterSpacing).toBe(bodyLetterSpacing);
       expect(noticeLetterSpacing).toBe(bodyLetterSpacing);
       expect(cronLetterSpacing).toBe(bodyLetterSpacing);
     } finally {

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -3299,7 +3299,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
-  it("matches the reading prototype's transcript letter spacing", async () => {
+  it("matches the reading prototype's transcript letter spacing without changing shared text", async () => {
     const page = await openBrowserPage(1366, 900);
     try {
       await page.setContent(`<!doctype html><html data-theme-mode="dark"><head><style>${readUiCss()}</style></head><body>
@@ -3317,12 +3317,22 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
             </div>
           </div>
         </div>
+        <div class="chat-notice"><div class="chat-text chat-notice__body">Compact notice</div></div>
+        <div class="cron-run-entry__body chat-text">Cron output</div>
       </body></html>`);
 
-      const letterSpacing = await page
-        .locator(".chat-text")
+      const transcriptLetterSpacing = await page
+        .locator(".chat-bubble .chat-text")
         .evaluate((element) => getComputedStyle(element).letterSpacing);
-      expect(letterSpacing).toBe("normal");
+      const noticeLetterSpacing = await page
+        .locator(".chat-notice .chat-text")
+        .evaluate((element) => getComputedStyle(element).letterSpacing);
+      const cronLetterSpacing = await page
+        .locator(".cron-run-entry__body.chat-text")
+        .evaluate((element) => getComputedStyle(element).letterSpacing);
+      expect(transcriptLetterSpacing).toBe("normal");
+      expect(noticeLetterSpacing).toBe("-0.12px");
+      expect(cronLetterSpacing).toBe("-0.14px");
     } finally {
       await closeBrowserPage(page);
     }

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -3322,7 +3322,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       const letterSpacing = await page
         .locator(".chat-text")
         .evaluate((element) => getComputedStyle(element).letterSpacing);
-      expect(letterSpacing).toBe("0px");
+      expect(letterSpacing).toBe("normal");
     } finally {
       await closeBrowserPage(page);
     }

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -562,7 +562,10 @@ img.chat-avatar.chat-avatar--logo {
   box-sizing: border-box;
   min-width: 0;
   overflow-wrap: break-word;
-  letter-spacing: 0; /* .chat-text is shared by notices and Cron; transcript tracking belongs here. */
+}
+
+.chat-thread .chat-bubble {
+  letter-spacing: 0; /* Custodian shares .chat-bubble but keeps the application-wide tracking. */
 }
 
 .chat-group.workspace-conflict .chat-group-messages {

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -562,6 +562,7 @@ img.chat-avatar.chat-avatar--logo {
   box-sizing: border-box;
   min-width: 0;
   overflow-wrap: break-word;
+  letter-spacing: 0; /* .chat-text is shared by notices and Cron; transcript tracking belongs here. */
 }
 
 .chat-group.workspace-conflict .chat-group-messages {

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -20,7 +20,6 @@
 
 .chat-text {
   font-size: var(--chat-text-size);
-  letter-spacing: 0;
   line-height: 1.5;
   color: var(--chat-text);
   overflow-wrap: anywhere;

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -20,6 +20,7 @@
 
 .chat-text {
   font-size: var(--chat-text-size);
+  letter-spacing: 0;
   line-height: 1.5;
   color: var(--chat-text);
   overflow-wrap: anywhere;


### PR DESCRIPTION
Closes #122324

## What Problem This Solves

Fixes an issue where users reading long Control UI transcript replies see text that is slightly tighter than the reading prototype, even though font family, weight, color, and font smoothing already match.

The affected surface is the Markdown transcript body, especially dark-theme prose where small tracking differences are easy to notice when scanning.

## Why This Change Was Made

The source comparison found one rendering delta that can be applied without changing layout: production inherits `letter-spacing: -0.01em` from `body`, while the prototype's `.message-body` explicitly uses `letter-spacing: 0`.

This PR scopes `letter-spacing: 0` to `.chat-thread .chat-bubble`. The scope is intentional: `.chat-text` is also used by compact notices and Cron output, while `.chat-bubble` is also used by Custodian. Those non-transcript consumers retain the application-wide body tracking. The change does not alter width, measure, max-width, margins, block gaps, block balancing, or line-height. The separate production/prototype line-height delta (21px vs 22.12px) is recorded in issue #122324 for Vyctor's decision and is not implemented here.

## User Impact

Transcript prose uses the same letter spacing as the reading prototype. The existing message column, wrapping, vertical rhythm, code/table/widget widths, and current 1.5 line-height remain unchanged. Compact notices, Cron output, and Custodian messages keep their existing tracking.

## Evidence

Same text, same Chromium fixture, production on the left and Vyctor's `prototypes/conversation-map/index.html` on the right. Each image is a crop-oriented side-by-side comparison at the requested inspection scale:

### Before

![Production before vs prototype — light, 100%](https://github.com/user-attachments/assets/b40b2f01-e88b-4d15-8515-c7adb57fa804)

![Production before vs prototype — light, 200%](https://github.com/user-attachments/assets/0496ddfb-68b0-455b-b570-aceb8fbd90d2)

![Production before vs prototype — dark, 100%](https://github.com/user-attachments/assets/71258757-d5cd-4d32-a772-698911db248c)

![Production before vs prototype — dark, 200%](https://github.com/user-attachments/assets/424138ac-0cbe-408c-b757-15d0496299c2)

### After

![Production after vs prototype — light, 100%](https://github.com/user-attachments/assets/f0666cd4-d5aa-49ef-a988-aeae5f750c31)

![Production after vs prototype — light, 200%](https://github.com/user-attachments/assets/deb47a90-61de-4a6b-af93-20fb04971578)

![Production after vs prototype — dark, 100%](https://github.com/user-attachments/assets/694ef821-6405-4804-8c4f-5fbc5ddbdef3)

![Production after vs prototype — dark, 200%](https://github.com/user-attachments/assets/13618984-2f14-450c-96b3-9fd72c99620f)

The browser probe reports:

| Property | Production before | Production after | Prototype |
| --- | --- | --- | --- |
| Letter spacing | -0.14px | normal / 0 | normal / 0 |
| Font family | Inter/system fallback | unchanged | Inter/system fallback |
| Effective weight | 400 | unchanged | 400 |
| WebKit smoothing | antialiased | unchanged | antialiased |
| macOS smoothing | grayscale | unchanged | grayscale |
| Text rendering | auto | unchanged | auto |
| Font features | normal | unchanged | normal |
| Body color | matching in light/dark | unchanged | matching in light/dark |
| Line-height | 21px | 21px | 22.12px, intentionally unchanged |

Validation:

- Direct Chromium comparison: passed at 100% and 200% in light and dark themes.
- Before probe failed the new contract with production `letter-spacing: -0.14px`; after probe matched the prototype with `normal`.
- Browser regression covers the transcript plus shared non-transcript consumers: compact notice, Cron output, and Custodian.
- `git diff --check`: passed.
- Final exact-head CI and sequential review status are recorded in the landing comment.

Source evidence: `ui/src/styles/base.css`, `ui/src/styles/chat/grouped.css`, `ui/src/pages/chat/components/chat-thread.ts`, and `ui/src/pages/custodian/custodian-surface.ts`.

Landing authorized by Vyctor.
