### PR TITLE
fix(plugins): keep startup convergence read-only

### DIFF
--- a/src/commands/doctor-config-preflight-plugin-verification.ts
+++ b/src/commands/doctor-config-preflight-plugin-verification.ts
@@ -97,7 +97,6 @@ export async function runStartupUpgradeConvergence(params: {
         cfg: params.cfg,
         env: params.env,
         compatibilityHostVersion: resolveCompatibilityHostVersion(params.env),
-        baselineInstallRecords: plan.installRecords,
       }),
     params.measure,
   );

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -647,7 +647,7 @@ describe("runDoctorConfigPreflight state migration", () => {
     expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
   });
 
-  it("pins startup plugin convergence to the explicit compatibility host version", async () => {
+  it("pins startup plugin convergence without re-persisting the installed record snapshot", async () => {
     needsStartupMigrationCheckpoint.mockReturnValue(true);
     const previousHostVersion = process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
     process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION = "2026.7.2-beta.7";
@@ -670,7 +670,6 @@ describe("runDoctorConfigPreflight state migration", () => {
       cfg: { gateway: { mode: "local", port: 19091 } },
       env: expect.any(Object),
       compatibilityHostVersion: "2026.7.2-beta.7",
-      baselineInstallRecords: {},
     });
   });
 


### PR DESCRIPTION
## Summary

- stop startup verification from re-persisting an unchanged install-record baseline
- keep update-time convergence persistence unchanged
- preserve the existing migration identity refusal for real input changes

## Verification

- `pnpm exec vitest run src/commands/doctor-config-preflight.state-migration.test.ts` (30 passed)
- `pnpm check`
- built the branch and verified gateway readiness through the normal startup path