### PR TITLE
fix(skills): keep always-on skills eligible across OS gates

### DIFF
--- a/src/shared/config-eval.test.ts
+++ b/src/shared/config-eval.test.ts
@@ -229,6 +229,18 @@ describe("evaluateRuntimeEligibility", () => {
     expect(result).toBe(true);
   });
 
+  it("bypasses OS requirements when always=true", () => {
+    const result = evaluateRuntimeEligibility({
+      always: true,
+      os: ["definitely-not-a-runtime-platform"],
+      remotePlatforms: [],
+      hasBin: () => true,
+      hasEnv: () => true,
+      isConfigPathTruthy: () => true,
+    });
+    expect(result).toBe(true);
+  });
+
   it("evaluates runtime requirements when always is false", () => {
     const result = evaluateRuntimeEligibility({
       requires: {

--- a/src/shared/config-eval.ts
+++ b/src/shared/config-eval.ts
@@ -133,6 +133,9 @@ export function evaluateRuntimeEligibility(
     always?: boolean;
   } & RuntimeRequirementEvalParams,
 ): boolean {
+  if (params.always === true) {
+    return true;
+  }
   const osList = params.os ?? [];
   const remotePlatforms = params.remotePlatforms ?? [];
   if (
@@ -141,9 +144,6 @@ export function evaluateRuntimeEligibility(
     !remotePlatforms.some((platform) => osList.includes(platform))
   ) {
     return false;
-  }
-  if (params.always === true) {
-    return true;
   }
   return evaluateRuntimeRequires({
     requires: params.requires,


### PR DESCRIPTION
Fixes #122271

## What Problem This Solves

Fixes an issue where an always-on skill could disappear from the available skill set when its OS metadata did not match the local or any connected runtime, even though `always: true` is documented to bypass runtime gates.

## Why This Change Was Made

The shared runtime eligibility evaluator now gives `always: true` precedence over OS and runtime-requirement checks. Explicit disablement, unavailable-secret handling, and bundled allowlist policy remain in their existing outer loader boundaries.

## User Impact

Skills marked `always: true` remain available across OS metadata mismatches, matching the documented behavior and the existing requirements-status evaluator.

## Evidence

- Before the fix, the focused regression returned `false` for `always: true` with an unmatched OS.
- After the fix, the ClawSweeper acceptance set passes: 3 Vitest shards, 54 tests total.
  - `node scripts/run-vitest.mjs src/shared/config-eval.test.ts src/skills/loading/skills.test.ts src/hooks/config.test.ts src/shared/requirements.test.ts`
- Real workspace-loader proof on exact head `d55f69b3509eec8a61cc4241b3415222d75d09e2` used an isolated temporary workspace containing an actual `skills/always-os-proof/SKILL.md` with `always: true` and an intentionally impossible OS value. The production embedded-run entry path (`resolveEmbeddedRunSkillEntries` -> `loadWorkspaceSkills`) returned the skill as available:

  ```json
  {
    "platform": "win32",
    "mismatchedOs": "definitely-not-a-runtime-platform",
    "shouldLoadSkillEntries": true,
    "loadedSkillNames": ["always-os-proof"],
    "alwaysOsProofPresent": true
  }
  ```

  The temporary workspace was removed after the run; no user configuration or installed skill directory was used.
- `oxfmt`, `oxlint`, and `git diff --check` pass for the two changed files.
- AutoReview reported no actionable P0-P2 findings and classified the patch as correct.
