### PR TITLE
fix(ui): show nested session parent in chat header

### DIFF
--- a/ui/src/e2e/chat-header-axis.e2e.test.ts
+++ b/ui/src/e2e/chat-header-axis.e2e.test.ts
@@ -29,14 +29,14 @@ suite.define(() => {
             {
               key: "agent:main:parent",
               kind: "direct",
-              label: "Release prep",
+              label: "Release readiness and production rollout coordination",
               spawnedCwd: "/repo/openclaw",
               updatedAt: 1,
             },
             {
               key: "agent:main:session-a",
               kind: "direct",
-              label: "Implementation",
+              label: "Implement parent breadcrumb navigation and polish overflow behavior",
               parentSessionKey: "agent:main:parent",
               spawnedCwd: "/repo/openclaw",
               updatedAt: 2,
@@ -77,11 +77,29 @@ suite.define(() => {
         }
         expect(await header.locator(".chat-pane__crumb-sep").count()).toBe(2);
         const parent = header.locator(".chat-pane__parent-session");
-        expect((await parent.textContent())?.trim()).toBe("Release prep");
+        const nestedTrail = await header.evaluate((root) => {
+          const parent = root.querySelector<HTMLElement>(".chat-pane__parent-session")!;
+          const child = root.querySelector<HTMLElement>(".chat-pane__session-title")!;
+          const parentText = root.querySelector<HTMLElement>(".chat-pane__parent-session-text")!;
+          const childText = root.querySelector<HTMLElement>(".chat-pane__session-title-text")!;
+          const headerRect = root.getBoundingClientRect();
+          return {
+            childEllipses: childText.scrollWidth > childText.clientWidth,
+            headerWidth: headerRect.width,
+            parentEllipses: parentText.scrollWidth > parentText.clientWidth,
+            width: child.getBoundingClientRect().right - parent.getBoundingClientRect().left,
+          };
+        });
+        expect(nestedTrail.parentEllipses).toBe(true);
+        expect(nestedTrail.childEllipses).toBe(true);
+        expect(nestedTrail.width).toBeLessThanOrEqual(nestedTrail.headerWidth / 2 + 1);
+        expect((await parent.textContent())?.trim()).toBe(
+          "Release readiness and production rollout coordination",
+        );
         await parent.click();
         await expect
           .poll(() => header.locator(".chat-pane__session-title-text").textContent())
-          .toBe("Release prep");
+          .toBe("Release readiness and production rollout coordination");
       } finally {
         await suite.closeBrowserContext(context);
       }

--- a/ui/src/e2e/chat-header-axis.e2e.test.ts
+++ b/ui/src/e2e/chat-header-axis.e2e.test.ts
@@ -11,7 +11,7 @@ const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
   for (const colorScheme of ["light", "dark"] as const) {
-    it(`centers the project trail with the header actions in ${colorScheme} mode`, async () => {
+    it(`centers and navigates the project-parent-child trail in ${colorScheme} mode`, async () => {
       const context = await suite.newBrowserContext({
         colorScheme,
         locale: "en-US",
@@ -27,9 +27,17 @@ suite.define(() => {
         methodResponses: {
           "sessions.list": chatSessionListResponse([
             {
+              key: "agent:main:parent",
+              kind: "direct",
+              label: "Release prep",
+              spawnedCwd: "/repo/openclaw",
+              updatedAt: 1,
+            },
+            {
               key: "agent:main:session-a",
               kind: "direct",
-              label: "Session A",
+              label: "Implementation",
+              parentSessionKey: "agent:main:parent",
               spawnedCwd: "/repo/openclaw",
               updatedAt: 2,
             },
@@ -59,6 +67,7 @@ suite.define(() => {
             projectText: centerY(".chat-pane__workspace-chip span"),
             search: centerY(".chat-pane__palette-open svg"),
             separator: centerY(".chat-pane__crumb-sep"),
+            parentText: centerY(".chat-pane__parent-session-text"),
             sessionText: centerY(".chat-pane__session-title-text"),
           };
         });
@@ -66,6 +75,13 @@ suite.define(() => {
         for (const center of Object.values(centers)) {
           expect(Math.abs(center - centers.nav), JSON.stringify(centers)).toBeLessThanOrEqual(0.1);
         }
+        expect(await header.locator(".chat-pane__crumb-sep").count()).toBe(2);
+        const parent = header.locator(".chat-pane__parent-session");
+        expect((await parent.textContent())?.trim()).toBe("Release prep");
+        await parent.click();
+        await expect
+          .poll(() => header.locator(".chat-pane__session-title-text").textContent())
+          .toBe("Release prep");
       } finally {
         await suite.closeBrowserContext(context);
       }

--- a/ui/src/e2e/chat-header-axis.e2e.test.ts
+++ b/ui/src/e2e/chat-header-axis.e2e.test.ts
@@ -78,7 +78,7 @@ suite.define(() => {
         expect(await header.locator(".chat-pane__crumb-sep").count()).toBe(2);
         const parent = header.locator(".chat-pane__parent-session");
         const nestedTrail = await header.evaluate((root) => {
-          const parent = root.querySelector<HTMLElement>(".chat-pane__parent-session")!;
+          const parentCrumb = root.querySelector<HTMLElement>(".chat-pane__parent-session")!;
           const child = root.querySelector<HTMLElement>(".chat-pane__session-title")!;
           const parentText = root.querySelector<HTMLElement>(".chat-pane__parent-session-text")!;
           const childText = root.querySelector<HTMLElement>(".chat-pane__session-title-text")!;
@@ -87,7 +87,7 @@ suite.define(() => {
             childEllipses: childText.scrollWidth > childText.clientWidth,
             headerWidth: headerRect.width,
             parentEllipses: parentText.scrollWidth > parentText.clientWidth,
-            width: child.getBoundingClientRect().right - parent.getBoundingClientRect().left,
+            width: child.getBoundingClientRect().right - parentCrumb.getBoundingClientRect().left,
           };
         });
         expect(nestedTrail.parentEllipses).toBe(true);

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4581,6 +4581,7 @@ export const en: TranslationMap = {
       renameAria: "Rename session {title}",
       renameInputAria: "Session title",
       renameInputPlaceholder: "Session title",
+      openParent: "Open parent session {title}",
       panels: "Panels",
       layout: "Layout",
       workspaceAria: "Workspace actions for {workspace}",

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -38,6 +38,7 @@ import type {
 import {
   canRevealSessionWorkspace,
   renderChatPaneHeader,
+  resolveChatPaneParentSession,
   resolveChatPaneWorkspace,
 } from "./components/chat-pane-header.ts";
 import { renderSessionRailToggle } from "./components/chat-session-rail-toggle.ts";
@@ -308,6 +309,7 @@ export abstract class ChatPaneHeader extends ChatPaneSessionMenu {
       workspaceRoot: workspace.root,
       workspaceLabel: workspace.label,
       workspaceIcon: this.resolveWorkspaceIcon(workspace.root ? row?.key : undefined),
+      parentSession: resolveChatPaneParentSession(row, this.state?.sessionsResult?.sessions ?? []),
       branch,
       branches:
         this.state && this.state.chatBranchesSessionKey === this.state.sessionKey
@@ -448,6 +450,9 @@ export abstract class ChatPaneHeader extends ChatPaneSessionMenu {
         if (row) {
           this.handleHeaderMenuAction(action, row, workspace.root, branch);
         }
+      },
+      onOpenParentSession: (sessionKey) => {
+        this.onPaneSessionChange?.(this.paneId, sessionKey);
       },
       onBranchSelect: (leafEntryId) => {
         const access = readChatSessionActionAccess(

--- a/ui/src/pages/chat/chat-pane-session-access.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-access.test.ts
@@ -11,6 +11,47 @@ import { createBackgroundTasksProps } from "./components/chat-background-tasks.t
 import { createSessionWorkspaceProps } from "./components/chat-session-workspace.ts";
 
 describe("chat pane session access", () => {
+  it("opens the resolved parent from the header breadcrumb", () => {
+    const { pane, state } = createTestChatPane({
+      client: {} as GatewayBrowserClient,
+      sessions: {} as SessionCapability,
+    });
+    const parent = {
+      key: "agent:main:parent",
+      kind: "direct",
+      label: "Release prep",
+      updatedAt: 1,
+    } satisfies GatewaySessionRow;
+    const child = {
+      key: "agent:main:child",
+      kind: "direct",
+      label: "Implementation",
+      parentSessionKey: parent.key,
+      updatedAt: 2,
+    } satisfies GatewaySessionRow;
+    state.sessionsResult = { sessions: [parent, child] } as NonNullable<
+      typeof state.sessionsResult
+    >;
+    pane.paneId = "pane-child";
+    pane.onPaneSessionChange = vi.fn();
+    const container = document.createElement("div");
+
+    render(
+      pane.renderPaneHeader(
+        createSessionWorkspaceProps(state),
+        createBackgroundTasksProps(state),
+        child,
+        false,
+        undefined,
+        false,
+      ),
+      container,
+    );
+    container.querySelector<HTMLButtonElement>(".chat-pane__parent-session")?.click();
+
+    expect(pane.onPaneSessionChange).toHaveBeenCalledExactlyOnceWith("pane-child", parent.key);
+  });
+
   it("refuses ordinary session creation without operator.write", async () => {
     const sessions = {
       create: vi.fn(async () => "agent:main:new"),

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -1115,6 +1115,62 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
+  it("keeps the parent and child breadcrumb distinct in a narrow pane", async () => {
+    const page = await openBrowserPage(430, 180);
+    try {
+      const splitViewCss = readStyleSheet("ui/src/styles/chat/split-view.css");
+      await page.setContent(
+        `<!doctype html><html><head><style>${readUiCss()}\n${splitViewCss}</style></head><body>
+          <div class="chat-split-view__cell" style="width: 320px;">
+            <div class="chat-pane__header">
+              <div class="chat-pane__crumbs">
+                <wa-dropdown class="chat-pane__workspace-menu">
+                  <button class="chat-pane__workspace-chip" type="button">
+                    ${iconSvg()}<span>openclaw</span>
+                  </button>
+                </wa-dropdown>
+                <span class="chat-pane__crumb-sep" aria-hidden="true">/</span>
+                <button class="chat-pane__parent-session" type="button">
+                  <span class="chat-pane__parent-session-text">Release preparation with a long parent name</span>
+                </button>
+                <span class="chat-pane__crumb-sep" aria-hidden="true">/</span>
+                <button class="chat-pane__session-title chat-pane__session-title-button" type="button">
+                  <span class="chat-pane__session-title-text">Implementation details with a long child name</span>
+                </button>
+              </div>
+              <div class="chat-pane__actions">
+                <button class="btn btn--ghost btn--icon chat-icon-btn chat-pane__close-pane" type="button">X</button>
+              </div>
+            </div>
+          </div>
+        </body></html>`,
+      );
+
+      const state = await page.locator(".chat-pane__header").evaluate((header) => {
+        const separators = [...header.querySelectorAll<HTMLElement>(".chat-pane__crumb-sep")];
+        const parent = header.querySelector<HTMLElement>(".chat-pane__parent-session-text")!;
+        const child = header.querySelector<HTMLElement>(".chat-pane__session-title-text")!;
+        return {
+          firstSeparator: getComputedStyle(separators[0]!).display,
+          secondSeparator: getComputedStyle(separators[1]!).display,
+          parentEllipses: parent.scrollWidth > parent.clientWidth,
+          childEllipses: child.scrollWidth > child.clientWidth,
+          overflow: (header as HTMLElement).scrollWidth - (header as HTMLElement).clientWidth,
+        };
+      });
+
+      expect(state).toEqual({
+        firstSeparator: "none",
+        secondSeparator: "block",
+        parentEllipses: true,
+        childEllipses: true,
+        overflow: 0,
+      });
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
   it("keeps a Done status disjoint from a long compact session headline", async () => {
     const page = await openBrowserPage(320, 240);
     try {

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -1115,13 +1115,13 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
-  it("keeps the parent and child breadcrumb distinct in a narrow pane", async () => {
-    const page = await openBrowserPage(430, 180);
+  it("caps a nested session trail at half the header while ellipsizing both titles", async () => {
+    const page = await openBrowserPage(720, 180);
     try {
       const splitViewCss = readStyleSheet("ui/src/styles/chat/split-view.css");
       await page.setContent(
         `<!doctype html><html><head><style>${readUiCss()}\n${splitViewCss}</style></head><body>
-          <div class="chat-split-view__cell" style="width: 320px;">
+          <div class="chat-split-view__cell" style="width: 640px;">
             <div class="chat-pane__header">
               <div class="chat-pane__crumbs">
                 <wa-dropdown class="chat-pane__workspace-menu">
@@ -1146,26 +1146,49 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         </body></html>`,
       );
 
-      const state = await page.locator(".chat-pane__header").evaluate((header) => {
-        const separators = [...header.querySelectorAll<HTMLElement>(".chat-pane__crumb-sep")];
-        const parent = header.querySelector<HTMLElement>(".chat-pane__parent-session-text")!;
-        const child = header.querySelector<HTMLElement>(".chat-pane__session-title-text")!;
-        return {
-          firstSeparator: getComputedStyle(separators[0]!).display,
-          secondSeparator: getComputedStyle(separators[1]!).display,
-          parentEllipses: parent.scrollWidth > parent.clientWidth,
-          childEllipses: child.scrollWidth > child.clientWidth,
-          overflow: (header as HTMLElement).scrollWidth - (header as HTMLElement).clientWidth,
-        };
-      });
+      const readState = () =>
+        page.locator(".chat-pane__header").evaluate((header) => {
+          const separators = [...header.querySelectorAll<HTMLElement>(".chat-pane__crumb-sep")];
+          const parentText = header.querySelector<HTMLElement>(".chat-pane__parent-session-text")!;
+          const childText = header.querySelector<HTMLElement>(".chat-pane__session-title-text")!;
+          const parent = header.querySelector<HTMLElement>(".chat-pane__parent-session")!;
+          const child = header.querySelector<HTMLElement>(".chat-pane__session-title")!;
+          const headerRect = header.getBoundingClientRect();
+          const parentRect = parent.getBoundingClientRect();
+          const childRect = child.getBoundingClientRect();
+          return {
+            firstSeparator: getComputedStyle(separators[0]!).display,
+            secondSeparator: getComputedStyle(separators[1]!).display,
+            parentEllipses: parentText.scrollWidth > parentText.clientWidth,
+            childEllipses: childText.scrollWidth > childText.clientWidth,
+            headerWidth: headerRect.width,
+            nestedTrailWidth: childRect.right - parentRect.left,
+            overflow: (header as HTMLElement).scrollWidth - (header as HTMLElement).clientWidth,
+          };
+        });
 
-      expect(state).toEqual({
+      const normal = await readState();
+      expect(normal).toMatchObject({
+        firstSeparator: "block",
+        secondSeparator: "block",
+        parentEllipses: true,
+        childEllipses: true,
+        overflow: 0,
+      });
+      expect(normal.nestedTrailWidth).toBeLessThanOrEqual(normal.headerWidth / 2 + 1);
+
+      await page.locator(".chat-split-view__cell").evaluate((cell) => {
+        (cell as HTMLElement).style.width = "320px";
+      });
+      const narrow = await readState();
+      expect(narrow).toMatchObject({
         firstSeparator: "none",
         secondSeparator: "block",
         parentEllipses: true,
         childEllipses: true,
         overflow: 0,
       });
+      expect(narrow.nestedTrailWidth).toBeLessThanOrEqual(narrow.headerWidth / 2 + 1);
     } finally {
       await closeBrowserPage(page);
     }

--- a/ui/src/pages/chat/components/chat-pane-header.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test.ts
@@ -15,6 +15,7 @@ import {
 import {
   canRevealSessionWorkspace,
   renderChatPaneHeader,
+  resolveChatPaneParentSession,
   resolveChatPaneWorkspace,
 } from "./chat-pane-header.ts";
 
@@ -80,6 +81,7 @@ function mount(patch: Partial<ChatPaneHeaderProps> = {}) {
     workspaceRoot: "/repo/openclaw",
     workspaceLabel: "openclaw",
     workspaceIcon: null,
+    parentSession: null,
     branch: "feature/header",
     branches: [],
     branchSwitchDisabledReason: null,
@@ -100,6 +102,7 @@ function mount(patch: Partial<ChatPaneHeaderProps> = {}) {
     onCancelRename: vi.fn(),
     onMenuOpenChange: vi.fn(),
     onMenuAction: vi.fn(),
+    onOpenParentSession: vi.fn(),
     onBranchSelect: vi.fn(),
     ...patch,
   };
@@ -324,6 +327,24 @@ describe("chat pane header", () => {
     );
   });
 
+  it("places a clickable parent between the project and child session", () => {
+    const parentSession = { key: "agent:main:parent", title: "Release prep" };
+    const { container, props } = mount({ parentSession });
+    const crumbs = container.querySelector(".chat-pane__crumbs");
+
+    expect([...(crumbs?.children ?? [])].map((child) => child.className)).toEqual([
+      "chat-pane__workspace-menu",
+      "chat-pane__crumb-sep",
+      "chat-pane__parent-session",
+      "chat-pane__crumb-sep",
+      "chat-pane__session-title chat-pane__session-title-button",
+    ]);
+    const parent = crumbs?.querySelector<HTMLButtonElement>(".chat-pane__parent-session");
+    expect(parent?.textContent?.trim()).toBe("Release prep");
+    parent?.click();
+    expect(props.onOpenParentSession).toHaveBeenCalledExactlyOnceWith("agent:main:parent");
+  });
+
   it("drops the separator when the session has no project segment", () => {
     const { container } = mount({ workspaceLabel: null, workspaceRoot: null });
     expect(container.querySelector(".chat-pane__crumb-sep")).toBeNull();
@@ -505,6 +526,38 @@ describe("chat pane header", () => {
       }),
     );
     expect(props.onBranchSelect).not.toHaveBeenCalled();
+  });
+});
+
+describe("chat pane parent resolution", () => {
+  it("uses the navigation parent and its canonical display name", () => {
+    const parent = row({
+      key: "agent:main:parent",
+      label: "Release prep",
+    });
+    const controlOwner = row({
+      key: "agent:main:control-owner",
+      label: "Coordinator",
+    });
+
+    expect(
+      resolveChatPaneParentSession(
+        row({
+          key: "agent:main:child",
+          parentSessionKey: parent.key,
+          spawnedBy: controlOwner.key,
+        }),
+        [controlOwner, parent],
+      ),
+    ).toEqual({ key: parent.key, title: "Release prep" });
+  });
+
+  it("omits unresolved and self-referential parents", () => {
+    const child = row({ key: "agent:main:child", parentSessionKey: "agent:main:missing" });
+    expect(resolveChatPaneParentSession(child, [child])).toBeNull();
+    expect(
+      resolveChatPaneParentSession({ ...child, parentSessionKey: child.key }, [child]),
+    ).toBeNull();
   });
 });
 

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -151,8 +151,8 @@ export function resolveChatPaneParentSession(
 /**
  * Header identity trail: which project, then which session inside it. Segments
  * and separators are rendered from one list so a further segment — the parent
- * session of a nested thread (#121700), yielding project / parent / child —
- * slots in without moving the project chip or the title.
+ * session of a nested thread, yielding project / parent / child — slots in
+ * without moving the project chip or the title.
  */
 function renderIdentityCrumbs(
   props: ChatPaneHeaderProps,

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -22,8 +22,18 @@ import "../../../components/workspace-icon.ts";
 import "../../../components/web-awesome.ts";
 import { t } from "../../../i18n/index.ts";
 import { formatRelativeTimestamp } from "../../../lib/format.ts";
+import { resolveSessionDisplayName } from "../../../lib/session-display.ts";
+import {
+  areUiSessionKeysEquivalent,
+  resolveUiSessionNavigationParentKey,
+} from "../../../lib/sessions/session-key.ts";
 
 export type ChatPaneHeaderAction = "reveal" | "copy-path" | "copy-branch";
+
+type ChatPaneParentSession = {
+  key: string;
+  title: string;
+};
 
 type ChatPaneHeaderProps = {
   paneId: string;
@@ -40,6 +50,7 @@ type ChatPaneHeaderProps = {
   workspaceLabel: string | null;
   /** Gateway-resolved project icon for the chip; absent keeps the folder glyph. */
   workspaceIcon: { routeUrl: string; authTokens: readonly string[]; authReady: boolean } | null;
+  parentSession: ChatPaneParentSession | null;
   branch: string | null;
   branches: SessionBranch[];
   branchSwitchDisabledReason: string | null;
@@ -66,6 +77,7 @@ type ChatPaneHeaderProps = {
   onCancelRename: () => void;
   onMenuOpenChange: (open: boolean) => void;
   onMenuAction: (action: ChatPaneHeaderAction) => void;
+  onOpenParentSession: (sessionKey: string) => void;
   onBranchSelect: (leafEntryId: string) => void;
   onOpenSplitView?: () => void;
   onSplitDown?: (paneId: string) => void;
@@ -124,6 +136,18 @@ export function resolveChatPaneWorkspace(params: {
   return { root, label };
 }
 
+export function resolveChatPaneParentSession(
+  session: GatewaySessionRow | undefined,
+  sessions: readonly GatewaySessionRow[],
+): ChatPaneParentSession | null {
+  const parentKey = resolveUiSessionNavigationParentKey(session);
+  if (!parentKey || (session && areUiSessionKeysEquivalent(parentKey, session.key))) {
+    return null;
+  }
+  const parent = sessions.find((row) => areUiSessionKeysEquivalent(row.key, parentKey));
+  return parent ? { key: parent.key, title: resolveSessionDisplayName(parent.key, parent) } : null;
+}
+
 /**
  * Header identity trail: which project, then which session inside it. Segments
  * and separators are rendered from one list so a further segment — the parent
@@ -138,6 +162,10 @@ function renderIdentityCrumbs(
 ) {
   const projectCrumb = renderProjectCrumb(props, copied, copyPathLabel, copyBranchLabel);
   const segments: TemplateResult[] = projectCrumb ? [projectCrumb] : [];
+  const parentCrumb = renderParentSessionCrumb(props);
+  if (parentCrumb) {
+    segments.push(parentCrumb);
+  }
   segments.push(renderSessionCrumb(props));
   return html`
     <div class="chat-pane__crumbs">
@@ -149,6 +177,23 @@ function renderIdentityCrumbs(
       )}
     </div>
   `;
+}
+
+function renderParentSessionCrumb(props: ChatPaneHeaderProps): TemplateResult | null {
+  const parent = props.parentSession;
+  if (!parent) {
+    return null;
+  }
+  const label = t("chat.sessionHeader.openParent", { title: parent.title });
+  return html`<button
+    class="chat-pane__parent-session"
+    type="button"
+    title=${label}
+    aria-label=${label}
+    @click=${() => props.onOpenParentSession(parent.key)}
+  >
+    <span class="chat-pane__parent-session-text">${parent.title}</span>
+  </button>`;
 }
 
 function renderSessionCrumb(props: ChatPaneHeaderProps) {

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -241,6 +241,13 @@ openclaw-chat-pane {
   color: var(--text);
 }
 
+/* Keep nested identity contextual rather than letting it become the header.
+   The two titles share at most half the container after separator spacing. */
+.chat-pane__crumbs:has(.chat-pane__parent-session) .chat-pane__parent-session,
+.chat-pane__crumbs:has(.chat-pane__parent-session) .chat-pane__session-title {
+  max-width: min(18ch, calc((50cqw - 20px) / 2));
+}
+
 .chat-pane__session-title-text,
 .chat-pane__parent-session-text {
   display: block;

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -201,7 +201,8 @@ openclaw-chat-pane {
   font-size: 12px;
 }
 
-.chat-pane__session-title-button {
+.chat-pane__session-title-button,
+.chat-pane__parent-session {
   display: block;
   /* Hover padding is drawn outside the text box: the plain-span title (catalog
      and rename-disabled panes) has none, and without the pull-back the same
@@ -212,16 +213,36 @@ openclaw-chat-pane {
   border-radius: var(--radius-sm);
   background: transparent;
   text-align: left;
+}
+
+.chat-pane__session-title-button {
   cursor: text;
 }
 
 .chat-pane__session-title-button:hover,
-.chat-pane__session-title-button:focus-visible {
+.chat-pane__session-title-button:focus-visible,
+.chat-pane__parent-session:hover,
+.chat-pane__parent-session:focus-visible {
   background: color-mix(in srgb, var(--text) 7%, transparent);
   outline: none;
 }
 
-.chat-pane__session-title-text {
+.chat-pane__parent-session {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 12px;
+  cursor: var(--cursor-action);
+}
+
+.chat-pane__parent-session:hover,
+.chat-pane__parent-session:focus-visible {
+  color: var(--text);
+}
+
+.chat-pane__session-title-text,
+.chat-pane__parent-session-text {
   display: block;
   overflow: hidden;
   white-space: nowrap;
@@ -622,7 +643,7 @@ openclaw-chat-pane {
 
   /* The project name is gone at this width, so the separator would trail an
      icon-only pill and read as punctuation with nothing on its left. */
-  .chat-pane__crumb-sep {
+  .chat-pane__workspace-menu + .chat-pane__crumb-sep {
     display: none;
   }
 


### PR DESCRIPTION
Closes #121700

## What Problem This Solves

Fixes an issue where operators opening a nested session could see its parent relationship in the sidebar, but the Chat top bar presented that same child as a standalone session.

## Why This Change Was Made

This PR adds the immediate navigation parent between the existing project and child-session crumbs. It resolves the parent through the canonical `parentSessionKey ?? spawnedBy` rule, uses the already-loaded session roster for its display name, and routes clicks through the pane's existing session-navigation callback. No request or fallback label is added; unresolved, root, and self-referential parents remain absent.

The nested parent/separator/child trail is capped below half the top-bar width. Both titles have independent ellipsis and an additional `18ch` ceiling, keeping the identity trail compact even when the header has abundant space. On narrow panes, only the project separator is suppressed; the parent-to-child separator remains visible.

## User Impact

Operators can identify a child session's parent without returning to the sidebar and can open that parent directly from the Chat top bar. Long parent and child names stay contextual instead of taking over the header. Root sessions keep the existing project-to-session trail, and the child title keeps its rename affordance.

## Evidence

### Before / after

| Theme | Before: `project / child` | After in this PR: compact `project / parent / child` |
| --- | --- | --- |
| Light | ![Light theme before: nested child shown without its parent in the Chat top bar](https://github.com/user-attachments/assets/e1cf7390-7974-48c3-b98b-b123a30d072c) | ![Light theme after: long parent and child labels truncate independently in a compact top-bar breadcrumb](https://github.com/user-attachments/assets/b4c2d68b-3fcd-446c-9c5c-e976fe9d2adc) |
| Dark | ![Dark theme before: nested child shown without its parent in the Chat top bar](https://github.com/user-attachments/assets/1c5a54a3-97dc-41e9-af4e-77553fa25b0a) | ![Dark theme after: long parent and child labels truncate independently in a compact top-bar breadcrumb](https://github.com/user-attachments/assets/b6fa8063-42c2-45a6-9645-a9b14ffd8efc) |

### State matrix

| State | Light | Dark |
| --- | --- | --- |
| Default, long parent + child | ![Light default header with a compact long-title breadcrumb](https://github.com/user-attachments/assets/c67ffab8-227d-4953-a3f5-e9934146f804) | ![Dark default header with a compact long-title breadcrumb](https://github.com/user-attachments/assets/ff479dc1-9b3a-4c91-9079-7992d800b48d) |
| Hover | ![Light parent breadcrumb hover state](https://github.com/user-attachments/assets/8ffc01d6-372f-44d4-bd8d-675d9d6bb5d5) | ![Dark parent breadcrumb hover state](https://github.com/user-attachments/assets/cf272200-576e-47f0-9126-5debba9ca1d8) |
| Keyboard focus | ![Light parent breadcrumb keyboard focus state](https://github.com/user-attachments/assets/96daa4c6-89b1-4789-9aa4-4eb1d05c558e) | ![Dark parent breadcrumb keyboard focus state](https://github.com/user-attachments/assets/7df529f7-2f5c-48ea-8cb0-080822b05439) |
| Long labels / 430 px viewport | ![Light narrow header with independently truncated parent and child labels](https://github.com/user-attachments/assets/0b8baa5c-c1df-4b39-9e03-3e11634ea5c8) | ![Dark narrow header with independently truncated parent and child labels](https://github.com/user-attachments/assets/252c3e3b-586b-44df-bb7a-1cd050674347) |
| Root or unresolved parent | ![Light root session retaining the existing project-to-session trail](https://github.com/user-attachments/assets/622c06c3-eb1a-443d-95e9-d6f7359c7339) | ![Dark root session retaining the existing project-to-session trail](https://github.com/user-attachments/assets/8536160d-1c4a-4d06-90bc-11b01dd41539) |
| Disabled | Not applicable: the parent crumb is rendered only when a navigable parent descriptor exists. | Not applicable: the parent crumb is rendered only when a navigable parent descriptor exists. |

### Validation

- Width regression red proof: before the cap, the parent-to-child trail measured 510 px in a 640 px header and failed the half-width assertion.
- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-pane-header.test.ts ui/src/pages/chat/chat-pane-session-access.test.ts` — 48 passed.
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts -t 'caps a nested session trail at half the header while ellipsizing both titles'` — passed at 640 px and 320 px, with real ellipsis on both labels.
- `node scripts/run-vitest.mjs ui/src/e2e/chat-header-axis.e2e.test.ts` — 2 passed across light and dark, including geometry and parent navigation.
- The refreshed light/dark proof uses long labels at normal and narrow widths; all ten after-state images were inspected before upload.

Production delta: +83 / -4 (net +79). Test delta: +209 / -2 (net +207).
