### PR TITLE
test(ci): parallelize channel contract projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2115,6 +2115,7 @@ jobs:
       - name: Run channel contract shard
         env:
           OPENCLAW_CONTRACT_INCLUDE_PATTERNS_JSON: ${{ toJson(matrix.includePatterns) }}
+          OPENCLAW_TEST_PROJECTS_PARALLEL: "4"
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## What Problem This Solves

Each existing channel-contract CI job runs four independent Vitest project processes serially on a 4-vCPU worker. The test body therefore occupies roughly 74–100 seconds even though the four projects already have separate process/module state and one Vitest worker each.

## Why This Change Was Made

This AI-assisted change sets the existing test-projects parallelism to four only for the existing channel-contract job. The four project configs keep their separate Vitest processes, non-isolated-runner cleanup, include routing, one-worker budgets, and writer-safe module-cache paths; they simply use the four CPUs already assigned to the job concurrently.

No CI job, matrix entry, runner, worker, shard, test, or production path is added.

## User Impact

Developers and CI get faster channel contract feedback without reducing contract coverage or increasing CI worker count.

## Evidence

Recent hosted baseline:

- channel shard A: **99.99s** test-projects duration / **152s** whole job
- channel shard B: **74.39s** test-projects duration / **125s** whole job

Same orb, Node 24.15, identical shard A include set, fresh isolated module-cache paths:

- 193/193 tests passed in both runs across all four projects
- serial baseline: **162.20s** test-projects / **162.41s** wall
- four-way project concurrency: **41.27s** test-projects / **41.47s** wall
- improvement: **74.6%** test-projects duration / **74.5%** wall time

Also passed:

- GitHub Actions workflow lint
- zizmor
- composite-run interpolation guard
- affected workflow formatting and `git diff --check`
- focused CI workflow guard

Exact-head hosted comparison:

- shard A: **99.99s → 56.93s** test command (**43.1% faster**); whole job **152s → 101s** (**33.6% faster**)
- shard B: **74.39s → 61.97s** test command (**16.7% faster**)
- channel-test critical path: **99.99s → 61.97s** (**38.0% faster**)
- both exact-head jobs passed; runner setup variance made shard B whole-job time 7s slower despite its faster test command


