### PR TITLE
fix(gateway): resolve combined store paths in title batches

### DIFF
--- a/src/gateway/session-transcript-title-reader.placeholder.test.ts
+++ b/src/gateway/session-transcript-title-reader.placeholder.test.ts
@@ -1,0 +1,44 @@
+import path from "node:path";
+import { afterEach, expect, test } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { persistSessionTranscriptTurn } from "../config/sessions/session-accessor.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { readSessionTitleFieldsFromTranscriptBatch } from "./session-transcript-title-reader.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+});
+
+test("resolves placeholder store paths before batched title reads", async () => {
+  const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+  const stateDir = tempDirs.make("openclaw-placeholder-batched-title-");
+  setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+  const sessionId = "reader-placeholder-batched-title";
+  const sessionKey = `agent:main:${sessionId}`;
+  const storePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+  try {
+    await persistSessionTranscriptTurn(
+      { agentId: "main", sessionId, sessionKey, storePath },
+      {
+        messages: [
+          { message: { role: "user", content: "real prompt" } },
+          { message: { role: "assistant", content: "real reply" } },
+        ],
+        touchSessionEntry: false,
+      },
+    );
+
+    expect(
+      readSessionTitleFieldsFromTranscriptBatch([
+        { agentId: "main", sessionId, sessionKey, storePath: "(multiple)" },
+      ]),
+    ).toEqual([{ firstUserMessage: "real prompt", lastMessagePreview: "real reply" }]);
+  } finally {
+    envSnapshot.restore();
+  }
+});

--- a/src/gateway/session-transcript-title-reader.ts
+++ b/src/gateway/session-transcript-title-reader.ts
@@ -234,7 +234,7 @@ function readSessionTitleFieldsFromTranscriptBatchCurrent(
   }
 
   const watermarks = readSessionTranscriptWatermarkBatch(
-    cachedCandidates.map((candidate) => candidate.scope),
+    cachedCandidates.map((candidate) => toTranscriptReadScope(candidate.target)),
   );
   for (const [candidateIndex, candidate] of cachedCandidates.entries()) {
     const watermark = watermarks[candidateIndex];
@@ -256,7 +256,11 @@ function readSessionTitleFieldsFromTranscriptBatchCurrent(
   }
 
   const probes =
-    misses.length > 0 ? readSessionTranscriptTitleProbeBatch(misses.map((miss) => miss.scope)) : [];
+    misses.length > 0
+      ? readSessionTranscriptTitleProbeBatch(
+          misses.map((miss) => toTranscriptReadScope(miss.target)),
+        )
+      : [];
   for (const [probeIndex, miss] of misses.entries()) {
     const probe = probes[probeIndex];
     if (!probe) {


### PR DESCRIPTION
## Summary
- resolve each transcript target before batched watermark reads
- resolve each transcript target before batched title probes
- cover the combined-store placeholder against a real per-agent SQLite transcript

## Validation
- focused regression: 3/3 project variants passed
- full `pnpm check` passed
- full `pnpm build` passed