### PR TITLE
refactor(plugins): consolidate public artifact resolution

### DIFF
--- a/src/plugins/web-provider-public-artifacts.explicit.ts
+++ b/src/plugins/web-provider-public-artifacts.explicit.ts
@@ -43,14 +43,6 @@ function isWebProviderPlugin(
   );
 }
 
-function isWebSearchProviderPlugin(value: unknown): value is WebSearchProviderPlugin {
-  return isWebProviderPlugin(value);
-}
-
-function isWebFetchProviderPlugin(value: unknown): value is WebFetchProviderPlugin {
-  return isWebProviderPlugin(value);
-}
-
 function collectProviderFactories<TProvider>(params: {
   mod: Record<string, unknown>;
   suffix: string;
@@ -92,10 +84,6 @@ function unableToInitializeProviderError(params: {
   });
 }
 
-function normalizeExplicitBundledPluginIds(pluginIds: readonly string[]): string[] {
-  return sortUniqueStrings(pluginIds);
-}
-
 function loadBundledProviderEntriesFromDir<TProvider extends object>(params: {
   dirName: string;
   pluginId: string;
@@ -127,16 +115,32 @@ function loadBundledProviderEntriesFromDir<TProvider extends object>(params: {
   return providers.map((provider) => Object.assign({}, provider, { pluginId: params.pluginId }));
 }
 
+function resolveBundledExplicitProviders<TProvider>(params: {
+  onlyPluginIds: readonly string[];
+  loadProviders: (pluginId: string) => TProvider[] | null;
+}): TProvider[] | null {
+  const providers: TProvider[] = [];
+  // Sorted plugin IDs plus each module's sorted factories preserve stable
+  // plugin and factory ordering across all three explicit resolution paths.
+  for (const pluginId of sortUniqueStrings(params.onlyPluginIds)) {
+    const loadedProviders = params.loadProviders(pluginId);
+    if (!loadedProviders) {
+      return null;
+    }
+    providers.push(...loadedProviders);
+  }
+  return providers;
+}
+
 export function loadBundledWebSearchProviderEntriesFromDir(params: {
   dirName: string;
   pluginId: string;
 }): PluginWebSearchProviderEntry[] | null {
   return loadBundledProviderEntriesFromDir<WebSearchProviderPlugin>({
-    dirName: params.dirName,
-    pluginId: params.pluginId,
+    ...params,
     artifactCandidates: WEB_SEARCH_ARTIFACT_CANDIDATES,
     suffix: "WebSearchProvider",
-    isProvider: isWebSearchProviderPlugin,
+    isProvider: (value): value is WebSearchProviderPlugin => isWebProviderPlugin(value),
   });
 }
 
@@ -145,11 +149,10 @@ export function loadBundledWebFetchProviderEntriesFromDir(params: {
   pluginId: string;
 }): PluginWebFetchProviderEntry[] | null {
   return loadBundledProviderEntriesFromDir<WebFetchProviderPlugin>({
-    dirName: params.dirName,
-    pluginId: params.pluginId,
+    ...params,
     artifactCandidates: WEB_FETCH_ARTIFACT_CANDIDATES,
     suffix: "WebFetchProvider",
-    isProvider: isWebFetchProviderPlugin,
+    isProvider: (value): value is WebFetchProviderPlugin => isWebProviderPlugin(value),
   });
 }
 
@@ -158,61 +161,39 @@ function loadBundledRuntimeWebFetchProviderEntriesFromDir(params: {
   pluginId: string;
 }): PluginWebFetchProviderEntry[] | null {
   return loadBundledProviderEntriesFromDir<WebFetchProviderPlugin>({
-    dirName: params.dirName,
-    pluginId: params.pluginId,
+    ...params,
     artifactCandidates: WEB_FETCH_RUNTIME_ARTIFACT_CANDIDATES,
     suffix: "WebFetchProvider",
-    isProvider: isWebFetchProviderPlugin,
+    isProvider: (value): value is WebFetchProviderPlugin => isWebProviderPlugin(value),
   });
 }
 
 export function resolveBundledExplicitWebSearchProvidersFromPublicArtifacts(params: {
   onlyPluginIds: readonly string[];
 }): PluginWebSearchProviderEntry[] | null {
-  const providers: PluginWebSearchProviderEntry[] = [];
-  for (const pluginId of normalizeExplicitBundledPluginIds(params.onlyPluginIds)) {
-    const loadedProviders = loadBundledWebSearchProviderEntriesFromDir({
-      dirName: pluginId,
-      pluginId,
-    });
-    if (!loadedProviders) {
-      return null;
-    }
-    providers.push(...loadedProviders);
-  }
-  return providers;
+  return resolveBundledExplicitProviders({
+    ...params,
+    loadProviders: (pluginId) =>
+      loadBundledWebSearchProviderEntriesFromDir({ dirName: pluginId, pluginId }),
+  });
 }
 
 export function resolveBundledExplicitWebFetchProvidersFromPublicArtifacts(params: {
   onlyPluginIds: readonly string[];
 }): PluginWebFetchProviderEntry[] | null {
-  const providers: PluginWebFetchProviderEntry[] = [];
-  for (const pluginId of normalizeExplicitBundledPluginIds(params.onlyPluginIds)) {
-    const loadedProviders = loadBundledWebFetchProviderEntriesFromDir({
-      dirName: pluginId,
-      pluginId,
-    });
-    if (!loadedProviders) {
-      return null;
-    }
-    providers.push(...loadedProviders);
-  }
-  return providers;
+  return resolveBundledExplicitProviders({
+    ...params,
+    loadProviders: (pluginId) =>
+      loadBundledWebFetchProviderEntriesFromDir({ dirName: pluginId, pluginId }),
+  });
 }
 
 export function resolveBundledExplicitRuntimeWebFetchProvidersFromPublicArtifacts(params: {
   onlyPluginIds: readonly string[];
 }): PluginWebFetchProviderEntry[] | null {
-  const providers: PluginWebFetchProviderEntry[] = [];
-  for (const pluginId of normalizeExplicitBundledPluginIds(params.onlyPluginIds)) {
-    const loadedProviders = loadBundledRuntimeWebFetchProviderEntriesFromDir({
-      dirName: pluginId,
-      pluginId,
-    });
-    if (!loadedProviders) {
-      return null;
-    }
-    providers.push(...loadedProviders);
-  }
-  return providers;
+  return resolveBundledExplicitProviders({
+    ...params,
+    loadProviders: (pluginId) =>
+      loadBundledRuntimeWebFetchProviderEntriesFromDir({ dirName: pluginId, pluginId }),
+  });
 }

--- a/src/plugins/web-provider-public-artifacts.ts
+++ b/src/plugins/web-provider-public-artifacts.ts
@@ -6,7 +6,6 @@ import { resolveEnabledBundledManifestContractPlugins } from "./bundled-manifest
 import { normalizePluginId } from "./config-state.js";
 import type { PluginLoadOptions } from "./loader.js";
 import { loadManifestMetadataSnapshot } from "./manifest-contract-eligibility.js";
-import type { PluginManifestRecord } from "./manifest-registry.js";
 import type { PluginWebFetchProviderEntry, PluginWebSearchProviderEntry } from "./types.js";
 import { resolveBundledWebFetchResolutionConfig } from "./web-fetch-providers.shared.js";
 import {
@@ -24,11 +23,6 @@ type BundledWebProviderPublicArtifactParams = {
   workspaceDir?: string;
   env?: PluginLoadOptions["env"];
   onlyPluginIds?: readonly string[];
-};
-
-type BundledCandidateResolution = {
-  pluginIds: string[];
-  manifestRecords?: readonly PluginManifestRecord[];
 };
 
 function filterAllowlistedBundledPluginIds(
@@ -57,7 +51,7 @@ function resolveBundledCandidatePluginIds(params: {
   workspaceDir?: string;
   env?: PluginLoadOptions["env"];
   onlyPluginIds?: readonly string[];
-}): BundledCandidateResolution {
+}) {
   if (params.onlyPluginIds !== undefined) {
     return {
       pluginIds: filterAllowlistedBundledPluginIds(params.config, [
@@ -84,31 +78,7 @@ function resolveBundledCandidatePluginIds(params: {
   };
 }
 
-function resolveBundledManifestRecordsByPluginId(params: {
-  config?: PluginLoadOptions["config"];
-  workspaceDir?: string;
-  env?: PluginLoadOptions["env"];
-  onlyPluginIds: readonly string[];
-  manifestRecords?: readonly PluginManifestRecord[];
-}) {
-  const allowedPluginIds = new Set(params.onlyPluginIds);
-  const manifestRecords =
-    params.manifestRecords ??
-    loadManifestMetadataSnapshot({
-      config: params.config,
-      workspaceDir: params.workspaceDir,
-      env: params.env,
-    }).plugins;
-  return new Map(
-    manifestRecords
-      .filter((record) => record.origin === "bundled" && allowedPluginIds.has(record.id))
-      .map((record) => [record.id, record] as const),
-  );
-}
-
 function resolveBundledRuntimeCandidatePluginIds(params: {
-  contract: "webFetchProviders";
-  configKey: "webFetch";
   config?: PluginLoadOptions["config"];
   workspaceDir?: string;
   env?: PluginLoadOptions["env"];
@@ -116,8 +86,8 @@ function resolveBundledRuntimeCandidatePluginIds(params: {
 }): string[] | null {
   const resolvedConfig = resolveBundledWebFetchResolutionConfig(params).config;
   const candidates = resolveManifestDeclaredWebProviderCandidates({
-    contract: params.contract,
-    configKey: params.configKey,
+    contract: "webFetchProviders",
+    configKey: "webFetch",
     config: resolvedConfig,
     workspaceDir: params.workspaceDir,
     env: params.env,
@@ -138,46 +108,58 @@ function resolveBundledRuntimeCandidatePluginIds(params: {
       workspaceDir: params.workspaceDir,
       env: params.env,
       onlyPluginIds: pluginIds,
-      contract: params.contract,
+      contract: "webFetchProviders",
     }).map((plugin) => plugin.id),
   );
   return pluginIds.filter((pluginId) => enabledPluginIds.has(pluginId));
 }
 
-export function resolveBundledWebSearchProvidersFromPublicArtifacts(
-  params: BundledWebProviderPublicArtifactParams,
-): PluginWebSearchProviderEntry[] | null {
-  const pluginIds = resolveBundledCandidatePluginIds({
-    contract: "webSearchProviders",
-    configKey: "webSearch",
-    config: params.config,
-    workspaceDir: params.workspaceDir,
-    env: params.env,
-    onlyPluginIds: params.onlyPluginIds,
+function resolveBundledWebProvidersFromPublicArtifacts<TProvider>(params: {
+  loadExplicit: (params: { onlyPluginIds: readonly string[] }) => TProvider[] | null;
+  loadFromDir: (params: { dirName: string; pluginId: string }) => TProvider[] | null;
+  contract: "webSearchProviders" | "webFetchProviders";
+  configKey: "webSearch" | "webFetch";
+  resolution: BundledWebProviderPublicArtifactParams;
+}): TProvider[] | null {
+  const candidates = resolveBundledCandidatePluginIds({
+    contract: params.contract,
+    configKey: params.configKey,
+    config: params.resolution.config,
+    workspaceDir: params.resolution.workspaceDir,
+    env: params.resolution.env,
+    onlyPluginIds: params.resolution.onlyPluginIds,
   });
-  if (pluginIds.pluginIds.length === 0) {
+  if (candidates.pluginIds.length === 0) {
     return [];
   }
-  const directProviders = resolveBundledExplicitWebSearchProvidersFromPublicArtifacts({
-    onlyPluginIds: pluginIds.pluginIds,
-  });
-  if (directProviders) {
-    return directProviders;
+  // Explicit scopes stay on named artifacts; unscoped discovery already carries
+  // manifest records into this fast-path attempt.
+  const explicitProviders = params.loadExplicit({ onlyPluginIds: candidates.pluginIds });
+  if (explicitProviders) {
+    return explicitProviders;
   }
-  const recordsByPluginId = resolveBundledManifestRecordsByPluginId({
-    config: params.config,
-    workspaceDir: params.workspaceDir,
-    env: params.env,
-    onlyPluginIds: pluginIds.pluginIds,
-    manifestRecords: pluginIds.manifestRecords,
-  });
-  const providers: PluginWebSearchProviderEntry[] = [];
-  for (const pluginId of pluginIds.pluginIds) {
+  const allowedPluginIds = new Set(candidates.pluginIds);
+  const recordsByPluginId = new Map(
+    (
+      candidates.manifestRecords ??
+      loadManifestMetadataSnapshot({
+        config: params.resolution.config,
+        workspaceDir: params.resolution.workspaceDir,
+        env: params.resolution.env,
+      }).plugins
+    )
+      .filter((record) => record.origin === "bundled" && allowedPluginIds.has(record.id))
+      .map((record) => [record.id, record] as const),
+  );
+  const providers: TProvider[] = [];
+  // Candidate coverage is authoritative: a missing artifact invalidates the
+  // complete resolution instead of returning a partial provider set.
+  for (const pluginId of candidates.pluginIds) {
     const record = recordsByPluginId.get(pluginId);
     if (!record) {
       return null;
     }
-    const loadedProviders = loadBundledWebSearchProviderEntriesFromDir({
+    const loadedProviders = params.loadFromDir({
       dirName: path.basename(record.rootDir),
       pluginId,
     });
@@ -189,49 +171,28 @@ export function resolveBundledWebSearchProvidersFromPublicArtifacts(
   return providers;
 }
 
+export function resolveBundledWebSearchProvidersFromPublicArtifacts(
+  params: BundledWebProviderPublicArtifactParams,
+): PluginWebSearchProviderEntry[] | null {
+  return resolveBundledWebProvidersFromPublicArtifacts({
+    contract: "webSearchProviders",
+    configKey: "webSearch",
+    resolution: params,
+    loadExplicit: resolveBundledExplicitWebSearchProvidersFromPublicArtifacts,
+    loadFromDir: loadBundledWebSearchProviderEntriesFromDir,
+  });
+}
+
 export function resolveBundledWebFetchProvidersFromPublicArtifacts(
   params: BundledWebProviderPublicArtifactParams,
 ): PluginWebFetchProviderEntry[] | null {
-  const pluginIds = resolveBundledCandidatePluginIds({
+  return resolveBundledWebProvidersFromPublicArtifacts({
     contract: "webFetchProviders",
     configKey: "webFetch",
-    config: params.config,
-    workspaceDir: params.workspaceDir,
-    env: params.env,
-    onlyPluginIds: params.onlyPluginIds,
+    resolution: params,
+    loadExplicit: resolveBundledExplicitWebFetchProvidersFromPublicArtifacts,
+    loadFromDir: loadBundledWebFetchProviderEntriesFromDir,
   });
-  if (pluginIds.pluginIds.length === 0) {
-    return [];
-  }
-  const directProviders = resolveBundledExplicitWebFetchProvidersFromPublicArtifacts({
-    onlyPluginIds: pluginIds.pluginIds,
-  });
-  if (directProviders) {
-    return directProviders;
-  }
-  const recordsByPluginId = resolveBundledManifestRecordsByPluginId({
-    config: params.config,
-    workspaceDir: params.workspaceDir,
-    env: params.env,
-    onlyPluginIds: pluginIds.pluginIds,
-    manifestRecords: pluginIds.manifestRecords,
-  });
-  const providers: PluginWebFetchProviderEntry[] = [];
-  for (const pluginId of pluginIds.pluginIds) {
-    const record = recordsByPluginId.get(pluginId);
-    if (!record) {
-      return null;
-    }
-    const loadedProviders = loadBundledWebFetchProviderEntriesFromDir({
-      dirName: path.basename(record.rootDir),
-      pluginId,
-    });
-    if (!loadedProviders) {
-      return null;
-    }
-    providers.push(...loadedProviders);
-  }
-  return providers;
 }
 
 export function resolveBundledRuntimeWebFetchProvidersFromPublicArtifacts(
@@ -240,8 +201,6 @@ export function resolveBundledRuntimeWebFetchProvidersFromPublicArtifacts(
   },
 ): PluginWebFetchProviderEntry[] | null {
   const pluginIds = resolveBundledRuntimeCandidatePluginIds({
-    contract: "webFetchProviders",
-    configKey: "webFetch",
     config: params.config,
     workspaceDir: params.workspaceDir,
     env: params.env,


### PR DESCRIPTION
## What Problem This Solves

The bundled web-provider public-artifact resolvers repeated the same explicit plugin loop and the same explicit-fast-path-to-manifest-fallback flow across search and fetch. That duplication made behavior-neutral maintenance of ordering, fallback, and complete-coverage semantics unnecessarily error-prone.

## Why This Change Was Made

This consolidates the repeated flows into one private generic resolver per existing module. Runtime web-fetch eligibility remains separate from artifact selection, and runtime resolution still excludes `web-fetch-contract-api.js`.

Preserved invariants:

- explicit scopes avoid manifest/runtime loading
- unscoped resolution remains manifest-first
- plugin and factory ordering stays deterministic
- plugin allowlists are unchanged
- healthy sibling factories survive one factory error
- all-failed factories retain actionable thrown errors
- `[]` remains authoritative empty; `null` remains complete-resolution failure
- partial provider coverage is never returned

No exports, callers, SDK surfaces, configuration, schemas, protocols, docs, tests, or changelog entries changed.

## User Impact

No user-visible behavior changes. The resolver implementation is smaller and has one canonical path for each repeated decision flow.

Production LOC: `+96/-156` (net `-60`). Test LOC: `+0/-0`.

## Evidence

Local focused proof:

- 3 focused files passed, 28 tests passed
- targeted formatting and oxlint passed
- `git diff --check` passed

Testbox exact-head proof:

- head `ea1dce45437c04404b2f2533ac0eb9c3ce5a7e26`
- tree `3c9d0698d26063bd91eb66fd1866f9a696d29cf6`
- lease `tbx_01kzsjnc48yqz862ndkks306z8`
- workflow `31546799121`, job `93960946709`
- 63 focused tests passed
- test types passed
- 1,049 plugin-contract tests passed
- build passed
- 28-check changed gate passed
- full workflow, SSH, post, and runner phases succeeded

AWS independent runtime proof:

- run `run_3daeabdd9792`, lease `cbx_727347899cc7`
- full build passed
- 63 focused tests passed
- compiled Brave and Firecrawl probe passed
- contract-only artifact resolution returned `null` for runtime use
- runtime selected an executable artifact and excluded `web-fetch-contract-api.js`
- CLI smokes passed
- lease released

AI-assisted: yes. The change was reviewed against the complete target modules, current focused tests, callers, public-surface loader contracts, and relevant history.
