### PR TITLE
fix(skills): stop reporting invalid source skills as installed

### DIFF
--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -683,6 +683,8 @@ describe("skills cli commands", () => {
   );
 
   it("installs a skill from a git source into the active workspace", async () => {
+    const config = { skills: { limits: { maxSkillFileBytes: 1234 } } };
+    loadConfigMock.mockReturnValue(config);
     installSkillFromSourceMock.mockResolvedValue({
       ok: true,
       slug: "tools",
@@ -695,9 +697,9 @@ describe("skills cli commands", () => {
     const installArgs = mockFirstObjectArg(installSkillFromSourceMock);
     expectObjectFields(installArgs, {
       workspaceDir: "/tmp/workspace",
+      config,
       spec: "git:owner/tools",
       force: false,
-      config: {},
     });
     expect(installArgs.slug).toBeUndefined();
     expectLogger(installArgs.logger);

--- a/src/skills/lifecycle/source-install.test.ts
+++ b/src/skills/lifecycle/source-install.test.ts
@@ -1,7 +1,8 @@
 // Source install tests cover installing skill sources from local and remote inputs.
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { runCommandWithTimeout } from "../../process/exec.js";
 import { withTestDir } from "../../test-helpers/temp-dir.js";
 import { buildWorkspaceSkillStatus } from "../discovery/status.js";
@@ -143,6 +144,63 @@ describe("installSkillFromSource", () => {
         name: "frontmatter-skill",
         skillKey: "custom-name",
       });
+    });
+  });
+
+  it("rejects unfenced SKILL.md metadata before copying the source", async () => {
+    await withTestDir({ prefix: "openclaw-skill-source-invalid-metadata-" }, async (root) => {
+      const workspaceDir = path.join(root, "workspace");
+      const sourceDir = path.join(root, "source");
+      const childDir = path.join(sourceDir, "child-skill");
+      await fs.mkdir(sourceDir, { recursive: true });
+      await fs.writeFile(
+        path.join(sourceDir, "SKILL.md"),
+        "name: probe-x\nversion: 1.0.0\ndescription: probe\n\nUse when testing.\n",
+      );
+      await writeSkill(childDir, { name: "child-skill" });
+
+      const readdir = vi.spyOn(fsSync, "readdirSync");
+      try {
+        const result = await installSkillFromSource({
+          workspaceDir,
+          spec: sourceDir,
+          slug: "probe-x",
+        });
+
+        expect(result).toMatchObject({
+          ok: false,
+          error: expect.stringContaining("invalid or missing frontmatter"),
+        });
+        await expect(fs.access(path.join(workspaceDir, "skills", "probe-x"))).rejects.toThrow();
+        expect(readdir.mock.calls.some(([dir]) => dir === sourceDir)).toBe(false);
+      } finally {
+        readdir.mockRestore();
+      }
+    });
+  });
+
+  it("rejects a valid root that exceeds the configured discovery byte limit", async () => {
+    await withTestDir({ prefix: "openclaw-skill-source-oversized-root-" }, async (root) => {
+      const workspaceDir = path.join(root, "workspace");
+      const sourceDir = path.join(root, "source");
+      await writeSkill(sourceDir, {
+        name: "oversized-root",
+        description: "A description that exceeds this test's deliberately small limit",
+      });
+
+      const result = await installSkillFromSource({
+        workspaceDir,
+        spec: sourceDir,
+        config: { skills: { limits: { maxSkillFileBytes: 32 } } },
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: expect.stringContaining("invalid or missing frontmatter"),
+      });
+      await expect(
+        fs.access(path.join(workspaceDir, "skills", "oversized-root")),
+      ).rejects.toThrow();
     });
   });
 

--- a/src/skills/lifecycle/source-install.ts
+++ b/src/skills/lifecycle/source-install.ts
@@ -12,7 +12,8 @@ import { isImmutableGitCommitRef, parseGitPluginSpec } from "../../plugins/git-i
 import type { InstallSafetyOverrides } from "../../plugins/install-security-scan.types.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
 import { resolveUserPath } from "../../utils.js";
-import { parseSkillFrontmatter } from "../loading/frontmatter.js";
+import { readSkillFrontmatterSafe } from "../loading/local-loader.js";
+import { resolveSkillDiscoveryLimits } from "../loading/skill-root-discovery.js";
 import { installExtractedSkillRoot, validateRequestedSkillSlug } from "./archive-install.js";
 import { untrackClawHubSkill } from "./clawhub.js";
 
@@ -129,34 +130,38 @@ async function resolveGitCommitish(params: {
   };
 }
 
-async function readSkillNameFromFrontmatter(skillDir: string): Promise<string | null> {
-  try {
-    const raw = await fs.readFile(path.join(skillDir, "SKILL.md"), "utf8");
-    const frontmatter = parseSkillFrontmatter(raw);
-    return normalizeOptionalString(frontmatter.name) ?? null;
-  } catch {
-    return null;
+function readLoadableSkillName(
+  skillDir: string,
+  maxSkillFileBytes: number,
+): { ok: true; name: string | null } | { ok: false } {
+  const frontmatter = readSkillFrontmatterSafe({
+    rootDir: skillDir,
+    filePath: path.join(skillDir, "SKILL.md"),
+    maxBytes: maxSkillFileBytes,
+  });
+  if (!frontmatter?.description?.trim()) {
+    return { ok: false };
   }
+  return { ok: true, name: normalizeOptionalString(frontmatter.name) ?? null };
 }
 
 function resolveFallbackSlugFromPath(sourcePath: string): string {
   return path.basename(path.resolve(sourcePath)).trim();
 }
 
-async function resolveSkillInstallSlug(params: {
-  sourceDir: string;
+function resolveSkillInstallSlug(params: {
+  frontmatterName: string | null;
   fallbackLabel: string;
   slug?: string;
-}): Promise<string> {
+}): string {
   const explicit = normalizeOptionalString(params.slug);
   if (explicit) {
     return validateRequestedSkillSlug(explicit);
   }
 
-  const frontmatterName = await readSkillNameFromFrontmatter(params.sourceDir);
-  if (frontmatterName) {
+  if (params.frontmatterName) {
     try {
-      return validateRequestedSkillSlug(frontmatterName);
+      return validateRequestedSkillSlug(params.frontmatterName);
     } catch {
       // Fall back to the source label when the display name is not a valid install slug.
     }
@@ -207,8 +212,19 @@ async function installLocalSkillDir(params: {
   onInstallPolicyWarning?: InstallSafetyOverrides["onInstallPolicyWarning"];
   git?: SkillSourceOrigin["git"];
 }): Promise<SkillSourceInstallResult> {
-  const slug = await resolveSkillInstallSlug({
-    sourceDir: params.sourceDir,
+  const sourceSkill = readLoadableSkillName(
+    params.sourceDir,
+    resolveSkillDiscoveryLimits(params.config).maxSkillFileBytes,
+  );
+  if (!sourceSkill.ok) {
+    return {
+      ok: false,
+      error:
+        "Skill source SKILL.md has invalid or missing frontmatter; add a leading YAML frontmatter block with a non-empty description.",
+    };
+  }
+  const slug = resolveSkillInstallSlug({
+    frontmatterName: sourceSkill.name,
     fallbackLabel: params.fallbackLabel,
     slug: params.slug,
   });


### PR DESCRIPTION
Closes #122298

## What Problem This Solves

Local-directory and Git skill installs could report success even when normal discovery would later skip the installed root `SKILL.md` because its frontmatter was invalid, its description was empty, or the file exceeded the configured discovery byte limit.

## What Changed

- Validate only the source root `SKILL.md` before copying, using the existing boundary-safe frontmatter reader.
- Apply the active target's `skills.limits.maxSkillFileBytes` during that validation.
- Require a non-empty description while retaining the existing explicit-slug and frontmatter-name fallback behavior.
- Pass the resolved target configuration from the skills CLI into the source installer.
- Preserve current `main`'s `onInstallPolicyWarning` callback through both local and Git source-install paths.

The validator intentionally does not enumerate nested child skills. An invalid root cannot be replaced by a valid nested skill, so third-party Git sources do not turn this single-root preflight into an unbounded directory scan.

## Compatibility Rebase

The branch was rebased onto `82d2c992a25bc38336e1a5d49e1ef15d03798f19` and the conflict was resolved in favor of the current warning-acknowledgement contract. Both interactive and noninteractive callback-propagation cases remain covered by the current CLI tests. The two subsequent `main` commits through `cbcbb005fdcf4c8c38770b65957b7f8b6527a1e4` do not touch this PR's files.

## Evidence (exact head `1e7c98df6db83dcf65caa32d1a5fa088aa4951e3`)

- `node scripts/run-vitest.mjs src/skills/lifecycle/source-install.test.ts --testNamePattern="^(?!.*reports ).*$"` — 12 passed, 2 skipped. The two excluded pre-existing Git policy cases require restrictive parent-directory permissions unavailable in this Windows checkout; the full file otherwise failed only those two environment checks.
- `node scripts/run-vitest.mjs src/cli/skills-cli.commands.test.ts` — 141 passed, including interactive and noninteractive install-policy warning callback propagation.
- `node scripts/run-vitest.mjs src/skills/loading/skill-root-discovery.test.ts --testNamePattern="maxSkillFileBytes"` — 2 passed, 25 skipped.
- Targeted `oxfmt --check` — passed.
- Targeted type-aware `oxlint` — passed.
- `git diff upstream/main...HEAD --check` — passed.

AI-assisted: implemented and reviewed with Codex.
