### PR TITLE
fix(memory): publish dreaming artifacts atomically

### DIFF
--- a/extensions/memory-core/src/dreaming-markdown.test.ts
+++ b/extensions/memory-core/src/dreaming-markdown.test.ts
@@ -252,6 +252,69 @@ describe("dreaming markdown storage", () => {
     expect(dreamsContent).toContain("- Lowercase target.");
   });
 
+  it.each([
+    {
+      label: "daily inline phase",
+      relativePath: path.join("memory", "2026-04-05.md"),
+      run: async (workspaceDir: string) =>
+        await writeDailyDreamingPhaseBlock({
+          workspaceDir,
+          phase: "light",
+          bodyLines: ["- Candidate: replacement"],
+          nowMs,
+          timezone,
+          storage: { mode: "inline", separateReports: false },
+        }),
+    },
+    {
+      label: "separate light report",
+      relativePath: path.join("memory", "dreaming", "light", "2026-04-05.md"),
+      run: async (workspaceDir: string) =>
+        await writeDailyDreamingPhaseBlock({
+          workspaceDir,
+          phase: "light",
+          bodyLines: ["- Candidate: replacement"],
+          nowMs,
+          timezone,
+          storage: { mode: "separate", separateReports: false },
+        }),
+    },
+    {
+      label: "separate deep report",
+      relativePath: path.join("memory", "dreaming", "deep", "2026-04-05.md"),
+      run: async (workspaceDir: string) =>
+        await writeDeepDreamingReport({
+          workspaceDir,
+          bodyLines: ["- Promoted: replacement"],
+          nowMs,
+          timezone,
+          storage: { mode: "separate", separateReports: false },
+        }),
+    },
+  ])("keeps an existing $label when replacement fails", async ({ relativePath, run }) => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-markdown-atomic-");
+    const targetPath = path.join(workspaceDir, relativePath);
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+    await fs.writeFile(targetPath, "# Previous dreaming artifact\n", "utf-8");
+    const priorBytes = await fs.readFile(targetPath);
+    const realRename = fs.rename;
+    vi.spyOn(fs, "rename").mockImplementation(async (source, destination) => {
+      if (
+        typeof destination === "string" &&
+        path.resolve(destination) === path.resolve(targetPath)
+      ) {
+        throw Object.assign(new Error("replace failed"), { code: "ENOSPC" });
+      }
+      await realRename(source, destination);
+    });
+
+    await expect(run(workspaceDir)).rejects.toThrow("replace failed");
+    await expect(fs.readFile(targetPath)).resolves.toEqual(priorBytes);
+    await expect(fs.readdir(path.dirname(targetPath))).resolves.toEqual([
+      path.basename(targetPath),
+    ]);
+  });
+
   it("refuses to overwrite a symlinked DREAMS.md for deep summaries", async () => {
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-markdown-");
     const targetPath = path.join(workspaceDir, "outside.txt");

--- a/extensions/memory-core/src/dreaming-markdown.ts
+++ b/extensions/memory-core/src/dreaming-markdown.ts
@@ -11,6 +11,7 @@ import {
   replaceManagedMarkdownBlock,
   withTrailingNewline,
 } from "openclaw/plugin-sdk/memory-host-markdown";
+import { replaceFileAtomic } from "openclaw/plugin-sdk/security-runtime";
 import { updateDeepDreamsFile } from "./dreaming-dreams-file.js";
 import { resolveMemoryCoreNowMs, resolveMemoryCoreTimestamp } from "./time.js";
 
@@ -58,6 +59,23 @@ function shouldWriteSeparate(storage: MemoryDreamingStorageConfig): boolean {
   return storage.mode === "separate" || storage.mode === "both" || storage.separateReports;
 }
 
+async function replaceDreamingMarkdownFile(filePath: string, content: string): Promise<void> {
+  const directoryPath = path.dirname(filePath);
+  await fs.mkdir(directoryPath, { recursive: true });
+  const dirMode = (await fs.stat(directoryPath)).mode & 0o7777;
+  await replaceFileAtomic({
+    filePath,
+    content,
+    dirMode,
+    mode: 0o600,
+    preserveExistingMode: true,
+    tempPrefix: `${path.basename(filePath)}.dreaming`,
+    syncTempFile: true,
+    syncParentDir: true,
+    throwOnCleanupError: true,
+  });
+}
+
 export async function writeDailyDreamingPhaseBlock(params: {
   workspaceDir: string;
   phase: Exclude<MemoryDreamingPhaseName, "deep">;
@@ -88,7 +106,7 @@ export async function writeDailyDreamingPhaseBlock(params: {
       endMarker: markers.end,
       body,
     });
-    await fs.writeFile(inlinePath, withTrailingNewline(updated), "utf-8");
+    await replaceDreamingMarkdownFile(inlinePath, withTrailingNewline(updated));
   }
 
   if (shouldWriteSeparate(params.storage)) {
@@ -98,14 +116,13 @@ export async function writeDailyDreamingPhaseBlock(params: {
       nowMs,
       params.timezone,
     );
-    await fs.mkdir(path.dirname(reportPath), { recursive: true });
     const report = [
       `# ${params.phase === "light" ? "Light Sleep" : "REM Sleep"}`,
       "",
       body,
       "",
     ].join("\n");
-    await fs.writeFile(reportPath, report, "utf-8");
+    await replaceDreamingMarkdownFile(reportPath, report);
   }
 
   await appendMemoryHostEvent(params.workspaceDir, {
@@ -141,8 +158,7 @@ export async function writeDeepDreamingReport(params: {
   let reportPath: string | undefined;
   if (shouldWriteSeparate(params.storage)) {
     reportPath = resolveSeparateReportPath(params.workspaceDir, "deep", nowMs, params.timezone);
-    await fs.mkdir(path.dirname(reportPath), { recursive: true });
-    await fs.writeFile(reportPath, `# Deep Sleep\n\n${body}\n`, "utf-8");
+    await replaceDreamingMarkdownFile(reportPath, `# Deep Sleep\n\n${body}\n`);
   }
   await appendMemoryHostEvent(params.workspaceDir, {
     type: "memory.dream.completed",


### PR DESCRIPTION
## What Problem This Solves

Closes #122342.

Memory Core wrote daily inline dreaming Markdown and standalone light/REM/deep reports directly to their final paths. Re-running a phase for the same day therefore truncated the prior artifact before replacement bytes were complete; a filesystem failure or interruption could destroy the previous valid memory file and still leave partial bytes visible.

## Why This Change Was Made

All three final writes now share one Memory Core helper backed by the existing Plugin SDK `replaceFileAtomic` contract already used by the same plugin for `DREAMS.md` and `MEMORY.md`.

The helper:

- preserves existing file and directory modes;
- creates new memory artifacts with mode `0600`;
- stages beside the target and serializes publication per path;
- syncs the staged file and parent directory;
- surfaces cleanup failures instead of hiding them.

Paths, rendered Markdown, storage-mode behavior, and completion-event ordering are unchanged. No dependency, SDK surface, configuration, schema, or compatibility path was added.

## User Impact

A failed same-day dreaming replacement no longer corrupts the previous daily or standalone report. The error propagates before the phase is recorded as completed, and temporary staging files are removed.

## Evidence

- New table-driven owner-boundary regressions cover:
  - daily inline light/REM storage;
  - standalone light/REM report storage;
  - standalone deep report storage while allowing the independent `DREAMS.md` update to complete.
- Each regression targets the exact final-path rename, seeds previous bytes, and verifies failure propagation, byte-identical preservation, and no staging residue.
- All three cases failed against current direct writes for the intended reason—the atomic rename was never reached and the operation reported success—then passed after the repair.
- `node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-markdown.test.ts` — 12 passed.
- `node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-markdown.test.ts extensions/memory-core/src/dreaming-narrative.test.ts extensions/memory-core/src/memory-events.test.ts` — 3 files, 50 tests passed.
- `pnpm tsgo:extensions && pnpm tsgo:extensions:test` — passed.
- Targeted extension Oxlint, formatting, and `git diff --check` — passed.
- Mandatory Codex autoreview and TruffleHog — clean, no accepted/actionable findings.
- Exact-head CI parent https://github.com/openclaw/openclaw/actions/runs/31547257963 completed successfully for `eb432c3cd85c66101730773aa61e126cabe2e1ed`.
- Native review artifacts validated `READY FOR /prepare-pr` with zero findings, and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 122343` completed with hosted gates passed.

Production LOC: +21/-5 (net +16). Tests: +63/-0 (net +63). The production growth centralizes the full existing Memory Core durability contract—mode preservation, private creation, fsync, parent sync, serialization, and cleanup—for three call sites that previously had no failure-safe publication owner.
