### PR TITLE
fix(mcp): reject mixed command and URL server configs

### DIFF
--- a/src/agents/mcp-transport-config.test.ts
+++ b/src/agents/mcp-transport-config.test.ts
@@ -11,10 +11,11 @@ describe("resolveMcpTransportConfig", () => {
     vi.mocked(logWarn).mockClear();
   });
 
-  it("resolves stdio config with connection timeout", () => {
+  it("resolves stdio config when the URL is blank", () => {
     const resolved = resolveMcpTransportConfig("probe", {
       command: "node",
       args: ["./server.mjs"],
+      url: " \t ",
       connectionTimeoutMs: 12_345,
     });
 
@@ -30,6 +31,19 @@ describe("resolveMcpTransportConfig", () => {
       requestTimeoutMs: 60_000,
       supportsParallelToolCalls: false,
     });
+  });
+
+  it("rejects configs that mix command and URL transports", () => {
+    const resolved = resolveMcpTransportConfig("probe", {
+      command: "node",
+      url: "https://mcp.example.com/http",
+      transport: "streamable-http",
+    });
+
+    expect(resolved).toBeNull();
+    expect(logWarn).toHaveBeenCalledWith(
+      'bundle-mcp: skipped server "probe" because "command" and "url" cannot both be non-empty; remove "url" for stdio or remove "command" for an HTTP transport.',
+    );
   });
 
   it("resolves canonical timeouts and parallel capability", () => {

--- a/src/agents/mcp-transport-config.test.ts
+++ b/src/agents/mcp-transport-config.test.ts
@@ -46,6 +46,17 @@ describe("resolveMcpTransportConfig", () => {
     );
   });
 
+  it("sanitizes config-controlled names in mixed-transport warnings", () => {
+    resolveMcpTransportConfig("probe\nWARN forged\u001b[31m", {
+      command: "node",
+      url: "https://mcp.example.com/http",
+    });
+
+    expect(logWarn).toHaveBeenCalledWith(
+      'bundle-mcp: skipped server "probeWARN forged" because "command" and "url" cannot both be non-empty; remove "url" for stdio or remove "command" for an HTTP transport.',
+    );
+  });
+
   it("resolves canonical timeouts and parallel capability", () => {
     const resolved = resolveMcpTransportConfig("probe", {
       command: "node",

--- a/src/agents/mcp-transport-config.ts
+++ b/src/agents/mcp-transport-config.ts
@@ -231,7 +231,7 @@ export function resolveMcpTransportConfig(
   if (getStringField(rawServer, ["command"]) && getStringField(rawServer, ["url"])) {
     if (logWarnings) {
       logWarn(
-        `bundle-mcp: skipped server "${serverName}" because "command" and "url" cannot both be non-empty; remove "url" for stdio or remove "command" for an HTTP transport.`,
+        `bundle-mcp: skipped server "${sanitizeForLog(serverName)}" because "command" and "url" cannot both be non-empty; remove "url" for stdio or remove "command" for an HTTP transport.`,
       );
     }
     return null;

--- a/src/agents/mcp-transport-config.ts
+++ b/src/agents/mcp-transport-config.ts
@@ -228,6 +228,14 @@ export function resolveMcpTransportConfig(
   const requestedTransport = getRequestedTransport(rawServer);
   const requestedTransportAlias = requestedTransport ? "" : getRequestedTransportAlias(rawServer);
   const effectiveTransport = requestedTransport || requestedTransportAlias;
+  if (getStringField(rawServer, ["command"]) && getStringField(rawServer, ["url"])) {
+    if (logWarnings) {
+      logWarn(
+        `bundle-mcp: skipped server "${serverName}" because "command" and "url" cannot both be non-empty; remove "url" for stdio or remove "command" for an HTTP transport.`,
+      );
+    }
+    return null;
+  }
   const stdioLaunch = resolveStdioMcpServerLaunchConfig(
     rawServer,
     logWarnings
@@ -239,8 +247,6 @@ export function resolveMcpTransportConfig(
       : undefined,
   );
   if (stdioLaunch.ok) {
-    // A command-bearing server is always treated as stdio even when HTTP-ish
-    // aliases are present, matching existing MCP config precedence.
     return {
       kind: "stdio",
       transportType: "stdio",

--- a/src/cli/mcp-cli.mixed-transport.test.ts
+++ b/src/cli/mcp-cli.mixed-transport.test.ts
@@ -1,0 +1,45 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withTempHome } from "../config/home-env.test-harness.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  cleanupMcpCliTestState,
+  createWorkspace,
+  lastErrorLine,
+  resetMcpCliTestState,
+  runMcpCommand,
+} from "./mcp-cli.test-harness.js";
+
+describe("mcp cli mixed transports", () => {
+  beforeEach(() => {
+    resetMcpCliTestState();
+  });
+
+  afterEach(async () => {
+    await cleanupMcpCliTestState();
+  });
+
+  it("rejects mixed command and URL transports before writing configuration", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async (home) => {
+      const workspaceDir = await createWorkspace();
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+
+      try {
+        await expect(
+          runMcpCommand([
+            "mcp",
+            "set",
+            "mixed",
+            '{"command":"node","url":"https://mcp.example.com/mcp"}',
+          ]),
+        ).rejects.toThrow("__exit__:1");
+        expect(lastErrorLine()).toContain('cannot define both a non-empty "command" and "url"');
+        await expect(fs.readFile(configPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+      } finally {
+        closeOpenClawStateDatabaseForTest();
+      }
+    });
+  });
+});

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -300,6 +300,91 @@ describe("legacy MCP server config migrate", () => {
     ]);
   });
 
+  it("preserves historical stdio behavior for mixed root and node-host transports", () => {
+    const raw = {
+      mcp: {
+        servers: {
+          mixed: {
+            command: "node",
+            args: ["server.mjs"],
+            env: { MCP_MODE: "local" },
+            cwd: "/srv/mcp",
+            url: "https://mcp.example.com/mcp",
+            transport: "streamable-http",
+            headers: { Authorization: "Bearer test" },
+            auth: "oauth",
+            oauth: { scope: "docs.read" },
+            sslVerify: false,
+            clientCert: "cert.pem",
+            clientKey: "key.pem",
+            requestTimeoutMs: 12_000,
+            toolFilter: { include: ["search"] },
+          },
+          explicitStdio: {
+            command: "stdio-mcp",
+            url: "https://stdio.example.com/mcp",
+            transport: "stdio",
+          },
+        },
+      },
+      nodeHost: {
+        mcp: {
+          servers: {
+            mixed: {
+              command: "node-host-mcp",
+              url: "https://node.example.com/mcp",
+              type: "streamable-http",
+              headers: { "X-Test": "value" },
+              connectionTimeoutMs: 3_000,
+            },
+          },
+        },
+      },
+    };
+
+    expect(findLegacyConfigIssues(raw)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "mcp.servers",
+          message: expect.stringContaining('both non-empty "command" and "url"'),
+        }),
+        expect.objectContaining({
+          path: "nodeHost.mcp.servers",
+          message: expect.stringContaining('both non-empty "command" and "url"'),
+        }),
+        expect.objectContaining({
+          path: "nodeHost.mcp.servers",
+          message: expect.stringContaining("CLI-native type aliases"),
+        }),
+      ]),
+    );
+
+    const res = migrateLegacyConfigForTest(raw);
+    expect(res.config?.mcp?.servers?.mixed).toEqual({
+      command: "node",
+      args: ["server.mjs"],
+      env: { MCP_MODE: "local" },
+      cwd: "/srv/mcp",
+      requestTimeoutMs: 12_000,
+      toolFilter: { include: ["search"] },
+    });
+    expect(res.config?.mcp?.servers?.explicitStdio).toEqual({
+      command: "stdio-mcp",
+      transport: "stdio",
+    });
+    expect(res.config?.nodeHost?.mcp?.servers?.mixed).toEqual({
+      command: "node-host-mcp",
+      connectionTimeoutMs: 3_000,
+    });
+    expect(res.changes).toEqual([
+      'Moved nodeHost.mcp.servers.mixed.type "streamable-http" → transport "streamable-http".',
+      "Preserved historical stdio behavior for nodeHost.mcp.servers.mixed by removing HTTP-only fields: url, transport, headers.",
+      "Preserved historical stdio behavior for mcp.servers.mixed by removing HTTP-only fields: url, transport, headers, auth, oauth, sslVerify, clientCert, clientKey.",
+      "Preserved historical stdio behavior for mcp.servers.explicitStdio by removing HTTP-only fields: url.",
+    ]);
+    expect(migrateLegacyConfigForTest(res.config)).toEqual({ config: null, changes: [] });
+  });
+
   it("moves MCP workingDirectory aliases to cwd with canonical values winning", () => {
     const raw = {
       mcp: {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.mcp.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.mcp.ts
@@ -11,14 +11,16 @@ import {
 } from "../../../config/mcp-config-normalize.js";
 import { isRecord } from "./legacy-config-record-shared.js";
 
-const MCP_SERVER_TYPE_RULE: LegacyConfigRule = {
-  path: ["mcp", "servers"],
-  message:
-    'mcp.servers entries use OpenClaw transport names; CLI-native type aliases are legacy here. Run "openclaw doctor --fix".',
+const MCP_SERVER_TYPE_RULES: LegacyConfigRule[] = [
+  ["mcp", "servers"],
+  ["nodeHost", "mcp", "servers"],
+].map((path) => ({
+  path,
+  message: `${path.join(".")} entries use OpenClaw transport names; CLI-native type aliases are legacy here. Run "openclaw doctor --fix".`,
   match: (value) =>
     isRecord(value) &&
     Object.values(value).some((server) => isRecord(server) && isKnownCliMcpTypeAlias(server.type)),
-};
+}));
 
 const MCP_SERVER_DISABLED_RULES: LegacyConfigRule[] = [
   ["mcp", "servers"],
@@ -70,6 +72,72 @@ const MCP_SERVER_ALIASES_RULES: LegacyConfigRule[] = [
     Object.values(value).some((server) => isRecord(server) && hasMcpServerLegacyAliases(server)),
 }));
 
+function hasMixedMcpServerTransports(server: Record<string, unknown>): boolean {
+  return (
+    typeof server.command === "string" &&
+    server.command.trim().length > 0 &&
+    typeof server.url === "string" &&
+    server.url.trim().length > 0
+  );
+}
+
+const MCP_SERVER_MIXED_TRANSPORT_RULES: LegacyConfigRule[] = [
+  ["mcp", "servers"],
+  ["nodeHost", "mcp", "servers"],
+].map((path) => ({
+  path,
+  message:
+    `${path.join(".")} entries cannot define both non-empty "command" and "url" fields. ` +
+    'Run "openclaw doctor --fix" to preserve their historical stdio behavior.',
+  match: (value) =>
+    isRecord(value) &&
+    Object.values(value).some((server) => isRecord(server) && hasMixedMcpServerTransports(server)),
+}));
+
+const MCP_SERVER_HTTP_ONLY_FIELDS = [
+  "url",
+  "transport",
+  "headers",
+  "auth",
+  "oauth",
+  "sslVerify",
+  "clientCert",
+  "clientKey",
+] as const;
+
+function migrateMixedMcpServerTransports(
+  servers: unknown,
+  pathPrefix: string,
+  changes: string[],
+): void {
+  if (!isRecord(servers)) {
+    return;
+  }
+  for (const [serverName, server] of Object.entries(servers)) {
+    if (!isRecord(server) || !hasMixedMcpServerTransports(server)) {
+      continue;
+    }
+    const removed: string[] = [];
+    for (const field of MCP_SERVER_HTTP_ONLY_FIELDS) {
+      if (
+        field === "transport" &&
+        server.transport !== "sse" &&
+        server.transport !== "streamable-http"
+      ) {
+        continue;
+      }
+      if (!Object.hasOwn(server, field)) {
+        continue;
+      }
+      delete server[field];
+      removed.push(field);
+    }
+    changes.push(
+      `Preserved historical stdio behavior for ${pathPrefix}.${serverName} by removing HTTP-only fields: ${removed.join(", ")}.`,
+    );
+  }
+}
+
 function migrateMcpServerAliases(servers: unknown, pathPrefix: string, changes: string[]): void {
   if (!isRecord(servers)) {
     return;
@@ -78,7 +146,9 @@ function migrateMcpServerAliases(servers: unknown, pathPrefix: string, changes: 
     if (!isRecord(value)) {
       continue;
     }
-    if (!hasMcpServerLegacyAliases(value)) {
+    const hasLegacyAliases = hasMcpServerLegacyAliases(value);
+    const hasTypeAlias = isKnownCliMcpTypeAlias(value.type);
+    if (!hasLegacyAliases && !hasTypeAlias) {
       continue;
     }
     const normalized = canonicalizeConfiguredMcpServer(value);
@@ -86,7 +156,21 @@ function migrateMcpServerAliases(servers: unknown, pathPrefix: string, changes: 
       continue;
     }
     servers[serverName] = normalized;
-    changes.push(`Canonicalized legacy aliases in ${pathPrefix}.${serverName}.`);
+    if (hasLegacyAliases) {
+      changes.push(`Canonicalized legacy aliases in ${pathPrefix}.${serverName}.`);
+      continue;
+    }
+    const rawType = typeof value.type === "string" ? value.type : "";
+    const alias = resolveOpenClawMcpTransportAlias(value.type);
+    if (typeof value.transport !== "string" && alias) {
+      changes.push(`Moved ${pathPrefix}.${serverName}.type "${rawType}" → transport "${alias}".`);
+    } else if (typeof value.transport === "string") {
+      changes.push(
+        `Removed ${pathPrefix}.${serverName}.type (transport "${value.transport}" already set).`,
+      );
+    } else {
+      changes.push(`Removed ${pathPrefix}.${serverName}.type "${rawType}".`);
+    }
   }
 }
 
@@ -168,9 +252,10 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_MCP: LegacyConfigMigrationSpec[] =
     describe: "Normalize legacy MCP server config",
     legacyRules: [
       ...MCP_SERVER_DISABLED_RULES,
-      MCP_SERVER_TYPE_RULE,
+      ...MCP_SERVER_TYPE_RULES,
       ...MCP_SERVER_TIMEOUT_ALIASES_RULES,
       ...MCP_SERVER_ALIASES_RULES,
+      ...MCP_SERVER_MIXED_TRANSPORT_RULES,
     ],
     apply: (raw, changes) => {
       const mcp = isRecord(raw.mcp) ? raw.mcp : undefined;
@@ -183,30 +268,13 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_MCP: LegacyConfigMigrationSpec[] =
       migrateMcpServerDisabledFlags(nodeHostMcp?.servers, "nodeHost.mcp.servers", changes);
       migrateMcpServerTimeoutAliases(nodeHostMcp?.servers, "nodeHost.mcp.servers", changes);
       migrateMcpServerAliases(nodeHostMcp?.servers, "nodeHost.mcp.servers", changes);
+      migrateMixedMcpServerTransports(nodeHostMcp?.servers, "nodeHost.mcp.servers", changes);
 
       const servers = isRecord(mcp?.servers) ? mcp?.servers : undefined;
       if (!servers) {
         return;
       }
-
-      for (const [serverName, rawServer] of Object.entries(servers)) {
-        if (!isRecord(rawServer) || !isKnownCliMcpTypeAlias(rawServer.type)) {
-          continue;
-        }
-        const rawType = typeof rawServer.type === "string" ? rawServer.type : "";
-        const alias = resolveOpenClawMcpTransportAlias(rawServer.type);
-        if (typeof rawServer.transport !== "string" && alias) {
-          rawServer.transport = alias;
-          changes.push(`Moved mcp.servers.${serverName}.type "${rawType}" → transport "${alias}".`);
-        } else if (typeof rawServer.transport === "string") {
-          changes.push(
-            `Removed mcp.servers.${serverName}.type (transport "${rawServer.transport}" already set).`,
-          );
-        } else {
-          changes.push(`Removed mcp.servers.${serverName}.type "${rawType}".`);
-        }
-        delete rawServer.type;
-      }
+      migrateMixedMcpServerTransports(servers, "mcp.servers", changes);
     },
   }),
 ];

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -248,6 +248,45 @@ describe("config schema", () => {
     }
   });
 
+  it("rejects mixed command and URL transports for root and node-host MCP servers", () => {
+    for (const { config, path } of [
+      {
+        config: {
+          mcp: {
+            servers: {
+              mixed: { command: "node", url: "https://mcp.example.com/mcp" },
+            },
+          },
+        },
+        path: ["mcp", "servers", "mixed", "url"],
+      },
+      {
+        config: {
+          nodeHost: {
+            mcp: {
+              servers: {
+                mixed: { command: "node", url: "https://mcp.example.com/mcp" },
+              },
+            },
+          },
+        },
+        path: ["nodeHost", "mcp", "servers", "mixed", "url"],
+      },
+    ]) {
+      const result = OpenClawSchema.safeParse(config);
+      expect(result.success).toBe(false);
+      if (result.success) {
+        throw new Error("Expected mixed MCP transports to fail validation");
+      }
+      expect(result.error.issues).toContainEqual(
+        expect.objectContaining({
+          message: 'MCP server cannot define both a non-empty "command" and "url"',
+          path,
+        }),
+      );
+    }
+  });
+
   it("rejects blank or whitespace-padded node-host MCP server names", () => {
     for (const serverName of ["", "  ", " docs "]) {
       expect(() =>

--- a/src/config/zod-schema.root-support.ts
+++ b/src/config/zod-schema.root-support.ts
@@ -354,6 +354,18 @@ const McpServerSchema = z
         path: ["disabled"],
       });
     }
+    if (
+      typeof data.command === "string" &&
+      data.command.trim().length > 0 &&
+      typeof data.url === "string" &&
+      data.url.trim().length > 0
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'MCP server cannot define both a non-empty "command" and "url"',
+        path: ["url"],
+      });
+    }
     if (data.oauth?.identity === "per-requester") {
       if (data.auth !== "oauth") {
         ctx.addIssue({


### PR DESCRIPTION
Related #72111

## What Problem This Solves

Fixes an MCP configuration ambiguity exposed by #72111: a server record containing both a command and an HTTP URL historically ran as stdio while silently ignoring its HTTP fields. Rejecting that shape only at runtime would disable already-shipped configurations without giving operators a safe upgrade path.

## Why This Change Was Made

Canonical root and node-host MCP configuration now rejects non-empty `command` + `url` records before they can be persisted. `openclaw doctor --fix` migrates existing mixed records to their historically effective stdio form by removing the URL and HTTP-only transport, header, OAuth, and TLS fields while preserving stdio launch settings and shared timeouts/tool filters. The transport resolver retains a fail-closed guard for raw plugin or bundle records that bypass the core schema.

Known legacy MCP `type` aliases are now detected in both root and node-host scopes and normalized through the same shared `canonicalizeConfiguredMcpServer` path before mixed-transport cleanup. This replaces the previous root-only conversion loop. A node-host record such as `{ command, url, type: "streamable-http" }` therefore becomes canonical first, then migrates to stdio without retaining `type`, `url`, or HTTP transport fields; a second Doctor pass is a no-op.

Command-only stdio, URL-only HTTP, and stdio records with a blank or whitespace-only URL keep their existing behavior. This is a current-main implementation informed by the focused proposal in #72515 from @Bojun-Vvibe; it is linked as related work rather than claiming that mixed-field precedence was the only cause of the reporter's historical OpenSpace incident.

## User Impact

New mixed configurations fail immediately with a precise validation error and are not written. Existing mixed root and node-host records receive an explicit Doctor finding and can be migrated idempotently without changing the stdio behavior they had in prior releases. Raw/plugin records are skipped with an actionable warning instead of silently choosing one transport.

## Review finding disposition

- Resolved the P2 node-host alias migration gap by extending the existing legacy-type rule to both MCP scopes and routing both through the shared canonicalizer.
- Removed the root-only 20-line type conversion loop instead of adding another migration path.
- The regression now uses node-host `type: "streamable-http"`, checks the alias finding, verifies the canonicalization and HTTP-field cleanup messages, and proves a second pass produces no changes.
- Sanitized the mixed-transport warning's configuration-controlled server name with the existing `sanitizeForLog()` helper and added a newline/ANSI injection regression.
- Moved the new CLI no-write regression into a focused 45-line test file because current main's existing `mcp-cli.test.ts` is already near the enforced max-lines budget.

## Evidence

Exact head: `96d53ffe55bcfe1a4361adefc72d5fa82c6f8860`

### Real persisted-config upgrade proof

This was a non-mocked exact-head run of the built OpenClaw CLI against an actual `openclaw.json` under an isolated `OPENCLAW_STATE_DIR`/`OPENCLAW_CONFIG_PATH`. It did not read or modify the operator's normal OpenClaw state. The two root commands pointed to a real local MCP server that initialized over stdio and exposed a synthetic `proof_echo` tool.

Persisted input (paths and synthetic values redacted):

```json
{
  "mcp": {
    "servers": {
      "mixed-root": {
        "command": "node",
        "args": ["<isolated>/mcp-proof-server.mjs"],
        "env": { "MCP_PROOF_MODE": "isolated" },
        "url": "https://root.example.invalid/mcp",
        "transport": "streamable-http",
        "headers": { "X-Proof": "synthetic" },
        "auth": "oauth",
        "oauth": { "scope": "proof.read" },
        "requestTimeoutMs": 12000,
        "toolFilter": { "include": ["proof_echo"] }
      },
      "explicit-stdio": {
        "command": "node",
        "args": ["<isolated>/mcp-proof-server.mjs"],
        "url": "https://stdio.example.invalid/mcp",
        "transport": "stdio"
      }
    }
  },
  "nodeHost": {
    "mcp": {
      "servers": {
        "mixed-node": {
          "command": "node-host-proof-server",
          "url": "https://node.example.invalid/mcp",
          "type": "streamable-http",
          "headers": { "X-Proof": "synthetic" },
          "connectionTimeoutMs": 3000
        }
      }
    }
  }
}
```

The real repair run exited 0 and reported:

```text
$ openclaw doctor --fix --yes --non-interactive --no-workspace-suggestions
Migrated legacy config keys in the active openclaw.json:
- Moved nodeHost.mcp.servers.mixed-node.type "streamable-http" -> transport "streamable-http".
- Preserved historical stdio behavior for nodeHost.mcp.servers.mixed-node by removing HTTP-only fields: url, transport, headers.
- Preserved historical stdio behavior for mcp.servers.mixed-root by removing HTTP-only fields: url, transport, headers, auth, oauth.
- Preserved historical stdio behavior for mcp.servers.explicit-stdio by removing HTTP-only fields: url.
Updated config: <isolated-state>/openclaw.json
Doctor complete.
```

The repaired file was then read from disk and validated by the real CLI:

```text
$ openclaw config validate
Config valid: <isolated-state>/openclaw.json
```

```json
{
  "mcp": {
    "servers": {
      "mixed-root": {
        "command": "node",
        "args": ["<isolated>/mcp-proof-server.mjs"],
        "env": { "MCP_PROOF_MODE": "isolated" },
        "requestTimeoutMs": 12000,
        "toolFilter": { "include": ["proof_echo"] }
      },
      "explicit-stdio": {
        "command": "node",
        "args": ["<isolated>/mcp-proof-server.mjs"],
        "transport": "stdio"
      }
    }
  },
  "nodeHost": {
    "mcp": {
      "servers": {
        "mixed-node": {
          "command": "node-host-proof-server",
          "connectionTimeoutMs": 3000
        }
      }
    }
  }
}
```

Doctor successfully inspected both migrated root stdio servers without an MCP startup or tool-schema warning. A second identical Doctor run exited 0 with no migration notice, no `Doctor changes`, and no `Updated config`, confirming the persisted migration is idempotent.

- Exact-head full `pnpm build` passed (all runtime, plugin-SDK, 149 public plugin exports, and Control UI phases; 14m 0.1s).

Rebased onto `main` at `8ebf4b9b8e78f74abdcdcd346840b08e86b75a35`.

- Exact-head focused acceptance suites passed across all four ownership boundaries:

  ```text
  src/commands/doctor/shared/legacy-config-migrate.test.ts  183 passed
  src/config/schema.test.ts                                  77 passed
  src/agents/mcp-transport-config.test.ts                    15 passed
  src/cli/mcp-cli.mixed-transport.test.ts                     1 passed
  Total                                                     276 passed
  ```

- The Doctor regression covers both config roots, legacy node-host `type`, explicit canonical transport, every removed HTTP-only field, preservation of stdio fields and shared timeouts/tool filters, and a second no-op migration pass.
- Exact-head formatting, targeted type-aware oxlint, and `git diff --check` passed for the reviewer-requested correction.
- The previous commit-mode AutoReview was clean with no accepted/actionable findings (0.98 confidence). It was not repeated after the focused reviewer-requested correction; exact-head behavior tests and a fresh ClawSweeper review are used for closeout.

Proof limitation: I did not rerun the reporter's third-party OpenSpace MCP server. The original incident may also have involved the MCP SDK/Accept-header behavior the reporter later discussed; this PR proves and repairs the independent mixed-transport lifecycle in OpenClaw.

AI-assisted: prepared with Codex; I reviewed the seven-file patch and understand the schema, migration, Doctor, CLI, and resolver behavior.