### PR TITLE
fix(channels): surface partial status failures

### DIFF
--- a/src/commands/channels.surfaces-signal-runtime-errors-channels-status-output.test.ts
+++ b/src/commands/channels.surfaces-signal-runtime-errors-channels-status-output.test.ts
@@ -111,6 +111,18 @@ describe("channels command", () => {
     expect(lines.join("\n")).toMatch(/eventLoopDelayMaxMs=62000/);
   });
 
+  it("surfaces top-level partial status warnings", () => {
+    const lines = formatGatewayChannelsStatusLines({
+      partial: true,
+      warnings: ["whatsapp:default status failed: snapshot failed"],
+      channelLabels: {},
+      channelAccounts: {},
+    });
+
+    expect(lines.join("\n")).toMatch(/Channel status is partial/);
+    expect(lines.join("\n")).toContain("whatsapp:default status failed: snapshot failed");
+  });
+
   it("surfaces transport liveness timestamps in channels status output", () => {
     const lines = formatGatewayChannelsStatusLines({
       channelLabels: {

--- a/src/commands/channels/status.runtime.ts
+++ b/src/commands/channels/status.runtime.ts
@@ -76,6 +76,20 @@ export function formatGatewayChannelsStatusLines(payload: Record<string, unknown
   if (eventLoopLine) {
     lines.push(theme.warn(`Gateway event loop degraded ${eventLoopLine}`));
   }
+  const statusWarnings = Array.isArray(payload.warnings)
+    ? payload.warnings
+        .filter(
+          (warning): warning is string => typeof warning === "string" && warning.trim().length > 0,
+        )
+        .slice(0, 50)
+    : [];
+  if (payload.partial === true || statusWarnings.length > 0) {
+    lines.push(theme.warn("Channel status is partial:"));
+    for (const warning of statusWarnings) {
+      lines.push(`- ${warning.slice(0, 500)}`);
+    }
+    lines.push("");
+  }
   const channelLabels =
     payload.channelLabels && typeof payload.channelLabels === "object"
       ? (payload.channelLabels as Record<string, unknown>)

--- a/src/gateway/server-methods/channels.status.test.ts
+++ b/src/gateway/server-methods/channels.status.test.ts
@@ -357,6 +357,40 @@ describe("channelsHandlers channels.status", () => {
     expect(String(accountProbe.error)).toContain("probe failed");
   });
 
+  it("marks account snapshot failures partial", async () => {
+    mocks.resolveChannelAccountSnapshot.mockRejectedValue(new Error("snapshot failed"));
+
+    const payload = await runChannelsStatus({ probe: false, timeoutMs: 1000 });
+
+    expect(payload.partial).toBe(true);
+    expect(payload.warnings).toEqual(["whatsapp:default status failed: Error: snapshot failed"]);
+    const channels = requireGatewayRecord(payload.channels, "channels payload");
+    expect(channels.whatsapp).toEqual({ configured: false });
+  });
+
+  it("isolates a failed channel status task while a sibling succeeds", async () => {
+    const broken = createChannelPlugin({ id: "broken" });
+    broken.config.listAccountIds = () => {
+      throw new Error("channel failed");
+    };
+    configureAutoEnabledChannels([broken, createChannelPlugin({ id: "healthy" })]);
+    mocks.buildChannelUiCatalog.mockImplementation((plugins: Array<{ id: string }>) => ({
+      order: plugins.map((plugin) => plugin.id),
+      labels: {},
+      detailLabels: {},
+      systemImages: {},
+      entries: {},
+    }));
+
+    const payload = await runChannelsStatus({ probe: false, timeoutMs: 1000 });
+
+    expect(payload.partial).toBe(true);
+    expect(payload.warnings).toEqual(["broken channel status failed: Error: channel failed"]);
+    expect(requireGatewayRecord(payload.channels, "channels payload").healthy).toEqual({
+      configured: true,
+    });
+  });
+
   it("isolates a timed-out channel probe while another channel succeeds", async () => {
     vi.useFakeTimers();
     try {

--- a/src/gateway/server-methods/channels.ts
+++ b/src/gateway/server-methods/channels.ts
@@ -510,6 +510,10 @@ export const channelsHandlers: GatewayRequestHandlers = {
             await buildAccountSnapshot(channelId, plugin, accountId, defaultAccountId),
         ),
         limit: probe ? CHANNEL_STATUS_PROBE_CONCURRENCY : accountIds.length || 1,
+        onTaskError: (error, index) => {
+          const accountId = accountIds[index] ?? `account ${index + 1}`;
+          statusWarnings.push(`${channelId}:${accountId} status failed: ${formatForLog(error)}`);
+        },
       });
       const accounts: ChannelAccountSnapshot[] = [];
       for (const result of results) {
@@ -572,6 +576,10 @@ export const channelsHandlers: GatewayRequestHandlers = {
         return { pluginId: plugin.id, summary, accounts, defaultAccountId };
       }),
       limit: probe ? CHANNEL_STATUS_PROBE_CONCURRENCY : selectedPlugins.length || 1,
+      onTaskError: (error, index) => {
+        const channelId = statusPlugins[index]?.id ?? `channel ${index + 1}`;
+        statusWarnings.push(`${channelId} channel status failed: ${formatForLog(error)}`);
+      },
     });
     for (const result of channelResults) {
       if (result) {
@@ -582,7 +590,7 @@ export const channelsHandlers: GatewayRequestHandlers = {
     }
     if (statusWarnings.length > 0) {
       payload.partial = true;
-      payload.warnings = statusWarnings.slice(0, 50);
+      payload.warnings = statusWarnings.toSorted().slice(0, 50);
     }
 
     respond(true, payload, undefined);


### PR DESCRIPTION
## What Problem This Solves

Closes #122347.

`channels.status` silently discarded rejected account and channel status tasks. A failed account snapshot could disappear and leave a misleading unconfigured fallback, while a failed channel could vanish beside healthy siblings without `partial`, warnings, or logs. Separately, the human `openclaw channels status` formatter ignored the Gateway's existing top-level `partial`/`warnings` contract and could print only `Gateway reachable.`

## Why This Change Was Made

Both bounded status pools now use their existing `onTaskError` callbacks to append contextual account/channel warnings while continuing to retain successful sibling results. Before response, the shared warning list is sorted for deterministic output and capped at the existing 50-warning protocol bound.

The human formatter now renders a bounded partial-status section before account rows, showing at most 50 non-empty warnings and capping each displayed line at 500 characters. Existing JSON payload shape, protocol fields, account-derived issues, and successful status behavior remain unchanged.

No protocol, configuration, schema, persistence, plugin, or security-policy surface was added.

## User Impact

Channel status failures no longer masquerade as a complete healthy snapshot. Operators and the Control UI receive an intentional partial result with the exact failed account/channel context, healthy siblings remain visible, and the CLI displays the Gateway warning instead of silently discarding it.

## Evidence

- New Gateway regressions prove:
  - a rejected account snapshot marks the payload partial and records `channel:account` context;
  - a rejected channel status task is isolated while a healthy sibling remains present.
- New CLI regression proves a payload containing `partial: true` and top-level warnings renders the partial-status notice and warning text.
- All three regressions failed on current main for the intended silent-loss reason, then passed after the repair.
- `node scripts/run-vitest.mjs src/gateway/server-methods/channels.status.test.ts` — 15 passed.
- `node scripts/run-vitest.mjs src/commands/channels.surfaces-signal-runtime-errors-channels-status-output.test.ts` — 5 passed.
- `node scripts/run-vitest.mjs src/commands/channels.adds-non-default-telegram-account.test.ts src/commands/channels.surfaces-signal-runtime-errors-channels-status-output.test.ts` — 2 files, 26 tests passed.
- `pnpm tsgo:core && pnpm tsgo:core:test` — passed.
- Targeted core Oxlint, formatting, and `git diff --check` — passed.
- Mandatory Codex autoreview and TruffleHog — clean, no accepted/actionable findings.
- Exact-head CI parent https://github.com/openclaw/openclaw/actions/runs/31548950747 completed successfully for `e9d5c624ecad0a323224fcb01c397c52e10fd157`.
- Native review artifacts validated `READY FOR /prepare-pr` with zero findings, and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 122349` completed with hosted gates passed.

Production LOC: +23/-1 (net +22). Tests: +46/-0 (net +46). The production growth records two previously discarded task-error boundaries and renders the already-shipped warning contract; there is no existing lower layer that can infer the lost channel/account identity after those pools return.
