### PR TITLE
test(system-agent): avoid bundled policy load in setup fixture

### DIFF
--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -2644,21 +2644,21 @@ describe("activateSetupInference", () => {
     const runAuth = vi.fn(async () => ({
       profiles: [
         {
-          profileId: "ollama:default",
+          profileId: "local-test:default",
           credential: {
             type: "api_key" as const,
-            provider: "ollama",
-            key: "ollama-local",
+            provider: "local-test",
+            key: "local-test-key",
           },
         },
       ],
       configPatch: {
         models: {
           providers: {
-            ollama: {
-              baseUrl: "http://127.0.0.1:11434",
+            "local-test": {
+              baseUrl: "http://127.0.0.1:12345",
               api: "ollama" as const,
-              apiKey: "ollama-local",
+              apiKey: "local-test-key",
               models: [],
             },
           },
@@ -2666,19 +2666,19 @@ describe("activateSetupInference", () => {
       },
     }));
     const detect = vi.fn(async () => ({
-      modelRef: "ollama/qwen3.5:4b",
-      detail: "qwen3.5:4b at http://127.0.0.1:11434",
+      modelRef: "local-test/qwen-test",
+      detail: "qwen-test at http://127.0.0.1:12345",
     }));
     const prepare = vi.fn(async () => ({
       profiles: [],
-      defaultModel: "ollama/qwen3.5:4b",
+      defaultModel: "local-test/qwen-test",
       configPatch: {
         models: {
           providers: {
-            ollama: {
-              baseUrl: "http://127.0.0.1:11434",
+            "local-test": {
+              baseUrl: "http://127.0.0.1:12345",
               api: "ollama" as const,
-              apiKey: "ollama-local",
+              apiKey: "local-test-key",
               models: [],
             },
           },
@@ -2686,13 +2686,13 @@ describe("activateSetupInference", () => {
       },
     }));
     const provider: ProviderPlugin = {
-      id: "ollama",
-      label: "Ollama",
-      pluginId: "ollama",
+      id: "local-test",
+      label: "Local Test Provider",
+      pluginId: "local-test",
       auth: [
         {
           id: "local",
-          label: "Ollama",
+          label: "Local Test Provider",
           kind: "custom",
           run: runAuth,
           appGuidedSetup: { detect, prepare },
@@ -2701,14 +2701,14 @@ describe("activateSetupInference", () => {
     };
     const runEmbeddedAgent = vi.fn(
       async (params: SuccessfulRunParams & { authProfileId?: string }) =>
-        successfulRun("ollama", "qwen3.5:4b", params),
+        successfulRun("local-test", "qwen-test", params),
     );
     const configHarness = createConfigTransformHarness(initialConfig);
 
     try {
       const result = await activateSetupInference({
         kind: "provider-auth",
-        authChoice: "ollama",
+        authChoice: "local-test",
         workspace: "/tmp/openclaw-workspace",
         prompter: { note: vi.fn(async () => {}) } as never,
         deps: {
@@ -2717,11 +2717,11 @@ describe("activateSetupInference", () => {
           }),
           resolvePluginProviders: () => [provider],
           resolveManifestProviderAuthChoice: () => ({
-            pluginId: "ollama",
-            providerId: "ollama",
+            pluginId: "local-test",
+            providerId: "local-test",
             methodId: "local",
-            choiceId: "ollama",
-            choiceLabel: "Ollama",
+            choiceId: "local-test",
+            choiceLabel: "Local Test Provider",
             appGuidedDiscovery: true,
           }),
           runEmbeddedAgent: runEmbeddedAgent as never,
@@ -2729,16 +2729,16 @@ describe("activateSetupInference", () => {
         },
       });
 
-      expect(result).toMatchObject({ ok: true, modelRef: "ollama/qwen3.5:4b" });
+      expect(result).toMatchObject({ ok: true, modelRef: "local-test/qwen-test" });
       expect(runAuth).toHaveBeenCalledOnce();
       expect(detect).toHaveBeenCalledWith(
         expect.objectContaining({
           config: expect.objectContaining({
             models: {
               providers: {
-                ollama: expect.objectContaining({
-                  baseUrl: "http://127.0.0.1:11434",
-                  apiKey: "ollama-local",
+                "local-test": expect.objectContaining({
+                  baseUrl: "http://127.0.0.1:12345",
+                  apiKey: "local-test-key",
                 }),
               },
             },
@@ -2746,7 +2746,7 @@ describe("activateSetupInference", () => {
         }),
       );
       expect(prepare).toHaveBeenCalledWith(
-        expect.objectContaining({ modelRef: "ollama/qwen3.5:4b" }),
+        expect.objectContaining({ modelRef: "local-test/qwen-test" }),
       );
     } finally {
       await removeOAuthTestTempRoot(stateDir);


### PR DESCRIPTION
## What Problem This Solves

One mocked core setup-orchestration test used Ollama as its fixture identity. Applying its fake config patch therefore loaded and transpiled Ollama's real bundled provider-policy graph through Jiti. The test spent 36.82s and peaked at 2.17 GiB even though its auth, detect, prepare, inference, persistence, and registry boundaries were mocked.

## Why This Change Was Made

- replace the provider-specific Ollama fixture with a synthetic local provider
- preserve the core test's unique auth → config patch → detect → prepare → probe sequencing and assertions
- leave Ollama's real detect/prepare behavior with its stronger plugin-owned test
- avoid new jobs, workers, shards, mocks, production seams, or product code

## User Impact

No product/runtime behavior changes. The same orchestration contract remains covered without compiling an unrelated bundled plugin graph.

## Test-value audit

The core test uniquely owns provider-auth sequencing after an app-guided discovery choice, so it is retained rather than deleted. Ollama-specific detection, exact-model preparation, config patching, and no-pull behavior remain covered by `extensions/ollama/index.test.ts` (`discovers and prepares a loaded tool-capable model without pulling it`). Using Ollama in the core mocked test duplicated that ownership and coupled a generic orchestration proof to plugin implementation loading.

## Evidence

Identical focused test, same orb, one worker:

| Metric | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Test body | 36.82s | 0.82s | **97.8% faster** |
| Vitest duration | 57.87s | 7.36s | **87.3% faster** |
| Wall time | 87.31s | 36.56s | **58.1% faster** |
| Max RSS | 2.17 GiB | 1.18 GiB | **45.5% lower** |

- full `src/system-agent/setup-inference.test.ts`: 127/127 passed, 42.89s Vitest / 54.80s wall
- focused Ollama owner contract: 1/1 passed
- targeted oxfmt, Oxlint, and `git diff --check` passed
- TruffleHog scan passed; structured autoreview could not run because this orb has no Codex/Claude/Pi review executable
