### PR TITLE
perf(gateway): keep session titles request-driven

### DIFF
--- a/src/gateway/server-startup-handler-prewarm.test.ts
+++ b/src/gateway/server-startup-handler-prewarm.test.ts
@@ -98,7 +98,7 @@ describe("scheduleGatewayHandlerPrewarm", () => {
         opts: {
           agentId: "main",
           configuredAgentsOnly: true,
-          includeDerivedTitles: true,
+          includeDerivedTitles: false,
           includeGlobal: true,
           includeUnknown: true,
           limit: 60,

--- a/src/gateway/server-startup-handler-prewarm.ts
+++ b/src/gateway/server-startup-handler-prewarm.ts
@@ -38,7 +38,9 @@ async function prewarmGatewaySessionListData(cfg: OpenClawConfig, agentId: strin
     opts: {
       agentId,
       configuredAgentsOnly: true,
-      includeDerivedTitles: true,
+      // Transcript title probes can touch multi-gigabyte agent databases. Keep that optional
+      // decoration request-driven so an idle gateway does not spend minutes warming it.
+      includeDerivedTitles: false,
       includeGlobal: true,
       includeUnknown: true,
       limit: SIDEBAR_SESSION_LIST_LIMIT,


### PR DESCRIPTION
Summary:
- keep startup session prewarm on lightweight list data
- leave transcript-derived title decoration to explicit client requests
- prevent idle startup work from opening large transcript stores across every configured agent

Validation:
- pnpm exec vitest run src/gateway/server-startup-handler-prewarm.test.ts src/gateway/session-transcript-title-reader.placeholder.test.ts
- pnpm check
- pnpm build