### PR TITLE
fix(ui): prevent duplicate initial log loads

### DIFF
--- a/ui/src/pages/logs/logs-page.test.ts
+++ b/ui/src/pages/logs/logs-page.test.ts
@@ -120,6 +120,25 @@ describe("LogsPage lifecycle", () => {
     expect(scheduleScroll).toHaveBeenCalledWith(true);
   });
 
+  it("does not restart a pending initial load for metadata-only gateway snapshots", async () => {
+    const pending = deferred<{ cursor: number; lines: string[]; reset: boolean }>();
+    const request = vi.fn(() => pending.promise);
+    const client = { request } as unknown as GatewayBrowserClient;
+    const page = document.createElement("openclaw-logs-page") as TestLogsPage;
+    const context = contextWithClient(client, true);
+    page.context = context;
+    document.body.append(page);
+    await page.updateComplete;
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+
+    context.gateway.publish({ client, phase: "connected" } as ApplicationGatewaySnapshot);
+    await Promise.resolve();
+
+    expect(request).toHaveBeenCalledOnce();
+    pending.resolve({ cursor: 1, lines: ["initial"], reset: true });
+    await vi.waitFor(() => expect(page.logsEntries).toHaveLength(1));
+  });
+
   it("discards a log response from a replaced gateway source that reuses its client", async () => {
     const pending = deferred<{ cursor: number; lines: string[]; reset: boolean }>();
     const client = {

--- a/ui/src/pages/logs/logs-page.test.ts
+++ b/ui/src/pages/logs/logs-page.test.ts
@@ -121,6 +121,25 @@ describe("LogsPage lifecycle", () => {
     expect(scheduleScroll).toHaveBeenCalledWith(true);
   });
 
+  it("does not restart a pending initial load for metadata-only gateway snapshots", async () => {
+    const pending = deferred<{ cursor: number; lines: string[]; reset: boolean }>();
+    const request = vi.fn(() => pending.promise);
+    const client = { request } as unknown as GatewayBrowserClient;
+    const page = document.createElement("openclaw-logs-page") as TestLogsPage;
+    const context = contextWithClient(client, true);
+    page.context = context;
+    document.body.append(page);
+    await page.updateComplete;
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+
+    context.gateway.publish({ client, phase: "connected" } as ApplicationGatewaySnapshot);
+    await Promise.resolve();
+
+    expect(request).toHaveBeenCalledOnce();
+    pending.resolve({ cursor: 1, lines: ["initial"], reset: true });
+    await vi.waitFor(() => expect(page.logsEntries).toHaveLength(1));
+  });
+
   it("discards a log response from a replaced gateway source that reuses its client", async () => {
     const pending = deferred<{ cursor: number; lines: string[]; reset: boolean }>();
     const client = {

--- a/ui/src/pages/logs/logs-page.ts
+++ b/ui/src/pages/logs/logs-page.ts
@@ -136,10 +136,8 @@ class LogsPage extends OpenClawLightDomElement {
       this.logsTaskQuiet = false;
       void this.logsTask.run([null, null, null, false, false]);
     },
-    onSnapshot: () => {
-      this.syncPolling();
-      this.ensureInitialLogs();
-    },
+    onSnapshot: () => this.syncPolling(),
+    ensureInitialData: () => this.ensureInitialLogs(),
   });
   private readonly streamFollow = new StreamAutoFollowController(this, {
     selector: ".log-stream",

--- a/ui/src/pages/logs/logs-page.ts
+++ b/ui/src/pages/logs/logs-page.ts
@@ -143,14 +143,8 @@ class LogsPage extends OpenClawLightDomElement {
       this.logsTaskQuiet = false;
       void this.logsTask.run([null, null, null, null, false, false]);
     },
-    onSnapshot: (change) => {
-      this.syncPolling();
-      if (change.becameConnected && this.logsFile !== null) {
-        void this.loadLogs({ reset: true, quiet: true });
-        return;
-      }
-      this.ensureInitialLogs();
-    },
+    onSnapshot: () => this.syncPolling(),
+    ensureInitialData: () => this.ensureInitialLogs(),
   });
   private readonly streamFollow = new StreamAutoFollowController(this, {
     selector: ".log-stream",

--- a/ui/src/pages/logs/logs-page.ts
+++ b/ui/src/pages/logs/logs-page.ts
@@ -144,7 +144,7 @@ class LogsPage extends OpenClawLightDomElement {
       void this.logsTask.run([null, null, null, null, false, false]);
     },
     onSnapshot: () => this.syncPolling(),
-    ensureInitialData: () => this.ensureInitialLogs(),
+    ensureInitialData: () => this.loadConnectionLogs(),
   });
   private readonly streamFollow = new StreamAutoFollowController(this, {
     selector: ".log-stream",
@@ -208,12 +208,18 @@ class LogsPage extends OpenClawLightDomElement {
     this.polling.start();
   }
 
-  private ensureInitialLogs() {
-    if (!this.gateway.connected || !this.gateway.client || this.logsEntries.length > 0) {
+  private loadConnectionLogs() {
+    if (!this.gateway.connected || !this.gateway.client) {
       return;
     }
-    void this.loadLogs({ reset: true }).then((current) => {
-      if (current) {
+    // The first successful tail records its source. Reconnects reload it quietly;
+    // keeping both paths here guarantees one reset per connection transition.
+    const reconnect = this.logsFile !== null;
+    if (!reconnect && this.logsEntries.length > 0) {
+      return;
+    }
+    void this.loadLogs({ reset: true, quiet: reconnect }).then((current) => {
+      if (current && !reconnect) {
         this.streamFollow.schedule(true);
       }
     });


### PR DESCRIPTION
## What Problem This Solves

Opening Gateway logs could start repeated initial tail reads when recovery metadata produced connected snapshot clones before the first read completed. Each reset superseded the pending read, so an incremental response could win and leave the page with an incomplete initial buffer.

## Why This Change Was Made

Initial and reconnect log refreshes now use `GatewayPageController.ensureInitialData`, the lifecycle hook that runs only for the initial connected binding or a real connection/identity transition. Ordinary connected snapshots still synchronize polling but cannot restart the reset read.

The rebased implementation also retains the newer reconnect behavior: a known log source reloads quietly once per connection transition, while the first connection keeps its visible initial-loading state.

## User Impact

The logs page makes one initial request during startup, preserves a stable initial buffer before incremental tailing, and still refreshes the complete source after reconnect.

## Evidence

Real Chromium against the production-built Control UI and fixture-only mock Gateway. The held initial request makes every same-payload replacement visible in the trace; recovery metadata had settled before each count was recorded.

| Viewport | Before on `main` | After in this PR |
| --- | --- | --- |
| Desktop 1440 | ![Before on main: three initial logs.tail requests at desktop 1440](https://github.com/user-attachments/assets/28db7d17-0f63-4801-a881-ce88b65e7710) | ![After in this PR: one initial logs.tail request at desktop 1440](https://github.com/user-attachments/assets/e1762773-4658-41e8-a5ae-7067d35ff27c) |
| Mobile 390 | ![Before on main: three initial logs.tail requests at mobile 390](https://github.com/user-attachments/assets/63838a3e-a96f-4d6c-89f8-36c4e03034cd) | ![After in this PR: one initial logs.tail request at mobile 390](https://github.com/user-attachments/assets/eb309c7b-9178-4a13-bd90-7499ad2f6e06) |

- Pre-fix regression: `logs-page.test.ts` failed because the request spy was called twice after one metadata-only snapshot; the same test passes in this PR (10/10 focused unit tests).
- Browser proof: desktop 1440 and mobile 390 each changed from three initial `logs.tail` requests on `main` to one in this PR (2/2).
- Sibling browser proof: mocked auto-follow and real-Gateway source-change/reconnect lifecycle tests passed (2/2).
- `OPENCLAW_VITEST_MAX_WORKERS=2 pnpm check:changed` passed all selected UI/core-test checks.
- Review found no accepted or actionable findings.
- Original CI symptom: [run 31547774995](https://github.com/openclaw/openclaw/actions/runs/31547774995), [UI E2E shard](https://github.com/openclaw/openclaw/actions/runs/31547774995/job/93965423953) rendered one row instead of 200.

### Risk and coverage

- Root cause: the Logs page owned initial loading in its per-snapshot callback, while reset reads are intentionally replaceable. The lifecycle controller is the architectural owner of connection transitions.
- Canonical fix: connection transitions perform one reset refresh; snapshot callbacks only synchronize polling. No parallel request path or fallback was added.
- Reconnect coverage: the existing source-change/reconnect test passes against a real ephemeral Gateway, preserving the behavior added after this PR was opened.
- Sibling coverage: polling, source replacement, stale-error recovery, disconnect fencing, same-client reconnect fencing, and auto-follow remain covered.
- No protocol, configuration, persistence, schema, authorization, dependency, or user-visible wording change.

### Review metrics

- Production: `+12/-12`, net `0`.
- Tests: `+19/-0`, net `+19`.
- No generated, lockfile, snapshot, config, or documentation changes.

### Provenance

Original diagnosis, fix direction, and regression test by @steipete. The race became user-visible after #115274 made reset reads replace pending work; #120348 carried the per-snapshot trigger into the current lifecycle controller. This PR rebases that contribution and preserves the reconnect reset introduced by #124369.

