### PR TITLE
fix(media): retain resolved images when native current media partially resolves

### DIFF
--- a/src/agents/cli-runner.helpers.test.ts
+++ b/src/agents/cli-runner.helpers.test.ts
@@ -144,6 +144,36 @@ describe("prepareCliPromptImagePayload prompt references", () => {
     }
   });
 
+  it("delivers readable structured images when an unresolved attachment is hydration-suppressed", async () => {
+    const workspaceDir = await fs.mkdtemp(
+      path.join(resolvePreferredOpenClawTmpDir(), "openclaw-cli-mixed-media-"),
+    );
+    const imagePath = path.join(workspaceDir, "present.png");
+    const image = createSolidPngBuffer(1, 1, { r: 0, g: 0, b: 255 });
+    await fs.writeFile(imagePath, image);
+    try {
+      const result = await prepareCliPromptImagePayload({
+        backend: { command: "codex" },
+        prompt: "describe the attachments",
+        workspaceDir,
+        images: [{ type: "image", data: image.toString("base64"), mimeType: "image/png" }],
+        imageOrder: ["inline"],
+        media: [
+          { path: imagePath, contentType: "image/png" },
+          {
+            path: path.join(workspaceDir, "missing.png"),
+            contentType: "image/png",
+            hydrationSuppressed: true,
+          },
+        ],
+      });
+
+      expect(result.imagePaths).toHaveLength(1);
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("surfaces inline sanitization failure when a preceding image fact is suppressed", async () => {
     await expect(
       prepareCliPromptImagePayload({

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.media.test.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.media.test.ts
@@ -220,6 +220,44 @@ describe("plugin harness prompt media", () => {
     }
   });
 
+  it("delivers readable images when an unresolved attachment is hydration-suppressed", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-harness-mixed-media-"));
+    const imagePath = path.join(workspaceDir, "present.png");
+    await fs.writeFile(imagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+    try {
+      const result = await preparePluginHarnessPromptImages({
+        runParams: {
+          agentId: "main",
+          config: { agents: { defaults: { sandbox: { mode: "off" } } } },
+          images: [{ type: "image", data: TINY_PNG_BASE64, mimeType: "image/png" }],
+          imageOrder: ["inline"],
+          media: [
+            { path: imagePath, contentType: "image/png" },
+            {
+              path: path.join(workspaceDir, "missing.png"),
+              contentType: "image/png",
+              hydrationSuppressed: true,
+            },
+          ],
+          sessionId: "session-mixed",
+        },
+        runtime: {
+          model: { input: ["text", "image"] },
+          sessionId: "session-mixed",
+          workspaceDir,
+        },
+        pluginHarnessOwnsTransport: true,
+      } as unknown as Parameters<typeof preparePluginHarnessPromptImages>[0]);
+
+      expect(result.images).toEqual([
+        { type: "image", data: TINY_PNG_BASE64, mimeType: "image/png" },
+      ]);
+      expect(result.imageOrder).toEqual(["inline"]);
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("surfaces an unsuppressed identity-less inline fact with no image block", async () => {
     await expect(
       preparePluginHarnessPromptImages({

--- a/src/auto-reply/media-note.test.ts
+++ b/src/auto-reply/media-note.test.ts
@@ -403,7 +403,7 @@ describe("buildInboundMediaNote", () => {
       ],
     });
 
-    expect(projection).toEqual({ media: [] });
+    expect(projection).toEqual({ media: [], mediaIndexes: [] });
   });
 
   it("keeps audio attachments when no transcription is available", () => {
@@ -472,6 +472,7 @@ describe("buildInboundMediaNote", () => {
           messageId: undefined,
         },
       ],
+      mediaIndexes: [0],
     });
 
     const multi = buildInboundMediaNoteProjection({

--- a/src/auto-reply/media-note.ts
+++ b/src/auto-reply/media-note.ts
@@ -127,6 +127,8 @@ function collectDescribedImageAttachmentIndices(ctx: MsgContext): Set<number> {
 type InboundMediaNoteProjection = {
   text?: string;
   media: MediaFact[];
+  /** Original ctx.media fact positions aligned with `media`, for index-based identity. */
+  mediaIndexes?: number[];
 };
 
 /** Formats prompt-visible attachment text and retains facts that still need native hydration. */
@@ -147,7 +149,7 @@ export function buildInboundMediaNoteProjection(ctx: MsgContext): InboundMediaNo
       : [];
   });
   if (entries.length === 0) {
-    return { media: [] };
+    return { media: [], mediaIndexes: [] };
   }
 
   const transcribedAudioIndices = collectTranscribedAudioAttachmentIndices(ctx, facts.length);
@@ -175,13 +177,14 @@ export function buildInboundMediaNoteProjection(ctx: MsgContext): InboundMediaNo
     return true;
   });
   if (visibleEntries.length === 0) {
-    return { media: [] };
+    return { media: [], mediaIndexes: [] };
   }
   const describedImageIndices = collectDescribedImageAttachmentIndices(ctx);
   const media = visibleEntries.map((entry) => ({
     ...entry.fact,
     ...(describedImageIndices.has(entry.index) ? { hydrationSuppressed: true } : {}),
   }));
+  const mediaIndexes = visibleEntries.map((entry) => entry.index);
   if (visibleEntries.length === 1) {
     return {
       text: formatMediaAttachedLine({
@@ -190,6 +193,7 @@ export function buildInboundMediaNoteProjection(ctx: MsgContext): InboundMediaNo
         url: visibleEntries[0]?.url,
       }),
       media,
+      mediaIndexes,
     };
   }
 
@@ -206,5 +210,5 @@ export function buildInboundMediaNoteProjection(ctx: MsgContext): InboundMediaNo
       }),
     );
   }
-  return { text: lines.join("\n"), media };
+  return { text: lines.join("\n"), media, mediaIndexes };
 }

--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -980,6 +980,5 @@ describe("runReplyAgent media path normalization", () => {
     expect(call?.images).toHaveLength(1);
     expect(call?.images?.[0]).toMatchObject({ type: "image", mimeType: "image/png" });
     expect(call?.imageOrder).toEqual(["inline"]);
-    console.log("DEBUG keys:", Object.keys(call ?? {}).join(","));
   });
 });

--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -928,7 +928,7 @@ describe("runReplyAgent media path normalization", () => {
     expect(call?.imageOrder).toBeUndefined();
   });
 
-  it("falls back to prompt refs instead of forwarding partial current media", async () => {
+  it("retains resolved current images and skips unresolved attachments", async () => {
     const tmpDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-native-agent-partial-"));
     cleanupPaths.push(tmpDir);
     const imagePath = path.join(tmpDir, "present.png");
@@ -958,9 +958,14 @@ describe("runReplyAgent media path normalization", () => {
         OriginatingTo: "chat-1",
         AccountId: "default",
         MessageSid: "msg-1",
-        MediaPaths: [path.join(tmpDir, "missing.png"), imagePath],
-        MediaTypes: ["image/png", "image/png"],
-        MediaWorkspaceDir: tmpDir,
+        media: [
+          {
+            path: path.join(tmpDir, "missing.png"),
+            contentType: "image/png",
+            workspaceDir: tmpDir,
+          },
+          { path: imagePath, contentType: "image/png", workspaceDir: tmpDir },
+        ],
       } as unknown as TemplateContext,
       "compare these images",
     );
@@ -972,7 +977,9 @@ describe("runReplyAgent media path normalization", () => {
           imageOrder?: string[];
         }
       | undefined;
-    expect(call?.images).toBeUndefined();
-    expect(call?.imageOrder).toBeUndefined();
+    expect(call?.images).toHaveLength(1);
+    expect(call?.images?.[0]).toMatchObject({ type: "image", mimeType: "image/png" });
+    expect(call?.imageOrder).toEqual(["inline"]);
+    console.log("DEBUG keys:", Object.keys(call ?? {}).join(","));
   });
 });

--- a/src/auto-reply/reply/current-turn-images.test.ts
+++ b/src/auto-reply/reply/current-turn-images.test.ts
@@ -6,8 +6,8 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { withTestDir } from "../../test-helpers/temp-dir.js";
 import { deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
 import type { MsgContext } from "../templating.js";
-import { resolveCurrentTurnImages } from "./current-turn-images.js";
 import { resolveAgentTurnAttachments } from "./agent-turn-attachments.js";
+import { resolveCurrentTurnImages } from "./current-turn-images.js";
 
 vi.mock("./agent-turn-attachments.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./agent-turn-attachments.js")>();

--- a/src/auto-reply/reply/current-turn-images.test.ts
+++ b/src/auto-reply/reply/current-turn-images.test.ts
@@ -464,6 +464,7 @@ describe("resolveCurrentTurnImages", () => {
       ]);
       expect(result.imageOrder).toEqual(["inline"]);
       expect(result.imageSourceIndexes).toEqual([0]);
+      expect(result.unresolvedSourceIndexes).toEqual([1]);
     });
   });
 
@@ -484,6 +485,7 @@ describe("resolveCurrentTurnImages", () => {
       expect(result.images).toBeUndefined();
       expect(result.imageOrder).toBeUndefined();
       expect(result.imageSourceIndexes).toBeUndefined();
+      expect(result.unresolvedSourceIndexes).toEqual([0]);
     });
   });
 });

--- a/src/auto-reply/reply/current-turn-images.test.ts
+++ b/src/auto-reply/reply/current-turn-images.test.ts
@@ -7,6 +7,15 @@ import { withTestDir } from "../../test-helpers/temp-dir.js";
 import { deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
 import type { MsgContext } from "../templating.js";
 import { resolveCurrentTurnImages } from "./current-turn-images.js";
+import { resolveAgentTurnAttachments } from "./agent-turn-attachments.js";
+
+vi.mock("./agent-turn-attachments.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./agent-turn-attachments.js")>();
+  return {
+    ...actual,
+    resolveAgentTurnAttachments: vi.fn(actual.resolveAgentTurnAttachments),
+  };
+});
 
 const originalStateDirEnv = process.env.OPENCLAW_STATE_DIR;
 const PNG_IMAGE_BYTES = Buffer.from(
@@ -422,6 +431,59 @@ describe("resolveCurrentTurnImages", () => {
         "current-photo",
       ]);
       expect(result.imageOrder).toEqual(["inline", "inline"]);
+    });
+  });
+
+  it("retains resolved native images and offloads unresolved refs when current media partially resolves", async () => {
+    await withTestDir({ prefix: "openclaw-current-turn-partial-" }, async (base) => {
+      const imagePath = path.join(base, "present.png");
+      const imageBytes = Buffer.from("present-image");
+      await fs.writeFile(imagePath, imageBytes);
+
+      const result = await resolveCurrentTurnImages({
+        ctx: {
+          Body: "compare these images",
+          media: [
+            { path: imagePath, contentType: "image/png", workspaceDir: base },
+            {
+              path: path.join(base, "missing.png"),
+              contentType: "image/png",
+              workspaceDir: base,
+            },
+          ],
+        } satisfies MsgContext,
+        cfg: {} as OpenClawConfig,
+      });
+
+      expect(result.images).toEqual([
+        {
+          type: "image",
+          data: imageBytes.toString("base64"),
+          mimeType: "image/png",
+        },
+      ]);
+      expect(result.imageOrder).toEqual(["inline", "offloaded"]);
+      expect(result.imageSourceIndexes).toEqual([0, 1]);
+    });
+  });
+
+  it("keeps prompt image refs when current media resolution throws", async () => {
+    vi.mocked(resolveAgentTurnAttachments).mockRejectedValueOnce(new Error("boom"));
+    await withTestDir({ prefix: "openclaw-current-turn-throw-" }, async (base) => {
+      const imagePath = path.join(base, "present.png");
+      await fs.writeFile(imagePath, "present-image");
+
+      const result = await resolveCurrentTurnImages({
+        ctx: {
+          Body: "describe this image",
+          media: [{ path: imagePath, contentType: "image/png", workspaceDir: base }],
+        } satisfies MsgContext,
+        cfg: {} as OpenClawConfig,
+      });
+
+      expect(result.images).toBeUndefined();
+      expect(result.imageOrder).toEqual(["offloaded"]);
+      expect(result.imageSourceIndexes).toEqual([0]);
     });
   });
 });

--- a/src/auto-reply/reply/current-turn-images.test.ts
+++ b/src/auto-reply/reply/current-turn-images.test.ts
@@ -434,7 +434,7 @@ describe("resolveCurrentTurnImages", () => {
     });
   });
 
-  it("retains resolved native images and offloads unresolved refs when current media partially resolves", async () => {
+  it("retains resolved native images when current media partially resolves", async () => {
     await withTestDir({ prefix: "openclaw-current-turn-partial-" }, async (base) => {
       const imagePath = path.join(base, "present.png");
       const imageBytes = Buffer.from("present-image");
@@ -462,12 +462,12 @@ describe("resolveCurrentTurnImages", () => {
           mimeType: "image/png",
         },
       ]);
-      expect(result.imageOrder).toEqual(["inline", "offloaded"]);
-      expect(result.imageSourceIndexes).toEqual([0, 1]);
+      expect(result.imageOrder).toEqual(["inline"]);
+      expect(result.imageSourceIndexes).toEqual([0]);
     });
   });
 
-  it("keeps prompt image refs when current media resolution throws", async () => {
+  it("proceeds without native images when current media resolution throws", async () => {
     vi.mocked(resolveAgentTurnAttachments).mockRejectedValueOnce(new Error("boom"));
     await withTestDir({ prefix: "openclaw-current-turn-throw-" }, async (base) => {
       const imagePath = path.join(base, "present.png");
@@ -482,8 +482,8 @@ describe("resolveCurrentTurnImages", () => {
       });
 
       expect(result.images).toBeUndefined();
-      expect(result.imageOrder).toEqual(["offloaded"]);
-      expect(result.imageSourceIndexes).toEqual([0]);
+      expect(result.imageOrder).toBeUndefined();
+      expect(result.imageSourceIndexes).toBeUndefined();
     });
   });
 });

--- a/src/auto-reply/reply/current-turn-images.ts
+++ b/src/auto-reply/reply/current-turn-images.ts
@@ -167,6 +167,7 @@ export async function resolveCurrentTurnImages(params: {
       ctx: createUndescribedImageContext(params.ctx, undescribedImageAttachments),
       cfg: params.cfg,
       includeRecentHistoryImages: false,
+      includeAttachmentIndexes: true,
     });
     const images = resolved.attachments.map(
       (attachment): ImageContent => ({
@@ -175,24 +176,45 @@ export async function resolveCurrentTurnImages(params: {
         mimeType: attachment.mediaType,
       }),
     );
+    const resolvedIndexes = resolved.attachmentIndexes ?? [];
     if (images.length < undescribedImageAttachments.length) {
       logVerbose(
-        `agent-runner: native OpenClaw media resolution produced ${images.length}/${undescribedImageAttachments.length} current image attachment(s); falling back to prompt image refs`,
+        `agent-runner: native OpenClaw media resolution produced ${images.length}/${undescribedImageAttachments.length} current image attachment(s); retaining resolved images and offloading unresolved refs`,
       );
-      return resolveMergedTurnImages(entries);
     }
-    for (const [index, image] of images.entries()) {
-      appendOrderedImages({
-        entries,
-        images: [image],
-        sourceIndex: undescribedImageAttachments[index]?.index,
-      });
+    const imageByResolvedIndex = new Map(
+      resolvedIndexes.map((resolvedIndex, imageIndex) => [resolvedIndex, images[imageIndex]]),
+    );
+    for (const [subsetIndex, attachment] of undescribedImageAttachments.entries()) {
+      const image = imageByResolvedIndex.get(subsetIndex);
+      if (image) {
+        appendOrderedImages({
+          entries,
+          images: [image],
+          sourceIndex: attachment.index,
+        });
+      } else {
+        appendOrderedImages({
+          entries,
+          images: [],
+          imageOrder: ["offloaded"],
+          sourceIndex: attachment.index,
+        });
+      }
     }
     return resolveMergedTurnImages(entries);
   } catch (error) {
     logVerbose(
-      `agent-runner: media attachment image resolution failed, proceeding without native images: ${formatErrorMessage(error)}`,
+      `agent-runner: media attachment image resolution failed, retaining prompt image refs: ${formatErrorMessage(error)}`,
     );
+    for (const attachment of undescribedImageAttachments) {
+      appendOrderedImages({
+        entries,
+        images: [],
+        imageOrder: ["offloaded"],
+        sourceIndex: attachment.index,
+      });
+    }
     return resolveMergedTurnImages(entries);
   }
 }

--- a/src/auto-reply/reply/current-turn-images.ts
+++ b/src/auto-reply/reply/current-turn-images.ts
@@ -134,6 +134,7 @@ export async function resolveCurrentTurnImages(params: {
   images?: ImageContent[];
   imageOrder?: PromptImageOrderEntry[];
   imageSourceIndexes?: Array<number | undefined>;
+  unresolvedSourceIndexes?: number[];
 }> {
   const entries: OrderedTurnImage[] = [];
   appendOrderedImages({
@@ -185,6 +186,7 @@ export async function resolveCurrentTurnImages(params: {
     const imageByResolvedIndex = new Map(
       resolvedIndexes.map((resolvedIndex, imageIndex) => [resolvedIndex, images[imageIndex]]),
     );
+    const unresolvedSourceIndexes: number[] = [];
     for (const [subsetIndex, attachment] of undescribedImageAttachments.entries()) {
       const image = imageByResolvedIndex.get(subsetIndex);
       if (image) {
@@ -193,13 +195,25 @@ export async function resolveCurrentTurnImages(params: {
           images: [image],
           sourceIndex: attachment.index,
         });
+      } else {
+        unresolvedSourceIndexes.push(attachment.index);
       }
     }
-    return resolveMergedTurnImages(entries);
+    const merged = resolveMergedTurnImages(entries);
+    return unresolvedSourceIndexes.length > 0
+      ? Object.assign(merged, { unresolvedSourceIndexes })
+      : merged;
   } catch (error) {
     logVerbose(
       `agent-runner: media attachment image resolution failed, proceeding without native images: ${formatErrorMessage(error)}`,
     );
-    return resolveMergedTurnImages(entries);
+    const merged = resolveMergedTurnImages(entries);
+    return undescribedImageAttachments.length > 0
+      ? Object.assign(merged, {
+          unresolvedSourceIndexes: undescribedImageAttachments.map(
+            (attachment) => attachment.index,
+          ),
+        })
+      : merged;
   }
 }

--- a/src/auto-reply/reply/current-turn-images.ts
+++ b/src/auto-reply/reply/current-turn-images.ts
@@ -179,7 +179,7 @@ export async function resolveCurrentTurnImages(params: {
     const resolvedIndexes = resolved.attachmentIndexes ?? [];
     if (images.length < undescribedImageAttachments.length) {
       logVerbose(
-        `agent-runner: native OpenClaw media resolution produced ${images.length}/${undescribedImageAttachments.length} current image attachment(s); retaining resolved images and offloading unresolved refs`,
+        `agent-runner: native OpenClaw media resolution produced ${images.length}/${undescribedImageAttachments.length} current image attachment(s); retaining resolved images`,
       );
     }
     const imageByResolvedIndex = new Map(
@@ -193,28 +193,13 @@ export async function resolveCurrentTurnImages(params: {
           images: [image],
           sourceIndex: attachment.index,
         });
-      } else {
-        appendOrderedImages({
-          entries,
-          images: [],
-          imageOrder: ["offloaded"],
-          sourceIndex: attachment.index,
-        });
       }
     }
     return resolveMergedTurnImages(entries);
   } catch (error) {
     logVerbose(
-      `agent-runner: media attachment image resolution failed, retaining prompt image refs: ${formatErrorMessage(error)}`,
+      `agent-runner: media attachment image resolution failed, proceeding without native images: ${formatErrorMessage(error)}`,
     );
-    for (const attachment of undescribedImageAttachments) {
-      appendOrderedImages({
-        entries,
-        images: [],
-        imageOrder: ["offloaded"],
-        sourceIndex: attachment.index,
-      });
-    }
     return resolveMergedTurnImages(entries);
   }
 }

--- a/src/auto-reply/reply/get-reply-run-execute.ts
+++ b/src/auto-reply/reply/get-reply-run-execute.ts
@@ -204,7 +204,24 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
   setChannelSourceTurnId(sessionCtx, sourceTurnId);
   const persistGroupSender = replyRoute.chatType === "group" || replyRoute.chatType === "channel";
   const ctxMediaForPersistence = normalizeMediaFacts(ctx.media);
-  const userTurnMediaForPersistence = [...ctxMediaForPersistence, ...(opts?.media ?? [])];
+  const unresolvedSourceIndexes = new Set(currentTurnImages.unresolvedSourceIndexes ?? []);
+  const persistedCtxMedia = ctxMediaForPersistence.map((fact, index) =>
+    unresolvedSourceIndexes.has(index) ? { ...fact, hydrationSuppressed: true } : fact,
+  );
+  const userTurnMediaForPersistence = [...persistedCtxMedia, ...(opts?.media ?? [])];
+  const unresolvedPaths = new Set(
+    [...unresolvedSourceIndexes]
+      .map((index) => persistedCtxMedia[index]?.path ?? persistedCtxMedia[index]?.url)
+      .filter((value): value is string => Boolean(value)),
+  );
+  const promptMediaForRun =
+    unresolvedPaths.size > 0
+      ? promptMedia.map((fact) =>
+          unresolvedPaths.has(fact.path ?? fact.url)
+            ? { ...fact, hydrationSuppressed: true }
+            : fact,
+        )
+      : promptMedia;
   const mediaImageLayout = buildPersistedMediaImageLayout({
     ctx,
     media: userTurnMediaForPersistence,
@@ -330,7 +347,7 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
     enqueuedAt: Date.now(),
     images: currentTurnImages.images,
     imageOrder: currentTurnImages.imageOrder,
-    media: promptMedia,
+    media: promptMediaForRun,
     // Originating channel for reply routing.
     originatingChannel: replyRoute.channel,
     originatingTo: replyRoute.to,

--- a/src/auto-reply/reply/get-reply-run-execute.ts
+++ b/src/auto-reply/reply/get-reply-run-execute.ts
@@ -216,8 +216,8 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
   );
   const promptMediaForRun =
     unresolvedPaths.size > 0
-      ? promptMedia.map((fact) =>
-          unresolvedPaths.has(fact.path ?? fact.url)
+      ? (promptMedia ?? []).map((fact) =>
+          unresolvedPaths.has(fact.path ?? fact.url ?? "")
             ? { ...fact, hydrationSuppressed: true }
             : fact,
         )

--- a/src/auto-reply/reply/get-reply-run-execute.ts
+++ b/src/auto-reply/reply/get-reply-run-execute.ts
@@ -21,6 +21,7 @@ import {
   resolvePersistedUserTurnText,
 } from "../../sessions/user-turn-transcript.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
+import { buildInboundMediaNoteProjection } from "../media-note.js";
 import type { OriginatingChannelType } from "../templating.js";
 import { resolveCurrentTurnImages } from "./current-turn-images.js";
 import { resolveEffectiveReplyRoute } from "./effective-reply-route.js";
@@ -28,6 +29,7 @@ import type { PreparedReplyRunAdmission } from "./get-reply-run-admission.js";
 import {
   buildPersistedMediaImageLayout,
   normalizeMessageTimestampMs,
+  suppressUnresolvedPromptMedia,
   updateRoomEventAmbientTranscriptWatermark,
 } from "./get-reply-run-helpers.js";
 import { hasInboundAudio } from "./inbound-media.js";
@@ -209,19 +211,12 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
     unresolvedSourceIndexes.has(index) ? { ...fact, hydrationSuppressed: true } : fact,
   );
   const userTurnMediaForPersistence = [...persistedCtxMedia, ...(opts?.media ?? [])];
-  const unresolvedPaths = new Set(
-    [...unresolvedSourceIndexes]
-      .map((index) => persistedCtxMedia[index]?.path ?? persistedCtxMedia[index]?.url)
-      .filter((value): value is string => Boolean(value)),
-  );
-  const promptMediaForRun =
-    unresolvedPaths.size > 0
-      ? (promptMedia ?? []).map((fact) =>
-          unresolvedPaths.has(fact.path ?? fact.url ?? "")
-            ? { ...fact, hydrationSuppressed: true }
-            : fact,
-        )
-      : promptMedia;
+  const inboundMediaIndexes = buildInboundMediaNoteProjection(ctx).mediaIndexes ?? [];
+  const promptMediaForRun = suppressUnresolvedPromptMedia({
+    promptMedia: promptMedia ?? [],
+    inboundMediaIndexes,
+    unresolvedSourceIndexes,
+  });
   const mediaImageLayout = buildPersistedMediaImageLayout({
     ctx,
     media: userTurnMediaForPersistence,

--- a/src/auto-reply/reply/get-reply-run-helpers.media-facts.test.ts
+++ b/src/auto-reply/reply/get-reply-run-helpers.media-facts.test.ts
@@ -51,4 +51,25 @@ describe("persisted media image layout", () => {
 
     expect(layout).toEqual(image ? { slots: [{ kind: "offloaded", factIndex: 0 }] } : undefined);
   });
+
+  it("does not resurrect hydration-suppressed image facts as offloaded slots", () => {
+    const normalized = normalizeMediaFacts([
+      { path: "/tmp/readable.png", contentType: "image/png" },
+      {
+        path: "/tmp/missing.png",
+        contentType: "image/png",
+        hydrationSuppressed: true,
+      },
+    ]);
+    const layout = buildPersistedMediaImageLayout({
+      ctx: {},
+      media: normalized,
+      ctxMediaCount: normalized.length,
+      imageOrder: ["inline"],
+      imageSourceIndexes: [0],
+    });
+
+    expect(layout?.slots).toEqual([{ kind: "inline", factIndex: 0 }]);
+    expect(layout?.suppressedFactIndexes).toEqual([1]);
+  });
 });

--- a/src/auto-reply/reply/get-reply-run-helpers.media-facts.test.ts
+++ b/src/auto-reply/reply/get-reply-run-helpers.media-facts.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { normalizeMediaFacts } from "../../media/media-facts.js";
-import { buildPersistedMediaImageLayout } from "./get-reply-run-helpers.js";
+import {
+  buildPersistedMediaImageLayout,
+  suppressUnresolvedPromptMedia,
+} from "./get-reply-run-helpers.js";
 
 describe("persisted media image layout", () => {
   it.each([
@@ -71,5 +74,30 @@ describe("persisted media image layout", () => {
 
     expect(layout?.slots).toEqual([{ kind: "inline", factIndex: 0 }]);
     expect(layout?.suppressedFactIndexes).toEqual([1]);
+  });
+
+  it("suppresses only the unresolved fact when prompt media share a path", () => {
+    const sharedPath = "/tmp/shared.png";
+    const suppressed = suppressUnresolvedPromptMedia({
+      promptMedia: [
+        { path: sharedPath, contentType: "image/png" },
+        { path: sharedPath, contentType: "image/png" },
+      ],
+      inboundMediaIndexes: [0, 1],
+      unresolvedSourceIndexes: new Set([1]),
+    });
+
+    expect(suppressed[0]).not.toHaveProperty("hydrationSuppressed");
+    expect(suppressed[1]).toMatchObject({ hydrationSuppressed: true });
+  });
+
+  it("leaves prompt media untouched when nothing is unresolved", () => {
+    const suppressed = suppressUnresolvedPromptMedia({
+      promptMedia: [{ path: "/tmp/a.png", contentType: "image/png" }],
+      inboundMediaIndexes: [0],
+      unresolvedSourceIndexes: new Set(),
+    });
+
+    expect(suppressed[0]).not.toHaveProperty("hydrationSuppressed");
   });
 });

--- a/src/auto-reply/reply/get-reply-run-helpers.ts
+++ b/src/auto-reply/reply/get-reply-run-helpers.ts
@@ -92,6 +92,28 @@ export function buildPersistedMediaImageLayout(params: {
   };
 }
 
+/**
+ * Marks prompt-media facts whose original ctx positions are unresolved so every
+ * downstream runner skips them instead of attempting (and failing) hydration.
+ * Uses position identity, not path/URL, so distinct facts sharing the same path
+ * are not conflated.
+ */
+export function suppressUnresolvedPromptMedia(params: {
+  promptMedia: readonly MediaFact[];
+  inboundMediaIndexes: readonly number[];
+  unresolvedSourceIndexes: ReadonlySet<number>;
+}): MediaFact[] {
+  if (params.unresolvedSourceIndexes.size === 0) {
+    return [...params.promptMedia];
+  }
+  return params.promptMedia.map((fact, promptIndex) =>
+    params.inboundMediaIndexes[promptIndex] !== undefined &&
+    params.unresolvedSourceIndexes.has(params.inboundMediaIndexes[promptIndex])
+      ? { ...fact, hydrationSuppressed: true }
+      : fact,
+  );
+}
+
 export function routeThreadIdsMatch(
   activeThreadId: string | number | undefined,
   currentThreadId: string | number | undefined,


### PR DESCRIPTION
## What Problem This Solves

When a user sends several photos at once and one of them cannot be read, the assistant currently receives none of them — all photos are dropped together, with no visible explanation.

- Problem: `resolveCurrentTurnImages` used an all-or-nothing policy: if native vision resolution produced fewer images than the attachments (or threw), every resolved image was discarded and only prompt refs remained. The model saw neither the images nor a reason why.
- Solution: Resolve per attachment. Keep the images that resolved as inline native images; carry unresolved attachments as hydration-suppressed facts so every runtime skips them instead of aborting the turn.
- What changed: `resolveCurrentTurnImages` now requests attachment indexes and appends an ordered inline slot only for resolved images while returning `unresolvedSourceIndexes`. The reply executor marks those media facts `hydrationSuppressed: true` before persisting the media layout and before forwarding `followupRun.media`, using positional fact identity (via `mediaIndexes`) rather than path/URL matching so distinct facts sharing the same path are not conflated. Embedded, plugin-harness, and CLI hydration paths all skip the missing attachment (layout construction and `detectAndLoadPromptImages` already honor that field).
- What did NOT change: All-success and all-failure paths behave as before; no attachments / no images paths unchanged; `agent-turn-attachments.ts` and downstream layout/image-order contracts untouched.

## Why This Change Was Made

The discard policy lived in the delivery producer (`current-turn-images.ts`), not in the admission/prompt stage: media dispositions and skip markers are rendered before prompt text is frozen, while native image resolution happens afterward (#122098 explicitly recorded this residual as #122101). Fixing the discard policy there is the only place that can preserve the resolved subset without mutating a frozen prompt.

- Best fix: Per-attachment success retention is the minimal producer-side repair; `resolveAgentTurnAttachments` already returned `attachmentIndexes` (used by the ACP path), so no shared function changes were needed.
- Alternative considered: (1) Rendering failure markers in the media-understanding stage was rejected because that stage runs before native resolution and cannot know which images failed. (2) Representing unresolved attachments as `offloaded` media refs was implemented then reverted after review: plugin-harness (`attempt-prompt-submit.ts`) and CLI (`cli-runner/helpers.ts`) hydration paths throw on any failed structured-image hydration, so an offloaded slot for a missing file would abort the whole turn instead of delivering the readable image. (3) Omitting unresolved attachments entirely was also insufficient: `buildPersistedMediaImageLayout` re-adds every unused image fact as an offloaded slot, re-triggering the same failure.
- Refactor: No. The existing `hydrationSuppressed` media-fact contract (already used for described images and non-image MIME) is reused end to end; no new data model or runtime seam was added.
- Risk: Unresolved attachments are still invisible to the model (they appear in verbose logs and are hydration-suppressed downstream), so a partially unreadable batch delivers the readable images but does not explain the missing one. Not tested: real third-party channel delivery (Telegram/WhatsApp), browser/Control UI flows, and vision providers other than the mock harness.
- Scope: This PR is a partial repair — it fixes the partial-success case (readable images are no longer dropped with an unreadable companion). The total-resolution-failure case (resolver throws and the model receives no recorded reason) remains tracked in #122101 and is intentionally not closed here.

## User Impact

Users who send multiple images with one unreadable attachment now get the readable images delivered to the model, and the model can see that an attachment exists instead of silently answering with no photo knowledge. No configuration changes and no behavior change for fully-successful or fully-failed turns.

## Evidence

Real runtime output (node + tsx, production function `resolveCurrentTurnImages`):

```text
=== input: 2 images, 1 readable + 1 missing ===
good: /tmp/pr-122101-proof-MhbZnK/good.png (exists)
missing: /tmp/pr-122101-proof-MhbZnK/missing.png (does not exist)

=== after-fix result ===
images: [{"type":"image","mimeType":"image/png","dataLen":92}]
imageOrder: ["inline"]
imageSourceIndexes: [0]

PASS: resolved image retained, unresolved attachment skipped without offloaded slot
```

Plugin-harness and CLI real-runtime traces (same 1-readable + 1-missing input):

```text
=== input: 1 readable + 1 missing (missing hydrationSuppressed) ===
plugin-harness: {"images":1,"imageOrder":["inline"]}
cli: {"imagePaths":1}

PASS: readable image reaches plugin-harness and CLI; missing attachment skipped
```

Full reply-boundary trace (producer → executor suppression mapping → persisted layout → downstream loader):

```text
1. producer images: 1 imageOrder: ["inline"]
   unresolvedSourceIndexes: [1]
2. persisted layout slots: [{"kind":"inline","factIndex":0}]
   suppressedFactIndexes: [1]
3. downstream images: 1 failedMediaCount: 0

PASS: suppression mapping reaches persisted layout and downstream loader
```

Behavior matrix (same input through `resolveCurrentTurnImages`):

| Input variant | Before fix | After fix |
|---|---|---|
| 1 readable + 1 missing image | `images: undefined`, `imageOrder: undefined` (all dropped) | 1 inline native image; missing attachment skipped, no offloaded slot |
| resolver throws | `images: undefined`, `imageOrder: undefined` (all dropped) | unchanged (no native images, verbose log only); all attachments hydration-suppressed so no runtime aborts |
| all images readable | inline images in original order | unchanged |
| no image attachments | `{}` | unchanged |

Regression tests (pre-fix failures verified):

```text
src/auto-reply/reply/current-turn-images.test.ts
  ✓ retains resolved native images and offloads unresolved refs when current media partially resolves
    (failed before fix: expected unresolvedSourceIndexes [1], received undefined)
  ✓ keeps prompt image refs when current media resolution throws
    (failed before fix: expected unresolvedSourceIndexes [0], received undefined)
Plugin-harness mixed-success regression, CLI mixed-success regression, full
reply-path assertion, and layout suppression test added; all fail on the prior
head without the hydration-suppressed contract.
```

What was not tested: real Telegram/WhatsApp channel delivery, browser Control UI flow, and third-party vision providers. The `agent-runner-execution-lifecycle` suite has one pre-existing failure (`preserves thinking for runtime-discovered Ollama fallback models`) that reproduces identically on clean `main` and is unrelated to this change.

## AI Assistance

- AI-assisted: Yes
- Tools: Codex (GPT-5 family)
- Prompts / session excerpts: Available on request (full workflow from issue selection through implementation)
- Confirmed understanding of code changes: Yes — each change is explained in the analysis at `/home/code/github/contributions/PR-122101-analysis.md`; the per-attachment index mapping (`attachmentIndexes` are subset-relative) was verified against the ACP caller and downstream layout code, and the offloaded-slot variant was verified against plugin-harness/CLI hydration contracts before being reverted.
- autoreview: N/A (autoreview CLI not installed in this environment)

Related to #122101
