### PR TITLE
refactor(plugins): share bounded run id tracking

### DIFF
--- a/src/plugins/host-hook-runtime.ts
+++ b/src/plugins/host-hook-runtime.ts
@@ -40,7 +40,7 @@ type PluginHostRuntimeState = {
 };
 
 const PLUGIN_HOST_RUNTIME_STATE_KEY = Symbol.for("openclaw.pluginHostRuntimeState");
-const CLOSED_RUN_IDS_MAX = 512;
+const TRACKED_RUN_IDS_MAX = 512;
 const PLUGIN_TERMINAL_EVENT_CLEANUP_WAIT_MS = 5_000;
 const log = createSubsystemLogger("plugins/host-hooks");
 
@@ -63,17 +63,21 @@ function copyJsonValue(value: PluginJsonValue): PluginJsonValue {
   return structuredClone(value);
 }
 
-function markPluginRunClosed(runId: string): void {
-  const state = getPluginHostRuntimeState();
-  state.closedRunIds.delete(runId);
-  state.closedRunIds.add(runId);
-  while (state.closedRunIds.size > CLOSED_RUN_IDS_MAX) {
-    const oldest = state.closedRunIds.values().next().value;
+function rememberBoundedRunId(runIds: Set<string>, runId: string): void {
+  runIds.delete(runId);
+  runIds.add(runId);
+
+  while (runIds.size > TRACKED_RUN_IDS_MAX) {
+    const oldest = runIds.values().next().value;
     if (oldest === undefined) {
       break;
     }
-    state.closedRunIds.delete(oldest);
+    runIds.delete(oldest);
   }
+}
+
+function markPluginRunClosed(runId: string): void {
+  rememberBoundedRunId(getPluginHostRuntimeState().closedRunIds, runId);
 }
 
 function isPluginRunClosed(runId: string): boolean {
@@ -81,16 +85,7 @@ function isPluginRunClosed(runId: string): boolean {
 }
 
 function markTerminalEventCleanupExpired(runId: string): void {
-  const state = getPluginHostRuntimeState();
-  state.terminalEventCleanupExpiredRunIds.delete(runId);
-  state.terminalEventCleanupExpiredRunIds.add(runId);
-  while (state.terminalEventCleanupExpiredRunIds.size > CLOSED_RUN_IDS_MAX) {
-    const oldest = state.terminalEventCleanupExpiredRunIds.values().next().value;
-    if (oldest === undefined) {
-      break;
-    }
-    state.terminalEventCleanupExpiredRunIds.delete(oldest);
-  }
+  rememberBoundedRunId(getPluginHostRuntimeState().terminalEventCleanupExpiredRunIds, runId);
 }
 
 function isTerminalEventCleanupExpired(runId: string): boolean {


### PR DESCRIPTION
## What Problem This Solves

The plugin host runtime maintained the same bounded run-ID retention policy in two separate lifecycle markers. This behavior-neutral, owner-local refactor removes that duplication so their refresh and eviction semantics cannot drift.

The closed-run marker originated in https://github.com/openclaw/openclaw/pull/72287. The terminal-cleanup expiry marker copied the same bounded-set policy in https://github.com/openclaw/openclaw/pull/75600.

## Why This Change Was Made

One private helper now owns delete-before-add refresh and oldest-entry eviction. The closed-run and terminal-cleanup expiry sets remain independent, with the same 512-entry bound and lifecycle behavior.

Production LOC: +13/-18 (net -5) | Tests: +0/-0

## User Impact

No user-visible behavior changes. This reduces duplicated lifecycle policy without changing plugin run-context cleanup, configuration, public contracts, or defaults.

No changelog entry is needed for this behavior-neutral internal refactor.

## Evidence

- Local: 96/96 focused tests passed; targeted format, oxlint, and `git diff --check` passed.
- Blacksmith Testbox: lease `tbx_01kztdjq4xg425hd7ms9327k2s`, workflow `31573659441`, job `94040856885`; 96/96 tests, test types, diff check, targeted oxlint, core typecheck, and tail checks passed; the full workflow completed successfully with natural cleanup.
- Compatibility ratchet: exact-base and exact-head output was identical. The due-date baseline `context-engine-legacy-host-param-default` is unrelated to this change.
- AWS Crabbox: run `run_599a649ec9a9`, lease `cbx_68e04ba4e9b6`; 96/96 tests, CLI and launcher smokes, and build passed; the lease was released.
- Fresh autoreview: no findings.
- Independent review: no findings; the private owner-local helper is the best fix.
