### PR TITLE
test(gateway): align title prewarm expectations

### DIFF
--- a/src/gateway/server.sessions.list-store-materialization.test.ts
+++ b/src/gateway/server.sessions.list-store-materialization.test.ts
@@ -95,7 +95,7 @@ test("sessions.list discovers store targets at most once per agent", async () =>
   }
 });
 
-test("startup prewarm fills session snapshot and title caches before the first list", async () => {
+test("startup prewarm fills the session snapshot while titles remain request-driven", async () => {
   const { storePath } = await createSessionStoreDir();
   const sessionKey = "agent:main:warm-cache";
   const sessionId = "warm-cache";
@@ -145,7 +145,7 @@ test("startup prewarm fills session snapshot and title caches before the first l
     await vi.advanceTimersToNextTimerAsync();
     await sessionPrewarm;
     sidecar.stop();
-    expect(titleBatchSpy).toHaveBeenCalled();
+    expect(titleBatchSpy).not.toHaveBeenCalled();
     expect(titlePageSpy).not.toHaveBeenCalled();
     titleBatchSpy.mockClear();
     titlePageSpy.mockClear();
@@ -163,7 +163,7 @@ test("startup prewarm fills session snapshot and title caches before the first l
     });
 
     expect(result.ok).toBe(true);
-    expect(titleBatchSpy).not.toHaveBeenCalled();
+    expect(titleBatchSpy).toHaveBeenCalled();
     expect(titlePageSpy).not.toHaveBeenCalled();
     const afterListEntries = sessionAccessor.listSessionEntriesReadOnly({
       agentId: "main",


### PR DESCRIPTION
## Summary

- align the session-list cache test with request-driven derived titles
- assert startup prewarm does not read transcript titles
- assert an explicit `includeDerivedTitles` request performs the title batch read

## What Problem This Solves

`5b843e1c3f0c65e3b7236f9afad2d8ea45b1ddb4` intentionally changed gateway startup prewarm to use `includeDerivedTitles: false`, but `server.sessions.list-store-materialization.test.ts` retained the previous expectation that startup must populate the title cache. The exact-main CI failure is visible in `checks-node-compact-small-3` from run 31550358169.

This is a test-contract correction only. Production behavior remains unchanged.

## Evidence

- Current-main synchronization: signed+DCO head `9de3ed79170a0dd373e8a1a282f008bf2f4ed5e4` includes `main@9dfc26ba63eb2d7e78bbd9d676a358f70751f95b`; the PR diff remains one test file at `+3/-3`.
- Exact red-to-green reproduction on the PR parent and head:

```text
$ git checkout ff73a14f5ae71a899e5db9a3a41718ab1d104517
$ node scripts/run-vitest.mjs src/gateway/server.sessions.list-store-materialization.test.ts \
    -t 'startup prewarm fills session snapshot and title caches before the first list'

FAIL gateway-server src/gateway/server.sessions.list-store-materialization.test.ts
AssertionError: expected "readSessionTranscriptTitleProbeBatch" to be called at least once
Test Files  1 failed (1)
Tests       1 failed | 4 skipped (5)
[test] FAILED (exit 1)
```

```text
$ git checkout 18c49c9be9e28d8662e31b9a80aaea816b1915d0
$ node scripts/run-vitest.mjs src/gateway/server.sessions.list-store-materialization.test.ts \
    -t 'startup prewarm fills the session snapshot while titles remain request-driven'

PASS gateway-server src/gateway/server.sessions.list-store-materialization.test.ts
Test Files  1 passed (1)
Tests       1 passed | 4 skipped (5)
Duration    20.19s
```

The mechanically synchronized current head was then revalidated against both affected test files:

```text
$ node scripts/run-vitest.mjs \
    src/gateway/server.sessions.list-store-materialization.test.ts \
    src/gateway/server-startup-handler-prewarm.test.ts

Test Files  2 passed (2)
Tests       12 passed (12)
[test] passed 1 Vitest shard in 28.27s
```

- reproduced the old assertion failure locally on the exact affected main behavior
- related gateway tests: 12/12 passed
- oxfmt: passed
- type-aware oxlint: 0 warnings, 0 errors
- `git diff --check`: passed
- TruffleHog: clean
- mandatory autoreview: no findings, patch correct (0.99 confidence)

AI-assisted: yes. The regression, intended behavior, and final test assertions were manually verified.
