### PR TITLE
fix(ui): preserve dynamic select values on first render

### DIFF
--- a/ui/src/pages/activity/view.test.ts
+++ b/ui/src/pages/activity/view.test.ts
@@ -147,4 +147,24 @@ describe("renderActivity", () => {
     );
     expect(meta).toContain("2m");
   });
+
+  it("reflects the active tool filter on first render", async () => {
+    await i18n.setLocale("en");
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    render(
+      renderActivity(
+        createProps({
+          entries: [createEntry({ toolName: "browser" })],
+          toolFilter: "browser",
+        }),
+      ),
+      container,
+    );
+
+    expect(container.querySelector<HTMLSelectElement>("select.settings-select")?.value).toBe(
+      "browser",
+    );
+  });
 });

--- a/ui/src/pages/activity/view.ts
+++ b/ui/src/pages/activity/view.ts
@@ -202,6 +202,7 @@ function renderEntry(props: ActivityProps, entry: ActivityEntry) {
 }
 
 export function renderActivity(props: ActivityProps) {
+  // The tool filter's .value commits before its mapped options exist, so options mark selection.
   const toolNames = resolveToolNames(props.entries);
   const filtered = filterEntries(props);
   const hasAnyFilters =
@@ -275,8 +276,15 @@ export function renderActivity(props: ActivityProps) {
               @change=${(event: Event) =>
                 props.onToolFilterChange((event.target as HTMLSelectElement).value)}
             >
-              <option value="">${t("activity.allTools")}</option>
-              ${toolNames.map((name) => html`<option value=${name}>${name}</option>`)}
+              <option value="" ?selected=${props.toolFilter === ""}>
+                ${t("activity.allTools")}
+              </option>
+              ${toolNames.map(
+                (name) =>
+                  html`<option value=${name} ?selected=${name === props.toolFilter}>
+                    ${name}
+                  </option>`,
+              )}
             </select>
           `,
         })}

--- a/ui/src/pages/channels/view.pairing.test.ts
+++ b/ui/src/pages/channels/view.pairing.test.ts
@@ -172,6 +172,23 @@ describe("channel DM access request views", () => {
     expect(container.querySelectorAll("select.settings-select")).toHaveLength(2);
   });
 
+  it("reflects both active pairing filters on first render", () => {
+    const container = renderInto(
+      renderChannelPairingQueue(
+        createProps({
+          pairingChannelFilter: "whatsapp",
+          pairingAccountFilter: "personal",
+        }),
+      ),
+    );
+
+    expect(
+      [...container.querySelectorAll<HTMLSelectElement>("select.settings-select")].map(
+        (select) => select.value,
+      ),
+    ).toEqual(["whatsapp", "personal"]);
+  });
+
   it("disables every request action while one mutation is active", () => {
     const secondRequest = {
       ...request,

--- a/ui/src/pages/channels/view.pairing.ts
+++ b/ui/src/pages/channels/view.pairing.ts
@@ -54,6 +54,7 @@ function renderFilters(props: ChannelsProps) {
     new Map(accounts.map((account) => [account.channel, account.channelLabel])).entries(),
   ).toSorted((left, right) => left[1].localeCompare(right[1]));
   const accountsForChannel = filteredAccounts(props);
+  // Filter .value bindings commit before mapped options exist, so options mark selection.
   return html`
     <div class="channels-pairing-filters">
       <label>
@@ -63,8 +64,15 @@ function renderFilters(props: ChannelsProps) {
           .value=${props.pairingChannelFilter ?? ""}
           @change=${(event: Event) => props.onPairingFilterChange(selectValue(event), null)}
         >
-          <option value="">${t("channels.pairing.allChannels")}</option>
-          ${channels.map(([channel, label]) => html`<option value=${channel}>${label}</option>`)}
+          <option value="" ?selected=${!props.pairingChannelFilter}>
+            ${t("channels.pairing.allChannels")}
+          </option>
+          ${channels.map(
+            ([channel, label]) =>
+              html`<option value=${channel} ?selected=${channel === props.pairingChannelFilter}>
+                ${label}
+              </option>`,
+          )}
         </select>
       </label>
       <label>
@@ -76,9 +84,17 @@ function renderFilters(props: ChannelsProps) {
           @change=${(event: Event) =>
             props.onPairingFilterChange(props.pairingChannelFilter, selectValue(event))}
         >
-          <option value="">${t("channels.pairing.allAccounts")}</option>
+          <option value="" ?selected=${!props.pairingAccountFilter}>
+            ${t("channels.pairing.allAccounts")}
+          </option>
           ${accountsForChannel.map(
-            (account) => html`<option value=${account.accountId}>${accountName(account)}</option>`,
+            (account) =>
+              html`<option
+                value=${account.accountId}
+                ?selected=${account.accountId === props.pairingAccountFilter}
+              >
+                ${accountName(account)}
+              </option>`,
           )}
         </select>
       </label>

--- a/ui/src/pages/debug/view.test.ts
+++ b/ui/src/pages/debug/view.test.ts
@@ -166,6 +166,24 @@ describe("renderDebug", () => {
     expect(container.textContent).toContain("gateway");
     expect(container.textContent).not.toContain("Invalid Date");
   });
+
+  it("reflects the selected Manual RPC method on first render", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderDebug(
+        createProps({
+          methods: ["status", "health"],
+          callMethod: "health",
+        }),
+      ),
+      container,
+    );
+
+    expect(container.querySelector<HTMLSelectElement>("select.settings-select")?.value).toBe(
+      "health",
+    );
+  });
 });
 
 describe("DebugPage", () => {

--- a/ui/src/pages/debug/view.ts
+++ b/ui/src/pages/debug/view.ts
@@ -118,6 +118,7 @@ export function renderDebug(props: DebugProps) {
     `,
   );
 
+  // The method's .value commits before its mapped options exist, so options mark selection.
   const rpcSection = renderSettingsSection(
     { title: t("debug.manualRpcTitle"), description: t("debug.manualRpcSubtitle") },
     html`
@@ -131,9 +132,13 @@ export function renderDebug(props: DebugProps) {
             @change=${(e: Event) => props.onCallMethodChange((e.target as HTMLSelectElement).value)}
           >
             ${!props.callMethod
-              ? html` <option value="" disabled>${t("debug.selectMethod")}</option> `
+              ? html` <option value="" disabled ?selected=${!props.callMethod}>
+                  ${t("debug.selectMethod")}
+                </option>`
               : nothing}
-            ${props.methods.map((m) => html`<option value=${m}>${m}</option>`)}
+            ${props.methods.map(
+              (m) => html`<option value=${m} ?selected=${m === props.callMethod}>${m}</option>`,
+            )}
           </select>
         `,
       })}


### PR DESCRIPTION
Related: #121811

AI-assisted: implemented and reviewed with Codex.

## What Problem This Solves

Fixes an issue where Control UI users open Activity, Debug, or Channels pairing filters with a persisted non-default value and the native select displays a different first option. The displayed filter can contradict the value used by the page.

## Why This Change Was Made

The affected mapped option lists are rendered after Lit commits the select `.value`, so the browser falls back to the first inserted option. Each affected option now declares its selected state from the authoritative page value. This is a narrow sibling follow-up to #121811, not a repo-wide native-select sweep; session-observer and model-providers are explicit non-goals.

## User Impact

Activity tool filtering, Debug manual RPC method selection, and Channels pairing channel/account filters correctly show the current value on first render.

## Evidence

Before the fix, production Lit/JSDOM rendering reproduced three deterministic failures: Activity `toolFilter=browser` rendered no selection, Debug `callMethod=health` rendered status, and pairing `channel=whatsapp` / `account=personal` rendered no selection.

After the change, the four focused suites passed 57/57. Formatting, oxlint, diff-check, Control UI production/test tsgo, and a production render probe passed. Commit-mode AutoReview was clean (real TruffleHog, 4.0s; zero findings).