### PR TITLE
fix(gateway): avoid cold title reads on first session list

### DIFF
--- a/src/gateway/server-startup-handler-prewarm.test.ts
+++ b/src/gateway/server-startup-handler-prewarm.test.ts
@@ -98,7 +98,7 @@ describe("scheduleGatewayHandlerPrewarm", () => {
         opts: {
           agentId: "main",
           configuredAgentsOnly: true,
-          includeDerivedTitles: false,
+          includeDerivedTitles: true,
           includeGlobal: true,
           includeUnknown: true,
           limit: 60,

--- a/src/gateway/server-startup-handler-prewarm.ts
+++ b/src/gateway/server-startup-handler-prewarm.ts
@@ -38,9 +38,7 @@ async function prewarmGatewaySessionListData(cfg: OpenClawConfig, agentId: strin
     opts: {
       agentId,
       configuredAgentsOnly: true,
-      // Transcript title probes can touch multi-gigabyte agent databases. Keep that optional
-      // decoration request-driven so an idle gateway does not spend minutes warming it.
-      includeDerivedTitles: false,
+      includeDerivedTitles: true,
       includeGlobal: true,
       includeUnknown: true,
       limit: SIDEBAR_SESSION_LIST_LIMIT,

--- a/src/gateway/server.sessions.list-store-materialization.test.ts
+++ b/src/gateway/server.sessions.list-store-materialization.test.ts
@@ -10,6 +10,7 @@ import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/sess
 import type { SessionEntry } from "../config/sessions/types.js";
 import { openOpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
 import { scheduleGatewayHandlerPrewarm } from "./server-startup-handler-prewarm.js";
+import type { SessionsListResult } from "./session-utils.types.js";
 import { testState, writeSessionStore } from "./test-helpers.js";
 import {
   directSessionReq,
@@ -95,7 +96,7 @@ test("sessions.list discovers store targets at most once per agent", async () =>
   }
 });
 
-test("startup prewarm fills the session snapshot before the first list", async () => {
+test("startup prewarm fills session snapshot and title caches before the first list", async () => {
   const { storePath } = await createSessionStoreDir();
   const sessionKey = "agent:main:warm-cache";
   const sessionId = "warm-cache";
@@ -114,6 +115,8 @@ test("startup prewarm fills the session snapshot before the first list", async (
     sessionKey,
     storePath,
   });
+  const titleBatchSpy = vi.spyOn(sessionAccessor, "readSessionTranscriptTitleProbeBatch");
+  const titlePageSpy = vi.spyOn(sessionAccessor, "readSessionTranscriptMessageEventPage");
   let sidecar: ReturnType<typeof scheduleGatewayHandlerPrewarm> | undefined;
   vi.useFakeTimers();
   try {
@@ -143,6 +146,10 @@ test("startup prewarm fills the session snapshot before the first list", async (
     await vi.advanceTimersToNextTimerAsync();
     await sessionPrewarm;
     sidecar.stop();
+    expect(titleBatchSpy).toHaveBeenCalled();
+    expect(titlePageSpy).not.toHaveBeenCalled();
+    titleBatchSpy.mockClear();
+    titlePageSpy.mockClear();
     vi.useRealTimers();
     const cachedEntries = sessionAccessor.listSessionEntriesReadOnly({
       agentId: "main",
@@ -151,9 +158,7 @@ test("startup prewarm fills the session snapshot before the first list", async (
       storePath,
     });
 
-    const result = await directSessionReq<{
-      sessions: Array<{ derivedTitle?: string; key?: string }>;
-    }>("sessions.list", {
+    const result = await directSessionReq<SessionsListResult>("sessions.list", {
       ...LIST_PARAMS,
       includeDerivedTitles: true,
     });
@@ -162,6 +167,8 @@ test("startup prewarm fills the session snapshot before the first list", async (
     expect(result.payload?.sessions).toContainEqual(
       expect.objectContaining({ key: sessionKey, derivedTitle: "Warm title" }),
     );
+    expect(titleBatchSpy).not.toHaveBeenCalled();
+    expect(titlePageSpy).not.toHaveBeenCalled();
     const afterListEntries = sessionAccessor.listSessionEntriesReadOnly({
       agentId: "main",
       clone: false,
@@ -172,6 +179,8 @@ test("startup prewarm fills the session snapshot before the first list", async (
   } finally {
     sidecar?.stop();
     vi.useRealTimers();
+    titleBatchSpy.mockRestore();
+    titlePageSpy.mockRestore();
   }
 });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the first dashboard session list after Gateway startup paid cold transcript-content reads for derived titles, even though startup had already completed its bounded session-list prewarm.

## Why This Change Was Made

Startup now includes derived titles in the existing 60-row prewarm, restoring the lower session snapshot and title-field cache contract without adding another read path. The existing 2,000-row admission gate and batched first/last-message title probe remain the bounds.

Root cause and provenance: #122358 changed only startup's `includeDerivedTitles` option to false and updated its mocked unit expectation. The canonical title batch owner did not move, so the owner-boundary regression continued to catch the first-list latency regression.

## User Impact

The first canonical session roster after startup can render its derived titles without another transcript-content probe. Normal watermark validation still keeps cached titles coherent.

## Evidence

- Pre-fix reproduction: `node scripts/run-vitest.mjs src/gateway/server.sessions.list-store-materialization.test.ts` failed because startup never called the title-probe batch.
- Focused regression passed three consecutive times after the repair: 5/5 tests each run.
- Sibling startup/list/cache proof passed: 101/101 tests across 6 files.
- `pnpm tsgo:core` passed.
- `pnpm tsgo:core:test` passed.
- Touched-file oxlint passed.
- Structured autoreview: clean, no accepted/actionable findings.
- Changed gate reached an unrelated current-main plugin-boundary baseline failure: one existing compatibility record is eligible for removal.

No changelog entry: internal startup latency repair.
