### PR TITLE
fix(logging): preserve sender IDs containing token-like suffixes

### DIFF
--- a/src/logging/redact-patterns.ts
+++ b/src/logging/redact-patterns.ts
@@ -184,7 +184,7 @@ export const DEFAULT_REDACT_PATTERNS: readonly string[] = [
   String.raw`(eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})`,
   String.raw`(pplx-[A-Za-z0-9_-]{10,})`,
   String.raw`(fal_[A-Za-z0-9_-]{10,})`,
-  String.raw`(fc-[A-Za-z0-9]{10,})`,
+  String.raw`${IDENTIFIER_SAFE_TOKEN_BOUNDARY}(fc-[A-Za-z0-9]{10,})`,
   String.raw`(bb_live_[A-Za-z0-9_-]{10,})`,
   String.raw`${BASE64_SAFE_TOKEN_BOUNDARY}(gAAAA[A-Za-z0-9_=-]{20,})`,
   String.raw`(sk_live_[A-Za-z0-9]{10,})`,

--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -1414,6 +1414,11 @@ describe("redactSensitiveText", () => {
     expect(output).toBe("r8_ABC…stuv");
   });
 
+  it("preserves an fc-shaped suffix embedded in a UUID", () => {
+    const profileId = "40cbc896-5872-4f9a-8bfc-21b3b0b25840";
+    expect(redactSensitiveText(profileId, { mode: "tools" })).toBe(profileId);
+  });
+
   it("masks expanded vendor-prefix token corpus", () => {
     const fireworksTokens = [
       { token: `fw-${"C".repeat(40)}`, redacted: "fw-CCC…CCCC" },


### PR DESCRIPTION
## What Problem This Solves

Fixes a silent transcript corruption where a random user-profile UUID whose fourth group ended in `fc` was mistaken for an embedded `fc-<12 hex>` credential. Transcript redaction persisted a truncated sender ID, so live events and RPC history could no longer resolve the sender profile or current avatar.

A v4 UUID hits this shape roughly once per 256 generated IDs. The same signature appeared in CI twice, including exact-head run 31556122073.

## Why This Change Was Made

The credential matcher now requires the existing identifier-safe left boundary before `fc-`. Standalone credentials remain masked by the existing vendor-token corpus test, while token-shaped substrings embedded in larger identifiers remain intact.

This fixes the producer boundary. It adds no Gateway fallback, retry, timeout increase, forced environment, or test-only production seam.

Production LOC: +1/-1 (net 0) | Tests: +5/-0

## User Impact

Legitimate sender/profile identifiers are no longer silently corrupted when they contain an embedded `fc-`-shaped suffix, so current sender avatar projection remains available across live events and transcript reads.

## Evidence

- Original failure: [CI 31556122073](https://github.com/openclaw/openclaw/actions/runs/31556122073), where `40cbc896-5872-4f9a-8bfc-21b3b0b25840` was persisted as `40cbc896-5872-4f9a-8b***` and the avatar was omitted.
- Deterministic owner regression: [Testbox 31556981503](https://github.com/openclaw/openclaw/actions/runs/31556981503) — 157/157 logging tests passed with the exact failing UUID.
- Full changed-file gate containing this identical two-file patch: [Testbox 31557411438](https://github.com/openclaw/openclaw/actions/runs/31557411438).
- Final branch autoreview is clean; `git diff --check` passes.

Provenance: PR #85196 introduced the unbounded matcher; PR #90552 later persisted arbitrary sender IDs through transcript redaction. CI 31298080981 previously hit the same 1-in-256 collision but it was misclassified as profile-state leakage.

The earlier context-engine compatibility repair from this branch landed independently as #122434 and is no longer part of this PR.
