### PR TITLE
fix(agents): treat malformed podman connection usernames as no machine match

### DIFF
--- a/src/agents/sandbox/podman-runtime.test.ts
+++ b/src/agents/sandbox/podman-runtime.test.ts
@@ -1,0 +1,90 @@
+// Podman runtime probe tests cover remote connection classification,
+// including malformed connection URIs reported by `podman system connection list`.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const podmanMocks = vi.hoisted(() => ({
+  execContainer: vi.fn(),
+}));
+
+vi.mock("./container-engine.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("./container-engine.js")>("./container-engine.js");
+  return {
+    ...actual,
+    execContainer: podmanMocks.execContainer,
+  };
+});
+
+const { resolvePodmanSandboxRuntimeInfo } = await import("./podman-runtime.js");
+
+function mockRemotePodmanProbe(connectionUri: string, remoteUsername = "user") {
+  podmanMocks.execContainer.mockImplementation(async (_engine: unknown, args: string[]) => {
+    if (args[0] === "info") {
+      return { code: 0, stdout: "true\ttrue\t\t5.2.0", stderr: "" };
+    }
+    if (args[0] === "system") {
+      return {
+        code: 0,
+        stdout: JSON.stringify([
+          {
+            Name: "podman-machine-default",
+            URI: connectionUri,
+            Default: true,
+            Identity: "",
+          },
+        ]),
+        stderr: "",
+      };
+    }
+    if (args[0] === "machine") {
+      return {
+        code: 0,
+        stdout: JSON.stringify([
+          {
+            Name: "podman-machine-default",
+            Running: true,
+            Port: 50321,
+            RemoteUsername: remoteUsername,
+            IdentityPath: "",
+          },
+        ]),
+        stderr: "",
+      };
+    }
+    return { code: 1, stdout: "", stderr: `unexpected podman args: ${args.join(" ")}` };
+  });
+}
+
+describe("resolvePodmanSandboxRuntimeInfo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.CONTAINER_HOST;
+    delete process.env.CONTAINER_CONNECTION;
+    delete process.env.CONTAINER_SSHKEY;
+  });
+
+  it("matches a Podman Machine connection with a percent-encoded username", async () => {
+    mockRemotePodmanProbe(
+      "ssh://user%40corp@127.0.0.1:50321/run/user/1000/podman/podman.sock",
+      "user@corp",
+    );
+
+    await expect(resolvePodmanSandboxRuntimeInfo()).resolves.toMatchObject({
+      machine: true,
+      rootless: true,
+      version: "5.2.0",
+    });
+  });
+
+  it("rejects a malformed connection username with the descriptive unsupported-connection error", async () => {
+    // WHATWG URL keeps a bare % in userinfo, so the probe sees "user%name".
+    mockRemotePodmanProbe("ssh://user%name@127.0.0.1:50321/run/user/1000/podman/podman.sock");
+
+    await expect(resolvePodmanSandboxRuntimeInfo()).rejects.toMatchObject({
+      code: "INVALID_CONFIG",
+      message: expect.stringContaining(
+        "Podman sandboxing supports a local Podman engine or Podman Machine",
+      ),
+    });
+  });
+});

--- a/src/agents/sandbox/podman-runtime.ts
+++ b/src/agents/sandbox/podman-runtime.ts
@@ -129,7 +129,15 @@ async function isPodmanMachineConnection(params: {
         ? String(machine.Port)
         : "";
     const portMatches = machinePort === uri.port;
-    const connectionUser = decodeURIComponent(uri.username);
+    // WHATWG URL parsing does not validate percent-escapes in userinfo, so a
+    // malformed username (e.g. "user%name") must fail soft like any other
+    // non-matching connection instead of throwing URIError out of the probe.
+    let connectionUser: string;
+    try {
+      connectionUser = decodeURIComponent(uri.username);
+    } catch {
+      return false;
+    }
     const rootConnection = params.selectedName === `${machineName}-root`;
     const userMatches =
       typeof machine.RemoteUsername === "string" &&


### PR DESCRIPTION
## Summary

`fix(agents): treat malformed podman connection usernames as no machine match so a bare % in the URI fails soft instead of crashing sandbox detection with a raw URIError`

## What Problem This Solves

When the Podman sandbox backend probes the active connection, it asks `podman system connection list` for the connection URI and checks whether that URI points at a local Podman Machine. The probe compares the URI's username against the machine's `RemoteUsername` after percent-decoding it.

A connection URI with a malformed percent escape in the username — one stray `%`, e.g. `ssh://user%name@127.0.0.1:50321/run/user/1000/podman/podman.sock` — is perfectly parseable by the WHATWG URL parser (it does not validate percent-escapes in userinfo), so the probe reaches `decodeURIComponent(uri.username)`, which throws `URIError: URI malformed`.

When that happens today, the user does not get the designed "unsupported connection" diagnostic: `resolvePodmanSandboxRuntimeInfo()` crashes with the raw `URIError`, and every caller that simply awaits it — the docker sandbox backend (`src/agents/sandbox/docker-backend.ts`), doctor sandbox checks — surfaces (or dies on) an opaque `URI malformed` that points nowhere near the offending connection.

**Code evidence**: in `src/agents/sandbox/podman-runtime.ts` (main, before this fix):

- `src/agents/sandbox/podman-runtime.ts:84-88` — `new URL(params.uri)` failure returns `false` (fail soft).
- `src/agents/sandbox/podman-runtime.ts:108-112` — `JSON.parse` of `podman machine list` output failure returns `false` (fail soft).
- `src/agents/sandbox/podman-runtime.ts:132` — `decodeURIComponent(uri.username)` was called **bare**. Any malformed escape throws `URIError` out of the boolean probe, breaking its fail-closed contract.

Minimal reproduction: point the active podman connection at `ssh://user%name@127.0.0.1:50321/...` and call `resolvePodmanSandboxRuntimeInfo()` — see Real Behavior Proof below.

## Root Cause

- Bug present since the probe entered current history in `8862cc46b3a` (2026-08-11).
- Violated invariant: `isPodmanMachineConnection` is a boolean classifier — its contract is "if the connection cannot be recognized as a local Podman Machine, return false". Every other unparseable-input path in it (bad URL, bad JSON, missing fields) already fails soft; the username decode was the single path that could throw, so one malformed character in an env/connection-config value escaped as an unhandled exception instead of a clean rejection.
- Trigger condition: the active podman connection (from `CONTAINER_HOST` or `podman system connection list`) has a username containing a `%` that is not valid percent-encoding, while `podman machine list` succeeds — realistic for hand-written `CONTAINER_HOST` values or connection names copied from docs.

## Why This Fix

- Option A: guard the decode inside the classifier and return `false` on failure (chosen) — restores the fail-closed contract exactly where it is violated; a malformed username deterministically behaves as "no machine match", and the caller surfaces the existing descriptive error (`Podman sandboxing supports a local Podman engine or Podman Machine...`, code `INVALID_CONFIG`).
- Option B: catch `URIError` in `resolvePodmanSandboxRuntimeInfo` and its callers — rejected: fixes the symptom at N call sites, and still treats a decode failure differently from every other non-match inside the classifier.
- Option C: pre-validate the username with a percent-encoding regex before decoding — rejected: duplicates rules `decodeURIComponent` already implements; a try/catch is the smaller, exact change.

Option A is the minimal change that makes all probe input paths equally throw-safe; two regression tests pin both directions (valid percent-encoded username still matches, malformed username fails soft).

## User Impact

- Affected scenario: using the Podman sandbox backend with a connection URI whose username contains a stray `%` (hand-written `CONTAINER_HOST`, copied connection configs).
- Before: sandbox setup / doctor crashes with `URIError: URI malformed` and no indication of which connection or field caused it.
- After: the connection is rejected with the intended diagnostic, e.g. `Podman sandboxing supports a local Podman engine or Podman Machine, but the active Podman connection is remote or could not be identified. Use the SSH sandbox backend for a remote host.` (code `INVALID_CONFIG`).
- Behavior change: malformed usernames now behave identically to any other non-matching connection; valid connections (including legitimately percent-encoded usernames like `user%40corp`) are unaffected.

## Real Behavior Proof

No mocks of the module under test: the proof drives the real exported `resolvePodmanSandboxRuntimeInfo` (`src/agents/sandbox/podman-runtime.ts`) end to end. The only fake is the process boundary — a `podman.cmd` placed first on `PATH` that answers `info` / `system connection list` / `machine list` with fixed payloads describing a Podman Machine whose connection URI has a bare `%` in the username (`ssh://user%name@127.0.0.1:50321/...`).

### Before (on main)

```bash
$ node --import tsx proof-podman-uri-decode.mjs   # main: decodeURIComponent(uri.username) bare
[proof] connection URI reported by podman: ssh://user%name@127.0.0.1:50321/run/user/1000/podman/podman.sock
[proof] WHATWG URL keeps the bare %: username=user%name
[proof] rejected: URIError: URI malformed (code=none)
[proof] RESULT: FAIL - a raw URIError escaped the fail-closed probe instead of the descriptive unsupported-connection error
exit=1
```

### After (with fix)

```bash
$ node --import tsx proof-podman-uri-decode.mjs   # HEAD: guarded decode -> no machine match
[proof] connection URI reported by podman: ssh://user%name@127.0.0.1:50321/run/user/1000/podman/podman.sock
[proof] WHATWG URL keeps the bare %: username=user%name
[proof] rejected: Error: Podman sandboxing supports a local Podman engine or Podman Machine, but the active Podman connection is remote or could not be identified. Use the SSH sandbox backend for a remote host. (code=INVALID_CONFIG)
[proof] RESULT: PASS - malformed connection username treated as no machine match and rejected with the descriptive INVALID_CONFIG error
exit=0
```

## Tests and Validation

- `node node_modules/vitest/vitest.mjs run src/agents/sandbox/podman-runtime.test.ts` — 4/4 tests passed (both `agents-core` and `agents-support` projects), including the new regression tests:
  - `matches a Podman Machine connection with a percent-encoded username` (`user%40corp` → matches `user@corp`, resolves normally);
  - `rejects a malformed connection username with the descriptive unsupported-connection error` (`user%name` → `INVALID_CONFIG`, no `URIError`).
- Manual verification (the proof above):
  1. On main, `resolvePodmanSandboxRuntimeInfo()` throws `URIError` for a connection URI with a bare `%` in the username — FAIL.
  2. With the fix, the same setup rejects with the descriptive `INVALID_CONFIG` error, and a valid percent-encoded username still matches — PASS.
