### PR TITLE
test(config): drop duplicate runtime migration probe

### DIFF
--- a/src/config/io.compat.test.ts
+++ b/src/config/io.compat.test.ts
@@ -1,13 +1,11 @@
 // Verifies config IO compatibility loading and migration behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { beforeAll, describe, expect, it, vi } from "vitest";
-import { normalizeCompatibilityConfigValues } from "../commands/doctor/shared/legacy-config-core-migrate.js";
+import { describe, expect, it, vi } from "vitest";
 import { VERSION } from "../version.js";
 import { createConfigIO } from "./io.js";
 import { normalizeExecSafeBinProfilesInConfig } from "./normalize-exec-safe-bin.js";
 import { withTempHome } from "./test-helpers.js";
-import type { OpenClawConfig } from "./types.openclaw.js";
 
 async function writeConfig(
   home: string,
@@ -30,29 +28,6 @@ function createIoForHome(home: string, env: NodeJS.ProcessEnv = {} as NodeJS.Pro
 }
 
 describe("config io paths", () => {
-  let whatsappSharedAccessDefaults: unknown;
-
-  beforeAll(() => {
-    const migrated = normalizeCompatibilityConfigValues({
-      channels: {
-        whatsapp: {
-          enabled: true,
-          dmPolicy: "allowlist",
-          allowFrom: ["+15550001111"],
-          groupPolicy: "open",
-          groupAllowFrom: [],
-          accounts: {
-            work: {
-              enabled: true,
-              authDir: "/tmp/wa-work",
-            },
-          },
-        },
-      },
-    } as OpenClawConfig);
-    whatsappSharedAccessDefaults = migrated.config.channels?.whatsapp?.accounts?.default;
-  });
-
   it("uses ~/.openclaw/openclaw.json when config exists", async () => {
     await withTempHome(async (home) => {
       const configPath = await writeConfig(home, ".openclaw", 19001);
@@ -334,14 +309,5 @@ describe("config io paths", () => {
       },
     });
     expect(cfg.agents?.list?.[0]?.tools?.exec?.safeBinTrustedDirs).toEqual(["/ops/bin"]);
-  });
-
-  it("moves WhatsApp shared access defaults into accounts.default during runtime compat", () => {
-    expect(whatsappSharedAccessDefaults).toEqual({
-      dmPolicy: "allowlist",
-      allowFrom: ["+15550001111"],
-      groupPolicy: "open",
-      groupAllowFrom: [],
-    });
   });
 });


### PR DESCRIPTION
## Summary

- remove an expensive config-I/O test that directly invoked the Doctor legacy-migration owner in `beforeAll`
- retain the stronger canonical Doctor migration test, which checks root-field removal, `accounts.default`, named-account inheritance, and the migration diagnostic
- remove no production coverage or behavior; this is a test-only ownership cleanup

## Test audit evidence

The removed case had stopped exercising `loadConfig()` in `0a670a058db` and became a direct call to `normalizeCompatibilityConfigValues`. Its exact WhatsApp fixture is covered more strongly by `src/commands/doctor-legacy-config.migrations.test.ts`.

Before/after cold Node 24 focused measurements on the same orb and commit base:

| Metric | Before | After | Improvement |
|---|---:|---:|---:|
| Vitest duration | 131.97s | 12.80s | 90.3% |
| Tests phase | 119.61s | 3.36s | 97.2% |
| Command wall | 138.89s | 19.34s | 86.1% |
| Tests | 16 | 15 | duplicate removed |

The immediately preceding hosted exact-head baseline was 66.00s for this file.

## Validation

- `node scripts/run-vitest.mjs src/config/io.compat.test.ts --maxWorkers=1 --reporter=verbose` — 15/15 passed
- retained owner test filter — 1/1 passed (`preserves inherited WhatsApp access policy when seeding accounts.default`)
- `oxfmt --check src/config/io.compat.test.ts`
- `node scripts/run-oxlint.mjs src/config/io.compat.test.ts`
- `git diff --check`
- changed-gate dry run: `coreTests` only
- autoreview TruffleHog preflight: clean; Codex executable unavailable in this environment
