### PR TITLE
fix(feishu): prevent silent replies after rejected card sends

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"71bba45fd19e23bdcad65dc617c22dbdfc7b3c2957b7aec28fd470f4d98de9e1","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}
+{"contentHash":"d9424f2e2712b7b32a8ffc657db9f4906150596a76a8ec2e655606b7e966fd5c","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"d9424f2e2712b7b32a8ffc657db9f4906150596a76a8ec2e655606b7e966fd5c","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}
+{"contentHash":"1fb3a95f1056d0e4f8bdaecdfb383109751f077ce5cbd6ed081bae9ffe120b15","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
@@ -1,1 +1,1 @@
-{"contentHash":"e0f0d842ad89e78e3f40e545821fc39a3fccbdb43f592f8d298dae35b197f792","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
+{"contentHash":"944bdc5e974956432708b812f77f04a70c0bfc87b5ca841ad4fb80c82cb27c62","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
@@ -1,1 +1,1 @@
-{"contentHash":"944bdc5e974956432708b812f77f04a70c0bfc87b5ca841ad4fb80c82cb27c62","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
+{"contentHash":"d2f39a774195cb48a2498568667ee8542592001c132d4edb954fbd3279e66523","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"4b54a0f38cb2d46ac2446e6ec7003fddbe1cbe19d8b34d28354b91cb70293f02","entrypoint":"agent-runtime","importSpecifier":"openclaw/plugin-sdk/agent-runtime"}
+{"contentHash":"c914f8eca80ecd66a1bc34988de3525ec607e40b167a6b332b943e9345109df2","entrypoint":"agent-runtime","importSpecifier":"openclaw/plugin-sdk/agent-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-core.json
@@ -1,1 +1,1 @@
-{"contentHash":"970f98d008137e204aed058afc38196a2f4862ccfcaf0b1aeb35fc565060e80d","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}
+{"contentHash":"a18b200ddecb75a3b399846b115d7225f30ae26c0ec877193f5082a3cfbaf146","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-core.json
@@ -1,1 +1,1 @@
-{"contentHash":"a18b200ddecb75a3b399846b115d7225f30ae26c0ec877193f5082a3cfbaf146","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}
+{"contentHash":"bd814130d3cc1294e6dadbb01fa099f3af5698f2518fecd0fd550e1eca88c7ea","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
@@ -1,1 +1,1 @@
-{"contentHash":"a1f13d0608db5e34ac8a96d65522063ad164f04779905aa95263c6a95ddd8477","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}
+{"contentHash":"b5f714cea554014abea631dd6a5640fca6df123e004dc7366805b7eb64b75824","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
@@ -1,1 +1,1 @@
-{"contentHash":"b5f714cea554014abea631dd6a5640fca6df123e004dc7366805b7eb64b75824","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}
+{"contentHash":"80714e47ec939526cd34ccf9e6730633230590e8761f33df1214b07c2223fe43","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-inbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-inbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"1934d2e58a1139d5f0fe9b69d231a9b1140a0a9f00f13c44ef36926e99d6d0cc","entrypoint":"channel-inbound","importSpecifier":"openclaw/plugin-sdk/channel-inbound"}
+{"contentHash":"ecae19435235f0a77d8f72fd7cb948b022076bad1199f1a3c5d2ebb1378a08e3","entrypoint":"channel-inbound","importSpecifier":"openclaw/plugin-sdk/channel-inbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-message.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-message.json
@@ -1,1 +1,1 @@
-{"contentHash":"175b8866474bbfb872445e0201b11ea0e2d12ee53c58318d936644898dc4e65f","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}
+{"contentHash":"d3d9faf1f55443db1cc34d619d4deb4bfeb9f3654ebf0ad9f7c192c6a6df5c32","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-message.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-message.json
@@ -1,1 +1,1 @@
-{"contentHash":"f8c7d30e1606d19045fa79d6fad7713cdad0c0da719586fd083630c97caa7a48","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}
+{"contentHash":"175b8866474bbfb872445e0201b11ea0e2d12ee53c58318d936644898dc4e65f","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"7b9539b83b719a681f4ad601650bd4eda9d313e2cbc1d8f2caa18429e3204f6e","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}
+{"contentHash":"21099d95b90792aff709b0b306857bb0ea2df56719c1938b85a34875f9631374","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"21099d95b90792aff709b0b306857bb0ea2df56719c1938b85a34875f9631374","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}
+{"contentHash":"5ccdac0497cd6abe466df75160177fb7636ba17bdaf2bfa17a7ec156dadad542","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-pairing.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-pairing.json
@@ -1,1 +1,1 @@
-{"contentHash":"7375a14d1a2ead1dce9d13bc9a6c5c94dc7e809cde37860a7ace9fce480b6751","entrypoint":"channel-pairing","importSpecifier":"openclaw/plugin-sdk/channel-pairing"}
+{"contentHash":"e0dd681327b90f1eff59ed34076690197454c64b9e1d71dd2738616a3b0c1be6","entrypoint":"channel-pairing","importSpecifier":"openclaw/plugin-sdk/channel-pairing"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
@@ -1,1 +1,1 @@
-{"contentHash":"aa85b1b210ded13f31f69d8656775aa3f12c86bfd4feeaa45477227891e5ddf9","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}
+{"contentHash":"38bb18bf746cc9011af8d31f6983510ab4dec4ff2791722133445d8b0520adf8","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
@@ -1,1 +1,1 @@
-{"contentHash":"0912d9c29be111d7899d426420841f63efd4b59f2c905d0b0f676522987a7435","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}
+{"contentHash":"aa85b1b210ded13f31f69d8656775aa3f12c86bfd4feeaa45477227891e5ddf9","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}

--- a/docs/.generated/plugin-sdk-api-baseline/core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/core.json
@@ -1,1 +1,1 @@
-{"contentHash":"dab3cc4ad5d01284c3458191168aad2eb829731334b5c2bc58909eed9df05a7f","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}
+{"contentHash":"59d79a7ed3adb85fef00f4a99349d9a56a498380ede34c6c79e9c89808a3e531","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}

--- a/docs/.generated/plugin-sdk-api-baseline/core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/core.json
@@ -1,1 +1,1 @@
-{"contentHash":"59d79a7ed3adb85fef00f4a99349d9a56a498380ede34c6c79e9c89808a3e531","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}
+{"contentHash":"08207f64d7b3b527a96362ea48b14da26eb651d5ea3f0e954bbca8212a7ffac7","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}

--- a/docs/.generated/plugin-sdk-api-baseline/discord.json
+++ b/docs/.generated/plugin-sdk-api-baseline/discord.json
@@ -1,1 +1,1 @@
-{"contentHash":"1aee60635c4552486cdd7a14e9767d39aef9ba90e38db8064a4bfa8d68ab8df3","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}
+{"contentHash":"0ff28c6d83574dbf441a185483c2986a75ea5c03f7d6103bd09014c6736cea81","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}

--- a/docs/.generated/plugin-sdk-api-baseline/discord.json
+++ b/docs/.generated/plugin-sdk-api-baseline/discord.json
@@ -1,1 +1,1 @@
-{"contentHash":"0ff28c6d83574dbf441a185483c2986a75ea5c03f7d6103bd09014c6736cea81","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}
+{"contentHash":"bb97ceaa2ea06165f5e09e15111362d2a195f48061221f200e8dfbdd49ce7721","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}

--- a/docs/.generated/plugin-sdk-api-baseline/error-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/error-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"1f61b7d845d0172c62a5413cd96559796dbe338b38866f91782ff74485aef96e","entrypoint":"error-runtime","importSpecifier":"openclaw/plugin-sdk/error-runtime"}
+{"contentHash":"812c7b126d55432242cb8c7a7963c2b3a007ca176a70f7479bd215152fa4c5a9","entrypoint":"error-runtime","importSpecifier":"openclaw/plugin-sdk/error-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
+++ b/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
@@ -1,1 +1,1 @@
-{"contentHash":"285b0678bd77f4e3f65f791d85f140636eef9d27687ab67d87116a599d5c9d59","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}
+{"contentHash":"6771e9b345cc6308370dbdec3883d51cdaf7b2f77714a869fb425494553a6698","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}

--- a/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
+++ b/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
@@ -1,1 +1,1 @@
-{"contentHash":"12fcbb778c804d28f2cb15077026e97edc13250b55b8fe7934d4e50d1c184fe1","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}
+{"contentHash":"285b0678bd77f4e3f65f791d85f140636eef9d27687ab67d87116a599d5c9d59","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}

--- a/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"805c19a024cee0370a81b3b8d60a88276b7f2ccfc3288e3082184e6d0503b4cc","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}
+{"contentHash":"3bb5ae0c2879ac121c30ea65680035e50ebfa9af8e0dc64d92575d9bbeb84465","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"3bb5ae0c2879ac121c30ea65680035e50ebfa9af8e0dc64d92575d9bbeb84465","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}
+{"contentHash":"df27a43f81e729d3a77ef76fd1c232f8a80d1a5fba444033d356878dde2a1f97","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
@@ -1,1 +1,1 @@
-{"contentHash":"6dfd9cb4d5826da0bf2d2693aec0c14d96a3eee836c8fc9e93a204a319b9dec8","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}
+{"contentHash":"5e7bb6bcc720997dde65b4399bff3a621becd2a32df1c38354cab8e6cea46493","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
@@ -1,1 +1,1 @@
-{"contentHash":"90de46f1e0f51185b27f551eb1a90a5cba679927da65b45bccdd2adb88b7cff6","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}
+{"contentHash":"6dfd9cb4d5826da0bf2d2693aec0c14d96a3eee836c8fc9e93a204a319b9dec8","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"119c93c0cb51b0e10e4d188f9f302c940ef8b17dc29c1845b07c51a840d5d9ae","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}
+{"contentHash":"4501ce1160e2c3951097fd03cd79eab1332fe064a46485ceb520ad0c30bdf5b6","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"169d46618a3fe5095c199ed12ef6bba91f64ec0cac95003dba9b61639c1b4c06","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}
+{"contentHash":"119c93c0cb51b0e10e4d188f9f302c940ef8b17dc29c1845b07c51a840d5d9ae","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"a3de84d3dade23b4808497128f5c2c51e3be5f924231288f1b67bc920fd8b773","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
+{"contentHash":"06f1edba8de8d6976d0118b7817c9df243279abf2c3891d1cbab447298286788","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"ffa80d2beeb2d3b6e3aff7520da7fa500b2b91d4466b636ea546096472d15e44","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
+{"contentHash":"a3de84d3dade23b4808497128f5c2c51e3be5f924231288f1b67bc920fd8b773","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/reply-dispatch-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/reply-dispatch-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"a41c05428a9a5430b2d81ed310aa5efcbeddcef7573adfd8af5ec415bfbbba97","entrypoint":"reply-dispatch-runtime","importSpecifier":"openclaw/plugin-sdk/reply-dispatch-runtime"}
+{"contentHash":"c4d79d67f095a7e1210b5a68f91aa7626e1c98be4fe3109301b735a3195ffd0b","entrypoint":"reply-dispatch-runtime","importSpecifier":"openclaw/plugin-sdk/reply-dispatch-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/reply-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/reply-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"74f042e649fe9ad18cee1eb327622b526636b470e7c230c2e280e11e990c7764","entrypoint":"reply-runtime","importSpecifier":"openclaw/plugin-sdk/reply-runtime"}
+{"contentHash":"21d4ae1e98b51930c6ce3329f561834d2cc95de1a0bff173a16a6e16c98fc063","entrypoint":"reply-runtime","importSpecifier":"openclaw/plugin-sdk/reply-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/runtime-store.json
+++ b/docs/.generated/plugin-sdk-api-baseline/runtime-store.json
@@ -1,1 +1,1 @@
-{"contentHash":"9a243e9ff6e6512ef4b635ed503159631e4e000a5dbc4d7743ffd091dfb1ef1d","entrypoint":"runtime-store","importSpecifier":"openclaw/plugin-sdk/runtime-store"}
+{"contentHash":"3ff1ef682530f2aa06b7e66050974d4c6075d5d658f1c864e8e0a9564f08f5dc","entrypoint":"runtime-store","importSpecifier":"openclaw/plugin-sdk/runtime-store"}

--- a/docs/.generated/plugin-sdk-api-baseline/session-catalog.json
+++ b/docs/.generated/plugin-sdk-api-baseline/session-catalog.json
@@ -1,1 +1,1 @@
-{"contentHash":"382193e8ef6f05d7bc0d872abefba471c374737bcc86db3810be780b893b72b4","entrypoint":"session-catalog","importSpecifier":"openclaw/plugin-sdk/session-catalog"}
+{"contentHash":"d28dd998c4b7073d37043bdbad8ec18b9aa5f894abb627e888c6788cb60afc37","entrypoint":"session-catalog","importSpecifier":"openclaw/plugin-sdk/session-catalog"}

--- a/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
+++ b/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
@@ -1,1 +1,1 @@
-{"contentHash":"14e690663ce3426b199897c3e08bc8fcde45e3ef34d52acf8ae55d5e837eb738","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}
+{"contentHash":"3a3b7a919d953df1be5c4f3b24035439a146c65ead4001c502c7e07f685eba9e","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}

--- a/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
+++ b/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
@@ -1,1 +1,1 @@
-{"contentHash":"3a3b7a919d953df1be5c4f3b24035439a146c65ead4001c502c7e07f685eba9e","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}
+{"contentHash":"80e073d1eb72f917d145dc757a9404f3ed706772a0d9abaaa14fd0c891258008","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}

--- a/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
+++ b/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
@@ -1,1 +1,1 @@
-{"contentHash":"886fac651c8ee8a85ea50cc883c475a966b66d91e7e65f01b08c995c20e8add7","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}
+{"contentHash":"02eab28d6d725bff297f827d416aad297b052ec4f30b091a704b65a0a324accc","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}

--- a/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
+++ b/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
@@ -1,1 +1,1 @@
-{"contentHash":"02eab28d6d725bff297f827d416aad297b052ec4f30b091a704b65a0a324accc","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}
+{"contentHash":"b907989ccbf2c8f5748d8fb0c12bb0ceafb80a33a0b696fb6f023b53021584b1","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}

--- a/docs/cli/audit.md
+++ b/docs/cli/audit.md
@@ -196,12 +196,15 @@ optional delivery kind, failure stage, duration, result count, normalized
 reason code, and keyed account/conversation/message/target pseudonyms. The
 current inbound boundary covers accepted messages that reach core dispatch,
 including core duplicate and terminal processing outcomes. The outbound
-boundary writes one terminal row per original logical reply payload that reaches
-shared durable delivery; chunking and adapter fan-out are aggregated in
-`resultCount`. Queued retryable or ambiguous sends are recorded only after an
-acknowledgement, dead letter, or reconciliation makes the outcome terminal.
-Plugin-local and direct-send paths that bypass those shared boundaries are not
-yet covered; absence of a row does not prove that no message existed.
+boundary covers shared durable delivery and settled direct channel-turn
+failures. A rejected final therefore leaves inbound processing completed and
+writes a separate outbound failure row. Durable delivery writes one terminal
+row per original logical reply payload; chunking and adapter fan-out are
+aggregated in `resultCount`. Queued retryable or ambiguous sends are recorded
+only after an acknowledgement, dead letter, or reconciliation makes the outcome
+terminal. Other plugin-local and direct-send paths that bypass those shared
+boundaries are not yet covered; absence of a row does not prove that no message
+existed.
 
 The audit ledger does not replace transcripts, task history, cron run history,
 or logs. It provides a small cross-run index for operator questions without

--- a/docs/gateway/audit.md
+++ b/docs/gateway/audit.md
@@ -167,11 +167,13 @@ Two authoritative boundaries produce message records:
 
 - **Inbound** rows are written when an accepted message reaches core dispatch,
   including duplicate and terminal processing outcomes.
-- **Outbound** rows are written when shared durable delivery reaches a
-  terminal outcome: sent, suppressed, failed, or an explicit `unknown` for
-  crash-ambiguous sends. Queue recovery and dead-letter outcomes are included.
-  Each original logical reply payload gets one terminal row; chunking and
-  adapter fan-out aggregate into `resultCount`.
+- **Outbound** rows are written when shared durable delivery, or a direct
+  channel-turn delivery failure, reaches a terminal outcome: sent, suppressed,
+  failed, or an explicit `unknown` for crash-ambiguous sends. Queue recovery
+  and dead-letter outcomes are included. A direct final rejection is recorded
+  separately from the successful inbound processing row. Each original logical
+  reply payload gets one terminal row where per-payload identity is available;
+  chunking and adapter fan-out aggregate into `resultCount`.
 
 ### Conversation-kind classification
 

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -845,14 +845,16 @@ describes the effective payload after hooks and rendering; suppressed or
 crash-ambiguous rows omit it.
 
 Current message coverage includes accepted inbound messages that reach core
-dispatch, including core duplicate/terminal outcomes. Outbound coverage writes
-one terminal row per original logical reply payload that reaches shared durable
-delivery; chunking and adapter fan-out are aggregated in `resultCount`. Queued
-retryable or ambiguous sends are recorded only after acknowledgement, dead
-letter, or reconciliation. Plugin-local and direct-send paths that bypass those
-shared boundaries are not yet covered. The bounded worker queue is best-effort
-and may drop records on failure or saturation, so this surface is not a
-lossless compliance archive.
+dispatch, including core duplicate/terminal outcomes. Outbound coverage
+includes shared durable delivery and settled direct channel-turn failures. A
+rejected final keeps the inbound processing row completed and produces a
+separate outbound failure row. Durable delivery writes one terminal row per
+original logical reply payload; chunking and adapter fan-out are aggregated in
+`resultCount`. Queued retryable or ambiguous sends are recorded only after
+acknowledgement, dead letter, or reconciliation. Other plugin-local and
+direct-send paths that bypass those shared boundaries are not yet covered. The
+bounded worker queue is best-effort and may drop records on failure or
+saturation, so this surface is not a lossless compliance archive.
 
 Recording is on by default and controlled by
 [`logging.audit.enabled`](/gateway/configuration-reference#audit). Message

--- a/docs/plugins/sdk-channel-inbound.md
+++ b/docs/plugins/sdk-channel-inbound.md
@@ -173,6 +173,22 @@ identity, then keeps the delivery failed so callers do not mistake partial
 success for a clean send. Do not report `visibleReplySent: false` after any
 preview, draft, attachment, or final message became visible.
 
+After final delivery settles, `dispatchResult.deliveryTerminal`, when present,
+reports the redacted recipient-visible outcome:
+
+| Outcome           | Meaning                                                                                                                                                   |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `delivered`       | The final delivery completed successfully.                                                                                                                |
+| `failed`          | Core proved no recipient-visible send began. `retryable` preserves the `PlatformMessageNotDispatchedError` disposition; permanent rejections use `false`. |
+| `partial_failure` | A preview, draft, attachment, or final message became visible before a later failure. It is never automatically retryable.                                |
+| `unknown`         | Core cannot prove whether a provider-visible send began. It is not safe to replay automatically.                                                          |
+
+Only the optional, explicitly redacted `publicError.code` from
+`PlatformMessageNotDispatchedError` can appear as `deliveryTerminal.error.code`.
+Raw causes and provider responses never cross this boundary. Do not use
+`PlatformMessageNotDispatchedError` to turn an ambiguous send into `failed`;
+leave it unmarked so core preserves the `unknown` outcome.
+
 When `reply_payload_sending` or `message_sending` is registered, those hooks
 must settle before anything provider-visible is created because either hook
 can rewrite or cancel the logical payload. An eager native preview would leak

--- a/docs/plugins/sdk-channel-outbound.md
+++ b/docs/plugins/sdk-channel-outbound.md
@@ -159,6 +159,14 @@ final dispatch boundary may make this assertion. Never use the marker after a
 finalization/send call begins or returns an ambiguous result; false marking can
 duplicate messages.
 
+`retryable` defaults to `true`; use that default only for a transient,
+authoritatively proven no-send failure. Set `retryable: false` for a permanent
+payload or policy rejection that must not be replayed. If the dispatch
+controller needs a provider code, pass only an explicitly redacted,
+provider-stable value as `publicError: { code }`. The raw `cause`, response,
+message, request identifiers, and credentials stay private to the adapter and
+must not be copied into `publicError`.
+
 ## Existing outbound adapters
 
 If the channel already has a compatible `outbound` adapter, derive the

--- a/extensions/feishu/src/bot.broadcast.test.ts
+++ b/extensions/feishu/src/bot.broadcast.test.ts
@@ -448,6 +448,7 @@ describe("broadcast dispatch", () => {
         queuedFinal: false,
         counts: { final: 0 },
         failedCounts: { tool: 0, block: 0, final: 1 },
+        deliveryTerminal: { outcome: "failed", retryable: false },
       });
     const ensureNoVisibleReplyFallback = vi.fn();
     mockCreateFeishuReplyDispatcher.mockReturnValueOnce({

--- a/extensions/feishu/src/bot.broadcast.test.ts
+++ b/extensions/feishu/src/bot.broadcast.test.ts
@@ -445,8 +445,8 @@ describe("broadcast dispatch", () => {
     mockDispatchReply
       .mockResolvedValueOnce({ queuedFinal: false, counts: { final: 1 } })
       .mockResolvedValueOnce({
-        queuedFinal: true,
-        counts: { final: 1 },
+        queuedFinal: false,
+        counts: { final: 0 },
         failedCounts: { tool: 0, block: 0, final: 1 },
       });
     const ensureNoVisibleReplyFallback = vi.fn();

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1210,6 +1210,7 @@ describe("handleFeishuMessage command authorization", () => {
         queuedFinal: false,
         counts: { tool: 0, block: 0, final: 0 },
         failedCounts: { tool: 0, block: 0, final: 1 },
+        noVisibleReplyFallbackEligible: true,
         deliveryTerminal: terminal,
       });
       const ensureNoVisibleReplyFallback = vi.fn();

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1178,6 +1178,7 @@ describe("handleFeishuMessage command authorization", () => {
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
       failedCounts: { tool: 0, block: 0, final: 1 },
+      deliveryTerminal: { outcome: "failed", retryable: false },
     });
     const ensureNoVisibleReplyFallback = vi.fn();
     mockCreateFeishuReplyDispatcher.mockReturnValueOnce({
@@ -1197,6 +1198,39 @@ describe("handleFeishuMessage command authorization", () => {
 
     expect(ensureNoVisibleReplyFallback).toHaveBeenCalledWith("dispatch-complete-no-visible-reply");
   });
+
+  it.each([
+    ["retryable", { outcome: "failed", retryable: true }],
+    ["partial", { outcome: "partial_failure", retryable: false }],
+    ["unknown", { outcome: "unknown", retryable: false }],
+  ] as const)(
+    "does not send no-visible fallback for a %s final outcome",
+    async (_name, terminal) => {
+      mockDispatchReplyFromConfig.mockResolvedValueOnce({
+        queuedFinal: false,
+        counts: { tool: 0, block: 0, final: 0 },
+        failedCounts: { tool: 0, block: 0, final: 1 },
+        deliveryTerminal: terminal,
+      });
+      const ensureNoVisibleReplyFallback = vi.fn();
+      mockCreateFeishuReplyDispatcher.mockReturnValueOnce({
+        dispatcherOptions: {},
+        delivery: { deliver: vi.fn(async () => undefined) },
+        replyOptions: {},
+        ensureNoVisibleReplyFallback,
+      });
+
+      await dispatchMessage({
+        cfg: createFeishuTestConfig({ dmPolicy: "open" }),
+        event: createFeishuTestEvent({
+          messageId: `msg-final-delivery-${_name}`,
+          senderOpenId: "ou-sender",
+        }),
+      });
+
+      expect(ensureNoVisibleReplyFallback).not.toHaveBeenCalled();
+    },
+  );
 
   it("uses refreshed config for dynamic agent dispatch", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1175,8 +1175,8 @@ describe("handleFeishuMessage command authorization", () => {
 
   it("sends no-visible fallback when queued final delivery fails", async () => {
     mockDispatchReplyFromConfig.mockResolvedValueOnce({
-      queuedFinal: true,
-      counts: { tool: 0, block: 0, final: 1 },
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
       failedCounts: { tool: 0, block: 0, final: 1 },
     });
     const ensureNoVisibleReplyFallback = vi.fn();

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -114,11 +114,11 @@ function shouldSendNoVisibleReplyFallback(dispatchResult: {
     dispatchResult.noVisibleReplyFallbackEligible === true &&
     dispatchResult.queuedFinal !== true &&
     finalCount === 0;
-  const queuedFinalFailed = dispatchResult.queuedFinal === true && failedFinalCount > 0;
+  const finalDeliveryFailed = failedFinalCount > 0;
   return (
     dispatchResult.sendPolicyDenied !== true &&
     dispatchResult.sourceReplyDeliveryMode !== "message_tool_only" &&
-    (emptyEligibleDispatch || queuedFinalFailed)
+    (emptyEligibleDispatch || finalDeliveryFailed)
   );
 }
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -102,19 +102,22 @@ const PERMISSION_ERROR_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
 
 function shouldSendNoVisibleReplyFallback(dispatchResult: {
   counts: { final?: number };
-  failedCounts?: { final?: number };
+  deliveryTerminal?:
+    | { outcome: "failed"; retryable: boolean }
+    | { outcome: "delivered" | "partial_failure" | "unknown" };
   noVisibleReplyFallbackEligible?: boolean;
   queuedFinal?: boolean;
   sendPolicyDenied?: boolean;
   sourceReplyDeliveryMode?: string;
 }): boolean {
   const finalCount = dispatchResult.counts.final ?? 0;
-  const failedFinalCount = dispatchResult.failedCounts?.final ?? 0;
   const emptyEligibleDispatch =
     dispatchResult.noVisibleReplyFallbackEligible === true &&
     dispatchResult.queuedFinal !== true &&
     finalCount === 0;
-  const finalDeliveryFailed = failedFinalCount > 0;
+  const finalDeliveryFailed =
+    dispatchResult.deliveryTerminal?.outcome === "failed" &&
+    !dispatchResult.deliveryTerminal.retryable;
   return (
     dispatchResult.sendPolicyDenied !== true &&
     dispatchResult.sourceReplyDeliveryMode !== "message_tool_only" &&

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -113,6 +113,7 @@ function shouldSendNoVisibleReplyFallback(dispatchResult: {
   const finalCount = dispatchResult.counts.final ?? 0;
   const emptyEligibleDispatch =
     dispatchResult.noVisibleReplyFallbackEligible === true &&
+    dispatchResult.deliveryTerminal === undefined &&
     dispatchResult.queuedFinal !== true &&
     finalCount === 0;
   const finalDeliveryFailed =

--- a/extensions/feishu/src/comment-shared.ts
+++ b/extensions/feishu/src/comment-shared.ts
@@ -1,3 +1,4 @@
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 // Feishu plugin module implements comment shared behavior.
 import { retryAsync } from "openclaw/plugin-sdk/retry-runtime";
 import {
@@ -78,17 +79,6 @@ function formatFeishuApiFailure(
   return `${errorPrefix}: ${details || "unknown error"}`;
 }
 
-function createFeishuApiError(
-  error: unknown,
-  errorPrefix: string,
-  options: {
-    includeConfigParams?: boolean;
-    includeNestedErrorLogId?: boolean;
-  } = {},
-): Error {
-  return new Error(formatFeishuApiFailure(error, errorPrefix, options), { cause: error });
-}
-
 const FEISHU_SEND_MAX_RETRIES = 2;
 const FEISHU_SEND_RETRY_BASE_MS = 500;
 
@@ -129,11 +119,22 @@ export async function requestFeishuApi<T>(
       },
     );
   } catch (error) {
+    const rateLimitCode = getFeishuSendRateLimitCode(error);
+    if (rateLimitCode !== undefined) {
+      throw new PlatformMessageNotDispatchedError(
+        formatFeishuApiFailure(error, errorPrefix, options),
+        {
+          cause: error,
+          retryable: true,
+          publicError: { code: String(rateLimitCode) },
+        },
+      );
+    }
     const rejection = createFeishuRejectedMessageApiError(error, errorPrefix);
-    if (rejection && getFeishuSendRateLimitCode(error) === undefined) {
+    if (rejection) {
       throw rejection;
     }
-    throw createFeishuApiError(error, errorPrefix, options);
+    throw new Error(formatFeishuApiFailure(error, errorPrefix, options), { cause: error });
   }
 }
 

--- a/extensions/feishu/src/comment-shared.ts
+++ b/extensions/feishu/src/comment-shared.ts
@@ -11,6 +11,7 @@ import {
   getFeishuSendRateLimitCode,
   getFeishuSendRateLimitCodeFromResponse,
 } from "./send-rate-limit.js";
+import { createFeishuRejectedMessageApiError } from "./send-result.js";
 
 export function encodeQuery(params: Record<string, string | undefined>): string {
   const query = new URLSearchParams();
@@ -128,6 +129,10 @@ export async function requestFeishuApi<T>(
       },
     );
   } catch (error) {
+    const rejection = createFeishuRejectedMessageApiError(error, errorPrefix);
+    if (rejection && getFeishuSendRateLimitCode(error) === undefined) {
+      throw rejection;
+    }
     throw createFeishuApiError(error, errorPrefix, options);
   }
 }

--- a/extensions/feishu/src/delivery-trace.test.ts
+++ b/extensions/feishu/src/delivery-trace.test.ts
@@ -609,6 +609,15 @@ describe("feishu producer custody boundaries", () => {
         ctxPayload: createTraceContext(),
         recordInboundSession: async () => undefined,
         dispatchReplyWithBufferedBlockDispatcher: async ({ dispatcherOptions }) => {
+          try {
+            await dispatcherOptions.deliver?.({ text: "the queued block" }, { kind: "block" });
+          } catch (blockError: unknown) {
+            expect(blockError).toMatchObject({
+              name: "PlatformMessageNotDispatchedError",
+              retryable: false,
+            });
+            await dispatcherOptions.onError?.(blockError, { kind: "block" });
+          }
           await dispatcherOptions.deliver?.(sourcePayload, { kind: "final" });
           return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
         },
@@ -635,6 +644,35 @@ describe("feishu producer custody boundaries", () => {
       await created.dispatcherOptions.onIdle?.();
       await created.dispatcherOptions.onIdle?.();
       expect(streamingStartBackoffUntilByAccount.has("main")).toBe(false);
+
+      created.dispatcherOptions.onCleanup?.();
+      traceState.messageResult = "identified";
+      const fresh = createFeishuReplyDispatcher({
+        cfg: {} as never,
+        agentId: "agent",
+        runtime: { log: () => {}, error: () => {} } as never,
+        chatId: "oc-trace-chat",
+        sendTarget: "oc-trace-chat",
+        ...dispatcherParams,
+      });
+      const freshDelivery = await fresh.delivery.deliver(
+        { text: "fresh independent turn" },
+        { kind: "final" },
+      );
+      await fresh.dispatcherOptions.onIdle?.();
+      if (!freshDelivery?.finalization) {
+        throw new Error("fresh streaming delivery did not expose finalization");
+      }
+      await expect(freshDelivery.finalization).resolves.toMatchObject({
+        visibleReplySent: true,
+        content: "fresh independent turn",
+      });
+      fresh.dispatcherOptions.onCleanup?.();
+      expect(
+        wireCalls.filter(
+          (call) => call.method === "im.message.reply" || call.method === "im.message.create",
+        ),
+      ).toHaveLength(2);
     },
   );
 

--- a/extensions/feishu/src/delivery-trace.test.ts
+++ b/extensions/feishu/src/delivery-trace.test.ts
@@ -13,10 +13,26 @@ import {
   type DeliveryTraceScenarioName,
   type WireRecorder,
 } from "openclaw/plugin-sdk/channel-contract-testing";
+import {
+  dispatchChannelInboundReply,
+  isChannelPartialDeliveryError,
+} from "openclaw/plugin-sdk/channel-inbound";
+import { setReplyPayloadMetadata } from "openclaw/plugin-sdk/reply-payload-testing";
 import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
-import { afterAll, afterEach, beforeAll, describe, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { FeishuConfigSchema } from "./config-schema.js";
+import { sendReplyOrFallbackDirect } from "./send.js";
 import type { ResolvedFeishuAccount } from "./types.js";
+
+const settlePendingFinalDeliveryMock = vi.hoisted(() =>
+  vi.fn(async (_completion: unknown, state: string) => ({ state })),
+);
+
+vi.mock("../../../src/infra/outbound/delivery-completion.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../src/infra/outbound/delivery-completion.js")>();
+  return { ...actual, settlePendingFinalDelivery: settlePendingFinalDeliveryMock };
+});
 
 type RecordedWireCall = Parameters<WireRecorder["recordWireCall"]>[0];
 type CreateFeishuReplyDispatcher =
@@ -34,6 +50,8 @@ type FeishuTraceState = {
   cardCount: number;
   setupCount: number;
   wireFaults: Array<{ fault: "rate-limit"; retryAfterMs: number }>;
+  messageResult: "identified" | "no-id";
+  failNextReplace: boolean;
 };
 
 const traceState = vi.hoisted(
@@ -47,6 +65,8 @@ const traceState = vi.hoisted(
     cardCount: 0,
     setupCount: 0,
     wireFaults: [],
+    messageResult: "identified",
+    failNextReplace: false,
   }),
 );
 
@@ -135,6 +155,10 @@ beforeAll(async () => {
   ({ streamingStartBackoffUntilByAccount } = await import("./reply-dispatcher-state.js"));
 });
 
+beforeEach(() => {
+  settlePendingFinalDeliveryMock.mockClear();
+});
+
 afterAll(() => {
   vi.doUnmock("./accounts.js");
   vi.doUnmock("./client.js");
@@ -171,11 +195,10 @@ function nextMessageId(): string {
 }
 
 function createRecordingLarkClient() {
-  const messageSendResult = (messageId: string) => ({
-    code: 0,
-    msg: "ok",
-    data: { message_id: messageId },
-  });
+  const messageSendResult = (messageId: string) =>
+    traceState.messageResult === "identified"
+      ? { code: 0, msg: "ok", data: { message_id: messageId } }
+      : { code: 0, msg: "ok", data: {} };
   return {
     im: {
       message: {
@@ -296,6 +319,14 @@ function createRecordingCardKitFetch(): typeof fetch {
       }
       if (wirePath.endsWith("/elements/content")) {
         const body = parseJsonRecord(init?.body);
+        if (traceState.failNextReplace) {
+          traceState.failNextReplace = false;
+          record(
+            { element: parseJsonRecord(body.element), sequence: body.sequence, uuid: body.uuid },
+            { status: 500 },
+          );
+          return jsonResponse({ code: 230099, msg: "replace rejected" }, 500);
+        }
         record(
           { element: parseJsonRecord(body.element), sequence: body.sequence, uuid: body.uuid },
           { code: 0 },
@@ -343,6 +374,8 @@ function setupFeishuTrace(recorder: WireRecorder, scenario: DeliveryTraceScenari
   traceState.reactionCount = 0;
   traceState.cardCount = 0;
   traceState.wireFaults = [];
+  traceState.messageResult = "identified";
+  traceState.failNextReplace = false;
   traceState.account = makeTraceAccount(scenario);
   traceState.larkClient = createRecordingLarkClient();
   traceState.cardKitFetch = createRecordingCardKitFetch();
@@ -406,6 +439,43 @@ const FEISHU_TRACE_SCENARIOS: readonly DeliveryTraceScenarioName[] = [
   "overflow-pagination",
 ];
 
+const pendingFinalCompletion = {
+  deliveryId: "delivery-feishu-custody",
+  intentId: "intent-feishu-custody",
+  sessionId: "session-feishu-custody",
+  sessionKey: "agent:agent:feishu:direct:oc-trace-chat",
+  storePath: "/tmp/feishu-custody-sessions.json",
+};
+
+function createTraceContext() {
+  return {
+    Body: "hello",
+    RawBody: "hello",
+    CommandBody: "hello",
+    CommandAuthorized: false,
+    From: "ou-sender",
+    To: "oc-trace-chat",
+    SessionKey: pendingFinalCompletion.sessionKey,
+    Provider: "feishu",
+    Surface: "feishu",
+  };
+}
+
+function expectDeliveredCustody() {
+  expect(settlePendingFinalDeliveryMock).toHaveBeenNthCalledWith(
+    1,
+    { kind: "pending-final", ...pendingFinalCompletion },
+    "unknown",
+    ["prepared", "queued"],
+  );
+  expect(settlePendingFinalDeliveryMock).toHaveBeenNthCalledWith(
+    2,
+    { kind: "pending-final", ...pendingFinalCompletion },
+    "delivered",
+    ["queued", "unknown"],
+  );
+}
+
 describe("feishu delivery trace goldens", () => {
   for (const scenarioName of FEISHU_TRACE_SCENARIOS) {
     it(`records ${scenarioName}`, async () => {
@@ -419,4 +489,125 @@ describe("feishu delivery trace goldens", () => {
       });
     });
   }
+});
+
+describe("feishu producer custody boundaries", () => {
+  it("settles an actual rejected message producer as permanent suppression", async () => {
+    const rejected = Object.assign(new Error("Request failed with status code 400"), {
+      response: {
+        status: 400,
+        data: { code: 230099, msg: "card table number over limit" },
+      },
+    });
+    const sourcePayload = setReplyPayloadMetadata(
+      { text: "the final answer" },
+      { pendingFinalDeliveryCompletion: pendingFinalCompletion },
+    );
+    const client = {
+      im: {
+        message: {
+          create: vi.fn(),
+          reply: vi.fn().mockRejectedValue(rejected),
+        },
+      },
+    };
+
+    await expect(
+      dispatchChannelInboundReply({
+        cfg: {},
+        channel: "feishu",
+        accountId: "main",
+        agentId: "agent",
+        routeSessionKey: pendingFinalCompletion.sessionKey,
+        storePath: pendingFinalCompletion.storePath,
+        ctxPayload: createTraceContext(),
+        recordInboundSession: async () => undefined,
+        dispatchReplyWithBufferedBlockDispatcher: async ({ dispatcherOptions }) => {
+          await dispatcherOptions.deliver?.(sourcePayload, { kind: "final" });
+          return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
+        },
+        delivery: {
+          deliver: async () =>
+            await sendReplyOrFallbackDirect(client, {
+              replyToMessageId: "om-inbound",
+              content: "{}",
+              msgType: "interactive",
+              directParams: {
+                receiveId: "oc-trace-chat",
+                receiveIdType: "chat_id",
+                content: "{}",
+                msgType: "interactive",
+              },
+              directErrorPrefix: "Feishu card send failed",
+              replyErrorPrefix: "Feishu card reply failed",
+            }),
+        },
+      }),
+    ).rejects.toMatchObject({ retryable: false, cause: rejected });
+
+    expect(settlePendingFinalDeliveryMock).toHaveBeenNthCalledWith(
+      2,
+      { kind: "pending-final", ...pendingFinalCompletion },
+      "suppressed",
+      ["prepared", "queued", "unknown"],
+    );
+    expect(client.im.message.reply).toHaveBeenCalledOnce();
+    expect(client.im.message.create).not.toHaveBeenCalled();
+  });
+
+  it("retains visible custody when no-ID preview disposition fails", async () => {
+    const wireCalls: RecordedWireCall[] = [];
+    traceState.recordWireCall = (call) => wireCalls.push(call);
+    traceState.messageCount = 0;
+    traceState.cardCount = 0;
+    traceState.messageResult = "no-id";
+    traceState.failNextReplace = true;
+    traceState.account = {
+      ...makeTraceAccount("final-only"),
+      config: FeishuConfigSchema.parse({ renderMode: "card", streaming: { mode: "partial" } }),
+    };
+    traceState.larkClient = createRecordingLarkClient();
+    traceState.cardKitFetch = createRecordingCardKitFetch();
+    const created = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: () => {}, error: () => {} } as never,
+      chatId: "oc-trace-chat",
+      sendTarget: "oc-trace-chat",
+      replyToMessageId: "om-inbound",
+    });
+    const sourcePayload = setReplyPayloadMetadata(
+      { text: "x".repeat(4001) },
+      { pendingFinalDeliveryCompletion: pendingFinalCompletion },
+    );
+
+    const error = await dispatchChannelInboundReply({
+      cfg: {},
+      channel: "feishu",
+      accountId: "main",
+      agentId: "agent",
+      routeSessionKey: pendingFinalCompletion.sessionKey,
+      storePath: pendingFinalCompletion.storePath,
+      ctxPayload: createTraceContext(),
+      recordInboundSession: async () => undefined,
+      dispatchReplyWithBufferedBlockDispatcher: async ({ dispatcherOptions }) => {
+        await dispatcherOptions.onReplyStart?.();
+        created.replyOptions.onPartialReply?.({ text: "accepted preview" });
+        await dispatcherOptions.deliver?.(sourcePayload, { kind: "final" });
+        return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
+      },
+      dispatcherOptions: created.dispatcherOptions,
+      replyOptions: created.replyOptions,
+      delivery: created.delivery,
+    }).catch((caught: unknown) => caught);
+
+    expect(isChannelPartialDeliveryError(error)).toBe(true);
+    expect(error).toMatchObject({
+      deliveryResult: { visibleReplySent: true, content: "accepted preview" },
+    });
+    expectDeliveredCustody();
+    expect(wireCalls.filter((call) => call.method === "im.message.reply")).toHaveLength(1);
+    expect(wireCalls.some((call) => call.method === "im.message.delete")).toBe(false);
+    expect(wireCalls.filter((call) => call.method.endsWith("/elements/content"))).toHaveLength(1);
+  });
 });

--- a/extensions/feishu/src/delivery-trace.test.ts
+++ b/extensions/feishu/src/delivery-trace.test.ts
@@ -13,15 +13,9 @@ import {
   type DeliveryTraceScenarioName,
   type WireRecorder,
 } from "openclaw/plugin-sdk/channel-contract-testing";
-import {
-  dispatchChannelInboundReply,
-  isChannelPartialDeliveryError,
-} from "openclaw/plugin-sdk/channel-inbound";
-import { setReplyPayloadMetadata } from "openclaw/plugin-sdk/reply-payload-testing";
 import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { FeishuConfigSchema } from "./config-schema.js";
-import { sendReplyOrFallbackDirect } from "./send.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
 const settlePendingFinalDeliveryMock = vi.hoisted(() =>
@@ -37,6 +31,13 @@ vi.mock("../../../src/infra/outbound/delivery-completion.js", async (importOrigi
 type RecordedWireCall = Parameters<WireRecorder["recordWireCall"]>[0];
 type CreateFeishuReplyDispatcher =
   typeof import("./reply-dispatcher.js").createFeishuReplyDispatcher;
+type DispatchChannelInboundReply =
+  typeof import("openclaw/plugin-sdk/channel-inbound").dispatchChannelInboundReply;
+type IsChannelPartialDeliveryError =
+  typeof import("openclaw/plugin-sdk/channel-inbound").isChannelPartialDeliveryError;
+type SendReplyOrFallbackDirect = typeof import("./send.js").sendReplyOrFallbackDirect;
+type SetReplyPayloadMetadata =
+  typeof import("openclaw/plugin-sdk/reply-payload-testing").setReplyPayloadMetadata;
 type StreamingStartBackoffMap =
   typeof import("./reply-dispatcher-state.js").streamingStartBackoffUntilByAccount;
 
@@ -50,7 +51,7 @@ type FeishuTraceState = {
   cardCount: number;
   setupCount: number;
   wireFaults: Array<{ fault: "rate-limit"; retryAfterMs: number }>;
-  messageResult: "identified" | "no-id";
+  messageResult: "identified" | "no-id" | "rejected";
   failNextReplace: boolean;
 };
 
@@ -145,13 +146,21 @@ vi.mock("./streaming-card.js", async (importOriginal) => {
 });
 
 let createFeishuReplyDispatcher: CreateFeishuReplyDispatcher;
+let dispatchChannelInboundReply: DispatchChannelInboundReply;
+let isChannelPartialDeliveryError: IsChannelPartialDeliveryError;
+let sendReplyOrFallbackDirect: SendReplyOrFallbackDirect;
+let setReplyPayloadMetadata: SetReplyPayloadMetadata;
 let streamingStartBackoffUntilByAccount: StreamingStartBackoffMap;
 
 beforeAll(async () => {
   // Collection can share a worker with suites that mock the same Feishu modules.
   // Reload only after this file's hoisted mocks are registered.
   vi.resetModules();
+  ({ dispatchChannelInboundReply, isChannelPartialDeliveryError } =
+    await import("openclaw/plugin-sdk/channel-inbound"));
+  ({ setReplyPayloadMetadata } = await import("openclaw/plugin-sdk/reply-payload-testing"));
   ({ createFeishuReplyDispatcher } = await import("./reply-dispatcher.js"));
+  ({ sendReplyOrFallbackDirect } = await import("./send.js"));
   ({ streamingStartBackoffUntilByAccount } = await import("./reply-dispatcher-state.js"));
 });
 
@@ -195,10 +204,14 @@ function nextMessageId(): string {
 }
 
 function createRecordingLarkClient() {
-  const messageSendResult = (messageId: string) =>
-    traceState.messageResult === "identified"
+  const messageSendResult = (messageId: string) => {
+    if (traceState.messageResult === "rejected") {
+      return { code: 230099, msg: "card table number over limit", data: {} };
+    }
+    return traceState.messageResult === "identified"
       ? { code: 0, msg: "ok", data: { message_id: messageId } }
       : { code: 0, msg: "ok", data: {} };
+  };
   return {
     im: {
       message: {
@@ -554,6 +567,76 @@ describe("feishu producer custody boundaries", () => {
     expect(client.im.message.reply).toHaveBeenCalledOnce();
     expect(client.im.message.create).not.toHaveBeenCalled();
   });
+
+  it.each([
+    { mode: "reply", dispatcherParams: { replyToMessageId: "om-inbound" } },
+    { mode: "root-create", dispatcherParams: { rootId: "om-root" } },
+    { mode: "ordinary-create", dispatcherParams: {} },
+  ])(
+    "keeps a permanent $mode streaming rejection terminal without static replay",
+    async ({ dispatcherParams }) => {
+      const wireCalls: RecordedWireCall[] = [];
+      traceState.recordWireCall = (call) => wireCalls.push(call);
+      traceState.messageCount = 0;
+      traceState.cardCount = 0;
+      traceState.messageResult = "rejected";
+      traceState.account = {
+        ...makeTraceAccount("final-only"),
+        config: FeishuConfigSchema.parse({ renderMode: "card", streaming: { mode: "partial" } }),
+      };
+      traceState.larkClient = createRecordingLarkClient();
+      traceState.cardKitFetch = createRecordingCardKitFetch();
+      const created = createFeishuReplyDispatcher({
+        cfg: {} as never,
+        agentId: "agent",
+        runtime: { log: () => {}, error: () => {} } as never,
+        chatId: "oc-trace-chat",
+        sendTarget: "oc-trace-chat",
+        ...dispatcherParams,
+      });
+      const sourcePayload = setReplyPayloadMetadata(
+        { text: "the final answer" },
+        { pendingFinalDeliveryCompletion: pendingFinalCompletion },
+      );
+
+      const error = await dispatchChannelInboundReply({
+        cfg: {},
+        channel: "feishu",
+        accountId: "main",
+        agentId: "agent",
+        routeSessionKey: pendingFinalCompletion.sessionKey,
+        storePath: pendingFinalCompletion.storePath,
+        ctxPayload: createTraceContext(),
+        recordInboundSession: async () => undefined,
+        dispatchReplyWithBufferedBlockDispatcher: async ({ dispatcherOptions }) => {
+          await dispatcherOptions.deliver?.(sourcePayload, { kind: "final" });
+          return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
+        },
+        dispatcherOptions: created.dispatcherOptions,
+        replyOptions: created.replyOptions,
+        delivery: created.delivery,
+      }).catch((caught: unknown) => caught);
+
+      expect(error).toMatchObject({
+        name: "PlatformMessageNotDispatchedError",
+        retryable: false,
+      });
+      expect(settlePendingFinalDeliveryMock).toHaveBeenNthCalledWith(
+        2,
+        { kind: "pending-final", ...pendingFinalCompletion },
+        "suppressed",
+        ["prepared", "queued", "unknown"],
+      );
+      expect(
+        wireCalls.filter(
+          (call) => call.method === "im.message.reply" || call.method === "im.message.create",
+        ),
+      ).toHaveLength(1);
+      await created.dispatcherOptions.onIdle?.();
+      await created.dispatcherOptions.onIdle?.();
+      expect(streamingStartBackoffUntilByAccount.has("main")).toBe(false);
+    },
+  );
 
   it("retains visible custody when no-ID preview disposition fails", async () => {
     const wireCalls: RecordedWireCall[] = [];

--- a/extensions/feishu/src/delivery-trace.test.ts
+++ b/extensions/feishu/src/delivery-trace.test.ts
@@ -594,6 +594,7 @@ describe("feishu producer custody boundaries", () => {
         sendTarget: "oc-trace-chat",
         ...dispatcherParams,
       });
+      const settled = vi.spyOn(created.dispatcherOptions, "onSettled");
       const sourcePayload = setReplyPayloadMetadata(
         { text: "the final answer" },
         { pendingFinalDeliveryCompletion: pendingFinalCompletion },
@@ -618,6 +619,8 @@ describe("feishu producer custody boundaries", () => {
             });
             await dispatcherOptions.onError?.(blockError, { kind: "block" });
           }
+          // Typing TTL/cleanup can fire while the same turn still has a queued final.
+          created.dispatcherOptions.onCleanup?.();
           await dispatcherOptions.deliver?.(sourcePayload, { kind: "final" });
           return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
         },
@@ -630,6 +633,8 @@ describe("feishu producer custody boundaries", () => {
         name: "PlatformMessageNotDispatchedError",
         retryable: false,
       });
+      await created.dispatcherOptions.onSettled?.();
+      expect(settled).toHaveBeenCalledOnce();
       expect(settlePendingFinalDeliveryMock).toHaveBeenNthCalledWith(
         2,
         { kind: "pending-final", ...pendingFinalCompletion },

--- a/extensions/feishu/src/delivery-trace.test.ts
+++ b/extensions/feishu/src/delivery-trace.test.ts
@@ -14,19 +14,9 @@ import {
   type WireRecorder,
 } from "openclaw/plugin-sdk/channel-contract-testing";
 import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { FeishuConfigSchema } from "./config-schema.js";
 import type { ResolvedFeishuAccount } from "./types.js";
-
-const settlePendingFinalDeliveryMock = vi.hoisted(() =>
-  vi.fn(async (_completion: unknown, state: string) => ({ state })),
-);
-
-vi.mock("../../../src/infra/outbound/delivery-completion.js", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("../../../src/infra/outbound/delivery-completion.js")>();
-  return { ...actual, settlePendingFinalDelivery: settlePendingFinalDeliveryMock };
-});
 
 type RecordedWireCall = Parameters<WireRecorder["recordWireCall"]>[0];
 type CreateFeishuReplyDispatcher =
@@ -36,8 +26,6 @@ type DispatchChannelInboundReply =
 type IsChannelPartialDeliveryError =
   typeof import("openclaw/plugin-sdk/channel-inbound").isChannelPartialDeliveryError;
 type SendReplyOrFallbackDirect = typeof import("./send.js").sendReplyOrFallbackDirect;
-type SetReplyPayloadMetadata =
-  typeof import("openclaw/plugin-sdk/reply-payload-testing").setReplyPayloadMetadata;
 type StreamingStartBackoffMap =
   typeof import("./reply-dispatcher-state.js").streamingStartBackoffUntilByAccount;
 
@@ -149,7 +137,6 @@ let createFeishuReplyDispatcher: CreateFeishuReplyDispatcher;
 let dispatchChannelInboundReply: DispatchChannelInboundReply;
 let isChannelPartialDeliveryError: IsChannelPartialDeliveryError;
 let sendReplyOrFallbackDirect: SendReplyOrFallbackDirect;
-let setReplyPayloadMetadata: SetReplyPayloadMetadata;
 let streamingStartBackoffUntilByAccount: StreamingStartBackoffMap;
 
 beforeAll(async () => {
@@ -158,14 +145,9 @@ beforeAll(async () => {
   vi.resetModules();
   ({ dispatchChannelInboundReply, isChannelPartialDeliveryError } =
     await import("openclaw/plugin-sdk/channel-inbound"));
-  ({ setReplyPayloadMetadata } = await import("openclaw/plugin-sdk/reply-payload-testing"));
   ({ createFeishuReplyDispatcher } = await import("./reply-dispatcher.js"));
   ({ sendReplyOrFallbackDirect } = await import("./send.js"));
   ({ streamingStartBackoffUntilByAccount } = await import("./reply-dispatcher-state.js"));
-});
-
-beforeEach(() => {
-  settlePendingFinalDeliveryMock.mockClear();
 });
 
 afterAll(() => {
@@ -452,10 +434,7 @@ const FEISHU_TRACE_SCENARIOS: readonly DeliveryTraceScenarioName[] = [
   "overflow-pagination",
 ];
 
-const pendingFinalCompletion = {
-  deliveryId: "delivery-feishu-custody",
-  intentId: "intent-feishu-custody",
-  sessionId: "session-feishu-custody",
+const traceTurn = {
   sessionKey: "agent:agent:feishu:direct:oc-trace-chat",
   storePath: "/tmp/feishu-custody-sessions.json",
 };
@@ -468,25 +447,10 @@ function createTraceContext() {
     CommandAuthorized: false,
     From: "ou-sender",
     To: "oc-trace-chat",
-    SessionKey: pendingFinalCompletion.sessionKey,
+    SessionKey: traceTurn.sessionKey,
     Provider: "feishu",
     Surface: "feishu",
   };
-}
-
-function expectDeliveredCustody() {
-  expect(settlePendingFinalDeliveryMock).toHaveBeenNthCalledWith(
-    1,
-    { kind: "pending-final", ...pendingFinalCompletion },
-    "unknown",
-    ["prepared", "queued"],
-  );
-  expect(settlePendingFinalDeliveryMock).toHaveBeenNthCalledWith(
-    2,
-    { kind: "pending-final", ...pendingFinalCompletion },
-    "delivered",
-    ["queued", "unknown"],
-  );
 }
 
 describe("feishu delivery trace goldens", () => {
@@ -512,10 +476,7 @@ describe("feishu producer custody boundaries", () => {
         data: { code: 230099, msg: "card table number over limit" },
       },
     });
-    const sourcePayload = setReplyPayloadMetadata(
-      { text: "the final answer" },
-      { pendingFinalDeliveryCompletion: pendingFinalCompletion },
-    );
+    const sourcePayload = { text: "the final answer" };
     const client = {
       im: {
         message: {
@@ -531,8 +492,8 @@ describe("feishu producer custody boundaries", () => {
         channel: "feishu",
         accountId: "main",
         agentId: "agent",
-        routeSessionKey: pendingFinalCompletion.sessionKey,
-        storePath: pendingFinalCompletion.storePath,
+        routeSessionKey: traceTurn.sessionKey,
+        storePath: traceTurn.storePath,
         ctxPayload: createTraceContext(),
         recordInboundSession: async () => undefined,
         dispatchReplyWithBufferedBlockDispatcher: async ({ dispatcherOptions }) => {
@@ -558,12 +519,6 @@ describe("feishu producer custody boundaries", () => {
       }),
     ).rejects.toMatchObject({ retryable: false, cause: rejected });
 
-    expect(settlePendingFinalDeliveryMock).toHaveBeenNthCalledWith(
-      2,
-      { kind: "pending-final", ...pendingFinalCompletion },
-      "suppressed",
-      ["prepared", "queued", "unknown"],
-    );
     expect(client.im.message.reply).toHaveBeenCalledOnce();
     expect(client.im.message.create).not.toHaveBeenCalled();
   });
@@ -595,18 +550,15 @@ describe("feishu producer custody boundaries", () => {
         ...dispatcherParams,
       });
       const settled = vi.spyOn(created.dispatcherOptions, "onSettled");
-      const sourcePayload = setReplyPayloadMetadata(
-        { text: "the final answer" },
-        { pendingFinalDeliveryCompletion: pendingFinalCompletion },
-      );
+      const sourcePayload = { text: "the final answer" };
 
       const error = await dispatchChannelInboundReply({
         cfg: {},
         channel: "feishu",
         accountId: "main",
         agentId: "agent",
-        routeSessionKey: pendingFinalCompletion.sessionKey,
-        storePath: pendingFinalCompletion.storePath,
+        routeSessionKey: traceTurn.sessionKey,
+        storePath: traceTurn.storePath,
         ctxPayload: createTraceContext(),
         recordInboundSession: async () => undefined,
         dispatchReplyWithBufferedBlockDispatcher: async ({ dispatcherOptions }) => {
@@ -635,12 +587,6 @@ describe("feishu producer custody boundaries", () => {
       });
       await created.dispatcherOptions.onSettled?.();
       expect(settled).toHaveBeenCalledOnce();
-      expect(settlePendingFinalDeliveryMock).toHaveBeenNthCalledWith(
-        2,
-        { kind: "pending-final", ...pendingFinalCompletion },
-        "suppressed",
-        ["prepared", "queued", "unknown"],
-      );
       expect(
         wireCalls.filter(
           (call) => call.method === "im.message.reply" || call.method === "im.message.create",
@@ -702,18 +648,15 @@ describe("feishu producer custody boundaries", () => {
       sendTarget: "oc-trace-chat",
       replyToMessageId: "om-inbound",
     });
-    const sourcePayload = setReplyPayloadMetadata(
-      { text: "x".repeat(4001) },
-      { pendingFinalDeliveryCompletion: pendingFinalCompletion },
-    );
+    const sourcePayload = { text: "x".repeat(4001) };
 
     const error = await dispatchChannelInboundReply({
       cfg: {},
       channel: "feishu",
       accountId: "main",
       agentId: "agent",
-      routeSessionKey: pendingFinalCompletion.sessionKey,
-      storePath: pendingFinalCompletion.storePath,
+      routeSessionKey: traceTurn.sessionKey,
+      storePath: traceTurn.storePath,
       ctxPayload: createTraceContext(),
       recordInboundSession: async () => undefined,
       dispatchReplyWithBufferedBlockDispatcher: async ({ dispatcherOptions }) => {
@@ -731,7 +674,6 @@ describe("feishu producer custody boundaries", () => {
     expect(error).toMatchObject({
       deliveryResult: { visibleReplySent: true, content: "accepted preview" },
     });
-    expectDeliveredCustody();
     expect(wireCalls.filter((call) => call.method === "im.message.reply")).toHaveLength(1);
     expect(wireCalls.some((call) => call.method === "im.message.delete")).toBe(false);
     expect(wireCalls.filter((call) => call.method.endsWith("/elements/content"))).toHaveLength(1);

--- a/extensions/feishu/src/delivery-trace.test.ts
+++ b/extensions/feishu/src/delivery-trace.test.ts
@@ -23,8 +23,6 @@ type CreateFeishuReplyDispatcher =
   typeof import("./reply-dispatcher.js").createFeishuReplyDispatcher;
 type DispatchChannelInboundReply =
   typeof import("openclaw/plugin-sdk/channel-inbound").dispatchChannelInboundReply;
-type IsChannelPartialDeliveryError =
-  typeof import("openclaw/plugin-sdk/channel-inbound").isChannelPartialDeliveryError;
 type SendReplyOrFallbackDirect = typeof import("./send.js").sendReplyOrFallbackDirect;
 type StreamingStartBackoffMap =
   typeof import("./reply-dispatcher-state.js").streamingStartBackoffUntilByAccount;
@@ -40,7 +38,6 @@ type FeishuTraceState = {
   setupCount: number;
   wireFaults: Array<{ fault: "rate-limit"; retryAfterMs: number }>;
   messageResult: "identified" | "no-id" | "rejected";
-  failNextReplace: boolean;
 };
 
 const traceState = vi.hoisted(
@@ -55,7 +52,6 @@ const traceState = vi.hoisted(
     setupCount: 0,
     wireFaults: [],
     messageResult: "identified",
-    failNextReplace: false,
   }),
 );
 
@@ -135,7 +131,6 @@ vi.mock("./streaming-card.js", async (importOriginal) => {
 
 let createFeishuReplyDispatcher: CreateFeishuReplyDispatcher;
 let dispatchChannelInboundReply: DispatchChannelInboundReply;
-let isChannelPartialDeliveryError: IsChannelPartialDeliveryError;
 let sendReplyOrFallbackDirect: SendReplyOrFallbackDirect;
 let streamingStartBackoffUntilByAccount: StreamingStartBackoffMap;
 
@@ -143,8 +138,7 @@ beforeAll(async () => {
   // Collection can share a worker with suites that mock the same Feishu modules.
   // Reload only after this file's hoisted mocks are registered.
   vi.resetModules();
-  ({ dispatchChannelInboundReply, isChannelPartialDeliveryError } =
-    await import("openclaw/plugin-sdk/channel-inbound"));
+  ({ dispatchChannelInboundReply } = await import("openclaw/plugin-sdk/channel-inbound"));
   ({ createFeishuReplyDispatcher } = await import("./reply-dispatcher.js"));
   ({ sendReplyOrFallbackDirect } = await import("./send.js"));
   ({ streamingStartBackoffUntilByAccount } = await import("./reply-dispatcher-state.js"));
@@ -314,14 +308,6 @@ function createRecordingCardKitFetch(): typeof fetch {
       }
       if (wirePath.endsWith("/elements/content")) {
         const body = parseJsonRecord(init?.body);
-        if (traceState.failNextReplace) {
-          traceState.failNextReplace = false;
-          record(
-            { element: parseJsonRecord(body.element), sequence: body.sequence, uuid: body.uuid },
-            { status: 500 },
-          );
-          return jsonResponse({ code: 230099, msg: "replace rejected" }, 500);
-        }
         record(
           { element: parseJsonRecord(body.element), sequence: body.sequence, uuid: body.uuid },
           { code: 0 },
@@ -370,7 +356,6 @@ function setupFeishuTrace(recorder: WireRecorder, scenario: DeliveryTraceScenari
   traceState.cardCount = 0;
   traceState.wireFaults = [];
   traceState.messageResult = "identified";
-  traceState.failNextReplace = false;
   traceState.account = makeTraceAccount(scenario);
   traceState.larkClient = createRecordingLarkClient();
   traceState.cardKitFetch = createRecordingCardKitFetch();
@@ -469,6 +454,60 @@ describe("feishu delivery trace goldens", () => {
 });
 
 describe("feishu producer custody boundaries", () => {
+  it("keeps exhausted provider throttling retryable through channel dispatch", async () => {
+    const throttled = Object.assign(new Error("Request failed with status code 429"), {
+      response: { status: 429, data: { code: 99991400, msg: "rate limited" } },
+    });
+    const client = {
+      im: {
+        message: {
+          create: vi.fn().mockRejectedValue(throttled),
+          reply: vi.fn(),
+        },
+      },
+    };
+
+    await expect(
+      dispatchChannelInboundReply({
+        cfg: {},
+        channel: "feishu",
+        accountId: "main",
+        agentId: "agent",
+        routeSessionKey: traceTurn.sessionKey,
+        storePath: traceTurn.storePath,
+        ctxPayload: createTraceContext(),
+        recordInboundSession: async () => undefined,
+        dispatchReplyWithBufferedBlockDispatcher: async ({ dispatcherOptions }) => {
+          await dispatcherOptions.deliver?.({ text: "the final answer" }, { kind: "final" });
+          return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
+        },
+        delivery: {
+          deliver: async () =>
+            await sendReplyOrFallbackDirect(client, {
+              content: "{}",
+              msgType: "interactive",
+              directParams: {
+                receiveId: "oc-trace-chat",
+                receiveIdType: "chat_id",
+                content: "{}",
+                msgType: "interactive",
+              },
+              directErrorPrefix: "Feishu card send failed",
+              replyErrorPrefix: "Feishu card reply failed",
+            }),
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: "PlatformMessageNotDispatchedError",
+      retryable: true,
+      publicError: { code: "429" },
+      cause: throttled,
+    });
+
+    expect(client.im.message.create).toHaveBeenCalledTimes(3);
+    expect(client.im.message.reply).not.toHaveBeenCalled();
+  });
+
   it("settles an actual rejected message producer as permanent suppression", async () => {
     const rejected = Object.assign(new Error("Request failed with status code 400"), {
       response: {
@@ -528,7 +567,7 @@ describe("feishu producer custody boundaries", () => {
     { mode: "root-create", dispatcherParams: { rootId: "om-root" } },
     { mode: "ordinary-create", dispatcherParams: {} },
   ])(
-    "keeps a permanent $mode streaming rejection terminal without static replay",
+    "preserves a permanent $mode streaming rejection when static fallback also fails",
     async ({ dispatcherParams }) => {
       const wireCalls: RecordedWireCall[] = [];
       traceState.recordWireCall = (call) => wireCalls.push(call);
@@ -562,17 +601,6 @@ describe("feishu producer custody boundaries", () => {
         ctxPayload: createTraceContext(),
         recordInboundSession: async () => undefined,
         dispatchReplyWithBufferedBlockDispatcher: async ({ dispatcherOptions }) => {
-          try {
-            await dispatcherOptions.deliver?.({ text: "the queued block" }, { kind: "block" });
-          } catch (blockError: unknown) {
-            expect(blockError).toMatchObject({
-              name: "PlatformMessageNotDispatchedError",
-              retryable: false,
-            });
-            await dispatcherOptions.onError?.(blockError, { kind: "block" });
-          }
-          // Typing TTL/cleanup can fire while the same turn still has a queued final.
-          created.dispatcherOptions.onCleanup?.();
           await dispatcherOptions.deliver?.(sourcePayload, { kind: "final" });
           return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
         },
@@ -584,6 +612,10 @@ describe("feishu producer custody boundaries", () => {
       expect(error).toMatchObject({
         name: "PlatformMessageNotDispatchedError",
         retryable: false,
+        cause: {
+          name: "AggregateError",
+          message: "Feishu streaming start and static fallback failed",
+        },
       });
       await created.dispatcherOptions.onSettled?.();
       expect(settled).toHaveBeenCalledOnce();
@@ -591,7 +623,7 @@ describe("feishu producer custody boundaries", () => {
         wireCalls.filter(
           (call) => call.method === "im.message.reply" || call.method === "im.message.create",
         ),
-      ).toHaveLength(1);
+      ).toHaveLength(2);
       await created.dispatcherOptions.onIdle?.();
       await created.dispatcherOptions.onIdle?.();
       expect(streamingStartBackoffUntilByAccount.has("main")).toBe(false);
@@ -623,59 +655,7 @@ describe("feishu producer custody boundaries", () => {
         wireCalls.filter(
           (call) => call.method === "im.message.reply" || call.method === "im.message.create",
         ),
-      ).toHaveLength(2);
+      ).toHaveLength(3);
     },
   );
-
-  it("retains visible custody when no-ID preview disposition fails", async () => {
-    const wireCalls: RecordedWireCall[] = [];
-    traceState.recordWireCall = (call) => wireCalls.push(call);
-    traceState.messageCount = 0;
-    traceState.cardCount = 0;
-    traceState.messageResult = "no-id";
-    traceState.failNextReplace = true;
-    traceState.account = {
-      ...makeTraceAccount("final-only"),
-      config: FeishuConfigSchema.parse({ renderMode: "card", streaming: { mode: "partial" } }),
-    };
-    traceState.larkClient = createRecordingLarkClient();
-    traceState.cardKitFetch = createRecordingCardKitFetch();
-    const created = createFeishuReplyDispatcher({
-      cfg: {} as never,
-      agentId: "agent",
-      runtime: { log: () => {}, error: () => {} } as never,
-      chatId: "oc-trace-chat",
-      sendTarget: "oc-trace-chat",
-      replyToMessageId: "om-inbound",
-    });
-    const sourcePayload = { text: "x".repeat(4001) };
-
-    const error = await dispatchChannelInboundReply({
-      cfg: {},
-      channel: "feishu",
-      accountId: "main",
-      agentId: "agent",
-      routeSessionKey: traceTurn.sessionKey,
-      storePath: traceTurn.storePath,
-      ctxPayload: createTraceContext(),
-      recordInboundSession: async () => undefined,
-      dispatchReplyWithBufferedBlockDispatcher: async ({ dispatcherOptions }) => {
-        await dispatcherOptions.onReplyStart?.();
-        created.replyOptions.onPartialReply?.({ text: "accepted preview" });
-        await dispatcherOptions.deliver?.(sourcePayload, { kind: "final" });
-        return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
-      },
-      dispatcherOptions: created.dispatcherOptions,
-      replyOptions: created.replyOptions,
-      delivery: created.delivery,
-    }).catch((caught: unknown) => caught);
-
-    expect(isChannelPartialDeliveryError(error)).toBe(true);
-    expect(error).toMatchObject({
-      deliveryResult: { visibleReplySent: true, content: "accepted preview" },
-    });
-    expect(wireCalls.filter((call) => call.method === "im.message.reply")).toHaveLength(1);
-    expect(wireCalls.some((call) => call.method === "im.message.delete")).toBe(false);
-    expect(wireCalls.filter((call) => call.method.endsWith("/elements/content"))).toHaveLength(1);
-  });
 });

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { Readable } from "node:stream";
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig } from "../runtime-api.js";
@@ -430,7 +431,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(callData<{ msg_type?: string }>(messageCreateMock).msg_type).toBe("image");
   });
 
-  it("preserves Feishu diagnostics when media sends reject before response checks", async () => {
+  it("classifies a structured media message rejection with bounded diagnostics", async () => {
     messageCreateMock.mockRejectedValueOnce(
       Object.assign(new Error("Request failed with status code 400"), {
         response: {
@@ -447,15 +448,16 @@ describe("sendMediaFeishu msg_type routing", () => {
       }),
     );
 
-    const send = sendMediaFeishu({
+    const error = await sendMediaFeishu({
       cfg: emptyConfig,
       to: "user:ou_target",
       mediaBuffer: validPngImage,
       fileName: "photo.png",
-    });
+    }).catch((caught: unknown) => caught);
 
-    await expect(send).rejects.toThrow(/Feishu image send failed: .*"feishu_code":9499/);
-    await expect(send).rejects.toThrow(/"feishu_log_id":"20260429124731MEDIA"/);
+    expect(error).toBeInstanceOf(PlatformMessageNotDispatchedError);
+    expect(error).toMatchObject({ retryable: false });
+    expect((error as Error).message).toBe("Feishu image send failed: Bad Request (code=9499)");
   });
 
   it("uses msg_type=media when replying with mp4", async () => {

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -457,7 +457,7 @@ describe("sendMediaFeishu msg_type routing", () => {
 
     expect(error).toBeInstanceOf(PlatformMessageNotDispatchedError);
     expect(error).toMatchObject({ retryable: false });
-    expect((error as Error).message).toBe("Feishu image send failed: Bad Request (code=9499)");
+    expect((error as Error).message).toMatch(/"feishu_log_id":"20260429124731MEDIA"/);
   });
 
   it("uses msg_type=media when replying with mp4", async () => {

--- a/extensions/feishu/src/reply-delivery-result.ts
+++ b/extensions/feishu/src/reply-delivery-result.ts
@@ -17,6 +17,8 @@ export type FeishuReplyDeliveryResult = {
   threadId?: string;
   replyToId?: string;
   visibleReplySent?: boolean;
+  /** Provider accepted custody, but returned no identity proving recipient visibility. */
+  visibilityUnknown?: true;
   content?: string;
 };
 
@@ -43,6 +45,7 @@ function hasProviderIdentity(
 export function createFeishuReplyDeliveryResult(params: {
   results?: readonly (FeishuReplyDeliverySource | null | undefined)[];
   visibleReplySent: boolean;
+  visibilityUnknown?: boolean;
   content?: string;
   kind?: MessageReceiptPartKind;
 }): FeishuReplyDeliveryResult {
@@ -57,13 +60,14 @@ export function createFeishuReplyDeliveryResult(params: {
   if (!receipt) {
     return {
       visibleReplySent: params.visibleReplySent,
+      ...(params.visibilityUnknown ? { visibilityUnknown: true as const } : {}),
       ...(params.content === undefined ? {} : { content: params.content }),
     };
   }
   return {
     messageIds: [...receipt.platformMessageIds],
     receipt,
-    visibleReplySent: params.visibleReplySent,
+    visibleReplySent: true,
     ...(params.content === undefined ? {} : { content: params.content }),
   };
 }
@@ -74,9 +78,12 @@ export function mergeFeishuReplyDeliveryResults(
   content?: string,
 ): FeishuReplyDeliveryResult {
   const visible = results.filter((result) => result.visibleReplySent === true);
+  const visibilityUnknown =
+    visible.length === 0 && results.some((result) => result.visibilityUnknown === true);
   return createFeishuReplyDeliveryResult({
     results: visible,
     visibleReplySent: visible.length > 0,
+    visibilityUnknown,
     content:
       content === undefined
         ? results.find((result) => result.content !== undefined)?.content

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -1799,6 +1799,45 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  it("settles an identity-less streaming final exactly once without static fallback", async () => {
+    const { result, options } = createDispatcherHarness();
+    const delivery = await options.deliver({ text: "accepted no-id final" }, { kind: "final" });
+    requireStreamingInstance(0).closeWithResult.mockResolvedValueOnce({
+      visibleReplySent: true,
+      content: "accepted no-id final",
+    });
+
+    await options.onIdle?.();
+
+    await expect(delivery?.finalization).resolves.toEqual({
+      visibleReplySent: true,
+      content: "accepted no-id final",
+    });
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    await expect(result.ensureNoVisibleReplyFallback("accepted-no-id-stream")).resolves.toBe(false);
+    expect(requireStreamingInstance(0).closeWithResult).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps identity-less accepted-card custody when final content update fails", async () => {
+    const { result, options } = createDispatcherHarness();
+    const delivery = await options.deliver({ text: "unaccepted final text" }, { kind: "final" });
+    requireStreamingInstance(0).closeWithResult.mockRejectedValueOnce(
+      new FeishuStreamingFinalizationError(new Error("final update failed"), {
+        visibleReplySent: true,
+      }),
+    );
+
+    await expect(options.onIdle?.()).rejects.toThrow("final update failed");
+    await expect(delivery?.finalization).rejects.toMatchObject({
+      code: "CHANNEL_PARTIAL_DELIVERY",
+      deliveryResult: { visibleReplySent: true, content: "" },
+    });
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    await expect(result.ensureNoVisibleReplyFallback("accepted-no-id-stream")).resolves.toBe(false);
+  });
+
   it("allows recovery after a final rewrite leaves only an earlier preview visible", async () => {
     const { result, options } = createDispatcherHarness();
     result.replyOptions.onPartialReply?.({ text: "accepted preview" });

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -32,7 +32,7 @@ const resolveReceiveIdTypeMock = vi.hoisted(() => vi.fn());
 const addTypingIndicatorMock = vi.hoisted(() => vi.fn(async () => ({ messageId: "om_msg" })));
 const removeTypingIndicatorMock = vi.hoisted(() => vi.fn(async () => {}));
 const streamingInstances = vi.hoisted((): StreamingSessionStub[] => []);
-const streamingStartFailure = vi.hoisted((): { error?: unknown } => ({}));
+const streamingStartFailure = vi.hoisted((): { error?: Error } => ({}));
 const shouldSuppressFeishuTextForVoiceMediaMock = vi.hoisted(
   () =>
     (params: {

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -5,6 +5,7 @@ import {
   createChannelPartialDeliveryError,
   isChannelPartialDeliveryError,
 } from "openclaw/plugin-sdk/channel-inbound";
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -31,6 +32,7 @@ const resolveReceiveIdTypeMock = vi.hoisted(() => vi.fn());
 const addTypingIndicatorMock = vi.hoisted(() => vi.fn(async () => ({ messageId: "om_msg" })));
 const removeTypingIndicatorMock = vi.hoisted(() => vi.fn(async () => {}));
 const streamingInstances = vi.hoisted((): StreamingSessionStub[] => []);
+const streamingStartFailure = vi.hoisted((): { error?: unknown } => ({}));
 const shouldSuppressFeishuTextForVoiceMediaMock = vi.hoisted(
   () =>
     (params: {
@@ -115,11 +117,21 @@ vi.mock("./typing.js", () => ({
 }));
 vi.mock("./streaming-card.js", () => {
   class FeishuStreamingFinalizationError extends Error {
-    result: { visibleReplySent: boolean; content?: string; messageId?: string };
+    result: {
+      visibleReplySent: boolean;
+      visibilityUnknown?: true;
+      content?: string;
+      messageId?: string;
+    };
 
     constructor(
       cause: unknown,
-      result: { visibleReplySent: boolean; content?: string; messageId?: string },
+      result: {
+        visibleReplySent: boolean;
+        visibilityUnknown?: true;
+        content?: string;
+        messageId?: string;
+      },
     ) {
       super(cause instanceof Error ? cause.message : String(cause), { cause });
       this.result = result;
@@ -132,6 +144,9 @@ vi.mock("./streaming-card.js", () => {
       active = false;
       credentials: unknown;
       start = vi.fn(async () => {
+        if (streamingStartFailure.error !== undefined) {
+          throw streamingStartFailure.error;
+        }
         this.active = true;
       });
       update = vi.fn(async () => {});
@@ -186,6 +201,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     vi.clearAllMocks();
     streamingStartBackoffUntilByAccount.clear();
     streamingInstances.length = 0;
+    streamingStartFailure.error = undefined;
     sendMediaFeishuMock.mockResolvedValue(undefined);
     sendStructuredCardFeishuMock.mockResolvedValue(undefined);
     getGlobalHookRunnerMock.mockReturnValue(null);
@@ -409,6 +425,76 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       typeof call[0] === "string" ? call[0] : "",
     );
   }
+
+  it.each([true, false])(
+    "falls back once to a static card after a retryable=%s proven streaming no-send",
+    async (retryable) => {
+      const rejection = new PlatformMessageNotDispatchedError("streaming rejected", {
+        cause: new Error("provider rejected"),
+        retryable,
+      });
+      streamingStartFailure.error = rejection;
+      sendStructuredCardFeishuMock.mockResolvedValueOnce({ messageId: "om-static" });
+      const { options } = createDispatcherHarness();
+
+      await expect(
+        options.deliver({ text: "static recovery" }, { kind: "final" }),
+      ).resolves.toMatchObject({
+        messageIds: ["om-static"],
+        visibleReplySent: true,
+      });
+
+      expect(requireStreamingInstance(0).start).toHaveBeenCalledOnce();
+      expect(sendStructuredCardFeishuMock).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("preserves the streaming rejection and static settlement when fallback fails", async () => {
+    const rejection = new PlatformMessageNotDispatchedError("streaming rejected", {
+      cause: new Error("provider rejected"),
+      retryable: false,
+    });
+    streamingStartFailure.error = rejection;
+    const fallbackFailure = new Error("static card rejected");
+    sendStructuredCardFeishuMock.mockRejectedValueOnce(fallbackFailure);
+    const { options } = createDispatcherHarness();
+
+    const error = await options
+      .deliver({ text: "static recovery" }, { kind: "final" })
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(AggregateError);
+    expect(error).toMatchObject({
+      message: "Feishu streaming start and static fallback failed",
+      errors: [rejection, fallbackFailure],
+    });
+    expect(sendStructuredCardFeishuMock).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the sole permanent fallback code independent of a retryable attempt", async () => {
+    streamingStartFailure.error = new PlatformMessageNotDispatchedError("streaming rejected", {
+      cause: new Error("streaming rejected"),
+      retryable: true,
+      publicError: { code: "230001" },
+    });
+    sendStructuredCardFeishuMock.mockRejectedValueOnce(
+      new PlatformMessageNotDispatchedError("static card rejected", {
+        cause: new Error("static card rejected"),
+        retryable: false,
+        publicError: { code: "230099" },
+      }),
+    );
+    const { options } = createDispatcherHarness();
+
+    await expect(
+      options.deliver({ text: "static recovery" }, { kind: "final" }),
+    ).rejects.toMatchObject({
+      name: "PlatformMessageNotDispatchedError",
+      retryable: true,
+      publicError: { code: "230099" },
+      cause: { message: "Feishu streaming start and static fallback failed" },
+    });
+  });
 
   it("skips typing indicator when account typingIndicator is disabled", async () => {
     resolveFeishuAccountMock.mockReturnValue({
@@ -1819,23 +1905,21 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(requireStreamingInstance(0).closeWithResult).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps identity-less accepted-card custody when final content update fails", async () => {
+  it("keeps identity-less accepted-card custody unknown when its first content update fails", async () => {
     const { result, options } = createDispatcherHarness();
     const delivery = await options.deliver({ text: "unaccepted final text" }, { kind: "final" });
     requireStreamingInstance(0).closeWithResult.mockRejectedValueOnce(
       new FeishuStreamingFinalizationError(new Error("final update failed"), {
-        visibleReplySent: true,
+        visibleReplySent: false,
+        visibilityUnknown: true,
       }),
     );
 
     await expect(options.onIdle?.()).rejects.toThrow("final update failed");
-    await expect(delivery?.finalization).rejects.toMatchObject({
-      code: "CHANNEL_PARTIAL_DELIVERY",
-      deliveryResult: { visibleReplySent: true, content: "" },
-    });
+    await expect(delivery?.finalization).rejects.toThrow("final update failed");
     expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
-    await expect(result.ensureNoVisibleReplyFallback("accepted-no-id-stream")).resolves.toBe(false);
+    expect(result.getVisibleReplyState().visibleReplySent).toBe(false);
   });
 
   it("allows recovery after a final rewrite leaves only an earlier preview visible", async () => {
@@ -3358,10 +3442,9 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
-  it("backs off streaming retries after start() throws (HTTP 400)", async () => {
+  it("fences an ambiguous streaming start failure until turn settlement", async () => {
     const errorMock = vi.fn();
     let shouldFailStart = true;
-    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000);
 
     // Intercept streaming instance creation to make first start() reject
     const origPush = streamingInstances.push.bind(streamingInstances);
@@ -3387,8 +3470,9 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
       const options = toTypingDispatcherOptions(result);
 
-      // First deliver with markdown triggers startStreaming - which will fail
-      await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
+      await expect(
+        options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" }),
+      ).rejects.toThrow("Create card request failed with HTTP 400");
 
       // Wait for the async error to propagate
       await vi.waitFor(() => {
@@ -3397,18 +3481,16 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
         );
       });
       expect(streamingInstances).toHaveLength(1);
-      expect(sendStructuredCardFeishuMock).toHaveBeenCalledTimes(1);
+      expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
 
-      // Immediate next markdown reply should skip a new streaming start and
-      // fall back directly to a normal card instead of paying the 400 latency.
-      await options.deliver({ text: "```ts\nconst y = 2\n```" }, { kind: "final" });
+      await expect(
+        options.deliver({ text: "```ts\nconst y = 2\n```" }, { kind: "final" }),
+      ).rejects.toThrow("Create card request failed with HTTP 400");
 
       expect(streamingInstances).toHaveLength(1);
-      expect(sendStructuredCardFeishuMock).toHaveBeenCalledTimes(2);
+      expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
 
-      // After the short backoff expires, retry streaming so fixed permissions
-      // or transient Feishu failures recover without a process restart.
-      nowSpy.mockReturnValue(62_000);
+      options.onSettled?.();
       await options.deliver({ text: "```ts\nconst z = 3\n```" }, { kind: "final" });
       await options.onIdle?.();
 
@@ -3417,7 +3499,6 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       expect(requireStreamingInstance(1).close).toHaveBeenCalled();
     } finally {
       streamingInstances.push = origPush;
-      nowSpy.mockRestore();
     }
   });
 });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -107,6 +107,31 @@ function rememberStreamingStartFailure(accountId: string, now = Date.now()): num
   return backoffUntil;
 }
 
+function combineStreamingStartFallbackFailures(
+  start: PlatformMessageNotDispatchedError,
+  fallback: unknown,
+): unknown {
+  const cause = new AggregateError(
+    [start, fallback],
+    "Feishu streaming start and static fallback failed",
+  );
+  if (!(fallback instanceof PlatformMessageNotDispatchedError)) {
+    return cause;
+  }
+  const permanentFailures = [start, fallback].filter((failure) => !failure.retryable);
+  const permanentCode = permanentFailures[0]?.publicError?.code;
+  const agreedPermanentCode =
+    permanentCode &&
+    permanentFailures.every((failure) => failure.publicError?.code === permanentCode)
+      ? permanentCode
+      : undefined;
+  return new PlatformMessageNotDispatchedError(fallback.message, {
+    cause,
+    retryable: start.retryable || fallback.retryable,
+    ...(agreedPermanentCode ? { publicError: { code: agreedPermanentCode } } : {}),
+  });
+}
+
 function normalizeEpochMs(timestamp: number | undefined): number | undefined {
   if (!Number.isFinite(timestamp) || timestamp === undefined || timestamp <= 0) {
     return undefined;
@@ -321,7 +346,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let sentIndependentBlockText = false;
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
-  let terminalStreamingStartError: PlatformMessageNotDispatchedError | undefined;
+  let streamingStartFallbackError: PlatformMessageNotDispatchedError | undefined;
+  let terminalStreamingStartError: unknown;
   let streamingGeneration = 0;
   let activeStreamingGeneration: number | undefined;
   let inFlightStreamingClose:
@@ -364,6 +390,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     const result = createFeishuReplyDeliveryResult({
       results: [error.result],
       visibleReplySent: error.result.visibleReplySent,
+      ...(error.result.visibilityUnknown ? { visibilityUnknown: true } : {}),
       content: error.result.content,
       kind: "card",
     });
@@ -470,6 +497,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       !streamingEnabled ||
       streamingStartPromise ||
       streaming ||
+      streamingStartFallbackError ||
       terminalStreamingStartError ||
       isStreamingStartBackedOff(account.accountId)
     ) {
@@ -511,19 +539,22 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         });
         streamingStartBackoffUntilByAccount.delete(account.accountId);
       } catch (error) {
-        if (error instanceof PlatformMessageNotDispatchedError && !error.retryable) {
-          // A provider-declared no-send is terminal for this logical payload.
-          // Keep the fact until delivery consumes it instead of replaying statically.
-          terminalStreamingStartError = error;
+        if (error instanceof PlatformMessageNotDispatchedError) {
+          // A provider-proven no-send permits exactly one alternate static-card attempt.
+          // Keep the rejection so a failed fallback settles with the original provider fact.
+          streamingStartFallbackError = error;
+          if (error.retryable) {
+            rememberStreamingStartFailure(account.accountId);
+          }
           params.runtime.error?.(
-            `feishu[${account.accountId}]: streaming start permanently rejected: ${String(error)}`,
+            `feishu[${account.accountId}]: streaming start rejected before dispatch; using non-streaming card fallback: ${String(error)}`,
           );
         } else {
-          rememberStreamingStartFailure(account.accountId);
+          // Transport failures do not prove whether the message API accepted custody.
+          // Fence replay until the caller settles the ambiguous attempt.
+          terminalStreamingStartError = error;
           params.runtime.error?.(
-            `feishu[${account.accountId}]: streaming start failed; using non-streaming card fallback for ${
-              STREAMING_START_FAILURE_BACKOFF_MS / 1000
-            }s: ${String(error)}`,
+            `feishu[${account.accountId}]: streaming start failed with unknown delivery state: ${String(error)}`,
           );
         }
         if (streaming === session) {
@@ -628,6 +659,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         const result = createFeishuReplyDeliveryResult({
           results: [closed],
           visibleReplySent: closed.visibleReplySent,
+          ...(closed.visibilityUnknown ? { visibilityUnknown: true } : {}),
           content: closed.content,
           kind: "card",
         });
@@ -986,7 +1018,11 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     content: string | undefined,
     infoKind?: string,
   ): Promise<FeishuReplyDeliveryResult | undefined> => {
-    if (result?.visibleReplySent === true || !content?.trim()) {
+    if (
+      result?.visibleReplySent === true ||
+      result?.visibilityUnknown === true ||
+      !content?.trim()
+    ) {
       return result;
     }
     const cardHeader = resolveCardHeader(agentId, identity);
@@ -1259,6 +1295,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       // Typing cleanup can run between serialized deliveries; dispatcher settlement
       // is the owner boundary that proves this turn can no longer attempt a replay.
       terminalStreamingStartError = undefined;
+      streamingStartFallbackError = undefined;
     },
     onCleanup: () => {
       typingCallbacks?.onCleanup?.();
@@ -1485,27 +1522,50 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         if (useCard) {
           const cardHeader = resolveCardHeader(agentId, identity);
           const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
-          deliveredResults.push(
-            await sendChunkedTextReply({
-              text,
-              useCard: true,
-              infoKind: info?.kind,
-              chunkMentions: requiredMentionTargets,
-              sendChunk: async ({ chunk, mentions }) =>
-                await sendStructuredCardFeishu({
-                  cfg,
-                  to: sendTarget,
-                  text: chunk,
-                  replyToMessageId: sendReplyToMessageId,
-                  replyInThread: effectiveReplyInThread,
-                  allowTopLevelReplyFallback,
-                  accountId,
-                  header: cardHeader,
-                  note: cardNote,
-                  ...(mentions ? { mentions } : {}),
-                }),
-            }),
-          );
+          try {
+            deliveredResults.push(
+              await sendChunkedTextReply({
+                text,
+                useCard: true,
+                infoKind: info?.kind,
+                chunkMentions: requiredMentionTargets,
+                sendChunk: async ({ chunk, mentions }) =>
+                  await sendStructuredCardFeishu({
+                    cfg,
+                    to: sendTarget,
+                    text: chunk,
+                    replyToMessageId: sendReplyToMessageId,
+                    replyInThread: effectiveReplyInThread,
+                    allowTopLevelReplyFallback,
+                    accountId,
+                    header: cardHeader,
+                    note: cardNote,
+                    ...(mentions ? { mentions } : {}),
+                  }),
+              }),
+            );
+            streamingStartFallbackError = undefined;
+          } catch (fallbackError: unknown) {
+            const startError = streamingStartFallbackError;
+            streamingStartFallbackError = undefined;
+            if (!startError) {
+              throw fallbackError;
+            }
+            const fallbackPartial = isChannelPartialDeliveryError(fallbackError)
+              ? fallbackError.deliveryResult
+              : undefined;
+            const fallbackCause =
+              fallbackPartial && fallbackError instanceof Error
+                ? (fallbackError.cause ?? fallbackError)
+                : fallbackError;
+            throw createFeishuPartialReplyDeliveryError(
+              combineStreamingStartFallbackFailures(startError, fallbackCause),
+              mergeFeishuReplyDeliveryResults([
+                ...deliveredResults,
+                ...(fallbackPartial ? [fallbackPartial] : []),
+              ]),
+            );
+          }
         } else {
           const firstChunkMentions =
             info?.kind === "final" && mentionTargets?.length ? mentionTargets : undefined;

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -14,6 +14,7 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 import {
   PlatformMessageNotDispatchedError,
+  toErrorObject,
   toStringifiedError as toFeishuError,
 } from "openclaw/plugin-sdk/error-runtime";
 import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
@@ -347,7 +348,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
   let streamingStartFallbackError: PlatformMessageNotDispatchedError | undefined;
-  let terminalStreamingStartError: unknown;
+  let terminalStreamingStartError: Error | undefined;
   let streamingGeneration = 0;
   let activeStreamingGeneration: number | undefined;
   let inFlightStreamingClose:
@@ -552,7 +553,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         } else {
           // Transport failures do not prove whether the message API accepted custody.
           // Fence replay until the caller settles the ambiguous attempt.
-          terminalStreamingStartError = error;
+          terminalStreamingStartError = toErrorObject(error, "Feishu streaming start failed");
           params.runtime.error?.(
             `feishu[${account.accountId}]: streaming start failed with unknown delivery state: ${String(error)}`,
           );

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -1255,10 +1255,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       await Promise.resolve(typingCallbacks?.onReplyStart?.());
     },
     onIdle: () => queueIdleSideEffects(),
-    onCleanup: () => {
-      // Per-delivery cleanup may run between serialized block/final payloads.
-      // Release a terminal start rejection only when the logical turn is exhausted.
+    onSettled: () => {
+      // Typing cleanup can run between serialized deliveries; dispatcher settlement
+      // is the owner boundary that proves this turn can no longer attempt a replay.
       terminalStreamingStartError = undefined;
+    },
+    onCleanup: () => {
       typingCallbacks?.onCleanup?.();
     },
   };

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -12,7 +12,10 @@ import {
   resolveChannelPreviewStreamMode,
   resolveChannelStreamingBlockEnabled,
 } from "openclaw/plugin-sdk/channel-outbound";
-import { toStringifiedError as toFeishuError } from "openclaw/plugin-sdk/error-runtime";
+import {
+  PlatformMessageNotDispatchedError,
+  toStringifiedError as toFeishuError,
+} from "openclaw/plugin-sdk/error-runtime";
 import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import {
   getReplyPayloadTtsSupplement,
@@ -318,6 +321,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let sentIndependentBlockText = false;
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
+  let terminalStreamingStartError: PlatformMessageNotDispatchedError | undefined;
   let streamingGeneration = 0;
   let activeStreamingGeneration: number | undefined;
   let inFlightStreamingClose:
@@ -343,6 +347,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
   const markVisibleReplySent = () => {
     visibleReplySent = true;
+  };
+
+  const throwIfStreamingStartRejected = () => {
+    if (terminalStreamingStartError) {
+      throw terminalStreamingStartError;
+    }
   };
 
   const normalizeStreamingFinalizationFailure = (
@@ -460,6 +470,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       !streamingEnabled ||
       streamingStartPromise ||
       streaming ||
+      terminalStreamingStartError ||
       isStreamingStartBackedOff(account.accountId)
     ) {
       return;
@@ -500,12 +511,21 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         });
         streamingStartBackoffUntilByAccount.delete(account.accountId);
       } catch (error) {
-        rememberStreamingStartFailure(account.accountId);
-        params.runtime.error?.(
-          `feishu[${account.accountId}]: streaming start failed; using non-streaming card fallback for ${
-            STREAMING_START_FAILURE_BACKOFF_MS / 1000
-          }s: ${String(error)}`,
-        );
+        if (error instanceof PlatformMessageNotDispatchedError && !error.retryable) {
+          // A provider-declared no-send is terminal for this logical payload.
+          // Keep the fact until delivery consumes it instead of replaying statically.
+          terminalStreamingStartError = error;
+          params.runtime.error?.(
+            `feishu[${account.accountId}]: streaming start permanently rejected: ${String(error)}`,
+          );
+        } else {
+          rememberStreamingStartFailure(account.accountId);
+          params.runtime.error?.(
+            `feishu[${account.accountId}]: streaming start failed; using non-streaming card fallback for ${
+              STREAMING_START_FAILURE_BACKOFF_MS / 1000
+            }s: ${String(error)}`,
+          );
+        }
         if (streaming === session) {
           streaming = null;
           streamingStartPromise = null;
@@ -518,6 +538,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const resetStreamingState = () => {
     streaming = null;
     streamingStartPromise = null;
+    terminalStreamingStartError = undefined;
     activeStreamingGeneration = undefined;
     partialUpdateQueue = Promise.resolve();
     streamText = "";
@@ -699,6 +720,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         await streamingStartPromise;
       }
       await partialUpdateQueue;
+      throwIfStreamingStartRejected();
       if (streaming?.isActive()) {
         try {
           await streaming.discard();
@@ -1398,6 +1420,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           if (streamingStartPromise) {
             await streamingStartPromise;
           }
+          throwIfStreamingStartRejected();
         }
 
         if (info?.kind === "final" && useStreamingCard) {
@@ -1405,6 +1428,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           if (streamingStartPromise) {
             await streamingStartPromise;
           }
+          throwIfStreamingStartRejected();
         }
 
         const shouldStreamText = info?.kind === "block" || info?.kind === "final";

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -1048,7 +1048,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               [...(providerFinalized ? [providerFinalized] : []), completion.result],
               deliveryError === undefined
                 ? (completion.result.content ?? providerFinalized?.content)
-                : (providerFinalized?.content ?? completion.result.content),
+                : (providerFinalized?.content ?? ""),
             );
             if (deliveryError !== undefined) {
               completion.reject(

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -538,7 +538,6 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const resetStreamingState = () => {
     streaming = null;
     streamingStartPromise = null;
-    terminalStreamingStartError = undefined;
     activeStreamingGeneration = undefined;
     partialUpdateQueue = Promise.resolve();
     streamText = "";
@@ -1257,6 +1256,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     },
     onIdle: () => queueIdleSideEffects(),
     onCleanup: () => {
+      // Per-delivery cleanup may run between serialized block/final payloads.
+      // Release a terminal start rejection only when the logical turn is exhausted.
+      terminalStreamingStartError = undefined;
       typingCallbacks?.onCleanup?.();
     },
   };

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -345,6 +345,27 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     visibleReplySent = true;
   };
 
+  const normalizeStreamingFinalizationFailure = (
+    error: unknown,
+  ): { result: FeishuReplyDeliveryResult; error: Error } | undefined => {
+    if (!(error instanceof FeishuStreamingFinalizationError)) {
+      return undefined;
+    }
+    const result = createFeishuReplyDeliveryResult({
+      results: [error.result],
+      visibleReplySent: error.result.visibleReplySent,
+      content: error.result.content,
+      kind: "card",
+    });
+    if (result.visibleReplySent) {
+      markVisibleReplySent();
+    }
+    return {
+      result,
+      error: createFeishuPartialReplyDeliveryError(error.cause ?? error, result),
+    };
+  };
+
   const formatReasoningPrefix = (thinking: string): string => {
     if (!thinking) {
       return "";
@@ -549,23 +570,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         try {
           closed = await streamingToClose.closeWithResult(text, { note: finalNote });
         } catch (error: unknown) {
-          if (!(error instanceof FeishuStreamingFinalizationError)) {
+          const failure = normalizeStreamingFinalizationFailure(error);
+          if (!failure) {
             throw error;
           }
-          const failedResult = createFeishuReplyDeliveryResult({
-            results: [error.result],
-            visibleReplySent: error.result.visibleReplySent,
-            content: error.result.content,
-            kind: "card",
-          });
-          if (failedResult.visibleReplySent) {
-            markVisibleReplySent();
-          }
+          const failedResult = failure.result;
           if (failedResult.visibleReplySent && finalizedAnswerText) {
-            const partialError = createFeishuPartialReplyDeliveryError(
-              error.cause ?? error,
-              failedResult,
-            );
             if (failedResult.content === text) {
               deliveredFinalTexts.add(finalizedAnswerText);
             }
@@ -573,12 +583,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               generationToClose,
               finalizedAnswerText,
               failedResult,
-              partialError,
+              failure.error,
             );
             return {
               result: failedResult,
               ...(generationToClose === undefined ? {} : { generation: generationToClose }),
-              error: partialError,
+              error: failure.error,
             };
           }
           // Preserve the non-visible result so the settlement owner can recover the accepted
@@ -690,7 +700,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       }
       await partialUpdateQueue;
       if (streaming?.isActive()) {
-        await streaming.discard();
+        try {
+          await streaming.discard();
+        } catch (error: unknown) {
+          const failure = normalizeStreamingFinalizationFailure(error);
+          throw failure?.result.visibleReplySent ? failure.error : error;
+        }
       }
     } finally {
       resetStreamingState();

--- a/extensions/feishu/src/send-rate-limit.ts
+++ b/extensions/feishu/src/send-rate-limit.ts
@@ -1,6 +1,7 @@
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 
-const FEISHU_SEND_RATE_LIMIT_CODES = new Set([230020, 11232]);
+// Feishu documents these as retryable per-chat, tenant, legacy V4, and gateway throttles.
+const FEISHU_SEND_RATE_LIMIT_CODES = new Set([230020, 11232, 11233, 99991400]);
 
 export function getFeishuSendRateLimitCode(error: unknown): number | undefined {
   if (!isRecord(error)) {

--- a/extensions/feishu/src/send-result.test.ts
+++ b/extensions/feishu/src/send-result.test.ts
@@ -1,6 +1,46 @@
 import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import { describe, expect, it } from "vitest";
-import { toFeishuSendResult } from "./send-result.js";
+import { assertFeishuMessageApiSuccess, toFeishuSendResult } from "./send-result.js";
+
+describe("assertFeishuMessageApiSuccess", () => {
+  it("classifies a fulfilled permanent provider rejection without exposing raw response data", () => {
+    const secretBearingResponse = {
+      code: 230099,
+      msg: "card table number over limit",
+      requestHeaders: { authorization: "secret" },
+      card: { body: "private" },
+    };
+
+    let caught: unknown;
+    try {
+      assertFeishuMessageApiSuccess(secretBearingResponse, "Feishu card send failed");
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(PlatformMessageNotDispatchedError);
+    expect(caught).toMatchObject({ retryable: false, cause: secretBearingResponse });
+    expect((caught as Error).message).toBe(
+      "Feishu card send failed: card table number over limit (code=230099)",
+    );
+    expect((caught as Error).message).not.toContain("secret");
+    expect((caught as Error).message).not.toContain("private");
+  });
+
+  it("keeps a code-less fulfilled response ambiguous instead of accepting it", () => {
+    let caught: unknown;
+    try {
+      assertFeishuMessageApiSuccess({ msg: "malformed gateway response" }, "Feishu send failed");
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught).not.toBeInstanceOf(PlatformMessageNotDispatchedError);
+    expect((caught as Error).message).toBe("Feishu send failed: malformed gateway response");
+  });
+});
 
 describe("toFeishuSendResult", () => {
   it.each([undefined, "", "   "])(

--- a/extensions/feishu/src/send-result.ts
+++ b/extensions/feishu/src/send-result.ts
@@ -18,12 +18,49 @@ type FeishuMessageApiResponse = {
 };
 
 const FEISHU_PROVIDER_DIAGNOSTIC_MAX_CHARS = 500;
+const FEISHU_REJECTION_DIAGNOSTIC_MAX_CHARS = 2_000;
+const FEISHU_REJECTION_STRING_FIELDS = [
+  "feishu_msg",
+  "feishu_log_id",
+  "feishu_troubleshooter",
+] as const;
 
 function normalizeFeishuProviderDiagnostic(value: unknown): string | undefined {
   const normalized = normalizeOptionalString(value);
   return normalized
     ? sliceUtf16Safe(normalized, 0, FEISHU_PROVIDER_DIAGNOSTIC_MAX_CHARS)
     : undefined;
+}
+
+function serializeFeishuRejectionDiagnostics(details: {
+  http_status?: number;
+  feishu_code?: number;
+  feishu_msg?: string;
+  feishu_log_id?: string;
+  feishu_troubleshooter?: string;
+}): string {
+  const serialized = JSON.stringify(details);
+  if (serialized.length <= FEISHU_REJECTION_DIAGNOSTIC_MAX_CHARS) {
+    return serialized;
+  }
+  const bounded = { ...details };
+  let candidate = serialized;
+  // JSON escaping can expand pre-bounded inputs sixfold. Trim the longest encoded
+  // field until the final diagnostic, rather than only each input, honors the cap.
+  while (candidate.length > FEISHU_REJECTION_DIAGNOSTIC_MAX_CHARS) {
+    const field = FEISHU_REJECTION_STRING_FIELDS.filter((key) => bounded[key])
+      .toSorted(
+        (left, right) =>
+          JSON.stringify(bounded[right]).length - JSON.stringify(bounded[left]).length,
+      )
+      .at(0);
+    if (!field) {
+      break;
+    }
+    bounded[field] = sliceUtf16Safe(bounded[field] ?? "", 0, -1);
+    candidate = JSON.stringify(bounded);
+  }
+  return candidate;
 }
 
 function createFeishuMessageRejection(params: {
@@ -64,7 +101,7 @@ export function createFeishuRejectedMessageApiError(
         response: data,
         errorPrefix,
         cause: error,
-        detail: JSON.stringify({
+        detail: serializeFeishuRejectionDiagnostics({
           http_status: typeof response?.status === "number" ? response.status : undefined,
           feishu_code: typeof data.code === "number" ? data.code : undefined,
           feishu_msg: normalizeFeishuProviderDiagnostic(data.msg),

--- a/extensions/feishu/src/send-result.ts
+++ b/extensions/feishu/src/send-result.ts
@@ -5,6 +5,9 @@ import {
   type MessageReceipt,
   type MessageReceiptPartKind,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
+import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 type FeishuMessageApiResponse = {
   code?: number;
@@ -13,6 +16,44 @@ type FeishuMessageApiResponse = {
     message_id?: string;
   };
 };
+
+const FEISHU_PROVIDER_ERROR_MESSAGE_MAX_CHARS = 500;
+
+function createFeishuMessageRejection(params: {
+  response: unknown;
+  errorPrefix: string;
+  cause: unknown;
+}): PlatformMessageNotDispatchedError | undefined {
+  const response = isRecord(params.response) ? params.response : undefined;
+  if (!response) {
+    return undefined;
+  }
+  if (typeof response.code !== "number" || response.code === 0) {
+    return undefined;
+  }
+  const providerMessage = normalizeOptionalString(response.msg);
+  const detail = providerMessage
+    ? `${sliceUtf16Safe(providerMessage, 0, FEISHU_PROVIDER_ERROR_MESSAGE_MAX_CHARS)} (code=${response.code})`
+    : `code ${response.code}`;
+  return new PlatformMessageNotDispatchedError(`${params.errorPrefix}: ${detail}`, {
+    cause: params.cause,
+    retryable: false,
+  });
+}
+
+export function createFeishuRejectedMessageApiError(
+  error: unknown,
+  errorPrefix: string,
+): PlatformMessageNotDispatchedError | undefined {
+  if (!isRecord(error)) {
+    return undefined;
+  }
+  const response = isRecord(error.response) ? error.response : undefined;
+  const data = isRecord(response?.data) ? response.data : undefined;
+  return data
+    ? createFeishuMessageRejection({ response: data, errorPrefix, cause: error })
+    : undefined;
+}
 
 export function resolveFeishuReceiptKind(msgType?: string): MessageReceiptPartKind {
   switch (msgType) {
@@ -59,9 +100,14 @@ export function assertFeishuMessageApiSuccess(
   response: FeishuMessageApiResponse,
   errorPrefix: string,
 ) {
-  if (response.code !== 0) {
-    throw new Error(`${errorPrefix}: ${response.msg || `code ${response.code}`}`);
+  if (response.code === 0) {
+    return;
   }
+  const rejection = createFeishuMessageRejection({ response, errorPrefix, cause: response });
+  if (rejection) {
+    throw rejection;
+  }
+  throw new Error(`${errorPrefix}: ${response.msg || `code ${response.code}`}`);
 }
 
 export function toFeishuSendResult(

--- a/extensions/feishu/src/send-result.ts
+++ b/extensions/feishu/src/send-result.ts
@@ -17,12 +17,20 @@ type FeishuMessageApiResponse = {
   };
 };
 
-const FEISHU_PROVIDER_ERROR_MESSAGE_MAX_CHARS = 500;
+const FEISHU_PROVIDER_DIAGNOSTIC_MAX_CHARS = 500;
+
+function normalizeFeishuProviderDiagnostic(value: unknown): string | undefined {
+  const normalized = normalizeOptionalString(value);
+  return normalized
+    ? sliceUtf16Safe(normalized, 0, FEISHU_PROVIDER_DIAGNOSTIC_MAX_CHARS)
+    : undefined;
+}
 
 function createFeishuMessageRejection(params: {
   response: unknown;
   errorPrefix: string;
   cause: unknown;
+  detail?: string;
 }): PlatformMessageNotDispatchedError | undefined {
   const response = isRecord(params.response) ? params.response : undefined;
   if (!response) {
@@ -31,10 +39,10 @@ function createFeishuMessageRejection(params: {
   if (typeof response.code !== "number" || response.code === 0) {
     return undefined;
   }
-  const providerMessage = normalizeOptionalString(response.msg);
-  const detail = providerMessage
-    ? `${sliceUtf16Safe(providerMessage, 0, FEISHU_PROVIDER_ERROR_MESSAGE_MAX_CHARS)} (code=${response.code})`
-    : `code ${response.code}`;
+  const providerMessage = normalizeFeishuProviderDiagnostic(response.msg);
+  const detail =
+    params.detail ??
+    (providerMessage ? `${providerMessage} (code=${response.code})` : `code ${response.code}`);
   return new PlatformMessageNotDispatchedError(`${params.errorPrefix}: ${detail}`, {
     cause: params.cause,
     retryable: false,
@@ -50,8 +58,24 @@ export function createFeishuRejectedMessageApiError(
   }
   const response = isRecord(error.response) ? error.response : undefined;
   const data = isRecord(response?.data) ? response.data : undefined;
+  const nestedError = isRecord(data?.error) ? data.error : undefined;
   return data
-    ? createFeishuMessageRejection({ response: data, errorPrefix, cause: error })
+    ? createFeishuMessageRejection({
+        response: data,
+        errorPrefix,
+        cause: error,
+        detail: JSON.stringify({
+          http_status: typeof response?.status === "number" ? response.status : undefined,
+          feishu_code: typeof data.code === "number" ? data.code : undefined,
+          feishu_msg: normalizeFeishuProviderDiagnostic(data.msg),
+          feishu_log_id:
+            normalizeFeishuProviderDiagnostic(data.log_id) ??
+            normalizeFeishuProviderDiagnostic(nestedError?.log_id),
+          feishu_troubleshooter:
+            normalizeFeishuProviderDiagnostic(data.troubleshooter) ??
+            normalizeFeishuProviderDiagnostic(nestedError?.troubleshooter),
+        }),
+      })
     : undefined;
 }
 

--- a/extensions/feishu/src/send-result.ts
+++ b/extensions/feishu/src/send-result.ts
@@ -83,6 +83,9 @@ function createFeishuMessageRejection(params: {
   return new PlatformMessageNotDispatchedError(`${params.errorPrefix}: ${detail}`, {
     cause: params.cause,
     retryable: false,
+    publicError: {
+      code: String(response.code),
+    },
   });
 }
 

--- a/extensions/feishu/src/send.reply-fallback.test.ts
+++ b/extensions/feishu/src/send.reply-fallback.test.ts
@@ -6,6 +6,8 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vites
 const resolveFeishuSendTargetMock = vi.hoisted(() => vi.fn());
 const resolveMarkdownTableModeMock = vi.hoisted(() => vi.fn(() => "preserve"));
 const convertMarkdownTablesMock = vi.hoisted(() => vi.fn((text: string) => text));
+const UNPAIRED_SURROGATE_RE =
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
 
 vi.mock("./send-target.js", () => ({
   resolveFeishuSendTarget: resolveFeishuSendTargetMock,
@@ -100,6 +102,47 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
       /Feishu send failed: .*"http_status":400.*"feishu_code":9499.*"feishu_msg":"Bad Request".*"feishu_log_id":"202604291247104BEF4C42D2420A9AD569".*"feishu_troubleshooter":"https:\/\/open\.feishu\.cn\/search\?log_id=202604291247104BEF4C42D2420A9AD569"/,
     );
     expect((error as Error).message).not.toMatch(/private|secret/);
+    expect(createMock).toHaveBeenCalledOnce();
+  });
+
+  it("bounds aggregate diagnostics after JSON escaping", async () => {
+    const escaped = (prefix: string) => `${prefix}${'\0"\\😀'.repeat(150)}`;
+    const apiError = Object.assign(new Error("private transport error"), {
+      config: { headers: { authorization: "secret request token" } },
+      response: {
+        status: 400,
+        data: {
+          code: 9499,
+          msg: escaped("message:"),
+          error: {
+            log_id: escaped("log:"),
+            troubleshooter: escaped("troubleshooter:"),
+          },
+          request_payload: "private response echo",
+        },
+      },
+    });
+    createMock.mockRejectedValue(apiError);
+
+    const error = await sendMessageFeishu({
+      cfg: {} as never,
+      to: "user:ou_target",
+      text: "hello",
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(PlatformMessageNotDispatchedError);
+    expect(error).toMatchObject({ retryable: false, cause: apiError });
+    const prefix = "Feishu send failed: ";
+    expect((error as Error).message.startsWith(prefix)).toBe(true);
+    const serialized = (error as Error).message.slice(prefix.length);
+    expect(serialized.length).toBeLessThanOrEqual(2_000);
+    expect(serialized).not.toMatch(UNPAIRED_SURROGATE_RE);
+    const details = JSON.parse(serialized) as Record<string, unknown>;
+    expect(details).toMatchObject({ http_status: 400, feishu_code: 9499 });
+    expect(details.feishu_msg).toMatch(/^message:/u);
+    expect(details.feishu_log_id).toMatch(/^log:/u);
+    expect(details.feishu_troubleshooter).toMatch(/^troubleshooter:/u);
+    expect(serialized).not.toMatch(/private|secret/u);
     expect(createMock).toHaveBeenCalledOnce();
   });
 

--- a/extensions/feishu/src/send.reply-fallback.test.ts
+++ b/extensions/feishu/src/send.reply-fallback.test.ts
@@ -1,5 +1,6 @@
 // Feishu tests cover send.reply fallback plugin behavior.
 import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const resolveFeishuSendTargetMock = vi.hoisted(() => vi.fn());
@@ -67,6 +68,10 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
 
   it("preserves Feishu diagnostics when direct sends reject before response checks", async () => {
     const apiError = Object.assign(new Error("Request failed with status code 400"), {
+      config: {
+        data: { content: "private request payload" },
+        headers: { authorization: "secret request token" },
+      },
       response: {
         status: 400,
         data: {
@@ -77,20 +82,25 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
             troubleshooter:
               "https://open.feishu.cn/search?log_id=202604291247104BEF4C42D2420A9AD569",
           },
+          request_payload: "private response echo",
         },
       },
     });
     createMock.mockRejectedValue(apiError);
 
-    await expect(
-      sendMessageFeishu({
-        cfg: {} as never,
-        to: "user:ou_target",
-        text: "hello",
-      }),
-    ).rejects.toThrow(
+    const error = await sendMessageFeishu({
+      cfg: {} as never,
+      to: "user:ou_target",
+      text: "hello",
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(PlatformMessageNotDispatchedError);
+    expect(error).toMatchObject({ retryable: false, cause: apiError });
+    expect((error as Error).message).toMatch(
       /Feishu send failed: .*"http_status":400.*"feishu_code":9499.*"feishu_msg":"Bad Request".*"feishu_log_id":"202604291247104BEF4C42D2420A9AD569".*"feishu_troubleshooter":"https:\/\/open\.feishu\.cn\/search\?log_id=202604291247104BEF4C42D2420A9AD569"/,
     );
+    expect((error as Error).message).not.toMatch(/private|secret/);
+    expect(createMock).toHaveBeenCalledOnce();
   });
 
   it("falls back to create for withdrawn post replies", async () => {

--- a/extensions/feishu/src/send.retry.test.ts
+++ b/extensions/feishu/src/send.retry.test.ts
@@ -137,7 +137,7 @@ describe("requestFeishuApi — no retry for non-rate-limit errors", () => {
     expect(error).toBeInstanceOf(PlatformMessageNotDispatchedError);
     expect(error).toMatchObject({ retryable: false, cause: rejected });
     expect((error as Error).message).toBe(
-      "Feishu card send failed: card table number over limit (code=230099)",
+      'Feishu card send failed: {"http_status":400,"feishu_code":230099,"feishu_msg":"card table number over limit"}',
     );
     expect(request).toHaveBeenCalledTimes(1);
   });

--- a/extensions/feishu/src/send.retry.test.ts
+++ b/extensions/feishu/src/send.retry.test.ts
@@ -5,6 +5,7 @@
  * so no fake timers are needed. Related: issue #70879.
  */
 
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { requestFeishuApi } from "./comment-shared.js";
 import {
@@ -124,6 +125,23 @@ describe("requestFeishuApi — retry on rate-limit", () => {
 });
 
 describe("requestFeishuApi — no retry for non-rate-limit errors", () => {
+  it("classifies a structured rejected message response as a permanent non-dispatch", async () => {
+    const rejected = axiosError(230099);
+    rejected.response.data.msg = "card table number over limit";
+    const request = vi.fn().mockRejectedValue(rejected);
+
+    const error = await requestFeishuApi(request, "Feishu card send failed", NO_DELAY).catch(
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toBeInstanceOf(PlatformMessageNotDispatchedError);
+    expect(error).toMatchObject({ retryable: false, cause: rejected });
+    expect((error as Error).message).toBe(
+      "Feishu card send failed: card table number over limit (code=230099)",
+    );
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
   it("throws immediately without retry for a non-rate-limit Feishu code", async () => {
     const request = vi.fn().mockRejectedValue(axiosError(230001));
 
@@ -135,6 +153,22 @@ describe("requestFeishuApi — no retry for non-rate-limit errors", () => {
     const request = vi.fn().mockRejectedValue(new Error("network failure"));
 
     await expect(requestFeishuApi(request, "prefix", NO_DELAY)).rejects.toThrow(/network failure/);
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps code-less transport failures ambiguous", async () => {
+    const request = vi.fn().mockRejectedValue(
+      Object.assign(new Error("socket closed"), {
+        response: { status: 502, data: { msg: "gateway unavailable" } },
+      }),
+    );
+
+    const error = await requestFeishuApi(request, "prefix", NO_DELAY).catch(
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(PlatformMessageNotDispatchedError);
     expect(request).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/feishu/src/send.retry.test.ts
+++ b/extensions/feishu/src/send.retry.test.ts
@@ -61,6 +61,10 @@ describe("getFeishuSendRateLimitCode", () => {
   it("returns undefined for null", () => {
     expect(getFeishuSendRateLimitCode(null)).toBeUndefined();
   });
+
+  it.each([11233, 99991400])("returns %s for a documented HTTP-400 rate-limit body", (code) => {
+    expect(getFeishuSendRateLimitCode(axiosError(code))).toBe(code);
+  });
 });
 
 describe("requestFeishuApi — success path", () => {
@@ -227,7 +231,8 @@ describe("requestFeishuApi — retry on expanded rate-limit signals", () => {
     const err = await requestFeishuApi(request, "Feishu send failed", NO_DELAY).catch(
       (e: unknown) => e,
     );
-    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(PlatformMessageNotDispatchedError);
+    expect(err).toMatchObject({ retryable: true, publicError: { code: "11232" } });
     expect((err as Error).message).toMatch(/11232/);
     // 1 initial attempt + 2 retries
     expect(request).toHaveBeenCalledTimes(3);
@@ -239,7 +244,8 @@ describe("requestFeishuApi — retry on expanded rate-limit signals", () => {
     const err = await requestFeishuApi(request, "Feishu send failed", NO_DELAY).catch(
       (e: unknown) => e,
     );
-    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(PlatformMessageNotDispatchedError);
+    expect(err).toMatchObject({ retryable: true, publicError: { code: "429" } });
     // The error wrapper records http_status:429 in the JSON-encoded message.
     expect((err as Error).message).toMatch(/429/);
     expect(request).toHaveBeenCalledTimes(3);
@@ -256,6 +262,21 @@ describe("requestFeishuApi — retry on expanded rate-limit signals", () => {
     expect(result).toBe("ok-mixed");
     expect(request).toHaveBeenCalledTimes(3);
   });
+
+  it.each([11233, 99991400])(
+    "retries an HTTP-400 response carrying documented rate-limit code %s",
+    async (code) => {
+      const request = vi
+        .fn()
+        .mockRejectedValueOnce(axiosError(code))
+        .mockResolvedValueOnce("ok-after-rate-limit");
+
+      await expect(requestFeishuApi(request, "prefix", NO_DELAY)).resolves.toBe(
+        "ok-after-rate-limit",
+      );
+      expect(request).toHaveBeenCalledTimes(2);
+    },
+  );
 });
 
 // Feishu SDK can fulfill (no throw) with a rate-limit code in the body, e.g.
@@ -284,6 +305,10 @@ describe("getFeishuSendRateLimitCodeFromResponse — fulfilled body classificati
     expect(getFeishuSendRateLimitCodeFromResponse(null)).toBeUndefined();
     expect(getFeishuSendRateLimitCodeFromResponse(undefined)).toBeUndefined();
     expect(getFeishuSendRateLimitCodeFromResponse("oops")).toBeUndefined();
+  });
+
+  it.each([11233, 99991400])("returns %s for a fulfilled rate-limit body", (code) => {
+    expect(getFeishuSendRateLimitCodeFromResponse({ code, msg: "rate limit" })).toBe(code);
   });
 });
 
@@ -318,7 +343,8 @@ describe("requestFeishuApi — retry on fulfilled rate-limit body (no throw)", (
     const err = await requestFeishuApi(request, "Feishu send failed", NO_DELAY).catch(
       (e: unknown) => e,
     );
-    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(PlatformMessageNotDispatchedError);
+    expect(err).toMatchObject({ retryable: true, publicError: { code: "11232" } });
     expect((err as Error).message).toMatch(/Feishu send failed/);
     expect((err as Error).message).toMatch(/11232/);
     // 1 initial attempt + 2 retries
@@ -332,6 +358,22 @@ describe("requestFeishuApi — retry on fulfilled rate-limit body (no throw)", (
     expect((result as { data: { message_id: string } }).data.message_id).toBe("om_first");
     expect(request).toHaveBeenCalledTimes(1);
   });
+
+  it.each([11233, 99991400])(
+    "retries when the SDK fulfills with documented rate-limit code %s",
+    async (code) => {
+      const request = vi
+        .fn()
+        .mockResolvedValueOnce({ code, msg: "rate limit" })
+        .mockResolvedValueOnce({ code: 0, data: { message_id: "om_ok" } });
+
+      await expect(requestFeishuApi(request, "prefix", NO_DELAY)).resolves.toEqual({
+        code: 0,
+        data: { message_id: "om_ok" },
+      });
+      expect(request).toHaveBeenCalledTimes(2);
+    },
+  );
 
   it("does not retry when SDK fulfills with a non-rate-limit error code", async () => {
     // Non-retryable error codes pass through to assertFeishuMessageApiSuccess upstream.

--- a/extensions/feishu/src/streaming-card.error-release.test.ts
+++ b/extensions/feishu/src/streaming-card.error-release.test.ts
@@ -140,7 +140,9 @@ describe("feishu streaming card error-path body release", () => {
     await session.start("chat_id", "open_id");
     loopback.settingsStatus = 500;
 
-    await expect(session.close()).resolves.toBe(false);
+    await expect(session.closeWithResult()).rejects.toMatchObject({
+      result: { visibleReplySent: false },
+    });
 
     expect(loopback.releases).toEqual([
       { bodyIsNull: false, bodyUsed: true },

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -363,30 +363,33 @@ describe("FeishuStreamingSession", () => {
     { mode: "reply", options: { replyToMessageId: "om_parent" } },
     { mode: "root-create", options: { rootId: "om_root" } },
     { mode: "create", options: undefined },
-  ])("finalizes an accepted no-identity card in place in $mode mode", async ({ mode, options }) => {
-    const harness = createStartHarness({ code: 0, msg: "ok" });
-    const session = new FeishuStreamingSession(
-      harness.client,
-      { appId: `app_no_id_${mode}`, appSecret: "secret" },
-      undefined,
-      harness.deps,
-    );
+  ])(
+    "proves no-identity visibility after the first CardKit content write in $mode mode",
+    async ({ mode, options }) => {
+      const harness = createStartHarness({ code: 0, msg: "ok" });
+      const session = new FeishuStreamingSession(
+        harness.client,
+        { appId: `app_no_id_${mode}`, appSecret: "secret" },
+        undefined,
+        harness.deps,
+      );
 
-    await session.start("oc_chat", "chat_id", options);
-    expect(session.isActive()).toBe(true);
-    const result = await session.closeWithResult("exact final answer");
+      await session.start("oc_chat", "chat_id", options);
+      expect(session.isActive()).toBe(true);
+      const result = await session.closeWithResult("exact final answer");
 
-    expect(result).toEqual({ visibleReplySent: true, content: "exact final answer" });
-    expect(session.isActive()).toBe(false);
-    expect(harness.messageCreate.mock.calls.length + harness.messageReply.mock.calls.length).toBe(
-      1,
-    );
-    expect(
-      harness.requests.filter(({ path }) => path.includes("/elements/content/content")),
-    ).toHaveLength(1);
-    expect(harness.requests.filter(({ path }) => path.endsWith("/settings"))).toHaveLength(1);
-    expect(harness.messageDelete).not.toHaveBeenCalled();
-  });
+      expect(result).toEqual({ visibleReplySent: true, content: "exact final answer" });
+      expect(session.isActive()).toBe(false);
+      expect(harness.messageCreate.mock.calls.length + harness.messageReply.mock.calls.length).toBe(
+        1,
+      );
+      expect(
+        harness.requests.filter(({ path }) => path.includes("/elements/content/content")),
+      ).toHaveLength(1);
+      expect(harness.requests.filter(({ path }) => path.endsWith("/settings"))).toHaveLength(1);
+      expect(harness.messageDelete).not.toHaveBeenCalled();
+    },
+  );
 
   it("disposes an accepted no-identity card in place without attempting message deletion", async () => {
     const harness = createStartHarness({ code: 0, msg: "ok" });
@@ -407,7 +410,7 @@ describe("FeishuStreamingSession", () => {
   });
 
   it.each(["content", "settings"] as const)(
-    "reports accepted no-identity custody when %s finalization fails",
+    "reports no-identity visibility only after CardKit accepts content when %s finalization fails",
     async (rejectedPath) => {
       const harness = createStartHarness({ code: 0, msg: "ok" }, rejectedPath);
       const session = new FeishuStreamingSession(
@@ -425,7 +428,9 @@ describe("FeishuStreamingSession", () => {
       expect(error).toBeInstanceOf(FeishuStreamingFinalizationError);
       expect(error).toMatchObject({
         result: {
-          visibleReplySent: true,
+          ...(rejectedPath === "content"
+            ? { visibleReplySent: false, visibilityUnknown: true }
+            : { visibleReplySent: true }),
           ...(rejectedPath === "settings" ? { content: "final answer" } : {}),
         },
       });

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -1,5 +1,6 @@
 // Feishu tests cover streaming card plugin behavior.
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -15,7 +16,7 @@ type FeishuStreamingFetch = typeof fetch;
 
 type StreamingSessionState = {
   cardId: string;
-  messageId: string;
+  messageId?: string;
   sequence: number;
   currentText: string;
   sentText: string;
@@ -286,6 +287,154 @@ describe("FeishuStreamingSession", () => {
     } as unknown as ConstructorParameters<typeof FeishuStreamingSession>[0];
     return { authTokens, client, deps };
   }
+
+  function createStartHarness(
+    response: { code: number; msg: string; messageId?: string },
+    rejectCardKitPath?: "content" | "settings",
+  ) {
+    const sendResponse = async () => ({
+      code: response.code,
+      msg: response.msg,
+      data: response.messageId ? { message_id: response.messageId } : {},
+    });
+    const messageCreate = vi.fn(sendResponse);
+    const messageReply = vi.fn(sendResponse);
+    const messageDelete = vi.fn(async () => ({ code: 0, msg: "ok" }));
+    const client = {
+      im: { message: { create: messageCreate, reply: messageReply, delete: messageDelete } },
+    } as unknown as ConstructorParameters<typeof FeishuStreamingSession>[0];
+    const requests: Array<{ path: string; body: string }> = [];
+    const deps = createMemoryFetch((url, body) => {
+      requests.push({ path: url.pathname, body });
+      if (url.pathname.includes("/auth/")) {
+        return jsonResponse({
+          code: 0,
+          msg: "ok",
+          tenant_access_token: "token",
+          expire: 7200,
+        });
+      }
+      if (url.pathname.endsWith("/cardkit/v1/cards")) {
+        return jsonResponse({ code: 0, msg: "ok", data: { card_id: "card_start" } });
+      }
+      if (
+        (rejectCardKitPath === "content" && url.pathname.includes("/elements/content/content")) ||
+        (rejectCardKitPath === "settings" && url.pathname.endsWith("/settings"))
+      ) {
+        return jsonResponse({ code: 19001, msg: `${rejectCardKitPath} rejected` });
+      }
+      return jsonResponse({ code: 0, msg: "ok" });
+    });
+    return { client, deps, messageCreate, messageReply, messageDelete, requests };
+  }
+
+  it.each([
+    { mode: "reply", options: { replyToMessageId: "om_parent" } },
+    { mode: "root-create", options: { rootId: "om_root" } },
+    { mode: "create", options: undefined },
+  ])("classifies fulfilled permanent rejection in $mode mode", async ({ mode, options }) => {
+    const harness = createStartHarness({
+      code: 230099,
+      msg: "card table number over limit",
+    });
+    const session = new FeishuStreamingSession(
+      harness.client,
+      { appId: `app_rejected_${mode}`, appSecret: "secret" },
+      undefined,
+      harness.deps,
+    );
+
+    const error = await session
+      .start("oc_chat", "chat_id", options)
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(PlatformMessageNotDispatchedError);
+    expect(error).toMatchObject({ retryable: false });
+    expect((error as Error).message).toBe(
+      "Send card failed: card table number over limit (code=230099)",
+    );
+    expect(session.isActive()).toBe(false);
+    expect(harness.messageCreate.mock.calls.length + harness.messageReply.mock.calls.length).toBe(
+      1,
+    );
+  });
+
+  it.each([
+    { mode: "reply", options: { replyToMessageId: "om_parent" } },
+    { mode: "root-create", options: { rootId: "om_root" } },
+    { mode: "create", options: undefined },
+  ])("finalizes an accepted no-identity card in place in $mode mode", async ({ mode, options }) => {
+    const harness = createStartHarness({ code: 0, msg: "ok" });
+    const session = new FeishuStreamingSession(
+      harness.client,
+      { appId: `app_no_id_${mode}`, appSecret: "secret" },
+      undefined,
+      harness.deps,
+    );
+
+    await session.start("oc_chat", "chat_id", options);
+    expect(session.isActive()).toBe(true);
+    const result = await session.closeWithResult("exact final answer");
+
+    expect(result).toEqual({ visibleReplySent: true, content: "exact final answer" });
+    expect(session.isActive()).toBe(false);
+    expect(harness.messageCreate.mock.calls.length + harness.messageReply.mock.calls.length).toBe(
+      1,
+    );
+    expect(
+      harness.requests.filter(({ path }) => path.includes("/elements/content/content")),
+    ).toHaveLength(1);
+    expect(harness.requests.filter(({ path }) => path.endsWith("/settings"))).toHaveLength(1);
+    expect(harness.messageDelete).not.toHaveBeenCalled();
+  });
+
+  it("disposes an accepted no-identity card in place without attempting message deletion", async () => {
+    const harness = createStartHarness({ code: 0, msg: "ok" });
+    const session = new FeishuStreamingSession(
+      harness.client,
+      { appId: "app_no_id_discard", appSecret: "secret" },
+      undefined,
+      harness.deps,
+    );
+
+    await session.start("oc_chat", "chat_id");
+    await session.discard();
+    await session.discard();
+
+    expect(harness.messageDelete).not.toHaveBeenCalled();
+    expect(harness.requests.filter(({ path }) => path.endsWith("/settings"))).toHaveLength(1);
+    expect(session.isActive()).toBe(false);
+  });
+
+  it.each(["content", "settings"] as const)(
+    "reports accepted no-identity custody when %s finalization fails",
+    async (rejectedPath) => {
+      const harness = createStartHarness({ code: 0, msg: "ok" }, rejectedPath);
+      const session = new FeishuStreamingSession(
+        harness.client,
+        { appId: `app_no_id_failed_${rejectedPath}`, appSecret: "secret" },
+        undefined,
+        harness.deps,
+      );
+
+      await session.start("oc_chat", "chat_id");
+      const error = await session
+        .closeWithResult("final answer")
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(FeishuStreamingFinalizationError);
+      expect(error).toMatchObject({
+        result: {
+          visibleReplySent: true,
+          ...(rejectedPath === "settings" ? { content: "final answer" } : {}),
+        },
+      });
+      expect((error as FeishuStreamingFinalizationError).result.messageId).toBeUndefined();
+      expect(harness.messageDelete).not.toHaveBeenCalled();
+      expect(harness.requests.filter(({ path }) => path.endsWith("/settings"))).toHaveLength(1);
+      expect(session.isActive()).toBe(false);
+    },
+  );
 
   it("rejects oversized streaming tenant-token JSON before buffering the full body", async () => {
     let streamState:
@@ -637,7 +786,7 @@ describe("FeishuStreamingSession", () => {
     expect(updateBodies).toHaveLength(0);
     expect(replaceBodies).toHaveLength(0);
 
-    await session.close();
+    await session.closeWithResult();
 
     expect(updateBodies).toHaveLength(0);
     expect(replaceBodies).toHaveLength(1);
@@ -693,8 +842,8 @@ describe("FeishuStreamingSession", () => {
     });
 
     await session.update(next);
-    // close() reports whether any accepted content remains visible, even when the final rewrite fails.
-    await expect(session.close()).resolves.toBe(true);
+    const error = await session.closeWithResult().catch((caught: unknown) => caught);
+    expect(error).toMatchObject({ result: { visibleReplySent: true, content: previous } });
 
     expect(replaceBodies).toHaveLength(1);
     expect(settingsBodies).toHaveLength(1);
@@ -887,7 +1036,7 @@ describe("FeishuStreamingSession", () => {
       lastUpdateTime: 3_000,
     });
 
-    await session.close("final answer");
+    await session.closeWithResult("final answer");
 
     expect(updateBodies).toHaveLength(0);
     expect(replaceBodies).toHaveLength(1);
@@ -955,7 +1104,7 @@ describe("FeishuStreamingSession", () => {
       lastUpdateTime: 3_000,
     });
 
-    await session.close(finalText);
+    await session.closeWithResult(finalText);
 
     expect(settingsBodies).toHaveLength(1);
     const settingsPayload = JSON.parse(settingsBodies[0] ?? "{}") as { settings?: string };
@@ -1005,7 +1154,9 @@ describe("FeishuStreamingSession", () => {
       lastUpdateTime: 3_000,
     });
 
-    await session.close("final answer");
+    await expect(session.closeWithResult("final answer")).rejects.toBeInstanceOf(
+      FeishuStreamingFinalizationError,
+    );
 
     expect(updateBodies).toHaveLength(0);
     expect(replaceBodies).toHaveLength(1);
@@ -1043,7 +1194,9 @@ describe("FeishuStreamingSession", () => {
       lastUpdateTime: 3_000,
     });
 
-    await expect(session.close("final answer")).resolves.toBe(false);
+    await expect(session.closeWithResult("final answer")).rejects.toMatchObject({
+      result: { visibleReplySent: false },
+    });
 
     expect(updateBodies).toHaveLength(1);
     expect(replaceBodies).toHaveLength(0);

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -47,6 +47,7 @@ type CardKitResponse = { code?: number; msg?: string };
 
 type FeishuStreamingCloseResult = {
   visibleReplySent: boolean;
+  visibilityUnknown?: true;
   content?: string;
   messageId?: string;
 };
@@ -640,7 +641,7 @@ export class FeishuStreamingSession {
     const apiBase = resolveApiBase(this.creds.domain);
     // A failed final rewrite does not erase previously accepted visible content.
     // sentText advances only for an accepted write; the return value reports any visible content.
-    let visibleContentSent = !this.state.messageId || Boolean(this.state.sentText.trim());
+    let visibleContentSent = Boolean(this.state.sentText.trim());
     let finalWriteError: unknown;
 
     // Only send final update if content differs from what's already displayed.
@@ -722,6 +723,7 @@ export class FeishuStreamingSession {
     this.log?.(`Closed streaming: cardId=${finalState.cardId}`);
     const result: FeishuStreamingCloseResult = {
       visibleReplySent: visibleContentSent,
+      ...(!visibleContentSent && !finalState.messageId ? { visibilityUnknown: true } : {}),
       ...(finalState.sentText.trim() ? { content: finalState.sentText } : {}),
       ...(finalState.messageId ? { messageId: finalState.messageId } : {}),
     };

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -14,6 +14,7 @@ import { FEISHU_HTTP_TIMEOUT_MS } from "./client-timeout.js";
 import { getFeishuUserAgent } from "./client.js";
 import { requestFeishuApi } from "./comment-shared.js";
 import { readFeishuJsonResponse } from "./json-response.js";
+import { assertFeishuMessageApiSuccess } from "./send-result.js";
 import { resolveFeishuCardTemplate, type CardHeaderConfig } from "./send.js";
 import { resolveStreamingCardSendMode } from "./streaming-card-send-mode.js";
 import type { FeishuDomain } from "./types.js";
@@ -26,7 +27,7 @@ type Credentials = {
 };
 type CardState = {
   cardId: string;
-  messageId: string;
+  messageId: string | undefined;
   sequence: number;
   currentText: string;
   sentText: string;
@@ -399,19 +400,18 @@ export class FeishuStreamingSession {
         "Send card failed",
       );
     }
-    if (sendRes.code !== 0 || !sendRes.data?.message_id) {
-      throw new Error(`Send card failed: ${sendRes.msg}`);
-    }
+    assertFeishuMessageApiSuccess(sendRes, "Send card failed");
+    const messageId = sendRes.data?.message_id?.trim() || undefined;
 
     this.state = {
       cardId,
-      messageId: sendRes.data.message_id,
+      messageId,
       sequence: 1,
       currentText: "",
       sentText: "",
       hasNote: Boolean(options?.note),
     };
-    this.log?.(`Started streaming: cardId=${cardId}, messageId=${sendRes.data.message_id}`);
+    this.log?.(`Started streaming: cardId=${cardId}, messageId=${messageId ?? "unavailable"}`);
   }
 
   private async updateCardContent(
@@ -640,7 +640,7 @@ export class FeishuStreamingSession {
     const apiBase = resolveApiBase(this.creds.domain);
     // A failed final rewrite does not erase previously accepted visible content.
     // sentText advances only for an accepted write; the return value reports any visible content.
-    let visibleContentSent = Boolean(this.state.sentText.trim());
+    let visibleContentSent = !this.state.messageId || Boolean(this.state.sentText.trim());
     let finalWriteError: unknown;
 
     // Only send final update if content differs from what's already displayed.
@@ -722,8 +722,8 @@ export class FeishuStreamingSession {
     this.log?.(`Closed streaming: cardId=${finalState.cardId}`);
     const result: FeishuStreamingCloseResult = {
       visibleReplySent: visibleContentSent,
-      ...(visibleContentSent ? { content: finalState.sentText } : {}),
-      messageId: finalState.messageId,
+      ...(finalState.sentText.trim() ? { content: finalState.sentText } : {}),
+      ...(finalState.messageId ? { messageId: finalState.messageId } : {}),
     };
     if (finalWriteError !== undefined || closeError !== undefined) {
       const cause =
@@ -738,19 +738,16 @@ export class FeishuStreamingSession {
     return result;
   }
 
-  async close(finalText?: string, options?: { note?: string }): Promise<boolean> {
-    try {
-      return (await this.closeWithResult(finalText, options)).visibleReplySent;
-    } catch (error: unknown) {
-      if (error instanceof FeishuStreamingFinalizationError) {
-        return error.result.visibleReplySent;
-      }
-      throw error;
-    }
-  }
-
   async discard(): Promise<void> {
     if (!this.state || this.closed) {
+      return;
+    }
+    const messageId = this.state.messageId;
+    if (!messageId) {
+      // CardKit accepted this single-send entity, but Feishu returned no message
+      // identity. Finalize it in place; retrying or deleting by a fabricated id
+      // would duplicate content or target an unrelated message.
+      await this.closeWithResult("");
       return;
     }
     this.closed = true;
@@ -760,7 +757,7 @@ export class FeishuStreamingSession {
     const currentState = this.state;
     try {
       const response = await this.client.im.message.delete({
-        path: { message_id: currentState.messageId },
+        path: { message_id: messageId },
       });
       if (response.code !== undefined && response.code !== 0) {
         throw new Error(`Delete streaming card message failed: ${response.msg ?? response.code}`);
@@ -771,7 +768,7 @@ export class FeishuStreamingSession {
     } catch (error) {
       this.log?.(`Discard failed: ${String(error)}`);
       this.closed = false;
-      await this.close("");
+      await this.closeWithResult("");
     }
   }
 

--- a/src/auto-reply/dispatch-delivery-terminal.test.ts
+++ b/src/auto-reply/dispatch-delivery-terminal.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { PlatformMessageNotDispatchedError } from "../infra/outbound/deliver-types.js";
+import { finalizeDispatchResult } from "./dispatch-delivery-terminal.js";
+import { createReplyDispatcher } from "./reply/reply-dispatcher.js";
+
+describe("dispatch delivery terminal", () => {
+  it("returns a redacted failed terminal for a permanent provider rejection", async () => {
+    const dispatcher = createReplyDispatcher({
+      deliver: async () => {
+        throw new PlatformMessageNotDispatchedError("provider rejected message", {
+          cause: new Error("secret provider response"),
+          retryable: false,
+          publicError: { code: "230099" },
+        });
+      },
+    });
+    dispatcher.sendFinalReply({ text: "the final answer" });
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    const result = finalizeDispatchResult(
+      { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } },
+      dispatcher,
+    );
+
+    expect(result).toMatchObject({
+      queuedFinal: false,
+      counts: { final: 0 },
+      failedCounts: { final: 1 },
+      deliveryTerminal: {
+        outcome: "failed",
+        retryable: false,
+        error: { code: "230099" },
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain("secret provider response");
+  });
+});

--- a/src/auto-reply/dispatch-delivery-terminal.test.ts
+++ b/src/auto-reply/dispatch-delivery-terminal.test.ts
@@ -35,4 +35,110 @@ describe("dispatch delivery terminal", () => {
     });
     expect(JSON.stringify(result)).not.toContain("secret provider response");
   });
+
+  it("aggregates failed finals independently of dispatch order", async () => {
+    for (const order of [
+      ["rejected", "ambiguous"],
+      ["ambiguous", "rejected"],
+    ]) {
+      const dispatcher = createReplyDispatcher({
+        deliver: async (payload) => {
+          if (payload.text === "rejected") {
+            throw new PlatformMessageNotDispatchedError("provider rejected message", {
+              cause: new Error("provider rejected message"),
+              retryable: false,
+              publicError: { code: "230099" },
+            });
+          }
+          throw new Error("provider outcome unknown");
+        },
+      });
+      for (const text of order) {
+        dispatcher.sendFinalReply({ text });
+      }
+      dispatcher.markComplete();
+      await dispatcher.waitForIdle();
+
+      expect(
+        finalizeDispatchResult(
+          { queuedFinal: true, counts: { tool: 0, block: 0, final: 2 } },
+          dispatcher,
+        ),
+      ).toMatchObject({
+        queuedFinal: false,
+        counts: { final: 0 },
+        failedCounts: { final: 2 },
+        deliveryTerminal: { outcome: "unknown", retryable: false },
+      });
+    }
+  });
+
+  it("keeps a single mixed streaming and fallback failure graph unknown", async () => {
+    const dispatcher = createReplyDispatcher({
+      deliver: async () => {
+        const rejected = new PlatformMessageNotDispatchedError("streaming rejected", {
+          cause: new Error("streaming rejected"),
+          retryable: false,
+          publicError: { code: "230099" },
+        });
+        throw new AggregateError([rejected, new Error("static fallback outcome unknown")]);
+      },
+    });
+    dispatcher.sendFinalReply({ text: "the final answer" });
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(
+      finalizeDispatchResult(
+        { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } },
+        dispatcher,
+      ),
+    ).toMatchObject({
+      queuedFinal: false,
+      counts: { final: 0 },
+      failedCounts: { final: 1 },
+      deliveryTerminal: { outcome: "unknown", retryable: false },
+    });
+  });
+
+  it("retains a permanent fallback code beside a retryable streaming attempt", async () => {
+    const dispatcher = createReplyDispatcher({
+      deliver: async () => {
+        const retryableStart = new PlatformMessageNotDispatchedError("streaming throttled", {
+          cause: new Error("streaming throttled"),
+          retryable: true,
+          publicError: { code: "230001" },
+        });
+        const permanentFallback = new PlatformMessageNotDispatchedError("fallback rejected", {
+          cause: new Error("fallback rejected"),
+          retryable: false,
+          publicError: { code: "230099" },
+        });
+        throw new PlatformMessageNotDispatchedError("fallback rejected", {
+          cause: new AggregateError([retryableStart, permanentFallback]),
+          retryable: true,
+          publicError: { code: "230099" },
+        });
+      },
+    });
+    dispatcher.sendFinalReply({ text: "the final answer" });
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(
+      finalizeDispatchResult(
+        { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } },
+        dispatcher,
+      ),
+    ).toMatchObject({
+      queuedFinal: false,
+      counts: { final: 0 },
+      failedCounts: { final: 1 },
+      deliveryTerminal: {
+        outcome: "failed",
+        retryable: true,
+        error: { code: "230099" },
+      },
+    });
+  });
 });

--- a/src/auto-reply/dispatch-delivery-terminal.ts
+++ b/src/auto-reply/dispatch-delivery-terminal.ts
@@ -1,0 +1,71 @@
+import { isChannelPartialDeliveryError } from "../channels/turn/delivery-result.js";
+import {
+  resolveChannelDeliveryFailureTerminal,
+  type ChannelDeliveryTerminal,
+} from "../channels/turn/delivery-terminal.js";
+import type { DispatchFromConfigResult } from "./reply/dispatch-from-config.types.js";
+import { readReplyDispatcherDeliveryFailures } from "./reply/reply-dispatcher-delivery-failures.js";
+import type { ReplyDispatcher } from "./reply/reply-dispatcher.types.js";
+
+function resolveFinalDeliveryTerminal(params: {
+  deliveredFinalCount: number;
+  failedFinalCount: number;
+  dispatcher: ReplyDispatcher;
+}): ChannelDeliveryTerminal | undefined {
+  if (params.failedFinalCount === 0) {
+    return params.deliveredFinalCount > 0 ? { outcome: "delivered" } : undefined;
+  }
+  const failures = readReplyDispatcherDeliveryFailures(params.dispatcher).filter(
+    (failure) => failure.kind === "final",
+  );
+  const failure = failures.at(-1);
+  return resolveChannelDeliveryFailureTerminal({
+    error: failure?.error,
+    deliveredBeforeFailure:
+      params.deliveredFinalCount > 0 ||
+      failures.some((candidate) => isChannelPartialDeliveryError(candidate.error)),
+    failedBeforeDeliver: failure?.outcome === "failed-before-deliver",
+  });
+}
+
+export function finalizeDispatchResult(
+  result: DispatchFromConfigResult,
+  dispatcher: ReplyDispatcher,
+): DispatchFromConfigResult {
+  const cancelledCounts = dispatcher.getCancelledCounts?.();
+  const failedCounts = dispatcher.getFailedCounts?.();
+  if (!cancelledCounts && !failedCounts) {
+    return result;
+  }
+
+  const resultCounts = {
+    tool: result.counts?.tool ?? 0,
+    block: result.counts?.block ?? 0,
+    final: result.counts?.final ?? 0,
+  };
+  // Queue counters include failures/cancellations; public counts describe visible dispatches.
+  const counts = {
+    tool: Math.max(0, resultCounts.tool - (cancelledCounts?.tool ?? 0) - (failedCounts?.tool ?? 0)),
+    block: Math.max(
+      0,
+      resultCounts.block - (cancelledCounts?.block ?? 0) - (failedCounts?.block ?? 0),
+    ),
+    final: Math.max(
+      0,
+      resultCounts.final - (cancelledCounts?.final ?? 0) - (failedCounts?.final ?? 0),
+    ),
+  };
+  const hasFailedCounts = Object.values(failedCounts ?? {}).some((count) => count > 0);
+  const deliveryTerminal = resolveFinalDeliveryTerminal({
+    deliveredFinalCount: counts.final,
+    failedFinalCount: failedCounts?.final ?? 0,
+    dispatcher,
+  });
+  return {
+    ...result,
+    queuedFinal: result.queuedFinal && counts.final > 0,
+    counts,
+    ...(hasFailedCounts ? { failedCounts } : {}),
+    ...(deliveryTerminal ? { deliveryTerminal } : {}),
+  };
+}

--- a/src/auto-reply/dispatch-delivery-terminal.ts
+++ b/src/auto-reply/dispatch-delivery-terminal.ts
@@ -1,8 +1,6 @@
 import { isChannelPartialDeliveryError } from "../channels/turn/delivery-result.js";
-import {
-  resolveChannelDeliveryFailureTerminal,
-  type ChannelDeliveryTerminal,
-} from "../channels/turn/delivery-terminal.js";
+import { resolveChannelDeliveryFailureTerminal } from "../channels/turn/delivery-terminal.js";
+import type { ChannelDeliveryTerminal } from "../channels/turn/delivery-terminal.types.js";
 import type { DispatchFromConfigResult } from "./reply/dispatch-from-config.types.js";
 import { readReplyDispatcherDeliveryFailures } from "./reply/reply-dispatcher-delivery-failures.js";
 import type { ReplyDispatcher } from "./reply/reply-dispatcher.types.js";

--- a/src/auto-reply/dispatch-delivery-terminal.ts
+++ b/src/auto-reply/dispatch-delivery-terminal.ts
@@ -1,5 +1,4 @@
-import { isChannelPartialDeliveryError } from "../channels/turn/delivery-result.js";
-import { resolveChannelDeliveryFailureTerminal } from "../channels/turn/delivery-terminal.js";
+import { resolveChannelDeliveryTerminalFromFailures } from "../channels/turn/delivery-terminal.js";
 import type { ChannelDeliveryTerminal } from "../channels/turn/delivery-terminal.types.js";
 import type { DispatchFromConfigResult } from "./reply/dispatch-from-config.types.js";
 import { readReplyDispatcherDeliveryFailures } from "./reply/reply-dispatcher-delivery-failures.js";
@@ -16,13 +15,15 @@ function resolveFinalDeliveryTerminal(params: {
   const failures = readReplyDispatcherDeliveryFailures(params.dispatcher).filter(
     (failure) => failure.kind === "final",
   );
-  const failure = failures.at(-1);
-  return resolveChannelDeliveryFailureTerminal({
-    error: failure?.error,
-    deliveredBeforeFailure:
-      params.deliveredFinalCount > 0 ||
-      failures.some((candidate) => isChannelPartialDeliveryError(candidate.error)),
-    failedBeforeDeliver: failure?.outcome === "failed-before-deliver",
+  if (failures.length === 0) {
+    return { outcome: "unknown", retryable: false };
+  }
+  return resolveChannelDeliveryTerminalFromFailures({
+    deliveredCount: params.deliveredFinalCount,
+    failures: failures.map((failure) => ({
+      error: failure.error,
+      failedBeforeDeliver: failure.outcome === "failed-before-deliver",
+    })),
   });
 }
 

--- a/src/auto-reply/dispatch.freshness.test.ts
+++ b/src/auto-reply/dispatch.freshness.test.ts
@@ -177,11 +177,11 @@ describe("foreground reply freshness", () => {
     releaseOlderFinal.resolve();
     const olderResult = await olderDispatch;
 
-    expect(newerResult).toEqual({
+    expect(newerResult).toMatchObject({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
     });
-    expect(olderResult).toEqual({
+    expect(olderResult).toMatchObject({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
     });
@@ -209,7 +209,7 @@ describe("foreground reply freshness", () => {
       },
     });
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
     });
@@ -250,7 +250,7 @@ describe("foreground reply freshness", () => {
       await hookStarted.promise;
       await vi.advanceTimersByTimeAsync(15_000);
 
-      await expect(dispatch).resolves.toEqual({
+      await expect(dispatch).resolves.toMatchObject({
         queuedFinal: true,
         counts: { tool: 0, block: 0, final: 1 },
         failedCounts: { tool: 0, block: 0, final: 1 },
@@ -291,7 +291,7 @@ describe("foreground reply freshness", () => {
       expect(deliveries).toEqual([]);
       await vi.advanceTimersByTimeAsync(1_000);
 
-      await expect(dispatch).resolves.toEqual(queuedFinalResult());
+      await expect(dispatch).resolves.toMatchObject(queuedFinalResult());
       expect(deliveries).toEqual([{ kind: "final", text: "budgeted final" }]);
       expect(vi.getTimerCount()).toBe(0);
     } finally {
@@ -340,11 +340,11 @@ describe("foreground reply freshness", () => {
     const olderResult = await olderDispatch;
 
     expect(beforeDeliver).toHaveBeenCalledTimes(1);
-    expect(newerResult).toEqual({
+    expect(newerResult).toMatchObject({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
     });
-    expect(olderResult).toEqual({
+    expect(olderResult).toMatchObject({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
     });
@@ -403,8 +403,8 @@ describe("foreground reply freshness", () => {
     await newerStarted.promise;
     releaseOlderFinal.resolve();
 
-    await expect(olderDispatch).resolves.toEqual(queuedFinalResult());
-    await expect(newerDispatch).resolves.toEqual({
+    await expect(olderDispatch).resolves.toMatchObject(queuedFinalResult());
+    await expect(newerDispatch).resolves.toMatchObject({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
     });
@@ -456,8 +456,8 @@ describe("foreground reply freshness", () => {
     expect(deliveries).toEqual([]);
 
     releaseNewerFinal.resolve();
-    await expect(newerDispatch).resolves.toEqual(queuedFinalResult());
-    await expect(olderDispatch).resolves.toEqual({
+    await expect(newerDispatch).resolves.toMatchObject(queuedFinalResult());
+    await expect(olderDispatch).resolves.toMatchObject({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
     });
@@ -518,11 +518,11 @@ describe("foreground reply freshness", () => {
     const olderResult = await olderDispatch;
 
     expect(beforeDeliver).toHaveBeenCalledTimes(1);
-    expect(newerResult).toEqual({
+    expect(newerResult).toMatchObject({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
     });
-    expect(olderResult).toEqual({
+    expect(olderResult).toMatchObject({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
     });
@@ -539,12 +539,12 @@ describe("foreground reply freshness", () => {
     );
 
     expect(beforeDeliver).toHaveBeenCalledTimes(1);
-    expect(newerResult).toEqual({
+    expect(newerResult).toMatchObject({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
       failedCounts: { tool: 0, block: 0, final: 1 },
     });
-    expect(olderResult).toEqual({
+    expect(olderResult).toMatchObject({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
     });
@@ -580,12 +580,12 @@ describe("foreground reply freshness", () => {
     );
 
     expect(beforeDeliver).toHaveBeenCalledTimes(1);
-    expect(newerResult).toEqual({
+    expect(newerResult).toMatchObject({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
       failedCounts: { tool: 0, block: 0, final: 1 },
     });
-    expect(olderResult).toEqual({
+    expect(olderResult).toMatchObject({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
     });
@@ -600,11 +600,11 @@ describe("foreground reply freshness", () => {
     );
 
     expect(beforeDeliver).toHaveBeenCalledTimes(1);
-    expect(newerResult).toEqual({
+    expect(newerResult).toMatchObject({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
     });
-    expect(olderResult).toEqual({
+    expect(olderResult).toMatchObject({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
     });
@@ -620,11 +620,11 @@ describe("foreground reply freshness", () => {
     );
 
     expect(beforeDeliver).toHaveBeenCalledTimes(1);
-    expect(newerResult).toEqual({
+    expect(newerResult).toMatchObject({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
     });
-    expect(olderResult).toEqual({
+    expect(olderResult).toMatchObject({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
     });
@@ -640,11 +640,11 @@ describe("foreground reply freshness", () => {
 
     expect(beforeDeliver).toHaveBeenCalledTimes(1);
     expect(olderSettled).toHaveBeenCalledTimes(1);
-    expect(newerResult).toEqual({
+    expect(newerResult).toMatchObject({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
     });
-    expect(olderResult).toEqual({
+    expect(olderResult).toMatchObject({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
     });
@@ -664,11 +664,11 @@ describe("foreground reply freshness", () => {
 
     expect(beforeDeliver).toHaveBeenCalledTimes(1);
     expect(olderFreshDelivery).not.toHaveBeenCalled();
-    expect(newerResult).toEqual({
+    expect(newerResult).toMatchObject({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
     });
-    expect(olderResult).toEqual({
+    expect(olderResult).toMatchObject({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
     });
@@ -742,13 +742,13 @@ describe("foreground reply freshness", () => {
       }),
       deliveries,
     );
-    await expect(secondDispatch).resolves.toEqual({
+    await expect(secondDispatch).resolves.toMatchObject({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
     });
 
     releaseFirstFinal.resolve();
-    await expect(firstDispatch).resolves.toEqual({
+    await expect(firstDispatch).resolves.toMatchObject({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
     });

--- a/src/auto-reply/dispatch.freshness.test.ts
+++ b/src/auto-reply/dispatch.freshness.test.ts
@@ -177,11 +177,12 @@ describe("foreground reply freshness", () => {
     releaseOlderFinal.resolve();
     const olderResult = await olderDispatch;
 
-    expect(newerResult).toMatchObject({
+    expect(newerResult).toEqual({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
+      deliveryTerminal: { outcome: "delivered" },
     });
-    expect(olderResult).toMatchObject({
+    expect(olderResult).toEqual({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
     });
@@ -209,7 +210,7 @@ describe("foreground reply freshness", () => {
       },
     });
 
-    expect(result).toMatchObject({
+    expect(result).toEqual({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
     });
@@ -250,10 +251,11 @@ describe("foreground reply freshness", () => {
       await hookStarted.promise;
       await vi.advanceTimersByTimeAsync(15_000);
 
-      await expect(dispatch).resolves.toMatchObject({
+      await expect(dispatch).resolves.toEqual({
         queuedFinal: true,
         counts: { tool: 0, block: 0, final: 1 },
         failedCounts: { tool: 0, block: 0, final: 1 },
+        deliveryTerminal: { outcome: "partial_failure", retryable: false },
       });
       expect(beforeDeliver).toHaveBeenCalledTimes(2);
       expect(deliveries).toEqual([{ kind: "final", text: "follow-up final" }]);
@@ -291,7 +293,10 @@ describe("foreground reply freshness", () => {
       expect(deliveries).toEqual([]);
       await vi.advanceTimersByTimeAsync(1_000);
 
-      await expect(dispatch).resolves.toMatchObject(queuedFinalResult());
+      await expect(dispatch).resolves.toEqual({
+        ...queuedFinalResult(),
+        deliveryTerminal: { outcome: "delivered" },
+      });
       expect(deliveries).toEqual([{ kind: "final", text: "budgeted final" }]);
       expect(vi.getTimerCount()).toBe(0);
     } finally {
@@ -340,13 +345,14 @@ describe("foreground reply freshness", () => {
     const olderResult = await olderDispatch;
 
     expect(beforeDeliver).toHaveBeenCalledTimes(1);
-    expect(newerResult).toMatchObject({
+    expect(newerResult).toEqual({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
     });
-    expect(olderResult).toMatchObject({
+    expect(olderResult).toEqual({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
+      deliveryTerminal: { outcome: "delivered" },
     });
     expect(deliveries).toEqual([{ kind: "final", text: "old rewritten final" }]);
   });
@@ -403,8 +409,11 @@ describe("foreground reply freshness", () => {
     await newerStarted.promise;
     releaseOlderFinal.resolve();
 
-    await expect(olderDispatch).resolves.toMatchObject(queuedFinalResult());
-    await expect(newerDispatch).resolves.toMatchObject({
+    await expect(olderDispatch).resolves.toEqual({
+      ...queuedFinalResult(),
+      deliveryTerminal: { outcome: "delivered" },
+    });
+    await expect(newerDispatch).resolves.toEqual({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
     });
@@ -456,8 +465,11 @@ describe("foreground reply freshness", () => {
     expect(deliveries).toEqual([]);
 
     releaseNewerFinal.resolve();
-    await expect(newerDispatch).resolves.toMatchObject(queuedFinalResult());
-    await expect(olderDispatch).resolves.toMatchObject({
+    await expect(newerDispatch).resolves.toEqual({
+      ...queuedFinalResult(),
+      deliveryTerminal: { outcome: "delivered" },
+    });
+    await expect(olderDispatch).resolves.toEqual({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
     });
@@ -518,11 +530,12 @@ describe("foreground reply freshness", () => {
     const olderResult = await olderDispatch;
 
     expect(beforeDeliver).toHaveBeenCalledTimes(1);
-    expect(newerResult).toMatchObject({
+    expect(newerResult).toEqual({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
+      deliveryTerminal: { outcome: "delivered" },
     });
-    expect(olderResult).toMatchObject({
+    expect(olderResult).toEqual({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
     });
@@ -539,14 +552,16 @@ describe("foreground reply freshness", () => {
     );
 
     expect(beforeDeliver).toHaveBeenCalledTimes(1);
-    expect(newerResult).toMatchObject({
+    expect(newerResult).toEqual({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
       failedCounts: { tool: 0, block: 0, final: 1 },
+      deliveryTerminal: { outcome: "unknown", retryable: false },
     });
-    expect(olderResult).toMatchObject({
+    expect(olderResult).toEqual({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
+      deliveryTerminal: { outcome: "delivered" },
     });
     expect(deliveries).toEqual([{ kind: "final", text: "old rewritten final" }]);
   });
@@ -559,6 +574,7 @@ describe("foreground reply freshness", () => {
           cause: new Error("second chunk failed"),
           results: [{ channel: "whatsapp", messageId: "wa-1" }],
         }),
+      expectedTerminal: { outcome: "unknown", retryable: false } as const,
     },
     {
       label: "channel partial-delivery envelope",
@@ -568,29 +584,33 @@ describe("foreground reply freshness", () => {
           messageIds: ["provider-1"],
           visibleReplySent: true,
         }),
+      expectedTerminal: { outcome: "partial_failure", retryable: false } as const,
     },
-  ])("suppresses an older foreground final after $label", async ({ createError }) => {
-    const { beforeDeliver, deliveries, newerResult, olderResult } = await runDelayedOlderFinalRace(
-      (raceDeliveries) => ({
-        deliver: async (payload, info) => {
-          raceDeliveries.push({ kind: info.kind, text: payload.text });
-          throw createError();
-        },
-      }),
-    );
+  ])(
+    "suppresses an older foreground final after $label",
+    async ({ createError, expectedTerminal }) => {
+      const { beforeDeliver, deliveries, newerResult, olderResult } =
+        await runDelayedOlderFinalRace((raceDeliveries) => ({
+          deliver: async (payload, info) => {
+            raceDeliveries.push({ kind: info.kind, text: payload.text });
+            throw createError();
+          },
+        }));
 
-    expect(beforeDeliver).toHaveBeenCalledTimes(1);
-    expect(newerResult).toMatchObject({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
-      failedCounts: { tool: 0, block: 0, final: 1 },
-    });
-    expect(olderResult).toMatchObject({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
-    });
-    expect(deliveries).toEqual([{ kind: "final", text: "new final" }]);
-  });
+      expect(beforeDeliver).toHaveBeenCalledTimes(1);
+      expect(newerResult).toEqual({
+        queuedFinal: false,
+        counts: { tool: 0, block: 0, final: 0 },
+        failedCounts: { tool: 0, block: 0, final: 1 },
+        deliveryTerminal: expectedTerminal,
+      });
+      expect(olderResult).toEqual({
+        queuedFinal: false,
+        counts: { tool: 0, block: 0, final: 0 },
+      });
+      expect(deliveries).toEqual([{ kind: "final", text: "new final" }]);
+    },
+  );
 
   it("keeps an older foreground final when a newer adapter reports non-visible delivery", async () => {
     const { beforeDeliver, deliveries, newerResult, olderResult } = await runDelayedOlderFinalRace(
@@ -600,13 +620,15 @@ describe("foreground reply freshness", () => {
     );
 
     expect(beforeDeliver).toHaveBeenCalledTimes(1);
-    expect(newerResult).toMatchObject({
+    expect(newerResult).toEqual({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
+      deliveryTerminal: { outcome: "delivered" },
     });
-    expect(olderResult).toMatchObject({
+    expect(olderResult).toEqual({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
+      deliveryTerminal: { outcome: "delivered" },
     });
     expect(deliveries).toEqual([{ kind: "final", text: "old rewritten final" }]);
   });
@@ -620,11 +642,12 @@ describe("foreground reply freshness", () => {
     );
 
     expect(beforeDeliver).toHaveBeenCalledTimes(1);
-    expect(newerResult).toMatchObject({
+    expect(newerResult).toEqual({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
+      deliveryTerminal: { outcome: "delivered" },
     });
-    expect(olderResult).toMatchObject({
+    expect(olderResult).toEqual({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
     });
@@ -640,11 +663,12 @@ describe("foreground reply freshness", () => {
 
     expect(beforeDeliver).toHaveBeenCalledTimes(1);
     expect(olderSettled).toHaveBeenCalledTimes(1);
-    expect(newerResult).toMatchObject({
+    expect(newerResult).toEqual({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
+      deliveryTerminal: { outcome: "delivered" },
     });
-    expect(olderResult).toMatchObject({
+    expect(olderResult).toEqual({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
     });
@@ -664,11 +688,12 @@ describe("foreground reply freshness", () => {
 
     expect(beforeDeliver).toHaveBeenCalledTimes(1);
     expect(olderFreshDelivery).not.toHaveBeenCalled();
-    expect(newerResult).toMatchObject({
+    expect(newerResult).toEqual({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
+      deliveryTerminal: { outcome: "delivered" },
     });
-    expect(olderResult).toMatchObject({
+    expect(olderResult).toEqual({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
     });
@@ -742,15 +767,17 @@ describe("foreground reply freshness", () => {
       }),
       deliveries,
     );
-    await expect(secondDispatch).resolves.toMatchObject({
+    await expect(secondDispatch).resolves.toEqual({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
+      deliveryTerminal: { outcome: "delivered" },
     });
 
     releaseFirstFinal.resolve();
-    await expect(firstDispatch).resolves.toMatchObject({
+    await expect(firstDispatch).resolves.toEqual({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
+      deliveryTerminal: { outcome: "delivered" },
     });
     expect(deliveries).toEqual([
       { kind: "final", text: "second chat final" },

--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -917,6 +917,7 @@ describe("withReplyDispatcher", () => {
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
       failedCounts: { tool: 0, block: 0, final: 1 },
+      deliveryTerminal: { outcome: "unknown", retryable: false },
     });
   });
 

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -22,6 +22,7 @@ import {
   resolveCommandTurnContext,
   resolveCommandTurnTargetSessionKey,
 } from "./command-turn-context.js";
+import { finalizeDispatchResult } from "./dispatch-delivery-terminal.js";
 import { withReplyDispatcher } from "./dispatch-dispatcher.js";
 import {
   foregroundReplyFenceByKey,
@@ -378,45 +379,6 @@ function buildDispatchTimelineAttributes(ctx: MsgContext | FinalizedMsgContext) 
 
 type DispatchInboundResult = DispatchFromConfigResult;
 export { settleReplyDispatcher, withReplyDispatcher } from "./dispatch-dispatcher.js";
-
-function finalizeDispatchResult(
-  result: DispatchFromConfigResult,
-  dispatcher: ReplyDispatcher,
-): DispatchFromConfigResult {
-  const cancelledCounts = dispatcher.getCancelledCounts?.();
-  const failedCounts = dispatcher.getFailedCounts?.();
-  if (!cancelledCounts && !failedCounts) {
-    return result;
-  }
-
-  const resultCounts = {
-    tool: result.counts?.tool ?? 0,
-    block: result.counts?.block ?? 0,
-    final: result.counts?.final ?? 0,
-  };
-  // Dispatcher counts include cancelled/failed queued blocks; public result counts do not.
-  const counts = {
-    tool: Math.max(0, resultCounts.tool - (cancelledCounts?.tool ?? 0) - (failedCounts?.tool ?? 0)),
-    block: Math.max(
-      0,
-      resultCounts.block - (cancelledCounts?.block ?? 0) - (failedCounts?.block ?? 0),
-    ),
-    final: Math.max(
-      0,
-      resultCounts.final - (cancelledCounts?.final ?? 0) - (failedCounts?.final ?? 0),
-    ),
-  };
-  const hasFailedCounts =
-    (failedCounts?.tool ?? 0) > 0 ||
-    (failedCounts?.block ?? 0) > 0 ||
-    (failedCounts?.final ?? 0) > 0;
-  return {
-    ...result,
-    queuedFinal: result.queuedFinal && counts.final > 0,
-    counts,
-    ...(hasFailedCounts ? { failedCounts } : {}),
-  };
-}
 
 /** Dispatches one finalized inbound message through reply resolution and queued delivery. */
 export async function dispatchInboundMessage(params: {

--- a/src/auto-reply/reply/dispatch-from-config.types.ts
+++ b/src/auto-reply/reply/dispatch-from-config.types.ts
@@ -1,3 +1,4 @@
+import type { ChannelDeliveryTerminal } from "../../channels/turn/delivery-terminal.js";
 // Shared type contracts for dispatch-from-config runtime execution.
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { SourceReplyDeliveryMode } from "../get-reply-options.types.js";
@@ -11,6 +12,8 @@ export type DispatchFromConfigResult = {
   queuedFinal: boolean;
   counts: Record<ReplyDispatchKind, number>;
   failedCounts?: Partial<Record<ReplyDispatchKind, number>>;
+  /** Settled final-delivery result; inbound processing has its own independent terminal. */
+  deliveryTerminal?: ChannelDeliveryTerminal;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   sendPolicyDenied?: boolean;
   observedReplyDelivery?: boolean;

--- a/src/auto-reply/reply/dispatch-from-config.types.ts
+++ b/src/auto-reply/reply/dispatch-from-config.types.ts
@@ -1,4 +1,4 @@
-import type { ChannelDeliveryTerminal } from "../../channels/turn/delivery-terminal.js";
+import type { ChannelDeliveryTerminal } from "../../channels/turn/delivery-terminal.types.js";
 // Shared type contracts for dispatch-from-config runtime execution.
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { SourceReplyDeliveryMode } from "../get-reply-options.types.js";

--- a/src/auto-reply/reply/reply-dispatcher-delivery-failures.ts
+++ b/src/auto-reply/reply/reply-dispatcher-delivery-failures.ts
@@ -1,0 +1,50 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import {
+  findPlatformMessageRejectedError,
+  isProvenDeliveryNotSentError,
+} from "../../infra/delivery-recovery.shared.js";
+import { collectErrorGraphCandidates } from "../../infra/errors.js";
+import type { ReplyDispatchKind, ReplyDispatcher } from "./reply-dispatcher.types.js";
+
+export type ReplyDispatchDeliveryFailure = {
+  kind: ReplyDispatchKind;
+  outcome: "failed-before-deliver" | "failed-deliver";
+  error: unknown;
+};
+
+const failuresByDispatcher = new WeakMap<ReplyDispatcher, ReplyDispatchDeliveryFailure[]>();
+
+export function isRetryableNoSendFailure(error: unknown): boolean {
+  return (
+    isProvenDeliveryNotSentError(error) &&
+    !findPlatformMessageRejectedError(error) &&
+    !collectErrorGraphCandidates(error, (candidate) => [
+      candidate.cause,
+      candidate.original,
+      candidate.error,
+      candidate.reason,
+      ...(Array.isArray(candidate.errors) ? candidate.errors : []),
+    ]).some(
+      (candidate) =>
+        isRecord(candidate) &&
+        (candidate.sentBeforeError === true ||
+          candidate.visibleReplySent === true ||
+          (isRecord(candidate.deliveryResult) &&
+            candidate.deliveryResult.visibleReplySent === true)),
+    )
+  );
+}
+
+/** Keeps raw delivery errors private while the controller derives a redacted terminal. */
+export function registerReplyDispatcherDeliveryFailures(
+  dispatcher: ReplyDispatcher,
+  failures: ReplyDispatchDeliveryFailure[],
+): void {
+  failuresByDispatcher.set(dispatcher, failures);
+}
+
+export function readReplyDispatcherDeliveryFailures(
+  dispatcher: ReplyDispatcher,
+): readonly ReplyDispatchDeliveryFailure[] {
+  return failuresByDispatcher.get(dispatcher)?.slice() ?? [];
+}

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -1,13 +1,7 @@
 // Dispatches final reply payloads through visible senders and message tools.
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { TypingCallbacks } from "../../channels/typing.js";
 import type { HumanDelayConfig } from "../../config/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import {
-  findPlatformMessageRejectedError,
-  isProvenDeliveryNotSentError,
-} from "../../infra/delivery-recovery.shared.js";
-import { collectErrorGraphCandidates } from "../../infra/errors.js";
 import { settlePendingFinalDelivery } from "../../infra/outbound/delivery-completion.js";
 import { generateSecureInt } from "../../infra/secure-random.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -26,6 +20,11 @@ import {
   type NormalizeReplyOutcome,
   type NormalizeReplySkipReason,
 } from "./normalize-reply.js";
+import {
+  isRetryableNoSendFailure,
+  registerReplyDispatcherDeliveryFailures,
+  type ReplyDispatchDeliveryFailure,
+} from "./reply-dispatcher-delivery-failures.js";
 import type {
   ReplyDispatchBeforeDeliver,
   ReplyDispatchBeforeDeliverOptions,
@@ -58,26 +57,10 @@ export type ReplyDispatchDeliveryOutcome =
   | "failed-before-deliver"
   | "failed-deliver";
 
-function isRetryableNoSendFailure(error: unknown): boolean {
-  return (
-    isProvenDeliveryNotSentError(error) &&
-    !findPlatformMessageRejectedError(error) &&
-    !collectErrorGraphCandidates(error, (candidate) => [
-      candidate.cause,
-      candidate.original,
-      candidate.error,
-      candidate.reason,
-      ...(Array.isArray(candidate.errors) ? candidate.errors : []),
-    ]).some(
-      (candidate) =>
-        isRecord(candidate) &&
-        (candidate.sentBeforeError === true ||
-          candidate.visibleReplySent === true ||
-          (isRecord(candidate.deliveryResult) &&
-            candidate.deliveryResult.visibleReplySent === true)),
-    )
-  );
-}
+type ReplyDispatchDeliveryAttempt = {
+  outcome: ReplyDispatchDeliveryOutcome;
+  error?: unknown;
+};
 
 type ReplyDispatchDeliveryOutcomeTracker = {
   promise: Promise<ReplyDispatchDeliveryOutcome>;
@@ -435,6 +418,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
     block: 0,
     final: 0,
   };
+  const deliveryFailures: ReplyDispatchDeliveryFailure[] = [];
 
   // Register this dispatcher globally for gateway restart coordination.
   const { unregister } = registerDispatcher({
@@ -496,7 +480,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
   const deliverOnce = async (
     payload: ReplyPayload,
     info: ReplyDispatchRuntimeInfo,
-  ): Promise<ReplyDispatchDeliveryOutcome> => {
+  ): Promise<ReplyDispatchDeliveryAttempt> => {
     let deliverPayload: ReplyPayload | null = payload;
     let deliveryStarted = false;
     const custody = getReplyPayloadMetadata(payload)?.pendingFinalDeliveryCompletion;
@@ -517,7 +501,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
             ]);
           }
           await notifyBeforeDeliverCancelled(payload, info);
-          return "cancelled";
+          return { outcome: "cancelled" };
         }
         deliverPayload = copyReplyPayloadMetadata(payload, deliverPayload);
       }
@@ -532,7 +516,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
         );
         if (claim.state !== "queued") {
           await notifyBeforeDeliverCancelled(payload, info);
-          return "cancelled";
+          return { outcome: "cancelled" };
         }
       }
       deliveryStarted = true;
@@ -542,7 +526,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
           "queued",
         ]);
       }
-      return "delivered";
+      return { outcome: "delivered" };
     } catch (error) {
       const outcome =
         deliveryStarted && !isRetryableNoSendFailure(error)
@@ -562,7 +546,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
       try {
         await options.onError?.(error, info);
       } catch {}
-      return outcome;
+      return { outcome, error };
     }
   };
 
@@ -623,12 +607,14 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
           }
         }
         const dispatchInfo = buildReplyDispatchRuntimeInfo(normalized, kind);
-        deliveryOutcome = await deliverOnce(normalized, dispatchInfo);
+        let attempt = await deliverOnce(normalized, dispatchInfo);
+        deliveryOutcome = attempt.outcome;
         if (
           deliveryFallback &&
           (deliveryOutcome === "cancelled" || deliveryOutcome === "failed-before-deliver")
         ) {
-          deliveryOutcome = await deliverOnce(deliveryFallback, dispatchInfo);
+          attempt = await deliverOnce(deliveryFallback, dispatchInfo);
+          deliveryOutcome = attempt.outcome;
         }
         if (deliveryOutcome === "cancelled") {
           cancelledCounts[kind] += 1;
@@ -637,10 +623,12 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
           deliveryOutcome === "failed-deliver"
         ) {
           failedCounts[kind] += 1;
+          deliveryFailures.push({ kind, outcome: deliveryOutcome, error: attempt.error });
         }
       })
       .catch(async (err: unknown) => {
         failedCounts[kind] += 1;
+        deliveryFailures.push({ kind, outcome: "failed-before-deliver", error: err });
         try {
           await options.onError?.(err, buildReplyDispatchRuntimeInfo(normalized, kind));
         } catch {}
@@ -722,6 +710,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
     normalize: (kind, payload) => normalizeForDispatch(kind, payload, true),
   });
   beforeDeliverCancelledHooks.set(dispatcher, appendedBeforeDeliverCancelledHooks);
+  registerReplyDispatcherDeliveryFailures(dispatcher, deliveryFailures);
   return dispatcher;
 }
 

--- a/src/channels/turn/delivery-reconciliation.test.ts
+++ b/src/channels/turn/delivery-reconciliation.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { reconcileNonVisibleChannelDeliveries } from "./delivery-reconciliation.js";
+
+const none = { tool: 0, block: 0, final: 0 } as const;
+
+describe("channel delivery reconciliation", () => {
+  it("removes delivered when every final is authoritatively non-visible", () => {
+    expect(
+      reconcileNonVisibleChannelDeliveries(
+        {
+          queuedFinal: true,
+          counts: { tool: 0, block: 0, final: 1 },
+          deliveryTerminal: { outcome: "delivered" },
+        },
+        { ...none, final: 1 },
+      ),
+    ).toEqual({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
+  });
+
+  it("keeps delivered while another final remains visible", () => {
+    expect(
+      reconcileNonVisibleChannelDeliveries(
+        {
+          queuedFinal: true,
+          counts: { tool: 0, block: 0, final: 2 },
+          deliveryTerminal: { outcome: "delivered" },
+        },
+        { ...none, final: 1 },
+      ),
+    ).toEqual({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+      deliveryTerminal: { outcome: "delivered" },
+    });
+  });
+
+  it("keeps a non-delivered terminal when visible counts reconcile to zero", () => {
+    expect(
+      reconcileNonVisibleChannelDeliveries(
+        {
+          queuedFinal: true,
+          counts: { tool: 0, block: 0, final: 1 },
+          deliveryTerminal: { outcome: "unknown", retryable: false },
+        },
+        { ...none, final: 1 },
+      ),
+    ).toEqual({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+      deliveryTerminal: { outcome: "unknown", retryable: false },
+    });
+  });
+});

--- a/src/channels/turn/delivery-reconciliation.ts
+++ b/src/channels/turn/delivery-reconciliation.ts
@@ -1,0 +1,25 @@
+import type { DispatchFromConfigResult } from "../../auto-reply/reply/dispatch-from-config.types.js";
+import type { ReplyDispatchKind } from "../../auto-reply/reply/reply-dispatcher.types.js";
+
+/** Reconciles dispatcher counts with authoritative native visibility outcomes. */
+export function reconcileNonVisibleChannelDeliveries(
+  result: DispatchFromConfigResult,
+  nonVisibleCounts: Readonly<Record<ReplyDispatchKind, number>>,
+): DispatchFromConfigResult {
+  const { deliveryTerminal, ...reconciledResult } = result;
+  const counts = {
+    tool: Math.max(0, result.counts.tool - nonVisibleCounts.tool),
+    block: Math.max(0, result.counts.block - nonVisibleCounts.block),
+    final: Math.max(0, result.counts.final - nonVisibleCounts.final),
+  };
+  const keepDeliveryTerminal =
+    deliveryTerminal?.outcome !== "delivered" || nonVisibleCounts.final === 0 || counts.final > 0;
+  return {
+    ...reconciledResult,
+    queuedFinal: result.queuedFinal && counts.final > 0,
+    counts,
+    // A successful terminal is authoritative only while at least one reconciled final remains
+    // visible. Suppression is intentional non-delivery, not a failure terminal.
+    ...(keepDeliveryTerminal && deliveryTerminal ? { deliveryTerminal } : {}),
+  };
+}

--- a/src/channels/turn/delivery-settlement.ts
+++ b/src/channels/turn/delivery-settlement.ts
@@ -8,6 +8,7 @@ import { settlePendingFinalDelivery } from "../../infra/outbound/delivery-comple
 import type { createMessageSentEmitter } from "../../infra/outbound/message-sent-hook.js";
 import { resolveMessageReceiptPrimaryId } from "../message/receipt.js";
 import {
+  createChannelPartialDeliveryError,
   isChannelPartialDeliveryError,
   type ChannelPartialDeliveryError,
 } from "./delivery-result.js";
@@ -49,22 +50,9 @@ export function isExplicitlyNonVisibleChannelDelivery(result: unknown): boolean 
   );
 }
 
-function markChannelDeliveryErrorVisible(error: unknown): unknown {
-  if (typeof error === "object" && error !== null && !Array.isArray(error)) {
-    try {
-      Object.assign(error, { sentBeforeError: true, visibleReplySent: true });
-      return error;
-    } catch {
-      // Fall back to a wrapper when a platform error object is non-extensible.
-    }
-  }
-  const visibleError = new Error("visible channel reply delivery failed", { cause: error });
-  Object.assign(visibleError, { sentBeforeError: true, visibleReplySent: true });
-  return visibleError;
-}
-
 export async function runChannelDeliveryObserver(params: {
   onDelivered: AnyChannelDeliveryAdapter["onDelivered"] | undefined;
+  onError?: (error: unknown, info: ChannelDeliveryInfo) => Promise<void> | void;
   payload: ReplyPayload;
   info: Parameters<NonNullable<ChannelEventDeliveryAdapter["onDelivered"]>>[1];
   result: Parameters<NonNullable<ChannelEventDeliveryAdapter["onDelivered"]>>[2];
@@ -75,9 +63,24 @@ export async function runChannelDeliveryObserver(params: {
   try {
     await params.onDelivered(params.payload, params.info, params.result);
   } catch (error: unknown) {
-    throw isExplicitlyNonVisibleChannelDelivery(params.result)
-      ? error
-      : markChannelDeliveryErrorVisible(error);
+    if (isExplicitlyNonVisibleChannelDelivery(params.result)) {
+      try {
+        await params.onError?.(error, params.info);
+      } catch {
+        // Error observers are best-effort and must not erase settled suppression provenance.
+      }
+      return;
+    }
+    // The send already completed; preserve its receipt in the canonical partial envelope so
+    // later settlement cannot downgrade visible custody to an ambiguous observer failure.
+    const deliveryResult: ChannelDeliveryResult = { ...params.result };
+    delete deliveryResult.deliveryIntent;
+    delete deliveryResult.suppression;
+    delete deliveryResult.finalization;
+    throw createChannelPartialDeliveryError(error, {
+      ...deliveryResult,
+      visibleReplySent: true,
+    });
   }
 }
 
@@ -113,7 +116,7 @@ export async function settleFailedPendingFinalDelivery(
 export async function settleChannelDeliveryAttempt(params: {
   attempt: PendingChannelDeliveryAttempt;
   onDelivered: AnyChannelDeliveryAdapter["onDelivered"] | undefined;
-  onFinalizationError?: (error: unknown) => Promise<void> | void;
+  onError?: (error: unknown, info: ChannelDeliveryInfo) => Promise<void> | void;
   emitMessageSent?: ReturnType<typeof createMessageSentEmitter>["emitMessageSent"];
 }): Promise<ChannelDeliveryResult | undefined> {
   const { attempt } = params;
@@ -140,7 +143,7 @@ export async function settleChannelDeliveryAttempt(params: {
       : undefined;
   } catch (error: unknown) {
     try {
-      await params.onFinalizationError?.(error);
+      await params.onError?.(error, attempt.info);
     } catch {
       // Error observers are best-effort and must not replace the native settlement failure.
     }
@@ -173,6 +176,7 @@ export async function settleChannelDeliveryAttempt(params: {
   }
   await runChannelDeliveryObserver({
     onDelivered: params.onDelivered,
+    onError: params.onError,
     payload: attempt.payload,
     info: attempt.info,
     result: finalized,
@@ -192,9 +196,7 @@ export async function settleChannelDeliveryAttempts(params: {
       const finalized = await settleChannelDeliveryAttempt({
         attempt,
         onDelivered: params.delivery.onDelivered,
-        onFinalizationError: async (error) => {
-          await Promise.resolve(params.delivery.onError?.(error, attempt.info));
-        },
+        onError: params.delivery.onError,
         emitMessageSent: params.emitMessageSent,
       });
       params.onSettled?.(attempt.info, finalized);

--- a/src/channels/turn/delivery-settlement.ts
+++ b/src/channels/turn/delivery-settlement.ts
@@ -1,0 +1,206 @@
+import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import { formatErrorMessage, toErrorObject } from "../../infra/errors.js";
+import {
+  isPlatformMessageNotDispatchedError,
+  isPlatformMessageRejectedError,
+} from "../../infra/outbound/deliver-types.js";
+import { settlePendingFinalDelivery } from "../../infra/outbound/delivery-completion.js";
+import type { createMessageSentEmitter } from "../../infra/outbound/message-sent-hook.js";
+import { resolveMessageReceiptPrimaryId } from "../message/receipt.js";
+import {
+  isChannelPartialDeliveryError,
+  type ChannelPartialDeliveryError,
+} from "./delivery-result.js";
+import { resolvePendingFinalCompletion } from "./direct-delivery-custody.js";
+import type {
+  ChannelDeliveryInfo,
+  ChannelDeliveryOutcome,
+  ChannelDeliveryResult,
+  ChannelEventDeliveryAdapter,
+  ChannelTurnDeliveryAdapter,
+} from "./types.js";
+
+type AnyChannelDeliveryAdapter = ChannelEventDeliveryAdapter | ChannelTurnDeliveryAdapter;
+
+export type PendingChannelDeliveryAttempt = {
+  payload: ReplyPayload;
+  info: ChannelDeliveryInfo;
+  result?: ChannelDeliveryResult | void;
+  error?: unknown;
+};
+
+type SettledChannelDeliveryFailure = {
+  error: unknown;
+  info: ChannelDeliveryInfo;
+};
+
+export function resolvePartialChannelDeliveryResult(
+  error: unknown,
+): ChannelPartialDeliveryError["deliveryResult"] | undefined {
+  return isChannelPartialDeliveryError(error) ? error.deliveryResult : undefined;
+}
+
+export function isExplicitlyNonVisibleChannelDelivery(result: unknown): boolean {
+  return (
+    typeof result === "object" &&
+    result !== null &&
+    !Array.isArray(result) &&
+    (result as { visibleReplySent?: unknown }).visibleReplySent === false
+  );
+}
+
+function markChannelDeliveryErrorVisible(error: unknown): unknown {
+  if (typeof error === "object" && error !== null && !Array.isArray(error)) {
+    try {
+      Object.assign(error, { sentBeforeError: true, visibleReplySent: true });
+      return error;
+    } catch {
+      // Fall back to a wrapper when a platform error object is non-extensible.
+    }
+  }
+  const visibleError = new Error("visible channel reply delivery failed", { cause: error });
+  Object.assign(visibleError, { sentBeforeError: true, visibleReplySent: true });
+  return visibleError;
+}
+
+export async function runChannelDeliveryObserver(params: {
+  onDelivered: AnyChannelDeliveryAdapter["onDelivered"] | undefined;
+  payload: ReplyPayload;
+  info: Parameters<NonNullable<ChannelEventDeliveryAdapter["onDelivered"]>>[1];
+  result: Parameters<NonNullable<ChannelEventDeliveryAdapter["onDelivered"]>>[2];
+}): Promise<void> {
+  if (!params.onDelivered) {
+    return;
+  }
+  try {
+    await params.onDelivered(params.payload, params.info, params.result);
+  } catch (error: unknown) {
+    throw isExplicitlyNonVisibleChannelDelivery(params.result)
+      ? error
+      : markChannelDeliveryErrorVisible(error);
+  }
+}
+
+function resolveChannelDeliveryMessageId(
+  result: ChannelDeliveryOutcome | undefined,
+): string | undefined {
+  return result?.receipt
+    ? resolveMessageReceiptPrimaryId(result.receipt)
+    : result?.messageIds?.find((messageId) => messageId.trim());
+}
+
+// Partial delivery is terminally delivered; permanent no-send is suppressed;
+// retryable no-send is replayable; ambiguity remains unknown for later notice.
+export async function settleFailedPendingFinalDelivery(
+  payload: ReplyPayload,
+  error: unknown,
+): Promise<void> {
+  const completion = resolvePendingFinalCompletion(payload);
+  if (!completion) {
+    return;
+  }
+  if (resolvePartialChannelDeliveryResult(error) !== undefined) {
+    await settlePendingFinalDelivery(completion, "delivered", ["queued", "unknown"]);
+  } else if (isPlatformMessageRejectedError(error)) {
+    await settlePendingFinalDelivery(completion, "suppressed", ["prepared", "queued", "unknown"]);
+  } else if (isPlatformMessageNotDispatchedError(error)) {
+    await settlePendingFinalDelivery(completion, "prepared", ["queued", "unknown"]);
+  } else {
+    await settlePendingFinalDelivery(completion, "unknown", ["queued", "unknown"]);
+  }
+}
+
+export async function settleChannelDeliveryAttempt(params: {
+  attempt: PendingChannelDeliveryAttempt;
+  onDelivered: AnyChannelDeliveryAdapter["onDelivered"] | undefined;
+  onFinalizationError?: (error: unknown) => Promise<void> | void;
+  emitMessageSent?: ReturnType<typeof createMessageSentEmitter>["emitMessageSent"];
+}): Promise<ChannelDeliveryResult | undefined> {
+  const { attempt } = params;
+  if ("error" in attempt) {
+    const partial = resolvePartialChannelDeliveryResult(attempt.error);
+    if (!isPlatformMessageNotDispatchedError(attempt.error)) {
+      params.emitMessageSent?.({
+        success: false,
+        content: partial?.content ?? attempt.payload.text ?? "",
+        error: formatErrorMessage(attempt.error),
+        messageId: resolveChannelDeliveryMessageId(partial),
+      });
+    }
+    return undefined;
+  }
+
+  let finalized: ChannelDeliveryResult | undefined;
+  try {
+    const result = attempt.result;
+    finalized = result
+      ? result.finalization
+        ? { ...result, ...(await result.finalization), finalization: undefined }
+        : result
+      : undefined;
+  } catch (error: unknown) {
+    try {
+      await params.onFinalizationError?.(error);
+    } catch {
+      // Error observers are best-effort and must not replace the native settlement failure.
+    }
+    await settleFailedPendingFinalDelivery(attempt.payload, error);
+    const partial = resolvePartialChannelDeliveryResult(error);
+    if (!isPlatformMessageNotDispatchedError(error)) {
+      params.emitMessageSent?.({
+        success: false,
+        content: partial?.content ?? attempt.payload.text ?? "",
+        error: formatErrorMessage(error),
+        messageId: resolveChannelDeliveryMessageId(partial),
+      });
+    }
+    throw toErrorObject(error, "channel delivery finalization failed");
+  }
+
+  if (!isExplicitlyNonVisibleChannelDelivery(finalized)) {
+    params.emitMessageSent?.({
+      success: true,
+      content: finalized?.content ?? attempt.payload.text ?? "",
+      messageId: resolveChannelDeliveryMessageId(finalized),
+    });
+  }
+  const completion = resolvePendingFinalCompletion(attempt.payload);
+  if (completion) {
+    await settlePendingFinalDelivery(
+      completion,
+      isExplicitlyNonVisibleChannelDelivery(finalized) ? "suppressed" : "delivered",
+    );
+  }
+  await runChannelDeliveryObserver({
+    onDelivered: params.onDelivered,
+    payload: attempt.payload,
+    info: attempt.info,
+    result: finalized,
+  });
+  return finalized;
+}
+
+export async function settleChannelDeliveryAttempts(params: {
+  attempts: readonly PendingChannelDeliveryAttempt[];
+  delivery: AnyChannelDeliveryAdapter;
+  emitMessageSent?: ReturnType<typeof createMessageSentEmitter>["emitMessageSent"];
+  onSettled?: (info: ChannelDeliveryInfo, result: ChannelDeliveryResult | undefined) => void;
+}): Promise<SettledChannelDeliveryFailure[]> {
+  const failures: SettledChannelDeliveryFailure[] = [];
+  for (const attempt of params.attempts) {
+    try {
+      const finalized = await settleChannelDeliveryAttempt({
+        attempt,
+        onDelivered: params.delivery.onDelivered,
+        onFinalizationError: async (error) => {
+          await Promise.resolve(params.delivery.onError?.(error, attempt.info));
+        },
+        emitMessageSent: params.emitMessageSent,
+      });
+      params.onSettled?.(attempt.info, finalized);
+    } catch (error: unknown) {
+      failures.push({ error, info: attempt.info });
+    }
+  }
+  return failures;
+}

--- a/src/channels/turn/delivery-terminal.test.ts
+++ b/src/channels/turn/delivery-terminal.test.ts
@@ -4,9 +4,17 @@ import { onTrustedMessageAuditEventForTest as onTrustedMessageAuditEvent } from 
 import { PlatformMessageNotDispatchedError } from "../../infra/outbound/deliver-types.js";
 import { createChannelPartialDeliveryError } from "./delivery-result.js";
 import {
+  applySettledChannelDeliveryFailures,
   emitChannelDeliveryTerminalObservations,
-  resolveChannelDeliveryFailureTerminal,
+  resolveChannelDeliveryTerminalFromFailures,
 } from "./delivery-terminal.js";
+
+function resolveSingleFailure(error: unknown) {
+  return resolveChannelDeliveryTerminalFromFailures({
+    deliveredCount: 0,
+    failures: [{ error }],
+  });
+}
 
 describe("channel delivery terminal", () => {
   it("exposes only the provider code for a permanent pre-dispatch rejection", () => {
@@ -17,10 +25,7 @@ describe("channel delivery terminal", () => {
       publicError: { code: "230099" },
     });
 
-    const terminal = resolveChannelDeliveryFailureTerminal({
-      error,
-      deliveredBeforeFailure: false,
-    });
+    const terminal = resolveSingleFailure(error);
 
     expect(terminal).toEqual({
       outcome: "failed",
@@ -36,18 +41,106 @@ describe("channel delivery terminal", () => {
       messageIds: ["om-visible"],
     });
 
-    expect(resolveChannelDeliveryFailureTerminal({ error, deliveredBeforeFailure: false })).toEqual(
-      { outcome: "partial_failure", retryable: false },
-    );
+    expect(resolveSingleFailure(error)).toEqual({ outcome: "partial_failure", retryable: false });
+
+    for (const wrapped of [
+      new Error("observer wrapper", { cause: error }),
+      new AggregateError([new Error("observer failed"), error]),
+      new AggregateError([error, new Error("observer failed")]),
+    ]) {
+      expect(resolveSingleFailure(wrapped)).toEqual({
+        outcome: "partial_failure",
+        retryable: false,
+      });
+    }
   });
 
   it("does not invent a failed disposition for an ambiguous provider error", () => {
-    expect(
-      resolveChannelDeliveryFailureTerminal({
-        error: new Error("socket closed"),
-        deliveredBeforeFailure: false,
+    expect(resolveSingleFailure(new Error("socket closed"))).toEqual({
+      outcome: "unknown",
+      retryable: false,
+    });
+  });
+
+  it("keeps a mixed proven and ambiguous error graph unknown", () => {
+    const rejected = new PlatformMessageNotDispatchedError("streaming rejected", {
+      cause: new Error("streaming rejected"),
+      retryable: false,
+      publicError: { code: "230099" },
+    });
+    const error = new AggregateError([rejected, new Error("static fallback outcome unknown")]);
+
+    expect(resolveSingleFailure(error)).toEqual({ outcome: "unknown", retryable: false });
+  });
+
+  it("combines retryability and exposes only an agreed provider code", () => {
+    const createFailure = (code: string, retryable: boolean) => ({
+      error: new PlatformMessageNotDispatchedError("provider rejected message", {
+        cause: new Error("provider rejected message"),
+        retryable,
+        publicError: { code },
       }),
-    ).toEqual({ outcome: "unknown", retryable: false });
+    });
+
+    expect(
+      resolveChannelDeliveryTerminalFromFailures({
+        deliveredCount: 0,
+        failures: [createFailure("230099", false), createFailure("230099", true)],
+      }),
+    ).toEqual({
+      outcome: "failed",
+      retryable: true,
+      error: { code: "230099" },
+    });
+    expect(
+      resolveChannelDeliveryTerminalFromFailures({
+        deliveredCount: 0,
+        failures: [createFailure("230099", false), createFailure("230001", true)],
+      }),
+    ).toEqual({ outcome: "failed", retryable: true, error: { code: "230099" } });
+    expect(
+      resolveChannelDeliveryTerminalFromFailures({
+        deliveredCount: 0,
+        failures: [createFailure("230001", true), createFailure("230099", false)],
+      }),
+    ).toEqual({ outcome: "failed", retryable: true, error: { code: "230099" } });
+    expect(
+      resolveChannelDeliveryTerminalFromFailures({
+        deliveredCount: 0,
+        failures: [createFailure("230099", false), createFailure("230001", false)],
+      }),
+    ).toEqual({ outcome: "failed", retryable: false });
+
+    const retryableStart = createFailure("230001", true).error;
+    const permanentFallback = createFailure("230099", false).error;
+    for (const errors of [
+      [retryableStart, permanentFallback],
+      [permanentFallback, retryableStart],
+    ]) {
+      expect(
+        resolveChannelDeliveryTerminalFromFailures({
+          deliveredCount: 0,
+          failures: [{ error: new AggregateError(errors) }],
+        }),
+      ).toEqual({ outcome: "failed", retryable: true, error: { code: "230099" } });
+    }
+
+    const partial = {
+      error: createChannelPartialDeliveryError(
+        new PlatformMessageNotDispatchedError("provider rejected edit", {
+          cause: new Error("provider rejected edit"),
+          retryable: false,
+          publicError: { code: "230001" },
+        }),
+        { visibleReplySent: true },
+      ),
+    };
+    expect(
+      resolveChannelDeliveryTerminalFromFailures({
+        deliveredCount: 0,
+        failures: [partial, createFailure("230099", false)],
+      }),
+    ).toEqual({ outcome: "partial_failure", retryable: false, error: { code: "230099" } });
   });
 
   it("records delivery failure separately without raw terminal details", () => {
@@ -80,4 +173,42 @@ describe("channel delivery terminal", () => {
     expect(JSON.stringify(events)).not.toContain("230099");
     expect(JSON.stringify(events)).not.toContain("agent:main:feishu");
   });
+
+  it.each([
+    ["matching", "230099", { code: "230099" }],
+    ["conflicting", "230001", undefined],
+  ] as const)(
+    "%s provider codes remain conservative across delivery-owner merges",
+    (_name, nextCode, expectedError) => {
+      const nextFailure = new PlatformMessageNotDispatchedError("provider rejected message", {
+        cause: new Error("provider rejected message"),
+        retryable: false,
+        publicError: { code: nextCode },
+      });
+
+      expect(
+        applySettledChannelDeliveryFailures(
+          {
+            queuedFinal: true,
+            counts: { tool: 0, block: 0, final: 1 },
+            deliveryTerminal: {
+              outcome: "partial_failure",
+              retryable: false,
+              error: { code: "230099" },
+            },
+          },
+          [{ kind: "final", error: nextFailure }],
+        ),
+      ).toEqual({
+        queuedFinal: false,
+        counts: { tool: 0, block: 0, final: 0 },
+        failedCounts: { final: 1 },
+        deliveryTerminal: {
+          outcome: "partial_failure",
+          retryable: false,
+          ...(expectedError ? { error: expectedError } : {}),
+        },
+      });
+    },
+  );
 });

--- a/src/channels/turn/delivery-terminal.test.ts
+++ b/src/channels/turn/delivery-terminal.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { TrustedMessageAuditEvent } from "../../audit/message-audit-events.js";
+import { onTrustedMessageAuditEventForTest as onTrustedMessageAuditEvent } from "../../audit/message-audit-events.test-support.js";
+import { PlatformMessageNotDispatchedError } from "../../infra/outbound/deliver-types.js";
+import { createChannelPartialDeliveryError } from "./delivery-result.js";
+import {
+  emitChannelDeliveryTerminalObservations,
+  resolveChannelDeliveryFailureTerminal,
+} from "./delivery-terminal.js";
+
+describe("channel delivery terminal", () => {
+  it("exposes only the provider code for a permanent pre-dispatch rejection", () => {
+    const raw = new Error("secret transport detail");
+    const error = new PlatformMessageNotDispatchedError("provider rejected message", {
+      cause: raw,
+      retryable: false,
+      publicError: { code: "230099" },
+    });
+
+    const terminal = resolveChannelDeliveryFailureTerminal({
+      error,
+      deliveredBeforeFailure: false,
+    });
+
+    expect(terminal).toEqual({
+      outcome: "failed",
+      retryable: false,
+      error: { code: "230099" },
+    });
+    expect(JSON.stringify(terminal)).not.toContain("secret");
+  });
+
+  it("keeps visible partial delivery terminal and non-retryable", () => {
+    const error = createChannelPartialDeliveryError(new Error("edit failed"), {
+      visibleReplySent: true,
+      messageIds: ["om-visible"],
+    });
+
+    expect(resolveChannelDeliveryFailureTerminal({ error, deliveredBeforeFailure: false })).toEqual(
+      { outcome: "partial_failure", retryable: false },
+    );
+  });
+
+  it("does not invent a failed disposition for an ambiguous provider error", () => {
+    expect(
+      resolveChannelDeliveryFailureTerminal({
+        error: new Error("socket closed"),
+        deliveredBeforeFailure: false,
+      }),
+    ).toEqual({ outcome: "unknown", retryable: false });
+  });
+
+  it("records delivery failure separately without raw terminal details", () => {
+    const events: TrustedMessageAuditEvent[] = [];
+    const unsubscribe = onTrustedMessageAuditEvent((event) => events.push(event));
+    try {
+      emitChannelDeliveryTerminalObservations({
+        terminal: { outcome: "failed", retryable: false, error: { code: "230099" } },
+        channel: "feishu",
+        to: "chat:redacted",
+        agentId: "main",
+        sessionKey: "agent:main:feishu:direct:redacted",
+        chatType: "direct",
+        startedAt: Date.now(),
+      });
+    } finally {
+      unsubscribe();
+    }
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      action: "message.outbound.finished",
+      direction: "outbound",
+      status: "failed",
+      outcome: "failed",
+      errorCode: "message_delivery_failed",
+      failureStage: "platform_send",
+      resultCount: 0,
+    });
+    expect(JSON.stringify(events)).not.toContain("230099");
+    expect(JSON.stringify(events)).not.toContain("agent:main:feishu");
+  });
+});

--- a/src/channels/turn/delivery-terminal.ts
+++ b/src/channels/turn/delivery-terminal.ts
@@ -1,0 +1,145 @@
+import type { DispatchFromConfigResult } from "../../auto-reply/reply/dispatch-from-config.types.js";
+import type { ReplyDispatchKind } from "../../auto-reply/reply/reply-dispatcher.types.js";
+import {
+  findPlatformMessageNotDispatchedError,
+  isProvenDeliveryNotSentError,
+} from "../../infra/delivery-recovery.shared.js";
+import { emitInternalDiagnosticEvent } from "../../infra/diagnostic-events.js";
+import {
+  emitOutboundAuditTerminals,
+  uniformOutboundAuditTerminals,
+} from "../../infra/outbound/outbound-audit.js";
+import { normalizeChatType } from "../chat-type.js";
+import { isChannelPartialDeliveryError } from "./delivery-result.js";
+
+export type ChannelDeliveryTerminal =
+  | { outcome: "delivered" }
+  | {
+      outcome: "failed";
+      retryable: boolean;
+      error?: { code?: string };
+    }
+  | {
+      outcome: "partial_failure";
+      retryable: false;
+      error?: { code?: string };
+    }
+  | { outcome: "unknown"; retryable: false };
+
+/** Classifies one settled delivery failure without exposing its raw error graph. */
+export function resolveChannelDeliveryFailureTerminal(params: {
+  error: unknown;
+  deliveredBeforeFailure: boolean;
+  failedBeforeDeliver?: boolean;
+}): Exclude<ChannelDeliveryTerminal, { outcome: "delivered" }> {
+  const platformFailure = findPlatformMessageNotDispatchedError(params.error);
+  const publicError = platformFailure?.publicError;
+  if (params.deliveredBeforeFailure || isChannelPartialDeliveryError(params.error)) {
+    return {
+      outcome: "partial_failure",
+      retryable: false,
+      ...(publicError ? { error: publicError } : {}),
+    };
+  }
+  if (platformFailure) {
+    return {
+      outcome: "failed",
+      retryable: platformFailure.retryable,
+      ...(publicError ? { error: publicError } : {}),
+    };
+  }
+  if (params.failedBeforeDeliver || isProvenDeliveryNotSentError(params.error)) {
+    return { outcome: "failed", retryable: false };
+  }
+  return { outcome: "unknown", retryable: false };
+}
+
+/** Keeps the most conservative settled fact when more than one delivery path failed. */
+function mergeChannelDeliveryTerminal(
+  current: ChannelDeliveryTerminal | undefined,
+  next: ChannelDeliveryTerminal,
+): ChannelDeliveryTerminal {
+  if (!current || current.outcome === "delivered") {
+    return next;
+  }
+  if (next.outcome === "delivered") {
+    return current;
+  }
+  const rank = { failed: 1, unknown: 2, partial_failure: 3 } as const;
+  return rank[current.outcome] >= rank[next.outcome] ? current : next;
+}
+
+export function applySettledChannelDeliveryFailure(
+  result: DispatchFromConfigResult,
+  failure: { error: unknown; kind: ReplyDispatchKind },
+): DispatchFromConfigResult {
+  const visiblePartial = isChannelPartialDeliveryError(failure.error);
+  const remainingKindCount = visiblePartial
+    ? result.counts[failure.kind]
+    : Math.max(0, result.counts[failure.kind] - 1);
+  const terminal = resolveChannelDeliveryFailureTerminal({
+    error: failure.error,
+    deliveredBeforeFailure: visiblePartial || remainingKindCount > 0,
+  });
+  return {
+    ...result,
+    queuedFinal: failure.kind === "final" && remainingKindCount === 0 ? false : result.queuedFinal,
+    counts: visiblePartial
+      ? result.counts
+      : { ...result.counts, [failure.kind]: remainingKindCount },
+    ...(!visiblePartial
+      ? {
+          failedCounts: {
+            ...result.failedCounts,
+            [failure.kind]: (result.failedCounts?.[failure.kind] ?? 0) + 1,
+          },
+        }
+      : {}),
+    deliveryTerminal: mergeChannelDeliveryTerminal(result.deliveryTerminal, terminal),
+  };
+}
+
+export function emitChannelDeliveryTerminalObservations(params: {
+  terminal: Exclude<ChannelDeliveryTerminal, { outcome: "delivered" }>;
+  channel: string;
+  to: string;
+  accountId?: string;
+  agentId: string;
+  runId?: string;
+  sessionKey: string;
+  chatType: string | undefined;
+  startedAt: number;
+}): void {
+  const conversationKind = normalizeChatType(params.chatType);
+  const auditTerminal =
+    params.terminal.outcome === "unknown"
+      ? ({ outcome: "unknown", failureStage: "platform_send" } as const)
+      : ({
+          outcome: "failed",
+          failureStage: "platform_send",
+          sentBeforeError: params.terminal.outcome === "partial_failure",
+        } as const);
+  emitOutboundAuditTerminals({
+    context: {
+      channel: params.channel,
+      to: params.to,
+      ...(params.accountId ? { accountId: params.accountId } : {}),
+      ...(params.runId ? { replyPayloadSendingHook: { runId: params.runId } } : {}),
+      session: {
+        key: params.sessionKey,
+        agentId: params.agentId,
+        ...(conversationKind ? { conversationKind } : {}),
+      },
+    },
+    terminals: uniformOutboundAuditTerminals(1, auditTerminal),
+    startedAt: params.startedAt,
+  });
+  emitInternalDiagnosticEvent({
+    type: "message.delivery.error",
+    channel: params.channel,
+    sessionKey: params.sessionKey,
+    deliveryKind: "other",
+    durationMs: Math.max(0, Date.now() - params.startedAt),
+    errorCategory: `channel_${params.terminal.outcome}`,
+  });
+}

--- a/src/channels/turn/delivery-terminal.ts
+++ b/src/channels/turn/delivery-terminal.ts
@@ -1,10 +1,11 @@
 import type { DispatchFromConfigResult } from "../../auto-reply/reply/dispatch-from-config.types.js";
 import type { ReplyDispatchKind } from "../../auto-reply/reply/reply-dispatcher.types.js";
 import {
-  findPlatformMessageNotDispatchedError,
+  findPlatformMessageNotDispatchedErrors,
   isProvenDeliveryNotSentError,
 } from "../../infra/delivery-recovery.shared.js";
 import { emitInternalDiagnosticEvent } from "../../infra/diagnostic-events.js";
+import { collectErrorGraphCandidates } from "../../infra/errors.js";
 import {
   emitOutboundAuditTerminals,
   uniformOutboundAuditTerminals,
@@ -14,34 +15,114 @@ import { isChannelPartialDeliveryError } from "./delivery-result.js";
 import type { ChannelDeliveryTerminal } from "./delivery-terminal.types.js";
 
 /** Classifies one settled delivery failure without exposing its raw error graph. */
-export function resolveChannelDeliveryFailureTerminal(params: {
+function resolveChannelDeliveryFailureTerminal(params: {
   error: unknown;
   deliveredBeforeFailure: boolean;
   failedBeforeDeliver?: boolean;
 }): Exclude<ChannelDeliveryTerminal, { outcome: "delivered" }> {
-  const platformFailure = findPlatformMessageNotDispatchedError(params.error);
-  const publicError = platformFailure?.publicError;
-  if (params.deliveredBeforeFailure || isChannelPartialDeliveryError(params.error)) {
+  const platformFailures = findPlatformMessageNotDispatchedErrors(params.error);
+  const publicError = resolveAgreedPlatformPublicError(platformFailures);
+  // Visibility proof wins even when an outer AggregateError also carries no-send branches;
+  // otherwise retry/fallback policy could replay a payload that a nested operation delivered.
+  const hasPartialDelivery = collectErrorGraphCandidates(params.error, (current) => [
+    current.cause,
+    current.original,
+    current.error,
+    current.reason,
+    ...(Array.isArray(current.errors) ? current.errors : []),
+  ]).some(isChannelPartialDeliveryError);
+  const wholeFailureProvesNoSend =
+    params.failedBeforeDeliver || isProvenDeliveryNotSentError(params.error);
+  if (params.deliveredBeforeFailure || hasPartialDelivery) {
     return {
       outcome: "partial_failure",
       retryable: false,
       ...(publicError ? { error: publicError } : {}),
     };
   }
-  if (platformFailure) {
+  if (platformFailures.length > 0 && wholeFailureProvesNoSend) {
     return {
       outcome: "failed",
-      retryable: platformFailure.retryable,
+      retryable: platformFailures.some((failure) => failure.retryable),
       ...(publicError ? { error: publicError } : {}),
     };
   }
-  if (params.failedBeforeDeliver || isProvenDeliveryNotSentError(params.error)) {
+  if (wholeFailureProvesNoSend) {
     return { outcome: "failed", retryable: false };
   }
   return { outcome: "unknown", retryable: false };
 }
 
-/** Keeps the most conservative settled fact when more than one delivery path failed. */
+type ChannelDeliveryFailureFact = {
+  error: unknown;
+  failedBeforeDeliver?: boolean;
+};
+
+function resolveAgreedPlatformPublicError(
+  failures: readonly ReturnType<typeof findPlatformMessageNotDispatchedErrors>[number][],
+): { code?: string } | undefined {
+  const permanentFailures = failures.filter((failure) => !failure.retryable);
+  const code = permanentFailures[0]?.publicError?.code;
+  return code && permanentFailures.every((failure) => failure.publicError?.code === code)
+    ? { code }
+    : undefined;
+}
+
+function resolveAgreedPublicError(
+  failures: readonly ChannelDeliveryFailureFact[],
+  terminals: readonly Exclude<ChannelDeliveryTerminal, { outcome: "delivered" }>[],
+): { code?: string } | undefined {
+  return resolveAgreedPlatformPublicError(
+    failures.flatMap((failure, index) =>
+      terminals[index]?.outcome === "failed"
+        ? findPlatformMessageNotDispatchedErrors(failure.error)
+        : [],
+    ),
+  );
+}
+
+function resolveMergedPublicError(
+  current: Exclude<ChannelDeliveryTerminal, { outcome: "delivered" }>,
+  next: Exclude<ChannelDeliveryTerminal, { outcome: "delivered" }>,
+): { code?: string } | undefined {
+  const currentCode = "error" in current ? current.error?.code : undefined;
+  const nextCode = "error" in next ? next.error?.code : undefined;
+  return currentCode && currentCode === nextCode ? { code: currentCode } : undefined;
+}
+
+/** Aggregates a settled final-delivery set without depending on payload order. */
+export function resolveChannelDeliveryTerminalFromFailures(params: {
+  deliveredCount: number;
+  failures: readonly ChannelDeliveryFailureFact[];
+}): ChannelDeliveryTerminal | undefined {
+  if (params.failures.length === 0) {
+    return params.deliveredCount > 0 ? { outcome: "delivered" } : undefined;
+  }
+  const terminals = params.failures.map((failure) =>
+    resolveChannelDeliveryFailureTerminal({
+      error: failure.error,
+      deliveredBeforeFailure: false,
+      failedBeforeDeliver: failure.failedBeforeDeliver,
+    }),
+  );
+  const error = resolveAgreedPublicError(params.failures, terminals);
+  if (
+    params.deliveredCount > 0 ||
+    terminals.some((terminal) => terminal.outcome === "partial_failure")
+  ) {
+    return { outcome: "partial_failure", retryable: false, ...(error ? { error } : {}) };
+  }
+  if (terminals.some((terminal) => terminal.outcome === "unknown")) {
+    return { outcome: "unknown", retryable: false };
+  }
+  return {
+    outcome: "failed",
+    retryable: terminals.some((terminal) => terminal.outcome === "failed" && terminal.retryable),
+    ...(error ? { error } : {}),
+  };
+}
+
+/** Keeps the most conservative settled fact when separate delivery owners failed. */
 function mergeChannelDeliveryTerminal(
   current: ChannelDeliveryTerminal | undefined,
   next: ChannelDeliveryTerminal,
@@ -53,36 +134,60 @@ function mergeChannelDeliveryTerminal(
     return current;
   }
   const rank = { failed: 1, unknown: 2, partial_failure: 3 } as const;
-  return rank[current.outcome] >= rank[next.outcome] ? current : next;
+  const outcome = rank[current.outcome] >= rank[next.outcome] ? current.outcome : next.outcome;
+  if (outcome === "unknown") {
+    return { outcome, retryable: false };
+  }
+  // Collapsed terminals no longer expose whether a missing code means no permanent failure or
+  // conflicting permanent failures, so preserve a code only when both owners still agree.
+  const error = resolveMergedPublicError(current, next);
+  if (outcome === "partial_failure") {
+    return { outcome, retryable: false, ...(error ? { error } : {}) };
+  }
+  return {
+    outcome,
+    retryable: current.retryable || next.retryable,
+    ...(error ? { error } : {}),
+  };
 }
 
-export function applySettledChannelDeliveryFailure(
+export function applySettledChannelDeliveryFailures(
   result: DispatchFromConfigResult,
-  failure: { error: unknown; kind: ReplyDispatchKind },
+  failures: readonly { error: unknown; kind: ReplyDispatchKind }[],
 ): DispatchFromConfigResult {
-  const visiblePartial = isChannelPartialDeliveryError(failure.error);
-  const remainingKindCount = visiblePartial
-    ? result.counts[failure.kind]
-    : Math.max(0, result.counts[failure.kind] - 1);
-  const terminal = resolveChannelDeliveryFailureTerminal({
-    error: failure.error,
-    deliveredBeforeFailure: visiblePartial || remainingKindCount > 0,
-  });
+  if (failures.length === 0) {
+    return result;
+  }
+  const counts = { ...result.counts };
+  const failedCounts = { ...result.failedCounts };
+  let hasFailedCounts = false;
+  // Settle every counter before classifying finals; intermediate counts still include later
+  // failures and would falsely prove that part of the final set was delivered.
+  for (const failure of failures) {
+    if (isChannelPartialDeliveryError(failure.error)) {
+      continue;
+    }
+    counts[failure.kind] = Math.max(0, counts[failure.kind] - 1);
+    failedCounts[failure.kind] = (failedCounts[failure.kind] ?? 0) + 1;
+    hasFailedCounts = true;
+  }
+  // Tool and block failures affect counters only; the terminal describes recipient-visible finals.
+  const finalFailures = failures.filter((failure) => failure.kind === "final");
+  const settledTerminal =
+    finalFailures.length > 0
+      ? resolveChannelDeliveryTerminalFromFailures({
+          deliveredCount: counts.final,
+          failures: finalFailures,
+        })
+      : undefined;
   return {
     ...result,
-    queuedFinal: failure.kind === "final" && remainingKindCount === 0 ? false : result.queuedFinal,
-    counts: visiblePartial
-      ? result.counts
-      : { ...result.counts, [failure.kind]: remainingKindCount },
-    ...(!visiblePartial
-      ? {
-          failedCounts: {
-            ...result.failedCounts,
-            [failure.kind]: (result.failedCounts?.[failure.kind] ?? 0) + 1,
-          },
-        }
+    queuedFinal: finalFailures.length > 0 && counts.final === 0 ? false : result.queuedFinal,
+    counts,
+    ...(hasFailedCounts ? { failedCounts } : {}),
+    ...(settledTerminal
+      ? { deliveryTerminal: mergeChannelDeliveryTerminal(result.deliveryTerminal, settledTerminal) }
       : {}),
-    deliveryTerminal: mergeChannelDeliveryTerminal(result.deliveryTerminal, terminal),
   };
 }
 

--- a/src/channels/turn/delivery-terminal.ts
+++ b/src/channels/turn/delivery-terminal.ts
@@ -13,8 +13,6 @@ import { normalizeChatType } from "../chat-type.js";
 import { isChannelPartialDeliveryError } from "./delivery-result.js";
 import type { ChannelDeliveryTerminal } from "./delivery-terminal.types.js";
 
-export type { ChannelDeliveryTerminal } from "./delivery-terminal.types.js";
-
 /** Classifies one settled delivery failure without exposing its raw error graph. */
 export function resolveChannelDeliveryFailureTerminal(params: {
   error: unknown;

--- a/src/channels/turn/delivery-terminal.ts
+++ b/src/channels/turn/delivery-terminal.ts
@@ -11,20 +11,9 @@ import {
 } from "../../infra/outbound/outbound-audit.js";
 import { normalizeChatType } from "../chat-type.js";
 import { isChannelPartialDeliveryError } from "./delivery-result.js";
+import type { ChannelDeliveryTerminal } from "./delivery-terminal.types.js";
 
-export type ChannelDeliveryTerminal =
-  | { outcome: "delivered" }
-  | {
-      outcome: "failed";
-      retryable: boolean;
-      error?: { code?: string };
-    }
-  | {
-      outcome: "partial_failure";
-      retryable: false;
-      error?: { code?: string };
-    }
-  | { outcome: "unknown"; retryable: false };
+export type { ChannelDeliveryTerminal } from "./delivery-terminal.types.js";
 
 /** Classifies one settled delivery failure without exposing its raw error graph. */
 export function resolveChannelDeliveryFailureTerminal(params: {

--- a/src/channels/turn/delivery-terminal.types.ts
+++ b/src/channels/turn/delivery-terminal.types.ts
@@ -1,0 +1,14 @@
+/** Redacted terminal state for the final recipient-visible delivery. */
+export type ChannelDeliveryTerminal =
+  | { outcome: "delivered" }
+  | {
+      outcome: "failed";
+      retryable: boolean;
+      error?: { code?: string };
+    }
+  | {
+      outcome: "partial_failure";
+      retryable: false;
+      error?: { code?: string };
+    }
+  | { outcome: "unknown"; retryable: false };

--- a/src/channels/turn/lifecycle.ts
+++ b/src/channels/turn/lifecycle.ts
@@ -1,7 +1,6 @@
 import { dispatchInboundMessageWithRoutedChannelDispatcher } from "../../auto-reply/dispatch.js";
 import { copyReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { suppressPendingFinalDelivery } from "../../auto-reply/reply/dispatch-from-config.pending-final.js";
-import type { DispatchFromConfigResult } from "../../auto-reply/reply/dispatch-from-config.types.js";
 import type { ReplyDispatchKind } from "../../auto-reply/reply/reply-dispatcher.types.js";
 import { runWithSessionInitConflictRetry } from "../../auto-reply/reply/session-init-conflict-retry.js";
 import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
@@ -17,6 +16,7 @@ import { summarizeOutboundPayloadForTransport } from "../../infra/outbound/paylo
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { createChannelReplyPipeline } from "../message/reply-pipeline.js";
 import { recordInboundSession } from "../session.js";
+import { reconcileNonVisibleChannelDeliveries } from "./delivery-reconciliation.js";
 import { createSuppressedChannelDeliveryResult } from "./delivery-result.js";
 import {
   isExplicitlyNonVisibleChannelDelivery,
@@ -28,7 +28,7 @@ import {
   type PendingChannelDeliveryAttempt,
 } from "./delivery-settlement.js";
 import {
-  applySettledChannelDeliveryFailure,
+  applySettledChannelDeliveryFailures,
   emitChannelDeliveryTerminalObservations,
 } from "./delivery-terminal.js";
 import {
@@ -173,22 +173,6 @@ async function applyRoutedDirectMessageSending(params: {
   return { payload: copyReplyPayloadMetadata(params.payload, payload) };
 }
 
-function reconcileNonVisibleChannelDeliveries(
-  result: DispatchFromConfigResult,
-  nonVisibleCounts: Readonly<Record<ReplyDispatchKind, number>>,
-): DispatchFromConfigResult {
-  const counts = {
-    tool: Math.max(0, result.counts.tool - nonVisibleCounts.tool),
-    block: Math.max(0, result.counts.block - nonVisibleCounts.block),
-    final: Math.max(0, result.counts.final - nonVisibleCounts.final),
-  };
-  return {
-    ...result,
-    queuedFinal: result.queuedFinal && counts.final > 0,
-    counts,
-  };
-}
-
 function createObserveOnlyDeliveryAdapter(): ChannelEventDeliveryAdapter {
   // Observe-only turns still run the agent, but transport delivery must remain impossible for
   // every assembled-turn entry point, including direct SDK dispatch.
@@ -308,6 +292,7 @@ async function dispatchChannelTurnWithDeliveryOwner(
                         await suppressPendingFinalDelivery(payload);
                         await runChannelDeliveryObserver({
                           onDelivered: delivery.onDelivered,
+                          onError: delivery.onError,
                           payload,
                           info,
                           result: createSuppressedChannelDeliveryResult({ reason }),
@@ -344,6 +329,7 @@ async function dispatchChannelTurnWithDeliveryOwner(
                       await suppressPendingFinalDelivery(payload);
                       await runChannelDeliveryObserver({
                         onDelivered: delivery.onDelivered,
+                        onError: delivery.onError,
                         payload,
                         info,
                         result: suppression,
@@ -373,6 +359,7 @@ async function dispatchChannelTurnWithDeliveryOwner(
                         // deliverOutboundPayloadsInternal after outbound hooks settle.
                         await runChannelDeliveryObserver({
                           onDelivered: delivery.onDelivered,
+                          onError: delivery.onError,
                           payload: preparedPayload,
                           info,
                           result: durable.delivery,
@@ -460,6 +447,7 @@ async function dispatchChannelTurnWithDeliveryOwner(
                           result,
                         },
                         onDelivered: delivery.onDelivered,
+                        onError: delivery.onError,
                         emitMessageSent: delivery.observeMessageSent
                           ? getMessageSentEmitter()?.emitMessageSent
                           : undefined,
@@ -513,13 +501,12 @@ async function dispatchChannelTurnWithDeliveryOwner(
           ownership === "routed-delivery"
             ? reconcileNonVisibleChannelDeliveries(dispatchResult!, nonVisibleDeliveryCounts)
             : dispatchResult!;
-        const finalResult = settlementFailures.reduce(
-          (result, failure) =>
-            applySettledChannelDeliveryFailure(result, {
-              error: failure.error,
-              kind: failure.info.kind,
-            }),
+        const finalResult = applySettledChannelDeliveryFailures(
           settledResult,
+          settlementFailures.map((failure) => ({
+            error: failure.error,
+            kind: failure.info.kind,
+          })),
         );
         const deliveryTerminal = finalResult.deliveryTerminal;
         if (deliveryTerminal && deliveryTerminal.outcome !== "delivered") {

--- a/src/channels/turn/lifecycle.ts
+++ b/src/channels/turn/lifecycle.ts
@@ -227,11 +227,12 @@ async function settleChannelDeliveryAttempts(params: {
   }
 }
 
-// Failed-send custody policy: a permanent typed non-dispatch rejection is a
-// proven no-send (terminal suppression, no replay, no notice); an untyped error
-// after the pre-I/O claim affirms real ambiguity (unknown -> owed notice); a
-// retryable typed rejection restores prepared custody so recovery can replay —
-// the pre-claim already wrote unknown, and leaving it would fake ambiguity.
+// Failed-send custody policy: visible partial delivery is terminally delivered;
+// a permanent typed non-dispatch rejection is a proven no-send (terminal
+// suppression, no replay, no notice); an untyped error after the pre-I/O claim
+// affirms real ambiguity (unknown -> owed notice); a retryable typed rejection
+// restores prepared custody so recovery can replay — the pre-claim already
+// wrote unknown, and leaving it would fake ambiguity.
 async function settleFailedPendingFinalDelivery(
   payload: ReplyPayload,
   error: unknown,
@@ -240,7 +241,9 @@ async function settleFailedPendingFinalDelivery(
   if (!completion) {
     return;
   }
-  if (isPlatformMessageRejectedError(error)) {
+  if (resolvePartialChannelDeliveryResult(error) !== undefined) {
+    await settlePendingFinalDelivery(completion, "delivered", ["queued", "unknown"]);
+  } else if (isPlatformMessageRejectedError(error)) {
     await settlePendingFinalDelivery(completion, "suppressed", ["prepared", "queued", "unknown"]);
   } else if (isPlatformMessageNotDispatchedError(error)) {
     await settlePendingFinalDelivery(completion, "prepared", ["queued", "unknown"]);

--- a/src/channels/turn/lifecycle.ts
+++ b/src/channels/turn/lifecycle.ts
@@ -9,28 +9,31 @@ import {
   deriveInboundMessageHookContext,
   resolveInboundReplyHookTarget,
 } from "../../hooks/message-hook-mappers.js";
-import { formatErrorMessage, toErrorObject } from "../../infra/errors.js";
+import { toErrorObject } from "../../infra/errors.js";
 import { applyMessageSendingHook } from "../../infra/outbound/deliver-hooks.js";
 import { normalizeEmptyPayloadForDelivery } from "../../infra/outbound/deliver-payload.js";
-import {
-  isPlatformMessageNotDispatchedError,
-  isPlatformMessageRejectedError,
-} from "../../infra/outbound/deliver-types.js";
-import { settlePendingFinalDelivery } from "../../infra/outbound/delivery-completion.js";
 import { createMessageSentEmitter } from "../../infra/outbound/message-sent-hook.js";
 import { summarizeOutboundPayloadForTransport } from "../../infra/outbound/payloads.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import { resolveMessageReceiptPrimaryId } from "../message/receipt.js";
 import { createChannelReplyPipeline } from "../message/reply-pipeline.js";
 import { recordInboundSession } from "../session.js";
+import { createSuppressedChannelDeliveryResult } from "./delivery-result.js";
 import {
-  createSuppressedChannelDeliveryResult,
-  isChannelPartialDeliveryError,
-} from "./delivery-result.js";
+  isExplicitlyNonVisibleChannelDelivery,
+  resolvePartialChannelDeliveryResult,
+  runChannelDeliveryObserver,
+  settleChannelDeliveryAttempt,
+  settleChannelDeliveryAttempts,
+  settleFailedPendingFinalDelivery,
+  type PendingChannelDeliveryAttempt,
+} from "./delivery-settlement.js";
+import {
+  applySettledChannelDeliveryFailure,
+  emitChannelDeliveryTerminalObservations,
+} from "./delivery-terminal.js";
 import {
   createDirectPendingFinalCustody,
   NO_PENDING_FINAL_CUSTODY,
-  resolvePendingFinalCompletion,
   toCoreManagedDeliveryInfo,
 } from "./direct-delivery-custody.js";
 import {
@@ -43,7 +46,6 @@ import type {
   AssembledChannelTurn,
   ChannelEventDeliveryAdapter,
   ChannelDeliveryInfo,
-  ChannelDeliveryOutcome,
   ChannelDeliveryResult,
   ChannelTurnDeliveryAdapter,
   ChannelTurnPlan,
@@ -61,21 +63,6 @@ type RoutedAssembledChannelTurn = Omit<
 };
 
 type DispatchableChannelTurn = AssembledChannelTurn | RoutedAssembledChannelTurn;
-type AnyChannelDeliveryAdapter = ChannelEventDeliveryAdapter | ChannelTurnDeliveryAdapter;
-
-type PendingChannelDeliveryAttempt = {
-  payload: ReplyPayload;
-  info: ChannelDeliveryInfo;
-  result?: ChannelDeliveryResult | void;
-  error?: unknown;
-};
-
-function resolvePartialChannelDeliveryResult(
-  error: unknown,
-): (ChannelDeliveryOutcome & { visibleReplySent: true }) | undefined {
-  return isChannelPartialDeliveryError(error) ? error.deliveryResult : undefined;
-}
-
 export function assembleResolvedChannelTurn<
   TDispatchResult,
   TDelivery extends ChannelTurnDeliveryAdapter,
@@ -139,187 +126,6 @@ function resolveAssembledReplyPipeline(
       ...(turnAdoptionLifecycle ? { turnAdoptionLifecycle } : {}),
     },
   };
-}
-
-function isExplicitlyNonVisibleChannelDelivery(result: unknown): boolean {
-  return (
-    typeof result === "object" &&
-    result !== null &&
-    !Array.isArray(result) &&
-    (result as { visibleReplySent?: unknown }).visibleReplySent === false
-  );
-}
-
-function markChannelDeliveryErrorVisible(error: unknown): unknown {
-  if (typeof error === "object" && error !== null && !Array.isArray(error)) {
-    try {
-      Object.assign(error, { sentBeforeError: true, visibleReplySent: true });
-      return error;
-    } catch {
-      // Fall back to a wrapper when a platform error object is non-extensible.
-    }
-  }
-  const visibleError = new Error("visible channel reply delivery failed", { cause: error });
-  Object.assign(visibleError, { sentBeforeError: true, visibleReplySent: true });
-  return visibleError;
-}
-
-async function runChannelDeliveryObserver(params: {
-  onDelivered: AnyChannelDeliveryAdapter["onDelivered"] | undefined;
-  payload: ReplyPayload;
-  info: Parameters<NonNullable<ChannelEventDeliveryAdapter["onDelivered"]>>[1];
-  result: Parameters<NonNullable<ChannelEventDeliveryAdapter["onDelivered"]>>[2];
-}): Promise<void> {
-  if (!params.onDelivered) {
-    return;
-  }
-  try {
-    await params.onDelivered(params.payload, params.info, params.result);
-  } catch (error: unknown) {
-    throw isExplicitlyNonVisibleChannelDelivery(params.result)
-      ? error
-      : markChannelDeliveryErrorVisible(error);
-  }
-}
-
-function resolveChannelDeliveryMessageId(
-  result: ChannelDeliveryOutcome | undefined,
-): string | undefined {
-  return result?.receipt
-    ? resolveMessageReceiptPrimaryId(result.receipt)
-    : result?.messageIds?.find((messageId) => messageId.trim());
-}
-
-async function settleChannelDeliveryAttempts(params: {
-  attempts: readonly PendingChannelDeliveryAttempt[];
-  delivery: AnyChannelDeliveryAdapter;
-  emitMessageSent?: ReturnType<typeof createMessageSentEmitter>["emitMessageSent"];
-  onSettled?: (info: ChannelDeliveryInfo, result: ChannelDeliveryResult | undefined) => void;
-}): Promise<void> {
-  let preferredSettlementError: unknown;
-
-  for (const attempt of params.attempts) {
-    try {
-      const finalized = await settleChannelDeliveryAttempt({
-        attempt,
-        onDelivered: params.delivery.onDelivered,
-        onFinalizationError: async (error) => {
-          await Promise.resolve(params.delivery.onError?.(error, attempt.info));
-        },
-        emitMessageSent: params.emitMessageSent,
-      });
-      params.onSettled?.(attempt.info, finalized);
-    } catch (error: unknown) {
-      // Any visible partial outcome must win over an earlier generic failure so callers
-      // retain provider identity and do not retry an already-visible logical payload.
-      if (
-        preferredSettlementError === undefined ||
-        (resolvePartialChannelDeliveryResult(error) !== undefined &&
-          resolvePartialChannelDeliveryResult(preferredSettlementError) === undefined)
-      ) {
-        preferredSettlementError = error;
-      }
-    }
-  }
-
-  if (preferredSettlementError !== undefined) {
-    throw toErrorObject(preferredSettlementError, "channel delivery settlement failed");
-  }
-}
-
-// Failed-send custody policy: visible partial delivery is terminally delivered;
-// a permanent typed non-dispatch rejection is a proven no-send (terminal
-// suppression, no replay, no notice); an untyped error after the pre-I/O claim
-// affirms real ambiguity (unknown -> owed notice); a retryable typed rejection
-// restores prepared custody so recovery can replay — the pre-claim already
-// wrote unknown, and leaving it would fake ambiguity.
-async function settleFailedPendingFinalDelivery(
-  payload: ReplyPayload,
-  error: unknown,
-): Promise<void> {
-  const completion = resolvePendingFinalCompletion(payload);
-  if (!completion) {
-    return;
-  }
-  if (resolvePartialChannelDeliveryResult(error) !== undefined) {
-    await settlePendingFinalDelivery(completion, "delivered", ["queued", "unknown"]);
-  } else if (isPlatformMessageRejectedError(error)) {
-    await settlePendingFinalDelivery(completion, "suppressed", ["prepared", "queued", "unknown"]);
-  } else if (isPlatformMessageNotDispatchedError(error)) {
-    await settlePendingFinalDelivery(completion, "prepared", ["queued", "unknown"]);
-  } else {
-    await settlePendingFinalDelivery(completion, "unknown", ["queued", "unknown"]);
-  }
-}
-
-async function settleChannelDeliveryAttempt(params: {
-  attempt: PendingChannelDeliveryAttempt;
-  onDelivered: AnyChannelDeliveryAdapter["onDelivered"] | undefined;
-  onFinalizationError?: (error: unknown) => Promise<void> | void;
-  emitMessageSent?: ReturnType<typeof createMessageSentEmitter>["emitMessageSent"];
-}): Promise<ChannelDeliveryResult | undefined> {
-  const { attempt } = params;
-  if ("error" in attempt) {
-    const partial = resolvePartialChannelDeliveryResult(attempt.error);
-    if (!isPlatformMessageNotDispatchedError(attempt.error)) {
-      params.emitMessageSent?.({
-        success: false,
-        content: partial?.content ?? attempt.payload.text ?? "",
-        error: formatErrorMessage(attempt.error),
-        messageId: resolveChannelDeliveryMessageId(partial),
-      });
-    }
-    return undefined;
-  }
-
-  let finalized: ChannelDeliveryResult | undefined;
-  try {
-    const result = attempt.result;
-    finalized = result
-      ? result.finalization
-        ? { ...result, ...(await result.finalization), finalization: undefined }
-        : result
-      : undefined;
-  } catch (error: unknown) {
-    try {
-      await params.onFinalizationError?.(error);
-    } catch {
-      // Error observers are best-effort and must not replace the native settlement failure.
-    }
-    await settleFailedPendingFinalDelivery(attempt.payload, error);
-    const partial = resolvePartialChannelDeliveryResult(error);
-    if (!isPlatformMessageNotDispatchedError(error)) {
-      params.emitMessageSent?.({
-        success: false,
-        content: partial?.content ?? attempt.payload.text ?? "",
-        error: formatErrorMessage(error),
-        messageId: resolveChannelDeliveryMessageId(partial),
-      });
-    }
-    throw toErrorObject(error, "channel delivery finalization failed");
-  }
-
-  if (!isExplicitlyNonVisibleChannelDelivery(finalized)) {
-    params.emitMessageSent?.({
-      success: true,
-      content: finalized?.content ?? attempt.payload.text ?? "",
-      messageId: resolveChannelDeliveryMessageId(finalized),
-    });
-  }
-  const completion = resolvePendingFinalCompletion(attempt.payload);
-  if (completion) {
-    await settlePendingFinalDelivery(
-      completion,
-      isExplicitlyNonVisibleChannelDelivery(finalized) ? "suppressed" : "delivered",
-    );
-  }
-  await runChannelDeliveryObserver({
-    onDelivered: params.onDelivered,
-    payload: attempt.payload,
-    info: attempt.info,
-    result: finalized,
-  });
-  return finalized;
 }
 
 async function applyRoutedDirectMessageSending(params: {
@@ -474,6 +280,7 @@ async function dispatchChannelTurnWithDeliveryOwner(
           }
         : {}),
       runDispatch: async () => {
+        const deliveryStartedAt = Date.now();
         let dispatchResult:
           | Awaited<ReturnType<AssembledChannelTurn["dispatchReplyWithBufferedBlockDispatcher"]>>
           | undefined;
@@ -679,39 +486,60 @@ async function dispatchChannelTurnWithDeliveryOwner(
           dispatchError = error;
         }
 
-        let settlementError: unknown;
-        try {
-          await settleChannelDeliveryAttempts({
+        const settlementFailures = [
+          ...(await settleChannelDeliveryAttempts({
             attempts: normalizationSuppressionAttempts,
             delivery,
-          });
-          await settleChannelDeliveryAttempts({
+          })),
+          ...(await settleChannelDeliveryAttempts({
             attempts: pendingDeliveryAttempts,
             delivery,
             emitMessageSent: getMessageSentEmitter()?.emitMessageSent,
             onSettled: recordSettledDelivery,
-          });
-        } catch (error: unknown) {
-          settlementError = error;
-        }
-        // Deferred settlement can carry the provider-visible receipt/content that the earlier
-        // dispatch failure lacks. Preserve that partial result so callers do not retry a send
-        // that the channel already accepted.
-        if (
-          settlementError !== undefined &&
-          resolvePartialChannelDeliveryResult(settlementError) !== undefined
-        ) {
-          throw toErrorObject(settlementError, "channel delivery settlement failed");
-        }
+          })),
+        ];
         if (dispatchError !== undefined) {
+          // A visible partial settlement owns replay safety even when dispatch also failed.
+          // Preserve that typed error so callers do not retry an already-visible payload.
+          const partialFailure = settlementFailures.find(
+            (failure) => resolvePartialChannelDeliveryResult(failure.error) !== undefined,
+          );
+          if (partialFailure) {
+            throw toErrorObject(partialFailure.error, "channel delivery settlement failed");
+          }
           throw toErrorObject(dispatchError, "channel dispatch failed");
         }
-        if (settlementError !== undefined) {
-          throw toErrorObject(settlementError, "channel delivery settlement failed");
+        const settledResult =
+          ownership === "routed-delivery"
+            ? reconcileNonVisibleChannelDeliveries(dispatchResult!, nonVisibleDeliveryCounts)
+            : dispatchResult!;
+        const finalResult = settlementFailures.reduce(
+          (result, failure) =>
+            applySettledChannelDeliveryFailure(result, {
+              error: failure.error,
+              kind: failure.info.kind,
+            }),
+          settledResult,
+        );
+        const deliveryTerminal = finalResult.deliveryTerminal;
+        if (deliveryTerminal && deliveryTerminal.outcome !== "delivered") {
+          const target = resolveInboundReplyHookTarget(
+            params.ctxPayload,
+            hookCtx ?? deriveInboundMessageHookContext(params.ctxPayload),
+          );
+          emitChannelDeliveryTerminalObservations({
+            terminal: deliveryTerminal,
+            channel: params.channel,
+            to: target,
+            ...(params.accountId ? { accountId: params.accountId } : {}),
+            agentId: params.agentId,
+            ...(agentRunId ? { runId: agentRunId } : {}),
+            sessionKey: params.routeSessionKey,
+            chatType: params.ctxPayload.ChatType,
+            startedAt: deliveryStartedAt,
+          });
         }
-        return ownership === "routed-delivery"
-          ? reconcileNonVisibleChannelDeliveries(dispatchResult!, nonVisibleDeliveryCounts)
-          : dispatchResult!;
+        return finalResult;
       },
     },
     { suppressObserveOnlyDispatch: false },

--- a/src/channels/turn/run-channel-turn.custody.test.ts
+++ b/src/channels/turn/run-channel-turn.custody.test.ts
@@ -4,6 +4,7 @@ import type { DispatchReplyWithDispatcher } from "../../auto-reply/reply/provide
 import type { FinalizedMsgContext } from "../../auto-reply/templating.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { PlatformMessageNotDispatchedError } from "../../infra/outbound/deliver-types.js";
+import { createChannelPartialDeliveryError } from "./delivery-result.js";
 import { dispatchRoutedChannelTurn } from "./lifecycle.js";
 
 const dispatchReplyWithRoutedChannelDispatcherCore = vi.hoisted(() => vi.fn());
@@ -106,6 +107,14 @@ describe("channel turn failed-send custody", () => {
       label: "untyped failure affirms unknown custody",
       error: new Error("adapter failed after entry"),
       failureSettle: ["unknown", ["queued", "unknown"]] as const,
+    },
+    {
+      label: "visible partial delivery settles delivered custody",
+      error: createChannelPartialDeliveryError(new Error("finalization failed"), {
+        visibleReplySent: true,
+        content: "accepted partial",
+      }),
+      failureSettle: ["delivered", ["queued", "unknown"]] as const,
     },
   ])("$label", async ({ error, failureSettle }) => {
     await expect(run(error)).rejects.toBe(error);

--- a/src/channels/turn/run-channel-turn.delivery.test.ts
+++ b/src/channels/turn/run-channel-turn.delivery.test.ts
@@ -383,6 +383,14 @@ describe("channel turn delivery", () => {
     const durable = vi.fn();
     const deliver = vi.fn();
     const onDelivered = vi.fn();
+    dispatchReplyWithRoutedChannelDispatcherCore.mockImplementationOnce(async (params) => {
+      await params.dispatcherOptions.deliver({ text: "reply" }, { kind: "final" });
+      return {
+        queuedFinal: true,
+        counts: { tool: 0, block: 0, final: 1 },
+        deliveryTerminal: { outcome: "delivered" as const },
+      };
+    });
 
     const result = await dispatchRoutedChannelTurn({
       cfg,
@@ -413,6 +421,7 @@ describe("channel turn delivery", () => {
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
     });
+    expect(result.dispatchResult).not.toHaveProperty("deliveryTerminal");
   });
 
   it("suppresses routed direct delivery and visible counts when message hooks cancel", async () => {
@@ -425,14 +434,18 @@ describe("channel turn delivery", () => {
       })),
     });
     const deliver = vi.fn();
-    const onDelivered = vi.fn();
+    const observerError = new Error("suppression observer failed");
+    const onDelivered = vi.fn(() => {
+      throw observerError;
+    });
+    const onError = vi.fn();
 
     const result = await dispatchRoutedChannelTurn({
       cfg,
       channel: "telegram",
       route: { agentId: "main", sessionKey: "agent:main:telegram:peer" },
       ctxPayload: createCtx({ Surface: "telegram", OriginatingTo: "chat-1" }),
-      delivery: { deliver, onDelivered, observeMessageSent: true },
+      delivery: { deliver, onDelivered, onError, observeMessageSent: true },
     });
 
     expect(deliver).not.toHaveBeenCalled();
@@ -449,6 +462,7 @@ describe("channel turn delivery", () => {
       },
     );
     expect(emitMessageSent).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(observerError, { kind: "final" });
     expectDispatched(result);
     expect(result.dispatchResult).toMatchObject({
       queuedFinal: false,
@@ -906,33 +920,37 @@ describe("channel turn delivery", () => {
 
   it("preserves visible delivery when post-delivery observers throw", async () => {
     const error = new Error("observer failed");
+    Object.freeze(error);
     const deliver = vi.fn(async () => ({ messageIds: ["local-1"], visibleReplySent: true }));
     const dispatchReplyWithBufferedBlockDispatcher = createDispatch();
 
-    await expect(
-      dispatchTestAssembledTurn({
-        channel: "telegram",
-        accountId: "acct",
-        routeSessionKey: "agent:main:telegram:peer",
-        ctxPayload: createCtx({ To: "123", OriginatingTo: "123" }),
-        recordInboundSession: createRecordInboundSession(),
-        dispatchReplyWithBufferedBlockDispatcher,
-        delivery: {
-          deliver,
-          durable: false,
-          onDelivered: () => {
-            throw error;
-          },
+    const caught = await dispatchTestAssembledTurn({
+      channel: "telegram",
+      accountId: "acct",
+      routeSessionKey: "agent:main:telegram:peer",
+      ctxPayload: createCtx({ To: "123", OriginatingTo: "123" }),
+      recordInboundSession: createRecordInboundSession(),
+      dispatchReplyWithBufferedBlockDispatcher,
+      delivery: {
+        deliver,
+        durable: false,
+        onDelivered: () => {
+          throw error;
         },
-      }),
-    ).rejects.toMatchObject({
+      },
+    }).catch((caughtError: unknown) => caughtError);
+
+    expect(caught).toMatchObject({
+      code: "CHANNEL_PARTIAL_DELIVERY",
+      cause: error,
       sentBeforeError: true,
       visibleReplySent: true,
+      deliveryResult: {
+        messageIds: ["local-1"],
+        visibleReplySent: true,
+      },
     });
-    expect(error).toMatchObject({
-      sentBeforeError: true,
-      visibleReplySent: true,
-    });
+    expect(error).not.toHaveProperty("sentBeforeError");
   });
 
   it("returns custom delivery result to the buffered dispatcher", async () => {

--- a/src/channels/turn/run-channel-turn.pipeline.test.ts
+++ b/src/channels/turn/run-channel-turn.pipeline.test.ts
@@ -235,23 +235,30 @@ describe("channel turn pipeline", () => {
     const observerError = new Error("observer failed");
     const onError = vi.fn();
 
-    await expect(
-      dispatchTestAssembledTurn({
-        channel: "feishu",
-        routeSessionKey: "agent:main:feishu:peer",
-        ctxPayload: createCtx({ Surface: "feishu", Provider: "feishu" }),
-        recordInboundSession: createRecordInboundSession(),
-        dispatchReplyWithBufferedBlockDispatcher: createDispatch(),
-        delivery: {
-          observeMessageSent: true,
-          deliver: async () => ({ messageIds: ["om-visible"], visibleReplySent: true }),
-          onDelivered: () => {
-            throw observerError;
-          },
-          onError,
+    const error = await dispatchTestAssembledTurn({
+      channel: "feishu",
+      routeSessionKey: "agent:main:feishu:peer",
+      ctxPayload: createCtx({ Surface: "feishu", Provider: "feishu" }),
+      recordInboundSession: createRecordInboundSession(),
+      dispatchReplyWithBufferedBlockDispatcher: createDispatch(),
+      delivery: {
+        observeMessageSent: true,
+        deliver: async () => ({ messageIds: ["om-visible"], visibleReplySent: true }),
+        onDelivered: () => {
+          throw observerError;
         },
-      }),
-    ).rejects.toBe(observerError);
+        onError,
+      },
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      code: "CHANNEL_PARTIAL_DELIVERY",
+      cause: observerError,
+      deliveryResult: {
+        messageIds: ["om-visible"],
+        visibleReplySent: true,
+      },
+    });
 
     expect(emitMessageSent).toHaveBeenCalledOnce();
     expect(emitMessageSent).toHaveBeenCalledWith({
@@ -260,6 +267,51 @@ describe("channel turn pipeline", () => {
       messageId: "om-visible",
     });
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("preserves a deferred visible result when its post-send observer throws", async () => {
+    const observerError = new Error("deferred observer failed");
+    const finalization = Promise.resolve({
+      content: "deferred reply",
+      messageIds: ["om-deferred"],
+      visibleReplySent: true as const,
+    });
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn(async (params) => {
+      await params.dispatcherOptions.deliver({ text: "deferred reply" }, { kind: "final" });
+      return {
+        queuedFinal: true,
+        counts: { tool: 0, block: 0, final: 1 },
+        deliveryTerminal: { outcome: "delivered" as const },
+      };
+    }) as DispatchReplyWithBufferedBlockDispatcher;
+
+    const result = await dispatchTestAssembledTurn({
+      channel: "feishu",
+      routeSessionKey: "agent:main:feishu:peer",
+      ctxPayload: createCtx({ Surface: "feishu", Provider: "feishu" }),
+      recordInboundSession: createRecordInboundSession(),
+      dispatchReplyWithBufferedBlockDispatcher,
+      delivery: {
+        observeMessageSent: true,
+        deliver: async () => ({ visibleReplySent: false, finalization }),
+        onDelivered: () => {
+          throw observerError;
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      dispatched: true,
+      dispatchResult: {
+        counts: { final: 1 },
+        deliveryTerminal: { outcome: "partial_failure", retryable: false },
+      },
+    });
+    expect(emitMessageSent).toHaveBeenCalledWith({
+      success: true,
+      content: "deferred reply",
+      messageId: "om-deferred",
+    });
   });
 
   it("observes early finalization rejection before reporting partial delivery", async () => {
@@ -433,6 +485,79 @@ describe("channel turn pipeline", () => {
       content: "accepted second preview",
       error: "second finalization failed",
       messageId: "om-second-preview",
+    });
+  });
+
+  it("does not infer partial delivery when every deferred finalization fails", async () => {
+    const firstFinalization = Promise.reject(new Error("first finalization failed"));
+    const secondFinalization = Promise.reject(new Error("second finalization failed"));
+    void firstFinalization.catch(() => undefined);
+    void secondFinalization.catch(() => undefined);
+    const deliver = vi
+      .fn()
+      .mockResolvedValueOnce({ visibleReplySent: false, finalization: firstFinalization })
+      .mockResolvedValueOnce({ visibleReplySent: false, finalization: secondFinalization });
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn(async (params) => {
+      await params.dispatcherOptions.deliver({ text: "first requested" }, { kind: "final" });
+      await params.dispatcherOptions.deliver({ text: "second requested" }, { kind: "final" });
+      return { queuedFinal: true, counts: { tool: 0, block: 0, final: 2 } };
+    }) as DispatchReplyWithBufferedBlockDispatcher;
+
+    const result = await dispatchTestAssembledTurn({
+      channel: "feishu",
+      routeSessionKey: "agent:main:feishu:peer",
+      ctxPayload: createCtx({ Surface: "feishu", Provider: "feishu" }),
+      recordInboundSession: createRecordInboundSession(),
+      dispatchReplyWithBufferedBlockDispatcher,
+      delivery: { observeMessageSent: true, deliver },
+    });
+
+    expect(result).toMatchObject({
+      dispatched: true,
+      dispatchResult: {
+        queuedFinal: false,
+        counts: { final: 0 },
+        failedCounts: { final: 2 },
+        deliveryTerminal: { outcome: "unknown", retryable: false },
+      },
+    });
+  });
+
+  it("keeps a successful final terminal when deferred tool delivery fails", async () => {
+    const toolFinalization = Promise.reject(new Error("tool finalization failed"));
+    void toolFinalization.catch(() => undefined);
+    const deliver = vi.fn(async (_payload: ReplyPayload, info: { kind: string }) =>
+      info.kind === "tool"
+        ? { visibleReplySent: false, finalization: toolFinalization }
+        : { visibleReplySent: true, messageIds: ["om-final"] },
+    );
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn(async (params) => {
+      await params.dispatcherOptions.deliver({ text: "tool output" }, { kind: "tool" });
+      await params.dispatcherOptions.deliver({ text: "final answer" }, { kind: "final" });
+      return {
+        queuedFinal: true,
+        counts: { tool: 1, block: 0, final: 1 },
+        deliveryTerminal: { outcome: "delivered" as const },
+      };
+    }) as DispatchReplyWithBufferedBlockDispatcher;
+
+    const result = await dispatchTestAssembledTurn({
+      channel: "feishu",
+      routeSessionKey: "agent:main:feishu:peer",
+      ctxPayload: createCtx({ Surface: "feishu", Provider: "feishu" }),
+      recordInboundSession: createRecordInboundSession(),
+      dispatchReplyWithBufferedBlockDispatcher,
+      delivery: { observeMessageSent: true, deliver },
+    });
+
+    expect(result).toMatchObject({
+      dispatched: true,
+      dispatchResult: {
+        queuedFinal: true,
+        counts: { tool: 0, final: 1 },
+        failedCounts: { tool: 1 },
+        deliveryTerminal: { outcome: "delivered" },
+      },
     });
   });
 

--- a/src/channels/turn/run-channel-turn.pipeline.test.ts
+++ b/src/channels/turn/run-channel-turn.pipeline.test.ts
@@ -294,20 +294,26 @@ describe("channel turn pipeline", () => {
       return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
     }) as DispatchReplyWithBufferedBlockDispatcher;
 
-    await expect(
-      dispatchTestAssembledTurn({
-        channel: "feishu",
-        routeSessionKey: "agent:main:feishu:peer",
-        ctxPayload: createCtx({ Surface: "feishu", Provider: "feishu" }),
-        recordInboundSession: createRecordInboundSession(),
-        dispatchReplyWithBufferedBlockDispatcher,
-        delivery: {
-          observeMessageSent: true,
-          deliver: async () => ({ visibleReplySent: false, finalization }),
-          onError,
-        },
-      }),
-    ).rejects.toBe(partialError);
+    const result = await dispatchTestAssembledTurn({
+      channel: "feishu",
+      routeSessionKey: "agent:main:feishu:peer",
+      ctxPayload: createCtx({ Surface: "feishu", Provider: "feishu" }),
+      recordInboundSession: createRecordInboundSession(),
+      dispatchReplyWithBufferedBlockDispatcher,
+      delivery: {
+        observeMessageSent: true,
+        deliver: async () => ({ visibleReplySent: false, finalization }),
+        onError,
+      },
+    });
+
+    expect(result).toMatchObject({
+      dispatched: true,
+      dispatchResult: {
+        counts: { final: 1 },
+        deliveryTerminal: { outcome: "partial_failure", retryable: false },
+      },
+    });
 
     expect(emitMessageSent).toHaveBeenCalledOnce();
     expect(emitMessageSent).toHaveBeenCalledWith({
@@ -397,16 +403,23 @@ describe("channel turn pipeline", () => {
       return { queuedFinal: true, counts: { tool: 0, block: 0, final: 2 } };
     }) as DispatchReplyWithBufferedBlockDispatcher;
 
-    await expect(
-      dispatchTestAssembledTurn({
-        channel: "feishu",
-        routeSessionKey: "agent:main:feishu:peer",
-        ctxPayload: createCtx({ Surface: "feishu", Provider: "feishu" }),
-        recordInboundSession: createRecordInboundSession(),
-        dispatchReplyWithBufferedBlockDispatcher,
-        delivery: { observeMessageSent: true, deliver },
-      }),
-    ).rejects.toBe(partialError);
+    const result = await dispatchTestAssembledTurn({
+      channel: "feishu",
+      routeSessionKey: "agent:main:feishu:peer",
+      ctxPayload: createCtx({ Surface: "feishu", Provider: "feishu" }),
+      recordInboundSession: createRecordInboundSession(),
+      dispatchReplyWithBufferedBlockDispatcher,
+      delivery: { observeMessageSent: true, deliver },
+    });
+
+    expect(result).toMatchObject({
+      dispatched: true,
+      dispatchResult: {
+        counts: { final: 1 },
+        failedCounts: { final: 1 },
+        deliveryTerminal: { outcome: "partial_failure", retryable: false },
+      },
+    });
 
     expect(emitMessageSent).toHaveBeenCalledTimes(2);
     expect(emitMessageSent).toHaveBeenNthCalledWith(1, {

--- a/src/infra/delivery-recovery.shared.ts
+++ b/src/infra/delivery-recovery.shared.ts
@@ -8,7 +8,6 @@ import { sleep } from "../utils/sleep.js";
 import { collectErrorGraphCandidates, extractErrorCode } from "./errors.js";
 import {
   isPlatformMessageNotDispatchedError,
-  isPlatformMessageRejectedError,
   type PlatformMessageNotDispatchedError,
 } from "./outbound/deliver-types.js";
 import { getRetryAttemptErrors } from "./retry-attempt-errors.js";
@@ -165,8 +164,18 @@ export function isProvenDeliveryNotSentError(err: unknown): boolean {
 export function findPlatformMessageRejectedError(
   err: unknown,
 ): (PlatformMessageNotDispatchedError & { readonly retryable: false }) | undefined {
+  const failure = findPlatformMessageNotDispatchedError(err);
+  return failure && !failure.retryable
+    ? (failure as PlatformMessageNotDispatchedError & { readonly retryable: false })
+    : undefined;
+}
+
+/** Finds any provider assertion that the payload did not cross the platform boundary. */
+export function findPlatformMessageNotDispatchedError(
+  err: unknown,
+): PlatformMessageNotDispatchedError | undefined {
   for (const candidate of collectErrorGraphCandidates(err, nestedErrorCandidates)) {
-    if (isPlatformMessageRejectedError(candidate)) {
+    if (isPlatformMessageNotDispatchedError(candidate)) {
       return candidate;
     }
   }

--- a/src/infra/delivery-recovery.shared.ts
+++ b/src/infra/delivery-recovery.shared.ts
@@ -109,12 +109,18 @@ function isProvenPreConnectCandidate(candidate: unknown): boolean {
   return syscall === "connect" || syscall === "getaddrinfo";
 }
 
-function nestedErrorCandidates(current: Record<string, unknown>): unknown[] {
+function nestedErrorCandidates(
+  current: Record<string, unknown>,
+  includeMarkerCauses = false,
+): unknown[] {
   const retryAttempts = getRetryAttemptErrors(current);
   const retryBranches = preserveProofBranches(retryAttempts);
   // The explicit marker covers its cause: the provider owns the final dispatch
   // boundary and proved that no recipient-visible send could have completed.
-  if (isPlatformMessageNotDispatchedError(current) || isProvenPreConnectCandidate(current)) {
+  if (
+    !includeMarkerCauses &&
+    (isPlatformMessageNotDispatchedError(current) || isProvenPreConnectCandidate(current))
+  ) {
     return retryBranches;
   }
   const nested = [current.cause, current.original, current.error, current.reason];
@@ -171,7 +177,7 @@ export function findPlatformMessageRejectedError(
 }
 
 /** Finds any provider assertion that the payload did not cross the platform boundary. */
-export function findPlatformMessageNotDispatchedError(
+function findPlatformMessageNotDispatchedError(
   err: unknown,
 ): PlatformMessageNotDispatchedError | undefined {
   for (const candidate of collectErrorGraphCandidates(err, nestedErrorCandidates)) {
@@ -180,6 +186,15 @@ export function findPlatformMessageNotDispatchedError(
     }
   }
   return undefined;
+}
+
+/** Retains every provider disposition carried by aggregate delivery wrappers. */
+export function findPlatformMessageNotDispatchedErrors(
+  err: unknown,
+): PlatformMessageNotDispatchedError[] {
+  return collectErrorGraphCandidates(err, (current) => nestedErrorCandidates(current, true)).filter(
+    isPlatformMessageNotDispatchedError,
+  );
 }
 
 export function computeBackoffMs(retryCount: number): number {

--- a/src/infra/outbound/deliver-types.ts
+++ b/src/infra/outbound/deliver-types.ts
@@ -56,14 +56,25 @@ const PLATFORM_MESSAGE_NOT_DISPATCHED_ERROR_CODE = "OPENCLAW_PLATFORM_MESSAGE_NO
 export class PlatformMessageNotDispatchedError extends Error {
   readonly code = PLATFORM_MESSAGE_NOT_DISPATCHED_ERROR_CODE;
   readonly retryable: boolean;
+  /** Provider-stable code safe to expose to the dispatch controller. */
+  readonly publicError?: { code?: string };
 
-  constructor(message: string, options: { cause: unknown; retryable?: boolean }) {
+  constructor(
+    message: string,
+    options: {
+      cause: unknown;
+      retryable?: boolean;
+      /** Explicitly redacted provider details; raw causes never cross the controller boundary. */
+      publicError?: { code?: string };
+    },
+  ) {
     const retryable = options.retryable !== false;
     super(retryable ? message : message.trim() || "Platform rejected the message before dispatch", {
       cause: options.cause,
     });
     this.name = "PlatformMessageNotDispatchedError";
     this.retryable = retryable;
+    this.publicError = options.publicError;
   }
 }
 


### PR DESCRIPTION
Closes #119862

## What Problem This Solves

Feishu could reject a final card before dispatch while shared settlement correctly recorded zero successful finals and one failed final. The Feishu completion predicate then required the stale queued-final flag, so it skipped the existing recovery notice. Structured provider rejections were also flattened into ambiguous errors, while an accepted streaming card without a message ID lost ownership and could be duplicated by static fallback.

## Why This Change Was Made

Classify authoritative nonzero Feishu message API responses at their producer as permanent not-dispatched outcomes, while preserving rate-limit and ambiguous-network semantics. Derive one conservative terminal from the complete final-only settlement set. After a provider-proven streaming no-send, attempt exactly one static card; ambiguous starts remain fenced. Keep code-zero no-ID CardKit sessions as the finalization owner, but leave visibility unknown until a successful nonempty CardKit write proves it.

## ClawSweeper Follow-up

All rank-up moves from the review of `116b542e81f0` are addressed:

- Final failures are aggregated set-wide and order-independently; partial outranks unknown, unknown outranks permanent failure, retryability is ORed, and a public provider code is retained only when every permanent failure agrees.
- Deferred settlement derives the terminal once from final attempts only. Tool/block failures cannot create or overwrite it.
- A provider-proven streaming no-send receives one static-card attempt. If both attempts fail, retryability and any unanimously agreed public code are combined without losing either cause.
- A code-zero response without `message_id` retains replay custody but remains visibility-unknown until a successful nonempty CardKit write.
- The additive Plugin SDK permanent/retryable/partial/unknown and redaction contracts are documented.
- All 27 freshness-result checks again assert the complete result shape, including explicit terminal presence or absence.

### Second local review (`fb81322fe92`)

The three additional findings are also addressed:

- Feishu codes `11233` and `99991400` now share the canonical retry path for both fulfilled SDK bodies and HTTP-400 response bodies, matching Feishu’s published throttling contract.
- A successful send followed by observer failure now preserves its receipt/content in the typed partial-delivery envelope for immediate and deferred settlement.
- Native non-visible reconciliation removes a stale `delivered` terminal only when no visible final remains; intentional suppression stays non-failure and non-delivered terminals are preserved.

### Third local review (`1129f846ebf`)

The two additional combined-state blockers are addressed:

- Generic empty-result recovery now requires `deliveryTerminal` to be absent, so unknown, partial, and retryable failures cannot trigger a duplicate fallback.
- Public provider-code agreement now considers only permanent non-retryable failures; retryable, partial, and unknown outcomes neither participate nor veto, while conflicting permanent codes remain redacted.

### Fourth local review (`f71084faba1`)

The remaining cross-owner merge blocker is addressed: collapsed terminals now retain a public provider code only when both delivery owners explicitly agree. Matching codes survive; conflicting or missing provenance redacts the code.

### Fifth local review (`2c31eeb9edc`)

The remaining whole-graph ambiguity blocker is addressed: a nested no-send marker classifies the terminal as failed only when every branch proves no send. A proven streaming rejection plus ambiguous static fallback remains `unknown`, both directly and through dispatcher finalization, preventing duplicate recovery.

## User Impact

Feishu users now receive the answer through a static card when streaming is definitively rejected but the alternate encoder works. If both sends definitively fail, the existing actionable recovery notice appears instead of silence. Accepted identity-less streaming cards finalize in place without duplicate answers or fabricated visibility. Existing success, rate-limit retry, withdrawn-target fallback, intentional suppression, media, and sibling-channel accounting remain unchanged.

## Evidence

Exact pushed head: `3f21a2c927a`.

- Clean Blacksmith Testbox: 219/219 focused regressions passed across Feishu, auto-reply, delivery-terminal, and the full 21-test channel-turn pipeline.
- `pnpm check:test-types`: passed, including core, extension, and root test projects.
- `pnpm plugin-sdk:api:check`: passed.
- `pnpm check:docs`: passed (format, Markdown lint, MDX, glossary, links, and config examples).
- Changed core and Feishu files: oxlint clean. The remote full core lint also completed the changed `src/auto-reply` and `src/channels` shards cleanly before the intentionally bounded run was stopped.
- Exact-head branch autoreview: no actionable findings; TruffleHog clean.
- `git diff --check`: clean. The rebased stack contains zero merge commits and current `origin/main` is its ancestor.

The unbounded `pnpm check` reached the repository ratchets and stopped only because current `main` still lists three moved Discord voice files in the max-lines baseline; this branch does not touch those files or that baseline. Every other executed repository ratchet passed.

Production/test LOC for the whole PR, excluding generated baselines: production `+987/-396` (net `+591`), tests `+1337/-133` (net `+1204`), docs net `+31`, generated net `0`. The second ClawSweeper follow-up is production net `-18`; the cumulative repair commit is production net `+139`. The remaining growth is the shared complete-set terminal reducer and the explicit one-attempt Feishu fallback/custody owner, replacing order-dependent per-failure policy rather than adding a parallel runtime path.

### Live Feishu proof

Behavioral head `2f8dc4c3523` was exercised through the production Feishu dispatcher against the live provider; current head `3f21a2c927a` differs by linear rebases plus the reviewed settlement/rate-limit/fallback repairs.

```json
{
  "scenario": "feishu-exact-head-streaming-settlement",
  "head": "2f8dc4c3523",
  "provider": {
    "liveRequestObserved": true,
    "streamingAccepted": true
  },
  "fallback": {
    "visibleReplySent": true,
    "receiptReturned": true,
    "contentDigest": "32f77eaae39de56925f66123aee25d0a58e49ef26f8e432bdb146b38a4cbde9f"
  },
  "cleanup": {
    "attempted": true,
    "providerCode": 0,
    "succeeded": true
  }
}
```

The account now accepts the streaming-card reference, so the earlier live `230001` rejection cannot be reproduced honestly on demand. That earlier provider proof remains evidence for rejection classification; the repaired one-static-fallback behavior is covered deterministically at both dispatcher and full delivery-trace owner boundaries. The live exact-behavior run proved provider acceptance, final receipt settlement, and provider-confirmed cleanup. A preliminary proof message was also located by its unique non-secret prefix and deleted successfully. No account, chat, user, message, token, or credential value is retained.








