### PR TITLE
fix: retry inbound messages when debounced dispatch fails

### DIFF
--- a/extensions/signal/src/monitor/event-handler.ingress-lifecycle.test.ts
+++ b/extensions/signal/src/monitor/event-handler.ingress-lifecycle.test.ts
@@ -16,13 +16,19 @@ type DispatchParams = {
 const { dispatchInboundMessageMock, recordInboundSessionMock, dispatchCapture, dispatchBehavior } =
   vi.hoisted(() => {
     const captured: DispatchParams[] = [];
-    const behavior = { adoptDuringDispatch: true };
+    const behavior = {
+      adoptDuringDispatch: true,
+      failBeforeAdoption: undefined as Error | undefined,
+    };
     return {
       dispatchCapture: captured,
       dispatchBehavior: behavior,
       recordInboundSessionMock: vi.fn(),
       dispatchInboundMessageMock: vi.fn(async (params: DispatchParams) => {
         captured.push(params);
+        if (behavior.failBeforeAdoption) {
+          throw behavior.failBeforeAdoption;
+        }
         if (behavior.adoptDuringDispatch) {
           // Mirror the real reply lane: adoption fires while dispatch runs.
           await params.replyOptions?.turnAdoptionLifecycle?.onAdopted();
@@ -102,9 +108,11 @@ beforeAll(async () => {
 function createTrackedLifecycle(): SignalIngressLifecycle & {
   adoptedCount: () => number;
   abandonedCount: () => number;
+  failedCount: () => number;
 } {
   let adopted = 0;
   let abandoned = 0;
+  let failed = 0;
   return {
     abortSignal: new AbortController().signal,
     onAdopted: async () => {
@@ -112,11 +120,15 @@ function createTrackedLifecycle(): SignalIngressLifecycle & {
     },
     onDeferred: () => {},
     onAdoptionFinalizing: () => {},
+    onFailed: () => {
+      failed += 1;
+    },
     onAbandoned: () => {
       abandoned += 1;
     },
     adoptedCount: () => adopted,
     abandonedCount: () => abandoned,
+    failedCount: () => failed,
   };
 }
 
@@ -133,6 +145,7 @@ describe("signal drain claim ownership", () => {
   beforeEach(() => {
     dispatchCapture.length = 0;
     dispatchBehavior.adoptDuringDispatch = true;
+    dispatchBehavior.failBeforeAdoption = undefined;
     dispatchInboundMessageMock.mockClear();
   });
 
@@ -178,6 +191,36 @@ describe("signal drain claim ownership", () => {
       },
       { timeout: 5_000 },
     );
+  });
+
+  it("fails every constituent claim when a merged dispatch rejects before adoption", async () => {
+    dispatchBehavior.failBeforeAdoption = new Error("merged dispatch failed");
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: { messages: { inbound: { debounceMs: 40 } } },
+      }),
+    );
+    const first = createTrackedLifecycle();
+    const second = createTrackedLifecycle();
+
+    const results = [
+      await handler(createDataEvent({ timestamp: 1700000003500, message: "part one" }), first),
+      await handler(createDataEvent({ timestamp: 1700000003600, message: "part two" }), second),
+    ];
+    expect(results).toEqual([{ kind: "deferred" }, { kind: "deferred" }]);
+
+    await vi.waitFor(
+      () => {
+        expect(dispatchInboundMessageMock).toHaveBeenCalledOnce();
+        expect(first.failedCount()).toBe(1);
+        expect(second.failedCount()).toBe(1);
+      },
+      { timeout: 5_000 },
+    );
+    expect(first.adoptedCount()).toBe(0);
+    expect(second.adoptedCount()).toBe(0);
+    expect(first.abandonedCount()).toBe(0);
+    expect(second.abandonedCount()).toBe(0);
   });
 
   it("settles the claim for a turn that finishes without adoption", async () => {

--- a/extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts
+++ b/extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts
@@ -21,7 +21,12 @@ import { runTelegramChannelInboundEventWithHarness } from "./bot.test-helpers.js
 import type { TelegramTransport } from "./fetch.js";
 import type { TelegramRuntime } from "./runtime.types.js";
 
-const downstreamTurns = vi.hoisted(() => vi.fn());
+const downstreamTurns = vi.hoisted(() =>
+  vi.fn(async (_ctx: MsgContext) => ({
+    queuedFinal: false,
+    counts: { block: 0, final: 0, tool: 0 },
+  })),
+);
 
 vi.mock("./fetch.js", () => ({
   resolveTelegramApiBase: (apiRoot?: string) => apiRoot ?? "https://api.telegram.org",
@@ -39,8 +44,7 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
     ...actual,
     runChannelInboundEvent: async (params: Parameters<typeof actual.runChannelInboundEvent>[0]) =>
       await runTelegramChannelInboundEventWithHarness(actual, params, async (dispatchParams) => {
-        downstreamTurns(dispatchParams.ctx);
-        return { queuedFinal: false, counts: { block: 0, final: 0, tool: 0 } };
+        return await downstreamTurns(dispatchParams.ctx);
       }),
   };
 });
@@ -255,7 +259,9 @@ describe("Telegram durable ingress coalescing", () => {
     process.env.OPENCLAW_STATE_DIR = stateDir;
     spoolDir = path.join(stateDir, "telegram", "ingress-spool-default");
     activeResources = [];
-    downstreamTurns.mockClear();
+    downstreamTurns
+      .mockReset()
+      .mockResolvedValue({ queuedFinal: false, counts: { block: 0, final: 0, tool: 0 } });
     resetInboundDedupe();
     resetPluginStateStoreForTests({ closeDatabase: false });
     resetTelegramAccountThrottlersForTest();
@@ -527,6 +533,42 @@ describe("Telegram durable ingress coalescing", () => {
     expect(turn.Body).toContain("First note");
     expect(turn.Body).toContain("Second note");
     await assertSpoolTombstoned({ spoolDir, updateIds: [401, 402] });
+
+    await monitor.stop();
+    await telegramTransport.close();
+  });
+
+  it("releases a stale forwarded claim once when custom debounce dispatch fails", async () => {
+    const update = forwardedTextUpdate({
+      updateId: 701,
+      messageId: 1,
+      text: "recovered forward",
+    });
+    const eventId = telegramQueueEventId(update.update_id);
+    const sessionError = new Error("Session changed while starting work. Retry.");
+    await writeTelegramSpooledUpdate({ spoolDir, update });
+    const queue = openTelegramIngressQueue(spoolDir);
+    expect(await queue.claim(eventId, { ownerId: "999:1:dead-owner" })).not.toBeNull();
+    downstreamTurns.mockRejectedValueOnce(sessionError);
+    const runtimeError = vi.fn();
+    const { monitor, telegramTransport } = await createMonitor({
+      adoptionStallTimeoutMs: 5_000,
+      onRuntimeError: runtimeError,
+    });
+
+    monitor.start();
+    await vi.waitFor(
+      async () => {
+        expect(await queue.listClaims()).toEqual([]);
+        expect(await queue.listFailed?.({ limit: "all" })).toEqual([]);
+        expect(await queue.listPending({ limit: "all" })).toMatchObject([
+          { id: eventId, attempts: 2, lastError: sessionError.message },
+        ]);
+      },
+      { timeout: 2_000, interval: 5 },
+    );
+    expect(downstreamTurns).toHaveBeenCalledOnce();
+    expect(runtimeError).toHaveBeenCalledOnce();
 
     await monitor.stop();
     await telegramTransport.close();

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -108,7 +108,11 @@ function createInboundDebounceFlush(params: {
     onAdoptionFinalizing: () => source?.onAdoptionFinalizing?.(),
     onFailed: source?.onFailed
       ? async (error) => {
-          await source.onFailed?.(error);
+          try {
+            await source.onFailed?.(error);
+          } finally {
+            markAdmitted();
+          }
         }
       : undefined,
     onAbandoned: async () => {
@@ -121,9 +125,15 @@ function createInboundDebounceFlush(params: {
   } catch (error) {
     completion = Promise.reject(toErrorObject(error, "Inbound debounce dispatch failed"));
   }
-  // A skipped or failed dispatch may never call a lifecycle hook; its terminal
-  // completion must still release the keyed chain.
-  void completion.then(markAdmitted, markAdmitted);
+  // A failed dispatch must settle its source claim before releasing the keyed
+  // lane; an already-admitted turn owns its later completion failure.
+  void completion
+    .then(markAdmitted, async (error: unknown) => {
+      if (!admitted) {
+        await lifecycle.onFailed?.(error);
+      }
+    })
+    .then(markAdmitted, markAdmitted);
   return { admission, completion };
 }
 
@@ -187,7 +197,7 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     activeCompletions.add(completion);
     const cleanup = () => activeCompletions.delete(completion);
     void completion.then(cleanup, cleanup);
-    await Promise.race([admission, completion]);
+    await admission;
   };
 
   const cancelItems = (items: T[]) => {

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -127,13 +127,13 @@ function createInboundDebounceFlush(params: {
   }
   // A failed dispatch must settle its source claim before releasing the keyed
   // lane; an already-admitted turn owns its later completion failure.
-  void completion
-    .then(markAdmitted, async (error: unknown) => {
-      if (!admitted) {
-        await lifecycle.onFailed?.(error);
-      }
-    })
-    .then(markAdmitted, markAdmitted);
+  completion = completion.then(markAdmitted).catch(async (error: unknown) => {
+    if (!admitted && lifecycle.onFailed) {
+      await Promise.allSettled([lifecycle.onFailed(error)]);
+    }
+    markAdmitted();
+    throw error;
+  });
   return { admission, completion };
 }
 
@@ -197,7 +197,7 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     activeCompletions.add(completion);
     const cleanup = () => activeCompletions.delete(completion);
     void completion.then(cleanup, cleanup);
-    await admission;
+    await Promise.race([admission, completion]);
   };
 
   const cancelItems = (items: T[]) => {

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -1008,6 +1008,45 @@ describe("createInboundDebouncer", () => {
     expect(calls).toEqual(["1", "2"]);
   });
 
+  it("releases serialized keys when custom completion rejects before admission", async () => {
+    const failure = new Error("custom flush failed");
+    const calls: string[] = [];
+    const reported: unknown[] = [];
+    const pendingAdmission = new Promise<void>(() => {});
+    const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+      debounceMs: 0,
+      serializeImmediate: true,
+      buildKey: (item) => item.key,
+      onFlush: (items) => {
+        const id = items[0]?.id ?? "";
+        calls.push(id);
+        if (id === "first") {
+          return { admission: pendingAdmission, completion: Promise.reject(failure) };
+        }
+        return flushOnCompletion(() => {});
+      },
+      onError: (error) => {
+        reported.push(error);
+        throw new Error("observer failed");
+      },
+    });
+
+    const first = debouncer.enqueue({ key: "a", id: "first" });
+    await vi.waitFor(() => expect(calls).toEqual(["first"]));
+    const second = debouncer.enqueue({ key: "a", id: "second" });
+    const secondOutcome = await Promise.race([
+      second.then(() => "completed" as const),
+      new Promise<"stalled">((resolve) => {
+        setTimeout(() => resolve("stalled"), 100);
+      }),
+    ]);
+
+    expect(secondOutcome).toBe("completed");
+    await Promise.all([first, second, debouncer.drain()]);
+    expect(calls).toEqual(["first", "second"]);
+    expect(reported).toEqual([failure]);
+  });
+
   it("does not leak unhandled rejections when a keyed flush failure is awaited", async () => {
     const debouncer = createInboundDebouncer<{ key: string; id: string }>({
       debounceMs: 0,

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -908,6 +908,43 @@ describe("createInboundDebouncer", () => {
     expect(completed).toEqual(["2", "1"]);
   });
 
+  it("hands pre-admission completion failures to the source lifecycle once", async () => {
+    const sessionError = new Error("Session changed while starting work. Retry.");
+    const onFailed = vi.fn(async () => {});
+    const onError = vi.fn();
+    let attempt = 0;
+    const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+      debounceMs: 0,
+      buildKey: (item) => item.key,
+      onFlush: (_items, createFlush) =>
+        createFlush({
+          lifecycle: { onFailed },
+          dispatch: async (lifecycle) => {
+            attempt += 1;
+            if (attempt === 1) {
+              throw sessionError;
+            }
+            await lifecycle.onAdopted();
+            throw new Error("post-adoption failure");
+          },
+        }),
+      onError,
+    });
+
+    await expect(debouncer.enqueue({ key: "a", id: "failed-before-admission" })).resolves.toBe(
+      undefined,
+    );
+    await expect(debouncer.enqueue({ key: "a", id: "failed-after-admission" })).resolves.toBe(
+      undefined,
+    );
+    await debouncer.drain();
+
+    expect(onFailed).toHaveBeenCalledOnce();
+    expect(onFailed).toHaveBeenCalledWith(sessionError);
+    expect(onError).toHaveBeenCalledTimes(2);
+    expect(onError.mock.calls[0]?.[0]).toBe(sessionError);
+  });
+
   it("drains same-key flushes queued before their completion is tracked", async () => {
     const started: string[] = [];
     let releaseFirst!: () => void;

--- a/src/channels/message/ingress-drain.debounce-failure.test.ts
+++ b/src/channels/message/ingress-drain.debounce-failure.test.ts
@@ -84,4 +84,62 @@ describe("channel ingress drain debounce failures", () => {
       drain.dispose();
     });
   });
+
+  it("keeps watchdog recovery after retry settlement fails", async () => {
+    vi.useFakeTimers();
+    await withTempState(async (stateDir) => {
+      let clock = 10_000;
+      const queue = createTestIngressQueue(stateDir, { now: () => clock });
+      await queue.enqueue(
+        "debounced-settlement-failure",
+        { text: "retry me" },
+        { laneKey: "shared", receivedAt: clock },
+      );
+      queue.release = async () => {
+        throw new Error("persistent release failure");
+      };
+
+      const sessionError = new Error("Session changed while starting work. Retry.");
+      const debouncer = createInboundDebouncer<{ lifecycle: ChannelIngressDispatchLifecycle }>({
+        debounceMs: 0,
+        buildKey: () => "shared",
+        onFlush: (entries, createFlush) =>
+          createFlush({
+            lifecycle: entries[0]?.lifecycle,
+            dispatch: async () => {
+              throw sessionError;
+            },
+          }),
+        onError: () => undefined,
+      });
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        now: () => clock,
+        adoptionStallTimeoutMs: 200_000,
+        dispatchClaimedEvent: async (_event, lifecycle) => {
+          await debouncer.enqueue({ lifecycle });
+          return { kind: "deferred" };
+        },
+      });
+
+      expect(await drain.drainOnce()).toEqual({ started: 1 });
+      await vi.advanceTimersByTimeAsync(127_000);
+      clock += 127_000;
+      await drain.waitForIdle();
+
+      expect((await queue.listClaims()).map((claim) => claim.id)).toEqual([
+        "debounced-settlement-failure",
+      ]);
+      expect(drain.activeLaneKeys().has("shared")).toBe(true);
+
+      clock += 73_000;
+      await vi.advanceTimersByTimeAsync(73_000);
+      expect(await queue.listClaims()).toEqual([]);
+      expect(await queue.listFailed?.({ limit: "all" })).toMatchObject([
+        { id: "debounced-settlement-failure", reason: "handler-timeout" },
+      ]);
+      expect(drain.activeLaneKeys().has("shared")).toBe(false);
+      drain.dispose();
+    });
+  });
 });

--- a/src/channels/message/ingress-drain.debounce-failure.test.ts
+++ b/src/channels/message/ingress-drain.debounce-failure.test.ts
@@ -1,0 +1,87 @@
+// Shared debounce-to-drain composition regression for pre-admission failures.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createInboundDebouncer } from "../../auto-reply/inbound-debounce.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { createChannelIngressDrain, DEFAULT_INGRESS_ADOPTION_STALL_MS } from "./ingress-drain.js";
+import {
+  createTestIngressQueue,
+  type IngressDrainTestPayload as Payload,
+  withTempState,
+} from "./ingress-drain.test-helpers.js";
+
+type ChannelIngressDispatchLifecycle = Parameters<
+  Parameters<typeof createChannelIngressDrain>[0]["dispatchClaimedEvent"]
+>[1];
+
+describe("channel ingress drain debounce failures", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    closeOpenClawStateDatabaseForTest();
+  });
+
+  it("retries a pre-admission failure without waiting for the watchdog", async () => {
+    await withTempState(async (stateDir) => {
+      let clock = 10_000;
+      const queue = createTestIngressQueue(stateDir, { now: () => clock });
+      await queue.enqueue(
+        "debounced-retry",
+        { text: "retry me" },
+        {
+          laneKey: "shared",
+          receivedAt: clock,
+        },
+      );
+      const sessionError = new Error("Session changed while starting work. Retry.");
+      const reportedErrors: unknown[] = [];
+      let attempt = 0;
+      const debouncer = createInboundDebouncer<{ lifecycle: ChannelIngressDispatchLifecycle }>({
+        debounceMs: 0,
+        buildKey: () => "shared",
+        onFlush: (entries, createFlush) =>
+          createFlush({
+            lifecycle: entries[0]?.lifecycle,
+            dispatch: async (lifecycle) => {
+              attempt += 1;
+              if (attempt === 1) {
+                throw sessionError;
+              }
+              await lifecycle.onAdopted();
+            },
+          }),
+        onError: (error) => reportedErrors.push(error),
+      });
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        now: () => clock,
+        adoptionStallTimeoutMs: DEFAULT_INGRESS_ADOPTION_STALL_MS,
+        retryPolicy: { baseMs: 1_000, maxMs: 1_000 },
+        dispatchClaimedEvent: async (_event, lifecycle) => {
+          await debouncer.enqueue({ lifecycle });
+          return { kind: "deferred" };
+        },
+      });
+
+      expect(await drain.drainOnce()).toEqual({ started: 1 });
+      await drain.waitForIdle();
+      expect(await queue.listPending({ limit: "all" })).toMatchObject([
+        { id: "debounced-retry", attempts: 1, lastError: sessionError.message },
+      ]);
+      expect(await queue.listFailed?.({ limit: "all" })).toEqual([]);
+
+      clock += 1_000;
+      expect(await drain.drainOnce()).toEqual({ started: 1 });
+      await drain.waitForIdle();
+      await debouncer.drain();
+
+      expect(attempt).toBe(2);
+      expect(reportedErrors).toEqual([sessionError]);
+      expect(await queue.listPending({ limit: "all" })).toEqual([]);
+      expect(await queue.listClaims()).toEqual([]);
+      expect(await queue.listFailed?.({ limit: "all" })).toEqual([]);
+      expect(await queue.enqueue("debounced-retry", { text: "retry me" })).toMatchObject({
+        kind: "completed",
+      });
+      drain.dispose();
+    });
+  });
+});

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -523,7 +523,7 @@ export function createChannelIngressDrain<
         if (state.guillotined || state.superseded) {
           return;
         }
-        clearStallTimer(state);
+        // Keep recovery armed until disposition commits; removeActive clears it after success.
         await state.settleOnce(async () => {
           await applyFailureDisposition(state.claim, error);
         });


### PR DESCRIPTION
Closes #121269

## What Problem This Solves

Fixes an issue where durably queued inbound messages could remain claimed for five minutes and then dead-letter when debounced dispatch failed before reply-lane adoption, instead of following the normal retry policy.

## Why This Change Was Made

The shared inbound debounce completion boundary now forwards pre-admission rejection into the existing durable failure lifecycle before releasing the keyed lane. Admission still races completion so custom flushes make progress, while fan-in and core ingress drain retain ownership of claim settlement, retry timing, and tombstoning.

## User Impact

Durably queued inbound messages now recover through the normal retry path immediately after a pre-admission debounce failure. Successful admission, same-key ordering, shutdown drain, observer isolation, and Telegram's independent custom debounce settlement remain unchanged.

## Evidence

- Rebased once without conflicts onto `d8ae7278b9b747d222a610e42cce8f43f75dfa14`; verified head is `833f578d4f101931223cf434b2966e6d2e494663`.
- 118 focused owner and sibling tests passed.
- Telegram full-composition E2E: 8/8 passed.
- Independent verifier: PASS.
- Adversarial falsifier: PASS with four refuted challenges and zero findings.
- Regression coverage includes original-error identity, exact-once fan-in failure, canonical pending retry and later tombstone, post-adoption behavior, custom completion progress, throwing-observer isolation, Signal merged failures, and the Telegram negative control.
- Production LOC: +14/-4 (net +10). Tests: +253/-5.
