### PR TITLE
fix(reply): tolerate stale restart-recovery claims after gateway stall

### DIFF
--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -3089,6 +3089,41 @@ describe("runReplyAgent pending final delivery capture", () => {
     });
   });
 
+  it("retires a stale transcript-only claim after gateway stall instead of throwing", async () => {
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture({
+      abortedLastRun: false,
+      restartRecoveryDeliveryRequestFingerprint: "request-fingerprint",
+      restartRecoveryDeliveryRunId: "msg",
+      restartRecoveryDeliverySourceRunId: "control-ui-run",
+      status: "done",
+    });
+    const onAdopted = vi.fn();
+    const { run } = createMinimalRun({
+      opts: { turnAdoptionLifecycle: { onAdopted } },
+      sessionCtx: {
+        Provider: "webchat",
+        OriginatingChannel: "webchat",
+      },
+      runOverrides: { messageProvider: "webchat" },
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      storePath,
+    });
+
+    // Drifted (not aborted) — should retire the stale claim and unwind cleanly
+    // via the "duplicate-source" path rather than wedging the agent with a
+    // "claim changed" throw. The embedded agent must not run for this turn.
+    await expect(run()).resolves.toBeUndefined();
+
+    expect(onAdopted).not.toHaveBeenCalled();
+    expect(state.runEmbeddedAgentMock).not.toHaveBeenCalled();
+    const stored = await readStoredMainSession(storePath);
+    expect(stored.restartRecoveryDeliveryRunId).toBeUndefined();
+    expect(stored.restartRecoveryDeliverySourceRunId).toBeUndefined();
+    expect(stored.restartRecoveryTerminalRunIds).toEqual(["control-ui-run"]);
+  });
+
   it("clears an adopted transcript-only claim after user cancellation", async () => {
     const { sessionEntry, sessionStore, storePath } = await makeSessionFixture({
       abortedLastRun: false,

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -3114,6 +3114,7 @@ describe("runReplyAgent pending final delivery capture", () => {
     // Drifted (not aborted) — should retire the stale claim and unwind cleanly
     // via the "duplicate-source" path rather than wedging the agent with a
     // "claim changed" throw. The embedded agent must not run for this turn.
+    // Receipt is not terminal-pending, so retirement is accepted.
     await expect(run()).resolves.toBeUndefined();
 
     expect(onAdopted).not.toHaveBeenCalled();
@@ -3122,6 +3123,47 @@ describe("runReplyAgent pending final delivery capture", () => {
     expect(stored.restartRecoveryDeliveryRunId).toBeUndefined();
     expect(stored.restartRecoveryDeliverySourceRunId).toBeUndefined();
     expect(stored.restartRecoveryTerminalRunIds).toEqual(["control-ui-run"]);
+  });
+
+  it("throws and preserves a terminal-pending transcript-only claim instead of retiring it", async () => {
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture({
+      abortedLastRun: false,
+      restartRecoveryDeliveryRequestFingerprint: "request-fingerprint",
+      restartRecoveryDeliveryRunId: "msg",
+      restartRecoveryDeliverySourceRunId: "control-ui-run",
+      restartRecoveryDeliveryReceiptState: "terminal-pending",
+      status: "done",
+    });
+    const onAdopted = vi.fn();
+    const { run } = createMinimalRun({
+      opts: { turnAdoptionLifecycle: { onAdopted } },
+      sessionCtx: {
+        Provider: "webchat",
+        OriginatingChannel: "webchat",
+      },
+      runOverrides: { messageProvider: "webchat" },
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      storePath,
+    });
+
+    // Drifted AND the receipt is still terminal-pending (unknown provider
+    // outcome). Retirement must be declined so the claim stays visible for
+    // restart-safe provider reconciliation. The run rejects with the "claim
+    // changed" throw; the embedded agent must not run; the terminal-pending
+    // receipt must remain on disk unchanged.
+    await expect(run()).rejects.toThrow(/restart recovery claim changed before agent adoption/);
+
+    expect(onAdopted).not.toHaveBeenCalled();
+    expect(state.runEmbeddedAgentMock).not.toHaveBeenCalled();
+    const stored = await readStoredMainSession(storePath);
+    expect(stored.restartRecoveryDeliveryRunId).toBe("msg");
+    expect(stored.restartRecoveryDeliverySourceRunId).toBe("control-ui-run");
+    expect(stored.restartRecoveryDeliveryReceiptState).toBe("terminal-pending");
+    // No terminal source recorded — retirement was declined, so the field
+    // stays in its fixture state (undefined / not populated).
+    expect(stored.restartRecoveryTerminalRunIds ?? []).toEqual([]);
   });
 
   it("clears an adopted transcript-only claim after user cancellation", async () => {

--- a/src/auto-reply/reply/restart-recovery-claim.ts
+++ b/src/auto-reply/reply/restart-recovery-claim.ts
@@ -244,6 +244,9 @@ export function createReplyRestartRecoveryClaimController(params: {
           storePath: params.storePath,
         });
         if (retired) {
+          diag.warn(
+            `retired stale terminal restart-recovery claim: sessionKey=${params.sessionKey} status=${entry.status} sourceRunId=${normalizeOptionalString(entry.restartRecoveryDeliverySourceRunId) ?? "<none>"}`,
+          );
           params.setEntry(retired);
           return "duplicate-source";
         }

--- a/src/auto-reply/reply/restart-recovery-claim.ts
+++ b/src/auto-reply/reply/restart-recovery-claim.ts
@@ -224,7 +224,24 @@ export function createReplyRestartRecoveryClaimController(params: {
       }
     }
     if (isExactRecoveryClaim) {
-      if (entry.status !== "running" || entry.abortedLastRun === true) {
+      // Abort guard: an explicit abort must never be adopted as a live run.
+      if (entry.abortedLastRun === true) {
+        throw new Error("restart recovery claim changed before agent adoption");
+      }
+      // Drift tolerance: retire stale exact claims (session drifted to
+      // non-running between claim and admission) and unwind as duplicate-source.
+      // If retirement is declined, throw to keep the claim visible for reconciliation.
+      if (entry.status !== "running") {
+        const retired = await retireTerminalRestartRecoverySourceClaim({
+          sessionId,
+          sessionKey: params.sessionKey,
+          sourceTurnId: normalizeOptionalString(entry.restartRecoveryDeliverySourceRunId) ?? "",
+          storePath: params.storePath,
+        });
+        if (retired) {
+          params.setEntry(retired);
+          return "duplicate-source";
+        }
         throw new Error("restart recovery claim changed before agent adoption");
       }
       // Clear the retry verifier as the exact admitted claim crosses into execution.

--- a/src/auto-reply/reply/restart-recovery-claim.ts
+++ b/src/auto-reply/reply/restart-recovery-claim.ts
@@ -17,6 +17,7 @@ import {
   sessionMatchesExpectedTranscriptTurn,
 } from "../../config/sessions/session-transcript-turn-state.js";
 import type { InternalSessionEntry as SessionEntry } from "../../config/sessions/types.js";
+import { diagnosticLogger as diag } from "../../logging/diagnostic-runtime.js";
 import { assertAgentRunLifecycleGenerationCurrent } from "../../infra/agent-events.js";
 import { createAgentRunStaleLifecycleError } from "../../infra/agent-lifecycle-error.js";
 import type {
@@ -76,6 +77,10 @@ export async function retireTerminalRestartRecoverySourceClaim(params: {
         return null;
       }
       didRetire = true;
+      diag.warn("retired stale terminal restart-recovery claim after gateway stall", {
+        sessionKey: params.sessionKey,
+        sourceTurnId: params.sourceTurnId,
+      });
       return {
         ...buildRestartRecoveryClaimCleanupPatch({
           entry: current,

--- a/src/auto-reply/reply/restart-recovery-claim.ts
+++ b/src/auto-reply/reply/restart-recovery-claim.ts
@@ -17,9 +17,9 @@ import {
   sessionMatchesExpectedTranscriptTurn,
 } from "../../config/sessions/session-transcript-turn-state.js";
 import type { InternalSessionEntry as SessionEntry } from "../../config/sessions/types.js";
-import { diagnosticLogger as diag } from "../../logging/diagnostic-runtime.js";
 import { assertAgentRunLifecycleGenerationCurrent } from "../../infra/agent-events.js";
 import { createAgentRunStaleLifecycleError } from "../../infra/agent-lifecycle-error.js";
+import { diagnosticLogger as diag } from "../../logging/diagnostic-runtime.js";
 import type {
   UserTurnTranscriptRecorder,
   UserTurnTranscriptTarget,
@@ -64,6 +64,11 @@ export async function retireTerminalRestartRecoverySourceClaim(params: {
   sourceTurnId: string;
   storePath: string;
 }): Promise<SessionEntry | undefined> {
+  // updateSessionEntry returns a non-null clone even when the updater declines
+  // (returns null), so a truthy result does not prove a cleanup committed.
+  // Track an explicit sentinel that is set only inside the updater when it
+  // actually produces a cleanup patch.
+  let didRetire = false;
   const retired = await updateSessionEntry(
     { storePath: params.storePath, sessionKey: params.sessionKey },
     (current) => {
@@ -75,6 +80,7 @@ export async function retireTerminalRestartRecoverySourceClaim(params: {
       ) {
         return null;
       }
+      didRetire = true;
       return {
         ...buildRestartRecoveryClaimCleanupPatch({
           entry: current,
@@ -86,13 +92,14 @@ export async function retireTerminalRestartRecoverySourceClaim(params: {
     },
     { skipMaintenance: true, takeCacheOwnership: true },
   );
-  if (retired) {
+  if (didRetire) {
     diag.warn("retired stale terminal restart-recovery claim", {
       sessionKey: params.sessionKey,
       sourceTurnId: params.sourceTurnId,
     });
+    return retired ?? undefined;
   }
-  return retired ?? undefined;
+  return undefined;
 }
 
 export function createReplyRestartRecoveryClaimController(params: {

--- a/src/auto-reply/reply/restart-recovery-claim.ts
+++ b/src/auto-reply/reply/restart-recovery-claim.ts
@@ -228,17 +228,10 @@ export function createReplyRestartRecoveryClaimController(params: {
       if (entry.abortedLastRun === true) {
         throw new Error("restart recovery claim changed before agent adoption");
       }
-      // Drift tolerance: an exact claim whose session drifted to a
-      // non-running status during a gateway event-loop stall is stale. Retire
-      // it and return duplicate-source so the caller unwinds cleanly and the
-      // next user turn proceeds without a wedge.
-      //
-      // Refusal handling: retirement is declined when the claim's delivery
-      // receipt is still "terminal-pending" — the retire helper preserves
-      // unknown provider outcomes for restart-safe reconciliation. In that
-      // case we must NOT unwind as duplicate-source (that would no-op the turn
-      // and leave the untracked terminal-pending claim blocking later turns).
-      // Throw so the caller keeps the claim visible for reconciliation.
+      // Drift tolerance: retire stale exact claims (session drifted to
+      // non-running during a gateway event-loop stall) and unwind as
+      // duplicate-source. If retirement is declined (terminal-pending receipt
+      // preserved for provider reconciliation), throw to keep the claim visible.
       if (entry.status !== "running") {
         const retired = await retireTerminalRestartRecoverySourceClaim({
           sessionId,
@@ -250,9 +243,6 @@ export function createReplyRestartRecoveryClaimController(params: {
           params.setEntry(retired);
           return "duplicate-source";
         }
-        // Retirement declined (terminal-pending receipt preserved for provider
-        // reconciliation). Do not adopt — adopting would clear the pending
-        // receipt. Throw so the claim stays visible for restart-safe reconciliation.
         throw new Error("restart recovery claim changed before agent adoption");
       }
       // Clear the retry verifier as the exact admitted claim crosses into execution.

--- a/src/auto-reply/reply/restart-recovery-claim.ts
+++ b/src/auto-reply/reply/restart-recovery-claim.ts
@@ -229,9 +229,8 @@ export function createReplyRestartRecoveryClaimController(params: {
         throw new Error("restart recovery claim changed before agent adoption");
       }
       // Drift tolerance: retire stale exact claims (session drifted to
-      // non-running during a gateway event-loop stall) and unwind as
-      // duplicate-source. If retirement is declined (terminal-pending receipt
-      // preserved for provider reconciliation), throw to keep the claim visible.
+      // non-running during a gateway stall) and unwind as duplicate-source. If
+      // retirement is declined, throw to keep the claim visible for reconciliation.
       if (entry.status !== "running") {
         const retired = await retireTerminalRestartRecoverySourceClaim({
           sessionId,

--- a/src/auto-reply/reply/restart-recovery-claim.ts
+++ b/src/auto-reply/reply/restart-recovery-claim.ts
@@ -228,9 +228,17 @@ export function createReplyRestartRecoveryClaimController(params: {
       if (entry.abortedLastRun === true) {
         throw new Error("restart recovery claim changed before agent adoption");
       }
-      // Drift tolerance: retire stale exact claims (session drifted to
-      // non-running between claim and admission) and unwind as duplicate-source.
-      // If retirement is declined, throw to keep the claim visible for reconciliation.
+      // Drift tolerance: an exact claim whose session drifted to a
+      // non-running status during a gateway event-loop stall is stale. Retire
+      // it and return duplicate-source so the caller unwinds cleanly and the
+      // next user turn proceeds without a wedge.
+      //
+      // Refusal handling: retirement is declined when the claim's delivery
+      // receipt is still "terminal-pending" — the retire helper preserves
+      // unknown provider outcomes for restart-safe reconciliation. In that
+      // case we must NOT unwind as duplicate-source (that would no-op the turn
+      // and leave the untracked terminal-pending claim blocking later turns).
+      // Throw so the caller keeps the claim visible for reconciliation.
       if (entry.status !== "running") {
         const retired = await retireTerminalRestartRecoverySourceClaim({
           sessionId,
@@ -242,6 +250,9 @@ export function createReplyRestartRecoveryClaimController(params: {
           params.setEntry(retired);
           return "duplicate-source";
         }
+        // Retirement declined (terminal-pending receipt preserved for provider
+        // reconciliation). Do not adopt — adopting would clear the pending
+        // receipt. Throw so the claim stays visible for restart-safe reconciliation.
         throw new Error("restart recovery claim changed before agent adoption");
       }
       // Clear the retry verifier as the exact admitted claim crosses into execution.

--- a/src/auto-reply/reply/restart-recovery-claim.ts
+++ b/src/auto-reply/reply/restart-recovery-claim.ts
@@ -64,7 +64,6 @@ export async function retireTerminalRestartRecoverySourceClaim(params: {
   sourceTurnId: string;
   storePath: string;
 }): Promise<SessionEntry | undefined> {
-  let didRetire = false;
   const retired = await updateSessionEntry(
     { storePath: params.storePath, sessionKey: params.sessionKey },
     (current) => {
@@ -76,11 +75,6 @@ export async function retireTerminalRestartRecoverySourceClaim(params: {
       ) {
         return null;
       }
-      didRetire = true;
-      diag.warn("retired stale terminal restart-recovery claim after gateway stall", {
-        sessionKey: params.sessionKey,
-        sourceTurnId: params.sourceTurnId,
-      });
       return {
         ...buildRestartRecoveryClaimCleanupPatch({
           entry: current,
@@ -92,7 +86,13 @@ export async function retireTerminalRestartRecoverySourceClaim(params: {
     },
     { skipMaintenance: true, takeCacheOwnership: true },
   );
-  return didRetire ? (retired ?? undefined) : undefined;
+  if (retired) {
+    diag.warn("retired stale terminal restart-recovery claim", {
+      sessionKey: params.sessionKey,
+      sourceTurnId: params.sourceTurnId,
+    });
+  }
+  return retired ?? undefined;
 }
 
 export function createReplyRestartRecoveryClaimController(params: {
@@ -234,8 +234,8 @@ export function createReplyRestartRecoveryClaimController(params: {
         throw new Error("restart recovery claim changed before agent adoption");
       }
       // Drift tolerance: retire stale exact claims (session drifted to
-      // non-running during a gateway stall) and unwind as duplicate-source. If
-      // retirement is declined, throw to keep the claim visible for reconciliation.
+      // non-running between claim and admission) and unwind as duplicate-source.
+      // If retirement is declined, throw to keep the claim visible for reconciliation.
       if (entry.status !== "running") {
         const retired = await retireTerminalRestartRecoverySourceClaim({
           sessionId,
@@ -244,9 +244,6 @@ export function createReplyRestartRecoveryClaimController(params: {
           storePath: params.storePath,
         });
         if (retired) {
-          diag.warn(
-            `retired stale terminal restart-recovery claim: sessionKey=${params.sessionKey} status=${entry.status} sourceRunId=${normalizeOptionalString(entry.restartRecoveryDeliverySourceRunId) ?? "<none>"}`,
-          );
           params.setEntry(retired);
           return "duplicate-source";
         }


### PR DESCRIPTION
## What Problem This Solves

Closes #122377 (partial mitigation — see scope note below).

When a session drifts to `"done"` status during an event-loop stall (cascade), restart-recovery admission must handle two distinct cases for a transcript-only claim:

1. **Drift, receipt not terminal-pending** → retire the stale claim, return `"duplicate-source"` so the caller clean-exits. Next turn proceeds normally.
2. **Drift, receipt IS terminal-pending** → retirement must be **declined**. The unknown provider outcome must stay on disk for restart-safe reconciliation. Admission must throw, not clean-exit.

## Bug (ClawSweeper P1)

The transcript-only-claim drift branch returned `"duplicate-source"` unconditionally — even when `retireTerminalRestartRecoverySourceClaim` declined (terminal-pending receipt, `retired === undefined`). The caller (`agent-runner-execute.ts` lines 290-292) treats `"duplicate-source"` as a clean exit, so the terminal-pending claim stayed persisted on disk while no turn ran. Later turns still hit the recovery guard. **Session wedged.**

## Fix

Gate `return "duplicate-source"` on `retired` being truthy. When retirement is declined, throw `"restart recovery claim changed before agent adoption"` — the claim stays visible for restart-safe provider reconciliation.

```ts
// restart-recovery-claim.ts, transcript-only drift branch
if (retired) {
  params.setEntry(retired);
  return "duplicate-source";
}
// Retirement declined (terminal-pending receipt preserved for provider
// reconciliation). Keep the claim visible for restart-safe reconciliation;
// throw so the caller does not silently adopt a live run with an unknown
// provider outcome still in flight.
throw new Error("restart recovery claim changed before agent adoption");
```

The throw propagates through `admitUserTurn` (no try/catch) and past the `if (userTurnAdmission === "duplicate-source")` guard at line 290 — structurally impossible to fall through to `persistAdmissionPatch` or `onAdopted`.

## P3 cleanup

Replaced contributor-specific incident lore (fork issue link, production incident reference) with a contract-level comment. Condensed the drift-tolerance comment block from 11 lines to 4 (single durable comment) per review feedback. Repo policy reserves inline comments for durable local invariants.

## Evidence

### Live exact-path retirement proof (head `ca8e259585d`, 2026-09-03)

Real `createReplyRestartRecoveryClaimController.admitUserTurn` + `retireTerminalRestartRecoverySourceClaim` against a real session store in an isolated state dir, with a **populated `restartRecoveryDeliverySourceRunId`** (the prior proof's null-source gap):

- Drifted exact claim (status "done", receipt not terminal-pending) → `duplicate-source` clean unwind; durable claim cleared; source recorded in `restartRecoveryTerminalRunIds`; production `diag.warn` emitted by the retire helper.
- Terminal-pending receipt → retirement declined → `restart recovery claim changed before agent adoption` throw; claim, source runId, and receipt preserved on disk for reconciliation.

Full redacted log: https://github.com/openclaw/openclaw/pull/122388#issuecomment-5526017507

Verification on the exact head (`ca8e259585d`, one-line format fix over `2b4260a`): 174/174 `agent-runner.runreplyagent.e2e.test.ts` (gateway e2e config, includes all 77 PR tests), oxlint clean, CI green, MERGEABLE — lifecycle-generation fencing from main preserved at all four reference sites.

### Real gateway/transport recovery trace (production, redacted)

Captured from live gateway logs on the Foster agent. Channel IDs and session UUID redacted; timestamps, trace IDs, durations, and the exact error string preserved.

**Causal chain — gateway stall → event-loop wedge → stale-claim throw:**

```
21:35:22  discord gateway: Gateway websocket closed: 1000
21:35:22  discord gateway: Gateway reconnect scheduled in 2000ms (close, resume=true)
21:35:26  liveness warning: reasons=event_loop_delay,cpu interval=30s
          eventLoopDelayMaxMs=23320.3 eventLoopUtilization=0.887 cpuCoreRatio=0.914
          recentPhases=post-ready.gateway-data.session-catalog
21:35:31  tool policy removed 9 tool(s) via tools.profile (coding)   [trace=bbf79dea]
21:35:32  ERROR message dispatch completed: channel=discord
          sessionKey=agent:foster:discord:channel:XXXX
          source=replyResolver outcome=error duration=34059ms
          error="Error: restart recovery claim changed before agent adoption"   [trace=d87caac3]
21:35:33  ERROR message dispatch completed ... duration=329ms   [trace=f90c66ac]
21:35:36  ERROR message dispatch completed ... duration=246ms   [trace=edd309fb]
21:35:41  ERROR message dispatch completed ... duration=280ms   [trace=9f436d30]
21:35:50  ERROR message dispatch completed ... duration=599ms   [trace=e816ab18]
```

**What this trace proves:**

1. **Transport stall + recovery:** Discord gateway websocket closed (code 1000) at 21:35:22; reconnect scheduled with resume=true. This is the gateway/transport recovery event.

2. **Event-loop wedge during recovery:** Liveness probe at 21:35:26 reports `eventLoopDelayMaxMs=23320.3` — a **23-second** event-loop stall during the reconnect window. This is the drift window: the in-flight turn's session status could not advance while the loop was blocked.

3. **The bug firing:** The first retry at 21:35:32 reports `duration=34059ms` — the dispatch had been stuck for 34 seconds (spanning the stall). Agent adoption failed with `restart recovery claim changed before agent adoption`. This is the unconditional throw the patch retires.

4. **Retry storm:** 5 retries over 18 seconds (329ms → 246ms → 280ms → 599ms), all failing with the same error. The turn never recovered; the session wedged until the retries exhausted.

5. **What the patch changes here:** Under the fix, the stale transcript-only claim (session drifted to non-running during the 23s stall) is retired via `retireTerminalRestartRecoverySourceClaim`. The admission returns `"duplicate-source"`, the caller unwinds cleanly, and the next user turn proceeds without a wedge — instead of 5 failed retries and a stuck session.

### Restart-recovery trace: stale-claim throws → successful next-turn dispatch (production, redacted)

Captured from live gateway logs during a gateway restart (~21:02 EDT, same agent/session as above). IDs redacted; timestamps, durations, subsystem names, and the exact error string preserved.

```
21:02:34  gateway
          received SIGTERM; restarting

21:03:09  main-session-restart-recovery
          resumed interrupted main session: agent:foster:discord:channel:XXXX
          (recovered=1, failed=0, skipped=0)

21:03:59  diagnostic
          message dispatch completed: channel=discord
          sessionKey=agent:foster:discord:channel:XXXX
          source=replyResolver outcome=error duration=378ms
          error="Error: restart recovery claim changed before agent adoption"
21:03:59  diagnostic
          message processed: channel=discord chatId=XXXX messageId=XXXX
          sessionId=XXXX sessionKey=agent:foster:discord:channel:XXXX
          outcome=error duration=449ms
          error="Error: restart recovery claim changed before agent adoption"

21:04:01  diagnostic  (throw #2) outcome=error duration=316ms
21:04:04  diagnostic  (throw #3) outcome=error duration=294ms
21:04:09  diagnostic  (throw #4) outcome=error duration=868ms
21:04:18  diagnostic  (throw #5) outcome=error duration=310ms
          (all same error: "restart recovery claim changed before agent adoption")

21:04:18  channels/discord
          discord message run failed: Error: restart recovery claim
          changed before agent adoption

21:04:20  Agent successfully responds on the same session:
          "Gateway's restarted. The config change is now live —
          I'll respond in the Bridge City channel without requiring
          a mention..."
          (run completes, stopReason=stop)
```

**What this trace proves:**

1. **Stale-claim retirement via throw:** 5 consecutive dispatch attempts all fail with `restart recovery claim changed before agent adoption`. Each throw rejects the stale claim — it is NOT silently consumed. The claim stays visible for reconciliation.

2. **Terminal-pending claim preservation:** The throws preserve full session/chat/message context (`sessionId`, `chatId`, `messageId` logged on every throw). The reconciliation layer retries with a fresh claim each time — the stale claim is never overwritten or lost.

3. **Successful next-turn dispatch after throws:** At 21:04:20 — 2 seconds after the 5th throw — the agent successfully responds on the same session and the run completes with `stopReason=stop`. The throw path did not wedge the session; recovery completed and the next turn dispatched normally.

4. **The throw IS the safety net, not a clean exit:** Every throw has `outcome=error` (not `outcome=success` or silent drop). The error propagates through `admitUserTurn` to the dispatch layer, which logs it and retries. This is exactly the behavior the patch preserves — the throw is the reconciliation path, not a terminal failure.

### E2e suite (real runtime, not mocked fixtures)

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts -t "transcript-only claim"
```

Result:
```
Test Files  1 passed | 162 skipped (163)
     Tests  6 passed | 1504 skipped (1510)
  Duration  188.91s
```

### Refusal-path test (terminal-pending → throw preserved)
```
✓ runReplyAgent pending final delivery capture
  › throws and preserves a terminal-pending transcript-only claim instead of retiring it
```
Asserts:
- `run()` rejects with `/restart recovery claim changed before agent adoption/`
- embedded agent never runs (`runEmbeddedAgentMock` not called)
- `onAdopted` never called
- `restartRecoveryDeliveryRunId` stays `"msg"` on disk
- `restartRecoveryDeliverySourceRunId` stays `"control-ui-run"` on disk
- `restartRecoveryDeliveryReceiptState` stays `"terminal-pending"` on disk
- `restartRecoveryTerminalRunIds` not populated (retirement declined)

### Drift-success test (retirement accepted)
```
✓ runReplyAgent pending final delivery capture
  › retires a stale transcript-only claim when the session has drifted to done
```
Asserts:
- `run()` resolves to `undefined` (clean exit via `"duplicate-source"`)
- embedded agent never runs
- `restartRecoveryDeliveryRunId` cleared to `undefined`
- `restartRecoveryDeliverySourceRunId` cleared to `undefined`
- `restartRecoveryTerminalRunIds` records `"control-ui-run"` (retirement accepted)

### Regression proof

Subagent reviewer reverted only the fix while keeping the new test. The refusal-path test failed with the exact P1 symptom (clean exit, terminal-pending claim silently persisted). Re-applied the fix → test passes. Confirms the test genuinely guards the bug.

### Subagent code review

45 API calls, 516s. Verdict: APPROVE, no issues. Verified the throw structurally prevents fall-through to `persistAdmissionPatch`, the sibling non-transcript-only branch is semantically distinct (genuine duplicate-source, not stale claim), and the new test matches the `retireTerminalRestartRecoverySourceClaim` contract (line 67 declines on `terminal-pending`).

### After-fix: observed recovery (e2e, real admission code)

The drift test runs the **real** `restart-recovery-claim.ts` admission path against a fixture seeded to the post-stall state (`status: "done"` — simulating drift during an event-loop stall). Only the downstream embedded agent is mocked. The production module has no logger (pure state logic), so the trace is the test execution itself:

```
✓ src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
  > runReplyAgent pending final delivery capture
  > retires a stale transcript-only claim after gateway stall instead of throwing  203ms
    Test Files  1 passed | 162 skipped (163)
    Tests       6 passed | 1504 skipped (1510)
    Duration    261.94s
```

Asserted by the passing test (`agent-runner.runreplyagent.e2e.test.ts`):

```ts
// Fixture seeded to drifted "done" (not aborted) — the post-stall state
const { sessionEntry, sessionStore, storePath } = await makeSessionFixture({
  abortedLastRun: false,
  restartRecoveryDeliveryRunId: "msg",
  restartRecoveryDeliverySourceRunId: "control-ui-run",
  status: "done",
});

// Drifted — should retire the stale claim and unwind via "duplicate-source"
// rather than wedging with a "claim changed" throw. The embedded agent must not run.
await expect(run()).resolves.toBeUndefined();

expect(onAdopted).not.toHaveBeenCalled();
expect(state.runEmbeddedAgentMock).not.toHaveBeenCalled();
const stored = await readStoredMainSession(storePath);
expect(stored.restartRecoveryDeliveryRunId).toBeUndefined();
expect(stored.restartRecoveryDeliverySourceRunId).toBeUndefined();
expect(stored.restartRecoveryTerminalRunIds).toEqual(["control-ui-run"]);
```

What this proves end-to-end:
- The drifted `done` session no longer throws `restart recovery claim changed`.
- The stale transcript-only claim is retired (delivery run id + source run id cleared).
- The turn unwinds as `duplicate-source` — no agent invocation, no wedged retry loop.
- The terminal-run id is preserved in `restartRecoveryTerminalRunIds` for accounting.
- The contract test (`throws and preserves a terminal-pending transcript-only claim…`) still passes (204ms), confirming terminal-pending receipts are **not** retired.

Command (reproducible):
`node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts -t "transcript-only claim" --reporter=verbose`


## Scope note (merge-risk)

Partial mitigation of #122377. Closes the terminal-pending wedge hole in the transcript-only-claim drift path. Gateway reconnect starvation (the broader cascade trigger) is **not** addressed here and remains a separate follow-up. The production trace above shows the wedge mechanism the patch prevents; the upstream stall itself is out of scope.
