### PR TITLE
test(agents): restore fast ACP spawn suite isolation

### DIFF
--- a/src/agents/subagents/spawn/acp-spawn.test.ts
+++ b/src/agents/subagents/spawn/acp-spawn.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AcpInitializeSessionInput } from "../../../acp/control-plane/manager.types.js";
 import type { SessionEntry } from "../../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
@@ -16,7 +16,6 @@ import {
 } from "../../../infra/outbound/session-binding-service.js";
 import { normalizeSessionDeliveryState } from "../../../utils/delivery-context.shared.js";
 import { reserveChildAdmissionSlot } from "../../child-admission.js";
-import { resolveThinkingDefault } from "../../model-selection.js";
 
 type SessionBindingAdapterCapabilities = NonNullable<SessionBindingAdapter["capabilities"]>;
 
@@ -235,8 +234,7 @@ vi.mock("../registry/subagent-registry.js", () => ({
   registerSubagentRun: hoisted.registerSubagentRunMock,
 }));
 
-vi.mock("../registry/subagent-registry-read.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../registry/subagent-registry-read.js")>()),
+vi.mock("../registry/subagent-registry-read.js", () => ({
   getSubagentRunByChildSessionKey: hoisted.getSubagentRunByChildSessionKeyMock,
 }));
 
@@ -691,16 +689,6 @@ function enableTelegramCurrentConversationBindings(): void {
 }
 
 describe("spawnAcpDirect", () => {
-  beforeAll(() => {
-    resolveThinkingDefault({
-      cfg: {
-        agents: { defaults: { model: { primary: "anthropic/claude-sonnet-4-6" } } },
-      },
-      provider: "anthropic",
-      model: "claude-sonnet-4-6",
-    });
-  });
-
   beforeEach(() => {
     replaceSpawnConfig(createDefaultSpawnConfig());
     hoisted.areHeartbeatsEnabledMock.mockReset().mockReturnValue(true);
@@ -1150,6 +1138,7 @@ describe("spawnAcpDirect", () => {
           },
         ],
         defaults: {
+          thinkingDefault: "off",
           subagents: {
             allowAgents: ["codex"],
             maxSpawnDepth: 2,
@@ -1173,7 +1162,7 @@ describe("spawnAcpDirect", () => {
       agent: "codex",
       runtimeOptions: {
         model: "anthropic/claude-sonnet-4-6",
-        thinking: "adaptive",
+        thinking: "off",
       },
     });
   });


### PR DESCRIPTION
## What Problem This Solves

The 71-test ACP spawn suite regressed to roughly 50-70 seconds after a registry-read refactor reintroduced a partial-real mock and the suite retained an assertion-free provider-policy warmup. This slows the agents-support CI shard even though the test bodies themselves execute in under two seconds.

## Why This Change Was Made

The suite now mocks only the registry-read export consumed by ACP admission, matching its existing narrow dependency mocks. It also removes the assertion-free thinking-policy warmup and keeps the ACP primary-model composition check focused on an explicit configured thinking default; provider-specific adaptive-default behavior remains covered by the canonical model-selection and thinking-policy suites.

All 71 ACP spawn policy, binding, cleanup, admission, relay, and routing tests remain.

AI-assisted: yes. The patch and retained contracts were reviewed against the test-audit value bar. The structured autoreview helper completed its TruffleHog scan cleanly but could not launch a reviewer because no supported `codex`, `claude`, or `pi` executable is installed in the orb.

## User Impact

No runtime behavior changes. Developers and CI get materially faster ACP spawn coverage with lower test setup cost.

## Evidence

Linux Node 24.15.0, one Vitest worker, same focused command:

- Vitest duration: 70.06s → 9.67s (**86.2% faster**)
- Wall time: 77.00s → 16.63s (**78.4% faster**)
- Tests phase: 42.96s → 1.65s (**96.2% faster**)
- Import phase: 24.12s → 7.02s (**70.9% faster**)
- Test inventory: 71/71 passed before and after

Validation:

- `node scripts/run-vitest.mjs src/agents/subagents/spawn/acp-spawn.test.ts --reporter=verbose`
- `node scripts/run-vitest.mjs src/agents/subagents/registry/subagent-registry-read.scoped.test.ts --reporter=verbose` (4/4 passed)
- `oxfmt --check src/agents/subagents/spawn/acp-spawn.test.ts`
- `node scripts/run-oxlint.mjs src/agents/subagents/spawn/acp-spawn.test.ts`
- `git diff --check`
- changed-gate classification: `coreTests`
