### PR TITLE
fix(agents): never restore a retired worktree via a generated name

### DIFF
--- a/docs/concepts/managed-worktrees.md
+++ b/docs/concepts/managed-worktrees.md
@@ -17,7 +17,7 @@ Each worktree lives at:
 <openclaw-state-dir>/worktrees/<repo-fingerprint>/<name>
 ```
 
-The repository fingerprint is the first 16 hexadecimal characters of a SHA-256 hash over the canonical git common directory and origin URL. A supplied name must match `[a-z0-9][a-z0-9-]{0,63}`. Without a name, OpenClaw generates a readable crustacean-themed name such as `brisk-lobster`. Inferred names already occupied by another owner, local branch, or unmanaged path get a numeric suffix such as `brisk-lobster-2`.
+The repository fingerprint is the first 16 hexadecimal characters of a SHA-256 hash over the canonical git common directory and origin URL. A supplied name must match `[a-z0-9][a-z0-9-]{0,63}`. Without a name, OpenClaw generates a readable crustacean-themed name such as `brisk-lobster`. Inferred names already occupied by any registered worktree (including the caller's own removed checkout), local branch, or unmanaged path get a numeric suffix such as `brisk-lobster-2`; only a supplied name reuses or restores the caller's existing record.
 
 OpenClaw creates branch `openclaw/<name>` at the requested base ref. Without a base ref, it fetches `origin`, uses the remote default branch when available, and falls back to local `HEAD` when the repository is offline or has no usable remote.
 

--- a/src/agents/worktrees/service.naming.test.ts
+++ b/src/agents/worktrees/service.naming.test.ts
@@ -101,6 +101,25 @@ describe("ManagedWorktreeService naming", () => {
     ).toHaveLength(1);
   });
 
+  it("numbers a generated name colliding with the owner's removed record", async () => {
+    const owner = {
+      repoRoot: repo,
+      baseRef: "HEAD",
+      ownerKind: "session" as const,
+      ownerId: "agent:main:main",
+    };
+    const first = await service.create({ ...owner, suggestedName: "same-title" });
+    await service.remove({ id: first.id, reason: "session-reset" });
+
+    const successor = await service.create({ ...owner, suggestedName: "same-title" });
+
+    expect(successor.id).not.toBe(first.id);
+    expect(successor.name).toBe("same-title-2");
+    expect((await service.list()).find((record) => record.id === first.id)?.removedAt).toEqual(
+      expect.any(Number),
+    );
+  });
+
   it("serializes overlapping numeric suffix families", async () => {
     await service.create({ repoRoot: repo, name: "task", baseRef: "HEAD" });
 

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -127,9 +127,16 @@ async function nameIsUnavailable(
 ): Promise<boolean> {
   const worktreePath = path.join(root, name);
   const registered = findRegistryWorktreeByPath(env, worktreePath);
-  if (owner.ownerId && registered && worktreeOwnerMatches(registered, owner)) {
-    // Let createForRepository reuse or restore the caller's existing record.
-    // Treating it as a collision can create a second checkout for one owner.
+  if (
+    owner.ownerId &&
+    registered &&
+    registered.removedAt === undefined &&
+    worktreeOwnerMatches(registered, owner)
+  ) {
+    // Let createForRepository reuse the caller's live checkout; a collision here
+    // could mint a second checkout for one owner. Removed records stay collisions:
+    // restore is explicit-name/id only, so a generated name (title slug or random
+    // crustacean) must never silently resurrect a retired checkout.
     return false;
   }
   if (registered || (await worktreePathExists(worktreePath))) {


### PR DESCRIPTION
## What Problem This Solves

`src/gateway/server.sessions.create.test.ts` ("sessions.create reset-in-place persists the returned worktree cwd") flaked on CI (run 31514115715, PR #122109 merge ref): `getRegistryWorktree(...).removedAt` came back `undefined` after a reset that had just retired the session worktree.

The reset ordering guarantee itself is sound — `removeIfLossless` is awaited inside the exclusive session-lifecycle mutation and `remove()` persists `removedAt` atomically before the RPC resolves. The flake is a real product bug downstream: the successor `sessions.create` (worktree, no label) allocates a random crustacean slug (`createCrustaceanSlug()`, 42 adjectives x 10 nouns = 420 combinations). When that roll collides with the just-retired worktree's name (~0.24% per run), `nameIsUnavailable`'s owner-match bypass reported the caller's own *removed* record as available, and `createForRepository` took its removed-with-snapshot branch and called `restore()` — resurrecting the same registry row, clearing `removedAt`, and reviving the old branch instead of minting the fresh worktree the caller asked for.

## Why This Change Was Made

Nondeterministic resurrection of a retired checkout on a random-name collision violates the documented naming contract from #114488: generated names that collide "get a numeric suffix such as `brisk-lobster-2`", and restore is its own explicit surface (`worktrees.restore <id>`, or create with an explicit name). The fix is at the owner: `nameIsUnavailable`'s same-owner bypass now applies to live records only, so generated names (title slugs and random slugs) treat the caller's removed records as collisions and take a numeric suffix. Explicit `worktreeName`/`params.name` skips `generateName` entirely and keeps its documented reuse/restore semantics unchanged.

Production logic delta: +1 predicate line in `src/agents/worktrees/service.ts` (plus comment); docs sentence sharpened in `docs/concepts/managed-worktrees.md`.

## User Impact

A session that leaves its worktree (reset / New Chat) and then starts a new worktree session can no longer randomly land back in the resurrected old record/branch; the retired worktree's registry audit fact (`removedAt`) stays persisted. Also deterministically de-flakes the reset-in-place gateway test.

## Evidence

- Regression test `src/agents/worktrees/service.naming.test.ts` ("numbers a generated name colliding with the owner's removed record") reproduces the original execution order deterministically and **fails pre-fix** with the exact flake signature (successor returned the same record id, `removedAt` cleared); passes post-fix (`same-title-2`, fresh id, `removedAt` intact).
- Full worktrees suite green: 40 files, 330 passed / 3 skipped.
- Originally flaky gateway file green: `src/gateway/server.sessions.create.test.ts`, 94 passed.
- `src/gateway/server-methods/worktrees.test.ts` + `src/plugins/runtime/index.test.ts` green.
- `tsgo` core + core-test lanes, oxlint on changed files, oxfmt, `git diff --check`: all clean. Full `check:changed` wrapper could not complete locally (repo-wide heavy-check lock contention from sibling worktrees + Crabbox broker auth outage), so lanes were run directly; hosted CI is authoritative.
- Codex autoreview (`gpt-5.6-sol`, high): clean, "patch is correct (0.99)", zero accepted findings.
