### PR TITLE
improve(ui): use Diff icon for session changes

### DIFF
--- a/ui/src/components/icons.ts
+++ b/ui/src/components/icons.ts
@@ -53,6 +53,9 @@ export const icons = {
     <path d="M9 10h6" />
     <path d="M12 13V7" />
     <path d="M9 17h6" />`),
+  diff: strokeIcon(svg` <path d="M12 3v14" />
+    <path d="M5 10h14" />
+    <path d="M5 21h14" />`),
   braces: strokeIcon(svg` <path
       d="M8 3H7a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2 2 2 0 0 1 2 2v5c0 1.1.9 2 2 2h1"
     />

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -230,7 +230,7 @@ export abstract class ChatPaneHeader extends ChatPaneSessionMenu {
       panelMenuActions.push({
         id: "changes",
         label: t("chat.sessionDiff.show"),
-        icon: icons.fileDiff,
+        icon: icons.diff,
         onActivate: sessionWorkspace.onOpenDiff,
       });
     }

--- a/ui/src/pages/chat/components/chat-header-session-menu.test.ts
+++ b/ui/src/pages/chat/components/chat-header-session-menu.test.ts
@@ -189,7 +189,7 @@ describe("chat header session menu", () => {
         {
           id: "changes",
           label: "Show session changes",
-          icon: icons.fileDiff,
+          icon: icons.diff,
           onActivate: showChanges,
         },
       ],

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -944,7 +944,7 @@ export function renderSessionDiffToggle(
         aria-label=${label}
         @click=${sessionWorkspace.onOpenDiff}
       >
-        ${icons.fileDiff}
+        ${icons.diff}
       </button>
     </openclaw-tooltip>
   `;
@@ -1012,7 +1012,7 @@ export function renderSessionWorkspaceRail(
             aria-label=${t("chat.sessionDiff.show")}
             @click=${sessionWorkspace.onOpenDiff}
           >
-            ${icons.fileDiff}
+            ${icons.diff}
           </button>
         </openclaw-tooltip>
       `


### PR DESCRIPTION
Closes #122398

## What Problem This Solves

Resolves a visual papercut where the Control UI **Show session changes** action uses a denser file-shaped glyph than the neighboring topbar actions.

## Why This Change Was Made

This PR adds Lucide `diff` through the existing `strokeIcon()` registry and uses it for every session-changes entry point: the topbar button, Panels quick action, and workspace rail. No layout, behavior, copy, or availability logic changes.

## User Impact

The session-changes action reads more clearly and fits the compact toolbar icon language in light and dark themes.

## Evidence

| Theme | Before | After |
| --- | --- | --- |
| Light | ![Before: Show session changes uses the file-diff icon in the light toolbar](https://github.com/user-attachments/assets/c9179703-aed3-4a94-af38-05d6e4e98532) | ![After: Show session changes uses the Diff icon in the light toolbar](https://github.com/user-attachments/assets/a070e65e-8cc9-409b-a2bf-2ea9ac91a57c) |
| Dark | ![Before: Show session changes uses the file-diff icon in the dark toolbar](https://github.com/user-attachments/assets/aec72ea2-91af-4b7e-8c9c-a91ff38861e6) | ![After: Show session changes uses the Diff icon in the dark toolbar](https://github.com/user-attachments/assets/ba94fe12-fbbb-4520-ad98-1080102629d7) |

Captured with the real Control UI E2E surface and mocked Gateway on Blacksmith Testbox at the base and exact PR head. Both visual runs passed 2/2. The focused session-menu suite passed 7/7 remotely at the exact PR head.

Remote `check:changed` passed for the four touched files on Blacksmith Testbox, including formatting, repository guards, dead-export scans, Control UI i18n verification, and relevant typechecks. Exact-head `openclaw/ci-gate` is green.
