### PR TITLE
fix(agents): project agent identity into outbound durable delivery

### DIFF
--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -181,6 +181,7 @@ function latestOutboundDeliveryArgs(): {
   bestEffort?: boolean;
   queuePolicy?: string;
   replyPayloadSendingHook?: ReplyPayloadSendingHookArgs;
+  identity?: { name?: string; avatarUrl?: string; emoji?: string; theme?: string };
 } {
   const args = lastMockArg(deliverOutboundPayloadsMock, "outbound delivery arguments");
   if (!args || typeof args !== "object") {
@@ -196,6 +197,7 @@ function latestOutboundDeliveryArgs(): {
     bestEffort?: boolean;
     queuePolicy?: string;
     replyPayloadSendingHook?: ReplyPayloadSendingHookArgs;
+    identity?: { name?: string; avatarUrl?: string; emoji?: string; theme?: string };
   };
 }
 
@@ -1498,6 +1500,44 @@ describe("deliverAgentCommandResult payload normalization", () => {
       error: true,
       reason: "unknown_channel",
     });
+  });
+
+  it("projects the configured agent identity into outbound delivery args", async () => {
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
+
+    const cfg = {
+      agents: {
+        list: [
+          {
+            id: "tester",
+            identity: { name: "Test Bot", emoji: "🤖" },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+
+    const delivered = await deliverAgentCommandResultForTest({
+      cfg,
+      payloads: [{ text: "Ready" }],
+    });
+
+    expect(delivered.deliverySucceeded).toBe(true);
+    expect(deliverOutboundPayloadsMock).toHaveBeenCalledTimes(1);
+    expect(latestOutboundDeliveryArgs().identity).toEqual({
+      name: "Test Bot",
+      emoji: "🤖",
+    });
+  });
+
+  it("omits identity when no agent identity is configured", async () => {
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
+
+    await deliverAgentCommandResultForTest({
+      payloads: [{ text: "Ready" }],
+    });
+
+    expect(deliverOutboundPayloadsMock).toHaveBeenCalledTimes(1);
+    expect(latestOutboundDeliveryArgs().identity).toBeUndefined();
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -556,15 +556,6 @@ export async function deliverAgentCommandResult(
       config: cfg,
     }) ??
     resolveDefaultAgentId(cfg);
-  // Project the active agent's configured identity (name/emoji/avatar) into the
-  // durable batch so channels that honor per-message authorship (e.g. Slack
-  // `username`/`icon_emoji` with `chat:write.customize`) render it. Without this
-  // the agent-RPC final-delivery path reaches shared outbound delivery with no
-  // identity metadata, so every message posts under the channel's default bot
-  // identity regardless of config. See #121513.
-  const deliveryIdentity = deliveryAgentId
-    ? resolveAgentOutboundIdentity(cfg, deliveryAgentId)
-    : undefined;
   const deliver = opts.deliver === true;
   const bestEffortDeliver = opts.bestEffortDeliver === true;
   const turnSourceChannel = opts.runContext?.messageChannel ?? opts.messageChannel;
@@ -937,6 +928,11 @@ export async function deliverAgentCommandResult(
   if (deliver && deliveryChannel && !isInternalMessageChannel(deliveryChannel)) {
     if (deliveryTarget && !deliveryStatus) {
       params.assertDeliveryCurrent?.();
+      // Resolve identity here, only on the send path, so non-delivering and
+      // preflight-failed branches never touch the identity/avatar filesystem.
+      const deliveryIdentity = deliveryAgentId
+        ? resolveAgentOutboundIdentity(cfg, deliveryAgentId)
+        : undefined;
       const restartAbort = createRestartOnlyAbortSignal(opts.abortSignal);
       let send: DurableSendResult;
       try {

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -36,6 +36,7 @@ import {
 } from "../../infra/outbound/agent-delivery.js";
 import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
 import { buildOutboundResultEnvelope } from "../../infra/outbound/envelope.js";
+import { resolveAgentOutboundIdentity } from "../../infra/outbound/identity.js";
 import {
   createOutboundPayloadPlan,
   formatOutboundPayloadLog,
@@ -555,6 +556,15 @@ export async function deliverAgentCommandResult(
       config: cfg,
     }) ??
     resolveDefaultAgentId(cfg);
+  // Project the active agent's configured identity (name/emoji/avatar) into the
+  // durable batch so channels that honor per-message authorship (e.g. Slack
+  // `username`/`icon_emoji` with `chat:write.customize`) render it. Without this
+  // the agent-RPC final-delivery path reaches shared outbound delivery with no
+  // identity metadata, so every message posts under the channel's default bot
+  // identity regardless of config. See #121513.
+  const deliveryIdentity = deliveryAgentId
+    ? resolveAgentOutboundIdentity(cfg, deliveryAgentId)
+    : undefined;
   const deliver = opts.deliver === true;
   const bestEffortDeliver = opts.bestEffortDeliver === true;
   const turnSourceChannel = opts.runContext?.messageChannel ?? opts.messageChannel;
@@ -958,6 +968,7 @@ export async function deliverAgentCommandResult(
           onDeliveryIntent: restartAbort.dispose,
           onError: logDeliveryError,
           onPayload: logPayload,
+          ...(deliveryIdentity ? { identity: deliveryIdentity } : {}),
           deps: createOutboundSendDeps(deps),
         });
       } finally {


### PR DESCRIPTION
## What Problem This Solves

Closes #121513.

A per-agent `identity: { name, emoji }` config block — documented behavior resolved via `resolveAgentIdentity()` and converted to Slack's `username`/`icon_emoji` by `resolveSlackSendIdentity()` in `extensions/slack/src/outbound-adapter.ts` — never appeared on outbound Slack messages sent through the agent-RPC final-delivery path, even with `chat:write.customize` granted and valid config. Every message posted under the Slack App's default bot identity.

## Why This Change Was Made

Root cause: `deliverAgentCommandResult` (`src/agents/command/delivery.ts`) resolved the active agent id (`deliveryAgentId`) but never projected that agent's configured identity into the durable message batch. The final-delivery branch calls `sendDurableMessageBatch({ ... })` without an `identity` field, so shared outbound delivery received no identity metadata and the Slack adapter's `resolveSlackSendIdentity(params.identity)` resolved nothing.

This was a pure omission: every piece of the pipeline already supported identity —

- `resolveAgentOutboundIdentity(cfg, agentId)` (`src/infra/outbound/identity.ts`) already resolves the agent's identity + avatar into channel-safe `OutboundIdentity`.
- `DurableMessageBatchSendParams` (via `DeliverOutboundPayloadsParams`, `src/infra/outbound/deliver-contracts.ts`) already accepts an optional `identity?: OutboundIdentity` field and threads it through to `deliverOutboundPayloads`.
- The Slack outbound adapter (`extensions/slack/src/outbound-adapter.ts`) already consumes `params.identity` via `resolveSlackSendIdentity` → `{ username, iconUrl, iconEmoji }`.

The only missing link was the call site populating `identity` from the already-resolved agent id.

### Canonical fix (owner boundary)

Resolve the agent's outbound identity inside the durable send branch (`deliveryTarget && !deliveryStatus`) and pass it into `sendDurableMessageBatch`. This is the single canonical producer for agent-RPC final delivery — sibling outbound paths (interactive reply, message-tool send) already carry identity through their own seams; this path was the gap.

Identity is resolved only on the actual send path, not at the top of `deliverAgentCommandResult`. `resolveAgentOutboundIdentity` → `resolveAgentAvatar` → `loadAgentIdentityFromWorkspace` → `loadIdentityFromFile` performs a **synchronous** `fs.realpathSync` + `readRegularFileSync` of the agent's `IDENTITY.md`. Resolving it eagerly would run that filesystem read even on `deliver: false` and preflight-failed paths that never send. The send branch is the owner of "a message is about to go out," so it owns identity resolution.

No new abstraction, type, or fallback is added — the existing `identity` field on the batch params is the contract, and `resolveAgentOutboundIdentity` already handles empty/absent identity by returning `undefined` (normalized away), which is why the field is spread conditionally.

### ClawSweeper findings addressed (head `c0117f20c7b`)

The initial ClawSweeper review (head `f880d365abf`) raised two actionable code findings; both are resolved on this head:

- **[P2] Resolve identity only when durable delivery will send** — moved `resolveAgentOutboundIdentity` out of the function preamble and into the `deliveryTarget && !deliveryStatus` send branch, so the synchronous identity/avatar filesystem read no longer runs on non-delivering or preflight-failed paths.
- **[P3] Shorten the issue-specific inline comment** — reduced from six lines of issue lore to a two-line owner-boundary rationale stating why identity resolves on the send path.

## User Impact

Operators who set `agents.list[].identity: { name, emoji }` (and grant `chat:write.customize`) now see agent-initiated outbound Slack messages render with the configured name/emoji instead of the default bot identity — matching the documented behavior. Operators without identity config see no change (identity field stays absent).

## Evidence

### Pre-fix reproduction (regression test fails on unpatched code)

Stashed only the production file (`git stash push -- src/agents/command/delivery.ts`) and ran the new regression test against the unpatched code:

```
 FAIL  src/agents/command/delivery.test.ts > projects the configured agent identity into outbound delivery args
AssertionError: expected undefined to deeply equal { name: 'Test Bot', emoji: '🤖' }

- Expected:
{
  "emoji": "🤖",
  "name": "Test Bot",
}

+ Received:
undefined
```

The unpatched `deliverAgentCommandResult` never populated `identity`, so `latestOutboundDeliveryArgs().identity` was `undefined`.

### Post-fix (all tests pass)

```
node scripts/run-vitest.mjs src/agents/command/delivery.test.ts
 Test Files  1 passed (1)
      Tests  53 passed (53)
```

### Production-vs-test LOC delta

- Production: `src/agents/command/delivery.ts` — +7 lines (1 import + identity resolution on the send path + conditional spread). The fix threads an already-supported field through an existing owner; no new branch or guard beyond the single conditional spread that mirrors how other optional batch params (e.g. `replyToId`, `threadId`) are passed.
- Tests: `src/agents/command/delivery.test.ts` — +40 lines (2 regression cases + helper type extension).

### Type check

`tsgo:core` (covers `src/agents/command/delivery.ts`) — exit 0, no errors.

`tsgo:core:test` — 4 pre-existing errors in unrelated files (`src/config/includes.ts`, `src/gateway/control-ui.ts`, `src/hooks/workspace.ts`, `src/skills/loading/local-loader.ts`, all `rejectSymlinks` not in `OpenRootFileSyncParams`) present on `main` before this change; none in the touched files. These are upstream main breakage, not introduced here.

### Files changed

- `src/agents/command/delivery.ts` — resolve `deliveryIdentity` from `deliveryAgentId` via `resolveAgentOutboundIdentity` inside the durable send branch; pass `identity` into `sendDurableMessageBatch`.
- `src/agents/command/delivery.test.ts` — regression test asserting identity is projected into outbound delivery args (fails pre-fix), plus a negative case asserting identity is omitted when no agent identity is configured.

