### PR TITLE
fix(ui): show local project icons in the chat header

### DIFF
--- a/src/gateway/server-methods/chat-history-handler.ts
+++ b/src/gateway/server-methods/chat-history-handler.ts
@@ -41,6 +41,7 @@ import {
   resolveSessionModelRef,
   resolveSessionStoreKey,
 } from "../session-utils.js";
+import { prepareSessionWorkspaceIcon } from "../workspace-icon-http.js";
 import { scheduleChatHistoryManagedMediaCleanup } from "./chat-assistant-content.js";
 import {
   CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES,
@@ -246,6 +247,16 @@ async function handleChatHistoryRequest({
       return;
     }
   }
+  const workspaceIconPreparation =
+    method === "chat.startup"
+      ? prepareSessionWorkspaceIcon({ sessionKey, agentId: sessionAgentId }).catch(
+          (error: unknown) => {
+            context.logGateway.debug(
+              `chat.startup continuing without a workspace icon: ${formatErrorMessage(error)}`,
+            );
+          },
+        )
+      : Promise.resolve();
   const modelCatalogPromise =
     method === "chat.history"
       ? (() => {
@@ -512,6 +523,7 @@ async function handleChatHistoryRequest({
     ...(includeAgentsList && startupAgentsList ? { agentsList: startupAgentsList } : {}),
     ...(startupMetadata ? { metadata: startupMetadata } : {}),
   };
+  await workspaceIconPreparation;
   respond(true, payload);
 }
 

--- a/src/gateway/workspace-icon-http.test.ts
+++ b/src/gateway/workspace-icon-http.test.ts
@@ -33,6 +33,7 @@ vi.mock("./server-methods/sessions-files.js", () => ({
 const {
   clearWorkspaceIconCacheForTest,
   handleWorkspaceIconHttpRequest,
+  prepareSessionWorkspaceIcon,
   resolveWorkspaceIcon,
   SVG_ICON_MAX_BYTES,
   WORKSPACE_ICON_MAX_BYTES,
@@ -73,22 +74,32 @@ afterEach(async () => {
 
 describe("resolveWorkspaceIcon", () => {
   const conventions = [
-    { relative: "public/favicon.svg", body: SVG_BYTES, contentType: "image/svg+xml" },
-    { relative: "public/favicon.ico", body: ICO_BYTES, contentType: "image/x-icon" },
-    { relative: "public/favicon.png", body: PNG_BYTES, contentType: "image/png" },
-    { relative: "public/apple-touch-icon.png", body: PNG_BYTES, contentType: "image/png" },
-    { relative: "static/favicon.svg", body: SVG_BYTES, contentType: "image/svg+xml" },
-    { relative: "static/favicon.ico", body: ICO_BYTES, contentType: "image/x-icon" },
-    { relative: "static/favicon.png", body: PNG_BYTES, contentType: "image/png" },
-    { relative: "app/icon.svg", body: SVG_BYTES, contentType: "image/svg+xml" },
-    { relative: "app/icon.png", body: PNG_BYTES, contentType: "image/png" },
-    { relative: "app/favicon.ico", body: ICO_BYTES, contentType: "image/x-icon" },
-    { relative: "src/app/icon.svg", body: SVG_BYTES, contentType: "image/svg+xml" },
-    { relative: "src/app/icon.png", body: PNG_BYTES, contentType: "image/png" },
-    { relative: "src/app/favicon.ico", body: ICO_BYTES, contentType: "image/x-icon" },
     { relative: "favicon.svg", body: SVG_BYTES, contentType: "image/svg+xml" },
     { relative: "favicon.ico", body: ICO_BYTES, contentType: "image/x-icon" },
     { relative: "favicon.png", body: PNG_BYTES, contentType: "image/png" },
+    { relative: "public/favicon.svg", body: SVG_BYTES, contentType: "image/svg+xml" },
+    { relative: "public/favicon.ico", body: ICO_BYTES, contentType: "image/x-icon" },
+    { relative: "public/favicon.png", body: PNG_BYTES, contentType: "image/png" },
+    { relative: "public/favicon-32.png", body: PNG_BYTES, contentType: "image/png" },
+    { relative: "ui/public/favicon-32.png", body: PNG_BYTES, contentType: "image/png" },
+    { relative: "ui/public/favicon.svg", body: SVG_BYTES, contentType: "image/svg+xml" },
+    { relative: "ui/public/favicon.ico", body: ICO_BYTES, contentType: "image/x-icon" },
+    { relative: "ui/public/favicon.png", body: PNG_BYTES, contentType: "image/png" },
+    { relative: "app/favicon.ico", body: ICO_BYTES, contentType: "image/x-icon" },
+    { relative: "app/favicon.png", body: PNG_BYTES, contentType: "image/png" },
+    { relative: "app/icon.svg", body: SVG_BYTES, contentType: "image/svg+xml" },
+    { relative: "app/icon.png", body: PNG_BYTES, contentType: "image/png" },
+    { relative: "app/icon.ico", body: ICO_BYTES, contentType: "image/x-icon" },
+    { relative: "src/favicon.ico", body: ICO_BYTES, contentType: "image/x-icon" },
+    { relative: "src/favicon.svg", body: SVG_BYTES, contentType: "image/svg+xml" },
+    { relative: "src/app/favicon.ico", body: ICO_BYTES, contentType: "image/x-icon" },
+    { relative: "src/app/icon.svg", body: SVG_BYTES, contentType: "image/svg+xml" },
+    { relative: "src/app/icon.png", body: PNG_BYTES, contentType: "image/png" },
+    { relative: "assets/icon.svg", body: SVG_BYTES, contentType: "image/svg+xml" },
+    { relative: "assets/icon.png", body: PNG_BYTES, contentType: "image/png" },
+    { relative: "assets/logo.svg", body: SVG_BYTES, contentType: "image/svg+xml" },
+    { relative: "assets/logo.png", body: PNG_BYTES, contentType: "image/png" },
+    { relative: ".idea/icon.svg", body: SVG_BYTES, contentType: "image/svg+xml" },
   ] as const;
 
   it.each(conventions)("resolves $relative as $contentType", async (convention) => {
@@ -99,16 +110,17 @@ describe("resolveWorkspaceIcon", () => {
     expect(icon?.etag).toMatch(/^"[\w-]+"$/u);
   });
 
-  it("prefers the framework-specific location over a bare root favicon", async () => {
+  it("uses the first valid icon in the fixed precedence", async () => {
     const root = await makeWorkspace({
       "favicon.ico": ICO_BYTES,
       "public/favicon.svg": SVG_BYTES,
+      "ui/public/favicon-32.png": PNG_BYTES,
     });
-    expect((await resolveWorkspaceIcon(root))?.contentType).toBe("image/svg+xml");
+    expect((await resolveWorkspaceIcon(root))?.contentType).toBe("image/x-icon");
   });
 
   const rejected = [
-    { label: "an unconventional location", files: { "assets/favicon.ico": ICO_BYTES } },
+    { label: "an unconventional location", files: { "public/apple-touch-icon.png": PNG_BYTES } },
     { label: "an empty file", files: { "favicon.ico": Buffer.alloc(0) } },
     { label: "bytes that are not an image", files: { "favicon.ico": Buffer.from("#!/bin/sh\n") } },
     {
@@ -212,6 +224,7 @@ describe("handleWorkspaceIconHttpRequest", () => {
   it("serves the session workspace icon with sandboxed asset headers", async () => {
     const root = await makeWorkspace({ "public/favicon.ico": ICO_BYTES });
     mocks.resolveLocalSessionWorkspaceRoot.mockReturnValue(root);
+    await prepareSessionWorkspaceIcon({ sessionKey: "agent:main:one" });
 
     const response = await fetch(iconRoute("agent:main:one"));
     expect(mocks.resolveLocalSessionWorkspaceRoot).toHaveBeenCalledWith({
@@ -233,6 +246,7 @@ describe("handleWorkspaceIconHttpRequest", () => {
   it("revalidates an unchanged icon without resending its bytes", async () => {
     const root = await makeWorkspace({ "favicon.png": PNG_BYTES });
     mocks.resolveLocalSessionWorkspaceRoot.mockReturnValue(root);
+    await prepareSessionWorkspaceIcon({ sessionKey: "agent:main:one" });
 
     const first = await fetch(iconRoute("agent:main:one"));
     const etag = first.headers.get("etag");
@@ -249,6 +263,7 @@ describe("handleWorkspaceIconHttpRequest", () => {
   it("omits the body but keeps the representation headers on HEAD", async () => {
     const root = await makeWorkspace({ "favicon.png": PNG_BYTES });
     mocks.resolveLocalSessionWorkspaceRoot.mockReturnValue(root);
+    await prepareSessionWorkspaceIcon({ sessionKey: "agent:main:one" });
 
     const response = await fetch(iconRoute("agent:main:one"), { method: "HEAD" });
     expect(response.status).toBe(200);
@@ -265,9 +280,60 @@ describe("handleWorkspaceIconHttpRequest", () => {
     mocks.resolveLocalSessionWorkspaceRoot.mockReturnValue(
       hasWorkspace ? await makeWorkspace({}) : undefined,
     );
+    await prepareSessionWorkspaceIcon({ sessionKey: "agent:main:one" });
     const response = await fetch(iconRoute("agent:main:one"));
     expect(response.status).toBe(404);
     expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("keeps a request made before chat startup retryable", async () => {
+    const response = await fetch(iconRoute("agent:main:one"));
+    expect(response.status).toBe(503);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("retry-after")).toBe("1");
+    expect(mocks.resolveLocalSessionWorkspaceRoot).not.toHaveBeenCalled();
+  });
+
+  it("waits for preparation already started by chat startup", async () => {
+    const root = await makeWorkspace({ "public/favicon.ico": ICO_BYTES });
+    mocks.resolveLocalSessionWorkspaceRoot.mockReturnValue(root);
+
+    const preparation = prepareSessionWorkspaceIcon({ sessionKey: "agent:main:pending" });
+    const responsePromise = fetch(iconRoute("agent:main:pending"));
+
+    await preparation;
+    const response = await responsePromise;
+    expect(response.status).toBe(200);
+    expect(Buffer.from(await response.arrayBuffer()).equals(ICO_BYTES)).toBe(true);
+  });
+
+  it("records the fallback when preparation fails", async () => {
+    mocks.resolveLocalSessionWorkspaceRoot.mockImplementation(() => {
+      throw new Error("broken workspace metadata");
+    });
+    await expect(prepareSessionWorkspaceIcon({ sessionKey: "agent:main:broken" })).rejects.toThrow(
+      "broken workspace metadata",
+    );
+
+    const response = await fetch(iconRoute("agent:main:broken"));
+    expect(response.status).toBe(404);
+  });
+
+  it("does no session-store or filesystem resolution in the HTTP request", async () => {
+    const root = await makeWorkspace({ "ui/public/favicon-32.png": PNG_BYTES });
+    mocks.resolveLocalSessionWorkspaceRoot.mockReturnValue(root);
+    await prepareSessionWorkspaceIcon({ sessionKey: "agent:main:one" });
+    mocks.resolveLocalSessionWorkspaceRoot.mockClear();
+    await fs.rm(path.join(root, "ui/public/favicon-32.png"));
+
+    const first = await fetch(iconRoute("agent:main:one"));
+    const second = await fetch(iconRoute("agent:main:one"));
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(Buffer.from(await first.arrayBuffer()).equals(PNG_BYTES)).toBe(true);
+    expect(Buffer.from(await second.arrayBuffer()).equals(PNG_BYTES)).toBe(true);
+    expect(mocks.resolveLocalSessionWorkspaceRoot).not.toHaveBeenCalled();
   });
 
   const malformed = ["/__openclaw__/workspace-icon/", "/__openclaw__/workspace-icon/a/b"];
@@ -316,6 +382,7 @@ describe("handleWorkspaceIconHttpRequest", () => {
     // resolveLocalSessionWorkspaceRoot withholds the root for exec-node sessions
     // so the route can never answer with this Gateway's own project icon.
     mocks.resolveLocalSessionWorkspaceRoot.mockReturnValue(undefined);
+    await prepareSessionWorkspaceIcon({ sessionKey: "agent:main:remote" });
     const response = await fetch(iconRoute("agent:main:remote"));
     expect(response.status).toBe(404);
     expect(response.headers.get("cache-control")).toBe("no-store");

--- a/src/gateway/workspace-icon-http.test.ts
+++ b/src/gateway/workspace-icon-http.test.ts
@@ -81,6 +81,10 @@ describe("resolveWorkspaceIcon", () => {
     { relative: "public/favicon.ico", body: ICO_BYTES, contentType: "image/x-icon" },
     { relative: "public/favicon.png", body: PNG_BYTES, contentType: "image/png" },
     { relative: "public/favicon-32.png", body: PNG_BYTES, contentType: "image/png" },
+    { relative: "public/apple-touch-icon.png", body: PNG_BYTES, contentType: "image/png" },
+    { relative: "static/favicon.svg", body: SVG_BYTES, contentType: "image/svg+xml" },
+    { relative: "static/favicon.ico", body: ICO_BYTES, contentType: "image/x-icon" },
+    { relative: "static/favicon.png", body: PNG_BYTES, contentType: "image/png" },
     { relative: "ui/public/favicon-32.png", body: PNG_BYTES, contentType: "image/png" },
     { relative: "ui/public/favicon.svg", body: SVG_BYTES, contentType: "image/svg+xml" },
     { relative: "ui/public/favicon.ico", body: ICO_BYTES, contentType: "image/x-icon" },
@@ -119,7 +123,7 @@ describe("resolveWorkspaceIcon", () => {
   });
 
   const rejected = [
-    { label: "an unconventional location", files: { "public/apple-touch-icon.png": PNG_BYTES } },
+    { label: "an unconventional location", files: { "vendor/favicon.png": PNG_BYTES } },
     { label: "an empty file", files: { "favicon.ico": Buffer.alloc(0) } },
     { label: "bytes that are not an image", files: { "favicon.ico": Buffer.from("#!/bin/sh\n") } },
     {
@@ -333,6 +337,21 @@ describe("handleWorkspaceIconHttpRequest", () => {
     expect(Buffer.from(await first.arrayBuffer()).equals(PNG_BYTES)).toBe(true);
     expect(Buffer.from(await second.arrayBuffer()).equals(PNG_BYTES)).toBe(true);
     expect(mocks.resolveLocalSessionWorkspaceRoot).not.toHaveBeenCalled();
+  });
+
+  it("keeps a recently served session snapshot across bounded-cache eviction", async () => {
+    const root = await makeWorkspace({ "favicon.png": PNG_BYTES });
+    mocks.resolveLocalSessionWorkspaceRoot.mockReturnValue(root);
+    await prepareSessionWorkspaceIcon({ sessionKey: "agent:main:kept" });
+    for (let index = 0; index < 127; index += 1) {
+      await prepareSessionWorkspaceIcon({ sessionKey: `agent:main:filler-${index}` });
+    }
+
+    expect((await fetch(iconRoute("agent:main:kept"))).status).toBe(200);
+    await prepareSessionWorkspaceIcon({ sessionKey: "agent:main:newest" });
+
+    expect((await fetch(iconRoute("agent:main:kept"))).status).toBe(200);
+    expect((await fetch(iconRoute("agent:main:filler-0"))).status).toBe(503);
   });
 
   const malformed = ["/__openclaw__/workspace-icon/", "/__openclaw__/workspace-icon/a/b"];

--- a/src/gateway/workspace-icon-http.test.ts
+++ b/src/gateway/workspace-icon-http.test.ts
@@ -99,7 +99,6 @@ describe("resolveWorkspaceIcon", () => {
     { relative: "assets/icon.png", body: PNG_BYTES, contentType: "image/png" },
     { relative: "assets/logo.svg", body: SVG_BYTES, contentType: "image/svg+xml" },
     { relative: "assets/logo.png", body: PNG_BYTES, contentType: "image/png" },
-    { relative: ".idea/icon.svg", body: SVG_BYTES, contentType: "image/svg+xml" },
   ] as const;
 
   it.each(conventions)("resolves $relative as $contentType", async (convention) => {

--- a/src/gateway/workspace-icon-http.ts
+++ b/src/gateway/workspace-icon-http.ts
@@ -57,7 +57,6 @@ const WORKSPACE_ICON_RELATIVE_PATHS = [
   "assets/icon.png",
   "assets/logo.svg",
   "assets/logo.png",
-  ".idea/icon.svg",
 ] as const;
 
 /** Icons are small by construction; anything larger is not a favicon. */

--- a/src/gateway/workspace-icon-http.ts
+++ b/src/gateway/workspace-icon-http.ts
@@ -1,9 +1,10 @@
 // Serves a workspace directory's own project icon so the Control UI can render
 // real project identity instead of a generic folder glyph.
 import { createHash } from "node:crypto";
-import fs from "node:fs";
+import { close } from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
+import { promisify } from "node:util";
 import { fileTypeFromBuffer } from "file-type";
 import {
   openRootFileFollowingParents,
@@ -26,28 +27,37 @@ import {
 import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
 
 /**
- * Conventional project icon locations, ordered by framework specificity and then
- * by rendering fidelity (vector before raster). Resolution stops at the first
- * hit, so this list is the whole filesystem cost of a workspace: keeping it
- * bounded is what makes icon lookup a one-time-per-workspace operation.
+ * Conventional project icon locations in deterministic product precedence.
+ * Resolution stops at the first valid hit, so this fixed list is the whole
+ * filesystem cost of opening a workspace and never becomes a recursive scan.
  */
 const WORKSPACE_ICON_RELATIVE_PATHS = [
-  "public/favicon.svg",
-  "public/favicon.ico",
-  "public/favicon.png",
-  "public/apple-touch-icon.png",
-  "static/favicon.svg",
-  "static/favicon.ico",
-  "static/favicon.png",
-  "app/icon.svg",
-  "app/icon.png",
-  "app/favicon.ico",
-  "src/app/icon.svg",
-  "src/app/icon.png",
-  "src/app/favicon.ico",
   "favicon.svg",
   "favicon.ico",
   "favicon.png",
+  "public/favicon.svg",
+  "public/favicon.ico",
+  "public/favicon.png",
+  "public/favicon-32.png",
+  "ui/public/favicon-32.png",
+  "ui/public/favicon.svg",
+  "ui/public/favicon.ico",
+  "ui/public/favicon.png",
+  "app/favicon.ico",
+  "app/favicon.png",
+  "app/icon.svg",
+  "app/icon.png",
+  "app/icon.ico",
+  "src/favicon.ico",
+  "src/favicon.svg",
+  "src/app/favicon.ico",
+  "src/app/icon.svg",
+  "src/app/icon.png",
+  "assets/icon.svg",
+  "assets/icon.png",
+  "assets/logo.svg",
+  "assets/logo.png",
+  ".idea/icon.svg",
 ] as const;
 
 /** Icons are small by construction; anything larger is not a favicon. */
@@ -55,8 +65,10 @@ export const WORKSPACE_ICON_MAX_BYTES = 512 * 1024;
 /** Vector icons are markup the renderer must parse, so they get a tighter cap. */
 export const SVG_ICON_MAX_BYTES = 64 * 1024;
 const WORKSPACE_ICON_CACHE_MAX_ENTRIES = 32;
+const SESSION_WORKSPACE_ICON_CACHE_MAX_ENTRIES = 128;
 const SVG_MIME_TYPE = "image/svg+xml";
 const ICO_MIME_TYPE = "image/x-icon";
+const closeFileDescriptor = promisify(close);
 
 /** Sniffable raster types the Control UI can render inside an <img> element. */
 const ALLOWED_RASTER_ICON_MIME_TYPES = new Set([
@@ -78,9 +90,11 @@ type WorkspaceIcon = {
 type WorkspaceIconResolution = WorkspaceIcon | null;
 
 let workspaceIconCache = new Map<string, Promise<WorkspaceIconResolution>>();
+let sessionWorkspaceIconCache = new Map<string, Promise<WorkspaceIconResolution>>();
 
 export function clearWorkspaceIconCacheForTest(): void {
   workspaceIconCache = new Map();
+  sessionWorkspaceIconCache = new Map();
 }
 
 /**
@@ -138,7 +152,7 @@ async function readWorkspaceIconCandidate(
   } catch {
     return undefined;
   } finally {
-    fs.closeSync(opened.fd);
+    await closeFileDescriptor(opened.fd);
   }
   if (body.byteLength === 0) {
     return undefined;
@@ -189,6 +203,36 @@ const getSessionsFilesModule = createLazyRuntimeModule(
   () => import("./server-methods/sessions-files.js"),
 );
 
+/**
+ * Prepares the immutable icon snapshot while opening a chat. The HTTP asset
+ * request only reads this map: no session-store or filesystem work is allowed
+ * on that hot path, and icon changes become visible after Gateway restart.
+ */
+export async function prepareSessionWorkspaceIcon(params: {
+  sessionKey: string;
+  agentId?: string;
+}): Promise<void> {
+  const preparation = (async (): Promise<WorkspaceIconResolution> => {
+    const workspaceRoot = (await getSessionsFilesModule()).resolveLocalSessionWorkspaceRoot(params);
+    return workspaceRoot ? await resolveWorkspaceIcon(workspaceRoot) : null;
+  })();
+  sessionWorkspaceIconCache.delete(params.sessionKey);
+  // A failed optional preparation still becomes a stable fallback snapshot;
+  // the returned promise rejects separately so chat.startup can record it.
+  sessionWorkspaceIconCache.set(
+    params.sessionKey,
+    preparation.catch(() => null),
+  );
+  pruneMapToMaxSize(sessionWorkspaceIconCache, SESSION_WORKSPACE_ICON_CACHE_MAX_ENTRIES);
+  await preparation;
+}
+
+function readPreparedSessionWorkspaceIcon(
+  sessionKey: string,
+): Promise<WorkspaceIconResolution> | undefined {
+  return sessionWorkspaceIconCache.get(sessionKey);
+}
+
 /** `matched` claims the response so a malformed key 404s instead of reaching the SPA. */
 type WorkspaceIconRequest = { matched: false } | { matched: true; sessionKey: string | null };
 
@@ -216,9 +260,8 @@ function parseWorkspaceIconRequest(
 }
 
 /**
- * Serves the icon of the workspace a session runs in. The request names a
- * session, never a path: the served file is whatever the process-cached
- * resolution already picked inside that session's own workspace root.
+ * Serves the icon snapshot prepared when the chat opened. The request names a
+ * session, never a path, and performs no filesystem or session-store work.
  */
 export async function handleWorkspaceIconHttpRequest(
   req: IncomingMessage,
@@ -272,15 +315,23 @@ export async function handleWorkspaceIconHttpRequest(
     return true;
   }
 
-  const workspaceRoot = parsed.sessionKey
-    ? (await getSessionsFilesModule()).resolveLocalSessionWorkspaceRoot({
-        sessionKey: parsed.sessionKey,
-      })
-    : undefined;
-  const icon = workspaceRoot ? await resolveWorkspaceIcon(workspaceRoot) : null;
+  if (!parsed.sessionKey) {
+    res.setHeader("cache-control", "no-store");
+    respondNotFound(res);
+    return true;
+  }
+  const prepared = readPreparedSessionWorkspaceIcon(parsed.sessionKey);
+  if (!prepared) {
+    // The header can paint before chat.startup finishes. Keep this state
+    // retryable so it cannot be cached as the workspace's resolved fallback.
+    res.statusCode = 503;
+    res.setHeader("cache-control", "no-store");
+    res.setHeader("retry-after", "1");
+    res.end("workspace icon snapshot is not ready");
+    return true;
+  }
+  const icon = await prepared;
   if (!icon) {
-    // A workspace can gain an icon later, and this route has no revalidation
-    // token for an absent one; caching the miss would hide it until expiry.
     res.setHeader("cache-control", "no-store");
     respondNotFound(res);
     return true;

--- a/src/gateway/workspace-icon-http.ts
+++ b/src/gateway/workspace-icon-http.ts
@@ -39,6 +39,10 @@ const WORKSPACE_ICON_RELATIVE_PATHS = [
   "public/favicon.ico",
   "public/favicon.png",
   "public/favicon-32.png",
+  "public/apple-touch-icon.png",
+  "static/favicon.svg",
+  "static/favicon.ico",
+  "static/favicon.png",
   "ui/public/favicon-32.png",
   "ui/public/favicon.svg",
   "ui/public/favicon.ico",
@@ -229,7 +233,12 @@ export async function prepareSessionWorkspaceIcon(params: {
 function readPreparedSessionWorkspaceIcon(
   sessionKey: string,
 ): Promise<WorkspaceIconResolution> | undefined {
-  return sessionWorkspaceIconCache.get(sessionKey);
+  const prepared = sessionWorkspaceIconCache.get(sessionKey);
+  if (prepared) {
+    sessionWorkspaceIconCache.delete(sessionKey);
+    sessionWorkspaceIconCache.set(sessionKey, prepared);
+  }
+  return prepared;
 }
 
 /** `matched` claims the response so a malformed key 404s instead of reaching the SPA. */

--- a/ui/src/e2e/chat-header-axis.e2e.test.ts
+++ b/ui/src/e2e/chat-header-axis.e2e.test.ts
@@ -63,8 +63,19 @@ suite.define(() => {
           };
         });
 
-        for (const center of Object.values(centers)) {
-          expect(Math.abs(center - centers.nav), JSON.stringify(centers)).toBeLessThanOrEqual(0.1);
+        expect(Math.abs(centers.search - centers.nav), JSON.stringify(centers)).toBeLessThanOrEqual(
+          0.1,
+        );
+        for (const center of [
+          centers.projectIcon,
+          centers.projectText,
+          centers.separator,
+          centers.sessionText,
+        ]) {
+          // Text and artwork carry more visible weight below their geometric
+          // boxes than Lucide actions, so the identity trail needs a 1px
+          // optical lift to share the topbar's perceived horizontal axis.
+          expect(centers.nav - center, JSON.stringify(centers)).toBeCloseTo(1, 1);
         }
       } finally {
         await suite.closeBrowserContext(context);

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -171,6 +171,10 @@ openclaw-chat-pane {
   flex: 0 1 auto;
   min-width: 0;
   align-items: center;
+  /* Inter's visible glyph mass sits slightly below the 28px action glyphs even
+     when their CSS boxes share a center. Lift the whole trail as one optical
+     unit so project icon, labels, and separator meet the chrome centerline. */
+  transform: translateY(-1px);
   /* Both interactive segments pull their 5px hover padding back out of flow, so
      this gap is the separator's actual optical air on each side. */
   gap: 6px;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening a project chat would see the generic folder mark even when the project already provides a conventional local favicon. It also fixes the project breadcrumb sitting slightly below the sidebar and search controls in the chat topbar.

## Why This Change Was Made

The Gateway now resolves the first valid icon from one short, deterministic list of literal paths, in this exact precedence:

```text
favicon.svg
favicon.ico
favicon.png
public/favicon.svg
public/favicon.ico
public/favicon.png
public/favicon-32.png
public/apple-touch-icon.png
static/favicon.svg
static/favicon.ico
static/favicon.png
ui/public/favicon-32.png
ui/public/favicon.svg
ui/public/favicon.ico
ui/public/favicon.png
app/favicon.ico
app/favicon.png
app/icon.svg
app/icon.png
app/icon.ico
src/favicon.ico
src/favicon.svg
src/app/favicon.ico
src/app/icon.svg
src/app/icon.png
assets/icon.svg
assets/icon.png
assets/logo.svg
assets/logo.png
```

There is no recursive search or dynamic scoring. Multiple matches always resolve by this fixed order; invalid or absent candidates continue to the next literal path, and a project with no valid match keeps the folder fallback.

Performance contract:

- `chat.startup` prepares the icon snapshot once when the project chat opens. The authenticated asset route performs zero filesystem/session-store discovery per request and never freshness-polls.
- This follows the repository's process-stable Gateway metadata rule: icon changes become visible after Gateway restart, not through hot-path `stat`/`realpath`/reread work.
- Every icon filesystem operation is asynchronous. The prior synchronous descriptor close was replaced; this path contains no `statSync`, `readFileSync`, `existsSync`, or `closeSync`.
- The selected icon bytes and content-derived ETag are read once and cached in the bounded process snapshot. Repeated HTTP requests serve those bytes even if the source file is subsequently removed.

The breadcrumb trail also receives a one-pixel optical lift as a unit, keeping the project icon, labels, and separator aligned with the topbar action glyphs.

## User Impact

Projects with an icon in one of the listed local locations now show their own identity in the chat header. ClawHub resolves `public/favicon.ico`; OpenClaw resolves `ui/public/favicon-32.png`; projects without an icon continue to show the generic folder. No remote icon fetch is introduced.

## Evidence

All screenshots were captured on Testbox from head `6fc0eed28dc` at the same 760×520 viewport. Each image is a tight crop of the rendered chat topbar, including sidebar/search controls for axis comparison.

| Project source | Light | Dark |
| --- | --- | --- |
| ClawHub — `public/favicon.ico` | ![ClawHub icon and aligned breadcrumb in light theme](https://github.com/user-attachments/assets/18e5e84c-c11e-461a-9a9c-c6beece09fca) | ![ClawHub icon and aligned breadcrumb in dark theme](https://github.com/user-attachments/assets/ab0380cb-313c-410f-9c39-9e1ab8799582) |
| OpenClaw — `ui/public/favicon-32.png` | ![OpenClaw icon and aligned breadcrumb in light theme](https://github.com/user-attachments/assets/d6d7efbe-71a5-4a78-9f10-2b7750210977) | ![OpenClaw icon and aligned breadcrumb in dark theme](https://github.com/user-attachments/assets/17a519fa-f8b9-408a-914a-dcbed5083875) |
| No matching icon — folder fallback | ![Folder fallback and aligned breadcrumb in light theme](https://github.com/user-attachments/assets/fa6cc2fa-4df5-4eb3-869d-bc04606f1186) | ![Folder fallback and aligned breadcrumb in dark theme](https://github.com/user-attachments/assets/93a7067c-b4b1-4315-b0bb-a93097702a44) |

Remote focused validation:

```text
node scripts/run-vitest.mjs src/gateway/workspace-icon-http.test.ts
58 passed

node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-header-axis.e2e.test.ts
2 passed (light + dark)

Temporary remote capture harness on the same head
6 passed (three project states × light/dark)
```

The Gateway tests remove the selected file after preparation and confirm that later HTTP requests still serve the original cached bytes without invoking session-root resolution again. They also prove that serving a session refreshes its recency so a 129th insertion evicts the oldest inactive snapshot, not the actively read one. The E2E asserts the action glyph centers and the breadcrumb's one-pixel optical offset in both themes.
