### PR TITLE
fix(update): show tracked status for detached deployments

### DIFF
--- a/src/infra/update-channels.ts
+++ b/src/infra/update-channels.ts
@@ -25,6 +25,14 @@ export const UPDATE_EFFECTIVE_CHANNEL_ENV = "OPENCLAW_UPDATE_EFFECTIVE_CHANNEL";
 /** Git branch that represents the development update stream. */
 export const DEV_BRANCH = "main";
 
+/** Resolves current tracking, or the configured Dev branch for detached HEAD. */
+export function resolveDevUpstreamRef(branch?: string | null, detached = false): string | null {
+  if (branch !== "HEAD") {
+    return "@{upstream}";
+  }
+  return detached ? `${DEV_BRANCH}@{upstream}` : null;
+}
+
 /** Normalizes config or CLI channel input to a supported update channel. */
 export function normalizeUpdateChannel(value?: string | null): UpdateChannel | null {
   const normalized = normalizeOptionalLowercaseString(value);

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -627,6 +627,62 @@ describe("formatGitInstallLabel", () => {
 });
 
 describe("checkUpdateStatus", () => {
+  it("uses the tracked dev branch for detached exact-SHA deployments", async () => {
+    await withTempDir({ prefix: "openclaw-update-check-detached-dev-" }, async (base) => {
+      const sourceRoot = path.join(base, "source");
+      const localRoot = path.join(base, "local");
+      await initGitRepo(sourceRoot);
+      await fs.writeFile(
+        path.join(sourceRoot, "package.json"),
+        JSON.stringify({ name: "openclaw", packageManager: "pnpm@10.0.0" }),
+      );
+      await runGit(sourceRoot, "add", "package.json");
+      await commitGit(sourceRoot, "base");
+      await runGit(base, "clone", "--quiet", sourceRoot, localRoot);
+      const sha = await runGit(localRoot, "rev-parse", "HEAD");
+      const readStatus = () =>
+        checkUpdateStatus({
+          root: localRoot,
+          includeRegistry: false,
+          fetchGit: false,
+          timeoutMs: 5000,
+          useDetachedDevUpstream: true,
+        });
+
+      await expect(readStatus()).resolves.toMatchObject({
+        git: {
+          branch: "main",
+          upstream: "origin/main",
+          upstreamSha: sha,
+          ahead: 0,
+          behind: 0,
+        },
+      });
+
+      await runGit(localRoot, "checkout", "--detach", sha);
+      await expect(readStatus()).resolves.toMatchObject({
+        git: {
+          branch: "HEAD",
+          upstream: "origin/main",
+          upstreamSha: sha,
+          ahead: 0,
+          behind: 0,
+        },
+      });
+
+      await runGit(localRoot, "branch", "--unset-upstream", "main");
+      await expect(readStatus()).resolves.toMatchObject({
+        git: {
+          branch: "HEAD",
+          upstream: null,
+          upstreamSha: null,
+          ahead: null,
+          behind: null,
+        },
+      });
+    });
+  });
+
   it("uses a matching receipt upstream only for the detached installed revision", async () => {
     await withTestDir({ prefix: "openclaw-update-check-receipt-fallback-" }, async (base) => {
       const sourceRoot = path.join(base, "source");

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -627,63 +627,7 @@ describe("formatGitInstallLabel", () => {
 });
 
 describe("checkUpdateStatus", () => {
-  it("uses the tracked dev branch for detached exact-SHA deployments", async () => {
-    await withTestDir({ prefix: "openclaw-update-check-detached-dev-" }, async (base) => {
-      const sourceRoot = path.join(base, "source");
-      const localRoot = path.join(base, "local");
-      await initGitRepo(sourceRoot);
-      await fs.writeFile(
-        path.join(sourceRoot, "package.json"),
-        JSON.stringify({ name: "openclaw", packageManager: "pnpm@10.0.0" }),
-      );
-      await runGit(sourceRoot, "add", "package.json");
-      await commitGit(sourceRoot, "base");
-      await runGit(base, "clone", "--quiet", sourceRoot, localRoot);
-      const sha = await runGit(localRoot, "rev-parse", "HEAD");
-      const readStatus = () =>
-        checkUpdateStatus({
-          root: localRoot,
-          includeRegistry: false,
-          fetchGit: false,
-          timeoutMs: 5000,
-          useDetachedDevUpstream: true,
-        });
-
-      await expect(readStatus()).resolves.toMatchObject({
-        git: {
-          branch: "main",
-          upstream: "origin/main",
-          upstreamSha: sha,
-          ahead: 0,
-          behind: 0,
-        },
-      });
-
-      await runGit(localRoot, "checkout", "--detach", sha);
-      await expect(readStatus()).resolves.toMatchObject({
-        git: {
-          branch: "HEAD",
-          upstream: "origin/main",
-          upstreamSha: sha,
-          ahead: 0,
-          behind: 0,
-        },
-      });
-
-      await runGit(localRoot, "branch", "--unset-upstream", "main");
-      await expect(readStatus()).resolves.toMatchObject({
-        git: {
-          branch: "HEAD",
-          upstream: null,
-          upstreamSha: null,
-          ahead: null,
-          behind: null,
-        },
-      });
-    });
-  });
-
-  it("uses a matching receipt upstream only for the detached installed revision", async () => {
+  it("resolves detached dev tracking before matching update receipts", async () => {
     await withTestDir({ prefix: "openclaw-update-check-receipt-fallback-" }, async (base) => {
       const sourceRoot = path.join(base, "source");
       const localRoot = path.join(base, "local");
@@ -706,8 +650,13 @@ describe("checkUpdateStatus", () => {
           includeRegistry: false,
           fetchGit: params.fetch ?? false,
           timeoutMs: 5000,
+          useDetachedDevUpstream: true,
           ...(params.fallback ? { gitUpstreamFallback: params.fallback } : {}),
         });
+
+      expect((await readStatus()).git?.upstream).toBe("origin/main");
+      await runGit(localRoot, "branch", "--unset-upstream", "main");
+      expect((await readStatus()).git?.upstream).toBeNull();
 
       const current = await readStatus({ fetch: true, fallback });
       expect(current.git).toMatchObject({

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -628,7 +628,7 @@ describe("formatGitInstallLabel", () => {
 
 describe("checkUpdateStatus", () => {
   it("uses the tracked dev branch for detached exact-SHA deployments", async () => {
-    await withTempDir({ prefix: "openclaw-update-check-detached-dev-" }, async (base) => {
+    await withTestDir({ prefix: "openclaw-update-check-detached-dev-" }, async (base) => {
       const sourceRoot = path.join(base, "source");
       const localRoot = path.join(base, "local");
       await initGitRepo(sourceRoot);

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -10,7 +10,7 @@ import {
 } from "./detect-package-manager.js";
 import { compareOpenClawReleaseVersions } from "./npm-registry-spec.js";
 import { compareValidSemver, normalizeLegacyDotBetaVersion } from "./semver.js";
-import { channelToNpmTag, type UpdateChannel } from "./update-channels.js";
+import { channelToNpmTag, resolveDevUpstreamRef, type UpdateChannel } from "./update-channels.js";
 import {
   fetchNpmPackageTargetStatus,
   type NpmMetadataCommandRunner,
@@ -229,6 +229,7 @@ async function checkGitUpdateStatus(params: {
   root: string;
   timeoutMs?: number;
   fetch?: boolean;
+  useDetachedDevUpstream?: boolean;
   upstreamFallback?: { currentSha: string; upstreamRef: string };
 }): Promise<GitUpdateStatus> {
   const timeoutMs = params.timeoutMs ?? 6000;
@@ -248,7 +249,7 @@ async function checkGitUpdateStatus(params: {
     fetchOk: null,
   };
 
-  const [branchRes, shaRes, commitAtRes, tagRes, upstreamRes, dirtyRes] = await Promise.all([
+  const [branchRes, shaRes, commitAtRes, tagRes, dirtyRes] = await Promise.all([
     runCommandWithTimeout(["git", "-C", root, "rev-parse", "--abbrev-ref", "HEAD"], {
       timeoutMs,
     }).catch(() => null),
@@ -259,9 +260,6 @@ async function checkGitUpdateStatus(params: {
       timeoutMs,
     }).catch(() => null),
     runCommandWithTimeout(["git", "-C", root, "describe", "--tags", "--exact-match"], {
-      timeoutMs,
-    }).catch(() => null),
-    runCommandWithTimeout(["git", "-C", root, "rev-parse", "--abbrev-ref", "@{upstream}"], {
       timeoutMs,
     }).catch(() => null),
     runCommandWithTimeout(
@@ -275,6 +273,13 @@ async function checkGitUpdateStatus(params: {
     return { ...base, error: branchRes?.stderr?.trim() || "git unavailable" };
   }
   const branch = branchRes.stdout.trim() || null;
+  const trackingRevision = resolveDevUpstreamRef(branch, params.useDetachedDevUpstream);
+  const upstreamRes = trackingRevision
+    ? await runCommandWithTimeout(
+        ["git", "-C", root, "rev-parse", "--abbrev-ref", "--symbolic-full-name", trackingRevision],
+        { timeoutMs },
+      ).catch(() => null)
+    : null;
 
   const sha = shaRes && shaRes.code === 0 ? shaRes.stdout.trim() : null;
   const commitAtSeconds =
@@ -311,8 +316,7 @@ async function checkGitUpdateStatus(params: {
 
   // Freeze the post-fetch upstream for both graph queries. Active tracking wins;
   // a matching successful update receipt keeps intentional detached installs comparable.
-  const upstreamRevision =
-    upstreamSource === "tracking" ? "@{upstream}^{commit}" : `${upstream}^{commit}`;
+  const upstreamRevision = `${upstreamSource === "tracking" ? trackingRevision : upstream}^{commit}`;
   const upstreamCommitRes =
     canCompareUpstream && upstream && sha
       ? await runCommandWithTimeout(
@@ -608,6 +612,7 @@ export async function checkUpdateStatus(params: {
   root: string | null;
   timeoutMs?: number;
   fetchGit?: boolean;
+  useDetachedDevUpstream?: boolean;
   gitUpstreamFallback?: { currentSha: string; upstreamRef: string };
   includeRegistry?: boolean;
   registryChannel?: UpdateChannel;
@@ -658,6 +663,7 @@ export async function checkUpdateStatus(params: {
           root,
           timeoutMs,
           fetch: Boolean(params.fetchGit),
+          useDetachedDevUpstream: params.useDetachedDevUpstream,
           upstreamFallback: params.gitUpstreamFallback,
         })
       : Promise.resolve(undefined),

--- a/src/infra/update-runner-git-preflight.ts
+++ b/src/infra/update-runner-git-preflight.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { trimLogTail } from "./restart-sentinel.js";
-import { DEV_BRANCH } from "./update-channels.js";
+import { DEV_BRANCH, resolveDevUpstreamRef } from "./update-channels.js";
 import { resolveDevUpdateTargetRevision, type DevUpdateTarget } from "./update-dev-target.js";
 import {
   managerInstallArgs,
@@ -210,9 +210,11 @@ async function resolveUpstreamCandidates(params: {
       );
     }
   }
-  const upstreamRefs = params.needsCheckoutMain
-    ? [`${DEV_BRANCH}@{upstream}`, ...remoteBranchRefs]
-    : ["@{upstream}"];
+  const trackingRevision = resolveDevUpstreamRef(
+    params.needsCheckoutMain ? "HEAD" : DEV_BRANCH,
+    true,
+  );
+  const upstreamRefs = [...(trackingRevision ? [trackingRevision] : []), ...remoteBranchRefs];
   let upstreamSha: string | null = null;
   let selectedDevUpstream: string | null = null;
   let sawResolvableUpstreamRef = false;

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -1097,6 +1097,7 @@ describe("update-startup", () => {
       timeoutMs: 2500,
       fetchGit: true,
       includeRegistry: false,
+      useDetachedDevUpstream: true,
     });
     expect(resolveNpmChannelTag).not.toHaveBeenCalled();
     expect(getUpdateAvailable()).toEqual({
@@ -1214,6 +1215,32 @@ describe("update-startup", () => {
     });
   });
 
+  it("continues managed dev campaigns from a detached tracked deployment", async () => {
+    mockDevGitStatus({ branch: "HEAD", upstreamSource: "tracking" });
+    const runAutoUpdate = createAutoUpdateSuccessMock();
+
+    await runGatewayUpdateCheck({
+      cfg: { update: { channel: "dev", auto: { enabled: true } } },
+      log: { info: vi.fn() },
+      isNixMode: false,
+      allowInTests: true,
+      activeWorkInspectors: idleActiveWorkInspectors(),
+      runAutoUpdate,
+    });
+
+    expect(getUpdateSchedule()?.campaign?.state).toBe("countdown");
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(runAutoUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        devTarget: {
+          mode: "tracked",
+          upstreamRef: "origin/main",
+          upstreamSha: "upstream-sha",
+        },
+      }),
+    );
+  });
+
   it.each([
     { name: "successful install", status: "ok", reason: undefined },
     {
@@ -1256,6 +1283,7 @@ describe("update-startup", () => {
       timeoutMs: 2500,
       fetchGit: true,
       includeRegistry: false,
+      useDetachedDevUpstream: true,
       gitUpstreamFallback: { currentSha: "current-sha", upstreamRef: "origin/main" },
     });
     expect(getUpdateSchedule()?.campaign?.state).toBe("countdown");
@@ -1275,7 +1303,10 @@ describe("update-startup", () => {
     { name: "ahead", git: { ahead: 1, behind: 0 } },
     { name: "diverged", git: { ahead: 1, behind: 2 } },
     { name: "non-main", git: { branch: "feature" } },
-    { name: "detached", git: { branch: "HEAD" } },
+    {
+      name: "detached without tracking",
+      git: { branch: "HEAD", upstream: null, upstreamSha: null, ahead: null, behind: null },
+    },
   ])("does not announce an automatic dev campaign for a $name checkout", async ({ git }) => {
     mockDevGitStatus(git);
     const runAutoUpdate = createAutoUpdateSuccessMock();

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -567,7 +567,7 @@ function clearAutoState(nextState: UpdateCheckState): void {
   delete nextState.autoFirstSeenAt;
 }
 
-async function resolveStartupInstallStatus(fetchGit: boolean) {
+async function resolveStartupInstallStatus(checkDevGit: boolean) {
   const [root, installReceipt] = await Promise.all([
     resolveOpenClawPackageRoot({
       moduleUrl: import.meta.url,
@@ -583,8 +583,9 @@ async function resolveStartupInstallStatus(fetchGit: boolean) {
   const status = await checkUpdateStatus({
     root,
     timeoutMs: 2500,
-    fetchGit,
+    fetchGit: checkDevGit,
     includeRegistry: false,
+    ...(checkDevGit ? { useDetachedDevUpstream: true } : {}),
     ...(gitUpstreamFallback ? { gitUpstreamFallback } : {}),
   });
   return { root, status, installReceipt };
@@ -1121,10 +1122,11 @@ export async function runGatewayUpdateCheck(params: {
         reason: EXTERNAL_SUPERVISOR_UPDATE_REQUIRED_REASON,
       });
     }
-    const hasTrackedMain = git.branch === DEV_BRANCH && git.upstreamSource === "tracking";
+    const hasTrackedDevUpstream =
+      (git.branch === DEV_BRANCH || git.branch === "HEAD") && git.upstreamSource === "tracking";
     const hasReceiptBackedDetachedHead = git.branch === "HEAD" && git.upstreamSource === "receipt";
     const canRunTrackedDevCampaign =
-      (hasTrackedMain || hasReceiptBackedDetachedHead) && git.ahead === 0;
+      (hasTrackedDevUpstream || hasReceiptBackedDetachedHead) && git.ahead === 0;
     if (shouldRunAutoUpdate && canRunTrackedDevCampaign) {
       const lastAttemptAt = state.autoLastAttemptAt ? Date.parse(state.autoLastAttemptAt) : null;
       const recentAttempt =


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where managed Dev deployments intentionally running an exact detached SHA showed update status as unavailable even though the local `main` branch had a valid configured upstream. On the live Team deployment before this change, HEAD was detached at `24bbb416b559e2d4a1aec13e0faffdf7e4ea4f9c`, `branch.main` tracked `origin/main`, but `update.status` returned `no-upstream` and the UI showed “No tracked upstream is configured.”

## Why This Change Was Made

Detached managed deployments now resolve the named Dev branch’s `main@{upstream}` through one shared policy used by both update status and the actual updater preflight. Automatic campaigns continue toward the announced pinned SHA; arbitrary detached checkouts without valid `main` tracking still fail closed, and attached-branch behavior is unchanged.

## User Impact

Operators of managed Dev deployments can see tracked update status and continue automatic pinned-SHA campaigns while the running checkout remains intentionally detached. A detached checkout gains this path only when its named local `main` has a valid configured upstream; without that tracking it remains unavailable and cannot start a campaign.

## Evidence

- Focused regression proof: `node scripts/run-vitest.mjs src/infra/update-check.test.ts src/infra/update-startup.test.ts` — 114 tests passed.
- Formatting: `oxfmt --check` passed for all six changed files.
- Patch hygiene: `git diff --check` passed.
- Autoreview: clean, with no accepted or actionable findings.
- Live before-deployment evidence: detached HEAD `24bbb416b559e2d4a1aec13e0faffdf7e4ea4f9c`; `branch.main` tracked `origin/main`; status reason was `no-upstream`; UI showed “No tracked upstream is configured.”
- Live after-deployment UI proof is pending; this PR does not deploy production.
- AI-assisted: yes. Implementation and review were agent-assisted without publishing private runtime identifiers.
