### PR TITLE
docs(qqbot): point install docs at the Tencent package

### DIFF
--- a/docs/channels/qqbot.md
+++ b/docs/channels/qqbot.md
@@ -19,7 +19,7 @@ Status: official downloadable plugin.
 ## Install
 
 ```bash
-openclaw plugins install @openclaw/qqbot
+openclaw plugins install @tencent-connect/openclaw-qqbot
 ```
 
 ## Setup

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -298,7 +298,7 @@ Each entry lists the package, distribution route, and description.
 
 - **[qianfan](/plugins/reference/qianfan)** (`@openclaw/qianfan-provider`) - npm; ClawHub: `clawhub:@openclaw/qianfan-provider`. Adds Qianfan model provider support to OpenClaw.
 
-- **[qqbot](/plugins/reference/qqbot)** (`@openclaw/qqbot`) - npm; ClawHub. OpenClaw QQ Bot channel plugin for group and direct-message workflows.
+- **[qqbot](/plugins/reference/qqbot)** (`@tencent-connect/openclaw-qqbot`) - npm. OpenClaw QQ Bot channel plugin for group and direct-message workflows.
 
 - **[qwen](/plugins/reference/qwen)** (`@openclaw/qwen-provider`) - npm; ClawHub: `clawhub:@openclaw/qwen-provider`. Adds Qwen, Qwen Cloud, Model Studio, DashScope, Qwen Token Plan, Bailian Token Plan model provider support to OpenClaw.
 

--- a/docs/plugins/reference/qqbot.md
+++ b/docs/plugins/reference/qqbot.md
@@ -11,8 +11,8 @@ OpenClaw QQ Bot channel plugin for group and direct-message workflows.
 
 ## Distribution
 
-- Package: `@openclaw/qqbot`
-- Install route: npm; ClawHub
+- Package: `@tencent-connect/openclaw-qqbot`
+- Install route: npm
 
 ## Surface
 

--- a/scripts/lib/official-external-channel-seed.json
+++ b/scripts/lib/official-external-channel-seed.json
@@ -123,15 +123,15 @@
           "docsSource": "official",
           "docsInventory": {
             "package": {
-              "name": "@openclaw/qqbot",
-              "description": "OpenClaw QQ Bot channel plugin for group and direct-message workflows.",
+              "name": "@tencent-connect/openclaw-qqbot",
+              "description": "OpenClaw QQ Bot channel plugin by the Tencent Connect team.",
               "openclaw": {
                 "install": {
-                  "npmSpec": "@openclaw/qqbot",
+                  "npmSpec": "@tencent-connect/openclaw-qqbot",
                   "defaultChoice": "npm"
                 },
                 "release": {
-                  "publishToClawHub": true,
+                  "publishToClawHub": false,
                   "publishToNpm": true
                 }
               }


### PR DESCRIPTION
## What Problem This Solves

After #107295 externalized QQBot to `@tencent-connect/openclaw-qqbot`, the user-facing install docs still advertised the retired `@openclaw/qqbot` npm package: the `docs/channels/qqbot.md` install command and the generated plugin reference/inventory pages (driven by the docs-inventory seed block that kept the old package metadata).

## Why This Change Was Made

A user following the documented `openclaw plugins install @openclaw/qqbot` would install the stale monorepo-published package instead of Tencent Connect's maintained one, while `openclaw channels add qqbot` (catalog-driven) installs the correct package. Docs and catalog now agree.

## User Impact

Docs-only: the channel page install command and generated reference/inventory pages now name `@tencent-connect/openclaw-qqbot` with the npm-only install route. No runtime behavior changes; the official external channel catalog output is byte-identical.

AI-assisted: yes.

## Evidence

- `node scripts/write-official-channel-catalog.mjs --check` passes and the committed catalog is unchanged by regeneration.
- `node --import tsx scripts/generate-plugin-inventory-doc.mts --check` passes; reference/inventory pages regenerated from the corrected seed.
- `pnpm docs:check-links`: 6444 internal links, 0 broken.
- `git diff --check` clean.
