### PR TITLE
fix(release): stamp correction version into docker images (#121958)

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -172,6 +172,7 @@ jobs:
     outputs:
       built_at: ${{ steps.build_provenance.outputs.built_at }}
       source_sha: ${{ steps.build_provenance.outputs.source_sha }}
+      version: ${{ needs.resolve_release_policy.outputs.version }}
     steps:
       - name: Checkout selected source
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -323,6 +324,7 @@ jobs:
           build-args: |
             GIT_COMMIT=${{ needs.resolve_build_provenance.outputs.source_sha }}
             OPENCLAW_BUILD_TIMESTAMP=${{ needs.resolve_build_provenance.outputs.built_at }}
+            OPENCLAW_RELEASE_VERSION=${{ needs.resolve_build_provenance.outputs.version }}
             OPENCLAW_EXTENSIONS=diagnostics-otel,codex
           tags: ${{ steps.tags.outputs.value }}
           labels: ${{ steps.labels.outputs.value }}
@@ -345,6 +347,7 @@ jobs:
           build-args: |
             GIT_COMMIT=${{ needs.resolve_build_provenance.outputs.source_sha }}
             OPENCLAW_BUILD_TIMESTAMP=${{ needs.resolve_build_provenance.outputs.built_at }}
+            OPENCLAW_RELEASE_VERSION=${{ needs.resolve_build_provenance.outputs.version }}
             OPENCLAW_EXTENSIONS=diagnostics-otel,codex
             OPENCLAW_INSTALL_BROWSER=1
           tags: ${{ steps.tags.outputs.browser }}
@@ -531,6 +534,7 @@ jobs:
           build-args: |
             GIT_COMMIT=${{ needs.resolve_build_provenance.outputs.source_sha }}
             OPENCLAW_BUILD_TIMESTAMP=${{ needs.resolve_build_provenance.outputs.built_at }}
+            OPENCLAW_RELEASE_VERSION=${{ needs.resolve_build_provenance.outputs.version }}
             OPENCLAW_EXTENSIONS=diagnostics-otel,codex
           tags: ${{ steps.tags.outputs.value }}
           labels: ${{ steps.labels.outputs.value }}
@@ -553,6 +557,7 @@ jobs:
           build-args: |
             GIT_COMMIT=${{ needs.resolve_build_provenance.outputs.source_sha }}
             OPENCLAW_BUILD_TIMESTAMP=${{ needs.resolve_build_provenance.outputs.built_at }}
+            OPENCLAW_RELEASE_VERSION=${{ needs.resolve_build_provenance.outputs.version }}
             OPENCLAW_EXTENSIONS=diagnostics-otel,codex
             OPENCLAW_INSTALL_BROWSER=1
           tags: ${{ steps.tags.outputs.browser }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,10 +116,25 @@ RUN set -eux; \
 # these after the dependency layer so a new timestamp does not invalidate install.
 ARG GIT_COMMIT=""
 ARG OPENCLAW_BUILD_TIMESTAMP=""
+# Resolved release version supplied by release automation. Correction-release
+# sources carry the base version in package.json (e.g. `2026.7.1`); stamping
+# the resolved correction version (e.g. `2026.7.1-2`) here makes the runtime
+# image's package.json and dist/build-info.json agree with the image tag and
+# the npm dist-tag, mirroring what the npm publish path already does.
+ARG OPENCLAW_RELEASE_VERSION=""
 ENV GIT_COMMIT=${GIT_COMMIT} \
-    OPENCLAW_BUILD_TIMESTAMP=${OPENCLAW_BUILD_TIMESTAMP}
+    OPENCLAW_BUILD_TIMESTAMP=${OPENCLAW_BUILD_TIMESTAMP} \
+    OPENCLAW_RELEASE_VERSION=${OPENCLAW_RELEASE_VERSION}
 
 COPY . .
+
+# Stamp the resolved release version into package.json before the build runs so
+# the runtime image's verbatim package.json copy and the build-info manifest
+# both carry the full correction version. A no-op for non-release builds where
+# OPENCLAW_RELEASE_VERSION is empty.
+RUN if [ -n "$OPENCLAW_RELEASE_VERSION" ]; then \
+      node -e "const fs=require('fs');const path='package.json';const pkg=JSON.parse(fs.readFileSync(path,'utf8'));if(pkg.version!==process.env.OPENCLAW_RELEASE_VERSION){pkg.version=process.env.OPENCLAW_RELEASE_VERSION;fs.writeFileSync(path,JSON.stringify(pkg,null,2)+'\n');}"; \
+    fi
 
 # The build stage also backs non-root live-test containers. Build contexts preserve
 # host modes, so normalize copied source readability without re-walking installed deps.


### PR DESCRIPTION
Fixes #121958

## What Problem This Solves

Correction-release container images (any tag of the form `YYYY.M.PATCH-N`) embed the **base version** in `/app/package.json`, so they under-report their version and the Control UI shows a permanent "update available" banner offering the release the image is already running.

**Root cause:** correction-release sources deliberately carry the base version (e.g. `2026.7.1`) in `package.json` (`scripts/release-version.ts`, `stable-release-closeout.mjs` `fallbackCorrection`). The npm publish path applies the resolved correction version before packing, but the Docker path copies `package.json` verbatim and `write-build-info.ts` reads the version only from `package.json`. `docker-release.yml` tolerates the tag/`package.json` mismatch (`v${package_version}-[1-9][0-9]*`), so nothing reconciles the two artifacts despite sharing a source commit.

**Fix (sole canonical version source = the Dockerfile stamp):**
- `docker-release.yml`: `resolve_build_provenance` now exposes the resolved release version (from `resolve_release_policy`, which is the full tag-derived version including the correction suffix) and all four `build-args` blocks (amd64/arm64 × default/browser) pass it through as `OPENCLAW_RELEASE_VERSION`.
- `Dockerfile`: build stage gains `ARG/ENV OPENCLAW_RELEASE_VERSION` and a RUN step (after `COPY . .`, before the build) that stamps the resolved version into `package.json`. The runtime image's verbatim `package.json` copy and `dist/build-info.json` (written by `write-build-info.ts` from `package.json`) both carry the full correction version. No-op when the arg is empty, so `main`/non-release builds are unaffected.

The Dockerfile stamp is the sole canonical version source; `build-info.json` inherits it via `write-build-info.ts` reading `package.json`, avoiding a second version source. `src/version.ts` confirms the CLI `--version` fast path reads `package.json` before falling back to `build-info.json`, so a stamped `package.json` makes `--version` correct too.

## Evidence

### 1. CI checks (post-amend)
- `check` / `preflight` / `build-artifacts` / `check-arm`: SUCCESS
- `actionlint`, `security-fast`, `security-sensitive-guard`, `dependency-guard`: SUCCESS
- `checks-fast-*` contracts, `check-prod-types`, `check-test-types`: SUCCESS
- `src/dockerfile.test.ts` (the test this PR initially broke by mentioning `pnpm build:docker` in a comment): now passing — `sourceCopy < readability < build` ordering verified (`indexOf("pnpm build:docker")` resolves to the real build RUN, not a comment).

### 2. Real behavior proof: stamp -> package.json -> build-info.json agree

Reproduced the correction-release flow with the **real** `scripts/write-build-info.ts` (upstream `main` version, no env override) and the **real** Dockerfile stamp RUN, simulating a correction-release source whose `package.json` carries the base version:

```text
$ cat package.json
{ "name": "openclaw", "version": "2026.7.1" }   # base version, as correction-release sources carry

$ OPENCLAW_RELEASE_VERSION=2026.7.1-2 node -e '<stamp RUN inline>'
(stamps package.json version -> OPENCLAW_RELEASE_VERSION)

$ cat package.json
{
  "name": "openclaw",
  "version": "2026.7.1-2"                        # <- stamped to the full correction version
}

$ tsx scripts/write-build-info.ts                # real upstream write-build-info.ts
$ cat dist/build-info.json
{
  "version": "2026.7.1-2",                       # <- inherits stamped package.json version
  "commit": null,
  "builtAt": "2026-08-12T16:16:48.881Z"
}
```

Three version sources agree on `2026.7.1-2`:

| Source | Before fix | After fix |
|---|---|---|
| `/app/package.json` (runtime image) | `2026.7.1` | `2026.7.1-2` |
| `/app/dist/build-info.json` | `2026.7.1` | `2026.7.1-2` |
| `node openclaw.mjs --version` | `2026.7.1` | `2026.7.1-2` |

The CLI row follows from `src/version.ts` (`PACKAGE_JSON_CANDIDATES` before `BUILD_INFO_CANDIDATES`) and the issue's own construction proof: *"Confirmed by construction: stamping `2026.7.1-2` into `/app/package.json` ... makes `--version` report `2026.7.1-2`."*

### 3. No-op for non-release builds

When `OPENCLAW_RELEASE_VERSION` is empty (main branch / local builds), the stamp RUN is a no-op and `package.json` keeps its source version — verified by the same RUN logic (`if [ -n "$OPENCLAW_RELEASE_VERSION" ]` guard).

### Verification limits

Docker image builds cannot be run in this environment: external registries (docker.io, ghcr.io) are network-blocked, and the only reachable node image (`node:22/24-bookworm-slim`) aborts inside the container with `uv_thread_create`/worker-thread assertion on this host kernel. The behavior proof above was therefore produced with the real stamp RUN and real `write-build-info.ts` on the host Node runtime. `src/dockerfile.test.ts` covers the in-image ordering invariant on CI.

## Note

A separate observation in the issue (`build-info.json` has `"commit": null` in official images) is not addressed here; this PR is scoped to the version-stamping defect.
