### PR TITLE
fix(deps): bump @openclaw/fs-safe to 0.5.5 for win32 zero-inode identity

### DIFF
--- a/extensions/onepassword/package.json
+++ b/extensions/onepassword/package.json
@@ -5,7 +5,7 @@
   "description": "1Password SecretRef resolver and audited agent secrets broker for OpenClaw",
   "type": "module",
   "dependencies": {
-    "@openclaw/fs-safe": "0.5.4",
+    "@openclaw/fs-safe": "0.5.5",
     "execa": "10.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2026,7 +2026,7 @@
     "@modelcontextprotocol/sdk": "1.30.0",
     "@mozilla/readability": "0.6.0",
     "@openclaw/ai": "workspace:*",
-    "@openclaw/fs-safe": "0.5.4",
+    "@openclaw/fs-safe": "0.5.5",
     "@openclaw/proxyline": "0.3.4",
     "@silvia-odwyer/photon-node": "0.3.4",
     "@trycua/cua-driver": "0.14.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,8 +89,8 @@ importers:
         specifier: workspace:*
         version: link:packages/ai
       '@openclaw/fs-safe':
-        specifier: 0.5.4
-        version: 0.5.4
+        specifier: 0.5.5
+        version: 0.5.5
       '@openclaw/proxyline':
         specifier: 0.3.4
         version: 0.3.4(undici@8.9.0)
@@ -1487,8 +1487,8 @@ importers:
   extensions/onepassword:
     dependencies:
       '@openclaw/fs-safe':
-        specifier: 0.5.4
-        version: 0.5.4
+        specifier: 0.5.5
+        version: 0.5.5
       execa:
         specifier: 10.0.0
         version: 10.0.0
@@ -2619,6 +2619,9 @@ packages:
   '@aws-sdk/core@3.977.1':
     resolution: {integrity: sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==}
     engines: {node: '>=20.0.0'}
+    deprecated: |-
+      Deprecated due to Document number parsing bug in JSON, see
+        https://github.com/aws/aws-sdk-js-v3/issues/8246. Newer version available.
 
   '@aws-sdk/credential-provider-cognito-identity@3.972.60':
     resolution: {integrity: sha512-16Fxa3veKIO6nHJr+vN76z3BkSU7725lzruc5S2SQSTUTbK4TXtmi8033WQljZj4k1+383UsMaNOHN6B76fK5A==}
@@ -4135,8 +4138,8 @@ packages:
     engines: {node: '>=22'}
     hasBin: true
 
-  '@openclaw/fs-safe@0.5.4':
-    resolution: {integrity: sha512-lttlWKRBQU7eYDYykU2BPoF1S6AESGrT77mVCXsuWBxnRBTAI/PuGB89DB3D1lBCDaqTykIjymPJz4pFesGnkg==}
+  '@openclaw/fs-safe@0.5.5':
+    resolution: {integrity: sha512-x8wYigrOwmnsE8v4LfAh2eTvvkuDMspBrQeBp/GyB9/c7eFf8aL7gK4keewDbhscKX1pACD8Yd+ehZq6o29xHw==}
     engines: {node: '>=22'}
 
   '@openclaw/libterminal@0.3.2':
@@ -6279,6 +6282,7 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   css-functions-list@3.3.3:
     resolution: {integrity: sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==}
@@ -11426,7 +11430,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@openclaw/fs-safe@0.5.4':
+  '@openclaw/fs-safe@0.5.5':
     optionalDependencies:
       jszip: 3.10.1
       tar: 7.5.22

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ minimumReleaseAge: 2880
 
 minimumReleaseAgeExclude:
   - "@openclaw/crabline@0.1.11"
-  - "@openclaw/fs-safe@0.5.4"
+  - "@openclaw/fs-safe@0.5.5"
   - "@openclaw/libterminal@0.3.2"
   - "@openclaw/proxyline@0.3.4"
   - "@openclaw/uirouter@0.1.1"


### PR DESCRIPTION
## What Problem This Solves

`@openclaw/fs-safe` 0.5.4 (bumped in #121508) added `verifyStableReadTarget`, which compares path-based `lstat` identity against fd-based `stat` identity. On Windows, libuv's path-stat falls back to `FindFirstFile` data when the file cannot be opened for stat (antivirus/indexer contention) and reports `ino=0`/`dev=0`; fs-safe exempted zero `dev` but not zero `ino`, so legitimate reads nondeterministically failed with `FsSafeError("path-mismatch")`. In CI this surfaced as flaky `checks-windows-node-test` failures in `src/media/local-media-path.windows.test.ts > ingests an uppercase file URL into managed outgoing media` (sanitized as `ManagedImageAttachmentError`), first red on main at a0ad38e71ab727 right after the 0.5.4 bump.

## Why This Change Was Made

The fix belongs upstream and shipped as fs-safe 0.5.5 (openclaw/fs-safe#129): zero win32 inodes are now treated as unknown identity, mirroring the accepted zero-device rule. This PR bumps the pin (root + onepassword plugin + minimumReleaseAgeExclude) so the Windows lane stops flaking.

## User Impact

Windows gateway hosts and CI no longer hit spurious "File changed during read" failures on managed media reads under antivirus/indexer contention.

## Evidence

- Upstream fix: https://github.com/openclaw/fs-safe/pull/129 (merged ee747c56), released as `v0.5.5` (npm `@openclaw/fs-safe@0.5.5`, dist-tag latest, published 2026-08-12T04:16Z; release CI fully green incl. both Windows lanes and an identity-swap regression matrix).
- Local: `pnpm install` passes supply-chain/minimum-release-age policy with zero `fs-safe@0.5.4` lockfile refs; installed dist contains the new identity guard; `node scripts/run-vitest.mjs src/infra/fs-safe-remove.test.ts` passes.
- The affected test self-skips on macOS; `checks-windows-node-test` on this PR's CI is the changed-surface proof.
