### PR TITLE
fix(packaging): hoist mdast-util-from-markdown for bundled memory-wiki plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -2052,6 +2052,7 @@
     "jszip": "3.10.1",
     "kysely": "0.29.4",
     "linkedom": "0.18.13",
+    "mdast-util-from-markdown": "2.0.3",
     "minimatch": "10.2.5",
     "ms": "2.1.3",
     "node-edge-tts": "1.2.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       linkedom:
         specifier: 0.18.13
         version: 0.18.13
+      mdast-util-from-markdown:
+        specifier: 2.0.3
+        version: 2.0.3(supports-color@10.2.2)
       minimatch:
         specifier: 10.2.5
         version: 10.2.5
@@ -8309,10 +8312,6 @@ packages:
   qoa-format@1.0.1:
     resolution: {integrity: sha512-dMB0Z6XQjdpz/Cw4Rf6RiBpQvUSPCfYlQMWvmuWlWkAT7nDQD29cVZ1SwDUB6DYJSitHENwbt90lqfI+7bvMcw==}
 
-  qrcode-terminal@0.12.0:
-    resolution: {integrity: sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==}
-    hasBin: true
-
   qrcode@1.5.4:
     resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
     engines: {node: '>=10.13.0'}
@@ -8600,10 +8599,6 @@ packages:
   sigstore@5.0.0:
     resolution: {integrity: sha512-hJqJfoG/e4qFQaauQL00c6J6FrHLBGKtkFvW3JbTSIEFOhLrSjdSM/gWd/yUOfYo/gsERehTXGC1VZWX+9X4Dg==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
-
-  silk-wasm@3.7.1:
-    resolution: {integrity: sha512-mXPwLRtZxrYV3TZx41jMAeKc80wvmyrcXIcs8HctFxK15Ahz2OJQENYhNgEPeCEOdI6Mbx1NxQsqxzwc3DKerw==}
-    engines: {node: '>=16.11.0'}
 
   simple-git@3.36.0:
     resolution: {integrity: sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==}
@@ -15818,8 +15813,6 @@ snapshots:
     dependencies:
       '@thi.ng/bitstream': 2.4.54
 
-  qrcode-terminal@0.12.0: {}
-
   qrcode@1.5.4:
     dependencies:
       dijkstrajs: 1.0.3
@@ -16215,8 +16208,6 @@ snapshots:
     transitivePeerDependencies:
       - kerberos
       - supports-color
-
-  silk-wasm@3.7.1: {}
 
   simple-git@3.36.0(supports-color@10.2.2):
     dependencies:


### PR DESCRIPTION
## What Problem This Solves

The bundled Memory Wiki plugin (`extensions/memory-wiki`) declares `mdast-util-from-markdown: 2.0.3` in its manifest and imports `fromMarkdown` at runtime (`extensions/memory-wiki/src/markdown.ts:4`), but the root OpenClaw package manifest omits that dependency. The post-install step prunes plugin-local `node_modules` (`scripts/postinstall-bundled-plugins.mjs`), so on a clean official npm install the plugin's declared runtime dependency is never resolvable from the bundled plugin root. The documented Memory Wiki path (`docs/cli/wiki.md`) therefore fails to load its required module after installation.

## Why

Every other declared runtime dependency of the bundled memory-wiki plugin (`p-map`, `typebox`, `yaml`, `zod`) is already hoisted into the root manifest; `mdast-util-from-markdown` is the sole omission. Because bundled plugin dependencies must resolve from the root (plugin-local `node_modules` is pruned at post-install), the correct repair is to declare the dependency at the root so it is hoisted and resolvable from `dist/extensions/memory-wiki/` — matching how every other bundled plugin dependency is staged.

## User Impact

Users who install the official `openclaw` npm package and enable the bundled Memory Wiki plugin no longer hit an unresolved `mdast-util-from-markdown` module error. The documented Memory Wiki workflow works from a clean install without manual package patching or core modification.

## Evidence

`pnpm install --lockfile-only --no-frozen-lockfile` now records `mdast-util-from-markdown` under the root importer; the dependency is hoisted to root `node_modules` and resolves from the memory-wiki plugin root at version 2.0.3:

```text
$ node -e "const p=require('path');const r=require.resolve('mdast-util-from-markdown',{paths:[p.join(process.cwd(),'extensions/memory-wiki')]});console.log('resolved from memory-wiki root:',r);const fs=require('fs');const pkg=JSON.parse(fs.readFileSync(p.join(p.dirname(r),'package.json'),'utf8'));console.log('installed version:',pkg.version);const {fromMarkdown}=require('mdast-util-from-markdown');const tree=fromMarkdown('# Hello\n\nSome **bold** text.');console.log('parse ok, first heading text:',tree.children[0].children.map(c=>c.value).join(''));"
resolved from memory-wiki root: /home/0668001400/AI/code/openclaw/node_modules/mdast-util-from-markdown/index.js
installed version: 2.0.3
parse ok, first heading text: Hello
```

Acceptance test suites from the issue's ClawSweeper review all pass on this change:

```text
$ pnpm exec vitest run test/release-check.test.ts
 ✓  tooling  ../release-check.test.ts (61 tests) 403ms
 Test Files  1 passed (1)
      Tests  61 passed (61)

$ pnpm exec vitest run test/openclaw-npm-postpublish-verify.test.ts
 ✓  tooling  ../openclaw-npm-postpublish-verify.test.ts (51 tests) 3439ms
 Test Files  1 passed (1)
      Tests  51 passed (51)

$ pnpm exec vitest run src/plugins/contracts/extension-runtime-dependencies.contract.test.ts
 ✓  contracts-plugin  ../../src/plugins/contracts/extension-runtime-dependencies.contract.test.ts (451 tests) 5972ms
 Test Files  1 passed (1)
      Tests  451 passed (451)
```

`pnpm install` also pruned two orphaned lockfile entries (`qrcode-terminal@0.12.0`, `silk-wasm@3.7.1`) that no manifest references and no snapshot depends on.

[AI-assisted] — generated by an automated issue-hunter agent; fix implemented and verified against the acceptance criteria in #122357.