### PR TITLE
fix(worker): keep source bundles npm-installable

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -101,10 +101,12 @@
     "@anthropic-ai/sdk": "0.115.0",
     "@google/genai": "2.13.0",
     "@mistralai/mistralai": "2.5.0",
-    "@openclaw/normalization-core": "workspace:*",
     "openai": "6.49.0",
     "partial-json": "0.1.7",
     "typebox": "1.3.6"
+  },
+  "devDependencies": {
+    "@openclaw/normalization-core": "workspace:*"
   },
   "engines": {
     "node": ">=22.19.0"

--- a/packages/ai/src/package-dependencies.test.ts
+++ b/packages/ai/src/package-dependencies.test.ts
@@ -44,7 +44,7 @@ async function productionImportsPackage(packageName: string): Promise<boolean> {
 }
 
 describe("@openclaw/ai source dependency contract", () => {
-  it("declares normalization-core while production source imports it", async () => {
+  it("declares bundled normalization-core imports as a workspace dev dependency", async () => {
     const manifest = JSON.parse(
       await fs.readFile(path.join(PACKAGE_ROOT, "package.json"), "utf8"),
     ) as {
@@ -53,6 +53,7 @@ describe("@openclaw/ai source dependency contract", () => {
     };
 
     expect(await productionImportsPackage("@openclaw/normalization-core")).toBe(true);
-    expect(manifest.dependencies?.["@openclaw/normalization-core"]).toBe("workspace:*");
+    expect(manifest.dependencies?.["@openclaw/normalization-core"]).toBeUndefined();
+    expect(manifest.devDependencies?.["@openclaw/normalization-core"]).toBe("workspace:*");
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2167,9 +2167,6 @@ importers:
       '@mistralai/mistralai':
         specifier: 2.5.0
         version: 2.5.0(@opentelemetry/api@1.9.1)
-      '@openclaw/normalization-core':
-        specifier: workspace:*
-        version: link:../normalization-core
       openai:
         specifier: 6.49.0
         version: 6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/hash-node@4.4.14)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3)
@@ -2179,6 +2176,10 @@ importers:
       typebox:
         specifier: 1.3.6
         version: 1.3.6
+    devDependencies:
+      '@openclaw/normalization-core':
+        specifier: workspace:*
+        version: link:../normalization-core
 
   packages/gateway-client:
     dependencies:

--- a/src/gateway/worker-environments/bundle.test.ts
+++ b/src/gateway/worker-environments/bundle.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import * as tar from "tar";
 import { describe, expect, it, vi } from "vitest";
+import { runCommandWithTimeout } from "../../process/exec.js";
 import { withTestDir } from "../../test-helpers/temp-dir.js";
 import {
   createWorkerBundleProducer,
@@ -225,6 +226,76 @@ describe("worker bundle producer", () => {
       expect(vendored.dependencies).toEqual({ "partial-json": "0.1.7" });
       expect(vendored).not.toHaveProperty("scripts");
       expect(vendored).not.toHaveProperty("devDependencies");
+    });
+  });
+
+  it("installs a source bundle when the AI workspace import is bundled", async () => {
+    await withTestDir({ prefix: "openclaw-worker-bundle-npm-install-" }, async (root) => {
+      const repoRoot = path.resolve(import.meta.dirname, "../../..");
+      const aiManifest = JSON.parse(
+        await fs.readFile(path.join(repoRoot, "packages/ai/package.json"), "utf8"),
+      ) as {
+        dependencies?: Record<string, string>;
+        devDependencies?: Record<string, string>;
+      };
+      const dependencyFields = (["dependencies", "devDependencies"] as const).filter(
+        (field) => aiManifest[field]?.["@openclaw/normalization-core"] !== undefined,
+      );
+      if (dependencyFields.length !== 1) {
+        throw new Error(
+          "@openclaw/ai must classify normalization-core in exactly one dependency field",
+        );
+      }
+      const dependencyField = dependencyFields[0]!;
+      const normalizationCoreSpec = aiManifest[dependencyField]?.["@openclaw/normalization-core"];
+      if (!normalizationCoreSpec?.startsWith("workspace:")) {
+        throw new Error("@openclaw/ai must use a workspace normalization-core dependency");
+      }
+      const packageRoot = path.join(root, "package");
+      await writeFixture(packageRoot, [["dist/entry.js", 'import "@openclaw/ai";\nexport {};\n']]);
+      await fs.writeFile(
+        path.join(packageRoot, "package.json"),
+        `${JSON.stringify({
+          name: "openclaw",
+          version: "1.2.3",
+          type: "module",
+          files: ["dist/"],
+          dependencies: { "@openclaw/ai": "workspace:*" },
+        })}\n`,
+        "utf8",
+      );
+      const vendorSource = path.join(packageRoot, "node_modules/@openclaw/ai");
+      await fs.mkdir(path.join(vendorSource, "dist"), { recursive: true });
+      await fs.writeFile(
+        path.join(vendorSource, "package.json"),
+        `${JSON.stringify({
+          name: "@openclaw/ai",
+          version: "1.2.3",
+          type: "module",
+          main: "./dist/index.js",
+          [dependencyField]: { "@openclaw/normalization-core": normalizationCoreSpec },
+        })}\n`,
+        "utf8",
+      );
+      await fs.writeFile(path.join(vendorSource, "dist/index.js"), "export {};\n", "utf8");
+
+      const bundle = await createWorkerBundleProducer({
+        packageRoot,
+        cacheDir: path.join(root, "cache"),
+      }).prepare();
+      const extractRoot = path.join(root, "extract");
+      await fs.mkdir(extractRoot);
+      await tar.extract({ file: bundle.tarballPath, cwd: extractRoot });
+
+      const install = await runCommandWithTimeout(
+        ["npm", "install", "--ignore-scripts", "--omit=dev", "--no-audit", "--no-fund"],
+        {
+          cwd: extractRoot,
+          env: { NPM_CONFIG_CACHE: path.join(root, "npm-cache") },
+          timeoutMs: 30_000,
+        },
+      );
+      expect(install.code, install.stderr).toBe(0);
     });
   });
 


### PR DESCRIPTION
Context: regression introduced by #122020 and discovered during live QA for #122258; this is a separate source-bundle repair.

## What Problem This Solves

Fixes an issue where source-checkout Cloud Workers could not start because bootstrap's normal production npm install failed with `EUNSUPPORTEDPROTOCOL Unsupported URL Type "workspace:": workspace:*` before the worker process launched.

#122020 moved normalization helpers into the private `@openclaw/normalization-core` workspace and declared that package as an `@openclaw/ai` runtime dependency. The AI tsdown build already bundles normalization-core, but source Worker bundles vendor `@openclaw/ai` and preserve its runtime dependency metadata. That left an unresolvable nested `workspace:*` spec in the bundle. Generated `dist/extensions/*` package manifests also contain workspace development metadata, but those manifests are nested and inert; they are not part of npm's install graph and did not cause this failure. The defect was made visible while running the live QA setup for #122258, whose behavior change remains separate.

## Why This Change Was Made

The fix classifies bundled normalization-core as an AI workspace dev dependency, updates the lock importer and package contract, and adds a Worker-bundle regression that derives the real AI manifest field and runs a production-only npm install against the bundled artifact. This repairs dependency ownership at the package producer. It does not add a bootstrap retry, manifest sanitizer, or any preview, RPC, placement, or Worker runtime behavior.

This maintainer repair was AI-assisted and has been reviewed with the repository's mandatory autoreview workflow.

## User Impact

Operators running the Gateway from a source checkout can provision Cloud Workers again: the generated source bundle remains npm-installable and reaches worker startup. Published `@openclaw/ai` keeps its external runtime dependencies while the private, already-bundled normalization workspace no longer leaks into consumer install metadata.

## Evidence

- Pre-fix replay of the new bundle regression failed in all three routed Gateway projects with npm `EUNSUPPORTEDPROTOCOL` / `Unsupported URL Type "workspace:": workspace:*`.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/gateway/worker-environments/bundle.test.ts src/gateway/worker-environments/bootstrap.test.ts packages/ai/src/package-dependencies.test.ts` passed 44/44 tests.
- `pnpm build` passed.
- An actual built source-bundle probe reported `rootWorkspaceSpecs=0`, `aiWorkspaceSpecs=0`, `extensionManifests=58`, `extensionWorkspaceManifests=57`, and `npmInstallExit=0`. The extension workspace manifests are nested/inert and do not participate in the install.
- `node scripts/package-openclaw-for-docker.mjs --allow-unreleased-changelog --output-dir .artifacts/worker-bundle-package --output-name openclaw-current.tgz`, followed by `node scripts/check-openclaw-package-tarball.mjs --require-bundled-workspace-deps .artifacts/worker-bundle-package/openclaw-current.tgz`, passed.
- Standalone AI npm pack/install and runtime imports passed: `npmInstallExit=0`, `runtimeImportExit=0`, all 13 export specifiers imported, and no runtime normalization-core dependency remained.
- The full existing `packages/ai/src/package.e2e.test.ts` reached only its final external declaration `tsgo` step and timed out twice after 180 seconds on a saturated local host. Install and runtime import phases had already succeeded. Exact-head CI is the blocking proof for this remaining local gap.
- Changed-gate remote delegation was unavailable locally because the Blacksmith CLI/broker authentication was missing, so the workflow fell back locally. Package-lock validation for 94 packages, formatting, dependency pins, metadata, Plugin SDK API, deprecated APIs, wrapper shadowing, A2UI, patch guard, dead code, database/media/sidecar guards, `pnpm tsgo:all`, `pnpm lint`, and `pnpm check:import-cycles` passed. The aggregate stopped on one unrelated current-main plugin compatibility record due for removal; the unmodified checkout failed identically.
- `TMPDIR=/tmp .claude/skills/autoreview/scripts/autoreview --mode uncommitted` reported `autoreview clean: no accepted/actionable findings reported`.
- `git diff --check` passed.
- LOC classification: runtime production TypeScript `+0/-0`; package metadata `+3/-1`; lockfile `+4/-3`; tests `+74/-2`.
