### PR TITLE
refactor(gateway): remove orphan testing aliases

### DIFF
--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -1292,5 +1292,4 @@ export async function callGateway<T = Record<string, unknown>>(
 export function randomIdempotencyKey() {
   return randomUUID();
 }
-export { testing as __testing };
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -1392,5 +1392,4 @@ export async function handleOpenResponsesHttpRequest(
 
   return true;
 }
-export { testing as __testing };
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -1593,5 +1593,4 @@ export const agentsHandlers: GatewayRequestHandlers = {
     );
   },
 };
-export { testing as __testing };
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

Three internal Gateway modules still exported zero-caller `__testing` aliases alongside their canonical `testing` objects. Neighboring aliases had already been removed, but these lines were missed and kept unsupported compatibility surface alive.

## Why This Change Was Made

Delete only the three orphan aliases. Existing tests continue importing `testing` directly, and no Gateway package subpath exposes these deep modules as a public contract.

## User Impact

No intended user-visible change. Gateway runtime and test behavior are unchanged; internal export surface is smaller and consistent with neighboring modules.

## Evidence

- Gateway call, OpenResponses HTTP, and agent-mutation owner suites: 294 tests passed.
- Full changed-file gate passed formatting, production/test typechecks, lint, dead exports, SDK API, boundaries, ratchet, schema/storage guards, and cycle checks. Blacksmith/Testbox was unavailable on this host, so trusted heavy proof fell back locally.
- Structured autoreview and deleted-content secret scan: clean.
- `git diff --check`: clean.
- Production delta: -3 lines. No tests or replacement seams added.

AI-assisted maintenance cleanup; the repository caller graph, package export map, and alias history were reviewed directly.
