### PR TITLE
fix(macos): location works with While Using permission

### DIFF
--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -500,14 +500,9 @@ extension MacNodeRuntime {
             (Self.locationPreciseEnabled() ? .precise : .balanced)
         let services = await mainActorServices()
         let status = await services.locationAuthorizationStatus()
-        let hasPermission = switch mode {
-        case .always:
-            status == .authorizedAlways
-        case .whileUsing:
-            status == .authorizedAlways
-        case .off:
-            false
-        }
+        let hasPermission = PermissionManager.isLocationAuthorized(
+            status: status,
+            requireAlways: mode == .always)
         if !hasPermission {
             return BridgeInvokeResponse(
                 id: req.id,

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
@@ -130,6 +130,7 @@ struct MacNodeRuntimeTests {
         var actError: Error?
         var performCallCount = 0
         var releaseCallCount = 0
+        var locationStatus: CLAuthorizationStatus
         var receivedLifecycleGenerations: [UInt64] = []
         var receivedReleaseGenerations: [UInt64] = []
         private let snapshotInspection: SnapshotInspection?
@@ -147,6 +148,7 @@ struct MacNodeRuntimeTests {
             snapshotError: Error? = nil,
             snapshotInspection: SnapshotInspection? = nil,
             actError: Error? = nil,
+            locationAuthorizationStatus: CLAuthorizationStatus = .authorizedAlways,
             performEnteredGate: AsyncTestGate? = nil,
             allowPerformGate: AsyncTestGate? = nil)
         {
@@ -154,6 +156,7 @@ struct MacNodeRuntimeTests {
             self.snapshotError = snapshotError
             self.snapshotInspection = snapshotInspection
             self.actError = actError
+            self.locationStatus = locationAuthorizationStatus
             self.performEnteredGate = performEnteredGate
             self.allowPerformGate = allowPerformGate
         }
@@ -192,7 +195,7 @@ struct MacNodeRuntimeTests {
         }
 
         func locationAuthorizationStatus() -> CLAuthorizationStatus {
-            .authorizedAlways
+            self.locationStatus
         }
 
         func locationAccuracyAuthorization() -> CLAccuracyAuthorization {
@@ -450,6 +453,30 @@ struct MacNodeRuntimeTests {
             let response = await self.invoke(runtime, "req-4", OpenClawCameraCommand.list.rawValue)
             #expect(response.ok == false)
             #expect(response.error?.message.contains("CAMERA_DISABLED") == true)
+        }
+    }
+
+    @Test func `handle location invoke applies authorization required by mode`() async throws {
+        let authorizedWhenInUse = try #require(CLAuthorizationStatus(rawValue: 4))
+        let cases: [(mode: OpenClawLocationMode, status: CLAuthorizationStatus, accepted: Bool)] = [
+            (.whileUsing, authorizedWhenInUse, true),
+            (.always, authorizedWhenInUse, false),
+            (.whileUsing, .authorizedAlways, true),
+            (.always, .authorizedAlways, true),
+        ]
+
+        for testCase in cases {
+            await TestIsolation.withUserDefaultsValues([locationModeKey: testCase.mode.rawValue]) {
+                let services = await MainActor.run {
+                    MainActorServicesProbe(locationAuthorizationStatus: testCase.status)
+                }
+                let runtime = MacNodeRuntime(makeMainActorServices: { services })
+
+                let response = await self.invoke(
+                    runtime, "req-location", OpenClawLocationCommand.get.rawValue)
+
+                #expect(response.ok == testCase.accepted)
+            }
         }
     }
 


### PR DESCRIPTION
Closes #122429

## What Problem This Solves

Fixes an issue where macOS node users who selected **While Using** location access still received `LOCATION_PERMISSION_REQUIRED` when Core Location correctly reported `.authorizedWhenInUse`.

## Why This Change Was Made

`MacNodeRuntime` duplicated location authorization policy and required `.authorizedAlways` for both modes. The runtime now delegates to the canonical `PermissionManager.isLocationAuthorized(status:requireAlways:)` policy, requiring Always only when the selected mode is `.always`. The focused runtime-boundary test covers While Using and Always against both relevant authorization states. No TCC state, app launch, wording, protocol, config, dependency, generated baseline, or unrelated surface changes.

## User Impact

Users can use `location.get` with the permission level requested by the app's **While Using** setting. **Always** continues to require `.authorizedAlways`.

## Evidence

- Pre-fix regression proof: with only the production helper call temporarily reverted and the new test retained, `swift test --package-path apps/macos --filter MacNodeRuntimeTests` failed at `MacNodeRuntimeTests.swift:478` because the While Using case returned `response.ok == false` instead of `true`; the other 30 tests passed.
- Post-fix: `swift test --package-path apps/macos --filter MacNodeRuntimeTests` — 31 tests passed.
- `./scripts/format-swift.sh macos` — clean (0 files require formatting).
- `git diff --check` — clean.
- `node scripts/check-changed.mjs -- apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift` — hosted Testbox `tbx_01kzt3ybay1ga7vncv0swth2ym`, [Actions run 31563639539](https://github.com/openclaw/openclaw/actions/runs/31563639539), exit 0.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — TruffleHog clean; Codex review clean with no accepted/actionable findings.
- LOC: production `+3/-8` (net `-5`); tests `+28/-1`.

Proof gap: this deterministic owner-boundary test does not mutate real macOS TCC state or launch the app. Those behaviors are intentionally outside this focused permission-policy repair.

AI-assisted: yes; the patch was independently reviewed with the repository's Codex-backed autoreview workflow.
