### PR TITLE
fix(cli): validate capability image --resolution at parse time

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2375,11 +2375,11 @@ src/cli/acp-cli.ts	7
 src/cli/attach-cli.ts	3
 src/cli/capability-cli/audio.ts	3
 src/cli/capability-cli/embedding.ts	3
-src/cli/capability-cli/image.ts	21
+src/cli/capability-cli/image.ts	11
 src/cli/capability-cli/model.ts	4
 src/cli/capability-cli/shared.ts	6
 src/cli/capability-cli/tts.ts	6
-src/cli/capability-cli/video.ts	7
+src/cli/capability-cli/video.ts	6
 src/cli/capability-cli/web.ts	6
 src/cli/channel-auth.ts	4
 src/cli/channel-options.ts	1

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -2414,86 +2414,71 @@ describe("capability cli", () => {
     expect(firstImageGenerationCall()?.count).toBe(3);
   });
 
-  it("rejects unsupported image output format and background hints", async () => {
-    await expect(
-      runCapability(
-        "image",
-        "generate",
-        "--prompt",
-        "transparent sticker",
-        "--output-format",
-        "gif",
-        "--json",
-      ),
-    ).rejects.toThrow("exit 1");
-    expect(mocks.runtime.error).toHaveBeenCalledWith(
-      "--output-format must be one of png, jpeg, or webp",
-    );
+  // Both image subcommands share resolveImageGenerationOptions, so every advertised closed-union
+  // flag must be rejected before provider dispatch on both of them.
+  const rejectedImageEnumFlags = [
+    { flag: "--output-format", value: "gif", accepted: "png, jpeg, or webp" },
+    { flag: "--background", value: "clear", accepted: "transparent, opaque, or auto" },
+    { flag: "--openai-background", value: "clear", accepted: "transparent, opaque, or auto" },
+    { flag: "--openai-moderation", value: "none", accepted: "low or auto" },
+    { flag: "--quality", value: "expensive", accepted: "low, medium, high, or auto" },
+    // 720P/1080P are the sibling `video generate` values, so they are the natural typo here.
+    { flag: "--resolution", value: "1080p", accepted: "1K, 2K, or 4K" },
+    { flag: "--resolution", value: "hd", accepted: "1K, 2K, or 4K" },
+    // 8K was previously clamped to 4K by the geometry layer; it is advertised nowhere.
+    { flag: "--resolution", value: "8K", accepted: "1K, 2K, or 4K" },
+  ];
 
-    mocks.runtime.error.mockClear();
-    await expect(
-      runCapability(
-        "image",
-        "generate",
-        "--prompt",
-        "transparent sticker",
-        "--openai-background",
-        "clear",
-        "--json",
-      ),
-    ).rejects.toThrow("exit 1");
-    expect(mocks.runtime.error).toHaveBeenCalledWith(
-      "--openai-background must be one of transparent, opaque, or auto",
-    );
+  it.each(rejectedImageEnumFlags)(
+    "rejects $flag $value before image generate and image edit reach the provider",
+    async ({ flag, value, accepted }) => {
+      const expected = `${flag} must be one of ${accepted}`;
+      const editInput = path.join(tempDirs.make("openclaw-image-enum-reject-"), "input.png");
+      await fs.writeFile(editInput, Buffer.from(PNG_1X1_BASE64, "base64"));
 
-    mocks.runtime.error.mockClear();
-    await expect(
-      runCapability(
-        "image",
-        "generate",
-        "--prompt",
-        "transparent sticker",
-        "--background",
-        "clear",
-        "--json",
-      ),
-    ).rejects.toThrow("exit 1");
-    expect(mocks.runtime.error).toHaveBeenCalledWith(
-      "--background must be one of transparent, opaque, or auto",
-    );
+      await expect(
+        runCapability("image", "generate", "--prompt", "sticker", flag, value, "--json"),
+      ).rejects.toThrow("exit 1");
+      expect(mocks.runtime.error).toHaveBeenCalledWith(expected);
 
-    mocks.runtime.error.mockClear();
-    await expect(
-      runCapability(
-        "image",
-        "generate",
-        "--prompt",
-        "transparent sticker",
-        "--quality",
-        "expensive",
-        "--json",
-      ),
-    ).rejects.toThrow("exit 1");
-    expect(mocks.runtime.error).toHaveBeenCalledWith(
-      "--quality must be one of low, medium, high, or auto",
-    );
+      mocks.runtime.error.mockClear();
+      await expect(
+        runCapability(
+          "image",
+          "edit",
+          "--file",
+          editInput,
+          "--prompt",
+          "sticker",
+          flag,
+          value,
+          "--json",
+        ),
+      ).rejects.toThrow("exit 1");
+      expect(mocks.runtime.error).toHaveBeenCalledWith(expected);
 
-    mocks.runtime.error.mockClear();
-    await expect(
-      runCapability(
+      expect(mocks.generateImage).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["2k", " 2k "])(
+    "accepts case-insensitive image resolution %j and forwards the canonical value",
+    async (raw) => {
+      primeGeneratedImage("gpt-image-2", "resolution.png");
+
+      await runCapability(
         "image",
         "generate",
         "--prompt",
-        "transparent sticker",
-        "--openai-moderation",
-        "none",
+        "sticker",
+        "--resolution",
+        raw,
         "--json",
-      ),
-    ).rejects.toThrow("exit 1");
-    expect(mocks.runtime.error).toHaveBeenCalledWith(
-      "--openai-moderation must be one of low or auto",
-    );
-  });
+      );
+
+      expect(firstImageGenerationCall()?.resolution).toBe("2K");
+    },
+  );
 
   it("forwards size, aspect ratio, and resolution overrides for image edit", async () => {
     const pngBase64 =
@@ -2888,6 +2873,16 @@ describe("capability cli", () => {
     expect(videoCall?.audio).toBe(true);
     expect(videoCall?.watermark).toBe(true);
     expect(videoCall?.timeoutMs).toBe(300000);
+  });
+
+  it("rejects an unsupported video resolution before the provider is dispatched", async () => {
+    await expect(
+      runCapability("video", "generate", "--prompt", "lobster", "--resolution", "9000P", "--json"),
+    ).rejects.toThrow("exit 1");
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      "video resolution must be one of 360P, 480P, 540P, 720P, 768P, or 1080P",
+    );
+    expect(mocks.generateVideo).not.toHaveBeenCalled();
   });
 
   it("fails video generate when a provider returns an undeliverable asset", async () => {

--- a/src/cli/capability-cli/image.ts
+++ b/src/cli/capability-cli/image.ts
@@ -1,9 +1,6 @@
 import path from "node:path";
 import { detectMime } from "@openclaw/media-core/mime";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-} from "@openclaw/normalization-core/string-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { Command } from "commander";
 import { resolveAgentDir } from "../../agents/agent-scope.js";
 import { runWithImageModelFallback } from "../../agents/model-fallback-image.js";
@@ -18,6 +15,7 @@ import type {
   ImageGenerationOpenAIModeration,
   ImageGenerationOutputFormat,
   ImageGenerationQuality,
+  ImageGenerationResolution,
 } from "../../image-generation/types.js";
 import {
   describeImageFile,
@@ -37,6 +35,7 @@ import {
   formatEnvelopeForText,
   parseOptionalPositiveInteger,
   parseOptionalTimeoutMs,
+  parseUnionOption,
   providerHasGenericConfig,
   providerSummaryText,
   requireProviderModelOverride,
@@ -46,8 +45,11 @@ import {
   resolveSelectedProviderFromModelRef,
 } from "./shared.js";
 
-const IMAGE_OUTPUT_FORMATS = ["png", "jpeg", "webp"] as const;
-const IMAGE_BACKGROUNDS = ["transparent", "opaque", "auto"] as const;
+const IMAGE_OUTPUT_FORMATS: readonly ImageGenerationOutputFormat[] = ["png", "jpeg", "webp"];
+const IMAGE_BACKGROUNDS: readonly ImageGenerationBackground[] = ["transparent", "opaque", "auto"];
+const IMAGE_QUALITIES: readonly ImageGenerationQuality[] = ["low", "medium", "high", "auto"];
+const IMAGE_MODERATIONS: readonly ImageGenerationOpenAIModeration[] = ["low", "auto"];
+const IMAGE_RESOLUTIONS: readonly ImageGenerationResolution[] = ["1K", "2K", "4K"];
 
 async function runImageGenerate(params: {
   capability: "image.generate" | "image.edit";
@@ -56,7 +58,7 @@ async function runImageGenerate(params: {
   count?: number;
   size?: string;
   aspectRatio?: string;
-  resolution?: "1K" | "2K" | "4K";
+  resolution?: ImageGenerationResolution;
   outputFormat?: ImageGenerationOutputFormat;
   background?: ImageGenerationBackground;
   openaiBackground?: ImageGenerationBackground;
@@ -232,62 +234,6 @@ async function runImageDescribe(params: {
   } satisfies CapabilityEnvelope;
 }
 
-function normalizeImageOutputFormat(
-  raw: string | undefined,
-): ImageGenerationOutputFormat | undefined {
-  const normalized = normalizeLowercaseStringOrEmpty(raw);
-  if (!normalized) {
-    return undefined;
-  }
-  if ((IMAGE_OUTPUT_FORMATS as readonly string[]).includes(normalized)) {
-    return normalized as ImageGenerationOutputFormat;
-  }
-  throw new Error("--output-format must be one of png, jpeg, or webp");
-}
-
-function normalizeImageBackground(
-  raw: string | undefined,
-  label = "--background",
-): ImageGenerationBackground | undefined {
-  const normalized = normalizeLowercaseStringOrEmpty(raw);
-  if (!normalized) {
-    return undefined;
-  }
-  if ((IMAGE_BACKGROUNDS as readonly string[]).includes(normalized)) {
-    return normalized as ImageGenerationBackground;
-  }
-  throw new Error(`${label} must be one of transparent, opaque, or auto`);
-}
-
-function normalizeImageQuality(raw: string | undefined): ImageGenerationQuality | undefined {
-  const normalized = normalizeLowercaseStringOrEmpty(raw);
-  if (!normalized) {
-    return undefined;
-  }
-  if (
-    normalized === "low" ||
-    normalized === "medium" ||
-    normalized === "high" ||
-    normalized === "auto"
-  ) {
-    return normalized;
-  }
-  throw new Error("--quality must be one of low, medium, high, or auto");
-}
-
-function normalizeOpenAIModeration(
-  raw: string | undefined,
-): ImageGenerationOpenAIModeration | undefined {
-  const normalized = normalizeLowercaseStringOrEmpty(raw);
-  if (!normalized) {
-    return undefined;
-  }
-  if (normalized === "low" || normalized === "auto") {
-    return normalized;
-  }
-  throw new Error("--openai-moderation must be one of low or auto");
-}
-
 function resolveImageDescribeInput(filePath: string): string {
   const trimmed = filePath.trim();
   return /^https?:\/\//i.test(trimmed) ? trimmed : path.resolve(filePath);
@@ -321,15 +267,20 @@ function resolveImageGenerationOptions(opts: Record<string, unknown>, command: C
     count: parseOptionalPositiveInteger(opts.count, "--count"),
     size: opts.size as string | undefined,
     aspectRatio: opts.aspectRatio as string | undefined,
-    resolution: opts.resolution as "1K" | "2K" | "4K" | undefined,
-    outputFormat: normalizeImageOutputFormat(opts.outputFormat as string | undefined),
-    background: normalizeImageBackground(opts.background as string | undefined),
-    openaiBackground: normalizeImageBackground(
-      opts.openaiBackground as string | undefined,
+    resolution: parseUnionOption(opts.resolution, IMAGE_RESOLUTIONS, "--resolution"),
+    outputFormat: parseUnionOption(opts.outputFormat, IMAGE_OUTPUT_FORMATS, "--output-format"),
+    background: parseUnionOption(opts.background, IMAGE_BACKGROUNDS, "--background"),
+    openaiBackground: parseUnionOption(
+      opts.openaiBackground,
+      IMAGE_BACKGROUNDS,
       "--openai-background",
     ),
-    openaiModeration: normalizeOpenAIModeration(opts.openaiModeration as string | undefined),
-    quality: normalizeImageQuality(opts.quality as string | undefined),
+    openaiModeration: parseUnionOption(
+      opts.openaiModeration,
+      IMAGE_MODERATIONS,
+      "--openai-moderation",
+    ),
+    quality: parseUnionOption(opts.quality, IMAGE_QUALITIES, "--quality"),
     timeoutMs: parseOptionalTimeoutMs(opts.timeoutMs as string | number | undefined),
     output: opts.output as string | undefined,
   };

--- a/src/cli/capability-cli/shared.ts
+++ b/src/cli/capability-cli/shared.ts
@@ -2,6 +2,7 @@ import {
   parseStrictFiniteNumber,
   parseStrictPositiveInteger,
 } from "@openclaw/normalization-core/number-coercion";
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { Command } from "commander";
 import {
   resolveAgentOperationAgentId,
@@ -224,6 +225,27 @@ export function parseOptionalPositiveInteger(raw: unknown, label: string): numbe
     throw new Error(`${label} must be a positive integer`);
   }
   return value;
+}
+
+// Closed-union options are advertised in help text, so an unrecognized value is a user error the
+// parse boundary owns. Downstream capability layers treat an unknown value as "no override" and
+// silently drop it, which reports success for a request nobody honored.
+export function parseUnionOption<T extends string>(
+  raw: unknown,
+  allowed: readonly T[],
+  label: string,
+): T | undefined {
+  const normalized = normalizeLowercaseStringOrEmpty(raw);
+  if (!normalized) {
+    return undefined;
+  }
+  const match = allowed.find((value) => value.toLowerCase() === normalized);
+  if (match) {
+    return match;
+  }
+  const head = allowed.slice(0, -1).join(", ");
+  const list = head ? `${head}${allowed.length > 2 ? "," : ""} or ${allowed.at(-1)}` : allowed[0];
+  throw new Error(`${label} must be one of ${list}`);
 }
 
 export function parseOptionalTimeoutMs(raw: string | number | undefined): number | undefined {

--- a/src/cli/capability-cli/video.ts
+++ b/src/cli/capability-cli/video.ts
@@ -37,6 +37,7 @@ import {
   formatEnvelopeForText,
   parseOptionalFiniteNumber,
   parseOptionalTimeoutMs,
+  parseUnionOption,
   providerHasGenericConfig,
   requireProviderModelOverride,
   resolveCapabilityAgentOption,
@@ -46,24 +47,14 @@ import {
 } from "./shared.js";
 
 const GENERATED_VIDEO_DOWNLOAD_TIMEOUT_MS = 120_000;
-
-function normalizeVideoResolution(raw: string | undefined): VideoGenerationResolution | undefined {
-  const normalized = raw?.trim().toUpperCase();
-  if (!normalized) {
-    return undefined;
-  }
-  if (
-    normalized === "360P" ||
-    normalized === "480P" ||
-    normalized === "540P" ||
-    normalized === "720P" ||
-    normalized === "768P" ||
-    normalized === "1080P"
-  ) {
-    return normalized;
-  }
-  throw new Error("video resolution must be one of 360P, 480P, 540P, 720P, 768P, or 1080P");
-}
+const VIDEO_RESOLUTIONS: readonly VideoGenerationResolution[] = [
+  "360P",
+  "480P",
+  "540P",
+  "720P",
+  "768P",
+  "1080P",
+];
 
 async function fetchGeneratedVideoDownload(params: {
   cfg: OpenClawConfig;
@@ -298,7 +289,7 @@ export function registerVideoCapabilityCommands(capability: Command): void {
           output: opts.output as string | undefined,
           size: opts.size as string | undefined,
           aspectRatio: opts.aspectRatio as string | undefined,
-          resolution: normalizeVideoResolution(opts.resolution as string | undefined),
+          resolution: parseUnionOption(opts.resolution, VIDEO_RESOLUTIONS, "video resolution"),
           durationSeconds: parseOptionalFiniteNumber(opts.duration, "--duration"),
           audio: opts.audio === true ? true : undefined,
           watermark: opts.watermark === true ? true : undefined,


### PR DESCRIPTION
## What Problem This Solves

| change | kind |
|---|---|
| `image generate\|edit --resolution` now rejects, at the option boundary, any non-empty value that is not a trimmed case-insensitive spelling of `1K`, `2K` or `4K` (so `2k` and `" 2k "` are accepted and forwarded as `2K`) (omitting the flag still means "no override", unchanged and covered by every test that omits it) | **behaviour change** (the fix) |
| `--resolution 8K` now errors instead of being substituted with the nearest value the resolved model publishes (`4K` when that list is `1K, 2K, 4K`) | **behaviour change** (unavoidable consequence — see below) |
| five duplicated union normalizers replaced by one helper in `shared.ts` (4 in `image.ts`, 1 in `video.ts`) | behaviour-preserving refactor; all six **pre-existing** error messages byte-identical (a seventh, for `--resolution`, is new — it is the fix) |
| enum-rejection assertions consolidated into a table and extended | test-only |


Fixes an issue where users who pass a resolution the command does not support — for example
`openclaw capability image generate --prompt "…" --resolution 1080p` — get no error, and the request
proceeds with **no resolution override at all** and nothing saying the flag was dropped. The same
applies to `capability image edit`.

Provenance up front, because the parts of that sentence have different kinds of evidence:

- **Measured** (capture in *Evidence*, both subcommands, with controls): the unrecognized value got
  past option resolution and execution continued.
- **Read from source** (lines cited below): the override is then dropped rather than recorded, so no
  usable resolution override is passed on — the provider call receives `resolution: undefined`. What a
  given provider then puts on the wire was not observed.
- **Not observed, and stated as a consequence rather than a finding**: what the provider does when the
  field is absent. It applies its own default — that is the definition of a default, not something
  this PR measured. No billed generation was run for this PR, so there is no capture of a returned
  image at any resolution.

Both commands advertise a closed set in their own help text — `src/cli/capability-cli/image.ts:248`
reads `.option("--resolution <value>", "Resolution hint: 1K, 2K, or 4K")`, declared once in
`addImageGenerationOptions` and shared by both subcommands — so the flag reads as validated. It was not: the value was accepted at the command line and then dropped
further down without being recorded, and the CLI only reports ignored overrides when that list is
non-empty. The observed impact is exactly that: the command continues with no resolution override and
says nothing about it. Whether the resulting generation is billed, and what resolution comes back,
depends on the provider and was not observed here.

To be explicit about provenance: the capture in *Evidence* proves the accept-then-continue half — that
an unrecognized value got past option resolution and execution moved on. **That the override is then
dropped without being recorded is source-derived, not captured**, and what the provider does with an
absent resolution field is neither. The three lines the source claim rests on:

- `resolveMediaGeometryOverrides` in `src/media-generation/geometry-normalization.ts:115` — the
  resolution branch only runs when the model publishes a non-empty list; `:123` appends to
  `ignoredOverrides` **only if** `params.reportUnrecognizedOverrides` is set, so an unparseable value
  leaves `resolution` undefined and the list empty. `:122` is the substitution path that *does* record
  (`normalization.resolution`).
- `resolveImageGenerationOverrides` in `src/image-generation/normalization.ts:43` — the image caller of
  `resolveMediaGeometryOverrides` does not pass `reportUnrecognizedOverrides`. Only
  `resolveVideoGenerationOverrides` (`src/video-generation/normalization.ts:61`) passes it (`true`),
  which is why video is not affected.
- `formatEnvelopeForText` in `src/cli/capability-cli/shared.ts:75-76` — the envelope prints
  `ignoredOverrides` only when the array is non-empty, so an empty list prints nothing at all.

and the omission is visible at the dispatch site itself: `src/image-generation/runtime.ts:159` passes
`resolution: sanitized.resolution` into `provider.generateImage(...)`, where `sanitized` is the object
`resolveImageGenerationOverrides` returned at `:136`. When that resolved to `undefined`, `undefined` is
what the provider call receives — that is as far as the source establishes it; how each provider
serializes an absent resolution was not inspected. The comment at `:147-148` (*"Providers receive only
supported overrides"*) states the intent, but the line to check is `:159`.

The failing values include ones the CLI itself accepts elsewhere: `720P` and `1080P` are members of
`capability video generate --resolution`'s accepted set, so a user moving between the two commands
lands on a silently ignored flag instead of an error. `8K` behaved differently again, and the difference is worth naming precisely. `1080p` and `hd` are
**unparseable** by the geometry layer — it cannot map them onto a resolution at all, so it produced no
value. `8K` is **parseable but above the supported range**, so the geometry layer could rank it against
the resolved model's published list and substitute the nearest supported value — `4K` when that list is
`1K, 2K, 4K` — recording the substitution internally as `normalization.resolution`.

On this CLI surface, though, **neither class was visible to the user**: `src/cli/capability-cli/image.ts`
puts only `ignoredOverrides` into its envelope, never `normalization`, and `ignoredOverrides` stays
empty for the unparseable class. So for both an ignored value and a substituted one, the CLI emitted no
resolution diagnostic before dispatch. What the provider then returned was not observed. The `normalization` record does reach other consumers of the same runtime — the agent
tool reads `result.normalization?.resolution?.applied` and includes the record in its own result. That
is evidence the data is published for consumers, and it is consistent with a "record when we did not
honor the request" intent — it is not by itself proof of that intent, which I did not try to establish
from a producer-side contract. Either way the CLI path does not surface it.

## Why This Change Was Made

`src/cli/capability-cli/shared.ts` already owns the "parse one CLI option value or throw" policy for
this command family — `parseOptionalFiniteNumber`, `parseOptionalPositiveInteger`,
`parseOptionalTimeoutMs`, all `(raw, label)` and all throwing `` `${label} must be …` ``. The
closed-union case was the missing member of that family, and it had been hand-rolled instead.

The exact counts, since they are easy to misread:

- **7 closed-union flag declarations**, counting each `.option(...)` declaration once: six are
  declared in `addImageGenerationOptions` and therefore shared by `image generate` and `image edit`
  (`--output-format`, `--background`, `--openai-background`, `--openai-moderation`, `--quality`,
  `--resolution`), plus `--resolution` on `video generate`.
- **5 hand-rolled normalizers** served them: four in `image.ts` (`normalizeImageOutputFormat`,
  `normalizeImageBackground`, `normalizeImageQuality`, `normalizeOpenAIModeration` — `background`
  covered two of the sites via a `label` argument) and one in `video.ts`
  (`normalizeVideoResolution`). All five are deleted by this PR.
- **`--resolution` on the image commands was the one site with no normalizer at all** — it was cast
  and never checked. That is the defect.
- **6 allowed-value constants** replace them, because each distinct union needs its own list:
  five in `image.ts` and one in `video.ts` (`--background` and `--openai-background` share a list).

**The minimal defect-site change** is one line: in `resolveImageGenerationOptions`,
`resolution: opts.resolution as "1K" | "2K" | "4K" | undefined` becomes a validating call. Everything
else in the diff is the decision about *where that validator lives*.

**The fix:** `resolveImageGenerationOptions` now resolves `--resolution` through a validator that
rejects anything outside the advertised set, instead of casting the raw argv string. Rather than add
a fifth guard beside the four that already exist, the validator is added once to `shared.ts` as
`parseUnionOption(raw, allowed, label)` and the five duplicates are deleted — four in
`src/cli/capability-cli/image.ts` and one in `src/cli/capability-cli/video.ts`. Every union option on
both commands now goes through that one helper, `--resolution` included.

Declaring those six constants as `readonly ImageGenerationResolution[]`,
`readonly ImageGenerationOutputFormat[]`, `readonly ImageGenerationBackground[]`,
`readonly ImageGenerationQuality[]`, `readonly ImageGenerationOpenAIModeration[]` and
`readonly VideoGenerationResolution[]` also puts the compiler back in charge of the lists, which the
discarded `as` cast had defeated: a value that is not in the union no longer compiles.

`video.ts` has **no behaviour change** — its normalizer already validated correctly, and its error
wording is preserved byte-for-byte through the `label` argument. It is in this PR because of one
principle, stated plainly rather than by appeal to doctrine: **a policy should have one owner, and a
helper that five callers bypass is not an owner.** If `video.ts` keeps its own copy, `shared.ts` is
just a sixth place the same rule lives, and the next contributor adding a union flag has no single
obvious thing to call — which is exactly the condition that produced this bug. To be exact about the boundary:
`shared.ts` owns the **mechanism** — trim, case-insensitive membership, canonical return, message
formatting — while each command file keeps its own **vocabulary**, the allowed-value constants, beside
the flags that declare them. That split is deliberate: the vocabulary is command-specific (image
resolutions are not video resolutions), the mechanism is not. The repo's root
`AGENTS.md` Repair Doctrine says the same thing ("remove connected duplicate policy … in the same
change when they share the invariant"), but the reason stands without it.

The review risk that consolidation introduces is concrete and worth naming: one helper now formats the
message for all seven flags, so a mistake in its list formatting would change several user-visible
strings at once instead of one. That is why the two-item form (`low or auto`) and the three-or-more
form (`a, b, or c`) are both exercised, why this PR's table asserts all six pre-existing
messages verbatim (five of them already had assertions; video's did not — see below), and why the capture below shows the sibling command's untouched message in full on both sides.

The four input dimensions the old normalizers handled are preserved deliberately, not incidentally,
because the helper implements each one once:

| dimension | before | after | covered by |
|---|---|---|---|
| case | `normalizeLowercaseStringOrEmpty` lowercased, video's uppercased | helper lowercases and matches case-insensitively, returning the list's canonical member | added `2k` / `" 2k "` case; existing video `768p → 768P` |
| surrounding whitespace | trimmed (same helper) | trimmed (same helper) | added `" 2k "` case |
| omitted flag | returned `undefined`, no throw | returned `undefined`, no throw | every existing test that omits these flags |
| invalid input | threw with the flag's own message | throws the same message | the six verbatim message assertions |

Production LOC delta is **+53 / −89 (net −36)**; tests are **+67 / −72**.

Messages, kept separate from the flag and constant counts above because they do not line up one-to-one:

- **6 error messages existed before this PR** — five on the image command (`--output-format`,
  `--background`, `--openai-background`, `--openai-moderation`, `--quality`) and one on video
  (`video resolution must be one of …`). All six are byte-identical after the change; video's wording
  survives because it is passed as the `label` argument rather than hardcoded in the helper.
- **1 error message is new**: `--resolution must be one of 1K, 2K, or 4K`. There was no message before
  because there was no check.
- Of the six pre-existing messages, **five had assertions before this PR** (the image ones). Video's
  message existed in the code but **no test asserted it**, so this PR adds that assertion — which is
  what makes the video swap verifiable rather than merely claimed. After this PR all seven messages
  are asserted: five by pre-existing assertions carried into the new table, two by assertions this PR
  adds.

**Behaviour change to be aware of:** `--resolution 8K` was previously substituted by the geometry layer
with the nearest value the resolved model publishes (`4K` for a model publishing `1K, 2K, 4K`) and is
now rejected at the option boundary.

This is not a separable change and cannot be split into its own PR: `8K` is not in the accepted set,
so *any* validator for the advertised set rejects it. Keeping the clamp would mean special-casing `8K`
— that is, adding a fourth accepted value that the help text, the `ImageGenerationResolution` union,
and the agent-tool contract for the same field all omit, and that the agent-tool peer
(`src/agents/tools/image-generate-tool.ts` `normalizeResolution`) already rejects. **Scoped to this CLI path**, the
substitution was a side effect of the unchecked cast rather than a documented contract: an out-of-range
value could only reach the geometry layer from this command because the cast let it through. The
geometry layer's own substitution behaviour is unchanged and still serves its other consumers. The new
`8K` test pins the CLI-boundary rejection — it does not pin the old geometry substitution, which no test
in this diff exercises — so the decision is explicit rather than implicit.

### Non-scope

This change is limited to closed-union option validation inside `src/cli/capability-cli/`.
`--size` and `--aspect-ratio`, declared beside the others in `addImageGenerationOptions`
(`src/cli/capability-cli/image.ts`), remain free-form hints by design.
Substitution of *valid* enum values with the closest supported resolution keeps working as before.
The agent-tool path validates this field already and is owned elsewhere, so it stays as it is.
Config, default and plugin surfaces are all unchanged. The change is five files — three production,
one test, plus the repository ratchet baseline those production deletions force to shrink:

| file | why it is in this PR |
|---|---|
| `src/cli/capability-cli/shared.ts` | the owner of this command family's option-parsing policy; the new validator lives here, beside `parseOptionalPositiveInteger` / `parseOptionalTimeoutMs` |
| `src/cli/capability-cli/image.ts` | **the defect.** `--resolution` was cast, not validated. Its four duplicate normalizers are the structure that hid it, so they are deleted rather than joined by a fifth |
| `src/cli/capability-cli/video.ts` | the fifth copy of the same policy. Deleting it is what makes `shared.ts` the single owner; behaviour and message are unchanged, and the capture below shows both its rejection and acceptance paths are identical on either side |
| `src/cli/capability-cli.test.ts` | the file that already owns these cases (test-only) |
| `config/assertion-safety-baseline.txt` | not a choice. Deleting the four `normalize*` helpers removes SAFETY-commented assertions with them, so `image.ts` goes 21 → 11 and `video.ts` 7 → 6. `check:changed` runs a ratchet that requires the baseline to shrink when the count does, and it fails the build otherwise. Only those two counts are edited; the file's unrelated drift is left alone |

**Limitations:** the capture below covers the option-resolution boundary only, not a billed provider
response — see *What was not tested*.

Named follow-up (not in this PR): `src/agents/tools/image-generate-tool.ts` carries eight more copies of
the same closed-union policy — `normalizeResolution` (:298), `normalizeAspectRatio` (:309),
`normalizeQuality` (:322), `normalizeOutputFormat` (:333), `normalizeOpenAIBackground` (:344),
`normalizeBackground` (:357), `normalizeOpenAIModeration` (:368) and `normalizeFalCreativity` (:381).
They are a different owner because they raise `ToolInputError` rather than `Error`: the agent-tool
contract surfaces validation failures to the model as tool-input errors, so folding them in would mean
parameterising the helper by error type and changing a model-facing contract. Worth doing, separately.

## User Impact

`capability image generate` and `capability image edit` now fail immediately with the accepted set —
`--resolution must be one of 1K, 2K, or 4K` — instead of proceeding with the override silently dropped.
What that replaces, on the evidence here, is a run that continues with no resolution override (measured)
and therefore a generation at whatever the provider defaults to (not observed — see *Evidence*). Case and surrounding whitespace are accepted as they already were for
`video generate`, so `2k` and `" 2k "` both resolve to `2K` rather than being rejected. The capture
below covers `2k`; the whitespace-padded form is covered by the added
`it.each(["2k", " 2k "])` case in `src/cli/capability-cli.test.ts`.

Scripts passing a canonical value (`1K`, `2K`, `4K`) are unaffected. Scripts passing a **non-canonical
spelling of a valid value** see one observable change: `2k` or `" 2k "` previously reached the provider
as the literal string the user typed, because the bare cast forwarded it unchanged; they now arrive
canonicalized to `2K`. That matches what `video generate` has always done and what the geometry layer
would have resolved them to anyway, but it is a change at the boundary and worth knowing. The tested
cases are `4K` (pre-existing assertion), `2k` and `" 2k "` (added); the remaining valid spellings follow
from the helper matching the declared list case-insensitively rather than from a per-value test. Scripts that
pass something outside that set were already not getting the resolution they asked for; they now find
out. Scripts passing `8K` previously got whichever supported value was nearest — `4K` for a model
publishing `1K, 2K, 4K` — and now get an error.

## Evidence

## Real behavior proof

Behavior addressed: `capability image generate|edit --resolution <unrecognized>` is accepted at the
option boundary and then silently discarded, so the run continues to provider dispatch instead of
failing with the advertised set.
Real environment tested: Linux x86_64, node v24.18.0. Baseline `b8d6e799a31d` (the merge base this
branch is rebased onto; spelled as a SHA because `upstream/main` moves),
candidate `0488506b460a`. **No provider credentials were configured on either side, so no paid
generation was executed** — the defect is entirely upstream of provider dispatch, so the capture
does not need them.

How a silent drop is observed without credentials: every case passes `--model bogus` (no `/`).
`requireProviderModelOverride(params.model)` is the **first statement of `runImageGenerate`**
(`src/cli/capability-cli/image.ts:72`), and the provider call is 18 lines further down at `:90`
(`await generateImage({...})`). `runImageGenerate` is only invoked after
`resolveImageGenerationOptions(opts)` has been evaluated to build its argument object — `:305` for
`image generate`, `:324` for `image edit`. So the ordering is checkable from three line numbers, not
from the harness's labels: option resolution, then the model check at `:72`, then the provider at `:90`.
The message that surfaces therefore names the stage the run reached — `Model overrides must use the form
<provider/model>.` means option resolution accepted the value and execution moved on;
`--resolution must be one of 1K, 2K, or 4K` means it never got that far.

To be precise about what this capture does and does not show: it shows **which stage the run reached**
— that and nothing more. It does not contain a provider invocation counter. In particular the
`reachedProviderModelCheck` field is an execution-stage witness — it means "the run got as far as
`requireProviderModelOverride`" — and is **not** a claim that any provider request was attempted; no
request is attempted anywhere in this capture. The inference that the
provider is never called is structural: `generateImage` is invoked well after
`requireProviderModelOverride`, so a run that never reaches the model check cannot have reached the
provider. The literal call count is asserted separately, by the focused tests below, which assert the
generation mock was called zero times.

One thing to read carefully in the capture: the message list the harness prints at the top of each
block is **identical in BEFORE and AFTER, and includes `--resolution must be one of` even though the
baseline has no such validator and never emits it.** That is deliberate. The harness is byte-identical
on both sides — it declares one classification vocabulary and cannot tell which side it is running on,
which is what keeps the two runs comparable. So that list is the harness's configured vocabulary, not a
claim about what the baseline produces; the BEFORE rows show the message never appearing, which is the
finding.

Five control rows run in the same capture, in three classes, and every one of them is **identical on
both sides** — which is what makes the three differing rows readable rather than assumed:

- `--quality bogus` dies at option resolution on both sides → the observation window can see
  rejection at that stage, so the BEFORE rows are not just "the probe cannot see it".
- `--resolution 2K` and `2k` pass option resolution on both sides → valid values are unaffected.
- `video generate --resolution 9000P` / `768p` behave identically on both sides → absorbing the
  sibling command's normalizer into the shared helper is inert.

The same witness holds for `image edit` because both subcommand actions spread the result of the same
`resolveImageGenerationOptions` call into `runImageGenerate`; `edit` is therefore covered by the same
two stages, and it has its own row in the capture rather than being argued by analogy.

The five files listed in *Non-scope* are this PR's entire diff — the fourth is the test file and the
fifth is the ratchet baseline that deleting the helpers forces to shrink; the production surface is the
first three. The ClawProof harness, scenario and
evidence package are generated artifacts held outside the repository and are **not** part of this PR,
which is why the harness appears as `<harness>` below. The hand-run commands further down reproduce the
primary `1080p` rows for both subcommands and both controls without it. The `8K` and video rows appear
in the capture as well; `hd` is covered by the focused tests only and is not a capture row.

Exact steps or command run after this patch:

```sh
clawproof work start capability-image-resolution-union --baseline b8d6e799a31d469f60277427472b87036b1f9be7
git -C ~/.clawproof/work-items/capability-image-resolution-union/after reset --hard 0488506b460a6c388e8e03043b045e8ba1cb3bef
clawproof build plan capability-image-resolution-union --worktree before --apply
clawproof build plan capability-image-resolution-union --worktree after --apply
# Each side runs the same harness, which drives the real registered commander tree and
# spawns one child process per case so the CLI's own `process.exit` path is what is read:
#   PROOF_MODULE=src/cli/capability-cli.ts node --import tsx <harness> ...
clawproof prove capability-image-resolution-union --scenario default --final --problem-file docs/work-items/capability-image-resolution-union/proof/problem.md
ocw proof import capability-image-resolution-union
```

The observations, if you would rather run them by hand in a checkout with no provider key
configured (`--model bogus` is what makes the stage readable, as explained below):

```sh
pnpm openclaw capability image generate --prompt x --model bogus --resolution 1080p --json
# The input only has to exist; option resolution runs before the file is ever read. Written to a
# temp dir so nothing is left behind in the checkout:
IN=$(mktemp -d)/in.png
trap 'rm -rf "$(dirname "$IN")"' EXIT
printf 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+yf7kAAAAASUVORK5CYII=' | base64 -d > "$IN"
pnpm openclaw capability image edit --prompt x --model bogus --file "$IN" --resolution 1080p --json
pnpm openclaw capability image generate --prompt x --model bogus --quality bogus --json   # control
pnpm openclaw capability image generate --prompt x --model bogus --resolution 2K --json   # control
```

Before (pre-fix):

```text
===== BEFORE (baseline b8d6e799a31d, unfixed source) =====
--- harness.stderr ---
[harness: running image-generate-video-style-resolution]
[harness: running image-edit-video-style-resolution]
[harness: running image-generate-above-range-resolution]
[harness: running image-generate-invalid-quality]
[harness: running image-generate-valid-resolution]
[harness: running image-generate-lowercase-valid-resolution]
[harness: running video-generate-invalid-resolution]
[harness: running video-generate-lowercase-valid-resolution]
--- harness.stdout ---
{
  "moduleUnderTest": "src/cli/capability-cli.ts",
  "driver": "real registered commander tree via registerCapabilityCli, one child process per case",
  "stageWitness": {
    "optionResolution": [
      "--resolution must be one of",
      "--quality must be one of",
      "video resolution must be one of"
    ],
    "firstStatementAfterOptionResolution": "Model overrides must use the form <provider/model>."
  },
  "results": [
    {
      "case": "image-generate-video-style-resolution",
      "role": "defect",
      "argvTail": "--resolution 1080p",
      "exitCode": 1,
      "reported": "Error: Model overrides must use the form <provider/model>.",
      "stage": "accepted-by-option-resolution-then-ran",
      "providerCredentialsConfigured": false,
      "reachedProviderModelCheck": true
    },
    {
      "case": "image-edit-video-style-resolution",
      "role": "defect-sibling-subcommand",
      "argvTail": "--resolution 1080p",
      "exitCode": 1,
      "reported": "Error: Model overrides must use the form <provider/model>.",
      "stage": "accepted-by-option-resolution-then-ran",
      "providerCredentialsConfigured": false,
      "reachedProviderModelCheck": true
    },
    {
      "case": "image-generate-above-range-resolution",
      "role": "disclosed-behaviour-change",
      "argvTail": "--resolution 8K",
      "exitCode": 1,
      "reported": "Error: Model overrides must use the form <provider/model>.",
      "stage": "accepted-by-option-resolution-then-ran",
      "providerCredentialsConfigured": false,
      "reachedProviderModelCheck": true
    },
    {
      "case": "image-generate-invalid-quality",
      "role": "control-rejection-visible",
      "argvTail": "--quality bogus",
      "exitCode": 1,
      "reported": "Error: --quality must be one of low, medium, high, or auto",
      "stage": "rejected-at-option-resolution",
      "providerCredentialsConfigured": false,
      "reachedProviderModelCheck": false
    },
    {
      "case": "image-generate-valid-resolution",
      "role": "control-acceptance-visible",
      "argvTail": "--resolution 2K",
      "exitCode": 1,
      "reported": "Error: Model overrides must use the form <provider/model>.",
      "stage": "accepted-by-option-resolution-then-ran",
      "providerCredentialsConfigured": false,
      "reachedProviderModelCheck": true
    },
    {
      "case": "image-generate-lowercase-valid-resolution",
      "role": "control-acceptance-visible",
      "argvTail": "--resolution 2k",
      "exitCode": 1,
      "reported": "Error: Model overrides must use the form <provider/model>.",
      "stage": "accepted-by-option-resolution-then-ran",
      "providerCredentialsConfigured": false,
      "reachedProviderModelCheck": true
    },
    {
      "case": "video-generate-invalid-resolution",
      "role": "control-sibling-unchanged",
      "argvTail": "--resolution 9000P",
      "exitCode": 1,
      "reported": "Error: video resolution must be one of 360P, 480P, 540P, 720P, 768P, or 1080P",
      "stage": "rejected-at-option-resolution",
      "providerCredentialsConfigured": false,
      "reachedProviderModelCheck": false
    },
    {
      "case": "video-generate-lowercase-valid-resolution",
      "role": "control-sibling-unchanged",
      "argvTail": "--resolution 768p",
      "exitCode": 1,
      "reported": "Error: Model overrides must use the form <provider/model>.",
      "stage": "accepted-by-option-resolution-then-ran",
      "providerCredentialsConfigured": false,
      "reachedProviderModelCheck": true
    }
  ]
}
```

Evidence after fix:

```text
===== AFTER (candidate 0488506b460a, fix applied) =====
--- harness.stderr ---
[harness: running image-generate-video-style-resolution]
[harness: running image-edit-video-style-resolution]
[harness: running image-generate-above-range-resolution]
[harness: running image-generate-invalid-quality]
[harness: running image-generate-valid-resolution]
[harness: running image-generate-lowercase-valid-resolution]
[harness: running video-generate-invalid-resolution]
[harness: running video-generate-lowercase-valid-resolution]
--- harness.stdout ---
{
  "moduleUnderTest": "src/cli/capability-cli.ts",
  "driver": "real registered commander tree via registerCapabilityCli, one child process per case",
  "stageWitness": {
    "optionResolution": [
      "--resolution must be one of",
      "--quality must be one of",
      "video resolution must be one of"
    ],
    "firstStatementAfterOptionResolution": "Model overrides must use the form <provider/model>."
  },
  "results": [
    {
      "case": "image-generate-video-style-resolution",
      "role": "defect",
      "argvTail": "--resolution 1080p",
      "exitCode": 1,
      "reported": "Error: --resolution must be one of 1K, 2K, or 4K",
      "stage": "rejected-at-option-resolution",
      "providerCredentialsConfigured": false,
      "reachedProviderModelCheck": false
    },
    {
      "case": "image-edit-video-style-resolution",
      "role": "defect-sibling-subcommand",
      "argvTail": "--resolution 1080p",
      "exitCode": 1,
      "reported": "Error: --resolution must be one of 1K, 2K, or 4K",
      "stage": "rejected-at-option-resolution",
      "providerCredentialsConfigured": false,
      "reachedProviderModelCheck": false
    },
    {
      "case": "image-generate-above-range-resolution",
      "role": "disclosed-behaviour-change",
      "argvTail": "--resolution 8K",
      "exitCode": 1,
      "reported": "Error: --resolution must be one of 1K, 2K, or 4K",
      "stage": "rejected-at-option-resolution",
      "providerCredentialsConfigured": false,
      "reachedProviderModelCheck": false
    },
    {
      "case": "image-generate-invalid-quality",
      "role": "control-rejection-visible",
      "argvTail": "--quality bogus",
      "exitCode": 1,
      "reported": "Error: --quality must be one of low, medium, high, or auto",
      "stage": "rejected-at-option-resolution",
      "providerCredentialsConfigured": false,
      "reachedProviderModelCheck": false
    },
    {
      "case": "image-generate-valid-resolution",
      "role": "control-acceptance-visible",
      "argvTail": "--resolution 2K",
      "exitCode": 1,
      "reported": "Error: Model overrides must use the form <provider/model>.",
      "stage": "accepted-by-option-resolution-then-ran",
      "providerCredentialsConfigured": false,
      "reachedProviderModelCheck": true
    },
    {
      "case": "image-generate-lowercase-valid-resolution",
      "role": "control-acceptance-visible",
      "argvTail": "--resolution 2k",
      "exitCode": 1,
      "reported": "Error: Model overrides must use the form <provider/model>.",
      "stage": "accepted-by-option-resolution-then-ran",
      "providerCredentialsConfigured": false,
      "reachedProviderModelCheck": true
    },
    {
      "case": "video-generate-invalid-resolution",
      "role": "control-sibling-unchanged",
      "argvTail": "--resolution 9000P",
      "exitCode": 1,
      "reported": "Error: video resolution must be one of 360P, 480P, 540P, 720P, 768P, or 1080P",
      "stage": "rejected-at-option-resolution",
      "providerCredentialsConfigured": false,
      "reachedProviderModelCheck": false
    },
    {
      "case": "video-generate-lowercase-valid-resolution",
      "role": "control-sibling-unchanged",
      "argvTail": "--resolution 768p",
      "exitCode": 1,
      "reported": "Error: Model overrides must use the form <provider/model>.",
      "stage": "accepted-by-option-resolution-then-ran",
      "providerCredentialsConfigured": false,
      "reachedProviderModelCheck": true
    }
  ]
}
```

Observed result after fix: the three defect rows flip from `accepted-by-option-resolution-then-ran`
to `rejected-at-option-resolution` with `reachedProviderModelCheck: false`, on **both** `image
generate` and `image edit`. Every control row is byte-identical to its BEFORE counterpart.
What was not tested: a real billed generation. No provider credential was configured, so this
capture covers the option-resolution boundary and the stage the run reaches — not the provider
response. Two claims in this body are therefore source-based inference, not capture:

- **the old `8K` substitution** — `resolveClosestResolution`, called from
  `src/media-generation/geometry-normalization.ts:116`, ranks the requested
  value against whatever list the resolved model publishes and `:122` records
  `normalization.resolution = { requested, applied }` when the nearest supported value differs. For a
  model publishing `["1K", "2K", "4K"]` the nearest value to `8K` is `4K`; for a model publishing a
  narrower list it would be that list's maximum instead. The capture above only shows that pre-fix
  `8K` got past option resolution — not the clamp, and not any particular clamped value.
- **why an unparseable value leaves no trace** — the three lines listed under *What Problem This
  Solves* (`geometry-normalization.ts:115,123`, `image-generation/normalization.ts:43`,
  `capability-cli/shared.ts:75-76`). Readable from source; not shown by this capture.
Focused tests are supporting evidence; the real-CLI capture above is the primary proof.

### Focused tests

`node scripts/run-vitest.mjs src/cli/capability-cli.test.ts` → **198 passed**.

What already existed, unchanged in intent and still passing: rejection assertions for
`--output-format`, `--background`, `--openai-background`, `--openai-moderation` and `--quality`
(these are the "all five were already pinned by tests" messages referred to above), the
`--resolution 4K` forwarding assertion, and video's `768p → 768P` forwarding assertion.

What this PR changes about them: those five sequential assertions are consolidated into one
table-driven block, so the new coverage lands where this shape was already owned instead of in a
near-duplicate test, and every row now runs **both** `image generate` and `image edit` and asserts
the generation mock was called zero times — so the tests prove non-dispatch, not just the message.

What this PR adds: `--resolution 1080p` and `hd` rejection rows, an `8K` rejection row that pins the
behaviour change deliberately, the `2k` / `" 2k "` case-insensitivity case, and a first rejection test
for `video generate` — replacing its normalizer previously had no message-level coverage at all.

The exact matrix, since the row count and the failure count are different numbers:

- The rejection table has **8 rows** (5 pre-existing flags + `1080p` + `hd` + `8K`). Each row is **one**
  `it.each` case whose body issues **two** CLI invocations — `image generate` and then `image edit` —
  and asserts the same message for both, then asserts the generation mock was called zero times. So 8
  cases, 16 invocations.
- The case-insensitivity test is a separate `it.each` over `["2k", " 2k "]` = **2 cases**, on `image
  generate` only, asserting the forwarded value is `"2K"`.
- The revert check below therefore fails **7 tests**, not 8: the **3** resolution rows of the
  rejection table, the **2** case-insensitivity cases, the **1** new video rejection test, and the
  **1** pre-existing video `768p → 768P` forwarding assertion. The 5 pre-existing rejection rows keep
  passing, which is the point — the refactor alone has no teeth, the fix does.
- The `image edit` coverage difference between the tests and the capture is deliberate: the tests
  cover `edit` on **all 8** rejection rows, while the ClawProof capture below carries **one** `edit`
  row (the primary defect value, `1080p`) because a capture row costs a process and the two
  subcommands demonstrably share the same seam.

Revert check — and the exact patch matters, so to be precise: **both** `--resolution` call sites were
put back to a bare cast (`resolution: opts.resolution as ImageGenerationResolution | undefined` in
`image.ts`, and the `VideoGenerationResolution` equivalent in `video.ts`) while the shared helper and
all five other option sites stayed routed through it. Reverting the whole files instead would break the
`parseUnionOption` import and fail for the wrong reason.

That reverted tree fails exactly 7 tests:

| failing test | why |
|---|---|
| `--resolution 1080p`, `hd`, `8K` rejection rows (3) | image `--resolution` is unvalidated again |
| `2k` / `" 2k "` case-insensitivity (2) | the bare cast forwards `"2k"` verbatim instead of `"2K"` |
| new `video generate --resolution 9000P` rejection (1) | video's call site was reverted too |
| pre-existing video `768p → 768P` forwarding (1) | same — the bare cast no longer upper-cases |

The 5 pre-existing image enum rows keep passing throughout, because their routing is untouched by that
revert. Together those two facts are the causal claim: the refactor alone has no teeth, each
`--resolution` call site does, and video's brand-new test is load-bearing rather than decorative.

### Diff scope

`git diff --numstat b8d6e799a31d469f60277427472b87036b1f9be7 0488506b460a6c388e8e03043b045e8ba1cb3bef`
— the same base and candidate SHAs used by the proof above, so the scope claims are checkable rather
than asserted:

```text
2	2	config/assertion-safety-baseline.txt
67	72	src/cli/capability-cli.test.ts
21	70	src/cli/capability-cli/image.ts
22	0	src/cli/capability-cli/shared.ts
10	19	src/cli/capability-cli/video.ts
```

Production = the three non-test source files: **+53 / −89, net −36**. Tests = **+67 / −72**. The
fifth file is the repository's `max-lines`-style ratchet for assertion SAFETY comments: removing four
`normalize*` helpers takes `image.ts` from 21 assertions to 11 and `video.ts` from 7 to 6, and that
baseline may only shrink, so the two counts are lowered to match. No file under `src/config/`,
`src/plugins/`, `extensions/`, `docs/` or `.github/` appears, which is the concrete form of the
"no config, default or plugin surface" claim.

### Local gates

`oxfmt` clean, `oxlint` clean, and the `tsgo` core and core-test projects both exit 0.

`pnpm check:changed --base b8d6e799a31d469f60277427472b87036b1f9be7` is **green on this head**,
including the two whole-repo ratchets it selects. The base is spelled as a SHA rather than
`upstream/main` so the command reproduces the same result later; it is the same base the diff and the
proof above pin:

```text
[check:changed] lanes=core, coreTests
[check:changed] max-lines suppression ratchet   -> max-lines ratchet OK: 897 grandfathered suppressions.
[check:changed] assertion SAFETY comment ratchet -> assertion SAFETY ratchet OK: 4274 files, 13435 grandfathered assertions.
```

An earlier revision of this body disclosed a red `max-lines` lane naming two files outside this diff;
upstream has since cleared both, so that disclosure no longer applies and the lane passes on this base.

The assertion SAFETY lane is the one this change has to touch, and the reason is mechanical: the four
`normalize*` helpers this PR deletes contained SAFETY-commented assertions, so `image.ts` drops from 21
to 11 and `video.ts` from 7 to 6. That baseline may only shrink, so the two counts are lowered in the
same commit. Nothing else in `config/assertion-safety-baseline.txt` is touched — the file's own drift
for unrelated paths is left where it is rather than folded in here.

Remote delegation (Crabbox/Testbox) was unavailable in this environment, so these gates ran locally.
