### PR TITLE
fix(ui): confirm before logging out WhatsApp accounts

### DIFF
--- a/ui/src/e2e/channels-whatsapp-logout.e2e.test.ts
+++ b/ui/src/e2e/channels-whatsapp-logout.e2e.test.ts
@@ -1,6 +1,6 @@
 // Control UI tests cover WhatsApp logout feedback against a mocked Gateway.
 import { expect, it } from "vitest";
-import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { installMockGateway, waitForConfirmModal } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -13,7 +13,7 @@ const QR_DATA_URL =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WlY9Z8AAAAASUVORK5CYII=";
 
 suite.define(() => {
-  it("keeps the QR visible and explains a no-op logout", async () => {
+  it("confirms the explicit default account and preserves a no-op logout", async () => {
     await suite.withPage(
       {
         locale: "en-US",
@@ -72,6 +72,30 @@ suite.define(() => {
         await expect(qr.getAttribute("src")).resolves.toBe(QR_DATA_URL);
 
         await detail.getByRole("button", { name: "Logout" }).click();
+        await expect.poll(async () => gateway.getRequests("channels.logout")).toHaveLength(0);
+        const firstConfirm = await waitForConfirmModal(page);
+        await expect(firstConfirm.textContent()).resolves.toContain(
+          "Log out of WhatsApp account default?",
+        );
+        await expect(firstConfirm.textContent()).resolves.toContain(
+          "Logging out of account default stops its listener and deletes its saved credentials.",
+        );
+        await firstConfirm.getByRole("button", { name: "Cancel" }).click();
+        await expect.poll(() => page.locator("openclaw-modal-dialog").count()).toBe(1);
+        await expect.poll(async () => gateway.getRequests("channels.logout")).toHaveLength(0);
+        await expect(qr.getAttribute("src")).resolves.toBe(QR_DATA_URL);
+        await expect
+          .poll(() =>
+            detail
+              .locator("dt", { hasText: "Linked" })
+              .locator("xpath=following-sibling::dd[1]")
+              .textContent(),
+          )
+          .toContain("Yes");
+
+        await detail.getByRole("button", { name: "Logout" }).click();
+        const secondConfirm = await waitForConfirmModal(page);
+        await secondConfirm.getByRole("button", { name: "Logout" }).click();
         await expect
           .poll(async () => detail.locator(".settings-row__desc").allTextContents())
           .toContain(
@@ -80,9 +104,74 @@ suite.define(() => {
         await expect(qr.getAttribute("src")).resolves.toBe(QR_DATA_URL);
         await expect(detail.getByText("Logged out.", { exact: true }).count()).resolves.toBe(0);
         await expect.poll(async () => gateway.getRequests("channels.logout")).toHaveLength(1);
+        expect((await gateway.getRequests("channels.logout"))[0]?.params).toEqual({
+          channel: "whatsapp",
+          accountId: "default",
+        });
         await expect.poll(async () => gateway.getRequests("channels.status")).toHaveLength(3);
       },
     );
+  });
+
+  it("rejects a captured custom-account logout after the Gateway reconnects", async () => {
+    await suite.withPage({ locale: "en-US", serviceWorkers: "block" }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "channels.status": {
+            ts: Date.now(),
+            channelOrder: ["whatsapp"],
+            channelLabels: { whatsapp: "WhatsApp" },
+            channels: {
+              whatsapp: {
+                configured: true,
+                linked: true,
+                running: true,
+                connected: true,
+                reconnectAttempts: 0,
+              },
+            },
+            channelAccounts: {
+              whatsapp: [
+                {
+                  accountId: "work",
+                  configured: true,
+                  linked: true,
+                  running: true,
+                  connected: true,
+                },
+              ],
+            },
+            channelDefaultAccountId: { whatsapp: "work" },
+          },
+          "channels.pairing.list": {
+            accounts: [],
+            requests: [],
+            commandOwnerConfigured: true,
+            limits: { pendingPerAccount: 3, ttlMs: 3_600_000 },
+          },
+          "channels.logout": {
+            channel: "whatsapp",
+            accountId: "work",
+            cleared: true,
+            loggedOut: true,
+          },
+        },
+      });
+
+      await page.goto(`${suite.server.baseUrl}settings/channels`);
+      await page.locator(".channels-item", { hasText: "WhatsApp" }).first().click();
+      const detail = page.locator(".channels-detail");
+      await detail.waitFor();
+      await detail.getByRole("button", { name: "Logout" }).click();
+      const confirm = await waitForConfirmModal(page);
+      await expect(confirm.textContent()).resolves.toContain("work");
+      const socketCount = await gateway.getSocketCount();
+      await gateway.closeLatest(1012, "Reconnect during logout confirmation");
+      await expect.poll(() => gateway.getSocketCount()).toBeGreaterThan(socketCount);
+      await confirm.getByRole("button", { name: "Logout" }).click();
+      await expect.poll(() => page.locator("openclaw-modal-dialog").count()).toBe(1);
+      await expect.poll(async () => gateway.getRequests("channels.logout")).toHaveLength(0);
+    });
   });
 
   it("preserves standard channel details and the complete Telegram setup wizard", async () => {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -292,6 +292,9 @@ export const en: TranslationMap = {
       subtitle: "Link WhatsApp Web and monitor connection health.",
       phoneNumber: "Phone number",
       loggedOut: "Logged out.",
+      logoutConfirmTitle: "Log out of WhatsApp account {accountId}?",
+      logoutConfirmMessage:
+        "Logging out of account {accountId} stops its listener and deletes its saved credentials.",
       logoutNotCleared:
         "No stored WhatsApp session was cleared. It may already be absent, or its auth directory may require manual cleanup.",
     },

--- a/ui/src/pages/channels/channels-page.ts
+++ b/ui/src/pages/channels/channels-page.ts
@@ -27,6 +27,7 @@ import { importNostrProfile, parseValidationErrors, putNostrProfile } from "./no
 import { createNostrProfileFormState } from "./view.nostr-profile-form.ts";
 import { renderChannels } from "./view.ts";
 import type { ChannelPairingPrompt } from "./view.types.ts";
+import { runWhatsAppLogoutConfirmation } from "./whatsapp-logout.ts";
 import { ChannelWizardHost } from "./wizard-host.ts";
 
 type NostrProfileFormState = ReturnType<typeof createNostrProfileFormState> | null;
@@ -281,6 +282,23 @@ class ChannelsPage extends OpenClawLightDomElement {
     }
     await context.runtimeConfig.refresh({ discardPendingChanges: true });
     await context.channels.refresh(true);
+  }
+
+  private async confirmWhatsAppLogout() {
+    const context = this.context;
+    const channels = context.channels;
+    const scope = this.gateway.capture();
+    if (!scope || this.channelsSource !== channels) {
+      return;
+    }
+    await runWhatsAppLogoutConfirmation({
+      channels,
+      getWizardAccountId: () => this.wizardHost.whatsappAccountId,
+      isCurrent: () =>
+        this.gateway.isCurrent(scope) &&
+        this.context === context &&
+        this.channelsSource === channels,
+    });
   }
 
   private resolveNostrAccountId(): string {
@@ -706,8 +724,7 @@ class ChannelsPage extends OpenClawLightDomElement {
             void context.channels.startWhatsApp(force, this.wizardHost.whatsappAccountId),
           onWhatsAppWait: () =>
             void context.channels.waitWhatsApp(this.wizardHost.whatsappAccountId),
-          onWhatsAppLogout: () =>
-            void context.channels.logoutWhatsApp(this.wizardHost.whatsappAccountId),
+          onWhatsAppLogout: () => void this.confirmWhatsAppLogout(),
           onShowAdvancedSettings: (enabled) => this.setShowAdvancedSettings(enabled),
           onConfigPatch: (path, value) => context.runtimeConfig.patchForm(path, value),
           onConfigSave: () => void this.saveChannelConfig(),

--- a/ui/src/pages/channels/whatsapp-logout.ts
+++ b/ui/src/pages/channels/whatsapp-logout.ts
@@ -1,0 +1,60 @@
+// Page-side WhatsApp logout confirmation preserves the selected account and
+// Gateway owner across the operator's awaited decision.
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
+import type { ApplicationContext } from "../../app/context.ts";
+import { showConfirmDialog } from "../../components/confirm-dialog.ts";
+import { t } from "../../i18n/index.ts";
+import { resolveChannelAccounts } from "../../lib/channels/index.ts";
+
+type WhatsAppLogoutParams = {
+  channels: ApplicationContext["channels"];
+  getWizardAccountId: () => string | undefined;
+  isCurrent: () => boolean;
+};
+
+function resolveWhatsAppLogoutAccount(
+  channels: ApplicationContext["channels"],
+  wizardAccountId: string | undefined,
+) {
+  const snapshot = channels.state.channelsSnapshot;
+  const accountId = wizardAccountId ?? snapshot?.channelDefaultAccountId.whatsapp ?? "default";
+  const account = resolveChannelAccounts(snapshot?.channelAccounts, "whatsapp").find(
+    (candidate) => candidate.accountId === accountId,
+  );
+  if (!account && wizardAccountId !== undefined) {
+    return null;
+  }
+  return {
+    accountId,
+    linked:
+      account?.linked ??
+      (wizardAccountId === undefined
+        ? asNullableRecord(snapshot?.channels.whatsapp)?.linked
+        : undefined),
+  };
+}
+
+export async function runWhatsAppLogoutConfirmation(params: WhatsAppLogoutParams): Promise<void> {
+  const account = resolveWhatsAppLogoutAccount(params.channels, params.getWizardAccountId());
+  if (!account || !params.isCurrent()) {
+    return;
+  }
+  const confirmed = await showConfirmDialog({
+    title: t("channels.whatsapp.logoutConfirmTitle", { accountId: account.accountId }),
+    message: t("channels.whatsapp.logoutConfirmMessage", { accountId: account.accountId }),
+    confirmLabel: t("common.logout"),
+    danger: true,
+  });
+  if (!confirmed || !params.isCurrent()) {
+    return;
+  }
+  const currentAccount = resolveWhatsAppLogoutAccount(params.channels, params.getWizardAccountId());
+  if (
+    !currentAccount ||
+    currentAccount.accountId !== account.accountId ||
+    currentAccount.linked !== account.linked
+  ) {
+    return;
+  }
+  await params.channels.logoutWhatsApp(account.accountId);
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where clicking **Logout** for a linked WhatsApp account immediately stopped its listener and deleted saved credentials, without an in-app confirmation. An accidental click could therefore disrupt a working account with no chance to cancel.

## Why This Change Was Made

The Channels page now owns an account-bound destructive confirmation. It captures the effective WhatsApp account, waits for the operator's decision, and then revalidates the same Gateway lifecycle, page/channel owner, account selection, and linkage state before sending one explicit logout request. If the connection or account changes while the modal is open, the action fails closed.

The confirmation lifecycle lives in a focused page-side module so the channel renderer and Gateway remain transport-only, and so the existing Channels page stays below its line-count limit.

AI-assisted: yes. The final implementation was manually reviewed, exercised through the rendered Control UI, and passed fresh structured autoreview.

## User Impact

Operators now see which WhatsApp account will be logged out and what the action deletes. Cancel leaves the linked session and QR state untouched. Confirm preserves the existing success and no-op cleanup feedback, while reconnects or account changes cannot redirect a stale confirmation to a replacement account.

## Evidence

**Before action:** the linked-account detail where Logout previously dispatched immediately.

![Linked WhatsApp detail before logout](https://github.com/user-attachments/assets/6045b610-53f6-4145-94ef-396cbb7db885)

**After:** Logout opens an account-named, destructive in-app confirmation.

![WhatsApp logout confirmation](https://github.com/user-attachments/assets/0b077374-0de0-4110-a19c-fba25bc01b49)

Validation:

- Regression written against the rendered page and mock Gateway: the pre-fix path sent one `channels.logout` request on the first click; the fixed path sends zero before confirmation.
- `node scripts/run-vitest.mjs ui/src/e2e/channels-whatsapp-logout.e2e.test.ts` — 3/3 passed.
- `node scripts/check-changed.mjs -- ui/src/pages/channels/channels-page.ts ui/src/pages/channels/whatsapp-logout.ts ui/src/i18n/locales/en.ts ui/src/e2e/channels-whatsapp-logout.e2e.test.ts` — passed on Testbox `tbx_01kzt3p03n1jk00jyqnfenk58x` ([run](https://github.com/openclaw/openclaw/actions/runs/31563396860)).
- `pnpm build` — passed on Testbox `tbx_01kzt3zn2kbwgqsa6dtej4k0za` ([run](https://github.com/openclaw/openclaw/actions/runs/31563676919)).
- Hosted exact-head CI — green ([run](https://github.com/openclaw/openclaw/actions/runs/31564019431)).
- Fresh rebased-head autoreview — clean, no accepted/actionable findings.
- Production/i18n: +82/−2 lines; tests: +91/−2 lines. The growth is the account-resolution, confirmation, stale-owner validation, and required page split; no Gateway or channel-controller path was added.
