### PR TITLE
fix(delivery): clear resolved ambiguity notices

### DIFF
--- a/src/infra/outbound/delivery-completion.test.ts
+++ b/src/infra/outbound/delivery-completion.test.ts
@@ -136,7 +136,7 @@ describe("pending-final delivery completion", () => {
 
   it("does not owe a notice for the pre-dispatch claim or terminal outcomes", async () => {
     await installContextOnPendingFinal();
-    // prepared -> unknown is the pre-I/O claim on every healthy send.
+    await settlePendingFinalDelivery(completion, "queued", ["prepared"]);
     await settlePendingFinalDelivery(completion, "unknown", ["prepared", "queued"]);
     await settlePendingFinalDelivery(completion, "delivered");
 

--- a/src/infra/outbound/delivery-completion.ts
+++ b/src/infra/outbound/delivery-completion.ts
@@ -94,9 +94,6 @@ export async function settlePendingFinalDelivery(
         current === "suppressed" ||
         (current === "unknown" && state === "unknown");
       settled = terminal ? current : state;
-      // Unknown affirmed after a claimed send is ambiguity the user must hear
-      // about: record durable notice debt for the next same-route turn. The
-      // prepared->unknown transition is the pre-I/O claim and never owes one.
       const pending = internalEntry.pendingFinalDelivery;
       const existingNotice = internalEntry.pendingDeliveryNotice;
       const owedNotice =
@@ -115,7 +112,13 @@ export async function settlePendingFinalDelivery(
               },
             }
           : undefined;
-      if (settled === current && !owedNotice) {
+      const clearsNotice =
+        settled !== "queued" &&
+        settled !== "unknown" &&
+        existingNotice?.intentId === pending.intentId;
+      // The pre-I/O claim preserves crash-window ambiguity. Any authoritative
+      // fate for that intent must clear debt before a later turn can surface it.
+      if (settled === current && !owedNotice && !clearsNotice) {
         return null;
       }
       wakeRecovery =
@@ -135,7 +138,7 @@ export async function settlePendingFinalDelivery(
           ...internalEntry.pendingFinalDelivery,
           deliveries: deliveries.with(index, { id: completion.deliveryId, state: settled }),
         },
-        ...owedNotice,
+        ...(clearsNotice ? { pendingDeliveryNotice: undefined } : owedNotice),
         updatedAt: Date.now(),
       };
     },


### PR DESCRIPTION
## Summary
- clear pending delivery-notice debt when the same final reaches an authoritative terminal outcome
- cover the real `prepared -> queued -> unknown -> delivered` sequence

## Root cause
The pre-platform-I/O custody claim records `unknown` and creates notice debt. Successful settlement moved the delivery to `delivered` but left that debt behind, so the next same-route inbound turn emitted a false uncertainty notice.

## Proof
- regression fails under the old rule with an owed notice after `delivered`
- `node scripts/run-vitest.mjs src/infra/outbound/` (169 files, 2567 tests)
- targeted type-aware Oxlint
- `pnpm tsgo`
- `pnpm check:test-types`
- production LOC: +3 net; same-row terminal cleanup, no new I/O

Co-authored-by: Ayaan Zaidi <hi@obviy.us>

## Telegram E2E verdict
```json
{"head":"d8cc635de3562f02a3c899c9a669b9fd84c1fb3f","realUserDm":true,"providerRequests":2,"secondTurnSutMessages":1,"secondTurnText":"OPENCLAW_E2E_SECOND","uncertaintyNoticeMatches":0,"scratchRemoved":true}
```