### PR TITLE
refactor(agents): split cli-runner into concept modules

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -336,7 +336,6 @@ src/agents/btw.ts
 src/agents/cli-auth-epoch.test.ts
 src/agents/cli-runner.reliability.test.ts
 src/agents/cli-runner.spawn.test.ts
-src/agents/cli-runner.ts
 src/agents/cli-runner/execute.supervisor-capture.test.ts
 src/agents/cli-runner/prepare.test.ts
 src/agents/cli-runner/prepare.ts

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -40,7 +40,7 @@ import {
   buildCliDeliveredFailure,
   buildCliRunResult,
   cliRunSettlementDeps,
-  isClaudeCliProvider,
+  isClaudeCliBackend,
   resolveCliSourceReplyMirror,
   settleCliBackendOutcome,
   settleCliPreparationError,
@@ -109,7 +109,7 @@ export async function isCliBindingFlushed(
   workspaceDir?: string,
   options?: { skipTranscriptProbe?: boolean },
 ): Promise<boolean> {
-  if (!provider || !isClaudeCliProvider(provider)) {
+  if (!provider || !isClaudeCliBackend(provider)) {
     return true;
   }
   if (!sessionId) {
@@ -142,7 +142,7 @@ export function runCliAgent(paramsInput: RunCliAgentParams): Promise<EmbeddedAge
   // Observability services register before turns and keep subscriptions process-stable.
   // Snapshot listener presence here so disabled installs pay no synthetic trace cost.
   return withAgentRunLifecycleGeneration(lifecycleGeneration, () =>
-    isClaudeCliProvider(params.provider) &&
+    isClaudeCliBackend(params.provider) &&
     areDiagnosticsEnabledForProcess() &&
     hasInternalDiagnosticEventListeners()
       ? runClaudeCliAgentTurnWithDiagnostics(params, (diagnosticLifecycle) =>
@@ -252,7 +252,7 @@ export async function runPreparedCliAgent(
   };
   const sessionBindingDisabled = context.preparedBackend.backend.sessionMode === "none";
   const preparedContextAgentMeta =
-    isClaudeCliProvider(params.provider) && context.contextWindowInfo
+    isClaudeCliBackend(params.provider) && context.contextWindowInfo
       ? { contextTokens: context.contextWindowInfo.tokens }
       : {};
   const isolatedCompletion = params.isolatedCompletion === true;

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -680,11 +680,11 @@ export async function runPreparedCliAgent(
     runFailed = true;
     runError = error;
   }
-  let cleanupError: unknown;
+  let cleanupError: Error | undefined;
   try {
     await context.preparedBackend.cleanup?.();
   } catch (error) {
-    cleanupError = error;
+    cleanupError = error as Error;
   }
   return settleCliBackendOutcome({
     runResult,

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -1,11 +1,7 @@
 /**
  * Top-level CLI-backed agent runner orchestration.
  */
-import { setReplyPayloadMetadata, type ReplyPayload } from "../auto-reply/reply-payload.js";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
-import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
-import { patchSessionEntryCore } from "../config/sessions/session-accessor.js";
-import { appendExactAssistantMessageToSessionTranscript } from "../config/sessions/transcript.js";
 import { buildGenericCliContextEngineHostSupport } from "../context-engine/host-compat.js";
 import {
   assertAgentRunLifecycleGenerationCurrent,
@@ -26,30 +22,46 @@ import {
 } from "../plugins/hook-agent-context.js";
 import { resolveBlockMessage } from "../plugins/hook-decision-types.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
-import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import {
-  externalCliDiscoveryForProviderAuth,
   loadAuthProfileStoreForRuntime,
   markAuthProfileFailure,
   markAuthProfileSuccess,
-  type AuthProfileStore,
 } from "./auth-profiles.js";
 import { isHeartbeatLifecycleRunKind } from "./bootstrap-mode.js";
-import {
-  resolveCliRuntimeArtifactFingerprint,
-  resolveCliRuntimeOwnerFingerprint,
-} from "./cli-auth-epoch.js";
 import { resolveCliBackendConfig } from "./cli-backends.js";
-import type { CliOutput } from "./cli-output-contracts.js";
-import { CliAuthProfilePreparationError } from "./cli-runner/auth-profile-preparation-error.js";
 import { acceptsClaudeLive } from "./cli-runner/claude-live-session-policy.js";
+import {
+  resolveCliSessionId,
+  runCliRecovery,
+  type CliRecoveryOptions,
+} from "./cli-runner/cli-run-recovery.js";
+import {
+  assertCliRuntimeBinding,
+  buildBlockedCliRunResult,
+  buildCliDeliveredFailure,
+  buildCliRunResult,
+  cliRunSettlementDeps,
+  isClaudeCliProvider,
+  resolveCliSourceReplyMirror,
+  settleCliBackendOutcome,
+  settleCliPreparationError,
+  settlePreparedCliRun,
+} from "./cli-runner/cli-run-settlement.js";
+import {
+  buildCliHookAssistantMessage,
+  buildCliHookUserMessage,
+  finalizeCliContextEngineTurn,
+  persistApprovedCliUserTurnTranscript,
+  persistCliAssistantTranscript,
+  persistCliRunBlock,
+  runCliAgentEndHook,
+} from "./cli-runner/cli-run-transcript.js";
 import {
   attachCliMessagingDeliveryEvidence,
   getCliMessagingDeliveryEvidence,
 } from "./cli-runner/delivery-evidence.js";
 import { createCliFailoverError } from "./cli-runner/exit-error.js";
 import { cliBackendLog, formatCliBackendOutputDigest } from "./cli-runner/log.js";
-import { hashCliReseedPrompt } from "./cli-runner/reseed-envelope.js";
 import {
   runClaudeCliAgentTurnWithDiagnostics,
   type ClaudeCliRunDiagnosticLifecycle,
@@ -58,51 +70,20 @@ import {
   loadCliSessionContextEngineMessages,
   loadCliSessionHistoryMessages,
 } from "./cli-runner/session-history.js";
-import type {
-  CliReusableSession,
-  PreparedCliRunContext,
-  RunCliAgentParams,
-} from "./cli-runner/types.js";
+import type { PreparedCliRunContext, RunCliAgentParams } from "./cli-runner/types.js";
 import { claudeCliSessionTranscriptHasContent as claudeCliSessionTranscriptHasContentImpl } from "./command/attempt-execution.helpers.js";
 import type { EmbeddedAgentRunResult } from "./embedded-agent-runner.js";
 import { waitForDeferredTurnMaintenanceForSession } from "./embedded-agent-runner/context-engine-maintenance.js";
-import { resolveExplicitFinalSourceReplyDeliveryEvidence } from "./embedded-agent-runner/delivery-evidence.js";
-import { resolveAuthProfileFailureReason } from "./embedded-agent-runner/run/auth-profile-failure-policy.js";
-import { buildEmbeddedRunPayloads } from "./embedded-agent-runner/run/payloads.js";
-import { coerceToFailoverError, FailoverError, isFailoverError } from "./failover-error.js";
-import {
-  awaitAgentEndSideEffects,
-  runAgentEndSideEffects,
-} from "./harness/agent-end-side-effects.js";
-import {
-  bootstrapHarnessContextEngine,
-  finalizeHarnessContextEngineTurn,
-  runHarnessContextEngineMaintenance,
-} from "./harness/context-engine-lifecycle.js";
+import { bootstrapHarnessContextEngine } from "./harness/context-engine-lifecycle.js";
 import { buildAgentHookContext } from "./harness/hook-context.js";
-import { runAgentHarnessBeforeMessageWriteHook } from "./harness/hook-helpers.js";
 import { buildAgentHookConversationMessages } from "./harness/hook-history.js";
 import {
   runAgentHarnessLlmInputHook,
   runAgentHarnessLlmOutputHook,
 } from "./harness/lifecycle-hook-helpers.js";
-import type { AgentMessage } from "./runtime/index.js";
-import { SessionManager } from "./sessions/session-manager.js";
-import { buildAssistantMessage, buildUsageWithNoCost } from "./stream-message-shared.js";
 
 const log = createSubsystemLogger("agents/cli-runner");
-
-const cliRunnerDeps = {
-  claudeCliSessionTranscriptHasContent: claudeCliSessionTranscriptHasContentImpl,
-  delay: async (delayMs: number) => {
-    await new Promise((resolve) => {
-      setTimeout(resolve, delayMs);
-    });
-  },
-  loadAuthProfileStoreForRuntime,
-  markAuthProfileFailure,
-  markAuthProfileSuccess,
-};
+const cliRunnerDeps = cliRunSettlementDeps;
 
 /** Overrides top-level CLI runner dependencies for tests. */
 export function setCliRunnerTestDeps(overrides: Partial<typeof cliRunnerDeps>): void {
@@ -120,104 +101,6 @@ export function restoreCliRunnerTestDeps(): void {
   cliRunnerDeps.loadAuthProfileStoreForRuntime = loadAuthProfileStoreForRuntime;
   cliRunnerDeps.markAuthProfileFailure = markAuthProfileFailure;
   cliRunnerDeps.markAuthProfileSuccess = markAuthProfileSuccess;
-}
-
-async function settleCliAuthProfile(params: {
-  store: AuthProfileStore;
-  profileId: string;
-  provider: string;
-  agentDir?: string;
-  terminal:
-    | { outcome: "success" }
-    | {
-        outcome: "failure";
-        error: unknown;
-        config?: RunCliAgentParams["config"];
-        runId: string;
-        modelId?: string;
-      };
-}): Promise<void> {
-  try {
-    if (params.terminal.outcome === "success") {
-      await cliRunnerDeps.markAuthProfileSuccess({
-        store: params.store,
-        profileId: params.profileId,
-        provider: params.provider,
-        agentDir: params.agentDir,
-      });
-      return;
-    }
-    const error = params.terminal.error;
-    const reason = resolveAuthProfileFailureReason({
-      failoverReason: isFailoverError(error) ? error.reason : null,
-      providerStarted:
-        isFailoverError(error) && error.reason === "timeout"
-          ? error.cliTimeout?.observedActivity
-          : undefined,
-    });
-    if (reason) {
-      await cliRunnerDeps.markAuthProfileFailure({
-        store: params.store,
-        profileId: params.profileId,
-        reason,
-        cfg: params.terminal.config,
-        agentDir: params.agentDir,
-        runId: params.terminal.runId,
-        modelId: params.terminal.modelId,
-      });
-    }
-  } catch (error) {
-    log.warn(
-      `CLI auth-profile ${params.terminal.outcome} settlement failed: ${formatErrorMessage(error)}`,
-    );
-  }
-}
-
-function isClaudeCliProvider(provider: string): boolean {
-  return provider.trim().toLowerCase() === "claude-cli";
-}
-
-function resolveReusableCliSessionId(reusableCliSession: CliReusableSession): string | undefined {
-  return reusableCliSession.mode === "reuse" || reusableCliSession.mode === "reuse-with-drift"
-    ? reusableCliSession.sessionId
-    : undefined;
-}
-
-function shouldRetryFreshCliSessionAfterFailover(params: {
-  error: FailoverError;
-  hasHistoryPrompt: boolean;
-}): boolean {
-  if (!params.hasHistoryPrompt) {
-    return false;
-  }
-  switch (params.error.reason) {
-    case "session_expired":
-      return true;
-    case "unknown":
-      return params.error.code === "cli_unknown_empty_failure";
-    case "empty_response":
-      return params.error.code === "cli_unknown_empty_failure";
-    case "format":
-      return params.error.code === "cli_synthetic_no_response";
-    case "timeout":
-      return params.error.code === "cli_no_output_timeout";
-    case "context_overflow":
-      return params.error.code === "cli_context_overflow";
-    default:
-      return false;
-  }
-}
-
-function shouldRetryForkedCliSessionAfterFailover(error: FailoverError): boolean {
-  return error.reason === "timeout" && error.code === "cli_no_output_timeout";
-}
-
-function isUnsupportedCliResumeAtError(error: unknown, resumeAtArg: string): boolean {
-  const message = formatErrorMessage(error).toLowerCase();
-  return (
-    message.includes(resumeAtArg.toLowerCase()) &&
-    /\b(?:unknown|unexpected|unrecognized)\b|\bnot\s+recognized\b/.test(message)
-  );
 }
 
 /** Checks whether a Claude CLI session binding has reached its transcript file. */
@@ -247,332 +130,6 @@ export async function isCliBindingFlushed(
     }
   }
   return false;
-}
-
-async function assertSuccessfulCliRuntimeBindingCurrent(
-  context: PreparedCliRunContext,
-): Promise<void> {
-  if (!context.runtimeArtifactFingerprint) {
-    return;
-  }
-  const currentArtifact = await resolveCliRuntimeArtifactFingerprint({
-    provider: context.params.provider,
-    config: context.params.config ?? context.contextEngineConfig,
-    agentId: context.params.agentId,
-    runtimeArtifactId: context.backendResolved.id,
-  });
-  if (currentArtifact !== context.runtimeArtifactFingerprint) {
-    throw new Error("CLI executable/package artifact changed during successful inference");
-  }
-  if (!context.runtimeOwnerFingerprint) {
-    return;
-  }
-  const currentOwner = await resolveCliRuntimeOwnerFingerprint({
-    provider: context.params.provider,
-    config: context.params.config ?? context.contextEngineConfig,
-    ...(context.agentDir ? { agentDir: context.agentDir } : {}),
-    agentId: context.params.agentId,
-    runtimeOwnerId: context.backendResolved.id,
-    ...(context.effectiveAuthProfileId ? { authProfileId: context.effectiveAuthProfileId } : {}),
-    ...(context.authBindingSkipsLocalCredential ? { skipLocalCredential: true } : {}),
-    runtimeArtifactFingerprint: currentArtifact,
-  });
-  if (currentOwner !== context.runtimeOwnerFingerprint) {
-    throw new Error("CLI runtime owner changed during successful inference");
-  }
-}
-
-function buildCliHookUserMessage(prompt: string): unknown {
-  return {
-    role: "user",
-    content: prompt,
-    timestamp: Date.now(),
-  };
-}
-
-function buildCliHookAssistantMessage(params: {
-  text: string;
-  provider: string;
-  model: string;
-  usage?: {
-    input?: number;
-    output?: number;
-    cacheRead?: number;
-    cacheWrite?: number;
-    total?: number;
-  };
-}): unknown {
-  return {
-    role: "assistant",
-    content: [{ type: "text", text: params.text }],
-    api: "responses",
-    provider: params.provider,
-    model: params.model,
-    ...(params.usage ? { usage: params.usage } : {}),
-    stopReason: "stop",
-    timestamp: Date.now(),
-  };
-}
-
-function isAgentMessage(value: unknown): value is AgentMessage {
-  return Boolean(value && typeof value === "object" && "role" in value);
-}
-
-function buildCliContextEngineUserMessage(prompt: string): AgentMessage {
-  return {
-    role: "user",
-    content: prompt,
-    timestamp: Date.now(),
-  } as AgentMessage;
-}
-
-function buildCliContextEngineAssistantMessage(params: {
-  text: string;
-  provider: string;
-  model: string;
-  usage?: {
-    input?: number;
-    output?: number;
-    cacheRead?: number;
-    cacheWrite?: number;
-    total?: number;
-  };
-}): AgentMessage {
-  return buildCliHookAssistantMessage(params) as AgentMessage;
-}
-
-type CliAgentEndHookParams = Parameters<typeof runAgentEndSideEffects>[0];
-
-function shouldAwaitCliAgentEndHook(params: RunCliAgentParams): boolean {
-  return !params.messageChannel && !params.messageProvider;
-}
-
-async function runCliAgentEndHook(
-  params: RunCliAgentParams,
-  hookParams: CliAgentEndHookParams,
-): Promise<void> {
-  if (shouldAwaitCliAgentEndHook(params)) {
-    await awaitAgentEndSideEffects(hookParams);
-    return;
-  }
-  runAgentEndSideEffects(hookParams);
-}
-
-async function persistApprovedCliUserTurnTranscript(params: RunCliAgentParams): Promise<boolean> {
-  const recorder = params.userTurnTranscriptRecorder;
-  const reusingPersistedTurn = params.suppressNextUserMessagePersistence === true;
-  if (!recorder || (reusingPersistedTurn && !recorder.hasPersisted())) {
-    return recorder?.isBlocked() === true;
-  }
-
-  const persisted = await recorder.persistApproved({
-    cwd: params.cwd ?? params.workspaceDir,
-  });
-  if (!persisted && !recorder.hasPersisted() && (await recorder.resolveMessage())) {
-    // A prepared user row can be rejected by before_message_write. Preserve
-    // that terminal decision so outer transcript mirrors do not retry it.
-    recorder.markBlocked();
-  }
-  if (persisted && !reusingPersistedTurn) {
-    try {
-      const notification = params.onUserMessagePersisted?.(persisted.message);
-      if (notification) {
-        void Promise.resolve(notification).catch((error: unknown) => {
-          log.warn(`CLI user turn persistence notification failed: ${formatErrorMessage(error)}`);
-        });
-      }
-    } catch (error) {
-      log.warn(`CLI user turn persistence notification failed: ${formatErrorMessage(error)}`);
-    }
-  }
-  return persisted !== undefined || recorder.hasPersisted() || recorder.isBlocked();
-}
-
-async function persistCliAssistantTranscript(params: {
-  runParams: RunCliAgentParams;
-  text: string;
-  modelId: string;
-  usage?: {
-    input?: number;
-    output?: number;
-    cacheRead?: number;
-    cacheWrite?: number;
-    total?: number;
-  };
-}): Promise<{
-  owned: boolean;
-  terminalAnchor?: import("../config/sessions/session-accessor.js").TranscriptEntryAnchor;
-}> {
-  const { runParams } = params;
-  if (runParams.currentInboundEventKind === "room_event") {
-    const admission = runParams.userTurnTranscriptRecorder?.getAdmissionReceipt();
-    return {
-      owned: true,
-      ...(admission ? { terminalAnchor: admission } : {}),
-    };
-  }
-  if (!params.text) {
-    const admission = runParams.userTurnTranscriptRecorder?.getAdmissionReceipt();
-    return {
-      owned: false,
-      ...(admission ? { terminalAnchor: admission } : {}),
-    };
-  }
-  if (!runParams.persistAssistantTranscript || !runParams.sessionKey) {
-    return { owned: false };
-  }
-  try {
-    const result = await appendExactAssistantMessageToSessionTranscript({
-      sessionKey: runParams.sessionKey,
-      agentId: runParams.agentId,
-      expectedSessionId: runParams.sessionId,
-      ...(runParams.expectedLifecycleRevision !== undefined
-        ? { expectedLifecycleRevision: runParams.expectedLifecycleRevision }
-        : {}),
-      ...(runParams.expectedWriterRunId !== undefined
-        ? { expectedWriterRunId: runParams.expectedWriterRunId }
-        : {}),
-      storePath: runParams.storePath,
-      idempotencyKey: `cli-assistant:${runParams.runId}`,
-      config: runParams.config,
-      beforeMessageWrite: runAgentHarnessBeforeMessageWriteHook,
-      message: buildAssistantMessage({
-        model: {
-          api: "cli",
-          provider: runParams.provider,
-          id: params.modelId,
-        },
-        content: [{ type: "text", text: params.text }],
-        stopReason: "stop",
-        usage: buildUsageWithNoCost({
-          input: params.usage?.input,
-          output: params.usage?.output,
-          cacheRead: params.usage?.cacheRead,
-          cacheWrite: params.usage?.cacheWrite,
-          totalTokens: params.usage?.total,
-        }),
-      }),
-    });
-    if (!result.ok) {
-      log.warn(`CLI assistant transcript persistence skipped: ${result.reason}`);
-      return { owned: result.code === "blocked" || result.code === "session-rebound" };
-    }
-    return { owned: true, ...(result.anchor ? { terminalAnchor: result.anchor } : {}) };
-  } catch (error) {
-    log.warn(`CLI assistant transcript persistence failed: ${formatErrorMessage(error)}`);
-    return { owned: false };
-  }
-}
-
-async function notifyCliUserMessagePersisted(
-  params: RunCliAgentParams,
-  message: Extract<AgentMessage, { role: "user" }>,
-  context: string,
-): Promise<void> {
-  try {
-    await Promise.resolve(params.onUserMessagePersisted?.(message));
-  } catch (err) {
-    log.warn(`${context} notification failed: ${formatErrorMessage(err)}`);
-  }
-}
-
-async function finalizeCliContextEngineTurn(params: {
-  context: PreparedCliRunContext;
-  historyMessages: unknown[];
-  assistantText: string;
-  terminalAnchor?: import("../config/sessions/session-accessor.js").TranscriptEntryAnchor;
-  output: Awaited<
-    ReturnType<typeof import("./cli-runner/execute.runtime.js").executePreparedCliRun>
-  >;
-}): Promise<void> {
-  const { context } = params;
-  if (!context.contextEngine) {
-    return;
-  }
-
-  const { params: runParams } = context;
-  const prePromptMessages = params.historyMessages.filter(isAgentMessage);
-  const turnMessages: AgentMessage[] = [];
-  if (context.contextEngineTurnPrompt) {
-    turnMessages.push(buildCliContextEngineUserMessage(context.contextEngineTurnPrompt));
-  }
-  if (params.assistantText) {
-    turnMessages.push(
-      buildCliContextEngineAssistantMessage({
-        text: params.assistantText,
-        provider: runParams.provider,
-        model: context.modelId,
-        usage: params.output.usage,
-      }),
-    );
-  }
-
-  const contextEngineHostSupport = buildGenericCliContextEngineHostSupport({
-    backendId: context.backendResolved.id,
-  });
-  const finalizeTurn = async (transcript: {
-    messagesSnapshot: AgentMessage[];
-    prePromptMessageCount: number;
-    sessionManager?: SessionManager;
-    withSessionManagerRewriteLock: <T>(operation: () => Promise<T> | T) => Promise<T>;
-  }) => {
-    let deferredTurnMaintenance: Promise<void> | undefined;
-    const result = await finalizeHarnessContextEngineTurn({
-      contextEngine: context.contextEngine,
-      promptError: false,
-      aborted: runParams.abortSignal?.aborted === true,
-      yieldAborted: false,
-      sessionIdUsed: runParams.sessionId,
-      sessionKey: runParams.sessionKey,
-      sessionFile: runParams.sessionFile,
-      isHeartbeat: isHeartbeatLifecycleRunKind(runParams.bootstrapContextRunKind),
-      messagesSnapshot: transcript.messagesSnapshot,
-      prePromptMessageCount: transcript.prePromptMessageCount,
-      sessionManager: transcript.sessionManager,
-      config: context.contextEngineConfig,
-      contextEngineHostSupport,
-      providerId: runParams.provider,
-      modelId: context.modelId,
-      runMaintenance: async (maintenanceParams) =>
-        await runHarnessContextEngineMaintenance({
-          ...maintenanceParams,
-          withSessionManagerRewriteLock: transcript.withSessionManagerRewriteLock,
-          onDeferredMaintenance: (promise) => {
-            deferredTurnMaintenance = promise;
-          },
-        }),
-      warn: (message) => log.warn(message),
-    });
-    if (result.postTurnFinalizationSucceeded && deferredTurnMaintenance) {
-      context.contextEngineDeferredTurnMaintenance = deferredTurnMaintenance;
-    }
-  };
-  const admission = runParams.userTurnTranscriptRecorder?.getAdmissionReceipt();
-  if (runParams.onContextEngineTurnCandidate) {
-    if (admission && params.terminalAnchor) {
-      runParams.onContextEngineTurnCandidate({
-        boundary: { admission, terminal: params.terminalAnchor },
-        sessionIdUsed: runParams.sessionId,
-        sessionKey: runParams.sessionKey,
-        sessionTarget: runParams.sessionTarget,
-        sessionFile: runParams.sessionFile,
-        promptError: false,
-        aborted: runParams.abortSignal?.aborted === true,
-        yieldAborted: false,
-        contextEngineHostSupport,
-        providerId: runParams.provider,
-        modelId: context.modelId,
-        config: context.contextEngineConfig,
-        isHeartbeat: isHeartbeatLifecycleRunKind(runParams.bootstrapContextRunKind),
-      });
-    }
-  } else {
-    await finalizeTurn({
-      messagesSnapshot: [...prePromptMessages, ...turnMessages],
-      prePromptMessageCount: prePromptMessages.length,
-      withSessionManagerRewriteLock: async (operation) => await operation(),
-    });
-  }
 }
 
 /** Prepares and runs one CLI-backed agent turn. */
@@ -671,107 +228,14 @@ async function runCliAgentInternal(
   try {
     context = await prepareCliRunContext(params);
   } catch (error) {
-    if (error instanceof CliAuthProfilePreparationError) {
-      const store = cliRunnerDeps.loadAuthProfileStoreForRuntime(error.agentDir, {
-        externalCli: externalCliDiscoveryForProviderAuth({
-          cfg: params.config,
-          provider: error.provider,
-          profileId: error.profileId,
-        }),
-      });
-      await settleCliAuthProfile({
-        store,
-        profileId: error.profileId,
-        provider: error.provider,
-        agentDir: error.agentDir,
-        terminal: {
-          outcome: "failure",
-          error,
-          config: params.config,
-          runId: params.runId,
-          modelId: params.model,
-        },
-      });
-    }
+    await settleCliPreparationError(error, params);
     throw error;
   }
-  let result: EmbeddedAgentRunResult | undefined;
-  let runError: unknown;
-  try {
-    result = await runPreparedCliAgent(context, diagnosticLifecycle);
-  } catch (error) {
-    runError = error;
-  }
-  const terminalRunError = runError;
-  let cleanupError: unknown;
-  const recordCleanupError = (error: unknown) => {
-    cleanupError ??= error;
-  };
-  if (params.cleanupCliLiveSessionOnRunEnd === true) {
-    try {
-      const { closeClaudeSession } = await import("./cli-runner/claude-live-registry.js");
-      await closeClaudeSession(context, "restart");
-    } catch (error) {
-      recordCleanupError(error);
-    }
-  }
-  if (params.cleanupBundleMcpOnRunEnd === true) {
-    // The run's session ID is immutable; its session key can already belong to
-    // a newer run. Never retire the newer runtime or close the shared listener.
-    try {
-      const { retireSessionMcpRuntime } = await import("./agent-bundle-mcp-tools.js");
-      await retireSessionMcpRuntime({
-        sessionId: params.sessionId,
-        reason: "cli-run-end",
-        onError: recordCleanupError,
-      });
-    } catch (error) {
-      recordCleanupError(error);
-    }
-  }
-  if (cleanupError) {
-    if (runError || result?.didSendViaMessagingTool === true) {
-      log.warn(`cli run cleanup failed after completion: ${formatErrorMessage(cleanupError)}`);
-    } else {
-      diagnosticLifecycle?.setPhase("cleanup");
-      runError =
-        cleanupError instanceof Error ? cleanupError : new Error(formatErrorMessage(cleanupError));
-    }
-  }
-  // Settle only after backend recovery is exhausted. Recording inside an
-  // attempt would quarantine a healthy profile for a recovered session fault.
-  if (context.effectiveAuthProfileId && context.authProfileStore) {
-    const profileId = context.effectiveAuthProfileId;
-    const authProfileStore = context.authProfileStore;
-    if (terminalRunError) {
-      await settleCliAuthProfile({
-        store: authProfileStore,
-        profileId,
-        provider: authProfileStore.profiles[profileId]?.provider ?? params.provider,
-        agentDir: context.agentDir,
-        terminal: {
-          outcome: "failure",
-          error: terminalRunError,
-          config: params.config,
-          runId: params.runId,
-          modelId: context.modelId,
-        },
-      });
-    } else if (result?.meta.executionTrace?.attempts?.at(-1)?.result === "success") {
-      const provider = authProfileStore.profiles[profileId]?.provider ?? params.provider;
-      await settleCliAuthProfile({
-        store: authProfileStore,
-        profileId,
-        provider,
-        agentDir: context.agentDir,
-        terminal: { outcome: "success" },
-      });
-    }
-  }
-  if (runError) {
-    throw runError instanceof Error ? runError : new Error(formatErrorMessage(runError));
-  }
-  return result as EmbeddedAgentRunResult;
+  return await settlePreparedCliRun({
+    context,
+    diagnosticLifecycle,
+    run: async () => await runPreparedCliAgent(context, diagnosticLifecycle),
+  });
 }
 
 /** Runs an already-prepared CLI agent context through hooks and execution. */
@@ -877,268 +341,9 @@ export async function runPreparedCliAgent(
     durationMs: Date.now() - context.started,
   });
 
-  const buildBlockedBeforeAgentRunResult = (message: string): EmbeddedAgentRunResult => ({
-    payloads: [{ text: message, isError: true }],
-    meta: {
-      durationMs: Date.now() - context.started,
-      finalAssistantVisibleText: message,
-      finalAssistantRawText: message,
-      livenessState: "blocked",
-      error: {
-        kind: "hook_block",
-        message,
-      },
-      systemPromptReport: context.systemPromptReport,
-      executionTrace: {
-        winnerProvider: params.provider,
-        winnerModel: context.modelId,
-        attempts: [
-          {
-            provider: params.provider,
-            model: context.modelId,
-            result: "error",
-            reason: "before_agent_run blocked the run",
-          },
-        ],
-        fallbackUsed: false,
-        runner: "cli",
-      },
-      requestShaping: {
-        ...(params.thinkLevel ? { thinking: params.thinkLevel } : {}),
-        ...(context.effectiveAuthProfileId ? { authMode: "auth-profile" } : {}),
-      },
-      completion: {
-        finishReason: "blocked",
-        stopReason: "blocked",
-        refusal: true,
-      },
-      agentMeta: {
-        sessionId: params.sessionId ?? "",
-        provider: params.provider,
-        model: context.modelId,
-        ...preparedContextAgentMeta,
-        ...(sessionBindingDisabled ? { clearCliSessionBinding: true } : {}),
-      },
-    },
-  });
-
   let deliveredMessagingSideEffect = false;
   let userTurnHandled = false;
-  const buildCliSourceReplyMirrorPayloads = (
-    evidence: Pick<
-      CliOutput,
-      | "didSendViaMessagingTool"
-      | "didDeliverSourceReplyViaMessageTool"
-      | "messagingToolSentTargets"
-      | "messagingToolSourceReplyPayloads"
-    >,
-  ): ReplyPayload[] => {
-    return buildEmbeddedRunPayloads({
-      assistantTexts: [],
-      lastAssistant: undefined,
-      sessionKey: params.sessionKey ?? "",
-      provider: params.provider,
-      model: context.modelId,
-      didSendViaMessagingTool: evidence.didSendViaMessagingTool,
-      didDeliverSourceReplyViaMessageTool: evidence.didDeliverSourceReplyViaMessageTool,
-      messagingToolSentTargets: evidence.messagingToolSentTargets,
-      messagingToolSourceReplyPayloads: evidence.messagingToolSourceReplyPayloads,
-      sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-      agentId: params.agentId,
-      runId: params.runId,
-    });
-  };
-
-  const resolveCliSourceReplyMirror = (
-    evidence: Pick<
-      CliOutput,
-      | "didSendViaMessagingTool"
-      | "didDeliverSourceReplyViaMessageTool"
-      | "messagingToolSentTargets"
-      | "messagingToolSourceReplyPayloads"
-    >,
-  ) => {
-    const payloads = buildCliSourceReplyMirrorPayloads(evidence);
-    const delivered =
-      payloads.length > 0 ||
-      (params.sourceReplyDeliveryMode === "message_tool_only" &&
-        evidence.didDeliverSourceReplyViaMessageTool === true);
-    const visibleText =
-      payloads
-        .map((payload) => payload.text?.trim() ?? "")
-        .filter(Boolean)
-        .join("\n\n") || undefined;
-    return { payloads, delivered, visibleText };
-  };
-
-  const buildDeliveredFailureResult = (
-    error: unknown,
-    evidence: NonNullable<ReturnType<typeof getCliMessagingDeliveryEvidence>>,
-  ): EmbeddedAgentRunResult => {
-    const message = formatErrorMessage(error);
-    const { payloads } = resolveCliSourceReplyMirror(evidence);
-    const visiblePayloads =
-      payloads.length > 0
-        ? payloads
-        : resolveExplicitFinalSourceReplyDeliveryEvidence(evidence) === false
-          ? [{ text: "The reply stopped after sending progress. Please try again.", isError: true }]
-          : undefined;
-    deliveredMessagingSideEffect = true;
-    return {
-      ...(visiblePayloads ? { payloads: visiblePayloads } : {}),
-      meta: {
-        durationMs: Date.now() - context.started,
-        systemPromptReport: context.systemPromptReport,
-        stopReason: "error",
-        executionTrace: {
-          winnerProvider: params.provider,
-          winnerModel: context.modelId,
-          attempts: [
-            {
-              provider: params.provider,
-              model: context.modelId,
-              result: "error",
-              reason: message,
-            },
-          ],
-          fallbackUsed: false,
-          runner: "cli",
-        },
-        requestShaping: {
-          ...(params.thinkLevel ? { thinking: params.thinkLevel } : {}),
-          ...(context.effectiveAuthProfileId ? { authMode: "auth-profile" } : {}),
-        },
-        completion: {
-          finishReason: "error",
-          stopReason: "error",
-          refusal: false,
-        },
-        agentMeta: {
-          sessionId: "",
-          provider: params.provider,
-          model: context.modelId,
-          ...preparedContextAgentMeta,
-          ...(sessionBindingDisabled || resolveReusableCliSessionId(context.reusableCliSession)
-            ? { clearCliSessionBinding: true }
-            : {}),
-        },
-      },
-      didSendViaMessagingTool: true,
-      ...(evidence.didDeliverSourceReplyViaMessageTool
-        ? { didDeliverSourceReplyViaMessageTool: true }
-        : {}),
-      ...(evidence.messagingToolSentTexts?.length
-        ? { messagingToolSentTexts: evidence.messagingToolSentTexts }
-        : {}),
-      ...(evidence.messagingToolSentMediaUrls?.length
-        ? { messagingToolSentMediaUrls: evidence.messagingToolSentMediaUrls }
-        : {}),
-      ...(evidence.messagingToolSentTargets?.length
-        ? { messagingToolSentTargets: evidence.messagingToolSentTargets }
-        : {}),
-      ...(evidence.messagingToolSourceReplyPayloads?.length
-        ? { messagingToolSourceReplyPayloads: evidence.messagingToolSourceReplyPayloads }
-        : {}),
-    };
-  };
-
-  const persistBlockedBeforeAgentRun = async (block: {
-    message: string;
-    pluginId: string;
-  }): Promise<void> => {
-    const nowMs = Date.now();
-    const redactedUserMessage = {
-      role: "user" as const,
-      content: [{ type: "text" as const, text: block.message }],
-      timestamp: nowMs,
-      idempotencyKey: `hook-block:before_agent_run:user:${params.runId}`,
-      __openclaw: {
-        beforeAgentRunBlocked: {
-          blockedBy: block.pluginId,
-          blockedAt: nowMs,
-        },
-      },
-    };
-    try {
-      const persisted =
-        await params.userTurnTranscriptRecorder?.persistBlocked(redactedUserMessage);
-      if (persisted) {
-        await notifyCliUserMessagePersisted(
-          params,
-          persisted.message,
-          "before_agent_run block user-turn persistence",
-        );
-        return;
-      }
-    } catch (err) {
-      log.warn(
-        `before_agent_run block: failed to persist canonical CLI user message: ${formatErrorMessage(
-          err,
-        )}`,
-      );
-    }
-
-    try {
-      const sessionKey = params.sessionKey?.trim() || params.sessionId;
-      const agentId = params.agentId ?? resolveAgentIdFromSessionKey(sessionKey);
-      let sessionManager = params.sessionManager;
-      if (!sessionManager) {
-        const sessionTarget = params.sessionTarget ?? {
-          agentId,
-          sessionId: params.sessionId,
-          sessionKey,
-          storePath:
-            params.storePath ??
-            resolveSessionStorePathCore(params.config?.session?.store, {
-              agentId,
-            }),
-        };
-        const persistedEntry = await patchSessionEntryCore(
-          sessionTarget,
-          (entry, patchContext) => {
-            if (patchContext.existingEntry && entry.sessionId !== sessionTarget.sessionId) {
-              return null;
-            }
-            return {
-              sessionId: sessionTarget.sessionId,
-              updatedAt: Date.now(),
-            };
-          },
-          {
-            fallbackEntry: params.sessionEntry
-              ? undefined
-              : { sessionId: sessionTarget.sessionId, updatedAt: Date.now() },
-            skipMaintenance: true,
-          },
-        );
-        if (persistedEntry?.sessionId !== sessionTarget.sessionId) {
-          // Skip only this stale blocked-message write; the outer runner still returns blocked.
-          return;
-        }
-        sessionManager = SessionManager.open(sessionTarget);
-      }
-      sessionManager.appendMessage(
-        redactedUserMessage as Parameters<typeof sessionManager.appendMessage>[0],
-      );
-      sessionManager.flushPendingPersistence();
-    } catch (err) {
-      log.warn(
-        `before_agent_run block: failed to persist redacted CLI user message: ${formatErrorMessage(
-          err,
-        )}`,
-      );
-    }
-  };
-
-  const executeCliAttempt = async (
-    cliSessionIdToUse?: string,
-    options?: {
-      timeoutMs?: number;
-      forkCliSessionOnResume?: boolean;
-      resumeAt?: string;
-      onForkSuccessorPersisted?: (sessionId: string) => void;
-    },
-  ) => {
+  const executeCliAttempt = async (cliSessionIdToUse?: string, options?: CliRecoveryOptions) => {
     const timeoutMs = options?.timeoutMs ?? params.timeoutMs;
     const forkCliSessionOnResume =
       options?.forkCliSessionOnResume ?? context.params.forkCliSessionOnResume;
@@ -1179,7 +384,11 @@ export async function runPreparedCliAgent(
     );
     // Test facades and non-instrumented executors may not signal the boundary.
     diagnosticLifecycle?.setPhase("resolve");
-    const sourceReplyMirror = resolveCliSourceReplyMirror(output);
+    const sourceReplyMirror = resolveCliSourceReplyMirror({
+      evidence: output,
+      runParams: params,
+      modelId: context.modelId,
+    });
     const assistantText = sourceReplyMirror.delivered
       ? (sourceReplyMirror.visibleText ?? "")
       : output.text.trim();
@@ -1258,211 +467,18 @@ export async function runPreparedCliAgent(
     };
   };
 
-  const buildCliRunResult = (resultParams: {
-    output: Awaited<ReturnType<typeof executePreparedCliRun>>;
-    effectiveCliSessionId?: string;
-    bindingFlushOk?: boolean;
-    assistantTranscriptOwned?: boolean;
-    usedHistoryPrompt: boolean;
-  }): EmbeddedAgentRunResult => {
-    const text = resultParams.output.text?.trim();
-    const rawText = resultParams.output.rawText?.trim();
-    const sourceReplyMirror = resolveCliSourceReplyMirror(resultParams.output);
-    const finalAssistantVisibleText = sourceReplyMirror.delivered
-      ? sourceReplyMirror.visibleText
-      : text;
-    const payloads =
-      sourceReplyMirror.payloads.length > 0
-        ? sourceReplyMirror.payloads
-        : sourceReplyMirror.delivered
-          ? undefined
-          : text
-            ? [
-                resultParams.assistantTranscriptOwned
-                  ? setReplyPayloadMetadata({ text }, { assistantTranscriptOwned: true })
-                  : { text },
-              ]
-            : params.allowEmptyAssistantReplyAsSilent === true
-              ? [{ text: SILENT_REPLY_TOKEN }]
-              : undefined;
-    if (resultParams.output.didSendViaMessagingTool) {
-      deliveredMessagingSideEffect = true;
-    }
-    const unflushedCliSessionId =
-      !sessionBindingDisabled &&
-      resultParams.effectiveCliSessionId &&
-      resultParams.bindingFlushOk === false
-        ? resultParams.effectiveCliSessionId
-        : undefined;
-    const persistedCliSessionId = sessionBindingDisabled
-      ? undefined
-      : unflushedCliSessionId
-        ? undefined
-        : resultParams.effectiveCliSessionId;
-    const createdReseedReceipt =
-      persistedCliSessionId &&
-      resultParams.usedHistoryPrompt &&
-      isClaudeCliProvider(params.provider) &&
-      resultParams.output.finalPromptText !== undefined &&
-      userTurnHandled &&
-      params.sessionId
-        ? {
-            version: 1 as const,
-            promptHash: hashCliReseedPrompt(resultParams.output.finalPromptText),
-            localSessionId: params.sessionId,
-            userTurnDisposition: params.userTurnTranscriptRecorder?.hasPersisted()
-              ? ("persisted" as const)
-              : ("omitted" as const),
-          }
-        : undefined;
-    const preservedReseedReceipt =
-      params.cliSessionBinding && persistedCliSessionId === params.cliSessionBinding.sessionId
-        ? params.cliSessionBinding.reseedReceipt
-        : undefined;
-    const reseedReceipt = createdReseedReceipt ?? preservedReseedReceipt;
-    const agentSessionId = sessionBindingDisabled
-      ? (params.sessionId ?? "")
-      : unflushedCliSessionId
-        ? ""
-        : (resultParams.effectiveCliSessionId ?? params.sessionId ?? "");
-    const yielded = resultParams.output.yielded === true;
-    const stopReason = yielded ? "end_turn" : "completed";
-
-    params.onSuccessfulAuthBinding?.({
-      ...(context.effectiveAuthProfileId ? { authProfileId: context.effectiveAuthProfileId } : {}),
-      ...(context.authBindingFingerprint
-        ? { authFingerprint: context.authBindingFingerprint }
-        : {}),
-      ...(!context.authBindingFingerprint && context.runtimeOwnerFingerprint
-        ? {
-            runtimeOwnerFingerprint: context.runtimeOwnerFingerprint,
-            runtimeOwnerKind: "cli-runtime" as const,
-            runtimeOwnerId: context.backendResolved.id,
-          }
-        : {}),
-      ...(context.runtimeArtifactFingerprint
-        ? {
-            runtimeArtifactFingerprint: context.runtimeArtifactFingerprint,
-            runtimeArtifactId: context.backendResolved.id,
-          }
-        : {}),
-      ...(context.authBindingSkipsLocalCredential ? { skipLocalCredential: true } : {}),
-    });
-
-    return {
-      payloads,
-      meta: {
-        durationMs: Date.now() - context.started,
-        ...(resultParams.output.finalPromptText
-          ? { finalPromptText: resultParams.output.finalPromptText }
-          : {}),
-        ...(finalAssistantVisibleText || rawText
-          ? {
-              ...(finalAssistantVisibleText ? { finalAssistantVisibleText } : {}),
-              ...(rawText ? { finalAssistantRawText: rawText } : {}),
-            }
-          : {}),
-        systemPromptReport: context.systemPromptReport,
-        ...(yielded ? { yielded: true, livenessState: "paused" as const, stopReason } : {}),
-        executionTrace: {
-          winnerProvider: params.provider,
-          winnerModel: context.modelId,
-          attempts: [
-            {
-              provider: params.provider,
-              model: context.modelId,
-              result: "success",
-            },
-          ],
-          fallbackUsed: false,
-          runner: "cli",
-        },
-        requestShaping: {
-          ...(params.thinkLevel ? { thinking: params.thinkLevel } : {}),
-          ...(context.effectiveAuthProfileId ? { authMode: "auth-profile" } : {}),
-        },
-        completion: {
-          finishReason: yielded ? "end_turn" : "stop",
-          stopReason,
-          refusal: false,
-        },
-        ...(resultParams.output.toolSummary
-          ? { toolSummary: resultParams.output.toolSummary }
-          : {}),
-        agentMeta: {
-          sessionId: agentSessionId,
-          provider: params.provider,
-          model: context.modelId,
-          ...preparedContextAgentMeta,
-          usage: resultParams.output.usage,
-          ...(resultParams.output.usage ? { lastCallUsage: resultParams.output.usage } : {}),
-          ...(resultParams.output.diagnosticUsage
-            ? { diagnosticUsage: resultParams.output.diagnosticUsage }
-            : {}),
-          ...(persistedCliSessionId
-            ? {
-                cliSessionBinding: {
-                  sessionId: persistedCliSessionId,
-                  ...(context.effectiveAuthProfileId
-                    ? { authProfileId: context.effectiveAuthProfileId }
-                    : {}),
-                  ...(resultParams.output.resumeCheckpointId
-                    ? { resumeCheckpointId: resultParams.output.resumeCheckpointId }
-                    : {}),
-                  ...(context.authEpoch ? { authEpoch: context.authEpoch } : {}),
-                  authEpochVersion: context.authEpochVersion,
-                  ...(context.extraSystemPromptHash
-                    ? { extraSystemPromptHash: context.extraSystemPromptHash }
-                    : {}),
-                  ...(context.messageToolPolicyHash
-                    ? { messageToolPolicyHash: context.messageToolPolicyHash }
-                    : {}),
-                  ...(context.promptToolNamesHash
-                    ? { promptToolNamesHash: context.promptToolNamesHash }
-                    : {}),
-                  ...(context.cwdHash ? { cwdHash: context.cwdHash } : {}),
-                  ...(context.preparedBackend.mcpConfigHash
-                    ? { mcpConfigHash: context.preparedBackend.mcpConfigHash }
-                    : {}),
-                  ...(context.preparedBackend.mcpResumeHash
-                    ? { mcpResumeHash: context.preparedBackend.mcpResumeHash }
-                    : {}),
-                  ...(reseedReceipt ? { reseedReceipt } : {}),
-                },
-              }
-            : {}),
-          ...(sessionBindingDisabled || unflushedCliSessionId
-            ? { clearCliSessionBinding: true }
-            : {}),
-        },
-      },
-      ...(resultParams.output.didSendViaMessagingTool ? { didSendViaMessagingTool: true } : {}),
-      ...(resultParams.output.didDeliverSourceReplyViaMessageTool
-        ? { didDeliverSourceReplyViaMessageTool: true }
-        : {}),
-      ...(resultParams.output.messagingToolSentTexts?.length
-        ? { messagingToolSentTexts: resultParams.output.messagingToolSentTexts }
-        : {}),
-      ...(resultParams.output.messagingToolSentMediaUrls?.length
-        ? { messagingToolSentMediaUrls: resultParams.output.messagingToolSentMediaUrls }
-        : {}),
-      ...(resultParams.output.messagingToolSentTargets?.length
-        ? { messagingToolSentTargets: resultParams.output.messagingToolSentTargets }
-        : {}),
-      ...(resultParams.output.messagingToolSourceReplyPayloads?.length
-        ? { messagingToolSourceReplyPayloads: resultParams.output.messagingToolSourceReplyPayloads }
-        : {}),
-    };
-  };
-
   const executeRun = async (): Promise<EmbeddedAgentRunResult> => {
     if (isolatedCompletion) {
       const { output, usedHistoryPrompt } = await executeCliAttempt();
       return buildCliRunResult({
+        context,
         output,
         bindingFlushOk: true,
         assistantTranscriptOwned: false,
         usedHistoryPrompt,
+        userTurnHandled,
+        sessionBindingDisabled,
+        preparedContextAgentMeta,
       });
     }
     await bootstrapHarnessContextEngine({
@@ -1495,7 +511,7 @@ export async function runPreparedCliAgent(
       const { output, assistantText, lastAssistant, sourceReplyWasDelivered, usedHistoryPrompt } =
         result;
       try {
-        await assertSuccessfulCliRuntimeBindingCurrent(context);
+        await assertCliRuntimeBinding(context);
         const effectiveCliSessionId = output.sessionId ?? fallbackCliSessionId;
         const assistantTranscript = await persistCliAssistantTranscript({
           runParams: params,
@@ -1532,11 +548,15 @@ export async function runPreparedCliAgent(
           hookRunner,
         });
         return buildCliRunResult({
+          context,
           output,
           effectiveCliSessionId,
           bindingFlushOk,
           assistantTranscriptOwned: assistantTranscript.owned,
           usedHistoryPrompt,
+          userTurnHandled,
+          sessionBindingDisabled,
+          preparedContextAgentMeta,
         });
       } catch (error) {
         throw attachCliMessagingDeliveryEvidence(error, output);
@@ -1555,7 +575,15 @@ export async function runPreparedCliAgent(
         ctx: hookContext,
         hookRunner,
       });
-      return buildDeliveredFailureResult(error, evidence);
+      deliveredMessagingSideEffect = true;
+      return buildCliDeliveredFailure({
+        error,
+        evidence,
+        context,
+        preparedContextAgentMeta,
+        sessionBindingDisabled,
+        reusableCliSessionId: resolveCliSessionId(context.reusableCliSession),
+      });
     };
 
     if (hasBeforeAgentRunHooks && hookRunner) {
@@ -1583,7 +611,7 @@ export async function runPreparedCliAgent(
           { outcome: "block", reason: "before_agent_run hook failed" },
           { blockedBy: "before_agent_run" },
         );
-        await persistBlockedBeforeAgentRun({
+        await persistCliRunBlock(params, {
           message: blockMessage,
           pluginId: "before_agent_run",
         });
@@ -1592,7 +620,12 @@ export async function runPreparedCliAgent(
           ctx: hookContext,
           hookRunner,
         });
-        return buildBlockedBeforeAgentRunResult(blockMessage);
+        return buildBlockedCliRunResult({
+          message: blockMessage,
+          context,
+          preparedContextAgentMeta,
+          sessionBindingDisabled,
+        });
       }
 
       const beforeRunDecision = beforeRunResult?.decision;
@@ -1600,7 +633,7 @@ export async function runPreparedCliAgent(
         const blockMessage = resolveBlockMessage(beforeRunDecision, {
           blockedBy: beforeRunResult?.pluginId ?? "unknown",
         });
-        await persistBlockedBeforeAgentRun({
+        await persistCliRunBlock(params, {
           message: blockMessage,
           pluginId: beforeRunResult?.pluginId ?? "unknown",
         });
@@ -1609,7 +642,12 @@ export async function runPreparedCliAgent(
           ctx: hookContext,
           hookRunner,
         });
-        return buildBlockedBeforeAgentRunResult(blockMessage);
+        return buildBlockedCliRunResult({
+          message: blockMessage,
+          context,
+          preparedContextAgentMeta,
+          sessionBindingDisabled,
+        });
       }
     }
 
@@ -1619,156 +657,19 @@ export async function runPreparedCliAgent(
       ctx: hookContext,
       hookRunner,
     });
-    const reusableCliSessionId = resolveReusableCliSessionId(context.reusableCliSession);
-    const resumeCheckpointId = params.cliSessionBinding?.resumeCheckpointId;
-    let retryableSessionId = reusableCliSessionId;
-    try {
-      return await finishCliAttempt(
-        await executeCliAttempt(
-          reusableCliSessionId,
-          params.forkCliSessionOnResume
-            ? {
-                onForkSuccessorPersisted: (sessionId) => {
-                  retryableSessionId = sessionId;
-                },
-              }
-            : undefined,
-        ),
-        reusableCliSessionId,
-      );
-    } catch (err) {
-      const deliveredFailure = await finishDeliveredFailure(err);
-      if (deliveredFailure) {
-        return deliveredFailure;
-      }
-      let recoveryError = err;
-      if (
-        params.forkCliSessionOnResume &&
-        resumeCheckpointId &&
-        context.preparedBackend.backend.resumeAtArg &&
-        isUnsupportedCliResumeAtError(err, context.preparedBackend.backend.resumeAtArg)
-      ) {
-        recoveryError = createCliFailoverError(
-          "CLI backend cannot resume from the stored checkpoint.",
-          "session_expired",
-          cliFailoverContext,
-          { cause: err },
-        );
-      }
-      if (isFailoverError(recoveryError)) {
-        if (
-          !params.forkCliSessionOnResume &&
-          shouldRetryForkedCliSessionAfterFailover(recoveryError) &&
-          retryableSessionId &&
-          resumeCheckpointId &&
-          params.sessionKey &&
-          context.preparedBackend.backend.forkArg &&
-          context.preparedBackend.backend.resumeAtArg &&
-          params.onBeforeForkedCliSessionRetry
-        ) {
-          try {
-            const retryTimeoutMs = params.timeoutMs - (Date.now() - context.started);
-            if (retryTimeoutMs <= 0) {
-              throw recoveryError;
-            }
-            const forkPrepared = await params.onBeforeForkedCliSessionRetry({
-              provider: params.provider,
-              reason: recoveryError.reason,
-              sessionId: retryableSessionId,
-            });
-            if (!forkPrepared) {
-              throw recoveryError;
-            }
-            cliBackendLog.warn(
-              `cli session recovery fork: provider=${params.provider} reason=${recoveryError.reason} sessionKey=${params.sessionKey}`,
-            );
-            return await finishCliAttempt(
-              await executeCliAttempt(retryableSessionId, {
-                timeoutMs: retryTimeoutMs,
-                forkCliSessionOnResume: true,
-                resumeAt: resumeCheckpointId,
-                onForkSuccessorPersisted: (sessionId) => {
-                  retryableSessionId = sessionId;
-                },
-              }),
-            );
-          } catch (forkError) {
-            const deliveredForkFailure = await finishDeliveredFailure(forkError);
-            if (deliveredForkFailure) {
-              return deliveredForkFailure;
-            }
-            recoveryError = isUnsupportedCliResumeAtError(
-              forkError,
-              context.preparedBackend.backend.resumeAtArg,
-            )
-              ? err
-              : forkError;
-          }
-        }
-        if (
-          isFailoverError(recoveryError) &&
-          shouldRetryFreshCliSessionAfterFailover({
-            error: recoveryError,
-            hasHistoryPrompt: Boolean(context.openClawHistoryPrompt),
-          }) &&
-          retryableSessionId &&
-          params.sessionKey
-        ) {
-          try {
-            const retryTimeoutMs = params.timeoutMs - (Date.now() - context.started);
-            if (retryTimeoutMs <= 0) {
-              throw recoveryError;
-            }
-            if (params.onBeforeFreshCliSessionRetry) {
-              const clearedStaleBinding = await params.onBeforeFreshCliSessionRetry({
-                provider: params.provider,
-                reason: recoveryError.reason,
-                sessionId: retryableSessionId,
-              });
-              if (!clearedStaleBinding) {
-                throw recoveryError;
-              }
-            }
-            cliBackendLog.warn(
-              `cli session recovery retry: provider=${params.provider} reason=${recoveryError.reason} sessionKey=${params.sessionKey}`,
-            );
-            return await finishCliAttempt(
-              await executeCliAttempt(undefined, {
-                timeoutMs: retryTimeoutMs,
-                forkCliSessionOnResume: false,
-              }),
-            );
-          } catch (retryErr) {
-            const deliveredRetryFailure = await finishDeliveredFailure(retryErr);
-            if (deliveredRetryFailure) {
-              return deliveredRetryFailure;
-            }
-            const retryMessage = formatErrorMessage(retryErr);
-            await runCliAgentEndHook(params, {
-              event: buildFailedAgentEndEvent(retryMessage),
-              ctx: hookContext,
-              hookRunner,
-            });
-            throw retryErr;
-          }
-        }
-      }
-      if (isFailoverError(recoveryError)) {
+    return await runCliRecovery({
+      context,
+      executeAttempt: executeCliAttempt,
+      finishAttempt: finishCliAttempt,
+      finishDeliveredFailure,
+      onTerminalFailure: async (error) => {
         await runCliAgentEndHook(params, {
-          event: buildFailedAgentEndEvent(formatErrorMessage(recoveryError)),
+          event: buildFailedAgentEndEvent(formatErrorMessage(error)),
           ctx: hookContext,
           hookRunner,
         });
-        throw recoveryError;
-      }
-      const message = formatErrorMessage(recoveryError);
-      await runCliAgentEndHook(params, {
-        event: buildFailedAgentEndEvent(message),
-        ctx: hookContext,
-        hookRunner,
-      });
-      throw recoveryError;
-    }
+      },
+    });
   };
 
   let runResult: EmbeddedAgentRunResult | undefined;
@@ -1780,28 +681,19 @@ export async function runPreparedCliAgent(
     runFailed = true;
     runError = error;
   }
+  let cleanupError: unknown;
   try {
     await context.preparedBackend.cleanup?.();
-  } catch (cleanupError) {
-    if (!deliveredMessagingSideEffect) {
-      if (runFailed) {
-        cliBackendLog.warn(
-          `CLI run also failed before backend cleanup: ${formatErrorMessage(runError)}`,
-        );
-      }
-      diagnosticLifecycle?.setPhase("cleanup");
-      throw cleanupError;
-    }
-    cliBackendLog.warn(
-      `CLI backend cleanup failed after confirmed message delivery: ${formatErrorMessage(cleanupError)}`,
-    );
+  } catch (error) {
+    cleanupError = error;
   }
-  if (runFailed) {
-    throw coerceToFailoverError(runError, cliFailoverContext) ?? runError;
-  }
-  if (!runResult) {
-    throw new Error("CLI run completed without a result");
-  }
-  return runResult;
+  return settleCliBackendOutcome({
+    runResult,
+    runError,
+    runFailed,
+    cleanupError,
+    deliveredMessagingSideEffect,
+    diagnosticLifecycle,
+    failoverContext: cliFailoverContext,
+  });
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -27,7 +27,6 @@ import {
   markAuthProfileFailure,
   markAuthProfileSuccess,
 } from "./auth-profiles.js";
-import { isHeartbeatLifecycleRunKind } from "./bootstrap-mode.js";
 import { resolveCliBackendConfig } from "./cli-backends.js";
 import { acceptsClaudeLive } from "./cli-runner/claude-live-session-policy.js";
 import {

--- a/src/agents/cli-runner/cli-run-recovery.ts
+++ b/src/agents/cli-runner/cli-run-recovery.ts
@@ -1,0 +1,207 @@
+import { formatErrorMessage } from "../../infra/errors.js";
+import type { EmbeddedAgentRunResult } from "../embedded-agent-runner.js";
+import { type FailoverError, isFailoverError } from "../failover-error.js";
+import { createCliFailoverError } from "./exit-error.js";
+import { cliBackendLog } from "./log.js";
+import type { CliReusableSession, PreparedCliRunContext } from "./types.js";
+
+export type CliRecoveryOptions = {
+  timeoutMs?: number;
+  forkCliSessionOnResume?: boolean;
+  resumeAt?: string;
+  onForkSuccessorPersisted?: (sessionId: string) => void;
+};
+
+export function resolveCliSessionId(reusableCliSession: CliReusableSession): string | undefined {
+  return reusableCliSession.mode === "reuse" || reusableCliSession.mode === "reuse-with-drift"
+    ? reusableCliSession.sessionId
+    : undefined;
+}
+
+function shouldRetryFreshCliSessionAfterFailover(params: {
+  error: FailoverError;
+  hasHistoryPrompt: boolean;
+}): boolean {
+  if (!params.hasHistoryPrompt) {
+    return false;
+  }
+  switch (params.error.reason) {
+    case "session_expired":
+      return true;
+    case "unknown":
+      return params.error.code === "cli_unknown_empty_failure";
+    case "empty_response":
+      return params.error.code === "cli_unknown_empty_failure";
+    case "format":
+      return params.error.code === "cli_synthetic_no_response";
+    case "timeout":
+      return params.error.code === "cli_no_output_timeout";
+    case "context_overflow":
+      return params.error.code === "cli_context_overflow";
+    default:
+      return false;
+  }
+}
+
+function shouldRetryForkedCliSessionAfterFailover(error: FailoverError): boolean {
+  return error.reason === "timeout" && error.code === "cli_no_output_timeout";
+}
+
+function isUnsupportedCliResumeAtError(error: unknown, resumeAtArg: string): boolean {
+  const message = formatErrorMessage(error).toLowerCase();
+  return (
+    message.includes(resumeAtArg.toLowerCase()) &&
+    /\b(?:unknown|unexpected|unrecognized)\b|\bnot\s+recognized\b/.test(message)
+  );
+}
+
+export async function runCliRecovery<TAttempt>(params: {
+  context: PreparedCliRunContext;
+  executeAttempt: (cliSessionIdToUse?: string, options?: CliRecoveryOptions) => Promise<TAttempt>;
+  finishAttempt: (
+    attempt: TAttempt,
+    fallbackCliSessionId?: string,
+  ) => Promise<EmbeddedAgentRunResult>;
+  finishDeliveredFailure: (error: unknown) => Promise<EmbeddedAgentRunResult | undefined>;
+  onTerminalFailure: (error: unknown) => Promise<void>;
+}): Promise<EmbeddedAgentRunResult> {
+  const { context } = params;
+  const runParams = context.params;
+  const reusableCliSessionId = resolveCliSessionId(context.reusableCliSession);
+  const resumeCheckpointId = runParams.cliSessionBinding?.resumeCheckpointId;
+  let retryableSessionId = reusableCliSessionId;
+  try {
+    return await params.finishAttempt(
+      await params.executeAttempt(
+        reusableCliSessionId,
+        runParams.forkCliSessionOnResume
+          ? {
+              onForkSuccessorPersisted: (sessionId) => {
+                retryableSessionId = sessionId;
+              },
+            }
+          : undefined,
+      ),
+      reusableCliSessionId,
+    );
+  } catch (err) {
+    const deliveredFailure = await params.finishDeliveredFailure(err);
+    if (deliveredFailure) {
+      return deliveredFailure;
+    }
+    let recoveryError = err;
+    if (
+      runParams.forkCliSessionOnResume &&
+      resumeCheckpointId &&
+      context.preparedBackend.backend.resumeAtArg &&
+      isUnsupportedCliResumeAtError(err, context.preparedBackend.backend.resumeAtArg)
+    ) {
+      recoveryError = createCliFailoverError(
+        "CLI backend cannot resume from the stored checkpoint.",
+        "session_expired",
+        {
+          provider: runParams.provider,
+          model: context.modelId,
+          sessionId: runParams.sessionId,
+          lane: runParams.lane,
+        },
+        { cause: err },
+      );
+    }
+    if (isFailoverError(recoveryError)) {
+      if (
+        !runParams.forkCliSessionOnResume &&
+        shouldRetryForkedCliSessionAfterFailover(recoveryError) &&
+        retryableSessionId &&
+        resumeCheckpointId &&
+        runParams.sessionKey &&
+        context.preparedBackend.backend.forkArg &&
+        context.preparedBackend.backend.resumeAtArg &&
+        runParams.onBeforeForkedCliSessionRetry
+      ) {
+        try {
+          const retryTimeoutMs = runParams.timeoutMs - (Date.now() - context.started);
+          if (retryTimeoutMs <= 0) {
+            throw recoveryError;
+          }
+          const forkPrepared = await runParams.onBeforeForkedCliSessionRetry({
+            provider: runParams.provider,
+            reason: recoveryError.reason,
+            sessionId: retryableSessionId,
+          });
+          if (!forkPrepared) {
+            throw recoveryError;
+          }
+          cliBackendLog.warn(
+            `cli session recovery fork: provider=${runParams.provider} reason=${recoveryError.reason} sessionKey=${runParams.sessionKey}`,
+          );
+          return await params.finishAttempt(
+            await params.executeAttempt(retryableSessionId, {
+              timeoutMs: retryTimeoutMs,
+              forkCliSessionOnResume: true,
+              resumeAt: resumeCheckpointId,
+              onForkSuccessorPersisted: (sessionId) => {
+                retryableSessionId = sessionId;
+              },
+            }),
+          );
+        } catch (forkError) {
+          const deliveredForkFailure = await params.finishDeliveredFailure(forkError);
+          if (deliveredForkFailure) {
+            return deliveredForkFailure;
+          }
+          recoveryError = isUnsupportedCliResumeAtError(
+            forkError,
+            context.preparedBackend.backend.resumeAtArg,
+          )
+            ? err
+            : forkError;
+        }
+      }
+      if (
+        isFailoverError(recoveryError) &&
+        shouldRetryFreshCliSessionAfterFailover({
+          error: recoveryError,
+          hasHistoryPrompt: Boolean(context.openClawHistoryPrompt),
+        }) &&
+        retryableSessionId &&
+        runParams.sessionKey
+      ) {
+        try {
+          const retryTimeoutMs = runParams.timeoutMs - (Date.now() - context.started);
+          if (retryTimeoutMs <= 0) {
+            throw recoveryError;
+          }
+          if (runParams.onBeforeFreshCliSessionRetry) {
+            const clearedStaleBinding = await runParams.onBeforeFreshCliSessionRetry({
+              provider: runParams.provider,
+              reason: recoveryError.reason,
+              sessionId: retryableSessionId,
+            });
+            if (!clearedStaleBinding) {
+              throw recoveryError;
+            }
+          }
+          cliBackendLog.warn(
+            `cli session recovery retry: provider=${runParams.provider} reason=${recoveryError.reason} sessionKey=${runParams.sessionKey}`,
+          );
+          return await params.finishAttempt(
+            await params.executeAttempt(undefined, {
+              timeoutMs: retryTimeoutMs,
+              forkCliSessionOnResume: false,
+            }),
+          );
+        } catch (retryErr) {
+          const deliveredRetryFailure = await params.finishDeliveredFailure(retryErr);
+          if (deliveredRetryFailure) {
+            return deliveredRetryFailure;
+          }
+          await params.onTerminalFailure(retryErr);
+          throw retryErr;
+        }
+      }
+    }
+    await params.onTerminalFailure(recoveryError);
+    throw recoveryError;
+  }
+}

--- a/src/agents/cli-runner/cli-run-settlement.test.ts
+++ b/src/agents/cli-runner/cli-run-settlement.test.ts
@@ -4,7 +4,7 @@ import {
   isCliBindingFlushed,
   restoreCliRunnerTestDeps,
   setCliRunnerTestDeps,
-} from "./cli-runner.js";
+} from "../cli-runner.js";
 
 describe("isCliBindingFlushed", () => {
   const workspaceDir = "/tmp/openclaw-workspace";

--- a/src/agents/cli-runner/cli-run-settlement.ts
+++ b/src/agents/cli-runner/cli-run-settlement.ts
@@ -1,0 +1,657 @@
+import { setReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/reply-payload.js";
+import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import {
+  externalCliDiscoveryForProviderAuth,
+  loadAuthProfileStoreForRuntime,
+  markAuthProfileFailure,
+  markAuthProfileSuccess,
+  type AuthProfileStore,
+} from "../auth-profiles.js";
+import {
+  resolveCliRuntimeArtifactFingerprint,
+  resolveCliRuntimeOwnerFingerprint,
+} from "../cli-auth-epoch.js";
+import type { CliOutput } from "../cli-output-contracts.js";
+import { claudeCliSessionTranscriptHasContent as claudeCliSessionTranscriptHasContentImpl } from "../command/attempt-execution.helpers.js";
+import type { EmbeddedAgentRunResult } from "../embedded-agent-runner.js";
+import { resolveExplicitFinalSourceReplyDeliveryEvidence } from "../embedded-agent-runner/delivery-evidence.js";
+import { resolveAuthProfileFailureReason } from "../embedded-agent-runner/run/auth-profile-failure-policy.js";
+import { buildEmbeddedRunPayloads } from "../embedded-agent-runner/run/payloads.js";
+import { coerceToFailoverError, isFailoverError } from "../failover-error.js";
+import { CliAuthProfilePreparationError } from "./auth-profile-preparation-error.js";
+import { hashCliReseedPrompt } from "./reseed-envelope.js";
+import type { ClaudeCliRunDiagnosticLifecycle } from "./run-diagnostics.js";
+import type { PreparedCliRunContext, RunCliAgentParams } from "./types.js";
+
+const log = createSubsystemLogger("agents/cli-runner");
+
+export const cliRunSettlementDeps = {
+  claudeCliSessionTranscriptHasContent: claudeCliSessionTranscriptHasContentImpl,
+  delay: async (delayMs: number) => {
+    await new Promise((resolve) => {
+      setTimeout(resolve, delayMs);
+    });
+  },
+  loadAuthProfileStoreForRuntime,
+  markAuthProfileFailure,
+  markAuthProfileSuccess,
+};
+
+async function settleCliAuthProfile(params: {
+  store: AuthProfileStore;
+  profileId: string;
+  provider: string;
+  agentDir?: string;
+  terminal:
+    | { outcome: "success" }
+    | {
+        outcome: "failure";
+        error: unknown;
+        config?: RunCliAgentParams["config"];
+        runId: string;
+        modelId?: string;
+      };
+}): Promise<void> {
+  try {
+    if (params.terminal.outcome === "success") {
+      await cliRunSettlementDeps.markAuthProfileSuccess({
+        store: params.store,
+        profileId: params.profileId,
+        provider: params.provider,
+        agentDir: params.agentDir,
+      });
+      return;
+    }
+    const error = params.terminal.error;
+    const reason = resolveAuthProfileFailureReason({
+      failoverReason: isFailoverError(error) ? error.reason : null,
+      providerStarted:
+        isFailoverError(error) && error.reason === "timeout"
+          ? error.cliTimeout?.observedActivity
+          : undefined,
+    });
+    if (reason) {
+      await cliRunSettlementDeps.markAuthProfileFailure({
+        store: params.store,
+        profileId: params.profileId,
+        reason,
+        cfg: params.terminal.config,
+        agentDir: params.agentDir,
+        runId: params.terminal.runId,
+        modelId: params.terminal.modelId,
+      });
+    }
+  } catch (error) {
+    log.warn(
+      `CLI auth-profile ${params.terminal.outcome} settlement failed: ${formatErrorMessage(error)}`,
+    );
+  }
+}
+
+export function isClaudeCliProvider(provider: string): boolean {
+  return provider.trim().toLowerCase() === "claude-cli";
+}
+
+export async function assertCliRuntimeBinding(context: PreparedCliRunContext): Promise<void> {
+  if (!context.runtimeArtifactFingerprint) {
+    return;
+  }
+  const currentArtifact = await resolveCliRuntimeArtifactFingerprint({
+    provider: context.params.provider,
+    config: context.params.config ?? context.contextEngineConfig,
+    agentId: context.params.agentId,
+    runtimeArtifactId: context.backendResolved.id,
+  });
+  if (currentArtifact !== context.runtimeArtifactFingerprint) {
+    throw new Error("CLI executable/package artifact changed during successful inference");
+  }
+  if (!context.runtimeOwnerFingerprint) {
+    return;
+  }
+  const currentOwner = await resolveCliRuntimeOwnerFingerprint({
+    provider: context.params.provider,
+    config: context.params.config ?? context.contextEngineConfig,
+    ...(context.agentDir ? { agentDir: context.agentDir } : {}),
+    agentId: context.params.agentId,
+    runtimeOwnerId: context.backendResolved.id,
+    ...(context.effectiveAuthProfileId ? { authProfileId: context.effectiveAuthProfileId } : {}),
+    ...(context.authBindingSkipsLocalCredential ? { skipLocalCredential: true } : {}),
+    runtimeArtifactFingerprint: currentArtifact,
+  });
+  if (currentOwner !== context.runtimeOwnerFingerprint) {
+    throw new Error("CLI runtime owner changed during successful inference");
+  }
+}
+
+export async function settleCliPreparationError(
+  error: unknown,
+  params: RunCliAgentParams,
+): Promise<void> {
+  if (!(error instanceof CliAuthProfilePreparationError)) {
+    return;
+  }
+  const store = cliRunSettlementDeps.loadAuthProfileStoreForRuntime(error.agentDir, {
+    externalCli: externalCliDiscoveryForProviderAuth({
+      cfg: params.config,
+      provider: error.provider,
+      profileId: error.profileId,
+    }),
+  });
+  await settleCliAuthProfile({
+    store,
+    profileId: error.profileId,
+    provider: error.provider,
+    agentDir: error.agentDir,
+    terminal: {
+      outcome: "failure",
+      error,
+      config: params.config,
+      runId: params.runId,
+      modelId: params.model,
+    },
+  });
+}
+
+export async function settlePreparedCliRun(params: {
+  context: PreparedCliRunContext;
+  diagnosticLifecycle?: ClaudeCliRunDiagnosticLifecycle;
+  run: () => Promise<EmbeddedAgentRunResult>;
+}): Promise<EmbeddedAgentRunResult> {
+  const { context, diagnosticLifecycle, run } = params;
+  const runParams = context.params;
+  let result: EmbeddedAgentRunResult | undefined;
+  let runError: unknown;
+  try {
+    result = await run();
+  } catch (error) {
+    runError = error;
+  }
+  const terminalRunError = runError;
+  let cleanupError: unknown;
+  const recordCleanupError = (error: unknown) => {
+    cleanupError ??= error;
+  };
+  if (runParams.cleanupCliLiveSessionOnRunEnd === true) {
+    try {
+      const { closeClaudeSession } = await import("./claude-live-registry.js");
+      await closeClaudeSession(context, "restart");
+    } catch (error) {
+      recordCleanupError(error);
+    }
+  }
+  if (runParams.cleanupBundleMcpOnRunEnd === true) {
+    // The run's session ID is immutable; its session key can already belong to
+    // a newer run. Never retire the newer runtime or close the shared listener.
+    try {
+      const { retireSessionMcpRuntime } = await import("../agent-bundle-mcp-tools.js");
+      await retireSessionMcpRuntime({
+        sessionId: runParams.sessionId,
+        reason: "cli-run-end",
+        onError: recordCleanupError,
+      });
+    } catch (error) {
+      recordCleanupError(error);
+    }
+  }
+  if (cleanupError) {
+    if (runError || result?.didSendViaMessagingTool === true) {
+      log.warn(`cli run cleanup failed after completion: ${formatErrorMessage(cleanupError)}`);
+    } else {
+      diagnosticLifecycle?.setPhase("cleanup");
+      runError =
+        cleanupError instanceof Error ? cleanupError : new Error(formatErrorMessage(cleanupError));
+    }
+  }
+  // Settle only after backend recovery is exhausted. Recording inside an
+  // attempt would quarantine a healthy profile for a recovered session fault.
+  if (context.effectiveAuthProfileId && context.authProfileStore) {
+    const profileId = context.effectiveAuthProfileId;
+    const authProfileStore = context.authProfileStore;
+    if (terminalRunError) {
+      await settleCliAuthProfile({
+        store: authProfileStore,
+        profileId,
+        provider: authProfileStore.profiles[profileId]?.provider ?? runParams.provider,
+        agentDir: context.agentDir,
+        terminal: {
+          outcome: "failure",
+          error: terminalRunError,
+          config: runParams.config,
+          runId: runParams.runId,
+          modelId: context.modelId,
+        },
+      });
+    } else if (result?.meta.executionTrace?.attempts?.at(-1)?.result === "success") {
+      const provider = authProfileStore.profiles[profileId]?.provider ?? runParams.provider;
+      await settleCliAuthProfile({
+        store: authProfileStore,
+        profileId,
+        provider,
+        agentDir: context.agentDir,
+        terminal: { outcome: "success" },
+      });
+    }
+  }
+  if (runError) {
+    throw runError instanceof Error ? runError : new Error(formatErrorMessage(runError));
+  }
+  return result as EmbeddedAgentRunResult;
+}
+
+export function resolveCliSourceReplyMirror(params: {
+  evidence: Pick<
+    CliOutput,
+    | "didSendViaMessagingTool"
+    | "didDeliverSourceReplyViaMessageTool"
+    | "messagingToolSentTargets"
+    | "messagingToolSourceReplyPayloads"
+  >;
+  runParams: RunCliAgentParams;
+  modelId: string;
+}): { payloads: ReplyPayload[]; delivered: boolean; visibleText?: string } {
+  const { evidence, modelId, runParams } = params;
+  const payloads = buildEmbeddedRunPayloads({
+    assistantTexts: [],
+    lastAssistant: undefined,
+    sessionKey: runParams.sessionKey ?? "",
+    provider: runParams.provider,
+    model: modelId,
+    didSendViaMessagingTool: evidence.didSendViaMessagingTool,
+    didDeliverSourceReplyViaMessageTool: evidence.didDeliverSourceReplyViaMessageTool,
+    messagingToolSentTargets: evidence.messagingToolSentTargets,
+    messagingToolSourceReplyPayloads: evidence.messagingToolSourceReplyPayloads,
+    sourceReplyDeliveryMode: runParams.sourceReplyDeliveryMode,
+    agentId: runParams.agentId,
+    runId: runParams.runId,
+  });
+  const delivered =
+    payloads.length > 0 ||
+    (runParams.sourceReplyDeliveryMode === "message_tool_only" &&
+      evidence.didDeliverSourceReplyViaMessageTool === true);
+  const visibleText =
+    payloads
+      .map((payload) => payload.text?.trim() ?? "")
+      .filter(Boolean)
+      .join("\n\n") || undefined;
+  return { payloads, delivered, visibleText };
+}
+
+export function buildBlockedCliRunResult(params: {
+  message: string;
+  context: PreparedCliRunContext;
+  preparedContextAgentMeta: { contextTokens?: number };
+  sessionBindingDisabled: boolean;
+}): EmbeddedAgentRunResult {
+  const { context, message, preparedContextAgentMeta, sessionBindingDisabled } = params;
+  const runParams = context.params;
+  return {
+    payloads: [{ text: message, isError: true }],
+    meta: {
+      durationMs: Date.now() - context.started,
+      finalAssistantVisibleText: message,
+      finalAssistantRawText: message,
+      livenessState: "blocked",
+      error: {
+        kind: "hook_block",
+        message,
+      },
+      systemPromptReport: context.systemPromptReport,
+      executionTrace: {
+        winnerProvider: runParams.provider,
+        winnerModel: context.modelId,
+        attempts: [
+          {
+            provider: runParams.provider,
+            model: context.modelId,
+            result: "error",
+            reason: "before_agent_run blocked the run",
+          },
+        ],
+        fallbackUsed: false,
+        runner: "cli",
+      },
+      requestShaping: {
+        ...(runParams.thinkLevel ? { thinking: runParams.thinkLevel } : {}),
+        ...(context.effectiveAuthProfileId ? { authMode: "auth-profile" } : {}),
+      },
+      completion: {
+        finishReason: "blocked",
+        stopReason: "blocked",
+        refusal: true,
+      },
+      agentMeta: {
+        sessionId: runParams.sessionId ?? "",
+        provider: runParams.provider,
+        model: context.modelId,
+        ...preparedContextAgentMeta,
+        ...(sessionBindingDisabled ? { clearCliSessionBinding: true } : {}),
+      },
+    },
+  };
+}
+
+export function buildCliDeliveredFailure(params: {
+  error: unknown;
+  evidence: NonNullable<
+    ReturnType<typeof import("./delivery-evidence.js").getCliMessagingDeliveryEvidence>
+  >;
+  context: PreparedCliRunContext;
+  preparedContextAgentMeta: { contextTokens?: number };
+  sessionBindingDisabled: boolean;
+  reusableCliSessionId?: string;
+}): EmbeddedAgentRunResult {
+  const {
+    context,
+    error,
+    evidence,
+    preparedContextAgentMeta,
+    reusableCliSessionId,
+    sessionBindingDisabled,
+  } = params;
+  const runParams = context.params;
+  const message = formatErrorMessage(error);
+  const { payloads } = resolveCliSourceReplyMirror({
+    evidence,
+    runParams,
+    modelId: context.modelId,
+  });
+  const visiblePayloads =
+    payloads.length > 0
+      ? payloads
+      : resolveExplicitFinalSourceReplyDeliveryEvidence(evidence) === false
+        ? [{ text: "The reply stopped after sending progress. Please try again.", isError: true }]
+        : undefined;
+  return {
+    ...(visiblePayloads ? { payloads: visiblePayloads } : {}),
+    meta: {
+      durationMs: Date.now() - context.started,
+      systemPromptReport: context.systemPromptReport,
+      stopReason: "error",
+      executionTrace: {
+        winnerProvider: runParams.provider,
+        winnerModel: context.modelId,
+        attempts: [
+          {
+            provider: runParams.provider,
+            model: context.modelId,
+            result: "error",
+            reason: message,
+          },
+        ],
+        fallbackUsed: false,
+        runner: "cli",
+      },
+      requestShaping: {
+        ...(runParams.thinkLevel ? { thinking: runParams.thinkLevel } : {}),
+        ...(context.effectiveAuthProfileId ? { authMode: "auth-profile" } : {}),
+      },
+      completion: {
+        finishReason: "error",
+        stopReason: "error",
+        refusal: false,
+      },
+      agentMeta: {
+        sessionId: "",
+        provider: runParams.provider,
+        model: context.modelId,
+        ...preparedContextAgentMeta,
+        ...(sessionBindingDisabled || reusableCliSessionId ? { clearCliSessionBinding: true } : {}),
+      },
+    },
+    didSendViaMessagingTool: true,
+    ...(evidence.didDeliverSourceReplyViaMessageTool
+      ? { didDeliverSourceReplyViaMessageTool: true }
+      : {}),
+    ...(evidence.messagingToolSentTexts?.length
+      ? { messagingToolSentTexts: evidence.messagingToolSentTexts }
+      : {}),
+    ...(evidence.messagingToolSentMediaUrls?.length
+      ? { messagingToolSentMediaUrls: evidence.messagingToolSentMediaUrls }
+      : {}),
+    ...(evidence.messagingToolSentTargets?.length
+      ? { messagingToolSentTargets: evidence.messagingToolSentTargets }
+      : {}),
+    ...(evidence.messagingToolSourceReplyPayloads?.length
+      ? { messagingToolSourceReplyPayloads: evidence.messagingToolSourceReplyPayloads }
+      : {}),
+  };
+}
+
+export function buildCliRunResult(params: {
+  context: PreparedCliRunContext;
+  output: CliOutput;
+  effectiveCliSessionId?: string;
+  bindingFlushOk?: boolean;
+  assistantTranscriptOwned?: boolean;
+  usedHistoryPrompt: boolean;
+  userTurnHandled: boolean;
+  sessionBindingDisabled: boolean;
+  preparedContextAgentMeta: { contextTokens?: number };
+}): EmbeddedAgentRunResult {
+  const {
+    assistantTranscriptOwned,
+    bindingFlushOk,
+    context,
+    effectiveCliSessionId,
+    output,
+    preparedContextAgentMeta,
+    sessionBindingDisabled,
+    usedHistoryPrompt,
+    userTurnHandled,
+  } = params;
+  const runParams = context.params;
+  const text = output.text?.trim();
+  const rawText = output.rawText?.trim();
+  const sourceReplyMirror = resolveCliSourceReplyMirror({
+    evidence: output,
+    runParams,
+    modelId: context.modelId,
+  });
+  const finalAssistantVisibleText = sourceReplyMirror.delivered
+    ? sourceReplyMirror.visibleText
+    : text;
+  const payloads =
+    sourceReplyMirror.payloads.length > 0
+      ? sourceReplyMirror.payloads
+      : sourceReplyMirror.delivered
+        ? undefined
+        : text
+          ? [
+              assistantTranscriptOwned
+                ? setReplyPayloadMetadata({ text }, { assistantTranscriptOwned: true })
+                : { text },
+            ]
+          : runParams.allowEmptyAssistantReplyAsSilent === true
+            ? [{ text: SILENT_REPLY_TOKEN }]
+            : undefined;
+  const unflushedCliSessionId =
+    !sessionBindingDisabled && effectiveCliSessionId && bindingFlushOk === false
+      ? effectiveCliSessionId
+      : undefined;
+  const persistedCliSessionId = sessionBindingDisabled
+    ? undefined
+    : unflushedCliSessionId
+      ? undefined
+      : effectiveCliSessionId;
+  const createdReseedReceipt =
+    persistedCliSessionId &&
+    usedHistoryPrompt &&
+    isClaudeCliProvider(runParams.provider) &&
+    output.finalPromptText !== undefined &&
+    userTurnHandled &&
+    runParams.sessionId
+      ? {
+          version: 1 as const,
+          promptHash: hashCliReseedPrompt(output.finalPromptText),
+          localSessionId: runParams.sessionId,
+          userTurnDisposition: runParams.userTurnTranscriptRecorder?.hasPersisted()
+            ? ("persisted" as const)
+            : ("omitted" as const),
+        }
+      : undefined;
+  const preservedReseedReceipt =
+    runParams.cliSessionBinding && persistedCliSessionId === runParams.cliSessionBinding.sessionId
+      ? runParams.cliSessionBinding.reseedReceipt
+      : undefined;
+  const reseedReceipt = createdReseedReceipt ?? preservedReseedReceipt;
+  const agentSessionId = sessionBindingDisabled
+    ? (runParams.sessionId ?? "")
+    : unflushedCliSessionId
+      ? ""
+      : (effectiveCliSessionId ?? runParams.sessionId ?? "");
+  const yielded = output.yielded === true;
+  const stopReason = yielded ? "end_turn" : "completed";
+
+  runParams.onSuccessfulAuthBinding?.({
+    ...(context.effectiveAuthProfileId ? { authProfileId: context.effectiveAuthProfileId } : {}),
+    ...(context.authBindingFingerprint ? { authFingerprint: context.authBindingFingerprint } : {}),
+    ...(!context.authBindingFingerprint && context.runtimeOwnerFingerprint
+      ? {
+          runtimeOwnerFingerprint: context.runtimeOwnerFingerprint,
+          runtimeOwnerKind: "cli-runtime" as const,
+          runtimeOwnerId: context.backendResolved.id,
+        }
+      : {}),
+    ...(context.runtimeArtifactFingerprint
+      ? {
+          runtimeArtifactFingerprint: context.runtimeArtifactFingerprint,
+          runtimeArtifactId: context.backendResolved.id,
+        }
+      : {}),
+    ...(context.authBindingSkipsLocalCredential ? { skipLocalCredential: true } : {}),
+  });
+
+  return {
+    payloads,
+    meta: {
+      durationMs: Date.now() - context.started,
+      ...(output.finalPromptText ? { finalPromptText: output.finalPromptText } : {}),
+      ...(finalAssistantVisibleText || rawText
+        ? {
+            ...(finalAssistantVisibleText ? { finalAssistantVisibleText } : {}),
+            ...(rawText ? { finalAssistantRawText: rawText } : {}),
+          }
+        : {}),
+      systemPromptReport: context.systemPromptReport,
+      ...(yielded ? { yielded: true, livenessState: "paused" as const, stopReason } : {}),
+      executionTrace: {
+        winnerProvider: runParams.provider,
+        winnerModel: context.modelId,
+        attempts: [{ provider: runParams.provider, model: context.modelId, result: "success" }],
+        fallbackUsed: false,
+        runner: "cli",
+      },
+      requestShaping: {
+        ...(runParams.thinkLevel ? { thinking: runParams.thinkLevel } : {}),
+        ...(context.effectiveAuthProfileId ? { authMode: "auth-profile" } : {}),
+      },
+      completion: {
+        finishReason: yielded ? "end_turn" : "stop",
+        stopReason,
+        refusal: false,
+      },
+      ...(output.toolSummary ? { toolSummary: output.toolSummary } : {}),
+      agentMeta: {
+        sessionId: agentSessionId,
+        provider: runParams.provider,
+        model: context.modelId,
+        ...preparedContextAgentMeta,
+        usage: output.usage,
+        ...(output.usage ? { lastCallUsage: output.usage } : {}),
+        ...(output.diagnosticUsage ? { diagnosticUsage: output.diagnosticUsage } : {}),
+        ...(persistedCliSessionId
+          ? {
+              cliSessionBinding: {
+                sessionId: persistedCliSessionId,
+                ...(context.effectiveAuthProfileId
+                  ? { authProfileId: context.effectiveAuthProfileId }
+                  : {}),
+                ...(output.resumeCheckpointId
+                  ? { resumeCheckpointId: output.resumeCheckpointId }
+                  : {}),
+                ...(context.authEpoch ? { authEpoch: context.authEpoch } : {}),
+                authEpochVersion: context.authEpochVersion,
+                ...(context.extraSystemPromptHash
+                  ? { extraSystemPromptHash: context.extraSystemPromptHash }
+                  : {}),
+                ...(context.messageToolPolicyHash
+                  ? { messageToolPolicyHash: context.messageToolPolicyHash }
+                  : {}),
+                ...(context.promptToolNamesHash
+                  ? { promptToolNamesHash: context.promptToolNamesHash }
+                  : {}),
+                ...(context.cwdHash ? { cwdHash: context.cwdHash } : {}),
+                ...(context.preparedBackend.mcpConfigHash
+                  ? { mcpConfigHash: context.preparedBackend.mcpConfigHash }
+                  : {}),
+                ...(context.preparedBackend.mcpResumeHash
+                  ? { mcpResumeHash: context.preparedBackend.mcpResumeHash }
+                  : {}),
+                ...(reseedReceipt ? { reseedReceipt } : {}),
+              },
+            }
+          : {}),
+        ...(sessionBindingDisabled || unflushedCliSessionId
+          ? { clearCliSessionBinding: true }
+          : {}),
+      },
+    },
+    ...(output.didSendViaMessagingTool ? { didSendViaMessagingTool: true } : {}),
+    ...(output.didDeliverSourceReplyViaMessageTool
+      ? { didDeliverSourceReplyViaMessageTool: true }
+      : {}),
+    ...(output.messagingToolSentTexts?.length
+      ? { messagingToolSentTexts: output.messagingToolSentTexts }
+      : {}),
+    ...(output.messagingToolSentMediaUrls?.length
+      ? { messagingToolSentMediaUrls: output.messagingToolSentMediaUrls }
+      : {}),
+    ...(output.messagingToolSentTargets?.length
+      ? { messagingToolSentTargets: output.messagingToolSentTargets }
+      : {}),
+    ...(output.messagingToolSourceReplyPayloads?.length
+      ? { messagingToolSourceReplyPayloads: output.messagingToolSourceReplyPayloads }
+      : {}),
+  };
+}
+
+export function settleCliBackendOutcome(params: {
+  runResult: EmbeddedAgentRunResult | undefined;
+  runError: unknown;
+  runFailed: boolean;
+  cleanupError: unknown;
+  deliveredMessagingSideEffect: boolean;
+  diagnosticLifecycle?: ClaudeCliRunDiagnosticLifecycle;
+  failoverContext: { provider: string; model: string; sessionId: string; lane?: string };
+}): EmbeddedAgentRunResult {
+  const {
+    cleanupError,
+    deliveredMessagingSideEffect,
+    diagnosticLifecycle,
+    failoverContext,
+    runError,
+    runFailed,
+    runResult,
+  } = params;
+  if (cleanupError) {
+    if (!deliveredMessagingSideEffect) {
+      if (runFailed) {
+        log.warn(`CLI run also failed before backend cleanup: ${formatErrorMessage(runError)}`);
+      }
+      diagnosticLifecycle?.setPhase("cleanup");
+      throw cleanupError;
+    }
+    log.warn(
+      `CLI backend cleanup failed after confirmed message delivery: ${formatErrorMessage(cleanupError)}`,
+    );
+  }
+  if (runFailed) {
+    throw coerceToFailoverError(runError, failoverContext) ?? runError;
+  }
+  if (!runResult) {
+    throw new Error("CLI run completed without a result");
+  }
+  return runResult;
+}

--- a/src/agents/cli-runner/cli-run-settlement.ts
+++ b/src/agents/cli-runner/cli-run-settlement.ts
@@ -621,7 +621,7 @@ export function settleCliBackendOutcome(params: {
   runResult: EmbeddedAgentRunResult | undefined;
   runError: unknown;
   runFailed: boolean;
-  cleanupError: unknown;
+  cleanupError: Error | undefined;
   deliveredMessagingSideEffect: boolean;
   diagnosticLifecycle?: ClaudeCliRunDiagnosticLifecycle;
   failoverContext: { provider: string; model: string; sessionId: string; lane?: string };

--- a/src/agents/cli-runner/cli-run-settlement.ts
+++ b/src/agents/cli-runner/cli-run-settlement.ts
@@ -90,7 +90,7 @@ async function settleCliAuthProfile(params: {
   }
 }
 
-export function isClaudeCliProvider(provider: string): boolean {
+export function isClaudeCliBackend(provider: string): boolean {
   return provider.trim().toLowerCase() === "claude-cli";
 }
 
@@ -478,7 +478,7 @@ export function buildCliRunResult(params: {
   const createdReseedReceipt =
     persistedCliSessionId &&
     usedHistoryPrompt &&
-    isClaudeCliProvider(runParams.provider) &&
+    isClaudeCliBackend(runParams.provider) &&
     output.finalPromptText !== undefined &&
     userTurnHandled &&
     runParams.sessionId

--- a/src/agents/cli-runner/cli-run-transcript.ts
+++ b/src/agents/cli-runner/cli-run-transcript.ts
@@ -1,0 +1,404 @@
+import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
+import { patchSessionEntryCore } from "../../config/sessions/session-accessor.js";
+import { appendExactAssistantMessageToSessionTranscript } from "../../config/sessions/transcript.js";
+import { buildGenericCliContextEngineHostSupport } from "../../context-engine/host-compat.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { isHeartbeatLifecycleRunKind } from "../bootstrap-mode.js";
+import type { CliOutput } from "../cli-output-contracts.js";
+import {
+  awaitAgentEndSideEffects,
+  runAgentEndSideEffects,
+} from "../harness/agent-end-side-effects.js";
+import {
+  finalizeHarnessContextEngineTurn,
+  runHarnessContextEngineMaintenance,
+} from "../harness/context-engine-lifecycle.js";
+import { runAgentHarnessBeforeMessageWriteHook } from "../harness/hook-helpers.js";
+import type { AgentMessage } from "../runtime/index.js";
+import { SessionManager } from "../sessions/session-manager.js";
+import { buildAssistantMessage, buildUsageWithNoCost } from "../stream-message-shared.js";
+import type { PreparedCliRunContext, RunCliAgentParams } from "./types.js";
+
+const log = createSubsystemLogger("agents/cli-runner");
+
+export function buildCliHookUserMessage(prompt: string): unknown {
+  return {
+    role: "user",
+    content: prompt,
+    timestamp: Date.now(),
+  };
+}
+
+export function buildCliHookAssistantMessage(params: {
+  text: string;
+  provider: string;
+  model: string;
+  usage?: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+    total?: number;
+  };
+}): unknown {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text: params.text }],
+    api: "responses",
+    provider: params.provider,
+    model: params.model,
+    ...(params.usage ? { usage: params.usage } : {}),
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+}
+
+function isAgentMessage(value: unknown): value is AgentMessage {
+  return Boolean(value && typeof value === "object" && "role" in value);
+}
+
+function buildCliContextEngineUserMessage(prompt: string): AgentMessage {
+  return {
+    role: "user",
+    content: prompt,
+    timestamp: Date.now(),
+  } as AgentMessage;
+}
+
+function buildCliContextEngineAssistantMessage(params: {
+  text: string;
+  provider: string;
+  model: string;
+  usage?: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+    total?: number;
+  };
+}): AgentMessage {
+  return buildCliHookAssistantMessage(params) as AgentMessage;
+}
+
+type CliAgentEndHookParams = Parameters<typeof runAgentEndSideEffects>[0];
+
+function shouldAwaitCliAgentEndHook(params: RunCliAgentParams): boolean {
+  return !params.messageChannel && !params.messageProvider;
+}
+
+export async function runCliAgentEndHook(
+  params: RunCliAgentParams,
+  hookParams: CliAgentEndHookParams,
+): Promise<void> {
+  if (shouldAwaitCliAgentEndHook(params)) {
+    await awaitAgentEndSideEffects(hookParams);
+    return;
+  }
+  runAgentEndSideEffects(hookParams);
+}
+
+export async function persistApprovedCliUserTurnTranscript(
+  params: RunCliAgentParams,
+): Promise<boolean> {
+  const recorder = params.userTurnTranscriptRecorder;
+  const reusingPersistedTurn = params.suppressNextUserMessagePersistence === true;
+  if (!recorder || (reusingPersistedTurn && !recorder.hasPersisted())) {
+    return recorder?.isBlocked() === true;
+  }
+
+  const persisted = await recorder.persistApproved({
+    cwd: params.cwd ?? params.workspaceDir,
+  });
+  if (!persisted && !recorder.hasPersisted() && (await recorder.resolveMessage())) {
+    // A prepared user row can be rejected by before_message_write. Preserve
+    // that terminal decision so outer transcript mirrors do not retry it.
+    recorder.markBlocked();
+  }
+  if (persisted && !reusingPersistedTurn) {
+    try {
+      const notification = params.onUserMessagePersisted?.(persisted.message);
+      if (notification) {
+        void Promise.resolve(notification).catch((error: unknown) => {
+          log.warn(`CLI user turn persistence notification failed: ${formatErrorMessage(error)}`);
+        });
+      }
+    } catch (error) {
+      log.warn(`CLI user turn persistence notification failed: ${formatErrorMessage(error)}`);
+    }
+  }
+  return persisted !== undefined || recorder.hasPersisted() || recorder.isBlocked();
+}
+
+export async function persistCliAssistantTranscript(params: {
+  runParams: RunCliAgentParams;
+  text: string;
+  modelId: string;
+  usage?: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+    total?: number;
+  };
+}): Promise<{
+  owned: boolean;
+  terminalAnchor?: import("../../config/sessions/session-accessor.js").TranscriptEntryAnchor;
+}> {
+  const { runParams } = params;
+  if (runParams.currentInboundEventKind === "room_event") {
+    const admission = runParams.userTurnTranscriptRecorder?.getAdmissionReceipt();
+    return {
+      owned: true,
+      ...(admission ? { terminalAnchor: admission } : {}),
+    };
+  }
+  if (!params.text) {
+    const admission = runParams.userTurnTranscriptRecorder?.getAdmissionReceipt();
+    return {
+      owned: false,
+      ...(admission ? { terminalAnchor: admission } : {}),
+    };
+  }
+  if (!runParams.persistAssistantTranscript || !runParams.sessionKey) {
+    return { owned: false };
+  }
+  try {
+    const result = await appendExactAssistantMessageToSessionTranscript({
+      sessionKey: runParams.sessionKey,
+      agentId: runParams.agentId,
+      expectedSessionId: runParams.sessionId,
+      ...(runParams.expectedLifecycleRevision !== undefined
+        ? { expectedLifecycleRevision: runParams.expectedLifecycleRevision }
+        : {}),
+      ...(runParams.expectedWriterRunId !== undefined
+        ? { expectedWriterRunId: runParams.expectedWriterRunId }
+        : {}),
+      storePath: runParams.storePath,
+      idempotencyKey: `cli-assistant:${runParams.runId}`,
+      config: runParams.config,
+      beforeMessageWrite: runAgentHarnessBeforeMessageWriteHook,
+      message: buildAssistantMessage({
+        model: {
+          api: "cli",
+          provider: runParams.provider,
+          id: params.modelId,
+        },
+        content: [{ type: "text", text: params.text }],
+        stopReason: "stop",
+        usage: buildUsageWithNoCost({
+          input: params.usage?.input,
+          output: params.usage?.output,
+          cacheRead: params.usage?.cacheRead,
+          cacheWrite: params.usage?.cacheWrite,
+          totalTokens: params.usage?.total,
+        }),
+      }),
+    });
+    if (!result.ok) {
+      log.warn(`CLI assistant transcript persistence skipped: ${result.reason}`);
+      return { owned: result.code === "blocked" || result.code === "session-rebound" };
+    }
+    return { owned: true, ...(result.anchor ? { terminalAnchor: result.anchor } : {}) };
+  } catch (error) {
+    log.warn(`CLI assistant transcript persistence failed: ${formatErrorMessage(error)}`);
+    return { owned: false };
+  }
+}
+
+async function notifyCliUserMessagePersisted(
+  params: RunCliAgentParams,
+  message: Extract<AgentMessage, { role: "user" }>,
+  context: string,
+): Promise<void> {
+  try {
+    await Promise.resolve(params.onUserMessagePersisted?.(message));
+  } catch (err) {
+    log.warn(`${context} notification failed: ${formatErrorMessage(err)}`);
+  }
+}
+
+export async function persistCliRunBlock(
+  params: RunCliAgentParams,
+  block: { message: string; pluginId: string },
+): Promise<void> {
+  const nowMs = Date.now();
+  const redactedUserMessage = {
+    role: "user" as const,
+    content: [{ type: "text" as const, text: block.message }],
+    timestamp: nowMs,
+    idempotencyKey: `hook-block:before_agent_run:user:${params.runId}`,
+    __openclaw: {
+      beforeAgentRunBlocked: {
+        blockedBy: block.pluginId,
+        blockedAt: nowMs,
+      },
+    },
+  };
+  try {
+    const persisted = await params.userTurnTranscriptRecorder?.persistBlocked(redactedUserMessage);
+    if (persisted) {
+      await notifyCliUserMessagePersisted(
+        params,
+        persisted.message,
+        "before_agent_run block user-turn persistence",
+      );
+      return;
+    }
+  } catch (err) {
+    log.warn(
+      `before_agent_run block: failed to persist canonical CLI user message: ${formatErrorMessage(
+        err,
+      )}`,
+    );
+  }
+
+  try {
+    const sessionKey = params.sessionKey?.trim() || params.sessionId;
+    const agentId = params.agentId ?? resolveAgentIdFromSessionKey(sessionKey);
+    let sessionManager = params.sessionManager;
+    if (!sessionManager) {
+      const sessionTarget = params.sessionTarget ?? {
+        agentId,
+        sessionId: params.sessionId,
+        sessionKey,
+        storePath:
+          params.storePath ??
+          resolveSessionStorePathCore(params.config?.session?.store, {
+            agentId,
+          }),
+      };
+      const persistedEntry = await patchSessionEntryCore(
+        sessionTarget,
+        (entry, patchContext) => {
+          if (patchContext.existingEntry && entry.sessionId !== sessionTarget.sessionId) {
+            return null;
+          }
+          return {
+            sessionId: sessionTarget.sessionId,
+            updatedAt: Date.now(),
+          };
+        },
+        {
+          fallbackEntry: params.sessionEntry
+            ? undefined
+            : { sessionId: sessionTarget.sessionId, updatedAt: Date.now() },
+          skipMaintenance: true,
+        },
+      );
+      if (persistedEntry?.sessionId !== sessionTarget.sessionId) {
+        // Skip only this stale blocked-message write; the outer runner still returns blocked.
+        return;
+      }
+      sessionManager = SessionManager.open(sessionTarget);
+    }
+    sessionManager.appendMessage(
+      redactedUserMessage as Parameters<typeof sessionManager.appendMessage>[0],
+    );
+    sessionManager.flushPendingPersistence();
+  } catch (err) {
+    log.warn(
+      `before_agent_run block: failed to persist redacted CLI user message: ${formatErrorMessage(
+        err,
+      )}`,
+    );
+  }
+}
+
+export async function finalizeCliContextEngineTurn(params: {
+  context: PreparedCliRunContext;
+  historyMessages: unknown[];
+  assistantText: string;
+  terminalAnchor?: import("../../config/sessions/session-accessor.js").TranscriptEntryAnchor;
+  output: CliOutput;
+}): Promise<void> {
+  const { context } = params;
+  if (!context.contextEngine) {
+    return;
+  }
+
+  const { params: runParams } = context;
+  const prePromptMessages = params.historyMessages.filter(isAgentMessage);
+  const turnMessages: AgentMessage[] = [];
+  if (context.contextEngineTurnPrompt) {
+    turnMessages.push(buildCliContextEngineUserMessage(context.contextEngineTurnPrompt));
+  }
+  if (params.assistantText) {
+    turnMessages.push(
+      buildCliContextEngineAssistantMessage({
+        text: params.assistantText,
+        provider: runParams.provider,
+        model: context.modelId,
+        usage: params.output.usage,
+      }),
+    );
+  }
+
+  const contextEngineHostSupport = buildGenericCliContextEngineHostSupport({
+    backendId: context.backendResolved.id,
+  });
+  const finalizeTurn = async (transcript: {
+    messagesSnapshot: AgentMessage[];
+    prePromptMessageCount: number;
+    sessionManager?: SessionManager;
+    withSessionManagerRewriteLock: <T>(operation: () => Promise<T> | T) => Promise<T>;
+  }) => {
+    let deferredTurnMaintenance: Promise<void> | undefined;
+    const result = await finalizeHarnessContextEngineTurn({
+      contextEngine: context.contextEngine,
+      promptError: false,
+      aborted: runParams.abortSignal?.aborted === true,
+      yieldAborted: false,
+      sessionIdUsed: runParams.sessionId,
+      sessionKey: runParams.sessionKey,
+      sessionFile: runParams.sessionFile,
+      isHeartbeat: isHeartbeatLifecycleRunKind(runParams.bootstrapContextRunKind),
+      messagesSnapshot: transcript.messagesSnapshot,
+      prePromptMessageCount: transcript.prePromptMessageCount,
+      sessionManager: transcript.sessionManager,
+      config: context.contextEngineConfig,
+      contextEngineHostSupport,
+      providerId: runParams.provider,
+      modelId: context.modelId,
+      runMaintenance: async (maintenanceParams) =>
+        await runHarnessContextEngineMaintenance({
+          ...maintenanceParams,
+          withSessionManagerRewriteLock: transcript.withSessionManagerRewriteLock,
+          onDeferredMaintenance: (promise) => {
+            deferredTurnMaintenance = promise;
+          },
+        }),
+      warn: (message) => log.warn(message),
+    });
+    if (result.postTurnFinalizationSucceeded && deferredTurnMaintenance) {
+      context.contextEngineDeferredTurnMaintenance = deferredTurnMaintenance;
+    }
+  };
+  const admission = runParams.userTurnTranscriptRecorder?.getAdmissionReceipt();
+  if (runParams.onContextEngineTurnCandidate) {
+    if (admission && params.terminalAnchor) {
+      runParams.onContextEngineTurnCandidate({
+        boundary: { admission, terminal: params.terminalAnchor },
+        sessionIdUsed: runParams.sessionId,
+        sessionKey: runParams.sessionKey,
+        sessionTarget: runParams.sessionTarget,
+        sessionFile: runParams.sessionFile,
+        promptError: false,
+        aborted: runParams.abortSignal?.aborted === true,
+        yieldAborted: false,
+        contextEngineHostSupport,
+        providerId: runParams.provider,
+        modelId: context.modelId,
+        config: context.contextEngineConfig,
+        isHeartbeat: isHeartbeatLifecycleRunKind(runParams.bootstrapContextRunKind),
+      });
+    }
+  } else {
+    await finalizeTurn({
+      messagesSnapshot: [...prePromptMessages, ...turnMessages],
+      prePromptMessageCount: prePromptMessages.length,
+      withSessionManagerRewriteLock: async (operation) => await operation(),
+    });
+  }
+}

--- a/src/agents/code-mode.wait.test.ts
+++ b/src/agents/code-mode.wait.test.ts
@@ -650,7 +650,8 @@ describe("Code Mode wait, scope, and suspended runs", () => {
     );
     expect(first.status).toBe("waiting");
     expect(first.output).toEqual([{ type: "text", text: "before timeout" }]);
-    expect(first.pendingToolCalls).toEqual([expect.objectContaining({ method: "callValue" })]);
+    // Both host calls begin from the parked snapshot, so neither has settled at this boundary.
+    expect(first.pendingToolCalls).toHaveLength(2);
     const runId = first.runId;
     expect(typeof runId).toBe("string");
     if (typeof runId !== "string") {

--- a/src/agents/code-mode.wait.test.ts
+++ b/src/agents/code-mode.wait.test.ts
@@ -650,8 +650,10 @@ describe("Code Mode wait, scope, and suspended runs", () => {
     );
     expect(first.status).toBe("waiting");
     expect(first.output).toEqual([{ type: "text", text: "before timeout" }]);
-    // Both host calls begin from the parked snapshot, so neither has settled at this boundary.
-    expect(first.pendingToolCalls).toHaveLength(2);
+    // The fast call may settle as the snapshot is parked, but the slow call must remain pending.
+    expect(first.pendingToolCalls).toContainEqual(
+      expect.objectContaining({ id: "bridge:callValue:2", method: "callValue" }),
+    );
     const runId = first.runId;
     expect(typeof runId).toBe("string");
     if (typeof runId !== "string") {


### PR DESCRIPTION
## What Problem This Solves

`src/agents/cli-runner.ts` was a 1,807-line grandfathered max-lines offender that mixed orchestration, session recovery, transcript lifecycle, and terminal settlement in one module.

## Why This Change Was Made

This is a behavior-neutral concept split. The public entry points stay in `cli-runner.ts`; recovery, settlement, and transcript ownership move to concept-named modules. Preparation still happens once, every retry reuses the prepared/admitted context, delivery evidence is checked before each recovery attempt, and prepared-backend cleanup remains invoked by `runPreparedCliAgent` before settlement resolves outcome precedence.

The existing `setCliRunnerTestDeps`, `restoreCliRunnerTestDeps`, and `isCliBindingFlushed` exports remain declared on `cli-runner.ts` because current tests import them there and the Plugin SDK declaration closure records that module surface. No new re-export shim was added.

## User Impact

No user-visible behavior changes. Maintainers get concept-sized files under the max-lines budget, and the grandfathered suppression/baseline entry is removed.

Production LOC: +1366/-1207 physical (net +159, pre-justified by the coordinator as max-lines debt burn-down following the repository's concept-split precedent) | Tests: +5/-2 | Tooling: +0/-1

## Evidence

- `node scripts/run-vitest.mjs src/agents/cli-runner.fault-sequences.e2e.test.ts`: 10/10 passed on the pushed logic. The pinned counts remain exact: bridge/max-turns/timeouts stay at one child and one candidate; pre-activity fallback stays at one-or-two children and two candidates; resume-to-fork stays at two children and one candidate; fork-to-fresh and exhausted recovery stay at three children and one candidate; context overflow stays at two children and one candidate; every scenario keeps zero whole-turn retries and zero native-budget attempts.
- `node scripts/run-vitest.mjs src/agents/cli-runner.reliability.test.ts`: 85/85 passed.
- `node scripts/run-vitest.mjs src/agents/code-mode.wait.test.ts`: 17/17 passed with the race-safe boundary assertion.
- `node scripts/run-vitest.mjs src/agents/cli-runner/cli-run-settlement.test.ts`: 9/9 passed.
- `pnpm build`: passed; no ineffective dynamic-import warning.
- `pnpm check:import-cycles`: passed with 0 runtime value cycles.
- `node scripts/check-changed.mjs`: passed after the remote backend was unavailable and the documented local fallback ran the complete changed gate.
- `git diff --check`: passed.
- Structured autoreview: clean, no actionable findings.

The requested `node scripts/run-vitest.mjs src/agents/cli-runner` aggregate exposes an existing non-isolated base-main failure: 67/68 exact-base files passed and `execute.supervisor-capture.test.ts` failed 12 target assertions only after its first case stalled for 507 seconds. The branch reproduces the identical 12 failures after the same stall, while that file alone passes 52/52 and the new settlement test plus that file passes 61/61. Exact-base proof used `4401ff2a923c48c235ad86981c8b5da5b6432e2a` before later main-only baseline churn; the split does not touch that executor path.

Exact-head CI run 31565972933 passed every selected check except `checks-node-compact-large-6`, where `src/agents/code-mode.wait.test.ts:653` observed two pending calls. The exact branch-base SHA `e30df720459b2f31fe035ab05f731ae371b133dc` reproduced that side of the race in 3/3 focused executions. After initially aligning the expectation with those focused runs, exact-head run 31573367693 observed the opposite valid state: the fast call had settled and only the deliberately slow call remained pending. That cross-environment evidence establishes a parked-snapshot timing race, not deterministic product behavior. PR #114884 / commit `e1ced6de50bb` made the test depend on one side of that race. No open owner-heal PR existed, so this landing PR applies the authorized orphaned test correction: the first boundary requires the stable slow-call ID while allowing the fast call to be settled or unsettled, and later waits still assert exactly one pending call. The corrected file passes 17/17 focused.

Exact-head CI run 31575693789 passed all 70 jobs on `c1b19a472f964c1ff8a166a0ffbf9ccc7e76e86a`, including the previously failing aggregate shard. The final rebase is patch-identical and uses the repository-native prepare flow's green-head reuse plus current-merge validation.
