### PR TITLE
improve: reduce provider auth parity test time

### DIFF
--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -20,6 +20,7 @@ import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import type { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { runGitHubCopilotDeviceFlow } from "./login.js";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 const mocks = vi.hoisted(() => ({
   fetchWithSsrFGuard: vi.fn<typeof fetchWithSsrFGuard>(async (params) => ({
@@ -61,6 +62,7 @@ type RegisteredMemoryEmbeddingProvider = Parameters<
 type RegisteredProvider = Parameters<OpenClawPluginApi["registerProvider"]>[0];
 type GithubCopilotTestProvider = RegisteredProvider & {
   auth: Array<{
+    id: string;
     run: (ctx: unknown) => Promise<ProviderAuthResult | null>;
     runNonInteractive: (ctx: unknown) => Promise<OpenClawConfig | null>;
   }>;
@@ -1444,23 +1446,46 @@ describe("github-copilot plugin", () => {
   it("stores GitHub Copilot token from non-interactive onboarding", async () => {
     const provider = registerProviderWithPluginConfig({});
     const method = requireAuthMethod(provider.auth, 0);
+    const choice = expectDefined(
+      manifest.providerAuthChoices.find((entry) => entry.choiceId === "github-copilot"),
+      "GitHub Copilot manifest auth choice",
+    );
+    const optionKey = expectDefined(choice.optionKey, "GitHub Copilot option key");
+    const setupProvider = expectDefined(
+      manifest.setup.providers.find((entry) => entry.id === choice.provider),
+      "GitHub Copilot setup provider",
+    );
+    const envVar = expectDefined(setupProvider.envVars[0], "GitHub Copilot setup env var");
     const agentDir = await createAgentDir();
     const runtime = { error: vi.fn(), exit: vi.fn() };
+    const resolveApiKey = vi.fn(async () => ({
+      key: "ghu_test123",
+      source: "flag" as const,
+    }));
 
     const result = await method.runNonInteractive({
-      authChoice: "github-copilot",
+      authChoice: choice.choiceId,
       config: {},
       baseConfig: {},
-      opts: { githubCopilotToken: "ghu_test\r\n123" },
+      opts: { [optionKey]: "ghu_test\r\n123" },
       runtime,
       agentDir,
-      resolveApiKey: vi.fn(async () => ({
-        key: "ghu_test123",
-        source: "flag" as const,
-      })),
+      resolveApiKey,
       toApiKeyCredential: vi.fn(),
     });
 
+    expect(provider.id).toBe(choice.provider);
+    expect(method.id).toBe(choice.method);
+    expect(provider.envVars).toEqual(setupProvider.envVars);
+    expect(resolveApiKey).toHaveBeenCalledWith({
+      provider: choice.provider,
+      flagValue: "ghu_test123",
+      flagName: choice.cliFlag,
+      envVar,
+      envVarName: envVar,
+      allowProfile: false,
+      required: false,
+    });
     expect(runtime.error).not.toHaveBeenCalled();
     expect(result?.auth?.profiles?.["github-copilot:github"]).toEqual({
       provider: "github-copilot",

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -3153,6 +3153,11 @@ function classifyTarget(arg: string, cwd: string) {
   if (agentVitestProjectOwners.embeddedIncompleteTurn.include.includes(relative)) {
     return agentVitestProjectOwners.embeddedIncompleteTurn.kind;
   }
+  // Explicit isolation ownership wins over inferred unit-fast eligibility.
+  // Otherwise a thin wrapper can move a stateful tooling test into a shared worker.
+  if (isToolingIsolatedTestFile(relative)) {
+    return "toolingIsolated";
+  }
   if (resolveUnitFastTimerTestIncludePattern(relative)) {
     return "unitFastFakeTimers";
   }
@@ -3241,9 +3246,6 @@ function classifyTarget(arg: string, cwd: string) {
   }
   if (isBoundaryTestFile(relative)) {
     return "boundary";
-  }
-  if (isToolingIsolatedTestFile(relative)) {
-    return "toolingIsolated";
   }
   if (relative === TOOLING_DOCKER_TEST_TARGET) {
     return "toolingDocker";

--- a/test/plugins/bundled-provider-auth-literal-parity.2.test.ts
+++ b/test/plugins/bundled-provider-auth-literal-parity.2.test.ts
@@ -1,3 +1,3 @@
 import { defineBundledProviderAuthLiteralParityTests } from "./bundled-provider-auth-literal-parity.test-support.js";
 
-defineBundledProviderAuthLiteralParityTests(0);
+defineBundledProviderAuthLiteralParityTests(1);

--- a/test/plugins/bundled-provider-auth-literal-parity.3.test.ts
+++ b/test/plugins/bundled-provider-auth-literal-parity.3.test.ts
@@ -1,3 +1,3 @@
 import { defineBundledProviderAuthLiteralParityTests } from "./bundled-provider-auth-literal-parity.test-support.js";
 
-defineBundledProviderAuthLiteralParityTests(0);
+defineBundledProviderAuthLiteralParityTests(2);

--- a/test/plugins/bundled-provider-auth-literal-parity.test-support.ts
+++ b/test/plugins/bundled-provider-auth-literal-parity.test-support.ts
@@ -1,0 +1,307 @@
+// Keeps manifest providerAuthChoices literals aligned with registered provider.auth methods.
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { listBundledPluginMetadata } from "../../src/plugins/bundled-plugin-metadata.js";
+import type { PluginManifest } from "../../src/plugins/manifest.js";
+import type {
+  ProviderAuthMethod,
+  ProviderPlugin,
+  ProviderResolveNonInteractiveApiKeyParams,
+} from "../../src/plugins/types.js";
+import { createNonExitingRuntime } from "../../src/runtime.js";
+import { createCapturedPluginRegistration } from "../../src/test-utils/plugin-registration.js";
+
+const PARITY_TIMEOUT_MS = 120_000;
+const PARITY_SHARD_COUNT = 3;
+const SENTINEL_API_KEY = "parity-sentinel-api-key";
+// These entries pass their manifest directly to defineSingleProviderPluginEntry,
+// so provider-entry and provider-api-key-auth owner tests already prove the
+// same literal projection. Runtime probes remain for custom/explicit auth.
+const MANIFEST_DERIVED_PLUGIN_IDS = new Set([
+  "baseten",
+  "byteplus",
+  "cerebras",
+  "clawrouter",
+  "cohere",
+  "deepseek",
+  "featherless",
+  "fireworks",
+  "gmi",
+  "groq",
+  "huggingface",
+  "kilocode",
+  "kimi",
+  "longcat",
+  "meta",
+  "mistral",
+  "novita",
+  "nvidia",
+  "opencode",
+  "opencode-go",
+  "openrouter",
+  "qianfan",
+  "synthetic",
+  "together",
+  "venice",
+  "vercel-ai-gateway",
+  "volcengine",
+]);
+// GitHub Copilot's owner test derives these literals from its manifest and
+// exercises the full token setup result in the already-loaded plugin suite.
+const OWNER_TESTED_PLUGIN_IDS = new Set(["github-copilot"]);
+
+type ApiKeyStyleChoice = PluginManifestProviderAuthChoice & {
+  optionKey: string;
+  cliFlag: string;
+};
+
+type PluginManifestProviderAuthChoice = NonNullable<PluginManifest["providerAuthChoices"]>[number];
+
+type ParityCase = {
+  pluginId: string;
+  providerId: string;
+  methodId: string;
+  optionKey: string;
+  cliFlag: string;
+  setupEnvVars: readonly string[];
+};
+
+type PluginRegister = (api: ReturnType<typeof createCapturedPluginRegistration>["api"]) => void;
+type CapturedPluginRegistration = ReturnType<typeof createCapturedPluginRegistration>;
+
+type PluginEntryModule = {
+  default?: {
+    id?: string;
+    register?: PluginRegister;
+  };
+  register?: PluginRegister;
+};
+
+function isApiKeyStyleChoice(
+  choice: PluginManifestProviderAuthChoice,
+): choice is ApiKeyStyleChoice {
+  return Boolean(choice.optionKey?.trim() && choice.cliFlag?.trim());
+}
+
+function listParityCases(): ParityCase[] {
+  return listBundledPluginMetadata({ includeChannelConfigs: false }).flatMap((plugin) => {
+    const choices = plugin.manifest.providerAuthChoices ?? [];
+    if (choices.length === 0) {
+      return [];
+    }
+    const setupEnvByProvider = new Map(
+      (plugin.manifest.setup?.providers ?? []).map((entry) => [
+        entry.id,
+        entry.envVars ?? ([] as readonly string[]),
+      ]),
+    );
+    return choices.filter(isApiKeyStyleChoice).map((choice) => ({
+      pluginId: plugin.manifest.id,
+      providerId: choice.provider,
+      methodId: choice.method,
+      optionKey: choice.optionKey,
+      cliFlag: choice.cliFlag,
+      setupEnvVars: setupEnvByProvider.get(choice.provider) ?? [],
+    }));
+  });
+}
+
+async function loadPluginRegister(pluginId: string): Promise<PluginRegister> {
+  // Dynamic import keeps this file out of the unit-fast lane: loading built
+  // plugin dists pulls large module graphs into the shared worker cache and
+  // breaks co-resident vi.mock-based unit tests (observed with memory-host-sdk).
+  const { loadBundledPluginFacade, resolveBundledPluginPublicModulePath } =
+    await import("../../src/test-utils/bundled-plugin-public-surface.js");
+  // Resolve first so unknown plugin ids fail with a clear path error before import.
+  resolveBundledPluginPublicModulePath({
+    pluginId,
+    artifactBasename: "index.js",
+  });
+  const mod = await loadBundledPluginFacade<PluginEntryModule>({
+    pluginId,
+    artifactBasename: "index.js",
+  });
+  const register = mod.default?.register ?? mod.register;
+  if (!register) {
+    throw new Error(`bundled plugin ${pluginId} has no register() entry`);
+  }
+  return register;
+}
+
+function findRegisteredProvider(
+  providers: readonly ProviderPlugin[],
+  providerId: string,
+): ProviderPlugin | undefined {
+  return providers.find(
+    (provider) => provider.id === providerId || provider.hookAliases?.includes(providerId) === true,
+  );
+}
+
+async function probeRuntimeAuthLiterals(params: {
+  method: ProviderAuthMethod;
+  optionKey: string;
+  agentDir: string;
+}): Promise<ProviderResolveNonInteractiveApiKeyParams | undefined> {
+  if (!params.method.runNonInteractive) {
+    return undefined;
+  }
+  // The sentinel maps only to the expected optionKey so flagValue === sentinel
+  // proves the method read the right key. Other keys get distinct placeholders
+  // to satisfy provider-specific preflight opts (e.g. account/gateway ids)
+  // without weakening that proof.
+  const opts = new Proxy<Record<string, unknown>>(
+    { [params.optionKey]: SENTINEL_API_KEY },
+    {
+      get: (target, key) =>
+        typeof key === "string" ? (target[key] ?? `parity-extra-${key}`) : undefined,
+    },
+  );
+  let captured: ProviderResolveNonInteractiveApiKeyParams | undefined;
+  try {
+    await params.method.runNonInteractive({
+      authChoice: "parity",
+      agentDir: params.agentDir,
+      config: {},
+      baseConfig: {},
+      opts,
+      runtime: createNonExitingRuntime(),
+      resolveApiKey: async (resolveParams) => {
+        if (!captured) {
+          captured = resolveParams;
+        }
+        return null;
+      },
+      toApiKeyCredential: () => null,
+    });
+  } catch {
+    // Some methods throw when credentials are incomplete; captured params still count.
+  }
+  return captured;
+}
+
+const allParityCases = listParityCases().toSorted((left, right) => {
+  const pluginOrder = left.pluginId.localeCompare(right.pluginId);
+  if (pluginOrder !== 0) {
+    return pluginOrder;
+  }
+  const providerOrder = left.providerId.localeCompare(right.providerId);
+  if (providerOrder !== 0) {
+    return providerOrder;
+  }
+  return left.methodId.localeCompare(right.methodId);
+});
+
+const allParityPluginIds = [...new Set(allParityCases.map((entry) => entry.pluginId))];
+export function defineBundledProviderAuthLiteralParityTests(shardIndex: number): void {
+  const parityPluginIds = allParityPluginIds.filter(
+    (pluginId, index) =>
+      index % PARITY_SHARD_COUNT === shardIndex &&
+      !MANIFEST_DERIVED_PLUGIN_IDS.has(pluginId) &&
+      !OWNER_TESTED_PLUGIN_IDS.has(pluginId),
+  );
+  const parityPluginIdSet = new Set(parityPluginIds);
+  const parityCases = allParityCases.filter((entry) => parityPluginIdSet.has(entry.pluginId));
+  const probeAgentDir = mkdtempSync(path.join(tmpdir(), "openclaw-auth-parity-"));
+  const registrationResultByPluginId = new Map<
+    string,
+    PromiseSettledResult<CapturedPluginRegistration>
+  >();
+
+  beforeAll(async () => {
+    // Full plugin entry graphs contend heavily when transformed concurrently.
+    for (const pluginId of parityPluginIds) {
+      try {
+        const register = await loadPluginRegister(pluginId);
+        const captured = createCapturedPluginRegistration({
+          id: pluginId,
+          name: pluginId,
+          source: `bundled:${pluginId}`,
+        });
+        register(captured.api);
+        registrationResultByPluginId.set(pluginId, { status: "fulfilled", value: captured });
+      } catch (reason) {
+        registrationResultByPluginId.set(pluginId, { status: "rejected", reason });
+      }
+    }
+  });
+
+  afterAll(() => {
+    rmSync(probeAgentDir, { recursive: true, force: true });
+  });
+
+  describe(`bundled provider manifest↔runtime auth literal parity (${shardIndex + 1}/${PARITY_SHARD_COUNT})`, () => {
+    it("discovers custom api-key-style provider auth choices", () => {
+      expect(allParityCases.length).toBeGreaterThan(parityCases.length);
+      expect(parityCases.length).toBeGreaterThan(0);
+    });
+
+    it.each(parityCases)(
+      "$pluginId $providerId/$methodId optionKey=$optionKey",
+      { timeout: PARITY_TIMEOUT_MS },
+      async (parityCase) => {
+        const registrationResult = registrationResultByPluginId.get(parityCase.pluginId);
+        if (!registrationResult) {
+          throw new Error(`bundled plugin ${parityCase.pluginId} was not preloaded`);
+        }
+        if (registrationResult.status === "rejected") {
+          throw new Error(`bundled plugin ${parityCase.pluginId} preload or registration failed`, {
+            cause: registrationResult.reason,
+          });
+        }
+        const captured = registrationResult.value;
+
+        const provider = findRegisteredProvider(captured.providers, parityCase.providerId);
+        if (!provider) {
+          // Capability-only plugins (video/image onboard flags) register no text
+          // providers at all. A plugin that registers text providers but not the
+          // manifest-declared id has drifted — the exact mismatch this test guards.
+          expect(
+            captured.providers.map((entry) => entry.id),
+            `${parityCase.pluginId} manifest declares provider ${parityCase.providerId} but runtime registers different providers`,
+          ).toEqual([]);
+          return;
+        }
+
+        const method = provider.auth.find((entry) => entry.id === parityCase.methodId);
+        expect(
+          method,
+          `${parityCase.pluginId} runtime auth missing method ${parityCase.methodId}`,
+        ).toBeDefined();
+        if (!method) {
+          return;
+        }
+
+        // methodId (manifest `method`) ↔ runtime auth id
+        expect(method.id).toBe(parityCase.methodId);
+
+        const probed = await probeRuntimeAuthLiterals({
+          method,
+          optionKey: parityCase.optionKey,
+          agentDir: probeAgentDir,
+        });
+        // Fail closed: an api-key-style choice whose method cannot be probed
+        // would otherwise leave its flag/env literals unchecked while CI stays
+        // green — the same silent-drift hole this test exists to close.
+        expect(
+          probed,
+          `${parityCase.pluginId} auth method ${parityCase.methodId} did not resolve an API key non-interactively; flag/env literals unverifiable`,
+        ).toBeDefined();
+        if (!probed) {
+          return;
+        }
+
+        // cliFlag ↔ flagName; optionKey proven when opts[optionKey] becomes flagValue
+        expect(probed.flagName).toBe(parityCase.cliFlag);
+        expect(probed.flagValue).toBe(SENTINEL_API_KEY);
+
+        // envVar ↔ setup.providers[].envVars and/or provider.envVars
+        const knownEnvVars = new Set([...parityCase.setupEnvVars, ...(provider.envVars ?? [])]);
+        if (knownEnvVars.size > 0) {
+          expect(knownEnvVars.has(probed.envVar)).toBe(true);
+        }
+      },
+    );
+  });
+}

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -956,14 +956,15 @@ describe("scripts/test-projects changed-target routing", () => {
     );
   });
 
-  it("routes the bundled provider auth parity test to the isolated tooling shard", () => {
-    expectSingleVitestRunPlan(
-      buildVitestRunPlans(["test/plugins/bundled-provider-auth-literal-parity.test.ts"]),
-      {
-        config: "test/vitest/vitest.tooling-isolated.config.ts",
-        includePatterns: ["test/plugins/bundled-provider-auth-literal-parity.test.ts"],
-      },
-    );
+  it.each([
+    "test/plugins/bundled-provider-auth-literal-parity.test.ts",
+    "test/plugins/bundled-provider-auth-literal-parity.2.test.ts",
+    "test/plugins/bundled-provider-auth-literal-parity.3.test.ts",
+  ])("routes bundled provider auth parity test %s to the isolated tooling shard", (testFile) => {
+    expectSingleVitestRunPlan(buildVitestRunPlans([testFile]), {
+      config: "test/vitest/vitest.tooling-isolated.config.ts",
+      includePatterns: [testFile],
+    });
   });
 
   it.each([

--- a/test/vitest/vitest.tooling-isolated-paths.mjs
+++ b/test/vitest/vitest.tooling-isolated-paths.mjs
@@ -1,6 +1,8 @@
 // Tooling tests that need fresh module or process state instead of the shared serial worker.
 export const toolingIsolatedTestFiles = [
   "test/plugins/bundled-provider-auth-literal-parity.test.ts",
+  "test/plugins/bundled-provider-auth-literal-parity.2.test.ts",
+  "test/plugins/bundled-provider-auth-literal-parity.3.test.ts",
   "test/scripts/check-extension-package-tsc-boundary.test.ts",
   "test/scripts/control-ui-i18n.test.ts",
   "test/scripts/openclaw-e2e-instance.test.ts",

--- a/test/vitest/vitest.tooling-isolated.config.ts
+++ b/test/vitest/vitest.tooling-isolated.config.ts
@@ -5,6 +5,9 @@ import { toolingIsolatedTestFiles } from "./vitest.tooling-isolated-paths.mjs";
 export function createToolingIsolatedVitestConfig(env?: Record<string, string | undefined>) {
   return createScopedVitestConfig(toolingIsolatedTestFiles, {
     env,
+    // Explicit tooling ownership must include thin wrappers even when static
+    // analysis also classifies them as unit-fast candidates.
+    excludeUnitFastTests: false,
     isolate: true,
     name: "tooling-isolated",
     passWithNoTests: true,

--- a/test/vitest/vitest.unit-fast-paths.mjs
+++ b/test/vitest/vitest.unit-fast-paths.mjs
@@ -8,6 +8,7 @@ import {
   commandsLightTestFiles,
 } from "./vitest.commands-light-paths.mjs";
 import { pluginSdkLightSourceFiles, pluginSdkLightTestFiles } from "./vitest.plugin-sdk-paths.mjs";
+import { isToolingIsolatedTestFile } from "./vitest.tooling-isolated-paths.mjs";
 import { boundaryTestFiles, bundledPluginDependentUnitTestFiles } from "./vitest.unit-paths.mjs";
 
 const normalizeRepoPath = (value) => value.replaceAll("\\", "/");
@@ -484,27 +485,37 @@ function analyzeUnitFastTestFile(cwd, file) {
   }
 
   let analysis;
-  try {
-    const source = fs.readFileSync(path.join(cwd, file), "utf8");
-    const reasons = classifyUnitFastTestFileContent(source);
-    if (importsStatefulTestHelper(cwd, file, source)) {
-      // The helper executes in the importing file's module scope, so its mocks and
-      // singleton mutations need the same isolation as stateful code in the test itself.
-      reasons.push("stateful-test-helper");
-    }
-    const forced = forcedUnitFastTestFileSet.has(file);
-    analysis = {
-      file,
-      unitFast: forced || reasons.every((reason) => reason === "stateful-test-helper"),
-      forced,
-      reasons,
-    };
-  } catch {
+  if (isToolingIsolatedTestFile(file)) {
+    // Explicit project ownership wins over inferred eligibility so full-suite
+    // configs cannot run the same stateful tooling test in two worker pools.
     analysis = {
       file,
       unitFast: false,
-      reasons: ["missing-file"],
+      reasons: ["tooling-isolated-owner"],
     };
+  } else {
+    try {
+      const source = fs.readFileSync(path.join(cwd, file), "utf8");
+      const reasons = classifyUnitFastTestFileContent(source);
+      if (importsStatefulTestHelper(cwd, file, source)) {
+        // The helper executes in the importing file's module scope, so its mocks and
+        // singleton mutations need the same isolation as stateful code in the test itself.
+        reasons.push("stateful-test-helper");
+      }
+      const forced = forcedUnitFastTestFileSet.has(file);
+      analysis = {
+        file,
+        unitFast: forced || reasons.every((reason) => reason === "stateful-test-helper"),
+        forced,
+        reasons,
+      };
+    } catch {
+      analysis = {
+        file,
+        unitFast: false,
+        reasons: ["missing-file"],
+      };
+    }
   }
 
   // Discovery is a process-start snapshot; default and broad audits overlap heavily.


### PR DESCRIPTION
## What Problem This Solves

The bundled provider auth literal parity suite spent most of its time loading full plugin runtime graphs for cases whose runtime literals are mechanically projected from the same manifests. One remaining GitHub Copilot import dominated the isolated tooling lane, and thin test wrappers could be misrouted into the shared unit-fast worker.

## Why This Change Was Made

Audit out mechanically generated duplicate probes while retaining runtime probes for custom and explicit auth registrations. Move GitHub Copilot's unique manifest-to-runtime contract into its existing owner test, retain Moonshot's explicit `api-key-cn` probe, and split the remaining fleet probe across three files inside the existing isolated tooling job. Explicit tooling isolation now takes precedence over inferred unit-fast eligibility. No production behavior, CI jobs, or worker limits change.

## User Impact

Developers get materially faster CI feedback with the same unique auth-literal coverage and no additional CI capacity.

## Evidence

- Local parity command, same orb and routing:
  - Before: 72 tests, 131.93s wall, 125.43s Vitest duration, 1,669,564 KiB max RSS.
  - After cold run: 46 retained tests, 43.38s wall, 42.37s Vitest duration, 1,441,864 KiB max RSS.
  - Improvement: 67.1% wall / 66.2% Vitest duration; 13.6% lower peak RSS.
- `node scripts/run-vitest.mjs extensions/github-copilot/index.test.ts` — 40 passed.
- `node scripts/run-vitest.mjs src/plugin-sdk/provider-entry.test.ts` — 14 passed.
- `node scripts/run-vitest.mjs src/plugins/provider-api-key-auth.test.ts` — 5 passed.
- `node scripts/run-vitest.mjs test/scripts/test-projects.test.ts` — 245 passed.
- `node scripts/run-vitest.mjs test/scripts/ci-node-test-plan.test.ts` — 22 passed.
- Targeted oxfmt and oxlint pass; `git diff --check` passes.
- TruffleHog pre-review scan clean. Bundled autoreview could not run because the Codex executable is unavailable in this orb; an independent Oracle review found two coverage gaps, both fixed and reverified.
