### PR TITLE
feat(webui): auto-request notification permission on first chat send

### DIFF
--- a/docs/web/notifications.md
+++ b/docs/web/notifications.md
@@ -7,7 +7,7 @@ read_when:
   - Comparing Control UI notifications with mobile push
 ---
 
-OpenClaw can ping you when something needs your attention — in the browser that runs the Control UI, or through native macOS notifications when you use the OpenClaw macOS app. Everything lives under **Settings → Notifications**: enable the current device, check its status, and send yourself a test.
+OpenClaw can ping you when something needs your attention — in the browser that runs the Control UI, or through native macOS notifications when you use the OpenClaw macOS app. Your first chat send may request permission automatically; **Settings → Notifications** remains the place to enable or repair the current device, check its status, and send yourself a test.
 
 This page covers those two surfaces. It does not control channel reaction notifications, Android notification forwarding, or iOS background push — the mobile apps register for push through their own node paths; see [iOS](/platforms/ios) and [Nodes](/nodes).
 

--- a/docs/web/notifications.md
+++ b/docs/web/notifications.md
@@ -25,6 +25,8 @@ The macOS app deliberately uses the native permission flow instead of browser pu
 
 ## Enable browser notifications
 
+The Control UI asks for notification permission automatically the first time you send a chat message, once per browser and origin. **Settings → Notifications** remains the manual path for enabling or repairing notifications, including after you deny the automatic prompt.
+
 1. Open the Control UI in a browser that supports service workers, `PushManager`, and notifications.
 2. Make sure the Control UI is connected to the Gateway.
 3. Open **Settings → Notifications** and select **Enable notifications**.
@@ -36,6 +38,8 @@ Behind the scenes, enabling creates a push subscription in this browser and regi
 **Send test** asks the Gateway to push a test message to every registered browser subscription. **Unsubscribe** removes the current browser's endpoint from the Gateway, then unsubscribes locally.
 
 ## Enable notifications in the macOS app
+
+The macOS app also asks automatically on your first chat send, but only while permission is **Not requested**. It never opens System Settings automatically after a denial; use **Settings → Notifications** to manage permission manually.
 
 1. Open **Settings → Notifications** in the OpenClaw macOS app.
 2. Select **Enable notifications** while the permission shows **Not requested**.

--- a/ui/src/app/notifications-auto-prompt.test.ts
+++ b/ui/src/app/notifications-auto-prompt.test.ts
@@ -1,0 +1,140 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStorageMock } from "../test-helpers/storage.ts";
+import { autoPromptNotificationsOnSend } from "./notifications-auto-prompt.ts";
+
+const STORAGE_KEY = "openclaw.control.notificationsAutoPrompt.v1";
+
+type AutoPromptContext = Parameters<typeof autoPromptNotificationsOnSend>[0];
+type NativePermission = "granted" | "denied" | "notDetermined" | "unknown";
+
+let storage: Storage;
+
+beforeEach(() => {
+  storage = createStorageMock();
+  vi.stubGlobal("localStorage", storage);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function createContext(
+  overrides: {
+    supported?: boolean;
+    permission?: NotificationPermission | "unsupported";
+    subscribed?: boolean;
+    loading?: boolean;
+    nativePermission?: NativePermission | null;
+  } = {},
+) {
+  const enable = vi.fn(async () => undefined);
+  const requestPermission = vi.fn();
+  const nativePermission = overrides.nativePermission ?? null;
+  const context = {
+    nativeNotifications:
+      nativePermission === null
+        ? null
+        : { snapshot: { permission: nativePermission }, requestPermission },
+    webPush: {
+      snapshot: {
+        supported: overrides.supported ?? true,
+        permission: overrides.permission ?? "default",
+        subscribed: overrides.subscribed ?? false,
+        loading: overrides.loading ?? false,
+        error: null,
+      },
+      enable,
+    },
+  } as unknown as AutoPromptContext;
+  return { context, enable, requestPermission };
+}
+
+describe("notification auto-prompt", () => {
+  it("enables eligible web push only once", () => {
+    const { context, enable } = createContext();
+
+    autoPromptNotificationsOnSend(context);
+    autoPromptNotificationsOnSend(context);
+
+    expect(enable).toHaveBeenCalledOnce();
+    expect(storage.getItem(STORAGE_KEY)).toBe("1");
+  });
+
+  it("does nothing when the one-shot flag is already set", () => {
+    storage.setItem(STORAGE_KEY, "1");
+    const { context, enable } = createContext();
+
+    autoPromptNotificationsOnSend(context);
+
+    expect(enable).not.toHaveBeenCalled();
+  });
+
+  it.each(["denied", "granted"] as const)(
+    "does not enable web push when permission is %s",
+    (permission) => {
+      const { context, enable } = createContext({ permission });
+
+      autoPromptNotificationsOnSend(context);
+
+      expect(enable).not.toHaveBeenCalled();
+      expect(storage.getItem(STORAGE_KEY)).toBeNull();
+    },
+  );
+
+  it.each([
+    ["subscribed", { subscribed: true }],
+    ["loading", { loading: true }],
+    ["unsupported", { supported: false, permission: "unsupported" as const }],
+  ])("does not enable web push when it is %s", (_name, overrides) => {
+    const { context, enable } = createContext(overrides);
+
+    autoPromptNotificationsOnSend(context);
+
+    expect(enable).not.toHaveBeenCalled();
+    expect(storage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("prefers the native permission flow when permission is not determined", () => {
+    const { context, enable, requestPermission } = createContext({
+      nativePermission: "notDetermined",
+    });
+
+    autoPromptNotificationsOnSend(context);
+
+    expect(requestPermission).toHaveBeenCalledOnce();
+    expect(enable).not.toHaveBeenCalled();
+    expect(storage.getItem(STORAGE_KEY)).toBe("1");
+  });
+
+  it.each(["denied", "unknown"] as const)(
+    "does not request native permission when it is %s",
+    (nativePermission) => {
+      const { context, enable, requestPermission } = createContext({ nativePermission });
+
+      autoPromptNotificationsOnSend(context);
+
+      expect(requestPermission).not.toHaveBeenCalled();
+      expect(enable).not.toHaveBeenCalled();
+      expect(storage.getItem(STORAGE_KEY)).toBeNull();
+    },
+  );
+
+  it("fails closed when the localStorage getter throws", () => {
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      get() {
+        throw new Error("opaque origin");
+      },
+    });
+    const { context, enable, requestPermission } = createContext({
+      nativePermission: "notDetermined",
+    });
+
+    expect(() => autoPromptNotificationsOnSend(context)).not.toThrow();
+    expect(requestPermission).not.toHaveBeenCalled();
+    expect(enable).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/app/notifications-auto-prompt.test.ts
+++ b/ui/src/app/notifications-auto-prompt.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import {
   autoPromptNotificationsOnSend,
+  hasActiveNotificationPromptGesture,
   shouldAutoPromptNotificationsOnSend,
 } from "./notifications-auto-prompt.ts";
 
@@ -175,6 +176,24 @@ describe("notification auto-prompt send boundary", () => {
     expect(
       shouldAutoPromptNotificationsOnSend({ ...candidate, message: "", hasAttachments: true }),
     ).toBe(true);
+  });
+
+  it("recognizes only the synchronous browser event dispatch", async () => {
+    const button = document.createElement("button");
+    let duringDispatch = false;
+    let afterDispatch = true;
+    button.addEventListener("click", () => {
+      duringDispatch = hasActiveNotificationPromptGesture();
+      queueMicrotask(() => {
+        afterDispatch = hasActiveNotificationPromptGesture();
+      });
+    });
+
+    button.click();
+    await Promise.resolve();
+
+    expect(duringDispatch).toBe(true);
+    expect(afterDispatch).toBe(false);
   });
 
   it.each([

--- a/ui/src/app/notifications-auto-prompt.test.ts
+++ b/ui/src/app/notifications-auto-prompt.test.ts
@@ -2,7 +2,10 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createStorageMock } from "../test-helpers/storage.ts";
-import { autoPromptNotificationsOnSend } from "./notifications-auto-prompt.ts";
+import {
+  autoPromptNotificationsOnSend,
+  shouldAutoPromptNotificationsOnSend,
+} from "./notifications-auto-prompt.ts";
 
 const STORAGE_KEY = "openclaw.control.notificationsAutoPrompt.v1";
 
@@ -10,10 +13,13 @@ type AutoPromptContext = Parameters<typeof autoPromptNotificationsOnSend>[0];
 type NativePermission = "granted" | "denied" | "notDetermined" | "unknown";
 
 let storage: Storage;
+let browserRequestPermission: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   storage = createStorageMock();
   vi.stubGlobal("localStorage", storage);
+  browserRequestPermission = vi.fn(() => Promise.resolve("granted" as NotificationPermission));
+  vi.stubGlobal("Notification", { requestPermission: browserRequestPermission });
 });
 
 afterEach(() => {
@@ -53,13 +59,29 @@ function createContext(
 }
 
 describe("notification auto-prompt", () => {
-  it("enables eligible web push only once", () => {
+  it("requests browser permission synchronously and enables web push only once", async () => {
     const { context, enable } = createContext();
 
     autoPromptNotificationsOnSend(context);
     autoPromptNotificationsOnSend(context);
 
+    expect(browserRequestPermission).toHaveBeenCalledOnce();
+    expect(enable).not.toHaveBeenCalled();
+    await Promise.resolve();
     expect(enable).toHaveBeenCalledOnce();
+    expect(storage.getItem(STORAGE_KEY)).toBe("1");
+  });
+
+  it("records a dismissed browser prompt without enabling web push", async () => {
+    browserRequestPermission.mockResolvedValue("default");
+    const { context, enable } = createContext();
+
+    autoPromptNotificationsOnSend(context);
+    autoPromptNotificationsOnSend(context);
+    await Promise.resolve();
+
+    expect(browserRequestPermission).toHaveBeenCalledOnce();
+    expect(enable).not.toHaveBeenCalled();
     expect(storage.getItem(STORAGE_KEY)).toBe("1");
   });
 
@@ -136,5 +158,31 @@ describe("notification auto-prompt", () => {
     expect(() => autoPromptNotificationsOnSend(context)).not.toThrow();
     expect(requestPermission).not.toHaveBeenCalled();
     expect(enable).not.toHaveBeenCalled();
+  });
+});
+
+describe("notification auto-prompt send boundary", () => {
+  const candidate = {
+    connected: true,
+    directComposerSend: true,
+    message: "hello",
+    hasAttachments: false,
+    isCommand: false,
+  };
+
+  it("accepts a direct composer prompt or attachment", () => {
+    expect(shouldAutoPromptNotificationsOnSend(candidate)).toBe(true);
+    expect(
+      shouldAutoPromptNotificationsOnSend({ ...candidate, message: "", hasAttachments: true }),
+    ).toBe(true);
+  });
+
+  it.each([
+    ["programmatic send", { directComposerSend: false }],
+    ["recognized command", { isCommand: true }],
+    ["disconnected composer", { connected: false }],
+    ["empty composer", { message: "" }],
+  ])("rejects a %s", (_name, override) => {
+    expect(shouldAutoPromptNotificationsOnSend({ ...candidate, ...override })).toBe(false);
   });
 });

--- a/ui/src/app/notifications-auto-prompt.ts
+++ b/ui/src/app/notifications-auto-prompt.ts
@@ -12,6 +12,12 @@ type NotificationsAutoPromptCandidate = {
   isCommand: boolean;
 };
 
+export function hasActiveNotificationPromptGesture(): boolean {
+  // User activation can survive awaited work. window.event exists only while
+  // the originating input event is dispatching, so deferred sends stay out.
+  return typeof window !== "undefined" && window.event !== undefined;
+}
+
 export function shouldAutoPromptNotificationsOnSend(
   candidate: NotificationsAutoPromptCandidate,
 ): boolean {

--- a/ui/src/app/notifications-auto-prompt.ts
+++ b/ui/src/app/notifications-auto-prompt.ts
@@ -4,6 +4,25 @@ const NOTIFICATIONS_AUTO_PROMPT_KEY = "openclaw.control.notificationsAutoPrompt.
 
 type NotificationsContext = Pick<ApplicationContext, "nativeNotifications" | "webPush">;
 
+type NotificationsAutoPromptCandidate = {
+  connected: boolean;
+  directComposerSend: boolean;
+  message: string;
+  hasAttachments: boolean;
+  isCommand: boolean;
+};
+
+export function shouldAutoPromptNotificationsOnSend(
+  candidate: NotificationsAutoPromptCandidate,
+): boolean {
+  return (
+    candidate.connected &&
+    candidate.directComposerSend &&
+    !candidate.isCommand &&
+    (candidate.message.trim().length > 0 || candidate.hasAttachments)
+  );
+}
+
 function markAutoPrompted(storage: Storage): void {
   // Persist the one-shot contract before asking so re-entrant sends cannot prompt twice.
   try {
@@ -52,7 +71,16 @@ export function autoPromptNotificationsOnSend(context: NotificationsContext): vo
   }
   markAutoPrompted(storage);
   try {
-    void context.webPush.enable();
+    // Invoke the browser prompt before leaving the user-gesture tick. Web-push
+    // subscription can continue asynchronously after permission is granted.
+    const permission = Notification.requestPermission();
+    void permission
+      .then((next) => {
+        if (next === "granted") {
+          void context.webPush.enable();
+        }
+      })
+      .catch(() => {});
   } catch {
     // Notification prompting must never interrupt chat sending.
   }

--- a/ui/src/app/notifications-auto-prompt.ts
+++ b/ui/src/app/notifications-auto-prompt.ts
@@ -1,0 +1,59 @@
+import type { ApplicationContext } from "./context.ts";
+
+const NOTIFICATIONS_AUTO_PROMPT_KEY = "openclaw.control.notificationsAutoPrompt.v1";
+
+type NotificationsContext = Pick<ApplicationContext, "nativeNotifications" | "webPush">;
+
+function markAutoPrompted(storage: Storage): void {
+  // Persist the one-shot contract before asking so re-entrant sends cannot prompt twice.
+  try {
+    storage.setItem(NOTIFICATIONS_AUTO_PROMPT_KEY, "1");
+  } catch {
+    // Permission state still prevents repeat prompts after a completed decision.
+  }
+}
+
+export function autoPromptNotificationsOnSend(context: NotificationsContext): void {
+  let storage: Storage;
+  try {
+    storage = localStorage;
+    if (storage.getItem(NOTIFICATIONS_AUTO_PROMPT_KEY) !== null) {
+      return;
+    }
+  } catch {
+    return;
+  }
+
+  const nativeNotifications = context.nativeNotifications;
+  if (nativeNotifications) {
+    // Denied is terminal for auto-asks; the manual path may open System Settings.
+    if (nativeNotifications.snapshot.permission !== "notDetermined") {
+      return;
+    }
+    markAutoPrompted(storage);
+    // Keep the permission request in the user-gesture tick for Safari transient activation.
+    try {
+      nativeNotifications.requestPermission();
+    } catch {
+      // Notification prompting must never interrupt chat sending.
+    }
+    return;
+  }
+
+  const snapshot = context.webPush.snapshot;
+  if (
+    !snapshot.supported ||
+    snapshot.permission !== "default" ||
+    snapshot.subscribed ||
+    snapshot.loading
+  ) {
+    // Denied and granted permissions are terminal for automatic prompts.
+    return;
+  }
+  markAutoPrompted(storage);
+  try {
+    void context.webPush.enable();
+  } catch {
+    // Notification prompting must never interrupt chat sending.
+  }
+}

--- a/ui/src/pages/chat/chat-state-page.ts
+++ b/ui/src/pages/chat/chat-state-page.ts
@@ -2,6 +2,7 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { AgentsListResult } from "../../api/types.ts";
 import { fetchAssistantIdentity } from "../../app/assistant-identity.ts";
 import type { ApplicationContext } from "../../app/context.ts";
+import { autoPromptNotificationsOnSend } from "../../app/notifications-auto-prompt.ts";
 import { loadLocalUserIdentity, loadSettings, patchSettings } from "../../app/settings.ts";
 import { t } from "../../i18n/index.ts";
 import { resolveSafeExternalUrl } from "../../lib/open-external-url.ts";
@@ -277,8 +278,15 @@ export function createPageState(
   };
   attachChatRealtimeActions(state);
   state.loadAssistantIdentity = () => loadPageAssistantIdentity(state);
-  state.handleSendChat = (messageOverride, options) =>
-    handleSendChat(state, messageOverride, options as never);
+  state.handleSendChat = (messageOverride, options) => {
+    if (
+      state.connected &&
+      ((messageOverride ?? state.chatMessage).trim().length > 0 || state.chatAttachments.length > 0)
+    ) {
+      autoPromptNotificationsOnSend(context);
+    }
+    return handleSendChat(state, messageOverride, options as never);
+  };
   state.handleAbortChat = async (options) => {
     await handleAbortChat(state, options as never);
     renderLifecycle.invalidate();

--- a/ui/src/pages/chat/chat-state-page.ts
+++ b/ui/src/pages/chat/chat-state-page.ts
@@ -4,6 +4,7 @@ import { fetchAssistantIdentity } from "../../app/assistant-identity.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import {
   autoPromptNotificationsOnSend,
+  hasActiveNotificationPromptGesture,
   shouldAutoPromptNotificationsOnSend,
 } from "../../app/notifications-auto-prompt.ts";
 import { loadLocalUserIdentity, loadSettings, patchSettings } from "../../app/settings.ts";
@@ -290,7 +291,10 @@ export function createPageState(
     if (
       shouldAutoPromptNotificationsOnSend({
         connected: state.connected,
-        directComposerSend: messageOverride === undefined && options === undefined,
+        directComposerSend:
+          messageOverride === undefined &&
+          options === undefined &&
+          hasActiveNotificationPromptGesture(),
         message,
         hasAttachments: state.chatAttachments.length > 0,
         isCommand,

--- a/ui/src/pages/chat/chat-state-page.ts
+++ b/ui/src/pages/chat/chat-state-page.ts
@@ -2,9 +2,13 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { AgentsListResult } from "../../api/types.ts";
 import { fetchAssistantIdentity } from "../../app/assistant-identity.ts";
 import type { ApplicationContext } from "../../app/context.ts";
-import { autoPromptNotificationsOnSend } from "../../app/notifications-auto-prompt.ts";
+import {
+  autoPromptNotificationsOnSend,
+  shouldAutoPromptNotificationsOnSend,
+} from "../../app/notifications-auto-prompt.ts";
 import { loadLocalUserIdentity, loadSettings, patchSettings } from "../../app/settings.ts";
 import { t } from "../../i18n/index.ts";
+import { parseSlashCommand } from "../../lib/chat/commands.ts";
 import { resolveSafeExternalUrl } from "../../lib/open-external-url.ts";
 import {
   canonicalUiSessionKeyForPersistence,
@@ -30,7 +34,7 @@ import {
 } from "./input-history.ts";
 import { beginQueuedMessageEdit, cancelQueuedMessageEdit } from "./queued-message-edit.ts";
 import type { RenderLifecycle } from "./render-lifecycle.ts";
-import { handleAbortChat } from "./run-lifecycle.ts";
+import { handleAbortChat, hasAbortableSessionRun, isChatStopCommand } from "./run-lifecycle.ts";
 import { handleChatScroll, resetChatScroll, scheduleChatScroll } from "./scroll.ts";
 import type { ChatMessageCache } from "./session-message-cache.ts";
 import {
@@ -279,9 +283,18 @@ export function createPageState(
   attachChatRealtimeActions(state);
   state.loadAssistantIdentity = () => loadPageAssistantIdentity(state);
   state.handleSendChat = (messageOverride, options) => {
+    const message = messageOverride ?? state.chatMessage;
+    const isCommand =
+      parseSlashCommand(message) !== null ||
+      (isChatStopCommand(message) && hasAbortableSessionRun(state));
     if (
-      state.connected &&
-      ((messageOverride ?? state.chatMessage).trim().length > 0 || state.chatAttachments.length > 0)
+      shouldAutoPromptNotificationsOnSend({
+        connected: state.connected,
+        directComposerSend: messageOverride === undefined && options === undefined,
+        message,
+        hasAttachments: state.chatAttachments.length > 0,
+        isCommand,
+      })
     ) {
       autoPromptNotificationsOnSend(context);
     }


### PR DESCRIPTION
## What Problem This Solves

Enabling Control UI notifications is manual-only today (Settings -> Notifications), so most operators never turn them on and miss agent completions.

## Why This Change Was Made

Requested by maintainer: auto-ask once on the first real prompt send, never re-ask after denial; Settings already surfaces the denied/blocked state as the manual repair path. The one-shot flag lives in per-origin `localStorage` because notification permission itself is per-browser/per-origin state. The browser permission call fires synchronously during an actively dispatching, direct, non-command composer gesture; subscription and Gateway registration continue asynchronously after permission is granted. Deferred catalog handoffs, Skill Workshop sends, widgets, and recognized commands cannot consume the one-shot. In the macOS app the same hook routes to the native permission prompt only while permission is `notDetermined`, and never auto-opens System Settings after denial.

## User Impact

The first real chat prompt in a supported, connected browser triggers the browser permission prompt; accepting registers the web push subscription immediately. Denying or dismissing means the browser is never auto-asked again; Settings -> Notifications continues to show status and blocked hints and remains the manual path. No new settings or configuration surface is added.

## Evidence

- ClawSweeper-requested paired proof: `node scripts/run-vitest.mjs ui/src/app/notifications-auto-prompt.test.ts ui/src/pages/chat/chat-pane-retained-presentation.test.ts` passed both shards: notification policy 18/18 (976ms) and retained-presentation handoff 7/7 (7.55s). Coverage proves the gesture fact is present during synchronous browser event dispatch and absent in the queued microtask, alongside permission, dismissal, direct composer, programmatic, command, disconnected, and empty-send cases.
- `pnpm docs:list` passed and indexed `web/notifications.md`.
- Local `node scripts/check-changed.mjs`: conflict-marker check passed, but the max-lines ratchet raced an advancing `origin/main` and requested removal of baseline entries for `extensions/discord/src/voice/manager.e2e.test.ts`, `extensions/discord/src/voice/manager.ts`, `extensions/discord/src/voice/realtime.ts`, `extensions/openai/realtime-voice-provider.test.ts`, and `extensions/openai/realtime-voice-provider.ts`, all untouched by this PR. Remote Crabbox/Testbox backends were unavailable on this host (`no ready provider for workload=ci-fast`; provider doctors failed/timed out), so the wrapper used its authorized local fallback. Hosted exact-head CI is the authoritative proof for this known stale-origin race and remains mandatory before landing.
- Fresh Codex autoreview (`gpt-5.6-sol`, high) after each ClawSweeper correction was clean with 0 accepted/actionable findings.
- ClawSweeper findings addressed: programmatic and deferred sends cannot consume the one-shot, browser permission is requested synchronously before deferred subscription work, and the documentation identifies Settings as the management and recovery path.
- The prompt itself is browser chrome rather than page UI, so before/after screenshots do not apply. The post-permission subscription flow remains the same shipped `webPush.enable()` path used by the Settings button.
