### PR TITLE
fix(ui): keep shared Control UI tests deterministic

### DIFF
--- a/test/vitest/vitest.ui-isolated-paths.mjs
+++ b/test/vitest/vitest.ui-isolated-paths.mjs
@@ -6,6 +6,7 @@ export const uiIsolatedTestFiles = [
   "ui/src/app/bootstrap.test.ts",
   "ui/src/app/router-outlet.test.ts",
   "ui/src/components/resizable-divider.test.ts",
+  "ui/src/components/sidebar-update-card.test.ts",
   "ui/src/components/viewer-facepile.test.ts",
   "ui/src/pages/agents/memory/memory-panel.test.ts",
   "ui/src/pages/chat/chat-page-attachment-handoff.test.ts",

--- a/ui/src/components/sidebar-update-card.test.ts
+++ b/ui/src/components/sidebar-update-card.test.ts
@@ -7,9 +7,10 @@ import {
   NATIVE_UPDATE_DECLINED_EVENT,
 } from "../app/native-link-routing.ts";
 import {
+  answerConfirmDialog,
+  cancelOpenModalDialogs,
   installDialogPolyfill,
-  nextFrame,
-  waitForRenderedModalDialog,
+  waitForConfirmDialogActions,
 } from "../test-helpers/modal-dialog.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import "./sidebar-update-card.ts";
@@ -20,15 +21,9 @@ const DISMISS_KEY = "openclaw:control-ui:update-banner-dismissed:v1";
 async function resolveUpdateConfirmation(
   label: "Cancel" | "Update and restart" | "Update Mac app and restart",
 ) {
-  const { modal } = await waitForRenderedModalDialog(document.body);
-  const button = [...modal.querySelectorAll("button")].find(
-    (candidate) => candidate.textContent?.trim() === label,
-  );
-  if (!(button instanceof HTMLButtonElement)) {
-    throw new Error(`Expected ${label} button in the update confirmation`);
-  }
-  button.click();
-  await nextFrame();
+  const actions = await waitForConfirmDialogActions();
+  expect(actions.textContent).toContain(label);
+  answerConfirmDialog(actions, label === "Cancel" ? "cancel" : "confirm");
 }
 
 type SidebarUpdateCardElement = HTMLElement & {
@@ -79,6 +74,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+  cancelOpenModalDialogs();
   document.body.replaceChildren();
   restoreDialogPolyfill();
   if (originalLocalStorage) {
@@ -91,6 +87,7 @@ afterEach(() => {
   } else {
     Reflect.deleteProperty(window, "webkit");
   }
+  vi.resetModules();
 });
 
 describe("SidebarUpdateCard", () => {
@@ -163,7 +160,7 @@ describe("SidebarUpdateCard", () => {
     expect(element.querySelector(".sidebar-update-card__subtitle")).toBeNull();
     expect(element.querySelector(".sidebar-update-card__arrow")).toBeNull();
     action?.click();
-    await nextFrame();
+    await waitForConfirmDialogActions();
 
     expect(onUpdate).not.toHaveBeenCalled();
     await resolveUpdateConfirmation("Update and restart");
@@ -239,7 +236,7 @@ describe("SidebarUpdateCard", () => {
     expect(action?.textContent).toContain("Update Mac app + Gateway");
     expect(action?.textContent).toContain("v2.0.0");
     action?.click();
-    await nextFrame();
+    await waitForConfirmDialogActions();
 
     expect(postMessage).not.toHaveBeenCalled();
     await resolveUpdateConfirmation("Update Mac app and restart");

--- a/ui/src/components/tooltip.test.ts
+++ b/ui/src/components/tooltip.test.ts
@@ -153,6 +153,24 @@ describe("openclaw-tooltip", () => {
     expect(webAwesomeTooltip(tooltip)?.anchor).toBe(trigger);
   });
 
+  it("recognizes an HTML trigger created by another document realm", async () => {
+    const frame = document.createElement("iframe");
+    document.body.append(frame);
+    const foreignDocument = frame.contentDocument;
+    if (!foreignDocument) {
+      throw new Error("Expected iframe document");
+    }
+    const tooltip = document.createElement("openclaw-tooltip") as TooltipElement;
+    tooltip.content = "Cross-realm tooltip";
+    const trigger = foreignDocument.createElement("button");
+    trigger.textContent = "trigger";
+    tooltip.append(trigger);
+    document.body.append(tooltip);
+    await tooltip.updateComplete;
+
+    expect(trigger.getAttribute("aria-describedby")).toBeTruthy();
+  });
+
   it("restores the normal hover delay after the provider reconnects", async () => {
     const provider = createProvider();
     provider.delay = 40;

--- a/ui/src/components/tooltip.ts
+++ b/ui/src/components/tooltip.ts
@@ -24,6 +24,10 @@ function normalizeTooltipText(text: string) {
   return text.replace(/\s+/gu, " ").trim();
 }
 
+function isHtmlElement(element: Element): element is HTMLElement {
+  return element.namespaceURI === "http://www.w3.org/1999/xhtml";
+}
+
 class TooltipProvider extends OpenClawLitElement {
   @property({ type: Number }) delay = HOVER_DELAY;
   @property({ type: Number }) skipDelay = SKIP_DELAY;
@@ -189,9 +193,7 @@ class Tooltip extends OpenClawLitElement {
 
   private attachTrigger() {
     const slot = this.renderRoot.querySelector<HTMLSlotElement>("slot:not([name])");
-    const trigger = slot
-      ?.assignedElements({ flatten: true })
-      .find((element): element is HTMLElement => element instanceof HTMLElement);
+    const trigger = slot?.assignedElements({ flatten: true }).find(isHtmlElement);
     if (trigger === this.triggerElement) {
       return;
     }
@@ -412,7 +414,7 @@ class Tooltip extends OpenClawLitElement {
     const content = normalizeTooltipText(this.content);
     const triggerText = normalizeTooltipText(trigger.textContent ?? "");
     const clipsContent = [trigger, ...trigger.querySelectorAll("*")].some(
-      (element) => element instanceof HTMLElement && element.scrollWidth > element.clientWidth,
+      (element) => isHtmlElement(element) && element.scrollWidth > element.clientWidth,
     );
     return Boolean(content && triggerText && triggerText.includes(content) && !clipsContent);
   }

--- a/ui/src/pages/chat/chat-pane-task-suggestions.test.ts
+++ b/ui/src/pages/chat/chat-pane-task-suggestions.test.ts
@@ -8,11 +8,8 @@ import type {
 } from "../../../../packages/gateway-protocol/src/index.js";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import { copyToClipboard } from "../../lib/clipboard.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import { createTestChatPane } from "./chat-pane.test-support.ts";
-
-vi.mock("../../lib/clipboard.ts", () => ({ copyToClipboard: vi.fn() }));
 
 const suggestion: TaskSuggestion = {
   id: "task_123",
@@ -27,16 +24,41 @@ const suggestion: TaskSuggestion = {
 
 describe("chat pane task suggestion lifecycle", () => {
   it("surfaces clipboard failure through the pane error path", async () => {
-    vi.mocked(copyToClipboard).mockResolvedValueOnce(false);
+    const originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+    const originalExecCommand = Object.getOwnPropertyDescriptor(document, "execCommand");
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+    const execCommand = vi.fn(() => false);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
     const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
     const { pane, state } = createTestChatPane({
       client,
       sessions: {} as SessionCapability,
     });
 
-    await pane.copyTaskSuggestionPrompt(suggestion);
+    try {
+      await pane.copyTaskSuggestionPrompt(suggestion);
+    } finally {
+      if (originalClipboard) {
+        Object.defineProperty(navigator, "clipboard", originalClipboard);
+      } else {
+        Reflect.deleteProperty(navigator, "clipboard");
+      }
+      if (originalExecCommand) {
+        Object.defineProperty(document, "execCommand", originalExecCommand);
+      } else {
+        Reflect.deleteProperty(document, "execCommand");
+      }
+    }
 
-    expect(copyToClipboard).toHaveBeenCalledWith(suggestion.prompt);
+    expect(writeText).toHaveBeenCalledWith(suggestion.prompt);
+    expect(execCommand).toHaveBeenCalledWith("copy");
     expect(state.lastError).toBe("Couldn't copy the prompt to the clipboard");
     expect(state.chatError).toBe("Couldn't copy the prompt to the clipboard");
   });

--- a/ui/src/test-helpers/modal-dialog.ts
+++ b/ui/src/test-helpers/modal-dialog.ts
@@ -70,6 +70,13 @@ export function answerConfirmDialog(actions: HTMLElement, choice: "confirm" | "c
   button.click();
 }
 
+/** Let each dialog owner release its module state before a test removes the DOM. */
+export function cancelOpenModalDialogs() {
+  for (const dialog of document.body.querySelectorAll("openclaw-modal-dialog")) {
+    dialog.dispatchEvent(new CustomEvent("modal-cancel"));
+  }
+}
+
 /** Await a dialog whose owner loads it behind a lazy import, then read it. */
 export async function waitForRenderedModalDialog(container: HTMLElement) {
   await vi.waitFor(() => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the shared `checks-ui` worker could fail unrelated Control UI changes when a predecessor suite cached the real clipboard module, a lazy update dialog retained module state across jsdom suites, or a delayed tooltip callback ran after Vitest replaced the browser realm.

## Why This Change Was Made

The update-card suite now uses the shared in-app confirmation helpers, releases modal-owner state before removing DOM hosts, resets lazy modules, and runs in the existing singleton-sensitive UI project. The task-suggestion regression drives the actual Clipboard API and fallback owners instead of asserting a later mock export that production may not reference. Tooltip trigger detection now uses the HTML namespace rather than the transient global `HTMLElement`, which is also correct for HTML nodes created by another document realm.

This is the owner-boundary fix: it preserves the production clipboard error path and update-confirmation behavior, while removing test-order coupling instead of adding waits or weakening assertions.

## User Impact

No user-facing workflow changes. Maintainers get deterministic Control UI CI, and tooltip triggers remain correct across document realms.

## Evidence

Pre-fix reproductions:

- `chat-pane-terminal.test.ts` followed by `chat-pane-task-suggestions.test.ts` in one `isolate:false` worker failed because the asserted clipboard mock had zero calls while the production pane retained the real import.
- Exact local `checks-ui` packing emitted `ReferenceError: HTMLElement is not defined` from a delayed tooltip slot callback after jsdom teardown.
- The new cross-document tooltip regression failed before the owner fix with `expected null to be truthy`.

Post-fix proof:

- Sidebar update-card file alone: 24/24, three consecutive runs.
- Task-suggestion file alone: 5/5, three consecutive runs.
- Both files together: 29/29, three consecutive runs.
- Owner neighborhood: 59/59 across tooltip, update runtime, sidebar, task suggestions, and the known clipboard predecessor.
- Exact full UI command: 623 files passed; 9,073 tests passed, one skipped; no post-teardown `HTMLElement` exception.
- `tsgo:ui`, `tsgo:core:test`, core/UI oxlint, scripts lint, UI stylelint, and UI i18n verification passed.
- Autoreview: clean, no accepted/actionable findings.

Production LOC: +6/-4 (net +2) | Tests/test support: +65/-20 (net +45)

Provenance: lazy update confirmation and its original sidebar test flow came from #121234 (commit `95fdce70493`, code/PR author and merger @vyctorbrzezowski, 2026-08-09) and was extended by #121686 (commit `e7ba2e1f6b1`, same author/merger, 2026-08-11). The fragile clipboard export mock came from #121259 (commit `5207c4765d7`, code/PR author and merger @steipete, 2026-08-09). The global-realm tooltip check was carried forward from #100024 (commit `65e12328aa20`, code author Shakker, PR author/merger @shakkernerd, 2026-07-04).

Best-fix verdict: best. Isolating every affected chat test would preserve the wrong clipboard assertion and slow the shared lane; arbitrary render waits would not repair module identity or teardown ownership; adding test-only production injection would create a seam no product caller needs.

One broader `check:changed` attempt stopped on unrelated current-main max-lines ratchet entries for removed OpenAI realtime-voice files. The task-owned checks above all passed.
