### PR TITLE
fix(discord): let active turns receive steering

### DIFF
--- a/extensions/discord/src/monitor/inbound-job.test.ts
+++ b/extensions/discord/src/monitor/inbound-job.test.ts
@@ -11,28 +11,6 @@ function jsonRoundTrip<T>(value: T): T {
 }
 
 describe("buildDiscordInboundJob", () => {
-  it("prefers route session key, then base session key, then channel id for queueing", async () => {
-    const routed = await createBaseDiscordMessageContext({
-      route: { sessionKey: "agent:main:discord:direct:routed" },
-      baseSessionKey: "agent:main:discord:direct:base",
-      messageChannelId: "channel-routed",
-    });
-    const baseOnly = await createBaseDiscordMessageContext({
-      route: { sessionKey: "" },
-      baseSessionKey: "agent:main:discord:direct:base-only",
-      messageChannelId: "channel-base",
-    });
-    const channelFallback = await createBaseDiscordMessageContext({
-      route: { sessionKey: "   " },
-      baseSessionKey: "   ",
-      messageChannelId: "channel-fallback",
-    });
-
-    expect(buildDiscordInboundJob(routed).queueKey).toBe("agent:main:discord:direct:routed");
-    expect(buildDiscordInboundJob(baseOnly).queueKey).toBe("agent:main:discord:direct:base-only");
-    expect(buildDiscordInboundJob(channelFallback).queueKey).toBe("channel-fallback");
-  });
-
   it("keeps live runtime references out of the payload", async () => {
     const ctx = await createBaseDiscordMessageContext({
       message: {

--- a/extensions/discord/src/monitor/inbound-job.ts
+++ b/extensions/discord/src/monitor/inbound-job.ts
@@ -21,7 +21,6 @@ type DiscordInboundJobRuntime = Pick<DiscordMessagePreflightContext, DiscordInbo
 type DiscordInboundJobPayload = Omit<DiscordMessagePreflightContext, DiscordInboundJobRuntimeField>;
 
 export type DiscordInboundJob = {
-  queueKey: string;
   payload: DiscordInboundJobPayload;
   runtime: DiscordInboundJobRuntime;
   ingressSettlement?: {
@@ -29,20 +28,6 @@ export type DiscordInboundJob = {
     abandon: (error?: unknown) => Promise<void>;
   };
 };
-
-function resolveDiscordInboundJobQueueKey(ctx: DiscordMessagePreflightContext): string {
-  // Serialize work by the eventual session route so one conversation cannot
-  // race itself when Discord channel and session identifiers differ.
-  const sessionKey = ctx.route.sessionKey?.trim();
-  if (sessionKey) {
-    return sessionKey;
-  }
-  const baseSessionKey = ctx.baseSessionKey?.trim();
-  if (baseSessionKey) {
-    return baseSessionKey;
-  }
-  return ctx.messageChannelId;
-}
 
 export function buildDiscordInboundJob(
   ctx: DiscordMessagePreflightContext,
@@ -64,7 +49,6 @@ export function buildDiscordInboundJob(
 
   const sanitizedMessage = sanitizeDiscordInboundMessage(message);
   return {
-    queueKey: resolveDiscordInboundJobQueueKey(ctx),
     payload: {
       ...payload,
       message: sanitizedMessage,

--- a/extensions/discord/src/monitor/message-handler.queue.test.ts
+++ b/extensions/discord/src/monitor/message-handler.queue.test.ts
@@ -112,16 +112,30 @@ function createPreflightContext(channelId = "ch-1") {
   };
 }
 
+function createPreflightContextForMessage(data: { channel_id: string; message: { id: string } }) {
+  const ctx = createPreflightContext(data.channel_id);
+  return {
+    ...ctx,
+    message: { ...ctx.message, id: data.message.id },
+    data: {
+      ...ctx.data,
+      message: { ...ctx.data.message, id: data.message.id },
+    },
+  };
+}
+
 function createHandlerWithDefaultPreflight(overrides?: { setStatus?: SetStatusFn }) {
-  preflightDiscordMessageMock.mockImplementation(async (params: { data: { channel_id: string } }) =>
-    createPreflightContext(params.data.channel_id),
+  preflightDiscordMessageMock.mockImplementation(
+    async (params: { data: ReturnType<typeof createMessageData> }) =>
+      createPreflightContextForMessage(params.data),
   );
   return createDiscordMessageHandler(createDiscordHandlerParams(overrides));
 }
 
 function installDefaultDiscordPreflight() {
-  preflightDiscordMessageMock.mockImplementation(async (params: { data: { channel_id: string } }) =>
-    createPreflightContext(params.data.channel_id),
+  preflightDiscordMessageMock.mockImplementation(
+    async (params: { data: ReturnType<typeof createMessageData> }) =>
+      createPreflightContextForMessage(params.data),
   );
 }
 
@@ -177,7 +191,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
     expectStatusPatch(setStatus, { activeRuns: 0, busy: false });
   });
 
-  it("returns immediately and tracks busy status while queued runs execute", async () => {
+  it("lets a same-session message reach steer admission while the first run is active", async () => {
     preflightDiscordMessageMock.mockReset();
     processDiscordMessageMock.mockReset();
 
@@ -190,8 +204,12 @@ describe("createDiscordMessageHandler queue behavior", () => {
       .mockImplementationOnce(async () => {
         await secondRun.promise;
       });
+    preflightDiscordMessageMock.mockImplementation(
+      async (params: { data: ReturnType<typeof createMessageData> }) =>
+        createPreflightContextForMessage(params.data),
+    );
     const setStatus = vi.fn();
-    const handler = createHandlerWithDefaultPreflight({ setStatus });
+    const handler = createDiscordMessageHandler(createDiscordHandlerParams({ setStatus }));
 
     await expect(handler(createMessageData("m-1") as never, {} as never)).resolves.toBeUndefined();
 
@@ -203,16 +221,17 @@ describe("createDiscordMessageHandler queue behavior", () => {
 
     await flushQueueWork();
     expect(preflightDiscordMessageMock).toHaveBeenCalledTimes(2);
-    expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
-
-    firstRun.resolve();
-    await firstRun.promise;
-
-    await flushQueueWork();
     expect(processDiscordMessageMock).toHaveBeenCalledTimes(2);
+    expectStatusPatch(setStatus, { activeRuns: 2, busy: true });
 
     secondRun.resolve();
     await secondRun.promise;
+
+    await flushQueueWork();
+    expectStatusPatch(setStatus, { activeRuns: 1, busy: true });
+
+    firstRun.resolve();
+    await firstRun.promise;
 
     await flushQueueWork();
     const lastStatusPatch = statusPatches(setStatus).at(-1);
@@ -375,7 +394,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
     expect(stop).toHaveBeenCalledTimes(1);
   });
 
-  it("does not abort long queued runs with a Discord-owned channel timeout", async () => {
+  it("does not abort concurrent runs with a Discord-owned channel timeout", async () => {
     vi.useFakeTimers();
     try {
       preflightDiscordMessageMock.mockReset();
@@ -407,27 +426,21 @@ describe("createDiscordMessageHandler queue behavior", () => {
         handler(createMessageData("m-2") as never, {} as never),
       ).resolves.toBeUndefined();
       await flushQueueWork();
-      expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+      expect(processDiscordMessageMock).toHaveBeenCalledTimes(2);
 
       await vi.advanceTimersByTimeAsync(60_000);
       await flushQueueWork();
 
-      expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
-      expect(capturedAbortSignals).toEqual([undefined]);
+      expect(processDiscordMessageMock).toHaveBeenCalledTimes(2);
+      expect(capturedAbortSignals).toEqual([undefined, undefined]);
       const runtimeError = params.runtime.error as unknown as MockCallSource;
       expect(
         mockCalls(runtimeError).some(([message]) => String(message).includes("timed out")),
       ).toBe(false);
 
       firstRun.resolve();
-      await firstRun.promise;
-      await flushQueueWork();
-
-      expect(processDiscordMessageMock).toHaveBeenCalledTimes(2);
-      expect(capturedAbortSignals).toEqual([undefined, undefined]);
-
       secondRun.resolve();
-      await secondRun.promise;
+      await Promise.all([firstRun.promise, secondRun.promise]);
     } finally {
       vi.useRealTimers();
     }
@@ -545,101 +558,6 @@ describe("createDiscordMessageHandler queue behavior", () => {
     expect(getEventListeners(abortController.signal, "abort")).toHaveLength(initialListenerCount);
   });
 
-  it("skips queued runs that have not started yet after deactivation", async () => {
-    preflightDiscordMessageMock.mockReset();
-    processDiscordMessageMock.mockReset();
-
-    const firstRun = createDeferred<void>();
-    processDiscordMessageMock
-      .mockImplementationOnce(async () => {
-        await firstRun.promise;
-      })
-      .mockImplementationOnce(async () => undefined);
-    preflightDiscordMessageMock.mockImplementation(
-      async (params: { data: { channel_id: string } }) =>
-        createPreflightContext(params.data.channel_id),
-    );
-
-    const handler = createDiscordMessageHandler(createDiscordHandlerParams());
-    await expect(handler(createMessageData("m-1") as never, {} as never)).resolves.toBeUndefined();
-    await flushQueueWork();
-    expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
-
-    await expect(handler(createMessageData("m-2") as never, {} as never)).resolves.toBeUndefined();
-    const deactivation = handler.deactivate();
-
-    firstRun.resolve();
-    await firstRun.promise;
-    await deactivation;
-    await Promise.resolve();
-
-    expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("continues queued durable cleanup after an earlier settlement failure", async () => {
-    preflightDiscordMessageMock.mockReset();
-    processDiscordMessageMock.mockReset();
-
-    const firstRun = createDeferred<void>();
-    processDiscordMessageMock.mockImplementation(async () => {
-      await firstRun.promise;
-    });
-    preflightDiscordMessageMock.mockImplementation(
-      async (params: {
-        data: { channel_id: string };
-        abortSignal?: AbortSignal;
-        turnAdoptionLifecycle?: DiscordIngressLifecycle;
-      }) => ({
-        ...createPreflightContext(params.data.channel_id),
-        abortSignal: params.abortSignal,
-        turnAdoptionLifecycle: params.turnAdoptionLifecycle,
-      }),
-    );
-
-    const handlerParams = createDiscordHandlerParams();
-    const handler = createDiscordMessageHandler(handlerParams);
-    const activeIngress = createIngressLifecycle();
-    const failingQueuedIngress = createIngressLifecycle();
-    const laterQueuedIngress = createIngressLifecycle();
-    failingQueuedIngress.onAbandoned.mockRejectedValueOnce(
-      new Error("simulated durable release failure"),
-    );
-
-    await expect(
-      handler(createMessageData("m-1") as never, {} as never, {
-        turnAdoptionLifecycle: activeIngress,
-      }),
-    ).resolves.toEqual({ kind: "deferred" });
-    await flushQueueWork();
-    expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
-
-    await expect(
-      handler(createMessageData("m-2") as never, {} as never, {
-        turnAdoptionLifecycle: failingQueuedIngress,
-      }),
-    ).resolves.toEqual({ kind: "deferred" });
-    await expect(
-      handler(createMessageData("m-3") as never, {} as never, {
-        turnAdoptionLifecycle: laterQueuedIngress,
-      }),
-    ).resolves.toEqual({ kind: "deferred" });
-
-    const deactivation = handler.deactivate();
-    await vi.waitFor(() => expect(failingQueuedIngress.onAbandoned).toHaveBeenCalledTimes(1));
-    firstRun.resolve();
-
-    await expect(deactivation).resolves.toBeUndefined();
-    expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
-    expect(activeIngress.onAbandoned).toHaveBeenCalledTimes(1);
-    expect(laterQueuedIngress.onAbandoned).toHaveBeenCalledTimes(1);
-    const runtimeError = handlerParams.runtime.error as unknown as MockCallSource;
-    expect(
-      mockCalls(runtimeError).some(([message]) =>
-        String(message).includes("discord queued message cleanup failed"),
-      ),
-    ).toBe(true);
-  });
-
   it("preserves non-debounced message ordering by awaiting debouncer enqueue", async () => {
     preflightDiscordMessageMock.mockReset();
     processDiscordMessageMock.mockReset();
@@ -684,7 +602,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
     expect(processedMessageIds).toEqual(["m-1", "m-2"]);
   });
 
-  it("recovers queue progress after a run failure without leaving busy state stuck", async () => {
+  it("reports a concurrent run failure without leaving busy state stuck", async () => {
     preflightDiscordMessageMock.mockReset();
     processDiscordMessageMock.mockReset();
 

--- a/extensions/discord/src/monitor/message-handler.queue.test.ts
+++ b/extensions/discord/src/monitor/message-handler.queue.test.ts
@@ -191,7 +191,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
     expectStatusPatch(setStatus, { activeRuns: 0, busy: false });
   });
 
-  it("lets a same-session message reach steer admission while the first run is active", async () => {
+  it("starts a second same-session event while the first run is active", async () => {
     preflightDiscordMessageMock.mockReset();
     processDiscordMessageMock.mockReset();
 

--- a/extensions/discord/src/monitor/message-run-queue.ts
+++ b/extensions/discord/src/monitor/message-run-queue.ts
@@ -129,7 +129,9 @@ export function createDiscordMessageRunQueue(
         return;
       }
       skippedCleanup.add(cleanupSkipped);
-      runQueue.enqueue(job.queueKey, async ({ lifecycleSignal }) => {
+      // Core reply admission owns session serialization. A transport event key
+      // lets later Discord messages reach active-run steering while this run continues.
+      runQueue.enqueue(job.payload.message.id, async ({ lifecycleSignal }) => {
         // Once the task starts, normal process/commit handling owns cleanup.
         // Leaving it in skippedCleanup would double-release replay state.
         skippedCleanup.delete(cleanupSkipped);

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -39,7 +39,11 @@ import {
   REPLY_OPERATION_RUN_STATE,
   type ReplyOperationRunState,
 } from "./reply-operation-run-state.js";
-import { createReplyOperation, type ReplyOperation } from "./reply-run-registry.js";
+import {
+  createReplyOperation,
+  type ReplyOperation,
+  replyRunRegistry,
+} from "./reply-run-registry.js";
 import { testing as replyRunTesting } from "./reply-run-registry.test-support.js";
 import { bindReplyOperationTyping } from "./reply-run-typing.js";
 import { consumeReplyUsageState } from "./reply-usage-state.js";
@@ -558,6 +562,12 @@ describe("runReplyAgent active steering", () => {
 
   it("injects a steer without claiming a new agent reply", async () => {
     const runState: ReplyOperationRunState = {};
+    const active = createReplyOperation({
+      sessionKey: "main",
+      sessionId: "session",
+      resetTriggered: false,
+    });
+    active.setPhase("running");
     state.beforeAgentReplyHasHooksMock.mockImplementation(
       (hookName) => hookName === "before_agent_reply",
     );
@@ -583,16 +593,22 @@ describe("runReplyAgent active steering", () => {
       },
     });
 
-    await expect(run()).resolves.toBeUndefined();
+    try {
+      await expect(run()).resolves.toBeUndefined();
 
-    expect(runState.admission).toEqual({ status: "accepted", mode: "steer" });
-    expect(state.beforeAgentReplyRunMock).not.toHaveBeenCalled();
-    expect(state.queueEmbeddedAgentMessageMock).toHaveBeenCalledOnce();
-    expect(state.queueEmbeddedAgentMessageMock).toHaveBeenCalledWith(
-      "session",
-      "hello",
-      expect.objectContaining({ steeringMode: "all" }),
-    );
+      expect(runState.admission).toEqual({ status: "accepted", mode: "steer" });
+      expect(state.beforeAgentReplyRunMock).not.toHaveBeenCalled();
+      expect(state.queueEmbeddedAgentMessageMock).toHaveBeenCalledOnce();
+      expect(state.queueEmbeddedAgentMessageMock).toHaveBeenCalledWith(
+        "session",
+        "hello",
+        expect.objectContaining({ steeringMode: "all" }),
+      );
+      expect(state.runEmbeddedAgentMock).not.toHaveBeenCalled();
+      expect(replyRunRegistry.get("main")).toBe(active);
+    } finally {
+      active.complete();
+    }
   });
 
   it("does not let before_agent_reply claim an accepted steer", async () => {


### PR DESCRIPTION
Related: #48003

## What Problem This Solves

Fixes an issue where Discord users sending a correction during an active turn would have that message held until the original turn finished, so default `steer` mode could not affect the running model.

## Why This Change Was Made

Discord no longer serializes complete model turns by session at the transport layer. Each Discord event can reach the shared reply admission path, which already owns session ordering and chooses active-run steering or a queued follow-up.

## User Impact

Normal Discord messages sent during an active turn can steer that turn at the next model boundary. Discord busy-state tracking, durable ingress, shutdown cleanup, and transport ordering remain intact.

## Evidence

- Before fix: focused regression failed because the second same-session message completed preflight but never reached message processing while the first run was active.
- After fix: the same regression passes and records two active Discord events before the first settles. Shared admission then accepts the Discord correction as `steer`, injects it once, starts no second agent run, and retains the original run owner.
- Redacted Discord E2E: the first request was held active at the provider for 3 seconds; a second same-session correction arrived 1 second later. The recorder observed one final `OPENCLAW_E2E_STEERED_OK` and no original-turn completion marker. Message IDs, account IDs, channel IDs, and usernames are omitted.
- `pnpm test -- 'extensions/discord/src/monitor/**/*.test.ts'`: 89 files, 1,048 tests passed.
- `pnpm vitest run src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts`: 15 shared-admission tests passed.
- `pnpm test -- extensions/discord/src/monitor/message-handler.queue.test.ts`: 15 Discord queue tests passed.
- `pnpm tsgo:prod`
- `pnpm check:test-types`
- Targeted Oxlint and Oxfmt on all touched files.
- Telegram final-head sibling-channel non-regression: a real-user DM produced two typing events and one `OPENCLAW_E2E_BASIC` reply after one provider request; the isolated gateway scratch state was removed after exit. Account, bot, chat, and message identifiers are omitted.

Production delta: `+3/-17` lines. Test delta: `+63/-151` lines.
