### PR TITLE
test(agents): reset CLI prepare dependencies between tests

### DIFF
--- a/src/agents/cli-runner/prepare.test-support.ts
+++ b/src/agents/cli-runner/prepare.test-support.ts
@@ -1,6 +1,7 @@
 import "./prepare.js";
 
 type CliRunnerPrepareTestApi = {
+  resetCliRunnerPrepareTestDeps(): void;
   setCliRunnerPrepareTestDeps(overrides: Record<string, unknown>): void;
 };
 
@@ -12,4 +13,8 @@ function getTestApi(): CliRunnerPrepareTestApi {
 
 export function setCliRunnerPrepareTestDeps(overrides: Record<string, unknown>): void {
   getTestApi().setCliRunnerPrepareTestDeps(overrides);
+}
+
+export function resetCliRunnerPrepareTestDeps(): void {
+  getTestApi().resetCliRunnerPrepareTestDeps();
 }

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -62,7 +62,10 @@ import {
 import type { SandboxWorkspaceInfo } from "../sandbox/types.js";
 import type { SystemAgentToolOptions } from "../tools/system-agent-tool.js";
 import { prepareCliRunContext } from "./prepare.js";
-import { setCliRunnerPrepareTestDeps } from "./prepare.test-support.js";
+import {
+  resetCliRunnerPrepareTestDeps,
+  setCliRunnerPrepareTestDeps,
+} from "./prepare.test-support.js";
 import type { RunCliAgentParams } from "./types.js";
 
 function registerTestContextEngine(
@@ -401,6 +404,7 @@ describe("prepareCliRunContext", () => {
 
   afterEach(() => {
     cliBackendsTesting.resetDepsForTest();
+    resetCliRunnerPrepareTestDeps();
     resetCliAuthEpochTestDeps();
     getRuntimeConfigMock.mockReset();
     mockGetGlobalHookRunner.mockReset();

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -171,7 +171,7 @@ type RunCliAgentPrepareParams = RunCliAgentParams & {
   systemAgentTool?: import("../tools/system-agent-tool.js").SystemAgentToolOptions;
 };
 
-const prepareDeps = {
+const defaultPrepareDeps = {
   isWorkspaceBootstrapPending: isWorkspaceBootstrapPendingImpl,
   makeBootstrapWarn: makeBootstrapWarnImpl,
   resolveBootstrapContextForRun: resolveBootstrapContextForRunImpl,
@@ -195,6 +195,7 @@ const prepareDeps = {
   readExternalCliBootstrapCredential,
   resolveApiKeyForProfile,
 };
+const prepareDeps = { ...defaultPrepareDeps };
 
 function resolveReusableCliSessionId(reusableCliSession: CliReusableSession): string | undefined {
   return reusableCliSession.mode === "reuse" || reusableCliSession.mode === "reuse-with-drift"
@@ -320,6 +321,11 @@ function setCliRunnerPrepareTestDeps(overrides: Partial<typeof prepareDeps>): vo
   Object.assign(prepareDeps, overrides);
 }
 
+/** Restores preparation dependencies after CLI runner tests. */
+function resetCliRunnerPrepareTestDeps(): void {
+  Object.assign(prepareDeps, defaultPrepareDeps);
+}
+
 /** Returns whether profile-owned prepared execution should skip local CLI epoch hashing. */
 function shouldSkipLocalCliCredentialEpoch(params: {
   authEpochMode?: CliBackendAuthEpochMode;
@@ -337,6 +343,7 @@ function shouldSkipLocalCliCredentialEpoch(params: {
 
 if (process.env.VITEST || process.env.NODE_ENV === "test") {
   (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.cliRunnerPrepareTestApi")] = {
+    resetCliRunnerPrepareTestDeps,
     setCliRunnerPrepareTestDeps: (overrides: Record<string, unknown>) => {
       setCliRunnerPrepareTestDeps(overrides as Partial<typeof prepareDeps>);
     },


### PR DESCRIPTION
Related: #122432

## What Problem This Solves

Fixes an issue where the `src/agents/cli-runner` aggregate test suite produced three order-sensitive `prepare.test.ts` failures under shuffle seed 1. A warm Claude CLI session test left an orphan-transcript probe installed, so a later cwd-resolution test incorrectly invalidated a reusable session.

## Why This Change Was Made

The CLI preparation dependency seam now owns a canonical default snapshot and exposes a private reset operation. The prepare suite invokes that owner reset during lifecycle cleanup, matching the existing CLI-backend and auth test-seam patterns instead of resetting individual consumers or forcing test order.

AI-assisted; the final diff and owner boundary were independently reviewed.

## User Impact

No product runtime behavior changes. Maintainers get deterministic CLI-runner aggregate coverage in default and shuffled order, and future prepare dependency overrides cannot leak across tests.

## Evidence

Pre-fix reproduction:

- `node scripts/run-vitest.mjs src/agents/cli-runner --sequence.shuffle --sequence.seed=1`
- Three identical prepare failures across `unit-fast`, `agents-core`, and `agents-support`: expected session reuse, received `invalidate/orphaned-tool-use`.

Post-fix Blacksmith Testbox proof: https://github.com/openclaw/openclaw/actions/runs/31565736687

- Focused shuffled prepare: 206/206 passed.
- Default CLI-runner aggregate: 1,202/1,202 passed.
- Seed-1 CLI-runner aggregate: 1,202/1,202 passed.
- `git diff --check` clean.
- Changed-lane dry run classified `core, coreTests`.
- Fresh Codex autoreview: no accepted/actionable findings.
