### PR TITLE
fix: CLI backend sessions no longer flagged stuck while streaming

### DIFF
--- a/src/logging/diagnostic-session-attention.test.ts
+++ b/src/logging/diagnostic-session-attention.test.ts
@@ -172,6 +172,48 @@ describe("classifySessionAttention", () => {
         recoveryEligible: false,
       },
     },
+    {
+      name: "queued CLI-style streaming without activeWorkKind is not stuck",
+      queueDepth: 1,
+      activity: {
+        lastProgressAgeMs: 10_000,
+        lastProgressReason: "cli_live:stream_progress",
+      },
+      expected: {
+        eventType: "session.long_running",
+        reason: "queued_behind_active_work",
+        classification: "long_running",
+        recoveryEligible: false,
+      },
+    },
+    {
+      name: "queued CLI-style streaming with stale progress is stuck",
+      queueDepth: 1,
+      activity: {
+        lastProgressAgeMs: 31_000,
+        lastProgressReason: "cli_live:stream_progress",
+      },
+      expected: {
+        eventType: "session.stuck",
+        reason: "queued_work_without_active_run",
+        classification: "stale_session_state",
+        recoveryEligible: true,
+      },
+    },
+    {
+      name: "CLI-style streaming without queued work is long-running",
+      queueDepth: 0,
+      activity: {
+        lastProgressAgeMs: 10_000,
+        lastProgressReason: "cli_live:stream_progress",
+      },
+      expected: {
+        eventType: "session.long_running",
+        reason: "active_work",
+        classification: "long_running",
+        recoveryEligible: false,
+      },
+    },
   ])("$name", ({ activity, expected, queueDepth, state }) => {
     expect(
       classifySessionAttention({

--- a/src/logging/diagnostic-session-attention.ts
+++ b/src/logging/diagnostic-session-attention.ts
@@ -134,6 +134,16 @@ export function classifySessionAttention(params: {
     };
   }
 
+  const lastProgressAgeMs = params.activity.lastProgressAgeMs;
+  if (typeof lastProgressAgeMs === "number" && lastProgressAgeMs <= params.staleMs) {
+    return {
+      eventType: "session.long_running",
+      reason: params.queueDepth > 0 ? "queued_behind_active_work" : "active_work",
+      classification: "long_running",
+      recoveryEligible: false,
+    };
+  }
+
   return {
     eventType: "session.stuck",
     reason: params.queueDepth > 0 ? "queued_work_without_active_run" : "stale_session_state",

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -992,6 +992,61 @@ describe("stuck session diagnostics threshold", () => {
     expect(recoverStuckSession).not.toHaveBeenCalled();
   });
 
+  it("does not recover queued CLI streaming without an active-work marker while progress is fresh", () => {
+    // CLI backends emit cli_live:stream_progress without activeWorkKind. This
+    // heartbeat path is what prevents requestStuckSessionRecovery for that case.
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn();
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test-followup" });
+
+      for (let i = 0; i < 3; i += 1) {
+        vi.advanceTimersByTime(29_000);
+        markDiagnosticRunProgressForTest({
+          sessionId: "s1",
+          sessionKey: "main",
+          runId: "run-1",
+          reason: "cli_live:stream_progress",
+        });
+        vi.advanceTimersByTime(1_000);
+      }
+    } finally {
+      unsubscribe();
+    }
+
+    expect(events.some((event) => event.type === "session.stuck")).toBe(false);
+    expect(events.some((event) => event.type === "session.stalled")).toBe(false);
+    expect(recoverStuckSession).not.toHaveBeenCalled();
+    const longRunningEvents = events.filter((event) => event.type === "session.long_running");
+    expect(longRunningEvents).toHaveLength(1);
+    expectRecordFields(requireRecord(longRunningEvents[0], "long-running event"), {
+      classification: "long_running",
+      reason: "queued_behind_active_work",
+      queueDepth: 1,
+      lastProgressReason: "cli_live:stream_progress",
+    });
+    expect(longRunningEvents[0]).not.toHaveProperty("activeWorkKind");
+    const activity = getDiagnosticSessionActivitySnapshot({ sessionId: "s1", sessionKey: "main" });
+    expect(activity.activeWorkKind).toBeUndefined();
+    expect(activity.hasActiveEmbeddedRun).toBeUndefined();
+    expectRecordFields(activity, {
+      lastProgressReason: "cli_live:stream_progress",
+    });
+  });
+
   it("recovers stale model calls through the active embedded-run abort path", async () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running CLI backends (for example claude-cli) would see stuck-session warnings and recovery attempts while the session was still streaming output.

Closes #122448

## Why This Change Was Made

CLI live turns emit `cli_live:stream_progress` without an `activeWorkKind` marker. The session-attention classifier's no-owner fallback used to treat that state as recoverable `session.stuck` once the session aged past the warn threshold, even when progress was still fresh. Sibling branches already gate stuck detection on `lastProgressAgeMs`; this change applies the same freshness check on the fallback path so recent streaming is `session.long_running` and not recovery-eligible.

The heartbeat still recovers truly stale no-owner progress. This PR does not change recovery for hung sessions.

## User Impact

Operators using CLI-style backends should no longer get false stuck-session alerts or recovery attempts during long but healthy streaming runs. Genuinely stale CLI sessions still warn and remain recovery-eligible.

## Evidence

Production change is unchanged from the original classifier freshness guard (`src/logging/diagnostic-session-attention.ts`). Heartbeat Vitest still covers the recovery decision with fake timers. This follow-up adds a **real wall-clock** after-fix trace against the built package.

### Environment

- OS: Linux 6.12.94+ x86_64
- Node: v24.15.0
- pnpm: 11.15.1
- Head SHA: `703d457020e4a9efc09c1619f4d462ed51b8d634`
- Import source: built `dist/plugin-sdk` (`logging-core`, `diagnostic-runtime`, `text-runtime`) after `node --import tsx scripts/tsdown-build.mts`
- Isolated `HOME=/tmp/openclaw-proof-home` and `OPENCLAW_STATE_DIR=/tmp/openclaw-proof-state`
- Production timings: heartbeat 30s, `stuckSessionWarnMs` 120s (no fake timers, no `testTimings` shortcut)

### Exact commands

```bash
nvm use 24.15.0
corepack enable
corepack prepare pnpm@11.15.1 --activate
pnpm install
node --import tsx scripts/tsdown-build.mts
HOME=/tmp/openclaw-proof-home \
OPENCLAW_STATE_DIR=/tmp/openclaw-proof-state \
OPENCLAW_LOG_LEVEL=warn \
node /tmp/cli-stream-heartbeat-proof.mjs
```

The harness boots production `startDiagnosticHeartbeat` from the built package, queues a processing session with a follow-up (`queueDepth` backlog = 1), and emits trusted `run.progress` events with `reason=cli_live:stream_progress` on the same path Claude live-turn uses (`emitTrustedDiagnosticEvent`). Progress frames were sent every 20s for 150s, then stopped for 150s. Recovery was observed via the heartbeat's `recoverStuckSession` callback plus `session.recovery.requested` events.

### After-fix observation (redacted; no secrets)

Streaming while progress stayed fresh (age 120s, last progress 20s old):

```
[diagnostic] long-running session: sessionId=cli-stream-proof sessionKey=main state=processing age=120s queueDepth=1 reason=queued_behind_active_work classification=long_running lastProgress=cli_live:stream_progress lastProgressAge=20s recovery=none
```

Structured event at the same tick: `session.long_running`, `activeWorkKind=null`, `recoverCallCount=0`, no `session.stuck`, no `session.recovery.requested`.

Still fresh at age 240s / lastProgressAge 100s (under the 120s warn window):

```
[diagnostic] long-running session: sessionId=cli-stream-proof sessionKey=main state=processing age=240s queueDepth=1 reason=queued_behind_active_work classification=long_running lastProgress=cli_live:stream_progress lastProgressAge=100s recovery=none
```

After progress stopped and `lastProgressAge` crossed 120s (age 270s / lastProgressAge 130s):

```
[diagnostic] stuck session: sessionId=cli-stream-proof sessionKey=main state=processing age=270s queueDepth=1 reason=queued_work_without_active_run classification=stale_session_state lastProgress=cli_live:stream_progress lastProgressAge=130s recovery=checking
```

That tick also emitted `session.stuck`, `session.recovery.requested`, and called `recoverStuckSession`.

Harness verdict: `okStreaming=true`, `okStale=true`, exit 0.

### Heartbeat Vitest (still valid, not the live trace)

Queued, no-owner `cli_live:stream_progress` through `startDiagnosticHeartbeat` with fake timers:

```
node scripts/run-vitest.mjs src/logging/diagnostic.test.ts -t "does not recover queued CLI streaming"
 Test Files  1 passed (1)
      Tests  1 passed | 82 skipped (83)
```

### What was NOT tested

- No live `claude` / claude-cli binary, operator credentials, or attached Gateway process.
- No end-to-end CLI backend turn through `src/agents/cli-runner/claude-live-turn.ts`; progress was injected with the same trusted `run.progress` / `cli_live:stream_progress` event that function emits.
- Recovery was observed at the request boundary (`session.recovery.requested` + `recoverStuckSession` call). The callback returned `observe_only` / skipped, so this did not mutate a real session store or abort a live run.
- No channel-visible stuck warning (Telegram/Discord/etc.).

### LOC

This follow-up: production +0 / tests +55. Full PR vs base: production +10, tests +97.
