### PR TITLE
fix(ui): restore sidebar session delete and rename dialogs

### DIFF
--- a/ui/src/components/session-organizer-controller.ts
+++ b/ui/src/components/session-organizer-controller.ts
@@ -33,11 +33,27 @@ import {
   type SidebarSessionPatch,
   type SidebarSessionStatusFilter,
 } from "./app-sidebar-session-types.ts";
+import type { ApplicationContext } from "../app/context.ts";
+import { loadSettings, patchSettings } from "../app/settings.ts";
+import type { RouteId } from "../app-route-paths.ts";
+import { showConfirmDialog, type ConfirmDialogSkipPreference } from "./confirm-dialog.ts";
 import type { SessionDataController } from "./session-data-controller.ts";
 import type { SessionMenuAction } from "./session-menu.ts";
 
 type SessionOrganizerOperations = typeof import("./session-organizer-operations.runtime.ts");
 type InputDialogOpener = (typeof import("./input-dialog.ts"))["showInputDialog"];
+
+function sidebarSessionDeleteSkipPreference(
+  context: ApplicationContext<RouteId>,
+): ConfirmDialogSkipPreference {
+  return {
+    skipped: loadSettings().sessionDeleteConfirm === false,
+    remember: () => {
+      patchSettings({ sessionDeleteConfirm: false });
+      context.theme.refresh();
+    },
+  };
+}
 
 export interface SessionOrganizerControllerHost extends ReactiveControllerHost {
   readonly sessionData: Pick<
@@ -196,14 +212,28 @@ export class SessionOrganizerController implements ReactiveController {
   }
 
   async deleteSession(session: SidebarRecentSession): Promise<void> {
+    const context = this.host.sessionData.context;
+    if (!context) {
+      return;
+    }
+    // Match rename: confirm in the owned dialog before capturing a mutation
+    // scope or loading operations, so desktop webviews never depend on native
+    // confirm and a stale scope cannot suppress the prompt entirely.
+    const confirmed = await showConfirmDialog({
+      message: t("sessionsView.deleteSessionConfirm", { session: session.label }),
+      confirmLabel: t("common.delete"),
+      danger: true,
+      skipPreference: sidebarSessionDeleteSkipPreference(context),
+    });
+    if (!confirmed) {
+      return;
+    }
     const scope = this.host.sessionData.beginSessionMutation();
     if (!scope) {
       return;
     }
     const operations = await this.loadOperations(scope);
-    // Sidebar is the surface the delete-confirm setting names, so it is the one
-    // caller allowed to offer the opt-out.
-    await operations?.deleteSession(this.host, session, scope, { offerSkip: true });
+    await operations?.deleteSession(this.host, session, scope, { skipConfirm: true });
   }
 
   startSidebarRouteDrag(event: DragEvent, route: SidebarNavRoute) {

--- a/ui/src/components/session-organizer-operations.runtime.ts
+++ b/ui/src/components/session-organizer-operations.runtime.ts
@@ -246,8 +246,8 @@ async function restoreArchivedSessions(
  * deliberately get none: the first is a rare shared-resource action and the
  * second destroys the only copy of uncommitted work.
  */
-function sessionDeleteSkipPreference(
-  scope: SidebarSessionMutationScope,
+export function sessionDeleteSkipPreference(
+  scope: Pick<SidebarSessionMutationScope, "context">,
 ): ConfirmDialogSkipPreference {
   return {
     skipped: loadSettings().sessionDeleteConfirm === false,
@@ -535,15 +535,21 @@ export async function deleteSession(
   scope: SidebarSessionMutationScope,
   // The chat header shares this operation, so the opt-out is opt-in per caller:
   // only the sidebar the setting names may offer it, and the default keeps asking.
-  options: { offerSkip?: boolean } = {},
+  // Sidebar confirms before capturing a mutation scope; callers that already
+  // confirmed pass skipConfirm so the owned dialog is not shown twice.
+  options: { offerSkip?: boolean; skipConfirm?: boolean } = {},
 ) {
-  const confirmed = await showConfirmDialog({
-    message: t("sessionsView.deleteSessionConfirm", { session: session.label }),
-    confirmLabel: t("common.delete"),
-    danger: true,
-    ...(options.offerSkip ? { skipPreference: sessionDeleteSkipPreference(scope) } : {}),
-  });
-  if (!confirmed || !host.sessionData.isSessionMutationScopeCurrent(scope)) {
+  if (!options.skipConfirm) {
+    const confirmed = await showConfirmDialog({
+      message: t("sessionsView.deleteSessionConfirm", { session: session.label }),
+      confirmLabel: t("common.delete"),
+      danger: true,
+      ...(options.offerSkip ? { skipPreference: sessionDeleteSkipPreference(scope) } : {}),
+    });
+    if (!confirmed || !host.sessionData.isSessionMutationScopeCurrent(scope)) {
+      return;
+    }
+  } else if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
     return;
   }
   const agentId = parseAgentSessionKey(session.key)?.agentId ?? scope.selectedAgentId;

--- a/ui/src/test-helpers/app-sidebar-cases/session-mutations.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-mutations.ts
@@ -14,6 +14,7 @@ import {
 import {
   answerConfirmDialog,
   installDialogPolyfill,
+  submitInputDialog,
   waitForConfirmDialogActions,
 } from "../modal-dialog.ts";
 import { waitForFast } from "../wait-for.ts";
@@ -436,5 +437,52 @@ describe("AppSidebar session mutation feedback", () => {
       expect(document.body.querySelector("openclaw-modal-dialog")).toBeNull(),
     );
     expect(request).not.toHaveBeenCalled();
+  });
+
+  it("opens the owned rename dialog from the Rename menu item without native prompts", async () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockImplementation(() => true);
+    const promptSpy = vi.spyOn(window, "prompt").mockImplementation(() => "ignored");
+    try {
+      const { harness, sidebar } = await mountMutationHarness();
+      const menu = await openSessionMenu(sidebar, "agent:main:a");
+      menu.querySelector<HTMLElement>('[value="rename"]')?.click();
+      await waitForFast(() => {
+        expect(document.body.querySelector('input[name="value"]')).toBeInstanceOf(HTMLInputElement);
+      });
+      expect(confirmSpy).not.toHaveBeenCalled();
+      expect(promptSpy).not.toHaveBeenCalled();
+      await submitInputDialog("Renamed from menu");
+      await waitForFast(() =>
+        expect(harness.patch).toHaveBeenCalledWith(
+          "agent:main:a",
+          { label: "Renamed from menu" },
+          expect.objectContaining({ agentId: "main" }),
+        ),
+      );
+    } finally {
+      confirmSpy.mockRestore();
+      promptSpy.mockRestore();
+    }
+  });
+
+  it("opens the owned delete confirm from the Delete menu item without native prompts", async () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockImplementation(() => true);
+    const promptSpy = vi.spyOn(window, "prompt").mockImplementation(() => "ignored");
+    const restoreDialogPolyfill = installDialogPolyfill();
+    try {
+      const { harness, sidebar } = await mountMutationHarness();
+      harness.deleteSession.mockResolvedValueOnce({ deleted: true });
+      const menu = await openSessionMenu(sidebar, "agent:main:a");
+      menu.querySelector<HTMLElement>('[value="delete"]')?.click();
+      const actions = await waitForConfirmDialogActions();
+      expect(confirmSpy).not.toHaveBeenCalled();
+      expect(promptSpy).not.toHaveBeenCalled();
+      answerConfirmDialog(actions, "confirm");
+      await waitForFast(() => expect(harness.deleteSession).toHaveBeenCalledOnce());
+    } finally {
+      restoreDialogPolyfill();
+      confirmSpy.mockRestore();
+      promptSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
Closes #121702

## What Problem This Solves

Fixes an issue where users choosing **Delete…** or **Rename…** on a Control UI / Webchat sidebar session would see no dialog and no effect in desktop webviews that lack native `window.confirm` / `window.prompt` bridges.

## Why This Change Was Made

Rename already used the owned input dialog; delete now confirms in that same in-app dialog **before** capturing a mutation scope (matching rename’s dialog-first flow) so a stale scope cannot suppress the prompt. Sidebar delete passes `skipConfirm` into the shared delete operation so the confirm is not shown twice.

## User Impact

Sidebar **Rename…** opens the themed rename dialog; **Delete…** opens the themed danger confirm (with the existing “don’t ask again” opt-out). Cancelling leaves the session unchanged; confirming runs the mutation.

## Evidence

```
cd ui && ../node_modules/.bin/vitest run src/components/app-sidebar.test.ts src/components/confirm-dialog.test.ts --config vitest.config.ts
Test Files  2 passed (2)
Tests  261 passed (261)
```

Added regression cases that click the **Rename…** / **Delete…** menu items and assert `window.confirm` / `window.prompt` are never called.