### PR TITLE
fix(ui): restore prior terminal dock when toggling fill

### DIFF
--- a/ui/src/components/dock-layout-controller.ts
+++ b/ui/src/components/dock-layout-controller.ts
@@ -24,6 +24,7 @@ export class DockLayoutController<TDock extends DockPanelPlacement> implements R
   height: number;
   width: number;
 
+  private previousDock: TDock | undefined;
   private suppressed = false;
   private resizeCleanup: (() => void) | null = null;
   private readonly onViewportResize = () => {
@@ -57,6 +58,7 @@ export class DockLayoutController<TDock extends DockPanelPlacement> implements R
     const layout = this.options.layout.load();
     this.open = layout.open && this.options.isAvailable();
     this.dock = layout.dock;
+    this.previousDock = layout.previousDock;
     this.height = layout.height;
     this.width = layout.width;
     window.addEventListener("resize", this.onViewportResize);
@@ -128,10 +130,26 @@ export class DockLayoutController<TDock extends DockPanelPlacement> implements R
     this.host.requestUpdate();
   }
 
+  setRestorableDock(dock: TDock): void {
+    if (dock !== this.dock) {
+      this.previousDock = this.dock;
+    }
+    this.setDock(dock);
+  }
+
+  toggleDock(dock: TDock): void {
+    if (this.dock === dock) {
+      this.setDock(this.previousDock ?? this.options.layout.defaults.dock);
+    } else {
+      this.setRestorableDock(dock);
+    }
+  }
+
   persist(): void {
     this.options.layout.save({
       open: this.open,
       dock: this.dock,
+      ...(this.previousDock ? { previousDock: this.previousDock } : {}),
       height: this.height,
       width: this.width,
     });

--- a/ui/src/components/dock-panel-layout.ts
+++ b/ui/src/components/dock-panel-layout.ts
@@ -4,6 +4,7 @@ export type DockPanelPlacement = DockPanelSide | "main";
 type DockPanelLayout<TDock extends DockPanelPlacement> = {
   open: boolean;
   dock: TDock;
+  previousDock?: TDock;
   height: number;
   width: number;
 };
@@ -67,6 +68,9 @@ export function createDockPanelLayout<TDock extends DockPanelPlacement>(
           dock: options.supportedDocks.includes(parsed.dock as TDock)
             ? (parsed.dock as TDock)
             : defaults.dock,
+          ...(options.supportedDocks.includes(parsed.previousDock as TDock)
+            ? { previousDock: parsed.previousDock as TDock }
+            : {}),
           height: clampSize(parsed.height, options.minHeight, maxHeight(), defaults.height),
           width: clampSize(parsed.width, options.minWidth, maxWidth(), defaults.width),
         };

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -78,35 +78,50 @@ describe("OpenClawTerminalPanel", () => {
     await waitForFast(() => expect(panel.terminalPanelOpen).toBe(true));
   });
 
-  it("persists and restores the main content placement without a resizer", async () => {
-    localStorage.setItem(
-      "openclaw.terminal.panel.v1",
-      JSON.stringify({ open: true, dock: "bottom", height: 320, width: 520 }),
-    );
-    const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
-    panel.available = true;
-    document.body.append(panel);
-    await panel.updateComplete;
+  it.each(["bottom", "right"] as const)(
+    "toggles main content placement back to the persisted %s dock",
+    async (dock) => {
+      localStorage.setItem(
+        "openclaw.terminal.panel.v1",
+        JSON.stringify({ open: true, dock, height: 320, width: 520 }),
+      );
+      const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
+      panel.available = true;
+      document.body.append(panel);
+      await panel.updateComplete;
 
-    panel.renderRoot
-      .querySelector<HTMLButtonElement>('[aria-label="Fill main content area"]')
-      ?.click();
-    await panel.updateComplete;
+      panel.renderRoot
+        .querySelector<HTMLButtonElement>('[aria-label="Fill main content area"]')
+        ?.click();
+      await panel.updateComplete;
 
-    expect(panel.renderRoot.querySelector(".tp")?.classList.contains("tp--main")).toBe(true);
-    expect(panel.renderRoot.querySelector(".tp-resizer")).toBeNull();
-    expect(JSON.parse(localStorage.getItem("openclaw.terminal.panel.v1") ?? "{}")).toMatchObject({
-      open: true,
-      dock: "main",
-    });
+      expect(panel.renderRoot.querySelector(".tp")?.classList.contains("tp--main")).toBe(true);
+      expect(panel.renderRoot.querySelector(".tp-resizer")).toBeNull();
+      expect(JSON.parse(localStorage.getItem("openclaw.terminal.panel.v1") ?? "{}")).toMatchObject({
+        open: true,
+        dock: "main",
+        previousDock: dock,
+      });
 
-    panel.remove();
-    const restored = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
-    restored.available = true;
-    document.body.append(restored);
-    await restored.updateComplete;
-    expect(restored.renderRoot.querySelector(".tp")?.classList.contains("tp--main")).toBe(true);
-  });
+      panel.remove();
+      const restored = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
+      restored.available = true;
+      document.body.append(restored);
+      await restored.updateComplete;
+      restored.renderRoot
+        .querySelector<HTMLButtonElement>('[aria-label="Fill main content area"]')
+        ?.click();
+      await restored.updateComplete;
+
+      expect(restored.renderRoot.querySelector(".tp")?.classList.contains(`tp--${dock}`)).toBe(
+        true,
+      );
+      expect(
+        restored.renderRoot.querySelector('[aria-label="Fill main content area"]')?.classList,
+      ).not.toContain("is-active");
+      restored.remove();
+    },
+  );
 
   it("opens new sessions for the selected agent", async () => {
     let createOptions: CreateOptions | undefined;
@@ -366,6 +381,7 @@ describe("OpenClawTerminalPanel", () => {
     expect(JSON.parse(localStorage.getItem("openclaw.terminal.panel.v1") ?? "{}")).toMatchObject({
       open: true,
       dock: "main",
+      previousDock: "bottom",
     });
 
     await waitForFast(() => {
@@ -378,6 +394,11 @@ describe("OpenClawTerminalPanel", () => {
     expect(sessionStorage.getItem("openclaw.terminal.sessions.v1")).toBe(
       JSON.stringify(["persisted-1"]),
     );
+    panel.renderRoot
+      .querySelector<HTMLButtonElement>('[aria-label="Fill main content area"]')
+      ?.click();
+    await panel.updateComplete;
+    expect(panel.renderRoot.querySelector(".tp")?.classList.contains("tp--bottom")).toBe(true);
   });
 
   it("restores a vanished persisted session as exited without replaying stale output", async () => {

--- a/ui/src/components/terminal/terminal-panel.ts
+++ b/ui/src/components/terminal/terminal-panel.ts
@@ -196,7 +196,7 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
         return;
       }
       if (detail.catalog) {
-        this.dockLayout.setDock("main");
+        this.dockLayout.setRestorableDock("main");
       }
       this.dockLayout.setOpen(true);
       void (detail.terminalSessionId
@@ -313,7 +313,11 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
   }
 
   private setDock(dock: TerminalDock): void {
-    this.dockLayout.setDock(dock);
+    if (dock === "main") {
+      this.dockLayout.toggleDock(dock);
+    } else {
+      this.dockLayout.setDock(dock);
+    }
     void this.updateComplete.then(() => fitAllTerminalSessions(this.terminalSessions.tabs));
   }
 

--- a/ui/src/e2e/terminal-panel-layout.e2e.test.ts
+++ b/ui/src/e2e/terminal-panel-layout.e2e.test.ts
@@ -1,0 +1,144 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import {
+  waitForControlUiGatewayReady,
+  waitForControlUiTerminalReady,
+} from "../test-helpers/control-ui-e2e-readiness.ts";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI terminal panel layout",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`.`,
+});
+
+const screenshotDir = process.env.OPENCLAW_TERMINAL_LAYOUT_SCREENSHOT_DIR?.trim();
+
+async function captureLayout(page: Page, theme: string, state: string): Promise<void> {
+  if (!screenshotDir) {
+    return;
+  }
+  await fs.mkdir(screenshotDir, { recursive: true });
+  await page.screenshot({
+    animations: "disabled",
+    caret: "hide",
+    path: path.join(screenshotDir, `${theme}-${state}-context.png`),
+  });
+  await page.locator("openclaw-terminal-panel .tp-header").screenshot({
+    animations: "disabled",
+    caret: "hide",
+    path: path.join(screenshotDir, `${theme}-${state}-crop.png`),
+  });
+}
+
+suite.define(() => {
+  it.each(["light", "dark"] as const)(
+    "toggles main content back to bottom and right in %s mode",
+    async (theme) => {
+      await suite.withPage(
+        {
+          colorScheme: theme,
+          locale: "en-US",
+          serviceWorkers: "block",
+          viewport: { height: 800, width: 1280 },
+        },
+        async ({ page }) => {
+          const gateway = await installMockGateway(page, {
+            historyMessages: [
+              {
+                content: [{ type: "text", text: "Review the release checklist and recent CI." }],
+                role: "user",
+                timestamp: Date.now() - 3_000,
+              },
+              {
+                content: [
+                  {
+                    type: "text",
+                    text: [
+                      "## Release workspace",
+                      "",
+                      "- CI checks are green",
+                      "- Two review notes remain",
+                      "- Terminal is ready for the focused command",
+                    ].join("\n"),
+                  },
+                ],
+                role: "assistant",
+                timestamp: Date.now() - 2_000,
+              },
+              {
+                content: [
+                  { type: "text", text: "Keep the transcript visible while we verify it." },
+                ],
+                role: "user",
+                timestamp: Date.now() - 1_000,
+              },
+            ],
+            featureMethods: ["terminal.open"],
+            methodResponses: {
+              "terminal.list": { sessions: [] },
+              "terminal.open": {
+                agentId: "main",
+                confined: false,
+                cwd: "/workspace/openclaw",
+                sessionId: `terminal-layout-${theme}`,
+                shell: "/bin/zsh",
+              },
+            },
+            terminalEnabled: true,
+          });
+
+          await page.goto(`${suite.server.baseUrl}chat`);
+          await waitForControlUiGatewayReady(page);
+          await waitForControlUiTerminalReady(page);
+          await expect.poll(() => page.locator("html").getAttribute("data-theme-mode")).toBe(theme);
+          await page.keyboard.press("Control+Backquote");
+          await gateway.waitForRequest("terminal.open");
+          await gateway.emitGatewayEvent("terminal.data", {
+            sessionId: `terminal-layout-${theme}`,
+            seq: 0,
+            data: "OpenClaw release workspace\r\n$ pnpm test ui/src/components/terminal/terminal-panel.test.ts\r\n22 tests passed\r\n$ ",
+          });
+
+          const panel = page.locator("openclaw-terminal-panel");
+          const surface = panel.locator(".tp");
+          const fill = panel.getByRole("button", { name: "Fill main content area" });
+          const bottom = panel.getByRole("button", { name: "Dock to bottom" });
+          const right = panel.getByRole("button", { name: "Dock to right" });
+
+          await expect.poll(() => surface.getAttribute("class")).toContain("tp--bottom");
+          await captureLayout(page, theme, "bottom");
+          await fill.click();
+          await expect.poll(() => surface.getAttribute("class")).toContain("tp--main");
+          expect(await fill.getAttribute("class")).toContain("is-active");
+          await captureLayout(page, theme, "bottom-fill");
+          await fill.click();
+          const bottomRestored = await surface.getAttribute("class");
+          const bottomActive = await bottom.getAttribute("class");
+          await captureLayout(page, theme, "bottom-restored");
+
+          await right.click();
+          await expect.poll(() => surface.getAttribute("class")).toContain("tp--right");
+          await captureLayout(page, theme, "right");
+          await fill.click();
+          await expect.poll(() => surface.getAttribute("class")).toContain("tp--main");
+          expect(await fill.getAttribute("class")).toContain("is-active");
+          await captureLayout(page, theme, "right-fill");
+          await fill.click();
+          const rightRestored = await surface.getAttribute("class");
+          const rightActive = await right.getAttribute("class");
+          await captureLayout(page, theme, "right-restored");
+
+          expect(bottomRestored).toContain("tp--bottom");
+          expect(bottomActive).toContain("is-active");
+          expect(rightRestored).toContain("tp--right");
+          expect(rightActive).toContain("is-active");
+        },
+      );
+    },
+  );
+});


### PR DESCRIPTION
Closes #122397

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where Control UI users who selected **Fill main content area** for the terminal could not use the same control to return to their prior bottom or right layout.

## Why This Change Was Made

In this PR, the dock layout controller records the prior supported dock alongside the active dock and owns the toggle back from `main`. The terminal toolbar and catalog-open path use that owner-level transition, so the restore target survives panel remounts instead of being inferred by the view.

History for #120708 describes `main` as a switchable, persisted third placement and does not establish one-way behavior. The added persisted fact is the smallest owner-level capability needed for the requested toggle; production delta is +26 lines (tests: +165 net).

## User Impact

Selecting **Fill main content area** a second time returns the terminal to the preceding bottom or right layout. The active placement remains visible throughout, in both light and dark themes.

## Evidence

All test, build, and browser proof below ran remotely on Blacksmith Testbox. No local tests were run.

### State matrix

Each row uses a populated chat transcript. “Baseline” is the second click before the fix; “PR” shows initial → fill → second-click restore plus the active-button crops.

| Case | Expected and rendered | Screenshots |
| --- | --- | --- |
| `bottom → fill → bottom` · light | Baseline remained in fill. In this PR the second click restores bottom; fill is active only in the middle state, then bottom is active. | **Baseline after second click**<br><img alt="Light bottom baseline remains in fill after second click" width="260" src="https://github.com/user-attachments/assets/21894def-0540-47b4-88eb-c278d47b26bc"><br>**PR initial → fill → restored**<br><img alt="Light bottom initial populated chat context" width="180" src="https://github.com/user-attachments/assets/d500f497-605c-4fe2-9933-0a3944d63bbe"> <img alt="Light bottom fill context" width="180" src="https://github.com/user-attachments/assets/2d08bb26-6667-4584-89b3-0184c08de45d"> <img alt="Light bottom restored context" width="180" src="https://github.com/user-attachments/assets/bdb9d2cd-5a17-4a7e-a069-637f6c271552"><br>**Active controls: fill → bottom**<br><img alt="Light fill button active" width="240" src="https://github.com/user-attachments/assets/cf241d8f-a1da-44e2-a3e8-cf365d9840ec"> <img alt="Light bottom button active after restore" width="240" src="https://github.com/user-attachments/assets/5ec680ce-78b7-4ef6-8d99-2c3fecb8572e"> |
| `bottom → fill → bottom` · dark | Baseline remained in fill. In this PR the second click restores bottom with the corresponding active state. | **Baseline after second click**<br><img alt="Dark bottom baseline remains in fill after second click" width="260" src="https://github.com/user-attachments/assets/60f62f64-d1a9-4499-b0c6-b21e2bd78945"><br>**PR initial → fill → restored**<br><img alt="Dark bottom initial populated chat context" width="180" src="https://github.com/user-attachments/assets/a2bd60f7-86ec-4367-9405-49383f0f0e1c"> <img alt="Dark bottom fill context" width="180" src="https://github.com/user-attachments/assets/2c388ce8-3c3e-4ccb-ad97-61c41c94e19b"> <img alt="Dark bottom restored context" width="180" src="https://github.com/user-attachments/assets/488846d1-954f-4ed0-b64c-fa3c8b2b56f7"><br>**Active controls: fill → bottom**<br><img alt="Dark fill button active" width="240" src="https://github.com/user-attachments/assets/1ff5932f-e676-4b26-b9f2-b5ec5a9174b2"> <img alt="Dark bottom button active after restore" width="240" src="https://github.com/user-attachments/assets/eb89c48d-1e74-4002-84e7-505a2c860f84"> |
| `right → fill → right` · light | Baseline remained in fill. In this PR the second click restores the split/right layout and its active state. | **Baseline after second click**<br><img alt="Light right baseline remains in fill after second click" width="260" src="https://github.com/user-attachments/assets/ad330986-c1e3-4a0e-9c2f-68763a4f0df9"><br>**PR initial → fill → restored**<br><img alt="Light right initial populated chat context" width="180" src="https://github.com/user-attachments/assets/8c943f41-795f-4456-abe8-214c3e24a1aa"> <img alt="Light right fill context" width="180" src="https://github.com/user-attachments/assets/e0fe8fc0-574d-4135-acc3-ebde0efa3102"> <img alt="Light right restored split context" width="180" src="https://github.com/user-attachments/assets/f0063113-1119-4c21-96a2-90f4c86fdb64"><br>**Active controls: fill → right**<br><img alt="Light fill button active from right" width="240" src="https://github.com/user-attachments/assets/ef6611a6-ceca-4149-9e76-c6ea4d33bf47"> <img alt="Light right button active after restore" width="240" src="https://github.com/user-attachments/assets/41731ab1-3b12-40e9-8913-91f8b77e24cd"> |
| `right → fill → right` · dark | Baseline remained in fill. In this PR the second click restores the split/right layout and its active state. | **Baseline after second click**<br><img alt="Dark right baseline remains in fill after second click" width="260" src="https://github.com/user-attachments/assets/ea24f0b7-e417-4521-a60e-c1fc8b826316"><br>**PR initial → fill → restored**<br><img alt="Dark right initial populated chat context" width="180" src="https://github.com/user-attachments/assets/1c722c94-44df-4191-a74a-4886d0e51a29"> <img alt="Dark right fill context" width="180" src="https://github.com/user-attachments/assets/058b65e0-e2ed-4fce-9251-2eef1c5302b0"> <img alt="Dark right restored split context" width="180" src="https://github.com/user-attachments/assets/432bacdd-2bd5-4cb4-a6c2-456e2e665c7f"><br>**Active controls: fill → right**<br><img alt="Dark fill button active from right" width="240" src="https://github.com/user-attachments/assets/da7f35a6-292b-43a3-81b3-9e6765f0aa09"> <img alt="Dark right button active after restore" width="240" src="https://github.com/user-attachments/assets/7eb7ede2-1695-45ef-ac58-84b074ef11c8"> |

### Remote validation

- Baseline regression: `terminal-panel-layout.e2e.test.ts` failed 2/2 in light and dark because the second click still rendered `tp--main`.
- Focused component suites: 28/28 passed (`dock-panel-layout.test.ts`, `terminal-panel.test.ts`).
- Post-fix browser suite: 2/2 passed, covering bottom and right restore plus active-state assertions in both themes.
- Final rebased head `100588fd21c29f34be525289dd3cc93050a9cf3c`: remote `pnpm check:changed` passed, including format, i18n, dead-code, typechecks, and lint ([Testbox Actions run](https://github.com/openclaw/openclaw/actions/runs/31566476411)).
- Screenshot/red→green lease: `tbx_01kzt68fxjp2rpdgtsan2j0yf5` ([Actions run](https://github.com/openclaw/openclaw/actions/runs/31565865699)); all 48 downloaded PNGs were inspected before upload.
- Technical deslop and final autoreview: clean; no actionable findings.

### Visual re-review — judge gaps (remote Testbox)

Reproof on unchanged head `100588fd21c29f34be525289dd3cc93050a9cf3c`: remote lease `tbx_01kztgc86mftj2rvbhcvc66j47`, [Actions run](https://github.com/openclaw/openclaw/actions/runs/31577175687). The temporary capture harness passed 2/2 (light and dark); all 20 PNGs below were inspected at original resolution. No code change or visual defect was found.

| Case | Expected → rendered | Light evidence | Dark evidence |
| --- | --- | --- | --- |
| Hover on Fill | Toolbar hover remains legible and Fill target is visible in the populated transcript. | <img alt="light fill hover context" width="220" src="https://github.com/user-attachments/assets/8be671e5-a2fe-44b9-af02-016d7932b731"> <img alt="light fill hover crop" width="220" src="https://github.com/user-attachments/assets/1f8f0654-4360-4da3-b1aa-01d10dcaf416"> | <img alt="dark fill hover context" width="220" src="https://github.com/user-attachments/assets/c4675e89-2cb1-49b6-b717-340e242cbf2e"> <img alt="dark fill hover crop" width="220" src="https://github.com/user-attachments/assets/938d80cd-bafa-40c9-8f02-13708fa23ec0"> |
| Focus on Fill | Keyboard focus is visible on the Fill control without changing layout. | <img alt="light fill focus context" width="220" src="https://github.com/user-attachments/assets/f2be39a6-1a30-4820-baee-a50366a82622"> <img alt="light fill focus crop" width="220" src="https://github.com/user-attachments/assets/d62a1dbc-75db-44d9-8dea-7af3b64993e1"> | <img alt="dark fill focus context" width="220" src="https://github.com/user-attachments/assets/f741bebe-dc57-4ca8-897f-88670e0f6478"> <img alt="dark fill focus crop" width="220" src="https://github.com/user-attachments/assets/a80fbdee-694c-45eb-8373-aeaabb54617b"> |
| Constrained overflow (640×420) | Main-fill remains contained; toolbar and internal scroll remain intact at a narrow viewport. | <img alt="light constrained context" width="220" src="https://github.com/user-attachments/assets/5008a7e2-402b-4553-8a4b-f0610aa8aca2"> <img alt="light constrained crop" width="220" src="https://github.com/user-attachments/assets/6d072928-d17f-44a9-afbe-3c183356a0df"> | <img alt="dark constrained context" width="220" src="https://github.com/user-attachments/assets/dbeb36f5-794a-44c2-8f30-c2ea7c3adc3d"> <img alt="dark constrained crop" width="220" src="https://github.com/user-attachments/assets/6dcb0d05-0269-4e69-8cf8-46ae67424576"> |
| Close → reopen | Main-fill survives close/reopen and remains the active layout. | <img alt="light close reopen context" width="220" src="https://github.com/user-attachments/assets/450287b7-e521-4d03-baa7-68227c9af317"> <img alt="light close reopen crop" width="220" src="https://github.com/user-attachments/assets/3bae6796-5e3c-4b11-b797-84dfce467970"> | <img alt="dark close reopen context" width="220" src="https://github.com/user-attachments/assets/006827ba-4f32-479e-8fe7-bc0c5731cecf"> <img alt="dark close reopen crop" width="220" src="https://github.com/user-attachments/assets/24ffd222-47e8-4459-bda3-4cb99433df0d"> |
| Restore → remount | Restored bottom mode and its active state survive remount. | <img alt="light bottom remount context" width="220" src="https://github.com/user-attachments/assets/0c81f0a1-81bd-4dcc-9b55-2ccc7f9022b9"> <img alt="light bottom remount crop" width="220" src="https://github.com/user-attachments/assets/06759e7c-6c98-4583-90c9-82d1a90a14d6"> | <img alt="dark bottom remount context" width="220" src="https://github.com/user-attachments/assets/7499e060-4f3b-4089-860a-30ec9814d203"> <img alt="dark bottom remount crop" width="220" src="https://github.com/user-attachments/assets/2b1a1862-726b-489a-87c6-064d0a25e3bf"> |

Remote command: `node --import tsx scripts/test-projects.mts ui/src/e2e/terminal-panel-visual-gaps.e2e.test.ts` with `OPENCLAW_TERMINAL_GAPS_SCREENSHOT_DIR=.artifacts/terminal-visual-gaps`. No local tests/build, no push/rebase, no landing.
