### PR TITLE
fix(discord): channel stops responding for up to 24 hours after one undeliverable message

### DIFF
--- a/extensions/discord/src/monitor/ingress.test.ts
+++ b/extensions/discord/src/monitor/ingress.test.ts
@@ -247,4 +247,47 @@ describe("Discord durable ingress", () => {
       }
     });
   });
+
+  it("dead-letters a retryable poison event instead of holding its lane for a day", async () => {
+    vi.useFakeTimers();
+    try {
+      await withQueue(async (queue) => {
+        const dispatch = vi.fn(async () => {
+          throw new Error("poison");
+        });
+        const monitor = createDiscordIngressMonitor({
+          accountId: "default",
+          client: {} as never,
+          runtime: runtime(),
+          queue,
+          dispatch,
+        });
+        monitor.start();
+        try {
+          const poison = createRawMessage("1006");
+          void monitor.accept(poison).catch(() => undefined);
+
+          // Ten virtual minutes is far beyond the retry ladder, and far short of
+          // the generic 24-hour dead-letter floor. If Discord inherits that floor
+          // the row is still pending here and its channel lane is blocked.
+          let terminal = false;
+          for (let tick = 0; tick < 40 && !terminal; tick += 1) {
+            await vi.advanceTimersByTimeAsync(15_000);
+            const verdict = await queue.enqueue("1006", payloadFor(poison));
+            terminal = verdict.kind === "failed";
+          }
+
+          expect(
+            terminal,
+            "poison event never reached a terminal state within ten virtual minutes: Discord is inheriting the generic 24-hour dead-letter floor, so one undeliverable event blocks its channel lane for a full day",
+          ).toBe(true);
+          expect(dispatch.mock.calls.length).toBeGreaterThan(1);
+        } finally {
+          await monitor.stop();
+        }
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/extensions/discord/src/monitor/ingress.ts
+++ b/extensions/discord/src/monitor/ingress.ts
@@ -3,6 +3,7 @@ import { GatewayDispatchEvents, type APIMessage } from "discord-api-types/v10";
 import {
   createChannelIngressError,
   createChannelIngressMonitor,
+  DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
   type ChannelIngressQueue,
   type ChannelIngressMonitorDeliveryResult,
   type ChannelIngressMonitorLifecycle,
@@ -147,6 +148,13 @@ export function createDiscordIngressMonitor(params: {
     },
     appendRetryDelaysMs: [0],
     drain: {
+      retryPolicy: {
+        maxAttempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+        // Discord drains each channel lane serially, so the generic 24-hour
+        // dead-letter floor lets one poison event block its channel lane for a
+        // full day while live traffic queues behind it. Matches LINE and Zalo.
+        deadLetterMinAgeMs: 0,
+      },
       resolveNonRetryableFailure: (error) => {
         if (error instanceof DiscordIngressPayloadError) {
           return { reason: "invalid-event", message: error.message };


### PR DESCRIPTION
Closes #122465

## What Problem This Solves

Fixes an issue where a Discord channel would stop responding for up to 24 hours after a single inbound message failed to be delivered. The channel goes quiet with no operator-visible error: later messages are accepted and queued, but none of them are processed until the stuck message finally ages out roughly a day later.

In production this was observed as one Discord lane holding **1000 pending events, the oldest 35.6 hours old**.

## Why This Change Was Made

Discord's durable ingress drains each channel lane **serially**, and it did not pass a `drain.retryPolicy`, so it inherited the generic default from `src/channels/message/ingress-monitor.ts:311-316`.

The terminal condition is an `AND` (`src/channels/message/ingress-retry-policy.ts:88`):

```ts
return attempt >= maxAttempts && now - event.receivedAt >= deadLetterMinAgeMs;
```

`maxAttempts` (8) is exhausted after ~4 minutes of backoff, but `deadLetterMinAgeMs` defaults to 24 hours. So the event finishes retrying, fails to become terminal, and sits at the head of its lane for the rest of the day while live traffic queues behind it.

This change gives Discord the same `retryPolicy` that LINE and Zalo already carry: keep the standard 8-attempt ladder, but drop the 24-hour floor so an exhausted event dead-letters immediately and its lane resumes.

LINE fixed exactly this in #109819 with the comment *"LINE previously dead-lettered on attempt eight. The generic 24-hour floor would let one poison event block its user/group lane for a full day."* Zalo carries the same override at `extensions/zalo/src/webhook-spool.ts:187`. Discord moved onto the shared durable ingress monitor in #111186 without one.

**Non-goal / scope:** this PR changes Discord only. 19 of the 22 ingress-owning channel plugins currently inherit the same 24-hour floor, and I suspect the shared default is the real defect — but Discord is the only channel I have direct production evidence for, so I am not speculatively changing behaviour for channels I cannot demonstrate a failure on. See the footnote below if maintainers want to take the general case.

## User Impact

A deterministic failure on one Discord message no longer silently mutes that channel for a day. The bad event is dead-lettered once its retries are exhausted (~4 minutes) and the channel keeps serving everyone else. Retry behaviour for transient failures is unchanged — the same 8-attempt ladder still runs.

## Evidence

**New regression test**, `extensions/discord/src/monitor/ingress.test.ts` — "dead-letters a retryable poison event instead of holding its lane for a day". It uses fake timers to advance ten virtual minutes: past the ~4-minute retry ladder, far short of 24 hours, so it is only satisfiable by the fix.

I verified the test actually discriminates rather than merely passing — with the one-line fix reverted and the test kept, it fails with:

```
poison event never reached a terminal state within ten virtual minutes:
Discord is inheriting the generic 24-hour dead-letter floor, so one
undeliverable event blocks its channel lane for a full day
```

Restoring the fix turns it green again.

**Full extension suite** (`pnpm test:extension discord`) against this branch:

```
Test Files  214 passed (214)
     Tests  2579 passed (2579)
  Duration  42.05s
```

**Production observation** that motivated it: the 1000 pending rows had `attempts` **min=0, max=0** — they had never been dispatched at all. That rules out retry amplification and confirms head-of-line blockage: the queue was not busy, it was waiting on one event that could not die.

---

<details>
<summary>Footnote: the same default is inherited by 19 other channels</summary>

While confirming the cause I enumerated the ingress-owning channel plugins. Of 22, only **LINE**, **Zalo** and (with this PR) **Discord** override `deadLetterMinAgeMs`; the other 19 inherit the 24-hour floor:

`feishu, googlechat, imessage, irc, matrix, mattermost, msteams, nextcloud-talk, nostr, policy, signal, slack, sms, synology-chat, telegram, tlon, twitch, whatsapp, zalouser`

Two teams independently hit this and opted out with near-identical comments, which suggests the generic default may be wrong rather than the plugins being under-configured. I have deliberately **not** included that change here: I can only prove the Discord case, and a 19-channel behaviour change deserves its own PR and its own review. Flagging it in case a maintainer wants to take the general fix — happy to open it if that is wanted.

Unrelated but noticed in the same sweep: `whatsapp` sets `failedMaxEntries: 450`, which is far below its siblings (1k–5k) and may evict failed rows that are still referenced.

</details>
