### PR TITLE
fix(agents): keep concurrent isolated completions independent

### DIFF
--- a/src/agents/isolated-completion.test.ts
+++ b/src/agents/isolated-completion.test.ts
@@ -777,7 +777,7 @@ describe("runIsolatedCompletion", () => {
       admitted: AdmittedRunContext;
       authority: AgentRunDelegatedAuthority;
       params: IsolatedCliRunParams;
-      release: ReturnType<typeof createDeferred>;
+      release: ReturnType<typeof createDeferred<void>>;
     }> = [];
     mocks.runCliAgent.mockImplementation(async (params) => {
       const admitted = await params.preparedRunAdmission.admit("embedded");

--- a/src/agents/isolated-completion.test.ts
+++ b/src/agents/isolated-completion.test.ts
@@ -1,8 +1,25 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import {
+  type AgentRunDelegatedAuthority,
+  validateAgentRunDelegatedAuthority,
+} from "../infra/agent-run-registry.js";
 import type { AssistantMessage } from "../llm/types.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { mintSecretSentinel } from "../secrets/sentinel.js";
+import {
+  getAdmittedRunDelegatedAuthority,
+  type AdmittedRunContext,
+  type PreparedAgentRunAdmission,
+} from "./admitted-run-context.js";
 import type { AgentHarness } from "./harness/types.js";
+
+type IsolatedCliRunParams = {
+  preparedRunAdmission: PreparedAgentRunAdmission;
+  prompt: string;
+  runId: string;
+  sessionId: string;
+};
 
 const mocks = vi.hoisted(() => ({
   acquireAgentRunPreparedModelRuntime: vi.fn(),
@@ -20,7 +37,7 @@ const mocks = vi.hoisted(() => ({
   resolveCliRuntimeExecutionProvider: vi.fn<() => string | undefined>(() => undefined),
   resolveEmbeddedCliBackendDispatchEligibility: vi.fn(() => undefined),
   resolveEffectiveAgentRuntime: vi.fn(() => "codex"),
-  runCliAgent: vi.fn(),
+  runCliAgent: vi.fn<(params: IsolatedCliRunParams) => Promise<unknown>>(),
 }));
 
 vi.mock("./agent-scope.js", () => ({
@@ -749,6 +766,81 @@ describe("runIsolatedCompletion", () => {
         cliToolAvailability: { native: [], openClaw: [] },
       }),
     );
+  });
+
+  it("keeps concurrent CLI isolated completions independently admitted", async () => {
+    mocks.isCliRuntimeAliasForProvider.mockReturnValue(true);
+    const clock = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const firstStarted = createDeferred();
+    const bothStarted = createDeferred();
+    const calls: Array<{
+      admitted: AdmittedRunContext;
+      authority: AgentRunDelegatedAuthority;
+      params: IsolatedCliRunParams;
+      release: ReturnType<typeof createDeferred>;
+    }> = [];
+    mocks.runCliAgent.mockImplementation(async (params) => {
+      const admitted = await params.preparedRunAdmission.admit("embedded");
+      const authority = getAdmittedRunDelegatedAuthority(admitted);
+      if (!authority) {
+        throw new Error("expected active isolated completion authority");
+      }
+      const release = createDeferred();
+      calls.push({ admitted, authority, params, release });
+      if (calls.length === 1) {
+        firstStarted.resolve();
+      }
+      if (calls.length === 2) {
+        bothStarted.resolve();
+      }
+      await release.promise;
+      return { payloads: [{ text: `done: ${params.prompt}` }] };
+    });
+
+    const first = runIsolatedCompletion({ ...request(), prompt: "first" });
+    let second: ReturnType<typeof runIsolatedCompletion> | undefined;
+    try {
+      await Promise.race([
+        firstStarted.promise,
+        first.then(() => {
+          throw new Error("first isolated completion settled before reaching the barrier");
+        }),
+      ]);
+      second = runIsolatedCompletion({ ...request(), prompt: "second" });
+      await Promise.race([
+        bothStarted.promise,
+        Promise.all([first, second]).then(() => {
+          throw new Error("isolated completions settled before reaching the barrier");
+        }),
+      ]);
+      const firstCall = calls.find(({ params }) => params.prompt === "first");
+      const secondCall = calls.find(({ params }) => params.prompt === "second");
+      if (!firstCall || !secondCall) {
+        throw new Error("expected both isolated completions to start");
+      }
+      expect(firstCall.params.runId).toBe(firstCall.params.sessionId);
+      expect(secondCall.params.runId).toBe(secondCall.params.sessionId);
+      expect(firstCall.params.runId).not.toBe(secondCall.params.runId);
+      expect(firstCall.admitted.operationalRunInstance.runId).toBe(firstCall.params.runId);
+      expect(secondCall.admitted.operationalRunInstance.runId).toBe(secondCall.params.runId);
+      expect(validateAgentRunDelegatedAuthority(firstCall.authority)).toBe(true);
+      expect(validateAgentRunDelegatedAuthority(secondCall.authority)).toBe(true);
+
+      firstCall.release.resolve();
+      await expect(first).resolves.toMatchObject({ text: "done: first" });
+      expect(validateAgentRunDelegatedAuthority(firstCall.authority)).toBe(false);
+      expect(validateAgentRunDelegatedAuthority(secondCall.authority)).toBe(true);
+
+      secondCall.release.resolve();
+      await expect(second).resolves.toMatchObject({ text: "done: second" });
+      expect(validateAgentRunDelegatedAuthority(secondCall.authority)).toBe(false);
+    } finally {
+      for (const call of calls) {
+        call.release.resolve();
+      }
+      await Promise.allSettled(second ? [first, second] : [first]);
+      clock.mockRestore();
+    }
   });
 
   it("keeps unavailable CLI usage absent", async () => {

--- a/src/agents/isolated-completion.ts
+++ b/src/agents/isolated-completion.ts
@@ -5,6 +5,7 @@
  * transcript, hook, and delivery lifecycle. Execution owners either prove a
  * literal empty native tool surface or fail before inference starts.
  */
+import { randomUUID } from "node:crypto";
 import path from "node:path";
 import type { ThinkLevel } from "../auto-reply/thinking.js";
 import { getRuntimeConfig } from "../config/config.js";
@@ -187,7 +188,7 @@ async function runCliIsolatedCompletion(params: {
     { rootDir: resolvePreferredOpenClawTmpDir(), prefix: "openclaw-isolated-completion-" },
     async ({ dir }) => {
       const { runCliAgent } = await import("./cli-runner.runtime.js");
-      const sessionId = `isolated-completion-${Date.now()}`;
+      const sessionId = `isolated-completion-${randomUUID()}`;
       const config = params.request.config ?? getRuntimeConfig();
       const preparedRunAdmission = prepareSystemAgentRunAdmission(
         config,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where two CLI-backed isolated completions starting in the same millisecond could receive the same internal run identity. The second admission then looked like a replacement execution and could revoke or overwrite the first completion's still-live authority and supervisor state.

## Why This Change Was Made

The isolated-completion producer now mints one UUID-backed wrapper identity and continues using that exact value for both its session ID and run ID. Registry replacement semantics and supervisor ownership remain unchanged; they were correctly rejecting distinct operational instances that shared one key.

The regression holds two real prepared admissions open concurrently with a frozen clock, proves their IDs and delegated authorities remain independent, then verifies closing one admission does not revoke the other.

AI-assisted: yes. The final implementation and concurrency test were manually reviewed and passed fresh structured autoreview.

## User Impact

Concurrent internal side-question/completion work no longer fails or cancels the wrong run merely because both operations started within the same millisecond. There is no public API, protocol, configuration, schema, or migration change.

## Evidence

- Pre-fix regression: both concurrent calls received `isolated-completion-1000`, causing the authority boundary to collide.
- `node scripts/run-vitest.mjs src/agents/isolated-completion.test.ts` — 21/21 passed on the final rebased head.
- `node scripts/check-changed.mjs -- src/agents/isolated-completion.ts src/agents/isolated-completion.test.ts` — passed on Testbox `tbx_01kzt7gr5r8jbcdxcy5q0y31bd` ([run](https://github.com/openclaw/openclaw/actions/runs/31567078253)).
- Final rebase retained identical patch IDs; focused test, formatting, and `git diff --check` passed again.
- Hosted exact-head CI — green on attempt 2 ([run](https://github.com/openclaw/openclaw/actions/runs/31567842974)); attempt 1 only hit an unrelated `src/infra/ssh-tunnel.test.ts` timeout, which passed unchanged on rerun.
- Production: +2/−1 lines; tests: +93/−1 lines. The test growth is the real concurrent admission/authority lifecycle proof; production remains a one-line owner fix plus import.
