### PR TITLE
test(agents): remove exact duplicate cases

### DIFF
--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -790,25 +790,6 @@ describe("exec approval followup", () => {
     },
   );
 
-  it("accepts direct followup success without a delivery status", async () => {
-    vi.mocked(sendMessage).mockResolvedValueOnce({
-      channel: "discord",
-      to: "123",
-      via: "gateway",
-      mediaUrl: null,
-      result: { messageId: "gateway-message-1" },
-    });
-
-    await expect(
-      sendExecApprovalFollowup({
-        approvalId: "req-gateway-compatible",
-        turnSourceChannel: "discord",
-        turnSourceTo: "123",
-        resultText: "Exec finished (gateway id=req-gateway-compatible, code 0)\nall good",
-      }),
-    ).resolves.toBe(true);
-  });
-
   it("redacts credentials before direct delivery", async () => {
     const secret = "sk-abcdefghijklmnopqrstuvwxyz123456";
 

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -4498,17 +4498,6 @@ describe("resolveCliNoOutputTimeoutMs", () => {
     expect(timeoutMs).toBe(480_000);
   });
 
-  it("lets configured agent default timeouts lift the default resume no-output ceiling", () => {
-    const timeoutMs = resolveCliNoOutputTimeoutMs({
-      backend: { command: "codex" },
-      timeoutMs: 600_000,
-      runTimeoutOverrideMs: 600_000,
-      useResume: true,
-      trigger: "user",
-    });
-    expect(timeoutMs).toBe(480_000);
-  });
-
   it("keeps inherited user resume timeouts on the default resume no-output ceiling", () => {
     const timeoutMs = resolveCliNoOutputTimeoutMs({
       backend: { command: "codex" },

--- a/src/agents/embedded-agent-runner/extra-params.kilocode.test.ts
+++ b/src/agents/embedded-agent-runner/extra-params.kilocode.test.ts
@@ -124,17 +124,6 @@ describe("extra-params: Kilocode wrapper", () => {
     expect(headers?.["X-KILOCODE-FEATURE"]).toBe("openclaw");
   });
 
-  it("keeps Kilocode runtime wrapping under restrictive plugins.allow", () => {
-    delete process.env.KILOCODE_FEATURE;
-
-    const { headers } = applyAndCapture({
-      provider: "kilocode",
-      modelId: "anthropic/claude-sonnet-4",
-    });
-
-    expect(headers?.["X-KILOCODE-FEATURE"]).toBe("openclaw");
-  });
-
   it("does not inject header for non-kilocode providers", () => {
     const { headers } = applyAndCapture({
       provider: "openrouter",

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1451,36 +1451,6 @@ describe("runWithModelFallback", () => {
     expect(run).toHaveBeenCalledTimes(1);
   });
 
-  it("does not prepare agent harness plugins for forced OpenClaw runtime candidates", async () => {
-    const cfg = makeCfg({
-      models: {
-        providers: {
-          openai: {
-            baseUrl: "https://api.openai.com/v1",
-            agentRuntime: { id: "openclaw" },
-            models: [],
-          },
-        },
-      },
-    });
-    const prepareAgentHarnessRuntime = vi.fn(() => {
-      throw new Error("OpenClaw candidates should not prepare plugin harnesses");
-    });
-    const run = vi.fn().mockResolvedValueOnce("ok");
-
-    const result = await runWithModelFallback({
-      cfg,
-      provider: "openai",
-      model: "gpt-5.5",
-      prepareAgentHarnessRuntime,
-      run,
-    });
-
-    expect(result.result).toBe("ok");
-    expect(prepareAgentHarnessRuntime).not.toHaveBeenCalled();
-    expect(run).toHaveBeenCalledTimes(1);
-  });
-
   it("does not prepare agent harness plugins for implicit Codex candidates", async () => {
     const cfg = makeCfg();
     const prepareAgentHarnessRuntime = vi.fn(() => {

--- a/src/agents/model-runtime-aliases.test.ts
+++ b/src/agents/model-runtime-aliases.test.ts
@@ -131,17 +131,6 @@ describe("resolveCliRuntimeExecutionProvider", () => {
     ).toBe("claude-cli");
   });
 
-  it("uses prepared Anthropic auth choice aliases without metadata discovery", () => {
-    expect(
-      resolveCliRuntimeExecutionProvider({
-        authProfileId: "anthropic:claude-cli",
-        cfg: createAnthropicAuthConfig({ order: ["anthropic:api"] }),
-        provider: "anthropic",
-        modelId: "opus-4.7",
-      }),
-    ).toBe("claude-cli");
-  });
-
   it("does not override an explicit OpenClaw model-runtime policy with CLI auth", () => {
     // Runtime policy is more explicit than profile order, so CLI auth cannot
     // force a model onto the CLI harness when config says OpenClaw.

--- a/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
+++ b/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
@@ -295,32 +295,6 @@ describe("openai transport stream", () => {
     expect(params.prompt_cache_retention).toBeUndefined();
   });
 
-  it("treats canonical OpenAI Codex responses models as native Codex responses", () => {
-    const params = buildOpenAIResponsesParams(
-      makeResponsesModel({
-        id: "gpt-5.5",
-        name: "GPT-5.5",
-        api: "openai-chatgpt-responses",
-        baseUrl: "https://chatgpt.com/backend-api/codex",
-        contextWindow: 400000,
-        maxTokens: 128000,
-      }),
-      {
-        systemPrompt: "",
-        messages: [{ role: "user", content: "Reply OK", timestamp: 1 }],
-        tools: [],
-      } as never,
-      {
-        maxTokens: 16,
-        sessionId: "session-123",
-      },
-    ) as Record<string, unknown>;
-
-    expect(params.instructions).toBe("Follow the user request.");
-    expect(params.max_output_tokens).toBeUndefined();
-    expect(params.prompt_cache_retention).toBeUndefined();
-  });
-
   it("does not add fallback instructions for custom Codex-compatible responses backends", () => {
     const params = buildOpenAIResponsesParams(
       makeResponsesModel({

--- a/src/agents/sandbox/context.user-fallback.test.ts
+++ b/src/agents/sandbox/context.user-fallback.test.ts
@@ -55,16 +55,6 @@ describe("resolveSandboxDockerUser", () => {
     expect(resolved.user).toBe("1001:1002");
   });
 
-  it("applies workspace ownership fallback for rootful Podman", async () => {
-    const resolved = await resolveSandboxDockerUser({
-      backend: "podman",
-      docker: baseDocker,
-      workspaceDir: "/tmp/workspace",
-      stat: async () => ({ uid: 1001, gid: 1002 }),
-    });
-    expect(resolved.user).toBe("1001:1002");
-  });
-
   it("leaves Podman user unset when host ownership IDs are zero", async () => {
     const docker = { ...baseDocker };
     const resolved = await resolveSandboxDockerUser({

--- a/src/agents/subagents/spawn/subagent-spawn.mode-session-diagnostics.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.mode-session-diagnostics.test.ts
@@ -99,26 +99,4 @@ describe('spawnSubagentDirect mode="session" with thread binding-capable channel
       expect(result.error).toContain("sessions_send");
     }
   });
-
-  it("rejects thread=true with actionable guidance when hooks do not bind the requester channel", async () => {
-    const result = await spawnSubagentDirect(
-      {
-        task: "persistent planning session",
-        mode: "session",
-        thread: true,
-        context: "isolated",
-      },
-      {
-        agentSessionKey: "agent:main:main",
-        agentChannel: "webchat",
-      },
-    );
-
-    expect(result.status).toBe("error");
-    if (result.status === "error") {
-      expect(result.error).toContain("not running on a channel");
-      expect(result.error).toContain('mode="run"');
-      expect(result.error).toContain("sessions_send");
-    }
-  });
 });

--- a/src/agents/tools/video-generate-tool.test.ts
+++ b/src/agents/tools/video-generate-tool.test.ts
@@ -437,24 +437,6 @@ describe("createVideoGenerateTool", () => {
     expect(properties.audioRoles).toBeUndefined();
   });
 
-  it("hides reference-audio params for known video provider aliases without audio input support", () => {
-    const properties = toolParameterProperties(
-      createVideoGenerateTool({
-        config: asConfig({
-          agents: {
-            defaults: {
-              videoGenerationModel: { primary: "openai/sora-2" },
-            },
-          },
-        }),
-      }),
-    );
-
-    expect(properties.audioRef).toBeUndefined();
-    expect(properties.audioRefs).toBeUndefined();
-    expect(properties.audioRoles).toBeUndefined();
-  });
-
   it("exposes reference-audio params when the configured video provider declares audio inputs", () => {
     const properties = toolParameterProperties(
       createVideoGenerateTool({

--- a/src/llm/providers/stream-wrappers/openai.test.ts
+++ b/src/llm/providers/stream-wrappers/openai.test.ts
@@ -655,16 +655,6 @@ describe("createOpenAIThinkingLevelWrapper", () => {
     expect(payloads[0]?.reasoning).toBeUndefined();
   });
 
-  it("overrides existing reasoning.effort from upstream wrappers", () => {
-    const { baseStreamFn, payloads } = createPayloadCapture({
-      initialReasoning: { effort: "none" },
-    });
-    const wrapped = createOpenAIThinkingLevelWrapper(baseStreamFn, "medium");
-    void wrapped(codexModel, { messages: [] }, {});
-
-    expect(payloads[0]?.reasoning).toEqual({ effort: "medium" });
-  });
-
   it("returns underlying streamFn unchanged when thinkingLevel is undefined", () => {
     const { baseStreamFn } = createPayloadCapture();
     const wrapped = createOpenAIThinkingLevelWrapper(baseStreamFn, undefined);


### PR DESCRIPTION
## What Problem This Solves

Ten agent/runtime tests duplicated another case with the same inputs and assertions, or fabricated an unreachable result shape. They added maintenance and execution cost without detecting a distinct regression.

## Why This Change Was Made

Delete the later duplicate in each pair while retaining the canonical owner test and every neighboring distinct case. This includes the newly landed status-less exec follow-up test, whose mocked Gateway result cannot occur because that path always uses gateway-owned durable delivery.

## User Impact

No intended user-visible change. Agent, provider, sandbox, fallback, subagent, media-tool, and delivery behavior is unchanged; CI runs fewer redundant cases.

## Evidence

- Ten affected owner suites: 397 tests passed across six Vitest shards.
- Full changed-file gate passed formatting, core test typecheck/lint, dead exports, boundaries, max-lines ratchet, schema/storage guards, and cycle checks. Blacksmith/Testbox was unavailable on this host, so trusted heavy proof fell back locally.
- Structured autoreview and deleted-content secret scan: clean.
- `git diff --check`: clean.
- Test-only delta: -168 lines. No production or test-support seams added.

AI-assisted maintenance cleanup; paired callbacks, production reachability, caller paths, and history were reviewed directly.
