### PR TITLE
fix(ui): use blue tokens for transcript links

### DIFF
--- a/ui/src/e2e/github-link-hovercard.e2e.test.ts
+++ b/ui/src/e2e/github-link-hovercard.e2e.test.ts
@@ -39,6 +39,11 @@ async function expectText(locator: Locator, text: string): Promise<void> {
   await expect.poll(() => locator.textContent()).toContain(text);
 }
 
+const TRANSCRIPT_LINK_TOKENS = {
+  dark: "oklch(70.7% 0.165 254.624)",
+  light: "oklch(48.8% 0.243 264.376)",
+} as const;
+
 describeControlUiE2e("GitHub link hover cards", () => {
   beforeAll(async () => {
     if (!chromiumAvailable) {
@@ -121,12 +126,17 @@ describeControlUiE2e("GitHub link hover cards", () => {
             {
               type: "text",
               text: [
-                "Review https://github.com/openclaw/openclaw/pull/99816,",
-                "then https://github.com/openclaw/openclaw/issues/99815.",
+                "### Release review",
+                "",
+                "The rollout plan is in [the docs](https://docs.openclaw.ai/web/control-ui).",
+                "",
+                "- Review https://github.com/openclaw/openclaw/pull/99816.",
+                "- Confirm https://github.com/openclaw/openclaw/issues/99815.",
+                "- Update `README.md:12` and ui/src/styles/chat/text.css.",
+                "- Ask the [release crew](mailto:release@example.com) if the [repository](https://github.com/openclaw/openclaw) needs another pass.",
+                "",
                 "A [missing item](https://github.com/openclaw/openclaw/issues/999999) stays usable.",
-                "The [repository](https://github.com/openclaw/openclaw) has no item preview.",
-                "Styling notes live in [the docs](https://docs.openclaw.ai/web/control-ui).",
-              ].join(" "),
+              ].join("\n"),
             },
           ],
           role: "assistant",
@@ -146,28 +156,87 @@ describeControlUiE2e("GitHub link hover cards", () => {
     });
     await page.goto(`${server.baseUrl}chat`);
 
-    const message = page.locator(".chat-text").filter({ hasText: "Review" });
+    const message = page.locator(".chat-text").filter({ hasText: "Release review" });
+    const pullLink = page.getByRole("link", { name: "openclaw/openclaw#99816" });
+    const docsLink = page.getByRole("link", { name: "the docs" });
+    const fileLink = page.locator('a.markdown-file-link[data-file-path="README.md"]');
+    const card = page.locator(".github-link-hovercard");
     const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
-    if (artifactDir) {
+    const capture = async (name: string, fullPage = false, target = message) => {
+      if (!artifactDir) {
+        return;
+      }
       await mkdir(artifactDir, { recursive: true });
-      await message.screenshot({ path: path.join(artifactDir, "github-references-light.png") });
+      if (fullPage) {
+        await page.screenshot({ fullPage: true, path: path.join(artifactDir, `${name}.png`) });
+        return;
+      }
+      await target.screenshot({ path: path.join(artifactDir, `${name}.png`) });
+    };
+    const expectTranscriptLinkColor = async (themeMode: keyof typeof TRANSCRIPT_LINK_TOKENS) => {
+      const expectedToken = TRANSCRIPT_LINK_TOKENS[themeMode];
+      const actualToken = await page
+        .locator("html")
+        .evaluate((element) => getComputedStyle(element).getPropertyValue("--chat-link").trim());
+      expect(actualToken).not.toBe("");
+      const [actualColor, expectedColor] = await page.evaluate(
+        (colors) => {
+          const probe = document.createElement("span");
+          document.body.append(probe);
+          const resolved = colors.map((color) => {
+            probe.style.color = color;
+            return getComputedStyle(probe).color;
+          });
+          probe.remove();
+          return resolved;
+        },
+        [actualToken, expectedToken],
+      );
+      expect(actualColor).toBe(expectedColor);
+      for (const link of [docsLink, pullLink, fileLink]) {
+        expect(await link.evaluate((element) => getComputedStyle(element).color)).toBe(
+          expectedColor,
+        );
+      }
+      expect(
+        await pullLink.evaluate((element) => getComputedStyle(element, "::before").backgroundColor),
+      ).toBe(expectedColor);
+      expect(
+        await fileLink.evaluate((element) => getComputedStyle(element, "::before").backgroundColor),
+      ).toBe(expectedColor);
+    };
+
+    await expect.poll(() => message.count()).toBe(1);
+    await capture("rest-light-context", true);
+    await capture("rest-light-crop");
+
+    if (artifactDir) {
       await page.emulateMedia({ colorScheme: "dark" });
       await expect.poll(() => page.locator("html").getAttribute("data-theme-mode")).toBe("dark");
-      await message.screenshot({ path: path.join(artifactDir, "github-references-dark.png") });
+      await capture("rest-dark-context", true);
+      await capture("rest-dark-crop");
       await page.emulateMedia({ colorScheme: "light" });
       await expect.poll(() => page.locator("html").getAttribute("data-theme-mode")).toBe("light");
     }
+    await expectTranscriptLinkColor("light");
+
+    await pullLink.focus();
+    await expectText(card, "Merged");
+    await capture("focus-light-context", true);
+    await capture("focus-light-crop");
+    await page.keyboard.press("Escape");
+    await expect.poll(() => card.count()).toBe(0);
+    await pullLink.evaluate((element) => element.blur());
 
     const longLink = page.getByRole("link", {
       name: "a-very-long-organization-name/a-very-long-repository-name#99817",
     });
+    const longMessage = longLink.locator("xpath=ancestor::*[contains(@class, 'chat-text')]");
     await page.setViewportSize({ height: 800, width: 360 });
     expect(await longLink.evaluate((element) => getComputedStyle(element).lineBreak)).toBe(
       "anywhere",
     );
-    const longMessageBox = await longLink
-      .locator("xpath=ancestor::*[contains(@class, 'chat-text')]")
-      .boundingBox();
+    const longMessageBox = await longMessage.boundingBox();
     const longLinkBox = await longLink.boundingBox();
     expect(longMessageBox).not.toBeNull();
     expect(longLinkBox).not.toBeNull();
@@ -175,21 +244,28 @@ describeControlUiE2e("GitHub link hover cards", () => {
     expect(longLinkBox!.x + longLinkBox!.width).toBeLessThanOrEqual(
       longMessageBox!.x + longMessageBox!.width,
     );
+    await capture("overflow-light-context", true);
+    await capture("overflow-light-crop", false, longMessage);
+    await page.emulateMedia({ colorScheme: "dark" });
+    await expect.poll(() => page.locator("html").getAttribute("data-theme-mode")).toBe("dark");
+    await capture("overflow-dark-context", true);
+    await capture("overflow-dark-crop", false, longMessage);
+    await page.emulateMedia({ colorScheme: "light" });
+    await expect.poll(() => page.locator("html").getAttribute("data-theme-mode")).toBe("light");
     await page.setViewportSize({ height: 800, width: 1180 });
-
-    const pullLink = page.getByRole("link", { name: "openclaw/openclaw#99816" });
 
     // The mark carries the link signal at rest, so the underline only returns on
     // hover. Non-GitHub links keep the base underline, which keeps the rule scoped.
     const decorationLine = (link: Locator) =>
       link.evaluate((element) => getComputedStyle(element).textDecorationLine);
     expect(await decorationLine(pullLink)).toBe("none");
-    expect(await decorationLine(page.getByRole("link", { name: "the docs" }))).toBe("underline");
+    expect(await decorationLine(docsLink)).toBe("underline");
 
     await pullLink.hover();
     await expect.poll(() => decorationLine(pullLink)).toBe("underline");
-    const card = page.locator(".github-link-hovercard");
     await expectText(card, "Merged");
+    await capture("hover-light-context", true);
+    await capture("hover-light-crop");
     await expectText(card, "openclaw/openclaw #99816");
     await expectText(card, "+101");
     await expectText(card, "−12");
@@ -235,11 +311,16 @@ describeControlUiE2e("GitHub link hover cards", () => {
     await expect.poll(() => page.locator("html").getAttribute("data-theme-mode")).toBe("dark");
     await pullLink.hover();
     await expectText(card, "Merged");
+    await expectTranscriptLinkColor("dark");
+    await capture("hover-dark-context", true);
+    await capture("hover-dark-crop");
     expect((await gateway.getRequests("controlUi.githubPreview")).length).toBe(3);
     await page.mouse.move(1, 1);
 
     await pullLink.focus();
     await expectText(card, "Merged");
+    await capture("focus-dark-context", true);
+    await capture("focus-dark-crop");
     await page.keyboard.press("Escape");
     await expect.poll(() => card.count()).toBe(0);
     await expect

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -28,6 +28,7 @@
   --text: #bcbcc0;
   --text-strong: #f4f4f5;
   --chat-text: #bcbcc0;
+  --chat-link: oklch(70.7% 0.165 254.624);
   --muted: #8b8b94;
   --muted-strong: #898990;
   --muted-foreground: #8b8b94;
@@ -241,6 +242,7 @@
   --text: #403c35;
   --text-strong: #211e1a;
   --chat-text: #403c35;
+  --chat-link: oklch(48.8% 0.243 264.376);
   --muted: #6e6960;
   --muted-strong: #56524a;
   --muted-foreground: #6e6960;

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -236,13 +236,13 @@
   }
 }
 
-.chat-text :where(a) {
-  color: var(--accent);
+:is(.chat-text, .chat-thinking) :where(a) {
+  color: var(--chat-link);
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
-.chat-text :where(a:hover) {
+:is(.chat-text, .chat-thinking) :where(a:hover) {
   opacity: 0.8;
 }
 
@@ -292,7 +292,7 @@
    purpose: each renderer's own :where(a) and code rules would otherwise win on
    source order, and sidebar-markdown.css is imported after this file. */
 :is(.chat-text, .sidebar-markdown) a.markdown-file-link {
-  color: var(--accent);
+  color: var(--chat-link);
   /* File links are href-less anchors (driven by data-file-path), so the UA
      link pointer does not apply; they are content links and keep the hand. */
   cursor: pointer;
@@ -427,7 +427,7 @@
    rather than resetting them here, so no theme override has to be out-specified;
    this rule only has to undo the separate mono-font declarations. */
 :is(.chat-text, .sidebar-markdown) a.markdown-file-link > code {
-  color: var(--accent);
+  color: var(--chat-link);
   font-family: inherit;
   font-size: inherit;
 }


### PR DESCRIPTION
Fixes #122450

## What Problem This Solves

Fixes an issue where links in the Control UI transcript used the theme's red accent color, making navigation links read like warning or destructive actions.

## Why This Change Was Made

In this PR, transcript links use one canonical `--chat-link` theme token: `#1447E6` in light mode (`oklch(48.8% 0.243 264.376)`) and `#51A2FF` in dark mode (`oklch(70.7% 0.165 254.624)`). Normal Markdown links, reasoning links, GitHub references, and file links consume the token; GitHub and file glyphs continue to inherit through `currentColor`.

The previous rules consumed the general-purpose `--accent`, which is red across the shipped theme families. #121728 added the GitHub mark and scoped its underline behavior, but did not establish a separate transcript-link palette. This keeps that underline behavior unchanged and removes the transcript's dependency on the action accent.

Production delta: +2 lines for the light/dark tokens. The transcript selectors are net-neutral replacements; tests are +81 net lines.

## User Impact

Transcript links are now consistently blue in light and dark themes. The exact color follows theme mode rather than theme family, while existing hover, focus, navigation, preview, and long-URL wrapping behavior remains intact.

## Evidence

### Before / after — light

| Before | After |
| --- | --- |
| ![Light theme before: transcript links and their GitHub and file icons use the red accent](https://github.com/user-attachments/assets/7c87541b-4f64-4117-8a4f-a0ffe4261763) | ![Light theme after: transcript links and their GitHub and file icons use the blue link token](https://github.com/user-attachments/assets/a3aca674-eac8-4548-b500-ee35c9f9f3e2) |
| ![Light theme before, changed transcript row](https://github.com/user-attachments/assets/6ff3eae6-eba4-4fff-9778-6ad86f3eaa1c) | ![Light theme after, changed transcript row](https://github.com/user-attachments/assets/cdefdff6-643b-4c34-8ad1-91388a91587c) |

### Before / after — dark

| Before | After |
| --- | --- |
| ![Dark theme before: transcript links and their GitHub and file icons use the red accent](https://github.com/user-attachments/assets/694c188b-a2aa-4693-ac27-63cc57a18aa9) | ![Dark theme after: transcript links and their GitHub and file icons use the blue link token](https://github.com/user-attachments/assets/37c0e596-279b-4c37-a76a-f951a8c8016c) |
| ![Dark theme before, changed transcript row](https://github.com/user-attachments/assets/d0c13545-f03c-4445-b938-c3c107e438f5) | ![Dark theme after, changed transcript row](https://github.com/user-attachments/assets/6b3f0374-4b36-4e2c-b313-8437361f698c) |

### State matrix

| State | Light | Dark | Result |
| --- | --- | --- | --- |
| Rest | [Rich transcript](https://github.com/user-attachments/assets/cdefdff6-643b-4c34-8ad1-91388a91587c) | [Rich transcript](https://github.com/user-attachments/assets/6b3f0374-4b36-4e2c-b313-8437361f698c) | Normal links keep their underline. GitHub and file links keep their glyph-led, no-underline rest state. Text and glyphs resolve to `--chat-link`. |
| Hover | ![Light hover state with GitHub preview](https://github.com/user-attachments/assets/f597f749-69e9-4798-b018-df3a6ce6f754) | ![Dark hover state with GitHub preview](https://github.com/user-attachments/assets/7e30a14b-f0dc-4a3d-8b9c-72f677d609cf) | Existing 80% opacity and hover underline remain; preview behavior is unchanged. |
| Keyboard focus | ![Light keyboard-focus state with GitHub preview](https://github.com/user-attachments/assets/ce409ac9-f373-4275-b2f3-64fe1d5015e1) | ![Dark keyboard-focus state with GitHub preview](https://github.com/user-attachments/assets/d56938e2-c487-438c-989c-d162e7c2156c) | Link text and glyph stay blue. The existing global focus ring and keyboard preview behavior remain. |
| Visited | — | — | There is no distinct `:visited` rule; visited links continue to resolve through `--chat-link`. |
| Narrow / overflow | ![Light narrow transcript with a wrapped long GitHub URL](https://github.com/user-attachments/assets/b023071c-cb65-422d-9b5a-921497c64f28) | ![Dark narrow transcript with a wrapped long GitHub URL](https://github.com/user-attachments/assets/a139da7e-89d8-4dcc-bcf3-a1f29f2d669f) | Long references still wrap within the transcript width in both themes. |

The regression test failed before the fix because `--chat-link` was absent, then passed with the exact light/dark values and computed-color checks for normal links, GitHub references, file links, GitHub marks, and file glyphs. Final validation passed 13 tests across five relevant files, UI typechecking, stylesheet linting, formatting, the path-scoped change gate, and the final review.
