### PR TITLE
test(core): remove residual duplicate cases

### DIFF
--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -1536,36 +1536,6 @@ describe("resolveGroupRequireMention", () => {
     await expect(resolveGroupRequireMention({ cfg, ctx, groupResolution })).resolves.toBe(false);
   });
 
-  it("keeps core reply-stage resolution aligned for Slack default-account wildcard fallbacks", async () => {
-    const cfg: OpenClawConfig = {
-      channels: {
-        slack: {
-          defaultAccount: "work",
-          accounts: {
-            work: {
-              channels: {
-                "*": { requireMention: false },
-              },
-            },
-          },
-        },
-      },
-    };
-    const ctx: TemplateContext = {
-      Provider: "slack",
-      From: "slack:channel:C123",
-      GroupSubject: "#alerts",
-    };
-    const groupResolution: GroupKeyResolution = {
-      key: "slack:group:C123",
-      channel: "slack",
-      id: "C123",
-      chatType: "group",
-    };
-
-    await expect(resolveGroupRequireMention({ cfg, ctx, groupResolution })).resolves.toBe(false);
-  });
-
   it("uses Discord fallback resolver semantics for guild slug matches", async () => {
     const cfg: OpenClawConfig = {
       channels: {

--- a/src/claws/package-remove.test.ts
+++ b/src/claws/package-remove.test.ts
@@ -296,23 +296,6 @@ describe("Claw package removal", () => {
     expect(decisions).toMatchObject([{ action: "retain", reason: expect.any(String) }]);
   });
 
-  it("does not inspect global plugin artifact state during removal planning", async () => {
-    const ref = packageRef();
-    const decisions = await planClawPackageRemovals(install, [ref], {
-      deps: {
-        readPackageRefs: vi.fn().mockReturnValue([ref]),
-        resolvePlugin: vi.fn(),
-      },
-    });
-    expect(decisions).toMatchObject([
-      {
-        action: "retain",
-        reason:
-          "Claw add introduced this shared requirement; removal releases its dependency edge and retains the artifact. Use its canonical owner separately to uninstall it.",
-      },
-    ]);
-  });
-
   it("retains a same-version plugin whose installed integrity drifted", async () => {
     const ref = packageRef();
     const decisions = await planClawPackageRemovals(install, [ref], {

--- a/src/commands/doctor-security.test.ts
+++ b/src/commands/doctor-security.test.ts
@@ -523,27 +523,7 @@ describe("noteSecurityWarnings gateway exposure", () => {
     await expectAgentExecHostPolicyWarning("*");
   });
 
-  it("does not invent a deny host policy when exec-approvals defaults.security is unset", async () => {
-    await withExecApprovalsFile(
-      {
-        version: 1,
-        agents: {},
-      },
-      async () => {
-        await noteSecurityWarnings({
-          tools: {
-            exec: {
-              mode: "ask",
-            },
-          },
-        } as OpenClawConfig);
-      },
-    );
-
-    expect(note).not.toHaveBeenCalled();
-  });
-
-  it("does not invent an on-miss host ask policy when exec-approvals defaults.ask is unset", async () => {
+  it("does not invent host policy defaults when exec-approvals defaults are unset", async () => {
     await withExecApprovalsFile(
       {
         version: 1,

--- a/src/config/issue-location.test.ts
+++ b/src/config/issue-location.test.ts
@@ -205,26 +205,6 @@ describe("resolveConfigIssueLineInRaw", () => {
     expect(resolveConfigIssueLineInRaw(raw, ["a"])).toBe(2);
   });
 
-  it("handles array index navigation with nested objects", () => {
-    const raw = [
-      "{",
-      '  "agents": {',
-      '    "list": [',
-      "      {",
-      '        "id": "main"',
-      "      },",
-      "      {",
-      '        "tools": {',
-      '          "profile": "none"',
-      "        }",
-      "      }",
-      "    ]",
-      "  }",
-      "}",
-    ].join("\n");
-    expect(resolveConfigIssueLineInRaw(raw, ["agents", "list", 1, "tools", "profile"])).toBe(9);
-  });
-
   it("gracefully degrades for unresolvable paths", () => {
     const raw = ["{", '  "a": 1', "}"].join("\n");
     expect(resolveConfigIssueLineInRaw(raw, ["nonexistent"])).toBeUndefined();

--- a/src/config/plugin-auto-enable.core.test.ts
+++ b/src/config/plugin-auto-enable.core.test.ts
@@ -697,35 +697,6 @@ describe("applyPluginAutoEnable core", () => {
     ]);
   });
 
-  it("auto-enables Codex when OpenAI agent models use the implicit runtime default", () => {
-    const result = applyPluginAutoEnable({
-      config: {
-        agents: {
-          defaults: {
-            model: "openai/gpt-5.5",
-          },
-        },
-      },
-      env,
-      manifestRegistry: makeRegistry([
-        { id: "openai", channels: [], providers: ["openai", "openai"] },
-        {
-          id: "codex",
-          channels: [],
-          providers: ["codex"],
-          activation: { onAgentHarnesses: ["codex"] },
-        },
-      ]),
-    });
-
-    expect(result.config.plugins?.entries?.openai?.enabled).toBe(true);
-    expect(result.config.plugins?.entries?.codex?.enabled).toBe(true);
-    expect(result.changes).toEqual([
-      "openai/gpt-5.5 model configured, enabled automatically.",
-      "codex agent runtime configured, enabled automatically.",
-    ]);
-  });
-
   it("auto-enables Codex when OpenAI is a selectable default agent model", () => {
     const result = applyPluginAutoEnable({
       config: {

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -263,14 +263,6 @@ describe("channel-health-monitor", () => {
     monitor.stop();
   });
 
-  it("accepts timing.monitorStartupGraceMs", async () => {
-    const manager = createMockChannelManager();
-    const monitor = startDefaultMonitor(manager, { timing: { monitorStartupGraceMs: 60_000 } });
-    await vi.advanceTimersByTimeAsync(5_001);
-    expect(manager.getRuntimeSnapshot).not.toHaveBeenCalled();
-    monitor.stop();
-  });
-
   it("skips healthy channels (running + connected)", async () => {
     const manager = createSnapshotManager({
       discord: {

--- a/src/gateway/handshake-timeouts.test.ts
+++ b/src/gateway/handshake-timeouts.test.ts
@@ -9,7 +9,6 @@ import {
   MIN_CONNECT_CHALLENGE_TIMEOUT_MS,
   resolveConnectChallengeTimeoutMs,
 } from "../../packages/gateway-client/src/timeouts.js";
-import { MAX_SAFE_TIMEOUT_DELAY_MS } from "../../packages/gateway-client/src/timeouts.js";
 import { resolvePreauthHandshakeTimeoutMs } from "./handshake-timeouts.js";
 
 describe("gateway handshake timeouts", () => {
@@ -75,20 +74,6 @@ describe("gateway handshake timeouts", () => {
     expect(resolvePreauthHandshakeTimeoutMs({ env: {} })).toBe(
       DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS,
     );
-  });
-
-  test("caps preauth handshake timeout env and config values to the safe timer range", () => {
-    expect(
-      resolvePreauthHandshakeTimeoutMs({
-        env: { OPENCLAW_HANDSHAKE_TIMEOUT_MS: "3000000000" },
-      }),
-    ).toBe(MAX_SAFE_TIMEOUT_DELAY_MS);
-    expect(
-      resolvePreauthHandshakeTimeoutMs({
-        env: {},
-        configuredTimeoutMs: 3_000_000_000,
-      }),
-    ).toBe(MAX_SAFE_TIMEOUT_DELAY_MS);
   });
 
   test("resolves preauth handshake timeout from the test-only env before config", () => {

--- a/src/infra/outbound/message-action-send.validation.test.ts
+++ b/src/infra/outbound/message-action-send.validation.test.ts
@@ -432,17 +432,4 @@ describe("message body alias normalization", () => {
       },
     });
   });
-
-  it("still rejects send with no message and no alias", async () => {
-    await expect(
-      runDrySend({
-        cfg: workspaceConfig,
-        actionParams: {
-          channel: "workspace",
-          target: "#C12345678",
-        },
-        toolContext: { currentChannelId: "C12345678" },
-      }),
-    ).rejects.toThrow(/message required/i);
-  });
 });

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -1443,27 +1443,6 @@ describe("provider-runtime", () => {
     );
   });
 
-  it("respects the shared GPT-5 prompt overlay personality config", () => {
-    const contribution = resolveProviderSystemPromptContribution({
-      provider: "openai",
-      config: {
-        plugins: {
-          entries: {
-            openai: { config: { personality: "off" } },
-          },
-        },
-      },
-      context: {
-        provider: "openai",
-        modelId: "gpt-5.4",
-        promptMode: "full",
-      } as never,
-    });
-
-    expect(contribution?.stablePrefix).toContain("<persona_latch>");
-    expect(contribution?.sectionOverrides).toStrictEqual({});
-  });
-
   it("lets provider-owned prompt overlays compose after the built-in GPT-5 overlay", () => {
     const resolvePromptOverlay = vi.fn((ctx) => ({
       stablePrefix: "provider overlay",

--- a/src/plugins/providers.test.ts
+++ b/src/plugins/providers.test.ts
@@ -928,40 +928,6 @@ describe("resolvePluginProviders", () => {
     expect(resolveRuntimePluginRegistryMock).not.toHaveBeenCalled();
   });
 
-  it("filters bundled provider plugins by allowlist by default", () => {
-    setManifestPlugins([
-      createManifestProviderPlugin({
-        id: "kilocode",
-        providerIds: ["kilocode"],
-        origin: "bundled",
-        enabledByDefault: true,
-      }),
-      createManifestProviderPlugin({
-        id: "moonshot",
-        providerIds: ["moonshot"],
-        origin: "bundled",
-        enabledByDefault: true,
-      }),
-      createManifestProviderPlugin({
-        id: "openrouter",
-        providerIds: ["openrouter"],
-        origin: "bundled",
-        enabledByDefault: true,
-      }),
-    ]);
-
-    const discovered = resolveDiscoveredProviderPluginIds({
-      config: {
-        plugins: {
-          allow: ["openrouter"],
-        },
-      },
-      env: {} as NodeJS.ProcessEnv,
-    });
-
-    expect(discovered).toEqual(["openrouter"]);
-  });
-
   it("filters bundled provider plugins through restrictive allowlists", () => {
     setManifestPlugins([
       createManifestProviderPlugin({

--- a/src/utils/cjk-chars.test.ts
+++ b/src/utils/cjk-chars.test.ts
@@ -7,10 +7,6 @@ import {
 } from "./cjk-chars.js";
 
 describe("estimateStringChars", () => {
-  it("returns plain string length for ASCII text", () => {
-    expect(estimateStringChars("hello world")).toBe(11);
-  });
-
   it("returns 0 for empty string", () => {
     expect(estimateStringChars("")).toBe(0);
   });
@@ -20,12 +16,6 @@ describe("estimateStringChars", () => {
     // Each CJK char counted as CHARS_PER_TOKEN_ESTIMATE (4) chars
     // .length = 3, adjusted = 3 + 3 * (4 - 1) = 12
     expect(estimateStringChars("你好世")).toBe(12);
-  });
-
-  it("handles mixed ASCII and CJK text", () => {
-    // "hi你好" = 2 ASCII + 2 CJK
-    // .length = 4, adjusted = 4 + 2 * 3 = 10
-    expect(estimateStringChars("hi你好")).toBe(10);
   });
 
   it("handles Japanese hiragana", () => {
@@ -53,11 +43,6 @@ describe("estimateStringChars", () => {
     );
   });
 
-  it("handles CJK punctuation and symbols in the extended range", () => {
-    // "⺀" (U+2E80) is a rare radical that current tokenizers encode as 3 tokens.
-    expect(estimateStringChars("⺀")).toBe(CHARS_PER_TOKEN_ESTIMATE * 3);
-  });
-
   it("does not inflate standard Latin characters", () => {
     const latin = "The quick brown fox jumps over the lazy dog";
     expect(estimateStringChars(latin)).toBe(latin.length);
@@ -68,68 +53,15 @@ describe("estimateStringChars", () => {
     expect(estimateStringChars(text)).toBe(text.length);
   });
 
-  it("weights CJK Extension B characters for their measured token cost", () => {
-    // "𠀀" (U+20000) is represented as a surrogate pair in UTF-16.
-    expect(estimateStringChars("𠀀")).toBe(CHARS_PER_TOKEN_ESTIMATE * 4);
-  });
-
   it("handles mixed BMP and Extension B CJK weights", () => {
     expect(estimateStringChars("你𠀀好")).toBe(CHARS_PER_TOKEN_ESTIMATE * 6);
-  });
-
-  it("weights halfwidth Japanese, halfwidth Hangul, and supplementary CJK", () => {
-    expect(estimateStringChars("ｺﾝﾆﾁﾊ")).toBe(CHARS_PER_TOKEN_ESTIMATE * 10);
-    expect(estimateStringChars(String.fromCodePoint(0xffa1))).toBe(CHARS_PER_TOKEN_ESTIMATE * 2);
-    expect(estimateStringChars(String.fromCodePoint(0x30000))).toBe(CHARS_PER_TOKEN_ESTIMATE * 4);
-  });
-
-  it("weights decomposed Hangul and compatibility forms", () => {
-    const decomposedHangul = "안녕하세요".normalize("NFD");
-    expect(estimateStringChars(decomposedHangul)).toBe(
-      decomposedHangul.length * CHARS_PER_TOKEN_ESTIMATE * 3,
-    );
-    expect(estimateStringChars(String.fromCodePoint(0xa960))).toBe(CHARS_PER_TOKEN_ESTIMATE * 3);
-    expect(estimateStringChars(String.fromCodePoint(0xd7b0))).toBe(CHARS_PER_TOKEN_ESTIMATE * 3);
-    expect(estimateStringChars(String.fromCodePoint(0xfe10))).toBe(CHARS_PER_TOKEN_ESTIMATE * 2);
-    expect(estimateStringChars(String.fromCodePoint(0xffe0))).toBe(CHARS_PER_TOKEN_ESTIMATE * 2);
-  });
-
-  it.each([0x2e80, 0x3400, 0x9fff, 0xa000, 0xf900])(
-    "weights rare BMP CJK U+%s conservatively",
-    (codePoint) => {
-      expect(estimateStringChars(String.fromCodePoint(codePoint))).toBe(
-        CHARS_PER_TOKEN_ESTIMATE * 3,
-      );
-    },
-  );
-
-  it.each([0x16fe3, 0x1aff0, 0x1b001, 0x1b11f, 0x1b132, 0x1f200])(
-    "weights supplementary CJK U+%s conservatively",
-    (codePoint) => {
-      expect(estimateStringChars(String.fromCodePoint(codePoint))).toBe(
-        CHARS_PER_TOKEN_ESTIMATE * 4,
-      );
-    },
-  );
-
-  it("covers CJK script-extension marks with measured weights", () => {
-    expect(estimateStringChars(String.fromCodePoint(0x00b7))).toBe(CHARS_PER_TOKEN_ESTIMATE);
-    expect(estimateStringChars("·".repeat(32))).toBe(32 * CHARS_PER_TOKEN_ESTIMATE);
-    expect(estimateStringChars(String.fromCodePoint(0x02ca))).toBe(CHARS_PER_TOKEN_ESTIMATE * 2);
-    expect(estimateStringChars(String.fromCodePoint(0xa700))).toBe(CHARS_PER_TOKEN_ESTIMATE * 3);
-    expect(estimateStringChars(String.fromCodePoint(0x1d360))).toBe(CHARS_PER_TOKEN_ESTIMATE * 3);
-  });
-
-  it("does not collapse non-CJK surrogate pairs like emoji", () => {
-    // Emoji is a surrogate pair in UTF-16, but not matched by NON_LATIN_RE.
-    // Its weighted length should remain the UTF-16 length (2).
-    expect(estimateStringChars("😀")).toBe(2);
   });
 
   it("keeps mixed CJK and emoji weighting consistent", () => {
     // "你" counts as 4, emoji remains 2 => total 6
     expect(estimateStringChars("你😀")).toBe(6);
   });
+
   it("yields ~1 token per CJK char when divided by CHARS_PER_TOKEN_ESTIMATE", () => {
     // 10 CJK chars should estimate as ~10 tokens
     const cjk = "这是一个测试用的句子呢";


### PR DESCRIPTION
## What Problem This Solves

Eleven core test suites still contained exact duplicate cases, strict-subset replays, or root compatibility tests that repeated the package owner's inputs and assertions. These copies added maintenance and CI cost without protecting a distinct regression.

## Why This Change Was Made

Delete the later duplicate in each pair while retaining the canonical owner test and every distinct neighboring case. The root CJK and Gateway timeout suites now keep only coverage not already owned by `normalization-core` and `gateway-client`. The surviving doctor fixture is renamed to describe both omitted host defaults it actually covers.

## User Impact

No intended user-visible change. Runtime, configuration, plugin activation, outbound delivery, Gateway health monitoring, and timeout behavior are unchanged; CI runs fewer redundant cases.

## Evidence

- Focused owner proof: 497 tests passed across ten Vitest projects, including the package-owner CJK/timeout suites and Slack's plugin-owned wildcard policy.
- Full changed-file gate passed formatting, core test typecheck/lint, dead exports, plugin boundaries, dependency guards, max-lines ratchet, and cycle/static checks. Blacksmith/Testbox was unavailable on this host, so the trusted heavy gate used the documented local fallback.
- Structured autoreview and deleted-content secret scan: clean.
- `git diff --check`: clean.
- Test-only delta: 2 insertions, 277 deletions across 11 files; zero production or test-support changes.
- Codex dependency contract checked directly at `openai/codex@78d3665d1569b6b0cf227a8668a837f8d6c79aab`: `OPENAI_PROVIDER_ID` remains `openai`, the thread store defaults to that provider, and the default test model is `gpt-5.5`.

AI-assisted maintenance cleanup; candidate tests, production owners, retained proof, history, and dependency contracts were reviewed directly.
