### PR TITLE
feat(gateway): recover channels and health promptly after host sleep

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayConnectivityCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnectivityCoordinator.swift
@@ -32,6 +32,9 @@ final class GatewayConnectivityCoordinator {
     private init() {
         self.sleepCycleController = GatewaySleepCycleController(
             requestID: "macos-sleep-\(UUID().uuidString.lowercased())",
+            // Route tokens and the shared RPC connection both follow the endpoint
+            // store; a switch between the two reads fails conservatively — the wake
+            // path drops a mismatched lease and lets it self-expire.
             currentRoute: { [weak self] in
                 guard case let .ready(_, url, _, _, _) = self?.endpointState else { return nil }
                 return url.absoluteString

--- a/apps/macos/Sources/OpenClaw/GatewayConnectivityCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnectivityCoordinator.swift
@@ -1,5 +1,17 @@
+import AppKit
 import Foundation
 import Observation
+import OpenClawProtocol
+import OSLog
+
+private let gatewayConnectivityLogger = Logger(
+    subsystem: "ai.openclaw",
+    category: "gateway.connectivity")
+
+private struct GatewaySleepPrepareResponse: Decodable {
+    let status: String
+    let suspensionId: String?
+}
 
 @MainActor
 @Observable
@@ -7,8 +19,10 @@ final class GatewayConnectivityCoordinator {
     static let shared = GatewayConnectivityCoordinator()
 
     private var endpointTask: Task<Void, Never>?
+    private var workspaceObservers: [NSObjectProtocol] = []
     private var lastResolvedURL: URL?
     private var lastRouteRevision: UInt64?
+    @ObservationIgnored private var sleepCycleController: GatewaySleepCycleController?
 
     private(set) var endpointState: GatewayEndpointState?
     private(set) var resolvedURL: URL?
@@ -16,11 +30,39 @@ final class GatewayConnectivityCoordinator {
     private(set) var resolvedHostLabel: String?
 
     private init() {
+        self.sleepCycleController = GatewaySleepCycleController(
+            requestID: "macos-sleep-\(UUID().uuidString.lowercased())",
+            currentRoute: { [weak self] in
+                guard case let .ready(_, url, _, _, _) = self?.endpointState else { return nil }
+                return url.absoluteString
+            },
+            prepare: { requestID in
+                let data = try await GatewayConnection.shared.request(
+                    method: "gateway.suspend.prepare",
+                    params: ["requestId": AnyCodable(requestID)],
+                    timeoutMs: 3000,
+                    retryTransportFailures: false)
+                let response = try JSONDecoder().decode(GatewaySleepPrepareResponse.self, from: data)
+                guard response.status == "ready", let suspensionID = response.suspensionId else {
+                    return .busy
+                }
+                return .ready(suspensionID: suspensionID)
+            },
+            resume: { suspensionID in
+                _ = try await GatewayConnection.shared.request(
+                    method: "gateway.suspend.resume",
+                    params: ["suspensionId": AnyCodable(suspensionID)],
+                    timeoutMs: 3000,
+                    retryTransportFailures: false)
+            },
+            refresh: { await GatewayEndpointStore.shared.refresh() },
+            log: { message in gatewayConnectivityLogger.error("\(message, privacy: .public)") })
         self.start()
     }
 
     func start() {
         guard self.endpointTask == nil else { return }
+        self.registerSleepWakeObservers()
         self.endpointTask = Task { [weak self] in
             guard let self else { return }
             let stream = await GatewayEndpointStore.shared.subscribe()
@@ -30,8 +72,32 @@ final class GatewayConnectivityCoordinator {
         }
     }
 
+    private func registerSleepWakeObservers() {
+        let center = NSWorkspace.shared.notificationCenter
+        self.workspaceObservers.append(center.addObserver(
+            forName: NSWorkspace.willSleepNotification,
+            object: nil,
+            queue: .main)
+        { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self, let sleepCycleController = self.sleepCycleController else { return }
+                await sleepCycleController.willSleep(mode: self.resolvedMode)
+            }
+        })
+        self.workspaceObservers.append(center.addObserver(
+            forName: NSWorkspace.didWakeNotification,
+            object: nil,
+            queue: .main)
+        { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self, let sleepCycleController = self.sleepCycleController else { return }
+                await sleepCycleController.didWake(mode: self.resolvedMode)
+            }
+        })
+    }
+
     var localEndpointHostLabel: String? {
-        guard self.resolvedMode == .local, let url = self.resolvedURL else { return nil }
+        guard self.resolvedMode == .local, let url = resolvedURL else { return nil }
         return Self.hostLabel(for: url)
     }
 
@@ -58,7 +124,9 @@ final class GatewayConnectivityCoordinator {
 
     private static func hostLabel(for url: URL) -> String {
         let host = url.host ?? url.absoluteString
-        if let port = url.port { return "\(host):\(port)" }
+        if let port = url.port {
+            return "\(host):\(port)"
+        }
         return host
     }
 }

--- a/apps/macos/Sources/OpenClaw/GatewaySleepCycleController.swift
+++ b/apps/macos/Sources/OpenClaw/GatewaySleepCycleController.swift
@@ -11,12 +11,17 @@ final class GatewaySleepCycleController {
     typealias Resume = (String) async throws -> Void
     typealias Refresh = () async -> Void
     typealias CurrentRoute = () -> String?
+    typealias RetryDelay = (Duration) async -> Void
+
+    private static let resumeAttempts = 3
+    private static let resumeRetryDelay: Duration = .seconds(2)
 
     private let requestID: String
     private let currentRoute: CurrentRoute
     private let prepare: Prepare
     private let resume: Resume
     private let refresh: Refresh
+    private let retryDelay: RetryDelay
     private let log: (String) -> Void
     private var suspension: (id: String, route: String?)?
     private var cycleGeneration: UInt64 = 0
@@ -27,6 +32,7 @@ final class GatewaySleepCycleController {
         prepare: @escaping Prepare,
         resume: @escaping Resume,
         refresh: @escaping Refresh,
+        retryDelay: @escaping RetryDelay = { try? await Task.sleep(for: $0) },
         log: @escaping (String) -> Void)
     {
         self.requestID = requestID
@@ -34,6 +40,7 @@ final class GatewaySleepCycleController {
         self.prepare = prepare
         self.resume = resume
         self.refresh = refresh
+        self.retryDelay = retryDelay
         self.log = log
     }
 
@@ -71,17 +78,33 @@ final class GatewaySleepCycleController {
             }
             return
         }
+        let generation = self.cycleGeneration
+        // Refresh first: after real sleep the transport is usually dead, and the
+        // resume RPC needs the re-established connection to succeed at all.
+        await self.refresh()
         if let suspension {
             if let route = suspension.route, self.currentRoute() == route {
-                do {
-                    try await self.resume(suspension.id)
-                } catch {
-                    self.log("gateway wake resume failed: \(error.localizedDescription)")
-                }
+                await self.resumeWithRetries(suspension.id, generation: generation)
             } else {
                 self.log("dropping gateway sleep lease: route/mode changed across sleep; lease will self-expire")
             }
         }
-        await self.refresh()
+    }
+
+    private func resumeWithRetries(_ suspensionID: String, generation: UInt64) async {
+        for attempt in 1...Self.resumeAttempts {
+            // A new sleep cycle owns the connection; abandoned leases self-expire.
+            guard generation == self.cycleGeneration else { return }
+            do {
+                try await self.resume(suspensionID)
+                return
+            } catch {
+                self.log("gateway wake resume attempt \(attempt) failed: \(error.localizedDescription)")
+                if attempt < Self.resumeAttempts {
+                    await self.retryDelay(Self.resumeRetryDelay)
+                }
+            }
+        }
+        self.log("giving up on gateway wake resume; lease will self-expire")
     }
 }

--- a/apps/macos/Sources/OpenClaw/GatewaySleepCycleController.swift
+++ b/apps/macos/Sources/OpenClaw/GatewaySleepCycleController.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+enum GatewaySleepPrepareResult: Equatable {
+    case ready(suspensionID: String)
+    case busy
+}
+
+@MainActor
+final class GatewaySleepCycleController {
+    typealias Prepare = (String) async throws -> GatewaySleepPrepareResult
+    typealias Resume = (String) async throws -> Void
+    typealias Refresh = () async -> Void
+    typealias CurrentRoute = () -> String?
+
+    private let requestID: String
+    private let currentRoute: CurrentRoute
+    private let prepare: Prepare
+    private let resume: Resume
+    private let refresh: Refresh
+    private let log: (String) -> Void
+    private var suspension: (id: String, route: String?)?
+    private var cycleGeneration: UInt64 = 0
+
+    init(
+        requestID: String,
+        currentRoute: @escaping CurrentRoute,
+        prepare: @escaping Prepare,
+        resume: @escaping Resume,
+        refresh: @escaping Refresh,
+        log: @escaping (String) -> Void)
+    {
+        self.requestID = requestID
+        self.currentRoute = currentRoute
+        self.prepare = prepare
+        self.resume = resume
+        self.refresh = refresh
+        self.log = log
+    }
+
+    func willSleep(mode: AppState.ConnectionMode?) async {
+        guard mode == .local else { return }
+        self.cycleGeneration &+= 1
+        let generation = self.cycleGeneration
+        do {
+            switch try await self.prepare(self.requestID) {
+            case let .ready(suspensionID):
+                guard generation == self.cycleGeneration else { return }
+                self.suspension = (id: suspensionID, route: self.currentRoute())
+            case .busy:
+                self.log("gateway sleep preparation skipped because the gateway is busy")
+            }
+        } catch {
+            self.log("gateway sleep preparation failed: \(error.localizedDescription)")
+        }
+    }
+
+    func didWake(mode: AppState.ConnectionMode?) async {
+        let suspension = self.suspension
+        self.suspension = nil
+        // Invalidate a prepare response that arrives after the wake notification;
+        // its short-lived lease must expire instead of surviving into a later cycle.
+        self.cycleGeneration &+= 1
+        guard mode == .local else {
+            if suspension != nil {
+                self.log("dropping gateway sleep lease: route/mode changed across sleep; lease will self-expire")
+            }
+            return
+        }
+        if let suspension {
+            if let route = suspension.route, self.currentRoute() == route {
+                do {
+                    try await self.resume(suspension.id)
+                } catch {
+                    self.log("gateway wake resume failed: \(error.localizedDescription)")
+                }
+            } else {
+                self.log("dropping gateway sleep lease: route/mode changed across sleep; lease will self-expire")
+            }
+        }
+        await self.refresh()
+    }
+}

--- a/apps/macos/Sources/OpenClaw/GatewaySleepCycleController.swift
+++ b/apps/macos/Sources/OpenClaw/GatewaySleepCycleController.swift
@@ -44,7 +44,12 @@ final class GatewaySleepCycleController {
         do {
             switch try await self.prepare(self.requestID) {
             case let .ready(suspensionID):
-                guard generation == self.cycleGeneration else { return }
+                guard generation == self.cycleGeneration else {
+                    // The wake already happened; release the late lease right away
+                    // instead of fencing the gateway until its two-minute expiry.
+                    try await self.resume(suspensionID)
+                    return
+                }
                 self.suspension = (id: suspensionID, route: self.currentRoute())
             case .busy:
                 self.log("gateway sleep preparation skipped because the gateway is busy")

--- a/apps/macos/Tests/OpenClawIPCTests/GatewaySleepCycleControllerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewaySleepCycleControllerTests.swift
@@ -1,0 +1,143 @@
+@testable import OpenClaw
+import Testing
+
+private struct PrepareFailure: Error {}
+
+@Suite(.serialized)
+@MainActor
+struct GatewaySleepCycleControllerTests {
+    @Test func `ready preparation resumes its suspension once and refreshes`() async {
+        var preparedRequestIDs: [String] = []
+        var resumedIDs: [String] = []
+        var refreshCount = 0
+        let route = "ws://127.0.0.1:18789"
+        let controller = GatewaySleepCycleController(
+            requestID: "macos-sleep-test-run",
+            currentRoute: { route },
+            prepare: { requestID in
+                preparedRequestIDs.append(requestID)
+                return .ready(suspensionID: "suspension-1")
+            },
+            resume: { resumedIDs.append($0) },
+            refresh: { refreshCount += 1 },
+            log: { _ in }
+        )
+
+        await controller.willSleep(mode: .local)
+        await controller.didWake(mode: .local)
+        await controller.didWake(mode: .local)
+
+        #expect(preparedRequestIDs == ["macos-sleep-test-run"])
+        #expect(resumedIDs == ["suspension-1"])
+        #expect(refreshCount == 2)
+    }
+
+    @Test func `busy preparation does not resume but still refreshes`() async {
+        var resumeCount = 0
+        var refreshCount = 0
+        let controller = GatewaySleepCycleController(
+            requestID: "macos-sleep-test-run",
+            currentRoute: { "ws://127.0.0.1:18789" },
+            prepare: { _ in .busy },
+            resume: { _ in resumeCount += 1 },
+            refresh: { refreshCount += 1 },
+            log: { _ in }
+        )
+
+        await controller.willSleep(mode: .local)
+        await controller.didWake(mode: .local)
+
+        #expect(resumeCount == 0)
+        #expect(refreshCount == 1)
+    }
+
+    @Test func `failed preparation does not resume but still refreshes`() async {
+        var resumeCount = 0
+        var refreshCount = 0
+        let controller = GatewaySleepCycleController(
+            requestID: "macos-sleep-test-run",
+            currentRoute: { "ws://127.0.0.1:18789" },
+            prepare: { _ in throw PrepareFailure() },
+            resume: { _ in resumeCount += 1 },
+            refresh: { refreshCount += 1 },
+            log: { _ in }
+        )
+
+        await controller.willSleep(mode: .local)
+        await controller.didWake(mode: .local)
+
+        #expect(resumeCount == 0)
+        #expect(refreshCount == 1)
+    }
+
+    @Test func `remote mode performs no sleep or wake work`() async {
+        var prepareCount = 0
+        var resumeCount = 0
+        var refreshCount = 0
+        let controller = GatewaySleepCycleController(
+            requestID: "macos-sleep-test-run",
+            currentRoute: { "ws://127.0.0.1:18789" },
+            prepare: { _ in
+                prepareCount += 1
+                return .ready(suspensionID: "unused")
+            },
+            resume: { _ in resumeCount += 1 },
+            refresh: { refreshCount += 1 },
+            log: { _ in }
+        )
+
+        await controller.willSleep(mode: .remote)
+        await controller.didWake(mode: .remote)
+
+        #expect(prepareCount == 0)
+        #expect(resumeCount == 0)
+        #expect(refreshCount == 0)
+    }
+
+    @Test func `changed route drops the suspension and still refreshes`() async {
+        var route = "ws://127.0.0.1:18789"
+        var resumedIDs: [String] = []
+        var refreshCount = 0
+        var logs: [String] = []
+        let controller = GatewaySleepCycleController(
+            requestID: "macos-sleep-test-run",
+            currentRoute: { route },
+            prepare: { _ in .ready(suspensionID: "suspension-1") },
+            resume: { resumedIDs.append($0) },
+            refresh: { refreshCount += 1 },
+            log: { logs.append($0) }
+        )
+
+        await controller.willSleep(mode: .local)
+        route = "ws://127.0.0.1:19001"
+        await controller.didWake(mode: .local)
+        route = "ws://127.0.0.1:18789"
+        await controller.didWake(mode: .local)
+
+        #expect(resumedIDs.isEmpty)
+        #expect(refreshCount == 2)
+        #expect(logs == ["dropping gateway sleep lease: route/mode changed across sleep; lease will self-expire"])
+    }
+
+    @Test func `remote wake clears a held local suspension`() async {
+        var resumedIDs: [String] = []
+        var refreshCount = 0
+        var logs: [String] = []
+        let controller = GatewaySleepCycleController(
+            requestID: "macos-sleep-test-run",
+            currentRoute: { "ws://127.0.0.1:18789" },
+            prepare: { _ in .ready(suspensionID: "suspension-1") },
+            resume: { resumedIDs.append($0) },
+            refresh: { refreshCount += 1 },
+            log: { logs.append($0) }
+        )
+
+        await controller.willSleep(mode: .local)
+        await controller.didWake(mode: .remote)
+        await controller.didWake(mode: .local)
+
+        #expect(resumedIDs.isEmpty)
+        #expect(refreshCount == 1)
+        #expect(logs == ["dropping gateway sleep lease: route/mode changed across sleep; lease will self-expire"])
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/GatewaySleepCycleControllerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewaySleepCycleControllerTests.swift
@@ -1,5 +1,5 @@
-@testable import OpenClaw
 import Testing
+@testable import OpenClaw
 
 private struct PrepareFailure: Error {}
 
@@ -20,8 +20,7 @@ struct GatewaySleepCycleControllerTests {
             },
             resume: { resumedIDs.append($0) },
             refresh: { refreshCount += 1 },
-            log: { _ in }
-        )
+            log: { _ in })
 
         await controller.willSleep(mode: .local)
         await controller.didWake(mode: .local)
@@ -30,6 +29,33 @@ struct GatewaySleepCycleControllerTests {
         #expect(preparedRequestIDs == ["macos-sleep-test-run"])
         #expect(resumedIDs == ["suspension-1"])
         #expect(refreshCount == 2)
+    }
+
+    @Test func `prepare response arriving after wake resumes the late lease immediately`() async {
+        var resumedIDs: [String] = []
+        var releasePrepare: CheckedContinuation<Void, Never>?
+        let controller = GatewaySleepCycleController(
+            requestID: "macos-sleep-test-run",
+            currentRoute: { "ws://127.0.0.1:18789" },
+            prepare: { _ in
+                await withCheckedContinuation { releasePrepare = $0 }
+                return .ready(suspensionID: "late-suspension")
+            },
+            resume: { resumedIDs.append($0) },
+            refresh: {},
+            log: { _ in })
+
+        let sleepTask = Task { await controller.willSleep(mode: .local) }
+        // Let willSleep reach the suspended prepare before waking.
+        while releasePrepare == nil {
+            await Task.yield()
+        }
+        await controller.didWake(mode: .local)
+        releasePrepare?.resume()
+        await sleepTask.value
+        await controller.didWake(mode: .local)
+
+        #expect(resumedIDs == ["late-suspension"])
     }
 
     @Test func `busy preparation does not resume but still refreshes`() async {
@@ -41,8 +67,7 @@ struct GatewaySleepCycleControllerTests {
             prepare: { _ in .busy },
             resume: { _ in resumeCount += 1 },
             refresh: { refreshCount += 1 },
-            log: { _ in }
-        )
+            log: { _ in })
 
         await controller.willSleep(mode: .local)
         await controller.didWake(mode: .local)
@@ -60,8 +85,7 @@ struct GatewaySleepCycleControllerTests {
             prepare: { _ in throw PrepareFailure() },
             resume: { _ in resumeCount += 1 },
             refresh: { refreshCount += 1 },
-            log: { _ in }
-        )
+            log: { _ in })
 
         await controller.willSleep(mode: .local)
         await controller.didWake(mode: .local)
@@ -83,8 +107,7 @@ struct GatewaySleepCycleControllerTests {
             },
             resume: { _ in resumeCount += 1 },
             refresh: { refreshCount += 1 },
-            log: { _ in }
-        )
+            log: { _ in })
 
         await controller.willSleep(mode: .remote)
         await controller.didWake(mode: .remote)
@@ -105,8 +128,7 @@ struct GatewaySleepCycleControllerTests {
             prepare: { _ in .ready(suspensionID: "suspension-1") },
             resume: { resumedIDs.append($0) },
             refresh: { refreshCount += 1 },
-            log: { logs.append($0) }
-        )
+            log: { logs.append($0) })
 
         await controller.willSleep(mode: .local)
         route = "ws://127.0.0.1:19001"
@@ -129,8 +151,7 @@ struct GatewaySleepCycleControllerTests {
             prepare: { _ in .ready(suspensionID: "suspension-1") },
             resume: { resumedIDs.append($0) },
             refresh: { refreshCount += 1 },
-            log: { logs.append($0) }
-        )
+            log: { logs.append($0) })
 
         await controller.willSleep(mode: .local)
         await controller.didWake(mode: .remote)

--- a/apps/macos/Tests/OpenClawIPCTests/GatewaySleepCycleControllerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewaySleepCycleControllerTests.swift
@@ -58,6 +58,72 @@ struct GatewaySleepCycleControllerTests {
         #expect(resumedIDs == ["late-suspension"])
     }
 
+    @Test func `resume retries after a transport failure and succeeds`() async {
+        var resumeAttempts = 0
+        var delays = 0
+        let controller = GatewaySleepCycleController(
+            requestID: "macos-sleep-test-run",
+            currentRoute: { "ws://127.0.0.1:18789" },
+            prepare: { _ in .ready(suspensionID: "suspension-retry") },
+            resume: { _ in
+                resumeAttempts += 1
+                if resumeAttempts == 1 { throw PrepareFailure() }
+            },
+            refresh: {},
+            retryDelay: { _ in delays += 1 },
+            log: { _ in })
+
+        await controller.willSleep(mode: .local)
+        await controller.didWake(mode: .local)
+
+        #expect(resumeAttempts == 2)
+        #expect(delays == 1)
+    }
+
+    @Test func `resume gives up after exhausting retries`() async {
+        var resumeAttempts = 0
+        var logs: [String] = []
+        let controller = GatewaySleepCycleController(
+            requestID: "macos-sleep-test-run",
+            currentRoute: { "ws://127.0.0.1:18789" },
+            prepare: { _ in .ready(suspensionID: "suspension-exhaust") },
+            resume: { _ in
+                resumeAttempts += 1
+                throw PrepareFailure()
+            },
+            refresh: {},
+            retryDelay: { _ in },
+            log: { logs.append($0) })
+
+        await controller.willSleep(mode: .local)
+        await controller.didWake(mode: .local)
+
+        #expect(resumeAttempts == 3)
+        #expect(logs.contains { $0.contains("giving up") })
+    }
+
+    @Test func `a new sleep cycle aborts in-flight resume retries`() async {
+        var resumeAttempts = 0
+        var beginNextSleep: (() async -> Void)?
+        let controller = GatewaySleepCycleController(
+            requestID: "macos-sleep-test-run",
+            currentRoute: { "ws://127.0.0.1:18789" },
+            prepare: { _ in .ready(suspensionID: "suspension-abort") },
+            resume: { _ in
+                resumeAttempts += 1
+                throw PrepareFailure()
+            },
+            refresh: {},
+            retryDelay: { _ in await beginNextSleep?() },
+            log: { _ in })
+
+        await controller.willSleep(mode: .local)
+        beginNextSleep = { await controller.willSleep(mode: .local) }
+        await controller.didWake(mode: .local)
+
+        #expect(resumeAttempts == 1)
+    }
+
     @Test func `busy preparation does not resume but still refreshes`() async {
         var resumeCount = 0
         var refreshCount = 0

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"592d7a63d16191c80337a99b54d1bd7abc90dec80ec5619a33aa0127f8065cd9","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}
+{"contentHash":"32b0a82676f998c3b3e1df8b319c9b930dc75c46933d4130ea738e29230c287a","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
@@ -1,1 +1,1 @@
-{"contentHash":"9966a1fe3a54b7d4441c797b1278fdefbbdc570ad2a16c54a7e1d59d79b0d78c","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
+{"contentHash":"f00efd8f5dfd884bed1e0941d9c3ab3251ace31e5ddb9710d1c75e8ad5ce2393","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-core.json
@@ -1,1 +1,1 @@
-{"contentHash":"235411e28d230c2601c89729616e91bdf467e9aafead3986d6b3944f8a3793e2","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}
+{"contentHash":"e4158783bc6e43a8ae391a97b762d5e035c2b9ca44d28e9a2c3c0ecda0ce29c9","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
@@ -1,1 +1,1 @@
-{"contentHash":"64ab8862f4dc8bb89cba1508704737dfdb760e74de3330308ee33160d109e085","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}
+{"contentHash":"7ff5e9dba022e6d2ca5f0aa0d52276dc957336b94e842730ced0e8511f1a3379","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-message.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-message.json
@@ -1,1 +1,1 @@
-{"contentHash":"1bee58753249c7720eb218b9a160d58c460c9051d2e55c5c16e6b560565b1670","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}
+{"contentHash":"c3046c34991b6f1198e85626a65ba99b051ce5f0164939dd20f3ad5507defed9","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"5751ca5bba6c92d75ab169cdb8614be5e7a65e3a15cc68873a9c73b8e9e59f2a","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}
+{"contentHash":"a5ad372d98616d72d4e0e2f9b94748d225220cc7cb48be03504d4a543d325ccf","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
@@ -1,1 +1,1 @@
-{"contentHash":"9a3dae76ff23015d94e5b1946236534ea2fa92b6d7b51cf9e9e409cac134a972","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}
+{"contentHash":"4f0930ae4e406c8fcf0ec0bcd40221bf0d5abb7065f767354b96a1df84799b9a","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}

--- a/docs/.generated/plugin-sdk-api-baseline/core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/core.json
@@ -1,1 +1,1 @@
-{"contentHash":"bf1d2b91991796d3bf82a1802d2997e4c8692d5ee68ca9e07b7dab99bfc3c5fb","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}
+{"contentHash":"1b7fff39aa4b673831b12f5c07df1eada426d73e9bc9871d77a4401ed94d64c5","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}

--- a/docs/.generated/plugin-sdk-api-baseline/discord.json
+++ b/docs/.generated/plugin-sdk-api-baseline/discord.json
@@ -1,1 +1,1 @@
-{"contentHash":"b45ce74762fee5267b16b339f8f97ccce0f4f5df92608a56bc48dc9f46824055","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}
+{"contentHash":"c2dfb03df2bbb707a232ee91811202f4aaa85d8ee741c86feacd9f62d5ecd1c7","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}

--- a/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
+++ b/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
@@ -1,1 +1,1 @@
-{"contentHash":"36d41a6be6c6d5e523ae164662a8080bfb7c34e37d1b66e00964ec078db22c93","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}
+{"contentHash":"2a1fafedf1200dee212dd915eba1791c372b092e81b5b9819dc2463960d0e875","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}

--- a/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"0b85bf09a339ce32b3f8e43159eb88fbfb1691b6a8346b97d0798e5188d2d32a","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}
+{"contentHash":"63b8f308e7cbd894066187e0bae95194526b3ad8b5e01eb9dd48a951ce099127","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
@@ -1,1 +1,1 @@
-{"contentHash":"73cf4e87d121ed568cf4339436d3fa629144c86902060bbf6e1e8fe06f261fa6","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}
+{"contentHash":"996ade9307d3bcfade9deb9cf40f78b02db775dcb92232d006c1716136cbb5cd","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"5dd6717af8284afcf6ef88f19593a4d6f5363cb3be26f693157605bc64a29ea0","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}
+{"contentHash":"2ab771f4f79212930cb19e5cf4942035df45f2e7f3d4d1a57ed03ccb6677d77a","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"a860f6e24630ad2c4f1964f10f1de3300e01029cf40dae90586c0913a7bf0867","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
+{"contentHash":"f47f26c3b79c1ca93a06c14c3ccb06d9c4742d04eba728f55a880917f7d1bef9","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
+++ b/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
@@ -1,1 +1,1 @@
-{"contentHash":"9c9485971934a4223d97838ab69a6d8cb381092d2e552933c9bf98e6b5d643c6","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}
+{"contentHash":"7e20bf53a813baefaaee19d0931afafb0dc54e63f47155e7a1ef16b296a8cb6c","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}

--- a/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
+++ b/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
@@ -1,1 +1,1 @@
-{"contentHash":"14e9274585375d9e517da0d7a45724407c76a56e57c2ad2a0c12c32e868d31ee","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}
+{"contentHash":"e2d6f4289ee3a4a9b5d9f384261baf45360d401da0c73ea86b925210bad4a063","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}

--- a/docs/gateway/restart-recovery.md
+++ b/docs/gateway/restart-recovery.md
@@ -43,6 +43,19 @@ Only work that cannot finish inside the drain budget (or any run interrupted
 by a forced restart or a crash) is aborted — and before that happens, each
 affected session is marked for recovery.
 
+## Host sleep and process freezes
+
+When a gateway host wakes from sleep, a virtual machine resumes, or the process
+continues after a long pause, the gateway detects the freeze within about 30
+seconds. It restarts channel connections and refreshes cached health and
+presence so clients do not wait for stale sockets or snapshots to expire.
+
+The macOS app cooperates with a local gateway by preparing a short suspension
+lease before the Mac sleeps and resuming it after wake. Remote gateways are not
+suspended when the Mac sleeps. A deliberate suspension through
+`gateway.suspend.*` keeps recovery deferred until the controller resumes the
+gateway.
+
 ## How interrupted work is detected
 
 Three complementary mechanisms mark sessions whose turn did not finish:

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -14,6 +14,7 @@ function createMockChannelManager(overrides?: Partial<ChannelManager>): ChannelM
     getRuntimeSnapshot: vi.fn(() => ({ channels: {}, channelAccounts: {} })),
     getPluginCommandCatalogAccounts: vi.fn(() => new Map()),
     startChannels: vi.fn(async () => {}),
+    restartRunningChannels: vi.fn(async () => {}),
     startChannel: vi.fn(async () => {}),
     stopChannel: vi.fn(async () => {}),
     setAutostartSuppression: vi.fn(),

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -14,7 +14,6 @@ function createMockChannelManager(overrides?: Partial<ChannelManager>): ChannelM
     getRuntimeSnapshot: vi.fn(() => ({ channels: {}, channelAccounts: {} })),
     getPluginCommandCatalogAccounts: vi.fn(() => new Map()),
     startChannels: vi.fn(async () => {}),
-    restartRunningChannels: vi.fn(async () => {}),
     startChannel: vi.fn(async () => {}),
     stopChannel: vi.fn(async () => {}),
     setAutostartSuppression: vi.fn(),

--- a/src/gateway/channel-thaw-restart.ts
+++ b/src/gateway/channel-thaw-restart.ts
@@ -1,0 +1,47 @@
+// Host-thaw channel restart over the public ChannelManager surface.
+import type { ChannelId } from "../channels/plugins/index.js";
+import type { ChannelManager } from "./server-channels.js";
+
+type ThawRestartManager = Pick<
+  ChannelManager,
+  "getRuntimeSnapshot" | "isManuallyStopped" | "stopChannel" | "startChannel"
+>;
+
+/**
+ * Restarts every running, non-manually-stopped channel account after a host
+ * thaw. Dead sockets from a freeze otherwise wait for the slow health sweep.
+ */
+export async function restartRunningChannelAccounts(
+  manager: ThawRestartManager,
+  opts: { shouldContinue: () => boolean; onError: (message: string) => void },
+): Promise<void> {
+  const snapshot = manager.getRuntimeSnapshot();
+  for (const [channelId, accounts] of Object.entries(snapshot.channelAccounts)) {
+    for (const [accountId, status] of Object.entries(accounts ?? {})) {
+      const channel = channelId as ChannelId;
+      if (status?.running !== true || manager.isManuallyStopped(channel, accountId)) {
+        continue;
+      }
+      // A suspension can commit while an account stop is awaited; later
+      // accounts must stay untouched so the prepared gateway remains quiet.
+      if (!opts.shouldContinue()) {
+        return;
+      }
+      try {
+        await manager.stopChannel(channel, accountId, { manual: false });
+        if (!opts.shouldContinue()) {
+          return;
+        }
+        await manager.startChannel(channel, accountId, { preserveManualStop: true });
+        const restarted = manager.getRuntimeSnapshot().channelAccounts[channel]?.[accountId];
+        if (restarted?.restartPending === true) {
+          // A timed-out stop uses a two-call recovery contract: the first call
+          // requests replacement and the second discards the stale task.
+          await manager.startChannel(channel, accountId, { preserveManualStop: true });
+        }
+      } catch (error) {
+        opts.onError(`[${channel}:${accountId}] host-thaw restart failed: ${String(error)}`);
+      }
+    }
+  }
+}

--- a/src/gateway/host-thaw-recovery.test.ts
+++ b/src/gateway/host-thaw-recovery.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import { createHostThawRecovery } from "./host-thaw-recovery.js";
+
+// Mirrors the module-private threshold contract in host-thaw-recovery.ts.
+const HOST_THAW_MIN_FROZEN_MS = 45_000;
+import { TICK_INTERVAL_MS } from "./server-constants.js";
+
+function createHarness() {
+  let nowMs = 0;
+  let admissionClosed = false;
+  const deps = {
+    nowMs: () => nowMs,
+    restartChannels: vi.fn(async () => {}),
+    refreshHealth: vi.fn(async () => {}),
+    refreshPresence: vi.fn(),
+    resetEventLoopHealth: vi.fn(),
+    isAdmissionClosed: () => admissionClosed,
+    logger: { info: vi.fn(), error: vi.fn() },
+  };
+  const recovery = createHostThawRecovery(deps);
+  return {
+    deps,
+    setAdmissionClosed: (closed: boolean) => {
+      admissionClosed = closed;
+    },
+    advance: async (gapMs: number) => {
+      nowMs += gapMs;
+      await recovery.tick();
+    },
+  };
+}
+
+function expectRecoveryCount(harness: ReturnType<typeof createHarness>, count: number) {
+  expect(harness.deps.restartChannels).toHaveBeenCalledTimes(count);
+  expect(harness.deps.refreshHealth).toHaveBeenCalledTimes(count);
+  expect(harness.deps.refreshPresence).toHaveBeenCalledTimes(count);
+  expect(harness.deps.resetEventLoopHealth).toHaveBeenCalledTimes(count);
+}
+
+describe("host thaw recovery", () => {
+  it.each([
+    ["normal cadence", TICK_INTERVAL_MS],
+    ["one millisecond below the thaw threshold", TICK_INTERVAL_MS + HOST_THAW_MIN_FROZEN_MS - 1],
+  ])("does not recover on %s", async (_label, gapMs) => {
+    const harness = createHarness();
+
+    await harness.advance(gapMs);
+
+    expectRecoveryCount(harness, 0);
+    expect(harness.deps.logger.info).not.toHaveBeenCalled();
+  });
+
+  it("recovers and reports the frozen duration at the threshold", async () => {
+    const harness = createHarness();
+
+    await harness.advance(TICK_INTERVAL_MS + HOST_THAW_MIN_FROZEN_MS);
+
+    expectRecoveryCount(harness, 1);
+    expect(harness.deps.logger.info).toHaveBeenCalledWith(
+      expect.stringContaining(`frozen ~${HOST_THAW_MIN_FROZEN_MS}ms`),
+    );
+  });
+
+  it("defers a detected thaw until admission reopens and recovers once", async () => {
+    const harness = createHarness();
+    harness.setAdmissionClosed(true);
+
+    await harness.advance(TICK_INTERVAL_MS + HOST_THAW_MIN_FROZEN_MS);
+    expectRecoveryCount(harness, 0);
+
+    harness.setAdmissionClosed(false);
+    await harness.advance(TICK_INTERVAL_MS);
+    await harness.advance(TICK_INTERVAL_MS);
+
+    expectRecoveryCount(harness, 1);
+  });
+
+  it("re-pends the full recovery when admission closes between steps", async () => {
+    const harness = createHarness();
+    harness.deps.resetEventLoopHealth.mockImplementationOnce(() => {
+      harness.setAdmissionClosed(true);
+    });
+
+    await harness.advance(TICK_INTERVAL_MS + HOST_THAW_MIN_FROZEN_MS);
+
+    expect(harness.deps.resetEventLoopHealth).toHaveBeenCalledTimes(1);
+    expect(harness.deps.restartChannels).not.toHaveBeenCalled();
+    expect(harness.deps.refreshHealth).not.toHaveBeenCalled();
+    expect(harness.deps.refreshPresence).not.toHaveBeenCalled();
+
+    harness.setAdmissionClosed(false);
+    await harness.advance(TICK_INTERVAL_MS);
+
+    expect(harness.deps.restartChannels).toHaveBeenCalledTimes(1);
+    expect(harness.deps.refreshHealth).toHaveBeenCalledTimes(1);
+    expect(harness.deps.refreshPresence).toHaveBeenCalledTimes(1);
+    expect(harness.deps.resetEventLoopHealth).toHaveBeenCalledTimes(2);
+    expect(harness.deps.logger.info).toHaveBeenCalledWith(
+      "host thaw recovery deferred: gateway suspension began mid-recovery",
+    );
+  });
+
+  it("recovers independently after consecutive thaws", async () => {
+    const harness = createHarness();
+    const thawGap = TICK_INTERVAL_MS + HOST_THAW_MIN_FROZEN_MS;
+
+    await harness.advance(thawGap);
+    await harness.advance(thawGap);
+
+    expectRecoveryCount(harness, 2);
+  });
+});

--- a/src/gateway/host-thaw-recovery.ts
+++ b/src/gateway/host-thaw-recovery.ts
@@ -1,0 +1,75 @@
+import { TICK_INTERVAL_MS } from "./server-constants.js";
+
+// A real host freeze loses at least 45s beyond the expected maintenance cadence;
+// shorter gaps are ordinary event-loop load and must not churn channel sockets.
+const HOST_THAW_MIN_FROZEN_MS = 45_000;
+
+type HostThawDeps = {
+  nowMs: () => number;
+  restartChannels: () => Promise<void>;
+  refreshHealth: () => Promise<void>;
+  refreshPresence: () => void;
+  resetEventLoopHealth: () => void;
+  isAdmissionClosed: () => boolean;
+  logger: { info: (message: string) => void; error: (message: string) => void };
+};
+
+export function createHostThawRecovery(deps: HostThawDeps): { tick: () => Promise<void> } {
+  let lastTickAtMs = deps.nowMs();
+  let pendingFrozenMs: number | undefined;
+  let activeRecovery: Promise<void> | undefined;
+
+  const runStep = async (label: string, step: () => void | Promise<void>) => {
+    try {
+      await step();
+    } catch (error) {
+      deps.logger.error(`host thaw ${label} failed: ${String(error)}`);
+    }
+  };
+
+  const recover = async (frozenMs: number) => {
+    deps.logger.info(
+      `host thaw detected: process was frozen ~${Math.round(frozenMs)}ms; restarting channels and refreshing health`,
+    );
+    const recoverySteps: ReadonlyArray<readonly [string, () => void | Promise<void>]> = [
+      ["event-loop reset", deps.resetEventLoopHealth],
+      ["channel restart", deps.restartChannels],
+      ["health refresh", deps.refreshHealth],
+      ["presence refresh", deps.refreshPresence],
+    ];
+    for (const [label, step] of recoverySteps) {
+      if (deps.isAdmissionClosed()) {
+        // Every recovery step is idempotent, so a partially completed thaw is
+        // deliberately replayed from the start after admission reopens.
+        pendingFrozenMs = Math.max(pendingFrozenMs ?? 0, frozenMs);
+        deps.logger.info("host thaw recovery deferred: gateway suspension began mid-recovery");
+        return;
+      }
+      await runStep(label, step);
+    }
+  };
+
+  return {
+    tick: async () => {
+      const nowMs = deps.nowMs();
+      const gapMs = nowMs - lastTickAtMs;
+      lastTickAtMs = nowMs;
+      if (gapMs >= TICK_INTERVAL_MS + HOST_THAW_MIN_FROZEN_MS) {
+        pendingFrozenMs = Math.max(pendingFrozenMs ?? 0, gapMs - TICK_INTERVAL_MS);
+      }
+      // Suspension/restart owns the closed period. Recovery must wait rather than
+      // waking channels while the controller deliberately keeps the gateway quiet.
+      if (pendingFrozenMs === undefined || deps.isAdmissionClosed() || activeRecovery) {
+        return;
+      }
+      const frozenMs = pendingFrozenMs;
+      pendingFrozenMs = undefined;
+      activeRecovery = recover(frozenMs);
+      try {
+        await activeRecovery;
+      } finally {
+        activeRecovery = undefined;
+      }
+    },
+  };
+}

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -934,6 +934,46 @@ describe("server-channels auto restart", () => {
     expect(account?.restartPending).toBe(false);
   });
 
+  it("sanitizes late writes from an abandoned stopAccount racing a replacement", async () => {
+    let releaseStop: (() => void) | undefined;
+    let lateSetStatus: ((next: ChannelAccountSnapshot) => void) | undefined;
+    const stopAccount = vi.fn(
+      async ({ setStatus }: { setStatus: (next: ChannelAccountSnapshot) => void }) => {
+        lateSetStatus = setStatus;
+        await new Promise<void>((resolve) => {
+          releaseStop = resolve;
+        });
+      },
+    );
+    const startAccount = vi.fn(async ({ abortSignal }: { abortSignal: AbortSignal }) => {
+      await new Promise<void>((resolve) => {
+        abortSignal.addEventListener("abort", () => resolve(), { once: true });
+      });
+    });
+    installTestRegistry(createTestPlugin({ startAccount, stopAccount }));
+    const manager = createManager();
+    await manager.startChannels();
+    await vi.waitFor(() => expect(startAccount).toHaveBeenCalledTimes(1));
+
+    const restartTask = restartRunningChannelAccounts(manager, {
+      shouldContinue: () => true,
+      onError: () => {},
+    });
+    await vi.advanceTimersByTimeAsync(11_000);
+    await restartTask;
+    const replacement = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(replacement?.running).toBe(true);
+
+    // The abandoned stop settles late and tries to repaint the replacement.
+    lateSetStatus?.({ accountId: DEFAULT_ACCOUNT_ID, running: false, lifecycle: "stopped" });
+    releaseStop?.();
+    await flushMicrotasks();
+
+    const after = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(after?.running).toBe(true);
+    expect(after?.lifecycle).not.toBe("stopped");
+  });
+
   it("stops thaw restarts once admission closes mid-pass", async () => {
     const starts: string[] = [];
     const stops: string[] = [];

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -880,6 +880,56 @@ describe("server-channels auto restart", () => {
     expect(startAccount).toHaveBeenCalledTimes(1);
   });
 
+  it("restarts only running accounts after a host thaw", async () => {
+    const starts: string[] = [];
+    const stops: string[] = [];
+    installTestRegistry(
+      createTestPlugin({
+        listAccountIds: () => ["running", "manual"],
+        startAccount: async (context) => {
+          starts.push(context.accountId);
+          await new Promise<void>((resolve) => {
+            context.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+          });
+        },
+        stopAccount: async (context) => {
+          stops.push(context.accountId);
+        },
+      }),
+    );
+    const manager = createManager();
+    await manager.startChannels();
+    await vi.waitFor(() => expect(starts).toHaveLength(2));
+    await manager.stopChannel("discord", "manual");
+    starts.length = 0;
+    stops.length = 0;
+
+    await manager.restartRunningChannels();
+
+    expect(starts).toEqual(["running"]);
+    expect(stops).toEqual(["running"]);
+    expect(manager.isManuallyStopped("discord", "manual")).toBe(true);
+  });
+
+  it("completes a timed-out channel restart in one host-thaw pass", async () => {
+    const startAccount = vi.fn(async ({ abortSignal }: { abortSignal: AbortSignal }) => {
+      abortSignal.addEventListener("abort", () => {}, { once: true });
+      await new Promise<void>(() => {});
+    });
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager();
+    await manager.startChannels();
+
+    const restartTask = manager.restartRunningChannels();
+    await vi.advanceTimersByTimeAsync(5_000);
+    await restartTask;
+
+    const account = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(startAccount).toHaveBeenCalledTimes(2);
+    expect(account?.running).toBe(true);
+    expect(account?.restartPending).toBe(false);
+  });
+
   it("does not auto-restart a channel task exit marked as terminal disconnect", async () => {
     const lifecycleAtHandoff: Array<ChannelAccountSnapshot["lifecycle"]> = [];
     const startAccount = vi.fn(

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -930,6 +930,31 @@ describe("server-channels auto restart", () => {
     expect(account?.restartPending).toBe(false);
   });
 
+  it("bounds a hung stopAccount so a host-thaw restart still completes", async () => {
+    const stopAccount = vi.fn(async () => {
+      // A pathological plugin stop that never settles must not wedge recovery.
+      await new Promise<void>(() => {});
+    });
+    const startAccount = vi.fn(async ({ abortSignal }: { abortSignal: AbortSignal }) => {
+      await new Promise<void>((resolve) => {
+        abortSignal.addEventListener("abort", () => resolve(), { once: true });
+      });
+    });
+    installTestRegistry(createTestPlugin({ startAccount, stopAccount }));
+    const manager = createManager();
+    await manager.startChannels();
+    await vi.waitFor(() => expect(startAccount).toHaveBeenCalledTimes(1));
+
+    const restartTask = manager.restartRunningChannels();
+    await vi.advanceTimersByTimeAsync(11_000);
+    await restartTask;
+
+    const account = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(stopAccount).toHaveBeenCalledTimes(1);
+    expect(startAccount.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(account?.running).toBe(true);
+  });
+
   it("does not auto-restart a channel task exit marked as terminal disconnect", async () => {
     const lifecycleAtHandoff: Array<ChannelAccountSnapshot["lifecycle"]> = [];
     const startAccount = vi.fn(

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -34,6 +34,7 @@ import {
 } from "../secrets/runtime-degraded-state.js";
 import { evaluateChannelHealth } from "./channel-health-policy.js";
 import { channelReadyPatch, createTransportActivityStatusPatch } from "./channel-status-patches.js";
+import { restartRunningChannelAccounts } from "./channel-thaw-restart.js";
 import { createChannelManager, type ChannelManager } from "./server-channels.js";
 
 const hoisted = vi.hoisted(() => {
@@ -904,7 +905,7 @@ describe("server-channels auto restart", () => {
     starts.length = 0;
     stops.length = 0;
 
-    await manager.restartRunningChannels();
+    await restartRunningChannelAccounts(manager, { shouldContinue: () => true, onError: () => {} });
 
     expect(starts).toEqual(["running"]);
     expect(stops).toEqual(["running"]);
@@ -920,7 +921,10 @@ describe("server-channels auto restart", () => {
     const manager = createManager();
     await manager.startChannels();
 
-    const restartTask = manager.restartRunningChannels();
+    const restartTask = restartRunningChannelAccounts(manager, {
+      shouldContinue: () => true,
+      onError: () => {},
+    });
     await vi.advanceTimersByTimeAsync(5_000);
     await restartTask;
 
@@ -928,6 +932,45 @@ describe("server-channels auto restart", () => {
     expect(startAccount).toHaveBeenCalledTimes(2);
     expect(account?.running).toBe(true);
     expect(account?.restartPending).toBe(false);
+  });
+
+  it("stops thaw restarts once admission closes mid-pass", async () => {
+    const starts: string[] = [];
+    const stops: string[] = [];
+    installTestRegistry(
+      createTestPlugin({
+        listAccountIds: () => ["first", "second"],
+        startAccount: async (context) => {
+          starts.push(context.accountId);
+          await new Promise<void>((resolve) => {
+            context.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+          });
+        },
+        stopAccount: async (context) => {
+          stops.push(context.accountId);
+        },
+      }),
+    );
+    const manager = createManager();
+    await manager.startChannels();
+    await vi.waitFor(() => expect(starts).toHaveLength(2));
+    starts.length = 0;
+    stops.length = 0;
+
+    let open = true;
+    await restartRunningChannelAccounts(manager, {
+      shouldContinue: () => {
+        if (stops.length > 0) {
+          // Simulate a suspension committing while the first stop was awaited.
+          open = false;
+        }
+        return open;
+      },
+      onError: () => {},
+    });
+
+    expect(stops).toEqual(["first"]);
+    expect(starts).toEqual([]);
   });
 
   it("bounds a hung stopAccount so a host-thaw restart still completes", async () => {
@@ -945,7 +988,10 @@ describe("server-channels auto restart", () => {
     await manager.startChannels();
     await vi.waitFor(() => expect(startAccount).toHaveBeenCalledTimes(1));
 
-    const restartTask = manager.restartRunningChannels();
+    const restartTask = restartRunningChannelAccounts(manager, {
+      shouldContinue: () => true,
+      onError: () => {},
+    });
     await vi.advanceTimersByTimeAsync(11_000);
     await restartTask;
 

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -258,6 +258,7 @@ export type ChannelManager = {
   getRuntimeSnapshot: () => ChannelRuntimeSnapshot;
   getPluginCommandCatalogAccounts: () => ReadonlyMap<ChannelId, ReadonlySet<string>>;
   startChannels: () => Promise<void>;
+  restartRunningChannels: () => Promise<void>;
   startChannel: (
     channel: ChannelId,
     accountId?: string,
@@ -1348,6 +1349,31 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         .map(([channelId, store]) => [channelId, new Set(store.pluginCommandCatalogOwners.keys())]),
     );
 
+  const restartRunningChannels = async () => {
+    const snapshot = getRuntimeSnapshot();
+    for (const [channelId, accounts] of Object.entries(snapshot.channelAccounts)) {
+      for (const [accountId, status] of Object.entries(accounts ?? {})) {
+        const channel = channelId as ChannelId;
+        if (status?.running !== true || isManuallyStoppedFlag(channel, accountId)) {
+          continue;
+        }
+        try {
+          await stopChannel(channel, accountId, { manual: false });
+          await startChannel(channel, accountId, { preserveManualStop: true });
+          if (getRuntime(channel, accountId).restartPending === true) {
+            // A timed-out stop uses a two-call recovery contract: the first call
+            // requests replacement and the second discards the stale task.
+            await startChannel(channel, accountId, { preserveManualStop: true });
+          }
+        } catch (error) {
+          ensureChannelLog(channel).error?.(
+            `[${accountId}] host-thaw restart failed: ${formatErrorMessage(error)}`,
+          );
+        }
+      }
+    }
+  };
+
   const isManuallyStoppedFlag = (channelId: ChannelId, accountId: string): boolean => {
     return manuallyStopped.has(restartKey(channelId, accountId));
   };
@@ -1364,6 +1390,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     getRuntimeSnapshot,
     getPluginCommandCatalogAccounts,
     startChannels,
+    restartRunningChannels,
     startChannel,
     stopChannel,
     setAutostartSuppression: (suppression) => {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -258,7 +258,6 @@ export type ChannelManager = {
   getRuntimeSnapshot: () => ChannelRuntimeSnapshot;
   getPluginCommandCatalogAccounts: () => ReadonlyMap<ChannelId, ReadonlySet<string>>;
   startChannels: () => Promise<void>;
-  restartRunningChannels: () => Promise<void>;
   startChannel: (
     channel: ChannelId,
     accountId?: string,
@@ -1367,31 +1366,6 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         .map(([channelId, store]) => [channelId, new Set(store.pluginCommandCatalogOwners.keys())]),
     );
 
-  const restartRunningChannels = async () => {
-    const snapshot = getRuntimeSnapshot();
-    for (const [channelId, accounts] of Object.entries(snapshot.channelAccounts)) {
-      for (const [accountId, status] of Object.entries(accounts ?? {})) {
-        const channel = channelId as ChannelId;
-        if (status?.running !== true || isManuallyStoppedFlag(channel, accountId)) {
-          continue;
-        }
-        try {
-          await stopChannel(channel, accountId, { manual: false });
-          await startChannel(channel, accountId, { preserveManualStop: true });
-          if (getRuntime(channel, accountId).restartPending === true) {
-            // A timed-out stop uses a two-call recovery contract: the first call
-            // requests replacement and the second discards the stale task.
-            await startChannel(channel, accountId, { preserveManualStop: true });
-          }
-        } catch (error) {
-          ensureChannelLog(channel).error?.(
-            `[${accountId}] host-thaw restart failed: ${formatErrorMessage(error)}`,
-          );
-        }
-      }
-    }
-  };
-
   const isManuallyStoppedFlag = (channelId: ChannelId, accountId: string): boolean => {
     return manuallyStopped.has(restartKey(channelId, accountId));
   };
@@ -1408,7 +1382,6 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     getRuntimeSnapshot,
     getPluginCommandCatalogAccounts,
     startChannels,
-    restartRunningChannels,
     startChannel,
     stopChannel,
     setAutostartSuppression: (suppression) => {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -1123,16 +1123,34 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           if (plugin?.gateway?.stopAccount) {
             try {
               const account = plugin.config.resolveAccount(cfg, id);
-              await plugin.gateway.stopAccount({
-                cfg,
-                accountId: id,
-                account,
-                runtime,
-                abortSignal: abort?.signal ?? new AbortController().signal,
-                log,
-                getStatus: () => getRuntime(channelId, id),
-                setStatus: (next) => setRuntime(channelId, id, next),
-              });
+              // A plugin stopAccount that never settles must not wedge every
+              // stop-driven flow (health monitor sweeps, thaw recovery, reload).
+              // Bound it like the task teardown below; the timed-out path flows
+              // into the existing recoveryStopTimedOut two-call restart contract.
+              const stopAccountAttempt = plugin.gateway
+                .stopAccount({
+                  cfg,
+                  accountId: id,
+                  account,
+                  runtime,
+                  abortSignal: abort?.signal ?? new AbortController().signal,
+                  log,
+                  getStatus: () => getRuntime(channelId, id),
+                  setStatus: (next) => setRuntime(channelId, id, next),
+                })
+                .catch((error: unknown) => {
+                  outcome = { status: "rejected", error };
+                  log.warn?.(`[${id}] stopAccount failed: ${formatErrorMessage(error)}`);
+                });
+              const stopAccountSettled = await waitForChannelStopGracefully(
+                stopAccountAttempt,
+                CHANNEL_STOP_ABORT_TIMEOUT_MS,
+              );
+              if (!stopAccountSettled) {
+                log.warn?.(
+                  `[${id}] stopAccount exceeded ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms; continuing stop`,
+                );
+              }
             } catch (error) {
               outcome = { status: "rejected", error };
               log.warn?.(`[${id}] stopAccount failed: ${formatErrorMessage(error)}`);

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -1126,6 +1126,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               // stop-driven flow (health monitor sweeps, thaw recovery, reload).
               // Bound it like the task teardown below; the timed-out path flows
               // into the existing recoveryStopTimedOut two-call restart contract.
+              let stopAttemptAbandoned = false;
               const stopAccountAttempt = plugin.gateway
                 .stopAccount({
                   cfg,
@@ -1135,9 +1136,25 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                   abortSignal: abort?.signal ?? new AbortController().signal,
                   log,
                   getStatus: () => getRuntime(channelId, id),
-                  setStatus: (next) => setRuntime(channelId, id, next),
+                  setStatus: (next) => {
+                    // A stop we abandoned may settle after a replacement started;
+                    // its late writes must not repaint or tear down that account.
+                    setRuntime(
+                      channelId,
+                      id,
+                      stopAttemptAbandoned
+                        ? sanitizeAbortedTaskStatusPatch(next, getRuntime(channelId, id))
+                        : next,
+                    );
+                  },
                 })
                 .catch((error: unknown) => {
+                  if (stopAttemptAbandoned) {
+                    log.warn?.(
+                      `[${id}] abandoned stopAccount failed late: ${formatErrorMessage(error)}`,
+                    );
+                    return;
+                  }
                   outcome = { status: "rejected", error };
                   log.warn?.(`[${id}] stopAccount failed: ${formatErrorMessage(error)}`);
                 });
@@ -1146,6 +1163,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 CHANNEL_STOP_ABORT_TIMEOUT_MS,
               );
               if (!stopAccountSettled) {
+                stopAttemptAbandoned = true;
                 log.warn?.(
                   `[${id}] stopAccount exceeded ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms; continuing stop`,
                 );

--- a/src/gateway/server-core-runtime.ts
+++ b/src/gateway/server-core-runtime.ts
@@ -26,7 +26,12 @@ import { resolveGatewayStartupPluginActivationConfig } from "./plugin-activation
 import type { prepareGatewayLifecycle } from "./server-lifecycle.js";
 import type { GatewayRequestHandlers } from "./server-methods/types.js";
 import type { GatewayPluginReloadResult } from "./server-reload-handlers.js";
-import { getHealthVersion, getPresenceVersion } from "./server/health-state.js";
+import {
+  getHealthVersion,
+  getPresenceVersion,
+  incrementPresenceVersion,
+} from "./server/health-state.js";
+import { broadcastPresenceSnapshot } from "./server/presence-events.js";
 
 type GatewayLifecycle = Awaited<ReturnType<typeof prepareGatewayLifecycle>>;
 type GatewayLogger = ReturnType<typeof createSubsystemLogger>;
@@ -115,6 +120,7 @@ export async function startGatewayCoreRuntime(input: {
     kernel,
     startupTrace,
     channelManager,
+    readinessEventLoopHealth,
     workerDispatchAuthority,
     clients,
     startChannel,
@@ -168,6 +174,10 @@ export async function startGatewayCoreRuntime(input: {
         getPresenceVersion,
         getHealthVersion,
         refreshGatewayHealthSnapshot: refreshGatewayHealthSnapshotWithRuntime,
+        restartRunningChannels: channelManager.restartRunningChannels,
+        refreshPresence: () =>
+          broadcastPresenceSnapshot({ broadcast, incrementPresenceVersion, getHealthVersion }),
+        resetEventLoopHealth: readinessEventLoopHealth.reset,
         logHealth,
         dedupe,
         chatAbortControllers,

--- a/src/gateway/server-core-runtime.ts
+++ b/src/gateway/server-core-runtime.ts
@@ -9,7 +9,9 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { completePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import { isGatewayWorkAdmissionClosed } from "../process/gateway-work-admission.js";
 import { createAgentRuntimeApprovalAuthorityValidator } from "./agent-runtime-identity-token.js";
+import { restartRunningChannelAccounts } from "./channel-thaw-restart.js";
 import type { ExecApprovalManager } from "./exec-approval-manager.js";
 import { revokeAttachGrantsForSession } from "./mcp-grant-store.js";
 import { ADMIN_SCOPE } from "./method-scopes.js";
@@ -174,7 +176,11 @@ export async function startGatewayCoreRuntime(input: {
         getPresenceVersion,
         getHealthVersion,
         refreshGatewayHealthSnapshot: refreshGatewayHealthSnapshotWithRuntime,
-        restartRunningChannels: channelManager.restartRunningChannels,
+        restartRunningChannels: async () =>
+          await restartRunningChannelAccounts(channelManager, {
+            shouldContinue: () => !isGatewayWorkAdmissionClosed(),
+            onError: (message) => logHealth.error(message),
+          }),
         refreshPresence: () =>
           broadcastPresenceSnapshot({ broadcast, incrementPresenceVersion, getHealthVersion }),
         resetEventLoopHealth: readinessEventLoopHealth.reset,

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -48,7 +48,7 @@ function createActiveRun(
 function createMaintenanceTimerDeps() {
   return {
     ...createGatewayMaintenanceStateForTest(),
-    logHealth: { error: vi.fn() },
+    logHealth: { info: vi.fn(), error: vi.fn() },
     runWorktreeGc: vi.fn(async () => undefined),
     runDeliveryQueueMediaGc: vi.fn(async () => undefined),
     runManagedOutgoingMediaGc: cleanupManagedOutgoingMediaRecordsMock,
@@ -327,7 +327,7 @@ describe("startGatewayMaintenanceTimers", () => {
     const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");
     const deps = {
       ...createMaintenanceTimerDeps(),
-      logHealth: { error: vi.fn() },
+      logHealth: { info: vi.fn(), error: vi.fn() },
     };
 
     const timers = startGatewayMaintenanceTimers({

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -12,6 +12,7 @@ import { sweepStaleRunContexts } from "../infra/agent-run-registry.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { pruneOrphanedDeliveryQueueMedia } from "../infra/outbound/delivery-queue-media-spool.js";
 import { cleanOldMedia, prunePlaybackTranscodeCache } from "../media/store.js";
+import { isGatewayWorkAdmissionClosed } from "../process/gateway-work-admission.js";
 import { createLazyPromiseLoader } from "../shared/lazy-promise.js";
 import {
   runScheduledSkillCollectionReviews,
@@ -26,6 +27,7 @@ import {
 import type { QueuedChatTurnMap } from "./chat-queued-turns.js";
 import { pruneStaleControlPlaneBuckets } from "./control-plane-rate-limit.js";
 import type { HealthSummary } from "./health/types.js";
+import { createHostThawRecovery } from "./host-thaw-recovery.js";
 import { chatAbortMarkerTimestampMs } from "./server-chat-state.js";
 import type { ChatRunState } from "./server-chat-state.js";
 import type { ChatRunEntry } from "./server-chat.js";
@@ -67,7 +69,10 @@ export function startGatewayMaintenanceTimers(params: {
     probe?: boolean;
     includeSensitive?: boolean;
   }) => Promise<HealthSummary>;
-  logHealth: { error: (msg: string) => void };
+  logHealth: { info: (msg: string) => void; error: (msg: string) => void };
+  restartRunningChannels: () => Promise<void>;
+  refreshPresence: () => void;
+  resetEventLoopHealth: () => void;
   dedupe: Map<string, DedupeEntry>;
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   chatQueuedTurns: QueuedChatTurnMap;
@@ -106,8 +111,21 @@ export function startGatewayMaintenanceTimers(params: {
     params.nodeSendToAllSubscribed("health", snap);
   });
 
+  const hostThawRecovery = createHostThawRecovery({
+    nowMs: Date.now,
+    restartChannels: params.restartRunningChannels,
+    refreshHealth: async () => {
+      await params.refreshGatewayHealthSnapshot({ probe: true });
+    },
+    refreshPresence: params.refreshPresence,
+    resetEventLoopHealth: params.resetEventLoopHealth,
+    isAdmissionClosed: isGatewayWorkAdmissionClosed,
+    logger: params.logHealth,
+  });
+
   // periodic keepalive
   const tickInterval = setInterval(() => {
+    void hostThawRecovery.tick();
     const payload = { ts: Date.now() };
     params.broadcast("tick", payload);
     params.nodeSendToAllSubscribed("tick", payload);

--- a/src/gateway/server-startup-early.ts
+++ b/src/gateway/server-startup-early.ts
@@ -77,6 +77,9 @@ export async function startGatewayEarlyRuntime(params: {
   getPresenceVersion: GatewayMaintenanceParams["getPresenceVersion"];
   getHealthVersion: GatewayMaintenanceParams["getHealthVersion"];
   refreshGatewayHealthSnapshot: GatewayMaintenanceParams["refreshGatewayHealthSnapshot"];
+  restartRunningChannels: GatewayMaintenanceParams["restartRunningChannels"];
+  refreshPresence: GatewayMaintenanceParams["refreshPresence"];
+  resetEventLoopHealth: GatewayMaintenanceParams["resetEventLoopHealth"];
   logHealth: GatewayMaintenanceParams["logHealth"];
   dedupe: GatewayMaintenanceParams["dedupe"];
   chatAbortControllers: GatewayMaintenanceParams["chatAbortControllers"];
@@ -177,6 +180,9 @@ export async function startGatewayEarlyRuntime(params: {
         getPresenceVersion: params.getPresenceVersion,
         getHealthVersion: params.getHealthVersion,
         refreshGatewayHealthSnapshot: params.refreshGatewayHealthSnapshot,
+        restartRunningChannels: params.restartRunningChannels,
+        refreshPresence: params.refreshPresence,
+        resetEventLoopHealth: params.resetEventLoopHealth,
         logHealth: params.logHealth,
         dedupe: params.dedupe,
         chatAbortControllers: params.chatAbortControllers,

--- a/src/gateway/server/event-loop-health.test.ts
+++ b/src/gateway/server/event-loop-health.test.ts
@@ -254,4 +254,19 @@ describe("createGatewayEventLoopHealthMonitor", () => {
     expect(harness.delayMonitor["disable"]).toHaveBeenCalledTimes(1);
     expect(harness.monitor.snapshot()).toBeUndefined();
   });
+
+  it("resets delay and rate baselines after a host thaw", () => {
+    const harness = createMonitorHarness({ cpuMsPerWallMs: 0.1, utilization: 0.2 });
+    harness.setDelay({ maxMs: 90_000 });
+    harness.setNow(90_000);
+
+    harness.monitor.reset();
+    harness.setNow(91_000);
+
+    expectSnapshotFields(harness.monitor.snapshot(), {
+      degraded: false,
+      intervalMs: 1_000,
+      delayMaxMs: 0,
+    });
+  });
 });

--- a/src/gateway/server/event-loop-health.ts
+++ b/src/gateway/server/event-loop-health.ts
@@ -30,6 +30,7 @@ export type GatewayEventLoopHealth = {
 type GatewayEventLoopHealthMonitor = {
   snapshot: () => GatewayEventLoopHealth | undefined;
   persistentDegradationSnapshot: () => GatewayEventLoopHealth | undefined;
+  reset: () => void;
   stop: () => void;
 };
 
@@ -177,6 +178,15 @@ export function createGatewayEventLoopHealthMonitor(
     return health;
   };
 
+  const reset = () => {
+    monitor?.reset();
+    lastWallAt = nowMs();
+    lastCpuUsage = readCpuUsage();
+    lastEventLoopUtilization = readEventLoopUtilization();
+    lastSnapshot = undefined;
+    firstDegradedAtMs = null;
+  };
+
   return {
     snapshot,
     // The diagnostic heartbeat is the timer owner. This filtered pull keeps
@@ -188,6 +198,7 @@ export function createGatewayEventLoopHealthMonitor(
         ? current
         : undefined;
     },
+    reset,
     stop: () => {
       monitor?.disable();
       monitor = null;

--- a/src/gateway/server/readiness.test.ts
+++ b/src/gateway/server/readiness.test.ts
@@ -32,7 +32,6 @@ function createManager(snapshot: ChannelRuntimeSnapshot): ChannelManager {
     getRuntimeSnapshot: vi.fn(() => snapshot),
     getPluginCommandCatalogAccounts: vi.fn(() => new Map()),
     startChannels: vi.fn(),
-    restartRunningChannels: vi.fn(),
     startChannel: vi.fn(),
     stopChannel: vi.fn(),
     setAutostartSuppression: vi.fn(),

--- a/src/gateway/server/readiness.test.ts
+++ b/src/gateway/server/readiness.test.ts
@@ -32,6 +32,7 @@ function createManager(snapshot: ChannelRuntimeSnapshot): ChannelManager {
     getRuntimeSnapshot: vi.fn(() => snapshot),
     getPluginCommandCatalogAccounts: vi.fn(() => new Map()),
     startChannels: vi.fn(),
+    restartRunningChannels: vi.fn(),
     startChannel: vi.fn(),
     stopChannel: vi.fn(),
     setAutostartSuppression: vi.fn(),

--- a/src/gateway/test-helpers.maintenance-state.ts
+++ b/src/gateway/test-helpers.maintenance-state.ts
@@ -17,7 +17,10 @@ export function createGatewayMaintenanceStateForTest(params?: {
     getHealthVersion: () => params?.healthVersion ?? 1,
     refreshGatewayHealthSnapshot: async () =>
       params?.healthSummary ?? ({ ok: true } as HealthSummary),
-    logHealth: { error: () => {} },
+    logHealth: { info: () => {}, error: () => {} },
+    restartRunningChannels: async () => {},
+    refreshPresence: () => {},
+    resetEventLoopHealth: () => {},
     dedupe: new Map(),
     chatAbortControllers: new Map(),
     chatQueuedTurns: new Map(),


### PR DESCRIPTION
## What Problem This Solves

When the host sleeps (laptop lid, VM pause, `SIGSTOP`), the gateway freezes with no warning and recovers badly: there is no freeze detection anywhere, channel sockets killed during sleep take up to ~35 minutes to notice (30-minute stale threshold + 5-minute health sweep), health/presence serve stale data, and the frozen interval registers as a giant phantom event-loop delay spike. The macOS app — the gateway's own supervisor — has no sleep/wake awareness at all, even though #122100 gave it a complete cooperative-suspension RPC to use.

Cron needs nothing: its timer delay is already clamped to 60 s specifically to recover from pauses ([timer-scheduler.ts:95](../blob/HEAD/src/cron/service/timer-scheduler.ts)), so this PR deliberately does not touch cron.

## Why This Change Was Made

- **Core thaw detector** ([host-thaw-recovery.ts](../blob/HEAD/src/gateway/host-thaw-recovery.ts)): dependency-free, rides the existing 30 s maintenance tick — no new timers, residents, or config. A tick arriving ≥45 s late beyond cadence declares a thaw; recovery restarts running channel accounts (new `ChannelManager.restartRunningChannels`, manual stops respected), refreshes health + presence, and resets the event-loop histogram so the freeze does not read as degradation. If work admission is closed (deliberate suspension or restart drain) recovery defers to the first open tick — a controller-suspended gateway stays quiet until resumed.
- **macOS app cooperation** ([GatewaySleepCycleController.swift](../blob/HEAD/apps/macos/Sources/OpenClaw/GatewaySleepCycleController.swift)): `NSWorkspace` will-sleep/did-wake observers owned by `GatewayConnectivityCoordinator`, gated to local-mode gateways only. Will-sleep best-effort calls `gateway.suspend.prepare` (3 s timeout, never blocks or delays sleep; busy → log and proceed). Did-wake resumes a held suspension and nudges the endpoint store; a generation counter discards prepare responses that land after wake. Failure is always safe: the lease self-expires in 2 minutes.

Production LOC is modest (+~150 core TS + ~150 Swift, tests separate); the SDK baseline refresh is the additive `restartRunningChannels` on `ChannelManager` rippling through entrypoint type graphs.

## User Impact

A Mac (or any host) waking from sleep gets a responsive bot within ~30 seconds instead of up to 35 minutes of silently dead channel connections — the worst bug class: actions producing nothing with nothing explaining why. Operators see one clear log line (`host thaw detected: process was frozen ~Nms; restarting channels and refreshing health`). Docs: https://docs.openclaw.ai/gateway/restart-recovery

## Evidence

- **Live freeze proof** (isolated dev gateway, dist build, port 19878): `SIGSTOP` for 85 s → on `SIGCONT` the pending tick fired immediately: `host thaw detected: process was frozen ~57683ms; restarting channels and refreshing health`; post-thaw `health ok: true`, `eventLoop.degraded: false` (histogram reset worked), zero errors in the gateway log.
- Focused vitest: host-thaw-recovery 5/5 (cadence/threshold/deferral/repeat cases), server-channels 31 incl. running-only + manual-stop restart coverage, event-loop-health reset, maintenance fixtures, channel-health-monitor + readiness stubs — 142 + 77 tests green.
- `swift build` + full macOS suite: 1,675 tests / 181 suites green, incl. 4 new `GatewaySleepCycleControllerTests` (ready→resume once; busy → no resume but refresh; remote mode inert).
- `pnpm tsgo:core` + `tsgo:core:test`, oxlint on changed files, `format:check`, `check:import-cycles`, `plugin-sdk:api:check` + `surface:check`, `pnpm build` (no `[INEFFECTIVE_DYNAMIC_IMPORT]`) — all green locally. The knip deadcode gate could not run locally (broken shared pnpm dlx cache; it passed on the worker's Testbox run and runs in CI).
- Codex autoreview (Sol, high): clean, no actionable findings (0.98).

Not live-tested: a real lid-close sleep cycle through the macOS app observers (would suspend the machine running the test); covered by the Swift unit tests plus the live suspend/resume RPC proof from #122100.
