### PR TITLE
fix(media): let sandboxed agents read staged documents

### DIFF
--- a/src/auto-reply/reply/get-reply.message-hooks.test.ts
+++ b/src/auto-reply/reply/get-reply.message-hooks.test.ts
@@ -468,6 +468,48 @@ describe("getReplyFromConfig message hooks", () => {
     expect(enable).not.toHaveBeenCalled();
   });
 
+  it("promotes a remote document staged before media understanding", async () => {
+    const remotePath = "/remote/report.docx";
+    const stagedPath = "media/inbound/report.docx";
+    const contentType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+    vi.mocked(stageSandboxMediaMock).mockImplementationOnce(async (params) => {
+      const stagedFacts = [
+        {
+          path: stagedPath,
+          contentType,
+          workspaceDir: "/tmp/workspace",
+        },
+      ];
+      params.ctx.media = stagedFacts;
+      params.sessionCtx.media = stagedFacts;
+      return { staged: new Map([[0, stagedPath]]) };
+    });
+    const enable = await runLocalPathSelfServeCase({
+      ctx: {
+        ...hostDocumentCtx,
+        media: [
+          {
+            path: remotePath,
+            contentType,
+          },
+        ],
+        MediaRemoteHost: "user@gateway-host",
+        OriginatingChannel: "telegram",
+        AccountId: "default",
+        SenderId: "42",
+      },
+      cfg: {
+        agents: {
+          defaults: { sandbox: { mode: "non-main", scope: "agent" } },
+          list: [{ id: "main", default: true }],
+        },
+      },
+    });
+
+    expect(stageSandboxMediaMock).toHaveBeenCalledOnce();
+    expect(enable).toHaveBeenCalledWith(expect.any(Array), new Map([[0, stagedPath]]));
+  });
+
   it("withholds local document self-service when the turn cannot read files", async () => {
     const enable = await runLocalPathSelfServeCase({
       ctx: hostDocumentCtx,

--- a/src/auto-reply/reply/get-reply.message-hooks.test.ts
+++ b/src/auto-reply/reply/get-reply.message-hooks.test.ts
@@ -428,7 +428,29 @@ describe("getReplyFromConfig message hooks", () => {
     expect(enable).toHaveBeenCalledOnce();
   });
 
-  it("withholds local document self-service from a sandboxed external conversation", async () => {
+  it("promotes the staged document path for a sandboxed external conversation", async () => {
+    const stagedPath = "media/inbound/report.docx";
+    vi.mocked(stageSandboxMediaMock).mockResolvedValueOnce({
+      staged: new Map([[0, stagedPath]]),
+    });
+    const enable = await runLocalPathSelfServeCase({
+      ctx: {
+        ...hostDocumentCtx,
+        OriginatingChannel: "telegram",
+        AccountId: "default",
+        SenderId: "42",
+      },
+      cfg: {
+        agents: {
+          defaults: { sandbox: { mode: "non-main", scope: "agent" } },
+          list: [{ id: "main", default: true }],
+        },
+      },
+    });
+    expect(enable).toHaveBeenCalledWith(expect.any(Array), new Map([[0, stagedPath]]));
+  });
+
+  it("withholds local document self-service when sandbox staging fails", async () => {
     const enable = await runLocalPathSelfServeCase({
       ctx: {
         ...hostDocumentCtx,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -30,7 +30,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { ApplyMediaUnderstandingResult } from "../../media-understanding/apply.js";
 import type { ExtractedFileImage } from "../../media-understanding/extracted-file-images.js";
-import { hasStagedMediaFacts } from "../../media/media-facts.js";
+import { hasStagedMediaFacts, normalizeMediaFacts } from "../../media/media-facts.js";
 import { defaultRuntime } from "../../runtime.js";
 import {
   isModelSelectionLocked,
@@ -203,11 +203,9 @@ function canSelfServeLocalPaths(params: {
   opts?: GetReplyOptions;
   senderIsOwner: boolean;
   spawnedBy?: string;
+  stagedPathsAvailable: boolean;
 }): boolean {
-  if (
-    params.opts?.disableTools === true ||
-    !resolveEffectiveToolFsRootExpansionAllowed({ cfg: params.cfg, agentId: params.agentId })
-  ) {
+  if (params.opts?.disableTools === true) {
     return false;
   }
   const policySessionKey = resolveRuntimePolicySessionKey({
@@ -215,7 +213,15 @@ function canSelfServeLocalPaths(params: {
     ctx: params.ctx,
     sessionKey: params.sessionKey,
   });
-  if (resolveSandboxRuntimeStatus({ cfg: params.cfg, sessionKey: policySessionKey }).sandboxed) {
+  const sandboxed = resolveSandboxRuntimeStatus({
+    cfg: params.cfg,
+    sessionKey: policySessionKey,
+  }).sandboxed;
+  if (
+    (sandboxed && !params.stagedPathsAvailable) ||
+    (!sandboxed &&
+      !resolveEffectiveToolFsRootExpansionAllowed({ cfg: params.cfg, agentId: params.agentId }))
+  ) {
     return false;
   }
   const capabilityProfile = resolveConversationCapabilityProfile({
@@ -256,6 +262,15 @@ function canSelfServeLocalPaths(params: {
       toolNames: ["read"],
       warn: () => {},
     }).length === 1
+  );
+}
+
+function collectStagedAttachmentPaths(ctx: MsgContext): ReadonlyMap<number, string> {
+  return new Map(
+    normalizeMediaFacts(ctx.media).flatMap((fact, index) => {
+      const mediaPath = normalizeOptionalString(fact.path);
+      return mediaPath ? [[index, mediaPath] as const] : [];
+    }),
   );
 }
 
@@ -871,9 +886,10 @@ export async function getReplyFromConfig(
         opts: resolvedOpts,
         senderIsOwner: fastCommand.senderIsOwner,
         spawnedBy: normalizeOptionalString(sessionEntry.spawnedBy),
+        stagedPathsAvailable: false,
       })
     ) {
-      enableLocalPathSelfServe(finalized, sessionCtx);
+      enableLocalPathSelfServe([finalized, sessionCtx]);
     }
     logResolverTiming("milestone", "before_fast_directive_prepared_reply");
     const fastReplyResult = await traceGetReplyPhase("reply.run_prepared_reply", () =>
@@ -1171,6 +1187,30 @@ export async function getReplyFromConfig(
     }
   }
 
+  let stagedAttachmentPaths = hasStagedMediaFacts(finalized.media)
+    ? collectStagedAttachmentPaths(finalized)
+    : new Map<number, string>();
+  // Already-staged facts or SDK projections must remain a single-stage contract.
+  if (
+    !useFastTestBootstrap &&
+    sessionKey &&
+    !inboundMediaWasAlreadyStaged &&
+    !hasStagedMediaFacts(ctx.media) &&
+    hasInboundMedia(ctx)
+  ) {
+    const { stageSandboxMedia } = await loadStageSandboxMediaRuntime();
+    const stageResult = await traceGetReplyPhase("reply.stage_media", () =>
+      stageSandboxMedia({
+        ctx,
+        sessionCtx,
+        cfg,
+        sessionKey,
+        workspaceDir,
+      }),
+    );
+    stagedAttachmentPaths = stageResult.staged;
+  }
+
   if (
     enableLocalPathSelfServe &&
     canSelfServeLocalPaths({
@@ -1185,28 +1225,12 @@ export async function getReplyFromConfig(
       opts: resolvedOpts,
       senderIsOwner: command.senderIsOwner,
       spawnedBy: normalizeOptionalString(sessionEntry.spawnedBy),
+      stagedPathsAvailable: stagedAttachmentPaths.size > 0,
     })
   ) {
-    enableLocalPathSelfServe(finalized, sessionCtx);
-  }
-
-  // Already-staged facts or SDK projections must remain a single-stage contract.
-  if (
-    !useFastTestBootstrap &&
-    sessionKey &&
-    !inboundMediaWasAlreadyStaged &&
-    !hasStagedMediaFacts(ctx.media) &&
-    hasInboundMedia(ctx)
-  ) {
-    const { stageSandboxMedia } = await loadStageSandboxMediaRuntime();
-    await traceGetReplyPhase("reply.stage_media", () =>
-      stageSandboxMedia({
-        ctx,
-        sessionCtx,
-        cfg,
-        sessionKey,
-        workspaceDir,
-      }),
+    enableLocalPathSelfServe(
+      [finalized, sessionCtx],
+      stagedAttachmentPaths.size > 0 ? stagedAttachmentPaths : undefined,
     );
   }
 

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -2296,10 +2296,16 @@ describe("applyMediaUnderstanding", () => {
     );
     expect(ctx.Body).not.toContain("approved local file path");
 
-    result.enableLocalPathSelfServe?.(ctx);
+    result.enableLocalPathSelfServe?.([ctx], new Map());
+
+    expect(ctx.Body).not.toContain("approved local file path");
+
+    const stagedPath = "media/inbound/sandboxed.doc";
+    result.enableLocalPathSelfServe?.([ctx], new Map([[0, stagedPath]]));
 
     expect(ctx.Body).toContain("approved local file path");
-    expect(ctx.Body).toContain(filePath);
+    expect(ctx.Body).toContain(stagedPath);
+    expect(ctx.Body).not.toContain(filePath);
     expect(ctx.Body).not.toContain("PDF and plain-text attachments can be read");
   });
 

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -61,7 +61,10 @@ export type ApplyMediaUnderstandingResult = {
   appliedAudio: boolean;
   appliedVideo: boolean;
   appliedFile: boolean;
-  enableLocalPathSelfServe?: (...contexts: MsgContext[]) => void;
+  enableLocalPathSelfServe?: (
+    contexts: MsgContext[],
+    stagedPaths?: ReadonlyMap<number, string>,
+  ) => void;
 };
 
 const CAPABILITY_ORDER: MediaUnderstandingCapability[] = ["image", "audio", "video"];
@@ -114,7 +117,11 @@ type ClassifiedFileAttachment = {
 };
 
 type AttachmentContextBlock = { text: string; consumesMarkerBudget: boolean };
-type LocalPathSelfServeUpgrade = { fallback: string; selfServe: string };
+type LocalPathSelfServeUpgrade = {
+  attachmentIndex: number;
+  fallback: string;
+  render: (path?: string) => string | undefined;
+};
 
 // URL attachments may carry signed query credentials; only the pathname
 // basename is safe to surface as a model-visible display name.
@@ -312,7 +319,7 @@ async function extractFileContext(params: {
       );
     }
     const blockText = renderFileAttachmentOutcome(outcome, {
-      selfServeLocalPaths: params.selfServePathsEnabled,
+      selfServeLocalPath: params.selfServePathsEnabled ? undefined : false,
     });
     if (blockText === null) {
       continue;
@@ -330,12 +337,19 @@ async function extractFileContext(params: {
       consumesMarkerBudget: isSkippedFileOutcome(outcome),
     });
     if (outcome.kind === "unsupported-format" && outcome.localPath) {
-      const fallback = renderFileAttachmentOutcome(outcome, { selfServeLocalPaths: false });
-      const selfServe = renderFileAttachmentOutcome(outcome, { selfServeLocalPaths: true });
+      const fallback = renderFileAttachmentOutcome(outcome, { selfServeLocalPath: false });
+      const selfServe = renderFileAttachmentOutcome(outcome);
       if (fallback && selfServe) {
         localPathSelfServeUpgrades.push({
+          attachmentIndex: attachment.index,
           fallback: renderBlock(fallback),
-          selfServe: renderBlock(selfServe),
+          render: (path) => {
+            const rendered = renderFileAttachmentOutcome(
+              outcome,
+              path ? { selfServeLocalPath: path } : undefined,
+            );
+            return rendered ? renderBlock(rendered) : undefined;
+          },
         });
       }
     }
@@ -348,13 +362,22 @@ const SELF_SERVE_CONTEXT_FIELDS = ["Body", "BodyForAgent", "agentText"] as const
 function enableLocalPathSelfServe(
   upgrades: LocalPathSelfServeUpgrade[],
   contexts: MsgContext[],
+  stagedPaths?: ReadonlyMap<number, string>,
 ): void {
   for (const context of contexts) {
     for (const upgrade of upgrades) {
+      const stagedPath = stagedPaths?.get(upgrade.attachmentIndex);
+      if (stagedPaths && !stagedPath) {
+        continue;
+      }
+      const selfServe = upgrade.render(stagedPath);
+      if (!selfServe) {
+        continue;
+      }
       for (const field of SELF_SERVE_CONTEXT_FIELDS) {
         const value = context[field];
         if (typeof value === "string") {
-          context[field] = value.replace(upgrade.fallback, upgrade.selfServe);
+          context[field] = value.replace(upgrade.fallback, selfServe);
         }
       }
     }
@@ -618,8 +641,15 @@ export async function applyMediaUnderstanding(params: {
       appliedFile: fileContext.blocks.length > 0,
       ...(fileContext.localPathSelfServeUpgrades.length > 0
         ? {
-            enableLocalPathSelfServe: (...contexts: MsgContext[]) =>
-              enableLocalPathSelfServe(fileContext.localPathSelfServeUpgrades, contexts),
+            enableLocalPathSelfServe: (
+              contexts: MsgContext[],
+              stagedPaths?: ReadonlyMap<number, string>,
+            ) =>
+              enableLocalPathSelfServe(
+                fileContext.localPathSelfServeUpgrades,
+                contexts,
+                stagedPaths,
+              ),
           }
         : {}),
     };

--- a/src/media-understanding/file-attachment-outcomes.test.ts
+++ b/src/media-understanding/file-attachment-outcomes.test.ts
@@ -169,4 +169,20 @@ describe("renderFileAttachmentOutcome", () => {
     const normalized = rendered?.replace(/[a-f0-9]{16}/g, "<id>") ?? null;
     expect(normalized).toBe(expected);
   });
+
+  it("accepts normalized staged paths but rejects workspace traversal", () => {
+    const outcome = { kind: "unsupported-format" as const, mime: "application/msword" };
+    expect(
+      renderFileAttachmentOutcome(outcome, {
+        selfServeLocalPath: "media/inbound/report.doc",
+      }),
+    ).toContain("media/inbound/report.doc");
+    expect(
+      renderFileAttachmentOutcome(outcome, {
+        selfServeLocalPath: "media/inbound/../secrets.txt",
+      }),
+    ).toBe(
+      "[Unsupported document format: application/msword. PDF and plain-text attachments can be read.]",
+    );
+  });
 });

--- a/src/media-understanding/file-attachment-outcomes.ts
+++ b/src/media-understanding/file-attachment-outcomes.ts
@@ -63,11 +63,17 @@ const POSIX_ABSOLUTE_PATH = /^\//;
 const WINDOWS_ABSOLUTE_PATH = /^[A-Za-z]:\\/;
 const MARKER_PATH_SAFE = /^[\p{L}\p{M}\p{N} /\\:._-]+$/u;
 
-function markerSafeLocalPath(value?: string): string | undefined {
+function markerSafeLocalPath(value?: string, allowWorkspaceRelative = false): string | undefined {
   if (!value || value.length > MARKER_LOCAL_PATH_MAX_CHARS) {
     return undefined;
   }
-  if (!POSIX_ABSOLUTE_PATH.test(value) && !WINDOWS_ABSOLUTE_PATH.test(value)) {
+  const isAbsolute = POSIX_ABSOLUTE_PATH.test(value) || WINDOWS_ABSOLUTE_PATH.test(value);
+  if (
+    !isAbsolute &&
+    (!allowWorkspaceRelative ||
+      value.includes("\\") ||
+      value.split("/").some((segment) => !segment || segment === "." || segment === ".."))
+  ) {
     return undefined;
   }
   return MARKER_PATH_SAFE.test(value) ? value : undefined;
@@ -86,7 +92,7 @@ export function isSkippedFileOutcome(outcome: FileAttachmentOutcome): boolean {
 
 export function renderFileAttachmentOutcome(
   outcome: FileAttachmentOutcome,
-  options?: { selfServeLocalPaths?: boolean },
+  options?: { selfServeLocalPath?: string | false },
 ): string | null {
   switch (outcome.kind) {
     case "extracted":
@@ -100,8 +106,12 @@ export function renderFileAttachmentOutcome(
       const formatClause = mime
         ? `Unsupported document format: ${mime}.`
         : "Unsupported document format.";
-      const localPath =
-        options?.selfServeLocalPaths === false ? undefined : markerSafeLocalPath(outcome.localPath);
+      const localPath = markerSafeLocalPath(
+        options?.selfServeLocalPath === false
+          ? undefined
+          : (options?.selfServeLocalPath ?? outcome.localPath),
+        typeof options?.selfServeLocalPath === "string",
+      );
       // Modern OOXML files unzip to XML; legacy OLE formats (msword, x-cfb) do
       // not, and a wrong hint sends the agent down a dead extraction path.
       const formatHint = outcome.mime?.startsWith("application/vnd.openxmlformats-officedocument")


### PR DESCRIPTION
Fixes #122411

## What Problem This Solves

Fixes an issue where sandboxed agents receiving DOCX and other unsupported document attachments were told that the format was unsupported even after OpenClaw had copied the file into their workspace.

## Why This Change Was Made

Document self-service now happens after inbound media staging. Sandboxed turns receive only the successful `media/inbound/...` path for each attachment; failed or partial staging keeps the existing unsupported-format message. Non-sandbox policy remains unchanged.

The canonical staged media facts cover both local staging and remote pre-understanding staging. No host path, broad mount, fallback reader, or compatibility path was added.

## User Impact

Sandboxed agents can use their existing read and shell tools on staged document attachments instead of dead-ending on an unsupported-format notice.

## Evidence

- Red before fix: sandbox boundary test reported zero path-promotion calls.
- `pnpm vitest run src/media-understanding src/auto-reply/reply/get-reply.message-hooks.test.ts` — 63 files passed, 2 skipped; 958 tests passed, 10 skipped.
- Touched-file Oxfmt and Oxlint passed.
- `pnpm tsgo` and `pnpm check:test-types` passed.
- Local ClawSweeper: correct patch, zero findings, zero security concerns; requested Telegram proof added below.

Telegram E2E on exact head `7ce4c6763d963343a2a0f120f33a752b2de36668`:

```json
{
  "result": "pass",
  "transport": "real Telegram DM",
  "sandboxMode": "all",
  "attachment": "DOCX",
  "stagedPath": "media/inbound/<generated>.docx",
  "providerRequests": 2,
  "tool": "exec",
  "toolOutputContains": "Q3 revenue summary",
  "reply": "OPENCLAW_E2E_DOCUMENT_SELF_SERVE_OK",
  "timelineMs": [6141, 7150, 8105]
}
```

The provider’s first request contained only the staged workspace path, not the host path. The sandbox tool read `word/document.xml` from that path. The second request contained the expected document text, and the recorded Telegram turn showed the success reply plus the one-tool-call status edit.

Production delta: +64 lines. The growth carries the staged attachment index/path contract through the existing media-understanding promotion boundary; tests add +86 net lines across local, failed, partial, and remote staging cases.
