### PR TITLE
test(core): remove orphan test exports

### DIFF
--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -641,8 +641,6 @@ async function resolveImagesForRequest(
 }
 
 export const testOnlyOpenAiHttp = {
-  resolveImagesForRequest,
-  resolveOpenAiChatCompletionsLimits,
   resolveChatCompletionUsage,
 };
 

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -188,8 +188,13 @@ function expectSuccessfulSessionsUsage(
   return result.sessions;
 }
 
-function mockStoredSession(key: string, sessionId: string) {
+function mockStoredSession(
+  key: string,
+  sessionId: string,
+  options: { resolution?: "valid" | "missing" } = {},
+) {
   const entry = { sessionId, updatedAt: 1_000 };
+  const storePath = "/tmp/agents/opus/agent/openclaw-agent.sqlite";
   vi.mocked(loadGatewaySessionEntryReadOnly).mockReturnValueOnce({
     cfg: TEST_RUNTIME_CONFIG,
     canonicalKey: key,
@@ -197,8 +202,11 @@ function mockStoredSession(key: string, sessionId: string) {
     legacyKey: undefined,
     store: { [key]: entry },
     storeKeys: [key],
-    storePath: "/tmp/agents/opus/sessions/sessions.json",
+    storePath,
   });
+  vi.mocked(resolveExistingUsageSessionFile).mockReturnValueOnce(
+    options.resolution === "missing" ? undefined : `sqlite:opus:${sessionId}:${storePath}`,
+  );
   return entry;
 }
 
@@ -852,8 +860,7 @@ describe("sessions.usage", () => {
 
   it("fails closed when a canonical stored target no longer matches", async () => {
     const key = "agent:opus:stale";
-    mockStoredSession(key, "stale");
-    vi.mocked(resolveExistingUsageSessionFile).mockReturnValueOnce(undefined);
+    mockStoredSession(key, "stale", { resolution: "missing" });
     const respond = await runSessionsUsageTimeseries({ key });
     expect(mockArg(respond, 0, 0)).toBe(false);
     expect(vi.mocked(loadSessionUsageTimeSeries)).not.toHaveBeenCalled();

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -1130,18 +1130,13 @@ function mergeUsageCacheStatus(
 
 // Exposed for unit tests (kept as a single export to avoid widening the public API surface).
 export const testApi = {
-  parseDateParts,
   parseUtcOffsetToMinutes,
-  resolveDateInterpretation,
   parseDateToMs,
   parseDays,
   resolveDateRange,
-  discoverAllSessionsForUsage,
   loadCostUsageSummaryCached,
   costUsageCache,
-  loadSessionsUsageResultCached,
   sessionsUsageCache,
-  sessionsUsageCacheKey,
 };
 
 export type { SessionUsageEntry, SessionsUsageAggregates, SessionsUsageResult };

--- a/src/plugin-sdk/sqlite-runtime-testing.ts
+++ b/src/plugin-sdk/sqlite-runtime-testing.ts
@@ -6,8 +6,6 @@ import {
   type TranscriptEvent,
 } from "../config/sessions/session-accessor.js";
 
-export type SqliteSessionTranscriptEventForTest = TranscriptEvent;
-
 /** Appends a raw SQLite transcript event for first-party tests only. */
 export async function appendSqliteSessionTranscriptEventForTest(
   params: SessionTranscriptAccessScope & { event: TranscriptEvent },


### PR DESCRIPTION
## What Problem This Solves

Three core test-only surfaces retained eight unused exports after their original direct tests were removed or moved to owner boundaries. While validating their removal, the current `main` Gateway usage suite also exposed a stale file-era mock: it passed a retired JSON store path into the real canonical SQLite resolver, causing seven tests to fail before usage loading.

## Why This Change Was Made

Remove only the zero-caller aliases/properties while retaining every live production function and public compatibility export. Update the Gateway composition fixture to return a canonical SQLite marker explicitly; the dedicated infra resolver suite continues to own real SQLite identity and stale-target behavior.

## User Impact

No intended user-visible change. Gateway usage, OpenAI HTTP image limits, SQLite transcripts, and Plugin SDK runtime behavior are unchanged. Test-support surface is smaller, and the previously red `sessions.usage` suite passes again against canonical storage semantics.

## Evidence

- Reproduced the same seven `sessions.usage` failures on clean `main`; all returned `INVALID_REQUEST` before the export cleanup was involved.
- Focused owner/consumer proof: 253 tests passed across Gateway, infra, E2E, memory-core, and QA Lab projects. The E2E lane rebuilt TypeScript and bundled plugin assets successfully.
- `pnpm plugin-sdk:surface:check` passed with no package-exported forbidden subpaths.
- Full changed-file gate passed core/extension typechecks and lint, Plugin SDK API/export/surface checks, database-first and schema guards, import cycles, dead exports, boundaries, and dependency guards. Blacksmith/Testbox was unavailable on this host, so trusted heavy proof used the documented local fallback.
- Structured autoreview and deleted-content secret scan: clean.
- `git diff --check`: clean.
- Delta: nine test-support export lines removed from production-owned modules; test fixture +7 net lines; overall -2 lines.

AI-assisted maintenance cleanup; callers, public compatibility boundaries, storage ownership, retained resolver proof, and current-main failure behavior were reviewed directly.
