### PR TITLE
fix: keep sidebar group on /reset, clear it on /new

### DIFF
--- a/src/auto-reply/reply/get-reply-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-fast-path.ts
@@ -42,7 +42,10 @@ import {
   usesFullReplyRuntime,
 } from "./reply-config-runtime-mode.js";
 import { createReplySessionEntryHandle } from "./session-entry-handle.js";
-import { resolveSessionResetCommand } from "./session-reset-command.js";
+import {
+  explicitResetPreservesSessionCategory,
+  resolveSessionResetCommand,
+} from "./session-reset-command.js";
 import type { SessionInitResult } from "./session.js";
 
 function isSlowReplyTestAllowed(env: NodeJS.ProcessEnv = process.env): boolean {
@@ -237,6 +240,10 @@ export function initFastReplySessionState(params: {
     ...(resetTriggered && existingEntry
       ? {
           previousSessionId: existingEntry.sessionId,
+          // `/reset` stays in the user's sidebar group; `/new` starts ungrouped.
+          ...(explicitResetPreservesSessionCategory(resetCommand.matchedResetTriggerLower)
+            ? { category: existingEntry.category }
+            : {}),
           spawnedBy: existingEntry.spawnedBy,
           spawnedWorkspaceDir: existingEntry.spawnedWorkspaceDir,
           spawnedCwd: existingEntry.spawnedCwd,

--- a/src/auto-reply/reply/get-reply.fast-path.reset-category.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.reset-category.test.ts
@@ -1,0 +1,54 @@
+// Tests that fast reply bootstrap honors the reset-trigger sidebar group rule.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { initFastReplySessionState } from "./get-reply-fast-path.js";
+import { buildGetReplyCtx } from "./get-reply.test-fixtures.js";
+
+describe("initFastReplySessionState sidebar group handling", () => {
+  beforeEach(() => {
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+  });
+
+  afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
+    vi.unstubAllEnvs();
+  });
+
+  it.each([
+    { body: "/reset", expected: "Operations" as string | undefined },
+    { body: "/new", expected: undefined },
+  ])("keeps the category for $body only when it is a reset", async ({ body, expected }) => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fast-reset-category-"));
+    const storePath = path.join(home, "sessions.json");
+    const sessionKey = "agent:main:telegram:fast-reset-category";
+    await replaceSessionEntry({ storePath, sessionKey }, {
+      sessionId: "existing-fast-reset-category",
+      updatedAt: Date.now(),
+      category: "Operations",
+    } as unknown as SessionEntry);
+
+    const result = initFastReplySessionState({
+      ctx: buildGetReplyCtx({
+        Body: body,
+        RawBody: body,
+        CommandBody: body,
+        SessionKey: sessionKey,
+      }),
+      cfg: { session: { store: storePath } } as OpenClawConfig,
+      agentId: "main",
+      commandAuthorized: true,
+      workspaceDir: home,
+    });
+
+    expect(result.resetTriggered).toBe(true);
+    // Fast bootstrap only mints the entry; the store row is written later by the
+    // reply run, so the prepared entry is the observable contract here.
+    expect(result.sessionEntry.category).toBe(expected);
+  });
+});

--- a/src/auto-reply/reply/get-reply.fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.test.ts
@@ -825,6 +825,43 @@ describe("getReplyFromConfig fast test bootstrap", () => {
     expect(result.sessionEntry.responseUsage).toBe("full");
   });
 
+  it("keeps the sidebar category on /reset and clears it on /new during fast bootstrap", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fast-reset-category-"));
+    const storePath = path.join(home, "sessions.json");
+    const sessionKey = "agent:main:telegram:fast-reset-category";
+
+    for (const testCase of [
+      { body: "/reset", expected: "Operations" as string | undefined },
+      { body: "/new", expected: undefined },
+    ]) {
+      await seedFastPathSessionStore(storePath, {
+        [sessionKey]: {
+          sessionId: "existing-fast-reset-category",
+          updatedAt: Date.now(),
+          category: "Operations",
+        },
+      });
+
+      const result = initFastReplySessionState({
+        ctx: buildGetReplyCtx({
+          Body: testCase.body,
+          RawBody: testCase.body,
+          CommandBody: testCase.body,
+          SessionKey: sessionKey,
+        }),
+        cfg: { session: { store: storePath } } as OpenClawConfig,
+        agentId: "main",
+        commandAuthorized: true,
+        workspaceDir: home,
+      });
+
+      expect(result.resetTriggered, testCase.body).toBe(true);
+      // Fast bootstrap only mints the entry; the store row is written later by the
+      // reply run, so the prepared entry is the observable contract here.
+      expect(result.sessionEntry.category, testCase.body).toBe(testCase.expected);
+    }
+  });
+
   it("preserves the exact multiline reset payload during fast bootstrap", () => {
     const payload = "keep [Q3]\nline 2";
     const result = initFastReplySessionState({

--- a/src/auto-reply/reply/get-reply.fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.test.ts
@@ -825,43 +825,6 @@ describe("getReplyFromConfig fast test bootstrap", () => {
     expect(result.sessionEntry.responseUsage).toBe("full");
   });
 
-  it("keeps the sidebar category on /reset and clears it on /new during fast bootstrap", async () => {
-    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fast-reset-category-"));
-    const storePath = path.join(home, "sessions.json");
-    const sessionKey = "agent:main:telegram:fast-reset-category";
-
-    for (const testCase of [
-      { body: "/reset", expected: "Operations" as string | undefined },
-      { body: "/new", expected: undefined },
-    ]) {
-      await seedFastPathSessionStore(storePath, {
-        [sessionKey]: {
-          sessionId: "existing-fast-reset-category",
-          updatedAt: Date.now(),
-          category: "Operations",
-        },
-      });
-
-      const result = initFastReplySessionState({
-        ctx: buildGetReplyCtx({
-          Body: testCase.body,
-          RawBody: testCase.body,
-          CommandBody: testCase.body,
-          SessionKey: sessionKey,
-        }),
-        cfg: { session: { store: storePath } } as OpenClawConfig,
-        agentId: "main",
-        commandAuthorized: true,
-        workspaceDir: home,
-      });
-
-      expect(result.resetTriggered, testCase.body).toBe(true);
-      // Fast bootstrap only mints the entry; the store row is written later by the
-      // reply run, so the prepared entry is the observable contract here.
-      expect(result.sessionEntry.category, testCase.body).toBe(testCase.expected);
-    }
-  });
-
   it("preserves the exact multiline reset payload during fast bootstrap", () => {
     const payload = "keep [Q3]\nline 2";
     const result = initFastReplySessionState({

--- a/src/auto-reply/reply/session-reset-command.ts
+++ b/src/auto-reply/reply/session-reset-command.ts
@@ -239,6 +239,18 @@ function isTranscriptOnlyCommand(ctx: MsgContext, commandText: string): boolean 
   );
 }
 
+/**
+ * Decides whether an explicit reset trigger keeps the user's sidebar category.
+ *
+ * `/reset` clears conversation context but stays in the group the user filed the
+ * session under; `/new` starts a fresh ungrouped chat. Implicit rollovers
+ * (idle/daily) pass `undefined` and keep the category, matching the Gateway
+ * reset writer which only drops it for `reason: "new"`.
+ */
+export function explicitResetPreservesSessionCategory(matchedResetTriggerLower?: string): boolean {
+  return matchedResetTriggerLower === undefined || matchedResetTriggerLower === "/reset";
+}
+
 export function resolveSessionResetCommand(params: {
   commandText: string;
   rawText: string;

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -3169,6 +3169,30 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     }
   });
 
+  it("keeps the sidebar category on /reset and clears it on /new", async () => {
+    const storePath = await createStorePath("openclaw-reset-sidebar-category-");
+    const sessionKey = "agent:main:telegram:dm:user-sidebar-category";
+    const existingSessionId = "existing-session-sidebar-category";
+    const cases = await runExplicitResetCases({
+      storePath,
+      sessionKey,
+      sessionId: existingSessionId,
+      entry: { category: "Operations" },
+    });
+
+    for (const { name, result, stored } of cases) {
+      expect(result.resetTriggered, name).toBe(true);
+      const storedEntry = expectDefined(stored[sessionKey], "stored[sessionKey] test invariant");
+      if (name === "reset") {
+        expect(result.sessionEntry.category, name).toBe("Operations");
+        expect(storedEntry.category, name).toBe("Operations");
+      } else {
+        expect(result.sessionEntry.category, name).toBeUndefined();
+        expect(storedEntry.category, name).toBeUndefined();
+      }
+    }
+  });
+
   it("preserves selected auth profile overrides across /new and /reset", async () => {
     const storePath = await createStorePath("openclaw-reset-model-auth-");
     const sessionKey = "agent:main:telegram:dm:user-model-auth";

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -120,7 +120,10 @@ import {
 } from "./session-init-conflict-retry.js";
 import { prepareReplySessionParentFork } from "./session-parent-fork-prepare.js";
 import { clearSessionResetRuntimeState } from "./session-reset-cleanup.js";
-import { resolveSessionResetCommand } from "./session-reset-command.js";
+import {
+  explicitResetPreservesSessionCategory,
+  resolveSessionResetCommand,
+} from "./session-reset-command.js";
 import {
   stripThreadFromSessionRoute,
   stripThreadIdFromDeliveryContext,
@@ -379,7 +382,11 @@ function selectSessionModelOverride(
   };
 }
 
-function resolveReplySessionRolloverState(entry: SessionEntry): Partial<SessionEntry> {
+function resolveReplySessionRolloverState(params: {
+  entry: SessionEntry;
+  preservesCategory: boolean;
+}): Partial<SessionEntry> {
+  const { entry } = params;
   const preservedSelection = resolveResetPreservedSelection({ entry });
   return {
     thinkingLevel: entry.thinkingLevel,
@@ -394,6 +401,10 @@ function resolveReplySessionRolloverState(entry: SessionEntry): Partial<SessionE
     authProfileOverrideCompactionCount: preservedSelection.authProfileOverrideCompactionCount,
     label: entry.label,
     displayName: entry.displayName,
+    // `/reset` keeps the sidebar group the user filed this session under; only an
+    // explicit `/new` starts an ungrouped chat. Implicit idle/daily rollovers keep
+    // the group too, matching the Gateway reset writer's reason-based rule.
+    ...(params.preservesCategory ? { category: entry.category } : {}),
     // Notice debt survives rollover: erasing it here would recreate the
     // silent ambiguous-loss outcome the debt exists to prevent.
     pendingDeliveryNotice: entry.pendingDeliveryNotice,
@@ -789,7 +800,10 @@ async function initSessionStateAttemptLocked(
       // Explicit /new and /reset rotate CLI conversation bindings elsewhere.
       // Lineage/control facts belong to the session node and survive ANY rollover
       // from an existing entry, following the #90119 carry pattern.
-      preservedState = resolveReplySessionRolloverState(entry);
+      preservedState = resolveReplySessionRolloverState({
+        entry,
+        preservesCategory: explicitResetPreservesSessionCategory(matchedResetTriggerLower),
+      });
     }
   }
 

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -252,6 +252,34 @@ test("keyed sessions remain recoverable across overlapping create and delete wav
   }
 });
 
+test("sessions.reset preserves the session sidebar category", async () => {
+  const key = "agent:main:reset-category-regression";
+  const created = await directSessionReq<{ key: string }>("sessions.create", {
+    agentId: "main",
+    key,
+  });
+  expect(created.ok).toBe(true);
+
+  const patched = await directSessionReq("sessions.patch", {
+    agentId: "main",
+    key,
+    category: "Operations",
+  });
+  expect(patched.ok).toBe(true);
+  expect(loadSessionEntry({ agentId: "main", sessionKey: key })?.category).toBe("Operations");
+
+  const reset = await directSessionReq<{ entry?: { category?: string } }>("sessions.reset", {
+    agentId: "main",
+    key,
+  });
+  expect(reset.ok).toBe(true);
+  expect(reset.payload?.entry?.category).toBe("Operations");
+  expect(loadSessionEntry({ agentId: "main", sessionKey: key })?.category).toBe("Operations");
+
+  const deleted = await directSessionReq("sessions.delete", { agentId: "main", key });
+  expect(deleted.ok).toBe(true);
+});
+
 test("sessions.create keeps incognito rows process-local through list, spawn, reset, and delete", async () => {
   const { storePath } = await createSessionStoreDir();
   try {

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -276,6 +276,15 @@ test("sessions.reset preserves the session sidebar category", async () => {
   expect(reset.payload?.entry?.category).toBe("Operations");
   expect(loadSessionEntry({ agentId: "main", sessionKey: key })?.category).toBe("Operations");
 
+  const newSession = await directSessionReq<{ entry?: { category?: string } }>("sessions.reset", {
+    agentId: "main",
+    key,
+    reason: "new",
+  });
+  expect(newSession.ok).toBe(true);
+  expect(newSession.payload?.entry?.category).toBeUndefined();
+  expect(loadSessionEntry({ agentId: "main", sessionKey: key })?.category).toBeUndefined();
+
   const deleted = await directSessionReq("sessions.delete", { agentId: "main", key });
   expect(deleted.ok).toBe(true);
 });

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -1637,6 +1637,7 @@ export async function performGatewaySessionReset(params: {
             subagentControlScope: currentEntry?.subagentControlScope,
             label: currentEntry?.label,
             displayName: currentEntry?.displayName,
+            category: currentEntry?.category,
             delivery: currentEntry?.delivery,
             pendingDeliveryNotice: currentEntry?.pendingDeliveryNotice,
             groupId: currentEntry?.groupId,

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -1637,7 +1637,7 @@ export async function performGatewaySessionReset(params: {
             subagentControlScope: currentEntry?.subagentControlScope,
             label: currentEntry?.label,
             displayName: currentEntry?.displayName,
-            category: currentEntry?.category,
+            category: params.reason === "reset" ? currentEntry?.category : undefined,
             delivery: currentEntry?.delivery,
             pendingDeliveryNotice: currentEntry?.pendingDeliveryNotice,
             groupId: currentEntry?.groupId,


### PR DESCRIPTION
## What Problem This Solves

`/reset` is commonly used to clear a session context, similar to `/compact`, but it should not remove the session from its user-organized left-sidebar group. Starting a fresh ungrouped session stays the job of `/new`.

Two writers rotate a session entry, and both dropped the group:

- `performGatewaySessionReset()` (Control UI reset, `sessions.reset` RPC, bare `/reset` and `/new`)
- the auto-reply session writers (`initSessionState()` and the fast reply bootstrap), which own resets that arrive as chat messages, including `/reset <prompt>` and implicit idle/daily rollovers

Fixing only the Gateway writer left chat `/reset` still falling out of its group, so this PR now covers both paths behind one shared rule.

## Behavior After This Change

| Trigger | Sidebar group |
| --- | --- |
| `/reset`, `/reset <prompt>` | kept |
| `/new`, `/new <prompt>` | cleared (ungrouped) |
| `sessions.reset` with `reason: "reset"` (or omitted) | kept |
| `sessions.reset` with `reason: "new"` | cleared |
| implicit idle/daily rollover | kept |

## Summary

- `session-reset-service.ts`: preserve `category` only when the lifecycle reason is `reset`
- `session-reset-command.ts`: add `explicitResetPreservesSessionCategory()` as the single source of truth for the trigger rule
- `session.ts`: carry `category` through `resolveReplySessionRolloverState()` according to that rule
- `get-reply-fast-path.ts`: apply the same rule when the fast bootstrap mints a reset entry
- channel/group routing metadata (`groupId`, `groupChannel`, `subject`, `space`) is untouched
- regression tests on all three writers

## Evidence

Local test runs (`corepack pnpm` / repo runners):

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway-server.config.ts src/gateway/server.sessions.create.test.ts` → **95 passed**, including `sessions.reset preserves the session sidebar category` (reset keeps it, `reason: "new"` clears it)
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/session.test.ts src/auto-reply/reply/get-reply.fast-path.test.ts src/auto-reply/reply/get-reply.fast-path.reset-category.test.ts` → **passed**, including the new `keeps the sidebar category on /reset and clears it on /new` cases on both auto-reply writers
- `node scripts/run-oxlint.mjs src/auto-reply` → 0 warnings, 0 errors
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json` → clean

Real behavior on a running gateway (2026.7.1-2, session seeded into the custom group `回归测试分组`, group read back from the session store after each command):

| Path | Command | Stored `category` after |
| --- | --- | --- |
| `sessions.reset` RPC | `reason: "reset"` | `回归测试分组` |
| `sessions.reset` RPC | `reason: "new"` | `null` |
| bare chat command | `/reset` | `回归测试分组` |
| bare chat command | `/new` | `null` |
| auto-reply with payload | `/reset 只回复 OK` | `回归测试分组` |
| auto-reply with payload | `/new 只回复 OK` | `null` |

Earlier Control UI screenshots in this PR still describe the intended split: `/reset` stays in its group, `/new` lands ungrouped.

## Compatibility Note

This intentionally changes what `/reset` does for sessions with a sidebar group: users who relied on `/reset` to drop a session out of its group need `/new` (or an explicit group edit) instead.

## Notes

The source branch is maintained in `AppleSpriter/openclaw`; this is a cross-repository PR targeting `openclaw/openclaw:main`.
