### PR TITLE
improve: speed up secrets audit test shard

### DIFF
--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -235,6 +235,7 @@ async function buildPluginConfigExecSecretRefPlan(home: string) {
         id: "acme-secrets",
         origin: "global",
         rootDir: pluginRoot,
+        channels: [],
         secretProviderIntegrations: {
           "secret-store": {
             source: "exec",
@@ -252,6 +253,7 @@ async function buildPluginConfigExecSecretRefPlan(home: string) {
       {
         id: "acme-plugin",
         origin: "global",
+        channels: [],
         configContracts: {
           secretInputs: {
             paths: [{ path: "apiKey", expected: "string" }],

--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
   resolveAuthProfileDatabasePath,
@@ -72,6 +72,7 @@ async function writeExecSecretsAuditConfig(params: {
     baseUrl: string;
     modelId: string;
     modelName: string;
+    headerRefId?: string;
   }>;
 }) {
   await writeJsonFile(params.fixture.configPath, {
@@ -98,6 +99,17 @@ async function writeExecSecretsAuditConfig(params: {
               provider: "execmain",
               id: `providers/${provider.id}/apiKey`,
             },
+            ...(provider.headerRefId
+              ? {
+                  headers: {
+                    Authorization: {
+                      source: "exec",
+                      provider: "execmain",
+                      id: provider.headerRefId,
+                    },
+                  },
+                }
+              : {}),
             models: [{ id: provider.modelId, name: provider.modelName }],
           },
         ]),
@@ -215,18 +227,6 @@ async function seedAuditFixture(fixture: AuditFixture): Promise<void> {
 
 describe("secrets audit", () => {
   let fixture: AuditFixture;
-
-  beforeAll(async () => {
-    const warmFixture = await createAuditFixture();
-    try {
-      await writeJsonFile(warmFixture.configPath, {});
-      await runSecretsAudit({ env: warmFixture.env });
-    } finally {
-      closeOpenClawAgentDatabasesForTest();
-      closeOpenClawStateDatabaseForTest();
-      await fs.rm(warmFixture.rootDir, { recursive: true, force: true });
-    }
-  });
 
   async function writeModelsProvider(
     overrides: Partial<{
@@ -413,7 +413,7 @@ describe("secrets audit", () => {
       logPath: execLogPath,
       values: {
         "providers/openai/apiKey": "value:providers/openai/apiKey",
-        "providers/moonshot/apiKey": "value:providers/moonshot/apiKey",
+        "providers/openai/headers/Authorization": "value:providers/openai/headers/Authorization",
       },
     });
     await writeExecSecretsAuditConfig({
@@ -425,18 +425,14 @@ describe("secrets audit", () => {
           baseUrl: "https://api.openai.com/v1",
           modelId: "gpt-5",
           modelName: "gpt-5",
-        },
-        {
-          id: "moonshot",
-          baseUrl: "https://api.moonshot.cn/v1",
-          modelId: "moonshot-v1-8k",
-          modelName: "moonshot-v1-8k",
+          headerRefId: "providers/openai/headers/Authorization",
         },
       ],
     });
 
     const report = await runSecretsAudit({ env: fixture.env, allowExec: true });
     expect(report.summary.unresolvedRefCount).toBe(0);
+    expect(report.resolution.refsChecked).toBe(2);
 
     const callLog = await fs.readFile(execLogPath, "utf8");
     const callCount = countNonEmptyLines(callLog);
@@ -480,13 +476,14 @@ describe("secrets audit", () => {
                 baseUrl: "https://api.openai.com/v1",
                 api: "openai-completions",
                 apiKey: { source: "exec", provider: "execmain", id: "providers/openai/apiKey" },
+                headers: {
+                  Authorization: {
+                    source: "exec",
+                    provider: "execmain",
+                    id: "providers/openai/headers/Authorization",
+                  },
+                },
                 models: [{ id: "gpt-5", name: "gpt-5" }],
-              },
-              moonshot: {
-                baseUrl: "https://api.moonshot.cn/v1",
-                api: "openai-completions",
-                apiKey: { source: "exec", provider: "execmain", id: "providers/moonshot/apiKey" },
-                models: [{ id: "moonshot-v1-8k", name: "moonshot-v1-8k" }],
               },
             },
           },
@@ -545,24 +542,27 @@ describe("secrets audit", () => {
     });
   });
 
-  it("does not flag models.json marker values as plaintext", async () => {
-    await writeModelsProvider();
+  it("exempts only known models.json apiKey markers from plaintext audit", async () => {
+    await writeJsonFile(fixture.modelsPath, {
+      providers: {
+        knownMarker: {
+          apiKey: OPENAI_API_KEY_MARKER,
+        },
+        arbitraryAllCaps: {
+          apiKey: "ALLCAPS_SAMPLE", // pragma: allowlist secret
+        },
+      },
+    });
 
     const report = await runSecretsAudit({ env: fixture.env });
     expectModelsFinding(report, {
       code: "PLAINTEXT_FOUND",
-      jsonPath: "providers.openai.apiKey",
+      jsonPath: "providers.knownMarker.apiKey",
       present: false,
     });
-  });
-
-  it("flags arbitrary all-caps models.json apiKey values as plaintext", async () => {
-    await writeModelsProvider({ apiKey: "ALLCAPS_SAMPLE" }); // pragma: allowlist secret
-
-    const report = await runSecretsAudit({ env: fixture.env });
     expectModelsFinding(report, {
       code: "PLAINTEXT_FOUND",
-      jsonPath: "providers.openai.apiKey",
+      jsonPath: "providers.arbitraryAllCaps.apiKey",
     });
   });
 
@@ -660,53 +660,33 @@ describe("secrets audit", () => {
     expect(report.filesScanned).toContain(externalModelsPath);
   });
 
-  it("does not flag $VAR shorthand env refs in auth profiles as plaintext", async () => {
+  it("classifies auth profile env shorthands as refs with or without explicit keyRef", async () => {
     writeAuthStore(fixture, {
       version: 1,
       profiles: {
-        "openai:default": {
+        "openai:dollar": {
           type: "api_key",
           provider: "openai",
           key: "$OPENAI_API_KEY", // pragma: allowlist secret
         },
-      },
-    });
-
-    const report = await runSecretsAudit({ env: fixture.env });
-    expect(
-      hasFinding(
-        report,
-        (entry) => entry.code === "PLAINTEXT_FOUND" && entry.file === fixture.authStorePath,
-      ),
-    ).toBe(false);
-  });
-
-  it("does not flag ${VAR} env refs in auth profiles as plaintext", async () => {
-    writeAuthStore(fixture, {
-      version: 1,
-      profiles: {
-        "openai:default": {
+        "openai:braced": {
           type: "api_key",
           provider: "openai",
           key: "${OPENAI_API_KEY}", // pragma: allowlist secret
         },
-      },
-    });
-
-    const report = await runSecretsAudit({ env: fixture.env });
-    expect(
-      hasFinding(
-        report,
-        (entry) => entry.code === "PLAINTEXT_FOUND" && entry.file === fixture.authStorePath,
-      ),
-    ).toBe(false);
-  });
-
-  it("still flags auth profile plaintext when an explicit ref is also configured", async () => {
-    writeAuthStore(fixture, {
-      version: 1,
-      profiles: {
-        "openai:default": {
+        "openai:dollar-with-ref": {
+          type: "api_key",
+          provider: "openai",
+          key: "$OPENAI_API_KEY", // pragma: allowlist secret
+          keyRef: { source: "env", id: "OPENAI_API_KEY" },
+        },
+        "openai:braced-with-ref": {
+          type: "api_key",
+          provider: "openai",
+          key: "${OPENAI_API_KEY}", // pragma: allowlist secret
+          keyRef: { source: "env", id: "OPENAI_API_KEY" },
+        },
+        "openai:plaintext-with-ref": {
           type: "api_key",
           provider: "openai",
           key: "sk-leftover-plaintext", // pragma: allowlist secret
@@ -716,46 +696,13 @@ describe("secrets audit", () => {
     });
 
     const report = await runSecretsAudit({ env: fixture.env });
-    expect(
-      hasFinding(
-        report,
-        (entry) =>
-          entry.code === "PLAINTEXT_FOUND" &&
-          entry.file === fixture.authStorePath &&
-          entry.jsonPath === "profiles.openai:default.key",
-      ),
-    ).toBe(true);
+    const authPlaintextPaths = report.findings
+      .filter((entry) => entry.code === "PLAINTEXT_FOUND" && entry.file === fixture.authStorePath)
+      .map((entry) => entry.jsonPath);
+    expect(authPlaintextPaths).toEqual(["profiles.openai:plaintext-with-ref.key"]);
   });
 
-  it.each(["$OPENAI_API_KEY", "${OPENAI_API_KEY}"])(
-    "does not flag %s auth profile env refs when an explicit ref is also configured",
-    async (value) => {
-      writeAuthStore(fixture, {
-        version: 1,
-        profiles: {
-          "openai:default": {
-            type: "api_key",
-            provider: "openai",
-            key: value,
-            keyRef: { source: "env", id: "OPENAI_API_KEY" },
-          },
-        },
-      });
-
-      const report = await runSecretsAudit({ env: fixture.env });
-      expect(
-        hasFinding(
-          report,
-          (entry) =>
-            entry.code === "PLAINTEXT_FOUND" &&
-            entry.file === fixture.authStorePath &&
-            entry.jsonPath === "profiles.openai:default.key",
-        ),
-      ).toBe(false);
-    },
-  );
-
-  it("does not flag non-sensitive routing headers in openclaw config", async () => {
+  it("exempts direct routing headers but audits request headers in openclaw config", async () => {
     await writeJsonFile(fixture.configPath, {
       models: {
         providers: {
@@ -766,32 +713,6 @@ describe("secrets audit", () => {
             headers: {
               "X-Proxy-Region": "us-west",
             },
-            models: [{ id: "gpt-5", name: "gpt-5" }],
-          },
-        },
-      },
-    });
-
-    const report = await runSecretsAudit({ env: fixture.env });
-    expect(
-      hasFinding(
-        report,
-        (entry) =>
-          entry.code === "PLAINTEXT_FOUND" &&
-          entry.file === fixture.configPath &&
-          entry.jsonPath === "models.providers.openai.headers.X-Proxy-Region",
-      ),
-    ).toBe(false);
-  });
-
-  it("keeps request headers in openclaw config covered by plaintext audit", async () => {
-    await writeJsonFile(fixture.configPath, {
-      models: {
-        providers: {
-          openai: {
-            baseUrl: "https://api.openai.com/v1",
-            api: "openai-completions",
-            apiKey: { source: "env", provider: "default", id: OPENAI_API_KEY_MARKER },
             request: {
               headers: {
                 "X-Proxy-Region": "us-west",
@@ -810,65 +731,50 @@ describe("secrets audit", () => {
         (entry) =>
           entry.code === "PLAINTEXT_FOUND" &&
           entry.file === fixture.configPath &&
+          entry.jsonPath === "models.providers.openai.headers.X-Proxy-Region",
+      ),
+    ).toBe(false);
+    expect(
+      hasFinding(
+        report,
+        (entry) =>
+          entry.code === "PLAINTEXT_FOUND" &&
+          entry.file === fixture.configPath &&
           entry.jsonPath === "models.providers.openai.request.headers.X-Proxy-Region",
       ),
     ).toBe(true);
   });
 
-  it("does not flag openclaw.json model provider apiKey marker values as plaintext", async () => {
-    await writeJsonFile(fixture.configPath, {
-      models: {
-        providers: {
-          lmstudio: {
-            baseUrl: "http://127.0.0.1:1234/v1",
-            api: "openai-completions",
-            apiKey: "lmstudio-local",
-            models: [{ id: "lmstudio-local", name: "lmstudio-local" }],
-          },
-          ollama: {
-            baseUrl: "http://127.0.0.1:11434/v1",
-            api: "openai-completions",
-            apiKey: "ollama-local",
-            models: [{ id: "ollama-local", name: "ollama-local" }],
-          },
-          openai: {
-            baseUrl: "https://api.openai.com/v1",
-            api: "openai-completions",
-            apiKey: "sk-real-plaintext",
-            models: [{ id: "gpt-5", name: "gpt-5" }],
+  it("exempts only known openclaw.json model provider apiKey markers", async () => {
+    for (const { apiKey, isPlaintext } of [
+      { apiKey: "lmstudio-local", isPlaintext: false },
+      { apiKey: "ollama-local", isPlaintext: false },
+      { apiKey: "sk-real-plaintext", isPlaintext: true },
+    ]) {
+      await writeJsonFile(fixture.configPath, {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              api: "openai-completions",
+              apiKey,
+              models: [{ id: "gpt-5", name: "gpt-5" }],
+            },
           },
         },
-      },
-    });
+      });
 
-    const report = await runSecretsAudit({ env: fixture.env });
-    expect(
-      hasFinding(
-        report,
-        (entry) =>
-          entry.code === "PLAINTEXT_FOUND" &&
-          entry.file === fixture.configPath &&
-          entry.jsonPath === "models.providers.lmstudio.apiKey",
-      ),
-    ).toBe(false);
-    expect(
-      hasFinding(
-        report,
-        (entry) =>
-          entry.code === "PLAINTEXT_FOUND" &&
-          entry.file === fixture.configPath &&
-          entry.jsonPath === "models.providers.ollama.apiKey",
-      ),
-    ).toBe(false);
-    expect(
-      hasFinding(
-        report,
-        (entry) =>
-          entry.code === "PLAINTEXT_FOUND" &&
-          entry.file === fixture.configPath &&
-          entry.jsonPath === "models.providers.openai.apiKey",
-      ),
-    ).toBe(true);
+      const report = await runSecretsAudit({ env: fixture.env });
+      expect(
+        hasFinding(
+          report,
+          (entry) =>
+            entry.code === "PLAINTEXT_FOUND" &&
+            entry.file === fixture.configPath &&
+            entry.jsonPath === "models.providers.openai.apiKey",
+        ),
+      ).toBe(isPlaintext);
+    }
   });
 
   it("scans .env in legacy .clawdbot state directory via automatic fallback", async () => {

--- a/src/secrets/audit.ts
+++ b/src/secrets/audit.ts
@@ -194,9 +194,10 @@ function collectConfigSecrets(params: {
   config: OpenClawConfig;
   configPath: string;
   collector: AuditCollector;
+  env: NodeJS.ProcessEnv;
 }): void {
   const defaults = params.config.secrets?.defaults;
-  for (const target of discoverConfigSecretTargets(params.config)) {
+  for (const target of discoverConfigSecretTargets(params.config, { env: params.env })) {
     if (!target.entry.includeInAudit) {
       continue;
     }
@@ -236,14 +237,7 @@ function collectConfigSecrets(params: {
       }
       continue;
     }
-
-    if (isNonSecretHeader) {
-      continue;
-    }
-    if (isModelMarker) {
-      continue;
-    }
-    if (!hasPlaintext) {
+    if (isNonSecretHeader || isModelMarker || !hasPlaintext) {
       continue;
     }
     addFinding(params.collector, {
@@ -670,6 +664,7 @@ export async function runSecretsAudit(
       config,
       configPath,
       collector,
+      env,
     });
     for (const agentDir of listAuthProfileStoreAgentDirs(config, stateDir)) {
       collectAuthStoreSecrets({

--- a/src/secrets/channel-contract-api.ts
+++ b/src/secrets/channel-contract-api.ts
@@ -196,9 +196,10 @@ export function loadChannelSecretContractApi(params: {
   config: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   loadablePluginOrigins?: ReadonlyMap<string, PluginOrigin>;
+  bundledOnly?: boolean;
 }): BundledChannelSecretContractApi | undefined {
   const bundled = loadBundledChannelSecretContractApi(params.channelId);
-  if (bundled) {
+  if (bundled || params.bundledOnly) {
     return bundled;
   }
   // External contracts are considered only after bundled artifacts so core channels keep their

--- a/src/secrets/target-registry-data.current-snapshot.test.ts
+++ b/src/secrets/target-registry-data.current-snapshot.test.ts
@@ -1,9 +1,18 @@
 /** Tests target-registry data built from the current runtime snapshot. */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanupTrackedTempDirs, makeTrackedTempDir } from "../plugins/test-helpers/fs-fixtures.js";
+
+const tempDirs: string[] = [];
 
 const metadataMocks = vi.hoisted(() => ({
   listBundledPluginMetadata: vi.fn(),
-  resolvePluginMetadataSnapshot: vi.fn(() => ({ plugins: [] })),
+  resolvePluginMetadataSnapshot: vi.fn<
+    (params?: { config?: { plugins?: { load?: { paths?: string[] } } } }) => {
+      plugins: never[];
+    }
+  >(() => ({ plugins: [] })),
 }));
 
 vi.mock("../plugins/bundled-plugin-metadata.js", () => ({
@@ -14,6 +23,37 @@ vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
   resolvePluginMetadataSnapshot: metadataMocks.resolvePluginMetadataSnapshot,
 }));
 
+function writeChannelContract(params: {
+  channelId: string;
+  pluginId: string;
+  targetId: string;
+  ownership: "channelConfigs" | "channels";
+}) {
+  const rootDir = makeTrackedTempDir("openclaw-target-registry-channel", tempDirs);
+  fs.writeFileSync(
+    path.join(rootDir, "secret-contract-api.cjs"),
+    `module.exports = { secretTargetRegistryEntries: [${JSON.stringify({
+      id: params.targetId,
+      targetType: params.targetId,
+      configFile: "openclaw.json",
+      pathPattern: params.targetId,
+      secretShape: "secret_input",
+      expectedResolvedValue: "string",
+      includeInPlan: true,
+      includeInConfigure: true,
+      includeInAudit: true,
+    })}] };`,
+    "utf8",
+  );
+  return {
+    id: params.pluginId,
+    origin: "config",
+    channels: params.ownership === "channels" ? [params.channelId] : [],
+    channelConfigs: params.ownership === "channelConfigs" ? { [params.channelId]: {} } : {},
+    rootDir,
+  };
+}
+
 describe("getSecretTargetRegistry metadata reuse", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -23,6 +63,10 @@ describe("getSecretTargetRegistry metadata reuse", () => {
     });
     metadataMocks.resolvePluginMetadataSnapshot.mockClear();
     metadataMocks.resolvePluginMetadataSnapshot.mockReturnValue({ plugins: [] });
+  });
+
+  afterEach(() => {
+    cleanupTrackedTempDirs(tempDirs);
   });
 
   it("allows configless runtime targets to reuse the lifecycle workspace", async () => {
@@ -95,5 +139,68 @@ describe("getSecretTargetRegistry metadata reuse", () => {
 
     expect(ids).toContain("channels.qqbot.clientSecret");
     expect(ids).toContain("channels.qqbot.accounts.*.clientSecret");
+  });
+
+  it("builds config-scoped registries independently instead of reusing the singleton", async () => {
+    metadataMocks.resolvePluginMetadataSnapshot.mockImplementation(
+      (params?: { config?: { plugins?: { load?: { paths?: string[] } } } }) => {
+        const pluginId = params?.config?.plugins?.load?.paths?.[0] ?? "missing";
+        return {
+          plugins: [
+            {
+              id: pluginId,
+              origin: "config",
+              channels: [],
+              configContracts: {
+                secretInputs: { paths: [{ path: "credentials.token" }] },
+              },
+            },
+          ],
+        } as never;
+      },
+    );
+    const { getSecretTargetRegistry } = await import("./target-registry-data.js");
+    const firstConfig = { plugins: { load: { paths: ["first-plugin"] }, entries: {} } };
+    const secondConfig = { plugins: { load: { paths: ["second-plugin"] }, entries: {} } };
+
+    const firstIds = getSecretTargetRegistry({ config: firstConfig, env: {} }).map(
+      (entry) => entry.id,
+    );
+    const secondIds = getSecretTargetRegistry({ config: secondConfig, env: {} }).map(
+      (entry) => entry.id,
+    );
+
+    expect(firstIds).toContain("plugins.entries.first-plugin.config.credentials.token");
+    expect(firstIds).not.toContain("plugins.entries.second-plugin.config.credentials.token");
+    expect(secondIds).toContain("plugins.entries.second-plugin.config.credentials.token");
+    expect(secondIds).not.toContain("plugins.entries.first-plugin.config.credentials.token");
+  });
+
+  it("loads channel contracts from every supported ownership field", async () => {
+    const records = [
+      writeChannelContract({
+        channelId: "custom",
+        pluginId: "custom-primary",
+        targetId: "channels.custom.primaryToken",
+        ownership: "channels",
+      }),
+      writeChannelContract({
+        channelId: "custom",
+        pluginId: "custom-secondary",
+        targetId: "channels.custom.secondaryToken",
+        ownership: "channelConfigs",
+      }),
+    ];
+    metadataMocks.resolvePluginMetadataSnapshot.mockReturnValue({ plugins: records } as never);
+    const { getSecretTargetRegistry } = await import("./target-registry-data.js");
+
+    const ids = getSecretTargetRegistry({
+      config: { plugins: { load: { paths: records.map((record) => record.rootDir) } } },
+      env: {},
+    }).map((entry) => entry.id);
+
+    expect(ids).toEqual(
+      expect.arrayContaining(["channels.custom.primaryToken", "channels.custom.secondaryToken"]),
+    );
   });
 });

--- a/src/secrets/target-registry-data.ts
+++ b/src/secrets/target-registry-data.ts
@@ -1,4 +1,5 @@
 /** Builds the static and plugin-derived registry of secret migration targets. */
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { loadChannelSecretContractApiForRecord } from "./channel-contract-api.js";
@@ -92,10 +93,6 @@ function listChannelSecretTargetRegistryEntries(
   const entries: SecretTargetRegistryEntry[] = [];
 
   for (const record of channelPlugins) {
-    const channelIds = record.channels;
-    if (channelIds.length === 0) {
-      continue;
-    }
     try {
       const contractApi = loadChannelSecretContractApiForRecord(record);
       entries.push(...(contractApi?.secretTargetRegistryEntries ?? []));
@@ -445,15 +442,23 @@ const CORE_SECRET_TARGET_REGISTRY: SecretTargetRegistryEntry[] = [
 let cachedSecretTargetRegistry: SecretTargetRegistryEntry[] | null = null;
 
 function loadSecretTargetRegistryFromPluginMetadata(params: {
+  config?: OpenClawConfig;
   env: NodeJS.ProcessEnv;
   preferPersisted?: boolean;
 }): SecretTargetRegistryEntry[] {
   const plugins = resolvePluginMetadataSnapshot({
+    ...(params.config !== undefined ? { config: params.config } : {}),
     env: params.env,
     allowWorkspaceScopedCurrent: true,
     ...(params.preferPersisted !== undefined ? { preferPersisted: params.preferPersisted } : {}),
   }).plugins;
-  const channelPlugins = plugins.filter((record) => record.channels.length > 0);
+  const channelPlugins = plugins.filter(
+    (record) =>
+      record.channels.length > 0 ||
+      Object.keys(record.channelConfigs ?? {}).length > 0 ||
+      Boolean(record.channelCatalogMeta?.id) ||
+      Boolean(record.packageChannel?.id),
+  );
   // Installed/workspace plugins own secret targets exactly like bundled ones
   // (#104320: the Exa split moved web providers out of bundled origin and their
   // targets vanished from the gateway's known-target registry). Entries stay
@@ -487,6 +492,8 @@ export function getCoreSecretTargetRegistry(): SecretTargetRegistryEntry[] {
 /** Returns the process-cached registry including bundled plugin/channel metadata. */
 /** Returns core plus plugin/channel secret target registry entries for the current metadata view. */
 export function getSecretTargetRegistry(params?: {
+  config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
   sourceTree?: boolean;
 }): SecretTargetRegistryEntry[] {
   if (params?.sourceTree) {
@@ -497,6 +504,14 @@ export function getSecretTargetRegistry(params?: {
         OPENCLAW_BUNDLED_PLUGINS_DIR: process.env.OPENCLAW_BUNDLED_PLUGINS_DIR ?? "extensions",
       },
       preferPersisted: false,
+    });
+  }
+  if (params?.config) {
+    // Config-scoped plugin roots and policy are not process-stable. Compile these registries per
+    // request so one config cannot poison discovery for a later config in the same process.
+    return loadSecretTargetRegistryFromPluginMetadata({
+      config: params.config,
+      env: params.env ?? process.env,
     });
   }
   if (cachedSecretTargetRegistry) {

--- a/src/secrets/target-registry-query.ts
+++ b/src/secrets/target-registry-query.ts
@@ -78,18 +78,15 @@ function buildConfigTargetIdIndex(
   return byId;
 }
 
-function getCompiledSecretTargetRegistryState() {
-  if (compiledSecretTargetRegistryState) {
-    return compiledSecretTargetRegistryState;
-  }
-  const compiledSecretTargetRegistry = getSecretTargetRegistry().map(compileTargetRegistryEntry);
+function compileSecretTargetRegistryState(registry: SecretTargetRegistryEntry[]) {
+  const compiledSecretTargetRegistry = registry.map(compileTargetRegistryEntry);
   const openClawCompiledSecretTargets = compiledSecretTargetRegistry.filter(
     (entry) => entry.configFile === "openclaw.json",
   );
   const authProfilesCompiledSecretTargets = compiledSecretTargetRegistry.filter(
     (entry) => entry.configFile === "auth-profiles.json",
   );
-  compiledSecretTargetRegistryState = {
+  return {
     authProfilesCompiledSecretTargets,
     authProfilesTargetsById: buildConfigTargetIdIndex(authProfilesCompiledSecretTargets),
     compiledSecretTargetRegistry,
@@ -98,7 +95,18 @@ function getCompiledSecretTargetRegistryState() {
     openClawTargetsById: buildConfigTargetIdIndex(openClawCompiledSecretTargets),
     targetsByType: buildTargetTypeIndex(compiledSecretTargetRegistry),
   };
+}
+
+function getCompiledSecretTargetRegistryState() {
+  if (compiledSecretTargetRegistryState) {
+    return compiledSecretTargetRegistryState;
+  }
+  compiledSecretTargetRegistryState = compileSecretTargetRegistryState(getSecretTargetRegistry());
   return compiledSecretTargetRegistryState;
+}
+
+function getConfiguredSecretTargetRegistryState(config: OpenClawConfig, env: NodeJS.ProcessEnv) {
+  return compileSecretTargetRegistryState(getSecretTargetRegistry({ config, env }));
 }
 
 function getCompiledCoreOpenClawTargetState() {
@@ -176,10 +184,31 @@ function configHasPluginEntries(config: OpenClawConfig): boolean {
 
 function getConfiguredChannelOpenClawTargets(
   config: OpenClawConfig,
-): CompiledTargetRegistryEntry[] {
-  return Object.keys(config.channels ?? {}).flatMap(
-    (channelId) => getCompiledChannelOpenClawTargets(channelId) ?? [],
-  );
+  env: NodeJS.ProcessEnv,
+): CompiledTargetRegistryEntry[] | null {
+  const entries: CompiledTargetRegistryEntry[] = [];
+  for (const channelId of Object.keys(config.channels ?? {})) {
+    if (channelId === "defaults" || channelId === "modelByChannel" || channelId === "tools") {
+      continue;
+    }
+    const contract = loadChannelSecretContractApi({
+      channelId,
+      config,
+      env,
+      bundledOnly: true,
+    });
+    if (!contract) {
+      // External/custom channels may have multiple manifest owners. Only the full registry can
+      // prove their target set is complete; a config-scoped first-contract lookup cannot.
+      return null;
+    }
+    entries.push(
+      ...(contract.secretTargetRegistryEntries
+        ?.filter((entry) => entry.configFile === "openclaw.json")
+        .map(compileTargetRegistryEntry) ?? []),
+    );
+  }
+  return entries;
 }
 
 function resolveDiscoveryEntries(params: {
@@ -463,13 +492,12 @@ export function resolveConfigSecretTargetByPath(pathSegments: string[]): Resolve
   return null;
 }
 
-/**
- * Discovers configured secret-bearing values in openclaw.json using the full registry.
- */
+/** Discovers configured secret-bearing values in openclaw.json. */
 export function discoverConfigSecretTargets(
   config: OpenClawConfig,
+  options: { env?: NodeJS.ProcessEnv } = {},
 ): DiscoveredConfigSecretTarget[] {
-  return discoverConfigSecretTargetsByIds(config);
+  return discoverConfigSecretTargetsByIds(config, undefined, options);
 }
 
 /**
@@ -478,25 +506,33 @@ export function discoverConfigSecretTargets(
 export function discoverConfigSecretTargetsByIds(
   config: OpenClawConfig,
   targetIds?: Iterable<string>,
+  options: { env?: NodeJS.ProcessEnv } = {},
 ): DiscoveredConfigSecretTarget[] {
+  const env = options.env ?? process.env;
   const allowedTargetIds = normalizeAllowedTargetIds(targetIds);
   const coreState = getCompiledCoreOpenClawTargetState();
   const hasOnlyCoreTargetIds =
     allowedTargetIds !== null &&
     Array.from(allowedTargetIds).every((targetId) => coreState.knownTargetIds.has(targetId));
+  const configuredChannelEntries =
+    !hasOnlyCoreTargetIds && !configHasPluginEntries(config)
+      ? getConfiguredChannelOpenClawTargets(config, env)
+      : null;
   const configuredEntries = hasOnlyCoreTargetIds
     ? coreState.openClawCompiledSecretTargets
-    : allowedTargetIds !== null && !configHasPluginEntries(config)
-      ? [...coreState.openClawCompiledSecretTargets, ...getConfiguredChannelOpenClawTargets(config)]
+    : configuredChannelEntries
+      ? [...coreState.openClawCompiledSecretTargets, ...configuredChannelEntries]
       : null;
   const configuredEntriesById = configuredEntries
     ? buildConfigTargetIdIndex(configuredEntries)
     : null;
   const canUseConfiguredEntries =
     configuredEntries !== null &&
-    allowedTargetIds !== null &&
-    Array.from(allowedTargetIds).every((targetId) => configuredEntriesById?.has(targetId));
-  const registryState = canUseConfiguredEntries ? null : getCompiledSecretTargetRegistryState();
+    (allowedTargetIds === null ||
+      Array.from(allowedTargetIds).every((targetId) => configuredEntriesById?.has(targetId)));
+  const registryState = canUseConfiguredEntries
+    ? null
+    : getConfiguredSecretTargetRegistryState(config, env);
   const discoveryEntries = resolveDiscoveryEntries({
     allowedTargetIds,
     defaultEntries: configuredEntries ?? registryState?.openClawCompiledSecretTargets ?? [],

--- a/src/secrets/target-registry.fast-path.test.ts
+++ b/src/secrets/target-registry.fast-path.test.ts
@@ -1,10 +1,14 @@
-/** Tests that explicit channel secret target lookup avoids broad manifest rediscovery. */
+/** Tests that configured-only secret target lookup avoids broad manifest rediscovery. */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { loadPluginManifestRegistryMock } = vi.hoisted(() => ({
   loadPluginManifestRegistryMock: vi.fn(() => {
-    throw new Error("manifest registry should stay off the explicit channel target fast path");
+    throw new Error("manifest registry should stay off configured-only target fast paths");
   }),
+}));
+
+const { getSecretTargetRegistryMock } = vi.hoisted(() => ({
+  getSecretTargetRegistryMock: vi.fn(),
 }));
 
 const { loadBundledPluginPublicArtifactModuleSyncMock } = vi.hoisted(() => ({
@@ -60,7 +64,38 @@ vi.mock("../plugins/public-surface-loader.js", () => ({
   loadBundledPluginPublicArtifactModuleSync: loadBundledPluginPublicArtifactModuleSyncMock,
 }));
 
+vi.mock("./target-registry-data.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./target-registry-data.js")>();
+  const channelTarget = (id: string) => ({
+    id,
+    targetType: id,
+    configFile: "openclaw.json" as const,
+    pathPattern: id,
+    secretShape: "secret_input" as const,
+    expectedResolvedValue: "string" as const,
+    includeInPlan: true,
+    includeInConfigure: true,
+    includeInAudit: true,
+  });
+  getSecretTargetRegistryMock.mockImplementation(
+    (params?: { config?: { plugins?: { load?: { paths?: string[] } } } }) => {
+      const loadPath = params?.config?.plugins?.load?.paths?.[0];
+      const channelEntries =
+        loadPath === "/plugins/custom-next"
+          ? [channelTarget("channels.customNext.token")]
+          : [
+              channelTarget("channels.qqbot.clientSecret"),
+              channelTarget("channels.custom.primaryToken"),
+              channelTarget("channels.custom.secondaryToken"),
+            ];
+      return [...actual.getCoreSecretTargetRegistry(), ...channelEntries];
+    },
+  );
+  return { ...actual, getSecretTargetRegistry: getSecretTargetRegistryMock };
+});
+
 import {
+  discoverConfigSecretTargets,
   discoverConfigSecretTargetsByIds,
   resolveConfigSecretTargetByPath,
   resolvePlanTargetAgainstRegistry,
@@ -70,6 +105,7 @@ describe("secret target registry fast path", () => {
   beforeEach(() => {
     loadPluginManifestRegistryMock.mockClear();
     loadBundledPluginPublicArtifactModuleSyncMock.mockClear();
+    getSecretTargetRegistryMock.mockClear();
   });
 
   it("resolves bundled channel targets by explicit channel id without manifest scans", () => {
@@ -109,6 +145,52 @@ describe("secret target registry fast path", () => {
 
     expect(targets.map((target) => target.entry.id)).toContain("channels.telegram.botToken");
     expect(loadPluginManifestRegistryMock).not.toHaveBeenCalled();
+  });
+
+  it("discovers all core and configured channel targets without loading plugin metadata", () => {
+    const targets = discoverConfigSecretTargets({
+      gateway: { auth: { token: "gateway-token" } },
+      channels: { telegram: { botToken: "telegram-token" } },
+    });
+
+    const targetIds = targets.map((target) => target.entry.id);
+    expect(targetIds).toEqual(
+      expect.arrayContaining(["gateway.auth.token", "channels.telegram.botToken"]),
+    );
+    expect(targetIds.some((targetId) => targetId.startsWith("plugins.entries."))).toBe(false);
+    expect(loadPluginManifestRegistryMock).not.toHaveBeenCalled();
+  });
+
+  it("uses the complete registry for configured external and custom channels", () => {
+    const env = { HOME: "/audit-home" };
+    const config = {
+      plugins: { load: { paths: ["/plugins/custom"] }, entries: {} },
+      channels: {
+        qqbot: { clientSecret: "qqbot-secret" },
+        custom: {
+          primaryToken: "primary-secret",
+          secondaryToken: "secondary-secret",
+        },
+      },
+    };
+    const targets = discoverConfigSecretTargets(config, { env });
+
+    expect(targets.map((target) => target.entry.id)).toEqual(
+      expect.arrayContaining([
+        "channels.qqbot.clientSecret",
+        "channels.custom.primaryToken",
+        "channels.custom.secondaryToken",
+      ]),
+    );
+    expect(getSecretTargetRegistryMock).toHaveBeenLastCalledWith({ config, env });
+
+    const nextConfig = {
+      plugins: { load: { paths: ["/plugins/custom-next"] }, entries: {} },
+      channels: { customNext: { token: "next-secret" } },
+    };
+    const nextTargets = discoverConfigSecretTargets(nextConfig, { env });
+    expect(nextTargets.map((target) => target.entry.id)).toContain("channels.customNext.token");
+    expect(getSecretTargetRegistryMock).toHaveBeenLastCalledWith({ config: nextConfig, env });
   });
 
   it("resolves channel plan targets without loading plugin metadata", () => {

--- a/src/secrets/target-registry.test.ts
+++ b/src/secrets/target-registry.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../test-utils/talk-test-provider.js";
 import { getCoreSecretTargetRegistry } from "./target-registry-data.js";
 import {
+  discoverConfigSecretTargets,
   discoverConfigSecretTargetsByIds,
   resolveConfigSecretTargetByPath,
   resolveSecretPlanTargetByPathCore,
@@ -101,6 +102,21 @@ describe("secret target registry", () => {
       "apiKey",
     ]);
     expect(fetchTarget?.entry?.id).toBe("plugins.entries.firecrawl.config.webFetch.apiKey");
+
+    const configuredTargets = discoverConfigSecretTargets({
+      plugins: {
+        entries: {
+          exa: {
+            config: {
+              webSearch: { apiKey: "configured-plugin-key" },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig);
+    expect(configuredTargets.map((entry) => entry.entry.id)).toContain(
+      "plugins.entries.exa.config.webSearch.apiKey",
+    );
   });
 
   it("derives bundled plugin SecretInput contract target paths from plugin manifests", () => {


### PR DESCRIPTION
## What Problem This Solves

The secrets audit test shard spent roughly 77 seconds on 29 tests because an empty-config warmup and otherwise focused fixtures repeatedly initialized broad plugin metadata. This made a small owner suite disproportionately slow in local and hosted CI.

## Why This Change Was Made

The audit suite now consolidates duplicate full-audit invocations while retaining their positive and negative observable contracts (markers, headers, malformed files, env shorthands, `.env` locations, and exec behavior). The exec batching fixture uses two fields on one core provider, so it still proves two refs resolve through one subprocess without triggering unrelated provider discovery.

Unfiltered config discovery now uses core targets plus directly configured bundled-channel contracts without building the plugin-derived registry. Configs with `plugins.entries` or configured official-external/custom channels retain complete config-scoped plugin discovery, including multiple channel owners; config-scoped registries bypass the process singleton so different `plugins.load.paths` cannot poison each other.

## User Impact

Developers get a substantially faster secrets audit shard with lower memory use. Runtime secret discovery behavior remains complete for plugin and custom channel configurations.

## Evidence

Exact cold command, before and after:

```bash
/usr/bin/time -v node scripts/run-vitest.mjs src/secrets/audit.test.ts --maxWorkers=1 --reporter=verbose
```

- Wall: **77.08s → 17.93s (76.7% faster)**
- Vitest: **70.41s → 11.67s (83.4% faster)**
- Peak RSS: **1,456,852 KiB → 727,168 KiB (50.1% lower)**
- Audit tests: **29 → 23**; removed invocations were duplicate warmups/fixtures, not independent contracts

Validation:

- 52/52 combined audit, channel-contract, and target-registry owner tests passed
- `pnpm tsgo:core` passed
- `pnpm tsgo:core:test` passed
- changed-file Oxlint and formatting passed
- structured final review: clean, no P0/P1 findings
