### PR TITLE
fix(ui): confirm before removing automations

### DIFF
--- a/ui/src/e2e/cron-remove.e2e.test.ts
+++ b/ui/src/e2e/cron-remove.e2e.test.ts
@@ -1,0 +1,106 @@
+// Control UI tests own the destructive Automation removal flow through the rendered page.
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway, waitForConfirmModal } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI cron removal mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}.`,
+});
+
+const job = {
+  id: "nightly-digest",
+  name: "Nightly digest",
+  enabled: true,
+  createdAtMs: Date.parse("2026-08-11T08:00:00.000Z"),
+  updatedAtMs: Date.parse("2026-08-11T08:05:00.000Z"),
+  schedule: { kind: "every", everyMs: 60_000 },
+  sessionTarget: "isolated",
+  wakeMode: "now",
+  payload: { kind: "agentTurn", message: "Summarize the overnight activity" },
+  state: {},
+};
+
+function cronListResponse(jobs: unknown[]) {
+  return {
+    jobs,
+    snapshotRevision: jobs.length > 0 ? "cron-remove-present" : "cron-remove-empty",
+    total: jobs.length,
+    offset: 0,
+    limit: 50,
+    hasMore: false,
+    nextOffset: null,
+  };
+}
+
+async function chooseRemove(page: Page) {
+  const menu = page.locator("wa-dropdown.cron-job-menu").first();
+  await menu.locator(".cron-job-menu__trigger").click();
+  await menu.locator('wa-dropdown-item[value="remove"]').click();
+}
+
+suite.define(() => {
+  it("confirms removal and rejects a decision captured before reconnect", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1_280 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "cron.list": cronListResponse([job]),
+            "cron.runs": { entries: [], total: 0, offset: 0, limit: 50, hasMore: false },
+            "cron.status": { enabled: true, jobs: 1, nextWakeAtMs: null },
+          },
+        });
+
+        const response = await page.goto(`${suite.server.baseUrl}cron`);
+        expect(response?.status()).toBe(200);
+        const row = page.locator(`[data-test-id="cron-row-${job.id}"]`);
+        await row.waitFor({ state: "visible", timeout: 10_000 });
+        await row.locator(".cron-table__name-text").click();
+        const detail = page.locator('.cron-page[data-panel-mode="job"]');
+        await detail.waitFor({ state: "visible" });
+
+        await chooseRemove(page);
+        const cancelled = await waitForConfirmModal(page);
+        await expect(cancelled.textContent()).resolves.toContain(job.name);
+        await expect(cancelled.textContent()).resolves.toContain("permanently deletes");
+        await expect(cancelled.textContent()).resolves.toContain("stops all future runs");
+        expect(await cancelled.getByRole("checkbox").count()).toBe(0);
+        await expect.poll(async () => gateway.getRequests("cron.remove")).toHaveLength(0);
+        await cancelled.getByRole("button", { name: "Cancel" }).click();
+        await expect.poll(async () => gateway.getRequests("cron.remove")).toHaveLength(0);
+        await detail.waitFor({ state: "visible" });
+        await expect
+          .poll(() => detail.locator(".cron-detail-title").textContent())
+          .toContain(job.name);
+
+        await chooseRemove(page);
+        const stale = await waitForConfirmModal(page);
+        const socketCount = await gateway.getSocketCount();
+        await gateway.closeLatest(1012, "Reconnect during automation removal confirmation");
+        await expect.poll(() => gateway.getSocketCount()).toBeGreaterThan(socketCount);
+        await stale.getByRole("button", { name: "Remove" }).click();
+        await expect.poll(async () => gateway.getRequests("cron.remove")).toHaveLength(0);
+        await row.waitFor({ state: "visible", timeout: 10_000 });
+
+        await chooseRemove(page);
+        const stable = await waitForConfirmModal(page);
+        const remove = stable.getByRole("button", { name: "Remove" });
+        await expect.poll(() => remove.getAttribute("class")).toContain("danger");
+        await gateway.setMethodResponse("cron.list", cronListResponse([]));
+        await remove.click();
+
+        await expect.poll(async () => gateway.getRequests("cron.remove")).toHaveLength(1);
+        expect((await gateway.getRequests("cron.remove"))[0]?.params).toEqual({ id: job.id });
+        await expect.poll(() => row.count()).toBe(0);
+      },
+    );
+  });
+});

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5608,6 +5608,9 @@ export const en: TranslationMap = {
       resume: "Resume",
       clone: "Clone",
       remove: "Remove",
+      removeConfirmTitle: 'Remove "{name}"?',
+      removeConfirmMessage:
+        "This permanently deletes the automation and stops all future runs. This action cannot be undone.",
       more: "More actions",
     },
     runNotStarted: {

--- a/ui/src/pages/cron/cron-page.test.ts
+++ b/ui/src/pages/cron/cron-page.test.ts
@@ -4,8 +4,11 @@ import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient, GatewayEventListener } from "../../api/gateway.ts";
 import type { CronJob, CronJobsListResult } from "../../api/types.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { showConfirmDialog } from "../../components/confirm-dialog.ts";
 import type { CronState } from "../../lib/cron/index.ts";
 import "./cron-page.ts";
+
+vi.mock("../../components/confirm-dialog.ts", () => ({ showConfirmDialog: vi.fn() }));
 
 type CronTestPage = HTMLElement & {
   context: ApplicationContext;
@@ -158,6 +161,7 @@ function createRequest() {
 
 afterEach(() => {
   document.body.replaceChildren();
+  vi.mocked(showConfirmDialog).mockReset();
   vi.restoreAllMocks();
 });
 
@@ -443,6 +447,7 @@ describe("CronPage editor state sync", () => {
     const removeButton = Array.from(page.querySelectorAll(".cron-job-menu__item")).find(
       (item) => item.textContent?.trim() === "Remove",
     ) as HTMLButtonElement;
+    vi.mocked(showConfirmDialog).mockResolvedValueOnce(true);
     removeButton.click();
     await waitForCronPage(() => expect(page.cron.cronEditingJobId).toBeNull());
     await waitForCronPage(() => expect(page.cron.cronRunsScope).toBe("all"));

--- a/ui/src/pages/cron/cron-page.ts
+++ b/ui/src/pages/cron/cron-page.ts
@@ -6,7 +6,9 @@ import { titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { readGatewayOperatorAccess } from "../../app/operator-access.ts";
 import { renderAgentScopeControl } from "../../components/agent-scope-control.ts";
+import { showConfirmDialog } from "../../components/confirm-dialog.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
+import { t } from "../../i18n/index.ts";
 import { watchAgentScope } from "../../lib/agents/index.ts";
 import {
   addCronJob,
@@ -286,6 +288,51 @@ class CronPage extends OpenClawLightDomElement {
     this.requestCronUpdate();
   }
 
+  private async removeJob(job: CronJob) {
+    const context = this.context;
+    const cronState = this.cron;
+    const connectionScope = this.gateway.capture();
+    const hadAdminAccess = this.canManageCron;
+    const selectedJob = cronState.cronJobs.find(
+      (entry) => entry.id === job.id && entry.updatedAtMs === job.updatedAtMs,
+    );
+    if (!connectionScope || !hadAdminAccess || !selectedJob) {
+      return;
+    }
+    const selectedJobId = selectedJob.id;
+    const selectedJobRevision = selectedJob.updatedAtMs;
+    const selectedJobName = selectedJob.name;
+    const confirmed = await showConfirmDialog({
+      title: t("cron.actions.removeConfirmTitle", { name: selectedJobName }),
+      message: t("cron.actions.removeConfirmMessage"),
+      confirmLabel: t("cron.actions.remove"),
+      danger: true,
+    });
+    const currentJob = cronState.cronJobs.find((entry) => entry.id === selectedJobId);
+    // The modal yields while every owner can rotate. Reject stale decisions so
+    // an old row can never delete a replacement task on a new page or Gateway.
+    if (
+      !confirmed ||
+      this.context !== context ||
+      this.cron !== cronState ||
+      !this.gateway.isCurrent(connectionScope) ||
+      !this.canManageCron ||
+      !currentJob ||
+      currentJob.updatedAtMs !== selectedJobRevision
+    ) {
+      return;
+    }
+    await this.runCronTask(async (current) => {
+      await removeCronJob(current, currentJob);
+      // Removing the selected task drops the panel back to overview;
+      // the runs scope must follow or recent activity stays empty.
+      if (current.cronRunsScope === "job" && current.cronRunsJobId === null) {
+        updateCronRunsFilter(current, { cronRunsScope: "all" });
+        await loadCronRuns(current, null);
+      }
+    });
+  }
+
   private closePanel() {
     cancelCronEdit(this.cron);
     this.cron.cronCreateOpen = false;
@@ -426,16 +473,7 @@ class CronPage extends OpenClawLightDomElement {
             }),
           onRun: (job, mode) =>
             this.runCronAdminTask((cronState) => runCronJob(cronState, job.id, mode ?? "force")),
-          onRemove: (job) =>
-            this.runCronAdminTask(async (cronState) => {
-              await removeCronJob(cronState, job);
-              // Removing the selected task drops the panel back to overview;
-              // the runs scope must follow or recent activity stays empty.
-              if (cronState.cronRunsScope === "job" && cronState.cronRunsJobId === null) {
-                updateCronRunsFilter(cronState, { cronRunsScope: "all" });
-                await loadCronRuns(cronState, null);
-              }
-            }),
+          onRemove: (job) => void this.removeJob(job),
           onLoadMoreJobs: () =>
             void this.runCronTask((cronState) =>
               loadCronJobsPage(cronState, { append: true, tableFilters: true }),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where selecting **Remove** for an Automation immediately sent `cron.remove`. Because the operation permanently deletes the scheduled task, an accidental click had no cancellation step.

## Why This Change Was Made

`CronPage` now owns a named, unskippable danger confirmation. Before opening the modal it captures the current Gateway connection, application context, Cron state object, admin capability, and task revision. After the operator confirms, it revalidates every owner and refuses the deletion if the connection, page state, permissions, or task revision changed.

The leaf renderer and Cron RPC helper remain transport-only. Existing post-removal list and run-history reconciliation is preserved.

AI-assisted: yes. The final implementation was manually reviewed, exercised through the rendered Control UI, and passed fresh structured autoreview.

## User Impact

Operators now see which Automation will be permanently removed and can cancel safely. Reconnects, scope changes, page-state replacement, or task edits while the dialog is open cannot redirect a stale confirmation. A stable confirmation sends exactly one removal request.

## Evidence

**Before action:** the Automation exists in the list; previously choosing Remove dispatched immediately.

![Automation list before removal](https://github.com/user-attachments/assets/3a006624-075c-48fd-99c3-069376142227)

**After:** Remove opens a named, destructive confirmation explaining the permanent effect.

![Named Automation removal confirmation](https://github.com/user-attachments/assets/9ccacf5e-2c87-48f8-a507-bb9c9f3ff610)

**Cancel:** the selected Automation detail remains intact.

![Cancelled removal preserves Automation](https://github.com/user-attachments/assets/c8c373df-59f2-417c-a568-3c85745229a9)

**Confirm:** one removal request reconciles to the empty list.

![Confirmed removal updates Automation list](https://github.com/user-attachments/assets/5ff46ae9-a97c-4aff-a7a7-db41649f4596)

Validation:

- Pre-fix rendered regression failed because the Remove selection sent immediately and no modal appeared.
- `node scripts/run-vitest.mjs ui/src/pages/cron/cron-page.test.ts ui/src/e2e/cron-remove.e2e.test.ts` — 17 unit tests plus 1 Chromium E2E passed on the final rebased head.
- `node scripts/check-changed.mjs -- ui/src/pages/cron/cron-page.ts ui/src/pages/cron/cron-page.test.ts ui/src/e2e/cron-remove.e2e.test.ts ui/src/i18n/locales/en.ts` — passed on Testbox `tbx_01kztb49h7m3hc7nyrrey7q1vr` ([run](https://github.com/openclaw/openclaw/actions/runs/31570804721)).
- Final rebase retained the identical patch; focused tests, formatting, and `git diff --check` passed again.
- Hosted exact-head CI — green ([run](https://github.com/openclaw/openclaw/actions/runs/31571831559)).
- Fresh rebased-head autoreview — clean, no accepted/actionable findings.
- Production/i18n: +51/−10 lines; tests: +111/−0 lines. The growth is the page-owned confirmation and stale-owner guards plus one source-blind destructive-action E2E; no Gateway or Cron RPC path was added.
