### PR TITLE
fix(ui): show each chat panel button once, in the pane header

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -2442,6 +2442,10 @@ function createMockGatewayPlugin(scenario: ControlUiMockGatewayScenario): Plugin
         res.end(bootstrapBody);
       });
     },
+    // ui/vite.config.ts registers a placeholder bootstrap-config middleware and
+    // config-file plugins load first, so without "pre" its stub answers every
+    // request and the scenario's bootstrap fields never reach the app.
+    enforce: "pre",
     name: "openclaw-control-ui-mock-gateway",
     transformIndexHtml(html) {
       return html.replace(

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -1472,8 +1472,10 @@ async function createChatPickerScenario(
     // Advertised Gateway methods gate session actions (see
     // ui/src/lib/session-method-access.ts). Omitting the mutation methods left
     // every session context-menu row disabled, so the harness could not show
-    // the menu operators actually see.
+    // the menu operators actually see. browser.request/terminal.open likewise
+    // gate the chat header's panel toggles, which stayed invisible here.
     featureMethods: [
+      "browser.request",
       "chat.metadata",
       "chat.startup",
       "question.list",
@@ -1493,7 +1495,11 @@ async function createChatPickerScenario(
       "sessions.catalog.list",
       "sessions.catalog.read",
       "system.info",
+      "terminal.open",
     ],
+    // Terminal has a second gate beyond the advertised method (see
+    // ui/src/lib/terminal-availability.ts).
+    terminalEnabled: true,
     historyMessages: buildScrollableChatHistory(baseTime),
     // Lights up the footer facepile and who's-online roster; the email-only
     // entry keeps the roster's no-display-name row exercised.

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -186,6 +186,18 @@ export abstract class ChatPaneHeader extends ChatPaneSessionMenu {
           detail: { open: true },
         }),
       );
+    const browserPanelAction = sessionWorkspace.onToggleBrowser
+      ? html`<openclaw-tooltip .content=${t("browser.toggle")}>
+          <button
+            class="btn btn--ghost btn--icon chat-icon-btn chat-browser-panel-toggle"
+            type="button"
+            aria-label=${t("browser.toggle")}
+            @click=${sessionWorkspace.onToggleBrowser}
+          >
+            ${icons.globe}
+          </button>
+        </openclaw-tooltip>`
+      : nothing;
     const desktopPanelAction = desktopPanelAvailable
       ? html`<openclaw-tooltip .content=${t("desktop.toggle")}>
           <button
@@ -208,6 +220,14 @@ export abstract class ChatPaneHeader extends ChatPaneSessionMenu {
         label: t("terminal.toggle"),
         icon: icons.terminal,
         onActivate: sessionWorkspace.onToggleTerminal,
+      });
+    }
+    if (sessionWorkspace.onToggleBrowser) {
+      panelMenuActions.push({
+        id: "browser",
+        label: t("browser.toggle"),
+        icon: icons.globe,
+        onActivate: sessionWorkspace.onToggleBrowser,
       });
     }
     if (desktopPanelAvailable) {
@@ -324,7 +344,7 @@ export abstract class ChatPaneHeader extends ChatPaneSessionMenu {
         this.state,
         this.catalogSession,
         sessionWorkspace.onToggleTerminal,
-      )}${desktopPanelAction}`,
+      )}${browserPanelAction}${desktopPanelAction}`,
       discussionAction: this.renderSessionDiscussionAction(discussion),
       diffAction: renderSessionDiffToggle(sessionWorkspace),
       backgroundTasksAction: renderBackgroundTasksToggle(backgroundTasks),

--- a/ui/src/pages/chat/chat-pane-terminal.test.ts
+++ b/ui/src/pages/chat/chat-pane-terminal.test.ts
@@ -5,8 +5,10 @@ import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient, GatewayHelloOk } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import {
+  BROWSER_PANEL_TOGGLE_EVENT,
   DESKTOP_PANEL_TOGGLE_EVENT,
   TERMINAL_PANEL_TOGGLE_EVENT,
+  type BrowserPanelToggleDetail,
   type DesktopPanelToggleDetail,
   type TerminalPanelToggleDetail,
 } from "../../components/panel-toggle-contract.ts";
@@ -127,6 +129,59 @@ describe("chat pane terminal action", () => {
       expect(container.querySelector('[aria-label="Toggle desktop panel"]')).toBeNull();
     } finally {
       window.removeEventListener(DESKTOP_PANEL_TOGGLE_EVENT, listener);
+    }
+  });
+
+  it("renders the browser control only when available and exposes it in the narrow menu", () => {
+    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+    const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    const session = {
+      key: state.sessionKey,
+      kind: "direct",
+      updatedAt: 0,
+    } satisfies GatewaySessionRow;
+    const container = document.createElement("div");
+    const renderHeader = () =>
+      render(
+        pane.renderPaneHeader(
+          createSessionWorkspaceProps(state),
+          createBackgroundTasksProps(state),
+          session,
+          false,
+          undefined,
+          false,
+        ),
+        container,
+      );
+    const panelActionIds = () =>
+      container
+        .querySelector<HTMLElement & { panelActions: Array<{ id: string }> }>(
+          "openclaw-chat-header-session-menu",
+        )
+        ?.panelActions.map((action) => action.id) ?? [];
+
+    state.browserPanelAvailable = false;
+    renderHeader();
+    expect(container.querySelector(".chat-browser-panel-toggle")).toBeNull();
+    expect(panelActionIds()).not.toContain("browser");
+
+    const events: CustomEvent<BrowserPanelToggleDetail>[] = [];
+    const listener = (event: Event) => events.push(event as CustomEvent<BrowserPanelToggleDetail>);
+    window.addEventListener(BROWSER_PANEL_TOGGLE_EVENT, listener);
+    try {
+      state.browserPanelAvailable = true;
+      renderHeader();
+      const button = container.querySelector<HTMLButtonElement>(".chat-browser-panel-toggle");
+      expect(button).not.toBeNull();
+      button?.click();
+      expect(events).toHaveLength(1);
+
+      (pane as typeof pane & { narrow: boolean }).narrow = true;
+      renderHeader();
+      expect(container.querySelector(".chat-browser-panel-toggle")).toBeNull();
+      expect(panelActionIds()).toContain("browser");
+    } finally {
+      window.removeEventListener(BROWSER_PANEL_TOGGLE_EVENT, listener);
     }
   });
 });

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1793,6 +1793,9 @@ describe("chat composer workbench", () => {
     const container = renderChatView({
       sessionWorkspace: createSessionWorkspace({
         narrowLayout: true,
+        onToggleTerminal: vi.fn(),
+        onToggleBrowser: vi.fn(),
+        onOpenDiff: vi.fn(),
       }),
     });
 
@@ -1801,6 +1804,8 @@ describe("chat composer workbench", () => {
     expect(container.querySelector(".chat-workspace-rail")).not.toBeNull();
     expect(container.querySelector(".chat-workspace-rail__dock")).toBeNull();
     expect(container.querySelector(".chat-workspace-rail__grip")).toBeNull();
+    expect(container.querySelector(".chat-workspace-rail__terminal")).toBeNull();
+    expect(container.querySelector(".chat-session-diff-toggle")).toBeNull();
   });
 
   it("moves the background-tasks rail to a bottom strip on narrow panes", () => {

--- a/ui/src/pages/chat/components/chat-session-workspace.test.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.test.ts
@@ -43,25 +43,6 @@ describe("toggleSessionWorkspace", () => {
   });
 });
 
-describe("custodian panel toggle", () => {
-  it("is available only while the gateway is connected and advertises chat", () => {
-    const state = {
-      client: null,
-      connected: false,
-      handleOpenSidebar: vi.fn(),
-      hello: gatewayHello(["openclaw.chat"]),
-      requestUpdate: vi.fn(),
-      sessionKey: "agent:main:current",
-      sessions: {},
-    } as unknown as SessionWorkspaceHost;
-
-    expect(createSessionWorkspaceProps(state).onToggleCustodian).toBeUndefined();
-
-    state.connected = true;
-    expect(createSessionWorkspaceProps(state).onToggleCustodian).toBeTypeOf("function");
-  });
-});
-
 describe("session workspace artifacts", () => {
   function createArtifactHost(params: { data: string; mimeType: string; title?: string }) {
     const handleOpenSidebar = vi.fn();

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -20,7 +20,6 @@ import {
 import { icons } from "../../../components/icons.ts";
 import {
   BROWSER_PANEL_TOGGLE_EVENT,
-  CUSTODIAN_PANEL_TOGGLE_EVENT,
   TERMINAL_PANEL_TOGGLE_EVENT,
 } from "../../../components/panel-toggle-contract.ts";
 import "../../../components/tooltip.ts";
@@ -65,7 +64,6 @@ export type SessionWorkspaceProps = {
   onOpenArtifact: (artifactId: string) => void;
   onToggleTerminal?: () => void;
   onToggleBrowser?: () => void;
-  onToggleCustodian?: () => void;
   /** Opens the session diff panel; absent until a usable checkout is known. */
   onOpenDiff?: () => void;
 };
@@ -828,10 +826,6 @@ export function createSessionWorkspaceProps(
           window.dispatchEvent(new CustomEvent(BROWSER_PANEL_TOGGLE_EVENT, {}));
         }
       : undefined,
-    onToggleCustodian:
-      state.connected && isGatewayMethodAdvertised(state, "openclaw.chat") === true
-        ? () => window.dispatchEvent(new CustomEvent(CUSTODIAN_PANEL_TOGGLE_EVENT))
-        : undefined,
     onOpenDiff: canOpenDiff
       ? () => state.handleOpenSidebar(buildSessionDiffSidebarContent(state))
       : undefined,
@@ -961,62 +955,6 @@ export function renderSessionWorkspaceRail(
   // Narrow panes always present the rail as a bottom strip; a side column
   // would crush the thread below its readable minimum.
   const dock = sessionWorkspace.narrowLayout ? "bottom" : sessionWorkspace.dock;
-  const terminalButton = sessionWorkspace.onToggleTerminal
-    ? html`
-        <openclaw-tooltip .content=${t("terminal.toggle")}>
-          <button
-            type="button"
-            class="chat-workspace-rail__terminal"
-            aria-label=${t("terminal.toggle")}
-            @click=${sessionWorkspace.onToggleTerminal}
-          >
-            ${icons.terminal}
-          </button>
-        </openclaw-tooltip>
-      `
-    : nothing;
-  const browserButton = sessionWorkspace.onToggleBrowser
-    ? html`
-        <openclaw-tooltip .content=${t("browser.toggle")}>
-          <button
-            type="button"
-            class="chat-workspace-rail__terminal"
-            aria-label=${t("browser.toggle")}
-            @click=${sessionWorkspace.onToggleBrowser}
-          >
-            ${icons.globe}
-          </button>
-        </openclaw-tooltip>
-      `
-    : nothing;
-  const custodianButton = sessionWorkspace.onToggleCustodian
-    ? html`
-        <openclaw-tooltip .content=${t("custodian.panel.toggle")}>
-          <button
-            type="button"
-            class="chat-workspace-rail__terminal"
-            aria-label=${t("custodian.panel.toggle")}
-            @click=${sessionWorkspace.onToggleCustodian}
-          >
-            ${icons.lobster}
-          </button>
-        </openclaw-tooltip>
-      `
-    : nothing;
-  const diffButton = sessionWorkspace.onOpenDiff
-    ? html`
-        <openclaw-tooltip .content=${t("chat.sessionDiff.show")}>
-          <button
-            type="button"
-            class="chat-workspace-rail__terminal chat-session-diff-toggle"
-            aria-label=${t("chat.sessionDiff.show")}
-            @click=${sessionWorkspace.onOpenDiff}
-          >
-            ${icons.diff}
-          </button>
-        </openclaw-tooltip>
-      `
-    : nothing;
   const files = sessionWorkspace.list?.files ?? [];
   const modifiedFiles = files.filter((file) => file.kind === "modified");
   const readFiles = files.filter((file) => file.kind === "read");
@@ -1306,7 +1244,6 @@ export function renderSessionWorkspaceRail(
           <strong>${t("chat.workspaceFiles.files")}</strong>
         </div>
         <div class="chat-workspace-rail__actions">
-          ${diffButton} ${terminalButton} ${browserButton} ${custodianButton}
           ${sessionWorkspace.narrowLayout
             ? nothing
             : html`

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -454,7 +454,6 @@ openclaw-chat-sidebar-region,
   gap: 6px;
 }
 
-.chat-workspace-rail__terminal,
 .chat-workspace-rail__refresh,
 .chat-workspace-rail__dock,
 .chat-workspace-rail__collapse-toggle {
@@ -476,24 +475,6 @@ openclaw-chat-sidebar-region,
   cursor: grabbing;
 }
 
-.chat-workspace-rail__terminal {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  /* Chromeless at rest like the sibling ghost buttons; chrome on hover only. */
-  border: 1px solid transparent;
-  border-radius: var(--radius-md);
-  background: transparent;
-  color: var(--muted);
-}
-
-.chat-workspace-rail__terminal:hover,
-.chat-workspace-rail__terminal:focus-visible {
-  color: var(--text);
-  border-color: color-mix(in srgb, var(--accent) 34%, var(--border));
-  background: color-mix(in srgb, var(--accent) 8%, transparent);
-}
-
 /* Overrides the shared .nav-collapse-toggle chrome (border, elevated
    background, inset highlight): rail header buttons only show chrome on
    hover. */
@@ -510,7 +491,6 @@ openclaw-chat-sidebar-region,
   transform: none;
 }
 
-.chat-workspace-rail__terminal svg,
 .chat-workspace-rail__refresh svg,
 .chat-workspace-rail__dock svg,
 .chat-workspace-rail__collapse-toggle svg,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using the chat page would see the same panel buttons twice, and would have to hunt inside a file rail to find others.

The chat page has two icon rows: the pane header at the top, and the "SESSION / Workspace" rail header below it. The rail header had grown four buttons that do not belong to it:

- **Terminal** and **Changes** rendered in *both* rows at once, under identical gating — two buttons, one action, no way to tell them apart.
- **Browser** rendered *only* inside the workspace rail, so the browser panel was reachable only after expanding a files rail.
- **Ask OpenClaw** sat in a per-session rail even though it is a global surface that already owns a sidebar entry (Settings → Ask OpenClaw).

The crowding was also a layout bug: with every button available, the rail's action row overflowed and drew on top of its own "Workspace" title (see before/after below).

## Why This Change Was Made

One invariant now decides where a button lives: **the workspace rail header owns workspace-file actions only (dock, refresh, collapse); panel toggles live in the chat pane header; Ask OpenClaw lives in the sidebar.**

Browser moves up beside Terminal in the pane header and gains a narrow-header overflow entry, matching how Terminal and Desktop already work. The duplicated Terminal and Changes buttons and the Ask OpenClaw toggle are deleted from the rail, along with the CSS that styled them.

Non-goal, deliberately left for follow-up: `CUSTODIAN_PANEL_TOGGLE_EVENT` and its listeners in `custodian-panel.ts` / `app-shell-chrome.ts` now have no production dispatcher. The floating Ask OpenClaw panel still works — it re-opens itself when you navigate away from `/custodian` mid-conversation — but that event contract and the now-unused `custodian.panel.toggle` string should be removed (or re-pointed at a sidebar opener) in a change that owns the panel's open API, not this one.

Two harness fixes ride along because the change could not otherwise be seen:

1. The mock Control UI never advertised `browser.request` or `terminal.open` and left `terminalEnabled` false, so these very buttons were invisible in `pnpm dev:ui:mock`.
2. `ui/vite.config.ts` registers a placeholder `/control-ui-config.json` middleware, and config-file plugins load before inline ones — so the mock gateway plugin's bootstrap body was silently discarded and *every* scenario bootstrap field was dropped. Marking the mock plugin `enforce: "pre"` lets it answer first.

## User Impact

Each panel button appears exactly once, in one predictable row. The Browser panel is now reachable from the chat header instead of only from inside the workspace file rail, and the "Workspace" title is no longer overdrawn by its own buttons. Ask OpenClaw is reached through the sidebar, where it already lived.

## Evidence

**Chat pane, before → after.** Before, the rail header's buttons collide with the "Workspace" label; after, the rail keeps only dock/refresh/collapse and the pane header carries every panel toggle.

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/9c5d1fd4-467e-4e33-ade0-e658aafda90d) | ![after](https://github.com/user-attachments/assets/e3a7866a-9c09-42e4-a7ba-de738ded4036) |

**Pane header action row** — Terminal was already here; Browser (globe) joins it:

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/51f79249-0129-4ffd-bfe2-f09e2dd1bc53) | ![after](https://github.com/user-attachments/assets/93779c6d-7108-46a9-bd85-f411c8512d48) |

**Workspace rail header** — four foreign buttons removed, overlap gone:

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/4b0f8aac-0ae0-4218-8086-bbc01c12e3b7) | ![after](https://github.com/user-attachments/assets/370c2ebe-00c9-4eab-934f-74233bc241b5) |

Screenshots are from the mocked Control UI (`pnpm dev:ui:mock`) driven by Playwright at 1440x900, dark theme; all session content is mock fixture data.

**Focused tests**

```
node scripts/run-vitest.mjs \
  ui/src/pages/chat/chat-pane-terminal.test.ts \
  ui/src/pages/chat/components/chat-session-workspace.test.ts \
  ui/src/pages/chat/components/chat-pane-header.test.ts \
  ui/src/pages/chat/chat-view.test.ts

Test Files  4 passed (4)
     Tests  297 passed (297)
```

New coverage: `chat-pane-terminal.test.ts` asserts the Browser control renders only when `browserPanelAvailable`, dispatches `openclaw:browser-toggle`, and collapses into the narrow overflow menu as id `browser`. `chat-view.test.ts` asserts the rail action row no longer contains `.chat-workspace-rail__terminal` or `.chat-session-diff-toggle`. The obsolete custodian-availability test is deleted rather than weakened.

**LOC** — production `+21 −84` (net **−63**); tests `+60 −19`; harness `+12 −1`.

**Review** — `autoreview --mode branch` (codex / gpt-5.6-sol / high): clean, no accepted or actionable findings.
