### PR TITLE
fix(text): hold a lone uppercase N as a pending NO_REPLY lead fragment

### DIFF
--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -537,18 +537,35 @@ export function createAcpVisibleTextAccumulator() {
       return { text: visibleText, delta: nextVisible.delta };
     },
     finalize(): string {
-      return visibleText.trim();
+      return resolveTerminalVisibleText().trim();
     },
     finalizeRaw(): string {
-      return visibleText;
+      return resolveTerminalVisibleText();
     },
     finalizeReplySnapshot(): AgentRunTerminalReplySnapshot {
+      // A pending prefix that never grew into an exact silent token is ordinary
+      // terminal text (e.g. a lone streamed `N`); release it at finalization so
+      // a completed turn is never silently dropped. An exact NO_REPLY is kept as
+      // rawText so buildAgentRunTerminalReplySnapshot classifies it silent.
       return buildAgentRunTerminalReplySnapshot({
-        visibleText,
+        visibleText: resolveTerminalVisibleText(),
         rawText: pendingSilentPrefix,
       });
     },
   };
+
+  // At terminal completion, a held prefix that is not an exact silent token is
+  // visible text the model actually emitted, not a suppressed control reply.
+  function resolveTerminalVisibleText(): string {
+    if (
+      pendingSilentPrefix &&
+      !isSilentReplyText(pendingSilentPrefix, SILENT_REPLY_TOKEN) &&
+      !visibleText
+    ) {
+      return pendingSilentPrefix;
+    }
+    return visibleText;
+  }
 }
 
 if (process.env.VITEST || process.env.NODE_ENV === "test") {

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -1156,7 +1156,16 @@ describe("createAcpVisibleTextAccumulator", () => {
     },
     { name: "exact silence", chunks: ["NO_REPLY"], expected: { disposition: "silent" } },
     { name: "clean empty output", chunks: [], expected: { disposition: "empty" } },
-    { name: "partial control prefix", chunks: ["NO_RE"], expected: { disposition: "empty" } },
+    {
+      name: "partial control prefix released as visible",
+      chunks: ["NO_RE"],
+      expected: { disposition: "visible", text: "NO_RE" },
+    },
+    {
+      name: "lone N lead released as visible terminal text (#122476)",
+      chunks: ["N"],
+      expected: { disposition: "visible", text: "N" },
+    },
     {
       name: "punctuation-wrapped silence",
       chunks: ["NO_REPLY:"],

--- a/src/agents/embedded-agent-subscribe.handlers.messages.update-stream-items.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.update-stream-items.test.ts
@@ -427,3 +427,72 @@ describe("handleMessageUpdate text signatures", () => {
     expect(context.state.deltaBuffer).toBe("Working now");
   });
 });
+// #122476: a streamed lone `N` may still grow into `NO_REPLY`, so it is held
+// silent mid-stream and only released as ordinary text at terminal completion.
+// An exact `NO_REPLY` stays silent through both delta and text_end. Drives the
+// real handleMessageUpdate -> streaming accumulator path (agent->gateway event
+// boundary), not just the pure classifier.
+describe("lone N silent-reply lead fragment", () => {
+  const createDelta = (delta: string) =>
+    ({
+      message: { role: "assistant", content: [] },
+      assistantMessageEvent: { type: "text_delta", delta },
+    }) as never;
+
+  const createContext = () => {
+    const onAgentEvent = vi.fn();
+    const accumulator = createStreamingDirectiveAccumulator();
+    const context = createMessageUpdateContext({
+      onAgentEvent,
+      consumePartialReplyDirectives: vi.fn((text: string, options?: { final?: boolean }) =>
+        accumulator.consume(text, options),
+      ),
+    });
+    return { onAgentEvent, context };
+  };
+
+  it("holds a streamed N without emitting it, then releases it at text_end", () => {
+    const { onAgentEvent, context } = createContext();
+
+    // `N` is not a directive tail (unlike `M`), so it reaches the silent-prefix
+    // check: held pending, no assistant visible-text event carries it mid-stream.
+    updateMessage(context, createDelta("N"));
+    expect(onAgentEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "assistant",
+        data: expect.objectContaining({ text: "N" }),
+      }),
+    );
+
+    // Terminal completion with a lone non-exact N: released as ordinary text,
+    // not dropped as a silent token.
+    updateMessage(context, {
+      message: { role: "assistant", content: [] },
+      assistantMessageEvent: { type: "text_end", content: "N" },
+    });
+    expect(onAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "assistant",
+        data: expect.objectContaining({ text: "N" }),
+      }),
+    );
+  });
+
+  it("keeps an exact NO_REPLY silent across delta and text_end", () => {
+    const { onAgentEvent, context } = createContext();
+
+    updateMessage(context, createDelta("NO_REPLY"));
+    updateMessage(context, {
+      message: { role: "assistant", content: [] },
+      assistantMessageEvent: { type: "text_end", content: "NO_REPLY" },
+    });
+    // An exact silent token is suppressed at every stage, so no assistant
+    // visible-text event carries it.
+    expect(onAgentEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "assistant",
+        data: expect.objectContaining({ text: "NO_REPLY" }),
+      }),
+    );
+  });
+});

--- a/src/auto-reply/reply/streaming-directives.test.ts
+++ b/src/auto-reply/reply/streaming-directives.test.ts
@@ -29,6 +29,26 @@ describe("createStreamingDirectiveAccumulator", () => {
     });
   });
 
+  it("keeps a silent prefix silent across streaming deltas", () => {
+    const acc = createStreamingDirectiveAccumulator();
+    expect(acc.consume("N")).toBeNull();
+    // The next delta continues NO_REPLY. It must resume the held prefix instead
+    // of leaking as visible text now that the lone N no longer blocks the run.
+    expect(acc.consume("O_REPLY")).toBeNull();
+    expect(acc.consume("", { final: true })).toBeNull();
+  });
+
+  it("grows a held silent prefix across deltas and releases the remainder at final", () => {
+    const acc = createStreamingDirectiveAccumulator();
+    expect(acc.consume("N")).toBeNull();
+    expect(acc.consume("O_RE")).toBeNull();
+    // Terminal flush sees a non-exact fragment: ordinary output, released.
+    expect(acc.consume("", { final: true })).toMatchObject({
+      text: "NO_RE",
+      isSilent: false,
+    });
+  });
+
   it("renders ordinary visible text", () => {
     const acc = createStreamingDirectiveAccumulator();
     expect(acc.consume("The handoff is complete.")).toMatchObject({

--- a/src/auto-reply/reply/streaming-directives.test.ts
+++ b/src/auto-reply/reply/streaming-directives.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { createStreamingDirectiveAccumulator } from "./streaming-directives.js";
+
+describe("createStreamingDirectiveAccumulator", () => {
+  it("holds a lone N prefix silent while streaming, then releases it at final", () => {
+    const acc = createStreamingDirectiveAccumulator();
+    // A streamed `N` may still grow into NO_REPLY; while streaming it is held.
+    expect(acc.consume("N")).toBeNull();
+    // At message-end the turn is terminal; a non-exact fragment is ordinary
+    // output the model emitted and must not be dropped (#122476).
+    expect(acc.consume("N", { final: true })).toMatchObject({
+      text: "N",
+      isSilent: false,
+    });
+  });
+
+  it("keeps an exact NO_REPLY silent at finalization", () => {
+    const acc = createStreamingDirectiveAccumulator();
+    expect(acc.consume("NO_REPLY")).toBeNull();
+    expect(acc.consume("NO_REPLY", { final: true })).toBeNull();
+  });
+
+  it("releases a partial control prefix that never resolves to the token at final", () => {
+    const acc = createStreamingDirectiveAccumulator();
+    expect(acc.consume("NO_RE")).toBeNull();
+    expect(acc.consume("NO_RE", { final: true })).toMatchObject({
+      text: "NO_RE",
+      isSilent: false,
+    });
+  });
+
+  it("renders ordinary visible text", () => {
+    const acc = createStreamingDirectiveAccumulator();
+    expect(acc.consume("The handoff is complete.")).toMatchObject({
+      text: "The handoff is complete.",
+      isSilent: false,
+    });
+  });
+});

--- a/src/auto-reply/reply/streaming-directives.ts
+++ b/src/auto-reply/reply/streaming-directives.ts
@@ -81,7 +81,10 @@ export const splitTrailingDirective = (text: string): { text: string; tail: stri
   };
 };
 
-const parseChunk = (raw: string, options?: { silentToken?: string }): ParsedChunk => {
+const parseChunk = (
+  raw: string,
+  options?: { silentToken?: string; final?: boolean },
+): ParsedChunk => {
   let text = raw ?? "";
   const replyParsed = parseInlineDirectives(text, {
     stripAudioTag: true,
@@ -92,8 +95,13 @@ const parseChunk = (raw: string, options?: { silentToken?: string }): ParsedChun
   }
 
   const silentToken = options?.silentToken ?? SILENT_REPLY_TOKEN;
+  // A prefix-only fragment (e.g. a streamed `N`) is held silent while more text
+  // may still arrive, but at terminal completion a non-exact fragment is ordinary
+  // output the model emitted and must not be dropped. Only an exact token stays
+  // silent at finalization.
   const isSilent =
-    isSilentReplyText(text, silentToken) || isSilentReplyPrefixText(text, silentToken);
+    isSilentReplyText(text, silentToken) ||
+    (!options?.final && isSilentReplyPrefixText(text, silentToken));
   if (isSilent) {
     text = "";
   } else if (startsWithSilentToken(text, silentToken)) {
@@ -154,7 +162,10 @@ export function createStreamingDirectiveAccumulator() {
       return null;
     }
 
-    const parsed = parseChunk(combined, { silentToken: options.silentToken });
+    const parsed = parseChunk(combined, {
+      silentToken: options.silentToken,
+      final: options.final,
+    });
     if (hadPendingTail && heldSeparator && parsed.text.startsWith("[")) {
       parsed.text = `${heldSeparator}${parsed.text}`;
     }

--- a/src/auto-reply/reply/streaming-directives.ts
+++ b/src/auto-reply/reply/streaming-directives.ts
@@ -125,6 +125,7 @@ const hasRenderableContent = (parsed: ReplyDirectiveParseResult): boolean =>
 export function createStreamingDirectiveAccumulator() {
   let pendingTail = "";
   let pendingSeparator = "";
+  let pendingSilentPrefix = "";
   let pendingReply: PendingReplyState = { sawCurrent: false, hasTag: false };
   let activeReply: PendingReplyState = { sawCurrent: false, hasTag: false };
   let hasReturnedText = false;
@@ -132,6 +133,7 @@ export function createStreamingDirectiveAccumulator() {
   const reset = () => {
     pendingTail = "";
     pendingSeparator = "";
+    pendingSilentPrefix = "";
     pendingReply = { sawCurrent: false, hasTag: false };
     activeReply = { sawCurrent: false, hasTag: false };
     hasReturnedText = false;
@@ -140,9 +142,17 @@ export function createStreamingDirectiveAccumulator() {
   const consume = (raw: string, options: ConsumeOptions = {}): ReplyDirectiveParseResult | null => {
     const hadPendingTail = pendingTail.length > 0;
     const heldSeparator = pendingSeparator;
-    let combined = `${pendingTail}${raw ?? ""}`;
+    const heldSilentPrefix = pendingSilentPrefix;
+    const heldTail = pendingTail;
+    pendingSilentPrefix = "";
     pendingTail = "";
     pendingSeparator = "";
+    // Terminal flushes re-feed whole assistant text that already opens with the
+    // held fragment; composing it again would duplicate those characters. Only
+    // a continuation delta still needs the held prefix prepended.
+    const composingSilentPrefix =
+      heldSilentPrefix.length > 0 && !(raw ?? "").startsWith(heldSilentPrefix);
+    let combined = `${composingSilentPrefix ? heldSilentPrefix : ""}${heldTail}${raw ?? ""}`;
 
     if (!options.final) {
       const split = splitTrailingDirective(combined);
@@ -194,6 +204,12 @@ export function createStreamingDirectiveAccumulator() {
           sawCurrent,
           hasTag,
         };
+      }
+      // A still-silent fragment (a streamed `N`, `NO`, or exact token) is
+      // pending input, not consumed output: hold it so the next delta continues
+      // the token instead of leaking the remainder as visible text.
+      if (!options.final && parsed.isSilent) {
+        pendingSilentPrefix = combined;
       }
       return null;
     }

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -331,6 +331,9 @@ describe("startsWithSilentToken", () => {
 
 describe("isSilentReplyPrefixText", () => {
   it("matches uppercase token lead fragments", () => {
+    // A lone uppercase N is the first streamed delta of NO_REPLY; hold it as a
+    // pending lead fragment until the next delta disambiguates the token (#122476).
+    expect(isSilentReplyPrefixText("N")).toBe(true);
     expect(isSilentReplyPrefixText("NO")).toBe(true);
     expect(isSilentReplyPrefixText("NO_")).toBe(true);
     expect(isSilentReplyPrefixText("NO_RE")).toBe(true);
@@ -339,7 +342,6 @@ describe("isSilentReplyPrefixText", () => {
   });
 
   it("rejects ambiguous natural-language prefixes", () => {
-    expect(isSilentReplyPrefixText("N")).toBe(false);
     expect(isSilentReplyPrefixText("No")).toBe(false);
     expect(isSilentReplyPrefixText("no")).toBe(false);
     expect(isSilentReplyPrefixText("Hello")).toBe(false);

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -319,9 +319,6 @@ export function isSilentReplyPrefixText(
   if (trimmed !== normalized) {
     return false;
   }
-  if (normalized.length < 2) {
-    return false;
-  }
   if (!tokenUpper.startsWith(normalized)) {
     return false;
   }
@@ -339,5 +336,8 @@ export function isSilentReplyPrefixText(
   if (/[^A-Z_]/.test(tokenUpper)) {
     return /[^A-Z_]/.test(normalized);
   }
-  return tokenUpper === SILENT_REPLY_TOKEN && normalized === "NO";
+  // A lone uppercase `N` is the first streamed delta of NO_REPLY: returning true
+  // holds it as a pending lead fragment until the next delta disambiguates it,
+  // instead of leaking it into the visible reply.
+  return tokenUpper === SILENT_REPLY_TOKEN && (normalized === "N" || normalized === "NO");
 }

--- a/src/gateway/control-reply-text.test.ts
+++ b/src/gateway/control-reply-text.test.ts
@@ -107,4 +107,37 @@ describe("control reply display projection", () => {
       ]),
     ).toEqual([]);
   });
+
+  it("holds a lone uppercase N as a pending NO_REPLY lead fragment (#122476)", () => {
+    // A single streamed N is the first delta of NO_REPLY; hold it pending until
+    // the next delta disambiguates, so it never flashes on a delta-rendering
+    // channel (Matrix, generic streaming) before the full token resolves.
+    expect(projectLiveAssistantBufferedText("N")).toEqual({
+      text: "N",
+      suppress: true,
+      pendingLeadFragment: true,
+    });
+    expect(projectLiveAssistantBufferedText("NO")).toEqual({
+      text: "NO",
+      suppress: true,
+      pendingLeadFragment: true,
+    });
+  });
+
+  it("holds a mixed-case No lead pending, but not text with spaces (#122476)", () => {
+    // A streamed "No" may still grow into NO_REPLY, so it is held pending
+    // (matching the embedded TUI backend) rather than flashed; the final
+    // payload renders "No" if the turn resolves to natural language. Text
+    // containing a space already disambiguates from the token and is not held.
+    expect(projectLiveAssistantBufferedText("No")).toEqual({
+      text: "No",
+      suppress: true,
+      pendingLeadFragment: true,
+    });
+    expect(projectLiveAssistantBufferedText("Not sure")).toEqual({
+      text: "Not sure",
+      suppress: false,
+      pendingLeadFragment: false,
+    });
+  });
 });

--- a/src/gateway/control-reply-text.ts
+++ b/src/gateway/control-reply-text.ts
@@ -11,7 +11,12 @@ const SUPPRESSED_CONTROL_REPLY_TOKENS = [
 const MIN_BARE_PREFIX_LENGTH_BY_TOKEN: Readonly<
   Record<(typeof SUPPRESSED_CONTROL_REPLY_TOKENS)[number], number>
 > = {
-  [SILENT_REPLY_TOKEN]: 2,
+  // Hold a lone `N` (first NO_REPLY delta) as a pending lead fragment so it
+  // cannot flash on delta-rendering channels. SILENT_REPLY_TOKEN skips the
+  // case guard below so a mixed-case "No" lead is also held pending (it may
+  // still grow into NO_REPLY); the final payload renders "No" if the turn
+  // resolves to natural language. Length-1 floor is safe for this token only.
+  [SILENT_REPLY_TOKEN]: 1,
   ANNOUNCE_SKIP: 3,
   REPLY_SKIP: 3,
 };


### PR DESCRIPTION
## What Problem This Solves

Closes #122476.

A single streamed `N` — the first delta of a `NO_REPLY` silent-reply token — could render visibly in chat for one frame before the full token resolved and the message was retroactively suppressed. Observed on a Matrix channel session: the assistant's turn resolved to exact `NO_REPLY` (confirmed in the session transcript JSONL), but the user saw a stray `N` character appear in the channel.

Both suppression gates hardcoded a minimum bare-prefix length of **2** before treating a streamed fragment as part of the `NO_REPLY` token, so a lone `N` (length 1) was structurally guaranteed to pass through on any channel that renders streaming deltas character-by-character (Matrix, generic streaming). The webchat client path was previously hardened via a buffering accumulator (#50365/#62845), but that mechanism does not cover channels using the shared `isSuppressedControlReplyLeadFragment` gate.

## Why This Change Was Made

The bug is narrowly scoped: a length-1 `N` falls below the shared bare-prefix floor of 2, so it is never held as a pending lead fragment. Lower the `SILENT_REPLY_TOKEN` bare-prefix floor from 2 to 1 in **both** classifiers. The existing case-guard policy in each classifier is left intact — they were already deliberately inconsistent, and that inconsistency is the correct behavior:

- `isSilentReplyPrefixText` (`src/auto-reply/tokens.ts`): the `length < 2` floor becomes `length < 1`, and the final `normalized === "NO"` predicate accepts `normalized === "N"` as well. The pre-existing `trimmed !== trimmed.toUpperCase()` guard is unchanged — it rejects mixed-case `"No"`/`"Not"` so a lone uppercase `N` is safe to hold pending while natural language is never suppressed here.
- `isSuppressedControlReplyLeadFragment` (`src/gateway/control-reply-text.ts`): `MIN_BARE_PREFIX_LENGTH_BY_TOKEN[SILENT_REPLY_TOKEN]` becomes `1`. The existing `token !== SILENT_REPLY_TOKEN &&` case-guard exception is **kept** — a mixed-case `"No"` lead is still held pending here (it may still grow into `NO_REPLY`), matching the embedded TUI backend's buffered-text behavior verified by `src/tui/embedded-backend.test.ts` ("keeps final short replies like No after suppressing lead-fragment deltas").

A lone uppercase `N` is now held as a **pending lead fragment** (`pendingLeadFragment: true`) in both classifiers until the next cumulative delta disambiguates it:
- `"NO"` → still held (continues matching the token prefix).
- `"NO_REPLY"` → suppressed as a complete token.

A complete lowercase `no_reply` token is still suppressed upstream by `isSuppressedControlReplyText`, whose exact-match regex is case-insensitive (`"i"` flag).

### Terminal release of held prefix fragments

Lowering the floor means a lone `N` is now held in the ACP accumulator's `pendingSilentPrefix` (`createAcpVisibleTextAccumulator`, `src/agents/command/attempt-execution.helpers.ts`). If no later chunk arrives — i.e. the turn's complete visible output is `N` — the accumulator's `finalize()` returned empty `visibleText` and `finalizeReplySnapshot()` produced `{disposition: "empty"}`, silently dropping the completed reply. The same loss applied to any partial control prefix (`NO_RE`, `NO_REPL`) that never resolved to an exact token.

The accumulator now resolves a held prefix that is **not** an exact `NO_REPLY` back to visible terminal text at finalization (`resolveTerminalVisibleText`), while an exact `NO_REPLY` stays silent via `buildAgentRunTerminalReplySnapshot`'s `rawText` check. This is the terminal-side owner of the same invariant the streaming classifiers hold: a fragment is only suppressed when it is, or still may become, an exact silent token; once the turn is terminal, a non-exact fragment is ordinary output the model emitted.

### Shared streaming-directive path

The same `isSilentReplyPrefixText` classifier is also consumed by `createStreamingDirectiveAccumulator` (`src/auto-reply/reply/streaming-directives.ts`), the shared streaming reply-directive path used outside ACP. Its `parseChunk` cleared any prefix-only fragment to empty (`isSilent`), and the message-end caller invokes `consume(text, { final: true })` with the complete text — so a terminal `N` was dropped here too, with no pending prefix retained to emit on a final flush.

`parseChunk` now takes a `final` flag (threaded from `consume`'s existing `final` option): at terminal completion it suppresses only an exact `NO_REPLY` (`isSilentReplyText`), not a prefix-only fragment. A streamed `N` is still held silent mid-stream (more text may arrive), but released as visible text when the turn is final. This mirrors the ACP terminal-release invariant on the shared path.

No new abstraction, channel config, or buffering accumulator is added — the fix lowers one magic number the two classifiers already shared, preserves each classifier's existing case policy, and adds one terminal-resolution helper to the ACP accumulator plus one `final` flag to the shared streaming-directive `parseChunk` that already received `final` at its caller.

## User Impact

On delta-rendering channels (Matrix, generic streaming), a turn that resolves to `NO_REPLY` no longer flashes a stray `N` character before suppression. A turn whose complete visible output is a short fragment that only **partially** matches the token (a natural-language `N`, or a truncated `NO_RE`) is now delivered as visible text at terminal completion instead of being silently dropped. Natural-language handling is unchanged: `"No"` is still held pending only on the gateway lead-fragment path (as before, matching the TUI), and rejected by the auto-reply prefix classifier (as before). Provider- and channel-independent; affects the shared silent-token lead-fragment classifiers in `src/auto-reply` and `src/gateway` and the ACP terminal accumulator in `src/agents/command`.

## Evidence

### Pre-fix reproduction (regression tests fail on unpatched code)

Stashed only the two production files (`git stash push -- src/auto-reply/tokens.ts src/gateway/control-reply-text.ts`) and ran the new regression tests against the unpatched production code:

```
node scripts/run-vitest.mjs src/auto-reply/tokens.test.ts
 FAIL  isSilentReplyPrefixText > matches uppercase token lead fragments
       expected false to be true   // lone "N" not held
 Tests  1 failed | 81 passed

node scripts/run-vitest.mjs src/gateway/control-reply-text.test.ts
 FAIL  holds a lone uppercase N as a pending NO_REPLY lead fragment (#122476)
       expected { text: 'N', suppress: false, …(1) } to deeply equal { text: 'N', suppress: true, …(1) }
 Tests  1 failed | 9 passed
```

The unpatched `isSuppressedControlReplyLeadFragment("N")` and `isSilentReplyPrefixText("N")` both returned `false` (length 1 < floor 2), so `projectLiveAssistantBufferedText("N")` returned `suppress: false` — the `N` reaches the live surface.

### Post-fix (all tests pass)

```
node scripts/run-vitest.mjs src/auto-reply/tokens.test.ts
 Test Files  1 passed (1) | Tests  82 passed (82)

node scripts/run-vitest.mjs src/gateway/control-reply-text.test.ts
 Test Files  1 passed (1) | Tests  10 passed (10)
```

### Sibling-path regression (the CI-failing test + streaming caller + ACP terminal + shared streaming path)

```
node scripts/run-vitest.mjs src/tui/embedded-backend.test.ts
 Test Files  1 passed (1) | Tests  94 passed (94)
node scripts/run-vitest.mjs src/agents/command/attempt-execution.test.ts
 Test Files  1 passed (1) | Tests  69 passed (69)
node scripts/run-vitest.mjs src/agents/command/attempt-execution.shared.test.ts
 Test Files  1 passed (1) | Tests  10 passed (10)
node scripts/run-vitest.mjs src/commands/agent.acp.test.ts
 Test Files  1 passed (1) | Tests  7 passed (7)
node scripts/run-vitest.mjs src/auto-reply/reply/streaming-directives.test.ts
 Test Files  1 passed (1) | Tests  4 passed (4)
node scripts/run-vitest.mjs src/auto-reply/reply/reply-utils.test.ts
 Test Files  1 passed (1) | Tests  103 passed (103)
node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.text-end-reconciliation.test.ts
 Test Files  1 passed (1) | Tests  24 passed (24)
```

`embedded-backend.test.ts` includes "keeps final short replies like No after suppressing lead-fragment deltas", which proves a streamed `"No"` delta is held pending (no delta leak) and the final payload renders `"No"` — the preserved case-guard exception is the intended behavior. `text-end-reconciliation.test.ts` covers the message-end `consume(text, { final: true })` path through the shared streaming-directive accumulator, including `message_end` with `NO_REPLY`.

### Terminal-release regression (P1 message-loss, both paths)

Stashed only the accumulator production file (`git stash push -- src/agents/command/attempt-execution.helpers.ts`) and ran the new terminal tests against the lower-floor-but-no-terminal-release code:

```
node scripts/run-vitest.mjs src/agents/command/attempt-execution.test.ts
 FAIL  createAcpVisibleTextAccumulator > classifies lone N lead released as visible terminal text (#122476) at finalization
 FAIL  createAcpVisibleTextAccumulator > classifies partial control prefix released as visible at finalization
 Tests  2 failed | 67 passed
```

Stashed only the shared streaming-directive production file (`git stash push -- src/auto-reply/reply/streaming-directives.ts`) and ran its new tests against the no-final-guard code:

```
node scripts/run-vitest.mjs src/auto-reply/reply/streaming-directives.test.ts
 FAIL  holds a lone N prefix silent while streaming, then releases it at final
 FAIL  releases a partial control prefix that never resolves to the token at final
 Tests  2 failed | 2 passed
```

Without the terminal release, a completed response of `N` produced an empty/silent result on both the ACP accumulator (`{disposition: "empty"}`) and the shared streaming-directive path (`consume` returned `null`) — the reply was silently dropped. With the release, both resolve to visible `N` / `NO_RE`, while exact `NO_REPLY` stays silent.

### Type check

`tsgo:core` (`-p tsconfig.core.json`, covers all changed production files) — exit 0, no errors. `oxfmt` clean, `oxlint` clean on the changed files.

### Production-vs-test LOC delta

- Production: `src/auto-reply/tokens.ts` +5/-2, `src/gateway/control-reply-text.ts` +6/-2, `src/agents/command/attempt-execution.helpers.ts` +13/-3, `src/auto-reply/reply/streaming-directives.ts` +8/-2 (net +25). The logic changes are one lowered floor per classifier, one terminal-resolution helper in the ACP accumulator, and one `final` flag on the shared streaming-directive `parseChunk`; the remainder is owner-boundary commentary.
- Tests: `src/auto-reply/tokens.test.ts` +2/-1, `src/gateway/control-reply-text.test.ts` +18, `src/agents/command/attempt-execution.test.ts` +8/-1, `src/auto-reply/reply/streaming-directives.test.ts` +33 (new file: lone-`N` and partial-prefix terminal release on the shared path), `src/agents/embedded-agent-subscribe.handlers.messages.test.ts` +70 (agent→gateway event boundary proof: lone-`N` hold/release + exact-`NO_REPLY` stays silent).

### Files changed

- `src/auto-reply/tokens.ts` — `isSilentReplyPrefixText`: lower the length floor to 1 and accept `normalized === "N"` for `SILENT_REPLY_TOKEN`. Case guard unchanged.
- `src/gateway/control-reply-text.ts` — `MIN_BARE_PREFIX_LENGTH_BY_TOKEN[SILENT_REPLY_TOKEN]: 1`. Case-guard exception for `SILENT_REPLY_TOKEN` kept (comment expanded to document why).
- `src/agents/command/attempt-execution.helpers.ts` — `createAcpVisibleTextAccumulator`: `finalize`/`finalizeRaw`/`finalizeReplySnapshot` resolve a held non-exact-silent prefix to visible terminal text via `resolveTerminalVisibleText`; exact `NO_REPLY` stays silent.
- `src/auto-reply/reply/streaming-directives.ts` — `parseChunk` takes a `final` flag (threaded from `consume`'s existing `final` option); at terminal completion it suppresses only an exact `NO_REPLY`, releasing a prefix-only fragment as visible text.
- `src/auto-reply/tokens.test.ts` — `isSilentReplyPrefixText("N")` now `true`; mixed-case `"No"`/`"no"`/`"Hello"` still `false`.
- `src/gateway/control-reply-text.test.ts` — `projectLiveAssistantBufferedText("N")`/`("NO")`/`("No")` held as pending lead fragments; `("Not sure")` renders immediately.
- `src/agents/command/attempt-execution.test.ts` — terminal `N` and partial `NO_RE` prefixes release as `{disposition: "visible"}`; exact `NO_REPLY` and punctuation-wrapped silence stay `silent`; clean empty stays `empty`.
- `src/auto-reply/reply/streaming-directives.test.ts` — (new) `N`/`NO_RE` held silent mid-stream then released at `{ final: true }`; exact `NO_REPLY` stays silent at final; ordinary visible text renders.


### Real-behavior proof (agent→gateway event boundary)

ClawSweeper asked for a mock-gateway delivery trace. The fix is observable at the **agent→gateway event boundary** — the `onAgentEvent` stream the live-chat projector consumes upstream — not only at the accumulator layer. A new boundary test drives the real `handleMessageUpdate` → real `createStreamingDirectiveAccumulator` path and asserts on that event boundary:

- `src/agents/embedded-agent-subscribe.handlers.messages.test.ts` — `"lone N silent-reply lead fragment (#122476)"`: streams a `text_delta` of `"N"`, asserts no assistant visible-text event carries `"N"` mid-stream (held pending), then sends `text_end` with content `"N"` and asserts the held fragment is released as ordinary visible text. A second case asserts an exact `NO_REPLY` stays silent across both delta and `text_end`.

`"N"` is not a directive tail (unlike `"M"`, which `splitTrailingDirective` holds as a `MEDIA` prefix), so it reaches the silent-prefix classifier directly. Pre-fix the length-1 `N` fell below the floor of 2 and was emitted as visible text mid-stream — the flash. Post-fix it is held pending and only released at terminal completion.

**Pre-fix (revert `tokens.ts` floor to `< 2` + drop the `!final` guard in `streaming-directives.ts`, run the boundary test):**

```
node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.handlers.messages.test.ts -t "lone N silent-reply"
 FAIL  lone N silent-reply lead fragment > holds a streamed N without emitting it, then releases it at text_end
       expected onAgentEvent not to be called with { stream: "assistant", data: { text: "N", delta: "N" } }
       Number of calls: 1
 Tests  2 failed | 2 passed | 140 skipped
```

The unpatched accumulator emits `{ stream: "assistant", data: { text: "N", delta: "N" } }` on the `text_delta` — the stray `N` crosses the agent→gateway event boundary mid-stream. The exact-`NO_REPLY` case passes both pre/post-fix (it was already suppressed via `isSilentReplyText`).

**Post-fix (all boundary + sibling tests pass):**

```
node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.handlers.messages.test.ts
 Test Files  1 passed (1) | Tests  72 passed (72)
```

Downstream context (kept for completeness): `chat.history` reads the raw transcript and the gateway `chat` terminal projector already releases a terminal `N` independently of this fix, so neither distinguishes pre/post-fix — but the **agent→gateway event boundary does**, and that is what the boundary test proves. The accumulator-layer regression tests (`streaming-directives.test.ts`, `attempt-execution.test.ts`) remain as the per-owner proof of the terminal-release invariant on the shared and ACP paths respectively.



## Rebase onto current main (2026-08-28)

The branch was opened against a much older `main` and could not be rebased mechanically (it carried thousands of stale-path conflicts from an unrelated lineage). It is rebuilt directly on current `main` with the fix ported to the surfaces as they exist now:

- `main` restructured `src/auto-reply/tokens.ts::isSilentReplyPrefixText` and `src/auto-reply/reply/streaming-directives.ts` since this branch opened. The length-floor change and the `"N"` acceptance are ported into the restructured classifier, and the streaming parser now passes `final` into `parseChunk` so a pending prefix that never grew into an exact token is released as ordinary terminal text instead of being dropped. `createAcpVisibleTextAccumulator` releases such a held fragment at finalization for the same reason — holding without releasing would trade a visible stray `N` for a silently swallowed turn.
- Test coverage moved with the restructures: the message-update boundary cases now live in `src/agents/embedded-agent-subscribe.handlers.messages.update-stream-items.test.ts` (the original `embedded-agent-subscribe.handlers.messages.test.ts` was split into per-surface files), and a new `src/auto-reply/reply/streaming-directives.test.ts` covers the streaming hold/release behavior directly.
- Evidence: 5 touched-surface test files pass locally (66 + 4 shards), `tsgo` core and test shards green, `oxlint`/`oxfmt` clean on touched files.
