### PR TITLE
fix(failover): classify claude-cli usage-credit exhaustion as billing

### DIFF
--- a/src/agents/cli-runner.usage-credit-billing.e2e.test.ts
+++ b/src/agents/cli-runner.usage-credit-billing.e2e.test.ts
@@ -1,0 +1,250 @@
+// Boundary proof for #122010: a real claude-cli child process reporting Claude
+// subscription credit exhaustion must classify as `billing` — driving the auth-profile
+// disable contract and cross-provider model fallback — instead of dying as `unknown`.
+//
+// Unlike the colocated predicate unit tests (failover/classify.message-predicates.test.ts),
+// this spawns a real CLI child through the production process supervisor and drives the
+// full seam: parseCliOutput -> createCliOutputFailoverError -> classifyFailoverReason ->
+// settlePreparedCliRun profile disable -> runWithModelFallback. Only the two external
+// boundaries are stubbed: the `claude` executable and the fallback provider's HTTP API.
+import fs from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import {
+  loadAuthProfileStoreForRuntime,
+  saveAuthProfileStore,
+  type AuthProfileStore,
+} from "./auth-profiles.js";
+import { runPreparedCliAgent } from "./cli-runner.js";
+import { buildPreparedCliRunContext } from "./cli-runner.test-helpers.js";
+import { settlePreparedCliRun } from "./cli-runner/cli-run-settlement.js";
+import { classifyEmbeddedAgentRunResultForModelFallback } from "./embedded-agent-runner/result-fallback-classifier.js";
+import type { EmbeddedAgentRunResult } from "./embedded-agent-runner/types.js";
+import { describeFailoverError, isFailoverError } from "./failover-error.js";
+import { runWithModelFallback } from "./model-fallback-runner.js";
+
+// Verbatim wording from the reported incident; the classifier must match this exact
+// prose arriving as CLI stdout, not a hand-shaped variant.
+const EXHAUSTION_TEXT =
+  "You're out of usage credits. Run /usage-credits to keep using Fable 5 or /model to switch models.";
+const PROFILE_ID = "claude-cli:subscription";
+const FALLBACK_ANSWER = "fallback provider answered";
+const E2E_TIMEOUT_MS = 60_000;
+
+let envSnapshot: ReturnType<typeof captureEnv>;
+let tempRoot = "";
+let agentDir = "";
+let stubCliPath = "";
+let fallbackBaseUrl = "";
+let fallbackServer: http.Server | undefined;
+let fallbackHits = 0;
+
+beforeAll(async () => {
+  envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+  // macOS os.tmpdir() is a /var -> /private/var symlink; realpath before any
+  // production path resolution so recorded paths compare equal.
+  tempRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "oc-cli-billing-e2e-")));
+  const stateDir = path.join(tempRoot, "state");
+  agentDir = path.join(stateDir, "agents", "main", "agent");
+  await fs.mkdir(agentDir, { recursive: true });
+  setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+
+  // Boundary stub 1: the `claude` executable. Emits the stream-json terminal record the
+  // real CLI produces for an exhausted subscription, then exits nonzero. Invoked through
+  // the current node binary so the test has no PATH/shebang dependence.
+  stubCliPath = path.join(tempRoot, "claude-stub.mjs");
+  const terminalRecord = {
+    type: "result",
+    subtype: "error_during_execution",
+    is_error: true,
+    session_id: "00000000-0000-4000-8000-000000000001",
+    result: EXHAUSTION_TEXT,
+  };
+  await fs.writeFile(
+    stubCliPath,
+    `process.stdout.write(${JSON.stringify(`${JSON.stringify(terminalRecord)}\n`)});\nprocess.exit(1);\n`,
+    "utf8",
+  );
+
+  // Boundary stub 2: the fallback provider's HTTP endpoint.
+  fallbackServer = http.createServer((req, res) => {
+    req.resume();
+    req.on("end", () => {
+      fallbackHits += 1;
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ choices: [{ message: { content: FALLBACK_ANSWER } }] }));
+    });
+  });
+  fallbackBaseUrl = await new Promise<string>((resolve) => {
+    fallbackServer?.listen(0, "127.0.0.1", () => {
+      const addr = fallbackServer?.address();
+      resolve(`http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`);
+    });
+  });
+
+  // Real SQLite auth-profile store with the one subscription login the incident used.
+  const store = loadAuthProfileStoreForRuntime(agentDir);
+  store.profiles[PROFILE_ID] = {
+    type: "oauth",
+    provider: "claude-cli",
+    access: "synthetic-access-token-never-real",
+    refresh: "synthetic-refresh-token-never-real",
+    expires: Date.now() + 3_600_000,
+  };
+  saveAuthProfileStore(store, agentDir);
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => {
+    if (fallbackServer) {
+      fallbackServer.close(() => resolve());
+    } else {
+      resolve();
+    }
+  });
+  envSnapshot?.restore();
+  if (tempRoot) {
+    await fs.rm(tempRoot, { recursive: true, force: true, maxRetries: 5 });
+  }
+});
+
+function buildStubCliContext(params: { runId: string; store: AuthProfileStore }) {
+  const context = buildPreparedCliRunContext({
+    provider: "claude-cli",
+    model: "sonnet-4.6",
+    runId: params.runId,
+    sessionId: params.runId,
+    sessionKey: `agent:main:${params.runId}`,
+    workspaceDir: tempRoot,
+    timeoutMs: 20_000,
+    backend: { command: process.execPath, args: [stubCliPath] },
+  });
+  // The settle path only records profile health when the run carries its auth binding;
+  // wire the same fields prepareCliRunContext resolves in production.
+  context.agentDir = agentDir;
+  context.effectiveAuthProfileId = PROFILE_ID;
+  context.authProfileStore = params.store;
+  return context;
+}
+
+async function fetchFallbackCompletion(): Promise<EmbeddedAgentRunResult> {
+  const response = await fetch(`${fallbackBaseUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
+  });
+  const payload = (await response.json()) as {
+    choices: Array<{ message: { content: string } }>;
+  };
+  return {
+    payloads: [{ text: payload.choices[0]?.message.content ?? "" }],
+    meta: { durationMs: 1 },
+  };
+}
+
+describe("claude-cli usage-credit exhaustion boundary (#122010)", () => {
+  it(
+    "classifies a real CLI credit-exhaustion exit as billing, disables the profile, and reaches the cross-provider fallback",
+    async () => {
+      const runId = `run-billing-${Date.now()}`;
+      const attempts: string[] = [];
+      const failoverReasons: string[] = [];
+
+      const outcome = await runWithModelFallback<EmbeddedAgentRunResult>({
+        cfg: undefined,
+        provider: "claude-cli",
+        model: "sonnet-4.6",
+        agentId: "main",
+        agentDir,
+        sessionId: runId,
+        runId,
+        fallbacksOverride: ["openai/gpt-5.6-luna"],
+        run: async (provider) => {
+          attempts.push(provider);
+          if (provider === "claude-cli") {
+            // Production wiring from cli-runner.ts runCliAgent: spawn the real child
+            // process, parse its stream-json, classify, and settle the auth profile.
+            const context = buildStubCliContext({
+              runId,
+              store: loadAuthProfileStoreForRuntime(agentDir),
+            });
+            return await settlePreparedCliRun({
+              context,
+              run: async () => await runPreparedCliAgent(context),
+            });
+          }
+          return await fetchFallbackCompletion();
+        },
+        onError: ({ error }) => {
+          if (isFailoverError(error)) {
+            failoverReasons.push(describeFailoverError(error).reason ?? "unknown");
+          }
+        },
+      });
+
+      // The CLI terminal error must classify as billing — `unknown` also retries
+      // remaining candidates, but skips the billing recovery contract below.
+      expect(failoverReasons).toEqual(["billing"]);
+
+      // Billing recovery contract: the exhausted login is disabled with a long backoff
+      // instead of a short generic cooldown, so later turns rotate off it.
+      const settled = loadAuthProfileStoreForRuntime(agentDir);
+      const stats = settled.usageStats?.[PROFILE_ID];
+      expect(stats?.disabledReason).toBe("billing");
+      expect(stats?.disabledUntil).toBeGreaterThan(Date.now());
+      expect(stats?.failureCounts?.billing).toBe(1);
+
+      // The turn is served by the healthy cross-provider candidate over real HTTP.
+      expect(attempts).toEqual(["claude-cli", "openai"]);
+      expect(fallbackHits).toBeGreaterThan(0);
+      expect(outcome.result.payloads?.[0]?.text).toBe(FALLBACK_ANSWER);
+    },
+    E2E_TIMEOUT_MS,
+  );
+
+  it(
+    "advances the embedded-result fallback chain when the same CLI text arrives as a terminal error payload",
+    async () => {
+      // Embedded-result path: the failure surfaces as an isError payload instead of a
+      // thrown error. Here an unmatched classification is chain-fatal — the run is
+      // accepted as terminal and no fallback candidate is attempted at all.
+      const runId = `run-billing-embedded-${Date.now()}`;
+      const attempts: string[] = [];
+      const hitsBefore = fallbackHits;
+      const exhaustedResult: EmbeddedAgentRunResult = {
+        payloads: [{ text: EXHAUSTION_TEXT, isError: true }],
+        meta: { durationMs: 1 },
+      };
+
+      const outcome = await runWithModelFallback<EmbeddedAgentRunResult>({
+        cfg: undefined,
+        provider: "claude-cli",
+        model: "sonnet-4.6",
+        agentId: "main",
+        agentDir,
+        sessionId: runId,
+        runId,
+        fallbacksOverride: ["openai/gpt-5.6-luna"],
+        // Exact production classifier wiring from src/agents/runtime-plan/build.ts.
+        classifyResult: ({ result }) =>
+          classifyEmbeddedAgentRunResultForModelFallback({
+            result,
+            provider: "claude-cli",
+            model: "sonnet-4.6",
+          }),
+        run: async (provider) => {
+          attempts.push(provider);
+          return provider === "claude-cli" ? exhaustedResult : await fetchFallbackCompletion();
+        },
+      });
+
+      expect(attempts).toEqual(["claude-cli", "openai"]);
+      expect(fallbackHits).toBeGreaterThan(hitsBefore);
+      expect(outcome.result.payloads?.[0]?.text).toBe(FALLBACK_ANSWER);
+    },
+    E2E_TIMEOUT_MS,
+  );
+});

--- a/src/agents/failover/classify.message-predicates.test.ts
+++ b/src/agents/failover/classify.message-predicates.test.ts
@@ -24,8 +24,12 @@ describe("Claude subscription usage credits (#122010)", () => {
     "You're out of usage credits. Run /usage-credits to keep using Fable 5 or /model to switch models.";
 
   it("classifies claude-cli usage-credit exhaustion as billing", () => {
-    // Left unmatched `classifyFailoverReason` returns `null`, which does not advance the
-    // model fallback chain, so a configured cross-provider fallback is never reached.
+    // Left unmatched, `classifyFailoverReason` returns `null`. On the embedded-result path
+    // that keeps `classifyProviderErrorPayloadReason` at `null`, so the failed run is
+    // accepted as terminal and the model fallback chain never advances. A thrown CLI error
+    // still retries remaining candidates, but as `unknown` it skips the billing recovery
+    // contract — no profile disable with backoff — so every candidate keeps reusing the
+    // exhausted login.
     expect(isBillingErrorMessage(reported)).toBe(true);
     expect(classifyFailoverReason(reported, { provider: "anthropic" })).toBe("billing");
   });

--- a/src/agents/failover/classify.message-predicates.test.ts
+++ b/src/agents/failover/classify.message-predicates.test.ts
@@ -19,6 +19,40 @@ describe("matchesFormatErrorPattern", () => {
   });
 });
 
+describe("Claude subscription usage credits (#122010)", () => {
+  const reported =
+    "You're out of usage credits. Run /usage-credits to keep using Fable 5 or /model to switch models.";
+
+  it("classifies claude-cli usage-credit exhaustion as billing", () => {
+    // Left unmatched this lands in `unknown`, which does not advance the model fallback
+    // chain, so a configured cross-provider fallback is never reached.
+    expect(isBillingErrorMessage(reported)).toBe(true);
+    expect(classifyFailoverReason(reported, { provider: "anthropic" })).toBe("billing");
+  });
+
+  it("classifies the uncontracted wording the same way", () => {
+    const raw =
+      "You are out of usage credits. Run /usage-credits to keep using Opus 5 or /model to switch models.";
+    expect(classifyFailoverReason(raw, { provider: "anthropic" })).toBe("billing");
+  });
+
+  it("does not misclassify usage-credit exhaustion as auth or rate limit", () => {
+    expect(isAuthErrorMessage(reported)).toBe(false);
+    expect(isRateLimitErrorMessage(reported)).toBe(false);
+  });
+
+  it("keeps unrelated credit and usage prose out of billing", () => {
+    // Informational prose naming usage credits must not read as exhaustion.
+    expect(isBillingErrorMessage("insufficient to reconcile the final balance")).toBe(false);
+    expect(isBillingErrorMessage("The model produced credits toward the usage report")).toBe(false);
+    expect(isBillingErrorMessage("You have 5 usage credits remaining this month")).toBe(false);
+    expect(isBillingErrorMessage("Your usage credits reset at midnight UTC")).toBe(false);
+    expect(isBillingErrorMessage("Run /usage-credits to view your remaining usage credits")).toBe(
+      false,
+    );
+  });
+});
+
 describe("Z.ai vendor error codes (#48988)", () => {
   describe("error 1311 — model not included in subscription plan", () => {
     it("classifies Z.ai 1311 JSON body as billing", () => {

--- a/src/agents/failover/classify.message-predicates.test.ts
+++ b/src/agents/failover/classify.message-predicates.test.ts
@@ -24,8 +24,8 @@ describe("Claude subscription usage credits (#122010)", () => {
     "You're out of usage credits. Run /usage-credits to keep using Fable 5 or /model to switch models.";
 
   it("classifies claude-cli usage-credit exhaustion as billing", () => {
-    // Left unmatched this lands in `unknown`, which does not advance the model fallback
-    // chain, so a configured cross-provider fallback is never reached.
+    // Left unmatched `classifyFailoverReason` returns `null`, which does not advance the
+    // model fallback chain, so a configured cross-provider fallback is never reached.
     expect(isBillingErrorMessage(reported)).toBe(true);
     expect(classifyFailoverReason(reported, { provider: "anthropic" })).toBe("billing");
   });

--- a/src/agents/failover/message-patterns.ts
+++ b/src/agents/failover/message-patterns.ts
@@ -232,6 +232,11 @@ const ERROR_PATTERNS = {
     /out of extra usage/i,
     /draw from your extra usage/i,
     /extra usage is required(?: for long context requests)?/i,
+    // Claude subscription exhaustion surfaced by the claude-cli runtime: "You're out of
+    // usage credits. Run /usage-credits ...". Without this the turn lands in `unknown`,
+    // which does not advance the model fallback chain, so a configured cross-provider
+    // fallback is never reached (#122010).
+    /\bout of usage credits\b/i,
     // Chinese provider billing messages
     "余额不足",
     "账户余额不足",

--- a/src/agents/failover/message-patterns.ts
+++ b/src/agents/failover/message-patterns.ts
@@ -234,8 +234,10 @@ const ERROR_PATTERNS = {
     /extra usage is required(?: for long context requests)?/i,
     // Claude subscription exhaustion surfaced by the claude-cli runtime: "You're out of
     // usage credits. Run /usage-credits ...". Without this the classifier returns `null`
-    // (unmatched), which does not advance the model fallback chain, so a configured
-    // cross-provider fallback is never reached (#122010).
+    // (unmatched). On the embedded-result path that leaves the run accepted as terminal, so
+    // the model fallback chain never advances; a thrown CLI error still retries remaining
+    // candidates, but as `unknown` it skips the billing recovery contract (profile disable
+    // with backoff) and keeps reusing the exhausted login (#122010).
     /\bout of usage credits\b/i,
     // Chinese provider billing messages
     "余额不足",

--- a/src/agents/failover/message-patterns.ts
+++ b/src/agents/failover/message-patterns.ts
@@ -233,9 +233,9 @@ const ERROR_PATTERNS = {
     /draw from your extra usage/i,
     /extra usage is required(?: for long context requests)?/i,
     // Claude subscription exhaustion surfaced by the claude-cli runtime: "You're out of
-    // usage credits. Run /usage-credits ...". Without this the turn lands in `unknown`,
-    // which does not advance the model fallback chain, so a configured cross-provider
-    // fallback is never reached (#122010).
+    // usage credits. Run /usage-credits ...". Without this the classifier returns `null`
+    // (unmatched), which does not advance the model fallback chain, so a configured
+    // cross-provider fallback is never reached (#122010).
     /\bout of usage credits\b/i,
     // Chinese provider billing messages
     "余额不足",


### PR DESCRIPTION
Related: #122010

## What Problem This Solves

Fixes an issue where operators whose Claude subscription runs out of credits would find the agent completely unresponsive, even with a healthy cross-provider fallback configured.

When the subscription is exhausted, the `claude-cli` runtime emits `You're out of usage credits. Run /usage-credits to keep using Fable 5 or /model to switch models.` No failover pattern matched that wording, so every turn classified as `unknown` — and only auth failures, rate limits and timeouts advance the model fallback chain. In the reported incident the agent was down for 43 minutes, stepping between two models on the same exhausted credentials while the configured `openai/gpt-5.6-sol` fallback was never attempted.

## Why This Change Was Made

The central `billing` matcher already carries the whole sibling family for this failure class — `insufficient credits`, `used all available credits`, `out of extra usage`, `credit balance`, `insufficient quota`, the Chinese billing phrases, Volcengine `InvalidSubscription`, Z.ai 1311 — but not this wording. `isBillingErrorMessage` reads that one group, so this is a single canonical site rather than a scattered fix.

Classifying it as `billing` gives it the recovery contract that already exists for every other credit-exhaustion message: disable the profile with a long backoff, rotate, and let the fallback chain advance.

**Scope is deliberately the classification only.** ClawSweeper's review split the issue in two and called extending the central matcher *"the correct narrow repair"*. The second half — whether native Claude CLI billing should additionally bypass its own disabled state to guarantee cross-provider rotation — conflicts with an intentional CLI cooldown-bypass contract and is flagged `needs-product-decision`. I have not touched that, and left it for the maintainer decision on the issue. The `unknown` classification is wrong however that resolves, so this stands on its own.

Not touched: `model-fallback-cooldown.ts`, `auth-profiles/usage.ts` disable/rotate behaviour, and the `BILLING_402_HINTS` list (only reached by `hasExplicit402BillingSignal` for HTTP 402 response bodies — this is plain CLI text, not a 402, so it does not route there). Also left alone is the reporter's separate `auth_profile_state.lastGood` observation.

This is not provider-gated the way `isClaudeCliLoggedOutError` is, for two reasons: the billing group's convention is un-gated prose (`out of extra usage`, `does not have a valid coding plan subscription`, the Chinese phrases are all provider-specific wording matched globally), and the two cases differ in kind — "not logged in · please run /login" selects a Claude-CLI-specific recovery action, whereas "out of usage credits" states a billing fact that deserves the same classification whoever emits it. Gating it would leave an identical message from another surface misclassified as `unknown`.

## User Impact

An exhausted Claude subscription no longer strands the agent. The turn is recognised as a billing failure, so the profile is disabled with backoff and the model fallback chain advances to the next configured provider instead of dying on `unknown`. Operators with a cross-provider fallback keep serving requests through the outage instead of going hard-down until manual intervention.

## Evidence

Before/after against the **real** production classifiers, no mocks — including `classifyEmbeddedAgentRunResultForModelFallback`, the gate that decides whether a failed run advances the chain at all.

```
BEFORE (upstream/main, unmodified)
A. Reported claude-cli billing text
  "You're out of usage credits. Run /usage-credits to keep us"...
  FAIL      classifyFailoverReason  -> null
  FAIL      isBillingErrorMessage  -> false
  FAIL      run-result reason  -> undefined
  FAIL      advances fallback chain  -> false
  "You are out of usage credits. Run /usage-credits to keep u"...
  FAIL      classifyFailoverReason  -> null
  FAIL      advances fallback chain  -> false
FAIL (8 assertion(s))

AFTER (this branch)
A. Reported claude-cli billing text
  "You're out of usage credits. Run /usage-credits to keep us"...
  ok        classifyFailoverReason  -> "billing"
  ok        isBillingErrorMessage  -> true
  ok        run-result reason  -> "billing"
  ok        advances fallback chain  -> true
  "You are out of usage credits. Run /usage-credits to keep u"...
  ok        classifyFailoverReason  -> "billing"
  ok        advances fallback chain  -> true

B. Existing billing phrases (must stay billing — no regression)
  ok      "Insufficient credits"  -> "billing"
  ok      "You've used all available credits"  -> "billing"
  ok      "You are out of extra usage"  -> "billing"
  ok      "Your credit balance is too low to run this request"  -> "billing"
  ok      "HTTP 402 Payment Required"  -> "billing"

C. NEGATIVE CONTROL: non-billing errors must not become billing
  ok    "Request timed out after 60000ms" -> "timeout"
  ok    "429 Too Many Requests" -> "rate_limit"
  ok    "string should match pattern" -> "format"
  ok    "API key not valid. Please pass a valid API key." -> "auth"
  ok    "insufficient to reconcile the final balance" -> null
  ok    "The model produced credits toward the usage report" -> null
  ok    "read ECONNRESET" -> "timeout"
  ok    "model not found: gpt-5.6-sol" -> "model_not_found"
  ok    "You have 5 usage credits remaining this month" -> null
  ok    "Your usage credits reset at midnight UTC" -> null
  ok    "Run /usage-credits to view your remaining usage cred" -> null
  ok    "Usage credits are billed monthly; see the usage repo" -> null
PASS
```

The negative controls are the point of that third block: every already-matched billing phrase and every non-billing error classifies **identically** before and after, including near-miss prose that mentions usage credits without reporting exhaustion. The matcher was not widened into unrelated text.

### Production-boundary proof (added after ClawSweeper review)

ClawSweeper asked for proof that a real CLI billing failure reaches a healthy cross-provider fallback, not just that the classifier returns `billing`. This drives the **real** model fallback runner (`runWithModelFallback`, `src/agents/model-fallback-runner.ts`) with the **real** result classifier. Only the provider call itself is stubbed: every `anthropic` candidate returns the verbatim credit-exhaustion payload — they share the one exhausted login, exactly as reported — and the `openai` candidate answers.

Configured chain: `anthropic/claude-fable-5` → `anthropic/claude-opus-5` → `openai/gpt-5.6-sol`.

```
BEFORE (pattern removed == upstream/main)
SCENARIO: reported claude-cli credit exhaustion
  attempt 1: anthropic/claude-fable-5
  reached healthy cross-provider fallback: false
  final payloads: [{"isError":true,"text":"You're out of usage credits. Run /usage-credits to keep using Fable 5 or /model to switch models."}]
SCENARIO: CONTROL "Insufficient credits" (already matched before this PR)
  reached healthy cross-provider fallback: true (attempts=3)
FAIL: configured cross-provider fallback was NOT attempted

AFTER (this branch)
SCENARIO: reported claude-cli credit exhaustion
  attempt 1: anthropic/claude-fable-5
  attempt 2: anthropic/claude-opus-5
  attempt 3: openai/gpt-5.6-sol
  reached healthy cross-provider fallback: true
  final payloads: [{"text":"fallback provider answered"}]
SCENARIO: CONTROL "Insufficient credits" (already matched before this PR)
  reached healthy cross-provider fallback: true (attempts=3)
PASS: configured cross-provider fallback was attempted
```

Before the fix the chain dies on the first candidate and hands back the error payload — the reporter's exact symptom, with the configured fallback never attempted. After it, both exhausted `anthropic` candidates are skipped and the healthy `openai/gpt-5.6-sol` fallback answers. The runner's own `model_fallback_decision` events now carry `reason=billing` where the issue's trace showed `reason: "unknown"`.

The control matters as much as the result: `Insufficient credits` (already matched before this PR) reaches the cross-provider fallback in **both** builds. The chain machinery was never broken — only the classification of this one wording was.

Command: `node --import tsx .agents/proof/pr122010-fallback-boundary.mts`

### Tests

- `node scripts/run-vitest.mjs src/agents/failover` — 2131 passed (17 files), including the golden `failover-classification.corpus` suite that exists to catch reclassification drift.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/result-fallback-classifier.test.ts src/agents/session-suspension.test.ts src/agents/auth-profiles/usage.test.ts src/agents/auth-profiles.cooldown-auto-expiry.test.ts` — 125 passed across the consumers of the `billing` reason (cooldown, profile disable, session suspension).
- `node scripts/run-tsgo.mjs -p tsconfig.core.json`, `oxfmt --check`, `scripts/run-oxlint.mjs` — clean.
- I reverted the pattern and confirmed the two new tests fail without it, so they have teeth.

Production delta is +5 lines against +34 test lines.

## Real behavior proof

Behavior addressed: `claude-cli` usage-credit exhaustion classified as `unknown`, so the model fallback chain never advanced to a configured healthy cross-provider fallback and the agent stayed down.

Real environment tested: the real production classifiers with no mocks — `classifyFailoverReason` (`src/agents/failover/classify.ts`), `isBillingErrorMessage` (`src/agents/failover/message-patterns.ts`), and `classifyEmbeddedAgentRunResultForModelFallback` (`src/agents/embedded-agent-runner/result-fallback-classifier.ts`), driven with the same result shape a failed CLI turn produces. macOS 25.6.0, node v22.22.3, branch rebased on current `main`.

Exact steps or command run after this patch: `node --import tsx .agents/proof/pr122010-usage-credits-billing.mts`

Evidence after fix: the BEFORE/AFTER blocks above — `classifyFailoverReason` moves from `null` to `"billing"`, and `advances fallback chain` moves from `false` to `true`, with all 5 existing billing phrases and all 12 negative controls unchanged.

Observed result after fix: the reported wording and its uncontracted variant classify as `billing` instead of `unknown`, and the run-result classifier returns a fallback-worthy classification instead of `null` — so the chain advances rather than stranding.

What was not tested: no live Claude subscription was driven to credit exhaustion, so the trigger text comes from the issue report rather than a fresh capture. I did not reproduce the reporter's full end-to-end cross-provider recovery, because that also depends on the native-CLI cooldown-bypass policy this PR deliberately leaves to the maintainer decision — this change proves the classification and the chain-advance gate, not the CLI-specific bypass.

---

AI-assisted: authored with Claude (Opus 5) and reviewed with `codex review` (no findings). The before/after output above is real local run output.



---

### Update — real-behavior proof, and a correction to this PR's own framing

**Proof (the outstanding blocker).** ClawSweeper asked for "a real Claude CLI terminal error reaching the changed path." That does not require an exhausted subscription: the CLI binary is the external boundary and is configurable via the backend `command`, so a stub executable emitting the exhaustion `stream-json` reaches the identical production path with no Anthropic call involved.

The harness spawns a **real `claude` child process** through the real OpenClaw process supervisor, from a real Node process with an isolated `OPENCLAW_STATE_DIR`, then runs entirely real production code: `parseCliOutput` → `createCliOutputFailoverError` → `classifyFailoverReason` → `settlePreparedCliRun` → `markAuthProfileFailure` (real SQLite store) → `runWithModelFallback`. Only the `claude` binary and the fallback provider's HTTP endpoint are mocked.

BEFORE was captured by reverting `message-patterns.ts` to `origin/main` and verifying the revert landed — note `git stash push` would have silently no-opped here, since the pattern is committed on the branch rather than uncommitted; the baseline was confirmed byte-identical to `origin/main` with the pattern grep-confirmed absent.

```
BEFORE  auth profile failure state updated: reason=unknown window=cooldown
        [FAIL] CLI failure classification: FailoverError(reason: "unknown")
        [FAIL] billing recovery contract: disabledReason=null disabledUntil=none failureCounts={"unknown":1}
        [ok  ] thrown path reaches the healthy provider (unchanged by this PR)
        [FAIL] embedded-result path advances the fallback chain at all:
               attempts=["claude-cli/claude-fable-5"] fallbackHTTPHits=0
        [FAIL] native path user-visible copy: userCopy="LLM request failed."
        [FAIL] native path suspension reason: resolveSessionSuspensionReason("unknown") = "circuit_open"
        RESULT: FAIL — BUG SIGNATURE

AFTER   auth profile failure state updated: reason=billing window=disabled
        [ok] FailoverError(reason: "billing")
        [ok] disabledReason="billing" disabledUntil=+17999s failureCounts={"billing":1}
        [ok] embedded-result path: attempts=[...,"openai/gpt-5.6-sol"] fallbackHTTPHits=1
        [ok] native path userCopy="⚠️ claude-cli (claude-fable-5) returned a billing error — ..."
        [ok] resolveSessionSuspensionReason("billing") = "manual"
        RESULT: PASS
```

**Correction to this PR's framing, surfaced by the harness.** The thrown path *already* reached the fallback provider before this change — `model-fallback-runner.ts` states outright that "even unrecognized errors should not abort the fallback loop when there are remaining candidates." So the original "fallback is never reached" claim holds only for the **embedded-result** path, where `classifyProviderErrorPayloadReason` returns `null` and `if (errorText.trim()) return null` accepts the failed run as terminal. On the thrown path the real gain is narrower but still concrete: `unknown` skips the billing recovery contract, so every candidate keeps reusing the exhausted login. Those checks are labelled "unchanged by this PR" above rather than presented as wins, and the P3 comment finding — which is what pointed at this — is fixed in both the source and the adjacent test comment.

**One item deliberately not implemented.** `codex review` raised a P2 I verified as factually correct: `cli-runner/prepare.ts:638-641` clears `effectiveAuthProfileId` for the native `anthropic:claude-cli` identity, so that path has no profile row to disable. Its suggested remedy is the cooldown-bypass half that ClawSweeper flagged `needs-product-decision` and advised keeping out of scope, so I left it alone rather than expanding this PR into a product decision. Scenario C instead demonstrates the classification is not a no-op there: before, a native-login user saw only `"LLM request failed."`; after, they get explicit billing copy and a different suspension reason. Happy to take the wider fix in a follow-up if a maintainer wants it.

**Gate.** Focused failover suites pass (43 + 1 on the touched files) · `oxfmt --check` clean · scoped `run-oxlint` on `src/agents/failover/` exit 0 · `pnpm tsgo:core` exit 0 · max-lines ratchet OK · `git diff --check` clean. Diff vs merge-base is 7 production lines and 38 test lines.

Proof gaps, stated plainly: the full-core oxlint lane was terminated after 40 minutes under heavy local load rather than being allowed to finish — its wrapper reported success but the log showed `[oxlint] FAILED (exit 143)` from the SIGTERM, so it is not counted here; the scoped run above stands in and CI covers the full lane. No Crabbox/Testbox breadth run.

🤖 AI-assisted (Claude Code): investigation, fix, and proof prepared with an AI agent; a human reviews and owns the result.


---

### Update 2 — the proof is now an auditable committed test

The previous update described a production-boundary harness, and the re-review answered, correctly: *"its tracked head contains no auditable harness or actual Claude CLI exhausted-credit capture."* That was fair — the harness lived in a git-excluded directory, so neither a reviewer nor CI could ever see it, which makes a pasted transcript an unverifiable claim. It is now a tracked test.

**`src/agents/cli-runner.usage-credit-billing.e2e.test.ts`** — test-only, production untouched (still +7 lines, one matcher plus explanatory comments).

It runs in CI: `test/vitest/vitest.e2e.config.ts` includes `src/**/*.e2e.test.ts`, executed by `pnpm test:e2e`. Placement and naming follow the sibling `src/agents/cli-runner.fault-sequences.e2e.test.ts`, and real-child-process spawning in this lane has precedent in `src/agents/bash-tools.process.e2e.test.ts`.

**What it drives, end to end:** a stub `claude` written by the test into a realpath'd temp dir and spawned as a **real child process** through the production supervisor — the test deliberately does not import `execute.test-support.ts`, since merely importing it installs the spawn mock — then real `parseCliOutput` → `createCliOutputFailoverError` → `classifyFailoverReason` → `settlePreparedCliRun`/`runPreparedCliAgent` (the exact production pairing at `cli-runner.ts:236`) → real SQLite auth-profile billing disable → `runWithModelFallback` reaching a loopback second candidate. The second case covers the embedded-result path through `classifyEmbeddedAgentRunResultForModelFallback`, where an unmatched classification is chain-fatal. Only the CLI binary and the fallback provider endpoint are stubbed; the stub is invoked via `process.execPath`, so there is no PATH or shebang dependence.

**RED against `origin/main`'s `message-patterns.ts`** (verified on a scratch branch, revert confirmed applied rather than silently no-oped — `git stash` would have no-oped here, since the pattern is committed on the branch):

```
× classifies a real CLI credit-exhaustion exit as billing, disables the profile,
  and reaches the cross-provider fallback
  AssertionError: expected [ 'unknown' ] to deeply equal [ 'billing' ]

× advances the embedded-result fallback chain when the same CLI text arrives as a
  terminal error payload
  AssertionError: expected [ 'claude-cli' ] to deeply equal [ 'claude-cli', 'openai' ]
```

Both fail for the intended reason: classification stays `unknown`, so no billing disable happens and the embedded chain never advances. GREEN on this head.

This also satisfies the repo's own bar rather than just the reviewer's — *"changes to delivery, dispatch, or session paths need at least one boundary-level proof (harness or live), not only unit tests of the changed function."* The existing predicate tests assert classifier return values on strings; they never cross the process or profile-health seams, so this is the boundary complement, not a duplicate.

**Gate.** New e2e test 2 passed · failover unit suites 117 + 682 passed · oxfmt clean · oxlint exit 0 (it caught a real ternary-as-statement, fixed) · `pnpm tsgo:core` exit 0 · `agents-root` test-shard typecheck exit 0 · max-lines ratchet OK · `git diff --check` clean. `codex review --base origin/main`: no findings, with sibling Codex behavior verified at `../codex/codex-rs/exec/src/exec_events.rs:8-94` and `../codex/codex-rs/exec/src/lib.rs:956-1061`.

LOC unchanged on the production side: **+7 production**, +288 test.

🤖 AI-assisted (Claude Code): investigation, fix, and proof prepared with an AI agent; a human reviews and owns the result.
