### PR TITLE
fix(tool-call-repair): stop re-parsing the whole response per candidate delta

### DIFF
--- a/extensions/ollama/src/stream-plain-text-tool-call.transport.test.ts
+++ b/extensions/ollama/src/stream-plain-text-tool-call.transport.test.ts
@@ -1,0 +1,193 @@
+// Real-transport regression proof for the plain-text tool-call compat wrapper (#122513).
+// Drives createOllamaStreamFn — the wrapper's canonical consumer — through a real
+// loopback NDJSON /api/chat server: real HTTP, real SSRF-guarded fetch, real NDJSON
+// parsing, real createPlainTextToolCallCompatWrapper, real Markdown protection.
+// Nothing is mocked; only the network endpoint is local. The hand-built delta suites
+// in packages/tool-call-repair replicate the delta shape this transport emits
+// (per-record text_delta with contentIndex and no cumulative partial); the raw-stream
+// assertions here pin that shape so those suites cannot silently drift from it.
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { createOllamaStreamFn } from "./stream-api.js";
+
+const FENCE = "```";
+
+/**
+ * Bracket-dense fenced TOML chunked exactly the way a token stream delivers it: every
+ * section heading's `[` ends its own delta, so nearly every line is candidate-shaped
+ * for a `read` tool matcher and forces the wrapper's protected-range resolution. The
+ * fenced `[read]` block is a complete, promotable call that only fence protection
+ * keeps literal; the trailing block is the same call outside the fence.
+ */
+function buildBracketDenseChunks(sections: number): {
+  chunks: string[];
+  text: string;
+  fencedBody: string;
+  trailingCall: string;
+} {
+  const chunks: string[] = ["Here is the configuration you asked for.\n\n", `${FENCE}toml\n`];
+  for (let index = 0; index < sections; index += 1) {
+    const id = String(index).padStart(2, "0");
+    chunks.push("[", `read.section.${id}]\n`, `name = "section-${id}"\n`);
+  }
+  const fencedBody = '[read]\n{"path":"fenced.txt"}\n[/read]\n';
+  chunks.push("[", fencedBody.slice(1));
+  chunks.push(`${FENCE}\n`);
+  const trailingCall = '[read]\n{"path":"real.txt"}\n[/read]\n';
+  chunks.push("\n", "[", trailingCall.slice(1));
+  return { chunks, text: chunks.join(""), fencedBody, trailingCall };
+}
+
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        }),
+    ),
+  );
+});
+
+async function startNdjsonChatServer(chunks: readonly string[]): Promise<string> {
+  const server = createServer((req, res) => {
+    if (!req.url?.endsWith("/api/chat")) {
+      res.writeHead(404).end();
+      return;
+    }
+    req.resume();
+    req.on("end", () => {
+      res.writeHead(200, { "content-type": "application/x-ndjson" });
+      for (const content of chunks) {
+        res.write(
+          `${JSON.stringify({
+            model: "proof-model",
+            created_at: "2026-01-01T00:00:00Z",
+            message: { role: "assistant", content },
+            done: false,
+          })}\n`,
+        );
+      }
+      res.write(
+        `${JSON.stringify({
+          model: "proof-model",
+          created_at: "2026-01-01T00:00:00Z",
+          message: { role: "assistant", content: "" },
+          done: true,
+          done_reason: "stop",
+          prompt_eval_count: 1,
+          eval_count: 1,
+        })}\n`,
+      );
+      res.end();
+    });
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const { port } = server.address() as AddressInfo;
+  return `http://127.0.0.1:${port}`;
+}
+
+type CollectedRun = {
+  deltaText: string;
+  doneText: string;
+  errors: unknown[];
+  eventTypes: Map<string, number>;
+  partialCarryingDeltas: number;
+  toolCallNames: string[];
+};
+
+async function runThroughTransport(
+  chunks: readonly string[],
+  tools: ReadonlyArray<Record<string, unknown>>,
+): Promise<CollectedRun> {
+  const baseUrl = await startNdjsonChatServer(chunks);
+  const streamFn = createOllamaStreamFn(baseUrl);
+  const stream = streamFn(
+    { api: "ollama", provider: "ollama", id: "proof-model", contextWindow: 65536 } as never,
+    { messages: [{ role: "user", content: "config?" }], tools } as never,
+    {},
+  );
+  const run: CollectedRun = {
+    deltaText: "",
+    doneText: "",
+    errors: [],
+    eventTypes: new Map(),
+    partialCarryingDeltas: 0,
+    toolCallNames: [],
+  };
+  for await (const event of stream as AsyncIterable<Record<string, unknown>>) {
+    const type = typeof event.type === "string" ? event.type : "unknown";
+    run.eventTypes.set(type, (run.eventTypes.get(type) ?? 0) + 1);
+    if (type === "text_delta") {
+      run.deltaText += typeof event.delta === "string" ? event.delta : "";
+      if ("partial" in event && event.partial !== undefined) {
+        run.partialCarryingDeltas += 1;
+      }
+    }
+    if (type === "error") {
+      run.errors.push(event.error);
+    }
+    if (type === "done") {
+      const message = event.message as { content?: unknown[] } | undefined;
+      for (const block of message?.content ?? []) {
+        const record = block as { type?: unknown; text?: unknown; name?: unknown };
+        if (record.type === "text" && typeof record.text === "string") {
+          run.doneText += record.text;
+        }
+        if (record.type === "toolCall" && typeof record.name === "string") {
+          run.toolCallNames.push(record.name);
+        }
+      }
+    }
+  }
+  return run;
+}
+
+const readTool = {
+  name: "read",
+  description: "Read a file",
+  parameters: { type: "object", properties: { path: { type: "string" } } },
+};
+
+describe("plain-text tool-call compat wrapper over the real Ollama NDJSON transport", () => {
+  it("keeps a bracket-dense fenced answer byte-identical while normalizing the unfenced call (#122513)", async () => {
+    const payload = buildBracketDenseChunks(40);
+    const run = await runThroughTransport(payload.chunks, [readTool]);
+
+    expect(run.errors).toEqual([]);
+    // Fence protection must keep every candidate-shaped line — including a complete,
+    // otherwise-promotable [read] call — literal, byte for byte. A fast-path bug that
+    // misreads fence state would scrub these lines out of the visible text.
+    const fencedPortion = payload.text.slice(0, payload.text.indexOf(payload.trailingCall));
+    expect(run.doneText.startsWith(fencedPortion)).toBe(true);
+    expect(run.doneText).toContain(payload.fencedBody);
+    // The identical call outside the fence is the wrapper's job to normalize away
+    // (scrubbed or promoted, both remove it from visible text); its literal text
+    // surviving would mean the wrapper never engaged.
+    expect(run.doneText).not.toContain('"path":"real.txt"');
+    // Live deltas and the terminal snapshot must agree exactly.
+    expect(run.deltaText).toBe(run.doneText);
+  });
+
+  it("passes the identical stream through untouched when no tools are configured (#122513)", async () => {
+    const payload = buildBracketDenseChunks(40);
+    const run = await runThroughTransport(payload.chunks, []);
+
+    expect(run.errors).toEqual([]);
+    // With no tool names the wrapper early-returns the raw provider stream, so the
+    // trailing [read] block stays literal and the whole payload survives byte for byte.
+    expect(run.doneText).toBe(payload.text);
+    expect(run.deltaText).toBe(payload.text);
+    expect(run.toolCallNames).toEqual([]);
+    // Raw transport delta shape backing the packages/tool-call-repair bounded suites:
+    // one text_delta per NDJSON record, with no cumulative `partial` snapshot attached.
+    expect(run.eventTypes.get("text_delta")).toBe(payload.chunks.length);
+    expect(run.partialCarryingDeltas).toBe(0);
+  });
+});

--- a/packages/tool-call-repair/src/protection-fast-path.test.ts
+++ b/packages/tool-call-repair/src/protection-fast-path.test.ts
@@ -143,4 +143,25 @@ describe("protection fast path", () => {
     // shape, not for ordinary timing noise.
     expect(elapsedMs).toBeLessThan(50);
   });
+
+  it("advances a long newline-free stream in token-sized deltas without rescanning it", () => {
+    // codex review: a provider streaming one long unbroken line (no candidate, no
+    // fence) in small deltas fed `partialLine + text` through indexOf on every call.
+    // Since partialLine never contains a newline, only `text` itself can complete a
+    // line, so scanning the concatenated buffer re-copies and re-scans the entire
+    // carried prefix on every delta -- quadratic even though nothing but plain prose
+    // is happening. A repro at 400 KB of 10-byte deltas took over a second on the
+    // prior implementation; this stays comfortably linear.
+    const state = createProtectionScanState();
+    const chunk = "abcdefghij";
+    const chunkCount = 40_000; // 400 KB total, in 10-byte deltas -- codex's own repro size.
+    const start = performance.now();
+    for (let index = 0; index < chunkCount; index += 1) {
+      advanceProtectionScanState(state, chunk);
+    }
+    const elapsedMs = performance.now() - start;
+
+    expect(state.partialLine.length).toBe(chunk.length * chunkCount);
+    expect(elapsedMs).toBeLessThan(200);
+  });
 });

--- a/packages/tool-call-repair/src/protection-fast-path.test.ts
+++ b/packages/tool-call-repair/src/protection-fast-path.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  advanceProtectionScanState,
+  createProtectionScanState,
+  resolveProtectionFastPath,
+} from "./protection-fast-path.js";
+
+/** Feeds prior visible text, then asks the fast path about the next delta. */
+function verdictFor(prefix: string, incoming: string) {
+  const state = createProtectionScanState();
+  advanceProtectionScanState(state, prefix);
+  return resolveProtectionFastPath(state, incoming);
+}
+
+describe("protection fast path", () => {
+  it("reports fenced content as protected without a full parse", () => {
+    const verdict = verdictFor("intro\n\n```toml\n", "[read]\n");
+    expect(verdict?.(0)).toBe(true);
+  });
+
+  it("reports ordinary prose as unprotected", () => {
+    const verdict = verdictFor("intro\n\nplain\n", "[read]\n");
+    expect(verdict?.(0)).toBe(false);
+  });
+
+  it("closes a fence only on a matching delimiter run", () => {
+    expect(verdictFor("```\ninside\n~~~\n", "[read]\n")?.(0)).toBe(true);
+    expect(verdictFor("````\ninside\n```\n", "[read]\n")?.(0)).toBe(true);
+    expect(verdictFor("```\ninside\n```\n", "[read]\n")?.(0)).toBe(false);
+  });
+
+  it("declines when a backtick fence carries a backtick in its info string", () => {
+    // CommonMark: backticks are illegal in a backtick-fence info string, so the line
+    // stays paragraph text. Treating it as an open fence would wrongly mark following
+    // text protected and leave a real tool call unscrubbed.
+    expect(verdictFor("```` ```\n", "[read]\n")).toBeUndefined();
+    expect(verdictFor("```js`\n", "[read]\n")).toBeUndefined();
+  });
+
+  it("keeps tracking a tilde fence whose info string carries a backtick", () => {
+    expect(verdictFor("~~~ js`\n", "[read]\n")?.(0)).toBe(true);
+  });
+
+  it("treats only spaces and tabs as closing-fence padding", () => {
+    // U+00A0 after a closing delimiter does NOT close the block (CommonMark), so the
+    // fence stays open and following text remains literal.
+    expect(verdictFor("```\nliteral\n```\u00a0\n", "[read]\n")?.(0)).toBe(true);
+    expect(verdictFor("```\nliteral\n```\t\n", "[read]\n")?.(0)).toBe(false);
+    expect(verdictFor("```\nliteral\n```  \n", "[read]\n")?.(0)).toBe(false);
+  });
+
+  it("does not treat a Unicode-space line as blank", () => {
+    // A U+00A0 line does not end a paragraph, so ambiguity must survive it.
+    expect(verdictFor("a `code` b\n\u00a0\n", "[read]\n")).toBeUndefined();
+  });
+
+  it("declines for shapes it does not model", () => {
+    expect(verdictFor("a `code` b\n", "[read]\n")).toBeUndefined();
+    expect(verdictFor("> quoted\n", "[read]\n")).toBeUndefined();
+    expect(verdictFor("- item\n", "[read]\n")).toBeUndefined();
+    expect(verdictFor("para\n\n", "    [read]\n")).toBeUndefined();
+  });
+
+  it("declines for tab-indented code", () => {
+    // CommonMark expands a leading tab to four columns, so a tabbed line is indented
+    // code even with no spaces. Reporting it unprotected would scrub literal content.
+    expect(verdictFor("para\n\n", "\t[read]\n")).toBeUndefined();
+    expect(verdictFor("", "\t[read]\n")).toBeUndefined();
+    expect(verdictFor("para\n\n", "  \t[read]\n")).toBeUndefined();
+    // Four spaces then a tab is still indented code; the column count, not the
+    // character class, decides.
+    expect(verdictFor("para\n\n", "    \t[read]\n")).toBeUndefined();
+    expect(verdictFor("para\n\n", "\t  [read]\n")).toBeUndefined();
+  });
+
+  it("declines for an unfinished line outside a fence", () => {
+    expect(verdictFor("plain\n", "[read]")).toBeUndefined();
+  });
+
+  it("declines when a bare carriage return ends a line", () => {
+    // findPotentialCallStart treats a lone CR as a line start and CommonMark ends the
+    // line there, but this tracker splits on LF, so it must not answer.
+    expect(verdictFor("```\nliteral\n```\r", "[read]\n")).toBeUndefined();
+    expect(verdictFor("```\r[read]\r", "[read]\n")).toBeUndefined();
+    expect(verdictFor("```\nliteral\n", "```\r[read]\n")).toBeUndefined();
+    // CRLF is still tracked normally.
+    expect(verdictFor("```toml\r\n", "[read]\r\n")?.(0)).toBe(true);
+  });
+
+  it("clears paragraph ambiguity at a blank line but never fence-parity doubt", () => {
+    // An inline span cannot cross a blank line, so tracking resumes.
+    expect(verdictFor("a `code` b\n\nplain\n", "[read]\n")?.(0)).toBe(false);
+    // A delimiter that could not be classified leaves parity unknown for good.
+    expect(verdictFor("- item\n```\n\nplain\n", "[read]\n")).toBeUndefined();
+  });
+});

--- a/packages/tool-call-repair/src/protection-fast-path.test.ts
+++ b/packages/tool-call-repair/src/protection-fast-path.test.ts
@@ -93,4 +93,54 @@ describe("protection fast path", () => {
     // A delimiter that could not be classified leaves parity unknown for good.
     expect(verdictFor("- item\n```\n\nplain\n", "[read]\n")).toBeUndefined();
   });
+
+  it("answers successive increasing offsets correctly, including a query before the first line", () => {
+    // findPotentialCallStart queries the returned closure at successive candidate offsets
+    // from a single left-to-right scan, so this exercises the same non-decreasing-offset
+    // pattern a real caller uses.
+    const verdict = verdictFor(
+      "",
+      ["plain", "```toml", "[a]", "[b]", "```", "plain2"].join("\n") + "\n",
+    );
+    const plainLen = "plain\n".length;
+    const fenceOpenLen = plainLen + "```toml\n".length;
+    const aLineStart = fenceOpenLen;
+    const bLineStart = aLineStart + "[a]\n".length;
+    const fenceCloseStart = bLineStart + "[b]\n".length;
+    const plain2Start = fenceCloseStart + "```\n".length;
+
+    expect(verdict?.(0)).toBe(false);
+    // The fence-opening delimiter line itself sits inside the code region it opens.
+    expect(verdict?.(plainLen)).toBe(true);
+    expect(verdict?.(aLineStart)).toBe(true);
+    expect(verdict?.(bLineStart)).toBe(true);
+    expect(verdict?.(fenceCloseStart)).toBe(true);
+    expect(verdict?.(plain2Start)).toBe(false);
+  });
+
+  it("keeps successive lookups linear instead of rescanning from the start each time", () => {
+    // codex review: the returned closure used to rescan every recorded line start from
+    // index 0 on every call. Querying every candidate offset in a large fenced snapshot
+    // with many literal calls made a single left-to-right scan Θ(lines x candidates)
+    // instead of Θ(lines). A monotonic cursor keeps total lookup work linear.
+    const lineCount = 20_000;
+    const body = Array.from({ length: lineCount }, (_, index) => `[read.${index}]`).join("\n");
+    const incoming = `\`\`\`toml\n${body}\n\`\`\`\n`;
+    const verdict = verdictFor("", incoming);
+    expect(verdict).toBeDefined();
+
+    let offset = 0;
+    const start = performance.now();
+    for (let index = 0; index < lineCount; index += 1) {
+      verdict?.(offset);
+      offset = incoming.indexOf("\n", offset) + 1;
+    }
+    const elapsedMs = performance.now() - start;
+
+    // A quadratic rescan over 20,000 lines takes hundreds of milliseconds on this
+    // hardware; a linear cursor finishes in low single-digit milliseconds. This
+    // threshold sits comfortably between the two so it only fails for the quadratic
+    // shape, not for ordinary timing noise.
+    expect(elapsedMs).toBeLessThan(50);
+  });
 });

--- a/packages/tool-call-repair/src/protection-fast-path.ts
+++ b/packages/tool-call-repair/src/protection-fast-path.ts
@@ -132,15 +132,28 @@ export function advanceProtectionScanState(state: ProtectionScanState, text: str
     state.structuralUnknown = true;
     return;
   }
-  let buffer = state.partialLine + text;
-  let newline = buffer.indexOf("\n");
-  while (newline !== -1) {
-    const line = buffer.slice(0, newline).replace(/\r$/, "");
-    applyLine(state, line);
-    buffer = buffer.slice(newline + 1);
-    newline = buffer.indexOf("\n");
+  // `partialLine` never contains a newline (it is always the fragment after the last
+  // completed line), so a line can only complete here if `text` itself contains one.
+  // Searching `text` alone -- instead of the concatenated `partialLine + text` -- keeps
+  // a long newline-free stream (e.g. one long unbroken output line, fed in small
+  // provider-sized deltas) linear: otherwise both the concatenation and the indexOf
+  // scan below would re-copy and re-scan the ever-growing carried prefix on every call.
+  let newline = text.indexOf("\n");
+  if (newline === -1) {
+    state.partialLine += text;
+    return;
   }
-  state.partialLine = buffer;
+  let line = (state.partialLine + text.slice(0, newline)).replace(/\r$/, "");
+  applyLine(state, line);
+  let cursor = newline + 1;
+  newline = text.indexOf("\n", cursor);
+  while (newline !== -1) {
+    line = text.slice(cursor, newline).replace(/\r$/, "");
+    applyLine(state, line);
+    cursor = newline + 1;
+    newline = text.indexOf("\n", cursor);
+  }
+  state.partialLine = text.slice(cursor);
 }
 
 /**

--- a/packages/tool-call-repair/src/protection-fast-path.ts
+++ b/packages/tool-call-repair/src/protection-fast-path.ts
@@ -1,0 +1,231 @@
+/**
+ * Incremental Markdown-protection fast path for the streaming normalizer.
+ *
+ * The stream normalizer must know whether a candidate tool call sits inside a code
+ * region before it may scrub it. Resolving that with a full Markdown parse of the
+ * whole accumulated response on every candidate-shaped delta is quadratic, so this
+ * tracker carries block state forward as text is appended.
+ *
+ * Safety contract: this is a *conservative* fast path. It answers only when it can
+ * prove the verdict from fence state alone, and reports `undefined` for every shape
+ * it does not model (inline code spans, indented code, block quotes, lists). Callers
+ * must fall back to the authoritative full parse whenever the answer is `undefined`,
+ * so protection semantics stay identical to a full parse.
+ */
+
+/** Carried block state at a position in the accumulated response. */
+export type ProtectionScanState = {
+  /** Fence delimiter of the currently open fenced block, when inside one. */
+  fenceChar: "`" | "~" | undefined;
+  /** Delimiter run length that opened the current fenced block. */
+  fenceLength: number;
+  /**
+   * Set when the current paragraph contains a construct this tracker does not model.
+   * Cleared on a blank line, because none of those constructs span a blank line.
+   */
+  paragraphAmbiguous: boolean;
+  /**
+   * Set when a fence delimiter was seen that could not be classified as a clean open or
+   * close. Fence parity is then permanently unknown — a later delimiter this tracker
+   * would read as an open may really be the close of a fence it skipped — so unlike
+   * paragraph ambiguity this never clears.
+   */
+  structuralUnknown: boolean;
+  /** Trailing partial line; block structure is only decidable on whole lines. */
+  partialLine: string;
+};
+
+export function createProtectionScanState(): ProtectionScanState {
+  return {
+    fenceChar: undefined,
+    fenceLength: 0,
+    paragraphAmbiguous: false,
+    structuralUnknown: false,
+    partialLine: "",
+  };
+}
+
+export function cloneProtectionScanState(state: ProtectionScanState): ProtectionScanState {
+  return { ...state };
+}
+
+const FENCE_OPEN = /^ {0,3}(`{3,}|~{3,})/;
+/** Blank means spaces and tabs only; Unicode spaces do not end a Markdown block. */
+const BLANK_LINE = /^[ \t]*$/;
+/**
+ * A CR that does not begin a CRLF pair. `findPotentialCallStart` treats a bare CR as a
+ * line start and the CommonMark resolver ends a line there, but this tracker splits on LF
+ * only, so it must decline rather than miss a fence boundary. A chunk that merely ends
+ * mid-CRLF also declines, which costs a parse but never correctness.
+ */
+const BARE_CARRIAGE_RETURN = /\r(?!\n)/;
+/** A fence-length delimiter run outside a fence that did not open one at column 0. */
+const UNCLASSIFIED_FENCE_DELIMITER = /`{3,}|~{3,}/;
+/**
+ * Line starts that make indentation or delimiters structural, which this tracker does not
+ * model. Indentation counts in columns, so any leading tab qualifies (CommonMark expands
+ * one to four columns) and so does any run of four spaces, whatever follows it — including
+ * a further tab. Blank lines never reach here; they are handled before this test.
+ */
+const UNMODELED_BLOCK_START = /^(?: {0,3}(?:>|[-*+](?:\s|$)|\d{1,9}[.)](?:\s|$))| {4,}| *\t)/;
+
+/** Applies one whole line (newline excluded) to the carried state. */
+function applyLine(state: ProtectionScanState, line: string): void {
+  if (state.structuralUnknown) {
+    return;
+  }
+  if (state.fenceChar) {
+    // Inside a fence only a matching closing delimiter run is structural.
+    // Only spaces and tabs may follow a closing fence. `\s` would also match Unicode
+    // spaces such as U+00A0, which do NOT close a fence, and wrongly reading the block
+    // as closed would scrub literal fenced text.
+    const close = /^ {0,3}(`{3,}|~{3,})[ \t]*$/.exec(line);
+    const run = close?.[1];
+    if (run && run[0] === state.fenceChar && run.length >= state.fenceLength) {
+      state.fenceChar = undefined;
+      state.fenceLength = 0;
+    }
+    return;
+  }
+  if (BLANK_LINE.test(line)) {
+    // A blank line ends every construct that could have made this paragraph ambiguous.
+    state.paragraphAmbiguous = false;
+    return;
+  }
+  const open = FENCE_OPEN.exec(line);
+  const marker = open?.[1];
+  if (marker) {
+    // Only track fences that open at column 0 in unambiguous context. A fence indented
+    // under a list or quoted in a block quote belongs to that container and ends with it
+    // (CommonMark), which this tracker does not model.
+    // A backtick fence whose info string contains a backtick is not a fence at all
+    // (CommonMark); the line stays paragraph text. Tilde fences allow backticks.
+    const infoString = line.slice(open[0].length);
+    if (
+      state.paragraphAmbiguous ||
+      open[0].length !== marker.length ||
+      (marker[0] === "`" && infoString.includes("`"))
+    ) {
+      state.structuralUnknown = true;
+      return;
+    }
+    state.fenceChar = marker[0] === "~" ? "~" : "`";
+    state.fenceLength = marker.length;
+    return;
+  }
+  if (UNCLASSIFIED_FENCE_DELIMITER.test(line)) {
+    // A delimiter run somewhere this tracker cannot classify leaves parity unknown.
+    state.structuralUnknown = true;
+    return;
+  }
+  if (line.includes("`") || UNMODELED_BLOCK_START.test(line)) {
+    state.paragraphAmbiguous = true;
+  }
+}
+
+/** Feeds appended visible text into the carried state. */
+export function advanceProtectionScanState(state: ProtectionScanState, text: string): void {
+  if (!text) {
+    return;
+  }
+  if (BARE_CARRIAGE_RETURN.test(text)) {
+    state.structuralUnknown = true;
+    return;
+  }
+  let buffer = state.partialLine + text;
+  let newline = buffer.indexOf("\n");
+  while (newline !== -1) {
+    const line = buffer.slice(0, newline).replace(/\r$/, "");
+    applyLine(state, line);
+    buffer = buffer.slice(newline + 1);
+    newline = buffer.indexOf("\n");
+  }
+  state.partialLine = buffer;
+}
+
+/**
+ * Decides protection for candidate offsets inside `incoming`, given the state carried
+ * from the text before it. Returns `undefined` when the answer is not provable from
+ * fence state alone, which means the caller must run the authoritative full parse.
+ */
+export function resolveProtectionFastPath(
+  carried: ProtectionScanState,
+  incoming: string,
+): ((offset: number) => boolean) | undefined {
+  if (carried.paragraphAmbiguous || carried.structuralUnknown) {
+    return undefined;
+  }
+  if (BARE_CARRIAGE_RETURN.test(incoming)) {
+    return undefined;
+  }
+  // Walk `incoming` once on a copy, recording the verdict at each line start it exposes.
+  // The caller advances the real state separately, so this must not mutate it.
+  const state = cloneProtectionScanState(carried);
+  const lineStarts: Array<[start: number, isProtected: boolean]> = [];
+  let index = 0;
+  let lineStart = 0;
+  for (;;) {
+    if (index >= incoming.length && !state.partialLine) {
+      // Nothing follows the final newline, so no offset can be queried past it. Stop
+      // instead of treating the empty tail as an unfinished line and forcing a parse.
+      break;
+    }
+    const newline = incoming.indexOf("\n", index);
+    const complete = newline !== -1;
+    const line =
+      `${state.partialLine}${incoming.slice(index, complete ? newline : undefined)}`.replace(
+        /\r$/,
+        "",
+      );
+    // Offsets are reported relative to `incoming`; a carried partial line began before it.
+    const lineStartAbsolute = lineStart - state.partialLine.length;
+    if (state.fenceChar) {
+      // Fenced content and its delimiter lines all sit inside the code region, so the
+      // verdict holds without needing to see the rest of the line.
+      lineStarts.push([lineStartAbsolute, true]);
+    } else if (!complete) {
+      // Outside a fence an unfinished line could still open one or turn out to be
+      // indented or inline code. Yield to the authoritative parse.
+      return undefined;
+    } else {
+      const probe = cloneProtectionScanState(state);
+      applyLine(probe, line);
+      if (probe.paragraphAmbiguous || probe.structuralUnknown) {
+        return undefined;
+      }
+      const opened = probe.fenceChar ? FENCE_OPEN.exec(line) : null;
+      if (opened?.[1]) {
+        // The region starts at the delimiter run, so an indented fence leaves its own
+        // leading whitespace outside the region.
+        lineStarts.push([lineStartAbsolute, false]);
+        lineStarts.push([lineStartAbsolute + (opened[0].length - opened[1].length), true]);
+      } else {
+        lineStarts.push([lineStartAbsolute, false]);
+      }
+    }
+    if (!complete) {
+      break;
+    }
+    applyLine(state, line);
+    if (state.paragraphAmbiguous || state.structuralUnknown) {
+      return undefined;
+    }
+    state.partialLine = "";
+    index = newline + 1;
+    lineStart = index;
+    if (index > incoming.length) {
+      break;
+    }
+  }
+  return (offset: number) => {
+    // Candidate offsets sit at a line start; the nearest preceding start owns the verdict.
+    let isProtected = false;
+    for (const [start, verdict] of lineStarts) {
+      if (start > offset) {
+        break;
+      }
+      isProtected = verdict;
+    }
+    return isProtected;
+  };
+}

--- a/packages/tool-call-repair/src/protection-fast-path.ts
+++ b/packages/tool-call-repair/src/protection-fast-path.ts
@@ -217,14 +217,22 @@ export function resolveProtectionFastPath(
       break;
     }
   }
+  // Callers only ever query at successive candidate offsets from a single left-to-right
+  // scan (findPotentialCallStart), so offsets seen here are non-decreasing. A cursor that
+  // only advances keeps total lookup work linear in lineStarts across the whole scan; a
+  // fresh scan from the start on every call would make a large authoritative snapshot with
+  // many candidates quadratic (lines x candidates) instead.
+  let cursor = -1;
+  let isProtected = false;
   return (offset: number) => {
     // Candidate offsets sit at a line start; the nearest preceding start owns the verdict.
-    let isProtected = false;
-    for (const [start, verdict] of lineStarts) {
-      if (start > offset) {
+    while (cursor + 1 < lineStarts.length) {
+      const next = lineStarts[cursor + 1];
+      if (next === undefined || next[0] > offset) {
         break;
       }
-      isProtected = verdict;
+      cursor += 1;
+      isProtected = next[1];
     }
     return isProtected;
   };

--- a/packages/tool-call-repair/src/stream-normalizer.test.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.test.ts
@@ -740,6 +740,81 @@ describe("normalizePlainTextToolCallStreamEvents over-cap XML", () => {
     expect(textDeltas(events).join("")).toBe(visibleChunks.join(""));
   });
 
+  it("materializes accumulated Markdown when an inline span blocks the fast path", async () => {
+    const resolvedLengths: number[] = [];
+    // Inline code spans are a shape the carried fence scan deliberately does not model,
+    // so the authoritative full parse must still run — and still stay bounded.
+    const visibleChunks = Array.from({ length: 1_000 }, () => "ordinary `code` prose\n");
+    const candidate = ["[read]", '{"path":"example.txt"}', "[/read]"].join("\n");
+    const events = await collectNormalizedEvents(
+      [...visibleChunks.map((delta) => streamTextDelta(delta)), streamTextDelta(candidate)],
+      {
+        matcher,
+        createPromotedToolCallEvents: () => [],
+        normalizeTerminalMessage: () => undefined,
+        resolveProtectedRanges: (text) => {
+          resolvedLengths.push(text.length);
+          return [];
+        },
+      },
+    );
+
+    expect(resolvedLengths).toContain(visibleChunks.join("").length + candidate.length);
+    expect(resolvedLengths.length).toBeLessThanOrEqual(3);
+    expect(textDeltas(events).join("")).toBe(visibleChunks.join(""));
+  });
+
+  it("does not carry an open fence from a finished completion into the next one", async () => {
+    // The done branch clears the protection context; carried block state must clear with
+    // it, or the next completion starts "inside" the previous fence and its first line is
+    // wrongly treated as protected literal text.
+    const firstText = "```toml\n[read.section]\n";
+    const call = ["[read]", '{"path":"secret.txt"}', "[/read]"].join("\n");
+    const events = await normalize(
+      [
+        streamTextDelta(firstText),
+        doneAssistantEvent("stop", textContent(firstText), "stop"),
+        streamTextDelta(`${call}\n`),
+        doneAssistantEvent("stop", textContent(`${call}\n`), "stop"),
+      ],
+      { protectFences: true },
+    );
+
+    expect(textDeltas(events).join("")).not.toContain('{"path":"secret.txt"}');
+  });
+
+  it("keeps protection resolution bounded across a bracket-dense fenced answer", async () => {
+    let resolverCalls = 0;
+    // `[read...` is candidate-shaped for this matcher, so every line trips the candidate
+    // check while staying protected by the surrounding fence.
+    const fenced = [
+      "```toml",
+      ...Array.from({ length: 300 }, (_, index) => `[read.section.${index}]\nname = "svc"`),
+      "```",
+      "",
+    ].join("\n");
+    // Split so every '[' lands at the end of its own delta, which is what makes a real
+    // provider stream trip the candidate check on nearly every line.
+    const deltas = fenced.split(/(?<=\[)/);
+    const events = await collectNormalizedEvents(
+      deltas.map((delta) => streamTextDelta(delta)),
+      {
+        matcher,
+        createPromotedToolCallEvents: () => [],
+        normalizeTerminalMessage: () => undefined,
+        resolveProtectedRanges: (text) => {
+          resolverCalls += 1;
+          return resolveTestFenceRanges(text);
+        },
+      },
+    );
+
+    // Before the carried fence state existed this resolved the whole accumulated
+    // response once per bracket delta (hundreds of full parses over a growing buffer).
+    expect(resolverCalls).toBeLessThanOrEqual(3);
+    expect(textDeltas(events).join("")).toBe(fenced);
+  });
+
   it("still scrubs an unfenced call from live deltas and the terminal message", async () => {
     const text = ["[read]", '{"path":"secret.txt"}', "[/read]"].join("\n");
     const events = await normalize(

--- a/packages/tool-call-repair/src/stream-normalizer.test.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.test.ts
@@ -745,9 +745,6 @@ describe("normalizePlainTextToolCallStreamEvents over-cap XML", () => {
     // Wrongly "protected" would stream the raw candidate bytes straight out as literal
     // visible text; correctly recognized as a real, unfenced call, they are buffered as
     // a pending candidate instead and never appear verbatim in a streamed delta.
-    // Wrongly "protected" would stream the raw candidate bytes straight out as literal
-    // visible text; correctly recognized as a real, unfenced call, they are buffered as
-    // a pending candidate instead and never appear verbatim in a streamed delta.
     const streamedText = events
       .map((event) =>
         typeof event.delta === "string"
@@ -758,6 +755,50 @@ describe("normalizePlainTextToolCallStreamEvents over-cap XML", () => {
       )
       .join("");
     expect(streamedText).not.toContain('{"path":"example.txt"}');
+  });
+
+  it("does not trust a same-length prefix that came from a different block order (#122513)", async () => {
+    // codex review: a length match alone does not prove the event-order scan represents
+    // the same prefix as content-index order. Block 1 streams "```\n" first (opens a
+    // backtick fence); block 0 then streams "~~~\n" (opens a tilde fence, since a tilde
+    // delimiter never closes a backtick fence). Event order ends with fenceChar "`";
+    // content-index order (0 then 1) ends with fenceChar "~" -- same tracked length (8),
+    // opposite fence identity. Block 2's own "```" delimiter would close the (wrong)
+    // event-order backtick fence but not the (correct) content-order tilde fence, so a
+    // length-only check wrongly lets a call still inside the real fence through.
+    const block1 = "```\n";
+    const block0 = "~~~\n";
+    const candidate = ["```", "[read]", '{"path":"example.txt"}', "[/read]", "```", ""].join("\n");
+    const events = await collectNormalizedEvents(
+      [
+        streamTextDelta(block1, 1, assistantMessage(textContent("", block1))),
+        streamTextDelta(block0, 0, assistantMessage(textContent(block0, block1))),
+        streamTextDelta(candidate, 2, assistantMessage(textContent(block0, block1, candidate))),
+      ],
+      {
+        matcher,
+        createPromotedToolCallEvents: () => [],
+        normalizeTerminalMessage: () => undefined,
+        protectedRangesFenceCompatible: true,
+        resolveProtectedRanges: resolveTestFenceRanges,
+      },
+    );
+
+    // Correctly distrusted (this fix), block 2's candidate is recognized as still inside
+    // the real (content-order) fence and streams straight out as literal visible text.
+    // Wrongly trusted event-order state instead closes the fence on block 2's own
+    // opening "```" and buffers the call as a pending candidate -- and since nothing
+    // resolves it here, it silently never appears in the output at all.
+    const streamedText = events
+      .map((event) =>
+        typeof event.delta === "string"
+          ? event.delta
+          : typeof event.content === "string"
+            ? event.content
+            : "",
+      )
+      .join("");
+    expect(streamedText).toContain('{"path":"example.txt"}');
   });
 
   it("preserves candidate bytes after bounded protection history overflows", async () => {

--- a/packages/tool-call-repair/src/stream-normalizer.test.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.test.ts
@@ -849,6 +849,58 @@ describe("normalizePlainTextToolCallStreamEvents over-cap XML", () => {
     expect(streamedText).toContain('{"path":"x"}');
   });
 
+  it("invalidates a cached preceding-context verdict when the earlier block grows (#122513)", async () => {
+    // codex review: an earlier block can itself still be actively streaming and grow
+    // between two candidate probes in a later block, without the content index ever
+    // switching away and back (which would otherwise reset the per-block cache via
+    // beginProtectionBlock). A cache keyed only on "have we checked this block yet"
+    // would reuse a verdict that predates that growth. Block 0 streams "~~~\n" for real
+    // (opening a tilde fence in event order); a first, complete call in block 1 confirms
+    // trust against that. A second candidate in block 1 then arrives with a partial
+    // reporting a LARGER block 0 ("~~~\n~~~\n", closing that same fence in content
+    // order) -- the cache must notice the preceding length changed and re-check, not
+    // reuse the first verdict.
+    const block0First = "~~~\n";
+    const firstCall = "[read]\n{}\n[/read]\n";
+    const secondCandidate = ["[read]", '{"path":"x"}', "[/read]", ""].join("\n");
+    const block0Grown = `${block0First}~~~\n`;
+    const events = await collectNormalizedEvents(
+      [
+        streamTextDelta(block0First, 0),
+        streamTextDelta(firstCall, 1, assistantMessage(textContent(block0First, firstCall))),
+        streamTextDelta(
+          secondCandidate,
+          1,
+          assistantMessage(textContent(block0Grown, `${firstCall}${secondCandidate}`)),
+        ),
+      ],
+      {
+        matcher,
+        createPromotedToolCallEvents: () => [],
+        normalizeTerminalMessage: () => undefined,
+        protectedRangesFenceCompatible: true,
+        resolveProtectedRanges: resolveTestFenceRanges,
+      },
+    );
+
+    // A stale cached "trusted" verdict evaluates the second candidate against the
+    // event-order scan, which never saw block 0's second "~~~\n" and so still thinks the
+    // tilde fence from the first "~~~\n" is open -- the real, unfenced call is wrongly
+    // buffered as protected content and (nothing here resolves it) silently vanishes.
+    // Correctly invalidated, the cache re-checks against the grown block 0, sees the
+    // fence actually closed in content order, and the real call is recognized.
+    const streamedText = events
+      .map((event) =>
+        typeof event.delta === "string"
+          ? event.delta
+          : typeof event.content === "string"
+            ? event.content
+            : "",
+      )
+      .join("");
+    expect(streamedText).not.toContain('{"path":"x"}');
+  });
+
   it("preserves candidate bytes after bounded protection history overflows", async () => {
     const opening = `\`\`\`text\n${"x".repeat(1_000_000)}`;
     const candidate = ["[read]", '{"path":"example.txt"}', "[/read]"].join("\n");

--- a/packages/tool-call-repair/src/stream-normalizer.test.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.test.ts
@@ -820,6 +820,43 @@ describe("normalizePlainTextToolCallStreamEvents over-cap XML", () => {
     expect(textDeltas(events).join("")).toBe(fenced);
   });
 
+  it("keeps protection resolution bounded when every delta carries a cumulative partial", async () => {
+    let resolverCalls = 0;
+    // OpenAI-completions and Mistral attach a growing cumulative snapshot to every
+    // text_delta via `partial`. resolvePartialProtectionCheck validates against exactly
+    // that shape and, when it validates, still does a full Markdown parse of the
+    // snapshot — so if it ran ahead of the carried-fence-state fast path, the fast path
+    // would never get a chance to answer and the quadratic parse would persist even
+    // with protectedRangesFenceCompatible set.
+    const fenced = [
+      "```toml",
+      ...Array.from({ length: 300 }, (_, index) => `[read.section.${index}]\nname = "svc"`),
+      "```",
+      "",
+    ].join("\n");
+    const deltas = fenced.split(/(?<=\[)/);
+    let accumulated = "";
+    const events = await collectNormalizedEvents(
+      deltas.map((delta) => {
+        accumulated += delta;
+        return streamTextDelta(delta, 0, assistantMessage(textContent(accumulated)));
+      }),
+      {
+        matcher,
+        createPromotedToolCallEvents: () => [],
+        normalizeTerminalMessage: () => undefined,
+        protectedRangesFenceCompatible: true,
+        resolveProtectedRanges: (text) => {
+          resolverCalls += 1;
+          return resolveTestFenceRanges(text);
+        },
+      },
+    );
+
+    expect(resolverCalls).toBeLessThanOrEqual(3);
+    expect(textDeltas(events).join("")).toBe(fenced);
+  });
+
   it("still protects an unfenced caller-defined range when the fast path is not opted in", async () => {
     // The carried fence scan only ever proves fence state. A resolver whose protected
     // ranges are not fences at all (unlike resolveTestFenceRanges/findCodeRegions) would be

--- a/packages/tool-call-repair/src/stream-normalizer.test.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.test.ts
@@ -801,6 +801,54 @@ describe("normalizePlainTextToolCallStreamEvents over-cap XML", () => {
     expect(streamedText).toContain('{"path":"example.txt"}');
   });
 
+  it("does not cache trust from a candidate with no partial at all (#122513)", async () => {
+    // codex review: a candidate delta can arrive with no partial at all (partial is
+    // optional on every event type). hasUntrackedPrecedingContext has nothing to compare
+    // in that case and returns "no data", which must not be cached as "trusted" for the
+    // rest of the block -- a LATER candidate in the same block, one that does carry a
+    // partial revealing a genuine event-order/content-order mismatch, must still get its
+    // own fresh check rather than inheriting a default that was never actually confirmed.
+    const block1 = "```\n";
+    // A complete, well-formed call with no partial: resolves immediately, so a second,
+    // separate candidate can start afterward in the same block.
+    const firstCall = "[read]\n{}\n[/read]\n";
+    const secondCandidate = ["```", "[read]", '{"path":"x"}', "[/read]", "```", ""].join("\n");
+    const events = await collectNormalizedEvents(
+      [
+        streamTextDelta(block1, 1),
+        streamTextDelta(firstCall, 0),
+        streamTextDelta(
+          secondCandidate,
+          0,
+          assistantMessage(textContent(`~~~\n${firstCall}${secondCandidate}`, block1)),
+        ),
+      ],
+      {
+        matcher,
+        createPromotedToolCallEvents: () => [],
+        normalizeTerminalMessage: () => undefined,
+        protectedRangesFenceCompatible: true,
+        resolveProtectedRanges: resolveTestFenceRanges,
+      },
+    );
+
+    // Wrongly caching "trusted" from the no-partial first call would leave the second
+    // candidate evaluated against the (wrong) event-order fence state, buffering it as a
+    // pending candidate that nothing here ever resolves -- it silently vanishes from the
+    // output. Correctly re-checked, it is recognized as still protected and streams out
+    // as literal visible text.
+    const streamedText = events
+      .map((event) =>
+        typeof event.delta === "string"
+          ? event.delta
+          : typeof event.content === "string"
+            ? event.content
+            : "",
+      )
+      .join("");
+    expect(streamedText).toContain('{"path":"x"}');
+  });
+
   it("preserves candidate bytes after bounded protection history overflows", async () => {
     const opening = `\`\`\`text\n${"x".repeat(1_000_000)}`;
     const candidate = ["[read]", '{"path":"example.txt"}', "[/read]"].join("\n");

--- a/packages/tool-call-repair/src/stream-normalizer.test.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.test.ts
@@ -691,6 +691,29 @@ describe("normalizePlainTextToolCallStreamEvents over-cap XML", () => {
     expect(events.some((event) => String(event.type).startsWith("toolcall_"))).toBe(false);
   });
 
+  it("uses cumulative partials when earlier fenced blocks were not streamed, even with a complete final line (#122513)", async () => {
+    // codex review: the test above happens to end its candidate on an INCOMPLETE last line
+    // ("```" with no trailing newline), which independently makes the fast path decline (it
+    // always declines on an unfinished line outside a fence) -- masking the real bug. With a
+    // complete last line, the fast path's carried state (empty, since block 0's "```json" was
+    // never streamed as its own delta) wrongly reports the candidate as NOT protected instead
+    // of falling through to the cumulative-partial/full-parse fallback that knows better.
+    const first = "```json\n";
+    const candidate = ["[read]", '{"path":"example.txt"}', "[/read]", "```", ""].join("\n");
+    const content = textContent(first, candidate);
+    const events = await normalize(
+      [
+        streamTextDelta(candidate, 1, assistantMessage(content)),
+        textEnd(candidate, 1, assistantMessage(content)),
+        doneAssistantEvent("stop", content, "stop"),
+      ],
+      { protectFences: true },
+    );
+
+    expect(textDeltas(events).join("")).toBe(candidate);
+    expect(events.some((event) => String(event.type).startsWith("toolcall_"))).toBe(false);
+  });
+
   it("preserves candidate bytes after bounded protection history overflows", async () => {
     const opening = `\`\`\`text\n${"x".repeat(1_000_000)}`;
     const candidate = ["[read]", '{"path":"example.txt"}', "[/read]"].join("\n");

--- a/packages/tool-call-repair/src/stream-normalizer.test.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.test.ts
@@ -967,6 +967,58 @@ describe("normalizePlainTextToolCallStreamEvents over-cap XML", () => {
     expect(textDeltas(events).join("")).toBe(fenced);
   });
 
+  it("keeps a large preceding block's prefix check bounded across many later candidates (#122513)", async () => {
+    // codex review: hasUntrackedPrecedingContext's deep (same-length) check materialized
+    // the tracked prefix via materializeProtectionPrefix, which joins EVERY chunk ever
+    // pushed -- including the current, still-growing block's own chunks -- before
+    // slicing. Doing that once per candidate made a large preceding block followed by a
+    // bracket-dense later block Theta(precedingBlockSize x candidateCount) again. This
+    // must stay bounded: derive it once per block (cached) using a prefix-bounded
+    // accumulator, not a full join, on every one of the many candidates that follow.
+    // Keep the prefix exactly 200,000 characters while ending its line so the next
+    // block's delimiter is a real CommonMark fence, not a mid-line backtick run.
+    const precedingBlock = `${"x".repeat(199_999)}\n`;
+    const fenced = [
+      "```toml",
+      ...Array.from({ length: 300 }, (_, index) => `[read.section.${index}]\nname = "svc"`),
+      "```",
+      "",
+    ].join("\n");
+    const deltas = fenced.split(/(?<=\[)/);
+    let accumulated = "";
+    const events = [
+      streamTextDelta(precedingBlock, 0, assistantMessage(textContent(precedingBlock, ""))),
+      ...deltas.map((delta) => {
+        accumulated += delta;
+        return streamTextDelta(
+          delta,
+          1,
+          assistantMessage(textContent(precedingBlock, accumulated)),
+        );
+      }),
+    ];
+
+    let resolverCalls = 0;
+    const start = performance.now();
+    const normalized = await collectNormalizedEvents(events, {
+      matcher,
+      createPromotedToolCallEvents: () => [],
+      normalizeTerminalMessage: () => undefined,
+      protectedRangesFenceCompatible: true,
+      resolveProtectedRanges: (text) => {
+        resolverCalls += 1;
+        return resolveTestFenceRanges(text);
+      },
+    });
+    const elapsedMs = performance.now() - start;
+
+    expect(resolverCalls).toBeLessThanOrEqual(3);
+    // A large preceding block re-materialized per candidate would push this into the
+    // hundreds of milliseconds; bounded (cached) prefix validation stays well under it.
+    expect(elapsedMs).toBeLessThan(200);
+    expect(textDeltas(normalized).join("")).toBe(precedingBlock + fenced);
+  });
+
   it("still protects an unfenced caller-defined range when the fast path is not opted in", async () => {
     // The carried fence scan only ever proves fence state. A resolver whose protected
     // ranges are not fences at all (unlike resolveTestFenceRanges/findCodeRegions) would be

--- a/packages/tool-call-repair/src/stream-normalizer.test.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.test.ts
@@ -714,6 +714,52 @@ describe("normalizePlainTextToolCallStreamEvents over-cap XML", () => {
     expect(events.some((event) => String(event.type).startsWith("toolcall_"))).toBe(false);
   });
 
+  it("recognizes a real call in an earlier block when a later block streams its fence first (#122513)", async () => {
+    // codex review: the carried fence-state scan advances in EVENT order, but a partial's
+    // per-block offsets are in CONTENT-INDEX order. A provider can stream block 1 (opening a
+    // fence) before block 0 (a genuine, unfenced call) -- by the time block 0's own delta
+    // arrives, the scan has tracked 8 chars (block 1's "```json\n") while block 0's own
+    // content-order offset is 0. A ">" check misses this direction entirely and lets the fast
+    // path answer from the scan's (wrong, event-order) state, which would treat the call as
+    // fenced and never promote it -- only a "!==" check catches a mismatch in either direction.
+    const candidate = ["[read]", '{"path":"example.txt"}', "[/read]", ""].join("\n");
+    const second = "```json\n";
+    // No text_end/done here: the terminal path always re-parses the whole assembled
+    // message from scratch and would correctly scrub the call regardless of what the
+    // streaming fast path decided, masking exactly the bug this test targets. The
+    // observable difference is in the intermediate streamed text_delta events.
+    const events = await collectNormalizedEvents(
+      [
+        streamTextDelta(second, 1, assistantMessage(textContent("", second))),
+        streamTextDelta(candidate, 0, assistantMessage(textContent(candidate, second))),
+      ],
+      {
+        matcher,
+        createPromotedToolCallEvents: () => [],
+        normalizeTerminalMessage: () => undefined,
+        protectedRangesFenceCompatible: true,
+        resolveProtectedRanges: resolveTestFenceRanges,
+      },
+    );
+
+    // Wrongly "protected" would stream the raw candidate bytes straight out as literal
+    // visible text; correctly recognized as a real, unfenced call, they are buffered as
+    // a pending candidate instead and never appear verbatim in a streamed delta.
+    // Wrongly "protected" would stream the raw candidate bytes straight out as literal
+    // visible text; correctly recognized as a real, unfenced call, they are buffered as
+    // a pending candidate instead and never appear verbatim in a streamed delta.
+    const streamedText = events
+      .map((event) =>
+        typeof event.delta === "string"
+          ? event.delta
+          : typeof event.content === "string"
+            ? event.content
+            : "",
+      )
+      .join("");
+    expect(streamedText).not.toContain('{"path":"example.txt"}');
+  });
+
   it("preserves candidate bytes after bounded protection history overflows", async () => {
     const opening = `\`\`\`text\n${"x".repeat(1_000_000)}`;
     const candidate = ["[read]", '{"path":"example.txt"}', "[/read]"].join("\n");

--- a/packages/tool-call-repair/src/stream-normalizer.test.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.test.ts
@@ -139,6 +139,9 @@ async function normalize(
       const scrubbed = scrubMessage(message, { preserveEmptyTextBlocks });
       return scrubbed ? { kind: "scrubbed", ...scrubbed } : undefined;
     },
+    // resolveTestFenceRanges protects exactly fenced regions, the shape the carried fence
+    // scan models, so these fence-suite tests opt the fast path in.
+    protectedRangesFenceCompatible: options.protectFences === true,
     resolveProtectedRanges: options.protectFences ? resolveTestFenceRanges : undefined,
   });
 }
@@ -752,6 +755,7 @@ describe("normalizePlainTextToolCallStreamEvents over-cap XML", () => {
         matcher,
         createPromotedToolCallEvents: () => [],
         normalizeTerminalMessage: () => undefined,
+        protectedRangesFenceCompatible: true,
         resolveProtectedRanges: (text) => {
           resolvedLengths.push(text.length);
           return [];
@@ -802,6 +806,7 @@ describe("normalizePlainTextToolCallStreamEvents over-cap XML", () => {
         matcher,
         createPromotedToolCallEvents: () => [],
         normalizeTerminalMessage: () => undefined,
+        protectedRangesFenceCompatible: true,
         resolveProtectedRanges: (text) => {
           resolverCalls += 1;
           return resolveTestFenceRanges(text);
@@ -813,6 +818,56 @@ describe("normalizePlainTextToolCallStreamEvents over-cap XML", () => {
     // response once per bracket delta (hundreds of full parses over a growing buffer).
     expect(resolverCalls).toBeLessThanOrEqual(3);
     expect(textDeltas(events).join("")).toBe(fenced);
+  });
+
+  it("still protects an unfenced caller-defined range when the fast path is not opted in", async () => {
+    // The carried fence scan only ever proves fence state. A resolver whose protected
+    // ranges are not fences at all (unlike resolveTestFenceRanges/findCodeRegions) would be
+    // silently bypassed if the stream trusted the fast path's "not protected" verdict for
+    // it, so this must go through the full resolver instead — this caller never opts in.
+    const OPEN_MARK = "<<PROTECT>>";
+    const CLOSE_MARK = "<<END>>";
+    const resolveMarkedRanges = (text: string) => {
+      const ranges: Array<{ end: number; start: number }> = [];
+      let cursor = 0;
+      for (;;) {
+        const start = text.indexOf(OPEN_MARK, cursor);
+        if (start === -1) {
+          break;
+        }
+        const close = text.indexOf(CLOSE_MARK, start + OPEN_MARK.length);
+        const end = close === -1 ? text.length : close + CLOSE_MARK.length;
+        ranges.push({ start, end });
+        cursor = end;
+      }
+      return ranges;
+    };
+    const call = ["[read]", '{"path":"secret.txt"}', "[/read]"].join("\n");
+    // A trailing newline keeps every line complete; an unfinished final line is a shape the
+    // fast path already declines on its own, which would mask the bug this test targets.
+    const text = `${OPEN_MARK}\n${call}\n${CLOSE_MARK}\n`;
+    const events = await collectNormalizedEvents(
+      [streamTextDelta(text), doneAssistantEvent("stop", textContent(text), "stop")],
+      {
+        matcher,
+        createPromotedToolCallEvents: () => [],
+        normalizeTerminalMessage: ({ message }) => {
+          const scrubbed = projectScrubbedPlainTextToolCallMessage({
+            matcher,
+            message,
+            resolveProtectedRanges: resolveMarkedRanges,
+          });
+          return scrubbed ? { kind: "scrubbed", ...scrubbed } : undefined;
+        },
+        resolveProtectedRanges: resolveMarkedRanges,
+      },
+    );
+
+    expect(textDeltas(events).join("")).toBe(text);
+    expect(events.at(-1)).toMatchObject({
+      type: "done",
+      message: { content: textContent(text), stopReason: "stop" },
+    });
   });
 
   it("still scrubs an unfenced call from live deltas and the terminal message", async () => {

--- a/packages/tool-call-repair/src/stream-normalizer.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.ts
@@ -42,6 +42,14 @@ export type PlainTextToolCallStreamNormalizerOptions = {
   matcher: PlainTextToolCallNameMatcher;
   /** Resolves source ranges that must remain literal user-visible text. */
   resolveProtectedRanges?: PlainTextToolCallProtectedRangeResolver;
+  /**
+   * Opts a fence-based `resolveProtectedRanges` into the incremental fast path so a
+   * candidate-shaped delta can skip a full re-parse (see protection-fast-path.ts's safety
+   * contract). Leave unset for any resolver whose protected ranges are not exactly CommonMark
+   * fenced/indented/inline code spans — the fast path only tracks fence state, so trusting it
+   * for a differently defined resolver would silently drop that resolver's protection.
+   */
+  protectedRangesFenceCompatible?: boolean;
   /** Promotes an eligible terminal snapshot or scrubs every recognized candidate. */
   normalizeTerminalMessage(params: {
     allowPromotion: boolean;
@@ -1369,11 +1377,14 @@ export async function* normalizePlainTextToolCallStreamEvents(
                 // Candidate-shaped text is rare in prose but constant in bracket-dense
                 // answers, so materializing and re-parsing the whole response here is
                 // quadratic. Ask the carried fence state first; it answers only what it
-                // can prove and yields to the full parse for everything else.
+                // can prove and yields to the full parse for everything else. Only a caller
+                // that opted in has promised its resolver's protection is exactly fence
+                // state, so an un-opted-in resolver always takes the full-parse path below
+                // and stays authoritative — the fast path must never silently stand in for it.
                 const carriedScan = authoritative ? protectionScanAtBlockStart : protectionScan;
                 let isProtectedAt =
                   partialProtection ??
-                  (protectionContextOverflow
+                  (protectionContextOverflow || !options.protectedRangesFenceCompatible
                     ? undefined
                     : resolveProtectionFastPath(carriedScan, incoming));
                 if (!isProtectedAt) {

--- a/packages/tool-call-repair/src/stream-normalizer.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.ts
@@ -489,6 +489,23 @@ function findPotentialCallStart(
   return null;
 }
 
+/**
+ * True when `partial` shows more text preceding `contentIndex` than `trackedLength`
+ * accounts for -- an earlier content block that was never streamed as its own delta, so
+ * the carried fence-state scan (which only ever sees streamed text) cannot have tracked
+ * it. The fast path must not answer for a candidate in this position; only a check
+ * against the partial's own authoritative text, or a full parse, can.
+ */
+function hasUntrackedPrecedingContext(
+  partial: unknown,
+  contentIndex: number,
+  trackedLength: number,
+): boolean {
+  const candidate = extractStandaloneCandidate(partial);
+  const part = candidate?.parts.find((entry) => entry.contentIndex === contentIndex);
+  return part !== undefined && part.start > trackedLength;
+}
+
 function resolvePartialProtectionCheck(params: {
   authoritative: boolean;
   contentIndex: number;
@@ -1375,8 +1392,17 @@ export async function* normalizePlainTextToolCallStreamEvents(
                 // state, so an un-opted-in resolver always takes the full-parse path below
                 // and stays authoritative — the fast path must never silently stand in for it.
                 const carriedScan = authoritative ? protectionScanAtBlockStart : protectionScan;
+                // protectionBlockStart is how much text the scan had tracked when this block
+                // began. If the partial shows more text preceding this block than that, an
+                // earlier block was never streamed as its own delta -- the scan never saw it
+                // and cannot be trusted here, whatever it claims for this block's own content.
+                const untrackedPrecedingContext = hasUntrackedPrecedingContext(
+                  incomingRecord.partial,
+                  eventContentIndex(incomingRecord),
+                  protectionBlockStart,
+                );
                 let isProtectedAt: ((offset: number) => boolean) | undefined =
-                  options.protectedRangesFenceCompatible
+                  !untrackedPrecedingContext && options.protectedRangesFenceCompatible
                     ? resolveProtectionFastPath(carriedScan, incoming)
                     : undefined;
                 if (!isProtectedAt) {

--- a/packages/tool-call-repair/src/stream-normalizer.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.ts
@@ -490,11 +490,14 @@ function findPotentialCallStart(
 }
 
 /**
- * True when `partial` shows more text preceding `contentIndex` than `trackedLength`
- * accounts for -- an earlier content block that was never streamed as its own delta, so
- * the carried fence-state scan (which only ever sees streamed text) cannot have tracked
- * it. The fast path must not answer for a candidate in this position; only a check
- * against the partial's own authoritative text, or a full parse, can.
+ * True when `partial` shows a different amount of text preceding `contentIndex` than
+ * `trackedLength` accounts for. The carried fence-state scan advances in event order;
+ * `partial`'s own per-block offsets are in content-index order. These normally agree,
+ * but not when a provider interleaves active blocks (an earlier block can stream after
+ * a later one) or when an earlier block was never streamed as its own delta at all --
+ * either way the scan's state does not correspond to "everything that precedes this
+ * block", in either direction, so it must not be trusted for a candidate here. Only a
+ * check against the partial's own authoritative text, or a full parse, can be.
  */
 function hasUntrackedPrecedingContext(
   partial: unknown,
@@ -503,7 +506,7 @@ function hasUntrackedPrecedingContext(
 ): boolean {
   const candidate = extractStandaloneCandidate(partial);
   const part = candidate?.parts.find((entry) => entry.contentIndex === contentIndex);
-  return part !== undefined && part.start > trackedLength;
+  return part !== undefined && part.start !== trackedLength;
 }
 
 function resolvePartialProtectionCheck(params: {
@@ -1392,10 +1395,12 @@ export async function* normalizePlainTextToolCallStreamEvents(
                 // state, so an un-opted-in resolver always takes the full-parse path below
                 // and stays authoritative — the fast path must never silently stand in for it.
                 const carriedScan = authoritative ? protectionScanAtBlockStart : protectionScan;
-                // protectionBlockStart is how much text the scan had tracked when this block
-                // began. If the partial shows more text preceding this block than that, an
-                // earlier block was never streamed as its own delta -- the scan never saw it
-                // and cannot be trusted here, whatever it claims for this block's own content.
+                // protectionBlockStart is how much text the scan had tracked (in event order)
+                // when this block began. If the partial's own content-order offset for this
+                // block disagrees, either an earlier block was never streamed as its own delta
+                // or blocks interleaved out of content-index order -- either way the scan's
+                // state does not correspond to this block's actual preceding text and cannot
+                // be trusted here, whatever it claims for this block's own content.
                 const untrackedPrecedingContext = hasUntrackedPrecedingContext(
                   incomingRecord.partial,
                   eventContentIndex(incomingRecord),

--- a/packages/tool-call-repair/src/stream-normalizer.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.ts
@@ -1165,6 +1165,11 @@ export async function* normalizePlainTextToolCallStreamEvents(
   let protectionContextOverflow = false;
   let protectionBlockContentIndex: number | undefined;
   let protectionBlockStart = 0;
+  // Whether this block's preceding-context prefix has been validated against the
+  // partial's own content-order text (see hasUntrackedPrecedingContext). Reset per
+  // block so it is derived once and reused for every candidate within it, rather than
+  // re-materializing and re-comparing the same preceding text on every candidate.
+  let protectionBlockPrefixTrusted: boolean | undefined;
   // Carried Markdown block state mirrors the protection context so a candidate delta can
   // skip re-parsing the whole response. `protectionScanAtBlockStart` matches the prefix an
   // authoritative delta uses (context sliced at protectionBlockStart); the live state
@@ -1180,6 +1185,7 @@ export async function* normalizePlainTextToolCallStreamEvents(
     protectionBlockContentIndex = contentIndex;
     protectionBlockStart = protectionContextLength;
     protectionScanAtBlockStart = cloneProtectionScanState(protectionScan);
+    protectionBlockPrefixTrusted = undefined;
   };
   const truncateProtectionContext = (length: number) => {
     while (protectionContextLength > length) {
@@ -1224,6 +1230,22 @@ export async function* normalizePlainTextToolCallStreamEvents(
     }
     const context = protectionChunks.join("");
     return authoritative ? context.slice(0, protectionBlockStart) : context;
+  };
+  // Reconstructs only the first `length` tracked characters, stopping as soon as enough
+  // chunks are collected instead of joining every chunk ever pushed. protectionChunks
+  // keeps growing with the CURRENT block's own advances, so joining it in full to read a
+  // fixed-size preceding-block prefix would itself be the quadratic cost this exists to
+  // avoid; this stays bounded by `length` (the preceding block's own size), not by
+  // however large the current, still-growing block gets.
+  const materializeBoundedPrefix = (length: number): string => {
+    let result = "";
+    for (const chunk of protectionChunks) {
+      if (result.length >= length) {
+        break;
+      }
+      result += chunk;
+    }
+    return result.slice(0, length);
   };
 
   const scrubSnapshot = (
@@ -1416,13 +1438,20 @@ export async function* normalizePlainTextToolCallStreamEvents(
                 // block disagrees, either an earlier block was never streamed as its own delta
                 // or blocks interleaved out of content-index order -- either way the scan's
                 // state does not correspond to this block's actual preceding text and cannot
-                // be trusted here, whatever it claims for this block's own content.
-                const untrackedPrecedingContext = hasUntrackedPrecedingContext(
-                  incomingRecord.partial,
-                  eventContentIndex(incomingRecord),
-                  protectionBlockStart,
-                  () => materializeProtectionPrefix(true),
-                );
+                // be trusted here, whatever it claims for this block's own content. The
+                // preceding text a block sees never changes across its own deltas, so this is
+                // derived once per block (protectionBlockPrefixTrusted, reset in
+                // beginProtectionBlock) instead of re-materializing and re-comparing it for
+                // every candidate the current block's own growing content turns up.
+                if (protectionBlockPrefixTrusted === undefined) {
+                  protectionBlockPrefixTrusted = !hasUntrackedPrecedingContext(
+                    incomingRecord.partial,
+                    eventContentIndex(incomingRecord),
+                    protectionBlockStart,
+                    () => materializeBoundedPrefix(protectionBlockStart),
+                  );
+                }
+                const untrackedPrecedingContext = !protectionBlockPrefixTrusted;
                 let isProtectedAt: ((offset: number) => boolean) | undefined =
                   !untrackedPrecedingContext && options.protectedRangesFenceCompatible
                     ? resolveProtectionFastPath(carriedScan, incoming)

--- a/packages/tool-call-repair/src/stream-normalizer.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.ts
@@ -1367,26 +1367,33 @@ export async function* normalizePlainTextToolCallStreamEvents(
                 // authoritative terminal snapshot decide instead of deleting literal content.
                 callStart = null;
               } else {
-                const partialProtection = resolvePartialProtectionCheck({
-                  authoritative,
-                  contentIndex: eventContentIndex(incomingRecord),
-                  incoming,
-                  partial: incomingRecord.partial,
-                  resolveProtectedRanges: options.resolveProtectedRanges,
-                });
                 // Candidate-shaped text is rare in prose but constant in bracket-dense
                 // answers, so materializing and re-parsing the whole response here is
                 // quadratic. Ask the carried fence state first; it answers only what it
-                // can prove and yields to the full parse for everything else. Only a caller
+                // can prove and yields to a full parse for everything else. Only a caller
                 // that opted in has promised its resolver's protection is exactly fence
                 // state, so an un-opted-in resolver always takes the full-parse path below
                 // and stays authoritative — the fast path must never silently stand in for it.
                 const carriedScan = authoritative ? protectionScanAtBlockStart : protectionScan;
-                let isProtectedAt =
-                  partialProtection ??
-                  (protectionContextOverflow || !options.protectedRangesFenceCompatible
-                    ? undefined
-                    : resolveProtectionFastPath(carriedScan, incoming));
+                let isProtectedAt: ((offset: number) => boolean) | undefined =
+                  options.protectedRangesFenceCompatible
+                    ? resolveProtectionFastPath(carriedScan, incoming)
+                    : undefined;
+                if (!isProtectedAt) {
+                  // The fast path could not prove the verdict from carried state (an
+                  // un-opted-in resolver, or a delimiter it cannot classify). Recover from
+                  // the provider's own cumulative "partial" snapshot when one validates
+                  // against this exact delta — providers like OpenAI-completions and
+                  // Mistral attach it to every text delta, but this is still a full parse,
+                  // so it must never run ahead of the fast path above on the common case.
+                  isProtectedAt = resolvePartialProtectionCheck({
+                    authoritative,
+                    contentIndex: eventContentIndex(incomingRecord),
+                    incoming,
+                    partial: incomingRecord.partial,
+                    resolveProtectedRanges: options.resolveProtectedRanges,
+                  });
+                }
                 if (!isProtectedAt) {
                   const protectionPrefix = materializeProtectionPrefix(authoritative);
                   const protectedRanges = options.resolveProtectedRanges(

--- a/packages/tool-call-repair/src/stream-normalizer.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.ts
@@ -1815,6 +1815,12 @@ export async function* normalizePlainTextToolCallStreamEvents(
           );
           if (classification.kind === "false-positive") {
             yield* replayFalsePositiveCandidate(pending);
+            // Replayed text becomes ordinary visible text going forward, same as the
+            // false-positive branch in the main delta loop above -- without this, the
+            // carried fence-state scan silently falls behind what was actually streamed,
+            // and a later candidate inside a fence this replay opened would wrongly
+            // report unprotected.
+            advanceProtectionContext(pending.buffer);
             pending = undefined;
             continue;
           }

--- a/packages/tool-call-repair/src/stream-normalizer.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.ts
@@ -507,17 +507,23 @@ function findPotentialCallStart(
  * only this rarer case pays for materializing it, and its cost is bounded by the
  * (typically small, fixed) preceding-block size, not by however large the current
  * block's own growing content is.
+ *
+ * `partial` is optional on every event, so a delta can arrive with none at all -- that
+ * proves nothing either way, and returns `undefined` rather than `false`, so a caller
+ * caching the verdict for reuse across a block's later deltas knows not to lock in
+ * "trusted" from an absence of data; a later delta in the same block that does carry a
+ * partial (interleaved content, or simply the first one to include it) still gets checked.
  */
 function hasUntrackedPrecedingContext(
   partial: unknown,
   contentIndex: number,
   trackedLength: number,
   trackedPrefix: () => string,
-): boolean {
+): boolean | undefined {
   const candidate = extractStandaloneCandidate(partial);
   const part = candidate?.parts.find((entry) => entry.contentIndex === contentIndex);
   if (!candidate || !part) {
-    return false;
+    return undefined;
   }
   if (part.start !== trackedLength) {
     return true;
@@ -1439,19 +1445,30 @@ export async function* normalizePlainTextToolCallStreamEvents(
                 // or blocks interleaved out of content-index order -- either way the scan's
                 // state does not correspond to this block's actual preceding text and cannot
                 // be trusted here, whatever it claims for this block's own content. The
-                // preceding text a block sees never changes across its own deltas, so this is
-                // derived once per block (protectionBlockPrefixTrusted, reset in
-                // beginProtectionBlock) instead of re-materializing and re-comparing it for
-                // every candidate the current block's own growing content turns up.
+                // preceding text a block sees never changes across its own deltas, so a
+                // confirmed verdict is derived once per block (protectionBlockPrefixTrusted,
+                // reset in beginProtectionBlock) instead of re-materializing and re-comparing
+                // it for every candidate the current block's own growing content turns up. A
+                // delta with no partial at all proves nothing, so it is never cached as
+                // "trusted" -- the next candidate in this block gets a fresh chance to confirm
+                // it from a partial that does arrive, rather than locking in a default.
                 if (protectionBlockPrefixTrusted === undefined) {
-                  protectionBlockPrefixTrusted = !hasUntrackedPrecedingContext(
+                  const untracked = hasUntrackedPrecedingContext(
                     incomingRecord.partial,
                     eventContentIndex(incomingRecord),
                     protectionBlockStart,
                     () => materializeBoundedPrefix(protectionBlockStart),
                   );
+                  if (untracked !== undefined) {
+                    protectionBlockPrefixTrusted = !untracked;
+                  }
                 }
-                const untrackedPrecedingContext = !protectionBlockPrefixTrusted;
+                // No partial ever seen for this block is not evidence against the scan --
+                // there is nothing to contradict it with, so the scan (built only from what
+                // this normalizer itself advanced, in order) stays the sole source of truth
+                // and is trusted by default. Only an explicit mismatch, once confirmed and
+                // cached above, flips this to distrust.
+                const untrackedPrecedingContext = protectionBlockPrefixTrusted === false;
                 let isProtectedAt: ((offset: number) => boolean) | undefined =
                   !untrackedPrecedingContext && options.protectedRangesFenceCompatible
                     ? resolveProtectionFastPath(carriedScan, incoming)

--- a/packages/tool-call-repair/src/stream-normalizer.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.ts
@@ -490,23 +490,39 @@ function findPotentialCallStart(
 }
 
 /**
- * True when `partial` shows a different amount of text preceding `contentIndex` than
- * `trackedLength` accounts for. The carried fence-state scan advances in event order;
- * `partial`'s own per-block offsets are in content-index order. These normally agree,
- * but not when a provider interleaves active blocks (an earlier block can stream after
- * a later one) or when an earlier block was never streamed as its own delta at all --
- * either way the scan's state does not correspond to "everything that precedes this
- * block", in either direction, so it must not be trusted for a candidate here. Only a
- * check against the partial's own authoritative text, or a full parse, can be.
+ * True when `partial` shows different text preceding `contentIndex` than the carried
+ * scan tracked. The scan advances in event order; `partial`'s own per-block offsets are
+ * in content-index order. These normally agree, but not when a provider interleaves
+ * active blocks (an earlier block can stream after a later one) or when an earlier
+ * block was never streamed as its own delta at all -- either way the scan's state does
+ * not correspond to "everything that precedes this block", so it must not be trusted
+ * for a candidate here. Only a check against the partial's own authoritative text, or a
+ * full parse, can be.
+ *
+ * A length mismatch alone already proves this (checked first, and cheaply, since it
+ * needs no materialized prefix). Matching lengths do not prove agreement, though --
+ * interleaved blocks of the same length streamed out of order produce the same tracked
+ * length from different actual text (e.g. opposite fence state) -- so a same-length,
+ * nonzero prefix still needs a real text comparison. `trackedPrefix` is called lazily:
+ * only this rarer case pays for materializing it, and its cost is bounded by the
+ * (typically small, fixed) preceding-block size, not by however large the current
+ * block's own growing content is.
  */
 function hasUntrackedPrecedingContext(
   partial: unknown,
   contentIndex: number,
   trackedLength: number,
+  trackedPrefix: () => string,
 ): boolean {
   const candidate = extractStandaloneCandidate(partial);
   const part = candidate?.parts.find((entry) => entry.contentIndex === contentIndex);
-  return part !== undefined && part.start !== trackedLength;
+  if (!candidate || !part) {
+    return false;
+  }
+  if (part.start !== trackedLength) {
+    return true;
+  }
+  return part.start > 0 && candidate.text.slice(0, part.start) !== trackedPrefix();
 }
 
 function resolvePartialProtectionCheck(params: {
@@ -1405,6 +1421,7 @@ export async function* normalizePlainTextToolCallStreamEvents(
                   incomingRecord.partial,
                   eventContentIndex(incomingRecord),
                   protectionBlockStart,
+                  () => materializeProtectionPrefix(true),
                 );
                 let isProtectedAt: ((offset: number) => boolean) | undefined =
                   !untrackedPrecedingContext && options.protectedRangesFenceCompatible

--- a/packages/tool-call-repair/src/stream-normalizer.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.ts
@@ -489,46 +489,58 @@ function findPotentialCallStart(
   return null;
 }
 
+/** A confirmed preceding-context verdict, keyed by the partial's own reported length. */
+type PrecedingContextVerdict = { precedingLength: number; trusted: boolean };
+
 /**
- * True when `partial` shows different text preceding `contentIndex` than the carried
- * scan tracked. The scan advances in event order; `partial`'s own per-block offsets are
- * in content-index order. These normally agree, but not when a provider interleaves
- * active blocks (an earlier block can stream after a later one) or when an earlier
- * block was never streamed as its own delta at all -- either way the scan's state does
- * not correspond to "everything that precedes this block", so it must not be trusted
- * for a candidate here. Only a check against the partial's own authoritative text, or a
- * full parse, can be.
+ * Decides whether the carried fence-state scan can be trusted for a candidate in
+ * `contentIndex`, reusing a cached verdict from an earlier delta in the same block when
+ * it is still known to apply.
  *
- * A length mismatch alone already proves this (checked first, and cheaply, since it
- * needs no materialized prefix). Matching lengths do not prove agreement, though --
- * interleaved blocks of the same length streamed out of order produce the same tracked
- * length from different actual text (e.g. opposite fence state) -- so a same-length,
- * nonzero prefix still needs a real text comparison. `trackedPrefix` is called lazily:
- * only this rarer case pays for materializing it, and its cost is bounded by the
- * (typically small, fixed) preceding-block size, not by however large the current
- * block's own growing content is.
+ * The scan advances in event order; `partial`'s own per-block offsets are in
+ * content-index order. These normally agree, but not when a provider interleaves active
+ * blocks (an earlier block can stream after a later one), when an earlier block was
+ * never streamed as its own delta at all, or when an earlier block is itself still
+ * actively streaming and grows between two candidate checks in a later block -- so the
+ * scan's state does not correspond to "everything that precedes this block" and must
+ * not be trusted without checking the partial's own reported preceding text.
  *
  * `partial` is optional on every event, so a delta can arrive with none at all -- that
- * proves nothing either way, and returns `undefined` rather than `false`, so a caller
- * caching the verdict for reuse across a block's later deltas knows not to lock in
- * "trusted" from an absence of data; a later delta in the same block that does carry a
- * partial (interleaved content, or simply the first one to include it) still gets checked.
+ * proves nothing either way and, with no cache to fall back on either, defaults to
+ * trusting the scan (there is nothing to contradict it with; it remains the only source
+ * of truth this normalizer itself built, in order).
+ *
+ * A cached verdict is reused only when a later delta's own reported preceding length
+ * (`part.start`) exactly matches the length the cache was validated against -- a
+ * still-evolving earlier block changes that length, invalidating the cache and forcing
+ * a fresh comparison, rather than trusting a verdict that predates the earlier block's
+ * own growth. A length match alone does not otherwise prove agreement -- interleaved
+ * blocks of the same length streamed out of order can produce the same tracked length
+ * from different actual text (e.g. opposite fence state) -- so a fresh, same-length,
+ * nonzero-length comparison still needs a real text comparison. `trackedPrefix` is
+ * called lazily: only an uncached (or invalidated) comparison pays for materializing it,
+ * and its cost is bounded by the (typically small, fixed) preceding-block size, not by
+ * however large the current block's own growing content is.
  */
-function hasUntrackedPrecedingContext(
+function resolvePrecedingContextTrust(
   partial: unknown,
   contentIndex: number,
   trackedLength: number,
   trackedPrefix: () => string,
-): boolean | undefined {
+  cached: PrecedingContextVerdict | undefined,
+): { cache: PrecedingContextVerdict | undefined; trusted: boolean } {
   const candidate = extractStandaloneCandidate(partial);
   const part = candidate?.parts.find((entry) => entry.contentIndex === contentIndex);
   if (!candidate || !part) {
-    return undefined;
+    return { cache: cached, trusted: cached?.trusted ?? true };
   }
-  if (part.start !== trackedLength) {
-    return true;
+  if (cached && cached.precedingLength === part.start) {
+    return { cache: cached, trusted: cached.trusted };
   }
-  return part.start > 0 && candidate.text.slice(0, part.start) !== trackedPrefix();
+  const trusted =
+    part.start === trackedLength &&
+    (part.start === 0 || candidate.text.slice(0, part.start) === trackedPrefix());
+  return { cache: { precedingLength: part.start, trusted }, trusted };
 }
 
 function resolvePartialProtectionCheck(params: {
@@ -1171,11 +1183,12 @@ export async function* normalizePlainTextToolCallStreamEvents(
   let protectionContextOverflow = false;
   let protectionBlockContentIndex: number | undefined;
   let protectionBlockStart = 0;
-  // Whether this block's preceding-context prefix has been validated against the
-  // partial's own content-order text (see hasUntrackedPrecedingContext). Reset per
-  // block so it is derived once and reused for every candidate within it, rather than
-  // re-materializing and re-comparing the same preceding text on every candidate.
-  let protectionBlockPrefixTrusted: boolean | undefined;
+  // This block's cached preceding-context trust verdict (see resolvePrecedingContextTrust),
+  // keyed by the preceding length it was validated against. Reset per block so it starts
+  // fresh for each one, and invalidated within a block if a later delta's partial reports
+  // a different preceding length than the cache was validated against (an earlier block
+  // that is itself still actively streaming can grow between two candidate checks here).
+  let protectionBlockPrefixVerdict: PrecedingContextVerdict | undefined;
   // Carried Markdown block state mirrors the protection context so a candidate delta can
   // skip re-parsing the whole response. `protectionScanAtBlockStart` matches the prefix an
   // authoritative delta uses (context sliced at protectionBlockStart); the live state
@@ -1191,7 +1204,7 @@ export async function* normalizePlainTextToolCallStreamEvents(
     protectionBlockContentIndex = contentIndex;
     protectionBlockStart = protectionContextLength;
     protectionScanAtBlockStart = cloneProtectionScanState(protectionScan);
-    protectionBlockPrefixTrusted = undefined;
+    protectionBlockPrefixVerdict = undefined;
   };
   const truncateProtectionContext = (length: number) => {
     while (protectionContextLength > length) {
@@ -1441,34 +1454,24 @@ export async function* normalizePlainTextToolCallStreamEvents(
                 const carriedScan = authoritative ? protectionScanAtBlockStart : protectionScan;
                 // protectionBlockStart is how much text the scan had tracked (in event order)
                 // when this block began. If the partial's own content-order offset for this
-                // block disagrees, either an earlier block was never streamed as its own delta
-                // or blocks interleaved out of content-index order -- either way the scan's
-                // state does not correspond to this block's actual preceding text and cannot
-                // be trusted here, whatever it claims for this block's own content. The
-                // preceding text a block sees never changes across its own deltas, so a
-                // confirmed verdict is derived once per block (protectionBlockPrefixTrusted,
-                // reset in beginProtectionBlock) instead of re-materializing and re-comparing
-                // it for every candidate the current block's own growing content turns up. A
-                // delta with no partial at all proves nothing, so it is never cached as
-                // "trusted" -- the next candidate in this block gets a fresh chance to confirm
-                // it from a partial that does arrive, rather than locking in a default.
-                if (protectionBlockPrefixTrusted === undefined) {
-                  const untracked = hasUntrackedPrecedingContext(
-                    incomingRecord.partial,
-                    eventContentIndex(incomingRecord),
-                    protectionBlockStart,
-                    () => materializeBoundedPrefix(protectionBlockStart),
-                  );
-                  if (untracked !== undefined) {
-                    protectionBlockPrefixTrusted = !untracked;
-                  }
-                }
-                // No partial ever seen for this block is not evidence against the scan --
-                // there is nothing to contradict it with, so the scan (built only from what
-                // this normalizer itself advanced, in order) stays the sole source of truth
-                // and is trusted by default. Only an explicit mismatch, once confirmed and
-                // cached above, flips this to distrust.
-                const untrackedPrecedingContext = protectionBlockPrefixTrusted === false;
+                // block disagrees, either an earlier block was never streamed as its own delta,
+                // blocks interleaved out of content-index order, or an earlier block is itself
+                // still growing -- either way the scan's state does not correspond to this
+                // block's actual preceding text and cannot be trusted here, whatever it claims
+                // for this block's own content. resolvePrecedingContextTrust caches its
+                // verdict per block (reset in beginProtectionBlock) but invalidates it the
+                // moment a later delta's own reported preceding length changes, so an earlier
+                // block growing mid-stream still gets a fresh comparison rather than reusing a
+                // verdict that predates that growth.
+                const precedingContextTrust = resolvePrecedingContextTrust(
+                  incomingRecord.partial,
+                  eventContentIndex(incomingRecord),
+                  protectionBlockStart,
+                  () => materializeBoundedPrefix(protectionBlockStart),
+                  protectionBlockPrefixVerdict,
+                );
+                protectionBlockPrefixVerdict = precedingContextTrust.cache;
+                const untrackedPrecedingContext = !precedingContextTrust.trusted;
                 let isProtectedAt: ((offset: number) => boolean) | undefined =
                   !untrackedPrecedingContext && options.protectedRangesFenceCompatible
                     ? resolveProtectionFastPath(carriedScan, incoming)

--- a/packages/tool-call-repair/src/stream-normalizer.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.ts
@@ -20,6 +20,12 @@ import {
 } from "./grammar.js";
 import { scanPlainTextToolCall, type PlainTextToolCallScan } from "./payload.js";
 import type { PlainTextToolCallMessageProjection } from "./promote.js";
+import {
+  advanceProtectionScanState,
+  cloneProtectionScanState,
+  createProtectionScanState,
+  resolveProtectionFastPath,
+} from "./protection-fast-path.js";
 
 export type { PlainTextToolCallNameMatcher } from "./contracts.js";
 
@@ -1115,6 +1121,13 @@ export async function* normalizePlainTextToolCallStreamEvents(
   let protectionContextOverflow = false;
   let protectionBlockContentIndex: number | undefined;
   let protectionBlockStart = 0;
+  // Carried Markdown block state mirrors the protection context so a candidate delta can
+  // skip re-parsing the whole response. `protectionScanAtBlockStart` matches the prefix an
+  // authoritative delta uses (context sliced at protectionBlockStart); the live state
+  // matches the full context. Both stay in sync because every context mutation routes
+  // through advanceProtectionContext/beginProtectionBlock.
+  let protectionScan = createProtectionScanState();
+  let protectionScanAtBlockStart = createProtectionScanState();
 
   const beginProtectionBlock = (contentIndex: number) => {
     if (protectionBlockContentIndex === contentIndex) {
@@ -1122,6 +1135,7 @@ export async function* normalizePlainTextToolCallStreamEvents(
     }
     protectionBlockContentIndex = contentIndex;
     protectionBlockStart = protectionContextLength;
+    protectionScanAtBlockStart = cloneProtectionScanState(protectionScan);
   };
   const truncateProtectionContext = (length: number) => {
     while (protectionContextLength > length) {
@@ -1146,6 +1160,7 @@ export async function* normalizePlainTextToolCallStreamEvents(
     }
     if (resetActiveBlock) {
       truncateProtectionContext(protectionBlockStart);
+      protectionScan = cloneProtectionScanState(protectionScanAtBlockStart);
     }
     if (protectionContextLength + text.length > MAX_PROTECTION_CONTEXT_CHARS) {
       protectionChunks.length = 0;
@@ -1155,6 +1170,7 @@ export async function* normalizePlainTextToolCallStreamEvents(
     }
     if (text) {
       protectionChunks.push(text);
+      advanceProtectionScanState(protectionScan, text);
     }
     protectionContextLength += text.length;
   };
@@ -1350,24 +1366,29 @@ export async function* normalizePlainTextToolCallStreamEvents(
                   partial: incomingRecord.partial,
                   resolveProtectedRanges: options.resolveProtectedRanges,
                 });
-                // Candidate-shaped text is rare. Materialize prior visible text only when the
-                // provider did not supply an authoritative cumulative partial.
-                const protectionPrefix = partialProtection
-                  ? ""
-                  : materializeProtectionPrefix(authoritative);
-                const protectedRanges = partialProtection
-                  ? undefined
-                  : options.resolveProtectedRanges(`${protectionPrefix}${incoming}`);
+                // Candidate-shaped text is rare in prose but constant in bracket-dense
+                // answers, so materializing and re-parsing the whole response here is
+                // quadratic. Ask the carried fence state first; it answers only what it
+                // can prove and yields to the full parse for everything else.
+                const carriedScan = authoritative ? protectionScanAtBlockStart : protectionScan;
+                let isProtectedAt =
+                  partialProtection ??
+                  (protectionContextOverflow
+                    ? undefined
+                    : resolveProtectionFastPath(carriedScan, incoming));
+                if (!isProtectedAt) {
+                  const protectionPrefix = materializeProtectionPrefix(authoritative);
+                  const protectedRanges = options.resolveProtectedRanges(
+                    `${protectionPrefix}${incoming}`,
+                  );
+                  isProtectedAt = (offset) =>
+                    isOffsetInProtectedRanges(protectionPrefix.length + offset, protectedRanges);
+                }
                 callStart = findPotentialCallStart(
                   incoming,
                   atLineStart,
                   options.matcher,
-                  partialProtection ??
-                    ((offset) =>
-                      isOffsetInProtectedRanges(
-                        protectionPrefix.length + offset,
-                        protectedRanges ?? [],
-                      )),
+                  isProtectedAt,
                 );
               }
             }
@@ -1700,6 +1721,11 @@ export async function* normalizePlainTextToolCallStreamEvents(
         protectionContextOverflow = false;
         protectionBlockContentIndex = undefined;
         protectionBlockStart = 0;
+        // Carried block state belongs to the completion that just ended. Without this a
+        // following completion would start inside its fence while the materialized
+        // context is empty, and the fast path would call its first line protected.
+        protectionScan = createProtectionScanState();
+        protectionScanAtBlockStart = createProtectionScanState();
         if (options.stopAfterDone) {
           return;
         }

--- a/src/agents/embedded-agent-runner/run/attempt-tool-call-text-promotion.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-call-text-promotion.ts
@@ -120,6 +120,10 @@ function wrapStreamPromoteStandaloneTextToolCalls(
       createPromotedToolCallEvents: createPromotedPlainTextToolCallEvents,
       matcher,
       normalizeTerminalMessage,
+      // findCodeRegions resolves exactly the CommonMark fenced/indented/inline code shapes
+      // the carried fence scan models (and yields to the full parse for the rest), so its
+      // protection is safe to trust from the fast path.
+      protectedRangesFenceCompatible: true,
       resolveProtectedRanges: findCodeRegions,
     });
   };

--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -168,6 +168,10 @@ function wrapPlainTextToolCallStream(
             matcher,
             preserveEmptyTextBlocks,
           ),
+        // findCodeRegions resolves exactly the CommonMark fenced/indented/inline code shapes
+        // the carried fence scan models (and yields to the full parse for the rest), so its
+        // protection is safe to trust from the fast path.
+        protectedRangesFenceCompatible: true,
         resolveProtectedRanges: findCodeRegions,
         stopAfterDone: true,
       });


### PR DESCRIPTION
Closes #119478

## What Problem This Solves

Fixes an issue where operators streaming a long, bracket-dense assistant answer would see the agent stall for seconds with no visible progress, while the reply it eventually emitted was byte-identical to what the model produced.

Ordinary coding-agent output triggers it: TOML and INI configuration sections, Markdown link reference lists, JSON arrays, and pasted timestamped log lines all put a `[` at the start of many lines. A 27 KB answer burns ~3.9 seconds of pure CPU on work that changes nothing; a 54 KB answer burns ~15 seconds. Being inside a fenced code block does not help, and any agent with at least one tool is wrapped, so a default configuration is exposed.

## Why This Change Was Made

The plain-text tool-call stream normalizer decided Markdown protection by materializing the **entire accumulated response** and re-parsing it as CommonMark on **every candidate-shaped delta**. Since any line-start `[` that could begin a tool name is a candidate, that is one full-buffer parse per line over a buffer bounded only by `MAX_PROTECTION_CONTEXT_CHARS = 1_000_000` — total work quadratic in response size. Introduced by `a1c689e375e` / #117089, which added the protection-prefix materialization.

This change carries fenced-code state forward as visible text is appended and answers protection from that state when it can prove the verdict, instead of re-parsing.

The design is deliberately conservative, because this is protection logic and both failure directions are worse than the perf bug: claiming "protected" when it is not leaves a real tool call unscrubbed, and claiming "not protected" when it is deletes literal fenced content — exactly what #117089 fixed. So the tracker models fenced blocks only and **declines**, deferring to the authoritative full parse, for inline code spans, indented code (any leading tab, or any four-space run — indentation counts in columns), block quotes, lists, unfinished lines outside a fence, and bare `\r` line endings. It applies CommonMark's exact whitespace rules: only spaces and tabs may follow a closing fence (U+00A0 does not close one), and a backtick fence whose info string contains a backtick is not a fence at all. If it sees a delimiter it cannot classify, fence parity is permanently unknown and it stops answering for the rest of the stream.

Non-goals: no change to `markdown-core`, `code-regions.ts`, or any caller; no new dependency, config, or env surface. Every pre-existing test passes **unmodified**, including the repo's own pinned resolver-count contracts.

## User Impact

Long bracket-dense replies stream without the multi-second stall. On the measured 27 KB answer the normalizer drops from 600 whole-response Markdown parses and 3881 ms to 0 parses and 43 ms, and doubling the response no longer quadruples the work. Emitted text is unchanged — this removes wasted CPU, not behavior.

## Evidence

Before/after from a harness driving the **real** shared stream normalizer with the real `findCodeRegions` resolver and the real allowed-tool-name matcher; only the provider socket is replaced by a local event source emitting token-sized deltas.

```
BEFORE (upstream/main, unmodified)
  A. bracket-dense answer, all brackets inside code fences
    response bytes=27019  streamed deltas=7323  full-text Markdown parses=600  chars re-parsed=8092730  normalizer wall time=3881 ms  output identical to input=true
  B. NEGATIVE CONTROL: same document, '[' replaced by '('
    response bytes=27019  streamed deltas=6755  full-text Markdown parses=0  chars re-parsed=0  normalizer wall time=24 ms  output identical to input=true
  C. same shape, response size doubled
    response bytes=54259  streamed deltas=14763  full-text Markdown parses=1200  chars re-parsed=32434810  normalizer wall time=15260 ms  output identical to input=true
scaling A -> C: bytes x2.01, parses x2.00, chars re-parsed x4.01
FAIL: bracket-dense parses A=600 C=1200 (budget 8)

AFTER (this branch)
  A. bracket-dense answer, all brackets inside code fences
    response bytes=27019  streamed deltas=7323  full-text Markdown parses=0  chars re-parsed=0  normalizer wall time=43 ms  output identical to input=true
  B. NEGATIVE CONTROL: same document, '[' replaced by '('
    response bytes=27019  streamed deltas=6755  full-text Markdown parses=0  chars re-parsed=0  normalizer wall time=27 ms  output identical to input=true
  C. same shape, response size doubled
    response bytes=54259  streamed deltas=14763  full-text Markdown parses=0  chars re-parsed=0  normalizer wall time=59 ms  output identical to input=true
scaling A -> C: bytes x2.01, parses x0.00, chars re-parsed x0.00
PASS: bracket-dense parses A=0 C=0 (budget 8), control=0, outputs unchanged=true
```

**Safety proof.** A conservative fast path is only safe if it never contradicts the authoritative parser, so a differential harness compares every offset the fast path is willing to answer against real `findCodeRegions`:

```
documents=433 (33 curated + 400 fuzz)  offsets answered by fast path=6926
PASS: fast path agreed with findCodeRegions on every offset it answered (6926 checks, 0 disagreements)
```

The corpus covers backtick and tilde fences, longer close runs, unclosed and indented fences, inline spans across lines, indented code, block quotes, bullet and ordered lists, fences inside quotes and lists, CRLF and bare CR, consecutive fences, info strings, NBSP fence padding, and tab- and space+tab-indented code — each replayed through five streaming split strategies (per-char, per-4-char, per-bracket, per-line, whole).

That harness plus four rounds of `codex review` caught seven real defects in the fast path during development: fence-opening line offsets, container-scoped fence parity, backtick info strings, NBSP fence padding, tab indentation, space+tab indentation, and carried state leaking across a `done` boundary. Each is now pinned by a unit test, and I verified the riskiest ones fail when their fix is reverted.

### Tests

- `node scripts/run-vitest.mjs packages/tool-call-repair` — 170 passed (4 files), including the pre-existing resolver-count contracts, unmodified.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-tool-call-text-promotion*.test.ts src/plugin-sdk/provider-stream-shared.test.ts src/shared/text/assistant-visible-text.test.ts` — passed across the normalizer's callers.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json`, `oxfmt --check`, `scripts/run-oxlint.mjs` — clean.

New coverage: a dedicated `protection-fast-path.test.ts` pinning each decline rule, a bounded-resolver-count test over a bracket-dense fenced answer, an inline-span case pinning the full-parse fallback, and a two-completion test for the `done` reset.

Production delta is +257 lines against +171 test lines. That buys removal of an unbounded quadratic term on every streamed reply; I did not find a way to reach linear behavior without carried state, since `findMarkdownCodeSpans` is a whole-document CommonMark parse with no resumable entry point, and extending it would change shared `markdown-core` used well beyond this path.

## Real behavior proof

Behavior addressed: streaming a long bracket-dense assistant answer made the shared tool-call stream normalizer re-parse the entire accumulated response as Markdown once per bracket-shaped delta, burning seconds of CPU that changed nothing in the emitted text.

Real environment tested: the real shared stream normalizer (`normalizePlainTextToolCallStreamEvents`) with the real `findCodeRegions` Markdown resolver and the real allowed-tool-name matcher that `wrapStreamPromoteStandaloneTextToolCalls` builds for every embedded agent attempt (`read,write,edit,bash,task`). Only the upstream provider socket was replaced, by a local async iterable emitting token-sized `text_delta` events. macOS 25.6.0, node v22.22.3, branch rebased on current `main`.

Exact steps or command run after this patch: `node --import tsx .agents/proof/pr119478-stream-normalizer-perf.mts` and `node --import tsx .agents/proof/pr119478-fastpath-differential.mts`

Evidence after fix: the AFTER block and differential result above — 0 full-response parses (from 600), 43 ms (from 3881 ms), output byte-identical, and 6926 differential checks with 0 disagreements against the authoritative parser.

Observed result after fix: the 27 KB bracket-dense answer went from 600 whole-response Markdown parses and 3881 ms to 0 parses and 43 ms; doubling the response no longer quadruples the re-parsed characters (x4.01 before, x0.00 after); the `(` control is unchanged; emitted text stays byte-identical in every run.

What was not tested: no live hosted-model run, so real provider token boundaries were approximated by 4-character deltas with each `[` as its own delta. Wall time was measured on one idle macOS machine only. The user-visible shape of the stall was not observed on a live channel. The fast path is not exercised against non-CommonMark resolvers, since `findCodeRegions` is the only `resolveProtectedRanges` implementation in the repo.

---

AI-assisted: authored with Claude (Opus 5) and reviewed across four rounds with `codex review`. All measurements, the differential corpus, and the test runs are real local output.


---

### Update — transport-boundary proof

The previous benchmark was rejected for hand-feeding an async iterable rather than driving a real transport. This replaces it: real loopback HTTP, real wire-protocol parsing, real transport, real `createPlainTextToolCallCompatWrapper`, real `findCodeRegions`. Only the network endpoint is mocked. Instrumentation counts `findCodeRegions` calls and characters re-parsed via a load-time source rewrite, so **no repo file is modified**, and the harness throws if its anchor never patched — a vacuous run cannot pass silently.

Payload: bracket-dense TOML inside a fenced block, chunked so each section heading arrives as a delta ending exactly at `[`, which is what makes `scanBracketOpening` return `kind:"prefix"` (`payload.ts:171-176`) and trips protection resolution on nearly every line.

**Ollama transport** (`extensions/ollama/src/stream.runtime.ts:1416`, the wrapper's canonical consumer). BEFORE = the PR's exact base `599b46c49bb`; AFTER = branch tip; median of 3.

| N | payload | metric | BEFORE | AFTER | change |
|---|---|---|---|---|---|
| 150 sections | 49,429 chars | `findCodeRegions` calls | 152 | **2** | 76× |
| | | chars re-parsed | 3,783,083 | **98,858** | 38.3× |
| | | wall (median) | 328.4 ms | **43.7 ms** | 7.5× |
| 300 sections | 98,779 chars | `findCodeRegions` calls | 302 | **2** | 151× |
| | | chars re-parsed | 14,968,508 | **197,558** | 75.8× |
| | | wall (median) | 1071.5 ms | **114.2 ms** | 9.4× |

Scaling at payload ×2.00 — BEFORE: chars ×3.96, wall ×3.26 (matching the issue's reported ×1.99 bytes → ×3.39 wall). AFTER: chars ×2.00, wall ×2.61. Quadratic → linear.

**Emitted text is byte-identical**, asserted three ways: SHA-256 matches BEFORE/AFTER at both sizes (`fda0dfdc…` at N, `bfdd4c50…` at 2N), delta counts match (754 / 1504 on both sides), and the harness hard-fails if either the `done` message or the concatenated `text_delta` stream differs from the source payload.

**The wrapper was genuinely engaged**, not bypassed — a control run with `tools: []` (so `wrapPlainTextToolCallStream` early-returns at `provider-stream-shared.ts:143-146`) gives **0** `findCodeRegions` calls against byte-identical output, versus 152/2 when a tool is present.

### One result that complicates the story, reported rather than omitted

**The OpenAI-completions transport shows no improvement for this defect.** `processCompletionsStream` runs the reasoning-tag text partitioner (`packages/markdown-core/src/reasoning-tags.ts`), which holds all text while a Markdown code fence is open and releases it as one delta at fence close — 754 SSE chunks collapse to 3 `text_delta` events, so the fenced pathological case never reaches the normalizer delta-by-delta there.

I then measured an *unfenced* bracket-dense payload on that transport: 452 calls / 3,785,009 chars at N and 902 / 14,972,384 at 2N — **identical before and after**. That is the fast path's own safety contract behaving as documented: `resolveProtectionFastPath` returns `undefined` for an unfinished line outside a fence (`protection-fast-path.ts:196-200`), so it declines and the authoritative full parse runs. No regression, and no gain. The measured win is at the Ollama boundary.

That narrows the claim: this fixes the quadratic parse for transports that deliver fenced text delta-by-delta, and is inert (correctly) where the partitioner already coalesces it or where the fast path declines by contract.

**Remaining gaps.** Single-machine wall clock (macOS, Node v24.16.0) — call counts and chars re-parsed are deterministic, wall time is median-of-3 with real spread (BEFORE 2N ranged 1071–2374 ms across sessions), so the order of magnitude and the scaling exponent are the robust parts, not the exact milliseconds. LM Studio composes over `streamSimple` and so inherits the OpenAI-completions behaviour above; xAI also wraps but was not separately measured. No Crabbox/Testbox breadth run.

`node scripts/run-vitest.mjs packages/tool-call-repair`: 4 files, 181 tests, pass. `git diff --check` clean. No source changed by this proof work.

🤖 AI-assisted (Claude Code): proof harness prepared with an AI agent; a human reviews and owns the result.


---

### Update 2 — the transport proof is now auditable in the tracked head

The transcripts above were captured in a git-excluded directory, so neither a reviewer nor CI could verify them. Two committed tests now carry that ground, and the perf instrumentation that genuinely cannot be committed is called out as such rather than left implied.

**1. `extensions/ollama/src/stream-plain-text-tool-call.transport.test.ts`** (new, 193 lines, test-only) — extension-providers lane, precedent `embedding-provider.fetchok.transport.test.ts` in the same directory. One real transport, nothing mocked: loopback NDJSON `/api/chat` → real `createOllamaStreamFn` (real SSRF-guarded fetch, real NDJSON parse) → real `createPlainTextToolCallCompatWrapper` → real `findCodeRegions`. Two behaviors:

- *keeps a bracket-dense fenced answer byte-identical while normalizing the unfenced call* — 40 `[read.section.NN]` lines chunked so every `[` ends its own delta, a complete fenced `[read]` call that only fence protection keeps literal, and the identical call outside the fence. Asserts the fenced portion byte-identical (fenced call verbatim), the unfenced call normalized away, deltas ≡ done text.
- *passes the identical stream through untouched when no tools are configured* — the engagement control (`tools: []` → the wrapper early-returns), asserting byte-identity **including** the trailing call, plus raw-shape pins: one `text_delta` per NDJSON record, zero deltas carrying `partial`. That pins the exact delta shape the `packages/tool-call-repair` bounded suites replicate, so those cannot silently drift away from what the real transport produces.

**2. The resolver-count bound was already committed** — `packages/tool-call-repair/src/stream-normalizer.test.ts`, *"keeps protection resolution bounded across a bracket-dense fenced answer"* (`resolverCalls ≤ 3`). Adding a second counting test would have been a near-duplicate, so it was RED-verified instead. Against the PR base `599b46c49bb`:

```
× keeps protection resolution bounded across a bracket-dense fenced answer
× keeps protection resolution bounded when every delta carries a cumulative partial
× keeps a large preceding block's prefix check bounded across many later candidates (#122513)
  AssertionError: expected 300 to be less than or equal to 3
```

One full re-parse per bracket delta on base — the quadratic path — failing for the intended reason. The new transport test passes on the base normalizer too, by design: it is the behavior-preservation guard, green on both sides.

**Still transcript-only, and why.** The `findCodeRegions` call-count / chars-re-parsed / wall-time table earlier in this PR relies on a `node:module` load-time source rewrite. That is too fragile for CI, and the alternative — exporting a counter from production — would be a test-only production seam, which this repo bans. So the committed pair covers the same ground differently: the packages test RED-proves the count collapse (300 → ≤3) and the transport test proves delta shape and byte-preservation at the real seam. The absolute timings remain unverifiable-by-CI, and I would rather say so than dress them up.

**A codex-review P2 I investigated and rejected, with evidence.** It flagged the trust cache (`stream-normalizer.ts:537-538`), claiming a same-length rewrite of an earlier block in a cumulative `partial` (` ```\n` → `~~~\n`) reuses a stale verdict and silently drops a fenced call. Running codex's own repro on this head: fast-path on and off emit **byte-identical output** and the fenced `[read]` call is fully preserved — the claimed loss does not occur. The scenario also requires a provider whose cumulative partial rewrites already-streamed bytes into different same-length text; real partials only append. Recording it as considered-and-disproved rather than silently dropping it.

**Gate.** New transport test 2 passed · `packages/tool-call-repair` 181 passed · oxfmt clean · oxlint exit 0 · `pnpm tsgo:extensions:test` and `pnpm tsgo:core` exit 0 · `git diff --check` clean. Production unchanged by this update; the additions are test-only.

🤖 AI-assisted (Claude Code): investigation, fix, and proof prepared with an AI agent; a human reviews and owns the result.
