### PR TITLE
test(plugins): remove duplicate setup cases

### DIFF
--- a/extensions/codex/harness.test.ts
+++ b/extensions/codex/harness.test.ts
@@ -179,13 +179,6 @@ describe("Codex agent harness supports()", () => {
     });
   });
 
-  it("supports the canonical openai routing id (documented Codex path)", () => {
-    expect(harness.supports({ provider: "openai", requestedRuntime: "codex" })).toEqual({
-      supported: true,
-      priority: 100,
-    });
-  });
-
   it("supports an official route declared compatible with Codex", () => {
     expect(
       harness.supports({

--- a/extensions/whatsapp/src/setup-surface.test.ts
+++ b/extensions/whatsapp/src/setup-surface.test.ts
@@ -9,19 +9,16 @@ import { DEFAULT_ACCOUNT_ID, type OpenClawConfig } from "openclaw/plugin-sdk/set
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { whatsappSetupWizard } from "./setup-surface.js";
 import {
-  createWhatsAppAllowlistModeInput,
   createWhatsAppLinkingHarness,
   createWhatsAppOwnerAllowlistHarness,
   createWhatsAppPersonalPhoneHarness,
   createWhatsAppRootAllowFromConfig,
   createWhatsAppWorkAccountConfig,
   expectNoWhatsAppLoginFollowup,
-  expectWhatsAppAllowlistModeSetup,
   expectWhatsAppLoginFollowup,
   expectWhatsAppOpenPolicySetup,
   expectWhatsAppOwnerAllowlistSetup,
   expectWhatsAppPersonalPhoneSetup,
-  expectWhatsAppSeparatePhoneDisabledSetup,
   expectWhatsAppWorkAccountAccessNote,
   expectWhatsAppWorkAccountOpenAccess,
 } from "./setup-test-helpers.js";
@@ -138,20 +135,6 @@ function expectFinalizeResult(result: Awaited<ReturnType<typeof runFinalizeWithH
   return result as { cfg: OpenClawConfig };
 }
 
-async function runSeparatePhoneFlow(params: { selectValues: string[]; textValues?: string[] }) {
-  hoisted.pathExists.mockResolvedValue(true);
-  const harness = createSeparatePhoneHarness({
-    selectValues: params.selectValues,
-    textValues: params.textValues,
-  });
-  const result = expectFinalizeResult(
-    await runFinalizeWithHarness({
-      harness,
-    }),
-  );
-  return { harness, result };
-}
-
 describe("whatsapp setup wizard", () => {
   beforeEach(() => {
     hoisted.detectWhatsAppLinked.mockReset();
@@ -184,14 +167,6 @@ describe("whatsapp setup wizard", () => {
 
     expect(hoisted.loginWeb).not.toHaveBeenCalled();
     expectWhatsAppOwnerAllowlistSetup(result.cfg, harness);
-  });
-
-  it("supports disabled DM policy for separate-phone setup", async () => {
-    const { harness, result } = await runSeparatePhoneFlow({
-      selectValues: ["separate", "disabled"],
-    });
-
-    expectWhatsAppSeparatePhoneDisabledSetup(result.cfg, harness);
   });
 
   it("writes named-account DM policy and allowFrom instead of the channel root", async () => {
@@ -308,12 +283,6 @@ describe("whatsapp setup wizard", () => {
 
     expectWhatsAppWorkAccountOpenAccess(result.cfg);
     expectWhatsAppWorkAccountAccessNote(harness);
-  });
-
-  it("normalizes allowFrom entries when list mode is selected", async () => {
-    const { result } = await runSeparatePhoneFlow(createWhatsAppAllowlistModeInput());
-
-    expectWhatsAppAllowlistModeSetup(result.cfg);
   });
 
   it("enables allowlist self-chat mode for personal-phone setup", async () => {


### PR DESCRIPTION
## What Problem This Solves

The Codex harness suite contained two byte-identical `openai` routing tests after provider-id unification. WhatsApp's setup-surface suite also replayed disabled-policy and allowlist-normalization behavior already owned by `finalizeWhatsAppSetup`, leaving a forwarding-only helper and three imports alive solely for those duplicates.

## Why This Change Was Made

Delete the duplicate Codex case and the two forwarding-layer WhatsApp policy replays. Retain the direct owner tests plus independent setup-surface coverage for linking, account scope, persistence guards, and other forwarding behavior. Remove the helper/import plumbing that became unused.

## User Impact

No intended user-visible change. Codex routing and WhatsApp setup behavior are unchanged; plugin CI runs fewer implementation-coupled cases.

## Evidence

- Focused owner proof: 94 tests passed across Codex harness/registration and WhatsApp finalizer/setup-surface suites.
- Full extension test gate passed formatting, extension test typecheck/lint, dead exports, plugin boundaries, dependency guards, and static checks. The first gate run correctly exposed the newly dead WhatsApp helper/imports; after removing them, the fresh rerun passed. Blacksmith/Testbox was unavailable on this host, so trusted heavy proof used the documented local fallback.
- Structured autoreview and deleted-content secret scan: clean after the final helper cleanup.
- `git diff --check`: clean.
- Test-only delta: 38 lines removed across two files.
- Codex dependency contract checked directly at `openai/codex@78d3665d1569b6b0cf227a8668a837f8d6c79aab`: canonical/default provider ID remains `openai`.

AI-assisted maintenance cleanup; duplicate inputs/assertions, owner boundaries, forwarding coverage, history, and the upstream Codex contract were reviewed directly.
