### PR TITLE
fix(ui): let chats scroll beneath the composer

### DIFF
--- a/ui/src/e2e/chat-floating-composer.e2e.test.ts
+++ b/ui/src/e2e/chat-floating-composer.e2e.test.ts
@@ -202,17 +202,8 @@ suite.define(() => {
           0,
         );
 
-        if (viewportName === "mobile") {
-          await thread.evaluate((element) => {
-            const threadElement = element as HTMLElement;
-            threadElement.scrollTop = threadElement.scrollHeight;
-            threadElement.dispatchEvent(new Event("scroll", { bubbles: true }));
-          });
-        } else {
-          // The proof intentionally keeps the toast visible; force the semantic
-          // action so its overlay cannot make the scroll assertion timing-sensitive.
-          await scrollToLatest.click({ force: true });
-        }
+        // Keep the toast visible so this exercises the real pointer path.
+        await scrollToLatest.click();
         await expect
           .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
           .toBeLessThanOrEqual(8);

--- a/ui/src/e2e/chat-floating-composer.e2e.test.ts
+++ b/ui/src/e2e/chat-floating-composer.e2e.test.ts
@@ -1,0 +1,210 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import {
+  chatThreadDistanceFromBottom,
+  createChatFlowE2eSuite,
+  installMockGateway,
+  scrollChatThreadToTop,
+  waitForChatScrollIdle,
+} from "./chat-flow.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+const proofStage = process.env.OPENCLAW_FLOATING_COMPOSER_PROOF_STAGE?.trim() || "proposed";
+
+async function setThemeMode(page: Page, mode: "dark" | "light"): Promise<void> {
+  await page.emulateMedia({ colorScheme: mode });
+  await page.evaluate((nextMode) => {
+    const root = document.documentElement;
+    root.dataset.themeMode = nextMode;
+    root.dataset.themeResolved = nextMode;
+    root.classList.toggle("wa-light", nextMode === "light");
+    root.classList.toggle("wa-dark", nextMode === "dark");
+    root.style.colorScheme = nextMode;
+  }, mode);
+}
+
+async function captureProof(page: Page, theme: "dark" | "light", state: string) {
+  if (!artifactDir) {
+    return;
+  }
+  await mkdir(artifactDir, { recursive: true });
+  await page.screenshot({
+    animations: "disabled",
+    fullPage: true,
+    path: path.join(artifactDir, `${proofStage}-${theme}-${state}-context.png`),
+  });
+  await page.locator(".chat-main__conversation").screenshot({
+    animations: "disabled",
+    path: path.join(artifactDir, `${proofStage}-${theme}-${state}-conversation.png`),
+  });
+}
+
+suite.define(() => {
+  it.each(["dark", "light"] as const)(
+    "floats the complete composer dock over a reachable transcript in %s mode",
+    async (theme) => {
+      const context = await suite.newBrowserContext({
+        colorScheme: theme,
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+      });
+      const page = await context.newPage();
+      const baseTs = Date.now() - 100_000;
+      const historyMessages = Array.from({ length: 42 }, (_, index) => ({
+        content: [
+          {
+            text:
+              index === 41
+                ? "Deployment summary complete. The final receipt remains fully reachable above the composer."
+                : `Release review ${index + 1}\n${"Verified transcript detail. ".repeat(5)}`,
+            type: "text",
+          },
+        ],
+        role: index % 2 === 0 ? "user" : "assistant",
+        timestamp: baseTs + index,
+        __openclaw: {
+          id: index === 41 ? "floating-composer-tail" : `history-${index}`,
+          seq: index + 1,
+        },
+      }));
+      const gateway = await installMockGateway(page, { historyMessages });
+
+      try {
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await setThemeMode(page, theme);
+        const textarea = page.locator(".agent-chat__composer-combobox textarea");
+        const tail = page.locator('[data-entry-id="floating-composer-tail"]');
+        await tail.waitFor({ state: "visible", timeout: 10_000 });
+        await waitForChatScrollIdle(page);
+        await scrollChatThreadToTop(page);
+        const scrollToLatest = page.getByRole("button", { name: "Scroll to latest" });
+        await scrollToLatest.waitFor({ state: "visible", timeout: 10_000 });
+
+        await gateway.setOnline(false);
+        await gateway.closeLatest();
+        for (const message of [
+          "Queue the accessibility pass after reconnect",
+          "Then publish the release checklist with the final screenshots",
+        ]) {
+          await textarea.fill(message);
+          await textarea.press("Enter");
+          await page.locator(".chat-queue__item", { hasText: message }).waitFor({
+            state: "visible",
+            timeout: 10_000,
+          });
+        }
+
+        await textarea.fill(
+          [
+            "Add the remaining release notes:",
+            "- confirm the migration path",
+            "- document the rollback signal",
+            "- attach the light and dark evidence",
+            "- notify the release owner",
+          ].join("\n"),
+        );
+        await page.locator("openclaw-toast-host").evaluate((element) => {
+          const host = element as HTMLElement & {
+            show: (options: { durationMs: number; message: string }) => void;
+          };
+          host.show({
+            durationMs: 60_000,
+            message: "Draft restored. Review the queued release work before reconnecting.",
+          });
+        });
+        await page.locator(".app-toast").waitFor({ state: "visible" });
+        await captureProof(page, theme, "backscroll");
+
+        const conversation = page.locator(".chat-main__conversation");
+        const thread = page.locator(".chat-thread");
+        const dock = page.locator(".chat-bottom-dock");
+        await dock.waitFor({ state: "visible" });
+        const readDockLayout = () =>
+          conversation.evaluate((element) => {
+            const thread = element.querySelector<HTMLElement>(".chat-thread");
+            const dock = element.querySelector<HTMLElement>(".chat-bottom-dock");
+            const button = element.querySelector<HTMLElement>(".chat-scroll-to-bottom");
+            const toast = document.querySelector<HTMLElement>(".app-toast");
+            if (!thread || !dock || !toast) {
+              throw new Error("expected transcript, composer dock, and toast");
+            }
+            const conversationRect = element.getBoundingClientRect();
+            const threadRect = thread.getBoundingClientRect();
+            const dockRect = dock.getBoundingClientRect();
+            const buttonRect = button?.getBoundingClientRect();
+            const toastRect = toast.getBoundingClientRect();
+            return {
+              buttonGap: buttonRect ? dockRect.top - buttonRect.bottom : null,
+              dockBottom: dockRect.bottom,
+              dockHeight: dockRect.height,
+              dockTop: dockRect.top,
+              paddingBottom: Number.parseFloat(getComputedStyle(thread).paddingBottom),
+              threadBottom: threadRect.bottom,
+              toastGap: dockRect.top - toastRect.bottom,
+              viewportBottom: conversationRect.bottom,
+            };
+          });
+
+        const expanded = await readDockLayout();
+        expect(Math.abs(expanded.threadBottom - expanded.viewportBottom)).toBeLessThanOrEqual(1);
+        expect(Math.abs(expanded.dockBottom - expanded.viewportBottom)).toBeLessThanOrEqual(1);
+        expect(expanded.paddingBottom).toBeGreaterThan(expanded.dockHeight);
+        expect(expanded.buttonGap ?? Number.NEGATIVE_INFINITY).toBeGreaterThanOrEqual(8);
+        expect(expanded.toastGap).toBeGreaterThanOrEqual(8);
+
+        const scrollTopBeforeResize = await thread.evaluate((element) => element.scrollTop);
+        await textarea.fill("Short follow-up draft");
+        await expect
+          .poll(async () => (await readDockLayout()).dockHeight)
+          .toBeLessThan(expanded.dockHeight);
+        await expect
+          .poll(async () => (await readDockLayout()).paddingBottom)
+          .toBeLessThan(expanded.paddingBottom);
+        const compact = await readDockLayout();
+        expect(compact.dockHeight).toBeLessThan(expanded.dockHeight);
+        expect(await thread.evaluate((element) => element.scrollTop)).toBeCloseTo(
+          scrollTopBeforeResize,
+          0,
+        );
+
+        await textarea.fill(
+          [
+            "Add the remaining release notes:",
+            "- confirm the migration path",
+            "- document the rollback signal",
+            "- attach the light and dark evidence",
+            "- notify the release owner",
+          ].join("\n"),
+        );
+        await expect
+          .poll(async () => (await readDockLayout()).dockHeight)
+          .toBeGreaterThan(compact.dockHeight);
+        await expect
+          .poll(async () => (await readDockLayout()).paddingBottom)
+          .toBeGreaterThan(compact.paddingBottom);
+        expect(await thread.evaluate((element) => element.scrollTop)).toBeCloseTo(
+          scrollTopBeforeResize,
+          0,
+        );
+
+        await scrollToLatest.click();
+        await expect
+          .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
+          .toBeLessThanOrEqual(8);
+        await tail.waitFor({ state: "visible" });
+        const endLayout = await readDockLayout();
+        const tailBox = await tail.locator(".chat-text").boundingBox();
+        expect(tailBox).not.toBeNull();
+        const tailBottom = tailBox ? tailBox.y + tailBox.height : endLayout.dockTop;
+        expect(endLayout.dockTop - tailBottom).toBeGreaterThanOrEqual(0);
+        await captureProof(page, theme, "exact-end");
+      } finally {
+        await context.close();
+      }
+    },
+  );
+});

--- a/ui/src/e2e/chat-floating-composer.e2e.test.ts
+++ b/ui/src/e2e/chat-floating-composer.e2e.test.ts
@@ -202,6 +202,54 @@ suite.define(() => {
         const tailBottom = tailBox ? tailBox.y + tailBox.height : endLayout.dockTop;
         expect(endLayout.dockTop - tailBottom).toBeGreaterThanOrEqual(0);
         await captureProof(page, theme, "exact-end");
+
+        for (let index = 0; index < 24; index += 1) {
+          await textarea.fill(
+            `Queued follow-up ${index + 3}: verify the remaining release evidence`,
+          );
+          await textarea.press("Enter");
+        }
+        const composerAdjuncts = page.locator(".chat-composer-adjuncts");
+        await expect.poll(() => page.locator(".chat-queue__item").count()).toBe(26);
+        const overflowLayout = await conversation.evaluate((element) => {
+          const dock = element.querySelector<HTMLElement>(".chat-bottom-dock");
+          const adjuncts = element.querySelector<HTMLElement>(".chat-composer-adjuncts");
+          const composer = element.querySelector<HTMLElement>(".agent-chat__composer-shell");
+          if (!dock || !adjuncts || !composer) {
+            throw new Error("expected dock, composer adjuncts, and composer");
+          }
+          const conversationRect = element.getBoundingClientRect();
+          const dockRect = dock.getBoundingClientRect();
+          const composerRect = composer.getBoundingClientRect();
+          return {
+            adjunctClientHeight: adjuncts.clientHeight,
+            adjunctScrollHeight: adjuncts.scrollHeight,
+            composerBottom: composerRect.bottom,
+            conversationBottom: conversationRect.bottom,
+            dockHeight: dockRect.height,
+            viewportHeight: conversationRect.height,
+          };
+        });
+        expect(overflowLayout.dockHeight).toBeLessThanOrEqual(overflowLayout.viewportHeight + 1);
+        expect(overflowLayout.composerBottom).toBeLessThanOrEqual(
+          overflowLayout.conversationBottom + 1,
+        );
+        expect(overflowLayout.adjunctScrollHeight).toBeGreaterThan(
+          overflowLayout.adjunctClientHeight,
+        );
+
+        await composerAdjuncts.evaluate((element) => {
+          element.scrollTop = element.scrollHeight;
+        });
+        const finalQueuedItem = page.locator(".chat-queue__item").last();
+        await expect.poll(async () => finalQueuedItem.isVisible()).toBe(true);
+        const finalQueuedBox = await finalQueuedItem.boundingBox();
+        const adjunctBox = await composerAdjuncts.boundingBox();
+        expect(finalQueuedBox).not.toBeNull();
+        expect(adjunctBox).not.toBeNull();
+        const finalQueuedBottom = finalQueuedBox ? finalQueuedBox.y + finalQueuedBox.height : 0;
+        const adjunctBottom = adjunctBox ? adjunctBox.y + adjunctBox.height : 0;
+        expect(finalQueuedBottom).toBeLessThanOrEqual(adjunctBottom + 1);
       } finally {
         await context.close();
       }

--- a/ui/src/e2e/chat-floating-composer.e2e.test.ts
+++ b/ui/src/e2e/chat-floating-composer.e2e.test.ts
@@ -43,14 +43,19 @@ async function captureProof(page: Page, theme: "dark" | "light", state: string) 
 }
 
 suite.define(() => {
-  it.each(["dark", "light"] as const)(
-    "floats the complete composer dock over a reachable transcript in %s mode",
-    async (theme) => {
+  it.each([
+    ["dark", "desktop", 1440, 900],
+    ["light", "desktop", 1440, 900],
+    ["dark", "mobile", 393, 852],
+    ["light", "mobile", 393, 852],
+  ] as const)(
+    "floats the complete composer dock over a reachable transcript in %s %s mode",
+    async (theme, viewportName, viewportWidth, viewportHeight) => {
       const context = await suite.newBrowserContext({
         colorScheme: theme,
         locale: "en-US",
         serviceWorkers: "block",
-        viewport: { height: 900, width: 1440 },
+        viewport: { height: viewportHeight, width: viewportWidth },
       });
       const page = await context.newPage();
       const baseTs = Date.now() - 100_000;
@@ -117,11 +122,17 @@ suite.define(() => {
           });
         });
         await page.locator(".app-toast").waitFor({ state: "visible" });
-        await captureProof(page, theme, "backscroll");
+        await captureProof(page, theme, `${viewportName}-backscroll`);
 
         const conversation = page.locator(".chat-main__conversation");
         const thread = page.locator(".chat-thread");
         const dock = page.locator(".chat-bottom-dock");
+        if ((await dock.count()) === 0 && proofStage === "before") {
+          await scrollToLatest.click();
+          await waitForChatScrollIdle(page);
+          await captureProof(page, theme, `${viewportName}-exact-end`);
+          return;
+        }
         await dock.waitFor({ state: "visible" });
         const readDockLayout = () =>
           conversation.evaluate((element) => {
@@ -201,7 +212,7 @@ suite.define(() => {
         expect(tailBox).not.toBeNull();
         const tailBottom = tailBox ? tailBox.y + tailBox.height : endLayout.dockTop;
         expect(endLayout.dockTop - tailBottom).toBeGreaterThanOrEqual(0);
-        await captureProof(page, theme, "exact-end");
+        await captureProof(page, theme, `${viewportName}-exact-end`);
 
         for (let index = 0; index < 24; index += 1) {
           await textarea.fill(
@@ -250,6 +261,7 @@ suite.define(() => {
         const finalQueuedBottom = finalQueuedBox ? finalQueuedBox.y + finalQueuedBox.height : 0;
         const adjunctBottom = adjunctBox ? adjunctBox.y + adjunctBox.height : 0;
         expect(finalQueuedBottom).toBeLessThanOrEqual(adjunctBottom + 1);
+        await captureProof(page, theme, `${viewportName}-adjunct-overflow`);
       } finally {
         await context.close();
       }

--- a/ui/src/e2e/chat-floating-composer.e2e.test.ts
+++ b/ui/src/e2e/chat-floating-composer.e2e.test.ts
@@ -202,9 +202,17 @@ suite.define(() => {
           0,
         );
 
-        // The proof intentionally keeps the toast visible; force the semantic
-        // action so its overlay cannot make the scroll assertion timing-sensitive.
-        await scrollToLatest.click({ force: true });
+        if (viewportName === "mobile") {
+          await thread.evaluate((element) => {
+            const threadElement = element as HTMLElement;
+            threadElement.scrollTop = threadElement.scrollHeight;
+            threadElement.dispatchEvent(new Event("scroll", { bubbles: true }));
+          });
+        } else {
+          // The proof intentionally keeps the toast visible; force the semantic
+          // action so its overlay cannot make the scroll assertion timing-sensitive.
+          await scrollToLatest.click({ force: true });
+        }
         await expect
           .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
           .toBeLessThanOrEqual(8);

--- a/ui/src/e2e/chat-floating-composer.e2e.test.ts
+++ b/ui/src/e2e/chat-floating-composer.e2e.test.ts
@@ -125,16 +125,16 @@ suite.define(() => {
         await dock.waitFor({ state: "visible" });
         const readDockLayout = () =>
           conversation.evaluate((element) => {
-            const thread = element.querySelector<HTMLElement>(".chat-thread");
-            const dock = element.querySelector<HTMLElement>(".chat-bottom-dock");
+            const threadElement = element.querySelector<HTMLElement>(".chat-thread");
+            const dockElement = element.querySelector<HTMLElement>(".chat-bottom-dock");
             const button = element.querySelector<HTMLElement>(".chat-scroll-to-bottom");
             const toast = document.querySelector<HTMLElement>(".app-toast");
-            if (!thread || !dock || !toast) {
+            if (!threadElement || !dockElement || !toast) {
               throw new Error("expected transcript, composer dock, and toast");
             }
             const conversationRect = element.getBoundingClientRect();
-            const threadRect = thread.getBoundingClientRect();
-            const dockRect = dock.getBoundingClientRect();
+            const threadRect = threadElement.getBoundingClientRect();
+            const dockRect = dockElement.getBoundingClientRect();
             const buttonRect = button?.getBoundingClientRect();
             const toastRect = toast.getBoundingClientRect();
             return {
@@ -142,7 +142,7 @@ suite.define(() => {
               dockBottom: dockRect.bottom,
               dockHeight: dockRect.height,
               dockTop: dockRect.top,
-              paddingBottom: Number.parseFloat(getComputedStyle(thread).paddingBottom),
+              paddingBottom: Number.parseFloat(getComputedStyle(threadElement).paddingBottom),
               threadBottom: threadRect.bottom,
               toastGap: dockRect.top - toastRect.bottom,
               viewportBottom: conversationRect.bottom,
@@ -212,14 +212,14 @@ suite.define(() => {
         const composerAdjuncts = page.locator(".chat-composer-adjuncts");
         await expect.poll(() => page.locator(".chat-queue__item").count()).toBe(26);
         const overflowLayout = await conversation.evaluate((element) => {
-          const dock = element.querySelector<HTMLElement>(".chat-bottom-dock");
+          const dockElement = element.querySelector<HTMLElement>(".chat-bottom-dock");
           const adjuncts = element.querySelector<HTMLElement>(".chat-composer-adjuncts");
           const composer = element.querySelector<HTMLElement>(".agent-chat__composer-shell");
-          if (!dock || !adjuncts || !composer) {
+          if (!dockElement || !adjuncts || !composer) {
             throw new Error("expected dock, composer adjuncts, and composer");
           }
           const conversationRect = element.getBoundingClientRect();
-          const dockRect = dock.getBoundingClientRect();
+          const dockRect = dockElement.getBoundingClientRect();
           const composerRect = composer.getBoundingClientRect();
           return {
             adjunctClientHeight: adjuncts.clientHeight,

--- a/ui/src/e2e/chat-floating-composer.e2e.test.ts
+++ b/ui/src/e2e/chat-floating-composer.e2e.test.ts
@@ -79,11 +79,11 @@ suite.define(() => {
         historyMessages,
         methodResponses: {
           "sessions.list": chatSessionListResponse([
-            { key: tallKey, kind: "direct", label: "Tall draft", updatedAt: 2 },
-            { key: compactKey, kind: "direct", label: "Compact draft", updatedAt: 1 },
+            { key: compactKey, kind: "direct", label: "Compact draft", updatedAt: 2 },
+            { key: tallKey, kind: "direct", label: "Tall draft", updatedAt: 1 },
           ]),
         },
-        sessionKey: tallKey,
+        sessionKey: compactKey,
       });
 
       const readActiveLayout = () =>
@@ -175,6 +175,15 @@ suite.define(() => {
         const activeDock = () =>
           page.locator("openclaw-chat-pane[aria-hidden='false'] .chat-bottom-dock");
 
+        await activeTextarea().fill("Compact retained draft");
+        await waitForChatScrollIdle(page);
+        const compactDockHeight = await activeDock().evaluate(
+          (element) => element.getBoundingClientRect().height,
+        );
+        await scrollChatThreadToTop(page);
+        await page.getByRole("button", { name: "Scroll to latest" }).waitFor();
+
+        await switchToSession(tallKey, "Tall draft");
         await activeTextarea().fill(
           [
             "Keep this retained composer expanded:",
@@ -188,23 +197,7 @@ suite.define(() => {
         const tallDockHeight = await activeDock().evaluate(
           (element) => element.getBoundingClientRect().height,
         );
-        await scrollChatThreadToTop(page);
-        await page.getByRole("button", { name: "Scroll to latest" }).waitFor();
-
-        await switchToSession(compactKey, "Compact draft");
-        await activeTextarea().fill("Compact retained draft");
-        await waitForChatScrollIdle(page);
-        const compactDockHeight = await activeDock().evaluate(
-          (element) => element.getBoundingClientRect().height,
-        );
         expect(compactDockHeight).toBeLessThan(tallDockHeight);
-        await scrollChatThreadToTop(page);
-        await page.getByRole("button", { name: "Scroll to latest" }).waitFor();
-        await showToast();
-        await expectActiveLayout();
-        await dismissToast();
-
-        await switchToSession(tallKey, "Tall draft");
         await scrollChatThreadToTop(page);
         await page.getByRole("button", { name: "Scroll to latest" }).waitFor();
         await showToast();
@@ -222,6 +215,13 @@ suite.define(() => {
         await showToast();
         await expectActiveLayout();
         await captureProof(page, theme, `${viewportName}-retained-compact`);
+        await dismissToast();
+
+        await switchToSession(tallKey, "Tall draft");
+        await scrollChatThreadToTop(page);
+        await page.getByRole("button", { name: "Scroll to latest" }).waitFor();
+        await showToast();
+        await expectActiveLayout();
       } finally {
         await context.close();
       }

--- a/ui/src/e2e/chat-floating-composer.e2e.test.ts
+++ b/ui/src/e2e/chat-floating-composer.e2e.test.ts
@@ -202,7 +202,9 @@ suite.define(() => {
           0,
         );
 
-        await scrollToLatest.click();
+        // The proof intentionally keeps the toast visible; force the semantic
+        // action so its overlay cannot make the scroll assertion timing-sensitive.
+        await scrollToLatest.click({ force: true });
         await expect
           .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
           .toBeLessThanOrEqual(8);

--- a/ui/src/e2e/chat-floating-composer.e2e.test.ts
+++ b/ui/src/e2e/chat-floating-composer.e2e.test.ts
@@ -166,6 +166,7 @@ suite.define(() => {
               .poll(() => page.locator(".shell").getAttribute("class"))
               .not.toContain("shell--nav-drawer-open");
           }
+          await waitForChatScrollIdle(page);
         };
         const activeTextarea = () =>
           page.locator(
@@ -183,6 +184,7 @@ suite.define(() => {
             "- notify the release owner",
           ].join("\n"),
         );
+        await waitForChatScrollIdle(page);
         const tallDockHeight = await activeDock().evaluate(
           (element) => element.getBoundingClientRect().height,
         );
@@ -191,6 +193,7 @@ suite.define(() => {
 
         await switchToSession(compactKey, "Compact draft");
         await activeTextarea().fill("Compact retained draft");
+        await waitForChatScrollIdle(page);
         const compactDockHeight = await activeDock().evaluate(
           (element) => element.getBoundingClientRect().height,
         );

--- a/ui/src/e2e/chat-floating-composer.e2e.test.ts
+++ b/ui/src/e2e/chat-floating-composer.e2e.test.ts
@@ -4,6 +4,7 @@ import type { Page } from "playwright";
 import { expect, it } from "vitest";
 import {
   chatThreadDistanceFromBottom,
+  chatSessionListResponse,
   createChatFlowE2eSuite,
   installMockGateway,
   scrollChatThreadToTop,
@@ -36,13 +37,194 @@ async function captureProof(page: Page, theme: "dark" | "light", state: string) 
     fullPage: true,
     path: path.join(artifactDir, `${proofStage}-${theme}-${state}-context.png`),
   });
-  await page.locator(".chat-main__conversation").screenshot({
-    animations: "disabled",
-    path: path.join(artifactDir, `${proofStage}-${theme}-${state}-conversation.png`),
-  });
+  await page
+    .locator("openclaw-chat-pane[aria-hidden='false'] .chat-main__conversation")
+    .screenshot({
+      animations: "disabled",
+      path: path.join(artifactDir, `${proofStage}-${theme}-${state}-conversation.png`),
+    });
 }
 
 suite.define(() => {
+  it.each([
+    ["dark", "desktop", 1440, 900],
+    ["light", "desktop", 1440, 900],
+    ["dark", "mobile", 393, 852],
+    ["light", "mobile", 393, 852],
+  ] as const)(
+    "syncs active dock geometry when retained chats switch in %s %s mode",
+    async (theme, viewportName, viewportWidth, viewportHeight) => {
+      const context = await suite.newBrowserContext({
+        colorScheme: theme,
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: viewportHeight, width: viewportWidth },
+      });
+      const page = await context.newPage();
+      const tallKey = "agent:main:thread:aaaaaaaa-1111-4111-8111-111111111111";
+      const compactKey = "agent:main:thread:bbbbbbbb-2222-4222-8222-222222222222";
+      const baseTs = Date.now() - 100_000;
+      const historyMessages = Array.from({ length: 42 }, (_, index) => ({
+        content: [
+          {
+            text: `Retained session review ${index + 1}\n${"Verified transcript detail. ".repeat(5)}`,
+            type: "text",
+          },
+        ],
+        role: index % 2 === 0 ? "user" : "assistant",
+        timestamp: baseTs + index,
+        __openclaw: { id: `retained-history-${index}`, seq: index + 1 },
+      }));
+      await installMockGateway(page, {
+        historyMessages,
+        methodResponses: {
+          "sessions.list": chatSessionListResponse([
+            { key: tallKey, kind: "direct", label: "Tall draft", updatedAt: 2 },
+            { key: compactKey, kind: "direct", label: "Compact draft", updatedAt: 1 },
+          ]),
+        },
+        sessionKey: tallKey,
+      });
+
+      const readActiveLayout = () =>
+        page.locator("openclaw-chat-pane[aria-hidden='false']").evaluate((pane) => {
+          const shell = pane.closest<HTMLElement>(".shell");
+          const dock = pane.querySelector<HTMLElement>(".chat-bottom-dock");
+          const button = [...document.querySelectorAll<HTMLElement>(".chat-scroll-to-bottom")].find(
+            (candidate) => candidate.checkVisibility(),
+          );
+          const toast = document.querySelector<HTMLElement>(".app-toast");
+          if (!shell || !dock || !button || !toast) {
+            throw new Error(
+              `expected active layout: shell=${Boolean(shell)} dock=${Boolean(dock)} scroll=${Boolean(button)} toast=${Boolean(toast)}`,
+            );
+          }
+          const dockRect = dock.getBoundingClientRect();
+          const buttonRect = button.getBoundingClientRect();
+          const toastRect = toast.getBoundingClientRect();
+          return {
+            activeDockHeight: Number.parseFloat(
+              getComputedStyle(shell).getPropertyValue("--chat-active-bottom-dock-height"),
+            ),
+            buttonGap: dockRect.top - buttonRect.bottom,
+            dockHeight: dockRect.height,
+            toastGap: dockRect.top - toastRect.bottom,
+          };
+        });
+
+      const expectActiveLayout = async () => {
+        await expect
+          .poll(async () => {
+            const layout = await readActiveLayout();
+            return Math.abs(layout.activeDockHeight - layout.dockHeight);
+          })
+          .toBeLessThanOrEqual(1);
+        const layout = await readActiveLayout();
+        expect(layout.buttonGap).toBeGreaterThanOrEqual(8);
+        expect(layout.toastGap).toBeGreaterThanOrEqual(8);
+      };
+
+      const showToast = async () => {
+        await page.locator("openclaw-toast-host").evaluate((element) => {
+          const host = element as HTMLElement & {
+            show: (options: { durationMs: number; message: string }) => void;
+          };
+          host.show({
+            durationMs: 60_000,
+            message: "Retained session restored with its own composer height.",
+          });
+        });
+        await page.locator(".app-toast").waitFor({ state: "visible" });
+      };
+
+      const dismissToast = async () => {
+        await page.locator(".app-toast__dismiss").click();
+        await page.locator(".app-toast").waitFor({ state: "hidden" });
+      };
+
+      try {
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await setThemeMode(page, theme);
+        const switchToSession = async (sessionKey: string, title: string) => {
+          if (viewportName === "mobile") {
+            await page
+              .locator(".topbar-nav-toggle:visible, .chat-pane__nav-toggle:visible")
+              .first()
+              .click();
+          }
+          await page
+            .locator(
+              `.sidebar-recent-session[data-session-key="${sessionKey}"] a.sidebar-recent-session__link`,
+            )
+            .click();
+          await page
+            .locator(".chat-pane-cache__pane--visible .chat-pane__session-title")
+            .getByText(title)
+            .waitFor();
+          if (viewportName === "mobile") {
+            await expect
+              .poll(() => page.locator(".shell").getAttribute("class"))
+              .not.toContain("shell--nav-drawer-open");
+          }
+        };
+        const activeTextarea = () =>
+          page.locator(
+            "openclaw-chat-pane[aria-hidden='false'] .agent-chat__composer-combobox textarea",
+          );
+        const activeDock = () =>
+          page.locator("openclaw-chat-pane[aria-hidden='false'] .chat-bottom-dock");
+
+        await activeTextarea().fill(
+          [
+            "Keep this retained composer expanded:",
+            "- confirm the migration path",
+            "- document the rollback signal",
+            "- attach the light and dark evidence",
+            "- notify the release owner",
+          ].join("\n"),
+        );
+        const tallDockHeight = await activeDock().evaluate(
+          (element) => element.getBoundingClientRect().height,
+        );
+        await scrollChatThreadToTop(page);
+        await page.getByRole("button", { name: "Scroll to latest" }).waitFor();
+
+        await switchToSession(compactKey, "Compact draft");
+        await activeTextarea().fill("Compact retained draft");
+        const compactDockHeight = await activeDock().evaluate(
+          (element) => element.getBoundingClientRect().height,
+        );
+        expect(compactDockHeight).toBeLessThan(tallDockHeight);
+        await scrollChatThreadToTop(page);
+        await page.getByRole("button", { name: "Scroll to latest" }).waitFor();
+        await showToast();
+        await expectActiveLayout();
+        await dismissToast();
+
+        await switchToSession(tallKey, "Tall draft");
+        await scrollChatThreadToTop(page);
+        await page.getByRole("button", { name: "Scroll to latest" }).waitFor();
+        await showToast();
+        await expectActiveLayout();
+        await captureProof(page, theme, `${viewportName}-retained-tall`);
+        await page.getByRole("button", { name: "Scroll to latest" }).click();
+        await expect
+          .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
+          .toBeLessThanOrEqual(8);
+        await dismissToast();
+
+        await switchToSession(compactKey, "Compact draft");
+        await scrollChatThreadToTop(page);
+        await page.getByRole("button", { name: "Scroll to latest" }).waitFor();
+        await showToast();
+        await expectActiveLayout();
+        await captureProof(page, theme, `${viewportName}-retained-compact`);
+      } finally {
+        await context.close();
+      }
+    },
+  );
+
   it.each([
     ["dark", "desktop", 1440, 900],
     ["light", "desktop", 1440, 900],

--- a/ui/src/e2e/chat-flow.streaming.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.streaming.e2e.test.ts
@@ -367,9 +367,13 @@ suite.define(() => {
         expect(await alert.locator("button").count()).toBe(0);
         expect(await page.locator(".chat-thread-inner").getByText(errorText).count()).toBe(0);
         expect(
-          await alert.evaluate((element) =>
-            element.nextElementSibling?.classList.contains("agent-chat__composer-shell"),
-          ),
+          await alert.evaluate((element) => {
+            const adjuncts = element.closest(".chat-composer-adjuncts");
+            return (
+              adjuncts?.lastElementChild === element &&
+              adjuncts.nextElementSibling?.classList.contains("agent-chat__composer-shell")
+            );
+          }),
         ).toBe(true);
         const [alertBox, composerBox] = await Promise.all([
           alert.boundingBox(),

--- a/ui/src/pages/chat/chat-pane-retained-presentation.ts
+++ b/ui/src/pages/chat/chat-pane-retained-presentation.ts
@@ -44,6 +44,9 @@ export abstract class ChatPaneRetainedPresentation extends ChatPaneBoard {
     if (presented) {
       this.boardProviderLifecycleConnected = true;
       this.minutePoll.start();
+      // Retained panes keep their layout observer while hidden, so activation
+      // must republish which dock owns the shell-level floating chrome.
+      this.chatState.syncActiveBottomDockHeight();
       this.consumeSessionHandoff(this.sessionKey);
       this.syncActiveBindings();
       void this.refreshSessionPullRequests();

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -955,6 +955,38 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
+  it("anchors the mobile session companion above the measured composer dock", async () => {
+    const page = await openBrowserPage(393, 852);
+    try {
+      await page.setContent(
+        `<!doctype html><html><head><style>${readUiCss()}</style></head><body>
+          <div class="shell shell--chat">
+            <main class="content content--chat">
+              <div class="chat-main" style="--chat-bottom-dock-height: 180px; height: 852px">
+                <div class="chat-session-rail chat-session-rail--pill">Reviewing the session</div>
+              </div>
+            </main>
+          </div>
+        </body></html>`,
+      );
+
+      const offsets = await page.evaluate(() => {
+        const companion = document.querySelector<HTMLElement>(".chat-session-rail--pill");
+        if (!companion) {
+          throw new Error("session companion missing");
+        }
+        return {
+          computed: Number.parseFloat(getComputedStyle(companion).bottom),
+          visible: window.innerHeight - companion.getBoundingClientRect().bottom,
+        };
+      });
+      expect(offsets.computed).toBeCloseTo(192, 0);
+      expect(offsets.visible).toBeGreaterThan(180);
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
   it("keeps the split-pane close button reachable as the pane narrows", async () => {
     const page = await openBrowserPage(1100, 240);
     try {

--- a/ui/src/pages/chat/chat-state-controller.ts
+++ b/ui/src/pages/chat/chat-state-controller.ts
@@ -24,16 +24,17 @@ type ChatRenderLifecycleScope = {
 const CHAT_BOTTOM_DOCK_HEIGHT_PROPERTY = "--chat-bottom-dock-height";
 const ACTIVE_CHAT_BOTTOM_DOCK_HEIGHT_PROPERTY = "--chat-active-bottom-dock-height";
 
-function syncActiveChatBottomDockHeight(shell: HTMLElement): void {
-  const heights = [
-    ...shell.querySelectorAll<HTMLElement>(
-      'openclaw-chat-pane[aria-hidden="false"] .chat-bottom-dock',
-    ),
-  ].map((dock) => dock.getBoundingClientRect().height);
-  shell.style.setProperty(
-    ACTIVE_CHAT_BOTTOM_DOCK_HEIGHT_PROPERTY,
-    `${Math.ceil(Math.max(0, ...heights))}px`,
-  );
+function syncChatBottomDockHeight(dock: HTMLElement): void {
+  const height = `${Math.ceil(dock.getBoundingClientRect().height)}px`;
+  dock
+    .closest<HTMLElement>(".chat-main")
+    ?.style.setProperty(CHAT_BOTTOM_DOCK_HEIGHT_PROPERTY, height);
+  const pane = dock.closest<HTMLElement>("openclaw-chat-pane");
+  if (pane?.getAttribute("aria-hidden") === "false") {
+    dock
+      .closest<HTMLElement>(".shell")
+      ?.style.setProperty(ACTIVE_CHAT_BOTTOM_DOCK_HEIGHT_PROPERTY, height);
+  }
 }
 
 export class ChatStateController<TState extends ChatPageHost> implements ReactiveController {
@@ -282,16 +283,7 @@ export class ChatStateController<TState extends ChatPageHost> implements Reactiv
       return;
     }
 
-    const syncDockHeight = () => {
-      const height = Math.ceil(dock.getBoundingClientRect().height);
-      dock
-        .closest<HTMLElement>(".chat-main")
-        ?.style.setProperty(CHAT_BOTTOM_DOCK_HEIGHT_PROPERTY, `${height}px`);
-      const shell = dock.closest<HTMLElement>(".shell");
-      if (shell) {
-        syncActiveChatBottomDockHeight(shell);
-      }
-    };
+    const syncDockHeight = () => syncChatBottomDockHeight(dock);
     syncDockHeight();
 
     // The transcript virtualizer still owns row measurement and anchoring. This
@@ -312,9 +304,8 @@ export class ChatStateController<TState extends ChatPageHost> implements Reactiv
 
   syncActiveBottomDockHeight(): void {
     const dock = this.chatBottomDockResizeTarget;
-    const shell = dock?.closest<HTMLElement>(".shell");
-    if (shell) {
-      syncActiveChatBottomDockHeight(shell);
+    if (dock) {
+      syncChatBottomDockHeight(dock);
     }
   }
 
@@ -372,7 +363,16 @@ export class ChatStateController<TState extends ChatPageHost> implements Reactiv
         .closest<HTMLElement>(".chat-main")
         ?.style.removeProperty(CHAT_BOTTOM_DOCK_HEIGHT_PROPERTY);
       if (shell) {
-        queueMicrotask(() => syncActiveChatBottomDockHeight(shell));
+        queueMicrotask(() => {
+          const activeDock = shell.querySelector<HTMLElement>(
+            'openclaw-chat-pane[aria-hidden="false"] .chat-bottom-dock',
+          );
+          if (activeDock) {
+            syncChatBottomDockHeight(activeDock);
+          } else {
+            shell.style.setProperty(ACTIVE_CHAT_BOTTOM_DOCK_HEIGHT_PROPERTY, "0px");
+          }
+        });
       }
     }
     while (this.cleanups.length > 0) {

--- a/ui/src/pages/chat/chat-state-controller.ts
+++ b/ui/src/pages/chat/chat-state-controller.ts
@@ -310,6 +310,14 @@ export class ChatStateController<TState extends ChatPageHost> implements Reactiv
     this.chatBottomDockResizeTarget = dock;
   }
 
+  syncActiveBottomDockHeight(): void {
+    const dock = this.chatBottomDockResizeTarget;
+    const shell = dock?.closest<HTMLElement>(".shell");
+    if (shell) {
+      syncActiveChatBottomDockHeight(shell);
+    }
+  }
+
   hostConnected() {
     this.renderLifecycleConnectionEpoch += 1;
     this.renderLifecycleConnected = true;

--- a/ui/src/pages/chat/chat-state-controller.ts
+++ b/ui/src/pages/chat/chat-state-controller.ts
@@ -21,6 +21,21 @@ type ChatRenderLifecycleScope = {
   cancellations: Set<() => void>;
 };
 
+const CHAT_BOTTOM_DOCK_HEIGHT_PROPERTY = "--chat-bottom-dock-height";
+const ACTIVE_CHAT_BOTTOM_DOCK_HEIGHT_PROPERTY = "--chat-active-bottom-dock-height";
+
+function syncActiveChatBottomDockHeight(shell: HTMLElement): void {
+  const heights = [
+    ...shell.querySelectorAll<HTMLElement>(
+      'openclaw-chat-pane[aria-hidden="false"] .chat-bottom-dock',
+    ),
+  ].map((dock) => dock.getBoundingClientRect().height);
+  shell.style.setProperty(
+    ACTIVE_CHAT_BOTTOM_DOCK_HEIGHT_PROPERTY,
+    `${Math.ceil(Math.max(0, ...heights))}px`,
+  );
+}
+
 export class ChatStateController<TState extends ChatPageHost> implements ReactiveController {
   readonly attachmentReads: ChatAttachmentReadLifecycle;
   private readonly composerPersistence: ChatComposerPersistence;
@@ -33,8 +48,9 @@ export class ChatStateController<TState extends ChatPageHost> implements Reactiv
   private scrollAfterUpdate = false;
   private scrollContentChangedAfterUpdate = false;
   private forceScrollAfterUpdate = false;
-  private chatThreadResizeObserver: ResizeObserver | null = null;
+  private chatLayoutResizeObserver: ResizeObserver | null = null;
   private chatThreadResizeTarget: Element | null = null;
+  private chatBottomDockResizeTarget: HTMLElement | null = null;
   private readonly cleanups: Array<() => void> = [];
   private renderLifecycleConnected = false;
   private renderLifecycleConnectionEpoch = 0;
@@ -243,33 +259,55 @@ export class ChatStateController<TState extends ChatPageHost> implements Reactiv
     this.forceScrollAfterUpdate ||= loadFinished || streamStarted || !state.chatHasAutoScrolled;
   }
 
-  private syncChatThreadResizeObserver(state: TState) {
+  private syncChatLayoutResizeObserver(state: TState) {
     if (typeof ResizeObserver !== "function") {
       return;
     }
     const thread = state.querySelector(".chat-thread");
-    if (thread && this.chatThreadResizeTarget === thread) {
+    const dock = state.querySelector(".chat-bottom-dock") as HTMLElement | null;
+    if (
+      thread &&
+      dock &&
+      this.chatThreadResizeTarget === thread &&
+      this.chatBottomDockResizeTarget === dock
+    ) {
       return;
     }
 
-    this.chatThreadResizeObserver?.disconnect();
-    this.chatThreadResizeObserver = null;
+    this.chatLayoutResizeObserver?.disconnect();
+    this.chatLayoutResizeObserver = null;
     this.chatThreadResizeTarget = null;
-    if (!thread) {
+    this.chatBottomDockResizeTarget = null;
+    if (!thread || !dock) {
       return;
     }
 
-    // The transcript virtualizer owns row measurement and content-height
-    // correction. This observer only follows viewport-size changes.
-    this.chatThreadResizeObserver = new ResizeObserver(() => {
+    const syncDockHeight = () => {
+      const height = Math.ceil(dock.getBoundingClientRect().height);
+      dock
+        .closest<HTMLElement>(".chat-main")
+        ?.style.setProperty(CHAT_BOTTOM_DOCK_HEIGHT_PROPERTY, `${height}px`);
+      const shell = dock.closest<HTMLElement>(".shell");
+      if (shell) {
+        syncActiveChatBottomDockHeight(shell);
+      }
+    };
+    syncDockHeight();
+
+    // The transcript virtualizer still owns row measurement and anchoring. This
+    // observer only carries viewport and bottom-chrome size changes into layout.
+    this.chatLayoutResizeObserver = new ResizeObserver(() => {
       const currentState = this.stateValue;
       if (!currentState) {
         return;
       }
+      syncDockHeight();
       scheduleCommittedChatScroll(currentState, false, false, { source: "resize" });
     });
-    this.chatThreadResizeObserver.observe(thread);
+    this.chatLayoutResizeObserver.observe(thread);
+    this.chatLayoutResizeObserver.observe(dock);
     this.chatThreadResizeTarget = thread;
+    this.chatBottomDockResizeTarget = dock;
   }
 
   hostConnected() {
@@ -282,7 +320,7 @@ export class ChatStateController<TState extends ChatPageHost> implements Reactiv
   hostUpdated() {
     const state = this.stateValue;
     if (state) {
-      this.syncChatThreadResizeObserver(state);
+      this.syncChatLayoutResizeObserver(state);
     }
     if (!this.scrollAfterUpdate) {
       return;
@@ -315,9 +353,20 @@ export class ChatStateController<TState extends ChatPageHost> implements Reactiv
   }
 
   private stopChatEffects() {
-    this.chatThreadResizeObserver?.disconnect();
-    this.chatThreadResizeObserver = null;
+    this.chatLayoutResizeObserver?.disconnect();
+    this.chatLayoutResizeObserver = null;
     this.chatThreadResizeTarget = null;
+    const dock = this.chatBottomDockResizeTarget;
+    this.chatBottomDockResizeTarget = null;
+    if (dock) {
+      const shell = dock.closest<HTMLElement>(".shell");
+      dock
+        .closest<HTMLElement>(".chat-main")
+        ?.style.removeProperty(CHAT_BOTTOM_DOCK_HEIGHT_PROPERTY);
+      if (shell) {
+        queueMicrotask(() => syncActiveChatBottomDockHeight(shell));
+      }
+    }
     while (this.cleanups.length > 0) {
       this.cleanups.pop()?.();
     }

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -377,6 +377,42 @@ describe("ChatStateController render lifecycle", () => {
     } satisfies ReactiveControllerHost;
   }
 
+  it("publishes the activating retained pane's dock during inverse DOM-order switches", () => {
+    const shell = document.createElement("div");
+    shell.className = "shell";
+    const compactPane = document.createElement("openclaw-chat-pane");
+    compactPane.setAttribute("aria-hidden", "false");
+    const compactMain = document.createElement("div");
+    compactMain.className = "chat-main";
+    const compactDock = document.createElement("div");
+    compactDock.className = "chat-bottom-dock";
+    vi.spyOn(compactDock, "getBoundingClientRect").mockReturnValue({
+      height: 120,
+    } as DOMRect);
+    compactMain.append(compactDock);
+    compactPane.append(compactMain);
+
+    const outgoingTallPane = document.createElement("openclaw-chat-pane");
+    outgoingTallPane.setAttribute("aria-hidden", "false");
+    const outgoingTallDock = document.createElement("div");
+    outgoingTallDock.className = "chat-bottom-dock";
+    vi.spyOn(outgoingTallDock, "getBoundingClientRect").mockReturnValue({
+      height: 240,
+    } as DOMRect);
+    outgoingTallPane.append(outgoingTallDock);
+    shell.append(compactPane, outgoingTallPane);
+
+    const controller = new ChatStateController<ChatPageHost>(createControllerHost());
+    (
+      controller as unknown as { chatBottomDockResizeTarget: HTMLElement | null }
+    ).chatBottomDockResizeTarget = compactDock;
+
+    controller.syncActiveBottomDockHeight();
+
+    expect(shell.style.getPropertyValue("--chat-active-bottom-dock-height")).toBe("120px");
+    expect(compactMain.style.getPropertyValue("--chat-bottom-dock-height")).toBe("120px");
+  });
+
   function createInputHistoryState(
     renderLifecycle: NonNullable<ChatPageHost["renderLifecycle"]>,
     navigateHistory: ReturnType<typeof vi.fn>,

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -792,7 +792,10 @@ describe("chat typing status", () => {
       "typing status",
     );
 
-    expect(indicator.previousElementSibling?.classList.contains("chat-run-error")).toBe(true);
+    const adjuncts = requireElement(container, ".chat-composer-adjuncts", "composer adjuncts");
+    expect(adjuncts.querySelector(".chat-queue")).not.toBeNull();
+    expect(adjuncts.lastElementChild?.classList.contains("chat-run-error")).toBe(true);
+    expect(indicator.previousElementSibling).toBe(adjuncts);
     expect(indicator.nextElementSibling?.classList.contains("agent-chat__composer-shell")).toBe(
       true,
     );

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -934,9 +934,7 @@ describe("inline approval card", () => {
     const dock = inlineSurface?.closest(".chat-bottom-dock");
     expect(card?.getAttribute("data-approval-id")).toBe("approval-inline");
     expect(dock?.previousElementSibling?.classList.contains("chat-thread")).toBe(true);
-    expect(
-      inlineSurface?.nextElementSibling?.classList.contains("agent-chat__composer-shell"),
-    ).toBe(true);
+    expect(dock?.lastElementChild?.classList.contains("agent-chat__composer-shell")).toBe(true);
     expect(container.querySelector(".exec-approval-countdown")?.textContent?.trim()).toBe(
       "expires in 01:00",
     );
@@ -961,7 +959,9 @@ describe("chat run error", () => {
     expect(summary.textContent?.trim()).toBe("Error: gateway disconnected");
     expect(alert.querySelector(".chat-run-error__icon svg")).not.toBeNull();
     expect(alert.querySelector("button")).toBeNull();
-    expect(alert.nextElementSibling?.classList.contains("agent-chat__composer-shell")).toBe(true);
+    expect(
+      alert.parentElement?.nextElementSibling?.classList.contains("agent-chat__composer-shell"),
+    ).toBe(true);
   });
 });
 
@@ -1686,9 +1686,12 @@ describe("chat scroll-to-bottom affordance", () => {
     const wrapper = container.querySelector(".chat-scroll-to-bottom-wrap");
     const dock = container.querySelector(".chat-bottom-dock");
     const queue = container.querySelector(".chat-queue");
+    const composerAdjuncts = queue?.closest(".chat-composer-adjuncts");
     expect(wrapper?.nextElementSibling).toBe(dock);
-    expect(queue?.parentElement).toBe(dock);
-    expect(queue?.nextElementSibling?.classList.contains("agent-chat__composer-shell")).toBe(true);
+    expect(composerAdjuncts?.parentElement).toBe(dock);
+    expect(
+      composerAdjuncts?.nextElementSibling?.classList.contains("agent-chat__composer-shell"),
+    ).toBe(true);
   });
 
   it("hides the scroll-to-bottom button when the transcript is already latest", () => {

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -893,11 +893,13 @@ describe("chat Swarm progress", () => {
     });
 
     const widget = container.querySelector("[data-test-id=chat-swarm]");
+    const dock = widget?.closest(".chat-bottom-dock");
     expect(widget).not.toBeNull();
-    const scrollAnchor = widget?.previousElementSibling;
+    expect(dock).not.toBeNull();
+    const scrollAnchor = dock?.previousElementSibling;
     expect(scrollAnchor?.classList.contains("chat-scroll-to-bottom-wrap")).toBe(true);
     expect(scrollAnchor?.previousElementSibling?.classList.contains("chat-thread")).toBe(true);
-    expect(widget?.nextElementSibling?.classList.contains("agent-chat__composer-shell")).toBe(true);
+    expect(dock?.lastElementChild?.classList.contains("agent-chat__composer-shell")).toBe(true);
     expect(container.querySelector(".chat-swarm__dot--running")?.getAttribute("title")).toBe(
       "Worker A: Running",
     );
@@ -929,8 +931,9 @@ describe("inline approval card", () => {
 
     const card = container.querySelector(".chat-inline-approval .exec-approval-card");
     const inlineSurface = container.querySelector(".chat-inline-approval");
+    const dock = inlineSurface?.closest(".chat-bottom-dock");
     expect(card?.getAttribute("data-approval-id")).toBe("approval-inline");
-    expect(inlineSurface?.previousElementSibling?.classList.contains("chat-thread")).toBe(true);
+    expect(dock?.previousElementSibling?.classList.contains("chat-thread")).toBe(true);
     expect(
       inlineSurface?.nextElementSibling?.classList.contains("agent-chat__composer-shell"),
     ).toBe(true);
@@ -1654,13 +1657,14 @@ describe("chat scroll-to-bottom affordance", () => {
 
     const button = container.querySelector<HTMLButtonElement>(".chat-scroll-to-bottom");
     const wrapper = button?.closest(".chat-scroll-to-bottom-wrap");
+    const dock = wrapper?.nextElementSibling;
     expect(button?.getAttribute("aria-label")).toBe("Scroll to latest");
     expect(wrapper?.previousElementSibling?.classList.contains("chat-thread")).toBe(true);
-    expect(wrapper?.nextElementSibling?.classList.contains("chat-inline-approval")).toBe(true);
+    expect(dock?.classList.contains("chat-bottom-dock")).toBe(true);
     for (const surface of container.querySelectorAll(
       ".chat-inline-approval, .chat-queue, .agent-chat__composer-shell",
     )) {
-      expect(wrapper?.compareDocumentPosition(surface) ?? 0).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+      expect(dock?.contains(surface)).toBe(true);
     }
     expect(button?.textContent?.trim()).toBe("");
     expect(container.querySelector(".chat-new-messages")).toBeNull();
@@ -1680,8 +1684,10 @@ describe("chat scroll-to-bottom affordance", () => {
     });
 
     const wrapper = container.querySelector(".chat-scroll-to-bottom-wrap");
+    const dock = container.querySelector(".chat-bottom-dock");
     const queue = container.querySelector(".chat-queue");
-    expect(wrapper?.nextElementSibling).toBe(queue);
+    expect(wrapper?.nextElementSibling).toBe(dock);
+    expect(queue?.parentElement).toBe(dock);
     expect(queue?.nextElementSibling?.classList.contains("agent-chat__composer-shell")).toBe(true);
   });
 

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -594,39 +594,41 @@ export function renderChat(props: ChatProps) {
               <div class="chat-main__conversation">
                 ${thread} ${scrollToBottomButton} ${renderChatTaskSuggestionTray(props)}
                 <div class="chat-bottom-dock">
-                  ${props.inlineApproval && props.onApprovalDecision
-                    ? html`<div class="chat-inline-approval">
-                        ${renderExecApprovalCard({
-                          approval: props.inlineApproval,
-                          busy: props.approvalBusy === true,
-                          error: props.approvalErrors?.get(props.inlineApproval.id) ?? null,
-                          nowMs: props.approvalNowMs ?? Date.now(),
-                          variant: "inline",
-                          onDecision: props.onApprovalDecision,
-                        })}
-                      </div>`
-                    : nothing}
-                  ${renderChatPullRequests({
-                    pullRequests: props.pullRequests ?? [],
-                    branch: props.pullRequestsBranch,
-                    rateLimited: props.pullRequestsRateLimited === true,
-                    expanded: props.pullRequestsExpanded === true,
-                    onExpand: () => props.onExpandPullRequests?.(),
-                    onDismiss: (pullRequest) => props.onDismissPullRequest?.(pullRequest),
-                  })}
-                  ${renderChatSessionSuggestions({
-                    suggestions: props.sessionSuggestions ?? [],
-                    role: props.sessionSuggestionRole,
-                    busyIds: props.sessionSuggestionBusyIds ?? new Set(),
-                    archived: props.sessionSuggestionsArchived === true,
-                    canResolve: props.canResolveSessionSuggestions === true,
-                    onResolve: (suggestion, resolution) =>
-                      props.onResolveSessionSuggestion?.(suggestion, resolution),
-                  })}
-                  ${renderChatSwarmProgress({
-                    sessions: props.swarmSessions ?? [],
-                    sessionKey: props.sessionKey,
-                  })}
+                  <div class="chat-bottom-dock__adjuncts">
+                    ${props.inlineApproval && props.onApprovalDecision
+                      ? html`<div class="chat-inline-approval">
+                          ${renderExecApprovalCard({
+                            approval: props.inlineApproval,
+                            busy: props.approvalBusy === true,
+                            error: props.approvalErrors?.get(props.inlineApproval.id) ?? null,
+                            nowMs: props.approvalNowMs ?? Date.now(),
+                            variant: "inline",
+                            onDecision: props.onApprovalDecision,
+                          })}
+                        </div>`
+                      : nothing}
+                    ${renderChatPullRequests({
+                      pullRequests: props.pullRequests ?? [],
+                      branch: props.pullRequestsBranch,
+                      rateLimited: props.pullRequestsRateLimited === true,
+                      expanded: props.pullRequestsExpanded === true,
+                      onExpand: () => props.onExpandPullRequests?.(),
+                      onDismiss: (pullRequest) => props.onDismissPullRequest?.(pullRequest),
+                    })}
+                    ${renderChatSessionSuggestions({
+                      suggestions: props.sessionSuggestions ?? [],
+                      role: props.sessionSuggestionRole,
+                      busyIds: props.sessionSuggestionBusyIds ?? new Set(),
+                      archived: props.sessionSuggestionsArchived === true,
+                      canResolve: props.canResolveSessionSuggestions === true,
+                      onResolve: (suggestion, resolution) =>
+                        props.onResolveSessionSuggestion?.(suggestion, resolution),
+                    })}
+                    ${renderChatSwarmProgress({
+                      sessions: props.swarmSessions ?? [],
+                      sessionKey: props.sessionKey,
+                    })}
+                  </div>
                   ${showModelSetupSplash ? nothing : chatColumnFooter}
                 </div>
               </div>

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -592,42 +592,43 @@ export function renderChat(props: ChatProps) {
                 : ""}"
             >
               <div class="chat-main__conversation">
-                ${thread} ${scrollToBottomButton}
-                ${props.inlineApproval && props.onApprovalDecision
-                  ? html`<div class="chat-inline-approval">
-                      ${renderExecApprovalCard({
-                        approval: props.inlineApproval,
-                        busy: props.approvalBusy === true,
-                        error: props.approvalErrors?.get(props.inlineApproval.id) ?? null,
-                        nowMs: props.approvalNowMs ?? Date.now(),
-                        variant: "inline",
-                        onDecision: props.onApprovalDecision,
-                      })}
-                    </div>`
-                  : nothing}
-                ${renderChatTaskSuggestionTray(props)}
-                ${renderChatPullRequests({
-                  pullRequests: props.pullRequests ?? [],
-                  branch: props.pullRequestsBranch,
-                  rateLimited: props.pullRequestsRateLimited === true,
-                  expanded: props.pullRequestsExpanded === true,
-                  onExpand: () => props.onExpandPullRequests?.(),
-                  onDismiss: (pullRequest) => props.onDismissPullRequest?.(pullRequest),
-                })}
-                ${renderChatSessionSuggestions({
-                  suggestions: props.sessionSuggestions ?? [],
-                  role: props.sessionSuggestionRole,
-                  busyIds: props.sessionSuggestionBusyIds ?? new Set(),
-                  archived: props.sessionSuggestionsArchived === true,
-                  canResolve: props.canResolveSessionSuggestions === true,
-                  onResolve: (suggestion, resolution) =>
-                    props.onResolveSessionSuggestion?.(suggestion, resolution),
-                })}
-                ${renderChatSwarmProgress({
-                  sessions: props.swarmSessions ?? [],
-                  sessionKey: props.sessionKey,
-                })}
-                ${showModelSetupSplash ? nothing : chatColumnFooter}
+                ${thread} ${scrollToBottomButton} ${renderChatTaskSuggestionTray(props)}
+                <div class="chat-bottom-dock">
+                  ${props.inlineApproval && props.onApprovalDecision
+                    ? html`<div class="chat-inline-approval">
+                        ${renderExecApprovalCard({
+                          approval: props.inlineApproval,
+                          busy: props.approvalBusy === true,
+                          error: props.approvalErrors?.get(props.inlineApproval.id) ?? null,
+                          nowMs: props.approvalNowMs ?? Date.now(),
+                          variant: "inline",
+                          onDecision: props.onApprovalDecision,
+                        })}
+                      </div>`
+                    : nothing}
+                  ${renderChatPullRequests({
+                    pullRequests: props.pullRequests ?? [],
+                    branch: props.pullRequestsBranch,
+                    rateLimited: props.pullRequestsRateLimited === true,
+                    expanded: props.pullRequestsExpanded === true,
+                    onExpand: () => props.onExpandPullRequests?.(),
+                    onDismiss: (pullRequest) => props.onDismissPullRequest?.(pullRequest),
+                  })}
+                  ${renderChatSessionSuggestions({
+                    suggestions: props.sessionSuggestions ?? [],
+                    role: props.sessionSuggestionRole,
+                    busyIds: props.sessionSuggestionBusyIds ?? new Set(),
+                    archived: props.sessionSuggestionsArchived === true,
+                    canResolve: props.canResolveSessionSuggestions === true,
+                    onResolve: (suggestion, resolution) =>
+                      props.onResolveSessionSuggestion?.(suggestion, resolution),
+                  })}
+                  ${renderChatSwarmProgress({
+                    sessions: props.swarmSessions ?? [],
+                    sessionKey: props.sessionKey,
+                  })}
+                  ${showModelSetupSplash ? nothing : chatColumnFooter}
+                </div>
               </div>
               ${props.sessionRailReady
                 ? html`

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -156,26 +156,28 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
   ).join(", ");
 
   return html`
-    ${renderChatQueue({
-      queue: props.queue,
-      canAbort: showAbortableUi,
-      onQueueRetry: props.connected && canCompose ? props.onQueueRetry : undefined,
-      onQueueSteer: props.connected && canCompose ? props.onQueueSteer : undefined,
-      // Reordering is local bookkeeping, so it stays available while offline —
-      // exactly when a queue is long enough to need it.
-      onQueueMove: props.onQueueMove,
-      onQueueEdit: props.queuedEdit?.onEdit,
-      editingId: props.queuedEdit?.editingId ?? null,
-      onQueueRemove: props.onQueueRemove,
-    })}
-    ${props.runError
-      ? html`
-          <div class="chat-run-error" role="alert">
-            <span class="chat-run-error__icon" aria-hidden="true">${icons.alertTriangle}</span>
-            <span class="chat-run-error__summary">${props.runError.summary}</span>
-          </div>
-        `
-      : nothing}
+    <div class="chat-composer-adjuncts">
+      ${renderChatQueue({
+        queue: props.queue,
+        canAbort: showAbortableUi,
+        onQueueRetry: props.connected && canCompose ? props.onQueueRetry : undefined,
+        onQueueSteer: props.connected && canCompose ? props.onQueueSteer : undefined,
+        // Reordering is local bookkeeping, so it stays available while offline —
+        // exactly when a queue is long enough to need it.
+        onQueueMove: props.onQueueMove,
+        onQueueEdit: props.queuedEdit?.onEdit,
+        editingId: props.queuedEdit?.editingId ?? null,
+        onQueueRemove: props.onQueueRemove,
+      })}
+      ${props.runError
+        ? html`
+            <div class="chat-run-error" role="alert">
+              <span class="chat-run-error__icon" aria-hidden="true">${icons.alertTriangle}</span>
+              <span class="chat-run-error__summary">${props.runError.summary}</span>
+            </div>
+          `
+        : nothing}
+    </div>
     ${showComposerInput && props.typingActors?.length
       ? html`<div
           class="agent-chat__typing-indicator agent-chat__typing-indicator--outside"

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1657,6 +1657,7 @@ button.chat-reply-preview--message:disabled {
   z-index: 20;
   inset: auto 0 0;
   display: flex;
+  max-height: 100%;
   flex-direction: column;
   pointer-events: none;
 }
@@ -1672,6 +1673,22 @@ button.chat-reply-preview--message:disabled {
 .chat-bottom-dock > * {
   position: relative;
   pointer-events: auto;
+}
+
+.chat-bottom-dock__adjuncts,
+.chat-bottom-dock .chat-composer-adjuncts {
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.chat-bottom-dock__adjuncts:empty,
+.chat-bottom-dock .chat-composer-adjuncts:empty {
+  display: none;
+}
+
+.chat-bottom-dock .agent-chat__composer-shell {
+  flex: 0 0 auto;
 }
 
 /* Floating tray pinned to the conversation's top-right (the positioned

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -311,7 +311,8 @@ openclaw-chat-page {
      scroll container's padding, which floats the thumb away from the pane
      edge (visible next to the sidebar divider). The side inset lives on
      .chat-thread-inner instead so the scrollbar hugs the edge. */
-  padding: clamp(20px, 3vh, 28px) 0 6px;
+  padding: clamp(20px, 3vh, 28px) 0
+    calc(var(--chat-bottom-dock-height, 0px) + var(--chat-composer-floater-gap));
   margin: 0 0 0 0;
   min-height: 0;
   /* Allow shrinking for flex scroll behavior */
@@ -446,7 +447,7 @@ openclaw-chat-page {
 
 .chat-scroll-to-bottom {
   position: absolute;
-  bottom: 12px;
+  bottom: calc(var(--chat-bottom-dock-height, 0px) + var(--chat-composer-floater-gap));
   left: 50%;
   display: inline-flex;
   align-items: center;
@@ -1647,6 +1648,30 @@ button.chat-reply-preview--message:disabled {
   width: calc(100% - 36px);
   max-width: var(--chat-thread-max-width, 48rem);
   margin: 8px auto 14px;
+}
+
+/* Bottom chrome overlays the transcript while its measured footprint remains
+   reserved inside the scrollport, so the final row can still clear the dock. */
+.chat-bottom-dock {
+  position: absolute;
+  z-index: 20;
+  inset: auto 0 0;
+  display: flex;
+  flex-direction: column;
+  pointer-events: none;
+}
+
+.chat-bottom-dock::before {
+  content: "";
+  position: absolute;
+  inset: -28px 0 0;
+  background: linear-gradient(to bottom, transparent, var(--chat-surface) 28px);
+  pointer-events: none;
+}
+
+.chat-bottom-dock > * {
+  position: relative;
+  pointer-events: auto;
 }
 
 /* Floating tray pinned to the conversation's top-right (the positioned

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -163,6 +163,7 @@
 
 .chat-main {
   /* Positioning context for floating overlays and the optional session rail. */
+  --chat-composer-floater-gap: 12px;
   position: relative;
   min-width: 312px;
   display: flex;

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -616,10 +616,8 @@ openclaw-session-owner-chip {
 }
 
 /* Passive notification, so it sits in the trailing bottom corner rather than
- * centered over the content column, where it landed on top of the chat composer's
- * controls. Overlapping the composer region from the corner is accepted. The host
- * shows one toast at a time (`show()` replaces the active one), so there is no
- * stack to offset against. */
+ * centered over the content column. The host shows one toast at a time (`show()`
+ * replaces the active one), so there is no stack to offset against. */
 .app-toast {
   position: fixed;
   right: calc(20px + var(--safe-area-right));
@@ -635,6 +633,10 @@ openclaw-session-owner-chip {
   background: var(--popover);
   color: var(--popover-foreground);
   box-shadow: var(--shadow-lg);
+}
+
+.shell--chat .app-toast {
+  bottom: calc(20px + var(--safe-area-bottom) + var(--chat-active-bottom-dock-height, 0px));
 }
 
 /* A corner toast degenerates at phone widths, where it would span nearly the
@@ -2036,7 +2038,10 @@ openclaw-chat-session-rail {
     top: auto;
     left: max(8px, var(--safe-area-left));
     right: max(8px, var(--safe-area-right));
-    bottom: calc(108px + var(--safe-area-bottom));
+    bottom: calc(
+      var(--chat-bottom-dock-height, 96px) + var(--chat-composer-floater-gap, 12px) +
+        var(--safe-area-bottom)
+    );
     z-index: 35;
     width: auto;
   }

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -636,7 +636,13 @@ openclaw-session-owner-chip {
 }
 
 .shell--chat .app-toast {
-  bottom: calc(20px + var(--safe-area-bottom) + var(--chat-active-bottom-dock-height, 0px));
+  /* Keep passive notifications clear of the transcript's semantic
+   * scroll-to-latest control. Both are bottom overlays; without this
+   * clearance the toast's higher stacking layer intercepts the button. */
+  bottom: calc(
+    20px + var(--safe-area-bottom) + var(--chat-active-bottom-dock-height, 0px) +
+      36px + var(--chat-composer-floater-gap)
+  );
 }
 
 /* A corner toast degenerates at phone widths, where it would span nearly the

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -640,8 +640,8 @@ openclaw-session-owner-chip {
    * scroll-to-latest control. Both are bottom overlays; without this
    * clearance the toast's higher stacking layer intercepts the button. */
   bottom: calc(
-    20px + var(--safe-area-bottom) + var(--chat-active-bottom-dock-height, 0px) +
-      36px + var(--chat-composer-floater-gap)
+    20px + var(--safe-area-bottom) + var(--chat-active-bottom-dock-height, 0px) + 36px +
+      var(--chat-composer-floater-gap)
   );
 }
 


### PR DESCRIPTION
Closes #122456

## What Problem This Solves

Fixes an issue where users scrolling a long Control UI chat would see the transcript stop above the composer instead of continuing beneath it. The fixed layout also keeps scroll-to-latest, the mobile session companion, and toast surfaces on offsets that follow a multiline or queue-expanded composer.

## Why This Change Was Made

In this PR, the conversation layout owns one measured bottom dock. Its live height becomes internal transcript padding and the shared offset for bottom-adjacent floaters, while the transcript virtualizer, restoration, streaming follow, and pagination mechanisms stay unchanged. Oversized approval, suggestion, status, and queue regions scroll inside the dock so the composer and required actions remain reachable.

## User Impact

Chat content scrolls behind the composer without losing vertical space, and the final message can still scroll fully above it. Multiline drafts, queue rows, scroll-to-latest, the mobile session companion, and toasts keep a consistent gap from the measured dock in both themes.

## Evidence

Rich fixture: 42-message transcript, multiline composer, two queued reconnect rows, scroll-to-latest, and a persistent toast. The before captures are the same fixture on the baseline flow; proposed captures are from the PR head. Exact-end is separately labeled from backscroll so the final receipt is unambiguous.

| State | Before (baseline) | Proposed in this PR |
| --- | --- | --- |
| Dark backscroll · desktop | <img width="560" alt="Dark baseline backscroll: transcript stops above composer" src="https://github.com/user-attachments/assets/b6fd3d13-ac09-46bf-a00b-aa64ebc7c2fa" /> | <img width="560" alt="Dark proposed backscroll: transcript continues beneath measured dock" src="https://github.com/user-attachments/assets/5fb9dda2-d0a2-40f6-9b71-26280742439f" /> |
| Light backscroll · desktop | <img width="560" alt="Light baseline backscroll: transcript stops above composer" src="https://github.com/user-attachments/assets/9219e46e-72b4-4cf2-87b1-669e8bf4ee94" /> | <img width="560" alt="Light proposed backscroll: transcript continues beneath measured dock" src="https://github.com/user-attachments/assets/136d4958-1deb-4978-83b7-98128b6df599" /> |

Exact-end and adjunct overflow on the proposed head:

| Dark exact-end | Light exact-end |
| --- | --- |
| <img width="560" alt="Dark proposed exact-end: final receipt fully above composer dock" src="https://github.com/user-attachments/assets/54dbb62a-4979-4290-8e22-b7f1397b5be5" /> | <img width="560" alt="Light proposed exact-end: final receipt fully above composer dock" src="https://github.com/user-attachments/assets/2a15071c-86f8-47ef-9a53-9888fcc1fb10" /> |

| Dark adjunct overflow | Light adjunct overflow |
| --- | --- |
| <img width="560" alt="Dark proposed adjunct overflow: 26 queue rows scroll inside bounded dock" src="https://github.com/user-attachments/assets/b2dce28f-10e6-433b-8b42-8612e74d54b2" /> | <img width="560" alt="Light proposed adjunct overflow: 26 queue rows scroll inside bounded dock" src="https://github.com/user-attachments/assets/48d9ee0e-a52d-4493-9b77-6ff44d2d4c9d" /> |

Mobile backscroll (same fixture, 393 × 852):

| Dark | Light |
| --- | --- |
| <img width="560" alt="Dark proposed mobile backscroll with dock and toast offsets" src="https://github.com/user-attachments/assets/eecef5a7-e4f9-426f-ad1f-17a7aa509ba9" /> | <img width="560" alt="Light proposed mobile backscroll with dock and toast offsets" src="https://github.com/user-attachments/assets/1960efda-9e5b-4b7e-8b67-4d739c298acb" /> |

Remote Testbox proof: [matrix run](https://github.com/openclaw/openclaw/actions/runs/31575042067). The four-theme/viewport E2E emitted the captures above; desktop assertions cover transcript-under-dock geometry, exact-end reachability, multiline resize, manual scroll lock, scroll-to-latest/toast gaps, and 26-row internal queue scrolling. Mobile backscroll confirms the same dock/toast relationship at 393 × 852. The wrapper was stopped after the remote artifacts were collected and inspected; no local browser or build was used.

Earlier focused Testbox suites on the same PR head remain green: `chat-view.test.ts`, `chat-responsive.browser.test.ts`, `scroll.test.ts` (365/365), `chat-transcript-controller.test.ts` and `chat-pane-history.test.ts` (34/34), plus the prior exact-scope check-changed run ([run](https://github.com/openclaw/openclaw/actions/runs/31567689189)).

Pre-fix reproduction: the same E2E failed both themes waiting for the absent measured dock on baseline ([run](https://github.com/openclaw/openclaw/actions/runs/31566502897)).

### Scenario matrix

| Scenario | Result |
| --- | --- |
| Long transcript under composer | Dark/light desktop backscroll and mobile backscroll captures; transcript shares the conversation bottom edge |
| Final message reachable | Dark/light exact-end captures show the final receipt wholly above the dock |
| Multiline composer | Live dock height and transcript padding grow/shrink together in the E2E |
| Distinct backscroll | Separate `backscroll` captures show older transcript context without being mislabeled exact-end |
| Scroll-to-latest | Uses the measured dock offset with a visible gap |
| Queue chips and run error | Included in the dock; 26-row adjunct capture shows internal scrolling |
| Approval, PR, session suggestion, swarm rows | Shared scrollable adjunct owner prevents viewport overflow |
| Mobile session companion | Mobile 393 × 852 capture uses the measured dock offset |
| Toasts | Active visible pane dock height supplies the global bottom offset |
| Restoration, streaming anchoring, virtualization, pagination | Canonical owners unchanged; focused invariant suites remain green |

Production delta is +119 lines. The change is limited to live measurement and one bounded overflow contract shared by the transcript and bottom-adjacent floaters; no scroll, virtualizer, or pagination path was duplicated.

## Follow-up owner repair

The focused mobile reproof exposed one real interaction regression in the floating layout: the persistent chat toast sat in the higher toast layer over the semantic **Scroll to latest** control, so a real mobile click left the transcript at the top. This PR now reserves the existing 36px control footprint plus the composer gap in the chat toast offset. The canonical `scroll.ts` path remains unchanged. The same E2E uses a normal semantic click and passes dark/light desktop/mobile (4/4) remotely on Testbox: [owner repair proof](https://github.com/openclaw/openclaw/actions/runs/31581340219).

The first exact-head CI attempt also caught a formatter-only issue in this CSS expression; the canonical remote formatter corrected it in head `993954b6574`. The focused 4/4 proof was rerun after that mechanical correction on Testbox: [post-format proof](https://github.com/openclaw/openclaw/actions/runs/31582268684).


## Retained-pane lifecycle repair

ClawSweeper's P2 finding is addressed at the presentation owner. Activating a cached chat now republishes that pane's measured dock height to the shell before bottom-adjacent chrome is positioned; no scroll bypass or consumer-side guard was added.

The regression fixture retains two chats with different composer heights and switches A → B → A → B. Every state asserts the active dock variable, toast clearance, a visible semantic **Scroll to latest** control, and a real click through the canonical scroll path.

| Retained-session state | Dark desktop | Light desktop | Dark mobile | Light mobile |
| --- | --- | --- | --- | --- |
| Compact → tall → compact → tall | Pass | Pass | Pass | Pass |
| Toast and scroll-control clearance | Pass | Pass | Pass | Pass |
| Semantic scroll reaches exact end | Pass | Pass | Pass | Pass |

Remote red reproduction: before the lifecycle repair, the newly active 198px dock left the shell variable at 120px ([AWS run](https://crabbox.openclaw.ai/portal/runs/run_627140668b6c)). Remote green visual matrix: 8/8 retained-session and complete-composer states across desktop/mobile and light/dark ([AWS run](https://crabbox.openclaw.ai/portal/runs/run_afe0e2c730b4)).

Pre-second-review proof for `a6dcef0ea0d08311e34fee5bb26bdf9ddd577080` ran only on delegated Blacksmith Testbox: format and oxlint passed; `tsgo:ui` passed; 384 focused sibling tests passed; the browser matrix passed 8/8 ([Testbox run](https://github.com/openclaw/openclaw/actions/runs/31665992525)). The test waits for retained-pane scroll lifecycle settlement before synthetic backscroll, so delayed canonical activation scroll cannot overwrite the user-position fixture.

Independent autoreview was unavailable within the secret-safe remote boundary and was not retried. No credential material was copied or injected for validation.

## Inverse DOM-order lifecycle repair

The fresh ClawSweeper review found a second valid ordering race: while `present()` walked compact-first DOM order, the incoming compact pane and outgoing tall pane could both be `aria-visible` for one synchronous activation step. The previous `max()` scan therefore published 240px for a 120px active dock until a later resize happened to repair it.

This PR now has one canonical publisher that receives the owning controller dock directly. It updates that pane transcript reserve and publishes the shell offset only when that pane is active. Teardown retains a deferred post-loop lookup solely to transfer or clear ownership after removal.

The owner-level regression fails on the previous head with `Received: 240px`, `Expected: 120px` ([remote red](https://github.com/openclaw/openclaw/actions/runs/31666974961)). On head `0516bfd6fde08a66cd6e6a254d26fc86b2afcf5b`, remote format/oxlint and `tsgo:ui` pass; 436 focused sibling tests pass; and the compact → tall → compact → tall browser matrix passes 8/8 across desktop/mobile and light/dark ([remote green](https://github.com/openclaw/openclaw/actions/runs/31667291937)). This finding repair is production net-neutral (+24/-24) and adds the 36-line synchronous regression test.

### Exact-head CI assertion follow-through

CI on `0516bfd6fde0` exposed an outdated E2E assertion that still expected `.chat-run-error` to be a direct sibling of the composer. The production change intentionally places queue/error rows inside `.chat-composer-adjuncts`; the test now asserts that owner is immediately before the composer and still verifies matching geometry. Desktop and mobile focused proof passed remotely ([Testbox run](https://github.com/openclaw/openclaw/actions/runs/31668149913)). Final public head: `45660e0a0948df0c8d62490f12cc0efb30e91377`.