### PR TITLE
fix(ci): prepare sandbox before repo E2E

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -977,7 +977,7 @@ jobs:
     if: inputs.include_repo_e2e && inputs.live_suite_filter == ''
     continue-on-error: ${{ inputs.advisory }}
     runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-32vcpu-ubuntu-2404' }}
-    timeout-minutes: ${{ inputs.release_test_profile == 'full' && 90 || 60 }}
+    timeout-minutes: 90
     env:
       OPENCLAW_BUILD_PRIVATE_QA: "1"
       OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1"
@@ -1003,6 +1003,9 @@ jobs:
 
       - name: Install Playwright Chromium
         run: pnpm --dir ui exec playwright install --with-deps chromium
+
+      - name: Build sandbox image
+        run: scripts/sandbox-setup.sh
 
       - name: Run repo E2E suite
         run: pnpm test:e2e

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -3190,6 +3190,14 @@ NODE
       OPENCLAW_BUILD_PRIVATE_QA: "1",
       OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1",
     });
+    expect(releaseChecks.jobs.validate_repo_e2e["timeout-minutes"]).toBe(90);
+    const repoE2eSteps = releaseChecks.jobs.validate_repo_e2e.steps as WorkflowStep[];
+    const sandboxSetupIndex = repoE2eSteps.findIndex(
+      (step) => step.name === "Build sandbox image" && step.run === "scripts/sandbox-setup.sh",
+    );
+    const repoE2eIndex = repoE2eSteps.findIndex((step) => step.name === "Run repo E2E suite");
+    expect(sandboxSetupIndex).toBeGreaterThanOrEqual(0);
+    expect(repoE2eIndex).toBeGreaterThan(sandboxSetupIndex);
     const targetedGroupStep = releaseChecks.jobs.plan_docker_lane_groups.steps.find(
       (step: WorkflowStep) => step.name === "Build targeted Docker lane groups",
     );


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation problem where the repository E2E lane could run without the sandbox image it exercises and could time out after 60 minutes on non-full profiles.

## Why This Change Was Made

The reusable release workflow now builds the canonical sandbox image before starting repository E2E and gives that lane a consistent 90-minute budget. Workflow guards lock both the ordering and timeout without changing the sandbox setup script.

## User Impact

Maintainers get deterministic repository E2E validation for frozen release candidates instead of a missing-prerequisite failure or premature timeout.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` (114 passed, 2 skipped)
- `node scripts/check-changed.mjs -- .github/workflows/openclaw-live-and-e2e-checks-reusable.yml test/scripts/ci-workflow-guards.test.ts` (Testbox green; testRoot and tooling lanes)
- `git diff --check`
- Autoreview: clean, no accepted/actionable findings

AI-assisted: yes. The change and evidence were reviewed by the maintainer before publication.
