### PR TITLE
fix(channels): fail-fast headless channel setup with plugin-declared env contracts

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"ceeafb07e044221f76b571890f590c2458ed22063b30cb49257b51e43ab2fc56","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}
+{"contentHash":"610515547976f67620649d5537e97885a1f90f4b04866375cba5e0f4b4604b3c","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"81edf86f9ac989d2c85a531a271396c8ca553bd40f80a3e93903b3cf34385146","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}
+{"contentHash":"1811c3a3bd4ceb95886a0fe41fd5f789c169ea59e599f322531a8601d86e614e","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"c79713b3dbca29f261fd7f81e7c5ef3c2bfb828cceb0986b6cc808654d172bd7","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}
+{"contentHash":"ceeafb07e044221f76b571890f590c2458ed22063b30cb49257b51e43ab2fc56","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"1811c3a3bd4ceb95886a0fe41fd5f789c169ea59e599f322531a8601d86e614e","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}
+{"contentHash":"515c1a05ff342697874738fc02bc7a5f8e0d2fc3723d0fbed21a3592022f7839","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"610515547976f67620649d5537e97885a1f90f4b04866375cba5e0f4b4604b3c","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}
+{"contentHash":"b21d2945a313e9ef483faf1c411598d16fc1ff5a77e29481b0738d52e4a760c9","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"b21d2945a313e9ef483faf1c411598d16fc1ff5a77e29481b0738d52e4a760c9","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}
+{"contentHash":"f0a3282bbb9dd2ff22df32d5f86a27a488e6f7f6b007548d2026712b4e59a6c5","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"515c1a05ff342697874738fc02bc7a5f8e0d2fc3723d0fbed21a3592022f7839","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}
+{"contentHash":"c79713b3dbca29f261fd7f81e7c5ef3c2bfb828cceb0986b6cc808654d172bd7","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
@@ -1,1 +1,1 @@
-{"contentHash":"a657fd3bfd501b113e06ebf42fd4d0582534505a92fe58812b2d65a2aeddcbe1","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
+{"contentHash":"60140db5b14eb3811a0398983df4729a0c4c2036f49a85622c1ed4a62b2e232a","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
@@ -1,1 +1,1 @@
-{"contentHash":"1bb99b68596361bc2ef9f1c8011f1d87fbbdc78d0bde58d9e89625a5e2bf2de7","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
+{"contentHash":"411d365fac50219e7eef891301ee9c6de36e3af2645b494f72f691b310318c81","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
@@ -1,1 +1,1 @@
-{"contentHash":"411d365fac50219e7eef891301ee9c6de36e3af2645b494f72f691b310318c81","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
+{"contentHash":"e6f7734a3db6b275a3e62b8dda647f70843f6a0d73231ca456f5e9b47843e008","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
@@ -1,1 +1,1 @@
-{"contentHash":"e6f7734a3db6b275a3e62b8dda647f70843f6a0d73231ca456f5e9b47843e008","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
+{"contentHash":"9caccca5b80c481dbf15bb87429e2f3f1f72766cfcd48b192c7d56a1b682e360","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
@@ -1,1 +1,1 @@
-{"contentHash":"3f751c43a454fda706010bda9d6be7426d0f5b53241b8975ea27dbb4e74d6fe1","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
+{"contentHash":"a657fd3bfd501b113e06ebf42fd4d0582534505a92fe58812b2d65a2aeddcbe1","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
@@ -1,1 +1,1 @@
-{"contentHash":"9caccca5b80c481dbf15bb87429e2f3f1f72766cfcd48b192c7d56a1b682e360","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
+{"contentHash":"85a3b930a0f93d8a2d7967ea05884f9b2ce633a68fff5aeebcbc85e9206ac6a5","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
@@ -1,1 +1,1 @@
-{"contentHash":"85a3b930a0f93d8a2d7967ea05884f9b2ce633a68fff5aeebcbc85e9206ac6a5","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
+{"contentHash":"3f751c43a454fda706010bda9d6be7426d0f5b53241b8975ea27dbb4e74d6fe1","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"be42cc2220e3924f4d5fac6e6fb1cf8a4e8679b0e51ad64b8806efd519ef47a5","entrypoint":"agent-runtime","importSpecifier":"openclaw/plugin-sdk/agent-runtime"}
+{"contentHash":"553851d17f28d68315786060ff119703656f95fbc971a193abc133af0748975c","entrypoint":"agent-runtime","importSpecifier":"openclaw/plugin-sdk/agent-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"553851d17f28d68315786060ff119703656f95fbc971a193abc133af0748975c","entrypoint":"agent-runtime","importSpecifier":"openclaw/plugin-sdk/agent-runtime"}
+{"contentHash":"872b2dd9de282ac6a571bab611e652474230972f713cf28b8d8c237aef842375","entrypoint":"agent-runtime","importSpecifier":"openclaw/plugin-sdk/agent-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"872b2dd9de282ac6a571bab611e652474230972f713cf28b8d8c237aef842375","entrypoint":"agent-runtime","importSpecifier":"openclaw/plugin-sdk/agent-runtime"}
+{"contentHash":"a5fd8c9fbf19c5a9eb6dca252cd551616571ddf344cf8e2963135e4b418cf063","entrypoint":"agent-runtime","importSpecifier":"openclaw/plugin-sdk/agent-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"0411ae87d138ede40528ca7416fb1a9716f7f73b2b788e7c322048a6854b40d9","entrypoint":"agent-runtime","importSpecifier":"openclaw/plugin-sdk/agent-runtime"}
+{"contentHash":"be42cc2220e3924f4d5fac6e6fb1cf8a4e8679b0e51ad64b8806efd519ef47a5","entrypoint":"agent-runtime","importSpecifier":"openclaw/plugin-sdk/agent-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-core.json
@@ -1,1 +1,1 @@
-{"contentHash":"fd24b38cc4fa68fa0ba84b2db80b2466531ae166006665406a75ee3dab96e580","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}
+{"contentHash":"123c2fda06ca6c20c5bebc203722df29611e5ffc659187c020d3a197cb6c6d64","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-core.json
@@ -1,1 +1,1 @@
-{"contentHash":"123c2fda06ca6c20c5bebc203722df29611e5ffc659187c020d3a197cb6c6d64","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}
+{"contentHash":"749d16c95f510ce2bddb0650e5e1fbad310130ca17768d005b601642dddbb949","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-core.json
@@ -1,1 +1,1 @@
-{"contentHash":"749d16c95f510ce2bddb0650e5e1fbad310130ca17768d005b601642dddbb949","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}
+{"contentHash":"6429c5d3e75b11181d6685f2abfd4662cb687054505bb8ba57afe492a7f28980","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-core.json
@@ -1,1 +1,1 @@
-{"contentHash":"6c638b1fcf5a1cadce5a5363ae4cd8f29fe513feb90331272349ef5bf70bc63a","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}
+{"contentHash":"4d75ed614c9983aaf0f2465574790bfa18663623d56b15795fec115ef790ca66","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-core.json
@@ -1,1 +1,1 @@
-{"contentHash":"5da19ce6581d04d321e813790293ffadf446bd8d785f767c04d2b9611c949e8c","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}
+{"contentHash":"e78d0b185d0a718fc12254b09e8432265614c8cdddae804a383fd0da3093968a","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-core.json
@@ -1,1 +1,1 @@
-{"contentHash":"4d75ed614c9983aaf0f2465574790bfa18663623d56b15795fec115ef790ca66","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}
+{"contentHash":"fd24b38cc4fa68fa0ba84b2db80b2466531ae166006665406a75ee3dab96e580","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-core.json
@@ -1,1 +1,1 @@
-{"contentHash":"6429c5d3e75b11181d6685f2abfd4662cb687054505bb8ba57afe492a7f28980","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}
+{"contentHash":"5da19ce6581d04d321e813790293ffadf446bd8d785f767c04d2b9611c949e8c","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
@@ -1,1 +1,1 @@
-{"contentHash":"3cdd444879b80ce6d6a0501c5e5c76b9578ba4cb69bf229ed79c60ecb52faf3c","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}
+{"contentHash":"9a973550748f2368a9d343b554aabecce014bce42538cf4b4d1c220f44491867","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
@@ -1,1 +1,1 @@
-{"contentHash":"9f812b6a1bb52444864fce41c47ace63303dc304bf1949d6665fdba913ef5ec8","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}
+{"contentHash":"ce010d1513ad12fb151bd133f12ee73fed04d7ca318b27fcafaf8228a7df5992","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
@@ -1,1 +1,1 @@
-{"contentHash":"124cab1bcce6584a0e342045048050cf5d63c7e534cde1d602a4b618ec523958","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}
+{"contentHash":"9f812b6a1bb52444864fce41c47ace63303dc304bf1949d6665fdba913ef5ec8","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
@@ -1,1 +1,1 @@
-{"contentHash":"ce010d1513ad12fb151bd133f12ee73fed04d7ca318b27fcafaf8228a7df5992","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}
+{"contentHash":"f1804d094895fffe929f32fbda11ddbef26be518eb310efff3b337cc069feb53","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
@@ -1,1 +1,1 @@
-{"contentHash":"bc4d167428d9afd18cabd141802354b32df1a559c2b018e49f14622f60ea661d","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}
+{"contentHash":"124cab1bcce6584a0e342045048050cf5d63c7e534cde1d602a4b618ec523958","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
@@ -1,1 +1,1 @@
-{"contentHash":"fa4140b50658ecfab11c323c24ba6f0fe0a5cb1608c8fa3e8eefa3e4e4192e77","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}
+{"contentHash":"3cdd444879b80ce6d6a0501c5e5c76b9578ba4cb69bf229ed79c60ecb52faf3c","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
@@ -1,1 +1,1 @@
-{"contentHash":"9a973550748f2368a9d343b554aabecce014bce42538cf4b4d1c220f44491867","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}
+{"contentHash":"bc4d167428d9afd18cabd141802354b32df1a559c2b018e49f14622f60ea661d","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-message.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-message.json
@@ -1,1 +1,1 @@
-{"contentHash":"9b43824aface89f63f2ffa6fadf643cc78fc844e94b216f12d867791a9ddc5d1","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}
+{"contentHash":"cd7c4960f564c6128457e34a8d0289226795674f2b9f2b80d3005f25a24fdc78","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-message.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-message.json
@@ -1,1 +1,1 @@
-{"contentHash":"a3f5ea1b63505189dc9031a969b91c55f30ddb6bbc8b2b52c41756cfe132a2f2","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}
+{"contentHash":"9b43824aface89f63f2ffa6fadf643cc78fc844e94b216f12d867791a9ddc5d1","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-message.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-message.json
@@ -1,1 +1,1 @@
-{"contentHash":"cd7c4960f564c6128457e34a8d0289226795674f2b9f2b80d3005f25a24fdc78","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}
+{"contentHash":"9e96e620155dbc97b8cc74b1eeaf8987fc535d23e9f3c86450a9a75cc202964d","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-message.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-message.json
@@ -1,1 +1,1 @@
-{"contentHash":"871a0410ea1e63b4fc4a3b54ea6d13a2625a10807bc43ac816c2462c5a09ff07","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}
+{"contentHash":"b1e4ca431d8b2b1086a1bee523f3c18636b195ef5fdf47ed118d8091d4b3ef9a","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-message.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-message.json
@@ -1,1 +1,1 @@
-{"contentHash":"5c1b1998403a8527055fff05caa86f51ccd981c08ebd8ba8c7f9da19a8e16e33","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}
+{"contentHash":"871a0410ea1e63b4fc4a3b54ea6d13a2625a10807bc43ac816c2462c5a09ff07","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-message.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-message.json
@@ -1,1 +1,1 @@
-{"contentHash":"47ffc8c32eecc25e542d91007ebabd72eba68b52ddd7f8d6831fc2b140dbac87","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}
+{"contentHash":"a3f5ea1b63505189dc9031a969b91c55f30ddb6bbc8b2b52c41756cfe132a2f2","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-message.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-message.json
@@ -1,1 +1,1 @@
-{"contentHash":"b1e4ca431d8b2b1086a1bee523f3c18636b195ef5fdf47ed118d8091d4b3ef9a","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}
+{"contentHash":"47ffc8c32eecc25e542d91007ebabd72eba68b52ddd7f8d6831fc2b140dbac87","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"8acd6e572fc0673faf1a677e896d5b75ddb00de23e79952a4935e0bfb8e6eaf8","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}
+{"contentHash":"febc6854cb89d5c26debeec50008526d0a8d97738f727011c3942509bb538fcc","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"88de5e2ee36fc48176dd10b32b141b0bf71fd64040b0febb569acb1d4332be53","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}
+{"contentHash":"d82aae31c60ebecfb6faed8c1f8c61e9e16555f7142db2181b2face1b4a425c7","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"f7942300508de97a94c48aa45d05c1862c868ef90019da47cb8d3e7b46a2f7c9","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}
+{"contentHash":"0401646cd754ffa6a5223dd6bf338f09729a830a45d5e0d52f0e09d6db8dbe9f","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"0401646cd754ffa6a5223dd6bf338f09729a830a45d5e0d52f0e09d6db8dbe9f","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}
+{"contentHash":"8acd6e572fc0673faf1a677e896d5b75ddb00de23e79952a4935e0bfb8e6eaf8","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"4d25ef19a327666dc2f6f42b7bd81f3e4ec142ffb3788894b2069bb24350ead2","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}
+{"contentHash":"f7942300508de97a94c48aa45d05c1862c868ef90019da47cb8d3e7b46a2f7c9","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"751d37b918948737d4324f6323e1f8f6151f991d55c3794e1908f79225745fc7","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}
+{"contentHash":"88de5e2ee36fc48176dd10b32b141b0bf71fd64040b0febb569acb1d4332be53","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"d82aae31c60ebecfb6faed8c1f8c61e9e16555f7142db2181b2face1b4a425c7","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}
+{"contentHash":"4d25ef19a327666dc2f6f42b7bd81f3e4ec142ffb3788894b2069bb24350ead2","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
@@ -1,1 +1,1 @@
-{"contentHash":"75f46270d23ccf042d76679b9bf7969f98a4e6405ca78a1a4eccd056319a2c11","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}
+{"contentHash":"b3806b628ae37ac8242ab0f0a8387cd209c78ff9233486269e279677afda4c1b","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
@@ -1,1 +1,1 @@
-{"contentHash":"38898b2cfef10f547af95e2f8a054b6c16cd1a60e4c95ea29e4b28ccabc2b9ec","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}
+{"contentHash":"8843caf0e5d4fb9cb4a2b8340535708056b13dc169247d5f77d647bfc40ab57f","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
@@ -1,1 +1,1 @@
-{"contentHash":"d9a501d22d750dfcdd199f40a015c659eb19f0de7aa0d56e44c06e73692cc241","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}
+{"contentHash":"75f46270d23ccf042d76679b9bf7969f98a4e6405ca78a1a4eccd056319a2c11","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
@@ -1,1 +1,1 @@
-{"contentHash":"8843caf0e5d4fb9cb4a2b8340535708056b13dc169247d5f77d647bfc40ab57f","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}
+{"contentHash":"456aeed33f447af3961a54ec5530c328ce24a08858bd35dc3667fdd023e2d058","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
@@ -1,1 +1,1 @@
-{"contentHash":"8a533619d631ff3137243cee9e5832488409ebec7d6ecce8a867459bf1e048c6","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}
+{"contentHash":"38898b2cfef10f547af95e2f8a054b6c16cd1a60e4c95ea29e4b28ccabc2b9ec","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
@@ -1,1 +1,1 @@
-{"contentHash":"456aeed33f447af3961a54ec5530c328ce24a08858bd35dc3667fdd023e2d058","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}
+{"contentHash":"d9a501d22d750dfcdd199f40a015c659eb19f0de7aa0d56e44c06e73692cc241","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
@@ -1,1 +1,1 @@
-{"contentHash":"87d04d89c9a3b50fc63ea3da73e04bf4f6e5ce5738cfe1be11d4023aa680ec78","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}
+{"contentHash":"8a533619d631ff3137243cee9e5832488409ebec7d6ecce8a867459bf1e048c6","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-secret-basic-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-secret-basic-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"f26500e09cfa2c76e2919664a02bc97850066a315f87cc87388fbd40080e1b44","entrypoint":"channel-secret-basic-runtime","importSpecifier":"openclaw/plugin-sdk/channel-secret-basic-runtime"}
+{"contentHash":"7e762365f58f15f23cc90ff932c3bfab59c91a2ba975bdc68f55c92c47ba14bd","entrypoint":"channel-secret-basic-runtime","importSpecifier":"openclaw/plugin-sdk/channel-secret-basic-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-secret-basic-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-secret-basic-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"c31c0725f25f9910d084befaee059ce147c62aaf378c6e85a510c2147ca9a42f","entrypoint":"channel-secret-basic-runtime","importSpecifier":"openclaw/plugin-sdk/channel-secret-basic-runtime"}
+{"contentHash":"7ef6217ef88ca8e36f380108f5fe6f7817828c31d554fd0240ecc76787de47f5","entrypoint":"channel-secret-basic-runtime","importSpecifier":"openclaw/plugin-sdk/channel-secret-basic-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-secret-basic-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-secret-basic-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"93778b369dbce0e315560f7cbfd015ed60dfc3812e33e8f8ce54c666700b96d1","entrypoint":"channel-secret-basic-runtime","importSpecifier":"openclaw/plugin-sdk/channel-secret-basic-runtime"}
+{"contentHash":"f26500e09cfa2c76e2919664a02bc97850066a315f87cc87388fbd40080e1b44","entrypoint":"channel-secret-basic-runtime","importSpecifier":"openclaw/plugin-sdk/channel-secret-basic-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-secret-basic-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-secret-basic-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"7ef6217ef88ca8e36f380108f5fe6f7817828c31d554fd0240ecc76787de47f5","entrypoint":"channel-secret-basic-runtime","importSpecifier":"openclaw/plugin-sdk/channel-secret-basic-runtime"}
+{"contentHash":"93778b369dbce0e315560f7cbfd015ed60dfc3812e33e8f8ce54c666700b96d1","entrypoint":"channel-secret-basic-runtime","importSpecifier":"openclaw/plugin-sdk/channel-secret-basic-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-secret-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-secret-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"04559e1437a2ae4412ba253c826023b7e45a4f019c699ee0b14942f1c17c9bdc","entrypoint":"channel-secret-runtime","importSpecifier":"openclaw/plugin-sdk/channel-secret-runtime"}
+{"contentHash":"00b6986194f4bc07c4d8e2a4c4c3b4231710a618c5d836ac9099074551a8469a","entrypoint":"channel-secret-runtime","importSpecifier":"openclaw/plugin-sdk/channel-secret-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-secret-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-secret-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"00b6986194f4bc07c4d8e2a4c4c3b4231710a618c5d836ac9099074551a8469a","entrypoint":"channel-secret-runtime","importSpecifier":"openclaw/plugin-sdk/channel-secret-runtime"}
+{"contentHash":"c705cf7c1ba06b0d473d6cd83e4701e8ec464b226446d5465ebffb0f656dc4d0","entrypoint":"channel-secret-runtime","importSpecifier":"openclaw/plugin-sdk/channel-secret-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-secret-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-secret-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"5b98fc01464d667865fd85ea3b13e97775deec44d33fd2f8b808e47cf6eb7e1c","entrypoint":"channel-secret-runtime","importSpecifier":"openclaw/plugin-sdk/channel-secret-runtime"}
+{"contentHash":"04559e1437a2ae4412ba253c826023b7e45a4f019c699ee0b14942f1c17c9bdc","entrypoint":"channel-secret-runtime","importSpecifier":"openclaw/plugin-sdk/channel-secret-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-secret-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-secret-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"9be41f5b34b2d2c74794053df4f4bacfa071250456affed4e4b298ecad608ff7","entrypoint":"channel-secret-runtime","importSpecifier":"openclaw/plugin-sdk/channel-secret-runtime"}
+{"contentHash":"5b98fc01464d667865fd85ea3b13e97775deec44d33fd2f8b808e47cf6eb7e1c","entrypoint":"channel-secret-runtime","importSpecifier":"openclaw/plugin-sdk/channel-secret-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-setup.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-setup.json
@@ -1,1 +1,1 @@
-{"contentHash":"02568442a1df10e1626b79a61f16271fcd6982a773afb3036c552f162d76c13d","entrypoint":"channel-setup","importSpecifier":"openclaw/plugin-sdk/channel-setup"}
+{"contentHash":"66c296a7c2c6b86252810a4f2b728ddff6611e40fc8e3ef192792e83c4de0a88","entrypoint":"channel-setup","importSpecifier":"openclaw/plugin-sdk/channel-setup"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-setup.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-setup.json
@@ -1,1 +1,1 @@
-{"contentHash":"66c296a7c2c6b86252810a4f2b728ddff6611e40fc8e3ef192792e83c4de0a88","entrypoint":"channel-setup","importSpecifier":"openclaw/plugin-sdk/channel-setup"}
+{"contentHash":"4b303f35b0f922552e61098aa6908b74d896b017d5185a25b65e514641376fa3","entrypoint":"channel-setup","importSpecifier":"openclaw/plugin-sdk/channel-setup"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-setup.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-setup.json
@@ -1,1 +1,1 @@
-{"contentHash":"4b303f35b0f922552e61098aa6908b74d896b017d5185a25b65e514641376fa3","entrypoint":"channel-setup","importSpecifier":"openclaw/plugin-sdk/channel-setup"}
+{"contentHash":"260ab5662d762b7fea46e29b3a03686d9b33b6d8aa33003dd41c81f235152603","entrypoint":"channel-setup","importSpecifier":"openclaw/plugin-sdk/channel-setup"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-setup.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-setup.json
@@ -1,1 +1,1 @@
-{"contentHash":"260ab5662d762b7fea46e29b3a03686d9b33b6d8aa33003dd41c81f235152603","entrypoint":"channel-setup","importSpecifier":"openclaw/plugin-sdk/channel-setup"}
+{"contentHash":"7a5e4516352775c3c3ed72faf36240357c6437dda7f9dd223088f5e5766cc3e2","entrypoint":"channel-setup","importSpecifier":"openclaw/plugin-sdk/channel-setup"}

--- a/docs/.generated/plugin-sdk-api-baseline/config-mutation.json
+++ b/docs/.generated/plugin-sdk-api-baseline/config-mutation.json
@@ -1,1 +1,1 @@
-{"contentHash":"bef445f8bd95679762b297e755361867a8342ae8fbfdd61d17229a3443a66d11","entrypoint":"config-mutation","importSpecifier":"openclaw/plugin-sdk/config-mutation"}
+{"contentHash":"4a7b634db7f14a41f64bd99ad1ffb86c98bfa86d3d9d29201b173775270ea534","entrypoint":"config-mutation","importSpecifier":"openclaw/plugin-sdk/config-mutation"}

--- a/docs/.generated/plugin-sdk-api-baseline/config-mutation.json
+++ b/docs/.generated/plugin-sdk-api-baseline/config-mutation.json
@@ -1,1 +1,1 @@
-{"contentHash":"05b0a1316e17e53b2f5de3b2a8900224ab955a120e32416dfea33efbce3b7ee7","entrypoint":"config-mutation","importSpecifier":"openclaw/plugin-sdk/config-mutation"}
+{"contentHash":"bef445f8bd95679762b297e755361867a8342ae8fbfdd61d17229a3443a66d11","entrypoint":"config-mutation","importSpecifier":"openclaw/plugin-sdk/config-mutation"}

--- a/docs/.generated/plugin-sdk-api-baseline/config-mutation.json
+++ b/docs/.generated/plugin-sdk-api-baseline/config-mutation.json
@@ -1,1 +1,1 @@
-{"contentHash":"4a7b634db7f14a41f64bd99ad1ffb86c98bfa86d3d9d29201b173775270ea534","entrypoint":"config-mutation","importSpecifier":"openclaw/plugin-sdk/config-mutation"}
+{"contentHash":"f2849884f368eadff174176a2808c1c74d041968049b460d6f8b408682c5862b","entrypoint":"config-mutation","importSpecifier":"openclaw/plugin-sdk/config-mutation"}

--- a/docs/.generated/plugin-sdk-api-baseline/config-mutation.json
+++ b/docs/.generated/plugin-sdk-api-baseline/config-mutation.json
@@ -1,1 +1,1 @@
-{"contentHash":"99e8ca8cbf3a57960650ea6f69422dbd88c8cc80074c8166350e57a5124a5ccb","entrypoint":"config-mutation","importSpecifier":"openclaw/plugin-sdk/config-mutation"}
+{"contentHash":"05b0a1316e17e53b2f5de3b2a8900224ab955a120e32416dfea33efbce3b7ee7","entrypoint":"config-mutation","importSpecifier":"openclaw/plugin-sdk/config-mutation"}

--- a/docs/.generated/plugin-sdk-api-baseline/config-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/config-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"9e3cbd25edad375fda76a9ea0029c0c76e96908cb6db531acaa193115fec8168","entrypoint":"config-runtime","importSpecifier":"openclaw/plugin-sdk/config-runtime"}
+{"contentHash":"ed41fb70bc318b893d5ac4b45185a76813c70b783df459fcccbf53da690ac3af","entrypoint":"config-runtime","importSpecifier":"openclaw/plugin-sdk/config-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/config-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/config-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"ed41fb70bc318b893d5ac4b45185a76813c70b783df459fcccbf53da690ac3af","entrypoint":"config-runtime","importSpecifier":"openclaw/plugin-sdk/config-runtime"}
+{"contentHash":"2c21d121fd9d14d7f45368b5f02dff257b6750215d63d4be9ace28b5c0d3c0f8","entrypoint":"config-runtime","importSpecifier":"openclaw/plugin-sdk/config-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/config-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/config-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"c21f020ef8f64d952590f6e532639ca678a97368b02df665e7819397869226e6","entrypoint":"config-runtime","importSpecifier":"openclaw/plugin-sdk/config-runtime"}
+{"contentHash":"f7bfd37003ed26a628b727a3f99558ef39d9524b4c9d6de32a95c1cb8e1b3882","entrypoint":"config-runtime","importSpecifier":"openclaw/plugin-sdk/config-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/config-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/config-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"f7bfd37003ed26a628b727a3f99558ef39d9524b4c9d6de32a95c1cb8e1b3882","entrypoint":"config-runtime","importSpecifier":"openclaw/plugin-sdk/config-runtime"}
+{"contentHash":"9e3cbd25edad375fda76a9ea0029c0c76e96908cb6db531acaa193115fec8168","entrypoint":"config-runtime","importSpecifier":"openclaw/plugin-sdk/config-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/core.json
@@ -1,1 +1,1 @@
-{"contentHash":"2c95ec54b192b730e9a9c606f77e66a2d0dd9eb09dd66a3c6ad8fea9fca31585","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}
+{"contentHash":"8ae99ed18f83cfd9626738171a8952d54626108ee4e6567437de565e9cf15a05","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}

--- a/docs/.generated/plugin-sdk-api-baseline/core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/core.json
@@ -1,1 +1,1 @@
-{"contentHash":"6b5748e15f14522463cb279b5a2adc632270c419b4184825c121cf88af2e9e48","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}
+{"contentHash":"c93ed6e7f99d2ca7a0a21380617c1dd3393d78db742b5a7f5bcb44acddac7471","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}

--- a/docs/.generated/plugin-sdk-api-baseline/core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/core.json
@@ -1,1 +1,1 @@
-{"contentHash":"c28335a6d8ca1516679365e4053dc505f2b2ceeba0b5b3dbd0752536409c0eee","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}
+{"contentHash":"870590d312c84b74c0e69527d0593f6203512d5454707c7a11b864739d8074ce","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}

--- a/docs/.generated/plugin-sdk-api-baseline/core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/core.json
@@ -1,1 +1,1 @@
-{"contentHash":"870590d312c84b74c0e69527d0593f6203512d5454707c7a11b864739d8074ce","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}
+{"contentHash":"6b5748e15f14522463cb279b5a2adc632270c419b4184825c121cf88af2e9e48","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}

--- a/docs/.generated/plugin-sdk-api-baseline/core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/core.json
@@ -1,1 +1,1 @@
-{"contentHash":"fc77477266fca471ec511621deeb6ccb7df9ea3df39f8059f7e6f66afb4d030c","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}
+{"contentHash":"c28335a6d8ca1516679365e4053dc505f2b2ceeba0b5b3dbd0752536409c0eee","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}

--- a/docs/.generated/plugin-sdk-api-baseline/core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/core.json
@@ -1,1 +1,1 @@
-{"contentHash":"8ae99ed18f83cfd9626738171a8952d54626108ee4e6567437de565e9cf15a05","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}
+{"contentHash":"fc77477266fca471ec511621deeb6ccb7df9ea3df39f8059f7e6f66afb4d030c","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}

--- a/docs/.generated/plugin-sdk-api-baseline/core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/core.json
@@ -1,1 +1,1 @@
-{"contentHash":"c93ed6e7f99d2ca7a0a21380617c1dd3393d78db742b5a7f5bcb44acddac7471","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}
+{"contentHash":"4ba3f7cf748c5ba26f22d626499c4bce05ef8e17f69bf864a87c1df3ab2dc5d4","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}

--- a/docs/.generated/plugin-sdk-api-baseline/discord.json
+++ b/docs/.generated/plugin-sdk-api-baseline/discord.json
@@ -1,1 +1,1 @@
-{"contentHash":"3c4866c677b56d0c2367dfdd0212305dd8f6e02a9b465786904b1a542e77f964","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}
+{"contentHash":"84f1d6fdd28ab1fade74448ec47a19532eb42eeeb4bb3ec51d495ddd9502089c","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}

--- a/docs/.generated/plugin-sdk-api-baseline/discord.json
+++ b/docs/.generated/plugin-sdk-api-baseline/discord.json
@@ -1,1 +1,1 @@
-{"contentHash":"9195c6edb2c7d0ae0b5ca434da1f96c2705c739a548628c6e9322e29cd948ee3","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}
+{"contentHash":"02070cb2cb299ce77433c6848eb01256d289d936b7feb687df4151f0e486af9d","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}

--- a/docs/.generated/plugin-sdk-api-baseline/discord.json
+++ b/docs/.generated/plugin-sdk-api-baseline/discord.json
@@ -1,1 +1,1 @@
-{"contentHash":"84f1d6fdd28ab1fade74448ec47a19532eb42eeeb4bb3ec51d495ddd9502089c","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}
+{"contentHash":"518f095d39488d9c6fcfff4cf68043bca7308e4e807020d718f6a05f139d1b6b","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}

--- a/docs/.generated/plugin-sdk-api-baseline/discord.json
+++ b/docs/.generated/plugin-sdk-api-baseline/discord.json
@@ -1,1 +1,1 @@
-{"contentHash":"02070cb2cb299ce77433c6848eb01256d289d936b7feb687df4151f0e486af9d","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}
+{"contentHash":"f98697030c4264e55dca5495a994574800bd42cf41b9e3563f57595555b63dde","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}

--- a/docs/.generated/plugin-sdk-api-baseline/discord.json
+++ b/docs/.generated/plugin-sdk-api-baseline/discord.json
@@ -1,1 +1,1 @@
-{"contentHash":"7172a0e645e4c64e6dccee1e0aa150741a1cb5b88c6b949734a247602ce23da4","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}
+{"contentHash":"9195c6edb2c7d0ae0b5ca434da1f96c2705c739a548628c6e9322e29cd948ee3","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}

--- a/docs/.generated/plugin-sdk-api-baseline/discord.json
+++ b/docs/.generated/plugin-sdk-api-baseline/discord.json
@@ -1,1 +1,1 @@
-{"contentHash":"f98697030c4264e55dca5495a994574800bd42cf41b9e3563f57595555b63dde","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}
+{"contentHash":"3c4866c677b56d0c2367dfdd0212305dd8f6e02a9b465786904b1a542e77f964","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}

--- a/docs/.generated/plugin-sdk-api-baseline/discord.json
+++ b/docs/.generated/plugin-sdk-api-baseline/discord.json
@@ -1,1 +1,1 @@
-{"contentHash":"d2051c433956de7d579b91d4e21e39d48334e63a632baf941bde0cef85ca8ac0","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}
+{"contentHash":"7172a0e645e4c64e6dccee1e0aa150741a1cb5b88c6b949734a247602ce23da4","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}

--- a/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
+++ b/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
@@ -1,1 +1,1 @@
-{"contentHash":"6ad1e525b93b415d72e5d940670eac79bf2ad4000b53921259026d0225e53d75","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}
+{"contentHash":"642351a06618b94261bfbbda2013b9467f90826a11a1b82a8152c4cd6686285b","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}

--- a/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
+++ b/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
@@ -1,1 +1,1 @@
-{"contentHash":"642351a06618b94261bfbbda2013b9467f90826a11a1b82a8152c4cd6686285b","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}
+{"contentHash":"2924c518b19ea6c6da4bbac172681aa3d7eda750d6bb710f61082695ecd66b82","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}

--- a/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
+++ b/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
@@ -1,1 +1,1 @@
-{"contentHash":"2924c518b19ea6c6da4bbac172681aa3d7eda750d6bb710f61082695ecd66b82","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}
+{"contentHash":"0b9f344ae47e7e58b44553ea00eaaa9f85713a6f2b33ed2d1d4779cd53198dbe","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}

--- a/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
+++ b/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
@@ -1,1 +1,1 @@
-{"contentHash":"0b9f344ae47e7e58b44553ea00eaaa9f85713a6f2b33ed2d1d4779cd53198dbe","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}
+{"contentHash":"8b35ab0994d669d6bb95dd64bcd1d2c721fb5716d8c997d048775ab7d9cd0153","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}

--- a/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
+++ b/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
@@ -1,1 +1,1 @@
-{"contentHash":"844247d8b7baa184297d5600b6f0dad50b756243f1e9ae7adf4aa0f40a2e58ec","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}
+{"contentHash":"6ad1e525b93b415d72e5d940670eac79bf2ad4000b53921259026d0225e53d75","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}

--- a/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
+++ b/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
@@ -1,1 +1,1 @@
-{"contentHash":"a9e35fd79c8ba80ca1de7760b0b83a243a383bffbda1730818e5dec2a049ddce","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}
+{"contentHash":"c5884de718799d4bd4385ceb5d0573b877d6600524e6744208745b51f1d15aea","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}

--- a/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
+++ b/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
@@ -1,1 +1,1 @@
-{"contentHash":"c5884de718799d4bd4385ceb5d0573b877d6600524e6744208745b51f1d15aea","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}
+{"contentHash":"844247d8b7baa184297d5600b6f0dad50b756243f1e9ae7adf4aa0f40a2e58ec","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}

--- a/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"4da0e4177bb1d57e8b72c787559e274518962afe6b2fc521bae2741ad63b53b8","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}
+{"contentHash":"0d3f0f6da8ff38bca5c59f0e05c4ccc275144dda156dc6c70563138db656a373","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"5fc151c320d8cc2750115d048bfa3c451100ad9f338a509a13167d33449a45de","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}
+{"contentHash":"4da0e4177bb1d57e8b72c787559e274518962afe6b2fc521bae2741ad63b53b8","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"0d3f0f6da8ff38bca5c59f0e05c4ccc275144dda156dc6c70563138db656a373","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}
+{"contentHash":"4b14a2263c14226886194fde3d81270e4f695b5a38d32a84545f31ca66111efa","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"3ba67320fb902e12fdf2399c4d8e74403e78e74add8dfed8213154f4ab68a858","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}
+{"contentHash":"401305ac12d22db8b7b3e5a0251421e2b82cb4506083884c6676370be4bcc339","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"401305ac12d22db8b7b3e5a0251421e2b82cb4506083884c6676370be4bcc339","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}
+{"contentHash":"5fc151c320d8cc2750115d048bfa3c451100ad9f338a509a13167d33449a45de","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"fb18c66685c7b68ecf6afd885e4060fadb7d84e320679f587a71fcf29a81a0cb","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}
+{"contentHash":"3447ab3b4f9d00dd164e97954dbccb7cd53d2298aa5204c2017f390f15588437","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"4b14a2263c14226886194fde3d81270e4f695b5a38d32a84545f31ca66111efa","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}
+{"contentHash":"fb18c66685c7b68ecf6afd885e4060fadb7d84e320679f587a71fcf29a81a0cb","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/model-session-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/model-session-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"e5d28bea8559a8c9d6703b3a7e8aaed9bf7584494a85b35e44992955d2dc6ada","entrypoint":"model-session-runtime","importSpecifier":"openclaw/plugin-sdk/model-session-runtime"}
+{"contentHash":"f055ec776e23200252282885fce1ff40555ae2e0d108fa10c7a16c08b776a43e","entrypoint":"model-session-runtime","importSpecifier":"openclaw/plugin-sdk/model-session-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/model-session-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/model-session-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"f055ec776e23200252282885fce1ff40555ae2e0d108fa10c7a16c08b776a43e","entrypoint":"model-session-runtime","importSpecifier":"openclaw/plugin-sdk/model-session-runtime"}
+{"contentHash":"674427cc84ebe5ddaa187fe0773d005b21f5912f96b32c0fd8b3b95a98a5f9f3","entrypoint":"model-session-runtime","importSpecifier":"openclaw/plugin-sdk/model-session-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/model-session-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/model-session-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"674427cc84ebe5ddaa187fe0773d005b21f5912f96b32c0fd8b3b95a98a5f9f3","entrypoint":"model-session-runtime","importSpecifier":"openclaw/plugin-sdk/model-session-runtime"}
+{"contentHash":"9c8d6c57eae34ab72ec465dbf610f75d5d1bf737d7f04eadab63c806ea8a51fa","entrypoint":"model-session-runtime","importSpecifier":"openclaw/plugin-sdk/model-session-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/model-session-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/model-session-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"8103ae760481a799b4b1a476cdd2d6ec18010a562a9d126af7cd0ca12cd6b089","entrypoint":"model-session-runtime","importSpecifier":"openclaw/plugin-sdk/model-session-runtime"}
+{"contentHash":"e5d28bea8559a8c9d6703b3a7e8aaed9bf7584494a85b35e44992955d2dc6ada","entrypoint":"model-session-runtime","importSpecifier":"openclaw/plugin-sdk/model-session-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
@@ -1,1 +1,1 @@
-{"contentHash":"ca3136e446cf1fc294279e24078e3a4c6342a048b00f8012d519903c887ef3a7","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}
+{"contentHash":"4c98b74635e88da55f41715297138761fc756d03ccf0ae9e4fbbc816d5a0b648","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
@@ -1,1 +1,1 @@
-{"contentHash":"4861d4fe679daca4a4b568658963e5c44bae7c26b1f230a610deb9647beeb1d8","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}
+{"contentHash":"6dea61641b09e01cdf88055074dceebfb16545da28b6dfefed6b1d85e66dbfeb","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
@@ -1,1 +1,1 @@
-{"contentHash":"4c98b74635e88da55f41715297138761fc756d03ccf0ae9e4fbbc816d5a0b648","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}
+{"contentHash":"7c4ed6ffaea426b72fdd965f17912b2caca0ce3c8c61889735650036a82ea15c","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
@@ -1,1 +1,1 @@
-{"contentHash":"afba4630205defe4cac0bbfb7d3529f0ad37716d979e1066c5af5ad97f6ae3fc","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}
+{"contentHash":"ebfd7123d7f5748b6377c68f32ebde1506bacae07f3a35b9620cfd19537d7b01","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
@@ -1,1 +1,1 @@
-{"contentHash":"7c4ed6ffaea426b72fdd965f17912b2caca0ce3c8c61889735650036a82ea15c","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}
+{"contentHash":"afba4630205defe4cac0bbfb7d3529f0ad37716d979e1066c5af5ad97f6ae3fc","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
@@ -1,1 +1,1 @@
-{"contentHash":"7adfd5b37db482d72cec83f21e6ccbb195fe1d8a76a70a46ef13e32f6b52f4a6","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}
+{"contentHash":"4861d4fe679daca4a4b568658963e5c44bae7c26b1f230a610deb9647beeb1d8","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
@@ -1,1 +1,1 @@
-{"contentHash":"ebfd7123d7f5748b6377c68f32ebde1506bacae07f3a35b9620cfd19537d7b01","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}
+{"contentHash":"7adfd5b37db482d72cec83f21e6ccbb195fe1d8a76a70a46ef13e32f6b52f4a6","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"26604e123ef69bde9352f87f2e0e73d522d4acb2fd67ffeb3196c4fd724c7026","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}
+{"contentHash":"309b3a421d9767f68c61360bf00bb222437cb961eb73bf85e700f95be645ae09","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"05d7847c8fe1b53ec5a22cc23a5ca523eaa80b4c5a9e22c5d8e52cfffe79472c","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}
+{"contentHash":"c9e9acdc7f66b6020b738d7a26657a09edce6f21c5ab5acd65e0dac8a7c3bb6f","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"05d6114f5156b6825044a5d8d1a7e5fe2dcd2d4e7e7fc14c1542fadfb8141cd8","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}
+{"contentHash":"05d7847c8fe1b53ec5a22cc23a5ca523eaa80b4c5a9e22c5d8e52cfffe79472c","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"309b3a421d9767f68c61360bf00bb222437cb961eb73bf85e700f95be645ae09","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}
+{"contentHash":"6dda1fc0ff9e7d57418afe076e2e7aedc267a434a84a734f501456f78fc54941","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"6dda1fc0ff9e7d57418afe076e2e7aedc267a434a84a734f501456f78fc54941","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}
+{"contentHash":"05d6114f5156b6825044a5d8d1a7e5fe2dcd2d4e7e7fc14c1542fadfb8141cd8","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"c20f04ce9c335c1e987da9b7520d97f593795f1fb18fc4e5ab07da7bfc6f113d","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}
+{"contentHash":"26604e123ef69bde9352f87f2e0e73d522d4acb2fd67ffeb3196c4fd724c7026","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"5f0b7be43fcb5e2240053e7ada316b35f28cbcdd0619b724463627961927dcb9","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}
+{"contentHash":"c20f04ce9c335c1e987da9b7520d97f593795f1fb18fc4e5ab07da7bfc6f113d","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-auth.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-auth.json
@@ -1,1 +1,1 @@
-{"contentHash":"a82f45bdc59736c09a6124e788bae6a54b6d28c19dafde34458445f81ada3b74","entrypoint":"provider-auth","importSpecifier":"openclaw/plugin-sdk/provider-auth"}
+{"contentHash":"3e19e71a88b2338396a38e2ea732774678d8918528c0fce57aaedb02843a85e4","entrypoint":"provider-auth","importSpecifier":"openclaw/plugin-sdk/provider-auth"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-auth.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-auth.json
@@ -1,1 +1,1 @@
-{"contentHash":"ef41dd24ab4a7d24bc325d232773d0f6bf07049b1e061716e5fa9ed9b2aba8c6","entrypoint":"provider-auth","importSpecifier":"openclaw/plugin-sdk/provider-auth"}
+{"contentHash":"3f49109f1ba9851480baaf9da7164da06be41fdd628cb6e51e58505a9a85c92b","entrypoint":"provider-auth","importSpecifier":"openclaw/plugin-sdk/provider-auth"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-auth.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-auth.json
@@ -1,1 +1,1 @@
-{"contentHash":"3e19e71a88b2338396a38e2ea732774678d8918528c0fce57aaedb02843a85e4","entrypoint":"provider-auth","importSpecifier":"openclaw/plugin-sdk/provider-auth"}
+{"contentHash":"ef41dd24ab4a7d24bc325d232773d0f6bf07049b1e061716e5fa9ed9b2aba8c6","entrypoint":"provider-auth","importSpecifier":"openclaw/plugin-sdk/provider-auth"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-auth.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-auth.json
@@ -1,1 +1,1 @@
-{"contentHash":"3f49109f1ba9851480baaf9da7164da06be41fdd628cb6e51e58505a9a85c92b","entrypoint":"provider-auth","importSpecifier":"openclaw/plugin-sdk/provider-auth"}
+{"contentHash":"c63113a4720b3d4795a3deb00ce3652cc9481522af311b9a269e4fe0d84703bb","entrypoint":"provider-auth","importSpecifier":"openclaw/plugin-sdk/provider-auth"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"eea976294e5c7062d0ab9a4f80bbbf6eb87ad350acd34b778ceecac57bef9a59","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
+{"contentHash":"e34fcd35386e806d573b6ddd6a3e6b1760df7d0f9844a93f73ca197245ffff59","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"5c9f0b8207f962f9c32228970abe15c23de32c08a00e3d42cbdf5fecbd4c1f1e","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
+{"contentHash":"0165f00824a92e8aecf348c8cb62d9a1b008bef4382f14c1474aadb6f3391146","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"e1a03acbdaa2bc509c3139b164ee1a0f4a7a94d91b294e93a2384d9489cbbbd4","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
+{"contentHash":"39a95d07f23a101f7bed3f232a1e5edaed8a936ee7a5a599cac617189ac544c6","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"bb09ca405c5a1b04cf925e0d7fb96e44bc93a1d3bd374538e9f41956e960a7c6","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
+{"contentHash":"a45abfd8f04f808a9b7bd2703b903be221b0bdb55fb3782f7e0e9d4ee71871a0","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"39a95d07f23a101f7bed3f232a1e5edaed8a936ee7a5a599cac617189ac544c6","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
+{"contentHash":"eea976294e5c7062d0ab9a4f80bbbf6eb87ad350acd34b778ceecac57bef9a59","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"0165f00824a92e8aecf348c8cb62d9a1b008bef4382f14c1474aadb6f3391146","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
+{"contentHash":"e1a03acbdaa2bc509c3139b164ee1a0f4a7a94d91b294e93a2384d9489cbbbd4","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"e34fcd35386e806d573b6ddd6a3e6b1760df7d0f9844a93f73ca197245ffff59","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
+{"contentHash":"bb09ca405c5a1b04cf925e0d7fb96e44bc93a1d3bd374538e9f41956e960a7c6","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/secret-input-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/secret-input-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"f7455239d48a07fb8964da6cadea583955bf027adba97e45e0d4a70ff6de64b2","entrypoint":"secret-input-runtime","importSpecifier":"openclaw/plugin-sdk/secret-input-runtime"}
+{"contentHash":"3686c85e955c6ae8a13b1a42772eb720ea7ac55fa4e12e02b179ec16160fbdd1","entrypoint":"secret-input-runtime","importSpecifier":"openclaw/plugin-sdk/secret-input-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/secret-input-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/secret-input-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"1d27caa829b7524183b4e547ae73984d89068963222700da4a944ef983bc45f2","entrypoint":"secret-input-runtime","importSpecifier":"openclaw/plugin-sdk/secret-input-runtime"}
+{"contentHash":"c5c8fce94eb8205d8040c0de81c6bb17617620a4730de6313b036d6df4bbc6ad","entrypoint":"secret-input-runtime","importSpecifier":"openclaw/plugin-sdk/secret-input-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/secret-input-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/secret-input-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"63f33404c7d000c437c4f5c5f4aa061e6bb17207fbff5b43edeba79988809b04","entrypoint":"secret-input-runtime","importSpecifier":"openclaw/plugin-sdk/secret-input-runtime"}
+{"contentHash":"1d27caa829b7524183b4e547ae73984d89068963222700da4a944ef983bc45f2","entrypoint":"secret-input-runtime","importSpecifier":"openclaw/plugin-sdk/secret-input-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/secret-input-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/secret-input-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"c5c8fce94eb8205d8040c0de81c6bb17617620a4730de6313b036d6df4bbc6ad","entrypoint":"secret-input-runtime","importSpecifier":"openclaw/plugin-sdk/secret-input-runtime"}
+{"contentHash":"f7455239d48a07fb8964da6cadea583955bf027adba97e45e0d4a70ff6de64b2","entrypoint":"secret-input-runtime","importSpecifier":"openclaw/plugin-sdk/secret-input-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/secret-ref-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/secret-ref-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"252f2b779c5d40d04d4a31002f864e425af9b8381f176e238664f4ab8a1b7438","entrypoint":"secret-ref-runtime","importSpecifier":"openclaw/plugin-sdk/secret-ref-runtime"}
+{"contentHash":"0d0d184165355b27731442674cc6b7b641c30cf90889a833effb3e8733f5a7d4","entrypoint":"secret-ref-runtime","importSpecifier":"openclaw/plugin-sdk/secret-ref-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/secret-ref-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/secret-ref-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"3b0271ae0b52397a149e3f55b376f741129f476129285568c460a6fd2e6317b5","entrypoint":"secret-ref-runtime","importSpecifier":"openclaw/plugin-sdk/secret-ref-runtime"}
+{"contentHash":"845017552fc828b2992b0e8e530ec6d313d559c873562d3fa49f160acf359734","entrypoint":"secret-ref-runtime","importSpecifier":"openclaw/plugin-sdk/secret-ref-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/secret-ref-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/secret-ref-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"282d5444becc41e8230f56d6122f3a9fb6f5f33a1adfc254d772fd14d11c3dc3","entrypoint":"secret-ref-runtime","importSpecifier":"openclaw/plugin-sdk/secret-ref-runtime"}
+{"contentHash":"3b0271ae0b52397a149e3f55b376f741129f476129285568c460a6fd2e6317b5","entrypoint":"secret-ref-runtime","importSpecifier":"openclaw/plugin-sdk/secret-ref-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/secret-ref-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/secret-ref-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"845017552fc828b2992b0e8e530ec6d313d559c873562d3fa49f160acf359734","entrypoint":"secret-ref-runtime","importSpecifier":"openclaw/plugin-sdk/secret-ref-runtime"}
+{"contentHash":"252f2b779c5d40d04d4a31002f864e425af9b8381f176e238664f4ab8a1b7438","entrypoint":"secret-ref-runtime","importSpecifier":"openclaw/plugin-sdk/secret-ref-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/setup-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/setup-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"e65962e6433f65767823ad915f21875f04a9f9373dbf0c314f17dbf855912cf6","entrypoint":"setup-runtime","importSpecifier":"openclaw/plugin-sdk/setup-runtime"}
+{"contentHash":"19bbe24a8d2e70f8c9a34686275d86df4ac4829dbe37c83df530fe5685d3ae9b","entrypoint":"setup-runtime","importSpecifier":"openclaw/plugin-sdk/setup-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/setup-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/setup-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"2c101c35ee01127f3b41ba216b4a7c0588f0272b03e9312b18bc9b3c33229366","entrypoint":"setup-runtime","importSpecifier":"openclaw/plugin-sdk/setup-runtime"}
+{"contentHash":"e65962e6433f65767823ad915f21875f04a9f9373dbf0c314f17dbf855912cf6","entrypoint":"setup-runtime","importSpecifier":"openclaw/plugin-sdk/setup-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/setup-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/setup-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"93827c27397a0d4b2872c801e4175ce371f4ec4b7aa5f85331bd46f5323174c9","entrypoint":"setup-runtime","importSpecifier":"openclaw/plugin-sdk/setup-runtime"}
+{"contentHash":"6c9f2c713b67421ae57b1625db53998772e6539b242e143bb6446dccf53742ca","entrypoint":"setup-runtime","importSpecifier":"openclaw/plugin-sdk/setup-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/setup-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/setup-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"6c9f2c713b67421ae57b1625db53998772e6539b242e143bb6446dccf53742ca","entrypoint":"setup-runtime","importSpecifier":"openclaw/plugin-sdk/setup-runtime"}
+{"contentHash":"2c101c35ee01127f3b41ba216b4a7c0588f0272b03e9312b18bc9b3c33229366","entrypoint":"setup-runtime","importSpecifier":"openclaw/plugin-sdk/setup-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/setup.json
+++ b/docs/.generated/plugin-sdk-api-baseline/setup.json
@@ -1,1 +1,1 @@
-{"contentHash":"713d698d49f9dcfea998d3d520458dc61c1a6840cb4d1266fff353a9086af30d","entrypoint":"setup","importSpecifier":"openclaw/plugin-sdk/setup"}
+{"contentHash":"306d5fa92d5963a4be01a846c9f8398a30eb7110dd54234f666952d8b78ee2c8","entrypoint":"setup","importSpecifier":"openclaw/plugin-sdk/setup"}

--- a/docs/.generated/plugin-sdk-api-baseline/setup.json
+++ b/docs/.generated/plugin-sdk-api-baseline/setup.json
@@ -1,1 +1,1 @@
-{"contentHash":"f853d50ca745e54f26aae6d0db2d5b4882a75850b229f347a91992d6bb2cffbc","entrypoint":"setup","importSpecifier":"openclaw/plugin-sdk/setup"}
+{"contentHash":"dfeb0d39ecf0867612baec597f632356cfe7405b05c9923994c3dd7831afdc56","entrypoint":"setup","importSpecifier":"openclaw/plugin-sdk/setup"}

--- a/docs/.generated/plugin-sdk-api-baseline/setup.json
+++ b/docs/.generated/plugin-sdk-api-baseline/setup.json
@@ -1,1 +1,1 @@
-{"contentHash":"dfeb0d39ecf0867612baec597f632356cfe7405b05c9923994c3dd7831afdc56","entrypoint":"setup","importSpecifier":"openclaw/plugin-sdk/setup"}
+{"contentHash":"fe9cc43264a17feb6d108ddeb13a6b0ebc731575fca56460c10291fe116102fb","entrypoint":"setup","importSpecifier":"openclaw/plugin-sdk/setup"}

--- a/docs/.generated/plugin-sdk-api-baseline/setup.json
+++ b/docs/.generated/plugin-sdk-api-baseline/setup.json
@@ -1,1 +1,1 @@
-{"contentHash":"306d5fa92d5963a4be01a846c9f8398a30eb7110dd54234f666952d8b78ee2c8","entrypoint":"setup","importSpecifier":"openclaw/plugin-sdk/setup"}
+{"contentHash":"f853d50ca745e54f26aae6d0db2d5b4882a75850b229f347a91992d6bb2cffbc","entrypoint":"setup","importSpecifier":"openclaw/plugin-sdk/setup"}

--- a/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
+++ b/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
@@ -1,1 +1,1 @@
-{"contentHash":"9e26380e89032d9ac2f02e360ff71d632066318089508be70028a9ffb8cb2afd","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}
+{"contentHash":"be0a4385e2e599ad66b66fe72cffede83773ec4c49266c7161f85f6810164bf1","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}

--- a/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
+++ b/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
@@ -1,1 +1,1 @@
-{"contentHash":"79fa5f103ed663a676029be187d6cc8875044f1f15a4978b97fcb8d93ab3c805","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}
+{"contentHash":"5845335d86ea45a1664bb00a316aa132de85e1987c9114a4bd737410098ddfc1","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}

--- a/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
+++ b/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
@@ -1,1 +1,1 @@
-{"contentHash":"5845335d86ea45a1664bb00a316aa132de85e1987c9114a4bd737410098ddfc1","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}
+{"contentHash":"1eb2b2acfea15003f8ee6a6df525c2f2a43ad556b557dd21fe5c7df7f0ef0b32","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}

--- a/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
+++ b/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
@@ -1,1 +1,1 @@
-{"contentHash":"50052d33dd979b2df130f842fe35b93f121be570a76782c032f4df1acd6536e7","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}
+{"contentHash":"9e26380e89032d9ac2f02e360ff71d632066318089508be70028a9ffb8cb2afd","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}

--- a/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
+++ b/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
@@ -1,1 +1,1 @@
-{"contentHash":"be0a4385e2e599ad66b66fe72cffede83773ec4c49266c7161f85f6810164bf1","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}
+{"contentHash":"79fa5f103ed663a676029be187d6cc8875044f1f15a4978b97fcb8d93ab3c805","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}

--- a/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
+++ b/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
@@ -1,1 +1,1 @@
-{"contentHash":"1eb2b2acfea15003f8ee6a6df525c2f2a43ad556b557dd21fe5c7df7f0ef0b32","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}
+{"contentHash":"dffc96ff312adfa28713a43b47d8ffc70e44c65be64c65e129d775a8fd77728b","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}

--- a/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
+++ b/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
@@ -1,1 +1,1 @@
-{"contentHash":"018adbdc87ee4a490fdea45b3ee249a55dca337d655cad8929e63986f4e633bb","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}
+{"contentHash":"50052d33dd979b2df130f842fe35b93f121be570a76782c032f4df1acd6536e7","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}

--- a/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
+++ b/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
@@ -1,1 +1,1 @@
-{"contentHash":"60264493841a596088802d7dee7d257196c2dc1f4b7d95b57fa21eb467f485d6","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}
+{"contentHash":"4a6a6b7e93f7169d0aed68b74121ff4676d120d4a88e1b06ced1f2434e030677","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}

--- a/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
+++ b/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
@@ -1,1 +1,1 @@
-{"contentHash":"5d0dfab461ccc3286164bae46a9eee06530dce21390aba7a061b9ded7b65f7ee","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}
+{"contentHash":"475fe43dfb74ce1795e086e8f68a1aac79cf1371649feaf17d0598deb868c9e0","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}

--- a/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
+++ b/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
@@ -1,1 +1,1 @@
-{"contentHash":"475fe43dfb74ce1795e086e8f68a1aac79cf1371649feaf17d0598deb868c9e0","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}
+{"contentHash":"b4150f108aa1e71816f41906ed1ac36d204466f2a0a39a96e82cd2772cec9bd5","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}

--- a/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
+++ b/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
@@ -1,1 +1,1 @@
-{"contentHash":"a65905e8196146289b28b810e1a5aaff33d38726d5403d1f7dd27085ce6f722d","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}
+{"contentHash":"60264493841a596088802d7dee7d257196c2dc1f4b7d95b57fa21eb467f485d6","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}

--- a/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
+++ b/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
@@ -1,1 +1,1 @@
-{"contentHash":"b4150f108aa1e71816f41906ed1ac36d204466f2a0a39a96e82cd2772cec9bd5","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}
+{"contentHash":"a65905e8196146289b28b810e1a5aaff33d38726d5403d1f7dd27085ce6f722d","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}

--- a/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
+++ b/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
@@ -1,1 +1,1 @@
-{"contentHash":"50e69cbd44165ca843f21fd9d7152f51b7df3dbe0a5d56def334d34ef9d9ddf7","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}
+{"contentHash":"5d0dfab461ccc3286164bae46a9eee06530dce21390aba7a061b9ded7b65f7ee","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}

--- a/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
+++ b/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
@@ -1,1 +1,1 @@
-{"contentHash":"1dac77955687176848405413e59d76ea0511e30722eaa32bf3a3cdd44c5a6395","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}
+{"contentHash":"50e69cbd44165ca843f21fd9d7152f51b7df3dbe0a5d56def334d34ef9d9ddf7","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}

--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -79,6 +79,25 @@ openclaw channels add --channel nostr --private-key "$NOSTR_PRIVATE_KEY"
 openclaw channels remove --channel telegram --delete
 ```
 
+For a headless host, complete non-interactive onboarding first, then add each channel with explicit credential flags or its environment-backed setup option:
+
+```bash
+export OPENAI_API_KEY="<provider-key>"
+export TELEGRAM_BOT_TOKEN="<bot-token>"
+
+openclaw onboard --non-interactive --accept-risk --skip-health \
+  --mode local \
+  --auth-choice openai-api-key \
+  --secret-input-mode ref \
+  --skip-channels \
+  --no-install-daemon
+openclaw channels add --channel telegram --use-env
+```
+
+`--use-env` validates the environment variables declared by the selected channel plugin before writing config. For Telegram, the command requires `TELEGRAM_BOT_TOKEN`; other plugins name their missing variables in the error. The Gateway service must receive the same environment variables as the bootstrap shell. If the Gateway is already running with config reload enabled, it watches the config write and restarts the affected channel automatically.
+
+See [CLI automation](/start/wizard-cli-automation) for additional non-interactive provider and Gateway options. Container deployments should also follow the [Docker headless bootstrap](/install/docker#headless-bootstrap) environment guidance.
+
 <Tip>
 `openclaw channels add telegram --help` or `openclaw channels add --channel telegram --help` shows only Telegram's setup flags. `openclaw channels add --help` shows only the shared command envelope.
 </Tip>
@@ -112,6 +131,8 @@ When you run `openclaw channels add` with no direct account, credential, or chan
 openclaw channels add telegram
 openclaw channels add --channel telegram
 ```
+
+Guided setup requires an interactive terminal. In a non-TTY shell, OpenClaw exits immediately instead of waiting for input; use `openclaw channels add --channel <id> --use-env` or pass the selected plugin's credential flags.
 
 The wizard can prompt for:
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -102,6 +102,37 @@ Hosting multiple users? See [Multi-tenant hosting](/gateway/multi-tenant-hosting
   </Step>
 </Steps>
 
+### Headless bootstrap
+
+For an unattended container host, put provider, Gateway, and channel credentials in the Compose `.env` file so both the one-shot bootstrap container and the long-running Gateway receive the same values:
+
+```bash
+OPENAI_API_KEY=<provider-key>
+OPENCLAW_GATEWAY_TOKEN=<gateway-token>
+TELEGRAM_BOT_TOKEN=<bot-token>
+```
+
+Run onboarding and channel provisioning without a pseudo-TTY, then start the Gateway:
+
+```bash
+docker compose run -T --rm --no-deps --entrypoint node openclaw-gateway \
+  dist/index.js onboard --non-interactive --accept-risk --skip-health \
+  --mode local \
+  --auth-choice openai-api-key \
+  --secret-input-mode ref \
+  --gateway-auth token \
+  --gateway-token-ref-env OPENCLAW_GATEWAY_TOKEN \
+  --skip-channels \
+  --no-install-daemon
+docker compose run -T --rm --no-deps --entrypoint node openclaw-gateway \
+  dist/index.js channels add --channel telegram --use-env
+docker compose up -d openclaw-gateway
+```
+
+The channel command fails before changing config if a plugin-declared environment variable is missing. Keep `TELEGRAM_BOT_TOKEN` in `.env` after bootstrap: `--use-env` leaves credential lookup to the environment without copying the token into `openclaw.json`, and the running Gateway needs the same variable. When channel config changes after startup, the Gateway's config watcher hot-reloads the affected channel automatically.
+
+See [`openclaw channels`](/cli/channels) for credential-flag alternatives and other channel plugins.
+
 ### Manual flow
 
 ```bash

--- a/docs/plugins/sdk-setup.md
+++ b/docs/plugins/sdk-setup.md
@@ -162,6 +162,8 @@ export const setupContract = defineChannelSetupContract({
 
 Supported field kinds are `string`, `boolean`, `integer`, `string-list`, and `choice`. Use `sensitive: true` for credentials. Each field key must equal the camelCased attribute name of its long CLI flag, including any negated form, such as `apiToken` for `--api-token`. Boolean fields may add `cli.negatedFlags` when both positive and `--no-*` forms are needed. `channel`, `account`, and the account display `name` remain the shared control envelope.
 
+For a boolean `useEnv` field, set `envVars` to the static environment variable names required by the plugin runtime. Non-interactive channel setup then rejects `--use-env` before writing config when any declared variable is empty. Set `envVarMode: "any"` when one variable from the list is sufficient, such as an inline credential or file-path alternative. Omitting `envVars` preserves the plugin's existing validation behavior.
+
 The released `setup`/`ChannelSetupInput` adapter stays available for existing external plugins. New plugins should expose `setupContract`; OpenClaw always prefers it when both are present.
 
 | Field                                  | Type       | What it means                                                                 |

--- a/extensions/buzz/package.json
+++ b/extensions/buzz/package.json
@@ -70,7 +70,8 @@
             "cli": {
               "flags": "--use-env",
               "description": "Use BUZZ_PRIVATE_KEY with the supplied relay URL"
-            }
+            },
+            "envVars": ["BUZZ_PRIVATE_KEY"]
           }
         ]
       }

--- a/extensions/buzz/src/setup-core.test.ts
+++ b/extensions/buzz/src/setup-core.test.ts
@@ -31,21 +31,6 @@ describe("buzzSetupContract", () => {
     });
   });
 
-  it("rejects --use-env when BUZZ_PRIVATE_KEY is unset", () => {
-    vi.stubEnv("BUZZ_PRIVATE_KEY", "");
-    if (!buzzSetupContract.validateInput) {
-      throw new Error("Expected buzzSetupContract.validateInput to be defined");
-    }
-
-    expect(
-      buzzSetupContract.validateInput({
-        cfg: {} as OpenClawConfig,
-        accountId: "default",
-        input: { relayUrl: "wss://buzz.example.com", useEnv: true },
-      }),
-    ).toBe("BUZZ_PRIVATE_KEY is not set.");
-  });
-
   it("clears an identity-bound auth tag when changing the private key", () => {
     const cfg = {
       channels: {

--- a/extensions/buzz/src/setup-core.ts
+++ b/extensions/buzz/src/setup-core.ts
@@ -57,18 +57,17 @@ const buzzSetupAdapter: ChannelSetupAdapter<BuzzSetupInput> = {
     if (!validRelayUrl(input.relayUrl)) {
       return "Buzz requires --relay-url with a ws:// or wss:// URL.";
     }
-    if (input.useEnv) {
-      return process.env.BUZZ_PRIVATE_KEY?.trim() ? null : "BUZZ_PRIVATE_KEY is not set.";
-    }
-    if (!input.privateKey?.trim()) {
+    if (!input.useEnv && !input.privateKey?.trim()) {
       return "Buzz requires --private-key or --use-env.";
     }
-    try {
-      decodeBuzzPrivateKey(input.privateKey);
-      return null;
-    } catch (error) {
-      return error instanceof Error ? error.message : "Invalid Buzz private key.";
+    if (!input.useEnv) {
+      try {
+        decodeBuzzPrivateKey(input.privateKey);
+      } catch (error) {
+        return error instanceof Error ? error.message : "Invalid Buzz private key.";
+      }
     }
+    return null;
   },
   applyAccountConfig: ({ cfg, input }) => {
     const currentPrivateKey = resolveComparableCurrentKey(cfg);
@@ -110,6 +109,7 @@ export const buzzSetupContract = defineChannelSetupContract({
         flags: "--use-env",
         description: "Use BUZZ_PRIVATE_KEY with the supplied relay URL",
       },
+      envVars: ["BUZZ_PRIVATE_KEY"],
     },
   },
   adapter: buzzSetupAdapter,

--- a/extensions/buzz/src/setup-core.ts
+++ b/extensions/buzz/src/setup-core.ts
@@ -57,15 +57,17 @@ const buzzSetupAdapter: ChannelSetupAdapter<BuzzSetupInput> = {
     if (!validRelayUrl(input.relayUrl)) {
       return "Buzz requires --relay-url with a ws:// or wss:// URL.";
     }
-    if (!input.useEnv && !input.privateKey?.trim()) {
+    if (input.useEnv) {
+      return null;
+    }
+    const privateKey = input.privateKey?.trim();
+    if (!privateKey) {
       return "Buzz requires --private-key or --use-env.";
     }
-    if (!input.useEnv) {
-      try {
-        decodeBuzzPrivateKey(input.privateKey);
-      } catch (error) {
-        return error instanceof Error ? error.message : "Invalid Buzz private key.";
-      }
+    try {
+      decodeBuzzPrivateKey(privateKey);
+    } catch (error) {
+      return error instanceof Error ? error.message : "Invalid Buzz private key.";
     }
     return null;
   },

--- a/extensions/clickclack/package.json
+++ b/extensions/clickclack/package.json
@@ -127,7 +127,8 @@
             "cli": {
               "flags": "--use-env",
               "description": "Use CLICKCLACK_BOT_TOKEN"
-            }
+            },
+            "envVars": ["CLICKCLACK_BOT_TOKEN"]
           }
         ]
       }

--- a/extensions/clickclack/src/setup-core.ts
+++ b/extensions/clickclack/src/setup-core.ts
@@ -382,6 +382,7 @@ export const clickClackSetupContract = defineChannelSetupContract({
     useEnv: {
       kind: "boolean",
       cli: { flags: "--use-env", description: "Use CLICKCLACK_BOT_TOKEN" },
+      envVars: ["CLICKCLACK_BOT_TOKEN"],
     },
   },
   legacyAdapter: clickClackSetupAdapter,

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -74,7 +74,8 @@
             "cli": {
               "flags": "--use-env",
               "description": "Use DISCORD_BOT_TOKEN"
-            }
+            },
+            "envVars": ["DISCORD_BOT_TOKEN"]
           }
         ]
       },

--- a/extensions/discord/src/setup-adapter.ts
+++ b/extensions/discord/src/setup-adapter.ts
@@ -25,6 +25,7 @@ export const discordSetupContract = defineChannelSetupContract({
     useEnv: {
       kind: "boolean",
       cli: { flags: "--use-env", description: "Use DISCORD_BOT_TOKEN" },
+      envVars: ["DISCORD_BOT_TOKEN"],
     },
   },
   legacyAdapter: discordSetupAdapter,

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -122,7 +122,9 @@
             "cli": {
               "flags": "--use-env",
               "description": "Use Google Chat environment credentials"
-            }
+            },
+            "envVars": ["GOOGLE_CHAT_SERVICE_ACCOUNT", "GOOGLE_CHAT_SERVICE_ACCOUNT_FILE"],
+            "envVarMode": "any"
           }
         ]
       }

--- a/extensions/googlechat/src/setup-core.ts
+++ b/extensions/googlechat/src/setup-core.ts
@@ -82,6 +82,8 @@ export const googlechatSetupContract = defineChannelSetupContract({
     useEnv: {
       kind: "boolean",
       cli: { flags: "--use-env", description: "Use Google Chat environment credentials" },
+      envVars: ["GOOGLE_CHAT_SERVICE_ACCOUNT", "GOOGLE_CHAT_SERVICE_ACCOUNT_FILE"],
+      envVarMode: "any",
     },
   },
   legacyAdapter: googlechatSetupAdapter,

--- a/extensions/irc/package.json
+++ b/extensions/irc/package.json
@@ -114,7 +114,8 @@
             "cli": {
               "flags": "--use-env",
               "description": "Use IRC environment configuration"
-            }
+            },
+            "envVars": ["IRC_HOST", "IRC_NICK"]
           }
         ]
       }

--- a/extensions/irc/src/setup-core.ts
+++ b/extensions/irc/src/setup-core.ts
@@ -176,6 +176,7 @@ export const ircSetupContract = defineChannelSetupContract({
     useEnv: {
       kind: "boolean",
       cli: { flags: "--use-env", description: "Use IRC environment configuration" },
+      envVars: ["IRC_HOST", "IRC_NICK"],
     },
   },
   legacyAdapter: ircSetupAdapter,

--- a/extensions/line/package.json
+++ b/extensions/line/package.json
@@ -100,7 +100,8 @@
             "cli": {
               "flags": "--use-env",
               "description": "Use LINE environment credentials"
-            }
+            },
+            "envVars": ["LINE_CHANNEL_ACCESS_TOKEN", "LINE_CHANNEL_SECRET"]
           }
         ]
       }

--- a/extensions/line/src/setup-core.ts
+++ b/extensions/line/src/setup-core.ts
@@ -136,6 +136,7 @@ export const lineSetupContract = defineChannelSetupContract({
     useEnv: {
       kind: "boolean",
       cli: { flags: "--use-env", description: "Use LINE environment credentials" },
+      envVars: ["LINE_CHANNEL_ACCESS_TOKEN", "LINE_CHANNEL_SECRET"],
     },
   },
   legacyAdapter: lineSetupAdapter,

--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -78,7 +78,8 @@
             "cli": {
               "flags": "--use-env",
               "description": "Use Mattermost environment credentials"
-            }
+            },
+            "envVars": ["MATTERMOST_BOT_TOKEN", "MATTERMOST_URL"]
           }
         ]
       }

--- a/extensions/mattermost/src/setup-core.ts
+++ b/extensions/mattermost/src/setup-core.ts
@@ -134,6 +134,7 @@ export const mattermostSetupContract = defineChannelSetupContract({
     useEnv: {
       kind: "boolean",
       cli: { flags: "--use-env", description: "Use Mattermost environment credentials" },
+      envVars: ["MATTERMOST_BOT_TOKEN", "MATTERMOST_URL"],
     },
   },
   legacyAdapter: mattermostSetupAdapter,

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -117,7 +117,8 @@
             "cli": {
               "flags": "--use-env",
               "description": "Use Nextcloud Talk environment credentials"
-            }
+            },
+            "envVars": ["NEXTCLOUD_TALK_BOT_SECRET"]
           }
         ]
       }

--- a/extensions/nextcloud-talk/src/setup-core.ts
+++ b/extensions/nextcloud-talk/src/setup-core.ts
@@ -245,6 +245,7 @@ export const nextcloudTalkSetupContract = defineChannelSetupContract({
     useEnv: {
       kind: "boolean",
       cli: { flags: "--use-env", description: "Use Nextcloud Talk environment credentials" },
+      envVars: ["NEXTCLOUD_TALK_BOT_SECRET"],
     },
   },
   legacyAdapter: nextcloudTalkSetupAdapter,

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -69,7 +69,8 @@
             "cli": {
               "flags": "--use-env",
               "description": "Use NOSTR_PRIVATE_KEY"
-            }
+            },
+            "envVars": ["NOSTR_PRIVATE_KEY"]
           }
         ]
       }

--- a/extensions/nostr/src/channel.setup.ts
+++ b/extensions/nostr/src/channel.setup.ts
@@ -8,6 +8,7 @@ import {
 import { buildChannelConfigSchema, type ChannelPlugin } from "./channel-api.js";
 import { NostrConfigSchema } from "./config-schema.js";
 import { DEFAULT_RELAYS } from "./default-relays.js";
+import { resolveNostrPrivateKey } from "./private-key.js";
 import {
   createNostrSetupAdapter,
   createNostrSetupContract,
@@ -38,7 +39,7 @@ function resolveSetupNostrAccount(params: {
 }): ResolvedNostrAccount {
   const nostrCfg = getNostrConfig(params.cfg);
   const accountId = params.accountId?.trim() || resolveDefaultSetupNostrAccountId(params.cfg);
-  const privateKey = typeof nostrCfg?.privateKey === "string" ? nostrCfg.privateKey.trim() : "";
+  const privateKey = resolveNostrPrivateKey(nostrCfg?.privateKey);
   const configured = Boolean(privateKey);
   return {
     accountId,

--- a/extensions/nostr/src/channel.test.ts
+++ b/extensions/nostr/src/channel.test.ts
@@ -5,7 +5,7 @@ import {
   runSetupWizardConfigure,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import type { WizardPrompter } from "openclaw/plugin-sdk/plugin-test-runtime";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
 import { nostrPlugin } from "./channel.js";
 import { normalizePubkey } from "./nostr-key-utils.js";
@@ -18,6 +18,10 @@ import {
   createConfiguredNostrCfg,
 } from "./test-fixtures.js";
 import { listNostrAccountIds, resolveDefaultNostrAccountId, resolveNostrAccount } from "./types.js";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe("nostr target classification", () => {
   it("accepts only valid direct-message public keys", () => {
@@ -433,6 +437,7 @@ describe("nostr unresolved SecretRef privateKey", () => {
   it.each(unresolvedSecretRefPrivateKeyCases)(
     "$name does not treat unresolved SecretRef privateKey as configured",
     ({ assert }) => {
+      vi.stubEnv("NOSTR_PRIVATE_KEY", TEST_HEX_PRIVATE_KEY);
       assert(createUnresolvedNostrPrivateKeyCfg());
     },
   );
@@ -507,6 +512,16 @@ describe("nostr account helpers", () => {
       expect(account.publicKey).toBe("");
       expect(account.relays).toContain("wss://relay.damus.io");
       expect(account.relays).toContain("wss://nos.lol");
+    });
+
+    it("resolves the default account private key from NOSTR_PRIVATE_KEY", () => {
+      vi.stubEnv("NOSTR_PRIVATE_KEY", TEST_HEX_PRIVATE_KEY);
+
+      const account = resolveNostrAccount({ cfg: { channels: { nostr: { enabled: true } } } });
+
+      expect(account.configured).toBe(true);
+      expect(account.privateKey).toBe(TEST_HEX_PRIVATE_KEY);
+      expect(account.publicKey).toMatch(/^[0-9a-f]{64}$/);
     });
 
     it("handles disabled channel", () => {

--- a/extensions/nostr/src/private-key.ts
+++ b/extensions/nostr/src/private-key.ts
@@ -1,0 +1,15 @@
+import {
+  hasConfiguredSecretInput,
+  normalizeSecretInputString,
+  type SecretInput,
+} from "openclaw/plugin-sdk/secret-input";
+
+export const NOSTR_PRIVATE_KEY_ENV_VAR = "NOSTR_PRIVATE_KEY";
+
+export function resolveNostrPrivateKey(value: SecretInput | undefined): string {
+  const configured = normalizeSecretInputString(value);
+  if (configured || hasConfiguredSecretInput(value)) {
+    return configured ?? "";
+  }
+  return process.env[NOSTR_PRIVATE_KEY_ENV_VAR]?.trim() ?? "";
+}

--- a/extensions/nostr/src/setup-adapter.ts
+++ b/extensions/nostr/src/setup-adapter.ts
@@ -13,6 +13,7 @@ import {
 } from "openclaw/plugin-sdk/setup";
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { DEFAULT_RELAYS } from "./default-relays.js";
+import { NOSTR_PRIVATE_KEY_ENV_VAR } from "./private-key.js";
 
 const channel = "nostr" as const;
 
@@ -106,6 +107,7 @@ export function createNostrSetupContract(adapter: ChannelSetupAdapter<NostrSetup
       useEnv: {
         kind: "boolean",
         cli: { flags: "--use-env", description: "Use NOSTR_PRIVATE_KEY" },
+        envVars: [NOSTR_PRIVATE_KEY_ENV_VAR],
       },
     },
     adapter,

--- a/extensions/nostr/src/types.ts
+++ b/extensions/nostr/src/types.ts
@@ -6,11 +6,12 @@ import {
   normalizeOptionalAccountId,
 } from "openclaw/plugin-sdk/account-id";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { normalizeSecretInputString, type SecretInput } from "openclaw/plugin-sdk/secret-input";
+import type { SecretInput } from "openclaw/plugin-sdk/secret-input";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { NostrProfile } from "./config-schema.js";
 import { DEFAULT_RELAYS } from "./default-relays.js";
 import { getPublicKeyFromPrivate } from "./nostr-key-utils.js";
+import { resolveNostrPrivateKey } from "./private-key.js";
 
 interface NostrAccountConfig {
   enabled?: boolean;
@@ -42,7 +43,7 @@ const {
   fallbackAccountIdWhenEmpty: false,
   resolveImplicitAccountId: (cfg) => {
     const account = cfg.channels?.nostr as NostrAccountConfig | undefined;
-    return normalizeSecretInputString(account?.privateKey)
+    return resolveNostrPrivateKey(account?.privateKey)
       ? (normalizeOptionalAccountId(account?.defaultAccount) ?? DEFAULT_ACCOUNT_ID)
       : undefined;
   },
@@ -63,7 +64,7 @@ export function resolveNostrAccount(opts: {
     | undefined;
 
   const baseEnabled = nostrCfg?.enabled !== false;
-  const privateKey = normalizeSecretInputString(nostrCfg?.privateKey) ?? "";
+  const privateKey = resolveNostrPrivateKey(nostrCfg?.privateKey);
   const configured = Boolean(privateKey);
 
   let publicKey = "";

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -139,7 +139,8 @@
             "cli": {
               "flags": "--use-env",
               "description": "Use Slack environment credentials"
-            }
+            },
+            "envVars": ["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"]
           }
         ]
       }

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -140,7 +140,7 @@
               "flags": "--use-env",
               "description": "Use Slack environment credentials"
             },
-            "envVars": ["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"]
+            "envVars": ["SLACK_BOT_TOKEN"]
           }
         ]
       }

--- a/extensions/slack/src/channel-actions-setup-status.contract.test.ts
+++ b/extensions/slack/src/channel-actions-setup-status.contract.test.ts
@@ -5,7 +5,7 @@ import {
   installChannelStatusContractSuite,
 } from "openclaw/plugin-sdk/channel-test-helpers";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { describe, expect } from "vitest";
+import { afterEach, describe, expect, vi } from "vitest";
 import { slackPlugin } from "../api.js";
 import { slackSetupPlugin } from "../setup-plugin-api.js";
 
@@ -24,6 +24,10 @@ const slackDefaultActions = [
   "member-info",
   "emoji-list",
 ] as const;
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe("slack actions contract", () => {
   installChannelActionsContractSuite({
@@ -86,6 +90,58 @@ describe("slack setup contract", () => {
         },
         expectedAccountId: "ops",
         expectedValidation: "Slack env tokens can only be used for the default account.",
+      },
+      {
+        name: "HTTP env setup accepts a configured signing secret without an app token",
+        cfg: {
+          channels: {
+            slack: {
+              mode: "http",
+              signingSecret: "test-signing-secret",
+            },
+          },
+        } as OpenClawConfig,
+        input: {
+          useEnv: true,
+        },
+        beforeTest: () => {
+          vi.stubEnv("SLACK_BOT_TOKEN", "xoxb-test");
+          vi.stubEnv("SLACK_APP_TOKEN", "");
+        },
+        assertPatchedConfig: (cfg) => {
+          expect(cfg.channels?.slack).toMatchObject({
+            enabled: true,
+            mode: "http",
+            signingSecret: "test-signing-secret",
+          });
+          expect(cfg.channels?.slack?.appToken).toBeUndefined();
+        },
+      },
+      {
+        name: "Socket Mode env setup rejects a missing app token",
+        cfg: {} as OpenClawConfig,
+        input: {
+          useEnv: true,
+        },
+        beforeTest: () => {
+          vi.stubEnv("SLACK_BOT_TOKEN", "xoxb-test");
+          vi.stubEnv("SLACK_APP_TOKEN", "");
+        },
+        expectedValidation: "Slack Socket Mode requires SLACK_APP_TOKEN when using --use-env.",
+      },
+      {
+        name: "Socket Mode env setup accepts bot and app tokens",
+        cfg: {} as OpenClawConfig,
+        input: {
+          useEnv: true,
+        },
+        beforeTest: () => {
+          vi.stubEnv("SLACK_BOT_TOKEN", "xoxb-test");
+          vi.stubEnv("SLACK_APP_TOKEN", "xapp-test");
+        },
+        assertPatchedConfig: (cfg) => {
+          expect(cfg.channels?.slack).toMatchObject({ enabled: true });
+        },
       },
       {
         name: "user identity stores the user and Socket Mode transport tokens",

--- a/extensions/slack/src/setup-core.ts
+++ b/extensions/slack/src/setup-core.ts
@@ -187,9 +187,24 @@ const slackSetupAdapterBase = createPatchedAccountSetupAdapter({
       return 'Slack user identity setup supports mode "socket" or "http", not "relay".';
     }
     if (setupInput.useEnv) {
-      return identity === "user"
-        ? "Slack user identity setup does not support --use-env; configure userToken and the transport credential explicitly."
-        : null;
+      if (identity === "user") {
+        return "Slack user identity setup does not support --use-env; configure userToken and the transport credential explicitly.";
+      }
+      if (
+        mode === "socket" &&
+        !normalizeOptionalString(setupInput.appToken) &&
+        account.appTokenStatus === "missing"
+      ) {
+        return "Slack Socket Mode requires SLACK_APP_TOKEN when using --use-env.";
+      }
+      if (
+        mode === "http" &&
+        !normalizeOptionalString(setupInput.signingSecret) &&
+        account.signingSecretStatus === "missing"
+      ) {
+        return "Slack HTTP mode requires a configured signing secret when using --use-env.";
+      }
+      return null;
     }
     if (hasSlackSetupCredentials({ input: setupInput, identity, mode })) {
       return null;
@@ -263,7 +278,7 @@ export const slackSetupContract = defineChannelSetupContract({
     useEnv: {
       kind: "boolean",
       cli: { flags: "--use-env", description: "Use Slack environment credentials" },
-      envVars: ["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"],
+      envVars: ["SLACK_BOT_TOKEN"],
     },
   },
   legacyAdapter: slackSetupAdapter,

--- a/extensions/slack/src/setup-core.ts
+++ b/extensions/slack/src/setup-core.ts
@@ -263,6 +263,7 @@ export const slackSetupContract = defineChannelSetupContract({
     useEnv: {
       kind: "boolean",
       cli: { flags: "--use-env", description: "Use Slack environment credentials" },
+      envVars: ["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"],
     },
   },
   legacyAdapter: slackSetupAdapter,

--- a/extensions/synology-chat/package.json
+++ b/extensions/synology-chat/package.json
@@ -68,7 +68,8 @@
             "cli": {
               "flags": "--use-env",
               "description": "Use Synology Chat environment credentials"
-            }
+            },
+            "envVars": ["SYNOLOGY_CHAT_TOKEN"]
           }
         ]
       }

--- a/extensions/synology-chat/src/setup-surface.ts
+++ b/extensions/synology-chat/src/setup-surface.ts
@@ -218,6 +218,7 @@ export const synologyChatSetupContract = defineChannelSetupContract({
     useEnv: {
       kind: "boolean",
       cli: { flags: "--use-env", description: "Use Synology Chat environment credentials" },
+      envVars: ["SYNOLOGY_CHAT_TOKEN"],
     },
   },
   legacyAdapter: synologyChatSetupAdapter,

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -74,7 +74,8 @@
             "cli": {
               "flags": "--use-env",
               "description": "Use TELEGRAM_BOT_TOKEN"
-            }
+            },
+            "envVars": ["TELEGRAM_BOT_TOKEN"]
           }
         ]
       },

--- a/extensions/telegram/src/setup-core.ts
+++ b/extensions/telegram/src/setup-core.ts
@@ -124,6 +124,7 @@ export const telegramSetupContract = defineChannelSetupContract({
     useEnv: {
       kind: "boolean",
       cli: { flags: "--use-env", description: "Use TELEGRAM_BOT_TOKEN" },
+      envVars: ["TELEGRAM_BOT_TOKEN"],
     },
   },
   legacyAdapter: telegramSetupAdapter,

--- a/extensions/zalo/package.json
+++ b/extensions/zalo/package.json
@@ -73,7 +73,8 @@
             "cli": {
               "flags": "--use-env",
               "description": "Use ZALO_BOT_TOKEN"
-            }
+            },
+            "envVars": ["ZALO_BOT_TOKEN"]
           }
         ]
       }

--- a/extensions/zalo/src/setup-core.ts
+++ b/extensions/zalo/src/setup-core.ts
@@ -58,6 +58,7 @@ export const zaloSetupContract = defineChannelSetupContract({
     useEnv: {
       kind: "boolean",
       cli: { flags: "--use-env", description: "Use ZALO_BOT_TOKEN" },
+      envVars: ["ZALO_BOT_TOKEN"],
     },
   },
   legacyAdapter: zaloSetupAdapter,

--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -2153,8 +2153,7 @@
                   "description": "Use Slack environment credentials"
                 },
                 "envVars": [
-                  "SLACK_BOT_TOKEN",
-                  "SLACK_APP_TOKEN"
+                  "SLACK_BOT_TOKEN"
                 ]
               }
             ]

--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -298,7 +298,10 @@
                 "cli": {
                   "flags": "--use-env",
                   "description": "Use BUZZ_PRIVATE_KEY with the supplied relay URL"
-                }
+                },
+                "envVars": [
+                  "BUZZ_PRIVATE_KEY"
+                ]
               }
             ]
           }
@@ -624,7 +627,10 @@
                 "cli": {
                   "flags": "--use-env",
                   "description": "Use CLICKCLACK_BOT_TOKEN"
-                }
+                },
+                "envVars": [
+                  "CLICKCLACK_BOT_TOKEN"
+                ]
               }
             ]
           }
@@ -692,7 +698,10 @@
                 "cli": {
                   "flags": "--use-env",
                   "description": "Use DISCORD_BOT_TOKEN"
-                }
+                },
+                "envVars": [
+                  "DISCORD_BOT_TOKEN"
+                ]
               }
             ]
           },
@@ -874,7 +883,12 @@
                 "cli": {
                   "flags": "--use-env",
                   "description": "Use Google Chat environment credentials"
-                }
+                },
+                "envVars": [
+                  "GOOGLE_CHAT_SERVICE_ACCOUNT",
+                  "GOOGLE_CHAT_SERVICE_ACCOUNT_FILE"
+                ],
+                "envVarMode": "any"
               }
             ]
           }
@@ -1059,7 +1073,11 @@
                 "cli": {
                   "flags": "--use-env",
                   "description": "Use IRC environment configuration"
-                }
+                },
+                "envVars": [
+                  "IRC_HOST",
+                  "IRC_NICK"
+                ]
               }
             ]
           }
@@ -1152,7 +1170,11 @@
                 "cli": {
                   "flags": "--use-env",
                   "description": "Use LINE environment credentials"
-                }
+                },
+                "envVars": [
+                  "LINE_CHANNEL_ACCESS_TOKEN",
+                  "LINE_CHANNEL_SECRET"
+                ]
               }
             ]
           }
@@ -1363,7 +1385,11 @@
                 "cli": {
                   "flags": "--use-env",
                   "description": "Use Mattermost environment credentials"
-                }
+                },
+                "envVars": [
+                  "MATTERMOST_BOT_TOKEN",
+                  "MATTERMOST_URL"
+                ]
               }
             ]
           }
@@ -1518,7 +1544,10 @@
                 "cli": {
                   "flags": "--use-env",
                   "description": "Use Nextcloud Talk environment credentials"
-                }
+                },
+                "envVars": [
+                  "NEXTCLOUD_TALK_BOT_SECRET"
+                ]
               }
             ]
           }
@@ -1578,7 +1607,10 @@
                 "cli": {
                   "flags": "--use-env",
                   "description": "Use NOSTR_PRIVATE_KEY"
-                }
+                },
+                "envVars": [
+                  "NOSTR_PRIVATE_KEY"
+                ]
               }
             ]
           }
@@ -2119,7 +2151,11 @@
                 "cli": {
                   "flags": "--use-env",
                   "description": "Use Slack environment credentials"
-                }
+                },
+                "envVars": [
+                  "SLACK_BOT_TOKEN",
+                  "SLACK_APP_TOKEN"
+                ]
               }
             ]
           }
@@ -2317,7 +2353,10 @@
                 "cli": {
                   "flags": "--use-env",
                   "description": "Use Synology Chat environment credentials"
-                }
+                },
+                "envVars": [
+                  "SYNOLOGY_CHAT_TOKEN"
+                ]
               }
             ]
           }
@@ -2656,7 +2695,10 @@
                 "cli": {
                   "flags": "--use-env",
                   "description": "Use ZALO_BOT_TOKEN"
-                }
+                },
+                "envVars": [
+                  "ZALO_BOT_TOKEN"
+                ]
               }
             ]
           }

--- a/src/channels/plugins/account-config-mutation.test.ts
+++ b/src/channels/plugins/account-config-mutation.test.ts
@@ -145,6 +145,31 @@ describe("channel account config mutations", () => {
     expect(applyAccountConfig).not.toHaveBeenCalled();
   });
 
+  it("preserves --use-env behavior for contracts without env metadata", async () => {
+    const applyAccountConfig = vi.fn(({ cfg }) => cfg);
+    const plugin = {
+      ...createChannelTestPluginBase({ id: "third-party-chat" }),
+      setupContract: defineChannelSetupContract({
+        fields: {
+          useEnv: {
+            kind: "boolean",
+            cli: { flags: "--use-env", description: "Use plugin environment credentials" },
+          },
+        },
+        adapter: { applyAccountConfig },
+      }),
+    } as ChannelPlugin;
+
+    const prepared = await prepareChannelAccountConfiguration({
+      cfg: {},
+      plugin,
+      resolveInput: () => ({ useEnv: true }),
+      runtime,
+    });
+
+    expect(prepared.ok).toBe(true);
+  });
+
   it("normalizes plugin-resolved account IDs only at the config mutation boundary", async () => {
     const applyAccountConfig = vi.fn(({ cfg }) => cfg);
     const onAccountConfigChanged = vi.fn();

--- a/src/channels/plugins/account-config-mutation.ts
+++ b/src/channels/plugins/account-config-mutation.ts
@@ -3,7 +3,10 @@ import { err as resultError, ok, type Result } from "@openclaw/normalization-cor
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-key.js";
 import type { RuntimeEnv } from "../../runtime.js";
-import { resolveChannelSetupExecutionAdapter } from "./setup-contract.js";
+import {
+  resolveChannelSetupExecutionAdapter,
+  type ChannelSetupFieldMetadata,
+} from "./setup-contract.js";
 import { moveSingleAccountChannelSectionToDefaultAccount } from "./setup-helpers.js";
 import type { ChannelSetupAdapter } from "./types.adapters.js";
 import type { ChannelPlugin } from "./types.plugin.js";
@@ -32,19 +35,19 @@ function resolveMissingSetupEnvMessage(plugin: ChannelPlugin, input: unknown): s
     return undefined;
   }
   const useEnvField = plugin.setupContract.metadata.fields.find(
-    (field) => field.key === "useEnv" && field.kind === "boolean",
+    (field): field is Extract<ChannelSetupFieldMetadata, { kind: "boolean" }> =>
+      field.kind === "boolean" && field.key === "useEnv",
   );
-  const envVars = useEnvField?.envVars;
-  if (!envVars?.length) {
+  if (!useEnvField?.envVars?.length) {
     return undefined;
   }
+  const { envVars, envVarMode } = useEnvField;
   const missing = envVars.filter((name) => !process.env[name]?.trim());
-  const ready =
-    useEnvField.envVarMode === "any" ? missing.length < envVars.length : !missing.length;
+  const ready = envVarMode === "any" ? missing.length < envVars.length : !missing.length;
   if (ready) {
     return undefined;
   }
-  return useEnvField.envVarMode === "any"
+  return envVarMode === "any"
     ? `Set one of these environment variables before using --use-env: ${missing.join(", ")}.`
     : `Set these environment variables before using --use-env: ${missing.join(", ")}.`;
 }

--- a/src/channels/plugins/account-config-mutation.ts
+++ b/src/channels/plugins/account-config-mutation.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { err as resultError, ok, type Result } from "@openclaw/normalization-core/result";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-key.js";
@@ -25,6 +26,28 @@ type PreparedChannelAccountConfiguration = {
   accountId: string;
   input: unknown;
 };
+
+function resolveMissingSetupEnvMessage(plugin: ChannelPlugin, input: unknown): string | undefined {
+  if (!plugin.setupContract || !isRecord(input) || input.useEnv !== true) {
+    return undefined;
+  }
+  const useEnvField = plugin.setupContract.metadata.fields.find(
+    (field) => field.key === "useEnv" && field.kind === "boolean",
+  );
+  const envVars = useEnvField?.envVars;
+  if (!envVars?.length) {
+    return undefined;
+  }
+  const missing = envVars.filter((name) => !process.env[name]?.trim());
+  const ready =
+    useEnvField.envVarMode === "any" ? missing.length < envVars.length : !missing.length;
+  if (ready) {
+    return undefined;
+  }
+  return useEnvField.envVarMode === "any"
+    ? `Set one of these environment variables before using --use-env: ${missing.join(", ")}.`
+    : `Set these environment variables before using --use-env: ${missing.join(", ")}.`;
+}
 
 export async function prepareChannelAccountConfiguration(params: {
   cfg: OpenClawConfig;
@@ -76,6 +99,10 @@ export async function prepareChannelAccountConfiguration(params: {
   });
   if (validationError) {
     return resultError({ kind: "invalid-input", message: validationError });
+  }
+  const missingEnvMessage = resolveMissingSetupEnvMessage(params.plugin, input);
+  if (missingEnvMessage) {
+    return resultError({ kind: "invalid-input", message: missingEnvMessage });
   }
 
   return ok({

--- a/src/channels/plugins/setup-contract.test.ts
+++ b/src/channels/plugins/setup-contract.test.ts
@@ -222,6 +222,12 @@ describe("defineChannelSetupContract", () => {
           choices: ["socket", "http"],
           cli: { flags: "--mode <mode>", description: "Connection mode" },
         },
+        useEnv: {
+          kind: "boolean",
+          cli: { flags: "--use-env", description: "Use environment credentials" },
+          envVars: ["CHAT_TOKEN", "CHAT_TOKEN_FILE"],
+          envVarMode: "any",
+        },
       },
       adapter: {
         applyAccountConfig: ({ cfg }) => cfg,
@@ -241,6 +247,13 @@ describe("defineChannelSetupContract", () => {
           kind: "choice",
           choices: ["socket", "http"],
           cli: { flags: "--mode <mode>", description: "Connection mode" },
+        },
+        {
+          key: "useEnv",
+          kind: "boolean",
+          cli: { flags: "--use-env", description: "Use environment credentials" },
+          envVars: ["CHAT_TOKEN", "CHAT_TOKEN_FILE"],
+          envVarMode: "any",
         },
       ],
     });

--- a/src/channels/plugins/setup-contract.ts
+++ b/src/channels/plugins/setup-contract.ts
@@ -22,6 +22,8 @@ type ChannelSetupStringField = {
 type ChannelSetupBooleanField = {
   kind: "boolean";
   cli: ChannelSetupCliOption;
+  envVars?: readonly string[];
+  envVarMode?: "all" | "any";
 };
 
 type ChannelSetupIntegerField = {

--- a/src/channels/plugins/setup-contract.ts
+++ b/src/channels/plugins/setup-contract.ts
@@ -50,9 +50,11 @@ type ChannelSetupField =
   | ChannelSetupStringListField
   | ChannelSetupChoiceField;
 
-export type ChannelSetupFieldMetadata = ChannelSetupField & {
-  key: string;
-};
+type ChannelSetupFieldMetadataFor<Field extends ChannelSetupField> = Field extends ChannelSetupField
+  ? Field & { key: string }
+  : never;
+
+export type ChannelSetupFieldMetadata = ChannelSetupFieldMetadataFor<ChannelSetupField>;
 
 export type ChannelSetupMetadata = {
   fields: readonly ChannelSetupFieldMetadata[];

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -551,9 +551,8 @@ describe("channelsAddCommand", () => {
       { hasFlags: true },
     );
 
-    const error = String(runtime.error.mock.calls[0]?.[0] ?? "");
     for (const missing of testCase.missing) {
-      expect(error).toContain(missing);
+      expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining(missing));
     }
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(configMocks.writeConfigFile).not.toHaveBeenCalled();

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -1,6 +1,6 @@
 // Channels add tests cover guided setup, plugin install paths, and channel account config writes.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { getBundledChannelSetupPlugin } from "../channels/plugins/bundled.js";
 import type { ChannelPluginCatalogEntry } from "../channels/plugins/catalog.js";
 import { defineChannelSetupContract } from "../channels/plugins/setup-contract.js";
@@ -45,6 +45,10 @@ const registryRefreshMocks = vi.hoisted(() => ({
 
 const pluginInstallRecordCommitMocks = vi.hoisted(() => ({
   commitConfigWithPendingPluginInstalls: vi.fn(),
+}));
+
+const terminalMocks = vi.hoisted(() => ({
+  isTerminalInteractive: vi.fn(() => true),
 }));
 
 const channelWizardMocks = vi.hoisted(() => {
@@ -98,6 +102,8 @@ vi.mock("./channel-setup/plugin-install.js", () => pluginInstallMocks);
 vi.mock("../plugins/registry-refresh.js", () => registryRefreshMocks);
 
 vi.mock("../plugins/install-record-commit.js", () => pluginInstallRecordCommitMocks);
+
+vi.mock("../cli/terminal-interactivity.js", () => terminalMocks);
 
 vi.mock("../wizard/clack-prompter.js", () => ({
   createClackPrompter: () => channelWizardMocks.prompter,
@@ -365,6 +371,17 @@ function registerExternalChatSetupPlugin(pluginId = "@vendor/external-chat-plugi
   );
 }
 
+async function registerBundledSetupPlugin(channelId: string): Promise<void> {
+  const actual = await vi.importActual<typeof import("../channels/plugins/bundled.js")>(
+    "../channels/plugins/bundled.js",
+  );
+  const plugin = actual.getBundledChannelSetupPlugin(channelId as never);
+  if (!plugin) {
+    throw new Error(`Expected bundled setup plugin: ${channelId}`);
+  }
+  setActivePluginRegistry(createTestRegistry([{ pluginId: channelId, plugin, source: "test" }]));
+}
+
 type SignalAfterAccountConfigWritten = NonNullable<
   NonNullable<ChannelPlugin["setup"]>["afterAccountConfigWritten"]
 >;
@@ -450,6 +467,7 @@ describe("channelsAddCommand", () => {
     runtime.log.mockClear();
     runtime.error.mockClear();
     runtime.exit.mockClear();
+    terminalMocks.isTerminalInteractive.mockReset().mockReturnValue(true);
     catalogMocks.getChannelPluginCatalogEntry.mockClear();
     catalogMocks.getChannelPluginCatalogEntry.mockReturnValue(undefined);
     catalogMocks.listChannelPluginCatalogEntries.mockClear();
@@ -482,6 +500,88 @@ describe("channelsAddCommand", () => {
       async (...args: unknown[]) => args[0] as OpenClawConfig,
     );
     setMinimalChannelsAddRegistryForTests();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("fails fast before guided setup when no interactive terminal is available", async () => {
+    terminalMocks.isTerminalInteractive.mockReturnValue(false);
+    configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot });
+
+    await channelsAddCommand({ channel: "telegram" }, runtime, { hasFlags: false });
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("channels add --channel <id> --use-env"),
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(channelWizardMocks.setupChannels).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      channel: "telegram",
+      options: {},
+      env: { TELEGRAM_BOT_TOKEN: "" },
+      missing: ["TELEGRAM_BOT_TOKEN"],
+    },
+    {
+      channel: "slack",
+      options: {},
+      env: { SLACK_BOT_TOKEN: "", SLACK_APP_TOKEN: "" },
+      missing: ["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"],
+    },
+    {
+      channel: "buzz",
+      options: { relayUrl: "wss://buzz.example.com" },
+      env: { BUZZ_PRIVATE_KEY: "" },
+      missing: ["BUZZ_PRIVATE_KEY"],
+    },
+  ])("rejects $channel --use-env when declared env vars are missing", async (testCase) => {
+    for (const [name, value] of Object.entries(testCase.env)) {
+      vi.stubEnv(name, value);
+    }
+    await registerBundledSetupPlugin(testCase.channel);
+    configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot });
+
+    await channelsAddCommand(
+      { channel: testCase.channel, useEnv: true, ...testCase.options },
+      runtime,
+      { hasFlags: true },
+    );
+
+    const error = String(runtime.error.mock.calls[0]?.[0] ?? "");
+    for (const missing of testCase.missing) {
+      expect(error).toContain(missing);
+    }
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      channel: "telegram",
+      env: { TELEGRAM_BOT_TOKEN: "telegram-token" },
+    },
+    {
+      channel: "slack",
+      env: { SLACK_BOT_TOKEN: "xoxb-token", SLACK_APP_TOKEN: "xapp-token" },
+    },
+  ])("commits $channel --use-env config when declared env vars are present", async (testCase) => {
+    for (const [name, value] of Object.entries(testCase.env)) {
+      vi.stubEnv(name, value);
+    }
+    await registerBundledSetupPlugin(testCase.channel);
+    configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot });
+
+    await channelsAddCommand({ channel: testCase.channel, useEnv: true }, runtime, {
+      hasFlags: true,
+    });
+
+    expect(writtenChannel(testCase.channel)).toEqual({ enabled: true });
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
   });
 
   it("keeps guided channel setup lazy until the user selects a channel", async () => {

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -529,8 +529,8 @@ describe("channelsAddCommand", () => {
     {
       channel: "slack",
       options: {},
-      env: { SLACK_BOT_TOKEN: "", SLACK_APP_TOKEN: "" },
-      missing: ["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"],
+      env: { SLACK_BOT_TOKEN: "xoxb-token", SLACK_APP_TOKEN: "" },
+      missing: ["SLACK_APP_TOKEN"],
     },
     {
       channel: "buzz",
@@ -579,6 +579,38 @@ describe("channelsAddCommand", () => {
     });
 
     expect(writtenChannel(testCase.channel)).toEqual({ enabled: true });
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("commits Slack HTTP --use-env config without SLACK_APP_TOKEN", async () => {
+    vi.stubEnv("SLACK_BOT_TOKEN", "xoxb-token");
+    vi.stubEnv("SLACK_APP_TOKEN", "");
+    await registerBundledSetupPlugin("slack");
+    const config: OpenClawConfig = {
+      channels: {
+        slack: {
+          mode: "http",
+          signingSecret: "test-signing-secret",
+        },
+      },
+    };
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      sourceConfig: config,
+      config,
+    });
+
+    await channelsAddCommand({ channel: "slack", useEnv: true }, runtime, {
+      hasFlags: true,
+    });
+
+    expect(writtenChannel("slack")).toMatchObject({
+      enabled: true,
+      mode: "http",
+      signingSecret: "test-signing-secret",
+    });
+    expect(writtenChannel("slack").appToken).toBeUndefined();
     expect(runtime.error).not.toHaveBeenCalled();
     expect(runtime.exit).not.toHaveBeenCalled();
   });

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -17,6 +17,7 @@ import {
   formatUnknownChannelMessage,
   formatUnsupportedChannelActionMessage,
 } from "../../cli/error-format.js";
+import { isTerminalInteractive } from "../../cli/terminal-interactivity.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { commitConfigWithPendingPluginInstalls } from "../../plugins/install-record-commit.js";
 import { refreshPluginRegistryAfterConfigMutation } from "../../plugins/registry-refresh.js";
@@ -154,6 +155,13 @@ async function channelsAddCommandImpl(
 
   const useWizard = shouldUseWizard(params);
   if (useWizard) {
+    if (!isTerminalInteractive()) {
+      runtime.error(
+        "Interactive channel setup requires a TTY. Use `openclaw channels add --channel <id> --use-env` or pass the channel's credential flags for non-interactive setup.",
+      );
+      runtime.exit(1);
+      return;
+    }
     const { resolveInitialWizardChannel, runChannelsAddWizardFlow } =
       await import("./add-wizard.js");
     const initialChannel = await resolveInitialWizardChannel(opts.channel ?? "", cfg);

--- a/src/plugins/manifest-registry-installed.test.ts
+++ b/src/plugins/manifest-registry-installed.test.ts
@@ -681,6 +681,8 @@ describe("loadPluginManifestRegistryForInstalledIndex", () => {
                 {
                   key: "useEnv",
                   kind: "boolean",
+                  envVars: ["INSTALLED_TOKEN", "INSTALLED_TOKEN_FILE"],
+                  envVarMode: "any",
                   cli: {
                     flags: "--use-env",
                     negatedFlags: "--no-use-env",
@@ -740,6 +742,8 @@ describe("loadPluginManifestRegistryForInstalledIndex", () => {
         {
           key: "useEnv",
           kind: "boolean",
+          envVars: ["INSTALLED_TOKEN", "INSTALLED_TOKEN_FILE"],
+          envVarMode: "any",
           cli: {
             flags: "--use-env",
             negatedFlags: "--no-use-env",

--- a/src/plugins/manifest-registry-installed.ts
+++ b/src/plugins/manifest-registry-installed.ts
@@ -353,6 +353,19 @@ function normalizePackageChannelSetup(setup: unknown): PluginPackageChannel["set
       });
       continue;
     }
+    if (kind === "boolean") {
+      const envVars = normalizeOptionalTrimmedStringList(value.envVars);
+      const envVarMode =
+        value.envVarMode === "any" || value.envVarMode === "all" ? value.envVarMode : undefined;
+      fields.push({
+        key,
+        kind,
+        ...(envVars?.length ? { envVars } : {}),
+        ...(envVars?.length && envVarMode ? { envVarMode } : {}),
+        cli,
+      });
+      continue;
+    }
     fields.push({ key, kind, cli });
   }
   return { fields };


### PR DESCRIPTION
## What Problem This Solves

Headless/cloud bootstrap needs scriptable channel provisioning, and `channels add` had three silent-failure defects in that path:

1. Selection-only `openclaw channels add --channel <id>` enters the interactive wizard with no TTY guard — an unattended script hangs forever (`src/commands/channels/add.ts`, `src/wizard/clack-prompter.ts`).
2. Most `--use-env` setups bypass required-credential validation without checking the environment variable actually exists (e.g. Telegram, `extensions/telegram/src/setup-core.ts`). A typo'd or missing env var yields a "configured" channel that never connects, with nothing explaining why. Buzz and Matrix already validated env presence locally — the policy existed, duplicated, in two plugins.
3. Nostr `--use-env` was broken end-to-end: setup cleared the stored key while runtime account resolution never read `NOSTR_PRIVATE_KEY` (`extensions/nostr/src/setup-adapter.ts`, `extensions/nostr/src/types.ts`) — a guaranteed dead channel.

## Why This Change Was Made

Second step of the cloud-container deployment track (after #122477): make `openclaw channels add --channel <id> --use-env` a safe, fail-fast primitive for scripted deployments.

- **Non-TTY fail-fast:** guided `channels add` without a TTY now exits 1 with the non-interactive alternative named, instead of hanging. Guard placed in `channels add` (not `createClackPrompter`, which has 14 other production consumers).
- **Plugin-declared env contract (additive SDK surface):** the setup contract's `useEnv` boolean field gains optional `envVars: readonly string[]` and `envVarMode: "all" | "any"` (`src/channels/plugins/setup-contract.ts`). Core validates presence generically at the shared account-config seam (`src/channels/plugins/account-config-mutation.ts`) and fails fast naming the exact missing variables. Channels without the declaration behave exactly as before, so third-party plugins are unaffected. Core stays plugin-agnostic — no channel names or env names in core.
- 13 in-tree contracts migrated (Telegram, Discord, Slack `SLACK_BOT_TOKEN`+`SLACK_APP_TOKEN`, Google Chat with `any`-of value/file, IRC, LINE, Mattermost, Nextcloud Talk, Synology Chat, Zalo, ClickClack, Buzz, Nostr). Buzz's duplicate local check is removed in the same change. Matrix keeps its account-scoped `MATRIX_*` validation — that contract is per-account and not expressible as a static list.
- **Nostr fix:** a shared `resolveNostrPrivateKey` resolver now honors `NOSTR_PRIVATE_KEY` in both setup and runtime, matching the Telegram/Discord ambient-fallback pattern.
- Docs: headless provisioning recipe (non-interactive onboard → `channels add --use-env` → gateway env requirements → config hot-reload behavior) on the channels CLI and Docker install pages.

## User Impact

- Scripted/cloud deployments fail fast with actionable errors instead of hanging or silently producing dead channels.
- `--use-env` semantics are otherwise unchanged (ambient runtime fallback; no SecretRef changes).
- Third-party channel plugins: no behavior change without opting into the new optional metadata.

## Evidence

- Focused Vitest: 258 tests across 7 shards, all passing.
- Plugin SDK surface gate (`pnpm plugin-sdk:surface:check`) and API gates: pass (28 generated surface baselines updated for the additive fields).
- Docs build: 770 MDX files pass, 6448 links, 0 broken.
- Built-CLI black-box checks: non-TTY wizard exits 1 with remediation; missing `TELEGRAM_BOT_TOKEN` / Slack token pair exit 1 naming the variables; present env succeeds and commits config exactly as before.
- Regression coverage: non-TTY guard, per-channel missing/present env, undeclared-contract passthrough (third-party compat), Nostr env fallback (fails on pre-fix code), Buzz coverage moved to the shared seam.
