### PR TITLE
fix(qa): prevent parent skip controls from disabling child channels

### DIFF
--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -636,6 +636,34 @@ describe("buildQaRuntimeEnv", () => {
     expect(developmentEnv.NODE_ENV).toBe("development");
   });
 
+  it("does not inherit parent channel or provider skip controls", () => {
+    const env = buildQaRuntimeEnv({
+      ...createParams({
+        OPENCLAW_SKIP_CHANNELS: "1",
+        OPENCLAW_SKIP_PROVIDERS: "1",
+      }),
+    });
+
+    expect(env.OPENCLAW_SKIP_CHANNELS).toBeUndefined();
+    expect(env.OPENCLAW_SKIP_PROVIDERS).toBeUndefined();
+  });
+
+  it("honors explicit channel and provider skip controls", () => {
+    const env = buildQaRuntimeEnv({
+      ...createParams({
+        OPENCLAW_SKIP_CHANNELS: "inherited",
+        OPENCLAW_SKIP_PROVIDERS: "inherited",
+      }),
+      runtimeEnvPatch: {
+        OPENCLAW_SKIP_CHANNELS: "patched-channels",
+        OPENCLAW_SKIP_PROVIDERS: "patched-providers",
+      },
+    });
+
+    expect(env.OPENCLAW_SKIP_CHANNELS).toBe("patched-channels");
+    expect(env.OPENCLAW_SKIP_PROVIDERS).toBe("patched-providers");
+  });
+
   it("maps live frontier key aliases into provider env vars", () => {
     const env = buildQaRuntimeEnv({
       ...createParams({

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -543,6 +543,9 @@ export function buildQaRuntimeEnv(params: {
       : {}),
   };
   const normalizedEnv = normalizeQaProviderModeEnv(env, params.providerMode);
+  // Test-runner skip flags are parent controls; each QA child declares its own runtime needs.
+  delete normalizedEnv.OPENCLAW_SKIP_CHANNELS;
+  delete normalizedEnv.OPENCLAW_SKIP_PROVIDERS;
   Object.assign(normalizedEnv, params.runtimeEnvPatch);
   normalizedEnv.OPENCLAW_BUILD_PRIVATE_QA = "1";
   delete normalizedEnv[QA_LIVE_ANTHROPIC_SETUP_TOKEN_ENV];


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QA scenarios that launch a Gateway child could inherit
`OPENCLAW_SKIP_CHANNELS` or `OPENCLAW_SKIP_PROVIDERS` from an earlier test in
the shared runner. This made release validation order-dependent and could leave
the QA channel disabled with no child-local request to disable it.

## Why This Change Was Made

The QA Gateway child now drops inherited channel/provider skip controls before
applying its explicit `runtimeEnvPatch`. Scenario-owned patch values remain
honored, while ambient test-runner state no longer changes child startup.

## User Impact

Release and QA validation can start the channels and providers requested by
each scenario regardless of preceding test order. There is no production
runtime or configuration change.

## Evidence

- Before: exact one-worker order failed on
  `vision-channel-offload.e2e.test.ts` after the approvals suites because
  `qa-channel` stayed stopped:
  https://github.com/openclaw/openclaw/actions/runs/31573478825
- After: the same ordered Testbox command passed all 3 files and 4 tests:
  https://github.com/openclaw/openclaw/actions/runs/31574391519
- Focused local regression: `gateway-child.test.ts` passed 113/113 tests.
- Formatting and `git diff --check` passed.
- Autoreview reported no accepted/actionable findings.

AI-assisted: yes.
