### PR TITLE
fix(browser): wake extension relay through gateway

### DIFF
--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -154,13 +154,22 @@ openclaw browser extension cdp --json
   challenge/complete binding. It never prints the relay key or an authorization
   header by default.
 
+Automatic local bootstrap connects through the local Gateway's exact
+`/browser/extension` route so the first authenticated extension connection
+starts the lazy browser-control service. Keep `openclaw gateway run` or the
+managed Gateway service running; no separate browser request or prewarm is
+needed. Local OpenClaw and mcporter calls still use the profile relay port
+reported by `extension pair` or `extension cdp` after that wakeup. Browser-node
+pairings continue to use the relay on the browser-node host, while explicit
+`--gateway-url` pairings remain direct-remote and manual-only.
+
 `extension cdp --legacy-bearer` is a temporary migration escape hatch. It
 prints the old Bearer header with a warning only while
 `browser.extensionRelay.allowLegacyAuth=true`; otherwise it exits with an error
 without printing a credential. Use `--json` for machine output; warnings remain
 on stderr so stdout stays valid JSON.
 
-Setup, security model, and migration steps: [Chrome extension](/tools/chrome-extension).
+Setup, security model, and recovery steps: [Chrome extension](/tools/chrome-extension).
 
 If the extension already attempted automatic setup before the native host
 existed, Chromium retains that miss for the running browser process. Restart

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -163,6 +163,10 @@ reported by `extension pair` or `extension cdp` after that wakeup. Browser-node
 pairings continue to use the relay on the browser-node host, while explicit
 `--gateway-url` pairings remain direct-remote and manual-only.
 
+The advanced manual `extension pair` command without `--gateway-url` retains
+the host-local `/extension` relay URL. It does not wake Browser control, so the
+selected profile relay must already be running before the extension connects.
+
 `extension cdp --legacy-bearer` is a temporary migration escape hatch. It
 prints the old Bearer header with a warning only while
 `browser.extensionRelay.allowLegacyAuth=true`; otherwise it exits with an error

--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -101,6 +101,18 @@ openclaw config set browser.defaultProfile chrome
 Fresh automatic pairings use **All tabs**. Existing valid pairings are never
 overwritten, and older pairings keep their stored access mode.
 
+For local setup, native bootstrap connects the extension through the local
+Gateway's exact `/browser/extension` route. That first authenticated connection
+wakes the lazy browser-control service and starts the profile's loopback relay;
+OpenClaw and local clients such as mcporter then use that profile relay port.
+Keep `openclaw gateway run` or the managed Gateway service running. A separate
+browser request or prewarm step is not required.
+
+Browser-node setup remains different: the extension connects to the relay on
+the browser-node host while the node uses its configured remote Gateway. An
+explicit `--gateway-url` pairing connects directly to that remote Gateway and
+remains a manual-only flow.
+
 ### Choose tab access
 
 - **All tabs** exposes every eligible ordinary tab in that Chrome profile,
@@ -129,6 +141,11 @@ local setup** switch.
   detaches debugger sessions, and persists the opt-out.
 - **Use local OpenClaw** clears the opt-out and retries the native host.
 - Saving an explicit manual pairing also clears the opt-out.
+
+Pre-release development installs that paired before local Gateway wakeup
+routing keep their existing pairing unchanged. In Settings, use **Disconnect
+and disable automatic setup**, then **Use local OpenClaw** to create the new
+local pairing. Released builds do not require this recovery step.
 
 ### Upgrades from the retired tab copilot
 
@@ -270,8 +287,10 @@ openclaw doctor
   OpenClaw**.
 - **Manual setup required:** use Settings for the advanced pairing flow. This
   is expected on Windows and direct extension-only remote Gateway setups.
-- **Relay unavailable:** confirm the Gateway or browser node is running, then
-  run browser doctor.
+- **Relay unavailable:** confirm `openclaw gateway run` or the managed Gateway
+  service is running for local setup, or confirm the browser node is running
+  for browser-node setup. Then run browser doctor. No separate browser prewarm
+  should be necessary.
 
 See [Browser](/tools/browser) for the full profile model and the managed
 `openclaw` and Chrome MCP `user` profiles.

--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -195,6 +195,10 @@ openclaw browser extension pair
 Manual pairing remains useful on Windows and for recovery. Treat the complete
 pairing string as a password.
 
+Without `--gateway-url`, this command retains the host-local `/extension` relay
+for standalone manual pairing. It does not wake Browser control; the selected
+profile relay must already be running before the extension connects.
+
 For a laptop that has Chrome but does not run OpenClaw or a browser node, pair
 directly to a remote Gateway:
 

--- a/extensions/browser/chrome-extension/bootstrap.chromium.test.ts
+++ b/extensions/browser/chrome-extension/bootstrap.chromium.test.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
+import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -12,8 +13,9 @@ import {
   stableChromeExtensionDir,
 } from "../src/browser/extension-install-layout.js";
 import { installChromeExtensionBootstrap } from "../src/browser/extension-install.js";
-import { startExtensionRelayServer } from "../src/browser/extension-relay/relay-server.js";
+import { handleGatewayExtensionUpgrade } from "../src/browser/extension-relay/gateway-relay-route.js";
 import { getFreePort } from "../src/browser/test-port.js";
+import { getBrowserControlState, stopBrowserControlService } from "../src/control-service.js";
 import { relayTestKey } from "./relay-key.test-support.js";
 
 declare const chrome: {
@@ -146,7 +148,11 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
     const homeDir = path.join(root, "home");
     const stateDir = path.join(root, "custom-state");
     const configPath = path.join(root, "custom-config", "openclaw.json");
-    const relayPort = await getFreePort();
+    const gatewayPort = await getFreePort();
+    let relayPort = await getFreePort();
+    while (relayPort === gatewayPort) {
+      relayPort = await getFreePort();
+    }
     const linuxConfigHome = path.join(homeDir, ".config");
     const chromeRootEnv =
       process.platform === "linux"
@@ -166,11 +172,15 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
     );
     await fs.writeFile(
       configPath,
-      `${JSON.stringify({ browser: { profiles: { e2e: { driver: "extension", cdpPort: relayPort } } } })}\n`,
+      `${JSON.stringify({ gateway: { port: gatewayPort }, browser: { profiles: { e2e: { driver: "extension", cdpPort: relayPort } } } })}\n`,
       { mode: 0o600 },
     );
     await withEnvAsync(
-      { OPENCLAW_STATE_DIR: stateDir, OPENCLAW_CONFIG_PATH: configPath },
+      {
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_GATEWAY_PORT: String(gatewayPort),
+      },
       async () => {
         const extensionSource = path.dirname(fileURLToPath(import.meta.url));
         const nativeHostPath = await fs.realpath(
@@ -187,12 +197,28 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
             ...chromeRootEnv,
             OPENCLAW_STATE_DIR: stateDir,
             OPENCLAW_CONFIG_PATH: configPath,
+            OPENCLAW_GATEWAY_PORT: String(gatewayPort),
           },
           nodePath: tsxPath,
           nativeHostPath,
         };
-        const relay = await startExtensionRelayServer({ port: relayPort, token });
-        cleanups.push(relay.close);
+        const gatewayServer = http.createServer((_req, res) => {
+          res.writeHead(426);
+          res.end();
+        });
+        gatewayServer.on("upgrade", (req, socket, head) => {
+          void handleGatewayExtensionUpgrade(req, socket, head);
+        });
+        await new Promise<void>((resolve) => {
+          gatewayServer.listen(gatewayPort, "127.0.0.1", resolve);
+        });
+        cleanups.push(
+          async () =>
+            await new Promise<void>((resolve) => {
+              gatewayServer.close(() => resolve());
+            }),
+        );
+        cleanups.push(stopBrowserControlService);
         const browserEnv: NodeJS.ProcessEnv = {
           ...process.env,
           HOME: homeDir,
@@ -291,7 +317,13 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
         }
         expect(extensionStatus).toMatchObject({ paired: true, accessMode: "all" });
         try {
-          await expect.poll(() => relay.bridge.extensionConnected, { timeout: 15_000 }).toBe(true);
+          await expect
+            .poll(
+              () =>
+                getBrowserControlState()?.extensionRelays?.get("e2e")?.bridge.extensionConnected,
+              { timeout: 15_000 },
+            )
+            .toBe(true);
         } catch (error) {
           extensionStatus = await extensionPage.evaluate(
             async () => await chrome.runtime.sendMessage({ type: "getStatus" }),
@@ -299,6 +331,10 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
           throw new Error(`Extension relay did not connect: ${JSON.stringify(extensionStatus)}`, {
             cause: error,
           });
+        }
+        const relay = getBrowserControlState()?.extensionRelays?.get("e2e");
+        if (!relay || relay.port !== relayPort) {
+          throw new Error("Gateway wakeup did not start the configured extension relay");
         }
 
         const registration = status.registrations.find(
@@ -349,7 +385,9 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
         }
         if (
           relayUrl.hostname !== "127.0.0.1" ||
-          relayUrl.port !== String(relayPort) ||
+          relayUrl.port !== String(gatewayPort) ||
+          relayUrl.pathname !== "/browser/extension" ||
+          relayUrl.searchParams.get("gateway") !== `ws://127.0.0.1:${gatewayPort}` ||
           nativeResponse.pairingString.slice(fragmentAt + 1) !== token
         ) {
           throw new Error("native host did not use the custom installation context");

--- a/extensions/browser/chrome-extension/modules/relay-core.js
+++ b/extensions/browser/chrome-extension/modules/relay-core.js
@@ -155,8 +155,8 @@ function validatePairingFields(relayUrl, token, gatewayUrl) {
 
 /**
  * Parse a pairing string printed by `openclaw browser extension pair`.
- * Local and direct-remote pairings use the Gateway route; browser nodes and
- * legacy local pairings use the host relay route.
+ * Native local and direct-remote pairings use the Gateway route; local manual,
+ * browser-node, and legacy local pairings use the host relay route.
  * The additive gateway hint is not a credential; old extensions safely pass
  * it through to the relay while new extensions remove it before connecting.
  */

--- a/extensions/browser/chrome-extension/modules/relay-core.js
+++ b/extensions/browser/chrome-extension/modules/relay-core.js
@@ -155,7 +155,8 @@ function validatePairingFields(relayUrl, token, gatewayUrl) {
 
 /**
  * Parse a pairing string printed by `openclaw browser extension pair`.
- * Shape: ws://127.0.0.1:<port>/extension?gateway=<url>#<token>
+ * Local and direct-remote pairings use the Gateway route; browser nodes and
+ * legacy local pairings use the host relay route.
  * The additive gateway hint is not a credential; old extensions safely pass
  * it through to the relay while new extensions remove it before connecting.
  */

--- a/extensions/browser/chrome-extension/modules/relay-core.test.ts
+++ b/extensions/browser/chrome-extension/modules/relay-core.test.ts
@@ -131,11 +131,11 @@ describe("persisted pairing storage", () => {
       },
     },
     {
-      label: "a loopback relay with an independent Gateway hint",
+      label: "an SSH-tunneled browser-node pairing with a loopback Gateway hint",
       stored: {
         relayUrl: "ws://127.0.0.1:18797/extension",
         token: RELAY_SECRET,
-        gatewayUrl: "wss://gateway.example.com/base",
+        gatewayUrl: "ws://127.0.0.1:19089",
       },
     },
     {

--- a/extensions/browser/native-host-entry.ts
+++ b/extensions/browser/native-host-entry.ts
@@ -26,7 +26,11 @@ async function main(): Promise<void> {
     write: (frame) => {
       responseFrame = frame;
     },
-    buildPairing: async () => await buildBrowserExtensionPairing({ cfg: getRuntimeConfig() }),
+    buildPairing: async () =>
+      await buildBrowserExtensionPairing({
+        cfg: getRuntimeConfig(),
+        localTransport: "gateway",
+      }),
   });
   const response = responseFrame;
   if (!response) {

--- a/extensions/browser/src/browser/extension-install.test.ts
+++ b/extensions/browser/src/browser/extension-install.test.ts
@@ -489,7 +489,7 @@ describe("native host registration", () => {
         v: 1,
         ok: true,
         nonce,
-        pairingString: `ws://127.0.0.1:${relayPort}/extension?gateway=ws%3A%2F%2F127.0.0.1%3A18789#${token}`,
+        pairingString: `ws://127.0.0.1:18789/browser/extension?gateway=ws%3A%2F%2F127.0.0.1%3A18789#${token}`,
       });
     },
   );

--- a/extensions/browser/src/browser/extension-pairing.test.ts
+++ b/extensions/browser/src/browser/extension-pairing.test.ts
@@ -7,7 +7,7 @@ const RELAY_KEY = relayTestKey(5);
 const ensureToken = async () => RELAY_KEY;
 
 describe("buildBrowserExtensionPairing", () => {
-  it("routes local bootstrap through the Gateway while retaining relay metadata", async () => {
+  it("preserves the standalone host relay for local manual pairing compatibility", async () => {
     await withEnvAsync({ OPENCLAW_GATEWAY_PORT: undefined }, async () => {
       await expect(
         buildBrowserExtensionPairing({
@@ -17,6 +17,27 @@ describe("buildBrowserExtensionPairing", () => {
               profiles: { chrome: { driver: "extension", cdpPort: 19_199 } },
             },
           },
+          ensureToken,
+        }),
+      ).resolves.toEqual({
+        pairingString: `ws://127.0.0.1:19199/extension?gateway=ws%3A%2F%2F127.0.0.1%3A19089#${RELAY_KEY}`,
+        relayPort: 19_199,
+        topology: "local",
+      });
+    });
+  });
+
+  it("routes local native bootstrap through the Gateway while retaining relay metadata", async () => {
+    await withEnvAsync({ OPENCLAW_GATEWAY_PORT: undefined }, async () => {
+      await expect(
+        buildBrowserExtensionPairing({
+          cfg: {
+            gateway: { port: 19_089 },
+            browser: {
+              profiles: { chrome: { driver: "extension", cdpPort: 19_199 } },
+            },
+          },
+          localTransport: "gateway",
           ensureToken,
         }),
       ).resolves.toEqual({

--- a/extensions/browser/src/browser/extension-pairing.test.ts
+++ b/extensions/browser/src/browser/extension-pairing.test.ts
@@ -1,0 +1,88 @@
+import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it } from "vitest";
+import { relayTestKey } from "../../chrome-extension/relay-key.test-support.js";
+import { buildBrowserExtensionPairing } from "./extension-pairing.js";
+
+const RELAY_KEY = relayTestKey(5);
+const ensureToken = async () => RELAY_KEY;
+
+describe("buildBrowserExtensionPairing", () => {
+  it("routes local bootstrap through the Gateway while retaining relay metadata", async () => {
+    await withEnvAsync({ OPENCLAW_GATEWAY_PORT: undefined }, async () => {
+      await expect(
+        buildBrowserExtensionPairing({
+          cfg: {
+            gateway: { port: 19_089 },
+            browser: {
+              profiles: { chrome: { driver: "extension", cdpPort: 19_199 } },
+            },
+          },
+          ensureToken,
+        }),
+      ).resolves.toEqual({
+        pairingString: `ws://127.0.0.1:19089/browser/extension?gateway=ws%3A%2F%2F127.0.0.1%3A19089#${RELAY_KEY}`,
+        relayPort: 19_199,
+        topology: "local",
+      });
+    });
+  });
+
+  it.each([
+    {
+      label: "remote TLS Gateway",
+      gatewayUrl: "wss://gateway.example.com:9444",
+      encodedGateway: "wss%3A%2F%2Fgateway.example.com%3A9444",
+    },
+    {
+      label: "loopback SSH tunnel to a remote Gateway",
+      gatewayUrl: "ws://127.0.0.1:29089",
+      encodedGateway: "ws%3A%2F%2F127.0.0.1%3A29089",
+    },
+  ])("keeps browser-node bootstrap on the host-local relay for $label", async (testCase) => {
+    await expect(
+      buildBrowserExtensionPairing({
+        cfg: {
+          gateway: {
+            mode: "remote",
+            remote: { url: testCase.gatewayUrl },
+          },
+          browser: {
+            profiles: { chrome: { driver: "extension", cdpPort: 19_198 } },
+          },
+        },
+        ensureToken,
+      }),
+    ).resolves.toEqual({
+      pairingString: `ws://127.0.0.1:19198/extension?gateway=${testCase.encodedGateway}#${RELAY_KEY}`,
+      relayPort: 19_198,
+      topology: "browser-node",
+    });
+  });
+
+  it("keeps an explicit remote Gateway direct and manual-only", async () => {
+    await expect(
+      buildBrowserExtensionPairing({
+        cfg: {
+          browser: {
+            profiles: { chrome: { driver: "extension", cdpPort: 19_197 } },
+          },
+        },
+        gatewayUrl: "wss://gateway.example.com:9443",
+        ensureToken,
+      }),
+    ).resolves.toEqual({
+      pairingString: `wss://gateway.example.com:9443/browser/extension?gateway=wss%3A%2F%2Fgateway.example.com%3A9443#${RELAY_KEY}`,
+      relayPort: 19_197,
+      topology: "direct-remote",
+    });
+  });
+
+  it("requires an explicit certificate hostname for local Gateway TLS", async () => {
+    await expect(
+      buildBrowserExtensionPairing({
+        cfg: { gateway: { tls: { enabled: true } } },
+        ensureToken,
+      }),
+    ).rejects.toThrow("--gateway-url wss://<certificate-host>");
+  });
+});

--- a/extensions/browser/src/browser/extension-pairing.ts
+++ b/extensions/browser/src/browser/extension-pairing.ts
@@ -3,7 +3,7 @@ import { type BrowserConfig, type OpenClawConfig, resolveGatewayPort } from "../
 import { resolveBrowserConfig } from "./config.js";
 import { ensureExtensionRelayToken } from "./extension-relay/relay-auth.js";
 
-/** Gateway route for direct extension-only remote pairing. */
+/** Gateway route for extension pairing that must wake Browser control. */
 const GATEWAY_EXTENSION_RELAY_PATH = "/browser/extension";
 
 type BrowserExtensionPairing = {
@@ -26,8 +26,8 @@ function firstExtensionRelayPort(cfg: PairingConfig): number {
   return resolved.extensionRelayDefaultPort;
 }
 
-/** Resolve a safe direct-Gateway relay URL with the v2-bound route path. */
-function buildDirectGatewayRelayUrl(raw: string): string {
+/** Resolve a safe Gateway relay URL with the v2-bound route path. */
+function buildGatewayExtensionRelayUrl(raw: string): string {
   let url: URL;
   try {
     url = new URL(raw.trim());
@@ -65,7 +65,7 @@ export async function buildBrowserExtensionPairing(params: {
   const token = await (params.ensureToken ?? ensureExtensionRelayToken)();
   const gateway = params.gatewayUrl?.trim();
   if (gateway) {
-    const relayUrl = new URL(buildDirectGatewayRelayUrl(gateway));
+    const relayUrl = new URL(buildGatewayExtensionRelayUrl(gateway));
     relayUrl.searchParams.set("gateway", gateway);
     return {
       pairingString: `${relayUrl.toString()}#${token}`,
@@ -80,7 +80,11 @@ export async function buildBrowserExtensionPairing(params: {
     throw new Error("Gateway TLS pairing requires --gateway-url wss://<certificate-host>[:port]");
   }
   const gatewayHint = configuredRemote || `ws://127.0.0.1:${resolveGatewayPort(params.cfg)}`;
-  const relayUrl = new URL(`ws://127.0.0.1:${relayPort}/extension`);
+  // The local Gateway route owns lazy Browser startup. Browser nodes already
+  // own their relay runtime, so they keep connecting to the host-local port.
+  const relayUrl = configuredRemote
+    ? new URL(`ws://127.0.0.1:${relayPort}/extension`)
+    : new URL(buildGatewayExtensionRelayUrl(gatewayHint));
   relayUrl.searchParams.set("gateway", gatewayHint);
   return {
     pairingString: `${relayUrl.toString()}#${token}`,

--- a/extensions/browser/src/browser/extension-pairing.ts
+++ b/extensions/browser/src/browser/extension-pairing.ts
@@ -59,6 +59,7 @@ function buildGatewayExtensionRelayUrl(raw: string): string {
 export async function buildBrowserExtensionPairing(params: {
   cfg: PairingConfig;
   gatewayUrl?: string;
+  localTransport?: "relay" | "gateway";
   ensureToken?: typeof ensureExtensionRelayToken;
 }): Promise<BrowserExtensionPairing> {
   const relayPort = firstExtensionRelayPort(params.cfg);
@@ -80,11 +81,12 @@ export async function buildBrowserExtensionPairing(params: {
     throw new Error("Gateway TLS pairing requires --gateway-url wss://<certificate-host>[:port]");
   }
   const gatewayHint = configuredRemote || `ws://127.0.0.1:${resolveGatewayPort(params.cfg)}`;
-  // The local Gateway route owns lazy Browser startup. Browser nodes already
-  // own their relay runtime, so they keep connecting to the host-local port.
-  const relayUrl = configuredRemote
-    ? new URL(`ws://127.0.0.1:${relayPort}/extension`)
-    : new URL(buildGatewayExtensionRelayUrl(gatewayHint));
+  // Native local bootstrap needs the Gateway to wake Browser control. Manual
+  // local pairing and browser nodes target an already-running host relay.
+  const relayUrl =
+    !configuredRemote && params.localTransport === "gateway"
+      ? new URL(buildGatewayExtensionRelayUrl(gatewayHint))
+      : new URL(`ws://127.0.0.1:${relayPort}/extension`);
   relayUrl.searchParams.set("gateway", gatewayHint);
   return {
     pairingString: `${relayUrl.toString()}#${token}`,

--- a/extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts
+++ b/extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts
@@ -96,6 +96,7 @@ describe.sequential("local Gateway extension relay wakeup", () => {
 
             const pairing = await buildBrowserExtensionPairing({
               cfg: config,
+              localTransport: "gateway",
               ensureToken: async () => RELAY_KEY,
             });
             expect(pairing).toMatchObject({ relayPort, topology: "local" });

--- a/extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts
+++ b/extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts
@@ -1,0 +1,179 @@
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import http, { type Server } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
+import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocket, type RawData } from "ws";
+import { parsePairingString } from "../../../chrome-extension/modules/relay-core.js";
+import { relayTestKey } from "../../../chrome-extension/relay-key.test-support.js";
+import { getBrowserControlState, stopBrowserControlService } from "../../control-service.js";
+import { buildBrowserExtensionPairing } from "../extension-pairing.js";
+import { getFreePort } from "../test-port.js";
+import { createRelayProof, randomRelayNonce, relayKeyIdFromHex } from "./auth-v2-crypto.js";
+import { BROWSER_RELAY_EXTENSION_SUBPROTOCOL } from "./auth-v2.js";
+import { handleGatewayExtensionUpgrade } from "./gateway-relay-route.js";
+
+const RELAY_KEY = relayTestKey(8);
+
+function rawDataText(data: RawData): string {
+  if (Array.isArray(data)) {
+    return Buffer.concat(data).toString("utf8");
+  }
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(data).toString("utf8");
+  }
+  return Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString("utf8");
+}
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+afterEach(async () => {
+  await stopBrowserControlService();
+  clearRuntimeConfigSnapshot();
+});
+
+describe.sequential("local Gateway extension relay wakeup", () => {
+  it("starts Browser control and the CDP relay from the first authenticated extension request", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-relay-wakeup-"));
+    try {
+      const gatewayPort = await getFreePort();
+      let relayPort = await getFreePort();
+      while (relayPort === gatewayPort) {
+        relayPort = await getFreePort();
+      }
+      await fs.mkdir(path.join(stateDir, "credentials"), { recursive: true });
+      await fs.writeFile(
+        path.join(stateDir, "credentials", "browser-extension-relay.secret"),
+        `${RELAY_KEY}\n`,
+        { mode: 0o600 },
+      );
+
+      const config = {
+        gateway: {
+          port: gatewayPort,
+          auth: { mode: "token" as const, token: "gateway-integration-test" },
+        },
+        browser: {
+          enabled: true,
+          extensionRelay: { allowLegacyAuth: false },
+          profiles: { chrome: { driver: "extension" as const, cdpPort: relayPort } },
+        },
+      };
+      setRuntimeConfigSnapshot(config, config);
+
+      await withEnvAsync(
+        {
+          OPENCLAW_STATE_DIR: stateDir,
+          OPENCLAW_GATEWAY_PORT: String(gatewayPort),
+        },
+        async () => {
+          const gatewayServer = http.createServer((_req, res) => {
+            res.writeHead(426);
+            res.end();
+          });
+          gatewayServer.on("upgrade", (req, socket, head) => {
+            void handleGatewayExtensionUpgrade(req, socket, head);
+          });
+          let extension: WebSocket | undefined;
+          try {
+            await new Promise<void>((resolve) => {
+              gatewayServer.listen(gatewayPort, "127.0.0.1", resolve);
+            });
+            expect(getBrowserControlState()).toBeNull();
+
+            const pairing = await buildBrowserExtensionPairing({
+              cfg: config,
+              ensureToken: async () => RELAY_KEY,
+            });
+            expect(pairing).toMatchObject({ relayPort, topology: "local" });
+            const parsed = parsePairingString(pairing.pairingString);
+            if (!parsed) {
+              throw new Error("local pairing did not parse");
+            }
+
+            extension = new WebSocket(parsed.relayUrl, BROWSER_RELAY_EXTENSION_SUBPROTOCOL, {
+              origin: "chrome-extension://gateway-wakeup-integration",
+            });
+            await once(extension, "open");
+            const clientNonce = randomRelayNonce();
+            const challengeMessage = once(extension, "message");
+            extension.send(
+              JSON.stringify({
+                type: "auth.hello",
+                v: 2,
+                keyId: relayKeyIdFromHex(RELAY_KEY),
+                clientNonce,
+              }),
+            );
+            const [challengeData] = (await challengeMessage) as [RawData];
+            const challenge = JSON.parse(rawDataText(challengeData));
+            const okMessage = once(extension, "message");
+            extension.send(
+              JSON.stringify({
+                type: "auth.response",
+                v: 2,
+                sessionId: challenge.sessionId,
+                clientProof: createRelayProof(RELAY_KEY, "client", challenge),
+              }),
+            );
+            const [okData] = (await okMessage) as [RawData];
+            expect(JSON.parse(rawDataText(okData))).toMatchObject({ type: "auth.ok", v: 2 });
+            extension.send(
+              JSON.stringify({
+                type: "hello",
+                userAgent: "gateway-wakeup-test",
+                browserVersion: "Chrome/test",
+                extensionVersion: "2",
+                tabs: [],
+              }),
+            );
+
+            await expect
+              .poll(
+                () =>
+                  getBrowserControlState()?.extensionRelays?.get("chrome")?.bridge
+                    .extensionConnected,
+              )
+              .toBe(true);
+            const relay = getBrowserControlState()?.extensionRelays?.get("chrome");
+            expect(relay?.port).toBe(pairing.relayPort);
+            if (!relay) {
+              throw new Error("extension relay did not start");
+            }
+
+            const authorization = Buffer.from(`openclaw-internal:${relay.internalToken}`).toString(
+              "base64",
+            );
+            const response = await fetch(`http://127.0.0.1:${pairing.relayPort}/json/version`, {
+              headers: { Authorization: `Basic ${authorization}` },
+            });
+            expect(response.status).toBe(200);
+            await expect(response.json()).resolves.toMatchObject({
+              Browser: "Chrome/test",
+              webSocketDebuggerUrl: `ws://127.0.0.1:${pairing.relayPort}/cdp`,
+            });
+          } finally {
+            extension?.terminate();
+            await stopBrowserControlService();
+            await closeServer(gatewayServer);
+          }
+        },
+      );
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/extensions/browser/src/cli/browser-cli-extension.test.ts
+++ b/extensions/browser/src/cli/browser-cli-extension.test.ts
@@ -141,7 +141,7 @@ describe("browser extension pairing Gateway URL", () => {
     await program.parseAsync(["browser", "extension", "pair", "--json"], { from: "user" });
 
     expect(writeJsonSpy).toHaveBeenCalledWith({
-      pairingString: expect.stringContaining("127.0.0.1:18789/browser/extension"),
+      pairingString: expect.stringContaining("127.0.0.1:18798/extension"),
       relayPort: 18798,
       remote: false,
     });

--- a/extensions/browser/src/cli/browser-cli-extension.test.ts
+++ b/extensions/browser/src/cli/browser-cli-extension.test.ts
@@ -2,7 +2,6 @@ import { Command } from "commander";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createCliRuntimeCapture } from "../../test-support.js";
 import type { installChromeExtensionBootstrap } from "../browser/extension-install.js";
-import { buildBrowserExtensionPairing } from "../browser/extension-pairing.js";
 import { relayKeyIdFromHex } from "../browser/extension-relay/auth-v2-crypto.js";
 import * as cliCoreApiModule from "./core-api.js";
 
@@ -81,33 +80,6 @@ describe("browser extension pairing Gateway URL", () => {
     expect(output.at(-1)).toContain("deterministic extension identity verified");
   });
 
-  it("uses loopback only for a plaintext local Gateway", async () => {
-    await expect(
-      buildBrowserExtensionPairing({ cfg: {}, ensureToken: async () => relayMocks.relayKey }),
-    ).resolves.toMatchObject({
-      pairingString: expect.stringContaining("gateway=ws%3A%2F%2F127.0.0.1%3A18789"),
-      topology: "local",
-    });
-  });
-
-  it("requires the certificate hostname for a TLS Gateway", async () => {
-    await expect(
-      buildBrowserExtensionPairing({
-        cfg: { gateway: { tls: { enabled: true } } },
-        ensureToken: async () => relayMocks.relayKey,
-      }),
-    ).rejects.toThrow("--gateway-url wss://<certificate-host>");
-    await expect(
-      buildBrowserExtensionPairing({
-        cfg: { gateway: { mode: "remote", remote: { url: "wss://gateway.example" } } },
-        ensureToken: async () => relayMocks.relayKey,
-      }),
-    ).resolves.toMatchObject({
-      pairingString: expect.stringContaining("gateway=wss%3A%2F%2Fgateway.example"),
-      topology: "browser-node",
-    });
-  });
-
   it("rejects path-rewriting proxy prefixes for strict v2 resource binding", async () => {
     vi.spyOn(cliCoreApiModule, "getRuntimeConfig").mockReturnValue({});
     const errorSpy = vi
@@ -169,7 +141,7 @@ describe("browser extension pairing Gateway URL", () => {
     await program.parseAsync(["browser", "extension", "pair", "--json"], { from: "user" });
 
     expect(writeJsonSpy).toHaveBeenCalledWith({
-      pairingString: expect.stringContaining("127.0.0.1:18798/extension"),
+      pairingString: expect.stringContaining("127.0.0.1:18789/browser/extension"),
       relayPort: 18798,
       remote: false,
     });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a newly paired local Chrome extension could connect before Browser control had started, leaving the extension waiting on the profile relay until some separate browser request happened to wake it.

## Why This Change Was Made

Fresh local native pairings now use the local Gateway's authenticated `/browser/extension` route, which owns lazy Browser-control startup and then bridges into the configured profile relay. Browser-node pairings—including loopback SSH tunnels to a remote Gateway—stay on the browser host's local `/extension` relay, and explicit direct-remote pairings remain manual-only.

The pairing builder now requires an explicit local transport intent at the native boundary: native bootstrap selects Gateway wakeup, while the default/manual `openclaw browser extension pair` flow retains its byte-compatible host-local `/extension` URL. Existing stored pairings remain authoritative and are neither migrated nor overwritten. No eager runtime, authentication, origin, custody, access-mode, or fallback behavior changes.

## User Impact

After normal local installation, the extension's first authenticated connection starts Browser control automatically. Operators no longer need a separate browser request or prewarm before OpenClaw or another local relay client can use the extension profile.

Advanced local manual pairing continues to work against an already-running standalone profile relay without requiring a Gateway. Pre-release development installs with an older local pairing can use **Disconnect and disable automatic setup**, then **Use local OpenClaw** once. Released installs do not need that recovery step.

## Evidence

- Focused tests: `node scripts/run-vitest.mjs extensions/browser/chrome-extension/bootstrap.chromium.test.ts extensions/browser/chrome-extension/modules/relay-core.test.ts extensions/browser/chrome-extension/modules/native-bootstrap.test.ts extensions/browser/chrome-extension/background.test.ts extensions/browser/chrome-extension/background.access-mode.test.ts extensions/browser/chrome-extension/package.contract.test.ts extensions/browser/src/browser/extension-install.test.ts extensions/browser/src/browser/extension-native-host.test.ts extensions/browser/src/browser/extension-pairing.test.ts extensions/browser/src/browser/extension-relay/gateway-relay-route.test.ts extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts extensions/browser/src/cli/browser-cli-extension.test.ts` — 210 passed, 1 environment-gated Chromium test skipped.
- Cold Chromium E2E: `OPENCLAW_BROWSER_EXTENSION_E2E=1 node scripts/run-vitest.mjs extensions/browser/chrome-extension/bootstrap.chromium.test.ts` — passed; native registration, automatic pairing, Gateway wakeup, configured relay startup, and launcher probe succeeded.
- `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` passed; full `pnpm build` passed; `pnpm plugin-sdk:surface:check` verified 152 public subpaths.
- `pnpm check:docs` passed formatting, Markdown lint, MDX, glossary, 6,556 internal links, and config-example validation.
- Live signed-in proof on isolated ports: Settings reached Connected / Automatic bootstrap ready / All tabs; the first extension connection opened the configured relay, and a policy-required local client listed a public tab and evaluated Example Domain through the persistent daemon.
- Fresh max-P1 Codex autoreview and TruffleHog scan are clean; `git diff --check` is clean.
