### PR TITLE
improve(ai): experiment with cached Responses WebSocket prewarm

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -1314,22 +1314,32 @@ not declared Codex-compatible.
 
 <AccordionGroup>
   <Accordion title="Transport (WebSocket vs SSE)">
-    OpenClaw uses WebSocket-first with SSE fallback (`"auto"`) for `openai/*`.
+    Direct OpenAI API-key requests use SSE by default. You can explicitly select
+    a WebSocket transport for the official OpenAI Responses endpoint.
 
-    In `"auto"` mode, OpenClaw:
-    - Retries one early WebSocket failure before falling back to SSE
+    With a session id, `"auto"` and `"websocket-cached"` reuse one cached
+    connection. OpenClaw starts that connection and sends a non-generating
+    prewarm request while the first real request is prepared; the real request
+    then continues from the prewarm response. This behavior applies only to
+    those explicit session-cached modes on the official endpoint.
+
+    For WebSocket requests, OpenClaw keeps the existing failure policy:
+
+    - Falls back to SSE when WebSocket setup fails before request dispatch
     - After a failure, marks WebSocket as degraded for 60 seconds and uses SSE
       during cool-down
+    - Does not replay over SSE after dispatch when the request outcome is unknown
     - Attaches stable session and turn identity headers for retries and
       reconnects
     - Normalizes usage counters (`input_tokens` / `prompt_tokens`) across
       transport variants
 
-    | Value                | Behavior                          |
-    | ---------------------- | ------------------------------------ |
-    | `"auto"` (default)   | WebSocket first, SSE fallback     |
-    | `"sse"`              | Force SSE only                    |
-    | `"websocket"`        | Force WebSocket only              |
+    | Value                  | Behavior                                                        |
+    | ---------------------- | --------------------------------------------------------------- |
+    | `"sse"` (default)     | SSE only                                                        |
+    | `"auto"`              | Session-cached WebSocket with prewarm, then pre-dispatch fallback to SSE |
+    | `"websocket-cached"`  | Session-cached WebSocket with prewarm and pre-dispatch SSE fallback |
+    | `"websocket"`         | Transient WebSocket with pre-dispatch SSE fallback; no prewarm  |
 
     ```json5
     {

--- a/packages/ai/src/internal/openai.ts
+++ b/packages/ai/src/internal/openai.ts
@@ -16,5 +16,7 @@ export * from "../providers/openai-tool-schema-compat.js";
 export * from "../providers/openai-tool-schema.js";
 export * from "../providers/schema-keyword-strip.js";
 export * from "../providers/tool-schema-json-projection.js";
+export { responsesPrewarmOperation } from "../transports/openai-responses-contracts.js";
 export { responsesPromptObserver } from "../transports/openai-responses-contracts.js";
+export { supportsNativeOpenAIResponsesWebSocket } from "../transports/openai-responses-websocket.js";
 export type { ResponsesPromptObservation } from "../transports/openai-responses-contracts.js";

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -23,6 +23,7 @@ import {
 import {
   AZURE_RESPONSES_FIRST_EVENT_TIMEOUT_MS,
   OpenAIResponsesWebSocketPreDispatchError,
+  responsesPrewarmOperation,
   type OpenAIResponsesOptions,
 } from "./openai-responses-contracts.js";
 import {
@@ -45,9 +46,11 @@ import {
 import { processResponsesStream } from "./openai-responses-stream-internal.js";
 import { observeResponsesStream } from "./openai-responses-stream-observer-internal.js";
 import {
+  beginOpenAIResponsesWebSocketPrewarm,
   createOpenAIResponsesWebSocketStream,
   type OpenAIResponsesWebSocketMode,
   supportsNativeOpenAIResponsesWebSocket,
+  waitForOpenAIResponsesWebSocketPrewarm,
 } from "./openai-responses-websocket.js";
 import {
   assertCodeModeResponsesToolSurface,
@@ -180,6 +183,7 @@ type ResponsesTransportExecutorOptions = {
 function createResponsesTransportExecutor(config: ResponsesTransportExecutorOptions): StreamFn {
   return (model, context, options) => {
     const responsesOptions = options as OpenAIResponsesOptions | undefined;
+    const isPrewarmOperation = Reflect.get(options ?? {}, responsesPrewarmOperation) === true;
     const eventStream = createAssistantMessageEventStream();
     const stream = eventStream as unknown as { push(event: unknown): void; end(): void };
     void (async () => {
@@ -201,6 +205,7 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
         timestamp: Date.now(),
       };
       let firstEventAbort: ReturnType<typeof createFirstStreamEventAbortController> | undefined;
+      let websocketPrewarm: ReturnType<typeof beginOpenAIResponsesWebSocketPrewarm>;
       try {
         const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
         const websocketMode = resolveNativeOpenAIResponsesWebSocketMode(
@@ -231,6 +236,18 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
           turnState?.headers,
           options?.sessionId,
         );
+        if (isPrewarmOperation && websocketMode) {
+          websocketPrewarm = beginOpenAIResponsesWebSocketPrewarm({
+            client,
+            mode: websocketMode,
+            sessionId: options?.sessionId,
+            headers: websocketHeaders,
+          });
+        }
+        if (isPrewarmOperation && !websocketPrewarm) {
+          eventStream.end(output);
+          return;
+        }
         const buildRequest = async (replayMode: OpenAIResponsesReplayMode) => {
           let params = config.buildRequest(
             model,
@@ -289,6 +306,11 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
           model,
           requestOptions?.timeout,
         );
+        if (isPrewarmOperation) {
+          await websocketPrewarm?.(params, websocketSignal);
+          eventStream.end(output);
+          return;
+        }
         emitModelTransportDebug(
           log,
           `[responses] start provider=${model.provider} api=${model.api} model=${model.id} ` +
@@ -336,6 +358,12 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
               `model=${model.id} reason=${reason}`,
           );
         if (websocketMode) {
+          await waitForOpenAIResponsesWebSocketPrewarm({
+            client,
+            mode: websocketMode,
+            sessionId: options?.sessionId,
+            headers: websocketHeaders,
+          });
           try {
             const websocket = createOpenAIResponsesWebSocketStream({
               client,
@@ -422,6 +450,11 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
         stream.push({ type: "done", reason: output.stopReason as never, message: output as never });
         stream.end();
       } catch (error) {
+        if (isPrewarmOperation) {
+          void websocketPrewarm?.();
+          eventStream.end(output);
+          return;
+        }
         if (error instanceof ResponsesStreamFailure && error.observation) {
           logResponsesFailedNoDetails(error.observation);
         }

--- a/packages/ai/src/transports/openai-responses-contracts.ts
+++ b/packages/ai/src/transports/openai-responses-contracts.ts
@@ -89,6 +89,7 @@ export type OpenAIResponsesOptions = BaseOpenAIStreamOptions & {
 };
 
 const PROMPT_OBSERVER = Symbol("openaiResponsesPromptObserver");
+export const responsesPrewarmOperation = Symbol.for("openclaw.openaiResponsesPrewarmOperation");
 export type ResponsesPromptObservation = {
   egress: "responses-sdk" | "responses-websocket" | "native-codex-websocket" | "native-codex-sse";
   payloadVariant: "initial" | "reasoning-stripped" | "compaction-stripped";

--- a/packages/ai/src/transports/openai-responses-websocket-client.test.ts
+++ b/packages/ai/src/transports/openai-responses-websocket-client.test.ts
@@ -63,7 +63,7 @@ vi.mock("openai", () => {
 
 vi.mock("openai/resources/responses/ws.js", () => ({
   ResponsesWS: class MockResponsesWS {
-    socket = { readyState: 1 };
+    socket = { readyState: 0 };
     private responseMessages: StreamMessage[] = [];
 
     constructor(
@@ -92,7 +92,9 @@ vi.mock("openai/resources/responses/ws.js", () => ({
     stream() {
       const handshake = transportState.handshakeMessages.shift() ?? { type: "open" as const };
       const readResponses = () => this.responseMessages;
+      const socket = this.socket;
       return (async function* () {
+        socket.readyState = 1;
         yield handshake;
         if (handshake.type !== "open") {
           return;
@@ -112,6 +114,7 @@ vi.mock("openai/resources/responses/ws.js", () => ({
 }));
 
 import { createOpenAIResponsesTransportStreamFn } from "./openai-responses-client.js";
+import { responsesPrewarmOperation } from "./openai-responses-contracts.js";
 
 const initialHost = getAiTransportHost();
 const model = {
@@ -231,6 +234,7 @@ async function run(
     model?: Model<"openai-responses">;
     transport?: "sse" | "websocket" | "websocket-cached" | "auto";
     sessionId?: string;
+    events?: unknown[];
     timeoutMs?: number;
     onPayload?: (payload: Record<string, unknown>) => Record<string, unknown>;
     headers?: Record<string, string>;
@@ -245,6 +249,38 @@ async function run(
     onPayload: overrides.onPayload,
     headers: overrides.headers,
   } as never);
+  return stream.result();
+}
+
+async function runPrewarm(
+  context: Context,
+  overrides: {
+    events?: unknown[];
+    model?: Model<"openai-responses">;
+    transport?: "sse" | "websocket" | "websocket-cached" | "auto" | null;
+    onPayload?: (
+      payload: Record<string, unknown>,
+    ) => Promise<Record<string, unknown>> | Record<string, unknown>;
+  } = {},
+): Promise<AssistantMessage> {
+  const options = {
+    apiKey: "test-key",
+    sessionId: "session-1",
+    ...(overrides.transport === null
+      ? {}
+      : { transport: overrides.transport ?? "websocket-cached" }),
+    reasoningEffort: "low",
+    onPayload: overrides.onPayload,
+  };
+  Reflect.set(options, responsesPrewarmOperation, true);
+  const stream = await createOpenAIResponsesTransportStreamFn()(
+    overrides.model ?? model,
+    context,
+    options as never,
+  );
+  for await (const event of stream) {
+    overrides.events?.push(event);
+  }
   return stream.result();
 }
 
@@ -295,6 +331,117 @@ describe("native OpenAI Responses WebSocket client integration", () => {
   afterEach(() => {
     cleanupSessionResources();
     configureAiTransportHost(initialHost);
+  });
+
+  it("preconnects, waits once, continues actual input, and resets with session cleanup", async () => {
+    transportState.responseBatches.push(
+      [{ type: "delay", ms: 20 }, message(completedEvent("resp_warm"))],
+      [message(completedEvent("resp_real"))],
+      [message(completedEvent("resp_warm_2"))],
+    );
+    let releasePayload!: () => void;
+    const payloadPending = new Promise<void>((resolve) => {
+      releasePayload = resolve;
+    });
+    const events: unknown[] = [];
+    const prewarm = runPrewarm(
+      { systemPrompt: "stable prompt", messages: [], tools: [] },
+      {
+        events,
+        onPayload: async (payload) => {
+          await payloadPending;
+          return payload;
+        },
+      },
+    );
+    await Promise.resolve();
+    expect(transportState.websocketOptions).toHaveLength(1);
+    releasePayload();
+    await vi.waitFor(() => expect(transportState.websocketRequests).toHaveLength(1));
+
+    const real = run({
+      systemPrompt: "stable prompt",
+      messages: [userMessage("actual question", 1)],
+      tools: [],
+    });
+    expect(transportState.websocketOptions).toHaveLength(1);
+    expect(transportState.websocketRequests).toHaveLength(1);
+    await Promise.all([prewarm, real]);
+    await runPrewarm({ systemPrompt: "stable prompt", messages: [], tools: [] });
+
+    expect(events).toEqual([]);
+    expect(transportState.websocketOptions[0]?.headers).toMatchObject({
+      "OpenAI-Beta": "responses_websockets=2026-02-06",
+    });
+    expect(transportState.websocketRequests).toHaveLength(2);
+    expect(transportState.websocketRequests[0]).toMatchObject({
+      type: "response.create",
+      generate: false,
+      input: [
+        {
+          type: "message",
+          role: "developer",
+          content: [{ type: "input_text", text: "stable prompt" }],
+        },
+      ],
+    });
+    expect(transportState.websocketRequests[1]).toMatchObject({
+      previous_response_id: "resp_warm",
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "actual question" }],
+        },
+      ],
+    });
+    expect(transportState.websocketRequests[1]).not.toHaveProperty("generate");
+
+    cleanupSessionResources("session-1");
+    expect(transportState.websocketCloseReasons).toContain("session_cleanup");
+
+    await runPrewarm({ systemPrompt: "stable prompt", messages: [], tools: [] });
+    expect(transportState.websocketOptions).toHaveLength(2);
+  });
+
+  it("keeps speculative failures and unexpected output out of SSE and cooldown", async () => {
+    transportState.handshakeMessages.push(
+      { type: "error", error: new Error("speculative connect failed") },
+      { type: "error", error: new Error("real connect failed") },
+    );
+    transportState.sdkOutcomes.push(sdkCompletion("resp_sse"));
+
+    await runPrewarm({ systemPrompt: "stable", messages: [], tools: [] });
+    expect(transportState.sdkRequests).toEqual([]);
+    expect((await run({ messages: [userMessage("real", 1)], tools: [] })).stopReason).toBe("stop");
+    expect(transportState.websocketOptions).toHaveLength(2);
+    expect(transportState.sdkRequests).toHaveLength(1);
+
+    cleanupSessionResources();
+    transportState.responseBatches.push(
+      [message(completedEvent("resp_bad_warm", "unexpected"))],
+      [message(completedEvent("resp_real"))],
+    );
+    await runPrewarm({ systemPrompt: "stable", messages: [], tools: [] });
+    await run({ systemPrompt: "stable", messages: [userMessage("real", 2)], tools: [] });
+    expect(transportState.websocketOptions).toHaveLength(4);
+    expect(transportState.websocketRequests.at(-1)).not.toHaveProperty("previous_response_id");
+  });
+
+  it("does not speculate for the API-key SSE default, custom endpoints, or managed transport", async () => {
+    await runPrewarm({ systemPrompt: "stable", messages: [], tools: [] }, { transport: null });
+    await runPrewarm(
+      { systemPrompt: "stable", messages: [], tools: [] },
+      { model: { ...model, baseUrl: "https://compatible.example/v1" } },
+    );
+    configureAiTransportHost({
+      ...getAiTransportHost(),
+      requiresManagedTransport: () => true,
+    });
+    await runPrewarm({ systemPrompt: "stable", messages: [], tools: [] });
+
+    expect(transportState.websocketOptions).toEqual([]);
+    expect(transportState.sdkRequests).toEqual([]);
   });
 
   it("continues past provider-only output metadata with one socket and only new input", async () => {

--- a/packages/ai/src/transports/openai-responses-websocket.ts
+++ b/packages/ai/src/transports/openai-responses-websocket.ts
@@ -20,7 +20,9 @@ import { sha256Hex } from "./transport-utils.js";
 
 const SESSION_WEBSOCKET_CACHE_TTL_MS = 5 * 60 * 1000;
 const SESSION_WEBSOCKET_MAX_AGE_MS = 55 * 60 * 1000;
+const WEBSOCKET_CONNECTING_STATE = 0;
 const WEBSOCKET_OPEN_STATE = 1;
+const RESPONSES_WEBSOCKET_V2_BETA = "responses_websockets=2026-02-06";
 
 type ResponsesWebSocketRequest = Record<string, unknown> & {
   input?: ResponseInput;
@@ -40,6 +42,7 @@ type CachedWebSocketConnection = {
   createdAt: number;
   idleTimer?: ReturnType<typeof setTimeout>;
   continuation?: CachedWebSocketContinuation;
+  prewarm?: PromiseWithResolvers<void>;
 };
 
 type ResponsesWebSocketStreamMessage =
@@ -61,6 +64,10 @@ type OpenAIResponsesWebSocketStream = {
     | "socket_not_cached";
   finish: (options?: { keep?: boolean }) => void;
 };
+type OpenAIResponsesWebSocketPrewarm = (
+  request?: Record<string, unknown>,
+  signal?: AbortSignal,
+) => Promise<void>;
 
 // Keep this credential-keyed SDK/normalized-replay cache separate from ChatGPT/Codex's
 // raw-socket cache, which matches wire bodies and has sticky SSE fallback. Both use
@@ -89,6 +96,7 @@ function isOfficialOpenAIResponsesBaseUrl(baseUrl: string | undefined): boolean 
     return false;
   }
 }
+
 export function supportsNativeOpenAIResponsesWebSocket(params: {
   provider: string;
   api: string;
@@ -112,6 +120,7 @@ function invalidateOwnedWebSocketSession(
   entry: CachedWebSocketConnection,
   reason = "done",
 ): void {
+  entry.prewarm?.resolve();
   if (entry.idleTimer) {
     clearTimeout(entry.idleTimer);
     entry.idleTimer = undefined;
@@ -144,6 +153,7 @@ type PreparedWebSocketConnection = {
 function prepareWebSocketConnection(
   client: OpenAI,
   headers: Record<string, string> | undefined,
+  useV2 = false,
 ): PreparedWebSocketConnection {
   if (!isOfficialOpenAIResponsesBaseUrl(client.baseURL)) {
     throw new Error("OpenAI Responses WebSocket requires the official API endpoint");
@@ -159,6 +169,18 @@ function prepareWebSocketConnection(
       delete resolvedHeaders[key];
     }
   }
+  const identityHeaders = Object.entries(resolvedHeaders).toSorted(([a], [b]) =>
+    a.localeCompare(b),
+  );
+  if (useV2) {
+    const existingBeta = Object.keys(resolvedHeaders).find(
+      (key) => key.toLowerCase() === "openai-beta",
+    );
+    if (existingBeta) {
+      delete resolvedHeaders[existingBeta];
+    }
+    resolvedHeaders["OpenAI-Beta"] = RESPONSES_WEBSOCKET_V2_BETA;
+  }
   if (!resolvedApiKey) {
     throw new Error("OpenAI Responses WebSocket requires a resolved API key");
   }
@@ -166,13 +188,7 @@ function prepareWebSocketConnection(
   return {
     client: resolvedClient,
     headers: resolvedHeaders,
-    identity: sha256Hex(
-      JSON.stringify([
-        resolvedApiKey,
-        client.baseURL,
-        Object.entries(resolvedHeaders).toSorted(([a], [b]) => a.localeCompare(b)),
-      ]),
-    ),
+    identity: sha256Hex(JSON.stringify([resolvedApiKey, client.baseURL, identityHeaders])),
   };
 }
 
@@ -259,7 +275,11 @@ function acquireWebSocket(
       return createTransientWebSocketLease(connection);
     }
     const expired = Date.now() - cached.createdAt >= SESSION_WEBSOCKET_MAX_AGE_MS;
-    if (!expired && cached.socket.socket.readyState === WEBSOCKET_OPEN_STATE) {
+    const readyState = cached.socket.socket.readyState;
+    if (
+      !expired &&
+      (readyState === WEBSOCKET_CONNECTING_STATE || readyState === WEBSOCKET_OPEN_STATE)
+    ) {
       return createCachedWebSocketLease(cacheKey, cached, true);
     }
     invalidateOwnedWebSocketSession(cacheKey, cached, expired ? "connection_age_limit" : "done");
@@ -442,8 +462,9 @@ export function createOpenAIResponsesWebSocketStream(params: {
   signal?: AbortSignal;
   callerSignal?: AbortSignal;
   degradeCooldownMs?: number;
+  prewarm?: boolean;
 }): OpenAIResponsesWebSocketStream {
-  const connection = prepareWebSocketConnection(params.client, params.headers);
+  const connection = prepareWebSocketConnection(params.client, params.headers, params.prewarm);
   const fullRequest = sanitizeWebSocketRequest(params.request);
   const requestModel = typeof fullRequest.model === "string" ? fullRequest.model : "";
   const degradationKey = `${params.sessionId ?? ""}\0${connection.identity}\0${requestModel}`;
@@ -455,6 +476,9 @@ export function createOpenAIResponsesWebSocketStream(params: {
   }
   degradedWebSocketConnections.delete(degradationKey);
   const markDegraded = () => {
+    if (params.prewarm) {
+      return;
+    }
     const cooldownMs = params.degradeCooldownMs;
     if (cooldownMs === undefined || !Number.isFinite(cooldownMs) || cooldownMs <= 0) {
       return;
@@ -527,9 +551,12 @@ export function createOpenAIResponsesWebSocketStream(params: {
             if (!requestDispatched) {
               // Set before send because a thrown send cannot prove the frame stayed local.
               requestDispatched = true;
+              // `generate` controls this frame only; keeping it out of `fullRequest`
+              // lets the completed warmup match the semantic real request.
               lease.socket.send({
                 ...prepared.request,
                 type: "response.create",
+                ...(params.prewarm ? { generate: false } : {}),
               } as ResponsesClientEvent);
             }
             continue;
@@ -586,6 +613,86 @@ export function createOpenAIResponsesWebSocketStream(params: {
     continuationStatus: prepared.continuationStatus,
     finish,
   };
+}
+
+export function beginOpenAIResponsesWebSocketPrewarm(params: {
+  client: OpenAI;
+  mode: OpenAIResponsesWebSocketMode;
+  sessionId?: string;
+  headers?: Record<string, string>;
+}): OpenAIResponsesWebSocketPrewarm | undefined {
+  if (params.mode === "websocket" || !params.sessionId) {
+    return undefined;
+  }
+  let connection: PreparedWebSocketConnection;
+  try {
+    connection = prepareWebSocketConnection(params.client, params.headers, true);
+  } catch {
+    return undefined;
+  }
+  const cacheKey = `${params.sessionId}\0${connection.identity}`;
+  if (websocketSessionCache.has(cacheKey)) {
+    return undefined;
+  }
+  const prewarm = Promise.withResolvers<void>();
+  const socket = createWebSocket(connection, (failedSocket) => {
+    const failedEntry = websocketSessionCache.get(cacheKey);
+    if (failedEntry?.socket === failedSocket) {
+      invalidateOwnedWebSocketSession(cacheKey, failedEntry, "transport_error");
+    }
+  });
+  const entry: CachedWebSocketConnection = {
+    socket,
+    sessionId: params.sessionId,
+    busy: false,
+    createdAt: Date.now(),
+    prewarm,
+  };
+  websocketSessionCache.set(cacheKey, entry);
+  const cancel = () => invalidateOwnedWebSocketSession(cacheKey, entry, "prewarm_cancelled");
+  return async (request, signal) => {
+    if (!request) {
+      cancel();
+      return;
+    }
+    let response: OpenAIResponsesWebSocketStream | undefined;
+    try {
+      response = createOpenAIResponsesWebSocketStream({
+        ...params,
+        request,
+        signal,
+        prewarm: true,
+      });
+      let completed = false;
+      for await (const event of response.stream) {
+        if (isRecord(event) && event.type === "response.completed" && isRecord(event.response)) {
+          completed = Array.isArray(event.response.output) && event.response.output.length === 0;
+        }
+      }
+      response.finish({ keep: completed });
+    } catch {
+      response?.finish({ keep: false });
+      cancel();
+    } finally {
+      prewarm.resolve();
+    }
+  };
+}
+
+export async function waitForOpenAIResponsesWebSocketPrewarm(params: {
+  client: OpenAI;
+  mode: OpenAIResponsesWebSocketMode;
+  sessionId?: string;
+  headers?: Record<string, string>;
+}): Promise<void> {
+  if (params.mode === "websocket" || !params.sessionId) {
+    return;
+  }
+  try {
+    const connection = prepareWebSocketConnection(params.client, params.headers);
+    await websocketSessionCache.get(`${params.sessionId}\0${connection.identity}`)?.prewarm
+      ?.promise;
+  } catch {}
 }
 
 function closeOpenAIResponsesWebSocketSessions(sessionId?: string): void {

--- a/src/agents/embedded-agent-runner/provider-prompt-state.test.ts
+++ b/src/agents/embedded-agent-runner/provider-prompt-state.test.ts
@@ -1,4 +1,4 @@
-import { responsesPromptObserver } from "@openclaw/ai/internal/openai";
+import { responsesPrewarmOperation, responsesPromptObserver } from "@openclaw/ai/internal/openai";
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import {
   createAssistantMessageEventStream,
@@ -335,6 +335,34 @@ describe("provider prompt state", () => {
       timestamp: 1,
     });
     await result.result();
+    clearProviderPromptState(runId);
+  });
+
+  it("does not admit speculative Responses prewarm into provider retry state", async () => {
+    const runId = "responses-prewarm";
+    const state = getProviderPromptState(runId);
+    const transport = vi.fn<StreamFn>(async (_model, _context, options) => {
+      await options?.onPayload?.({ input: [], model: model.id }, model);
+      return createResultStream("stop");
+    });
+    const wrapped = wrapStreamFnWithProviderPromptState({
+      streamFn: transport,
+      state,
+      effectiveContextTokenBudget: 128_000,
+    });
+    const options = { onPayload: (payload: unknown) => payload };
+    Reflect.set(options, responsesPrewarmOperation, true);
+
+    const result = await wrapped(
+      model,
+      { systemPrompt: "stable", messages: [], tools: [] },
+      options,
+    );
+    await result.result();
+
+    expect(transport).toHaveBeenCalledOnce();
+    expect(state.lastAttempt).toBeUndefined();
+    expect(markLastProviderPromptContextRejected(state)).toBeUndefined();
     clearProviderPromptState(runId);
   });
 });

--- a/src/agents/embedded-agent-runner/provider-prompt-state.ts
+++ b/src/agents/embedded-agent-runner/provider-prompt-state.ts
@@ -1,6 +1,6 @@
 import { Buffer } from "node:buffer";
 import crypto from "node:crypto";
-import { responsesPromptObserver } from "@openclaw/ai/internal/openai";
+import { responsesPrewarmOperation, responsesPromptObserver } from "@openclaw/ai/internal/openai";
 import { stableStringify } from "@openclaw/normalization-core";
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type { Model } from "openclaw/plugin-sdk/llm";
@@ -89,6 +89,9 @@ export function wrapStreamFnWithProviderPromptState(params: {
   recordEvent?: (type: string, data?: Record<string, unknown>) => void;
 }): StreamFn {
   return async (model, context, options) => {
+    if (options && Reflect.get(options, responsesPrewarmOperation) === true) {
+      return params.streamFn(model, context, options);
+    }
     params.state.lastAttempt = undefined; // Custom transports must not leave a stale candidate.
     const originalOnPayload = options?.onPayload;
     const observedOptions: NonNullable<Parameters<StreamFn>[2]> = {

--- a/src/agents/embedded-agent-runner/run/attempt-execution-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-phase.ts
@@ -1,5 +1,10 @@
 /** Prepares the guarded stream runtime before prompt execution and settlement. */
 import {
+  responsesPrewarmOperation,
+  supportsNativeOpenAIResponsesWebSocket,
+} from "@openclaw/ai/internal/openai";
+import { resolveAgentReasoningOption } from "../../../../packages/agent-core/src/reasoning.js";
+import {
   bindOwnedSessionTranscriptWrites,
   withOwnedSessionTranscriptWrites,
 } from "../../../config/sessions/transcript-write-context.js";
@@ -48,7 +53,7 @@ export async function runEmbeddedAttemptExecutionPhase(
     settleTracker: { abortActiveSession, trackPromptSettlePromise },
     state: sessionRuntimeState,
     transcriptPolicy,
-    transport: { effectiveAgentTransport, providerTextTransforms },
+    transport: { effectiveAgentTransport, providerTextTransforms, streamStrategy },
   } = sessionRuntime;
   const { orphanRepair } = sessionRuntime.boundary;
   const { capabilityToolNames, liveAllowedToolNames, replayAllowedToolNames } =
@@ -122,6 +127,34 @@ export async function runEmbeddedAttemptExecutionPhase(
   }
 
   const isProbeSession = attempt.sessionId?.startsWith("probe-") ?? false;
+  if (
+    !input.isRawModelRun &&
+    !isProbeSession &&
+    (effectiveAgentTransport === "auto" || effectiveAgentTransport === "websocket-cached") &&
+    (streamStrategy === "provider" || streamStrategy === "boundary-aware:openai-responses") &&
+    supportsNativeOpenAIResponsesWebSocket(attempt.model)
+  ) {
+    const { agent } = activeSession;
+    const options = {
+      [responsesPrewarmOperation]: true,
+      sessionId: attempt.sessionId,
+      transport: effectiveAgentTransport,
+      signal: input.runAbortController.signal,
+      reasoning: resolveAgentReasoningOption(attempt.model, agent.state.thinkingLevel),
+      thinkingBudgets: agent.thinkingBudgets,
+      maxRetryDelayMs: agent.maxRetryDelayMs,
+      onPayload: agent.onPayload,
+      onResponse: agent.onResponse,
+    };
+    const prewarm = agent.streamFn(
+      attempt.model,
+      { systemPrompt: agent.state.systemPrompt, messages: [], tools: agent.state.tools },
+      options,
+    );
+    void Promise.resolve(prewarm)
+      .then((stream) => stream.result())
+      .catch(() => undefined);
+  }
   const queueHandleRef: { current?: EmbeddedAgentQueueHandle } = {};
   const abortRun = createEmbeddedAttemptRunAbort({
     abortActiveSession,

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -1,3 +1,4 @@
+import { responsesPrewarmOperation } from "@openclaw/ai/internal/openai";
 import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 /**
@@ -187,6 +188,9 @@ export function wrapStreamFnWithDiagnosticModelCallEvents(
   ctx: ModelCallDiagnosticContext,
 ): StreamFn {
   return ((model, streamContext, options) => {
+    if (options && Reflect.get(options, responsesPrewarmOperation) === true) {
+      return streamFn(model, streamContext, options);
+    }
     const lifecycle = createModelLifecycle({
       ctx,
       options,

--- a/src/agents/embedded-agent-runner/run/llm-idle-timeout.ts
+++ b/src/agents/embedded-agent-runner/run/llm-idle-timeout.ts
@@ -1,3 +1,4 @@
+import { responsesPrewarmOperation } from "@openclaw/ai/internal/openai";
 import { onLlmRequestActivity } from "@openclaw/ai/internal/runtime";
 import { isCloudModelRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 /**
@@ -430,6 +431,9 @@ export function streamWithIdleTimeout(
   const guardIterationGaps = opts?.scope !== "creation-only";
   const runId = opts?.runId;
   return (model, context, options) => {
+    if (options && Reflect.get(options, responsesPrewarmOperation) === true) {
+      return baseFn(model, context, options);
+    }
     const createIdleTimeoutError = () =>
       new Error(`LLM idle timeout (${Math.floor(timeoutMs / 1000)}s): no response from model`);
 


### PR DESCRIPTION
Related: #122497
Related: #122483

> [!CAUTION]
> **Negative experiment — do not merge.** The authenticated latency gate failed. This draft preserves the implementation and evidence, but the direct API-key SSE default should remain unchanged and the prewarm behavior should not ship.

## What Problem This Solves

Direct OpenAI Responses users who explicitly select a session-cached WebSocket transport pay the cold connection cost on the first generated turn. The experiment tests whether Codex-style handshake preconnect plus a `response.create` frame with `generate=false` can hide that cold cost and make the cached WebSocket path competitive with the direct SSE default.

## Why This Change Was Made

The branch reuses the existing session-owned WebSocket cache, starts a v2 WebSocket before payload construction completes, sends a non-generating request with the stable system prompt and tools, waits for `response.completed`, and lets the real request continue from that response ID. It adds no config, environment, protocol, dependency, or storage surface, and keeps direct API-key traffic on SSE by default.

The implementation is intentionally isolated from normal prompt-retry admission, model-call diagnostics, idle-timeout accounting, assistant output, transcript persistence, degradation cooldown, and SSE fallback. Speculative failure closes only the candidate socket; the real request keeps the existing pre-dispatch fallback behavior.

Production LOC: +198/-11 (net +187) | Tests: +177/-2 (net +175) | Docs: +18/-8 (net +10)

## User Impact

**No behavior should ship from this branch.** The prewarm wire contract worked, but operator-visible latency regressed materially. Keep direct API-key Responses on SSE by default and keep explicit cached WebSocket continuation from #122483 without adding this prewarm round trip.

A future attempt would need either a real idle session-start window before the operator submits a prompt or a server-side warmup whose completion cost is close to zero. Merely moving this request earlier inside the active turn is not sufficient.

## Evidence

Authenticated live OpenAI A/B on this exact branch, `gpt-5.6-luna`, 12 alternating samples per lane, 12,162-character stable system prefix:

| Lane | First provider event median | First text median | Total median | Reuse / continuation | Fallbacks |
| --- | ---: | ---: | ---: | ---: | ---: |
| SSE | 320 ms | 580 ms | 703 ms | n/a | 0/12 |
| Cold cached WebSocket | 417 ms | 835 ms | 923 ms | 0/12 / 0/12 | 0/12 |
| Warm cached WebSocket | 114 ms | 896 ms | 973 ms | 12/12 / 12/12 | 0/12 |
| Preconnected + `generate=false` prewarm | 550 ms | 1,062 ms | 1,162 ms | 12/12 / 12/12 | 0/12 |

The prewarm request was accepted and continuation succeeded on every sample, so this is not a correctness or fallback failure. It is a latency failure: median first text was about 83% slower than SSE and 27% slower than a cold cached WebSocket request.

Focused regression proof:

- `node scripts/run-vitest.mjs packages/ai/src/transports/openai-responses-websocket.test.ts packages/ai/src/transports/openai-responses-websocket-client.test.ts src/agents/embedded-agent-runner/provider-prompt-state.test.ts src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts`
- Result: 5 files, 172 tests passed across 3 Vitest shards.
- `git diff --check`: clean.
- Targeted `oxfmt` and `oxlint`: clean.
- Codex autoreview (`gpt-5.6-sol`, high): TruffleHog clean; no accepted/actionable findings; patch correctness 0.98. The review agreed the measured regression argues against retaining the experiment.

Dependency and sibling-contract inspection:

- `codex-rs/core/src/client.rs`: session-owned WebSocket cache, handshake-only preconnect, v2 beta header, `generate=false`, completion drain, and response-ID continuation.
- `codex-rs/codex-api/src/endpoint/responses_websocket.rs`: exclusive socket request lifecycle and discard-on-terminal-error behavior.
- OpenAI SDK 6.49.0 `ResponsesWS`: constructor-time connect, connecting-state send queue, auth headers, and async iterator lifecycle.

AI-assisted: yes. The implementation, upstream contract review, focused proof, authenticated live A/B, and final decision were reviewed by the maintainer.
