### PR TITLE
fix(agents): heartbeats lose all conversation context on claude-cli chat↔heartbeat transitions

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"8c6ff70bbf195705355c6599c50819065f5f350f0faaddc4a868b5e86da65e28","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}
+{"contentHash":"5a2ba42b1444dae8f5b1d28b928047e8a22ba56c04b30d4ba1aba117841bd1c0","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
@@ -1,1 +1,1 @@
-{"contentHash":"91311c46d7fa124d5b79e0a8a6640f2ef8436c5000c1dafa3391f8c1303054b7","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
+{"contentHash":"b31cc56b834044a83232136e289ff83d89068d5182b24c0117cdddf08f042d07","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-core.json
@@ -1,1 +1,1 @@
-{"contentHash":"c3b22d889dc4c65a0ab8c4f5743e49df7f18a399a77b271a56e2cd60a2671fea","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}
+{"contentHash":"46eef9b562378a587f7cdfd8604f63026df62bfee6557871b92bdd7823935e31","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
@@ -1,1 +1,1 @@
-{"contentHash":"7cc678c87c2d6063305951bc9bcd75f78f4fe2a9408a263bc1cb294c66075b50","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}
+{"contentHash":"77591515b9cdc4fe31e18fd9013c5df6f826b25f746c98f49a1210ed8ce72e89","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-message.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-message.json
@@ -1,1 +1,1 @@
-{"contentHash":"f30a3ff93dab57ce1a6e73c10b027d2bb748968cd87cda27228654fc41811a03","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}
+{"contentHash":"7fabcfff703e44743e7429f9a2d1f20e470d8401645a2fd1ad32fd2800284b66","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"b6ef4ba8c3840141bff65a7fee3a5ea8efbe3da79696f5d59b41f8ccf1e32914","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}
+{"contentHash":"f18d5dd7d39fc2b4960c2b0342ec61659d6928d0cf444103f0228bd656fe15e2","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
@@ -1,1 +1,1 @@
-{"contentHash":"43afd1b1996e17f373e75c3922cbea6a0223782b0b68f6d05f7c29bbd83b8ebb","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}
+{"contentHash":"ac7c89c376612af981ee375088efba9cfe0dd9b77cc7d8f3507c7f4a0b4279d4","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}

--- a/docs/.generated/plugin-sdk-api-baseline/core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/core.json
@@ -1,1 +1,1 @@
-{"contentHash":"4d6021d0ae4ad15e1ce39d8700756ec415d604606ed538240c8f8aa9bf0acc37","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}
+{"contentHash":"562ecf5cc0b6651606d94e4095e773a6135cecc234f96895d4523a834d3d398c","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}

--- a/docs/.generated/plugin-sdk-api-baseline/discord.json
+++ b/docs/.generated/plugin-sdk-api-baseline/discord.json
@@ -1,1 +1,1 @@
-{"contentHash":"17eaa6392ffdf071bbe104a7c5720892042a906109be42478dec03b8bf5291a0","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}
+{"contentHash":"8a592c739ca28ee4131a6a80f84d890d051c36d8a787c671fc3d05d4adc673e8","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}

--- a/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
+++ b/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
@@ -1,1 +1,1 @@
-{"contentHash":"7bbbe7b8509abe241992eb632b1b484df2c270534f485ecf0f80e48b5671566a","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}
+{"contentHash":"96fe22cd2ef38b67b3c022f25c3513c45648f139d38fba88ca3f739f7ee96a12","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}

--- a/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"00ae2e13016a7ba0ebd4baef8b34a2b3811e0221799f6351d2189f6e0ea694ba","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}
+{"contentHash":"18b0d00c1f447c2ab0a28864309b97e0ce1c03e6a18823afe4044cd08200cbb3","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
@@ -1,1 +1,1 @@
-{"contentHash":"e20acaab6a8d3d56b57a487168439da89adfe250f0474a4c53350424415ac498","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}
+{"contentHash":"af35a3d387d8c2be7e1edf3ffe734392e91cee9f240fc84ff37864b4789cbebf","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"31e0fb8e73f98c8f69f8808aec8d8dc18fc2a074a21b9fc82414729fa1acceee","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}
+{"contentHash":"f58929a3f916812b8396bd54dd31ba8e96f012a61f850abc9a1b3266aed87a50","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"4918ded36f8fc0701bd94e4be965577c1c035977e6c5d32db1c17862775d6318","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
+{"contentHash":"ffc4685076b6f5015558f7a71e19184b67be4e8ea330ef2eb248cd56df4fabda","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
+++ b/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
@@ -1,1 +1,1 @@
-{"contentHash":"cd199186dee1148dc53d05710cb9785fdcff475bedbc92f5c18b5ddca675dbe7","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}
+{"contentHash":"03a83e9f6241cd93ad7677baf6ccfe198f91c5a5670d8509fdd83726c93bc83a","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}

--- a/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
+++ b/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
@@ -1,1 +1,1 @@
-{"contentHash":"265be26af18bed1c86ddc4636df78ac2f064848dcfc9e9da8e05842c69750ba4","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}
+{"contentHash":"a0e8d201ba9bdf6cea797b0df0063bbfeff9fdb533c362c991f46bf8f4a19790","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}

--- a/src/agents/command/prepare.ts
+++ b/src/agents/command/prepare.ts
@@ -1,8 +1,6 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import {
-  isSyntheticSourceReplyTurn,
-  resolveSourceReplyDeliveryMode,
-} from "../../auto-reply/reply/source-reply-delivery-mode.js";
+import { resolveSessionStableReplyMode } from "../../auto-reply/reply/session-stable-reply-mode.js";
+import { isSyntheticSourceReplyTurn } from "../../auto-reply/reply/source-reply-delivery-mode.js";
 import {
   formatThinkingLevels,
   normalizeThinkLevel,
@@ -31,10 +29,6 @@ import {
   resolveAgentHarnessSessionContextError,
 } from "../../sessions/agent-harness-session-key.js";
 import { resolveUserPath } from "../../utils.js";
-import {
-  sessionDeliveryChannel,
-  sessionDeliveryOrigin,
-} from "../../utils/delivery-context.shared.js";
 import { isDeliverableMessageChannel, resolveMessageChannel } from "../../utils/message-channel.js";
 import { resolveAgentRuntimeConfig } from "../agent-runtime-config.js";
 import {
@@ -45,7 +39,6 @@ import {
   resolveAgentWorkspaceDir,
 } from "../agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
-import { selectAgentHarness } from "../harness/selection.js";
 import { AGENT_LANE_SUBAGENT } from "../lanes.js";
 import type { ModelManifestNormalizationContext } from "../model-ref-shared.js";
 import { buildConfiguredModelCatalog, resolveConfiguredModelRef } from "../model-selection.js";
@@ -345,42 +338,17 @@ export async function prepareAgentCommandExecution(opts: AgentCommandOpts, runti
       isHeartbeat: commandOpts.bootstrapContextRunKind === "heartbeat",
     })
   ) {
-    // Lifecycle turns keep their effective delivery mode, but CLI reuse belongs
-    // to the existing session's normal source-reply policy.
-    const stableReplyContext = {
-      CommandAuthorized: false,
-      ChatType: sessionEntryRaw.chatType,
-      Provider: sessionDeliveryOrigin(sessionEntryRaw)?.provider,
-      Surface: sessionDeliveryChannel(sessionEntryRaw),
-      InputProvenance: commandOpts.inputProvenance,
-    };
-    const stableProvider = sessionEntryRaw.modelProvider ?? configuredModel.provider;
-    const stableModel = sessionEntryRaw.model ?? configuredModel.model;
-    const stableRuntime = resolveEffectiveAgentRuntime({
-      cfg,
-      provider: stableProvider,
-      modelId: stableModel,
-      agentId: sessionAgentId,
-      sessionKey,
-      sessionEntry: sessionEntryRaw,
-    });
-    const harness = selectAgentHarness({
-      provider: stableProvider,
-      modelId: stableModel,
-      config: cfg,
-      agentId: sessionAgentId,
-      sessionKey,
-      agentHarnessRuntimeOverride: stableRuntime,
-    });
-    const defaultVisibleReplies =
-      harness.deliveryDefaults?.visibleReplies ?? harness.deliveryDefaults?.sourceVisibleReplies;
     commandOpts = {
       ...commandOpts,
       cliSessionBindingFacts: {
-        sourceReplyDeliveryMode: resolveSourceReplyDeliveryMode({
+        sourceReplyDeliveryMode: resolveSessionStableReplyMode({
           cfg,
-          ctx: stableReplyContext,
-          defaultVisibleReplies,
+          sessionEntry: sessionEntryRaw,
+          sessionAgentId,
+          sessionKey,
+          defaultProvider: configuredModel.provider,
+          defaultModel: configuredModel.model,
+          inputProvenance: commandOpts.inputProvenance,
         }),
       },
     };

--- a/src/agents/command/prepare.ts
+++ b/src/agents/command/prepare.ts
@@ -343,12 +343,10 @@ export async function prepareAgentCommandExecution(opts: AgentCommandOpts, runti
       cliSessionBindingFacts: {
         sourceReplyDeliveryMode: resolveSessionStableReplyMode({
           cfg,
+          ctx: { CommandAuthorized: false },
           sessionEntry: sessionEntryRaw,
           sessionAgentId,
           sessionKey,
-          defaultProvider: configuredModel.provider,
-          defaultModel: configuredModel.model,
-          inputProvenance: commandOpts.inputProvenance,
         }),
       },
     };

--- a/src/auto-reply/reply/dispatch-from-config.harness-defaults.ts
+++ b/src/auto-reply/reply/dispatch-from-config.harness-defaults.ts
@@ -24,7 +24,6 @@ import {
   loadSessionStoreEntry,
   resolveSessionStorePathCore,
 } from "./dispatch-from-config.runtime.js";
-import type { DispatchFromConfigParams } from "./dispatch-from-config.types.js";
 import { resolveStoredModelOverride } from "./stored-model-override.js";
 
 type HarnessSourceVisibleRepliesDefault = "automatic" | "message_tool";
@@ -98,7 +97,7 @@ function resolveHarnessDefaultParentSessionKey(params: {
 }
 
 export function resolveTurnModelOverride(
-  replyOptions: DispatchFromConfigParams["replyOptions"],
+  replyOptions: { isHeartbeat?: boolean; heartbeatModelOverride?: string } | undefined,
 ): string | undefined {
   if (replyOptions?.isHeartbeat !== true) {
     return undefined;

--- a/src/auto-reply/reply/dispatch-from-config.harness-defaults.ts
+++ b/src/auto-reply/reply/dispatch-from-config.harness-defaults.ts
@@ -205,7 +205,47 @@ function resolveModelOverrideCandidate(params: {
   })?.ref;
 }
 
-export function resolveHarnessSourceVisibleRepliesDefault(params: {
+/**
+ * Resolves the configured visible-replies mode plus the guarded harness
+ * default. One owner for dispatch and synthetic-turn binding facts: both must
+ * derive the same session-stable delivery mode or CLI session bindings
+ * ping-pong across turn kinds (#121485).
+ */
+export function resolveVisibleRepliesPolicy(params: {
+  cfg: OpenClawConfig;
+  chatType?: string;
+  ctx: FinalizedMsgContext;
+  entry?: SessionEntry;
+  sessionAgentId: string;
+  sessionKey?: string;
+  sessionStore?: Record<string, SessionEntry>;
+  turnModelOverride?: string;
+}): {
+  configuredVisibleReplies?: "automatic" | "message_tool";
+  harnessDefaultVisibleReplies?: "automatic" | "message_tool";
+} {
+  const configuredVisibleReplies =
+    params.chatType === "group" || params.chatType === "channel"
+      ? (params.cfg.messages?.groupChat?.visibleReplies ?? params.cfg.messages?.visibleReplies)
+      : params.cfg.messages?.visibleReplies;
+  const harnessDefaultVisibleReplies =
+    configuredVisibleReplies === undefined &&
+    params.chatType !== "group" &&
+    params.chatType !== "channel"
+      ? resolveHarnessSourceVisibleRepliesDefault({
+          cfg: params.cfg,
+          ctx: params.ctx,
+          entry: params.entry,
+          sessionAgentId: params.sessionAgentId,
+          sessionKey: params.sessionKey,
+          sessionStore: params.sessionStore,
+          turnModelOverride: params.turnModelOverride,
+        })
+      : undefined;
+  return { configuredVisibleReplies, harnessDefaultVisibleReplies };
+}
+
+function resolveHarnessSourceVisibleRepliesDefault(params: {
   cfg: OpenClawConfig;
   ctx: FinalizedMsgContext;
   entry?: SessionEntry;

--- a/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
@@ -35,8 +35,8 @@ import {
 } from "./dispatch-from-config.context.js";
 import type { PluginBindingTranscriptOwner } from "./dispatch-from-config.events.js";
 import {
-  resolveHarnessSourceVisibleRepliesDefault,
   resolveTurnModelOverride,
+  resolveVisibleRepliesPolicy,
 } from "./dispatch-from-config.harness-defaults.js";
 import { extendPreparedDispatchState } from "./dispatch-from-config.phase-state.js";
 import type { PrepareDispatchDeliveryReadyState } from "./dispatch-from-config.prepare-delivery.js";
@@ -222,22 +222,16 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
         ? cfg.surfaces?.[silentReplySurface]?.silentReply
         : undefined,
     }) === "allow";
-  const configuredVisibleReplies =
-    chatType === "group" || chatType === "channel"
-      ? (cfg.messages?.groupChat?.visibleReplies ?? cfg.messages?.visibleReplies)
-      : cfg.messages?.visibleReplies;
-  const harnessDefaultVisibleReplies =
-    configuredVisibleReplies === undefined && chatType !== "group" && chatType !== "channel"
-      ? resolveHarnessSourceVisibleRepliesDefault({
-          cfg,
-          ctx,
-          entry: sessionStoreEntry.entry,
-          sessionAgentId,
-          sessionKey: acpDispatchSessionKey,
-          sessionStore: sessionStoreEntry.store,
-          turnModelOverride: resolveTurnModelOverride(params.replyOptions),
-        })
-      : undefined;
+  const { configuredVisibleReplies, harnessDefaultVisibleReplies } = resolveVisibleRepliesPolicy({
+    cfg,
+    chatType,
+    ctx,
+    entry: sessionStoreEntry.entry,
+    sessionAgentId,
+    sessionKey: acpDispatchSessionKey,
+    sessionStore: sessionStoreEntry.store,
+    turnModelOverride: resolveTurnModelOverride(params.replyOptions),
+  });
   const effectiveVisibleReplies = configuredVisibleReplies ?? harnessDefaultVisibleReplies;
   const prefersMessageToolDelivery =
     params.replyOptions?.sourceReplyDeliveryMode === "message_tool_only" ||

--- a/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
@@ -303,6 +303,7 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
       ? resolveStableMessageToolAvailability({
           cfg,
           ctx,
+          sessionEntry: sessionStoreEntry.entry,
           sessionAgentId,
           sessionKey: acpDispatchSessionKey,
         })

--- a/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
@@ -46,6 +46,7 @@ import { emitMessageReceivedHooks as emitSharedMessageReceivedHooks } from "./me
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { waitForReplyDispatcherIdle } from "./reply-dispatcher.js";
 import { isDuplicateRestartRecoverySource } from "./restart-recovery-claim.js";
+import { resolveStableMessageToolAvailability } from "./session-stable-reply-mode.js";
 import {
   isExplicitSourceReplyCommand,
   isUnauthorizedTextSlashCommand,
@@ -293,6 +294,19 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
     subagentPolicy,
     inheritedToolPolicy,
   ]);
+  // The stable mode's tool-only downgrade must be sender-independent, or a
+  // sender-scoped message denial hashes a different binding policy than the
+  // sender-less synthetic turns on the same session. Only tool-only candidates
+  // can downgrade, so skip the second policy pass otherwise.
+  const sessionStableMessageToolAvailable =
+    effectiveVisibleReplies === "message_tool"
+      ? resolveStableMessageToolAvailability({
+          cfg,
+          ctx,
+          sessionAgentId,
+          sessionKey: acpDispatchSessionKey,
+        })
+      : undefined;
   const sourceReplyPolicyParams = {
     cfg,
     ctx,
@@ -302,6 +316,7 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
     explicitSuppressTyping: params.replyOptions?.suppressTyping === true,
     shouldSuppressTyping: state.shouldSuppressTyping,
     messageToolAvailable,
+    sessionStableMessageToolAvailable,
     isHeartbeat: params.replyOptions?.isHeartbeat,
   } as const;
   let sourceReplyPolicy = resolveSourceReplyVisibilityPolicy({

--- a/src/auto-reply/reply/get-reply-run-context.ts
+++ b/src/auto-reply/reply/get-reply-run-context.ts
@@ -49,7 +49,11 @@ import {
   resolveBareResetBootstrapFileAccess,
   resolveBareSessionResetPromptState,
 } from "./session-reset-prompt.js";
-import { isExplicitSourceReplyCommand } from "./source-reply-delivery-mode.js";
+import { resolveSessionStableReplyMode } from "./session-stable-reply-mode.js";
+import {
+  isExplicitSourceReplyCommand,
+  isSyntheticSourceReplyTurn,
+} from "./source-reply-delivery-mode.js";
 import { shouldApplyStartupContext, buildSessionStartupContextPrelude } from "./startup-context.js";
 import { resolveTypingMode } from "./typing-mode.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
@@ -107,8 +111,29 @@ export async function prepareReplyRunContext(params: RunPreparedReplyParams) {
     isHeartbeat,
   });
   const inboundEventKind = promptSessionCtx.InboundEventKind;
-  const { sourceReplyDeliveryMode, sessionPromptSourceReplyDeliveryMode } =
+  const { sourceReplyDeliveryMode, sessionPromptSourceReplyDeliveryMode: injectedStableMode } =
     resolvePromptSourceReplyMode({ promptSessionCtx, opts });
+  // Direct resolver callers (heartbeat wakes, system events) skip dispatch's
+  // stable-mode injection; resolve the same session-stable fact here so their
+  // binding facts and messageToolPolicyHash match dispatched chat turns —
+  // otherwise chat<->heartbeat transitions ping-pong the CLI session (#121485).
+  const sessionPromptSourceReplyDeliveryMode =
+    injectedStableMode ??
+    (sessionEntry &&
+    isSyntheticSourceReplyTurn({
+      inputProvenance: promptSessionCtx.InputProvenance,
+      isHeartbeat,
+    })
+      ? resolveSessionStableReplyMode({
+          cfg,
+          sessionEntry,
+          sessionAgentId: agentId,
+          sessionKey,
+          defaultProvider: provider,
+          defaultModel: model,
+          inputProvenance: promptSessionCtx.InputProvenance,
+        })
+      : undefined);
   const silentReplyConversationType = resolvePromptSilentReplyConversationType({
     ctx: promptSessionCtx,
     inboundSessionKey: ctx.SessionKey,

--- a/src/auto-reply/reply/get-reply-run-context.ts
+++ b/src/auto-reply/reply/get-reply-run-context.ts
@@ -111,29 +111,33 @@ export async function prepareReplyRunContext(params: RunPreparedReplyParams) {
     isHeartbeat,
   });
   const inboundEventKind = promptSessionCtx.InboundEventKind;
-  const { sourceReplyDeliveryMode, sessionPromptSourceReplyDeliveryMode: injectedStableMode } =
+  const { sourceReplyDeliveryMode, sessionPromptSourceReplyDeliveryMode: promptStableMode } =
     resolvePromptSourceReplyMode({ promptSessionCtx, opts });
   // Direct resolver callers (heartbeat wakes, system events) skip dispatch's
   // stable-mode injection; resolve the same session-stable fact here so their
   // binding facts and messageToolPolicyHash match dispatched chat turns —
   // otherwise chat<->heartbeat transitions ping-pong the CLI session (#121485).
+  // Synthetic turns must not fall back to their effective turn mode: a
+  // response-tool heartbeat's message_tool_only is per-turn enforcement, not
+  // session policy, and hashing it recreates the ping-pong.
+  const isSyntheticTurn = isSyntheticSourceReplyTurn({
+    inputProvenance: promptSessionCtx.InputProvenance,
+    isHeartbeat,
+  });
   const sessionPromptSourceReplyDeliveryMode =
-    injectedStableMode ??
-    (sessionEntry &&
-    isSyntheticSourceReplyTurn({
-      inputProvenance: promptSessionCtx.InputProvenance,
-      isHeartbeat,
-    })
+    opts?.sessionPromptSourceReplyDeliveryMode ??
+    (isSyntheticTurn && sessionEntry
       ? resolveSessionStableReplyMode({
           cfg,
+          ctx: { ...promptSessionCtx, CommandAuthorized: false },
           sessionEntry,
           sessionAgentId: agentId,
           sessionKey,
-          defaultProvider: provider,
-          defaultModel: model,
-          inputProvenance: promptSessionCtx.InputProvenance,
+          sessionStore,
+          turnModelOverride:
+            isHeartbeat && opts ? normalizeOptionalString(opts.heartbeatModelOverride) : undefined,
         })
-      : undefined);
+      : promptStableMode);
   const silentReplyConversationType = resolvePromptSilentReplyConversationType({
     ctx: promptSessionCtx,
     inboundSessionKey: ctx.SessionKey,

--- a/src/auto-reply/reply/get-reply-run-context.ts
+++ b/src/auto-reply/reply/get-reply-run-context.ts
@@ -24,6 +24,7 @@ import { resolveEnvelopeFormatOptions } from "../envelope.js";
 import { normalizeThinkLevel } from "../thinking.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import { applySessionHints } from "./body.js";
+import { resolveTurnModelOverride } from "./dispatch-from-config.harness-defaults.js";
 import { shouldUseReplyFastTestRuntime } from "./get-reply-fast-path.js";
 import {
   buildExecOverridePromptHint,
@@ -111,8 +112,10 @@ export async function prepareReplyRunContext(params: RunPreparedReplyParams) {
     isHeartbeat,
   });
   const inboundEventKind = promptSessionCtx.InboundEventKind;
-  const { sourceReplyDeliveryMode, sessionPromptSourceReplyDeliveryMode: promptStableMode } =
-    resolvePromptSourceReplyMode({ promptSessionCtx, opts });
+  const { sourceReplyDeliveryMode, injectedSessionStableMode } = resolvePromptSourceReplyMode({
+    promptSessionCtx,
+    opts,
+  });
   // Direct resolver callers (heartbeat wakes, system events) skip dispatch's
   // stable-mode injection; resolve the same session-stable fact here so their
   // binding facts and messageToolPolicyHash match dispatched chat turns —
@@ -125,7 +128,7 @@ export async function prepareReplyRunContext(params: RunPreparedReplyParams) {
     isHeartbeat,
   });
   const sessionPromptSourceReplyDeliveryMode =
-    opts?.sessionPromptSourceReplyDeliveryMode ??
+    injectedSessionStableMode ??
     (isSyntheticTurn && sessionEntry
       ? resolveSessionStableReplyMode({
           cfg,
@@ -134,10 +137,9 @@ export async function prepareReplyRunContext(params: RunPreparedReplyParams) {
           sessionAgentId: agentId,
           sessionKey,
           sessionStore,
-          turnModelOverride:
-            isHeartbeat && opts ? normalizeOptionalString(opts.heartbeatModelOverride) : undefined,
+          turnModelOverride: resolveTurnModelOverride(opts),
         })
-      : promptStableMode);
+      : sourceReplyDeliveryMode);
   const silentReplyConversationType = resolvePromptSilentReplyConversationType({
     ctx: promptSessionCtx,
     inboundSessionKey: ctx.SessionKey,

--- a/src/auto-reply/reply/get-reply-run-source-mode.ts
+++ b/src/auto-reply/reply/get-reply-run-source-mode.ts
@@ -2,6 +2,11 @@ import type { TemplateContext } from "../templating.js";
 import type { InternalGetReplyOptions } from "./get-reply-run.types.js";
 import { isInternalSourceReplyChannel } from "./source-reply-delivery-mode.js";
 
+/**
+ * Resolves the turn's effective source-reply mode and surfaces dispatch's
+ * injected session-stable mode separately, so the caller owns the synthetic
+ * fallback in one place instead of un-mixing the two afterwards.
+ */
 export function resolvePromptSourceReplyMode(params: {
   promptSessionCtx: TemplateContext;
   opts?: InternalGetReplyOptions;
@@ -15,7 +20,6 @@ export function resolvePromptSourceReplyMode(params: {
         : params.opts?.sourceReplyDeliveryMode;
   return {
     sourceReplyDeliveryMode,
-    sessionPromptSourceReplyDeliveryMode:
-      params.opts?.sessionPromptSourceReplyDeliveryMode ?? sourceReplyDeliveryMode,
+    injectedSessionStableMode: params.opts?.sessionPromptSourceReplyDeliveryMode,
   };
 }

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -3090,6 +3090,16 @@ describe("runPreparedReply media-only handling", () => {
             sourceReplyDeliveryMode ?? "automatic",
           ].join(":"),
       );
+      // The direct-caller heartbeat run below resolves the stable mode from
+      // config instead of injected opts; keep both sources agreeing per case.
+      const caseCfg = {
+        session: {},
+        channels: {},
+        agents: { defaults: {} },
+        ...(stableMode === "message_tool_only"
+          ? { messages: { visibleReplies: "message_tool" as const } }
+          : {}),
+      };
       const sessionEntry: SessionEntry = {
         sessionId: "session-telegram-group",
         updatedAt: 1,
@@ -3107,6 +3117,7 @@ describe("runPreparedReply media-only handling", () => {
       };
 
       await runPrepared({
+        cfg: caseCfg,
         opts: {
           sourceReplyDeliveryMode: "message_tool_only",
           sessionPromptSourceReplyDeliveryMode: stableMode,
@@ -3125,6 +3136,7 @@ describe("runPreparedReply media-only handling", () => {
         },
       });
       await runPrepared({
+        cfg: caseCfg,
         opts: {
           sourceReplyDeliveryMode: stableMode,
           sessionPromptSourceReplyDeliveryMode: stableMode,
@@ -3142,6 +3154,7 @@ describe("runPreparedReply media-only handling", () => {
         },
       });
       await runPrepared({
+        cfg: caseCfg,
         opts: {
           isHeartbeat: true,
           sourceReplyDeliveryMode: stableMode,
@@ -3160,10 +3173,30 @@ describe("runPreparedReply media-only handling", () => {
           Provider: "cron-event",
         },
       });
+      // Production heartbeat wakes call the reply resolver directly, without
+      // dispatch's injected delivery modes; their binding facts must still
+      // match dispatched turns or the CLI session ping-pongs (#121485).
+      await runPrepared({
+        cfg: caseCfg,
+        opts: { isHeartbeat: true },
+        isNewSession: false,
+        systemSent: true,
+        sessionEntry,
+        ctx: {
+          ...createInboundBody("scheduled wake"),
+          Provider: "heartbeat",
+          SessionKey: "agent:main:telegram:-100123",
+        },
+        sessionCtx: {
+          ...createSessionBody("scheduled wake"),
+          Provider: "heartbeat",
+        },
+      });
 
       const roomEventRun = requireRunReplyAgentCall(0).followupRun.run;
       const primaryRun = requireRunReplyAgentCall(1).followupRun.run;
       const heartbeatRun = requireRunReplyAgentCall(2).followupRun.run;
+      const directHeartbeatRun = requireRunReplyAgentCall(3).followupRun.run;
       expect(roomEventRun.sourceReplyDeliveryMode).toBe("message_tool_only");
       expect(primaryRun.sourceReplyDeliveryMode).toBe(stableMode);
       expect(heartbeatRun.sourceReplyDeliveryMode).toBe(stableMode);
@@ -3180,6 +3213,9 @@ describe("runPreparedReply media-only handling", () => {
       });
       expect(primaryRun.cliSessionBindingFacts).toEqual(roomEventRun.cliSessionBindingFacts);
       expect(heartbeatRun.cliSessionBindingFacts).toEqual(roomEventRun.cliSessionBindingFacts);
+      expect(directHeartbeatRun.cliSessionBindingFacts).toEqual(
+        roomEventRun.cliSessionBindingFacts,
+      );
     },
   );
 

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -3192,11 +3192,31 @@ describe("runPreparedReply media-only handling", () => {
           Provider: "heartbeat",
         },
       });
+      // Response-tool heartbeats carry an effective message_tool_only turn
+      // mode; that is per-turn enforcement and must not become the session
+      // policy fact, or these heartbeats keep ping-ponging the binding.
+      await runPrepared({
+        cfg: caseCfg,
+        opts: { isHeartbeat: true, sourceReplyDeliveryMode: "message_tool_only" },
+        isNewSession: false,
+        systemSent: true,
+        sessionEntry,
+        ctx: {
+          ...createInboundBody("scheduled wake"),
+          Provider: "heartbeat",
+          SessionKey: "agent:main:telegram:-100123",
+        },
+        sessionCtx: {
+          ...createSessionBody("scheduled wake"),
+          Provider: "heartbeat",
+        },
+      });
 
       const roomEventRun = requireRunReplyAgentCall(0).followupRun.run;
       const primaryRun = requireRunReplyAgentCall(1).followupRun.run;
       const heartbeatRun = requireRunReplyAgentCall(2).followupRun.run;
       const directHeartbeatRun = requireRunReplyAgentCall(3).followupRun.run;
+      const responseToolHeartbeatRun = requireRunReplyAgentCall(4).followupRun.run;
       expect(roomEventRun.sourceReplyDeliveryMode).toBe("message_tool_only");
       expect(primaryRun.sourceReplyDeliveryMode).toBe(stableMode);
       expect(heartbeatRun.sourceReplyDeliveryMode).toBe(stableMode);
@@ -3216,8 +3236,62 @@ describe("runPreparedReply media-only handling", () => {
       expect(directHeartbeatRun.cliSessionBindingFacts).toEqual(
         roomEventRun.cliSessionBindingFacts,
       );
+      expect(responseToolHeartbeatRun.sourceReplyDeliveryMode).toBe("message_tool_only");
+      expect(responseToolHeartbeatRun.cliSessionBindingFacts).toEqual(
+        roomEventRun.cliSessionBindingFacts,
+      );
     },
   );
+
+  it("downgrades the synthetic stable mode when the message tool is policy-denied", async () => {
+    vi.mocked(buildGroupChatContext).mockImplementation(({ sourceReplyDeliveryMode }) =>
+      ["group", sourceReplyDeliveryMode ?? "automatic"].join(":"),
+    );
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-telegram-group",
+      updatedAt: 1,
+      systemSent: true,
+      chatType: "group",
+      delivery: normalizeSessionDeliveryState({
+        context: { channel: "telegram", to: "-100123" },
+        origin: {
+          provider: "telegram",
+          surface: "telegram",
+          chatType: "group",
+          to: "-100123",
+        },
+      }),
+    };
+
+    // Tool-only delivery configured, but the message tool is denied: dispatch
+    // downgrades its stable mode to automatic, so the synthetic fallback must
+    // record automatic too or the binding hashes diverge again.
+    await runPrepared({
+      cfg: {
+        session: {},
+        channels: {},
+        agents: { defaults: {} },
+        messages: { visibleReplies: "message_tool" as const },
+        tools: { deny: ["message"] },
+      },
+      opts: { isHeartbeat: true },
+      isNewSession: false,
+      systemSent: true,
+      sessionEntry,
+      ctx: {
+        ...createInboundBody("scheduled wake"),
+        Provider: "heartbeat",
+        SessionKey: "agent:main:telegram:-100123",
+      },
+      sessionCtx: {
+        ...createSessionBody("scheduled wake"),
+        Provider: "heartbeat",
+      },
+    });
+
+    const run = requireRunReplyAgentCall(0).followupRun.run;
+    expect(run.cliSessionBindingFacts?.sourceReplyDeliveryMode).toBe("automatic");
+  });
 
   it("keeps per-message room-event metadata out of CLI binding facts", async () => {
     vi.mocked(buildGroupChatContext).mockImplementation(({ sessionCtx, sourceReplyDeliveryMode }) =>

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -3243,6 +3243,41 @@ describe("runPreparedReply media-only handling", () => {
     },
   );
 
+  it("resolves origin-less sessions as internal for synthetic stable facts", async () => {
+    vi.mocked(buildDirectChatContext).mockReturnValue("direct-context");
+    // An entry with no persisted delivery origin has only ever been driven
+    // internally; the wake provider ("heartbeat") must not leak into the
+    // stable context as a non-internal surface or the fact diverges from
+    // dispatch's live webchat turns.
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-internal",
+      updatedAt: 1,
+      systemSent: true,
+      chatType: "direct",
+    };
+
+    await runPrepared({
+      cfg: { session: {}, channels: {}, agents: { defaults: {} } },
+      opts: { isHeartbeat: true },
+      isNewSession: false,
+      systemSent: true,
+      sessionEntry,
+      ctx: {
+        ...createInboundBody("scheduled wake"),
+        Provider: "heartbeat",
+        SessionKey: "agent:main:main",
+      },
+      sessionCtx: {
+        ...createSessionBody("scheduled wake"),
+        Provider: "heartbeat",
+        ChatType: "direct",
+      },
+    });
+
+    const run = requireRunReplyAgentCall(0).followupRun.run;
+    expect(run.cliSessionBindingFacts?.sourceReplyDeliveryMode).toBe("automatic");
+  });
+
   it("downgrades the synthetic stable mode when the message tool is policy-denied", async () => {
     vi.mocked(buildGroupChatContext).mockImplementation(({ sourceReplyDeliveryMode }) =>
       ["group", sourceReplyDeliveryMode ?? "automatic"].join(":"),

--- a/src/auto-reply/reply/session-stable-reply-mode.ts
+++ b/src/auto-reply/reply/session-stable-reply-mode.ts
@@ -2,77 +2,152 @@
 // system events, inter-session announcements) that reach the reply resolver
 // without dispatch's injected delivery-mode facts.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { selectAgentHarness } from "../../agents/harness/selection.js";
-import { resolveEffectiveAgentRuntime } from "../../agents/thinking-runtime.js";
+import {
+  resolveEffectiveToolPolicy,
+  resolveGroupToolPolicy,
+  resolveInheritedToolPolicyForSession,
+  resolveSubagentToolPolicyForSession,
+} from "../../agents/agent-tools.policy.js";
+import {
+  isSubagentEnvelopeSession,
+  resolveSubagentCapabilityStore,
+} from "../../agents/subagent-capabilities.js";
+import { isToolAllowedByPolicies } from "../../agents/tool-policy-match.js";
+import { mergeAlsoAllowPolicy, resolveToolProfilePolicy } from "../../agents/tool-policy.js";
+import { normalizeChatType } from "../../channels/chat-type.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import { resolveGroupSessionKey } from "../../config/sessions/group.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { logVerbose } from "../../globals.js";
-import { formatErrorMessage } from "../../infra/errors.js";
-import type { InputProvenance } from "../../sessions/input-provenance.js";
 import {
   sessionDeliveryChannel,
   sessionDeliveryOrigin,
 } from "../../utils/delivery-context.shared.js";
 import type { SourceReplyDeliveryMode } from "../get-reply-options.types.js";
+import type { FinalizedMsgContext } from "../templating.js";
+import { resolveVisibleRepliesPolicy } from "./dispatch-from-config.harness-defaults.js";
+import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { resolveSourceReplyDeliveryMode } from "./source-reply-delivery-mode.js";
 
 /**
- * Resolves the session's stable source-reply mode from persisted session facts.
- * Synthetic turns keep their effective delivery mode, but CLI session reuse
- * belongs to the existing session's normal source-reply policy — every turn
- * kind on a session must derive the same messageToolPolicyHash, or chat and
- * heartbeat turns ping-pong the CLI binding on each transition (#121485).
+ * Resolves the session's stable source-reply mode the way dispatch does, from
+ * a synthetic turn's restored context plus persisted session facts. Synthetic
+ * turns keep their effective delivery mode, but CLI session reuse belongs to
+ * the session's normal source-reply policy — every turn kind must derive the
+ * same messageToolPolicyHash, or chat and heartbeat turns ping-pong the CLI
+ * binding on each transition (#121485).
  */
 export function resolveSessionStableReplyMode(params: {
   cfg: OpenClawConfig;
+  ctx: FinalizedMsgContext;
   sessionEntry: SessionEntry;
   sessionAgentId: string;
   sessionKey?: string;
-  defaultProvider: string;
-  defaultModel: string;
-  inputProvenance?: InputProvenance;
+  sessionStore?: Record<string, SessionEntry>;
+  turnModelOverride?: string;
 }): SourceReplyDeliveryMode {
-  const { cfg, sessionEntry } = params;
+  const { cfg, ctx, sessionEntry } = params;
+  const chatType =
+    normalizeChatType(ctx.ChatType) ?? normalizeChatType(sessionEntry.chatType) ?? undefined;
   const stableReplyContext = {
     CommandAuthorized: false,
-    ChatType: sessionEntry.chatType,
-    Provider: sessionDeliveryOrigin(sessionEntry)?.provider,
-    Surface: sessionDeliveryChannel(sessionEntry),
-    InputProvenance: params.inputProvenance,
+    ChatType: chatType,
+    Provider:
+      normalizeOptionalString(ctx.Provider) ?? sessionDeliveryOrigin(sessionEntry)?.provider,
+    Surface: normalizeOptionalString(ctx.Surface) ?? sessionDeliveryChannel(sessionEntry),
+    ExplicitDeliverRoute: ctx.ExplicitDeliverRoute,
   };
-  const stableProvider =
-    normalizeOptionalString(sessionEntry.modelProvider) ?? params.defaultProvider;
-  const stableModel = normalizeOptionalString(sessionEntry.model) ?? params.defaultModel;
-  // Harness defaults are advisory here, as in dispatch's visible-reply default
-  // resolution; a lookup failure must not fail the turn, config still decides.
-  let defaultVisibleReplies: "automatic" | "message_tool" | undefined;
-  try {
-    const stableRuntime = resolveEffectiveAgentRuntime({
-      cfg,
-      provider: stableProvider,
-      modelId: stableModel,
-      agentId: params.sessionAgentId,
-      sessionKey: params.sessionKey,
-      sessionEntry,
-    });
-    const harness = selectAgentHarness({
-      provider: stableProvider,
-      modelId: stableModel,
-      config: cfg,
-      agentId: params.sessionAgentId,
-      sessionKey: params.sessionKey,
-      agentHarnessRuntimeOverride: stableRuntime,
-    });
-    defaultVisibleReplies =
-      harness.deliveryDefaults?.visibleReplies ?? harness.deliveryDefaults?.sourceVisibleReplies;
-  } catch (error) {
-    logVerbose(
-      `session-stable reply mode: could not resolve harness visible-reply defaults: ${formatErrorMessage(error)}`,
-    );
+  const { harnessDefaultVisibleReplies } = resolveVisibleRepliesPolicy({
+    cfg,
+    chatType,
+    ctx,
+    entry: sessionEntry,
+    sessionAgentId: params.sessionAgentId,
+    sessionKey: params.sessionKey,
+    sessionStore: params.sessionStore,
+    turnModelOverride: params.turnModelOverride,
+  });
+  const candidateMode = resolveSourceReplyDeliveryMode({
+    cfg,
+    ctx: stableReplyContext,
+    defaultVisibleReplies: harnessDefaultVisibleReplies,
+  });
+  if (candidateMode !== "message_tool_only") {
+    return candidateMode;
   }
+  // Dispatch downgrades tool-only delivery to automatic when the message tool
+  // is policy-denied; the stable fact must downgrade identically or the two
+  // turn kinds hash different policies. Sender fields are deliberately absent:
+  // session-stable policy cannot vary by sender.
   return resolveSourceReplyDeliveryMode({
     cfg,
     ctx: stableReplyContext,
-    defaultVisibleReplies,
+    defaultVisibleReplies: harnessDefaultVisibleReplies,
+    messageToolAvailable: resolveStableMessageToolAvailability(params),
   });
+}
+
+function resolveStableMessageToolAvailability(params: {
+  cfg: OpenClawConfig;
+  ctx: FinalizedMsgContext;
+  sessionAgentId: string;
+  sessionKey?: string;
+}): boolean {
+  const { cfg, ctx } = params;
+  const {
+    globalPolicy,
+    globalProviderPolicy,
+    agentPolicy,
+    agentProviderPolicy,
+    profile,
+    providerProfile,
+    profileAlsoAllow,
+    providerProfileAlsoAllow,
+  } = resolveEffectiveToolPolicy({
+    config: cfg,
+    sessionKey: params.sessionKey,
+    agentId: params.sessionAgentId,
+  });
+  // Tool-only delivery force-allows the message tool at the profile layer
+  // (dispatch's runtimeProfileAlsoAllow); only outer deny layers can make it
+  // unavailable.
+  const profilePolicy = mergeAlsoAllowPolicy(resolveToolProfilePolicy(profile), [
+    ...(profileAlsoAllow ?? []),
+    "message",
+  ]);
+  const providerProfilePolicy = mergeAlsoAllowPolicy(resolveToolProfilePolicy(providerProfile), [
+    ...(providerProfileAlsoAllow ?? []),
+    "message",
+  ]);
+  const groupPolicy = resolveGroupToolPolicy({
+    config: cfg,
+    sessionKey: params.sessionKey,
+    messageProvider: resolveOriginMessageProvider({
+      originatingChannel: ctx.OriginatingChannel,
+      provider: ctx.Provider ?? ctx.Surface,
+    }),
+    groupId: resolveGroupSessionKey(ctx)?.id,
+    groupChannel:
+      normalizeOptionalString(ctx.GroupChannel) ?? normalizeOptionalString(ctx.GroupSubject),
+    groupSpace: normalizeOptionalString(ctx.GroupSpace),
+    accountId: ctx.AccountId,
+  });
+  const subagentStore = resolveSubagentCapabilityStore(params.sessionKey, { cfg });
+  const subagentPolicy =
+    params.sessionKey && isSubagentEnvelopeSession(params.sessionKey, { cfg, store: subagentStore })
+      ? resolveSubagentToolPolicyForSession(cfg, params.sessionKey, { store: subagentStore })
+      : undefined;
+  const inheritedToolPolicy = resolveInheritedToolPolicyForSession(cfg, params.sessionKey, {
+    store: subagentStore,
+  });
+  return isToolAllowedByPolicies("message", [
+    profilePolicy,
+    providerProfilePolicy,
+    globalProviderPolicy,
+    agentProviderPolicy,
+    globalPolicy,
+    agentPolicy,
+    groupPolicy,
+    subagentPolicy,
+    inheritedToolPolicy,
+  ]);
 }

--- a/src/auto-reply/reply/session-stable-reply-mode.ts
+++ b/src/auto-reply/reply/session-stable-reply-mode.ts
@@ -11,7 +11,7 @@ import {
 import {
   isSubagentEnvelopeSession,
   resolveSubagentCapabilityStore,
-} from "../../agents/subagent-capabilities.js";
+} from "../../agents/subagents/spawn/subagent-capabilities.js";
 import { isToolAllowedByPolicies } from "../../agents/tool-policy-match.js";
 import { mergeAlsoAllowPolicy, resolveToolProfilePolicy } from "../../agents/tool-policy.js";
 import { normalizeChatType } from "../../channels/chat-type.js";

--- a/src/auto-reply/reply/session-stable-reply-mode.ts
+++ b/src/auto-reply/reply/session-stable-reply-mode.ts
@@ -19,12 +19,15 @@ import type { SessionEntry } from "../../config/sessions.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
+  deliveryContextFromSession,
   sessionDeliveryChannel,
   sessionDeliveryOrigin,
 } from "../../utils/delivery-context.shared.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
 import type { SourceReplyDeliveryMode } from "../get-reply-options.types.js";
 import type { FinalizedMsgContext } from "../templating.js";
 import { resolveVisibleRepliesPolicy } from "./dispatch-from-config.harness-defaults.js";
+import { isSystemEventProvider } from "./effective-reply-route.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { resolveSourceReplyDeliveryMode } from "./source-reply-delivery-mode.js";
 
@@ -48,12 +51,18 @@ export function resolveSessionStableReplyMode(params: {
   const { cfg, ctx, sessionEntry } = params;
   const chatType =
     normalizeChatType(ctx.ChatType) ?? normalizeChatType(sessionEntry.chatType) ?? undefined;
+  // System-event provider strings ("heartbeat", "cron-event") are wake
+  // plumbing, not the session's surface; an entry with no persisted delivery
+  // origin has only ever been driven internally, so it must resolve the same
+  // internal-channel branch dispatch's live webchat turns do.
   const stableReplyContext = {
     CommandAuthorized: false,
     ChatType: chatType,
     Provider:
-      normalizeOptionalString(ctx.Provider) ?? sessionDeliveryOrigin(sessionEntry)?.provider,
-    Surface: normalizeOptionalString(ctx.Surface) ?? sessionDeliveryChannel(sessionEntry),
+      resolveStableChannelFact(ctx.Provider) ??
+      sessionDeliveryOrigin(sessionEntry)?.provider ??
+      INTERNAL_MESSAGE_CHANNEL,
+    Surface: resolveStableChannelFact(ctx.Surface) ?? sessionDeliveryChannel(sessionEntry),
     ExplicitDeliverRoute: ctx.ExplicitDeliverRoute,
   };
   const { harnessDefaultVisibleReplies } = resolveVisibleRepliesPolicy({
@@ -75,15 +84,17 @@ export function resolveSessionStableReplyMode(params: {
     return candidateMode;
   }
   // Dispatch downgrades tool-only delivery to automatic when the message tool
-  // is policy-denied; the stable fact must downgrade identically or the two
-  // turn kinds hash different policies. Sender fields are deliberately absent:
+  // is policy-denied (source-reply-delivery-mode.ts availability gate); with a
+  // stable ctx that is the boolean's only effect, so apply it directly rather
+  // than re-deriving the whole mode. Sender fields are deliberately absent:
   // session-stable policy cannot vary by sender.
-  return resolveSourceReplyDeliveryMode({
-    cfg,
-    ctx: stableReplyContext,
-    defaultVisibleReplies: harnessDefaultVisibleReplies,
-    messageToolAvailable: resolveStableMessageToolAvailability(params),
-  });
+  return resolveStableMessageToolAvailability(params) ? candidateMode : "automatic";
+}
+
+/** Strips system-event wake providers so only real channel surfaces remain. */
+function resolveStableChannelFact(value: string | undefined): string | undefined {
+  const normalized = normalizeOptionalString(value);
+  return normalized && !isSystemEventProvider(normalized) ? normalized : undefined;
 }
 
 /**
@@ -95,10 +106,11 @@ export function resolveSessionStableReplyMode(params: {
 export function resolveStableMessageToolAvailability(params: {
   cfg: OpenClawConfig;
   ctx: FinalizedMsgContext;
+  sessionEntry?: SessionEntry;
   sessionAgentId: string;
   sessionKey?: string;
 }): boolean {
-  const { cfg, ctx } = params;
+  const { cfg, ctx, sessionEntry } = params;
   const {
     globalPolicy,
     globalProviderPolicy,
@@ -124,18 +136,29 @@ export function resolveStableMessageToolAvailability(params: {
     ...(providerProfileAlsoAllow ?? []),
     "message",
   ]);
+  // Direct callers (command prepare, synthetic wakes) may carry a bare ctx;
+  // fall back to the persisted session facts dispatch sees on live turns, or
+  // group/account-scoped policies resolve differently per producer.
   const groupPolicy = resolveGroupToolPolicy({
     config: cfg,
     sessionKey: params.sessionKey,
     messageProvider: resolveOriginMessageProvider({
-      originatingChannel: ctx.OriginatingChannel,
-      provider: ctx.Provider ?? ctx.Surface,
+      originatingChannel:
+        ctx.OriginatingChannel ?? (sessionEntry ? sessionDeliveryChannel(sessionEntry) : undefined),
+      provider:
+        resolveStableChannelFact(ctx.Provider ?? ctx.Surface) ??
+        (sessionEntry ? sessionDeliveryOrigin(sessionEntry)?.provider : undefined),
     }),
-    groupId: resolveGroupSessionKey(ctx)?.id,
+    groupId: resolveGroupSessionKey(ctx)?.id ?? sessionEntry?.groupId,
     groupChannel:
-      normalizeOptionalString(ctx.GroupChannel) ?? normalizeOptionalString(ctx.GroupSubject),
+      normalizeOptionalString(ctx.GroupChannel) ??
+      normalizeOptionalString(ctx.GroupSubject) ??
+      normalizeOptionalString(sessionEntry?.groupChannel) ??
+      normalizeOptionalString(sessionEntry?.subject),
     groupSpace: normalizeOptionalString(ctx.GroupSpace),
-    accountId: ctx.AccountId,
+    accountId:
+      ctx.AccountId ??
+      (sessionEntry ? deliveryContextFromSession(sessionEntry)?.accountId : undefined),
   });
   const subagentStore = resolveSubagentCapabilityStore(params.sessionKey, { cfg });
   const subagentPolicy =

--- a/src/auto-reply/reply/session-stable-reply-mode.ts
+++ b/src/auto-reply/reply/session-stable-reply-mode.ts
@@ -1,0 +1,78 @@
+// Session-stable source-reply mode for synthetic turns (heartbeat wakes,
+// system events, inter-session announcements) that reach the reply resolver
+// without dispatch's injected delivery-mode facts.
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { selectAgentHarness } from "../../agents/harness/selection.js";
+import { resolveEffectiveAgentRuntime } from "../../agents/thinking-runtime.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { logVerbose } from "../../globals.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import type { InputProvenance } from "../../sessions/input-provenance.js";
+import {
+  sessionDeliveryChannel,
+  sessionDeliveryOrigin,
+} from "../../utils/delivery-context.shared.js";
+import type { SourceReplyDeliveryMode } from "../get-reply-options.types.js";
+import { resolveSourceReplyDeliveryMode } from "./source-reply-delivery-mode.js";
+
+/**
+ * Resolves the session's stable source-reply mode from persisted session facts.
+ * Synthetic turns keep their effective delivery mode, but CLI session reuse
+ * belongs to the existing session's normal source-reply policy — every turn
+ * kind on a session must derive the same messageToolPolicyHash, or chat and
+ * heartbeat turns ping-pong the CLI binding on each transition (#121485).
+ */
+export function resolveSessionStableReplyMode(params: {
+  cfg: OpenClawConfig;
+  sessionEntry: SessionEntry;
+  sessionAgentId: string;
+  sessionKey?: string;
+  defaultProvider: string;
+  defaultModel: string;
+  inputProvenance?: InputProvenance;
+}): SourceReplyDeliveryMode {
+  const { cfg, sessionEntry } = params;
+  const stableReplyContext = {
+    CommandAuthorized: false,
+    ChatType: sessionEntry.chatType,
+    Provider: sessionDeliveryOrigin(sessionEntry)?.provider,
+    Surface: sessionDeliveryChannel(sessionEntry),
+    InputProvenance: params.inputProvenance,
+  };
+  const stableProvider =
+    normalizeOptionalString(sessionEntry.modelProvider) ?? params.defaultProvider;
+  const stableModel = normalizeOptionalString(sessionEntry.model) ?? params.defaultModel;
+  // Harness defaults are advisory here, as in dispatch's visible-reply default
+  // resolution; a lookup failure must not fail the turn, config still decides.
+  let defaultVisibleReplies: "automatic" | "message_tool" | undefined;
+  try {
+    const stableRuntime = resolveEffectiveAgentRuntime({
+      cfg,
+      provider: stableProvider,
+      modelId: stableModel,
+      agentId: params.sessionAgentId,
+      sessionKey: params.sessionKey,
+      sessionEntry,
+    });
+    const harness = selectAgentHarness({
+      provider: stableProvider,
+      modelId: stableModel,
+      config: cfg,
+      agentId: params.sessionAgentId,
+      sessionKey: params.sessionKey,
+      agentHarnessRuntimeOverride: stableRuntime,
+    });
+    defaultVisibleReplies =
+      harness.deliveryDefaults?.visibleReplies ?? harness.deliveryDefaults?.sourceVisibleReplies;
+  } catch (error) {
+    logVerbose(
+      `session-stable reply mode: could not resolve harness visible-reply defaults: ${formatErrorMessage(error)}`,
+    );
+  }
+  return resolveSourceReplyDeliveryMode({
+    cfg,
+    ctx: stableReplyContext,
+    defaultVisibleReplies,
+  });
+}

--- a/src/auto-reply/reply/session-stable-reply-mode.ts
+++ b/src/auto-reply/reply/session-stable-reply-mode.ts
@@ -86,7 +86,13 @@ export function resolveSessionStableReplyMode(params: {
   });
 }
 
-function resolveStableMessageToolAvailability(params: {
+/**
+ * Sender-independent message-tool availability for the session-stable mode.
+ * One owner for dispatch's stable-mode downgrade and synthetic-turn binding
+ * facts: sender-scoped denials apply to the sender's turn, never to the
+ * session policy every turn kind must hash identically (#121485).
+ */
+export function resolveStableMessageToolAvailability(params: {
   cfg: OpenClawConfig;
   ctx: FinalizedMsgContext;
   sessionAgentId: string;

--- a/src/auto-reply/reply/source-reply-delivery-mode.test.ts
+++ b/src/auto-reply/reply/source-reply-delivery-mode.test.ts
@@ -436,6 +436,40 @@ describe("resolveSourceReplyVisibilityPolicy", () => {
     },
   );
 
+  it("keeps the stable mode tool-only under a sender-scoped message denial", () => {
+    // A sender-scoped denial downgrades the sender's effective delivery, but
+    // the session-stable mode feeds CLI binding facts shared by sender-less
+    // synthetic turns; downgrading it too splits the policy hash and resets
+    // the CLI session on chat<->heartbeat transitions.
+    expectPolicyFields(
+      resolveSourceReplyVisibilityPolicy({
+        cfg: globalToolOnlyReplyConfig,
+        ctx: { ChatType: "direct" },
+        sendPolicy: "allow",
+        messageToolAvailable: false,
+        sessionStableMessageToolAvailable: true,
+      }),
+      {
+        sourceReplyDeliveryMode: "automatic",
+        sessionStableSourceReplyDeliveryMode: "message_tool_only",
+      },
+    );
+    // Without a sender-independent verdict, the stable mode still follows the
+    // turn's availability (session-wide denials downgrade both).
+    expectPolicyFields(
+      resolveSourceReplyVisibilityPolicy({
+        cfg: globalToolOnlyReplyConfig,
+        ctx: { ChatType: "direct" },
+        sendPolicy: "allow",
+        messageToolAvailable: false,
+      }),
+      {
+        sourceReplyDeliveryMode: "automatic",
+        sessionStableSourceReplyDeliveryMode: "automatic",
+      },
+    );
+  });
+
   it("suppresses automatic source delivery for opted-in message-tool group turns without suppressing typing", () => {
     expectPolicyFields(
       resolveSourceReplyVisibilityPolicy({

--- a/src/auto-reply/reply/source-reply-delivery-mode.ts
+++ b/src/auto-reply/reply/source-reply-delivery-mode.ts
@@ -153,6 +153,13 @@ export function resolveSourceReplyVisibilityPolicy(params: {
   explicitSuppressTyping?: boolean;
   shouldSuppressTyping?: boolean;
   messageToolAvailable?: boolean;
+  /**
+   * Sender-independent availability for the session-stable mode. The stable
+   * mode feeds CLI binding facts shared by every turn kind, so a sender-scoped
+   * message-tool denial must not downgrade it while sender-less synthetic
+   * turns resolve tool-only — that hash split resets the CLI session (#121485).
+   */
+  sessionStableMessageToolAvailable?: boolean;
   defaultVisibleReplies?: "automatic" | "message_tool";
   isHeartbeat?: boolean;
 }): SourceReplyVisibilityPolicy {
@@ -175,7 +182,8 @@ export function resolveSourceReplyVisibilityPolicy(params: {
     : resolveSourceReplyDeliveryMode({
         cfg: params.cfg,
         ctx: toSessionStableDeliveryModeContext(params.ctx),
-        messageToolAvailable: params.messageToolAvailable,
+        messageToolAvailable:
+          params.sessionStableMessageToolAvailable ?? params.messageToolAvailable,
         defaultVisibleReplies: params.defaultVisibleReplies,
       });
   const sendPolicyDenied = params.sendPolicy === "deny";


### PR DESCRIPTION
Closes #121485
Re-opening PR #121509 

## What Problem This Solves

Fixes an issue where operators running a claude-cli-backed agent with heartbeats enabled would get heartbeat turns that are blind to the conversation happening on the same session. Every transition between a chat turn and a heartbeat turn
hard-invalidated the CLI session binding (`cli session reset: reason=message-policy` — 13×/day in the reporting deployment, at every chat↔heartbeat boundary and never inside same-kind stretches), and the replacement heartbeat session started with no history at all (`historyPrompt=none`). Observed symptom: heartbeats don't have context from chat messages that happened prior.

## Why This Change Was Made

Dispatched chat turns get the session-stable delivery mode injected into their binding facts, so prepare computes a `messageToolPolicyHash`; heartbeat wakes (and other direct `getReplyFromConfig` callers) bypass dispatch, resolved no mode, and computed no hash — and `resolveCliSessionReuse` treats a one-sided hash as a policy change. This is the same turn-kind ping-pong #99595 fixed for room-event vs addressed turns; heartbeats were the one turn kind never brought
under its session-stable-facts invariant (`prepareAgentCommandExecution` already honors it for inter-session announce turns).

The fix records the fact at the producer: the synthetic-turn stable-mode resolution that `prepareAgentCommandExecution` already used is extracted into `resolveSessionStableReplyMode`, and `prepareReplyRunContext` now applies it whenever a synthetic turn arrives without dispatch's injected mode — so every turn kind on a session derives the same binding facts and hash. No change to the reuse comparison itself. Bindings persisted by pre-fix heartbeat turns lack the hash, so the first policied turn after upgrade invalidates once, then the binding is stable.

## User Impact

Heartbeats on claude-cli deployments now resume the same CLI session as chat turns: they see the conversation that just happened and act on it. Prompt-cache reuse survives chat↔heartbeat transitions instead of being discarded up to dozens of times per day. No config changes needed; this is the default path (`dmScope: main` + heartbeats).

## Evidence

Gateway log from the reporting deployment (full day): every `invalidated:message-policy` reset sits exactly at a chat↔heartbeat boundary; heartbeat→heartbeat stretches (7 turns, 18:51–21:51) and user→user stretches reuse cleanly. Binding dumps show the mechanism: heartbeat-persisted bindings omit `messageToolPolicyHash`; chat-persisted bindings carry `sha256('{"sourceReplyDeliveryMode":"automatic","requireExplicitMessageTarget":false}')`.

Regression test: extended the #99595 stable-facts table test in `get-reply-run.media-only.test.ts` with a fourth run shaped like a production heartbeat wake (`isHeartbeat: true`, no injected delivery modes) asserting its binding facts equal the dispatched turns' facts — red without the fix (both table cases), green with it.

Validation (local, Crabbox routing unavailable in this environment):
- `node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-run.media-only.test.ts` — 111/111
- `node scripts/run-vitest.mjs src/commands/agent.test.ts` — 43/43 (rewired caller)
- `node scripts/run-vitest.mjs src/agents/cli-session.test.ts src/agents/cli-runner/prepare.test.ts` — green (untouched vs main)
- `pnpm check:import-cycles` — 0 cycles (new module)
- `pnpm tsgo`, `scripts/run-oxlint.mjs`, `pnpm format` — clean

### Live verification (reporting deployment, 2026-08-10)

Gateway restarted onto this fix at 01:22:52. Heartbeat interval temporarily set to 1m to exercise chat↔heartbeat transitions quickly.

**Before (2026-08-09, pre-fix — same deployment, one day of `cli exec` lines):**
every chat↔heartbeat transition invalidated, 13/13; heartbeat resets got no history at all:

```
21:51:12 heartbeat resume=true  reusable
21:52:49 user      resume=false invalidated:message-policy
22:21:14 heartbeat resume=false invalidated:message-policy   historyPrompt=none
22:45:51 user      resume=false invalidated:message-policy
22:51:12 heartbeat resume=false invalidated:message-policy   historyPrompt=none
23:11:16 user      resume=false invalidated:message-policy
```

**After (post-restart):**

```
01:23:01 cli session reset: provider=claude-cli reason=message-policy
01:23:01 cli exec: trigger=user      useResume=false reuse=invalidated:message-policy
01:23:30 cli exec: trigger=user      useResume=true  resumeSession=11171aec0e40 reuse=reusable
01:26:41 cli exec: trigger=user      useResume=true  resumeSession=11171aec0e40 reuse=reusable
01:30:49 cli exec: trigger=user      useResume=true  resumeSession=11171aec0e40 reuse=reusable
01:33:13 cli exec: trigger=heartbeat useResume=true  resumeSession=11171aec0e40 reuse=reusable
01:34:12 cli exec: trigger=heartbeat useResume=true  resumeSession=11171aec0e40 reuse=reusable
```

- The single 01:23:01 invalidation is the expected one-time upgrade step: the stored binding was persisted by a pre-fix heartbeat and lacks the hash, so the first policied turn invalidates once and re-persists a complete binding.
- Everything after shares one native CLI session (`11171aec0e40`) across user turns **and** heartbeat turns — the chat→heartbeat transition at 01:33:13 resumes instead of resetting, which never happened pre-fix (0 occurrences in the full prior day's log).
- Operator-visible behavior confirmed: heartbeats now see the conversation that just happened on the session.

## Upgrade behavior (accepted tradeoff)

Bindings persisted before this fix lack a messageToolPolicyHash, so the first policied turn after upgrade invalidates once and re-persists a complete stable binding — that's the single 01:23:01 reset visible in the trace above. CLI session bindings are reuse-cache, not persistent user state, so a bounded one-time rebuild is preferred over a backfill migration per the repo's storage doctrine; steady state afterward is zero transition resets.