### PR TITLE
fix(channels): honor terminal reaction hold timing

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -1957,9 +1957,13 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     });
     expect(statusReactionControllerMock.setQueued).toHaveBeenCalledTimes(1);
     expect(statusReactionControllerMock.setDone).toHaveBeenCalledTimes(1);
+    expect(statusReactionControllerMock.restoreInitial).toHaveBeenCalledTimes(1);
+    expect(statusReactionControllerMock.setDone.mock.invocationCallOrder[0]).toBeLessThan(
+      statusReactionControllerMock.restoreInitial.mock.invocationCallOrder[0] ?? 0,
+    );
   });
 
-  it("marks a recovered agent failure as failed after delivering its visible error reply", async () => {
+  it("marks a recovered agent failure as failed then restores its initial reaction", async () => {
     mockedAgentRunTerminalOutcome = "failed";
     mockedNativeStreaming = true;
     mockedSlackStreamingMode = "progress";
@@ -1985,6 +1989,10 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(collectNativeTaskUpdates().at(-1)).toEqual(expect.objectContaining({ status: "error" }));
     expect(statusReactionControllerMock.setError).toHaveBeenCalledTimes(1);
     expect(statusReactionControllerMock.setDone).not.toHaveBeenCalled();
+    expect(statusReactionControllerMock.restoreInitial).toHaveBeenCalledTimes(1);
+    expect(statusReactionControllerMock.setError.mock.invocationCallOrder[0]).toBeLessThan(
+      statusReactionControllerMock.restoreInitial.mock.invocationCallOrder[0] ?? 0,
+    );
   });
 
   it("keeps Slack lifecycle reactions off by default when an ack reaction exists", async () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -572,6 +572,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   if (statusReactionsEnabled) {
     if (dispatchError || agentRunFailed) {
       await statusReactions.setError();
+      void statusReactions.restoreInitial();
     } else if (anyReplyDelivered) {
       await statusReactions.setDone();
       void statusReactions.restoreInitial();

--- a/src/channels/status-reactions.slack-lifecycle.test.ts
+++ b/src/channels/status-reactions.slack-lifecycle.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createStatusReactionController,
   DEFAULT_EMOJIS,
+  DEFAULT_TIMING,
   type StatusReactionAdapter,
 } from "./status-reactions.js";
 
@@ -67,7 +68,9 @@ describe("Slack status reaction lifecycle", () => {
     expect(active.has(WEB_SEARCH_TOOL_EMOJI)).toBe(true);
     expect(active.has(DEFAULT_EMOJIS.thinking)).toBe(true);
 
-    await ctrl.setDone();
+    const donePromise = ctrl.setDone();
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.doneHoldMs);
+    await donePromise;
     expect(active.has(DEFAULT_EMOJIS.done)).toBe(true);
     expect(active.has(WEB_SEARCH_TOOL_EMOJI)).toBe(false);
     expect(active.has(DEFAULT_EMOJIS.thinking)).toBe(false);
@@ -90,7 +93,9 @@ describe("Slack status reaction lifecycle", () => {
     await vi.advanceTimersByTimeAsync(10);
     expect(active.has("eyes")).toBe(true);
 
-    await ctrl.setError();
+    const errorPromise = ctrl.setError();
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.errorHoldMs);
+    await errorPromise;
     expect(active.has(DEFAULT_EMOJIS.error)).toBe(true);
     expect(active.has("eyes")).toBe(false);
 
@@ -155,7 +160,9 @@ describe("Slack status reaction lifecycle", () => {
 
     void ctrl.setQueued();
     await vi.advanceTimersByTimeAsync(10);
-    await ctrl.setDone();
+    const donePromise = ctrl.setDone();
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.doneHoldMs);
+    await donePromise;
 
     await ctrl.restoreInitial();
 

--- a/src/channels/status-reactions.test.ts
+++ b/src/channels/status-reactions.test.ts
@@ -252,23 +252,61 @@ describe("createStatusReactionController", () => {
       name: "setDone",
       run: (controller: ReturnType<typeof createStatusReactionController>) => controller.setDone(),
       expected: DEFAULT_EMOJIS.done,
+      holdMs: DEFAULT_TIMING.doneHoldMs,
     },
     {
       name: "setError",
       run: (controller: ReturnType<typeof createStatusReactionController>) => controller.setError(),
       expected: DEFAULT_EMOJIS.error,
+      holdMs: DEFAULT_TIMING.errorHoldMs,
     },
   ] as const;
 
   it.each(immediateTerminalCases)(
-    "should execute $name immediately without debounce",
-    async ({ run, expected }) => {
+    "should hold $name before an immediately queued restore",
+    async ({ run, expected, holdMs }) => {
       const { calls, controller } = createEnabledController();
 
-      await run(controller);
-      await vi.runAllTimersAsync();
+      void controller.setQueued();
+      await vi.advanceTimersByTimeAsync(0);
 
-      expectSetEmojiCall(calls, expected);
+      let terminalResolved = false;
+      let restoreResolved = false;
+      const terminalPromise = run(controller).then(() => {
+        terminalResolved = true;
+      });
+      const restorePromise = controller.restoreInitial().then(() => {
+        restoreResolved = true;
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(calls).toEqual([
+        { method: "set", emoji: "👀" },
+        { method: "set", emoji: expected },
+        { method: "remove", emoji: "👀" },
+      ]);
+      expect(terminalResolved).toBe(false);
+      expect(restoreResolved).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(holdMs - 1);
+
+      expect(collectEmojisForMethod(calls, "set")).toEqual(["👀", expected]);
+      expect(terminalResolved).toBe(false);
+      expect(restoreResolved).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await Promise.all([terminalPromise, restorePromise]);
+
+      expect(calls).toEqual([
+        { method: "set", emoji: "👀" },
+        { method: "set", emoji: expected },
+        { method: "remove", emoji: "👀" },
+        { method: "set", emoji: "👀" },
+        { method: "remove", emoji: expected },
+      ]);
+      expect(terminalResolved).toBe(true);
+      expect(restoreResolved).toBe(true);
+      expect(countCallsForEmoji(calls, expected)).toBe(2);
     },
   );
 
@@ -277,6 +315,7 @@ describe("createStatusReactionController", () => {
       name: "ignore setThinking after setDone (terminal state)",
       terminal: (controller: ReturnType<typeof createStatusReactionController>) =>
         controller.setDone(),
+      holdMs: DEFAULT_TIMING.doneHoldMs,
       followup: (controller: ReturnType<typeof createStatusReactionController>) => {
         void controller.setThinking();
       },
@@ -285,16 +324,19 @@ describe("createStatusReactionController", () => {
       name: "ignore setTool after setError (terminal state)",
       terminal: (controller: ReturnType<typeof createStatusReactionController>) =>
         controller.setError(),
+      holdMs: DEFAULT_TIMING.errorHoldMs,
       followup: (controller: ReturnType<typeof createStatusReactionController>) => {
         void controller.setTool("exec");
       },
     },
   ] as const;
 
-  it.each(terminalIgnoreCases)("should $name", async ({ terminal, followup }) => {
+  it.each(terminalIgnoreCases)("should $name", async ({ terminal, holdMs, followup }) => {
     const { calls, controller } = createEnabledController();
 
-    await terminal(controller);
+    const terminalPromise = terminal(controller);
+    await vi.advanceTimersByTimeAsync(holdMs);
+    await terminalPromise;
     const callsAfterTerminal = calls.length;
     followup(controller);
     await vi.advanceTimersByTimeAsync(1000);
@@ -386,7 +428,9 @@ describe("createStatusReactionController", () => {
     void controller.setTool("exec");
     await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.debounceMs);
 
-    await controller.setDone();
+    const donePromise = controller.setDone();
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.doneHoldMs);
+    await donePromise;
 
     const removeEmojis = collectEmojisForMethod(calls, "remove");
     expect(removeEmojis).toEqual([
@@ -404,7 +448,9 @@ describe("createStatusReactionController", () => {
     void controller.setThinking();
     await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.debounceMs);
 
-    await controller.setDone();
+    const donePromise = controller.setDone();
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.doneHoldMs);
+    await donePromise;
 
     expect(calls).toEqual([
       { method: "set", emoji: DEFAULT_EMOJIS.thinking },
@@ -420,7 +466,9 @@ describe("createStatusReactionController", () => {
     void controller.setThinking();
     await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.debounceMs);
 
-    await controller.setDone();
+    const donePromise = controller.setDone();
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.doneHoldMs);
+    await donePromise;
     await controller.restoreInitial();
 
     expect(calls).toEqual([
@@ -511,9 +559,34 @@ describe("createStatusReactionController", () => {
 
     expectSetEmojiCall(calls, "🤔");
 
-    await controller.setDone();
-    await vi.runAllTimersAsync();
+    const donePromise = controller.setDone();
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.doneHoldMs);
+    await donePromise;
     expectSetEmojiCall(calls, "🎉");
+  });
+
+  it("should cancel a terminal hold when explicitly cleared", async () => {
+    const { calls, controller } = createEnabledController();
+
+    void controller.setQueued();
+    await vi.advanceTimersByTimeAsync(0);
+    let terminalResolved = false;
+    const terminalPromise = controller.setError().then(() => {
+      terminalResolved = true;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expectSetEmojiCall(calls, DEFAULT_EMOJIS.error);
+    expect(terminalResolved).toBe(false);
+    expect(vi.getTimerCount()).toBe(1);
+
+    const clearPromise = controller.clear();
+    await vi.advanceTimersByTimeAsync(0);
+    await Promise.all([terminalPromise, clearPromise]);
+
+    expect(terminalResolved).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(collectEmojisForMethod(calls, "remove")).toEqual(["👀", DEFAULT_EMOJIS.error]);
   });
 
   it("should use custom timing when provided", async () => {

--- a/src/channels/status-reactions.ts
+++ b/src/channels/status-reactions.ts
@@ -225,6 +225,8 @@ export function createStatusReactionController(params: {
   let debounceTimer: NodeJS.Timeout | null = null;
   let stallSoftTimer: NodeJS.Timeout | null = null;
   let stallHardTimer: NodeJS.Timeout | null = null;
+  let terminalHold: { timer: NodeJS.Timeout; resolve: () => void } | null = null;
+  let terminalHoldGeneration = 0;
   let finished = false;
   let chainPromise = Promise.resolve();
   const activeEmojis = new Set<string>();
@@ -234,7 +236,7 @@ export function createStatusReactionController(params: {
     return chainPromise;
   }
 
-  function clearAllTimers(): void {
+  function clearActivityTimers(): void {
     if (debounceTimer) {
       clearTimeout(debounceTimer);
       debounceTimer = null;
@@ -247,6 +249,30 @@ export function createStatusReactionController(params: {
       clearTimeout(stallHardTimer);
       stallHardTimer = null;
     }
+  }
+
+  function cancelTerminalHold(): void {
+    terminalHoldGeneration += 1;
+    const hold = terminalHold;
+    if (!hold) {
+      return;
+    }
+    terminalHold = null;
+    clearTimeout(hold.timer);
+    hold.resolve();
+  }
+
+  function waitForTerminalHold(holdMs: number, generation: number): Promise<void> {
+    if (holdMs <= 0 || generation !== terminalHoldGeneration) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        terminalHold = null;
+        resolve();
+      }, holdMs);
+      terminalHold = { timer, resolve };
+    });
   }
 
   function clearDebounceTimer(): void {
@@ -374,28 +400,30 @@ export function createStatusReactionController(params: {
     pendingEmoji = "";
   }
 
-  function finishWithEmoji(emoji: string): Promise<void> {
+  function finishWithEmoji(emoji: string, holdMs: number): Promise<void> {
     if (!enabled) {
       return Promise.resolve();
     }
 
     finished = true;
-    clearAllTimers();
+    clearActivityTimers();
+    const holdGeneration = terminalHoldGeneration;
 
-    // Return the updated chain so callers can wait for terminal cleanup.
+    // The serialized hold keeps an immediate restore queued, while explicit clear can cancel it.
     return enqueue(async () => {
       await applyEmoji(emoji);
       await removeActiveEmojis({ keepEmoji: emoji });
       pendingEmoji = "";
+      await waitForTerminalHold(holdMs, holdGeneration);
     });
   }
 
   function setDone(): Promise<void> {
-    return finishWithEmoji(emojis.done);
+    return finishWithEmoji(emojis.done, timing.doneHoldMs);
   }
 
   function setError(): Promise<void> {
-    return finishWithEmoji(emojis.error);
+    return finishWithEmoji(emojis.error, timing.errorHoldMs);
   }
 
   async function clear(): Promise<void> {
@@ -403,7 +431,8 @@ export function createStatusReactionController(params: {
       return;
     }
 
-    clearAllTimers();
+    clearActivityTimers();
+    cancelTerminalHold();
     finished = true;
 
     await enqueue(async () => {
@@ -436,12 +465,17 @@ export function createStatusReactionController(params: {
     const pendingBeforeClear = pendingEmoji;
     const hadDebouncedPending = debounceTimer !== null;
     const hasExtraActiveEmoji = Array.from(activeEmojis).some((emoji) => emoji !== initialEmoji);
-    clearAllTimers();
-    if (alreadyInitial && (!pendingBeforeClear || hadDebouncedPending) && !hasExtraActiveEmoji) {
+    clearActivityTimers();
+    if (
+      !finished &&
+      alreadyInitial &&
+      (!pendingBeforeClear || hadDebouncedPending) &&
+      !hasExtraActiveEmoji
+    ) {
       pendingEmoji = "";
       return;
     }
-    if (pendingBeforeClear === initialEmoji && !hadDebouncedPending) {
+    if (!finished && pendingBeforeClear === initialEmoji && !hadDebouncedPending) {
       await chainPromise;
       return;
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where configured terminal reaction holds were never applied. Most channels restored the initial reaction immediately after setting ✅ or ❌, making the terminal status effectively invisible. Slack errors had the opposite problem: ❌ was never restored and could remain indefinitely.

## Why This Change Was Made

The shared status-reaction controller now owns terminal timing inside its existing serialized state machine. The terminal emoji is applied immediately, an immediate restore queues behind the configured done/error hold, and explicit cleanup can cancel the hold without leaking timers or waiting unnecessarily.

Slack error handling now restores the initial reaction through the same shared lifecycle as successful delivery. No channel-specific sleeps or parallel reaction paths were added.

AI-assisted: yes. The final shared-state implementation and tests were manually reviewed and passed fresh structured autoreview.

## User Impact

Operators can now see terminal success and failure reactions for their configured hold durations. Reactions restore consistently after both Slack success and error, while explicit cleanup remains immediate.

## Evidence

- Shared fake-timer regressions prove done/error reactions apply immediately, remain visible through `holdMs - 1`, restore exactly at the configured hold, and are removed once.
- Explicit `clear()` during a terminal hold cancels the timer, resolves pending work, removes active reactions, and leaves zero timers.
- `node scripts/run-vitest.mjs src/channels/status-reactions.test.ts src/channels/status-reactions.slack-lifecycle.test.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts` — 195/195 passed on the final rebased head.
- `node scripts/check-changed.mjs -- ...` — passed on Testbox `tbx_01kztfe46bp93h1yt8qmggdsgg` ([run](https://github.com/openclaw/openclaw/actions/runs/31575952687)).
- Final rebase retained an identical patch ID; focused tests, formatting, and `git diff --check` passed again.
- Hosted exact-head CI — green ([run](https://github.com/openclaw/openclaw/actions/runs/31577136717)).
- Fresh rebased-head autoreview — clean, no accepted/actionable findings.
- Production: +45/−10 lines; tests: +105/−17 lines. The +35 production delta is the cancelable terminal-hold state owned by the existing serialized controller plus the one-line Slack error restoration; no channel-local timer implementation was added.
- No live Slack write was performed; proof is deterministic at the shared controller and Slack dispatch boundaries.
