### PR TITLE
fix(memory-wiki): guard wiki_get against missing or wrong-typed lookup

### DIFF
--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -1785,28 +1785,27 @@ describe("getMemoryWikiPage", () => {
     );
   });
 
-  it("reports a clean error instead of crashing when lookup is missing or wrong-typed", async () => {
+  it("reports a clean error instead of crashing for malformed wiki_get params", async () => {
     const { config } = await createQueryVault({
       initialize: true,
       config: { search: { backend: "shared", corpus: "memory" } },
     });
-    const manager = createMemoryManager({
-      readResult: { path: "memory/notes.md", text: "durable notes", from: 1, lines: 1 },
-    });
-    getActiveMemorySearchManagerMock.mockResolvedValue({ manager });
-
     const tool = createWikiGetTool(config, createAppConfig());
+    const malformedParams = [
+      null,
+      { path: "sources/example/note.md" },
+      { lookup: "   " },
+      { lookup: 42 },
+    ];
 
-    // Wrong parameter name (e.g. `path` instead of `lookup`) leaves lookup undefined.
-    // This used to throw "Cannot read properties of undefined (reading 'trim')".
-    const missing = await tool.execute("wiki-get-bad-param", {
-      path: "sources/example/note.md",
-    } as never);
+    for (const params of malformedParams) {
+      const result = await tool.execute("wiki-get-bad-param", params);
 
-    expect(missing.details).toEqual({ found: false });
-    expect(missing.content).toEqual([
-      { type: "text", text: "wiki_get requires a non-empty `lookup` path or id." },
-    ]);
+      expect(result.details).toEqual({ found: false });
+      expect(result.content).toEqual([
+        { type: "text", text: "wiki_get requires a non-empty `lookup` path or id." },
+      ]);
+    }
   });
 
   it("normalizes extensionless shared memory lookups before reading", async () => {

--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -1785,6 +1785,30 @@ describe("getMemoryWikiPage", () => {
     );
   });
 
+  it("reports a clean error instead of crashing when lookup is missing or wrong-typed", async () => {
+    const { config } = await createQueryVault({
+      initialize: true,
+      config: { search: { backend: "shared", corpus: "memory" } },
+    });
+    const manager = createMemoryManager({
+      readResult: { path: "memory/notes.md", text: "durable notes", from: 1, lines: 1 },
+    });
+    getActiveMemorySearchManagerMock.mockResolvedValue({ manager });
+
+    const tool = createWikiGetTool(config, createAppConfig());
+
+    // Wrong parameter name (e.g. `path` instead of `lookup`) leaves lookup undefined.
+    // This used to throw "Cannot read properties of undefined (reading 'trim')".
+    const missing = await tool.execute("wiki-get-bad-param", {
+      path: "sources/example/note.md",
+    } as never);
+
+    expect(missing.details).toEqual({ found: false });
+    expect(missing.content).toEqual([
+      { type: "text", text: "wiki_get requires a non-empty `lookup` path or id." },
+    ]);
+  });
+
   it("normalizes extensionless shared memory lookups before reading", async () => {
     const { config } = await createQueryVault({
       initialize: true,

--- a/extensions/memory-wiki/src/tool.ts
+++ b/extensions/memory-wiki/src/tool.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { optionalFiniteNumberSchema } from "openclaw/plugin-sdk/channel-actions";
 import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
+import { asNonArrayRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { Type } from "typebox";
 import type { AnyAgentTool, OpenClawConfig } from "../api.js";
 import { applyMemoryWikiMutation, normalizeMemoryWikiMutationInput } from "./apply.js";
@@ -277,7 +278,7 @@ export function createWikiGetTool(
       "Read a wiki page by id or relative path, or fall back to the active memory corpus when shared search is enabled.",
     parameters: WikiGetSchema,
     execute: async (_toolCallId, rawParams) => {
-      const params = rawParams as {
+      const params = asNonArrayRecord(rawParams) as {
         lookup?: string;
         fromLine?: number;
         lineCount?: number;
@@ -287,12 +288,7 @@ export function createWikiGetTool(
       const lookup = typeof params.lookup === "string" ? params.lookup.trim() : "";
       if (!lookup) {
         return {
-          content: [
-            {
-              type: "text",
-              text: "wiki_get requires a non-empty `lookup` path or id.",
-            },
-          ],
+          content: [{ type: "text", text: "wiki_get requires a non-empty `lookup` path or id." }],
           details: { found: false },
         };
       }
@@ -312,7 +308,7 @@ export function createWikiGetTool(
       });
       if (!result) {
         return {
-          content: [{ type: "text", text: `Wiki page not found: ${params.lookup}` }],
+          content: [{ type: "text", text: `Wiki page not found: ${lookup}` }],
           details: { found: false },
         };
       }

--- a/extensions/memory-wiki/src/tool.ts
+++ b/extensions/memory-wiki/src/tool.ts
@@ -278,12 +278,24 @@ export function createWikiGetTool(
     parameters: WikiGetSchema,
     execute: async (_toolCallId, rawParams) => {
       const params = rawParams as {
-        lookup: string;
+        lookup?: string;
         fromLine?: number;
         lineCount?: number;
         backend?: ResolvedMemoryWikiConfig["search"]["backend"];
         corpus?: ResolvedMemoryWikiConfig["search"]["corpus"];
       };
+      const lookup = typeof params.lookup === "string" ? params.lookup.trim() : "";
+      if (!lookup) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "wiki_get requires a non-empty `lookup` path or id.",
+            },
+          ],
+          details: { found: false },
+        };
+      }
       await syncImportedSourcesIfNeeded(config, appConfig);
       const result = await getMemoryWikiPage({
         config,
@@ -292,7 +304,7 @@ export function createWikiGetTool(
         agentSessionKey: memoryContext.agentSessionKey,
         sandboxed: memoryContext.sandboxed,
         conversationRecall: memoryContext.conversationRecall,
-        lookup: params.lookup,
+        lookup,
         fromLine: params.fromLine,
         lineCount: params.lineCount,
         ...(params.backend ? { searchBackend: params.backend } : {}),


### PR DESCRIPTION
Closes #122548

## What Problem This Solves

`wiki_get` could receive malformed raw tool arguments even though its TypeBox schema requires `lookup`. A missing, blank, non-string, or `null` payload reached an unsafe type assertion and could crash before the tool returned an actionable result.

## Why This Change Was Made

The erased agent-tool contract accepts `unknown`, and the plugin dispatcher forwards those arguments to the tool implementation. The memory-wiki owner boundary assumed the payload was already an object with a string `lookup`; the query layer then called `.trim()` on that value.

This keeps query helpers on their canonical string-only contract and fixes the producer boundary instead:

- normalize raw arguments with the existing plugin SDK `asNonArrayRecord` helper;
- trim and validate `lookup` once in `wiki_get`;
- return `found: false` with an actionable message for malformed input;
- use the normalized lookup for page resolution and not-found output.

## User Impact

- Before: malformed `wiki_get` calls could fail with `Cannot read properties of null/undefined (reading 'lookup'/'trim')`.
- After: malformed calls return `wiki_get requires a non-empty \`lookup\` path or id.` with `found: false`; valid reads are unchanged.

## Evidence

- Red proof: the focused regression failed on the pre-fix branch with `TypeError: Cannot read properties of null (reading 'lookup')` at `extensions/memory-wiki/src/tool.ts`.
- Focused green: `node scripts/run-vitest.mjs extensions/memory-wiki/src/query.test.ts` -> 53/53 tests passed.
- Extension green: `node scripts/run-vitest.mjs extensions/memory-wiki` -> 42 files, 454 tests passed.
- Exact-base changed gate: `node scripts/check-changed.mjs -- extensions/memory-wiki/src/tool.ts extensions/memory-wiki/src/query.test.ts` passed on Blacksmith Testbox, including extension production/test typechecks, zero-warning lint, Plugin SDK and plugin-boundary checks, storage guards, and import-cycle checks.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/31667541013
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine codex --model gpt-5.6-sol --thinking high` -> clean, no accepted/actionable findings; patch judged correct at 0.99 confidence.

### Real Configured Runtime Proof

Ran the production `createWikiGetTool` path from exact head `d54baaf83816` against a disposable configured memory-wiki vault using the production SQLite plugin-state store, real vault initialization, and a real Markdown source page. No Vitest harness or mocked query/runtime dependency was used.

```json
{
  "configuredRuntime": {
    "vault": "<temporary-vault>",
    "stateStore": "SQLite",
    "searchBackend": "local",
    "searchCorpus": "wiki"
  },
  "malformedCall": null,
  "malformedResult": {
    "message": "wiki_get requires a non-empty `lookup` path or id.",
    "found": false
  },
  "validCall": {
    "lookup": "sources/runtime-proof.md"
  },
  "validResult": {
    "found": true,
    "corpus": "wiki",
    "path": "sources/runtime-proof.md",
    "title": "Runtime Proof",
    "kind": "source",
    "content": "This page proves wiki_get reads a configured filesystem-backed vault."
  }
}
```

## Review Surface

- Production: `+12/-4` (net `+8`) in `extensions/memory-wiki/src/tool.ts`.
- Tests: `+23/-0` in `extensions/memory-wiki/src/query.test.ts`.
- No config, SDK surface, protocol, storage, dependency, or feature change.
- The positive production delta is the owner-boundary validation and actionable tool result; it reuses the existing public plugin SDK record normalizer instead of adding a local guard.

## AI-Assisted

The contributor used AI assistance. A maintainer independently reproduced the null-input failure, rewrote the branch at the canonical plugin boundary, ran focused and extension-wide proof, completed the exact-base Testbox gate, and ran isolated autoreview.

pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaV1E1TlFBNTFTODdIM0FOVjA1REVRUgB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl8zODZGRjVCMzQxQTI2NzQzQjJDREEzMEY0RAB3cmtfMDFLWlZNSFQzS0JYNVNYMFhRV1pSWkg2SjUAc2VzXzAxS1pWTUhXV1JOUVI0QTVKQ1YyVEZYR1A2AGNhbG0td29ya3Nob3AtY2VkYXItaHgAb3BlbmNsYXcvb3BlbmNsYXcAADEyMjU0OQA3OTE3OTQxMmMyZTMyZGRjZWZiMDk0Nzc0MjFjZTBiYjJmZjVlMDgyMmM0N2YzYWUxYWU5NDkyYjNlMDBjOWNiAHNpZ25pbmctdjEAR3I1TUd0ZG51NTh4UkIyVWNPYzFFRWR6ejc3cDRnZ1lsLVZsXzA1Yl9zVVFNdkwtekgyVFFhSDJxa2hxdU5kYXNsTmw2cGpiLVVCQncxeDVjYTVLQUEAMjAyNi0wOC0xM1QwNDo0ODowMC43NDZaAA.D15rAtodSskgJe6JCekPPIM7_aMFzZr5ubZ13OUr2QALg2dj57KcTSvZmyXq6FCyis7dxlxUBXGhFweGUct3CA
