### PR TITLE
fix(camera): URL download preserves existing output on failure

### DIFF
--- a/src/cli/nodes-camera.test.ts
+++ b/src/cli/nodes-camera.test.ts
@@ -522,7 +522,7 @@ describe("nodes camera helpers", () => {
     expect(tracked.wasCanceled()).toBe(true);
   });
 
-  it("removes partially written file when url stream fails", async () => {
+  it("preserves an existing file when url stream fails", async () => {
     const stream = new ReadableStream<Uint8Array>({
       start(controller) {
         controller.enqueue(new TextEncoder().encode("partial"));
@@ -533,6 +533,10 @@ describe("nodes camera helpers", () => {
 
     await withCameraTempDir(async (dir) => {
       const out = path.join(dir, "broken.bin");
+      const sentinel = Buffer.from("existing-camera");
+      await fs.writeFile(out, sentinel);
+      await fs.chmod(out, 0o640);
+
       await expect(
         writeCameraPayloadToFile({
           filePath: out,
@@ -540,7 +544,40 @@ describe("nodes camera helpers", () => {
           expectedHost: "198.51.100.42",
         }),
       ).rejects.toThrow(/stream exploded/i);
-      await expectPathMissing(out);
+      await expect(fs.readFile(out)).resolves.toEqual(sentinel);
+      if (process.platform !== "win32") {
+        expect((await fs.stat(out)).mode & 0o777).toBe(0o640);
+      }
+      expect(await fs.readdir(dir)).toEqual(["broken.bin"]);
+    });
+  });
+
+  it("rejects a url stream that closes without data", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close();
+      },
+    });
+    stubFetchResponse(new Response(stream, { status: 200 }));
+
+    await withCameraTempDir(async (dir) => {
+      const out = path.join(dir, "empty.bin");
+      const sentinel = Buffer.from("existing-camera");
+      await fs.writeFile(out, sentinel);
+      await fs.chmod(out, 0o640);
+
+      await expect(
+        writeCameraPayloadToFile({
+          filePath: out,
+          payload: { url: "https://198.51.100.42/empty.bin" },
+          expectedHost: "198.51.100.42",
+        }),
+      ).rejects.toThrow(/empty download/i);
+      await expect(fs.readFile(out)).resolves.toEqual(sentinel);
+      if (process.platform !== "win32") {
+        expect((await fs.stat(out)).mode & 0o777).toBe(0o640);
+      }
+      expect(await fs.readdir(dir)).toEqual(["empty.bin"]);
     });
   });
 });

--- a/src/cli/nodes-camera.ts
+++ b/src/cli/nodes-camera.ts
@@ -195,39 +195,38 @@ async function writeUrlToFile(filePath: string, url: string, opts: { expectedHos
       throw new Error(`failed to download ${url}: empty response body`);
     }
 
-    const fileHandle = await fs.open(filePath, "w");
-    let thrown: unknown;
-    const reader = body.getReader();
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) {
-          break;
-        }
-        if (!value || value.byteLength === 0) {
-          continue;
-        }
-        bytes += value.byteLength;
-        if (bytes > MAX_CAMERA_URL_DOWNLOAD_BYTES) {
+    await publishOutputFileAtomically({
+      filePath,
+      writeTemp: async (tempPath) => {
+        const fileHandle = await fs.open(tempPath, "wx");
+        const reader = body.getReader();
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) {
+              break;
+            }
+            bytes += value.byteLength;
+            if (bytes > MAX_CAMERA_URL_DOWNLOAD_BYTES) {
+              await reader.cancel().catch(() => undefined);
+              throw new Error(
+                `writeUrlToFile: downloaded ${bytes} bytes, exceeds max ${MAX_CAMERA_URL_DOWNLOAD_BYTES}`,
+              );
+            }
+            await fileHandle.write(value);
+          }
+        } catch (err) {
           await reader.cancel().catch(() => undefined);
-          throw new Error(
-            `writeUrlToFile: downloaded ${bytes} bytes, exceeds max ${MAX_CAMERA_URL_DOWNLOAD_BYTES}`,
-          );
+          throw toErrorObject(err, "Non-Error thrown");
+        } finally {
+          reader.releaseLock();
+          await fileHandle.close();
         }
-        await fileHandle.write(value);
-      }
-    } catch (err) {
-      thrown = err;
-      await reader.cancel().catch(() => undefined);
-    } finally {
-      reader.releaseLock();
-      await fileHandle.close();
-    }
-
-    if (thrown) {
-      await fs.unlink(filePath).catch(() => {});
-      throw toErrorObject(thrown, "Non-Error thrown");
-    }
+        if (bytes === 0) {
+          throw new Error(`writeUrlToFile: empty download from ${url}`);
+        }
+      },
+    });
   } finally {
     await release();
   }


### PR DESCRIPTION
Closes #122539

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where URL-backed node camera captures could destroy an existing output file when the response stream failed after writing began. A non-null response body that closed without yielding any bytes was also reported as a successfully saved camera artifact.

## Why This Change Was Made

The URL download path opened the final destination directly with `"w"` and deleted it after a later stream failure. It now streams through the existing `publishOutputFileAtomically` owner used by the base64 media path, so an owned sibling staging file is published only after a complete, non-empty download; staging cleanup owns failures and the previous destination bytes and mode remain untouched.

The existing HTTPS, expected-host, redirect-host, HTTP status, content-length, streamed-size, cancellation, and guarded-response release behavior is unchanged.

## User Impact

Camera snap and clip URL downloads no longer replace or remove a previous valid output unless the complete new artifact has been written. Empty URL bodies now fail visibly instead of producing a false saved-file result.

## Evidence

- Pre-fix proof after rebasing: `node scripts/run-vitest.mjs src/cli/nodes-camera.test.ts` failed exactly 2/42 tests. The mid-stream regression observed `ENOENT` because the old writer deleted the pre-seeded destination; the zero-byte regression resolved successfully instead of rejecting.
- Post-fix focused proof: the same command passed 42/42 tests.
- The regressions pre-seed sentinel bytes and mode `0640`, then assert byte/mode preservation and no sibling staging residue for both a mid-stream failure and a zero-byte close.
- Hosted changed gate: Blacksmith Testbox lease `tbx_01kztg65yw2hk12e369n0ca3cd`, Actions run https://github.com/openclaw/openclaw/actions/runs/31576924940, exit 0. Core production/test typechecks, lint, formatting, dependency/boundary/media-helper guards, and import-cycle checks passed.
- Exact-head PR CI: https://github.com/openclaw/openclaw/actions/runs/31577612228 completed successfully for `dcdd8ad6d11ec64f4d8491e602e6a5d914a888b1`; 55 jobs passed, no jobs failed, and `openclaw/ci-gate` is green.
- Fresh Codex autoreview: branch mode against `origin/main`, TruffleHog clean, no accepted/actionable findings, confidence 0.98.
- Formatting and `git diff --check origin/main...HEAD` are clean.
- Production LOC: +30/-31 (net -1). Tests: +39/-2 (net +37).

Proof gap: the failure cases use deterministic mocked `ReadableStream` responses. No live camera or external network proof was run or needed for this owner-local stream/publication invariant.

AI-assisted: yes. The patch and tests were reviewed, reproduced pre-fix, and verified after repair.
