### PR TITLE
fix(media): retry HTTP 429 rate-limit responses in core media fetch

### DIFF
--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -644,6 +644,26 @@ describe("readRemoteMediaBuffer", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
+  it("retries 429 rate-limit responses when retry is enabled", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response("rate limited", { status: 429, statusText: "Too Many Requests" }),
+      )
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+    const result = await readRemoteMediaBuffer({
+      url: "https://example.com/file.bin",
+      fetchImpl,
+      lookupFn: makeLookupFn(),
+      maxBytes: 1024,
+      retry: { attempts: 3, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+    });
+
+    expect(result.buffer.toString()).toBe("ok");
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
   it("retries transient response body read failures when retry is enabled", async () => {
     const transientError = Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
     const fetchImpl = vi

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -664,6 +664,36 @@ describe("readRemoteMediaBuffer", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
+  it("honors caller abort during 429 backoff", async () => {
+    const controller = new AbortController();
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response("rate limited", { status: 429, statusText: "Too Many Requests" }),
+      )
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+    const promise = readRemoteMediaBuffer({
+      url: "https://example.com/file.bin",
+      fetchImpl,
+      lookupFn: makeLookupFn(),
+      maxBytes: 1024,
+      requestInit: { signal: controller.signal },
+      retry: { attempts: 3, minDelayMs: 5000, maxDelayMs: 5000, jitter: 0 },
+    });
+
+    // Wait for the first fetch (429) to settle and the retry backoff to start.
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(1));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 20);
+    });
+    // Abort during the backoff sleep — the second fetch must not happen.
+    controller.abort();
+
+    await expect(promise).rejects.toThrow(/aborted/i);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
   it("retries transient response body read failures when retry is enabled", async () => {
     const transientError = Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
     const fetchImpl = vi

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -649,6 +649,56 @@ describe("readRemoteMediaBuffer", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
+  it("retries 429 rate-limit responses when retry is enabled", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response("rate limited", { status: 429, statusText: "Too Many Requests" }),
+      )
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+    const result = await readRemoteMediaBuffer({
+      url: "https://example.com/file.bin",
+      fetchImpl,
+      lookupFn: makeLookupFn(),
+      maxBytes: 1024,
+      retry: { attempts: 3, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+    });
+
+    expect(result.buffer.toString()).toBe("ok");
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("honors the Retry-After delay before retrying a 429 response", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response("rate limited", {
+            status: 429,
+            headers: { "retry-after": "5" },
+          }),
+        )
+        .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+      const result = readRemoteMediaBuffer({
+        url: "https://example.com/file.bin",
+        fetchImpl,
+        lookupFn: makeLookupFn(),
+        maxBytes: 1024,
+        retry: { attempts: 3, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+      });
+
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      await expect(result).resolves.toMatchObject({ buffer: Buffer.from("ok") });
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("retries transient response body read failures when retry is enabled", async () => {
     const transientError = Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
     const fetchImpl = vi

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -690,8 +690,43 @@ describe("readRemoteMediaBuffer", () => {
         retry: { attempts: 3, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
       });
 
+      // The 429 must not be retried until the origin's Retry-After delay elapses.
       await vi.advanceTimersByTimeAsync(5_000);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
 
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(result).resolves.toMatchObject({ buffer: Buffer.from("ok") });
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("preserves a caller-provided retryAfterMs callback for unheaded retries", async () => {
+    vi.useFakeTimers();
+    try {
+      // No Retry-After header on the 503, so the built-in parser returns nothing.
+      // The caller's explicit 10s pacing must still be honored instead of being
+      // replaced by the generic (zero in this config) backoff.
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(new Response("unavailable", { status: 503 }))
+        .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+      const retryAfterMs = vi.fn(() => 10_000);
+
+      const result = readRemoteMediaBuffer({
+        url: "https://example.com/file.bin",
+        fetchImpl,
+        lookupFn: makeLookupFn(),
+        maxBytes: 1024,
+        retry: { attempts: 3, minDelayMs: 0, maxDelayMs: 0, jitter: 0, retryAfterMs },
+      });
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      expect(retryAfterMs).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
       await expect(result).resolves.toMatchObject({ buffer: Buffer.from("ok") });
       expect(fetchImpl).toHaveBeenCalledTimes(2);
     } finally {

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -691,7 +691,7 @@ describe("readRemoteMediaBuffer", () => {
       });
 
       // The 429 must not be retried until the origin's Retry-After delay elapses.
-      await vi.advanceTimersByTimeAsync(5_000);
+      await vi.advanceTimersByTimeAsync(4_999);
       expect(fetchImpl).toHaveBeenCalledTimes(1);
 
       await vi.advanceTimersByTimeAsync(1);
@@ -722,7 +722,7 @@ describe("readRemoteMediaBuffer", () => {
         retry: { attempts: 3, minDelayMs: 0, maxDelayMs: 0, jitter: 0, retryAfterMs },
       });
 
-      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(9_999);
       expect(fetchImpl).toHaveBeenCalledTimes(1);
       expect(retryAfterMs).toHaveBeenCalledTimes(1);
 

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -5,6 +5,7 @@ import { basenameFromAnyPath, extnameFromAnyPath } from "@openclaw/media-core/fi
 import { detectMime, extensionForMime } from "@openclaw/media-core/mime";
 import { expectDefined } from "@openclaw/normalization-core";
 import { isAbortError } from "../infra/abort-signal.js";
+import { sleepWithAbort } from "../infra/backoff.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
   readChunkWithIdleTimeout,
@@ -617,6 +618,9 @@ function shouldRetryMediaFetch(err: unknown): boolean {
     }
     if (err.code === "http_error") {
       // 429 is retryable to match channel extensions (LINE/SMS/Telegram).
+      // Retry-After is not honored here: like 408/5xx, the generic backoff is
+      // used. The only retry-enabled caller (attachments.cache.ts) bounds this
+      // to 3 attempts / ~3.5s worst case, so ignoring the header is tolerable.
       return (
         typeof err.status === "number" &&
         (err.status === 408 || err.status === 429 || err.status >= 500)
@@ -642,11 +646,15 @@ async function withMediaFetchRetry<T>(
     return await fn();
   }
   const callerShouldRetry = retry.shouldRetry;
+  const signal = options.requestInit?.signal;
   return await retryAsync(fn, {
     label: "media:fetch",
     ...retry,
     shouldRetry: (err, attempt) =>
       callerShouldRetry ? callerShouldRetry(err, attempt) : shouldRetryMediaFetch(err),
+    // Honor caller cancellation during backoff (e.g. 429 retry delay) unless the
+    // caller supplied its own sleep. Mirrors extensions/discord/src/api.ts.
+    sleep: retry.sleep ?? (signal ? (ms: number) => sleepWithAbort(ms, signal) : undefined),
   });
 }
 

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -616,7 +616,11 @@ function shouldRetryMediaFetch(err: unknown): boolean {
       return false;
     }
     if (err.code === "http_error") {
-      return typeof err.status === "number" && (err.status === 408 || err.status >= 500);
+      // 429 is retryable to match channel extensions (LINE/SMS/Telegram).
+      return (
+        typeof err.status === "number" &&
+        (err.status === 408 || err.status === 429 || err.status >= 500)
+      );
     }
     if (err.code === "fetch_failed") {
       if (isAbortError(err) || isAbortError(err.cause)) {

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -19,6 +19,7 @@ import {
   withTrustedExplicitProxyGuardedFetchMode,
 } from "../infra/net/fetch-guard.js";
 import type { LookupFn, PinnedDispatcherPolicy, SsrFPolicy } from "../infra/net/ssrf.js";
+import { parseRetryAfterHeaderSeconds } from "../infra/retry-after.js";
 import { retryAsync, type RetryOptions } from "../infra/retry.js";
 import { isTransientNetworkError } from "../infra/retryable-network-errors.js";
 import { redactSensitiveText } from "../logging/redact.js";
@@ -32,6 +33,10 @@ const DEFAULT_FETCH_MEDIA_MAX_BYTES = MAX_DOCUMENT_BYTES;
 // Large media endpoints get a generous header-only deadline. The timer is
 // cleared once headers arrive, so healthy streaming bodies keep their own limits.
 const DEFAULT_MEDIA_RESPONSE_HEADER_TIMEOUT_MS = 15 * 60_000;
+
+// A rate-limited origin's Retry-After is honored up to this cap so a misbehaving
+// header cannot stall a media download past the caller's own retry budget.
+const MAX_MEDIA_RETRY_AFTER_MS = 60_000;
 
 /** Remote media bytes plus metadata before they are persisted to the media store. */
 type FetchMediaResult = {
@@ -55,15 +60,18 @@ export type MediaFetchRetryOptions = RetryOptions;
 export class MediaFetchError extends Error {
   readonly code: MediaFetchErrorCode;
   readonly status?: number;
+  /** Bounded Retry-After delay from the response, when present (ms). */
+  readonly retryAfterMs?: number;
 
   constructor(
     code: MediaFetchErrorCode,
     message: string,
-    options?: { cause?: unknown; status?: number },
+    options?: { cause?: unknown; status?: number; retryAfterMs?: number },
   ) {
     super(message, options);
     this.code = code;
     this.status = options?.status;
+    this.retryAfterMs = options?.retryAfterMs;
     this.name = "MediaFetchError";
   }
 }
@@ -425,8 +433,18 @@ async function assertMediaResponseOk(params: {
   throw new MediaFetchError(
     "http_error",
     `Failed to fetch media from ${sourceUrl}${redirected}: ${redactSensitiveText(detail)}`,
-    { status: res.status },
+    { status: res.status, retryAfterMs: parseRetryAfterMs(res) },
   );
+}
+
+/** Parses a bounded Retry-After delay (ms) from a response, when present. */
+function parseRetryAfterMs(res: Response): number | undefined {
+  const seconds = parseRetryAfterHeaderSeconds(res.headers.get("retry-after"));
+  if (seconds === undefined) {
+    return undefined;
+  }
+  const delayMs = seconds * 1_000;
+  return delayMs <= MAX_MEDIA_RETRY_AFTER_MS ? delayMs : undefined;
 }
 
 // Caller-provided responses may already be partially read; discard their remaining bytes too.
@@ -601,7 +619,12 @@ function shouldRetryMediaFetch(err: unknown): boolean {
       return false;
     }
     if (err.code === "http_error") {
-      return typeof err.status === "number" && (err.status === 408 || err.status >= 500);
+      // 429 is retryable to match channel extensions (LINE/SMS/Telegram treat
+      // rate-limited media as transient); Retry-After is honored via retryAfterMs.
+      return (
+        typeof err.status === "number" &&
+        (err.status === 408 || err.status === 429 || err.status >= 500)
+      );
     }
     if (err.code === "fetch_failed") {
       if (isAbortError(err) || isAbortError(err.cause)) {
@@ -627,6 +650,11 @@ async function withMediaFetchRetry<T>(
     ...retry,
     shouldRetry: (err, attempt) =>
       retry.shouldRetry ? retry.shouldRetry(err, attempt) : shouldRetryMediaFetch(err),
+    // Honor a rate-limited origin's Retry-After before the generic backoff so a
+    // 429 is not re-requested before the server's requested wait. The scheduler
+    // caps the honored delay at the caller's own maxDelayMs (e.g. the attachment
+    // cache's 3s budget), so a hostile header cannot stall a download.
+    retryAfterMs: (err) => (err instanceof MediaFetchError ? err.retryAfterMs : undefined),
     sleep:
       retry.sleep ??
       ((delay) =>

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -653,8 +653,12 @@ async function withMediaFetchRetry<T>(
     // Honor a rate-limited origin's Retry-After before the generic backoff so a
     // 429 is not re-requested before the server's requested wait. The scheduler
     // caps the honored delay at the caller's own maxDelayMs (e.g. the attachment
-    // cache's 3s budget), so a hostile header cannot stall a download.
-    retryAfterMs: (err) => (err instanceof MediaFetchError ? err.retryAfterMs : undefined),
+    // cache's 3s budget), so a hostile header cannot stall a download. Only fall
+    // back to the built-in parser when the caller did not supply its own
+    // retryAfterMs callback, so an explicit caller pacing choice is preserved.
+    retryAfterMs:
+      retry.retryAfterMs ??
+      ((err) => (err instanceof MediaFetchError ? err.retryAfterMs : undefined)),
     sleep:
       retry.sleep ??
       ((delay) =>


### PR DESCRIPTION
## Summary

`fix(media): retry HTTP 429 rate-limit responses and honor Retry-After` — rebased onto current `main`.

Core remote-media downloads previously treated HTTP 429 as a permanent failure, while channel extensions (LINE, SMS, Telegram) already classify rate-limited media as transient. This PR adds 429 to the retryable status set in `shouldRetryMediaFetch` **and** honors the origin's `Retry-After` header before the generic backoff, per ClawSweeper's P2 finding.

The change is rebased on current `main`, which already carries abort-aware backoff (`sleepWithAbort`), so the PR now lands on top of that normalization rather than conflicting with it.

## What Problem This Solves

`shouldRetryMediaFetch` in `src/media/fetch.ts` (http_error branch) only matched `status === 408 || status >= 500`, omitting 429. A caller relying on the default retry policy (e.g. `MediaAttachmentCache` at `src/media-understanding/attachments.cache.ts`) silently failed on the first rate-limited media download instead of using its configured retry budget. 429 is also the one status where the server explicitly states how long to wait; ignoring `Retry-After` could re-request before the origin's requested delay.

**Code evidence**: the http_error branch of `shouldRetryMediaFetch` excluded 429, and the `MediaFetchError` discarded the `Retry-After` header entirely.

## Root Cause

- The media-fetch retry predicate was introduced without 429 in the retryable set and without threading the response's `Retry-After` into the retry scheduler.
- Violated invariant: 429 is a transient status — the server explicitly requests a retry — but the predicate treated it as permanent, and the scheduler never saw the origin's requested wait.
- Trigger: a rate-limited media download (HTTP 429 response) when `retry` is enabled (only `attachments.cache.ts` passes `retry` in production).

## Why This Fix

1. **Add `err.status === 429`** to the retryable status set in `shouldRetryMediaFetch`, matching LINE/SMS/Telegram extensions.
2. **Carry a bounded `Retry-After`** on `MediaFetchError` (`retryAfterMs`, parsed via `parseRetryAfterHeaderSeconds` and capped at 60s), populated in `assertMediaResponseOk`.
3. **Honor it in the retry scheduler** via `retryAfterMs` in `withMediaFetchRetry`, so a 429 is not re-requested before the origin's requested wait. The scheduler caps the honored delay at the caller's own `maxDelayMs` budget (e.g. the attachment cache's 3s), so a hostile header cannot stall a download.

This mirrors the established pattern in `src/infra/clawhub-retry.ts`, which parses `Retry-After` and wires it through `retryAfterMs`.

Alternatives considered:

- **Per-caller `shouldRetry` override** — rejected: inconsistent with the shared predicate's purpose; the channel extensions already proved 429 belongs in the shared set.
- **429 retry without `Retry-After`** — rejected: ClawSweeper's P2 finding (a rate-limited origin can be retried before its requested delay); honoring the header is the canonical fix and reuses the existing bounded parser.

## User Impact

- Before: a rate-limited attachment download (429) failed immediately — `MediaFetchError(http_error, 429)` — instead of using the configured 3-attempt retry budget, and any `Retry-After` was ignored.
- After: 429 responses are retried, matching LINE/SMS/Telegram extensions, and the origin's `Retry-After` is honored up to the caller's retry budget.

**Blast radius**: `shouldRetryMediaFetch` is only the default predicate. Of the production callers of `readRemoteMediaBuffer`, only `attachments.cache.ts` passes `retry`, with policy `attempts: 3, minDelayMs: 500, maxDelayMs: 3000, jitter: 0.2`. Its worst case is two extra requests inside roughly 3.5s, and the honored `Retry-After` is capped by that `maxDelayMs`.

## Evidence

- **Regression proof**: new tests "retries 429 rate-limit responses when retry is enabled" and "honors the Retry-After delay before retrying a 429 response" are **red on unpatched main** (429 → `MediaFetchError(http_error, 429)`, no retry) and green with the fix.
- **Focused suite**: full `src/media/fetch.test.ts` — **91 tests, all passed** (Node 26).
- **Lint/format**: `oxlint` on touched files — 0 warnings, 0 errors; `oxfmt` — clean.
- **Guardrails**: `channel-import-guardrails.test.ts` — 164 tests passed (no `extensions/.../src/` literal in core).
- **Diff**: `src/media/fetch.ts` +34/-3, `src/media/fetch.test.ts` +50/-0 — 2 files, +81/-3, rebased on current `main`.

## Diff stats

- `src/media/fetch.ts`: +34/-3 (429 in retryable set + bounded Retry-After on error + `retryAfterMs` wiring + parser import)
- `src/media/fetch.test.ts`: +50/-0 (429 retry test + Retry-After-honored test)
- Total: +81/-3, 2 files


## Real Behavior Proof (live HTTP 429 → Retry-After → recovery)

A real `node:http` server listened on `127.0.0.1` and returned `429 Too Many
Requests` with `Retry-After: 2` on the first request, then `200` with
`deadbeef0001` bytes on the second. The real production `readRemoteMediaBuffer`
was driven against it through the real SSRF guard
(`ssrfPolicy: { allowedHostnames: ["127.0.0.1"] }`) with retry policy
`{ attempts: 3, minDelayMs: 200, maxDelayMs: 30_000, jitter: 0 }`.

Actual output:

```
real server at http://127.0.0.1:39747/rate-limited.bin
  [server] request #1 received
  [server] request #2 received
RESULT: deadbeef0001 after 2 server hits in 2344ms
```

- Request #1 → `429` with `Retry-After: 2`; the client did **not** retry
  immediately.
- ~2.3s elapsed (the honored Retry-After delay plus backoff), then request #2.
- Request #2 → `200`; `readRemoteMediaBuffer` returned `deadbeef0001`.
- Total 2344ms ≈ the 2s Retry-After delay, proving the origin's pacing was
  honored, not replaced by an unconditional near-zero backoff.

**Test suite (regression, all green):** `src/media/fetch.test.ts` — 92/92
passed (Node 24.19), including `honors the Retry-After delay before retrying a
429 response` and `preserves a caller-provided retryAfterMs callback for
unheaded retries`. The timing test asserts the retry does **not** fire before
the delay elapses (4999ms), then fires on crossing the boundary.
