### PR TITLE
improve: speed up target registry tests

### DIFF
--- a/src/secrets/target-registry.test.ts
+++ b/src/secrets/target-registry.test.ts
@@ -1,24 +1,22 @@
-/** Tests secret target registry matching and docs coverage. */
-import { beforeAll, describe, expect, it } from "vitest";
+/** Tests core secret target registry queries without plugin discovery. */
+import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   buildTalkTestProviderConfig,
   TALK_TEST_PROVIDER_API_KEY_PATH,
   TALK_TEST_PROVIDER_ID,
 } from "../test-utils/talk-test-provider.js";
-import { getCoreSecretTargetRegistry } from "./target-registry-data.js";
 import {
-  discoverConfigSecretTargets,
   discoverConfigSecretTargetsByIds,
   resolveConfigSecretTargetByPath,
   resolveSecretPlanTargetByPathCore,
 } from "./target-registry.js";
 
-describe("secret target registry", () => {
-  beforeAll(() => {
-    resolveConfigSecretTargetByPath(["channels", "googlechat", "serviceAccount"]);
-  });
+vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
+  resolvePluginMetadataSnapshot: () => ({ plugins: [] }),
+}));
 
+describe("secret target registry", () => {
   it("supports filtered discovery by target ids", () => {
     const config = {
       ...buildTalkTestProviderConfig({ source: "env", provider: "default", id: "TALK_API_KEY" }),
@@ -35,12 +33,6 @@ describe("secret target registry", () => {
     expect(targets[0]?.entry?.id).toBe("talk.providers.*.apiKey");
     expect(targets[0]?.providerId).toBe(TALK_TEST_PROVIDER_ID);
     expect(targets[0]?.path).toBe(TALK_TEST_PROVIDER_API_KEY_PATH);
-  });
-
-  it("resolves config targets by exact path", () => {
-    const target = resolveConfigSecretTargetByPath(["channels", "googlechat", "serviceAccount"]);
-
-    expect(target?.entry?.id).toBe("channels.googlechat.serviceAccount");
   });
 
   it("resolves talk realtime provider api key targets", () => {
@@ -75,87 +67,5 @@ describe("secret target registry", () => {
     expect(configTarget?.entry.targetType).toBe("models.providers.apiKey");
     expect(configTarget?.providerId).toBe("openai");
     expect(authProfileTarget?.entry.targetType).toBe("auth-profiles.api_key.key");
-  });
-
-  it("derives bundled web provider api key target paths from plugin manifests", () => {
-    const coreTargetIds = new Set(getCoreSecretTargetRegistry().map((entry) => entry.id));
-    expect(coreTargetIds.has("plugins.entries.exa.config.webSearch.apiKey")).toBe(false);
-    expect(coreTargetIds.has("plugins.entries.firecrawl.config.webFetch.apiKey")).toBe(false);
-
-    const target = resolveConfigSecretTargetByPath([
-      "plugins",
-      "entries",
-      "exa",
-      "config",
-      "webSearch",
-      "apiKey",
-    ]);
-
-    expect(target?.entry?.id).toBe("plugins.entries.exa.config.webSearch.apiKey");
-
-    const fetchTarget = resolveConfigSecretTargetByPath([
-      "plugins",
-      "entries",
-      "firecrawl",
-      "config",
-      "webFetch",
-      "apiKey",
-    ]);
-    expect(fetchTarget?.entry?.id).toBe("plugins.entries.firecrawl.config.webFetch.apiKey");
-
-    const configuredTargets = discoverConfigSecretTargets({
-      plugins: {
-        entries: {
-          exa: {
-            config: {
-              webSearch: { apiKey: "configured-plugin-key" },
-            },
-          },
-        },
-      },
-    } as OpenClawConfig);
-    expect(configuredTargets.map((entry) => entry.entry.id)).toContain(
-      "plugins.entries.exa.config.webSearch.apiKey",
-    );
-  });
-
-  it("derives bundled plugin SecretInput contract target paths from plugin manifests", () => {
-    const coreTargetIds = new Set(getCoreSecretTargetRegistry().map((entry) => entry.id));
-    expect(coreTargetIds.has("plugins.entries.voice-call.config.twilio.authToken")).toBe(false);
-    expect(coreTargetIds.has("plugins.entries.codex.config.appServer.authToken")).toBe(false);
-
-    const target = resolveConfigSecretTargetByPath([
-      "plugins",
-      "entries",
-      "voice-call",
-      "config",
-      "tts",
-      "providers",
-      "elevenlabs",
-      "apiKey",
-    ]);
-
-    expect(target?.entry?.id).toBe("plugins.entries.voice-call.config.tts.providers.*.apiKey");
-
-    const codexAuthTarget = resolveConfigSecretTargetByPath([
-      "plugins",
-      "entries",
-      "codex",
-      "config",
-      "appServer",
-      "authToken",
-    ]);
-    expect(codexAuthTarget?.entry?.id).toBe("plugins.entries.codex.config.appServer.authToken");
-
-    const codexHeaderTarget = resolveConfigSecretTargetByPath([
-      "plugins",
-      "entries",
-      "codex",
-      "config",
-      "appServer",
-      "headers",
-      "x-codex-client-session-token",
-    ]);
-    expect(codexHeaderTarget?.entry?.id).toBe("plugins.entries.codex.config.appServer.headers.*");
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The target-registry query suite spent nearly all of its 45-second runtime discovering and loading the entire plugin tree for assertions already owned by focused metadata, contract, generated-docs, and command-runtime suites.

## Why This Change Was Made

The suite now isolates its four core query contracts with an empty plugin metadata snapshot. It deletes an artificial warm-up plus three duplicate integration tests: exact Google Chat lookup remains in the fast-path owner, plugin metadata composition remains in current-snapshot and generated-matrix tests, and real Codex, voice-call, Exa, and Firecrawl paths remain covered by their contract/runtime owners.

## User Impact

No product behavior changes. Contributors get substantially faster focused and CI test feedback without adding workers.

## Evidence

Same cold command before and after:

```text
/usr/bin/time -v node scripts/run-vitest.mjs \
  src/secrets/target-registry.test.ts --maxWorkers=1 --reporter=verbose

                         Before       After       Improvement
Wall time                 44.71s       7.60s      83.0% faster
Vitest duration            38.09s       1.09s      97.1% faster
Test phase                 36.16s       0.04s      99.9% faster
Maximum RSS              773684 KiB  236332 KiB   69.5% lower
Tests                       7 passed    4 passed   3 duplicates removed
```

Retained-owner validation:

- `target-registry.fast-path.test.ts`
- `target-registry-data.current-snapshot.test.ts`
- `target-registry.docs.test.ts`
- `runtime-config-collectors-plugins.bundled.test.ts`
- `runtime-command-secrets.test.ts`
- 24/24 tests passed across those five suites
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs -- src/secrets/target-registry.test.ts`: passed
- mandatory autoreview helper failed closed because its Codex executable is not installed; manual owner/overlap review found no blocking findings
