### PR TITLE
fix(ci): keep hosted gate verifier standalone

### DIFF
--- a/scripts/verify-pr-hosted-gates.mts
+++ b/scripts/verify-pr-hosted-gates.mts
@@ -2,7 +2,6 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { parseDateStringTimestampMs } from "@openclaw/normalization-core/number-coercion";
 import { isRecord, readStringField } from "@openclaw/normalization-core/record-coerce";
 import { minimatch } from "minimatch";
 import { parse } from "yaml";
@@ -289,7 +288,8 @@ function latestRun(runs: WorkflowRun[]) {
 }
 
 function runUpdatedAtMs(run: Pick<WorkflowRun, "updated_at"> | undefined) {
-  return parseDateStringTimestampMs(run?.updated_at) ?? null;
+  const value = Date.parse(run?.updated_at ?? "");
+  return Number.isFinite(value) ? value : null;
 }
 
 function isRecentRun(run: WorkflowRun | undefined, nowMs: number) {

--- a/test/scripts/verify-pr-hosted-gates.test.ts
+++ b/test/scripts/verify-pr-hosted-gates.test.ts
@@ -1,3 +1,7 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
 import {
@@ -170,6 +174,53 @@ function patchReuseOptions(
 }
 
 describe("verify-pr-hosted-gates", () => {
+  it("starts from an older target cwd without current normalization helpers", () => {
+    const targetRoot = mkdtempSync(join(tmpdir(), "openclaw-hosted-gates-old-cwd-"));
+    try {
+      const normalizationRoot = join(targetRoot, "packages/normalization-core/src");
+      mkdirSync(normalizationRoot, { recursive: true });
+      writeFileSync(
+        join(targetRoot, "tsconfig.json"),
+        JSON.stringify({
+          compilerOptions: {
+            baseUrl: ".",
+            paths: {
+              "@openclaw/normalization-core/*": ["packages/normalization-core/src/*"],
+            },
+          },
+        }),
+      );
+      writeFileSync(join(normalizationRoot, "number-coercion.ts"), "export const legacy = true;\n");
+      writeFileSync(
+        join(normalizationRoot, "record-coerce.ts"),
+        [
+          "export function isRecord(value: unknown): value is Record<string, unknown> {",
+          '  return typeof value === "object" && value !== null && !Array.isArray(value);',
+          "}",
+          "export function readStringField(record: Record<string, unknown>, key: string) {",
+          "  const value = record[key];",
+          '  return typeof value === "string" ? value : undefined;',
+          "}",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [join(process.cwd(), "scripts/verify-pr-hosted-gates.mjs"), "--older-cwd-startup-probe"],
+        {
+          cwd: targetRoot,
+          encoding: "utf8",
+        },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("Unknown option: --older-cwd-startup-probe");
+    } finally {
+      rmSync(targetRoot, { force: true, recursive: true });
+    }
+  });
+
   it("derives hosted-gate applicability from declared workflow path filters", () => {
     expect(notApplicableScheduledHostedWorkflows([".github/workflows/ci.yml"])).toEqual([]);
     expect(


### PR DESCRIPTION
Related: #113111
Regression from #122458 (`b080dd1e765a295a93087eca7e66bad00a983f4d`).

## What Problem This Solves

Fixes an issue where maintainers landing an older pull request could not run the current hosted-gate verifier because TSX resolved workspace aliases from the target pull request's working directory. The verifier imported a helper added on current `main`, so an older target checkout failed during module startup before hosted gates could be evaluated.

## Why This Change Was Made

Restores the verifier's bounded local `Date.parse` logic so the trusted current wrapper remains standalone across older target working directories. The regression test runs the current wrapper from a synthetic older checkout whose normalization package lacks the newer helper and verifies startup reaches CLI argument parsing.

This does not modify, rebase, or merge #113111.

## User Impact

Maintainers can use the landing tooling on older pull requests again without reinstalling or rebasing the target branch. There is no product runtime change.

## Evidence

- Red on current `main`: `node scripts/run-vitest.mjs test/scripts/verify-pr-hosted-gates.test.ts` failed the new subprocess test with `does not provide an export named 'parseDateStringTimestampMs'`.
- Green locally: the same focused suite passed 72/72.
- Blacksmith Testbox `tbx_01kztjb0y90hwhyed3c7wrk9y2`: changed checks passed, then the focused suite passed 72/72.
- Testbox Actions run: https://github.com/openclaw/openclaw/actions/runs/31579754632
- Max-P1 autoreview: `gpt-5.6-sol` at high reasoning, no accepted/actionable findings.
- Production/tooling LOC: 2 additions, 2 deletions (net zero). Tests: 51 additions.

Punchcard-Session: silver-valley-orchard-nq
