### PR TITLE
improve(cli): cover node daemon adapter behavior

### DIFF
--- a/src/cli/node-cli/daemon.test.ts
+++ b/src/cli/node-cli/daemon.test.ts
@@ -2,7 +2,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayServiceRuntime } from "../../daemon/service-runtime.js";
 import type { GatewayServiceCommandConfig } from "../../daemon/service-types.js";
-import { runNodeDaemonInstall, runNodeDaemonStatus } from "./daemon.js";
+import {
+  runNodeDaemonInstall,
+  runNodeDaemonRestart,
+  runNodeDaemonStart,
+  runNodeDaemonStatus,
+  runNodeDaemonStop,
+  runNodeDaemonUninstall,
+} from "./daemon.js";
 
 const mocks = vi.hoisted(() => {
   const service = {
@@ -31,6 +38,7 @@ const mocks = vi.hoisted(() => {
       environment: {},
       environmentValueSources: {},
     })),
+    failIfNixDaemonInstallMode: vi.fn(() => false),
     loadNodeHostConfig: vi.fn(),
     isSystemdUserServiceAvailable: vi.fn(async () => true),
     resolveSystemdUserServiceAccount: vi.fn(() => "pi"),
@@ -40,6 +48,10 @@ const mocks = vi.hoisted(() => {
         linger: "no",
       }),
     ),
+    runServiceRestart: vi.fn(),
+    runServiceStart: vi.fn(),
+    runServiceStop: vi.fn(),
+    runServiceUninstall: vi.fn(),
   };
 });
 
@@ -57,6 +69,13 @@ vi.mock("../../commands/node-daemon-install-helpers.js", () => ({
 
 vi.mock("../../node-host/config.js", () => ({
   loadNodeHostConfig: mocks.loadNodeHostConfig,
+}));
+
+vi.mock("../daemon-cli/lifecycle-core.js", () => ({
+  runServiceRestart: mocks.runServiceRestart,
+  runServiceStart: mocks.runServiceStart,
+  runServiceStop: mocks.runServiceStop,
+  runServiceUninstall: mocks.runServiceUninstall,
 }));
 
 vi.mock("../../daemon/runtime-hints.js", () => ({
@@ -104,7 +123,7 @@ vi.mock("../daemon-cli/shared.js", async () => {
     }),
     formatRuntimeStatus: (runtime: GatewayServiceRuntime | undefined) => runtime?.status ?? "",
     resolveRuntimeStatusColor: () => "",
-    failIfNixDaemonInstallMode: () => false,
+    failIfNixDaemonInstallMode: mocks.failIfNixDaemonInstallMode,
   };
 });
 
@@ -114,6 +133,7 @@ describe("runNodeDaemonInstall", () => {
     mocks.runtime.error.mockClear();
     mocks.runtime.writeJson.mockClear();
     mocks.runtime.exit.mockClear();
+    mocks.failIfNixDaemonInstallMode.mockReset().mockReturnValue(false);
     mocks.service.install.mockReset().mockResolvedValue(undefined);
     mocks.service.isLoaded.mockReset().mockResolvedValue(false);
     mocks.buildNodeInstallPlan.mockReset().mockResolvedValue({
@@ -203,6 +223,26 @@ describe("runNodeDaemonInstall", () => {
     expect(mocks.runtime.error).toHaveBeenCalledWith(
       expect.stringContaining("--no-tls cannot be combined with --tls-fingerprint"),
     );
+  });
+
+  it.each([
+    ["an invalid explicit port", { port: "abc" }, "Invalid --port"],
+    ["an unsupported runtime", { runtime: "deno" }, 'Invalid --runtime (use "node"'],
+  ])("rejects %s before building an install plan", async (_name, opts, error) => {
+    await runNodeDaemonInstall(opts);
+
+    expect(mocks.runtime.error).toHaveBeenCalledWith(expect.stringContaining(error));
+    expect(mocks.buildNodeInstallPlan).not.toHaveBeenCalled();
+    expect(mocks.service.install).not.toHaveBeenCalled();
+  });
+
+  it("does not build or install a service in Nix daemon mode", async () => {
+    mocks.failIfNixDaemonInstallMode.mockReturnValue(true);
+
+    await runNodeDaemonInstall({});
+
+    expect(mocks.buildNodeInstallPlan).not.toHaveBeenCalled();
+    expect(mocks.service.install).not.toHaveBeenCalled();
   });
 
   it("warns about disabled systemd lingering after a fresh install (text mode)", async () => {
@@ -309,6 +349,59 @@ describe("runNodeDaemonInstall", () => {
   });
 });
 
+describe("node daemon lifecycle adapters", () => {
+  beforeEach(() => {
+    mocks.runServiceRestart.mockReset();
+    mocks.runServiceStart.mockReset();
+    mocks.runServiceStop.mockReset();
+    mocks.runServiceUninstall.mockReset();
+  });
+
+  it.each([
+    {
+      name: "start",
+      action: runNodeDaemonStart,
+      delegate: mocks.runServiceStart,
+      expected: { renderStartHints: expect.any(Function) },
+    },
+    {
+      name: "stop",
+      action: runNodeDaemonStop,
+      delegate: mocks.runServiceStop,
+      expected: {},
+    },
+    {
+      name: "restart",
+      action: runNodeDaemonRestart,
+      delegate: mocks.runServiceRestart,
+      expected: { renderStartHints: expect.any(Function) },
+    },
+    {
+      name: "uninstall",
+      action: runNodeDaemonUninstall,
+      delegate: mocks.runServiceUninstall,
+      expected: {
+        stopBeforeUninstall: false,
+        assertNotLoadedAfterUninstall: false,
+      },
+    },
+  ])(
+    "delegates $name with node-specific service options",
+    async ({ action, delegate, expected }) => {
+      await action({ json: true });
+
+      expect(delegate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceNoun: "Node",
+          service: mocks.service,
+          opts: { json: true },
+          ...expected,
+        }),
+      );
+    },
+  );
+});
+
 describe("runNodeDaemonStatus", () => {
   function stdout(): string {
     return mocks.runtime.log.mock.calls.map(([line]) => line).join("\n");
@@ -351,6 +444,18 @@ describe("runNodeDaemonStatus", () => {
     });
     expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
     expect(mocks.runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("reports an unknown runtime when runtime inspection fails", async () => {
+    mocks.service.readRuntime.mockRejectedValue(new Error("permission denied"));
+
+    await runNodeDaemonStatus({ json: true });
+
+    expect(mocks.runtime.writeJson).toHaveBeenCalledWith({
+      service: expect.objectContaining({
+        runtime: { status: "unknown", detail: "Error: permission denied" },
+      }),
+    });
   });
 
   it("keeps missing service-unit status on stderr and prints recovery hints on stdout", async () => {

--- a/src/cli/node-cli/register.test.ts
+++ b/src/cli/node-cli/register.test.ts
@@ -61,12 +61,48 @@ describe("registerNodeCli", () => {
     daemonMocks.runNodeDaemonUninstall.mockClear();
   });
 
-  it("registers node start for the macOS app node service manager", async () => {
+  it.each([
+    ["status", daemonMocks.runNodeDaemonStatus],
+    ["uninstall", daemonMocks.runNodeDaemonUninstall],
+    ["stop", daemonMocks.runNodeDaemonStop],
+    ["start", daemonMocks.runNodeDaemonStart],
+    ["restart", daemonMocks.runNodeDaemonRestart],
+  ])("registers node %s and forwards --json", async (command, action) => {
     const program = createProgram();
 
-    await program.parseAsync(["node", "start", "--json"], { from: "user" });
+    await program.parseAsync(["node", command, "--json"], { from: "user" });
 
-    expect(daemonMocks.runNodeDaemonStart.mock.calls[0]?.[0]?.json).toBe(true);
+    expect(action.mock.calls[0]?.[0]?.json).toBe(true);
+  });
+
+  it("forwards node install options to the daemon adapter", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(
+      [
+        "node",
+        "install",
+        "--port",
+        "19000",
+        "--host",
+        "gateway.example",
+        "--runtime",
+        "node",
+        "--force",
+        "--json",
+      ],
+      { from: "user" },
+    );
+
+    expect(daemonMocks.runNodeDaemonInstall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        port: "19000",
+        host: "gateway.example",
+        runtime: "node",
+        force: true,
+        json: true,
+      }),
+    );
   });
 
   it("rejects an explicit invalid node run port", async () => {


### PR DESCRIPTION
Closes #83924

Replacement for #86450. The contributor branch cannot be edited by maintainers and now conflicts with newer node daemon coverage from #118430, so this carries forward only the still-distinct reachable cases.

Credit: xin zhuang (@1052326311), co-authored in commit `2c1ce4f464278dfbb29142a15d94bf9c65284ad2`.

Punchcard-Session: golden-valley-cedar-5x

## What Problem This Solves

The node CLI registration and daemon adapter boundaries still lacked focused coverage for install option forwarding, explicit install validation, Nix rejection, lifecycle delegation, and runtime-status inspection failures.

## Why This Change Was Made

This preserves the current `main` test harness and all linger coverage from #118430 while transplanting only the non-overlapping cases from #86450. Related assertions are parameterized, the runtime-forwarding case uses the supported `node` runtime, and no saved gateway port `0` case is carried forward.

## User Impact

No runtime behavior changes. Maintainers get regression coverage for existing node-service CLI behavior without changing production code, configuration, dependencies, documentation, or release metadata.

Production LOC: +0/-0. Tests: +146/-5.

## Evidence

- Blacksmith Testbox `tbx_01kztje3frhq15vmdfx4bj1dw2`: 81/81 focused tests passed across:
  - `src/cli/node-cli/daemon.test.ts`
  - `src/cli/node-cli/register.test.ts`
  - `src/commands/node-daemon-install-helpers.test.ts`
  - `src/cli/daemon-cli/lifecycle-core.test.ts`
- The same Testbox run passed the scoped changed gate for the two modified files, including formatting, core test typecheck, lint, dead-export checks, and repository guards.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/31579891898
- Local focused proof: 8/8 new daemon cases and 53/53 registration/helper/lifecycle tests passed.
- `git diff --check origin/main...HEAD` passed.
- P1 autoreview was clean with no accepted/actionable findings; TruffleHog was clean.
