### PR TITLE
improve: speed up doctor process tests

### DIFF
--- a/src/commands/doctor-config-preflight.process.test.ts
+++ b/src/commands/doctor-config-preflight.process.test.ts
@@ -1,11 +1,12 @@
 // Process regression for typed gateway startup-migration refusal and lease cleanup.
-import { spawnSync } from "node:child_process";
+import { execFile, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { pathToFileURL } from "node:url";
-import { afterEach, describe, expect, it } from "vitest";
+import { promisify } from "node:util";
+import { afterAll, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { hasActiveStartupMigrationLease } from "../infra/startup-migration-checkpoint.js";
@@ -14,14 +15,15 @@ const STARTUP_REFUSAL =
   "OpenClaw startup migrations did not complete cleanly; refusing to report the gateway ready.";
 const STARTUP_RECOVERY =
   'Run "openclaw doctor --fix" against the same state/config, then restart the gateway.';
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const tempDirs = useAutoCleanupTempDirTracker(afterAll);
+const execFileAsync = promisify(execFile);
 
 function runIsolatedModuleScript(
   env: NodeJS.ProcessEnv,
   script: string,
   options: { runtimeRoot?: string; timeoutMs?: number } = {},
 ) {
-  return spawnSync(
+  return execFileAsync(
     process.execPath,
     [
       ...(options.runtimeRoot ? ["--preserve-symlinks"] : []),
@@ -116,7 +118,7 @@ function seedPluginStateConflict(stateDir: string): void {
   }
 }
 
-describe("gateway startup-migration refusal", () => {
+describe.concurrent("gateway startup-migration refusal", () => {
   it("exits cleanly after reporting the refusal once and releasing its lease", async () => {
     const temporaryRoot = await fs.promises.mkdtemp(
       path.join(os.tmpdir(), "openclaw-startup-migration-exit-"),
@@ -225,10 +227,7 @@ describe("gateway startup-migration refusal", () => {
         runtimeRoot,
         timeoutMs: 60_000,
       });
-    const readResult = (result: ReturnType<typeof runIsolatedModuleScript>) => {
-      expect(result.error, `${result.stderr}\n${result.stdout}`).toBeUndefined();
-      expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(0);
-      expect(result.signal, `${result.stderr}\n${result.stdout}`).toBeNull();
+    const readResult = (result: Awaited<ReturnType<typeof runIsolatedModuleScript>>) => {
       const resultLine = result.stdout.split("\n").find((line) => line.startsWith("__RESULT__"));
       expect(resultLine, `${result.stderr}\n${result.stdout}`).toBeDefined();
       return JSON.parse(resultLine!.slice("__RESULT__".length)) as {
@@ -237,8 +236,8 @@ describe("gateway startup-migration refusal", () => {
       };
     };
 
-    const first = readResult(run());
-    const second = readResult(run());
+    const first = readResult(await run());
+    const second = readResult(await run());
 
     expect(first).toEqual({ activeLease: false, stateMigrationsImported: true });
     expect(second).toEqual({ activeLease: false, stateMigrationsImported: false });
@@ -306,7 +305,7 @@ describe("gateway startup-migration refusal", () => {
       import.meta.url,
     ).href;
     const prompterUrl = new URL("./doctor-prompter.ts", import.meta.url).href;
-    const result = runIsolatedModuleScript(
+    const result = await runIsolatedModuleScript(
       env,
       `
         const fs = await import("node:fs");
@@ -356,9 +355,6 @@ describe("gateway startup-migration refusal", () => {
       `,
       { timeoutMs: 60_000 },
     );
-    expect(result.error, `${result.stderr}\n${result.stdout}`).toBeUndefined();
-    expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(0);
-    expect(result.signal, `${result.stderr}\n${result.stdout}`).toBeNull();
     const resultLine = result.stdout.split("\n").find((line) => line.startsWith("__RESULT__"));
     expect(resultLine, `${result.stderr}\n${result.stdout}`).toBeDefined();
     expect(JSON.parse(resultLine!.slice("__RESULT__".length))).toEqual({


### PR DESCRIPTION
## What Problem This Solves

The three remaining doctor preflight process regressions each create isolated state/config roots, but the suite ran their expensive child processes serially. A focused run spent about 26 seconds in tests and 36 seconds wall time despite no shared fixtures.

## Why This Change Was Made

The suite now runs its independent process cases concurrently and uses asynchronous child execution for the successful module scripts. Temporary roots stay isolated and are cleaned after the concurrent suite settles.

A test-audit review retained all three tests because each protects a distinct credible boundary: CLI refusal/lease release, cross-process checkpoint reuse with an absent config, and metadata invalidation after manifest repair. This changes only test scheduling; no production code or CI worker/job count changes.

## User Impact

No product behavior changes. Contributors get faster focused and CI feedback from the doctor command shard without additional workers.

## Evidence

Same cold command before and after:

```text
/usr/bin/time -v node scripts/run-vitest.mjs \
  src/commands/doctor-config-preflight.process.test.ts \
  --maxWorkers=1 --reporter=verbose

                         Before       After       Improvement
Wall time                 36.39s      17.58s      51.7% faster
Vitest duration            29.81s      11.20s      62.4% faster
Test phase                 25.77s      10.09s      60.8% faster
Tests                       3 passed    3 passed   all retained
```

A second after run completed in 17.58s wall / 11.20s Vitest. The first after run completed in 19.81s wall / 13.30s Vitest.

Validation:

- focused suite: 3/3 passed twice
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs -- src/commands/doctor-config-preflight.process.test.ts`: passed
- `git diff --check`: passed
- test LOC: +11/-15; production LOC: +0/-0
- structured autoreview unavailable because no supported reviewer executable is installed; manual test-isolation, history, owner, and sibling coverage review found no blocking issue
