### PR TITLE
fix(codex): reuse completed OAuth rotations

### DIFF
--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -39,7 +39,7 @@ const computerUseServiceMocks = vi.hoisted(() => ({
 
 const providerRuntimeMocks = vi.hoisted(() => ({
   formatProviderAuthProfileApiKeyWithPlugin: vi.fn(),
-  refreshProviderOAuthCredentialWithPlugin: vi.fn(
+  refreshOAuthCredential: vi.fn(
     async (params: { provider?: string; context: { refresh: string } }) => {
       const refreshed = await oauthMocks.refreshOpenAICodexToken(params.context.refresh);
       return refreshed
@@ -84,7 +84,7 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => {
       }
       let oauthCredential = credential;
       if (params.forceRefresh || (oauthCredential.expires ?? 0) <= Date.now()) {
-        const refreshed = await providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin({
+        const refreshed = await providerRuntimeMocks.refreshOAuthCredential({
           provider: oauthCredential.provider,
           context: oauthCredential,
         });
@@ -109,7 +109,7 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => {
     refreshOAuthCredentialForRuntime: async (
       params: Parameters<typeof actual.refreshOAuthCredentialForRuntime>[0],
     ) => {
-      const refreshed = await providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin({
+      const refreshed = await providerRuntimeMocks.refreshOAuthCredential({
         provider: params.credential.provider,
         context: params.credential,
       });
@@ -133,7 +133,7 @@ afterEach(() => {
   clearRuntimeAuthProfileStoreSnapshots();
   oauthMocks.refreshOpenAICodexToken.mockReset();
   providerRuntimeMocks.formatProviderAuthProfileApiKeyWithPlugin.mockReset();
-  providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin.mockClear();
+  providerRuntimeMocks.refreshOAuthCredential.mockClear();
   computerUseServiceMocks.ensureCodexComputerUseServiceApp.mockClear();
 });
 
@@ -1198,7 +1198,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
-  it("keeps a prepared persisted store aligned across rotating refresh tokens", async () => {
+  it("force-refreshes unchanged prepared credentials and keeps rotations aligned", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
     oauthMocks.refreshOpenAICodexToken
       .mockResolvedValueOnce({
@@ -1221,6 +1221,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
           access: "initial-access",
           refresh: "initial-refresh",
           expires: Date.now() + 60_000,
+          accountId: "prepared-account",
         },
       });
       const authProfileStore = loadAuthProfileStoreForSecretsRuntime(agentDir);
@@ -1229,11 +1230,13 @@ describe("bridgeCodexAppServerStartOptions", () => {
         agentDir,
         authProfileId: "openai:work",
         authProfileStore,
+        previousAccountId: "prepared-account",
       });
       await refreshCodexAppServerAuthTokens({
         agentDir,
         authProfileId: "openai:work",
         authProfileStore,
+        previousAccountId: "prepared-account",
       });
 
       expect(oauthMocks.refreshOpenAICodexToken.mock.calls).toEqual([
@@ -1244,6 +1247,163 @@ describe("bridgeCodexAppServerStartOptions", () => {
         access: "second-rotated-access",
         refresh: "second-rotated-refresh",
       });
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("force-refreshes after metadata-only persisted changes", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const expires = Date.now() + 10 * 60_000;
+    oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
+      access: "refreshed-access",
+      refresh: "refreshed-refresh",
+      expires: Date.now() + 20 * 60_000,
+      accountId: "prepared-account",
+    });
+    try {
+      const credential = {
+        type: "oauth" as const,
+        provider: "openai",
+        access: "initial-access",
+        refresh: "initial-refresh",
+        expires,
+        accountId: "prepared-account",
+      };
+      upsertAuthProfile({ agentDir, profileId: "openai:work", credential });
+      const authProfileStore = loadAuthProfileStoreForSecretsRuntime(agentDir);
+      upsertAuthProfile({
+        agentDir,
+        profileId: "openai:work",
+        credential: { ...credential, rateLimitTier: "updated-tier" },
+      });
+
+      await expect(
+        refreshCodexAppServerAuthTokens({
+          agentDir,
+          authProfileId: "openai:work",
+          authProfileStore,
+          previousAccountId: "prepared-account",
+        }),
+      ).resolves.toMatchObject({
+        accessToken: "refreshed-access",
+        chatgptAccountId: "prepared-account",
+      });
+      expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledWith("initial-refresh");
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    {
+      name: "access-only",
+      rotation: { access: "late-access" },
+      expectedAccess: "late-access",
+    },
+    {
+      name: "refresh-only",
+      rotation: { refresh: "late-refresh" },
+      expectedAccess: "initial-access",
+    },
+    {
+      name: "expiry-only",
+      rotation: { expires: Date.now() + 20 * 60_000 },
+      expectedAccess: "initial-access",
+    },
+  ])("reuses a late persisted same-account $name rotation", async (scenario) => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    try {
+      const credential = {
+        type: "oauth" as const,
+        provider: "openai",
+        access: "initial-access",
+        refresh: "initial-refresh",
+        expires: Date.now() + 10 * 60_000,
+        accountId: "prepared-account",
+      };
+      upsertAuthProfile({ agentDir, profileId: "openai:work", credential });
+      const authProfileStore = loadAuthProfileStoreForSecretsRuntime(agentDir);
+      upsertAuthProfile({
+        agentDir,
+        profileId: "openai:work",
+        credential: { ...credential, ...scenario.rotation },
+      });
+
+      await expect(
+        refreshCodexAppServerAuthTokens({
+          agentDir,
+          authProfileId: "openai:work",
+          authProfileStore,
+          previousAccountId: "prepared-account",
+        }),
+      ).resolves.toMatchObject({
+        accessToken: scenario.expectedAccess,
+        chatgptAccountId: "prepared-account",
+      });
+      expect(oauthMocks.refreshOpenAICodexToken).not.toHaveBeenCalled();
+      expect(authProfileStore.profiles["openai:work"]).toMatchObject(scenario.rotation);
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    {
+      name: "different-account",
+      accountId: "different-account",
+      expires: () => Date.now() + 10 * 60_000,
+      expectedRefresh: "initial-refresh",
+    },
+    {
+      name: "expired",
+      accountId: "prepared-account",
+      expires: () => Date.now() - 60_000,
+      expectedRefresh: "persisted-refresh",
+    },
+  ])("does not reuse a $name persisted credential", async (scenario) => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
+      access: "refreshed-access",
+      refresh: "refreshed-refresh",
+      expires: Date.now() + 60_000,
+      accountId: "prepared-account",
+    });
+    try {
+      upsertAuthProfile({
+        agentDir,
+        profileId: "openai:work",
+        credential: {
+          type: "oauth",
+          provider: "openai",
+          access: "initial-access",
+          refresh: "initial-refresh",
+          expires: Date.now() + 60_000,
+          accountId: "prepared-account",
+        },
+      });
+      const authProfileStore = loadAuthProfileStoreForSecretsRuntime(agentDir);
+      upsertAuthProfile({
+        agentDir,
+        profileId: "openai:work",
+        credential: {
+          type: "oauth",
+          provider: "openai",
+          access: "persisted-access",
+          refresh: "persisted-refresh",
+          expires: scenario.expires(),
+          accountId: scenario.accountId,
+        },
+      });
+
+      await refreshCodexAppServerAuthTokens({
+        agentDir,
+        authProfileId: "openai:work",
+        authProfileStore,
+        previousAccountId: "prepared-account",
+      });
+
+      expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledWith(scenario.expectedRefresh);
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
     }
@@ -2928,9 +3088,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
           'Codex app-server auth profile "openai:work" must use the canonical OpenAI auth provider; run "openclaw doctor --fix" to migrate legacy provider IDs.',
         );
         expect(oauthMocks.refreshOpenAICodexToken).not.toHaveBeenCalled();
-        expect(
-          providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin,
-        ).not.toHaveBeenCalled();
+        expect(providerRuntimeMocks.refreshOAuthCredential).not.toHaveBeenCalled();
       } finally {
         await fs.rm(agentDir, { recursive: true, force: true });
       }

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -21,7 +21,7 @@ import {
   type AuthProfileStore,
   type OAuthCredential,
 } from "openclaw/plugin-sdk/agent-runtime";
-import { hasUsableOAuthCredential } from "openclaw/plugin-sdk/provider-auth";
+import * as providerAuth from "openclaw/plugin-sdk/provider-auth";
 import { readSecretFile } from "openclaw/plugin-sdk/secret-file";
 import {
   resolveCodexAppServerHomeDir,
@@ -700,6 +700,7 @@ export async function refreshCodexAppServerAuthTokens(params: {
   authProfileId?: string;
   authProfileStore?: AuthProfileStore;
   config?: AuthProfileOrderConfig;
+  previousAccountId?: string;
 }): Promise<CodexChatgptAuthTokensRefreshResponse> {
   const loginParams = await resolveCodexAppServerAuthProfileLoginParamsInternal({
     ...params,
@@ -721,6 +722,7 @@ async function resolveCodexAppServerAuthProfileLoginParamsInternal(params: {
   authProfileStore?: AuthProfileStore;
   forceOAuthRefresh?: boolean;
   config?: AuthProfileOrderConfig;
+  previousAccountId?: string;
 }): Promise<CodexLoginAccountParams | undefined> {
   const store = resolveCodexAppServerAuthProfileStore({
     agentDir: params.agentDir,
@@ -751,6 +753,7 @@ async function resolveCodexAppServerAuthProfileLoginParamsInternal(params: {
     preferStoreCredential: Boolean(params.authProfileStore?.profiles[profileId]),
     forceOAuthRefresh: params.forceOAuthRefresh === true,
     config: params.config,
+    previousAccountId: params.previousAccountId,
   });
   if (!loginParams) {
     throw new CodexAppServerAuthProfileUnavailableError(
@@ -841,6 +844,7 @@ async function resolveLoginParamsForCredential(
     preferStoreCredential: boolean;
     forceOAuthRefresh: boolean;
     config?: AuthProfileOrderConfig;
+    previousAccountId?: string;
   },
 ): Promise<CodexLoginAccountParams | undefined> {
   // Runtime honors the persisted auth profile type. Shape-based remediation
@@ -879,6 +883,7 @@ async function resolveLoginParamsForCredential(
     preferStoreCredential: params.preferStoreCredential,
     forceRefresh: params.forceOAuthRefresh,
     config: params.config,
+    previousAccountId: params.previousAccountId,
   });
   const accessToken = resolvedCredential.access?.trim();
   return accessToken
@@ -895,6 +900,7 @@ async function resolveOAuthCredentialForCodexAppServer(
     preferStoreCredential: boolean;
     forceRefresh: boolean;
     config?: AuthProfileOrderConfig;
+    previousAccountId?: string;
   },
 ): Promise<OAuthCredential> {
   const ownerAgentDir = resolvePersistedAuthProfileOwnerAgentDir({
@@ -913,6 +919,7 @@ async function resolveOAuthCredentialForCodexAppServer(
       persistedCredential,
       suppliedCredential: credential,
       config: params.config,
+      previousAccountId: params.previousAccountId,
     });
   const store = useScopedCredential
     ? params.store
@@ -932,6 +939,11 @@ async function resolveOAuthCredentialForCodexAppServer(
     ownerCredential?.type === "oauth" && isCodexAppServerAuthProvider(ownerCredential.provider)
       ? ownerCredential
       : undefined;
+  const reusePersistedCredential =
+    params.forceRefresh &&
+    persistedOAuthCredential !== undefined &&
+    providerAuth.hasOAuthTokenMaterialChanged(persistedOAuthCredential, credential) &&
+    providerAuth.hasUsableOAuthCredential(persistedOAuthCredential);
   if (useScopedCredential && overlaidOAuthCredential) {
     return await resolveScopedOAuthCredential({
       store,
@@ -954,7 +966,8 @@ async function resolveOAuthCredentialForCodexAppServer(
     store,
     profileId,
     agentDir: ownerAgentDir,
-    forceRefresh: params.forceRefresh && Boolean(persistedOAuthCredential),
+    forceRefresh:
+      params.forceRefresh && Boolean(persistedOAuthCredential) && !reusePersistedCredential,
   });
   const refreshed = useScopedCredential
     ? undefined
@@ -983,6 +996,7 @@ function shouldUseScopedOAuthCredential(params: {
   persistedCredential: AuthProfileCredential | undefined;
   suppliedCredential: OAuthCredential;
   config?: AuthProfileOrderConfig;
+  previousAccountId?: string;
 }): boolean {
   if (!params.store.runtimePersistedProfileIds?.includes(params.profileId)) {
     return true;
@@ -999,13 +1013,17 @@ function shouldUseScopedOAuthCredential(params: {
   }
   return (
     !isDeepStrictEqual(persisted, params.suppliedCredential) &&
-    !hasMatchingOAuthIdentity(persisted, params.suppliedCredential)
+    !hasMatchingOAuthIdentity(persisted, params.suppliedCredential, params.previousAccountId)
   );
 }
 
-function hasMatchingOAuthIdentity(persisted: OAuthCredential, supplied: OAuthCredential): boolean {
+function hasMatchingOAuthIdentity(
+  persisted: OAuthCredential,
+  supplied: OAuthCredential,
+  previousAccountId?: string,
+): boolean {
   const persistedAccountId = persisted.accountId?.trim();
-  const suppliedAccountId = supplied.accountId?.trim();
+  const suppliedAccountId = previousAccountId?.trim() || supplied.accountId?.trim();
   if (persistedAccountId && suppliedAccountId) {
     return persistedAccountId === suppliedAccountId;
   }
@@ -1024,7 +1042,7 @@ async function resolveScopedOAuthCredential(params: {
   if (existingRefresh) {
     return await existingRefresh;
   }
-  if (!params.forceRefresh && hasUsableOAuthCredential(params.credential)) {
+  if (!params.forceRefresh && providerAuth.hasUsableOAuthCredential(params.credential)) {
     return params.credential;
   }
 
@@ -1033,7 +1051,7 @@ async function resolveScopedOAuthCredential(params: {
   const refresh = (async () => {
     const current = params.store.profiles[params.profileId];
     const credential = current?.type === "oauth" ? current : params.credential;
-    if (!params.forceRefresh && hasUsableOAuthCredential(credential)) {
+    if (!params.forceRefresh && providerAuth.hasUsableOAuthCredential(credential)) {
       return credential;
     }
     const refreshed = await refreshOAuthCredentialForRuntime({ credential });

--- a/extensions/codex/src/app-server/client-runtime.test.ts
+++ b/extensions/codex/src/app-server/client-runtime.test.ts
@@ -72,12 +72,15 @@ describe("Codex app-server client runtime", () => {
     harness.send({
       id: "refresh-1",
       method: "account/chatgptAuthTokens/refresh",
-      params: { reason: "expired" },
+      params: { reason: "expired", previousAccountId: "previous-account" },
     });
 
     await vi.waitFor(() => expect(mocks.mergeRateLimitUpdate).toHaveBeenCalledTimes(1));
     await vi.waitFor(() => expect(mocks.refreshAuth).toHaveBeenCalledTimes(1));
-    expect(mocks.refreshAuth).toHaveBeenCalledWith(updatedContext);
+    expect(mocks.refreshAuth).toHaveBeenCalledWith({
+      ...updatedContext,
+      previousAccountId: "previous-account",
+    });
     expect(mocks.mergeRateLimitUpdate).toHaveBeenCalledWith(harness.client, {
       rateLimits: { primary: { usedPercent: 12 } },
     });

--- a/extensions/codex/src/app-server/client-runtime.ts
+++ b/extensions/codex/src/app-server/client-runtime.ts
@@ -111,6 +111,7 @@ export function ensureCodexAppServerClientRuntime(
         ? { authProfileStore: runtime.context.authProfileStore }
         : {}),
       config: runtime.context.config,
+      previousAccountId: (request.params as { previousAccountId?: string })?.previousAccountId,
     })) as unknown as JsonValue;
   });
   client.addNotificationHandler((notification) => {

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -1017,6 +1017,7 @@ describe("shared Codex app-server client", () => {
       authProfileId: "openai:scoped",
       authProfileStore: preparedAuthProfileStore,
       config: undefined,
+      previousAccountId: "scoped-account",
     });
     expect(JSON.parse(harness.writes.at(-1) ?? "{}")).toEqual({
       id: "refresh-1",
@@ -1087,6 +1088,7 @@ describe("shared Codex app-server client", () => {
       authProfileId: "openai:scoped",
       authProfileStore,
       config: undefined,
+      previousAccountId: "scoped-account",
     });
   });
 
@@ -1288,6 +1290,7 @@ describe("shared Codex app-server client", () => {
       agentDir: "/tmp/openclaw-persisted-agent",
       authProfileId: "openai:persisted",
       config: undefined,
+      previousAccountId: "persisted-account",
     });
     expect(JSON.parse(harness.writes.at(-1) ?? "{}")).toEqual({
       id: "refresh-persisted",


### PR DESCRIPTION
Related: #89278

Depends on https://github.com/openclaw/openclaw/pull/121764.

## What Problem This Solves

Fixes an issue where Codex could request another OAuth refresh after a caller deadline even though the prior same-account refresh had completed and persisted a usable token rotation.

## Why This Change Was Made

The Codex app-server auth bridge now forwards `previousAccountId`, rereads the authoritative persisted credential before forced refresh, and reuses it only when usable access/refresh/expiry material changed for the same canonical provider and account.

The architectural owner is the Codex bridge's forced-refresh reuse decision. It imports the shared Plugin SDK token-material comparator for rotation detection while retaining deep equality for full-store compare-and-swap ownership. Metadata-only changes, account mismatches, expired credentials, missing credentials, and provider mismatches cannot bypass refresh.

## User Impact

A late successful OAuth rotation can satisfy the next Codex callback for the same account without duplicate provider work. Stale token material and credentials from another account remain fail-closed.

## Evidence

- Base: `stack/oauth-provider-refresh-hooks` at `1b8eb8ce9f295f7212d936f2af1fbaa70fb9008c`
- Exact head: `74320de10bec34a1a14b0f83db5b1aedb58d2559`
- Tree: `9f7a0a6b1779119b28a5c961431b981acac34f18`
- Full diff SHA-256: `82788ea5f82fbae8115771800cb05819a66139779c6310906d529b7c99f1dd97`
- Stable patch ID: `3b46320093c408a13e44d6c68787e777ffee2f80`
- Commit: signed, includes `Punchcard-Session: golden-meadow-cedar-dv`, and was attested by the execution session.
- Production LOC: `+26/-7` (net `+19`)
- Test LOC: `+174/-10` (net `+164`)
- Exact-stack focused proof: `673` tests passed across OAuth ownership, CAS, `AuthStorage`, provider hooks, lazy loading, and the Codex bridge.
- Final-stack static proof: SDK API generation/check, surface (`337` entrypoints / `7,800` exports; public `152` / `4,879`), export sync, scoped format, Oxlint, diff, and privacy checks passed.
- Full proof on the semantically equivalent pre-final-main stack: non-sparse `pnpm check:test-types` and `pnpm build` passed; trusted changed-surface run https://github.com/openclaw/openclaw/actions/runs/31615859746 passed.
- Final delegated Testbox allocation https://github.com/openclaw/openclaw/actions/runs/31621343194 completed the changed-surface wrapper with exit `0`, including extension typecheck/lint, SDK API, boundary, database-first, and import-cycle guards. The workflow `headSha` is the contemporaneous `main`, not this PR head, and the backing Actions lifecycle is `cancelled` after external Testbox cleanup; the operator-captured wrapper exit is the proof source.

The regressions cover metadata-only forced refresh, access-only/refresh-only/expiry-only rotations, account mismatch with and without a prepared store, expired credentials, canonical provider matching, and `previousAccountId` propagation.

Direct Codex contract check: `openai/codex@4ef836f883c38ba6d39e6920f335ce6452b7de33` defines the 10-second external callback deadline and previous-account forwarding in `codex-rs/app-server/src/external_auth.rs:18,33-45`; the request shape is in `codex-rs/app-server-protocol/src/protocol/v2/account.rs:266-275`, and optional refresh-token rotation is modeled in `codex-rs/login/src/auth/manager.rs:1515-1521,1647-1652`.

The first Codex callback can still time out after 10 seconds; a completed rotation may persist and be reused by the next same-account callback. Realtime/GPT-Live remains Platform API-key authenticated. This PR does not enable native GPT-Live OAuth.

Punchcard-Session: golden-meadow-cedar-dv
