### PR TITLE
fix(memory-wiki): lint failure preserves previous report

### DIFF
--- a/extensions/memory-wiki/src/lint.test.ts
+++ b/extensions/memory-wiki/src/lint.test.ts
@@ -1,7 +1,8 @@
 // Memory Wiki tests cover lint plugin behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { replaceFileAtomic } from "openclaw/plugin-sdk/security-runtime";
+import { describe, expect, it, vi } from "vitest";
 import { lintMemoryWikiVault } from "./lint.js";
 import {
   renderWikiMarkdown,
@@ -11,6 +12,14 @@ import {
 } from "./markdown.js";
 import { writeMemoryWikiSourceSyncState } from "./source-sync-state.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
+
+vi.mock("openclaw/plugin-sdk/security-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/security-runtime")>();
+  return {
+    ...actual,
+    replaceFileAtomic: vi.fn(actual.replaceFileAtomic),
+  };
+});
 
 const { createVault } = createMemoryWikiTestHarness();
 
@@ -704,6 +713,52 @@ describe("lintMemoryWikiVault", () => {
     await expect(fs.readFile(result.reportPath, "utf8")).resolves.toContain(
       "Frontmatter failed to parse: Unexpected scalar",
     );
+  });
+
+  it("keeps the previous lint report when atomic publication fails", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-atomic-report-",
+    });
+    const reportsDir = path.join(rootDir, "reports");
+    const reportPath = path.join(reportsDir, "lint.md");
+    await fs.mkdir(reportsDir, { recursive: true });
+    const previousReport = renderWikiMarkdown({
+      frontmatter: {
+        pageType: "report",
+        id: "report.lint",
+        title: "Lint Report",
+        status: "active",
+      },
+      body: "# Lint Report\n\nPrevious valid lint report.\n",
+    });
+    await fs.writeFile(reportPath, previousReport, "utf8");
+    await fs.chmod(reportPath, 0o640);
+    const previousBytes = await fs.readFile(reportPath);
+    const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/security-runtime")>(
+      "openclaw/plugin-sdk/security-runtime",
+    );
+    const publicationError = Object.assign(new Error("injected lint report publication failure"), {
+      code: "EIO",
+    });
+    vi.mocked(replaceFileAtomic).mockImplementationOnce((options) =>
+      actual.replaceFileAtomic({
+        ...options,
+        beforeRename: async ({ tempPath }) => {
+          await fs.writeFile(tempPath, "partial lint report", "utf8");
+          throw publicationError;
+        },
+      }),
+    );
+
+    await expect(lintMemoryWikiVault(config)).rejects.toBe(publicationError);
+    await expect(fs.readFile(reportPath)).resolves.toEqual(previousBytes);
+    if (process.platform !== "win32") {
+      expect((await fs.stat(reportPath)).mode & 0o777).toBe(0o640);
+    }
+    const lintPublicationFiles = (await fs.readdir(reportsDir)).filter(
+      (entry) => entry === "lint.md" || entry.startsWith("lint.md.lint-report."),
+    );
+    expect(lintPublicationFiles).toEqual(["lint.md"]);
   });
 
   it.each([

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -5,6 +5,7 @@ import {
   replaceManagedMarkdownBlock,
   withTrailingNewline,
 } from "openclaw/plugin-sdk/memory-host-markdown";
+import { replaceFileAtomic } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   assessPageFreshness,
@@ -476,6 +477,9 @@ function buildLintReportBody(issues: MemoryWikiLintIssue[]): string {
 
 async function writeLintReport(rootDir: string, issues: MemoryWikiLintIssue[]): Promise<string> {
   const reportPath = path.join(rootDir, "reports", "lint.md");
+  const directoryPath = path.dirname(reportPath);
+  await fs.mkdir(directoryPath, { recursive: true });
+  const dirMode = (await fs.stat(directoryPath)).mode & 0o7777;
   const original = await fs.readFile(reportPath, "utf8").catch(() =>
     renderWikiMarkdown({
       frontmatter: {
@@ -497,7 +501,17 @@ async function writeLintReport(rootDir: string, issues: MemoryWikiLintIssue[]): 
     endMarker: "<!-- openclaw:wiki:lint:end -->",
     body: buildLintReportBody(issues),
   });
-  await fs.writeFile(reportPath, withTrailingNewline(updated), "utf8");
+  await replaceFileAtomic({
+    filePath: reportPath,
+    content: withTrailingNewline(updated),
+    dirMode,
+    mode: 0o600,
+    preserveExistingMode: true,
+    tempPrefix: `${path.basename(reportPath)}.lint-report`,
+    syncTempFile: true,
+    syncParentDir: true,
+    throwOnCleanupError: true,
+  });
   return reportPath;
 }
 


### PR DESCRIPTION
Closes #122558

## What Problem This Solves

Fixes an issue where Memory Wiki operators rerunning lint could lose or truncate the previous valid `reports/lint.md` when report publication failed after a direct final-path write began.

## Why This Change Was Made

The Memory Wiki lint producer now publishes the managed report through the existing public Plugin SDK atomic replacement owner. It preserves an existing report mode, uses `0600` for a new report, retains the reports directory mode, synchronizes the staged file and parent directory, scopes staging names to the lint report, and surfaces cleanup failures.

## User Impact

An interrupted or failed lint report publication leaves the last valid report intact instead of exposing partial Markdown. Successful lint output and its CLI, Gateway, and tool result shape remain unchanged.

## Evidence

- Pre-fix regression proof: with only production reverted to the direct writer, `node scripts/run-vitest.mjs extensions/memory-wiki/src/lint.test.ts` failed 1 of 15 tests. The new regression resolved instead of rejecting because the old path bypassed the injected atomic `EIO`.
- Post-fix focused proof: the same command passed all 15 tests.
- Hosted changed gate: `node scripts/check-changed.mjs -- extensions/memory-wiki/src/lint.ts extensions/memory-wiki/src/lint.test.ts` passed on Blacksmith Testbox `tbx_01kztk506nkbq4025stf0wsaym`: https://github.com/openclaw/openclaw/actions/runs/31580850315
- Formatting and patch hygiene: targeted `oxfmt --check` passed; `git diff --check origin/main...HEAD` passed.
- Fresh branch autoreview: clean, no accepted/actionable findings, overall 0.99; TruffleHog clean.
- Exact-head PR CI: run `31581860565` passed for `cd775d7c190e99874f9a62c6078f39f3a9d2a29d`, including `openclaw/ci-gate`: https://github.com/openclaw/openclaw/actions/runs/31581860565
- Production LOC: +15/-1 (net +14). Tests: +56/-1 (net +55).
- Proof gap: the failure is deterministic through a partial sibling-temp write plus `beforeRename` `EIO`; no live user vault was mutated.

AI-assisted implementation and validation; the patch and proof were reviewed by the author.
