### PR TITLE
improve: speed changed-test routing scans

### DIFF
--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -1484,15 +1484,25 @@ function listImportGraphGrepMatches(cwd: string, term: string, options: ImportGr
     return cachedImportGraphGrepMatches.get(cacheKey) ?? null;
   }
 
-  const result = spawnSync(
-    "git",
+  const roots = tooling ? TOOLING_IMPORT_GRAPH_ROOTS : SOURCE_ROOTS_FOR_IMPORT_GRAPH;
+  const extensions = tooling ? TOOLING_IMPORTABLE_FILE_EXTENSIONS : IMPORTABLE_FILE_EXTENSIONS;
+  let result = spawnSync(
+    "rg",
     [
-      "grep",
-      "-l",
+      "--files-with-matches",
       "--fixed-strings",
+      "--hidden",
+      "--no-ignore",
+      ...extensions.flatMap((ext) => ["--glob", `*${ext}`]),
+      "--glob",
+      "!**/node_modules/**",
+      "--glob",
+      "!**/dist/**",
+      "--glob",
+      "!**/vendor/**",
       term,
       "--",
-      ...(tooling ? TOOLING_IMPORT_GRAPH_GREP_PATHS : IMPORT_GRAPH_GREP_PATHS),
+      ...roots,
     ],
     {
       cwd,
@@ -1500,6 +1510,24 @@ function listImportGraphGrepMatches(cwd: string, term: string, options: ImportGr
       stdio: ["ignore", "pipe", "pipe"],
     },
   );
+  if (result.error || (result.status !== 0 && result.status !== 1)) {
+    result = spawnSync(
+      "git",
+      [
+        "grep",
+        "-l",
+        "--fixed-strings",
+        term,
+        "--",
+        ...(tooling ? TOOLING_IMPORT_GRAPH_GREP_PATHS : IMPORT_GRAPH_GREP_PATHS),
+      ],
+      {
+        cwd,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+  }
   if (result.status === 1) {
     cachedImportGraphGrepMatches.set(cacheKey, []);
     return [];
@@ -1508,16 +1536,19 @@ function listImportGraphGrepMatches(cwd: string, term: string, options: ImportGr
     cachedImportGraphGrepMatches.set(cacheKey, null);
     return null;
   }
+  const trackedFiles = new Set(listImportGraphFilesForCwd(cwd, { tooling }));
   const matches = result.stdout
     .split("\n")
     .map((line) => normalizePathPattern(line.trim()))
     .filter(
       (line) =>
         line.length > 0 &&
+        trackedFiles.has(line) &&
         (tooling
           ? TOOLING_IMPORTABLE_FILE_EXTENSIONS.some((ext) => line.endsWith(ext))
           : isImportableGraphFile(line)),
-    );
+    )
+    .toSorted((left, right) => left.localeCompare(right));
   cachedImportGraphGrepMatches.set(cacheKey, matches);
   return matches;
 }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where changed-test routing repeatedly spent most of its runtime in repository-wide `git grep` subprocesses. The focused planner suite took 42.15s wall / 35.79s Vitest, slowing tooling CI and local changed-test planning.

## Why This Change Was Made

Use ripgrep for targeted import/reference candidate discovery, then retain only Git-tracked import-graph files and preserve deterministic ordering. If ripgrep is absent or fails, the existing `git grep` path remains the compatibility fallback. No CI jobs or workers are added.

Test-audit review retained all 246 cases because they enforce distinct routing, shard, fallback, and watchdog contracts; no test was deleted without a stronger owner-boundary proof.

## User Impact

Changed-test routing and its CI owner suite complete substantially faster without changing selected test targets. Environments without ripgrep retain existing behavior.

## Evidence

Same cold focused command, `--maxWorkers=1 --reporter=verbose`:

- Wall: 42.15s → 21.49s (**49.0% faster**)
- Vitest: 35.79s → 14.72s (**58.9% faster**)
- Test bodies: 34.24s → 14.10s (**58.8% faster**)
- Tests: 246/246 passed before and after
- Max RSS: 350,448 KiB → 306,424 KiB on the final run

Compatibility proof: forced `rg` to exit 2; the focused owner assertion passed through the `git grep` fallback (1 passed, 245 skipped).

Static proof:

- `pnpm format:check --no-error-on-unmatched-pattern -- scripts/test-projects.test-support.mts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/test-projects.test-support.mts`
- `git diff --check`

Structured autoreview could not start because no supported `codex` executable is installed in the orb; direct review covered search parity, tracked-file filtering, deterministic ordering, missing-ripgrep fallback, callers, and the full owner suite.
