### PR TITLE
fix(update): keep runnable companions when stable cohort is unavailable

### DIFF
--- a/src/cli/plugins-cli.update.test.ts
+++ b/src/cli/plugins-cli.update.test.ts
@@ -1423,6 +1423,7 @@ describe("plugins cli update", () => {
       expect(updateParams.officialPluginUpdateChannel).toBe(
         resolveRegistryUpdateChannel({ configChannel: updateChannel, currentVersion: VERSION }),
       );
+      expect(updateParams.versionBoundToCorePluginIds).toEqual(new Set(["codex"]));
     },
   );
 

--- a/src/cli/plugins-update-command.ts
+++ b/src/cli/plugins-update-command.ts
@@ -1,6 +1,7 @@
 // `openclaw plugins update` command implementation for tracked npm plugins and hook packs.
 import { isDeepStrictEqual } from "node:util";
 import { theme } from "../../packages/terminal-core/src/theme.js";
+import { VERSION_BOUND_RUNTIME_PLUGIN_IDS } from "../commands/doctor/shared/configured-runtime-plugin-installs.js";
 import {
   assertConfigWriteAllowedInCurrentMode,
   getRuntimeConfig,
@@ -420,6 +421,7 @@ async function runPluginUpdateCommandUnlocked(params: RunPluginUpdateCommandPara
                 officialPluginUpdateChannel,
                 syncOfficialPluginInstalls: params.opts.all ? true : undefined,
                 coreVersion: VERSION,
+                versionBoundToCorePluginIds: VERSION_BOUND_RUNTIME_PLUGIN_IDS,
                 ...installPolicyWarningAcknowledgement,
                 ...resolvePluginCapabilityConsentCliOptions({
                   acceptCapabilities: params.opts.acceptCapabilities,

--- a/src/cli/update-cli/update-command-plugins.ts
+++ b/src/cli/update-cli/update-command-plugins.ts
@@ -2,6 +2,7 @@
 import { PLUGIN_CAPABILITY_CONSENT_REQUIRED } from "../../../packages/gateway-protocol/src/capability-consent-error-details.js";
 import { stripAnsi } from "../../../packages/terminal-core/src/ansi.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
+import { VERSION_BOUND_RUNTIME_PLUGIN_IDS } from "../../commands/doctor/shared/configured-runtime-plugin-installs.js";
 import { readConfigFileSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../../config/types.plugins.js";
@@ -296,6 +297,7 @@ export async function updatePluginsAfterCoreUpdate(params: {
       timeoutMs: params.timeoutMs,
       updateChannel: pluginUpdateChannel,
       coreVersion: coreVersion ?? undefined,
+      versionBoundToCorePluginIds: VERSION_BOUND_RUNTIME_PLUGIN_IDS,
       skipDisabledPlugins: true,
       syncOfficialPluginInstalls: true,
       disableOnFailure: true,
@@ -317,6 +319,7 @@ export async function updatePluginsAfterCoreUpdate(params: {
     timeoutMs: params.timeoutMs,
     updateChannel: pluginUpdateChannel,
     coreVersion: coreVersion ?? undefined,
+    versionBoundToCorePluginIds: VERSION_BOUND_RUNTIME_PLUGIN_IDS,
     skipIds: resolvePostSyncPluginUpdateSkipIds({
       switchedToClawHub: syncResult.summary.switchedToClawHub,
       switchedToNpm: syncResult.summary.switchedToNpm,

--- a/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
@@ -13,6 +13,7 @@ import { withPluginLifecycleLease } from "../../../plugins/plugin-lifecycle-leas
 import { updateNpmInstalledPlugins } from "../../../plugins/update.js";
 import { resolveUserPath } from "../../../utils.js";
 import { resolveCompatibilityHostVersion } from "../../../version.js";
+import { VERSION_BOUND_RUNTIME_PLUGIN_IDS } from "./configured-runtime-plugin-installs.js";
 import {
   collectDownloadableInstallCandidates,
   collectUpdateDeferredPluginIds,
@@ -272,6 +273,7 @@ async function repairMissingPluginInstallsWithLease(
       skipDisabledPlugins: true,
       updateChannel,
       coreVersion: resolveCompatibilityHostVersion(env),
+      versionBoundToCorePluginIds: VERSION_BOUND_RUNTIME_PLUGIN_IDS,
       logger: {
         terminalLinks: false,
         warn: (message) => {

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -3462,6 +3462,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     const updateArg = expectRecordFields(mockCallArg(mocks.updateNpmInstalledPlugins), {
       pluginIds: ["demo"],
     });
+    expect(updateArg.versionBoundToCorePluginIds).toEqual(new Set(["codex"]));
     const updateConfig = updateArg.config as Record<string, unknown>;
     expectRecordFields(updateConfig.plugins, { installs: records });
     const persistedRecords = mockCallArg(mocks.writePersistedInstalledPluginIndexInstallRecords);

--- a/src/plugins/install-types.ts
+++ b/src/plugins/install-types.ts
@@ -119,6 +119,8 @@ export function isUnavailableNpmTarget(result: {
 }): boolean {
   return (
     result.code === PLUGIN_INSTALL_ERROR_CODE.NPM_PACKAGE_NOT_FOUND ||
-    /\b(ETARGET|notarget)\b|No matching version found|dist-tag|tag .*not found/i.test(result.error)
+    /\b(ETARGET|notarget)\b|No matching version found|Package not found on npm:|dist-tag|tag .*not found/i.test(
+      result.error,
+    )
   );
 }

--- a/src/plugins/update-installed.ts
+++ b/src/plugins/update-installed.ts
@@ -1,22 +1,17 @@
 import { PLUGIN_CAPABILITY_CONSENT_REQUIRED } from "../../packages/gateway-protocol/src/capability-consent-error-details.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveNpmSpecMetadata } from "../infra/install-source-utils.js";
 import { parseRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import {
   readInstalledPackageManifest,
   readInstalledPackageVersion,
 } from "../infra/package-update-utils.js";
-import type { UpdateChannel } from "../infra/update-channels.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveBundledPluginSources } from "./bundled-sources.js";
-import {
-  capturePluginCapabilityConsentHandlerErrors,
-  type PluginCapabilityConsentHandler,
-} from "./capability-consent.js";
+import { capturePluginCapabilityConsentHandlerErrors } from "./capability-consent.js";
 import { buildClawHubPluginInstallRecordFields } from "./clawhub-install-records.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
-import type { InstallSafetyOverrides } from "./install-security-scan.types.js";
 import { copyPluginInstallTransactionRequest } from "./install-transaction.js";
+import { isUnavailableNpmTarget } from "./install-types.js";
 import { PLUGIN_INSTALL_ERROR_CODE, resolvePluginInstallDir } from "./install.js";
 import {
   buildNpmResolutionInstallFields,
@@ -59,6 +54,7 @@ import {
   resolveRecordedExtensionsDir,
   withoutPluginInstallRecord,
 } from "./update-config.js";
+import type { UpdateNpmInstalledPluginsParams } from "./update-installed.types.js";
 import {
   expectedIntegrityForNpmFallback,
   expectedIntegrityForNpmUpdate,
@@ -75,8 +71,6 @@ import {
   shouldBypassTrustedOfficialUnchangedNpmCheck,
   shouldSkipUnchangedNpmInstall,
   type PluginUpdateChannelFallback,
-  type PluginUpdateIntegrityDriftParams,
-  type PluginUpdateLogger,
   type PluginUpdateOutcome,
   type PluginUpdateSummary,
 } from "./update-source.js";
@@ -88,27 +82,9 @@ import {
 } from "./update-summary.js";
 import { reconcileUnchangedUpdate } from "./update-unchanged.js";
 
-export async function updateNpmInstalledPlugins(params: {
-  config: OpenClawConfig;
-  logger?: PluginUpdateLogger;
-  pluginIds?: string[];
-  skipIds?: Set<string>;
-  skipDisabledPlugins?: boolean;
-  syncOfficialPluginInstalls?: boolean;
-  disableOnFailure?: boolean;
-  timeoutMs?: number;
-  dryRun?: boolean;
-  updateChannel?: UpdateChannel;
-  officialPluginUpdateChannel?: UpdateChannel;
-  coreVersion?: string;
-  dangerouslyForceUnsafeInstall?: boolean;
-  onInstallPolicyWarning?: InstallSafetyOverrides["onInstallPolicyWarning"];
-  specOverrides?: Record<string, string>;
-  onIntegrityDrift?: (params: PluginUpdateIntegrityDriftParams) => boolean | Promise<boolean>;
-  onCapabilityConsent?: PluginCapabilityConsentHandler;
-  beforePersistentEffect?: () => void | Promise<void>;
-  packagePluginIds?: Readonly<Record<string, readonly string[]>>;
-}): Promise<PluginUpdateSummary> {
+export async function updateNpmInstalledPlugins(
+  params: UpdateNpmInstalledPluginsParams,
+): Promise<PluginUpdateSummary> {
   const logger = params.logger ?? {};
   const consentCallbacks = capturePluginCapabilityConsentHandlerErrors(params.onCapabilityConsent);
   const installs = params.config.plugins?.installs ?? {};
@@ -225,8 +201,15 @@ export async function updateNpmInstalledPlugins(params: {
             updateChannel,
             officialPackageName: officialNpmPackageName,
             coreVersion: params.coreVersion,
+            versionBoundToCore: params.versionBoundToCorePluginIds?.has(pluginId),
           })
         : undefined;
+    const resolvedVersionBoundOfficialCohort =
+      updateChannel === "stable" &&
+      params.versionBoundToCorePluginIds?.has(pluginId) === true &&
+      trustedOfficialNpmSpec !== undefined &&
+      npmSpecs?.installSpec !== undefined &&
+      npmSpecs.installSpec !== npmSpecs.recordSpec;
     const clawhubSpecs =
       record.source === "clawhub"
         ? resolveClawHubUpdateSpecs({
@@ -355,13 +338,8 @@ export async function updateNpmInstalledPlugins(params: {
     }
     // Payload validation is filesystem work needed only to preserve state after metadata failures.
     // Every failure path below ends this plugin iteration, so the result cannot be reused.
-    const hasRunnableInstalledPayloadForFailure = async (code?: string): Promise<boolean> => {
-      if (
-        code !== PLUGIN_INSTALL_ERROR_CODE.NPM_METADATA_FAILURE ||
-        !params.disableOnFailure ||
-        params.dryRun ||
-        currentVersion === undefined
-      ) {
+    const hasRunnableInstalledPayload = async (): Promise<boolean> => {
+      if (!params.disableOnFailure || params.dryRun || currentVersion === undefined) {
         return false;
       }
       try {
@@ -371,6 +349,9 @@ export async function updateNpmInstalledPlugins(params: {
         return false;
       }
     };
+    const hasRunnableInstalledPayloadForFailure = async (code?: string): Promise<boolean> =>
+      code === PLUGIN_INSTALL_ERROR_CODE.NPM_METADATA_FAILURE &&
+      (await hasRunnableInstalledPayload());
     const extensionsDir = resolveRecordedExtensionsDir({
       pluginId,
       installPath,
@@ -458,6 +439,24 @@ export async function updateNpmInstalledPlugins(params: {
           recordFailure(pluginId, `Failed to check ${pluginId}: ${metadataResult.error}`, {
             code,
             installedPayloadRunnable: await hasRunnableInstalledPayloadForFailure(code),
+          });
+          continue;
+        }
+        if (
+          resolvedVersionBoundOfficialCohort &&
+          installedManifest?.name === officialNpmPackageName &&
+          isUnavailableNpmTarget(metadataResult) &&
+          currentVersion !== undefined &&
+          (await hasRunnableInstalledPayload())
+        ) {
+          const message = `Keeping "${pluginId}" at ${currentVersion}: exact stable companion cohort ${effectiveSpec} is unavailable.`;
+          logger.warn?.(message);
+          outcomes.push({
+            pluginId,
+            status: "unchanged",
+            currentVersion,
+            nextVersion: currentVersion,
+            message,
           });
           continue;
         }

--- a/src/plugins/update-installed.types.ts
+++ b/src/plugins/update-installed.types.ts
@@ -1,0 +1,28 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { UpdateChannel } from "../infra/update-channels.js";
+import type { PluginCapabilityConsentHandler } from "./capability-consent.js";
+import type { InstallSafetyOverrides } from "./install-security-scan.types.js";
+import type { PluginUpdateIntegrityDriftParams, PluginUpdateLogger } from "./update-source.js";
+
+export type UpdateNpmInstalledPluginsParams = {
+  config: OpenClawConfig;
+  logger?: PluginUpdateLogger;
+  pluginIds?: string[];
+  skipIds?: Set<string>;
+  skipDisabledPlugins?: boolean;
+  syncOfficialPluginInstalls?: boolean;
+  disableOnFailure?: boolean;
+  timeoutMs?: number;
+  dryRun?: boolean;
+  updateChannel?: UpdateChannel;
+  officialPluginUpdateChannel?: UpdateChannel;
+  coreVersion?: string;
+  versionBoundToCorePluginIds?: ReadonlySet<string>;
+  dangerouslyForceUnsafeInstall?: boolean;
+  onInstallPolicyWarning?: InstallSafetyOverrides["onInstallPolicyWarning"];
+  specOverrides?: Record<string, string>;
+  onIntegrityDrift?: (params: PluginUpdateIntegrityDriftParams) => boolean | Promise<boolean>;
+  onCapabilityConsent?: PluginCapabilityConsentHandler;
+  beforePersistentEffect?: () => void | Promise<void>;
+  packagePluginIds?: Readonly<Record<string, readonly string[]>>;
+};

--- a/src/plugins/update-source.ts
+++ b/src/plugins/update-source.ts
@@ -659,6 +659,7 @@ export function resolveNpmUpdateSpecs(params: {
   updateChannel?: UpdateChannel;
   officialPackageName?: string;
   coreVersion?: string;
+  versionBoundToCore?: boolean;
 }): {
   installSpec?: string;
   recordSpec?: string;
@@ -678,6 +679,7 @@ export function resolveNpmUpdateSpecs(params: {
     updateChannel: params.updateChannel,
     officialPackageName: params.officialPackageName,
     coreVersion: params.coreVersion,
+    versionBoundToCore: params.versionBoundToCore,
   });
 }
 

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -555,11 +555,13 @@ function createNpmUpdateFixture(params: {
   installerVersion?: string;
   installerResolvedSpec?: string;
   peerDependencies?: Record<string, string>;
+  runnable?: boolean;
 }) {
   const installPath = createInstalledPackageDir({
     name: params.packageName,
     version: params.installedVersion,
     ...(params.peerDependencies ? { peerDependencies: params.peerDependencies } : {}),
+    runnable: params.runnable,
   });
   if (params.registryVersion) {
     mockNpmViewMetadata({
@@ -3937,6 +3939,95 @@ describe("updateNpmInstalledPlugins", () => {
       });
     },
   );
+
+  it("targets the exact core cohort for a stable version-bound plugin", async () => {
+    const { config } = createNpmUpdateFixture({
+      pluginId: "codex",
+      packageName: "@openclaw/codex",
+      installedVersion: "2026.8.0",
+      registryVersion: "2026.8.1",
+      installerVersion: "2026.8.1",
+      installerResolvedSpec: "@openclaw/codex@2026.8.1",
+    });
+
+    await updatePlugin(config, "codex", {
+      updateChannel: "stable",
+      coreVersion: "2026.8.1",
+      versionBoundToCorePluginIds: new Set(["codex"]),
+    });
+
+    expect(npmInstallCall()?.spec).toBe("@openclaw/codex@2026.8.1");
+  });
+
+  it("preserves a runnable stable companion when npm normalizes a missing cohort to E404", async () => {
+    runCommandWithTimeoutMock.mockResolvedValueOnce({
+      code: 1,
+      stdout: "",
+      stderr:
+        "npm ERR! code E404\nnpm ERR! 404 '@openclaw/codex@2026.8.1' is not in this registry.",
+    });
+    const { config, installPath } = createNpmUpdateFixture({
+      pluginId: "codex",
+      packageName: "@openclaw/codex",
+      installedVersion: "2026.8.0",
+      runnable: true,
+    });
+
+    const result = await updatePlugin(config, "codex", {
+      updateChannel: "stable",
+      coreVersion: "2026.8.1",
+      versionBoundToCorePluginIds: new Set(["codex"]),
+      disableOnFailure: true,
+    });
+
+    expect(installPluginFromNpmSpecMock).not.toHaveBeenCalled();
+    expect(result.changed).toBe(false);
+    expect(result.config.plugins?.installs?.codex?.installPath).toBe(installPath);
+    expect(result.config.plugins?.entries?.codex?.enabled).not.toBe(false);
+    expect(result.outcomes).toEqual([
+      expect.objectContaining({
+        pluginId: "codex",
+        status: "unchanged",
+        currentVersion: "2026.8.0",
+        nextVersion: "2026.8.0",
+      }),
+    ]);
+  });
+
+  it("does not preserve a third-party payload behind stale official install metadata", async () => {
+    runCommandWithTimeoutMock.mockResolvedValueOnce({
+      code: 1,
+      stdout: "",
+      stderr: "npm ERR! code E404\nnpm ERR! 404 '@acme/codex' is not in this registry.",
+    });
+    installPluginFromNpmSpecMock.mockResolvedValue({
+      ok: false,
+      error: "npm install failed",
+    });
+    const { config } = createNpmUpdateFixture({
+      pluginId: "codex",
+      packageName: "@acme/codex",
+      installedVersion: "1.0.0",
+      runnable: true,
+    });
+    const record = config.plugins?.installs?.codex;
+    if (record) {
+      record.spec = "@openclaw/codex";
+      record.resolvedName = "@openclaw/codex";
+      record.resolvedSpec = "@openclaw/codex@1.0.0";
+    }
+
+    const result = await updatePlugin(config, "codex", {
+      updateChannel: "stable",
+      coreVersion: "2026.8.1",
+      versionBoundToCorePluginIds: new Set(["codex"]),
+      disableOnFailure: true,
+    });
+
+    expect(npmInstallCall()?.spec).toBe("@openclaw/codex@2026.8.1");
+    expect(result.changed).toBe(true);
+    expect(result.config.plugins?.entries?.codex?.enabled).toBe(false);
+  });
 
   it("preserves an explicit official pin during extended-stable updates", async () => {
     const { config } = createNpmUpdateFixture({


### PR DESCRIPTION
Related: #122019

## What Problem This Solves

Fixes an issue where a stable OpenClaw update could disable a working release-bound runtime companion when the exact matching companion cohort was not yet available from npm.

## Why This Change Was Made

The updater now reuses the existing version-bound release policy across post-core updates, manual plugin updates, and doctor repair. When npm reports that the exact stable cohort is unavailable, OpenClaw preserves the installed companion only when the record is catalog-verified as official and its payload is still runnable.

This deliberately does not add a pre-update planner, managed-profile inspection, advisory JSON/text output, or a new public contract.

## User Impact

Stable updates no longer unnecessarily disable an older working official companion while its matching release artifact is temporarily unavailable. Third-party packages, corrupt or missing payloads, explicit pins, and non-stable channels keep their existing update behavior.

## Evidence

Exact head: `02635bae1ef189b1bb4164251a60c85ef5807979`

- 396/396 focused tests passed across plugin update, post-core update, manual plugin update, and doctor repair paths.
- Regression coverage includes exact stable-cohort selection, ETARGET and normalized E404 preservation, runnable-payload validation, and rejection of third-party or mixed-metadata impersonation.
- Packaged normalized-E404 fault proof preserved the enabled companion, install path, payload, config, and installed version while probing the exact stable cohort. Artifact SHA-256: `53077ded5c26aa93b2c52dbae2386d99c9624bf73bf6b79574a1410673261649`.
- Exact-file formatting, Oxlint, import-cycle checks, and `git diff --check` passed.
- Independent exact-head Codex review found no actionable P0-P2 defects.
- The changed-file gate passed every non-type guard. Local full build/typecheck remained blocked by stale shared `node_modules` (`nostr-tools`, `rolldown`, and untouched package type errors); the same failures reproduced on untouched current `main`, so hosted CI is the clean dependency-authority check.

## Owner Acceptance Card

- **Assurance:** Critical — this touches core update/release availability behavior and requires normal domain-maintainer review before merge.
- **Changed boundary:** existing release-bound plugin resolution and its three update callers; no config, protocol, documentation, or advisory-output surface.
- **Strongest evidence:** focused regression coverage across all three callers plus a clean exact-head independent review.
- **Known falsifier:** preserving a third-party, corrupt, or missing payload, or disabling a runnable verified official companion solely because its exact stable cohort is unavailable.
- **Rollback:** revert this commit to restore the previous disable-on-failure behavior.
- **Reviewability:** 10 files, +169/-38 overall; production is +76/-38 and tests are +93. Each file belongs to the same existing version-bound update contract.

AI-assisted: yes. Codex implemented and independently reviewed the rewrite; the contributor approved replacing the broader PR with this narrow fix.
