### PR TITLE
improve: speed SQLite reliability proof

### DIFF
--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -321,7 +321,8 @@ const STRIPE_FILE_SECONDS_HINTS = new Map<string, number>([
   ["src/auto-reply/reply/commands-status.test.ts", 12],
   ["src/auto-reply/reply/commands-system-prompt.test.ts", 8],
   ["src/scripts/test-projects.test.ts", 21],
-  ["test/scripts/bench-sqlite-reliability.test.ts", 9],
+  // Focused cold proof is ~34s after right-sizing and concurrent crash phases.
+  ["test/scripts/bench-sqlite-reliability.test.ts", 34],
   ["test/scripts/bundled-plugin-install-uninstall-probe.test.ts", 4],
   ["test/scripts/changed-lanes.test.ts", 5],
   ["test/scripts/ci-workflow-guards.test.ts", 12],

--- a/scripts/lib/sqlite-reliability-contract.ts
+++ b/scripts/lib/sqlite-reliability-contract.ts
@@ -305,7 +305,9 @@ export type ReliabilityReport = {
 
 export const PROFILES: Record<ProfileId, ProfileConfig> = {
   smoke: {
-    iterations: 4,
+    // One snapshot before the forced writer crash and one after restart prove
+    // both distinct smoke paths; larger profiles retain repeated stress loops.
+    iterations: 2,
     maxWalBytes: 64 * 1024 * 1024,
     payloadBytes: 512,
     retainedBatches: 32,

--- a/scripts/lib/sqlite-reliability-runner.ts
+++ b/scripts/lib/sqlite-reliability-runner.ts
@@ -57,13 +57,29 @@ type IterationMetric = {
 
 type CompactionProof = ReliabilityReport["maintenanceProof"]["compaction"];
 
-// Exceed the 1 MiB interruption thresholds without copying an arbitrary 64 MiB
-// through every repository and restore crash phase.
-const COMPACTION_BLOAT_ROWS = 64;
+// Keep 50% headroom above the 2 MiB staged-restore threshold without copying
+// an arbitrarily large payload through every repository and restore crash phase.
+const COMPACTION_BLOAT_ROWS = 12;
 const COMPACTION_BLOAT_PAYLOAD_BYTES = 256 * 1024;
 
 function nowMs(): number {
   return Number(process.hrtime.bigint()) / 1e6;
+}
+
+async function runProofsConcurrently<First, Second>(
+  first: Promise<First>,
+  second: Promise<Second>,
+): Promise<[First, Second]> {
+  // Wait for both proofs to release their child processes before outer scratch
+  // cleanup starts, even when one proof fails.
+  const [firstResult, secondResult] = await Promise.allSettled([first, second]);
+  if (firstResult.status === "rejected") {
+    throw firstResult.reason;
+  }
+  if (secondResult.status === "rejected") {
+    throw secondResult.reason;
+  }
+  return [firstResult.value, secondResult.value];
 }
 
 function percentile(values: number[], pct: number): number {
@@ -485,23 +501,6 @@ async function runMaintenanceRoundTrip(params: {
       `compaction payload setup failed: rows=${expectedPayload.rows} bytes=${expectedPayload.bytes}`,
     );
   }
-  const repositoryInterruption = await runRepositoryInterruptionProof({
-    expectedPayload,
-    expectedState,
-    identity: params.target.identity,
-    repositoryPath: path.join(params.restoreRoot, "repository-interruptions"),
-    sourcePath: params.target.path,
-    validationRootPath: params.validationRoot,
-    verifyPayload: readCompactionPayload,
-    verifyState: (databasePath) =>
-      verifyRestoredDatabase({
-        expectedState,
-        identity: params.target.identity,
-        path: databasePath,
-        rowsPerBatch: params.rowsPerBatch,
-        uncommittedBatch: null,
-      }),
-  });
   const interruptedSnapshot = await params.repositoryProvider.create({
     identity: params.target.identity,
     path: params.target.path,
@@ -510,24 +509,43 @@ async function runMaintenanceRoundTrip(params: {
     interruptedSnapshot.ref.path,
     params.syncedRepository,
   );
-  const restoreInterruption = await runRestoreInterruptionProof({
-    expectedPayload,
-    expectedSnapshotBytes: interruptedSnapshot.manifest.artifact.sizeBytes,
-    expectedState,
-    repositoryPath: params.syncedRepository,
-    scratchPath: path.join(params.restoreRoot, "interrupted"),
-    snapshotPath: interruptedCopiedPath,
-    validationRootPath: params.validationRoot,
-    verifyPayload: readCompactionPayload,
-    verifyState: (databasePath) =>
-      verifyRestoredDatabase({
-        expectedState,
-        identity: params.target.identity,
-        path: databasePath,
-        rowsPerBatch: params.rowsPerBatch,
-        uncommittedBatch: null,
-      }),
-  });
+  const [repositoryInterruption, restoreInterruption] = await runProofsConcurrently(
+    runRepositoryInterruptionProof({
+      expectedPayload,
+      expectedState,
+      identity: params.target.identity,
+      repositoryPath: path.join(params.restoreRoot, "repository-interruptions"),
+      sourcePath: params.target.path,
+      validationRootPath: params.validationRoot,
+      verifyPayload: readCompactionPayload,
+      verifyState: (databasePath) =>
+        verifyRestoredDatabase({
+          expectedState,
+          identity: params.target.identity,
+          path: databasePath,
+          rowsPerBatch: params.rowsPerBatch,
+          uncommittedBatch: null,
+        }),
+    }),
+    runRestoreInterruptionProof({
+      expectedPayload,
+      expectedSnapshotBytes: interruptedSnapshot.manifest.artifact.sizeBytes,
+      expectedState,
+      repositoryPath: params.syncedRepository,
+      scratchPath: path.join(params.restoreRoot, "interrupted"),
+      snapshotPath: interruptedCopiedPath,
+      validationRootPath: params.validationRoot,
+      verifyPayload: readCompactionPayload,
+      verifyState: (databasePath) =>
+        verifyRestoredDatabase({
+          expectedState,
+          identity: params.target.identity,
+          path: databasePath,
+          rowsPerBatch: params.rowsPerBatch,
+          uncommittedBatch: null,
+        }),
+    }),
+  );
   const vacuumInterruption = await runVacuumInterruptionProof({
     env: params.env,
     expectedAutoVacuum: autoVacuumBeforeKill,
@@ -725,22 +743,23 @@ export async function runReliabilityStress(options: CliOptions): Promise<Reliabi
       rowsPerBatch: profile.rowsPerBatch,
       uncommittedBatch: null,
     });
-    const publicationInterruptionProof = await runPublicationInterruptionProof({
-      expectedState: stableState,
-      scratchPath: path.join(runScratch, "publication-interruptions"),
-      sourcePath: target.path,
-      verifyDatabase: (databasePath) =>
-        verifyRestoredDatabase({
+    const [publicationInterruptionProof, indexRepairInterruptionProof] =
+      await runProofsConcurrently(
+        runPublicationInterruptionProof({
           expectedState: stableState,
-          identity: target.identity,
-          path: databasePath,
-          rowsPerBatch: profile.rowsPerBatch,
-          uncommittedBatch: null,
+          scratchPath: path.join(runScratch, "publication-interruptions"),
+          sourcePath: target.path,
+          verifyDatabase: (databasePath) =>
+            verifyRestoredDatabase({
+              expectedState: stableState,
+              identity: target.identity,
+              path: databasePath,
+              rowsPerBatch: profile.rowsPerBatch,
+              uncommittedBatch: null,
+            }),
         }),
-    });
-    const indexRepairInterruptionProof = await runIndexRepairInterruptionProof(
-      path.join(runScratch, "index-repair-interruptions"),
-    );
+        runIndexRepairInterruptionProof(path.join(runScratch, "index-repair-interruptions")),
+      );
     const maintenanceProof = await runMaintenanceRoundTrip({
       env,
       repositoryProvider,

--- a/test/scripts/bench-sqlite-reliability.test.ts
+++ b/test/scripts/bench-sqlite-reliability.test.ts
@@ -187,7 +187,7 @@ describe("scripts/bench-sqlite-reliability", () => {
     expect(result.status, result.stderr).toBe(0);
     expect(result.stderr).toBe("");
     expect(result.stdout).toContain("SQLITE_RELIABILITY_TARGET=global");
-    expect(result.stdout).toContain("SQLITE_RELIABILITY_RESTORES_VERIFIED=7");
+    expect(result.stdout).toContain("SQLITE_RELIABILITY_RESTORES_VERIFIED=5");
     expect(result.stdout).toContain("SQLITE_RELIABILITY_CRASH_RECOVERY=verified");
     expect(result.stdout).toContain("SQLITE_RELIABILITY_PUBLICATION_INTERRUPTION=verified");
     expect(result.stdout).toContain("SQLITE_RELIABILITY_RESTORE_INTERRUPTION=verified");
@@ -197,8 +197,8 @@ describe("scripts/bench-sqlite-reliability", () => {
     expect(result.stdout).toContain("SQLITE_RELIABILITY_POST_COMPACT_RESTORE=verified");
     expect(result.stdout).not.toContain("=missing");
     const firstReport = JSON.parse(fs.readFileSync(output, "utf8")) as ReliabilityReport;
-    expect(firstReport.concurrentRestoresVerified).toBe(4);
-    expect(firstReport.restoresVerified).toBe(7);
+    expect(firstReport.concurrentRestoresVerified).toBe(2);
+    expect(firstReport.restoresVerified).toBe(5);
     expect(
       firstReport.crashRecoveryProof.exit.code !== null ||
         firstReport.crashRecoveryProof.exit.signal !== null,


### PR DESCRIPTION
## What Problem This Solves

The SQLite reliability proof dominated its tooling shard: one five-test file took about 62 seconds wall time, with 53.8 seconds spent in the full crash/snapshot proof. It repeated equivalent smoke iterations, copied a much larger payload than its staged-restore boundary required, and serialized independent crash barriers.

## Why This Change Was Made

This AI-assisted change keeps every distinct snapshot, writer-crash, publication, repository, restore, index-repair, vacuum, compaction, and state-reuse contract while:

- running independent publication/index-repair and repository/restore crash proofs concurrently with cleanup-safe failure settling;
- retaining one pre-crash and one post-restart smoke snapshot instead of two additional duplicate iterations (larger profiles keep repeated stress loops);
- keeping a 3 MiB payload, 50% above the 2 MiB staged-restore threshold, instead of copying 16 MiB through every phase;
- refreshing the existing four-way tooling stripe hint from 9s to the measured 34s without adding CI jobs or workers.

## User Impact

Developers and CI get the same end-to-end SQLite durability coverage with a shorter tooling critical path. No production runtime or user-facing behavior changes.

## Evidence

Same Node 24.15 focused command before and after:

`/usr/bin/time -v node scripts/run-vitest.mjs test/scripts/bench-sqlite-reliability.test.ts --maxWorkers=1 --reporter=verbose`

| Metric | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Wrapper wall | 62.02s | 41.30s | 33.4% faster |
| Vitest duration | 55.41s | 34.99s | 36.9% faster |
| Full reliability proof | 53.760s | 33.070s | 38.5% faster |

Focused validation:

- SQLite reliability suite: 5/5 passed
- CI node test plan suite: 22/22 passed
- `oxfmt --check` on all four changed files: passed
- targeted scripts `oxlint`: 0 warnings, 0 errors
- `git diff --check`: passed

The four tooling stripe weights remain balanced (before: 334/334/335/334; after corrected timing: 341/340/340/341), and the shard count remains four.
