### PR TITLE
fix(ai): preserve structured error code through Responses failed-event normalization

### DIFF
--- a/packages/ai/src/transports/openai-responses-debug.test.ts
+++ b/packages/ai/src/transports/openai-responses-debug.test.ts
@@ -1,5 +1,16 @@
+import type { Model } from "@openclaw/llm-core";
 import { describe, expect, it } from "vitest";
-import { summarizeResponsesPayload } from "./openai-responses-debug.js";
+import {
+  normalizeResponsesFailedEvent,
+  ResponsesStreamFailure,
+  summarizeResponsesPayload,
+} from "./openai-responses-debug.js";
+
+const failedEventModel = {
+  provider: "openai",
+  api: "openai-responses",
+  id: "gpt-5.6-luna",
+} as unknown as Model;
 
 describe("OpenAI Responses payload debug summary", () => {
   it("reports compaction replay identities without exposing opaque content", () => {
@@ -33,5 +44,46 @@ describe("OpenAI Responses payload debug summary", () => {
     expect(summarizeResponsesPayload({ input: "hello" })).toContain(
       "compactionItems=0 compactionIdHashes=none compactionPayloadHashes=none compactionInputIndexes=none",
     );
+  });
+});
+
+describe("normalizeResponsesFailedEvent", () => {
+  it("preserves the structured provider error code on the failure and ResponsesStreamFailure (#117609)", () => {
+    const summary = normalizeResponsesFailedEvent(
+      {
+        response: {
+          id: "resp_failed",
+          status: "failed",
+          error: { code: "server_error", message: "provider failed" },
+        },
+      },
+      failedEventModel,
+    );
+    // The prose message still embeds the code, but the structured code is now
+    // preserved so downstream failover classification routes on it instead of
+    // guessing from the prose.
+    expect(summary.code).toBe("server_error");
+    expect(summary.message).toBe("server_error: provider failed");
+    expect(summary.responseId).toBe("resp_failed");
+
+    const failure = new ResponsesStreamFailure(summary, undefined);
+    expect(failure.code).toBe("server_error");
+    expect(failure.message).toBe("server_error: provider failed");
+    expect(failure.responseId).toBe("resp_failed");
+  });
+
+  it("omits code when the failed response has no error code", () => {
+    const summary = normalizeResponsesFailedEvent(
+      {
+        response: {
+          id: "resp_failed",
+          status: "failed",
+          error: { message: "provider failed" },
+        },
+      },
+      failedEventModel,
+    );
+    expect(summary.code).toBeUndefined();
+    expect(summary.message).toBe("unknown: provider failed");
   });
 });

--- a/packages/ai/src/transports/openai-responses-debug.ts
+++ b/packages/ai/src/transports/openai-responses-debug.ts
@@ -202,6 +202,10 @@ type ResponsesFailedNoDetailsObservation = {
 type ResponsesFailedEventSummary = {
   message: string;
   responseId?: string;
+  // Structured provider error code (e.g. "server_error") preserved from
+  // response.failed so downstream failover classification can route on it
+  // instead of guessing from the prose message (#117609).
+  code?: string;
   observation?: ResponsesFailedNoDetailsObservation;
 };
 
@@ -225,11 +229,15 @@ function readResponseFailedString(
 function buildResponsesFailedEventSummary(
   message: string,
   responseId: string | undefined,
+  code?: string,
   observation?: ResponsesFailedNoDetailsObservation,
 ): ResponsesFailedEventSummary {
   const summary: ResponsesFailedEventSummary = { message };
   if (responseId) {
     summary.responseId = responseId;
+  }
+  if (code) {
+    summary.code = code;
   }
   if (observation) {
     summary.observation = observation;
@@ -439,6 +447,7 @@ export function normalizeResponsesFailedEvent(
       return buildResponsesFailedEventSummary(
         `${code || "unknown"}: ${message || "no message"}`,
         responseId,
+        code || undefined,
       );
     }
   }
@@ -452,6 +461,7 @@ export function normalizeResponsesFailedEvent(
   return buildResponsesFailedEventSummary(
     RESPONSE_FAILED_NO_DETAILS_MESSAGE,
     responseId,
+    undefined,
     buildResponsesFailedNoDetailsObservation(event, model, response),
   );
 }
@@ -459,6 +469,7 @@ export function normalizeResponsesFailedEvent(
 export class ResponsesStreamFailure extends Error {
   readonly responseId?: string;
   readonly response: unknown;
+  readonly code?: string;
   readonly observation: ReturnType<typeof normalizeResponsesFailedEvent>["observation"];
 
   constructor(failure: ReturnType<typeof normalizeResponsesFailedEvent>, response: unknown) {
@@ -466,6 +477,7 @@ export class ResponsesStreamFailure extends Error {
     this.name = "ResponsesStreamFailure";
     this.responseId = failure.responseId;
     this.response = response;
+    this.code = failure.code;
     this.observation = failure.observation;
   }
 }

--- a/src/agents/embedded-agent-helpers/assistant-message-failures.ts
+++ b/src/agents/embedded-agent-helpers/assistant-message-failures.ts
@@ -7,6 +7,7 @@ import {
   isBillingErrorMessage,
   isRateLimitErrorMessage,
 } from "../failover/classify.js";
+import type { PreparedProviderFailoverOwner } from "../failover/provider-patterns.js";
 import { extractFailoverSignalDetails } from "../failover/signal-details.js";
 import type { FailoverReason, FailoverSignal } from "../failover/signal.js";
 export function buildAssistantFailoverSignal(
@@ -24,12 +25,18 @@ export function buildAssistantFailoverSignal(
 }
 export function classifyAssistantFailoverReason(
   msg: AssistantMessage | undefined,
-  opts?: { provider?: string },
+  opts?: { provider?: string; providerOwner?: PreparedProviderFailoverOwner },
 ): FailoverReason | null {
   if (!msg || msg.stopReason !== "error" || isReplayUnsafeAssistantError(msg)) {
     return null;
   }
-  const classification = classifyFailoverSignal(buildAssistantFailoverSignal(msg, opts));
+  // Runtime preparation carries the resolved owner here so packaged runs do
+  // not rediscover provider policy through a source-relative loader.
+  const providerOwner = opts?.providerOwner;
+  const classification = classifyFailoverSignal(
+    buildAssistantFailoverSignal(msg, { provider: providerOwner?.id ?? opts?.provider }),
+    { providerPlugin: providerOwner },
+  );
   return classification?.kind === "reason"
     ? classification.reason
     : classification

--- a/src/agents/embedded-agent-runner/run/assistant-failure.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failure.test.ts
@@ -1,6 +1,6 @@
 import http from "node:http";
 import type { AddressInfo } from "node:net";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Context, Model } from "../../../../packages/ai/src/types.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { AssistantMessage } from "../../../llm/types.js";
@@ -256,6 +256,10 @@ async function streamIncompleteMistralResponseOverLoopback() {
 }
 
 describe("handleEmbeddedAssistantFailure", () => {
+  beforeEach(() => {
+    providerRuntimeMocks.classifyProviderFailoverSignalWithPlugin.mockReset();
+  });
+
   it.each(["auth", "auth_permanent"] as const)(
     "carries %s profile failures into terminal resolution",
     async (reason) => {
@@ -302,17 +306,14 @@ describe("handleEmbeddedAssistantFailure", () => {
     fixture.input.model = modelId;
     fixture.input.activeErrorContext = { provider, model: modelId };
     fixture.input.authProfileId = undefined;
-    fixture.input.providerOwner = { id: "openrouter" };
+    fixture.input.providerOwner = {
+      id: "openrouter",
+      classifyFailoverReason: ({ errorMessage: classifiedError }) =>
+        classifiedError === errorMessage ? "billing" : undefined,
+    };
     fixture.input.resolveAuthProfileFailureReason = vi.fn((reason) =>
       reason === "billing" ? "billing" : null,
     );
-    providerRuntimeMocks.classifyProviderFailoverSignalWithPlugin.mockImplementation(
-      ({ provider: classifiedProvider, context }) =>
-        classifiedProvider === "openrouter" && context.errorMessage === errorMessage
-          ? "billing"
-          : undefined,
-    );
-
     const outcome = await handleEmbeddedAssistantFailure(fixture.input);
 
     expect(outcome).toMatchObject({
@@ -328,6 +329,43 @@ describe("handleEmbeddedAssistantFailure", () => {
         stage: "assistant",
       },
     ]);
+  });
+
+  it("uses the prepared OpenAI owner for structured Responses failures", async () => {
+    const fixture = makeExhaustedCredentialFailureInput();
+    const assistant = buildEmbeddedRunnerAssistant({
+      provider: "openai",
+      model: "gpt-5.6-luna",
+      stopReason: "error",
+      errorMessage: "server_error: provider failed",
+      errorCode: "server_error",
+    });
+    const attempt = makeEmbeddedRunnerAttempt({
+      lastAssistant: assistant,
+      currentAttemptAssistant: assistant,
+    });
+    fixture.input.attempt = attempt;
+    fixture.input.attemptAssistant = assistant;
+    fixture.input.currentAttemptAssistant = assistant;
+    fixture.input.terminalState = resolveEmbeddedRunAttemptTerminalState({ attempt, assistant });
+    fixture.input.provider = "openai";
+    fixture.input.providerOwner = {
+      id: "openai",
+      classifyFailoverReason: ({ code }) =>
+        code?.toUpperCase() === "SERVER_ERROR" ? "server_error" : undefined,
+    };
+    fixture.input.modelId = "gpt-5.6-luna";
+    fixture.input.model = "gpt-5.6-luna";
+    fixture.input.activeErrorContext = { provider: "openai", model: "gpt-5.6-luna" };
+    fixture.input.authProfileId = undefined;
+    fixture.input.advanceAuthProfile = vi.fn(async () => false);
+    providerRuntimeMocks.classifyProviderFailoverSignalWithPlugin.mockReturnValue(undefined);
+
+    await expect(handleEmbeddedAssistantFailure(fixture.input)).rejects.toMatchObject({
+      reason: "server_error",
+      status: 500,
+    });
+    expect(fixture.input.maybeBackoffBeforeOverloadFailover).toHaveBeenCalledWith("server_error");
   });
 
   it.each([PROVIDER_FAILURE_WITH_OUTPUT_ERROR_CODE, PROVIDER_POST_DISPATCH_AMBIGUITY_ERROR_CODE])(

--- a/src/agents/embedded-agent-runner/run/assistant-failure.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failure.ts
@@ -110,7 +110,7 @@ export async function handleEmbeddedAssistantFailure(input: {
   const billingFailure = isBillingAssistantError(input.attemptAssistant);
   const failoverFailure = isFailoverAssistantError(input.attemptAssistant);
   const assistantFailoverReason = classifyAssistantFailoverReason(input.attemptAssistant, {
-    provider: input.providerOwner?.id,
+    providerOwner: input.providerOwner,
   });
   const assistantProviderStarted =
     Boolean(input.currentAttemptAssistant?.provider) ||

--- a/src/agents/failover/provider-structured-signals.test.ts
+++ b/src/agents/failover/provider-structured-signals.test.ts
@@ -399,4 +399,26 @@ describe("provider failover hook structured signals", () => {
       });
     }
   });
+
+  it("routes a preserved server_error code to server_error instead of timeout (#117609)", () => {
+    // The OpenAI provider hook maps SERVER_ERROR -> server_error. When the
+    // structured code is preserved at the transport boundary, the hook outranks
+    // the prose classifier that would otherwise match "server_error" substring
+    // and misclassify as timeout.
+    providerRuntimeMocks.classifyProviderFailoverSignalWithPlugin.mockImplementation(
+      ({ context }) =>
+        context.provider === "openai" && context.code === "server_error"
+          ? "server_error"
+          : undefined,
+    );
+
+    expect(
+      classifyFailoverSignal({
+        provider: "openai",
+        code: "server_error",
+        message: "server_error: provider failed",
+      }),
+    ).toEqual({ kind: "reason", reason: "server_error" });
+    expect(providerRuntimeMocks.classifyProviderFailoverSignalWithPlugin).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/agents/failover/provider-structured-signals.test.ts
+++ b/src/agents/failover/provider-structured-signals.test.ts
@@ -402,9 +402,11 @@ describe("provider failover hook structured signals", () => {
 
   it("routes a preserved server_error code to server_error instead of timeout (#117609)", () => {
     // The OpenAI provider hook maps SERVER_ERROR -> server_error. When the
-    // structured code is preserved at the transport boundary, the hook outranks
-    // the prose classifier that would otherwise match "server_error" substring
-    // and misclassify as timeout.
+    // structured code is preserved at the transport boundary, hasStructuredDescriptor
+    // becomes true, the hook is consulted, and it outranks the prose classifier.
+    // The folded message "server_error: ..." otherwise matches isServerErrorMessage
+    // (ERROR_PATTERNS.serverError includes "server_error") and classifies as timeout
+    // with the hook skipped. Same message, only the preserved code differs.
     providerRuntimeMocks.classifyProviderFailoverSignalWithPlugin.mockImplementation(
       ({ context }) =>
         context.provider === "openai" && context.code === "server_error"
@@ -412,6 +414,17 @@ describe("provider failover hook structured signals", () => {
           : undefined,
     );
 
+    // Pre-fix shape: code lost in normalization -> no structured descriptor ->
+    // hook skipped -> prose misclassifies as timeout.
+    expect(
+      classifyFailoverSignal({
+        provider: "openai",
+        message: "server_error: provider failed",
+      }),
+    ).toEqual({ kind: "reason", reason: "timeout" });
+    expect(providerRuntimeMocks.classifyProviderFailoverSignalWithPlugin).not.toHaveBeenCalled();
+
+    // Post-fix shape: code preserved -> hook consulted -> server_error.
     expect(
       classifyFailoverSignal({
         provider: "openai",

--- a/src/agents/openai-transport-stream.base.test.ts
+++ b/src/agents/openai-transport-stream.base.test.ts
@@ -197,6 +197,43 @@ describe("openai transport stream", () => {
     expect(output.responseId).toBe("resp_failed_empty_error");
   });
 
+  it("preserves the structured error code on a thrown Responses failure (#117609)", async () => {
+    // A real response.failed SSE event carries error.code. The transport must
+    // preserve that code on the thrown ResponsesStreamFailure so the failover
+    // classifier can hand it to the provider hook. Without the code, the hook is
+    // skipped (no structured descriptor) and the prose classifier matches the
+    // "server_error" substring in the folded message as timeout. Pre-fix the
+    // thrown failure carried no code field at all.
+    const model = createAzureResponsesModel();
+    const output = createResponsesAssistantOutput(model);
+
+    const failure = await testing
+      .processResponsesStream(
+        streamChunks([
+          {
+            type: "response.failed",
+            response: {
+              id: "resp_failed_server_error",
+              status: "failed",
+              model: "gpt-5.4-pro",
+              error: { code: "server_error", message: "provider failed" },
+            },
+          },
+        ]),
+        output,
+        { push: vi.fn() },
+        model,
+      )
+      .catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as { name?: string }).name).toBe("ResponsesStreamFailure");
+    expect((failure as { code?: string }).code).toBe("server_error");
+    // The message stays in the prose-folded form, which is exactly what the
+    // prose classifier would misread as timeout without the preserved code.
+    expect((failure as { message?: string }).message).toBe("server_error: provider failed");
+  });
+
   it("tags Responses encrypted reasoning with replay provenance while streaming", async () => {
     const model = makeResponsesModel({
       id: "gpt-5.4",

--- a/src/agents/openai-transport-stream.failed-sse.test.ts
+++ b/src/agents/openai-transport-stream.failed-sse.test.ts
@@ -124,6 +124,11 @@ describe("failed Responses loopback SSE", () => {
             responseModel: "gpt-5.6-luna",
             stopReason: "error",
             errorMessage: "server_error: provider failed after consuming tokens",
+            // The structured error.code must survive normalization -> the thrown
+            // ResponsesStreamFailure -> projectProviderError into errorCode, so the
+            // failover classifier receives a structured descriptor and consults the
+            // provider hook instead of misreading the folded message as timeout (#117609).
+            errorCode: "server_error",
             usage: {
               input: 13,
               output: 4,


### PR DESCRIPTION
## What Problem This Solves

OpenAI Responses can end a successful HTTP stream with a typed `response.failed` event. Its `response.error.code` was folded into text and then discarded.

The embedded run then received text such as `server_error: provider failed` without the structured code. It also dropped the provider plugin that runtime preparation had already resolved. The packaged fallback classifier therefore used prose and selected `timeout` instead of the OpenAI-owned `server_error` policy.

Related to #117609. This pull request fixes the typed Responses-event path. The broader issue remains open for its other transient failure paths.

## Why This Change Was Made

The transport now preserves `response.error.code` on `ResponsesStreamFailure`. Provider-error projection carries it into the assistant terminal message.

The canonical assistant failure classifier now accepts the prepared provider plugin. The embedded runner uses that shared path, with no duplicate classifier or runtime discovery.

This matches the official [OpenAI `response.failed` contract](https://developers.openai.com/api/reference/resources/responses/streaming-events#response.failed), where `response.error.code` is structured data.

## User Impact

Transient OpenAI `server_error` failures now select the server-error fallback policy and status 500. They no longer appear as timeouts with status 408.

Operators see the configured model fallback and receive its successful answer.

## Evidence

**Live red:** An exact dispatch-main package probe passed the same structured signal through the packaged classifier. The unreachable dynamic bridge selected `timeout`; the packaged OpenAI provider object selected `server_error`.

**Live green:** A real Telegram Test Server user sent a unique direct message through a fresh isolated Gateway. A loopback OpenAI Responses server returned a real `response.failed` server-sent event with `error.code=server_error` and positive output usage. The packaged transport retained the code. The embedded owner selected `server_error`, status 500, and `fallback_model`. Provider request 2 used the configured fallback model. Telegram showed the fallback notice and the unique final reply.

**Control:** The same user, Gateway, provider transport, and primary model completed a separate unique message in one provider request. No failover decision occurred.

The canonical-classifier rank-up changes only the code owner. The exact final head keeps the already-proven behavior and passes the shared classifier and embedded runner suites.

Validation:

- `pnpm build` on exact head `4f9f8fb95c85`
- 159 focused transport, projection, classifier, embedded-owner, and OpenAI provider tests from the live-proven behavior head
- 44 final-head canonical classifier and embedded runner tests
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- formatting, Oxlint, dead exports, import cycles, Plugin SDK API baseline, and changed-scope repository guards
- `git diff --check`

Production LOC: +19 net. Tests: +167 net. The production growth preserves the missing structured transport field and carries the already-prepared provider owner through the canonical classifier. No new retry, timeout, config, protocol, or compatibility path was added.
