### PR TITLE
fix(qa): artifact write failure preserves previous files

### DIFF
--- a/extensions/qa-lab/src/suite-artifacts.ts
+++ b/extensions/qa-lab/src/suite-artifacts.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawCrablineChannelDriverSelection } from "@openclaw/crabline";
+import { replaceFileAtomic } from "openclaw/plugin-sdk/security-runtime";
 import { assertQaSuiteArtifactWritten } from "./artifact-assertion.js";
 import {
   hasQaCrablineArtifactPath,
@@ -24,6 +25,28 @@ type QaCrablineRuntime = typeof import("@openclaw/crabline");
 type QaCrablineChannelDriverSmokeResult = Awaited<
   ReturnType<QaCrablineRuntime["runOpenClawCrablineChannelDriverSmoke"]>
 >;
+
+/** Atomically replaces each file in order; summary-last is a completion signal, not a set transaction. */
+export async function publishQaSuiteArtifactFiles(params: {
+  outputDir: string;
+  files: readonly { content: string | Uint8Array; filePath: string }[];
+}) {
+  await fs.mkdir(params.outputDir, { recursive: true });
+  const dirMode = (await fs.stat(params.outputDir)).mode & 0o7777;
+  for (const file of params.files) {
+    await replaceFileAtomic({
+      filePath: file.filePath,
+      content: file.content,
+      dirMode,
+      mode: 0o600,
+      preserveExistingMode: true,
+      tempPrefix: `${path.basename(file.filePath)}.qa-artifact`,
+      syncTempFile: true,
+      syncParentDir: true,
+      throwOnCleanupError: true,
+    });
+  }
+}
 
 export type QaSuiteSummaryJsonParams = {
   scenarios: QaSuiteScenarioResult[];
@@ -264,22 +287,26 @@ export async function writeQaSuiteArtifacts(params: {
     );
   }
   const writeEvidenceFile = params.writeEvidenceFile ?? true;
-  await fs.writeFile(reportPath, report, "utf8");
-  if (evidence && writeEvidenceFile) {
-    await fs.writeFile(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`, "utf8");
-  }
-  await fs.writeFile(
-    summaryPath,
-    `${JSON.stringify(
-      buildQaSuiteSummaryJson({
-        ...params,
-        channelDriverSelection: effectiveChannelDriverSelection,
-      }),
-      null,
-      2,
-    )}\n`,
-    "utf8",
-  );
+  await publishQaSuiteArtifactFiles({
+    outputDir: params.outputDir,
+    files: [
+      { filePath: reportPath, content: report },
+      ...(evidence && writeEvidenceFile
+        ? [{ filePath: evidencePath, content: `${JSON.stringify(evidence, null, 2)}\n` }]
+        : []),
+      {
+        filePath: summaryPath,
+        content: `${JSON.stringify(
+          buildQaSuiteSummaryJson({
+            ...params,
+            channelDriverSelection: effectiveChannelDriverSelection,
+          }),
+          null,
+          2,
+        )}\n`,
+      },
+    ],
+  });
   await assertQaSuiteArtifactWritten("report", reportPath);
   await assertQaSuiteArtifactWritten("summary", summaryPath);
   if (evidence && writeEvidenceFile) {

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -14,11 +14,13 @@ import type {
 const {
   crablineRuntimeLoads,
   prepareDockerE2eEnvironment,
+  replaceFileAtomicMock,
   runQaFlowSuite,
   runQaTestFileScenarios,
 } = vi.hoisted(() => ({
   crablineRuntimeLoads: vi.fn(),
   prepareDockerE2eEnvironment: vi.fn(),
+  replaceFileAtomicMock: vi.fn(),
   runQaFlowSuite: vi.fn(),
   runQaTestFileScenarios: vi.fn(),
 }));
@@ -42,6 +44,12 @@ vi.mock("./test-file-scenario-docker-batch.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./test-file-scenario-docker-batch.js")>()),
   prepareDockerE2eEnvironment,
 }));
+
+vi.mock("openclaw/plugin-sdk/security-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/security-runtime")>();
+  replaceFileAtomicMock.mockImplementation(actual.replaceFileAtomic);
+  return { ...actual, replaceFileAtomic: replaceFileAtomicMock };
+});
 
 import { runQaSuite, runQaSuiteWithInfraRetry } from "./suite-launch.runtime.js";
 
@@ -122,6 +130,7 @@ function mockFlowPartitionFailures(failuresByScenarioId: ReadonlyMap<string, rea
 
 describe("qa suite runtime launcher", () => {
   beforeEach(() => {
+    replaceFileAtomicMock.mockClear();
     runQaFlowSuite.mockReset();
     runQaTestFileScenarios.mockReset();
     prepareDockerE2eEnvironment.mockReset();
@@ -1224,6 +1233,80 @@ describe("qa suite runtime launcher", () => {
       "log=.artifacts/qa-e2e/mixed/playwright/control-ui-chat-flow-playwright.log",
     );
   });
+
+  it.each([
+    { kind: "evidence", fileName: "qa-evidence.json" },
+    { kind: "report", fileName: "qa-suite-report.md" },
+    { kind: "summary", fileName: "qa-suite-summary.json" },
+  ])(
+    "preserves the prior unified $kind artifact when atomic publication fails",
+    async ({ fileName }) => {
+      const repoRoot = await makeTempRepo("qa-suite-unified-artifact-atomic-");
+      const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "artifact-atomic");
+      const canonicalFileNames = [
+        "qa-evidence.json",
+        "qa-suite-report.md",
+        "qa-suite-summary.json",
+      ];
+      const sentinels = new Map(
+        canonicalFileNames.map((canonicalFileName) => [
+          canonicalFileName,
+          `prior ${canonicalFileName}\n`,
+        ]),
+      );
+      await fs.mkdir(outputDir, { recursive: true, mode: 0o750 });
+      await fs.chmod(outputDir, 0o750);
+      for (const [canonicalFileName, sentinel] of sentinels) {
+        const finalPath = path.join(outputDir, canonicalFileName);
+        await fs.writeFile(finalPath, sentinel, { encoding: "utf8", mode: 0o640 });
+        await fs.chmod(finalPath, 0o640);
+      }
+      const actualSecurityRuntime = await vi.importActual<
+        typeof import("openclaw/plugin-sdk/security-runtime")
+      >("openclaw/plugin-sdk/security-runtime");
+      const publicationOrder: string[] = [];
+      const failSelectedArtifact = async (options: Parameters<typeof replaceFileAtomicMock>[0]) => {
+        publicationOrder.push(path.basename(options.filePath));
+        return await actualSecurityRuntime.replaceFileAtomic({
+          ...options,
+          ...(path.basename(options.filePath) === fileName
+            ? {
+                beforeRename: async ({ tempPath }: { tempPath: string }) => {
+                  await fs.writeFile(tempPath, "partial replacement\n", "utf8");
+                  throw Object.assign(new Error("injected QA artifact publication failure"), {
+                    code: "EIO",
+                  });
+                },
+              }
+            : {}),
+        });
+      };
+
+      await replaceFileAtomicMock.withImplementation(failSelectedArtifact, async () => {
+        await expect(
+          runQaSuite({
+            repoRoot,
+            outputDir: ".artifacts/qa-e2e/artifact-atomic",
+            scenarioIds: ["control-ui-chat-flow-playwright"],
+          }),
+        ).rejects.toMatchObject({ code: "EIO" });
+      });
+
+      const selectedPath = path.join(outputDir, fileName);
+      await expect(fs.readFile(selectedPath, "utf8")).resolves.toBe(sentinels.get(fileName));
+      if (process.platform !== "win32") {
+        expect((await fs.stat(selectedPath)).mode & 0o777).toBe(0o640);
+        expect((await fs.stat(outputDir)).mode & 0o7777).toBe(0o750);
+      }
+      const selectedIndex = canonicalFileNames.indexOf(fileName);
+      expect(publicationOrder).toEqual(canonicalFileNames.slice(0, selectedIndex + 1));
+      expect(
+        (await fs.readdir(outputDir)).filter((entry) =>
+          entry.startsWith(`${fileName}.qa-artifact.`),
+        ),
+      ).toEqual([]);
+    },
+  );
 
   it("aggregates mixed-kind progress through the parent lab", async () => {
     const repoRoot = await makeTempRepo("qa-suite-mixed-progress-");

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -4,8 +4,10 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QaSuiteInfraError } from "./errors.js";
 import type { QaLabServerHandle } from "./lab-server.types.js";
+import type { QaTransportAdapter } from "./qa-transport.js";
+import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
 import type { QaSuiteScenarioResult } from "./suite.js";
-import { throwQaSuiteCleanupErrors } from "./suite.js";
+import { qaSuiteProgressTesting, throwQaSuiteCleanupErrors } from "./suite.js";
 import type {
   QaTestFileScenario,
   QaTestFileScenarioRunResult,
@@ -126,6 +128,64 @@ function mockFlowPartitionFailures(failuresByScenarioId: ReadonlyMap<string, rea
     return await run(params);
   });
   return attempts;
+}
+
+async function expectArtifactPublicationFailurePreservesPrior(params: {
+  canonicalFileNames: readonly string[];
+  failedFileName: string;
+  outputDir: string;
+  publish: () => Promise<unknown>;
+}) {
+  const sentinels = new Map(
+    params.canonicalFileNames.map((fileName) => [fileName, `prior ${fileName}\n`]),
+  );
+  await fs.mkdir(params.outputDir, { recursive: true, mode: 0o750 });
+  await fs.chmod(params.outputDir, 0o750);
+  for (const [fileName, sentinel] of sentinels) {
+    const finalPath = path.join(params.outputDir, fileName);
+    await fs.writeFile(finalPath, sentinel, { encoding: "utf8", mode: 0o640 });
+    await fs.chmod(finalPath, 0o640);
+  }
+  const actualSecurityRuntime = await vi.importActual<
+    typeof import("openclaw/plugin-sdk/security-runtime")
+  >("openclaw/plugin-sdk/security-runtime");
+  const publicationOrder: string[] = [];
+  const failSelectedArtifact = async (options: Parameters<typeof replaceFileAtomicMock>[0]) => {
+    publicationOrder.push(path.basename(options.filePath));
+    return await actualSecurityRuntime.replaceFileAtomic({
+      ...options,
+      ...(path.basename(options.filePath) === params.failedFileName
+        ? {
+            beforeRename: async ({ tempPath }: { tempPath: string }) => {
+              await fs.writeFile(tempPath, "partial replacement\n", "utf8");
+              throw Object.assign(new Error("injected QA artifact publication failure"), {
+                code: "EIO",
+              });
+            },
+          }
+        : {}),
+    });
+  };
+
+  await replaceFileAtomicMock.withImplementation(failSelectedArtifact, async () => {
+    await expect(params.publish()).rejects.toMatchObject({ code: "EIO" });
+  });
+
+  const selectedPath = path.join(params.outputDir, params.failedFileName);
+  await expect(fs.readFile(selectedPath, "utf8")).resolves.toBe(
+    sentinels.get(params.failedFileName),
+  );
+  if (process.platform !== "win32") {
+    expect((await fs.stat(selectedPath)).mode & 0o777).toBe(0o640);
+    expect((await fs.stat(params.outputDir)).mode & 0o7777).toBe(0o750);
+  }
+  const selectedIndex = params.canonicalFileNames.indexOf(params.failedFileName);
+  expect(publicationOrder).toEqual(params.canonicalFileNames.slice(0, selectedIndex + 1));
+  expect(
+    (await fs.readdir(params.outputDir)).filter((entry) =>
+      entry.startsWith(`${params.failedFileName}.qa-artifact.`),
+    ),
+  ).toEqual([]);
 }
 
 describe("qa suite runtime launcher", () => {
@@ -1235,6 +1295,39 @@ describe("qa suite runtime launcher", () => {
   });
 
   it.each([
+    { kind: "report", fileName: "qa-suite-report.md" },
+    { kind: "evidence", fileName: "qa-evidence.json" },
+    { kind: "summary", fileName: "qa-suite-summary.json" },
+  ])(
+    "preserves the prior standard $kind artifact when atomic publication fails",
+    async ({ fileName }) => {
+      const outputDir = await makeTempRepo("qa-suite-standard-artifact-atomic-");
+      await expectArtifactPublicationFailurePreservesPrior({
+        canonicalFileNames: ["qa-suite-report.md", "qa-evidence.json", "qa-suite-summary.json"],
+        failedFileName: fileName,
+        outputDir,
+        publish: async () =>
+          await qaSuiteProgressTesting.writeQaSuiteArtifacts({
+            outputDir,
+            startedAt: new Date("2026-08-12T00:00:00.000Z"),
+            finishedAt: new Date("2026-08-12T00:01:00.000Z"),
+            scenarios: [{ name: "Atomic publication", status: "pass", steps: [] }],
+            scenarioDefinitions: [makeQaSuiteTestScenario("channel-chat-baseline")],
+            transport: {
+              id: "qa-channel",
+              createReportNotes: () => [],
+            } as unknown as QaTransportAdapter,
+            providerMode: "mock-openai",
+            primaryModel: "mock-openai/gpt-5.6-luna",
+            alternateModel: "mock-openai/gpt-5.6-luna-alt",
+            fastMode: true,
+            concurrency: 1,
+          }),
+      });
+    },
+  );
+
+  it.each([
     { kind: "evidence", fileName: "qa-evidence.json" },
     { kind: "report", fileName: "qa-suite-report.md" },
     { kind: "summary", fileName: "qa-suite-summary.json" },
@@ -1243,68 +1336,17 @@ describe("qa suite runtime launcher", () => {
     async ({ fileName }) => {
       const repoRoot = await makeTempRepo("qa-suite-unified-artifact-atomic-");
       const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "artifact-atomic");
-      const canonicalFileNames = [
-        "qa-evidence.json",
-        "qa-suite-report.md",
-        "qa-suite-summary.json",
-      ];
-      const sentinels = new Map(
-        canonicalFileNames.map((canonicalFileName) => [
-          canonicalFileName,
-          `prior ${canonicalFileName}\n`,
-        ]),
-      );
-      await fs.mkdir(outputDir, { recursive: true, mode: 0o750 });
-      await fs.chmod(outputDir, 0o750);
-      for (const [canonicalFileName, sentinel] of sentinels) {
-        const finalPath = path.join(outputDir, canonicalFileName);
-        await fs.writeFile(finalPath, sentinel, { encoding: "utf8", mode: 0o640 });
-        await fs.chmod(finalPath, 0o640);
-      }
-      const actualSecurityRuntime = await vi.importActual<
-        typeof import("openclaw/plugin-sdk/security-runtime")
-      >("openclaw/plugin-sdk/security-runtime");
-      const publicationOrder: string[] = [];
-      const failSelectedArtifact = async (options: Parameters<typeof replaceFileAtomicMock>[0]) => {
-        publicationOrder.push(path.basename(options.filePath));
-        return await actualSecurityRuntime.replaceFileAtomic({
-          ...options,
-          ...(path.basename(options.filePath) === fileName
-            ? {
-                beforeRename: async ({ tempPath }: { tempPath: string }) => {
-                  await fs.writeFile(tempPath, "partial replacement\n", "utf8");
-                  throw Object.assign(new Error("injected QA artifact publication failure"), {
-                    code: "EIO",
-                  });
-                },
-              }
-            : {}),
-        });
-      };
-
-      await replaceFileAtomicMock.withImplementation(failSelectedArtifact, async () => {
-        await expect(
-          runQaSuite({
+      await expectArtifactPublicationFailurePreservesPrior({
+        canonicalFileNames: ["qa-evidence.json", "qa-suite-report.md", "qa-suite-summary.json"],
+        failedFileName: fileName,
+        outputDir,
+        publish: async () =>
+          await runQaSuite({
             repoRoot,
             outputDir: ".artifacts/qa-e2e/artifact-atomic",
             scenarioIds: ["control-ui-chat-flow-playwright"],
           }),
-        ).rejects.toMatchObject({ code: "EIO" });
       });
-
-      const selectedPath = path.join(outputDir, fileName);
-      await expect(fs.readFile(selectedPath, "utf8")).resolves.toBe(sentinels.get(fileName));
-      if (process.platform !== "win32") {
-        expect((await fs.stat(selectedPath)).mode & 0o777).toBe(0o640);
-        expect((await fs.stat(outputDir)).mode & 0o7777).toBe(0o750);
-      }
-      const selectedIndex = canonicalFileNames.indexOf(fileName);
-      expect(publicationOrder).toEqual(canonicalFileNames.slice(0, selectedIndex + 1));
-      expect(
-        (await fs.readdir(outputDir)).filter((entry) =>
-          entry.startsWith(`${fileName}.qa-artifact.`),
-        ),
-      ).toEqual([]);
     },
   );
 

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -28,6 +28,7 @@ import {
   type QaSeedScenarioWithSource,
 } from "./scenario-catalog.js";
 import { expandQaScenarioExecutionCells, type QaScenarioExecutionCell } from "./scenario-lane.js";
+import { publishQaSuiteArtifactFiles } from "./suite-artifacts.js";
 import {
   mapQaSuiteWithConcurrency,
   normalizeQaSuiteConcurrency,
@@ -705,7 +706,6 @@ async function writeUnifiedQaSuiteArtifacts(params: {
   scenarios: readonly QaSuiteScenarioResult[];
   startedAt: Date;
 }) {
-  await fs.mkdir(params.outputDir, { recursive: true });
   const evidencePath = path.join(params.outputDir, QA_EVIDENCE_FILENAME);
   const reportPath = path.join(params.outputDir, "qa-suite-report.md");
   const summaryPath = path.join(params.outputDir, "qa-suite-summary.json");
@@ -729,9 +729,14 @@ async function writeUnifiedQaSuiteArtifacts(params: {
     scenarios: [...params.scenarios],
     startedAt: params.startedAt,
   }) satisfies QaSuiteSummaryJson;
-  await fs.writeFile(evidencePath, `${JSON.stringify(params.evidence, null, 2)}\n`, "utf8");
-  await fs.writeFile(reportPath, report, "utf8");
-  await fs.writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+  await publishQaSuiteArtifactFiles({
+    outputDir: params.outputDir,
+    files: [
+      { filePath: evidencePath, content: `${JSON.stringify(params.evidence, null, 2)}\n` },
+      { filePath: reportPath, content: report },
+      { filePath: summaryPath, content: `${JSON.stringify(summary, null, 2)}\n` },
+    ],
+  });
   return {
     evidencePath,
     outputDir: params.outputDir,

--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -12,22 +12,14 @@ import { qaSuiteProgressTesting, runQaFlowSuite } from "./suite.js";
 import { createTempDirHarness } from "./temp-dir.test-helper.js";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
-const replaceFileAtomicMock = vi.hoisted(() => vi.fn());
 const tempDirs = createTempDirHarness();
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
 }));
 
-vi.mock("openclaw/plugin-sdk/security-runtime", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/security-runtime")>();
-  replaceFileAtomicMock.mockImplementation(actual.replaceFileAtomic);
-  return { ...actual, replaceFileAtomic: replaceFileAtomicMock };
-});
-
 afterEach(async () => {
   fetchWithSsrFGuardMock.mockReset();
-  replaceFileAtomicMock.mockClear();
   vi.useRealTimers();
   await tempDirs.cleanup();
 });
@@ -629,89 +621,6 @@ describe("qa suite", () => {
       await fs.rm(outputDir, { recursive: true, force: true });
     }
   });
-
-  it.each([
-    { kind: "report", fileName: "qa-suite-report.md" },
-    { kind: "evidence", fileName: "qa-evidence.json" },
-    { kind: "summary", fileName: "qa-suite-summary.json" },
-  ])(
-    "preserves the prior canonical $kind artifact when atomic publication fails",
-    async ({ fileName }) => {
-      const outputDir = await tempDirs.makeTempDir("qa-suite-artifact-atomic-");
-      const canonicalFileNames = [
-        "qa-suite-report.md",
-        "qa-evidence.json",
-        "qa-suite-summary.json",
-      ];
-      const sentinels = new Map(
-        canonicalFileNames.map((canonicalFileName) => [
-          canonicalFileName,
-          `prior ${canonicalFileName}\n`,
-        ]),
-      );
-      await fs.chmod(outputDir, 0o750);
-      for (const [canonicalFileName, sentinel] of sentinels) {
-        const finalPath = path.join(outputDir, canonicalFileName);
-        await fs.writeFile(finalPath, sentinel, { encoding: "utf8", mode: 0o640 });
-        await fs.chmod(finalPath, 0o640);
-      }
-      const actualSecurityRuntime = await vi.importActual<
-        typeof import("openclaw/plugin-sdk/security-runtime")
-      >("openclaw/plugin-sdk/security-runtime");
-      const publicationOrder: string[] = [];
-      const failSelectedArtifact = async (options: Parameters<typeof replaceFileAtomicMock>[0]) => {
-        publicationOrder.push(path.basename(options.filePath));
-        return await actualSecurityRuntime.replaceFileAtomic({
-          ...options,
-          ...(path.basename(options.filePath) === fileName
-            ? {
-                beforeRename: async ({ tempPath }: { tempPath: string }) => {
-                  await fs.writeFile(tempPath, "partial replacement\n", "utf8");
-                  throw Object.assign(new Error("injected QA artifact publication failure"), {
-                    code: "EIO",
-                  });
-                },
-              }
-            : {}),
-        });
-      };
-
-      await replaceFileAtomicMock.withImplementation(failSelectedArtifact, async () => {
-        await expect(
-          qaSuiteProgressTesting.writeQaSuiteArtifacts({
-            outputDir,
-            startedAt: new Date("2026-08-12T00:00:00.000Z"),
-            finishedAt: new Date("2026-08-12T00:01:00.000Z"),
-            scenarios: [{ name: "Atomic publication", status: "pass", steps: [] }],
-            scenarioDefinitions: [makeQaSuiteTestScenario("channel-chat-baseline")],
-            transport: {
-              id: "qa-channel",
-              createReportNotes: () => [],
-            } as unknown as QaTransportAdapter,
-            providerMode: "mock-openai",
-            primaryModel: "mock-openai/gpt-5.6-luna",
-            alternateModel: "mock-openai/gpt-5.6-luna-alt",
-            fastMode: true,
-            concurrency: 1,
-          }),
-        ).rejects.toMatchObject({ code: "EIO" });
-      });
-
-      const selectedPath = path.join(outputDir, fileName);
-      await expect(fs.readFile(selectedPath, "utf8")).resolves.toBe(sentinels.get(fileName));
-      if (process.platform !== "win32") {
-        expect((await fs.stat(selectedPath)).mode & 0o777).toBe(0o640);
-        expect((await fs.stat(outputDir)).mode & 0o7777).toBe(0o750);
-      }
-      const selectedIndex = canonicalFileNames.indexOf(fileName);
-      expect(publicationOrder).toEqual(canonicalFileNames.slice(0, selectedIndex + 1));
-      expect(
-        (await fs.readdir(outputDir)).filter((entry) =>
-          entry.startsWith(`${fileName}.qa-artifact.`),
-        ),
-      ).toEqual([]);
-    },
-  );
 
   it("can return evidence without writing duplicate child evidence files", async () => {
     const outputDir = await tempDirs.makeTempDir("qa-suite-artifacts-memory-evidence-");

--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -12,14 +12,22 @@ import { qaSuiteProgressTesting, runQaFlowSuite } from "./suite.js";
 import { createTempDirHarness } from "./temp-dir.test-helper.js";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+const replaceFileAtomicMock = vi.hoisted(() => vi.fn());
 const tempDirs = createTempDirHarness();
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
 }));
 
+vi.mock("openclaw/plugin-sdk/security-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/security-runtime")>();
+  replaceFileAtomicMock.mockImplementation(actual.replaceFileAtomic);
+  return { ...actual, replaceFileAtomic: replaceFileAtomicMock };
+});
+
 afterEach(async () => {
   fetchWithSsrFGuardMock.mockReset();
+  replaceFileAtomicMock.mockClear();
   vi.useRealTimers();
   await tempDirs.cleanup();
 });
@@ -608,10 +616,102 @@ describe("qa suite", () => {
         evidence?: unknown;
       };
       expect(summary.evidence).toBeUndefined();
+      if (process.platform !== "win32") {
+        for (const artifactPath of [
+          artifacts.reportPath,
+          artifacts.evidencePath,
+          artifacts.summaryPath,
+        ]) {
+          expect((await fs.stat(artifactPath)).mode & 0o777).toBe(0o600);
+        }
+      }
     } finally {
       await fs.rm(outputDir, { recursive: true, force: true });
     }
   });
+
+  it.each([
+    { kind: "report", fileName: "qa-suite-report.md" },
+    { kind: "evidence", fileName: "qa-evidence.json" },
+    { kind: "summary", fileName: "qa-suite-summary.json" },
+  ])(
+    "preserves the prior canonical $kind artifact when atomic publication fails",
+    async ({ fileName }) => {
+      const outputDir = await tempDirs.makeTempDir("qa-suite-artifact-atomic-");
+      const canonicalFileNames = [
+        "qa-suite-report.md",
+        "qa-evidence.json",
+        "qa-suite-summary.json",
+      ];
+      const sentinels = new Map(
+        canonicalFileNames.map((canonicalFileName) => [
+          canonicalFileName,
+          `prior ${canonicalFileName}\n`,
+        ]),
+      );
+      await fs.chmod(outputDir, 0o750);
+      for (const [canonicalFileName, sentinel] of sentinels) {
+        const finalPath = path.join(outputDir, canonicalFileName);
+        await fs.writeFile(finalPath, sentinel, { encoding: "utf8", mode: 0o640 });
+        await fs.chmod(finalPath, 0o640);
+      }
+      const actualSecurityRuntime = await vi.importActual<
+        typeof import("openclaw/plugin-sdk/security-runtime")
+      >("openclaw/plugin-sdk/security-runtime");
+      const publicationOrder: string[] = [];
+      const failSelectedArtifact = async (options: Parameters<typeof replaceFileAtomicMock>[0]) => {
+        publicationOrder.push(path.basename(options.filePath));
+        return await actualSecurityRuntime.replaceFileAtomic({
+          ...options,
+          ...(path.basename(options.filePath) === fileName
+            ? {
+                beforeRename: async ({ tempPath }: { tempPath: string }) => {
+                  await fs.writeFile(tempPath, "partial replacement\n", "utf8");
+                  throw Object.assign(new Error("injected QA artifact publication failure"), {
+                    code: "EIO",
+                  });
+                },
+              }
+            : {}),
+        });
+      };
+
+      await replaceFileAtomicMock.withImplementation(failSelectedArtifact, async () => {
+        await expect(
+          qaSuiteProgressTesting.writeQaSuiteArtifacts({
+            outputDir,
+            startedAt: new Date("2026-08-12T00:00:00.000Z"),
+            finishedAt: new Date("2026-08-12T00:01:00.000Z"),
+            scenarios: [{ name: "Atomic publication", status: "pass", steps: [] }],
+            scenarioDefinitions: [makeQaSuiteTestScenario("channel-chat-baseline")],
+            transport: {
+              id: "qa-channel",
+              createReportNotes: () => [],
+            } as unknown as QaTransportAdapter,
+            providerMode: "mock-openai",
+            primaryModel: "mock-openai/gpt-5.6-luna",
+            alternateModel: "mock-openai/gpt-5.6-luna-alt",
+            fastMode: true,
+            concurrency: 1,
+          }),
+        ).rejects.toMatchObject({ code: "EIO" });
+      });
+
+      const selectedPath = path.join(outputDir, fileName);
+      await expect(fs.readFile(selectedPath, "utf8")).resolves.toBe(sentinels.get(fileName));
+      if (process.platform !== "win32") {
+        expect((await fs.stat(selectedPath)).mode & 0o777).toBe(0o640);
+        expect((await fs.stat(outputDir)).mode & 0o7777).toBe(0o750);
+      }
+      const selectedIndex = canonicalFileNames.indexOf(fileName);
+      expect(publicationOrder).toEqual(canonicalFileNames.slice(0, selectedIndex + 1));
+      expect(
+        (await fs.readdir(outputDir)).filter((entry) =>
+          entry.startsWith(`${fileName}.qa-artifact.`),
+        ),
+      ).toEqual([]);
+    },
+  );
 
   it("can return evidence without writing duplicate child evidence files", async () => {
     const outputDir = await tempDirs.makeTempDir("qa-suite-artifacts-memory-evidence-");


### PR DESCRIPTION
Closes #122573

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where QA Lab operators reusing an artifact directory could lose the last valid canonical report, evidence, or summary when an I/O failure interrupted publication. Direct final-path writes could truncate a previous artifact before surfacing the error, and the existing existence check could not distinguish that partial file from a valid result.

## Why This Change Was Made

One QA-owned publisher now routes both standard/isolated and unified canonical artifacts through the public Plugin SDK atomic replacement primitive. It replaces each file atomically in the existing order, preserves an existing file's mode, creates new files as `0600`, synchronizes staged content and the parent directory, and surfaces cleanup failures.

The summary remains the last completion signal. This is intentionally per-file atomic publication, not a multi-file transaction: the canonical public paths are stable and their output directory also contains noncanonical run assets, so a directory swap would change the ownership boundary and artifact contract.

## User Impact

After a failed canonical artifact write, operators and downstream QA/parity tooling retain the prior complete file instead of observing truncated Markdown or JSON. Successful runs keep the same paths, result shapes, optional-evidence behavior, publication order, and existing permissions.

## Evidence

- Authentic pre-fix reproduction with the new tests retained and only production reverted: `node scripts/run-vitest.mjs extensions/qa-lab/src/suite.test.ts extensions/qa-lab/src/suite-launch.runtime.test.ts` failed as intended with 7 failures / 87 passes. All three standard and all three unified injected failures bypassed atomic publication; the new-file mode assertion also observed `0644` instead of `0600`.
- Post-fix focused proof: the same command passes 94/94 tests.
- Hosted changed gate: Blacksmith Testbox `tbx_01kztptwmq87fmj3f2kzn6c9k5`, https://github.com/openclaw/openclaw/actions/runs/31585726581 — passed extension production/test typechecks, lint, formatting, Plugin SDK contracts/boundaries, dead-export scan, and repository guards.
- Review: fresh full-branch autoreview clean with no accepted/actionable findings; TruffleHog clean; overall 0.98.
- Exact-head pull-request CI: https://github.com/openclaw/openclaw/actions/runs/31586512917 — all selected jobs and `openclaw/ci-gate` passed on `a06e6a6d22d57b95e85f50e089c370b464c65915`.
- ClawSweeper exact-head review artifact: no findings; correctness confidence 0.92, proof tier A. Its fresh-file permission question is resolved by the maintainer work order's explicit `0600` requirement. The durable comment publisher is late; no rebase was done solely for advisory behind-main drift because GitHub reports the head mergeable and exact-head CI is green.
- LOC: production +52/-20 (net +32); tests +135/-1 (net +134). Production growth establishes one canonical owner for durable publication and removes both direct-write paths.

Proof gap: the regression is deterministic filesystem failure injection and no live provider/channel behavior changes. Per the scoped work order, no live QA, release, or deployment was run.
