### PR TITLE
fix(test): wait for gateway hook model activity

### DIFF
--- a/test/gateway-hook-concurrency.e2e.test.ts
+++ b/test/gateway-hook-concurrency.e2e.test.ts
@@ -89,7 +89,10 @@ describe("Gateway hook concurrency", () => {
         error: "hook agent run did not start before admission timeout",
         runId: expect.any(String),
       });
-      expect(modelServer.active(), instance.logs()).toBeGreaterThan(0);
+      await vi.waitFor(() => expect(modelServer.active(), instance.logs()).toBeGreaterThan(0), {
+        interval: 20,
+        timeout: 30_000,
+      });
       expect(modelServer.peak(), instance.logs()).toBeLessThanOrEqual(SHARED_BUDGET);
       expect(modelServer.requestCount(), instance.logs()).toBeLessThanOrEqual(SHARED_BUDGET + 1);
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the gateway hook concurrency E2E could fail after all hook responses settled but before the held model server recorded its first active request.

## Why This Change Was Made

The test now waits within the existing 30-second synchronization budget for model activity instead of sampling it once. The assertion still reports captured gateway logs on timeout, and no production behavior changes.

## User Impact

No user-visible product change. Release validation no longer fails on this model-request scheduling race.

## Evidence

- Four independent Blacksmith Testbox focused runs passed:
  - `tbx_01kztpyr6pdzjqea5h7by2qvtx`
  - `tbx_01kztpyr6xjyhw7yg4ybqrbj6r`
  - `tbx_01kztpyr69jpqyb7rhad09fm2e`
  - `tbx_01kztpyr81ca9s7nj97e4v5t16`
- Known predecessor-order slice passed: 2 files, 11 tests (`tbx_01kztqahqzn44mbdyqywdn2w2j`).
- Scoped changed checks passed (`tbx_01kztqn4syyxgemk4kx7hqa2p5`).
- `git diff --check` passed.
- Autoreview: clean, no accepted/actionable findings.
