### PR TITLE
fix(doctor): report legacy cache scan failures

### DIFF
--- a/src/commands/doctor-usage-cost-cache.test.ts
+++ b/src/commands/doctor-usage-cost-cache.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -10,9 +10,15 @@ import {
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { maybeRepairLegacyRuntimeFiles } from "./doctor-usage-cost-cache.js";
 
+const note = vi.hoisted(() => vi.fn());
+
+vi.mock("../../packages/terminal-core/src/note.js", () => ({ note }));
+
 let root: string | undefined;
 
 afterEach(async () => {
+  vi.restoreAllMocks();
+  note.mockReset();
   closeOpenClawAgentDatabasesForTest();
   closeOpenClawStateDatabaseForTest();
   if (root) {
@@ -125,8 +131,89 @@ describe("legacy usage-cost cache cleanup", () => {
       ]);
     }
   });
+
+  it.each([
+    [
+      "reports an unreadable agent root without claiming a complete scan",
+      "root",
+      "readdir",
+      "EACCES",
+      false,
+      true,
+    ],
+    [
+      "reports an unreadable temp entry without removing partial scan results",
+      "entry",
+      "stat",
+      "EIO",
+      true,
+      true,
+    ],
+    ["treats a missing agent root as harmless absence", "root", "readdir", "ENOENT", true, false],
+    [
+      "skips a temp entry that disappears between readdir and stat",
+      "entry",
+      "stat",
+      "ENOENT",
+      true,
+      false,
+    ],
+  ] as const)("%s", async (_name, scope, operation, code, shouldRepair, diagnostic) => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), `openclaw-usage-cost-${scope}-fault-`));
+    const agentsDir = path.join(root, "agents");
+    const sessionsDir =
+      scope === "root" ? path.join(root, "sessions") : path.join(agentsDir, "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    if (scope === "root") {
+      await fs.mkdir(agentsDir);
+    }
+    const cacheFile = path.join(sessionsDir, ".usage-cost-cache.json");
+    const tempFile = path.join(sessionsDir, ".usage-cost-cache.123.tmp");
+    await fs.writeFile(cacheFile, "x");
+    if (scope === "entry") {
+      await fs.writeFile(tempFile, "x");
+    }
+    const error = fsError(code);
+    if (operation === "readdir") {
+      vi.spyOn(fs, "readdir").mockRejectedValueOnce(error);
+    } else {
+      vi.spyOn(fs, "stat").mockRejectedValueOnce(error);
+    }
+
+    await maybeRepairLegacyRuntimeFiles(shouldRepair, {
+      OPENCLAW_STATE_DIR: root,
+    } as NodeJS.ProcessEnv);
+
+    if (diagnostic) {
+      const action = shouldRepair ? "scan and cleanup" : "scan";
+      expect(note).toHaveBeenCalledOnce();
+      expect(note).toHaveBeenCalledWith(
+        expect.stringMatching(
+          new RegExp(`usage-cost cache ${action} could not be completed`, "iu"),
+        ),
+        "Usage cost cache",
+      );
+      expect(note.mock.calls[0]?.[0]).toContain(scope === "root" ? agentsDir : tempFile);
+      expect(note.mock.calls[0]?.[0]).toContain(code);
+      expect(note.mock.calls[0]?.[0]).toContain(
+        shouldRepair ? "openclaw doctor --fix" : "openclaw doctor",
+      );
+      expect(note.mock.calls[0]?.[0]).not.toContain("Removed");
+      await expect(fs.readFile(cacheFile, "utf8")).resolves.toBe("x");
+      return;
+    }
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining("Removed 1 rebuildable legacy usage-cost cache file"),
+      "Usage cost cache",
+    );
+    await expect(fs.stat(cacheFile)).rejects.toMatchObject({ code: "ENOENT" });
+  });
 });
 
 function randomUploadId(): string {
   return "11111111-1111-4111-8111-111111111111";
+}
+
+function fsError(code: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(`${code}: injected filesystem failure`), { code });
 }

--- a/src/commands/doctor-usage-cost-cache.ts
+++ b/src/commands/doctor-usage-cost-cache.ts
@@ -23,7 +23,9 @@ async function readFilesystemEntryOrMissing<T>(
     if (hasErrnoCode(error, "ENOENT")) {
       return null;
     }
-    throw new Error(`${shortenHomePath(filePath)}: ${formatErrorMessage(error)}`);
+    throw new Error(`${shortenHomePath(filePath)}: ${formatErrorMessage(error)}`, {
+      cause: error,
+    });
   }
 }
 
@@ -84,7 +86,7 @@ async function maybeRemoveLegacyUsageCostCacheFiles(params: {
   env?: NodeJS.ProcessEnv;
   homedir?: () => string;
 }): Promise<void> {
-  const files = await detectLegacyUsageCostCacheFiles(params).catch((error) => {
+  const files = await detectLegacyUsageCostCacheFiles(params).catch((error: unknown) => {
     const command = params.shouldRepair ? "openclaw doctor --fix" : "openclaw doctor";
     const action = params.shouldRepair ? "scan and cleanup" : "scan";
     note(

--- a/src/commands/doctor-usage-cost-cache.ts
+++ b/src/commands/doctor-usage-cost-cache.ts
@@ -4,12 +4,28 @@ import os from "node:os";
 import path from "node:path";
 import { note } from "../../packages/terminal-core/src/note.js";
 import { resolveStateDir } from "../config/paths.js";
+import { formatErrorMessage, hasErrnoCode } from "../infra/errors.js";
 import { deleteSessionCostUsageRollupsExcept } from "../infra/session-cost-usage-cache.sqlite.js";
 import { listOpenClawRegisteredAgentDatabases } from "../state/openclaw-agent-db.js";
+import { shortenHomePath } from "../utils.js";
 import { runDoctorAgentDatabaseOperation } from "./doctor-agent-database-operation.js";
 import { maybeScrubConfigAuditLog } from "./doctor-config-audit-scrub.js";
 
 const LEGACY_USAGE_COST_TEMP_GRACE_MS = 10_000;
+
+async function readFilesystemEntryOrMissing<T>(
+  filePath: string,
+  read: () => Promise<T>,
+): Promise<T | null> {
+  try {
+    return await read();
+  } catch (error) {
+    if (hasErrnoCode(error, "ENOENT")) {
+      return null;
+    }
+    throw new Error(`${shortenHomePath(filePath)}: ${formatErrorMessage(error)}`);
+  }
+}
 
 function isLegacyUsageCostCacheTempName(name: string): boolean {
   return (
@@ -28,7 +44,10 @@ async function detectLegacyUsageCostCacheFiles(params?: {
   const stateDir = resolveStateDir(params?.env ?? process.env, params?.homedir ?? os.homedir);
   const sessionDirs = [path.join(stateDir, "sessions")];
   const agentsDir = path.join(stateDir, "agents");
-  const agentEntries = await fs.readdir(agentsDir, { withFileTypes: true }).catch(() => []);
+  const agentEntries =
+    (await readFilesystemEntryOrMissing(agentsDir, () =>
+      fs.readdir(agentsDir, { withFileTypes: true }),
+    )) ?? [];
   for (const entry of agentEntries) {
     if (entry.isDirectory()) {
       sessionDirs.push(path.join(agentsDir, entry.name, "sessions"));
@@ -36,7 +55,10 @@ async function detectLegacyUsageCostCacheFiles(params?: {
   }
   const files: string[] = [];
   for (const sessionDir of sessionDirs) {
-    const entries = await fs.readdir(sessionDir, { withFileTypes: true }).catch(() => []);
+    const entries =
+      (await readFilesystemEntryOrMissing(sessionDir, () =>
+        fs.readdir(sessionDir, { withFileTypes: true }),
+      )) ?? [];
     for (const entry of entries) {
       if (!entry.isFile()) {
         continue;
@@ -47,7 +69,7 @@ async function detectLegacyUsageCostCacheFiles(params?: {
         continue;
       }
       if (isLegacyUsageCostCacheTempName(entry.name)) {
-        const stats = await fs.stat(filePath).catch(() => null);
+        const stats = await readFilesystemEntryOrMissing(filePath, () => fs.stat(filePath));
         if (stats && Date.now() - stats.mtimeMs >= LEGACY_USAGE_COST_TEMP_GRACE_MS) {
           files.push(filePath);
         }
@@ -62,7 +84,22 @@ async function maybeRemoveLegacyUsageCostCacheFiles(params: {
   env?: NodeJS.ProcessEnv;
   homedir?: () => string;
 }): Promise<void> {
-  const files = await detectLegacyUsageCostCacheFiles(params);
+  const files = await detectLegacyUsageCostCacheFiles(params).catch((error) => {
+    const command = params.shouldRepair ? "openclaw doctor --fix" : "openclaw doctor";
+    const action = params.shouldRepair ? "scan and cleanup" : "scan";
+    note(
+      [
+        `Legacy usage-cost cache ${action} could not be completed; ${params.shouldRepair ? "no sidecar files were removed" : "cache state may remain uninspected"}.`,
+        `- ${formatErrorMessage(error)}`,
+        `Resolve the filesystem error and rerun \`${command}\`.`,
+      ].join("\n"),
+      "Usage cost cache",
+    );
+    return null;
+  });
+  if (!files) {
+    return;
+  }
   if (files.length === 0) {
     return;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Doctor treated every legacy usage-cost cache scan failure as an empty directory. Permission and I/O errors such as `EACCES` or `EIO` could therefore disappear, letting `openclaw doctor` or `doctor --fix` finish without explaining that cache state was uninspected or that cleanup was skipped.

## Why This Change Was Made

The usage-cache scanner now treats only `ENOENT` as absence. Other directory and temp-file stat failures retain shortened path context, produce an actionable Doctor note, and abort cleanup before any files from an incomplete scan are removed. A file disappearing between listing and stat remains a harmless race.

The fix stays local to usage-cost cache scanning; adjacent skill-upload and database cleanup behavior is unchanged.

AI-assisted: yes. The final implementation and fault-injection tests were manually reviewed and passed fresh structured autoreview.

## User Impact

Doctor now tells operators when permissions or filesystem I/O prevented a complete legacy cache scan, names the affected path, and gives the exact command to retry. `doctor --fix` no longer claims or performs partial sidecar cleanup after an incomplete scan.

## Evidence

- Pre-fix fault regression: injected root `EACCES` produced no diagnostic, and entry `EIO` allowed a false removal claim.
- Focused fault matrix covers root `EACCES`, entry `EIO`, root `ENOENT`, and an entry disappearing with `ENOENT`.
- `node scripts/run-vitest.mjs src/commands/doctor-usage-cost-cache.test.ts` — 8/8 passed on the final rebased head.
- Full changed gate passed on Testbox `tbx_01kztqc0pdz03qtk9wm9ne32sf` ([run](https://github.com/openclaw/openclaw/actions/runs/31586425671)).
- Final rebase preserved both patch IDs; formatting and `git diff --check` passed.
- Hosted exact-head CI — green on attempt 2 ([run](https://github.com/openclaw/openclaw/actions/runs/31587214625)); attempt 1 only hit an unrelated timer-sensitive `ui/src/api/gateway.node.test.ts` failure, which passed unchanged on rerun.
- Fresh rebased-head autoreview — clean.
- Production +43/−4 (net +39); tests +88/−1. Growth is one reusable ENOENT-aware filesystem reader plus the visible incomplete-scan diagnostic; no new API, config, or generalized filesystem layer was added.
- A separate follow-up commit preserved the original filesystem error as `cause` after the changed gate identified lint requirements; behavior is unchanged.
