### PR TITLE
fix(doctor): stop scanning sibling account state directories

### DIFF
--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -477,7 +477,7 @@ That stages grounded durable candidates into the short-term dreaming store while
     - **Session directory permissions**: checks existing session and store directories for writability. Missing archive directories are healthy on fresh profiles and are created when needed.
     - **Legacy transcript mismatch**: warns when recent legacy session entries have missing transcript files. SQLite-owned sessions do not require archived JSONL files.
     - **Legacy main session "1-line JSONL"**: flags when an unimported main transcript has only one line (history was not accumulating).
-    - **Multiple state dirs**: warns when multiple `~/.openclaw` folders exist across home directories, or when `OPENCLAW_STATE_DIR` points elsewhere (history can split between installs).
+    - **Multiple state dirs**: warns when the active state directory differs from the current account's default `~/.openclaw` directory and that default exists (history can split between installs).
     - **Remote mode reminder**: if `gateway.mode=remote`, doctor reminds you to run it on the remote host (the state lives there).
     - **Config file permissions**: warns if `~/.openclaw/openclaw.json` is group/world readable and offers to tighten to `600`.
 

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -477,7 +477,7 @@ That stages grounded durable candidates into the short-term dreaming store while
     - **Session directory permissions**: checks existing session and store directories for writability. Missing archive directories are healthy on fresh profiles and are created when needed.
     - **Legacy transcript mismatch**: warns when recent legacy session entries have missing transcript files. SQLite-owned sessions do not require archived JSONL files.
     - **Legacy main session "1-line JSONL"**: flags when an unimported main transcript has only one line (history was not accumulating).
-    - **Multiple state dirs**: warns when the active state directory differs from the current account's default `~/.openclaw` directory and that default exists (history can split between installs).
+    - **Multiple state dirs**: warns when the active state directory differs from the effective home's default `~/.openclaw` directory and that default exists (history can split between installs). The effective home honors `OPENCLAW_HOME`, `HOME`, and `USERPROFILE`; Doctor does not enumerate other accounts' home directories.
     - **Remote mode reminder**: if `gateway.mode=remote`, doctor reminds you to run it on the remote host (the state lives there).
     - **Config file permissions**: warns if `~/.openclaw/openclaw.json` is group/world readable and offers to tighten to `600`.
 

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -457,7 +457,7 @@ That stages grounded durable candidates into the short-term dreaming store while
     - **Session dirs missing**: `sessions/` and the session store directory are required to persist history and avoid `ENOENT` crashes.
     - **Transcript mismatch**: warns when recent session entries have missing transcript files.
     - **Main session "1-line JSONL"**: flags when the main transcript has only one line (history is not accumulating).
-    - **Multiple state dirs**: warns when multiple `~/.openclaw` folders exist across home directories, or when `OPENCLAW_STATE_DIR` points elsewhere (history can split between installs).
+    - **Multiple state dirs**: warns when the active state directory differs from the current account's default `~/.openclaw` directory and that default exists (history can split between installs).
     - **Remote mode reminder**: if `gateway.mode=remote`, doctor reminds you to run it on the remote host (the state lives there).
     - **Config file permissions**: warns if `~/.openclaw/openclaw.json` is group/world readable and offers to tighten to `600`.
 

--- a/src/commands/doctor-state-integrity.linux-storage.test.ts
+++ b/src/commands/doctor-state-integrity.linux-storage.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   detectLinuxSdBackedStateDir,
+  findOtherStateDirs,
   formatLinuxSdBackedStateDirWarning,
 } from "./doctor-state-integrity.js";
 
@@ -13,6 +14,34 @@ function encodeMountInfoPath(value: string): string {
     .replace(/\t/g, "\\011")
     .replace(/ /g, "\\040");
 }
+
+describe("findOtherStateDirs", () => {
+  it("only checks the current account default state dir", () => {
+    const probedDirs: string[] = [];
+
+    const result = findOtherStateDirs("/var/lib/openclaw", {
+      defaultStateDir: "/home/alice/.openclaw",
+      existsDir: (dir) => {
+        probedDirs.push(dir);
+        return true;
+      },
+    });
+
+    expect(result).toEqual(["/home/alice/.openclaw"]);
+    expect(probedDirs).toEqual(["/home/alice/.openclaw"]);
+  });
+
+  it("does not report the active default state dir as an extra state dir", () => {
+    const result = findOtherStateDirs("/home/alice/.openclaw", {
+      defaultStateDir: "/home/alice/.openclaw",
+      existsDir: () => {
+        throw new Error("default state dir should not be probed when it is active");
+      },
+    });
+
+    expect(result).toEqual([]);
+  });
+});
 
 describe("detectLinuxSdBackedStateDir", () => {
   it("detects state dir on mmc-backed mount", () => {

--- a/src/commands/doctor-state-integrity.linux-storage.test.ts
+++ b/src/commands/doctor-state-integrity.linux-storage.test.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   detectLinuxSdBackedStateDir,
-  findOtherStateDirs,
   formatLinuxSdBackedStateDirWarning,
 } from "./doctor-state-integrity.js";
 
@@ -14,34 +13,6 @@ function encodeMountInfoPath(value: string): string {
     .replace(/\t/g, "\\011")
     .replace(/ /g, "\\040");
 }
-
-describe("findOtherStateDirs", () => {
-  it("only checks the current account default state dir", () => {
-    const probedDirs: string[] = [];
-
-    const result = findOtherStateDirs("/var/lib/openclaw", {
-      defaultStateDir: "/home/alice/.openclaw",
-      existsDir: (dir) => {
-        probedDirs.push(dir);
-        return true;
-      },
-    });
-
-    expect(result).toEqual(["/home/alice/.openclaw"]);
-    expect(probedDirs).toEqual(["/home/alice/.openclaw"]);
-  });
-
-  it("does not report the active default state dir as an extra state dir", () => {
-    const result = findOtherStateDirs("/home/alice/.openclaw", {
-      defaultStateDir: "/home/alice/.openclaw",
-      existsDir: () => {
-        throw new Error("default state dir should not be probed when it is active");
-      },
-    });
-
-    expect(result).toEqual([]);
-  });
-});
 
 describe("detectLinuxSdBackedStateDir", () => {
   it("detects state dir on mmc-backed mount", () => {

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -12,7 +12,12 @@ import { writeConfigMachineState } from "../state/config-machine-state.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withTestDir } from "../test-helpers/temp-dir.js";
-import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
+import {
+  captureEnv,
+  deleteTestEnvValue,
+  setTestEnvValue,
+  withEnvAsync,
+} from "../test-utils/env.js";
 import {
   collectWorkspaceBackupTip,
   detectStateIntegrityHealthIssues,
@@ -526,4 +531,104 @@ describe("doctor state integrity oauth dir checks", () => {
     expect(text.includes("without a matching agents.list entry")).toBe(!configuredAgentDirExists);
     expect(text.includes("Examples: Research (id research)")).toBe(!configuredAgentDirExists);
   });
+});
+
+describe("doctor state directory discovery", () => {
+  it.each([
+    { homeSource: "HOME", activeDefault: false, defaultExists: true, warns: true },
+    { homeSource: "HOME", activeDefault: true, defaultExists: true, warns: false },
+    { homeSource: "HOME", activeDefault: false, defaultExists: false, warns: false },
+    { homeSource: "USERPROFILE", activeDefault: false, defaultExists: true, warns: true },
+    { homeSource: "OPENCLAW_HOME", activeDefault: false, defaultExists: true, warns: true },
+    { homeSource: "OPENCLAW_HOME", activeDefault: false, defaultExists: false, warns: false },
+  ])(
+    "compares only the effective home ($homeSource, activeDefault=$activeDefault, defaultExists=$defaultExists)",
+    async ({ homeSource, activeDefault, defaultExists, warns }) => {
+      await withTestDir({ prefix: "openclaw-doctor-discovery-" }, async (root) => {
+        const osHome = path.join(root, "os-home");
+        const effectiveHome =
+          homeSource === "OPENCLAW_HOME" ? path.join(root, "relocated") : osHome;
+        const defaultState = path.join(effectiveHome, ".openclaw");
+        const activeState = activeDefault ? defaultState : path.join(root, "selected-state");
+        fs.mkdirSync(activeState, { recursive: true, mode: 0o700 });
+        if (defaultExists) {
+          fs.mkdirSync(defaultState, { recursive: true, mode: 0o700 });
+        }
+        if (homeSource === "OPENCLAW_HOME") {
+          fs.mkdirSync(path.join(osHome, ".openclaw"), { recursive: true, mode: 0o700 });
+        }
+        await withEnvAsync(
+          {
+            HOME: homeSource === "USERPROFILE" ? undefined : osHome,
+            USERPROFILE: osHome,
+            OPENCLAW_HOME: homeSource === "OPENCLAW_HOME" ? effectiveHome : undefined,
+            OPENCLAW_STATE_DIR: activeState,
+            OPENCLAW_AGENT_DIR: undefined,
+            OPENCLAW_OAUTH_DIR: undefined,
+          },
+          async () => {
+            const attemptedProbes: string[] = [];
+            const readdir = fs.readdirSync;
+            const exists = fs.existsSync;
+            const stat = fs.statSync;
+            const isSiblingPath = (target: fs.PathLike) => {
+              const targetPath = path.resolve(String(target));
+              return (
+                /^\/(?:Users|home)(?:\/|$)/u.test(targetPath) &&
+                targetPath !== root &&
+                !targetPath.startsWith(`${root}${path.sep}`)
+              );
+            };
+            // Fence real account roots, but record every attempt so the old scanner fails.
+            const readdirSpy = vi.spyOn(fs, "readdirSync").mockImplementation((target, options) => {
+              if (isSiblingPath(target)) {
+                attemptedProbes.push(`readdir ${String(target)}`);
+                throw new Error("account-root enumeration is outside Doctor's state scope");
+              }
+              return readdir(target, options);
+            });
+            const existsSpy = vi.spyOn(fs, "existsSync").mockImplementation((target) => {
+              if (isSiblingPath(target)) {
+                attemptedProbes.push(`exists ${String(target)}`);
+                return false;
+              }
+              return exists(target);
+            });
+            const statSpy = vi.spyOn(fs, "statSync").mockImplementation((target, options) => {
+              if (isSiblingPath(target)) {
+                attemptedProbes.push(`stat ${String(target)}`);
+                throw new Error("sibling-account metadata is outside Doctor's state scope");
+              }
+              return stat(target, options);
+            });
+            noteMock.mockClear();
+            try {
+              await noteStateIntegrityRaw(withMainAgentRoster({}), {
+                confirmRuntimeRepair: vi.fn(async () => false),
+                note: noteMock,
+              });
+              const text = stateIntegrityText();
+              expect(attemptedProbes).toEqual([]);
+              expect(text.includes("Multiple state directories detected")).toBe(warns);
+              if (warns) {
+                expect(text).toContain(
+                  homeSource === "OPENCLAW_HOME"
+                    ? "  - $OPENCLAW_HOME/.openclaw"
+                    : "  - ~/.openclaw",
+                );
+                expect(text).toContain(`Active state dir: ${activeState}`);
+              }
+              expect(text).toContain("OAuth dir not present");
+            } finally {
+              readdirSpy.mockRestore();
+              existsSpy.mockRestore();
+              statSpy.mockRestore();
+              closeOpenClawAgentDatabasesForTest();
+              closeOpenClawStateDatabaseForTest();
+            }
+          },
+        );
+      });
+    },
+  );
 });

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -322,27 +322,6 @@ function countJsonlLines(filePath: string): number {
   }
 }
 
-export function findOtherStateDirs(
-  stateDir: string,
-  deps?: {
-    defaultStateDir?: string;
-    existsDir?: (dir: string) => boolean;
-  },
-): string[] {
-  const resolvedState = path.resolve(stateDir);
-  const defaultStateDir = path.resolve(
-    deps?.defaultStateDir ?? path.join(os.homedir(), ".openclaw"),
-  );
-  if (defaultStateDir === resolvedState) {
-    return [];
-  }
-  const dirExists = deps?.existsDir ?? existsDir;
-  if (!dirExists(defaultStateDir)) {
-    return [];
-  }
-  return [defaultStateDir];
-}
-
 function isPathUnderRoot(targetPath: string, rootPath: string): boolean {
   const normalizedTarget = path.resolve(targetPath);
   const normalizedRoot = path.resolve(rootPath);
@@ -1247,15 +1226,12 @@ export async function noteStateIntegrity(
     }
   }
 
-  const extraStateDirs = new Set<string>();
-  for (const other of findOtherStateDirs(stateDir, { defaultStateDir })) {
-    extraStateDirs.add(other);
-  }
-  if (extraStateDirs.size > 0) {
+  // Compare only the effective home's default; other accounts do not share this history.
+  if (path.resolve(stateDir) !== path.resolve(defaultStateDir) && existsDir(defaultStateDir)) {
     warnings.push(
       [
         "- Multiple state directories detected. This can split session history.",
-        ...Array.from(extraStateDirs).map((dir) => `  - ${shortenHomePath(dir)}`),
+        `  - ${shortenHomePath(defaultStateDir)}`,
         `  Active state dir: ${displayStateDir}`,
       ].join("\n"),
     );

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -322,37 +322,25 @@ function countJsonlLines(filePath: string): number {
   }
 }
 
-function findOtherStateDirs(stateDir: string): string[] {
+export function findOtherStateDirs(
+  stateDir: string,
+  deps?: {
+    defaultStateDir?: string;
+    existsDir?: (dir: string) => boolean;
+  },
+): string[] {
   const resolvedState = path.resolve(stateDir);
-  const roots =
-    process.platform === "darwin" ? ["/Users"] : process.platform === "linux" ? ["/home"] : [];
-  const found: string[] = [];
-  for (const root of roots) {
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(root, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const entry of entries) {
-      if (!entry.isDirectory()) {
-        continue;
-      }
-      if (entry.name.startsWith(".")) {
-        continue;
-      }
-      const candidates = [".openclaw"].map((dir) => path.resolve(root, entry.name, dir));
-      for (const candidate of candidates) {
-        if (candidate === resolvedState) {
-          continue;
-        }
-        if (existsDir(candidate)) {
-          found.push(candidate);
-        }
-      }
-    }
+  const defaultStateDir = path.resolve(
+    deps?.defaultStateDir ?? path.join(os.homedir(), ".openclaw"),
+  );
+  if (defaultStateDir === resolvedState) {
+    return [];
   }
-  return found;
+  const dirExists = deps?.existsDir ?? existsDir;
+  if (!dirExists(defaultStateDir)) {
+    return [];
+  }
+  return [defaultStateDir];
 }
 
 function isPathUnderRoot(targetPath: string, rootPath: string): boolean {
@@ -1260,12 +1248,7 @@ export async function noteStateIntegrity(
   }
 
   const extraStateDirs = new Set<string>();
-  if (path.resolve(stateDir) !== path.resolve(defaultStateDir)) {
-    if (existsDir(defaultStateDir)) {
-      extraStateDirs.add(defaultStateDir);
-    }
-  }
-  for (const other of findOtherStateDirs(stateDir)) {
+  for (const other of findOtherStateDirs(stateDir, { defaultStateDir })) {
     extraStateDirs.add(other);
   }
   if (extraStateDirs.size > 0) {

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -308,37 +308,25 @@ function countJsonlLines(filePath: string): number {
   }
 }
 
-function findOtherStateDirs(stateDir: string): string[] {
+export function findOtherStateDirs(
+  stateDir: string,
+  deps?: {
+    defaultStateDir?: string;
+    existsDir?: (dir: string) => boolean;
+  },
+): string[] {
   const resolvedState = path.resolve(stateDir);
-  const roots =
-    process.platform === "darwin" ? ["/Users"] : process.platform === "linux" ? ["/home"] : [];
-  const found: string[] = [];
-  for (const root of roots) {
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(root, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const entry of entries) {
-      if (!entry.isDirectory()) {
-        continue;
-      }
-      if (entry.name.startsWith(".")) {
-        continue;
-      }
-      const candidates = [".openclaw"].map((dir) => path.resolve(root, entry.name, dir));
-      for (const candidate of candidates) {
-        if (candidate === resolvedState) {
-          continue;
-        }
-        if (existsDir(candidate)) {
-          found.push(candidate);
-        }
-      }
-    }
+  const defaultStateDir = path.resolve(
+    deps?.defaultStateDir ?? path.join(os.homedir(), ".openclaw"),
+  );
+  if (defaultStateDir === resolvedState) {
+    return [];
   }
-  return found;
+  const dirExists = deps?.existsDir ?? existsDir;
+  if (!dirExists(defaultStateDir)) {
+    return [];
+  }
+  return [defaultStateDir];
 }
 
 function isPathUnderRoot(targetPath: string, rootPath: string): boolean {
@@ -1271,12 +1259,7 @@ export async function noteStateIntegrity(
   }
 
   const extraStateDirs = new Set<string>();
-  if (path.resolve(stateDir) !== path.resolve(defaultStateDir)) {
-    if (existsDir(defaultStateDir)) {
-      extraStateDirs.add(defaultStateDir);
-    }
-  }
-  for (const other of findOtherStateDirs(stateDir)) {
+  for (const other of findOtherStateDirs(stateDir, { defaultStateDir })) {
     extraStateDirs.add(other);
   }
   if (extraStateDirs.size > 0) {


### PR DESCRIPTION
Closes #68170
Supersedes #82495 because its source fork is archived and cannot accept maintainer updates.

Original fix by @lidge-jun; reported by @richard-scott; carried forward by @vincentkoc.

## What Problem This Solves

Fixes an issue where users running `openclaw doctor` would see other accounts' state paths or backup-home false positives because Doctor enumerated sibling `/home/*` or `/Users/*` directories.

## Why This Change Was Made

Remove ambient account discovery at the state-integrity owner. Doctor compares the selected state directory only with the effective home's default `.openclaw` directory, using the existing `OPENCLAW_HOME`, `HOME`, and `USERPROFILE` resolution. The obsolete scanner, collection assembly, and exported test-only helper are gone; regression tests exercise `noteStateIntegrity` directly.

## User Impact

Doctor no longer enumerates other accounts' homes or probes their state candidates. Selected-state diagnostics remain intact, and the split-history warning remains when an alternate state directory is selected and the same effective home's default exists. The active-default path does not emit that warning. No new options, environment variables, config keys, schema, persistence semantics, or migrations are introduced. [Doctor documentation](https://docs.openclaw.ai/gateway/doctor) describes the boundary.

## Evidence

Reviewed candidate: `d95a8771dd180ff881b22fb33aaaffb8c68b8ec6`, based on `45be2a2ed06889541212c0a419acec92a8ecfb39`.

- Six new boundary cases fail on baseline specifically on attempted `readdir /home`; the candidate and existing siblings pass all 59 tests across five files. The existing built invalid-config process regression passes on both revisions.
- Ten real built-CLI probes ran in disposable Linux mount/network/PID namespaces with synthetic homes and a cleared environment, without test-fast/plugin/channel skip flags. All exited 0 and printed `Doctor complete.` Valid and unparseable configs, default and explicit state, and relocated effective home were covered.
- Every baseline variant performed one account-root enumeration and four unrelated sibling metadata probes; all five candidate variants performed zero of either. The same-home warning remains for explicit/relocated state and is absent for active-default state.
- Full scoped `check-changed` passed: formatting, types, lint, dead exports (0), import cycles (0), and guards. Fresh independent Codex autoreview found no actionable P0–P2 findings. Source hashes match the real proof.
- Production LOC: +3/-44 (net -41); tests: +106/-1 (net +105); docs: +1/-1. Three final changed paths.

The two ClawSweeper rank-up moves are addressed: the current-main conflict refresh is included, and regression coverage is at the Doctor boundary without a test-only production export. Exact-head [CI run 33570817951](https://github.com/openclaw/openclaw/actions/runs/33570817951) passed on attempt 1 for the reviewed candidate. Details are in the existing [proof comment](https://github.com/openclaw/openclaw/pull/122586#issuecomment-5501428026).

Proof setup failures were not counted as passing: the initial environment needed baseline/dependency setup, a child reaper, and output ownership cleanup. A replacement disposable environment completed the final proof; both environments were stopped. The [hosting workflow](https://github.com/openclaw/openclaw/actions/runs/33567554638) is lease context only, not exact-head CI. No operator state or services were probed. Runtime syscall proof is Linux; no macOS syscall run is claimed.
