### PR TITLE
fix(ci): restore Slack enterprise fixture coverage

### DIFF
--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -321,7 +321,9 @@ describe("auth.test boot call", () => {
           dmPolicy: "disabled",
           groupPolicy: "open",
           slashCommand: { enabled: true, name: "openclaw" },
-          channels: { C12345678: { allow: true, requireMention: true } },
+          channels: {
+            "team:TWORKSPACE:channel:C12345678": { allow: true, requireMention: true },
+          },
         },
       },
     });
@@ -886,7 +888,9 @@ describe("connected identity health", () => {
         slack: {
           dmPolicy: "disabled",
           groupPolicy: "open",
-          channels: { C12345678: { allow: true, requireMention: true } },
+          channels: {
+            "team:TWORKSPACE:channel:C12345678": { allow: true, requireMention: true },
+          },
         },
       },
     });

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -542,6 +542,13 @@ const PRECISE_SOURCE_TEST_TARGETS = new Map<string, string[]>([
       "src/plugins/contracts/tts.contract.test.ts",
     ],
   ],
+  [
+    "extensions/slack/src/monitor/enterprise-install.ts",
+    [
+      "extensions/slack/src/monitor/enterprise-install.test.ts",
+      "extensions/slack/src/monitor/provider.auth-test-token.test.ts",
+    ],
+  ],
 ]);
 const DOCS_CONFIG_EXAMPLES_TEST_TARGET = "src/config/docs-config-examples.test.ts";
 const RUNTIME_SIDECAR_BASELINE_OWNER_TEST_TARGETS = ["src/plugins/bundled-plugin-metadata.test.ts"];

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1932,6 +1932,16 @@ describe("scripts/test-projects changed-target routing", () => {
     ]);
   });
 
+  it("routes Slack enterprise install changes through both owning tests", () => {
+    expectChangedTargets(
+      ["extensions/slack/src/monitor/enterprise-install.ts"],
+      [
+        "extensions/slack/src/monitor/enterprise-install.test.ts",
+        "extensions/slack/src/monitor/provider.auth-test-token.test.ts",
+      ],
+    );
+  });
+
   it("keeps unknown root surfaces cheap by default", () => {
     expect(
       resolveChangedTargetArgs(["--changed", "origin/main"], process.cwd(), () => [


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Slack provider-auth tests failed after Enterprise Grid channel policy began requiring workspace-scoped stable channel keys. It also closes a changed-test routing gap where edits to the Enterprise install policy owner did not run the provider startup/recovery coverage that consumes that policy.

## Why This Change Was Made

The two Enterprise fixtures now use the canonical `team:TWORKSPACE:channel:C12345678` key. The precise changed-test planner routes `enterprise-install.ts` to both its sibling test and `provider.auth-test-token.test.ts`; runtime code is unchanged.

## User Impact

No user-visible runtime change. Maintainers get passing Slack Enterprise provider-auth coverage and complete focused test selection for future policy changes.

## Evidence

- Red baseline: `provider.auth-test-token.test.ts` failed 2 of 26 tests because `C12345678` was rejected as an unscoped Enterprise channel key.
- Focused Slack proof: 71/71 tests passed across `provider.auth-test-token.test.ts` and `enterprise-install.test.ts`.
- Planner proof: the exact new routing assertion passed (1 passed, 246 skipped).
- `pnpm format` on all three changed files: passed.
- `git diff --check`: passed.
- Exact-head offline ClawSweeper: no actionable issue; best-fix verdict yes. Its neutral result records only that the read-only review sandbox could not create Vitest temp files; the focused tests above ran independently.
- Exact-commit autoreview: clean, no accepted/actionable findings; patch-correct confidence 0.99.
- Scoped `check-changed` reached Testbox on run https://github.com/openclaw/openclaw/actions/runs/31587929327, then stopped before project checks because the delegated checkout could not resolve the `origin/main` merge base for the environment-variable ratchet. The single classified retry was used; no unchanged retry was started.

AI-assisted implementation and review.
