### PR TITLE
fix(memory-wiki): keep default vaults in configured state directory

### DIFF
--- a/docs/plugins/memory-wiki.md
+++ b/docs/plugins/memory-wiki.md
@@ -387,7 +387,7 @@ Key toggles:
 | ------------------------------------------ | ---------------------------------------------- | ----------------------------------------------------------------------------- |
 | `vaultMode`                                | `isolated` (default), `bridge`, `unsafe-local` | chooses input and integration behavior                                        |
 | `vault.scope`                              | `global` (default), `agent`                    | one shared vault or one child vault per agent                                 |
-| `vault.path`                               | global default `~/.openclaw/wiki/main`         | exact vault globally; agent-scope parent defaults to `~/.openclaw/wiki`       |
+| `vault.path`                               | global default `<state-dir>/wiki/main`         | exact vault globally; agent-scope parent defaults to `<state-dir>/wiki`       |
 | `vault.renderMode`                         | `native` (default), `obsidian`                 |                                                                               |
 | `bridge.readMemoryArtifacts`               | default `true`                                 | import active memory plugin public artifacts                                  |
 | `bridge.followMemoryEvents`                | default `true`                                 | include event logs in bridge mode                                             |
@@ -398,6 +398,11 @@ Key toggles:
 | `context.includeCompiledDigestPrompt`      | default `false`                                | append the selected agent's compact digest snapshot to memory prompt sections |
 | `render.createBacklinks`                   | default `true`                                 | generate deterministic related blocks                                         |
 | `render.createDashboards`                  | default `true`                                 | generate dashboard pages                                                      |
+
+The state directory is `~/.openclaw` by default. When `OPENCLAW_STATE_DIR` is
+set, default wiki vaults use that directory instead. Explicit `vault.path`
+values keep their configured location, and `~/` still expands against the home
+directory.
 
 ### Per-agent vaults
 
@@ -436,8 +441,9 @@ normalized agent id:
 
 This resolves to `~/.openclaw/wiki/support` and
 `~/.openclaw/wiki/marketing`. If `vault.path` is omitted in agent scope, the
-parent defaults to `~/.openclaw/wiki`. The default `main` agent therefore keeps
-the existing `~/.openclaw/wiki/main` path.
+parent defaults to `<state-dir>/wiki`, where the state directory is
+`~/.openclaw` or the value of `OPENCLAW_STATE_DIR`. The default `main` agent
+therefore uses `<state-dir>/wiki/main`.
 
 Agent tools, compiled prompt digests, and the wiki supplement exposed through
 `memory_search` / `memory_get` resolve the vault from the active agent context.

--- a/extensions/memory-wiki/README.md
+++ b/extensions/memory-wiki/README.md
@@ -100,9 +100,11 @@ normalized agent id:
 
 This resolves agents such as `support` and `marketing` to
 `~/.openclaw/wiki/support` and `~/.openclaw/wiki/marketing`. With no explicit
-path, the parent defaults to `~/.openclaw/wiki`; the default `main` agent
-therefore keeps the existing `~/.openclaw/wiki/main` path. In global scope,
-`vault.path` remains the exact shared vault path.
+path, the parent defaults to `<state-dir>/wiki`; the default `main` agent
+therefore uses `<state-dir>/wiki/main`. The state directory is `~/.openclaw` by
+default and follows `OPENCLAW_STATE_DIR` when configured. In global scope,
+`vault.path` remains the exact shared vault path; explicit paths and `~/`
+expansion keep their existing behavior.
 
 Wiki tools and compiled prompt/corpus supplements resolve the active runtime
 agent on each call. In bridge mode, an agent vault imports only public memory

--- a/extensions/memory-wiki/cli-metadata.test.ts
+++ b/extensions/memory-wiki/cli-metadata.test.ts
@@ -45,6 +45,7 @@ describe("memory-wiki cli metadata entry", () => {
       name: "Memory Wiki",
       registerCli,
     });
+    api.runtime = {} as typeof api.runtime;
     const program = new Command();
     const appConfig = {
       plugins: {

--- a/extensions/memory-wiki/doctor-contract-api.test.ts
+++ b/extensions/memory-wiki/doctor-contract-api.test.ts
@@ -116,6 +116,36 @@ describe("memory-wiki doctor source sync migration", () => {
     );
   });
 
+  it("migrates the default state-directory vault without touching the real-home vault", async () => {
+    const stateDir = await tempDirs.createTempDir("memory-wiki-doctor-state-");
+    const homeDir = await tempDirs.createTempDir("memory-wiki-doctor-home-");
+    const stateVault = path.join(stateDir, "wiki", "main");
+    const homeVault = path.join(homeDir, ".openclaw", "wiki", "main");
+    const cacheRelativePath = path.join(".openclaw-wiki", "cache", "agent-digest.json");
+    const stateCache = path.join(stateVault, cacheRelativePath);
+    const homeCache = path.join(homeVault, cacheRelativePath);
+    for (const cachePath of [stateCache, homeCache]) {
+      await fs.mkdir(path.dirname(cachePath), { recursive: true });
+      await fs.writeFile(cachePath, "stale\n", "utf8");
+    }
+    const params = {
+      ...migrationParams({ stateDir, vaultRoot: stateVault }),
+      config: { plugins: { entries: { "memory-wiki": { config: {} } } } },
+      env: { ...process.env, HOME: homeDir, OPENCLAW_STATE_DIR: stateDir },
+    };
+    const migration = requireStateMigration("memory-wiki-compiled-cache-file-cleanup");
+
+    await expect(migration.detectLegacyState(params)).resolves.toEqual({
+      preview: [expect.stringContaining(stateCache)],
+    });
+    await expect(migration.migrateLegacyState(params)).resolves.toEqual({
+      changes: [expect.stringContaining(stateCache)],
+      warnings: [],
+    });
+    await expect(fs.stat(stateCache)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.readFile(homeCache, "utf8")).resolves.toBe("stale\n");
+  });
+
   it("skips configured vaults that have not been initialized", async () => {
     const stateDir = await tempDirs.createTempDir("memory-wiki-doctor-");
     const vaultRoot = path.join(stateDir, "missing-vault");
@@ -151,9 +181,14 @@ describe("memory-wiki doctor source sync migration", () => {
 
   it("detects and migrates legacy source-sync.json into plugin state", async () => {
     const stateDir = await tempDirs.createTempDir("memory-wiki-doctor-");
-    const vaultRoot = path.join(stateDir, "vault");
+    const homeDir = await tempDirs.createTempDir("memory-wiki-doctor-home-");
+    const vaultRoot = path.join(stateDir, "wiki", "main");
     const legacyPath = resolveMemoryWikiSourceSyncStatePath(vaultRoot);
+    const homeLegacyPath = resolveMemoryWikiSourceSyncStatePath(
+      path.join(homeDir, ".openclaw", "wiki", "main"),
+    );
     await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+    await fs.mkdir(path.dirname(homeLegacyPath), { recursive: true });
     await fs.writeFile(
       legacyPath,
       `${JSON.stringify({
@@ -170,7 +205,13 @@ describe("memory-wiki doctor source sync migration", () => {
         },
       })}\n`,
     );
-    const params = migrationParams({ stateDir, vaultRoot });
+    const homeSourceSync = await fs.readFile(legacyPath, "utf8");
+    await fs.writeFile(homeLegacyPath, homeSourceSync, "utf8");
+    const params = {
+      ...migrationParams({ stateDir, vaultRoot }),
+      config: { plugins: { entries: { "memory-wiki": { config: {} } } } },
+      env: { ...process.env, HOME: homeDir, OPENCLAW_STATE_DIR: stateDir },
+    };
     const migration = requireStateMigration("memory-wiki-source-sync-json-to-plugin-state");
 
     await expect(migration.detectLegacyState(params)).resolves.toEqual({
@@ -200,6 +241,8 @@ describe("memory-wiki doctor source sync migration", () => {
     });
     await expect(fs.stat(legacyPath)).rejects.toMatchObject({ code: "ENOENT" });
     await expect(fs.stat(`${legacyPath}.migrated`)).resolves.toBeDefined();
+    await expect(fs.readFile(homeLegacyPath, "utf8")).resolves.toBe(homeSourceSync);
+    await expect(fs.stat(`${homeLegacyPath}.migrated`)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("detects and migrates legacy import-run records into plugin state", async () => {

--- a/extensions/memory-wiki/doctor-contract-api.ts
+++ b/extensions/memory-wiki/doctor-contract-api.ts
@@ -90,6 +90,7 @@ function resolveConfiguredVaultRoots(params: {
   const homeDir = resolveHomeDir(params.env);
   const resolved = resolveMemoryWikiConfig(readConfiguredPluginConfig(params.config), {
     homedir: homeDir,
+    env: params.env,
   });
   if (resolved.vault.scope === "global") {
     return [resolved.vault.path];

--- a/extensions/memory-wiki/index.test.ts
+++ b/extensions/memory-wiki/index.test.ts
@@ -1,6 +1,7 @@
 // Memory Wiki tests cover index plugin behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { withEnv } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "./api.js";
 import plugin from "./index.js";
@@ -106,6 +107,22 @@ describe("memory-wiki plugin", () => {
           hasSubcommands: true,
         },
       ],
+    });
+  });
+
+  it("registers default-vault tools inside the configured state directory", () => {
+    const stateDir = "/tmp/openclaw-memory-wiki-runtime-state";
+    const { api, registerTool } = createPluginApi();
+
+    withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
+      plugin.register(api);
+      const statusFactory = registerTool.mock.calls.find(
+        ([, registration]) => registration.name === "wiki_status",
+      )?.[0];
+
+      expect(statusFactory?.({ agentId: "main" })).toMatchObject({
+        testConfig: { vault: { path: path.join(stateDir, "wiki", "main") } },
+      });
     });
   });
 

--- a/extensions/memory-wiki/src/config.test.ts
+++ b/extensions/memory-wiki/src/config.test.ts
@@ -5,6 +5,7 @@ import {
   validateJsonSchemaValue,
   type JsonSchemaObject,
 } from "openclaw/plugin-sdk/json-schema-runtime";
+import { withEnv } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../api.js";
 import {
@@ -39,6 +40,35 @@ describe("resolveMemoryWikiConfig", () => {
     expect(config.context.includeCompiledDigestPrompt).toBe(false);
   });
 
+  it.each([
+    { scope: "global" as const, segments: ["wiki", "main"] },
+    { scope: "agent" as const, segments: ["wiki"] },
+  ])("keeps default $scope vaults inside the configured state directory", ({ scope, segments }) => {
+    const stateDir = "/tmp/openclaw-isolated-state";
+    const config = resolveMemoryWikiConfig(
+      { vault: { scope } },
+      {
+        homedir: "/Users/tester",
+        env: { HOME: "/Users/tester", OPENCLAW_STATE_DIR: stateDir },
+      },
+    );
+
+    expect(config.vault.path).toBe(path.join(stateDir, ...segments));
+  });
+
+  it("uses the configured state directory for schema-resolved defaults", () => {
+    const stateDir = "/tmp/openclaw-schema-state";
+
+    withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
+      const parsed = memoryWikiConfigSchema.safeParse?.(undefined);
+
+      expect(parsed).toMatchObject({
+        success: true,
+        data: { vault: { path: path.join(stateDir, "wiki", "main") } },
+      });
+    });
+  });
+
   it("expands ~/ paths and preserves explicit modes", () => {
     const config = resolveMemoryWikiConfig(
       {
@@ -48,7 +78,10 @@ describe("resolveMemoryWikiConfig", () => {
           renderMode: "obsidian",
         },
       },
-      { homedir: "/Users/tester" },
+      {
+        homedir: "/Users/tester",
+        env: { HOME: "/Users/tester", OPENCLAW_STATE_DIR: "/tmp/openclaw-isolated-state" },
+      },
     );
 
     expect(config.vaultMode).toBe("bridge");

--- a/extensions/memory-wiki/src/config.ts
+++ b/extensions/memory-wiki/src/config.ts
@@ -8,6 +8,7 @@ import {
   resolveSessionAgentId,
 } from "openclaw/plugin-sdk/agent-scope-runtime";
 import { mapPluginConfigIssues } from "openclaw/plugin-sdk/extension-shared";
+import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import {
   buildPluginConfigSchema,
   z,
@@ -234,34 +235,27 @@ function expandHomePath(inputPath: string, homedir: string): string {
   return inputPath;
 }
 
-function resolveDefaultMemoryWikiVaultPath(homedir = os.homedir()): string {
-  return path.join(homedir, ".openclaw", "wiki", "main");
-}
-
-function resolveDefaultMemoryWikiVaultRoot(homedir = os.homedir()): string {
-  return path.join(homedir, ".openclaw", "wiki");
-}
-
 export function resolveMemoryWikiConfig(
   config: MemoryWikiPluginConfig | undefined,
-  options?: { homedir?: string },
+  options?: { homedir?: string; env?: NodeJS.ProcessEnv },
 ): ResolvedMemoryWikiConfig {
   const homedir = options?.homedir ?? os.homedir();
   const parsed = config ? MemoryWikiConfigSource.safeParse(config) : null;
   const safeConfig = parsed?.success ? parsed.data : (config ?? {});
   const vaultScope = safeConfig.vault?.scope ?? DEFAULT_WIKI_VAULT_SCOPE;
+  const vaultPath =
+    safeConfig.vault?.path ??
+    path.join(
+      resolveStateDir({ ...(options?.env ?? process.env), HOME: homedir }),
+      "wiki",
+      ...(vaultScope === "agent" ? [] : ["main"]),
+    );
 
   return {
     vaultMode: safeConfig.vaultMode ?? DEFAULT_WIKI_VAULT_MODE,
     vault: {
       scope: vaultScope,
-      path: expandHomePath(
-        safeConfig.vault?.path ??
-          (vaultScope === "agent"
-            ? resolveDefaultMemoryWikiVaultRoot(homedir)
-            : resolveDefaultMemoryWikiVaultPath(homedir)),
-        homedir,
-      ),
+      path: expandHomePath(vaultPath, homedir),
       renderMode: safeConfig.vault?.renderMode ?? DEFAULT_WIKI_RENDER_MODE,
     },
     obsidian: {


### PR DESCRIPTION
Closes #122567

## What Problem This Solves

Memory Wiki resolved both default global and per-agent vaults beneath the operating-system home directory even when `OPENCLAW_STATE_DIR` selected an isolated OpenClaw state directory. An isolated agent run or Doctor migration could therefore read, delete, or archive the operator's real Memory Wiki data.

## Why This Change Was Made

The Memory Wiki configuration resolver is the shared owner used by full runtime registration, config-schema defaults, CLI metadata, and Doctor migrations. It now derives default vault roots from the existing public `openclaw/plugin-sdk/state-paths` resolver and removes the two duplicate home-directory-based defaults. Doctor passes its explicitly supplied environment through the same resolver. Explicit `vault.path` values and `~/` expansion keep their existing behavior.

Centralizing state-root selection also avoids the earlier implementation's CLI regression: CLI metadata intentionally receives an empty runtime facade, so it must not dereference `api.runtime.state`.

## User Impact

- Default global vaults resolve to `<state-dir>/wiki/main`; agent-scoped vaults resolve beneath `<state-dir>/wiki`.
- `OPENCLAW_STATE_DIR` isolates Memory Wiki runtime, CLI, schema defaults, cache cleanup, and legacy source-sync migrations from the operator's real home directory.
- Explicit vault locations, home expansion, existing default-home installs, stored SQLite schemas, and plugin public contracts remain unchanged.

## Evidence

Exact reviewed head: `f75ecfed6e1d11d6ac7d0f873738a383ed0a639e`.

Pre-fix owner regressions failed for both default vault scopes, config-schema defaults, and Doctor choosing the real-home cache. The repaired owner passes:

```bash
node scripts/run-vitest.mjs \
  extensions/memory-wiki/src/config.test.ts \
  extensions/memory-wiki/doctor-contract-api.test.ts \
  extensions/memory-wiki/cli-metadata.test.ts \
  extensions/memory-wiki/index.test.ts
```

Result: four test files and 30 tests passed. The strengthened existing source-sync migration regression was then rerun directly with one worker:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  extensions/memory-wiki/doctor-contract-api.test.ts \
  -t 'detects and migrates legacy source-sync.json into plugin state'
```

That regression creates valid identical `source-sync.json` files beneath independent real-home and isolated-state roots, migrates and archives only the isolated file, and verifies the real-home bytes remain unchanged with no `.migrated` archive.

A direct, source-loaded CLI registrar probe using the real Commander program and `runtime: {}` registered the `wiki` command and resolved its vault beneath the configured state directory. Focused formatting and `git diff --check` passed. The changed gate completed its first eight guards before it was stopped to avoid competing with unrelated extreme host load; exact-head hosted CI supplies the complete remaining gate.

Production: +11/-16, net -5 lines. Independent maintainer verification and structured Codex autoreview reported no actionable findings.

Original contribution by @rohit-jsfreaky is preserved in this pull request and the commit's verified `Co-authored-by` trailer.
