### PR TITLE
fix(ci): restore Slack tool-result reaction checks

### DIFF
--- a/extensions/slack/src/monitor.tool-result.test.ts
+++ b/extensions/slack/src/monitor.tool-result.test.ts
@@ -265,9 +265,7 @@ describe("monitorSlackProvider tool results", () => {
         ackReaction: "👀",
         ackReactionScope: "group-mentions",
         groupChat: { visibleReplies: "automatic" },
-        statusReactions: statusReactionsEnabled
-          ? { enabled: true, timing: { debounceMs: 0, doneHoldMs: 0, errorHoldMs: 0 } }
-          : { enabled: false },
+        statusReactions: statusReactionsEnabled ? { enabled: true } : { enabled: false },
       },
       channels: {
         slack: {
@@ -544,7 +542,6 @@ describe("monitorSlackProvider tool results", () => {
         groupChat: { visibleReplies: "message_tool" },
         statusReactions: {
           enabled: true,
-          timing: { debounceMs: 0, doneHoldMs: 0, errorHoldMs: 0 },
         },
       },
       channels: {
@@ -738,7 +735,6 @@ describe("monitorSlackProvider tool results", () => {
         groupChat: { visibleReplies: "message_tool" },
         statusReactions: {
           enabled: true,
-          timing: { debounceMs: 0, doneHoldMs: 0, errorHoldMs: 0 },
         },
       },
       channels: {
@@ -767,7 +763,7 @@ describe("monitorSlackProvider tool results", () => {
     );
   });
 
-  it("keeps the error reaction when dispatch fails before any reply is delivered", async () => {
+  it("restores the ack reaction when dispatch fails before any reply is delivered", async () => {
     replyMock.mockRejectedValue(new Error("boom"));
     setMentionGatedAckConfig(true);
     mockGeneralChannelInfo();
@@ -779,7 +775,7 @@ describe("monitorSlackProvider tool results", () => {
         expectReactionFlow({
           startsWith: ["eyes", "x"],
           includes: "x",
-          endsWith: "x",
+          endsWith: "eyes",
         }),
       { timeout: 5_000 },
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Slack tool-result test lane failed after status-reaction timing configuration was retired and failed dispatches began restoring the acknowledgement reaction.

## Why This Change Was Made

The fixtures now use the current status-reaction config shape and assert the observed `eyes -> x -> eyes` restoration sequence. This is test-only and does not change Slack runtime behavior.

## User Impact

No user-visible behavior changes. Maintainers regain a reliable Slack test signal for the current reaction lifecycle.

## Evidence

- Focused Slack test: 29 passed.
- Targeted changed gate: passed locally through the repo-native fallback after delegated Testbox sync omitted `origin/main`.
- `git diff --check`: passed.
- Exact-head local autoreview: clean, no accepted/actionable findings.
- Production LOC: `+0/-0`; tests: `+3/-7`.

AI-assisted implementation and review.
