### PR TITLE
improve(ci): parallelize Windows test configs [AI]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3012,7 +3012,9 @@ jobs:
     timeout-minutes: 60
     env:
       NODE_OPTIONS: --max-old-space-size=8192
-      # Keep total concurrency predictable on the smaller Windows runner.
+      # Overlap two independent config groups on the 8-vCPU runner while keeping
+      # each Vitest group serial for Windows process/path predictability.
+      OPENCLAW_TEST_PROJECTS_PARALLEL: "2"
       OPENCLAW_VITEST_MAX_WORKERS: 1
       OPENCLAW_TEST_SKIP_FULL_EXTENSIONS_SHARD: 1
     defaults:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -133,9 +133,10 @@ The slowest Node test families are split or balanced so each job stays small wit
 
 Once admitted, canonical Linux CI permits up to 28 concurrent Node test jobs and
 12 for the smaller fast/check lanes; Windows and Android stay at two because
-those runner pools are narrower. Compact whole-config batches run with a
-120-minute batch timeout, while include-pattern groups share the same bounded
-job budget.
+those runner pools are narrower. The Windows job overlaps up to two independent
+Vitest config groups on its 8-vCPU runner while keeping each group at one worker
+for process/path isolation. Compact whole-config batches run with a 120-minute
+batch timeout, while include-pattern groups share the same bounded job budget.
 
 Android CI runs both `testPlayDebugUnitTest` and `testThirdPartyDebugUnitTest` and then builds the Play debug APK. The third-party flavor has no separate source set or manifest; its unit-test lane still compiles the flavor with the SMS/call-log BuildConfig flags, while avoiding a duplicate debug APK packaging job on every Android-relevant push. Each current Gradle task has one protected sticky disk; PR jobs use disposable clones, while protected runs refresh content-addressed Gradle entries in place.
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2574,6 +2574,8 @@ NODE
     expect(workflow.jobs["check-shard"].strategy["max-parallel"]).toBe(12);
     expect(workflow.jobs["check-additional-shard"].strategy["max-parallel"]).toBe(12);
     expect(workflow.jobs["checks-windows"].strategy["max-parallel"]).toBe(2);
+    expect(workflow.jobs["checks-windows"].env.OPENCLAW_TEST_PROJECTS_PARALLEL).toBe("2");
+    expect(workflow.jobs["checks-windows"].env.OPENCLAW_VITEST_MAX_WORKERS).toBe(1);
     expect(workflow.jobs.android.strategy["max-parallel"]).toBe(2);
   });
 


### PR DESCRIPTION
Closes #122593

## What Problem This Solves

The Windows CI lane is an avoidable critical-path tail on full `main` runs. In successful run 31587205859, `checks-windows-node-test` spent 374 seconds in its test step after a 70-second dependency install and completed after every Linux compact shard.

## Why This Change Was Made

Run up to two independent Vitest config groups concurrently inside the existing 8-vCPU Windows job while retaining one Vitest worker per group. This keeps the same runner, Actions registration, matrix row, test inventory, and process/path isolation while overlapping independently configured groups.

## User Impact

No product behavior changes. Maintainers should receive faster Windows CI feedback without increasing runner-registration pressure or reducing coverage.

## Evidence

- Baseline: [main CI run 31587205859](https://github.com/openclaw/openclaw/actions/runs/31587205859), where the Windows job took 491 seconds wall time and its test step took 374 seconds.
- `CI=1 node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` — 117 tests passed.
- `CI=1 node --import tsx scripts/check-workflows.mts` — actionlint, zizmor, and interpolation checks passed.
- `CI=1 node scripts/check-changed.mjs` — passed.
- `CI=1 ./node_modules/.bin/oxfmt --check .github/workflows/ci.yml docs/ci.md test/scripts/ci-workflow-guards.test.ts` — passed.
- `git diff --check` — passed.
- Independent read-only review found no blocking issues and rated this the best conservative fix.
- [Exact-head hosted CI run 31589652589](https://github.com/openclaw/openclaw/actions/runs/31589652589): Windows completed green on `dfc71e621a18b28c1244888f938e323257d2467f`; its test step fell from 374s to 151s (59.6%), and job wall fell from 491s to 237s (51.7%) versus baseline run 31587205859. The log confirms 25 Vitest config groups at parallelism 2 and one worker each.

AI-assisted: implementation and review were performed with Amp.
