### PR TITLE
fix(browser): check-test-types fails on main from CDP helper test lookup stubs

### DIFF
--- a/extensions/browser/src/browser/cdp.helpers.test.ts
+++ b/extensions/browser/src/browser/cdp.helpers.test.ts
@@ -167,7 +167,7 @@ describe("cdp helpers", () => {
     await expect(
       resolvePinnedHostnameWithPolicy("browser.example", {
         policy: scoped,
-        lookupFn: async () => [{ address: "10.0.0.8", family: 4 }],
+        lookupFn: (async () => [{ address: "10.0.0.8", family: 4 }]) as never,
       }),
     ).rejects.toThrow(/private\/internal\/special-use ip address/i);
   });
@@ -188,7 +188,7 @@ describe("cdp helpers", () => {
     await expect(
       resolvePinnedHostnameWithPolicy("browser.example", {
         policy: scoped,
-        lookupFn: async () => [{ address: "10.0.0.8", family: 4 }],
+        lookupFn: (async () => [{ address: "10.0.0.8", family: 4 }]) as never,
       }),
     ).resolves.toEqual(expect.objectContaining({ addresses: ["10.0.0.8"] }));
   });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where `check:test-types` fails on `main`, which turns every open pull request red regardless of its own changes. The failure is in the browser extension test suite:

```
extensions/browser/src/browser/cdp.helpers.test.ts(170,9): error TS2322
extensions/browser/src/browser/cdp.helpers.test.ts(191,9): error TS2322
```

## Why This Change Was Made

The two CDP SSRF tests pass an inline DNS lookup stub to `resolvePinnedHostnameWithPolicy`. That option is typed as the overloaded `dns.lookup` signature, so a bare `async () => [...]` stub is not assignable. The repo already stubs this option with an explicit `as never` cast in `extensions/browser/src/test-support/browser-security.mock.ts`; this change applies the same pattern to the two inline stubs. Test behavior is unchanged — the stub still resolves the private address that both assertions depend on.

## User Impact

Developers get a green `check-test-types` lane again, so unrelated pull requests stop inheriting a red required check. No runtime or product behavior changes.

## Evidence

Before, on current `main`, CI `check-test-types` fails with the two `TS2322` errors above (observed on an unrelated UI pull request whose diff does not touch this file).

After this change, locally:

```
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json
# exits 0, no diagnostics
```

`oxfmt --check` reports `All matched files use the correct format.`
