### PR TITLE
fix: inherited auth-profile cooldown writes target the child store and silently no-op

### DIFF
--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -19,6 +19,7 @@ import {
 } from "./runtime-external-profile-references.js";
 import {
   ensureAuthProfileStoreForLocalUpdate,
+  isSharedMainAuthProfileAgentDir,
   resolvePersistedAuthProfileOwnerAgentDir,
   saveAuthProfileStore,
   updateAuthProfileStoreWithLock,
@@ -79,12 +80,13 @@ function replaceProviderAuthState<T>(
 function updateSuccessfulUsageStatsEntry(
   store: AuthProfileStore,
   profileId: string,
-  lastUsed: number,
+  lastUsed?: number,
 ): void {
   store.usageStats = store.usageStats ?? {};
-  store.usageStats[profileId] = resetAuthProfileFailureState(store.usageStats[profileId] ?? {}, {
-    lastUsed,
-  });
+  store.usageStats[profileId] = resetAuthProfileFailureState(
+    store.usageStats[profileId] ?? {},
+    lastUsed === undefined ? undefined : { lastUsed },
+  );
 }
 
 /** Sets or clears explicit auth profile order for a provider. */
@@ -329,22 +331,39 @@ export async function markAuthProfileSuccess(params: {
 }): Promise<void> {
   const { store, provider, profileId, agentDir } = params;
   const providerKey = resolveProviderIdForAuth(provider);
+  const profile = store.profiles[profileId];
+  if (!profile || resolveProviderIdForAuth(profile.provider) !== providerKey) {
+    return;
+  }
+  const ownerAgentDir = resolvePersistedAuthProfileOwnerAgentDir({ agentDir, profileId });
+  const inherited = ownerAgentDir === undefined && !isSharedMainAuthProfileAgentDir(agentDir);
   const lastUsed = Date.now();
+  let applied = false;
   const updated = await updateAuthProfileStoreWithLock({
-    agentDir,
+    agentDir: ownerAgentDir,
     updater: (freshStore) => {
-      const profile = freshStore.profiles[profileId];
-      if (!profile || resolveProviderIdForAuth(profile.provider) !== providerKey) {
+      const freshProfile = freshStore.profiles[profileId];
+      if (!freshProfile || resolveProviderIdForAuth(freshProfile.provider) !== providerKey) {
         return false;
       }
-      freshStore.lastGood = replaceProviderAuthState(freshStore.lastGood, providerKey, profileId);
-      updateSuccessfulUsageStatsEntry(freshStore, profileId, lastUsed);
+      // Inherited selection ownership is not defined. Clear shared health in
+      // the credential owner without changing its last-good or rotation state.
+      if (!inherited) {
+        freshStore.lastGood = replaceProviderAuthState(freshStore.lastGood, providerKey, profileId);
+      }
+      updateSuccessfulUsageStatsEntry(freshStore, profileId, inherited ? undefined : lastUsed);
+      applied = true;
       return true;
     },
   });
-  if (updated) {
-    store.lastGood = updated.lastGood;
-    store.usageStats = updated.usageStats;
+  if (updated && applied) {
+    const usage = updated.usageStats?.[profileId];
+    if (usage) {
+      store.usageStats = { ...store.usageStats, [profileId]: usage };
+    }
+    if (!inherited) {
+      store.lastGood = replaceProviderAuthState(store.lastGood, providerKey, profileId);
+    }
     return;
   }
   if (updated === null) {

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -1282,6 +1282,17 @@ export function ensureAuthProfileStoreWithoutExternalProfiles(
   );
 }
 
+/** Whether an agent dir resolves to the shared main auth-profile owner. */
+export function isSharedMainAuthProfileAgentDir(agentDir?: string): boolean {
+  const effectiveAgentDir = resolveRuntimeAuthProfileAgentDir(agentDir);
+  if (!effectiveAgentDir) {
+    return true;
+  }
+  const mainAgentDir = resolveRuntimeAuthProfileAgentDir();
+  const mainPath = mainAgentDir ? resolveAgentAuthPath(mainAgentDir) : resolveSharedAuthPath();
+  return resolveAgentAuthPath(effectiveAgentDir) === mainPath;
+}
+
 /** Find a persisted credential in the scoped store, falling back to the main store. */
 export function findPersistedAuthProfileCredential(params: {
   agentDir?: string;
@@ -1301,10 +1312,7 @@ export function findPersistedAuthProfileCredential(params: {
     return requestedProfile;
   }
 
-  const requestedPath = resolveAgentAuthPath(agentDir);
-  const mainAgentDir = resolveRuntimeAuthProfileAgentDir();
-  const mainPath = mainAgentDir ? resolveAgentAuthPath(mainAgentDir) : resolveSharedAuthPath();
-  if (requestedPath === mainPath) {
+  if (isSharedMainAuthProfileAgentDir(agentDir)) {
     return requestedProfile;
   }
 
@@ -1326,13 +1334,11 @@ export function resolvePersistedAuthProfileOwnerAgentDir(params: {
     return undefined;
   }
   const requestedStore = loadPersistedAuthProfileStore(agentDir);
-  const requestedPath = resolveAgentAuthPath(agentDir);
-  const mainAgentDir = resolveRuntimeAuthProfileAgentDir();
-  const mainPath = mainAgentDir ? resolveAgentAuthPath(mainAgentDir) : resolveSharedAuthPath();
-  if (requestedPath === mainPath) {
+  if (isSharedMainAuthProfileAgentDir(agentDir)) {
     return undefined;
   }
 
+  const mainAgentDir = resolveRuntimeAuthProfileAgentDir();
   const mainStore = loadPersistedAuthProfileStore(mainAgentDir);
   const requestedProfile = requestedStore?.profiles[params.profileId];
   if (requestedProfile) {

--- a/src/agents/auth-profiles/usage.inherited-owner.test.ts
+++ b/src/agents/auth-profiles/usage.inherited-owner.test.ts
@@ -1,0 +1,201 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { resetFileLockStateForTest } from "../../infra/file-lock.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { captureEnv, setTestEnvValue } from "../../test-utils/env.js";
+import { resolveAuthProfileOrder } from "./order.js";
+import { loadPersistedAuthProfileStore } from "./persisted.js";
+import { markAuthProfileSuccess } from "./profiles.js";
+import { clearRuntimeAuthProfileStoreSnapshots } from "./runtime-snapshots.js";
+import { ensureAuthProfileStore, saveAuthProfileStore } from "./store.js";
+import type { AuthProfileStore } from "./types.js";
+import {
+  clearAuthProfileCooldown,
+  markAuthProfileBlockedUntil,
+  markAuthProfileFailure,
+} from "./usage.js";
+
+const PRIMARY_ID = "openai:primary";
+const BACKUP_ID = "openai:backup";
+const LOCAL_ID = "openai:local";
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function createMainStore(): AuthProfileStore {
+  const expires = Date.now() + 30 * 60 * 1000;
+  return {
+    version: 1,
+    profiles: {
+      [PRIMARY_ID]: {
+        type: "oauth",
+        provider: "openai",
+        access: "primary-access",
+        refresh: "primary-refresh",
+        expires,
+      },
+      [BACKUP_ID]: {
+        type: "oauth",
+        provider: "openai",
+        access: "backup-access",
+        refresh: "backup-refresh",
+        expires,
+      },
+    },
+    order: { openai: [PRIMARY_ID, BACKUP_ID] },
+  };
+}
+
+describe("inherited auth-profile usage persistence", () => {
+  const env = captureEnv(["OPENCLAW_STATE_DIR", "OPENCLAW_AGENT_DIR"]);
+  let rootDir: string;
+  let mainAgentDir: string;
+  let childAgentDir: string;
+
+  beforeEach(() => {
+    resetFileLockStateForTest();
+    rootDir = tempDirs.make("inherited-auth-owner-");
+    mainAgentDir = path.join(rootDir, "agents", "main", "agent");
+    childAgentDir = path.join(rootDir, "agents", "child", "agent");
+    fs.mkdirSync(mainAgentDir, { recursive: true });
+    fs.mkdirSync(childAgentDir, { recursive: true });
+    setTestEnvValue("OPENCLAW_STATE_DIR", rootDir);
+    setTestEnvValue("OPENCLAW_AGENT_DIR", mainAgentDir);
+    clearRuntimeAuthProfileStoreSnapshots();
+  });
+
+  afterEach(() => {
+    clearRuntimeAuthProfileStoreSnapshots();
+    closeOpenClawAgentDatabasesForTest();
+    resetFileLockStateForTest();
+    env.restore();
+  });
+
+  function writeMainStore(): void {
+    saveAuthProfileStore(createMainStore(), mainAgentDir, {
+      filterExternalAuthProfiles: false,
+      syncExternalCli: false,
+    });
+  }
+
+  it("keeps an inherited primary blocked for the next child run", async () => {
+    writeMainStore();
+    const localCooldownUntil = Date.now() + 30 * 60 * 1000;
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          [LOCAL_ID]: { type: "api_key", provider: "openai", key: "local-key" },
+        },
+        usageStats: { [LOCAL_ID]: { cooldownUntil: localCooldownUntil } },
+      },
+      childAgentDir,
+      { filterExternalAuthProfiles: false, syncExternalCli: false },
+    );
+    const childStore = ensureAuthProfileStore(childAgentDir);
+    const blockedUntil = Date.now() + 60 * 60 * 1000;
+
+    await markAuthProfileBlockedUntil({
+      store: childStore,
+      profileId: PRIMARY_ID,
+      blockedUntil,
+      source: "codex_rate_limits",
+      agentDir: childAgentDir,
+      modelId: "gpt-5.6-sol",
+    });
+
+    expect(childStore.usageStats?.[LOCAL_ID]?.cooldownUntil).toBe(localCooldownUntil);
+    const persistedChild = loadPersistedAuthProfileStore(childAgentDir);
+    expect(persistedChild?.profiles[PRIMARY_ID]).toBeUndefined();
+    expect(persistedChild?.usageStats?.[LOCAL_ID]?.cooldownUntil).toBe(localCooldownUntil);
+
+    clearRuntimeAuthProfileStoreSnapshots();
+    const nextRunStore = ensureAuthProfileStore(childAgentDir);
+    expect({
+      ownerBlockedUntil:
+        loadPersistedAuthProfileStore(mainAgentDir)?.usageStats?.[PRIMARY_ID]?.blockedUntil,
+      nextRunOrder: resolveAuthProfileOrder({ store: nextRunStore, provider: "openai" }),
+    }).toEqual({
+      ownerBlockedUntil: blockedUntil,
+      nextRunOrder: [BACKUP_ID, LOCAL_ID, PRIMARY_ID],
+    });
+  });
+
+  it("writes and clears inherited failure state in the owner store", async () => {
+    writeMainStore();
+    const childStore = ensureAuthProfileStore(childAgentDir);
+
+    await markAuthProfileFailure({
+      store: childStore,
+      profileId: PRIMARY_ID,
+      reason: "timeout",
+      agentDir: childAgentDir,
+    });
+    expect(
+      loadPersistedAuthProfileStore(mainAgentDir)?.usageStats?.[PRIMARY_ID]?.cooldownUntil,
+    ).toBeTypeOf("number");
+
+    await clearAuthProfileCooldown({
+      store: childStore,
+      profileId: PRIMARY_ID,
+      agentDir: childAgentDir,
+    });
+    const ownerStats = loadPersistedAuthProfileStore(mainAgentDir)?.usageStats?.[PRIMARY_ID];
+    expect(ownerStats?.cooldownUntil).toBeUndefined();
+    expect(ownerStats?.errorCount).toBe(0);
+  });
+
+  it("clears inherited health without changing selection ownership", async () => {
+    const lastUsed = Date.now() - 60_000;
+    const mainStore = createMainStore();
+    mainStore.lastGood = { openai: BACKUP_ID };
+    mainStore.usageStats = {
+      [PRIMARY_ID]: {
+        lastUsed,
+        errorCount: 2,
+        cooldownUntil: Date.now() + 60_000,
+        cooldownReason: "rate_limit",
+        cooldownClassification: "wham_token_expired",
+      },
+    };
+    saveAuthProfileStore(mainStore, mainAgentDir, {
+      filterExternalAuthProfiles: false,
+      syncExternalCli: false,
+    });
+    const localCooldownUntil = Date.now() + 30_000;
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          [LOCAL_ID]: { type: "api_key", provider: "openai", key: "local-key" },
+        },
+        usageStats: { [LOCAL_ID]: { cooldownUntil: localCooldownUntil } },
+      },
+      childAgentDir,
+      { filterExternalAuthProfiles: false, syncExternalCli: false },
+    );
+    const childStore = ensureAuthProfileStore(childAgentDir);
+
+    await markAuthProfileSuccess({
+      store: childStore,
+      provider: "openai",
+      profileId: PRIMARY_ID,
+      agentDir: childAgentDir,
+    });
+
+    const persistedMain = loadPersistedAuthProfileStore(mainAgentDir);
+    expect(persistedMain?.lastGood?.openai).toBe(BACKUP_ID);
+    expect(persistedMain?.usageStats?.[PRIMARY_ID]).toMatchObject({
+      lastUsed,
+      errorCount: 0,
+    });
+    expect(persistedMain?.usageStats?.[PRIMARY_ID]?.cooldownUntil).toBeUndefined();
+    expect(persistedMain?.usageStats?.[PRIMARY_ID]?.cooldownClassification).toBeUndefined();
+    expect(childStore.usageStats?.[LOCAL_ID]?.cooldownUntil).toBe(localCooldownUntil);
+    expect(childStore.usageStats?.[PRIMARY_ID]?.cooldownUntil).toBeUndefined();
+    const persistedChild = loadPersistedAuthProfileStore(childAgentDir);
+    expect(persistedChild?.profiles[PRIMARY_ID]).toBeUndefined();
+    expect(persistedChild?.usageStats?.[PRIMARY_ID]).toBeUndefined();
+    expect(persistedChild?.lastGood?.openai).toBeUndefined();
+  });
+});

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -27,17 +27,25 @@ import { testing as authProfileUsageTesting } from "./usage.test-support.js";
 const WHAM_HALF_OPEN_REPROBE_INTERVAL_MS = 45 * 60 * 1000;
 
 const storeMocks = vi.hoisted(() => ({
+  resolvePersistedAuthProfileOwnerAgentDir: vi.fn(
+    (params: { agentDir?: string }) => params.agentDir,
+  ),
   saveAuthProfileStore: vi.fn(),
   updateAuthProfileStoreWithLock: vi.fn().mockResolvedValue(null),
 }));
 const fetchMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./store.js", () => ({
+  resolvePersistedAuthProfileOwnerAgentDir: storeMocks.resolvePersistedAuthProfileOwnerAgentDir,
   updateAuthProfileStoreWithLock: storeMocks.updateAuthProfileStoreWithLock,
   saveAuthProfileStore: storeMocks.saveAuthProfileStore,
 }));
 
 beforeEach(() => {
+  storeMocks.resolvePersistedAuthProfileOwnerAgentDir.mockReset();
+  storeMocks.resolvePersistedAuthProfileOwnerAgentDir.mockImplementation(
+    (params: { agentDir?: string }) => params.agentDir,
+  );
   storeMocks.saveAuthProfileStore.mockReset();
   storeMocks.updateAuthProfileStoreWithLock.mockReset();
   fetchMock.mockReset();

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -18,7 +18,10 @@ import { readProviderJsonResponse } from "../provider-http-errors.js";
 import { resolveProviderRequestHeaders } from "../provider-request-config.js";
 import { notifyAuthProfileFailureHook, setAuthProfileFailureHook } from "./failure-hook.js";
 import { logAuthProfileFailureStateChange } from "./state-observation.js";
-import { updateAuthProfileStoreWithLock } from "./store.js";
+import {
+  resolvePersistedAuthProfileOwnerAgentDir,
+  updateAuthProfileStoreWithLock,
+} from "./store.js";
 import type {
   AuthProfileBlockedSource,
   AuthProfileCooldownClassification,
@@ -73,6 +76,32 @@ function logDroppedAuthProfileBookkeeping(kind: string, profileId: string): void
     profileId,
     tags: ["auth_profiles", "persistence"],
   });
+}
+
+async function updateOwnedAuthProfileUsage(
+  store: AuthProfileStore,
+  profileId: string,
+  update: Parameters<typeof updateAuthProfileStoreWithLock>[0],
+) {
+  // Inherited credentials exist only in the owner's SQLite store. A child lock
+  // cannot persist their health state, so resolve the owner before the write.
+  let changed = false;
+  const updated = await authProfileUsageDeps.updateAuthProfileStoreWithLock({
+    ...update,
+    agentDir: resolvePersistedAuthProfileOwnerAgentDir({
+      agentDir: update.agentDir,
+      profileId,
+    }),
+    updater: (freshStore) => {
+      changed = update.updater(freshStore);
+      return changed;
+    },
+  });
+  const usage = changed ? updated?.usageStats?.[profileId] : undefined;
+  if (usage) {
+    store.usageStats = { ...store.usageStats, [profileId]: usage };
+  }
+  return updated;
 }
 
 const INLINE_API_KEY_USAGE_ID_PREFIX = "inline-api-key:";
@@ -462,7 +491,7 @@ async function claimWhamHalfOpenReprobe(params: {
   startedAt: number;
 }): Promise<WhamBlockGeneration | null> {
   let generation: WhamBlockGeneration | undefined;
-  const updated = await authProfileUsageDeps.updateAuthProfileStoreWithLock({
+  const updated = await updateOwnedAuthProfileUsage(params.store, params.profileId, {
     agentDir: params.agentDir,
     updater: (freshStore) => {
       const currentProfile = freshStore.profiles[params.profileId];
@@ -496,7 +525,6 @@ async function claimWhamHalfOpenReprobe(params: {
     },
   });
   if (updated && generation) {
-    params.store.usageStats = updated.usageStats;
     return generation;
   }
   if (updated === null) {
@@ -521,8 +549,7 @@ async function runWhamHalfOpenReprobe(params: {
   if (!result || (!result.available && !result.blockedUntil)) {
     return;
   }
-  let applied = false;
-  const updated = await authProfileUsageDeps.updateAuthProfileStoreWithLock({
+  const updated = await updateOwnedAuthProfileUsage(params.store, params.profileId, {
     agentDir: params.agentDir,
     updater: (freshStore) => {
       const currentProfile = freshStore.profiles[params.profileId];
@@ -560,13 +587,10 @@ async function runWhamHalfOpenReprobe(params: {
         }
         return existing ?? {};
       });
-      applied = true;
       return true;
     },
   });
-  if (updated && applied) {
-    params.store.usageStats = updated.usageStats;
-  } else if (updated === null) {
+  if (updated === null) {
     logDroppedAuthProfileBookkeeping("wham_half_open_reprobe", params.profileId);
   }
 }
@@ -1015,7 +1039,7 @@ export async function markAuthProfileFailure(params: {
   let nextStats: ProfileUsageStats | undefined;
   let previousStats: ProfileUsageStats | undefined;
   let updateTime = 0;
-  const updated = await authProfileUsageDeps.updateAuthProfileStoreWithLock({
+  const updated = await updateOwnedAuthProfileUsage(store, profileId, {
     agentDir,
     updater: (freshStore) => {
       const profileValue = freshStore.profiles[profileId];
@@ -1058,7 +1082,6 @@ export async function markAuthProfileFailure(params: {
     },
   });
   if (updated) {
-    store.usageStats = updated.usageStats;
     if (nextStats) {
       logAuthProfileFailureStateChange({
         runId,
@@ -1141,7 +1164,7 @@ export async function markAuthProfileBlockedUntil(params: {
   let nextStats: ProfileUsageStats | undefined;
   let previousStats: ProfileUsageStats | undefined;
   let updateTime = 0;
-  const updated = await authProfileUsageDeps.updateAuthProfileStoreWithLock({
+  const updated = await updateOwnedAuthProfileUsage(store, profileId, {
     agentDir,
     updater: (freshStore) => {
       const profileLocal = freshStore.profiles[profileId];
@@ -1166,7 +1189,6 @@ export async function markAuthProfileBlockedUntil(params: {
     },
   });
   if (updated) {
-    store.usageStats = updated.usageStats;
     if (nextStats) {
       logAuthProfileFailureStateChange({
         runId,
@@ -1276,7 +1298,7 @@ export async function clearAuthProfileCooldown(params: {
   agentDir?: string;
 }): Promise<void> {
   const { store, profileId, agentDir } = params;
-  const updated = await authProfileUsageDeps.updateAuthProfileStoreWithLock({
+  const updated = await updateOwnedAuthProfileUsage(store, profileId, {
     agentDir,
     updater: (freshStore) => {
       if (!freshStore.usageStats?.[profileId]) {
@@ -1288,7 +1310,6 @@ export async function clearAuthProfileCooldown(params: {
     },
   });
   if (updated) {
-    store.usageStats = updated.usageStats;
     return;
   }
   if (updated === null) {


### PR DESCRIPTION
Closes #122569

## What Problem This Solves

A child agent can use an OAuth profile inherited from the main agent. The cooldown writers received the child agent directory and locked the child SQLite store. That store intentionally has no inherited credential, so the guarded update returned without saving the provider reset time.

The next run then retried the exhausted primary instead of selecting an available backup.

## Predating contract

Stable tag `v2026.7.1-2` at `0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c` predates this pull request. Its auth-profile owner contract merges main-store usage state into a child runtime view, and its order contract places active-cooldown profiles after available profiles.

## Fix

The shared usage mutation boundary now resolves the persisted profile owner before it takes the SQLite write lock. It projects only the changed owner entry back into the merged child view, so unrelated child-local cooldowns remain active. Failure, provider block, manual clear, and both WHAM re-probe writes use that one boundary.

Inherited success now clears health in the persisted profile owner through the same resolver. It preserves owner `lastGood` and `lastUsed`, because no predating contract assigns inherited selection state to the main owner. Locally owned success behavior is unchanged.

No schema, configuration, default, protocol, or migration changed.

## Evidence

The same source-independent production-module driver ran against both revisions with real main and child SQLite stores.

- Main `f5eea3197c55c0ed0e609d182bd88a7f09ec55e9`: owner persistence was false and the next child run ordered `primary, backup, local`.
- Head `128b12de7f4cdaee5e2141b65d62d0dbc3f0b830`: owner persistence, child-local cooldown retention, and child credential isolation were true; the next child run ordered `backup, local, primary`.
- In the success trace, main left owner health stale. Head cleared owner health while keeping owner `lastGood`, owner `lastUsed`, child-local cooldown, and child credential isolation unchanged.
- Prior repair head `ddb79444e480a59800229e51412e39a862d04e2e` failed the mixed-owner regression because it erased the child-local cooldown in memory.
- Anti-cheat: the driver clears runtime snapshots, reopens persisted state, and checks both owner and child stores before resolving the next run.

Main:

```json
{"ownerBlockPersisted":false,"childLocalCooldownPreserved":true,"childCredentialFree":true,"nextRunOrder":["openai:primary","openai:backup","openai:local"]}
```

Head:

```json
{"ownerBlockPersisted":true,"childLocalCooldownPreserved":true,"childCredentialFree":true,"nextRunOrder":["openai:backup","openai:local","openai:primary"]}
```

Inherited success on main and head:

```json
{"main":{"ownerHealthCleared":false,"ownerSelectionUnchanged":true,"childLocalCooldownPreserved":true,"childHasNoInheritedState":true},"head":{"ownerHealthCleared":true,"ownerSelectionUnchanged":true,"childLocalCooldownPreserved":true,"childHasNoInheritedState":true}}
```

## Validation

- Focused auth-profile suites — 210 tests passed.
- Focused Oxlint, Oxfmt, conflict-marker, max-lines, assertion-safety, test-temp, and diff checks passed.
- Production delta: `+46`; tests: `+209`.
