### PR TITLE
fix(outbound): report broadcast delivery outcomes

### DIFF
--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -16,6 +16,7 @@ import {
   runMessageAction,
   setMessageActionTestPlugin as setTestPlugin,
 } from "./message-action-runner.test-helpers.js";
+import type { MessageSendResult } from "./message.js";
 
 const requireLabeledRecord = createRequireRecord("record", "expected-label");
 
@@ -373,6 +374,127 @@ describe("runMessageAction plugin dispatch", () => {
         },
       });
       expect(mocks.executeSendAction).not.toHaveBeenCalled();
+    });
+
+    it.each<{
+      name: string;
+      delivery: Partial<MessageSendResult>;
+      outcome: { ok: boolean; error?: string; sentBeforeError?: true };
+    }>([
+      {
+        name: "sent",
+        delivery: { deliveryStatus: "sent" },
+        outcome: { ok: true },
+      },
+      {
+        name: "suppressed",
+        delivery: {
+          deliveryStatus: "suppressed",
+          suppressionReason: "cancelled_by_message_sending_hook",
+        },
+        outcome: {
+          ok: false,
+          error: "Broadcast send suppressed: cancelled_by_message_sending_hook.",
+        },
+      },
+      {
+        name: "failed",
+        delivery: {
+          deliveryStatus: "failed",
+          error: "provider rejected the message",
+        },
+        outcome: { ok: false, error: "provider rejected the message" },
+      },
+      {
+        name: "failed without an error",
+        delivery: { deliveryStatus: "failed" },
+        outcome: { ok: false, error: "Broadcast send failed." },
+      },
+      {
+        name: "partial_failed",
+        delivery: {
+          deliveryStatus: "partial_failed",
+          error: "second payload failed",
+          sentBeforeError: true,
+        },
+        outcome: { ok: false, error: "second payload failed", sentBeforeError: true },
+      },
+      {
+        name: "partial_failed without an error",
+        delivery: { deliveryStatus: "partial_failed", sentBeforeError: true },
+        outcome: {
+          ok: false,
+          error: "Broadcast send partially failed.",
+          sentBeforeError: true,
+        },
+      },
+      {
+        name: "legacy result without deliveryStatus",
+        delivery: {
+          via: "gateway",
+          result: { messageId: "legacy-message-1" },
+        },
+        outcome: { ok: true },
+      },
+    ])("derives broadcast truth from a $name send result", async ({ delivery, outcome }) => {
+      const nestedPayload = { ok: true, nested: "payload" };
+      const sendResult = {
+        channel: "gatewaychat",
+        to: "user-123",
+        via: "direct",
+        mediaUrl: null,
+        ...delivery,
+      } satisfies MessageSendResult;
+      const gatewayPlugin = createGatewayActionPlugin({
+        pluginId: "gatewaychat",
+        label: "Gateway Chat",
+        blurb: "Gateway Chat delivery truth test plugin.",
+        actions: ["send"],
+        messaging: {
+          targetResolver: {
+            looksLikeId: () => true,
+          },
+        },
+        handleAction: vi.fn(async () => jsonResult({ ok: true })),
+      });
+      setTestPlugin(gatewayPlugin, "gatewaychat");
+      mocks.executeSendAction.mockResolvedValue({
+        handledBy: "core",
+        payload: nestedPayload,
+        sendResult,
+      });
+
+      const result = await runMessageAction({
+        cfg: {
+          channels: {
+            gatewaychat: {
+              enabled: true,
+            },
+          },
+        } as OpenClawConfig,
+        action: "broadcast",
+        params: {
+          channel: "gatewaychat",
+          targets: ["user-123"],
+          message: "hello from broadcast",
+        },
+      });
+
+      expect(result.kind).toBe("broadcast");
+      if (result.kind !== "broadcast") {
+        throw new Error("expected broadcast result");
+      }
+      expect(result.payload.results).toEqual([
+        {
+          channel: "gatewaychat",
+          to: "user-123",
+          ...outcome,
+          payload: nestedPayload,
+          result: sendResult,
+        },
+      ]);
+      expect(result.payload.results[0]?.payload).toBe(nestedPayload);
+      expect(result.payload.results[0]?.result).toBe(sendResult);
     });
 
     it("preserves partial-delivery evidence from failed broadcast sends", async () => {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -57,6 +57,34 @@ function withSendNormalization(
   return normalization && result.kind === "send" ? { ...result, normalization } : result;
 }
 
+function deriveBroadcastEntryOutcome(
+  sendResult?: MessageSendResult,
+): { ok: true } | { ok: false; error: string; sentBeforeError?: true } {
+  if (
+    !sendResult ||
+    sendResult.deliveryStatus === undefined ||
+    sendResult.deliveryStatus === "sent"
+  ) {
+    return { ok: true };
+  }
+  switch (sendResult.deliveryStatus) {
+    case "suppressed":
+      return {
+        ok: false,
+        error: `Broadcast send suppressed: ${sendResult.suppressionReason ?? "unknown reason"}.`,
+      };
+    case "failed":
+      return { ok: false, error: sendResult.error ?? "Broadcast send failed." };
+    case "partial_failed":
+      return {
+        ok: false,
+        error: sendResult.error ?? "Broadcast send partially failed.",
+        sentBeforeError: true,
+      };
+  }
+  return sendResult.deliveryStatus satisfies never;
+}
+
 async function handleBroadcastAction(
   input: MessageActionInput,
   params: Record<string, unknown>,
@@ -147,7 +175,9 @@ async function handleBroadcastAction(
         results.push({
           channel: targetChannel,
           to: resolved.to,
-          ok: true,
+          ...deriveBroadcastEntryOutcome(
+            sendResult.kind === "send" ? sendResult.sendResult : undefined,
+          ),
           payload: sendResult.kind === "send" ? sendResult.payload : undefined,
           result: sendResult.kind === "send" ? sendResult.sendResult : undefined,
         });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where message broadcast entries reported `ok: true` whenever a nested send returned, even when structured delivery said the message was suppressed, failed, or partially failed. Consumers could therefore receive contradictory success and non-delivery evidence.

## Why This Change Was Made

The shared broadcast runner now derives each entry from the nested `MessageSendResult.deliveryStatus`:

- `sent` is successful.
- `suppressed` and `failed` are unsuccessful with an explanatory error.
- `partial_failed` is unsuccessful and preserves `sentBeforeError`.
- Legacy results without a delivery status keep the existing success behavior.

Nested payload and structured result objects remain intact. Thrown errors and abort handling are unchanged.

AI-assisted: yes. The final mapping and boundary tests were manually reviewed and passed fresh structured autoreview after the final rebase.

## User Impact

Broadcast results now truthfully identify destinations that did not receive a message. Models and downstream delivery logic no longer have to contradict an incorrect top-level success flag.

## Evidence

- Table-driven runner coverage includes sent, suppressed, failed with/without error, partial failure with/without error, and legacy no-status sends.
- Structured nested payload/result identity is retained in every case.
- Final rebased focused proof: 51 tests passed across the broadcast runner and downstream source-reply evidence.
- Broadcast changed gate passed on Testbox `tbx_01kzttrzt0yebham72k5ryaarf` ([run](https://github.com/openclaw/openclaw/actions/runs/31590819447)).
- An earlier exact-head run exposed an unrelated test type failure already present on its base ([run](https://github.com/openclaw/openclaw/actions/runs/31591648309)); that base repair landed independently in [#122607](https://github.com/openclaw/openclaw/pull/122607) and is not part of this PR.
- A follow-up changed gate including core and extension test typechecks passed on Testbox `tbx_01kztvvappqdxczy46vnare6zj` ([run](https://github.com/openclaw/openclaw/actions/runs/31592210473)).
- Rebase onto current `main` preserved patch ID `e0d141718bcb03b5c006415288658ce3ba33ef20`; formatting and `git diff --check` passed.
- Fresh complete-branch autoreview after rebase: clean.
- Production +31/−1; tests +122/−0. Production growth is one closed status-to-outcome mapping at the broadcast owner; no downstream inference or compatibility shim was added.
