### PR TITLE
fix(test): restore browser test typecheck after CDP pinning

### DIFF
--- a/extensions/browser/src/browser/cdp.helpers.test.ts
+++ b/extensions/browser/src/browser/cdp.helpers.test.ts
@@ -1,6 +1,7 @@
 // Browser tests cover cdp.helpers plugin behavior.
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LookupFn } from "../infra/net/ssrf.js";
 import {
   assertChromeMcpCdpTransportAllowed,
   resolveCdpReachabilityPolicy,
@@ -12,6 +13,11 @@ import { assertBrowserNavigationAllowed } from "./navigation-guard.js";
 const PROFILE_HTTP_REACHABILITY_TIMEOUT_MS = 300;
 const PROFILE_WS_REACHABILITY_MIN_TIMEOUT_MS = 200;
 const PROFILE_WS_REACHABILITY_MAX_TIMEOUT_MS = 2000;
+
+function createLookupFn(address: string): LookupFn {
+  const family = address.includes(":") ? 6 : 4;
+  return vi.fn(async () => [{ address, family }]) as unknown as LookupFn;
+}
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
 
@@ -167,7 +173,7 @@ describe("cdp helpers", () => {
     await expect(
       resolvePinnedHostnameWithPolicy("browser.example", {
         policy: scoped,
-        lookupFn: async () => [{ address: "10.0.0.8", family: 4 }],
+        lookupFn: createLookupFn("10.0.0.8"),
       }),
     ).rejects.toThrow(/private\/internal\/special-use ip address/i);
   });
@@ -188,7 +194,7 @@ describe("cdp helpers", () => {
     await expect(
       resolvePinnedHostnameWithPolicy("browser.example", {
         policy: scoped,
-        lookupFn: async () => [{ address: "10.0.0.8", family: 4 }],
+        lookupFn: createLookupFn("10.0.0.8"),
       }),
     ).resolves.toEqual(expect.objectContaining({ addresses: ["10.0.0.8"] }));
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where canonical `main` and pull requests fail `check-test-types` after the guarded CDP transport change because two DNS lookup test doubles do not implement Node's overloaded lookup type.

## Why This Change Was Made

Use the Browser tests' existing typed `LookupFn` mock pattern for both CDP policy cases. This keeps the test behavior unchanged while satisfying the real SSRF lookup contract; no production code changes.

## User Impact

No runtime behavior changes. Developers regain a green browser test typecheck and CI can gate unrelated pull requests normally.

## Evidence

Before, canonical main run [31590440071](https://github.com/openclaw/openclaw/actions/runs/31590440071) failed `check-test-types` at `cdp.helpers.test.ts:170` and `:191` with TS2322.

After locally on Node 24 with `CI=1`:

- `pnpm check:test-types` — passed
- `node scripts/check-changed.mjs` — passed
- `node scripts/run-vitest.mjs extensions/browser/src/browser/cdp.helpers.test.ts` — 48 tests passed
- formatter and `git diff --check` — passed

The configured autoreview could not execute because the `codex` binary is unavailable in this orb; the one-file test-only diff was manually reviewed.
