### PR TITLE
fix(tts): preserve hidden-only tagged fallback text

### DIFF
--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -3086,6 +3086,61 @@ describe("tryDispatchAcpReplyCore", () => {
     expect(dispatcherCall(dispatcher.sendFinalReply).text).toBe("Visible.  Done.");
   });
 
+  it.each([
+    {
+      expectedText: "Private ACP speech.",
+      ttsReply: { text: "Private ACP speech." },
+      finalReply: {},
+      streamedText: "[[tts:text]]Private ACP speech.[[/tts:text]]",
+    },
+    {
+      expectedText: undefined,
+      ttsReply: {
+        text: "Private ACP speech.",
+        mediaUrl: "/tmp/openclaw-media/acp-tts.ogg",
+        audioAsVoice: true,
+      },
+      finalReply: {
+        mediaUrl: "/tmp/openclaw-media/acp-tts.ogg",
+        audioAsVoice: true,
+      },
+      streamedText: "[[tts:text]]Private ACP speech.[[/tts:text]]",
+    },
+    {
+      expectedText: "Visible ACP answer. ",
+      ttsReply: { text: "Visible ACP answer." },
+      finalReply: undefined,
+      streamedText: "Visible ACP answer. [[tts:text]]Private speech.[[/tts:text]]",
+    },
+  ])("keeps tagged ACP TTS delivery single for $streamedText", async (testCase) => {
+    setReadyAcpResolution();
+    queueTtsReplies(testCase.ttsReply as MockTtsReply);
+    mockVisibleTextTurn(testCase.streamedText);
+    const { dispatcher } = createDispatcher();
+
+    await runDispatch({
+      bodyForAgent: "reply",
+      cfg: createAcpTestConfig({
+        acp: { enabled: true, stream: { deliveryMode: "live" } },
+        tts: { auto: "tagged" },
+      }),
+      dispatcher,
+      ctxOverrides: { Provider: "telegram", Surface: "telegram" },
+    });
+
+    const blockReply = vi.mocked(dispatcher.sendBlockReply).mock.calls[0]?.[0];
+    const deliveredPayload = testCase.finalReply
+      ? dispatcherCall(dispatcher.sendFinalReply)
+      : blockReply;
+    expect(deliveredPayload?.text).toBe(testCase.expectedText);
+    if (testCase.finalReply) {
+      expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+      expect(deliveredPayload).toMatchObject(testCase.finalReply);
+    } else {
+      expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    }
+  });
+
   it("falls back to Telegram ACP text when a routed captioned voice is suppressed", async () => {
     setReadyAcpResolution();
     ttsCapabilityMocks.captionedFinalText = true;

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -56,6 +56,7 @@ import {
   createAcpDispatchDeliveryCoordinator,
   type AcpDispatchDeliveryCoordinator,
 } from "./dispatch-acp-delivery.js";
+import { needsTtsFallback } from "./dispatch-from-config.finalize.js";
 import { appendRecentHistoryImageContext } from "./history-media.js";
 import { hasInboundMediaForUnderstanding } from "./inbound-media.js";
 import type { ReplyDispatchKind, ReplyDispatcher } from "./reply-dispatcher.types.js";
@@ -362,6 +363,13 @@ async function finalizeAcpTurnOutput(params: {
         queuedFinal = queuedFinal || delivered;
         finalMediaDelivered = params.delivery.hasDeliveredFinalTtsMedia();
       } else if (shouldDeferVisibleTextForTts && ttsSyntheticReply.text?.trim()) {
+        const delivered = await params.delivery.deliver(
+          "final",
+          { text: ttsSyntheticReply.text },
+          { skipTts: true },
+        );
+        queuedFinal = queuedFinal || delivered;
+      } else if (needsTtsFallback(true, accumulatedVisibleBlockText, ttsSyntheticReply.text)) {
         const delivered = await params.delivery.deliver(
           "final",
           { text: ttsSyntheticReply.text },

--- a/src/auto-reply/reply/dispatch-from-config.delivery-and-tts.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.delivery-and-tts.test-utils.ts
@@ -15,6 +15,7 @@ import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
 import type { MsgContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import { needsTtsFallback } from "./dispatch-from-config.finalize.js";
 import {
   createDispatcher,
   diagnosticMocks,
@@ -2223,5 +2224,55 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendBlockReply).toHaveBeenCalledWith({ text: "Plain tagged text." });
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
+
+  it.each([
+    {
+      expectedText: "Private speech.",
+      ttsReply: { text: "Private speech." },
+      finalReply: {},
+      streamedText: "[[tts:text]]Private speech.[[/tts:text]]",
+    },
+    {
+      expectedText: undefined,
+      ttsReply: { text: "Private speech.", mediaUrl: "https://x/tts.opus", audioAsVoice: true },
+      finalReply: { mediaUrl: "https://x/tts.opus", audioAsVoice: true },
+      streamedText: "[[tts:text]]Private speech.[[/tts:text]]",
+    },
+    {
+      expectedText: "Visible answer.",
+      ttsReply: { text: "Visible answer." },
+      finalReply: undefined,
+      streamedText: "Visible answer. [[tts:text]]Private speech.[[/tts:text]]",
+    },
+  ])("keeps tagged TTS delivery single for $streamedText", async (testCase) => {
+    setNoAbort();
+    ttsMocks.state.statusSnapshot.autoMode = "tagged";
+    ttsMocks.maybeApplyTtsToPayload.mockResolvedValueOnce(testCase.ttsReply);
+    const dispatcher = createDispatcher();
+    const replyResolver = async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onBlockReply?.({ text: testCase.streamedText });
+      return undefined;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx: buildTestCtx({ Provider: "telegram", Surface: "telegram" }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    const blockReply = vi.mocked(dispatcher.sendBlockReply).mock.calls[0]?.[0];
+    const deliveredPayload = testCase.finalReply ? firstFinalReplyPayload(dispatcher) : blockReply;
+    expect(deliveredPayload?.text?.trim()).toBe(testCase.expectedText);
+    if (testCase.finalReply) {
+      expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+      expect(deliveredPayload).toMatchObject(testCase.finalReply);
+    } else {
+      expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    }
+  });
+
+  it("skips fallback when directives stay visible", () =>
+    expect(needsTtsFallback(false, "[[tts:text]]x", "x")).toBe(false));
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -31,6 +31,9 @@ type ExecuteDispatchReadyState = Extract<
   { status: "ready" }
 >["state"];
 
+export const needsTtsFallback = (clean: boolean, visible: string, fallback?: string) =>
+  clean && !visible.trim() && Boolean(fallback?.trim());
+
 export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState) {
   const {
     cfg,
@@ -228,6 +231,19 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
                 { visibleTextAlreadyDelivered: true },
               );
           const finalReply = await state.sendFinalPayload(ttsOnlyPayload, {
+            abortSignal: getDispatchAbortSignal(),
+            skipTts: true,
+          });
+          queuedFinal = finalReply.queuedFinal || queuedFinal;
+          routedFinalCount += finalReply.routedFinalCount;
+        } else if (
+          needsTtsFallback(
+            Boolean(state.cleanBlockTtsDirectiveText),
+            cleanDeferredFinalText(deferredTtsTextPending),
+            ttsSyntheticReply.text,
+          )
+        ) {
+          const finalReply = await state.sendFinalPayload(ttsSyntheticReply, {
             abortSignal: getDispatchAbortSignal(),
             skipTts: true,
           });


### PR DESCRIPTION
Fixes #76531. Reported by @cavit99.

## What Problem This Solves

Fixes an issue where users relying on tagged text-to-speech replies would receive no message when a reply contained only a hidden `[[tts:text]]` block and speech synthesis failed.

## Why This Change Was Made

The TTS runtime already preserves the tagged text as a fallback after a synthesis miss, but the normal and ACP dispatch finalizers only consumed non-media synthetic replies in caption-deferred mode. Tagged mode intentionally does not defer captions, so a hidden-only reply left the cleaned visible accumulator empty and the fallback was silently dropped.

Both dispatch owners now consume that non-media fallback only when their cleaned visible block accumulator is empty, and mark the delivery `skipTts` to prevent reprocessing. Existing media delivery, caption deferral, and ordinary visible tagged replies are unchanged.

Provenance: the affected finalizer branches were carried forward by #83988 (`b8f6086411cf`), authored by @Jerry-Xin and merged by @obviyus. The hidden-only synthesis-miss case was not covered there.

## User Impact

Hidden-only tagged replies now remain visible as text when TTS synthesis fails. Replies that already emitted visible text are not duplicated, and successful voice/media replies keep their existing behavior.

## Evidence

- Focused tests: 490 passed across `dispatch-from-config`, `dispatch-acp`, and `tts-runtime-fallbacks`.
- Changed-scope Testbox on exact head `493e70354d5`: `tbx_01kzv09p2s7zn9hnhbvnpn1me0`, exit 0 ([run](https://github.com/openclaw/openclaw/actions/runs/31598279732)).
- Max-P1 autoreview: clean, no accepted or actionable findings.
- Scope: production `+24/-0`; tests `+106/-0`; four authorized files only.
- Ad-hoc ephemeral QA channel + real Gateway + mock OpenAI provider + failing mock OpenAI TTS proof:

```json
{
  "normal": {
    "outboundCount": 1,
    "outboundTexts": ["ISSUE_76531_NORMAL_FALLBACK"],
    "providerRequestCount": 1,
    "ttsRequestCount": 1,
    "ttsInputs": ["ISSUE_76531_NORMAL_FALLBACK"],
    "exactlyOneFallback": true,
    "noDuplicate": true
  },
  "acp": {
    "outboundCount": 1,
    "outboundTexts": ["ISSUE_76531_ACP_FALLBACK"],
    "providerRequestCount": 1,
    "ttsRequestCount": 1,
    "ttsInputs": ["ISSUE_76531_ACP_FALLBACK"],
    "exactlyOneFallback": true,
    "noDuplicate": true
  },
  "verdict": "pass"
}
```

Punchcard-Session: golden-brook-lantern-zw


