### PR TITLE
test(browser): type CDP lookup mocks

### DIFF
--- a/extensions/browser/src/browser/cdp.helpers.test.ts
+++ b/extensions/browser/src/browser/cdp.helpers.test.ts
@@ -23,6 +23,7 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
   };
 });
 
+import type { LookupFn } from "../infra/net/ssrf.js";
 import {
   assertCdpEndpointAllowed,
   fetchJson,
@@ -167,7 +168,7 @@ describe("cdp helpers", () => {
     await expect(
       resolvePinnedHostnameWithPolicy("browser.example", {
         policy: scoped,
-        lookupFn: async () => [{ address: "10.0.0.8", family: 4 }],
+        lookupFn: (async () => [{ address: "10.0.0.8", family: 4 }]) as unknown as LookupFn,
       }),
     ).rejects.toThrow(/private\/internal\/special-use ip address/i);
   });
@@ -188,7 +189,7 @@ describe("cdp helpers", () => {
     await expect(
       resolvePinnedHostnameWithPolicy("browser.example", {
         policy: scoped,
-        lookupFn: async () => [{ address: "10.0.0.8", family: 4 }],
+        lookupFn: (async () => [{ address: "10.0.0.8", family: 4 }]) as unknown as LookupFn,
       }),
     ).resolves.toEqual(expect.objectContaining({ addresses: ["10.0.0.8"] }));
   });


### PR DESCRIPTION
## What Problem This Solves

Repairs current-main CI failure [31590440071](https://github.com/openclaw/openclaw/actions/runs/31590440071), where `check-test-types` rejects two browser CDP DNS mocks. Each mock intentionally returns the all-addresses result used by `resolvePinnedHostnameWithPolicy`, but the injected `LookupFn` contract is Node's overloaded one-or-all lookup function.

## Why This Change Was Made

The tests now type the two all-address mock implementations against the existing `LookupFn` contract. Production behavior and assertions are unchanged; this is the established test-only adapter for an overloaded Node API.

Production LOC: +0/-0 | Tests: +3/-2

## User Impact

No user-visible behavior changes. Main and downstream PRs can pass the extension test-type gate again.

## Evidence

- [Testbox 31592544394](https://github.com/openclaw/openclaw/actions/runs/31592544394): browser CDP helpers 48/48 green; complete `check:test-types` green.
- Pinned formatter check passed.
- `git diff --check` passed.
- Structured autoreview reported no accepted/actionable findings.

This exact one-file repair also appears as the final commit of broad feature PR #122489. This focused PR isolates the red-main repair so CI recovery does not depend on landing the unrelated host-sleep feature.
