### PR TITLE
test(browser): type SSRF lookup mocks

### DIFF
--- a/extensions/browser/src/browser/cdp.helpers.test.ts
+++ b/extensions/browser/src/browser/cdp.helpers.test.ts
@@ -1,6 +1,7 @@
 // Browser tests cover cdp.helpers plugin behavior.
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LookupFn } from "../infra/net/ssrf.js";
 import {
   assertChromeMcpCdpTransportAllowed,
   resolveCdpReachabilityPolicy,
@@ -167,7 +168,7 @@ describe("cdp helpers", () => {
     await expect(
       resolvePinnedHostnameWithPolicy("browser.example", {
         policy: scoped,
-        lookupFn: async () => [{ address: "10.0.0.8", family: 4 }],
+        lookupFn: (async () => [{ address: "10.0.0.8", family: 4 }]) as unknown as LookupFn,
       }),
     ).rejects.toThrow(/private\/internal\/special-use ip address/i);
   });
@@ -188,7 +189,7 @@ describe("cdp helpers", () => {
     await expect(
       resolvePinnedHostnameWithPolicy("browser.example", {
         policy: scoped,
-        lookupFn: async () => [{ address: "10.0.0.8", family: 4 }],
+        lookupFn: (async () => [{ address: "10.0.0.8", family: 4 }]) as unknown as LookupFn,
       }),
     ).resolves.toEqual(expect.objectContaining({ addresses: ["10.0.0.8"] }));
   });


### PR DESCRIPTION
## What Problem This Solves

Resolves a new `check-test-types` failure where the Browser CDP SSRF tests no longer typecheck after the shared DNS lookup contract became overload-sensitive. The failure blocks exact-head validation for https://github.com/openclaw/openclaw/pull/122589 and https://github.com/openclaw/openclaw/pull/122592.

## Why This Change Was Made

The two array-returning DNS fixtures now use the Browser plugin's sanctioned `LookupFn` facade type. The cast is limited to the test mocks and preserves their values and runtime behavior; production code, configuration, documentation, and release surfaces are unchanged.

## User Impact

No user-visible behavior changes. Maintainers regain a green extension test typecheck lane for branches based on this `main` state.

## Evidence

- Red: Actions run `31591204990`, job `94096550194` reported `TS2322` at the two Browser lookup mocks.
- Focused behavior: `node scripts/run-vitest.mjs extensions/browser/src/browser/cdp.helpers.test.ts` — 48 tests passed.
- Exact extension typecheck: Blacksmith Testbox `tbx_01kztw46d0aprb5n0vvdd3rdan`, Actions run `31592581162` — `pnpm tsgo:extensions:test` passed.
- Targeted `oxfmt`, `scripts/run-oxlint.mjs`, and `git diff --check` passed.
- Local exact-head ClawSweeper: `nothing_found`, high confidence; best-fix verdict yes.
- Production LOC: `0`; tests: `+3/-2`.

AI-assisted implementation and review.
