### PR TITLE
test(sqlite): stabilize VACUUM interruption proof

### DIFF
--- a/scripts/lib/sqlite-reliability-runner.ts
+++ b/scripts/lib/sqlite-reliability-runner.ts
@@ -57,9 +57,9 @@ type IterationMetric = {
 
 type CompactionProof = ReliabilityReport["maintenanceProof"]["compaction"];
 
-// Keep 50% headroom above the 2 MiB staged-restore threshold without copying
-// an arbitrarily large payload through every repository and restore crash phase.
-const COMPACTION_BLOAT_ROWS = 12;
+// Keep enough work in VACUUM that the parent can observe its active journal and
+// deliver SIGKILL before the transaction commits, including on fast CI disks.
+const COMPACTION_BLOAT_ROWS = 64;
 const COMPACTION_BLOAT_PAYLOAD_BYTES = 256 * 1024;
 
 function nowMs(): number {


### PR DESCRIPTION
## What Problem This Solves

Repairs current-main CI failure [31593274407](https://github.com/openclaw/openclaw/actions/runs/31593274407), where the SQLite reliability proof observed an active `VACUUM` journal but the transaction committed before the parent delivered `SIGKILL`. That changed `auto_vacuum` from `NONE` to `INCREMENTAL`, invalidating the forced-crash rollback proof.

## Why This Change Was Made

PR #122576 reduced the compaction fixture from 64 rows to 12. On fast CI disks, the smaller workload leaves too little time between journal observation and termination. This restores the previously stable 64-row workload and documents that its size owns the cross-runner interruption window.

No timeout, retry, production runtime, assertion, or fallback changes.

Production LOC: +0/-0 | Test tooling: +3/-3

## User Impact

No product behavior changes. Main CI reliably proves SQLite `VACUUM` rollback under forced termination again.

## Evidence

- Original failure: [run 31593274407](https://github.com/openclaw/openclaw/actions/runs/31593274407), `checks-node-compact-small-14`.
- Original scenario after repair: [Testbox 31594140067](https://github.com/openclaw/openclaw/actions/runs/31594140067) — 5/5 passed; the reliability round trip completed in about 19 seconds.
- Pinned formatter and `git diff --check` passed.
- Structured autoreview reported no accepted/actionable findings.
