### PR TITLE
fix(browser): model DNS lookup overloads in CDP tests

### DIFF
--- a/extensions/browser/src/browser/cdp.helpers.test.ts
+++ b/extensions/browser/src/browser/cdp.helpers.test.ts
@@ -1,4 +1,5 @@
 // Browser tests cover cdp.helpers plugin behavior.
+import type { LookupAddress, LookupAllOptions, LookupOneOptions, LookupOptions } from "node:dns";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { LookupFn } from "../infra/net/ssrf.js";
@@ -15,8 +16,22 @@ const PROFILE_WS_REACHABILITY_MIN_TIMEOUT_MS = 200;
 const PROFILE_WS_REACHABILITY_MAX_TIMEOUT_MS = 2000;
 
 function createLookupFn(address: string): LookupFn {
-  const family = address.includes(":") ? 6 : 4;
-  return vi.fn(async () => [{ address, family }]) as unknown as LookupFn;
+  const result: LookupAddress = { address, family: address.includes(":") ? 6 : 4 };
+  function lookup(_hostname: string, family: number): Promise<LookupAddress>;
+  function lookup(_hostname: string, options: LookupOneOptions): Promise<LookupAddress>;
+  function lookup(_hostname: string, options: LookupAllOptions): Promise<LookupAddress[]>;
+  function lookup(
+    _hostname: string,
+    options: LookupOptions,
+  ): Promise<LookupAddress | LookupAddress[]>;
+  function lookup(_hostname: string): Promise<LookupAddress>;
+  async function lookup(
+    _hostname: string,
+    options?: number | LookupOptions,
+  ): Promise<LookupAddress | LookupAddress[]> {
+    return typeof options === "object" && options.all ? [result] : result;
+  }
+  return lookup;
 }
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());


### PR DESCRIPTION
## What Problem This Solves

Resolves a test-contract gap where the CDP DNS stub was forced through `LookupFn` with a broad cast, masking Node's single-result and `all: true` overload semantics.

## Why This Change Was Made

The test helper now implements the complete `dns/promises.lookup` overload contract and returns either one address or an address array according to the requested options. Production behavior and assertions are unchanged.

## User Impact

No user-visible behavior changes. Browser SSRF tests remain type-safe as Node's DNS declarations evolve.

## Evidence

- `extensions/browser/src/browser/cdp.helpers.test.ts`: 48/48 focused tests passed on Blacksmith Testbox.
- `pnpm check:test-types`: passed on Blacksmith Testbox.
- `node scripts/check-changed.mjs -- extensions/browser/src/browser/cdp.helpers.test.ts`: passed on Blacksmith Testbox.
- Autoreview: clean, no actionable findings.
