### PR TITLE
fix(gateway): refresh health after account removal

### DIFF
--- a/src/gateway/server-methods/health.ts
+++ b/src/gateway/server-methods/health.ts
@@ -33,17 +33,6 @@ function shouldScheduleRequestRefresh(
   return true;
 }
 
-function cachedAccountForRuntimeSnapshot(params: {
-  cachedChannel: ChannelHealthSummary | undefined;
-  accountId: string | undefined;
-}): ChannelHealthSummary | undefined {
-  const accountId = params.accountId;
-  if (accountId && params.cachedChannel?.accounts?.[accountId]) {
-    return params.cachedChannel.accounts[accountId];
-  }
-  return undefined;
-}
-
 function cachedLifecycleDiffersFromRuntime(params: {
   cachedAccount: ChannelHealthSummary | undefined;
   runtimeSnapshot: ChannelAccountSnapshot;
@@ -82,16 +71,19 @@ function cachedHealthDiffersFromRuntime(
       continue;
     }
     const cachedChannel = cached.channels[channelId];
+    const cachedAccounts = cachedChannel?.accounts;
+    if (
+      Object.keys(cachedAccounts ?? {}).some((accountId) => !Object.hasOwn(accounts, accountId))
+    ) {
+      return true;
+    }
     for (const [accountId, runtimeSnapshot] of Object.entries(accounts)) {
       if (!runtimeSnapshot) {
         continue;
       }
       if (
         cachedLifecycleDiffersFromRuntime({
-          cachedAccount: cachedAccountForRuntimeSnapshot({
-            cachedChannel,
-            accountId,
-          }),
+          cachedAccount: cachedAccounts?.[accountId],
           runtimeSnapshot,
         })
       ) {

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -4839,6 +4839,43 @@ describe("gateway healthHandlers.health cache freshness", () => {
     });
     expect(respond).toHaveBeenCalledWith(true, fresh, undefined);
   });
+
+  it("refreshes cached health after hot reload removes a runtime account", async () => {
+    const current = createSingleChannelHealthSnapshot({
+      channelId: "discord",
+      label: "Discord",
+      running: true,
+      connected: true,
+    });
+    const cached = {
+      ...current,
+      channels: {
+        discord: {
+          ...current.channels.discord,
+          accounts: {
+            ...current.channels.discord.accounts,
+            work: channelHealthAccount({ accountId: "work", running: true, connected: true }),
+          },
+        },
+      },
+    };
+    const { respond, refreshHealthSnapshot } = await requestHealthSnapshot({
+      cached,
+      fresh: current,
+      runtimeSnapshot: {
+        channels: {},
+        channelAccounts: {
+          discord: { default: { accountId: "default", running: true, connected: true } },
+        },
+      },
+    });
+
+    expect(refreshHealthSnapshot).toHaveBeenCalledWith({
+      probe: false,
+      includeSensitive: false,
+    });
+    expect(respond).toHaveBeenCalledWith(true, current, undefined);
+  });
 });
 
 describe("logs.tail", () => {


### PR DESCRIPTION
## What Problem This Solves

After a completed channel hot reload removed an account, the default cached `health` RPC could still report that deleted account as running and connected for up to the health-cache interval. Cache freshness checked live accounts missing from the cache, but not cached accounts missing from the complete runtime account map.

## Why This Change Was Made

The Gateway health-cache owner already has both authoritative account snapshots. It now compares account topology in both directions before serving a fresh-enough cached response:

- a live account absent from cached health still forces refresh;
- a cached account absent from the runtime snapshot now also forces refresh;
- unchanged account topology retains the existing cached fast path;
- lifecycle changes continue to force refresh as before.

The change also removes a redundant single-account lookup wrapper. No protocol, configuration, persistence, or fallback surface is added.

AI-assisted: yes. The final owner-boundary repair and regression were manually inspected and passed fresh structured autoreview on the rebased head.

## User Impact

`openclaw health` and other default health callers now reflect completed account removal on their first read instead of briefly presenting a deleted account as healthy.

## Evidence

- Pre-fix regression returned cached account `work` as connected/running after the runtime snapshot contained only `default`.
- Post-fix focused proof: 513 tests passed across the health handler, hot-reload promotion, and channel runtime eviction suites.
- Hosted changed gate passed on Testbox `tbx_01kztyx0ccd18mqd76tf7dp6ny` ([run](https://github.com/openclaw/openclaw/actions/runs/31596293418)).
- Exact-head CI passed on attempt 2 ([run](https://github.com/openclaw/openclaw/actions/runs/31597021883)); attempt 1's only failure was an unrelated transcript-repair SQLite race in the broad agents-support shard.
- Targeted formatting and `git diff --check` passed.
- Fresh complete-branch autoreview: clean.
- Production +7/−15 (net −8); tests +37/−0.
