### PR TITLE
chore: speed up cron direct delivery tests

### DIFF
--- a/src/cron/isolated-agent.delivery.test-helpers.ts
+++ b/src/cron/isolated-agent.delivery.test-helpers.ts
@@ -1,9 +1,7 @@
 // Isolated agent delivery test helpers build delivery targets and mocks.
-import { expect, vi } from "vitest";
+import { vi } from "vitest";
 import { runEmbeddedAgent } from "../agents/embedded-agent.js";
 import type { CliDeps } from "../cli/deps.js";
-import { runCronIsolatedAgentTurn } from "./isolated-agent.js";
-import { makeCfg, makeJob } from "./isolated-agent.test-harness.js";
 
 /** Creates mocked CLI delivery deps for isolated-agent delivery tests. */
 export function createCliDeps(overrides: Partial<CliDeps> = {}): CliDeps {
@@ -31,45 +29,5 @@ export function mockAgentPayloads(
       agentMeta: { sessionId: "s", provider: "p", model: "m" },
     },
     ...extra,
-  });
-}
-
-export function expectDirectTelegramDelivery(
-  deps: CliDeps,
-  params: { chatId: string; text: string; messageThreadId?: number },
-) {
-  expect(deps.sendMessageTelegram).toHaveBeenCalledTimes(1);
-  expect(deps.sendMessageTelegram).toHaveBeenCalledWith(
-    params.chatId,
-    params.text,
-    expect.objectContaining(
-      params.messageThreadId === undefined ? {} : { messageThreadId: params.messageThreadId },
-    ),
-  );
-}
-
-export async function runTelegramAnnounceTurn(params: {
-  home: string;
-  storePath: string;
-  deps: CliDeps;
-  delivery: {
-    mode: "announce";
-    channel: string;
-    to?: string;
-    bestEffort?: boolean;
-  };
-}): Promise<Awaited<ReturnType<typeof runCronIsolatedAgentTurn>>> {
-  return runCronIsolatedAgentTurn({
-    cfg: makeCfg(params.home, params.storePath, {
-      channels: { telegram: { botToken: "t-1" } },
-    }),
-    deps: params.deps,
-    job: {
-      ...makeJob({ kind: "agentTurn", message: "do it" }),
-      delivery: params.delivery,
-    },
-    message: "do it",
-    sessionKey: "cron:job-1",
-    lane: "cron",
   });
 }

--- a/src/cron/isolated-agent.direct-delivery-core-channels.test.ts
+++ b/src/cron/isolated-agent.direct-delivery-core-channels.test.ts
@@ -1,598 +1,78 @@
-// Direct delivery tests cover isolated agent delivery through core channel targets.
-import "./isolated-agent.mocks.js";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { runSubagentAnnounceFlow } from "../agents/subagents/announce/subagent-announce.js";
-import type {
-  ChannelOutboundAdapter,
-  ChannelOutboundContext,
-} from "../channels/plugins/types.adapters.js";
-import type { CliDeps } from "../cli/deps.js";
+// Direct delivery tests keep the active runtime config through isolated cron orchestration.
+import { afterEach, describe, expect, it } from "vitest";
 import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../config/config.js";
-import { callGateway } from "../gateway/call.js";
-import { resolveOutboundSendDep } from "../infra/outbound/send-deps.js";
-import { setActivePluginRegistry } from "../plugins/runtime.js";
-import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
-  createCliDeps,
-  expectDirectTelegramDelivery,
-  mockAgentPayloads,
-  runTelegramAnnounceTurn,
-} from "./isolated-agent.delivery.test-helpers.js";
-import { runCronIsolatedAgentTurn } from "./isolated-agent.js";
+  makeIsolatedAgentJobFixture,
+  makeIsolatedAgentParamsFixture,
+} from "./isolated-agent/job-fixtures.js";
+import { setupRunCronIsolatedAgentTurnSuite } from "./isolated-agent/run.suite-helpers.js";
 import {
-  makeCfg,
-  makeJob,
-  withTempCronHome,
-  writeSessionStore,
-} from "./isolated-agent.test-harness.js";
-import { setupIsolatedAgentTurnMocks } from "./isolated-agent.test-setup.js";
+  dispatchCronDeliveryMock,
+  loadRunCronIsolatedAgentTurn,
+  resolveCronDeliveryPlanMock,
+  resolveDeliveryTargetMock,
+} from "./isolated-agent/run.test-harness.js";
 
-type ChannelCase = {
-  name: string;
-  channel: "slack" | "discord" | "whatsapp" | "imessage";
-  to: string;
-  sendKey: keyof Pick<
-    CliDeps,
-    "sendMessageSlack" | "sendMessageDiscord" | "sendMessageWhatsApp" | "sendMessageIMessage"
-  >;
-  expectedTo: string;
-};
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
 
-const CASES: ChannelCase[] = [
-  {
-    name: "Slack",
-    channel: "slack",
-    to: "channel:C12345",
-    sendKey: "sendMessageSlack",
-    expectedTo: "channel:C12345",
-  },
-  {
-    name: "Discord",
-    channel: "discord",
-    to: "channel:789",
-    sendKey: "sendMessageDiscord",
-    expectedTo: "channel:789",
-  },
-  {
-    name: "WhatsApp",
-    channel: "whatsapp",
-    to: "+15551234567",
-    sendKey: "sendMessageWhatsApp",
-    expectedTo: "+15551234567",
-  },
-  {
-    name: "iMessage",
-    channel: "imessage",
-    to: "friend@example.com",
-    sendKey: "sendMessageIMessage",
-    expectedTo: "friend@example.com",
-  },
-];
-
-async function runExplicitAnnounceTurn(params: {
-  cfg: ReturnType<typeof makeCfg>;
-  deps: CliDeps;
-  channel: ChannelCase["channel"];
-  deleteAfterRun?: boolean;
-  to: string;
-}) {
-  return await runCronIsolatedAgentTurn({
-    cfg: params.cfg,
-    deps: params.deps,
-    job: {
-      ...makeJob({ kind: "agentTurn", message: "do it" }),
-      ...(params.deleteAfterRun === true ? { deleteAfterRun: true } : {}),
-      delivery: {
-        mode: "announce",
-        channel: params.channel,
-        to: params.to,
-      },
-    },
-    message: "do it",
-    sessionKey: "cron:job-1",
-    lane: "cron",
-  });
-}
-
-type CoreChannelSendFn = CliDeps[ChannelCase["sendKey"]];
-type MockedTestSendFn = TestSendFn & {
-  mock: { calls: Parameters<TestSendFn>[] };
-};
-
-function expectCoreChannelSendCall({
-  cfg,
-  expectedText,
-  expectedTo,
-  sendFn,
-  sentAt,
-}: {
-  cfg: ReturnType<typeof makeCfg>;
-  expectedText: string;
-  expectedTo: string;
-  sendFn: CoreChannelSendFn;
-  sentAt: number;
-}): void {
-  const calls = (sendFn as MockedTestSendFn).mock.calls;
-  const call = calls[sentAt];
-  expect(call?.[0]).toBe(expectedTo);
-  expect(call?.[1]).toBe(expectedText);
-  expect(call?.[2]?.cfg).toStrictEqual(cfg);
-  expect(call?.[2]?.accountId).toBeUndefined();
-}
-
-async function expectCoreChannelAnnounceDelivery({
-  assertSend,
-  deleteAfterRun,
-  meta,
-  payloads,
-  testCase,
-}: {
-  assertSend: (sendFn: CoreChannelSendFn, cfg: ReturnType<typeof makeCfg>) => void;
-  meta?: Parameters<typeof mockAgentPayloads>[1];
-  payloads: Parameters<typeof mockAgentPayloads>[0];
-  testCase: ChannelCase;
-  deleteAfterRun?: boolean;
-}): Promise<void> {
-  await withTempCronHome(async (home) => {
-    const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
-    const cfg = makeCfg(home, storePath);
-    const deps = createCliDeps();
-    if (meta) {
-      mockAgentPayloads(payloads, meta);
-    } else {
-      mockAgentPayloads(payloads);
-    }
-
-    const res = await runExplicitAnnounceTurn({
-      cfg,
-      deps,
-      channel: testCase.channel,
-      deleteAfterRun,
-      to: testCase.to,
-    });
-
-    expect(res.status).toBe("ok");
-    expect(res.delivered).toBe(true);
-    expect(res.deliveryAttempted).toBe(true);
-    expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
-    assertSend(deps[testCase.sendKey], cfg);
-  });
-}
-
-type CoreChannel = ChannelCase["channel"];
-type TestSendFn = (
-  to: string,
-  text: string,
-  options?: Record<string, unknown>,
-) => Promise<{ messageId?: string } & Record<string, unknown>>;
-
-function withRequiredMessageId(channel: CoreChannel, result: Awaited<ReturnType<TestSendFn>>) {
-  return {
-    channel,
-    ...result,
-    messageId:
-      typeof result.messageId === "string" && result.messageId.trim()
-        ? result.messageId
-        : `${channel}-test-message`,
-  };
-}
-
-function resolveCoreChannelSender(
-  channel: CoreChannel,
-  deps: ChannelOutboundContext["deps"],
-): TestSendFn {
-  const sender = resolveOutboundSendDep<TestSendFn>(deps, channel);
-  if (!sender) {
-    throw new Error(`missing ${channel} sender`);
-  }
-  return sender;
-}
-
-function createCliDelegatingOutbound(params: {
-  channel: CoreChannel;
-  deliveryMode?: ChannelOutboundAdapter["deliveryMode"];
-  preferFinalAssistantVisibleText?: boolean;
-  resolveTarget?: ChannelOutboundAdapter["resolveTarget"];
-}): ChannelOutboundAdapter {
-  return {
-    deliveryMode: params.deliveryMode ?? "direct",
-    ...(params.preferFinalAssistantVisibleText !== undefined
-      ? { preferFinalAssistantVisibleText: params.preferFinalAssistantVisibleText }
-      : {}),
-    ...(params.resolveTarget ? { resolveTarget: params.resolveTarget } : {}),
-    sendText: async ({ cfg, to, text, accountId, deps }) =>
-      withRequiredMessageId(
-        params.channel,
-        await resolveCoreChannelSender(params.channel, deps)(to, text, {
-          cfg,
-          accountId: accountId ?? undefined,
-        }),
-      ),
-  };
-}
-
-const identityResolveTarget: ChannelOutboundAdapter["resolveTarget"] = ({ to }) => {
-  const trimmed = to?.trim();
-  return trimmed
-    ? { ok: true, to: trimmed }
-    : { ok: false, error: new Error("target is required") };
-};
-
-function makeRunMeta(finalAssistantVisibleText: string) {
-  return {
-    durationMs: 5,
-    agentMeta: { sessionId: "s", provider: "p", model: "m" },
-    finalAssistantVisibleText,
-  };
-}
-
-async function expectTelegramAnnounceDelivery({
-  expected,
-  meta,
-  payloads,
-  to,
-}: {
-  expected: Parameters<typeof expectDirectTelegramDelivery>[1];
-  meta?: Parameters<typeof mockAgentPayloads>[1];
-  payloads: Parameters<typeof mockAgentPayloads>[0];
-  to: string;
-}): Promise<void> {
-  await withTempCronHome(async (home) => {
-    const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
-    const deps = createCliDeps();
-    if (meta) {
-      mockAgentPayloads(payloads, meta);
-    } else {
-      mockAgentPayloads(payloads);
-    }
-
-    const res = await runTelegramAnnounceTurn({
-      home,
-      storePath,
-      deps,
-      delivery: { mode: "announce", channel: "telegram", to },
-    });
-
-    expect(res.status).toBe("ok");
-    expect(res.delivered).toBe(true);
-    expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
-    expectDirectTelegramDelivery(deps, expected);
-  });
-}
-
-function setupCoreChannelMocks(): void {
-  setupIsolatedAgentTurnMocks({ fast: true });
-  setActivePluginRegistry(
-    createTestRegistry([
-      {
-        pluginId: "slack",
-        plugin: createOutboundTestPlugin({
-          id: "slack",
-          outbound: createCliDelegatingOutbound({ channel: "slack" }),
-        }),
-        source: "test",
-      },
-      {
-        pluginId: "discord",
-        plugin: createOutboundTestPlugin({
-          id: "discord",
-          outbound: createCliDelegatingOutbound({
-            channel: "discord",
-            preferFinalAssistantVisibleText: true,
-          }),
-        }),
-        source: "test",
-      },
-      {
-        pluginId: "whatsapp",
-        plugin: createOutboundTestPlugin({
-          id: "whatsapp",
-          outbound: createCliDelegatingOutbound({
-            channel: "whatsapp",
-            deliveryMode: "gateway",
-            resolveTarget: identityResolveTarget,
-          }),
-        }),
-        source: "test",
-      },
-      {
-        pluginId: "imessage",
-        plugin: createOutboundTestPlugin({
-          id: "imessage",
-          outbound: createCliDelegatingOutbound({ channel: "imessage" }),
-        }),
-        source: "test",
-      },
-    ]),
-  );
-}
-
-describe("runCronIsolatedAgentTurn core-channel direct delivery", () => {
-  beforeAll(async () => {
-    setupCoreChannelMocks();
-    const slack = CASES[0];
-    if (!slack) {
-      throw new Error("expected Slack channel case");
-    }
-    await expectCoreChannelAnnounceDelivery({
-      testCase: slack,
-      payloads: [{ text: "warm runtime" }],
-      assertSend: () => {},
-    });
-    clearRuntimeConfigSnapshot();
-  });
-
-  beforeEach(setupCoreChannelMocks);
+describe("runCronIsolatedAgentTurn direct delivery config", () => {
+  setupRunCronIsolatedAgentTurnSuite({ fast: true });
 
   afterEach(() => {
     clearRuntimeConfigSnapshot();
   });
 
-  it("delivers only the final Slack result after an earlier heartbeat acknowledgement", async () => {
-    const slack = CASES[0];
-    if (!slack) {
-      throw new Error("expected Slack channel case");
-    }
-    const finalResult = "Critical deployment failure: database unavailable.";
-    await expectCoreChannelAnnounceDelivery({
-      testCase: slack,
-      deleteAfterRun: true,
-      payloads: [{ text: "HEARTBEAT_OK" }, { text: finalResult }],
-      meta: { meta: makeRunMeta(finalResult) },
-      assertSend: (sendFn, cfg) => {
-        expect(sendFn).toHaveBeenCalledTimes(1);
-        expectCoreChannelSendCall({
-          cfg,
-          expectedText: finalResult,
-          expectedTo: slack.expectedTo,
-          sendFn,
-          sentAt: 0,
-        });
+  it("keeps the active runtime snapshot after agent-default derivation", async () => {
+    const sourceCfg = {
+      channels: {
+        discord: {
+          accounts: {
+            default: {
+              token: { provider: "default", source: "env", id: "DISCORD_BOT_TOKEN" },
+            },
+          },
+        },
       },
+    } satisfies OpenClawConfig;
+    const runtimeCfg = {
+      channels: {
+        discord: {
+          accounts: { default: { token: "resolved-discord-token" } },
+        },
+      },
+    } satisfies OpenClawConfig;
+    setRuntimeConfigSnapshot(runtimeCfg, sourceCfg);
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "discord",
+      to: "channel:789",
     });
-    expect(callGateway).toHaveBeenCalledWith(
-      expect.objectContaining({ method: "sessions.delete" }),
+    resolveDeliveryTargetMock.mockResolvedValue({
+      ok: true,
+      channel: "discord",
+      to: "channel:789",
+      accountId: undefined,
+      threadId: undefined,
+      mode: "explicit",
+    });
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentParamsFixture({
+        cfg: sourceCfg,
+        job: makeIsolatedAgentJobFixture({
+          delivery: { mode: "announce", channel: "discord", to: "channel:789" },
+        }),
+      }),
     );
-  });
 
-  for (const testCase of CASES) {
-    it(`routes ${testCase.name} text-only announce delivery through the outbound adapter`, async () => {
-      await expectCoreChannelAnnounceDelivery({
-        testCase,
-        payloads: [{ text: "hello from cron" }],
-        assertSend: (sendFn, cfg) => {
-          expect(sendFn).toHaveBeenCalledTimes(1);
-          expectCoreChannelSendCall({
-            cfg,
-            expectedText: "hello from cron",
-            expectedTo: testCase.expectedTo,
-            sendFn,
-            sentAt: 0,
-          });
-        },
-      });
-    });
-
-    if (testCase.channel === "discord") {
-      it("keeps isolated Discord delivery on the active runtime snapshot after agent-default derivation", async () => {
-        await withTempCronHome(async (home) => {
-          const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
-          const sourceCfg = makeCfg(home, storePath, {
-            channels: {
-              discord: {
-                accounts: {
-                  default: {
-                    token: { provider: "default", source: "env", id: "DISCORD_BOT_TOKEN" },
-                  },
-                },
-              },
-            },
-          });
-          const runtimeCfg = makeCfg(home, storePath, {
-            channels: {
-              discord: {
-                accounts: { default: { token: "resolved-discord-token" } },
-              },
-            },
-          });
-          setRuntimeConfigSnapshot(runtimeCfg, sourceCfg);
-          const deps = createCliDeps();
-          mockAgentPayloads([{ text: "hello from cron" }]);
-
-          const res = await runExplicitAnnounceTurn({
-            cfg: sourceCfg,
-            deps,
-            channel: "discord",
-            to: testCase.to,
-          });
-
-          expect(res.status).toBe("ok");
-          expect(res.delivered).toBe(true);
-          expect(deps.sendMessageDiscord).toHaveBeenCalledTimes(1);
-          expect(deps.sendMessageDiscord).toHaveBeenCalledWith(
-            testCase.expectedTo,
-            "hello from cron",
-            expect.objectContaining({
-              cfg: expect.objectContaining({ channels: runtimeCfg.channels }),
-            }),
-          );
-        });
-      });
-
-      it("collapses Discord text-only announce delivery to the final assistant text", async () => {
-        await expectCoreChannelAnnounceDelivery({
-          testCase,
-          payloads: [{ text: "Working on it..." }, { text: "Final weather summary" }],
-          meta: {
-            meta: {
-              durationMs: 5,
-              agentMeta: { sessionId: "s", provider: "p", model: "m" },
-              finalAssistantVisibleText: "Final weather summary",
-            },
-          },
-          assertSend: (sendFn, cfg) => {
-            expect(sendFn).toHaveBeenCalledTimes(1);
-            expectCoreChannelSendCall({
-              cfg,
-              expectedText: "Final weather summary",
-              expectedTo: testCase.expectedTo,
-              sendFn,
-              sentAt: 0,
-            });
-          },
-        });
-      });
-      continue;
-    }
-
-    it(`preserves multi-payload text-only announce delivery for ${testCase.name} even when final assistant text exists`, async () => {
-      await expectCoreChannelAnnounceDelivery({
-        testCase,
-        payloads: [{ text: "Working on it..." }, { text: "Final weather summary" }],
-        meta: {
-          meta: {
-            durationMs: 5,
-            agentMeta: { sessionId: "s", provider: "p", model: "m" },
-            finalAssistantVisibleText: "Final weather summary",
-          },
-        },
-        assertSend: (sendFn, cfg) => {
-          expect(sendFn).toHaveBeenCalledTimes(2);
-          expectCoreChannelSendCall({
-            cfg,
-            expectedText: "Working on it...",
-            expectedTo: testCase.expectedTo,
-            sendFn,
-            sentAt: 0,
-          });
-          expectCoreChannelSendCall({
-            cfg,
-            expectedText: "Final weather summary",
-            expectedTo: testCase.expectedTo,
-            sendFn,
-            sentAt: 1,
-          });
-        },
-      });
-    });
-  }
-});
-
-describe("runCronIsolatedAgentTurn telegram forum-topic direct delivery", () => {
-  beforeEach(() => {
-    setupIsolatedAgentTurnMocks();
-  });
-
-  it("routes forum-topic telegram targets through the correct delivery path", async () => {
-    await expectTelegramAnnounceDelivery({
-      to: "123:topic:42",
-      payloads: [{ text: "forum message" }],
-      expected: {
-        chatId: "123",
-        text: "forum message",
-        messageThreadId: 42,
-      },
-    });
-  });
-
-  it("preserves explicit supergroup topic targets for cron announce delivery", async () => {
-    await expectTelegramAnnounceDelivery({
-      to: "-1003774691294:topic:47",
-      payloads: [{ text: "topic 47 completion" }],
-      expected: {
-        chatId: "-1003774691294",
-        text: "topic 47 completion",
-        messageThreadId: 47,
-      },
-    });
-  });
-
-  it("does not report delivered when telegram announce produces no platform result", async () => {
-    await withTempCronHome(async (home) => {
-      const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
-      const sendText = vi.fn(async () => ({ channel: "telegram", messageId: "" }));
-      setActivePluginRegistry(
-        createTestRegistry([
-          {
-            pluginId: "telegram",
-            plugin: createOutboundTestPlugin({
-              id: "telegram",
-              outbound: {
-                deliveryMode: "direct",
-                preferFinalAssistantVisibleText: true,
-                sendText,
-                resolveTarget: ({ to }) =>
-                  to?.trim()
-                    ? { ok: true, to: to.trim() }
-                    : { ok: false, error: new Error("target is required") },
-              },
-              messaging: {
-                parseExplicitTarget: ({ raw }) => ({ to: raw.trim() }),
-              },
-            }),
-            source: "test",
-          },
-        ]),
-      );
-      const deps = createCliDeps();
-      mockAgentPayloads([{ text: "cron message with no platform receipt" }]);
-
-      const res = await runTelegramAnnounceTurn({
-        home,
-        storePath,
-        deps,
-        delivery: { mode: "announce", channel: "telegram", to: "123" },
-      });
-
-      expect(res.status).toBe("ok");
-      expect(res.delivered).toBe(false);
-      expect(res.deliveryAttempted).toBe(true);
-      expect(res.delivery).toMatchObject({
-        fallbackUsed: true,
-        delivered: false,
-      });
-      expect(sendText).toHaveBeenCalledTimes(1);
-      expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
-    });
-  });
-
-  it("delivers only the final assistant-visible text to forum-topic telegram targets", async () => {
-    await expectTelegramAnnounceDelivery({
-      to: "123:topic:42",
-      payloads: [
-        { text: "section 1" },
-        { text: "temporary error", isError: true },
-        { text: "section 2" },
-      ],
-      meta: { meta: makeRunMeta("section 1\nsection 2") },
-      expected: {
-        chatId: "123",
-        text: "section 1\nsection 2",
-        messageThreadId: 42,
-      },
-    });
-  });
-
-  it("routes plain telegram targets through the correct delivery path", async () => {
-    await expectTelegramAnnounceDelivery({
-      to: "123",
-      payloads: [{ text: "plain message" }],
-      expected: {
-        chatId: "123",
-        text: "plain message",
-      },
-    });
-  });
-
-  it("delivers only the final assistant-visible text to plain telegram targets", async () => {
-    await expectTelegramAnnounceDelivery({
-      to: "123",
-      payloads: [{ text: "Working on it..." }, { text: "Final weather summary" }],
-      meta: { meta: makeRunMeta("Final weather summary") },
-      expected: {
-        chatId: "123",
-        text: "Final weather summary",
-      },
-    });
+    expect(result).toMatchObject({ status: "ok", delivered: true });
+    expect(dispatchCronDeliveryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg: sourceCfg,
+        cfgWithAgentDefaults: expect.objectContaining({ channels: runtimeCfg.channels }),
+      }),
+    );
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The isolated cron core-channel delivery suite replayed target parsing, payload selection, outbound dispatch, channel preferences, and empty-receipt handling through 16 full agent turns. On a clean module cache, this one file took 86.19 seconds and about 2.13 GB peak RSS.

## Why This Change Was Made

Keep the one unique run-orchestration regression: an applicable active runtime snapshot must survive agent-default derivation and reach delivery with resolved channel config. Remove 15 cross-owner integration cases already enforced by the delivery-target, cron payload, delivery-dispatch, outbound-delivery, and channel-plugin suites, plus their now-unused Telegram test helpers.

## User Impact

No runtime behavior changes. CI gets a substantially shorter, lower-memory cron test lane without additional workers.

## Evidence

Same command, clean independent module caches, one worker:

```text
baseline:  86.19s wall, 2,126,408 KiB peak RSS, 16 tests
candidate: 24.55s wall,   881,472 KiB peak RSS,  1 focused test
speedup:   71.5%
```

Independent stability run: 24.78s wall (71.3% faster).

```bash
node scripts/run-vitest.mjs \
  src/cron/isolated-agent.direct-delivery-core-channels.test.ts \
  --maxWorkers=1 --reporter=verbose
```

Retained owner validation:

```text
cron orchestration + payload/heartbeat owners: 42 passed
cron dispatch/target owner filters:             6 passed
outbound empty-receipt owner:                   1 passed
Discord/Slack preference owners:                2 passed
helper consumer (delivery awareness):           3 passed
```

Also passed:

```text
pnpm exec oxfmt --check <changed test files>
pnpm exec oxlint <changed test files>
CI=1 OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs
```
