### PR TITLE
improve: speed up Claude CLI doctor tests

### DIFF
--- a/src/commands/doctor-claude-cli.test.ts
+++ b/src/commands/doctor-claude-cli.test.ts
@@ -5,9 +5,25 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CLAUDE_CLI_PROFILE_ID } from "../agents/auth-profiles/constants.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
-import { testing as cliBackendsTesting } from "../agents/cli-backends.test-support.js";
 import { resolveClaudeCliProjectDirForWorkspace } from "../agents/command/claude-cli-project-dir.js";
 import { noteClaudeCliHealth } from "./doctor-claude-cli.js";
+
+const resolveCliBackendConfigMock = vi.hoisted(() => vi.fn());
+const resolveModelAgentRuntimeMetadataMock = vi.hoisted(() =>
+  vi.fn((_params: { agentId: string }) => ({ id: "openclaw", source: "implicit" })),
+);
+
+vi.mock("../agents/cli-backends.js", () => ({
+  resolveCliBackendConfig: resolveCliBackendConfigMock,
+}));
+
+vi.mock("../agents/agent-runtime-metadata.js", () => ({
+  resolveModelAgentRuntimeMetadata: resolveModelAgentRuntimeMetadataMock,
+}));
+
+vi.mock("../agents/auth-profiles/store.js", () => ({
+  ensureAuthProfileStore: vi.fn(),
+}));
 
 function createStore(profiles: AuthProfileStore["profiles"] = {}): AuthProfileStore {
   return {
@@ -55,36 +71,21 @@ function noteTitle(noteFn: ReturnType<typeof vi.fn>): string {
   return value;
 }
 
-describe("resolveClaudeCliProjectDirForWorkspace", () => {
-  it("matches Claude's sanitized workspace project dir shape", () => {
-    expect(
-      resolveClaudeCliProjectDirForWorkspace({
-        workspaceDir: "/Users/vincentkoc/GIT/_Perso/openclaw/.openclaw/workspace",
-        homeDir: "/Users/vincentkoc",
-      }),
-    ).toBe(
-      "/Users/vincentkoc/.claude/projects/-Users-vincentkoc-GIT--Perso-openclaw--openclaw-workspace",
-    );
-  });
-});
-
 describe("noteClaudeCliHealth", () => {
   afterEach(() => {
-    cliBackendsTesting.resetDepsForTest();
+    resolveCliBackendConfigMock.mockReset();
+    resolveModelAgentRuntimeMetadataMock
+      .mockReset()
+      .mockReturnValue({ id: "openclaw", source: "implicit" });
     vi.restoreAllMocks();
   });
 
-  it("probes the executable registered by the owning backend plugin", async () => {
+  it("probes the executable resolved by the owning backend", async () => {
     await withTempHome(({ homeDir, workspaceDir }) => {
-      cliBackendsTesting.setDepsForTest({
-        resolvePluginSetupCliBackend: () => undefined,
-        resolveRuntimeCliBackends: () => [
-          {
-            id: "claude-cli",
-            pluginId: "custom-anthropic",
-            config: { command: "/opt/custom/bin/claude" },
-          },
-        ],
+      resolveCliBackendConfigMock.mockReturnValue({
+        id: "claude-cli",
+        pluginId: "custom-anthropic",
+        config: { command: "/opt/custom/bin/claude" },
       });
       const resolveCommandPath = vi.fn(() => undefined);
 
@@ -164,21 +165,16 @@ describe("noteClaudeCliHealth", () => {
 
   it("advises on a version below the first-known floor without declaring it unsupported", async () => {
     await withTempHome(({ homeDir, workspaceDir }) => {
-      cliBackendsTesting.setDepsForTest({
-        resolvePluginSetupCliBackend: () => undefined,
-        resolveRuntimeCliBackends: () => [
-          {
-            id: "claude-cli",
-            pluginId: "anthropic",
-            config: { command: "claude" },
-            liveSessionRequirement: {
-              capability: "msg_lifecycle_v1",
-              minimumVersion: "2.1.206",
-              versionArgs: ["--version"],
-              updateCommand: "claude update",
-            },
-          },
-        ],
+      resolveCliBackendConfigMock.mockReturnValue({
+        id: "claude-cli",
+        pluginId: "anthropic",
+        config: { command: "claude" },
+        liveSessionRequirement: {
+          capability: "msg_lifecycle_v1",
+          minimumVersion: "2.1.206",
+          versionArgs: ["--version"],
+          updateCommand: "claude update",
+        },
       });
       const noteFn = vi.fn();
 
@@ -208,6 +204,10 @@ describe("noteClaudeCliHealth", () => {
 
   it("stays quiet for a healthy non-default Claude CLI runtime agent", async () => {
     await withTempHome(({ homeDir, workspaceDir }) => {
+      resolveModelAgentRuntimeMetadataMock.mockImplementation(({ agentId }) => ({
+        id: agentId === "xiaoao" ? "claude-cli" : "openclaw",
+        source: agentId === "xiaoao" ? "model" : "implicit",
+      }));
       const root = path.dirname(workspaceDir);
       const defaultWorkspace = path.join(root, "workspace-coder");
       const claudeWorkspace = path.join(root, "workspace-xiaoao");
@@ -361,6 +361,10 @@ describe("noteClaudeCliHealth", () => {
 
   it("lists Claude CLI agents only when a problem is reported", async () => {
     await withTempHome(({ homeDir, workspaceDir }) => {
+      resolveModelAgentRuntimeMetadataMock.mockReturnValue({
+        id: "claude-cli",
+        source: "model",
+      });
       const root = path.dirname(workspaceDir);
       const alphaWorkspace = path.join(root, "workspace-alpha");
       const zetaWorkspace = path.join(root, "workspace-zeta");

--- a/src/commands/doctor-claude-cli.ts
+++ b/src/commands/doctor-claude-cli.ts
@@ -11,7 +11,7 @@ import {
   listAgentIds,
   resolveAgentWorkspaceDir,
   tryResolveDefaultAgentId,
-} from "../agents/agent-scope.js";
+} from "../agents/agent-scope-config.js";
 import { CLAUDE_CLI_PROFILE_ID } from "../agents/auth-profiles/constants.js";
 import { resolveAuthStorePathForDisplay } from "../agents/auth-profiles/paths.js";
 import { ensureAuthProfileStore } from "../agents/auth-profiles/store.js";


### PR DESCRIPTION
## What Problem This Solves

The Claude CLI doctor test loaded the complete CLI backend, model-selection, auth-profile store, and plugin/provider runtime graphs even though the suite only verifies doctor formatting and orchestration. On a clean module cache, that made 10 small tests take 25.73s wall time and about 482MB peak RSS.

## Why This Change Was Made

Mock the three owner boundaries exercised as inputs by the doctor suite, keep backend/runtime policy behavior in their existing owner tests, and import agent roster/workspace helpers from their narrow source module instead of the broad `agent-scope` barrel. Remove one duplicate project-directory sanitizer assertion already covered with stronger canonical-path and symlink cases by `attempt-execution.test.ts`.

No CI worker, job, or shard count changes. Doctor runtime behavior is unchanged.

## User Impact

No user-visible behavior changes. The focused CI test starts faster and uses less memory, while the same doctor health outcomes remain covered.

## Evidence

Same command, clean independent module-cache paths, one worker:

```bash
/usr/bin/time -v env \
  PATH=/tmp/node-v24.15.0-linux-x64/bin:$PATH \
  OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=<fresh-path> \
  node scripts/run-vitest.mjs \
  src/commands/doctor-claude-cli.test.ts \
  --maxWorkers=1 --reporter=verbose
```

- Baseline: **25.73s** wall, **481,888 KB** peak RSS, Vitest **18.33s**, 10 tests.
- Final candidate: **14.21s** wall, **295,732 KB** peak RSS, Vitest **6.02s**, 9 tests.
- Independent candidate run before the duplicate assertion deletion: **12.91s** wall, **299,652 KB** peak RSS.
- Conservative final reduction: **44.8% wall time**, **38.6% peak RSS**.

Coverage retained:

- 9 focused doctor health behavior tests pass.
- `src/agents/model-runtime-policy.test.ts`: 21 passed.
- `src/agents/agent-scope-config.test.ts`: 7 passed.
- `src/agents/cli-backends.test.ts`: 12 passed.
- Canonical Claude project-directory owner assertion in `src/agents/command/attempt-execution.test.ts`: passed.
- Full changed-file gate passed after fixing the mock signature caught by core test typecheck.
- oxfmt, oxlint, and `git diff --check` pass.
- Autoreview TruffleHog scan was clean; the Codex executable is unavailable in the orb, so manual review plus exact-head hosted CI are the review gates.
