### PR TITLE
fix(agents): detect sustained same-target write churn

### DIFF
--- a/src/agents/agent-tools.before-tool-call.diagnostics.ts
+++ b/src/agents/agent-tools.before-tool-call.diagnostics.ts
@@ -639,22 +639,14 @@ export async function reconcileLoopCallExecutionParams(args: {
       cwd: args.ctx.cwd ?? args.ctx.workspaceDir,
       warningThreshold: resolveToolLoopWarningThreshold(),
     });
-    if (churn.active) {
+    if (churn.active || churn.executionParamsChanged) {
+      // A trusted novel rewrite can clear before execution; unchanged duplicate
+      // preparation cannot, because its completed outcome owns any later clear.
       markDiagnosticArgumentChurnObservation({
         sessionKey: args.ctx.sessionKey,
         sessionId: args.ctx.sessionId,
         runId: args.ctx.runId,
-        active: true,
-      });
-    } else if (churn.executionParamsChanged) {
-      // A trusted rewrite to a novel execution variant is authoritative before
-      // the tool starts. Duplicate prepared/wrapped admission of unchanged
-      // params is not; its completed outcome owns any later clear.
-      markDiagnosticArgumentChurnObservation({
-        sessionKey: args.ctx.sessionKey,
-        sessionId: args.ctx.sessionId,
-        runId: args.ctx.runId,
-        active: false,
+        active: churn.active,
       });
     }
   } catch (err) {

--- a/src/agents/agent-tools.before-tool-call.diagnostics.ts
+++ b/src/agents/agent-tools.before-tool-call.diagnostics.ts
@@ -639,12 +639,24 @@ export async function reconcileLoopCallExecutionParams(args: {
       cwd: args.ctx.cwd ?? args.ctx.workspaceDir,
       warningThreshold: resolveToolLoopWarningThreshold(),
     });
-    markDiagnosticArgumentChurnObservation({
-      sessionKey: args.ctx.sessionKey,
-      sessionId: args.ctx.sessionId,
-      runId: args.ctx.runId,
-      active: churn.active,
-    });
+    if (churn.active) {
+      markDiagnosticArgumentChurnObservation({
+        sessionKey: args.ctx.sessionKey,
+        sessionId: args.ctx.sessionId,
+        runId: args.ctx.runId,
+        active: true,
+      });
+    } else if (churn.executionParamsChanged) {
+      // A trusted rewrite to a novel execution variant is authoritative before
+      // the tool starts. Duplicate prepared/wrapped admission of unchanged
+      // params is not; its completed outcome owns any later clear.
+      markDiagnosticArgumentChurnObservation({
+        sessionKey: args.ctx.sessionKey,
+        sessionId: args.ctx.sessionId,
+        runId: args.ctx.runId,
+        active: false,
+      });
+    }
   } catch (err) {
     log.warn(
       `tool loop execution-param reconciliation failed: tool=${args.toolName} error=${String(err)}`,

--- a/src/agents/agent-tools.before-tool-call.diagnostics.ts
+++ b/src/agents/agent-tools.before-tool-call.diagnostics.ts
@@ -603,6 +603,7 @@ export async function reconcileLoopCallExecutionParams(args: {
       toolParams: args.toolParams,
       toolCallId: args.toolCallId,
       runId: args.ctx.runId,
+      cwd: args.ctx.cwd ?? args.ctx.workspaceDir,
       warningThreshold: resolveToolLoopWarningThreshold(),
     });
     markDiagnosticArgumentChurnObservation({
@@ -635,7 +636,7 @@ export async function recordLoopOutcome(args: {
   let recordedOutcome: ToolOutcomeObservation | undefined;
   try {
     const {
-      getArgumentChurnNoProgressStreak,
+      getToolArgumentChurnStreak,
       getDiagnosticSessionState,
       markDiagnosticArgumentChurnObservation,
       recordToolCallOutcome,
@@ -652,13 +653,15 @@ export async function recordLoopOutcome(args: {
       error: args.error,
       config: args.ctx.loopDetection,
       ...(args.ctx.runId && { runId: args.ctx.runId }),
+      cwd: args.ctx.cwd ?? args.ctx.workspaceDir,
     });
     const churnContinues =
       record !== undefined &&
-      getArgumentChurnNoProgressStreak(
-        (sessionState.toolCallHistory ?? []).filter((call) => call.runId === record.runId),
-        record.toolName,
-        record.argsHash,
+      getToolArgumentChurnStreak(
+        (sessionState.toolCallHistory ?? []).filter(
+          (call) => call.runId === record.runId && call !== record,
+        ),
+        record,
       ).count > 0;
     markDiagnosticArgumentChurnObservation({
       sessionKey: args.ctx.sessionKey,

--- a/src/agents/agent-tools.before-tool-call.diagnostics.ts
+++ b/src/agents/agent-tools.before-tool-call.diagnostics.ts
@@ -560,11 +560,7 @@ export function summarizeToolParams(params: unknown): DiagnosticToolParamsSummar
   return { kind: "other" };
 }
 
-export function shouldEmitLoopWarning(
-  state: SessionState,
-  warningKey: string,
-  count: number,
-): boolean {
+function shouldEmitLoopWarning(state: SessionState, warningKey: string, count: number): boolean {
   if (!state.toolLoopWarningBuckets) {
     state.toolLoopWarningBuckets = new Map();
   }
@@ -695,39 +691,43 @@ export async function recordLoopOutcome(args: {
       ...(args.ctx.runId && { runId: args.ctx.runId }),
       cwd: args.ctx.cwd ?? args.ctx.workspaceDir,
     });
-    const scopedHistory = record
-      ? (sessionState.toolCallHistory ?? []).filter((call) => call.runId === record.runId)
-      : [];
-    const churn = record
-      ? getToolArgumentChurnStreak(
-          record.outcomeKind === "write-mutation"
-            ? scopedHistory.filter((call) => call !== record)
-            : scopedHistory,
-          record,
-        )
-      : { count: 0, variantCount: 0 };
-    const warningThreshold = resolveToolLoopWarningThreshold();
-    const writeMutationAtWarning =
-      churn.kind === "write_mutation" && churn.count >= warningThreshold;
-    const churnContinues =
-      churn.count > 0 && (churn.kind !== "write_mutation" || writeMutationAtWarning);
-    if (record && writeMutationAtWarning) {
-      const warning = buildArgumentChurnWarning(record.toolName, churn);
-      emitLoopWarning({
-        ctx: args.ctx,
-        sessionState,
-        toolName: record.toolName,
-        warning,
-        logToolLoopAction,
+    if (args.ctx.loopDetection?.enabled === true) {
+      const scopedHistory = record
+        ? (sessionState.toolCallHistory ?? []).filter((call) => call.runId === record.runId)
+        : [];
+      const churn = record
+        ? getToolArgumentChurnStreak(
+            record.outcomeKind === "write-mutation"
+              ? scopedHistory.filter((call) => call !== record)
+              : scopedHistory,
+            record,
+          )
+        : { count: 0, variantCount: 0 };
+      const warningThreshold = resolveToolLoopWarningThreshold();
+      const writeMutationAtWarning =
+        churn.kind === "write_mutation" && churn.count >= warningThreshold;
+      const churnContinues =
+        churn.count > 0 && (churn.kind !== "write_mutation" || writeMutationAtWarning);
+      if (record && writeMutationAtWarning) {
+        const warning = buildArgumentChurnWarning(record.toolName, churn);
+        emitLoopWarning({
+          ctx: args.ctx,
+          sessionState,
+          toolName: record.toolName,
+          warning,
+          logToolLoopAction,
+        });
+      }
+      // Parallel batches first gain mutation-threshold evidence from completed
+      // outcomes; stable no-progress reconciliation still requires an existing lease.
+      markDiagnosticArgumentChurnObservation({
+        sessionKey: args.ctx.sessionKey,
+        sessionId: args.ctx.sessionId,
+        runId: args.ctx.runId,
+        active: churnContinues,
+        existingOnly: !writeMutationAtWarning,
       });
     }
-    markDiagnosticArgumentChurnObservation({
-      sessionKey: args.ctx.sessionKey,
-      sessionId: args.ctx.sessionId,
-      runId: args.ctx.runId,
-      active: churnContinues,
-      existingOnly: true,
-    });
     if (record?.resultHash && args.ctx.onToolOutcome) {
       recordedOutcome = {
         toolName: record.toolName,

--- a/src/agents/agent-tools.before-tool-call.diagnostics.ts
+++ b/src/agents/agent-tools.before-tool-call.diagnostics.ts
@@ -12,6 +12,7 @@ import {
   emitTrustedSkillUsedDiagnosticEvent,
   emitTrustedSecurityEvent,
   type DiagnosticEventPrivateData,
+  type DiagnosticToolLoopEvent,
   type DiagnosticToolParamsSummary,
   type DiagnosticToolSource,
   type DiagnosticToolTerminalReason,
@@ -577,6 +578,38 @@ export function shouldEmitLoopWarning(
   return true;
 }
 
+type ToolLoopWarning = Pick<
+  DiagnosticToolLoopEvent,
+  "detector" | "count" | "message" | "pairedToolName"
+> & { warningKey?: string };
+
+export function emitLoopWarning(args: {
+  ctx: HookContext;
+  sessionState: SessionState;
+  toolName: string;
+  warning: ToolLoopWarning;
+  logToolLoopAction: typeof import("../logging/diagnostic.js").logToolLoopAction;
+}): boolean {
+  const baseWarningKey = args.warning.warningKey ?? `${args.warning.detector}:${args.toolName}`;
+  const warningKey = args.ctx.runId ? `${args.ctx.runId}:${baseWarningKey}` : baseWarningKey;
+  if (!shouldEmitLoopWarning(args.sessionState, warningKey, args.warning.count)) {
+    return false;
+  }
+  log.warn(`Loop warning for ${args.toolName}: ${args.warning.message}`);
+  args.logToolLoopAction({
+    sessionKey: args.ctx.sessionKey,
+    sessionId: args.ctx.sessionId,
+    toolName: args.toolName,
+    level: "warning",
+    action: "warn",
+    detector: args.warning.detector,
+    count: args.warning.count,
+    message: args.warning.message,
+    ...(args.warning.pairedToolName ? { pairedToolName: args.warning.pairedToolName } : {}),
+  });
+  return true;
+}
+
 /** Reconcile loop liveness with the final post-policy arguments before execution. */
 export async function reconcileLoopCallExecutionParams(args: {
   ctx?: HookContext;
@@ -636,10 +669,13 @@ export async function recordLoopOutcome(args: {
   let recordedOutcome: ToolOutcomeObservation | undefined;
   try {
     const {
+      buildArgumentChurnWarning,
       getToolArgumentChurnStreak,
       getDiagnosticSessionState,
+      logToolLoopAction,
       markDiagnosticArgumentChurnObservation,
       recordToolCallOutcome,
+      resolveToolLoopWarningThreshold,
     } = await loadBeforeToolCallRuntime();
     const sessionState = getDiagnosticSessionState({
       sessionKey: args.ctx.sessionKey,
@@ -655,14 +691,29 @@ export async function recordLoopOutcome(args: {
       ...(args.ctx.runId && { runId: args.ctx.runId }),
       cwd: args.ctx.cwd ?? args.ctx.workspaceDir,
     });
+    const churn = record
+      ? getToolArgumentChurnStreak(
+          (sessionState.toolCallHistory ?? []).filter(
+            (call) => call.runId === record.runId && call !== record,
+          ),
+          record,
+        )
+      : { count: 0, variantCount: 0 };
+    const warningThreshold = resolveToolLoopWarningThreshold();
+    const writeMutationAtWarning =
+      churn.kind === "write_mutation" && churn.count >= warningThreshold;
     const churnContinues =
-      record !== undefined &&
-      getToolArgumentChurnStreak(
-        (sessionState.toolCallHistory ?? []).filter(
-          (call) => call.runId === record.runId && call !== record,
-        ),
-        record,
-      ).count > 0;
+      churn.count > 0 && (churn.kind !== "write_mutation" || writeMutationAtWarning);
+    if (record && writeMutationAtWarning) {
+      const warning = buildArgumentChurnWarning(record.toolName, churn);
+      emitLoopWarning({
+        ctx: args.ctx,
+        sessionState,
+        toolName: record.toolName,
+        warning,
+        logToolLoopAction,
+      });
+    }
     markDiagnosticArgumentChurnObservation({
       sessionKey: args.ctx.sessionKey,
       sessionId: args.ctx.sessionId,

--- a/src/agents/agent-tools.before-tool-call.diagnostics.ts
+++ b/src/agents/agent-tools.before-tool-call.diagnostics.ts
@@ -691,11 +691,14 @@ export async function recordLoopOutcome(args: {
       ...(args.ctx.runId && { runId: args.ctx.runId }),
       cwd: args.ctx.cwd ?? args.ctx.workspaceDir,
     });
+    const scopedHistory = record
+      ? (sessionState.toolCallHistory ?? []).filter((call) => call.runId === record.runId)
+      : [];
     const churn = record
       ? getToolArgumentChurnStreak(
-          (sessionState.toolCallHistory ?? []).filter(
-            (call) => call.runId === record.runId && call !== record,
-          ),
+          record.outcomeKind === "write-mutation"
+            ? scopedHistory.filter((call) => call !== record)
+            : scopedHistory,
           record,
         )
       : { count: 0, variantCount: 0 };

--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -48,6 +48,7 @@ import {
   runBeforeToolCallHook,
   wrapToolWithBeforeToolCallHook,
 } from "./agent-tools.before-tool-call.js";
+import { beforeToolCallRuntime } from "./agent-tools.before-tool-call.runtime.js";
 import { createOpenClawCodingTools } from "./agent-tools.js";
 import { createReadTool, createWriteTool } from "./sessions/index.js";
 import { TOOL_LOOP_WARNING_THRESHOLD } from "./tool-loop-thresholds.js";
@@ -539,6 +540,41 @@ describe("before_tool_call loop detection behavior", () => {
     });
   });
 
+  it("does not activate changed-write liveness below the warning threshold", async () => {
+    const sessionId = "same-target-write-below-threshold-session";
+    const runId = "same-target-write-below-threshold-run";
+    const execute = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "write complete" }],
+      details: { changed: true },
+    });
+    const loopDetectionContext = {
+      ...enabledLoopDetectionContext,
+      cwd: "/tmp",
+      sessionId,
+      runId,
+    };
+    markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey: "main", runId });
+    const writeTool = createWrappedTool("write", execute, loopDetectionContext);
+    const markChurn = vi.spyOn(beforeToolCallRuntime, "markDiagnosticArgumentChurnObservation");
+
+    try {
+      for (let index = 0; index < TOOL_LOOP_WARNING_THRESHOLD; index += 1) {
+        await expectUnblockedToolExecution(writeTool, `same-target-write-below-${index}`, {
+          path: "draft.md",
+          content: `synthetic revision ${index}`,
+        });
+      }
+
+      expect(
+        markChurn.mock.calls
+          .map(([observation]) => observation)
+          .filter((observation) => observation.existingOnly),
+      ).not.toContainEqual(expect.objectContaining({ active: true }));
+    } finally {
+      markChurn.mockRestore();
+    }
+  });
+
   it("warns on same-target changed-write churn while preserving execution and read escape", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-same-target-churn-"));
     const sessionId = "same-target-write-churn-session";
@@ -572,6 +608,7 @@ describe("before_tool_call loop detection behavior", () => {
           path: "notes/../draft.md",
           content: "synthetic next revision",
         });
+        expect(emitted).toHaveLength(1);
         expect(emitted.at(-1)).toMatchObject({
           type: "tool.loop",
           level: "warning",

--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -645,6 +645,37 @@ describe("before_tool_call loop detection behavior", () => {
     }
   });
 
+  it("activates stable no-progress churn on the sixth completed outcome", async () => {
+    const sessionId = "stable-churn-completion-session";
+    const runId = "stable-churn-completion-run";
+    const markChurn = vi.spyOn(beforeToolCallRuntime, "markDiagnosticArgumentChurnObservation");
+    const tool = createWrappedTool(
+      "write",
+      vi.fn().mockResolvedValue(createStableNoProgressWriteResult()),
+      { ...enabledLoopDetectionContext, sessionId, runId },
+    );
+    markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey: "main", runId });
+
+    try {
+      for (let index = 0; index < 6; index += 1) {
+        await expectUnblockedToolExecution(tool, `stable-churn-completion-${index}`, {
+          path: index % 2 === 0 ? "/tmp/a.md" : "/tmp/b.md",
+          content: "same content",
+        });
+      }
+      const outcomeObservations = markChurn.mock.calls
+        .map(([observation]) => observation)
+        .filter((observation) => observation.existingOnly === true);
+      expect(outcomeObservations).toHaveLength(6);
+      expect(outcomeObservations.slice(0, 5).every((observation) => !observation.active)).toBe(
+        true,
+      );
+      expect(outcomeObservations.at(-1)?.active).toBe(true);
+    } finally {
+      markChurn.mockRestore();
+    }
+  });
+
   it("warns on non-strict same-tool argument churn while preserving tool execution", async () => {
     const execute = vi.fn().mockImplementation(async (toolCallId: string, _params: unknown) => {
       const progressed = toolCallId === "write-churn-progress";

--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -49,7 +49,8 @@ import {
   wrapToolWithBeforeToolCallHook,
 } from "./agent-tools.before-tool-call.js";
 import { createOpenClawCodingTools } from "./agent-tools.js";
-import { createWriteTool } from "./sessions/index.js";
+import { createReadTool, createWriteTool } from "./sessions/index.js";
+import { TOOL_LOOP_WARNING_THRESHOLD } from "./tool-loop-thresholds.js";
 import type { AnyAgentTool } from "./tools/common.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
@@ -536,6 +537,75 @@ describe("before_tool_call loop detection behavior", () => {
         toolName: "exec",
       });
     });
+  });
+
+  it("warns on same-target changed-write churn while preserving execution and read escape", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-same-target-churn-"));
+    const sessionId = "same-target-write-churn-session";
+    const runId = "same-target-write-churn-run";
+    const loopDetectionContext = {
+      ...enabledLoopDetectionContext,
+      cwd: tmpDir,
+      sessionId,
+      runId,
+    };
+    markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey: "main", runId });
+    const writeTool = wrapToolWithBeforeToolCallHook(
+      createWriteTool(tmpDir) as unknown as AnyAgentTool,
+      loopDetectionContext,
+    );
+    const readTool = wrapToolWithBeforeToolCallHook(
+      createReadTool(tmpDir) as unknown as AnyAgentTool,
+      loopDetectionContext,
+    );
+
+    try {
+      for (let index = 0; index < TOOL_LOOP_WARNING_THRESHOLD; index += 1) {
+        await expectUnblockedToolExecution(writeTool, `same-target-write-${index}`, {
+          path: "draft.md",
+          content: `synthetic revision ${index}`,
+        });
+      }
+
+      await withToolLoopEvents(async (emitted) => {
+        await expectUnblockedToolExecution(writeTool, "same-target-write-warning", {
+          path: "notes/../draft.md",
+          content: "synthetic next revision",
+        });
+        expect(emitted.at(-1)).toMatchObject({
+          type: "tool.loop",
+          level: "warning",
+          action: "warn",
+          detector: "argument_churn",
+          toolName: "write",
+          count: TOOL_LOOP_WARNING_THRESHOLD,
+        });
+      });
+      expect(getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey: "main" })).toMatchObject(
+        {
+          lastProgressReason: "tool_loop:argument_churn",
+        },
+      );
+      await expect(fs.readFile(path.join(tmpDir, "draft.md"), "utf8")).resolves.toBe(
+        "synthetic next revision",
+      );
+
+      await expectUnblockedToolExecution(readTool, "same-target-write-readback", {
+        path: "draft.md",
+      });
+      await withToolLoopEvents(async (emitted) => {
+        await expectUnblockedToolExecution(writeTool, "same-target-write-after-read", {
+          path: "draft.md",
+          content: "verified revision",
+        });
+        expect(emitted).toHaveLength(0);
+      });
+      await expect(fs.readFile(path.join(tmpDir, "draft.md"), "utf8")).resolves.toBe(
+        "verified revision",
+      );
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it("warns on non-strict same-tool argument churn while preserving tool execution", async () => {

--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -422,46 +422,49 @@ describe("before_tool_call loop detection behavior", () => {
     }
   });
 
-  it("does not activate reconciled churn when loop detection is unconfigured", async () => {
-    const sessionId = "write-churn-unconfigured-session";
-    const sessionKey = "main";
-    const runId = "write-churn-unconfigured-run";
-    const progressReasonsDuringExecution: Array<string | undefined> = [];
-    const execute = vi.fn().mockImplementation(async (_toolCallId: string, params: unknown) => {
-      const targetPath =
-        typeof params === "object" && params !== null && "path" in params
-          ? String(params.path)
-          : "unknown";
-      progressReasonsDuringExecution.push(
-        getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey }).lastProgressReason,
-      );
-      return {
-        content: [{ type: "text", text: `wrote ${targetPath}` }],
-        details: { ok: true, path: targetPath },
-      };
-    });
-    markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey, runId });
-    const tool = createWrappedTool("write", execute, {
-      agentId: "main",
-      sessionId,
-      sessionKey,
-      runId,
-    });
-    const paths = ["/tmp/a.md", "/tmp/b.md", "/tmp/a.md", "/tmp/a.md", "/tmp/b.md"];
-
-    for (let index = 0; index < GLOBAL_CIRCUIT_BREAKER_THRESHOLD; index += 1) {
-      await expectUnblockedToolExecution(tool, `write-churn-unconfigured-${index}`, {
-        path: paths[index % paths.length] ?? "/tmp/a.md",
-        content: "same content",
+  it.each([
+    { label: "unconfigured", loopDetection: undefined },
+    { label: "disabled", loopDetection: { enabled: false } },
+  ])(
+    "does not warn or activate changed-write churn when loop detection is $label",
+    async (testCase) => {
+      const sessionId = `write-churn-${testCase.label}-session`;
+      const sessionKey = "main";
+      const runId = `write-churn-${testCase.label}-run`;
+      const execute = vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: "write complete" }],
+        details: { changed: true },
       });
-    }
-    await expectUnblockedToolExecution(tool, "write-churn-unconfigured-next", {
-      path: "/tmp/a.md",
-      content: "same content",
-    });
+      markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey, runId });
+      const tool = createWrappedTool("write", execute, {
+        agentId: "main",
+        cwd: "/tmp",
+        sessionId,
+        sessionKey,
+        runId,
+        ...(testCase.loopDetection ? { loopDetection: testCase.loopDetection } : {}),
+      });
+      const markChurn = vi.spyOn(beforeToolCallRuntime, "markDiagnosticArgumentChurnObservation");
 
-    expect(progressReasonsDuringExecution.at(-1)).not.toBe("tool_loop:argument_churn");
-  });
+      try {
+        await withToolLoopEvents(async (emitted) => {
+          for (let index = 0; index <= TOOL_LOOP_WARNING_THRESHOLD; index += 1) {
+            await expectUnblockedToolExecution(tool, `write-churn-${testCase.label}-${index}`, {
+              path: "draft.md",
+              content: `synthetic revision ${index}`,
+            });
+          }
+          expect(emitted).toHaveLength(0);
+        });
+        expect(markChurn).not.toHaveBeenCalled();
+        expect(
+          getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey }).lastProgressReason,
+        ).not.toBe("tool_loop:argument_churn");
+      } finally {
+        markChurn.mockRestore();
+      }
+    },
+  );
 
   it("does not block known poll loops when output progresses", async () => {
     const execute = vi.fn().mockImplementation(async (toolCallId: string) => {

--- a/src/agents/agent-tools.before-tool-call.runtime.ts
+++ b/src/agents/agent-tools.before-tool-call.runtime.ts
@@ -6,7 +6,7 @@ import { markDiagnosticArgumentChurnObservation } from "../logging/diagnostic-ru
  */
 import { getDiagnosticSessionState } from "../logging/diagnostic-session-state.js";
 import { logToolLoopAction } from "../logging/diagnostic.js";
-import { getArgumentChurnNoProgressStreak } from "./tool-loop-argument-churn.js";
+import { getToolArgumentChurnStreak } from "./tool-loop-argument-churn.js";
 import { reconcileToolCallExecutionParams } from "./tool-loop-call-reconciliation.js";
 import {
   detectToolCallLoop,
@@ -17,7 +17,7 @@ import { resolveToolLoopWarningThreshold } from "./tool-loop-thresholds.js";
 
 /** Runtime seam for before_tool_call diagnostics and loop detection. */
 export const beforeToolCallRuntime = {
-  getArgumentChurnNoProgressStreak,
+  getToolArgumentChurnStreak,
   markDiagnosticArgumentChurnObservation,
   getDiagnosticSessionState,
   logToolLoopAction,

--- a/src/agents/agent-tools.before-tool-call.runtime.ts
+++ b/src/agents/agent-tools.before-tool-call.runtime.ts
@@ -6,7 +6,10 @@ import { markDiagnosticArgumentChurnObservation } from "../logging/diagnostic-ru
  */
 import { getDiagnosticSessionState } from "../logging/diagnostic-session-state.js";
 import { logToolLoopAction } from "../logging/diagnostic.js";
-import { getToolArgumentChurnStreak } from "./tool-loop-argument-churn.js";
+import {
+  buildArgumentChurnWarning,
+  getToolArgumentChurnStreak,
+} from "./tool-loop-argument-churn.js";
 import { reconcileToolCallExecutionParams } from "./tool-loop-call-reconciliation.js";
 import {
   detectToolCallLoop,
@@ -17,6 +20,7 @@ import { resolveToolLoopWarningThreshold } from "./tool-loop-thresholds.js";
 
 /** Runtime seam for before_tool_call diagnostics and loop detection. */
 export const beforeToolCallRuntime = {
+  buildArgumentChurnWarning,
   getToolArgumentChurnStreak,
   markDiagnosticArgumentChurnObservation,
   getDiagnosticSessionState,

--- a/src/agents/embedded-agent-runner/run/tool-loop-write-churn.integration.test.ts
+++ b/src/agents/embedded-agent-runner/run/tool-loop-write-churn.integration.test.ts
@@ -10,6 +10,7 @@ import {
 import type { Model } from "../../../llm/types.js";
 import { createAssistantMessageEventStream } from "../../../llm/utils/event-stream.js";
 import {
+  getDiagnosticSessionActivitySnapshot,
   markDiagnosticEmbeddedRunStarted,
   resetDiagnosticRunActivityForTest,
 } from "../../../logging/diagnostic-run-activity.js";
@@ -140,6 +141,84 @@ describe("embedded write-churn batch lifecycle", () => {
     } finally {
       stop();
       stopInternal();
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("starts churn liveness when a default-parallel batch reaches the mutation threshold", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-write-churn-parallel-"));
+    const sessionId = "write-churn-parallel-session";
+    const sessionKey = "agent:main:write-churn-parallel";
+    const runId = "write-churn-parallel-run";
+    const ctx = {
+      agentId: "main",
+      cwd: tmpDir,
+      sessionId,
+      sessionKey,
+      runId,
+      loopDetection: { enabled: true },
+    };
+    const writes = Array.from({ length: TOOL_LOOP_WARNING_THRESHOLD + 1 }, (_, index) => ({
+      type: "toolCall" as const,
+      id: `parallel-write-${index}`,
+      name: "write",
+      arguments: { path: "draft.md", content: `parallel revision ${index}` },
+    }));
+    let turn = 0;
+    const streamFn: StreamFn = (activeModel) => {
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const content = turn++ === 0 ? writes : [{ type: "text" as const, text: "done" }];
+        const stopReason = content.some((item) => item.type === "toolCall") ? "toolUse" : "stop";
+        stream.push({
+          type: "done",
+          reason: stopReason,
+          message: {
+            role: "assistant",
+            content,
+            api: activeModel.api,
+            provider: activeModel.provider,
+            model: activeModel.id,
+            usage,
+            stopReason,
+            timestamp: turn,
+          },
+        });
+        stream.end();
+      });
+      return stream;
+    };
+    const writeTool = wrapToolWithBeforeToolCallHook(
+      createWriteTool(tmpDir) as unknown as AnyAgentTool,
+      ctx,
+    );
+    const agent = new Agent({
+      initialState: { model, tools: [writeTool] },
+      streamFn,
+    });
+    setInternalBeforeToolBatch(agent, createToolLoopBatchAdmission(ctx));
+    markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey, runId });
+    const warnings: Array<{ detector?: string; count?: number }> = [];
+    const stop = onDiagnosticEvent((event) => {
+      if (event.type === "tool.loop" && event.level === "warning") {
+        warnings.push(event);
+      }
+    });
+
+    try {
+      await agent.prompt("rewrite the draft in one default-parallel batch");
+
+      expect(warnings).toEqual([
+        expect.objectContaining({
+          detector: "argument_churn",
+          count: TOOL_LOOP_WARNING_THRESHOLD,
+        }),
+      ]);
+      expect(getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey })).toMatchObject({
+        lastProgressReason: "tool_loop:argument_churn",
+      });
+    } finally {
+      stop();
       await fs.rm(tmpDir, { recursive: true, force: true });
     }
   });

--- a/src/agents/embedded-agent-runner/run/tool-loop-write-churn.integration.test.ts
+++ b/src/agents/embedded-agent-runner/run/tool-loop-write-churn.integration.test.ts
@@ -1,0 +1,146 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  onInternalDiagnosticEvent,
+  onDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+} from "../../../infra/diagnostic-events.js";
+import type { Model } from "../../../llm/types.js";
+import { createAssistantMessageEventStream } from "../../../llm/utils/event-stream.js";
+import {
+  markDiagnosticEmbeddedRunStarted,
+  resetDiagnosticRunActivityForTest,
+} from "../../../logging/diagnostic-run-activity.js";
+import { resetDiagnosticSessionStateForTest } from "../../../logging/diagnostic-session-state.js";
+import { wrapToolWithBeforeToolCallHook } from "../../agent-tools.before-tool-call.js";
+import { Agent, type StreamFn } from "../../runtime/index.js";
+import { setInternalBeforeToolBatch } from "../../runtime/internal-hooks.js";
+import { createWriteTool } from "../../sessions/index.js";
+import { TOOL_LOOP_WARNING_THRESHOLD } from "../../tool-loop-thresholds.js";
+import type { AnyAgentTool } from "../../tools/common.js";
+import { createToolLoopBatchAdmission } from "./tool-loop-recovery.js";
+
+const model: Model = {
+  id: "write-churn-test-model",
+  name: "Write Churn Test Model",
+  api: "openai-responses",
+  provider: "test",
+  baseUrl: "https://example.test",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 1_000,
+  maxTokens: 1_000,
+};
+
+const usage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+afterEach(() => {
+  resetDiagnosticEventsForTest();
+  resetDiagnosticRunActivityForTest();
+  resetDiagnosticSessionStateForTest();
+});
+
+describe("embedded write-churn batch lifecycle", () => {
+  it("emits the warning when a sequential batch reaches the mutation threshold", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-write-churn-batch-"));
+    const sessionId = "write-churn-batch-session";
+    const sessionKey = "agent:main:write-churn-batch";
+    const runId = "write-churn-batch-run";
+    const ctx = {
+      agentId: "main",
+      cwd: tmpDir,
+      sessionId,
+      sessionKey,
+      runId,
+      loopDetection: { enabled: true },
+    };
+    const writes = Array.from({ length: TOOL_LOOP_WARNING_THRESHOLD + 1 }, (_, index) => ({
+      type: "toolCall" as const,
+      id: `write-${index}`,
+      name: "write",
+      arguments: { path: "draft.md", content: `synthetic revision ${index}` },
+    }));
+    let turn = 0;
+    const streamFn: StreamFn = (activeModel) => {
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const content = turn++ === 0 ? writes : [{ type: "text" as const, text: "done" }];
+        const stopReason = content.some((item) => item.type === "toolCall") ? "toolUse" : "stop";
+        stream.push({
+          type: "done",
+          reason: stopReason,
+          message: {
+            role: "assistant",
+            content,
+            api: activeModel.api,
+            provider: activeModel.provider,
+            model: activeModel.id,
+            usage,
+            stopReason,
+            timestamp: turn,
+          },
+        });
+        stream.end();
+      });
+      return stream;
+    };
+    const writeTool = wrapToolWithBeforeToolCallHook(
+      createWriteTool(tmpDir) as unknown as AnyAgentTool,
+      ctx,
+    );
+    const agent = new Agent({
+      initialState: { model, tools: [writeTool] },
+      streamFn,
+      toolExecution: "sequential",
+    });
+    setInternalBeforeToolBatch(agent, createToolLoopBatchAdmission(ctx));
+    markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey, runId });
+    const warnings: Array<{ detector?: string; count?: number }> = [];
+    const thresholdTimeline: string[] = [];
+    const stop = onDiagnosticEvent((event) => {
+      if (event.type === "tool.loop" && event.level === "warning") {
+        warnings.push(event);
+      }
+    });
+    const stopInternal = onInternalDiagnosticEvent((event) => {
+      if (event.type === "tool.loop" && event.level === "warning") {
+        thresholdTimeline.push(`warning:${event.count}`);
+      }
+      if (event.type === "tool.execution.started" && event.toolCallId === "write-10") {
+        thresholdTimeline.push(`started:${event.toolCallId}`);
+      }
+    });
+
+    try {
+      await agent.prompt("rewrite the draft in one sequential batch");
+
+      expect(warnings).toEqual([
+        expect.objectContaining({
+          detector: "argument_churn",
+          count: TOOL_LOOP_WARNING_THRESHOLD,
+        }),
+      ]);
+      expect(thresholdTimeline).toEqual([
+        `warning:${TOOL_LOOP_WARNING_THRESHOLD}`,
+        "started:write-10",
+      ]);
+      await expect(fs.readFile(path.join(tmpDir, "draft.md"), "utf8")).resolves.toBe(
+        `synthetic revision ${TOOL_LOOP_WARNING_THRESHOLD}`,
+      );
+    } finally {
+      stop();
+      stopInternal();
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agents/tool-loop-admission.test.ts
+++ b/src/agents/tool-loop-admission.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { onDiagnosticEvent, resetDiagnosticEventsForTest } from "../infra/diagnostic-events.js";
 import {
+  getDiagnosticSessionActivitySnapshot,
+  markDiagnosticArgumentChurnObservation,
+  markDiagnosticEmbeddedRunStarted,
+  resetDiagnosticRunActivityForTest,
+} from "../logging/diagnostic-run-activity.js";
+import {
   getDiagnosticSessionState,
   resetDiagnosticSessionStateForTest,
 } from "../logging/diagnostic-session-state.js";
@@ -31,6 +37,7 @@ function call(id: string, name: string, args: Record<string, unknown>) {
 
 describe("whole-batch tool-loop admission", () => {
   beforeEach(() => {
+    resetDiagnosticRunActivityForTest();
     resetDiagnosticSessionStateForTest();
     resetDiagnosticEventsForTest();
     resetAdjustedParamsByToolCallIdForTests();
@@ -161,6 +168,34 @@ describe("whole-batch tool-loop admission", () => {
     });
     expect(state.toolCallHistory).toHaveLength(1);
     expect(consumeBatchAdmittedToolCall(admitted.toolCall.id, ctx.runId)).toBe(false);
+  });
+
+  it("leaves an established churn lease intact until an admitted escape call completes", async () => {
+    markDiagnosticEmbeddedRunStarted({
+      sessionId: ctx.sessionId,
+      sessionKey: ctx.sessionKey,
+      runId: ctx.runId,
+    });
+    markDiagnosticArgumentChurnObservation({
+      sessionId: ctx.sessionId,
+      sessionKey: ctx.sessionKey,
+      runId: ctx.runId,
+      active: true,
+      now: 1,
+    });
+
+    const admitted = call("pending-read-escape", "read", { path: "/tmp/a" });
+    const admission = await admitToolCallBatch([admitted], ctx);
+    admission.commitReadyCalls?.([{ toolCallId: admitted.toolCall.id, args: admitted.args }]);
+
+    expect(
+      getDiagnosticSessionActivitySnapshot({
+        sessionId: ctx.sessionId,
+        sessionKey: ctx.sessionKey,
+      }),
+    ).toMatchObject({
+      lastProgressReason: "tool_loop:argument_churn",
+    });
   });
 
   it("cleans an admitted marker when a run ends before the wrapped tool consumes it", async () => {

--- a/src/agents/tool-loop-admission.ts
+++ b/src/agents/tool-loop-admission.ts
@@ -242,12 +242,17 @@ export async function admitToolCallBatch(
         logToolLoopAction,
       });
     }
-    markDiagnosticArgumentChurnObservation({
-      sessionKey: ctx.sessionKey,
-      sessionId: ctx.sessionId,
-      runId: ctx.runId,
-      active: churn.active,
-    });
+    // Batch admission is advisory until the call completes. Do not let an
+    // inactive partial verdict clear a lease owned by an earlier completed
+    // mutation; recordLoopOutcome owns the authoritative clear.
+    if (churn.active) {
+      markDiagnosticArgumentChurnObservation({
+        sessionKey: ctx.sessionKey,
+        sessionId: ctx.sessionId,
+        runId: ctx.runId,
+        active: true,
+      });
+    }
     committedIds.add(readyCall.toolCallId);
   };
   return {

--- a/src/agents/tool-loop-admission.ts
+++ b/src/agents/tool-loop-admission.ts
@@ -6,8 +6,8 @@ import type {
 import type { SessionState } from "../logging/diagnostic-session-state.js";
 import {
   beforeToolCallLog as log,
+  emitLoopWarning,
   loadBeforeToolCallRuntime,
-  shouldEmitLoopWarning,
 } from "./agent-tools.before-tool-call.diagnostics.js";
 import {
   recordBatchAdmittedToolCall,
@@ -83,22 +83,7 @@ async function evaluateToolLoopCall(
       reason: result.message,
     };
   }
-  const baseWarningKey = result.warningKey ?? `${result.detector}:${toolName}`;
-  const warningKey = ctx.runId ? `${ctx.runId}:${baseWarningKey}` : baseWarningKey;
-  if (shouldEmitLoopWarning(sessionState, warningKey, result.count)) {
-    log.warn(`Loop warning for ${toolName}: ${result.message}`);
-    logToolLoopAction({
-      sessionKey: ctx.sessionKey,
-      sessionId: ctx.sessionId,
-      toolName,
-      level: "warning",
-      action: "warn",
-      detector: result.detector,
-      count: result.count,
-      message: result.message,
-      pairedToolName: result.pairedToolName,
-    });
-  }
+  emitLoopWarning({ ctx, sessionState, toolName, warning: result, logToolLoopAction });
   return undefined;
 }
 
@@ -142,7 +127,9 @@ export async function admitToolCallBatch(
     return {};
   }
   const {
+    buildArgumentChurnWarning,
     getDiagnosticSessionState,
+    logToolLoopAction,
     markDiagnosticArgumentChurnObservation,
     reconcileToolCallExecutionParams,
     recordToolCall,
@@ -246,6 +233,15 @@ export async function admitToolCallBatch(
       cwd: ctx.cwd ?? ctx.workspaceDir,
       warningThreshold,
     });
+    if (churn.active && churn.kind === "write_mutation") {
+      emitLoopWarning({
+        ctx,
+        sessionState,
+        toolName: admitted.toolName,
+        warning: buildArgumentChurnWarning(admitted.toolName, churn),
+        logToolLoopAction,
+      });
+    }
     markDiagnosticArgumentChurnObservation({
       sessionKey: ctx.sessionKey,
       sessionId: ctx.sessionId,

--- a/src/agents/tool-loop-admission.ts
+++ b/src/agents/tool-loop-admission.ts
@@ -28,6 +28,11 @@ type ToolLoopBatchAdmission = InternalBeforeToolBatchResult & {
   releaseSkippedCalls?: (toolCallIds: readonly string[]) => void;
 };
 
+function toolLoopScope(ctx: HookContext) {
+  const cwd = ctx.cwd ?? ctx.workspaceDir;
+  return ctx.runId || cwd ? { runId: ctx.runId, cwd } : undefined;
+}
+
 async function evaluateToolLoopCall(
   call: ToolLoopCall,
   ctx: HookContext,
@@ -50,7 +55,7 @@ async function evaluateToolLoopCall(
     toolName,
     call.params,
     ctx.loopDetection,
-    ctx.runId ? { runId: ctx.runId } : undefined,
+    toolLoopScope(ctx),
   );
   if (!result.stuck) {
     return undefined;
@@ -108,7 +113,7 @@ async function recordToolLoopCall(call: ToolLoopCall, ctx: HookContext): Promise
     call.params,
     call.toolCallId,
     ctx.loopDetection,
-    ctx.runId ? { runId: ctx.runId } : undefined,
+    toolLoopScope(ctx),
   );
 }
 
@@ -159,7 +164,7 @@ export async function admitToolCallBatch(
       call.args,
       call.toolCall.id,
       ctx.loopDetection,
-      ctx.runId ? { runId: ctx.runId } : undefined,
+      toolLoopScope(ctx),
     );
     const projectedCall = state.toolCallHistory?.at(-1);
     if (projectedCall) {
@@ -231,13 +236,14 @@ export async function admitToolCallBatch(
       readyCall.args,
       readyCall.toolCallId,
       ctx.loopDetection,
-      ctx.runId ? { runId: ctx.runId } : undefined,
+      toolLoopScope(ctx),
     );
     const churn = reconcileToolCallExecutionParams(sessionState, {
       toolName: admitted.toolName,
       toolParams: readyCall.args,
       toolCallId: readyCall.toolCallId,
       runId: ctx.runId,
+      cwd: ctx.cwd ?? ctx.workspaceDir,
       warningThreshold,
     });
     markDiagnosticArgumentChurnObservation({

--- a/src/agents/tool-loop-argument-churn.ts
+++ b/src/agents/tool-loop-argument-churn.ts
@@ -2,7 +2,7 @@ import type { ToolCallRecord } from "../logging/diagnostic-session-state.js";
 
 const MIN_STABLE_CALLS_PER_VARIANT = 3;
 
-export function getArgumentChurnNoProgressStreak(
+function getArgumentChurnNoProgressStreak(
   history: readonly ToolCallRecord[],
   toolName: string,
   currentArgsHash: string,
@@ -54,7 +54,7 @@ export function getArgumentChurnNoProgressStreak(
     : { count: 0, variantCount: 0 };
 }
 
-export function getWriteMutationChurnStreak(
+function getWriteMutationChurnStreak(
   history: readonly ToolCallRecord[],
   current: Pick<ToolCallRecord, "argsHash" | "mutationTargetHash" | "outcomeKind" | "resultHash">,
 ): { count: number; variantCount: number } {

--- a/src/agents/tool-loop-argument-churn.ts
+++ b/src/agents/tool-loop-argument-churn.ts
@@ -54,10 +54,84 @@ export function getArgumentChurnNoProgressStreak(
     : { count: 0, variantCount: 0 };
 }
 
+export function getWriteMutationChurnStreak(
+  history: readonly ToolCallRecord[],
+  current: Pick<ToolCallRecord, "argsHash" | "mutationTargetHash" | "outcomeKind" | "resultHash">,
+): { count: number; variantCount: number } {
+  if (
+    !current.mutationTargetHash ||
+    ((current.resultHash !== undefined || current.outcomeKind !== undefined) &&
+      current.outcomeKind !== "write-mutation")
+  ) {
+    return { count: 0, variantCount: 0 };
+  }
+  const variants = new Set<string>();
+  for (let i = history.length - 1; i >= 0; i -= 1) {
+    const record = history[i];
+    if (
+      !record ||
+      record.toolName !== "write" ||
+      record.outcomeKind !== "write-mutation" ||
+      record.mutationTargetHash !== current.mutationTargetHash
+    ) {
+      break;
+    }
+    variants.add(record.argsHash);
+  }
+  if (variants.has(current.argsHash)) {
+    return { count: 0, variantCount: 0 };
+  }
+  return { count: variants.size, variantCount: variants.size };
+}
+
+export function getToolArgumentChurnStreak(
+  history: readonly ToolCallRecord[],
+  current: ToolCallRecord,
+): {
+  count: number;
+  variantCount: number;
+  kind?: "write_mutation";
+  mutationTargetHash?: string;
+} {
+  if (current.outcomeKind === "write-mutation") {
+    const writeMutation = getWriteMutationChurnStreak(history, current);
+    return writeMutation.count > 0
+      ? { ...writeMutation, kind: "write_mutation", mutationTargetHash: current.mutationTargetHash }
+      : writeMutation;
+  }
+  if (current.resultHash !== undefined && current.noProgress !== true) {
+    return { count: 0, variantCount: 0 };
+  }
+  const noProgress = getArgumentChurnNoProgressStreak(history, current.toolName, current.argsHash);
+  if (noProgress.count > 0) {
+    return noProgress;
+  }
+  const writeMutation = getWriteMutationChurnStreak(history, current);
+  return writeMutation.count > 0
+    ? { ...writeMutation, kind: "write_mutation", mutationTargetHash: current.mutationTargetHash }
+    : writeMutation;
+}
+
 export function buildArgumentChurnWarning(
   toolName: string,
-  churn: { count: number; variantCount: number },
+  churn: {
+    count: number;
+    variantCount: number;
+    kind?: "write_mutation";
+    mutationTargetHash?: string;
+  },
 ) {
+  if (churn.kind === "write_mutation") {
+    return {
+      stuck: true as const,
+      level: "warning" as const,
+      detector: "argument_churn" as const,
+      count: churn.count,
+      message: `WARNING: ${toolName} has changed the same target with ${churn.variantCount} distinct argument variants and no intervening verification. Continued rewriting is treated as stalled run activity, but this tool call remains allowed. Read or verify the current result before rewriting it again.`,
+      warningKey: `argument-churn:${toolName}:write-mutation:${churn.mutationTargetHash ?? "unknown"}`,
+      livenessSignal: "argument_churn" as const,
+    };
+  }
   return {
     stuck: true as const,
     level: "warning" as const,

--- a/src/agents/tool-loop-call-reconciliation.ts
+++ b/src/agents/tool-loop-call-reconciliation.ts
@@ -1,7 +1,8 @@
 import { normalizeOptionalString as normalizeRunId } from "@openclaw/normalization-core/string-coerce";
 import type { SessionState } from "../logging/diagnostic-session-state.js";
-import { getArgumentChurnNoProgressStreak } from "./tool-loop-argument-churn.js";
+import { getToolArgumentChurnStreak } from "./tool-loop-argument-churn.js";
 import { hashToolCall } from "./tool-loop-detection.js";
+import { hashWriteMutationTarget } from "./tool-loop-write-outcome.js";
 
 /**
  * Rebind the pending admission record to the arguments that will actually
@@ -15,6 +16,7 @@ export function reconcileToolCallExecutionParams(
     toolParams: unknown;
     toolCallId?: string;
     runId?: string;
+    cwd?: string;
     warningThreshold: number;
   },
 ): { active: boolean; count: number; variantCount: number } {
@@ -42,10 +44,15 @@ export function reconcileToolCallExecutionParams(
     }
 
     call.argsHash = argsHash;
+    call.mutationTargetHash = hashWriteMutationTarget(
+      params.toolName,
+      params.toolParams,
+      params.cwd,
+    );
     const scopedHistory = history
       .slice(0, index)
       .filter((record) => normalizeRunId(record.runId) === runId);
-    const churn = getArgumentChurnNoProgressStreak(scopedHistory, params.toolName, argsHash);
+    const churn = getToolArgumentChurnStreak(scopedHistory, call);
     return {
       active: churn.count >= params.warningThreshold,
       ...churn,

--- a/src/agents/tool-loop-call-reconciliation.ts
+++ b/src/agents/tool-loop-call-reconciliation.ts
@@ -19,10 +19,20 @@ export function reconcileToolCallExecutionParams(
     cwd?: string;
     warningThreshold: number;
   },
-): ReturnType<typeof getToolArgumentChurnStreak> & { active: boolean } {
+): ReturnType<typeof getToolArgumentChurnStreak> & {
+  active: boolean;
+  matchedPendingCall: boolean;
+  executionParamsChanged: boolean;
+} {
   const history = state.toolCallHistory;
   if (!history) {
-    return { active: false, count: 0, variantCount: 0 };
+    return {
+      active: false,
+      count: 0,
+      variantCount: 0,
+      matchedPendingCall: false,
+      executionParamsChanged: false,
+    };
   }
 
   const runId = normalizeRunId(params.runId);
@@ -43,6 +53,7 @@ export function reconcileToolCallExecutionParams(
       continue;
     }
 
+    const executionParamsChanged = call.argsHash !== argsHash;
     call.argsHash = argsHash;
     call.mutationTargetHash = hashWriteMutationTarget(
       params.toolName,
@@ -55,9 +66,17 @@ export function reconcileToolCallExecutionParams(
     const churn = getToolArgumentChurnStreak(scopedHistory, call);
     return {
       active: churn.count >= params.warningThreshold,
+      matchedPendingCall: true,
+      executionParamsChanged,
       ...churn,
     };
   }
 
-  return { active: false, count: 0, variantCount: 0 };
+  return {
+    active: false,
+    count: 0,
+    variantCount: 0,
+    matchedPendingCall: false,
+    executionParamsChanged: false,
+  };
 }

--- a/src/agents/tool-loop-call-reconciliation.ts
+++ b/src/agents/tool-loop-call-reconciliation.ts
@@ -19,7 +19,7 @@ export function reconcileToolCallExecutionParams(
     cwd?: string;
     warningThreshold: number;
   },
-): { active: boolean; count: number; variantCount: number } {
+): ReturnType<typeof getToolArgumentChurnStreak> & { active: boolean } {
   const history = state.toolCallHistory;
   if (!history) {
     return { active: false, count: 0, variantCount: 0 };

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -852,7 +852,35 @@ describe("tool-loop-detection", () => {
         warningThreshold: 6,
       });
 
-      expect(reconciled).toEqual({ active: true, count: 6, variantCount: 2 });
+      expect(reconciled).toEqual({
+        active: true,
+        count: 6,
+        variantCount: 2,
+        matchedPendingCall: true,
+        executionParamsChanged: true,
+      });
+    });
+
+    it("reports unchanged prepared params without treating them as an escape", () => {
+      const state = createState();
+      const params = { path: "/tmp/draft.md", content: "same content" };
+      recordToolCall(state, "write", params, "prepared-call", undefined, { runId: "run-1" });
+
+      expect(
+        reconcileToolCallExecutionParams(state, {
+          toolName: "write",
+          toolParams: params,
+          toolCallId: "prepared-call",
+          runId: "run-1",
+          warningThreshold: 6,
+        }),
+      ).toEqual({
+        active: false,
+        count: 0,
+        variantCount: 0,
+        matchedPendingCall: true,
+        executionParamsChanged: false,
+      });
     });
 
     it("does not reconcile a completed loop veto as a pending call", () => {
@@ -877,7 +905,13 @@ describe("tool-loop-detection", () => {
           toolParams: { path: "/tmp/rewritten.md", content: "same content" },
           warningThreshold: 6,
         }),
-      ).toEqual({ active: false, count: 0, variantCount: 0 });
+      ).toEqual({
+        active: false,
+        count: 0,
+        variantCount: 0,
+        matchedPendingCall: true,
+        executionParamsChanged: true,
+      });
       expect(state.toolCallHistory[0]?.argsHash).not.toBe("pending-args");
       expect(state.toolCallHistory[1]?.argsHash).toBe("vetoed-args");
     });

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -511,6 +511,212 @@ describe("tool-loop-detection", () => {
       }
     });
 
+    it("warns on repeated changed writes to one target without vetoing the next call", () => {
+      const state = createState();
+      const targetPath = "/tmp/draft.md";
+
+      for (let index = 0; index < WARNING_THRESHOLD; index += 1) {
+        const content = `synthetic revision ${index}`;
+        recordSuccessfulCall(
+          state,
+          "write",
+          { path: targetPath, content },
+          {
+            content: [{ type: "text", text: "write complete" }],
+            details: {
+              changed: true,
+              created: index === 0,
+              diff: `+${content}`,
+              patch: `--- ${targetPath}\n+++ ${targetPath}\n+${content}`,
+            },
+          },
+          index,
+        );
+      }
+
+      const nextParams = { path: targetPath, content: "synthetic next revision" };
+      expect(
+        detectToolCallLoop(state, "write", nextParams, enabledLoopDetectionConfig),
+      ).toMatchObject({
+        stuck: true,
+        level: "warning",
+        detector: "argument_churn",
+        count: WARNING_THRESHOLD,
+        livenessSignal: "argument_churn",
+      });
+      expect(state.toolCallHistory).toHaveLength(WARNING_THRESHOLD);
+    });
+
+    it("resets changed-write churn after target escape or verification", () => {
+      const state = createState();
+      const targetPath = "/tmp/draft.md";
+      const changedResult = {
+        content: [{ type: "text", text: "write complete" }],
+        details: { changed: true, created: false },
+      };
+      for (let index = 0; index < WARNING_THRESHOLD; index += 1) {
+        recordSuccessfulCall(
+          state,
+          "write",
+          { path: targetPath, content: `revision ${index}` },
+          changedResult,
+          index,
+        );
+      }
+
+      expect(
+        detectToolCallLoop(
+          state,
+          "write",
+          { path: "/tmp/other.md", content: "other" },
+          enabledLoopDetectionConfig,
+        ),
+      ).toEqual({ stuck: false });
+
+      recordSuccessfulCall(
+        state,
+        "read",
+        { path: targetPath },
+        { content: [{ type: "text", text: "verified" }], details: { ok: true } },
+        WARNING_THRESHOLD,
+      );
+      expect(
+        detectToolCallLoop(
+          state,
+          "write",
+          { path: targetPath, content: "verified revision" },
+          enabledLoopDetectionConfig,
+        ),
+      ).toEqual({ stuck: false });
+    });
+
+    it("does not treat a repeated body as changed-write argument churn", () => {
+      const state = createState();
+      const targetPath = "/tmp/draft.md";
+      for (let index = 0; index < WARNING_THRESHOLD; index += 1) {
+        recordSuccessfulCall(
+          state,
+          "write",
+          { path: targetPath, content: `revision ${index}` },
+          {
+            content: [{ type: "text", text: "write complete" }],
+            details: { changed: true, created: false },
+          },
+          index,
+        );
+      }
+      expect(
+        detectToolCallLoop(
+          state,
+          "write",
+          { path: targetPath, content: "revision 9" },
+          enabledLoopDetectionConfig,
+        ),
+      ).toEqual({ stuck: false });
+    });
+
+    it("normalizes built-in write path aliases against the execution cwd", () => {
+      const state = createState();
+      const scope = { cwd: "/tmp/workspace" };
+      const fileUrl = "file:///tmp/workspace/draft.md";
+      for (let index = 0; index < WARNING_THRESHOLD; index += 1) {
+        const params = {
+          path: index % 2 === 0 ? "@draft.md" : fileUrl,
+          content: `revision ${index}`,
+        };
+        const toolCallId = `write-alias-${index}`;
+        recordToolCall(state, "write", params, toolCallId, enabledLoopDetectionConfig, scope);
+        recordToolCallOutcome(state, {
+          toolName: "write",
+          toolParams: params,
+          toolCallId,
+          result: {
+            content: [{ type: "text", text: "write complete" }],
+            details: { changed: true, created: false },
+          },
+          config: enabledLoopDetectionConfig,
+          cwd: scope.cwd,
+        });
+      }
+      expect(
+        detectToolCallLoop(
+          state,
+          "write",
+          { path: "notes/../draft.md", content: "next revision" },
+          enabledLoopDetectionConfig,
+          scope,
+        ),
+      ).toMatchObject({
+        stuck: true,
+        detector: "argument_churn",
+        count: WARNING_THRESHOLD,
+      });
+    });
+
+    it("scopes changed-write warning buckets to the mutation target", () => {
+      const warningKeys = ["/tmp/first.md", "/tmp/second.md"].map((targetPath) => {
+        const state = createState();
+        for (let index = 0; index < WARNING_THRESHOLD; index += 1) {
+          recordSuccessfulCall(
+            state,
+            "write",
+            { path: targetPath, content: `revision ${index}` },
+            {
+              content: [{ type: "text", text: "write complete" }],
+              details: { changed: true, created: false },
+            },
+            index,
+          );
+        }
+        const result = detectToolCallLoop(
+          state,
+          "write",
+          { path: targetPath, content: "next revision" },
+          enabledLoopDetectionConfig,
+        );
+        if (!result.stuck) {
+          throw new Error("expected same-target write churn warning");
+        }
+        expect(result).toMatchObject({ detector: "argument_churn" });
+        return result.warningKey;
+      });
+
+      expect(warningKeys[0]).toBeTypeOf("string");
+      expect(warningKeys[1]).toBeTypeOf("string");
+      expect(warningKeys[0]).not.toBe(warningKeys[1]);
+    });
+
+    it("keeps whitespace-distinct write targets separate", () => {
+      const state = createState();
+      const scope = { cwd: "/tmp/workspace" };
+      for (let index = 0; index < WARNING_THRESHOLD; index += 1) {
+        const params = { path: "draft.md", content: `revision ${index}` };
+        const toolCallId = `write-whitespace-${index}`;
+        recordToolCall(state, "write", params, toolCallId, enabledLoopDetectionConfig, scope);
+        recordToolCallOutcome(state, {
+          toolName: "write",
+          toolParams: params,
+          toolCallId,
+          result: {
+            content: [{ type: "text", text: "write complete" }],
+            details: { changed: true, created: false },
+          },
+          config: enabledLoopDetectionConfig,
+          cwd: scope.cwd,
+        });
+      }
+
+      expect(
+        detectToolCallLoop(
+          state,
+          "write",
+          { path: " draft.md ", content: "separate target" },
+          enabledLoopDetectionConfig,
+          scope,
+        ),
+      ).toEqual({ stuck: false });
+    });
+
     it("warns on repeated stable argument churn without vetoing the next call", () => {
       const state = createState();
       const paths = ["/tmp/a.md", "/tmp/b.md", "/tmp/a.md", "/tmp/a.md", "/tmp/b.md"];

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -16,12 +16,12 @@ import { isPlainObject } from "../utils.js";
 import { isMessagingToolSendAction } from "./embedded-agent-messaging.js";
 import {
   buildArgumentChurnWarning,
-  getArgumentChurnNoProgressStreak,
+  getToolArgumentChurnStreak,
 } from "./tool-loop-argument-churn.js";
 import { isKnownPollToolCall } from "./tool-loop-call-kind.js";
 import { getNoProgressStreak } from "./tool-loop-no-progress.js";
 import { TOOL_LOOP_WARNING_THRESHOLD } from "./tool-loop-thresholds.js";
-import { isWriteNoProgressOutcome } from "./tool-loop-write-outcome.js";
+import { hashWriteMutationTarget, isWriteNoProgressOutcome } from "./tool-loop-write-outcome.js";
 
 const log = createSubsystemLogger("agents/loop-detection");
 
@@ -78,9 +78,7 @@ type ResolvedLoopDetectionConfig = {
   };
 };
 
-type ToolLoopDetectionScope = {
-  runId?: string;
-};
+type ToolLoopDetectionScope = { runId?: string; cwd?: string };
 
 function selectHistoryForScope(
   history: readonly ToolCallRecord[],
@@ -329,6 +327,12 @@ function hashToolOutcome(
   if (toolName === "write" && isWriteNoProgressOutcome(details)) {
     return { resultHash: digestStable({ status: "unchanged" }), noProgress: true };
   }
+  if (toolName === "write" && details.changed === true) {
+    return {
+      resultHash: digestStable({ details, text }),
+      outcomeKind: "write-mutation",
+    };
+  }
   if (isKnownPollToolCall(toolName, params) && toolName === "process" && isPlainObject(params)) {
     const action = params.action;
     if (action === "poll") {
@@ -523,7 +527,12 @@ export function detectToolCallLoop(
   const unknownToolStreak = getUnknownToolRepeatStreak(history, toolName);
   const noProgress = getNoProgressStreak(history, toolName, currentHash);
   const noProgressStreak = noProgress.count;
-  const argumentChurn = getArgumentChurnNoProgressStreak(history, toolName, currentHash);
+  const argumentChurn = getToolArgumentChurnStreak(history, {
+    toolName,
+    argsHash: currentHash,
+    mutationTargetHash: hashWriteMutationTarget(toolName, params, scope?.cwd),
+    timestamp: Date.now(),
+  });
   const knownPollTool = isKnownPollToolCall(toolName, params);
   const pingPong = getPingPongStreak(history, currentHash);
   const argumentChurnLivenessSignal =
@@ -694,6 +703,7 @@ export function recordToolCall(
   state.toolCallHistory.push({
     toolName,
     argsHash: hashToolCall(toolName, params),
+    mutationTargetHash: hashWriteMutationTarget(toolName, params, scope?.cwd),
     toolCallId,
     ...(runId && { runId }),
     timestamp: Date.now(),
@@ -717,6 +727,7 @@ export function recordToolCallOutcome(
     error?: unknown;
     config?: ToolLoopDetectionConfig;
     runId?: string;
+    cwd?: string;
   },
 ): ToolCallRecord | undefined {
   const resolvedConfig = resolveLoopDetectionConfig(params.config);
@@ -767,6 +778,7 @@ export function recordToolCallOutcome(
     const record: ToolCallRecord = {
       toolName: params.toolName,
       argsHash,
+      mutationTargetHash: hashWriteMutationTarget(params.toolName, params.toolParams, params.cwd),
       toolCallId: params.toolCallId,
       ...(runId && { runId }),
       outcomeKind: outcome.outcomeKind,

--- a/src/agents/tool-loop-write-outcome.ts
+++ b/src/agents/tool-loop-write-outcome.ts
@@ -1,5 +1,25 @@
+import { createHash } from "node:crypto";
+import { stableStringify } from "@openclaw/normalization-core";
+import { resolveToCwd } from "./sessions/tools/path-utils.js";
+
 export function isWriteNoProgressOutcome(details: Record<string, unknown>): boolean {
   // The built-in no-op result echoes the requested path in display text.
   // Its structured `changed: false` flag is the semantic no-progress contract.
   return details.changed === false;
+}
+
+export function hashWriteMutationTarget(
+  toolName: string,
+  params: unknown,
+  cwd?: string,
+): string | undefined {
+  if (toolName !== "write" || !params || typeof params !== "object" || Array.isArray(params)) {
+    return undefined;
+  }
+  const rawPath = Reflect.get(params, "path");
+  if (typeof rawPath !== "string" || rawPath.length === 0) {
+    return undefined;
+  }
+  const path = cwd ? resolveToCwd(rawPath, cwd) : rawPath;
+  return createHash("sha256").update(stableStringify({ path })).digest("hex");
 }

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -22,9 +22,10 @@ export type SessionState = {
 export type ToolCallRecord = {
   toolName: string;
   argsHash: string;
+  mutationTargetHash?: string;
   toolCallId?: string;
   runId?: string;
-  outcomeKind?: "tool-loop-veto" | "terminal-exec-failure";
+  outcomeKind?: "tool-loop-veto" | "terminal-exec-failure" | "write-mutation";
   resultHash?: string;
   noProgress?: true;
   unknownToolName?: string;

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -20,6 +20,7 @@ import { withDiagnosticPhase } from "./diagnostic-phase.js";
 import {
   getDiagnosticSessionActivitySnapshot,
   createDiagnosticEmbeddedRunOwner,
+  markDiagnosticArgumentChurnObservation,
   markDiagnosticEmbeddedRunEnded,
   markDiagnosticEmbeddedRunStarted,
   resetDiagnosticRunActivityForTest,
@@ -748,6 +749,55 @@ describe("stuck session diagnostics threshold", () => {
     expectRecoveryCall(
       recoverStuckSession,
       { sessionId: "s1", sessionKey: "main", queueDepth: 0, allowActiveAbort: true },
+      ["ageMs", "stateGeneration"],
+    );
+  });
+
+  it("aborts continuous argument churn without requiring queued follow-up work", () => {
+    const recoverStuckSession = vi.fn();
+    const stuckSessionAbortMs = 5 * 60_000;
+    const sessionId = "argument-churn-zero-queue";
+    const sessionKey = "main";
+    const runId = "argument-churn-run";
+
+    startDiagnosticHeartbeat(
+      { diagnostics: { enabled: true } },
+      {
+        recoverStuckSession,
+        testTimings: { stuckSessionWarnMs: 30_000, stuckSessionAbortMs },
+      },
+    );
+    logSessionStateChange({ sessionId, sessionKey, state: "processing" });
+    markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey, runId });
+    markDiagnosticArgumentChurnObservation({
+      sessionId,
+      sessionKey,
+      runId,
+      active: true,
+    });
+
+    for (let step = 1; step <= 9; step += 1) {
+      vi.advanceTimersByTime(30_000);
+      markDiagnosticRunProgressForTest({
+        sessionId,
+        sessionKey,
+        runId,
+        reason: "model_call:stream_progress",
+      });
+      markDiagnosticArgumentChurnObservation({
+        sessionId,
+        sessionKey,
+        runId,
+        active: true,
+      });
+    }
+    expect(recoverStuckSession).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(30_000);
+
+    expectRecoveryCall(
+      recoverStuckSession,
+      { sessionId, sessionKey, queueDepth: 0, allowActiveAbort: true },
       ["ageMs", "stateGeneration"],
     );
   });


### PR DESCRIPTION
Related: #122577

## What Problem This Solves

Fixes an issue where an agent can repeatedly overwrite one file with different successful contents while never producing a final response. Because every write has different arguments and reports `changed: true`, current loop detection treats the sequence as ordinary progress indefinitely.

This PR proposes a conservative behavioral boundary for maintainer review. The issue is currently marked as requiring a product decision; this PR does not claim that decision has already been made.

## Why This Change Was Made

The change keeps successful writes classified as real mutations and adds a separate, warning-first run-liveness signal for a contiguous tail of content-changing writes to one resolved target. Target identity excludes document content and is stored only as a hash.

The existing loop warning threshold is reused. The warned write remains allowed. Continuity clears when the run changes tools (including read/verification), changes targets, repeats an earlier argument variant, or completes/replaces its lifecycle. If churn remains continuous through the existing stale-run boundary, owner-bound recovery can abort only that run whether or not follow-up work is queued.

The behavior is limited to the built-in `write` result contract (`details.changed === true`). It is not tied to a provider, model, transport, channel, or reported private document. No new configuration or default surface is added.

## Batch and Liveness Semantics

A whole assistant batch is admitted before its calls have outcomes. This revision therefore keeps warning and liveness behavior aligned at both lifecycle boundaries:

- successful write-mutation liveness stays inactive below the shared warning threshold;
- a sequential batch emits the same run-scoped warning before the threshold-crossing write implementation starts;
- a post-outcome fallback covers parallel or out-of-order batch completions;
- the shared warning bucket prevents duplicate pre- and post-outcome warnings;
- the existing stable no-progress classifier still includes the just-recorded outcome and activates on its original boundary.

## Scope and LOC

Against the integrated main snapshot `9e9ea746f4b3e1db2b5ced75fad972e994b57431`: 14 files, 1058 additions and 115 deletions, including tests. This update merges that main snapshot rather than rebasing away contributor history.

The integration repairs preserve current outcome hashing and propagate launch/completion warnings through existing model-facing feedback paths after raw outcome recording. Sequential and default-parallel integration regressions now require exactly one model-facing warning and complete result delivery. The successful-write recovery policy is unchanged and still requires maintainer acceptance.

## User Impact

Runaway same-file rewrite sequences become bounded without immediately blocking normal edits. Short rewrite sequences, multi-file work, write/read/write verification, repeated identical content, and successful writes outside the sustained same-target pattern retain their existing behavior. The latest file state and session remain available after recovery.

## Policy Status

ClawSweeper marked #122577 as requiring a maintainer product decision and disabled automated fix-PR queueing. This PR implements one conservative proposal for review; it does not claim that maintainers have approved the warning, escape, or recovery boundary. It is ready for maintainer review of that decision, but does not claim approval or merge readiness.

## Evidence

Behavioral incident baseline: `v2026.7.2-beta.7` (`dabe1915362e20c25704af91612a32a8f4c96e83`). The beta is provenance only; the patch and tests target current `upstream/main`.

Negative controls observed before their fixes:

```text
same-target detector: expected warning, received { stuck: false }
below-threshold liveness: active=true after the second distinct changed write
embedded sequential batch: 11 successful writes, warning event list empty
stable no-progress boundary: sixth completed outcome still reported active=false
default-parallel batch: warning emitted, first churn lease remained absent
loop detection omitted/disabled: changed-write churn emitted a warning
CI dependency scan: three internal helpers were exported but unused
```

## Current revision and verification

Head: `8f7f649ef66fb4fe3839145ed8ce420d694c6892`
Tree: `d5706668cae6c18f966177ad1b09d1c04bd439fa`
Integrated main snapshot: `9e9ea746f4b3e1db2b5ced75fad972e994b57431`

- Independent review approved the integrated tree before the final, semantics-equivalent `return` → `return undefined` lint repair.
- Before that one-line repair: full before-tool E2E **107 passed**, selected test typechecks and formatting passed; warning-delivery regression cases were observed failing before the feedback fix and passing afterward.
- After the final repair: targeted type-aware lint and both sequential/parallel write-churn integration tests passed. The existing diagnostics file-length warning remains nonblocking.
- Final committed revision: formatting, lint, whitespace, full production build, and fresh isolated gateway proof passed. Build metadata and clean repository checks match the exact head before/after the proof; the target-file digest was independently read back.
- Hosted CI is separate; no green hosted-CI claim is made here.

### Fresh gateway proof

The real gateway, authenticated loopback agent RPC, embedded runner, built-in write/read tools, diagnostic heartbeat, and owner-bound recovery were exercised using a deterministic loopback model transport. No outbound-channel delivery or live-provider claim.

```text
canonical warning: argument_churn / warn / count 10 (seq 192)
later warning: argument_churn / warn / count 20 (seq 295)
continuous churn duration: 384719 ms
session.stalled: age 383494 ms, model_call (seq 362)
recovery requested: abort, same age (seq 363)
recovery completed: abort_embedded_run / aborted / embedded_run (seq 368)
healthy concurrent control: passed
post-recovery control: passed
same-session file readback: passed
target-file digest readback: matched
artifact verifier: passed, no failures
```

The previous proof at head `737c2d2ca1b1ceb3f33e9b66b2a11cd7dd43836f` is historical only. This evidence is bound to the new head, not to any subsequent rebase or source change. The synthetic provider harness was adjusted to select the latest marked proof prompt because runtime context can follow it as another user-role message; no production logic or timing constants were changed for the proof.

The [exact-head update comment](https://github.com/openclaw/openclaw/pull/122631#issuecomment-5746076190) contains the sanitized event evidence and artifact digests. Raw logs, runtime identifiers, local paths, credentials, and provider configuration are intentionally not published.

## Remaining decisions

Maintainer acceptance of successful-write abortability versus warning-only remains required. Local verification does not replace hosted checks or maintainer approval; this update does not assert merge readiness.
