### PR TITLE
docs(cli): complete config and backup command tree

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -119,6 +119,7 @@ openclaw [--dev] [--profile <name>] <command>
   config
     get
     set
+    patch
     unset
     file
     schema
@@ -129,6 +130,20 @@ openclaw [--dev] [--profile <name>] <command>
   backup
     create
     verify
+    restore
+    sqlite
+      create
+      list
+      verify
+      restore
+    git
+      init
+      create
+      log
+      verify
+      restore
+    enable
+    disable
   migrate
     list
     plan <provider>


### PR DESCRIPTION
## What Problem This Solves

The [CLI command map](https://docs.openclaw.ai/cli#command-tree) omits `config patch` and most existing backup commands. Readers can find archive creation and verification, but the map leaves out archive restore, SQLite snapshots, Git backup history, and scheduled backups.

## Why This Change Was Made

Complete the configuration and backup branches in the existing index, matching their current registrations and dedicated [config](https://docs.openclaw.ai/cli/config) and [backup](https://docs.openclaw.ai/cli/backup) references. The added entries follow registration order: `config patch`; archive `restore`; SQLite `create`, `list`, `verify`, and `restore`; Git `init`, `create`, `log`, `verify`, and `restore`; and backup `enable`/`disable`.

## User Impact

Operators can discover these existing configuration and recovery workflows from the main CLI index. This changes only `docs/cli/index.md`: documentation +15/-0; production and tests +0/-0. Thanks @Adkid-Zephyr.

## Evidence

The candidate is `93fadcebf826500f64365865aeb966d5e0d78909`.

Maintainer source review traced the core command registry and descriptors into `registerConfigCli` and `registerBackupCommand`, compared all added entries and sibling order against both complete registration modules and dedicated reference pages, and inspected existing real-Commander registration/action coverage. Current main still omits these entries. The command implementations already exist; this PR adds no new runtime behavior.

Fresh exact-head [CI](https://github.com/openclaw/openclaw/actions/runs/32246460315) and [Workflow Sanity](https://github.com/openclaw/openclaw/actions/runs/32246460363) passed on their second attempts. The [docs job](https://github.com/openclaw/openclaw/actions/runs/32246460315/job/99361565814) passed formatting, Markdown lint, MDX compilation of 779 files, internal links, and config-example validation. Its checked-out page blob matches the candidate exactly. The i18n glossary history check skipped because its checkout lacked a merge base; this English-only command list adds no translated glossary terms.

The exact candidate page also passed local trusted MDX compilation, explicit-config formatting, docs-list discovery, and `git diff --check`. Fresh full-branch Codex review found no accepted P0 findings. The previous ClawSweeper review had no correctness findings; its pending docs-check request is resolved, and a fresh review has been requested because of its age.

No runtime command or live backup operation is claimed as new proof for this docs-only change. Contributor scripts and configuration are not executed locally; documentation validation uses trusted tools with the candidate page treated as data.
