### PR TITLE
fix(build): cancel stalled CLI metadata renderers

### DIFF
--- a/scripts/write-cli-startup-metadata.ts
+++ b/scripts/write-cli-startup-metadata.ts
@@ -101,6 +101,10 @@ type RenderTaskContext = {
   reportFailure: (error: unknown) => void;
   signal: AbortSignal;
 };
+type SourceHelpRenderer<T = string> = (
+  renderContext: RootHelpRenderContext,
+  taskContext?: RenderTaskContext,
+) => Awaitable<T>;
 type KillableChild = {
   kill(signal: NodeJS.Signals): boolean;
   pid?: number;
@@ -111,19 +115,12 @@ type RunTaskkill = (
   options: { stdio: "ignore" },
 ) => { error?: unknown; status?: number | null } | undefined;
 
-class MissingBundledRootHelpError extends Error {
-  readonly code = "CLI_STARTUP_ROOT_HELP_BUNDLE_MISSING";
-}
-
-function isMissingBundledRootHelpError(error: unknown): error is MissingBundledRootHelpError {
-  return error instanceof MissingBundledRootHelpError;
-}
-
 class CliStartupMetadataRenderSupervisor {
   readonly #abortController = new AbortController();
   readonly #parentSignalHandlers: Array<{ handler: () => void; signal: NodeJS.Signals }> = [];
   #firstFailure: Error | undefined;
   #parentSignal: NodeJS.Signals | null = null;
+  #preserveRenderState = false;
 
   constructor() {
     const signals: NodeJS.Signals[] =
@@ -148,7 +145,18 @@ class CliStartupMetadataRenderSupervisor {
     return this.#abortController.signal;
   }
 
+  get preserveRenderState(): boolean {
+    return this.#preserveRenderState;
+  }
+
   reportFailure(error: unknown): void {
+    if (
+      error instanceof Error &&
+      "preserveRenderState" in error &&
+      error.preserveRenderState === true
+    ) {
+      this.#preserveRenderState = true;
+    }
     if (this.#firstFailure || this.#parentSignal) {
       return;
     }
@@ -156,27 +164,28 @@ class CliStartupMetadataRenderSupervisor {
     this.#abortController.abort(this.#firstFailure);
   }
 
-  run<T>(render: (context: RenderTaskContext) => Awaitable<T>): Promise<T> {
-    return Promise.resolve()
-      .then(async () => {
-        if (this.signal.aborted) {
-          throw this.signal.reason ?? new Error("CLI startup metadata render aborted");
-        }
-        return await render({
-          reportFailure: (error) => this.reportFailure(error),
-          signal: this.signal,
-        });
-      })
-      .then(
-        (value) => value,
-        (error: unknown) => {
-          this.reportFailure(error);
-          throw error;
-        },
-      );
+  async run<T>(render: (context: RenderTaskContext) => Awaitable<T>): Promise<T> {
+    // Register every sibling before a synchronous renderer can abort the shared group.
+    await Promise.resolve();
+    if (this.signal.aborted) {
+      throw this.signal.reason ?? new Error("CLI startup metadata render aborted");
+    }
+    try {
+      return await render({
+        reportFailure: (error) => this.reportFailure(error),
+        signal: this.signal,
+      });
+    } catch (error) {
+      this.reportFailure(error);
+      throw error;
+    }
   }
 
-  finish(primaryFailure: unknown, cleanupError?: unknown): never | void {
+  finish(
+    primaryFailure: unknown,
+    cleanupError?: unknown,
+    preservedStateDir?: string,
+  ): never | void {
     for (const { signal, handler } of this.#parentSignalHandlers) {
       process.off(signal, handler);
     }
@@ -198,6 +207,9 @@ class CliStartupMetadataRenderSupervisor {
     }
     if (cleanupError) {
       Object.assign(failure, { cleanupError });
+    }
+    if (preservedStateDir) {
+      failure.message += `\nPreserved CLI startup metadata render state: ${preservedStateDir}`;
     }
     throw failure;
   }
@@ -436,22 +448,26 @@ async function settleRootHelpRenderPromises<T extends readonly unknown[]>(
   stateDir: string,
   supervisor: CliStartupMetadataRenderSupervisor,
 ): Promise<{ -readonly [P in keyof T]: Awaited<T[P]> }> {
-  let result: { -readonly [P in keyof T]: Awaited<T[P]> } | undefined;
-  let primaryFailure: unknown;
-  try {
-    result = await Promise.all(values);
-  } catch (error) {
-    primaryFailure = error;
-  }
-  await Promise.allSettled(values);
+  const settled = await Promise.allSettled(values);
+  const rejected = settled.find(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
   let cleanupError: unknown;
-  try {
-    cleanupRootHelpRenderStateDir(stateDir);
-  } catch (error) {
-    cleanupError = error;
+  if (!supervisor.preserveRenderState) {
+    try {
+      cleanupRootHelpRenderStateDir(stateDir);
+    } catch (error) {
+      cleanupError = error;
+    }
   }
-  supervisor.finish(primaryFailure, cleanupError);
-  return result as { -readonly [P in keyof T]: Awaited<T[P]> };
+  supervisor.finish(
+    rejected?.reason,
+    cleanupError,
+    supervisor.preserveRenderState ? stateDir : undefined,
+  );
+  return settled.map((result) => (result as PromiseFulfilledResult<unknown>).value) as {
+    -readonly [P in keyof T]: Awaited<T[P]>;
+  };
 }
 
 function createIsolatedRootHelpRenderContext(
@@ -488,7 +504,14 @@ function createSpawnTextFailure(params: {
   cause?: unknown;
   detail?: string;
   failureMessage: string;
-  kind: "aborted" | "nonzero-exit" | "output-limit" | "spawn-error" | "stream-error" | "timeout";
+  kind:
+    | "aborted"
+    | "nonzero-exit"
+    | "output-limit"
+    | "process-tree-cleanup"
+    | "spawn-error"
+    | "stream-error"
+    | "timeout";
   startedAt: number;
 }): Error {
   const elapsedMs = Date.now() - params.startedAt;
@@ -503,7 +526,9 @@ function createSpawnTextFailure(params: {
           ? "ETIMEDOUT"
           : params.kind === "aborted"
             ? "EABORTED"
-            : "ECLI_STARTUP_METADATA_RENDER",
+            : params.kind === "process-tree-cleanup"
+              ? "EPROCESSGROUP_CLEANUP_FAILED"
+              : "ECLI_STARTUP_METADATA_RENDER",
       elapsedMs,
       renderFailureKind: params.kind,
     },
@@ -548,12 +573,9 @@ async function spawnText(
     let stdout = "";
     let stderr = "";
     let outputBytes = 0;
-    let outputExceeded = false;
-    let outputStreamError: { streamName: "stdout" | "stderr"; error: Error } | undefined;
     let settled = false;
-    let timedOut = false;
-    let aborted = false;
     let terminalFailure: Error | undefined;
+    let processTreeCleanupFailure: Error | undefined;
     let waitingForKillGrace = false;
     let forceKillInFlight = false;
     let childClosedResult: { code: number | null; signal: NodeJS.Signals | null } | null = null;
@@ -597,20 +619,28 @@ async function spawnText(
       options.onTerminalFailure?.(error);
       return error;
     };
+    const createFailure = (
+      kind: Parameters<typeof createSpawnTextFailure>[0]["kind"],
+      detail: string,
+      cause?: unknown,
+    ) =>
+      createSpawnTextFailure({
+        cause,
+        detail,
+        failureMessage: options.failureMessage,
+        kind,
+        startedAt,
+      });
+    const fail = (
+      kind: Parameters<typeof createSpawnTextFailure>[0]["kind"],
+      detail: string,
+      cause?: unknown,
+    ) => recordTerminalFailure(createFailure(kind, detail, cause));
     const abortListener = () => {
       if (settled || terminalFailure) {
         return;
       }
-      aborted = true;
-      recordTerminalFailure(
-        createSpawnTextFailure({
-          cause: options.signal?.reason,
-          detail: "aborted after sibling failure",
-          failureMessage: options.failureMessage,
-          kind: "aborted",
-          startedAt,
-        }),
-      );
+      fail("aborted", "aborted after sibling failure", options.signal?.reason);
       signalChild("SIGTERM");
       scheduleKill();
     };
@@ -628,20 +658,19 @@ async function spawnText(
     };
     const finishClose = (result: { code: number | null; signal: NodeJS.Signals | null }) => {
       settle(() => {
-        if (result.code === 0 && !terminalFailure && !timedOut && !outputExceeded && !aborted) {
+        if (result.code === 0 && !terminalFailure) {
           resolve(stdout);
           return;
         }
         const detail = stderr.trim() || (result.signal ? `terminated by ${result.signal}` : "");
-        reject(
-          terminalFailure ??
-            createSpawnTextFailure({
-              detail,
-              failureMessage: options.failureMessage,
-              kind: "nonzero-exit",
-              startedAt,
-            }),
-        );
+        const failure = terminalFailure ?? createFailure("nonzero-exit", detail);
+        if (processTreeCleanupFailure) {
+          Object.assign(failure, {
+            preserveRenderState: true,
+            processTreeCleanupFailure,
+          });
+        }
+        reject(failure);
       });
     };
     const scheduleKill = () => {
@@ -660,17 +689,22 @@ async function spawnText(
         void forceDrain.then((drained) => {
           forceKillInFlight = false;
           if (!drained) {
-            recordTerminalFailure(
-              createSpawnTextFailure({
-                detail: `process group did not exit within ${killGraceMs}ms after SIGKILL`,
-                failureMessage: options.failureMessage,
-                kind: "nonzero-exit",
-                startedAt,
-              }),
+            processTreeCleanupFailure = Object.assign(
+              createFailure(
+                "process-tree-cleanup",
+                `process group did not exit within ${killGraceMs}ms after SIGKILL`,
+              ),
+              { preserveRenderState: true },
             );
+            options.onTerminalFailure?.(processTreeCleanupFailure);
           }
           if (childClosedResult) {
             finishClose(childClosedResult);
+          } else if (!drained) {
+            child.stdout.destroy();
+            child.stderr.destroy();
+            child.unref?.();
+            finishClose({ code: null, signal: "SIGKILL" });
           }
         });
       }, killGraceMs);
@@ -701,50 +735,25 @@ async function spawnText(
     const failOutputStream = (streamName: "stdout" | "stderr", error: Error) => {
       // Keep the first stop cause: killing for a timeout or output cap can make
       // the stdio pipes fail secondarily while the child is shutting down.
-      if (outputStreamError || timedOut || outputExceeded) {
+      if (terminalFailure) {
         return;
       }
-      outputStreamError = { streamName, error };
-      recordTerminalFailure(
-        createSpawnTextFailure({
-          cause: error,
-          detail: `${streamName} read error: ${error.message}`,
-          failureMessage: options.failureMessage,
-          kind: "stream-error",
-          startedAt,
-        }),
-      );
+      fail("stream-error", `${streamName} read error: ${error.message}`, error);
       requestStop();
     };
     const timeout = setTimeout(() => {
-      timedOut = true;
-      recordTerminalFailure(
-        createSpawnTextFailure({
-          detail: `timed out after ${options.timeoutMs}ms`,
-          failureMessage: options.failureMessage,
-          kind: "timeout",
-          startedAt,
-        }),
-      );
+      fail("timeout", `timed out after ${options.timeoutMs}ms`);
       requestStop();
     }, options.timeoutMs);
     timeout.unref();
     child.stdout.setEncoding("utf8");
     child.stdout.on("data", (chunk: string) => {
-      if (outputExceeded) {
+      if (terminalFailure) {
         return;
       }
       outputBytes += Buffer.byteLength(chunk);
       if (outputBytes > maxOutputBytes) {
-        outputExceeded = true;
-        recordTerminalFailure(
-          createSpawnTextFailure({
-            detail: `output exceeded ${maxOutputBytes} bytes`,
-            failureMessage: options.failureMessage,
-            kind: "output-limit",
-            startedAt,
-          }),
-        );
+        fail("output-limit", `output exceeded ${maxOutputBytes} bytes`);
         requestStop();
         return;
       }
@@ -752,20 +761,12 @@ async function spawnText(
     });
     child.stderr.setEncoding("utf8");
     child.stderr.on("data", (chunk: string) => {
-      if (outputExceeded) {
+      if (terminalFailure) {
         return;
       }
       outputBytes += Buffer.byteLength(chunk);
       if (outputBytes > maxOutputBytes) {
-        outputExceeded = true;
-        recordTerminalFailure(
-          createSpawnTextFailure({
-            detail: `output exceeded ${maxOutputBytes} bytes`,
-            failureMessage: options.failureMessage,
-            kind: "output-limit",
-            startedAt,
-          }),
-        );
+        fail("output-limit", `output exceeded ${maxOutputBytes} bytes`);
         requestStop();
         return;
       }
@@ -778,14 +779,10 @@ async function spawnText(
       failOutputStream("stderr", error);
     });
     child.once("error", (error) => {
-      const failure = recordTerminalFailure(
-        createSpawnTextFailure({
-          cause: error,
-          detail: error instanceof Error ? error.message : String(error),
-          failureMessage: options.failureMessage,
-          kind: "spawn-error",
-          startedAt,
-        }),
+      const failure = fail(
+        "spawn-error",
+        error instanceof Error ? error.message : String(error),
+        error,
       );
       settle(() => {
         reject(failure);
@@ -794,14 +791,7 @@ async function spawnText(
     child.once("close", (code, signal) => {
       const result = { code, signal };
       if (code !== 0 && !terminalFailure) {
-        recordTerminalFailure(
-          createSpawnTextFailure({
-            detail: stderr.trim() || (signal ? `terminated by ${signal}` : ""),
-            failureMessage: options.failureMessage,
-            kind: "nonzero-exit",
-            startedAt,
-          }),
-        );
+        fail("nonzero-exit", stderr.trim() || (signal ? `terminated by ${signal}` : ""));
       }
       if (processGroupIsAlive()) {
         childClosedResult = result;
@@ -831,9 +821,7 @@ async function renderBundledRootHelpText(
   }
   const bundleIdentity = resolveCliStartupRootHelpBundleIdentity(_distDirOverride);
   if (!bundleIdentity) {
-    throw new MissingBundledRootHelpError(
-      "No root-help bundle found in dist; cannot write CLI startup metadata.",
-    );
+    throw new Error("No root-help bundle found in dist; cannot write CLI startup metadata.");
   }
   const moduleUrl = pathToFileURL(path.join(_distDirOverride, bundleIdentity.bundleName)).href;
   const renderOptions = {
@@ -991,26 +979,11 @@ async function writeCliStartupMetadata(options?: {
   extensionsDir?: string;
   sourceRootDir?: string;
   renderBundledRootHelpText?: typeof renderBundledRootHelpText;
-  renderSourceRootHelpText?: (
-    renderContext: RootHelpRenderContext,
-    taskContext?: RenderTaskContext,
-  ) => Awaitable<string>;
-  renderSourceBrowserHelpText?: (
-    renderContext: RootHelpRenderContext,
-    taskContext?: RenderTaskContext,
-  ) => Awaitable<string>;
-  renderSourceSecretsHelpText?: (
-    renderContext: RootHelpRenderContext,
-    taskContext?: RenderTaskContext,
-  ) => Awaitable<string>;
-  renderSourceNodesHelpText?: (
-    renderContext: RootHelpRenderContext,
-    taskContext?: RenderTaskContext,
-  ) => Awaitable<string>;
-  renderSourceSubcommandHelpTextRecord?: (
-    renderContext: RootHelpRenderContext,
-    taskContext?: RenderTaskContext,
-  ) => Awaitable<PrecomputedSubcommandHelpText>;
+  renderSourceRootHelpText?: SourceHelpRenderer;
+  renderSourceBrowserHelpText?: SourceHelpRenderer;
+  renderSourceSecretsHelpText?: SourceHelpRenderer;
+  renderSourceNodesHelpText?: SourceHelpRenderer;
+  renderSourceSubcommandHelpTextRecord?: SourceHelpRenderer<PrecomputedSubcommandHelpText>;
 }): Promise<void> {
   const resolvedDistDir = options?.distDir ?? distDir;
   const resolvedOutputPath = options?.outputPath ?? outputPath;
@@ -1098,25 +1071,20 @@ async function writeCliStartupMetadata(options?: {
   const supervisor = new CliStartupMetadataRenderSupervisor();
   const rootHelpTextPromise = reusableRootHelpText
     ? Promise.resolve(reusableRootHelpText)
-    : supervisor.run(async (taskContext) => {
-        try {
-          return await (options?.renderBundledRootHelpText ?? renderBundledRootHelpText)(
-            resolvedDistDir,
-            renderContext,
-            taskContext,
-          );
-        } catch (error) {
-          if (!isMissingBundledRootHelpError(error)) {
-            throw error;
-          }
-          // Keep the fallback asynchronous: sibling help renders share this
-          // event loop, so blocking here can turn completed children into false timeouts.
-          return await (options?.renderSourceRootHelpText ?? renderSourceRootHelpText)(
-            renderContext,
-            taskContext,
-          );
-        }
-      });
+    : supervisor.run(async (taskContext) =>
+        bundleIdentity
+          ? (options?.renderBundledRootHelpText ?? renderBundledRootHelpText)(
+              resolvedDistDir,
+              renderContext,
+              taskContext,
+            )
+          : // Missing built metadata is the only source-fallback contract. A built
+            // renderer failure is terminal and must cancel the whole render group.
+            (options?.renderSourceRootHelpText ?? renderSourceRootHelpText)(
+              renderContext,
+              taskContext,
+            ),
+      );
   const hasCustomCommandRenderer =
     options?.renderSourceBrowserHelpText ||
     options?.renderSourceSecretsHelpText ||

--- a/scripts/write-cli-startup-metadata.ts
+++ b/scripts/write-cli-startup-metadata.ts
@@ -12,6 +12,7 @@ import fs, {
 import { availableParallelism, tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { toErrorObject } from "@openclaw/normalization-core/error-coercion";
 import pMap from "p-map";
 import type { RootHelpRenderOptions } from "../src/cli/program/root-help.js";
 import type { OpenClawConfig } from "../src/config/config.js";
@@ -96,9 +97,9 @@ type ExistingCliStartupMetadata = {
   subcommandHelpText?: unknown;
   rootHelpText?: unknown;
 };
-type SpawnTextParentSignalState = {
-  done: boolean;
-  signal: NodeJS.Signals | null;
+type RenderTaskContext = {
+  reportFailure: (error: unknown) => void;
+  signal: AbortSignal;
 };
 type KillableChild = {
   kill(signal: NodeJS.Signals): boolean;
@@ -110,15 +111,96 @@ type RunTaskkill = (
   options: { stdio: "ignore" },
 ) => { error?: unknown; status?: number | null } | undefined;
 
-const activeSpawnTextParentSignals = new Set<SpawnTextParentSignalState>();
+class MissingBundledRootHelpError extends Error {
+  readonly code = "CLI_STARTUP_ROOT_HELP_BUNDLE_MISSING";
+}
 
-function maybeReraiseSpawnTextParentSignal(signal: NodeJS.Signals): void {
-  for (const state of activeSpawnTextParentSignals) {
-    if (state.signal === null || !state.done) {
-      return;
+function isMissingBundledRootHelpError(error: unknown): error is MissingBundledRootHelpError {
+  return error instanceof MissingBundledRootHelpError;
+}
+
+class CliStartupMetadataRenderSupervisor {
+  readonly #abortController = new AbortController();
+  readonly #parentSignalHandlers: Array<{ handler: () => void; signal: NodeJS.Signals }> = [];
+  #firstFailure: Error | undefined;
+  #parentSignal: NodeJS.Signals | null = null;
+
+  constructor() {
+    const signals: NodeJS.Signals[] =
+      process.platform === "win32" ? ["SIGINT", "SIGTERM"] : ["SIGINT", "SIGTERM", "SIGHUP"];
+    for (const signal of signals) {
+      const handler = () => {
+        this.#parentSignal ??= signal;
+        if (!this.#abortController.signal.aborted) {
+          this.#abortController.abort(new Error(`CLI startup metadata interrupted by ${signal}`));
+        }
+      };
+      this.#parentSignalHandlers.push({ handler, signal });
+      process.once(signal, handler);
     }
   }
-  process.kill(process.pid, signal);
+
+  get firstFailure(): Error | undefined {
+    return this.#firstFailure;
+  }
+
+  get signal(): AbortSignal {
+    return this.#abortController.signal;
+  }
+
+  reportFailure(error: unknown): void {
+    if (this.#firstFailure || this.#parentSignal) {
+      return;
+    }
+    this.#firstFailure = toErrorObject(error, "CLI startup metadata render failed");
+    this.#abortController.abort(this.#firstFailure);
+  }
+
+  run<T>(render: (context: RenderTaskContext) => Awaitable<T>): Promise<T> {
+    return Promise.resolve()
+      .then(async () => {
+        if (this.signal.aborted) {
+          throw this.signal.reason ?? new Error("CLI startup metadata render aborted");
+        }
+        return await render({
+          reportFailure: (error) => this.reportFailure(error),
+          signal: this.signal,
+        });
+      })
+      .then(
+        (value) => value,
+        (error: unknown) => {
+          this.reportFailure(error);
+          throw error;
+        },
+      );
+  }
+
+  finish(primaryFailure: unknown, cleanupError?: unknown): never | void {
+    for (const { signal, handler } of this.#parentSignalHandlers) {
+      process.off(signal, handler);
+    }
+    this.#parentSignalHandlers.length = 0;
+    if (this.#parentSignal) {
+      process.kill(process.pid, this.#parentSignal);
+      return;
+    }
+    const failure =
+      this.#firstFailure ??
+      (primaryFailure
+        ? toErrorObject(primaryFailure, "CLI startup metadata render failed")
+        : undefined);
+    if (!failure) {
+      if (cleanupError) {
+        throw toErrorObject(cleanupError, "CLI startup metadata cleanup failed");
+      }
+      return;
+    }
+    if (cleanupError) {
+      Object.assign(failure, { cleanupError });
+    }
+    throw failure;
+  }
 }
 
 function signalWindowsProcessTree(
@@ -352,13 +434,24 @@ function withIsolatedRootHelpRenderContext<T>(
 async function settleRootHelpRenderPromises<T extends readonly unknown[]>(
   values: T,
   stateDir: string,
+  supervisor: CliStartupMetadataRenderSupervisor,
 ): Promise<{ -readonly [P in keyof T]: Awaited<T[P]> }> {
+  let result: { -readonly [P in keyof T]: Awaited<T[P]> } | undefined;
+  let primaryFailure: unknown;
   try {
-    return await Promise.all(values);
-  } finally {
-    await Promise.allSettled(values);
-    cleanupRootHelpRenderStateDir(stateDir);
+    result = await Promise.all(values);
+  } catch (error) {
+    primaryFailure = error;
   }
+  await Promise.allSettled(values);
+  let cleanupError: unknown;
+  try {
+    cleanupRootHelpRenderStateDir(stateDir);
+  } catch (error) {
+    cleanupError = error;
+  }
+  supervisor.finish(primaryFailure, cleanupError);
+  return result as { -readonly [P in keyof T]: Awaited<T[P]> };
 }
 
 function createIsolatedRootHelpRenderContext(
@@ -391,6 +484,32 @@ function createIsolatedRootHelpRenderContext(
   return { config, env };
 }
 
+function createSpawnTextFailure(params: {
+  cause?: unknown;
+  detail?: string;
+  failureMessage: string;
+  kind: "aborted" | "nonzero-exit" | "output-limit" | "spawn-error" | "stream-error" | "timeout";
+  startedAt: number;
+}): Error {
+  const elapsedMs = Date.now() - params.startedAt;
+  return Object.assign(
+    new Error(
+      `${params.failureMessage}${params.detail ? `: ${params.detail}` : ""} (elapsed ${elapsedMs}ms)`,
+      params.cause === undefined ? undefined : { cause: params.cause },
+    ),
+    {
+      code:
+        params.kind === "timeout"
+          ? "ETIMEDOUT"
+          : params.kind === "aborted"
+            ? "EABORTED"
+            : "ECLI_STARTUP_METADATA_RENDER",
+      elapsedMs,
+      renderFailureKind: params.kind,
+    },
+  );
+}
+
 async function spawnText(
   args: string[],
   options: {
@@ -399,6 +518,8 @@ async function spawnText(
     failureMessage: string;
     killGraceMs?: number;
     maxOutputBytes?: number;
+    onTerminalFailure?: (error: Error) => void;
+    signal?: AbortSignal;
     spawnProcess?: typeof spawn;
     timeoutMs: number;
   },
@@ -407,6 +528,16 @@ async function spawnText(
   const killGraceMs = options.killGraceMs ?? COMMAND_HELP_RENDER_KILL_GRACE_MS;
   const spawnProcess = options.spawnProcess ?? spawn;
   const useProcessGroup = process.platform !== "win32";
+  const startedAt = Date.now();
+  if (options.signal?.aborted) {
+    throw createSpawnTextFailure({
+      cause: options.signal.reason,
+      detail: "aborted before start",
+      failureMessage: options.failureMessage,
+      kind: "aborted",
+      startedAt,
+    });
+  }
   return await new Promise((resolve, reject) => {
     const child = spawnProcess(process.execPath, args, {
       cwd: options.cwd,
@@ -421,19 +552,12 @@ async function spawnText(
     let outputStreamError: { streamName: "stdout" | "stderr"; error: Error } | undefined;
     let settled = false;
     let timedOut = false;
+    let aborted = false;
+    let terminalFailure: Error | undefined;
     let waitingForKillGrace = false;
+    let forceKillInFlight = false;
     let childClosedResult: { code: number | null; signal: NodeJS.Signals | null } | null = null;
     let killTimer: ReturnType<typeof setTimeout> | undefined;
-    let parentSignalPending: NodeJS.Signals | null = null;
-    const parentSignalState: SpawnTextParentSignalState = { done: false, signal: null };
-    activeSpawnTextParentSignals.add(parentSignalState);
-    const parentSignalHandlers: { handler: () => void; signal: NodeJS.Signals }[] = [];
-    const cleanupParentSignalHandlers = () => {
-      for (const { signal, handler } of parentSignalHandlers) {
-        process.off(signal, handler);
-      }
-      parentSignalHandlers.length = 0;
-    };
     const signalChild = (signal: NodeJS.Signals) => {
       signalCliStartupMetadataProcessTree(child, signal, {
         appendDiagnostic: (message) => {
@@ -442,39 +566,6 @@ async function spawnText(
         useProcessGroup,
       });
     };
-    const relayParentSignal = (signal: NodeJS.Signals) => {
-      const handler = () => {
-        parentSignalPending = signal;
-        parentSignalState.signal = signal;
-        signalChild(signal);
-        cleanupParentSignalHandlers();
-        if (!processGroupIsAlive()) {
-          parentSignalState.done = true;
-          maybeReraiseSpawnTextParentSignal(signal);
-          return;
-        }
-        if (killTimer) {
-          clearTimeout(killTimer);
-        }
-        // Keep this timer ref'ed so parent signal relay waits long enough to
-        // force-kill stubborn detached descendants before re-raising.
-        waitingForKillGrace = true;
-        killTimer = setTimeout(() => {
-          waitingForKillGrace = false;
-          killTimer = undefined;
-          signalChild("SIGKILL");
-          parentSignalState.done = true;
-          maybeReraiseSpawnTextParentSignal(signal);
-        }, killGraceMs);
-      };
-      parentSignalHandlers.push({ handler, signal });
-      process.once(signal, handler);
-    };
-    if (useProcessGroup) {
-      relayParentSignal("SIGINT");
-      relayParentSignal("SIGTERM");
-      relayParentSignal("SIGHUP");
-    }
     const processGroupIsAlive = () => {
       if (!useProcessGroup || typeof child.pid !== "number") {
         return false;
@@ -486,50 +577,70 @@ async function spawnText(
         return (error as NodeJS.ErrnoException).code === "EPERM";
       }
     };
+    const waitForProcessGroupExit = async (timeoutMs: number) => {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        if (!processGroupIsAlive()) {
+          return true;
+        }
+        await new Promise((resolvePoll) => {
+          setTimeout(resolvePoll, 25);
+        });
+      }
+      return !processGroupIsAlive();
+    };
+    const recordTerminalFailure = (error: Error) => {
+      if (terminalFailure) {
+        return terminalFailure;
+      }
+      terminalFailure = error;
+      options.onTerminalFailure?.(error);
+      return error;
+    };
+    const abortListener = () => {
+      if (settled || terminalFailure) {
+        return;
+      }
+      aborted = true;
+      recordTerminalFailure(
+        createSpawnTextFailure({
+          cause: options.signal?.reason,
+          detail: "aborted after sibling failure",
+          failureMessage: options.failureMessage,
+          kind: "aborted",
+          startedAt,
+        }),
+      );
+      signalChild("SIGTERM");
+      scheduleKill();
+    };
     const settle = (callback: () => void) => {
       if (settled) {
         return;
       }
       settled = true;
       clearTimeout(timeout);
-      if (!parentSignalPending && killTimer) {
+      if (killTimer) {
         clearTimeout(killTimer);
       }
-      if (!parentSignalPending) {
-        activeSpawnTextParentSignals.delete(parentSignalState);
-      }
-      cleanupParentSignalHandlers();
+      options.signal?.removeEventListener("abort", abortListener);
       callback();
     };
     const finishClose = (result: { code: number | null; signal: NodeJS.Signals | null }) => {
       settle(() => {
-        if (outputStreamError) {
-          reject(
-            new Error(
-              `${options.failureMessage}: ${outputStreamError.streamName} read error: ${outputStreamError.error.message}`,
-              { cause: outputStreamError.error },
-            ),
-          );
-          return;
-        }
-        if (result.code === 0 && !timedOut && !outputExceeded) {
+        if (result.code === 0 && !terminalFailure && !timedOut && !outputExceeded && !aborted) {
           resolve(stdout);
           return;
         }
-        const detail = stderr.trim();
+        const detail = stderr.trim() || (result.signal ? `terminated by ${result.signal}` : "");
         reject(
-          new Error(
-            options.failureMessage +
-              (outputExceeded
-                ? `: output exceeded ${maxOutputBytes} bytes`
-                : timedOut
-                  ? `: timed out after ${options.timeoutMs}ms`
-                  : detail
-                    ? `: ${detail}`
-                    : result.signal
-                      ? `: terminated by ${result.signal}`
-                      : ""),
-          ),
+          terminalFailure ??
+            createSpawnTextFailure({
+              detail,
+              failureMessage: options.failureMessage,
+              kind: "nonzero-exit",
+              startedAt,
+            }),
         );
       });
     };
@@ -541,16 +652,52 @@ async function spawnText(
       killTimer = setTimeout(() => {
         waitingForKillGrace = false;
         killTimer = undefined;
+        forceKillInFlight = true;
         signalChild("SIGKILL");
-        if (childClosedResult) {
-          finishClose(childClosedResult);
-        }
+        const forceDrain = useProcessGroup
+          ? waitForProcessGroupExit(killGraceMs)
+          : Promise.resolve(true);
+        void forceDrain.then((drained) => {
+          forceKillInFlight = false;
+          if (!drained) {
+            recordTerminalFailure(
+              createSpawnTextFailure({
+                detail: `process group did not exit within ${killGraceMs}ms after SIGKILL`,
+                failureMessage: options.failureMessage,
+                kind: "nonzero-exit",
+                startedAt,
+              }),
+            );
+          }
+          if (childClosedResult) {
+            finishClose(childClosedResult);
+          }
+        });
       }, killGraceMs);
+      if (useProcessGroup) {
+        void waitForProcessGroupExit(killGraceMs).then((drained) => {
+          if (!drained || !waitingForKillGrace) {
+            return;
+          }
+          waitingForKillGrace = false;
+          if (killTimer) {
+            clearTimeout(killTimer);
+            killTimer = undefined;
+          }
+          if (childClosedResult) {
+            finishClose(childClosedResult);
+          }
+        });
+      }
     };
     const requestStop = () => {
       signalChild("SIGTERM");
       scheduleKill();
     };
+    options.signal?.addEventListener("abort", abortListener, { once: true });
+    if (options.signal?.aborted) {
+      abortListener();
+    }
     const failOutputStream = (streamName: "stdout" | "stderr", error: Error) => {
       // Keep the first stop cause: killing for a timeout or output cap can make
       // the stdio pipes fail secondarily while the child is shutting down.
@@ -558,10 +705,27 @@ async function spawnText(
         return;
       }
       outputStreamError = { streamName, error };
+      recordTerminalFailure(
+        createSpawnTextFailure({
+          cause: error,
+          detail: `${streamName} read error: ${error.message}`,
+          failureMessage: options.failureMessage,
+          kind: "stream-error",
+          startedAt,
+        }),
+      );
       requestStop();
     };
     const timeout = setTimeout(() => {
       timedOut = true;
+      recordTerminalFailure(
+        createSpawnTextFailure({
+          detail: `timed out after ${options.timeoutMs}ms`,
+          failureMessage: options.failureMessage,
+          kind: "timeout",
+          startedAt,
+        }),
+      );
       requestStop();
     }, options.timeoutMs);
     timeout.unref();
@@ -573,6 +737,14 @@ async function spawnText(
       outputBytes += Buffer.byteLength(chunk);
       if (outputBytes > maxOutputBytes) {
         outputExceeded = true;
+        recordTerminalFailure(
+          createSpawnTextFailure({
+            detail: `output exceeded ${maxOutputBytes} bytes`,
+            failureMessage: options.failureMessage,
+            kind: "output-limit",
+            startedAt,
+          }),
+        );
         requestStop();
         return;
       }
@@ -586,6 +758,14 @@ async function spawnText(
       outputBytes += Buffer.byteLength(chunk);
       if (outputBytes > maxOutputBytes) {
         outputExceeded = true;
+        recordTerminalFailure(
+          createSpawnTextFailure({
+            detail: `output exceeded ${maxOutputBytes} bytes`,
+            failureMessage: options.failureMessage,
+            kind: "output-limit",
+            startedAt,
+          }),
+        );
         requestStop();
         return;
       }
@@ -598,27 +778,36 @@ async function spawnText(
       failOutputStream("stderr", error);
     });
     child.once("error", (error) => {
+      const failure = recordTerminalFailure(
+        createSpawnTextFailure({
+          cause: error,
+          detail: error instanceof Error ? error.message : String(error),
+          failureMessage: options.failureMessage,
+          kind: "spawn-error",
+          startedAt,
+        }),
+      );
       settle(() => {
-        reject(error);
+        reject(failure);
       });
     });
     child.once("close", (code, signal) => {
       const result = { code, signal };
-      if (parentSignalPending) {
-        if (processGroupIsAlive()) {
-          childClosedResult = result;
-          return;
-        }
-        if (killTimer) {
-          clearTimeout(killTimer);
-          killTimer = undefined;
-        }
-        parentSignalState.done = true;
-        maybeReraiseSpawnTextParentSignal(parentSignalPending);
-        return;
+      if (code !== 0 && !terminalFailure) {
+        recordTerminalFailure(
+          createSpawnTextFailure({
+            detail: stderr.trim() || (signal ? `terminated by ${signal}` : ""),
+            failureMessage: options.failureMessage,
+            kind: "nonzero-exit",
+            startedAt,
+          }),
+        );
       }
-      if (waitingForKillGrace && processGroupIsAlive()) {
+      if (processGroupIsAlive()) {
         childClosedResult = result;
+        if (!waitingForKillGrace && !forceKillInFlight) {
+          requestStop();
+        }
         return;
       }
       finishClose(result);
@@ -629,6 +818,7 @@ async function spawnText(
 async function renderBundledRootHelpText(
   _distDirOverride: string = distDir,
   renderContext?: RootHelpRenderContext,
+  taskContext?: RenderTaskContext,
 ): Promise<string> {
   if (!renderContext) {
     const bundledPluginsDir = existsSync(path.join(_distDirOverride, "extensions"))
@@ -636,12 +826,14 @@ async function renderBundledRootHelpText(
       : extensionsDir;
     return await withIsolatedRootHelpRenderContext(
       bundledPluginsDir,
-      async (context) => await renderBundledRootHelpText(_distDirOverride, context),
+      async (context) => await renderBundledRootHelpText(_distDirOverride, context, taskContext),
     );
   }
   const bundleIdentity = resolveCliStartupRootHelpBundleIdentity(_distDirOverride);
   if (!bundleIdentity) {
-    throw new Error("No root-help bundle found in dist; cannot write CLI startup metadata.");
+    throw new MissingBundledRootHelpError(
+      "No root-help bundle found in dist; cannot write CLI startup metadata.",
+    );
   }
   const moduleUrl = pathToFileURL(path.join(_distDirOverride, bundleIdentity.bundleName)).href;
   const renderOptions = {
@@ -661,13 +853,21 @@ async function renderBundledRootHelpText(
     // RootHelpRenderOptions marks env optional; spawnText requires one.
     env: renderContext.env ?? process.env,
     failureMessage: `Failed to render bundled root help from ${bundleIdentity.bundleName}`,
+    onTerminalFailure: taskContext?.reportFailure,
+    signal: taskContext?.signal,
     timeoutMs: ROOT_HELP_RENDER_TIMEOUT_MS,
   });
 }
 
-async function renderSourceRootHelpText(renderContext?: RootHelpRenderContext): Promise<string> {
+async function renderSourceRootHelpText(
+  renderContext?: RootHelpRenderContext,
+  taskContext?: RenderTaskContext,
+): Promise<string> {
   if (!renderContext) {
-    return await withIsolatedRootHelpRenderContext(extensionsDir, renderSourceRootHelpText);
+    return await withIsolatedRootHelpRenderContext(
+      extensionsDir,
+      async (context) => await renderSourceRootHelpText(context, taskContext),
+    );
   }
   const moduleUrl = pathToFileURL(path.join(rootDir, "src/cli/program/root-help.ts")).href;
   const renderOptions = {
@@ -688,21 +888,27 @@ async function renderSourceRootHelpText(renderContext?: RootHelpRenderContext): 
     cwd: rootDir,
     env: renderContext.env ?? process.env,
     failureMessage: "Failed to render source root help",
+    onTerminalFailure: taskContext?.reportFailure,
+    signal: taskContext?.signal,
     timeoutMs: ROOT_HELP_RENDER_TIMEOUT_MS,
   });
 }
 
-async function renderSourceBrowserHelpText(renderContext: RootHelpRenderContext): Promise<string> {
+async function renderSourceBrowserHelpText(
+  renderContext: RootHelpRenderContext,
+  taskContext?: RenderTaskContext,
+): Promise<string> {
   // The launcher CLI boot renders byte-identical browser help to a direct
   // tsx source render (registerBrowserCli + configureProgramHelp) while
   // avoiding a tsx evaluation of the whole browser CLI import graph, which
   // dominated this script's wall time.
-  return await renderSourceCommandHelpText("browser", renderContext);
+  return await renderSourceCommandHelpText("browser", renderContext, taskContext);
 }
 
 async function renderSourceCommandHelpText(
   command: SourceCommandHelpCommand,
   renderContext: RootHelpRenderContext,
+  taskContext?: RenderTaskContext,
 ): Promise<string> {
   return await spawnText(["openclaw.mjs", command, "--help"], {
     cwd: rootDir,
@@ -711,41 +917,65 @@ async function renderSourceCommandHelpText(
       OPENCLAW_DISABLE_CLI_STARTUP_HELP_FAST_PATH: "1",
     },
     failureMessage: `Failed to render source ${command} help`,
+    onTerminalFailure: taskContext?.reportFailure,
+    signal: taskContext?.signal,
     timeoutMs: COMMAND_HELP_RENDER_TIMEOUT_MS,
   });
 }
 
-async function renderSourceSecretsHelpText(renderContext: RootHelpRenderContext): Promise<string> {
-  return await renderSourceCommandHelpText("secrets", renderContext);
+async function renderSourceSecretsHelpText(
+  renderContext: RootHelpRenderContext,
+  taskContext?: RenderTaskContext,
+): Promise<string> {
+  return await renderSourceCommandHelpText("secrets", renderContext, taskContext);
 }
 
-async function renderSourceNodesHelpText(renderContext: RootHelpRenderContext): Promise<string> {
-  return await renderSourceCommandHelpText("nodes", renderContext);
+async function renderSourceNodesHelpText(
+  renderContext: RootHelpRenderContext,
+  taskContext?: RenderTaskContext,
+): Promise<string> {
+  return await renderSourceCommandHelpText("nodes", renderContext, taskContext);
 }
 
 async function renderSourceCommandHelpTextRecord(
   commands: readonly SourceCommandHelpCommand[],
   renderContext: RootHelpRenderContext,
+  supervisor: CliStartupMetadataRenderSupervisor,
 ): Promise<SourceCommandHelpText> {
-  const helpTexts = await pMap(
+  const helpTexts: Partial<Record<SourceCommandHelpCommand, string>> = {};
+  await pMap(
     commands,
-    async (commandName) => await renderSourceCommandHelpText(commandName, renderContext),
+    async (commandName) => {
+      if (supervisor.signal.aborted) {
+        return;
+      }
+      try {
+        helpTexts[commandName] = await supervisor.run(async (taskContext) =>
+          renderSourceCommandHelpText(commandName, renderContext, taskContext),
+        );
+      } catch {
+        // Keep the mapper fulfilled so p-map waits for every active process-tree drain.
+      }
+    },
     {
       concurrency: COMMAND_HELP_RENDER_CONCURRENCY,
-      stopOnError: true,
+      stopOnError: false,
     },
   );
-  return Object.fromEntries(
-    commands.map((commandName, index) => [commandName, helpTexts[index]]),
-  ) as SourceCommandHelpText;
+  if (supervisor.signal.aborted) {
+    throw supervisor.firstFailure ?? supervisor.signal.reason;
+  }
+  return helpTexts as SourceCommandHelpText;
 }
 
 async function renderSourceSubcommandHelpTextRecord(
   renderContext: RootHelpRenderContext,
+  supervisor: CliStartupMetadataRenderSupervisor,
 ): Promise<PrecomputedSubcommandHelpText> {
   const commandHelpText = await renderSourceCommandHelpTextRecord(
     PRECOMPUTED_SUBCOMMAND_HELP_COMMANDS,
     renderContext,
+    supervisor,
   );
   return Object.fromEntries(
     PRECOMPUTED_SUBCOMMAND_HELP_COMMANDS.map((commandName) => [
@@ -761,12 +991,25 @@ async function writeCliStartupMetadata(options?: {
   extensionsDir?: string;
   sourceRootDir?: string;
   renderBundledRootHelpText?: typeof renderBundledRootHelpText;
-  renderSourceRootHelpText?: (renderContext: RootHelpRenderContext) => Awaitable<string>;
-  renderSourceBrowserHelpText?: (renderContext: RootHelpRenderContext) => Awaitable<string>;
-  renderSourceSecretsHelpText?: (renderContext: RootHelpRenderContext) => Awaitable<string>;
-  renderSourceNodesHelpText?: (renderContext: RootHelpRenderContext) => Awaitable<string>;
+  renderSourceRootHelpText?: (
+    renderContext: RootHelpRenderContext,
+    taskContext?: RenderTaskContext,
+  ) => Awaitable<string>;
+  renderSourceBrowserHelpText?: (
+    renderContext: RootHelpRenderContext,
+    taskContext?: RenderTaskContext,
+  ) => Awaitable<string>;
+  renderSourceSecretsHelpText?: (
+    renderContext: RootHelpRenderContext,
+    taskContext?: RenderTaskContext,
+  ) => Awaitable<string>;
+  renderSourceNodesHelpText?: (
+    renderContext: RootHelpRenderContext,
+    taskContext?: RenderTaskContext,
+  ) => Awaitable<string>;
   renderSourceSubcommandHelpTextRecord?: (
     renderContext: RootHelpRenderContext,
+    taskContext?: RenderTaskContext,
   ) => Awaitable<PrecomputedSubcommandHelpText>;
 }): Promise<void> {
   const resolvedDistDir = options?.distDir ?? distDir;
@@ -852,22 +1095,28 @@ async function writeCliStartupMetadata(options?: {
     existsSync(bundledPluginsDir) ? bundledPluginsDir : resolvedExtensionsDir,
     renderStateDir,
   );
+  const supervisor = new CliStartupMetadataRenderSupervisor();
   const rootHelpTextPromise = reusableRootHelpText
     ? Promise.resolve(reusableRootHelpText)
-    : (async () => {
+    : supervisor.run(async (taskContext) => {
         try {
           return await (options?.renderBundledRootHelpText ?? renderBundledRootHelpText)(
             resolvedDistDir,
             renderContext,
+            taskContext,
           );
-        } catch {
+        } catch (error) {
+          if (!isMissingBundledRootHelpError(error)) {
+            throw error;
+          }
           // Keep the fallback asynchronous: sibling help renders share this
           // event loop, so blocking here can turn completed children into false timeouts.
           return await (options?.renderSourceRootHelpText ?? renderSourceRootHelpText)(
             renderContext,
+            taskContext,
           );
         }
-      })();
+      });
   const hasCustomCommandRenderer =
     options?.renderSourceBrowserHelpText ||
     options?.renderSourceSecretsHelpText ||
@@ -889,27 +1138,36 @@ async function writeCliStartupMetadata(options?: {
   const commandHelpTextPromise =
     hasCustomCommandRenderer || sourceCommandsToRender.length === 0
       ? null
-      : renderSourceCommandHelpTextRecord(sourceCommandsToRender, renderContext);
+      : renderSourceCommandHelpTextRecord(sourceCommandsToRender, renderContext, supervisor);
   const browserHelpTextPromise = reusableBrowserHelpText
     ? Promise.resolve(reusableBrowserHelpText)
     : commandHelpTextPromise
       ? commandHelpTextPromise.then((commandHelpText) => commandHelpText.browser)
-      : Promise.resolve().then(() =>
-          (options?.renderSourceBrowserHelpText ?? renderSourceBrowserHelpText)(renderContext),
+      : supervisor.run((taskContext) =>
+          (options?.renderSourceBrowserHelpText ?? renderSourceBrowserHelpText)(
+            renderContext,
+            taskContext,
+          ),
         );
   const secretsHelpTextPromise = reusableSecretsHelpText
     ? Promise.resolve(reusableSecretsHelpText)
     : commandHelpTextPromise
       ? commandHelpTextPromise.then((commandHelpText) => commandHelpText.secrets)
-      : Promise.resolve().then(() =>
-          (options?.renderSourceSecretsHelpText ?? renderSourceSecretsHelpText)(renderContext),
+      : supervisor.run((taskContext) =>
+          (options?.renderSourceSecretsHelpText ?? renderSourceSecretsHelpText)(
+            renderContext,
+            taskContext,
+          ),
         );
   const nodesHelpTextPromise = reusableNodesHelpText
     ? Promise.resolve(reusableNodesHelpText)
     : commandHelpTextPromise
       ? commandHelpTextPromise.then((commandHelpText) => commandHelpText.nodes)
-      : Promise.resolve().then(() =>
-          (options?.renderSourceNodesHelpText ?? renderSourceNodesHelpText)(renderContext),
+      : supervisor.run((taskContext) =>
+          (options?.renderSourceNodesHelpText ?? renderSourceNodesHelpText)(
+            renderContext,
+            taskContext,
+          ),
         );
   const subcommandHelpTextPromise = reusableSubcommandHelpText
     ? Promise.resolve(reusableSubcommandHelpText)
@@ -923,11 +1181,11 @@ async function writeCliStartupMetadata(options?: {
               ]),
             ) as PrecomputedSubcommandHelpText,
         )
-      : Promise.resolve().then(() =>
-          (options?.renderSourceSubcommandHelpTextRecord ?? renderSourceSubcommandHelpTextRecord)(
-            renderContext,
-          ),
-        );
+      : options?.renderSourceSubcommandHelpTextRecord
+        ? supervisor.run((taskContext) =>
+            options.renderSourceSubcommandHelpTextRecord!(renderContext, taskContext),
+          )
+        : renderSourceSubcommandHelpTextRecord(renderContext, supervisor);
   const [rootHelpText, browserHelpText, secretsHelpText, nodesHelpText, subcommandHelpText] =
     await settleRootHelpRenderPromises(
       [
@@ -938,6 +1196,7 @@ async function writeCliStartupMetadata(options?: {
         subcommandHelpTextPromise,
       ] as const,
       renderStateDir,
+      supervisor,
     );
 
   mkdirSync(resolvedDistDir, { recursive: true });
@@ -986,5 +1245,4 @@ export const testing = {
 
 if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
   await writeCliStartupMetadata();
-  process.exit(0);
 }

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -344,6 +344,11 @@ describe("openclaw launcher", () => {
       JSON.stringify({ rootHelpText: "PRECOMPUTED help\n" }),
       "utf8",
     );
+    await fs.writeFile(
+      path.join(fixtureRoot, "dist", "entry.js"),
+      "throw new Error('root help fast path must not import runtime resource owners');\n",
+      "utf8",
+    );
 
     const result = spawnSync(process.execPath, [path.join(fixtureRoot, "openclaw.mjs"), "--help"], {
       cwd: fixtureRoot,
@@ -364,6 +369,11 @@ describe("openclaw launcher", () => {
     await fs.writeFile(
       path.join(fixtureRoot, "dist", "cli-startup-metadata.json"),
       JSON.stringify({ [params.metadataKey]: `PRECOMPUTED ${params.command} help\n` }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(fixtureRoot, "dist", "entry.js"),
+      "throw new Error('command help fast path must not import runtime resource owners');\n",
       "utf8",
     );
 
@@ -388,6 +398,11 @@ describe("openclaw launcher", () => {
       await fs.writeFile(
         path.join(fixtureRoot, "dist", "cli-startup-metadata.json"),
         JSON.stringify({ subcommandHelpText: { [command]: `PRECOMPUTED ${command} help\n` } }),
+        "utf8",
+      );
+      await fs.writeFile(
+        path.join(fixtureRoot, "dist", "entry.js"),
+        "throw new Error('subcommand help fast path must not import runtime resource owners');\n",
         "utf8",
       );
 

--- a/test/scripts/write-cli-startup-metadata.test.ts
+++ b/test/scripts/write-cli-startup-metadata.test.ts
@@ -2,6 +2,7 @@
 import { spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
 import fs, { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { availableParallelism } from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 import { pathToFileURL } from "node:url";
@@ -17,6 +18,18 @@ vi.mock("node:child_process", async (importOriginal) => {
 
 // These subprocess tests use explicit ready/close signals; timeout only catches broken fixtures.
 const LOAD_SENSITIVE_PROCESS_TIMEOUT_MS = process.env.CI ? 30_000 : 15_000;
+const COMMAND_HELP_RENDER_CONCURRENCY = Math.min(8, Math.max(2, availableParallelism()));
+const DEFAULT_COMMAND_HELP_NAMES = [
+  "browser",
+  "secrets",
+  "nodes",
+  "doctor",
+  "gateway",
+  "models",
+  "plugins",
+  "sessions",
+  "tasks",
+] as const;
 
 function writeFixtureFile(rootDir: string, relativePath: string, contents: string): void {
   const filePath = path.join(rootDir, relativePath);
@@ -79,7 +92,7 @@ function expectedTaskkillPath(): string {
 
 function createSpawnTextChild() {
   return Object.assign(new EventEmitter(), {
-    kill: vi.fn(() => true),
+    kill: vi.fn((_signal?: NodeJS.Signals) => true),
     stderr: new PassThrough(),
     stdout: new PassThrough(),
   });
@@ -188,7 +201,9 @@ describe("write-cli-startup-metadata", () => {
       child.emit("close", null, "SIGTERM");
 
       await expect(render).rejects.toMatchObject({
-        message: `render failed: ${streamName} read error: ${streamName} pipe failed`,
+        message: expect.stringContaining(
+          `render failed: ${streamName} read error: ${streamName} pipe failed`,
+        ),
         cause: streamError,
       });
       expect(child.kill).toHaveBeenCalledWith("SIGTERM");
@@ -214,6 +229,187 @@ describe("write-cli-startup-metadata", () => {
 
     await expect(render).rejects.toThrow("render failed: output exceeded 5 bytes");
   });
+
+  it("aborts and drains the default command batch before removing shared state", async () => {
+    const actualSpawn = (
+      await vi.importActual<typeof import("node:child_process")>("node:child_process")
+    ).spawn;
+    const spawnMock = vi.mocked(spawn);
+    const tempRoot = createTempDir("openclaw-startup-metadata-batch-failure-");
+    const distDir = path.join(tempRoot, "dist");
+    const extensionsDir = path.join(tempRoot, "extensions");
+    const outputPath = path.join(distDir, "cli-startup-metadata.json");
+    const events: string[] = [];
+    const children: Array<ReturnType<typeof createSpawnTextChild> & { commandName: string }> = [];
+    const realRmSync = fs.rmSync.bind(fs);
+    const removeState = vi.spyOn(fs, "rmSync").mockImplementation((target, options) => {
+      events.push("cleanup");
+      return realRmSync(target, options);
+    });
+
+    writeStartupMetadataSourceSignatureFixture(tempRoot);
+    writeFixtureFile(distDir, "root-help-fixture.js", "export function outputRootHelp() {}\n");
+
+    spawnMock.mockImplementation((_command, args) => {
+      const commandName = String(args[1]);
+      const child = Object.assign(createSpawnTextChild(), { commandName });
+      child.kill.mockImplementation((signal) => {
+        events.push(`kill:${commandName}:${signal}`);
+        queueMicrotask(() => {
+          events.push(`close:${commandName}`);
+          child.emit("close", null, signal);
+        });
+        return true;
+      });
+      children.push(child);
+      return child as unknown as ReturnType<typeof spawn>;
+    });
+
+    try {
+      const writePromise = testing.writeCliStartupMetadata({
+        distDir,
+        outputPath,
+        extensionsDir,
+        sourceRootDir: tempRoot,
+        renderBundledRootHelpText: async () => "Usage: openclaw\n",
+      });
+      const deadline = Date.now() + 1_000;
+      while (children.length < COMMAND_HELP_RENDER_CONCURRENCY && Date.now() < deadline) {
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+      expect(children.map((child) => child.commandName)).toEqual(
+        DEFAULT_COMMAND_HELP_NAMES.slice(0, COMMAND_HELP_RENDER_CONCURRENCY),
+      );
+
+      const browser = children[0];
+      expect(browser).toBeDefined();
+      browser?.stderr.write("browser renderer failed\n");
+      browser?.emit("close", 7, null);
+
+      const error = await writePromise.then(
+        () => undefined,
+        (reason: unknown) => reason,
+      );
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain("Failed to render source browser help");
+      expect((error as Error).message).toContain("browser renderer failed");
+      expect((error as Error).message).toMatch(/browser renderer failed \(elapsed \d+ms\)/u);
+      expect(children.map((child) => child.commandName)).not.toContain("tasks");
+      for (const child of children.slice(1)) {
+        expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+        expect(events).toContain(`close:${child.commandName}`);
+      }
+      expect(events.at(-1)).toBe("cleanup");
+      expect(existsSync(outputPath)).toBe(false);
+    } finally {
+      removeState.mockRestore();
+      spawnMock.mockImplementation(actualSpawn);
+    }
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "cancels a default-batch sibling process tree after another command fails",
+    async () => {
+      const actualSpawn = (
+        await vi.importActual<typeof import("node:child_process")>("node:child_process")
+      ).spawn;
+      const spawnMock = vi.mocked(spawn);
+      const tempRoot = createTempDir("openclaw-startup-metadata-batch-tree-");
+      const distDir = path.join(tempRoot, "dist");
+      const extensionsDir = path.join(tempRoot, "extensions");
+      const outputPath = path.join(distDir, "cli-startup-metadata.json");
+      const grandchildPidPath = path.join(tempRoot, "grandchild.pid");
+      const startedCommands: string[] = [];
+      const startedChildren: Array<ReturnType<typeof spawn>> = [];
+      let grandchildPid = 0;
+
+      writeStartupMetadataSourceSignatureFixture(tempRoot);
+      writeFixtureFile(distDir, "root-help-fixture.js", "export function outputRootHelp() {}\n");
+
+      const failingScript = [
+        "const { existsSync } = await import('node:fs');",
+        `const marker = ${JSON.stringify(grandchildPidPath)};`,
+        "const timer = setInterval(() => {",
+        "  if (!existsSync(marker)) return;",
+        "  clearInterval(timer);",
+        "  process.stderr.write('browser sentinel failure\\n', () => process.exit(9));",
+        "}, 5);",
+      ].join("\n");
+      const grandchildScript = [
+        "process.on('SIGTERM', () => setTimeout(() => process.exit(0), 50));",
+        "setInterval(() => {}, 1000);",
+      ].join("\n");
+      const siblingScript = [
+        "const { spawn } = await import('node:child_process');",
+        "const { writeFileSync } = await import('node:fs');",
+        `const grandchild = spawn(process.execPath, ["--eval", ${JSON.stringify(grandchildScript)}], { stdio: "ignore" });`,
+        `writeFileSync(${JSON.stringify(grandchildPidPath)}, String(grandchild.pid));`,
+        "process.on('SIGTERM', () => setTimeout(() => process.exit(0), 100));",
+        "setInterval(() => {}, 1000);",
+      ].join("\n");
+      const idleScript = [
+        "process.on('SIGTERM', () => process.exit(0));",
+        "setInterval(() => {}, 1000);",
+      ].join("\n");
+
+      spawnMock.mockImplementation((_command, args, options) => {
+        const commandName = String(args[1]);
+        startedCommands.push(commandName);
+        const script =
+          commandName === "browser"
+            ? failingScript
+            : commandName === "secrets"
+              ? siblingScript
+              : idleScript;
+        const child = actualSpawn(
+          process.execPath,
+          ["--input-type=module", "--eval", script],
+          options,
+        );
+        startedChildren.push(child);
+        return child;
+      });
+
+      try {
+        const startedAt = Date.now();
+        const error = await testing
+          .writeCliStartupMetadata({
+            distDir,
+            outputPath,
+            extensionsDir,
+            sourceRootDir: tempRoot,
+            renderBundledRootHelpText: async () => "Usage: openclaw\n",
+          })
+          .then(
+            () => undefined,
+            (reason: unknown) => reason,
+          );
+
+        grandchildPid = Number(readFileSync(grandchildPidPath, "utf8"));
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toContain("browser sentinel failure");
+        expect(Date.now() - startedAt).toBeLessThan(LOAD_SENSITIVE_PROCESS_TIMEOUT_MS);
+        expect(startedCommands).toHaveLength(COMMAND_HELP_RENDER_CONCURRENCY);
+        expect(startedCommands).not.toContain("tasks");
+        await waitForProcessExit(grandchildPid);
+        expect(existsSync(outputPath)).toBe(false);
+      } finally {
+        spawnMock.mockImplementation(actualSpawn);
+        for (const child of startedChildren) {
+          if (child.pid && processIsAlive(child.pid)) {
+            try {
+              process.kill(-child.pid, "SIGKILL");
+            } catch {}
+          }
+        }
+        if (grandchildPid > 0 && processIsAlive(grandchildPid)) {
+          try {
+            process.kill(grandchildPid, "SIGKILL");
+          } catch {}
+        }
+      }
+    },
+  );
 
   it("signals Windows command help render process trees with taskkill", () => {
     const childKill = vi.fn(() => true);
@@ -303,6 +499,39 @@ describe("write-cli-startup-metadata", () => {
   );
 
   it.runIf(process.platform !== "win32")(
+    "drains descendants when a command leader exits nonzero",
+    async () => {
+      const tempRoot = createTempDir("openclaw-startup-metadata-nonzero-tree-");
+      const markerPath = path.join(tempRoot, "grandchild.pid");
+      const grandchildScript = [
+        "process.on('SIGTERM', () => {});",
+        "setInterval(() => {}, 1000);",
+      ].join("\n");
+      const parentScript = [
+        "const { spawn } = await import('node:child_process');",
+        "const { writeFileSync } = await import('node:fs');",
+        `const grandchild = spawn(process.execPath, ["--eval", ${JSON.stringify(grandchildScript)}], { stdio: "ignore" });`,
+        `writeFileSync(${JSON.stringify(markerPath)}, String(grandchild.pid));`,
+        "process.stderr.write('leader failed\\n', () => process.exit(7));",
+      ].join("\n");
+
+      await expect(
+        testing.spawnText(["--input-type=module", "--eval", parentScript], {
+          cwd: tempRoot,
+          env: process.env,
+          failureMessage: "render failed",
+          killGraceMs: 25,
+          maxOutputBytes: 1024,
+          timeoutMs: 5_000,
+        }),
+      ).rejects.toThrow(/render failed: leader failed.*elapsed \d+ms/u);
+
+      const grandchildPid = Number(readFileSync(markerPath, "utf8"));
+      await waitForProcessExit(grandchildPid);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "waits for all command help descendants before re-raising parent signals",
     async () => {
       const tempRoot = createTempDir("openclaw-startup-metadata-signal-");
@@ -311,6 +540,9 @@ describe("write-cli-startup-metadata", () => {
       const commandPath = path.join(tempRoot, "command.mjs");
       const runnerPath = path.join(tempRoot, "runner.mjs");
       const grandchildPidPath = path.join(tempRoot, "grandchild.pid");
+      const renderStatePath = path.join(tempRoot, "render-state.txt");
+      const distDir = path.join(tempRoot, "dist");
+      const outputPath = path.join(distDir, "cli-startup-metadata.json");
       const grandchildScript = [
         "process.on('SIGTERM', () => {});",
         "setInterval(() => {}, 1000);",
@@ -339,6 +571,8 @@ describe("write-cli-startup-metadata", () => {
           "setInterval(() => {}, 1000);",
         ].join("\n"),
       );
+      writeStartupMetadataSourceSignatureFixture(tempRoot);
+      writeFixtureFile(distDir, "root-help-fixture.js", "export function outputRootHelp() {}\n");
       writeFixtureFile(
         tempRoot,
         "runner.mjs",
@@ -346,28 +580,36 @@ describe("write-cli-startup-metadata", () => {
           `const { testing } = await import(${JSON.stringify(
             pathToFileURL(path.resolve("scripts/write-cli-startup-metadata.ts")).href,
           )});`,
-          "void testing.spawnText(",
-          `  [${JSON.stringify(fastCommandPath)}],`,
-          "  {",
+          "const { writeFileSync } = await import('node:fs');",
+          "const renderCommand = (commandPath, failureMessage) => (context, taskContext) => {",
+          "  if (!taskContext) throw new Error('missing render task context');",
+          `  writeFileSync(${JSON.stringify(renderStatePath)}, context.env.OPENCLAW_STATE_DIR);`,
+          "  return testing.spawnText([commandPath], {",
           `    cwd: ${JSON.stringify(tempRoot)},`,
           "    env: process.env,",
-          "    failureMessage: 'fast render failed',",
+          "    failureMessage,",
           "    killGraceMs: 100,",
           "    maxOutputBytes: 1024,",
+          "    onTerminalFailure: taskContext.reportFailure,",
+          "    signal: taskContext.signal,",
           "    timeoutMs: 30_000,",
-          "  },",
-          ").catch(() => undefined);",
-          "void testing.spawnText(",
-          `  [${JSON.stringify(commandPath)}],`,
-          "  {",
-          `    cwd: ${JSON.stringify(tempRoot)},`,
-          "    env: process.env,",
-          "    failureMessage: 'render failed',",
-          "    killGraceMs: 100,",
-          "    maxOutputBytes: 1024,",
-          "    timeoutMs: 30_000,",
-          "  },",
-          ").catch(() => undefined);",
+          "  });",
+          "};",
+          "await testing.writeCliStartupMetadata({",
+          `  distDir: ${JSON.stringify(distDir)},`,
+          `  outputPath: ${JSON.stringify(outputPath)},`,
+          `  extensionsDir: ${JSON.stringify(path.join(tempRoot, "extensions"))},`,
+          `  sourceRootDir: ${JSON.stringify(tempRoot)},`,
+          "  renderBundledRootHelpText: async () => 'Usage: openclaw\\n',",
+          `  renderSourceBrowserHelpText: renderCommand(${JSON.stringify(fastCommandPath)}, 'fast render failed'),`,
+          `  renderSourceSecretsHelpText: renderCommand(${JSON.stringify(commandPath)}, 'render failed'),`,
+          "  renderSourceNodesHelpText: () => 'Usage: openclaw nodes\\n',",
+          "  renderSourceSubcommandHelpTextRecord: () => ({",
+          "    doctor: 'Usage: openclaw doctor\\n', gateway: 'Usage: openclaw gateway\\n',",
+          "    models: 'Usage: openclaw models\\n', plugins: 'Usage: openclaw plugins\\n',",
+          "    sessions: 'Usage: openclaw sessions\\n', tasks: 'Usage: openclaw tasks\\n',",
+          "  }),",
+          "});",
         ].join("\n"),
       );
 
@@ -405,6 +647,8 @@ describe("write-cli-startup-metadata", () => {
           signal: "SIGTERM",
         });
         await waitForProcessExit(grandchildPid);
+        const renderStateDir = readFileSync(renderStatePath, "utf8");
+        expect(existsSync(renderStateDir)).toBe(false);
       } finally {
         if (runner.pid && processIsAlive(runner.pid)) {
           runner.kill("SIGKILL");
@@ -442,9 +686,6 @@ describe("write-cli-startup-metadata", () => {
       distDir,
       outputPath,
       extensionsDir,
-      renderBundledRootHelpText: async () => {
-        throw new Error("dist root help unavailable");
-      },
       renderSourceRootHelpText: () => "Usage: openclaw\n",
       renderSourceBrowserHelpText: () => "Usage: openclaw browser\n",
       renderSourceSecretsHelpText: () => "Usage: openclaw secrets\n",
@@ -491,6 +732,49 @@ describe("write-cli-startup-metadata", () => {
     expect(written.subcommandHelpText.plugins).toContain("openclaw plugins");
     expect(written.subcommandHelpText.sessions).toContain("openclaw sessions");
     expect(written.subcommandHelpText.tasks).toContain("openclaw tasks");
+  });
+
+  it("does not source-fallback a bundled root resource failure", async () => {
+    const tempRoot = createTempDir("openclaw-startup-metadata-root-resource-failure-");
+    const distDir = path.join(tempRoot, "dist");
+    const extensionsDir = path.join(tempRoot, "extensions");
+    const outputPath = path.join(distDir, "cli-startup-metadata.json");
+    const renderSourceRootHelpText = vi.fn(() => "Usage: source fallback\n");
+
+    writeStartupMetadataSourceSignatureFixture(tempRoot);
+    writeFixtureFile(distDir, "root-help-fixture.js", "export function outputRootHelp() {}\n");
+
+    const error = await testing
+      .writeCliStartupMetadata({
+        distDir,
+        outputPath,
+        extensionsDir,
+        sourceRootDir: tempRoot,
+        renderBundledRootHelpText: async () => {
+          throw Object.assign(new Error("bundled root timed out"), { code: "ETIMEDOUT" });
+        },
+        renderSourceRootHelpText,
+        renderSourceBrowserHelpText: () => "Usage: openclaw browser\n",
+        renderSourceSecretsHelpText: () => "Usage: openclaw secrets\n",
+        renderSourceNodesHelpText: () => "Usage: openclaw nodes\n",
+        renderSourceSubcommandHelpTextRecord: () => ({
+          doctor: "Usage: openclaw doctor\n",
+          gateway: "Usage: openclaw gateway\n",
+          models: "Usage: openclaw models\n",
+          plugins: "Usage: openclaw plugins\n",
+          sessions: "Usage: openclaw sessions\n",
+          tasks: "Usage: openclaw tasks\n",
+        }),
+      })
+      .then(
+        () => undefined,
+        (reason: unknown) => reason,
+      );
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("bundled root timed out");
+    expect(renderSourceRootHelpText).not.toHaveBeenCalled();
+    expect(existsSync(outputPath)).toBe(false);
   });
 
   it("selects the root-help bundle that exports the renderer", async () => {
@@ -682,6 +966,63 @@ describe("write-cli-startup-metadata", () => {
       retryDelay: 25,
     });
     removeState.mockRestore();
+  });
+
+  it("does not let shared-state cleanup mask the primary render failure", async () => {
+    const tempRoot = createTempDir("openclaw-startup-metadata-cleanup-failure-");
+    const distDir = path.join(tempRoot, "dist");
+    const extensionsDir = path.join(tempRoot, "extensions");
+    const outputPath = path.join(distDir, "cli-startup-metadata.json");
+    const cleanupFailure = new Error("cleanup failed");
+    const realRmSync = fs.rmSync.bind(fs);
+    let renderStateDir = "";
+    const removeState = vi.spyOn(fs, "rmSync").mockImplementation((target, options) => {
+      if (String(target) === renderStateDir) {
+        throw cleanupFailure;
+      }
+      return realRmSync(target, options);
+    });
+
+    writeStartupMetadataSourceSignatureFixture(tempRoot);
+    writeFixtureFile(distDir, "root-help-fixture.js", "export function outputRootHelp() {}\n");
+
+    try {
+      const error = await testing
+        .writeCliStartupMetadata({
+          distDir,
+          outputPath,
+          extensionsDir,
+          sourceRootDir: tempRoot,
+          renderBundledRootHelpText: async () => "Usage: openclaw\n",
+          renderSourceBrowserHelpText: (renderContext) => {
+            renderStateDir = renderContext.env?.OPENCLAW_STATE_DIR ?? "";
+            throw new Error("primary browser failure");
+          },
+          renderSourceSecretsHelpText: () => "Usage: openclaw secrets\n",
+          renderSourceNodesHelpText: () => "Usage: openclaw nodes\n",
+          renderSourceSubcommandHelpTextRecord: () => ({
+            doctor: "Usage: openclaw doctor\n",
+            gateway: "Usage: openclaw gateway\n",
+            models: "Usage: openclaw models\n",
+            plugins: "Usage: openclaw plugins\n",
+            sessions: "Usage: openclaw sessions\n",
+            tasks: "Usage: openclaw tasks\n",
+          }),
+        })
+        .then(
+          () => undefined,
+          (reason: unknown) => reason,
+        );
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain("primary browser failure");
+      expect(error).toMatchObject({ cleanupError: cleanupFailure });
+    } finally {
+      removeState.mockRestore();
+      if (renderStateDir) {
+        realRmSync(renderStateDir, { force: true, recursive: true });
+      }
+    }
   });
 
   it("regenerates nodes help when bundled canvas CLI help sources change", async () => {

--- a/test/scripts/write-cli-startup-metadata.test.ts
+++ b/test/scripts/write-cli-startup-metadata.test.ts
@@ -308,6 +308,91 @@ describe("write-cli-startup-metadata", () => {
   });
 
   it.runIf(process.platform !== "win32")(
+    "preserves shared state when a canceled process group cannot be proven dead",
+    async () => {
+      const tempRoot = createTempDir("openclaw-startup-metadata-undrained-tree-");
+      const distDir = path.join(tempRoot, "dist");
+      const extensionsDir = path.join(tempRoot, "extensions");
+      const outputPath = path.join(distDir, "cli-startup-metadata.json");
+      const child = Object.assign(createSpawnTextChild(), { pid: 123 });
+      const realProcessKill = process.kill.bind(process);
+      const processKill = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+        if (pid === -123) {
+          return true;
+        }
+        return realProcessKill(pid, signal);
+      });
+      let renderStateDir = "";
+
+      writeStartupMetadataSourceSignatureFixture(tempRoot);
+      writeFixtureFile(distDir, "root-help-fixture.js", "export function outputRootHelp() {}\n");
+
+      try {
+        const writePromise = testing.writeCliStartupMetadata({
+          distDir,
+          outputPath,
+          extensionsDir,
+          sourceRootDir: tempRoot,
+          renderBundledRootHelpText: async () => "Usage: openclaw\n",
+          renderSourceBrowserHelpText: (renderContext, taskContext) => {
+            renderStateDir = renderContext.env?.OPENCLAW_STATE_DIR ?? "";
+            if (!taskContext) {
+              throw new Error("missing render task context");
+            }
+            return testing.spawnText(["openclaw.mjs", "browser", "--help"], {
+              cwd: tempRoot,
+              env: process.env,
+              failureMessage: "browser render failed",
+              killGraceMs: 10,
+              maxOutputBytes: 1024,
+              onTerminalFailure: taskContext.reportFailure,
+              signal: taskContext.signal,
+              spawnProcess: (() => child as unknown as ReturnType<typeof spawn>) as typeof spawn,
+              timeoutMs: 5_000,
+            });
+          },
+          renderSourceSecretsHelpText: () => "Usage: openclaw secrets\n",
+          renderSourceNodesHelpText: () => "Usage: openclaw nodes\n",
+          renderSourceSubcommandHelpTextRecord: () => ({
+            doctor: "Usage: openclaw doctor\n",
+            gateway: "Usage: openclaw gateway\n",
+            models: "Usage: openclaw models\n",
+            plugins: "Usage: openclaw plugins\n",
+            sessions: "Usage: openclaw sessions\n",
+            tasks: "Usage: openclaw tasks\n",
+          }),
+        });
+        await new Promise((resolve) => setImmediate(resolve));
+        child.stderr.write("primary browser failure\n");
+        child.emit("close", 7, null);
+
+        const error = await writePromise.then(
+          () => undefined,
+          (reason: unknown) => reason,
+        );
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toContain("primary browser failure");
+        expect((error as Error).message).toContain(
+          `Preserved CLI startup metadata render state: ${renderStateDir}`,
+        );
+        expect(error).toMatchObject({
+          preserveRenderState: true,
+          processTreeCleanupFailure: {
+            code: "EPROCESSGROUP_CLEANUP_FAILED",
+          },
+        });
+        expect(existsSync(renderStateDir)).toBe(true);
+        expect(existsSync(outputPath)).toBe(false);
+      } finally {
+        processKill.mockRestore();
+        if (renderStateDir) {
+          fs.rmSync(renderStateDir, { force: true, recursive: true });
+        }
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "cancels a default-batch sibling process tree after another command fails",
     async () => {
       const actualSpawn = (
@@ -921,13 +1006,14 @@ describe("write-cli-startup-metadata", () => {
       extensionsDir,
       sourceRootDir: tempRoot,
       renderBundledRootHelpText: async () => "Usage: openclaw\n",
-      renderSourceBrowserHelpText: (renderContext) => {
+      renderSourceBrowserHelpText: async (renderContext) => {
         stateDir = renderContext.env?.OPENCLAW_STATE_DIR ?? "";
         const sqliteDir = path.join(stateDir, "state");
         mkdirSync(sqliteDir, { recursive: true });
         for (const suffix of ["", "-shm", "-wal"]) {
           writeFileSync(path.join(sqliteDir, `openclaw.sqlite${suffix}`), "fixture", "utf8");
         }
+        await new Promise((resolve) => setImmediate(resolve));
         if (failRender) {
           throw new Error("browser help failed");
         }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where source builds could time out while generating CLI startup metadata after one help renderer failed, because sibling renderer process trees continued running outside the failed aggregate promise.

## Why This Change Was Made

The metadata generator now owns one abort-and-drain lifecycle across root help and every command help renderer. The first terminal failure cancels the other started process trees, prevents queued renders from starting, waits for descendant teardown, and only then removes shared state and reports the original command-specific failure. A missing built root-help bundle remains the sole source-fallback case; resource failures no longer start a second render path.

The bounded forced-drain path preserves its isolated state and attaches a cleanup diagnostic when a process group cannot be proven dead. Help and version launcher fast paths retain explicit runtime-import tripwires.

## User Impact

Developers and release automation get bounded, diagnosable CLI metadata generation under host contention instead of command-specific timeout drift or detached renderer trees.

## Evidence

- Blacksmith Testbox `tbx_01kzv222msxc0xy4sg1c0k72yp`: 22/22 focused metadata supervisor tests passed, including default-batch queued suppression, sibling and descendant cancellation, nonzero-leader drain, parent-signal ordering, cleanup precedence, and preserved evidence for an unproven SIGKILL drain.
- Launcher import proof: 49 passed, 1 expected Bun-only skip across root/command help and version fast paths.
- Constrained cold generation: `ulimit -n 128` followed by a fresh metadata render completed successfully in 11.9 seconds and produced all required root, browser, nodes, and subcommand help fields.
- Path-scoped changed gate passed: scripts and root-test typechecks, formatting, dependency/coercion guards, and scripts lint.
- Autoreview passed on the full branch with no accepted/actionable findings.

Production LOC is +226 net. The growth is the lifecycle ownership boundary that was previously absent: shared cancellation and parent signals, cross-platform process-tree escalation, verified drain before cleanup, bounded cleanup failure, and retained diagnostics/evidence. Tests are +440 net.
