### PR TITLE
fix(ci): restore Slack Enterprise client fixture

### DIFF
--- a/extensions/slack/src/monitor/provider.allowlist.test.ts
+++ b/extensions/slack/src/monitor/provider.allowlist.test.ts
@@ -120,6 +120,8 @@ describe("slack startup user allowlist resolution", () => {
       },
     });
     getSlackClient().auth.test.mockResolvedValueOnce({
+      user_id: "UENTERPRISE",
+      bot_id: "BENTERPRISE",
       enterprise_id: "E123",
       app_id: "A123",
       is_enterprise_install: true,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Slack Enterprise Grid approval-client fixture entered degraded identity startup, causing the main CI test to reuse one client for different workspace team IDs.

## Why This Change Was Made

The fixture now supplies the `user_id` and `bot_id` returned by a successful bot-token `auth.test` response. This keeps the test on the Enterprise identity path it is intended to verify without changing production behavior.

## User Impact

No user-visible behavior changes. This restores deterministic CI coverage for per-workspace Slack Enterprise approval clients.

## Evidence

- Before: `provider.allowlist.test.ts` failed 1 of 9 tests because `T111` and `T222` resolved to the same client object.
- After: focused Slack proof passed 35 of 35 tests across `provider.allowlist.test.ts` and `provider.auth-test-token.test.ts`.
- `node scripts/check-changed.mjs -- extensions/slack/src/monitor/provider.allowlist.test.ts` passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31602875557
- Targeted formatting, extension test typecheck, oxlint, and `git diff --check` passed.
- Direct dependency inspection: pinned `@slack/web-api@8.0.0` defines both `user_id` and `bot_id` on `AuthTestResponse`.
- Local exact-head ClawSweeper review of `60acb8f354a27c1a989312a225c3bba82f83c5e7`: no findings, high confidence.
- Exact-head hosted CI passed: https://github.com/openclaw/openclaw/actions/runs/31604219125
- Exact-head channel Critical Quality passed: https://github.com/openclaw/openclaw/actions/runs/31604219195

AI-assisted implementation and review.
