### PR TITLE
fix: archived chat composer returns after session navigation

### DIFF
--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -520,6 +520,7 @@ export type SessionsBranchesSwitchResult =
 export type SessionsPatchResult = SessionsPatchResultBase<{
   sessionId: string;
   updatedAt?: number;
+  archivedAt?: number;
   thinkingLevel?: string;
   fastMode?: FastMode;
   verboseLevel?: string;

--- a/ui/src/e2e/session-management.archive.e2e.test.ts
+++ b/ui/src/e2e/session-management.archive.e2e.test.ts
@@ -7,6 +7,7 @@ import {
   controlUiSessionUrl,
   createSessionManagementE2eSuite,
   installMockGateway,
+  navigateToControlUiSession,
   requireRecord,
   sessionRow,
   sessionsListResponse,
@@ -549,6 +550,96 @@ suite.define(() => {
           ),
         )
         .toBe(selected.key);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("keeps archive state after navigating away and back", async () => {
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const baseTime = Date.parse("2026-07-01T16:00:00.000Z");
+    const main = sessionRow("agent:main:main", "Main", baseTime);
+    const archived = {
+      ...sessionRow("agent:main:navigation-archive", "Navigation archive", baseTime - 1_000),
+      sessionId: "navigation-archive",
+    };
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": sessionsListResponse([main, archived]),
+        "sessions.patch": {},
+      },
+      sessionKey: main.key,
+    });
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, archived.key));
+      const sidebar = page.locator("openclaw-app-sidebar");
+      const rowFor = (key: string) =>
+        sidebar.locator(`.sidebar-recent-session[data-session-key="${key}"]`);
+      const archivedRow = rowFor(archived.key);
+      await archivedRow.waitFor({ state: "visible", timeout: 10_000 });
+      await archivedRow.hover();
+      await archivedRow.getByRole("button", { name: "Open session menu" }).click();
+      await activateSelfRemovingControl(
+        page.locator("openclaw-session-menu").getByRole("menuitem", {
+          name: "Archive session",
+        }),
+      );
+      await waitForPatch(
+        gateway,
+        (params) => params.key === archived.key && params.archived === true,
+      );
+      const archivedNotice = page
+        .locator("openclaw-chat-pane.chat-pane-cache__pane--active")
+        .locator(".agent-chat__disabled-banner");
+      await archivedNotice.waitFor({ state: "visible", timeout: 10_000 });
+
+      await navigateToControlUiSession(page, main.key);
+      await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(main.key));
+
+      await gateway.setMethodResponse("sessions.list", sessionsListResponse([main]));
+      let listRequestCount = (await gateway.getRequests("sessions.list")).length;
+      await gateway.emitGatewayEvent("sessions.changed", {
+        ...main,
+        updatedAt: baseTime + 1_000,
+        reason: "update",
+        sessionKey: main.key,
+      });
+      await expect
+        .poll(async () => (await gateway.getRequests("sessions.list")).length)
+        .toBeGreaterThan(listRequestCount);
+      await archivedRow.waitFor({ state: "detached", timeout: 10_000 });
+
+      await gateway.setMethodResponse(
+        "sessions.list",
+        sessionsListResponse([
+          { ...main, updatedAt: baseTime + 2_000 },
+          { ...archived, archived: false, updatedAt: baseTime + 3_000 },
+        ]),
+      );
+      listRequestCount = (await gateway.getRequests("sessions.list")).length;
+      await gateway.emitGatewayEvent("sessions.changed", {
+        ...main,
+        updatedAt: baseTime + 2_000,
+        reason: "update",
+        sessionKey: main.key,
+      });
+      await expect
+        .poll(async () => (await gateway.getRequests("sessions.list")).length)
+        .toBeGreaterThan(listRequestCount);
+
+      await page.goBack();
+      await expect
+        .poll(() => new URL(page.url()).pathname)
+        .toBe(controlUiSessionPath(archived.key));
+      await archivedNotice.waitFor({ state: "visible", timeout: 10_000 });
+      await expect.poll(() => archivedNotice.textContent()).toContain("This session is archived.");
+      await archivedRow.locator(".sidebar-session__archive-glyph").waitFor({ state: "visible" });
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/session-management.groups.e2e.test.ts
+++ b/ui/src/e2e/session-management.groups.e2e.test.ts
@@ -327,19 +327,19 @@ suite.define(() => {
         key: "agent:main:research",
       });
 
-      // Selecting a visible row must not reshuffle the list: the highlight
-      // moves while every row keeps its slot. (The mocked gateway keeps
-      // returning the same list, so the archived row stays visible here.)
-      const researchLink = sidebarResearch.locator("a").first();
-      await researchLink.click();
+      // The confirmed archive wins over the mocked Gateway's stale active row,
+      // while selecting another visible row keeps the remaining order stable.
+      await sidebarResearch.waitFor({ state: "detached" });
+      const migrationLink = sidebarMigration.locator("a").first();
+      await migrationLink.click();
       await expect
         .poll(() => new URL(page.url()).pathname)
-        .toBe(controlUiSessionPath("agent:main:research"));
-      await expect.poll(rowNames).toEqual(["Release planning", "Data migration", "Research notes"]);
+        .toBe(controlUiSessionPath("agent:main:migration"));
+      await expect.poll(rowNames).toEqual(["Release planning", "Data migration"]);
       await expect
         .poll(() =>
           chatRows
-            .filter({ hasText: "Research notes" })
+            .filter({ hasText: "Data migration" })
             .first()
             .evaluate((row) => row.classList.contains("sidebar-recent-session--active")),
         )

--- a/ui/src/e2e/session-management.test-support.ts
+++ b/ui/src/e2e/session-management.test-support.ts
@@ -7,13 +7,20 @@ import {
   controlUiSessionPath,
   controlUiSessionUrl,
   installMockGateway,
+  navigateToControlUiSession,
   waitForConfirmModal,
   type MockGatewayControls,
   type MockGatewayRequest,
 } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-export { controlUiSessionPath, controlUiSessionUrl, installMockGateway, waitForConfirmModal };
+export {
+  controlUiSessionPath,
+  controlUiSessionUrl,
+  installMockGateway,
+  navigateToControlUiSession,
+  waitForConfirmModal,
+};
 
 export const collapsedSessionSectionsStorageKey = "openclaw:sidebar:sessions:collapsed-sections";
 export const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";

--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -28,6 +28,56 @@ function sessionChangedEvent(key: string): GatewayEventFrame {
 }
 
 describe("createSessionCapability", () => {
+  it.each(["direct", "subscription"] as const)(
+    "ignores stale archive state after a newer unarchive via %s reconciliation",
+    async (path) => {
+      const key = "agent:main:main";
+      const request = vi.fn(async (method: string) => {
+        if (method !== "sessions.list") {
+          throw new Error(`Unexpected request: ${method}`);
+        }
+        return sessionsResult(
+          [
+            {
+              key,
+              kind: "direct",
+              sessionId: "main-session",
+              updatedAt: 30,
+              archived: false,
+            },
+          ],
+          30,
+        );
+      });
+      const client = { request } as unknown as GatewayBrowserClient;
+      const { emitEvent, gateway } = createGatewayHarness(client);
+      const sessions = createSessionCapability(gateway);
+      await sessions.refresh({ agentId: "main", force: true });
+      const staleArchive = {
+        sessionKey: key,
+        key,
+        kind: "direct" as const,
+        sessionId: "main-session",
+        updatedAt: 20,
+        archived: true,
+        archivedAt: 20,
+        reason: "update",
+      };
+
+      if (path === "direct") {
+        sessions.reconcileChanged(staleArchive);
+      } else {
+        emitEvent({ type: "event", event: "sessions.changed", payload: staleArchive });
+      }
+
+      expect(sessions.state.result?.sessions.find((row) => row.key === key)).toMatchObject({
+        archived: false,
+        updatedAt: 30,
+      });
+      sessions.dispose();
+    },
+  );
+
   it("allows an advertised group catalog load to be retried after failure", async () => {
     let groupsCalls = 0;
     const request = vi.fn(async (method: string) => {

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -288,19 +288,25 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     };
   };
 
+  const reconcileChangedEvent = (payload: unknown, options?: SessionReconcileOptions) => {
+    const previous = state.result;
+    const eventInfo = readSessionChangedEvent(payload);
+    const reconciled = reconcileSessionChanged(
+      previous,
+      payload,
+      reconcileChangedOptions(payload, options),
+    );
+    if (reconciled.result !== previous && reconciled.key && eventInfo) {
+      mutations.observeArchiveState(reconciled.key, eventInfo.archived, reconciled.row);
+    }
+    return { eventInfo, reconciled };
+  };
+
   const reconcileChanged = (
     payload: unknown,
     options?: SessionReconcileOptions,
   ): SessionChangedResult => {
-    const base = reconcileSessionChanged(
-      state.result,
-      payload,
-      reconcileChangedOptions(payload, options),
-    );
-    const eventInfo = readSessionChangedEvent(payload);
-    if (base.key && eventInfo) {
-      mutations.observeArchiveState(base.key, eventInfo.archived, base.row);
-    }
+    const { reconciled: base } = reconcileChangedEvent(payload, options);
     const result = decorateRows(base.result);
     const reconciled =
       result === base.result
@@ -406,15 +412,10 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     if (decoratedResult !== state.result) {
       publish({ ...state, result: decoratedResult });
     }
-    const eventInfo = readSessionChangedEvent(event.payload);
-    const reconcileOptions = reconcileChangedOptions(event.payload, {
+    const { eventInfo, reconciled } = reconcileChangedEvent(event.payload, {
       resultAgentId: state.agentId,
       archivedFilter: roster.lastOptions().archivedFilter,
     });
-    const reconciled = reconcileSessionChanged(state.result, event.payload, reconcileOptions);
-    if (reconciled.key && eventInfo) {
-      mutations.observeArchiveState(reconciled.key, eventInfo.archived, reconciled.row);
-    }
     if (eventInfo?.archived !== null) {
       const result = decorateRows(reconciled.result);
       if (result !== state.result) {

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -128,7 +128,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
   // UI-owned facts the capability keeps beside them, so every published result
   // passes through the same overlay: swarm notes, then in-flight pin intents.
   const decorateRows = (result: SessionsListResult | null): SessionsListResult | null =>
-    mutations.applyPendingPins(swarmActivity.decorate(result));
+    mutations.applyConfirmedArchives(mutations.applyPendingPins(swarmActivity.decorate(result)));
 
   const roster = createSessionRosterRefresh({
     connection,
@@ -297,6 +297,10 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       payload,
       reconcileChangedOptions(payload, options),
     );
+    const eventInfo = readSessionChangedEvent(payload);
+    if (base.key && eventInfo) {
+      mutations.observeArchiveState(base.key, eventInfo.archived, base.row);
+    }
     const result = decorateRows(base.result);
     const reconciled =
       result === base.result
@@ -408,6 +412,15 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       archivedFilter: roster.lastOptions().archivedFilter,
     });
     const reconciled = reconcileSessionChanged(state.result, event.payload, reconcileOptions);
+    if (reconciled.key && eventInfo) {
+      mutations.observeArchiveState(reconciled.key, eventInfo.archived, reconciled.row);
+    }
+    if (eventInfo?.archived !== null) {
+      const result = decorateRows(reconciled.result);
+      if (result !== state.result) {
+        publishReconciledState({ ...state, result });
+      }
+    }
     const eventReason = (event.payload as { reason?: unknown } | null)?.reason;
     const payloadAgentId = (event.payload as { agentId?: unknown } | null)?.agentId;
     if (eventReason === "groups") {

--- a/ui/src/lib/sessions/list-options.test.ts
+++ b/ui/src/lib/sessions/list-options.test.ts
@@ -133,6 +133,13 @@ describe("session list replacement options", () => {
     const sessions = createSessions({ request } as unknown as GatewayBrowserClient, key);
 
     await sessions.refresh({ agentId: "main", includeDerivedTitles: true, force: true });
+    let observedArchive = false;
+    let archiveReverted = false;
+    const stop = sessions.subscribe((state) => {
+      const archived = state.result?.sessions.find((row) => row.key === key)?.archived;
+      observedArchive ||= archived === true;
+      archiveReverted ||= observedArchive && archived === false;
+    });
     const archive = sessions.patch(key, { archived: true }, { agentId: "main" });
     await archiveReplacementStarted.promise;
     const foreground = sessions.refresh({ agentId: "main", force: true });
@@ -157,6 +164,9 @@ describe("session list replacement options", () => {
     expect(listCalls[1]?.[1]).toMatchObject({ agentId: "main", includeDerivedTitles: true });
     expect(listCalls[2]?.[1]).toMatchObject({ agentId: "main", includeDerivedTitles: true });
     expect(sessions.state.result?.sessions[0]?.derivedTitle).toBe("Readable planning title");
+    expect(sessions.state.result?.sessions[0]?.archived).toBe(true);
+    expect(archiveReverted).toBe(false);
+    stop();
     sessions.dispose();
   });
 

--- a/ui/src/lib/sessions/list-options.test.ts
+++ b/ui/src/lib/sessions/list-options.test.ts
@@ -220,6 +220,69 @@ describe("session list replacement options", () => {
     sessions.dispose();
   });
 
+  it("retains confirmed archive state after the routed row is evicted", async () => {
+    const key = "agent:main:dashboard:archived";
+    const otherKey = "agent:main:dashboard:other";
+    const snapshot = {
+      client: null as GatewayBrowserClient | null,
+      phase: "connected" as const,
+      sessionKey: key,
+      assistantAgentId: "main",
+      hello: null,
+    };
+    let listCallCount = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.patch") {
+        return { ok: true, entry: { archivedAt: 20, updatedAt: 20 } };
+      }
+      if (method !== "sessions.list") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      listCallCount += 1;
+      if (listCallCount === 3) {
+        return sessionsResult([{ key: otherKey, kind: "direct", updatedAt: 30 }], listCallCount);
+      }
+      return sessionsResult(
+        [
+          { key, kind: "direct", sessionId: "archived-session", updatedAt: 40, archived: false },
+          { key: otherKey, kind: "direct", updatedAt: 30 },
+        ],
+        listCallCount,
+      );
+    });
+    snapshot.client = { request } as unknown as GatewayBrowserClient;
+    const sessions = createSessionCapability({
+      snapshot,
+      subscribe: () => () => undefined,
+      subscribeEvents: () => () => undefined,
+    });
+
+    await sessions.refresh({ agentId: "main", force: true });
+    await sessions.patch(key, { archived: true }, { agentId: "main" });
+    snapshot.sessionKey = otherKey;
+    await sessions.refresh({ agentId: "main", force: true });
+    expect(sessions.state.result?.sessions.some((row) => row.key === key)).toBe(false);
+
+    await sessions.refresh({ agentId: "main", force: true });
+    expect(sessions.state.result?.sessions.find((row) => row.key === key)).toMatchObject({
+      archived: true,
+      archivedAt: 20,
+    });
+
+    sessions.reconcileChanged({
+      sessionKey: key,
+      key,
+      kind: "direct",
+      sessionId: "archived-session",
+      updatedAt: 50,
+      archived: false,
+      archivedAt: null,
+      reason: "update",
+    });
+    expect(sessions.state.result?.sessions.find((row) => row.key === key)?.archived).toBe(false);
+    sessions.dispose();
+  });
+
   it("keeps derived titles while an enriched roster response is temporarily degraded", async () => {
     const key = "agent:main:dashboard:session-1";
     let listCallCount = 0;

--- a/ui/src/lib/sessions/list-options.test.ts
+++ b/ui/src/lib/sessions/list-options.test.ts
@@ -298,16 +298,25 @@ describe("session list replacement options", () => {
       }
       listCallCount += 1;
       if (listCallCount === 1) {
-        return sessionsResult([{ key, kind: "direct", updatedAt: 10 }], listCallCount);
+        return sessionsResult(
+          [{ key, kind: "direct", sessionId: "archived-session", updatedAt: 10 }],
+          listCallCount,
+        );
       }
       if (listCallCount === 2) {
+        return sessionsResult(
+          [{ key, kind: "direct", updatedAt: 30, archived: false }],
+          listCallCount,
+        );
+      }
+      if (listCallCount === 3) {
         return sessionsResult(
           [
             {
               key,
               kind: "direct",
               sessionId: "replacement-session",
-              updatedAt: 30,
+              updatedAt: 40,
               archived: false,
             },
           ],
@@ -315,7 +324,7 @@ describe("session list replacement options", () => {
         );
       }
       return sessionsResult(
-        [{ key, kind: "direct", updatedAt: 40, archived: false }],
+        [{ key, kind: "direct", updatedAt: 50, archived: false }],
         listCallCount,
       );
     });
@@ -323,6 +332,12 @@ describe("session list replacement options", () => {
 
     await sessions.refresh({ agentId: "main", force: true });
     await sessions.patch(key, { archived: true }, { agentId: "main" });
+    expect(sessions.state.result?.sessions[0]).toMatchObject({
+      archived: false,
+    });
+    expect(sessions.state.result?.sessions[0]?.sessionId).toBeUndefined();
+
+    await sessions.refresh({ agentId: "main", force: true });
     expect(sessions.state.result?.sessions[0]).toMatchObject({
       sessionId: "replacement-session",
       archived: false,

--- a/ui/src/lib/sessions/list-options.test.ts
+++ b/ui/src/lib/sessions/list-options.test.ts
@@ -283,6 +283,56 @@ describe("session list replacement options", () => {
     sessions.dispose();
   });
 
+  it("does not carry confirmed archive state into a replacement session", async () => {
+    const key = "agent:main:dashboard:replaced";
+    let listCallCount = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.patch") {
+        return {
+          ok: true,
+          entry: { sessionId: "archived-session", archivedAt: 20, updatedAt: 20 },
+        };
+      }
+      if (method !== "sessions.list") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      listCallCount += 1;
+      if (listCallCount === 1) {
+        return sessionsResult([{ key, kind: "direct", updatedAt: 10 }], listCallCount);
+      }
+      if (listCallCount === 2) {
+        return sessionsResult(
+          [
+            {
+              key,
+              kind: "direct",
+              sessionId: "replacement-session",
+              updatedAt: 30,
+              archived: false,
+            },
+          ],
+          listCallCount,
+        );
+      }
+      return sessionsResult(
+        [{ key, kind: "direct", updatedAt: 40, archived: false }],
+        listCallCount,
+      );
+    });
+    const sessions = createSessions({ request } as unknown as GatewayBrowserClient, key);
+
+    await sessions.refresh({ agentId: "main", force: true });
+    await sessions.patch(key, { archived: true }, { agentId: "main" });
+    expect(sessions.state.result?.sessions[0]).toMatchObject({
+      sessionId: "replacement-session",
+      archived: false,
+    });
+
+    await sessions.refresh({ agentId: "main", force: true });
+    expect(sessions.state.result?.sessions[0]?.archived).toBe(false);
+    sessions.dispose();
+  });
+
   it("keeps derived titles while an enriched roster response is temporarily degraded", async () => {
     const key = "agent:main:dashboard:session-1";
     let listCallCount = 0;

--- a/ui/src/lib/sessions/reconcile.test.ts
+++ b/ui/src/lib/sessions/reconcile.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment node
 import { describe, expect, it, test } from "vitest";
 import type { SessionsListResult } from "../../api/types.ts";
-import { reconcileSessionChanged, reconcileSessionHistory } from "./reconcile.ts";
+import {
+  preserveRosterPresentationMetadata,
+  reconcileSessionChanged,
+  reconcileSessionHistory,
+} from "./reconcile.ts";
 
 function buildResult(sessions: SessionsListResult["sessions"]): SessionsListResult {
   return {
@@ -12,6 +16,44 @@ function buildResult(sessions: SessionsListResult["sessions"]): SessionsListResu
     sessions,
   };
 }
+
+describe("preserveRosterPresentationMetadata", () => {
+  it("preserves a newer archive over an older active-list row", () => {
+    const key = "agent:main:dashboard:archived";
+
+    expect(
+      preserveRosterPresentationMetadata(
+        { key, kind: "direct", sessionId: "s1", updatedAt: 10, archived: false },
+        {
+          key,
+          kind: "direct",
+          sessionId: "s1",
+          updatedAt: 20,
+          archived: true,
+          archivedAt: 20,
+        },
+      ),
+    ).toMatchObject({ archived: true, archivedAt: 20 });
+  });
+
+  it("accepts an unarchive row newer than the prior archive", () => {
+    const key = "agent:main:dashboard:archived";
+
+    expect(
+      preserveRosterPresentationMetadata(
+        { key, kind: "direct", sessionId: "s1", updatedAt: 30, archived: false },
+        {
+          key,
+          kind: "direct",
+          sessionId: "s1",
+          updatedAt: 20,
+          archived: true,
+          archivedAt: 20,
+        },
+      ).archived,
+    ).toBe(false);
+  });
+});
 
 test("sessions.changed removes a label when the event carries null", () => {
   const result: SessionsListResult = {

--- a/ui/src/lib/sessions/reconcile.test.ts
+++ b/ui/src/lib/sessions/reconcile.test.ts
@@ -18,6 +18,28 @@ function buildResult(sessions: SessionsListResult["sessions"]): SessionsListResu
 }
 
 describe("preserveRosterPresentationMetadata", () => {
+  it("does not preserve presentation metadata without a known matching session identity", () => {
+    const key = "agent:main:dashboard:replacement";
+
+    expect(
+      preserveRosterPresentationMetadata(
+        { key, kind: "direct", sessionId: "replacement-session", updatedAt: 20 },
+        {
+          key,
+          kind: "direct",
+          updatedAt: 10,
+          derivedTitle: "Previous session title",
+          lastMessagePreview: "Previous session preview",
+        },
+      ),
+    ).toEqual({
+      key,
+      kind: "direct",
+      sessionId: "replacement-session",
+      updatedAt: 20,
+    });
+  });
+
   it("does not infer archive state from row timestamps", () => {
     const key = "agent:main:dashboard:archived";
 

--- a/ui/src/lib/sessions/reconcile.test.ts
+++ b/ui/src/lib/sessions/reconcile.test.ts
@@ -18,7 +18,7 @@ function buildResult(sessions: SessionsListResult["sessions"]): SessionsListResu
 }
 
 describe("preserveRosterPresentationMetadata", () => {
-  it("preserves a newer archive over an older active-list row", () => {
+  it("does not infer archive state from row timestamps", () => {
     const key = "agent:main:dashboard:archived";
 
     expect(
@@ -33,25 +33,7 @@ describe("preserveRosterPresentationMetadata", () => {
           archivedAt: 20,
         },
       ),
-    ).toMatchObject({ archived: true, archivedAt: 20 });
-  });
-
-  it("accepts an unarchive row newer than the prior archive", () => {
-    const key = "agent:main:dashboard:archived";
-
-    expect(
-      preserveRosterPresentationMetadata(
-        { key, kind: "direct", sessionId: "s1", updatedAt: 30, archived: false },
-        {
-          key,
-          kind: "direct",
-          sessionId: "s1",
-          updatedAt: 20,
-          archived: true,
-          archivedAt: 20,
-        },
-      ).archived,
-    ).toBe(false);
+    ).toEqual({ key, kind: "direct", sessionId: "s1", updatedAt: 10, archived: false });
   });
 });
 

--- a/ui/src/lib/sessions/reconcile.ts
+++ b/ui/src/lib/sessions/reconcile.ts
@@ -151,20 +151,43 @@ export function preserveRosterPresentationMetadata(
   incoming: GatewaySessionRow,
   existing: GatewaySessionRow | undefined,
 ): GatewaySessionRow {
-  if (
-    !existing ||
-    !incoming.sessionId ||
-    incoming.sessionId !== existing.sessionId ||
-    (incoming.derivedTitle !== undefined && incoming.lastMessagePreview !== undefined)
-  ) {
+  if (!existing) {
+    return incoming;
+  }
+  const sameSessionWindow =
+    incoming.sessionId && existing.sessionId
+      ? incoming.sessionId === existing.sessionId
+      : incoming.key === existing.key;
+  const preserveArchive =
+    sameSessionWindow &&
+    existing.archived === true &&
+    incoming.archived !== true &&
+    typeof existing.archivedAt === "number" &&
+    (typeof incoming.updatedAt !== "number" || incoming.updatedAt < existing.archivedAt);
+  const preservePresentation =
+    Boolean(incoming.sessionId) &&
+    incoming.sessionId === existing.sessionId &&
+    (incoming.derivedTitle === undefined || incoming.lastMessagePreview === undefined);
+  if (!preserveArchive && !preservePresentation) {
     return incoming;
   }
   return {
     ...incoming,
-    ...(incoming.derivedTitle === undefined && existing.derivedTitle !== undefined
+    ...(preserveArchive
+      ? {
+          archived: true,
+          archivedAt: existing.archivedAt,
+          ...(existing.archivedBy ? { archivedBy: existing.archivedBy } : {}),
+        }
+      : {}),
+    ...(preservePresentation &&
+    incoming.derivedTitle === undefined &&
+    existing.derivedTitle !== undefined
       ? { derivedTitle: existing.derivedTitle }
       : {}),
-    ...(incoming.lastMessagePreview === undefined && existing.lastMessagePreview !== undefined
+    ...(preservePresentation &&
+    incoming.lastMessagePreview === undefined &&
+    existing.lastMessagePreview !== undefined
       ? { lastMessagePreview: existing.lastMessagePreview }
       : {}),
   };

--- a/ui/src/lib/sessions/reconcile.ts
+++ b/ui/src/lib/sessions/reconcile.ts
@@ -158,28 +158,15 @@ export function preserveRosterPresentationMetadata(
     incoming.sessionId && existing.sessionId
       ? incoming.sessionId === existing.sessionId
       : incoming.key === existing.key;
-  const preserveArchive =
-    sameSessionWindow &&
-    existing.archived === true &&
-    incoming.archived !== true &&
-    typeof existing.archivedAt === "number" &&
-    (typeof incoming.updatedAt !== "number" || incoming.updatedAt < existing.archivedAt);
   const preservePresentation =
+    sameSessionWindow &&
     Boolean(incoming.sessionId) &&
-    incoming.sessionId === existing.sessionId &&
     (incoming.derivedTitle === undefined || incoming.lastMessagePreview === undefined);
-  if (!preserveArchive && !preservePresentation) {
+  if (!preservePresentation) {
     return incoming;
   }
   return {
     ...incoming,
-    ...(preserveArchive
-      ? {
-          archived: true,
-          archivedAt: existing.archivedAt,
-          ...(existing.archivedBy ? { archivedBy: existing.archivedBy } : {}),
-        }
-      : {}),
     ...(preservePresentation &&
     incoming.derivedTitle === undefined &&
     existing.derivedTitle !== undefined

--- a/ui/src/lib/sessions/reconcile.ts
+++ b/ui/src/lib/sessions/reconcile.ts
@@ -151,30 +151,20 @@ export function preserveRosterPresentationMetadata(
   incoming: GatewaySessionRow,
   existing: GatewaySessionRow | undefined,
 ): GatewaySessionRow {
-  if (!existing) {
-    return incoming;
-  }
-  const sameSessionWindow =
-    incoming.sessionId && existing.sessionId
-      ? incoming.sessionId === existing.sessionId
-      : incoming.key === existing.key;
-  const preservePresentation =
-    sameSessionWindow &&
-    Boolean(incoming.sessionId) &&
-    (incoming.derivedTitle === undefined || incoming.lastMessagePreview === undefined);
-  if (!preservePresentation) {
+  if (
+    !existing ||
+    !incoming.sessionId ||
+    incoming.sessionId !== existing.sessionId ||
+    (incoming.derivedTitle !== undefined && incoming.lastMessagePreview !== undefined)
+  ) {
     return incoming;
   }
   return {
     ...incoming,
-    ...(preservePresentation &&
-    incoming.derivedTitle === undefined &&
-    existing.derivedTitle !== undefined
+    ...(incoming.derivedTitle === undefined && existing.derivedTitle !== undefined
       ? { derivedTitle: existing.derivedTitle }
       : {}),
-    ...(preservePresentation &&
-    incoming.lastMessagePreview === undefined &&
-    existing.lastMessagePreview !== undefined
+    ...(incoming.lastMessagePreview === undefined && existing.lastMessagePreview !== undefined
       ? { lastMessagePreview: existing.lastMessagePreview }
       : {}),
   };

--- a/ui/src/lib/sessions/session-mutations.ts
+++ b/ui/src/lib/sessions/session-mutations.ts
@@ -501,8 +501,12 @@ export function createSessionMutations(host: SessionMutationsHost) {
         if (!archive) {
           return row;
         }
-        if (archive.sessionId && row.sessionId && archive.sessionId !== row.sessionId) {
-          confirmedArchives.delete(row.key);
+        if (archive.sessionId && archive.sessionId !== row.sessionId) {
+          // An id-less row may be a same-key replacement whose identity has not arrived.
+          // Do not transfer archive state; retire it only after a different identity appears.
+          if (row.sessionId) {
+            confirmedArchives.delete(row.key);
+          }
           return row;
         }
         if (row.archived === true) {

--- a/ui/src/lib/sessions/session-mutations.ts
+++ b/ui/src/lib/sessions/session-mutations.ts
@@ -305,14 +305,13 @@ export function createSessionMutations(host: SessionMutationsHost) {
       }
       if (archivedPresentationRow) {
         const archivedAt = result.entry?.archivedAt ?? Date.now();
+        const archivedSessionId = result.entry?.sessionId ?? archivedPresentationRow.sessionId;
         confirmedArchives.set(normalizedKey, {
           archivedAt,
           ...(archivedPresentationRow.archivedBy
             ? { archivedBy: archivedPresentationRow.archivedBy }
             : {}),
-          ...(archivedPresentationRow.sessionId
-            ? { sessionId: archivedPresentationRow.sessionId }
-            : {}),
+          ...(archivedSessionId ? { sessionId: archivedSessionId } : {}),
         });
         const state = host.readState();
         if (state.result) {
@@ -499,11 +498,14 @@ export function createSessionMutations(host: SessionMutationsHost) {
       let changed = false;
       const sessions = result.sessions.map((row) => {
         const archive = confirmedArchives.get(row.key);
-        if (
-          !archive ||
-          row.archived === true ||
-          (archive.sessionId && row.sessionId && archive.sessionId !== row.sessionId)
-        ) {
+        if (!archive) {
+          return row;
+        }
+        if (archive.sessionId && row.sessionId && archive.sessionId !== row.sessionId) {
+          confirmedArchives.delete(row.key);
+          return row;
+        }
+        if (row.archived === true) {
           return row;
         }
         changed = true;

--- a/ui/src/lib/sessions/session-mutations.ts
+++ b/ui/src/lib/sessions/session-mutations.ts
@@ -30,6 +30,8 @@ import {
 /** The Gateway's single pin fact: `pinned` is a projection of `pinnedAt`. */
 type SessionPinFields = { pinned: boolean; pinnedAt: number | undefined };
 
+type ConfirmedArchiveState = Pick<GatewaySessionRow, "archivedAt" | "archivedBy" | "sessionId">;
+
 type SessionMutationsHost = {
   connection: SessionConnectionOwner;
   readState: () => SessionState;
@@ -50,6 +52,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
     string,
     { token: symbol; previous: SessionPinFields; next: SessionPinFields }
   >();
+  const confirmedArchives = new Map<string, ConfirmedArchiveState>();
   const preparedWorkSessionKeys = new Set<string>();
 
   const setModelOverride = (key: string, value: string | null | undefined) => {
@@ -301,9 +304,18 @@ export function createSessionMutations(host: SessionMutationsHost) {
         return null;
       }
       if (archivedPresentationRow) {
+        const archivedAt = result.entry?.archivedAt ?? Date.now();
+        confirmedArchives.set(normalizedKey, {
+          archivedAt,
+          ...(archivedPresentationRow.archivedBy
+            ? { archivedBy: archivedPresentationRow.archivedBy }
+            : {}),
+          ...(archivedPresentationRow.sessionId
+            ? { sessionId: archivedPresentationRow.sessionId }
+            : {}),
+        });
         const state = host.readState();
         if (state.result) {
-          const archivedAt = result.entry?.archivedAt ?? Date.now();
           const archivedRow = {
             ...archivedPresentationRow,
             archived: true,
@@ -324,6 +336,8 @@ export function createSessionMutations(host: SessionMutationsHost) {
             result: { ...state.result, count: sessions.length, sessions },
           });
         }
+      } else if (patchParams.archived === false) {
+        confirmedArchives.delete(normalizedKey);
       }
       confirmPinPatch();
       if (!options.deferListRefresh) {
@@ -361,6 +375,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
         return { deleted: false };
       }
       host.retirePullRequestSummary(key);
+      confirmedArchives.delete(key.trim());
       preparedWorkSessionKeys.delete(key.trim());
       host.publish({ ...host.readState(), deletedSessions: [{ key, agentId: options.agentId }] });
       setModelOverride(key, undefined);
@@ -410,6 +425,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
     if (deleted.length > 0 && host.connection.isCurrent(scope)) {
       for (const key of deleted) {
         host.retirePullRequestSummary(key);
+        confirmedArchives.delete(key.trim());
         preparedWorkSessionKeys.delete(key.trim());
       }
       host.publish({
@@ -476,6 +492,58 @@ export function createSessionMutations(host: SessionMutationsHost) {
       });
       return changed ? { ...result, sessions } : result;
     },
+    applyConfirmedArchives(result: SessionsListResult | null): SessionsListResult | null {
+      if (!result || confirmedArchives.size === 0) {
+        return result;
+      }
+      let changed = false;
+      const sessions = result.sessions.map((row) => {
+        const archive = confirmedArchives.get(row.key);
+        if (
+          !archive ||
+          row.archived === true ||
+          (archive.sessionId && row.sessionId && archive.sessionId !== row.sessionId)
+        ) {
+          return row;
+        }
+        changed = true;
+        return {
+          ...row,
+          archived: true,
+          ...(archive.archivedAt !== undefined ? { archivedAt: archive.archivedAt } : {}),
+          ...(archive.archivedBy ? { archivedBy: archive.archivedBy } : {}),
+        };
+      });
+      return changed ? { ...result, sessions } : result;
+    },
+    observeArchiveState(key: string, archived: boolean | null, row?: GatewaySessionRow): void {
+      const normalizedKey = key.trim();
+      if (!normalizedKey || archived === null) {
+        return;
+      }
+      if (!archived) {
+        confirmedArchives.delete(normalizedKey);
+        return;
+      }
+      const previous = confirmedArchives.get(normalizedKey);
+      confirmedArchives.set(normalizedKey, {
+        ...(row?.archivedAt !== undefined
+          ? { archivedAt: row.archivedAt }
+          : previous?.archivedAt !== undefined
+            ? { archivedAt: previous.archivedAt }
+            : {}),
+        ...(row?.archivedBy
+          ? { archivedBy: row.archivedBy }
+          : previous?.archivedBy
+            ? { archivedBy: previous.archivedBy }
+            : {}),
+        ...(row?.sessionId
+          ? { sessionId: row.sessionId }
+          : previous?.sessionId
+            ? { sessionId: previous.sessionId }
+            : {}),
+      });
+    },
     reset,
     retireModelOverride,
     setModelOverride,
@@ -493,6 +561,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
       // rehydrates wholesale; only the model-override side map outlives that
       // replacement, so it is the one that needs an explicit rollback below.
       pendingPinPatches.clear();
+      confirmedArchives.clear();
       preparedWorkSessionKeys.clear();
       const state = host.readState();
       if (Object.keys(state.modelOverrides).length > 0) {
@@ -502,6 +571,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
     dispose() {
       pendingModelPatches.clear();
       pendingPinPatches.clear();
+      confirmedArchives.clear();
       preparedWorkSessionKeys.clear();
     },
   };

--- a/ui/src/lib/sessions/session-mutations.ts
+++ b/ui/src/lib/sessions/session-mutations.ts
@@ -303,9 +303,12 @@ export function createSessionMutations(host: SessionMutationsHost) {
       if (archivedPresentationRow) {
         const state = host.readState();
         if (state.result) {
+          const archivedAt = result.entry?.archivedAt ?? Date.now();
           const archivedRow = {
             ...archivedPresentationRow,
             archived: true,
+            archivedAt,
+            updatedAt: result.entry?.updatedAt ?? archivedPresentationRow.updatedAt,
             pinned: false,
             pinnedAt: undefined,
           };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who archived the selected Control UI chat could see the active composer return after a delayed session refresh or after navigating away and back, even though the Gateway kept the session archived.

## Why This Change Was Made

The session capability records confirmed archive state independently of roster-row lifetime and reapplies it to stale list projections. The reconciler remains the freshness authority: rejected stale events cannot update the overlay, explicit unarchive events clear it, and replacement session identities retire it. Presentation metadata remains gated on a known matching `sessionId`.

## User Impact

Archived chats continue to show the archived-session notice and keep the composer disabled across refreshes and session navigation. Unarchiving or replacing the session restores the active projection normally, and replacement sessions do not inherit an earlier session's title or message preview.

## Evidence

- AI-assisted implementation and review.
- Live verification reproduced the original reversion and confirmed that archive state persists after navigating to another session.
- ClawSweeper P1 addressed: both changed-event paths update archive state only when reconciliation accepts the event. A newer unarchive followed by a stale archive event stays unarchived.
- ClawSweeper P2 addressed: presentation metadata is preserved only when both rows have the same known `sessionId`. A partial prior row followed by a replacement identity cannot transfer its title or preview.
- P1 autoreview follow-up addressed: confirmed archive state uses the patch response's authoritative `sessionId` and retires on an identity mismatch, so a replacement session cannot inherit the old archive state.
- CI failure reproduced locally: `session-management.groups.e2e.test.ts` expected a stale active-list row to restore the archived row. The scenario asserts that the confirmed archive leaves the Active view while retaining its separate selection-order coverage.
- `pnpm --dir ui exec vitest run --config vitest.config.ts src/lib/sessions/index.test.ts src/lib/sessions/list-options.test.ts src/lib/sessions/reconcile.test.ts`: 67 tests passed on head `bfcd8f7ac22`.
- `pnpm test:ui:e2e ui/src/e2e/session-management.archive.e2e.test.ts ui/src/e2e/session-management.groups.e2e.test.ts`: 20 tests passed on head `bfcd8f7ac22`.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs`: passed on head `bfcd8f7ac22`.
- P2 autoreview reported no accepted or actionable findings after the identity-gating fix.
- Production delta: +99/-9 (net +90). Tests and test support: +327/-10 (net +317). The production growth owns confirmed archive state at the session capability boundary across roster eviction, event ordering, session identity replacement, deletion, and connection retirement. The presentation-metadata helper has no production delta from `main`.
- Screenshots are not attached because this is a transient state-reconciliation defect rather than a visual styling change. The browser regression exercises the archive, navigation, stale refresh, and return sequence.
