### PR TITLE
feat(gateway): expose public worker ingress

### DIFF
--- a/docs/plan/runners.md
+++ b/docs/plan/runners.md
@@ -23,7 +23,7 @@ advances a milestone.
 | 3   | `openclaw connect` one-paste onboarding + `/j/` join route | in progress | #120768, #122499          |
 | 4   | Picker: grouping, placement, liveness, enrichment          | in progress | #120804, #122531, #122635 |
 | F   | Real-wire session boundary harness                         | landed      | #121212                   |
-| 5   | Public worker ingress path                                 | in progress | #122578                   |
+| 5   | Public worker ingress path                                 | in progress | #122578, #122643          |
 | 6   | Node worker provider (device runners)                      | not started | —                         |
 | 7   | Bundle push consent + runner updates                       | not started | —                         |
 | 8   | Stop-and-continue moves                                    | not started | —                         |

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -59,12 +59,12 @@ export const AUTH_RATE_LIMIT_SCOPE_BOOTSTRAP_TOKEN = "bootstrap-token";
 // Public join-code exchange burns SQLite state, so misses are serialized and
 // throttled before they can queue unbounded writes behind the shared DB lock.
 export const AUTH_RATE_LIMIT_SCOPE_DEVICE_JOIN = "device-join";
-// Public worker admission performs store-backed credential verification before
-// the worker is authenticated, so it gets an independent per-IP guess budget.
-export const AUTH_RATE_LIMIT_SCOPE_WORKER_ADMISSION = "worker-admission";
 // Public watchOS challenge issuance is throttled separately from credential
 // failures so challenge floods cannot displace legitimate device handshakes.
 export const AUTH_RATE_LIMIT_SCOPE_WATCH_CHALLENGE = "watch-challenge";
+// Public worker admission verifies a high-entropy dispatch credential, but
+// failures still need their own per-IP budget before store-backed retries.
+export const AUTH_RATE_LIMIT_SCOPE_WORKER_ADMISSION = "worker-admission";
 export const AUTH_RATE_LIMIT_SCOPE_HOOK_AUTH = "hook-auth";
 const BROWSER_ORIGIN_RATE_LIMIT_KEY_PREFIX = "browser-origin:";
 const IDENTITY_RATE_LIMIT_KEY_PREFIX = "identity:";

--- a/src/gateway/control-ui-routing.test.ts
+++ b/src/gateway/control-ui-routing.test.ts
@@ -316,6 +316,24 @@ describe("classifyControlUiRequest", () => {
         expected: { kind: "not-control-ui" as const },
       },
       {
+        name: "keeps worker admission outside the SPA catch-all",
+        pathname: "/__openclaw__/worker",
+        method: "GET",
+        expected: { kind: "not-control-ui" as const },
+      },
+      {
+        name: "keeps worker admission descendants outside the SPA catch-all",
+        pathname: "/__openclaw__/worker/other",
+        method: "GET",
+        expected: { kind: "not-control-ui" as const },
+      },
+      {
+        name: "preserves SPA routes that only resemble worker admission",
+        pathname: "/__openclaw__/workers",
+        method: "GET",
+        expected: { kind: "serve" as const, spaFallback: true },
+      },
+      {
         name: "keeps health probe descendants outside the SPA catch-all",
         pathname: "/healthz/details",
         method: "GET",

--- a/src/gateway/control-ui-routing.ts
+++ b/src/gateway/control-ui-routing.ts
@@ -3,6 +3,7 @@ import { acceptsControlUiHtmlResponse, isReadHttpMethod } from "./control-ui-htt
 import {
   classifyGatewayProbePath,
   classifyMcpAppStandalonePath,
+  classifyWorkerGatewayPath,
 } from "./gateway-http-route-contracts.js";
 
 type ControlUiRequestClassification =
@@ -68,6 +69,11 @@ export function classifyControlUiRequest(params: {
     // The standalone host owns this namespace when enabled. When disabled or
     // malformed, plugins may still claim it before the final Gateway 404.
     if (classifyMcpAppStandalonePath(pathname) !== "outside") {
+      return { kind: "not-control-ui" };
+    }
+    // Worker admission is upgrade-only; never let the root SPA turn a plain GET
+    // or a malformed descendant into an apparently successful HTML response.
+    if (classifyWorkerGatewayPath(pathname) !== "outside") {
       return { kind: "not-control-ui" };
     }
     // Keep plugin-owned HTTP routes outside the root-mounted Control UI SPA

--- a/src/gateway/gateway-http-route-contracts.ts
+++ b/src/gateway/gateway-http-route-contracts.ts
@@ -9,6 +9,7 @@ const GATEWAY_PROBE_ROUTES = new Map<string, "live" | "ready" | "startup">([
 
 export const MCP_APP_STANDALONE_PATH = "/__openclaw__/mcp-app";
 export const MCP_APP_STANDALONE_VIEW_PATH = `${MCP_APP_STANDALONE_PATH}/view`;
+const WORKER_GATEWAY_PATH = "/__openclaw__/worker";
 
 export function classifyGatewayProbePath(
   pathname: string,
@@ -34,4 +35,11 @@ export function classifyMcpAppStandalonePath(
     return "view";
   }
   return pathname.startsWith(`${MCP_APP_STANDALONE_PATH}/`) ? "namespace" : "outside";
+}
+
+export function classifyWorkerGatewayPath(pathname: string): "worker" | "namespace" | "outside" {
+  if (pathname === WORKER_GATEWAY_PATH) {
+    return "worker";
+  }
+  return pathname.startsWith(`${WORKER_GATEWAY_PATH}/`) ? "namespace" : "outside";
 }

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -966,7 +966,12 @@ export function attachGatewayUpgradeHandler(opts: {
       const originalWorkerGatewayRoute = originalRequestPath
         ? classifyWorkerGatewayPath(originalRequestPath)
         : "outside";
-      if (originalWorkerGatewayRoute === "worker" && workerIngressEnabled) {
+      if (originalWorkerGatewayRoute === "worker" && !workerIngressEnabled) {
+        writeGatewayUpgradeServiceUnavailable(socket, "Worker websocket ingress unavailable");
+        socket.destroy();
+        return;
+      }
+      if (originalWorkerGatewayRoute === "worker") {
         const rateCheck = publicRateLimiter?.check(
           requestClientIp,
           AUTH_RATE_LIMIT_SCOPE_WORKER_ADMISSION,

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -9,7 +9,6 @@ import {
 import { createServer as createHttpsServer } from "node:https";
 import type { TlsOptions } from "node:tls";
 import type { WebSocketServer } from "ws";
-import { WORKER_PUBLIC_INGRESS_PATH } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
 import { isCoreCanvasHostEnabled } from "../canvas/config.js";
 import { isCanvasDocumentHttpPath } from "../canvas/constants.js";
 import { resolveBundledChannelGatewayAuthBypassPaths } from "../channels/plugins/gateway-auth-bypass.js";
@@ -29,6 +28,7 @@ import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
 import { resolveAssistantIdentity } from "./assistant-identity.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
+import { AUTH_RATE_LIMIT_SCOPE_WORKER_ADMISSION } from "./auth-rate-limit.js";
 import {
   authorizeHttpGatewayConnect,
   isLocalDirectRequest,
@@ -50,6 +50,7 @@ import type { DesktopSessionRegistry } from "./desktop/session-registry.js";
 import {
   classifyGatewayProbePath,
   classifyMcpAppStandalonePath,
+  classifyWorkerGatewayPath,
 } from "./gateway-http-route-contracts.js";
 import type { AuthorizedGatewayHttpRequest } from "./http-auth-utils.js";
 import {
@@ -73,6 +74,7 @@ import {
   type PluginRoutePathContext,
 } from "./server/plugins-http/path-context.js";
 import type { PreauthConnectionBudget } from "./server/preauth-connection-budget.js";
+import { markPublicWorkerIngress } from "./server/public-worker-ingress-context.js";
 import type { ReadinessChecker, StartupChecker, StartupResult } from "./server/readiness.js";
 import {
   GATEWAY_WS_CONNECTION_KIND_PROPERTY,
@@ -559,6 +561,12 @@ export function createGatewayHttpServer(opts: {
         run: GatewayHttpRequestStage["run"],
       ) => addRequestStage(name, enabled, run, true);
 
+      const workerGatewayRoute = classifyWorkerGatewayPath(scopedRequestPath);
+      addRequestStage("worker-gateway", workerGatewayRoute !== "outside", () => {
+        respondNotFound(res);
+        return true;
+      });
+
       const devicePairingJoinShortcode = parseDevicePairingJoinRequestPath(scopedRequestPath);
       if (devicePairingJoinShortcode !== null) {
         addAdmittedStage("device-pairing-join", true, async () =>
@@ -926,9 +934,11 @@ export function attachGatewayUpgradeHandler(opts: {
   getResolvedAuth?: () => ResolvedGatewayAuth;
   /** Optional rate limiter for auth brute-force protection. */
   rateLimiter?: AuthRateLimiter;
+  /** Strict public-ingress limiter; loopback is never exempt. */
+  publicRateLimiter?: AuthRateLimiter;
+  workerIngressEnabled?: boolean;
   /** Optional logger for error diagnostics. */
   log?: { warn: (msg: string) => void };
-  workerIngressEnabled?: boolean;
   desktopSessionRegistry?: DesktopSessionRegistry;
 }) {
   const {
@@ -941,6 +951,8 @@ export function attachGatewayUpgradeHandler(opts: {
     preauthConnectionBudget,
     resolvedAuth,
     rateLimiter,
+    publicRateLimiter,
+    workerIngressEnabled,
     log,
   } = opts;
   const getResolvedAuth = opts.getResolvedAuth ?? (() => resolvedAuth);
@@ -950,20 +962,22 @@ export function attachGatewayUpgradeHandler(opts: {
       const trustedProxies = configSnapshot.gateway?.trustedProxies ?? [];
       const allowRealIpFallback = configSnapshot.gateway?.allowRealIpFallback === true;
       const requestClientIp = resolveRequestClientIp(req, trustedProxies, allowRealIpFallback);
-      const scopedNodeCapability = normalizePluginNodeCapabilityScopedUrl(req.url ?? "/");
-      if (scopedNodeCapability.malformedScopedPath) {
-        writeUpgradeAuthFailure(socket, { ok: false, reason: "unauthorized" });
-        socket.destroy();
-        return;
-      }
-      if (scopedNodeCapability.rewrittenUrl) {
-        req.url = scopedNodeCapability.rewrittenUrl;
-      }
-      const resolvedAuthLocal = getResolvedAuth();
-      const requestPath = scopedNodeCapability.pathname;
-      if (requestPath === WORKER_PUBLIC_INGRESS_PATH) {
-        if (!opts.workerIngressEnabled) {
-          writeGatewayUpgradeServiceUnavailable(socket, "Worker websocket ingress unavailable");
+      const originalRequestPath = URL.parse(req.url ?? "/", "http://localhost")?.pathname;
+      const originalWorkerGatewayRoute = originalRequestPath
+        ? classifyWorkerGatewayPath(originalRequestPath)
+        : "outside";
+      if (originalWorkerGatewayRoute === "worker" && workerIngressEnabled) {
+        const rateCheck = publicRateLimiter?.check(
+          requestClientIp,
+          AUTH_RATE_LIMIT_SCOPE_WORKER_ADMISSION,
+        );
+        if (rateCheck && !rateCheck.allowed) {
+          writeUpgradeAuthFailure(socket, {
+            ok: false,
+            reason: "rate_limited",
+            rateLimited: true,
+            retryAfterMs: rateCheck.retryAfterMs,
+          });
           socket.destroy();
           return;
         }
@@ -979,6 +993,10 @@ export function attachGatewayUpgradeHandler(opts: {
             prepareSocket: (workerSocket) => {
               workerSocket[GATEWAY_WS_CONNECTION_KIND_PROPERTY] = "worker";
               workerSocket[GATEWAY_WS_WORKER_INGRESS_PROPERTY] = "public";
+              markPublicWorkerIngress(workerSocket, {
+                clientIp: requestClientIp,
+                rateLimiter: publicRateLimiter,
+              });
             },
           });
         } catch {
@@ -986,7 +1004,29 @@ export function attachGatewayUpgradeHandler(opts: {
         }
         return;
       }
+      if (originalWorkerGatewayRoute !== "outside") {
+        socket.write("HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n");
+        socket.destroy();
+        return;
+      }
+      const scopedNodeCapability = normalizePluginNodeCapabilityScopedUrl(req.url ?? "/");
+      if (scopedNodeCapability.malformedScopedPath) {
+        writeUpgradeAuthFailure(socket, { ok: false, reason: "unauthorized" });
+        socket.destroy();
+        return;
+      }
+      if (scopedNodeCapability.rewrittenUrl) {
+        req.url = scopedNodeCapability.rewrittenUrl;
+      }
+      const resolvedAuthLocal = getResolvedAuth();
+      const requestPath = scopedNodeCapability.pathname;
       const pathContext = resolvePluginRoutePathContext(requestPath);
+      const workerGatewayRoute = classifyWorkerGatewayPath(requestPath);
+      if (workerGatewayRoute !== "outside") {
+        socket.write("HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n");
+        socket.destroy();
+        return;
+      }
       const nodeCapability = resolvePluginNodeCapabilityRoute?.(pathContext);
       if (nodeCapability) {
         // Node-capability WebSocket upgrades authenticate before plugin upgrade dispatch so

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -303,8 +303,9 @@ export async function createGatewayHttpTransport(params: {
       resolvedAuth: params.resolvedAuth,
       getResolvedAuth: params.getResolvedAuth,
       rateLimiter: params.rateLimiter,
-      log: params.log,
+      publicRateLimiter: params.joinRateLimiter,
       workerIngressEnabled: params.workerIngressEnabled,
+      log: params.log,
       desktopSessionRegistry: params.desktopSessionRegistry,
     });
     gatewayHttpServers.push(httpServer);

--- a/src/gateway/server.public-worker-ingress.test.ts
+++ b/src/gateway/server.public-worker-ingress.test.ts
@@ -1,0 +1,469 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocket, WebSocketServer } from "ws";
+import {
+  GATEWAY_CLIENT_IDS,
+  GATEWAY_CLIENT_MODES,
+} from "../../packages/gateway-protocol/src/client-info.js";
+import {
+  PROTOCOL_VERSION,
+  type WorkerConnectParams,
+  WORKER_RPC_SET_VERSION,
+} from "../../packages/gateway-protocol/src/index.js";
+import { createAuthRateLimiter } from "./auth-rate-limit.js";
+import type { ResolvedGatewayAuth } from "./auth.js";
+import {
+  attachGatewayUpgradeHandler,
+  attachWorkerGatewayUpgradeHandler,
+  createGatewayHttpServer,
+} from "./server-http.js";
+import { createPreauthConnectionBudget } from "./server/preauth-connection-budget.js";
+import { attachGatewayWsConnectionHandler } from "./server/ws-connection.js";
+import { createGatewayWsTestLogger } from "./server/ws-connection.test-helpers.js";
+import type { WorkerConnectionService } from "./server/ws-connection/worker-connection.js";
+import type { GatewayWsClient } from "./server/ws-types.js";
+import { withTempConfig } from "./test-temp-config.js";
+import {
+  admitWorkerConnection,
+  validateWorkerConnectionIdentity,
+} from "./worker-environments/admission.js";
+import {
+  createWorkerCredentialMaterial,
+  hashWorkerCredential,
+  type WorkerCredentialRecord,
+} from "./worker-environments/credential.js";
+import type {
+  WorkerEnvironmentRecord,
+  WorkerEnvironmentStore,
+} from "./worker-environments/store.js";
+
+const BUILD = {
+  bundleHash: "a".repeat(64),
+  openclawVersion: "2026.8.12",
+  protocolFeatures: ["worker-heartbeat-v1"],
+} as const;
+const WORKER_GATEWAY_PATH = "/__openclaw__/worker";
+const RESOLVED_AUTH: ResolvedGatewayAuth = { mode: "none", allowTailscale: false };
+const activeHarnesses: PublicWorkerHarness[] = [];
+
+type RejectedWorker = {
+  response: unknown;
+  close: { code: number; reason: string };
+};
+
+function workerConnect(
+  credential: string,
+  overrides: Partial<WorkerConnectParams["admission"]> = {},
+): WorkerConnectParams {
+  return {
+    minProtocol: PROTOCOL_VERSION,
+    maxProtocol: PROTOCOL_VERSION,
+    client: {
+      id: GATEWAY_CLIENT_IDS.WORKER,
+      version: BUILD.openclawVersion,
+      platform: "linux",
+      mode: GATEWAY_CLIENT_MODES.WORKER,
+    },
+    role: "worker",
+    admission: {
+      environmentId: "worker-public",
+      credential,
+      sessionId: null,
+      runId: null,
+      ownerEpoch: 1,
+      rpcSetVersion: WORKER_RPC_SET_VERSION,
+      handshake: BUILD,
+      ...overrides,
+    } as WorkerConnectParams["admission"],
+  };
+}
+
+function connectFrame(params: WorkerConnectParams) {
+  return { type: "req", id: "connect-1", method: "connect", params };
+}
+
+async function waitForOpen(ws: WebSocket): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    ws.once("open", resolve);
+    ws.once("error", reject);
+  });
+}
+
+async function waitForClose(ws: WebSocket): Promise<{ code: number; reason: string }> {
+  return await new Promise((resolve) => {
+    ws.once("close", (code, reason) => resolve({ code, reason: reason.toString() }));
+  });
+}
+
+async function rejectWorker(url: string, params: unknown): Promise<RejectedWorker> {
+  const ws = new WebSocket(url);
+  await waitForOpen(ws);
+  return await rejectOpenedWorker(ws, params);
+}
+
+async function rejectOpenedWorker(ws: WebSocket, params: unknown): Promise<RejectedWorker> {
+  const response = new Promise<unknown>((resolve) => {
+    ws.once("message", (data) => resolve(JSON.parse(rawDataToString(data))));
+  });
+  const close = waitForClose(ws);
+  ws.send(JSON.stringify(connectFrame(params as WorkerConnectParams)));
+  return { response: await response, close: await close };
+}
+
+async function requestUpgradeRejection(
+  port: number,
+  pathname: string,
+): Promise<{ status: number; body: string }> {
+  return await new Promise((resolve, reject) => {
+    const req = http.request({
+      host: "127.0.0.1",
+      port,
+      path: pathname,
+      headers: {
+        Connection: "Upgrade",
+        Upgrade: "websocket",
+        "Sec-WebSocket-Key": "dGVzdC1rZXktMDEyMzQ1Ng==",
+        "Sec-WebSocket-Version": "13",
+      },
+    });
+    req.once("upgrade", (_res, socket) => {
+      socket.destroy();
+      reject(new Error("expected websocket upgrade rejection"));
+    });
+    req.once("response", (res) => {
+      let body = "";
+      res.setEncoding("utf8");
+      res.on("data", (chunk) => {
+        body += chunk;
+      });
+      res.once("end", () => resolve({ status: res.statusCode ?? 0, body }));
+    });
+    req.once("error", reject);
+    req.end();
+  });
+}
+
+class PublicWorkerHarness {
+  readonly credential = createWorkerCredentialMaterial().credential;
+  readonly environment: WorkerEnvironmentRecord;
+  readonly credentialRecord: WorkerCredentialRecord;
+  readonly store: WorkerEnvironmentStore;
+  readonly workerService: WorkerConnectionService;
+  readonly clients = new Set<GatewayWsClient>();
+  readonly wss = new WebSocketServer({ noServer: true, maxPayload: 64 * 1024 });
+  readonly preauthBudget: ReturnType<typeof createPreauthConnectionBudget>;
+  readonly publicRateLimiter: ReturnType<typeof createAuthRateLimiter>;
+  readonly logWsControl = createGatewayWsTestLogger();
+  readonly handlePluginUpgrade = vi.fn(async () => false);
+  readonly httpServer: ReturnType<typeof createGatewayHttpServer>;
+  readonly admitWorker: ReturnType<typeof vi.fn<WorkerConnectionService["admitWorker"]>>;
+  port = 0;
+
+  constructor(options: { preauthLimit?: number; rateLimitMaxAttempts?: number } = {}) {
+    const nowMs = Date.now();
+    this.environment = {
+      environmentId: "worker-public",
+      state: "ready",
+      ownerEpoch: 1,
+      destroyRequestedAtMs: null,
+      bootstrapReceipt: BUILD,
+    } as unknown as WorkerEnvironmentRecord;
+    this.credentialRecord = {
+      environmentId: this.environment.environmentId,
+      credentialHash: hashWorkerCredential(this.credential),
+      bundleHash: BUILD.bundleHash,
+      sessionId: null,
+      rpcSetVersion: WORKER_RPC_SET_VERSION,
+      ownerEpoch: 1,
+      expiresAtMs: nowMs + 60_000,
+      deliveredAtMs: null,
+    };
+    this.store = {
+      get: (environmentId: string) =>
+        environmentId === this.environment.environmentId ? this.environment : undefined,
+      getCredential: (environmentId: string) =>
+        environmentId === this.credentialRecord.environmentId ? this.credentialRecord : undefined,
+      findCredentialByHash: (credentialHash: string) =>
+        credentialHash === this.credentialRecord.credentialHash ? this.credentialRecord : undefined,
+    } as WorkerEnvironmentStore;
+    this.admitWorker = vi.fn(async (admission) =>
+      admitWorkerConnection({
+        store: this.store,
+        admission,
+        expectedBuild: BUILD,
+        nowMs: Date.now(),
+      }),
+    );
+    this.workerService = {
+      admitWorker: this.admitWorker,
+      validateWorkerConnection: (identity) =>
+        validateWorkerConnectionIdentity({ store: this.store, identity, nowMs: Date.now() }),
+      commitTranscript: async () => ({ ok: false, reason: "invalid-batch" }),
+      pushLiveEvent: async () => ({ ok: false, details: { reason: "invalid-event" } }),
+    };
+    this.preauthBudget = createPreauthConnectionBudget(options.preauthLimit ?? 8);
+    this.publicRateLimiter = createAuthRateLimiter({
+      maxAttempts: options.rateLimitMaxAttempts ?? 10,
+      exemptLoopback: false,
+      pruneIntervalMs: 0,
+    });
+    this.httpServer = createGatewayHttpServer({
+      clients: this.clients,
+      controlUiEnabled: true,
+      controlUiBasePath: "",
+      openAiChatCompletionsEnabled: false,
+      openResponsesEnabled: false,
+      handleHooksRequest: async () => false,
+      resolvedAuth: RESOLVED_AUTH,
+    });
+  }
+
+  async start(): Promise<void> {
+    const logGateway = createGatewayWsTestLogger();
+    attachGatewayWsConnectionHandler({
+      wss: this.wss,
+      clients: this.clients,
+      preauthConnectionBudget: this.preauthBudget,
+      port: 0,
+      getResolvedAuth: () => RESOLVED_AUTH,
+      preauthHandshakeTimeoutMs: 5_000,
+      gatewayMethods: [],
+      events: [],
+      refreshHealthSnapshot: vi.fn(async () => ({}) as never),
+      logGateway: logGateway as never,
+      logHealth: createGatewayWsTestLogger() as never,
+      logWsControl: this.logWsControl as never,
+      extraHandlers: {},
+      broadcast: vi.fn(),
+      buildRequestContext: () => ({}) as never,
+      workerConnectionService: this.workerService,
+    });
+    attachGatewayUpgradeHandler({
+      httpServer: this.httpServer,
+      wss: this.wss,
+      handlePluginUpgrade: this.handlePluginUpgrade,
+      clients: this.clients,
+      preauthConnectionBudget: this.preauthBudget,
+      resolvedAuth: RESOLVED_AUTH,
+      publicRateLimiter: this.publicRateLimiter,
+      workerIngressEnabled: true,
+    });
+    await new Promise<void>((resolve) => {
+      this.httpServer.listen(0, "127.0.0.1", resolve);
+    });
+    this.port = (this.httpServer.address() as AddressInfo).port;
+  }
+
+  url(pathname = WORKER_GATEWAY_PATH): string {
+    return `ws://127.0.0.1:${this.port}${pathname}`;
+  }
+
+  async close(): Promise<void> {
+    this.publicRateLimiter.dispose();
+    for (const socket of this.wss.clients) {
+      socket.terminate();
+    }
+    await new Promise<void>((resolve) => {
+      this.wss.close(() => resolve());
+    });
+    if (this.httpServer.listening) {
+      await new Promise<void>((resolve, reject) => {
+        this.httpServer.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  }
+}
+
+async function withHarness(
+  options: ConstructorParameters<typeof PublicWorkerHarness>[0],
+  run: (harness: PublicWorkerHarness) => Promise<void>,
+): Promise<void> {
+  await withTempConfig({
+    cfg: {},
+    prefix: "openclaw-public-worker-ingress-",
+    run: async () => {
+      const harness = new PublicWorkerHarness(options);
+      activeHarnesses.push(harness);
+      await harness.start();
+      await run(harness);
+    },
+  });
+}
+
+afterEach(async () => {
+  for (const harness of activeHarnesses.splice(0)) {
+    await harness.close();
+  }
+});
+
+describe("public worker ingress", () => {
+  it("admits a store-backed worker on the reserved public path", async () => {
+    await withHarness({}, async (harness) => {
+      const response = new Promise<unknown>((resolve) => {
+        const ws = new WebSocket(harness.url());
+        ws.once("open", () =>
+          ws.send(JSON.stringify(connectFrame(workerConnect(harness.credential)))),
+        );
+        ws.once("message", (data) => {
+          resolve(JSON.parse(rawDataToString(data)));
+          ws.close();
+        });
+      });
+
+      await expect(response).resolves.toMatchObject({
+        ok: true,
+        payload: { type: "worker-hello-ok", environmentId: "worker-public" },
+      });
+      expect(harness.handlePluginUpgrade).not.toHaveBeenCalled();
+      expect(harness.publicRateLimiter.size()).toBe(0);
+    });
+  });
+
+  it("returns one opaque failure while retaining precise server reasons", async () => {
+    await withHarness({}, async (harness) => {
+      const badCredential = await rejectWorker(
+        harness.url(),
+        workerConnect("invalid-worker-credential-fixture"),
+      );
+      const wrongEnvironment = await rejectWorker(
+        harness.url(),
+        workerConnect(harness.credential, { environmentId: "worker-other" }),
+      );
+
+      expect(badCredential).toEqual(wrongEnvironment);
+      expect(badCredential).toEqual({
+        response: {
+          type: "res",
+          id: "connect-1",
+          ok: false,
+          error: {
+            code: "INVALID_REQUEST",
+            message: "worker admission rejected",
+            details: { reason: "invalid-handshake" },
+          },
+        },
+        close: { code: 1008, reason: "invalid-handshake" },
+      });
+      expect(harness.logWsControl.warn).toHaveBeenCalledWith(
+        "worker admission rejected reason=invalid-credential",
+      );
+      expect(harness.logWsControl.warn).toHaveBeenCalledWith(
+        "worker admission rejected reason=environment-mismatch",
+      );
+    });
+  });
+
+  it("forces connection kind from the route in both directions", async () => {
+    await withHarness({}, async (harness) => {
+      const operator = new WebSocket(harness.url());
+      const operatorClose = waitForClose(operator);
+      await waitForOpen(operator);
+      operator.send(
+        JSON.stringify(
+          connectFrame({
+            minProtocol: PROTOCOL_VERSION,
+            maxProtocol: PROTOCOL_VERSION,
+            client: { id: "test", version: "1", platform: "test", mode: "cli" },
+            role: "operator",
+            scopes: [],
+          } as never),
+        ),
+      );
+      await expect(operatorClose).resolves.toEqual({ code: 1008, reason: "invalid-handshake" });
+
+      const worker = new WebSocket(harness.url("/"));
+      const workerClose = waitForClose(worker);
+      await waitForOpen(worker);
+      worker.send(JSON.stringify(connectFrame(workerConnect(harness.credential))));
+      await expect(workerClose).resolves.toEqual({ code: 1008, reason: "invalid-handshake" });
+    });
+  });
+
+  it("shares the gateway preauth budget without affecting loopback worker ingress", async () => {
+    await withHarness({ preauthLimit: 1 }, async (harness) => {
+      const publicWorker = new WebSocket(harness.url());
+      await waitForOpen(publicWorker);
+
+      await expect(requestUpgradeRejection(harness.port, "/")).resolves.toEqual({
+        status: 503,
+        body: "Too many unauthenticated sockets",
+      });
+
+      const loopbackServer = http.createServer();
+      attachWorkerGatewayUpgradeHandler({
+        httpServer: loopbackServer,
+        wss: harness.wss,
+        preauthConnectionBudget: createPreauthConnectionBudget(1),
+      });
+      await new Promise<void>((resolve) => {
+        loopbackServer.listen(0, "127.0.0.1", resolve);
+      });
+      const loopbackPort = (loopbackServer.address() as AddressInfo).port;
+      const loopbackWorker = new WebSocket(`ws://127.0.0.1:${loopbackPort}`);
+      try {
+        await waitForOpen(loopbackWorker);
+      } finally {
+        const loopbackClose = waitForClose(loopbackWorker);
+        const publicClose = waitForClose(publicWorker);
+        loopbackWorker.close();
+        publicWorker.close();
+        await Promise.all([loopbackClose, publicClose]);
+        await new Promise<void>((resolve, reject) => {
+          loopbackServer.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    });
+  });
+
+  it("rate-limits parallel invalid admissions before repeated store work", async () => {
+    await withHarness({ rateLimitMaxAttempts: 2 }, async (harness) => {
+      const sockets = Array.from({ length: 6 }, () => new WebSocket(harness.url()));
+      await Promise.all(sockets.map((socket) => waitForOpen(socket)));
+      const attempts = await Promise.all(
+        sockets.map((socket, index) =>
+          rejectOpenedWorker(
+            socket,
+            workerConnect(`invalid-worker-credential-${index.toString().padStart(2, "0")}`),
+          ),
+        ),
+      );
+
+      expect(harness.admitWorker).toHaveBeenCalledTimes(2);
+      expect(new Set(attempts.map((attempt) => JSON.stringify(attempt)))).toEqual(
+        new Set([
+          JSON.stringify({
+            response: {
+              type: "res",
+              id: "connect-1",
+              ok: false,
+              error: {
+                code: "INVALID_REQUEST",
+                message: "worker admission rejected",
+                details: { reason: "invalid-handshake" },
+              },
+            },
+            close: { code: 1008, reason: "invalid-handshake" },
+          }),
+        ]),
+      );
+    });
+  });
+
+  it("reserves the worker namespace for non-upgrade requests and scoped aliases", async () => {
+    await withHarness({}, async (harness) => {
+      const response = await fetch(`http://127.0.0.1:${harness.port}${WORKER_GATEWAY_PATH}`);
+      expect(response.status).toBe(404);
+      await expect(response.text()).resolves.toBe("Not Found");
+
+      await expect(
+        requestUpgradeRejection(
+          harness.port,
+          `/__openclaw__/cap/${"a".repeat(32)}${WORKER_GATEWAY_PATH}`,
+        ),
+      ).resolves.toEqual({ status: 404, body: "" });
+      expect(harness.handlePluginUpgrade).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/gateway/server/public-worker-ingress-context.ts
+++ b/src/gateway/server/public-worker-ingress-context.ts
@@ -1,0 +1,23 @@
+import type { WebSocket } from "ws";
+import type { AuthRateLimiter } from "../auth-rate-limit.js";
+
+export type PublicWorkerIngressContext = {
+  clientIp: string | undefined;
+  rateLimiter: AuthRateLimiter | undefined;
+};
+
+const publicWorkerIngressContexts = new WeakMap<WebSocket, PublicWorkerIngressContext>();
+
+/** Carry route-authenticated public ingress facts into the shared connection owner. */
+export function markPublicWorkerIngress(
+  socket: WebSocket,
+  context: PublicWorkerIngressContext,
+): void {
+  publicWorkerIngressContexts.set(socket, context);
+}
+
+export function takePublicWorkerIngress(socket: WebSocket): PublicWorkerIngressContext | undefined {
+  const context = publicWorkerIngressContexts.get(socket);
+  publicWorkerIngressContexts.delete(socket);
+  return context;
+}

--- a/src/gateway/server/ws-connection-diagnostics.ts
+++ b/src/gateway/server/ws-connection-diagnostics.ts
@@ -1,0 +1,95 @@
+import type { Socket } from "node:net";
+import type { WebSocket } from "ws";
+import { truncateUtf16Safe } from "../../utils.js";
+
+const LOG_HEADER_MAX_LEN = 300;
+const LOG_HEADER_FORMAT_REGEX = /\p{Cf}/gu;
+
+function replaceControlChars(value: string): string {
+  let cleaned = "";
+  for (const char of value) {
+    const codePoint = char.codePointAt(0);
+    if (
+      codePoint !== undefined &&
+      (codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f))
+    ) {
+      cleaned += " ";
+      continue;
+    }
+    cleaned += char;
+  }
+  return cleaned;
+}
+
+export function stringMetaValue(meta: Record<string, unknown>, key: string): string | undefined {
+  const value = meta[key];
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+export function sanitizeWsLogValue(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const cleaned = replaceControlChars(value)
+    .replace(LOG_HEADER_FORMAT_REGEX, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!cleaned) {
+    return undefined;
+  }
+  if (cleaned.length <= LOG_HEADER_MAX_LEN) {
+    return cleaned;
+  }
+  return truncateUtf16Safe(cleaned, LOG_HEADER_MAX_LEN);
+}
+
+function formatSocketEndpoint(
+  address: string | undefined,
+  port: number | undefined,
+): string | undefined {
+  if (!address) {
+    return undefined;
+  }
+  if (port === undefined) {
+    return address;
+  }
+  return address.includes(":") ? `[${address}]:${port}` : `${address}:${port}`;
+}
+
+export function resolveSocketAddress(socket: WebSocket): {
+  remoteAddr?: string;
+  remotePort?: number;
+  localAddr?: string;
+  localPort?: number;
+  endpoint?: string;
+} {
+  const rawSocket = (socket as WebSocket & { _socket?: Socket })["_socket"];
+  const remoteAddr = rawSocket?.remoteAddress;
+  const remotePort = rawSocket?.remotePort;
+  const localAddr = rawSocket?.localAddress;
+  const localPort = rawSocket?.localPort;
+  const remoteEndpoint = formatSocketEndpoint(remoteAddr, remotePort);
+  const localEndpoint = formatSocketEndpoint(localAddr, localPort);
+  return {
+    remoteAddr,
+    remotePort,
+    localAddr,
+    localPort,
+    endpoint:
+      remoteEndpoint && localEndpoint
+        ? `${remoteEndpoint}->${localEndpoint}`
+        : (remoteEndpoint ?? localEndpoint),
+  };
+}
+
+export function isWsPayloadLimitError(err: unknown): boolean {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  const code = (err as { code?: unknown }).code;
+  if (code === "WS_ERR_UNSUPPORTED_MESSAGE_LENGTH") {
+    return true;
+  }
+  const message = (err as { message?: unknown }).message;
+  return typeof message === "string" && /max payload size exceeded/i.test(message);
+}

--- a/src/gateway/server/ws-connection.test.ts
+++ b/src/gateway/server/ws-connection.test.ts
@@ -44,8 +44,8 @@ vi.mock("../talk-session-registry.js", () => ({
   cleanupTalkConnection: cleanupTalkConnectionMock,
 }));
 
-import { attachGatewayWsConnectionHandler } from "./ws-connection.js";
 import { markPublicWorkerIngress } from "./public-worker-ingress-context.js";
+import { attachGatewayWsConnectionHandler } from "./ws-connection.js";
 import { resolveSharedGatewaySessionGeneration } from "./ws-shared-generation.js";
 import {
   GATEWAY_WS_CONNECTION_KIND_PROPERTY,

--- a/src/gateway/server/ws-connection.test.ts
+++ b/src/gateway/server/ws-connection.test.ts
@@ -45,6 +45,7 @@ vi.mock("../talk-session-registry.js", () => ({
 }));
 
 import { attachGatewayWsConnectionHandler } from "./ws-connection.js";
+import { markPublicWorkerIngress } from "./public-worker-ingress-context.js";
 import { resolveSharedGatewaySessionGeneration } from "./ws-shared-generation.js";
 import {
   GATEWAY_WS_CONNECTION_KIND_PROPERTY,
@@ -154,7 +155,7 @@ describe("attachGatewayWsConnectionHandler", () => {
     expect(gatewayBudget.release).not.toHaveBeenCalled();
   });
 
-  it("uses the main budget and auth limiter for public worker sockets", async () => {
+  it("uses the main budget and public admission context for public worker sockets", async () => {
     const socket = createGatewayWsTestSocket();
     const gatewayBudget = { release: vi.fn() };
     const rateLimiter = { check: vi.fn() };
@@ -163,25 +164,24 @@ describe("attachGatewayWsConnectionHandler", () => {
       [GATEWAY_WS_WORKER_INGRESS_PROPERTY]: "public",
       __openclawPreauthBudgetKey: "203.0.113.10",
     });
+    markPublicWorkerIngress(socket as never, {
+      clientIp: "203.0.113.10",
+      rateLimiter: rateLimiter as never,
+    });
 
     await connectTestWs({
       socket,
       options: {
         preauthConnectionBudget: gatewayBudget as never,
-        rateLimiter: rateLimiter as never,
       },
     });
 
     const handler = firstAttachedWorkerHandlerParams() as {
-      ingress: string;
-      rateLimiter: unknown;
-      rateLimitClientIp: string;
+      publicAdmission: { clientIp: string; rateLimiter: unknown };
       setClient(client: never): boolean;
     };
     expect(handler).toMatchObject({
-      ingress: "public",
-      rateLimiter,
-      rateLimitClientIp: "203.0.113.10",
+      publicAdmission: { clientIp: "203.0.113.10", rateLimiter },
     });
     expect(handler.setClient({ socket } as never)).toBe(true);
     expect(gatewayBudget.release).toHaveBeenCalledWith("203.0.113.10");

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -1,6 +1,5 @@
 // Gateway WebSocket connection handler owns pre-auth limits, handshake auth, presence, and message-handler attachment.
 import { randomUUID } from "node:crypto";
-import type { Socket } from "node:net";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { RawData, WebSocket, WebSocketServer } from "ws";
 import { WORKER_PROTOCOL_MAX_PAYLOAD_BYTES } from "../../../packages/gateway-protocol/src/index.js";
@@ -10,7 +9,6 @@ import { touchPresence, upsertPresence } from "../../infra/system-presence.js";
 import { logRejectedLargePayload } from "../../logging/diagnostic-payload.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import { removeRemoteNodeInfo } from "../../skills/runtime/remote.js";
-import { truncateUtf16Safe } from "../../utils.js";
 import { isWebchatClient } from "../../utils/message-channel.js";
 import type { AuthRateLimiter } from "../auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "../auth.js";
@@ -35,6 +33,12 @@ import type { PreauthConnectionBudget } from "./preauth-connection-budget.js";
 import { broadcastPresenceSnapshot } from "./presence-events.js";
 import { takePublicWorkerIngress } from "./public-worker-ingress-context.js";
 import {
+  isWsPayloadLimitError,
+  resolveSocketAddress,
+  sanitizeWsLogValue,
+  stringMetaValue,
+} from "./ws-connection-diagnostics.js";
+import {
   buildHandshakeAuthLogKey,
   HandshakeAuthLogLimiter,
   shouldLimitMissingCredentialAuthLog,
@@ -52,106 +56,18 @@ import { resolveSharedGatewaySessionGeneration } from "./ws-shared-generation.js
 import {
   GATEWAY_WS_CONNECTION_KIND_PROPERTY,
   GATEWAY_WS_PREAUTH_BUDGET_PROPERTY,
+  GATEWAY_WS_WORKER_INGRESS_PROPERTY,
   WS_HANDSHAKE_PHASES,
   type GatewayIngressWebSocket,
+  type GatewayWorkerIngress,
   type GatewayWsClient,
   type WsHandshakePhase,
 } from "./ws-types.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
-const LOG_HEADER_MAX_LEN = 300;
-const LOG_HEADER_FORMAT_REGEX = /\p{Cf}/gu;
 const MAX_QUEUED_MESSAGE_HANDLER_FRAMES = 16;
 const unauthorizedCloseBeforeConnectLogLimiter = new HandshakeAuthLogLimiter();
-
-function replaceControlChars(value: string): string {
-  let cleaned = "";
-  for (const char of value) {
-    const codePoint = char.codePointAt(0);
-    if (
-      codePoint !== undefined &&
-      (codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f))
-    ) {
-      cleaned += " ";
-      continue;
-    }
-    cleaned += char;
-  }
-  return cleaned;
-}
-
-function stringMetaValue(meta: Record<string, unknown>, key: string): string | undefined {
-  const value = meta[key];
-  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
-}
-const sanitizeLogValue = (value: string | undefined): string | undefined => {
-  if (!value) {
-    return undefined;
-  }
-  const cleaned = replaceControlChars(value)
-    .replace(LOG_HEADER_FORMAT_REGEX, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-  if (!cleaned) {
-    return undefined;
-  }
-  if (cleaned.length <= LOG_HEADER_MAX_LEN) {
-    return cleaned;
-  }
-  return truncateUtf16Safe(cleaned, LOG_HEADER_MAX_LEN);
-};
-
-function formatSocketEndpoint(
-  address: string | undefined,
-  port: number | undefined,
-): string | undefined {
-  if (!address) {
-    return undefined;
-  }
-  if (port === undefined) {
-    return address;
-  }
-  return address.includes(":") ? `[${address}]:${port}` : `${address}:${port}`;
-}
-
-function resolveSocketAddress(socket: WebSocket): {
-  remoteAddr?: string;
-  remotePort?: number;
-  localAddr?: string;
-  localPort?: number;
-  endpoint?: string;
-} {
-  const rawSocket = (socket as WebSocket & { _socket?: Socket })["_socket"];
-  const remoteAddr = rawSocket?.remoteAddress;
-  const remotePort = rawSocket?.remotePort;
-  const localAddr = rawSocket?.localAddress;
-  const localPort = rawSocket?.localPort;
-  const remoteEndpoint = formatSocketEndpoint(remoteAddr, remotePort);
-  const localEndpoint = formatSocketEndpoint(localAddr, localPort);
-  return {
-    remoteAddr,
-    remotePort,
-    localAddr,
-    localPort,
-    endpoint:
-      remoteEndpoint && localEndpoint
-        ? `${remoteEndpoint}->${localEndpoint}`
-        : (remoteEndpoint ?? localEndpoint),
-  };
-}
-
-function isWsPayloadLimitError(err: unknown): boolean {
-  if (!err || typeof err !== "object") {
-    return false;
-  }
-  const code = (err as { code?: unknown }).code;
-  if (code === "WS_ERR_UNSUPPORTED_MESSAGE_LENGTH") {
-    return true;
-  }
-  const message = (err as { message?: unknown }).message;
-  return typeof message === "string" && /max payload size exceeded/i.test(message);
-}
 
 type GatewayWsSharedHandlerParams = {
   wss: WebSocketServer;
@@ -277,7 +193,10 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
     const connId = randomUUID();
     const ingressSocket = socket as GatewayIngressWebSocket;
     const connectionKind = ingressSocket[GATEWAY_WS_CONNECTION_KIND_PROPERTY] ?? "gateway";
-    const publicWorkerIngress = takePublicWorkerIngress(socket);
+    const workerIngress: GatewayWorkerIngress =
+      ingressSocket[GATEWAY_WS_WORKER_INGRESS_PROPERTY] ?? "loopback";
+    const publicWorkerIngress =
+      workerIngress === "public" ? takePublicWorkerIngress(socket) : undefined;
     const connectionPreauthBudget =
       ingressSocket[GATEWAY_WS_PREAUTH_BUDGET_PROPERTY] ?? preauthConnectionBudget;
     const { remoteAddr, remotePort, localAddr, localPort, endpoint } = resolveSocketAddress(socket);
@@ -489,11 +408,11 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
 
     const handleSocketClose = async (code: number, reason: Buffer) => {
       const durationMs = Date.now() - openedAt;
-      const logForwardedFor = sanitizeLogValue(forwardedFor);
-      const logOrigin = sanitizeLogValue(requestOrigin);
-      const logHost = sanitizeLogValue(requestHost);
-      const logUserAgent = sanitizeLogValue(requestUserAgent);
-      const logReason = sanitizeLogValue(reason?.toString());
+      const logForwardedFor = sanitizeWsLogValue(forwardedFor);
+      const logOrigin = sanitizeWsLogValue(requestOrigin);
+      const logHost = sanitizeWsLogValue(requestHost);
+      const logUserAgent = sanitizeWsLogValue(requestUserAgent);
+      const logReason = sanitizeWsLogValue(reason?.toString());
       const handshakeIncomplete = lastHandshakePhase !== "ready";
       const closeContext = {
         cause: closeCause,
@@ -682,6 +601,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         connId,
         service: workerConnectionService,
         isStartupPending,
+        ingress: workerIngress,
         send,
         close,
         isClosed: () => closed,

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -33,6 +33,7 @@ import { formatForLog, logWs } from "../ws-log.js";
 import { getHealthVersion, incrementPresenceVersion } from "./health-state.js";
 import type { PreauthConnectionBudget } from "./preauth-connection-budget.js";
 import { broadcastPresenceSnapshot } from "./presence-events.js";
+import { takePublicWorkerIngress } from "./public-worker-ingress-context.js";
 import {
   buildHandshakeAuthLogKey,
   HandshakeAuthLogLimiter,
@@ -51,7 +52,6 @@ import { resolveSharedGatewaySessionGeneration } from "./ws-shared-generation.js
 import {
   GATEWAY_WS_CONNECTION_KIND_PROPERTY,
   GATEWAY_WS_PREAUTH_BUDGET_PROPERTY,
-  GATEWAY_WS_WORKER_INGRESS_PROPERTY,
   WS_HANDSHAKE_PHASES,
   type GatewayIngressWebSocket,
   type GatewayWsClient,
@@ -277,7 +277,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
     const connId = randomUUID();
     const ingressSocket = socket as GatewayIngressWebSocket;
     const connectionKind = ingressSocket[GATEWAY_WS_CONNECTION_KIND_PROPERTY] ?? "gateway";
-    const workerIngress = ingressSocket[GATEWAY_WS_WORKER_INGRESS_PROPERTY] ?? "loopback";
+    const publicWorkerIngress = takePublicWorkerIngress(socket);
     const connectionPreauthBudget =
       ingressSocket[GATEWAY_WS_PREAUTH_BUDGET_PROPERTY] ?? preauthConnectionBudget;
     const { remoteAddr, remotePort, localAddr, localPort, endpoint } = resolveSocketAddress(socket);
@@ -682,9 +682,6 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         connId,
         service: workerConnectionService,
         isStartupPending,
-        ingress: workerIngress,
-        rateLimiter: workerIngress === "public" ? rateLimiter : undefined,
-        rateLimitClientIp: workerIngress === "public" ? preauthBudgetKey : undefined,
         send,
         close,
         isClosed: () => closed,
@@ -699,6 +696,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         setLastFrameMeta,
         logGateway,
         logWsControl,
+        publicAdmission: publicWorkerIngress,
       });
       return;
     }

--- a/src/gateway/server/ws-connection/message-handler.worker.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.worker.test.ts
@@ -223,9 +223,10 @@ function attachHarness(
     socket: socket as unknown as WebSocket,
     connId: "worker-connection",
     service,
-    ingress: options.ingress,
-    rateLimiter: options.rateLimiter,
-    rateLimitClientIp: options.rateLimiter ? "203.0.113.10" : undefined,
+    publicAdmission:
+      options.ingress === "public"
+        ? { clientIp: "203.0.113.10", rateLimiter: options.rateLimiter }
+        : undefined,
     send: (frame) => responses.push(frame),
     close,
     isClosed: () => false,
@@ -300,8 +301,8 @@ describe("dedicated worker websocket protocol", () => {
   it.each(["invalid-credential", "environment-mismatch"] as const)(
     "projects public %s failures to one opaque reason",
     async (internalReason) => {
-      const recordFailureAndDelay = vi.fn(async () => {});
-      const rateLimiter = createRateLimiter({ recordFailureAndDelay });
+      const recordFailure = vi.fn();
+      const rateLimiter = createRateLimiter({ recordFailure });
       const harness = attachHarness({
         admissionFailure: internalReason,
         ingress: "public",
@@ -310,17 +311,17 @@ describe("dedicated worker websocket protocol", () => {
       harness.sendConnect();
 
       await waitForWorkerProtocol(() =>
-        expect(harness.close).toHaveBeenCalledWith(1008, "admission-rejected"),
+        expect(harness.close).toHaveBeenCalledWith(1008, "invalid-handshake"),
       );
       expect(harness.responses[0]).toMatchObject({
         ok: false,
-        error: { details: { reason: "admission-rejected" } },
+        error: { details: { reason: "invalid-handshake" } },
       });
       expect(harness.logWsControl.warn).toHaveBeenCalledWith(
         `worker admission rejected reason=${internalReason}`,
       );
       expect(harness.setCloseCause).toHaveBeenCalledWith(internalReason);
-      expect(recordFailureAndDelay).toHaveBeenCalledWith("203.0.113.10", "worker-admission");
+      expect(recordFailure).toHaveBeenCalledWith("203.0.113.10", "worker-admission");
     },
   );
 
@@ -332,14 +333,12 @@ describe("dedicated worker websocket protocol", () => {
     harness.sendConnect();
 
     await waitForWorkerProtocol(() =>
-      expect(harness.close).toHaveBeenCalledWith(1008, "admission-rejected"),
+      expect(harness.close).toHaveBeenCalledWith(1008, "invalid-handshake"),
     );
     expect(harness.responses[0]).toMatchObject({
       ok: false,
       error: {
-        details: { reason: "admission-rejected" },
-        retryable: true,
-        retryAfterMs: 12_000,
+        details: { reason: "invalid-handshake" },
       },
     });
     expect(harness.service.admitWorker).not.toHaveBeenCalled();
@@ -355,10 +354,10 @@ describe("dedicated worker websocket protocol", () => {
     expect(reset).toHaveBeenCalledWith("203.0.113.10", "worker-admission");
   });
 
-  it("keeps public ownership failures opaque without charging the credential budget", async () => {
+  it("keeps public ownership failures opaque and charges the admission budget", async () => {
     const reset = vi.fn();
-    const recordFailureAndDelay = vi.fn(async () => {});
-    const rateLimiter = createRateLimiter({ reset, recordFailureAndDelay });
+    const recordFailure = vi.fn();
+    const rateLimiter = createRateLimiter({ reset, recordFailure });
     const harness = attachHarness({
       ingress: "public",
       rateLimiter,
@@ -367,13 +366,13 @@ describe("dedicated worker websocket protocol", () => {
     harness.sendConnect();
 
     await waitForWorkerProtocol(() =>
-      expect(harness.close).toHaveBeenCalledWith(1008, "admission-rejected"),
+      expect(harness.close).toHaveBeenCalledWith(1008, "invalid-handshake"),
     );
     expect(harness.logWsControl.warn).toHaveBeenCalledWith(
       "worker admission rejected reason=credential-replaced",
     );
-    expect(reset).toHaveBeenCalledOnce();
-    expect(recordFailureAndDelay).not.toHaveBeenCalled();
+    expect(recordFailure).toHaveBeenCalledWith("203.0.113.10", "worker-admission");
+    expect(reset).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/src/gateway/server/ws-connection/message-handler.worker.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.worker.test.ts
@@ -157,6 +157,7 @@ function attachHarness(
     identity?: WorkerConnectionIdentity;
     liveFailure?: WorkerLiveEventErrorDetails;
     ingress?: "loopback" | "public";
+    omitPublicAdmission?: boolean;
     rateLimiter?: AuthRateLimiter;
     onInferenceLaunch?: (sink: InferenceSink) => void;
     onSessionTool?: (signal: AbortSignal | undefined) => Promise<WorkerSessionToolResult>;
@@ -223,8 +224,9 @@ function attachHarness(
     socket: socket as unknown as WebSocket,
     connId: "worker-connection",
     service,
+    ingress: options.ingress ?? "loopback",
     publicAdmission:
-      options.ingress === "public"
+      options.ingress === "public" && !options.omitPublicAdmission
         ? { clientIp: "203.0.113.10", rateLimiter: options.rateLimiter }
         : undefined,
     send: (frame) => responses.push(frame),
@@ -296,6 +298,19 @@ describe("dedicated worker websocket protocol", () => {
       `worker admission rejected reason=${reason}`,
     );
     expect(harness.setClient).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when public ingress context is missing", async () => {
+    const harness = attachHarness({ ingress: "public", omitPublicAdmission: true });
+    harness.sendConnect();
+
+    await waitForWorkerProtocol(() =>
+      expect(harness.close).toHaveBeenCalledWith(1008, "invalid-handshake"),
+    );
+    expect(harness.service.admitWorker).not.toHaveBeenCalled();
+    expect(harness.logWsControl.warn).toHaveBeenCalledWith(
+      "worker admission rejected reason=public-ingress-context-missing",
+    );
   });
 
   it.each(["invalid-credential", "environment-mismatch"] as const)(

--- a/src/gateway/server/ws-connection/worker-admission-boundary.ts
+++ b/src/gateway/server/ws-connection/worker-admission-boundary.ts
@@ -1,0 +1,76 @@
+import type {
+  WorkerConnectParams,
+  WorkerProtocolCloseReason,
+} from "../../../../packages/gateway-protocol/src/index.js";
+import { AUTH_RATE_LIMIT_SCOPE_WORKER_ADMISSION } from "../../auth-rate-limit.js";
+import { withSerializedRateLimitAttempt } from "../../rate-limit-attempt-serialization.js";
+import type { WorkerConnectionIdentity } from "../../worker-environments/connection-identity.js";
+import type { PublicWorkerIngressContext } from "../public-worker-ingress-context.js";
+
+type WorkerAdmissionService = {
+  admitWorker(
+    admission: WorkerConnectParams["admission"],
+  ): Promise<
+    | { ok: true; identity: WorkerConnectionIdentity }
+    | { ok: false; reason: WorkerProtocolCloseReason }
+  >;
+  validateWorkerConnection(identity: WorkerConnectionIdentity): WorkerProtocolCloseReason | null;
+};
+
+type WorkerAdmissionBoundaryResult =
+  | { ok: true; identity: WorkerConnectionIdentity }
+  | { ok: false; reason: WorkerProtocolCloseReason | "rate-limited" | "claim-rejected" };
+
+/** Serialize public credential checks and charge only failed admission attempts. */
+export async function runWorkerAdmissionBoundary(params: {
+  service: WorkerAdmissionService | undefined;
+  admission: WorkerConnectParams["admission"];
+  publicAdmission: PublicWorkerIngressContext | undefined;
+  claim(identity: WorkerConnectionIdentity): boolean;
+}): Promise<WorkerAdmissionBoundaryResult> {
+  const run = async (): Promise<WorkerAdmissionBoundaryResult> => {
+    const publicAdmission = params.publicAdmission;
+    const rateCheck = publicAdmission?.rateLimiter?.check(
+      publicAdmission.clientIp,
+      AUTH_RATE_LIMIT_SCOPE_WORKER_ADMISSION,
+    );
+    if (rateCheck && !rateCheck.allowed) {
+      return { ok: false, reason: "rate-limited" };
+    }
+    const admission =
+      (await params.service?.admitWorker(params.admission)) ??
+      ({ ok: false, reason: "environment-unavailable" } as const);
+    if (!admission.ok) {
+      publicAdmission?.rateLimiter?.recordFailure(
+        publicAdmission.clientIp,
+        AUTH_RATE_LIMIT_SCOPE_WORKER_ADMISSION,
+      );
+      return admission;
+    }
+    const ownershipFailure = params.service?.validateWorkerConnection(admission.identity);
+    if (ownershipFailure) {
+      publicAdmission?.rateLimiter?.recordFailure(
+        publicAdmission.clientIp,
+        AUTH_RATE_LIMIT_SCOPE_WORKER_ADMISSION,
+      );
+      return { ok: false, reason: ownershipFailure };
+    }
+    if (!params.claim(admission.identity)) {
+      return { ok: false, reason: "claim-rejected" };
+    }
+    publicAdmission?.rateLimiter?.reset(
+      publicAdmission.clientIp,
+      AUTH_RATE_LIMIT_SCOPE_WORKER_ADMISSION,
+    );
+    return admission;
+  };
+
+  if (!params.publicAdmission?.rateLimiter) {
+    return await run();
+  }
+  return await withSerializedRateLimitAttempt({
+    ip: params.publicAdmission.clientIp,
+    scope: AUTH_RATE_LIMIT_SCOPE_WORKER_ADMISSION,
+    run,
+  });
+}

--- a/src/gateway/server/ws-connection/worker-connection.ts
+++ b/src/gateway/server/ws-connection/worker-connection.ts
@@ -58,7 +58,7 @@ import { AUTH_RATE_LIMIT_SCOPE_WORKER_ADMISSION } from "../../auth-rate-limit.js
 import type { WorkerConnectionIdentity } from "../../worker-environments/connection-identity.js";
 import { MAX_RUNNING_WORKER_SESSION_TOOL_OPERATIONS } from "../../worker-environments/placement-session-tool-operations.js";
 import type { PublicWorkerIngressContext } from "../public-worker-ingress-context.js";
-import type { GatewayWsClient, WsHandshakePhase } from "../ws-types.js";
+import type { GatewayWorkerIngress, GatewayWsClient, WsHandshakePhase } from "../ws-types.js";
 import { runWorkerAdmissionBoundary } from "./worker-admission-boundary.js";
 import {
   buildWorkerHello,
@@ -141,6 +141,7 @@ type WorkerWsMessageHandlerParams = {
   connId: string;
   service?: WorkerConnectionService;
   isStartupPending?: () => boolean;
+  ingress: GatewayWorkerIngress;
   send(frame: unknown): void;
   close(code?: number, reason?: string): void;
   isClosed(): boolean;
@@ -403,8 +404,7 @@ export function attachWorkerWsMessageHandler(params: WorkerWsMessageHandlerParam
         ? "invalid-handshake"
         : rejection.reason;
     const wireError =
-      rejection.error ??
-      workerProtocolError(wireReason, { message: "worker admission rejected" });
+      rejection.error ?? workerProtocolError(wireReason, { message: "worker admission rejected" });
     params.setHandshakeState("failed");
     params.setCloseCause(internalReason);
     params.logWsControl.warn(`worker admission rejected reason=${internalReason}`);
@@ -427,6 +427,14 @@ export function attachWorkerWsMessageHandler(params: WorkerWsMessageHandlerParam
           retryAfterMs: GATEWAY_STARTUP_RETRY_AFTER_MS,
         }),
         code: 1013,
+      });
+      return;
+    }
+    if (params.ingress === "public" && !params.publicAdmission) {
+      rejectAdmission({
+        id,
+        reason: "invalid-handshake",
+        internalReason: "public-ingress-context-missing",
       });
       return;
     }

--- a/src/gateway/server/ws-connection/worker-connection.ts
+++ b/src/gateway/server/ws-connection/worker-connection.ts
@@ -54,13 +54,12 @@ import {
   runWithGatewayIndependentRootWorkContinuation,
   tryBeginGatewayRootWorkAdmission,
 } from "../../../process/gateway-work-admission.js";
-import {
-  AUTH_RATE_LIMIT_SCOPE_WORKER_ADMISSION,
-  type AuthRateLimiter,
-} from "../../auth-rate-limit.js";
+import { AUTH_RATE_LIMIT_SCOPE_WORKER_ADMISSION } from "../../auth-rate-limit.js";
 import type { WorkerConnectionIdentity } from "../../worker-environments/connection-identity.js";
 import { MAX_RUNNING_WORKER_SESSION_TOOL_OPERATIONS } from "../../worker-environments/placement-session-tool-operations.js";
-import type { GatewayWorkerIngress, GatewayWsClient, WsHandshakePhase } from "../ws-types.js";
+import type { PublicWorkerIngressContext } from "../public-worker-ingress-context.js";
+import type { GatewayWsClient, WsHandshakePhase } from "../ws-types.js";
+import { runWorkerAdmissionBoundary } from "./worker-admission-boundary.js";
 import {
   buildWorkerHello,
   workerInferenceError,
@@ -137,22 +136,11 @@ type WorkerLogger = { warn(message: string): void };
 const MAX_QUEUED_WORKER_FRAMES = 16;
 const MAX_QUEUED_WORKER_BYTES = 32 * 1024 * 1024;
 
-function isWorkerCredentialFailure(reason: WorkerProtocolCloseReason): boolean {
-  return (
-    reason === "invalid-credential" ||
-    reason === "environment-mismatch" ||
-    reason === "credential-expired"
-  );
-}
-
 type WorkerWsMessageHandlerParams = {
   socket: WebSocket;
   connId: string;
   service?: WorkerConnectionService;
   isStartupPending?: () => boolean;
-  ingress?: GatewayWorkerIngress;
-  rateLimiter?: AuthRateLimiter;
-  rateLimitClientIp?: string;
   send(frame: unknown): void;
   close(code?: number, reason?: string): void;
   isClosed(): boolean;
@@ -165,6 +153,7 @@ type WorkerWsMessageHandlerParams = {
   setLastFrameMeta(meta: { type?: string; method?: string }): void;
   logGateway: WorkerLogger;
   logWsControl: WorkerLogger;
+  publicAdmission?: PublicWorkerIngressContext;
 };
 
 function rejectWorkerRequest(params: {
@@ -376,6 +365,10 @@ export function attachWorkerWsMessageHandler(params: WorkerWsMessageHandlerParam
     params.close(code, reason);
   };
   const failHandshake = (code: number, reason: WorkerProtocolCloseReason) => {
+    params.publicAdmission?.rateLimiter?.recordFailure(
+      params.publicAdmission.clientIp,
+      AUTH_RATE_LIMIT_SCOPE_WORKER_ADMISSION,
+    );
     params.setHandshakeState("failed");
     params.setCloseCause(reason);
     params.logWsControl.warn(`worker admission rejected reason=${reason}`);
@@ -397,29 +390,25 @@ export function attachWorkerWsMessageHandler(params: WorkerWsMessageHandlerParam
   };
   const rejectAdmission = (rejection: {
     id: string;
-    reason: WorkerProtocolCloseReason;
+    reason: WorkerProtocolCloseReason | "rate-limited";
     internalReason?: string;
     error?: WorkerErrorShape;
     code?: number;
+    opaqueOnPublicIngress?: boolean;
   }) => {
     const internalReason = rejection.internalReason ?? rejection.reason;
+    const wireReason: WorkerProtocolCloseReason =
+      (rejection.opaqueOnPublicIngress && params.publicAdmission) ||
+      rejection.reason === "rate-limited"
+        ? "invalid-handshake"
+        : rejection.reason;
+    const wireError =
+      rejection.error ??
+      workerProtocolError(wireReason, { message: "worker admission rejected" });
     params.setHandshakeState("failed");
     params.setCloseCause(internalReason);
     params.logWsControl.warn(`worker admission rejected reason=${internalReason}`);
-    sendError(
-      rejection.id,
-      rejection.reason,
-      rejection.error ??
-        workerProtocolError(rejection.reason, { message: "worker admission rejected" }),
-      rejection.code ?? 1008,
-    );
-  };
-  const rejectVerifiedAdmission = (id: string, internalReason: WorkerProtocolCloseReason) => {
-    rejectAdmission({
-      id,
-      reason: params.ingress === "public" ? "admission-rejected" : internalReason,
-      internalReason,
-    });
+    sendError(rejection.id, wireReason, wireError, rejection.code ?? 1008);
   };
 
   const handleConnect = async (
@@ -445,61 +434,39 @@ export function attachWorkerWsMessageHandler(params: WorkerWsMessageHandlerParam
       rejectAdmission({ id, reason: "protocol-mismatch" });
       return;
     }
-    const rateLimit = params.rateLimiter?.check(
-      params.rateLimitClientIp,
-      AUTH_RATE_LIMIT_SCOPE_WORKER_ADMISSION,
-    );
-    if (rateLimit && !rateLimit.allowed) {
-      rejectAdmission({
-        id,
-        reason: "admission-rejected",
-        internalReason: "rate-limited",
-        error: workerProtocolError("admission-rejected", {
-          code: ErrorCodes.UNAVAILABLE,
-          message: "worker admission rejected",
-          retryable: true,
-          retryAfterMs: rateLimit.retryAfterMs,
-        }),
-      });
-      return;
-    }
-    const admission =
-      (await params.service?.admitWorker(connect.admission)) ??
-      ({ ok: false, reason: "environment-unavailable" } as const);
-    if (!admission.ok) {
-      if (isWorkerCredentialFailure(admission.reason)) {
-        await params.rateLimiter?.recordFailureAndDelay(
-          params.rateLimitClientIp,
-          AUTH_RATE_LIMIT_SCOPE_WORKER_ADMISSION,
-        );
-      }
-      rejectVerifiedAdmission(id, admission.reason);
-      return;
-    }
-    params.rateLimiter?.reset(params.rateLimitClientIp, AUTH_RATE_LIMIT_SCOPE_WORKER_ADMISSION);
-    const ownershipFailure = params.service?.validateWorkerConnection(admission.identity);
-    if (ownershipFailure) {
-      rejectVerifiedAdmission(id, ownershipFailure);
-      return;
-    }
-    const client: GatewayWsClient = {
-      socket: params.socket,
-      connect: {
-        minProtocol: connect.minProtocol,
-        maxProtocol: connect.maxProtocol,
-        client: connect.client,
-        role: "worker",
-        scopes: [],
+    const admission = await runWorkerAdmissionBoundary({
+      service: params.service,
+      admission: connect.admission,
+      publicAdmission: params.publicAdmission,
+      claim: (identity) => {
+        const client: GatewayWsClient = {
+          socket: params.socket,
+          connect: {
+            minProtocol: connect.minProtocol,
+            maxProtocol: connect.maxProtocol,
+            client: connect.client,
+            role: "worker",
+            scopes: [],
+          },
+          connId: params.connId,
+          connectionKind: "worker",
+          worker: identity,
+          usesSharedGatewayAuth: false,
+        };
+        params.clearHandshakeTimer();
+        params.advanceHandshakePhase("auth_validated");
+        if (!params.setClient(client)) {
+          params.setHandshakeState("failed");
+          return false;
+        }
+        return true;
       },
-      connId: params.connId,
-      connectionKind: "worker",
-      worker: admission.identity,
-      usesSharedGatewayAuth: false,
-    };
-    params.clearHandshakeTimer();
-    params.advanceHandshakePhase("auth_validated");
-    if (!params.setClient(client)) {
-      params.setHandshakeState("failed");
+    });
+    if (!admission.ok) {
+      if (admission.reason === "claim-rejected") {
+        return;
+      }
+      rejectAdmission({ id, reason: admission.reason, opaqueOnPublicIngress: true });
       return;
     }
     params.setHandshakeState("connected");

--- a/src/worker/worker-fault-injection.test-support.ts
+++ b/src/worker/worker-fault-injection.test-support.ts
@@ -659,6 +659,7 @@ export class ComposedGatewayHarness {
           return result;
         },
       } as workerServer.WorkerConnectionService,
+      ingress: "loopback",
       send: (frame) => this.send(socket, frame),
       close: (code = 1000, reason = "") => socket.close(code, reason),
       isClosed: () => closed || socket.readyState === WebSocket.CLOSED,


### PR DESCRIPTION
Related: #122454

AI-assisted: yes. The implementation and proof were reviewed with the repository autoreview workflow.

## What Problem This Solves

Workers can currently reach admission only through a dedicated loopback listener, which requires the SSH reverse-tunnel transport. That prevents a worker on a paired or otherwise internet-connected machine from dialing the gateway's normal public TLS endpoint directly.

## Why This Change Was Made

This adds the reserved, upgrade-only `/__openclaw__/worker` route to the normal gateway endpoint and force-tags sockets selected by that exact original request path as worker connections. The route reuses the existing store-backed worker admission service and shared WebSocket server; the loopback ingress remains separate and unchanged.

The public boundary also carries its resolved client IP and strict limiter through a private route-context handoff. Failed public admissions are serialized and rate-limited per IP, while simultaneous unauthenticated sockets share the gateway's existing preauth budget. No worker protocol schema, SDK surface, config surface, or protocol version changes.

## User Impact

A worker process on any host that can reach the gateway's public TLS endpoint can now complete admission at `/__openclaw__/worker` when it presents a valid dispatch credential and matching environment binding. Plain HTTP requests and malformed descendants return 404 instead of Control UI SPA HTML.

Existing SSH cloud workers continue to use the loopback listener with its existing detailed failure behavior and separate preauth budget.

## Evidence

- Exact-head CI for `aeab35352bd4163f1571f801662bb6b5ff470265`
  - Green: https://github.com/openclaw/openclaw/actions/runs/31605302527
- `node scripts/run-vitest.mjs src/gateway/server.public-worker-ingress.test.ts src/gateway/control-ui-routing.test.ts src/gateway/server/ws-connection/message-handler.worker.test.ts src/gateway/server.preauth-hardening.test.ts src/gateway/worker-environments/admission.test.ts`
  - 5 files passed, 117 tests passed.
- Post-rebase sanity: `node scripts/run-vitest.mjs src/gateway/server.public-worker-ingress.test.ts src/gateway/control-ui-routing.test.ts src/gateway/server/ws-connection/message-handler.worker.test.ts`
  - 3 files passed, 95 tests passed.
- `node scripts/check-changed.mjs -- src/gateway/auth-rate-limit.ts src/gateway/control-ui-routing.ts src/gateway/control-ui-routing.test.ts src/gateway/gateway-http-route-contracts.ts src/gateway/server-http.ts src/gateway/server-runtime-state.ts src/gateway/server.public-worker-ingress.test.ts src/gateway/server/public-worker-ingress-context.ts src/gateway/server/ws-connection.ts src/gateway/server/ws-connection/worker-admission-boundary.ts src/gateway/server/ws-connection/worker-connection.ts`
  - Passed all selected core/core-test type, lint, dead-export, API-contract, import-cycle, schema, and architecture guards. The configured remote backend was unavailable, so the repository wrapper used its documented local fallback.
- `pnpm build`
  - Passed in 8m 38s; all 152 public plugin-SDK subpaths verified and no ineffective dynamic import was reported.
- `pnpm plugin-sdk:api:check`
  - Passed; no Plugin SDK contract drift.
- `pnpm format <changed paths>` and `git diff --check`
  - Passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt <security scope>`
  - Clean: no accepted/actionable findings.

Security note: public service-backed admission and immediate ownership failures retain their precise typed reasons in server logs/structured close cause, but the client receives one identical `invalid-handshake` error frame and close reason. Bad credentials and valid credentials paired with the wrong environment are asserted byte-for-byte identical on the wire. The public route uses the main gateway preauth connection budget, then serializes failed credential admissions under a dedicated strict per-IP auth-rate scope so parallel guesses cannot race the threshold. Successful admission resets that scope only after the authenticated socket is claimed. Route matching uses the original URL pathname, so capability-path rewriting cannot alias into the worker ingress.
