### PR TITLE
fix(agents): reclaim compacted prompt projections

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-prompt-build.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-build.ts
@@ -48,6 +48,7 @@ import {
 import {
   resolveLiveToolResultAggregateMaxChars,
   resolveLiveToolResultMaxChars,
+  reconcileToolResultPromptProjectionState,
   toolResultWarningDedupe,
   truncateOversizedToolResultsInMessages,
 } from "../tool-result-truncation.js";
@@ -473,6 +474,14 @@ export function prepareEmbeddedAttemptPromptContext(input: {
   );
   if (sessionMessages.length < input.messages.length) {
     input.replaceSessionMessages(sessionMessages);
+  }
+  // Raw probes temporarily hide durable history; only normal prepared history
+  // is authoritative for reclaiming session-owned provider projections.
+  if (!input.isRawModelRun) {
+    reconcileToolResultPromptProjectionState(
+      sessionMessages,
+      input.toolResultPromptProjectionState,
+    );
   }
   const prePromptMessageCount = sessionMessages.length;
   const contextTokenBudget = attempt.contextTokenBudget ?? DEFAULT_CONTEXT_TOKENS;

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-context.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-context.test.ts
@@ -8,6 +8,7 @@ import type { EmbeddedRunAttemptParams } from "./types.js";
 const hoisted = vi.hoisted(() => ({
   info: vi.fn(),
   promptPressureKeys: new Set<string>(),
+  reconcileToolResultPromptProjectionState: vi.fn(),
   resolveLiveToolResultAggregateMaxChars: vi.fn(() => 200),
   resolveLiveToolResultMaxChars: vi.fn(() => 100),
   truncateOversizedToolResultsInMessages: vi.fn(),
@@ -20,6 +21,7 @@ vi.mock("../logger.js", () => ({
 vi.mock("../tool-result-truncation.js", () => ({
   resolveLiveToolResultAggregateMaxChars: hoisted.resolveLiveToolResultAggregateMaxChars,
   resolveLiveToolResultMaxChars: hoisted.resolveLiveToolResultMaxChars,
+  reconcileToolResultPromptProjectionState: hoisted.reconcileToolResultPromptProjectionState,
   toolResultWarningDedupe: {
     promptPressure: {
       check: (key: string) => {
@@ -115,6 +117,7 @@ function createInput(options?: {
 beforeEach(() => {
   vi.clearAllMocks();
   hoisted.promptPressureKeys.clear();
+  hoisted.reconcileToolResultPromptProjectionState.mockReset();
   hoisted.truncateOversizedToolResultsInMessages.mockImplementation((inputMessages) => ({
     messages: inputMessages,
     truncatedCount: 0,
@@ -152,6 +155,10 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
     });
     expect(fixture.replaceSessionMessages).not.toHaveBeenCalled();
     expect(fixture.setActiveSessionSystemPrompt).not.toHaveBeenCalled();
+    expect(hoisted.reconcileToolResultPromptProjectionState).toHaveBeenCalledWith(
+      messages,
+      projectionState,
+    );
     const clonedProjectionState = hoisted.truncateOversizedToolResultsInMessages.mock.calls[0]?.[4];
     expect(clonedProjectionState).not.toBe(projectionState);
   });
@@ -170,6 +177,14 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
 
     expect(result.llmBoundaryPromptForPrecheck).toContain('"name":"Alice"');
     expect(result.llmBoundaryPromptForPrecheck).toContain("Visible request");
+  });
+
+  it("does not reconcile session projection state for raw probes", () => {
+    const fixture = createInput();
+
+    prepareEmbeddedAttemptPromptContext({ ...fixture.input, isRawModelRun: true });
+
+    expect(hoisted.reconcileToolResultPromptProjectionState).not.toHaveBeenCalled();
   });
 
   it("injects the latest heartbeat outcome only as hidden runtime context", () => {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -24,9 +24,11 @@ import {
   calculateMaxToolResultCharsWithCap,
   resolveAutoLiveToolResultMaxChars,
 } from "../tool-result-limits.js";
+import { prepareEmbeddedAttemptPromptContext } from "./run/attempt-prompt-build.js";
 import { buildRuntimeContextCustomMessage } from "./run/runtime-context-prompt.js";
 import {
   clearEmbeddedSessionPromptStates,
+  cloneToolResultPromptProjectionState,
   getEmbeddedSessionPromptState,
   type ToolResultPromptProjectionState,
 } from "./session-prompt-state.js";
@@ -78,7 +80,11 @@ beforeEach(async () => {
 afterEach(async () => {
   toolResultWarningDedupe.promptPressure.clear();
   toolResultWarningDedupe.sessionRecovery.clear();
-  clearEmbeddedSessionPromptStates(["session-99495", "session-99495-shrink"]);
+  clearEmbeddedSessionPromptStates([
+    "session-99495",
+    "session-99495-reclamation",
+    "session-99495-shrink",
+  ]);
   if (tmpDir) {
     await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     tmpDir = undefined;
@@ -97,6 +103,42 @@ function makeToolResult(text: string, toolCallId = "call_1", details?: unknown):
     ...(details !== undefined ? { details } : {}),
     timestamp: nextTimestamp(),
   };
+}
+
+function preparePromptProjectionStateForTest(params: {
+  sessionId: string;
+  messages: AgentMessage[];
+  state: ToolResultPromptProjectionState;
+  raw?: boolean;
+}) {
+  const prompt = params.raw ? "raw probe" : "continue";
+  prepareEmbeddedAttemptPromptContext({
+    attempt: {
+      config: {},
+      contextTokenBudget: 128_000,
+      sessionId: params.sessionId,
+      sessionKey: `agent:main:${params.sessionId}`,
+      suppressNextUserMessagePersistence: false,
+    },
+    includeBoundaryTimestamp: false,
+    isRawModelRun: params.raw ?? false,
+    messages: params.messages,
+    prompt: {
+      effectivePrompt: prompt,
+      promptBeforePromptBuildHooks: prompt,
+      hasPromptBuildContext: false,
+      effectiveTranscriptPrompt: prompt,
+      transcriptPromptForRuntimeSplit: prompt,
+      promptForRuntimeContextSplit: prompt,
+      promptForModelBeforeRuntimeContextSplit: prompt,
+      promptForRuntimeContextBeforeAnnotation: prompt,
+    },
+    replaceSessionMessages: () => {},
+    sessionAgentId: "main",
+    setActiveSessionSystemPrompt: () => {},
+    systemPromptText: params.raw ? "" : "system",
+    toolResultPromptProjectionState: params.state,
+  });
 }
 
 describe("tool-result warning dedupe", () => {
@@ -835,6 +877,39 @@ describe("truncateOversizedToolResultsInMessages", () => {
     expect(second.messages.slice(0, history.length)).toEqual(first.messages);
   });
 
+  it("reclaims #99495 state from canonical compaction, not filtered projections", () => {
+    const sessionId = "session-99495-reclamation";
+    const state = getEmbeddedSessionPromptState(sessionId).toolResults;
+    const removed = makeToolResult("removed".repeat(100_000), "removed_after_compaction");
+    const retained = makeToolResult("retained".repeat(100_000), "retained_after_compaction");
+    const projected = truncateOversizedToolResultsInMessages(
+      [removed, retained],
+      128_000,
+      5_000,
+      20_000,
+      state,
+    );
+
+    // Provider-specific filtering is not authoritative; the removed result can return on fallback.
+    truncateOversizedToolResultsInMessages([retained], 128_000, 5_000, 20_000, state);
+    expect(state.sourceTextByKey.size).toBe(2);
+
+    preparePromptProjectionStateForTest({ sessionId, messages: [], state, raw: true });
+    expect(state.sourceTextByKey.size).toBe(2);
+
+    preparePromptProjectionStateForTest({ sessionId, messages: [retained], state });
+
+    expect(state.sourceTextByKey.size).toBe(1);
+    expect(state.frozen.size).toBe(1);
+    expect(state.replacements.size).toBe(1);
+    expect([...state.sourceTextByKey.values()].flat()).not.toContain(
+      getFirstToolResultText(removed),
+    );
+    expect(
+      truncateOversizedToolResultsInMessages([retained], 128_000, 5_000, 20_000, state).messages,
+    ).toEqual(projected.messages.slice(1));
+  });
+
   it("shrinks #99495 frozen bytes monotonically only under a tighter hard cap", () => {
     const state = getEmbeddedSessionPromptState("session-99495-shrink").toolResults;
     const history = [
@@ -1415,6 +1490,79 @@ describe("truncateOversizedToolResultsInMessages", () => {
 
     expect(first.messages[0]).not.toEqual(first.messages[1]);
     expect(filtered.messages[0]).toEqual(first.messages[1]);
+    preparePromptProjectionStateForTest({
+      sessionId: "ambiguous-filtered-history",
+      messages: [duplicate("b".repeat(100))],
+      state: projectionState,
+    });
+    expect(projectionState.sourceTextByKey.size).toBe(1);
+    expect(projectionState.frozen.size).toBe(1);
+    expect(projectionState.replacements.size).toBe(0);
+    expect(projectionState.ambiguousBaseKeys.size).toBe(1);
+    expect(
+      truncateOversizedToolResultsInMessages(
+        [duplicate("b".repeat(100))],
+        128_000,
+        100,
+        100,
+        projectionState,
+      ).messages[0],
+    ).toEqual(first.messages[1]);
+    preparePromptProjectionStateForTest({
+      sessionId: "ambiguous-removed-history",
+      messages: [],
+      state: projectionState,
+    });
+    expect(projectionState.ambiguousBaseKeys.size).toBe(0);
+  });
+
+  it("drops an unselected identical-occurrence key without changing projected bytes", () => {
+    const projectionState = createPromptProjectionStateForTest();
+    const duplicate = (): ToolResultMessage => ({
+      role: "toolResult",
+      toolCallId: "identical-call",
+      toolName: "duplicate",
+      isError: false,
+      content: [{ type: "text", text: "x".repeat(100) }],
+      timestamp: 1_000,
+    });
+    const history = [duplicate(), makeAssistantMessage("separator"), duplicate()];
+    const first = truncateOversizedToolResultsInMessages(
+      history,
+      128_000,
+      100,
+      100,
+      projectionState,
+    );
+    const stateWithStaleOccurrence = cloneToolResultPromptProjectionState(projectionState);
+    expect(stateWithStaleOccurrence.frozen.size).toBe(2);
+
+    preparePromptProjectionStateForTest({
+      sessionId: "identical-occurrence-compaction",
+      messages: [duplicate()],
+      state: projectionState,
+    });
+
+    const retainedWithStale = truncateOversizedToolResultsInMessages(
+      [duplicate()],
+      128_000,
+      100,
+      100,
+      stateWithStaleOccurrence,
+    );
+    const retainedAfterPrune = truncateOversizedToolResultsInMessages(
+      [duplicate()],
+      128_000,
+      100,
+      100,
+      projectionState,
+    );
+    // After the first identical occurrence disappears, both states select :0;
+    // retaining the unreachable :1 entry cannot preserve or change provider bytes.
+    expect(retainedAfterPrune.messages).toEqual(retainedWithStale.messages);
+    expect(retainedAfterPrune.messages[0]).toEqual(first.messages[0]);
+    expect(projectionState.frozen.size).toBe(1);
+    expect(projectionState.sourceTextByKey.size).toBe(1);
   });
 });
 

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -794,6 +794,31 @@ function getToolResultProjectionKeys(
   });
 }
 
+/** Drops projections whose source messages no longer exist in canonical session history. */
+export function reconcileToolResultPromptProjectionState(
+  messages: AgentMessage[],
+  projectionState: ToolResultPromptProjectionState,
+): void {
+  const canonicalKeys = new Set(getToolResultProjectionKeys(messages, projectionState));
+  for (const key of [
+    ...projectionState.frozen,
+    ...projectionState.replacements.keys(),
+    ...projectionState.sourceTextByKey.keys(),
+  ]) {
+    if (!canonicalKeys.has(key)) {
+      projectionState.frozen.delete(key);
+      projectionState.replacements.delete(key);
+      projectionState.sourceTextByKey.delete(key);
+    }
+  }
+  const representedBaseKeys = new Set(messages.map(getToolResultProjectionBaseKey));
+  for (const baseKey of projectionState.ambiguousBaseKeys) {
+    if (!representedBaseKeys.has(baseKey)) {
+      projectionState.ambiguousBaseKeys.delete(baseKey);
+    }
+  }
+}
+
 function mergeProjectedToolResultMessage(
   message: AgentMessage,
   projectedMessage: AgentMessage,


### PR DESCRIPTION
## What Problem This Solves

Embedded session prompt projection state retained full original tool-result text, frozen keys, and replacement messages after transcript compaction removed those tool results from canonical history. The outer session map was bounded, but an active session's inner projection collections could grow indefinitely and keep compacted multi-megabyte outputs reachable.

## Why This Change Was Made

The prompt builder now reconciles session-owned tool-result projection state against canonical prepared history before provider-specific projection:

- entries absent from canonical history are removed from `sourceTextByKey`, `frozen`, and `replacements`;
- ambiguous-base markers are removed only when no canonical result still represents that base;
- raw model probes skip reconciliation because they temporarily hide durable history;
- provider-filtered views cannot reclaim state;
- retained normal, ambiguous, and identical-duplicate results preserve the selected frozen projection bytes across retries and fallback.

This keeps the shrink-only prompt-cache contract introduced by #99495 while giving compaction ownership of memory reclamation. No config, protocol, persistence, timeout, or second cache is added.

AI-assisted: yes. The first conservative implementation was simplified from +58 to +34 production lines, then the final branch passed fresh structured autoreview after rebase.

## User Impact

Long-lived embedded sessions can reclaim large compacted tool-result sources instead of retaining them for the remainder of the process, reducing memory growth without rewriting retained prompt history.

## Evidence

- Pre-fix regression retained two projection sources after canonical history removed one 700,000-character tool result; post-fix state contains only the retained result.
- Full focused lifecycle proof: 135 tests passed across projection/truncation, prompt context/submission, retries, overflow recovery, session state, and reset cleanup.
- Duplicate-occurrence coverage proves removing unreachable same-base keys does not change selected provider bytes.
- Raw-probe and provider-filtered coverage proves only canonical non-raw history authorizes reclamation.
- Hosted changed gate passed on Testbox `tbx_01kzv4rvzy0wz92z7qj41tt5yj` ([run](https://github.com/openclaw/openclaw/actions/runs/31605050981)).
- Exact-head CI passed ([run](https://github.com/openclaw/openclaw/actions/runs/31606050819)).
- Targeted formatting, lint, typechecks, import-cycle checks, and `git diff --check` passed.
- Focused local proof completed in 46.36s with 1.36 GB peak test-runner RSS.
- Rebase preserved stable patch ID `3c6fdcf1c9378ffef989690e6cf15676b9d550ba`.
- Fresh complete-branch autoreview: clean.
- Production +34/−0; tests +164/−1. The production growth is one canonical-key reconciliation and the raw-probe ownership guard; the initial broader fallback-prefix design was removed.
