### PR TITLE
fix(tool-display): keep shell compound blocks as one exec stage

### DIFF
--- a/src/agents/tool-display-exec-shell.ts
+++ b/src/agents/tool-display-exec-shell.ts
@@ -481,16 +481,60 @@ function splitTopLevel(
   return parts.map((part) => part.trim()).filter((part) => part.length > 0);
 }
 
+/**
+ * Shell keywords that open a compound block. A `;` inside such a block separates
+ * commands *within* the block, so it must not end the surrounding stage.
+ */
+const COMPOUND_BLOCK_OPENERS = new Set(["for", "while", "until", "if", "case", "select"]);
+/** Keywords that close a compound block opened by {@link COMPOUND_BLOCK_OPENERS}. */
+const COMPOUND_BLOCK_CLOSERS = new Set(["done", "fi", "esac"]);
+/**
+ * Keywords after which the next word is again a command (`do echo hi`), so a
+ * following keyword still counts as being in command position.
+ */
+const COMPOUND_BLOCK_BODY_KEYWORDS = new Set(["do", "then", "else", "elif"]);
+const SHELL_WORD_BOUNDARY = /[\s;&|()<>]/;
+
 /** Splits a command on top-level stage separators such as `;`, `&&`, and `||`. */
 export function splitTopLevelStages(command: string): string[] {
+  // A compound block (`for …; do …; done`) is a single stage: splitting on its
+  // inner `;` yields fragments like `do echo x` and `done`, which the summarizer
+  // then renders as if `do` and `done` were binaries.
+  let blockDepth = 0;
+  let word = "";
+  // Keywords are only keywords in command position — `echo if` is an argument.
+  let atCommandPosition = true;
+
+  const closeWord = (): void => {
+    if (word.length === 0) {
+      return;
+    }
+    const keyword = word;
+    word = "";
+    if (atCommandPosition && COMPOUND_BLOCK_OPENERS.has(keyword)) {
+      blockDepth += 1;
+    } else if (atCommandPosition && COMPOUND_BLOCK_CLOSERS.has(keyword) && blockDepth > 0) {
+      blockDepth -= 1;
+    }
+    atCommandPosition = COMPOUND_BLOCK_BODY_KEYWORDS.has(keyword);
+  };
+
   return splitTopLevel(command, (char, index) => {
-    if (char === ";") {
-      return 1;
+    if (!SHELL_WORD_BOUNDARY.test(char)) {
+      word += char;
+      return 0;
     }
-    if ((char === "&" || char === "|") && command[index + 1] === char) {
-      return 2;
+    closeWord();
+    const isStageSeparator =
+      char === ";" || ((char === "&" || char === "|") && command[index + 1] === char);
+    if (!isStageSeparator) {
+      return 0;
     }
-    return 0;
+    atCommandPosition = true;
+    if (blockDepth > 0) {
+      return 0;
+    }
+    return char === ";" ? 1 : 2;
   });
 }
 

--- a/src/agents/tool-display-exec-shell.ts
+++ b/src/agents/tool-display-exec-shell.ts
@@ -511,12 +511,18 @@ export function splitTopLevelStages(command: string): string[] {
     }
     const keyword = word;
     word = "";
-    if (atCommandPosition && COMPOUND_BLOCK_OPENERS.has(keyword)) {
+    const wasAtCommandPosition = atCommandPosition;
+    // A body keyword only re-opens command position when it is itself in command
+    // position: in `echo do if`, `do` is an argument, so `if` stays an argument too.
+    atCommandPosition = wasAtCommandPosition && COMPOUND_BLOCK_BODY_KEYWORDS.has(keyword);
+    if (!wasAtCommandPosition) {
+      return;
+    }
+    if (COMPOUND_BLOCK_OPENERS.has(keyword)) {
       blockDepth += 1;
-    } else if (atCommandPosition && COMPOUND_BLOCK_CLOSERS.has(keyword) && blockDepth > 0) {
+    } else if (COMPOUND_BLOCK_CLOSERS.has(keyword) && blockDepth > 0) {
       blockDepth -= 1;
     }
-    atCommandPosition = COMPOUND_BLOCK_BODY_KEYWORDS.has(keyword);
   };
 
   return splitTopLevel(command, (char, index) => {

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -668,6 +668,43 @@ describe("tool display details", () => {
     ]);
   });
 
+  it("keeps a compound block as a single stage", () => {
+    const command = 'for d in $(ls ~/x); do echo "$d"; ls "$d"; done';
+
+    expect(splitTopLevelStages(command)).toEqual([command]);
+  });
+
+  it("keeps if/while/case blocks as single stages", () => {
+    expect(splitTopLevelStages("if [ -f a ]; then cat a; else echo no; fi")).toEqual([
+      "if [ -f a ]; then cat a; else echo no; fi",
+    ]);
+    expect(splitTopLevelStages('while read l; do echo "$l"; done')).toEqual([
+      'while read l; do echo "$l"; done',
+    ]);
+    expect(splitTopLevelStages("case $x in a) echo A;; b) echo B;; esac")).toEqual([
+      "case $x in a) echo A;; b) echo B;; esac",
+    ]);
+  });
+
+  it("splits around a compound block without splitting inside it", () => {
+    expect(splitTopLevelStages("echo a; for x in 1; do echo b; done; echo c")).toEqual([
+      "echo a",
+      "for x in 1; do echo b; done",
+      "echo c",
+    ]);
+  });
+
+  it("tracks nested compound blocks", () => {
+    const command = "for a in 1; do for b in 2; do echo x; done; done";
+
+    expect(splitTopLevelStages(command)).toEqual([command]);
+  });
+
+  it("treats block keywords outside command position as plain arguments", () => {
+    expect(splitTopLevelStages("echo if; echo x")).toEqual(["echo if", "echo x"]);
+    expect(splitTopLevelStages("echo done1; echo two")).toEqual(["echo done1", "echo two"]);
+  });
+
   it("does not treat the overlapping end of a here-string as a heredoc", () => {
     const command = ["cat <<<true", "npm test && npm build", "true", "pnpm test"].join("\n");
 

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -705,6 +705,20 @@ describe("tool display details", () => {
     expect(splitTopLevelStages("echo done1; echo two")).toEqual(["echo done1", "echo two"]);
   });
 
+  it("does not let a body keyword in argument position open a block", () => {
+    expect(splitTopLevelStages("echo do if; npm test; echo c")).toEqual([
+      "echo do if",
+      "npm test",
+      "echo c",
+    ]);
+    expect(splitTopLevelStages("echo then if; npm test")).toEqual(["echo then if", "npm test"]);
+    expect(splitTopLevelStages("echo else case; ls; echo x")).toEqual([
+      "echo else case",
+      "ls",
+      "echo x",
+    ]);
+  });
+
   it("does not treat the overlapping end of a here-string as a heredoc", () => {
     const command = ["cat <<<true", "npm test && npm build", "true", "pnpm test"].join("\n");
 


### PR DESCRIPTION
Fixes the display half of #122506. (The reporter retracted the grep `-E` half in the issue thread after source review, so this PR does not touch `search`/`grep`.)

## The problem

`splitTopLevelStages()` splits on every top-level `;`, `&&` and `||` with no awareness of shell control flow. A compound block is torn into fragments, and each fragment is handed to `summarizeKnownExec()`, which reads its first token as a binary name.

## Real behaviour, before and after

Rendered through the actual display path — `formatToolDetail(resolveToolDisplay({ name: "exec", args: { command }, detailMode: "explain" }))` — with the only difference between the two runs being `src/agents/tool-display-exec-shell.ts` checked out from `origin/main` vs this branch.

**Before (`origin/main`):**

```
$ ls ~/proj; for d in a b; do echo "$d"; ls "$d"; done; echo done
  list files in ~/proj → run for d → run do echo → list files in $d → run done → print text

$ for d in a b; do echo "$d"; ls "$d"; done
  run for d → run do echo → list files in $d → run done

$ npm run build; if [ -f x ]; then cat x; fi; npm test
  run build → run if → run then cat → run fi → run tests
```

**After (this branch):**

```
$ ls ~/proj; for d in a b; do echo "$d"; ls "$d"; done; echo done
  list files in ~/proj → run for d → print text

$ for d in a b; do echo "$d"; ls "$d"; done
  for d in a b; do echo "$d"; ls "$d"; done

$ npm run build; if [ -f x ]; then cat x; fi; npm test
  run build → run if → run tests
```

`run do echo`, `run done`, `run then cat` and `run fi` are gone, because `do`, `done`, `then` and `fi` are no longer treated as binaries.

## The fix

Track compound-block depth while scanning: `for`/`while`/`until`/`if`/`case`/`select` open a block, `done`/`fi`/`esac` close one, and separators inside a block no longer end the stage.

Keywords count **only in command position**, and that gate applies to body keywords too — this was the review finding on the first revision. `do`/`then`/`else`/`elif` re-open command position only when they are themselves in command position, so an argument list cannot open a block:

```js
splitTopLevelStages("echo do if; npm test; echo c")
// ["echo do if", "npm test", "echo c"]   ← three stages, unchanged from main
```

Blocks nest, and a block between ordinary stages still separates cleanly:

```js
splitTopLevelStages("echo a; for x in 1; do echo b; done; echo c")
// ["echo a", "for x in 1; do echo b; done", "echo c"]
```

## Testing

- 6 regression tests in `src/agents/tool-display.test.ts`. **4 fail on `origin/main` and pass here**; the other two (`echo if` / `echo done1`, and the `echo do if` case from review) guard against this change over-reaching, and pass both before and after by design.
- `src/agents/tool-display.test.ts`: **66 passed**.
- Full `src/agents/` suite: **4445 passed**, 2 skipped. The 2 failures in that directory (`resolves Unicode-equivalent filenames…`, `retries a transient boundary-resolution failure…`) reproduce identically with `tool-display-exec-shell.ts` restored from `origin/main`, so they are pre-existing on this machine (macOS Unicode normalisation), not caused by this change.
- `tsc --noEmit`: clean.

## Out of scope, but noticed

`$( … )` contents are also split, since the scanner does not treat command substitution as protected:

```js
splitTopLevelStages("echo $(a; b); echo c")
// ["echo $(a", "b)", "echo c"]
```

Same family of defect, different mechanism. Happy to open a separate issue or fold a fix in here — whichever you prefer.
