### PR TITLE
fix(ui): keep GitHub hovercards open while users interact

### DIFF
--- a/ui/src/components/github-link-hovercard.test.ts
+++ b/ui/src/components/github-link-hovercard.test.ts
@@ -107,6 +107,7 @@ describe("openclaw-github-link-hovercard-provider", () => {
     );
 
     leave(anchor);
+    await vi.advanceTimersByTimeAsync(150);
     expect(document.querySelector(".github-link-hovercard")).toBeNull();
     await hover(anchor);
     expect(request).toHaveBeenCalledTimes(1);
@@ -140,6 +141,77 @@ describe("openclaw-github-link-hovercard-provider", () => {
     expect(document.querySelector(".github-link-hovercard")?.textContent).toContain("Open");
     anchor.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
     expect(document.querySelector(".github-link-hovercard")).toBeNull();
+  });
+
+  it("stays open while the pointer crosses from the link into the interactive card", async () => {
+    const request = vi.fn().mockResolvedValue({
+      closedAt: null,
+      comments: 4,
+      createdAt: "2026-07-05T08:00:00Z",
+      kind: "issue",
+      login: "octocat",
+      number: 99815,
+      owner: "openclaw",
+      repo: "openclaw",
+      state: "open",
+      stateReason: null,
+      title: "Keep hover previews compact",
+      updatedAt: "2026-07-05T09:55:00Z",
+    });
+    const href = "https://github.com/openclaw/openclaw/issues/99815";
+    const { anchor, provider } = createLink(href, "#99815");
+    provider.client = { request } as unknown as GatewayBrowserClient;
+    await hover(anchor);
+
+    const card = document.querySelector<HTMLElement>(".github-link-hovercard");
+    const action = card?.querySelector<HTMLAnchorElement>(".github-link-hovercard__action");
+    expect(card?.getAttribute("role")).toBe("dialog");
+    expect(action?.href).toBe(href);
+    expect(action?.target).toBe("_blank");
+    expect(action?.rel).toBe("noopener noreferrer");
+
+    leave(anchor);
+    await vi.advanceTimersByTimeAsync(50);
+    card?.dispatchEvent(new MouseEvent("pointerenter"));
+    await vi.advanceTimersByTimeAsync(150);
+    expect(document.querySelector(".github-link-hovercard")).toBe(card);
+
+    card?.dispatchEvent(new MouseEvent("pointerleave"));
+    await vi.advanceTimersByTimeAsync(150);
+    expect(document.querySelector(".github-link-hovercard")).toBeNull();
+  });
+
+  it("keeps the card open when its action receives focus and restores the source on Escape", async () => {
+    const request = vi.fn().mockResolvedValue({
+      closedAt: null,
+      comments: 4,
+      createdAt: "2026-07-05T08:00:00Z",
+      kind: "issue",
+      login: "octocat",
+      number: 99815,
+      owner: "openclaw",
+      repo: "openclaw",
+      state: "open",
+      stateReason: null,
+      title: "Keep hover previews compact",
+      updatedAt: "2026-07-05T09:55:00Z",
+    });
+    const { anchor, provider } = createLink(
+      "https://github.com/openclaw/openclaw/issues/99815",
+      "#99815",
+    );
+    provider.client = { request } as unknown as GatewayBrowserClient;
+
+    anchor.focus();
+    await vi.advanceTimersByTimeAsync(0);
+    const action = document.querySelector<HTMLAnchorElement>(".github-link-hovercard__action");
+    action?.focus();
+    expect(document.activeElement).toBe(action);
+    expect(document.querySelector(".github-link-hovercard")).not.toBeNull();
+
+    action?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    expect(document.querySelector(".github-link-hovercard")).toBeNull();
+    expect(document.activeElement).toBe(anchor);
   });
 
   it("ignores unsupported GitHub links and shows a quiet unavailable state", async () => {
@@ -265,6 +337,7 @@ describe("openclaw-github-link-hovercard-provider", () => {
         comments: "{count} comentários",
         pullRequest: "pull request",
         issue: "issue",
+        openOnGitHub: "Abrir no GitHub",
         ariaLabel: "{state} {kind} {repo} #{number}: {title}, por {author}",
       },
     });

--- a/ui/src/components/github-link-hovercard.ts
+++ b/ui/src/components/github-link-hovercard.ts
@@ -5,11 +5,13 @@ import { ReactiveElement } from "lit";
 import type { ControlUiGitHubPreview } from "../../../src/gateway/control-ui-contract.js";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import { i18n, t } from "../i18n/index.ts";
+import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../lib/external-link.ts";
 import { formatRelativeTimestamp } from "../lib/format.ts";
 import { parseGitHubItemPath, type GitHubItemTarget } from "./github-link-target.ts";
 
 const GITHUB_HOST = "github.com";
 const OPEN_DELAY_MS = 250;
+const CLOSE_DELAY_MS = 150;
 const SUCCESS_CACHE_MS = 5 * 60_000;
 const FAILURE_CACHE_MS = 30_000;
 const CACHE_LIMIT = 100;
@@ -151,14 +153,26 @@ function appendMetric(parent: HTMLElement, className: string, text: string): voi
   appendTextElement(parent, "span", `github-link-hovercard__metric ${className}`, text);
 }
 
-function renderLoading(card: HTMLDivElement): void {
+function appendOpenAction(card: HTMLDivElement, href: string): void {
+  const action = document.createElement("a");
+  action.className = "github-link-hovercard__action";
+  action.href = href;
+  action.target = EXTERNAL_LINK_TARGET;
+  action.rel = buildExternalLinkRel();
+  action.textContent = t("githubPreview.openOnGitHub");
+  card.append(action);
+}
+
+function renderLoading(card: HTMLDivElement, href: string): void {
   card.replaceChildren();
   card.dataset.loading = "true";
   card.removeAttribute("data-state");
   appendTextElement(card, "div", "github-link-hovercard__loading", t("githubPreview.loading"));
+  appendOpenAction(card, href);
+  card.setAttribute("aria-label", t("githubPreview.loading"));
 }
 
-function renderUnavailable(card: HTMLDivElement): void {
+function renderUnavailable(card: HTMLDivElement, href: string): void {
   card.replaceChildren();
   card.dataset.loading = "false";
   card.dataset.state = "unavailable";
@@ -168,6 +182,8 @@ function renderUnavailable(card: HTMLDivElement): void {
     "github-link-hovercard__unavailable",
     t("githubPreview.unavailable"),
   );
+  appendOpenAction(card, href);
+  card.setAttribute("aria-label", t("githubPreview.unavailable"));
 }
 
 function renderPreview(card: HTMLDivElement, preview: GitHubPreview): void {
@@ -244,6 +260,7 @@ function renderPreview(card: HTMLDivElement, preview: GitHubPreview): void {
   }
   footer.append(metrics);
   card.append(header, title, footer);
+  appendOpenAction(card, preview.href);
   card.setAttribute(
     "aria-label",
     t("githubPreview.ariaLabel", {
@@ -276,6 +293,7 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
   private activeAnchor: HTMLAnchorElement | null = null;
   private activeTarget: GitHubLinkTarget | null = null;
   private card: HTMLDivElement | null = null;
+  private closeTimer: number | null = null;
   private describedBy: string | null = null;
   private focusInside = false;
   private openTimer: number | null = null;
@@ -298,11 +316,12 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     },
     onError: () => {
       const card = this.card;
-      if (!card) {
+      const target = this.activeTarget;
+      if (!card || !target) {
         return;
       }
       this.renderedUnavailable = true;
-      renderUnavailable(card);
+      renderUnavailable(card, target.href);
       this.positionCard();
     },
   });
@@ -346,15 +365,16 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
 
   private readonly handleLocaleChange = () => {
     const card = this.card;
-    if (!card) {
+    const target = this.activeTarget;
+    if (!card || !target) {
       return;
     }
     if (this.renderedPreview) {
       renderPreview(card, this.renderedPreview);
     } else if (this.renderedUnavailable) {
-      renderUnavailable(card);
+      renderUnavailable(card, target.href);
     } else {
-      renderLoading(card);
+      renderLoading(card, target.href);
     }
     this.positionCard();
   };
@@ -369,6 +389,7 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     if (!anchor || !target) {
       return;
     }
+    this.clearCloseTimer();
     this.activate(anchor, target, OPEN_DELAY_MS);
     this.pointerInside = true;
   };
@@ -383,7 +404,7 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     }
     this.pointerInside = false;
     if (!this.focusInside) {
-      this.close();
+      this.closeSoon();
     }
   };
 
@@ -401,7 +422,10 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     if (!this.activeAnchor) {
       return;
     }
-    if (event.relatedTarget instanceof Node && this.activeAnchor.contains(event.relatedTarget)) {
+    if (
+      event.relatedTarget instanceof Node &&
+      (this.activeAnchor.contains(event.relatedTarget) || this.card?.contains(event.relatedTarget))
+    ) {
       return;
     }
     this.focusInside = false;
@@ -412,6 +436,46 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
 
   private readonly handleKeyDown = (event: KeyboardEvent) => {
     if (event.key === "Escape") {
+      if (this.card?.contains(document.activeElement)) {
+        this.activeAnchor?.focus({ preventScroll: true });
+      }
+      this.close();
+      event.preventDefault();
+    }
+  };
+
+  private readonly handleCardPointerEnter = () => {
+    this.clearCloseTimer();
+    this.pointerInside = true;
+  };
+
+  private readonly handleCardPointerLeave = () => {
+    this.pointerInside = false;
+    if (!this.focusInside) {
+      this.closeSoon();
+    }
+  };
+
+  private readonly handleCardFocusIn = () => {
+    this.focusInside = true;
+  };
+
+  private readonly handleCardFocusOut = (event: FocusEvent) => {
+    const relatedTarget = event.relatedTarget;
+    if (
+      relatedTarget instanceof Node &&
+      (this.card?.contains(relatedTarget) || this.activeAnchor?.contains(relatedTarget))
+    ) {
+      return;
+    }
+    this.focusInside = false;
+    if (!this.pointerInside) {
+      this.close();
+    }
+  };
+
+  private readonly handleCardClick = (event: MouseEvent) => {
+    if (event.target instanceof Element && event.target.closest("a")) {
       this.close();
     }
   };
@@ -444,11 +508,17 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     card.id = `openclaw-github-hovercard-${nextHovercardId}`;
     card.className = "github-link-hovercard";
     card.dataset.open = "true";
-    card.setAttribute("role", "tooltip");
+    card.setAttribute("role", "dialog");
     card.setAttribute("aria-live", "polite");
+    card.addEventListener("pointerenter", this.handleCardPointerEnter);
+    card.addEventListener("pointerleave", this.handleCardPointerLeave);
+    card.addEventListener("focusin", this.handleCardFocusIn);
+    card.addEventListener("focusout", this.handleCardFocusOut);
+    card.addEventListener("keydown", this.handleKeyDown);
+    card.addEventListener("click", this.handleCardClick);
     this.renderedPreview = null;
     this.renderedUnavailable = false;
-    renderLoading(card);
+    renderLoading(card, target.href);
     document.body.append(card);
     this.card = card;
     anchor.setAttribute(
@@ -512,6 +582,7 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
   }
 
   private close(): void {
+    this.clearCloseTimer();
     if (this.openTimer !== null) {
       window.clearTimeout(this.openTimer);
       this.openTimer = null;
@@ -535,6 +606,23 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     this.focusInside = false;
     this.pointerInside = false;
     this.stopListeningForViewportChanges();
+  }
+
+  private closeSoon(): void {
+    this.clearCloseTimer();
+    this.closeTimer = window.setTimeout(() => {
+      this.closeTimer = null;
+      if (!this.pointerInside && !this.focusInside) {
+        this.close();
+      }
+    }, CLOSE_DELAY_MS);
+  }
+
+  private clearCloseTimer(): void {
+    if (this.closeTimer !== null) {
+      window.clearTimeout(this.closeTimer);
+      this.closeTimer = null;
+    }
   }
 
   private readonly handleViewportChange = () => {

--- a/ui/src/e2e/github-link-hovercard.e2e.test.ts
+++ b/ui/src/e2e/github-link-hovercard.e2e.test.ts
@@ -203,6 +203,19 @@ describeControlUiE2e("GitHub link hover cards", () => {
     expect(pullBox!.x + pullBox!.width).toBeLessThanOrEqual(1180);
     expect(pullBox!.y + pullBox!.height).toBeLessThanOrEqual(800);
 
+    const openOnGitHub = card.getByRole("link", { name: "Open on GitHub" });
+    await openOnGitHub.hover();
+    await page.clock.runFor(200);
+    await expect.poll(() => card.count()).toBe(1);
+    expect(await openOnGitHub.getAttribute("href")).toBe(
+      "https://github.com/openclaw/openclaw/pull/99816",
+    );
+    const cardPopupPromise = page.waitForEvent("popup");
+    await openOnGitHub.click();
+    const cardPopup = await cardPopupPromise;
+    await cardPopup.waitForLoadState("domcontentloaded");
+    expect(cardPopup.url()).toBe("https://github.com/openclaw/openclaw/pull/99816");
+
     const issueLink = page.getByRole("link", { name: "openclaw/openclaw#99815" });
     await issueLink.hover();
     await expectText(card, "Keep hover previews compact");

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -152,6 +152,7 @@ export const en: TranslationMap = {
     comments: "{count} comments",
     pullRequest: "pull request",
     issue: "issue",
+    openOnGitHub: "Open on GitHub",
     ariaLabel: "{state} {kind} {repo} #{number}: {title}, by {author}",
   },
   channels: {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -732,7 +732,6 @@ openclaw-session-owner-chip {
   box-shadow: var(--shadow-lg);
   color: var(--text);
   font-family: var(--font-body);
-  pointer-events: none;
   opacity: 0;
   transform: translateY(-5px) scale(0.99);
   transform-origin: bottom left;
@@ -875,6 +874,22 @@ openclaw-session-owner-chip {
 
 .github-link-hovercard__metric--deletions {
   color: var(--danger);
+}
+
+.github-link-hovercard__action {
+  display: block;
+  width: fit-content;
+  margin: 12px 0 0 auto;
+  color: var(--accent);
+  font-size: var(--control-ui-text-sm);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.github-link-hovercard__action:hover,
+.github-link-hovercard__action:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }
 
 .github-link-hovercard__loading,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users hovering GitHub issue or pull request links could not move the pointer into the preview card. The card closed as soon as the pointer left the source link, so users could not interact with preview content.

## Why This Change Was Made

The source link and portaled hovercard now share one pointer and focus region with a short close delay that bridges the layout gap. The card uses dialog semantics and includes an **Open on GitHub** action.

## User Impact

Users can move the pointer from a GitHub link into its preview card and open the item from the card. Keyboard focus can also enter the card without dismissing it.

## Evidence

- `node scripts/run-vitest.mjs ui/src/components/github-link-hovercard.test.ts` (12 tests passed)
- `node scripts/run-vitest.mjs ui/src/e2e/github-link-hovercard.e2e.test.ts` (1 Chromium test passed; verifies link-to-card pointer movement and the GitHub action)
- `git diff --check origin/main...HEAD` (passed)
- `./node_modules/.bin/oxfmt --check ui/src/components/github-link-hovercard.test.ts ui/src/components/github-link-hovercard.ts ui/src/e2e/github-link-hovercard.e2e.test.ts ui/src/i18n/locales/en.ts ui/src/styles/components.css` (passed)

AI-assisted: Codex helped diagnose, implement, and validate this change. I reviewed the behavior and code.
