### PR TITLE
refactor(ui): consolidate repeated control UI paths

### DIFF
--- a/ui/src/pages/devices/view-inventory.ts
+++ b/ui/src/pages/devices/view-inventory.ts
@@ -84,7 +84,7 @@ export function renderDeviceInventory(props: DevicesProps) {
   // this section's empty state depends only on its own rows.
   const empty = groups.length === 0 && !gatewayPresence;
   const deviceRows = html`
-    ${gatewayPresence ? renderGatewayEntry(gatewayPresence) : nothing}
+    ${gatewayPresence ? renderPresenceRow({ kind: "gateway", entry: gatewayPresence }) : nothing}
     ${empty
       ? renderSettingsEmpty(loading ? t("common.loading") : t("devices.inventory.empty"))
       : groups.map((group) => renderInventoryGroup(group, props))}
@@ -109,7 +109,7 @@ export function renderDeviceInventory(props: DevicesProps) {
     ${unpairedPresence.length > 0
       ? renderSettingsSection(
           { title: t("devices.inventory.connectedWithoutPairing") },
-          unpairedPresence.map((entry) => renderPresenceOnlyEntry(entry)),
+          unpairedPresence.map((entry) => renderPresenceRow({ kind: "unpaired", entry })),
         )
       : nothing}
   `;
@@ -345,44 +345,35 @@ function presenceMetaParts(entry: PresenceEntry): string[] {
   return parts;
 }
 
-function renderGatewayEntry(entry: PresenceEntry) {
+function renderPresenceRow(
+  presence: { kind: "gateway"; entry: PresenceEntry } | { kind: "unpaired"; entry: PresenceEntry },
+) {
+  const { entry } = presence;
+  const gateway = presence.kind === "gateway";
   const parts = presenceMetaParts(entry);
+  if (!gateway && Array.isArray(entry.roles)) {
+    parts.push(...entry.roles.filter(Boolean));
+  }
+  const icon = gateway
+    ? icons.server
+    : deviceIcon({ clientMode: entry.mode ?? undefined, platform: entry.platform ?? undefined });
+  const title = gateway
+    ? (entry.host ?? t("devices.execApprovals.gateway"))
+    : (entry.host ?? entry.mode ?? t("devices.inventory.unknownClient"));
   return html`
     <div class="settings-row device-entry">
-      ${renderDeviceTile(icons.server)}
+      ${renderDeviceTile(icon)}
       <div class="settings-row__text">
-        <span class="settings-row__title">${entry.host ?? t("devices.execApprovals.gateway")}</span>
+        <span class="settings-row__title">${title}</span>
         ${parts.length > 0
           ? html`<span class="settings-row__desc">${parts.join(" · ")}</span>`
           : nothing}
       </div>
       <div class="settings-row__control">
         ${renderSettingsStatus({ kind: "ok", label: t("devices.inventory.connected") })}
-        ${renderSettingsStatus({ kind: "accent", label: t("devices.inventory.gateway") })}
-      </div>
-    </div>
-  `;
-}
-
-function renderPresenceOnlyEntry(entry: PresenceEntry) {
-  const roles = Array.isArray(entry.roles) ? entry.roles.filter(Boolean) : [];
-  const parts = [...presenceMetaParts(entry), ...roles];
-  return html`
-    <div class="settings-row device-entry">
-      ${renderDeviceTile(
-        deviceIcon({ clientMode: entry.mode ?? undefined, platform: entry.platform ?? undefined }),
-      )}
-      <div class="settings-row__text">
-        <span class="settings-row__title">
-          ${entry.host ?? entry.mode ?? t("devices.inventory.unknownClient")}
-        </span>
-        ${parts.length > 0
-          ? html`<span class="settings-row__desc">${parts.join(" · ")}</span>`
-          : nothing}
-      </div>
-      <div class="settings-row__control">
-        ${renderSettingsStatus({ kind: "ok", label: t("devices.inventory.connected") })}
-        ${renderSettingsStatus({ kind: "muted", label: t("devices.inventory.unpaired") })}
+        ${gateway
+          ? renderSettingsStatus({ kind: "accent", label: t("devices.inventory.gateway") })
+          : renderSettingsStatus({ kind: "muted", label: t("devices.inventory.unpaired") })}
       </div>
     </div>
   `;

--- a/ui/src/pages/devices/view.devices.test.ts
+++ b/ui/src/pages/devices/view.devices.test.ts
@@ -654,7 +654,8 @@ describe("devices exec approvals rendering", () => {
 });
 
 describe("devices agent bindings", () => {
-  it("reports the keyed agent id when a binding changes", () => {
+  it("reports node bindings and translates each unbound sentinel", () => {
+    const onBindDefault = vi.fn();
     const onBindAgent = vi.fn();
     const container = renderDevicesContainer({
       nodes: [
@@ -672,14 +673,26 @@ describe("devices agent bindings", () => {
           },
         },
       },
+      onBindDefault,
       onBindAgent,
     });
     const bindingSection = getSection(container, "Exec node binding");
     const selects = bindingSection.querySelectorAll<HTMLSelectElement>("select.settings-select");
 
-    selects[1]!.value = "worker-node";
-    selects[1]!.dispatchEvent(new Event("change"));
+    const [defaultBinding, mainBinding] = selects;
+    defaultBinding!.value = "worker-node";
+    defaultBinding!.dispatchEvent(new Event("change"));
+    defaultBinding!.value = "";
+    defaultBinding!.dispatchEvent(new Event("change"));
+    mainBinding!.value = "worker-node";
+    mainBinding!.dispatchEvent(new Event("change"));
+    mainBinding!.value = "__default__";
+    mainBinding!.dispatchEvent(new Event("change"));
 
-    expect(onBindAgent).toHaveBeenCalledWith("MAIN", "worker-node");
+    expect(onBindDefault.mock.calls).toEqual([["worker-node"], [null]]);
+    expect(onBindAgent.mock.calls).toEqual([
+      ["MAIN", "worker-node"],
+      ["MAIN", null],
+    ]);
   });
 });

--- a/ui/src/pages/devices/view.ts
+++ b/ui/src/pages/devices/view.ts
@@ -74,7 +74,6 @@ function resolveBindingsState(props: DevicesProps): BindingState {
 
 function renderBindings(state: BindingState) {
   const supportsBinding = state.nodes.length > 0;
-  const defaultValue = state.defaultBinding ?? "";
   const saveButton = html`
     <button class="btn" ?disabled=${state.disabled || !state.configDirty} @click=${state.onSave}>
       ${state.configSaving ? t("common.saving") : t("common.save")}
@@ -99,28 +98,7 @@ function renderBindings(state: BindingState) {
             description: supportsBinding
               ? t("devices.binding.defaultBindingHint")
               : html`${t("devices.binding.defaultBindingHint")} ${t("devices.binding.noNodes")}`,
-            control: html`
-              <select
-                class="settings-select"
-                aria-label=${t("devices.binding.node")}
-                ?disabled=${state.disabled || !supportsBinding}
-                @change=${(event: Event) => {
-                  const target = event.target as HTMLSelectElement;
-                  const value = target.value.trim();
-                  state.onBindDefault(value ? value : null);
-                }}
-              >
-                <option value="" ?selected=${defaultValue === ""}>
-                  ${t("devices.binding.anyNode")}
-                </option>
-                ${state.nodes.map(
-                  (node) =>
-                    html`<option value=${node.id} ?selected=${defaultValue === node.id}>
-                      ${node.label}
-                    </option>`,
-                )}
-              </select>
-            `,
+            control: renderBindingSelect(null, state),
           })}
           ${state.agents.length === 0
             ? renderSettingsRow({ title: t("devices.binding.noAgents") })
@@ -140,7 +118,6 @@ function renderBindings(state: BindingState) {
 function renderAgentBinding(agent: BindingAgent, state: BindingState) {
   const bindingValue = agent.binding ?? "__default__";
   const label = agent.name?.trim() ? `${agent.name} (${agent.id})` : agent.id;
-  const supportsBinding = state.nodes.length > 0;
   return renderSettingsRow({
     title: label,
     description: html`
@@ -151,29 +128,38 @@ function renderAgentBinding(agent: BindingAgent, state: BindingState) {
           })
         : t("devices.binding.override", { node: agent.binding ?? "" })}
     `,
-    control: html`
-      <select
-        class="settings-select"
-        aria-label=${t("devices.binding.binding")}
-        ?disabled=${state.disabled || !supportsBinding}
-        @change=${(event: Event) => {
-          const target = event.target as HTMLSelectElement;
-          const value = target.value.trim();
-          state.onBindAgent(agent.id, value === "__default__" ? null : value);
-        }}
-      >
-        <option value="__default__" ?selected=${bindingValue === "__default__"}>
-          ${t("devices.binding.useDefault")}
-        </option>
-        ${state.nodes.map(
-          (node) =>
-            html`<option value=${node.id} ?selected=${bindingValue === node.id}>
-              ${node.label}
-            </option>`,
-        )}
-      </select>
-    `,
+    control: renderBindingSelect(agent, state),
   });
+}
+
+function renderBindingSelect(agent: BindingAgent | null, state: BindingState) {
+  const isDefault = agent === null;
+  const sentinel = isDefault ? "" : "__default__";
+  const value = isDefault ? (state.defaultBinding ?? "") : (agent.binding ?? "__default__");
+  const onChange = (event: Event) => {
+    const value = (event.target as HTMLSelectElement).value.trim();
+    if (agent === null) {
+      state.onBindDefault(value || null);
+    } else {
+      state.onBindAgent(agent.id, value === "__default__" ? null : value);
+    }
+  };
+  return html`
+    <select
+      class="settings-select"
+      aria-label=${t(isDefault ? "devices.binding.node" : "devices.binding.binding")}
+      ?disabled=${state.disabled || state.nodes.length === 0}
+      @change=${onChange}
+    >
+      <option value=${sentinel} ?selected=${value === sentinel}>
+        ${t(isDefault ? "devices.binding.anyNode" : "devices.binding.useDefault")}
+      </option>
+      ${state.nodes.map(
+        (node) =>
+          html`<option value=${node.id} ?selected=${value === node.id}>${node.label}</option>`,
+      )}
+    </select>
+  `;
 }
 
 function resolveExecNodes(nodes: Array<Record<string, unknown>>): BindingNode[] {

--- a/ui/src/pages/devices/view.ts
+++ b/ui/src/pages/devices/view.ts
@@ -135,7 +135,7 @@ function renderAgentBinding(agent: BindingAgent, state: BindingState) {
 function renderBindingSelect(agent: BindingAgent | null, state: BindingState) {
   const isDefault = agent === null;
   const sentinel = isDefault ? "" : "__default__";
-  const value = isDefault ? (state.defaultBinding ?? "") : (agent.binding ?? "__default__");
+  const selected = isDefault ? (state.defaultBinding ?? "") : (agent.binding ?? "__default__");
   const onChange = (event: Event) => {
     const value = (event.target as HTMLSelectElement).value.trim();
     if (agent === null) {
@@ -151,12 +151,12 @@ function renderBindingSelect(agent: BindingAgent | null, state: BindingState) {
       ?disabled=${state.disabled || state.nodes.length === 0}
       @change=${onChange}
     >
-      <option value=${sentinel} ?selected=${value === sentinel}>
+      <option value=${sentinel} ?selected=${selected === sentinel}>
         ${t(isDefault ? "devices.binding.anyNode" : "devices.binding.useDefault")}
       </option>
       ${state.nodes.map(
         (node) =>
-          html`<option value=${node.id} ?selected=${value === node.id}>${node.label}</option>`,
+          html`<option value=${node.id} ?selected=${selected === node.id}>${node.label}</option>`,
       )}
     </select>
   `;

--- a/ui/src/pages/usage/request-usage-snapshot.ts
+++ b/ui/src/pages/usage/request-usage-snapshot.ts
@@ -1,0 +1,34 @@
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { CostUsageSummary } from "../../api/types.ts";
+import { buildSessionUsageDateParams, requestSessionUsage } from "../../lib/sessions/index.ts";
+import type { ProviderUsageSummary } from "./data-types.ts";
+
+export async function requestUsageSnapshot(
+  client: GatewayBrowserClient,
+  query: {
+    startDate: string;
+    endDate: string;
+    scope: "instance" | "family";
+    timeZone: "local" | "utc";
+    agentId?: string;
+  },
+  signal?: AbortSignal,
+) {
+  const costParams = {
+    startDate: query.startDate,
+    endDate: query.endDate,
+    ...(query.agentId ? { agentId: query.agentId } : { agentScope: "all" as const }),
+    ...buildSessionUsageDateParams(query.timeZone),
+  };
+  const [result, costSummary, providerUsageSummary] = await Promise.all([
+    requestSessionUsage(client, query),
+    signal
+      ? client.request<CostUsageSummary>("usage.cost", costParams, { signal })
+      : client.request<CostUsageSummary>("usage.cost", costParams),
+    (signal
+      ? client.request<ProviderUsageSummary>("usage.status", undefined, { signal })
+      : client.request<ProviderUsageSummary>("usage.status")
+    ).catch(() => null),
+  ]);
+  return { result, costSummary, providerUsageSummary };
+}

--- a/ui/src/pages/usage/route.ts
+++ b/ui/src/pages/usage/route.ts
@@ -1,14 +1,12 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
-import type { CostUsageSummary } from "../../api/types.ts";
 import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import {
   formatMissingOperatorReadScopeMessage,
   isMissingOperatorReadScopeError,
 } from "../../lib/gateway-errors.ts";
-import { buildSessionUsageDateParams, requestSessionUsage } from "../../lib/sessions/index.ts";
-import type { ProviderUsageSummary } from "./data-types.ts";
+import { requestUsageSnapshot } from "./request-usage-snapshot.ts";
 import type { UsageRouteData } from "./usage-page.ts";
 
 function currentLocalDate(): string {
@@ -51,26 +49,15 @@ async function loadUsageRouteData(context: ApplicationContext): Promise<UsageRou
   }
 
   try {
-    const [result, costSummary, providerUsageSummary] = await Promise.all([
-      requestSessionUsage(gatewaySnapshot.client, {
-        ...query,
-        agentId: query.agentId ?? undefined,
-      }),
-      gatewaySnapshot.client.request<CostUsageSummary>("usage.cost", {
-        startDate: query.startDate,
-        endDate: query.endDate,
-        ...(query.agentId ? { agentId: query.agentId } : { agentScope: "all" as const }),
-        ...buildSessionUsageDateParams(query.timeZone),
-      }),
-      gatewaySnapshot.client.request<ProviderUsageSummary>("usage.status").catch(() => null),
-    ]);
+    const snapshot = await requestUsageSnapshot(gatewaySnapshot.client, {
+      ...query,
+      agentId: query.agentId ?? undefined,
+    });
     return {
       gateway,
       gatewaySnapshot,
       query,
-      result,
-      costSummary,
-      providerUsageSummary,
+      ...snapshot,
       loadedAtMs: Date.now(),
       error: null,
     };

--- a/ui/src/pages/usage/usage-page.ts
+++ b/ui/src/pages/usage/usage-page.ts
@@ -25,8 +25,6 @@ import {
   isMissingOperatorReadScopeError,
 } from "../../lib/gateway-errors.ts";
 import {
-  buildSessionUsageDateParams,
-  requestSessionUsage,
   requestSessionUsageLogs,
   requestSessionUsageTimeSeries,
 } from "../../lib/sessions/index.ts";
@@ -48,6 +46,7 @@ import {
 } from "./helpers.ts";
 import { renderUsagePageShell } from "./page-shell.ts";
 import { UsageRefreshPolicy } from "./refresh-policy.ts";
+import { requestUsageSnapshot } from "./request-usage-snapshot.ts";
 import {
   DEFAULT_VISIBLE_COLUMNS,
   type SessionLogEntry,
@@ -72,12 +71,6 @@ export type UsageRouteData = {
   providerUsageSummary: ProviderUsageSummary | null;
   loadedAtMs: number | null;
   error: string | null;
-};
-
-type UsageTaskValue = {
-  result: SessionsUsageResult;
-  costSummary: CostUsageSummary;
-  providerUsageSummary: ProviderUsageSummary | null;
 };
 
 type UsageDetailTaskValue<T> = {
@@ -190,24 +183,7 @@ class UsagePage extends OpenClawLightDomElement {
       }
       this.refreshPolicy.beginLoad();
       const agentId = normalizedAgentId || undefined;
-      const agentScopeParams = agentId ? { agentId } : { agentScope: "all" as const };
-      const [result, costSummary, providerUsageSummary] = await Promise.all([
-        requestSessionUsage(client, { startDate, endDate, agentId, scope, timeZone }),
-        client.request<CostUsageSummary>(
-          "usage.cost",
-          {
-            startDate,
-            endDate,
-            ...agentScopeParams,
-            ...buildSessionUsageDateParams(timeZone),
-          },
-          { signal },
-        ),
-        client
-          .request<ProviderUsageSummary>("usage.status", undefined, { signal })
-          .catch(() => null),
-      ]);
-      return { result, costSummary, providerUsageSummary } satisfies UsageTaskValue;
+      return requestUsageSnapshot(client, { startDate, endDate, agentId, scope, timeZone }, signal);
     },
     onComplete: (value) => {
       this.usageTaskActiveClient = null;


### PR DESCRIPTION
## What Problem This Solves

The Control UI maintained parallel implementations for structurally identical presence rows, default/agent binding selects, and usage snapshot RPCs. Those copies made small rendering or request-policy changes easy to apply to one path but not its sibling.

This is an AI-assisted, maintainer-requested cleanup batch.

## Why This Change Was Made

Use one discriminated presence-row renderer for gateway and unpaired entries, one binding-select renderer parameterized by default versus agent ownership, and one usage snapshot request helper shared by route preload and live-page refresh.

Visible copy, icons, metadata ordering, status styles, ARIA labels, select values, callbacks, RPC methods/parameters, optional status failure handling, and request cancellation behavior are intentionally unchanged.

## User Impact

No user-visible behavior change. Contributors now have one owner for each repeated UI/RPC decision, reducing the chance that device and usage paths drift apart.

Production: 95 additions, 121 deletions (net -26). Tests: 18 additions, 5 deletions (net +13). Overall net -13.

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/devices/view.devices.test.ts ui/src/pages/route-provenance.test.ts ui/src/pages/gateway-source-replacement.test.ts ui/src/pages/usage/usage-page.test.ts ui/src/lib/sessions/usage.test.ts` under Node 24 — 5 files, 52 tests passed.
- `oxfmt --check` on all six touched files — 6/6 passed.
- `oxlint` on all six touched files — 0 warnings, 0 errors.
- `pnpm tsgo:ui` under Node 24 — passed with no diagnostics.
- Complete UI changed-path gate and `git diff --check` passed on the exact head.
- Independent Amp review found no P0/P1 findings and verified browser-visible text/whitespace, accessibility labels, selected/disabled state, callbacks, RPC contracts, route provenance, and a clean synthetic merge with current `main`.
- Prior exact-head TruffleHog scan was clean.

No screenshot is included because this refactor intentionally produces the same rendered UI. Source comparison and jsdom tests cover the affected states; the known non-blocking gap is that no real-Chromium reconnect/visual run was available in the review orb.
