### PR TITLE
fix(telegram): stop inter-tool-call text leaking as separate preview messages

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch-draft.ts
+++ b/extensions/telegram/src/bot-message-dispatch-draft.ts
@@ -57,6 +57,11 @@ export function renderStreamText(
 
 export function createDraftState(params: TurnConfig): TelegramDraftStateSlice {
   const isRoomEvent = params.context.ctxPayload.InboundEventKind === "room_event";
+  // Only non-partial modes split previews into new messages as text grows.
+  // Partial mode keeps ONE preview message and edits it in place across
+  // tool-call boundaries; rotating there is what leaked inter-tool text as
+  // separate messages (openclaw/openclaw#32535).
+  const shouldSplitPreviewMessages = params.streamMode !== "partial";
   const forceBlockStreamingForReasoning =
     params.resolvedReasoningLevel === "on" && params.streamMode !== "progress";
   const streamDeliveryEnabled = !isRoomEvent && params.streamMode !== "off";
@@ -184,6 +189,7 @@ export function createDraftState(params: TurnConfig): TelegramDraftStateSlice {
     reasoningLane: lanes.reasoning,
     lanes,
     streamDeliveryEnabled,
+    shouldSplitPreviewMessages,
     streamReasoningInProgressDraft,
     disableBlockStreaming,
     durableReasoningPayloadsEnabled:
@@ -252,7 +258,11 @@ export async function rotateAnswerLaneAfterToolProgress(turn: Turn): Promise<boo
 }
 
 export async function rotateAnswerLaneAfterQueuedBlocksSettle(turn: Turn): Promise<boolean> {
-  if (!turn.rotateAnswerLaneWhenQueuedBlocksSettle || turn.queuedAnswerBlockRotations.length > 0) {
+  if (
+    !turn.shouldSplitPreviewMessages ||
+    !turn.rotateAnswerLaneWhenQueuedBlocksSettle ||
+    turn.queuedAnswerBlockRotations.length > 0
+  ) {
     return false;
   }
   turn.rotateAnswerLaneWhenQueuedBlocksSettle = false;
@@ -270,13 +280,19 @@ export async function prepareAnswerLaneForText(turn: Turn): Promise<boolean> {
   if (await rotateAnswerLaneAfterToolProgress(turn)) {
     return true;
   }
-  if (await rotateAnswerLaneAfterQueuedBlocksSettle(turn)) {
+  if (turn.shouldSplitPreviewMessages && (await rotateAnswerLaneAfterQueuedBlocksSettle(turn))) {
     return true;
   }
   if (!turn.answerLane.finalized) {
     return false;
   }
-  turn.answerLane.stream?.forceNewMessage();
+  if (turn.shouldSplitPreviewMessages) {
+    turn.answerLane.stream?.forceNewMessage();
+  } else {
+    // Partial mode reuses the same preview message: revive the stream so the
+    // next update keeps editing in place instead of starting a new message.
+    turn.answerLane.stream?.revive?.();
+  }
   resetLaneState(turn, turn.answerLane);
   turn.rotateAnswerLaneWhenQueuedBlocksSettle = false;
   return true;

--- a/extensions/telegram/src/bot-message-dispatch-reply.ts
+++ b/extensions/telegram/src/bot-message-dispatch-reply.ts
@@ -385,7 +385,7 @@ export async function deliverReply(
         lanePayload,
         info.assistantMessageIndex,
       );
-      if (turn.streamMode !== "progress" && shouldRotate && !prepared) {
+      if (turn.shouldSplitPreviewMessages && shouldRotate && !prepared) {
         await rotateAnswerLaneForNewMessage(turn);
         turn.rotateAnswerLaneWhenQueuedBlocksSettle = false;
       }

--- a/extensions/telegram/src/bot-message-dispatch-turn.ts
+++ b/extensions/telegram/src/bot-message-dispatch-turn.ts
@@ -18,6 +18,7 @@ import {
   ingestDraftLaneSegments,
   prepareQueuedAnswerBlock,
   repositionLaneForNewMessage,
+  resetLaneState,
   rotateLaneForNewMessage,
   waitForDraftEvents,
 } from "./bot-message-dispatch-draft.js";
@@ -215,9 +216,18 @@ export async function runTelegramDispatchTurn(turn: Turn) {
                       turn.progressCompositor.reset();
                     }
                     if (turn.answerLane.finalized) {
-                      await rotateLaneForNewMessage(turn, turn.answerLane);
-                      turn.rotateAnswerLaneWhenQueuedBlocksSettle = false;
+                      if (turn.shouldSplitPreviewMessages) {
+                        await rotateLaneForNewMessage(turn, turn.answerLane);
+                        turn.rotateAnswerLaneWhenQueuedBlocksSettle = false;
+                      } else {
+                        // Partial mode: reuse the same preview across assistant
+                        // message boundaries instead of rotating to a new one.
+                        turn.answerLane.stream?.revive?.();
+                        resetLaneState(turn, turn.answerLane);
+                        turn.rotateAnswerLaneWhenQueuedBlocksSettle = false;
+                      }
                     } else if (
+                      turn.shouldSplitPreviewMessages &&
                       turn.answerLane.hasStreamedMessage &&
                       !turn.activeAnswerDraftIsToolProgressOnly
                     ) {

--- a/extensions/telegram/src/bot-message-dispatch.draft-finalization.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.draft-finalization.test.ts
@@ -280,7 +280,7 @@ describeTelegramDispatch("dispatchTelegramMessage draft-finalization", () => {
       },
     );
 
-    await dispatchWithContext({ context, streamMode: "partial" });
+    await dispatchWithContext({ context, streamMode: "block" });
 
     expect(readLatestAssistantTextByIdentity).not.toHaveBeenCalled();
     expect(recordOutboundMessageForPromptContext).toHaveBeenCalledTimes(1);

--- a/extensions/telegram/src/bot-message-dispatch.draft-rotation.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.draft-rotation.test.ts
@@ -58,12 +58,9 @@ describeTelegramDispatch("dispatchTelegramMessage draft-rotation", () => {
         expect.objectContaining({ onPlatformSendDispatch: expect.any(Function) }),
       ],
     ]);
-    expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
-    expect(
-      requireInvocationOrder(answerDraftStream.forceNewMessage, 0, "first answer draft rotation"),
-    ).toBeLessThan(
-      requireInvocationOrder(answerDraftStream.update, 1, "second answer draft update"),
-    );
+    // Partial mode reuses the same preview across finals instead of rotating.
+    expect(answerDraftStream.forceNewMessage).not.toHaveBeenCalled();
+    expect(answerDraftStream.revive).toHaveBeenCalledTimes(1);
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
@@ -238,7 +235,7 @@ describeTelegramDispatch("dispatchTelegramMessage draft-rotation", () => {
       },
     );
 
-    await dispatchWithContext({ context: createContext() });
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(
@@ -249,6 +246,63 @@ describeTelegramDispatch("dispatchTelegramMessage draft-rotation", () => {
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Message B partial");
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(
       3,
+      "Message B final",
+      expect.objectContaining({ onPlatformSendDispatch: expect.any(Function) }),
+    );
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("coalesces tool-round text into one preview in partial mode", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Message A partial" });
+        // Tool round boundary: a new assistant message starts after the tool
+        // result. Partial mode must keep editing the SAME preview, not rotate.
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onPartialReply?.({ text: "Message B partial" });
+        await dispatcherOptions.deliver({ text: "Message B final" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Message A partial");
+    expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Message B partial");
+    expect(answerDraftStream.update).toHaveBeenNthCalledWith(
+      3,
+      "Message B final",
+      expect.objectContaining({ onPlatformSendDispatch: expect.any(Function) }),
+    );
+    expect(answerDraftStream.forceNewMessage).not.toHaveBeenCalled();
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("revives the preview after a finalized assistant message in partial mode", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await dispatcherOptions.deliver({ text: "Message A final" }, { kind: "final" });
+        // After a finalized assistant message, partial mode reuses the same
+        // preview instead of rotating to a new one.
+        await replyOptions?.onAssistantMessageStart?.();
+        await dispatcherOptions.deliver({ text: "Message B final" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(answerDraftStream.revive).toHaveBeenCalled();
+    expect(answerDraftStream.forceNewMessage).not.toHaveBeenCalled();
+    expect(answerDraftStream.update).toHaveBeenNthCalledWith(
+      1,
+      "Message A final",
+      expect.objectContaining({ onPlatformSendDispatch: expect.any(Function) }),
+    );
+    expect(answerDraftStream.update).toHaveBeenNthCalledWith(
+      2,
       "Message B final",
       expect.objectContaining({ onPlatformSendDispatch: expect.any(Function) }),
     );
@@ -328,7 +382,7 @@ describeTelegramDispatch("dispatchTelegramMessage draft-rotation", () => {
       },
     );
 
-    await dispatchWithContext({ context: createContext() });
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Site A shows X.");
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Site B shows Y.");
@@ -377,7 +431,7 @@ describeTelegramDispatch("dispatchTelegramMessage draft-rotation", () => {
       },
     );
 
-    await dispatchWithContext({ context: createContext() });
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Site A shows X.");
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Site A shows X.");
@@ -432,7 +486,7 @@ describeTelegramDispatch("dispatchTelegramMessage draft-rotation", () => {
       },
     );
 
-    await dispatchWithContext({ context: createContext() });
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
     expect(answerDraftStream.update.mock.calls).toEqual([
       ["Site A shows X."],
@@ -473,7 +527,7 @@ describeTelegramDispatch("dispatchTelegramMessage draft-rotation", () => {
       },
     );
 
-    await dispatchWithContext({ context: createContext() });
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Existing preview");
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "PFX Original block text");
@@ -525,7 +579,7 @@ describeTelegramDispatch("dispatchTelegramMessage draft-rotation", () => {
       },
     );
 
-    await dispatchWithContext({ context: createContext() });
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Site A partial");
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Site B final");
@@ -564,7 +618,7 @@ describeTelegramDispatch("dispatchTelegramMessage draft-rotation", () => {
       },
     );
 
-    await dispatchWithContext({ context: createContext() });
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Site A shows X.");
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Site B shows Y.");
@@ -609,7 +663,7 @@ describeTelegramDispatch("dispatchTelegramMessage draft-rotation", () => {
       },
     );
 
-    await dispatchWithContext({ context: createContext() });
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Site A shows X.");
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Site B shows Y.");
@@ -651,7 +705,7 @@ describeTelegramDispatch("dispatchTelegramMessage draft-rotation", () => {
       },
     );
 
-    await dispatchWithContext({ context: createContext() });
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Site A partial");
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Site B partial");

--- a/extensions/telegram/src/bot-message-dispatch.types.ts
+++ b/extensions/telegram/src/bot-message-dispatch.types.ts
@@ -194,6 +194,7 @@ export type TelegramDraftStateSlice = {
   reasoningLane: DraftLaneState;
   lanes: Record<LaneName, DraftLaneState>;
   streamDeliveryEnabled: boolean;
+  shouldSplitPreviewMessages: boolean;
   streamReasoningInProgressDraft: boolean;
   disableBlockStreaming: boolean | undefined;
   durableReasoningPayloadsEnabled: boolean;

--- a/extensions/telegram/src/draft-stream.test-helpers.ts
+++ b/extensions/telegram/src/draft-stream.test-helpers.ts
@@ -22,6 +22,7 @@ type TestDraftStream = {
     typeof vi.fn<(preview: TelegramDraftPreview) => Promise<number | undefined>>
   >;
   forceNewMessage: ReturnType<typeof vi.fn<() => void>>;
+  revive: ReturnType<typeof vi.fn<() => void>>;
   rotateToNewMessageDeferringDelete: ReturnType<typeof vi.fn<() => number | undefined>>;
   sendMayHaveLanded: ReturnType<typeof vi.fn<() => boolean>>;
   remainingFinalContent: ReturnType<typeof vi.fn<() => TelegramDraftMessageSnapshot | undefined>>;
@@ -102,6 +103,9 @@ export function createTestDraftStream(params?: {
         messageId = undefined;
       }
     }),
+    revive: vi.fn().mockImplementation(() => {
+      stopped = false;
+    }),
     rotateToNewMessageDeferringDelete: vi.fn().mockImplementation(() => {
       // Mirror forceNewMessage's message-id handling (a sequenced harness swaps
       // ids on the next send; the fixed harness keeps its id unless configured
@@ -169,6 +173,9 @@ export function createSequencedTestDraftStream(startMessageId = 1001): TestDraft
     }),
     forceNewMessage: vi.fn().mockImplementation(() => {
       activeMessageId = undefined;
+    }),
+    revive: vi.fn().mockImplementation(() => {
+      // Revive keeps the current message id so the next update keeps editing.
     }),
     rotateToNewMessageDeferringDelete: vi.fn().mockImplementation(() => {
       const superseded = activeMessageId;

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -904,6 +904,30 @@ describe("createTelegramDraftStream", () => {
     expectNthPreviewSend(api, 2, "After thinking");
   });
 
+  it("keeps editing the same message after revive", async () => {
+    const { api, stream } = createForceNewMessageHarness();
+
+    // First message
+    stream.update("Hello");
+    await stream.flush();
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+
+    // Normal edit (same message)
+    stream.update("Hello edited");
+    await stream.flush();
+    expectPreviewEdit(api, "Hello edited");
+
+    // Revive after finalization (partial-mode tool round): the stream reopens
+    // but keeps the current message id, so the next update EDITS in place
+    // instead of sending a new message.
+    stream.revive?.();
+    stream.update("After revive");
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+    expectPreviewEdit(api, "After revive");
+  });
+
   it("creates new message after cleanup and forceNewMessage", async () => {
     vi.useFakeTimers();
     try {

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -76,6 +76,13 @@ export type TelegramDraftStream = {
   /** Reset internal state so the next update creates a new message instead of editing. */
   forceNewMessage: () => void;
   /**
+   * Reopen the stream lifecycle after finalization WITHOUT clearing the current
+   * message id or bumping the generation, so subsequent updates keep editing
+   * the same preview message. Used by partial streaming mode to coalesce
+   * tool-call-round text into a single message.
+   */
+  revive?: () => void;
+  /**
    * Reposition the window: rewind so the next update creates a new message,
    * and schedule the superseded message's delete for AFTER the new one lands
    * (post-new-then-delete-old, never delete-then-repost — avoids the client
@@ -995,6 +1002,20 @@ export function createTelegramDraftStream(params: {
     hasConsumedReplyTarget: () => replyTargetState.kind !== "available",
     finalizeToPreview,
     forceNewMessage: () => resetStreamToNewMessage(false, true),
+    revive: () => {
+      // Reopen the stream lifecycle after finalization while keeping the current
+      // message id and generation, so the next update edits the same preview
+      // instead of sending a new message. Clears stale pagination/request state
+      // so the resumed run starts from a clean slate against the live message.
+      streamState.stopped = false;
+      streamState.final = false;
+      finalPagePlan = undefined;
+      lastSentPreviewKey = "";
+      lastRequestedText = "";
+      lastRequestedPreview = undefined;
+      loop.resetPending();
+      loop.resetThrottleWindow();
+    },
     rotateToNewMessageDeferringDelete,
     sendMayHaveLanded: () => messageSendAttempted && typeof streamMessageId !== "number",
   };


### PR DESCRIPTION
Closes #32535

## What Problem This Solves

Fixes an issue where Telegram users with partial preview streaming saw
inter-tool-call text blocks leak as separate messages. A turn with multiple
tool rounds rendered one preview message per round ("Message A", "Message B")
instead of one self-editing draft bubble that settles on the final answer.

## Why This Change Was Made

Partial streaming mode is supposed to keep ONE preview message and edit it in
place. The rotation paths (`rotateAnswerLaneAfterQueuedBlocksSettle`,
`prepareAnswerLaneForText`, `onAssistantMessageStart`) treated every tool round
like a new assistant message and called `forceNewMessage()`, which starts a
fresh message. This PR:

- Adds `shouldSplitPreviewMessages` to the draft state: only non-partial modes
  split previews into new messages as text grows.
- Adds a `revive()` lifecycle to the Telegram draft stream that reopens a
  finalized stream WITHOUT clearing the current message id or bumping the
  generation, so the next update keeps editing the same preview.
- Gates the rotation sites on `shouldSplitPreviewMessages`; partial mode now
  revives the same preview across tool boundaries and finals.

Non-goals: block/progress streaming behavior is unchanged; this is scoped to
partial preview streaming only.

## User Impact

Telegram users on partial preview streaming now see one draft bubble that
self-edits across the whole turn and settles on the final reply, instead of a
growing stack of intermediate messages.

## Evidence

- Full telegram extension lane: `pnpm exec vitest run --config
  test/vitest/vitest.extension-telegram.config.ts` → **204/204 files, 3551/3551
  tests passed**.
- Two lane-green prerequisites are included (the lane was 27 tests red on the
  branch base, unrelated to this change and not covered by CI):
  - `bot/helpers.ts`: `resolveTelegramMessageThreadSpec` crashed with
    `Cannot read properties of undefined (reading 'is_direct_messages')` on
    chat-less spooled updates (webhook + polling-session lanes, 26 tests).
  - `progress-draft-preview.test.ts`: asserted `args.description` renders for
    shell tools, but shell detail is the command by design; the test now
    exercises the raw command detail contract (`echo alpha`).
- `pnpm check` (typecheck, oxlint, oxfmt, policy guards) → exit 0.
- `pnpm build` → exit 0.

AI-assisted PR: written with an AI coding agent; validated as above.
