### PR TITLE
refactor: consolidate repeated runtime shaping

### DIFF
--- a/extensions/parallel/src/parallel-free-web-search-provider.runtime.ts
+++ b/extensions/parallel/src/parallel-free-web-search-provider.runtime.ts
@@ -1,8 +1,6 @@
 import {
   mergeScopedSearchConfig,
   readCachedSearchPayload,
-  readStringArrayParam,
-  readStringParam,
   resolveProviderWebSearchPluginConfig,
   resolveSearchCacheTtlMs,
   resolveSearchTimeoutSeconds,
@@ -12,14 +10,9 @@ import {
 import { PARALLEL_MCP_SEARCH_URL, runParallelMcpSearch } from "./parallel-mcp-search.runtime.js";
 import {
   buildParallelCacheKey,
-  invalidSearchQueriesPayload,
-  mapParallelResults,
-  normalizeParallelClientModel,
-  normalizeParallelObjective,
-  normalizeParallelSearchQueries,
-  normalizeParallelSessionId,
+  buildParallelSearchPayload,
   PARALLEL_FREE_SESSION_ID_MAX_LENGTH,
-  resolveParallelSearchCount,
+  normalizeParallelSearchRequest,
   stripParallelGeneratedSessionId,
 } from "./parallel-search-normalize.js";
 
@@ -34,23 +27,15 @@ export async function executeParallelFreeWebSearchProviderTool(
     resolveProviderWebSearchPluginConfig(ctx.config, "parallel-free"),
   ) as SearchConfigRecord | undefined;
 
-  // Mirror the paid provider's generic `query` fallback (the operator CLI passes
-  // `{ query, count }`); agent callers supply the native objective/search_queries.
-  const objective = normalizeParallelObjective(readStringParam(args, "objective"));
-  const cliQuery = normalizeParallelObjective(readStringParam(args, "query"));
-  let searchQueries = normalizeParallelSearchQueries(readStringArrayParam(args, "search_queries"));
-  if (searchQueries.length === 0 && cliQuery) {
-    searchQueries = normalizeParallelSearchQueries([cliQuery]);
-  }
-  if (searchQueries.length === 0) {
-    return invalidSearchQueriesPayload();
-  }
-  const count = resolveParallelSearchCount(args, searchConfig?.maxResults);
-  const sessionId = normalizeParallelSessionId(
-    readStringParam(args, "session_id"),
+  const request = normalizeParallelSearchRequest(
+    args,
+    searchConfig?.maxResults,
     PARALLEL_FREE_SESSION_ID_MAX_LENGTH,
   );
-  const clientModel = normalizeParallelClientModel(readStringParam(args, "client_model"));
+  if ("error" in request) {
+    return request.error;
+  }
+  const { objective, searchQueries, count, sessionId, clientModel } = request;
   const cacheKey = buildParallelCacheKey({
     endpoint: PARALLEL_MCP_SEARCH_URL,
     objective,
@@ -74,34 +59,13 @@ export async function executeParallelFreeWebSearchProviderTool(
     timeoutSeconds: resolveSearchTimeoutSeconds(searchConfig),
     signal,
   });
-  const results = mapParallelResults(response);
-
-  const payload: Record<string, unknown> = {
-    ...(objective ? { objective } : {}),
-    searchQueries,
+  const payload = buildParallelSearchPayload({
     provider: "parallel-free",
-    count: results.length,
-    tookMs: Date.now() - start,
-    externalContent: {
-      untrusted: true,
-      source: "web_search",
-      provider: "parallel-free",
-      wrapped: true,
-    },
-    results,
-  };
-  if (typeof response.search_id === "string") {
-    payload.searchId = response.search_id;
-  }
-  if (typeof response.session_id === "string") {
-    payload.sessionId = response.session_id;
-  }
-  if (Array.isArray(response.warnings) && response.warnings.length > 0) {
-    payload.warnings = response.warnings;
-  }
-  if (Array.isArray(response.usage) && response.usage.length > 0) {
-    payload.usage = response.usage;
-  }
+    objective,
+    searchQueries,
+    response,
+    start,
+  });
 
   const cachePayload = sessionId ? payload : stripParallelGeneratedSessionId(payload);
   writeCachedSearchPayload(cacheKey, cachePayload, resolveSearchCacheTtlMs(searchConfig));

--- a/extensions/parallel/src/parallel-search-normalize.ts
+++ b/extensions/parallel/src/parallel-search-normalize.ts
@@ -153,7 +153,7 @@ export function normalizeParallelSearchQueries(value: unknown): string[] {
   return out;
 }
 
-export function invalidSearchQueriesPayload() {
+function invalidSearchQueriesPayload() {
   return {
     error: "invalid_search_queries",
     message:
@@ -176,7 +176,7 @@ export function normalizeParallelResults(payload: unknown): ParallelSearchResult
 }
 
 /** Maps a Parallel v1 response into wrapped `web_search` result entries. */
-export function mapParallelResults(response: ParallelSearchResponse): Record<string, unknown>[] {
+function mapParallelResults(response: ParallelSearchResponse): Record<string, unknown>[] {
   return normalizeParallelResults(response).map((entry) => {
     const title = typeof entry.title === "string" ? entry.title : "";
     const url = typeof entry.url === "string" ? entry.url : "";

--- a/extensions/parallel/src/parallel-search-normalize.ts
+++ b/extensions/parallel/src/parallel-search-normalize.ts
@@ -7,6 +7,8 @@ import {
   buildSearchCacheKey,
   DEFAULT_SEARCH_COUNT,
   readPositiveIntegerParam,
+  readStringArrayParam,
+  readStringParam,
   resolveSiteName,
   wrapWebContent,
 } from "openclaw/plugin-sdk/provider-web-search";
@@ -42,6 +44,37 @@ export type ParallelSearchResponse = {
   warnings?: unknown;
   usage?: unknown;
 };
+
+export function normalizeParallelSearchRequest(
+  args: Record<string, unknown>,
+  configuredCount: unknown,
+  sessionIdMaxLength: number,
+):
+  | { error: ReturnType<typeof invalidSearchQueriesPayload> }
+  | {
+      objective?: string;
+      searchQueries: string[];
+      count: number;
+      sessionId?: string;
+      clientModel?: string;
+    } {
+  const objective = normalizeParallelObjective(readStringParam(args, "objective"));
+  const cliQuery = normalizeParallelObjective(readStringParam(args, "query"));
+  let searchQueries = normalizeParallelSearchQueries(readStringArrayParam(args, "search_queries"));
+  if (searchQueries.length === 0 && cliQuery) {
+    searchQueries = normalizeParallelSearchQueries([cliQuery]);
+  }
+  if (searchQueries.length === 0) {
+    return { error: invalidSearchQueriesPayload() };
+  }
+  return {
+    objective,
+    searchQueries,
+    count: resolveParallelSearchCount(args, configuredCount),
+    sessionId: normalizeParallelSessionId(readStringParam(args, "session_id"), sessionIdMaxLength),
+    clientModel: normalizeParallelClientModel(readStringParam(args, "client_model")),
+  };
+}
 
 export function resolveParallelSearchCount(
   args: Record<string, unknown>,
@@ -166,6 +199,43 @@ export function mapParallelResults(response: ParallelSearchResponse): Record<str
       excerpts.length > 0 ? { excerpts } : {},
     );
   });
+}
+
+export function buildParallelSearchPayload(params: {
+  provider: "parallel" | "parallel-free";
+  objective?: string;
+  searchQueries: readonly string[];
+  response: ParallelSearchResponse;
+  start: number;
+}): Record<string, unknown> {
+  const results = mapParallelResults(params.response);
+  const payload: Record<string, unknown> = {
+    ...(params.objective ? { objective: params.objective } : {}),
+    searchQueries: params.searchQueries,
+    provider: params.provider,
+    count: results.length,
+    tookMs: Date.now() - params.start,
+    externalContent: {
+      untrusted: true,
+      source: "web_search",
+      provider: params.provider,
+      wrapped: true,
+    },
+    results,
+  };
+  if (typeof params.response.search_id === "string") {
+    payload.searchId = params.response.search_id;
+  }
+  if (typeof params.response.session_id === "string") {
+    payload.sessionId = params.response.session_id;
+  }
+  if (Array.isArray(params.response.warnings) && params.response.warnings.length > 0) {
+    payload.warnings = params.response.warnings;
+  }
+  if (Array.isArray(params.response.usage) && params.response.usage.length > 0) {
+    payload.usage = params.response.usage;
+  }
+  return payload;
 }
 
 /**

--- a/extensions/parallel/src/parallel-web-search-provider.runtime.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.runtime.ts
@@ -9,8 +9,6 @@ import {
   readCachedSearchPayload,
   readConfiguredSecretString,
   readProviderEnvValue,
-  readStringArrayParam,
-  readStringParam,
   resolveProviderWebSearchPluginConfig,
   resolveSearchCacheTtlMs,
   resolveSearchTimeoutSeconds,
@@ -21,11 +19,11 @@ import {
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   buildParallelCacheKey,
-  invalidSearchQueriesPayload,
-  mapParallelResults,
+  buildParallelSearchPayload,
   normalizeParallelClientModel,
   normalizeParallelObjective,
   normalizeParallelResults,
+  normalizeParallelSearchRequest,
   normalizeParallelSearchQueries,
   normalizeParallelSessionId,
   PARALLEL_SESSION_ID_MAX_LENGTH,
@@ -190,30 +188,17 @@ export async function executeParallelWebSearchProviderTool(
   }
   const endpoint = endpointResult.endpoint;
 
-  // Generic `query` arg fallback: openclaw's operator-facing CLI
-  // (`openclaw capability web.search ...`) always passes the shared
-  // lowest-common-denominator shape `{ query, count, limit }` to whatever
-  // provider is active and doesn't know about Parallel's richer
-  // `{ objective, search_queries }` schema. When `search_queries` is absent
-  // we promote `query` into the lone search query. `objective` stays unset
-  // in that case rather than being faked from the keyword string.
-  const objective = normalizeParallelObjective(readStringParam(args, "objective"));
-  const cliQuery = normalizeParallelObjective(readStringParam(args, "query"));
-  let searchQueries = normalizeParallelSearchQueries(readStringArrayParam(args, "search_queries"));
-  if (searchQueries.length === 0 && cliQuery) {
-    searchQueries = normalizeParallelSearchQueries([cliQuery]);
-  }
-  if (searchQueries.length === 0) {
-    return invalidSearchQueriesPayload();
-  }
-  // Always pass max_results so Parallel matches the openclaw web_search default
-  // of 5 instead of Parallel's own default of 10.
-  const count = resolveParallelSearchCount(args, searchConfig?.maxResults);
-  const sessionId = normalizeParallelSessionId(
-    readStringParam(args, "session_id"),
+  const request = normalizeParallelSearchRequest(
+    args,
+    searchConfig?.maxResults,
     PARALLEL_SESSION_ID_MAX_LENGTH,
   );
-  const clientModel = normalizeParallelClientModel(readStringParam(args, "client_model"));
+  if ("error" in request) {
+    return request.error;
+  }
+  const { objective, searchQueries, count, sessionId, clientModel } = request;
+  // Always pass max_results so Parallel matches the openclaw web_search default
+  // of 5 instead of Parallel's own default of 10.
   const cacheKey = buildParallelCacheKey({
     endpoint,
     objective,
@@ -240,34 +225,13 @@ export async function executeParallelWebSearchProviderTool(
     signal,
   });
   signal?.throwIfAborted();
-  const results = mapParallelResults(response);
-
-  const payload: Record<string, unknown> = {
-    ...(objective ? { objective } : {}),
-    searchQueries,
+  const payload = buildParallelSearchPayload({
     provider: "parallel",
-    count: results.length,
-    tookMs: Date.now() - start,
-    externalContent: {
-      untrusted: true,
-      source: "web_search",
-      provider: "parallel",
-      wrapped: true,
-    },
-    results,
-  };
-  if (typeof response.search_id === "string") {
-    payload.searchId = response.search_id;
-  }
-  if (typeof response.session_id === "string") {
-    payload.sessionId = response.session_id;
-  }
-  if (Array.isArray(response.warnings) && response.warnings.length > 0) {
-    payload.warnings = response.warnings;
-  }
-  if (Array.isArray(response.usage) && response.usage.length > 0) {
-    payload.usage = response.usage;
-  }
+    objective,
+    searchQueries,
+    response,
+    start,
+  });
 
   // Don't persist a Parallel-generated session id into the shared cache:
   // identical queries from unrelated tasks would otherwise share that id.

--- a/scripts/lib/test-group-report.mts
+++ b/scripts/lib/test-group-report.mts
@@ -498,41 +498,27 @@ function formatOptionalSignedBytes(value: number | null): string {
   return typeof value === "number" ? formatSignedBytesAsMb(value) : "n/a";
 }
 
-function pushChangeRows(
+function pushRows<Entry>(
   lines: string[],
-  entries: GroupedTestComparison["groups"],
-  options: { limit: number },
+  entries: Entry[],
+  limit: number,
+  formatRow: (entry: Entry, index: number) => string,
 ): void {
-  const selected = entries.slice(0, options.limit);
+  const selected = entries.slice(0, limit);
   if (selected.length === 0) {
     lines.push("  (none)");
-    return;
-  }
-
-  for (const [index, entry] of selected.entries()) {
-    lines.push(
-      `${String(index + 1).padStart(2, " ")}. ${formatSignedMs(entry.delta.durationMs).padStart(11, " ")} (${formatPercent(entry.percent.durationMs).padStart(7, " ")}) | before=${formatMs(entry.before.durationMs).padStart(10, " ")} after=${formatMs(entry.after.durationMs).padStart(10, " ")} | files=${formatCountDelta(entry.delta.fileCount ?? 0).padStart(4, " ")} tests=${formatCountDelta(entry.delta.testCount ?? 0).padStart(5, " ")} | ${entry.key}`,
-    );
+  } else {
+    for (const [index, entry] of selected.entries()) {
+      lines.push(formatRow(entry, index));
+    }
   }
 }
 
-function pushFileChangeRows(
-  lines: string[],
-  entries: GroupedTestComparison["files"],
-  options: { limit: number },
-): void {
-  const selected = entries.slice(0, options.limit);
-  if (selected.length === 0) {
-    lines.push("  (none)");
-    return;
-  }
+const formatChangeRow = (entry: GroupedTestComparison["groups"][number], index: number) =>
+  `${String(index + 1).padStart(2, " ")}. ${formatSignedMs(entry.delta.durationMs).padStart(11, " ")} (${formatPercent(entry.percent.durationMs).padStart(7, " ")}) | before=${formatMs(entry.before.durationMs).padStart(10, " ")} after=${formatMs(entry.after.durationMs).padStart(10, " ")} | files=${formatCountDelta(entry.delta.fileCount ?? 0).padStart(4, " ")} tests=${formatCountDelta(entry.delta.testCount ?? 0).padStart(5, " ")} | ${entry.key}`;
 
-  for (const [index, entry] of selected.entries()) {
-    lines.push(
-      `${String(index + 1).padStart(2, " ")}. ${formatSignedMs(entry.delta.durationMs).padStart(11, " ")} (${formatPercent(entry.percent.durationMs).padStart(7, " ")}) | before=${formatMs(entry.before.durationMs).padStart(10, " ")} after=${formatMs(entry.after.durationMs).padStart(10, " ")} | tests=${formatCountDelta(entry.delta.testCount).padStart(4, " ")} | ${entry.config} | ${entry.file}`,
-    );
-  }
-}
+const formatFileChangeRow = (entry: GroupedTestComparison["files"][number], index: number) =>
+  `${String(index + 1).padStart(2, " ")}. ${formatSignedMs(entry.delta.durationMs).padStart(11, " ")} (${formatPercent(entry.percent.durationMs).padStart(7, " ")}) | before=${formatMs(entry.before.durationMs).padStart(10, " ")} after=${formatMs(entry.after.durationMs).padStart(10, " ")} | tests=${formatCountDelta(entry.delta.testCount).padStart(4, " ")} | ${entry.config} | ${entry.file}`;
 
 /**
  * Renders a grouped test comparison as CLI-friendly text.
@@ -561,16 +547,16 @@ export function renderGroupedTestComparison(
     "",
     `Top group regressions (${Math.min(limit, groupRegressions.length)} of ${groupRegressions.length})`,
   );
-  pushChangeRows(lines, groupRegressions, { limit });
+  pushRows(lines, groupRegressions, limit, formatChangeRow);
 
   lines.push("", `Top group gains (${Math.min(limit, groupGains.length)} of ${groupGains.length})`);
-  pushChangeRows(lines, groupGains, { limit });
+  pushRows(lines, groupGains, limit, formatChangeRow);
 
   lines.push(
     "",
     `Config duration deltas (${Math.min(limit, comparison.configs.length)} of ${comparison.configs.length})`,
   );
-  pushChangeRows(lines, comparison.configs, { limit });
+  pushRows(lines, comparison.configs, limit, formatChangeRow);
 
   if (comparison.runs.length > 0) {
     lines.push(
@@ -588,10 +574,10 @@ export function renderGroupedTestComparison(
     "",
     `Top file regressions (${Math.min(topFiles, fileRegressions.length)} of ${fileRegressions.length})`,
   );
-  pushFileChangeRows(lines, fileRegressions, { limit: topFiles });
+  pushRows(lines, fileRegressions, topFiles, formatFileChangeRow);
 
   lines.push("", `Top file gains (${Math.min(topFiles, fileGains.length)} of ${fileGains.length})`);
-  pushFileChangeRows(lines, fileGains, { limit: topFiles });
+  pushRows(lines, fileGains, topFiles, formatFileChangeRow);
 
   return lines.join("\n");
 }

--- a/src/infra/advertised-lan-host.ts
+++ b/src/infra/advertised-lan-host.ts
@@ -186,41 +186,30 @@ async function resolveDefaultRouteHints(params: {
   runCommandWithTimeout: AdvertisedLanHostCommandRunner;
   timeoutMs: number;
 }): Promise<AdvertisedLanRouteHint[]> {
+  let argv: string[];
+  let parse: typeof parseWindowsDefaultRouteHints;
   if (params.platform === "win32") {
-    const stdout = await runRouteHintCommand(
-      params.runCommandWithTimeout,
-      [
-        "powershell.exe",
-        "-NoProfile",
-        "-ExecutionPolicy",
-        "Bypass",
-        "-Command",
-        WINDOWS_DEFAULT_ROUTE_COMMAND,
-      ],
-      params.timeoutMs,
-    );
-    return stdout ? parseWindowsDefaultRouteHints(stdout) : [];
+    argv = [
+      "powershell.exe",
+      "-NoProfile",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-Command",
+      WINDOWS_DEFAULT_ROUTE_COMMAND,
+    ];
+    parse = parseWindowsDefaultRouteHints;
+  } else if (params.platform === "darwin") {
+    argv = ["route", "-n", "get", "default"];
+    parse = parseMacOsDefaultRouteHints;
+  } else if (params.platform === "linux") {
+    argv = ["ip", "-4", "route", "show", "default"];
+    parse = parseLinuxDefaultRouteHints;
+  } else {
+    return [];
   }
 
-  if (params.platform === "darwin") {
-    const stdout = await runRouteHintCommand(
-      params.runCommandWithTimeout,
-      ["route", "-n", "get", "default"],
-      params.timeoutMs,
-    );
-    return stdout ? parseMacOsDefaultRouteHints(stdout) : [];
-  }
-
-  if (params.platform === "linux") {
-    const stdout = await runRouteHintCommand(
-      params.runCommandWithTimeout,
-      ["ip", "-4", "route", "show", "default"],
-      params.timeoutMs,
-    );
-    return stdout ? parseLinuxDefaultRouteHints(stdout) : [];
-  }
-
-  return [];
+  const stdout = await runRouteHintCommand(params.runCommandWithTimeout, argv, params.timeoutMs);
+  return stdout ? parse(stdout) : [];
 }
 
 export async function resolveAdvertisedLanHostCore(


### PR DESCRIPTION
## What Problem This Solves

LAN host advertisement, test-group report comparison, and the paid/free Parallel search runtimes each carried small repeated branches for structurally identical decisions. In particular, the Parallel runtimes could drift in request normalization and result-count handling even though transport ownership intentionally differs.

This is an AI-assisted, maintainer-requested cleanup batch. The LAN, report, and Parallel changes remain separate commits for review and blame clarity.

## Why This Change Was Made

Flatten LAN route-hint selection, traverse report comparison rows once, and move shared Parallel request/count shaping into the plugin's normalization owner while keeping transport-specific helpers local to each runtime.

Platform dispatch and fallback behavior, report bytes and row order, paid API versus free MCP transport, payload shape, query text, result counts, and response normalization are intentionally unchanged.

## User Impact

No user-visible behavior change. The affected paths now express each shared decision once and retain provider-specific behavior at the transport boundary.

Runtime production: 124 additions, 137 deletions (net -13). Tooling: 18 additions, 32 deletions (net -14). Overall: 142 additions, 169 deletions (net -27).

## Evidence

- `node scripts/run-vitest.mjs extensions/parallel/src/parallel-web-search-provider.test.ts src/infra/advertised-lan-host.test.ts src/infra/advertised-lan-host.windows.test.ts test/scripts/test-group-report.test.ts` — 100 tests passed across three repository shards; the Windows-only test was skipped on Linux.
- `oxfmt --check` on all five touched files — passed.
- `git diff --check` — passed.
- Differential base/head probes passed for 8 LAN cases, 7 report-render variants, 9 Parallel request/count cases, and 2 paid/free payload cases; generated report output was byte-identical.
- Complete changed-path gate and exact-content TruffleHog scan passed on this head during branch validation.
- Independent Amp review of exact head `cf9e81f22c7ee8bb77dc0ef144836cf64e57b8dd` found no P0/P1 findings and recommended no changes.
- Current `main` has zero changed-path overlap with the branch; a synthetic merge is clean.

No live paid Parallel API or free MCP request was made, and platform commands were fixture/argument verified rather than exercised on live Windows/macOS. Those external/platform contracts are unchanged; the focused paid/free payload, normalization, fallback, and platform tests passed.
