### PR TITLE
refactor(ui): delete the orphaned Ask OpenClaw panel toggle contract

### DIFF
--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -11,7 +11,6 @@ import {
 } from "../components/command-palette-contract.ts";
 import {
   BROWSER_PANEL_TOGGLE_EVENT,
-  CUSTODIAN_PANEL_TOGGLE_EVENT,
   TERMINAL_PANEL_TOGGLE_EVENT,
   UI_COMMAND_EVENT,
 } from "../components/panel-toggle-contract.ts";
@@ -87,9 +86,7 @@ type TestOptionalCustomElement = {
 type ShellLazySurfaceState = ShellKeyboardState & {
   browserPanelElement: TestOptionalCustomElement;
   commandPaletteElement: TestOptionalCustomElement;
-  custodianPanelElement: TestOptionalCustomElement;
   handleDeferredBrowserToggle: (event: Event) => void;
-  handleDeferredCustodianToggle: (event: Event) => void;
   handleDeferredTerminalToggle: (event: Event) => void;
   terminalPanelElement: TestOptionalCustomElement;
 };
@@ -869,14 +866,11 @@ describe("OpenClaw shell keyboard shortcuts", () => {
   it("delivers first panel toggles after their lazy modules load", async () => {
     const terminalElement = createLazyElementSpec("terminal panel");
     const browserElement = createLazyElementSpec("browser panel");
-    const custodianElement = createLazyElementSpec("custodian panel");
     const terminalToggle = vi.fn();
     const browserToggle = vi.fn();
-    const custodianToggle = vi.fn();
     const shell = document.createElement("openclaw-app-shell") as unknown as ShellLazySurfaceState;
     shell.terminalPanelElement = terminalElement;
     shell.browserPanelElement = browserElement;
-    shell.custodianPanelElement = custodianElement;
     shell.runtime = {
       context: {
         gateway: {
@@ -904,9 +898,6 @@ describe("OpenClaw shell keyboard shortcuts", () => {
         if (selector === browserElement.tagName) {
           return { handleToggleRequest: browserToggle };
         }
-        if (selector === custodianElement.tagName) {
-          return { handleToggleRequest: custodianToggle };
-        }
         return null;
       },
     });
@@ -914,16 +905,13 @@ describe("OpenClaw shell keyboard shortcuts", () => {
       detail: { dock: "right", open: true },
     });
     const browserEvent = new CustomEvent(BROWSER_PANEL_TOGGLE_EVENT);
-    const custodianEvent = new CustomEvent(CUSTODIAN_PANEL_TOGGLE_EVENT);
 
     shell.handleDeferredTerminalToggle(terminalEvent);
     shell.handleDeferredBrowserToggle(browserEvent);
-    shell.handleDeferredCustodianToggle(custodianEvent);
 
     await vi.waitFor(() => {
       expect(terminalToggle).toHaveBeenCalledWith(terminalEvent);
       expect(browserToggle).toHaveBeenCalledWith(browserEvent);
-      expect(custodianToggle).toHaveBeenCalledWith(custodianEvent);
     });
   });
 

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -477,8 +477,6 @@ class OpenClawShell
     this.shellChrome.handleDeferredTerminalToggle(event);
   readonly handleDeferredBrowserToggle = (event: Event) =>
     this.shellChrome.handleDeferredBrowserToggle(event);
-  readonly handleDeferredCustodianToggle = (event: Event) =>
-    this.shellChrome.handleDeferredCustodianToggle(event);
   readonly handleCommandPaletteSlashCommand = (command: string) =>
     this.shellChrome.handleCommandPaletteSlashCommand(command);
 

--- a/ui/src/app/app-shell-chrome.ts
+++ b/ui/src/app/app-shell-chrome.ts
@@ -12,7 +12,6 @@ import {
 import type { OpenClawModalDialog } from "../components/modal-dialog.ts";
 import {
   BROWSER_PANEL_TOGGLE_EVENT,
-  CUSTODIAN_PANEL_TOGGLE_EVENT,
   DESKTOP_PANEL_TOGGLE_EVENT,
   isTerminalPanelShortcut,
   TERMINAL_PANEL_TOGGLE_EVENT,
@@ -72,7 +71,6 @@ export interface ShellChromeHost extends HTMLElement {
   readonly terminalPanelElement: OptionalCustomElement;
   readonly browserPanelElement: OptionalCustomElement;
   readonly desktopPanelElement: OptionalCustomElement;
-  readonly custodianPanelElement: OptionalCustomElement;
   readonly execApprovalElement: OptionalCustomElement;
   readonly commandPalette: CommandPaletteElement | undefined;
   readonly approvalOverlay: (HTMLElement & { show(): void }) | undefined;
@@ -117,7 +115,6 @@ export class ShellChromeOwner {
     window.addEventListener(TERMINAL_PANEL_TOGGLE_EVENT, this.handleDeferredTerminalToggle);
     window.addEventListener(BROWSER_PANEL_TOGGLE_EVENT, this.handleDeferredBrowserToggle);
     window.addEventListener(DESKTOP_PANEL_TOGGLE_EVENT, this.handleDeferredDesktopToggle);
-    window.addEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, this.handleDeferredCustodianToggle);
   }
 
   disconnect(): void {
@@ -138,7 +135,6 @@ export class ShellChromeOwner {
     window.removeEventListener(TERMINAL_PANEL_TOGGLE_EVENT, this.handleDeferredTerminalToggle);
     window.removeEventListener(BROWSER_PANEL_TOGGLE_EVENT, this.handleDeferredBrowserToggle);
     window.removeEventListener(DESKTOP_PANEL_TOGGLE_EVENT, this.handleDeferredDesktopToggle);
-    window.removeEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, this.handleDeferredCustodianToggle);
   }
 
   toggleNavigationSurface(trigger?: HTMLElement): void {
@@ -511,17 +507,6 @@ export class ShellChromeOwner {
       return;
     }
     this.deliverPanelEventAfterLoad(host.desktopPanelElement, event);
-  };
-
-  readonly handleDeferredCustodianToggle = (event: Event): void => {
-    const host = this.host;
-    if (isOptionalElementDefined(host.custodianPanelElement)) {
-      return;
-    }
-    const snapshot = host.context?.gateway?.snapshot;
-    if (snapshot && isGatewayMethodAdvertised(snapshot, "openclaw.chat") === true) {
-      this.deliverPanelEventAfterLoad(host.custodianPanelElement, event);
-    }
   };
 
   readonly handleCommandPaletteSlashCommand = (command: string): void => {

--- a/ui/src/components/custodian/custodian-panel.test.ts
+++ b/ui/src/components/custodian/custodian-panel.test.ts
@@ -5,7 +5,6 @@ import { createContext } from "../../pages/custodian/custodian-page.test-harness
 import { CustodianSessionStore } from "../../pages/custodian/custodian-session-store.ts";
 import { createApplicationContextProvider } from "../../test-helpers/application-context.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
-import { CUSTODIAN_PANEL_TOGGLE_EVENT } from "../panel-toggle-contract.ts";
 import "./custodian-panel.ts";
 
 type TestCustodianPanel = HTMLElement & {
@@ -88,16 +87,22 @@ describe("custodian panel", () => {
     expect(panel.custodianPanelOpen).toBe(true);
   });
 
-  it("suppresses the dock on the full page and ignores explicit toggles there", async () => {
-    const { panel } = await mountPanel();
+  it("hides and restores the dock across full-page suppression", async () => {
+    const { panel, store } = await mountPanel();
+    store.messages = [
+      { id: 1, role: "user", text: "Check this system", at: 1, question: null, step: null },
+    ];
 
-    window.dispatchEvent(new CustomEvent(CUSTODIAN_PANEL_TOGGLE_EVENT, { detail: { open: true } }));
+    panel.suppressed = false;
+    panel.minimizeRequestId = 1;
+    await panel.updateComplete;
+    expect(panel.custodianPanelOpen).toBe(true);
+
+    panel.suppressed = true;
     await panel.updateComplete;
     expect(panel.custodianPanelOpen).toBe(false);
 
     panel.suppressed = false;
-    await panel.updateComplete;
-    window.dispatchEvent(new CustomEvent(CUSTODIAN_PANEL_TOGGLE_EVENT, { detail: { open: true } }));
     await panel.updateComplete;
     expect(panel.custodianPanelOpen).toBe(true);
 
@@ -155,8 +160,11 @@ describe("custodian panel", () => {
 
   it("updates the panel mascot mood with shared sending state", async () => {
     const { panel, store } = await mountPanel();
+    store.messages = [
+      { id: 1, role: "user", text: "Check this system", at: 1, question: null, step: null },
+    ];
     panel.suppressed = false;
-    window.dispatchEvent(new CustomEvent(CUSTODIAN_PANEL_TOGGLE_EVENT, { detail: { open: true } }));
+    panel.minimizeRequestId = 1;
     await panel.updateComplete;
 
     store.sending = true;

--- a/ui/src/components/custodian/custodian-panel.ts
+++ b/ui/src/components/custodian/custodian-panel.ts
@@ -10,10 +10,6 @@ import {
 import { DockLayoutController } from "../dock-layout-controller.ts";
 import { createDockPanelLayout, type DockPanelSide } from "../dock-panel-layout.ts";
 import { icons } from "../icons.ts";
-import {
-  CUSTODIAN_PANEL_TOGGLE_EVENT,
-  type CustodianPanelToggleDetail,
-} from "../panel-toggle-contract.ts";
 import "../../pages/custodian/custodian-surface.ts";
 import "../../styles/custodian-panel.css";
 
@@ -40,7 +36,6 @@ export class OpenClawCustodianPanel extends OpenClawLightDomElement {
     reservationPrefix: "custodian",
     isAvailable: () => this.available,
   });
-  private readonly onToggleRequest = (event: Event) => this.handleToggleRequest(event);
   private handledMinimizeRequestId = 0;
   private subscribedStore: CustodianSessionStore | null = null;
   private storeCleanup: (() => void) | null = null;
@@ -48,12 +43,10 @@ export class OpenClawCustodianPanel extends OpenClawLightDomElement {
   override connectedCallback(): void {
     super.connectedCallback();
     this.subscribeToStore();
-    window.addEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, this.onToggleRequest);
     this.dockLayout.setSuppressed(this.suppressed);
   }
 
   override disconnectedCallback(): void {
-    window.removeEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, this.onToggleRequest);
     this.storeCleanup?.();
     this.storeCleanup = null;
     this.subscribedStore = null;
@@ -92,39 +85,6 @@ export class OpenClawCustodianPanel extends OpenClawLightDomElement {
     this.storeCleanup?.();
     this.subscribedStore = this.store;
     this.storeCleanup = this.store.subscribe(() => this.requestUpdate());
-  }
-
-  toggle(): void {
-    if (!this.available || this.suppressed) {
-      return;
-    }
-    if (this.dockLayout.open) {
-      this.dockLayout.setOpen(false);
-    } else {
-      this.dockLayout.setOpen(true);
-    }
-  }
-
-  handleToggleRequest(event: Event): void {
-    const detail =
-      event instanceof CustomEvent && typeof event.detail === "object" && event.detail !== null
-        ? (event.detail as CustodianPanelToggleDetail)
-        : null;
-    if (detail?.dock === "right" || detail?.dock === "bottom") {
-      this.dockLayout.setDock(detail.dock, false);
-    }
-    if (detail?.open === false) {
-      this.dockLayout.setOpen(false);
-      return;
-    }
-    if (detail?.open === true) {
-      if (!this.available || this.suppressed) {
-        return;
-      }
-      this.dockLayout.setOpen(true);
-      return;
-    }
-    this.toggle();
   }
 
   private setDock(dock: CustodianDock): void {

--- a/ui/src/components/panel-toggle-contract.ts
+++ b/ui/src/components/panel-toggle-contract.ts
@@ -3,7 +3,6 @@ import type { UiCommandParams } from "@openclaw/gateway-protocol";
 export const TERMINAL_PANEL_TOGGLE_EVENT = "openclaw:terminal-toggle";
 export const BROWSER_PANEL_TOGGLE_EVENT = "openclaw:browser-toggle";
 export const DESKTOP_PANEL_TOGGLE_EVENT = "openclaw:desktop-toggle";
-export const CUSTODIAN_PANEL_TOGGLE_EVENT = "openclaw:custodian-toggle";
 export const UI_COMMAND_EVENT = "openclaw:ui-command";
 
 export type UiCommandDetail = UiCommandParams;
@@ -29,11 +28,6 @@ export type DesktopPanelToggleDetail = {
   dock?: "bottom" | "right";
   open?: boolean;
   environmentId?: string;
-};
-
-export type CustodianPanelToggleDetail = {
-  dock?: "bottom" | "right";
-  open?: boolean;
 };
 
 export type PanelToggleElement = HTMLElement & {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2345,7 +2345,6 @@ export const en: TranslationMap = {
     unsupportedGateway: "Update the Gateway to continue setup with OpenClaw.",
     panel: {
       title: "OpenClaw",
-      toggle: "Ask OpenClaw",
       close: "Close Ask OpenClaw",
       resize: "Resize Ask OpenClaw",
       dockBottom: "Dock Ask OpenClaw at bottom",


### PR DESCRIPTION
Follow-up to #122507.

## What Problem This Solves

Removes dead code, with no user-visible change.

#122507 removed the Ask OpenClaw (custodian) toggle button from the chat session workspace rail, because Ask OpenClaw belongs only in the sidebar (settings route `custodian`). That button was the last thing in the product that dispatched `CUSTODIAN_PANEL_TOGGLE_EVENT`. Everything hanging off that event became unreachable: the event constant and its detail type, the panel's `window` listener and `handleToggleRequest`, the panel's public `toggle()` whose only caller was `handleToggleRequest`, the shell's `handleDeferredCustodianToggle`, its forwarding delegate on the shell host, the `custodianPanelElement` member of the `ShellChromeHost` interface, and the `custodian.panel.toggle` English string.

An event nothing dispatches is not a contract, it is debt — it reads to the next person like a supported way to open the panel.

## Why This Change Was Made

Deleted rather than re-pointed at a new opener, because the maintainer decision on #122507 was explicitly "sidebar only, no dedicated opener button" — chosen over a variant that added a sidebar opener. Reviving the event would relitigate that.

The floating Ask OpenClaw panel is unaffected and still works. Its real open path is `minimizeRequestId` plus `store.hasRealUserTurn()` in `custodian-panel.ts` `willUpdate`, raised by `app-shell-navigation.ts` when the operator navigates away from `/custodian` mid-conversation. Preloading is untouched and still gated on `openclaw.chat` in `app-host.ts` — the same predicate the deleted deferred handler used — so the panel still mounts exactly when it could be available. The shared `deliverPanelEventAfterLoad` machinery and the terminal, browser and desktop deferred handlers are all left intact.

The sibling strings `custodian.panel.title` / `close` / `resize` / `dockBottom` / `dockRight` are still rendered by the panel and are kept; only `toggle` is removed. Foreign locales are one-line virtual re-exports, so no locale file needed editing, and no generated i18n artifact changed.

## User Impact

None. No surface moves, appears, or disappears. Ask OpenClaw is reached through the sidebar and the floating panel still follows an in-progress conversation off the `/custodian` route, exactly as it does on `main` today.

## Evidence

**LOC** — production `−64` with **zero lines added**; tests `+15 −19`.

**Tests**

```
node scripts/run-vitest.mjs ui/src/components/custodian ui/src/app/app-host.test.ts ui/src/pages/custodian

Test Files  591 passed | 10 skipped (601)
     Tests  8626 passed | 50 skipped (8676)
```

(The path filters match broadly, so this run covers far more than the touched files.)

Targeted run of the changed suites plus the panels that share the deferred-delivery path:

```
node scripts/run-vitest.mjs ui/src/components/custodian/custodian-panel.test.ts ui/src/app/app-host.test.ts
Test Files  2 passed (2)   Tests  36 passed (36)

node scripts/run-vitest.mjs ui/src/components/browser ui/src/components/terminal ui/src/components/desktop
Test Files  19 passed (19)  Tests  176 passed (176)
```

**Tests moved, not deleted.** The three sites in `custodian-panel.test.ts` that used the event now drive the panel through its surviving minimize path. The suppression test was retitled from "suppresses the dock on the full page and ignores explicit toggles there" to "hides and restores the dock across full-page suppression", because "explicit toggles" no longer exist; it now proves something the neighbouring route-leave test does not — that suppression hides an already-open dock and that lifting suppression restores it. In `app-host.test.ts` only the custodian third of the shared lazy-load test was removed; terminal and browser coverage is untouched.

**Both rewritten tests were checked to still fail for the right reason.** Making `setSuppressed(true)` a no-op failed the suppression test (expected `false`, received `true`); making the minimize branch call `setOpen(false)` failed the mascot test because the unopened panel renders no mascot. Both sabotages were reverted and `dock-layout-controller.ts` has no diff.

**i18n**

```
pnpm ui:i18n:verify
control-ui-i18n: raw-copy: baseline entries=92
control-ui-i18n: source: keys=4893
```

Only `ui/src/i18n/locales/en.ts` changed under `ui/src/i18n/`; no translation memory, locale metadata, or catalog fallback was touched.

**Static** — repo-wide grep for `CUSTODIAN_PANEL_TOGGLE_EVENT`, `CustodianPanelToggleDetail`, `handleDeferredCustodianToggle`, `openclaw:custodian-toggle`, and `custodian.panel.toggle` returns no matches. `git diff --check` clean.

**Review** — `autoreview --mode branch` (codex / gpt-5.6-sol / high).
