### PR TITLE
fix(ci): preserve output across process polls

### DIFF
--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -737,7 +737,7 @@ describe("exec tool backgrounding", () => {
       await expect
         .poll(async () => {
           const pollResult = await pollProcessSession({ tool: processTool, sessionId });
-          output = pollResult.output ?? "";
+          output += pollResult.output ?? "";
           return pollResult.status;
         }, BACKGROUND_POLL_OPTIONS)
         .toBe(PROCESS_STATUS_COMPLETED);


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI race where the background-process polling test could fail when an earlier poll consumed `done` before the terminal poll reported completion.

## Why This Change Was Made

The test now accumulates output returned across all polls instead of replacing the prior output with the latest poll. The terminal status and `done` assertions are unchanged. Production code, timeouts, retries, and process behavior are untouched.

## User Impact

No runtime behavior changes. This stabilizes the agents-core CI shard so unrelated pull requests are not blocked by a legitimate multi-poll completion sequence.

## Evidence

- Pre-fix CI failure: `checks-node-compact-large-7` showed the terminal poll returning `(no new output)` after a prior poll consumed `done`: https://github.com/openclaw/openclaw/actions/runs/31602248664/job/94138292367
- Focused repetition: 10/10 runs passed after the fix.
- Full touched file: 35/35 tests passed.
- Blacksmith Testbox changed gate passed: https://github.com/openclaw/openclaw/actions/runs/31606630035
- Exact current `checks-node-compact-large-7` planner job passed on the patch-identical pre-rebase head: 5,103 tests passed, 29 skipped: https://github.com/openclaw/openclaw/actions/runs/31607374121
- Clean rebase onto current `main` produced head `458ef600121860d62efcacdbe6df7c6ff0b27491`; post-rebase focused proof passed.
- `git diff --check` and `oxfmt --check src/agents/bash-tools.test.ts` passed.
- Max-P1 autoreview: no accepted/actionable findings, correctness confidence 0.99.
- Production LOC: +0/-0. Tests: +1/-1.

Source credit: @AppleSpriter independently identified this CI race and submitted the same accumulator repair first in https://github.com/openclaw/openclaw/pull/122600.

AI-assisted: yes.

Punchcard-Session: brisk-willow-summit-z9
