### PR TITLE
Update MiniMax-M2.x warning about reasoning content

### DIFF
--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -165,7 +165,8 @@ Model refs follow the auth path: `minimax/<model>` for API-key setups, `minimax-
     ```
 
     <Warning>
-    MiniMax-M2.x's Anthropic-compatible streaming endpoint emits `reasoning_content` in OpenAI-style delta chunks instead of native Anthropic thinking blocks, which leaks internal reasoning into visible output if thinking is left enabled implicitly. OpenClaw disables M2.x thinking by default unless you explicitly set `thinking` yourself. MiniMax-M3 (and forward-compatible M3.x) is exempt: M3 emits proper Anthropic thinking blocks and requires thinking active to produce visible content, so OpenClaw keeps M3 on the provider's adaptive thinking path. See the Thinking defaults section under Advanced configuration below.
+MiniMax-M2.x's Anthropic-compatible streaming endpoint emits `reasoning_content` in OpenAI-style delta chunks instead of native Anthropic thinking blocks. OpenClaw defaults the M2.x thinking level to `off` and sends `thinking: { type: "disabled" }` when no thinking setting is provided, but MiniMax M2.x accepts and ignores this setting, so thinking remains enabled upstream. OpenClaw's `off` setting therefore does not guarantee that MiniMax M2.x reasoning or `reasoning_content` output is disabled. MiniMax-M3 (and forward-compatible M3.x) is exempt: M3 emits proper Anthropic thinking blocks and supports disabling thinking, so OpenClaw keeps M3 on the provider's adaptive thinking path. See the Thinking defaults section under Advanced configuration below.
+
     </Warning>
 
     <Note>


### PR DESCRIPTION
Clarified MiniMax-M2.x thinking settings and behavior regarding reasoning output.
solves issue - #122598

<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: docs
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

<!--
Fixes an issue where the MiniMax docs made it look like thinking: { type: "disabled" } actually turns off thinking for M2.x models.

It doesn't change any UI or code rather only the docs.
-->

## Why This Change Was Made

<!--
The docs now make the difference between OpenClaw's off setting and MiniMax's actual behavior clear. OpenClaw can send the disabled thinking payload, but MiniMax M2.x accepts it and ignores it, so thinking stays enabled.
-->

## User Impact

<!--
Users can now tell that /think off or the M2.x default does not mean that MiniMax M2.x thinking or reasoning_content is disabled.
-->

## Evidence

<!--
- Checked the OpenClaw M2.x thinking defaults and request handling.
- Checked MiniMax's API documentation for M2.x thinking behavior.
- This is a docs-only change; no runtime behavior was changed.
-->
