### PR TITLE
fix(imessage): preserve imsg retry-safe no-send result

### DIFF
--- a/extensions/imessage/src/approval-reaction-poller.test.ts
+++ b/extensions/imessage/src/approval-reaction-poller.test.ts
@@ -175,6 +175,7 @@ describe("iMessage approval reaction poller", () => {
 
     expect(request).toHaveBeenCalledWith("chats.list", { limit: 50 }, { timeoutMs: 10_000 });
     expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith({
+      accountId,
       cfg: buildApprovalConfig(),
       approvalId: "exec-1",
       approvalKind: "exec",
@@ -407,6 +408,7 @@ describe("iMessage approval reaction poller", () => {
       { timeoutMs: 10_000 },
     );
     expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith({
+      accountId,
       cfg: buildApprovalConfig("+15551239999"),
       approvalId: "exec-handle",
       approvalKind: "exec",
@@ -456,6 +458,7 @@ describe("iMessage approval reaction poller", () => {
 
     expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledTimes(1);
     expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith({
+      accountId,
       cfg: buildApprovalConfig(APPROVER),
       approvalId: "exec-1",
       approvalKind: "exec",
@@ -563,6 +566,7 @@ describe("iMessage approval reaction poller", () => {
 
     expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledTimes(1);
     expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith({
+      accountId,
       cfg: buildApprovalConfig(APPROVER),
       approvalId: "exec-1",
       approvalKind: "exec",

--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -141,7 +141,7 @@ describe("IMessageRpcClient child stream error handling", () => {
       ),
     );
 
-    const error = await pending.catch((error: unknown) => error);
+    const error = await pending.catch((cause: unknown) => cause);
     expect(error).toBeInstanceOf(IMessageRpcRequestError);
     expect(error).toMatchObject({
       name: "IMessageRpcRequestError",

--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -113,6 +113,48 @@ describe("IMessageRpcClient child stream error handling", () => {
     await client.stop();
   });
 
+  it("preserves structured JSON-RPC error data for send callers", async () => {
+    const { IMessageRpcClient, IMessageRpcRequestError } = await import("./client.js");
+    const client = new IMessageRpcClient({ cliPath: "imsg" });
+    await client.start();
+    const data = {
+      retry_safe: true,
+      disposition: "not_started",
+      transport: "bridge_v2",
+      operation: "send-message",
+    };
+
+    const pending = client.request("send", {}, { timeoutMs: 0 });
+    pending.catch(() => {});
+    child.stdout.emit(
+      "data",
+      Buffer.from(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          error: {
+            code: -32603,
+            message: "Delivery failed before dispatch",
+            data,
+          },
+        })}\n`,
+      ),
+    );
+
+    const error = await pending.catch((error: unknown) => error);
+    expect(error).toBeInstanceOf(IMessageRpcRequestError);
+    expect(error).toMatchObject({
+      name: "IMessageRpcRequestError",
+      code: -32603,
+      data,
+      message:
+        'Delivery failed before dispatch: code=-32603 {\n  "retry_safe": true,\n  "disposition": "not_started",\n  "transport": "bridge_v2",\n  "operation": "send-message"\n}',
+    });
+
+    child.emit("close", 0, null);
+    await client.stop();
+  });
+
   it("finishes graceful shutdown without scheduling escalation after synchronous close", async () => {
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const { IMessageRpcClient } = await import("./client.js");

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -36,6 +36,17 @@ type IMessageRpcClientOptions = {
   onNotification?: (msg: IMessageRpcNotification) => void;
 };
 
+export class IMessageRpcRequestError extends Error {
+  constructor(
+    message: string,
+    readonly code?: number,
+    readonly data?: unknown,
+  ) {
+    super(message);
+    this.name = "IMessageRpcRequestError";
+  }
+}
+
 type PendingRequest = {
   resolve: (value: unknown) => void;
   reject: (error: Error) => void;
@@ -374,7 +385,9 @@ export class IMessageRpcClient {
           }
         }
         const msg = suffixes.length > 0 ? `${baseMessage}: ${suffixes.join(" ")}` : baseMessage;
-        pending.reject(new Error(msg));
+        pending.reject(
+          new IMessageRpcRequestError(msg, typeof code === "number" ? code : undefined, details),
+        );
         return;
       }
       pending.resolve(parsed.result);

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -15,10 +15,14 @@ import { resolveIMessageRemoteHost } from "./remote-host.js";
 import { loadFreshIMessageReplyCacheForTest } from "./test-support/runtime.js";
 
 type ApprovalReactionsModule = typeof import("./approval-reactions.js");
+type ClientModule = typeof import("./client.js");
+type ErrorRuntimeModule = typeof import("openclaw/plugin-sdk/error-runtime");
 type PersistedEchoCacheModule = typeof import("./monitor/persisted-echo-cache.js");
 type ReplyCacheModule = typeof import("./monitor-reply-cache.js");
 type SendModule = typeof import("./send.js");
 let clearIMessageApprovalReactionTargetsForTest: ApprovalReactionsModule["clearIMessageApprovalReactionTargetsForTest"];
+let IMessageRpcRequestError: ClientModule["IMessageRpcRequestError"];
+let PlatformMessageNotDispatchedError: ErrorRuntimeModule["PlatformMessageNotDispatchedError"];
 let resolveIMessageApprovalReactionTargetWithPersistence: ApprovalReactionsModule["resolveIMessageApprovalReactionTargetWithPersistence"];
 let hasPersistedIMessageEcho: PersistedEchoCacheModule["hasPersistedIMessageEcho"];
 let findLatestIMessageEntryForChat: ReplyCacheModule["findLatestIMessageEntryForChat"];
@@ -28,6 +32,8 @@ let sendMessageIMessage: SendModule["sendMessageIMessage"];
 async function loadFreshSendModule(): Promise<void> {
   ({ findLatestIMessageEntryForChat, rememberIMessageReplyCache } =
     await loadFreshIMessageReplyCacheForTest());
+  ({ IMessageRpcRequestError } = await import("./client.js"));
+  ({ PlatformMessageNotDispatchedError } = await import("openclaw/plugin-sdk/error-runtime"));
   ({
     clearIMessageApprovalReactionTargetsForTest,
     resolveIMessageApprovalReactionTargetWithPersistence,
@@ -1363,6 +1369,59 @@ describe("sendMessageIMessage receipts", () => {
     ).toBe(false);
   });
 
+  it("maps an authoritative pre-dispatch RPC failure to retry-safe platform custody", async () => {
+    const rpcError = new IMessageRpcRequestError("Delivery failed before dispatch", -32603, {
+      retry_safe: true,
+      disposition: "not_started",
+      transport: "bridge_v2",
+      operation: "send-message",
+    });
+    const client = createRejectingClient(rpcError);
+
+    const rejection = await sendMessageIMessage("chat_id:42", "hello", {
+      config: IMESSAGE_TEST_CFG,
+      client,
+    }).catch((error: unknown) => error);
+
+    expect(rejection).toBeInstanceOf(PlatformMessageNotDispatchedError);
+    expect(rejection).toMatchObject({ message: rpcError.message, cause: rpcError });
+    expect(getClientMocks(client).request).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    {
+      name: "may-have-completed disposition",
+      data: { disposition: "may_have_completed", retry_safe: true },
+    },
+    {
+      name: "still-in-flight disposition",
+      data: { disposition: "still_in_flight", retry_safe: true },
+    },
+    {
+      name: "missing retry-safe flag",
+      data: { disposition: "not_started" },
+    },
+    {
+      name: "false retry-safe flag",
+      data: { disposition: "not_started", retry_safe: false },
+    },
+  ])("keeps $name ambiguous", async ({ data }) => {
+    const rpcError = new IMessageRpcRequestError(
+      "Delivery outcome remains ambiguous",
+      -32001,
+      data,
+    );
+    const client = createRejectingClient(rpcError);
+
+    const rejection = await sendMessageIMessage("chat_id:42", "hello", {
+      config: IMESSAGE_TEST_CFG,
+      client,
+    }).catch((error: unknown) => error);
+
+    expect(rejection).toBe(rpcError);
+    expect(rejection).not.toBeInstanceOf(PlatformMessageNotDispatchedError);
+  });
+
   it("drops reply metadata from text sends when reply actions are disabled", async () => {
     const client = createClient({ guid: "p:0/imsg-plain" });
 
@@ -1791,6 +1850,43 @@ describe("sendMessageIMessage receipts", () => {
       },
       expect.any(Object),
     );
+  });
+
+  it("maps remote attachment pre-dispatch RPC failure to retry-safe platform custody", async () => {
+    const rpcError = new IMessageRpcRequestError("Delivery failed before dispatch", -32603, {
+      retry_safe: true,
+      disposition: "not_started",
+      transport: "bridge_v2",
+      operation: "send-attachment",
+    });
+    const client = createRejectingClient(rpcError);
+    const withRemoteFile = vi.fn(
+      async (params: { use: (remotePath: string) => Promise<Record<string, unknown>> }) =>
+        await params.use("/tmp/openclaw-imessage-safe/photo.png"),
+    );
+
+    const rejection = await sendMessageIMessage("chat_id:42", "", {
+      config: {
+        channels: {
+          imessage: {
+            accounts: { default: { remoteHost: "work@messages-b" } },
+          },
+        },
+      },
+      mediaUrl: "/gateway/photo.png",
+      resolveAttachmentImpl: async () => ({ path: "/gateway/photo.png" }),
+      createClient: async () => client,
+      withRemoteFile: withRemoteFile as never,
+    }).catch((error: unknown) => error);
+
+    expect(rejection).toBeInstanceOf(PlatformMessageNotDispatchedError);
+    expect(rejection).toMatchObject({ message: rpcError.message, cause: rpcError });
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
+      "send.attachment",
+      expect.objectContaining({ file: "/tmp/openclaw-imessage-safe/photo.png" }),
+      expect.any(Object),
+    );
+    expect(getClientMocks(client).stop).toHaveBeenCalledOnce();
   });
 
   it("resolves service-qualified remote media through the canonical send RPC", async () => {

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -12,6 +12,7 @@ import {
   type MessageReceiptSourceResult,
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import {
   extractOriginalFilename,
@@ -22,7 +23,10 @@ import {
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { sleep as delay } from "openclaw/plugin-sdk/runtime-env";
 import { openNodeSqliteDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
-import { normalizeOptionalString as stringValue } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  asOptionalRecord,
+  normalizeOptionalString as stringValue,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolvePreferredOpenClawTmpDir, withTempWorkspace } from "openclaw/plugin-sdk/temp-path";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
 import { stripInlineDirectiveTagsForDelivery } from "openclaw/plugin-sdk/text-chunking";
@@ -40,7 +44,11 @@ import {
 import { chatContextFromIMessageTarget } from "./chat-context.js";
 import { runIMessageCliJsonCommand } from "./cli-output.js";
 import { resolveIMessageChatDbLookupPath } from "./cli-path.js";
-import { createIMessageRpcClient, type IMessageRpcClient } from "./client.js";
+import {
+  createIMessageRpcClient,
+  IMessageRpcRequestError,
+  type IMessageRpcClient,
+} from "./client.js";
 import { DEFAULT_IMESSAGE_SEND_TIMEOUT_MS } from "./constants.js";
 import { resolveAuthorizedIMessageReplyReference } from "./message-resource.js";
 import { rememberIMessageReplyCache } from "./monitor-reply-cache.js";
@@ -500,6 +508,29 @@ function resolveIMessageSendFailure(result: Record<string, unknown>): string | n
     : "iMessage action failed";
 }
 
+function normalizeIMessageRpcSendError(error: unknown): unknown {
+  if (!(error instanceof IMessageRpcRequestError)) {
+    return error;
+  }
+  const data = asOptionalRecord(error.data);
+  return data?.disposition === "not_started" && data.retry_safe === true
+    ? new PlatformMessageNotDispatchedError(error.message, { cause: error })
+    : error;
+}
+
+async function requestIMessageRpcSend(
+  client: IMessageRpcClient,
+  method: string,
+  params: Record<string, unknown>,
+  timeoutMs: number,
+): Promise<Record<string, unknown>> {
+  try {
+    return await client.request<Record<string, unknown>>(method, params, { timeoutMs });
+  } catch (error) {
+    throw normalizeIMessageRpcSendError(error);
+  }
+}
+
 function isIMessageRpcSendTimeout(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return /imsg rpc timeout \(send\)/i.test(message);
@@ -909,7 +940,7 @@ export async function sendMessageIMessage(
       ? await opts.createClient({ cliPath, dbPath, remoteHost })
       : await createIMessageRpcClient({ cliPath, dbPath, remoteHost });
     try {
-      return await rpcClient.request<Record<string, unknown>>(method, rpcParams, { timeoutMs });
+      return await requestIMessageRpcSend(rpcClient, method, rpcParams, timeoutMs);
     } finally {
       await rpcClient.stop();
     }
@@ -1031,7 +1062,7 @@ export async function sendMessageIMessage(
   };
   const requestSuccessfulSend = async (sendParams: Record<string, unknown>) => {
     const request = async (nativeParams: Record<string, unknown>) =>
-      await client.request<Record<string, unknown>>("send", nativeParams, { timeoutMs });
+      await requestIMessageRpcSend(client, "send", nativeParams, timeoutMs);
     const response = filePath
       ? await withOriginalIMessageAttachmentPath(filePath, async (attachmentPath) => {
           if (remoteHost) {


### PR DESCRIPTION
Closes #122633

## What Problem This Solves

Fixes an issue where iMessage sends stayed in ambiguous delivery custody when imsg had authoritatively reported that the operation never started and was safe to retry. OpenClaw previously flattened imsg's structured JSON-RPC error into a plain `Error`, so the durable queue could not distinguish a proven no-send from a possibly delivered send.

## Why This Change Was Made

The iMessage RPC client now preserves JSON-RPC `code` and `data` in a typed local error without changing its existing human-readable message. The iMessage send owner uses one normalizer for text sends and remote attachment sends, mapping only `data.disposition === "not_started" && data.retry_safe === true` to the public Plugin SDK `PlatformMessageNotDispatchedError` custody contract.

Direct source inspection of imsg v0.14.0 and v0.14.1 confirms the dependency contract: [`DeliveryFailure.retrySafe`](https://github.com/openclaw/imsg/blob/v0.14.0/Sources/IMsgCore/DeliveryFailure.swift#L3-L44) is true only for `.notStarted`, [`RPCError.deliveryFailure`](https://github.com/openclaw/imsg/blob/v0.14.0/Sources/imsg/RPCServer%2BSupport.swift#L112-L148) emits the structured `retry_safe` and `disposition` fields, and [`RPCBridgeDeliveryTests`](https://github.com/openclaw/imsg/blob/v0.14.0/Tests/imsgTests/RPCBridgeDeliveryTests.swift#L38-L67) asserts the exact retry-safe frame. Those three files are unchanged in v0.14.1. Missing, false, malformed, unstructured, transport, `may_have_completed`, and `still_in_flight` outcomes continue to propagate as ambiguous failures.

## User Impact

Durable iMessage delivery can now safely retry when imsg proves that no recipient-visible send began. Uncertain outcomes remain protected from blind retries, preserving duplicate-send safety.

## Evidence

- Authentic pre-fix run with the new tests retained and only production changes reversed: `node scripts/run-vitest.mjs extensions/imessage/src/client.test.ts extensions/imessage/src/send.test.ts` ran 103 tests; 7 new custody tests failed and 96 passed.
- Exact-head post-fix iMessage proof: `node scripts/run-vitest.mjs extensions/imessage/src/client.test.ts extensions/imessage/src/send.test.ts extensions/imessage/src/approval-reaction-poller.test.ts` passed 117/117 tests.
- Existing downstream custody proof: `node scripts/run-vitest.mjs src/infra/outbound/deliver.queue-integration.test.ts` passed 30/30 tests, including clearing `send_attempt_started` only after typed no-dispatch proof.
- Hosted changed gate: Testbox `tbx_01kzv80t2r158bt5k1drex6vas` passed the five-file path-scoped extension production/test typechecks, lint, formatting, boundary guards, dead-code checks, and import-cycle checks: https://github.com/openclaw/openclaw/actions/runs/31610259028
- The first hosted run found a `no-shadow` lint issue in the new client test; the scoped rename was added as a follow-up commit and the exact-head gate was rerun green.
- The first exact-head PR CI run selected the existing iMessage approval-poller suite and exposed four stale `resolveApprovalOverGateway` call expectations on current `main`; focused reproduction failed 4/14. A test-only follow-up now asserts the `accountId` production already passes, and the same suite passes 14/14.
- Fresh exact-branch autoreview and TruffleHog scan: clean, no actionable findings, confidence 0.98.
- Targeted formatting and `git diff --check`: clean.
- Exact-head pull-request CI: green for head `cdd59258a05bd` in https://github.com/openclaw/openclaw/actions/runs/31611401380
- ClawSweeper rank-up moves addressed: the exact tagged imsg source and bridge-frame test are linked above, and exact-head CI is green. The exact-head re-review publisher started after the final push and is intentionally not a merge blocker.
- Production LOC: +49/-5 (net +44). Tests: +142/-0. The production growth is the typed RPC envelope plus one shared owner-boundary normalizer required to carry authoritative dependency evidence into the existing durable custody contract for both send paths; the extra four test lines repair stale current-main account-routing expectations exposed by CI.
- Proof gap: deterministic frame/failure injection only; no live message was sent and no real bridge fault was forced. This avoids external delivery while proving the exact dependency frame, plugin mapping, uncertainty controls, and core retry contract.

AI-assisted; the patch and dependency contract were inspected directly and verified with focused, hosted, and independent review gates.
