### PR TITLE
fix(ci): fail OpenGrep on Git discovery errors

### DIFF
--- a/scripts/run-opengrep.sh
+++ b/scripts/run-opengrep.sh
@@ -173,35 +173,35 @@ resolve_changed_diff_ref() {
 if (( PATHS_PASSED == 0 )); then
   if (( CHANGED_ONLY )); then
     CHANGED_DIFF_REF="$(resolve_changed_diff_ref)"
+    CHANGED_PATHS_DIR="$(mktemp -d)"
+    trap 'rm -rf -- "$CHANGED_PATHS_DIR"' EXIT
+    {
+      git diff --name-only -z --diff-filter=ACMRTUXB "$CHANGED_DIFF_REF"
+      git diff --cached --name-only -z --diff-filter=ACMRTUXB --
+      git diff --name-only -z --diff-filter=ACMRTUXB --
+      git ls-files -z --others --exclude-standard
+    } > "$CHANGED_PATHS_DIR/all"
+    LC_ALL=C sort -zu "$CHANGED_PATHS_DIR/all" > "$CHANGED_PATHS_DIR/sorted"
     SCAN_PATHS=()
-    while IFS= read -r path; do
-      # OpenGrep errors when an explicit changed path is a symlink; scan the
-      # real target content, not duplicate guide aliases such as CLAUDE.md.
-      if [[ -L "$path" ]]; then
-        continue
-      fi
-      if [[ ! -f "$path" && ! -d "$path" ]]; then
-        continue
-      fi
-      SCAN_PATHS+=( "$path" )
-    done < <(
-      {
-        git diff --name-only --diff-filter=ACMRTUXB "$CHANGED_DIFF_REF" 2>/dev/null || true
-        git diff --name-only --diff-filter=ACMRTUXB -- 2>/dev/null || true
-        git ls-files --others --exclude-standard
-      } | awk '/^(src|extensions|apps|packages|scripts)\// { print }' | sort -u
-    )
-    RULEPACK_CHANGED_PATHS=()
-    while IFS= read -r path; do
-      RULEPACK_CHANGED_PATHS+=( "$path" )
-    done < <(
-      {
-        git diff --name-only --diff-filter=ACMRTUXB "$CHANGED_DIFF_REF" 2>/dev/null || true
-        git diff --name-only --diff-filter=ACMRTUXB -- 2>/dev/null || true
-        git ls-files --others --exclude-standard
-      } | awk '/^(security\/opengrep\/|scripts\/run-opengrep\.sh$|\.semgrepignore$|\.github\/workflows\/opengrep-)/ { print }' | sort -u
-    )
-    if (( ${#SCAN_PATHS[@]} == 0 && ${#RULEPACK_CHANGED_PATHS[@]} > 0 )); then
+    RULEPACK_CHANGED=0
+    while IFS= read -r -d '' path; do
+      case "$path" in
+        src/*|extensions/*|apps/*|packages/*|scripts/*)
+          # OpenGrep errors when an explicit changed path is a symlink; scan the
+          # real target content, not duplicate guide aliases such as CLAUDE.md.
+          if [[ ! -L "$path" && ( -f "$path" || -d "$path" ) ]]; then
+            SCAN_PATHS+=( "$path" )
+          fi
+          ;;
+      esac
+      case "$path" in
+        security/opengrep/*|scripts/run-opengrep.sh|.semgrepignore|.github/workflows/opengrep-*)
+          RULEPACK_CHANGED=1
+          ;;
+      esac
+    done < "$CHANGED_PATHS_DIR/sorted"
+    rm -rf -- "$CHANGED_PATHS_DIR"
+    if (( ${#SCAN_PATHS[@]} == 0 && RULEPACK_CHANGED )); then
       # Exercise rulepack loading without scanning the compiled YAML, which contains
       # rule pattern literals that can match themselves.
       SCAN_PATHS=( "scripts/run-opengrep.sh" )

--- a/test/scripts/run-opengrep.test.ts
+++ b/test/scripts/run-opengrep.test.ts
@@ -1,5 +1,5 @@
 // Run Opengrep tests cover run opengrep script behavior.
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -27,6 +27,20 @@ function copyRunOpengrepFiles(repo: string): void {
   fs.chmodSync(path.join(repo, "scripts/run-opengrep.sh"), 0o755);
 }
 
+function installOpengrepStub(repo: string): { argsPath: string; binDir: string } {
+  const argsPath = path.join(repo, "opengrep-args.txt");
+  const binDir = path.join(repo, "bin");
+  fs.mkdirSync(binDir);
+  writeFile(
+    path.join(binDir, "opengrep"),
+    ["#!/usr/bin/env bash", `printf '%s\\n' "$@" > ${JSON.stringify(argsPath)}`, "exit 0", ""].join(
+      "\n",
+    ),
+  );
+  fs.chmodSync(path.join(binDir, "opengrep"), 0o755);
+  return { argsPath, binDir };
+}
+
 describe("run-opengrep.sh", () => {
   it("validates the rulepack when only OpenGrep rulepack files changed", () => {
     const repo = createTempDir("openclaw-run-opengrep-");
@@ -40,19 +54,7 @@ describe("run-opengrep.sh", () => {
     git(repo, "commit", "-qm", "initial");
 
     fs.appendFileSync(path.join(repo, "security/opengrep/precise.yml"), "# changed\n");
-    const argsPath = path.join(repo, "opengrep-args.txt");
-    const binDir = path.join(repo, "bin");
-    fs.mkdirSync(binDir);
-    writeFile(
-      path.join(binDir, "opengrep"),
-      [
-        "#!/usr/bin/env bash",
-        `printf '%s\\n' "$@" > ${JSON.stringify(argsPath)}`,
-        "exit 0",
-        "",
-      ].join("\n"),
-    );
-    fs.chmodSync(path.join(binDir, "opengrep"), 0o755);
+    const { argsPath, binDir } = installOpengrepStub(repo);
 
     execFileSync("bash", ["scripts/run-opengrep.sh", "--changed"], {
       cwd: repo,
@@ -64,7 +66,7 @@ describe("run-opengrep.sh", () => {
       encoding: "utf8",
     });
 
-    const args = fs.readFileSync(path.join(repo, "opengrep-args.txt"), "utf8");
+    const args = fs.readFileSync(argsPath, "utf8");
     expect(args).toContain("security/opengrep/precise.yml");
   });
 
@@ -84,19 +86,7 @@ describe("run-opengrep.sh", () => {
       path.join(repo, ".github/actions/ensure-base-commit/action.yml"),
       "# changed\n",
     );
-    const argsPath = path.join(repo, "opengrep-args.txt");
-    const binDir = path.join(repo, "bin");
-    fs.mkdirSync(binDir);
-    writeFile(
-      path.join(binDir, "opengrep"),
-      [
-        "#!/usr/bin/env bash",
-        `printf '%s\\n' "$@" > ${JSON.stringify(argsPath)}`,
-        "exit 0",
-        "",
-      ].join("\n"),
-    );
-    fs.chmodSync(path.join(binDir, "opengrep"), 0o755);
+    const { argsPath, binDir } = installOpengrepStub(repo);
 
     execFileSync("bash", ["scripts/run-opengrep.sh", "--changed", "--sarif", "--error"], {
       cwd: repo,
@@ -117,6 +107,73 @@ describe("run-opengrep.sh", () => {
     expect(sarif.runs[0].results).toEqual([]);
     expect(fs.existsSync(argsPath)).toBe(false);
   });
+
+  it.each([
+    {
+      failure: "invalid base range",
+      baseRef: "missing-base...HEAD",
+      failedGitCommand: null,
+      errorText: "missing-base...HEAD",
+    },
+    {
+      failure: "git ls-files",
+      baseRef: "HEAD",
+      failedGitCommand: "ls-files",
+      errorText: "forced git ls-files failure",
+    },
+  ])(
+    "fails when changed-path discovery hits $failure",
+    ({ baseRef, failedGitCommand, errorText }) => {
+      const repo = createTempDir("openclaw-run-opengrep-discovery-failure-");
+      git(repo, "init", "-q");
+      git(repo, "config", "user.email", "test@example.com");
+      git(repo, "config", "user.name", "Test User");
+
+      copyRunOpengrepFiles(repo);
+      writeFile(path.join(repo, "security/opengrep/precise.yml"), "rules: []\n");
+      git(repo, "add", ".");
+      git(repo, "commit", "-qm", "initial");
+
+      const { argsPath, binDir } = installOpengrepStub(repo);
+      if (failedGitCommand) {
+        const realGit = execFileSync("bash", ["-lc", "command -v git"], {
+          encoding: "utf8",
+        }).trim();
+        writeFile(
+          path.join(binDir, "git"),
+          [
+            "#!/usr/bin/env bash",
+            `if [[ "\${1:-}" == ${JSON.stringify(failedGitCommand)} ]]; then`,
+            '  echo "forced git ls-files failure" >&2',
+            "  exit 71",
+            "fi",
+            `exec ${JSON.stringify(realGit)} "$@"`,
+            "",
+          ].join("\n"),
+        );
+        fs.chmodSync(path.join(binDir, "git"), 0o755);
+      }
+
+      const result = spawnSync(
+        "bash",
+        ["scripts/run-opengrep.sh", "--changed", "--sarif", "--error"],
+        {
+          cwd: repo,
+          env: {
+            ...process.env,
+            PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+            OPENCLAW_OPENGREP_BASE_REF: baseRef,
+          },
+          encoding: "utf8",
+        },
+      );
+
+      expect.soft(result.status).not.toBe(0);
+      expect.soft(result.stderr).toContain(errorText);
+      expect.soft(fs.existsSync(argsPath)).toBe(false);
+      expect.soft(fs.existsSync(path.join(repo, ".opengrep-out/precise.sarif"))).toBe(false);
+    },
+  );
 
   it("scans PR files instead of main-only files when the payload base is stale", () => {
     const repo = createTempDir("openclaw-run-opengrep-merge-");
@@ -142,19 +199,7 @@ describe("run-opengrep.sh", () => {
     git(repo, "commit", "-qm", "main only");
     git(repo, "merge", "--no-ff", "feature", "-m", "synthetic merge");
 
-    const argsPath = path.join(repo, "opengrep-args.txt");
-    const binDir = path.join(repo, "bin");
-    fs.mkdirSync(binDir);
-    writeFile(
-      path.join(binDir, "opengrep"),
-      [
-        "#!/usr/bin/env bash",
-        `printf '%s\\n' "$@" > ${JSON.stringify(argsPath)}`,
-        "exit 0",
-        "",
-      ].join("\n"),
-    );
-    fs.chmodSync(path.join(binDir, "opengrep"), 0o755);
+    const { argsPath, binDir } = installOpengrepStub(repo);
 
     execFileSync("bash", ["scripts/run-opengrep.sh", "--changed"], {
       cwd: repo,


### PR DESCRIPTION
## What Problem This Solves

`run-opengrep.sh --changed` suppressed Git changed-path discovery failures. An invalid base ref or failed `git ls-files` could therefore print “No changed first-party paths,” write empty-success SARIF, skip OpenGrep, and exit 0.

## Why This Change Was Made

Changed-path discovery is now one explicit fail-fast, NUL-safe operation:

- base-range, staged, unstaged, and untracked paths are collected once;
- every Git command must succeed before filtering starts;
- paths are deterministically deduplicated with NUL delimiters;
- the same successful path set drives first-party and rulepack-change decisions;
- only a genuinely empty result emits empty SARIF and exits successfully.

This removes duplicate discovery pipelines and the `|| true` failure masking without changing the OpenGrep rulepack or workflow policy.

AI-assisted: yes. The wrapper/test refactor was manually inspected and passed fresh structured autoreview after the final rebase.

## User Impact

Broken PR/local Git discovery can no longer make the precise OpenGrep scan look green without scanning anything.

## Evidence

- Pre-fix invalid-base and forced `git ls-files` regressions both exited 0, skipped OpenGrep, and wrote empty SARIF.
- Post-fix focused suite: 5/5 tests passed, including genuine-empty and merge-first-parent behavior.
- Hosted changed gate passed on Testbox `tbx_01kzv79tfhfte2yryv23tb8kp6` ([run](https://github.com/openclaw/openclaw/actions/runs/31609097693)).
- `bash -n`, ShellCheck, targeted formatting, test-root typecheck, script lint, and `git diff --check` passed.
- Stock macOS `/usr/bin/sort` is `2.3-Apple (199)`, its local man page documents `-z`, `sort -zu` exits 0, and the 5/5 focused suite executed the wrapper on that host. Apple’s official [`sort(1)` source](https://github.com/apple-oss-distributions/text_cmds/raw/refs/heads/main/sort/sort.1.in) also documents `-z` as the NUL record separator.
- Rebase preserved stable patch ID `16e6e631804786c0bb842dc56c34bf1b876cac86`.
- Fresh complete-branch autoreview: clean.
- Tooling +28/−28 (net 0); tests +86/−41.
