### PR TITLE
fix(e2e): keep package git fixtures self-contained

### DIFF
--- a/scripts/e2e/lib/package-git-fixture.mjs
+++ b/scripts/e2e/lib/package-git-fixture.mjs
@@ -53,6 +53,10 @@ function prepare(root) {
   fs.rmSync(aiRuntimeTarget, { force: true, recursive: true });
   fs.mkdirSync(path.dirname(aiRuntimeTarget), { recursive: true });
   fs.renameSync(aiRuntimeSource, aiRuntimeTarget);
+  const relocatedAiRuntimePackageJson = path.join(aiRuntimeTarget, "package.json");
+  const relocatedAiRuntimePackage = readJson(relocatedAiRuntimePackageJson);
+  delete relocatedAiRuntimePackage.devDependencies;
+  writeJson(relocatedAiRuntimePackageJson, relocatedAiRuntimePackage);
 
   packageJson.dependencies ??= {};
   packageJson.dependencies["@openclaw/ai"] = "file:.openclaw-fixture/packages/ai";

--- a/test/scripts/package-git-fixture.test.ts
+++ b/test/scripts/package-git-fixture.test.ts
@@ -25,7 +25,14 @@ describe("package git fixture", () => {
     );
     writeFileSync(
       path.join(root, "node_modules", "@openclaw", "ai", "package.json"),
-      `${JSON.stringify({ name: "@openclaw/ai", version: "2026.6.11" })}\n`,
+      `${JSON.stringify({
+        name: "@openclaw/ai",
+        version: "2026.6.11",
+        type: "module",
+        main: "./dist/index.mjs",
+        exports: { ".": "./dist/index.mjs" },
+        devDependencies: { "@openclaw/normalization-core": "0.0.0-private" },
+      })}\n`,
     );
 
     const result = spawnSync(
@@ -41,14 +48,17 @@ describe("package git fixture", () => {
     const packageJson = JSON.parse(readFileSync(path.join(root, "package.json"), "utf8"));
     expect(packageJson.dependencies["@openclaw/ai"]).toBe("file:.openclaw-fixture/packages/ai");
     expect(packageJson.bundleDependencies).toEqual(["chalk"]);
-    expect(
-      JSON.parse(
-        readFileSync(
-          path.join(root, ".openclaw-fixture", "packages", "ai", "package.json"),
-          "utf8",
-        ),
-      ).name,
-    ).toBe("@openclaw/ai");
+    const relocatedAiPackage = JSON.parse(
+      readFileSync(path.join(root, ".openclaw-fixture", "packages", "ai", "package.json"), "utf8"),
+    );
+    expect(relocatedAiPackage).toMatchObject({
+      name: "@openclaw/ai",
+      version: "2026.6.11",
+      type: "module",
+      main: "./dist/index.mjs",
+      exports: { ".": "./dist/index.mjs" },
+    });
+    expect(relocatedAiPackage).not.toHaveProperty("devDependencies");
 
     mkdirSync(path.join(root, "node_modules", "chalk"), { recursive: true });
     writeFileSync(path.join(root, "node_modules", "chalk", "package.json"), "{}\n");


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation failure where git-style package install fixtures try to fetch workspace-only `@openclaw/ai` development dependencies from the public npm registry.

## Why This Change Was Made

The fixture now removes the relocated AI package manifest's complete `devDependencies` field before wiring that package as a local `file:` dependency. Package identity and runtime metadata remain unchanged; published package contents and product runtime behavior are out of scope.

## User Impact

Maintainers can run packaged install and update validation without a false `0.0.0-private` registry lookup from the synthetic git fixture. There is no user-facing runtime change.

## Evidence

- Original hosted reproduction: child run https://github.com/openclaw/openclaw/actions/runs/31601965721, job https://github.com/openclaw/openclaw/actions/runs/31601965721/job/94133878344, on qualification SHA `ade3456dd48f638cd5c8c50ecc0a3da3fe76d2ec`.
  - `npm error code E404`
  - `npm error 404 Not Found - GET https://registry.npmjs.org/@openclaw%2fnormalization-core - Not found`
  - `The requested resource '@openclaw/normalization-core@0.0.0-private' could not be found`
- Focused regression: `node scripts/run-vitest.mjs test/scripts/package-git-fixture.test.ts` - 1 file passed, 1 test passed.
- Exact-head Blacksmith Testbox: `tbx_01kzv8spct06z6m4b74t60349n`, https://github.com/openclaw/openclaw/actions/runs/31611496809.
  - `pnpm test:docker:doctor-switch` - passed, exit `0`.
  - `pnpm test:docker:update-channel-switch` - passed, exit `0`.
  - The combined command used `set +e`, captured both outcomes, and exited nonzero if either lane failed: `DOCKER_PROOF doctor-switch=0 update-channel-switch=0`.
- `git diff --check`

## Review Finding Resolution

ClawSweeper's P1 local-path premise is rejected by the observed fixture behavior. The original hosted `openclaw-git-install.log` shows the synthetic root install requesting the exact source-only AI `devDependency`, `@openclaw/normalization-core@0.0.0-private`, from the public registry. This PR's only behavior change removes that field from the relocated fixture manifest while preserving package identity and runtime fields. Both complete Docker consumers pass on the unchanged reviewed head `93794e262f5d2b6737976ef43e33623dffdbfd5b`, establishing that the relocated manifest was the causal resolver input for this package-derived fixture workflow.
