### PR TITLE
fix(qa): accept cumulative compaction counts

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-compaction.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-compaction.test.ts
@@ -72,6 +72,7 @@ describe("qa compaction scenario catalog", () => {
     const writeTranscriptToolCallIdExpr = readSetExpression("writeTranscriptToolCallId");
     const continuationChainExpr = readSetExpression("continuationChain");
     const compactionSummaryRequestsExpr = readSetExpression("compactionSummaryRequests");
+    const overflowCheckpointsExpr = readSetExpression("overflowCheckpoints");
     const continuationAssertIndex = actionIndex((action) =>
       readFlowAssertExpression(action).includes("continuationChain.valid === true"),
     );
@@ -100,6 +101,10 @@ describe("qa compaction scenario catalog", () => {
     );
     const compactionSummaryAssertExpr = readAssertExpression("compactionSummaryRequests.some");
     const noQualityRetryAssertExpr = readAssertExpression("Previous summary failed quality checks");
+    const compactionSnapshotAssertExpr = readAssertExpression(
+      "Number.isInteger(sessionEntry?.compactionCount)",
+    );
+    const overflowCheckpointAssertExpr = readAssertExpression("overflowCheckpoints.length === 1");
     const knownGap =
       "known-harness-gap compaction-retry-mutating-tool: provider-error recovery does not invoke Codex native compaction; native token-threshold compaction needs a separate scenario.";
 
@@ -288,6 +293,16 @@ describe("qa compaction scenario catalog", () => {
     expect(noQualityRetryAssertExpr).toContain(
       "!String(request.allInputText ?? '').includes('Previous summary failed quality checks')",
     );
+    expect(compactionSnapshotAssertExpr).toContain(
+      "Number.isInteger(sessionEntry?.compactionCount) && sessionEntry.compactionCount >= 1",
+    );
+    expect(compactionSnapshotAssertExpr).toContain(
+      "Number.isFinite(sessionEntry?.totalTokens) && sessionEntry?.totalTokensFresh === true",
+    );
+    expect(compactionSnapshotAssertExpr).not.toContain("compactionCount === 1");
+    expect(flow).not.toContain("sessionEntry?.compactionCount === 1");
+    expect(overflowCheckpointsExpr).toContain("checkpoint.reason === 'overflow-retry'");
+    expect(overflowCheckpointAssertExpr).toContain("overflowCheckpoints.length === 1");
     expect(flow).not.toContain("compactionSummaryRequests.length === 1");
     expect(flow).toContain(
       "writeRequest.rawByteLength < config.overflowThresholdBytes && writeRequest.rawByteLength < overflowRequest.rawByteLength",

--- a/qa/scenarios/runtime/compaction-retry-mutating-tool.yaml
+++ b/qa/scenarios/runtime/compaction-retry-mutating-tool.yaml
@@ -244,9 +244,9 @@ flow:
           value:
             expr: "store[sessionKey]"
         - assert:
-            expr: "sessionEntry?.compactionCount === 1 && Number.isFinite(sessionEntry?.totalTokens) && sessionEntry?.totalTokensFresh === true"
+            expr: "Number.isInteger(sessionEntry?.compactionCount) && sessionEntry.compactionCount >= 1 && Number.isFinite(sessionEntry?.totalTokens) && sessionEntry?.totalTokensFresh === true"
             message:
-              expr: "`OpenClaw token snapshot was not fresh after one compaction: ${JSON.stringify({ compactionCount: sessionEntry?.compactionCount, totalTokens: sessionEntry?.totalTokens, totalTokensFresh: sessionEntry?.totalTokensFresh })}`"
+              expr: "`OpenClaw token snapshot did not retain a positive compaction count with fresh token data: ${JSON.stringify({ compactionCount: sessionEntry?.compactionCount, totalTokens: sessionEntry?.totalTokens, totalTokensFresh: sessionEntry?.totalTokensFresh })}`"
         - set: checkpointPage
           value:
             expr: "await env.gateway.call('sessions.compaction.list', { key: sessionKey }, { timeoutMs: 15000 })"


### PR DESCRIPTION
## What Problem This Solves

Resolves a qualification false failure where the compaction retry scenario rejected a healthy session after a second legitimate compaction incremented the cumulative `compactionCount`.

## Why This Change Was Made

The scenario now requires a positive integer cumulative compaction count while preserving fresh finite token data. Its catalog contract still requires exactly one checkpoint with reason `overflow-retry` and explicitly rejects the old `compactionCount === 1` assertion.

## User Impact

No runtime behavior changes. Main qualification can accept the valid overflow-retry plus post-turn compaction sequence without weakening the exact overflow checkpoint proof.

## Evidence

- Hosted failure: Full Release Validation campaign `20260812T131756Z-main_sha-daily-ade3456dd48f`, QA job `94131547310`.
- Exact-head Blacksmith Testbox proof on `84394a7a68f87b15bf5a5f014eba3ff6fc210095`: `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build qaRuntime`, then `pnpm openclaw qa suite --provider-mode mock-openai --scenario compaction-retry-mutating-tool --concurrency 1 --output-dir .artifacts/qa-e2e/pr-122680-exact` - 1 scenario passed, 0 failed, 0 skipped. Testbox `tbx_01kzvb5xnjdnf0dqej4bj123k8`; Actions run https://github.com/openclaw/openclaw/actions/runs/31615261957.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog-compaction.test.ts` - 1 file passed, 3 tests passed.
- `./node_modules/.bin/oxfmt --check extensions/qa-lab/src/scenario-catalog-compaction.test.ts qa/scenarios/runtime/compaction-retry-mutating-tool.yaml` - passed.
- `git diff --check origin/main...HEAD` - passed.
- Autoreview on the complete local diff: clean, no accepted/actionable findings.
- Production LOC: +0/-0. QA/test LOC: +17/-2.
