### PR TITLE
fix(ui): tool call chains look failed when one call fails

### DIFF
--- a/ui/src/e2e/chat-tool-turn-outcome.e2e.test.ts
+++ b/ui/src/e2e/chat-tool-turn-outcome.e2e.test.ts
@@ -89,17 +89,21 @@ suite.define(() => {
     await expandCompletedWorkGroups(page);
 
     expect(await page.locator(".chat-tool-msg-summary__label").allTextContents()).toEqual([
-      "Tool error",
+      "Tool output",
       "Tool output",
     ]);
-    // The earlier failure must stay visibly marked as an error even though a
-    // later turn recovered; the recovered row must render neutral.
+    // Each failure keeps only its per-call badge even when its turn later
+    // recovers; both row summaries otherwise render neutral.
     const summaryClasses = await page
       .locator(".chat-tool-msg-summary")
       .evaluateAll((nodes) => nodes.map((node) => node.className));
     expect(summaryClasses).toHaveLength(2);
-    expect(summaryClasses[0]).toContain("chat-tool-msg-summary--error");
+    expect(summaryClasses[0]).not.toContain("chat-tool-msg-summary--error");
     expect(summaryClasses[1]).not.toContain("chat-tool-msg-summary--error");
+    expect(await page.locator(".chat-tool-row__badge").allTextContents()).toEqual([
+      "failed",
+      "failed",
+    ]);
     await context.close();
   });
 

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5373,17 +5373,11 @@ export const en: TranslationMap = {
         otherMany: "used {count} tools",
         emptyOne: "Ran a tool call",
         emptyMany: "Ran {count} tool calls",
-        failedOne: "{count} failed",
-        failedMany: "{count} failed",
-        activityErrorOne: "Activity: {count} tool, includes errors.",
-        activityErrorMany: "Activity: {count} tools, includes errors.",
       },
     },
     workRun: {
       workedFor: "Worked for {duration}",
       worked: "Worked",
-      workedForError: "Worked for {duration}, includes errors.",
-      workedError: "Worked, includes errors.",
     },
     backgroundTasks: {
       label: "Background tasks",

--- a/ui/src/lib/chat/chat-types.ts
+++ b/ui/src/lib/chat/chat-types.ts
@@ -143,7 +143,6 @@ export type MessageGroup = {
   messages: Array<{ message: unknown; key: string; duplicateCount?: number }>;
   timestamp: number;
   isStreaming: boolean;
-  turnSucceeded?: boolean;
 };
 
 /** Content item types in a normalized message */

--- a/ui/src/lib/chat/tool-call-grouping.ts
+++ b/ui/src/lib/chat/tool-call-grouping.ts
@@ -14,7 +14,6 @@ import {
 type ToolGroupSummaryInput = {
   name: string;
   args?: unknown;
-  isError?: boolean;
 };
 
 type FileActivity = "read" | "edit" | "write" | "delete";
@@ -31,7 +30,6 @@ type GroupCounts = {
   fetches: number;
   otherNames: Set<string>;
   others: number;
-  failed: number;
 };
 
 function countFiles(counts: GroupCounts, activity: FileActivity, paths: readonly string[]): void {
@@ -78,9 +76,6 @@ function countCard(counts: GroupCounts, card: ToolGroupSummaryInput): void {
         counts.otherNames.add(card.name);
     }
   }
-  if (card.isError) {
-    counts.failed += 1;
-  }
 }
 
 function countLabel(count: number, oneKey: string, manyKey: string): string {
@@ -108,7 +103,6 @@ export function summarizeToolGroup(cards: readonly ToolGroupSummaryInput[]): str
     fetches: 0,
     otherNames: new Set(),
     others: 0,
-    failed: 0,
   };
   for (const card of cards) {
     countCard(counts, card);
@@ -186,14 +180,5 @@ export function summarizeToolGroup(cards: readonly ToolGroupSummaryInput[]): str
     );
   }
   const label = segments.join(", ");
-  const capitalized = label.charAt(0).toUpperCase() + label.slice(1);
-  if (counts.failed === 0) {
-    return capitalized;
-  }
-  const failureLabel = countLabel(
-    counts.failed,
-    "chat.toolCards.group.failedOne",
-    "chat.toolCards.group.failedMany",
-  );
-  return `${capitalized} · ${failureLabel}`;
+  return label.charAt(0).toUpperCase() + label.slice(1);
 }

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -194,7 +194,7 @@ function activityAlignmentHtml() {
           <div class="chat-avatar tool">A</div>
           <div class="chat-group-messages">
             <div class="chat-activity-group is-open">
-              <button class="chat-activity-group__summary chat-activity-group__summary--error" type="button">
+              <button class="chat-activity-group__summary" type="button">
                 <span class="chat-activity-group__icon">${iconSvg()}</span>
                 <span class="chat-activity-group__label">Activity: 2 tools</span>
               </button>
@@ -212,10 +212,11 @@ function activityAlignmentHtml() {
                 </div>
                 <div class="chat-bubble chat-bubble--tool-shell">
                   <div class="chat-tool-msg-collapse">
-                    <button class="chat-tool-msg-summary chat-tool-msg-summary--error" type="button">
+                    <button class="chat-tool-msg-summary" data-failed-call-row type="button">
                       <span class="chat-tool-msg-summary__icon">${iconSvg()}</span>
-                      <span class="chat-tool-msg-summary__label">Tool error</span>
+                      <span class="chat-tool-msg-summary__label">Bash</span>
                       <span class="chat-tool-msg-summary__names">Bash</span>
+                      <span class="chat-tool-row__badge">failed</span>
                     </button>
                   </div>
                 </div>
@@ -1232,9 +1233,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
 
       await expectNoHorizontalOverflow(page);
       const callRow = await getRect(page, "[data-activity-call-row]");
-      const errorSummary = await getRect(page, ".chat-tool-msg-summary--error");
-      expect(Math.abs(callRow.right - errorSummary.right)).toBeLessThanOrEqual(1);
-      expect(Math.abs(callRow.height - errorSummary.height)).toBeLessThanOrEqual(1);
+      const failedSummary = await getRect(page, "[data-failed-call-row]");
+      expect(Math.abs(callRow.right - failedSummary.right)).toBeLessThanOrEqual(1);
+      expect(Math.abs(callRow.height - failedSummary.height)).toBeLessThanOrEqual(1);
       const styles = await page.evaluate(() => {
         const call = document.querySelector<HTMLElement>("[data-activity-call-row]")!;
         return {

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -29,7 +29,6 @@ import {
   shouldRenderQueuedSendInThread,
 } from "./chat-progress.ts";
 import {
-  annotateToolTurnOutcome,
   coalesceToolActivityMessages,
   groupMessages,
   isKeyedAssistantStreamFallbackMessage,
@@ -615,7 +614,5 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     appendQueuedSend(queued);
   }
 
-  return annotateToolTurnOutcome(
-    groupMessages(collapseSequentialDuplicateMessages(coalesceToolActivityMessages(items))),
-  );
+  return groupMessages(collapseSequentialDuplicateMessages(coalesceToolActivityMessages(items)));
 }

--- a/ui/src/pages/chat/chat-thread-grouping.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.ts
@@ -8,7 +8,7 @@ import type { ChatItem, MessageGroup, ToolCard } from "../../lib/chat/chat-types
 import { extractTextCached } from "../../lib/chat/message-extract.ts";
 import { normalizeMessage, normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
 import { senderIdentityKey } from "../../lib/chat/sender-label.ts";
-import { extractToolCardsCached, isToolCardError } from "../../lib/chat/tool-cards.ts";
+import { extractToolCardsCached } from "../../lib/chat/tool-cards.ts";
 import { resolveMessageToolUseId, resolveToolBlockId } from "./chat-thread-items.ts";
 import {
   assistantGroupIsForwardedBoundary,
@@ -460,52 +460,6 @@ export function coalesceToolActivityMessages(items: ChatItem[]): ChatItem[] {
   return coalesced.filter((_, index) => !suppressedIndexes.has(index));
 }
 
-function assistantGroupHasReplyText(group: MessageGroup): boolean {
-  return group.messages.some(({ message }) => {
-    if (extractTextCached(message)?.trim()) {
-      return true;
-    }
-    return safeNormalizeMessage(message)?.content.some((block) => block.type === "canvas") ?? false;
-  });
-}
-
-export function annotateToolTurnOutcome(
-  items: Array<ChatItem | MessageGroup>,
-): Array<ChatItem | MessageGroup> {
-  let sawAssistantReply = false;
-  for (let index = items.length - 1; index >= 0; index -= 1) {
-    const item = items[index];
-    if (!item || item.kind !== "group") {
-      if (item && chatItemStartsUserTurn(item)) {
-        sawAssistantReply = false;
-      }
-      continue;
-    }
-    const role = item.role.toLowerCase();
-    const forwardedBoundary = role === "assistant" && assistantGroupIsForwardedBoundary(item);
-    const startsTurn = chatItemStartsUserTurn(item);
-    if (role === "user") {
-      sawAssistantReply = false;
-    } else if (role === "assistant") {
-      if (forwardedBoundary) {
-        // Gateway preserves sessions_send provenance when projecting inputs as assistant groups.
-        // Those groups start a new autonomous turn; they are not replies to an earlier tool.
-        sawAssistantReply = false;
-      } else if (assistantGroupHasReplyText(item)) {
-        sawAssistantReply = true;
-      }
-    } else if (role === "tool") {
-      item.turnSucceeded = sawAssistantReply;
-    }
-    if (role !== "user" && !forwardedBoundary && startsTurn) {
-      // This group belongs to the new hidden-input turn. Reset only after
-      // processing it so replies from this turn cannot classify older tools.
-      sawAssistantReply = false;
-    }
-  }
-  return items;
-}
-
 type RenderChatItem = ChatItem | MessageGroup;
 type StreamRunRenderItem = {
   kind: "stream-run";
@@ -549,7 +503,6 @@ type WorkGroupRenderItem = {
   key: string;
   groups: MessageGroup[];
   durationMs: number | null;
-  hasError: boolean;
 };
 
 type ActivityRunRenderItem = {
@@ -604,17 +557,6 @@ function isFinalReplyGroup(item: TurnRenderItem): boolean {
     isCollapsibleWorkGroup(item) &&
     item.role.toLowerCase() === "assistant" &&
     assistantGroupHasVisibleReplyContent(item)
-  );
-}
-
-function workGroupHasError(groups: MessageGroup[]): boolean {
-  return groups.some(
-    (group) =>
-      group.role.toLowerCase() === "tool" &&
-      group.turnSucceeded !== true &&
-      group.messages.some((entry) =>
-        extractToolCardsCached(entry.message, entry.key).some(isToolCardError),
-      ),
   );
 }
 
@@ -717,7 +659,6 @@ export function collapseCompletedTurnWork(
       key: `work:${finalReply.key}`,
       groups,
       durationMs,
-      hasError: workGroupHasError(groups),
     });
     result.push(...turn.slice(segmentEnd + 1));
   }

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -631,7 +631,6 @@ describe("collapseCompletedTurnWork", () => {
     const work = requireWorkGroup(items[1]);
     expect(work.groups).toHaveLength(2);
     expect(work.durationMs).toBe(9_000);
-    expect(work.hasError).toBe(false);
     expect(requireGroup(items[2]).role).toBe("assistant");
   });
 
@@ -695,7 +694,7 @@ describe("collapseCompletedTurnWork", () => {
     expect(requireGroup(items[1]).role).toBe("tool");
   });
 
-  it("does not flag errors once the turn recovered with a reply", () => {
+  it("collapses failed work once the turn recovered with a reply", () => {
     const items = collapsedItems({
       messages: [
         userMessage("go", 1_000),
@@ -704,7 +703,7 @@ describe("collapseCompletedTurnWork", () => {
       ],
     });
 
-    expect(requireWorkGroup(items[1]).hasError).toBe(false);
+    expect(requireWorkGroup(items[1]).groups).toHaveLength(1);
   });
 
   it("keeps work after the final reply visible", () => {
@@ -967,15 +966,6 @@ describe("coalesceActivityRuns", () => {
 
     expect(singleton[0]).toBe(groups[0]);
     expect(coalesceActivityRuns(searchInput, { searchActive: true })).toBe(searchInput);
-  });
-
-  it("retains each member group's recovered or active error outcome", () => {
-    const groups = projectedToolGroups();
-    groups[0]!.turnSucceeded = true;
-    groups[1]!.turnSucceeded = false;
-    const run = requireActivityRun(coalesceActivityRuns(groups.slice(0, 2))[0]);
-
-    expect(run.groups.map((group) => group.turnSucceeded)).toEqual([true, false]);
   });
 });
 
@@ -1701,25 +1691,6 @@ describe("buildCachedChatItems", () => {
 
     expect(groups).toHaveLength(2);
     expect(groups.map((group) => group.senderLabel)).toEqual([null, "Forwarded from main"]);
-  });
-
-  it("marks earlier tool groups as succeeded when the same turn has an assistant reply", () => {
-    const groups = messageGroups({
-      messages: [
-        userMessage("search", 1000),
-        toolResultMessage("call-1", "web_search", JSON.stringify({ error: "No matches" }), 1001, {
-          isError: true,
-        }),
-        assistantMessage("I found another route.", 1002),
-        userMessage("again", 1003),
-        toolResultMessage("call-2", "web_search", JSON.stringify({ error: "No matches" }), 1004, {
-          isError: true,
-        }),
-      ],
-    });
-
-    const toolGroups = groups.filter((group) => group.role === "tool");
-    expect(toolGroups.map((group) => group.turnSucceeded)).toEqual([true, false]);
   });
 
   it("coalesces adjacent tool calls and results into one activity item", () => {
@@ -4088,115 +4059,4 @@ function mcpAppLiveResult(viewId: string, toolCallId: string, timestamp: number 
   );
 }
 
-describe("tool turn outcome annotation (#89683)", () => {
-  function failedTool(timestamp: number) {
-    return chatMessage("toolResult", JSON.stringify({ status: "failed", exitCode: 1 }), timestamp, {
-      toolName: "shell",
-      isError: true,
-    });
-  }
-  function assistantReply(text: string, timestamp: number) {
-    return assistantMessage([{ type: "text", text }], timestamp);
-  }
-  function toolGroups(messages: unknown[]): MessageGroup[] {
-    return messageGroups({ messages }).filter((group) => group.role === "tool");
-  }
-
-  it.each([
-    {
-      name: "marks a failed tool followed by an assistant reply as turnSucceeded",
-      reply: assistantReply("No matches found.", 3),
-      expected: true,
-    },
-    {
-      name: "leaves a terminal failed tool (no assistant reply) as not-succeeded",
-      reply: null,
-      expected: false,
-    },
-  ])("$name", ({ reply, expected }) => {
-    const tools = toolGroups([
-      userMessage("search foo", 1),
-      failedTool(2),
-      ...(reply ? [reply] : []),
-    ]);
-    expect(tools).toHaveLength(1);
-    expect(groupAt(tools, 0).turnSucceeded).toBe(expected);
-  });
-
-  it("does not count an assistant group without reply text as success", () => {
-    const tools = toolGroups([
-      userMessage("search foo", 1),
-      failedTool(2),
-      assistantMessage([], 3),
-    ]);
-    expect(groupAt(tools, 0).turnSucceeded).toBe(false);
-  });
-
-  it.each([
-    {
-      name: "scopes adjacent autonomous turns at an empty forwarded boundary",
-      content: [],
-    },
-    {
-      name: "does not treat a forwarded message as the prior turn's reply",
-      content: [{ type: "text", text: "Start the next autonomous task." }],
-    },
-  ])("$name", ({ content }) => {
-    const tools = toolGroups([
-      failedTool(1),
-      assistantMessage(content, 2, {
-        provenance: { kind: "inter_session", sourceTool: "sessions_send" },
-        senderLabel: "Forwarded from main",
-      }),
-      failedTool(3),
-      assistantReply("Recovered on the next autonomous turn.", 4),
-    ]);
-    expect(tools.map((group) => group.turnSucceeded)).toEqual([false, true]);
-  });
-
-  it("treats an ordinary labeled assistant message as a reply", () => {
-    const tools = toolGroups([
-      userMessage("check the service", 1),
-      failedTool(2),
-      assistantMessage([{ type: "text", text: "Parzival recovered the service." }], 3, {
-        senderLabel: "Parzival",
-      }),
-    ]);
-    expect(groupAt(tools, 0).turnSucceeded).toBe(true);
-  });
-
-  it("does not treat non-text assistant content as a turn boundary", () => {
-    const tools = toolGroups([
-      userMessage("make a preview", 1),
-      failedTool(2),
-      assistantMessage([createAssistantCanvasBlock({ suffix: "tool_turn_outcome" })], 3),
-      failedTool(4),
-      assistantReply("Done.", 5),
-    ]);
-    expect(tools.map((group) => group.turnSucceeded)).toEqual([true, true]);
-  });
-
-  it("scopes the outcome per turn at user boundaries", () => {
-    const tools = toolGroups([
-      userMessage("first", 1),
-      failedTool(2),
-      assistantReply("done", 3),
-      userMessage("second", 4),
-      failedTool(5),
-    ]);
-    expect(tools.map((group) => group.turnSucceeded)).toEqual([true, false]);
-  });
-
-  it("keeps internal system notices as semantic user-turn boundaries", () => {
-    const tools = toolGroups([
-      failedTool(1),
-      userMessage("[System] Continue the interrupted turn.", 2, {
-        provenance: { kind: "internal_system", sourceTool: "main_session_restart_recovery" },
-      }),
-      failedTool(3),
-      assistantReply("Recovered on the next turn.", 4),
-    ]);
-    expect(tools.map((group) => group.turnSucceeded)).toEqual([false, true]);
-  });
-});
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -77,7 +77,6 @@ function sameMessageGroup(previous: MessageGroup, next: MessageGroup): boolean {
     senderIdentityKey(previous.sender) === senderIdentityKey(next.sender) &&
     senderIdentityKey(previous.replyToSender) === senderIdentityKey(next.replyToSender) &&
     previous.isStreaming === next.isStreaming &&
-    previous.turnSucceeded === next.turnSucceeded &&
     previous.messages.length === next.messages.length &&
     previous.messages.every((entry, index) => {
       const candidate = next.messages[index];

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -217,7 +217,6 @@ export function renderGroupedMessage(
     showReasoning: boolean;
     showToolCalls?: boolean;
     runActive?: boolean;
-    turnSucceeded?: boolean;
     autoExpandToolCalls?: boolean;
     isToolMessageExpanded?: (messageId: string) => boolean | undefined;
     onToggleToolMessageExpanded?: (messageId: string, expanded?: boolean) => void;
@@ -328,7 +327,7 @@ export function renderGroupedMessage(
   const toolMessageExpanded = opts.isToolMessageExpanded?.(toolMessageDisclosureId) ?? false;
   const toolNames = [...new Set(toolCards.map((c) => c.name))];
   const singleToolCard = toolCards.length === 1 ? toolCards[0] : null;
-  const toolMessageHasError = toolCards.some(isToolCardError) && opts.turnSucceeded !== true;
+  const toolMessageHasError = toolCards.some(isToolCardError);
   const singleToolDisplay = singleToolCard
     ? resolveToolDisplay({
         name: singleToolCard.name,
@@ -337,28 +336,21 @@ export function renderGroupedMessage(
       })
     : null;
   const singleToolDisplayDetail =
-    !toolMessageHasError && singleToolCard && singleToolDisplay
+    singleToolCard && singleToolDisplay
       ? resolveCollapsedToolDetail(singleToolCard, singleToolDisplay.detail)
       : undefined;
-  const toolSummaryLabelRaw = toolMessageHasError
-    ? singleToolDisplay
-      ? singleToolDisplay.label
-      : toolNames.length <= 3
-        ? toolNames.join(", ")
-        : `${toolNames.slice(0, 2).join(", ")} +${toolNames.length - 2} more`
-    : singleToolDisplayDetail
-      ? !markdown && !hasImages
-        ? singleToolDisplayDetail
-        : singleToolCard?.outputText?.trim()
-          ? "output"
-          : undefined
-      : toolNames.length <= 3
-        ? toolNames.join(", ")
-        : `${toolNames.slice(0, 2).join(", ")} +${toolNames.length - 2} more`;
+  const toolSummaryLabelRaw = singleToolDisplayDetail
+    ? !markdown && !hasImages
+      ? singleToolDisplayDetail
+      : singleToolCard?.outputText?.trim()
+        ? "output"
+        : undefined
+    : toolNames.length <= 3
+      ? toolNames.join(", ")
+      : `${toolNames.slice(0, 2).join(", ")} +${toolNames.length - 2} more`;
   const toolPreview = markdown ? (formatCollapsedToolPreviewText(markdown) ?? "") : "";
-  const toolMessageLabelRaw = toolMessageHasError
-    ? t("chat.toolCards.toolError")
-    : singleToolDisplay && !markdown && !hasImages
+  const toolMessageLabelRaw =
+    singleToolDisplay && !markdown && !hasImages
       ? singleToolDisplay.label
       : t("chat.toolCards.toolOutput");
   const toolMessageLabel =
@@ -471,9 +463,7 @@ export function renderGroupedMessage(
                 : ""}"
             >
               <button
-                class="chat-tool-msg-summary ${toolMessageHasError
-                  ? "chat-tool-msg-summary--error"
-                  : ""}"
+                class="chat-tool-msg-summary"
                 type="button"
                 aria-expanded=${String(toolMessageExpanded)}
                 @click=${(event: MouseEvent) => {
@@ -489,6 +479,9 @@ export function renderGroupedMessage(
                   : toolPreview
                     ? html`<span class="chat-tool-msg-summary__preview">${toolPreview}</span>`
                     : nothing}
+                ${toolMessageHasError
+                  ? html`<span class="chat-tool-row__badge">${t("chat.toolCards.failed")}</span>`
+                  : nothing}
               </button>
               ${toolMessageExpanded
                 ? html`

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -8,7 +8,7 @@ import type { MessageGroup } from "../../../lib/chat/chat-types.ts";
 import { normalizeRoleForGrouping } from "../../../lib/chat/message-normalizer.ts";
 import { formatSenderLabel } from "../../../lib/chat/sender-label.ts";
 import { summarizeToolGroup } from "../../../lib/chat/tool-call-grouping.ts";
-import { extractToolCardsCached, isToolCardError } from "../../../lib/chat/tool-cards.ts";
+import { extractToolCardsCached } from "../../../lib/chat/tool-cards.ts";
 import type { EmbedSandboxMode } from "../../../lib/chat/tool-display.ts";
 import { fnv1aUtf16 } from "../../../lib/fnv1a.ts";
 import { resolveIdentityHue } from "../../../lib/identity-avatar.ts";
@@ -143,7 +143,6 @@ function buildGroupedMessageRenderOptions(
     showReasoning: opts.showReasoning,
     showToolCalls: opts.showToolCalls ?? true,
     runActive: opts.runActive,
-    turnSucceeded: group.turnSucceeded,
     autoExpandToolCalls: opts.autoExpandToolCalls ?? false,
     isToolMessageExpanded: opts.isToolMessageExpanded,
     onToggleToolMessageExpanded: opts.onToggleToolMessageExpanded,
@@ -231,11 +230,6 @@ export function renderActivityGroup(
   const latestCards = latestGroup.messages.flatMap((item) =>
     extractToolCardsCached(item.message, item.key),
   );
-  const toolCount =
-    cards.length || groups.reduce((count, group) => count + group.messages.length, 0);
-  // Aggregate chrome follows the latest group; older failures stay visible
-  // in the settled summary and expanded child rows.
-  const hasError = latestGroup.turnSucceeded !== true && latestCards.some(isToolCardError);
   // While a run is live, the newest still-running call names the group so
   // the collapsed header reads like a status line; afterwards it aggregates.
   const runningCard = opts.runActive
@@ -243,16 +237,10 @@ export function renderActivityGroup(
     : undefined;
   const groupSummaryLabel = runningCard
     ? `${resolveToolRowText(runningCard, opts.runActive)}…`
-    : summarizeToolGroup(
-        cards.map((card) => ({
-          name: card.name,
-          args: card.args,
-          isError: isToolCardError(card),
-        })),
-      );
+    : summarizeToolGroup(cards.map((card) => ({ name: card.name, args: card.args })));
   const activityDisclosureId = `activity:${firstGroup.key}`;
   const activityBodyId = `activity-body-${fnv1aUtf16(firstGroup.key).toString(16)}`;
-  const activityExpanded = opts.isToolMessageExpanded?.(activityDisclosureId) ?? hasError;
+  const activityExpanded = opts.isToolMessageExpanded?.(activityDisclosureId) ?? false;
   const showAvatarGutter = opts.showAvatarGutter !== false;
   const assistantName = opts.assistantName ?? "Assistant";
 
@@ -282,27 +270,17 @@ export function renderActivityGroup(
       <div class="chat-group-messages">
         <div class="chat-activity-group ${activityExpanded ? "is-open" : ""}">
           <button
-            class="chat-activity-group__summary ${hasError
-              ? "chat-activity-group__summary--error"
-              : ""}"
+            class="chat-activity-group__summary"
             type="button"
             aria-expanded=${String(activityExpanded)}
             aria-controls=${activityBodyId}
-            aria-label=${hasError
-              ? t(
-                  toolCount === 1
-                    ? "chat.toolCards.group.activityErrorOne"
-                    : "chat.toolCards.group.activityErrorMany",
-                  { count: String(toolCount) },
-                )
-              : nothing}
             @click=${(event: MouseEvent) => {
               if (shouldToggleSelectableDisclosure(event)) {
                 opts.onToggleToolMessageExpanded?.(activityDisclosureId, activityExpanded);
               }
             }}
           >
-            <span class="chat-activity-group__icon">${hasError ? icons.x : icons.activity}</span>
+            <span class="chat-activity-group__icon">${icons.activity}</span>
             <span class="chat-activity-group__label" title=${groupSummaryLabel}
               >${groupSummaryLabel}</span
             >

--- a/ui/src/pages/chat/components/chat-message-stream.ts
+++ b/ui/src/pages/chat/components/chat-message-stream.ts
@@ -154,11 +154,11 @@ export function renderStreamGroup(parts: StreamGroupPart[], opts: StreamGroupOpt
 
 /**
  * Collapsed-turn rollup header: one slim "Worked for X" disclosure standing in
- * for the turn's intermediate work once the run is done. The check/x icon is
+ * for the turn's intermediate work once the run is done. The check icon is
  * the turn's done indicator; the expanded groups render after this row.
  */
 export function renderWorkGroupSummary(
-  item: { key: string; durationMs: number | null; hasError: boolean },
+  item: { key: string; durationMs: number | null },
   opts: { expanded: boolean; onToggle: () => void },
 ) {
   const duration = formatDurationCompact(item.durationMs);
@@ -169,25 +169,16 @@ export function renderWorkGroupSummary(
       <div class="chat-group-messages">
         <div class="chat-activity-group chat-work-group ${opts.expanded ? "is-open" : ""}">
           <button
-            class="chat-activity-group__summary ${item.hasError
-              ? "chat-activity-group__summary--error"
-              : ""}"
+            class="chat-activity-group__summary"
             type="button"
             aria-expanded=${String(opts.expanded)}
-            aria-label=${item.hasError
-              ? duration
-                ? t("chat.workRun.workedForError", { duration })
-                : t("chat.workRun.workedError")
-              : nothing}
             @click=${(event: MouseEvent) => {
               if (shouldToggleSelectableDisclosure(event)) {
                 opts.onToggle();
               }
             }}
           >
-            <span class="chat-activity-group__icon">
-              ${item.hasError ? icons.x : icons.check}
-            </span>
+            <span class="chat-activity-group__icon">${icons.check}</span>
             <span class="chat-activity-group__label" title=${label}>${label}</span>
             <span
               class="collapse-chevron ${opts.expanded ? "" : "collapse-chevron--collapsed"}"

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -2255,18 +2255,14 @@ describe("grouped chat rendering", () => {
   it("uses the newest group's live card label without inheriting an earlier failure", () => {
     const container = document.createElement("div");
     const groups = [
-      createToolGroup(
-        "live-first",
-        [
-          createMessageEntry(
-            "failed-read",
-            createToolResultMessage("call-read", "read", JSON.stringify({ error: "failed" }), {
-              isError: true,
-            }),
-          ),
-        ],
-        { turnSucceeded: false },
-      ),
+      createToolGroup("live-first", [
+        createMessageEntry(
+          "failed-read",
+          createToolResultMessage("call-read", "read", JSON.stringify({ error: "failed" }), {
+            isError: true,
+          }),
+        ),
+      ]),
       createToolGroup(
         "live-second",
         [
@@ -2305,11 +2301,11 @@ describe("grouped chat rendering", () => {
 
     render(renderActivityGroup(groups, { ...opts, runActive: false }), container);
     expect(container.querySelector(".chat-activity-group__label")?.textContent).toBe(
-      "Read a file, edited a file · 1 failed",
+      "Read a file, edited a file",
     );
   });
 
-  it("derives cross-group error state from the latest group while retaining failed children", () => {
+  it("keeps cross-group activity neutral while retaining failed child badges", () => {
     const container = document.createElement("div");
     const failedMessage = (id: string) =>
       createAssistantMessage(
@@ -2324,11 +2320,9 @@ describe("grouped chat rendering", () => {
         ],
         { isError: true },
       );
-    const failed = createToolGroup(
-      "failed",
-      [createMessageEntry("failed-message", failedMessage("call-failed"))],
-      { turnSucceeded: false },
-    );
+    const failed = createToolGroup("failed", [
+      createMessageEntry("failed-message", failedMessage("call-failed")),
+    ]);
     const successful = createToolGroup("successful", [
       createMessageEntry("successful-message", createToolResultMessage("call-ok", "read", "ok")),
     ]);
@@ -2349,8 +2343,8 @@ describe("grouped chat rendering", () => {
     expect(recoveredSummary.classList.contains("chat-activity-group__summary--error")).toBe(false);
     expect(recoveredSummary.getAttribute("aria-expanded")).toBe("false");
     expect(recoveredSummary.getAttribute("aria-label")).toBeNull();
-    expect(container.querySelector(".chat-activity-group__label")?.textContent).toContain(
-      "1 failed",
+    expect(container.querySelector(".chat-activity-group__label")?.textContent).not.toContain(
+      "failed",
     );
 
     render(
@@ -2362,7 +2356,7 @@ describe("grouped chat rendering", () => {
       container,
     );
     expect(container.querySelector(".chat-activity-group__summary--error")).toBeNull();
-    expect(container.querySelectorAll(".chat-tool-msg-summary--error")).toHaveLength(1);
+    expect(container.querySelectorAll(".chat-tool-msg-summary--error")).toHaveLength(0);
     expect(container.querySelector(".chat-tool-row__badge")?.textContent).toBe("failed");
 
     render(
@@ -2377,10 +2371,10 @@ describe("grouped chat rendering", () => {
       ".chat-activity-group__summary",
       HTMLButtonElement,
     );
-    expect(container.querySelector(".chat-activity-group.is-open")).not.toBeNull();
-    expect(failedSummary.classList.contains("chat-activity-group__summary--error")).toBe(true);
-    expect(failedSummary.getAttribute("aria-expanded")).toBe("true");
-    expect(failedSummary.getAttribute("aria-label")).toBe("Activity: 2 tools, includes errors.");
+    expect(container.querySelector(".chat-activity-group.is-open")).toBeNull();
+    expect(failedSummary.classList.contains("chat-activity-group__summary--error")).toBe(false);
+    expect(failedSummary.getAttribute("aria-expanded")).toBe("false");
+    expect(failedSummary.getAttribute("aria-label")).toBeNull();
   });
 
   it("uses the running mutation verb in an active group summary", () => {
@@ -2418,7 +2412,7 @@ describe("grouped chat rendering", () => {
     );
   });
 
-  it("passes the effective default-expanded activity state to the toggle handler", () => {
+  it("keeps failed activity collapsed with neutral chain chrome", () => {
     const container = document.createElement("div");
     document.body.append(container);
     const onToggleToolMessageExpanded = vi.fn();
@@ -2440,24 +2434,17 @@ describe("grouped chat rendering", () => {
 
     renderMessageGroups(container, [group], { onToggleToolMessageExpanded });
 
-    expect(container.querySelector(".chat-activity-group.is-open")).toBeInstanceOf(HTMLElement);
+    expect(container.querySelector(".chat-activity-group.is-open")).toBeNull();
     const activitySummary = expectElement(
       container,
       ".chat-activity-group__summary",
       HTMLButtonElement,
     );
-    expect(activitySummary.classList.contains("chat-activity-group__summary--error")).toBe(true);
-    expect(activitySummary.getAttribute("aria-label")).toBe("Activity: 2 tools, includes errors.");
+    expect(activitySummary.classList.contains("chat-activity-group__summary--error")).toBe(false);
+    expect(activitySummary.getAttribute("aria-label")).toBeNull();
+    expect(activitySummary.getAttribute("aria-expanded")).toBe("false");
+    expect(activitySummary.textContent).not.toContain("failed");
     expect(activitySummary.querySelector(".chat-activity-group__badge")).toBeNull();
-    const errorSummary = expectElement(
-      container,
-      ".chat-tool-msg-summary--error",
-      HTMLButtonElement,
-    );
-    expect(errorSummary.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe(
-      "Tool error",
-    );
-    expect(errorSummary.querySelector(".chat-tool-msg-summary__error-badge")).toBeNull();
     selectText(expectElement(activitySummary, ".chat-activity-group__label", HTMLElement));
     pointerClick(activitySummary);
     expect(onToggleToolMessageExpanded).not.toHaveBeenCalled();
@@ -2465,73 +2452,65 @@ describe("grouped chat rendering", () => {
     window.getSelection()?.removeAllRanges();
     activitySummary.click();
 
-    expect(onToggleToolMessageExpanded).toHaveBeenCalledWith("activity:tool-group", true);
+    expect(onToggleToolMessageExpanded).toHaveBeenCalledWith("activity:tool-group", false);
     container.remove();
   });
 
-  it("keeps recovered grouped activity collapsed while retaining its failure summary", () => {
+  it("keeps recovered grouped activity collapsed without a failure summary", () => {
     const container = document.createElement("div");
-    const group = createToolGroup(
-      "tool-group",
-      [
-        createMessageEntry(
-          "tool-message-1",
-          createToolResultMessage("call-1", "web_search", JSON.stringify({ error: "No matches" }), {
-            isError: true,
-            timestamp: 1000,
-          }),
-        ),
-        createMessageEntry(
-          "tool-message-2",
-          createToolResultMessage("call-2", "read_file", "Fallback context", {
-            timestamp: 1001,
-          }),
-        ),
-      ],
-      { turnSucceeded: true },
-    );
+    const group = createToolGroup("tool-group", [
+      createMessageEntry(
+        "tool-message-1",
+        createToolResultMessage("call-1", "web_search", JSON.stringify({ error: "No matches" }), {
+          isError: true,
+          timestamp: 1000,
+        }),
+      ),
+      createMessageEntry(
+        "tool-message-2",
+        createToolResultMessage("call-2", "read_file", "Fallback context", {
+          timestamp: 1001,
+        }),
+      ),
+    ]);
 
     renderMessageGroups(container, [group]);
 
     expect(container.querySelector(".chat-activity-group.is-open")).toBeNull();
     expect(container.querySelector(".chat-activity-group__summary--error")).toBeNull();
-    expect(container.querySelector(".chat-activity-group__label")?.textContent).toContain(
-      "1 failed",
+    expect(container.querySelector(".chat-activity-group__label")?.textContent).not.toContain(
+      "failed",
     );
     expect(container.querySelector(".chat-tool-msg-body")).toBeNull();
   });
 
   it("keeps recovered coalesced tool failures neutral in the activity list", () => {
     const container = document.createElement("div");
-    const group = createToolGroup(
-      "recovered-tool-group",
-      [
-        createMessageEntry(
-          "recovered-tool-message",
-          createAssistantMessage(
-            [
-              {
-                type: "tool_use",
-                id: "call-recovered",
-                name: "bash",
-                input: { command: "run fallback" },
-              },
-              createToolResultBlock("call-recovered", "bash", "Primary path failed", {
-                isError: true,
-              }),
-            ],
-            { isError: true, timestamp: 1000 },
-          ),
+    const group = createToolGroup("recovered-tool-group", [
+      createMessageEntry(
+        "recovered-tool-message",
+        createAssistantMessage(
+          [
+            {
+              type: "tool_use",
+              id: "call-recovered",
+              name: "bash",
+              input: { command: "run fallback" },
+            },
+            createToolResultBlock("call-recovered", "bash", "Primary path failed", {
+              isError: true,
+            }),
+          ],
+          { isError: true, timestamp: 1000 },
         ),
-        createMessageEntry(
-          "recovered-followup",
-          createToolResultMessage("call-followup", "read_file", "Fallback context", {
-            timestamp: 1001,
-          }),
-        ),
-      ],
-      { turnSucceeded: true },
-    );
+      ),
+      createMessageEntry(
+        "recovered-followup",
+        createToolResultMessage("call-followup", "read_file", "Fallback context", {
+          timestamp: 1001,
+        }),
+      ),
+    ]);
 
     renderMessageGroups(container, [group], {
       isToolMessageExpanded: (id) => id === "activity:recovered-tool-group",
@@ -2540,10 +2519,10 @@ describe("grouped chat rendering", () => {
     const summaries = container.querySelectorAll(".chat-tool-msg-summary");
     expect(summaries).toHaveLength(2);
     expect(container.querySelector(".chat-activity-group__summary--error")).toBeNull();
-    expect(container.querySelector(".chat-activity-group__label")?.textContent).toContain(
-      "1 failed",
+    expect(container.querySelector(".chat-activity-group__label")?.textContent).not.toContain(
+      "failed",
     );
-    expect(container.querySelectorAll(".chat-tool-msg-summary--error")).toHaveLength(1);
+    expect(container.querySelectorAll(".chat-tool-msg-summary--error")).toHaveLength(0);
     expect(container.querySelector(".chat-tool-row__badge")?.textContent).toBe("failed");
     // Command calls render a `$ command` row instead of the tool-name label.
     expect(summaries[0]?.querySelector(".chat-tool-row__cmd")?.textContent).toBe("run fallback");
@@ -2848,7 +2827,7 @@ describe("grouped chat rendering", () => {
     expect(summary.querySelector(".chat-tool-msg-summary__error-badge")).toBeNull();
   });
 
-  it("marks status-only standalone tool-result summaries as errors", () => {
+  it("marks status-only standalone tool-result summaries with only a failed badge", () => {
     const container = document.createElement("div");
     document.body.append(container);
     const onToggleToolMessageExpanded = vi.fn();
@@ -2870,10 +2849,12 @@ describe("grouped chat rendering", () => {
     });
 
     let summary = expectElement(container, ".chat-tool-msg-summary", HTMLButtonElement);
-    expect(summary.classList.contains("chat-tool-msg-summary--error")).toBe(true);
-    expect(summary.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Tool error");
-    expect(summary.querySelector(".chat-tool-msg-summary__names")?.textContent).toBe("Sub-agent");
-    expect(summary.querySelector(".chat-tool-msg-summary__error-badge")).toBeNull();
+    expect(summary.classList.contains("chat-tool-msg-summary--error")).toBe(false);
+    expect(summary.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Tool output");
+    expect(summary.querySelector(".chat-tool-msg-summary__names")?.textContent).toBe(
+      "sessions_spawn",
+    );
+    expect(summary.querySelector(".chat-tool-row__badge")?.textContent).toBe("failed");
     selectText(expectElement(summary, ".chat-tool-msg-summary__label", HTMLElement));
     pointerClick(summary);
     expect(onToggleToolMessageExpanded).not.toHaveBeenCalled();
@@ -2887,39 +2868,13 @@ describe("grouped chat rendering", () => {
     });
 
     summary = expectElement(container, ".chat-tool-msg-summary", HTMLButtonElement);
-    expect(summary.classList.contains("chat-tool-msg-summary--error")).toBe(true);
-    expect(summary.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Tool error");
+    expect(summary.classList.contains("chat-tool-msg-summary--error")).toBe(false);
+    expect(summary.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Tool output");
+    expect(summary.querySelector(".chat-tool-row__badge")?.textContent).toBe("failed");
     expect(
       JSON.parse(container.querySelector(".chat-json-content code")?.textContent ?? "{}"),
     ).toEqual({ status: "error" });
     container.remove();
-  });
-
-  it("keeps succeeded standalone tool-result summaries collapsed without error styling", () => {
-    const container = document.createElement("div");
-    const groups = [
-      {
-        ...createMessageGroup(
-          createToolResultMessage(
-            "call-status-error",
-            "sessions_spawn",
-            JSON.stringify({ status: "error" }, null, 2),
-            { id: "tool-status-error" },
-          ),
-          "tool",
-        ),
-        turnSucceeded: true,
-      },
-    ];
-
-    renderMessageGroups(container, groups, {
-      isToolMessageExpanded: () => false,
-    });
-
-    const summary = expectElement(container, ".chat-tool-msg-summary", HTMLButtonElement);
-    expect(summary.classList.contains("chat-tool-msg-summary--error")).toBe(false);
-    expect(summary.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Tool output");
-    expect(summary.querySelector(".chat-tool-msg-summary__error-badge")).toBeNull();
   });
 
   it("collapses an inline tool call while keeping matching tool output visible", () => {

--- a/ui/src/pages/chat/components/chat-tool-cards.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.test.ts
@@ -339,9 +339,7 @@ describe("tool-cards", () => {
         expect(container.querySelector(".chat-tool-row__badge")?.textContent === "failed").toBe(
           state.failed,
         );
-        expect(container.querySelector(".chat-tool-msg-summary--error") !== null).toBe(
-          state.failed,
-        );
+        expect(container.querySelector(".chat-tool-msg-summary--error")).toBeNull();
       }
     }
   });
@@ -800,7 +798,7 @@ describe("tool-cards", () => {
     expect(sidebar.entryUrl).toBe("/__openclaw__/canvas/documents/cv_sidebar/index.html");
   });
 
-  it("renders an error summary without a redundant Error badge", () => {
+  it("renders error details with only a failed summary badge", () => {
     const container = document.createElement("div");
     render(
       renderToolCard(
@@ -819,14 +817,12 @@ describe("tool-cards", () => {
       container,
     );
 
-    expect(container.textContent).toContain("Tool error");
-    expect(container.textContent).not.toMatch(/\bTool output\b/);
     const summaryButton = container.querySelector("button.chat-tool-msg-summary");
-    expect(summaryButton?.classList.contains("chat-tool-msg-summary--error")).toBe(true);
+    expect(summaryButton?.classList.contains("chat-tool-msg-summary--error")).toBe(false);
     expect(summaryButton?.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe(
-      "Tool error",
+      "Web Search",
     );
-    expect(container.querySelector(".chat-tool-msg-summary__error-badge")).toBeNull();
+    expect(summaryButton?.querySelector(".chat-tool-row__badge")?.textContent).toBe("failed");
     const expandedCard = container.querySelector(".chat-tool-card");
     expect(expandedCard?.classList.contains("chat-tool-card--error")).toBe(true);
     expect(container.querySelector(".chat-tool-card__status-badge")).toBeNull();
@@ -837,7 +833,7 @@ describe("tool-cards", () => {
     ).toContain("Tool error");
   });
 
-  it("renders a Tool error label when output has a status-only error payload", () => {
+  it("renders a neutral summary for a status-only error payload", () => {
     const container = document.createElement("div");
     render(
       renderToolCard(
@@ -851,13 +847,14 @@ describe("tool-cards", () => {
       container,
     );
 
-    expect(container.textContent).toContain("Tool error");
-    expect(container.textContent).not.toMatch(/\bTool output\b/);
-    expect(container.querySelector(".chat-tool-msg-summary--error")).not.toBeNull();
+    const summary = container.querySelector(".chat-tool-msg-summary");
+    expect(summary?.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Sub-agent");
+    expect(summary?.querySelector(".chat-tool-row__badge")?.textContent).toBe("failed");
+    expect(container.querySelector(".chat-tool-msg-summary--error")).toBeNull();
     expect(container.querySelector(".chat-tool-card--error")).not.toBeNull();
   });
 
-  it("renders a Tool error label when output is the literal 'Tool not found'", () => {
+  it("renders a neutral summary when output is the literal 'Tool not found'", () => {
     const container = document.createElement("div");
     render(
       renderToolCard(
@@ -871,14 +868,15 @@ describe("tool-cards", () => {
       container,
     );
 
-    expect(container.textContent).toContain("Tool error");
-    expect(container.textContent).not.toMatch(/\bTool output\b/);
     const summaryButton = container.querySelector("button.chat-tool-msg-summary");
-    expect(summaryButton?.classList.contains("chat-tool-msg-summary--error")).toBe(true);
-    expect(container.querySelector(".chat-tool-msg-summary__error-badge")).toBeNull();
+    expect(summaryButton?.classList.contains("chat-tool-msg-summary--error")).toBe(false);
+    expect(summaryButton?.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe(
+      "Unknown",
+    );
+    expect(summaryButton?.querySelector(".chat-tool-row__badge")?.textContent).toBe("failed");
   });
 
-  it("renders a Tool error label when the tool card has an explicit error flag", () => {
+  it("renders a neutral summary when the tool card has an explicit error flag", () => {
     const container = document.createElement("div");
     render(
       renderToolCard(
@@ -893,9 +891,10 @@ describe("tool-cards", () => {
       container,
     );
 
-    expect(container.textContent).toContain("Tool error");
-    expect(container.textContent).not.toMatch(/\bTool output\b/);
-    expect(container.querySelector(".chat-tool-msg-summary--error")).not.toBeNull();
+    const summary = container.querySelector(".chat-tool-msg-summary");
+    expect(summary?.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Lookup");
+    expect(summary?.querySelector(".chat-tool-row__badge")?.textContent).toBe("failed");
+    expect(container.querySelector(".chat-tool-msg-summary--error")).toBeNull();
     expect(container.querySelector(".chat-tool-card--error")).not.toBeNull();
   });
 

--- a/ui/src/pages/chat/components/chat-tool-cards.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.ts
@@ -335,10 +335,9 @@ function renderToolRowContent(card: ToolCard, view: ToolCallView, outcome: ToolC
     card,
     displayLabel: display.label,
     displayDetail: display.detail,
-    isError: outcome === "failed",
   });
   const displayLabel = formatCollapsedToolSummaryText(summary.label) ?? summary.label;
-  const argumentPreview = outcome === "failed" ? undefined : toolArgumentPreview(card.args);
+  const argumentPreview = toolArgumentPreview(card.args);
   const displayName = distinctSummaryText(argumentPreview ?? summary.name, displayLabel);
   const aiTitle = getToolCallTitle(card.name, card.args);
   if (aiTitle) {
@@ -566,12 +565,7 @@ function resolveCollapsedToolSummaryParts(params: {
   card: ToolCard;
   displayLabel: string;
   displayDetail: string | undefined;
-  isError: boolean;
 }): { label: string; name?: string } {
-  if (params.isError) {
-    return { label: t("chat.toolCards.toolError"), name: params.displayLabel };
-  }
-
   const displayDetail = params.displayDetail?.trim();
   if (displayDetail) {
     return { label: params.displayLabel, name: displayDetail };
@@ -634,9 +628,7 @@ export function renderToolCard(
         : ""}"
     >
       <button
-        class="chat-tool-msg-summary chat-tool-row ${isError
-          ? "chat-tool-msg-summary--error"
-          : ""} ${isRunning ? "chat-tool-row--running" : ""}"
+        class="chat-tool-msg-summary chat-tool-row ${isRunning ? "chat-tool-row--running" : ""}"
         type="button"
         aria-expanded=${String(opts.expanded)}
         @click=${(event: MouseEvent) => {

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -131,7 +131,7 @@ function chatRenderItemGuardDependencies(item: ChatRenderItem): readonly unknown
     return [item.key, ...item.parts];
   }
   if (item.kind === "work-group") {
-    return [item.key, item.durationMs, item.hasError, ...item.groups];
+    return [item.key, item.durationMs, ...item.groups];
   }
   if (item.kind === "activity-run") {
     return [item.key, ...item.groups];
@@ -465,7 +465,7 @@ export function projectChatTranscript(
       });
     }
     if (item.kind === "work-group") {
-      const workExpanded = expandedToolCards.get(item.key) ?? item.hasError;
+      const workExpanded = expandedToolCards.get(item.key) ?? false;
       return html`
         ${renderWorkGroupSummary(item, {
           expanded: workExpanded,

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -121,11 +121,6 @@
   color: color-mix(in srgb, var(--muted) 82%, var(--text) 18%);
 }
 
-.chat-tool-msg-summary--error .chat-tool-msg-summary__icon,
-.chat-tool-msg-summary--error .chat-tool-msg-summary__label {
-  color: var(--destructive, var(--danger, #c0392b));
-}
-
 /* ── Kind-aware tool rows ── */
 .chat-tool-row__prompt {
   flex-shrink: 0;
@@ -1032,10 +1027,6 @@
   background: color-mix(in srgb, var(--bg-hover) 60%, transparent);
 }
 
-.chat-activity-group__summary--error {
-  color: var(--destructive, var(--danger, #c0392b));
-}
-
 .chat-activity-group__icon {
   display: inline-flex;
   align-items: center;
@@ -1045,10 +1036,6 @@
 
 .chat-activity-group__icon {
   color: var(--muted);
-}
-
-.chat-activity-group__summary--error .chat-activity-group__icon {
-  color: inherit;
 }
 
 .chat-activity-group__icon svg {
@@ -1104,10 +1091,6 @@
 
 .chat-work-group .chat-activity-group__label {
   color: var(--muted);
-}
-
-.chat-work-group .chat-activity-group__summary--error .chat-activity-group__label {
-  color: inherit;
 }
 
 /* Reading indicator = working claw: the brand pincer claws in place where the


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing a chain of tool calls would see the entire chain rendered as failed when one call failed. The chain header, error icon, failure summary, and automatic expansion made routine recoverable tool failures look like a turn-level problem.

## Why This Change Was Made

Tool chains and tool rows now keep neutral presentation while the individual failed call retains its `failed` badge and expandable diagnostic output. The change also removes the turn-level failure aggregation and forced-expansion paths that existed only to drive chain-level error chrome.

## User Impact

Routine tool failures remain visible on the call that produced them without making the surrounding tool chain look broken. Users can inspect the failed call while later recovery calls and the overall activity stay visually neutral.

## Evidence

**Before:** one failed call marks the row with a red error icon and `Tool error` header.

![Before: tool failure marks the full row as an error](https://github.com/user-attachments/assets/848dc715-6dc7-4ced-bf89-79854a1da335)

**After:** the row and chain remain neutral; only the individual `failed` badge remains.

![After: only the failed call badge shows failure](https://github.com/user-attachments/assets/416c6917-fed7-4ac5-b971-458bffcced22)

- Focused unit and browser coverage: 483 tests passed.
- Control UI E2E coverage: 6 tests passed, including the before/after failure fixture.
- `node scripts/check-changed.mjs`: passed on Testbox `tbx_01kzv69jrnwjr7hf36s4a6a86k`, including formatting, i18n verification, TypeScript checks, dead-export checks, and lint ([run](https://github.com/openclaw/openclaw/actions/runs/31607466049)).
- Production delta: 29 additions, 177 deletions (net -148 lines).

AI-assisted: yes. I reviewed the implementation, rebase integration, regression coverage, and rendered behavior.
