### PR TITLE
refactor(providers): flatten Cohere, Meta, and Fireworks stream wrappers

### DIFF
--- a/extensions/cohere/index.test.ts
+++ b/extensions/cohere/index.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from "vitest";
 import plugin from "./index.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 import { COHERE_LIVE_MODEL_DISCOVERY } from "./provider-catalog.js";
-import { createCohereCompletionsWrapper } from "./stream.js";
+import { wrapCohereProviderStream } from "./stream.js";
 
 const COHERE_COMMAND_A_PLUS_MODEL_ID = "command-a-plus-05-2026";
 const COHERE_COMMAND_A_REASONING_MODEL_ID = "command-a-reasoning-08-2025";
@@ -50,11 +50,17 @@ function captureCoherePayload(
     return {} as ReturnType<StreamFn>;
   };
 
-  const wrappedStreamFn = createCohereCompletionsWrapper(baseStreamFn);
+  const model = requireCohereModel(settings?.modelId);
+  const wrappedStreamFn = wrapCohereProviderStream({
+    provider: "cohere",
+    modelId: model.id,
+    model,
+    streamFn: baseStreamFn,
+  });
   if (!wrappedStreamFn) {
     throw new Error("Cohere wrapper did not return a stream function");
   }
-  void wrappedStreamFn(requireCohereModel(settings?.modelId), context, {
+  void wrappedStreamFn(model, context, {
     onPayload: (payload) => {
       captured = payload as Record<string, unknown>;
     },

--- a/extensions/cohere/index.ts
+++ b/extensions/cohere/index.ts
@@ -3,7 +3,7 @@ import { isModernCohereModelId } from "./models.js";
 import { applyCohereConfig } from "./onboard.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 import { COHERE_LIVE_MODEL_DISCOVERY } from "./provider-catalog.js";
-import { createCohereCompletionsWrapper } from "./stream.js";
+import { wrapCohereProviderStream } from "./stream.js";
 
 export default defineSingleProviderPluginEntry({
   id: "cohere",
@@ -17,8 +17,8 @@ export default defineSingleProviderPluginEntry({
     catalog: {
       liveModelDiscovery: COHERE_LIVE_MODEL_DISCOVERY,
     },
-    wrapStreamFn: (ctx) => createCohereCompletionsWrapper(ctx.streamFn),
-    wrapSimpleCompletionStreamFn: (ctx) => createCohereCompletionsWrapper(ctx.streamFn),
+    wrapStreamFn: wrapCohereProviderStream,
+    wrapSimpleCompletionStreamFn: wrapCohereProviderStream,
     isModernModelRef: ({ modelId }) => isModernCohereModelId(modelId),
   },
 });

--- a/extensions/cohere/stream.ts
+++ b/extensions/cohere/stream.ts
@@ -1,26 +1,20 @@
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
 import { createPayloadPatchStreamWrapper } from "openclaw/plugin-sdk/provider-stream-shared";
 
-function patchCoherePayload(payload: Record<string, unknown>): void {
-  // Cohere's Compatibility API uses developer, not system, for instructions.
-  if (Array.isArray(payload.messages)) {
-    payload.messages = payload.messages.map((message) =>
-      message &&
-      typeof message === "object" &&
-      (message as Record<string, unknown>).role === "system"
-        ? { ...(message as Record<string, unknown>), role: "developer" }
-        : message,
-    );
-  }
+export function wrapCohereProviderStream(ctx: ProviderWrapStreamFnContext) {
+  return createPayloadPatchStreamWrapper(ctx.streamFn, ({ payload }) => {
+    // Cohere's Compatibility API uses developer, not system, for instructions.
+    if (Array.isArray(payload.messages)) {
+      payload.messages = payload.messages.map((message) =>
+        message &&
+        typeof message === "object" &&
+        (message as Record<string, unknown>).role === "system"
+          ? { ...(message as Record<string, unknown>), role: "developer" }
+          : message,
+      );
+    }
 
-  // Cohere lets tool-capable models choose a tool when tool_choice is omitted.
-  delete payload.tool_choice;
-}
-
-export function createCohereCompletionsWrapper(
-  baseStreamFn: ProviderWrapStreamFnContext["streamFn"],
-): ProviderWrapStreamFnContext["streamFn"] {
-  return createPayloadPatchStreamWrapper(baseStreamFn, ({ payload }) =>
-    patchCoherePayload(payload),
-  );
+    // Cohere lets tool-capable models choose a tool when tool_choice is omitted.
+    delete payload.tool_choice;
+  });
 }

--- a/extensions/fireworks/stream.test.ts
+++ b/extensions/fireworks/stream.test.ts
@@ -37,7 +37,7 @@ function capturePayload(params: {
   return captured;
 }
 
-describe("createFireworksKimiThinkingDisabledWrapper", () => {
+describe("wrapFireworksProviderStream", () => {
   it("forces thinking disabled for Fireworks Kimi models", () => {
     expect(
       capturePayload({

--- a/extensions/fireworks/stream.ts
+++ b/extensions/fireworks/stream.ts
@@ -10,17 +10,6 @@ function isFireworksProviderId(providerId: string): boolean {
   return normalized === "fireworks" || normalized === "fireworks-ai";
 }
 
-function createFireworksKimiThinkingDisabledWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
-  return createPayloadPatchStreamWrapper(baseStreamFn, ({ payload }) => {
-    // Fireworks Kimi can emit chain-of-thought in visible `content` unless
-    // the Anthropic-style thinking toggle is explicitly disabled.
-    payload.thinking = { type: "disabled" };
-    delete payload.reasoning;
-    delete payload.reasoning_effort;
-    delete payload.reasoningEffort;
-  });
-}
-
 export function wrapFireworksProviderStream(
   ctx: ProviderWrapStreamFnContext,
 ): StreamFn | undefined {
@@ -31,5 +20,12 @@ export function wrapFireworksProviderStream(
   ) {
     return undefined;
   }
-  return createFireworksKimiThinkingDisabledWrapper(ctx.streamFn);
+  return createPayloadPatchStreamWrapper(ctx.streamFn, ({ payload }) => {
+    // Fireworks Kimi can emit chain-of-thought in visible `content` unless
+    // the Anthropic-style thinking toggle is explicitly disabled.
+    payload.thinking = { type: "disabled" };
+    delete payload.reasoning;
+    delete payload.reasoning_effort;
+    delete payload.reasoningEffort;
+  });
 }

--- a/extensions/meta/stream.ts
+++ b/extensions/meta/stream.ts
@@ -6,18 +6,11 @@ import { filterStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 const META_REASONING_ENCRYPTED_CONTENT_INCLUDE = "reasoning.encrypted_content";
 
-function ensureMetaResponsesReplayFields(payloadObj: Record<string, unknown>): void {
-  const existing = payloadObj.include;
-  const include = filterStringEntries(existing);
-  if (!include.includes(META_REASONING_ENCRYPTED_CONTENT_INCLUDE)) {
-    include.push(META_REASONING_ENCRYPTED_CONTENT_INCLUDE);
+export function wrapMetaProviderStream(ctx: ProviderWrapStreamFnContext): StreamFn | undefined {
+  if (ctx.provider !== "meta" || (ctx.sourceApi ?? ctx.model?.api) !== "openai-responses") {
+    return undefined;
   }
-  payloadObj.include = include;
-  payloadObj.store = false;
-}
-
-function createMetaResponsesWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
-  return createPayloadPatchStreamWrapper(baseStreamFn, ({ payload, model, options }) => {
+  return createPayloadPatchStreamWrapper(ctx.streamFn, ({ payload, model, options }) => {
     if (model.provider !== "meta") {
       return;
     }
@@ -29,13 +22,11 @@ function createMetaResponsesWrapper(baseStreamFn: StreamFn | undefined): StreamF
     if (!model.reasoning) {
       return;
     }
-    ensureMetaResponsesReplayFields(payload);
+    const include = filterStringEntries(payload.include);
+    if (!include.includes(META_REASONING_ENCRYPTED_CONTENT_INCLUDE)) {
+      include.push(META_REASONING_ENCRYPTED_CONTENT_INCLUDE);
+    }
+    payload.include = include;
+    payload.store = false;
   });
-}
-
-export function wrapMetaProviderStream(ctx: ProviderWrapStreamFnContext): StreamFn | undefined {
-  if (ctx.provider !== "meta" || (ctx.sourceApi ?? ctx.model?.api) !== "openai-responses") {
-    return undefined;
-  }
-  return createMetaResponsesWrapper(ctx.streamFn);
 }


### PR DESCRIPTION
## What Problem This Solves

Cohere, Meta, and Fireworks stream registrations each carried private one-use factory or payload-patch layers around the existing shared payload-wrapper owner. That indirection obscured the registered provider hook without adding a reusable contract.

## Why This Change Was Made

This flattens each provider at its existing ownership boundary: Cohere registers one clear `ProviderWrapStreamFnContext` hook for both stream paths, Meta keeps `wrapMetaProviderStream` while inlining its private replay/payload layers, and Fireworks composes the shared payload patch directly after its existing provider/API/model guards. Plugin SDK APIs, public exports, wrapper order, aliases, payload mutations, replay fields, and model semantics are unchanged.

Production LOC: +36/-55 (net -19) | Tests: +10/-4 (net +6)

## User Impact

No user-visible behavior change. Cohere still maps system instructions to developer messages and removes `tool_choice`; Meta still preserves its Responses cap and encrypted-reasoning replay fields; Fireworks Kimi requests still normalize aliases, force thinking off, and remove all reasoning fields.

AI-assisted: yes.

## Evidence

- `node scripts/run-vitest.mjs extensions/cohere/index.test.ts extensions/meta/index.test.ts extensions/fireworks/index.test.ts extensions/fireworks/stream.test.ts` — 37 tests passed across 4 files after rebasing onto current `origin/main`.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs --timed -- <six changed paths>` — complete `extensions, extensionTests` changed-path gate passed locally, including format, SDK API, boundaries, dead exports, extension production/test typechecks, oxlint, and import cycles. The normal Crabbox delegation was unavailable before dispatch in the orb, so the same gate used its local trusted-source fallback.
- `oxfmt --check --threads=1 <six changed paths>` and `git diff --check origin/main...HEAD` — passed on exact head.
- TruffleHog 3.96.0 autoreview preflight — clean on exact branch diff.
- Structured Codex autoreview was attempted twice but could not start because the orb has no trusted `codex` executable; no model-review result is claimed.
- Live open-PR searches for the three providers, exact paths, and `createPayloadPatchStreamWrapper` found no scoped path overlap; the only symbol-search candidate, #116016, changes unrelated provider-catalog files.
