### PR TITLE
fix(telegram): guard thread-spec resolution against chat-less updates

### DIFF
--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -423,18 +423,18 @@ export function resolveTelegramMessageThreadSpec(
   message: Message,
   isForum?: boolean,
 ): TelegramThreadSpec {
-  if (message.chat.is_direct_messages === true) {
+  if (message.chat?.is_direct_messages === true) {
     const id = parseStrictPositiveInteger(message.direct_messages_topic?.topic_id);
     return id === undefined ? { scope: "none" } : { id, scope: "direct-messages" };
   }
-  const isGroup = message.chat.type === "group" || message.chat.type === "supergroup";
+  const isGroup = message.chat?.type === "group" || message.chat?.type === "supergroup";
   return resolveTelegramThreadSpec({
     isGroup,
     isForum:
       isForum ??
       resolveTelegramMessageForumFlagHint({
-        chatType: message.chat.type,
-        isForum: message.chat.is_forum,
+        chatType: message.chat?.type,
+        isForum: message.chat?.is_forum,
         isTopicMessage: message.is_topic_message,
       }),
     messageThreadId: message.message_thread_id,


### PR DESCRIPTION
## What Problem This Solves

Fixes a crash where Telegram ingress processing throws
`TypeError: Cannot read properties of undefined (reading 'is_direct_messages')`
when a spooled update's message lacks a `chat` field. The webhook and polling
ingress paths compute a sequential lane key on the raw update payload before bot
normalization; `resolveTelegramMessageThreadSpec` assumed `message.chat` always
exists and crashed, causing webhook deliveries to respond 500 (Telegram
redelivers) and polling spool entries to fail enqueue.

## Why This Change Was Made

`resolveTelegramMessageThreadSpec` now reads `chat` defensively with optional
chaining across `is_direct_messages`, `type`, and `is_forum`. When `chat` is
absent the thread spec degrades to the existing no-thread fallback instead of
throwing. Real Telegram payloads always carry `chat`, so behavior for valid
traffic is unchanged; this only hardens the pre-normalization raw-payload path.

## User Impact

Telegram webhook updates with malformed or pre-normalization payloads no longer
crash lane-key resolution: webhook handlers stop returning 500 on this path, and
isolated ingress spooling works for chat-less messages.

## Evidence

- `extensions/telegram/src/webhook.test.ts` + `polling-session.test.ts`: 194/194
  passed (these two files were 26 tests red on `main` before this change; the
  extension-telegram lane is not covered by CI).
- `pnpm check` → exit 0; `pnpm build` → exit 0 (run locally on this branch).

AI-assisted PR: written with an AI coding agent; I understand the change and
validated it as above.
