### PR TITLE
fix(scripts): detect symlinked plugin SDK API barrels

### DIFF
--- a/scripts/lib/extension-wildcard-reexport-scanner.mts
+++ b/scripts/lib/extension-wildcard-reexport-scanner.mts
@@ -21,6 +21,17 @@ export type ExtensionWildcardReexportPolicy = {
   remediationMessage: string;
 };
 
+async function isFileFollowingLinks(filePath: string): Promise<boolean> {
+  try {
+    return (await fs.stat(filePath)).isFile();
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
 async function listGuardedFiles(policy: ExtensionWildcardReexportPolicy) {
   const files: string[] = [];
   const recursive = policy.fileScope === "all-extension-api-files";
@@ -39,7 +50,12 @@ async function listGuardedFiles(policy: ExtensionWildcardReexportPolicy) {
         await visit(filePath, depth + 1);
         continue;
       }
-      if ((recursive || depth === 1) && entry.isFile() && guardedFileNames.has(entry.name)) {
+      if (!guardedFileNames.has(entry.name) || (!recursive && depth !== 1)) {
+        continue;
+      }
+      // The root-only SDK guard historically follows API barrel symlinks; the
+      // recursive local-barrel guard intentionally retains Dirent semantics.
+      if (recursive ? entry.isFile() : await isFileFollowingLinks(filePath)) {
         files.push(filePath);
       }
     }

--- a/test/scripts/check-plugin-sdk-wildcard-reexports.test.ts
+++ b/test/scripts/check-plugin-sdk-wildcard-reexports.test.ts
@@ -1,6 +1,12 @@
 // Check Plugin Sdk Wildcard Reexports tests cover check plugin sdk wildcard reexports script behavior.
-import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { copyFileSync, mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import { findPluginSdkWildcardReexports } from "../../scripts/check-plugin-sdk-wildcard-reexports.mts";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("check-plugin-sdk-wildcard-reexports", () => {
   it("flags wildcard re-exports from plugin-sdk subpaths", () => {
@@ -33,5 +39,51 @@ describe("check-plugin-sdk-wildcard-reexports", () => {
         ].join("\n"),
       ),
     ).toStrictEqual([]);
+  });
+
+  it("follows extension-root API barrel symlinks", () => {
+    const root = tempDirs.make("openclaw-plugin-sdk-wildcard-");
+    const scriptsDir = path.join(root, "scripts");
+    const scriptsLibDir = path.join(scriptsDir, "lib");
+    const extensionDir = path.join(root, "extensions", "fixture");
+    mkdirSync(scriptsLibDir, { recursive: true });
+    mkdirSync(extensionDir, { recursive: true });
+    writeFileSync(path.join(root, "package.json"), '{"type":"module"}\n');
+    writeFileSync(path.join(root, "pnpm-workspace.yaml"), "packages: []\n");
+    copyFileSync(
+      new URL("../../scripts/check-plugin-sdk-wildcard-reexports.mts", import.meta.url),
+      path.join(scriptsDir, "check-plugin-sdk-wildcard-reexports.mts"),
+    );
+    for (const fileName of ["extension-wildcard-reexport-scanner.mts", "repo-root.mjs"]) {
+      copyFileSync(
+        new URL(`../../scripts/lib/${fileName}`, import.meta.url),
+        path.join(scriptsLibDir, fileName),
+      );
+    }
+    writeFileSync(
+      path.join(extensionDir, "actual-api.ts"),
+      'export * from "openclaw/plugin-sdk/foo";\n',
+    );
+    symlinkSync("actual-api.ts", path.join(extensionDir, "api.ts"));
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--import",
+        import.meta.resolve("tsx"),
+        path.join(scriptsDir, "check-plugin-sdk-wildcard-reexports.mts"),
+        "--json",
+      ],
+      { cwd: root, encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(1);
+    expect(JSON.parse(result.stdout)).toEqual([
+      {
+        file: "extensions/fixture/api.ts",
+        line: 1,
+        text: 'export * from "openclaw/plugin-sdk/foo";',
+      },
+    ]);
   });
 });

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -969,6 +969,7 @@ describe("scripts/test-projects changed-target routing", () => {
 
   it.each([
     "test/scripts/check-extension-package-tsc-boundary.test.ts",
+    "test/scripts/check-plugin-sdk-wildcard-reexports.test.ts",
     "test/scripts/control-ui-i18n.test.ts",
   ])("routes process-group test %s to the isolated tooling shard", (testFile) => {
     expectSingleVitestRunPlan(buildVitestRunPlans([testFile]), {
@@ -1370,6 +1371,7 @@ describe("scripts/test-projects changed-target routing", () => {
         forwardedArgs: [],
         includePatterns: [
           "test/scripts/check-extension-package-tsc-boundary.test.ts",
+          "test/scripts/check-plugin-sdk-wildcard-reexports.test.ts",
           "test/scripts/control-ui-i18n.test.ts",
           "test/scripts/openclaw-e2e-instance.test.ts",
         ],
@@ -1556,6 +1558,7 @@ describe("scripts/test-projects changed-target routing", () => {
         forwardedArgs: [],
         includePatterns: [
           "test/scripts/check-extension-package-tsc-boundary.test.ts",
+          "test/scripts/check-plugin-sdk-wildcard-reexports.test.ts",
           "test/scripts/control-ui-i18n.test.ts",
           "test/scripts/openclaw-e2e-instance.test.ts",
         ],

--- a/test/vitest/vitest.tooling-isolated-paths.mjs
+++ b/test/vitest/vitest.tooling-isolated-paths.mjs
@@ -4,6 +4,7 @@ export const toolingIsolatedTestFiles = [
   "test/plugins/bundled-provider-auth-literal-parity.2.test.ts",
   "test/plugins/bundled-provider-auth-literal-parity.3.test.ts",
   "test/scripts/check-extension-package-tsc-boundary.test.ts",
+  "test/scripts/check-plugin-sdk-wildcard-reexports.test.ts",
   "test/scripts/control-ui-i18n.test.ts",
   "test/scripts/openclaw-e2e-instance.test.ts",
 ];


### PR DESCRIPTION
Related: #122685

## What Problem This Solves

Fixes an issue where the Plugin SDK wildcard-reexport guard skipped a symlinked extension-root `api.ts` or `runtime-api.ts` barrel after scanner consolidation. That could let a prohibited wildcard SDK export pass the repository guard unnoticed.

## Why This Change Was Made

The root-only scanner now restores its previous `fs.stat` behavior, following file symlinks and ignoring broken links, while the recursive local-barrel scanner intentionally retains its prior `Dirent.isFile()` semantics. A subprocess test exercises the real command against a temporary repository with a symlinked API barrel. Because that regression now owns filesystem and child-process state, it is routed through the existing tooling-isolated config rather than changing the weighted tooling stripe inventory. The direct route and both full/glob planner expectations pin that owner.

## User Impact

No product runtime behavior changes. Maintainers regain the complete pre-consolidation guard coverage for symlinked extension API barrels.

## Evidence

- Reproduction before the fix: the command returned `[]` and exit 0 for a symlinked violating `api.ts`; the new regression test failed with expected status 1 versus received 0.
- `node scripts/run-vitest.mjs test/scripts/check-extension-wildcard-reexports.test.ts test/scripts/check-plugin-sdk-wildcard-reexports.test.ts test/scripts/ci-node-test-plan.test.ts test/scripts/test-projects.test.ts` — 275/275 passed across unit-fast, tooling-isolated, and tooling configs.
- The first PR-head CI exposed that filesystem/subprocess imports moved the test out of unit-fast into weighted tooling discovery, making stripe sizes 101/103/102/102. The isolated owner restores the intended routing. The next CI run exposed two stale expected full plans; both expectations and the direct route are now covered and green locally.
- Full changed-path scripts/test-root/tooling gate passed, including script and test typechecks, targeted lint, formatter, both wildcard guards, duplicate/coercion/dependency/patch checks, Docker-E2E boundary, and raw HTTP/2 guard.
- Targeted `oxfmt --check` and `git diff --check` passed.
- Fresh exact-diff TruffleHog scan passed. Structured Codex autoreview did not return a model verdict. Final independent review at exact head found no P0–P3 issues, verified all three routing expectations, and returned best-fix and test-audit pass verdicts.
- Exact-head GitHub CI run https://github.com/openclaw/openclaw/actions/runs/31616855401 passed at `c7324bbd3fb6acc76927ae8564a71975e2819a46`; required `openclaw/ci-gate` is green. One unrelated Kitchen Sink process-timeout test failed on the first attempt and passed when the failed job was rerun unchanged.


