### PR TITLE
fix(agents): preserve session classification

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -435,8 +435,9 @@ describe("sessions tools", () => {
           path: "/tmp/sessions.json",
           sessions: [
             {
-              key: "main",
+              key: "agent:main:main",
               kind: "direct",
+              classification: "main",
               sessionId: "s-main",
               updatedAt: 10,
               lastChannel: "whatsapp",
@@ -444,8 +445,10 @@ describe("sessions tools", () => {
               lastMessagePreview: "Latest assistant update",
             },
             {
-              key: "discord:group:dev",
+              key: "agent:main:discord:group:dev",
               kind: "group",
+              classification: "group",
+              peerKind: "group",
               sessionId: "s-group",
               updatedAt: 11,
               channel: "discord",
@@ -461,6 +464,7 @@ describe("sessions tools", () => {
             {
               key: "agent:main:dashboard:child",
               kind: "direct",
+              classification: "dashboard",
               sessionId: "s-dashboard-child",
               updatedAt: 12,
               parentSessionKey: "agent:main:main",
@@ -468,18 +472,20 @@ describe("sessions tools", () => {
             {
               key: "agent:main:subagent:worker",
               kind: "direct",
+              classification: "subagent",
               sessionId: "s-subagent-worker",
               updatedAt: 13,
               spawnedBy: "agent:main:main",
             },
             {
-              key: "cron:job-1",
+              key: "agent:main:cron:job-1",
               kind: "direct",
+              classification: "cron",
               sessionId: "s-cron",
               updatedAt: 9,
             },
-            { key: "global", kind: "global" },
-            { key: "unknown", kind: "unknown" },
+            { key: "global", kind: "global", classification: "global", agentId: "main" },
+            { key: "unknown", kind: "unknown", classification: "unknown", agentId: "main" },
           ],
         };
       }
@@ -537,7 +543,7 @@ describe("sessions tools", () => {
       }>;
     };
     expect(details.sessions).toHaveLength(5);
-    const main = details.sessions?.find((s) => s.key === "main");
+    const main = details.sessions?.find((s) => s.key === "agent:main:main");
     expect(main?.agentId).toBe("main");
     expect(main?.channel).toBe("whatsapp");
     expect(main?.derivedTitle).toBe("Main mailbox");
@@ -545,7 +551,7 @@ describe("sessions tools", () => {
     expect(main?.messages?.length).toBe(1);
     expect(main?.messages?.[0]?.role).toBe("assistant");
 
-    const group = details.sessions?.find((s) => s.key === "discord:group:dev");
+    const group = details.sessions?.find((s) => s.key === "agent:main:discord:group:dev");
     expect(group?.status).toBe("running");
     expect(group?.childSessions).toEqual(["agent:main:subagent:worker"]);
     expect(group?.derivedTitle).toBe("Dev room");
@@ -605,12 +611,14 @@ describe("sessions tools", () => {
               {
                 key: "agent:main:main",
                 kind: "direct",
+                classification: "main",
                 sessionId: "visible",
                 updatedAt: 20,
               },
               {
                 key: "agent:other:main",
                 kind: "direct",
+                classification: "main",
                 sessionId: "hidden",
                 updatedAt: 21,
               },
@@ -641,7 +649,7 @@ describe("sessions tools", () => {
           key: "agent:main:main",
           sessionId: "visible",
           agentId: "main",
-          kind: "other",
+          kind: "main",
           channel: "unknown",
           archived: false,
           pinned: false,
@@ -664,8 +672,9 @@ describe("sessions tools", () => {
           path: "(multiple)",
           sessions: [
             {
-              key: "main",
+              key: "agent:main:main",
               kind: "direct",
+              classification: "main",
               sessionId: "sess-main",
               updatedAt: 12,
             },
@@ -681,7 +690,7 @@ describe("sessions tools", () => {
     const details = result.details as {
       sessions?: Array<Record<string, unknown>>;
     };
-    const main = details.sessions?.find((session) => session.key === "main");
+    const main = details.sessions?.find((session) => session.key === "agent:main:main");
     expect(main).not.toHaveProperty("transcriptPath");
     expect(main).toHaveProperty("sessionId", "sess-main");
   });

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -21,7 +21,10 @@ export {
   shouldResolveSessionIdInput,
 } from "./sessions-resolution.js";
 import { normalizeOptionalString, type FastMode } from "@openclaw/normalization-core/string-coerce";
-import type { SessionRunStatus } from "../../../packages/gateway-protocol/src/schema/sessions-row.js";
+import type {
+  SessionRow,
+  SessionRunStatus,
+} from "../../../packages/gateway-protocol/src/schema/sessions-row.js";
 import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { parseRawSessionConversationRef } from "../../sessions/session-key-utils.js";
@@ -29,6 +32,16 @@ import type { FastModeSource } from "../../shared/fast-mode.js";
 
 /** Coarse session category used by session list/status tools. */
 type SessionKind = "main" | "group" | "cron" | "hook" | "node" | "other";
+
+const SESSION_KIND_BY_CLASSIFICATION: Readonly<Record<string, SessionKind>> = {
+  main: "main",
+  global: "main",
+  group: "group",
+  channel: "group",
+  cron: "cron",
+  hook: "hook",
+  node: "node",
+};
 
 /** Delivery target metadata attached to session rows. */
 type SessionListDeliveryContext = {
@@ -42,8 +55,10 @@ type SessionListDeliveryContext = {
 export type GatewaySessionListRow = {
   key: string;
   agentId?: string;
-  kind: SessionKind;
-  channel: string;
+  classification: NonNullable<SessionRow["classification"]>;
+  peerKind?: SessionRow["peerKind"];
+  kind: SessionRow["kind"];
+  channel?: string;
   origin?: {
     provider?: string;
     accountId?: string;
@@ -133,34 +148,15 @@ export function resolveSessionToolContext(opts?: {
   };
 }
 
-/** Classifies a session key/gateway kind into the row category used by tools. */
+/** Projects the Gateway's authoritative classification into the tool's coarse categories. */
 export function classifySessionListKind(params: {
-  key: string;
-  gatewayKind?: string | null;
-  alias: string;
-  mainKey: string;
+  classification: NonNullable<GatewaySessionListRow["classification"]>;
+  peerKind?: GatewaySessionListRow["peerKind"];
 }): SessionKind {
-  const key = params.key;
-  if (key === params.alias || key === params.mainKey) {
-    return "main";
+  if (params.classification === "thread") {
+    return params.peerKind === "group" || params.peerKind === "channel" ? "group" : "other";
   }
-  if (key.startsWith("cron:")) {
-    return "cron";
-  }
-  if (key.startsWith("hook:")) {
-    return "hook";
-  }
-  if (key.startsWith("node-") || key.startsWith("node:")) {
-    return "node";
-  }
-  if (params.gatewayKind === "group") {
-    return "group";
-  }
-  if (key.includes(":group:") || key.includes(":channel:")) {
-    // Gateway-less archived rows still encode group/channel shape in the session key.
-    return "group";
-  }
-  return "other";
+  return SESSION_KIND_BY_CLASSIFICATION[params.classification] ?? "other";
 }
 
 /** Derives the best channel label for a session row. */

--- a/src/agents/tools/sessions-list-tool.test.ts
+++ b/src/agents/tools/sessions-list-tool.test.ts
@@ -2,7 +2,9 @@
 // helpers, and numeric argument validation.
 import { Value } from "typebox/value";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { buildGatewaySessionRow } from "../../gateway/session-utils-row.js";
 import { compactToolOutputHint } from "../tool-schema-hints.js";
 import { createSessionsListTool } from "./sessions-list-tool.js";
 
@@ -81,12 +83,94 @@ describe("sessions-list-tool", () => {
     mocks.getSessionStateVersions.mockReturnValue({});
   });
 
+  it("filters Gateway-projected agent sessions by their authoritative classification", async () => {
+    const entries = [
+      ["agent:main:main", { sessionId: "session-main", updatedAt: 5 }],
+      [
+        "agent:main:slack:channel:C123",
+        { sessionId: "session-group", updatedAt: 4, chatType: "channel" },
+      ],
+      ["agent:main:cron:nightly", { sessionId: "session-cron", updatedAt: 3 }],
+      ["agent:main:hook:deploy", { sessionId: "session-hook", updatedAt: 2 }],
+      ["agent:main:node-device", { sessionId: "session-node", updatedAt: 1 }],
+    ] satisfies Array<[string, SessionEntry]>;
+    const store = Object.fromEntries(entries);
+    const sessions = entries.map(([key, entry]) =>
+      buildGatewaySessionRow({
+        cfg: VALID_CONFIG,
+        storePath: "/tmp/sessions.json",
+        store,
+        key,
+        entry,
+        skipTranscriptUsageFallback: true,
+        lightweightListRow: true,
+      }),
+    );
+    mocks.gatewayCall.mockResolvedValue({ path: "/tmp/sessions.json", sessions });
+    const tool = createSessionsListTool({ config: VALID_CONFIG });
+
+    const unfiltered = getSessionsListDetails(await tool.execute("all-kinds", {})).sessions ?? [];
+    const filteredKeys: Record<string, string[]> = {};
+    for (const kind of ["main", "group", "cron", "hook", "node"]) {
+      const result = getSessionsListDetails(
+        await tool.execute(`filter-${kind}`, { kinds: [kind] }),
+      );
+      filteredKeys[kind] = (result.sessions ?? []).map((row) => String(row.key));
+    }
+
+    expect({
+      projected: sessions.map(({ key, kind, classification }) => ({
+        key,
+        wireKind: kind,
+        classification,
+      })),
+      modelVisible: unfiltered.map(({ key, kind }) => ({ key, kind })),
+      filteredKeys,
+    }).toEqual({
+      projected: [
+        { key: "agent:main:main", wireKind: "direct", classification: "main" },
+        {
+          key: "agent:main:slack:channel:C123",
+          wireKind: "group",
+          classification: "channel",
+        },
+        { key: "agent:main:cron:nightly", wireKind: "direct", classification: "cron" },
+        { key: "agent:main:hook:deploy", wireKind: "direct", classification: "hook" },
+        { key: "agent:main:node-device", wireKind: "direct", classification: "node" },
+      ],
+      modelVisible: [
+        { key: "agent:main:main", kind: "main" },
+        { key: "agent:main:slack:channel:C123", kind: "group" },
+        { key: "agent:main:cron:nightly", kind: "cron" },
+        { key: "agent:main:hook:deploy", kind: "hook" },
+        { key: "agent:main:node-device", kind: "node" },
+      ],
+      filteredKeys: {
+        main: ["agent:main:main"],
+        group: ["agent:main:slack:channel:C123"],
+        cron: ["agent:main:cron:nightly"],
+        hook: ["agent:main:hook:deploy"],
+        node: ["agent:main:node-device"],
+      },
+    });
+  });
+
   it("adds nonzero state versions with one batch lookup", async () => {
     mocks.gatewayCall.mockResolvedValue({
       path: "/tmp/sessions.json",
       sessions: [
-        { key: "agent:main:main", kind: "main", sessionId: "main-1" },
-        { key: "agent:main:subagent:child", kind: "other", sessionId: "child-1" },
+        {
+          key: "agent:main:main",
+          kind: "direct",
+          classification: "main",
+          sessionId: "main-1",
+        },
+        {
+          key: "agent:main:subagent:child",
+          kind: "direct",
+          classification: "subagent",
+          sessionId: "child-1",
+        },
       ],
     });
     mocks.getSessionStateVersions.mockReturnValue({
@@ -107,8 +191,13 @@ describe("sessions-list-tool", () => {
     mocks.gatewayCall.mockResolvedValue({
       path: "(multiple)",
       sessions: [
-        { key: "agent:main:dashboard:visible", kind: "other" },
-        { key: "agent:main:dashboard:incognito-private", kind: "other", incognito: true },
+        { key: "agent:main:dashboard:visible", kind: "direct", classification: "dashboard" },
+        {
+          key: "agent:main:dashboard:incognito-private",
+          kind: "direct",
+          classification: "dashboard",
+          incognito: true,
+        },
       ],
     });
 
@@ -127,7 +216,8 @@ describe("sessions-list-tool", () => {
           key: "agent:main:subagent:child",
           sessionId: "session-child",
           agentId: "main",
-          kind: "other",
+          kind: "direct",
+          classification: "subagent",
           channel: "discord",
           label: "worker",
           displayName: "Worker",
@@ -196,6 +286,7 @@ describe("sessions-list-tool", () => {
             {
               key: "agent:main:dashboard:child",
               kind: "direct",
+              classification: "dashboard",
               sessionId: "sess-dashboard-child",
               deliveryContext: {
                 channel: "discord",
@@ -207,6 +298,7 @@ describe("sessions-list-tool", () => {
             {
               key: "agent:main:telegram:topic",
               kind: "direct",
+              classification: "custom",
               sessionId: "sess-telegram-topic",
               deliveryContext: {
                 channel: "telegram",
@@ -237,7 +329,8 @@ describe("sessions-list-tool", () => {
       sessions: [
         {
           key: "agent:main:subagent:child",
-          kind: "other",
+          kind: "direct",
+          classification: "subagent",
           parentSessionKey: "agent:main:subagent:parent",
           spawnedBy: "agent:main:main",
         },
@@ -261,26 +354,32 @@ describe("sessions-list-tool", () => {
             {
               key: "agent:main:slack:channel:C123:thread:1710000000.000100",
               kind: "group",
+              classification: "thread",
+              peerKind: "channel",
               sessionId: "sess-slack-thread",
             },
             {
               key: "discord:group:ops",
               kind: "group",
+              classification: "group",
               sessionId: "sess-discord-group",
             },
             {
               key: "agent:main:matrix:channel:!room:[2001:db8::1]",
               kind: "group",
+              classification: "channel",
               sessionId: "sess-matrix-room",
             },
             {
               key: "agent:main:agent:plugin:slack:channel:C123",
               kind: "group",
+              classification: "custom",
               sessionId: "sess-nested-agent",
             },
             {
               key: "agent::slack:channel:C123",
               kind: "group",
+              classification: "channel",
               sessionId: "sess-malformed-agent",
             },
           ],
@@ -309,8 +408,9 @@ describe("sessions-list-tool", () => {
           path: "/tmp/sessions.json",
           sessions: [
             {
-              key: "main",
+              key: "agent:main:main",
               kind: "direct",
+              classification: "main",
               sessionId: "sess-main",
               thinkingLevel: "high",
               fastMode: "auto",
@@ -334,7 +434,7 @@ describe("sessions-list-tool", () => {
 
     const session = details.sessions?.[0];
     expect(session).toEqual({
-      key: "main",
+      key: "agent:main:main",
       sessionId: "sess-main",
       agentId: "main",
       kind: "main",
@@ -351,6 +451,7 @@ describe("sessions-list-tool", () => {
         {
           key: "agent:main:dashboard:archived",
           kind: "direct",
+          classification: "dashboard",
           archived: true,
           archivedAt: 20,
           pinned: false,

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -284,8 +284,7 @@ export function createSessionsListTool(opts?: {
           continue;
         }
 
-        const gatewayKind = typeof entry.kind === "string" ? entry.kind : undefined;
-        const kind = classifySessionListKind({ key, gatewayKind, alias, mainKey });
+        const kind = classifySessionListKind(entry);
         if (allowedKinds && !allowedKinds.has(kind)) {
           continue;
         }

--- a/src/agents/tools/sessions-send-tool.a2a.test.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.test.ts
@@ -322,6 +322,7 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
     const session = {
       key: "agent:main:discord:channel:target-room",
       kind: "group",
+      classification: "channel",
       channel: "discord",
       deliveryContext: {
         channel: "discord",

--- a/src/gateway/session-classification.test.ts
+++ b/src/gateway/session-classification.test.ts
@@ -29,6 +29,7 @@ describe("sessionClassificationForRow", () => {
     ["agent:main:acp:child", false, "acp", true],
     ["agent:main:cron:job", false, "cron", true],
     ["agent:main:hook:run", false, "hook", true],
+    ["agent:main:node-device", false, "node", false],
     ["agent:main:harness:codex:supervision:thread", false, "harness", true],
     ["agent:main:voice:call:123", false, "voice", false],
     ["agent:main:dreaming-narrative-rem-workspace", false, "dreaming", true],

--- a/src/gateway/session-classification.ts
+++ b/src/gateway/session-classification.ts
@@ -55,6 +55,9 @@ function classifyRest(rest: string): SessionClassification {
   if (normalized.startsWith("hook:")) {
     return "hook";
   }
+  if (normalized.startsWith("node-") || normalized.startsWith("node:")) {
+    return "node";
+  }
   if (normalized.startsWith("harness:")) {
     return "harness";
   }


### PR DESCRIPTION
## What Problem This Solves

`sessions_list` discarded the Gateway’s authoritative session `classification` and re-derived coarse kinds from raw key prefixes. Real session keys are agent-scoped, so main, cron, hook, and node rows such as `agent:main:cron:nightly` were classified as `other`; kind-filtered calls could return empty results for sessions that existed.

## Why This Change Was Made

The agent tool now carries and projects the prepared Gateway classification instead of parsing keys again:

- main/global map to model-facing `main`;
- group/channel and group/channel threads map to `group`;
- cron, hook, and node retain their authoritative kinds;
- unsupported/background classifications remain `other`;
- node keys are classified at the Gateway producer alongside cron and hook.

Raw-key inference is removed. The built-in sessions tool and Gateway are same-version, in-process owners, so no legacy fallback is retained. The existing protocol field is reused; no schema or protocol change is introduced. The separate post-filter pagination issue is intentionally out of scope.

AI-assisted: yes. The owner-boundary repair and actual Gateway-row regression were manually inspected and passed fresh structured autoreview after final rebase.

## User Impact

Models can reliably list and filter real agent-scoped main, cron, hook, group, and node sessions instead of silently losing them as `other`.

## Evidence

- Pre-fix boundary proof projected real agent-scoped main/cron/hook/node rows as `other`; all four corresponding kind filters returned empty results. Node’s producer classification was also `custom`.
- Regression coverage uses actual `buildGatewaySessionRow` output instead of unrealistic unscoped fixture keys.
- Focused proof: 92 tests passed across Gateway classification, sessions-list, OpenClaw sessions tools, and sessions-send A2A.
- Hosted changed gate passed on Testbox `tbx_01kzv9z6a4jynjxjm09eewp61r` ([run](https://github.com/openclaw/openclaw/actions/runs/31613366075)).
- Exact-head CI passed ([run](https://github.com/openclaw/openclaw/actions/runs/31614301705)).
- Targeted formatting/lint, typechecks, import-cycle checks, and `git diff --check` passed.
- Rebase preserved exact range-diff and stable patch ID `7e3b69363ce7af370c83ca998aad8d7d0d9b8ea8`.
- Fresh complete-branch autoreview: clean.
- Production +28/−30 (net −2); tests +130/−18.
