### PR TITLE
refactor: centralize provider usage response handling

### DIFF
--- a/src/infra/provider-usage.fetch.codex.test.ts
+++ b/src/infra/provider-usage.fetch.codex.test.ts
@@ -4,9 +4,9 @@ import { createProviderUsageFetch, makeResponse } from "../test-utils/provider-u
 import { fetchCodexUsage } from "./provider-usage.fetch.codex.js";
 
 describe("fetchCodexUsage", () => {
-  it("returns token expired for auth failures", async () => {
+  it.each([401, 403])("returns token expired for a %s auth failure", async (status) => {
     const mockFetch = createProviderUsageFetch(async () =>
-      makeResponse(401, { error: "unauthorized" }),
+      makeResponse(status, { error: "unauthorized" }),
     );
 
     const result = await fetchCodexUsage("token", undefined, 5000, mockFetch);

--- a/src/infra/provider-usage.fetch.codex.ts
+++ b/src/infra/provider-usage.fetch.codex.ts
@@ -1,12 +1,7 @@
 import { parseStrictFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 // Fetches Codex provider usage windows.
 import { resolveProviderRequestHeaders } from "../agents/provider-request-config.js";
-import { cancelUnreadResponseBody } from "./http-body.js";
-import {
-  buildUsageHttpErrorSnapshot,
-  fetchJson,
-  readUsageJson,
-} from "./provider-usage.fetch.shared.js";
+import { fetchUsageJson } from "./provider-usage.fetch.shared.js";
 import { clampPercent, PROVIDER_LABELS } from "./provider-usage.shared.js";
 import type { ProviderUsageSnapshot, UsageWindow } from "./provider-usage.types.js";
 
@@ -81,23 +76,14 @@ export async function fetchCodexUsage(
       defaultHeaders,
     }) ?? defaultHeaders;
 
-  const res = await fetchJson(
-    "https://chatgpt.com/backend-api/wham/usage",
-    { method: "GET", headers },
+  const parsed = await fetchUsageJson({
+    provider: "openai",
+    url: "https://chatgpt.com/backend-api/wham/usage",
+    init: { method: "GET", headers },
     timeoutMs,
     fetchFn,
-  );
-
-  if (!res.ok) {
-    await cancelUnreadResponseBody(res);
-    return buildUsageHttpErrorSnapshot({
-      provider: "openai",
-      status: res.status,
-      tokenExpiredStatuses: [401, 403],
-    });
-  }
-
-  const parsed = await readUsageJson("openai", res);
+    tokenExpiredStatuses: [401, 403],
+  });
   if (!parsed.ok) {
     return parsed.snapshot;
   }

--- a/src/infra/provider-usage.fetch.deepseek.ts
+++ b/src/infra/provider-usage.fetch.deepseek.ts
@@ -1,12 +1,6 @@
 // Fetches and normalizes DeepSeek provider usage records.
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { cancelUnreadResponseBody } from "./http-body.js";
-import {
-  buildUsageHttpErrorSnapshot,
-  fetchJson,
-  parseFiniteNumber,
-  readUsageJson,
-} from "./provider-usage.fetch.shared.js";
+import { fetchUsageJson, parseFiniteNumber } from "./provider-usage.fetch.shared.js";
 import { PROVIDER_LABELS } from "./provider-usage.shared.js";
 import type { ProviderUsageSnapshot } from "./provider-usage.types.js";
 
@@ -61,9 +55,10 @@ export async function fetchDeepSeekUsage(
   timeoutMs: number,
   fetchFn: typeof fetch,
 ): Promise<ProviderUsageSnapshot> {
-  const res = await fetchJson(
-    DEEPSEEK_BALANCE_URL,
-    {
+  const parsed = await fetchUsageJson({
+    provider: "deepseek",
+    url: DEEPSEEK_BALANCE_URL,
+    init: {
       method: "GET",
       headers: {
         Authorization: `Bearer ${apiKey}`,
@@ -72,17 +67,7 @@ export async function fetchDeepSeekUsage(
     },
     timeoutMs,
     fetchFn,
-  );
-
-  if (!res.ok) {
-    await cancelUnreadResponseBody(res);
-    return buildUsageHttpErrorSnapshot({
-      provider: "deepseek",
-      status: res.status,
-    });
-  }
-
-  const parsed = await readUsageJson("deepseek", res);
+  });
   if (!parsed.ok) {
     return parsed.snapshot;
   }

--- a/src/infra/provider-usage.fetch.gemini.ts
+++ b/src/infra/provider-usage.fetch.gemini.ts
@@ -2,12 +2,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 // Fetches Gemini provider usage windows.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { cancelUnreadResponseBody } from "./http-body.js";
-import {
-  buildUsageHttpErrorSnapshot,
-  fetchJson,
-  readUsageJson,
-} from "./provider-usage.fetch.shared.js";
+import { fetchUsageJson } from "./provider-usage.fetch.shared.js";
 import { clampPercent, providerUsageLabel } from "./provider-usage.shared.js";
 import type {
   ProviderUsageSnapshot,
@@ -21,9 +16,10 @@ export async function fetchGeminiUsage(
   fetchFn: typeof fetch,
   provider: UsageProviderId,
 ): Promise<ProviderUsageSnapshot> {
-  const res = await fetchJson(
-    "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota",
-    {
+  const parsed = await fetchUsageJson({
+    provider,
+    url: "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota",
+    init: {
       method: "POST",
       headers: {
         Authorization: `Bearer ${token}`,
@@ -33,17 +29,7 @@ export async function fetchGeminiUsage(
     },
     timeoutMs,
     fetchFn,
-  );
-
-  if (!res.ok) {
-    await cancelUnreadResponseBody(res);
-    return buildUsageHttpErrorSnapshot({
-      provider,
-      status: res.status,
-    });
-  }
-
-  const parsed = await readUsageJson(provider, res);
+  });
   if (!parsed.ok) {
     return parsed.snapshot;
   }

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -1,27 +1,15 @@
 // Fetches and normalizes MiniMax provider usage records.
 import { asDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { readProviderJsonResponse } from "../agents/provider-http-errors.js";
 import { isRecord } from "../utils.js";
 import { readTrimmedStringAlias } from "../utils/string-readers.js";
-import { cancelUnreadResponseBody } from "./http-body.js";
-import {
-  buildUsageHttpErrorSnapshot,
-  fetchJson,
-  parseFiniteNumber,
-} from "./provider-usage.fetch.shared.js";
+import { fetchUsageJson, parseFiniteNumber } from "./provider-usage.fetch.shared.js";
 import { clampPercent, PROVIDER_LABELS } from "./provider-usage.shared.js";
 import type { ProviderUsageSnapshot, UsageWindow } from "./provider-usage.types.js";
 
 type MinimaxBaseResp = {
   status_code?: number;
   status_msg?: string;
-};
-
-type MinimaxUsageResponse = {
-  base_resp?: MinimaxBaseResp;
-  data?: Record<string, unknown>;
-  [key: string]: unknown;
 };
 
 type FetchMinimaxUsageOptions = {
@@ -529,9 +517,10 @@ export async function fetchMinimaxUsage(
   fetchFn: typeof fetch,
   options?: FetchMinimaxUsageOptions,
 ): Promise<ProviderUsageSnapshot> {
-  const res = await fetchJson(
-    resolveMinimaxUsageUrl(options?.baseUrl),
-    {
+  const parsed = await fetchUsageJson({
+    provider: "minimax",
+    url: resolveMinimaxUsageUrl(options?.baseUrl),
+    init: {
       method: "GET",
       headers: {
         Authorization: `Bearer ${apiKey}`,
@@ -541,19 +530,12 @@ export async function fetchMinimaxUsage(
     },
     timeoutMs,
     fetchFn,
-  );
-
-  if (!res.ok) {
-    await cancelUnreadResponseBody(res);
-    return buildUsageHttpErrorSnapshot({
-      provider: "minimax",
-      status: res.status,
-    });
+    malformedResponseError: "Invalid JSON",
+  });
+  if (!parsed.ok) {
+    return parsed.snapshot;
   }
-
-  const data = await readProviderJsonResponse<MinimaxUsageResponse>(res, "minimax usage").catch(
-    () => null,
-  );
+  const data = parsed.data;
   if (!isRecord(data)) {
     return {
       provider: "minimax",
@@ -563,7 +545,7 @@ export async function fetchMinimaxUsage(
     };
   }
 
-  const baseResp = isRecord(data.base_resp) ? data.base_resp : undefined;
+  const baseResp = isRecord(data.base_resp) ? (data.base_resp as MinimaxBaseResp) : undefined;
   if (baseResp && typeof baseResp.status_code === "number" && baseResp.status_code !== 0) {
     return {
       provider: "minimax",

--- a/src/infra/provider-usage.fetch.shared.test.ts
+++ b/src/infra/provider-usage.fetch.shared.test.ts
@@ -6,6 +6,7 @@ import {
   buildUsageErrorSnapshot,
   buildUsageHttpErrorSnapshot,
   fetchJson,
+  fetchUsageJson,
   parseFiniteNumber,
   readUsageJson,
 } from "./provider-usage.fetch.shared.js";
@@ -188,6 +189,69 @@ describe("provider usage fetch shared helpers", () => {
     });
 
     expect(snapshot.error).toBe("HTTP 429");
+  });
+
+  describe("fetchUsageJson", () => {
+    it("returns parsed data for a successful response", async () => {
+      const result = await fetchUsageJson({
+        provider: "zai",
+        url: "https://example.com/usage",
+        init: { method: "GET" },
+        timeoutMs: 1_000,
+        fetchFn: withFetchPreconnect(vi.fn(async () => Response.json({ plan: "Pro" }))),
+      });
+
+      expect(result).toEqual({ ok: true, data: { plan: "Pro" } });
+    });
+
+    it("cancels non-OK bodies and returns the configured provider error", async () => {
+      const response = Response.json({ error: "expired" }, { status: 403 });
+      const cancel = vi.spyOn(response.body!, "cancel").mockResolvedValue(undefined);
+
+      const result = await fetchUsageJson({
+        provider: "openai",
+        url: "https://example.com/usage",
+        init: { method: "GET" },
+        timeoutMs: 1_000,
+        fetchFn: withFetchPreconnect(vi.fn(async () => response)),
+        tokenExpiredStatuses: [401, 403],
+      });
+
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(result).toEqual({
+        ok: false,
+        snapshot: {
+          provider: "openai",
+          displayName: "OpenAI",
+          windows: [],
+          error: "Token expired",
+        },
+      });
+    });
+
+    it.each([
+      { malformedResponseError: undefined, expected: "Malformed usage response" },
+      { malformedResponseError: "Invalid JSON", expected: "Invalid JSON" },
+    ])("returns $expected for malformed JSON", async ({ malformedResponseError, expected }) => {
+      const result = await fetchUsageJson({
+        provider: "minimax",
+        url: "https://example.com/usage",
+        init: { method: "GET" },
+        timeoutMs: 1_000,
+        fetchFn: withFetchPreconnect(vi.fn(async () => new Response("{not-json"))),
+        malformedResponseError,
+      });
+
+      expect(result).toEqual({
+        ok: false,
+        snapshot: {
+          provider: "minimax",
+          displayName: "MiniMax",
+          windows: [],
+          error: expected,
+        },
+      });
+    });
   });
 
   describe("readUsageJson", () => {

--- a/src/infra/provider-usage.fetch.shared.ts
+++ b/src/infra/provider-usage.fetch.shared.ts
@@ -4,6 +4,7 @@ import {
   resolveTimerTimeoutMs,
 } from "@openclaw/normalization-core/number-coercion";
 import { readProviderJsonResponse } from "../agents/provider-http-errors.js";
+import { cancelUnreadResponseBody } from "./http-body.js";
 import { providerUsageLabel } from "./provider-usage.shared.js";
 import type { ProviderUsageSnapshot, UsageProviderId } from "./provider-usage.types.js";
 
@@ -36,6 +37,16 @@ type BuildUsageHttpErrorSnapshotOptions = {
   tokenExpiredStatuses?: readonly number[];
 };
 
+type FetchUsageJsonOptions = {
+  provider: UsageProviderId;
+  url: string;
+  init: RequestInit;
+  timeoutMs: number;
+  fetchFn: typeof fetch;
+  tokenExpiredStatuses?: readonly number[];
+  malformedResponseError?: string;
+};
+
 /** Builds a provider usage snapshot for non-HTTP fetch or parse failures. */
 export function buildUsageErrorSnapshot(
   provider: UsageProviderId,
@@ -63,6 +74,7 @@ export function buildUsageHttpErrorSnapshot(
 export async function readUsageJson(
   provider: UsageProviderId,
   response: Response,
+  malformedResponseError = "Malformed usage response",
 ): Promise<{ ok: true; data: unknown } | { ok: false; snapshot: ProviderUsageSnapshot }> {
   try {
     const data = await readProviderJsonResponse<unknown>(response, `${provider} usage`);
@@ -70,7 +82,25 @@ export async function readUsageJson(
   } catch {
     return {
       ok: false,
-      snapshot: buildUsageErrorSnapshot(provider, "Malformed usage response"),
+      snapshot: buildUsageErrorSnapshot(provider, malformedResponseError),
     };
   }
+}
+
+export async function fetchUsageJson(
+  options: FetchUsageJsonOptions,
+): Promise<{ ok: true; data: unknown } | { ok: false; snapshot: ProviderUsageSnapshot }> {
+  const response = await fetchJson(options.url, options.init, options.timeoutMs, options.fetchFn);
+  if (!response.ok) {
+    await cancelUnreadResponseBody(response);
+    return {
+      ok: false,
+      snapshot: buildUsageHttpErrorSnapshot({
+        provider: options.provider,
+        status: response.status,
+        tokenExpiredStatuses: options.tokenExpiredStatuses,
+      }),
+    };
+  }
+  return await readUsageJson(options.provider, response, options.malformedResponseError);
 }

--- a/src/infra/provider-usage.fetch.zai.ts
+++ b/src/infra/provider-usage.fetch.zai.ts
@@ -2,13 +2,7 @@
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { cancelUnreadResponseBody } from "./http-body.js";
-import {
-  buildUsageHttpErrorSnapshot,
-  fetchJson,
-  parseUsageResetAt,
-  readUsageJson,
-} from "./provider-usage.fetch.shared.js";
+import { fetchUsageJson, parseUsageResetAt } from "./provider-usage.fetch.shared.js";
 import { clampPercent, PROVIDER_LABELS } from "./provider-usage.shared.js";
 import type { ProviderUsageSnapshot, UsageWindow } from "./provider-usage.types.js";
 
@@ -66,9 +60,10 @@ export async function fetchZaiUsage(
   timeoutMs: number,
   fetchFn: typeof fetch,
 ): Promise<ProviderUsageSnapshot> {
-  const res = await fetchJson(
-    "https://api.z.ai/api/monitor/usage/quota/limit",
-    {
+  const parsed = await fetchUsageJson({
+    provider: "zai",
+    url: "https://api.z.ai/api/monitor/usage/quota/limit",
+    init: {
       method: "GET",
       headers: {
         Authorization: `Bearer ${apiKey}`,
@@ -77,17 +72,7 @@ export async function fetchZaiUsage(
     },
     timeoutMs,
     fetchFn,
-  );
-
-  if (!res.ok) {
-    await cancelUnreadResponseBody(res);
-    return buildUsageHttpErrorSnapshot({
-      provider: "zai",
-      status: res.status,
-    });
-  }
-
-  const parsed = await readUsageJson("zai", res);
+  });
   if (!parsed.ok) {
     return parsed.snapshot;
   }


### PR DESCRIPTION
## What Problem This Solves

Provider usage fetchers repeated the same HTTP response transition—cancel non-OK bodies, build a provider snapshot, parse bounded JSON, and unwrap the result. That duplication made cancellation, body limits, and provider-specific errors easier to drift apart.

## Why This Change Was Made

The existing `provider-usage.fetch.shared.ts` owner now handles that complete response transition. Codex, Gemini, DeepSeek, Z.ai, and MiniMax retain their exact endpoints, request headers, payload interpretation, and provider wording; Codex still maps 401/403 to `Token expired`, and MiniMax still reports malformed/oversized JSON as `Invalid JSON`. Claude's OAuth and web fallback paths are unchanged.

Production LOC: +67/-113 (net -46) | Tests: +66/-2

## User Impact

No intended user-visible behavior change. Provider usage requests keep the same success snapshots, HTTP errors, cancellation, timeout/signal, and bounded-body behavior with one canonical implementation.

## Evidence

- Before change: the six focused files passed 83 tests.
- After rebase: `node scripts/run-vitest.mjs src/infra/provider-usage.fetch.shared.test.ts src/infra/provider-usage.fetch.codex.test.ts src/infra/provider-usage.fetch.gemini.test.ts src/infra/provider-usage.fetch.deepseek.test.ts src/infra/provider-usage.fetch.zai.test.ts src/infra/provider-usage.fetch.minimax.test.ts` — 6 files, 88 tests passed.
- Changed-path gate: core typechecks, core-test typechecks, targeted oxlint/format, import-cycle, SDK API, plugin-boundary, dead-export, schema and policy guards all passed.
- `git diff --check origin/main...HEAD` passed.
- TruffleHog 3.95.9 scanned the exact patch: 0 verified and 0 unverified secrets.
- Characterization covers success, non-OK unread-body cancellation, Codex 401/403, malformed and oversized bounded JSON, request/body timeout and caller cancellation, provider error wording, endpoints, and headers.
- Required Codex contract check: upstream `openai/codex` commit `3d7f9b463795cdbdd1f243cdf679c9276c3e1da6`, specifically `codex-rs/backend-client/src/client/rate_limit_resets.rs`, `client.rs`, `rate_limit_resets_tests.rs`, and `codex-backend-openapi-models/src/models/rate_limit_window_snapshot.rs` for the wham usage route, account header, and response shape.
- Open-PR overlap scan found no PR touching the 12 scoped production/test paths (2,134 open PRs scanned at the start; live set changed during pagination, with newly opened PRs rechecked).
- Autoreview was attempted after its TruffleHog preflight passed, but the orb has no Codex/Claude/Pi review executable; no review verdict was produced.
