### PR TITLE
fix(ci): stabilize SQLite vacuum interruption proof

### DIFF
--- a/scripts/lib/sqlite-reliability-runner.ts
+++ b/scripts/lib/sqlite-reliability-runner.ts
@@ -61,6 +61,7 @@ type CompactionProof = ReliabilityReport["maintenanceProof"]["compaction"];
 // an arbitrarily large payload through every repository and restore crash phase.
 const COMPACTION_BLOAT_ROWS = 12;
 const COMPACTION_BLOAT_PAYLOAD_BYTES = 256 * 1024;
+const VACUUM_BLOAT_ROWS = 64;
 
 function nowMs(): number {
   return Number(process.hrtime.bigint()) / 1e6;
@@ -275,26 +276,33 @@ function verifyRestoredDatabase(params: {
   }
 }
 
-function createCompactionBloat(databasePath: string): number {
+function writeCompactionBloatRange(
+  databasePath: string,
+  firstId: number,
+  lastId: number,
+  reset = false,
+): void {
   const database = openNodeSqliteDatabase(databasePath);
   const payload = "b".repeat(COMPACTION_BLOAT_PAYLOAD_BYTES);
   try {
     database.exec("PRAGMA journal_mode = WAL;");
     database.exec("PRAGMA wal_autocheckpoint = 0;");
     database.exec("PRAGMA busy_timeout = 30000;");
-    database.exec(`
-      DROP TABLE IF EXISTS openclaw_reliability_compaction_bloat;
-      CREATE TABLE openclaw_reliability_compaction_bloat (
-        id INTEGER PRIMARY KEY,
-        payload TEXT NOT NULL
-      );
-      BEGIN IMMEDIATE;
-    `);
+    if (reset) {
+      database.exec(`
+        DROP TABLE IF EXISTS openclaw_reliability_compaction_bloat;
+        CREATE TABLE openclaw_reliability_compaction_bloat (
+          id INTEGER PRIMARY KEY,
+          payload TEXT NOT NULL
+        );
+      `);
+    }
+    database.exec("BEGIN IMMEDIATE;");
     const insert = database.prepare(
       "INSERT INTO openclaw_reliability_compaction_bloat (id, payload) VALUES (?, ?)",
     );
     try {
-      for (let id = 1; id <= COMPACTION_BLOAT_ROWS; id += 1) {
+      for (let id = firstId; id <= lastId; id += 1) {
         insert.run(id, payload);
       }
       database.exec("COMMIT;");
@@ -303,7 +311,6 @@ function createCompactionBloat(databasePath: string): number {
       throw error;
     }
     database.exec("PRAGMA wal_checkpoint(TRUNCATE);");
-    return COMPACTION_BLOAT_ROWS * COMPACTION_BLOAT_PAYLOAD_BYTES;
   } finally {
     database.close();
   }
@@ -335,13 +342,17 @@ function readCompactionPayload(databasePath: string): {
   }
 }
 
-function deleteCompactionBloat(databasePath: string): void {
+function deleteCompactionBloat(databasePath: string, retainThroughId?: number): void {
   const database = openNodeSqliteDatabase(databasePath);
   try {
-    database.exec(`
-      DELETE FROM openclaw_reliability_compaction_bloat;
-      PRAGMA wal_checkpoint(TRUNCATE);
-    `);
+    if (retainThroughId === undefined) {
+      database.exec("DELETE FROM openclaw_reliability_compaction_bloat;");
+    } else {
+      database
+        .prepare("DELETE FROM openclaw_reliability_compaction_bloat WHERE id > ?")
+        .run(retainThroughId);
+    }
+    database.exec("PRAGMA wal_checkpoint(TRUNCATE);");
   } finally {
     database.close();
   }
@@ -488,7 +499,7 @@ async function runMaintenanceRoundTrip(params: {
   validationRoot: string;
 }): Promise<ReliabilityReport["maintenanceProof"]> {
   const autoVacuumBeforeKill = prepareVacuumRollbackSentinel(params.target.path);
-  const bloatBytes = createCompactionBloat(params.target.path);
+  writeCompactionBloatRange(params.target.path, 1, COMPACTION_BLOAT_ROWS, true);
   const expectedState = verifyRestoredDatabase({
     identity: params.target.identity,
     path: params.target.path,
@@ -496,7 +507,10 @@ async function runMaintenanceRoundTrip(params: {
     uncommittedBatch: null,
   });
   const expectedPayload = readCompactionPayload(params.target.path);
-  if (expectedPayload.rows !== COMPACTION_BLOAT_ROWS || expectedPayload.bytes !== bloatBytes) {
+  if (
+    expectedPayload.rows !== COMPACTION_BLOAT_ROWS ||
+    expectedPayload.bytes !== COMPACTION_BLOAT_ROWS * COMPACTION_BLOAT_PAYLOAD_BYTES
+  ) {
     throw new Error(
       `compaction payload setup failed: rows=${expectedPayload.rows} bytes=${expectedPayload.bytes}`,
     );
@@ -546,24 +560,44 @@ async function runMaintenanceRoundTrip(params: {
         }),
     }),
   );
-  const vacuumInterruption = await runVacuumInterruptionProof({
-    env: params.env,
-    expectedAutoVacuum: autoVacuumBeforeKill,
-    expectedPayload,
-    expectedState,
-    readAutoVacuum: () => readAutoVacuum(params.target.path),
-    readPayload: () => readCompactionPayload(params.target.path),
-    recoverAndVerifyDatabase: () =>
-      verifyRestoredDatabase({
-        expectedState,
-        identity: params.target.identity,
-        path: params.target.path,
-        readOnly: false,
-        rowsPerBatch: params.rowsPerBatch,
-        uncommittedBatch: null,
-      }),
-    target: params.target,
-  });
+  let vacuumInterruption: ReliabilityReport["maintenanceProof"]["vacuumInterruption"];
+  try {
+    writeCompactionBloatRange(params.target.path, COMPACTION_BLOAT_ROWS + 1, VACUUM_BLOAT_ROWS);
+    const vacuumExpectedPayload = readCompactionPayload(params.target.path);
+    if (
+      vacuumExpectedPayload.rows !== VACUUM_BLOAT_ROWS ||
+      vacuumExpectedPayload.bytes !== VACUUM_BLOAT_ROWS * COMPACTION_BLOAT_PAYLOAD_BYTES
+    ) {
+      throw new Error(
+        `vacuum payload setup failed: rows=${vacuumExpectedPayload.rows} bytes=${vacuumExpectedPayload.bytes}`,
+      );
+    }
+    vacuumInterruption = await runVacuumInterruptionProof({
+      env: params.env,
+      expectedAutoVacuum: autoVacuumBeforeKill,
+      expectedPayload: vacuumExpectedPayload,
+      expectedState,
+      readAutoVacuum: () => readAutoVacuum(params.target.path),
+      readPayload: () => readCompactionPayload(params.target.path),
+      recoverAndVerifyDatabase: () =>
+        verifyRestoredDatabase({
+          expectedState,
+          identity: params.target.identity,
+          path: params.target.path,
+          readOnly: false,
+          rowsPerBatch: params.rowsPerBatch,
+          uncommittedBatch: null,
+        }),
+      target: params.target,
+    });
+  } catch (error) {
+    try {
+      deleteCompactionBloat(params.target.path, COMPACTION_BLOAT_ROWS);
+    } catch {
+      // Preserve the proof failure; it is the actionable root cause.
+    }
+    throw error;
+  }
   deleteCompactionBloat(params.target.path);
   const compaction = await compactTargetDatabase(params.target, params.env);
   verifyRestoredDatabase({
@@ -595,7 +629,7 @@ async function runMaintenanceRoundTrip(params: {
     uncommittedBatch: null,
   });
   return {
-    bloatBytes,
+    bloatBytes: vacuumInterruption.payloadBeforeKill.bytes,
     compaction,
     postCompact: {
       restoreMs: Number(restoreMs.toFixed(3)),

--- a/test/scripts/bench-sqlite-reliability.test.ts
+++ b/test/scripts/bench-sqlite-reliability.test.ts
@@ -25,6 +25,9 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const RELIABILITY_PROOF_TIMEOUT_MS = process.platform === "win32" ? 480_000 : 240_000;
 const RELIABILITY_SMOKE_TEST_TIMEOUT_MS = process.platform === "win32" ? 1_200_000 : 300_000;
 const MIN_MULTICHUNK_RESTORE_BYTES = 2 * 1024 * 1024;
+const COMPACTION_FIXTURE_ROWS = 12;
+const COMPACTION_PAYLOAD_BYTES = 256 * 1024;
+const VACUUM_PROOF_ROWS = 64;
 
 function reliabilitySmokeTest(name: string, test: () => void): void {
   it(name, test, RELIABILITY_SMOKE_TEST_TIMEOUT_MS);
@@ -256,7 +259,9 @@ describe("scripts/bench-sqlite-reliability", () => {
     expect(firstReport.transactionProof.heldRows).toBeGreaterThan(0);
     expect(firstReport.transactionProof.visibleAfterRestore).toBe(false);
     expect(firstReport.writer.rowsCommitted).toBeGreaterThan(0);
-    expect(firstReport.maintenanceProof.bloatBytes).toBeGreaterThan(0);
+    expect(firstReport.maintenanceProof.bloatBytes).toBe(
+      VACUUM_PROOF_ROWS * COMPACTION_PAYLOAD_BYTES,
+    );
     expect(firstReport.maintenanceProof.compaction.autoVacuum.after).toBe(2);
     expect(firstReport.maintenanceProof.compaction.freelistPages.before).toBeGreaterThan(0);
     expect(firstReport.maintenanceProof.compaction.freelistPages.after).toBe(0);
@@ -276,6 +281,11 @@ describe("scripts/bench-sqlite-reliability", () => {
     expect(firstReport.maintenanceProof.vacuumInterruption.payloadAfterRecovery).toEqual(
       firstReport.maintenanceProof.vacuumInterruption.payloadBeforeKill,
     );
+    expect(firstReport.maintenanceProof.vacuumInterruption.payloadBeforeKill).toEqual({
+      bytes: VACUUM_PROOF_ROWS * COMPACTION_PAYLOAD_BYTES,
+      idSum: (VACUUM_PROOF_ROWS * (VACUUM_PROOF_ROWS + 1)) / 2,
+      rows: VACUUM_PROOF_ROWS,
+    });
     expect(firstReport.maintenanceProof.vacuumInterruption.stateAfterRecovery).toEqual(
       firstReport.maintenanceProof.vacuumInterruption.stateBeforeKill,
     );
@@ -342,6 +352,11 @@ describe("scripts/bench-sqlite-reliability", () => {
     expect(firstReport.maintenanceProof.repositoryInterruption.pending.payload).toEqual(
       firstReport.maintenanceProof.repositoryInterruption.afterCommit.payload,
     );
+    expect(firstReport.maintenanceProof.repositoryInterruption.beforePending.payload).toEqual({
+      bytes: COMPACTION_FIXTURE_ROWS * COMPACTION_PAYLOAD_BYTES,
+      idSum: (COMPACTION_FIXTURE_ROWS * (COMPACTION_FIXTURE_ROWS + 1)) / 2,
+      rows: COMPACTION_FIXTURE_ROWS,
+    });
     expect(firstReport.maintenanceProof.restoreInterruption.snapshotBytes).toBeGreaterThan(
       MIN_MULTICHUNK_RESTORE_BYTES,
     );
@@ -365,7 +380,11 @@ describe("scripts/bench-sqlite-reliability", () => {
     ).toEqual(firstReport.maintenanceProof.postCompact.state);
     expect(
       firstReport.maintenanceProof.restoreInterruption.beforePublish.payloadAfterRecovery,
-    ).toEqual(firstReport.maintenanceProof.vacuumInterruption.payloadBeforeKill);
+    ).toEqual({
+      bytes: COMPACTION_FIXTURE_ROWS * COMPACTION_PAYLOAD_BYTES,
+      idSum: (COMPACTION_FIXTURE_ROWS * (COMPACTION_FIXTURE_ROWS + 1)) / 2,
+      rows: COMPACTION_FIXTURE_ROWS,
+    });
     expect(firstReport.maintenanceProof.restoreInterruption.afterPublish).toMatchObject({
       existingTargetPreserved: true,
       recoveryVerified: true,


### PR DESCRIPTION
Related: #122570

## What Problem This Solves

Fixes an issue where the SQLite reliability smoke could finish `VACUUM` before the interruption harness observed an active journal or WAL after the shared fixture was reduced from 64 rows to 12. This surfaced in `checks-node-compact-small-14` and blocked an unrelated locale refresh.

Failure provenance: https://github.com/openclaw/openclaw/actions/runs/31605730546/job/94144375403

## Why This Change Was Made

The repository and restore interruption proofs keep the faster 12-row / 3 MiB fixture. Immediately before the vacuum interruption proof, the same transactional range writer extends that fixture to 64 rows / 16 MiB, checkpoints it, and rereads the authoritative payload.

On failure, cleanup removes only the vacuum-only rows while preserving the original proof error. On success, the existing compaction path deletes the full fixture once. The report records the actual 16 MiB compaction workload. No timeout, retry, CI planner, product, or runtime behavior changes.

## User Impact

No user-visible runtime change. Maintainers get a deterministic SQLite interruption proof without restoring the larger payload to repository and restore copy paths.

## Evidence

- Signed exact head: `80dc015b77ffd6f31c8d87d1b89cc50da978d11f`
- Focused local smoke: `test/scripts/bench-sqlite-reliability.test.ts`, 5/5 tests passed.
- Linux stability proof: 3 consecutive focused runs passed on Testbox `tbx_01kzvae7apxajhm3t3wfa1p960`; wrapper exit 0. Backing run: https://github.com/openclaw/openclaw/actions/runs/31614108928
- Exact-head changed-file gate: Testbox `tbx_01kzvajdrw8m2gekwvycvmcmqb`; formatting, script/root-test typechecks, oxlint, and tooling guards passed; wrapper exit 0. Backing run: https://github.com/openclaw/openclaw/actions/runs/31614309907
- Independent exact-head review: no blocking findings. Product/runtime LOC `0`; tooling net `+34`; tests net `+19`.
