### PR TITLE
refactor(ui): centralize chat media readiness

### DIFF
--- a/ui/src/pages/chat/components/chat-audio-player.test.ts
+++ b/ui/src/pages/chat/components/chat-audio-player.test.ts
@@ -220,44 +220,6 @@ describe("ChatAudioPlayer", () => {
     ).not.toContain("playback=1");
   });
 
-  it("does not retain an errored source when a refreshed rendition is unavailable", async () => {
-    let resolveFirstRefresh: ((response: Response) => void) | undefined;
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(new Response(null, { status: 200 }))
-      .mockImplementationOnce(
-        async () =>
-          await new Promise<Response>((resolve) => {
-            resolveFirstRefresh = resolve;
-          }),
-      )
-      .mockResolvedValueOnce(new Response(null, { status: 500 }));
-    vi.stubGlobal("fetch", fetchMock);
-    const player = document.createElement("openclaw-chat-audio-player");
-    player.src = "/__openclaw__/assistant-media?source=voice.caf&mediaTicket=old";
-    player.sourceIdentity = "/tmp/voice.caf";
-    player.label = "voice.caf";
-    player.playback = "transcode";
-    document.body.append(player);
-    await vi.waitFor(() =>
-      expect(player.querySelector("audio")?.getAttribute("src")).toContain("mediaTicket=old"),
-    );
-
-    player.querySelector("audio")?.dispatchEvent(new Event("error"));
-    await player.updateComplete;
-    player.src = "/__openclaw__/assistant-media?source=voice.caf&mediaTicket=refresh-1";
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
-    player.src = "/__openclaw__/assistant-media?source=voice.caf&mediaTicket=refresh-2";
-
-    await vi.waitFor(() =>
-      expect(
-        player.querySelector(".chat-assistant-attachment-card__reason")?.textContent,
-      ).toContain("Can't play this format — download instead."),
-    );
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    resolveFirstRefresh?.(new Response(null, { status: 200 }));
-  });
-
   it("reuses the waveform fetch as the audio element Blob source", async () => {
     const samples = new Float32Array([0, 0.5, -1, 0.25]);
     const decodeAudioData = vi.fn(async () => ({
@@ -339,28 +301,6 @@ describe("ChatAudioPlayer", () => {
     vi.spyOn(refreshedMedia, "play").mockResolvedValue(undefined);
     refreshed.querySelector<HTMLButtonElement>(".chat-audio-player__toggle")!.click();
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
-    resolveFetch?.(new Response(null, { status: 500 }));
-  });
-
-  it("shows preparation while the initial rendition HEAD is pending", async () => {
-    let resolveFetch: ((response: Response) => void) | undefined;
-    vi.stubGlobal(
-      "fetch",
-      vi.fn<typeof fetch>(
-        async () =>
-          await new Promise<Response>((resolve) => {
-            resolveFetch = resolve;
-          }),
-      ),
-    );
-    const player = document.createElement("openclaw-chat-audio-player");
-    player.src = "/__openclaw__/assistant-media?source=voice.caf&mediaTicket=ticket";
-    player.sourceIdentity = "/tmp/voice.caf";
-    player.label = "voice.caf";
-    player.playback = "transcode";
-    document.body.append(player);
-
-    await vi.waitFor(() => expect(player.textContent).toContain("Preparing playback…"));
     resolveFetch?.(new Response(null, { status: 500 }));
   });
 
@@ -520,28 +460,6 @@ describe("ChatAudioPlayer", () => {
     expect(media.getAttribute("src")).toBe("blob:context-fallback");
   });
 
-  it("restarts transcode readiness after disconnecting during preparation", async () => {
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(new Response(null, { status: 202 }))
-      .mockResolvedValueOnce(new Response(null, { status: 200 }));
-    vi.stubGlobal("fetch", fetchMock);
-    const player = document.createElement("openclaw-chat-audio-player");
-    player.src = "/__openclaw__/assistant-media?source=voice.caf&mediaTicket=ticket";
-    player.sourceIdentity = "/tmp/voice.caf";
-    player.label = "voice.caf";
-    player.playback = "transcode";
-    document.body.append(player);
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
-
-    player.remove();
-    document.body.append(player);
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
-    await vi.waitFor(() =>
-      expect(player.querySelector("audio")?.getAttribute("src")).toContain("playback=1"),
-    );
-  });
-
   it("cancels the old source when identity changes during rendition preparation", async () => {
     let resolveFetch: ((response: Response) => void) | undefined;
     vi.stubGlobal(
@@ -576,32 +494,6 @@ describe("ChatAudioPlayer", () => {
     await vi.waitFor(() => expect(media.getAttribute("src")).toContain("playback=1"));
     media.dispatchEvent(new Event("loadedmetadata"));
     expect(play).not.toHaveBeenCalled();
-  });
-
-  it("clears a failed rendition after reconnect succeeds", async () => {
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(new Response(null, { status: 500 }))
-      .mockResolvedValueOnce(new Response(null, { status: 200 }));
-    vi.stubGlobal("fetch", fetchMock);
-    const player = document.createElement("openclaw-chat-audio-player");
-    player.src = "/__openclaw__/assistant-media?source=voice.caf&mediaTicket=ticket";
-    player.sourceIdentity = "/tmp/retry-voice.caf";
-    player.label = "voice.caf";
-    player.playback = "transcode";
-    document.body.append(player);
-    await vi.waitFor(() =>
-      expect(
-        player.querySelector(".chat-assistant-attachment-card__reason")?.textContent,
-      ).toContain("Can't play this format"),
-    );
-
-    player.remove();
-    document.body.append(player);
-    await vi.waitFor(() =>
-      expect(player.querySelector("audio")?.getAttribute("src")).toContain("playback=1"),
-    );
-    expect(player.textContent).not.toContain("Can't play this format — download instead.");
   });
 
   it("does not auto-resume a refreshed source after disconnecting before metadata", async () => {

--- a/ui/src/pages/chat/components/chat-audio-player.ts
+++ b/ui/src/pages/chat/components/chat-audio-player.ts
@@ -21,12 +21,7 @@ import {
   shouldFetchChatAudioWaveform,
   type CachedChatAudioBlob,
 } from "./chat-audio-waveform.ts";
-import {
-  appendChatMediaPlaybackParam,
-  buildChatMediaFetchHeaders,
-  waitForChatMediaPlayback,
-  type ChatMediaPlaybackMode,
-} from "./chat-media-playback.ts";
+import { buildChatMediaFetchHeaders, type ChatMediaPlaybackMode } from "./chat-media-playback.ts";
 import { ChatMediaSourceController } from "./chat-media-source.ts";
 
 const SEEK_STEP_SECONDS = 5;
@@ -100,19 +95,11 @@ class ChatAudioPlayer extends OpenClawLightDomContentsElement {
   @state() private duration = 0;
   @state() private buffered = 0;
   @state() private playing = false;
-  @state() private failed = false;
-  @state() private preparing = false;
-  @state() private playbackReady = true;
   @state() private waveformPeaks: readonly number[] | null = null;
 
   private media: HTMLAudioElement | null = null;
   private readonly sourceController = new ChatMediaSourceController();
-  private currentSourceFailed = false;
   private readonly cancelPendingResume = () => this.sourceController.cancelPendingResume();
-  private readinessController: AbortController | null = null;
-  private readinessKey = "";
-  private readinessPromise: Promise<boolean> | null = null;
-  private readySource = "";
   private playRequest: Promise<void> | null = null;
   private releaseWaveformBlob: (() => void) | undefined;
   private waveformController: AbortController | null = null;
@@ -124,19 +111,13 @@ class ChatAudioPlayer extends OpenClawLightDomContentsElement {
   }
 
   override disconnectedCallback(): void {
-    this.readinessController?.abort();
-    this.readinessController = null;
-    this.readinessKey = "";
-    this.readinessPromise = null;
-    this.readySource = "";
-    this.playbackReady = this.playback !== "transcode";
+    this.sourceController.cancel();
     this.releaseWaveformBlob?.();
     this.releaseWaveformBlob = undefined;
     this.waveformController?.abort();
     this.waveformController = null;
     this.waveformAttempted = false;
     if (this.media) {
-      this.sourceController.cancelPendingResume();
       if (!this.media.paused) {
         this.media.pause();
       }
@@ -174,10 +155,6 @@ class ChatAudioPlayer extends OpenClawLightDomContentsElement {
           this.media.pause();
           releaseChatAudioPlayback(this.media);
         }
-        if ((sourceIdentityChanged || changedProperties.has("authToken")) && this.media) {
-          this.sourceController.reset(this.media);
-          this.currentSourceFailed = false;
-        }
       }
       this.syncSource();
     }
@@ -190,77 +167,25 @@ class ChatAudioPlayer extends OpenClawLightDomContentsElement {
 
   private syncSource(): void {
     const media = this.media;
-    const source = this.src.trim();
-    if (!media || !source || !this.sourceIdentity.trim() || !this.isConnected) {
+    if (!media || !this.isConnected) {
       return;
     }
     if (this.releaseWaveformBlob) {
       return;
     }
-    const playbackSource =
-      this.playback === "transcode" ? appendChatMediaPlaybackParam(source) : source;
-    const hasCurrentAttachmentSource =
-      this.sourceController.currentIdentity === this.sourceIdentity.trim();
-    const hasUsableCurrentAttachmentSource =
-      hasCurrentAttachmentSource && !this.currentSourceFailed;
-    if (this.playback !== "transcode") {
-      this.readinessController?.abort();
-      this.readinessController = null;
-      this.readinessKey = "";
-      this.readinessPromise = null;
-      this.preparing = false;
-      this.playbackReady = true;
-      this.readySource = playbackSource;
-      this.failed = false;
-      this.currentSourceFailed = false;
-      this.sourceController.updateSource(media, playbackSource, this.sourceIdentity);
-      return;
-    }
-
-    const readinessKey = `${playbackSource}\0${this.authToken?.trim() ?? ""}`;
-    if (readinessKey === this.readinessKey && this.readinessController && this.readinessPromise) {
-      return;
-    }
-    this.readinessController?.abort();
-    const controller = new AbortController();
-    this.readinessController = controller;
-    this.readinessKey = readinessKey;
-    this.readySource = "";
-    this.preparing = !hasUsableCurrentAttachmentSource;
-    this.playbackReady = hasUsableCurrentAttachmentSource;
-    this.failed = false;
-    const pending = waitForChatMediaPlayback({
-      source: playbackSource,
-      authToken: this.authToken,
-      signal: controller.signal,
-      onPreparing: () => {
-        if (this.readinessController === controller && !hasUsableCurrentAttachmentSource) {
-          this.preparing = true;
-        }
-      },
-    }).then((result) => {
-      if (this.readinessController !== controller || result === "aborted") {
-        return false;
+    const pending = this.sourceController.sync(
+      media,
+      this.src,
+      this.sourceIdentity,
+      this.playback,
+      this.authToken,
+    );
+    this.requestUpdate();
+    void pending?.then(() => {
+      if (this.isConnected) {
+        this.requestUpdate();
       }
-      this.preparing = false;
-      if (result !== "ready") {
-        if (hasUsableCurrentAttachmentSource) {
-          this.readySource = this.sourceController.currentSource;
-          this.playbackReady = true;
-          return true;
-        }
-        this.failed = true;
-        this.playbackReady = false;
-        return false;
-      }
-      this.readySource = playbackSource;
-      this.playbackReady = true;
-      this.failed = false;
-      this.currentSourceFailed = false;
-      this.sourceController.updateSource(media, playbackSource, this.sourceIdentity);
-      return true;
     });
-    this.readinessPromise = pending;
   }
 
   private resolveWaveformCacheKey(): string {
@@ -306,7 +231,7 @@ class ChatAudioPlayer extends OpenClawLightDomContentsElement {
 
   private async prepareWaveformAudio(): Promise<void> {
     const media = this.media;
-    const source = this.readySource;
+    const source = this.sourceController.readySource;
     if (!media || !source || this.releaseWaveformBlob || this.waveformAttempted) {
       return;
     }
@@ -410,7 +335,7 @@ class ChatAudioPlayer extends OpenClawLightDomContentsElement {
 
   private togglePlayback(): void {
     const media = this.media;
-    if (!media || !this.playbackReady) {
+    if (!media || this.sourceController.readiness !== "ready") {
       return;
     }
     if (media.paused) {
@@ -517,6 +442,7 @@ class ChatAudioPlayer extends OpenClawLightDomContentsElement {
   override render() {
     const progress = this.duration > 0 ? Math.min(1, this.currentTime / this.duration) : 0;
     const downloadHref = safeAttachmentHref(this.src);
+    const failed = this.sourceController.readiness === "unavailable";
     return html`
       <div class="chat-assistant-attachment-card chat-assistant-attachment-card--audio">
         <div class="chat-assistant-attachment-card__header">
@@ -527,7 +453,7 @@ class ChatAudioPlayer extends OpenClawLightDomContentsElement {
                   >${t("chat.messages.voiceNote")}</span
                 >`
               : null}
-            ${downloadHref && !this.failed
+            ${downloadHref && !failed
               ? html`<!-- The download attribute is ignored for cross-origin URLs (rare here — attachment
                   hrefs are same-origin gateway routes); those open in a new tab instead. -->
                   <a
@@ -543,7 +469,7 @@ class ChatAudioPlayer extends OpenClawLightDomContentsElement {
               : null}
           </span>
         </div>
-        ${this.failed
+        ${failed
           ? html`<div class="chat-assistant-attachment-card__reason">
               ${t("chat.mediaPlayer.videoUnavailable")}
               ${downloadHref
@@ -557,7 +483,7 @@ class ChatAudioPlayer extends OpenClawLightDomContentsElement {
                   >`
                 : null}
             </div> `
-          : this.preparing
+          : this.sourceController.readiness === "preparing"
             ? html`<div class="chat-assistant-attachment-card__reason chat-media-preparing">
                 ${t("chat.mediaPlayer.preparing")}
               </div>`
@@ -569,7 +495,8 @@ class ChatAudioPlayer extends OpenClawLightDomContentsElement {
                 <button
                   type="button"
                   class="chat-audio-player__toggle"
-                  ?disabled=${!this.playbackReady}
+                  ?disabled=${this.playback === "transcode" &&
+                  this.sourceController.readiness !== "ready"}
                   aria-label=${t(this.playing ? "chat.mediaPlayer.pause" : "chat.mediaPlayer.play")}
                   @click=${() => this.togglePlayback()}
                 >
@@ -596,8 +523,6 @@ class ChatAudioPlayer extends OpenClawLightDomContentsElement {
             );
             this.duration = Number.isFinite(this.media.duration) ? this.media.duration : 0;
             this.currentTime = this.media.currentTime;
-            this.failed = false;
-            this.currentSourceFailed = false;
             this.updateBuffered();
             this.onMediaLoaded?.();
           }}
@@ -633,9 +558,8 @@ class ChatAudioPlayer extends OpenClawLightDomContentsElement {
             if (this.media && !this.sourceController.handleError(this.media)) {
               releaseChatAudioPlayback(this.media);
               this.playing = false;
-              this.failed = true;
-              this.currentSourceFailed = true;
             }
+            this.requestUpdate();
           }}
         ></audio>
       </div>

--- a/ui/src/pages/chat/components/chat-media-source.test.ts
+++ b/ui/src/pages/chat/components/chat-media-source.test.ts
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { ChatMediaSourceController } from "./chat-media-source.ts";
 
 function mockMediaState(
@@ -43,7 +43,208 @@ function mockMediaState(
   };
 }
 
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
 describe("ChatMediaSourceController", () => {
+  it("normalizes and applies native playback immediately", () => {
+    const media = document.createElement("audio");
+    const controller = new ChatMediaSourceController();
+
+    expect(controller.sync(media, "  /media/native.mp3  ", "  media:native  ", "native")).toBe(
+      null,
+    );
+
+    expect(controller.readiness).toBe("ready");
+    expect(controller.readySource).toBe("/media/native.mp3");
+    expect(controller.currentIdentity).toBe("media:native");
+    expect(media.getAttribute("src")).toBe("/media/native.mp3");
+  });
+
+  it("keeps preparation pending across a 202 and applies the ready rendition", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 202 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const media = document.createElement("video");
+    const controller = new ChatMediaSourceController();
+
+    const pending = controller.sync(
+      media,
+      "/media/clip.avi?mediaTicket=ticket",
+      "media:clip",
+      "transcode",
+    );
+    expect(controller.readiness).toBe("preparing");
+    expect(media.hasAttribute("src")).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    await pending;
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(controller.readiness).toBe("ready");
+    expect(media.getAttribute("src")).toContain("mediaTicket=ticket&playback=1");
+  });
+
+  it("aborts preparation and starts it again after reconnect", async () => {
+    let firstSignal: AbortSignal | undefined;
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockImplementationOnce(
+        async (_source, init) =>
+          await new Promise<Response>((_resolve, reject) => {
+            firstSignal = init?.signal ?? undefined;
+            firstSignal?.addEventListener(
+              "abort",
+              () => reject(new DOMException("disconnected", "AbortError")),
+              { once: true },
+            );
+          }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const media = document.createElement("audio");
+    const controller = new ChatMediaSourceController();
+    const source = "/media/voice.caf?mediaTicket=ticket";
+
+    const first = controller.sync(media, source, "media:voice", "transcode");
+    controller.cancel();
+    expect(firstSignal?.aborted).toBe(true);
+    expect(controller.readiness).toBe("idle");
+
+    const second = controller.sync(media, source, "media:voice", "transcode");
+    await Promise.all([first, second]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(controller.readiness).toBe("ready");
+    expect(media.getAttribute("src")).toContain("playback=1");
+  });
+
+  it("suppresses a stale completion after the readiness identity changes", async () => {
+    let resolveOld: ((response: Response) => void) | undefined;
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockImplementationOnce(
+        async () =>
+          await new Promise<Response>((resolve) => {
+            resolveOld = resolve;
+          }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const media = document.createElement("video");
+    const controller = new ChatMediaSourceController();
+
+    const oldRequest = controller.sync(
+      media,
+      "/media/old.avi?mediaTicket=old",
+      "media:old",
+      "transcode",
+      "old-token",
+    );
+    const newRequest = controller.sync(
+      media,
+      "/media/new.avi?mediaTicket=new",
+      "media:new",
+      "transcode",
+      "new-token",
+    );
+    await newRequest;
+    resolveOld?.(new Response(null, { status: 200 }));
+    await oldRequest;
+
+    expect(controller.currentIdentity).toBe("media:new");
+    expect(media.getAttribute("src")).toContain("mediaTicket=new&playback=1");
+  });
+
+  it("keeps a usable same-identity source when a refresh is unavailable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => new Response(null, { status: 500 })),
+    );
+    const media = document.createElement("audio");
+    const controller = new ChatMediaSourceController();
+    controller.sync(media, "/media/voice.mp3?mediaTicket=old", "media:voice", "native");
+    expect(controller.handleError(media)).toBe(false);
+    controller.sync(media, "/media/voice.mp3?mediaTicket=old", "media:voice", "native");
+
+    const pending = controller.sync(
+      media,
+      "/media/voice.mp3?mediaTicket=fresh",
+      "media:voice",
+      "transcode",
+    );
+    expect(controller.readiness).toBe("ready");
+    await pending;
+
+    expect(controller.readiness).toBe("ready");
+    expect(controller.readySource).toContain("mediaTicket=old");
+    expect(media.getAttribute("src")).toContain("mediaTicket=old");
+  });
+
+  it("reports an unavailable rendition when there is no usable fallback", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => new Response(null, { status: 500 })),
+    );
+    const media = document.createElement("audio");
+    const controller = new ChatMediaSourceController();
+    controller.sync(media, "/media/voice.caf?mediaTicket=old", "media:voice", "native");
+    expect(controller.handleError(media)).toBe(false);
+
+    await controller.sync(
+      media,
+      "/media/voice.caf?mediaTicket=refresh",
+      "media:voice",
+      "transcode",
+    );
+
+    expect(controller.readiness).toBe("unavailable");
+    expect(controller.readySource).toBe("");
+    expect(media.getAttribute("src")).toContain("mediaTicket=old");
+  });
+
+  it.each([
+    {
+      boundary: "authentication",
+      source: "/media/protected.caf?mediaTicket=refresh",
+      identity: "media:protected",
+      authToken: "principal-b",
+    },
+    {
+      boundary: "source identity",
+      source: "/media/replacement.caf?mediaTicket=refresh",
+      identity: "media:replacement",
+      authToken: "principal-a",
+    },
+  ])("removes the old source when a changed $boundary is unavailable", async (next) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => new Response(null, { status: 500 })),
+    );
+    const media = document.createElement("video");
+    const controller = new ChatMediaSourceController();
+    controller.sync(
+      media,
+      "/media/protected.mp4?mediaTicket=old",
+      "media:protected",
+      "native",
+      "principal-a",
+    );
+
+    const pending = controller.sync(media, next.source, next.identity, "transcode", next.authToken);
+    expect(media.hasAttribute("src")).toBe(false);
+    await pending;
+
+    expect(controller.readiness).toBe("unavailable");
+    expect(media.hasAttribute("src")).toBe(false);
+  });
+
   it("queues a refreshed ticket while paused mid-stream and restores it after failure", async () => {
     const media = document.createElement("audio");
     const state = { currentTime: 0, duration: 120, paused: true };
@@ -58,7 +259,6 @@ describe("ChatMediaSourceController", () => {
     controller.updateSource(media, "/media?mediaTicket=fresh", "/tmp/audio.mp3");
 
     expect(media.getAttribute("src")).toBe("/media?mediaTicket=old");
-    expect(controller.queuedSource).toBe("/media?mediaTicket=fresh");
 
     expect(controller.handleError(media)).toBe(true);
     expect(media.getAttribute("src")).toBe("/media?mediaTicket=fresh");
@@ -131,7 +331,6 @@ describe("ChatMediaSourceController", () => {
 
     expect(media.hasAttribute("src")).toBe(false);
     expect(load).toHaveBeenCalledOnce();
-    expect(controller.currentSource).toBe("");
     expect(controller.currentIdentity).toBe("");
   });
 
@@ -148,7 +347,6 @@ describe("ChatMediaSourceController", () => {
     controller.updateSource(media, "/media?mediaTicket=fresh", "/tmp/audio.mp3");
 
     expect(media.getAttribute("src")).toBe("/media?mediaTicket=fresh");
-    expect(controller.queuedSource).toBe("");
     media.currentTime = 0;
     state.error = null;
     controller.handleLoadedMetadata(media);
@@ -169,6 +367,5 @@ describe("ChatMediaSourceController", () => {
 
     expect(pause).toHaveBeenCalledOnce();
     expect(media.getAttribute("src")).toBe("/media?mediaTicket=second");
-    expect(controller.queuedSource).toBe("");
   });
 });

--- a/ui/src/pages/chat/components/chat-media-source.test.ts
+++ b/ui/src/pages/chat/components/chat-media-source.test.ts
@@ -169,9 +169,9 @@ describe("ChatMediaSourceController", () => {
     );
     const media = document.createElement("audio");
     const controller = new ChatMediaSourceController();
-    controller.sync(media, "/media/voice.mp3?mediaTicket=old", "media:voice", "native");
+    void controller.sync(media, "/media/voice.mp3?mediaTicket=old", "media:voice", "native");
     expect(controller.handleError(media)).toBe(false);
-    controller.sync(media, "/media/voice.mp3?mediaTicket=old", "media:voice", "native");
+    void controller.sync(media, "/media/voice.mp3?mediaTicket=old", "media:voice", "native");
 
     const pending = controller.sync(
       media,
@@ -194,7 +194,7 @@ describe("ChatMediaSourceController", () => {
     );
     const media = document.createElement("audio");
     const controller = new ChatMediaSourceController();
-    controller.sync(media, "/media/voice.caf?mediaTicket=old", "media:voice", "native");
+    void controller.sync(media, "/media/voice.caf?mediaTicket=old", "media:voice", "native");
     expect(controller.handleError(media)).toBe(false);
 
     await controller.sync(
@@ -229,7 +229,7 @@ describe("ChatMediaSourceController", () => {
     );
     const media = document.createElement("video");
     const controller = new ChatMediaSourceController();
-    controller.sync(
+    void controller.sync(
       media,
       "/media/protected.mp4?mediaTicket=old",
       "media:protected",

--- a/ui/src/pages/chat/components/chat-media-source.ts
+++ b/ui/src/pages/chat/components/chat-media-source.ts
@@ -1,3 +1,9 @@
+import {
+  appendChatMediaPlaybackParam,
+  waitForChatMediaPlayback,
+  type ChatMediaPlaybackMode,
+} from "./chat-media-playback.ts";
+
 type PlaybackRestore = {
   currentTime: number;
   paused: boolean;
@@ -14,17 +20,102 @@ export class ChatMediaSourceController {
   private pendingSource = "";
   private pendingIdentity = "";
   private restore: PlaybackRestore | null = null;
-
-  get currentSource(): string {
-    return this.appliedSource;
-  }
+  private sourceFailed = false;
+  private authorizationKey = "";
+  private readinessRequest: {
+    key: string;
+    controller: AbortController;
+    promise: Promise<void>;
+  } | null = null;
+  private playbackSource = "";
+  private playbackReadiness: "idle" | "preparing" | "ready" | "unavailable" = "idle";
 
   get currentIdentity(): string {
     return this.appliedIdentity;
   }
 
-  get queuedSource(): string {
-    return this.pendingSource;
+  get readySource(): string {
+    return this.playbackSource;
+  }
+
+  get readiness() {
+    return this.playbackReadiness;
+  }
+
+  sync(
+    media: HTMLMediaElement,
+    source: string,
+    sourceIdentity: string,
+    playback: ChatMediaPlaybackMode,
+    authToken?: string | null,
+  ): Promise<void> | null {
+    const nextSource = source.trim();
+    const nextIdentity = sourceIdentity.trim();
+    const nextAuthToken = authToken?.trim() ?? "";
+    if (!nextSource || !nextIdentity) {
+      return null;
+    }
+
+    const authorizationKey = `${nextIdentity}\0${nextAuthToken}`;
+    if (this.authorizationKey && authorizationKey !== this.authorizationKey) {
+      this.reset(media);
+    }
+    this.authorizationKey = authorizationKey;
+
+    const nextPlaybackSource =
+      playback === "transcode" ? appendChatMediaPlaybackParam(nextSource) : nextSource;
+    if (playback !== "transcode") {
+      this.abortReadiness();
+      this.sourceFailed = false;
+      this.playbackReadiness = "ready";
+      this.playbackSource = nextPlaybackSource;
+      this.updateSource(media, nextPlaybackSource, nextIdentity);
+      return null;
+    }
+
+    const readinessKey = [nextPlaybackSource, nextIdentity, nextAuthToken].join("\0");
+    if (readinessKey === this.readinessRequest?.key) {
+      if (this.playbackSource === nextPlaybackSource) {
+        this.updateSource(media, nextPlaybackSource, nextIdentity);
+      }
+      return this.readinessRequest.promise;
+    }
+
+    this.abortReadiness();
+    const controller = new AbortController();
+    const hasUsableSource = () => this.appliedIdentity === nextIdentity && !this.sourceFailed;
+    this.playbackSource = "";
+    this.playbackReadiness = hasUsableSource() ? "ready" : "preparing";
+    const pending = waitForChatMediaPlayback({
+      source: nextPlaybackSource,
+      authToken: nextAuthToken || null,
+      signal: controller.signal,
+    }).then((result) => {
+      if (this.readinessRequest?.controller !== controller || result === "aborted") {
+        return;
+      }
+      if (result !== "ready") {
+        if (hasUsableSource()) {
+          this.playbackSource = this.appliedSource;
+          this.playbackReadiness = "ready";
+        } else {
+          this.playbackReadiness = "unavailable";
+        }
+        return;
+      }
+      this.playbackSource = nextPlaybackSource;
+      this.playbackReadiness = "ready";
+      this.updateSource(media, nextPlaybackSource, nextIdentity);
+    });
+    this.readinessRequest = { key: readinessKey, controller, promise: pending };
+    return pending;
+  }
+
+  cancel(): void {
+    this.abortReadiness();
+    this.cancelPendingResume();
+    this.playbackSource = "";
+    this.playbackReadiness = "idle";
   }
 
   updateSource(media: HTMLMediaElement, source: string, sourceIdentity = source): void {
@@ -33,6 +124,7 @@ export class ChatMediaSourceController {
     if (!nextSource || !nextIdentity) {
       return;
     }
+    this.playbackReadiness = "ready";
     if (this.appliedIdentity && nextIdentity !== this.appliedIdentity) {
       if (!media.paused) {
         media.pause();
@@ -77,6 +169,9 @@ export class ChatMediaSourceController {
 
   handleError(media: HTMLMediaElement): boolean {
     if (!this.pendingSource) {
+      this.sourceFailed = true;
+      this.playbackSource = "";
+      this.playbackReadiness = "unavailable";
       return false;
     }
     this.applySource(media, this.pendingSource, this.pendingIdentity, {
@@ -121,16 +216,22 @@ export class ChatMediaSourceController {
   }
 
   reset(media: HTMLMediaElement): void {
+    if (!media.paused) {
+      media.pause();
+    }
     this.appliedSource = "";
     this.appliedIdentity = "";
     this.pendingSource = "";
     this.pendingIdentity = "";
     this.restore = null;
+    this.sourceFailed = false;
+    this.playbackSource = "";
     media.removeAttribute("src");
     media.load();
   }
 
   handleLoadedMetadata(media: HTMLMediaElement, canResume = () => true): void {
+    this.sourceFailed = false;
     const restore = this.restore;
     if (!restore) {
       return;
@@ -154,6 +255,12 @@ export class ChatMediaSourceController {
     this.pendingSource = "";
     this.pendingIdentity = "";
     this.restore = restore;
+    this.sourceFailed = false;
     media.src = source;
+  }
+
+  private abortReadiness(): void {
+    this.readinessRequest?.controller.abort();
+    this.readinessRequest = null;
   }
 }

--- a/ui/src/pages/chat/components/chat-video-player.test.ts
+++ b/ui/src/pages/chat/components/chat-video-player.test.ts
@@ -70,46 +70,6 @@ describe("ChatVideoPlayer", () => {
     );
   });
 
-  it("does not retain an errored source when a refreshed rendition is unavailable", async () => {
-    let resolveFirstRefresh: ((response: Response) => void) | undefined;
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(new Response(null, { status: 200 }))
-      .mockImplementationOnce(
-        async () =>
-          await new Promise<Response>((resolve) => {
-            resolveFirstRefresh = resolve;
-          }),
-      )
-      .mockResolvedValueOnce(new Response(null, { status: 500 }));
-    vi.stubGlobal("fetch", fetchMock);
-    const player = document.createElement("openclaw-chat-video-player");
-    player.src = "/__openclaw__/assistant-media?source=clip.avi&mediaTicket=old";
-    player.sourceIdentity = "media:clip";
-    player.label = "clip.avi";
-    player.playback = "transcode";
-    document.body.append(player);
-    await vi.waitFor(() =>
-      expect(player.querySelector("video")?.getAttribute("src")).toContain("mediaTicket=old"),
-    );
-
-    player.querySelector("video")?.dispatchEvent(new Event("error"));
-    await player.updateComplete;
-    player.src = "/__openclaw__/assistant-media?source=clip.avi&mediaTicket=refresh-1";
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
-    player.src = "/__openclaw__/assistant-media?source=clip.avi&mediaTicket=refresh-2";
-
-    await vi.waitFor(() =>
-      expect(
-        player
-          .querySelector(".chat-assistant-attachment-card--video")
-          ?.hasAttribute("data-unplayable"),
-      ).toBe(true),
-    );
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    resolveFirstRefresh?.(new Response(null, { status: 200 }));
-  });
-
   it("hides a previous attachment while the replacement HEAD is stalled", async () => {
     const player = document.createElement("openclaw-chat-video-player");
     player.src = "https://example.com/first.mp4";
@@ -129,68 +89,6 @@ describe("ChatVideoPlayer", () => {
     expect(fetchMock).toHaveBeenCalledOnce();
     await vi.waitFor(() => expect(player.textContent).toContain("Preparing playback…"));
     expect(player.querySelector("video")?.hasAttribute("src")).toBe(false);
-  });
-
-  it("clears authorized video while a new principal is checked", async () => {
-    let resolveRefresh: ((response: Response) => void) | undefined;
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(new Response(null, { status: 200 }))
-      .mockImplementationOnce(
-        async () =>
-          await new Promise<Response>((resolve) => {
-            resolveRefresh = resolve;
-          }),
-      );
-    vi.stubGlobal("fetch", fetchMock);
-    const player = document.createElement("openclaw-chat-video-player");
-    player.src = "/__openclaw__/assistant-media?source=clip.avi&mediaTicket=ticket";
-    player.sourceIdentity = "media:principal-clip";
-    player.authToken = "principal-a";
-    player.label = "clip.avi";
-    player.playback = "transcode";
-    document.body.append(player);
-    await vi.waitFor(() =>
-      expect(player.querySelector("video")?.getAttribute("src")).toContain("playback=1"),
-    );
-
-    player.authToken = "principal-b";
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
-    await vi.waitFor(() => expect(player.textContent).toContain("Preparing playback…"));
-    expect(player.querySelector("video")?.hasAttribute("src")).toBe(false);
-    resolveRefresh?.(new Response(null, { status: 500 }));
-  });
-
-  it("clears a failed rendition after reconnect succeeds", async () => {
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(new Response(null, { status: 500 }))
-      .mockResolvedValueOnce(new Response(null, { status: 200 }));
-    vi.stubGlobal("fetch", fetchMock);
-    const player = document.createElement("openclaw-chat-video-player");
-    player.src = "/__openclaw__/assistant-media?source=clip.avi&mediaTicket=ticket";
-    player.sourceIdentity = "media:retry-clip";
-    player.label = "clip.avi";
-    player.playback = "transcode";
-    document.body.append(player);
-    await vi.waitFor(() =>
-      expect(
-        player
-          .querySelector(".chat-assistant-attachment-card--video")
-          ?.hasAttribute("data-unplayable"),
-      ).toBe(true),
-    );
-
-    player.remove();
-    document.body.append(player);
-    await vi.waitFor(() =>
-      expect(player.querySelector("video")?.getAttribute("src")).toContain("playback=1"),
-    );
-    expect(
-      player
-        .querySelector(".chat-assistant-attachment-card--video")
-        ?.hasAttribute("data-unplayable"),
-    ).toBe(false);
   });
 
   it("pauses and clears the source when disconnected while playing", async () => {

--- a/ui/src/pages/chat/components/chat-video-player.ts
+++ b/ui/src/pages/chat/components/chat-video-player.ts
@@ -6,7 +6,7 @@ import { icons } from "../../../components/icons.ts";
 import { t } from "../../../i18n/index.ts";
 import { OpenClawLightDomContentsElement } from "../../../lit/openclaw-element.ts";
 import { safeAttachmentHref } from "./chat-attachment-href.ts";
-import { type ChatMediaPlaybackMode } from "./chat-media-playback.ts";
+import type { ChatMediaPlaybackMode } from "./chat-media-playback.ts";
 import { ChatMediaSourceController } from "./chat-media-source.ts";
 
 class ChatVideoPlayer extends OpenClawLightDomContentsElement {

--- a/ui/src/pages/chat/components/chat-video-player.ts
+++ b/ui/src/pages/chat/components/chat-video-player.ts
@@ -6,11 +6,7 @@ import { icons } from "../../../components/icons.ts";
 import { t } from "../../../i18n/index.ts";
 import { OpenClawLightDomContentsElement } from "../../../lit/openclaw-element.ts";
 import { safeAttachmentHref } from "./chat-attachment-href.ts";
-import {
-  appendChatMediaPlaybackParam,
-  waitForChatMediaPlayback,
-  type ChatMediaPlaybackMode,
-} from "./chat-media-playback.ts";
+import { type ChatMediaPlaybackMode } from "./chat-media-playback.ts";
 import { ChatMediaSourceController } from "./chat-media-source.ts";
 
 class ChatVideoPlayer extends OpenClawLightDomContentsElement {
@@ -24,15 +20,9 @@ class ChatVideoPlayer extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) onMediaLoaded: (() => void) | undefined;
 
   @state() private metadataLoaded = false;
-  @state() private failed = false;
-  @state() private preparing = false;
 
   private media: HTMLVideoElement | null = null;
   private readonly sourceController = new ChatMediaSourceController();
-  private currentSourceFailed = false;
-  private readinessController: AbortController | null = null;
-  private readinessKey = "";
-  private readySource = "";
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -40,15 +30,8 @@ class ChatVideoPlayer extends OpenClawLightDomContentsElement {
   }
 
   override disconnectedCallback(): void {
-    this.readinessController?.abort();
-    this.readinessController = null;
-    this.readinessKey = "";
-    this.readySource = "";
-    this.sourceController.cancelPendingResume();
+    this.sourceController.cancel();
     if (this.media) {
-      if (!this.media.paused) {
-        this.media.pause();
-      }
       this.sourceController.reset(this.media);
     }
     super.disconnectedCallback();
@@ -69,13 +52,6 @@ class ChatVideoPlayer extends OpenClawLightDomContentsElement {
           this.sourceController.currentIdentity !== this.sourceIdentity.trim())
       ) {
         this.metadataLoaded = false;
-        if (this.media && !this.media.paused) {
-          this.media.pause();
-        }
-        if (this.media) {
-          this.sourceController.reset(this.media);
-          this.currentSourceFailed = false;
-        }
       }
       this.syncSource();
     }
@@ -88,80 +64,30 @@ class ChatVideoPlayer extends OpenClawLightDomContentsElement {
 
   private syncSource(): void {
     const media = this.media;
-    const source = this.src.trim();
-    if (!media || !source || !this.sourceIdentity.trim() || !this.isConnected) {
+    if (!media || !this.isConnected) {
       return;
     }
-    const playbackSource =
-      this.playback === "transcode" ? appendChatMediaPlaybackParam(source) : source;
-    const hasCurrentAttachmentSource =
-      this.sourceController.currentIdentity === this.sourceIdentity.trim();
-    const hasUsableCurrentAttachmentSource =
-      hasCurrentAttachmentSource && !this.currentSourceFailed;
-    if (this.playback !== "transcode") {
-      this.readinessController?.abort();
-      this.readinessController = null;
-      this.readinessKey = "";
-      this.readySource = playbackSource;
-      this.preparing = false;
-      this.failed = false;
-      this.currentSourceFailed = false;
-      this.sourceController.updateSource(media, playbackSource, this.sourceIdentity);
-      return;
-    }
-
-    const readinessKey = `${playbackSource}\0${this.authToken?.trim() ?? ""}`;
-    if (!hasUsableCurrentAttachmentSource) {
+    const pending = this.sourceController.sync(
+      media,
+      this.src,
+      this.sourceIdentity,
+      this.playback,
+      this.authToken,
+    );
+    if (this.sourceController.readiness === "preparing") {
       this.metadataLoaded = false;
-      this.preparing = true;
     }
-    if (readinessKey === this.readinessKey) {
-      if (this.readySource === playbackSource) {
-        this.sourceController.updateSource(media, playbackSource, this.sourceIdentity);
-        return;
+    this.requestUpdate();
+    void pending?.then(() => {
+      if (this.isConnected) {
+        this.requestUpdate();
       }
-      if (this.readinessController) {
-        return;
-      }
-    }
-    this.readinessController?.abort();
-    const controller = new AbortController();
-    this.readinessController = controller;
-    this.readinessKey = readinessKey;
-    this.readySource = "";
-    this.preparing = !hasUsableCurrentAttachmentSource;
-    this.failed = false;
-    void waitForChatMediaPlayback({
-      source: playbackSource,
-      authToken: this.authToken,
-      signal: controller.signal,
-      onPreparing: () => {
-        if (this.readinessController === controller && !hasUsableCurrentAttachmentSource) {
-          this.preparing = true;
-        }
-      },
-    }).then((result) => {
-      if (this.readinessController !== controller || result === "aborted") {
-        return;
-      }
-      this.preparing = false;
-      if (result !== "ready") {
-        if (hasUsableCurrentAttachmentSource) {
-          this.readySource = this.sourceController.currentSource;
-          return;
-        }
-        this.failed = true;
-        return;
-      }
-      this.readySource = playbackSource;
-      this.failed = false;
-      this.currentSourceFailed = false;
-      this.sourceController.updateSource(media, playbackSource, this.sourceIdentity);
     });
   }
 
   override render() {
     const downloadHref = safeAttachmentHref(this.src);
+    const preparing = this.sourceController.readiness === "preparing";
     const dimensions =
       this.mediaWidth && this.mediaHeight
         ? { "aspect-ratio": `${this.mediaWidth} / ${this.mediaHeight}` }
@@ -170,7 +96,7 @@ class ChatVideoPlayer extends OpenClawLightDomContentsElement {
       <div
         class="chat-assistant-attachment-card chat-assistant-attachment-card--video"
         ?data-metadata-loaded=${this.metadataLoaded}
-        ?data-unplayable=${this.failed}
+        ?data-unplayable=${this.sourceController.readiness === "unavailable"}
       >
         <div class="chat-assistant-attachment-card__header">
           <span class="chat-assistant-attachment-card__title">${this.label}</span>
@@ -187,16 +113,12 @@ class ChatVideoPlayer extends OpenClawLightDomContentsElement {
               >`
             : null}
         </div>
-        ${this.preparing
+        ${preparing
           ? html`<div class="chat-assistant-attachment-card__reason chat-media-preparing">
               ${t("chat.mediaPlayer.preparing")}
             </div>`
           : null}
-        <div
-          class="chat-assistant-video-frame"
-          style=${styleMap(dimensions)}
-          ?hidden=${this.preparing}
-        >
+        <div class="chat-assistant-video-frame" style=${styleMap(dimensions)} ?hidden=${preparing}>
           <span class="chat-assistant-video-frame__placeholder" aria-hidden="true"
             >${icons.monitor}</span
           >
@@ -210,8 +132,6 @@ class ChatVideoPlayer extends OpenClawLightDomContentsElement {
               }
               this.sourceController.handleLoadedMetadata(this.media);
               this.metadataLoaded = true;
-              this.failed = false;
-              this.currentSourceFailed = false;
               this.onMediaLoaded?.();
             }}
             @ended=${() => {
@@ -222,13 +142,13 @@ class ChatVideoPlayer extends OpenClawLightDomContentsElement {
             @seeking=${() => {
               if (this.media?.error && this.sourceController.handleError(this.media)) {
                 this.metadataLoaded = false;
-                this.failed = false;
+                this.requestUpdate();
               }
             }}
             @error=${() => {
-              if (this.media && !this.sourceController.handleError(this.media)) {
-                this.failed = true;
-                this.currentSourceFailed = true;
+              if (this.media) {
+                this.sourceController.handleError(this.media);
+                this.requestUpdate();
               }
             }}
           ></video>


### PR DESCRIPTION
## What Problem This Solves

The Control UI audio and video players independently owned the same media transcode-readiness lifecycle. Keeping source normalization, rendition retries, cancellation, stale-result suppression, and refresh fallback policy in both components made behavior-preserving maintenance harder and allowed the two paths to drift.

## Why This Change Was Made

Move the shared readiness state machine into `ChatMediaSourceController`: normalized source/identity/auth inputs, native immediate readiness, transcode readiness polling, abort/replacement, stale completion suppression, same-identity fallback, and changed-auth/identity source clearing. Audio keeps waveform Blob substitution, coordinated/single-flight playback, and resume suppression locally; video keeps metadata and aspect/render behavior locally. Duplicate lifecycle tests move to the controller boundary rather than being copied across both components.

## User Impact

No user-visible behavior is intended to change. Audio and video attachments retain preparing/unavailable states, ticket-refresh recovery, continuous playback behavior, waveform reuse, coordinated audio playback, and stable video metadata/aspect rendering.

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-media-source.test.ts ui/src/pages/chat/components/chat-audio-player.test.ts ui/src/pages/chat/components/chat-video-player.test.ts ui/src/pages/chat/components/chat-media-playback.test.ts ui/src/pages/chat/components/chat-message.test.ts ui/src/pages/chat/components/chat-message-media-lifecycle.test.ts` — 6 files, 244 tests passed.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs -- <six changed paths>` — passed the complete `coreTests, ui` plan, including format, dead-export scan, Control UI i18n, core-test/UI tsgo, and targeted oxlint (0 warnings/errors).
- DOM/state assertions cover a single mounted video through 202 → ready, preparing and unavailable fallback text, removal of stale media across identity/auth changes, waveform Blob source reuse, coordinated audio playback, autoplay suppression after disconnect/supersede, and video reconnect source clearing.
- Targeted `pnpm format` and `git diff --check` passed.
- Production LOC: +159/-208 (net -49). Tests: +202/-215 (net -13).
- Remote changed-gate routing was unavailable because the selected Crabbox binary failed wrapper sanity checks, so the documented trusted-source local fallback was used. Autoreview/TruffleHog could not run because TruffleHog is not installed in the orb.
