### PR TITLE
feat(cli): allow editing automation display names

### DIFF
--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -54,7 +54,10 @@ openclaw automations create "*/15 * * * *" \
 
 Use `--display-name <name>` when the list and detail views should show a
 human-readable label distinct from the automation's stable name. Set or update
-that label with `automations add|edit --display-name`.
+that label with `automations add|edit --display-name`. Use
+`automations edit <job-id> --clear-display-name` to remove the label and restore
+the stable name in list and detail views. The set and clear options cannot be
+combined.
 
 ## Sessions
 

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -52,6 +52,10 @@ openclaw automations create "*/15 * * * *" \
 
 `--command <shell>` stores `argv: ["sh", "-lc", <shell>]`. Use `--command-argv '["node","scripts/report.mjs"]'` for exact argv execution. Command jobs capture stdout/stderr, record normal run history, and route output through the same `announce`, `webhook`, or `none` delivery modes as isolated jobs. A command that prints only `NO_REPLY` is suppressed.
 
+Use `--display-name <name>` when the list and detail views should show a
+human-readable label distinct from the automation's stable name. Set or update
+that label with `automations add|edit --display-name`.
+
 ## Sessions
 
 `--session` accepts `main`, `isolated`, `current`, or `session:<id>`.

--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -53,7 +53,23 @@ describe("cron edit command", () => {
     const help = editCommand?.helpInformation() ?? "";
 
     expect(help).toContain("--best-effort-deliver");
+    expect(help).toContain("--display-name <name>");
     expect(help).toMatch(/also\s+implies --announce when used alone/);
+  });
+
+  it("updates the human-readable display name without changing the job name", async () => {
+    await createCronProgram().parseAsync(["edit", "job-1", "--display-name", "Daily summary"], {
+      from: "user",
+    });
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith("cron.update", expect.anything(), {
+      id: "job-1",
+      patch: { displayName: "Daily summary" },
+    });
+  });
+
+  it.each(["", "   "])("rejects a blank --display-name value", async (value) => {
+    await expectCronEditRejection(["--display-name", value], "--display-name must not be blank");
   });
 
   it("updates one pacing bound while preserving the other", async () => {

--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -54,6 +54,7 @@ describe("cron edit command", () => {
 
     expect(help).toContain("--best-effort-deliver");
     expect(help).toContain("--display-name <name>");
+    expect(help).toContain("--clear-display-name");
     expect(help).toMatch(/also\s+implies --announce when used alone/);
   });
 
@@ -70,6 +71,24 @@ describe("cron edit command", () => {
 
   it.each(["", "   "])("rejects a blank --display-name value", async (value) => {
     await expectCronEditRejection(["--display-name", value], "--display-name must not be blank");
+  });
+
+  it("clears the display name and restores the stable name fallback", async () => {
+    await createCronProgram().parseAsync(["edit", "job-1", "--clear-display-name"], {
+      from: "user",
+    });
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith("cron.update", expect.anything(), {
+      id: "job-1",
+      patch: { displayName: null },
+    });
+  });
+
+  it("rejects combining display-name set and clear flags", async () => {
+    await expectCronEditRejection(
+      ["--display-name", "Daily summary", "--clear-display-name"],
+      "Use --display-name or --clear-display-name, not both",
+    );
   });
 
   it("updates one pacing bound while preserving the other", async () => {

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -60,6 +60,7 @@ export function registerCronEditCommand(cron: Command) {
       .argument("<id>", "Job id")
       .option("--name <name>", "Set name")
       .option("--display-name <name>", "Set human-readable display name")
+      .option("--clear-display-name", "Restore the stable name in list and detail views", false)
       .option("--description <text>", "Set description")
       .option("--enable", "Enable job", false)
       .option("--disable", "Disable job", false)
@@ -248,8 +249,14 @@ export function registerCronEditCommand(cron: Command) {
           if (typeof opts.displayName === "string" && !displayName) {
             throw new Error("--display-name must not be blank");
           }
+          if (displayName && opts.clearDisplayName) {
+            throw new Error("Use --display-name or --clear-display-name, not both");
+          }
           if (displayName) {
             patch.displayName = displayName;
+          }
+          if (opts.clearDisplayName) {
+            patch.displayName = null;
           }
           if (typeof opts.description === "string") {
             patch.description = opts.description;

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -59,6 +59,7 @@ export function registerCronEditCommand(cron: Command) {
       .description("Edit an automation (patch fields)")
       .argument("<id>", "Job id")
       .option("--name <name>", "Set name")
+      .option("--display-name <name>", "Set human-readable display name")
       .option("--description <text>", "Set description")
       .option("--enable", "Enable job", false)
       .option("--disable", "Disable job", false)
@@ -242,6 +243,13 @@ export function registerCronEditCommand(cron: Command) {
           const patch: Record<string, unknown> = {};
           if (typeof opts.name === "string") {
             patch.name = opts.name;
+          }
+          const displayName = normalizeOptionalString(opts.displayName);
+          if (typeof opts.displayName === "string" && !displayName) {
+            throw new Error("--display-name must not be blank");
+          }
+          if (displayName) {
+            patch.displayName = displayName;
           }
           if (typeof opts.description === "string") {
             patch.description = opts.description;


### PR DESCRIPTION
AI-assisted contribution prepared with Codex. I understand the implementation and validation described below.

## What Problem This Solves

Fixes the automation edit parity gap: users could assign a human-readable display label while creating an automation but could not update or clear that label later with `automations edit` / `cron edit`. The list surface prefers `displayName` over the stable job name, so the edit surface needs both lifecycle transitions.

The broader UI terminology cleanup and the `automations` CLI nomenclature are already present on `main` through the merged UI/CLI/docs changes (#114853, #114854, and #114855); this PR avoids duplicating those changes.

## Why This Change Was Made

Adds `--display-name <name>` to set or replace the label and `--clear-display-name` to send the existing Gateway contract's canonical `displayName: null` deletion patch. The two flags are mutually exclusive, and blank set values remain rejected. The docs describe both transitions.

## User Impact

Users can set, rename, or remove the label shown in automation lists and detail views while keeping the automation's stable `name` unchanged. Clearing restores the stable-name fallback.

## Evidence

- Rebased on current `main` `01a5bcc5c0a02f98fcedbf3dc2e33f3e762f006b`; exact PR head: `1b95cedb1b`.
- Focused regression at the rebased head: `./node_modules/.bin/vitest run --config test/vitest/vitest.cli.config.ts src/cli/cron-cli/register.cron-edit.test.ts` — 83/83 tests passed.
- Real behavior proof at exact PR head `1b95cedb1b`: the exact-branch TypeScript CLI connected to an isolated real Gateway process on localhost with a temporary state directory. It created a disabled job with `displayName: "Initial label"`, then `automations edit <id> --clear-display-name` persisted the deletion; a subsequent `automations list --all --json` returned `name: "proof-automation-final"` with no `displayName`, confirming fallback restoration. The Gateway shut down cleanly afterward; the token and temporary identifiers are omitted.
- Representative redacted transcript:
  ```
  $ openclaw automations add --every 1h --name proof-automation-final --display-name "Initial label" --system-event "proof event" --session main --disabled --json
  {"id":"<job-id>","displayName":"Initial label","name":"proof-automation-final","enabled":false}
  $ openclaw automations edit <job-id> --clear-display-name
  {"id":"<job-id>","name":"proof-automation-final","enabled":false}
  $ openclaw automations list --all --json
  {"jobs":[{"name":"proof-automation-final","enabled":false}]}
  ```
- Documentation validation on the rebased branch: `pnpm docs:list --headings` passed; `pnpm format:docs:check` passed; `pnpm docs:check-mdx` passed (772 files); `pnpm docs:check-i18n-glossary` passed; `pnpm docs:check-config-examples` passed; `pnpm docs:check-links` passed (6,471 internal links, 0 broken).
- Formatting: `pnpm exec oxfmt --check` passed for the three touched files; `git diff --check` passed.
- The broader `src/cli/cron-cli` lane has unrelated zero-width terminal-alignment failures on clean `main`; no changed command path is involved. `pnpm lint:docs` remains environment-blocked because `pnpm dlx` cannot download `markdownlint-cli2` from the npm registry, and `pnpm check:changed` remains blocked by its Crabbox binary sanity check.
- Maintainer sponsorship/product decision remains requested for this additive public CLI surface.