### PR TITLE
fix: clear CLI binding after manual compaction

### DIFF
--- a/src/auto-reply/reply/commands-compact.test.ts
+++ b/src/auto-reply/reply/commands-compact.test.ts
@@ -683,6 +683,38 @@ describe("handleCompactCommand", () => {
     expect(call.tokensAfter).toBe(321);
   });
 
+  it("invalidates the resolved CLI binding after manual compaction", async () => {
+    vi.mocked(compactEmbeddedAgentSession).mockResolvedValueOnce({
+      ok: true,
+      compacted: true,
+      result: { summary: "compacted", tokensBefore: 999, tokensAfter: 321 },
+    });
+
+    await handleCompactCommand(
+      {
+        ...buildCompactParams("/compact", {
+          agents: {
+            defaults: {
+              models: {
+                "anthropic/claude-opus-4-6": {
+                  agentRuntime: { id: "claude-cli" },
+                },
+              },
+            },
+          },
+          commands: { text: true },
+          channels: { whatsapp: { allowFrom: ["*"] } },
+        } as OpenClawConfig),
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        sessionEntry: { sessionId: "session-1", updatedAt: Date.now() },
+      } as HandleCommandsParams,
+      true,
+    );
+
+    expect(requireIncrementCompactionCountCall().cliProvider).toBe("claude-cli");
+  });
+
   it("reports authoritative compaction no-ops without incrementing", async () => {
     vi.mocked(compactEmbeddedAgentSession).mockResolvedValueOnce({
       ok: true,

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -16,6 +16,10 @@ import {
 } from "../../agents/embedded-agent-runner/compact-reasons.js";
 import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
 import {
+  isCliRuntimeAliasForProvider,
+  resolveCliRuntimeExecutionProvider,
+} from "../../agents/model-runtime-aliases.js";
+import {
   OPENAI_CODEX_PROVIDER_ID,
   OPENAI_PROVIDER_ID,
   resolveContextConfigProviderForRuntime,
@@ -328,6 +332,28 @@ export const handleCompactCommand: CommandHandler = async (params) => {
         : "Compaction skipped"
       : "Compaction failed";
   if (didCompact) {
+    const harnessRuntime = resolveAgentHarnessPolicy({
+      provider: params.provider,
+      modelId: params.model,
+      config: params.cfg,
+      agentId: sessionAgentId,
+      sessionKey: params.sessionKey,
+    }).runtime;
+    const cliProvider =
+      resolveCliRuntimeExecutionProvider({
+        provider: params.provider,
+        cfg: params.cfg,
+        agentId: sessionAgentId,
+        modelId: params.model,
+        authProfileId: targetSessionEntry.authProfileOverride,
+      }) ??
+      (isCliRuntimeAliasForProvider({
+        runtime: harnessRuntime,
+        provider: params.provider,
+        cfg: params.cfg,
+      })
+        ? harnessRuntime
+        : undefined);
     await runtime.incrementCompactionCount({
       agentId: sessionAgentId,
       cfg: params.cfg,
@@ -338,6 +364,7 @@ export const handleCompactCommand: CommandHandler = async (params) => {
       // Update token counts after compaction
       tokensAfter: result.result?.tokensAfter,
       newSessionId: result.result?.sessionId,
+      cliProvider,
     });
   }
   // Use the post-compaction token count for context summary if available

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -576,6 +576,41 @@ describe("incrementCompactionCount", () => {
     expect(requireStoredSession(stored, sessionKey).outputTokens).toBeUndefined();
   });
 
+  it("clears only the active CLI binding after compaction", async () => {
+    const entry = {
+      sessionId: "s1",
+      updatedAt: Date.now(),
+      cliSessionBindings: {
+        "claude-cli": { sessionId: "claude-session" },
+        "codex-cli": { sessionId: "codex-session" },
+      },
+      cliSessionIds: {
+        "claude-cli": "claude-session",
+        "codex-cli": "codex-session",
+      },
+      claudeCliSessionId: "claude-session",
+    } as SessionEntry;
+    const { storePath, sessionKey, sessionStore } = await createCompactionSessionFixture(entry);
+
+    await incrementCompactionCount({
+      sessionEntry: entry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      cliProvider: "claude-cli",
+    });
+
+    const stored = requireStoredSession(
+      { [sessionKey]: await loadStoredEntry(storePath, sessionKey) },
+      sessionKey,
+    );
+    expect(stored.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+    expect(stored.cliSessionIds?.["claude-cli"]).toBeUndefined();
+    expect(stored.claudeCliSessionId).toBeUndefined();
+    expect(stored.cliSessionBindings?.["codex-cli"]).toEqual({ sessionId: "codex-session" });
+    expect(stored.cliSessionIds?.["codex-cli"]).toBe("codex-session");
+  });
+
   it("accepts zero tokensAfter as a fresh post-compaction total", async () => {
     const entry = {
       sessionId: "s1",

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -1,6 +1,7 @@
 /** Session update helpers for skill snapshots, compaction, and lifecycle hooks. */
 import crypto from "node:crypto";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { clearCliSession } from "../../agents/cli-session.js";
 import {
   type ExecPolicyOverrides,
   resolveNodeExecEligibility,
@@ -325,6 +326,8 @@ export async function incrementCompactionCount(params: {
   tokensAfter?: number;
   /** Session id after compaction when a context engine changed identity. */
   newSessionId?: string;
+  /** CLI provider whose resume binding was invalidated by this compaction. */
+  cliProvider?: string;
 }): Promise<number | undefined> {
   const {
     agentId,
@@ -337,6 +340,7 @@ export async function incrementCompactionCount(params: {
     amount = 1,
     tokensAfter,
     newSessionId,
+    cliProvider,
   } = params;
   if (!sessionStore || !sessionKey) {
     return undefined;
@@ -352,6 +356,13 @@ export async function incrementCompactionCount(params: {
     compactionCount: nextCount,
     updatedAt: now,
   };
+  if (cliProvider) {
+    const nextWithoutCliBinding = { ...entry };
+    clearCliSession(nextWithoutCliBinding, cliProvider);
+    updates.cliSessionBindings = nextWithoutCliBinding.cliSessionBindings;
+    updates.cliSessionIds = nextWithoutCliBinding.cliSessionIds;
+    updates.claudeCliSessionId = nextWithoutCliBinding.claudeCliSessionId;
+  }
   const sessionIdChanged = Boolean(newSessionId && newSessionId !== entry.sessionId);
   if (sessionIdChanged && newSessionId) {
     updates.sessionId = newSessionId;


### PR DESCRIPTION
Closes #84593

## What Problem This Solves

Fixes an issue where users running a successful manual `/compact` on a CLI-backed session could still resume the pre-compaction CLI conversation on the next turn. The OpenClaw transcript was compacted, but the stale provider resume binding kept the backend's old context active.

## Why This Change Was Made

Successful manual compaction now resolves the active CLI backend provider and clears only that provider's persisted resume binding while updating compaction state. The existing binding helper is reused, so unrelated CLI provider bindings remain intact; non-CLI and unresolved-provider paths retain their existing behavior.

## User Impact

After manual compaction, the next turn starts the active CLI backend from the compacted OpenClaw session state instead of replaying the stale pre-compaction provider conversation. Other provider-specific continuity is preserved.

## Evidence

- Focused regression: `node scripts/run-vitest.mjs src/auto-reply/reply/commands-compact.test.ts -t "invalidates the resolved CLI binding after manual compaction"` — passed (1 test).
- Regression coverage verifies `claude-cli` binding fields are removed while a `codex-cli` binding is retained.
- Existing automatic CLI-compaction behavior was inspected and its matching regression path was exercised; its assertion passed, but the Windows test fixture teardown reported an environment-only SQLite WAL `EBUSY` cleanup failure.
- Targeted `oxfmt --check`, `oxlint`, and `git diff --check` passed.
- Relay-backed autoreview on final head `4c3bd86f76e50417f16576ae327fd4ab3a0ac125`: TruffleHog clean; no accepted/actionable findings; no P0 defects.
- The focused runtime tests use a temporary SQLite fixture. On this Windows host, some teardown attempts fail with `EBUSY` while unlinking SQLite/WAL files after assertions; no product assertion failed.

AI-assisted: implemented and reviewed with Codex; the author understands the change and its behavior.
