### PR TITLE
fix(qa): preserve model switch failure evidence

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-model-switch-tool-continuity-proof.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-model-switch-tool-continuity-proof.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createQaBusState } from "./bus-state.js";
 import { hasModelSwitchContinuitySignal } from "./model-switch-eval.js";
 import { runLoadedScenarioFlow } from "./scenario-flow-runner.test-support.js";
+import { runQaSuiteScenarioSteps } from "./suite-runtime-flow.js";
 
 function splitModelRef(raw: string) {
   const [provider, ...model] = raw.split("/");
@@ -24,6 +25,8 @@ function normalizeModelRef(raw: string) {
 async function runToolContinuity(
   alternateTools: string[],
   params?: {
+    catchFailureResult?: boolean;
+    primaryTools?: string[];
     primaryOutboundText?: string;
     primaryDelivery?: { status: string; resultCount: number } | null;
     alternateReplyText?: string;
@@ -85,7 +88,7 @@ async function runToolContinuity(
             turnId: `turn-${call}`,
             requested: { provider, model },
             effective: { provider, model, responseModel: model },
-            successfulToolNames: call === 1 ? ["read"] : alternateTools,
+            successfulToolNames: call === 1 ? (params?.primaryTools ?? ["read"]) : alternateTools,
             rerouted: false,
             terminalDisposition: "visible",
           },
@@ -107,6 +110,7 @@ async function runToolContinuity(
       normalizeLowercaseStringOrEmpty,
       resolveQaLiveTurnTimeoutMs: (_env: unknown, timeoutMs: number) => timeoutMs,
       hasModelSwitchContinuitySignal,
+      ...(params?.catchFailureResult ? { runScenario: runQaSuiteScenarioSteps } : {}),
       runAgentPrompt,
     },
   });
@@ -129,6 +133,7 @@ describe("model-switch tool continuity terminal evidence", () => {
     });
     expect(result.modelSwitchEvidence).toMatchObject({
       primary: { runId: "run-1", successfulToolNames: ["read"] },
+      primaryDelivery: { status: "sent", resultCount: 1 },
       alternate: { runId: "run-2", successfulToolNames: ["read"] },
       terminalReply: {
         disposition: "visible",
@@ -160,6 +165,26 @@ describe("model-switch tool continuity terminal evidence", () => {
     await expect(runToolContinuity([])).rejects.toThrow(
       "alternate-model run did not return exact owned successful read evidence",
     );
+  });
+
+  it("keeps primary evidence when the primary tool assertion fails", async () => {
+    const { result, runAgentPrompt } = await runToolContinuity(["read"], {
+      catchFailureResult: true,
+      primaryTools: [],
+    });
+
+    expect(result).toMatchObject({
+      status: "fail",
+      details: "default-model run did not return owned successful read evidence",
+      modelSwitchEvidence: {
+        primary: {
+          runId: "run-1",
+          successfulToolNames: [],
+        },
+        primaryDelivery: { status: "sent", resultCount: 1 },
+      },
+    });
+    expect(runAgentPrompt).toHaveBeenCalledTimes(1);
   });
 
   it("rejects unrelated later continuity text when the alternate reply lacks it", async () => {

--- a/qa/scenarios/models/model-switch-tool-continuity.yaml
+++ b/qa/scenarios/models/model-switch-tool-continuity.yaml
@@ -52,6 +52,12 @@ flow:
                 expr: config.initialPrompt
               timeoutMs:
                 expr: liveTurnTimeoutMs(env, 30000)
+        - set: modelSwitchEvidence
+          value:
+            primary:
+              ref: primaryRun.waited.terminalReceipt
+            primaryDelivery:
+              ref: primaryRun.waited.terminalDelivery
         - assert:
             expr: "(() => { const expected = normalizeModelRef(env.primaryModel); const receipt = primaryRun?.waited?.terminalReceipt; return receipt?.runId === primaryRun?.started?.runId && normalizeLowercaseStringOrEmpty(receipt.requested?.provider) === expected.provider && receipt.requested?.model === expected.model && receipt.successfulToolNames?.includes('read') && receipt.terminalDisposition === 'visible'; })()"
             message: default-model run did not return owned successful read evidence
@@ -71,6 +77,18 @@ flow:
                 expr: expectedAlternate.model
               timeoutMs:
                 expr: resolveQaLiveTurnTimeoutMs(env, 30000, env.alternateModel)
+        - set: modelSwitchEvidence
+          value:
+            primary:
+              ref: primaryRun.waited.terminalReceipt
+            primaryDelivery:
+              ref: primaryRun.waited.terminalDelivery
+            alternate:
+              ref: alternateRun.waited.terminalReceipt
+            terminalReply:
+              ref: alternateRun.waited.terminalReply
+            terminalDelivery:
+              ref: alternateRun.waited.terminalDelivery
         - assert:
             expr: "(() => { const receipt = alternateRun?.waited?.terminalReceipt; return receipt?.runId === alternateRun?.started?.runId && Boolean(receipt.sessionId) && Boolean(receipt.turnId) && normalizeLowercaseStringOrEmpty(receipt.requested?.provider) === expectedAlternate.provider && receipt.requested?.model === expectedAlternate.model && receipt.effective?.model === receipt.effective?.responseModel && receipt.successfulToolNames?.includes('read') && receipt.terminalDisposition === 'visible' && typeof receipt.rerouted === 'boolean' && `${receipt.effective?.provider}/${receipt.effective?.responseModel}` !== `${primaryRun.waited.terminalReceipt.effective?.provider}/${primaryRun.waited.terminalReceipt.effective?.responseModel}`; })()"
             message: alternate-model run did not return exact owned successful read evidence
@@ -80,14 +98,4 @@ flow:
         - assert:
             expr: "alternateRun?.waited?.terminalDelivery?.status === 'sent' && typeof alternateRun.waited.terminalDelivery.resultCount === 'number' && alternateRun.waited.terminalDelivery.resultCount > 0"
             message: alternate-model run did not return owned sent delivery evidence
-        - set: modelSwitchEvidence
-          value:
-            primary:
-              ref: primaryRun.waited.terminalReceipt
-            alternate:
-              ref: alternateRun.waited.terminalReceipt
-            terminalReply:
-              ref: alternateRun.waited.terminalReply
-            terminalDelivery:
-              ref: alternateRun.waited.terminalDelivery
       detailsExpr: alternateRun.waited.terminalReply.text


### PR DESCRIPTION
## What Problem This Solves

Fixes a QA diagnostics issue where the Anthropic model-switch continuity scenario failed before preserving its owned terminal receipt and delivery evidence. Full Release Validation at `ade3456dd48f638cd5c8c50ecc0a3da3fe76d2ec` therefore reported only `default-model run did not return owned successful read evidence`, leaving the controller unable to distinguish a product/tool regression from a fixture response.

## Why This Change Was Made

The scenario now records primary evidence immediately after the primary run, then replaces it with the complete primary and alternate evidence immediately after the alternate run. Assertions remain unchanged. The regression test uses the canonical QA suite failure catcher and proves a failed primary receipt with `successfulToolNames: []` retains the receipt and delivery while stopping after one agent prompt.

This intentionally stays scoped to the failing `model-switch-tool-continuity` campaign surface. Local ClawSweeper suggested applying the same observability pattern to `model-switch-follow-up`; that adjacent cleanup is deferred because it was not implicated by this qualification failure and would widen this PR beyond the requested repair.

## User Impact

No shipped runtime behavior changes. Qualification failures now retain the exact owned evidence needed for a narrow product-vs-fixture diagnosis.

## Evidence

- Original failure: https://github.com/openclaw/openclaw/actions/runs/31601965721/job/94131547483
  - SHA: `ade3456dd48f638cd5c8c50ecc0a3da3fe76d2ec`
  - Provider fixture: `mock-openai`
  - Primary: `anthropic/claude-opus-4-8`
  - Alternate: `anthropic/claude-sonnet-4-6`
  - Result: primary read assertion failed; `modelSwitchEvidence` was absent.
- Focused regression: `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog-model-switch-tool-continuity-proof.test.ts`
  - 1 file passed, 12 tests passed.
- `git diff --check`: passed.
- Local ClawSweeper reviewed exact head `5feb952d400f216756c7ad0bef52fb56d1d31bcf`; its only finding was the explicitly deferred sibling-scenario expansion above.
- Narrow Testbox diagnosis: https://github.com/openclaw/openclaw/actions/runs/31618664724
  - Provider: Blacksmith Testbox `tbx_01kzvdfb0vqs012fc4sqmv70n0`
  - Exact head: `5feb952d400f216756c7ad0bef52fb56d1d31bcf`
  - One scenario, concurrency 1, disposable `retryCount: 0` not included in this PR.
  - Primary receipt: requested/effective `anthropic/claude-opus-4-8`, `terminalDisposition: visible`, `successfulToolNames: []`.
  - Primary delivery: `status: sent`, `resultCount: 1`.
  - Conclusion: the QA repair works and retains the missing evidence; that evidence confirms a separate product/tool-execution failure which remains deferred to its own owner repair.
- Production LOC: `+0/-0`. QA scenario: `+17/-9`. Tests: `+26/-1`.
