### PR TITLE
fix(ui): show progress during new session startup

### DIFF
--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -44,6 +44,7 @@ import { createNativeChatDrafts } from "./native-bridge.ts";
 import { startNativeLinkRouting } from "./native-link-routing.ts";
 import { createNativeNotificationsCapability } from "./native-notifications.ts";
 import { createApplicationOverlays } from "./overlays.ts";
+import { navigateWithRouteTransition } from "./route-transition.ts";
 import {
   loadSettings,
   patchSettings,
@@ -476,11 +477,16 @@ export function bootstrapApplication(
       if (!routerStarted) {
         pendingRouterStartNavigation = { routeId, location, mode: "push" };
       }
-      void router
-        .navigate(routeId, context, { history: "push" }, location)
-        .catch((error: unknown) => {
-          console.error("[openclaw] route navigation failed", error);
-        });
+      void navigateWithRouteTransition({
+        document,
+        from: router.getState().matches[0]?.routeId,
+        to: routeId,
+        prefersReducedMotion:
+          globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false,
+        navigate: () => router.navigate(routeId, context, { history: "push" }, location),
+      }).catch((error: unknown) => {
+        console.error("[openclaw] route navigation failed", error);
+      });
     },
     replace: (routeId, options) => {
       const location = routeLocation(routeId, options);

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -477,12 +477,13 @@ export function bootstrapApplication(
       if (!routerStarted) {
         pendingRouterStartNavigation = { routeId, location, mode: "push" };
       }
-      void navigateWithRouteTransition({
+      return navigateWithRouteTransition({
         document,
         from: router.getState().matches[0]?.routeId,
         to: routeId,
         prefersReducedMotion:
           globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false,
+        prepare: () => router.preloadLocation(location, context),
         navigate: () => router.navigate(routeId, context, { history: "push" }, location),
       }).catch((error: unknown) => {
         console.error("[openclaw] route navigation failed", error);

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -451,6 +451,26 @@ export function bootstrapApplication(
   const cancelPendingGatewayConnection = () => {
     pendingGatewayConnection = null;
   };
+  const navigateAndWait = (routeId: RouteId, options?: ApplicationNavigationOptions) => {
+    const location = routeLocation(routeId, options);
+    // Preserve pre-start navigation exactly as the fire-and-forget entry point does.
+    if (!routerStarted) {
+      pendingRouterStartNavigation = { routeId, location, mode: "push" };
+    }
+    // New-session submission awaits this promise so its live progress remains
+    // visible until the destination route has completed the UI handoff.
+    return navigateWithRouteTransition({
+      document,
+      from: router.getState().matches[0]?.routeId,
+      to: routeId,
+      prefersReducedMotion:
+        globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false,
+      prepare: () => router.preloadLocation(location, context),
+      navigate: () => router.navigate(routeId, context, { history: "push" }, location),
+    }).catch((error: unknown) => {
+      console.error("[openclaw] route navigation failed", error);
+    });
+  };
   const context: ApplicationContext<RouteId> = {
     basePath,
     gateway,
@@ -473,22 +493,9 @@ export function bootstrapApplication(
     initialUserMessage,
     chatAttachmentHandoff,
     navigate: (routeId, options) => {
-      const location = routeLocation(routeId, options);
-      if (!routerStarted) {
-        pendingRouterStartNavigation = { routeId, location, mode: "push" };
-      }
-      return navigateWithRouteTransition({
-        document,
-        from: router.getState().matches[0]?.routeId,
-        to: routeId,
-        prefersReducedMotion:
-          globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false,
-        prepare: () => router.preloadLocation(location, context),
-        navigate: () => router.navigate(routeId, context, { history: "push" }, location),
-      }).catch((error: unknown) => {
-        console.error("[openclaw] route navigation failed", error);
-      });
+      void navigateAndWait(routeId, options);
     },
+    navigateAndWait,
     replace: (routeId, options) => {
       const location = routeLocation(routeId, options);
       if (!routerStarted) {

--- a/ui/src/app/context.ts
+++ b/ui/src/app/context.ts
@@ -115,7 +115,7 @@ export type ApplicationContext<TRouteId extends string = string> = {
   readonly skillWorkshopRevision: ApplicationSkillWorkshopRevisionHandoff;
   readonly initialUserMessage: ApplicationInitialUserMessageHandoff;
   readonly chatAttachmentHandoff: ApplicationChatAttachmentHandoff;
-  readonly navigate: (routeId: TRouteId, options?: ApplicationNavigationOptions) => void;
+  readonly navigate: (routeId: TRouteId, options?: ApplicationNavigationOptions) => Promise<void>;
   readonly replace: (routeId: TRouteId, options?: ApplicationNavigationOptions) => void;
   readonly revalidate: (routeId?: TRouteId) => Promise<void>;
   readonly preload: (routeId: TRouteId) => Promise<void>;

--- a/ui/src/app/context.ts
+++ b/ui/src/app/context.ts
@@ -115,7 +115,12 @@ export type ApplicationContext<TRouteId extends string = string> = {
   readonly skillWorkshopRevision: ApplicationSkillWorkshopRevisionHandoff;
   readonly initialUserMessage: ApplicationInitialUserMessageHandoff;
   readonly chatAttachmentHandoff: ApplicationChatAttachmentHandoff;
-  readonly navigate: (routeId: TRouteId, options?: ApplicationNavigationOptions) => Promise<void>;
+  readonly navigate: (routeId: TRouteId, options?: ApplicationNavigationOptions) => void;
+  /** Navigates and resolves after any route-specific handoff completes. */
+  readonly navigateAndWait: (
+    routeId: TRouteId,
+    options?: ApplicationNavigationOptions,
+  ) => Promise<void>;
   readonly replace: (routeId: TRouteId, options?: ApplicationNavigationOptions) => void;
   readonly revalidate: (routeId?: TRouteId) => Promise<void>;
   readonly preload: (routeId: TRouteId) => Promise<void>;

--- a/ui/src/app/route-transition.test.ts
+++ b/ui/src/app/route-transition.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import { navigateWithRouteTransition } from "./route-transition.ts";
+
+describe("navigateWithRouteTransition", () => {
+  it("crossfades the new-session route into chat", async () => {
+    const navigate = vi.fn(async () => undefined);
+    const startViewTransition = vi.fn((update: () => void | Promise<void>) => {
+      return { finished: Promise.resolve(update()).then(() => undefined) };
+    });
+    const outlet = document.createElement("openclaw-router-outlet") as HTMLElement & {
+      updateComplete: Promise<void>;
+    };
+    outlet.updateComplete = Promise.resolve();
+    const testDocument = {
+      documentElement: document.documentElement,
+      querySelector: () => outlet,
+      startViewTransition,
+    } as unknown as Document & { startViewTransition: typeof startViewTransition };
+
+    await navigateWithRouteTransition({
+      document: testDocument,
+      from: "new-session",
+      to: "chat",
+      navigate,
+      prefersReducedMotion: false,
+    });
+
+    expect(startViewTransition).toHaveBeenCalledOnce();
+    expect(navigate).toHaveBeenCalledOnce();
+    expect(document.documentElement.classList.contains("session-route-transition")).toBe(false);
+  });
+
+  it("falls back to direct navigation when the browser declines the transition", async () => {
+    const navigate = vi.fn(async () => undefined);
+    const startViewTransition = vi.fn(() => {
+      throw new Error("transition unavailable");
+    });
+    const testDocument = {
+      documentElement: document.documentElement,
+      startViewTransition,
+    } as unknown as Document & { startViewTransition: typeof startViewTransition };
+
+    await navigateWithRouteTransition({
+      document: testDocument,
+      from: "new-session",
+      to: "chat",
+      navigate,
+      prefersReducedMotion: false,
+    });
+
+    expect(navigate).toHaveBeenCalledOnce();
+    expect(document.documentElement.classList.contains("session-route-transition")).toBe(false);
+  });
+
+  it.each([
+    { from: "about" as const, to: "chat" as const, prefersReducedMotion: false },
+    { from: "new-session" as const, to: "about" as const, prefersReducedMotion: false },
+    { from: "new-session" as const, to: "chat" as const, prefersReducedMotion: true },
+  ])("navigates directly for $from to $to", async ({ from, to, prefersReducedMotion }) => {
+    const navigate = vi.fn(async () => undefined);
+    const startViewTransition = vi.fn();
+    const testDocument = {
+      documentElement: document.documentElement,
+      startViewTransition,
+    } as unknown as Document & { startViewTransition: typeof startViewTransition };
+
+    await navigateWithRouteTransition({
+      document: testDocument,
+      from,
+      to,
+      navigate,
+      prefersReducedMotion,
+    });
+
+    expect(startViewTransition).not.toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/src/app/route-transition.test.ts
+++ b/ui/src/app/route-transition.test.ts
@@ -1,5 +1,21 @@
-import { describe, expect, it, vi } from "vitest";
-import { navigateWithRouteTransition } from "./route-transition.ts";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CHAT_ROUTE_READY_EVENT, navigateWithRouteTransition } from "./route-transition.ts";
+
+function testDocumentWithOutlet(animate = vi.fn()) {
+  const outlet = document.createElement("openclaw-router-outlet") as HTMLElement & {
+    updateComplete: Promise<void>;
+  };
+  outlet.updateComplete = Promise.resolve();
+  outlet.animate = animate;
+  document.body.append(outlet);
+  return {
+    animate,
+    document,
+    outlet,
+  };
+}
+
+afterEach(() => document.body.replaceChildren());
 
 describe("navigateWithRouteTransition", () => {
   it("keeps the outgoing view live until the destination is prepared", async () => {
@@ -11,17 +27,9 @@ describe("navigateWithRouteTransition", () => {
         }),
     );
     const navigate = vi.fn(async () => undefined);
-    const startViewTransition = vi.fn((update: () => void | Promise<void>) => {
-      return { finished: Promise.resolve(update()).then(() => undefined) };
-    });
-    const testDocument = {
-      documentElement: document.documentElement,
-      querySelector: () => null,
-      startViewTransition,
-    } as unknown as Document & { startViewTransition: typeof startViewTransition };
-
+    const test = testDocumentWithOutlet();
     const transition = navigateWithRouteTransition({
-      document: testDocument,
+      document: test.document,
       from: "new-session",
       to: "chat",
       navigate,
@@ -31,76 +39,54 @@ describe("navigateWithRouteTransition", () => {
     await Promise.resolve();
 
     expect(prepare).toHaveBeenCalledOnce();
-    expect(startViewTransition).not.toHaveBeenCalled();
     expect(navigate).not.toHaveBeenCalled();
 
     finishPreparation();
+    await vi.waitFor(() => expect(navigate).toHaveBeenCalledOnce());
+    document.dispatchEvent(new Event(CHAT_ROUTE_READY_EVENT));
     await transition;
 
-    expect(startViewTransition).toHaveBeenCalledOnce();
     expect(navigate).toHaveBeenCalledOnce();
   });
 
-  it("crossfades the new-session route into chat", async () => {
-    const navigate = vi.fn(async () => undefined);
-    const startViewTransition = vi.fn((update: () => void | Promise<void>) => {
-      return { finished: Promise.resolve(update()).then(() => undefined) };
-    });
-    const outlet = document.createElement("openclaw-router-outlet") as HTMLElement & {
-      updateComplete: Promise<void>;
-    };
-    outlet.updateComplete = Promise.resolve();
-    const testDocument = {
-      documentElement: document.documentElement,
-      querySelector: () => outlet,
-      startViewTransition,
-    } as unknown as Document & { startViewTransition: typeof startViewTransition };
+  it("animates the rendered chat pane without freezing the outgoing document", async () => {
+    const finished = Promise.resolve({} as Animation);
+    const animate = vi.fn(() => ({ finished }) as Animation);
+    const test = testDocumentWithOutlet(animate);
+    let finishNavigation!: () => void;
+    const navigate = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishNavigation = resolve;
+        }),
+    );
 
-    await navigateWithRouteTransition({
-      document: testDocument,
+    const transition = navigateWithRouteTransition({
+      document: test.document,
       from: "new-session",
       to: "chat",
       navigate,
       prefersReducedMotion: false,
     });
-
-    expect(startViewTransition).toHaveBeenCalledOnce();
-    expect(navigate).toHaveBeenCalledOnce();
-    expect(document.documentElement.classList.contains("session-route-transition")).toBe(false);
-  });
-
-  it("falls back to direct navigation when the browser declines the transition", async () => {
-    const navigate = vi.fn(async () => undefined);
-    const startViewTransition = vi.fn(() => {
-      throw new Error("transition unavailable");
-    });
-    const testDocument = {
-      documentElement: document.documentElement,
-      startViewTransition,
-    } as unknown as Document & { startViewTransition: typeof startViewTransition };
-
-    await navigateWithRouteTransition({
-      document: testDocument,
-      from: "new-session",
-      to: "chat",
-      navigate,
-      prefersReducedMotion: false,
-    });
+    await vi.waitFor(() => expect(navigate).toHaveBeenCalledOnce());
+    expect(animate).not.toHaveBeenCalled();
+    finishNavigation();
+    document.dispatchEvent(new Event(CHAT_ROUTE_READY_EVENT));
+    await transition;
 
     expect(navigate).toHaveBeenCalledOnce();
-    expect(document.documentElement.classList.contains("session-route-transition")).toBe(false);
+    expect(animate).toHaveBeenCalledWith(
+      [{ transform: "translateY(5px) scale(0.997)" }, { transform: "none" }],
+      { duration: 180, easing: "cubic-bezier(0.16, 1, 0.3, 1)" },
+    );
   });
 
   it("navigates directly when destination preparation fails", async () => {
+    const test = testDocumentWithOutlet();
     const navigate = vi.fn(async () => undefined);
-    const startViewTransition = vi.fn();
-    const testDocument = {
-      documentElement: document.documentElement,
-      startViewTransition,
-    } as unknown as Document & { startViewTransition: typeof startViewTransition };
 
     await navigateWithRouteTransition({
-      document: testDocument,
+      document: test.document,
       from: "new-session",
       to: "chat",
       navigate,
@@ -110,31 +96,44 @@ describe("navigateWithRouteTransition", () => {
       prefersReducedMotion: false,
     });
 
-    expect(startViewTransition).not.toHaveBeenCalled();
     expect(navigate).toHaveBeenCalledOnce();
+    expect(test.animate).not.toHaveBeenCalled();
   });
 
   it.each([
     { from: "about" as const, to: "chat" as const, prefersReducedMotion: false },
     { from: "new-session" as const, to: "about" as const, prefersReducedMotion: false },
-    { from: "new-session" as const, to: "chat" as const, prefersReducedMotion: true },
   ])("navigates directly for $from to $to", async ({ from, to, prefersReducedMotion }) => {
+    const test = testDocumentWithOutlet();
     const navigate = vi.fn(async () => undefined);
-    const startViewTransition = vi.fn();
-    const testDocument = {
-      documentElement: document.documentElement,
-      startViewTransition,
-    } as unknown as Document & { startViewTransition: typeof startViewTransition };
 
     await navigateWithRouteTransition({
-      document: testDocument,
+      document: test.document,
       from,
       to,
       navigate,
       prefersReducedMotion,
     });
 
-    expect(startViewTransition).not.toHaveBeenCalled();
     expect(navigate).toHaveBeenCalledOnce();
+    expect(test.animate).not.toHaveBeenCalled();
+  });
+
+  it("waits for the chat route without animating when motion is reduced", async () => {
+    const test = testDocumentWithOutlet();
+    const navigate = vi.fn(async () => undefined);
+    const transition = navigateWithRouteTransition({
+      document: test.document,
+      from: "new-session",
+      to: "chat",
+      navigate,
+      prefersReducedMotion: true,
+    });
+
+    await vi.waitFor(() => expect(navigate).toHaveBeenCalledOnce());
+    document.dispatchEvent(new Event(CHAT_ROUTE_READY_EVENT));
+    await transition;
+
+    expect(test.animate).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/app/route-transition.test.ts
+++ b/ui/src/app/route-transition.test.ts
@@ -2,6 +2,45 @@ import { describe, expect, it, vi } from "vitest";
 import { navigateWithRouteTransition } from "./route-transition.ts";
 
 describe("navigateWithRouteTransition", () => {
+  it("keeps the outgoing view live until the destination is prepared", async () => {
+    let finishPreparation!: () => void;
+    const prepare = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishPreparation = resolve;
+        }),
+    );
+    const navigate = vi.fn(async () => undefined);
+    const startViewTransition = vi.fn((update: () => void | Promise<void>) => {
+      return { finished: Promise.resolve(update()).then(() => undefined) };
+    });
+    const testDocument = {
+      documentElement: document.documentElement,
+      querySelector: () => null,
+      startViewTransition,
+    } as unknown as Document & { startViewTransition: typeof startViewTransition };
+
+    const transition = navigateWithRouteTransition({
+      document: testDocument,
+      from: "new-session",
+      to: "chat",
+      navigate,
+      prepare,
+      prefersReducedMotion: false,
+    });
+    await Promise.resolve();
+
+    expect(prepare).toHaveBeenCalledOnce();
+    expect(startViewTransition).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+
+    finishPreparation();
+    await transition;
+
+    expect(startViewTransition).toHaveBeenCalledOnce();
+    expect(navigate).toHaveBeenCalledOnce();
+  });
+
   it("crossfades the new-session route into chat", async () => {
     const navigate = vi.fn(async () => undefined);
     const startViewTransition = vi.fn((update: () => void | Promise<void>) => {
@@ -50,6 +89,29 @@ describe("navigateWithRouteTransition", () => {
 
     expect(navigate).toHaveBeenCalledOnce();
     expect(document.documentElement.classList.contains("session-route-transition")).toBe(false);
+  });
+
+  it("navigates directly when destination preparation fails", async () => {
+    const navigate = vi.fn(async () => undefined);
+    const startViewTransition = vi.fn();
+    const testDocument = {
+      documentElement: document.documentElement,
+      startViewTransition,
+    } as unknown as Document & { startViewTransition: typeof startViewTransition };
+
+    await navigateWithRouteTransition({
+      document: testDocument,
+      from: "new-session",
+      to: "chat",
+      navigate,
+      prepare: async () => {
+        throw new Error("preload failed");
+      },
+      prefersReducedMotion: false,
+    });
+
+    expect(startViewTransition).not.toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledOnce();
   });
 
   it.each([

--- a/ui/src/app/route-transition.ts
+++ b/ui/src/app/route-transition.ts
@@ -1,0 +1,51 @@
+import type { RouteId } from "../app-routes.ts";
+
+type ViewTransitionDocument = Document & {
+  startViewTransition?: (update: () => void | Promise<void>) => {
+    finished: Promise<void>;
+  };
+};
+
+type RouteTransitionOptions = {
+  document: ViewTransitionDocument;
+  from: RouteId | undefined;
+  navigate: () => Promise<void>;
+  prefersReducedMotion: boolean;
+  to: RouteId;
+};
+
+const SESSION_ROUTE_TRANSITION_CLASS = "session-route-transition";
+
+async function navigateAndRender(document: ViewTransitionDocument, navigate: () => Promise<void>) {
+  await navigate();
+  const outlet = document.querySelector<HTMLElement & { updateComplete?: Promise<unknown> }>(
+    "openclaw-router-outlet",
+  );
+  await outlet?.updateComplete;
+}
+
+export function navigateWithRouteTransition(options: RouteTransitionOptions): Promise<void> {
+  const { document, from, navigate, prefersReducedMotion, to } = options;
+  if (
+    from !== "new-session" ||
+    to !== "chat" ||
+    prefersReducedMotion ||
+    typeof document.startViewTransition !== "function"
+  ) {
+    return navigate();
+  }
+
+  document.documentElement.classList.add(SESSION_ROUTE_TRANSITION_CLASS);
+  let navigation: Promise<void> | undefined;
+  try {
+    const transition = document.startViewTransition(
+      () => (navigation ??= navigateAndRender(document, navigate)),
+    );
+    return transition.finished.finally(() => {
+      document.documentElement.classList.remove(SESSION_ROUTE_TRANSITION_CLASS);
+    });
+  } catch {
+    document.documentElement.classList.remove(SESSION_ROUTE_TRANSITION_CLASS);
+    return navigation ?? navigate();
+  }
+}

--- a/ui/src/app/route-transition.ts
+++ b/ui/src/app/route-transition.ts
@@ -1,13 +1,7 @@
 import type { RouteId } from "../app-routes.ts";
 
-type ViewTransitionDocument = Document & {
-  startViewTransition?: (update: () => void | Promise<void>) => {
-    finished: Promise<void>;
-  };
-};
-
 type RouteTransitionOptions = {
-  document: ViewTransitionDocument;
+  document: Document;
   from: RouteId | undefined;
   navigate: () => Promise<void>;
   prepare?: () => Promise<void>;
@@ -15,24 +9,58 @@ type RouteTransitionOptions = {
   to: RouteId;
 };
 
-const SESSION_ROUTE_TRANSITION_CLASS = "session-route-transition";
+export const CHAT_ROUTE_READY_EVENT = "openclaw-chat-route-ready";
+const SESSION_ROUTE_ENTER_KEYFRAMES: Keyframe[] = [
+  { transform: "translateY(5px) scale(0.997)" },
+  { transform: "none" },
+];
+const SESSION_ROUTE_ENTER_OPTIONS: KeyframeAnimationOptions = {
+  duration: 180,
+  easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+};
 
-async function navigateAndRender(document: ViewTransitionDocument, navigate: () => Promise<void>) {
-  await navigate();
+function waitForChatRouteReady(document: Document) {
+  if (document.querySelector(".agent-chat__composer-combobox")) {
+    return { cancel: () => undefined, ready: Promise.resolve() };
+  }
+  let resolve!: () => void;
+  const ready = new Promise<void>((next) => {
+    resolve = next;
+  });
+  const handleReady = () => resolve();
+  document.addEventListener(CHAT_ROUTE_READY_EVENT, handleReady, { once: true });
+  return {
+    cancel: () => document.removeEventListener(CHAT_ROUTE_READY_EVENT, handleReady),
+    ready,
+  };
+}
+
+async function navigateAndAnimate(
+  document: Document,
+  navigate: () => Promise<void>,
+  prefersReducedMotion: boolean,
+) {
   const outlet = document.querySelector<HTMLElement & { updateComplete?: Promise<unknown> }>(
     "openclaw-router-outlet",
   );
-  await outlet?.updateComplete;
+  const chatReady = waitForChatRouteReady(document);
+  try {
+    await navigate();
+    await outlet?.updateComplete;
+    await chatReady.ready;
+  } finally {
+    chatReady.cancel();
+  }
+  if (prefersReducedMotion) {
+    return;
+  }
+  const animation = outlet?.animate?.(SESSION_ROUTE_ENTER_KEYFRAMES, SESSION_ROUTE_ENTER_OPTIONS);
+  await animation?.finished.catch(() => undefined);
 }
 
 export async function navigateWithRouteTransition(options: RouteTransitionOptions): Promise<void> {
   const { document, from, navigate, prepare, prefersReducedMotion, to } = options;
-  if (
-    from !== "new-session" ||
-    to !== "chat" ||
-    prefersReducedMotion ||
-    typeof document.startViewTransition !== "function"
-  ) {
+  if (from !== "new-session" || to !== "chat") {
     return navigate();
   }
 
@@ -44,17 +72,5 @@ export async function navigateWithRouteTransition(options: RouteTransitionOption
     return navigate();
   }
 
-  document.documentElement.classList.add(SESSION_ROUTE_TRANSITION_CLASS);
-  let navigation: Promise<void> | undefined;
-  try {
-    const transition = document.startViewTransition(
-      () => (navigation ??= navigateAndRender(document, navigate)),
-    );
-    return transition.finished.finally(() => {
-      document.documentElement.classList.remove(SESSION_ROUTE_TRANSITION_CLASS);
-    });
-  } catch {
-    document.documentElement.classList.remove(SESSION_ROUTE_TRANSITION_CLASS);
-    return navigation ?? navigate();
-  }
+  return navigateAndAnimate(document, navigate, prefersReducedMotion);
 }

--- a/ui/src/app/route-transition.ts
+++ b/ui/src/app/route-transition.ts
@@ -10,6 +10,7 @@ type RouteTransitionOptions = {
   document: ViewTransitionDocument;
   from: RouteId | undefined;
   navigate: () => Promise<void>;
+  prepare?: () => Promise<void>;
   prefersReducedMotion: boolean;
   to: RouteId;
 };
@@ -24,14 +25,22 @@ async function navigateAndRender(document: ViewTransitionDocument, navigate: () 
   await outlet?.updateComplete;
 }
 
-export function navigateWithRouteTransition(options: RouteTransitionOptions): Promise<void> {
-  const { document, from, navigate, prefersReducedMotion, to } = options;
+export async function navigateWithRouteTransition(options: RouteTransitionOptions): Promise<void> {
+  const { document, from, navigate, prepare, prefersReducedMotion, to } = options;
   if (
     from !== "new-session" ||
     to !== "chat" ||
     prefersReducedMotion ||
     typeof document.startViewTransition !== "function"
   ) {
+    return navigate();
+  }
+
+  try {
+    await prepare?.();
+  } catch {
+    // Preparation is an enhancement. Preserve direct navigation so its normal
+    // route error handling remains authoritative when preloading fails.
     return navigate();
   }
 

--- a/ui/src/e2e/new-session-page.transition.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.transition.e2e.test.ts
@@ -1,0 +1,75 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import {
+  createNewSessionPageE2eSuite,
+  createdSessionListResult,
+  installMockGateway,
+  waitForCommittedChatRoute,
+} from "./new-session-page.test-support.ts";
+
+const suite = createNewSessionPageE2eSuite();
+const SESSION_KEY = "agent:main:transition-proof-0f403cb8-3920-4cf1-8eb7-79f2f00ce488";
+const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "new-session-transition");
+
+async function captureProof(page: import("playwright").Page, fileName: string) {
+  if (process.env.OPENCLAW_CAPTURE_UI_PROOF !== "1") {
+    return;
+  }
+  await mkdir(proofDir, { recursive: true });
+  await page.screenshot({ fullPage: true, path: path.join(proofDir, fileName) });
+}
+
+suite.define(() => {
+  it("keeps startup progress active while preparing the exact chat route", async () => {
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    let releaseChatModule!: () => void;
+    let chatModuleRequested = false;
+    const chatModuleBlocked = new Promise<void>((resolve) => {
+      releaseChatModule = resolve;
+    });
+    await page.route("**/assets/chat-page-*.js*", async (route) => {
+      chatModuleRequested = true;
+      await chatModuleBlocked;
+      await route.continue();
+    });
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.create": { key: SESSION_KEY, runStarted: true },
+        "sessions.list": createdSessionListResult(SESSION_KEY),
+      },
+    });
+    try {
+      await page.goto(`${suite.server.baseUrl}new`);
+      const message = page.locator(".new-session-page__message");
+      const start = page.locator(".new-session-page__start-submit");
+      await message.fill("keep progress moving");
+      await expect.poll(() => start.isEnabled()).toBe(true);
+
+      await gateway.deferNext("sessions.create");
+      await start.click();
+      await gateway.waitForRequest("sessions.create");
+      await gateway.resolveDeferred("sessions.create", {
+        key: SESSION_KEY,
+        runStarted: true,
+      });
+      await expect.poll(() => chatModuleRequested).toBe(true);
+
+      await expect.poll(() => start.getAttribute("aria-busy")).toBe("true");
+      await captureProof(page, "01-chat-route-preparing.png");
+
+      releaseChatModule();
+      await waitForCommittedChatRoute(page);
+      await page.locator("openclaw-chat-page").waitFor();
+      await captureProof(page, "02-chat-route-ready.png");
+    } finally {
+      releaseChatModule();
+      await context.close();
+    }
+  });
+});

--- a/ui/src/e2e/new-session-page.transition.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.transition.e2e.test.ts
@@ -10,10 +10,12 @@ import {
 
 const suite = createNewSessionPageE2eSuite();
 const SESSION_KEY = "agent:main:transition-proof-0f403cb8-3920-4cf1-8eb7-79f2f00ce488";
+const RUN_ID = "transition-proof-run";
 const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "new-session-transition");
+const captureProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 
 async function captureProof(page: import("playwright").Page, fileName: string) {
-  if (process.env.OPENCLAW_CAPTURE_UI_PROOF !== "1") {
+  if (!captureProofEnabled) {
     return;
   }
   await mkdir(proofDir, { recursive: true });
@@ -21,7 +23,7 @@ async function captureProof(page: import("playwright").Page, fileName: string) {
 }
 
 suite.define(() => {
-  it("keeps startup progress active while preparing the exact chat route", async () => {
+  it("keeps the new-session view live until the focused chat is ready", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -40,7 +42,12 @@ suite.define(() => {
     });
     const gateway = await installMockGateway(page, {
       methodResponses: {
-        "sessions.create": { key: SESSION_KEY, runStarted: true },
+        "sessions.create": {
+          key: SESSION_KEY,
+          messageSeq: 1,
+          runId: RUN_ID,
+          runStarted: true,
+        },
         "sessions.list": createdSessionListResult(SESSION_KEY),
       },
     });
@@ -56,17 +63,88 @@ suite.define(() => {
       await gateway.waitForRequest("sessions.create");
       await gateway.resolveDeferred("sessions.create", {
         key: SESSION_KEY,
+        messageSeq: 1,
+        runId: RUN_ID,
         runStarted: true,
       });
       await expect.poll(() => chatModuleRequested).toBe(true);
 
       await expect.poll(() => start.getAttribute("aria-busy")).toBe("true");
+      const spinner = start.locator("svg");
+      const initialSpinnerTransform = await spinner.evaluate(
+        (element) => getComputedStyle(element).transform,
+      );
+      await expect
+        .poll(() => spinner.evaluate((element) => getComputedStyle(element).transform))
+        .not.toBe(initialSpinnerTransform);
       await captureProof(page, "01-chat-route-preparing.png");
 
+      await page.evaluate(() => {
+        const frames = { invalid: 0, running: true };
+        Reflect.set(globalThis, "__openclawSessionTransitionFrames", frames);
+        const sample = () => {
+          const outlet = document.querySelector("openclaw-router-outlet");
+          const handoffCover = outlet?.classList.contains("session-route-handoff") === true;
+          const newSessionVisible = Boolean(
+            document.querySelector(".new-session-page__start-submit")?.getClientRects().length,
+          );
+          const chatVisible = Boolean(
+            document.querySelector(".agent-chat__composer-combobox")?.getClientRects().length,
+          );
+          if (handoffCover || (!newSessionVisible && !chatVisible)) {
+            frames.invalid += 1;
+          }
+          if (frames.running) {
+            requestAnimationFrame(sample);
+          }
+        };
+        requestAnimationFrame(sample);
+      });
+
+      await gateway.deferNext("chat.startup");
       releaseChatModule();
+      await gateway.waitForRequest("chat.startup");
+      await expect
+        .poll(() =>
+          page.evaluate(() => ({
+            activeViewTransition: Boolean(document.activeViewTransition),
+            chatSurfaceReady: Boolean(document.querySelector(".agent-chat__composer-combobox")),
+            routeAnimation: document.getAnimations().some((animation) => {
+              const effect = animation.effect as KeyframeEffect | null;
+              return (
+                effect?.target instanceof HTMLElement &&
+                effect.target.tagName === "OPENCLAW-ROUTER-OUTLET" &&
+                effect.getKeyframes().every((keyframe) => keyframe.opacity === undefined)
+              );
+            }),
+          })),
+        )
+        .toEqual({ activeViewTransition: false, chatSurfaceReady: true, routeAnimation: true });
+      await expect
+        .poll(() => page.getByText("keep progress moving", { exact: true }).count())
+        .toBe(1);
+      const invalidFrames = await page.evaluate(() => {
+        const frames = Reflect.get(globalThis, "__openclawSessionTransitionFrames") as {
+          invalid: number;
+          running: boolean;
+        };
+        frames.running = false;
+        return frames.invalid;
+      });
+      expect(invalidFrames).toBe(0);
+      await captureProof(page, "02-session-route-transition.png");
+      await gateway.resolveDeferred("chat.startup");
       await waitForCommittedChatRoute(page);
       await page.locator("openclaw-chat-page").waitFor();
-      await captureProof(page, "02-chat-route-ready.png");
+      await expect
+        .poll(() =>
+          page.evaluate(
+            () =>
+              document.activeElement?.matches(".agent-chat__composer-combobox textarea") === true,
+          ),
+        )
+        .toBe(true);
+      await captureProof(page, "03-chat-route-ready.png");
     } finally {
       releaseChatModule();
       await context.close();

--- a/ui/src/lib/sessions/route-navigation.ts
+++ b/ui/src/lib/sessions/route-navigation.ts
@@ -36,6 +36,7 @@ type ContextSessionNavigationTargetParams<TRouteId extends string> = {
   mainKey?: never;
   shortIdLength?: number;
   preferenceDerivedFace?: boolean;
+  focusComposer?: boolean;
   navigationKey?: string;
 };
 
@@ -50,6 +51,7 @@ type ExplicitSessionNavigationTargetParams = {
   shortIdLength?: number;
   agentId?: never;
   preferenceDerivedFace?: boolean;
+  focusComposer?: boolean;
   navigationKey?: string;
 };
 
@@ -182,6 +184,9 @@ export function sessionNavigationTarget<TRouteId extends string>(
   const navigationParams = new URLSearchParams(search ?? "");
   if (params.preferenceDerivedFace && !row) {
     navigationParams.set(SESSION_FACE_PREFERENCE_PARAM, "1");
+  }
+  if (params.focusComposer) {
+    navigationParams.set(SESSION_COMPOSER_FOCUS_PARAM, "1");
   }
   const navigationKey = params.navigationKey?.trim() || row?.key;
   if (navigationKey && SESSION_KEY_UUID_SUFFIX_RE.test(navigationKey)) {

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -142,7 +142,11 @@ export class ChatPage extends OpenClawLightDomElement {
     const data = this.data;
     const activePane = this.layout ? findPane(this.layout, this.layout.activePaneId)?.pane : null;
     const activeSessionKey = this.layout ? (activePane?.sessionKey ?? null) : undefined;
-    const draftRendered = this.draftFocus.rendered(data, activeSessionKey, this.consumedDraftData);
+    const routeHandoffRendered = this.draftFocus.rendered(
+      data,
+      activeSessionKey,
+      this.consumedDraftData,
+    );
     if (changedProperties.has("data")) {
       this.routeHref = window.location.href;
       if (
@@ -171,7 +175,7 @@ export class ChatPage extends OpenClawLightDomElement {
       this.syncRouteToActivePane();
       this.retainedSessions.settleRoute(data.sessionKey);
     }
-    if (data && draftRendered) {
+    if (data && routeHandoffRendered) {
       queueMicrotask(() => {
         if (this.isConnected && this.data === data && this.consumedDraftData !== data) {
           this.draftFocus.beforeDraftCleanup(data);
@@ -388,7 +392,12 @@ export class ChatPage extends OpenClawLightDomElement {
 
   private updateRoute(sessionKey: string, replace = false, face = this.data.face ?? "chat") {
     const data = this.data;
-    if (data?.sessionKey === sessionKey && (data.face ?? "chat") === face && !data.draft) {
+    if (
+      data?.sessionKey === sessionKey &&
+      (data.face ?? "chat") === face &&
+      !data.draft &&
+      !data.focusComposer
+    ) {
       return;
     }
     const options = sessionNavigationTarget({

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -10,6 +10,7 @@ import {
   disposeQuestionPromptState,
   handleQuestionPromptEvent,
 } from "../../app/question-prompt.ts";
+import { CHAT_ROUTE_READY_EVENT } from "../../app/route-transition.ts";
 import { readPresenceEntries } from "../../app/user-profile.ts";
 import { BROWSER_ANNOTATION_EVENT } from "../../components/browser/browser-annotation.ts";
 import { t } from "../../i18n/index.ts";
@@ -62,6 +63,7 @@ const COMPOSER_PREFILL_ATTENTION_DURATION_MS = 1_200;
 const COMPOSER_PREFILL_ATTENTION_CLASS = "agent-chat__input--prefill-attention";
 
 export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
+  private chatRouteReadyReported = false;
   private stagedAttachmentGatewayOwner: ChatAttachmentGatewayOwner = null;
   private suppressStagedAttachmentHandoffOnDisconnect = false;
 
@@ -555,6 +557,12 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
   }
 
   override updated(changedProperties: Map<PropertyKey, unknown> = new Map()) {
+    if (!this.chatRouteReadyReported && this.querySelector(CHAT_COMPOSER_TEXTAREA_SELECTOR)) {
+      // The outer router commit is not a meaningful chat paint. Keep the
+      // handoff cover until this pane has committed its usable composer.
+      this.chatRouteReadyReported = true;
+      this.dispatchEvent(new Event(CHAT_ROUTE_READY_EVENT, { bubbles: true, composed: true }));
+    }
     if (changedProperties.has("focusComposer") && this.focusComposer) {
       const textarea = this.querySelector<HTMLTextAreaElement>(CHAT_COMPOSER_TEXTAREA_SELECTOR);
       const input = textarea?.closest<HTMLElement>(".agent-chat__input");

--- a/ui/src/pages/chat/route-draft-focus-handoff.ts
+++ b/ui/src/pages/chat/route-draft-focus-handoff.ts
@@ -60,7 +60,12 @@ export class RouteDraftComposerFocus {
       pendingHandoff = undefined;
       this.maintain(data.sessionKey);
     }
-    return Boolean(data?.draft && consumedData !== data && matchesActivePane);
+    return Boolean(
+      data &&
+      consumedData !== data &&
+      matchesActivePane &&
+      (data.draft !== undefined || data.focusComposer),
+    );
   }
 
   shouldFocusPane(

--- a/ui/src/pages/chat/route-draft.ts
+++ b/ui/src/pages/chat/route-draft.ts
@@ -22,9 +22,10 @@ export function locationWithoutDraft(location: RouteLocation): RouteLocation {
 
 export function draftRouteDataFromLocation(location: RouteLocation): RouteDraftHint {
   const draft = draftFromLocation(location);
+  const focusComposer = focusComposerFromLocation(location);
   return {
     draft,
-    ...(draft && focusComposerFromLocation(location) ? { focusComposer: true } : {}),
+    ...(focusComposer ? { focusComposer: true } : {}),
   };
 }
 
@@ -34,7 +35,7 @@ export function draftSearchFromLocation(location: RouteLocation): string {
   if (draft) {
     search.set("draft", draft);
   }
-  if (draft && focusComposerFromLocation(location)) {
+  if (focusComposerFromLocation(location)) {
     search.set(SESSION_COMPOSER_FOCUS_PARAM, "1");
   }
   return search.size > 0 ? "?" + search.toString() : "";

--- a/ui/src/pages/new-session/composer.test.ts
+++ b/ui/src/pages/new-session/composer.test.ts
@@ -163,6 +163,14 @@ describe("new-session composer start control", () => {
     expect(composer.querySelector("wa-dropdown-item[value='start-terminal']")).toBeNull();
   });
 
+  it("marks the Start button busy while the session is starting", () => {
+    const { composer } = renderComposer({ submitting: true });
+    const start = composer.querySelector<HTMLButtonElement>(".new-session-page__start-submit");
+
+    expect(start?.getAttribute("aria-busy")).toBe("true");
+    expect(start?.getAttribute("aria-label")).toBe("Starting…");
+  });
+
   it("renders the terminal action as a secondary split-button menu item", () => {
     const onStart = vi.fn();
     const { composer } = renderComposer({

--- a/ui/src/pages/new-session/composer.ts
+++ b/ui/src/pages/new-session/composer.ts
@@ -56,8 +56,9 @@ function renderStartControl(options: NewSessionComposerOptions) {
       <openclaw-tooltip content=${options.submitDisabledReason ?? t("newSession.start")}>
         <button
           type="button"
-          class="chat-send-btn"
+          class="chat-send-btn new-session-page__start-submit"
           ?disabled=${!options.canSubmit}
+          aria-busy=${String(options.submitting)}
           aria-label=${startLabel}
           @click=${options.onSubmit}
         >
@@ -72,8 +73,9 @@ function renderStartControl(options: NewSessionComposerOptions) {
       <openclaw-tooltip content=${options.submitDisabledReason ?? t("newSession.start")}>
         <button
           type="button"
-          class="chat-send-btn new-session-page__start-primary"
+          class="chat-send-btn new-session-page__start-submit new-session-page__start-primary"
           ?disabled=${!options.canSubmit}
+          aria-busy=${String(options.submitting)}
           aria-label=${startLabel}
           @click=${options.onSubmit}
         >

--- a/ui/src/pages/new-session/draft-submission-flow.test.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.test.ts
@@ -31,6 +31,7 @@ describe("DraftSubmissionFlow", () => {
         }),
     );
     const navigate = vi.fn();
+    const preload = vi.fn(async () => undefined);
     const setSessionKey = vi.fn();
     const selectAgent = vi.fn();
     const client = {
@@ -79,6 +80,7 @@ describe("DraftSubmissionFlow", () => {
       cloudStartup: { start },
       config: { current: {} },
       navigate,
+      preload,
     } as unknown as ApplicationContext;
     const host = new ControllerHost();
     const gateway = new DraftGatewayState(
@@ -201,5 +203,6 @@ describe("DraftSubmissionFlow", () => {
     expect(setSessionKey).toHaveBeenCalledWith(start.mock.calls[0]?.[0].recovery.sessionKey);
     expect(selectAgent).toHaveBeenCalledWith("cloud");
     expect(navigate).toHaveBeenCalledOnce();
+    expect(preload).toHaveBeenCalledWith("chat");
   });
 });

--- a/ui/src/pages/new-session/draft-submission-flow.test.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.test.ts
@@ -19,7 +19,7 @@ afterEach(() => {
 });
 
 describe("DraftSubmissionFlow", () => {
-  it("hands cloud startup to the application owner and navigates immediately", async () => {
+  it("keeps startup progress active through the navigation handoff", async () => {
     const createResult = vi.fn(async (params: Record<string, unknown>) => ({
       key: String(params.key),
       initialRun: { status: "idle" as const },
@@ -30,7 +30,13 @@ describe("DraftSubmissionFlow", () => {
           // Application-owned startup intentionally outlives this route.
         }),
     );
-    const navigate = vi.fn();
+    let finishNavigation!: () => void;
+    const navigate = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishNavigation = resolve;
+        }),
+    );
     const preload = vi.fn(async () => undefined);
     const setSessionKey = vi.fn();
     const selectAgent = vi.fn();
@@ -188,7 +194,12 @@ describe("DraftSubmissionFlow", () => {
       },
     ]);
 
-    await flow.submit();
+    const submission = flow.submit();
+    await vi.waitFor(() => expect(navigate).toHaveBeenCalledOnce());
+
+    expect(flow.submitting).toBe(true);
+    finishNavigation();
+    await submission;
 
     expect(start).toHaveBeenCalledOnce();
     expect(start.mock.calls[0]?.[0].recovery).toMatchObject({
@@ -202,7 +213,6 @@ describe("DraftSubmissionFlow", () => {
     expect(createResult).toHaveBeenCalledOnce();
     expect(setSessionKey).toHaveBeenCalledWith(start.mock.calls[0]?.[0].recovery.sessionKey);
     expect(selectAgent).toHaveBeenCalledWith("cloud");
-    expect(navigate).toHaveBeenCalledOnce();
-    expect(preload).toHaveBeenCalledWith("chat");
+    expect(preload).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/pages/new-session/draft-submission-flow.test.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.test.ts
@@ -31,7 +31,7 @@ describe("DraftSubmissionFlow", () => {
         }),
     );
     let finishNavigation!: () => void;
-    const navigate = vi.fn(
+    const navigateAndWait = vi.fn(
       () =>
         new Promise<void>((resolve) => {
           finishNavigation = resolve;
@@ -85,7 +85,7 @@ describe("DraftSubmissionFlow", () => {
       sessions: { state: { result: null }, createResult },
       cloudStartup: { start },
       config: { current: {} },
-      navigate,
+      navigateAndWait,
       preload,
     } as unknown as ApplicationContext;
     const host = new ControllerHost();
@@ -195,7 +195,7 @@ describe("DraftSubmissionFlow", () => {
     ]);
 
     const submission = flow.submit();
-    await vi.waitFor(() => expect(navigate).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(navigateAndWait).toHaveBeenCalledOnce());
 
     expect(flow.submitting).toBe(true);
     finishNavigation();

--- a/ui/src/pages/new-session/draft-submission-flow.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.ts
@@ -392,6 +392,9 @@ export class DraftSubmissionFlow {
     const submittedAt = Date.now();
     this.submittingValue = true;
     this.errorValue = null;
+    // Session creation is usually the long pole, so warm the destination while
+    // the current page continues to show startup progress.
+    void context.preload("chat").catch(() => undefined);
     this.place.browser.close();
     this.callbacks.closeTransientUi();
     this.callbacks.requestUpdate();

--- a/ui/src/pages/new-session/draft-submission-flow.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.ts
@@ -528,7 +528,7 @@ export class DraftSubmissionFlow {
           sessionKey: result.key,
           agentId: submissionAgentId,
         });
-        await context.navigate(
+        await context.navigateAndWait(
           "chat",
           sessionNavigationTarget({
             context,
@@ -572,7 +572,7 @@ export class DraftSubmissionFlow {
         sessionKey: result.key,
         agentId: submissionAgentId,
       });
-      await context.navigate(
+      await context.navigateAndWait(
         "chat",
         sessionNavigationTarget({
           context,

--- a/ui/src/pages/new-session/draft-submission-flow.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.ts
@@ -535,6 +535,7 @@ export class DraftSubmissionFlow {
             face: "chat",
             sessionKey: result.key,
             agentId: this.place.agentId,
+            focusComposer: true,
           }).options,
         );
         return;
@@ -578,6 +579,7 @@ export class DraftSubmissionFlow {
           face: "chat",
           sessionKey: result.key,
           agentId: this.place.agentId,
+          focusComposer: true,
         }).options,
       );
     } finally {

--- a/ui/src/pages/new-session/draft-submission-flow.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.ts
@@ -392,9 +392,6 @@ export class DraftSubmissionFlow {
     const submittedAt = Date.now();
     this.submittingValue = true;
     this.errorValue = null;
-    // Session creation is usually the long pole, so warm the destination while
-    // the current page continues to show startup progress.
-    void context.preload("chat").catch(() => undefined);
     this.place.browser.close();
     this.callbacks.closeTransientUi();
     this.callbacks.requestUpdate();
@@ -531,7 +528,7 @@ export class DraftSubmissionFlow {
           sessionKey: result.key,
           agentId: submissionAgentId,
         });
-        context.navigate(
+        await context.navigate(
           "chat",
           sessionNavigationTarget({
             context,
@@ -574,7 +571,7 @@ export class DraftSubmissionFlow {
         sessionKey: result.key,
         agentId: submissionAgentId,
       });
-      context.navigate(
+      await context.navigate(
         "chat",
         sessionNavigationTarget({
           context,

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -3677,6 +3677,52 @@ wa-dropdown.sidebar-identity-menu::part(menu) {
   min-height: 0;
 }
 
+html.session-route-transition .content--chat > openclaw-router-outlet {
+  view-transition-name: session-route;
+}
+
+/* Keep the shell chrome fixed; only the main routed pane participates. */
+html.session-route-transition::view-transition-old(root),
+html.session-route-transition::view-transition-new(root) {
+  animation: none;
+}
+
+html.session-route-transition::view-transition-old(session-route),
+html.session-route-transition::view-transition-new(session-route) {
+  mix-blend-mode: normal;
+  animation-duration: 180ms;
+  animation-timing-function: var(--ease-out);
+}
+
+html.session-route-transition::view-transition-old(session-route) {
+  animation-name: session-route-exit;
+}
+
+html.session-route-transition::view-transition-new(session-route) {
+  animation-name: session-route-enter;
+}
+
+@keyframes session-route-exit {
+  to {
+    opacity: 0;
+    transform: translateY(-3px) scale(0.997);
+  }
+}
+
+@keyframes session-route-enter {
+  from {
+    opacity: 0;
+    transform: translateY(5px) scale(0.997);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html.session-route-transition::view-transition-old(session-route),
+  html.session-route-transition::view-transition-new(session-route) {
+    animation: none;
+  }
+}
+
 .content--custodian {
   display: flex;
   flex-direction: column;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -3677,52 +3677,6 @@ wa-dropdown.sidebar-identity-menu::part(menu) {
   min-height: 0;
 }
 
-html.session-route-transition .content--chat > openclaw-router-outlet {
-  view-transition-name: session-route;
-}
-
-/* Keep the shell chrome fixed; only the main routed pane participates. */
-html.session-route-transition::view-transition-old(root),
-html.session-route-transition::view-transition-new(root) {
-  animation: none;
-}
-
-html.session-route-transition::view-transition-old(session-route),
-html.session-route-transition::view-transition-new(session-route) {
-  mix-blend-mode: normal;
-  animation-duration: 180ms;
-  animation-timing-function: var(--ease-out);
-}
-
-html.session-route-transition::view-transition-old(session-route) {
-  animation-name: session-route-exit;
-}
-
-html.session-route-transition::view-transition-new(session-route) {
-  animation-name: session-route-enter;
-}
-
-@keyframes session-route-exit {
-  to {
-    opacity: 0;
-    transform: translateY(-3px) scale(0.997);
-  }
-}
-
-@keyframes session-route-enter {
-  from {
-    opacity: 0;
-    transform: translateY(5px) scale(0.997);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  html.session-route-transition::view-transition-old(session-route),
-  html.session-route-transition::view-transition-new(session-route) {
-    animation: none;
-  }
-}
-
 .content--custodian {
   display: flex;
   flex-direction: column;

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -429,6 +429,16 @@ wa-popover.new-session-page__place-popover::part(body) {
   align-items: center;
 }
 
+.new-session-page__start-submit[aria-busy="true"] svg {
+  animation: new-session-start-spin 0.75s linear infinite;
+}
+
+@keyframes new-session-start-spin {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
 .new-session-page__start-primary {
   width: 34px;
   min-width: 34px;
@@ -492,6 +502,10 @@ wa-dropdown.new-session-page__start-menu {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .new-session-page__start-submit[aria-busy="true"] svg {
+    animation: none;
+  }
+
   .new-session-page__composer::after,
   .new-session-page__composer > *,
   .new-session-page__visibility {


### PR DESCRIPTION
Closes #122703

## What Problem This Solves

Fixes an issue where users starting a session from the Control UI would see the submit spinner freeze, disappear into a blank pane, or be replaced by a full-page spinner before the chat became usable. The new chat composer also was not focused after the handoff.

## Why This Change Was Made

The Control UI now prepares the chat route while leaving the submitted new-session view and its live spinner on screen. It swaps only after the chat composer is ready, applies a short transform-only entrance animation, focuses the composer, and preserves the existing fire-and-forget navigation contract for all other routes.

## User Impact

Starting a session now remains visually continuous: the current spinner stays animated until the complete chat appears, without an intermediate blank or full-page loading state. The composer is focused when the new chat opens so users can continue typing immediately.

## Evidence

- Live Gateway testing reproduced the frozen spinner, blank pane, and replacement-spinner states before the final repair; repeated force-refresh testing confirmed the continuous handoff afterward.
- The browser regression test samples every painted handoff frame. The replacement-spinner implementation produced 2 invalid frames; the repaired flow produces 0 and verifies that the composer becomes `document.activeElement`.
- `node scripts/run-vitest.mjs ui/src/app/route-transition.test.ts ui/src/pages/new-session/draft-submission-flow.test.ts` passes 7 focused tests.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.transition.e2e.test.ts` passes the focused browser test.
- `pnpm lint` and `pnpm tsgo:ui` pass on the rebased PR head.

AI-assisted. I reviewed the implementation, navigation ownership boundary, browser behavior, and validation results.
