### PR TITLE
test(gateway): capture session-store forensics on concurrent-adoption flake

### DIFF
--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -1,6 +1,7 @@
 // Session creation tests protect dashboard-origin session records, transcript
 // creation, parent linkage, and model/provider overrides exposed by the gateway API.
 import { execFile } from "node:child_process";
+import { readdirSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -215,6 +216,24 @@ test("sessions.create and sessions.delete preserve every concurrent session life
   }
 });
 
+// The adoption assertion below flaked once on CI (run 31609081812) with the persisted
+// row missing while all 16 creates succeeded; exhaustive owner-path analysis found no
+// mechanism, and the failure never reproduced locally. On mismatch, capture which SQLite
+// files exist and what session_nodes actually holds so the next occurrence names the
+// writer/reader split instead of printing a bare undefined.
+function describeSessionStoreForensics(storePath: string): string {
+  const storeDir = path.dirname(storePath);
+  const files = readdirSync(storeDir).toSorted();
+  const target = resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main" });
+  const database = openOpenClawAgentDatabase({ agentId: "main", path: target.path });
+  const rows = database.db
+    .prepare(
+      "SELECT session_key, length(entry_json) AS entry_bytes, updated_at FROM session_nodes ORDER BY session_key",
+    )
+    .all();
+  return JSON.stringify({ storeDir, files, resolvedTargetPath: target.path, rows });
+}
+
 test("concurrent sessions.create requests adopt one canonical keyed session", async () => {
   const { storePath } = await createSessionStoreDir();
   const key = "agent:main:dashboard:concurrent-keyed-session";
@@ -232,9 +251,12 @@ test("concurrent sessions.create requests adopt one canonical keyed session", as
   expect(new Set(created.map((result) => result.payload?.key))).toEqual(new Set([key]));
   const sessionIds = new Set(created.map((result) => result.payload?.sessionId));
   expect(sessionIds.size).toBe(1);
-  expect(loadSessionEntry({ sessionKey: key, storePath })?.sessionId).toBe(
-    created[0]?.payload?.sessionId,
-  );
+  const persistedSessionId = loadSessionEntry({ sessionKey: key, storePath })?.sessionId;
+  const canonicalSessionId = created[0]?.payload?.sessionId;
+  expect(
+    persistedSessionId,
+    persistedSessionId === canonicalSessionId ? "" : describeSessionStoreForensics(storePath),
+  ).toBe(canonicalSessionId);
 });
 
 test("keyed sessions remain recoverable across overlapping create and delete waves", async () => {


### PR DESCRIPTION
## What Problem This Solves

`src/gateway/server.sessions.create.test.ts` › "concurrent sessions.create requests adopt one canonical keyed session" flaked on CI for an unrelated extensions-only PR (#122671, run 31609081812, shard `agentic-control-plane-agent-chat`): `expected undefined to be '70154ab7-…'` — all 16 concurrent creates returned ok with one canonical sessionId, yet the persisted row read back `undefined`. It passed on rerun and never reproduces locally, so a bare `undefined` gives zero signal about which side (writer target, reader target, or row content) diverged.

## Why This Change Was Made

Root-cause investigation cleared every reachable mechanism before this change:
- The create/adopt path runs snapshot→decide→transcript→upsert entirely under the per-key lifecycle fence (`runExclusiveSessionLifecycleMutation`, `src/gateway/session-create-service.ts:1259`), so concurrent same-key creates are serialized and adoption converging on one sessionId is correct.
- The test's read is a direct SQL point-read (`readSessionEntryRow`, `src/config/sessions/session-accessor.sqlite-entry-store.ts:132`) on the same shared connection — the session-entry snapshot cache is not on its path.
- Post-commit cache publication runs synchronously with COMMIT (`runOpenClawAgentWriteTransaction`, `src/state/openclaw-agent-db.ts:470`); no window between commit and respond.
- No detached tail writes `session_nodes`: disk-budget eviction is threshold-gated and targets only unreferenced historical ids; transcript index reconcile touches only transcript tables; registry maintenance is unreachable from the gateway and preserves non-cron keys.
- Writer and reader resolve the identical SQLite file from the same lexical storePath given consistent ownership state (`resolveCustomStoreSqlitePath`, `src/config/sessions/session-sqlite-target.ts`).

With no named mechanism and no local repro (11 runs: 8× focused, 3× full file), the correct repair is to record the missing facts where the failure happens: on mismatch, the assertion now reports the case dir's sqlite files, the resolved target path, and raw `session_nodes` rows (key, entry bytes, updated_at). Two sqlite files in the dir would prove a writer/reader target flip; a `{}`-sized row would prove a placeholder won the last write; an absent row with one file would prove a lost commit. The next occurrence names the mechanism instead of printing `undefined`.

## User Impact

None at runtime — test-only. CI flakes on this assertion become self-diagnosing.

## Evidence

- Full file: `node scripts/run-vitest.mjs src/gateway/server.sessions.create.test.ts` — 95/95 passed.
- Forensic path proven: a forced mismatch renders the diagnostic (files, resolvedTargetPath, rows) in the assertion message, then was reverted.
- Format (`oxfmt --check`), lint (`scripts/run-oxlint.mjs`), and typecheck (`scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json`) clean on the changed file.
- `node scripts/check-changed.mjs` remote delegation was unavailable (Azure `standardDadv6Family` core-quota 409 on Crabbox lease); proof ran locally per the trusted-source fallback rule.
- Autoreview (branch mode): clean, no accepted/actionable findings.
- numstat: +27/−3, all test source; production delta 0.
