### PR TITLE
fix(xai): preserve Grok 4.6 xhigh over OAuth

### DIFF
--- a/extensions/xai/index.test.ts
+++ b/extensions/xai/index.test.ts
@@ -372,6 +372,30 @@ describe("xai provider plugin", () => {
     );
   });
 
+  it("preserves Grok 4.6 xhigh reasoning through OAuth auto", async () => {
+    mockXaiRuntimeOAuth();
+    stubXaiFetch((url) =>
+      url.endsWith("/settings")
+        ? Response.json({ default_model: "grok-4.6" })
+        : Response.json({
+            data: [{ id: "grok-4.6", api_backend: "responses" }],
+          }),
+    );
+    const { provider, result } = await runXaiCatalog();
+    const auto = result.models.find((model) => model.id === "auto");
+    const normalized = provider.normalizeResolvedModel?.({
+      provider: "xai",
+      modelId: "auto",
+      model: { ...auto, provider: "xai" },
+    } as never);
+
+    expect(normalized?.id).toBe("grok-4.6");
+    expect(normalized?.thinkingLevelMap?.xhigh).toBe("xhigh");
+    expect(normalized?.compat).toMatchObject({
+      supportedReasoningEfforts: ["low", "medium", "high", "xhigh"],
+    });
+  });
+
   it("uses runtime OAuth profiles when xAI catalog auth resolution is empty", async () => {
     mockXaiRuntimeOAuth();
     stubXaiFetch(() =>

--- a/extensions/xai/model-id.ts
+++ b/extensions/xai/model-id.ts
@@ -1,10 +1,17 @@
 // Xai plugin module implements model id behavior.
 export const XAI_OAUTH_AUTO_MODEL_ID = "auto";
 
+export function isXaiGrok46ModelId(id: string): boolean {
+  const normalized = normalizeXaiModelId(id.trim().toLowerCase());
+  return normalized === "grok-4.6" || normalized.startsWith("grok-4.6-");
+}
+
 export function isXaiFrontierModelId(id: string): boolean {
   const normalized = normalizeXaiModelId(id.trim().toLowerCase());
-  return ["grok-4.6", "grok-4.5"].some(
-    (prefix) => normalized === prefix || normalized.startsWith(`${prefix}-`),
+  return (
+    isXaiGrok46ModelId(normalized) ||
+    normalized === "grok-4.5" ||
+    normalized.startsWith("grok-4.5-")
   );
 }
 

--- a/extensions/xai/provider-policy-api.test.ts
+++ b/extensions/xai/provider-policy-api.test.ts
@@ -27,11 +27,9 @@ describe("xai provider thinking policy", () => {
   });
 
   it.each([
-    ["xai", "grok-4.6"],
     ["xai", "grok-4.5"],
     ["xai", "grok-4.5-latest"],
     ["xai", "grok-build-latest"],
-    ["x-ai", "grok-4.6"],
     ["x-ai", "grok-4.5"],
     ["x-ai", "grok-4.5-latest"],
     ["x-ai", "grok-build-latest"],
@@ -43,6 +41,13 @@ describe("xai provider thinking policy", () => {
 
     expect(profile).toEqual({
       levels: [{ id: "low" }, { id: "medium" }, { id: "high" }],
+      defaultLevel: "high",
+    });
+  });
+
+  it.each(["xai", "x-ai"])("exposes Grok 4.6 xhigh reasoning for %s", (provider) => {
+    expect(resolveThinkingProfile({ provider, modelId: "grok-4.6" })).toEqual({
+      levels: [{ id: "low" }, { id: "medium" }, { id: "high" }, { id: "xhigh" }],
       defaultLevel: "high",
     });
   });

--- a/extensions/xai/provider-policy-api.ts
+++ b/extensions/xai/provider-policy-api.ts
@@ -4,7 +4,7 @@ import type {
   ProviderThinkingProfile,
 } from "openclaw/plugin-sdk/plugin-entry";
 import { resolveXaiCatalogEntry } from "./model-definitions.js";
-import { isXaiFrontierModelId, normalizeXaiModelId } from "./model-id.js";
+import { isXaiFrontierModelId, isXaiGrok46ModelId, normalizeXaiModelId } from "./model-id.js";
 import { isXaiProviderId } from "./provider-id.js";
 
 export function resolveThinkingProfile(
@@ -16,8 +16,11 @@ export function resolveThinkingProfile(
   }
   const modelId = normalizeXaiModelId(ctx.modelId.trim().toLowerCase());
   if (isXaiFrontierModelId(modelId)) {
+    const levels: ProviderThinkingProfile["levels"] = isXaiGrok46ModelId(modelId)
+      ? [{ id: "low" }, { id: "medium" }, { id: "high" }, { id: "xhigh" }]
+      : [{ id: "low" }, { id: "medium" }, { id: "high" }];
     return {
-      levels: [{ id: "low" }, { id: "medium" }, { id: "high" }],
+      levels,
       defaultLevel: "high",
     };
   }

--- a/extensions/xai/runtime-model-compat.test.ts
+++ b/extensions/xai/runtime-model-compat.test.ts
@@ -24,29 +24,47 @@ describe("xai runtime model compat", () => {
     });
   });
 
-  it.each(["grok-4.6", "grok-4.5"])(
-    "maps %s thinking levels to its supported reasoning efforts",
-    (modelId) => {
-      const model = applyXaiRuntimeModelCompat({
-        id: modelId,
-        provider: "xai",
-        reasoning: true,
-      });
+  it("preserves Grok 4.6 xhigh reasoning", () => {
+    const model = applyXaiRuntimeModelCompat({
+      id: "grok-4.6",
+      provider: "xai",
+      reasoning: true,
+    });
 
-      expect(model.compat).toMatchObject({
-        supportsReasoningEffort: true,
-        supportedReasoningEfforts: ["low", "medium", "high"],
-      });
-      expect(model.thinkingLevelMap).toEqual({
-        off: null,
-        minimal: "low",
-        low: "low",
-        medium: "medium",
-        high: "high",
-        xhigh: "high",
-      });
-    },
-  );
+    expect(model.compat).toMatchObject({
+      supportsReasoningEffort: true,
+      supportedReasoningEfforts: ["low", "medium", "high", "xhigh"],
+    });
+    expect(model.thinkingLevelMap).toEqual({
+      off: null,
+      minimal: "low",
+      low: "low",
+      medium: "medium",
+      high: "high",
+      xhigh: "xhigh",
+    });
+  });
+
+  it("maps Grok 4.5 thinking levels to its supported reasoning efforts", () => {
+    const model = applyXaiRuntimeModelCompat({
+      id: "grok-4.5",
+      provider: "xai",
+      reasoning: true,
+    });
+
+    expect(model.compat).toMatchObject({
+      supportsReasoningEffort: true,
+      supportedReasoningEfforts: ["low", "medium", "high"],
+    });
+    expect(model.thinkingLevelMap).toEqual({
+      off: null,
+      minimal: "low",
+      low: "low",
+      medium: "medium",
+      high: "high",
+      xhigh: "high",
+    });
+  });
 
   it("suppresses reasoning efforts for non-reasoning models", () => {
     const model = applyXaiRuntimeModelCompat({

--- a/extensions/xai/runtime-model-compat.ts
+++ b/extensions/xai/runtime-model-compat.ts
@@ -2,7 +2,7 @@
 // Reasoning effort is configurable only for current flagship Grok models; encrypted reasoning
 // include/replay is handled separately in stream.ts for every reasoning-capable xAI model.
 import { applyXaiModelCompat } from "./model-compat.js";
-import { isXaiFrontierModelId } from "./model-id.js";
+import { isXaiFrontierModelId, isXaiGrok46ModelId } from "./model-id.js";
 
 type XaiRuntimeModelCompat = {
   compat?: unknown;
@@ -56,6 +56,7 @@ function resolveXaiReasoningEffortCompat(model: XaiRuntimeModelCompat): Record<s
       supportedReasoningEfforts: [
         ...(isGrok43Model(id) ? ["none"] : []),
         ...XAI_SUPPORTED_REASONING_EFFORTS,
+        ...(isXaiGrok46ModelId(id) ? ["xhigh"] : []),
       ],
     };
   }
@@ -82,6 +83,7 @@ export function applyXaiRuntimeModelCompat<T extends XaiRuntimeModelCompat>(
       ...withCompat.thinkingLevelMap,
       ...(supportsReasoningEffort ? XAI_REASONING_EFFORTS : XAI_UNSUPPORTED_REASONING_EFFORTS),
       ...(supportsReasoningEffort && isGrok43Model(id) ? { off: "none" } : {}),
+      ...(supportsReasoningEffort && isXaiGrok46ModelId(id) ? { xhigh: "xhigh" } : {}),
     },
   };
 }

--- a/extensions/xai/stream.test.ts
+++ b/extensions/xai/stream.test.ts
@@ -17,7 +17,7 @@ import {
 } from "./test-helpers.js";
 type XaiStreamApi = Extract<Api, "openai-completions" | "openai-responses">;
 type StreamEvent = Record<string, unknown> & { type?: string };
-const PAYLOAD_CAPTURE_TIMEOUT_MS = 5_000;
+const PAYLOAD_CAPTURE_TIMEOUT_MS = 10_000;
 
 async function collectEvents(stream: ReturnType<StreamFn>): Promise<StreamEvent[]> {
   const events: StreamEvent[] = [];
@@ -543,19 +543,26 @@ describe("xai stream wrappers", () => {
 
     expect(payload.reasoning).toEqual({ effort: "low", summary: "auto" });
     expect(payload.include).toEqual(["reasoning.encrypted_content"]);
-  }, 10_000);
+  }, 15_000);
+
+  it("preserves Grok 4.6 xhigh at the final xAI Responses payload boundary", async () => {
+    const payload = await captureXaiResponsesPayloadWithThinking("xhigh");
+
+    expect(payload.reasoning).toEqual({ effort: "xhigh", summary: "auto" });
+    expect(payload.include).toEqual(["reasoning.encrypted_content"]);
+  }, 15_000);
 
   it("clamps unsupported Grok 4.6 off reasoning to low", async () => {
     const payload = await captureXaiResponsesPayloadWithThinking("off");
 
     expect(payload.reasoning).toEqual({ effort: "low", summary: "auto" });
-  }, 10_000);
+  }, 15_000);
 
   it("maps Grok 4.3 off reasoning to xAI none", async () => {
     const payload = await captureXaiResponsesPayloadWithThinking("off", "grok-4.3");
 
     expect(payload.reasoning).toEqual({ effort: "none" });
-  }, 10_000);
+  }, 15_000);
 
   it("moves image-bearing tool results out of function_call_output payloads", () => {
     const payload: Record<string, unknown> = {


### PR DESCRIPTION
Related: #122682

## What Problem This Solves

Fixes an issue where users selecting `xhigh` for Grok 4.6 through xAI OAuth would receive only `high` reasoning because Grok 4.6 inherited the Grok 4.5 compatibility mapping.

## Why This Change Was Made

The xAI plugin now distinguishes the Grok 4.6 reasoning contract from Grok 4.5 at the model policy boundary. Grok 4.6 exposes and forwards `xhigh`, while Grok 4.5 keeps low, medium, and high with its existing `xhigh` to `high` downgrade. OAuth `auto` normalization is covered at the provider boundary.

This does not change authentication fallback policy. Issue #114510 remains separate. The parent branch independently corrected its X search setup hint, so this child PR contains only the reasoning contract fix.

## User Impact

Users authenticated through grok.com can select the full documented Grok 4.6 reasoning range without OpenClaw silently reducing `xhigh` to `high`. Existing Grok 4.5 OAuth behavior remains unchanged.

## Evidence

Official xAI sources confirm model ID `grok-4.6`, a 500,000 token context window, and reasoning efforts low, medium, high, and xhigh:

1. https://docs.x.ai/developers/grok-4-6
2. https://x.ai/news/grok-4-6

Redacted live OAuth proof used Grok CLI 1.0.0 with `XAI_API_KEY` removed from the environment:

1. `grok models` reported a grok.com login and selected `grok-4.6` as the default.
2. A one turn OAuth request with `grok-4.6` and `xhigh` returned the exact expected response.
3. The same OAuth request with `grok-4.5` rejected `xhigh` and listed only low, medium, and high.
4. No token, account identifier, or private response content was recorded.

Inspectable transcript:

```text
$ env -u XAI_API_KEY grok models
You are logged in with grok.com.

Default model: grok-4.6

Available models:
  * grok-4.6 (default)
  - grok-4.5

$ env -u XAI_API_KEY grok --model grok-4.6 --reasoning-effort xhigh --single "Return exactly this marker and nothing else: OPENCLAW_GROK_46_XHIGH_OK" --output-format plain --max-turns 1 --no-memory --no-subagents --disable-web-search --permission-mode dontAsk --verbatim
OPENCLAW_GROK_46_XHIGH_OK

$ env -u XAI_API_KEY grok --model grok-4.5 --reasoning-effort xhigh --single "Return exactly this marker and nothing else: OPENCLAW_GROK_45_XHIGH_UNEXPECTED" --output-format plain --max-turns 1 --no-memory --no-subagents --disable-web-search --permission-mode dontAsk --verbatim
--effort/--reasoning-effort: unknown effort level 'xhigh'; use one of: high, medium, low
Error: --effort/--reasoning-effort: unknown effort level 'xhigh'; use one of: high, medium, low
[exit 1]
```

The current pull request head was then exercised under Node 24 at the OAuth normalization, provider policy, and final Responses payload boundaries:

```text
$ pnpm exec vitest run --config test/vitest/vitest.extension-providers.config.ts extensions/xai/index.test.ts extensions/xai/provider-policy-api.test.ts extensions/xai/runtime-model-compat.test.ts extensions/xai/stream.test.ts
Test Files  4 passed (4)
Tests      100 passed (100)
```

Regression proof:

1. Four assertions failed before the fix for the missing or downgraded Grok 4.6 `xhigh` contract.
2. Focused OAuth, policy, compatibility, and final payload tests: 100 passed.
3. Complete xAI extension suite: 475 passed across 28 executed files.
4. The changed gate passed against `hannes/xai-default-grok-4-5`, including extension and test type checks, targeted lint, plugin boundaries, dead exports, dependency guards, sidecar guards, and import cycles.
5. `git diff --check` passed.
6. Mandatory autoreview reported no accepted or actionable findings with 0.99 confidence for both the implementation and the incremental final payload test.

The first GitHub Actions attempt had one existing stream payload test reach its five second callback deadline under two way shard contention. The changed compatibility test passed in that same shard, and the timed out stream test passed four consecutive times under Node 24 locally. The current head adds a direct Grok 4.6 `xhigh` final payload assertion and uses a finite ten second capture deadline beneath a fifteen second test deadline.

The remote Crabbox runner could not start because its selected binary failed the required version and help sanity checks. Repository policy allowed this trusted maintainer branch to use the complete local fallback above.

This contribution was prepared with AI assistance and manually verified against official xAI documentation, live OAuth behavior, repository tests, and the final diff.
