### PR TITLE
fix(ci): wait for managed Linux linger teardown

### DIFF
--- a/src/gateway/desktop/managed-linux.test.ts
+++ b/src/gateway/desktop/managed-linux.test.ts
@@ -320,9 +320,6 @@ describe("managed Linux desktop", () => {
     });
     expect(observer).toBeDefined();
     observer?.release();
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 10);
-    });
-    expect(desktop.status()).toEqual({ state: "not-started" });
+    await vi.waitFor(() => expect(desktop.status()).toEqual({ state: "not-started" }));
   });
 });


### PR DESCRIPTION
Closes #122720

AI-assisted: yes. I understand the change and independently verified the lifecycle boundary.

## What Problem This Solves

Fixes an issue where unrelated pull requests could receive a false-negative compact Linux shard when the managed desktop linger test's fixed 10 ms delay ended before asynchronous registry teardown completed.

Observed failure: https://github.com/openclaw/openclaw/actions/runs/31616914629/job/94182393465

## Why This Change Was Made

The test now waits for the public managed-desktop status to reach `not-started` instead of assuming timer-triggered teardown completes within a fixed wall-clock delay. Production lifecycle behavior and the linger path under test remain unchanged.

Alternatives were weaker: explicitly stopping the registry or desktop would bypass the linger behavior, while fake timers would still need to synchronize asynchronous process/filesystem teardown.

## User Impact

Contributors avoid an intermittent CI false negative and the resulting rerun delay. There is no runtime product behavior change.

## Evidence

- Condition-based version: 40/40 focused repeats passed under Node 24 with `CI=1` and one Vitest worker.
- Fresh post-rebase focused run: 7/7 tests passed.
- Independent read-only review: best minimal fix, no blocking or nonblocking findings; an additional 25/25 focused repeats passed.
- `oxfmt --check src/gateway/desktop/managed-linux.test.ts` passed.
- `git diff --check origin/main...HEAD` passed.
- Structured autoreview was attempted, but its Codex executable is unavailable in this orb; no Crabbox/Testbox substitute was used.
