### PR TITLE
fix(ai): recover missing OpenAI WebSocket response state

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -1314,22 +1314,29 @@ not declared Codex-compatible.
 
 <AccordionGroup>
   <Accordion title="Transport (WebSocket vs SSE)">
-    OpenClaw uses WebSocket-first with SSE fallback (`"auto"`) for `openai/*`.
+    Direct API-key requests use SSE by default. Set `params.transport` when you
+    want Responses WebSocket mode on an eligible official OpenAI endpoint.
 
-    In `"auto"` mode, OpenClaw:
-    - Retries one early WebSocket failure before falling back to SSE
-    - After a failure, marks WebSocket as degraded for 60 seconds and uses SSE
-      during cool-down
-    - Attaches stable session and turn identity headers for retries and
-      reconnects
-    - Normalizes usage counters (`input_tokens` / `prompt_tokens`) across
-      transport variants
+    | Value                 | Behavior |
+    | --------------------- | -------- |
+    | `"sse"` (default)     | Stream each request over SSE |
+    | `"auto"`              | Prefer a session-cached WebSocket, with pre-dispatch SSE fallback |
+    | `"websocket-cached"`  | Explicitly use the session-cached WebSocket path, with the same pre-dispatch SSE fallback |
+    | `"websocket"`         | Use a transient WebSocket for the request, with pre-dispatch SSE fallback |
 
-    | Value                | Behavior                          |
-    | ---------------------- | ------------------------------------ |
-    | `"auto"` (default)   | WebSocket first, SSE fallback     |
-    | `"sse"`              | Force SSE only                    |
-    | `"websocket"`        | Force WebSocket only              |
+    Cached modes keep one eligible connection per session. When the prior
+    request and response still match the current history, OpenClaw sends only
+    the new input and references the prior response with
+    `previous_response_id`. Otherwise it sends full history without that
+    reference.
+
+    A setup or handshake failure before request dispatch falls back to SSE; it
+    is not retried or reconnected first. After dispatch, failures with an
+    unknown outcome remain replay-unsafe and fail closed. The explicit server
+    rejections `previous_response_not_found` and
+    `websocket_connection_limit_reached` are safe exceptions: OpenClaw closes
+    the failed socket and retries that turn once over SSE with full history and
+    no rejected `previous_response_id`.
 
     ```json5
     {
@@ -1347,7 +1354,7 @@ not declared Codex-compatible.
     ```
 
     Related OpenAI docs:
-    - [Realtime API with WebSocket](https://platform.openai.com/docs/guides/realtime-websocket)
+    - [Responses API WebSocket mode](https://developers.openai.com/api/docs/guides/websocket-mode)
     - [Streaming API responses (SSE)](https://platform.openai.com/docs/guides/streaming-responses)
 
   </Accordion>

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -27,6 +27,7 @@ import {
 import {
   AZURE_RESPONSES_FIRST_EVENT_TIMEOUT_MS,
   OpenAIResponsesWebSocketPreDispatchError,
+  OpenAIResponsesWebSocketSafeRetryError,
   type OpenAIResponsesOptions,
 } from "./openai-responses-contracts.js";
 import {
@@ -333,8 +334,10 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
             `apiKey=${apiKey ? "present" : "missing"} ${summarizeResponsesPayload(params)}`,
         );
         let continuationBaseline: ResponsesContinuationRequest | undefined;
-        const createSseStream = async (): Promise<AsyncIterable<unknown>> => {
-          const initialRequest = (continuationClaim?.request ?? params) as typeof params;
+        const createSseStream = async (
+          initialRequest = (continuationClaim?.request ?? params) as typeof params,
+          initialAttemptKind: "initial" | "continuation-rejected" = "initial",
+        ): Promise<AsyncIterable<unknown>> => {
           const {
             stream: rawResponseStream,
             response,
@@ -345,6 +348,7 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
             requestOptions,
             model,
             observePrompt,
+            initialAttemptKind,
             buildFullHistoryRequest: () => buildRequest("full-history"),
             onCompactionRejected: () =>
               suppressOpenAIResponsesCompaction(output, model, {
@@ -416,6 +420,19 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
                     yield event;
                   }
                 } catch (error) {
+                  if (error instanceof OpenAIResponsesWebSocketSafeRetryError) {
+                    finishWebSocket?.({ keep: false });
+                    finishWebSocket = undefined;
+                    transport = "sse";
+                    logWebSocketFallback(
+                      `safe_server_error code=${error.code} status=${safeDebugValue(error.status)} param=${safeDebugValue(error.param)}`,
+                    );
+                    yield* await createSseStream(
+                      await buildRequest("full-history"),
+                      "continuation-rejected",
+                    );
+                    return;
+                  }
                   if (
                     websocketSignal.aborted ||
                     !(error instanceof OpenAIResponsesWebSocketPreDispatchError)

--- a/packages/ai/src/transports/openai-responses-contracts.ts
+++ b/packages/ai/src/transports/openai-responses-contracts.ts
@@ -59,7 +59,7 @@ export class OpenAIResponsesWebSocketPostDispatchError extends Error {
   }
 }
 
-export class OpenAIResponsesWebSocketServerError extends Error {
+class OpenAIResponsesWebSocketServerError extends Error {
   constructor(
     readonly code: string,
     readonly status: number | undefined,

--- a/packages/ai/src/transports/openai-responses-contracts.ts
+++ b/packages/ai/src/transports/openai-responses-contracts.ts
@@ -4,6 +4,7 @@ import {
   type Api,
   type ProviderReplayState,
 } from "@openclaw/llm-core";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type {
   FunctionTool,
   ResponseCreateParamsStreaming,
@@ -56,6 +57,59 @@ export class OpenAIResponsesWebSocketPostDispatchError extends Error {
     });
     this.name = "OpenAIResponsesWebSocketPostDispatchError";
   }
+}
+
+export class OpenAIResponsesWebSocketServerError extends Error {
+  constructor(
+    readonly code: string,
+    readonly status: number | undefined,
+    readonly param: string | null,
+    message: string,
+    cause: unknown,
+  ) {
+    super(message, { cause });
+    this.name = "OpenAIResponsesWebSocketServerError";
+  }
+}
+
+export class OpenAIResponsesWebSocketSafeRetryError extends OpenAIResponsesWebSocketServerError {}
+
+function readWebSocketServerError(value: unknown) {
+  if (!isRecord(value) || value.type !== "error") {
+    return undefined;
+  }
+  const details = isRecord(value.error) ? value.error : value;
+  if (typeof details.code !== "string" || typeof details.message !== "string") {
+    return undefined;
+  }
+  const rawStatus = value.status ?? value.status_code;
+  return {
+    code: details.code,
+    message: details.message,
+    param: typeof details.param === "string" ? details.param : null,
+    status: typeof rawStatus === "number" ? rawStatus : undefined,
+  };
+}
+
+export function parseOpenAIResponsesWebSocketServerError(cause: unknown) {
+  if (!isRecord(cause)) {
+    return undefined;
+  }
+  let details = readWebSocketServerError(cause.error) ?? readWebSocketServerError(cause);
+  if (!details && typeof cause.message === "string") {
+    try {
+      details = readWebSocketServerError(JSON.parse(cause.message));
+    } catch {}
+  }
+  if (!details) {
+    return undefined;
+  }
+  const ErrorClass =
+    details.code === "previous_response_not_found" ||
+    details.code === "websocket_connection_limit_reached"
+      ? OpenAIResponsesWebSocketSafeRetryError
+      : OpenAIResponsesWebSocketServerError;
+  return new ErrorClass(details.code, details.status, details.param, details.message, cause);
 }
 
 export type ReplayableResponseOutputMessage = Omit<ResponseOutputMessage, "id"> & { id?: string };

--- a/packages/ai/src/transports/openai-responses-replay-internal.ts
+++ b/packages/ai/src/transports/openai-responses-replay-internal.ts
@@ -281,6 +281,7 @@ export async function createResponsesStreamWithEncryptedContentRetry(params: {
   requestOptions: unknown;
   model: Model;
   observePrompt?: NonNullable<ReturnType<typeof createResponsesPromptEgressObserver>>;
+  initialAttemptKind?: "initial" | "continuation-rejected";
   onCompactionRejected?: () => void;
   buildFullHistoryRequest?: () =>
     | OpenAIResponsesRequestParams
@@ -303,7 +304,7 @@ export async function createResponsesStreamWithEncryptedContentRetry(params: {
   };
 
   let attempt: ResponsesEncryptedContentAttempt<OpenAIResponsesRequestParams> = {
-    kind: "initial",
+    kind: params.initialAttemptKind ?? "initial",
     request: params.request,
   };
   while (true) {

--- a/packages/ai/src/transports/openai-responses-websocket-client.test.ts
+++ b/packages/ai/src/transports/openai-responses-websocket-client.test.ts
@@ -5,9 +5,15 @@ import {
   type Context,
   type Model,
 } from "@openclaw/llm-core";
+import { WebSocketError } from "openai/resources/responses/internal-base.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { configureAiTransportHost, getAiTransportHost } from "../host.js";
 import { cleanupSessionResources } from "../session-resources.js";
+import {
+  OpenAIResponsesWebSocketSafeRetryError,
+  responsesPromptObserver,
+  type ResponsesPromptObservation,
+} from "./openai-responses-contracts.js";
 
 type StreamMessage =
   | { type: "open" }
@@ -111,7 +117,11 @@ vi.mock("openai/resources/responses/ws.js", () => ({
   },
 }));
 
-import { createOpenAIResponsesTransportStreamFn } from "./openai-responses-client.js";
+import {
+  createOpenAIResponsesClient,
+  createOpenAIResponsesTransportStreamFn,
+} from "./openai-responses-client.js";
+import { createOpenAIResponsesWebSocketStream } from "./openai-responses-websocket.js";
 
 const initialHost = getAiTransportHost();
 const model = {
@@ -179,6 +189,25 @@ function message(event: Record<string, unknown>): StreamMessage {
   return { type: "message", message: event };
 }
 
+function wrappedSdkServerError(params: {
+  code: string;
+  message: string;
+  param?: string;
+  status: number;
+}): WebSocketError {
+  const event = {
+    type: "error",
+    error: {
+      type: "invalid_request_error",
+      code: params.code,
+      message: params.message,
+      param: params.param ?? null,
+    },
+    status: params.status,
+  };
+  return new WebSocketError(JSON.stringify(event), event as never);
+}
+
 function toolCallResponse(responseId: string): StreamMessage[] {
   const functionCall = {
     type: "function_call",
@@ -233,16 +262,27 @@ async function run(
     sessionId?: string;
     timeoutMs?: number;
     headers?: Record<string, string>;
+    observations?: ResponsesPromptObservation[];
   } = {},
 ): Promise<AssistantMessage> {
-  const stream = await createOpenAIResponsesTransportStreamFn()(overrides.model ?? model, context, {
+  const options = {
     apiKey: "test-key",
     sessionId: overrides.sessionId ?? "session-1",
     transport: overrides.transport ?? "websocket-cached",
     reasoningEffort: "low",
     timeoutMs: overrides.timeoutMs,
     headers: overrides.headers,
-  } as never);
+  };
+  if (overrides.observations) {
+    responsesPromptObserver.set(options, (observation) =>
+      overrides.observations?.push(observation),
+    );
+  }
+  const stream = await createOpenAIResponsesTransportStreamFn()(
+    overrides.model ?? model,
+    context,
+    options as never,
+  );
   return stream.result();
 }
 
@@ -443,9 +483,118 @@ describe("native OpenAI Responses WebSocket client integration", () => {
     expect(transportState.sdkRequests).toHaveLength(2);
   });
 
+  it.each(["previous_response_not_found", "websocket_connection_limit_reached"])(
+    "recovers a cached continuation rejected with %s over full-history SSE",
+    async (code) => {
+      transportState.responseBatches.push(
+        [message(completedEvent("resp_1", "first answer"))],
+        [
+          {
+            type: "error",
+            error: wrappedSdkServerError({
+              code,
+              message: `safe rejection: ${code}`,
+              param: code === "previous_response_not_found" ? "previous_response_id" : undefined,
+              status: 400,
+            }),
+          },
+        ],
+        [message(completedEvent("resp_3", "third answer"))],
+      );
+      transportState.sdkOutcomes.push(sdkCompletion("resp_sse"));
+      const firstUser = userMessage("first question", 1);
+      const first = await run({ messages: [firstUser], tools: [] });
+
+      const secondUser = userMessage("second question", 2);
+      const observations: ResponsesPromptObservation[] = [];
+      const second = await run(
+        { messages: [firstUser, first, secondUser], tools: [] },
+        { observations },
+      );
+
+      expect(second.stopReason).toBe("stop");
+      expect(transportState.websocketRequests[1]).toMatchObject({
+        previous_response_id: "resp_1",
+        input: [
+          {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "second question" }],
+          },
+        ],
+      });
+      expect(transportState.websocketCloseCount).toBe(1);
+      expect(transportState.sdkRequests).toHaveLength(1);
+      expect(transportState.sdkRequests[0]).not.toHaveProperty("previous_response_id");
+      expect(transportState.sdkRequests[0]?.input).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ role: "user" }),
+          expect.objectContaining({ role: "assistant" }),
+          expect.objectContaining({ role: "user" }),
+        ]),
+      );
+      expect(
+        observations.map(({ egress, payloadVariant }) => ({ egress, payloadVariant })),
+      ).toEqual([
+        { egress: "responses-websocket", payloadVariant: "initial" },
+        { egress: "responses-sdk", payloadVariant: "continuation-rejected" },
+      ]);
+
+      const third = await run({
+        messages: [firstUser, first, secondUser, second, userMessage("third question", 3)],
+        tools: [],
+      });
+      expect(third.stopReason).toBe("stop");
+      expect(transportState.websocketOptions).toHaveLength(2);
+      expect(transportState.sdkRequests).toHaveLength(1);
+    },
+  );
+
+  it("preserves the wrapped server error details and original SDK cause", async () => {
+    const cause = wrappedSdkServerError({
+      code: "previous_response_not_found",
+      message: "previous response missing",
+      param: "previous_response_id",
+      status: 400,
+    });
+    transportState.responseBatches.push([{ type: "error", error: cause }]);
+    const response = createOpenAIResponsesWebSocketStream({
+      client: createOpenAIResponsesClient(model, { messages: [], tools: [] }, "test-key"),
+      request: { model: model.id, input: [] },
+      mode: "websocket",
+    });
+
+    let error: unknown;
+    try {
+      for await (const event of response.stream) {
+        void event;
+      }
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(OpenAIResponsesWebSocketSafeRetryError);
+    expect(error).toMatchObject({
+      code: "previous_response_not_found",
+      message: "previous response missing",
+      param: "previous_response_id",
+      status: 400,
+    });
+    expect((error as Error).cause).toBe(cause);
+    expect(transportState.websocketCloseCount).toBe(1);
+  });
+
   it("does not replay over SSE after an ambiguous post-dispatch disconnect", async () => {
     transportState.responseBatches.push([
-      { type: "error", error: new Error("connection lost after send") },
+      {
+        type: "error",
+        error: wrappedSdkServerError({
+          code: "invalid_websocket_request",
+          message: "request may have been dispatched",
+          param: "input",
+          status: 400,
+        }),
+      },
     ]);
 
     const result = await run({ messages: [userMessage("hello", 1)], tools: [] });

--- a/packages/ai/src/transports/openai-responses-websocket.ts
+++ b/packages/ai/src/transports/openai-responses-websocket.ts
@@ -13,9 +13,11 @@ import {
   type ResponsesContinuationStatus,
 } from "./openai-responses-continuation.js";
 import {
+  parseOpenAIResponsesWebSocketServerError,
   OpenAIResponsesWebSocketPostDispatchError,
   OpenAIResponsesWebSocketPreDispatchError,
   OpenAIResponsesWebSocketResponseFailedError,
+  OpenAIResponsesWebSocketSafeRetryError,
 } from "./openai-responses-contracts.js";
 import { transportAbortError } from "./transport-stream-shared.js";
 import { sha256Hex } from "./transport-utils.js";
@@ -302,7 +304,10 @@ function readServerEvent(
     return message.message;
   }
   if (message.type === "error") {
-    throw new Error("OpenAI Responses WebSocket transport failed", { cause: message.error });
+    throw (
+      parseOpenAIResponsesWebSocketServerError(message.error) ??
+      new Error("OpenAI Responses WebSocket transport failed", { cause: message.error })
+    );
   }
   if (message.type === "close") {
     throw new Error(`OpenAI Responses WebSocket closed before completion (code ${message.code})`);
@@ -438,7 +443,8 @@ export function createOpenAIResponsesWebSocketStream(params: {
         if (lease.entry) {
           lease.entry.continuation = undefined;
         }
-        if (!params.callerSignal?.aborted) {
+        const safeRetry = error instanceof OpenAIResponsesWebSocketSafeRetryError;
+        if (!params.callerSignal?.aborted && !safeRetry) {
           markDegraded();
         }
         if (!requestDispatched && !params.signal?.aborted) {
@@ -447,7 +453,8 @@ export function createOpenAIResponsesWebSocketStream(params: {
         if (
           !requestDispatched ||
           params.callerSignal?.aborted ||
-          error instanceof OpenAIResponsesWebSocketResponseFailedError
+          error instanceof OpenAIResponsesWebSocketResponseFailedError ||
+          safeRetry
         ) {
           throw error;
         }


### PR DESCRIPTION
Closes #122717
Related: #122483
Related: #122542

## What Problem This Solves

Fixes an issue where direct OpenAI API-key users on an explicit Responses WebSocket mode would receive a terminal agent error when the provider rejected a stale or unavailable `previous_response_id`, even though the provider explicitly reported that generation had not started and a full-history retry was safe.

The same flattening also hid `websocket_connection_limit_reached`, so an expired provider connection could fail the turn instead of recovering through the existing SSE fallback.

## Why This Change Was Made

OpenAI SDK 6.49.0 declares a flat `ResponseErrorEvent`, but the live Responses WebSocket service currently sends a wrapped frame with nested `error.code` and HTTP `status`. The SDK type-casts that frame without runtime normalization, leaving the structured JSON in `WebSocketError.message`. OpenClaw previously discarded it and projected every post-send failure as unknown-outcome ambiguity.

This repair normalizes both documented and observed SDK shapes, preserves code/status/param, and allowlists only `previous_response_not_found` and `websocket_connection_limit_reached` as safe retries. Those codes close the rejected socket without poisoning the cooldown, rebuild the canonical full-history request, and continue the same user turn over SSE. Every other post-dispatch failure remains replay-unsafe and fails closed.

The nearby provider documentation now matches the shipped product: direct API-key Responses defaults to SSE; `auto` and `websocket-cached` reuse a session socket; transient `websocket` and cached modes retain pre-dispatch SSE fallback; there is no automatic reconnect/retry before dispatch.

Production LOC: +85/-6 (net +79) | Tests: +153/-4 (net +149) | Docs: +24/-17 (net +7)

## User Impact

An OpenAI WebSocket session can recover transparently when its prior response state is gone or the provider's 60-minute connection limit is reached. The current user turn completes from full history instead of returning an ambiguity error, and later turns start with a fresh WebSocket state.

Direct API-key defaults do not change: SSE remains the default. This does not ship preconnect or `generate:false` prewarm; the closed experiment in #122542 remains rejected by latency evidence.

## Evidence

### Regression and focused proof

- Pre-fix boundary regression: both official safe-code cases failed with `stopReason: "error"` because the wrapped error was flattened into post-dispatch ambiguity.
- `node scripts/run-vitest.mjs packages/ai/src/transports/openai-responses-websocket.test.ts packages/ai/src/transports/openai-responses-websocket-client.test.ts packages/ai/src/transports/openai-responses-client.continuation.test.ts packages/ai/src/transports/openai-responses-continuation.test.ts`
- Result: 4 files, 46 tests passed.
- Targeted `oxfmt` and `oxlint`: clean.
- `git diff --check`: clean.
- `pnpm docs:list`: clean.

### Authenticated live OpenAI proof

A direct product-path call on this head deliberately injected a nonexistent response ID into the finalized first payload. The live service returned its current wrapped HTTP 400 `previous_response_not_found` frame. The same OpenClaw stream call then:

- rebuilt the payload through `buildRequest("full-history")`;
- sent no rejected `previous_response_id` on the SSE retry;
- emitted the typed `continuation-rejected` prompt observation;
- completed over SSE with `stopReason=stop` and exactly `OK`;
- emitted zero warnings.

Observed result:

```json
{
  "stopReason": "stop",
  "text": "OK",
  "payloadBuilds": 2,
  "safeFallbackObserved": true,
  "completedOverSse": true,
  "warningCount": 0
}
```

A separate raw protocol probe confirmed the service's exact wrapped shape and that a subsequent full request on a fresh connection succeeds.

### Dependency and sibling contract

Personally inspected current sibling Codex at `91d6f48992ad`:

- `codex-rs/codex-api/src/endpoint/responses_websocket.rs:158-162` defines the two safe codes.
- `responses_websocket.rs:582-648` parses the wrapped error frame and maps those codes to retryable outcomes.
- `responses_websocket.rs:718-725` performs that mapping before ordinary Responses event decoding.
- `codex-rs/core/src/client.rs:1663-1750` owns continuation request and failed-connection replacement.

Also inspected OpenAI SDK 6.49.0:

- `resources/responses/internal-base.ts:24-34` stores a typed `ResponseErrorEvent` on `WebSocketError`.
- `resources/responses/ws-base.ts:341-378` JSON-parses and type-casts without runtime validation.
- The generated `ResponseErrorEvent` type documents a flat shape, while the live service returned the nested wrapper captured above.

### Review

Codex autoreview (`gpt-5.6-sol`, high): TruffleHog clean; no accepted/actionable findings; patch correctness 0.97.

Provenance: clear. The generic error flattening and ambiguity classification were introduced in `f09a33ce4124` by Peter Steinberger in #121687. The current repair is also maintainer-authored.

AI-assisted: yes. The implementation, dependency review, focused tests, live provider proof, and final diff were reviewed by the maintainer.
