### PR TITLE
fix(acp): consult subagents.acpModel when runtime === "acp"

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -438,7 +438,12 @@ function resolveFirstModelFallbacksOverride(
   return undefined;
 }
 
-export type SubagentModelConfigSelectionSource = "subagent" | "agent" | "default-subagent";
+export type SubagentModelConfigSelectionSource =
+  | "subagent"
+  | "default-subagent"
+  | "acp-runtime"
+  | "default-acp"
+  | "agent";
 
 export type SubagentModelConfigSelectionResult = {
   raw: AgentModelConfig;
@@ -449,13 +454,33 @@ export function resolveSubagentModelConfigSelectionResult(params: {
   cfg: OpenClawConfig;
   agentId?: string;
   agentConfigOverride?: Pick<AgentConfig, "model" | "subagents">;
+  /**
+   * Spawn runtime discriminator. When "acp", the resolver prefers per-agent and
+   * default `subagents.acpModel` over `subagents.model`, so harness-correct vendor
+   * refs (e.g. openai/* for Codex ACP) can be set independently of the global
+   * subagent default. Undefined or "subagent" preserves the prior chain.
+   */
+  runtime?: "acp" | "subagent";
 }): SubagentModelConfigSelectionResult | undefined {
   const agentConfig =
     params.agentConfigOverride ??
     (params.agentId ? resolveAgentConfig(params.cfg, params.agentId) : undefined);
   // Keep cron and fallback routing aligned with native spawn: per-agent subagent,
-  // then the global subagent default, then agent-primary inheritance.
+  // then the global subagent default, then agent-primary inheritance. For ACP
+  // runtime the ACP-specific fields are checked first so a vendor-correct ref wins
+  // without affecting non-ACP defaults.
   const candidates: SubagentModelConfigSelectionResult[] = [
+    ...(params.runtime === "acp" && agentConfig?.subagents?.acpModel
+      ? [{ raw: agentConfig.subagents.acpModel, source: "acp-runtime" as const }]
+      : []),
+    ...(params.runtime === "acp" && params.cfg.agents?.defaults?.subagents?.acpModel
+      ? [
+          {
+            raw: params.cfg.agents.defaults.subagents.acpModel,
+            source: "default-acp" as const,
+          },
+        ]
+      : []),
     ...(agentConfig?.subagents?.model
       ? [{ raw: agentConfig.subagents.model, source: "subagent" as const }]
       : []),

--- a/src/agents/model-selection-config.test.ts
+++ b/src/agents/model-selection-config.test.ts
@@ -1,0 +1,125 @@
+// Tests the ACP-aware branch added to the subagent model configured-model
+// resolver. Covers #122708 — runtime === "acp" should consult per-agent and
+// default `subagents.acpModel` ahead of `subagents.model` so a harness-correct
+// vendor ref (e.g. openai/* for Codex ACP) is selected independently of the
+// outer subagent default.
+import { describe, expect, it } from "vitest";
+import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
+import type { AgentConfig } from "../config/types.agents.js";
+import type { OpenClawConfig } from "../config/types.js";
+import { resolveSubagentConfiguredModelSelection } from "./model-selection-config.js";
+
+function cfgWith(
+  agent: AgentConfig | undefined,
+  defaultsSubagents: AgentDefaultsConfig["subagents"] | undefined,
+): OpenClawConfig {
+  return {
+    agents: {
+      defaults: defaultsSubagents !== undefined ? { subagents: defaultsSubagents } : {},
+      list: agent ? [agent] : [],
+    },
+  } as unknown as OpenClawConfig;
+}
+
+describe("resolveSubagentConfiguredModelSelection — ACP runtime discriminator (#122708)", () => {
+  it("no runtime falls through to subagents.model (no regression)", () => {
+    const cfg = cfgWith(undefined, { model: "openrouter/minimax/minimax-m3" });
+    expect(resolveSubagentConfiguredModelSelection({ cfg, agentId: "research" })).toBe(
+      "openrouter/minimax/minimax-m3",
+    );
+  });
+
+  it("runtime=acp consults per-agent subagents.acpModel first", () => {
+    const cfg = cfgWith(
+      {
+        id: "research",
+        subagents: {
+          acpModel: "openai/gpt-5.4",
+          model: "openrouter/minimax/minimax-m3",
+        },
+      },
+      { model: "openrouter/minimax/minimax-m3" },
+    );
+    expect(
+      resolveSubagentConfiguredModelSelection({ cfg, agentId: "research", runtime: "acp" }),
+    ).toBe("openai/gpt-5.4");
+  });
+
+  it("runtime=acp with no per-agent acpModel falls back to default subagents.acpModel", () => {
+    const cfg = cfgWith(
+      {
+        id: "research",
+        model: "anthropic/claude-sonnet-4.5",
+        subagents: { model: "openrouter/minimax/minimax-m3" },
+      },
+      { acpModel: "openai/gpt-5.4" },
+    );
+    expect(
+      resolveSubagentConfiguredModelSelection({ cfg, agentId: "research", runtime: "acp" }),
+    ).toBe("openai/gpt-5.4");
+  });
+
+  it("runtime=acp with no acpModel anywhere falls through to subagents.model", () => {
+    const cfg = cfgWith(
+      {
+        id: "research",
+        subagents: { model: "openrouter/minimax/minimax-m3" },
+      },
+      { model: "openrouter/minimax/minimax-m3" },
+    );
+    expect(
+      resolveSubagentConfiguredModelSelection({ cfg, agentId: "research", runtime: "acp" }),
+    ).toBe("openrouter/minimax/minimax-m3");
+  });
+
+  it("runtime=acp with no acpModel or subagents.model falls through to agent primary", () => {
+    const cfg = cfgWith({ id: "research", model: "anthropic/claude-sonnet-4.5" }, undefined);
+    expect(
+      resolveSubagentConfiguredModelSelection({ cfg, agentId: "research", runtime: "acp" }),
+    ).toBe("anthropic/claude-sonnet-4.5");
+  });
+
+  it("per-agent acpModel beats default acpModel when runtime=acp", () => {
+    const cfg = cfgWith(
+      { id: "research", subagents: { acpModel: "openai/gpt-5.4" } },
+      { acpModel: "anthropic/claude-sonnet-4.5" },
+    );
+    expect(
+      resolveSubagentConfiguredModelSelection({ cfg, agentId: "research", runtime: "acp" }),
+    ).toBe("openai/gpt-5.4");
+  });
+
+  it("includeAgentPrimary=false keeps the runtime=acp ACP selection even when agent primary is set", () => {
+    const cfg = cfgWith(
+      {
+        id: "research",
+        model: "openrouter/minimax/minimax-m3",
+        subagents: { acpModel: "openai/gpt-5.4" },
+      },
+      undefined,
+    );
+    expect(
+      resolveSubagentConfiguredModelSelection({
+        cfg,
+        agentId: "research",
+        runtime: "acp",
+        includeAgentPrimary: false,
+      }),
+    ).toBe("openai/gpt-5.4");
+  });
+
+  it("object-shape acpModel returns the primary string (mirrors subagents.model behavior)", () => {
+    const cfg = cfgWith(
+      {
+        id: "research",
+        subagents: {
+          acpModel: { primary: "openai/gpt-5.4", fallbacks: ["openai/gpt-5.5"] },
+        },
+      },
+      undefined,
+    );
+    expect(
+      resolveSubagentConfiguredModelSelection({ cfg, agentId: "research", runtime: "acp" }),
+    ).toBe("openai/gpt-5.4");
+  });
+});

--- a/src/agents/model-selection-config.ts
+++ b/src/agents/model-selection-config.ts
@@ -45,9 +45,21 @@ export function resolveSubagentConfiguredModelSelection(params: {
   cfg: OpenClawConfig;
   agentId: string;
   includeAgentPrimary?: boolean;
+  /**
+   * Spawn runtime discriminator. When "acp", consult per-agent and default
+   * `subagents.acpModel` ahead of `subagents.model` so a harness-correct vendor
+   * ref (e.g. openai/* for Codex ACP) can be set independently. Undefined or
+   * "subagent" preserves the prior chain.
+   */
+  runtime?: "acp" | "subagent";
 }): string | undefined {
   const agentConfig = resolveAgentConfig(params.cfg, params.agentId);
+  const acpPreferred = params.runtime === "acp";
   return (
+    (acpPreferred ? normalizeModelSelection(agentConfig?.subagents?.acpModel) : undefined) ??
+    (acpPreferred
+      ? normalizeModelSelection(params.cfg.agents?.defaults?.subagents?.acpModel)
+      : undefined) ??
     normalizeModelSelection(agentConfig?.subagents?.model) ??
     normalizeModelSelection(params.cfg.agents?.defaults?.subagents?.model) ??
     (params.includeAgentPrimary === false ? undefined : normalizeModelSelection(agentConfig?.model))

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -320,6 +320,12 @@ export function resolveConfiguredSubagentSpawnModelSelection(params: {
   modelOverride?: unknown;
   defaultProvider?: string;
   includeAgentPrimary?: boolean;
+  /**
+   * Spawn runtime discriminator forwarded to the configured-model resolver.
+   * When "acp", per-agent and default `subagents.acpModel` are consulted ahead
+   * of `subagents.model`. Undefined or "subagent" preserves the prior chain.
+   */
+  runtime?: "acp" | "subagent";
 }): string | undefined {
   const raw =
     normalizeModelSelection(params.modelOverride) ??
@@ -327,6 +333,7 @@ export function resolveConfiguredSubagentSpawnModelSelection(params: {
       cfg: params.cfg,
       agentId: params.agentId,
       includeAgentPrimary: params.includeAgentPrimary,
+      runtime: params.runtime,
     });
   if (!raw) {
     return undefined;

--- a/src/agents/subagents/spawn/acp-spawn-runtime.ts
+++ b/src/agents/subagents/spawn/acp-spawn-runtime.ts
@@ -102,6 +102,11 @@ export function resolveAcpSpawnRuntimeOptions(params: {
     cfg: params.cfg,
     agentId: policyAgentId,
     modelOverride: params.model,
+    // Pass runtime so the resolver consults per-agent and default
+    // subagents.acpModel ahead of subagents.model. Without this, ACP harness
+    // spawns inherit the outer subagents.model (often an openrouter/* ref
+    // that the harness rejects as the wrong shape). See issue #122708.
+    runtime: "acp",
   });
   const targetAgentConfig = resolveAgentConfig(params.cfg, policyAgentId);
   const thinkingPlan = resolveSubagentThinkingOverride({

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -342,6 +342,13 @@ export type AgentDefaultsConfig = {
     archiveAfterMinutes?: number;
     /** Default model selection for spawned sub-agents (string or {primary,fallbacks}). */
     model?: AgentModelConfig;
+    /**
+     * Default model for ACP harness spawns (sessions_spawn with runtime: "acp", no explicit model).
+     * Codex/Claude/... ACP harnesses reject openrouter/* refs as the wrong shape; use this to set a
+     * harness-correct vendor ref (e.g. openai/<model>) without affecting non-ACP defaults.
+     * Falls back to `model` when unset.
+     */
+    acpModel?: AgentModelConfig;
     /** Default thinking level for spawned sub-agents (e.g. "off", "low", "medium", "high"). */
     thinking?: string;
     /** Default run timeout in seconds for spawned sub-agents (0 = no timeout). */

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -149,6 +149,11 @@ export type AgentConfig = {
     allowAgents?: string[];
     /** Per-agent default model for spawned sub-agents (string or {primary,fallbacks}). */
     model?: AgentModelConfig;
+    /**
+     * Per-agent default model for ACP harness spawns (runtime: "acp", no explicit model).
+     * Overrides agents.defaults.subagents.acpModel. See that field for vendor-prefix guidance.
+     */
+    acpModel?: AgentModelConfig;
     /** Per-agent default thinking level for spawned sub-agents. */
     thinking?: string;
     /** Require explicit agentId in sessions_spawn (no default same-as-caller). */


### PR DESCRIPTION
## What Problem This Solves

When `sessions_spawn` is called with `runtime: "acp"` and no explicit `model`, the dispatched ACP harness (Codex, Claude, etc.) inherits `agents.defaults.subagents.model` from the caller. With a typical outer default like `openrouter/<some-model>`, the Codex ACP harness aborts the turn before producing any response because the documented Codex model format is `openai/<model>` or `<model>/<reasoning-effort>`, and the documented Claude ACP format is `anthropic/<model>`.

There is currently no way to set a harness-correct default for ACP spawns that does not also become the wrong-shape default for non-ACP spawns. Operators running the typical `openrouter/*` outer default and an ACP harness either pass `model: "openai/<model>"` explicitly per call or hit the harness rejection.

## Why

Codex/Claude ACP spawns that want to omit the `model` parameter (the common case, since harness-correct refs are harness-specific) cannot do so without overriding every call. The acpx dispatch chain is healthy, but every default-model Codex or Claude ACP call fails at the harness boundary before the runtime can hand off to the acpx transport, making the feature feel broken even though it isn't.

This is a behavior defect (caller's intent — "use whatever default you have for this harness" — fails silently), so it's filed as a bug per the contribution guide rather than a feature request.

## What

This PR adds an opt-in `acpModel` field on the global and per-agent subagents surface (same shape as `subagents.model`: string or `{primary, fallbacks[]}`). When the ACP call site resolves a model, it now passes `runtime: "acp"` so the configured-model resolver prefers per-agent and default `acpModel` over the outer `subagents.model`. Non-ACP call sites pass no `runtime` and the prior chain is unchanged.

Five files touched, smallest additive change:

- `src/config/types.agent-defaults.ts` — optional `acpModel` on `agents.defaults.subagents`
- `src/config/types.agents.ts` — optional `acpModel` on `agents.entries.*.subagents`
- `src/agents/agent-scope.ts` — two new candidate sources (`acp-runtime`, `default-acp`) when `runtime === "acp"`
- `src/agents/model-selection-config.ts` + `src/agents/model-selection.ts` — thread `runtime` through to the configured-model resolver
- `src/agents/subagents/spawn/acp-spawn-runtime.ts` — pass `runtime: "acp"` from the ACP dispatch call site

## Compatibility

- Backwards compatible. `acpModel` is optional; existing repos that don't set it resolve exactly as before.
- Defaults unchanged. `subagents.model` remains the default for both ACP and non-ACP spawns.
- Non-ACP `sessions_spawn` call sites (cron, native, CLI, fallbacks path) pass no `runtime` and resolve identically. Verified by 8-case test lane including the no-regression case.
- Object-shape `{primary, fallbacks}` parity: `acpModel` accepts the same shape as `subagents.model`. Test asserts the primary is selected.

## Acceptance

- `sessions_spawn({ runtime: "acp", agentId: "codex" })` with no explicit `model` resolves to `agents.defaults.subagents.acpModel` (or per-agent override).
- Codex ACP accepts the resolved ref (no `openrouter/*` rejection).
- Non-ACP `sessions_spawn` continues to resolve to `subagents.model` (no regression).
- A new test lane (8 cases) asserts the ACP branch and the no-regression branch.

## Verified Against

- Commit `70842228` (current main). Branch: `fix/acp-runtime-model-default` in `DarojaAI/openclaw`.
- Targeted vitest lane `src/agents/model-selection-config.test.ts`: 8/8 pass.

## Prior Art (distinct surface, same root-cause class)

- openclaw/openclaw#118642 (Codex harness rejecting an OpenRouter default, merged via #118658). That report covers catalog-imported locked Codex sessions; this PR covers bare `sessions_spawn({ runtime: "acp" })` with no explicit `model` and no catalog. Different code path, same symptom class. ClawSweeper flagged "duplicate fix job is unsafe" on #118642; the surfaces are distinct and the fix shapes are related.
- openclaw/openclaw#58822, #19460, #34065, #51545 — all closed `subagents.model` precedence/override bugs. Distinct surface (default-shadowing vs. harness-prefix shape), not a duplicate.

## Scope of this proposal

**Not included in this PR:**

- AppArmor profile author + install (separate concern).
- `mode: null` strip in merge configuration (separate concern).
- A ClawHub plugin that exposes `acpModel` at the harness level. Could be a follow-on if maintainers prefer the plugin path over core; this PR ships the runtime consumer of the contract, with the schema surface available whether or not a ClawHub variant ever lands.
- Schema migration of any existing `subagents.model` into `acpModel`. No evidence any repo user has done this; no action needed.
- `acpModel` enforcement at the harness boundary (rejecting `openrouter/*` when ACP). The current PR trusts the operator's config; a separate validation pass could be a follow-on if maintainers want it.

## Related

- Issue #122708 (this PR closes)
- Docs: https://docs.openclaw.ai/concepts/model-failover (selection source policy and `subagents.model` semantics; no existing `acpModel` surface)
- Docs: https://docs.openclaw.ai/concepts/models (selection order and `agents.defaults.model` chain)
- Downstream consumer: DarojaAI/linux-desktop-seed#1252 (the Linux-side gating that catches the symptom loudly until this lands)
- Downstream config infrastructure: DarojaAI/linux-desktop-seed#1250 (the schema/config layer that ships `acpModel` defaults for downstream callers)
- Upstream prior art: #118642 / #118658 (catalog-imported locked Codex sessions, merged)

Allow edits by maintainers: enabled (per contribution guide, so maintainers can land follow-up fixes, changelog entries, or merge prep in-flight).