### PR TITLE
docs: document built-in env default SecretRef alias

### DIFF
--- a/docs/cli/secrets.md
+++ b/docs/cli/secrets.md
@@ -178,7 +178,9 @@ openclaw secrets configure --agent ops
 openclaw secrets configure --json
 ```
 
-Flow: provider setup first (add/edit/remove `secrets.providers` aliases), then credential mapping (select fields, assign `{source, provider, id}` refs), then preflight and optional apply. Refs whose `provider` matches the effective default for their source — the built-in `default` alias, or a configured `secrets.defaults.env` / `secrets.defaults.store` override — need no `secrets.providers` entry. Registration is only required for custom aliases and for `file`/`exec` sources.
+Flow: provider setup first (add/edit/remove `secrets.providers` aliases), then credential mapping (select fields, assign `{source, provider, id}` refs), then preflight and optional apply.
+
+For `env` and `store` refs, no provider entry is required when `provider` matches that source's effective default: `secrets.defaults.env` or `secrets.defaults.store`, falling back to `default` when unset. Other aliases and all `file`/`exec` refs require a matching `secrets.providers` entry.
 
 Flags:
 

--- a/docs/cli/secrets.md
+++ b/docs/cli/secrets.md
@@ -178,7 +178,7 @@ openclaw secrets configure --agent ops
 openclaw secrets configure --json
 ```
 
-Flow: provider setup first (add/edit/remove `secrets.providers` aliases), then credential mapping (select fields, assign `{source, provider, id}` refs), then preflight and optional apply.
+Flow: provider setup first (add/edit/remove `secrets.providers` aliases), then credential mapping (select fields, assign `{source, provider, id}` refs), then preflight and optional apply. The built-in `env` provider alias `default` needs no `secrets.providers` entry — registration is only required for custom aliases and for `file`/`exec`/`store` sources.
 
 Flags:
 

--- a/docs/cli/secrets.md
+++ b/docs/cli/secrets.md
@@ -178,7 +178,7 @@ openclaw secrets configure --agent ops
 openclaw secrets configure --json
 ```
 
-Flow: provider setup first (add/edit/remove `secrets.providers` aliases), then credential mapping (select fields, assign `{source, provider, id}` refs), then preflight and optional apply. The built-in `env` provider alias `default` needs no `secrets.providers` entry — registration is only required for custom aliases and for `file`/`exec`/`store` sources.
+Flow: provider setup first (add/edit/remove `secrets.providers` aliases), then credential mapping (select fields, assign `{source, provider, id}` refs), then preflight and optional apply. Refs whose `provider` matches the effective default for their source — the built-in `default` alias, or a configured `secrets.defaults.env` / `secrets.defaults.store` override — need no `secrets.providers` entry. Registration is only required for custom aliases and for `file`/`exec` sources.
 
 Flags:
 

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -718,7 +718,7 @@ Rules:
 }
 ```
 
-SecretRef details (including `secrets.providers` for `env`/`file`/`exec`/`store`) are in [Secrets Management](/gateway/secrets). The `provider: "default"` alias used above is the built-in default for `env` (and `store`) refs and does not need a `secrets.providers.default` entry; see [Secrets Management](/gateway/secrets) for when a custom alias is required.
+The `env` ref above uses the built-in `default` provider and needs no `secrets.providers.default` entry unless `secrets.defaults.env` selects another alias. The same rule applies to `store` refs and `secrets.defaults.store`. See [Secrets Management](/gateway/secrets#secretref-contract) for provider precedence and the required `file`/`exec` provider configuration.
 Supported credential paths are listed in [SecretRef Credential Surface](/reference/secretref-credential-surface).
 </Accordion>
 

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -718,7 +718,7 @@ Rules:
 }
 ```
 
-SecretRef details (including `secrets.providers` for `env`/`file`/`exec`/`store`) are in [Secrets Management](/gateway/secrets). The `provider: "default"` alias used above is a built-in env alias and does not need a `secrets.providers.default` entry; see [Secrets Management](/gateway/secrets) for when a custom alias is required.
+SecretRef details (including `secrets.providers` for `env`/`file`/`exec`/`store`) are in [Secrets Management](/gateway/secrets). The `provider: "default"` alias used above is the built-in default for `env` (and `store`) refs and does not need a `secrets.providers.default` entry; see [Secrets Management](/gateway/secrets) for when a custom alias is required.
 Supported credential paths are listed in [SecretRef Credential Surface](/reference/secretref-credential-surface).
 </Accordion>
 

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -718,7 +718,7 @@ Rules:
 }
 ```
 
-SecretRef details (including `secrets.providers` for `env`/`file`/`exec`/`store`) are in [Secrets Management](/gateway/secrets).
+SecretRef details (including `secrets.providers` for `env`/`file`/`exec`/`store`) are in [Secrets Management](/gateway/secrets). The `provider: "default"` alias used above is a built-in env alias and does not need a `secrets.providers.default` entry; see [Secrets Management](/gateway/secrets) for when a custom alias is required.
 Supported credential paths are listed in [SecretRef Credential Surface](/reference/secretref-credential-surface).
 </Accordion>
 

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -113,7 +113,7 @@ One object shape everywhere:
 { source: "env" | "file" | "exec" | "store", provider: "default", id: "..." }
 ```
 
-Each source has an effective default provider alias: `secrets.defaults.env` for env refs and `secrets.defaults.store` for store refs, falling back to the built-in `default` alias when unset. A ref whose `provider` equals that source's effective default is implicit — it resolves through the built-in reader with no `secrets.providers` entry required. A ref that names any other alias (including an explicit `default` when the default has been overridden to a different alias) must match a registered `secrets.providers` entry with the same `source`, or resolution fails.
+Each source has an effective default provider alias: `secrets.defaults.env` for env refs and `secrets.defaults.store` for store refs, falling back to the built-in `default` alias when unset. A ref whose `provider` equals that source's effective default is implicit: a matching same-source `secrets.providers` entry takes precedence when one exists, and otherwise the ref resolves through the built-in reader with no entry required. A ref that names any other alias (including an explicit `default` when the default has been overridden to a different alias) must match a registered `secrets.providers` entry with the same `source`, or resolution fails.
 
 <Tabs>
   <Tab title="env">

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -113,7 +113,9 @@ One object shape everywhere:
 { source: "env" | "file" | "exec" | "store", provider: "default", id: "..." }
 ```
 
-Each source has an effective default provider alias: `secrets.defaults.env` for env refs and `secrets.defaults.store` for store refs, falling back to the built-in `default` alias when unset. A ref whose `provider` equals that source's effective default is implicit: a matching same-source `secrets.providers` entry takes precedence when one exists, and otherwise the ref resolves through the built-in reader with no entry required. A ref that names any other alias (including an explicit `default` when the default has been overridden to a different alias) must match a registered `secrets.providers` entry with the same `source`, or resolution fails.
+`env` and `store` refs have an implicit provider at their source's effective default alias: `secrets.defaults.env` or `secrets.defaults.store`, falling back to `default` when unset. A matching same-source `secrets.providers` entry takes precedence; otherwise, the ref uses the built-in reader without a provider entry.
+
+Other aliases and all `file`/`exec` refs require a registered `secrets.providers` entry with the same `source`. Changing a source's default does not rewrite explicit refs: a ref that still names `default` after an override must match a registered same-source provider, or resolution fails.
 
 <Tabs>
   <Tab title="env">

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -113,6 +113,8 @@ One object shape everywhere:
 { source: "env" | "file" | "exec" | "store", provider: "default", id: "..." }
 ```
 
+`provider: "default"` is a built-in alias: for `env` refs it resolves through the built-in env reader with no `secrets.providers.default` entry required. If you set `secrets.defaults.env` to a different alias, that alias becomes the effective env default instead. Any other provider alias must be registered under `secrets.providers` with a matching `source`, or resolution fails.
+
 <Tabs>
   <Tab title="env">
     ```json5

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -113,7 +113,7 @@ One object shape everywhere:
 { source: "env" | "file" | "exec" | "store", provider: "default", id: "..." }
 ```
 
-`provider: "default"` is a built-in alias: for `env` refs it resolves through the built-in env reader with no `secrets.providers.default` entry required. If you set `secrets.defaults.env` to a different alias, that alias becomes the effective env default instead. Any other provider alias must be registered under `secrets.providers` with a matching `source`, or resolution fails.
+Each source has an effective default provider alias: `secrets.defaults.env` for env refs and `secrets.defaults.store` for store refs, falling back to the built-in `default` alias when unset. A ref whose `provider` equals that source's effective default is implicit — it resolves through the built-in reader with no `secrets.providers` entry required. A ref that names any other alias (including an explicit `default` when the default has been overridden to a different alias) must match a registered `secrets.providers` entry with the same `source`, or resolution fails.
 
 <Tabs>
   <Tab title="env">


### PR DESCRIPTION
## What Problem This Solves

The SecretRef examples use `provider: "default"` without explaining when that provider can be omitted from `secrets.providers`. Readers cannot tell whether the example is complete, and wording that applies implicit providers to every source would incorrectly include `file` and `exec`.

## Why This Change Was Made

Explain the existing rule in the contract, CLI flow, and configuration example: `env` and `store` can use their effective default provider implicitly; same-source explicit configuration takes precedence. Other aliases and all `file`/`exec` refs require a registered provider. Explicit refs keep their alias when a source default changes.

## User Impact

Operators can follow the examples without unnecessary provider registration and know when registration is required. This changes documentation only, with no new configuration, environment, persistence, or authentication behavior. Thanks @191612731-cloud for the clarification.

## Evidence

- Read the owning `src/secrets/ref-contract.ts` and `src/secrets/resolve.ts`, their existing resolver coverage, and the three affected guides. The built-in reader rule is explicitly limited to `env` and `store`.
- Trusted current-main proof: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/secrets/resolve.test.ts src/secrets/resolve-store.test.ts src/secrets/ref-contract.test.ts` passed all 51 cases across three files. This includes implicit defaults, source-specific aliases, explicit-provider precedence, and mismatches. A first attempt with shared dependencies failed build preparation; a separate frozen install resolved that tooling mismatch. The successful wrapper exited normally after artifact cleanup.
- Trusted main tooling checked the final Markdown as data: docs listing, MDX compilation, canonical formatter, internal links (6,457 checked; zero broken), and whitespace passed.
- Full candidate Codex autoreview passed with no accepted P0 findings. Production/test LOC: zero; docs: +7/-1.
- The latest ClawSweeper wording finding is addressed by explicitly naming `env` and `store` and preserving the `file`/`exec` registration requirement.

Public documentation: [SecretRef contract](https://docs.openclaw.ai/gateway/secrets#secretref-contract), [Secrets CLI](https://docs.openclaw.ai/cli/secrets), and [Configuration](https://docs.openclaw.ai/gateway/configuration).
