### PR TITLE
fix: make Codex onboarding survive inherited Node loader paths

### DIFF
--- a/extensions/codex/src/app-server/runtime-artifact.test.ts
+++ b/extensions/codex/src/app-server/runtime-artifact.test.ts
@@ -75,6 +75,20 @@ describe("Codex app-server runtime artifact", () => {
     });
   });
 
+  it("attests the sanitized environment when the host injects a runtime loader path", async () => {
+    await withTempDir("openclaw-codex-runtime-sanitized-env-", async (root) => {
+      const command = path.join(root, "codex");
+      await fs.writeFile(command, "native-v1");
+      const options = startOptions(command, {
+        env: { NODE_PATH: "/ambient/node_modules", LD_PRELOAD: "/ambient/inject.so" },
+      });
+
+      await expect(captureBinding({ options })).resolves.toMatchObject({
+        binding: { id: expect.stringMatching(/^codex-app-server:v1:/u) },
+      });
+    });
+  });
+
   it.runIf(process.platform !== "win32")(
     "resolves relative launch paths and shebang targets from the spawn cwd",
     async () => {

--- a/extensions/codex/src/app-server/runtime-artifact.ts
+++ b/extensions/codex/src/app-server/runtime-artifact.ts
@@ -23,17 +23,6 @@ const MAX_ARTIFACT_FILES = 8192;
 const MAX_ARTIFACT_TOTAL_BYTES = 1024n * 1024n * 1024n;
 const READ_CHUNK_BYTES = 64 * 1024;
 const CODE_MODE_HOST_PATH_ENV = "CODEX_CODE_MODE_HOST_PATH";
-const RUNTIME_INJECTION_ENV_KEYS = new Set([
-  "NODE_PATH",
-  "LD_AUDIT",
-  "LD_LIBRARY_PATH",
-  "LD_PRELOAD",
-  "DYLD_FALLBACK_FRAMEWORK_PATH",
-  "DYLD_FALLBACK_LIBRARY_PATH",
-  "DYLD_FRAMEWORK_PATH",
-  "DYLD_INSERT_LIBRARIES",
-  "DYLD_LIBRARY_PATH",
-]);
 const SAFE_NODE_OPTIONS_BOOLEAN_FLAGS = new Set([
   "--enable-network-family-autoselection",
   "--network-family-autoselection",
@@ -242,29 +231,20 @@ function pathIsWithin(rootPath: string, candidatePath: string): boolean {
   );
 }
 
-function assertNoRuntimeInjectionEnvironment(env: NodeJS.ProcessEnv): void {
+function assertSafeNodeOptions(env: NodeJS.ProcessEnv): void {
   for (const [rawKey, value] of Object.entries(env)) {
     const key = rawKey.toUpperCase();
-    if (!value?.trim()) {
+    if (key !== "NODE_OPTIONS" || !value?.trim()) {
       continue;
     }
-    if (key === "NODE_OPTIONS") {
-      const result = attestNodeOptions(value);
-      if (result.ok) {
-        continue;
-      }
-      if (result.option) {
-        throw new Error(
-          `Codex runtime artifact cannot attest NODE_OPTIONS option ${result.option}`,
-        );
-      }
-      throw new Error("Codex runtime artifact cannot safely parse NODE_OPTIONS");
+    const result = attestNodeOptions(value);
+    if (result.ok) {
+      continue;
     }
-    if (RUNTIME_INJECTION_ENV_KEYS.has(key) || key.startsWith("DYLD_")) {
-      // These variables can load code outside the selected launcher/package.
-      // Exact setup attestation must fail instead of minting a partial identity.
-      throw new Error(`Codex runtime artifact cannot attest injected runtime environment: ${key}`);
+    if (result.option) {
+      throw new Error(`Codex runtime artifact cannot attest NODE_OPTIONS option ${result.option}`);
     }
+    throw new Error("Codex runtime artifact cannot safely parse NODE_OPTIONS");
   }
 }
 
@@ -582,7 +562,7 @@ async function captureFilesystemDescriptor(params: {
     );
   }
   const env = resolveCodexAppServerSpawnEnv(params.startOptions);
-  assertNoRuntimeInjectionEnvironment(env);
+  assertSafeNodeOptions(env);
   // child_process resolves relative launchers and PATH entries after applying cwd.
   // Attestation must use the same base or it can bind bytes that spawn never executes.
   const spawnCwd = path.resolve(params.startOptions.cwd ?? process.cwd());

--- a/extensions/codex/src/app-server/transport-stdio.test.ts
+++ b/extensions/codex/src/app-server/transport-stdio.test.ts
@@ -79,6 +79,24 @@ describe("resolveCodexAppServerSpawnEnv", () => {
     });
   });
 
+  it("strips inherited runtime loader injection before spawn", () => {
+    expect({
+      ...resolveCodexAppServerSpawnEnv(
+        {
+          env: {
+            NODE_PATH: "/configured/node_modules",
+            DYLD_INSERT_LIBRARIES: "/configured/inject.dylib",
+          },
+        },
+        {
+          NODE_PATH: "/ambient/node_modules",
+          LD_PRELOAD: "/ambient/inject.so",
+          KEEP: "safe",
+        },
+      ),
+    }).toEqual({ KEEP: "safe" });
+  });
+
   it("uses a null-prototype env map and ignores prototype-polluting keys", () => {
     const overrides = Object.create(null) as Record<string, string | undefined>;
     Object.defineProperty(overrides, "__proto__", {

--- a/extensions/codex/src/app-server/transport-stdio.ts
+++ b/extensions/codex/src/app-server/transport-stdio.ts
@@ -11,6 +11,12 @@ import type { CodexAppServerStartOptions } from "./config.js";
 import type { CodexAppServerTransport } from "./transport.js";
 
 const UNSAFE_ENVIRONMENT_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+const RUNTIME_INJECTION_ENVIRONMENT_KEYS = new Set([
+  "NODE_PATH",
+  "LD_AUDIT",
+  "LD_LIBRARY_PATH",
+  "LD_PRELOAD",
+]);
 const QA_PARENT_PID_ENV = "OPENCLAW_QA_PARENT_PID";
 
 type CodexAppServerSpawnRuntime = {
@@ -71,7 +77,19 @@ export function resolveCodexAppServerSpawnEnv(
       delete env[key];
     }
   }
+  for (const key of Object.keys(env)) {
+    if (isCodexRuntimeInjectionEnvironmentKey(key)) {
+      // Package managers and agent hosts may inject loader paths into their children. Codex does
+      // not need them, so strip them before attestation and spawn instead of self-failing setup.
+      delete env[key];
+    }
+  }
   return env;
+}
+
+function isCodexRuntimeInjectionEnvironmentKey(rawKey: string): boolean {
+  const key = rawKey.toUpperCase();
+  return RUNTIME_INJECTION_ENVIRONMENT_KEYS.has(key) || key.startsWith("DYLD_");
 }
 
 /** Keeps QA-owned app-server processes inside the gateway process-group cleanup boundary. */

--- a/src/commands/onboard-guided-manual.ts
+++ b/src/commands/onboard-guided-manual.ts
@@ -14,7 +14,10 @@ import type { AuthChoiceGroup } from "./auth-choice-options.static.js";
 type ActivateSetupInference =
   typeof import("../system-agent/setup-inference.js").activateSetupInference;
 
-type LadderFailure = { label: string; status: SetupInferenceFailureStatus };
+export type SetupCandidateFailure = {
+  label: string;
+  result: Extract<ActivateSetupInferenceResult, { ok: false }>;
+};
 
 type CandidateAttempt =
   | { kind: "success"; result: Extract<ActivateSetupInferenceResult, { ok: true }> }
@@ -30,8 +33,16 @@ const SETUP_FAILURE_REASON_KEYS: Record<SetupInferenceFailureStatus, string> = {
   unknown: "wizard.guided.failureUnknown",
 };
 
-export function setupFailureReason(status: SetupInferenceFailureStatus): string {
+function setupFailureReason(status: SetupInferenceFailureStatus): string {
   return t(SETUP_FAILURE_REASON_KEYS[status]);
+}
+
+export function formatSetupCandidateFailure(failure: SetupCandidateFailure): string {
+  return t("wizard.guided.testFailure", {
+    label: failure.label,
+    reason: setupFailureReason(failure.result.status),
+    detail: failure.result.error,
+  });
 }
 
 async function noteActivationFailure(params: {
@@ -40,11 +51,7 @@ async function noteActivationFailure(params: {
   result: Extract<ActivateSetupInferenceResult, { ok: false }>;
 }): Promise<void> {
   await params.prompter.note(
-    t("wizard.guided.testFailure", {
-      label: params.label,
-      reason: setupFailureReason(params.result.status),
-      detail: params.result.error,
-    }),
+    formatSetupCandidateFailure({ label: params.label, result: params.result }),
     t("wizard.guided.aiAccessTitle"),
   );
 }
@@ -56,7 +63,7 @@ export async function tryCandidate(params: {
   prompter: WizardPrompter;
   activate: ActivateSetupInference;
   /** Auto-ladder failures collect into one quiet summary; manual retries stay loud. */
-  collectFailure?: (failure: LadderFailure) => void;
+  collectFailure?: (failure: SetupCandidateFailure) => void;
 }): Promise<CandidateAttempt> {
   const progress = params.prompter.progress(
     t("wizard.guided.testingCandidate", {
@@ -78,7 +85,7 @@ export async function tryCandidate(params: {
     return { kind: "success", result };
   }
   if (params.collectFailure) {
-    params.collectFailure({ label: params.candidate.label, status: result.status });
+    params.collectFailure({ label: params.candidate.label, result });
   } else {
     await noteActivationFailure({
       prompter: params.prompter,

--- a/src/commands/onboard-guided.test.ts
+++ b/src/commands/onboard-guided.test.ts
@@ -633,21 +633,29 @@ describe("runGuidedOnboarding", () => {
     expect(notes).toContain("Gateway: running");
   });
 
-  it("offers an auto-attempted transient failure for manual retry", async () => {
-    promptAuthChoiceGrouped.mockResolvedValueOnce("candidate:claude-cli");
+  it("surfaces an auto-attempted failure detail before offering manual retry", async () => {
+    promptAuthChoiceGrouped.mockResolvedValueOnce("candidate:codex-cli");
     const prompter = createWizardPrompter({
       confirm: vi.fn(async () => false),
     });
     const activate = vi
       .fn()
-      .mockResolvedValueOnce({ ok: false, status: "rate_limit", error: "try later" })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: "unknown",
+        error: "Codex runtime artifact cannot attest injected runtime environment: NODE_PATH",
+      })
       .mockResolvedValueOnce({
         ok: true,
-        modelRef: "claude-cli/opus",
+        modelRef: "openai/gpt-5.4",
         latencyMs: 700,
         lines: ["Gateway: running"],
       }) as GuidedOnboardingDeps["activate"];
-    const deps = setupDeps({ prompter, activate });
+    const deps = setupDeps({
+      prompter,
+      activate,
+      detect: vi.fn(async () => detection({ candidates: [candidate("codex-cli", "Codex")] })),
+    });
 
     await runGuidedOnboarding({ acceptRisk: true, workspace: "/tmp/work" }, makeRuntime(), deps);
 
@@ -658,8 +666,8 @@ describe("runGuidedOnboarding", () => {
           expect.objectContaining({
             options: [
               expect.objectContaining({
-                value: "candidate:claude-cli",
-                label: "Retry Claude Code (logged in)",
+                value: "candidate:codex-cli",
+                label: "Retry Codex (logged in)",
               }),
             ],
           }),
@@ -669,7 +677,9 @@ describe("runGuidedOnboarding", () => {
     expect(deps.launchHatchTui).toHaveBeenCalledWith("/tmp/work");
     const retryNotes = JSON.stringify((prompter.note as ReturnType<typeof vi.fn>).mock.calls);
     expect(retryNotes).toContain("These didn't work just now:");
-    expect(retryNotes).toContain("rate-limiting");
+    expect(retryNotes).toContain(
+      "Codex runtime artifact cannot attest injected runtime environment: NODE_PATH",
+    );
   });
 
   it("accepts and verifies a manual provider key without displaying it", async () => {

--- a/src/commands/onboard-guided.ts
+++ b/src/commands/onboard-guided.ts
@@ -10,7 +10,6 @@ import type { LocalOnboardingState } from "../state/local-onboarding-state.js";
 import type {
   SetupInferenceCandidate,
   SetupInferenceDetection,
-  SetupInferenceFailureStatus,
 } from "../system-agent/setup-inference.js";
 import { resolveUserPath, shortenHomePath } from "../utils.js";
 import { t } from "../wizard/i18n/index.js";
@@ -19,8 +18,9 @@ import { requireRiskAcknowledgement } from "../wizard/setup.shared.js";
 import type { runBrowserHatchHandoff } from "./onboard-browser-handoff.js";
 import {
   activationLines,
+  formatSetupCandidateFailure,
   runManualStage,
-  setupFailureReason,
+  type SetupCandidateFailure,
   tryCandidate,
 } from "./onboard-guided-manual.js";
 import {
@@ -65,8 +65,6 @@ export type GuidedOnboardingDeps = {
 export type GuidedAccessMode = "full" | "guarded";
 
 type GuidedOnboardingHandoff = { workspace: string; next: "browser" | "hatch" | "chat" };
-
-type LadderFailure = { label: string; status: SetupInferenceFailureStatus };
 
 async function openSystemAgentChat(
   deps: GuidedOnboardingDeps,
@@ -259,7 +257,7 @@ async function runGuidedOnboardingFlow(
   const detect =
     deps.detect ?? (await import("../system-agent/setup-inference.js")).detectSetupInference;
   const autoAttemptedKinds = new Set<SetupInferenceCandidate["kind"]>();
-  const ladderFailures: LadderFailure[] = [];
+  const ladderFailures: SetupCandidateFailure[] = [];
   let detection: SetupInferenceDetection | undefined;
   let resultLines: string[] | undefined;
   let successLabel: string | undefined;
@@ -384,7 +382,7 @@ async function runGuidedOnboardingFlow(
         activate,
         // Legacy chat handoff keeps loud per-candidate failures.
         ...(custodianMode
-          ? { collectFailure: (failure: LadderFailure) => ladderFailures.push(failure) }
+          ? { collectFailure: (failure: SetupCandidateFailure) => ladderFailures.push(failure) }
           : {}),
       });
       if (attempt.kind === "success") {
@@ -441,12 +439,7 @@ async function runGuidedOnboardingFlow(
         await prompter.note(
           [
             t("wizard.guided.failedOptionsIntro"),
-            ...ladderFailures.map((failure) =>
-              t("wizard.guided.failedOptionLine", {
-                label: failure.label,
-                reason: setupFailureReason(failure.status),
-              }),
-            ),
+            ...ladderFailures.map(formatSetupCandidateFailure),
           ].join("\n"),
           t("wizard.guided.aiAccessTitle"),
         );
@@ -468,12 +461,7 @@ async function runGuidedOnboardingFlow(
     }
   } else if (!resultLines) {
     if (ladderFailures.length > 0) {
-      const failureLines = ladderFailures.map((failure) =>
-        t("wizard.guided.failedOptionLine", {
-          label: failure.label,
-          reason: setupFailureReason(failure.status),
-        }),
-      );
+      const failureLines = ladderFailures.map(formatSetupCandidateFailure);
       await prompter.note(
         [t("wizard.guided.failedOptionsIntro"), ...failureLines].join("\n"),
         t("wizard.guided.aiAccessTitle"),

--- a/src/wizard/i18n/locales/en.ts
+++ b/src/wizard/i18n/locales/en.ts
@@ -293,7 +293,6 @@ export const en = {
         "I can see {labels} on this machine — good taste. Once your AI works I can bring their memories along too.",
       controlUiPreparing: "Preparing the Control UI…",
       custodianIntro: "Hi — I'm OpenClaw. I keep this system running. Let's get you set up.",
-      failedOptionLine: "{label}: {reason}",
       failedOptionsIntro: "These didn't work just now:",
       findMeLater:
         "You can always find me later — run `openclaw` in a terminal, or open Settings in the dashboard.",

--- a/src/wizard/i18n/locales/zh-CN.ts
+++ b/src/wizard/i18n/locales/zh-CN.ts
@@ -286,7 +286,6 @@ export const zh_CN = {
         "我看到这台机器上有 {labels} — 品味不错。等 AI 就绪后，我还能把它们的记忆一并带过来。",
       controlUiPreparing: "正在准备 Control UI…",
       custodianIntro: "你好 — 我是 OpenClaw，负责维护这套系统。我们开始设置吧。",
-      failedOptionLine: "{label}：{reason}",
       failedOptionsIntro: "刚才这些没有成功：",
       findMeLater: "以后随时可以找到我 — 在终端运行 `openclaw`，或在仪表盘中打开设置。",
       hatchingNow: "正在孵化你的智能体…",

--- a/src/wizard/i18n/locales/zh-TW.ts
+++ b/src/wizard/i18n/locales/zh-TW.ts
@@ -286,7 +286,6 @@ export const zh_TW = {
         "我看到這台機器上有 {labels} — 品味不錯。等 AI 就緒後，我還能把它們的記憶一併帶過來。",
       controlUiPreparing: "正在準備 Control UI…",
       custodianIntro: "你好 — 我是 OpenClaw，負責維護這套系統。我們開始設定吧。",
-      failedOptionLine: "{label}：{reason}",
       failedOptionsIntro: "剛才這些沒有成功：",
       findMeLater: "之後隨時找得到我 — 在終端機執行 `openclaw`，或在儀表板中開啟設定。",
       hatchingNow: "正在孵化你的智慧代理…",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users onboarding with an existing Codex login could have the default live test fail when the process host injected `NODE_PATH`. The first-pass candidate summary then replaced the specific attestation failure with “The completion failed for an unknown reason,” so the actionable cause appeared only after manually retrying Codex.

AI-assisted: yes (Codex). I reviewed the complete change and its runtime/security boundary.

## Why This Change Was Made

The Codex stdio transport now removes inherited module and dynamic-loader injection paths while it constructs the one environment used by both runtime-artifact attestation and the eventual child spawn. These variables cannot influence Codex after removal, so attestation still protects the exact environment that reaches the child. `NODE_OPTIONS` remains separately attested: bounded resource, warning, DNS, proxy, and CA options stay usable, while preload/import/debug/module-resolution options still fail closed.

The guided onboarding ladder now retains the full failed activation result and uses the same detailed formatter as the manual retry path. This removes duplicate summary rendering and makes the first displayed failure honest.

No OpenClaw-owned injector exists in this path: guided onboarding, activation, embedded-agent dispatch, Codex harness preparation, and pre-spawn capture stay in one process. Model-auth profiles and Codex plugin config add no `NODE_PATH`; the observed value was inherited from the external execution host. Upstream Codex defines the app-server’s stdio transport at [`cli/src/main.rs:535-546`](https://github.com/openai/codex/blob/3b67b03a3f6b0590589fb85d2be26d0eb58ac159/codex-rs/cli/src/main.rs#L535-L546), dispatches it directly at [`cli/src/main.rs:1134-1184`](https://github.com/openai/codex/blob/3b67b03a3f6b0590589fb85d2be26d0eb58ac159/codex-rs/cli/src/main.rs#L1134-L1184), and starts its stdio connection at [`app-server/src/lib.rs:711-725`](https://github.com/openai/codex/blob/3b67b03a3f6b0590589fb85d2be26d0eb58ac159/codex-rs/app-server/src/lib.rs#L711-L725). The environment boundary therefore belongs to OpenClaw’s spawn owner.

## User Impact

Codex onboarding can now complete from package-manager, agent-host, and similar launch contexts that add `NODE_PATH` or native loader paths. If a candidate still fails, the first failure panel includes the specific lower-layer reason instead of a generic dead end.

## Evidence

Before the fix, the host supplied an ambient `NODE_PATH` to a plain child Node process. Running the focused Codex artifact suite reproduced the product failure at the exact owner boundary:

```text
28 failed
Error: Codex runtime artifact cannot attest injected runtime environment: NODE_PATH
  at assertNoRuntimeInjectionEnvironment (.../runtime-artifact.ts:266)
```

After the fix:

```text
node scripts/run-vitest.mjs \
  extensions/codex/src/app-server/transport-stdio.test.ts \
  extensions/codex/src/app-server/runtime-artifact.test.ts \
  src/commands/onboard-guided.test.ts

Test Files  1 passed (1)   # commands shard
Tests       23 passed (23)
Test Files  2 passed (2)   # Codex extension shard
Tests       37 passed (37)
```

Live CLI proof used a fresh isolated `nptest2` profile while the same ambient `NODE_PATH` was present:

```text
AI found
Codex — logged in · ChatGPT subscription
Testing Codex (openai/gpt-5.6-sol) — real completion, not a ping…
AI check passed.
Use Codex?
```

The run was cancelled before service installation and the isolated profile was removed afterward. Autoreview reported no accepted/actionable findings. Production LOC is `+49/-59` (net `-10`); tests are `+50/-8`.

`node scripts/check-changed.mjs` also passed on hosted Blacksmith Testbox (`tbx_01kzvev44tynf6ma8txyh3vqc2`, [run 31620682782](https://github.com/openclaw/openclaw/actions/runs/31620682782)).
