### PR TITLE
fix(agents): keep profile workspaces inside profile state roots

### DIFF
--- a/packages/memory-host-sdk/src/host/config-utils.test.ts
+++ b/packages/memory-host-sdk/src/host/config-utils.test.ts
@@ -1,8 +1,21 @@
 import { describe, expect, it } from "vitest";
 import {
   normalizeConfiguredMemoryExtraPaths,
+  resolveMemoryHostAgentWorkspaceDir,
   resolveRememberAcrossConversations,
 } from "./config-utils.js";
+
+describe("resolveMemoryHostAgentWorkspaceDir", () => {
+  it("uses the active profile state root for the default agent workspace", () => {
+    expect(
+      resolveMemoryHostAgentWorkspaceDir({}, "main", {
+        HOME: "/home/peter",
+        OPENCLAW_PROFILE: "work",
+        OPENCLAW_STATE_DIR: "/home/peter/.openclaw-work",
+      }),
+    ).toBe("/home/peter/.openclaw-work/workspace");
+  });
+});
 
 describe("resolveRememberAcrossConversations", () => {
   it("honors keyed per-agent memory overrides", () => {

--- a/packages/memory-host-sdk/src/host/config-utils.ts
+++ b/packages/memory-host-sdk/src/host/config-utils.ts
@@ -227,7 +227,7 @@ function resolveDefaultAgentWorkspaceDir(env: NodeJS.ProcessEnv = process.env): 
   const home = resolveRequiredHomeDir(env, os.homedir);
   const profile = env.OPENCLAW_PROFILE?.trim();
   if (profile && normalizeLowercaseStringOrEmpty(profile) !== "default") {
-    return path.join(home, ".openclaw", `workspace-${profile}`);
+    return path.join(resolveStateDir(env), "workspace");
   }
   return path.join(home, ".openclaw", "workspace");
 }

--- a/src/agents/workspace-default.ts
+++ b/src/agents/workspace-default.ts
@@ -6,6 +6,7 @@
 import os from "node:os";
 import path from "node:path";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import { resolveProfileStateDir } from "../cli/profile-utils.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 
 /** Resolve the default agent workspace directory from env/profile/home state. */
@@ -20,7 +21,7 @@ export function resolveDefaultAgentWorkspaceDir(
   const home = resolveRequiredHomeDir(env, homedir);
   const profile = env.OPENCLAW_PROFILE?.trim();
   if (profile && normalizeOptionalLowercaseString(profile) !== "default") {
-    return path.join(home, ".openclaw", `workspace-${profile}`);
+    return path.join(resolveProfileStateDir(profile, env, homedir), "workspace");
   }
   return path.join(home, ".openclaw", "workspace");
 }

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -69,9 +69,29 @@ describe("resolveDefaultAgentWorkspaceDir", () => {
     expect(dir).toBe(path.join(path.resolve("/srv/openclaw-home"), ".openclaw", "workspace"));
   });
 
+  it("roots named profile workspaces inside the profile state directory", () => {
+    const dir = resolveDefaultAgentWorkspaceDir({
+      OPENCLAW_PROFILE: "work",
+      OPENCLAW_HOME: "/srv/openclaw-home",
+      HOME: "/home/other",
+    } as NodeJS.ProcessEnv);
+
+    expect(dir).toBe(path.join(path.resolve("/srv/openclaw-home"), ".openclaw-work", "workspace"));
+  });
+
+  it("rejects invalid environment-only profile names", () => {
+    expect(() =>
+      resolveDefaultAgentWorkspaceDir({
+        OPENCLAW_PROFILE: "../escape",
+        HOME: "/home/peter",
+      } as NodeJS.ProcessEnv),
+    ).toThrow('Invalid profile name: "../escape"');
+  });
+
   it("prefers OPENCLAW_WORKSPACE_DIR for default workspace resolution", () => {
     const dir = resolveDefaultAgentWorkspaceDir({
       OPENCLAW_WORKSPACE_DIR: "/srv/openclaw-workspace",
+      OPENCLAW_PROFILE: "work",
       OPENCLAW_HOME: "/srv/openclaw-home",
       HOME: "/home/other",
     } as NodeJS.ProcessEnv);

--- a/src/cli/profile-utils.ts
+++ b/src/cli/profile-utils.ts
@@ -1,5 +1,7 @@
 // Profile name validation and normalization helpers for root CLI profile routing.
+import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 
 const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/i;
 
@@ -23,4 +25,18 @@ export function normalizeProfileName(raw?: string | null): string | null {
     return null;
   }
   return profile;
+}
+
+/** Resolve the canonical home-scoped state root for a validated CLI profile. */
+export function resolveProfileStateDir(
+  profile: string,
+  env: NodeJS.ProcessEnv,
+  homedir: () => string,
+): string {
+  const trimmed = profile.trim();
+  if (!isValidProfileName(trimmed)) {
+    throw new Error(`Invalid profile name: ${JSON.stringify(profile)}`);
+  }
+  const suffix = normalizeLowercaseStringOrEmpty(trimmed) === "default" ? "" : `-${trimmed}`;
+  return path.join(resolveRequiredHomeDir(env, homedir), `.openclaw${suffix}`);
 }

--- a/src/cli/profile.ts
+++ b/src/cli/profile.ts
@@ -1,18 +1,15 @@
 // Root --profile/--dev parsing and environment projection for profile-specific state.
 import os from "node:os";
 import path from "node:path";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-} from "@openclaw/normalization-core/string-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   resolveGatewayLaunchAgentLabel,
   resolveGatewaySystemdServiceName,
   resolveGatewayWindowsTaskName,
 } from "../daemon/constants.js";
-import { resolveHomeRelativePath, resolveRequiredHomeDir } from "../infra/home-dir.js";
+import { resolveHomeRelativePath } from "../infra/home-dir.js";
 import { resolveCliArgvInvocation } from "./argv-invocation.js";
-import { isValidProfileName } from "./profile-utils.js";
+import { isValidProfileName, resolveProfileStateDir } from "./profile-utils.js";
 import { scanCliRootOptions } from "./root-option-scan.js";
 import { takeCliRootOptionValue } from "./root-option-value.js";
 
@@ -75,15 +72,6 @@ export function parseCliProfileArgs(argv: string[]): CliProfileParseResult {
   return { ok: true, profile, argv: scanned.argv };
 }
 
-function resolveProfileStateDir(
-  profile: string,
-  env: Record<string, string | undefined>,
-  homedir: () => string,
-): string {
-  const suffix = normalizeLowercaseStringOrEmpty(profile) === "default" ? "" : `-${profile}`;
-  return path.join(resolveRequiredHomeDir(env as NodeJS.ProcessEnv, homedir), `.openclaw${suffix}`);
-}
-
 export function applyCliProfileEnv(params: {
   profile: string;
   env?: Record<string, string | undefined>;
@@ -99,8 +87,9 @@ export function applyCliProfileEnv(params: {
   const inheritedProfile = normalizeOptionalString(env.OPENCLAW_PROFILE) ?? "default";
   const existingStateDir = normalizeOptionalString(env.OPENCLAW_STATE_DIR);
   const existingConfigPath = normalizeOptionalString(env.OPENCLAW_CONFIG_PATH);
-  const inheritedProfileStateDir = resolveProfileStateDir(inheritedProfile, env, homedir);
-  const selectedProfileStateDir = resolveProfileStateDir(profile, env, homedir);
+  const profileEnv = env as NodeJS.ProcessEnv;
+  const inheritedProfileStateDir = resolveProfileStateDir(inheritedProfile, profileEnv, homedir);
+  const selectedProfileStateDir = resolveProfileStateDir(profile, profileEnv, homedir);
   const switchesInheritedProfile = inheritedProfileStateDir !== selectedProfileStateDir;
   const switchesInheritedProfileState = Boolean(
     existingStateDir &&

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -796,6 +796,33 @@ async function runAutoMigrateLegacyStateWithLog(params: {
   return { result, log };
 }
 
+function getProfileWorkspaceMigrationPaths(root: string, profile = "work") {
+  return {
+    legacyDir: path.join(root, ".openclaw", `workspace-${profile}`),
+    targetDir: path.join(root, `.openclaw-${profile}`, "workspace"),
+    stateDir: path.join(root, `.openclaw-${profile}`),
+  };
+}
+
+async function runProfileWorkspaceDoctorMigration(root: string, profile = "work") {
+  const paths = getProfileWorkspaceMigrationPaths(root, profile);
+  fs.mkdirSync(paths.stateDir, { recursive: true });
+  const log = { info: vi.fn(), warn: vi.fn() };
+  const result = await autoMigrateLegacyState({
+    cfg: {},
+    env: {
+      HOME: root,
+      OPENCLAW_HOME: root,
+      OPENCLAW_PROFILE: profile,
+      OPENCLAW_STATE_DIR: paths.stateDir,
+    } as NodeJS.ProcessEnv,
+    homedir: () => root,
+    log,
+    doctorOnlyStateMigrations: true,
+  });
+  return { log, paths, result };
+}
+
 function expectTargetAlreadyExistsWarning(result: StateDirMigrationResult, targetDir: string) {
   expect(result.migrated).toBe(false);
   expect(result.warnings).toEqual([
@@ -4154,6 +4181,51 @@ describe("doctor legacy state migrations", () => {
     expect(log.info).toHaveBeenCalled();
     expect(store["main"]).toBeUndefined();
     expect(store["agent:main:main"]?.sessionId).toBe("legacy");
+  });
+
+  it("moves the active profile's legacy workspace into its state root", async () => {
+    const root = makeDoctorStateDir();
+    const paths = getProfileWorkspaceMigrationPaths(root);
+    fs.mkdirSync(paths.legacyDir, { recursive: true });
+    fs.writeFileSync(path.join(paths.legacyDir, "AGENTS.md"), "profile workspace", "utf8");
+
+    const { log, result } = await runProfileWorkspaceDoctorMigration(root);
+
+    expect(fs.existsSync(paths.legacyDir)).toBe(false);
+    expect(fs.readFileSync(path.join(paths.targetDir, "AGENTS.md"), "utf8")).toBe(
+      "profile workspace",
+    );
+    expect(result.changes).toContain(`Profile workspace: ${paths.legacyDir} → ${paths.targetDir}`);
+    expect(log.info).toHaveBeenCalledWith(expect.stringContaining(paths.targetDir));
+  });
+
+  it("keeps both profile workspaces when the canonical target already exists", async () => {
+    const root = makeDoctorStateDir();
+    const paths = getProfileWorkspaceMigrationPaths(root);
+    fs.mkdirSync(paths.legacyDir, { recursive: true });
+    fs.mkdirSync(paths.targetDir, { recursive: true });
+    fs.writeFileSync(path.join(paths.legacyDir, "legacy.txt"), "legacy", "utf8");
+    fs.writeFileSync(path.join(paths.targetDir, "current.txt"), "current", "utf8");
+
+    const { log, result } = await runProfileWorkspaceDoctorMigration(root);
+
+    const warning = `Profile workspace migration skipped: target already exists (${paths.targetDir}). Kept legacy workspace at ${paths.legacyDir}; merge manually.`;
+    expect(result.warnings).toContain(warning);
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining(warning));
+    expect(fs.readFileSync(path.join(paths.legacyDir, "legacy.txt"), "utf8")).toBe("legacy");
+    expect(fs.readFileSync(path.join(paths.targetDir, "current.txt"), "utf8")).toBe("current");
+  });
+
+  it("does nothing when the active profile has no legacy workspace", async () => {
+    const root = makeDoctorStateDir();
+
+    const { log, paths, result } = await runProfileWorkspaceDoctorMigration(root);
+
+    expect(fs.existsSync(paths.legacyDir)).toBe(false);
+    expect(fs.existsSync(paths.targetDir)).toBe(false);
+    expect(result.changes.some((entry) => entry.startsWith("Profile workspace:"))).toBe(false);
+    expect(result.warnings.some((entry) => entry.includes("Profile workspace"))).toBe(false);
+    expect(log.warn).not.toHaveBeenCalledWith(expect.stringContaining("Profile workspace"));
   });
 
   it("does nothing when no legacy state dir exists", async () => {

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { isValidProfileName } from "../cli/profile-utils.js";
+import { resolveProfileStateDir } from "../cli/profile-utils.js";
 import { resolveGatewayNativeServiceIdentityConflict } from "../daemon/constants.js";
 import { resolveHomeRelativePath, resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { parseTcpPort } from "../infra/tcp-port.js";
@@ -126,18 +126,6 @@ export function isDefaultStateDir(
   );
 }
 
-/** Canonical state directory name for the selected profile, mirroring root `--profile`. */
-function profileStateDirName(env: NodeJS.ProcessEnv): string | null {
-  const profile = env.OPENCLAW_PROFILE?.trim();
-  if (!profile || profile.toLowerCase() === "default") {
-    return NEW_STATE_DIRNAME;
-  }
-  if (!isValidProfileName(profile)) {
-    return null;
-  }
-  return `${NEW_STATE_DIRNAME}-${profile}`;
-}
-
 export function resolveNativeServiceProfileConflict(
   env: NodeJS.ProcessEnv = process.env,
   platform: NodeJS.Platform = process.platform,
@@ -187,13 +175,14 @@ export function isDefaultInstallIdentity(
   ) {
     return false;
   }
-  const stateDirName = profileStateDirName(env);
-  // Environment profiles can bypass root CLI parsing. Reject them before path
-  // construction so separators or dot segments cannot authorize a host service.
-  if (!stateDirName) {
+  let canonicalStateDir: string;
+  try {
+    canonicalStateDir = resolveProfileStateDir(env.OPENCLAW_PROFILE ?? "default", env, homedir);
+  } catch {
+    // Environment profiles can bypass root CLI parsing. Reject invalid names
+    // before path construction so separators cannot authorize a host service.
     return false;
   }
-  const canonicalStateDir = path.join(accountHome, stateDirName);
   if (
     normalizePathForComparison(resolveStateDir(env, envHomedir(env))) !==
     normalizePathForComparison(canonicalStateDir)
@@ -202,7 +191,7 @@ export function isDefaultInstallIdentity(
   }
   // Default installs historically allow implicit legacy config discovery.
   // Named profiles must resolve their own config so they cannot inherit the default profile.
-  if (stateDirName === NEW_STATE_DIRNAME && !env.OPENCLAW_CONFIG_PATH?.trim()) {
+  if (!isNamedProfile(env) && !env.OPENCLAW_CONFIG_PATH?.trim()) {
     return true;
   }
   return (

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -134,6 +134,7 @@ import {
 } from "./state-migrations.session-store.js";
 import {
   autoMigrateLegacyStateDir,
+  migrateLegacyProfileWorkspace,
   resetAutoMigrateLegacyTaskStateSidecarsForTest,
 } from "./state-migrations.state-dir.js";
 import {
@@ -1335,6 +1336,10 @@ export async function autoMigrateLegacyState(params: {
       ...(stateDirResult.notices?.length ? { notices: stateDirResult.notices } : {}),
     };
   }
+  const profileWorkspace =
+    params.doctorOnlyStateMigrations === true
+      ? migrateLegacyProfileWorkspace({ env, homedir })
+      : { changes: [], warnings: [] };
   const pluginDoctorConfig = params.pluginDoctorConfig ?? params.cfg;
   const configMachineState = migrateLegacyConfigMachineState({
     config: pluginDoctorConfig,
@@ -1431,6 +1436,7 @@ export async function autoMigrateLegacyState(params: {
   });
   const initialMigrationSources = [
     stateDirResult,
+    profileWorkspace,
     stateSchema,
     mediaPersistence,
     configMachineState,

--- a/src/infra/state-migrations.state-dir.ts
+++ b/src/infra/state-migrations.state-dir.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { resolveProfileStateDir } from "../cli/profile-utils.js";
 import { resolveLegacyStateDirs, resolveNewStateDir, resolveStateDir } from "../config/paths.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { isWithinDir } from "./path-safety.js";
@@ -29,6 +31,65 @@ type StateDirMigrationResult = {
   warnings: string[];
   notices?: string[];
 };
+
+function lstatIfPresent(filePath: string): fs.Stats | null {
+  try {
+    return fs.lstatSync(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export function migrateLegacyProfileWorkspace(params: {
+  env?: NodeJS.ProcessEnv;
+  homedir?: () => string;
+}): { changes: string[]; warnings: string[] } {
+  const env = params.env ?? process.env;
+  const homedir = params.homedir ?? os.homedir;
+  const profile = env.OPENCLAW_PROFILE?.trim();
+  if (!profile || normalizeLowercaseStringOrEmpty(profile) === "default") {
+    return { changes: [], warnings: [] };
+  }
+
+  try {
+    const legacyDir = path.join(
+      resolveProfileStateDir("default", env, homedir),
+      `workspace-${profile}`,
+    );
+    const targetDir = path.join(resolveProfileStateDir(profile, env, homedir), "workspace");
+    const legacyStat = lstatIfPresent(legacyDir);
+    if (!legacyStat) {
+      return { changes: [], warnings: [] };
+    }
+    if (!legacyStat.isDirectory() && !legacyStat.isSymbolicLink()) {
+      return {
+        changes: [],
+        warnings: [
+          `Profile workspace migration skipped: legacy path is not a directory (${legacyDir}).`,
+        ],
+      };
+    }
+    if (lstatIfPresent(targetDir)) {
+      return {
+        changes: [],
+        warnings: [
+          `Profile workspace migration skipped: target already exists (${targetDir}). Kept legacy workspace at ${legacyDir}; merge manually.`,
+        ],
+      };
+    }
+    fs.mkdirSync(path.dirname(targetDir), { recursive: true });
+    fs.renameSync(legacyDir, targetDir);
+    return { changes: [`Profile workspace: ${legacyDir} → ${targetDir}`], warnings: [] };
+  } catch (error) {
+    return {
+      changes: [],
+      warnings: [`Profile workspace migration failed: ${String(error)}`],
+    };
+  }
+}
 
 function resolveSymlinkTarget(linkPath: string): string | null {
   try {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running setup or onboarding with a named profile would create the default agent workspace in the operator's unprofiled state directory instead of the isolated profile state root.

On 2026-08-12, `openclaw onboard --profile ct2` reported:

```text
Workspace OK: ~/.openclaw/workspace-ct2
```

The operator's default state root currently contains 12 leaked profile workspaces, demonstrating the accumulated impact:

```text
workspace-codex-ollama-timeout-smoke
workspace-ct2
workspace-ct3
workspace-dev
workspace-gemma4-inferrs
workspace-guardtest
workspace-mtest1
workspace-obtest1
workspace-rtest1
workspace-rtest2
workspace-sr2
workspace-st1
```

## Why This Change Was Made

The root CLI's profile-to-state-root resolver is now the single owner of `~/.openclaw-<profile>`. Agent workspace resolution and install identity checks reuse it, while the memory-host sibling follows the active profile state root. Default-profile behavior and `OPENCLAW_WORKSPACE_DIR` precedence remain unchanged.

`openclaw doctor --fix` now owns the one-time persistent-state migration. For the active named profile only, it renames `~/.openclaw/workspace-<profile>` to `~/.openclaw-<profile>/workspace` when the target is absent. If the target already exists, doctor keeps both directories and reports both paths for manual merge. Runtime has no legacy read-through fallback.

Invalid environment-only profile names fail closed instead of constructing workspace paths. The normal `--profile` parser continues to reject those names before state resolution.

## User Impact

Named profiles now keep config, sessions, state, and the default workspace together under one isolated root. Existing profile workspaces can be repaired with `openclaw --profile <name> doctor --fix` without touching other profiles or clobbering an existing canonical workspace.

Default installs continue to use `~/.openclaw/workspace`, and explicit workspace overrides still win.

## Evidence

### Before/after resolver proof

The regression test failed on the old implementation with:

```text
Expected: /srv/openclaw-home/.openclaw-work/workspace
Received: /srv/openclaw-home/.openclaw/workspace-work
```

After the fix, the resolver group passes all four default/profile/override/invalid-name cases.

### Live setup and doctor migration

Fresh scratch-profile setup:

```json
{
  "ok": true,
  "configPath": "/Users/steipete/.openclaw-wstest1/openclaw.json",
  "configStatus": "created",
  "workspaceDir": "/Users/steipete/.openclaw-wstest1/workspace",
  "sessionsDir": "/Users/steipete/.openclaw-wstest1/agents/main/sessions"
}
```

The workspace contained `AGENTS.md`, `BOOTSTRAP.md`, `IDENTITY.md`, `SOUL.md`, and `USER.md`; `/Users/steipete/.openclaw/workspace-wstest1` did not exist.

After moving only that scratch workspace to the simulated legacy path, profile-scoped doctor reported:

```text
[state-migrations] Auto-migrated legacy state:
- Profile workspace: /Users/steipete/.openclaw/workspace-wstest1 → /Users/steipete/.openclaw-wstest1/workspace
```

The canonical workspace and all five files were present afterward, and the legacy path was absent. Both scratch paths were then removed from their live locations; the scratch profile was moved to Trash for recoverable cleanup.

### Automated validation

- `node scripts/run-vitest.mjs src/agents/workspace.test.ts -t "resolveDefaultAgentWorkspaceDir"`: 4 passed.
- `node scripts/run-vitest.mjs src/cli/profile.test.ts src/config/paths.test.ts packages/memory-host-sdk/src/host/config-utils.test.ts src/commands/doctor-state-migrations.test.ts`: 193 passed across three shards.
- Doctor migration coverage proves move, target-exists no-clobber/reporting, and missing-source no-op behavior.
- `node scripts/check-changed.mjs -- <10 changed files>`: green on Blacksmith Testbox lease `tbx_01kzvf16ap95mje7w34h73qhx2`, run https://github.com/openclaw/openclaw/actions/runs/31620964589.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output`: clean, no accepted/actionable findings.
- The post-rebase patch ID was byte-equivalent to the reviewed patch, and the focused tests passed again on exact head.

The full `src/agents/workspace.test.ts` file also exercises an unrelated pre-existing transient-boundary retry assertion that failed identically before and after this patch; the changed resolver group is green and the complete changed-surface gate passed.

AI-assisted by Codex; the maintainer verified the source paths, migration semantics, live CLI behavior, tests, and structured review.
