### PR TITLE
fix(ci): preserve periphery artifacts across reruns

### DIFF
--- a/.github/workflows/shared-openclawkit-periphery.yml
+++ b/.github/workflows/shared-openclawkit-periphery.yml
@@ -152,14 +152,17 @@ jobs:
             cp "$output_dir/periphery.stdout.json" "$output_dir/periphery.json"
           fi
 
+      # Failed-job reruns retain successful producer artifacts from the original attempt.
+      # Keep artifact slots run-scoped; rerun producers overwrite their slot.
       - name: Upload iOS consumer report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: shared-periphery-ios-${{ github.run_id }}-${{ github.run_attempt }}
+          name: shared-periphery-ios-${{ github.run_id }}
           path: ${{ runner.temp }}/shared-periphery-ios
           if-no-files-found: error
           retention-days: 14
+          overwrite: true
 
   scan-macos:
     name: Scan shared kit from macOS
@@ -225,10 +228,11 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: shared-periphery-macos-${{ github.run_id }}-${{ github.run_attempt }}
+          name: shared-periphery-macos-${{ github.run_id }}
           path: ${{ runner.temp }}/shared-periphery-macos
           if-no-files-found: error
           retention-days: 14
+          overwrite: true
 
   intersect:
     name: Intersect shared OpenClawKit dead code
@@ -247,13 +251,13 @@ jobs:
       - name: Download iOS consumer report
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: shared-periphery-ios-${{ github.run_id }}-${{ github.run_attempt }}
+          name: shared-periphery-ios-${{ github.run_id }}
           path: ${{ runner.temp }}/shared-periphery-ios
 
       - name: Download macOS consumer report
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: shared-periphery-macos-${{ github.run_id }}-${{ github.run_attempt }}
+          name: shared-periphery-macos-${{ github.run_id }}
           path: ${{ runner.temp }}/shared-periphery-macos
 
       - name: Intersect exact Swift identities
@@ -269,7 +273,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: shared-periphery-intersection-${{ github.run_id }}-${{ github.run_attempt }}
+          name: shared-periphery-intersection-${{ github.run_id }}
           path: ${{ runner.temp }}/shared-periphery-intersection
           if-no-files-found: warn
           retention-days: 14
+          overwrite: true

--- a/test/scripts/periphery-intersection.test.ts
+++ b/test/scripts/periphery-intersection.test.ts
@@ -19,7 +19,7 @@ type WorkflowStep = {
   id?: string;
   name?: string;
   run?: string;
-  with?: { name?: string; path?: string; script?: string };
+  with?: { name?: string; overwrite?: boolean; path?: string; script?: string };
 };
 
 type Workflow = {
@@ -148,8 +148,39 @@ describe("shared OpenClawKit Periphery workflow", () => {
     const macosUpload = workflow.jobs?.["scan-macos"]?.steps?.find(
       (step) => step.name === "Upload macOS consumer report",
     );
-    expect(iosUpload?.with?.name).toContain("shared-periphery-ios-");
-    expect(macosUpload?.with?.name).toContain("shared-periphery-macos-");
+    const iosDownload = workflow.jobs?.intersect?.steps?.find(
+      (step) => step.name === "Download iOS consumer report",
+    );
+    const macosDownload = workflow.jobs?.intersect?.steps?.find(
+      (step) => step.name === "Download macOS consumer report",
+    );
+    const intersectionUpload = workflow.jobs?.intersect?.steps?.find(
+      (step) => step.name === "Upload shared intersection",
+    );
+
+    expect(iosUpload?.with?.name).toBe("shared-periphery-ios-${{ github.run_id }}");
+    expect(iosDownload?.with?.name).toBe(iosUpload?.with?.name);
+    expect(macosUpload?.with?.name).toBe("shared-periphery-macos-${{ github.run_id }}");
+    expect(macosDownload?.with?.name).toBe(macosUpload?.with?.name);
+    expect(intersectionUpload?.with?.name).toBe(
+      "shared-periphery-intersection-${{ github.run_id }}",
+    );
+
+    const artifactNames = [
+      iosUpload?.with?.name,
+      iosDownload?.with?.name,
+      macosUpload?.with?.name,
+      macosDownload?.with?.name,
+      intersectionUpload?.with?.name,
+    ];
+    expect(artifactNames).not.toContain(undefined);
+    for (const artifactName of artifactNames) {
+      expect(artifactName).not.toContain("github.run_attempt");
+    }
+
+    expect(iosUpload?.with?.overwrite).toBe(true);
+    expect(macosUpload?.with?.overwrite).toBe(true);
+    expect(intersectionUpload?.with?.overwrite).toBe(true);
   });
 
   it("retains the generated protocol contract and leaves findings for the intersection", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where rerunning only failed Shared OpenClawKit Periphery jobs could leave the intersection job unable to find a successful producer's report. GitHub retains artifacts from successful jobs that are not rerun, but the workflow previously changed artifact names with `github.run_attempt`.

## Why This Change Was Made

Artifact slots are now scoped to the workflow `run_id`, so producers and consumers keep one stable name across selective reruns. All three producers use `overwrite: true`, allowing a rerun producer to replace its own run-scoped slot while unchanged successful producer artifacts remain consumable.

The GitHub-hosted runner fallback based on `github.run_attempt > 1` is unchanged.

## User Impact

Maintainers can rerun failed Shared OpenClawKit Periphery jobs without forcing both platform scans to rerun just to recreate attempt-suffixed artifacts.

## Evidence

- Regression proof before the workflow change: `test/scripts/periphery-intersection.test.ts` failed because the iOS artifact name included `${{ github.run_attempt }}`.
- Focused test on exact head: `node scripts/run-vitest.mjs test/scripts/periphery-intersection.test.ts` (11 passed).
- Target workflow lint on exact head: `actionlint -shellcheck= -pyflakes= .github/workflows/shared-openclawkit-periphery.yml`.
- Formatting on exact head: `node_modules/.bin/oxfmt --check .github/workflows/shared-openclawkit-periphery.yml test/scripts/periphery-intersection.test.ts`.
- `git diff --check origin/main...HEAD`.
- Repository workflow validation passed before the final rebase with `node --import tsx scripts/check-workflows.mts` (`zizmor` and composite interpolation checks).
- Local autoreview and offline ClawSweeper review found no actionable issue on the identical patch before the final rebase; ClawSweeper rated the best-fix judgment `yes`.
- `node scripts/check-changed.mjs -- .github/workflows/shared-openclawkit-periphery.yml test/scripts/periphery-intersection.test.ts` was attempted twice. Both Blacksmith Testbox runs failed during setup before repository checks because the TruffleHog download ended with `curl: (56) Connection died, tried 5 times before giving up`: https://github.com/openclaw/openclaw/actions/runs/31621773562 and https://github.com/openclaw/openclaw/actions/runs/31621934536.

## Scope

- Production/workflow LOC: `+10/-5`.
- Test LOC: `+34/-3`.
- No scripts, locale files, retries, timeouts, runner selection, standalone iOS/macOS workflows, or release surfaces changed.

## Follow-up

**Audit maturity-scorecard selective-rerun artifacts:** `.github/workflows/maturity-scorecard.yml` has the same class of `run_id` plus `run_attempt` producer/consumer naming. It is intentionally excluded from this narrow repair and should be assessed separately.

AI-assisted; the author reviewed the code, workflow semantics, and validation results.
