### PR TITLE
refactor(discord): remove thread binding test API

### DIFF
--- a/extensions/discord/session-binding-contract-api.ts
+++ b/extensions/discord/session-binding-contract-api.ts
@@ -1,3 +1,0 @@
-// Discord API module exposes the plugin public contract.
-export { createThreadBindingManager } from "./src/monitor/thread-bindings.manager.js";
-export { testing as discordThreadBindingTesting } from "./src/monitor/thread-bindings.manager.js";

--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -1,5 +1,5 @@
 // Discord tests cover message handler.preflight plugin behavior.
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { ChannelType, MessageType } from "../internal/discord.js";
 import { createPartialDiscordChannelWithThrowingGetters } from "../test-support/partial-channel.js";
 
@@ -57,7 +57,6 @@ vi.mock("openclaw/plugin-sdk/media-runtime", { spy: true });
 let preflightDiscordMessage: typeof import("./message-handler.preflight.js").preflightDiscordMessage;
 let resolvePreflightMentionRequirement: typeof import("./message-handler.preflight.js").resolvePreflightMentionRequirement;
 let shouldIgnoreBoundThreadWebhookMessage: typeof import("./message-handler.preflight.js").shouldIgnoreBoundThreadWebhookMessage;
-let threadBindingTesting: typeof import("./thread-bindings.js").testing;
 let createThreadBindingManager: typeof import("./thread-bindings.js").createThreadBindingManager;
 
 beforeAll(async () => {
@@ -66,8 +65,7 @@ beforeAll(async () => {
     resolvePreflightMentionRequirement,
     shouldIgnoreBoundThreadWebhookMessage,
   } = await import("./message-handler.preflight.js"));
-  ({ testing: threadBindingTesting, createThreadBindingManager } =
-    await import("./thread-bindings.js"));
+  ({ createThreadBindingManager } = await import("./thread-bindings.js"));
 });
 
 beforeEach(() => {
@@ -2476,7 +2474,6 @@ describe("preflightDiscordMessage", () => {
 describe("shouldIgnoreBoundThreadWebhookMessage", () => {
   beforeEach(() => {
     sessionBindingTesting.resetSessionBindingAdaptersForTests();
-    threadBindingTesting.resetThreadBindingsForTests();
   });
 
   afterEach(() => {
@@ -2534,6 +2531,7 @@ describe("shouldIgnoreBoundThreadWebhookMessage", () => {
       persist: false,
       enableSweeper: false,
     });
+    onTestFinished(() => manager.stop());
     const binding = await manager.bindTarget({
       threadId: "thread-1",
       channelId: "parent-1",

--- a/extensions/discord/src/monitor/message-handler.process.room-events.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.room-events.test.ts
@@ -1,5 +1,5 @@
 // Discord message processing coverage split by cohesive behavior.
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
 import {
   BASE_CHANNEL_ROUTE,
   createBaseContext,
@@ -299,6 +299,7 @@ describe("processDiscordMessage session routing and room events", () => {
       persist: false,
       enableSweeper: false,
     });
+    onTestFinished(() => threadBindings.stop());
     await threadBindings.bindTarget({
       threadId: "thread-1",
       channelId: "c-parent",

--- a/extensions/discord/src/monitor/message-handler.process.test-harness.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test-harness.ts
@@ -4,6 +4,7 @@ import { setReplyPayloadMetadata } from "openclaw/plugin-sdk/reply-payload-testi
 import { logVerbose, sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import { afterEach, beforeAll, beforeEach, vi } from "vitest";
 import type { DiscordMessagePreflightContext } from "./message-handler.preflight.js";
+import { resetThreadBindingsForTests } from "./thread-bindings.test-support.js";
 
 vi.mock("openclaw/plugin-sdk/runtime-env", { spy: true });
 
@@ -276,7 +277,6 @@ export const recordInboundSessionForTest = recordInboundSession;
 export const createDiscordRestClientSpyForTest = createDiscordRestClientSpy;
 let createBaseDiscordMessageContext: typeof import("./message-handler.test-harness.js").createBaseDiscordMessageContext;
 let createDiscordDirectMessageContextOverrides: typeof import("./message-handler.test-harness.js").createDiscordDirectMessageContextOverrides;
-let threadBindingTesting: typeof import("./thread-bindings.js").testing;
 export let createThreadBindingManager: typeof import("./thread-bindings.js").createThreadBindingManager;
 let processDiscordMessage: typeof import("./message-handler.process.js").processDiscordMessage;
 export let formatDiscordReplySkip: typeof import("./message-handler.process.js").formatDiscordReplySkip;
@@ -570,8 +570,7 @@ export function registerDiscordProcessTestLifecycle() {
     vi.useRealTimers();
     ({ createBaseDiscordMessageContext, createDiscordDirectMessageContextOverrides } =
       await import("./message-handler.test-harness.js"));
-    ({ testing: threadBindingTesting, createThreadBindingManager } =
-      await import("./thread-bindings.js"));
+    ({ createThreadBindingManager } = await import("./thread-bindings.js"));
     ({ processDiscordMessage, formatDiscordReplySkip } =
       await import("./message-handler.process.js"));
     ({ discordInboundEventDelivery } = await import("../inbound-event-delivery.js"));
@@ -603,7 +602,7 @@ export function registerDiscordProcessTestLifecycle() {
     readLatestAssistantTextByIdentity.mockResolvedValue(undefined);
     resolveStorePath.mockReturnValue("/tmp/openclaw-discord-process-test-sessions.json");
     getGlobalHookRunner.mockReturnValue(null);
-    threadBindingTesting.resetThreadBindingsForTests();
+    resetThreadBindingsForTests();
   });
 
   afterEach(() => {

--- a/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
@@ -19,6 +19,7 @@ import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { setDiscordRuntime } from "../runtime.js";
 import { EMPTY_DISCORD_TEST_CONFIG } from "../test-support/config.js";
+import { resetThreadBindingsForTests } from "./thread-bindings.test-support.js";
 
 type DiscordRuntime = Parameters<typeof setDiscordRuntime>[0];
 
@@ -67,7 +68,7 @@ vi.mock("../send.messages.js", () => ({
   createThreadDiscord: hoisted.createThreadDiscord,
 }));
 
-const { testing, createThreadBindingManager } = await import("./thread-bindings.manager.js");
+const { createThreadBindingManager } = await import("./thread-bindings.manager.js");
 const {
   autoBindSpawnedDiscordSubagent,
   reconcileAcpThreadBindingsOnStartup,
@@ -77,7 +78,6 @@ const {
 } = await import("./thread-bindings.lifecycle.js");
 const { resolveThreadBindingInactivityExpiresAt, resolveThreadBindingMaxAgeExpiresAt } =
   await import("./thread-bindings.state.js");
-const { resolveThreadBindingIntroText } = await import("./thread-bindings.messages.js");
 const discordClientModule = await import("../client.js");
 const discordThreadBindingApi = await import("./thread-bindings.discord-api.js");
 const acpRuntime = await import("openclaw/plugin-sdk/acp-runtime");
@@ -128,7 +128,7 @@ function mockCallArg(mock: unknown, callIndex: number, argIndex: number, label: 
 describe("thread binding lifecycle", () => {
   beforeEach(() => {
     resetPluginStateStoreForTests();
-    testing.resetThreadBindingsForTests();
+    resetThreadBindingsForTests();
     setDiscordRuntime({
       state: {
         openSyncKeyedStore: (options: OpenKeyedStoreOptions) =>
@@ -264,7 +264,7 @@ describe("thread binding lifecycle", () => {
     createTestThreadBindingManager({
       accountId: "default",
       persist: false,
-      enableSweeper: false,
+      enableSweeper: true,
       idleTimeoutMs: 24 * 60 * 60 * 1000,
       maxAgeMs: 0,
     });
@@ -294,27 +294,6 @@ describe("thread binding lifecycle", () => {
     return binding;
   };
 
-  it("includes idle and max-age details in intro text", () => {
-    const intro = resolveThreadBindingIntroText({
-      agentId: "main",
-      label: "worker",
-      idleTimeoutMs: 24 * 60 * 60 * 1000,
-      maxAgeMs: 48 * 60 * 60 * 1000,
-    });
-    expect(intro).toContain("idle auto-unfocus after 24h inactivity");
-    expect(intro).toContain("max age 48h");
-  });
-
-  it("includes cwd near the top of intro text", () => {
-    const intro = resolveThreadBindingIntroText({
-      agentId: "codex",
-      idleTimeoutMs: 24 * 60 * 60 * 1000,
-      sessionCwd: "/home/bob/clawd",
-      sessionDetails: ["session ids: pending (available after the first reply)"],
-    });
-    expect(intro).toContain("\ncwd: /home/bob/clawd\nsession ids: pending");
-  });
-
   it.each([
     {
       name: "auto-unfocuses idle-expired bindings and sends inactivity message",
@@ -338,7 +317,7 @@ describe("thread binding lifecycle", () => {
         accountId: "default",
         cfg: EMPTY_DISCORD_TEST_CONFIG,
         persist: false,
-        enableSweeper: false,
+        enableSweeper: true,
         idleTimeoutMs,
         maxAgeMs,
       });
@@ -361,7 +340,6 @@ describe("thread binding lifecycle", () => {
       hoisted.sendWebhookMessageDiscord.mockClear();
 
       await vi.advanceTimersByTimeAsync(120_000);
-      await testing.runThreadBindingSweepForAccount("default");
 
       expect(manager.getByThreadId("thread-1")).toBeUndefined();
       if (expectNoProbe) {
@@ -402,7 +380,6 @@ describe("thread binding lifecycle", () => {
       hoisted.restGet.mockRejectedValueOnce(probeError);
 
       await vi.advanceTimersByTimeAsync(120_000);
-      await testing.runThreadBindingSweepForAccount("default");
 
       if (keepsBinding) {
         expectFields(requireBinding(manager, "thread-1"), "thread binding", {
@@ -570,7 +547,7 @@ describe("thread binding lifecycle", () => {
       const manager = createTestThreadBindingManager({
         accountId: "default",
         persist: false,
-        enableSweeper: false,
+        enableSweeper: true,
         idleTimeoutMs: 60_000,
         maxAgeMs: 0,
       });
@@ -594,7 +571,6 @@ describe("thread binding lifecycle", () => {
       expect(updated[0]?.idleTimeoutMs).toBe(0);
 
       await vi.advanceTimersByTimeAsync(240_000);
-      await testing.runThreadBindingSweepForAccount("default");
 
       expectFields(requireBinding(manager, "thread-1"), "thread binding", {
         threadId: "thread-1",
@@ -612,7 +588,7 @@ describe("thread binding lifecycle", () => {
       const manager = createTestThreadBindingManager({
         accountId: "default",
         persist: false,
-        enableSweeper: false,
+        enableSweeper: true,
         idleTimeoutMs: 60_000,
         maxAgeMs: 0,
       });
@@ -658,7 +634,6 @@ describe("thread binding lifecycle", () => {
       hoisted.sendMessageDiscord.mockClear();
 
       await vi.advanceTimersByTimeAsync(120_000);
-      await testing.runThreadBindingSweepForAccount("default");
 
       expectFields(requireBinding(manager, "thread-2"), "thread binding", {
         threadId: "thread-2",
@@ -716,7 +691,7 @@ describe("thread binding lifecycle", () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-thread-bindings-"));
     process.env.OPENCLAW_STATE_DIR = stateDir;
     try {
-      testing.resetThreadBindingsForTests();
+      resetThreadBindingsForTests();
       vi.setSystemTime(new Date("2026-02-20T00:00:00.000Z"));
       const manager = createTestThreadBindingManager({
         accountId: "default",
@@ -740,7 +715,7 @@ describe("thread binding lifecycle", () => {
       vi.setSystemTime(touchedAt);
       manager.touchThread({ threadId: "thread-1" });
 
-      testing.resetThreadBindingsForTests();
+      resetThreadBindingsForTests();
       const reloaded = createTestThreadBindingManager({
         accountId: "default",
         persist: true,
@@ -758,7 +733,7 @@ describe("thread binding lifecycle", () => {
         }),
       ).toBe(new Date("2026-02-20T00:01:30.000Z").getTime());
     } finally {
-      testing.resetThreadBindingsForTests();
+      resetThreadBindingsForTests();
       if (previousStateDir === undefined) {
         delete process.env.OPENCLAW_STATE_DIR;
       } else {
@@ -1853,7 +1828,7 @@ describe("thread binding lifecycle", () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-thread-bindings-"));
     process.env.OPENCLAW_STATE_DIR = stateDir;
     try {
-      testing.resetThreadBindingsForTests();
+      resetThreadBindingsForTests();
       const now = Date.now();
       const store = createPluginStateSyncKeyedStoreForTests("discord", {
         namespace: "thread-bindings",
@@ -1879,7 +1854,7 @@ describe("thread binding lifecycle", () => {
       expect(removed).toHaveLength(1);
       expect(store.entries()).toStrictEqual([]);
     } finally {
-      testing.resetThreadBindingsForTests();
+      resetThreadBindingsForTests();
       if (previousStateDir === undefined) {
         delete process.env.OPENCLAW_STATE_DIR;
       } else {

--- a/extensions/discord/src/monitor/thread-bindings.manager.ts
+++ b/extensions/discord/src/monitor/thread-bindings.manager.ts
@@ -51,7 +51,6 @@ import {
   setBindingRecord,
   THREAD_BINDING_TOUCH_PERSIST_MIN_INTERVAL_MS,
   shouldDefaultPersist,
-  resetThreadBindingsForTests,
 } from "./thread-bindings.state.js";
 import {
   DEFAULT_THREAD_BINDING_IDLE_TIMEOUT_MS,
@@ -71,8 +70,6 @@ function unregisterManager(accountId: string, manager: ThreadBindingManager) {
     MANAGERS_BY_ACCOUNT_ID.delete(accountId);
   }
 }
-
-const SWEEPERS_BY_ACCOUNT_ID = new Map<string, () => Promise<void>>();
 
 function createNoopManager(accountIdRaw?: string): ThreadBindingManager {
   const accountId = normalizeAccountId(accountIdRaw);
@@ -232,8 +229,6 @@ export function createThreadBindingManager(params: {
       }
     }
   };
-  SWEEPERS_BY_ACCOUNT_ID.set(accountId, runSweepOnce);
-
   const manager: ThreadBindingManager = {
     accountId,
     getIdleTimeoutMs: () => idleTimeoutMs,
@@ -499,7 +494,6 @@ export function createThreadBindingManager(params: {
         clearInterval(sweepTimer);
         sweepTimer = null;
       }
-      SWEEPERS_BY_ACCOUNT_ID.delete(accountId);
       unregisterManager(accountId, manager);
       unregisterSessionBindingAdapter({
         channel: "discord",
@@ -543,14 +537,3 @@ export function getThreadBindingManager(accountId?: string): ThreadBindingManage
   const normalized = normalizeAccountId(accountId);
   return MANAGERS_BY_ACCOUNT_ID.get(normalized) ?? null;
 }
-
-export const testing = {
-  resolveThreadBindingThreadName,
-  resetThreadBindingsForTests,
-  runThreadBindingSweepForAccount: async (accountId?: string) => {
-    const sweep = SWEEPERS_BY_ACCOUNT_ID.get(normalizeAccountId(accountId));
-    if (sweep) {
-      await sweep();
-    }
-  },
-};

--- a/extensions/discord/src/monitor/thread-bindings.persona.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.persona.test.ts
@@ -1,10 +1,6 @@
 // Discord tests cover thread bindings.persona plugin behavior.
 import { describe, expect, it } from "vitest";
-import {
-  resolveThreadBindingPersona,
-  resolveThreadBindingPersonaFromRecord,
-} from "./thread-bindings.persona.js";
-import type { ThreadBindingRecord } from "./thread-bindings.types.js";
+import { resolveThreadBindingPersona } from "./thread-bindings.persona.js";
 
 describe("thread binding persona", () => {
   it("prefers explicit label and prefixes with gear", () => {
@@ -15,22 +11,6 @@ describe("thread binding persona", () => {
 
   it("falls back to agent id when label is missing", () => {
     expect(resolveThreadBindingPersona({ agentId: "codex" })).toBe("⚙️ codex");
-  });
-
-  it("builds persona from binding record", () => {
-    const record = {
-      accountId: "default",
-      channelId: "parent-1",
-      threadId: "thread-1",
-      targetKind: "acp",
-      targetSessionKey: "agent:codex:acp:session-1",
-      agentId: "codex",
-      boundBy: "system",
-      boundAt: Date.now(),
-      lastActivityAt: Date.now(),
-      label: "codex-thread",
-    } satisfies ThreadBindingRecord;
-    expect(resolveThreadBindingPersonaFromRecord(record)).toBe("⚙️ codex-thread");
   });
 
   it("does not split a surrogate pair at the length limit", () => {

--- a/extensions/discord/src/monitor/thread-bindings.shared-state.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.shared-state.test.ts
@@ -1,11 +1,8 @@
 // Discord tests cover thread bindings.shared state plugin behavior.
 import { beforeEach, describe, expect, it } from "vitest";
 import { EMPTY_DISCORD_TEST_CONFIG } from "../test-support/config.js";
-import {
-  testing as threadBindingsTesting,
-  createThreadBindingManager,
-  getThreadBindingManager,
-} from "./thread-bindings.js";
+import { createThreadBindingManager, getThreadBindingManager } from "./thread-bindings.js";
+import { resetThreadBindingsForTests } from "./thread-bindings.test-support.js";
 
 type ThreadBindingsModule = {
   getThreadBindingManager: typeof getThreadBindingManager;
@@ -18,7 +15,7 @@ async function loadThreadBindingsViaAlternateLoader(): Promise<ThreadBindingsMod
 
 describe("thread binding manager state", () => {
   beforeEach(() => {
-    threadBindingsTesting.resetThreadBindingsForTests();
+    resetThreadBindingsForTests();
   });
 
   it("shares managers between ESM and alternate-loaded module instances", async () => {

--- a/extensions/discord/src/monitor/thread-bindings.state.ts
+++ b/extensions/discord/src/monitor/thread-bindings.state.ts
@@ -489,19 +489,3 @@ export function resolveBindingIdsForSession(params: {
   }
   return out;
 }
-
-export function resetThreadBindingsForTests() {
-  for (const manager of MANAGERS_BY_ACCOUNT_ID.values()) {
-    manager.stop();
-  }
-  MANAGERS_BY_ACCOUNT_ID.clear();
-  BINDINGS_BY_THREAD_ID.clear();
-  BINDINGS_BY_SESSION_KEY.clear();
-  REUSABLE_WEBHOOKS_BY_ACCOUNT_CHANNEL.clear();
-  TOKENS_BY_ACCOUNT_ID.clear();
-  PERSIST_BY_ACCOUNT_ID.clear();
-  THREAD_BINDINGS_STATE.loadedBindings = false;
-  THREAD_BINDINGS_STATE.loadedPersistentBindings = false;
-  THREAD_BINDINGS_STATE.persistenceAvailable = true;
-  THREAD_BINDINGS_STATE.lastPersistedAtMs = 0;
-}

--- a/extensions/discord/src/monitor/thread-bindings.test-support.ts
+++ b/extensions/discord/src/monitor/thread-bindings.test-support.ts
@@ -1,0 +1,36 @@
+// Discord test support resets the intentionally cross-loader thread-binding registry.
+type ThreadBindingsTestState = {
+  managersByAccountId: Map<string, { stop(): void }>;
+  bindingsByThreadId: Map<string, unknown>;
+  bindingsBySessionKey: Map<string, Set<string>>;
+  tokensByAccountId: Map<string, string>;
+  reusableWebhooksByAccountChannel: Map<string, unknown>;
+  persistByAccountId: Map<string, boolean>;
+  loadedBindings: boolean;
+  loadedPersistentBindings: boolean;
+  persistenceAvailable: boolean;
+  lastPersistedAtMs: number;
+};
+
+const THREAD_BINDINGS_STATE_KEY = Symbol.for("openclaw.discordThreadBindingsState");
+
+export function resetThreadBindingsForTests() {
+  const globalStore = globalThis as Record<PropertyKey, unknown>;
+  const state = globalStore[THREAD_BINDINGS_STATE_KEY] as ThreadBindingsTestState | undefined;
+  if (!state) {
+    return;
+  }
+  for (const manager of state.managersByAccountId.values()) {
+    manager.stop();
+  }
+  state.managersByAccountId.clear();
+  state.bindingsByThreadId.clear();
+  state.bindingsBySessionKey.clear();
+  state.reusableWebhooksByAccountChannel.clear();
+  state.tokensByAccountId.clear();
+  state.persistByAccountId.clear();
+  state.loadedBindings = false;
+  state.loadedPersistentBindings = false;
+  state.persistenceAvailable = true;
+  state.lastPersistedAtMs = 0;
+}

--- a/extensions/discord/src/monitor/thread-bindings.ts
+++ b/extensions/discord/src/monitor/thread-bindings.ts
@@ -41,7 +41,6 @@ export {
 export type { AcpThreadBindingReconciliationResult } from "./thread-bindings.lifecycle.js";
 
 export {
-  testing,
   createNoopThreadBindingManager,
   createThreadBindingManager,
   getThreadBindingManager,

--- a/src/channels/plugins/contracts/test-helpers/registry-session-binding.ts
+++ b/src/channels/plugins/contracts/test-helpers/registry-session-binding.ts
@@ -62,13 +62,17 @@ const matrixSessionBindingAuth = {
   accessToken: "token",
 } as const;
 
-async function getContractApi<T extends Record<string, unknown>>(pluginId: string): Promise<T> {
-  const existing = contractApiPromises.get(pluginId);
+async function getContractApi<T extends Record<string, unknown>>(
+  pluginId: string,
+  artifact = "session-binding-contract-api",
+): Promise<T> {
+  const cacheKey = `${pluginId}:${artifact}`;
+  const existing = contractApiPromises.get(cacheKey);
   if (existing) {
     return (await existing) as T;
   }
-  const next = importBundledChannelContractArtifact<T>(pluginId, "session-binding-contract-api");
-  contractApiPromises.set(pluginId, next);
+  const next = importBundledChannelContractArtifact<T>(pluginId, artifact);
+  contractApiPromises.set(cacheKey, next);
   return await next;
 }
 
@@ -149,17 +153,13 @@ const baseSessionBindingCfg = {
 type ChannelConversationBindingManagerFactory = NonNullable<
   NonNullable<ChannelPlugin["conversationBindings"]>["createManager"]
 >;
+type ChannelConversationBindingManager = Awaited<
+  ReturnType<ChannelConversationBindingManagerFactory>
+>;
+let discordSessionBindingManager: ChannelConversationBindingManager | null = null;
 
 type DiscordContractApi = {
-  createThreadBindingManager: (params: {
-    accountId: string;
-    cfg?: OpenClawConfig;
-    persist: boolean;
-    enableSweeper: boolean;
-  }) => unknown;
-  discordThreadBindingTesting: {
-    resetThreadBindingsForTests: () => void;
-  };
+  discordPlugin: ChannelPlugin;
 };
 
 type FeishuContractApi = {
@@ -234,9 +234,27 @@ function setRegistryBackedConversationBindingPlugin(params: {
   );
 }
 
+async function getDiscordContractApi() {
+  return await getContractApi<DiscordContractApi>("discord", "channel-plugin-api");
+}
+
+async function stopDiscordSessionBindingManager() {
+  await discordSessionBindingManager?.stop();
+  discordSessionBindingManager = null;
+}
+
 async function prepareDiscordSessionBindingContract() {
-  const api = await getContractApi<DiscordContractApi>("discord");
-  api.discordThreadBindingTesting.resetThreadBindingsForTests();
+  await stopDiscordSessionBindingManager();
+  const { discordPlugin } = await getDiscordContractApi();
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: "discord",
+        plugin: discordPlugin,
+        source: "test",
+      },
+    ]),
+  );
 }
 
 async function prepareFeishuSessionBindingContract() {
@@ -338,17 +356,19 @@ const sessionBindingContractEntries = {
     targetKind: "subagent",
     label: "discord-child",
     placements: ["current", "child"],
-    preload: () => getContractApi<DiscordContractApi>("discord"),
+    preload: getDiscordContractApi,
     beforeEach: prepareDiscordSessionBindingContract,
     ensureManager: async () => {
-      const { createThreadBindingManager } = await getContractApi<DiscordContractApi>("discord");
-      createThreadBindingManager({
-        accountId: "default",
+      discordSessionBindingManager ??= await createContractChannelConversationBindingManager({
+        channelId: "discord",
         cfg: baseSessionBindingCfg,
-        persist: false,
-        enableSweeper: false,
+        accountId: "default",
       });
+      if (!discordSessionBindingManager) {
+        throw new Error("Discord session binding manager is unavailable");
+      }
     },
+    stopManager: stopDiscordSessionBindingManager,
   }),
   feishu: createSessionBindingContractEntry({
     id: "feishu",

--- a/src/channels/thread-bindings-messages.test.ts
+++ b/src/channels/thread-bindings-messages.test.ts
@@ -6,6 +6,29 @@ import {
 } from "./thread-bindings-messages.js";
 
 describe("thread-binding names", () => {
+  it("includes lifecycle details in intro text", () => {
+    const intro = resolveThreadBindingIntroText({
+      agentId: "main",
+      label: "worker",
+      idleTimeoutMs: 24 * 60 * 60 * 1000,
+      maxAgeMs: 48 * 60 * 60 * 1000,
+    });
+
+    expect(intro).toContain("idle auto-unfocus after 24h inactivity");
+    expect(intro).toContain("max age 48h");
+  });
+
+  it("places the working directory before session details", () => {
+    const intro = resolveThreadBindingIntroText({
+      agentId: "codex",
+      idleTimeoutMs: 24 * 60 * 60 * 1000,
+      sessionCwd: "/home/bob/clawd",
+      sessionDetails: ["session ids: pending (available after the first reply)"],
+    });
+
+    expect(intro).toContain("\ncwd: /home/bob/clawd\nsession ids: pending");
+  });
+
   it("does not split surrogate pairs at native name limits", () => {
     const threadName = resolveThreadBindingThreadName({
       label: `${"x".repeat(96)}🚀tail`,


### PR DESCRIPTION
## What Problem This Solves

Discord thread bindings exposed a generic production `testing` object and shipped a top-level `session-binding-contract-api.ts` sidecar solely for tests. Lifecycle tests manually invoked a private sweep function, and core contract coverage instantiated a private manager instead of using the channel plugin factory.

## Why This Change Was Made

Delete the packaged test-only sidecar and broad local `testing` export. The registry-backed contract now loads the lightweight `channel-plugin-api`, registers the real `discordPlugin`, creates the manager through `conversationBindings.createManager`, and owns manager cleanup.

Thread-binding resets move to a test-support module that clears the intentionally shared `globalThis` registry without adding a production export. Sweep tests drive the real 120-second interval with fake timers. Intro-text assertions move to the channel-neutral message owner, and a duplicate persona field-copy case is removed.

## User Impact

No user-visible behavior changes. Discord keeps the same thread-binding, sweep, persistence, and cross-loader behavior, while production/package surfaces no longer carry test APIs.

## Evidence

- 116 focused tests passed across Discord lifecycle/shared-state/persona/preflight/process, the registry-backed channel contract, and channel-neutral message ownership.
- Full OpenClaw build passed after deleting the top-level bundled-plugin artifact.
- Discord extension import-memory profile passed at 300.0 MB max RSS.
- Knip dependency, unused-file, and unused-export checks passed with zero findings.
- Discord and core test typechecks passed.
- Repository changed-file gate passed after the configured remote backend was unavailable because the `blacksmith` CLI is not installed on this host; the wrapper completed the core/extension gates locally.
- Runtime import-cycle and plugin-boundary checks passed.
- Structured autoreview found no accepted or actionable findings.
- The broad local Discord extension run is currently blocked by two 120-second ack-reaction test timeouts that reproduce identically on clean latest `main`; the changed binding-specific surfaces are green.
