### PR TITLE
refactor(opencode-go): simplify provider stream composition

### DIFF
--- a/extensions/opencode-go/index.test.ts
+++ b/extensions/opencode-go/index.test.ts
@@ -586,6 +586,12 @@ describe("opencode-go provider plugin", () => {
     );
   });
 
+  it("does not synthesize a stream when the runtime provides none", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    expect(provider.wrapStreamFn?.({ streamFn: undefined } as never)).toBeUndefined();
+  });
+
   it.each(["deepseek-v4-pro", "deepseek-v4-flash"] as const)(
     "disables invalid DeepSeek V4 reasoning_effort off payloads on OpenCode Go for %s",
     async (modelId) => {

--- a/extensions/opencode-go/stream.ts
+++ b/extensions/opencode-go/stream.ts
@@ -1,6 +1,7 @@
 // Opencode Go plugin module implements stream behavior.
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
 import {
+  composeProviderStreamWrappers,
   createDeepSeekV4OpenAICompatibleThinkingWrapper,
   createOpenAICompatibleCompletionsThinkingOffWrapper,
   createPayloadPatchStreamWrapper,
@@ -14,76 +15,6 @@ import {
   OPENCODE_GO_STREAM_IDLE_TIMEOUT_MS_DEFAULT,
 } from "./stream-termination.js";
 
-function createOpencodeGoDeepSeekV4Wrapper(
-  baseStreamFn: ProviderWrapStreamFnContext["streamFn"],
-  thinkingLevel: ProviderWrapStreamFnContext["thinkingLevel"],
-): ProviderWrapStreamFnContext["streamFn"] {
-  const flashWrapped = createDeepSeekV4OpenAICompatibleThinkingWrapper({
-    baseStreamFn,
-    thinkingLevel,
-    shouldPatchModel: (model) =>
-      model.provider === "opencode-go" && model.id === "deepseek-v4-flash",
-    resolveReasoningEffort: (level) => (level === "low" ? "low" : level === "max" ? "max" : "high"),
-  });
-  return createDeepSeekV4OpenAICompatibleThinkingWrapper({
-    baseStreamFn: flashWrapped,
-    thinkingLevel,
-    shouldPatchModel: (model) => model.provider === "opencode-go" && model.id === "deepseek-v4-pro",
-  });
-}
-
-function createOpencodeGoKimiNoReasoningWrapper(
-  baseStreamFn: ProviderWrapStreamFnContext["streamFn"],
-): ProviderWrapStreamFnContext["streamFn"] {
-  if (!baseStreamFn) {
-    return undefined;
-  }
-  return createPayloadPatchStreamWrapper(
-    baseStreamFn,
-    ({ payload }) => stripOpencodeGoKimiReasoningPayload(payload),
-    {
-      shouldPatch: ({ model }) =>
-        model.provider === "opencode-go" && isOpencodeGoKimiNoReasoningModelId(model.id),
-    },
-  );
-}
-
-function createOpencodeGoFixedAnthropicReasoningWrapper(
-  baseStreamFn: ProviderWrapStreamFnContext["streamFn"],
-): ProviderWrapStreamFnContext["streamFn"] {
-  if (!baseStreamFn) {
-    return undefined;
-  }
-  return createPayloadPatchStreamWrapper(
-    baseStreamFn,
-    ({ payload }) => {
-      delete payload.thinking;
-      delete payload.output_config;
-    },
-    {
-      shouldPatch: ({ model }) =>
-        model.provider === "opencode-go" && isOpencodeGoFixedAnthropicReasoningModelId(model.id),
-    },
-  );
-}
-
-function createOpencodeGoKimiK3ThinkingOffWrapper(
-  baseStreamFn: ProviderWrapStreamFnContext["streamFn"],
-  thinkingLevel: ProviderWrapStreamFnContext["thinkingLevel"],
-): ProviderWrapStreamFnContext["streamFn"] {
-  if (!baseStreamFn) {
-    return undefined;
-  }
-  const thinkingOff = createOpenAICompatibleCompletionsThinkingOffWrapper(
-    baseStreamFn,
-    thinkingLevel,
-  );
-  return (model, context, options) =>
-    model.provider === "opencode-go" && model.id === "kimi-k3"
-      ? thinkingOff(model, context, options)
-      : baseStreamFn(model, context, options);
-}
-
 export function createOpencodeGoWrapper(
   baseStreamFn: ProviderWrapStreamFnContext["streamFn"],
   thinkingLevel: ProviderWrapStreamFnContext["thinkingLevel"],
@@ -91,18 +22,69 @@ export function createOpencodeGoWrapper(
   if (!baseStreamFn) {
     return undefined;
   }
-  const kimiWrapped = createOpencodeGoKimiNoReasoningWrapper(baseStreamFn) ?? baseStreamFn;
-  const kimiK3Wrapped =
-    createOpencodeGoKimiK3ThinkingOffWrapper(kimiWrapped, thinkingLevel) ?? kimiWrapped;
-  const fixedAnthropicWrapped =
-    createOpencodeGoFixedAnthropicReasoningWrapper(kimiK3Wrapped) ?? kimiK3Wrapped;
-  const deepSeekWrapped =
-    createOpencodeGoDeepSeekV4Wrapper(fixedAnthropicWrapped, thinkingLevel) ??
-    fixedAnthropicWrapped;
+  const wrapped =
+    composeProviderStreamWrappers(
+      baseStreamFn,
+      (streamFn) =>
+        streamFn
+          ? createPayloadPatchStreamWrapper(
+              streamFn,
+              ({ payload }) => stripOpencodeGoKimiReasoningPayload(payload),
+              {
+                shouldPatch: ({ model }) =>
+                  model.provider === "opencode-go" && isOpencodeGoKimiNoReasoningModelId(model.id),
+              },
+            )
+          : undefined,
+      (streamFn) => {
+        if (!streamFn) {
+          return undefined;
+        }
+        const thinkingOff = createOpenAICompatibleCompletionsThinkingOffWrapper(
+          streamFn,
+          thinkingLevel,
+        );
+        return (model, context, options) =>
+          model.provider === "opencode-go" && model.id === "kimi-k3"
+            ? thinkingOff(model, context, options)
+            : streamFn(model, context, options);
+      },
+      (streamFn) =>
+        streamFn
+          ? createPayloadPatchStreamWrapper(
+              streamFn,
+              ({ payload }) => {
+                delete payload.thinking;
+                delete payload.output_config;
+              },
+              {
+                shouldPatch: ({ model }) =>
+                  model.provider === "opencode-go" &&
+                  isOpencodeGoFixedAnthropicReasoningModelId(model.id),
+              },
+            )
+          : undefined,
+      (streamFn) =>
+        createDeepSeekV4OpenAICompatibleThinkingWrapper({
+          baseStreamFn: streamFn,
+          thinkingLevel,
+          shouldPatchModel: (model) =>
+            model.provider === "opencode-go" && model.id === "deepseek-v4-flash",
+          resolveReasoningEffort: (level) =>
+            level === "low" ? "low" : level === "max" ? "max" : "high",
+        }) ?? streamFn,
+      (streamFn) =>
+        createDeepSeekV4OpenAICompatibleThinkingWrapper({
+          baseStreamFn: streamFn,
+          thinkingLevel,
+          shouldPatchModel: (model) =>
+            model.provider === "opencode-go" && model.id === "deepseek-v4-pro",
+        }) ?? streamFn,
+    ) ?? baseStreamFn;
   // Outermost layer: provider-owned stalled SSE termination so the underlying
   // OpenAI SDK request is aborted at the raw opencode-go boundary instead of
   // waiting for the shared runtime stuck-session recovery.
-  return createOpencodeGoStalledStreamWrapper(deepSeekWrapped, {
+  return createOpencodeGoStalledStreamWrapper(wrapped, {
     provider: "opencode-go",
     idleTimeoutMs: OPENCODE_GO_STREAM_IDLE_TIMEOUT_MS_DEFAULT,
     firstEventTimeoutMs: OPENCODE_GO_STREAM_FIRST_EVENT_TIMEOUT_MS_DEFAULT,


### PR DESCRIPTION
## What Problem This Solves

OpenCode Go's provider stream hook manually threaded six wrapper stages through four private one-use factories. That duplicated the Plugin SDK's existing composition mechanism and made the required wrapper order and optional-wrapper fallback behavior harder to review and maintain.

## Why This Change Was Made

The hook now composes its provider-local payload and reasoning stages with `composeProviderStreamWrappers`, while retaining the previous stream whenever an optional factory returns `undefined`. Kimi sanitization remains innermost, the DeepSeek Flash and Pro stages retain their order, and stalled-stream termination remains outermost. The four private one-use factories are removed; no Plugin SDK or public extension surface changes.

AI-assisted; the implementation and resulting diff were manually reviewed. A sanitized agent transcript was intentionally not included.

## User Impact

No user-visible behavior changes. OpenCode Go request shaping and stalled-stream handling keep the same behavior with fewer private layers and one canonical composition path.

## Evidence

- `node scripts/run-vitest.mjs extensions/opencode-go/index.test.ts extensions/opencode-go/stream-termination.test.ts src/plugin-sdk/provider-stream.test.ts` — 3 files / 61 tests passed after rebase.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs --timed -- extensions/opencode-go/stream.ts extensions/opencode-go/index.test.ts` — all `extensions` and `extensionTests` checks passed, including format, SDK API/boundaries, dead exports, production/test typechecks, lint (0 warnings/errors), and import cycles (0).
- `oxfmt --check extensions/opencode-go/stream.ts extensions/opencode-go/index.test.ts` and `git diff --check origin/main...HEAD` passed.
- Autoreview's TruffleHog preflight was clean. The Codex review engine failed before returning a verdict, so no model-review result is claimed.
