### PR TITLE
feat(backup): add whole-archive restore into a fresh staging directory

### DIFF
--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -21,6 +21,7 @@ openclaw backup create --verify
 openclaw backup create --no-include-workspace
 openclaw backup create --only-config
 openclaw backup verify ./2026-03-09T08-00-00.000+08-00-openclaw-backup.tar.gz
+openclaw backup restore ./2026-03-09T08-00-00.000+08-00-openclaw-backup.tar.gz --target ./restored-openclaw
 openclaw backup sqlite create --global --repository ~/Backups/openclaw-sqlite
 openclaw backup sqlite create --agent main --repository ~/Backups/openclaw-sqlite
 openclaw backup sqlite list --repository ~/Backups/openclaw-sqlite
@@ -36,10 +37,8 @@ openclaw backup enable --repository ~/Backups/openclaw-git --every 24h --push
 openclaw backup disable
 ```
 
-Archive `create` and `verify`, plus SQLite `create`, `list`, `verify`, and
+Archive `create`, `verify`, and `restore`, plus SQLite `create`, `list`, `verify`, and
 `restore`, accept `--json` for one machine-readable result on stdout.
-
-OpenClaw does not currently provide an `openclaw backup restore` command. Follow [Restore a full archive](/install/backups#restore-a-full-archive) for the manual, manifest-driven copy-back flow.
 
 ## Notes
 
@@ -48,6 +47,38 @@ OpenClaw does not currently provide an `openclaw backup restore` command. Follow
 - Existing archive files are never overwritten. Output paths inside the source state/workspace trees are rejected to avoid self-inclusion.
 - `openclaw backup verify <archive>` checks that the archive contains exactly one root manifest, rejects traversal-style archive paths and SQLite sidecars, confirms every manifest-declared payload exists, validates every SQLite snapshot's file shape, and runs full integrity and role checks on canonical OpenClaw databases. Dedicated plugin schemas remain opaque because they may require owner-defined SQLite capabilities. `openclaw backup create --verify` runs that validation immediately after writing the archive.
 - `openclaw backup create --only-config` backs up just the active JSON config file.
+
+## Restore a full archive
+
+Restore a complete archive into a fresh staging directory without touching the
+live state directory:
+
+```bash
+openclaw backup restore <archive.tar.gz> --target <fresh-directory>
+```
+
+The target must not exist or must be an empty directory. Restore verifies the
+archive and its SQLite databases before creating or writing the target, refuses
+a non-empty target, and removes an incomplete extraction if anything fails. It
+never restores in place and has no `--force` mode. The extracted layout retains
+the archive root, manifest, and `payload/` paths exactly as recorded in the
+archive.
+
+<Warning>
+  Restoring an archive is time travel. Messaging-channel credentials with
+  ratchet state, especially WhatsApp, may desynchronize after rollback and need
+  relinking. Approvals and delivery/dedupe state also roll back, so review
+  pending approvals before resuming the Gateway. Plugin `node_modules` trees
+  are not archived; after activation, run `openclaw plugins update <id>` or
+  reinstall with `openclaw plugins install <spec> --force`.
+</Warning>
+
+Activation is a separate offline operator step. Stop the Gateway, move the
+restored state asset into place or point `OPENCLAW_STATE_DIR` at that asset,
+then run `openclaw doctor` before restarting. Use `manifest.json` as the source
+of truth for the state, config, credentials, and workspace asset paths. See
+[Restore a full archive](/install/backups#restore-a-full-archive) for the full
+disaster-recovery sequence.
 
 ## SQLite snapshots
 

--- a/docs/install/backups.md
+++ b/docs/install/backups.md
@@ -58,6 +58,11 @@ tool before an update, reset, uninstall, or machine move, and a reasonable
 daily routine for small installs. For large workspaces or frequent backups,
 prefer snapshots or continuous replication below.
 
+On ephemeral container hosts, keep the archive outside the container and use
+`openclaw backup restore` as the disaster-recovery primitive for rebuilding a
+fresh persistent state tree. Restore stages files only; activation remains an
+explicit offline deployment step.
+
 ## Per-database snapshots
 
 ```bash
@@ -233,32 +238,29 @@ verify` checks archive structure and payload layout, but it does not
 authenticate the archive or make untrusted content safe.
 
 Before a full restore, review [What gets backed
-up](/cli/backup#what-gets-backed-up). Archives intentionally omit volatile
-files, plugin dependency trees, and installer-managed runtime roots such as
-state-local `tmp/`. Recreate those artifacts after restore.
-
-Verify before extracting, then stage the archive in a private temporary
-directory:
+up](/cli/backup#what-gets-backed-up). Then verify and extract into a fresh
+staging directory with one command:
 
 ```bash
-set -euo pipefail
-
 ARCHIVE=./2026-03-09T08-00-00.000+08-00-openclaw-backup.tar.gz
-
-openclaw backup verify "$ARCHIVE"
-
-restore_dir="$(mktemp -d -t openclaw-restore.XXXXXX)"
-trap 'rm -rf "$restore_dir"' EXIT
-
-tar -xzf "$ARCHIVE" -C "$restore_dir"
-manifest_path="$(find "$restore_dir" -mindepth 2 -maxdepth 2 -name manifest.json -print -quit)"
-test -n "$manifest_path"
-cat "$manifest_path"
+openclaw backup restore "$ARCHIVE" --target ./restored-openclaw
 ```
 
-Treat the staging directory as sensitive. It can contain credentials, auth
-profiles, sessions, and workspace data. The `trap` removes it when the shell
-exits.
+The target must not exist or must be empty. OpenClaw verifies archive structure,
+the manifest, hardlinks, and SQLite databases before it writes the target. A
+non-empty target is refused, and a failed extraction cleans its incomplete
+output. The command never touches the live state directory and has no force or
+in-place mode. Treat the restored directory as sensitive: it can contain
+credentials, auth profiles, sessions, and workspace data.
+
+<Warning>
+  Restoring an archive is time travel. Messaging-channel credentials with
+  ratchet state, especially WhatsApp, may desynchronize after rollback and need
+  relinking. Approvals and delivery/dedupe state also roll back, so review
+  pending approvals before resuming the Gateway. Plugin `node_modules` trees
+  are not archived; after activation, run `openclaw plugins update <id>` or
+  reinstall with `openclaw plugins install <spec> --force`.
+</Warning>
 
 The manifest records `archiveRoot`, the original paths under `paths`, and an
 `assets[]` list. Each asset includes its `kind`, original `sourcePath`, and
@@ -274,48 +276,13 @@ The archive layout is:
 <archive-root>/payload/relative/<relative-source-path>/...
 ```
 
-Before copying files back, stop the Gateway and any node hosts that use them.
-Make a fresh backup of the current state or move the current directories
-aside. Restore the smallest set of assets needed.
-
-For example, this restores the state asset to the current user's default
-state directory. The target stays absent until `cp -a` creates it, preserving
-the staged directory's mode and metadata:
-
-```bash
-set -euo pipefail
-
-state_archive_path="$(
-  node -e 'const fs = require("node:fs"); const manifest = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(manifest.assets.find((asset) => asset.kind === "state")?.archivePath ?? "");' "$manifest_path"
-)"
-test -n "$state_archive_path"
-
-state_source="$restore_dir/$state_archive_path"
-state_target="$HOME/.openclaw"
-state_backup="$HOME/.openclaw.pre-restore.$(date +%s)"
-
-test -d "$state_source"
-openclaw gateway stop
-
-if [ -e "$state_target" ] || [ -L "$state_target" ]; then
-  mv "$state_target" "$state_backup"
-fi
-test ! -e "$state_target"
-test ! -L "$state_target"
-cp -a "$state_source" "$state_target"
-
-openclaw doctor
-openclaw gateway start
-openclaw health
-openclaw status
-```
-
-For a same-machine restore, the manifest `sourcePath` values are usually the
-intended targets. On a new machine or under a different home directory,
-choose the new targets first, then copy only the matching asset payloads.
-Typical full-restore targets are the state directory, active config file,
-credentials directory, and workspace directories. See
-[Updating](/install/updating#rollback) for the rollback workflow.
+To activate, stop the Gateway and any node hosts that use the restored files.
+Make a fresh backup of current state or move it aside. Then move the extracted
+state asset into place, or point `OPENCLAW_STATE_DIR` at that asset, and run
+`openclaw doctor` before restarting the Gateway. On a new machine or under a
+different home directory, use the manifest to map config, credentials, and
+workspace assets to their new paths. See [Updating](/install/updating#rollback)
+for the rollback workflow.
 
 ### Restore a database
 

--- a/src/cli/program/core-command-descriptors.ts
+++ b/src/cli/program/core-command-descriptors.ts
@@ -45,7 +45,7 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "backup",
-    description: "Create and verify backup archives and SQLite snapshots",
+    description: "Create, verify, and restore backup archives and SQLite snapshots",
     hasSubcommands: true,
   },
   {

--- a/src/cli/program/register.backup.test.ts
+++ b/src/cli/program/register.backup.test.ts
@@ -5,6 +5,7 @@ import { registerBackupCommand } from "./register.backup.js";
 
 const mocks = vi.hoisted(() => ({
   backupCreateCommand: vi.fn(),
+  backupRestoreCommand: vi.fn(),
   backupSqliteCreateCommand: vi.fn(),
   backupSqliteListCommand: vi.fn(),
   backupSqliteRestoreCommand: vi.fn(),
@@ -18,6 +19,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 const backupCreateCommand = mocks.backupCreateCommand;
+const backupRestoreCommand = mocks.backupRestoreCommand;
 const backupSqliteCreateCommand = mocks.backupSqliteCreateCommand;
 const backupSqliteListCommand = mocks.backupSqliteListCommand;
 const backupSqliteRestoreCommand = mocks.backupSqliteRestoreCommand;
@@ -27,6 +29,10 @@ const runtime = mocks.runtime;
 
 vi.mock("../../commands/backup.js", () => ({
   backupCreateCommand: mocks.backupCreateCommand,
+}));
+
+vi.mock("../../commands/backup-restore.js", () => ({
+  backupRestoreCommand: mocks.backupRestoreCommand,
 }));
 
 vi.mock("../../commands/backup-verify.js", () => ({
@@ -54,6 +60,7 @@ describe("registerBackupCommand", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     backupCreateCommand.mockResolvedValue(undefined);
+    backupRestoreCommand.mockResolvedValue(undefined);
     backupSqliteCreateCommand.mockResolvedValue(undefined);
     backupSqliteListCommand.mockResolvedValue(undefined);
     backupSqliteRestoreCommand.mockResolvedValue(undefined);
@@ -111,6 +118,24 @@ describe("registerBackupCommand", () => {
     const options = expectForwardedOptions(backupVerifyCommand);
     expect(options.archive).toBe("/tmp/openclaw-backup.tar.gz");
     expect(options.json).toBe(true);
+  });
+
+  it("runs whole-archive restore with forwarded options", async () => {
+    await runCli([
+      "backup",
+      "restore",
+      "/tmp/openclaw-backup.tar.gz",
+      "--target",
+      "/tmp/restored-openclaw",
+      "--json",
+    ]);
+
+    const options = expectForwardedOptions(backupRestoreCommand);
+    expect(options).toEqual({
+      archive: "/tmp/openclaw-backup.tar.gz",
+      target: "/tmp/restored-openclaw",
+      json: true,
+    });
   });
 
   it("registers the SQLite snapshot command group", () => {

--- a/src/cli/program/register.backup.ts
+++ b/src/cli/program/register.backup.ts
@@ -9,6 +9,7 @@ import {
   backupGitRestoreCommand,
   backupGitVerifyCommand,
 } from "../../commands/backup-git.js";
+import { backupRestoreCommand } from "../../commands/backup-restore.js";
 import { backupDisableCommand, backupEnableCommand } from "../../commands/backup-schedule.js";
 import {
   backupSqliteCreateCommand,
@@ -27,7 +28,7 @@ import { formatHelpExamples } from "../help-format.js";
 export function registerBackupCommand(program: Command) {
   const backup = program
     .command("backup")
-    .description("Create and verify backup archives and SQLite snapshots")
+    .description("Create, verify, and restore backup archives and SQLite snapshots")
     .addHelpText(
       "after",
       () =>
@@ -102,6 +103,35 @@ export function registerBackupCommand(program: Command) {
       await runCommandWithRuntime(defaultRuntime, async () => {
         await backupVerifyCommand(defaultRuntime, {
           archive: archive as string,
+          json: Boolean(opts.json),
+        });
+      });
+    });
+
+  backup
+    .command("restore <archive>")
+    .description("Restore a verified backup archive to a fresh staging directory")
+    .requiredOption("--target <dir>", "Fresh target directory; non-empty directories are refused")
+    .option("--json", "Output JSON", false)
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          [
+            "openclaw backup restore ~/Backups/latest.tar.gz --target ./restored-openclaw",
+            "Verify, then extract the whole archive into a fresh staging directory.",
+          ],
+          [
+            "openclaw backup restore ~/Backups/latest.tar.gz --target ./restored-openclaw --json",
+            "Emit machine-readable restore details and rollback warnings.",
+          ],
+        ])}`,
+    )
+    .action(async (archive, opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await backupRestoreCommand(defaultRuntime, {
+          archive: archive as string,
+          target: opts.target as string,
           json: Boolean(opts.json),
         });
       });

--- a/src/commands/backup-restore.test.ts
+++ b/src/commands/backup-restore.test.ts
@@ -1,0 +1,276 @@
+// Backup restore tests cover verified whole-archive extraction and fresh-target safety.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { gzipSync } from "node:zlib";
+import * as tar from "tar";
+import { describe, expect, it, vi } from "vitest";
+import { createBackupArchive } from "../infra/backup-create.js";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import type { RuntimeEnv } from "../runtime.js";
+import {
+  closeOpenClawStateDatabase,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { backupRestoreCommand } from "./backup-restore.js";
+import { buildBackupArchivePath } from "./backup-shared.js";
+
+function createRuntime(): RuntimeEnv {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
+}
+
+async function listArchiveLeafEntries(archivePath: string): Promise<string[]> {
+  const entries: string[] = [];
+  await tar.t({
+    file: archivePath,
+    gzip: true,
+    onReadEntry: (entry) => {
+      if (entry.type !== "Directory") {
+        entries.push(entry.path.replace(/\/+$/u, ""));
+      }
+    },
+  });
+  return entries.toSorted();
+}
+
+async function listFilesystemLeafEntries(root: string, relative = ""): Promise<string[]> {
+  const entries: string[] = [];
+  for (const entry of await fs.readdir(path.join(root, relative), { withFileTypes: true })) {
+    const child = path.join(relative, entry.name);
+    if (entry.isDirectory()) {
+      entries.push(...(await listFilesystemLeafEntries(root, child)));
+    } else {
+      entries.push(child.split(path.sep).join("/"));
+    }
+  }
+  return entries.toSorted();
+}
+
+function encodeTarEntry(params: {
+  path: string;
+  contents?: string;
+  type?: "File" | "Directory" | "Link";
+  linkpath?: string;
+}): Buffer {
+  const body = Buffer.from(params.contents ?? "", "utf8");
+  const type = params.type ?? "File";
+  const header = new tar.Header({
+    path: params.path,
+    type,
+    size: type === "File" ? body.length : 0,
+    mode: type === "Directory" ? 0o700 : 0o600,
+    uid: 0,
+    gid: 0,
+    mtime: new Date(0),
+    ...(params.linkpath ? { linkpath: params.linkpath } : {}),
+  });
+  const headerBlock = Buffer.alloc(512);
+  header.encode(headerBlock);
+  if (type !== "File") {
+    return headerBlock;
+  }
+  return Buffer.concat([headerBlock, body, Buffer.alloc((512 - (body.length % 512)) % 512)]);
+}
+
+async function writeArchive(params: {
+  archivePath: string;
+  archiveRoot: string;
+  payloadPath: string;
+  manifest?: string;
+  extraEntries?: Buffer[];
+}): Promise<void> {
+  const manifest =
+    params.manifest ??
+    `${JSON.stringify({
+      schemaVersion: 1,
+      createdAt: "2026-08-12T00:00:00.000Z",
+      archiveRoot: params.archiveRoot,
+      runtimeVersion: "test",
+      platform: process.platform,
+      nodeVersion: process.version,
+      assets: [
+        {
+          kind: "config",
+          sourcePath: "/tmp/openclaw.json",
+          archivePath: params.payloadPath,
+        },
+      ],
+    })}\n`;
+  await fs.writeFile(
+    params.archivePath,
+    gzipSync(
+      Buffer.concat([
+        encodeTarEntry({ path: `${params.archiveRoot}/manifest.json`, contents: manifest }),
+        encodeTarEntry({ path: params.payloadPath, contents: "{}\n" }),
+        ...(params.extraEntries ?? []),
+        Buffer.alloc(1024),
+      ]),
+    ),
+  );
+}
+
+describe("backupRestoreCommand", () => {
+  it("round-trips a backup into a fresh target with matching inventory and readable databases", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-restore-roundtrip-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const outputDir = state.path("backups");
+        const targetPath = state.path("restored");
+        await fs.mkdir(outputDir, { recursive: true });
+        await state.writeText("operator-note.txt", "restore me\n");
+        openOpenClawStateDatabase({ env: state.env });
+
+        try {
+          const backup = await createBackupArchive({
+            output: outputDir,
+            includeWorkspace: false,
+            nowMs: Date.UTC(2026, 7, 12, 12, 0, 0),
+          });
+          const runtime = createRuntime();
+          const restored = await backupRestoreCommand(runtime, {
+            archive: backup.archivePath,
+            target: targetPath,
+            json: true,
+          });
+
+          expect(restored).toMatchObject({
+            ok: true,
+            archivePath: backup.archivePath,
+            targetPath,
+            archiveRoot: backup.archiveRoot,
+            assetCount: 1,
+          });
+          expect(restored.warnings.join("\n")).toMatch(/time travel/iu);
+          expect(restored.warnings.join("\n")).toMatch(/WhatsApp/iu);
+          expect(restored.warnings.join("\n")).toMatch(/pending approvals/iu);
+          expect(restored.warnings.join("\n")).toMatch(/plugins install <spec> --force/iu);
+          expect(runtime.log).toHaveBeenCalledOnce();
+          expect(JSON.parse(String(vi.mocked(runtime.log).mock.calls[0]?.[0]))).toEqual(restored);
+
+          expect(await listFilesystemLeafEntries(targetPath)).toEqual(
+            await listArchiveLeafEntries(backup.archivePath),
+          );
+          const databaseEntry = (await listArchiveLeafEntries(backup.archivePath)).find((entry) =>
+            entry.endsWith("/state/openclaw.sqlite"),
+          );
+          expect(databaseEntry).toBeDefined();
+          const sqlite = requireNodeSqlite();
+          const database = new sqlite.DatabaseSync(path.join(targetPath, databaseEntry ?? ""), {
+            readOnly: true,
+          });
+          try {
+            expect(database.prepare("PRAGMA integrity_check").get()).toEqual({
+              integrity_check: "ok",
+            });
+          } finally {
+            database.close();
+          }
+        } finally {
+          closeOpenClawStateDatabase();
+        }
+      },
+    );
+  });
+
+  it("accepts an empty directory and refuses a non-empty target", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-restore-target-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const archivePath = state.path("backup.tar.gz");
+        const emptyTarget = state.path("empty-target");
+        const nonEmptyTarget = state.path("non-empty-target");
+        const archiveRoot = "2026-08-12T00-00-00.000Z-openclaw-backup";
+        const payloadPath = buildBackupArchivePath(archiveRoot, "/tmp/openclaw.json");
+        await writeArchive({ archivePath, archiveRoot, payloadPath });
+        await fs.mkdir(emptyTarget);
+        await fs.mkdir(nonEmptyTarget);
+        await fs.writeFile(path.join(nonEmptyTarget, "keep.txt"), "keep\n");
+
+        await expect(
+          backupRestoreCommand(createRuntime(), { archive: archivePath, target: emptyTarget }),
+        ).resolves.toMatchObject({ targetPath: emptyTarget });
+        await expect(
+          backupRestoreCommand(createRuntime(), { archive: archivePath, target: nonEmptyTarget }),
+        ).rejects.toThrow(/target directory must be empty/iu);
+        await expect(fs.readFile(path.join(nonEmptyTarget, "keep.txt"), "utf8")).resolves.toBe(
+          "keep\n",
+        );
+      },
+    );
+  });
+
+  it("verifies a corrupt archive before touching an empty target", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-restore-corrupt-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const archivePath = state.path("corrupt.tar.gz");
+        const targetPath = state.path("restore-target");
+        const archiveRoot = "2026-08-12T00-00-00.000Z-openclaw-backup";
+        const payloadPath = buildBackupArchivePath(archiveRoot, "/tmp/openclaw.json");
+        await writeArchive({
+          archivePath,
+          archiveRoot,
+          payloadPath,
+          manifest: "{not-json}\n",
+        });
+        await fs.mkdir(targetPath);
+
+        await expect(
+          backupRestoreCommand(createRuntime(), { archive: archivePath, target: targetPath }),
+        ).rejects.toThrow(/manifest is not valid JSON/iu);
+        await expect(fs.readdir(targetPath)).resolves.toEqual([]);
+      },
+    );
+  });
+
+  it("cleans an incomplete fresh target when extraction fails", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-restore-cleanup-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const archivePath = state.path("unextractable.tar.gz");
+        const targetPath = state.path("restore-target");
+        const archiveRoot = "2026-08-12T00-00-00.000Z-openclaw-backup";
+        const assetPath = buildBackupArchivePath(archiveRoot, "/tmp/openclaw.json");
+        const directoryPath = `${archiveRoot}/payload/invalid-hardlink-target`;
+        await writeArchive({
+          archivePath,
+          archiveRoot,
+          payloadPath: assetPath,
+          extraEntries: [
+            encodeTarEntry({ path: directoryPath, type: "Directory" }),
+            encodeTarEntry({
+              path: `${archiveRoot}/payload/directory-hardlink`,
+              type: "Link",
+              linkpath: directoryPath,
+            }),
+          ],
+        });
+
+        await expect(
+          backupRestoreCommand(createRuntime(), { archive: archivePath, target: targetPath }),
+        ).rejects.toThrow(/incomplete target was cleaned/iu);
+        await expect(fs.lstat(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+      },
+    );
+  });
+});

--- a/src/commands/backup-restore.ts
+++ b/src/commands/backup-restore.ts
@@ -1,0 +1,145 @@
+// Restores one verified whole-archive backup into a fresh staging directory.
+import fs from "node:fs/promises";
+import path from "node:path";
+import * as tar from "tar";
+import { resolveStateDir } from "../config/config.js";
+import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
+import { resolveUserPath, shortenHomePath } from "../utils.js";
+import { BACKUP_MAX_DECOMPRESSION_RATIO, canonicalizePathForContainment } from "./backup-shared.js";
+import { verifyBackupArchive } from "./backup-verify.js";
+import { isPathWithin } from "./cleanup-utils.js";
+
+const BACKUP_RESTORE_WARNINGS = [
+  "Restoring an archive is time travel: every restored state surface rolls back to the archive timestamp.",
+  "Messaging-channel credentials with ratchet state, especially WhatsApp, may desynchronize after rollback and require relinking.",
+  "Approvals and delivery/dedupe state also roll back; review pending approvals before resuming the Gateway.",
+  "Plugin node_modules are not archived; after activation, run `openclaw plugins update <id>` or reinstall with `openclaw plugins install <spec> --force`.",
+] as const;
+
+type BackupRestoreOptions = {
+  archive: string;
+  target?: string;
+  json?: boolean;
+};
+
+type BackupRestoreResult = {
+  ok: true;
+  archivePath: string;
+  targetPath: string;
+  archiveRoot: string;
+  createdAt: string;
+  runtimeVersion: string;
+  assetCount: number;
+  entryCount: number;
+  warnings: string[];
+};
+
+function resolveRequiredTarget(value: string | undefined): string {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    throw new Error("Missing required --target value.");
+  }
+  return path.resolve(resolveUserPath(trimmed));
+}
+
+async function assertTargetOutsideLiveState(targetPath: string): Promise<void> {
+  const [canonicalTarget, canonicalStateDir] = await Promise.all([
+    canonicalizePathForContainment(targetPath),
+    canonicalizePathForContainment(resolveStateDir()),
+  ]);
+  if (isPathWithin(canonicalTarget, canonicalStateDir)) {
+    throw new Error(
+      `Backup restore target must be outside the live OpenClaw state directory: ${targetPath}`,
+    );
+  }
+}
+
+async function prepareRestoreTarget(targetPath: string): Promise<{ created: boolean }> {
+  try {
+    const stat = await fs.lstat(targetPath);
+    if (!stat.isDirectory()) {
+      throw new Error(`Backup restore target must be a directory: ${targetPath}`);
+    }
+    if ((await fs.readdir(targetPath)).length > 0) {
+      throw new Error(`Backup restore target directory must be empty: ${targetPath}`);
+    }
+    return { created: false };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  await fs.mkdir(targetPath, { recursive: true, mode: 0o700 });
+  return { created: true };
+}
+
+async function cleanupFailedRestore(targetPath: string, created: boolean): Promise<void> {
+  if (created) {
+    await fs.rm(targetPath, { recursive: true, force: true });
+    return;
+  }
+  for (const entry of await fs.readdir(targetPath)) {
+    await fs.rm(path.join(targetPath, entry), { recursive: true, force: true });
+  }
+}
+
+function formatRestoreResult(result: BackupRestoreResult): string {
+  return [
+    `Backup archive restored to staging: ${shortenHomePath(result.targetPath)}`,
+    `Verified archive: ${shortenHomePath(result.archivePath)}`,
+    `Archive root: ${result.archiveRoot}`,
+    `Archive entries restored: ${result.entryCount}`,
+    "",
+    "Rollback warnings:",
+    ...result.warnings.map((warning) => `- ${warning}`),
+    "",
+    "Activation is explicit: stop the Gateway, move the restored asset tree into place or point OPENCLAW_STATE_DIR at the restored state asset, then run `openclaw doctor`.",
+  ].join("\n");
+}
+
+/** Verify first, then extract a whole backup archive into a fresh staging directory. */
+export async function backupRestoreCommand(
+  runtime: RuntimeEnv,
+  options: BackupRestoreOptions,
+): Promise<BackupRestoreResult> {
+  const targetPath = resolveRequiredTarget(options.target);
+  await assertTargetOutsideLiveState(targetPath);
+  const verified = await verifyBackupArchive(options.archive);
+  const target = await prepareRestoreTarget(targetPath);
+
+  try {
+    await tar.x({
+      file: verified.archivePath,
+      gzip: true,
+      maxDecompressionRatio: BACKUP_MAX_DECOMPRESSION_RATIO,
+      cwd: targetPath,
+      strict: true,
+      preserveOwner: false,
+    });
+  } catch (error) {
+    try {
+      await cleanupFailedRestore(targetPath, target.created);
+    } catch (cleanupError) {
+      throw new Error(
+        `Backup restore failed and the incomplete target could not be cleaned: ${targetPath}`,
+        { cause: cleanupError },
+      );
+    }
+    throw new Error(`Backup restore failed; the incomplete target was cleaned: ${targetPath}`, {
+      cause: error,
+    });
+  }
+
+  const result: BackupRestoreResult = {
+    ...verified,
+    targetPath,
+    warnings: [...BACKUP_RESTORE_WARNINGS],
+  };
+  if (options.json) {
+    writeRuntimeJson(runtime, result);
+  } else {
+    runtime.log(formatRestoreResult(result));
+  }
+  return result;
+}

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -10,6 +10,10 @@ import {
 import { pathExists, shortenHomePath } from "../utils.js";
 import { buildCleanupPlan, isPathWithin } from "./cleanup-utils.js";
 
+// DEFLATE can legitimately encode zero-filled sparse ranges just over 1000:1.
+// Keep bounded headroom without disabling node-tar's decompression bomb guard.
+export const BACKUP_MAX_DECOMPRESSION_RATIO = 1100;
+
 type BackupAssetKind = "state" | "config" | "credentials" | "workspace";
 type BackupSkipReason = "covered" | "missing";
 
@@ -273,6 +277,27 @@ async function canonicalizeExistingPath(targetPath: string): Promise<string> {
     return await fs.realpath(targetPath);
   } catch {
     return path.resolve(targetPath);
+  }
+}
+
+/** Resolve symlinks in the existing prefix while retaining a not-yet-created suffix. */
+export async function canonicalizePathForContainment(targetPath: string): Promise<string> {
+  const resolved = path.resolve(targetPath);
+  const suffix: string[] = [];
+  let probe = resolved;
+
+  while (true) {
+    try {
+      const realProbe = await fs.realpath(probe);
+      return suffix.length === 0 ? realProbe : path.join(realProbe, ...suffix.toReversed());
+    } catch {
+      const parent = path.dirname(probe);
+      if (parent === probe) {
+        return resolved;
+      }
+      suffix.push(path.basename(probe));
+      probe = parent;
+    }
   }
 }
 

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -13,15 +13,12 @@ import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { isRecord, resolveUserPath } from "../utils.js";
-import { buildBackupArchivePath } from "./backup-shared.js";
+import { BACKUP_MAX_DECOMPRESSION_RATIO, buildBackupArchivePath } from "./backup-shared.js";
 
 const WINDOWS_ABSOLUTE_ARCHIVE_PATH_RE = /^[A-Za-z]:[\\/]/;
 const MAX_MANIFEST_BYTES = 1024 * 1024;
 const MAX_SQLITE_SNAPSHOT_EXTRACT_BYTES = 64 * 1024 * 1024 * 1024;
 const SQLITE_SNAPSHOT_FREE_SPACE_RESERVE_BYTES = 256 * 1024 * 1024;
-// DEFLATE can legitimately encode zero-filled sparse ranges just over 1000:1.
-// Keep bounded headroom without disabling node-tar's decompression bomb guard.
-const BACKUP_MAX_DECOMPRESSION_RATIO = 1100;
 const SQLITE_SNAPSHOT_SIDECAR_SUFFIXES = ["-wal", "-shm", "-journal"] as const;
 
 type BackupManifestAsset = {
@@ -712,12 +709,9 @@ async function verifySqliteSnapshots(params: {
   }
 }
 
-/** Verify a backup archive, including snapshot shape and canonical SQLite integrity checks. */
-export async function backupVerifyCommand(
-  runtime: RuntimeEnv,
-  opts: BackupVerifyOptions,
-): Promise<BackupVerifyResult> {
-  const archivePath = resolveUserPath(opts.archive);
+/** Verify a backup archive and return its normalized, integrity-checked inventory. */
+export async function verifyBackupArchive(archive: string): Promise<BackupVerifyResult> {
+  const archivePath = resolveUserPath(archive);
   const rawEntries = await listArchiveEntries(archivePath);
   if (rawEntries.length === 0) {
     throw new Error("Backup archive is empty.");
@@ -778,6 +772,16 @@ export async function backupVerifyCommand(
     assetCount: manifest.assets.length,
     entryCount: rawEntries.length,
   };
+
+  return result;
+}
+
+/** Verify a backup archive, including snapshot shape and canonical SQLite integrity checks. */
+export async function backupVerifyCommand(
+  runtime: RuntimeEnv,
+  opts: BackupVerifyOptions,
+): Promise<BackupVerifyResult> {
+  const result = await verifyBackupArchive(opts.archive);
 
   if (opts.json) {
     writeRuntimeJson(runtime, result);

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -8,6 +8,7 @@ import {
   buildBackupArchiveBasename,
   buildBackupArchivePath,
   buildBackupArchiveRoot,
+  canonicalizePathForContainment,
   type BackupAsset,
   resolveBackupPlanFromDisk,
 } from "../commands/backup-shared.js";
@@ -211,26 +212,6 @@ async function chooseBackupTempRoot(params: {
     );
   }
   return fallback;
-}
-
-async function canonicalizePathForContainment(targetPath: string): Promise<string> {
-  const resolved = path.resolve(targetPath);
-  const suffix: string[] = [];
-  let probe = resolved;
-
-  while (true) {
-    try {
-      const realProbe = await fs.realpath(probe);
-      return suffix.length === 0 ? realProbe : path.join(realProbe, ...suffix.toReversed());
-    } catch {
-      const parent = path.dirname(probe);
-      if (parent === probe) {
-        return resolved;
-      }
-      suffix.push(path.basename(probe));
-      probe = parent;
-    }
-  }
 }
 
 function buildManifest(params: {


### PR DESCRIPTION
## What Problem This Solves

`openclaw backup` produces whole archives (state directory, config, external `credentials/`, workspaces) and can `verify` them — but nothing can restore one. `backup sqlite restore` handles exactly one database snapshot. Disaster recovery on ephemeral hosts (containers, cloud instances) has no supported path from "I have a verified archive" to "I have a state tree again."

Fourth step of the cloud-container deployment track (#122477, #122530, #122662).

## Why This Change Was Made

Adds `openclaw backup restore <archive> --target <dir>`:

- **Verify first, extract second** — reuses the exact verification machinery `backup verify` runs (integrity, manifest, decompression-ratio bound) before any byte lands on disk.
- **Fresh staging only** — the target must not exist or be an empty directory, and must be outside the live OpenClaw state directory. Never in-place; activation stays an explicit operator step (stop Gateway, move tree / point `OPENCLAW_STATE_DIR`, run `openclaw doctor`).
- **Fail closed** — a failed extraction cleans the incomplete target (created directories removed, pre-existing empty dirs emptied).
- **Rollback warnings are product surface, not a docs footnote.** Restore output states plainly: restoring is time travel; ratchet-bearing channel credentials (WhatsApp) may desynchronize and need relinking; approvals and delivery/dedupe state roll back and pending approvals should be reviewed before resuming; plugin `node_modules` are not archived and need `plugins update`/`install --force` after activation. Same content in `--json`.
- Shared plumbing consolidated: `backup-verify` now exposes the reusable `verifyBackupArchive`, and duplicated containment/ratio helpers moved to `backup-shared`.

## User Impact

- Operators get a supported, safe DR restore for whole backups; previously this required hand-untarring an archive with no verification and no rollback guidance.
- No changes to backup creation, archive format, manifests, or `backup sqlite` behavior. No new config surface.

## Evidence

- Restore/verifier suites: 32 passed, 1 skipped; CLI registration: 9 passed (round-trip backup→restore→inventory match, non-empty-target refusal, corrupt-archive refusal via verify-first, `--json` shape, cleanup-on-failure).
- `tsgo:core` + `tsgo:core:test` lanes, touched-file oxlint, formatting, `git diff --check`: pass.
- Full `pnpm build` green locally (remote build backend unavailable — Blacksmith binary missing and two Crabbox AWS sync attempts failed on `git --unshallow`; local fallback per repo validation routing), zero `INEFFECTIVE_DYNAMIC_IMPORT`, built-CLI smoke of the new command.
- Autoreview: clean, no actionable findings.
