### PR TITLE
fix(ci): seed plugin update ownership metadata

### DIFF
--- a/scripts/e2e/lib/plugin-update/probe.mjs
+++ b/scripts/e2e/lib/plugin-update/probe.mjs
@@ -43,9 +43,25 @@ function writeJson(file, value) {
 }
 
 function seedInstallState() {
-  writeJson(openclawPath("extensions", "lossless-claw", "package.json"), {
+  const pluginRoot = openclawPath("extensions", "lossless-claw");
+  const pluginSource = path.join(pluginRoot, "index.js");
+  const pluginManifest = path.join(pluginRoot, "openclaw.plugin.json");
+  writeJson(path.join(pluginRoot, "package.json"), {
     name: "@example/lossless-claw",
     version: "0.9.0",
+    type: "module",
+    openclaw: {
+      extensions: ["./index.js"],
+    },
+  });
+  fs.writeFileSync(
+    pluginSource,
+    'export default { id: "lossless-claw", register() {} };\n',
+    "utf8",
+  );
+  writeJson(pluginManifest, {
+    id: "lossless-claw",
+    configSchema: { type: "object" },
   });
   writeJson(process.env.OPENCLAW_CONFIG_PATH, { plugins: {} });
   writePluginInstallIndexForE2E({
@@ -68,7 +84,36 @@ function seedInstallState() {
         shasum: "same",
       },
     },
-    plugins: [],
+    plugins: [
+      {
+        pluginId: "lossless-claw",
+        manifestPath: pluginManifest,
+        manifestHash: "docker-e2e",
+        source: pluginSource,
+        rootDir: pluginRoot,
+        origin: "global",
+        enabled: true,
+        startup: {
+          sidecar: false,
+          memory: false,
+          agentHarnesses: [],
+          configPaths: [],
+        },
+        contributions: {
+          channels: [],
+          channelConfigs: [],
+          providers: [],
+          modelCatalogProviders: [],
+          modelSupportPrefixes: [],
+          modelSupportPatterns: [],
+          autoEnableProviderIds: [],
+          commandAliases: [],
+          contracts: {},
+        },
+        compat: [],
+        installOwner: "lossless-claw",
+      },
+    ],
     diagnostics: [],
   });
 }

--- a/test/scripts/plugin-update-unchanged-docker.test.ts
+++ b/test/scripts/plugin-update-unchanged-docker.test.ts
@@ -4,8 +4,11 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "no
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
+import { loadInstalledPluginIndex } from "../../src/plugins/installed-plugin-index.js";
+import { resolveInstalledPluginPackageOwnership } from "../../src/plugins/installed-plugin-package-ownership.js";
 
 const PLUGIN_UPDATE_DOCKER_SCRIPT = "scripts/e2e/plugin-update-unchanged-docker.sh";
 const PLUGIN_UPDATE_SCENARIO_SCRIPT = "scripts/e2e/lib/plugin-update/unchanged-scenario.sh";
@@ -13,6 +16,29 @@ const CORRUPT_UPDATE_SCENARIO_SCRIPT = "scripts/e2e/lib/plugin-update/corrupt-up
 const PLUGIN_UPDATE_PROBE_SCRIPT = "scripts/e2e/lib/plugin-update/probe.mjs";
 const PLUGIN_UPDATE_REGISTRY_SCRIPT = "scripts/e2e/lib/plugin-update/registry-server.mjs";
 const CORRUPT_PLUGIN_ID = "demo-corrupt-plugin";
+const PLUGIN_INDEX_MODULE_URL = pathToFileURL(
+  path.resolve("scripts/e2e/lib/plugin-index-sqlite.mjs"),
+).href;
+
+function seedInstallState(root: string) {
+  const stateDir = path.join(root, ".openclaw");
+  const configPath = path.join(stateDir, "openclaw.json");
+  const env = {
+    ...process.env,
+    HOME: root,
+    OPENCLAW_CONFIG_PATH: configPath,
+    OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+    OPENCLAW_STATE_DIR: stateDir,
+    OPENCLAW_VERSION: "2026.8.1",
+    VITEST: "true",
+  };
+  execFileSync("node", [PLUGIN_UPDATE_PROBE_SCRIPT, "seed"], {
+    encoding: "utf8",
+    env,
+    stdio: "pipe",
+  });
+  return { configPath, env, stateDir };
+}
 
 function runProbe(command: string, payload: unknown): void {
   const root = mkdtempSync(path.join(tmpdir(), "openclaw-plugin-update-probe-"));
@@ -75,7 +101,7 @@ async function waitForPortFile(portFile: string): Promise<number> {
 }
 
 describe("plugin update unchanged Docker E2E", () => {
-  it("seeds current plugin install ledger state before checking config stability", () => {
+  it("seeds current plugin install ledger state before checking config stability", async () => {
     const runner = readFileSync(PLUGIN_UPDATE_DOCKER_SCRIPT, "utf8");
     const scenario = readFileSync(PLUGIN_UPDATE_SCENARIO_SCRIPT, "utf8");
     const probe = readFileSync(PLUGIN_UPDATE_PROBE_SCRIPT, "utf8");
@@ -88,6 +114,48 @@ describe("plugin update unchanged Docker E2E", () => {
     );
     expect(probe).toContain("installRecords: {");
     expect(probe).toContain('"lossless-claw": {');
+
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-plugin-update-seed-"));
+    try {
+      const { configPath, env, stateDir } = seedInstallState(root);
+      const config = JSON.parse(readFileSync(configPath, "utf8")) as {
+        plugins?: Record<string, unknown>;
+      };
+      expect(config).toEqual({ plugins: {} });
+
+      const { readPluginInstallIndex } = await import(PLUGIN_INDEX_MODULE_URL);
+      const persisted = readPluginInstallIndex({ configPath, stateDir });
+      expect(persisted.installRecords).toMatchObject({
+        "lossless-claw": {
+          source: "npm",
+          installPath: "~/.openclaw/extensions/lossless-claw",
+        },
+      });
+      expect(persisted.plugins).toEqual([
+        expect.objectContaining({
+          pluginId: "lossless-claw",
+          installOwner: "lossless-claw",
+          rootDir: path.join(stateDir, "extensions", "lossless-claw"),
+        }),
+      ]);
+
+      const liveIndex = loadInstalledPluginIndex({
+        config,
+        env,
+        stateDir,
+      });
+      expect(resolveInstalledPluginPackageOwnership(liveIndex, "lossless-claw", env)).toMatchObject(
+        {
+          ok: true,
+          value: {
+            installOwner: "lossless-claw",
+            pluginIds: ["lossless-claw"],
+          },
+        },
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("bounds the update command and prints diagnostics on hangs", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the plugin-update Docker qualification would reject its seeded npm plugin as having no authoritative runtime child list. The fixture persisted the package install owner but left `plugins` empty, so the fail-closed package ownership resolver could not prove that `lossless-claw` belonged to that install.

## Why This Change Was Made

The fixture now seeds a realistic single-entry plugin package and a matching persisted child row owned by `lossless-claw`. The focused regression executes the real seed in isolated state, checks the SQLite ledger, rebuilds the live installed-plugin index, and proves package ownership resolves to `pluginIds: ["lossless-claw"]`.

No production resolver, retry, timeout, controller, or unrelated plugin lifecycle behavior changes.

## User Impact

No production behavior change. Maintainers regain reliable packaged plugin-update qualification without weakening ownership validation.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/plugin-update-unchanged-docker.test.ts` - 9 tests passed.
- `pnpm lint:docker-e2e` - passed.
- Targeted OXLint and Oxfmt checks - passed.
- Local ClawSweeper exact-range review - no findings; production LOC +0.
- Blacksmith Testbox `tbx_01kzvjn04fah613qejna6zw3hp` ran `pnpm test:docker:plugin-update` on exact head `feabfc39be10dd744eebe6c8e0f80192b747d105`:
  - package build and tarball integrity passed;
  - `lossless-claw is up to date (0.9.0).`;
  - `Plugin update unchanged Docker E2E passed.`;
  - exit 0 in 8m54.736s.
