### PR TITLE
fix(onboard): avoid false missing-auth warning after API key entry

### DIFF
--- a/src/commands/auth-choice.model-check.test.ts
+++ b/src/commands/auth-choice.model-check.test.ts
@@ -97,6 +97,62 @@ describe("warnIfModelConfigLooksOff", () => {
     });
   });
 
+  it("accepts pending auth profiles collected by the current setup transaction", async () => {
+    const config = {
+      agents: { defaults: { model: "anthropic/claude-sonnet-4-6" } },
+    } as OpenClawConfig;
+    const pendingAuthProfiles = [
+      {
+        profileId: "anthropic:default",
+        credential: {
+          type: "api_key" as const,
+          provider: "anthropic",
+          key: "test-anthropic-key",
+        },
+      },
+    ];
+    const note = vi.fn(async () => {});
+
+    expect(resolveDefaultModelAuthStatus(config, { env: {}, pendingAuthProfiles })).toMatchObject({
+      status: "ready",
+      hasAuth: true,
+    });
+    await warnIfModelConfigLooksOff(config, makePrompter({ note }), {
+      env: {},
+      pendingAuthProfiles,
+      validateCatalog: false,
+    });
+
+    expect(note).not.toHaveBeenCalled();
+  });
+
+  it("does not use pending auth profiles from a different provider", async () => {
+    const config = {
+      agents: { defaults: { model: "anthropic/claude-sonnet-4-6" } },
+    } as OpenClawConfig;
+    const note = vi.fn(async () => {});
+
+    await warnIfModelConfigLooksOff(config, makePrompter({ note }), {
+      env: {},
+      pendingAuthProfiles: [
+        {
+          profileId: "openai:default",
+          credential: {
+            type: "api_key",
+            provider: "openai",
+            key: "test-openai-key",
+          },
+        },
+      ],
+      validateCatalog: false,
+    });
+
+    expect(note).toHaveBeenCalledWith(
+      'No auth configured for provider "anthropic". The agent may fail until credentials are added. Run `openclaw models auth login --provider anthropic`, `openclaw configure`, or set an API key env var.',
+      "Model check",
+    );
+  });
+
   it("accepts Codex OAuth profiles for canonical OpenAI models using the Codex runtime", async () => {
     const note = vi.fn(async (_message: string) => {});
     const prompter = makePrompter({ note });

--- a/src/commands/auth-choice.model-check.ts
+++ b/src/commands/auth-choice.model-check.ts
@@ -16,11 +16,20 @@ import { canonicalizeProviderModelId } from "../agents/provider-model-route.js";
 import type { ModelApi } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderModelRouteAuthRequirement } from "../plugin-sdk/provider-model-types.js";
+import type { ProviderAuthResult } from "../plugins/types.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 
 type ModelRouteObservation = {
   api?: ModelApi | null;
   baseUrl?: unknown;
+};
+
+type DefaultModelAuthOptions = {
+  agentId?: string;
+  agentDir?: string;
+  env?: NodeJS.ProcessEnv;
+  observedRoutes?: readonly ModelRouteObservation[];
+  pendingAuthProfiles?: ProviderAuthResult["profiles"];
 };
 
 type DefaultModelAuthStatus = {
@@ -45,12 +54,7 @@ type DefaultModelAuthStatus = {
  */
 export function resolveDefaultModelAuthStatus(
   config: OpenClawConfig,
-  options?: {
-    agentId?: string;
-    agentDir?: string;
-    env?: NodeJS.ProcessEnv;
-    observedRoutes?: readonly ModelRouteObservation[];
-  },
+  options?: DefaultModelAuthOptions,
 ): DefaultModelAuthStatus {
   const ref = resolveDefaultModelForAgent({
     cfg: config,
@@ -62,9 +66,18 @@ export function resolveDefaultModelAuthStatus(
     ...(ref.provider === "openai" ? { externalCliProviderIds: ["openai"] } : {}),
     readOnly: true,
   });
+  // Pending wizard credentials are transaction-local; include them without
+  // publishing or persisting them before setup commits.
+  const pendingAuthProfiles = options?.pendingAuthProfiles ?? [];
+  const authStore = pendingAuthProfiles.length
+    ? { ...store, profiles: { ...store.profiles } }
+    : store;
+  for (const { profileId, credential } of pendingAuthProfiles) {
+    authStore.profiles[profileId] = credential;
+  }
   const evaluation = createModelAuthAvailabilityResolver({
     cfg: config,
-    authStore: store,
+    authStore,
     ...(options?.agentDir ? { agentDir: options.agentDir } : {}),
     ...(options?.env ? { env: options.env } : {}),
   }).evaluateModelAuth(ref.provider, {
@@ -151,13 +164,7 @@ export function resolveDefaultModelCatalogFacts(
 export async function warnIfModelConfigLooksOff(
   config: OpenClawConfig,
   prompter: WizardPrompter,
-  options?: {
-    agentId?: string;
-    agentDir?: string;
-    validateCatalog?: boolean;
-    env?: NodeJS.ProcessEnv;
-    observedRoutes?: readonly ModelRouteObservation[];
-  },
+  options?: DefaultModelAuthOptions & { validateCatalog?: boolean },
 ) {
   const ref = resolveDefaultModelForAgent({
     cfg: config,
@@ -205,6 +212,7 @@ export async function warnIfModelConfigLooksOff(
     ...(options?.agentDir ? { agentDir: options.agentDir } : {}),
     ...(options?.env ? { env: options.env } : {}),
     ...(observedRoutes ? { observedRoutes } : {}),
+    ...(options?.pendingAuthProfiles ? { pendingAuthProfiles: options.pendingAuthProfiles } : {}),
   });
   if (authStatus.status === "missing") {
     warnings.push(

--- a/src/wizard/setup.model-auth.test.ts
+++ b/src/wizard/setup.model-auth.test.ts
@@ -147,6 +147,7 @@ describe("runSetupModelAuthStep", () => {
     expect(warnIfModelConfigLooksOff).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
       agentId: "ops",
       agentDir: "/tmp/ops-agent",
+      pendingAuthProfiles: [],
       validateCatalog: false,
     });
   });
@@ -167,6 +168,42 @@ describe("runSetupModelAuthStep", () => {
       agentDir: "/tmp/ops-agent",
       validateCatalog: false,
     });
+  });
+
+  it("passes collected auth profiles to the model check before persistence", async () => {
+    const config = createDefaultAgentConfig();
+    const pendingAuthProfiles = [
+      {
+        profileId: "anthropic:default",
+        credential: {
+          type: "api_key" as const,
+          provider: "anthropic",
+          key: "test-anthropic-key",
+        },
+      },
+    ];
+    const persistAuthProfiles = vi.fn(async () => {});
+    promptAuthChoiceGrouped.mockResolvedValueOnce("anthropic-cli");
+    applyAuthChoice.mockResolvedValueOnce({
+      config,
+      authProfiles: pendingAuthProfiles,
+      persistAuthProfiles,
+    });
+
+    await runSetupModelAuthStep({
+      config,
+      opts: {},
+      prompter: createPrompter(),
+      runtime: createRuntime(),
+    });
+
+    expect(warnIfModelConfigLooksOff).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
+      agentId: "ops",
+      agentDir: "/tmp/ops-agent",
+      pendingAuthProfiles,
+      validateCatalog: false,
+    });
+    expect(persistAuthProfiles).not.toHaveBeenCalled();
   });
 
   it("applies an interactive model selection to the agent override", async () => {

--- a/src/wizard/setup.model-auth.ts
+++ b/src/wizard/setup.model-auth.ts
@@ -333,6 +333,7 @@ export async function runSetupModelAuthStep(params: {
     await warnIfModelConfigLooksOff(nextConfig, prompter, {
       agentId: validationTarget.agentId,
       agentDir: validationTarget.agentDir,
+      pendingAuthProfiles: authProfiles,
       validateCatalog: false,
     });
     break;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who entered an API key during classic onboarding immediately saw a false “No auth configured” Model check warning before the wizard committed the credential transaction.

The warning contradicted the next live completion step, which could already use the same in-memory key. It also pointed users toward unnecessary re-authentication.

## Why This Change Was Made

The model-check owner now evaluates a request-scoped composite auth store: persisted read-only profiles plus credentials pending in the current setup transaction, with pending entries winning by profile ID. The wizard passes that pending snapshot only at the pre-persist check.

Deferred persistence remains intact. The skip path has no pending credential, agent creation persists through `applyAuthChoice` before checking, and finalize runs only after accepted credentials are persisted or failed credentials are discarded. Environment-variable auth behavior is unchanged.

AI-assisted: Yes (Codex). The final uncommitted patch passed the repository autoreview workflow with no actionable findings.

## User Impact

After entering an API key, onboarding no longer claims authentication is missing while the credential is intentionally still in memory. Aborting before commit still leaves no partial credential state, and an invalid key still produces the provider’s honest live-test authentication failure.

## Evidence

### Live reproduction and fix proof (macOS, 2026-08-12)

Before, profile `ct3` showed:

```text
Model configured — Default model set to anthropic/claude-opus-5
Model check — No auth configured for provider "anthropic"...
Test AI access now with a live completion? — Yes
AI access test failed: Authentication failed (provider returned HTTP 401).
```

At the false warning, no `auth-profiles.json` existed; the key was still pending in the wizard transaction.

After, profile `patest1` on explicit port `19433` showed:

```text
Model configured — Default model set to anthropic/claude-opus-5
Default model — Keep current (anthropic/claude-opus-5)
Test AI access now with a live completion?
```

There was no Model check warning between model selection and the live-test prompt. At that prompt, neither `auth-profiles.json` nor the agent auth SQLite database existed. Choosing Yes then produced the expected result for the fake key:

```text
AI access test failed: Authentication failed (provider returned HTTP 401).
```

The profile-specific LaunchAgent created by QuickStart was uninstalled, port `19433` was verified clear, and all `patest1` state/workspace artifacts were cleaned up. Port `18789` and the operator’s real profile were never touched.

### Regression and repository checks

The new matching-profile owner test and wizard handoff test both failed on pre-fix code for the intended reason (`missing` status and absent pending-profile option), then passed after the repair.

```text
node scripts/run-vitest.mjs src/commands/auth-choice.model-check.test.ts
  1 file passed, 16 tests passed

node scripts/run-vitest.mjs src/wizard/setup.model-auth.test.ts
  1 file passed, 7 tests passed

node scripts/check-changed.mjs
  exit 0 (Blacksmith Testbox tbx_01kzvgn6pk9qvqkkjkwb5q0mhp)
  https://github.com/openclaw/openclaw/actions/runs/31623341918

.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output
  autoreview clean: no accepted/actionable findings reported
```

Call-site audit: the interactive skip path has no pending profile; agent creation persists before checking; finalize runs after persistence/discard and therefore remains persisted-state-only.

Production LOC: +23/-14 (net +9). Tests: +93/-0.
