### PR TITLE
fix(queue): arbitrate shared capacity across grouped lanes

### DIFF
--- a/src/gateway/server-lanes.hook-group.test.ts
+++ b/src/gateway/server-lanes.hook-group.test.ts
@@ -153,6 +153,59 @@ describe("cron+hook capacity group", () => {
     await Promise.all(runs);
   });
 
+  it("does not let a sustained hook burst recapture capacity ahead of older cron work", async () => {
+    publish(HOOKS_ON);
+
+    const activeHookGates = Array.from({ length: DEFAULT_CRON_MAX_CONCURRENT_RUNS }, () => gate());
+    const activeHooks = activeHookGates.map((g) =>
+      enqueueCommandInLane(CommandLane.HookDispatch, async () => await g.promise, {
+        priority: "background",
+        warnAfterMs: 10_000,
+      }),
+    );
+    await settle();
+    expect(getCommandLaneSnapshot(CommandLane.HookDispatch).activeCount).toBe(
+      DEFAULT_CRON_MAX_CONCURRENT_RUNS,
+    );
+
+    const cronGate = gate();
+    const cronRun = enqueueCommandInLane(
+      CommandLane.CronNested,
+      async () => await cronGate.promise,
+      { priority: "background", warnAfterMs: 10_000 },
+    );
+    const lateHookGate = gate();
+    const lateHook = enqueueCommandInLane(
+      CommandLane.HookDispatch,
+      async () => await lateHookGate.promise,
+      { priority: "background", warnAfterMs: 10_000 },
+    );
+    await settle();
+    expect(getCommandLaneSnapshot(CommandLane.CronNested).queuedCount).toBe(1);
+    expect(getCommandLaneSnapshot(CommandLane.HookDispatch).queuedCount).toBe(1);
+
+    activeHookGates[0]?.release();
+    await activeHooks[0];
+    await settle();
+
+    expect(getCommandLaneSnapshot(CommandLane.CronNested)).toMatchObject({
+      activeCount: 1,
+      queuedCount: 0,
+      groupActive: DEFAULT_CRON_MAX_CONCURRENT_RUNS,
+    });
+    expect(getCommandLaneSnapshot(CommandLane.HookDispatch)).toMatchObject({
+      activeCount: DEFAULT_CRON_MAX_CONCURRENT_RUNS - 1,
+      queuedCount: 1,
+    });
+
+    cronGate.release();
+    for (const g of activeHookGates.slice(1)) {
+      g.release();
+    }
+    lateHookGate.release();
+    await Promise.all([cronRun, ...activeHooks.slice(1), lateHook]);
+  });
+
   it("admits seven cron plus one hook, then gives freed capacity to a second hook", async () => {
     publish(HOOKS_ON);
 

--- a/src/process/command-queue.capacity-groups.test.ts
+++ b/src/process/command-queue.capacity-groups.test.ts
@@ -19,6 +19,7 @@ import {
 
 const CRON = "cron-nested";
 const HOOK = "hook-dispatch";
+const DELIVERY = "delivery-dispatch";
 const GROUP = "cron-hooks";
 
 type LaneGroupSpec = NonNullable<Parameters<typeof publishLaneConfiguration>[0]["groups"]>[string];
@@ -53,6 +54,7 @@ beforeEach(() => {
   clearCommandLaneGroup(GROUP);
   setCommandLaneConcurrency(CRON, 8);
   setCommandLaneConcurrency(HOOK, 8);
+  setCommandLaneConcurrency(DELIVERY, 8);
 });
 
 afterEach(() => {
@@ -70,20 +72,26 @@ describe("command lane capacity groups", () => {
 
     // Fill the group to its budget minus the hook's reservation.
     const gates = Array.from({ length: 7 }, () => gate());
-    const cronRuns = gates.map((g) => enqueueCommandInLane(CRON, async () => await g.promise));
+    const cronRuns = gates.map((g) =>
+      enqueueCommandInLane(CRON, async () => await g.promise, { priority: "foreground" }),
+    );
     await settle();
     expect(getCommandLaneSnapshot(CRON).activeCount).toBe(7);
 
     // The 8th slot is the hook's hard reservation: cron must not take it.
     const extra = gate();
-    const blockedCron = enqueueCommandInLane(CRON, async () => await extra.promise);
+    const blockedCron = enqueueCommandInLane(CRON, async () => await extra.promise, {
+      priority: "foreground",
+    });
     await settle();
     expect(getCommandLaneSnapshot(CRON).activeCount).toBe(7);
     expect(getCommandLaneSnapshot(CRON).blockedBy).toBe("sibling-reservation");
 
     // And the hook starts immediately despite the group being otherwise full.
     const hookGate = gate();
-    const hookRun = enqueueCommandInLane(HOOK, async () => await hookGate.promise);
+    const hookRun = enqueueCommandInLane(HOOK, async () => await hookGate.promise, {
+      priority: "background",
+    });
     await settle();
     expect(getCommandLaneSnapshot(HOOK).activeCount).toBe(1);
     expect(getCommandLaneSnapshot(HOOK).groupActive).toBe(8);
@@ -176,6 +184,259 @@ describe("command lane capacity groups", () => {
     hookGate.release();
     b.release();
     await Promise.all([second, hookRun]);
+  });
+
+  test.each(["successful", "failing"] as const)(
+    "a %s completion gives shared capacity to the older eligible sibling head",
+    async (outcome) => {
+      setCommandLaneGroup(GROUP, {
+        budget: 2,
+        members: [CRON, HOOK],
+        reservations: { [HOOK]: 1 },
+      });
+
+      const firstHookGate = gate();
+      const secondHookGate = gate();
+      const firstHook = enqueueCommandInLane(
+        HOOK,
+        async () => {
+          await firstHookGate.promise;
+          if (outcome === "failing") {
+            throw new Error("expected hook failure");
+          }
+        },
+        { priority: "background" },
+      );
+      const secondHook = enqueueCommandInLane(HOOK, async () => await secondHookGate.promise, {
+        priority: "background",
+      });
+      await settle();
+      expect(getCommandLaneSnapshot(HOOK).activeCount).toBe(2);
+
+      // Cron queues first. A later hook queues behind the same full group. The
+      // completing hook lane must not synchronously reclaim the shared slot.
+      const cronGate = gate();
+      const cronRun = enqueueCommandInLane(CRON, async () => await cronGate.promise, {
+        priority: "background",
+      });
+      const thirdHookGate = gate();
+      const thirdHook = enqueueCommandInLane(HOOK, async () => await thirdHookGate.promise, {
+        priority: "background",
+      });
+      await settle();
+
+      firstHookGate.release();
+      if (outcome === "failing") {
+        await expect(firstHook).rejects.toThrow("expected hook failure");
+      } else {
+        await firstHook;
+      }
+      await settle();
+
+      expect(getCommandLaneSnapshot(CRON)).toMatchObject({ activeCount: 1, queuedCount: 0 });
+      expect(getCommandLaneSnapshot(HOOK)).toMatchObject({ activeCount: 1, queuedCount: 1 });
+
+      cronGate.release();
+      secondHookGate.release();
+      thirdHookGate.release();
+      await Promise.all([cronRun, secondHook, thirdHook]);
+    },
+  );
+
+  test("priority outranks group-global enqueue sequence", async () => {
+    setCommandLaneGroup(GROUP, { budget: 1, members: [CRON, HOOK] });
+
+    const blockerGate = gate();
+    const blocker = enqueueCommandInLane(HOOK, async () => await blockerGate.promise);
+    await settle();
+
+    const cronGate = gate();
+    const olderBackground = enqueueCommandInLane(CRON, async () => await cronGate.promise, {
+      priority: "background",
+    });
+    const hookGate = gate();
+    const newerForeground = enqueueCommandInLane(HOOK, async () => await hookGate.promise, {
+      priority: "foreground",
+    });
+
+    blockerGate.release();
+    await blocker;
+    await settle();
+
+    expect(getCommandLaneSnapshot(HOOK)).toMatchObject({ activeCount: 1, queuedCount: 0 });
+    expect(getCommandLaneSnapshot(CRON)).toMatchObject({ activeCount: 0, queuedCount: 1 });
+
+    hookGate.release();
+    await newerForeground;
+    cronGate.release();
+    await olderBackground;
+  });
+
+  test("three-member arbitration is independent of member iteration order", async () => {
+    setCommandLaneGroup(GROUP, { budget: 1, members: [CRON, HOOK, DELIVERY] });
+
+    const blockerGate = gate();
+    const blocker = enqueueCommandInLane(CRON, async () => await blockerGate.promise, {
+      priority: "background",
+    });
+    await settle();
+
+    // DELIVERY is last in the member Set but queues before HOOK. A simple
+    // sibling-first loop would start HOOK merely because it is visited first.
+    const deliveryGate = gate();
+    const olderDelivery = enqueueCommandInLane(DELIVERY, async () => await deliveryGate.promise, {
+      priority: "background",
+    });
+    const hookGate = gate();
+    const newerHook = enqueueCommandInLane(HOOK, async () => await hookGate.promise, {
+      priority: "background",
+    });
+
+    blockerGate.release();
+    await blocker;
+    await settle();
+
+    expect(getCommandLaneSnapshot(DELIVERY)).toMatchObject({ activeCount: 1, queuedCount: 0 });
+    expect(getCommandLaneSnapshot(HOOK)).toMatchObject({ activeCount: 0, queuedCount: 1 });
+
+    deliveryGate.release();
+    await olderDelivery;
+    hookGate.release();
+    await newerHook;
+  });
+
+  test("multi-slot reset re-arbitrates before stale completions arrive", async () => {
+    setCommandLaneGroup(GROUP, { budget: 2, members: [CRON, HOOK] });
+
+    const staleGates = [gate(), gate()];
+    const staleHooks = staleGates.map((g) =>
+      enqueueCommandInLane(HOOK, async () => await g.promise, { priority: "background" }),
+    );
+    await settle();
+
+    const cronGate = gate();
+    const cronRun = enqueueCommandInLane(CRON, async () => await cronGate.promise, {
+      priority: "background",
+    });
+    const queuedHookGates = [gate(), gate()];
+    const queuedHooks = queuedHookGates.map((g) =>
+      enqueueCommandInLane(HOOK, async () => await g.promise, { priority: "background" }),
+    );
+    await settle();
+
+    expect(resetCommandLane(HOOK)).toBe(2);
+    await settle();
+    expect(getCommandLaneSnapshot(CRON)).toMatchObject({ activeCount: 1, queuedCount: 0 });
+    expect(getCommandLaneSnapshot(HOOK)).toMatchObject({ activeCount: 1, queuedCount: 1 });
+    expect(getCommandLaneSnapshot(HOOK).groupActive).toBe(2);
+
+    // The reset invalidated these task IDs. Their late completions must neither
+    // remove new-generation IDs nor admit the remaining queued hook.
+    for (const g of staleGates) {
+      g.release();
+    }
+    await Promise.all(staleHooks);
+    await settle();
+    expect(getCommandLaneSnapshot(CRON).activeCount).toBe(1);
+    expect(getCommandLaneSnapshot(HOOK)).toMatchObject({ activeCount: 1, queuedCount: 1 });
+
+    cronGate.release();
+    queuedHookGates[0]?.release();
+    await Promise.all([cronRun, queuedHooks[0]]);
+    queuedHookGates[1]?.release();
+    await queuedHooks[1];
+  });
+
+  test("resetAllLanes refills a group by queue order rather than lane order", async () => {
+    setCommandLaneGroup(GROUP, { budget: 1, members: [HOOK, CRON] });
+
+    const staleGate = gate();
+    const staleHook = enqueueCommandInLane(HOOK, async () => await staleGate.promise, {
+      priority: "background",
+    });
+    await settle();
+
+    const cronGate = gate();
+    const olderCron = enqueueCommandInLane(CRON, async () => await cronGate.promise, {
+      priority: "background",
+    });
+    const hookGate = gate();
+    const newerHook = enqueueCommandInLane(HOOK, async () => await hookGate.promise, {
+      priority: "background",
+    });
+    await settle();
+
+    resetAllLanes();
+    await settle();
+    expect(getCommandLaneSnapshot(CRON)).toMatchObject({ activeCount: 1, queuedCount: 0 });
+    expect(getCommandLaneSnapshot(HOOK)).toMatchObject({ activeCount: 0, queuedCount: 1 });
+
+    staleGate.release();
+    await staleHook;
+    await settle();
+    expect(getCommandLaneSnapshot(CRON).activeCount).toBe(1);
+    expect(getCommandLaneSnapshot(HOOK).queuedCount).toBe(1);
+
+    cronGate.release();
+    await olderCron;
+    hookGate.release();
+    await newerHook;
+  });
+
+  test("commits a slot before an onWait callback can re-enter the group", async () => {
+    setCommandLaneConcurrency(CRON, 0);
+    setCommandLaneConcurrency(HOOK, 1);
+
+    const cronGate = gate();
+    const hookGate = gate();
+    let hookRun: Promise<void> | undefined;
+    let active = 0;
+    let peak = 0;
+    const cronRun = enqueueCommandInLane(
+      CRON,
+      async () => {
+        active += 1;
+        peak = Math.max(peak, active);
+        await cronGate.promise;
+        active -= 1;
+      },
+      {
+        priority: "background",
+        warnAfterMs: 0,
+        onWait: () => {
+          hookRun = enqueueCommandInLane(
+            HOOK,
+            async () => {
+              active += 1;
+              peak = Math.max(peak, active);
+              await hookGate.promise;
+              active -= 1;
+            },
+            { priority: "foreground" },
+          );
+        },
+      },
+    );
+    await settle();
+
+    publishLaneConfiguration({
+      lanes: { [CRON]: 1 },
+      groups: { [GROUP]: { budget: 1, members: [CRON, HOOK] } },
+    });
+    await settle();
+
+    expect(hookRun).toBeDefined();
+    expect(peak).toBe(1);
+    expect(getCommandLaneSnapshot(CRON).activeCount).toBe(1);
+    expect(getCommandLaneSnapshot(HOOK)).toMatchObject({ activeCount: 0, queuedCount: 1 });
+
+    cronGate.release();
+    await cronRun;
+    await settle();
+    expect(getCommandLaneSnapshot(HOOK).activeCount).toBe(1);
+    hookGate.release();
+    await hookRun;
+    expect(peak).toBe(1);
   });
 
   test("a failing task releases group capacity like a successful one", async () => {

--- a/src/process/command-queue.capacity-groups.ts
+++ b/src/process/command-queue.capacity-groups.ts
@@ -1,3 +1,4 @@
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 // Capacity groups: a shared, hard aggregate budget across several command
 // lanes, with per-member reservations. Split out of command-queue.ts to keep
 // that file within its size budget; the queue supplies its own `drainLane` so
@@ -5,8 +6,11 @@
 import { getQueueState, normalizeLane } from "./command-queue.state.js";
 import { CommandLane } from "./lanes.js";
 
-/** Drains at most `maxStarts` entries from one lane. Supplied to avoid a cycle. */
-type DrainLaneFn = (lane: string, maxStarts?: number) => number;
+/** Drains a single lane. Supplied by command-queue.ts to avoid a cycle. */
+type DrainLaneFn = (lane: string) => void;
+
+/** Internal bounded drain contract used by the group arbiter. */
+type BoundedDrainLaneFn = (lane: string, maxStarts?: number) => number;
 
 /** Why a lane cannot admit, from the narrowest cause outward. */
 export type CommandLaneBlockReason = "lane" | "group-budget" | "sibling-reservation" | null;
@@ -33,9 +37,13 @@ export type LaneGroupState = {
   budget: number;
   members: Set<string>;
   reservations: Map<string, number>;
-  /** Synchronous re-entrancy guard while this group selects queue heads. */
-  draining?: boolean;
 };
+
+/** Shared across fresh module instances so one group cannot re-enter its arbiter. */
+const DRAINING_GROUPS = resolveGlobalSingleton(
+  Symbol.for("openclaw.commandQueueDrainingGroups"),
+  () => new WeakSet<LaneGroupState>(),
+);
 
 /**
  * Lanes that must never join a group, because a group member can be made to
@@ -187,7 +195,7 @@ export function validateCommandLaneGroupSpec(
       `command lane group "${group}" reserves ${reservedTotal} slots but its budget is ${budget}`,
     );
   }
-  return { group, budget, members: new Set(members), reservations, draining: false };
+  return { group, budget, members: new Set(members), reservations };
 }
 
 /** Install a validated group, detaching its members from any previous owner. */
@@ -251,12 +259,12 @@ function resolveNextGroupLane(group: LaneGroupState): string | undefined {
  * group applies the same order across member queue heads so a completing lane
  * cannot synchronously reclaim shared capacity ahead of an older sibling.
  */
-export function drainCommandLaneGroup(lane: string, drainLane: DrainLaneFn): void {
+function drainCommandLaneGroup(lane: string, drainLane: BoundedDrainLaneFn): void {
   const group = getLaneGroup(lane);
-  if (!group || group.draining) {
+  if (!group || DRAINING_GROUPS.has(group)) {
     return;
   }
-  group.draining = true;
+  DRAINING_GROUPS.add(group);
   try {
     while (getGroupRegistry().groups.get(group.group) === group) {
       const selectedLane = resolveNextGroupLane(group);
@@ -265,6 +273,16 @@ export function drainCommandLaneGroup(lane: string, drainLane: DrainLaneFn): voi
       }
     }
   } finally {
-    group.draining = false;
+    DRAINING_GROUPS.delete(group);
   }
+}
+
+/**
+ * Re-drain the owning capacity group after a member changes state.
+ *
+ * The legacy exported name and callback surface stay stable for internal SDK
+ * consumers; the supplied queue drain also supports the private bounded call.
+ */
+export function drainGroupSiblings(lane: string, drainLane: DrainLaneFn): void {
+  drainCommandLaneGroup(lane, drainLane as BoundedDrainLaneFn);
 }

--- a/src/process/command-queue.capacity-groups.ts
+++ b/src/process/command-queue.capacity-groups.ts
@@ -10,7 +10,7 @@ import { CommandLane } from "./lanes.js";
 type DrainLaneFn = (lane: string) => void;
 
 /** Internal bounded drain contract used by the group arbiter. */
-type BoundedDrainLaneFn = (lane: string, maxStarts?: number) => number;
+type BoundedDrainLaneFn = (lane: string, maxStarts?: number) => number | void;
 
 /** Why a lane cannot admit, from the narrowest cause outward. */
 export type CommandLaneBlockReason = "lane" | "group-budget" | "sibling-reservation" | null;
@@ -284,5 +284,5 @@ function drainCommandLaneGroup(lane: string, drainLane: BoundedDrainLaneFn): voi
  * consumers; the supplied queue drain also supports the private bounded call.
  */
 export function drainGroupSiblings(lane: string, drainLane: DrainLaneFn): void {
-  drainCommandLaneGroup(lane, drainLane as BoundedDrainLaneFn);
+  drainCommandLaneGroup(lane, drainLane);
 }

--- a/src/process/command-queue.capacity-groups.ts
+++ b/src/process/command-queue.capacity-groups.ts
@@ -5,8 +5,8 @@
 import { getQueueState, normalizeLane } from "./command-queue.state.js";
 import { CommandLane } from "./lanes.js";
 
-/** Drains a single lane. Supplied by command-queue.ts to avoid a cycle. */
-type DrainLaneFn = (lane: string) => void;
+/** Drains at most `maxStarts` entries from one lane. Supplied to avoid a cycle. */
+type DrainLaneFn = (lane: string, maxStarts?: number) => number;
 
 /** Why a lane cannot admit, from the narrowest cause outward. */
 export type CommandLaneBlockReason = "lane" | "group-budget" | "sibling-reservation" | null;
@@ -33,6 +33,8 @@ export type LaneGroupState = {
   budget: number;
   members: Set<string>;
   reservations: Map<string, number>;
+  /** Synchronous re-entrancy guard while this group selects queue heads. */
+  draining?: boolean;
 };
 
 /**
@@ -185,7 +187,7 @@ export function validateCommandLaneGroupSpec(
       `command lane group "${group}" reserves ${reservedTotal} slots but its budget is ${budget}`,
     );
   }
-  return { group, budget, members: new Set(members), reservations };
+  return { group, budget, members: new Set(members), reservations, draining: false };
 }
 
 /** Install a validated group, detaching its members from any previous owner. */
@@ -213,34 +215,56 @@ export function installCommandLaneGroup(next: LaneGroupState): void {
 }
 
 /**
- * Drain the given member lanes.
- *
- * Never creates a lane: `drainLane` calls `getLaneState`, which would resurrect
- * a scoped lane that `retireIdleScopedCommandLane` had just removed. A lane
- * whose width is 0 admits nothing when pumped, so no width check is needed
- * here — it would only skip a call that is already a no-op.
+ * Select the highest-priority, oldest currently admissible member head.
  */
-function drainMembers(lanes: Iterable<string>, drainLane: DrainLaneFn): void {
-  for (const lane of lanes) {
+function resolveNextGroupLane(group: LaneGroupState): string | undefined {
+  let selected:
+    | {
+        lane: string;
+        priority: number;
+        sequence: number;
+      }
+    | undefined;
+  for (const lane of group.members) {
     const state = getQueueState().lanes.get(lane);
-    if (state && state.queue.length > 0 && !state.draining) {
-      drainLane(lane);
+    const head = state?.queue[0];
+    if (!state || !head || state.draining || resolveLaneBlockReason(lane) !== null) {
+      continue;
+    }
+    if (
+      !selected ||
+      head.priority > selected.priority ||
+      (head.priority === selected.priority &&
+        (head.sequence < selected.sequence ||
+          (head.sequence === selected.sequence && lane < selected.lane)))
+    ) {
+      selected = { lane, priority: head.priority, sequence: head.sequence };
     }
   }
+  return selected?.lane;
 }
 
 /**
- * Re-drain every OTHER member of `lane`'s group. Capacity that a completion
- * frees belongs to the group, not to the lane that freed it, so a lane-local
- * pump would leave siblings queued behind capacity that is already available.
+ * Drain a capacity group one admission at a time.
+ *
+ * Per-lane queues already order entries by priority and global sequence. The
+ * group applies the same order across member queue heads so a completing lane
+ * cannot synchronously reclaim shared capacity ahead of an older sibling.
  */
-export function drainGroupSiblings(lane: string, drainLane: DrainLaneFn): void {
+export function drainCommandLaneGroup(lane: string, drainLane: DrainLaneFn): void {
   const group = getLaneGroup(lane);
-  if (!group) {
+  if (!group || group.draining) {
     return;
   }
-  drainMembers(
-    [...group.members].filter((member) => member !== lane),
-    drainLane,
-  );
+  group.draining = true;
+  try {
+    while (getGroupRegistry().groups.get(group.group) === group) {
+      const selectedLane = resolveNextGroupLane(group);
+      if (!selectedLane || drainLane(selectedLane, 1) === 0) {
+        return;
+      }
+    }
+  } finally {
+    group.draining = false;
+  }
 }

--- a/src/process/command-queue.publish-transaction.test.ts
+++ b/src/process/command-queue.publish-transaction.test.ts
@@ -22,7 +22,9 @@ import {
 
 const CRON = "cron-nested";
 const HOOK = "hook-dispatch";
+const DELIVERY = "delivery-dispatch";
 const GROUP = "cron-hooks";
+const MOVED_GROUP = "cron-delivery";
 
 type LaneGroupSpec = NonNullable<Parameters<typeof publishLaneConfiguration>[0]["groups"]>[string];
 
@@ -53,10 +55,12 @@ async function settle(): Promise<void> {
 beforeEach(() => {
   resetAllLanes();
   clearCommandLaneGroup(GROUP);
+  clearCommandLaneGroup(MOVED_GROUP);
 });
 
 afterEach(() => {
   clearCommandLaneGroup(GROUP);
+  clearCommandLaneGroup(MOVED_GROUP);
   resetAllLanes();
 });
 
@@ -117,6 +121,78 @@ describe("publishLaneConfiguration", () => {
       g.release();
     }
     await Promise.all(runs);
+  });
+
+  test("commit dispatch uses group order rather than publication object order", async () => {
+    setCommandLaneConcurrency(CRON, 0);
+    setCommandLaneConcurrency(HOOK, 0);
+
+    const starts: string[] = [];
+    const cronGate = gate();
+    const hookGate = gate();
+    const olderCron = enqueueCommandInLane(
+      CRON,
+      async () => {
+        starts.push(CRON);
+        await cronGate.promise;
+      },
+      { priority: "background" },
+    );
+    const newerHook = enqueueCommandInLane(
+      HOOK,
+      async () => {
+        starts.push(HOOK);
+        await hookGate.promise;
+      },
+      { priority: "background" },
+    );
+
+    // Deliberately publish HOOK first in both objects. The older CRON head must
+    // still own the single shared slot.
+    publishLaneConfiguration({
+      lanes: { [HOOK]: 1, [CRON]: 1 },
+      groups: { [GROUP]: { budget: 1, members: [HOOK, CRON] } },
+    });
+    await settle();
+    expect(starts).toEqual([CRON]);
+
+    cronGate.release();
+    await olderCron;
+    await settle();
+    expect(starts).toEqual([CRON, HOOK]);
+    hookGate.release();
+    await newerHook;
+  });
+
+  test("moving a busy member wakes queued work in its previous group", async () => {
+    publishLaneConfiguration({
+      lanes: { [CRON]: 1, [HOOK]: 1, [DELIVERY]: 1 },
+      groups: { [GROUP]: { budget: 1, members: [CRON, HOOK] } },
+    });
+
+    const cronGate = gate();
+    const cronRun = enqueueCommandInLane(CRON, async () => await cronGate.promise);
+    const hookGate = gate();
+    const hookRun = enqueueCommandInLane(HOOK, async () => await hookGate.promise);
+    await settle();
+    expect(getCommandLaneSnapshot(HOOK)).toMatchObject({ activeCount: 0, queuedCount: 1 });
+
+    // CRON's active task stops counting against the old group as soon as it is
+    // moved. That newly free old-group capacity must wake HOOK immediately.
+    publishLaneConfiguration({
+      groups: { [MOVED_GROUP]: { budget: 1, members: [CRON, DELIVERY] } },
+    });
+    await settle();
+    expect(getCommandLaneSnapshot(HOOK)).toMatchObject({
+      group: GROUP,
+      activeCount: 1,
+      queuedCount: 0,
+    });
+    expect(getCommandLaneSnapshot(CRON).group).toBe(MOVED_GROUP);
+
+    cronGate.release();
+    hookGate.release();
+    await Promise.all([cronRun, hookRun]);
   });
 
   test("a rejected configuration does not leave lanes widened and dispatching", async () => {

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -11,7 +11,7 @@ import {
   canAdmitInGroup,
   type CommandLaneBlockReason,
   type CommandLaneGroupSpec,
-  drainGroupSiblings,
+  drainCommandLaneGroup,
   getGroupRegistry,
   getLaneGroup,
   getMemberActiveCount,
@@ -406,7 +406,7 @@ async function runQueueEntryTask(
   }
 }
 
-function drainLane(lane: string) {
+function drainLane(lane: string, maxStarts = Number.POSITIVE_INFINITY): number {
   const state = getLaneState(lane);
   if (state.draining) {
     if (state.activeTaskIds.size === 0 && state.queue.length > 0) {
@@ -414,84 +414,90 @@ function drainLane(lane: string) {
         `drainLane blocked: lane=${lane} draining=true active=0 queue=${state.queue.length}`,
       );
     }
-    return;
+    return 0;
   }
   state.draining = true;
-
-  const pump = () => {
-    try {
-      while (
-        state.activeTaskIds.size < state.maxConcurrent &&
-        state.queue.length > 0 &&
-        canAdmitInGroup(lane)
-      ) {
-        const entry = state.queue.shift() as QueueEntry;
-        const waitedMs = Date.now() - entry.enqueuedAt;
-        if (waitedMs >= entry.warnAfterMs) {
-          try {
-            entry.onWait?.(waitedMs, entry.queuedAheadAtEnqueue);
-          } catch (err) {
-            diag.error(`lane onWait callback failed: lane=${lane} error="${String(err)}"`);
-          }
-          diag.warn(
-            `lane wait exceeded: lane=${lane} waitedMs=${waitedMs} queueAhead=${entry.queuedAheadAtEnqueue} ` +
-              `activeAhead=${entry.activeAheadAtEnqueue} activeNow=${state.activeTaskIds.size} queueBehind=${state.queue.length}`,
-          );
+  let started = 0;
+  try {
+    while (
+      started < maxStarts &&
+      state.activeTaskIds.size < state.maxConcurrent &&
+      state.queue.length > 0 &&
+      canAdmitInGroup(lane)
+    ) {
+      const entry = state.queue.shift() as QueueEntry;
+      const waitedMs = Date.now() - entry.enqueuedAt;
+      const activeBeforeStart = state.activeTaskIds.size;
+      const taskId = getQueueState().nextTaskId++;
+      const taskGeneration = state.generation;
+      // Commit the admission before invoking callbacks or logging. Both can
+      // synchronously re-enter the queue, and the shared budget must already
+      // account for this task when that nested admission is evaluated.
+      state.activeTaskIds.add(taskId);
+      started += 1;
+      if (waitedMs >= entry.warnAfterMs) {
+        try {
+          entry.onWait?.(waitedMs, entry.queuedAheadAtEnqueue);
+        } catch (err) {
+          diag.error(`lane onWait callback failed: lane=${lane} error="${String(err)}"`);
         }
-        logLaneDequeue(lane, waitedMs, state.queue.length);
-        const taskId = getQueueState().nextTaskId++;
-        const taskGeneration = state.generation;
-        state.activeTaskIds.add(taskId);
-        void (async () => {
-          const startTime = Date.now();
-          try {
-            const result = await runQueueEntryTask(lane, entry, {
-              lane,
-              taskId,
-              generation: taskGeneration,
-            });
-            const completedCurrentGeneration = completeTask(state, taskId, taskGeneration);
-            if (completedCurrentGeneration) {
-              notifyActiveTaskWaiters();
-              diag.debug(
-                `lane task done: lane=${lane} durationMs=${Date.now() - startTime} active=${state.activeTaskIds.size} queued=${state.queue.length}`,
-              );
-              pump();
-              // Freed capacity belongs to the group, not to this lane.
-              drainGroupSiblings(lane, drainLane);
-            }
-            entry.resolve(result);
-          } catch (err) {
-            const completedCurrentGeneration = completeTask(state, taskId, taskGeneration);
-            const isProbeLane = isQuietProbeLane(lane);
-            if (!isProbeLane && !isExpectedNonErrorLaneFailure(err)) {
-              diag.error(
-                `lane task error: lane=${lane} durationMs=${Date.now() - startTime} error="${formatErrorMessage(err)}"`,
-                { errorName: readErrorName(err) || undefined },
-              );
-            } else if (!isProbeLane) {
-              diag.debug(
-                `lane task interrupted: lane=${lane} durationMs=${Date.now() - startTime} reason="${String(err)}"`,
-              );
-            }
-            if (completedCurrentGeneration) {
-              notifyActiveTaskWaiters();
-              pump();
-              // A failed task releases group capacity exactly like a successful
-              // one; siblings must be woken on both paths.
-              drainGroupSiblings(lane, drainLane);
-            }
-            entry.reject(err);
-          }
-        })();
+        diag.warn(
+          `lane wait exceeded: lane=${lane} waitedMs=${waitedMs} queueAhead=${entry.queuedAheadAtEnqueue} ` +
+            `activeAhead=${entry.activeAheadAtEnqueue} activeNow=${activeBeforeStart} queueBehind=${state.queue.length}`,
+        );
       }
-    } finally {
-      state.draining = false;
-      retireIdleScopedCommandLane(state);
+      logLaneDequeue(lane, waitedMs, state.queue.length);
+      void (async () => {
+        const startTime = Date.now();
+        try {
+          const result = await runQueueEntryTask(lane, entry, {
+            lane,
+            taskId,
+            generation: taskGeneration,
+          });
+          const completedCurrentGeneration = completeTask(state, taskId, taskGeneration);
+          if (completedCurrentGeneration) {
+            notifyActiveTaskWaiters();
+            diag.debug(
+              `lane task done: lane=${lane} durationMs=${Date.now() - startTime} active=${state.activeTaskIds.size} queued=${state.queue.length}`,
+            );
+            drainReadyCommandLane(lane);
+          }
+          entry.resolve(result);
+        } catch (err) {
+          const completedCurrentGeneration = completeTask(state, taskId, taskGeneration);
+          const isProbeLane = isQuietProbeLane(lane);
+          if (!isProbeLane && !isExpectedNonErrorLaneFailure(err)) {
+            diag.error(
+              `lane task error: lane=${lane} durationMs=${Date.now() - startTime} error="${formatErrorMessage(err)}"`,
+              { errorName: readErrorName(err) || undefined },
+            );
+          } else if (!isProbeLane) {
+            diag.debug(
+              `lane task interrupted: lane=${lane} durationMs=${Date.now() - startTime} reason="${String(err)}"`,
+            );
+          }
+          if (completedCurrentGeneration) {
+            notifyActiveTaskWaiters();
+            drainReadyCommandLane(lane);
+          }
+          entry.reject(err);
+        }
+      })();
     }
-  };
+  } finally {
+    state.draining = false;
+    retireIdleScopedCommandLane(state);
+  }
+  return started;
+}
 
-  pump();
+function drainReadyCommandLane(lane: string): void {
+  if (getLaneGroup(lane)) {
+    drainCommandLaneGroup(lane, drainLane);
+    return;
+  }
+  drainLane(lane);
 }
 
 /**
@@ -555,6 +561,17 @@ export function publishLaneConfiguration(config: {
     }
   }
   for (const next of validated) {
+    const { groups, groupByLane } = getGroupRegistry();
+    const previous = groups.get(next.group);
+    for (const member of previous?.members ?? []) {
+      touched.add(member);
+    }
+    for (const member of next.members) {
+      const previousOwner = groupByLane.get(member);
+      for (const previousSibling of groups.get(previousOwner ?? "")?.members ?? []) {
+        touched.add(previousSibling);
+      }
+    }
     installCommandLaneGroup(next);
     for (const member of next.members) {
       touched.add(member);
@@ -565,7 +582,7 @@ export function publishLaneConfiguration(config: {
   for (const lane of touched) {
     const state = getQueueState().lanes.get(lane);
     if (state && state.maxConcurrent > 0 && state.queue.length > 0 && !state.draining) {
-      drainLane(lane);
+      drainReadyCommandLane(lane);
     }
   }
 }
@@ -577,7 +594,7 @@ export function setCommandLaneConcurrency(lane: string, maxConcurrent: number) {
   const minConcurrent = isProbeLane ? 1 : 0;
   state.maxConcurrent = Math.max(minConcurrent, Math.floor(maxConcurrent));
   if (state.maxConcurrent > 0) {
-    drainLane(cleaned);
+    drainReadyCommandLane(cleaned);
   }
 }
 
@@ -613,7 +630,7 @@ export function enqueueCommandInLane<T>(
       onWait: opts?.onWait,
     });
     logLaneEnqueue(cleaned, getLaneDepth(state));
-    drainLane(cleaned);
+    drainReadyCommandLane(cleaned);
   });
 }
 
@@ -713,11 +730,9 @@ export function resetCommandLane(lane: string = CommandLane.Main): number {
   state.generation += 1;
   state.activeTaskIds.clear();
   state.draining = false;
-  if (state.queue.length > 0) {
-    drainLane(cleaned);
-  }
-  // Clearing activeTaskIds released group capacity; siblings may now admit.
-  drainGroupSiblings(cleaned, drainLane);
+  // Clearing activeTaskIds may release multiple shared slots. Re-arbitrate the
+  // whole group so the reset lane cannot reclaim them ahead of older siblings.
+  drainReadyCommandLane(cleaned);
   notifyActiveTaskWaiters();
   return released;
 }
@@ -750,7 +765,7 @@ export function resetAllLanes(): void {
   }
   // Drain after the full reset pass so all lanes are in a clean state first.
   for (const lane of lanesToDrain) {
-    drainLane(lane);
+    drainReadyCommandLane(lane);
   }
   notifyActiveTaskWaiters();
 }

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -11,7 +11,7 @@ import {
   canAdmitInGroup,
   type CommandLaneBlockReason,
   type CommandLaneGroupSpec,
-  drainCommandLaneGroup,
+  drainGroupSiblings,
   getGroupRegistry,
   getLaneGroup,
   getMemberActiveCount,
@@ -497,7 +497,7 @@ function drainLane(
 
 function drainReadyCommandLane(lane: string, completedState?: LaneState): void {
   if (getLaneGroup(lane)) {
-    drainCommandLaneGroup(lane, drainLane);
+    drainGroupSiblings(lane, drainLane);
     return;
   }
   // An idle scoped lane may have been retired and recreated while an older

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -406,8 +406,11 @@ async function runQueueEntryTask(
   }
 }
 
-function drainLane(lane: string, maxStarts = Number.POSITIVE_INFINITY): number {
-  const state = getLaneState(lane);
+function drainLane(
+  lane: string,
+  maxStarts = Number.POSITIVE_INFINITY,
+  state = getLaneState(lane),
+): number {
   if (state.draining) {
     if (state.activeTaskIds.size === 0 && state.queue.length > 0) {
       diag.warn(
@@ -461,7 +464,7 @@ function drainLane(lane: string, maxStarts = Number.POSITIVE_INFINITY): number {
             diag.debug(
               `lane task done: lane=${lane} durationMs=${Date.now() - startTime} active=${state.activeTaskIds.size} queued=${state.queue.length}`,
             );
-            drainReadyCommandLane(lane);
+            drainReadyCommandLane(lane, state);
           }
           entry.resolve(result);
         } catch (err) {
@@ -479,7 +482,7 @@ function drainLane(lane: string, maxStarts = Number.POSITIVE_INFINITY): number {
           }
           if (completedCurrentGeneration) {
             notifyActiveTaskWaiters();
-            drainReadyCommandLane(lane);
+            drainReadyCommandLane(lane, state);
           }
           entry.reject(err);
         }
@@ -492,12 +495,15 @@ function drainLane(lane: string, maxStarts = Number.POSITIVE_INFINITY): number {
   return started;
 }
 
-function drainReadyCommandLane(lane: string): void {
+function drainReadyCommandLane(lane: string, completedState?: LaneState): void {
   if (getLaneGroup(lane)) {
     drainCommandLaneGroup(lane, drainLane);
     return;
   }
-  drainLane(lane);
+  // An idle scoped lane may have been retired and recreated while an older
+  // task was finishing. Preserve the completion's captured state so its drain
+  // cannot retire a newer registry entry that it never owned.
+  drainLane(lane, Number.POSITIVE_INFINITY, completedState);
 }
 
 /**

--- a/test/gateway-hook-concurrency.e2e.test.ts
+++ b/test/gateway-hook-concurrency.e2e.test.ts
@@ -1,4 +1,4 @@
-// E2E: hook dispatch uses every free slot inside the shared cron budget.
+// E2E: hook dispatch uses the shared cron budget without starving older cron work.
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../src/config/types.openclaw.js";
@@ -11,6 +11,9 @@ import { createDeferred } from "./helpers/promise.js";
 const TEST_TIMEOUT_MS = 180_000;
 const MODEL_REF = "hook-concurrency/hook-concurrency";
 const SHARED_BUDGET = 8;
+const FAIRNESS_CRON_MARKER = "capacity group fairness cron marker";
+const FAIRNESS_HOOK_OFFSET = 100;
+const FAIRNESS_LATE_HOOK_INDEX = FAIRNESS_HOOK_OFFSET + SHARED_BUDGET;
 
 type Deferred = {
   promise: Promise<void>;
@@ -27,7 +30,9 @@ type HeldModelServer = {
   close: () => Promise<void>;
   hold: () => void;
   peak: () => number;
+  release: (index: number) => void;
   releaseAll: () => void;
+  requestBody: (index: number) => string | undefined;
   requestCount: () => number;
   url: string;
 };
@@ -42,7 +47,7 @@ afterEach(async () => {
 
 describe("Gateway hook concurrency", () => {
   it(
-    "admits eight hooks, times out the queued ninth, then admits after release",
+    "bounds hooks and admits an older cron turn before a later hook",
     { timeout: TEST_TIMEOUT_MS },
     async () => {
       const modelServer = await startHeldModelServer();
@@ -50,7 +55,7 @@ describe("Gateway hook concurrency", () => {
       const instance = await createOpenClawTestInstance({
         name: "gateway-hook-concurrency",
         config: createTestConfig(modelServer.url),
-        env: { OPENCLAW_SKIP_PROVIDERS: undefined },
+        env: { OPENCLAW_SKIP_CRON: undefined, OPENCLAW_SKIP_PROVIDERS: undefined },
       });
       instances.push(instance);
       await instance.startGateway();
@@ -111,6 +116,100 @@ describe("Gateway hook concurrency", () => {
         interval: 20,
         timeout: 30_000,
       });
+
+      // Saturate the real hook-dispatch lane again, then queue cron inner work
+      // before one later hook. Releasing one held provider request is the exact
+      // production completion edge that previously let the hook lane reclaim
+      // its own slot before the older cron sibling could compete for it.
+      modelServer.hold();
+      const fairnessRequestStart = modelServer.requestCount();
+      const fairnessHooks = Array.from({ length: SHARED_BUDGET }, (_, offset) =>
+        postHook(instance, FAIRNESS_HOOK_OFFSET + offset),
+      );
+      await vi.waitFor(
+        () => expect(modelServer.requestCount()).toBe(fairnessRequestStart + SHARED_BUDGET),
+        { interval: 20, timeout: 30_000 },
+      );
+      expect(modelServer.active(), instance.logs()).toBe(SHARED_BUDGET);
+
+      const addResult = await instance.cli([
+        "cron",
+        "add",
+        "--name",
+        "capacity group fairness proof",
+        "--every",
+        "1h",
+        "--session",
+        "isolated",
+        "--message",
+        FAIRNESS_CRON_MARKER,
+        "--no-deliver",
+        "--json",
+      ]);
+      expect(addResult.code, addResult.stderr).toBe(0);
+      const cronJob = JSON.parse(addResult.stdout) as { id?: string };
+      expect(cronJob.id).toEqual(expect.any(String));
+
+      const runResult = await instance.cli(["cron", "run", cronJob.id ?? ""]);
+      expect(runResult.code, runResult.stderr).toBe(0);
+      const cronRun = JSON.parse(runResult.stdout) as {
+        enqueued?: boolean;
+        ok?: boolean;
+        runId?: string;
+      };
+      expect(cronRun).toMatchObject({
+        enqueued: true,
+        ok: true,
+        runId: expect.any(String),
+      });
+
+      // cron.run acknowledges after queuing the outer cron task. Give the real
+      // isolated runner time to cross preparation and enqueue cron-nested, then
+      // submit the competing hook. Both remain provider-blocked at this point.
+      await delay(1_000);
+      const lateHook = postHook(instance, FAIRNESS_LATE_HOOK_INDEX);
+      await delay(1_000);
+      expect(modelServer.requestCount()).toBe(fairnessRequestStart + SHARED_BUDGET);
+      expect(modelServer.active()).toBe(SHARED_BUDGET);
+
+      modelServer.release(fairnessRequestStart);
+      const cronProviderRequest = fairnessRequestStart + SHARED_BUDGET;
+      await vi.waitFor(() => expect(modelServer.requestCount()).toBe(cronProviderRequest + 1), {
+        interval: 20,
+        timeout: 30_000,
+      });
+      expect(modelServer.requestBody(cronProviderRequest)).toContain(FAIRNESS_CRON_MARKER);
+      expect(modelServer.requestBody(cronProviderRequest)).not.toContain(
+        `hook concurrency request ${FAIRNESS_LATE_HOOK_INDEX}`,
+      );
+
+      modelServer.release(cronProviderRequest);
+      const lateHookProviderRequest = cronProviderRequest + 1;
+      await vi.waitFor(() => expect(modelServer.requestCount()).toBe(lateHookProviderRequest + 1), {
+        interval: 20,
+        timeout: 30_000,
+      });
+      expect(modelServer.requestBody(lateHookProviderRequest)).toContain(
+        `hook concurrency request ${FAIRNESS_LATE_HOOK_INDEX}`,
+      );
+      expect(modelServer.peak(), instance.logs()).toBeLessThanOrEqual(SHARED_BUDGET);
+
+      console.info(
+        `[capacity-group-fairness-trace] ${JSON.stringify({
+          afterOneHookRelease: "older-cron",
+          afterCronRelease: "later-hook",
+          peakProviderConcurrency: modelServer.peak(),
+          queuedOrder: ["cron", "later-hook"],
+          saturatedProviderRequests: SHARED_BUDGET,
+        })}`,
+      );
+
+      modelServer.releaseAll();
+      await expect(Promise.all(fairnessHooks)).resolves.toSatisfy((values: HookResponse[]) =>
+        values.every((value) => value.status === 200),
+      );
+      await expect(lateHook).resolves.toMatchObject({ status: 200 });
+      await waitForCronRun(instance, cronJob.id ?? "", cronRun.runId ?? "");
     },
   );
 });
@@ -210,6 +309,7 @@ async function postHook(instance: OpenClawTestInstance, index: number): Promise<
 
 async function startHeldModelServer(): Promise<HeldModelServer> {
   const releases: Deferred[] = [];
+  const requestBodies: string[] = [];
   let holdRequests = false;
   let active = 0;
   let peak = 0;
@@ -239,9 +339,10 @@ async function startHeldModelServer(): Promise<HeldModelServer> {
       return;
     }
 
-    await drainRequest(request);
+    const requestBody = await drainRequest(request);
     const index = requestCount;
     requestCount += 1;
+    requestBodies[index] = requestBody;
     const release = createDeferred();
     releases[index] = release;
     if (!holdRequests) {
@@ -280,7 +381,11 @@ async function startHeldModelServer(): Promise<HeldModelServer> {
       holdRequests = true;
     },
     peak: () => peak,
+    release: (index) => {
+      releases[index]?.resolve();
+    },
     releaseAll,
+    requestBody: (index) => requestBodies[index],
     requestCount: () => requestCount,
     url: `http://127.0.0.1:${address.port}`,
     close: async () => {
@@ -293,10 +398,44 @@ async function startHeldModelServer(): Promise<HeldModelServer> {
   };
 }
 
-async function drainRequest(request: IncomingMessage): Promise<void> {
+async function drainRequest(request: IncomingMessage): Promise<string> {
+  let body = "";
   for await (const chunk of request) {
-    void chunk;
+    body += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
   }
+  return body;
+}
+
+async function waitForCronRun(
+  instance: OpenClawTestInstance,
+  jobId: string,
+  runId: string,
+): Promise<void> {
+  await vi.waitFor(
+    async () => {
+      const result = await instance.cli([
+        "cron",
+        "runs",
+        "--id",
+        jobId,
+        "--run-id",
+        runId,
+        "--json",
+      ]);
+      expect(result.code, result.stderr).toBe(0);
+      const history = JSON.parse(result.stdout) as {
+        entries?: Array<{ runId?: string; status?: string }>;
+      };
+      expect(history.entries).toContainEqual(expect.objectContaining({ runId, status: "ok" }));
+    },
+    { interval: 200, timeout: 30_000 },
+  );
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }
 
 function writeModelResponse(response: ServerResponse, sequence: number): void {


### PR DESCRIPTION
Fixes #122763.

## What Problem This Solves

- move shared-slot ownership from the completing lane to the capacity-group dispatcher
- select one eligible member head at a time using the existing priority-descending, global-sequence-ascending policy
- route enqueue, completion, concurrency changes, reset, reset-all, and configuration publication through the same group-aware drain edge
- preserve hard reservations, per-lane widths, and the aggregate group budget
- wake old-group siblings and detached members when configuration moves a lane between groups

## Root cause

The completion path pumped its own lane before waking siblings. With own-lane backlog, that local pump reclaimed every newly free group slot; by the time sibling draining ran, the group was full again.

On base `2ce420091e1`, a deterministic budget-2 reproduction with two active hooks, an older queued background cron task, and a later queued background hook produced:

```text
cron-nested:   active=0 queued=1
hook-dispatch: active=2 queued=0
```

The expected state is `cron active=1` and the later hook still queued. This reproduces the shipped Gateway shape because both isolated hook and cron agent turns use background command-queue priority.

## Repair

The capacity group is now the canonical admission owner:

1. inspect one head per member;
2. discard heads blocked by lane width, group budget, or sibling reservations;
3. choose highest priority, then oldest process-global queue sequence;
4. start exactly one entry;
5. recompute live capacity before the next admission.

The active task ID is committed before `onWait` or diagnostics can synchronously re-enter the queue. The group re-entrancy guard uses the same process-global singleton ownership model as the queue, including across fresh module instances.

This does **not** introduce priority aging or promise eventual service against an infinite stream of higher-priority work. #79589 / #75299 remain the separate lane-local priority-policy discussion.

## Protected boundaries

New regressions cover:

- original starvation order on both success and rejection
- priority overriding an older lower-priority head
- hard reservation overriding a sibling's higher priority
- three-member order independent of member declaration order
- multi-slot `resetCommandLane` plus stale-generation completions
- `resetAllLanes` order
- synchronous `onWait` re-entry without budget oversubscription
- publication order independent of object/member order
- moving an active lane between groups wakes its old sibling
- a stale scoped-lane completion cannot retire a newer lane state
- shipped Gateway setup: eight active hooks, older queued cron, later queued hook

Existing timeout, hook reservation, hook burst, aggregate cap, hooks-off, lane-wait visibility, and fresh-module singleton tests remain green.

## Evidence

The committed E2E starts an ephemeral Gateway, enables the real cron service, drives cron through its CLI/RPC, and records provider request bodies while eight distinct hook sessions saturate the shared budget. The older cron turn reaches the provider after one hook completes; the later hook reaches it only after cron completes:

```text
[capacity-group-fairness-trace] {"afterOneHookRelease":"older-cron","afterCronRelease":"later-hook","peakProviderConcurrency":8,"queuedOrder":["cron","later-hook"],"saturatedProviderRequests":8}
```

Command and result:

```text
$ OPENCLAW_E2E_VERBOSE=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts test/gateway-hook-concurrency.e2e.test.ts --disableConsoleIntercept --reporter verbose
✓ test/gateway-hook-concurrency.e2e.test.ts > Gateway hook concurrency > bounds hooks and admits an older cron turn before a later hook
Test Files  1 passed (1)
Tests       1 passed (1)
```

Current patch validation before the final conflict-free rebase (`afb82527a308`, based on `9873b0f6ad8f`):

- `pnpm exec vitest run src/process/command-queue.capacity-groups.test.ts src/process/command-queue.publish-transaction.test.ts src/gateway/server-lanes.hook-group.test.ts --reporter=dot` — 3 files, 37 tests passed
- `pnpm tsgo:core` — passed
- `pnpm tsgo:test` — passed, including core-test shards, extensions, and root tests
- `git merge-tree --write-tree HEAD origin/main` — clean
- `git diff --check` — passed

The final head `0e29bb8b0271` rebases the same four patch commits onto `d61202b128` without conflicts; the three intervening base commits do not touch the queue, capacity-group, Gateway-lane, or committed E2E files, and its merge tree is clean.

Patch-equivalent validation before the final conflict-free rebase:

- the broader targeted run — 6 files, 92 tests passed
- the committed real-Gateway E2E shown above — 1 file, 1 test passed
- full TypeScript/plugin build executed by the E2E global setup — passed

Local limitations:

- current main's durable cron fence cannot obtain process-start identity on Windows, so a local current-head `cron run` stops before queue admission with `cron run cannot acquire a durable fence without process start identity`; the committed E2E remains unchanged and the hosted Linux run is authoritative
- current main replaced `plugin-sdk:api:check` with `plugin-sdk:api:diff`; that wrapper cannot spawn `pnpm` from Windows (`spawn pnpm ENOENT`), so the hosted Linux API check is authoritative

## Scope and risk

No public API, config, persistence, or reservation semantics change.

Production delta is `+164/-101` (`+63` net); tests are `+538/-9`. The production growth pays for one canonical per-slot group dispatcher, process-global re-entrancy protection, scoped-lane lifecycle preservation, and config-migration wakeups. A two-line completion reorder would not cover three-member groups, multi-slot reset/publication, priority, or member migration and would leave multiple bypass paths.
