### PR TITLE
fix(ui): show newly paired devices without reconnect

### DIFF
--- a/ui/src/e2e/new-session-page.places-live.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.places-live.e2e.test.ts
@@ -66,7 +66,13 @@ suite.define(() => {
             },
           ],
         },
-        "environments.list": { environments: [], profiles: [] },
+        "environments.list": {
+          environments: [
+            { id: "gateway", type: "local", status: "available" },
+            { id: "node:existing-mac", type: "node", status: "available" },
+          ],
+          profiles: [],
+        },
       },
     });
 
@@ -96,6 +102,14 @@ suite.define(() => {
           },
         ],
       });
+      await gateway.setMethodResponse("environments.list", {
+        environments: [
+          { id: "gateway", type: "local", status: "available" },
+          { id: "node:existing-mac", type: "node", status: "available" },
+          { id: "node:new-mac", type: "node", status: "available" },
+        ],
+        profiles: [],
+      });
       await gateway.emitGatewayEvent("presence", {
         presence: [
           { deviceId: "existing-mac", mode: "node", reason: "connect", ts: 1 },
@@ -106,12 +120,15 @@ suite.define(() => {
       await expect
         .poll(async () => (await gateway.getRequests("node.list")).length)
         .toBeGreaterThan(nodeRequests);
+      await expect
+        .poll(async () => (await gateway.getRequests("environments.list")).length)
+        .toBeGreaterThan(environmentRequests);
       await place.getByRole("button", { name: "New Mac" }).waitFor();
       await place.getByText("This gateway", { exact: true }).waitFor();
       await place.getByText("Your devices", { exact: true }).waitFor();
       expect(await place.getAttribute("open")).not.toBeNull();
-      expect(await gateway.getRequests("environments.list")).toHaveLength(environmentRequests);
 
+      const refreshedEnvironmentRequests = (await gateway.getRequests("environments.list")).length;
       await gateway.setMethodResponse("environments.list", {
         environments: [],
         profiles: [{ id: "aws", providerId: "crabbox", trust: "disposable" }],
@@ -123,7 +140,7 @@ suite.define(() => {
       });
       await expect
         .poll(async () => (await gateway.getRequests("environments.list")).length)
-        .toBeGreaterThan(environmentRequests);
+        .toBeGreaterThan(refreshedEnvironmentRequests);
       await place.getByText("Cloud", { exact: true }).waitFor();
       await place.getByRole("button", { name: "Cloud · aws" }).waitFor();
       expect(await place.getAttribute("open")).not.toBeNull();

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -184,17 +184,14 @@ class NewSessionPage extends OpenClawLightDomElement {
             if (this.context?.gateway !== gateway) {
               return;
             }
-            if (event.event === "config.changed") {
-              void this.gateway.refreshCloudProfiles();
-              return;
-            }
             if (
+              event.event === "config.changed" ||
               event.event === "node.pair.requested" ||
               event.event === "node.pair.resolved" ||
               event.event === "device.pair.requested" ||
               event.event === "device.pair.resolved"
             ) {
-              void this.place.refreshNodes();
+              this.refreshPlaceTopology();
               return;
             }
             const presence = event.event === "presence" ? readPresence(event.payload) : null;
@@ -204,7 +201,7 @@ class NewSessionPage extends OpenClawLightDomElement {
             const signature = presenceConnectivitySignature(presence);
             if (signature !== this.presenceSignature) {
               this.presenceSignature = signature;
-              void this.place.refreshNodes();
+              this.refreshPlaceTopology();
             }
           });
         },
@@ -221,6 +218,12 @@ class NewSessionPage extends OpenClawLightDomElement {
         () => this.context?.config,
         (config, notify) => config.subscribe(() => notify()),
       );
+  }
+
+  // Device visibility intersects both catalogs, so topology changes must refresh them together.
+  private refreshPlaceTopology() {
+    void this.place.refreshNodes();
+    void this.gateway.refreshCloudProfiles();
   }
 
   handleEvent(event: Event) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a newly paired device could remain missing from the new-session picker until the Control UI reconnected or another configuration refresh occurred. The picker could receive the device’s live presence while still filtering it out through a stale environment catalog.

## Why This Change Was Made

The picker decides device visibility from both the executable-node list and the environment catalog, so topology-changing pairing and presence events now refresh those two sources together. The repair stays at the topology refresh owner and keeps the existing quiet picker behavior; it does not add status UI, polling, or a fallback catalog path.

## User Impact

Newly paired devices appear in the open session-location picker as soon as their topology event arrives. Operators no longer need to reconnect or trigger an unrelated configuration change before selecting the device.

## Evidence

### Before

A presence update adds **New Mac** to the live node list, but the stale environment catalog keeps it hidden:

![Before: newly paired device remains hidden](https://github.com/user-attachments/assets/2d5a5b75-8440-4322-bcdc-4035d794eed4)

### After

The same event refreshes both topology sources and **New Mac** appears while the picker remains open:

![After: newly paired device appears](https://github.com/user-attachments/assets/2c848c09-c048-42fb-85b7-875b02073b6d)

- Picker browser E2E: 2 passed
- Picker/discovery unit tests: 16 passed
- Gateway replacement sibling E2E: 1 passed, 8 skipped
- Targeted formatting, UI i18n verification, core-test/UI typechecks, Oxc lint, and `git diff --check`: passed
- Codex-backed autoreview: no actionable findings
- Source-blind behavior validation: all four contract clauses passed

AI-assisted; implementation and proof were reviewed against the owning topology and picker paths.
