### PR TITLE
fix(test): wait for managed desktop linger teardown

### DIFF
--- a/src/gateway/desktop/managed-linux.test.ts
+++ b/src/gateway/desktop/managed-linux.test.ts
@@ -320,9 +320,6 @@ describe("managed Linux desktop", () => {
     });
     expect(observer).toBeDefined();
     observer?.release();
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 10);
-    });
-    expect(desktop.status()).toEqual({ state: "not-started" });
+    await vi.waitFor(() => expect(desktop.status()).toEqual({ state: "not-started" }));
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves an intermittent CI failure where the managed Linux desktop linger test could assert before asynchronous teardown completed on slower Linux runners.

## Why This Change Was Made

The test now waits for the observable `not-started` state with Vitest polling instead of assuming a fixed 10 ms delay is sufficient. Production code, registry behavior, retry policy, and timeouts are unchanged.

## User Impact

No runtime behavior changes. Maintainers get deterministic coverage of managed desktop linger teardown.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/desktop/managed-linux.test.ts -t "stops and removes its session when the registry linger expires"` (1 passed)
- `node scripts/run-vitest.mjs src/gateway/desktop/managed-linux.test.ts` (7 passed)
- `node scripts/run-vitest.mjs src/gateway/worker-environments/desktop-tunnel.test.ts` (14 passed)
- 50 fresh-process repetitions of the focused linger-teardown test passed locally (50/50) after the Blacksmith Testbox lease remained queued without an IP or run URL
- `./node_modules/.bin/oxfmt --check src/gateway/desktop/managed-linux.test.ts`
- `git diff --check`
- exact-head CI on `4306babe6de34e6e0f6e7df434e116ea6a6371ce`: 51 passed, 47 skipped, 0 failed or pending (`31630781034`)
- local autoreview: clean, no accepted/actionable findings
- local and hosted ClawSweeper exact-head review: no actionable findings or remaining rank-up moves; best-fix verdict yes; production `+0/-0`, tests `+1/-4`
