### PR TITLE
feat(codex): expose model auth readiness

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"0afe8b5e500dce4237ca4b5023ab225cfd31a9897e0d4bfdb2341886df035952","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}
+{"contentHash":"85324ff1701cfebf5d4e19fe5b99db981ab4a472fd11907385d5aee9f3d0ccc2","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
@@ -1,1 +1,1 @@
-{"contentHash":"4580a38b9e871c7d448c90cd247673929caaa7a298877d96d8e3f7e7c970b27a","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
+{"contentHash":"41d2c11385cf7c070863ed8b1c79171cfd7be8cbe09e8be8ab346427aec0eb2f","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-core.json
@@ -1,1 +1,1 @@
-{"contentHash":"b84b53ca4792a410eb488ae4fb303e362c3c84d8eb72e37cf9c922183792a7cd","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}
+{"contentHash":"006ad76bafc4715d66fb3672f4dd25bfb647dcbbbcd4d6fd1760ec458ab4578b","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
@@ -1,1 +1,1 @@
-{"contentHash":"cd582aff7d7278ddc71a3c99bd4f8b46e2083411f02096e8649e74b39ab001ea","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}
+{"contentHash":"df13944d5483b50101df4f33260dc3bdd252e6ecc0872e306f941322d849c4e0","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-message.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-message.json
@@ -1,1 +1,1 @@
-{"contentHash":"abb22832153a23cd5187f92f2cdee6d81889d61697fae04c8647eb3370a1aa93","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}
+{"contentHash":"2304e19902ec4cd66449fc1386cac1edadf346fc9c5ba7386cbacfd0e0972efe","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"a82dcfdcc661b2567ba2ba631d589887d5ca29cfe1d8600696fe0db859f4969f","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}
+{"contentHash":"673e3cad7ea569b3fa295da1838ed041ca191d3b1262fba5af49f6f380855429","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
@@ -1,1 +1,1 @@
-{"contentHash":"034d00199482a5490cb8202aa2ff6c5acd438486e8ab616b5f76674af7fb78c4","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}
+{"contentHash":"fd5e72043daa43e2da0d16f3a9367dbadd912a75f00a6e3fe40e992bcfdeeac4","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}

--- a/docs/.generated/plugin-sdk-api-baseline/core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/core.json
@@ -1,1 +1,1 @@
-{"contentHash":"2efff507ffe87196b554e29043eadc0ba17a32864f3ccd1864d4200add9d8f87","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}
+{"contentHash":"9ee712a108ab7f5d050c4065a4609289e12e509e1738fa4a1027371d41cf364f","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}

--- a/docs/.generated/plugin-sdk-api-baseline/diagnostic-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/diagnostic-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"fc77340b5990c42e5c9b18fd24f85ced694e2b9b66a85e236031bdf3d09d727a","entrypoint":"diagnostic-runtime","importSpecifier":"openclaw/plugin-sdk/diagnostic-runtime"}
+{"contentHash":"9960509e7bc1fda81c475840f04bbdb22aeebb997b16be87363b6f0a1d713a00","entrypoint":"diagnostic-runtime","importSpecifier":"openclaw/plugin-sdk/diagnostic-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/discord.json
+++ b/docs/.generated/plugin-sdk-api-baseline/discord.json
@@ -1,1 +1,1 @@
-{"contentHash":"31bfbc294becf37f8ee037a0f8f50c69e4d04e097ff9bea16089115ee93b80df","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}
+{"contentHash":"3b85be8fd57d36098cba565f1463063f6abfc116fa258e8831564a1ca9578f4e","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}

--- a/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
+++ b/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
@@ -1,1 +1,1 @@
-{"contentHash":"07dbe53008bb2487dd63f28db4d81424cfb67498e4508aae6d86667e78fe1855","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}
+{"contentHash":"e2bed895440406cc55fc92c0fb68d2edde9686d3cd51147eb652b2f2633f05ea","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}

--- a/docs/.generated/plugin-sdk-api-baseline/infra-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/infra-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"6f58c40f7e733eb8dae7d8afd7e49fd79d57d9ea4b808617990bf812dc6e1b71","entrypoint":"infra-runtime","importSpecifier":"openclaw/plugin-sdk/infra-runtime"}
+{"contentHash":"385d424d9fb76c43f1a2e69a9998329cb82648743345e1e6f91556d6827ab311","entrypoint":"infra-runtime","importSpecifier":"openclaw/plugin-sdk/infra-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"5ccd913160d86827e36459bf6c6e88a169306dd24e913b85e288cbbf2ea12157","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}
+{"contentHash":"42c542cba67104b0d9e60ca6be5146b08236a317a2c26afcffba1a28607241b9","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
@@ -1,1 +1,1 @@
-{"contentHash":"d9ae989750b9f69072b5767cdf8995bde3f431da315e031cb80f35d2052a3917","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}
+{"contentHash":"47fb1a761c09c00765aea54bf20e1db4974c9775fb032f607b69003f7acdd6c6","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"dce833138906cea4ce741068911c2e4818ebc37693edb2d2883e54eb7b25778e","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}
+{"contentHash":"46ba058284d4a6779659c01cdf54606feb397345a982077758d43bcb23bc3d08","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"0010661448f741237afcb47b75bdc2178d962e4e5751dfc4d26fdb1c4c487997","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
+{"contentHash":"d50a4810b16bf196540871ca0dedccd401f9cad4fb3c4341c0344eac98655628","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
+++ b/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
@@ -1,1 +1,1 @@
-{"contentHash":"a392d8bbb2ababa55a16ac115beff0ed0b790723c8e6c69c0a46d44c6984ed4e","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}
+{"contentHash":"b7483e36adf422338ec5e0153f1619e0785017eff94c8dc3af63b016107f2283","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}

--- a/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
+++ b/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
@@ -1,1 +1,1 @@
-{"contentHash":"a9f8b45ec3684fdb607c50fc47c41f62255c9ac0eae282b42441df58400fce31","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}
+{"contentHash":"a3ede0fee9ec741ca24915af67f968135b1d332d4fefbfc1413eb3d0f0d6ad0a","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}

--- a/extensions/codex/src/app-server/connection-health.test.ts
+++ b/extensions/codex/src/app-server/connection-health.test.ts
@@ -382,7 +382,9 @@ describe("Codex remote WebSocket connection health", () => {
 
     await service.start(ctx);
     await vi.waitFor(() => expect(client.request).toHaveBeenCalledOnce());
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10);
+    });
     expect(client.request).toHaveBeenCalledOnce();
 
     diagnosticMocks.emitTrustedDiagnosticEvent.mockClear();

--- a/extensions/codex/src/app-server/connection-health.test.ts
+++ b/extensions/codex/src/app-server/connection-health.test.ts
@@ -1,14 +1,16 @@
 import type { OpenClawPluginServiceContext } from "openclaw/plugin-sdk/plugin-entry";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { CodexAppServerClient } from "./client.js";
+import { CodexAppServerRpcError, type CodexAppServerClient } from "./client.js";
 import { createCodexAppServerConnectionHealthService } from "./connection-health.js";
 
 const sharedClientMocks = vi.hoisted(() => ({
   getLeasedSharedCodexAppServerClient: vi.fn(),
   releaseLeasedSharedCodexAppServerClient: vi.fn(),
 }));
+const diagnosticMocks = vi.hoisted(() => ({ emitTrustedDiagnosticEvent: vi.fn() }));
 
 vi.mock("./shared-client.js", () => sharedClientMocks);
+vi.mock("openclaw/plugin-sdk/diagnostic-runtime", () => diagnosticMocks);
 
 describe("Codex remote WebSocket connection health", () => {
   afterEach(() => {
@@ -32,7 +34,11 @@ describe("Codex remote WebSocket connection health", () => {
       expect(sharedClientMocks.getLeasedSharedCodexAppServerClient).toHaveBeenCalledOnce();
       expect(client.addCloseHandler).toHaveBeenCalledOnce();
     });
-    expect(client.request).not.toHaveBeenCalled();
+    expect(client.request).toHaveBeenCalledWith(
+      "account/read",
+      { refreshToken: false },
+      expect.objectContaining({ timeoutMs: 10_000, signal: expect.any(AbortSignal) }),
+    );
 
     await service.stop?.(ctx);
 
@@ -67,8 +73,8 @@ describe("Codex remote WebSocket connection health", () => {
       },
       { timeout: 3_000 },
     );
-    expect(first.request).not.toHaveBeenCalled();
-    expect(second.request).not.toHaveBeenCalled();
+    expect(first.request).toHaveBeenCalled();
+    expect(second.request).toHaveBeenCalled();
 
     await service.stop?.(ctx);
 
@@ -97,7 +103,7 @@ describe("Codex remote WebSocket connection health", () => {
       },
       { timeout: 3_000 },
     );
-    expect(client.request).not.toHaveBeenCalled();
+    expect(client.request).toHaveBeenCalled();
 
     await service.stop?.(ctx);
 
@@ -144,6 +150,12 @@ describe("Codex remote WebSocket connection health", () => {
     );
     expect(sharedClientMocks.getLeasedSharedCodexAppServerClient).not.toHaveBeenCalled();
 
+    await vi.waitFor(() => {
+      expect(diagnosticMocks.emitTrustedDiagnosticEvent).toHaveBeenLastCalledWith({
+        type: "model.auth.clear",
+      });
+    });
+
     await service.stop?.(ctx);
   });
 
@@ -159,11 +171,294 @@ describe("Codex remote WebSocket connection health", () => {
 
     expect(sharedClientMocks.getLeasedSharedCodexAppServerClient).not.toHaveBeenCalled();
   });
+
+  it("actively proves a ChatGPT account ready without starting a model", async () => {
+    const client = createClient(async (method) =>
+      method === "account/read"
+        ? { account: { type: "chatgpt" }, requiresOpenaiAuth: true }
+        : { rateLimits: {} },
+    );
+    sharedClientMocks.getLeasedSharedCodexAppServerClient.mockResolvedValueOnce(client.client);
+    const ctx = createServiceContext();
+    const service = createService(ctx);
+
+    await service.start(ctx);
+    await vi.waitFor(() => {
+      expect(diagnosticMocks.emitTrustedDiagnosticEvent).toHaveBeenCalledWith({
+        type: "model.auth.state",
+        state: "ready",
+        authMode: "subscription",
+        reason: "ready",
+      });
+    });
+    expect(client.request).toHaveBeenNthCalledWith(
+      1,
+      "account/read",
+      { refreshToken: false },
+      expect.anything(),
+    );
+    expect(client.request).toHaveBeenNthCalledWith(
+      2,
+      "account/rateLimits/read",
+      undefined,
+      expect.anything(),
+    );
+    await service.stop?.(ctx);
+  });
+
+  it("reports a missing ChatGPT account before user traffic", async () => {
+    const client = createClient(async () => ({ account: null, requiresOpenaiAuth: true }));
+    sharedClientMocks.getLeasedSharedCodexAppServerClient.mockResolvedValueOnce(client.client);
+    const ctx = createServiceContext();
+    const service = createService(ctx);
+
+    await service.start(ctx);
+    await vi.waitFor(() => {
+      expect(diagnosticMocks.emitTrustedDiagnosticEvent).toHaveBeenCalledWith({
+        type: "model.auth.state",
+        state: "not_ready",
+        authMode: "subscription",
+        reason: "missing_account",
+      });
+    });
+    expect(client.request).toHaveBeenCalledTimes(1);
+    await service.stop?.(ctx);
+  });
+
+  it("does not mark non-OpenAI routes as logged out without an active proof", async () => {
+    const client = createClient(async () => ({ account: null, requiresOpenaiAuth: false }));
+    sharedClientMocks.getLeasedSharedCodexAppServerClient.mockResolvedValueOnce(client.client);
+    const ctx = createServiceContext();
+    const service = createService(ctx);
+
+    await service.start(ctx);
+    await vi.waitFor(() => {
+      expect(diagnosticMocks.emitTrustedDiagnosticEvent).toHaveBeenCalledWith({
+        type: "model.auth.state",
+        state: "unknown",
+        authMode: "unknown",
+        reason: "unsupported_auth_mode",
+      });
+    });
+    expect(client.request).toHaveBeenCalledTimes(1);
+    await service.stop?.(ctx);
+  });
+
+  it("reports route mismatches without spending the wrong auth mode", async () => {
+    const cases = [
+      {
+        account: { type: "apiKey" },
+        requiresOpenaiAuth: true,
+        expectedAuthMode: "subscription",
+      },
+      {
+        account: { type: "chatgpt" },
+        requiresOpenaiAuth: false,
+        expectedAuthMode: "api_key",
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      diagnosticMocks.emitTrustedDiagnosticEvent.mockClear();
+      const client = createClient(async () => ({
+        account: testCase.account,
+        requiresOpenaiAuth: testCase.requiresOpenaiAuth,
+      }));
+      sharedClientMocks.getLeasedSharedCodexAppServerClient.mockResolvedValueOnce(client.client);
+      const ctx = createServiceContext();
+      const service = createService(ctx);
+
+      await service.start(ctx);
+      await vi.waitFor(() => {
+        expect(diagnosticMocks.emitTrustedDiagnosticEvent).toHaveBeenCalledWith({
+          type: "model.auth.state",
+          state: "not_ready",
+          authMode: testCase.expectedAuthMode,
+          reason: "route_mismatch",
+        });
+      });
+      expect(client.request).toHaveBeenCalledTimes(1);
+      await service.stop?.(ctx);
+    }
+  });
+
+  it("uses the packaged RPC error shape to classify only definite auth failures", async () => {
+    const fixtures = [
+      {
+        error: new CodexAppServerRpcError(
+          {
+            code: -32603,
+            message: "request failed",
+            data: { error: { statusCode: 401, action: "relogin" } },
+          },
+          "account/rateLimits/read",
+        ),
+        expectedState: "not_ready",
+        expectedReason: "unauthenticated",
+      },
+      {
+        error: new CodexAppServerRpcError(
+          { code: -32603, message: "request failed", data: { statusCode: 503 } },
+          "account/rateLimits/read",
+        ),
+        expectedState: "unknown",
+        expectedReason: "probe_error",
+      },
+    ] as const;
+
+    for (const fixture of fixtures) {
+      diagnosticMocks.emitTrustedDiagnosticEvent.mockClear();
+      const client = createClient(async (method) => {
+        if (method === "account/read") {
+          return { account: { type: "chatgpt" }, requiresOpenaiAuth: true };
+        }
+        throw fixture.error;
+      });
+      sharedClientMocks.getLeasedSharedCodexAppServerClient.mockResolvedValueOnce(client.client);
+      const ctx = createServiceContext();
+      const service = createService(ctx);
+      await service.start(ctx);
+      await vi.waitFor(() =>
+        expect(diagnosticMocks.emitTrustedDiagnosticEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: "model.auth.state",
+            state: fixture.expectedState,
+            reason: fixture.expectedReason,
+          }),
+        ),
+      );
+      await service.stop?.(ctx);
+    }
+  });
+
+  it("repeats serially and reports recovery", async () => {
+    let reads = 0;
+    const client = createClient(async (method) => {
+      if (method === "account/read") {
+        reads += 1;
+        return reads === 1
+          ? { account: null, requiresOpenaiAuth: true }
+          : { account: { type: "chatgpt" }, requiresOpenaiAuth: true };
+      }
+      return { rateLimits: {} };
+    });
+    sharedClientMocks.getLeasedSharedCodexAppServerClient.mockResolvedValueOnce(client.client);
+    const ctx = createServiceContext();
+    const service = createService(ctx, { modelAuthProbeIntervalMs: 5, random: () => 0.5 });
+
+    await service.start(ctx);
+    await vi.waitFor(() => {
+      expect(diagnosticMocks.emitTrustedDiagnosticEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ state: "not_ready", reason: "missing_account" }),
+      );
+      expect(diagnosticMocks.emitTrustedDiagnosticEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ state: "ready", reason: "ready" }),
+      );
+    });
+    await service.stop?.(ctx);
+  });
+
+  it("does not overlap probes and aborts the in-flight request on stop", async () => {
+    let activeRequests = 0;
+    let maxActiveRequests = 0;
+    const client = createClient(
+      async (_method, _params, requestOptions) =>
+        await new Promise((_resolve, reject) => {
+          activeRequests += 1;
+          maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
+          requestOptions?.signal?.addEventListener(
+            "abort",
+            () => {
+              activeRequests -= 1;
+              reject(new Error("test request aborted"));
+            },
+            { once: true },
+          );
+        }),
+    );
+    sharedClientMocks.getLeasedSharedCodexAppServerClient.mockResolvedValueOnce(client.client);
+    const ctx = createServiceContext();
+    const service = createService(ctx, { modelAuthProbeIntervalMs: 1, random: () => 0.5 });
+
+    await service.start(ctx);
+    await vi.waitFor(() => expect(client.request).toHaveBeenCalledOnce());
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(client.request).toHaveBeenCalledOnce();
+
+    diagnosticMocks.emitTrustedDiagnosticEvent.mockClear();
+    await service.stop?.(ctx);
+    expect(maxActiveRequests).toBe(1);
+    expect(activeRequests).toBe(0);
+    expect(diagnosticMocks.emitTrustedDiagnosticEvent).toHaveBeenCalledOnce();
+    expect(diagnosticMocks.emitTrustedDiagnosticEvent).toHaveBeenLastCalledWith({
+      type: "model.auth.clear",
+    });
+  });
+
+  it("clears auth state on stop and repopulates it after restart", async () => {
+    const first = createClient(async (method) =>
+      method === "account/read"
+        ? { account: { type: "chatgpt" }, requiresOpenaiAuth: true }
+        : { rateLimits: {} },
+    );
+    const second = createClient(async (method) =>
+      method === "account/read"
+        ? { account: { type: "chatgpt" }, requiresOpenaiAuth: true }
+        : { rateLimits: {} },
+    );
+    sharedClientMocks.getLeasedSharedCodexAppServerClient
+      .mockResolvedValueOnce(first.client)
+      .mockResolvedValueOnce(second.client);
+    const ctx = createServiceContext();
+    const service = createService(ctx);
+
+    await service.start(ctx);
+    await vi.waitFor(() =>
+      expect(diagnosticMocks.emitTrustedDiagnosticEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "model.auth.state", state: "ready" }),
+      ),
+    );
+    await service.stop?.(ctx);
+    expect(diagnosticMocks.emitTrustedDiagnosticEvent).toHaveBeenLastCalledWith({
+      type: "model.auth.clear",
+    });
+
+    diagnosticMocks.emitTrustedDiagnosticEvent.mockClear();
+    await service.start(ctx);
+    await vi.waitFor(() =>
+      expect(diagnosticMocks.emitTrustedDiagnosticEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "model.auth.state", state: "ready" }),
+      ),
+    );
+    expect(diagnosticMocks.emitTrustedDiagnosticEvent).not.toHaveBeenCalledWith({
+      type: "model.auth.clear",
+    });
+    await service.stop?.(ctx);
+  });
 });
 
-function createClient() {
+function createService(
+  ctx: OpenClawPluginServiceContext,
+  testOptions: { modelAuthProbeIntervalMs?: number; random?: () => number } = {},
+) {
+  return createCodexAppServerConnectionHealthService({
+    getPluginConfig: () => ({
+      appServer: { transport: "websocket", url: "ws://127.0.0.1:39175" },
+    }),
+    getRuntimeConfig: () => ctx.config,
+    ...testOptions,
+  });
+}
+
+function createClient(
+  requestImpl: (
+    method: string,
+    params?: unknown,
+    requestOptions?: { timeoutMs?: number; signal?: AbortSignal },
+  ) => Promise<unknown> = async () => ({ account: null }),
+) {
   const handlers = new Set<(client: CodexAppServerClient) => void>();
-  const request = vi.fn();
+  const request = vi.fn(requestImpl);
   const addCloseHandler = vi.fn((handler: (client: CodexAppServerClient) => void) => {
     handlers.add(handler);
     return () => handlers.delete(handler);

--- a/extensions/codex/src/app-server/connection-health.ts
+++ b/extensions/codex/src/app-server/connection-health.ts
@@ -59,7 +59,7 @@ export function createCodexAppServerConnectionHealthService(
       try {
         pluginConfig = options.getPluginConfig();
         runtime = resolveCodexAppServerRuntimeOptions({ pluginConfig });
-      } catch (error) {
+      } catch {
         if (!signal.aborted) {
           ctx.logger.error(
             "codex app-server remote WebSocket configuration is invalid; update the configuration before reconnecting",

--- a/extensions/codex/src/app-server/connection-health.ts
+++ b/extensions/codex/src/app-server/connection-health.ts
@@ -1,9 +1,19 @@
+import {
+  emitTrustedDiagnosticEvent,
+  type DiagnosticModelAuthStateEvent,
+} from "openclaw/plugin-sdk/diagnostic-runtime";
 import type {
   OpenClawPluginService,
   OpenClawPluginServiceContext,
 } from "openclaw/plugin-sdk/plugin-entry";
-import { isUnsupportedCodexAppServerVersionError, type CodexAppServerClient } from "./client.js";
+import {
+  CodexAppServerRpcError,
+  isCodexAppServerConnectionClosedError,
+  isUnsupportedCodexAppServerVersionError,
+  type CodexAppServerClient,
+} from "./client.js";
 import { resolveCodexAppServerRuntimeOptions } from "./config.js";
+import { isJsonObject } from "./protocol.js";
 import {
   getLeasedSharedCodexAppServerClient,
   releaseLeasedSharedCodexAppServerClient,
@@ -11,10 +21,17 @@ import {
 
 const INITIAL_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 30_000;
+const MODEL_AUTH_PROBE_INTERVAL_MS = 60_000;
+const MODEL_AUTH_PROBE_JITTER_RATIO = 0.1;
+const MODEL_AUTH_PROBE_TIMEOUT_MS = 10_000;
+
+type ModelAuthStateInput = Omit<DiagnosticModelAuthStateEvent, "seq" | "ts" | "type">;
 
 type CodexAppServerConnectionHealthServiceOptions = {
   getPluginConfig: () => unknown;
   getRuntimeConfig: () => OpenClawPluginServiceContext["config"] | undefined;
+  modelAuthProbeIntervalMs?: number;
+  random?: () => number;
 };
 
 export function createCodexAppServerConnectionHealthService(
@@ -44,9 +61,8 @@ export function createCodexAppServerConnectionHealthService(
         runtime = resolveCodexAppServerRuntimeOptions({ pluginConfig });
       } catch (error) {
         if (!signal.aborted) {
-          const message = error instanceof Error ? error.message : String(error);
           ctx.logger.error(
-            `codex app-server remote WebSocket configuration is invalid; update the configuration before reconnecting: ${message}`,
+            "codex app-server remote WebSocket configuration is invalid; update the configuration before reconnecting",
           );
         }
         return;
@@ -68,8 +84,19 @@ export function createCodexAppServerConnectionHealthService(
 
         consecutiveFailures = 0;
         ctx.logger.info("codex app-server remote WebSocket connection is healthy");
-        await waitForCodexAppServerClose(leasedClient, signal);
+        await runModelAuthProbeLoop({
+          client: leasedClient,
+          signal,
+          timeoutMs: Math.min(runtime.requestTimeoutMs, MODEL_AUTH_PROBE_TIMEOUT_MS),
+          intervalMs: options.modelAuthProbeIntervalMs ?? MODEL_AUTH_PROBE_INTERVAL_MS,
+          random: options.random ?? Math.random,
+        });
         if (!signal.aborted) {
+          emitModelAuthState({
+            state: "unknown",
+            authMode: "unknown",
+            reason: "transport_error",
+          });
           ctx.logger.warn("codex app-server remote WebSocket disconnected; reconnecting");
         }
       } catch (error) {
@@ -81,6 +108,11 @@ export function createCodexAppServerConnectionHealthService(
             );
             return;
           }
+          emitModelAuthState({
+            state: "unknown",
+            authMode: "unknown",
+            reason: "transport_error",
+          });
           consecutiveFailures += 1;
           ctx.logger.warn(`codex app-server remote WebSocket connection failed: ${message}`);
         }
@@ -109,7 +141,7 @@ export function createCodexAppServerConnectionHealthService(
         return;
       }
       abortController = new AbortController();
-      monitor = run(ctx, abortController.signal);
+      monitor = run(ctx, abortController.signal).finally(clearModelAuthState);
     },
     async stop() {
       abortController?.abort();
@@ -119,6 +151,121 @@ export function createCodexAppServerConnectionHealthService(
       abortController = undefined;
     },
   };
+}
+
+function emitModelAuthState(state: ModelAuthStateInput): void {
+  emitTrustedDiagnosticEvent({ type: "model.auth.state", ...state });
+}
+
+function clearModelAuthState(): void {
+  emitTrustedDiagnosticEvent({ type: "model.auth.clear" });
+}
+
+async function runModelAuthProbeLoop(params: {
+  client: CodexAppServerClient;
+  signal: AbortSignal;
+  timeoutMs: number;
+  intervalMs: number;
+  random: () => number;
+}): Promise<void> {
+  const connectionAbort = new AbortController();
+  const close = () => connectionAbort.abort();
+  const removeCloseHandler = params.client.addCloseHandler(close);
+  params.signal.addEventListener("abort", close, { once: true });
+  try {
+    while (!connectionAbort.signal.aborted) {
+      const state = await probeModelAuthState(params.client, {
+        signal: connectionAbort.signal,
+        timeoutMs: params.timeoutMs,
+      });
+      if (connectionAbort.signal.aborted) {
+        break;
+      }
+      emitModelAuthState(state);
+      await waitForReconnect(
+        jitteredModelAuthProbeDelayMs(params.intervalMs, params.random),
+        connectionAbort.signal,
+      );
+    }
+  } finally {
+    removeCloseHandler();
+    params.signal.removeEventListener("abort", close);
+  }
+}
+
+async function probeModelAuthState(
+  client: CodexAppServerClient,
+  options: { signal: AbortSignal; timeoutMs: number },
+): Promise<ModelAuthStateInput> {
+  try {
+    const response = await client.request("account/read", { refreshToken: false }, options);
+    const requiresOpenaiAuth =
+      response.requiresOpenaiAuth === true
+        ? true
+        : response.requiresOpenaiAuth === false
+          ? false
+          : undefined;
+    if (!response.account) {
+      return requiresOpenaiAuth === true
+        ? { state: "not_ready", authMode: "subscription", reason: "missing_account" }
+        : { state: "unknown", authMode: "unknown", reason: "unsupported_auth_mode" };
+    }
+    if (!isJsonObject(response.account) || typeof response.account.type !== "string") {
+      return { state: "unknown", authMode: "unknown", reason: "probe_error" };
+    }
+    if (response.account.type === "chatgpt" && requiresOpenaiAuth === false) {
+      return { state: "not_ready", authMode: "api_key", reason: "route_mismatch" };
+    }
+    if (response.account.type !== "chatgpt") {
+      if (requiresOpenaiAuth === true) {
+        return { state: "not_ready", authMode: "subscription", reason: "route_mismatch" };
+      }
+      return {
+        state: "unknown",
+        authMode: response.account.type === "apiKey" ? "api_key" : "native",
+        reason: "unsupported_auth_mode",
+      };
+    }
+    await client.request("account/rateLimits/read", undefined, options);
+    return { state: "ready", authMode: "subscription", reason: "ready" };
+  } catch (error) {
+    if (options.signal.aborted || isCodexAppServerConnectionClosedError(error)) {
+      return { state: "unknown", authMode: "unknown", reason: "transport_error" };
+    }
+    if (isDefiniteModelAuthFailure(error)) {
+      return { state: "not_ready", authMode: "subscription", reason: "unauthenticated" };
+    }
+    if (isUnsupportedModelAuthProbe(error)) {
+      return { state: "unknown", authMode: "unknown", reason: "unsupported_version" };
+    }
+    return { state: "unknown", authMode: "unknown", reason: "probe_error" };
+  }
+}
+
+function isDefiniteModelAuthFailure(error: unknown): boolean {
+  if (!(error instanceof CodexAppServerRpcError)) {
+    return false;
+  }
+  if (error.code === 401 || error.code === 403) {
+    return true;
+  }
+  const data = isJsonObject(error.data) ? error.data : undefined;
+  const nested = isJsonObject(data?.error) ? data.error : data;
+  return (
+    nested?.statusCode === 401 ||
+    nested?.statusCode === 403 ||
+    nested?.action === "relogin" ||
+    (nested?.reason === "cloudRequirements" && nested?.errorCode === "Auth")
+  );
+}
+
+function isUnsupportedModelAuthProbe(error: unknown): boolean {
+  return error instanceof CodexAppServerRpcError && error.code === -32601;
+}
+
+function jitteredModelAuthProbeDelayMs(intervalMs: number, random: () => number): number {
+  const factor = 1 - MODEL_AUTH_PROBE_JITTER_RATIO + random() * MODEL_AUTH_PROBE_JITTER_RATIO * 2;
+  return Math.max(1, Math.round(intervalMs * factor));
 }
 
 function isPermanentCodexAppServerConnectionFailure(error: unknown): boolean {
@@ -155,26 +302,6 @@ function isPermanentCodexAppServerConnectionFailure(error: unknown): boolean {
   }
 
   return false;
-}
-
-function waitForCodexAppServerClose(
-  client: CodexAppServerClient,
-  signal: AbortSignal,
-): Promise<void> {
-  return new Promise((resolve) => {
-    if (signal.aborted) {
-      resolve();
-      return;
-    }
-
-    const finish = () => {
-      removeCloseHandler();
-      signal.removeEventListener("abort", finish);
-      resolve();
-    };
-    const removeCloseHandler = client.addCloseHandler(finish);
-    signal.addEventListener("abort", finish, { once: true });
-  });
 }
 
 function waitForReconnect(delayMs: number, signal: AbortSignal): Promise<void> {

--- a/extensions/diagnostics-otel/src/service-events.ts
+++ b/extensions/diagnostics-otel/src/service-events.ts
@@ -76,6 +76,8 @@ export function createDiagnosticsEventHandler(params: {
     recordTelemetryExporter,
     recordPayloadLarge,
     recordModelFailover,
+    recordModelAuthState,
+    clearModelAuthState,
   } = recorders;
   return (
     evt: DiagnosticEventPayload,
@@ -189,6 +191,16 @@ export function createDiagnosticsEventHandler(params: {
           return;
         case "model.call.error":
           recordModelCallError(evt, metadata, privateData.modelContent);
+          return;
+        case "model.auth.state":
+          if (metadata.trusted) {
+            recordModelAuthState(evt);
+          }
+          return;
+        case "model.auth.clear":
+          if (metadata.trusted) {
+            clearModelAuthState();
+          }
           return;
         case "tool.execution.started":
           recordToolExecutionStarted(evt, metadata);

--- a/extensions/diagnostics-otel/src/service-metrics.ts
+++ b/extensions/diagnostics-otel/src/service-metrics.ts
@@ -1,4 +1,5 @@
-import type { Meter, MetricOptions } from "@opentelemetry/api";
+import type { Attributes, Meter, MetricOptions, ObservableResult } from "@opentelemetry/api";
+import type { DiagnosticModelAuthStateEvent } from "openclaw/plugin-sdk/diagnostic-runtime";
 import {
   AGENT_DURATION_MS_BUCKETS,
   CONTEXT_TOKENS_BUCKETS,
@@ -18,6 +19,35 @@ export function createDiagnosticsMetrics(
     meter.createCounter(resolveMetricName(name), options);
   const createHistogram = (name: `openclaw.${string}`, options?: MetricOptions) =>
     meter.createHistogram(resolveMetricName(name), options);
+  let modelAuthState:
+    | { value: number; observedAtSeconds: number; attributes: Attributes }
+    | undefined;
+  const modelAuthReadyGauge = meter.createObservableGauge(
+    resolveMetricName("openclaw.model_auth_ready"),
+    {
+      unit: "1",
+      description: "Latest actively observed Codex model authentication readiness",
+    },
+  );
+  const modelAuthLastProbeGauge = meter.createObservableGauge(
+    resolveMetricName("openclaw.model_auth_last_probe"),
+    {
+      unit: "s",
+      description: "Unix timestamp of the latest Codex model authentication probe",
+    },
+  );
+  const observeModelAuthReady = (result: ObservableResult) => {
+    if (modelAuthState) {
+      result.observe(modelAuthState.value, modelAuthState.attributes);
+    }
+  };
+  const observeModelAuthLastProbe = (result: ObservableResult) => {
+    if (modelAuthState) {
+      result.observe(modelAuthState.observedAtSeconds, modelAuthState.attributes);
+    }
+  };
+  modelAuthReadyGauge.addCallback(observeModelAuthReady);
+  modelAuthLastProbeGauge.addCallback(observeModelAuthLastProbe);
 
   const tokensCounter = createCounter("openclaw.tokens", {
     unit: "1",
@@ -286,6 +316,24 @@ export function createDiagnosticsMetrics(
     description: "Diagnostic telemetry exporter lifecycle and failure events",
   });
   return {
+    recordModelAuthState(evt: DiagnosticModelAuthStateEvent) {
+      modelAuthState = {
+        value: evt.state === "ready" ? 1 : evt.state === "not_ready" ? 0 : -1,
+        observedAtSeconds: evt.ts / 1_000,
+        attributes: {
+          "openclaw.auth_mode": evt.authMode,
+          "openclaw.reason": evt.reason,
+        },
+      };
+    },
+    clearModelAuthState() {
+      modelAuthState = undefined;
+    },
+    disposeModelAuthMetrics() {
+      modelAuthState = undefined;
+      modelAuthReadyGauge.removeCallback(observeModelAuthReady);
+      modelAuthLastProbeGauge.removeCallback(observeModelAuthLastProbe);
+    },
     tokensCounter,
     genAiTokenUsageHistogram,
     genAiOperationDurationHistogram,

--- a/extensions/diagnostics-otel/src/service-recorders-model.ts
+++ b/extensions/diagnostics-otel/src/service-recorders-model.ts
@@ -212,5 +212,7 @@ export function createModelRecorders(runtime: DiagnosticsRecorderRuntime) {
     recordModelCallStarted,
     recordModelCallCompleted,
     recordModelCallError,
+    recordModelAuthState: runtime.recordModelAuthState,
+    clearModelAuthState: runtime.clearModelAuthState,
   };
 }

--- a/extensions/diagnostics-otel/src/service-recorders-model.ts
+++ b/extensions/diagnostics-otel/src/service-recorders-model.ts
@@ -212,7 +212,8 @@ export function createModelRecorders(runtime: DiagnosticsRecorderRuntime) {
     recordModelCallStarted,
     recordModelCallCompleted,
     recordModelCallError,
-    recordModelAuthState: runtime.recordModelAuthState,
-    clearModelAuthState: runtime.clearModelAuthState,
+    recordModelAuthState: (evt: Extract<DiagnosticEventPayload, { type: "model.auth.state" }>) =>
+      runtime.recordModelAuthState(evt),
+    clearModelAuthState: () => runtime.clearModelAuthState(),
   };
 }

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -13,6 +13,14 @@ const telemetryState = vi.hoisted(() => {
   };
   const counters = new Map<string, { add: ReturnType<typeof vi.fn> }>();
   const histograms = new Map<string, { record: ReturnType<typeof vi.fn> }>();
+  const observableGauges = new Map<
+    string,
+    {
+      addCallback: ReturnType<typeof vi.fn>;
+      removeCallback: ReturnType<typeof vi.fn>;
+      callbacks: Set<(result: { observe(value: number, attrs?: unknown): void }) => void>;
+    }
+  >();
   const spans: Array<{
     name: string;
     addEvent: ReturnType<typeof vi.fn>;
@@ -52,8 +60,20 @@ const telemetryState = vi.hoisted(() => {
       histograms.set(name, histogram);
       return histogram;
     }),
+    createObservableGauge: vi.fn((name: string) => {
+      const callbacks = new Set<
+        (result: { observe(value: number, attrs?: unknown): void }) => void
+      >();
+      const gauge = {
+        callbacks,
+        addCallback: vi.fn((callback) => callbacks.add(callback)),
+        removeCallback: vi.fn((callback) => callbacks.delete(callback)),
+      };
+      observableGauges.set(name, gauge);
+      return gauge;
+    }),
   };
-  return { counters, histograms, spans, tracer, meter };
+  return { counters, histograms, observableGauges, spans, tracer, meter };
 });
 
 const traceProviderCtor = vi.hoisted(() => vi.fn());
@@ -713,11 +733,13 @@ describe("diagnostics-otel service", () => {
     delete process.env.OTEL_PROPAGATORS;
     telemetryState.counters.clear();
     telemetryState.histograms.clear();
+    telemetryState.observableGauges.clear();
     telemetryState.spans.length = 0;
     telemetryState.tracer.startSpan.mockClear();
     telemetryState.tracer.setSpanContext.mockClear();
     telemetryState.meter.createCounter.mockClear();
     telemetryState.meter.createHistogram.mockClear();
+    telemetryState.meter.createObservableGauge.mockClear();
     traceProviderCtor.mockClear();
     traceProviderShutdown.mockClear();
     meterProviderCtor.mockClear();
@@ -926,6 +948,88 @@ describe("diagnostics-otel service", () => {
       );
     },
   );
+
+  test("exports only the latest trusted model auth state and actual probe time", async () => {
+    const startedAtSeconds = Date.now() / 1_000;
+    const started = await startOtelService({ metrics: true });
+
+    const collect = (name: string) => {
+      const observations: Array<{ value: number; attrs?: unknown }> = [];
+      const gauge = telemetryState.observableGauges.get(name);
+      for (const callback of gauge?.callbacks ?? []) {
+        callback({ observe: (value, attrs) => observations.push({ value, attrs }) });
+      }
+      return observations;
+    };
+    expect(collect("openclaw.model_auth_ready")).toEqual([]);
+    expect(collect("openclaw.model_auth_last_probe")).toEqual([]);
+
+    emitTrustedDiagnosticEvent({
+      type: "model.auth.state",
+      state: "ready",
+      authMode: "subscription",
+      reason: "ready",
+    });
+    emitDiagnosticEvent({
+      type: "model.auth.state",
+      state: "not_ready",
+      authMode: "unknown",
+      reason: "missing_account",
+    });
+
+    expect(collect("openclaw.model_auth_ready")).toEqual([
+      {
+        value: 1,
+        attrs: { "openclaw.auth_mode": "subscription", "openclaw.reason": "ready" },
+      },
+    ]);
+
+    emitTrustedDiagnosticEvent({
+      type: "model.auth.state",
+      state: "not_ready",
+      authMode: "subscription",
+      reason: "unauthenticated",
+    });
+    expect(collect("openclaw.model_auth_ready")).toEqual([
+      {
+        value: 0,
+        attrs: {
+          "openclaw.auth_mode": "subscription",
+          "openclaw.reason": "unauthenticated",
+        },
+      },
+    ]);
+    const probe = collect("openclaw.model_auth_last_probe");
+    expect(probe).toHaveLength(1);
+    expect(probe[0]?.value).toBeGreaterThanOrEqual(startedAtSeconds);
+    expect(probe[0]?.attrs).toEqual({
+      "openclaw.auth_mode": "subscription",
+      "openclaw.reason": "unauthenticated",
+    });
+
+    emitDiagnosticEvent({ type: "model.auth.clear" });
+    expect(collect("openclaw.model_auth_ready")).toHaveLength(1);
+    emitTrustedDiagnosticEvent({ type: "model.auth.clear" });
+    expect(collect("openclaw.model_auth_ready")).toEqual([]);
+    expect(collect("openclaw.model_auth_last_probe")).toEqual([]);
+
+    emitTrustedDiagnosticEvent({
+      type: "model.auth.state",
+      state: "ready",
+      authMode: "subscription",
+      reason: "ready",
+    });
+    expect(collect("openclaw.model_auth_ready")).toEqual([
+      {
+        value: 1,
+        attrs: { "openclaw.auth_mode": "subscription", "openclaw.reason": "ready" },
+      },
+    ]);
+
+    await started.service.stop?.(started.ctx);
+    expect(collect("openclaw.model_auth_ready")).toEqual([]);
+    expect(collect("openclaw.model_auth_last_probe")).toEqual([]);
+  });
 
   test("records message-flow metrics and spans", async () => {
     await startOtelService({ traces: true, metrics: true, logs: true });

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -193,6 +193,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
   let unregisterOwnedSdkRuntime: (() => void) | null = null;
   let unregisterUnhandledRejectionHandler: (() => void) | null = null;
   let retireExporterRoutes: ((preserveFailures?: boolean) => void) | null = null;
+  let disposeDiagnosticMetrics: (() => void) | null = null;
   let preserveExporterRoutesOnNextStop = false;
 
   const stopStarted = async (options?: { preserveExporterRoutes?: boolean }) => {
@@ -205,6 +206,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
     const currentUnregisterOwnedSdkRuntime = unregisterOwnedSdkRuntime;
     const currentUnregisterUnhandledRejectionHandler = unregisterUnhandledRejectionHandler;
     const currentRetireExporterRoutes = retireExporterRoutes;
+    const currentDisposeDiagnosticMetrics = disposeDiagnosticMetrics;
 
     unsubscribe = null;
     unregisterTracePropagationBridge = null;
@@ -214,6 +216,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
     stopActiveTrustedSpans = null;
     unregisterOwnedSdkRuntime = null;
     unregisterUnhandledRejectionHandler = null;
+    disposeDiagnosticMetrics = null;
     retireExporterRoutes = options?.preserveExporterRoutes ? currentRetireExporterRoutes : null;
 
     const settle = async (...stops: Array<(() => void | Promise<void>) | null>) =>
@@ -226,6 +229,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       currentUnsubscribe,
       currentStopActiveTrustedSpans,
       currentUnregisterOwnedSdkRuntime,
+      currentDisposeDiagnosticMetrics,
     );
     const providerFailures = await settle(
       currentLogProvider ? () => currentLogProvider.shutdown() : null,
@@ -562,6 +566,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const diagnosticsTrace = createDiagnosticsTraceRuntime(tracer);
       stopActiveTrustedSpans = diagnosticsTrace.stopActiveTrustedSpans;
       const diagnosticMetrics = createDiagnosticsMetrics(meter, otel.metricNamePrefix);
+      disposeDiagnosticMetrics = diagnosticMetrics.disposeModelAuthMetrics;
 
       const diagnosticsLogs = createDiagnosticsLogExporter({
         contentCapturePolicy,

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -566,7 +566,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const diagnosticsTrace = createDiagnosticsTraceRuntime(tracer);
       stopActiveTrustedSpans = diagnosticsTrace.stopActiveTrustedSpans;
       const diagnosticMetrics = createDiagnosticsMetrics(meter, otel.metricNamePrefix);
-      disposeDiagnosticMetrics = diagnosticMetrics.disposeModelAuthMetrics;
+      disposeDiagnosticMetrics = () => diagnosticMetrics.disposeModelAuthMetrics();
 
       const diagnosticsLogs = createDiagnosticsLogExporter({
         contentCapturePolicy,

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -131,7 +131,8 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   "channel-reply-pipeline": 12,
   "interactive-runtime": 11,
   // +3: canonical incognito classifier projected through deprecated compatibility barrels.
-  "infra-runtime": 596,
+  // +2: model-auth state/clear diagnostic event contracts during the runtime-barrel migration.
+  "infra-runtime": 598,
   "ssrf-policy": 1,
   "ssrf-runtime": 1,
   // +1: deprecated agent media projection re-export during the media migration window.

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -350,7 +350,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +4: session-write lease no-op compatibility stubs through the 2026.10 train.
       // +7: restore still-existing deprecated inbound-dispatch compatibility re-exports.
       // +6: source-compatible harness contracts retained during the V2 migration window.
-      1142,
+      // +2: model-auth state/clear diagnostic events during the runtime-barrel migration.
+      1144,
       env,
     ),
     publicWildcardReexports: readPluginSdkSurfaceBudgetEnv(

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -266,7 +266,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +2: narrow channel agent-run terminal reader and outcome contract.
       // +5: narrow string, record, and error coercion helpers.
       // +1: normalized Gateway public origin resolver for plugin-generated links.
-      4308,
+      // +4: model-auth state/clear diagnostic event contracts through public runtime barrels.
+      4312,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -678,6 +678,27 @@ export type DiagnosticModelCallErrorEvent = DiagnosticModelCallBaseEvent & {
   usage?: DiagnosticModelCallUsage;
 };
 
+export type DiagnosticModelAuthStateEvent = DiagnosticBaseEvent & {
+  type: "model.auth.state";
+  state: "ready" | "not_ready" | "unknown";
+  authMode: "subscription" | "api_key" | "native" | "unknown";
+  reason:
+    | "ready"
+    | "missing_account"
+    | "unauthenticated"
+    | "route_mismatch"
+    | "unsupported_auth_mode"
+    | "probe_error"
+    | "transport_error"
+    | "transport_auth_error"
+    | "configuration_error"
+    | "unsupported_version";
+};
+
+export type DiagnosticModelAuthClearEvent = DiagnosticBaseEvent & {
+  type: "model.auth.clear";
+};
+
 type DiagnosticModelCallPromptStats = Readonly<{
   inputMessagesCount?: number;
   inputMessagesChars?: number;
@@ -838,6 +859,8 @@ export type DiagnosticEventPayload =
   | DiagnosticModelCallStartedEvent
   | DiagnosticModelCallCompletedEvent
   | DiagnosticModelCallErrorEvent
+  | DiagnosticModelAuthStateEvent
+  | DiagnosticModelAuthClearEvent
   | DiagnosticContextAssembledEvent
   | DiagnosticMemorySampleEvent
   | DiagnosticMemoryPressureEvent

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -248,6 +248,13 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
   };
 
   switch (event.type) {
+    case "model.auth.state":
+      record.outcome = event.state;
+      record.mode = event.authMode;
+      assignReasonCode(record, event.reason);
+      break;
+    case "model.auth.clear":
+      break;
     case "model.usage":
       record.channel = event.channel;
       record.provider = event.provider;

--- a/src/plugin-sdk/diagnostic-runtime.ts
+++ b/src/plugin-sdk/diagnostic-runtime.ts
@@ -36,6 +36,8 @@ export type {
   DiagnosticEventMetadata,
   DiagnosticEventPayload,
   DiagnosticEventPrivateData,
+  DiagnosticModelAuthClearEvent,
+  DiagnosticModelAuthStateEvent,
   DiagnosticModelCallContent,
 } from "../infra/diagnostic-events.js";
 export type { DiagnosticModelContentCapturePolicy } from "../infra/diagnostic-llm-content.js";


### PR DESCRIPTION
Closes #122778

## What Problem This Solves

Resolves a problem where operators could see a healthy Codex app-server WebSocket and gateway while the model account was no longer authenticated, leaving idle failures invisible until user traffic.

## Why This Change Was Made

The existing connection-health service now performs a bounded, no-model active ChatGPT authentication check on its shared client and emits a trusted tri-state diagnostic state plus actual probe time. Cached account inventory only selects the route; ambiguous backend, transport, and unsupported-mode failures remain unknown. A payload-free clear event removes stale LastValue state when the service stops.

This depends on Codex app-server preserving bounded structured authentication status for rate-limit RPC failures; without that dependency, unstructured failures remain unknown rather than false auth failures.

## User Impact

Operators can detect a connected-but-logged-out Codex model route before users send messages, while API-key/custom routes and backend outages are not mislabeled as bad credentials. No login, refresh, model turn, account identifier, URL, token, or raw provider error is emitted.

## Evidence

- Connection health: 15/15 focused tests passed.
- Diagnostics OTEL: 192/192 focused tests passed.
- Diagnostic events: 36/36 focused tests passed.
- `git diff --check` passed.
- Repository-wide `pnpm check` passed all guards except package-lock validation, which could not resolve the existing `@openclaw/fs-safe@0.5.5` package.

AI-assisted: yes. The implementation was source-traced, reviewed in separate correctness/docs/slop tracks, and the accepted review findings were fixed.