### PR TITLE
refactor(extensions): remove orphan test exports

### DIFF
--- a/extensions/google-meet/index.ts
+++ b/extensions/google-meet/index.ts
@@ -27,9 +27,6 @@ import { GOOGLE_MEET_NODE_COMMAND } from "./src/transports/google-meet-platform-
 
 export { testing };
 
-/** @deprecated Use `testing`. */
-export { testing as __testing };
-
 export default definePluginEntry({
   id: "google-meet",
   name: "Google Meet",

--- a/extensions/slack/api.ts
+++ b/extensions/slack/api.ts
@@ -46,13 +46,8 @@ export {
   buildSlackPresentationBlocks,
   type SlackBlock,
 } from "./src/blocks-render.js";
+export { resolveSlackChannelType } from "./src/channel-type.js";
 export {
-  resetSlackChannelTypeCacheForTest as __resetSlackChannelTypeCacheForTest,
-  resetSlackChannelTypeCacheForTest,
-  resolveSlackChannelType,
-} from "./src/channel-type.js";
-export {
-  clearSlackWriteClientCacheForTest,
   createSlackTokenCacheKey,
   createSlackWebClient,
   createSlackWriteClient,

--- a/extensions/slack/src/channel-type.ts
+++ b/extensions/slack/src/channel-type.ts
@@ -163,6 +163,3 @@ export async function resolveSlackChannelType(params: {
 export function resetSlackChannelTypeCacheForTest(): void {
   SLACK_CONVERSATION_INFO_CACHE.clear();
 }
-
-/** @deprecated Use `resetSlackChannelTypeCacheForTest`. */
-export { resetSlackChannelTypeCacheForTest as __resetSlackChannelTypeCacheForTest };

--- a/extensions/slack/src/client.test.ts
+++ b/extensions/slack/src/client.test.ts
@@ -32,7 +32,6 @@ let createSlackLookupClient: typeof import("./client.js").createSlackLookupClien
 let createSlackWriteClient: typeof import("./client.js").createSlackWriteClient;
 let createSlackTokenCacheKey: typeof import("./client.js").createSlackTokenCacheKey;
 let getSlackWriteClient: typeof import("./client.js").getSlackWriteClient;
-let clearSlackWriteClientCacheForTest: typeof import("./client.js").clearSlackWriteClientCacheForTest;
 let resolveSlackProxyDispatcher: typeof import("./client-options.js").resolveSlackProxyDispatcher;
 let resolveSlackWebClientOptions: typeof import("./client.js").resolveSlackWebClientOptions;
 let resolveSlackWriteClientOptions: typeof import("./client.js").resolveSlackWriteClientOptions;
@@ -114,7 +113,6 @@ beforeAll(async () => {
     createSlackWriteClient,
     createSlackTokenCacheKey,
     getSlackWriteClient,
-    clearSlackWriteClientCacheForTest,
     resolveSlackWebClientOptions,
     resolveSlackWriteClientOptions,
     SLACK_DEFAULT_RETRY_OPTIONS,
@@ -125,7 +123,6 @@ beforeAll(async () => {
 
 beforeEach(() => {
   WebClient.mockClear();
-  clearSlackWriteClientCacheForTest();
   clearSlackApiUrlEnvForTest();
   isDebugProxyGlobalFetchPatchInstalledMock.mockReturnValue(false);
 });
@@ -393,9 +390,9 @@ describe("slack web client config", () => {
     clearProxyEnvForTest();
     try {
       process.env.SLACK_API_URL = "http://127.0.0.1:49152/api/";
-      const first = getSlackWriteClient("xoxb-test");
+      const first = getSlackWriteClient("xoxb-env");
       process.env.SLACK_API_URL = "http://127.0.0.1:49153/api/";
-      const second = getSlackWriteClient("xoxb-test");
+      const second = getSlackWriteClient("xoxb-env");
 
       expect(second).not.toBe(first);
       expect(WebClient).toHaveBeenCalledTimes(2);

--- a/extensions/slack/src/client.ts
+++ b/extensions/slack/src/client.ts
@@ -15,7 +15,7 @@ const SLACK_WRITE_CLIENT_CACHE_MAX = 32;
 const SLACK_STARTUP_AUTH_TIMEOUT_MS = 10_000;
 const SLACK_STARTUP_AUTH_RETRY_BUDGET_MS = 35_000;
 const slackWriteClientCache = new Map<string, WebClient>();
-let slackListenerUploadCompletionClientCache = new WeakMap<
+const slackListenerUploadCompletionClientCache = new WeakMap<
   WebClient,
   { teamId: string; client: WebClient }
 >();
@@ -156,9 +156,4 @@ export function getSlackListenerUploadCompletionClient(params: {
   );
   slackListenerUploadCompletionClientCache.set(params.listenerClient, { teamId, client });
   return client;
-}
-
-export function clearSlackWriteClientCacheForTest(): void {
-  slackWriteClientCache.clear();
-  slackListenerUploadCompletionClientCache = new WeakMap();
 }

--- a/extensions/whatsapp/api.ts
+++ b/extensions/whatsapp/api.ts
@@ -63,7 +63,6 @@ export {
   normalizeWhatsAppMessagingTarget,
   normalizeWhatsAppTarget,
 } from "./src/normalize-target.js";
-export { testing as whatsappAccessControlTesting } from "./src/inbound/access-control.js";
 export {
   startWhatsAppQaDriverSession,
   type WhatsAppQaDriverObservedMessage,

--- a/extensions/whatsapp/contract-api.ts
+++ b/extensions/whatsapp/contract-api.ts
@@ -1,7 +1,6 @@
 // Whatsapp API module exposes the plugin public contract.
 import { whatsappCommandPolicy as whatsappCommandPolicyImpl } from "./src/command-policy.js";
 import { resolveLegacyGroupSessionKey as resolveLegacyGroupSessionKeyImpl } from "./src/group-session-contract.js";
-import { testing as whatsappAccessControlTestingImpl } from "./src/inbound/access-control.js";
 import {
   isWhatsAppGroupJid as isWhatsAppGroupJidImpl,
   normalizeWhatsAppTarget as normalizeWhatsAppTargetImpl,
@@ -18,5 +17,4 @@ export const isWhatsAppGroupJid = isWhatsAppGroupJidImpl;
 export const normalizeWhatsAppTarget = normalizeWhatsAppTargetImpl;
 export const resolveLegacyGroupSessionKey = resolveLegacyGroupSessionKeyImpl;
 export const resolveWhatsAppRuntimeGroupPolicy = resolveWhatsAppRuntimeGroupPolicyImpl;
-export const whatsappAccessControlTesting = whatsappAccessControlTestingImpl;
 export const whatsappCommandPolicy = whatsappCommandPolicyImpl;

--- a/extensions/whatsapp/src/inbound/access-control.ts
+++ b/extensions/whatsapp/src/inbound/access-control.ts
@@ -197,7 +197,3 @@ export async function checkInboundAccessControl(params: {
     }),
   };
 }
-
-export const testing = {
-  resolveWhatsAppInboundPolicy,
-};


### PR DESCRIPTION
## What Problem This Solves

Google Meet, Slack, and WhatsApp still shipped test-only aliases and barrel exports that no repository caller consumed:

- Google Meet retained deprecated `__testing` alongside the canonical `testing` export.
- Slack publicly re-exported cache reset helpers used only by tests importing their private owner modules directly.
- WhatsApp carried an access-control `testing` object through both `api.ts` and `contract-api.ts` after the generic contract moved to the dedicated runtime group-policy seam.

Slack's write-client reset also existed only to clear module state before every test.

## Why This Change Was Made

Delete the orphan aliases and public test exports instead of preserving undocumented compatibility. Remove Slack's write-client reset entirely: its cache tests already use independent routing keys, with the environment-scoped case given its own token. That also makes the listener completion cache binding immutable.

The conversation-type reset remains private and directly used because that suite deliberately fills the 1,024-entry LRU and needs explicit lifecycle cleanup.

## User Impact

No user-visible behavior changes. Plugin runtime behavior is unchanged while production code loses 23 net lines of test-only surface; tests lose 3 net lines.

## Evidence

- 284 focused tests passed across Google Meet entrypoints, Slack channel/client caches, WhatsApp access control, and generic channel/plugin contract suites.
- Repository production extension changed-file gate passed, including Plugin SDK API baseline checks, production and test typechecks, lint, plugin boundaries, doctor contract guards, sidecar guards, import cycles, and Knip production/full-tree/script unused-export scans with zero findings.
- The configured remote backend was unavailable because the `blacksmith` executable is not installed on this host, so the changed-file wrapper completed its documented local fallback.
- `git diff --check` passed.
- Structured branch autoreview found no accepted or actionable findings.
