### PR TITLE
fix(ci): expose AI pack failures in installer smoke

### DIFF
--- a/scripts/package-openclaw-for-docker.mts
+++ b/scripts/package-openclaw-for-docker.mts
@@ -723,7 +723,15 @@ export async function prepareBundledAiRuntimePackage(
   try {
     await runCaptureImpl(
       "pnpm",
-      ["--dir", "packages/ai", "pack", "--silent", "--pack-destination", outputDir],
+      [
+        "--dir",
+        "packages/ai",
+        "pack",
+        "--loglevel=error",
+        "--use-stderr",
+        "--pack-destination",
+        outputDir,
+      ],
       sourceDir,
       {
         deferForwardedSignalExit: true,

--- a/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
@@ -495,7 +495,15 @@ describe("package-openclaw-for-docker", () => {
         outputDir,
         async (command: string, args: string[], cwd: string) => {
           expect({ args, command, cwd }).toEqual({
-            args: ["--dir", "packages/ai", "pack", "--silent", "--pack-destination", outputDir],
+            args: [
+              "--dir",
+              "packages/ai",
+              "pack",
+              "--loglevel=error",
+              "--use-stderr",
+              "--pack-destination",
+              outputDir,
+            ],
             command: "pnpm",
             cwd: sourceDir,
           });
@@ -546,6 +554,37 @@ describe("package-openclaw-for-docker", () => {
     } finally {
       fs.rmSync(sourceDir, { recursive: true, force: true });
       fs.rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps real AI runtime pack failures visible for installer diagnostics", async () => {
+    const sourceDir = tempDirs.make("openclaw-docker-ai-failure-source-");
+    const outputDir = tempDirs.make("openclaw-docker-ai-failure-output-");
+    const packageJsonPath = path.join(sourceDir, "package.json");
+    const originalPackageJson = `${JSON.stringify({
+      dependencies: { "@openclaw/ai": "workspace:*" },
+      name: "openclaw",
+    })}\n`;
+    fs.mkdirSync(path.join(sourceDir, "packages", "ai"), { recursive: true });
+    fs.writeFileSync(
+      path.join(sourceDir, "packages", "ai", "package.json"),
+      '{"name":"@openclaw/ai"}\n',
+    );
+    fs.writeFileSync(packageJsonPath, originalPackageJson);
+    let stderr = "";
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderr += String(chunk);
+      return true;
+    });
+
+    try {
+      await expect(prepareBundledAiRuntimePackage(sourceDir, outputDir)).rejects.toThrow(
+        "pnpm --dir packages/ai pack --loglevel=error --use-stderr",
+      );
+      expect(stderr).toContain("ERR_PNPM_PACKAGE_VERSION_NOT_FOUND");
+      expect(fs.readFileSync(packageJsonPath, "utf8")).toBe(originalPackageJson);
+    } finally {
+      stderrWrite.mockRestore();
     }
   });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI diagnostics problem where the installer reused-image smoke reported only that the internal `@openclaw/ai` pack exited with code 1, while pnpm suppressed the error needed to classify the failure.

Related validation: https://github.com/openclaw/openclaw/actions/runs/31601965721/job/94135320048

## Why This Change Was Made

The internal AI pack now uses pnpm's error-only stderr output instead of `--silent`. This is intentionally diagnostics-only: it does not claim or attempt to fix the underlying AI package failure, change the generic command runner, or alter other pack commands.

## User Impact

Maintainers running installer qualification can see the exact pnpm error when the bundled AI runtime cannot be packed, so the next narrow retry can identify the real owner and repair.

## Evidence

- Before: the frozen installer run ended with only `pnpm --dir packages/ai pack --silent ... failed with 1`.
- `node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts` — 32 passed, 3 skipped.
- The regression invokes real pnpm against a versionless `@openclaw/ai` fixture and observes `ERR_PNPM_PACKAGE_VERSION_NOT_FOUND` on stderr.
- `node scripts/check-changed.mjs -- scripts/package-openclaw-for-docker.mts test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts` — green on Blacksmith Testbox `tbx_01kzvr1t0427gcc3v2fvqt3900`: https://github.com/openclaw/openclaw/actions/runs/31634109633
- `oxfmt --check` and `git diff --check` passed.
- Local ClawSweeper exact-head review: `nothing_found`, high confidence.
- Tooling LOC: +9/-1. Tests: +40/-1.

The full reusable-image smoke was not rerun here because the available backends failed or stalled before executing that lane. After this diagnostics change lands, the qualification controller should run one narrow installer-lane retry to capture the actual AI pack error.
