### PR TITLE
fix(cron): retain deleted job history by agent

### DIFF
--- a/src/cron/task-run-history.ts
+++ b/src/cron/task-run-history.ts
@@ -4,6 +4,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { uniqueValues } from "@openclaw/normalization-core/string-normalization";
+import { normalizeAgentId } from "../routing/session-key.js";
 import { listTaskRegistryRecordsByRuntimeSourceIdFromSqlite } from "../tasks/task-registry.store.sqlite.js";
 import type { TaskRecord } from "../tasks/task-registry.types.js";
 import type { CronRunLogEntry } from "./run-log-types.js";
@@ -23,8 +24,7 @@ type ReadCronTaskRunHistoryPageOptions = {
   limit?: number;
   offset?: number;
   jobId?: string;
-  /** Narrows the page to these job ids (caller-scope filtering). */
-  jobIds?: readonly string[];
+  agentId?: string;
   runId?: string;
   status?: CronRunHistoryStatusFilter;
   statuses?: CronRunStatus[];
@@ -127,7 +127,7 @@ export function readCronTaskRunHistoryPage(
   const statuses = normalizeStatuses(options);
   const deliveryStatuses = normalizeDeliveryStatuses(options);
   const runId = normalizeOptionalString(options.runId);
-  const jobIds = options.jobIds ? new Set(options.jobIds) : undefined;
+  const agentId = options.agentId ? normalizeAgentId(options.agentId) : undefined;
   const query = normalizeLowercaseStringOrEmpty(options.query);
   const sortDir: CronRunHistorySortDir = options.sortDir === "asc" ? "asc" : "desc";
   const rows = listTaskRegistryRecordsByRuntimeSourceIdFromSqlite({
@@ -135,12 +135,10 @@ export function readCronTaskRunHistoryPage(
     sourceId: jobId,
   })
     .filter((task) => cronTaskRecordStoreKey(task) === options.storeKey)
+    .filter((task) => !agentId || task.agentId === agentId)
     .map((task) => ({ task, entry: cronTaskRecordToRunLogEntry(task) }))
     .filter((row): row is { task: TaskRecord; entry: CronRunLogEntry } => row.entry !== null)
     .filter(({ entry }) => {
-      if (jobIds && !jobIds.has(entry.jobId)) {
-        return false;
-      }
       if (runId && entry.runId !== runId) {
         return false;
       }

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -1192,7 +1192,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       const page = readCronTaskRunHistoryPage({
         storeKey: cronStoreKey(context.cronStorePath),
         ...cronRunLogPageFilters(p),
-        ...(p.agentId ? { jobIds: jobs.map((job) => job.id) } : {}),
+        agentId: p.agentId,
         jobNameById,
       });
       respond(true, page, undefined);

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -11,6 +11,7 @@ import { resetConfigRuntimeState } from "../config/config.js";
 import { loadCronStore, saveCronStore } from "../cron/store.js";
 import type { GuardedFetchOptions } from "../infra/net/fetch-guard.js";
 import { peekSystemEvents } from "../infra/system-events.js";
+import { listTaskRegistryRecordsByRuntimeSourceIdFromSqlite } from "../tasks/task-registry.store.sqlite.js";
 import { getGatewayProcessInstanceId } from "./process-instance.js";
 import type { GatewayCronState } from "./server-cron.js";
 import {
@@ -1469,6 +1470,23 @@ describe("gateway server cron", () => {
       expect((writerRuns.payload as { entries: Array<{ jobId: string }> }).entries).toContainEqual(
         expect.objectContaining({ jobId: writerJobId }),
       );
+
+      const removeWriter = await directCronReq(cronState, "cron.remove", { id: writerJobId });
+      expect(removeWriter.ok).toBe(true);
+      expect(
+        listTaskRegistryRecordsByRuntimeSourceIdFromSqlite({
+          runtime: "cron",
+          sourceId: writerJobId,
+        }),
+      ).toEqual([expect.objectContaining({ agentId: "writer" })]);
+      const retainedWriterRuns = await directCronReq(cronState, "cron.runs", {
+        scope: "all",
+        agentId: "writer",
+      });
+      expect(retainedWriterRuns.payload).toMatchObject({
+        entries: [expect.objectContaining({ jobId: writerJobId })],
+        total: 1,
+      });
 
       const statusRes = await directCronReq(cronState, "cron.status", {});
       expect(statusRes.ok).toBe(true);


### PR DESCRIPTION
## What Problem This Solves

Cron task-run history intentionally survives job deletion and each durable task row records its effective `agentId`. However, `cron.runs { scope: "all", agentId }` derived allowed job IDs only from the current live job list. Deleting a job therefore made its retained history disappear from that agent’s overview even though the durable row still existed.

## Why This Change Was Made

The task-ledger history owner now filters by the authoritative durable task `agentId`:

- retained rows remain agent-filterable after job deletion;
- live jobs are used only to enrich current job names;
- exact-job reads still require a live matching owner when caller scope or agent filtering applies;
- caller-scoped authorization, paging, ordering, query/status filters, and all write paths remain unchanged.

No schema, migration, protocol, configuration, or persistent write behavior changes.

AI-assisted: yes. The read-owner repair and create→run→delete regression were manually inspected and passed fresh structured autoreview after final rebase.

## User Impact

Agent-filtered Cron history continues to show retained runs after their jobs are deleted, matching the existing history-retention contract.

## Evidence

- Pre-fix reproduction retained a durable task row with `agentId:"writer"` but returned zero entries after deleting the job and requesting that agent’s overview.
- Post-fix focused proof: 235 tests passed across task-run history, Gateway Cron behavior, and Cron parameter/authorization validation.
- Hosted changed gate passed on Testbox `tbx_01kzvs9r2nmpbr5h6qkzgw31ds` ([run](https://github.com/openclaw/openclaw/actions/runs/31635932137)).
- Exact-head CI passed ([run](https://github.com/openclaw/openclaw/actions/runs/31636700836)).
- Targeted formatting/lint, typechecks, import-cycle checks, and `git diff --check` passed.
- Rebase preserved exact range-diff and stable patch ID `d9d96c4b0c5755c4813ee393bc77f1fc0dce904a`.
- Fresh complete-branch autoreview: clean.
- Production +5/−7 (net −2); tests +18/−0.
