### PR TITLE
fix(compaction-safeguard): keep structured summary body when suffix is oversized (#122618)

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2858,6 +2858,10 @@ describe("compaction-safeguard recent-turn preservation", () => {
       setCompactionSafeguardRuntime(sessionManager, {
         model: createAnthropicModelFixture(),
         recentTurnsPreserve: 12,
+        // Default safeguard runtime enables the quality guard; the audit must
+        // see the SAME capped structured body the stored summary uses.
+        qualityGuardEnabled: true,
+        qualityGuardMaxRetries: 1,
         postCompactionSections: ["Session Startup", "Red Lines"],
         workspaceDir: workspaceRoot,
       });

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -610,8 +610,10 @@ describe("compaction-safeguard summary budgets", () => {
 
   it("keeps a floor share of the structured body when the suffix alone exceeds the cap", () => {
     const body = "## Decisions\n- keep flow\n## Open TODOs\n- fix eviction";
+    const workspaceTail =
+      "\n\n<workspace-critical-rules>\nNever touch prod.\n</workspace-critical-rules>";
     const oversizedSuffix =
-      "## Preserved turns\n" + "x".repeat(MAX_COMPACTION_SUMMARY_CHARS + 1000);
+      "## Preserved turns\n" + "x".repeat(MAX_COMPACTION_SUMMARY_CHARS) + workspaceTail;
 
     const capped = capCompactionSummaryPreservingSuffix(body, oversizedSuffix);
 
@@ -619,8 +621,8 @@ describe("compaction-safeguard summary budgets", () => {
     // Structured body must survive instead of being evicted entirely.
     expect(capped).toContain("## Decisions");
     expect(capped).toContain("keep flow");
-    // Suffix tail must still be preserved (workspace rules live at the tail).
-    expect(capped.endsWith("x")).toBe(true);
+    // Suffix tail (workspace-critical rules) must still be preserved verbatim.
+    expect(capped.endsWith(workspaceTail)).toBe(true);
   });
 
   it("keeps a fitting suffix whole instead of tail-slicing it below the cap", () => {
@@ -2801,6 +2803,97 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(compaction.summary).toContain("## Recent turns preserved verbatim");
     expect(compaction.summary).toContain("latest ask status");
     expect(compaction.summary).toContain("latest assistant reply");
+  });
+
+  it("keeps the structured body and workspace-critical tail when the preserved suffix exceeds the cap", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue(
+      summaryResult(
+        [
+          "## Decisions",
+          "Keep current flow.",
+          "## Open TODOs",
+          "None.",
+          "## Constraints/Rules",
+          "Preserve exact context.",
+          "## Pending user asks",
+          "Report status.",
+          "## Exact identifiers",
+          "svc-prod-1",
+        ].join("\n"),
+      ),
+    );
+
+    // Tool-heavy transcript: 12 preserved turns whose verbatim content alone
+    // exceeds the 16K summary cap (the issue's normal path, not a corner case).
+    const messages: AgentMessage[] = [];
+    for (let i = 0; i < 12; i += 1) {
+      messages.push({ role: "user", content: `ask ${i} `.repeat(100), timestamp: i * 4 + 1 });
+      messages.push({
+        role: "assistant",
+        content: [{ type: "text", text: `answer ${i} `.repeat(100) }],
+        timestamp: i * 4 + 2,
+      } as unknown as AgentMessage);
+      messages.push({
+        role: "assistant",
+        content: [{ type: "toolCall", id: `call_${i}`, name: "exec", arguments: {} }],
+        timestamp: i * 4 + 3,
+      } as unknown as AgentMessage);
+      messages.push({
+        role: "toolResult",
+        toolCallId: `call_${i}`,
+        toolName: "exec",
+        content: [{ type: "text", text: `output ${i} `.repeat(100) }],
+        timestamp: i * 4 + 4,
+      } as unknown as AgentMessage);
+    }
+
+    const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-compaction-cap-"));
+    try {
+      fs.writeFileSync(
+        path.join(workspaceRoot, "AGENTS.md"),
+        "## Session Startup\n\nRead AGENTS.md.\n\n## Red Lines\n\nNever touch prod.\n",
+      );
+      const sessionManager = stubSessionManager();
+      setCompactionSafeguardRuntime(sessionManager, {
+        model: createAnthropicModelFixture(),
+        recentTurnsPreserve: 12,
+        postCompactionSections: ["Session Startup", "Red Lines"],
+        workspaceDir: workspaceRoot,
+      });
+
+      const event = {
+        preparation: {
+          messagesToSummarize: messages,
+          turnPrefixMessages: [] as AgentMessage[],
+          firstKeptEntryId: "entry-1",
+          tokensBefore: 30_000,
+          fileOps: { read: [], edited: [], written: [] },
+          settings: { reserveTokens: 4_000 },
+          previousSummary: "previous compacted context",
+          isSplitTurn: false,
+        },
+        customInstructions: "",
+        signal: new AbortController().signal,
+      };
+
+      const { result } = await runCompactionScenario({
+        sessionManager,
+        event,
+        apiKey: "test-key",
+      });
+
+      const compaction = expectCompactionResult(result);
+      // Production boundary: the stored summary keeps the structured body...
+      expect(compaction.summary).toContain("## Decisions");
+      // ...and the workspace-critical tail survives verbatim at the end.
+      expect(compaction.summary.endsWith("</workspace-critical-rules>")).toBe(true);
+      expect(compaction.summary).toContain("Never touch prod.");
+      // Still bounded by the 16K cap.
+      expect(compaction.summary.length).toBeLessThanOrEqual(MAX_COMPACTION_SUMMARY_CHARS);
+    } finally {
+      fs.rmSync(workspaceRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -603,7 +603,49 @@ describe("compaction-safeguard summary budgets", () => {
   });
 
   it("keeps an oversized preserved suffix UTF-16 safe at its leading edge", () => {
-    expect(capCompactionSummaryPreservingSuffix("body", "A🚀tail", 5)).toBe("tail");
+    // Budget 5 with a 7-unit suffix: body keeps a floor share ("bo"), the
+    // suffix tail is preserved, and no surrogate pair is split.
+    expect(capCompactionSummaryPreservingSuffix("body", "A🚀tail", 5)).toBe("boail");
+  });
+
+  it("keeps a floor share of the structured body when the suffix alone exceeds the cap", () => {
+    const body = "## Decisions\n- keep flow\n## Open TODOs\n- fix eviction";
+    const oversizedSuffix =
+      "## Preserved turns\n" + "x".repeat(MAX_COMPACTION_SUMMARY_CHARS + 1000);
+
+    const capped = capCompactionSummaryPreservingSuffix(body, oversizedSuffix);
+
+    expect(capped.length).toBeLessThanOrEqual(MAX_COMPACTION_SUMMARY_CHARS);
+    // Structured body must survive instead of being evicted entirely.
+    expect(capped).toContain("## Decisions");
+    expect(capped).toContain("keep flow");
+    // Suffix tail must still be preserved (workspace rules live at the tail).
+    expect(capped.endsWith("x")).toBe(true);
+  });
+
+  it("gives the structured body at least half the budget when a large suffix squeezes it", () => {
+    const body = "## Decisions\n" + "y".repeat(4000);
+    const largeSuffix = "## Preserved turns\n" + "z".repeat(MAX_COMPACTION_SUMMARY_CHARS - 2000);
+
+    const capped = capCompactionSummaryPreservingSuffix(body, largeSuffix);
+
+    expect(capped.length).toBeLessThanOrEqual(MAX_COMPACTION_SUMMARY_CHARS);
+    // Body floor: the structured body keeps its full content when it fits in
+    // the half-budget floor instead of being squeezed to the remainder.
+    expect(capped.startsWith("## Decisions")).toBe(true);
+    expect(capped).toContain("y".repeat(4000));
+    // Suffix tail must still be preserved (workspace rules live at the tail).
+    expect(capped.endsWith("z")).toBe(true);
+  });
+
+  it("keeps the body and suffix whole when they fit within the cap", () => {
+    const body = "## Decisions\n- keep flow";
+    const suffix = "\n\n<workspace-critical-rules>\nRead AGENTS.md\n</workspace-critical-rules>";
+
+    const capped = capCompactionSummaryPreservingSuffix(body, suffix);
+
+    expect(capped).toBe(`${body}${suffix}`);
+    expect(capped.length).toBeLessThanOrEqual(MAX_COMPACTION_SUMMARY_CHARS);
   });
 });
 

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -623,19 +623,21 @@ describe("compaction-safeguard summary budgets", () => {
     expect(capped.endsWith("x")).toBe(true);
   });
 
-  it("gives the structured body at least half the budget when a large suffix squeezes it", () => {
+  it("keeps a fitting suffix whole instead of tail-slicing it below the cap", () => {
+    // Regression guard for sub-cap suffixes: split-turn and preserved recent
+    // turns are contractually kept intact, so a suffix that fits under the cap
+    // must NOT be tail-sliced to reserve body budget.
     const body = "## Decisions\n" + "y".repeat(4000);
     const largeSuffix = "## Preserved turns\n" + "z".repeat(MAX_COMPACTION_SUMMARY_CHARS - 2000);
 
     const capped = capCompactionSummaryPreservingSuffix(body, largeSuffix);
 
     expect(capped.length).toBeLessThanOrEqual(MAX_COMPACTION_SUMMARY_CHARS);
-    // Body floor: the structured body keeps its full content when it fits in
-    // the half-budget floor instead of being squeezed to the remainder.
+    // Suffix (14K < 16K cap) stays intact in full.
+    expect(capped.endsWith(largeSuffix)).toBe(true);
+    expect(capped).toContain("## Preserved turns");
+    // Body absorbs the remainder exactly as before this change.
     expect(capped.startsWith("## Decisions")).toBe(true);
-    expect(capped).toContain("y".repeat(4000));
-    // Suffix tail must still be preserved (workspace rules live at the tail).
-    expect(capped.endsWith("z")).toBe(true);
   });
 
   it("keeps the body and suffix whole when they fit within the cap", () => {

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -570,6 +570,27 @@ function capCompactionSummary(summary: string, maxChars = MAX_COMPACTION_SUMMARY
   return `${truncateUtf16Safe(summary, budget)}${marker}`;
 }
 
+/**
+ * Structured-body budget for the final summary cap. One allocation shared by
+ * the stored summary, the quality audit's structuralSummary, and the retry
+ * budget instruction, so the default quality-guard path cannot disagree with
+ * what capCompactionSummaryPreservingSuffix actually stores.
+ */
+function resolveSummaryBodyBudget(summaryBody: string, suffix: string, maxChars: number): number {
+  if (!suffix) {
+    return maxChars;
+  }
+  if (maxChars <= 0) {
+    return 0;
+  }
+  if (suffix.length >= maxChars) {
+    // Suffix alone exceeds the cap (tool-heavy turns): reserve the structured
+    // body a floor share (up to half), matching the stored summary allocation.
+    return Math.min(summaryBody.length, Math.floor(maxChars / 2));
+  }
+  return Math.max(0, maxChars - suffix.length);
+}
+
 function capCompactionSummaryPreservingSuffix(
   summaryBody: string,
   suffix: string,
@@ -586,13 +607,13 @@ function capCompactionSummaryPreservingSuffix(
     // structured body entirely; instead reserve it a floor share (up to half)
     // and keep the suffix TAIL, where workspace rules and post-compaction
     // instructions live. Keep the suffix whole whenever it fits below.
-    const bodyBudget = Math.min(summaryBody.length, Math.floor(maxChars / 2));
+    const bodyBudget = resolveSummaryBodyBudget(summaryBody, suffix, maxChars);
     const suffixBudget = maxChars - bodyBudget;
     const cappedBody = capCompactionSummary(summaryBody, bodyBudget);
     const cappedSuffix = sliceUtf16Safe(suffix, -suffixBudget);
     return `${cappedBody}${cappedSuffix}`;
   }
-  const bodyBudget = Math.max(0, maxChars - suffix.length);
+  const bodyBudget = resolveSummaryBodyBudget(summaryBody, suffix, maxChars);
   const cappedBody = capCompactionSummary(summaryBody, bodyBudget);
   return `${cappedBody}${suffix}`;
 }
@@ -951,13 +972,14 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         fileOpsSummary,
         workspaceContext: await workspaceContextPromise,
       });
-      const bodyBudget = Math.max(0, MAX_COMPACTION_SUMMARY_CHARS - suffix.length);
+      const bodyBudget = resolveSummaryBodyBudget(body, suffix, MAX_COMPACTION_SUMMARY_CHARS);
       return {
         summary: capCompactionSummaryPreservingSuffix(body, suffix),
-        structuralSummary:
-          suffix.length >= MAX_COMPACTION_SUMMARY_CHARS
-            ? ""
-            : capCompactionSummary(body, bodyBudget),
+        // Feed the SAME capped structured body to the quality audit: an empty
+        // structuralSummary (pre-fix) fails every heading check and the retry
+        // budget of 0 asks corrective generation to fit within zero characters,
+        // so default safeguard compaction cancels instead of storing anything.
+        structuralSummary: capCompactionSummary(body, bodyBudget),
         bodyBudget,
       };
     };

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -581,13 +581,18 @@ function capCompactionSummaryPreservingSuffix(
   if (maxChars <= 0) {
     return capCompactionSummary(`${summaryBody}${suffix}`, maxChars);
   }
-  if (suffix.length >= maxChars) {
-    // Preserve tail (workspace rules, diagnostics) over head (preserved turns).
-    return sliceUtf16Safe(suffix, -maxChars);
-  }
-  const bodyBudget = Math.max(0, maxChars - suffix.length);
+  // Structured body keeps a floor share; suffix keeps its TAIL (workspace
+  // rules and post-compaction instructions are appended last). When both fit,
+  // bodyBudget/suffixBudget cover their full lengths, so nothing is cut.
+  const bodyBudget = Math.min(
+    summaryBody.length,
+    Math.max(Math.floor(maxChars / 2), maxChars - suffix.length),
+  );
+  const suffixBudget = Math.max(0, maxChars - bodyBudget);
   const cappedBody = capCompactionSummary(summaryBody, bodyBudget);
-  return `${cappedBody}${suffix}`;
+  const cappedSuffix =
+    suffix.length > suffixBudget ? sliceUtf16Safe(suffix, -suffixBudget) : suffix;
+  return `${cappedBody}${cappedSuffix}`;
 }
 
 function resolveSummaryReserveTokens(

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -581,18 +581,20 @@ function capCompactionSummaryPreservingSuffix(
   if (maxChars <= 0) {
     return capCompactionSummary(`${summaryBody}${suffix}`, maxChars);
   }
-  // Structured body keeps a floor share; suffix keeps its TAIL (workspace
-  // rules and post-compaction instructions are appended last). When both fit,
-  // bodyBudget/suffixBudget cover their full lengths, so nothing is cut.
-  const bodyBudget = Math.min(
-    summaryBody.length,
-    Math.max(Math.floor(maxChars / 2), maxChars - suffix.length),
-  );
-  const suffixBudget = Math.max(0, maxChars - bodyBudget);
+  if (suffix.length >= maxChars) {
+    // Suffix alone exceeds the cap (tool-heavy turns). Current main evicts the
+    // structured body entirely; instead reserve it a floor share (up to half)
+    // and keep the suffix TAIL, where workspace rules and post-compaction
+    // instructions live. Keep the suffix whole whenever it fits below.
+    const bodyBudget = Math.min(summaryBody.length, Math.floor(maxChars / 2));
+    const suffixBudget = maxChars - bodyBudget;
+    const cappedBody = capCompactionSummary(summaryBody, bodyBudget);
+    const cappedSuffix = sliceUtf16Safe(suffix, -suffixBudget);
+    return `${cappedBody}${cappedSuffix}`;
+  }
+  const bodyBudget = Math.max(0, maxChars - suffix.length);
   const cappedBody = capCompactionSummary(summaryBody, bodyBudget);
-  const cappedSuffix =
-    suffix.length > suffixBudget ? sliceUtf16Safe(suffix, -suffixBudget) : suffix;
-  return `${cappedBody}${cappedSuffix}`;
+  return `${cappedBody}${suffix}`;
 }
 
 function resolveSummaryReserveTokens(


### PR DESCRIPTION
## What Problem This Solves

`capCompactionSummaryPreservingSuffix()` in the compaction-safeguard extension discards the **entire structured summary body** whenever the assembled suffix alone reaches `MAX_COMPACTION_SUMMARY_CHARS` (16,000):

```js
if (suffix.length >= maxChars) return sliceUtf16Safe(suffix, -maxChars);
```

The stored "summary" becomes the tail 16K chars of the suffix — typically mid-word / mid-URL / raw tool JSON, with none of the structured sections (`## Decisions`, `## Open TODOs`, exact identifiers) the quality guard just spent an LLM round enforcing. The issue reporter observed **5 of 8 compaction summaries in one day beginning mid-string** with no headings.

## Why

`assembleSuffix()` concatenates split-turn + preserved-turns + tool-failure + file-ops + workspace-context sections. On tool-heavy turns the split-turn/preserved-turns sections carry verbatim message content and alone exceed 16K, so the eviction branch is the normal path, not a corner case. Losing the structured body silently defeats the whole quality-guard round: the next compaction has no Decisions/Open TODOs to build on, and mid-string summaries are indistinguishable from model-quality failures, sending operators chasing the wrong root cause.

The fix keeps the cap's original purpose — preserving the suffix TAIL, where workspace critical rules and post-compaction instructions are appended last — while guaranteeing the structured body a floor share in the eviction branch. **Sub-cap suffixes are untouched**: when the suffix fits under the cap it is kept whole, so split-turn and preserved recent turns stay intact exactly as documented ("Recent messages are kept intact", `docs/concepts/compaction.md`).

## User Impact

- Compaction summaries keep their structured `## Decisions` / `## Open TODOs` / exact-identifier sections on tool-heavy turns where the suffix alone exceeds 16K — the quality-guard LLM round is no longer wasted and subsequent compactions retain decision context.
- Suffix tail (workspace critical rules, tool-failure diagnostics, file-ops summary) is still preserved in the eviction branch, exactly as before.
- Suffixes under the cap are kept whole (no regression to preserved recent-turn context); bodies that fit with the suffix pass through unchanged.

## Evidence

Harness against `capCompactionSummaryPreservingSuffix` via the module's testing export. **Pre-fix** (base `main`):

```text
CASE1 suffix>=cap (16000+2000):
  total len: 16000 (cap 16000)
  keeps structured body: false | false     <- "## Decisions" / "keep flow" EVICTED
  keeps suffix tail: true
  starts with body: false
CASE2 large suffix below cap (14000):
  total len: 16000 (cap 16000)
  suffix whole: true                       <- sub-cap suffix kept intact
CASE3 fits within cap: unchanged = true | len 95
```

**Post-fix** (same harness, same inputs):

```text
CASE1 suffix>=cap (16000+2000):
  total len: 16000 (cap 16000)
  keeps structured body: true | true       <- "## Decisions" / "keep flow" preserved
  keeps suffix tail: true
  starts with body: true
CASE2 suffix below cap (14000):
  total len: 16000 (cap 16000)
  suffix whole: true                       <- still intact (P1 regression guard)
CASE3 fits: unchanged = true | len 95
```

The intermediate version that tail-sliced sub-cap suffixes (flagged P1 by review) produced `CASE2 suffix whole: false`; the shipped version restores `true`.

**Production-boundary proof** — the real `session_before_compact` handler with the **default quality guard enabled** (the safeguard runtime turns it on by default), driven with a tool-heavy transcript (12 preserved turns whose verbatim content alone exceeds 16K) plus an `AGENTS.md` workspace-critical-rules section. **Pre-fix** (`main`), the stored summary is the raw suffix tail — no structured headings:

```text
AssertionError: expected ' answer 3 answer 3 answer 3 answer 3 …' to contain '## Decisions'
```

**With the earlier helper-only patch**, the default audit path still cancelled: `finalizeSummaryText` passed `structuralSummary: ""` and `bodyBudget: 0` whenever the suffix exceeded the cap, so the audit reported every required heading missing and corrective retries were asked to fit within zero characters — compaction cancelled instead of storing the repaired summary (flagged P1 by review).

**Post-fix**, one allocation (`resolveSummaryBodyBudget`) drives the stored summary, the audit's `structuralSummary`, and the retry budget; the stored compaction summary keeps the structured body and ends with the workspace-critical tail, still bounded by the 16K cap:

```text
✓ keeps the structured body and workspace-critical tail when the preserved suffix exceeds the cap
  (default quality guard ON; asserts: contains "## Decisions"; ends with "</workspace-critical-rules>";
   contains "Never touch prod."; length <= 16000; compaction stored, not cancelled)
```

This also addresses the review note that the suffix budget halves in the eviction branch: the bounded tail sections (tool failures 8×240, file ops 2,000, workspace rules 2,000 ≈ 5.9K) fit comfortably in the ≥8,000 suffix floor, and the regression suite now pins the verbatim tail (`endsWith("</workspace-critical-rules>")`) instead of only the last character.

Test suite — `src/agents/agent-hooks/compaction-safeguard.test.ts`, including the new regression guards (body floor in eviction branch; sub-cap suffix kept whole; full-handler body+tail preservation on the default quality-guard path), re-run against current `main` after rebase:

```text
$ pnpm vitest run src/agents/agent-hooks/compaction-safeguard.test.ts
 ✓  agents-core  ../../src/agents/agent-hooks/compaction-safeguard.test.ts (129 tests) 1597ms
 ✓  agents-support  ../../src/agents/agent-hooks/compaction-safeguard.test.ts (129 tests) 1656ms
 Test Files  2 passed (2)
      Tests  258 passed (258)
```

Typecheck and lint clean:

```text
$ pnpm exec tsc --noEmit -p tsconfig.json    # no compaction-safeguard diagnostics
$ pnpm exec oxlint src/agents/agent-hooks/compaction-safeguard.ts src/agents/agent-hooks/compaction-safeguard.test.ts
Found 0 warnings and 0 errors.
```

`node scripts/check-changed.mjs` requires the CI-only `crabbox` workload router, which is not installed in this sandbox (fails with "selected binary failed basic --version/--help sanity checks"); the equivalent local lint/type/test gates above all pass.

[AI-assisted] Implementation and evidence generated with agent tooling.
