### PR TITLE
fix(plugins): honor enabledByDefault in config validation warnings

### DIFF
--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -1879,6 +1879,53 @@ describe("config plugin validation", () => {
     });
   });
 
+  it.each([
+    {
+      pluginId: "canvas",
+      config: { host: { enabled: true } },
+      expectDisabledConfigWarning: false,
+    },
+    {
+      pluginId: "workboard",
+      config: {},
+      expectDisabledConfigWarning: true,
+    },
+  ] as const)(
+    "honors bundled default enablement for config-only $pluginId entries",
+    ({ pluginId, config, expectDisabledConfigWarning }) => {
+      const res = validateConfigObjectWithPlugins(
+        {
+          agents: { list: [{ id: "openclaw" }] },
+          plugins: {
+            entries: {
+              [pluginId]: { config },
+            },
+          },
+        },
+        {
+          env: {
+            ...suiteEnv(),
+            OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(process.cwd(), "extensions"),
+          },
+        },
+      );
+
+      expect(res.ok).toBe(true);
+      if (!res.ok) {
+        return;
+      }
+      const disabledConfigWarning = {
+        path: `plugins.entries.${pluginId}`,
+        message: "plugin disabled (bundled (disabled by default)) but config is present",
+      };
+      if (expectDisabledConfigWarning) {
+        expect(res.warnings).toContainEqual(disabledConfigWarning);
+        return;
+      }
+      expect(res.warnings).not.toContainEqual(disabledConfigWarning);
+    },
+  );
+
   it("ignores standalone helper scripts in auto-discovered global extensions", async () => {
     const helperPath = path.join(suiteHome, ".openclaw", "extensions", "my-helper.mjs");
     await mkdirSafe(path.dirname(helperPath));

--- a/src/config/validation-plugin-config.ts
+++ b/src/config/validation-plugin-config.ts
@@ -6,6 +6,7 @@ import {
   resolveEffectivePluginActivationState,
   resolveMemorySlotDecision,
 } from "../plugins/config-state.js";
+import { isPluginEnabledByDefaultForPlatform } from "../plugins/default-enablement.js";
 import { resolveManifestCommandAliasOwnerInRegistry } from "../plugins/manifest-command-aliases.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import {
@@ -360,11 +361,14 @@ export function validateExplicitPluginConfig(params: {
     seenPlugins.add(pluginId);
     const entry = normalizedPlugins.entries[pluginId];
     const entryHasConfig = Boolean(entry?.config);
+    // Honor manifest default enablement so config-only entries for default-on
+    // bundled plugins do not warn as disabled. List/runtime already pass this.
     const activationState = resolveEffectivePluginActivationState({
       id: pluginId,
       origin: record.origin,
       config: normalizedPlugins,
       rootConfig: effectiveConfig,
+      enabledByDefault: isPluginEnabledByDefaultForPlatform(record),
     });
     let enabled = activationState.activated;
     let reason = activationState.reason;


### PR DESCRIPTION
Closes #122746

## What Problem This Solves

Fixes an issue where operators who configure `plugins.entries.canvas` with a `config` block and no top-level `enabled: true` would see `openclaw plugins list` report Canvas as enabled, while `openclaw status` and `openclaw doctor` warned that the plugin was disabled: `plugins.entries.canvas: plugin disabled (bundled (disabled by default)) but config is present`.

## Why This Change Was Made

Plugin inventory already passes manifest default enablement into the shared activation resolver. Config validation called the same resolver without that argument, so default-on bundled plugins were classified as bundled-disabled-by-default whenever config was present without an explicit enable flag.

The fix is one pass-through on the validation owner: `enabledByDefault: isPluginEnabledByDefaultForPlatform(record)`, matching `plugins list` / runtime. No Canvas special case, no config-shape change, and no doctor/status warning rewrite.

## User Impact

Config-only entries for default-on bundled plugins such as Canvas no longer produce a false disabled warning. `plugins list` and doctor/status now agree. Config-only entries for default-off bundled plugins still warn, so unused config on opt-in plugins remains visible.

## Evidence

Production LOC: +4 / -0 (net +4: import, invariant comment, one activation argument) | Tests: +47 / -0

The +4 production delta is the missing activation argument plus the import and a short cross-path comment. A net-zero rewrite would omit the comment or skip `enabledByDefaultOnPlatforms`; list/runtime already use `isPluginEnabledByDefaultForPlatform`.

### Real behavior proof

Built and run from this PR branch. Packaged CLI `dist/` was not present in this checkout, so proof uses the real doctor/status producer: `validateConfigObjectWithPlugins` → `validateExplicitPluginConfig`. That is the path that emits `plugin disabled (...) but config is present`.

Proof script imported `src/config/validation.ts` with a temp `HOME` and `OPENCLAW_BUNDLED_PLUGINS_DIR=extensions`, then validated:

```js
plugins: {
  entries: {
    canvas: { config: { host: { enabled: true } } },
    // and separately:
    workboard: { config: {} },
  },
}
```

**Before (parent `main`, no fix):**

- SHA: `b4ffa3106f205a2beef985c9b43887d7c2a6091f`
- Command: `node --import tsx /tmp/canvas-enabled-by-default-proof.mjs before-fix`

```json
{
  "label": "before-fix",
  "sha": "b4ffa3106f205a2beef985c9b43887d7c2a6091f",
  "cases": [
    {
      "name": "default-on canvas config-only",
      "pluginId": "canvas",
      "ok": true,
      "warningCount": 1,
      "warnings": [
        {
          "path": "plugins.entries.canvas",
          "message": "plugin disabled (bundled (disabled by default)) but config is present"
        }
      ]
    },
    {
      "name": "default-off workboard config-only",
      "pluginId": "workboard",
      "ok": true,
      "warningCount": 1,
      "warnings": [
        {
          "path": "plugins.entries.workboard",
          "message": "plugin disabled (bundled (disabled by default)) but config is present"
        }
      ]
    }
  ]
}
```

**After (this PR head):**

- SHA: `2a603ba0572c55c6a0732e63f4f156b78b694f84`
- Command: `node --import tsx /tmp/canvas-enabled-by-default-proof.mjs after-fix`

```json
{
  "label": "after-fix",
  "sha": "2a603ba0572c55c6a0732e63f4f156b78b694f84",
  "cases": [
    {
      "name": "default-on canvas config-only",
      "pluginId": "canvas",
      "ok": true,
      "warningCount": 0,
      "warnings": []
    },
    {
      "name": "default-off workboard config-only",
      "pluginId": "workboard",
      "ok": true,
      "warningCount": 1,
      "warnings": [
        {
          "path": "plugins.entries.workboard",
          "message": "plugin disabled (bundled (disabled by default)) but config is present"
        }
      ]
    }
  ]
}
```

List/runtime already pass `enabledByDefault` (`src/plugins/loader-cli-registry.ts`). After this change, validation uses the same fact, so doctor/status no longer contradict `plugins list` for config-only Canvas.

### Focused tests

Regression test failed on pre-fix `main` for the intended reason (Canvas config-only still warned), then passed on this head:

```text
# pre-fix (expected fail)
node scripts/run-vitest.mjs src/config/config.plugin-validation.test.ts -t "honors bundled default enablement"
FAIL honors bundled default enablement for config-only 'canvas' entries
AssertionError: expected true to be false

# post-fix
node scripts/run-vitest.mjs src/config/config.plugin-validation.test.ts -t "honors bundled default enablement"
Tests  2 passed | 82 skipped (84)

node scripts/run-vitest.mjs src/config/config.plugin-validation.test.ts src/plugins/config-state.test.ts
Tests  84 passed (config.plugin-validation)
Tests  51 passed (config-state)
```

### Follow-up (not in this PR)

`src/plugins/bundle-commands.ts` also omits `enabledByDefault` when resolving activation. That path loads Claude bundle commands, not doctor/status warnings, so it is a sibling follow-up rather than this warning invariant. `src/commands/channel-setup/trusted-catalog.ts` uses the activation result only for workspace `source === "auto"` trust, not bundled default-on doctor warnings.

## Testing

- `node scripts/run-vitest.mjs src/config/config.plugin-validation.test.ts`
- `node scripts/run-vitest.mjs src/plugins/config-state.test.ts`
- Real validation-path before/after script above (SHAs `b4ffa3106f205a2beef985c9b43887d7c2a6091f` → `2a603ba0572c55c6a0732e63f4f156b78b694f84`)
