### PR TITLE
fix(matrix): fresh installs no longer report an empty inbound dedupe migration in doctor changes

### DIFF
--- a/extensions/matrix/doctor-contract-api.test.ts
+++ b/extensions/matrix/doctor-contract-api.test.ts
@@ -765,7 +765,7 @@ describe("matrix doctor contract state migrations", () => {
     await expect(migration.detectLegacyState(createMigrationParams(stateDir))).resolves.toBeNull();
   });
 
-  it("records an empty legacy scan and then skips historical databases", async () => {
+  it("records an empty legacy scan silently and then skips historical databases", async () => {
     const stateDir = tempDirs.make("openclaw-matrix-doctor-");
     const migration = migrationById("matrix-inbound-dedupe-to-claimable-dedupe");
     const params = createMigrationParams(stateDir);
@@ -773,10 +773,10 @@ describe("matrix doctor contract state migrations", () => {
     await expect(migration.detectLegacyState(params)).resolves.toEqual({
       preview: ["Matrix inbound dedupe legacy sources need a one-time migration scan"],
     });
+    // Fresh installs scan nothing: the durable receipt is recorded (proven by
+    // the historical-database skip below) without a user-visible change line.
     await expect(migration.migrateLegacyState(params)).resolves.toEqual({
-      changes: [
-        "Recorded Matrix inbound dedupe migration completion (0 SQLite roots, 0 JSON roots scanned)",
-      ],
+      changes: [],
       warnings: [],
     });
     const lateDatabasePath = path.join(

--- a/extensions/matrix/doctor-contract-api.ts
+++ b/extensions/matrix/doctor-contract-api.ts
@@ -346,9 +346,13 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
         }
         try {
           await recordMatrixInboundDedupeMigrationCompletion(params.context, params.env);
-          changes.push(
-            `Recorded Matrix inbound dedupe migration completion (${sources.sqliteRoots.length} SQLite roots, ${sources.jsonRoots.length} JSON roots scanned)`,
-          );
+          // Fresh installs scan zero roots; keep the durable receipt silent
+          // there so onboarding doesn't report a migration that touched nothing.
+          if (sources.sqliteRoots.length + sources.jsonRoots.length > 0) {
+            changes.push(
+              `Recorded Matrix inbound dedupe migration completion (${sources.sqliteRoots.length} SQLite roots, ${sources.jsonRoots.length} JSON roots scanned)`,
+            );
+          }
         } catch (err) {
           warnings.push(
             `Failed recording Matrix inbound dedupe migration completion: ${String(err)}`,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a pristine fresh OpenClaw profile's onboarding/doctor run printed a "Doctor changes" panel entry — "Auto-migrated legacy state: Recorded Matrix inbound dedupe migration completion (0 SQLite roots, 0 JSON roots scanned)" — on a brand-new install with nothing to migrate. Migration bookkeeping noise on the default out-of-box path.

## Why This Change Was Made

The empty-scan durable receipt is intentional and stays exactly as is: it prevents a later-appearing historical database from being opened by the completed migration. Only the user-visible `changes` line is now suppressed when zero SQLite/JSON roots were scanned; any real scan (≥1 root) still reports the receipt line. The doctor panel already skips empty `changes` arrays (`src/infra/state-migrations.doctor.ts`), so a silent receipt produces no panel entry.

## User Impact

Fresh installs no longer see a confusing "Auto-migrated legacy state" panel entry during onboarding/doctor. Installs with actual legacy Matrix inbound dedupe state see unchanged output.

## Evidence

- Updated `extensions/matrix/doctor-contract-api.test.ts` ("records an empty legacy scan silently and then skips historical databases"): asserts `changes: []` on a fresh state dir, then proves the durable receipt still exists by dropping a historical database afterward and asserting detection stays null. Fails pre-fix (old code pushed the 0/0 line).
- `node scripts/run-vitest.mjs extensions/matrix/doctor-contract-api.test.ts extensions/matrix/doctor-contract-api.capacity.test.ts` → 2 files, 19 tests passed.
- Codex autoreview (gpt-5.6-sol, xhigh) on the diff: clean, no actionable findings.
- Production LOC delta: +4 (two-line comment + conditional wrapper); other receipt-line tests scan ≥1 root and are unchanged.
