### PR TITLE
chore: parallelize web fetch CLI checks

### DIFF
--- a/test/scripts/bench-web-fetch.test.ts
+++ b/test/scripts/bench-web-fetch.test.ts
@@ -1,24 +1,40 @@
 // Bench Web Fetch tests cover the offline benchmark CLI contract.
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { describe, expect, it } from "vitest";
 
 const SCRIPT_PATH = "scripts/bench-web-fetch.ts";
 
 function runBenchWebFetch(...args: string[]) {
-  return spawnSync(process.execPath, ["--import", "tsx", SCRIPT_PATH, ...args], {
-    cwd: process.cwd(),
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      FIRECRAWL_API_KEY: "test-firecrawl-key-that-should-be-ignored",
-      NODE_NO_WARNINGS: "1",
+  return new Promise<{ status: number | null; stderr: string; stdout: string }>(
+    (resolve, reject) => {
+      const child = spawn(process.execPath, ["--import", "tsx", SCRIPT_PATH, ...args], {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          FIRECRAWL_API_KEY: "test-firecrawl-key-that-should-be-ignored",
+          NODE_NO_WARNINGS: "1",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
+      child.stdout.on("data", (chunk: string) => {
+        stdout += chunk;
+      });
+      child.stderr.on("data", (chunk: string) => {
+        stderr += chunk;
+      });
+      child.once("error", reject);
+      child.once("close", (status) => resolve({ status, stderr, stdout }));
     },
-  });
+  );
 }
 
 describe("web fetch benchmark script", () => {
-  it("accepts the package-manager separator documented for pnpm scripts", () => {
-    const result = runBenchWebFetch(
+  it.concurrent("accepts the package-manager separator documented for pnpm scripts", async () => {
+    const result = await runBenchWebFetch(
       "--",
       "--case",
       "tool-create",
@@ -42,8 +58,8 @@ describe("web fetch benchmark script", () => {
     expect(report.cases[0]?.samplesMs).toHaveLength(1);
   });
 
-  it("rejects duplicate singular flags without a stack trace", () => {
-    const result = runBenchWebFetch("--runs", "1", "--runs", "2");
+  it.concurrent("rejects duplicate singular flags without a stack trace", async () => {
+    const result = await runBenchWebFetch("--runs", "1", "--runs", "2");
 
     expect(result.status).toBe(2);
     expect(result.stdout).toBe("");
@@ -51,13 +67,13 @@ describe("web fetch benchmark script", () => {
     expect(result.stderr).not.toContain("\n    at ");
   });
 
-  it.each([
+  it.concurrent.each([
     ["--runs", "1e3", "--runs must be a positive integer"],
     ["--warmup", "1e3", "--warmup must be a non-negative integer"],
     ["--runs", "9007199254740993", "--runs must be a positive integer"],
     ["--warmup", "9007199254740993", "--warmup must be a non-negative integer"],
-  ])("rejects invalid benchmark count %s %s", (flag, value, expectedError) => {
-    const result = runBenchWebFetch(flag, value);
+  ])("rejects invalid benchmark count %s %s", async (flag, value, expectedError) => {
+    const result = await runBenchWebFetch(flag, value);
 
     expect(result.status).toBe(2);
     expect(result.stdout).toBe("");


### PR DESCRIPTION
## What Problem This Solves

The offline web-fetch benchmark CLI contract test serialized six independent Node/TSX subprocesses. The focused fresh-cache test spent 12.08 seconds in test execution and 24.50 seconds wall-clock, adding avoidable time to the broad unit-fast CI shard.

## Why This Change Was Made

Run the six isolated CLI invocations asynchronously and concurrently while retaining every package-manager separator, JSON-report, duplicate-flag, unsafe-count, stdout, stderr, and exit-status assertion. This changes no production code and adds no CI jobs or workers.

## User Impact

No user-visible behavior changes. Developers and CI get the same CLI contract coverage with less elapsed time.

## Evidence

Exact same fresh-cache command before and after:

```bash
rm -rf <unique-cache>
/usr/bin/time -v env \
  OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=<unique-cache> \
  OPENCLAW_VITEST_IMPORT_DURATIONS=1 \
  OPENCLAW_VITEST_PRINT_IMPORT_BREAKDOWN=1 \
  node scripts/run-vitest.mjs \
  test/scripts/bench-web-fetch.test.ts \
  --maxWorkers=1 --reporter=verbose
```

- Before: 24.50s wall, 12.08s tests, 6/6 passed.
- After: 15.63s wall, 3.66s tests, 6/6 passed.
- Improvement: 36.2% wall-clock.
- Peak reported RSS: 381,876 KB → 336,112 KB.
- Targeted oxfmt, oxlint, and `git diff --check` passed.
- `check-changed --dry-run` selected the root-test/tooling lanes.
- Autoreview: TruffleHog clean; the configured Codex executable is unavailable in this orb, so no automated model verdict is claimed.
