### PR TITLE
fix(plugins): align config validation with default-enabled bundled plugins (#122746)

### DIFF
--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -1879,6 +1879,65 @@ describe("config plugin validation", () => {
     });
   });
 
+  it("does not warn that a bundled default-enabled plugin with config is disabled", () => {
+    // canvas is bundled with enabledByDefault: true; a config-only entry (no
+    // top-level enabled: true) must not produce the disabled-config warning
+    // that plugins list contradicts.
+    const res = validateConfigObjectWithPlugins(
+      {
+        agents: { list: [{ id: "openclaw" }] },
+        plugins: {
+          entries: {
+            canvas: {
+              config: { host: { enabled: true } },
+            },
+          },
+        },
+      },
+      {
+        env: suiteEnv(),
+        pluginMetadataSnapshot: {
+          manifestRegistry: {
+            plugins: [
+              {
+                id: "canvas",
+                origin: "bundled",
+                enabledByDefault: true,
+                channels: [],
+                providers: [],
+                cliBackends: [],
+                skills: [],
+                hooks: [],
+                rootDir: "/tmp/plugins/canvas",
+                source: "test",
+                manifestPath: "/tmp/plugins/canvas/openclaw.plugin.json",
+                schemaCacheKey: "test:canvas",
+                configSchema: {
+                  type: "object",
+                  properties: {
+                    host: {
+                      type: "object",
+                      properties: { enabled: { type: "boolean" } },
+                    },
+                  },
+                },
+              },
+            ],
+            diagnostics: [],
+          },
+        },
+      },
+    );
+
+    expect(res.ok).toBe(true);
+    expect(res.warnings ?? []).not.toContainEqual(
+      expect.objectContaining({
+        path: "plugins.entries.canvas",
+        message: expect.stringContaining("plugin disabled"),
+      }),
+    );
+  });
+
   it("ignores standalone helper scripts in auto-discovered global extensions", async () => {
     const helperPath = path.join(suiteHome, ".openclaw", "extensions", "my-helper.mjs");
     await mkdirSafe(path.dirname(helperPath));

--- a/src/config/validation-plugin-config.ts
+++ b/src/config/validation-plugin-config.ts
@@ -6,6 +6,7 @@ import {
   resolveEffectivePluginActivationState,
   resolveMemorySlotDecision,
 } from "../plugins/config-state.js";
+import { isPluginEnabledByDefaultForPlatform } from "../plugins/default-enablement.js";
 import { resolveManifestCommandAliasOwnerInRegistry } from "../plugins/manifest-command-aliases.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import {
@@ -365,6 +366,10 @@ export function validateExplicitPluginConfig(params: {
       origin: record.origin,
       config: normalizedPlugins,
       rootConfig: effectiveConfig,
+      // Match the plugin inventory's default-enablement resolution so
+      // validation does not warn "disabled" for bundled plugins that are
+      // enabled by default (e.g. canvas) but only carry a config block.
+      enabledByDefault: isPluginEnabledByDefaultForPlatform(record),
     });
     let enabled = activationState.activated;
     let reason = activationState.reason;


### PR DESCRIPTION
## What Problem This Solves

`openclaw plugins list` shows the bundled `canvas` plugin as **enabled**, while `openclaw status` and `openclaw doctor` both warn `plugins.entries.canvas: plugin disabled (bundled (disabled by default)) but config is present` — for the same config (`plugins.entries.canvas` containing only a `config` block, no top-level `enabled: true`).

## Why

The two surfaces resolve plugin activation differently:

- **Plugin inventory / `plugins list`** (`isInstalledPluginEnabled` → `resolveEffectivePluginActivationState`) passes the manifest's default-enablement flag: `enabledByDefault: isPluginEnabledByDefaultForPlatform(record)` (`src/plugins/installed-plugin-index.ts:151-157`). `canvas`'s manifest declares `"enabledByDefault": true` (`extensions/canvas/openclaw.plugin.json`), so the inventory correctly reports it enabled.
- **Config validation** (`validatePluginConfigs` in `src/config/validation-plugin-config.ts:363-368`) calls the same `resolveEffectivePluginActivationState` **without** `enabledByDefault`. Without the flag, a bundled plugin with no explicit `enabled: true` resolves to `bundled-disabled-by-default` → the disabled-config warning at line 422-427.

Both paths share the same activation resolver; the validation call site simply drops the manifest default. The contradictory output sends operators chasing a phantom config problem (and the issue notes a duplicate report, #122738, was closed against this same symptom).

## User Impact

- `status` / `doctor` no longer warn that a bundled default-enabled plugin is disabled when it carries only a config block — the two commands agree with `plugins list` again.
- Plugins that are genuinely disabled (explicit `enabled: false`, `not in allowlist`, workspace plugins without allowlisting, etc.) still produce the disabled-config warning exactly as before — only the default-enabled bundled case is aligned.
- Default behavior is unchanged: canvas and other `enabledByDefault: true` bundled plugins remain enabled; the fix only stops the false "disabled" warning.

## Evidence

Regression test (`src/config/config.plugin-validation.test.ts`) with a bundled `canvas`-shaped record (`enabledByDefault: true`) and a config-only entry. **Fails on pre-fix `main`**:

```text
× does not warn that a bundled default-enabled plugin with config is disabled 68ms
AssertionError: expected [ { …(2) } ] to not deep equally contain ObjectContaining{…}
 Test Files  1 failed (1)
      Tests  1 failed | 82 skipped (83)
```

**Passes post-fix**:

```text
✓  runtime-config  ../../src/config/config.plugin-validation.test.ts (83 tests | 82 skipped) 137ms
 Test Files  1 passed (1)
      Tests  1 passed | 82 skipped (83)
```

Full suite (only pre-existing SQLite WAL-guard failure on this sandbox's Node 24.13.1 remains, present before the change):

```text
Test Files  1 failed (1)      # pre-existing env failure: "requires SQLite 3.51.3+ ... Node 24.13.1 embeds SQLite 3.51.2"
      Tests  1 failed | 82 passed (83)
```

Lint clean:

```text
$ pnpm exec oxlint src/config/validation-plugin-config.ts src/config/config.plugin-validation.test.ts
Found 0 warnings and 0 errors.
```

[AI-assisted] Implementation and evidence generated with agent tooling.

## Real CLI proof (fresh run 2026-08-16, commit `59815024224c` — exact PR head)

Drove the real `openclaw` CLI (Node 24.15.0, fresh state dir, `plugins registry --refresh` built the persisted manifest registry; canvas record: `origin=bundled, enabled=true, enabledByDefault=true`) with the reported setup — `plugins.entries.canvas` carrying only a `config` block, no top-level `enabled: true`:

**Pre-fix contrast** (same config + registry, validation call site without `enabledByDefault`):

```text
$ openclaw config validate
Config valid: .../openclaw.json
1 warning(s):
  ! plugins.entries.canvas: plugin disabled (bundled (disabled by default)) but config is present
```

**Post-fix (exact PR head `59815024224c`)**:

```text
$ openclaw config validate
Config valid: .../openclaw.json
```

`openclaw plugins list` (unchanged by the fix) reports the same canvas entry as enabled in both runs:

```text
│ Canvas │ canvas │ openclaw │ enabled │ stock:canvas/index.ts │ 2026.8.1 │
```

So inventory (`plugins list`) and config validation (`config validate`) now agree for a config-only default-enabled bundled plugin — the false disabled-config warning is gone, and genuinely disabled plugins still warn (covered by the unchanged regression tests). Status/doctor show no canvas warning post-fix either.

[AI-assisted]