### PR TITLE
fix(slack): session card stuck on Working after concurrent mentions

### DIFF
--- a/extensions/slack/src/delivery-trace.test.ts
+++ b/extensions/slack/src/delivery-trace.test.ts
@@ -22,7 +22,8 @@ import {
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { ReplyDispatchKind, ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
-import { afterAll, afterEach, describe, it, vi } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { noteSlackDraftConversationMessage } from "./draft-message-boundaries.js";
 import type { PreparedSlackMessage } from "./monitor/message-handler/types.js";
 
 type RecordedWireCall = {
@@ -638,4 +639,70 @@ describe("slack delivery trace goldens", () => {
       });
     });
   }
+
+  it("removes a progress card detached by a later human message", async () => {
+    let progressEvents = 0;
+    const events = await runDeliveryTraceScenario({
+      scenario: {
+        name: "progress-session-card-detached",
+        steps: [
+          { kind: "reply-start" },
+          { kind: "tool-progress", name: "read", phase: "start" },
+          { kind: "advance", ms: 2000 },
+          { kind: "tool-progress", name: "write", phase: "start" },
+          { kind: "advance", ms: 2000 },
+          { kind: "final", text: "The replacement session card is complete." },
+          { kind: "idle" },
+        ],
+      },
+      setup: async (recorder) => {
+        const dispatch = await setupSlackTrace(recorder, "progress-session-card");
+        return async (step) => {
+          if (step.kind === "tool-progress") {
+            progressEvents += 1;
+            if (progressEvents === 2) {
+              traceState.tsCounter += 1;
+              noteSlackDraftConversationMessage({
+                accountId: "default",
+                channelId: CHANNEL_ID,
+                threadTs: INBOUND_TS,
+                messageTs: `1767225601.${String(traceState.tsCounter).padStart(6, "0")}`,
+                userId: "U_SECOND",
+                botUserId: "UBOT",
+              });
+            }
+          }
+          await dispatch(step);
+        };
+      },
+      normalize: createSlackTsNormalizer(),
+    });
+
+    const workingPosts = events.filter(
+      (event) =>
+        event.kind === "chat.postMessage" && JSON.stringify(event.data).includes("🔄 *Working*"),
+    );
+    expect(workingPosts).toHaveLength(2);
+    const firstCardId = (workingPosts[0]?.data as { result?: { ts?: string } } | undefined)?.result
+      ?.ts;
+    const secondCardId = (workingPosts[1]?.data as { result?: { ts?: string } } | undefined)?.result
+      ?.ts;
+    expect(firstCardId).toBeTruthy();
+    expect(secondCardId).toBeTruthy();
+    expect(
+      events.some(
+        (event) =>
+          event.kind === "chat.delete" &&
+          (event.data as { target?: string } | undefined)?.target === firstCardId,
+      ),
+    ).toBe(true);
+    expect(
+      events.some(
+        (event) =>
+          event.kind === "chat.update" &&
+          (event.data as { target?: string } | undefined)?.target === secondCardId &&
+          JSON.stringify(event.data).includes("✅ *Working*"),
+      ),
+    ).toBe(true);
+  });
 });

--- a/extensions/slack/src/draft-stream.test.ts
+++ b/extensions/slack/src/draft-stream.test.ts
@@ -197,6 +197,45 @@ describe("createSlackDraftStream", () => {
     expect(stream.messageId()).toBe("333.444");
   });
 
+  it("drops a posted preview detached by forceNewMessage", async () => {
+    const { stream, remove } = createDraftStreamHarness();
+
+    stream.update("working");
+    await stream.flush();
+    stream.forceNewMessage();
+    await stream.dropDetachedMessages();
+    await stream.dropDetachedMessages();
+
+    expect(remove).toHaveBeenCalledOnce();
+    expect(remove).toHaveBeenCalledWith("C123", "111.222", {
+      token: "xoxb-test",
+      accountId: undefined,
+    });
+  });
+
+  it("does not drop a finalized preview after forceNewMessage", async () => {
+    const { stream, remove } = createDraftStreamHarness();
+
+    stream.update("finished");
+    await stream.flush();
+    await stream.seal();
+    await expect(stream.finalizeMessage("111.222", async () => {})).resolves.toBe(true);
+    stream.forceNewMessage();
+    await stream.dropDetachedMessages();
+
+    expect(remove).not.toHaveBeenCalled();
+  });
+
+  it("does not issue wire calls when no detached preview exists", async () => {
+    const { stream, send, edit, remove } = createDraftStreamHarness();
+
+    await stream.dropDetachedMessages();
+
+    expect(send).not.toHaveBeenCalled();
+    expect(edit).not.toHaveBeenCalled();
+    expect(remove).not.toHaveBeenCalled();
+  });
+
   it("rearms updates after sealing and finalizing the previous message", async () => {
     const send = vi
       .fn<DraftSendFn>()

--- a/extensions/slack/src/draft-stream.test.ts
+++ b/extensions/slack/src/draft-stream.test.ts
@@ -213,6 +213,66 @@ describe("createSlackDraftStream", () => {
     });
   });
 
+  it("drains previews detached during an in-flight removal", async () => {
+    const accountId = "detach-during-drop";
+    let finishFirstRemove: (() => void) | undefined;
+    const firstRemove = new Promise<void>((resolve) => {
+      finishFirstRemove = resolve;
+    });
+    const send = vi
+      .fn<DraftSendFn>()
+      .mockResolvedValueOnce(slackDraftSendResult("100.100"))
+      .mockResolvedValueOnce(slackDraftSendResult("100.300"));
+    const remove = vi
+      .fn<DraftRemoveFn>()
+      .mockImplementationOnce(async () => await firstRemove)
+      .mockResolvedValueOnce(undefined);
+    const { stream } = createDraftStreamHarness({
+      accountId,
+      threadTs: "100.000",
+      send,
+      remove,
+    });
+
+    stream.update("_first card_");
+    await stream.flush();
+    noteSlackDraftConversationMessage({
+      accountId,
+      channelId: "C123",
+      threadTs: "100.000",
+      messageTs: "100.200",
+      userId: "U_OWNER",
+    });
+
+    const dropping = stream.dropDetachedMessages();
+    await vi.waitFor(() => {
+      expect(remove).toHaveBeenCalledOnce();
+    });
+
+    stream.update("_second card_");
+    await stream.flush();
+    noteSlackDraftConversationMessage({
+      accountId,
+      channelId: "C123",
+      threadTs: "100.000",
+      messageTs: "100.400",
+      userId: "U_OWNER",
+    });
+
+    finishFirstRemove?.();
+    await dropping;
+
+    expect(remove).toHaveBeenCalledTimes(2);
+    expect(remove).toHaveBeenNthCalledWith(1, "C123", "100.100", {
+      token: "xoxb-test",
+      accountId,
+    });
+    expect(remove).toHaveBeenNthCalledWith(2, "C123", "100.300", {
+      token: "xoxb-test",
+      accountId,
+    });
+  });
+
   it("does not drop a finalized preview after forceNewMessage", async () => {
     const { stream, remove } = createDraftStreamHarness();
 

--- a/extensions/slack/src/draft-stream.ts
+++ b/extensions/slack/src/draft-stream.ts
@@ -218,8 +218,11 @@ export function createSlackDraftStream(params: {
   };
 
   const dropDetachedMessages = async () => {
-    const messages = detachedMessages.splice(0);
-    for (const { channelId, messageId } of messages) {
+    // The boundary notifier can append synchronously while removal awaits.
+    // Re-read the live queue so this drain also owns those later detachments.
+    let message: { channelId: string; messageId: string } | undefined;
+    while ((message = detachedMessages.shift()) !== undefined) {
+      const { channelId, messageId } = message;
       await removeMessage(channelId, messageId);
     }
   };

--- a/extensions/slack/src/draft-stream.ts
+++ b/extensions/slack/src/draft-stream.ts
@@ -21,6 +21,7 @@ type SlackDraftStream = {
   seal: () => Promise<void>;
   stop: () => void;
   forceNewMessage: () => void;
+  dropDetachedMessages: () => Promise<void>;
   finalizeMessage: (messageId: string, editFinal: () => Promise<void>) => Promise<boolean>;
   messageId: () => string | undefined;
   channelId: () => string | undefined;
@@ -63,6 +64,8 @@ export function createSlackDraftStream(params: {
   let untrackConversationBoundary: (() => void) | undefined;
   let lastVisibleUpdate: { text: string; blocks?: (Block | KnownBlock)[] } | undefined;
   let lastSentKey = "";
+  const detachedMessages: Array<{ channelId: string; messageId: string }> = [];
+  const finalizedMessageIds = new Set<string>();
   const streamState = { stopped: false, final: false };
 
   const normalizeUpdate = (update: SlackDraftStreamUpdate) =>
@@ -171,6 +174,18 @@ export function createSlackDraftStream(params: {
     loop.stop();
   };
 
+  const removeMessage = async (channelId: string, messageId: string) => {
+    try {
+      await remove(channelId, messageId, {
+        token: params.token,
+        accountId: params.accountId,
+        ...(params.eventScope ? { client: params.eventScope.client } : {}),
+      });
+    } catch (err) {
+      params.warn?.(`slack stream preview cleanup failed: ${formatSlackError(err)}`);
+    }
+  };
+
   const clear = async () => {
     stopTrackingConversationBoundary();
     await discardPending();
@@ -183,26 +198,30 @@ export function createSlackDraftStream(params: {
     if (!channelId || !messageId) {
       return;
     }
-    try {
-      await remove(channelId, messageId, {
-        token: params.token,
-        accountId: params.accountId,
-        ...(params.eventScope ? { client: params.eventScope.client } : {}),
-      });
-    } catch (err) {
-      params.warn?.(`slack stream preview cleanup failed: ${formatSlackError(err)}`);
-    }
+    await removeMessage(channelId, messageId);
   };
 
   const forceNewMessage = () => {
     stopTrackingConversationBoundary();
     streamState.stopped = false;
     streamState.final = false;
+    if (streamChannelId && streamMessageId && !finalizedMessageIds.has(streamMessageId)) {
+      // A card abandoned below a newer human message is unreachable through
+      // finalize/clear and would otherwise linger in its Working state.
+      detachedMessages.push({ channelId: streamChannelId, messageId: streamMessageId });
+    }
     streamMessageId = undefined;
     streamChannelId = undefined;
     lastVisibleUpdate = undefined;
     lastSentKey = "";
     loop.resetPending();
+  };
+
+  const dropDetachedMessages = async () => {
+    const messages = detachedMessages.splice(0);
+    for (const { channelId, messageId } of messages) {
+      await removeMessage(channelId, messageId);
+    }
   };
 
   const discardPendingAndStopTracking = async () => {
@@ -222,6 +241,7 @@ export function createSlackDraftStream(params: {
 
     await editFinal();
     if (streamChannelId === channelId && streamMessageId === messageId) {
+      finalizedMessageIds.add(messageId);
       stopTrackingConversationBoundary();
       return true;
     }
@@ -252,6 +272,7 @@ export function createSlackDraftStream(params: {
     seal,
     stop,
     forceNewMessage,
+    dropDetachedMessages,
     finalizeMessage,
     messageId: () => streamMessageId,
     channelId: () => streamChannelId,

--- a/extensions/slack/src/monitor/message-handler/dispatch-progress-card.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress-card.ts
@@ -102,6 +102,7 @@ export function createSlackDraftProgressCardRuntime(params: {
     if (!params.draftStream || !params.enabled) {
       return false;
     }
+    await params.draftStream.dropDetachedMessages();
     const terminalStatus = finalStatus === "error" || status === "error" ? "error" : "success";
     if (finalStatus === terminalStatus) {
       return true;
@@ -140,6 +141,9 @@ export function createSlackDraftProgressCardRuntime(params: {
     resolveText,
     resolvePresentation,
     finalize,
+    get hasTerminalized() {
+      return finalStatus !== undefined;
+    },
     setFallbackText(text: string) {
       latestFallbackText = text;
     },

--- a/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
@@ -140,6 +140,14 @@ export function createSlackProgressRuntime(runtimeParams: {
     getSnapshot: () => progressDraft.getSnapshot(),
     getThreadTs: () => delivery.usedReplyThreadTs,
   });
+  // Card-only cleanup. Other draft modes abandon a preview holding streamed
+  // assistant text the human already replied to; that message stays visible.
+  const dropDetachedProgressCards = async () => {
+    if (!useDraftProgressCard) {
+      return;
+    }
+    await draftStream?.dropDetachedMessages();
+  };
 
   const waitForNativeProgressStreamStart = async (): Promise<boolean> => {
     if (delivery.streamSession || !delivery.nativeProgressStreamStartPromise) {
@@ -574,6 +582,7 @@ export function createSlackProgressRuntime(runtimeParams: {
     } else {
       await progressCard.finalize("success", priorSnapshot, priorFallbackText);
       draftStream?.forceNewMessage();
+      await dropDetachedProgressCards();
     }
     resetProgressTurnState();
     nativeTaskState = new Map();
@@ -620,6 +629,16 @@ export function createSlackProgressRuntime(runtimeParams: {
           resetDraftDeliveryState();
           resetDraftProgressState();
         };
+  // A queued turn can drain after its dispatch returned, so dispatch closeout is
+  // no longer available to settle the card it published. Leave none in Working.
+  const onQueuedFollowupSettled = !useDraftProgressCard
+    ? undefined
+    : async () => {
+        if (!progressCard.hasTerminalized) {
+          await draftStream?.clear();
+        }
+        await dropDetachedProgressCards();
+      };
 
   return {
     draftStream,
@@ -654,9 +673,11 @@ export function createSlackProgressRuntime(runtimeParams: {
     beginNewProgressTurn,
     buildNativeProgressCompletionChunks,
     collapseProgressReceipt,
+    dropDetachedProgressCards,
     finalizeDraftProgressCard: progressCard.finalize,
     onDraftBoundary,
     onQueuedFollowupAdmitted,
+    onQueuedFollowupSettled,
     pushPlanProgress,
     pushPreviewProgress,
     pushReasoningProgress,

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -280,6 +280,7 @@ function createDraftStreamStub() {
     seal: vi.fn(noopAsync),
     stop: vi.fn(noop),
     forceNewMessage: vi.fn(),
+    dropDetachedMessages: vi.fn(noopAsync),
     finalizeMessage: vi.fn(async (_messageId: string, editFinal: () => Promise<void>) => {
       await editFinal();
       return true;
@@ -3879,6 +3880,36 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expectLastDraftUpdateText(draftStream, "Working\n\n• queued turn");
   });
 
+  it("clears re-armed queued progress when the followup settles without a final delivery", async () => {
+    const draftStream = createDraftStreamStub();
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    mockedSlackStreamingMode = "progress";
+    mockedSlackDraftMode = "status_final";
+    mockedDispatchSequence = [];
+    mockedReplyOptionEvents = [{ kind: "item", progressText: "silent turn" }];
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        accountConfig: { streaming: { mode: "progress", progress: { label: "Working" } } },
+      }),
+    );
+    await capturedReplyOptions?.onQueuedFollowupAdmitted?.();
+    await requireCapturedItemEventHandler()({ progressText: "queued turn" });
+    const clearCallsBeforeSettlement = draftStream.clear.mock.calls.length;
+    const dropCallsBeforeSettlement = draftStream.dropDetachedMessages.mock.calls.length;
+    await capturedReplyOptions?.onQueuedFollowupSettled?.();
+
+    expectLastDraftUpdateText(draftStream, "Working\n\n• queued turn");
+    expect(draftStream.clear).toHaveBeenCalledTimes(clearCallsBeforeSettlement + 1);
+    expect(draftStream.clear.mock.invocationCallOrder.at(-1)).toBeGreaterThan(
+      draftStream.update.mock.invocationCallOrder.at(-1) ?? Number.POSITIVE_INFINITY,
+    );
+    expect(draftStream.dropDetachedMessages).toHaveBeenCalledTimes(dropCallsBeforeSettlement + 1);
+    expect(draftStream.dropDetachedMessages.mock.invocationCallOrder.at(-1)).toBeGreaterThan(
+      draftStream.clear.mock.invocationCallOrder.at(-1) ?? Number.POSITIVE_INFINITY,
+    );
+  });
+
   it("forces a new draft message on assistant boundaries in partial mode", async () => {
     const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
@@ -3894,6 +3925,9 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     await dispatchPreparedSlackMessage(createPreparedSlackMessage({}));
 
     expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
+    // Detached-message cleanup is card-only: a rotated partial preview still
+    // holds streamed assistant text and must survive dispatch closeout.
+    expect(draftStream.dropDetachedMessages).not.toHaveBeenCalled();
   });
 
   it("starts a new draft delivery target when a queued followup is admitted", async () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -442,6 +442,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           return false;
         },
         onQueuedFollowupAdmitted: progress.onQueuedFollowupAdmitted,
+        onQueuedFollowupSettled: progress.onQueuedFollowupSettled,
         onReasoningStream:
           statusReactionsEnabled || progress.previewToolProgressEnabled
             ? async (payload) => {
@@ -592,6 +593,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   if (dispatchError || agentRunFailed) {
     await progress.finalizeDraftProgressCard("error");
   }
+  await progress.dropDetachedProgressCards();
 
   if (statusReactionsEnabled) {
     if (dispatchError || agentRunFailed) {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -628,6 +628,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     !(agentRunFailed && progress.useDraftProgressCard)
   ) {
     await draftStream?.clear();
+    await progress.dropDetachedProgressCards();
     return;
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Slack users who mention the bot several times in quick
succession in the same channel would be left looking at a progress card stuck on
`🔄 Working` forever. Observed live on 2026-08-12: three to four `@Clawd` mentions
within ~25s produced two session cards — one finalized correctly to `✅` with its
"Open in OpenClaw" button, while the earlier one never reached a terminal state
and kept claiming the agent was still working long after the turn had finished.

The single-mention flow was always clean, so the card feature looked healthy in
normal use. This is the silent-non-terminal-state class: the card asserts an
in-progress turn that no longer exists, and nothing ever corrects or removes it.

## Why This Change Was Made

The cause is not turn supersession — it is draft-message detachment.

Slack keeps a live preview pinned to its place in the conversation: when a later
human message lands in the same conversation bucket,
`noteSlackDraftConversationMessage` fires `onInterveningMessage`, which is
`forceNewMessage`. That handler clears `streamChannelId`/`streamMessageId` so the
next agent output posts *below* the human message. Correct and deliberate — but
the already-posted `🔄 Working` card still exists in Slack while the draft stream
has forgotten how to address it.

Every path that could give that card a terminal state reads the stream's
*current* identity, so all of them no-op at once: `progressCard.finalize()`
returns false, `draftStream.clear()` returns early, and therefore so does the
"could not terminalize, so drop it" fallback on the final-delivery path.
`beginNewProgressTurn` compounded it by discarding `finalize()`'s return value.
Because `app_mention` events themselves call the boundary notifier, each rapid
mention orphans whichever card is currently working; only the last card, with
nothing landing beneath it, finalizes.

The repair is at the producer. The draft stream now retains any message it
abandons while still un-finalized — skipping messages `finalizeMessage` already
terminalized, otherwise the deliberate finalize-then-rotate sequence would delete
a perfectly good `✅` card — and exposes `dropDetachedMessages()`. That drain runs
inside `progressCard.finalize()`, one placement covering final delivery, error
closeout, and turn rotation.

A second hole on the same invariant is closed here too: core has exposed
`onQueuedFollowupSettled` for some time and Telegram uses it to clean up its
drafts, but Slack never implemented it. A queued follow-up turn drains through
the callbacks of a dispatch that has already returned and run its cleanup, so a
queued turn settling without a final reply had no owner left to settle the card
it published.

Both cleanups are deliberately gated on the session-card mode. In `partial` and
`append` draft modes an abandoned preview holds streamed assistant text the human
has already replied to, and that message must stay visible.

Non-goals: the native progress-streaming tier is unchanged (it terminalizes
through its own stream stop), and no new card state, config key, or env var is
introduced. Terminal means the existing `✅`/`❌` or removal.

## User Impact

Slack progress cards can no longer be left claiming work is in progress after it
has finished. Every posted card now reaches a terminal state or is removed, even
when a concurrent mention detaches it mid-turn or when its turn is a queued
follow-up that settles without a reply. Users mentioning the bot several times in
a row see one truthful card per delivered answer instead of an abandoned spinner.

No configuration changes, and no behavior change for the single-mention flow or
for non-card streaming modes.

## Evidence

Regression test drives the **real** draft stream through the real dispatch path
(`extensions/slack/src/delivery-trace.test.ts`), reproducing the reported
scenario: two `🔄 Working` cards are posted, a later human message detaches the
first, and the test asserts `chat.delete` on card one plus `chat.update` to `✅`
on card two.

Verified failing before the fix, for the right reason — both Working cards were
already observed, and the missing terminalization is what failed:

```
 × removes a progress card detached by a later human message
 FAIL  extensions/slack/src/delivery-trace.test.ts
 AssertionError: expected false to be true // Object.is equality
 Test Files  1 failed (1)
      Tests  1 failed | 6 passed (7)
```

Full Slack suite after the fix:

```
$ node scripts/run-vitest.mjs extensions/slack/src
 Test Files  131 passed (133) [2 pre-existing failures, see below]
      Tests  2338 passed (2340)
```

The two failures are `exec-approvals.test.ts` and `monitor/ingress.test.ts`. Both
were confirmed to fail identically on the untouched base commit with this change
stashed, so they are pre-existing and unrelated to this PR.

Unit coverage added at the draft-stream seam: a detached preview is dropped, a
message already finalized by `finalizeMessage` is *not* dropped by a later
`forceNewMessage`, and a no-detachment drop issues zero wire calls. Dispatch-level
coverage added for queued-follow-up settlement with no final delivery, and an
assertion pinning that partial-mode previews survive dispatch closeout.

Formatting via `oxfmt` and `git diff --check` clean. Production delta +57/-9
(net +48), tests +141/-1; the growth is the retained lifecycle state plus the
settlement wiring needed to give a detached message an owner.

Note on why this shipped green: `dispatch.preview-fallback.test.ts` stubs
`createSlackDraftStream`, so it structurally cannot observe detachment. The new
coverage runs against the real stream.
