### PR TITLE
fix(cron): stop retrying permanent delivery rejection

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch-policy.ts
+++ b/src/cron/isolated-agent/delivery-dispatch-policy.ts
@@ -15,7 +15,7 @@ import {
   loadDeliveryQueueEntry,
   type DeliveryQueueCompletionRetention,
 } from "../../infra/delivery-queue-sqlite.js";
-import { isProvenDeliveryNotSentError } from "../../infra/delivery-recovery.shared.js";
+import * as deliveryRecovery from "../../infra/delivery-recovery.shared.js";
 import { isFastTestRuntimeEnv } from "../../infra/env.js";
 import { OUTBOUND_DELIVERY_QUEUE_NAME } from "../../infra/outbound/delivery-queue-media-staging.js";
 import { normalizeTargetForProvider } from "../../infra/outbound/target-normalization.js";
@@ -254,6 +254,9 @@ function summarizeDirectCronDeliveryError(error: unknown): string {
 }
 
 function isTransientDirectCronDeliveryError(error: unknown): boolean {
+  if (deliveryRecovery.findPlatformMessageRejectedError(error)) {
+    return false;
+  }
   const message = summarizeDirectCronDeliveryError(error);
   if (!message) {
     return false;
@@ -261,7 +264,7 @@ function isTransientDirectCronDeliveryError(error: unknown): boolean {
   if (PERMANENT_DIRECT_CRON_DELIVERY_ERROR_PATTERNS.some((re) => re.test(message))) {
     return false;
   }
-  return isProvenDeliveryNotSentError(error);
+  return deliveryRecovery.isProvenDeliveryNotSentError(error);
 }
 function resolveDirectCronRetryDelaysMs(): readonly number[] {
   return isFastTestRuntimeEnv() ? [0, 0, 0] : [5_000, 10_000, 20_000];

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -2327,6 +2327,25 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(deliverOutboundPayloads).toHaveBeenCalledTimes(2);
   });
 
+  it("does not retry permanent typed pre-dispatch rejections", async () => {
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    const rejection = new PlatformMessageNotDispatchedError("payload rejected", {
+      cause: new Error("invalid payload"),
+      retryable: false,
+    });
+    vi.mocked(deliverOutboundPayloads).mockRejectedValue(rejection);
+
+    const params = makeBaseParams({ synthesizedText: "Reject this once." });
+    const state = await dispatchCronDelivery(params);
+
+    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+    expectResultFields(state.result, {
+      status: "error",
+      error: String(rejection),
+      deliveryAttempted: true,
+    });
+  });
+
   it.each(["structured", "threaded"] as const)(
     "retries proven-not-sent %s cron delivery without duplicating a message",
     async (deliveryKind) => {


### PR DESCRIPTION
Closes #122796

## What Problem This Solves

Fixes an issue where isolated cron jobs using direct delivery would retry a provider-declared permanent pre-dispatch rejection four times, adding up to 35 seconds of delay and repeating work that could never succeed.

## Why This Change Was Made

Cron's transient classifier now consults the existing graph-aware permanent platform rejection classifier before the broader proven-not-sent classifier. This keeps retry ownership in the shared delivery contract: `retryable: false` is terminal, while retryable no-send and proven pre-connect failures remain eligible for retry.

The change adds no provider literals, configuration, schema, protocol, dependency, helper, or fallback. Existing retry controls remain unchanged: retryable no-send, proven pre-connect, ambiguous send, deadline/abort, caller `shouldRetryError`, best-effort, and legacy permanent-text behavior.

## User Impact

Cron jobs now fail immediately after one provider attempt when a channel rejects delivery permanently before dispatch. Transient pre-dispatch failures still retry as before, and ambiguous failures still avoid a duplicate send.

## Evidence

- Authentic pre-fix regression: expected one provider call for a typed `retryable: false` rejection and observed four.
- Post-fix focused boundary suite: `delivery-dispatch.double-announce.test.ts` passed 129/129 after the exact `origin/main` rebase.
- Post-rebase Testbox changed gate: `tbx_01kzvwea8azhjqkeydx4ctmpc0`, [run 31640497391](https://github.com/openclaw/openclaw/actions/runs/31640497391), wrapper exit 0. An earlier attempt, [run 31640260572](https://github.com/openclaw/openclaw/actions/runs/31640260572), stopped during setup when the TruffleHog download connection dropped; no repository gate ran in that attempt.
- Exact-head CI: [run 31641343995](https://github.com/openclaw/openclaw/actions/runs/31641343995) passed on attempt 2 at `384082876297`. Attempt 1 passed 5,275 tests but recorded an unrelated unhandled `ECONNRESET` in `desktop-stream-command.test.ts`; the failed shard passed on rerun. Workflow Sanity [run 31641332548](https://github.com/openclaw/openclaw/actions/runs/31641332548) also passed on attempt 2 after an HTTP 503 while downloading ShellCheck.
- Formatting and `git diff --check`: clean.
- Fresh branch Autoreview against exact `origin/main`: clean; patch correct 0.98; TruffleHog clean.
- ClawSweeper: no actionable findings; its sole optional rank-up move was successful exact-head CI, now complete.
- LOC: production +5/-2 (net +3); tests +19/-0.
- Proof gap: no live cron/state/provider action was performed. Evidence is deterministic owner-boundary regression coverage plus the hosted changed gate.

AI-assisted implementation and review; maintainer verified the diff and evidence.
