### PR TITLE
fix(ui): recover failed bundled plugin views

### DIFF
--- a/ui/src/app/router-outlet.ts
+++ b/ui/src/app/router-outlet.ts
@@ -1,8 +1,8 @@
 import type { RouteMatch, Router } from "@openclaw/uirouter";
-import { html, nothing } from "lit";
+import { nothing } from "lit";
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 import { property } from "lit/decorators.js";
-import { icon } from "../components/icons.ts";
+import { renderLazyViewError } from "../components/lazy-view-error.ts";
 import { renderLoadingState } from "../components/loading-state.ts";
 import { McpAppUnmountGate } from "../components/mcp-app-unmount.ts";
 import { t } from "../i18n/index.ts";
@@ -77,7 +77,6 @@ function renderError<TRouteId extends string, TLoadContext, TModule, TData>(
   routeId: TRouteId,
   render?: () => unknown,
 ) {
-  const routeError = error instanceof Error ? error.message : String(error);
   const staleChunk = isStaleChunkImportError(error);
   if (staleChunk) {
     // The chunk this document references was replaced by a newer build;
@@ -113,31 +112,7 @@ function renderError<TRouteId extends string, TLoadContext, TModule, TData>(
   };
   // Stale-chunk failures are routine after a gateway update, so present them
   // as an update prompt instead of a generic failure.
-  const errorClasses = [
-    "lazy-view-error",
-    render ? "lazy-view-error--inline" : "",
-    staleChunk ? "lazy-view-error--stale" : "",
-  ]
-    .filter(Boolean)
-    .join(" ");
-  return html`
-    ${render?.() ?? nothing}
-    <div class=${errorClasses} role="alert">
-      <div class="lazy-view-error__icon" aria-hidden="true">
-        ${icon(staleChunk ? "refresh" : "alertTriangle")}
-      </div>
-      <div class="lazy-view-error__title">
-        ${staleChunk ? t("lazyView.staleTitle") : t("lazyView.errorTitle")}
-      </div>
-      <div class="lazy-view-error__subtitle">
-        ${staleChunk ? t("lazyView.staleSubtitle") : t("lazyView.genericSubtitle")}
-      </div>
-      <button class="btn lazy-view-error__action" @click=${handleRetry}>
-        ${staleChunk ? t("common.reload") : t("lazyView.retry")}
-      </button>
-      <code class="lazy-view-error__detail">${routeError}</code>
-    </div>
-  `;
+  return renderLazyViewError({ error, onRetry: handleRetry, render, stale: staleChunk });
 }
 
 function renderRouterOutlet<TRouteId extends string, TLoadContext, TModule, TData = unknown>(

--- a/ui/src/components/lazy-view-error.ts
+++ b/ui/src/components/lazy-view-error.ts
@@ -1,0 +1,36 @@
+import { html, nothing } from "lit";
+import { t } from "../i18n/index.ts";
+import { icon } from "./icons.ts";
+
+export function renderLazyViewError({
+  error,
+  onRetry,
+  render,
+  stale = false,
+}: {
+  error: unknown;
+  onRetry: (event: Event) => void;
+  render?: () => unknown;
+  stale?: boolean;
+}) {
+  const detail = error instanceof Error ? error.message : String(error);
+  const errorClasses = `lazy-view-error${render ? " lazy-view-error--inline" : ""}${stale ? " lazy-view-error--stale" : ""}`;
+  return html`
+    ${render?.() ?? nothing}
+    <div class=${errorClasses} role="alert">
+      <div class="lazy-view-error__icon" aria-hidden="true">
+        ${icon(stale ? "refresh" : "alertTriangle")}
+      </div>
+      <div class="lazy-view-error__title">
+        ${stale ? t("lazyView.staleTitle") : t("lazyView.errorTitle")}
+      </div>
+      <div class="lazy-view-error__subtitle">
+        ${stale ? t("lazyView.staleSubtitle") : t("lazyView.genericSubtitle")}
+      </div>
+      <button class="btn lazy-view-error__action" @click=${onRetry}>
+        ${stale ? t("common.reload") : t("lazyView.retry")}
+      </button>
+      <code class="lazy-view-error__detail">${detail}</code>
+    </div>
+  `;
+}

--- a/ui/src/e2e/plugin-bundled-view-recovery.e2e.test.ts
+++ b/ui/src/e2e/plugin-bundled-view-recovery.e2e.test.ts
@@ -1,0 +1,120 @@
+// Source-blind browser proof for bundled plugin lazy-view recovery.
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import type { Route } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const artifactDir = path.resolve(".artifacts/control-ui-e2e/plugin-bundled-view-recovery");
+const bundledChunk = /\/assets\/[^/]+\.js(?:\?.*)?$/;
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI bundled plugin lazy-view recovery",
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not available at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`.`,
+});
+
+suite.define(() => {
+  it("reloads after a stale Logbook chunk failure and recovers", async () => {
+    await mkdir(artifactDir, { recursive: true });
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          controlUiTabs: [
+            { group: "control", id: "logbook", label: "Logbook", pluginId: "logbook" },
+          ],
+          methodResponses: {
+            "logbook.days": { days: [] },
+            "logbook.status": {
+              analysisIntervalMinutes: 15,
+              analysisRunning: false,
+              captureEnabled: true,
+              captureIntervalSeconds: 30,
+              capturePaused: false,
+              pendingFrames: 0,
+              retentionDays: 30,
+              timeZone: "UTC",
+              today: "2026-08-12",
+              todayCards: 0,
+              visionModelSource: "missing",
+            },
+            "logbook.timeline": {
+              cards: [],
+              day: "2026-08-12",
+              stats: { apps: [], categories: [], distractionMs: 0, trackedMs: 0 },
+            },
+          },
+        });
+
+        const response = await page.goto(`${suite.server.baseUrl}plugin?plugin=missing&id=missing`);
+        expect(response?.status()).toBe(200);
+        await page.getByText("Plugin panel unavailable").waitFor();
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(artifactDir, "before.png"),
+        });
+
+        let failedRequests = 0;
+        let assetRequests = 0;
+        const failFirstBundledChunk = async (route: Route) => {
+          assetRequests += 1;
+          if (failedRequests === 0) {
+            failedRequests += 1;
+            await route.abort("internetdisconnected");
+            return;
+          }
+          await route.continue();
+        };
+        let markDocumentReachable!: () => void;
+        const documentReachable = new Promise<void>((resolve) => {
+          markDocumentReachable = resolve;
+        });
+        await page.route(/\/plugin(?:\?.*)?$/u, async (route) => {
+          if (route.request().method() !== "HEAD") {
+            await route.continue();
+            return;
+          }
+          await documentReachable;
+          await route.fulfill({ status: 200 });
+        });
+        await page.route(bundledChunk, failFirstBundledChunk);
+        await page.getByRole("link", { name: "Logbook", exact: true }).click();
+        await expect.poll(() => failedRequests).toBe(1);
+
+        const alert = page.getByRole("alert");
+        await alert.waitFor();
+        expect(await alert.textContent()).toContain("A new version is available");
+        expect(await alert.textContent()).toContain("Failed to fetch dynamically imported module");
+        await alert.getByRole("button", { name: "Reload" }).waitFor();
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(artifactDir, "failure.png"),
+        });
+
+        let navigationCount = 0;
+        page.on("framenavigated", (frame) => {
+          if (frame === page.mainFrame()) {
+            navigationCount += 1;
+          }
+        });
+        markDocumentReachable();
+        await page.locator(".logbook").waitFor();
+        expect(await alert.count()).toBe(0);
+        expect(assetRequests).toBeGreaterThan(1);
+        expect(navigationCount).toBe(1);
+        await gateway.waitForRequest("logbook.status");
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(artifactDir, "recovered.png"),
+        });
+        expect(new URL(page.url()).pathname).toBe("/plugin");
+      },
+    );
+  });
+});

--- a/ui/src/e2e/plugin-bundled-view-recovery.e2e.test.ts
+++ b/ui/src/e2e/plugin-bundled-view-recovery.e2e.test.ts
@@ -16,7 +16,7 @@ const suite = createControlUiE2eSuite({
 });
 
 suite.define(() => {
-  it("reloads after a stale Logbook chunk failure and recovers", async () => {
+  it("stops automatic reloads after one failed recovery and keeps manual Reload", async () => {
     await mkdir(artifactDir, { recursive: true });
     await suite.withPage(
       {
@@ -62,9 +62,12 @@ suite.define(() => {
 
         let failedRequests = 0;
         let assetRequests = 0;
-        const failFirstBundledChunk = async (route: Route) => {
+        let failingChunkPath: string | null = null;
+        const failBundledChunkTwice = async (route: Route) => {
           assetRequests += 1;
-          if (failedRequests === 0) {
+          const requestPath = new URL(route.request().url()).pathname;
+          failingChunkPath ??= requestPath;
+          if (requestPath === failingChunkPath && failedRequests < 2) {
             failedRequests += 1;
             await route.abort("internetdisconnected");
             return;
@@ -83,7 +86,7 @@ suite.define(() => {
           await documentReachable;
           await route.fulfill({ status: 200 });
         });
-        await page.route(bundledChunk, failFirstBundledChunk);
+        await page.route(bundledChunk, failBundledChunkTwice);
         await page.getByRole("link", { name: "Logbook", exact: true }).click();
         await expect.poll(() => failedRequests).toBe(1);
 
@@ -104,10 +107,18 @@ suite.define(() => {
           }
         });
         markDocumentReachable();
+
+        await expect.poll(() => failedRequests).toBe(2);
+        await alert.waitFor();
+        await page.waitForTimeout(500);
+        expect(await alert.count()).toBe(1);
+        expect(navigationCount).toBe(1);
+
+        await alert.getByRole("button", { name: "Reload" }).click();
         await page.locator(".logbook").waitFor();
         expect(await alert.count()).toBe(0);
-        expect(assetRequests).toBeGreaterThan(1);
-        expect(navigationCount).toBe(1);
+        expect(assetRequests).toBeGreaterThan(2);
+        expect(navigationCount).toBe(2);
         await gateway.waitForRequest("logbook.status");
         await page.screenshot({
           fullPage: true,

--- a/ui/src/pages/plugin/plugin-page.lazy-load.test.ts
+++ b/ui/src/pages/plugin/plugin-page.lazy-load.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayHelloOk } from "../../api/gateway.ts";
+import type { RouteId } from "../../app-route-paths.ts";
+import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
+import { PluginPage } from "./plugin-page.ts";
+
+type TestBundledView = {
+  render: () => unknown;
+  stop: (host: object) => void;
+};
+
+function deferred<T>() {
+  let reject!: (error: unknown) => void;
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    reject = rejectPromise;
+    resolve = resolvePromise;
+  });
+  return { promise, reject, resolve };
+}
+
+class RejectedPluginPage extends PluginPage {
+  loads: Promise<TestBundledView>[] = [];
+
+  protected override loadBundledView(): Promise<TestBundledView> {
+    const load = this.loads.shift();
+    if (!load) {
+      throw new Error("Unexpected bundled view load");
+    }
+    return load;
+  }
+}
+
+const rejectedPluginPageTag = "openclaw-rejected-plugin-page-test";
+if (!customElements.get(rejectedPluginPageTag)) {
+  customElements.define(rejectedPluginPageTag, RejectedPluginPage);
+}
+
+function createPage(loads: Promise<TestBundledView>[], includeExternal = false) {
+  const hello: GatewayHelloOk = {
+    type: "hello-ok",
+    protocol: 3,
+    auth: { role: "operator", scopes: ["operator.write"] },
+    controlUiTabs: [
+      { pluginId: "logbook", id: "logbook", label: "Logbook" },
+      ...(includeExternal
+        ? [{ pluginId: "external-plugin", id: "panel", label: "External panel" }]
+        : []),
+    ],
+  };
+  const snapshot: ApplicationGatewaySnapshot = {
+    client: null,
+    phase: "connected",
+    offlineStable: false,
+    canvasPluginSurfaceUrl: null,
+    hello,
+    assistantAgentId: null,
+    sessionKey: "main",
+    lastError: null,
+    lastErrorCode: null,
+  };
+  const page = document.createElement(rejectedPluginPageTag) as RejectedPluginPage;
+  page.loads = loads;
+  page.pluginId = "logbook";
+  page.tabId = "logbook";
+  (page as unknown as { context: ApplicationContext<RouteId> }).context = {
+    gateway: { snapshot, subscribe: () => () => undefined },
+  } as unknown as ApplicationContext<RouteId>;
+  return page;
+}
+
+describe("PluginPage bundled view load failures", () => {
+  it("shows the current rejection and recovers when Retry succeeds", async () => {
+    const failedLoad = deferred<TestBundledView>();
+    const retryLoad = deferred<TestBundledView>();
+    const page = createPage([failedLoad.promise, retryLoad.promise]);
+    document.body.append(page);
+    try {
+      await waitForFast(() => expect(page.querySelector('[role="status"]')).not.toBeNull());
+      failedLoad.reject(new Error("Logbook chunk failed"));
+      await waitForFast(() =>
+        expect(page.querySelector('[role="alert"]')?.textContent).toContain("Logbook chunk failed"),
+      );
+
+      page.querySelector<HTMLButtonElement>('[role="alert"] button')?.click();
+      await waitForFast(() => expect(page.querySelector('[role="status"]')).not.toBeNull());
+      retryLoad.resolve({ render: () => "recovered Logbook view", stop: vi.fn() });
+      await waitForFast(() => expect(page.textContent).toContain("recovered Logbook view"));
+      expect(page.querySelector('[role="alert"]')).toBeNull();
+    } finally {
+      page.remove();
+    }
+  });
+
+  it("ignores a stale rejection after switching away and back", async () => {
+    const staleLoad = deferred<TestBundledView>();
+    const currentLoad = deferred<TestBundledView>();
+    const page = createPage([staleLoad.promise, currentLoad.promise], true);
+    document.body.append(page);
+    try {
+      await page.updateComplete;
+      page.pluginId = "external-plugin";
+      page.tabId = "panel";
+      await page.updateComplete;
+      page.pluginId = "logbook";
+      page.tabId = "logbook";
+      await page.updateComplete;
+
+      currentLoad.resolve({ render: () => "current Logbook view", stop: vi.fn() });
+      await waitForFast(() => expect(page.textContent).toContain("current Logbook view"));
+      staleLoad.reject(new Error("Failed to fetch dynamically imported module"));
+      await Promise.resolve();
+      await page.updateComplete;
+
+      expect(page.querySelector('[role="alert"]')).toBeNull();
+      expect(page.textContent).toContain("current Logbook view");
+    } finally {
+      page.remove();
+    }
+  });
+});

--- a/ui/src/pages/plugin/plugin-page.lazy-load.test.ts
+++ b/ui/src/pages/plugin/plugin-page.lazy-load.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 import type { GatewayHelloOk } from "../../api/gateway.ts";
 import type { RouteId } from "../../app-route-paths.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { scheduleStaleChunkReload } from "../../app/stale-chunk-reload.ts";
+import { CONTROL_UI_BUILD_INFO } from "../../build-info.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { PluginPage } from "./plugin-page.ts";
 
@@ -90,6 +92,46 @@ describe("PluginPage bundled view load failures", () => {
       expect(page.querySelector('[role="alert"]')).toBeNull();
     } finally {
       page.remove();
+    }
+  });
+
+  it("keeps stale recovery visible after this build already reloaded automatically", async () => {
+    const failedLoad = deferred<TestBundledView>();
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => void values.set(key, value),
+    };
+    vi.spyOn(window, "sessionStorage", "get").mockReturnValue(storage as Storage);
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    await scheduleStaleChunkReload({
+      buildId: CONTROL_UI_BUILD_INFO.buildId,
+      now: () => Date.now() - 6_000,
+      reload: vi.fn(),
+      storage,
+    });
+    fetchMock.mockClear();
+    const page = createPage([failedLoad.promise]);
+    document.body.append(page);
+    try {
+      await waitForFast(() => expect(page.querySelector('[role="status"]')).not.toBeNull());
+      failedLoad.reject(new Error("Failed to fetch dynamically imported module"));
+      await waitForFast(() =>
+        expect(page.querySelector('[role="alert"]')?.textContent).toContain(
+          "Failed to fetch dynamically imported module",
+        ),
+      );
+
+      await Promise.resolve();
+      await page.updateComplete;
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(page.querySelector('[role="alert"]')).not.toBeNull();
+    } finally {
+      page.remove();
+      vi.unstubAllGlobals();
+      vi.restoreAllMocks();
     }
   });
 

--- a/ui/src/pages/plugin/plugin-page.ts
+++ b/ui/src/pages/plugin/plugin-page.ts
@@ -16,6 +16,7 @@ import { hasOperatorApprovalsAccess } from "../../app/operator-access.ts";
 import {
   isStaleChunkImportError,
   retryStaleChunkReloadWhenReachable,
+  scheduleStaleChunkReload,
 } from "../../app/stale-chunk-reload.ts";
 import { renderLazyViewError } from "../../components/lazy-view-error.ts";
 import { renderLoadingState } from "../../components/loading-state.ts";
@@ -183,7 +184,7 @@ export class PluginPage extends OpenClawLightDomContentsElement {
       }
       this.bundledViewState = nextState;
       if (nextState.status === "error" && isStaleChunkImportError(nextState.error)) {
-        void retryStaleChunkReloadWhenReachable();
+        void scheduleStaleChunkReload();
       }
     };
     void this.loadBundledView(key).then(

--- a/ui/src/pages/plugin/plugin-page.ts
+++ b/ui/src/pages/plugin/plugin-page.ts
@@ -13,6 +13,12 @@ import type { GatewayBrowserClient, GatewayControlUiPluginTab } from "../../api/
 import type { RouteId } from "../../app-route-paths.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { hasOperatorApprovalsAccess } from "../../app/operator-access.ts";
+import {
+  isStaleChunkImportError,
+  retryStaleChunkReloadWhenReachable,
+} from "../../app/stale-chunk-reload.ts";
+import { renderLazyViewError } from "../../components/lazy-view-error.ts";
+import { renderLoadingState } from "../../components/loading-state.ts";
 import { t } from "../../i18n/index.ts";
 import { resolveEmbedSandbox } from "../../lib/chat/tool-display.ts";
 import { OpenClawLightDomContentsElement } from "../../lit/openclaw-element.ts";
@@ -45,6 +51,12 @@ type BundledPluginTabView = {
   }) => unknown;
   stop: (host: object) => void;
 };
+
+type BundledPluginTabViewState =
+  | { status: "idle" }
+  | { status: "loading"; id: string; token: object }
+  | { status: "error"; id: string; error: unknown }
+  | { status: "ready"; id: string; view: BundledPluginTabView };
 
 function pluginFrameGrantCoversTab(
   grant: ControlUiPluginFrameGrantAck,
@@ -88,12 +100,10 @@ export class PluginPage extends OpenClawLightDomContentsElement {
   @consume({ context: applicationContext, subscribe: true })
   private context?: ApplicationContext<RouteId>;
 
-  @state() private bundledView: BundledPluginTabView | null = null;
+  @state() private bundledViewState: BundledPluginTabViewState = { status: "idle" };
   @state() private externalAuthReadyKey: string | null = null;
   @state() private externalAuthUnavailableKey: string | null = null;
 
-  private bundledViewId: string | null = null;
-  private bundledViewLoadToken: object | null = null;
   private bundledViewHost: object = {};
   private gatewaySource?: ApplicationContext<RouteId>["gateway"];
   private gatewayClient: GatewayBrowserClient | null = null;
@@ -156,6 +166,44 @@ export class PluginPage extends OpenClawLightDomContentsElement {
     return load ? load() : Promise.reject(new Error(`Unknown bundled plugin tab: ${key}`));
   }
 
+  private hasCurrentBundledDescriptor(key: string): boolean {
+    return this.tabKey() === key && this.tabInfo() !== undefined && key in BUNDLED_TAB_VIEWS;
+  }
+
+  private startBundledViewLoad(key: string) {
+    const loading = { status: "loading", id: key, token: {} } as const;
+    this.bundledViewState = loading;
+    const settle = (nextState: BundledPluginTabViewState) => {
+      if (
+        this.bundledViewState.status !== "loading" ||
+        this.bundledViewState.token !== loading.token ||
+        !this.hasCurrentBundledDescriptor(key)
+      ) {
+        return;
+      }
+      this.bundledViewState = nextState;
+      if (nextState.status === "error" && isStaleChunkImportError(nextState.error)) {
+        void retryStaleChunkReloadWhenReachable();
+      }
+    };
+    void this.loadBundledView(key).then(
+      (view) => settle({ status: "ready", id: key, view }),
+      (error: unknown) => settle({ status: "error", id: key, error }),
+    );
+  }
+
+  private readonly retryBundledView = () => {
+    const viewState = this.bundledViewState;
+    if (viewState.status !== "error" || !this.hasCurrentBundledDescriptor(viewState.id)) {
+      return;
+    }
+    if (isStaleChunkImportError(viewState.error)) {
+      void retryStaleChunkReloadWhenReachable();
+    } else {
+      this.bundledViewState = { status: "idle" };
+    }
+  };
+
   override willUpdate() {
     if (!this.isConnected) {
       return;
@@ -163,25 +211,15 @@ export class PluginPage extends OpenClawLightDomContentsElement {
     const key = this.tabKey();
     const info = this.tabInfo();
     const hasBundledDescriptor = info !== undefined && key in BUNDLED_TAB_VIEWS;
+    const viewState = this.bundledViewState;
     // Switching between plugin tabs reuses this element; the previous bundled
     // view must stop its background polling before the next one renders. A
     // descriptor can also disappear in place after disablement or scope loss.
-    if (this.bundledViewId !== null && (this.bundledViewId !== key || !hasBundledDescriptor)) {
+    if (viewState.status !== "idle" && (viewState.id !== key || !hasBundledDescriptor)) {
       this.stopBundledView();
     }
-    if (this.bundledViewId === null && hasBundledDescriptor) {
-      const loadToken = {};
-      this.bundledViewId = key;
-      this.bundledViewLoadToken = loadToken;
-      void this.loadBundledView(key).then((view) => {
-        if (
-          this.bundledViewLoadToken === loadToken &&
-          this.bundledViewId === key &&
-          this.tabKey() === key
-        ) {
-          this.bundledView = view;
-        }
-      });
+    if (this.bundledViewState.status === "idle" && hasBundledDescriptor) {
+      this.startBundledViewLoad(key);
     }
     this.syncExternalTabAuth(info, hasBundledDescriptor);
   }
@@ -496,13 +534,13 @@ export class PluginPage extends OpenClawLightDomContentsElement {
 
   private stopBundledView() {
     this.replaceBundledViewHost();
-    this.bundledView = null;
-    this.bundledViewId = null;
-    this.bundledViewLoadToken = null;
+    this.bundledViewState = { status: "idle" };
   }
 
   private replaceBundledViewHost() {
-    this.bundledView?.stop(this.bundledViewHost);
+    if (this.bundledViewState.status === "ready") {
+      this.bundledViewState.view.stop(this.bundledViewHost);
+    }
     // Async controller work is keyed by host. A new host makes every completion
     // from the retired connection epoch unreachable without coupling plugins to Lit.
     this.bundledViewHost = {};
@@ -542,12 +580,23 @@ export class PluginPage extends OpenClawLightDomContentsElement {
     // inactive or whose required scopes the connection lacks.
     const info = this.tabInfo();
     if (info && this.tabKey() in BUNDLED_TAB_VIEWS) {
-      if (!this.bundledView) {
+      const viewState = this.bundledViewState;
+      if (viewState.status === "loading") {
+        return renderLoadingState();
+      }
+      if (viewState.status === "error") {
+        return renderLazyViewError({
+          error: viewState.error,
+          onRetry: this.retryBundledView,
+          stale: isStaleChunkImportError(viewState.error),
+        });
+      }
+      if (viewState.status !== "ready") {
         return nothing;
       }
       const snapshot = context.gateway.snapshot;
       const config = context.config?.current;
-      return this.bundledView.render({
+      return viewState.view.render({
         host: this.bundledViewHost,
         client: snapshot.client,
         connected: snapshot.phase === "connected",


### PR DESCRIPTION
## What Problem This Solves

Bundled plugin views such as Logbook handled successful lazy imports but not rejected imports. A transient chunk fetch or module-evaluation failure left the advertised page permanently blank with an unhandled rejection until the operator manually reloaded the Control UI.

## Why This Change Was Made

`PluginPage` now owns a closed bundled-view lifecycle:

- `idle`, `loading`, `error`, and `ready` states make every outcome renderable;
- load tokens plus current route/descriptor checks reject stale success and stale failure completions;
- generic module failures show the established lazy-view alert and Retry starts a fresh import;
- stale chunk failures use the existing guarded automatic reload path, while explicit Reload retains bounded reachability retry;
- switching tabs or losing the descriptor retires the ready view and its polling host;
- loading renders the shared loading state instead of a blank surface.

The router’s existing lazy-error UI was extracted into one shared renderer and retains its prior behavior. No protocol, config, storage, security, or new copy/i18n surface is added.

AI-assisted: yes. The initial +65-production-line implementation was simplified to +60 while preserving the closed lifecycle and stale fencing, then passed fresh structured autoreview after final rebase.

## User Impact

A failed Logbook chunk now produces a visible recovery path, automatically reloads at most once per build, and keeps explicit Reload available instead of leaving a blank page or looping on a broken build.

## Visual Proof

### Before — rejected Logbook import leaves a blank page

![Blank Logbook page before repair](https://github.com/user-attachments/assets/39d24024-24a5-4ef2-8603-e2300dbe45ff)

### After — visible stale-chunk recovery state

![Logbook load failure with reload guidance](https://github.com/user-attachments/assets/ec8fe855-47e2-4e79-8912-b77864628928)

### Recovered — Logbook renders after reload

![Recovered Logbook page](https://github.com/user-attachments/assets/291cc626-74ba-448a-ac40-1be06ea67911)

All screenshots use the isolated mock Gateway and synthetic account data.

## Evidence

- Pre-fix production-bundle Chromium reproduction showed the Logbook route selected with an empty content surface after the chunk failure.
- Post-fix focused proof: 35 PluginPage/router/stale-reload unit tests plus 1 source-blind production-bundle Chromium E2E passed.
- E2E aborts the same bundled chunk before and after the guarded automatic reload, proves exactly one automatic navigation with the recovery alert still visible, then proves explicit Reload performs the second navigation and renders Logbook.
- Final hosted changed gate passed on Testbox `tbx_01kzvz0qrtwvrhf468t3tq5my6` ([run](https://github.com/openclaw/openclaw/actions/runs/31644010983)); an earlier attempt failed before code execution during Testbox checkout hydration.
- Exact-head CI passed at `7a1df47efa84fc9a00e42967c3e4ca6c2db8b467` ([run](https://github.com/openclaw/openclaw/actions/runs/31644435238)), including all UI and UI E2E lanes.
- UI typecheck, i18n verification, stylelint, oxlint, max-lines, dead-export checks, formatting, and `git diff --check` passed.
- Fresh correction autoreview: clean at 0.99 confidence; fresh complete-branch autoreview: clean at 0.98 confidence.
- Production +112/−51 (net +61); tests +295/−0. Eleven net production lines are the shared router/plugin error renderer; the remainder is the explicit bundled-view lifecycle, token fencing, and guarded automatic/manual reload ownership.
