### PR TITLE
fix(slack): strip Exec failed traces from streaming replies

### DIFF
--- a/extensions/slack/src/__traces__/native-prose-then-exec-failed.trace.jsonl
+++ b/extensions/slack/src/__traces__/native-prose-then-exec-failed.trace.jsonl
@@ -1,0 +1,9 @@
+{"seq":1,"at":0,"dir":"in","kind":"reply-start"}
+{"seq":2,"at":0,"dir":"out","kind":"assistant.threads.setStatus","data":{"payload":{"channel_id":"C0TRACE","status":"is typing...","thread_ts":"ts#1"},"result":{"ok":true},"target":"C0TRACE/ts#1"}}
+{"seq":3,"at":0,"dir":"in","kind":"final","data":{"text":"The directory is missing."}}
+{"seq":4,"at":0,"dir":"out","kind":"users.info","data":{"payload":{"user":"U0TRACE"},"result":{"team_id":"T0TRACE"},"target":"U0TRACE"}}
+{"seq":5,"at":0,"dir":"in","kind":"final","data":{"text":"⚠️ 🛠️ Exec failed: "}}
+{"seq":6,"at":0,"dir":"in","kind":"idle"}
+{"seq":7,"at":0,"dir":"out","kind":"assistant.threads.setStatus","data":{"payload":{"channel_id":"C0TRACE","status":"","thread_ts":"ts#1"},"result":{"ok":true},"target":"C0TRACE/ts#1"}}
+{"seq":8,"at":0,"dir":"out","kind":"chat.startStream","data":{"payload":{"channel":"C0TRACE","recipient_team_id":"T0TRACE","recipient_user_id":"U0TRACE","thread_ts":"ts#1"},"result":{"ts":"ts#2"},"target":"C0TRACE"}}
+{"seq":9,"at":0,"dir":"out","kind":"chat.stopStream","data":{"payload":{"channel":"C0TRACE","chunks":[{"text":"The directory is missing.","type":"markdown_text"}],"ts":"ts#2"},"result":{"ok":true},"target":"ts#2"}}

--- a/extensions/slack/src/__traces__/preview-exec-failed-then-prose.trace.jsonl
+++ b/extensions/slack/src/__traces__/preview-exec-failed-then-prose.trace.jsonl
@@ -1,0 +1,9 @@
+{"seq":1,"at":0,"dir":"in","kind":"reply-start"}
+{"seq":2,"at":0,"dir":"out","kind":"assistant.threads.setStatus","data":{"payload":{"channel_id":"C0TRACE","status":"is typing...","thread_ts":"ts#1"},"result":{"ok":true},"target":"C0TRACE/ts#1"}}
+{"seq":3,"at":0,"dir":"in","kind":"partial","data":{"text":"⚠️ 🛠️ Exec failed: "}}
+{"seq":4,"at":1100,"dir":"in","kind":"partial","data":{"text":"The directory is missing."}}
+{"seq":5,"at":1100,"dir":"out","kind":"chat.postMessage","data":{"payload":{"channel":"C0TRACE","text":"The directory is missing.","thread_ts":"ts#1","unfurl_links":false},"result":{"ts":"ts#2"},"target":"C0TRACE"}}
+{"seq":6,"at":2200,"dir":"in","kind":"final","data":{"text":"The directory is missing."}}
+{"seq":7,"at":2200,"dir":"out","kind":"chat.update","data":{"payload":{"channel":"C0TRACE","text":"The directory is missing.","ts":"ts#2"},"result":{"ok":true},"target":"ts#2"}}
+{"seq":8,"at":2200,"dir":"in","kind":"idle"}
+{"seq":9,"at":2200,"dir":"out","kind":"assistant.threads.setStatus","data":{"payload":{"channel_id":"C0TRACE","status":"","thread_ts":"ts#1"},"result":{"ok":true},"target":"C0TRACE/ts#1"}}

--- a/extensions/slack/src/delivery-trace.test.ts
+++ b/extensions/slack/src/delivery-trace.test.ts
@@ -36,6 +36,7 @@ type RecordedWireCall = {
 type CapturedDispatcherOptions = {
   deliver: (payload: ReplyPayload, info: { kind: ReplyDispatchKind }) => Promise<unknown>;
   onError?: (err: unknown, info: { kind: string }) => Promise<void> | void;
+  transformReplyPayload?: (payload: ReplyPayload) => ReplyPayload | null;
   typingCallbacks?: {
     onReplyStart?: () => Promise<void>;
     onIdle?: () => void;
@@ -183,12 +184,15 @@ type SlackTraceScenarioName =
   | "preview-edit-fallback"
   | "progress-compact-commentary"
   | "progress-session-card"
-  | "progress-native-unified";
+  | "progress-native-unified"
+  | "native-prose-then-exec-failed"
+  | "preview-exec-failed-then-prose";
 
 const NATIVE_SCENARIOS = new Set<SlackTraceScenarioName>([
   "streaming-happy-native",
   "stream-stop-first-network-call",
   "final-blocks-and-text",
+  "native-prose-then-exec-failed",
 ]);
 
 const NATIVE_PROGRESS_NARRATION =
@@ -210,6 +214,8 @@ const SHORT_FINAL_TEXT = "All checks passed. Ship it.";
 const PREVIEW_PARTIAL_ONE = "Compiling the changelog";
 const PREVIEW_PARTIAL_TWO = "Compiling the changelog for 2026.1.0.";
 const PREVIEW_FINAL_TEXT = "Compiling the changelog for 2026.1.0.\n\nDone: 12 entries.";
+const EXEC_FAILED_TRACE = "⚠️ 🛠️ Exec failed: ";
+const EXEC_FAILED_PROSE = "The directory is missing.";
 const COMPACT_COMMENTARY_TEXT = "Checking the current Slack behavior.";
 const COMPACT_COMMENTARY_TEXT_UPDATED =
   "Checking the current Slack behavior and preparing the focused fix.";
@@ -306,6 +312,21 @@ const slackTraceScenarios: Record<SlackTraceScenarioName, readonly DeliveryTrace
     { kind: "partial", text: NATIVE_PROGRESS_NARRATION_UPDATED },
     { kind: "tool-progress", name: "write", phase: "result" },
     { kind: "final", text: "The unified native Slack turn is complete." },
+    { kind: "idle" },
+  ],
+  "native-prose-then-exec-failed": [
+    { kind: "reply-start" },
+    { kind: "final", text: EXEC_FAILED_PROSE },
+    { kind: "final", text: EXEC_FAILED_TRACE },
+    { kind: "idle" },
+  ],
+  "preview-exec-failed-then-prose": [
+    { kind: "reply-start" },
+    { kind: "partial", text: EXEC_FAILED_TRACE },
+    { kind: "advance", ms: 1100 },
+    { kind: "partial", text: EXEC_FAILED_PROSE },
+    { kind: "advance", ms: 1100 },
+    { kind: "final", text: EXEC_FAILED_PROSE },
     { kind: "idle" },
   ],
 };
@@ -623,8 +644,14 @@ async function setupSlackTrace(
   }
 
   const deliver = async (payload: ReplyPayload, kind: ReplyDispatchKind) => {
+    const transformed = turn.options.transformReplyPayload
+      ? turn.options.transformReplyPayload(payload)
+      : payload;
+    if (!transformed) {
+      return;
+    }
     try {
-      await turn.options.deliver(payload, { kind });
+      await turn.options.deliver(transformed, { kind });
       traceState.counts[kind] += 1;
     } catch (err) {
       // Mirrors the reply dispatcher: failed deliveries report onError and are
@@ -728,7 +755,67 @@ async function setupSlackTrace(
   };
 }
 
+function collectSlackWireTexts(events: readonly TraceEvent[]): string[] {
+  const texts: string[] = [];
+  const pushText = (value: unknown) => {
+    if (typeof value === "string" && value.length > 0) {
+      texts.push(value);
+    }
+  };
+  for (const event of events) {
+    if (event.dir !== "out" || !event.data || typeof event.data !== "object") {
+      continue;
+    }
+    const payload = (event.data as { payload?: unknown }).payload;
+    if (!payload || typeof payload !== "object") {
+      continue;
+    }
+    const record = payload as Record<string, unknown>;
+    pushText(record.text);
+    pushText(record.markdown_text);
+    if (Array.isArray(record.chunks)) {
+      for (const chunk of record.chunks) {
+        if (chunk && typeof chunk === "object") {
+          pushText((chunk as { text?: unknown }).text);
+        }
+      }
+    }
+  }
+  return texts;
+}
+
+function buildSlackDeliveryProofVerdict(params: {
+  scenario: SlackTraceScenarioName;
+  events: readonly TraceEvent[];
+  headSha: string;
+}): Record<string, unknown> {
+  const wireTexts = collectSlackWireTexts(params.events);
+  return {
+    kind: "mock-gateway",
+    liveSlack: false,
+    harness: "extensions/slack/src/delivery-trace.test.ts",
+    channel: "slack",
+    scenario: params.scenario,
+    headSha: params.headSha,
+    environment: {
+      node: process.version,
+      platform: process.platform,
+      slackApi: "recording WebClient",
+      provider: "scripted agent turn",
+      delivery: "real dispatchPreparedSlackMessage + ChatStreamer/draft preview",
+    },
+    inboundPayloads: params.events
+      .filter((event) => event.dir === "in" && (event.kind === "final" || event.kind === "partial"))
+      .map((event) => event.data),
+    deliveredWireTexts: wireTexts,
+    execFailedDelivered: wireTexts.some((text) => text.includes("Exec failed")),
+    proseDelivered: wireTexts.some((text) => text.includes(EXEC_FAILED_PROSE)),
+    outMethods: params.events.filter((event) => event.dir === "out").map((event) => event.kind),
+  };
+}
+
 describe("slack delivery trace goldens", () => {
+  const headSha = process.env.OPENCLAW_DELIVERY_PROOF_SHA ?? "";
   for (const scenarioName of Object.keys(slackTraceScenarios) as SlackTraceScenarioName[]) {
     it(`records ${scenarioName}`, async () => {
       const events = await runDeliveryTraceScenario({
@@ -740,6 +827,19 @@ describe("slack delivery trace goldens", () => {
         goldenUrl: new URL(`./__traces__/${scenarioName}.trace.jsonl`, import.meta.url),
         events,
       });
+      const wireTexts = collectSlackWireTexts(events);
+      expect(wireTexts.join("\n")).not.toMatch(/Exec failed/i);
+      if (
+        scenarioName === "native-prose-then-exec-failed" ||
+        scenarioName === "preview-exec-failed-then-prose"
+      ) {
+        expect(wireTexts.some((text) => text.includes(EXEC_FAILED_PROSE))).toBe(true);
+        if (process.env.OPENCLAW_DELIVERY_PROOF === "1") {
+          process.stdout.write(
+            `${JSON.stringify(buildSlackDeliveryProofVerdict({ scenario: scenarioName, events, headSha }), null, 2)}\n`,
+          );
+        }
+      }
     });
   }
 

--- a/extensions/slack/src/delivery-trace.test.ts
+++ b/extensions/slack/src/delivery-trace.test.ts
@@ -22,7 +22,7 @@ import {
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { ReplyDispatchKind, ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
-import { afterAll, afterEach, describe, it, vi } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import type { PreparedSlackMessage } from "./monitor/message-handler/types.js";
 
 type RecordedWireCall = {
@@ -166,12 +166,15 @@ type SlackTraceScenarioName =
   | "final-blocks-and-text"
   | "cancel-mid-stream"
   | "preview-edit-fallback"
-  | "progress-session-card";
+  | "progress-session-card"
+  | "native-prose-then-exec-failed"
+  | "preview-exec-failed-then-prose";
 
 const NATIVE_SCENARIOS = new Set<SlackTraceScenarioName>([
   "streaming-happy-native",
   "stream-stop-first-network-call",
   "final-blocks-and-text",
+  "native-prose-then-exec-failed",
 ]);
 
 // Long enough that the second stream append pushes the SDK buffer past
@@ -189,6 +192,12 @@ const SHORT_FINAL_TEXT = "All checks passed. Ship it.";
 const PREVIEW_PARTIAL_ONE = "Compiling the changelog";
 const PREVIEW_PARTIAL_TWO = "Compiling the changelog for 2026.1.0.";
 const PREVIEW_FINAL_TEXT = "Compiling the changelog for 2026.1.0.\n\nDone: 12 entries.";
+
+// Reported Slack streaming leak: a successful answer, then a separate compact
+// Exec-failed follow-up. The monitor transform must drop the follow-up on the
+// wire while still delivering the prose.
+const EXEC_FAILED_TRACE = "⚠️ 🛠️ Exec failed: ";
+const EXEC_FAILED_PROSE = "The directory is missing.";
 
 const BLOCKS_FINAL_TEXT = "Release 2026.1.0 is ready to ship.";
 // Portable presentation actions; slack renders them as Block Kit and must
@@ -261,6 +270,24 @@ const slackTraceScenarios: Record<SlackTraceScenarioName, readonly DeliveryTrace
     { kind: "tool-progress", name: "read", phase: "start" },
     { kind: "advance", ms: 2000 },
     { kind: "final", text: "The session card is complete." },
+    { kind: "idle" },
+  ],
+  // Native stream: answer first, then the compact failure as a second final.
+  // IN records both payloads; OUT must carry only the prose.
+  "native-prose-then-exec-failed": [
+    { kind: "reply-start" },
+    { kind: "final", text: EXEC_FAILED_PROSE },
+    { kind: "final", text: EXEC_FAILED_TRACE },
+    { kind: "idle" },
+  ],
+  // Draft preview: an Exec-failed partial must not post; later prose must.
+  "preview-exec-failed-then-prose": [
+    { kind: "reply-start" },
+    { kind: "partial", text: EXEC_FAILED_TRACE },
+    { kind: "advance", ms: 1100 },
+    { kind: "partial", text: EXEC_FAILED_PROSE },
+    { kind: "advance", ms: 1100 },
+    { kind: "final", text: EXEC_FAILED_PROSE },
     { kind: "idle" },
   ],
 };
@@ -631,7 +658,70 @@ async function setupSlackTrace(
   };
 }
 
+/** Visible Slack markdown/text from recorded Web API payloads. */
+function collectSlackWireTexts(events: readonly TraceEvent[]): string[] {
+  const texts: string[] = [];
+  const pushText = (value: unknown) => {
+    if (typeof value === "string" && value.length > 0) {
+      texts.push(value);
+    }
+  };
+  for (const event of events) {
+    if (event.dir !== "out" || !event.data || typeof event.data !== "object") {
+      continue;
+    }
+    const payload = (event.data as { payload?: unknown }).payload;
+    if (!payload || typeof payload !== "object") {
+      continue;
+    }
+    const record = payload as Record<string, unknown>;
+    pushText(record.text);
+    pushText(record.markdown_text);
+    if (!Array.isArray(record.chunks)) {
+      continue;
+    }
+    for (const chunk of record.chunks) {
+      if (chunk && typeof chunk === "object") {
+        pushText((chunk as { text?: unknown }).text);
+      }
+    }
+  }
+  return texts;
+}
+
+function buildSlackDeliveryProofVerdict(params: {
+  scenario: SlackTraceScenarioName;
+  events: readonly TraceEvent[];
+  headSha: string;
+}): Record<string, unknown> {
+  const wireTexts = collectSlackWireTexts(params.events);
+  const outEvents = params.events.filter((event) => event.dir === "out");
+  return {
+    kind: "mock-gateway",
+    liveSlack: false,
+    harness: "extensions/slack/src/delivery-trace.test.ts",
+    channel: "slack",
+    scenario: params.scenario,
+    headSha: params.headSha,
+    environment: {
+      node: process.version,
+      platform: process.platform,
+      slackApi: "recording WebClient",
+      provider: "scripted agent turn",
+      delivery: "real dispatchPreparedSlackMessage + ChatStreamer/draft preview",
+    },
+    inboundPayloads: params.events
+      .filter((event) => event.dir === "in" && (event.kind === "final" || event.kind === "partial"))
+      .map((event) => event.data),
+    deliveredWireTexts: wireTexts,
+    execFailedDelivered: wireTexts.some((text) => text.includes("Exec failed")),
+    proseDelivered: wireTexts.some((text) => text.includes(EXEC_FAILED_PROSE)),
+    outMethods: outEvents.map((event) => event.kind),
+  };
+}
+
 describe("slack delivery trace goldens", () => {
+  const headSha = process.env.OPENCLAW_DELIVERY_PROOF_SHA ?? "";
   for (const scenarioName of Object.keys(slackTraceScenarios) as SlackTraceScenarioName[]) {
     it(`records ${scenarioName}`, async () => {
       const events = await runDeliveryTraceScenario({
@@ -643,6 +733,19 @@ describe("slack delivery trace goldens", () => {
         goldenUrl: new URL(`./__traces__/${scenarioName}.trace.jsonl`, import.meta.url),
         events,
       });
+      const wireTexts = collectSlackWireTexts(events);
+      expect(wireTexts.join("\n")).not.toMatch(/Exec failed/i);
+      if (
+        scenarioName === "native-prose-then-exec-failed" ||
+        scenarioName === "preview-exec-failed-then-prose"
+      ) {
+        expect(wireTexts.some((text) => text.includes(EXEC_FAILED_PROSE))).toBe(true);
+        if (process.env.OPENCLAW_DELIVERY_PROOF === "1") {
+          process.stdout.write(
+            `${JSON.stringify(buildSlackDeliveryProofVerdict({ scenario: scenarioName, events, headSha }), null, 2)}\n`,
+          );
+        }
+      }
     });
   }
 });

--- a/extensions/slack/src/delivery-trace.test.ts
+++ b/extensions/slack/src/delivery-trace.test.ts
@@ -35,6 +35,7 @@ type RecordedWireCall = {
 type CapturedDispatcherOptions = {
   deliver: (payload: ReplyPayload, info: { kind: ReplyDispatchKind }) => Promise<unknown>;
   onError?: (err: unknown, info: { kind: string }) => Promise<void> | void;
+  transformReplyPayload?: (payload: ReplyPayload) => ReplyPayload | null;
   typingCallbacks?: {
     onReplyStart?: () => Promise<void>;
     onIdle?: () => void;
@@ -556,8 +557,14 @@ async function setupSlackTrace(
   }
 
   const deliver = async (payload: ReplyPayload, kind: ReplyDispatchKind) => {
+    const transformed = turn.options.transformReplyPayload
+      ? turn.options.transformReplyPayload(payload)
+      : payload;
+    if (!transformed) {
+      return;
+    }
     try {
-      await turn.options.deliver(payload, { kind });
+      await turn.options.deliver(transformed, { kind });
       traceState.counts[kind] += 1;
     } catch (err) {
       // Mirrors the reply dispatcher: failed deliveries report onError and are

--- a/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
@@ -14,6 +14,7 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { ReplyDispatchKind, ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { createSlackDraftStream } from "../../draft-stream.js";
 import { formatSlackError } from "../../errors.js";
 import { SLACK_EDIT_TEXT_MAX_BYTES, SLACK_TEXT_LIMIT } from "../../limits.js";
@@ -510,7 +511,7 @@ export function createSlackProgressRuntime(runtimeParams: {
   };
 
   const updateDraftFromPartial = (text?: string) => {
-    const trimmed = text?.trimEnd();
+    const trimmed = text && sanitizeAssistantVisibleText(text).trimEnd();
     if (!trimmed) {
       return false;
     }

--- a/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
@@ -23,7 +23,7 @@ import { resolveSlackStreamingConfig } from "../../stream-mode.js";
 import { resolveSlackThreadTargets } from "../../threading.js";
 import { normalizeSlackAllowOwnerEntry } from "../allow-list.js";
 import { resolveStorePath, updateLastRoute } from "../config.runtime.js";
-import { createSlackReplyDeliveryPlan } from "../replies.js";
+import { createSlackReplyDeliveryPlan, sanitizeSlackMonitorReplyPayload } from "../replies.js";
 import {
   isSlackStreamingEnabled,
   resolveSlackDisableBlockStreaming,
@@ -197,12 +197,7 @@ export async function createSlackDispatchSetup(prepared: PreparedSlackMessage) {
     agentId: route.agentId,
     channel: "slack",
     accountId: route.accountId,
-    transformReplyPayload: (payload) => {
-      if (payload.isReasoning === true) {
-        return null;
-      }
-      return payload;
-    },
+    transformReplyPayload: sanitizeSlackMonitorReplyPayload,
     typing: {
       start: async () => {
         if (!threadStatusGate.hasVisibleOutput()) {

--- a/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
@@ -25,6 +25,7 @@ import { resolveSlackThreadTargets } from "../../threading.js";
 import { normalizeSlackAllowOwnerEntry } from "../allow-list.js";
 import { resolveStorePath, updateLastRoute } from "../config.runtime.js";
 import { createSlackReplyDeliveryPlan } from "../replies.js";
+import { sanitizeSlackMonitorReplyPayload } from "../sanitize-monitor-reply.js";
 import {
   isSlackStreamingEnabled,
   resolveSlackDisableBlockStreaming,
@@ -193,12 +194,7 @@ export async function createSlackDispatchSetup(prepared: PreparedSlackMessage) {
     agentId: route.agentId,
     channel: "slack",
     accountId: route.accountId,
-    transformReplyPayload: (payload) => {
-      if (payload.isReasoning === true) {
-        return null;
-      }
-      return payload;
-    },
+    transformReplyPayload: (payload) => sanitizeSlackMonitorReplyPayload(payload),
     typing: {
       start: async () => {
         didSetStatus = true;

--- a/extensions/slack/src/monitor/message-handler/dispatch-streaming.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-streaming.ts
@@ -279,9 +279,6 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
     kind: ReplyDispatchKind;
     forcedThreadTs?: string;
   }): Promise<string | undefined> => {
-    if (params.payload.isReasoning === true) {
-      return undefined;
-    }
     const replyThreadTs = resolveDeliveryThreadTs(params);
     const deliveryReplyThreadTs =
       replyDeliveryMode === "off" && !forcedReplyThreadTs && !isThreadReply
@@ -381,9 +378,6 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
     appendSeparator?: boolean;
     taskDisplayMode?: "plan" | "timeline";
   }): Promise<void> => {
-    if (params.payload.isReasoning === true) {
-      return;
-    }
     const reply = resolveSendableOutboundReplyParts(params.payload);
     if (!isStreamingEligible(params.payload)) {
       await deliverNormally({

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -971,7 +971,8 @@ vi.mock("../config.runtime.js", () => ({
   updateLastRoute: updateLastRouteMock,
 }));
 
-vi.mock("../replies.js", () => ({
+vi.mock("../replies.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../replies.js")>()),
   createSlackReplyDeliveryPlan: () => ({
     peekThreadTs: () =>
       mockedReplyThreadTsSequence ? mockedReplyThreadTsSequence[0] : mockedReplyThreadTs,

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -2696,6 +2696,78 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     });
   });
 
+  it.each([
+    ["⚠️ 🛠️ Exec failed: ", "compact Exec failed"],
+    ["⚠️ 🛠️ `ls /tmp/missing` (agent) failed", "legacy agent-failed"],
+  ])("drops native-stream finals that are only %s traces", async (text) => {
+    mockedNativeStreaming = true;
+    mockedDispatchSequence = [{ kind: "final", payload: { text } }];
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(startSlackStreamMock).not.toHaveBeenCalled();
+    expect(deliverRepliesMock).not.toHaveBeenCalled();
+    expect(emitSlackMessageSentHooksMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps native-stream prose after stripping compact failure traces", async () => {
+    mockedNativeStreaming = true;
+    mockedDispatchSequence = [
+      {
+        kind: "final",
+        payload: {
+          text: "The directory is missing.\n⚠️ 🛠️ Exec failed: `ls /tmp/does-not-exist` (exit 2)",
+        },
+      },
+    ];
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(deliverRepliesMock).not.toHaveBeenCalled();
+    expect(startSlackStreamMock).toHaveBeenCalledTimes(1);
+    expectMockCallArgFields(startSlackStreamMock, 0, "native stream start", {
+      text: "The directory is missing.",
+    });
+  });
+
+  it("does not preview draft partials that are only compact failure traces", async () => {
+    const draftStream = createDraftStreamStub();
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    mockedDispatchSequence = [];
+    mockedReplyOptionEvents = [
+      { kind: "partial", text: "⚠️ 🛠️ Exec failed: " },
+      { kind: "partial", text: "The path is missing." },
+    ];
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(draftUpdateTexts(draftStream)).toEqual(["The path is missing."]);
+  });
+
+  it("keeps media when a native-stream final sanitizes to empty text", async () => {
+    mockedNativeStreaming = true;
+    mockedDispatchSequence = [
+      {
+        kind: "final",
+        payload: {
+          text: "⚠️ 🛠️ Exec failed: ",
+          mediaUrl: "https://example.com/shot.png",
+        },
+      },
+    ];
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(startSlackStreamMock).not.toHaveBeenCalled();
+    const delivered = requireRecord(
+      requireMockCall(deliverRepliesMock, 0, "media-only replies")[0],
+      "media-only replies params",
+    );
+    expect(delivered.replies).toEqual([
+      { text: undefined, mediaUrl: "https://example.com/shot.png" },
+    ]);
+  });
+
   it("routes split table fallbacks around native text streaming", async () => {
     mockedNativeStreaming = true;
     const payload = {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -164,9 +164,6 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     payload: ReplyPayload,
     info: { kind: ReplyDispatchKind },
   ): Promise<{ visibleReplySent: false } | void> => {
-    if (payload.isReasoning === true) {
-      return { visibleReplySent: false };
-    }
     if (info.kind === "final" && slackStreaming.mode === "progress" && progress.isProgressMode) {
       if (progress.useNativeProgressStreaming) {
         await progress.deliverNativeFinal(payload, info.kind);

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -31,6 +31,7 @@ import {
   type SlackStreamSession,
 } from "../../streaming.js";
 import { countSlackTextUtf8Bytes } from "../../truncate.js";
+import { sanitizeSlackMonitorDraftPartialText } from "../sanitize-monitor-reply.js";
 import { resolveSlackBotLoopProtection } from "./dispatch-helpers.js";
 import { createSlackProgressRuntime } from "./dispatch-progress.js";
 import { createSlackDispatchSetup } from "./dispatch-setup.js";
@@ -428,7 +429,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           : !previewStreamingEnabled
             ? undefined
             : async (payload) => {
-                return progress.updateDraftFromPartial(payload.text);
+                return progress.updateDraftFromPartial(
+                  sanitizeSlackMonitorDraftPartialText(payload.text),
+                );
               },
         onAssistantMessageStart: progress.onDraftBoundary
           ? async () => {

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -35,9 +35,39 @@ let deliverReplies: typeof import("./replies.js").deliverReplies;
 let createSlackReplyDeliveryPlan: typeof import("./replies.js").createSlackReplyDeliveryPlan;
 let resolveDeliveredSlackReplyThreadTs: typeof import("./replies.js").resolveDeliveredSlackReplyThreadTs;
 let resolveSlackThreadTs: typeof import("./replies.js").resolveSlackThreadTs;
-import { deliverSlackSlashReplies } from "./replies.js";
+import { deliverSlackSlashReplies, sanitizeSlackMonitorReplyPayload } from "./replies.js";
 
 const SLACK_TEST_CFG = { channels: { slack: { botToken: "xoxb-test" } } };
+
+describe("sanitizeSlackMonitorReplyPayload", () => {
+  it.each([
+    { name: "drops reasoning", payload: { text: "private", isReasoning: true }, expected: null },
+    { name: "drops internal-only text", payload: { text: "⚠️ 🛠️ Exec failed: " }, expected: null },
+    {
+      name: "preserves visible prose",
+      payload: { text: "The directory is missing.\n⚠️ 🛠️ Exec failed: " },
+      expected: { text: "The directory is missing." },
+    },
+    {
+      name: "preserves media when internal text is removed",
+      payload: { text: "⚠️ 🛠️ Exec failed: ", mediaUrl: "https://example.com/a.png" },
+      expected: { text: undefined, mediaUrl: "https://example.com/a.png" },
+    },
+    {
+      name: "preserves structured content when internal text is removed",
+      payload: {
+        text: "⚠️ 🛠️ Exec failed: ",
+        channelData: { slack: { blocks: [{ type: "divider" }] } },
+      },
+      expected: {
+        text: undefined,
+        channelData: { slack: { blocks: [{ type: "divider" }] } },
+      },
+    },
+  ])("$name", ({ payload, expected }) => {
+    expect(sanitizeSlackMonitorReplyPayload(payload)).toEqual(expected);
+  });
+});
 
 function baseParams(overrides?: Record<string, unknown>) {
   return {

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -19,6 +19,7 @@ import {
 } from "openclaw/plugin-sdk/reply-payload";
 import { createReplyReferencePlanner } from "openclaw/plugin-sdk/reply-reference";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { buildSlackBlocksFallbackText } from "../blocks-fallback.js";
 import { SLACK_MAX_BLOCKS } from "../blocks-input.js";
 import { markdownToSlackMrkdwnChunks } from "../format.js";
@@ -95,6 +96,21 @@ function compactSlackResponseUrlFallback(
 
 export function readSlackReplyBlocks(payload: ReplyPayload) {
   return resolveSlackReplyBlocks(payload);
+}
+
+export function sanitizeSlackMonitorReplyPayload(payload: ReplyPayload): ReplyPayload | null {
+  if (payload.isReasoning === true || typeof payload.text !== "string") {
+    return payload.isReasoning === true ? null : payload;
+  }
+  const text = sanitizeAssistantVisibleText(payload.text);
+  if (text === payload.text) {
+    return payload;
+  }
+  return text ||
+    resolveSendableOutboundReplyParts(payload).hasMedia ||
+    hasSlackReplyStructuredContent(payload)
+    ? { ...payload, text: text || undefined }
+    : null;
 }
 
 function resolveSlackMediaHookSpokenText(payload: ReplyPayload): string | undefined {

--- a/extensions/slack/src/monitor/sanitize-monitor-reply.ts
+++ b/extensions/slack/src/monitor/sanitize-monitor-reply.ts
@@ -1,4 +1,4 @@
-import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
+import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 
@@ -17,7 +17,12 @@ export function sanitizeSlackMonitorReplyPayload(payload: ReplyPayload): ReplyPa
     return payload;
   }
   const nextPayload = { ...payload, text: text || undefined };
-  if (!text && !hasOutboundReplyContent(nextPayload, { trimText: true })) {
+  if (
+    !text &&
+    !resolveSendableOutboundReplyParts(nextPayload).hasMedia &&
+    !nextPayload.presentation &&
+    !nextPayload.interactive
+  ) {
     return null;
   }
   return nextPayload;

--- a/extensions/slack/src/monitor/sanitize-monitor-reply.ts
+++ b/extensions/slack/src/monitor/sanitize-monitor-reply.ts
@@ -1,0 +1,31 @@
+import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
+
+// Native streams, direct monitor replies, and draft previews never pass through
+// Slack's generic outbound sanitizeText adapter. Strip here or Exec-failed traces
+// leak as a follow-up message after a successful answer.
+export function sanitizeSlackMonitorReplyPayload(payload: ReplyPayload): ReplyPayload | null {
+  if (payload.isReasoning === true) {
+    return null;
+  }
+  if (typeof payload.text !== "string") {
+    return payload;
+  }
+  const text = sanitizeAssistantVisibleText(payload.text);
+  if (text === payload.text) {
+    return payload;
+  }
+  const nextPayload = { ...payload, text: text || undefined };
+  if (!text && !hasOutboundReplyContent(nextPayload, { trimText: true })) {
+    return null;
+  }
+  return nextPayload;
+}
+
+export function sanitizeSlackMonitorDraftPartialText(text: string | undefined): string | undefined {
+  if (!text) {
+    return text;
+  }
+  return sanitizeAssistantVisibleText(text) || undefined;
+}

--- a/extensions/slack/src/monitor/slash-dispatch.runtime.ts
+++ b/extensions/slack/src/monitor/slash-dispatch.runtime.ts
@@ -11,6 +11,7 @@ import {
 } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveAgentRoute as resolveAgentRouteImpl } from "openclaw/plugin-sdk/routing";
 import { deliverSlackSlashReplies as deliverSlackSlashRepliesImpl } from "./replies.js";
+export { sanitizeSlackMonitorReplyPayload } from "./replies.js";
 
 type ResolveChunkMode = typeof import("openclaw/plugin-sdk/reply-runtime").resolveChunkMode;
 type FinalizeInboundContext =

--- a/extensions/slack/src/monitor/slash.test-harness.ts
+++ b/extensions/slack/src/monitor/slash.test-harness.ts
@@ -24,8 +24,9 @@ const mocks = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("./slash-dispatch.runtime.js", () => {
+vi.mock("./slash-dispatch.runtime.js", async (importOriginal) => {
   return {
+    ...(await importOriginal<typeof import("./slash-dispatch.runtime.js")>()),
     deliverSlackSlashReplies: (params: unknown) => mocks.deliverSlackSlashRepliesMock(params),
     dispatchChannelInboundTurn: async (plan: {
       cfg: unknown;

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -732,6 +732,7 @@ export async function registerSlackMonitorSlashCommands(params: {
         resolveChunkMode,
         resolveConversationLabel,
         resolveMarkdownTableMode,
+        sanitizeSlackMonitorReplyPayload,
       } = await loadSlashDispatchRuntime();
 
       const route =
@@ -855,14 +856,7 @@ export async function registerSlackMonitorSlashCommands(params: {
         },
         ctxPayload,
         dispatchReplyFromConfig: ctx.dispatchReplyFromConfig,
-        replyPipeline: {
-          transformReplyPayload: (payload) => {
-            if (payload.isReasoning === true) {
-              return null;
-            }
-            return payload;
-          },
-        },
+        replyPipeline: { transformReplyPayload: sanitizeSlackMonitorReplyPayload },
         dispatcherOptions: {
           // /login must expose its device code before the auth flow can finish. Other block
           // streams stay batched so the response_url planner can honor Slack's five-call cap.

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -46,6 +46,7 @@ import {
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { chunkItems } from "openclaw/plugin-sdk/text-chunking";
+import { sanitizeSlackMonitorReplyPayload } from "./sanitize-monitor-reply.js";
 import type { ResolvedSlackAccount } from "../accounts.js";
 import { SLACK_MAX_BLOCKS } from "../blocks-input.js";
 import { formatSlackError } from "../errors.js";
@@ -852,12 +853,7 @@ export async function registerSlackMonitorSlashCommands(params: {
         },
         ctxPayload,
         replyPipeline: {
-          transformReplyPayload: (payload) => {
-            if (payload.isReasoning === true) {
-              return null;
-            }
-            return payload;
-          },
+          transformReplyPayload: (payload) => sanitizeSlackMonitorReplyPayload(payload),
         },
         dispatcherOptions: {
           // /login must expose its device code before the auth flow can finish. Other block

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -46,7 +46,6 @@ import {
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { chunkItems } from "openclaw/plugin-sdk/text-chunking";
-import { sanitizeSlackMonitorReplyPayload } from "./sanitize-monitor-reply.js";
 import type { ResolvedSlackAccount } from "../accounts.js";
 import { SLACK_MAX_BLOCKS } from "../blocks-input.js";
 import { formatSlackError } from "../errors.js";
@@ -71,6 +70,7 @@ import {
   isSlackResponseAlreadyReportedError,
 } from "./response-url-budget.js";
 import { resolveSlackRoomContextHints } from "./room-context.js";
+import { sanitizeSlackMonitorReplyPayload } from "./sanitize-monitor-reply.js";
 
 const SLACK_COMMAND_ARG_ACTION_ID = "openclaw_cmdarg";
 const SLACK_COMMAND_ARG_ACTION_LISTENER = /^openclaw_cmdarg/;


### PR DESCRIPTION
Closes #122775

## What Problem This Solves

Fixes an issue where Slack users on the default streaming path would see a correct answer, then a separate `⚠️ 🛠️ Exec failed:` follow-up whenever a tool exited non-zero. Non-streaming Slack replies already hid that internal trace; native streaming and draft previews did not.

## Why This Change Was Made

Slack's generic outbound adapter already runs `sanitizeAssistantVisibleText`, but monitor native-stream, direct, and draft-preview delivery never used that adapter. The monitor now sanitizes non-reasoning payloads once at `transformReplyPayload`, drops the payload when nothing sendable remains, and sanitizes draft partials before preview updates because those bypass the transform. Slash-command replies share the same monitor transform. This stays inside Slack and does not broaden umbrella #90684.

## User Impact

Slack streaming replies keep the assistant's answer and no longer post the internal compact failure banner. Ordinary warnings and fenced examples of those traces still pass through unchanged.

## Evidence

This is **not** live Slack socket-mode. It is the repository Slack delivery-trace harness: recording Slack WebClient + scripted agent turn + real `dispatchPreparedSlackMessage` + real `@slack/web-api` `ChatStreamer` / draft preview. AGENTS.md treats that mock-gateway class as qualifying real-behavior proof for channel-visible changes when it covers the changed path.

- head SHA: `3203c55bcae1931ea0ca7d9d2f8477ac64f6a07e`
- environment: Linux, Node `v22.22.3`, no Slack token, no socket-mode connection
- command:

```bash
OPENCLAW_DELIVERY_PROOF=1 \
OPENCLAW_DELIVERY_PROOF_SHA=$(git rev-parse HEAD) \
node scripts/run-vitest.mjs extensions/slack/src/delivery-trace.test.ts
```

Result: 8 passed, including the two new scenarios below.

Focused unit tests on the same head (mocked `startSlackStream`, not wire-level):
- `node scripts/run-vitest.mjs extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts`

### Mock-gateway verdict JSON

Native stream: agent emits prose, then a separate compact Exec-failed final. Slack `chat.startStream` / `chat.stopStream` carry only the prose.

```json
{
  "kind": "mock-gateway",
  "liveSlack": false,
  "harness": "extensions/slack/src/delivery-trace.test.ts",
  "channel": "slack",
  "scenario": "native-prose-then-exec-failed",
  "headSha": "3203c55bcae1931ea0ca7d9d2f8477ac64f6a07e",
  "environment": {
    "node": "v22.22.3",
    "platform": "linux",
    "slackApi": "recording WebClient",
    "provider": "scripted agent turn",
    "delivery": "real dispatchPreparedSlackMessage + ChatStreamer/draft preview"
  },
  "inboundPayloads": [
    { "text": "The directory is missing." },
    { "text": "⚠️ 🛠️ Exec failed: " }
  ],
  "deliveredWireTexts": ["The directory is missing."],
  "execFailedDelivered": false,
  "proseDelivered": true,
  "outMethods": [
    "assistant.threads.setStatus",
    "users.info",
    "assistant.threads.setStatus",
    "chat.startStream",
    "chat.stopStream"
  ]
}
```

Draft preview: an Exec-failed partial is not posted; later prose is posted and then updated in place.

```json
{
  "kind": "mock-gateway",
  "liveSlack": false,
  "harness": "extensions/slack/src/delivery-trace.test.ts",
  "channel": "slack",
  "scenario": "preview-exec-failed-then-prose",
  "headSha": "3203c55bcae1931ea0ca7d9d2f8477ac64f6a07e",
  "environment": {
    "node": "v22.22.3",
    "platform": "linux",
    "slackApi": "recording WebClient",
    "provider": "scripted agent turn",
    "delivery": "real dispatchPreparedSlackMessage + ChatStreamer/draft preview"
  },
  "inboundPayloads": [
    { "text": "⚠️ 🛠️ Exec failed: " },
    { "text": "The directory is missing." },
    { "text": "The directory is missing." }
  ],
  "deliveredWireTexts": [
    "The directory is missing.",
    "The directory is missing."
  ],
  "execFailedDelivered": false,
  "proseDelivered": true,
  "outMethods": [
    "assistant.threads.setStatus",
    "chat.postMessage",
    "chat.update",
    "assistant.threads.setStatus"
  ]
}
```

### Redacted wire transcripts

Native stream golden (`extensions/slack/src/__traces__/native-prose-then-exec-failed.trace.jsonl`): IN records both finals; OUT `chat.stopStream` markdown is only `The directory is missing.` The Exec-failed final has no matching Slack write.

Draft preview golden (`extensions/slack/src/__traces__/preview-exec-failed-then-prose.trace.jsonl`): the Exec-failed partial produces no `chat.postMessage`; the later prose partial posts, and the final updates that same message.

### What was not tested

Live Slack socket-mode was not run. No `conversations.replies` from a real workspace. The issue's live 2026.7.1-2 socket-mode leak remains the before evidence. This after-fix proof is the repo mock-gateway delivery harness covering native-stream finalize and draft-preview, not a live channel.
