### PR TITLE
refactor(worker): streamline live preview delivery

### DIFF
--- a/src/worker/embedded-agent-live.runtime.test.ts
+++ b/src/worker/embedded-agent-live.runtime.test.ts
@@ -4,12 +4,14 @@ import type { AgentSessionEvent } from "../agents/sessions/agent-session.js";
 import { createWorkerLiveRuntime } from "./embedded-agent-live.runtime.js";
 
 describe("createWorkerLiveRuntime", () => {
-  it("redacts media payloads from tool diagnostics before cloud egress", async () => {
+  it("redacts media payloads from tool diagnostics before cloud egress", () => {
     const emitted: WorkerLiveEvent[] = [];
     const runtime = createWorkerLiveRuntime({
-      emit: async (event) => {
+      enqueuePreview: (event) => {
         emitted.push(event);
+        return true;
       },
+      emitTerminal: async (event) => void emitted.push(event),
     });
     const events: AgentSessionEvent[] = [
       {
@@ -42,9 +44,39 @@ describe("createWorkerLiveRuntime", () => {
     expect(emitted).toHaveLength(3);
   });
 
+  it("stops preparing previews after the client degrades", () => {
+    let previewCalls = 0;
+    const runtime = createWorkerLiveRuntime({
+      enqueuePreview: () => {
+        previewCalls += 1;
+        return false;
+      },
+      emitTerminal: async () => {},
+    });
+
+    runtime.handleSessionEvent({
+      type: "tool_execution_start",
+      toolCallId: "tool-1",
+      toolName: "read",
+      args: {},
+    });
+    runtime.handleSessionEvent({
+      type: "tool_execution_end",
+      toolCallId: "tool-1",
+      toolName: "read",
+      result: "ignored",
+      isError: false,
+    });
+
+    expect(previewCalls).toBe(1);
+  });
+
   it("redacts lifecycle errors before terminal cloud egress", async () => {
     const emitted: WorkerLiveEvent[] = [];
-    const runtime = createWorkerLiveRuntime({ emit: async (event) => void emitted.push(event) });
+    const runtime = createWorkerLiveRuntime({
+      enqueuePreview: () => false,
+      emitTerminal: async (event) => void emitted.push(event),
+    });
 
     runtime.enqueueRunFailure({
       aborted: false,

--- a/src/worker/embedded-agent-live.runtime.ts
+++ b/src/worker/embedded-agent-live.runtime.ts
@@ -33,7 +33,7 @@ function boundLiveValue(value: unknown): unknown {
       return null;
     }
     if (Buffer.byteLength(serialized, "utf8") <= MAX_LIVE_PREVIEW_BYTES) {
-      return structuredClone(value);
+      return value;
     }
     return { truncated: true, preview: truncateLiveText(serialized) };
   } catch {
@@ -48,7 +48,7 @@ function redactLiveText(value: string): string {
 
 function boundLiveEvent(event: WorkerLiveEvent): WorkerLiveEvent {
   if (liveEventBytes(event) <= MAX_LIVE_EVENT_BYTES) {
-    return structuredClone(event);
+    return event;
   }
   let bounded: WorkerLiveEvent;
   if (event.kind === "assistant") {
@@ -125,7 +125,8 @@ function readAssistantThinking(message: AgentMessage): string {
 }
 
 type WorkerLiveClient = {
-  emit: (event: WorkerLiveEvent) => Promise<void>;
+  enqueuePreview: (event: WorkerLiveEvent) => boolean;
+  emitTerminal: (event: WorkerLiveEvent) => Promise<void>;
 };
 
 type WorkerLiveRuntime = {
@@ -135,18 +136,10 @@ type WorkerLiveRuntime = {
 };
 
 export function createWorkerLiveRuntime(client: WorkerLiveClient): WorkerLiveRuntime {
-  let liveDegraded = false;
+  let previewEnabled = true;
   const enqueueLive = (event: WorkerLiveEvent) => {
-    if (liveDegraded) {
-      return;
-    }
-    try {
-      void client.emit(boundLiveEvent(event)).catch(() => {
-        // Preview loss must not block inference, transcript durability, or finishing.
-        liveDegraded = true;
-      });
-    } catch {
-      liveDegraded = true;
+    if (previewEnabled) {
+      previewEnabled = client.enqueuePreview(boundLiveEvent(event));
     }
   };
   const startedAt = Date.now();
@@ -282,7 +275,7 @@ export function createWorkerLiveRuntime(client: WorkerLiveClient): WorkerLiveRun
     if (!terminalLiveEvent) {
       return;
     }
-    await client.emit(boundLiveEvent(terminalLiveEvent));
+    await client.emitTerminal(boundLiveEvent(terminalLiveEvent));
   };
   return { handleSessionEvent, enqueueRunFailure, emitTerminal };
 }

--- a/src/worker/embedded-agent.runtime.ts
+++ b/src/worker/embedded-agent.runtime.ts
@@ -67,7 +67,8 @@ type WorkerEmbeddedTranscriptClient = {
 };
 
 type WorkerEmbeddedLiveClient = {
-  emit: (event: WorkerLiveEvent) => Promise<void>;
+  enqueuePreview: (event: WorkerLiveEvent) => boolean;
+  emitTerminal: (event: WorkerLiveEvent) => Promise<void>;
 };
 
 type RunWorkerEmbeddedTurnParams = {

--- a/src/worker/worker-rpc-client-shared.ts
+++ b/src/worker/worker-rpc-client-shared.ts
@@ -7,7 +7,7 @@ import type { WorkerInferenceErrorShape } from "../../packages/gateway-protocol/
 import type { WorkerConnection } from "./worker-connection.js";
 
 export type TranscriptResponseError = WorkerTranscriptCommitErrorShape | WorkerErrorShape;
-export type LiveResponseError = WorkerLiveEventErrorShape | WorkerErrorShape;
+type LiveResponseError = WorkerLiveEventErrorShape | WorkerErrorShape;
 export type InferenceResponseError = WorkerInferenceErrorShape | WorkerErrorShape;
 
 export function fenceForOwnershipError(

--- a/src/worker/worker-rpc-clients.test.ts
+++ b/src/worker/worker-rpc-clients.test.ts
@@ -125,6 +125,11 @@ const LIVE_EVENT: WorkerLiveEvent = {
   payload: { text: "local result", delta: "local result" },
 };
 
+const TERMINAL_EVENT: WorkerLiveEvent = {
+  kind: "lifecycle",
+  payload: { phase: "finishing", startedAt: 1, endedAt: 2 },
+};
+
 const INFERENCE_IDENTITY = {
   runEpoch: 3,
   sessionId: "session-1",
@@ -337,7 +342,7 @@ describe("worker transcript commit client", () => {
 });
 
 describe("worker live-event client", () => {
-  it("advances acknowledgements through the buffered tail", async () => {
+  it("advances acknowledgements through previews to the terminal barrier", async () => {
     const harness = connectionHarness();
     harness.requestLiveEvent
       .mockResolvedValueOnce({
@@ -351,17 +356,23 @@ describe("worker live-event client", () => {
         id: "live-response-2",
         ok: true,
         payload: { ackedSeq: 2 },
+      })
+      .mockResolvedValueOnce({
+        type: "res",
+        id: "live-response-3",
+        ok: true,
+        payload: { ackedSeq: 3 },
       });
     const client = new WorkerLiveEventClient(harness.connection, { runEpoch: 3 });
 
-    const first = client.emit("run-1", LIVE_EVENT);
-    const second = client.emit("run-1", {
+    client.enqueuePreview("run-1", LIVE_EVENT);
+    client.enqueuePreview("run-1", {
       kind: "assistant",
       payload: { text: "second", delta: "second" },
     });
 
-    await expect(Promise.all([first, second])).resolves.toEqual([{ ackedSeq: 1 }, { ackedSeq: 2 }]);
-    expect(harness.requestLiveEvent).toHaveBeenCalledTimes(2);
+    await expect(client.emitTerminal("run-1", TERMINAL_EVENT)).resolves.toBeUndefined();
+    expect(harness.requestLiveEvent).toHaveBeenCalledTimes(3);
     client.dispose();
   });
 
@@ -371,17 +382,24 @@ describe("worker live-event client", () => {
       createDeferred<Awaited<ReturnType<WorkerConnection["requestLiveEvent"]>>>();
     const secondResponse =
       createDeferred<Awaited<ReturnType<WorkerConnection["requestLiveEvent"]>>>();
+    const terminalResponse =
+      createDeferred<Awaited<ReturnType<WorkerConnection["requestLiveEvent"]>>>();
     harness.requestLiveEvent.mockImplementation(async (request) => {
-      return await (request.seq === 1 ? firstResponse.promise : secondResponse.promise);
+      return await (request.seq === 1
+        ? firstResponse.promise
+        : request.seq === 2
+          ? secondResponse.promise
+          : terminalResponse.promise);
     });
     const client = new WorkerLiveEventClient(harness.connection, { runEpoch: 3 });
 
-    const first = client.emit("run-1", LIVE_EVENT);
-    const second = client.emit("run-1", {
+    client.enqueuePreview("run-1", LIVE_EVENT);
+    client.enqueuePreview("run-1", {
       kind: "thinking",
       payload: { text: "second", delta: "second" },
     });
-    await vi.waitFor(() => expect(harness.requestLiveEvent).toHaveBeenCalledTimes(2));
+    const terminal = client.emitTerminal("run-1", TERMINAL_EVENT);
+    await vi.waitFor(() => expect(harness.requestLiveEvent).toHaveBeenCalledTimes(3));
     secondResponse.resolve({
       type: "res",
       id: "live-response-2",
@@ -389,15 +407,21 @@ describe("worker live-event client", () => {
       payload: { ackedSeq: 0 },
     });
     await Promise.resolve();
-    expect(harness.requestLiveEvent).toHaveBeenCalledTimes(2);
+    expect(harness.requestLiveEvent).toHaveBeenCalledTimes(3);
     firstResponse.resolve({
       type: "res",
       id: "live-response-1",
       ok: true,
       payload: { ackedSeq: 2 },
     });
+    terminalResponse.resolve({
+      type: "res",
+      id: "live-response-3",
+      ok: true,
+      payload: { ackedSeq: 3 },
+    });
 
-    await expect(Promise.all([first, second])).resolves.toEqual([{ ackedSeq: 2 }, { ackedSeq: 2 }]);
+    await expect(terminal).resolves.toBeUndefined();
     client.dispose();
   });
 
@@ -437,11 +461,8 @@ describe("worker live-event client", () => {
       });
     const client = new WorkerLiveEventClient(harness.connection, { runEpoch: 3 });
 
-    const preview = client.emit("run-1", LIVE_EVENT);
-    const finishing = client.emit("run-1", {
-      kind: "lifecycle",
-      payload: { phase: "finishing", startedAt: 1, endedAt: 2 },
-    });
+    client.enqueuePreview("run-1", LIVE_EVENT);
+    const finishing = client.emitTerminal("run-1", TERMINAL_EVENT);
     await vi.waitFor(() => expect(harness.requestLiveEvent).toHaveBeenCalledTimes(2));
     previewResponse.resolve({
       type: "res",
@@ -453,10 +474,6 @@ describe("worker live-event client", () => {
         details: { reason: "invalid-event" },
       },
     });
-    await expect(preview).rejects.toMatchObject({
-      name: "WorkerLiveEventError",
-      reason: "invalid-event",
-    });
     firstTerminalResponse.resolve({
       type: "res",
       id: "live-response-stale-finishing",
@@ -464,7 +481,7 @@ describe("worker live-event client", () => {
       payload: { ackedSeq: 0 },
     });
 
-    await expect(finishing).resolves.toEqual({ ackedSeq: 1 });
+    await expect(finishing).resolves.toBeUndefined();
     expect(harness.requestLiveEvent.mock.calls.map((call) => call[0])).toEqual([
       expect.objectContaining({ seq: 1, lastAckedSeq: 0, event: LIVE_EVENT }),
       expect.objectContaining({ seq: 2, lastAckedSeq: 0 }),
@@ -476,17 +493,10 @@ describe("worker live-event client", () => {
 
   it("recovers finishing emitted after an earlier preview rejection", async () => {
     const harness = connectionHarness();
+    const previewResponse =
+      createDeferred<Awaited<ReturnType<WorkerConnection["requestLiveEvent"]>>>();
     harness.requestLiveEvent
-      .mockResolvedValueOnce({
-        type: "res",
-        id: "live-response-preview",
-        ok: false,
-        error: {
-          code: "INVALID_REQUEST",
-          message: "Preview rejected",
-          details: { reason: "invalid-event" },
-        },
-      })
+      .mockImplementationOnce(async () => await previewResponse.promise)
       .mockImplementationOnce(async (request) =>
         request.lastAckedSeq > 0
           ? {
@@ -514,16 +524,28 @@ describe("worker live-event client", () => {
       });
     const client = new WorkerLiveEventClient(harness.connection, { runEpoch: 3 });
 
-    await expect(client.emit("run-1", LIVE_EVENT)).rejects.toMatchObject({
-      name: "WorkerLiveEventError",
-      reason: "invalid-event",
+    client.enqueuePreview("run-1", LIVE_EVENT);
+    previewResponse.resolve({
+      type: "res",
+      id: "live-response-preview",
+      ok: false,
+      error: {
+        code: "INVALID_REQUEST",
+        message: "Preview rejected",
+        details: { reason: "invalid-event" },
+      },
     });
-    await expect(
-      client.emit("run-1", {
-        kind: "lifecycle",
-        payload: { phase: "finishing", startedAt: 1, endedAt: 2 },
-      }),
-    ).resolves.toEqual({ ackedSeq: 1 });
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    expect(harness.requestLiveEvent).toHaveBeenCalledOnce();
+    client.enqueuePreview("run-1", {
+      kind: "assistant",
+      payload: { text: "dropped", delta: "dropped" },
+    });
+    expect(harness.requestLiveEvent).toHaveBeenCalledOnce();
+
+    await expect(client.emitTerminal("run-1", TERMINAL_EVENT)).resolves.toBeUndefined();
 
     expect(harness.requestLiveEvent.mock.calls.map((call) => call[0])).toEqual([
       expect.objectContaining({ seq: 1, lastAckedSeq: 0, event: LIVE_EVENT }),
@@ -551,6 +573,12 @@ describe("worker live-event client", () => {
         id: "live-response-2",
         ok: true,
         payload: { ackedSeq: 1 },
+      })
+      .mockResolvedValueOnce({
+        type: "res",
+        id: "live-response-terminal",
+        ok: true,
+        payload: { ackedSeq: 2 },
       });
     const client = new WorkerLiveEventClient(harness.connection, { runEpoch: 3 });
 
@@ -558,12 +586,12 @@ describe("worker live-event client", () => {
       kind: "assistant" as const,
       payload: { text: "local result", delta: "local result" },
     };
-    const emitted = client.emit("run-1", event);
+    client.enqueuePreview("run-1", event);
     event.payload.text = "caller mutation";
+    await vi.waitFor(() => expect(harness.requestLiveEvent).toHaveBeenCalledTimes(2));
+    await expect(client.emitTerminal("run-1", TERMINAL_EVENT)).resolves.toBeUndefined();
 
-    await expect(emitted).resolves.toEqual({ ackedSeq: 1 });
-
-    expect(harness.requestLiveEvent).toHaveBeenCalledTimes(2);
+    expect(harness.requestLiveEvent).toHaveBeenCalledTimes(3);
     const first = harness.requestLiveEvent.mock.calls[0]?.[0];
     const replay = harness.requestLiveEvent.mock.calls[1]?.[0];
     expect(replay).toEqual(first);
@@ -575,52 +603,54 @@ describe("worker live-event client", () => {
 
   it("renumbers the unacked tail when the gateway resets behind the local cursor", async () => {
     const harness = connectionHarness();
-    harness.requestLiveEvent
-      .mockResolvedValueOnce({
+    let responseIndex = 0;
+    harness.requestLiveEvent.mockImplementation(async () => {
+      responseIndex += 1;
+      if (responseIndex === 1) {
+        return {
+          type: "res",
+          id: "live-response-reset",
+          ok: false,
+          error: {
+            code: "INVALID_REQUEST",
+            message: "Replay required",
+            details: { reason: "resync-required", ackedSeq: 0, expectedSeq: 1 },
+          },
+        };
+      }
+      const ackedSeq = responseIndex === 2 ? 0 : responseIndex - 2;
+      return {
         type: "res",
-        id: "live-response-reset",
-        ok: false,
-        error: {
-          code: "INVALID_REQUEST",
-          message: "Replay required",
-          details: { reason: "resync-required", ackedSeq: 0, expectedSeq: 1 },
-        },
-      })
-      .mockResolvedValueOnce({
-        type: "res",
-        id: "live-response-1",
+        id: `live-response-${responseIndex}`,
         ok: true,
-        payload: { ackedSeq: 1 },
-      })
-      .mockResolvedValueOnce({
-        type: "res",
-        id: "live-response-2",
-        ok: true,
-        payload: { ackedSeq: 2 },
-      });
+        payload: { ackedSeq },
+      };
+    });
     const client = new WorkerLiveEventClient(harness.connection, {
       runEpoch: 3,
       initialAckedSeq: 5,
     });
 
-    const first = client.emit("run-1", LIVE_EVENT);
+    client.enqueuePreview("run-1", LIVE_EVENT);
     const secondEvent: WorkerLiveEvent = {
       kind: "assistant",
       payload: { text: "second", delta: "second" },
     };
-    const second = client.emit("run-1", secondEvent);
+    client.enqueuePreview("run-1", secondEvent);
+    await vi.waitFor(() => expect(harness.requestLiveEvent).toHaveBeenCalledTimes(4));
 
-    await expect(Promise.all([first, second])).resolves.toEqual([{ ackedSeq: 2 }, { ackedSeq: 2 }]);
+    await expect(client.emitTerminal("run-1", TERMINAL_EVENT)).resolves.toBeUndefined();
     expect(harness.requestLiveEvent.mock.calls.map((call) => call[0])).toEqual([
       expect.objectContaining({ seq: 6, lastAckedSeq: 5, event: LIVE_EVENT }),
       expect.objectContaining({ seq: 7, lastAckedSeq: 5, event: secondEvent }),
       expect.objectContaining({ seq: 1, lastAckedSeq: 0, event: LIVE_EVENT }),
       expect.objectContaining({ seq: 2, lastAckedSeq: 0, event: secondEvent }),
+      expect.objectContaining({ seq: 3, lastAckedSeq: 2, event: TERMINAL_EVENT }),
     ]);
     client.dispose();
   });
 
-  it("rejects a repeated no-progress resync instead of retrying forever", async () => {
+  it("recovers terminal delivery after a repeated no-progress preview resync", async () => {
     const harness = connectionHarness();
     const resyncResponse = {
       type: "res" as const,
@@ -635,26 +665,77 @@ describe("worker live-event client", () => {
     harness.requestLiveEvent
       .mockResolvedValueOnce(resyncResponse)
       .mockResolvedValueOnce(resyncResponse)
-      .mockRejectedValueOnce(new Error("unexpected third replay"));
+      .mockImplementationOnce(async (request) =>
+        request.lastAckedSeq > 0
+          ? resyncResponse
+          : {
+              type: "res",
+              id: "live-response-gap",
+              ok: true,
+              payload: { ackedSeq: 0 },
+            },
+      )
+      .mockResolvedValueOnce({
+        type: "res",
+        id: "live-response-finishing",
+        ok: true,
+        payload: { ackedSeq: 1 },
+      });
     const client = new WorkerLiveEventClient(harness.connection, {
       runEpoch: 3,
       initialAckedSeq: 5,
     });
 
-    await expect(client.emit("run-1", LIVE_EVENT)).rejects.toThrow(
-      "worker live-event resync did not advance",
-    );
-    expect(harness.requestLiveEvent).toHaveBeenCalledTimes(2);
+    client.enqueuePreview("run-1", LIVE_EVENT);
+    await vi.waitFor(() => expect(harness.requestLiveEvent).toHaveBeenCalledTimes(2));
+    await expect(client.emitTerminal("run-1", TERMINAL_EVENT)).resolves.toBeUndefined();
+    expect(harness.requestLiveEvent).toHaveBeenCalledTimes(4);
     client.dispose();
   });
 
-  it("rejects an event emitted after stop without rescheduling", async () => {
+  it("rejects terminal delivery when a preview receives an inconsistent resync cursor", async () => {
+    const harness = connectionHarness();
+    const previewResponse =
+      createDeferred<Awaited<ReturnType<WorkerConnection["requestLiveEvent"]>>>();
+    const terminalResponse =
+      createDeferred<Awaited<ReturnType<WorkerConnection["requestLiveEvent"]>>>();
+    harness.requestLiveEvent.mockImplementation(async (request) =>
+      request.event.kind === "lifecycle" ? terminalResponse.promise : previewResponse.promise,
+    );
+    const client = new WorkerLiveEventClient(harness.connection, { runEpoch: 3 });
+
+    client.enqueuePreview("run-1", LIVE_EVENT);
+    const terminal = client.emitTerminal("run-1", TERMINAL_EVENT);
+    await vi.waitFor(() => expect(harness.requestLiveEvent).toHaveBeenCalledTimes(2));
+    previewResponse.resolve({
+      type: "res",
+      id: "live-response-inconsistent-resync",
+      ok: false,
+      error: {
+        code: "INVALID_REQUEST",
+        message: "Replay required",
+        details: { reason: "resync-required", ackedSeq: 0, expectedSeq: 2 },
+      },
+    });
+
+    await expect(terminal).rejects.toThrow("worker live-event resync cursor is inconsistent");
+    terminalResponse.resolve({
+      type: "res",
+      id: "live-response-terminal",
+      ok: true,
+      payload: { ackedSeq: 2 },
+    });
+    client.dispose();
+  });
+
+  it("drops previews and rejects terminal delivery after stop without rescheduling", async () => {
     const harness = connectionHarness();
     harness.waitForReady.mockRejectedValue(new WorkerConnectionStoppedError());
     harness.emitState({ kind: "stopped" });
     const client = new WorkerLiveEventClient(harness.connection, { runEpoch: 3 });
 
-    await expect(client.emit("run-1", LIVE_EVENT)).rejects.toBeInstanceOf(
+    client.enqueuePreview("run-1", LIVE_EVENT);
+    await expect(client.emitTerminal("run-1", TERMINAL_EVENT)).rejects.toBeInstanceOf(
       WorkerConnectionStoppedError,
     );
     expect(harness.waitForReady).toHaveBeenCalledOnce();
@@ -662,16 +743,17 @@ describe("worker live-event client", () => {
     client.dispose();
   });
 
-  it("rejects buffered events when the worker is fenced", async () => {
+  it("rejects the terminal barrier when the worker is fenced", async () => {
     const harness = connectionHarness();
-    harness.requestLiveEvent.mockImplementationOnce(async () => await new Promise<never>(() => {}));
+    harness.requestLiveEvent.mockImplementation(async () => await new Promise<never>(() => {}));
     const client = new WorkerLiveEventClient(harness.connection, { runEpoch: 3 });
 
-    const emitted = client.emit("run-1", LIVE_EVENT);
-    await vi.waitFor(() => expect(harness.requestLiveEvent).toHaveBeenCalledOnce());
+    client.enqueuePreview("run-1", LIVE_EVENT);
+    const terminal = client.emitTerminal("run-1", TERMINAL_EVENT);
+    await vi.waitFor(() => expect(harness.requestLiveEvent).toHaveBeenCalledTimes(2));
     harness.emitState({ kind: "fenced", reason: "owner-epoch-mismatch" });
 
-    await expect(emitted).rejects.toEqual(new WorkerFencedError("owner-epoch-mismatch"));
+    await expect(terminal).rejects.toEqual(new WorkerFencedError("owner-epoch-mismatch"));
     client.dispose();
   });
 });

--- a/src/worker/worker-rpc-live-event-client.ts
+++ b/src/worker/worker-rpc-live-event-client.ts
@@ -1,26 +1,12 @@
-import type {
-  WorkerLiveEvent,
-  WorkerLiveEventResult,
-} from "../../packages/gateway-protocol/src/schema/worker-admission.js";
+import type { WorkerLiveEvent } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
+import { createDeferredCore, type Deferred } from "../shared/deferred.js";
 import {
   type WorkerConnection,
   WorkerConnectionInterruptedError,
   WorkerConnectionStoppedError,
   WorkerFencedError,
 } from "./worker-connection.js";
-import type { LiveResponseError } from "./worker-rpc-client-shared.js";
 import { fenceForOwnershipError, isTerminalConnection } from "./worker-rpc-client-shared.js";
-
-class WorkerLiveEventError extends Error {
-  constructor(readonly response: LiveResponseError) {
-    super(response.message);
-    this.name = "WorkerLiveEventError";
-  }
-
-  get reason(): LiveResponseError["details"]["reason"] {
-    return this.response.details.reason;
-  }
-}
 
 type WorkerLiveEventClientOptions = {
   runEpoch: number;
@@ -36,22 +22,12 @@ type BufferedLiveEvent = {
   // Claim the old send high-water once so the Gateway clears speculative
   // preview gaps before an authoritative terminal retry is renumbered.
   resyncFromSeq?: number;
-  resolve: (result: WorkerLiveEventResult) => void;
-  reject: (error: Error) => void;
+  completion?: Deferred;
 };
 
 // Keep worker requests below the Gateway's 16-frame ingress ceiling while allowing
 // preview delivery to advance independently of any one cumulative ACK.
 const MAX_IN_FLIGHT = 8;
-
-function isTerminalEvent(event: WorkerLiveEvent): boolean {
-  return (
-    event.kind === "lifecycle" &&
-    (event.payload.phase === "finishing" ||
-      event.payload.phase === "end" ||
-      event.payload.phase === "error")
-  );
-}
 
 export class WorkerLiveEventClient {
   private readonly buffered: BufferedLiveEvent[] = [];
@@ -65,6 +41,7 @@ export class WorkerLiveEventClient {
   // A preview may fail before finishing is enqueued; retain its send high-water
   // so that later terminal delivery still clears the resulting sequence gap.
   private terminalResyncFromSeq: number | undefined;
+  private previewDegraded = false;
   private disposed = false;
 
   constructor(
@@ -88,32 +65,48 @@ export class WorkerLiveEventClient {
     ];
   }
 
-  emit(runId: string, event: WorkerLiveEvent): Promise<WorkerLiveEventResult> {
-    if (this.disposed) {
-      return Promise.reject(new Error("worker live-event client disposed"));
+  enqueuePreview(runId: string, event: WorkerLiveEvent): boolean {
+    if (this.disposed || this.previewDegraded || isTerminalConnection(this.connection)) {
+      return false;
     }
-    if (
-      !isTerminalEvent(event) &&
-      this.buffered.length >= (this.options.maxBufferedEvents ?? 1_024)
-    ) {
-      return Promise.reject(new Error("worker live-event buffer capacity exceeded"));
+    if (this.buffered.length >= (this.options.maxBufferedEvents ?? 1_024)) {
+      this.degradePreviews();
+      return false;
     }
-    return new Promise((resolve, reject) => {
-      const terminalResyncFromSeq = isTerminalEvent(event) ? this.terminalResyncFromSeq : undefined;
-      if (terminalResyncFromSeq !== undefined) {
-        this.terminalResyncFromSeq = undefined;
-      }
+    try {
       this.buffered.push({
         seq: this.nextSeqValue,
         runId,
         event: structuredClone(event),
-        ...(terminalResyncFromSeq === undefined ? {} : { resyncFromSeq: terminalResyncFromSeq }),
-        resolve,
-        reject,
       });
-      this.nextSeqValue += 1;
-      this.pump();
+    } catch {
+      this.degradePreviews();
+      return false;
+    }
+    this.nextSeqValue += 1;
+    this.pump();
+    return true;
+  }
+
+  emitTerminal(runId: string, event: WorkerLiveEvent): Promise<void> {
+    if (this.disposed) {
+      return Promise.reject(new Error("worker live-event client disposed"));
+    }
+    const completion = createDeferredCore();
+    const terminalResyncFromSeq = this.terminalResyncFromSeq;
+    if (terminalResyncFromSeq !== undefined) {
+      this.terminalResyncFromSeq = undefined;
+    }
+    this.buffered.push({
+      seq: this.nextSeqValue,
+      runId,
+      event: structuredClone(event),
+      ...(terminalResyncFromSeq === undefined ? {} : { resyncFromSeq: terminalResyncFromSeq }),
+      completion,
     });
+    this.nextSeqValue += 1;
+    this.pump();
+    return completion.promise;
   }
 
   dispose(): void {
@@ -144,17 +137,15 @@ export class WorkerLiveEventClient {
       this.inFlight.add(entry);
       void this.send(entry);
     }
-    if (
-      this.inFlight.size === 0 &&
-      this.buffered.length > 0 &&
-      this.buffered.every((entry) => entry.blockedAck === this.ackedSeqValue)
-    ) {
+    if (this.inFlight.size === 0 && this.buffered[0]?.blockedAck === this.ackedSeqValue) {
       const head = this.buffered[0]!;
-      this.rejectAll(
+      this.handleFailure(
+        head,
         new Error(
           `worker live-event acknowledgement did not advance (seq=${head.seq} runId=${head.runId} ackedSeq=${this.ackedSeqValue} buffered=${this.buffered.length} runEpoch=${this.options.runEpoch})`,
         ),
       );
+      this.pump();
     }
   }
 
@@ -205,7 +196,7 @@ export class WorkerLiveEventClient {
         return;
       }
       fenceForOwnershipError(this.connection, response.error);
-      throw new WorkerLiveEventError(response.error);
+      throw new Error(response.error.message);
     } catch (error) {
       if (
         error instanceof WorkerConnectionInterruptedError &&
@@ -214,11 +205,7 @@ export class WorkerLiveEventClient {
         return;
       }
       const failure = error instanceof Error ? error : new Error(String(error));
-      if (!isTerminalEvent(entry.event) && !isTerminalConnection(this.connection)) {
-        this.recoverTerminalAfterPreviewFailure(failure);
-        return;
-      }
-      this.rejectAll(failure);
+      this.handleFailure(entry, failure);
     } finally {
       this.inFlight.delete(entry);
       this.pump();
@@ -227,13 +214,13 @@ export class WorkerLiveEventClient {
 
   private ackThrough(ackedSeq: number): void {
     this.ackedSeqValue = Math.max(this.ackedSeqValue, ackedSeq);
-    while (true) {
-      const entry = this.buffered[0];
-      if (!entry || entry.seq > this.ackedSeqValue) {
-        return;
-      }
-      this.buffered.shift();
-      entry.resolve({ ackedSeq: this.ackedSeqValue });
+    const pendingIndex = this.buffered.findIndex((entry) => entry.seq > this.ackedSeqValue);
+    const acknowledged = this.buffered.splice(
+      0,
+      pendingIndex < 0 ? this.buffered.length : pendingIndex,
+    );
+    for (const entry of acknowledged) {
+      entry.completion?.resolve();
     }
   }
 
@@ -259,29 +246,33 @@ export class WorkerLiveEventClient {
     this.maxSentSeqValue = ackedSeq;
   }
 
-  private recoverTerminalAfterPreviewFailure(error: Error): void {
+  private handleFailure(entry: BufferedLiveEvent, error: Error): void {
+    if (!entry.completion && !isTerminalConnection(this.connection)) {
+      this.degradePreviews();
+    } else {
+      this.rejectAll(error);
+    }
+  }
+
+  private degradePreviews(): void {
+    this.previewDegraded = true;
     this.replayGeneration += 1;
     this.lastResync = undefined;
     const resyncFromSeq = Math.max(this.terminalResyncFromSeq ?? 0, this.maxSentSeqValue);
-    const buffered = this.buffered.splice(0);
-    let terminalRetained = false;
-    for (const entry of buffered) {
-      if (isTerminalEvent(entry.event)) {
-        delete entry.blockedAck;
-        entry.resyncFromSeq = resyncFromSeq;
-        this.buffered.push(entry);
-        terminalRetained = true;
-      } else {
-        entry.reject(error);
-      }
+    const terminal = this.buffered.find((entry) => entry.completion);
+    this.buffered.length = 0;
+    if (terminal) {
+      delete terminal.blockedAck;
+      terminal.resyncFromSeq = resyncFromSeq;
+      this.buffered.push(terminal);
     }
-    this.terminalResyncFromSeq = terminalRetained ? undefined : resyncFromSeq;
+    this.terminalResyncFromSeq = terminal ? undefined : resyncFromSeq;
   }
 
   private rejectAll(error: Error): void {
     const buffered = this.buffered.splice(0);
     for (const entry of buffered) {
-      entry.reject(error);
+      entry.completion?.reject(error);
     }
   }
 }

--- a/src/worker/worker.fault-injection.test.ts
+++ b/src/worker/worker.fault-injection.test.ts
@@ -30,6 +30,10 @@ import { runWorkerDescriptor } from "./worker.runtime.js";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const REPLACEMENT_CREDENTIAL = ["worker", "replacement", "fixture"].join("-");
 const MODEL_REF = { provider: "fake", model: "fault-model" } as const;
+const TERMINAL_EVENT = {
+  kind: "lifecycle" as const,
+  payload: { phase: "finishing" as const, startedAt: 1, endedAt: 2 },
+};
 
 function transcriptMessage(text: string) {
   return {
@@ -179,13 +183,13 @@ describe("cloud worker milestone 2 fault injection", () => {
       transcriptMessage("partitioned user"),
       { ...doneMessage("partitioned reply"), timestamp: 2 },
     ]);
-    const live = ["one", "two", "three"].map((delta) =>
-      current.live.emit(RUN_ID, {
+    for (const delta of ["one", "two", "three"]) {
+      current.live.enqueuePreview(RUN_ID, {
         kind: "assistant",
         payload: { text: delta, delta },
-      }),
-    );
-    await expect(Promise.all(live)).resolves.toHaveLength(3);
+      });
+    }
+    await expect(current.live.emitTerminal(RUN_ID, TERMINAL_EVENT)).resolves.toBeUndefined();
 
     const transcriptRequests = harness.requestParams("worker.transcript.commit");
     expect(transcriptRequests).toHaveLength(2);
@@ -198,7 +202,7 @@ describe("cloud worker milestone 2 fault injection", () => {
       harness
         .requestParams("worker.live-event")
         .map((request) => (request as WorkerLiveEventParams).seq),
-    ).toEqual([1, 2, 3, 1, 2, 3]);
+    ).toEqual([1, 2, 3, 4, 1, 2, 3, 4]);
     const transcript = SessionManager.open(harness.sessionTarget).getEntries();
     expect(transcript).toHaveLength(2);
     expect(new Set(transcript.map((entry) => entry.id)).size).toBe(2);
@@ -221,20 +225,21 @@ describe("cloud worker milestone 2 fault injection", () => {
     harness.addFault({ kind: "drop-response", method: "worker.transcript.commit", restart: true });
     await current.connection.start();
 
-    await current.live.emit(RUN_ID, {
+    current.live.enqueuePreview(RUN_ID, {
       kind: "assistant",
       payload: { text: "acked", delta: "acked" },
     });
+    await vi.waitFor(() => expect(harness.liveDeltas).toEqual(["acked"]));
     const inference = current.inference.start(inferenceRequest(harness.epoch, "restart-turn"));
     await providerStarted.promise;
     const commit = current.transcript.commit([transcriptMessage("restart transcript")]);
     await commitEntered.promise;
-    const liveTail = ["tail-a", "tail-b"].map((delta) =>
-      current.live.emit(RUN_ID, {
+    for (const delta of ["tail-a", "tail-b"]) {
+      current.live.enqueuePreview(RUN_ID, {
         kind: "assistant",
         payload: { text: delta, delta },
-      }),
-    );
+      });
+    }
     // The restart fault fires when the gated commit response drains; make sure the
     // pre-restart tail-a live request reached the gateway first or the lost-window
     // replay assertion below becomes timing-dependent.
@@ -245,7 +250,7 @@ describe("cloud worker milestone 2 fault injection", () => {
 
     await expect(commit).resolves.toMatchObject({ entryIds: [expect.any(String)] });
     await expect(inference).resolves.toMatchObject({ type: "error", reason: "provider-error" });
-    await expect(Promise.all(liveTail)).resolves.toHaveLength(2);
+    await expect(current.live.emitTerminal(RUN_ID, TERMINAL_EVENT)).resolves.toBeUndefined();
     expect(harness.providerCalls).toBe(1);
     expect(harness.replacementProviderCalls).toBe(0);
     expect(harness.admissions.at(-1)).toMatchObject({
@@ -376,20 +381,20 @@ describe("cloud worker milestone 2 fault injection", () => {
     try {
       await current.connection.start();
 
-      await expect(
-        Promise.all(
-          ["one", "two"].map((delta) =>
-            current.live.emit(RUN_ID, { kind: "assistant", payload: { text: delta, delta } }),
-          ),
-        ),
-      ).resolves.toHaveLength(2);
+      for (const delta of ["one", "two"]) {
+        current.live.enqueuePreview(RUN_ID, {
+          kind: "assistant",
+          payload: { text: delta, delta },
+        });
+      }
+      await expect(current.live.emitTerminal(RUN_ID, TERMINAL_EVENT)).resolves.toBeUndefined();
 
       expect(harness.liveDeltas).toEqual(["one", "two"]);
       expect(
         harness
           .requestParams("worker.live-event")
           .map((request) => (request as WorkerLiveEventParams).seq),
-      ).toEqual([1, 2]);
+      ).toEqual([1, 2, 3]);
       expect(getAgentRunContext(RUN_ID)?.isControlUiVisible).toBe(true);
     } finally {
       clearAgentRunContext(RUN_ID);

--- a/src/worker/worker.runtime.test.ts
+++ b/src/worker/worker.runtime.test.ts
@@ -1559,9 +1559,14 @@ describe("worker reconnect clients", () => {
           timestamp: 1,
         },
       ]);
-      await live.emit(RUN_ID, {
+      live.enqueuePreview(RUN_ID, {
         kind: "assistant",
         payload: { text: "silent live event", delta: "silent live event" },
+      });
+      await waitForFast(() => expect(gateway.liveEventRequests).toHaveLength(2));
+      await live.emitTerminal(RUN_ID, {
+        kind: "lifecycle",
+        payload: { phase: "finishing", startedAt: 1, endedAt: 2 },
       });
       await inference.start({
         runEpoch: OWNER_EPOCH,
@@ -1575,7 +1580,7 @@ describe("worker reconnect clients", () => {
 
       expect(gateway.transcriptRequests).toHaveLength(2);
       expect(gateway.transcriptRequests[1]).toEqual(gateway.transcriptRequests[0]);
-      expect(gateway.liveEventRequests).toHaveLength(2);
+      expect(gateway.liveEventRequests).toHaveLength(3);
       expect(gateway.liveEventRequests[1]).toEqual(gateway.liveEventRequests[0]);
       expect(gateway.inferenceRequests).toHaveLength(2);
       expect(gateway.inferenceRequests[1]).toEqual(gateway.inferenceRequests[0]);
@@ -1623,10 +1628,14 @@ describe("worker reconnect clients", () => {
       await expect(commit).rejects.toBeInstanceOf(WorkerConnectionStoppedError);
 
       live = new WorkerLiveEventClient(connection, { runEpoch: OWNER_EPOCH });
+      live.enqueuePreview(RUN_ID, {
+        kind: "assistant",
+        payload: { text: "late live event", delta: "late live event" },
+      });
       await expect(
-        live.emit(RUN_ID, {
-          kind: "assistant",
-          payload: { text: "late live event", delta: "late live event" },
+        live.emitTerminal(RUN_ID, {
+          kind: "lifecycle",
+          payload: { phase: "finishing", startedAt: 1, endedAt: 2 },
         }),
       ).rejects.toBeInstanceOf(WorkerConnectionStoppedError);
       expect(waitForReady.mock.calls.length).toBeLessThanOrEqual(2);

--- a/src/worker/worker.runtime.ts
+++ b/src/worker/worker.runtime.ts
@@ -149,16 +149,10 @@ export async function runWorkerDescriptor(
           },
         },
         live: {
-          emit: async (event) => {
-            await live.emit(descriptor.assignment.runId, event);
-            if (
-              event.kind === "lifecycle" &&
-              (event.payload.phase === "finishing" ||
-                event.payload.phase === "end" ||
-                event.payload.phase === "error")
-            ) {
-              resultFenceAcked = true;
-            }
+          enqueuePreview: (event) => live.enqueuePreview(descriptor.assignment.runId, event),
+          emitTerminal: async (event) => {
+            await live.emitTerminal(descriptor.assignment.runId, event);
+            resultFenceAcked = true;
           },
         },
         sessions: connection,


### PR DESCRIPTION
## What Problem This Solves

Cloud Worker previews are intentionally lossy, but the worker client still created a Promise, completion callbacks, an acknowledgement result, and a catch microtask for every assistant or thinking delta. After preview delivery degraded, the embedded runtime also continued bounding and serializing events that the client would drop.

## Why This Change Was Made

This separates the internal API into fire-and-forget preview enqueueing and one awaited terminal barrier. Only terminal queue entries carry completion state, preview degradation is reported back to the embedded runtime so later preview preparation stops, cumulative ACK prefixes are removed in one batch, and the obsolete live-response error export is internalized. Replay, resync, reconnect, ownership fencing, and authoritative terminal recovery remain unchanged.

## User Impact

Cloud Worker streaming performs less allocation and less post-degradation work while preserving the same preview, reconnect, transcript, and durable finishing behavior.

## Evidence

- Focused worker proof: 64 tests passed across live RPC, embedded runtime, reconnect, rejection/resync recovery, and fault-injection suites.
- Added coverage verifies preview preparation stops after degradation and malformed resync cursors still fail the terminal barrier.
- Targeted oxfmt, oxlint, Plugin SDK API baseline, and `git diff --check` passed.
- Final Codex-backed autoreview reported no accepted/actionable findings.
- Local `check:changed` could not complete because unrelated OpenClaw worktrees continuously held the shared heavy-check lock; exact-head hosted CI is required before merge and is the authoritative complete gate.
- Production LOC before final rebase: +84/-105 (net -21). Tests: +236/-108.
