### PR TITLE
fix(zalo): promote setup surface to a stable top-level runtime entry

### DIFF
--- a/extensions/zalo/setup-api.ts
+++ b/extensions/zalo/setup-api.ts
@@ -1,7 +1,7 @@
 // Zalo API module exposes the plugin public contract.
 import { loadBundledEntryExportSync } from "openclaw/plugin-sdk/channel-entry-contract";
 
-type SetupSurfaceModule = typeof import("./src/setup-surface.js");
+type SetupSurfaceModule = typeof import("./setup-surface.js");
 
 function createLazyObjectValue<T extends object>(load: () => T): T {
   return new Proxy({} as T, {
@@ -23,7 +23,7 @@ function createLazyObjectValue<T extends object>(load: () => T): T {
 
 function loadSetupSurfaceModule(): SetupSurfaceModule {
   return loadBundledEntryExportSync<SetupSurfaceModule>(import.meta.url, {
-    specifier: "./src/setup-surface.js",
+    specifier: "./setup-surface.js",
   });
 }
 

--- a/extensions/zalo/setup-surface.test.ts
+++ b/extensions/zalo/setup-surface.test.ts
@@ -8,10 +8,14 @@ import {
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import type { WizardPrompter } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it, vi } from "vitest";
-import type { OpenClawConfig } from "../runtime-api.js";
-import { listZaloAccountIds, resolveDefaultZaloAccountId, resolveZaloAccount } from "./accounts.js";
-import { zaloDmPolicy } from "./setup-core.js";
+import type { OpenClawConfig } from "./runtime-api.js";
 import { zaloSetupAdapter, zaloSetupWizard } from "./setup-surface.js";
+import {
+  listZaloAccountIds,
+  resolveDefaultZaloAccountId,
+  resolveZaloAccount,
+} from "./src/accounts.js";
+import { zaloDmPolicy } from "./src/setup-core.js";
 
 const zaloSetupPlugin = {
   id: "zalo",

--- a/extensions/zalo/setup-surface.ts
+++ b/extensions/zalo/setup-surface.ts
@@ -11,9 +11,9 @@ import {
   type SecretInput,
   createSetupTranslator,
 } from "openclaw/plugin-sdk/setup";
-import { inspectZaloAccount } from "./accounts.js";
-import { noteZaloTokenHelp, promptZaloAllowFrom } from "./setup-allow-from.js";
-import { zaloDmPolicy } from "./setup-core.js";
+import { inspectZaloAccount } from "./src/accounts.js";
+import { noteZaloTokenHelp, promptZaloAllowFrom } from "./src/setup-allow-from.js";
+import { zaloDmPolicy } from "./src/setup-core.js";
 
 const t = createSetupTranslator();
 
@@ -96,7 +96,7 @@ function setZaloUpdateMode(
   } as OpenClawConfig;
 }
 
-export { zaloSetupAdapter } from "./setup-core.js";
+export { zaloSetupAdapter } from "./src/setup-core.js";
 
 export const zaloSetupWizard: ChannelSetupWizard = {
   channel,

--- a/extensions/zalo/src/channel.ts
+++ b/extensions/zalo/src/channel.ts
@@ -85,7 +85,7 @@ function looksLikeZaloChatId(raw: string, normalized?: string): boolean {
 
 const loadZaloChannelRuntime = createLazyRuntimeModule(() => import("./channel.runtime.js"));
 const zaloSetupWizard = createZaloSetupWizardProxy(
-  async () => (await import("./setup-surface.js")).zaloSetupWizard,
+  async () => (await import("../setup-surface.js")).zaloSetupWizard,
 );
 const zaloTextChunkLimit = 2000;
 

--- a/extensions/zalo/src/setup-status.test.ts
+++ b/extensions/zalo/src/setup-status.test.ts
@@ -2,7 +2,7 @@
 import { createPluginSetupWizardStatus } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
-import { zaloSetupWizard } from "./setup-surface.js";
+import { zaloSetupWizard } from "../setup-surface.js";
 
 const zaloGetStatus = createPluginSetupWizardStatus({
   id: "zalo",

--- a/test/plugin-npm-runtime-build.test.ts
+++ b/test/plugin-npm-runtime-build.test.ts
@@ -220,6 +220,25 @@ describe("plugin npm runtime build planning", () => {
     expect(plan.runtimeBuildOutputs).toContain("./dist/setup-api.js");
   });
 
+  it("plans Zalo setup surface as a stable top-level runtime entry", () => {
+    // Regression for #122801: the published Zalo setup API lazily loads
+    // ./setup-surface.js through loadBundledEntryExportSync, so the package
+    // build must emit it as a stable top-level public surface entry. When the
+    // file lived under src/, collectTopLevelPublicSurfaceEntries skipped it and
+    // the installed package failed with "Cannot find module './setup-surface.js'".
+    const plan = expectPluginNpmRuntimeBuildPlan(
+      resolvePluginNpmRuntimeBuildPlan({
+        repoRoot,
+        packageDir: path.join(repoRoot, "extensions", "zalo"),
+      }),
+    );
+
+    expect(plan.entry["setup-surface"]).toBe(
+      path.join(repoRoot, "extensions", "zalo", "setup-surface.ts"),
+    );
+    expect(plan.runtimeBuildOutputs).toContain("./dist/setup-surface.js");
+  });
+
   it("keeps published Codex runtime imports resolvable from the host package", async () => {
     const result = await buildPluginNpmRuntime({
       repoRoot,


### PR DESCRIPTION
## What Problem This Solves

Operators who install the official `@openclaw/zalo` plugin from npm/ClawHub can install it successfully, but the first time they open the Zalo setup wizard it throws `Cannot find module './src/setup-surface.js'` and onboarding is unusable. This PR moves the setup surface to a stable top-level package entry so the packed plugin's setup wizard works on first access.

- Problem: The published Zalo setup API ([`extensions/zalo/setup-api.ts`](extensions/zalo/setup-api.ts)) lazily loads `./src/setup-surface.js` at runtime via `loadBundledEntryExportSync`. However, the plugin npm runtime build only emits stable entries for top-level public surface files (`collectTopLevelPublicSurfaceEntries` scans files directly under the plugin root and skips subdirectories). Because `setup-surface.ts` lived under `src/`, no stable `dist/src/setup-surface.js` chunk was emitted, so the installed package failed the moment a lazy wizard property was accessed.
- Solution: Promote `setup-surface.ts` to the plugin top level so the build emits `./dist/setup-surface.js` as a stable entry, and point the public API (plus all internal callers) at the new location.
- What changed:
  - `extensions/zalo/setup-surface.ts` — moved from `src/` to the plugin root; internal imports updated to `./src/...`
  - `extensions/zalo/setup-surface.test.ts` — moved alongside; imports updated
  - `extensions/zalo/setup-api.ts` — public API specifier `./src/setup-surface.js` → `./setup-surface.js`
  - `extensions/zalo/src/channel.ts` — `./setup-surface.js` → `../setup-surface.js`
  - `extensions/zalo/src/setup-status.test.ts` — `./setup-surface.js` → `../setup-surface.js`
  - `test/plugin-npm-runtime-build.test.ts` — packed-build regression asserting the plan includes `./dist/setup-surface.js`
- What did NOT change: `zaloSetupWizard` business logic (net-zero), the generic `collectTopLevelPublicSurfaceEntries` builder contract, any other plugin, the storage/runtime layers. No compatibility shim is retained (the nested path was an internal unpublished contract, per the issue).

## Why This Change Was Made

This matches the issue's recommended best fix and the ClawSweeper review's explicit recommendation ("Move the runtime-needed setup surface to the plugin root and add a packed public-API regression"). The failure and repair boundary are narrow and clear.

- Best fix: Yes. Moving the file to the top level aligns with the package builder's intentional public-entry contract. The sibling `line` plugin avoids this bug because its `setup-api.ts` statically re-exports `lineSetupWizard` (the bundler inlines it into the setup-api chunk); zalo instead uses a lazy `loadBundledEntryExportSync` proxy that *requires* the path to exist as an independent stable entry, so the file must be a top-level public surface.
- Alternative considered: Broaden `collectTopLevelPublicSurfaceEntries` to scan nested `src/` files — rejected. That would preserve an unstable internal path as a public contract and is explicitly discouraged by the issue.
- Alternative considered: Add a compatibility shim emitting `dist/src/setup-surface.js` — rejected (issue: "Do not preserve the bad nested path through a compatibility shim").
- Refactor: Not needed. The change is a pure file relocation plus import-path correction.
- Risk: Source-checkout tests previously imported the source-local module directly and thus never exercised the packed public boundary, which is why this slipped through. The new regression closes that gap at the build-plan level. One pre-existing test (`configures a polling token flow`) fails on this machine due to a locale/i18n mismatch (the mock expects the English prompt `Enter Zalo bot token` but the local translator returns the localized Chinese variant of the same string); this fails identically on `origin/main` and is unrelated to this PR.

## User Impact

Operators installing the official Zalo plugin from npm or ClawHub can now run the Zalo setup wizard (enter bot token, choose polling vs. webhook, configure allow-from) without hitting a module-not-found error on first access. No configuration or migration changes; the plugin installs the same way, it just works when you open onboarding.

## Evidence

Real-runtime build-plan resolution (run with `node --import tsx` against the source, in an isolated worktree off `origin/main`):

Before fix (setup-surface under `src/`, current `origin/main` behavior):

```
$ node --import tsx proof-plan-122801.mts
entry['setup-surface']: <MISSING>
contains ./dist/setup-surface.js: false
runtimeBuildOutputs: [
  './dist/api.js',
  './dist/channel-plugin-api.js',
  './dist/contract-api.js',
  './dist/index.js',
  './dist/runtime-api.js',
  './dist/secret-contract-api.js',
  './dist/setup-api.js',
  './dist/setup-entry.js'
]
FAIL
```

After fix (setup-surface promoted to top level):

```
$ node --import tsx proof-plan-122801.mts
entry['setup-surface']: /home/code/github/openclaw-122801/extensions/zalo/setup-surface.ts
contains ./dist/setup-surface.js: true
runtimeBuildOutputs: [
  './dist/api.js',
  './dist/channel-plugin-api.js',
  './dist/contract-api.js',
  './dist/index.js',
  './dist/runtime-api.js',
  './dist/secret-contract-api.js',
  './dist/setup-api.js',
  './dist/setup-entry.js',
  './dist/setup-surface.js'
]
PASS
```

Packed-build regression (vitest, real plan resolver):

```
$ npx vitest run test/plugin-npm-runtime-build.test.ts
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

The new case `plans Zalo setup surface as a stable top-level runtime entry` asserts both `plan.entry["setup-surface"]` points at `extensions/zalo/setup-surface.ts` and `plan.runtimeBuildOutputs` contains `./dist/setup-surface.js`; it fails on `origin/main` (no such entry) and passes after this change.

Packed-artifact proof (the exact operator path): build the real `dist/` via `buildPluginNpmRuntime`, then load the emitted public setup API from `dist/setup-api.js` and access the lazy `zaloSetupWizard.channel` property (which triggers `loadBundledEntryExportSync`).

Before fix (setup-surface under `src/`, current `origin/main`):

```
$ node --import tsx proof-packed-122801.mts
=== Building @openclaw/zalo plugin runtime ===
build OK, runtimeFormat: esm
=== Emitted dist artifacts ===
dist/setup-surface.js exists: false
dist/setup-api.js exists: true
=== Loading emitted public setup API from dist ===
Error: bundled plugin entry "./src/setup-surface.js" failed to open from
".../extensions/zalo/dist/setup-api.js" (resolved ".../extensions/zalo/dist/src/setup-surface.js",
plugin root ".../extensions/zalo/dist", reason "path"):
ENOENT: no such file or directory, lstat '.../extensions/zalo/dist/src/setup-surface.js'
    at resolveBundledEntryModulePath (src/plugin-sdk/channel-entry-contract.ts:367)
    at loadBundledEntryModuleSync (src/plugin-sdk/channel-entry-contract.ts:409)
    at loadBundledEntryExportSync (src/plugin-sdk/channel-entry-contract.ts:467)
```

After fix (setup-surface promoted to top level):

```
$ node --import tsx proof-packed-122801.mts
=== Building @openclaw/zalo plugin runtime ===
build OK, runtimeFormat: esm
=== Emitted dist artifacts ===
dist/setup-surface.js exists: true
dist/setup-api.js exists: true
dist/setup-surface.js bytes: 6955
  contains zaloSetupWizard export: true
=== Loading emitted public setup API from dist ===
zaloSetupWizard.channel: zalo
zaloSetupWizard keys: [ 'channel', 'status', 'credentials', 'finalize', 'dmPolicy' ]

PASS: packed setup API loads, zaloSetupWizard.channel === "zalo"
```

Before the fix, the build emits no `dist/setup-surface.js` and accessing the lazy wizard property throws the exact `ENOENT` on `dist/src/setup-surface.js` reported in the issue; after the fix, the stable entry is emitted and the public lazy loader resolves `zaloSetupWizard.channel === "zalo"`.

Type check (`tsgo` over `tsconfig.extensions.json`): no errors in zalo or setup-surface (the single remaining error is pre-existing in `packages/terminal-core/src/ansi.ts:194`, unrelated to this PR). `oxfmt --check` and `oxlint` clean on all changed files.

What was not tested: A full `npm pack` + install-into-external-project end-to-end run. The packed-artifact proof above builds the actual `dist/` and loads the emitted public API from it, which exercises the exact lazy-load contract the operator path depends on; a separate `npm pack` install test would add the `node_modules` resolution layer on top but is not expected to surface a different failure mode.

## AI Assistance

- AI-assisted: Yes
- Tools: Claude (Claude Code, model glm-5.2)
- Prompts / session excerpts: User asked to analyze issue #122801 and follow the open-source-pr skill workflow. Key prompts: "analyze https://github.com/openclaw/openclaw/issues/122801"; confirmations at each of the four human-checkpoints (issue selection, technical plan, pre-commit, pre-push). Full session log available on request.
- Confirmed understanding of code changes: Yes — the bug is that `loadBundledEntryExportSync` resolves `./src/setup-surface.js` as an independent runtime chunk, but `collectTopLevelPublicSurfaceEntries` (scripts/lib/bundled-plugin-build-entries.mjs:115) only scans top-level files; moving setup-surface.ts to the plugin root makes it a stable top-level public surface entry, so `./dist/setup-surface.js` is emitted and the public lazy loader resolves.
- autoreview: N/A (no autoreview skill configured locally)

---

Fixes #122801
