### PR TITLE
fix(onboard): report requested daemon install failure regardless of --skip-health

### DIFF
--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -800,7 +800,8 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
 
         try {
           await expectOnboardLocalJsonSetupFailure({
-            runSetup: (opts, runtime) => runNonInteractiveSetup({ ...opts, skipHealth }, runtime),
+            runSetup: (opts, runtimeEnv) =>
+              runNonInteractiveSetup({ ...opts, skipHealth }, runtimeEnv),
             stateDir,
             runtime: runtimeWithCapture,
           });

--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -781,56 +781,60 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
     });
   });
 
-  it("emits a daemon-install failure when Linux user systemd is unavailable", async () => {
-    await withStateDir("state-local-daemon-install-json-fail-", async (stateDir) => {
-      installGatewayDaemonNonInteractiveMock.mockResolvedValueOnce({
-        installed: false,
-        skippedReason: "systemd-user-unavailable",
-      });
-
-      const { runtimeWithCapture, readCapturedJson } = createOnboardJsonCaptureRuntime();
-
-      const originalPlatform = process.platform;
-      Object.defineProperty(process, "platform", {
-        configurable: true,
-        value: "linux",
-      });
-
-      try {
-        await expectOnboardLocalJsonSetupFailure({
-          runSetup: runNonInteractiveSetup,
-          stateDir,
-          runtime: runtimeWithCapture,
+  it.each([false, true])(
+    "emits a daemon-install failure when Linux user systemd is unavailable (skipHealth: %s)",
+    async (skipHealth) => {
+      await withStateDir("state-local-daemon-install-json-fail-", async (stateDir) => {
+        installGatewayDaemonNonInteractiveMock.mockResolvedValueOnce({
+          installed: false,
+          skippedReason: "systemd-user-unavailable",
         });
-      } finally {
+
+        const { runtimeWithCapture, readCapturedJson } = createOnboardJsonCaptureRuntime();
+
+        const originalPlatform = process.platform;
         Object.defineProperty(process, "platform", {
           configurable: true,
-          value: originalPlatform,
+          value: "linux",
         });
-      }
 
-      const parsed = JSON.parse(readCapturedJson()) as {
-        ok: boolean;
-        phase: string;
-        daemonInstall?: {
-          requested?: boolean;
-          installed?: boolean;
-          skippedReason?: string;
+        try {
+          await expectOnboardLocalJsonSetupFailure({
+            runSetup: (opts, runtime) => runNonInteractiveSetup({ ...opts, skipHealth }, runtime),
+            stateDir,
+            runtime: runtimeWithCapture,
+          });
+        } finally {
+          Object.defineProperty(process, "platform", {
+            configurable: true,
+            value: originalPlatform,
+          });
+        }
+
+        const parsed = JSON.parse(readCapturedJson()) as {
+          ok: boolean;
+          phase: string;
+          daemonInstall?: {
+            requested?: boolean;
+            installed?: boolean;
+            skippedReason?: string;
+          };
+          hints?: string[];
         };
-        hints?: string[];
-      };
-      expect(parsed.ok).toBe(false);
-      expect(parsed.phase).toBe("daemon-install");
-      expect(parsed.daemonInstall).toEqual({
-        requested: true,
-        installed: false,
-        skippedReason: "systemd-user-unavailable",
+        expect(parsed.ok).toBe(false);
+        expect(parsed.phase).toBe("daemon-install");
+        expect(parsed.daemonInstall).toEqual({
+          requested: true,
+          installed: false,
+          skippedReason: "systemd-user-unavailable",
+        });
+        expect(parsed.hints).toContain(
+          "Fix: rerun without `--install-daemon` for one-shot setup, or enable a working user-systemd session and retry.",
+        );
       });
-      expect(parsed.hints).toContain(
-        "Fix: rerun without `--install-daemon` for one-shot setup, or enable a working user-systemd session and retry.",
-      );
-    });
-  }, 60_000);
+    },
+    60_000,
+  );
 
   it("emits structured JSON diagnostics when daemon health fails", async () => {
     await withStateDir("state-local-daemon-health-json-fail-", async (stateDir) => {

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -324,9 +324,9 @@ export async function runNonInteractiveLocalSetup(params: {
           installed: false,
           skippedReason: daemonInstall.skippedReason,
         };
-    if (!daemonInstall.installed && !opts.skipHealth) {
-      // Treat a failed requested daemon install as setup failure when health is
-      // expected; otherwise later probes would fail with less actionable output.
+    if (!daemonInstall.installed) {
+      // Skipping the health probe must not turn a requested install failure
+      // into successful onboarding.
       logNonInteractiveOnboardingFailure({
         opts,
         runtime,

--- a/src/commands/onboard-non-interactive/local/daemon-install.ts
+++ b/src/commands/onboard-non-interactive/local/daemon-install.ts
@@ -39,8 +39,8 @@ export async function installGatewayDaemonNonInteractive(params: {
   const systemdAvailable =
     process.platform === "linux" ? await isSystemdUserServiceAvailable() : true;
   if (process.platform === "linux" && !systemdAvailable) {
-    // Container and CI sessions often lack a user systemd manager; setup can
-    // still succeed with a direct gateway run, so this is a skip not a fatal.
+    // Container and CI sessions often lack a user systemd manager; onboarding
+    // owns the failure outcome for an explicitly requested installation.
     runtime.log(
       "Systemd user services are unavailable; skipping service install. Use a direct shell run (`openclaw gateway run`) or rerun without --install-daemon on this session.",
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where unattended onboarding could report `ok: true` and exit successfully after an explicitly requested Gateway daemon installation failed when `--skip-health` was also supplied. Windows release-install validation uses this exact flag combination, so the failure could also be hidden from a release check.

Fixes #122797.

## Why This Change Was Made

The local non-interactive onboarding owner incorrectly coupled the authoritative daemon-install outcome to the unrelated Gateway health-probe flag. A requested installation must fail whenever its installer reports `installed: false`; `--skip-health` only skips the later reachability probe.

The existing owner-boundary regression now covers both health modes in its existing test harness. This preserves the contributor's original fix while replacing the stale branch's duplicated 416-line test harness with one compact table-driven case.

## User Impact

Provisioning and release automation now receive a nonzero exit plus the existing `ok: false`, `phase: "daemon-install"` JSON response whenever a requested Gateway service cannot be installed. Explicit `--skip-daemon --skip-health` setup continues to succeed normally. The unavailable-systemd response retains its existing actionable recovery guidance.

## Evidence

Clean Linux Testbox: https://github.com/openclaw/openclaw/actions/runs/32338838217

- Failing-first regression: `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/commands/onboard-non-interactive.gateway.test.ts -- --reporter=verbose` failed only for `skipHealth: true` before the production fix.
- Fixed owner and sibling coverage: `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/commands/onboard-non-interactive.gateway.test.ts src/commands/onboard-non-interactive/local/daemon-install.test.ts -- --reporter=verbose` passed all 24 tests.
- Real installed CLI, fresh isolated Linux state, and an unavailable user-systemd bus:
  - `onboard --non-interactive --accept-risk --auth-choice skip --install-daemon --skip-health --json`: exit 1; `ok: false`, `phase: "daemon-install"`, `daemonInstall.installed: false`.
  - The same command without `--skip-health`: exit 1 with the identical daemon-install failure.
  - `onboard --non-interactive --accept-risk --auth-choice skip --skip-daemon --skip-health --json`: exit 0; `ok: true`, `installDaemon: false`.
- Contributor's original diagnosis and fix: @SunnyShu0925.
