### PR TITLE
fix(tooling): fail deadcode report on scan errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1551,7 +1551,7 @@
     "deadcode:exports": "node --import tsx scripts/check-deadcode-exports.mts",
     "deadcode:full": "pnpm --config.minimum-release-age=0 dlx --package knip@6.8.0 knip --config config/knip.config.ts --production --no-progress --reporter compact --no-config-hints --exclude duplicates && pnpm --config.minimum-release-age=0 dlx --package knip@6.8.0 knip --config config/knip.all-exports.config.ts --no-progress --reporter compact --no-config-hints --exports --exclude duplicates",
     "deadcode:knip": "pnpm --config.minimum-release-age=0 dlx --package knip@6.8.0 knip --config config/knip.config.ts --production --no-progress --reporter compact --files --dependencies",
-    "deadcode:report": "pnpm deadcode:full; pnpm deadcode:exports",
+    "deadcode:report": "pnpm deadcode:full && pnpm deadcode:exports",
     "deadcode:unused-files": "node --import tsx scripts/check-deadcode-unused-files.mts",
     "deps:root-ownership": "node --import tsx scripts/root-dependency-ownership-audit.mts",
     "deps:root-ownership:check": "node --import tsx scripts/root-dependency-ownership-audit.mts --check",

--- a/test/package-scripts.test.ts
+++ b/test/package-scripts.test.ts
@@ -152,6 +152,12 @@ describe("package scripts", () => {
     );
   });
 
+  it("runs dead-code reports fail-fast", () => {
+    expect(readPackageJson().scripts["deadcode:report"]).toBe(
+      "pnpm deadcode:full && pnpm deadcode:exports",
+    );
+  });
+
   it("runs runtime postbuild before plugin SDK strict export checks", () => {
     expect(readPackageJson().scripts["build:plugin-sdk:strict-smoke"]).toBe(
       "node --import tsx scripts/tsdown-build.mts && node scripts/runtime-postbuild.mjs && node --import tsx scripts/run-with-env.mts OPENCLAW_PLUGIN_SDK_CANONICAL_DTS=1 -- node --import tsx scripts/write-plugin-sdk-entry-dts.ts && node --import tsx scripts/check-plugin-sdk-exports.mts",


### PR DESCRIPTION
## What Problem This Solves

`pnpm deadcode:report` ran the full-tree scan and export scan with `;`. If `deadcode:full` failed but `deadcode:exports` passed, the second command replaced the first exit status and the report command exited successfully. That made a developer-facing validation command print a misleading final pass after a real scan failure.

## Why This Change Was Made

The package-script owner now uses ordinary fail-fast shell composition:

- `deadcode:full` must pass before `deadcode:exports` runs;
- the first failure remains the command exit status;
- CI architecture is unchanged because hosted CI already invokes the individual dead-code gates directly.

The existing package-script contract suite now protects the exact fail-fast composition. No new wrapper, dependency, compatibility path, or production runtime behavior is added.

AI-assisted: yes. The candidate came from a frozen current-main Auto QA tooling audit and was independently rechecked against the package-script contract, callers, and history before implementation.

## User Impact

Developers and maintainers running `pnpm deadcode:report` now receive a nonzero exit immediately when the full dead-code scan fails, instead of a false success after the export scan.

## Evidence

- Pre-fix shell reproduction: stubbed `deadcode:full` returned 23, `deadcode:exports` still ran, and the combined script exited 0.
- Post-fix same reproduction: only `deadcode:full` ran and the combined script exited 23.
- Focused test: `node scripts/run-vitest.mjs test/package-scripts.test.ts` — 47 tests passed.
- Hosted changed gate: Testbox `tbx_01kzw18mqfdeke0hmqqbdswn0q`, run https://github.com/openclaw/openclaw/actions/runs/31646863501 — passed.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/31647268947 attempt 2 — passed at `182bb2a54f55ca8ec4bdffed1f0312abea05fb48`. Attempt 1 had one unrelated `config-safe-write.e2e.test.ts` mocked-Gateway timeout; the failed jobs passed unchanged on rerun.
- Targeted formatting and `git diff --check` passed.
- Fresh local and complete-branch autoreviews: clean at 0.99 confidence.
- Tooling production delta: +1/−1 (net zero); tests: +6/−0.
