### PR TITLE
test(core): remove duplicate assertions

### DIFF
--- a/packages/acp-core/src/session-interaction-mode.test.ts
+++ b/packages/acp-core/src/session-interaction-mode.test.ts
@@ -99,8 +99,4 @@ describe("isRequesterParentOfBackgroundAcpSession", () => {
       ),
     ).toBe(true);
   });
-
-  it("delegates to isParentOwnedBackgroundAcpSession for target-only checks", () => {
-    expect(isParentOwnedBackgroundAcpSession(backgroundEntry)).toBe(true);
-  });
 });

--- a/src/gateway/http-common.fuzz.test.ts
+++ b/src/gateway/http-common.fuzz.test.ts
@@ -11,11 +11,8 @@ import {
   sendJson,
   sendMethodNotAllowed,
   sendRateLimited,
-  sendUnauthorized,
   setDefaultSecurityHeaders,
-  setSseHeaders,
   watchClientDisconnect,
-  writeDone,
 } from "./http-common.js";
 import { makeMockHttpReqRes, makeMockHttpResponse } from "./test-http-response.js";
 
@@ -176,20 +173,6 @@ describe("fuzz: sendMethodNotAllowed", () => {
   });
 });
 
-describe("fuzz: sendUnauthorized", () => {
-  it("is deterministic: always 401 with the canonical error payload", () => {
-    const expected = JSON.stringify({
-      error: { message: "Unauthorized", type: "unauthorized" },
-    });
-    for (let i = 0; i < ITERATIONS; i += 1) {
-      const { res, end } = makeMockHttpResponse();
-      sendUnauthorized(res);
-      expect(res.statusCode).toBe(401);
-      expect(end).toHaveBeenCalledWith(expected);
-    }
-  });
-});
-
 describe("fuzz: sendRateLimited", () => {
   it("sets Retry-After iff retryAfterMs is truthy and > 0, with ceil-seconds value", () => {
     const rng = makeRng(0x429);
@@ -314,42 +297,6 @@ describe("fuzz: readJsonBodyOrError", () => {
         expect(end).toHaveBeenCalledWith(expectedBody);
       }
       expect(readJsonBodyMock).toHaveBeenLastCalledWith(req, maxBytes);
-    }
-  });
-});
-
-describe("fuzz: writeDone", () => {
-  it("always writes the DONE sentinel exactly once per call", () => {
-    for (let i = 0; i < ITERATIONS; i += 1) {
-      const { res } = makeMockHttpResponse();
-      const write = vi.spyOn(res, "write");
-      writeDone(res);
-      expect(write).toHaveBeenCalledTimes(1);
-      expect(write).toHaveBeenCalledWith("data: [DONE]\n\n");
-    }
-  });
-});
-
-describe("fuzz: setSseHeaders", () => {
-  it("sets SSE headers and invokes flushHeaders when present", () => {
-    const rng = makeRng(0x55e);
-    for (let i = 0; i < ITERATIONS; i += 1) {
-      const { res, setHeader } = makeMockHttpResponse();
-      const hasFlush = rng() < 0.5;
-      const flushHeaders = vi.fn();
-      if (hasFlush) {
-        (res as unknown as { flushHeaders: () => void }).flushHeaders = flushHeaders;
-      }
-      setSseHeaders(res);
-      expect(res.statusCode).toBe(200);
-      expect(setHeader).toHaveBeenCalledWith("Content-Type", "text/event-stream; charset=utf-8");
-      expect(setHeader).toHaveBeenCalledWith("Cache-Control", "no-cache");
-      expect(setHeader).toHaveBeenCalledWith("Connection", "keep-alive");
-      if (hasFlush) {
-        expect(flushHeaders).toHaveBeenCalledTimes(1);
-      } else {
-        expect(flushHeaders).not.toHaveBeenCalled();
-      }
     }
   });
 });

--- a/src/infra/boundary-file-read.test.ts
+++ b/src/infra/boundary-file-read.test.ts
@@ -9,13 +9,6 @@ import * as shim from "./boundary-file-read.js";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("root file open shim", () => {
-  it("re-exports the fs-safe root file helpers", () => {
-    expect(shim.canUseRootFileOpen).toBe(upstream.canUseRootFileOpen);
-    expect(shim.matchRootFileOpenFailure).toBe(upstream.matchRootFileOpenFailure);
-    expect(shim.openRootFile).toBe(upstream.openRootFile);
-    expect(shim.openRootFileSync).toBe(upstream.openRootFileSync);
-  });
-
   it("separates missing, unreadable, and boundary-violating open failures", () => {
     const messageFor = (failure: upstream.RootFileOpenFailure) =>
       shim.describeRootFileOpenFailure({


### PR DESCRIPTION
## What Problem This Solves

Three core test surfaces repeated implementation or exhaustive unit coverage without adding behavior:

- `boundary-file-read.test.ts` compared four shim exports by function-object identity against `@openclaw/fs-safe/advanced`.
- an ACP test named for requester delegation never called the requester predicate and repeated the base parent-owned condition.
- three deterministic fuzz cases invoked zero-input stateless HTTP helpers 200 times, or randomly selected the same two `flushHeaders` branches already covered exactly.

## Why This Change Was Made

Delete only those duplicate assertions. Keep:

- OpenClaw-owned fs-safe error classification and bounded-read overflow tests;
- all actual requester-specific ACP cases and caller-level routing coverage;
- input-varying HTTP fuzz cases plus exact unit tests for unauthorized responses, SSE headers, and `[DONE]` framing.

Direct dependency inspection confirms `@openclaw/fs-safe/advanced` itself re-exports the four root-file functions; build/typechecking, production callers, and upstream behavior own that contract, not object identity.

## User Impact

No user-visible behavior changes. This removes 64 test lines with no production or package surface change.

## Evidence

- 60 focused tests passed across ACP interaction mode, Gateway HTTP unit/fuzz, and fs-safe boundary behavior.
- Repository core-test changed-file gate passed, including core-test typecheck, lint, boundaries, wrapper-shadowing, formatting, and Knip unused-export scans.
- Direct dependency inspection covered `@openclaw/fs-safe` 0.5.5 `dist/advanced.js`, `dist/root-file.d.ts`, and `dist/root-file.js`.
- The configured remote backend was unavailable because the `blacksmith` executable is not installed on this host, so the changed-file wrapper completed its documented local fallback.
- `git diff --check` passed.
- Structured branch autoreview found no accepted or actionable findings.
