### PR TITLE
fix(agents): preserve ACP lifecycle ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **ACP child lifecycle ownership:** keep spawned ACP runs under their canonical task owner, downgrade legacy subagent mirrors to topology-only observers, preserve canonical liveness across gateway restart reconciliation, and defer destructive one-shot session cleanup until a later corroborating maintenance pass.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.
 - **Updater plugin convergence:** keep pre-plugin doctor passes from installing configured plugins before the updater's plugin sweep, while preserving the final post-plugin migration pass and preventing ambient update-phase state from leaking into fresh doctor processes.

--- a/src/agents/subagents/registry/subagent-delivery-state.test.ts
+++ b/src/agents/subagents/registry/subagent-delivery-state.test.ts
@@ -41,6 +41,32 @@ describe("normalizeSubagentRunState", () => {
     expect(nonString.taskRunId).toBeUndefined();
   });
 
+  it("upgrades legacy ACP mirrors into topology-only observers", () => {
+    const entry = normalizeSubagentRunState(
+      baseRun({
+        childSessionKey: "agent:codex:acp:legacy-child",
+        taskRunId: "legacy-subagent-task",
+        requesterTurnRunId: "requester-turn",
+        requesterTurnYielded: true,
+        retireAfterRequesterTurn: true,
+        requesterSettleWake: { status: "pending", attemptCount: 0 },
+      }),
+    );
+
+    expect(entry).toMatchObject({
+      lifecycleOwner: "acp",
+      expectsCompletionMessage: false,
+      execution: { suppressSessionEffects: true },
+      completion: { required: false },
+      delivery: { status: "not_required" },
+    });
+    expect(entry.taskRunId).toBeUndefined();
+    expect(entry.requesterTurnRunId).toBeUndefined();
+    expect(entry.requesterTurnYielded).toBeUndefined();
+    expect(entry.retireAfterRequesterTurn).toBeUndefined();
+    expect(entry.requesterSettleWake).toBeUndefined();
+  });
+
   it("normalizes the durable delete-dispatch boundary", () => {
     const valid = normalizeSubagentRunState(baseRun({ deleteCleanupDispatchedAt: 200 }));
     const malformed = normalizeSubagentRunState(baseRun({ deleteCleanupDispatchedAt: Number.NaN }));

--- a/src/agents/subagents/registry/subagent-delivery-state.ts
+++ b/src/agents/subagents/registry/subagent-delivery-state.ts
@@ -1,3 +1,4 @@
+import { isAcpSessionKey } from "../../../sessions/session-key-utils.js";
 import { normalizeAgentRunTerminalReplySnapshot } from "../../agent-run-terminal-reply.js";
 import type {
   SubagentCompletionDeliveryState,
@@ -6,8 +7,10 @@ import type {
 } from "./subagent-registry.types.js";
 
 export function normalizeSubagentRunState(entry: SubagentRunRecord): SubagentRunRecord {
+  const isAcpObserver = entry.lifecycleOwner === "acp" || isAcpSessionKey(entry.childSessionKey);
+  entry.lifecycleOwner = isAcpObserver ? "acp" : undefined;
   const taskRunId = typeof entry.taskRunId === "string" ? entry.taskRunId.trim() : "";
-  entry.taskRunId = taskRunId || undefined;
+  entry.taskRunId = !isAcpObserver && taskRunId ? taskRunId : undefined;
   const requesterTurnRunId =
     typeof entry.requesterTurnRunId === "string" ? entry.requesterTurnRunId.trim() : "";
   entry.requesterTurnRunId = requesterTurnRunId || undefined;
@@ -15,6 +18,18 @@ export function normalizeSubagentRunState(entry: SubagentRunRecord): SubagentRun
     requesterTurnRunId && entry.requesterTurnYielded === true ? true : undefined;
   entry.retireAfterRequesterTurn =
     requesterTurnRunId && entry.retireAfterRequesterTurn === true ? true : undefined;
+  if (isAcpObserver) {
+    // Upgrade legacy ACP mirrors into topology-only observers. The canonical
+    // ACP task owns delivery, restart reconciliation, and every session effect.
+    entry.requesterTurnRunId = undefined;
+    entry.requesterTurnYielded = undefined;
+    entry.retireAfterRequesterTurn = undefined;
+    entry.expectsCompletionMessage = false;
+    entry.execution = { ...entry.execution, suppressSessionEffects: true };
+    entry.completion = { ...entry.completion, required: false };
+    entry.delivery = { status: "not_required" };
+    entry.requesterSettleWake = undefined;
+  }
   entry.generation =
     typeof entry.generation === "number" &&
     Number.isSafeInteger(entry.generation) &&

--- a/src/agents/subagents/registry/subagent-registry-run-launch.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-run-launch.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SubagentLaunchManager } from "./subagent-registry-run-launch.js";
+import type { SubagentManagerOptions } from "./subagent-registry-run-wait.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+const taskRuntimeMocks = vi.hoisted(() => ({
+  createQueuedTaskRun: vi.fn(),
+  createRunningTaskRun: vi.fn(),
+}));
+
+vi.mock("../../../tasks/detached-task-runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../tasks/detached-task-runtime.js")>()),
+  createQueuedTaskRun: taskRuntimeMocks.createQueuedTaskRun,
+  createRunningTaskRun: taskRuntimeMocks.createRunningTaskRun,
+}));
+
+function createManager(runs: Map<string, SubagentRunRecord>) {
+  const getRunsForChildSession = (childSessionKey: string) =>
+    [...runs.values()].filter((entry) => entry.childSessionKey === childSessionKey);
+  const options = {
+    runs,
+    getRunsForChildSession,
+    resumedRuns: new Set<string>(),
+    persist: vi.fn(),
+    persistOrThrow: vi.fn(),
+    callGateway: vi.fn(),
+    getRuntimeConfig: vi.fn(() => ({})),
+    ensureListener: vi.fn(),
+    startSweeper: vi.fn(),
+    stopSweeper: vi.fn(),
+    resumeSubagentRun: vi.fn(),
+    clearPendingLifecycleError: vi.fn(),
+    clearPendingLifecycleTimeout: vi.fn(),
+    resolveSubagentWaitTimeoutMs: vi.fn(() => 60_000),
+    scheduleSweep: vi.fn(),
+    resolveSubagentSessionCompletion: vi.fn(() => null),
+    resolveSubagentSessionStartedAt: vi.fn(),
+    notifyContextEngineSubagentEnded: vi.fn(async () => {}),
+    completeCleanupBookkeeping: vi.fn(),
+    completeSubagentRun: vi.fn(async () => {}),
+    resolveSubagentTask: vi.fn(() => ({ lookup: "unavailable" as const })),
+  } as unknown as SubagentManagerOptions;
+  return { manager: new SubagentLaunchManager(options), options };
+}
+
+describe("subagent launch lifecycle ownership", () => {
+  beforeEach(() => {
+    taskRuntimeMocks.createQueuedTaskRun.mockReset();
+    taskRuntimeMocks.createRunningTaskRun.mockReset();
+  });
+
+  it("persists ACP observers without creating a duplicate subagent task", () => {
+    const runs = new Map<string, SubagentRunRecord>();
+    const { manager, options } = createManager(runs);
+
+    manager.registerSubagentRun({
+      runId: "run-acp-observer",
+      lifecycleOwner: "acp",
+      childSessionKey: "agent:codex:acp:child",
+      requesterSessionKey: "agent:main:slack:direct:owner",
+      requesterDisplayKey: "owner",
+      task: "Review a pull request",
+      cleanup: "keep",
+      expectsCompletionMessage: false,
+      queued: true,
+    });
+
+    expect(runs.get("run-acp-observer")).toMatchObject({
+      lifecycleOwner: "acp",
+      execution: {
+        status: "queued",
+        suppressSessionEffects: true,
+      },
+      delivery: { status: "not_required" },
+    });
+    expect(options.persistOrThrow).toHaveBeenCalledWith("run-acp-observer");
+    expect(taskRuntimeMocks.createQueuedTaskRun).not.toHaveBeenCalled();
+    expect(taskRuntimeMocks.createRunningTaskRun).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/subagents/registry/subagent-registry-run-launch.ts
+++ b/src/agents/subagents/registry/subagent-registry-run-launch.ts
@@ -52,6 +52,8 @@ function resolveSwarmWaitOwnerSessionKeys(
 
 export type RegisterSubagentRunParams = {
   runId: string;
+  /** External runtime that owns terminal delivery and child-session cleanup. */
+  lifecycleOwner?: "acp";
   requesterTurnRunId?: string;
   childSessionKey: string;
   controllerSessionKey?: string;
@@ -115,6 +117,7 @@ export class SubagentLaunchManager extends SubagentRecoveryManager {
     const queued = registerParams.queued === true;
     const entry: SubagentRunRecord = normalizeSubagentRunState({
       runId,
+      lifecycleOwner: registerParams.lifecycleOwner,
       taskRunId: runId,
       ...(requesterTurnRunId && registerParams.expectsCompletionMessage === true
         ? { requesterTurnRunId }
@@ -160,6 +163,8 @@ export class SubagentLaunchManager extends SubagentRecoveryManager {
         status: queued ? "queued" : "running",
         startedAt: queued ? undefined : now,
         lifecycleGeneration: getAgentEventLifecycleGeneration(),
+        // ACP has its own canonical task, liveness, delivery, and cleanup owner.
+        suppressSessionEffects: registerParams.lifecycleOwner === "acp" ? true : undefined,
       },
       completion: {
         required: registerParams.expectsCompletionMessage === true,
@@ -189,6 +194,16 @@ export class SubagentLaunchManager extends SubagentRecoveryManager {
       throw error;
     }
     try {
+      if (registerParams.lifecycleOwner === "acp") {
+        // Keep the registry row for child topology and controls only. Creating a
+        // second subagent task gives the observer authority over ACP lifecycle.
+        this.options.ensureListener();
+        this.options.startSweeper();
+        if (!queued) {
+          void this.waitForSubagentCompletion(runId, waitTimeoutMs, entry);
+        }
+        return;
+      }
       const taskParams = {
         runtime: "subagent",
         sourceId: runId,

--- a/src/agents/subagents/registry/subagent-registry-sweeper-recovery.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-sweeper-recovery.test.ts
@@ -10,6 +10,12 @@ import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 const recoverRow = vi.hoisted(() => vi.fn());
 const getAgentRunContext = vi.hoisted(() => vi.fn<(_runId: string) => unknown>(() => undefined));
+const isAcpTurnActive = vi.hoisted(() => vi.fn<(_sessionKey: string) => boolean>(() => false));
+const listTasksForSessionKeyForStatus = vi.hoisted(() =>
+  vi.fn<(_sessionKey: string) => Array<{ runtime: "acp"; runId: string; status: "running" }>>(
+    () => [],
+  ),
+);
 const removeInternalSessionEffectsSession = vi.hoisted(() => vi.fn(async () => {}));
 const detachedTaskRuntime = vi.hoisted(() => ({
   finalizeTaskRunByRunId: vi.fn(() => [] as unknown[]),
@@ -37,6 +43,12 @@ vi.mock("../../../infra/agent-events.js", () => ({
 }));
 vi.mock("../../../infra/agent-run-registry.js", () => ({
   getAgentRunContext,
+}));
+vi.mock("../../../acp/control-plane/active-turns.js", () => ({
+  isAcpTurnActive,
+}));
+vi.mock("../../../tasks/task-status-access.js", () => ({
+  listTasksForSessionKeyForStatus,
 }));
 vi.mock("../../internal-session-effects.js", () => ({
   removeInternalSessionEffectsSession,
@@ -156,6 +168,8 @@ describe("subagent registry recovery scheduling", () => {
     resetGatewayWorkAdmission();
     recoverRow.mockReset();
     getAgentRunContext.mockReset().mockReturnValue(undefined);
+    isAcpTurnActive.mockReset().mockReturnValue(false);
+    listTasksForSessionKeyForStatus.mockReset().mockReturnValue([]);
     killRuntime.abortEmbeddedAgentRun.mockReset().mockReturnValue(false);
     killRuntime.isEmbeddedAgentRunActive.mockReset().mockReturnValue(false);
     killRuntime.clearSessionQueues.mockReset().mockReturnValue({
@@ -262,6 +276,40 @@ describe("subagent registry recovery scheduling", () => {
 
     expect(recoverRow.mock.calls.length).toBeGreaterThan(4);
     expect(finalizeInterruptedSubagentRun).not.toHaveBeenCalled();
+    sweeper.reset();
+  });
+
+  it("uses the canonical ACP task as durable liveness after restart", async () => {
+    const runtime = { current: {} as GatewayRecoveryRuntime };
+    const { entry, completeSubagentRunWithRecovery, sweeper } = createHarness(runtime);
+    entry.lifecycleOwner = "acp";
+    entry.execution.suppressSessionEffects = true;
+    listTasksForSessionKeyForStatus.mockReturnValue([
+      {
+        runtime: "acp",
+        runId: entry.runId,
+        status: "running",
+      },
+    ]);
+
+    await sweeper.sweepOnce();
+
+    expect(recoverRow).not.toHaveBeenCalled();
+    expect(completeSubagentRunWithRecovery).not.toHaveBeenCalled();
+    sweeper.reset();
+  });
+
+  it("uses the active ACP turn instead of native run context", async () => {
+    const runtime = { current: {} as GatewayRecoveryRuntime };
+    const { entry, completeSubagentRunWithRecovery, sweeper } = createHarness(runtime);
+    entry.lifecycleOwner = "acp";
+    entry.execution.suppressSessionEffects = true;
+    isAcpTurnActive.mockReturnValue(true);
+
+    await sweeper.sweepOnce();
+
+    expect(recoverRow).not.toHaveBeenCalled();
+    expect(completeSubagentRunWithRecovery).not.toHaveBeenCalled();
     sweeper.reset();
   });
 

--- a/src/agents/subagents/registry/subagent-registry-sweeper.ts
+++ b/src/agents/subagents/registry/subagent-registry-sweeper.ts
@@ -1,6 +1,5 @@
 import type { callGateway } from "../../../gateway/call.js";
 import type { GatewayRecoveryRuntime } from "../../../gateway/server-instance-runtime.types.js";
-import { getAgentRunContext } from "../../../infra/agent-run-registry.js";
 import { isFastTestRuntimeEnv } from "../../../infra/env.js";
 import { runWithGatewayIndependentRootWorkAdmission } from "../../../process/gateway-work-admission.js";
 import { emitSessionLifecycleEvent } from "../../../sessions/session-lifecycle-events.js";
@@ -33,7 +32,7 @@ import type {
   SubagentCompletionRequest,
   SubagentRunRecord,
 } from "./subagent-registry.types.js";
-import { isStaleUnendedSubagentRun } from "./subagent-run-liveness.js";
+import { hasLiveRunOwner, isStaleUnendedSubagentRun } from "./subagent-run-liveness.js";
 import { deleteSubagentSessionForCleanup } from "./subagent-session-cleanup.js";
 import {
   loadSubagentSessionEntry,
@@ -256,7 +255,7 @@ export function createSubagentRegistrySweeper(params: {
             ? 1
             : entry.terminalOwner === "interrupted-recovery"
               ? 2
-              : !getAgentRunContext(runId) && typeof entry.execution.endedAt !== "number"
+              : !hasLiveRunOwner(runId, entry) && typeof entry.execution.endedAt !== "number"
                 ? 3
                 : entry.killReconciliation
                   ? 4
@@ -356,15 +355,16 @@ export function createSubagentRegistrySweeper(params: {
           continue;
         }
         if (
+          entry.lifecycleOwner !== "acp" &&
           (entry.execution.restartRecovery?.phase === "accepted" ||
             entry.terminalOwner === "interrupted-recovery" ||
-            (!getAgentRunContext(runId) && typeof entry.execution.endedAt !== "number")) &&
+            (!hasLiveRunOwner(runId, entry) && typeof entry.execution.endedAt !== "number")) &&
           (await recovery.recover(runId, entry, now))
         ) {
           continue;
         }
         if (typeof entry.execution.endedAt !== "number") {
-          const hasLiveRunContext = Boolean(getAgentRunContext(runId));
+          const hasLiveRunContext = hasLiveRunOwner(runId, entry);
           const activeAgeMs = now - (entry.execution.startedAt ?? entry.createdAt);
           if (!hasLiveRunContext && activeAgeMs >= STALE_ACTIVE_SUBAGENT_GRACE_MS) {
             const orphanReason = resolveSubagentRunOrphanReason({ entry });

--- a/src/agents/subagents/registry/subagent-registry.types.ts
+++ b/src/agents/subagents/registry/subagent-registry.types.ts
@@ -216,6 +216,8 @@ type SubagentKillIntent = {
 
 export type SubagentRunRecord = {
   runId: string;
+  /** External runtime that owns terminal delivery and every child-session side effect. */
+  lifecycleOwner?: "acp";
   /** Detached task owner; steer/restart changes runId but continues the same task. */
   taskRunId?: string;
   /** Requester attempt that must settle before this completion row can retire. */

--- a/src/agents/subagents/registry/subagent-run-liveness.ts
+++ b/src/agents/subagents/registry/subagent-run-liveness.ts
@@ -3,6 +3,10 @@
  *
  * Ages out stale unended runs while keeping recent/composed child links visible.
  */
+import { isAcpTurnActive } from "../../../acp/control-plane/active-turns.js";
+import { getAgentRunContext } from "../../../infra/agent-run-registry.js";
+import { isActiveTaskStatus } from "../../../tasks/task-registry-common.js";
+import { listTasksForSessionKeyForStatus } from "../../../tasks/task-status-access.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 import { resolveSubagentRunDurationMs } from "./subagent-run-timeout.js";
 import { getSubagentSessionStartedAt } from "./subagent-session-metrics.js";
@@ -18,6 +22,23 @@ const STALE_UNENDED_SUBAGENT_RUN_MS = 2 * 60 * 60 * 1_000;
 export const RECENT_ENDED_SUBAGENT_CHILD_SESSION_MS = 30 * 60 * 1_000;
 const EXPLICIT_TIMEOUT_STALE_GRACE_MS = 60_000;
 const MIN_REALISTIC_RUN_TIMESTAMP_MS = Date.UTC(2020, 0, 1);
+
+export function hasLiveRunOwner(runId: string, entry: SubagentRunRecord): boolean {
+  if (getAgentRunContext(runId)) {
+    return true;
+  }
+  if (entry.lifecycleOwner !== "acp") {
+    return false;
+  }
+  if (isAcpTurnActive(entry.childSessionKey)) {
+    return true;
+  }
+  // The task row is durable, so it remains the ACP observer's liveness
+  // authority while a restarted gateway reconciles its process-local turn map.
+  return listTasksForSessionKeyForStatus(entry.childSessionKey).some(
+    (task) => task.runtime === "acp" && task.runId === runId && isActiveTaskStatus(task.status),
+  );
+}
 
 /** Return whether a subagent run has a finite execution end timestamp. */
 export function hasSubagentRunEnded<T extends { execution: { endedAt?: number } }>(

--- a/src/agents/subagents/spawn/acp-spawn.test.ts
+++ b/src/agents/subagents/spawn/acp-spawn.test.ts
@@ -1432,6 +1432,21 @@ describe("spawnAcpDirect", () => {
     });
   });
 
+  it("registers ACP children as topology-only lifecycle observers", async () => {
+    const result = await spawnAcpDirect(createSpawnRequest(), createRequesterContext());
+
+    expectAcceptedSpawn(result);
+    expect(hoisted.registerSubagentRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lifecycleOwner: "acp",
+        expectsCompletionMessage: false,
+      }),
+    );
+    expect(hoisted.registerSubagentRunMock.mock.calls[0]?.[0]).not.toHaveProperty(
+      "requesterTurnRunId",
+    );
+  });
+
   it("rejects ACP spawns that exceed subagent max depth", async () => {
     replaceSpawnConfig({
       ...hoisted.state.cfg,

--- a/src/agents/subagents/spawn/acp-spawn.ts
+++ b/src/agents/subagents/spawn/acp-spawn.ts
@@ -655,11 +655,10 @@ export async function spawnAcpDirect(
     hookRunner: getGlobalHookRunner(),
     progressOrigin,
     progressSessionKey: ownership.completionRequesterSessionKey,
-    buildRegistration: (state, runId) => {
-      const inlineDelivery = state.deliveryPlan?.useInlineDelivery === true;
+    buildRegistration: (_state, runId) => {
       return {
         runId,
-        requesterTurnRunId: ctx.requesterTurnRunId,
+        lifecycleOwner: "acp",
         childSessionKey: sessionKey,
         controllerSessionKey,
         requesterSessionKey: ownership.completionRequesterSessionKey,
@@ -673,9 +672,8 @@ export async function spawnAcpDirect(
         cleanup: spawnMode === "session" ? "keep" : params.cleanup === "delete" ? "delete" : "keep",
         label: params.label,
         runTimeoutSeconds,
-        expectsCompletionMessage: inlineDelivery
-          ? false
-          : params.expectsCompletionMessage !== false,
+        // The canonical ACP task owns delivery. This row is topology/control only.
+        expectsCompletionMessage: false,
         spawnMode,
       };
     },

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -455,6 +455,9 @@ function resolveTaskLostError(task: TaskRecord, context?: BackingSessionLookupCo
       return formatSubagentRecoveryWedgedReason(entry);
     }
   }
+  if (task.runtime === "acp") {
+    return "ACP runtime owner missing after liveness grace";
+  }
   return "backing session missing";
 }
 
@@ -553,6 +556,7 @@ function shouldCloseTerminalAcpSession(task: TaskRecord): boolean {
   const sessionKey = getNormalizedTaskChildSessionKey(task);
   if (
     !sessionKey ||
+    taskRegistryMaintenanceRuntime.hasActiveAcpTurn(sessionKey) ||
     taskRegistryMaintenanceRuntime.hasActiveTaskForChildSessionKey({
       sessionKey,
       excludeTaskId: task.taskId,
@@ -576,13 +580,18 @@ function shouldCloseTerminalAcpSession(task: TaskRecord): boolean {
   return !hasActiveSessionBinding(sessionKey);
 }
 
-function shouldCloseOrphanedParentOwnedAcpSession(acpEntry: AcpSessionStoreEntry): boolean {
+function shouldCloseOrphanedParentOwnedAcpSession(
+  acpEntry: AcpSessionStoreEntry,
+  preserveSessionKeys: ReadonlySet<string>,
+): boolean {
   if (!acpEntry.entry || !acpEntry.acp || !isParentOwnedAcpSessionEntry(acpEntry)) {
     return false;
   }
   const sessionKey = normalizeOptionalString(acpEntry.sessionKey);
   if (
     !sessionKey ||
+    preserveSessionKeys.has(sessionKey) ||
+    taskRegistryMaintenanceRuntime.hasActiveAcpTurn(sessionKey) ||
     taskRegistryMaintenanceRuntime.hasActiveTaskForChildSessionKey({ sessionKey })
   ) {
     return false;
@@ -637,7 +646,9 @@ async function cleanupTerminalAcpSession(task: TaskRecord): Promise<void> {
   }
 }
 
-async function cleanupOrphanedParentOwnedAcpSessions(): Promise<void> {
+async function cleanupOrphanedParentOwnedAcpSessions(
+  preserveSessionKeys: ReadonlySet<string>,
+): Promise<void> {
   let acpSessions: AcpSessionStoreEntry[];
   try {
     acpSessions = await taskRegistryMaintenanceRuntime.listAcpSessionEntries({ clone: false });
@@ -652,7 +663,7 @@ async function cleanupOrphanedParentOwnedAcpSessions(): Promise<void> {
       continue;
     }
     seenSessionKeys.add(sessionKey);
-    if (!shouldCloseOrphanedParentOwnedAcpSession(acpEntry)) {
+    if (!shouldCloseOrphanedParentOwnedAcpSession(acpEntry, preserveSessionKeys)) {
       continue;
     }
     const closeAcpSession = taskRegistryMaintenanceRuntime.closeAcpSession;
@@ -1015,6 +1026,9 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
   const cronRecoveryContext = createCronRecoveryContext();
   const backingSessionContext = createBackingSessionLookupContext();
   const recoveryHookRegistered = hasDetachedTaskRecoveryHook();
+  // A newly lost ACP task must not erase its backing state in the same pass;
+  // the next pass rechecks both the turn marker and durable task state.
+  const newlyLostAcpSessionKeys = new Set<string>();
   let processed = 0;
   for (const task of tasks) {
     const current = taskRegistryMaintenanceRuntime.getTaskById(task.taskId);
@@ -1072,6 +1086,12 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
       const next = markTaskLost(freshAfterHook, now, lostContext);
       if (next.status === "lost") {
         reconciled += 1;
+        if (next.runtime === "acp") {
+          const childSessionKey = getNormalizedTaskChildSessionKey(next);
+          if (childSessionKey) {
+            newlyLostAcpSessionKeys.add(childSessionKey);
+          }
+        }
       }
       processed += 1;
       if (processed % SWEEP_YIELD_BATCH_SIZE === 0) {
@@ -1108,7 +1128,7 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
       await yieldToEventLoop();
     }
   }
-  await cleanupOrphanedParentOwnedAcpSessions();
+  await cleanupOrphanedParentOwnedAcpSessions(newlyLostAcpSessionKeys);
   if (isPluginStateDatabaseOpen()) {
     try {
       sweepExpiredPluginStateEntries();

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -2954,7 +2954,7 @@ describe("task-registry", () => {
       expectRecordFields(tasks[0], {
         runId: "run-lost",
         status: "lost",
-        error: "backing session missing",
+        error: "ACP runtime owner missing after liveness grace",
       });
       expectRecordFields(requireTaskById(task.taskId), {
         status: "running",
@@ -3012,7 +3012,7 @@ describe("task-registry", () => {
       });
       expectRecordFields(requireTaskById(task.taskId), {
         status: "lost",
-        error: "backing session missing",
+        error: "ACP runtime owner missing after liveness grace",
       });
       const lostTask = getTaskById(task.taskId);
       expect(lostTask?.cleanupAfter).toBeGreaterThan(now);
@@ -3023,6 +3023,52 @@ describe("task-registry", () => {
         warnings: 1,
       });
       expect(summary.byCode.lost).toBe(1);
+    });
+  });
+
+  it("preserves a newly lost ACP session until a later corroborating sweep", async () => {
+    await withTaskRegistryTempDir(async () => {
+      resetTaskRegistryMemoryForTest();
+      const parentSessionKey = "agent:main:slack:direct:owner";
+      const childSessionKey = "agent:codex:acp:lost-grace";
+      const task = createTaskFixture("acp", {
+        ownerKey: parentSessionKey,
+        requesterSessionKey: parentSessionKey,
+        childSessionKey,
+        runId: "run-acp-lost-grace",
+        task: "Long ACP review",
+        lastEventAt: Date.now() - 10 * 60_000,
+      });
+      const currentTasks = new Map([[task.taskId, task]]);
+      const closeAcpSession = vi.fn().mockResolvedValue(undefined);
+      const acpEntry = createAcpSessionStoreEntry({
+        sessionKey: childSessionKey,
+        parentSessionKey,
+        mode: "oneshot",
+      });
+      configureTaskRegistryMaintenanceRuntimeForTest({
+        currentTasks,
+        snapshotTasks: [task],
+        acpEntry,
+        acpEntries: [acpEntry],
+        closeAcpSession,
+      });
+
+      await runTaskRegistryMaintenance();
+
+      expectRecordFields(currentTasks.get(task.taskId), {
+        status: "lost",
+        error: "ACP runtime owner missing after liveness grace",
+      });
+      expect(closeAcpSession).not.toHaveBeenCalled();
+
+      await runTaskRegistryMaintenance();
+
+      expect(closeAcpSession).toHaveBeenCalledWith({
+        cfg: {},
+        sessionKey: childSessionKey,
+        reason: "terminal-task-cleanup",
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

- keep spawned ACP runs under their canonical `acp` task owner while retaining a topology/control observer in the subagent registry
- stop ACP observer rows from creating duplicate `subagent` task projections, terminal delivery obligations, or child-session cleanup authority
- upgrade persisted legacy ACP mirrors during normalization and use the active ACP turn or canonical durable task as observer liveness
- emit a specific ACP owner-loss reason and preserve one-shot session state until a later corroborating maintenance pass

Fixes [GEN-6353](https://linear.app/genhealth/issue/GEN-6353/openclaw-loses-active-shrimp-acp-backing-sessions-after-the-legacy).

## What Problem This Solves

An ACP spawn created the canonical `runtime=acp` task, then the shared spawn pipeline registered the same run as a native subagent. The mirror's sweeper checked `getAgentRunContext`, which never represented external ACP liveness, so it false-failed after the stale grace and ran session-scoped cleanup. Task maintenance later treated only the process-local ACP turn marker as backing evidence, marked the canonical task lost after its grace, and could close the one-shot session in that same pass.

The observed production intervals match those two grace periods plus sweep cadence.

## Design

Patterns found and retained:

- the shared spawn registry remains the source for child topology, admission caps, status, and control
- the ACP manager/task registry remains the canonical lifecycle, progress, delivery, and cleanup owner
- observer ownership is persisted in the existing forward-compatible payload JSON; no SQLite schema change is required
- legacy ACP rows are recognized by their canonical ACP session key and normalized into observer-only state

Patterns intentionally not used:

- native subagent restart recovery and native `AgentRunContext` liveness, because Codex/ACP has a separate durable thread/session identity and resume contract
- deleting ACP rows from the subagent registry, which would regress topology and child controls
- immediate session deletion after declaring loss; cleanup now requires a later pass and rechecks the active turn

## Evidence

- `pnpm test src/agents/subagents/registry/subagent-delivery-state.test.ts src/agents/subagents/registry/subagent-registry-run-launch.test.ts src/agents/subagents/registry/subagent-registry-sweeper-recovery.test.ts src/agents/subagents/registry/subagent-run-liveness.test.ts src/agents/subagents/spawn/acp-spawn.test.ts src/tasks/task-registry.test.ts`
  - 239 tests passed across 3 Vitest shards
- `pnpm tsgo`
- `pnpm tsgo:test`
- scoped `oxlint` and `oxfmt --check`

`pnpm check:changed` could not run because the local Crabbox binary failed its built-in version/help sanity check; the equivalent scoped formatting, lint, type, and focused test checks above passed.
