### PR TITLE
fix(matrix): keep streamed replies visible when replacement fails

### DIFF
--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -234,7 +234,7 @@ The full config accepts `{ mode, chunkMode, block, preview, progress }`:
 Notes:
 
 - If a preview grows past Matrix's per-event size limit, OpenClaw stops preview streaming and falls back to final-only delivery.
-- Media replies always send attachments normally; if a stale preview cannot be reused safely, OpenClaw redacts it before sending the final media reply.
+- Media replies always send attachments normally. If a visible preview cannot be reused safely, OpenClaw keeps it until the complete replacement is confirmed and then redacts it. If replacement delivery fails, is partial, or produces no visible event, the preview remains visible.
 - Tool-progress preview updates are on by default when preview streaming is active. Set `streaming.preview.toolProgress: false` to keep preview edits for answer text but leave tool progress on the normal delivery path.
 - Preview edits cost extra Matrix API calls. Leave `streaming.mode: "off"` for the most conservative rate-limit profile.
 - Legacy scalar/boolean `streaming` values and the flat `blockStreaming` / `chunkMode` keys are rewritten to this nested shape by `openclaw doctor --fix`.

--- a/extensions/matrix/src/matrix/monitor/handler-draft-controller.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-draft-controller.ts
@@ -38,7 +38,8 @@ export async function createMatrixDraftController(params: {
     client,
     logVerboseMessage,
   } = params;
-  let draftConsumed = false;
+  type DraftDisposition = "active" | "retained" | "consumed";
+  let draftDisposition: DraftDisposition = "active";
 
   const draftStreamingEnabled = streaming !== "off";
   const quietDraftStreaming = streaming === "quiet" || streaming === "progress";
@@ -238,7 +239,7 @@ export async function createMatrixDraftController(params: {
   const resetDraftDeliveryState = async () => {
     await draftStream?.discardPending();
     draftStream?.reset();
-    draftConsumed = false;
+    draftDisposition = "active";
     currentDraftMessageGeneration = 0;
     currentDraftBlockOffset = 0;
     latestDraftFullText = "";
@@ -259,12 +260,15 @@ export async function createMatrixDraftController(params: {
     resetPreviewToolProgress,
     resetDraftDeliveryState,
     updateDraftFromLatestFullText,
-    isDraftConsumed: () => draftConsumed,
-    markDraftConsumed: () => {
-      draftConsumed = true;
+    draftDisposition: () => draftDisposition,
+    beginDraftGeneration: () => {
+      draftDisposition = "active";
     },
-    clearDraftConsumed: () => {
-      draftConsumed = false;
+    markDraftConsumed: () => {
+      draftDisposition = "consumed";
+    },
+    markDraftRetained: () => {
+      draftDisposition = "retained";
     },
     currentReplyToId: () => currentDraftReplyToId,
     setCurrentReplyToId: (replyToId: string | undefined) => {

--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
@@ -81,6 +81,15 @@ export function createMatrixReplyDispatcher(config: {
   const hasRepliedRef = { value: false };
   let finalReplyDeliveryFailed = false;
   let nonFinalReplyDeliveryFailed = false;
+  const beginNextBlockDraft = () => {
+    // Each block owns a new draft generation; prior retained/consumed state must not
+    // suppress settlement or cleanup for the next provider-visible event.
+    draftController.beginDraftGeneration();
+    draftController.advanceDraftBlockBoundary({ fallbackToLatestEnd: true });
+    draftStream?.reset();
+    draftController.resetReplyToIdForNextBlock();
+    draftController.updateDraftFromLatestFullText();
+  };
 
   const dispatcherOptions = {
     ...prefixOptions,
@@ -90,11 +99,7 @@ export function createMatrixReplyDispatcher(config: {
         result: MatrixReplyDeliveryResult,
       ): Promise<MatrixReplyDeliveryResult> => {
         if (info.kind === "block") {
-          draftController.clearDraftConsumed();
-          draftController.advanceDraftBlockBoundary({ fallbackToLatestEnd: true });
-          draftStream?.reset();
-          draftController.resetReplyToIdForNextBlock();
-          draftController.updateDraftFromLatestFullText();
+          beginNextBlockDraft();
 
           // Re-assert typing so the user still sees the indicator while
           // the next block generates.
@@ -122,16 +127,30 @@ export function createMatrixReplyDispatcher(config: {
           content,
         };
       };
-      const createSurvivingDraftDelivery = (
-        id: string,
-        redacted: boolean,
-      ): MatrixReplyDeliveryResult => {
-        const content = redacted ? undefined : draftStream?.content();
-        return content
-          ? // Failed redaction leaves an accepted provider event visible. Preserve it so
-            // settlement and retries cannot mistake a partial delivery for total failure.
-            createDraftDeliveryResult(id, content)
-          : mergeMatrixReplyDeliveryResults([]);
+      const settleDraftReplacement = async (params: {
+        draftEventId: string;
+        draftContent: string;
+        deliver: () => Promise<MatrixReplyDeliveryResult>;
+      }): Promise<MatrixReplyDeliveryResult> => {
+        const draftDelivery = createDraftDeliveryResult(params.draftEventId, params.draftContent);
+        let replacement: MatrixReplyDeliveryResult;
+        try {
+          replacement = await params.deliver();
+        } catch (error: unknown) {
+          draftController.markDraftRetained();
+          throw toMatrixPartialDeliveryError(error, [draftDelivery]);
+        }
+        if (!replacement.visibleReplySent) {
+          draftController.markDraftRetained();
+          return draftDelivery;
+        }
+        const draftRedacted = await redactMatrixDraftEvent(client, roomId, params.draftEventId);
+        if (!draftRedacted) {
+          draftController.markDraftRetained();
+          return mergeMatrixReplyDeliveryResults([draftDelivery, replacement]);
+        }
+        draftController.markDraftConsumed();
+        return replacement;
       };
       if (draftStream && info.kind !== "tool" && !payload.isCompactionNotice) {
         const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
@@ -143,7 +162,7 @@ export function createMatrixReplyDispatcher(config: {
             ? { ...payload, text: ttsSupplement.spokenText }
             : payload;
 
-        if (draftController.isDraftConsumed()) {
+        if (draftController.draftDisposition() !== "active") {
           await draftStream.discardPending();
           return await completeDelivery(
             await deliverMatrixReplies({
@@ -265,33 +284,32 @@ export function createMatrixReplyDispatcher(config: {
               },
             }),
             deliverNormally: async () => {
-              const draftRedacted = await redactMatrixDraftEvent(client, roomId, draftEventId);
-              const survivingDraft = createSurvivingDraftDelivery(draftEventId, draftRedacted);
-              let deliveredFallback: MatrixReplyDeliveryResult;
-              try {
-                deliveredFallback = await deliverMatrixReplies({
-                  cfg,
-                  replies: [fallbackPayload],
-                  roomId,
-                  client,
-                  runtime,
-                  textLimit,
-                  replyToMode,
-                  hasRepliedRef,
-                  threadId: threadTarget,
-                  replyToId: threadTarget ?? replyToEventId ?? undefined,
-                  accountId,
-                  mediaLocalRoots,
-                  tableMode,
-                });
-              } catch (error: unknown) {
-                throw toMatrixPartialDeliveryError(error, [survivingDraft]);
-              }
-              fallbackResult = mergeMatrixReplyDeliveryResults([survivingDraft, deliveredFallback]);
+              fallbackResult = await settleDraftReplacement({
+                draftEventId,
+                draftContent: draftStream.content() ?? preparedFinalPreviewContent,
+                deliver: async () =>
+                  await deliverMatrixReplies({
+                    cfg,
+                    replies: [fallbackPayload],
+                    roomId,
+                    client,
+                    runtime,
+                    textLimit,
+                    replyToMode,
+                    hasRepliedRef,
+                    threadId: threadTarget,
+                    replyToId: threadTarget ?? replyToEventId ?? undefined,
+                    accountId,
+                    mediaLocalRoots,
+                    tableMode,
+                  }),
+              });
               return fallbackResult.visibleReplySent;
             },
           });
-          draftController.markDraftConsumed();
+          if (previewResult.kind === "preview-finalized") {
+            draftController.markDraftConsumed();
+          }
           const settledResult =
             previewResult.kind === "preview-finalized" && previewResult.liveState?.receipt
               ? createDraftDeliveryResult(
@@ -351,9 +369,6 @@ export function createMatrixReplyDispatcher(config: {
           }
           const reusesDraftAsFinalText = Boolean(payloadText?.trim()) && textEditOk;
           const draftContent = draftStream.content();
-          const draftRedacted = reusesDraftAsFinalText
-            ? false
-            : await redactMatrixDraftEvent(client, roomId, draftEventId);
           const mediaPayload =
             ttsSupplement && reusesDraftAsFinalText
               ? buildTtsSupplementMediaPayload(payload)
@@ -370,12 +385,11 @@ export function createMatrixReplyDispatcher(config: {
           const previewDelivery =
             reusesDraftAsFinalText && providerDraftContent
               ? createDraftDeliveryResult(draftEventId, providerDraftContent)
-              : !draftRedacted && draftContent
+              : draftContent
                 ? createDraftDeliveryResult(draftEventId, draftContent)
                 : mergeMatrixReplyDeliveryResults([]);
-          let mediaDelivery: MatrixReplyDeliveryResult;
-          try {
-            mediaDelivery = await deliverMatrixReplies({
+          const deliverMedia = async () =>
+            await deliverMatrixReplies({
               cfg,
               replies: [mediaPayload],
               roomId,
@@ -390,13 +404,28 @@ export function createMatrixReplyDispatcher(config: {
               mediaLocalRoots,
               tableMode,
             });
-          } catch (error: unknown) {
-            throw toMatrixPartialDeliveryError(error, [previewDelivery]);
+          if (reusesDraftAsFinalText) {
+            draftController.markDraftConsumed();
+            let mediaDelivery: MatrixReplyDeliveryResult;
+            try {
+              mediaDelivery = await deliverMedia();
+            } catch (error: unknown) {
+              throw toMatrixPartialDeliveryError(error, [previewDelivery]);
+            }
+            return await completeDelivery(
+              mergeMatrixReplyDeliveryResults([previewDelivery, mediaDelivery]),
+            );
           }
-          draftController.markDraftConsumed();
-          return await completeDelivery(
-            mergeMatrixReplyDeliveryResults([previewDelivery, mediaDelivery]),
-          );
+          if (draftContent) {
+            return await completeDelivery(
+              await settleDraftReplacement({
+                draftEventId,
+                draftContent,
+                deliver: deliverMedia,
+              }),
+            );
+          }
+          return await completeDelivery(await deliverMedia());
         }
         const shouldRedactDraft =
           Boolean(draftEventId) &&
@@ -404,17 +433,8 @@ export function createMatrixReplyDispatcher(config: {
             payloadReplyMismatch ||
             mustDeliverFinalNormally ||
             draftFinalTextNeedsNormalMentionDelivery);
-        const draftRedacted =
-          shouldRedactDraft && draftEventId
-            ? await redactMatrixDraftEvent(client, roomId, draftEventId)
-            : false;
-        const survivingDraft =
-          shouldRedactDraft && draftEventId
-            ? createSurvivingDraftDelivery(draftEventId, draftRedacted)
-            : mergeMatrixReplyDeliveryResults([]);
-        let deliveredFallback: MatrixReplyDeliveryResult;
-        try {
-          deliveredFallback = await deliverMatrixReplies({
+        const deliverFallback = async () =>
+          await deliverMatrixReplies({
             cfg,
             replies: [fallbackPayload],
             roomId,
@@ -429,15 +449,17 @@ export function createMatrixReplyDispatcher(config: {
             mediaLocalRoots,
             tableMode,
           });
-        } catch (error: unknown) {
-          throw toMatrixPartialDeliveryError(error, [survivingDraft]);
+        const draftContent = draftStream.content();
+        if (shouldRedactDraft && draftEventId && draftContent) {
+          return await completeDelivery(
+            await settleDraftReplacement({
+              draftEventId,
+              draftContent,
+              deliver: deliverFallback,
+            }),
+          );
         }
-        if (shouldRedactDraft || deliveredFallback.visibleReplySent) {
-          draftController.markDraftConsumed();
-        }
-        return await completeDelivery(
-          mergeMatrixReplyDeliveryResults([survivingDraft, deliveredFallback]),
-        );
+        return await completeDelivery(await deliverFallback());
       }
       return await completeDelivery(
         await deliverMatrixReplies({
@@ -464,7 +486,7 @@ export function createMatrixReplyDispatcher(config: {
         nonFinalReplyDeliveryFailed = true;
       }
       if (info.kind === "block") {
-        draftController.advanceDraftBlockBoundary({ fallbackToLatestEnd: true });
+        beginNextBlockDraft();
       }
       runtime.error?.(`matrix ${info.kind} reply failed: ${String(err)}`);
     },

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -3914,18 +3914,6 @@ describe("matrix monitor handler draft streaming", () => {
 
       const result = await deliver(payload, { kind: "final" });
       await finish();
-      if (redactEventMock.mock.calls.length > 0) {
-        throw new Error(
-          [
-            "non-visible replacement redacted the visible draft",
-            `draftSendOrder=${sendSingleTextMessageMatrixMock.mock.invocationCallOrder[0] ?? "none"}`,
-            `redactionOrders=${redactEventMock.mock.invocationCallOrder.join(",")}`,
-            `replacementOrder=${deliverMatrixRepliesMock.mock.invocationCallOrder[0] ?? "none"}`,
-            `replacementResult=${JSON.stringify(result)}`,
-            `postHandlerRedactionCount=${redactEventMock.mock.calls.length}`,
-          ].join(" "),
-        );
-      }
 
       expect(result).toMatchObject({
         messageIds: ["$draft1"],
@@ -4030,7 +4018,7 @@ describe("matrix monitor handler draft streaming", () => {
   it.each(
     (["retained", "consumed"] as const).flatMap((priorDisposition) =>
       (["block", "followup"] as const).flatMap((boundary) =>
-        (["complete", "abort"] as const).map((outcome) => ({
+        (["complete", "unfinished"] as const).map((outcome) => ({
           priorDisposition,
           boundary,
           outcome,
@@ -4575,12 +4563,16 @@ describe("matrix monitor handler draft streaming", () => {
     await finish();
   });
 
-  it("stops draft stream on handler error (no leaked timer)", async () => {
+  it("stops quiet draft stream on handler error and cleans a draft accepted during shutdown", async () => {
     vi.useFakeTimers();
     try {
-      sendSingleTextMessageMatrixMock
-        .mockReset()
-        .mockResolvedValue({ messageId: "$draft1", roomId: "!room" });
+      let resolveDraftSend: ((value: { messageId: string; roomId: string }) => void) | undefined;
+      sendSingleTextMessageMatrixMock.mockReset().mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveDraftSend = resolve;
+          }),
+      );
       editMessageMatrixMock.mockReset().mockResolvedValue("$edited");
       deliverMatrixRepliesMock.mockReset().mockResolvedValue(createMockMatrixDeliveryResult());
       const redactEventMock = vi.fn(async () => "$redacted");
@@ -4600,18 +4592,20 @@ describe("matrix monitor handler draft streaming", () => {
           capturedReplyOpts = args?.replyOptions;
           // Simulate streaming then model error.
           capturedReplyOpts?.onPartialReply?.({ text: "partial" });
-          await waitForMatrixState(() => {
-            expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
-          });
           throw new Error("model timeout");
         }) as never,
       });
 
       // Handler should not throw (outer catch absorbs it).
-      await handler(
+      const handlerPromise = handler(
         "!room:example.org",
         createMatrixTextMessageEvent({ eventId: "$msg1", body: "hello" }),
       );
+      await waitForMatrixState(() => {
+        expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+      });
+      resolveDraftSend?.({ messageId: "$draft1", roomId: "!room" });
+      await handlerPromise;
 
       expect(redactEventMock).toHaveBeenCalledWith("!room:example.org", "$draft1");
 
@@ -4626,7 +4620,7 @@ describe("matrix monitor handler draft streaming", () => {
     }
   });
 
-  it("redacts partial live drafts when generation aborts mid-stream", async () => {
+  it("retains visible live drafts when generation aborts mid-stream", async () => {
     sendSingleTextMessageMatrixMock
       .mockReset()
       .mockResolvedValue({ messageId: "$draft1", roomId: "!room" });
@@ -4660,7 +4654,7 @@ describe("matrix monitor handler draft streaming", () => {
       createMatrixTextMessageEvent({ eventId: "$msg1", body: "hello" }),
     );
 
-    expect(redactEventMock).toHaveBeenCalledWith("!room:example.org", "$draft1");
+    expect(redactEventMock).not.toHaveBeenCalled();
   });
 
   it("keeps shutdown cleanup for empty final payloads that send nothing", async () => {

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { MAX_DATE_TIMESTAMP_MS } from "openclaw/plugin-sdk/number-runtime";
 import {
   testing as sessionBindingTesting,
@@ -2883,6 +2884,7 @@ describe("matrix monitor handler draft streaming", () => {
       spokenText?: string;
       ttsSupplement?: { spokenText: string; visibleTextAlreadyDelivered?: boolean };
       isCompactionNotice?: boolean;
+      isError?: boolean;
       replyToId?: string;
     },
     info: { kind: string },
@@ -2956,6 +2958,7 @@ describe("matrix monitor handler draft streaming", () => {
     accountConfig?: import("../../types.js").MatrixConfig;
   }) {
     let capturedDeliver: DeliverFn | undefined;
+    let capturedOnError: ((error: unknown, info: { kind: string }) => void) | undefined;
     let capturedReplyOpts: ReplyOpts | undefined;
     let resolveCaptured: (() => void) | undefined;
     const captured = new Promise<void>((resolve) => {
@@ -2992,6 +2995,7 @@ describe("matrix monitor handler draft streaming", () => {
       logVerboseMessage,
       createReplyDispatcherWithTyping: (params: Record<string, unknown> | undefined) => {
         capturedDeliver = params?.deliver as DeliverFn | undefined;
+        capturedOnError = params?.onError as typeof capturedOnError;
         notifyCaptured();
         return {
           dispatcher: {
@@ -3021,6 +3025,7 @@ describe("matrix monitor handler draft streaming", () => {
       await captured;
       return {
         deliver: capturedDeliver!,
+        onError: capturedOnError!,
         opts: capturedReplyOpts!,
         // Release the run gate and wait for the handler to finish
         // (including the finally block that stops the draft stream).
@@ -3408,7 +3413,7 @@ describe("matrix monitor handler draft streaming", () => {
     vi.useRealTimers();
   });
 
-  it("replaces Matrix tool-start progress when command output completes", async () => {
+  it("keeps Matrix tool progress free of terminal status text", async () => {
     vi.useFakeTimers();
     const { dispatch } = createStreamingHarness({
       streaming: "progress",
@@ -3437,7 +3442,7 @@ describe("matrix monitor handler draft streaming", () => {
     await vi.advanceTimersByTimeAsync(5_000);
 
     expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
-    expect(singleTextMessageBody()).toContain("install dependencies");
+    expect(singleTextMessageBody()).toContain("Exec");
 
     await opts.onItemEvent?.({
       itemId: "fc-call-2",
@@ -3463,7 +3468,7 @@ describe("matrix monitor handler draft streaming", () => {
         eventId === "$draft1" && typeof body === "string" && body.includes("completed"),
     );
     expect(completedEdit).toBeUndefined();
-    expect(singleTextMessageBody()).toContain("install dependencies");
+    expect(singleTextMessageBody()).toContain("Exec");
     vi.useRealTimers();
   });
 
@@ -3852,6 +3857,203 @@ describe("matrix monitor handler draft streaming", () => {
     });
     await finish();
   });
+
+  it.each([
+    { branch: "final-edit", payload: { text: "Final text" }, failEdit: true },
+    { branch: "media", payload: { mediaUrl: "https://example.com/image.png" }, failEdit: false },
+    { branch: "generic", payload: { text: "Something failed", isError: true }, failEdit: false },
+  ])("retains a visible draft when $branch replacement throws", async ({ payload, failEdit }) => {
+    const { dispatch, redactEventMock } = createStreamingHarness({ streaming: "partial" });
+    const { deliver, opts, finish } = await dispatch();
+
+    opts.onPartialReply?.({ text: "Visible preview" });
+    await waitForMatrixState(() => {
+      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+    });
+    if (failEdit) {
+      editMessageMatrixMock.mockRejectedValueOnce(new Error("final edit failed"));
+    }
+    deliverMatrixRepliesMock.mockRejectedValueOnce(new Error("replacement failed"));
+
+    const error = await deliver(payload, { kind: "final" }).catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      code: "CHANNEL_PARTIAL_DELIVERY",
+      deliveryResult: {
+        messageIds: ["$draft1"],
+        visibleReplySent: true,
+        content: "Visible preview",
+      },
+    });
+    expect(redactEventMock).not.toHaveBeenCalled();
+    await finish();
+    expect(redactEventMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { branch: "final-edit", payload: { text: "Final text" }, failEdit: true },
+    { branch: "media", payload: { mediaUrl: "https://example.com/image.png" }, failEdit: false },
+    { branch: "generic", payload: { text: "Something failed", isError: true }, failEdit: false },
+  ])(
+    "retains a visible draft when $branch replacement reports no visible event",
+    async ({ payload, failEdit }) => {
+      const { dispatch, redactEventMock } = createStreamingHarness({ streaming: "partial" });
+      const { deliver, opts, finish } = await dispatch();
+
+      opts.onPartialReply?.({ text: "Visible preview" });
+      await waitForMatrixState(() => {
+        expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+      });
+      if (failEdit) {
+        editMessageMatrixMock.mockRejectedValueOnce(new Error("final edit failed"));
+      }
+      deliverMatrixRepliesMock.mockResolvedValueOnce({
+        visibleReplySent: false,
+        suppression: { reason: "no_visible_result" },
+      });
+
+      const result = await deliver(payload, { kind: "final" });
+
+      expect(result).toMatchObject({
+        messageIds: ["$draft1"],
+        visibleReplySent: true,
+        content: "Visible preview",
+      });
+      expect(redactEventMock).not.toHaveBeenCalled();
+      await finish();
+      expect(redactEventMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { branch: "final-edit", payload: { text: "Final text" }, failEdit: true },
+    { branch: "media", payload: { mediaUrl: "https://example.com/image.png" }, failEdit: false },
+    { branch: "generic", payload: { text: "Something failed", isError: true }, failEdit: false },
+  ])(
+    "redacts a visible draft only after complete $branch replacement",
+    async ({ payload, failEdit }) => {
+      const { dispatch, redactEventMock } = createStreamingHarness({ streaming: "partial" });
+      const { deliver, opts, finish } = await dispatch();
+
+      opts.onPartialReply?.({ text: "Visible preview" });
+      await waitForMatrixState(() => {
+        expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+      });
+      if (failEdit) {
+        editMessageMatrixMock.mockRejectedValueOnce(new Error("final edit failed"));
+      }
+
+      const result = await deliver(payload, { kind: "final" });
+
+      expect(result).toMatchObject({ messageIds: ["$reply1"], visibleReplySent: true });
+      expect(deliverMatrixRepliesMock.mock.invocationCallOrder[0]).toBeLessThan(
+        redactEventMock.mock.invocationCallOrder[0]!,
+      );
+      expect(redactEventMock).toHaveBeenCalledExactlyOnceWith("!room:example.org", "$draft1");
+      await finish();
+      expect(redactEventMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each([
+    { branch: "final-edit", payload: { text: "Final text" }, failEdit: true },
+    { branch: "media", payload: { mediaUrl: "https://example.com/image.png" }, failEdit: false },
+    { branch: "generic", payload: { text: "Something failed", isError: true }, failEdit: false },
+  ])(
+    "combines a visible draft with accepted $branch replacement prefixes",
+    async ({ payload, failEdit }) => {
+      const { dispatch, redactEventMock } = createStreamingHarness({ streaming: "partial" });
+      const { deliver, opts, finish } = await dispatch();
+
+      opts.onPartialReply?.({ text: "Visible preview" });
+      await waitForMatrixState(() => {
+        expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+      });
+      if (failEdit) {
+        editMessageMatrixMock.mockRejectedValueOnce(new Error("final edit failed"));
+      }
+      deliverMatrixRepliesMock.mockRejectedValueOnce(
+        createChannelPartialDeliveryError(new Error("second replacement event failed"), {
+          ...createMockMatrixDeliveryResult("$accepted-prefix", "Accepted prefix"),
+          visibleReplySent: true as const,
+        }),
+      );
+
+      const error = await deliver(payload, { kind: "final" }).catch((caught: unknown) => caught);
+
+      expect(error).toMatchObject({
+        code: "CHANNEL_PARTIAL_DELIVERY",
+        deliveryResult: {
+          messageIds: ["$draft1", "$accepted-prefix"],
+          visibleReplySent: true,
+          content: "Visible preview\nAccepted prefix",
+        },
+      });
+      expect(redactEventMock).not.toHaveBeenCalled();
+      await finish();
+      expect(redactEventMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("reports both visible events when post-replacement redaction fails", async () => {
+    const { dispatch, redactEventMock } = createStreamingHarness({ streaming: "partial" });
+    const { deliver, opts, finish } = await dispatch();
+
+    opts.onPartialReply?.({ text: "Visible preview" });
+    await waitForMatrixState(() => {
+      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+    });
+    redactEventMock.mockRejectedValueOnce(new Error("redaction failed"));
+
+    const result = await deliver({ text: "Something failed", isError: true }, { kind: "final" });
+
+    expect(result).toMatchObject({
+      messageIds: ["$draft1", "$reply1"],
+      visibleReplySent: true,
+      content: "Visible preview\ndelivered",
+    });
+    await finish();
+    expect(redactEventMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([{ branch: "followup" }, { branch: "block" }])(
+    "starts an active draft generation after a retained $branch boundary",
+    async ({ branch }) => {
+      const { dispatch, redactEventMock } = createStreamingHarness({ streaming: "partial" });
+      const { deliver, onError, opts, finish } = await dispatch();
+
+      opts.onPartialReply?.({ text: "Retained preview" });
+      await waitForMatrixState(() => {
+        expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+      });
+      deliverMatrixRepliesMock.mockRejectedValueOnce(new Error("replacement failed"));
+      if (branch === "block") {
+        await opts.onBlockReplyQueued?.({ text: "Retained preview" });
+      }
+      await deliver(
+        { text: "Something failed", isError: true },
+        { kind: branch === "block" ? "block" : "final" },
+      ).catch(() => undefined);
+      if (branch === "followup") {
+        await opts.onQueuedFollowupAdmitted?.();
+      } else {
+        onError(new Error("replacement failed"), { kind: "block" });
+        opts.onAssistantMessageStart?.();
+      }
+
+      sendSingleTextMessageMatrixMock.mockResolvedValueOnce({
+        messageId: "$draft2",
+        roomId: "!room",
+      });
+      opts.onPartialReply?.({ text: "Next generation" });
+      await waitForMatrixState(() => {
+        expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(2);
+      });
+      await finish();
+
+      expect(redactEventMock).toHaveBeenCalledExactlyOnceWith("!room:example.org", "$draft2");
+    },
+  );
 
   it("falls back with visible text when TTS supplement preview has no event id", async () => {
     const { dispatch, redactEventMock } = createStreamingHarness({

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -3913,13 +3913,23 @@ describe("matrix monitor handler draft streaming", () => {
       });
 
       const result = await deliver(payload, { kind: "final" });
+      if (redactEventMock.mock.calls.length > 0) {
+        throw new Error(
+          [
+            "non-visible replacement redacted the visible draft",
+            `draftSendOrder=${sendSingleTextMessageMatrixMock.mock.invocationCallOrder[0] ?? "none"}`,
+            `redactionOrder=${redactEventMock.mock.invocationCallOrder[0] ?? "none"}`,
+            `replacementOrder=${deliverMatrixRepliesMock.mock.invocationCallOrder[0] ?? "none"}`,
+            `replacementResult=${JSON.stringify(result)}`,
+          ].join(" "),
+        );
+      }
 
       expect(result).toMatchObject({
         messageIds: ["$draft1"],
         visibleReplySent: true,
         content: "Visible preview",
       });
-      expect(redactEventMock).not.toHaveBeenCalled();
       await finish();
       expect(redactEventMock).not.toHaveBeenCalled();
     },
@@ -4016,28 +4026,47 @@ describe("matrix monitor handler draft streaming", () => {
     expect(redactEventMock).toHaveBeenCalledTimes(1);
   });
 
-  it.each([{ branch: "followup" }, { branch: "block" }])(
-    "starts an active draft generation after a retained $branch boundary",
-    async ({ branch }) => {
+  it.each(
+    (["retained", "consumed"] as const).flatMap((priorDisposition) =>
+      (["block", "followup"] as const).flatMap((boundary) =>
+        (["complete", "abort"] as const).map((outcome) => ({
+          priorDisposition,
+          boundary,
+          outcome,
+        })),
+      ),
+    ),
+  )(
+    "settles $priorDisposition then $boundary draft generations through $outcome",
+    async ({ priorDisposition, boundary, outcome }) => {
       const { dispatch, redactEventMock } = createStreamingHarness({ streaming: "partial" });
       const { deliver, onError, opts, finish } = await dispatch();
 
-      opts.onPartialReply?.({ text: "Retained preview" });
+      opts.onPartialReply?.({ text: "First generation" });
       await waitForMatrixState(() => {
         expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
       });
-      deliverMatrixRepliesMock.mockRejectedValueOnce(new Error("replacement failed"));
-      if (branch === "block") {
-        await opts.onBlockReplyQueued?.({ text: "Retained preview" });
+      if (priorDisposition === "retained") {
+        deliverMatrixRepliesMock.mockRejectedValueOnce(new Error("replacement failed"));
       }
-      await deliver(
-        { text: "Something failed", isError: true },
-        { kind: branch === "block" ? "block" : "final" },
-      ).catch(() => undefined);
-      if (branch === "followup") {
+      if (boundary === "block") {
+        await opts.onBlockReplyQueued?.({ text: "First generation" });
+      }
+      const firstDelivery = deliver(
+        { text: "First replacement", isError: true },
+        { kind: boundary === "block" ? "block" : "final" },
+      );
+      if (priorDisposition === "retained") {
+        await firstDelivery.catch(() => undefined);
+      } else {
+        await firstDelivery;
+      }
+      if (boundary === "followup") {
         await opts.onQueuedFollowupAdmitted?.();
       } else {
-        onError(new Error("replacement failed"), { kind: "block" });
+        if (priorDisposition === "retained") {
+          onError(new Error("replacement failed"), { kind: "block" });
+        }
         opts.onAssistantMessageStart?.();
       }
 
@@ -4049,9 +4078,22 @@ describe("matrix monitor handler draft streaming", () => {
       await waitForMatrixState(() => {
         expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(2);
       });
+      if (outcome === "complete") {
+        await deliver({ text: "Second replacement", isError: true }, { kind: "final" });
+      }
       await finish();
 
-      expect(redactEventMock).toHaveBeenCalledExactlyOnceWith("!room:example.org", "$draft2");
+      const redactedEventIds = redactEventMock.mock.calls.map(([, eventId]) => eventId);
+      expect(redactedEventIds.filter((eventId) => eventId === "$draft1")).toHaveLength(
+        priorDisposition === "consumed" ? 1 : 0,
+      );
+      expect(redactedEventIds.filter((eventId) => eventId === "$draft2")).toHaveLength(1);
+      expect(deliverMatrixRepliesMock).toHaveBeenCalledTimes(outcome === "complete" ? 2 : 1);
+      if (outcome === "complete") {
+        expect(deliverMatrixRepliesMock.mock.invocationCallOrder[1]).toBeLessThan(
+          redactEventMock.mock.invocationCallOrder.at(-1)!,
+        );
+      }
     },
   );
 

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -4083,7 +4083,9 @@ describe("matrix monitor handler draft streaming", () => {
       }
       await finish();
 
-      const redactedEventIds = redactEventMock.mock.calls.map(([, eventId]) => eventId);
+      const redactedEventIds = mockCalls(redactEventMock, "redactEvent").map(
+        ([, eventId]) => eventId,
+      );
       expect(redactedEventIds.filter((eventId) => eventId === "$draft1")).toHaveLength(
         priorDisposition === "consumed" ? 1 : 0,
       );

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -3913,14 +3913,16 @@ describe("matrix monitor handler draft streaming", () => {
       });
 
       const result = await deliver(payload, { kind: "final" });
+      await finish();
       if (redactEventMock.mock.calls.length > 0) {
         throw new Error(
           [
             "non-visible replacement redacted the visible draft",
             `draftSendOrder=${sendSingleTextMessageMatrixMock.mock.invocationCallOrder[0] ?? "none"}`,
-            `redactionOrder=${redactEventMock.mock.invocationCallOrder[0] ?? "none"}`,
+            `redactionOrders=${redactEventMock.mock.invocationCallOrder.join(",")}`,
             `replacementOrder=${deliverMatrixRepliesMock.mock.invocationCallOrder[0] ?? "none"}`,
             `replacementResult=${JSON.stringify(result)}`,
+            `postHandlerRedactionCount=${redactEventMock.mock.calls.length}`,
           ].join(" "),
         );
       }
@@ -3930,7 +3932,6 @@ describe("matrix monitor handler draft streaming", () => {
         visibleReplySent: true,
         content: "Visible preview",
       });
-      await finish();
       expect(redactEventMock).not.toHaveBeenCalled();
     },
   );

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -611,6 +611,14 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       );
       await commitInboundEventIfClaimed();
     } catch (err) {
+      const draftController = draftControllerRef;
+      if (
+        draftController?.draftStream?.eventId() &&
+        draftController.draftDisposition() === "active"
+      ) {
+        // A Matrix-accepted preview is the only visible reply after an abort.
+        draftController.markDraftRetained();
+      }
       runtime.error?.(`matrix handler failed: ${String(err)}`);
     } finally {
       // Stop the draft stream timer so partial drafts don't leak if the

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -618,7 +618,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       const draftStream = draftControllerRef?.draftStream;
       if (draftStream) {
         const draftEventId = await draftStream.stop().catch(() => undefined);
-        if (draftEventId && draftControllerRef?.isDraftConsumed() !== true) {
+        if (draftEventId && draftControllerRef?.draftDisposition() === "active") {
           await redactMatrixDraftEvent(client, roomId, draftEventId);
         }
       }

--- a/extensions/qa-lab/src/live-transports/matrix/matrix-scenario-flows.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/matrix-scenario-flows.test.ts
@@ -77,7 +77,7 @@ describe("Matrix QA Lab scenario flows", () => {
 
   it("expands every Matrix module call through the shared flow host", () => {
     const bindings = new Set<string>();
-    expect(scenarios).toHaveLength(82);
+    expect(scenarios).toHaveLength(83);
     for (const scenario of scenarios) {
       expect(scenario.execution.kind, scenario.id).toBe("flow");
       if (scenario.execution.kind !== "flow") {
@@ -98,7 +98,7 @@ describe("Matrix QA Lab scenario flows", () => {
         "result.details ?? (result.artifacts ? JSON.stringify(result.artifacts, null, 2) : undefined)",
       );
     }
-    expect(bindings.size).toBe(82);
+    expect(bindings.size).toBe(83);
   });
 
   it("prepares the shared canary only for canary-dependent scenarios", () => {

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-room.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-room.ts
@@ -45,6 +45,7 @@ export {
 export {
   runPartialStreamingPreviewScenario,
   runQuietStreamingPreviewScenario,
+  runStreamingReplacementRetentionScenario,
 } from "./scenario-runtime-streaming-preview.js";
 
 export {

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-streaming-preview.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-streaming-preview.ts
@@ -33,6 +33,163 @@ export async function runPartialStreamingPreviewScenario(context: MatrixQaScenar
   });
 }
 
+const MATRIX_REPLACEMENT_FAULT_RULE_ID = "matrix-streaming-replacement-failure";
+
+export async function runStreamingReplacementRetentionScenario(
+  context: MatrixQaScenarioContext,
+): Promise<MatrixQaScenarioExecution> {
+  if (!context.installFaultRule) {
+    throw new Error("Matrix streaming replacement QA requires in-place fault injection");
+  }
+  const { client, startSince } = await primeMatrixQaDriverScenarioClient(context);
+  const firstText = `@room ${buildMatrixStreamingPreviewFinalText("MATRIX_QA_RETAINED_DRAFT")}`;
+  const firstToken = firstText.split(" ")[1]!;
+  const firstDriverEventId = await client.sendTextMessage({
+    body: buildMatrixPartialStreamingPrompt(context.sutUserId, firstText),
+    mentionUserIds: [context.sutUserId],
+    roomId: context.roomId,
+  });
+  const firstPreview = await client
+    .waitForRoomEvent({
+      observedEvents: context.observedEvents,
+      predicate: (event) =>
+        event.roomId === context.roomId &&
+        event.sender === context.sutUserId &&
+        isMatrixQaMessageLikeKind(event.kind) &&
+        event.body?.includes(firstToken) === true &&
+        event.body !== firstText,
+      roomId: context.roomId,
+      since: startSince,
+      timeoutMs: context.timeoutMs,
+    })
+    .catch((error: unknown) => {
+      throw new Error("Matrix replacement QA timed out waiting for the first draft", {
+        cause: error,
+      });
+    });
+  const firstDraftEventId = firstPreview.event.replacesEventId ?? firstPreview.event.eventId;
+  const faultRule = context.installFaultRule({
+    id: MATRIX_REPLACEMENT_FAULT_RULE_ID,
+    match: (request) =>
+      request.bearerToken === context.sutAccessToken &&
+      request.path.includes("/send/m.room.message/"),
+    response: () => ({
+      body: { errcode: "M_UNKNOWN", error: "Matrix QA injected replacement failure" },
+      status: 503,
+    }),
+  });
+  let firstWindow;
+  try {
+    firstWindow = await client.waitForOptionalRoomEvent({
+      observedEvents: context.observedEvents,
+      predicate: (event) =>
+        event.roomId === context.roomId &&
+        event.sender === context.sutUserId &&
+        (event.redactsEventId === firstDraftEventId || event.body === firstText),
+      roomId: context.roomId,
+      since: firstPreview.since,
+      timeoutMs: Math.min(8_000, context.timeoutMs),
+    });
+    if (firstWindow.matched) {
+      throw new Error(`Matrix failed replacement did not retain draft ${firstDraftEventId}`);
+    }
+    if (faultRule.hits().length === 0) {
+      throw new Error("Matrix replacement fault rule did not observe a replacement request");
+    }
+  } finally {
+    faultRule.remove();
+  }
+
+  const secondText = `@room ${buildMatrixStreamingPreviewFinalText("MATRIX_QA_SUPERSEDED_DRAFT")}`;
+  const secondToken = secondText.split(" ")[1]!;
+  const secondDriverEventId = await client.sendTextMessage({
+    body: buildMatrixPartialStreamingPrompt(context.sutUserId, secondText),
+    mentionUserIds: [context.sutUserId],
+    roomId: context.roomId,
+  });
+  const secondPreview = await client
+    .waitForRoomEvent({
+      observedEvents: context.observedEvents,
+      predicate: (event) =>
+        event.roomId === context.roomId &&
+        event.sender === context.sutUserId &&
+        isMatrixQaMessageLikeKind(event.kind) &&
+        event.body?.includes(secondToken) === true &&
+        event.eventId !== firstPreview.event.eventId &&
+        event.body !== secondText,
+      roomId: context.roomId,
+      since: firstWindow.since,
+      timeoutMs: context.timeoutMs,
+    })
+    .catch((error: unknown) => {
+      throw new Error("Matrix replacement QA timed out waiting for the second draft", {
+        cause: error,
+      });
+    });
+  const secondDraftEventId = secondPreview.event.replacesEventId ?? secondPreview.event.eventId;
+  const secondReply = await client
+    .waitForRoomEvent({
+      observedEvents: context.observedEvents,
+      predicate: (event) =>
+        event.roomId === context.roomId &&
+        event.sender === context.sutUserId &&
+        isMatrixQaMessageLikeKind(event.kind) &&
+        event.eventId !== secondDraftEventId &&
+        event.replacesEventId === undefined,
+      roomId: context.roomId,
+      since: secondPreview.since,
+      timeoutMs: context.timeoutMs,
+    })
+    .catch((error: unknown) => {
+      throw new Error("Matrix replacement QA timed out waiting for the healthy replacement", {
+        cause: error,
+      });
+    });
+  const secondRedaction = await client
+    .waitForRoomEvent({
+      observedEvents: context.observedEvents,
+      predicate: (event) =>
+        event.roomId === context.roomId &&
+        event.sender === context.sutUserId &&
+        event.kind === "redaction",
+      roomId: context.roomId,
+      since: secondReply.since,
+      timeoutMs: context.timeoutMs,
+    })
+    .catch((error: unknown) => {
+      throw new Error("Matrix replacement QA timed out waiting for post-replacement redaction", {
+        cause: error,
+      });
+    });
+  if (secondRedaction.event.redactsEventId === firstDraftEventId) {
+    throw new Error("Matrix healthy replacement redacted the retained first-generation draft");
+  }
+  advanceMatrixQaActorCursor({
+    actorId: "driver",
+    syncState: context.syncState,
+    nextSince: secondRedaction.since,
+    startSince,
+  });
+  return {
+    artifacts: {
+      faultHitCount: faultRule.hits().length,
+      faultRuleId: MATRIX_REPLACEMENT_FAULT_RULE_ID,
+      firstDriverEventId,
+      previewEventId: firstDraftEventId,
+      redactionEventId: secondRedaction.event.eventId,
+      secondDriverEventId,
+      secondReply: buildMatrixReplyArtifact(secondReply.event, secondText),
+    },
+    details: [
+      `retained draft event: ${firstDraftEventId}`,
+      `replacement fault hits: ${faultRule.hits().length}`,
+      `second draft event: ${secondDraftEventId}`,
+      `second replacement event: ${secondReply.event.eventId}`,
+      `second redaction event: ${secondRedaction.event.eventId}`,
+    ].join("\n"),
+  } satisfies MatrixQaScenarioExecution;
+}
+
 function buildMatrixStreamingPreviewFinalText(prefix: string) {
   const token = `${prefix}_${randomUUID().slice(0, 8).toUpperCase()}`;
   return [

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-streaming-preview.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-streaming-preview.ts
@@ -134,7 +134,7 @@ export async function runStreamingReplacementRetentionScenario(
         event.roomId === context.roomId &&
         event.sender === context.sutUserId &&
         isMatrixQaMessageLikeKind(event.kind) &&
-        doesMatrixQaReplyBodyMatchToken(event, secondText) &&
+        event.body?.includes(secondToken) === true &&
         event.eventId !== secondDraftEventId &&
         event.replacesEventId === undefined,
       roomId: context.roomId,
@@ -198,7 +198,8 @@ export async function runStreamingReplacementRetentionScenario(
       redactionEventId: secondRedaction.event.eventId,
       redactionTargetEventId: secondRedaction.event.redactsEventId,
       secondDriverEventId,
-      secondReply: buildMatrixReplyArtifact(secondReply.event, secondText),
+      secondReply: buildMatrixReplyArtifact(secondReply.event),
+      secondToken,
     },
     details: [
       `retained draft event: ${firstDraftEventId}`,

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-streaming-preview.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-streaming-preview.ts
@@ -134,6 +134,7 @@ export async function runStreamingReplacementRetentionScenario(
         event.roomId === context.roomId &&
         event.sender === context.sutUserId &&
         isMatrixQaMessageLikeKind(event.kind) &&
+        doesMatrixQaReplyBodyMatchToken(event, secondText) &&
         event.eventId !== secondDraftEventId &&
         event.replacesEventId === undefined,
       roomId: context.roomId,
@@ -161,13 +162,30 @@ export async function runStreamingReplacementRetentionScenario(
         cause: error,
       });
     });
-  if (secondRedaction.event.redactsEventId === firstDraftEventId) {
-    throw new Error("Matrix healthy replacement redacted the retained first-generation draft");
+  if (secondRedaction.event.redactsEventId !== secondDraftEventId) {
+    throw new Error(
+      `Matrix healthy replacement redacted ${secondRedaction.event.redactsEventId ?? "<unknown>"} instead of its own draft ${secondDraftEventId}`,
+    );
+  }
+  const duplicateRedaction = await client.waitForOptionalRoomEvent({
+    observedEvents: context.observedEvents,
+    predicate: (event) =>
+      event.roomId === context.roomId &&
+      event.sender === context.sutUserId &&
+      event.kind === "redaction",
+    roomId: context.roomId,
+    since: secondRedaction.since,
+    timeoutMs: Math.min(8_000, context.timeoutMs),
+  });
+  if (duplicateRedaction.matched) {
+    throw new Error(
+      `Matrix healthy replacement emitted a second redaction ${duplicateRedaction.event.eventId}`,
+    );
   }
   advanceMatrixQaActorCursor({
     actorId: "driver",
     syncState: context.syncState,
-    nextSince: secondRedaction.since,
+    nextSince: duplicateRedaction.since,
     startSince,
   });
   return {
@@ -176,7 +194,9 @@ export async function runStreamingReplacementRetentionScenario(
       faultRuleId: MATRIX_REPLACEMENT_FAULT_RULE_ID,
       firstDriverEventId,
       previewEventId: firstDraftEventId,
+      redactionCount: 1,
       redactionEventId: secondRedaction.event.eventId,
+      redactionTargetEventId: secondRedaction.event.redactsEventId,
       secondDriverEventId,
       secondReply: buildMatrixReplyArtifact(secondReply.event, secondText),
     },
@@ -186,6 +206,8 @@ export async function runStreamingReplacementRetentionScenario(
       `second draft event: ${secondDraftEventId}`,
       `second replacement event: ${secondReply.event.eventId}`,
       `second redaction event: ${secondRedaction.event.eventId}`,
+      `second redaction target: ${secondRedaction.event.redactsEventId}`,
+      "healthy replacement redaction count: 1",
     ].join("\n"),
   } satisfies MatrixQaScenarioExecution;
 }

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-types.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-types.ts
@@ -72,6 +72,8 @@ type MatrixQaScenarioArtifacts = {
   reactionEventId?: string;
   reactionTargetEventId?: string;
   redactionEventId?: string;
+  redactionTargetEventId?: string;
+  redactionCount?: number;
   reply?: MatrixQaReplyArtifact;
   replies?: Array<{
     eventId: string;

--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -27,7 +27,7 @@ describe("qa scenario catalog channel contracts", () => {
       (scenario) => scenario.execution.flowKind === "module",
     );
 
-    expect(moduleFlows).toHaveLength(143);
+    expect(moduleFlows).toHaveLength(144);
     expect(moduleFlows.every((scenario) => scenario.execution.flow)).toBe(true);
   });
 

--- a/qa/scenarios/channels/matrix-streaming-replacement-retention.yaml
+++ b/qa/scenarios/channels/matrix-streaming-replacement-retention.yaml
@@ -1,0 +1,24 @@
+title: Matrix streaming replacement retention
+scenario:
+  id: matrix-streaming-replacement-retention
+  surface: channels
+  coverage:
+    primary:
+      - matrix.conversation-routing-and-delivery
+  docsRefs:
+    - docs/channels/matrix.md
+  execution:
+    kind: flow
+    channel: matrix
+    timeoutMs: 90000
+    retryCount: 0
+    config:
+      matrixConfigOverrides:
+        streaming: partial
+        textChunkLimit: 160
+
+flow:
+  module: ./live-transports/matrix/scenarios/scenario-runtime-room.js
+  call: runStreamingReplacementRetentionScenario
+  args:
+    - expr: "scenarioContext"


### PR DESCRIPTION
Closes #122498

## What Problem This Solves

Matrix could redact a visible streaming preview before its required final replacement was known to be visible. A failed, partial, suppressed, or aborted replacement path could therefore leave the user with no visible assistant reply.

## Why This Change Was Made

Matrix now settles every non-reusable preview through one plugin-owned path. It attempts replacement delivery first, retains and reports the preview for raw, partial, or non-visible outcomes, and redacts only after a complete visible replacement. The draft controller records each generation as active, retained, or consumed.

The outer handler now records an already accepted active preview as retained when the model or handler aborts. Final cleanup still stops the stream timer and still redacts a draft that was not accepted until shutdown, so unfinished hidden work does not leak into the room.

## User Impact

Matrix users keep the last visible streamed preview when final replacement delivery or the enclosing turn fails instead of seeing it disappear. Successful replacements still remove the superseded preview, in-place finalization is unchanged, and no configuration or migration is required.

## Evidence

- The focused handler-abort regression failed before the owner fix because cleanup redacted `$draft1`; it passes after the catch records the accepted preview as retained.
- Local owner/sibling proof: Matrix handler/controller/draft-stream 191 tests passed; shared live-preview lifecycle 17 tests passed; QA flow/catalog 28 tests passed.
- The retained/consumed generation table covers block and follow-up boundaries through complete and unfinished shutdown outcomes; the real exception path is covered separately by the model-timeout handler regression.
- Disposable Tuwunel + real Matrix plugin + Gateway fault-injection scenario passed 1/1 on trusted Testbox: https://github.com/openclaw/openclaw/actions/runs/31656013611
- Full changed gate passed on trusted Testbox, including all-project typecheck, lint, formatting, plugin boundaries, dead-code and import-cycle guards: https://github.com/openclaw/openclaw/actions/runs/31656210774
- Exact branch autoreview reported no accepted/actionable findings (`patch is correct`, confidence 0.96).

## Change Size

Production Matrix runtime: +114/-80 (net +34). Tests and QA evidence/support: +464/-16. Docs: +1/-1.

The positive runtime delta replaces three pre-redaction branches with one canonical settlement helper and adds the disposition transition needed to preserve accepted previews across replacement failures, generation boundaries, and handler aborts.
