### PR TITLE
ci: fingerprint preferred pnpm hooks

### DIFF
--- a/.github/actions/setup-node-env/dependency-fingerprint.mjs
+++ b/.github/actions/setup-node-env/dependency-fingerprint.mjs
@@ -35,6 +35,7 @@ const INSTALL_INPUT_FILES = [
   "pnpm-lock.yaml",
   "pnpm-workspace.yaml",
   ".npmrc",
+  ".pnpmfile.mjs",
   ".pnpmfile.cjs",
   "pnpmfile.cjs",
   ".github/actions/setup-node-env/dependency-fingerprint.mjs",

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -3516,6 +3516,17 @@ printf '%s\n' "$((usage + count * 4096))" > "$OPENCLAW_TEST_USAGE_FILE"
       rmSync(path.join(root, ".pnpmfile.cjs"));
       expect(fingerprint()).toBe(baseline);
 
+      writeFileSync(path.join(root, ".pnpmfile.mjs"), "export const hooks = {};\n");
+      const mjsHookFingerprint = fingerprint();
+      expect(mjsHookFingerprint).not.toBe(baseline);
+      writeFileSync(
+        path.join(root, ".pnpmfile.mjs"),
+        "export const hooks = { readPackage: (pkg) => pkg };\n",
+      );
+      expect(fingerprint()).not.toBe(mjsHookFingerprint);
+      rmSync(path.join(root, ".pnpmfile.mjs"));
+      expect(fingerprint()).toBe(baseline);
+
       mkdirSync(path.join(root, "scripts"), { recursive: true });
       writeFileSync(path.join(root, "scripts", "prepare-git-hooks.mjs"), "export {};\n");
       expect(fingerprint()).not.toBe(baseline);


### PR DESCRIPTION
Closes #122838
Follow-up to #122839.

AI-assisted.

## What Problem This Solves

Fixes an issue where a future tracked `.pnpmfile.mjs` hook could change dependency resolution without invalidating canonical `main`'s protected dependency snapshot. pnpm 11.15.1 automatically prefers that MJS hook over `.pnpmfile.cjs`, but the dependency fingerprint omitted it.

## Why This Change Was Made

The existing install-input owner now hashes pnpm's preferred default MJS hook filename alongside the already-covered CJS names. The existing behavioral fingerprint test proves add, content-change, and removal invalidation; no workflow, fanout, coverage, runner, timeout, or concurrency changes.

## User Impact

Canonical-main CI keeps the metadata-only warm-snapshot optimization from #122839 without serving stale dependencies if the repository later adopts pnpm's preferred MJS hook format.

## Evidence

- Exact pnpm `v11.15.1` source (`pnpm11/hooks/pnpmfile/src/requireHooks.ts`) probes `.pnpmfile.mjs` first and falls back to `.pnpmfile.cjs`; hooks such as `readPackage`, `preResolution`, `afterAllResolved`, `updateConfig`, and `importPackage` can change install output.
- Pre-fix focused reproduction: adding a tracked MJS `readPackage` hook left the fingerprint unchanged (`equal=true`).
- Post-fix same reproduction: fingerprint changes (`equal=false`).
- Node 24 / `CI=1`: `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` — 117/117 passed.
- Targeted oxfmt, oxlint, and `git diff --check` passed.
- Structured autoreview could not start because no isolated Codex/Claude/Pi reviewer executable is installed in this orb; independent exact-head review will be requested.
- No Crabbox or Testbox execution was used.
