### PR TITLE
test(channels): stop the --use-env contract tests loading a real bundled plugin [AI]

### DIFF
--- a/extensions/buzz/src/setup-core.test.ts
+++ b/extensions/buzz/src/setup-core.test.ts
@@ -7,6 +7,13 @@ describe("buzzSetupContract", () => {
     vi.unstubAllEnvs();
   });
 
+  // Core rejects headless setup from this declaration; dropping it silently
+  // restores the pre-#122530 behavior of writing an unusable Buzz account.
+  it("declares BUZZ_PRIVATE_KEY as the --use-env contract", () => {
+    const useEnvField = buzzSetupContract.metadata.fields.find((field) => field.key === "useEnv");
+    expect(useEnvField).toMatchObject({ envVars: ["BUZZ_PRIVATE_KEY"] });
+  });
+
   it("removes a stored private key when switching to BUZZ_PRIVATE_KEY", () => {
     vi.stubEnv("BUZZ_PRIVATE_KEY", "22".repeat(32));
     const cfg = {

--- a/extensions/telegram/src/setup-surface.test.ts
+++ b/extensions/telegram/src/setup-surface.test.ts
@@ -2,7 +2,11 @@
 import { installChannelDmPolicyContractSuite } from "openclaw/plugin-sdk/channel-test-helpers";
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/setup";
 import { describe, expect, it, vi } from "vitest";
-import { promptTelegramAllowFromForAccount, telegramSetupAdapter } from "./setup-core.js";
+import {
+  promptTelegramAllowFromForAccount,
+  telegramSetupAdapter,
+  telegramSetupContract,
+} from "./setup-core.js";
 import {
   buildTelegramDmAccessWarningLines,
   ensureTelegramDefaultGroupMentionGate,
@@ -15,6 +19,15 @@ describe("Telegram setup promotion contract", () => {
   it("exposes webhookSecret without widening named-account promotion", () => {
     expect(telegramSetupAdapter.singleAccountKeysToMove).toEqual(["streaming", "webhookSecret"]);
     expect(telegramSetupAdapter.namedAccountPromotionKeys).toEqual(["botToken", "tokenFile"]);
+  });
+
+  // Core rejects headless setup from this declaration; dropping it silently
+  // restores the pre-#122530 behavior of writing an unusable Telegram account.
+  it("declares TELEGRAM_BOT_TOKEN as the --use-env contract", () => {
+    const useEnvField = telegramSetupContract.metadata.fields.find(
+      (field) => field.key === "useEnv",
+    );
+    expect(useEnvField).toMatchObject({ envVars: ["TELEGRAM_BOT_TOKEN"] });
   });
 });
 

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -540,16 +540,38 @@ describe("channelsAddCommand", () => {
     expect(channelWizardMocks.setupChannels).not.toHaveBeenCalled();
   });
 
-  it("rejects --use-env when every declared env var is missing", async () => {
-    vi.stubEnv("TYPED_CHAT_TOKEN", "");
-    vi.stubEnv("TYPED_CHAT_SECRET", "");
+  // A declared contract without `envVarMode: "any"` is all-required, so a partially supplied
+  // environment must reject too. Covering only the both-missing case would still pass if that
+  // check regressed to rejecting solely when nothing at all is set.
+  it.each([
+    {
+      case: "every declared env var is missing",
+      token: "",
+      secret: "",
+      missing: ["TYPED_CHAT_TOKEN", "TYPED_CHAT_SECRET"],
+    },
+    {
+      case: "only the trailing declared env var is missing",
+      token: "typed-chat-token",
+      secret: "",
+      missing: ["TYPED_CHAT_SECRET"],
+    },
+    {
+      case: "only the leading declared env var is missing",
+      token: "",
+      secret: "typed-chat-secret",
+      missing: ["TYPED_CHAT_TOKEN"],
+    },
+  ])("rejects --use-env when $case", async ({ token, secret, missing }) => {
+    vi.stubEnv("TYPED_CHAT_TOKEN", token);
+    vi.stubEnv("TYPED_CHAT_SECRET", secret);
     registerEnvContractSetupPlugin(["TYPED_CHAT_TOKEN", "TYPED_CHAT_SECRET"]);
     configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot });
 
     await channelsAddCommand({ channel: "typed-chat", useEnv: true }, runtime, { hasFlags: true });
 
-    for (const missing of ["TYPED_CHAT_TOKEN", "TYPED_CHAT_SECRET"]) {
-      expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining(missing));
+    for (const name of missing) {
+      expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining(name));
     }
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(configMocks.writeConfigFile).not.toHaveBeenCalled();

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -1,5 +1,4 @@
 // Channels add tests cover guided setup, plugin install paths, and channel account config writes.
-import path from "node:path";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { getBundledChannelSetupPlugin } from "../channels/plugins/bundled.js";
@@ -372,17 +371,36 @@ function registerExternalChatSetupPlugin(pluginId = "@vendor/external-chat-plugi
   );
 }
 
-async function registerBundledSetupPlugin(channelId: string): Promise<void> {
-  // Exercise the checked-in declarations, not a stale local dist tree left by an earlier build.
-  vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", path.resolve("extensions"));
-  const actual = await vi.importActual<typeof import("../channels/plugins/bundled.js")>(
-    "../channels/plugins/bundled.js",
+// Env-contract rejection is core policy over a plugin-declared field, so a fixture
+// contract proves it. Loading a real bundled setup plugin here would run the plugin
+// source loader, whose cost and resolved artifact depend on the local build tree.
+function registerEnvContractSetupPlugin(envVars: readonly string[]): void {
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: "typed-chat",
+        plugin: {
+          ...createChannelTestPluginBase({ id: "typed-chat", label: "Typed Chat" }),
+          setupContract: defineChannelSetupContract({
+            fields: {
+              useEnv: {
+                kind: "boolean",
+                cli: { flags: "--use-env", description: "Use environment credentials" },
+                envVars,
+              },
+            },
+            adapter: {
+              applyAccountConfig: ({ cfg }) => ({
+                ...cfg,
+                channels: { ...cfg.channels, "typed-chat": { enabled: true } },
+              }),
+            },
+          }),
+        } as ChannelPlugin,
+        source: "test",
+      },
+    ]),
   );
-  const plugin = actual.getBundledChannelSetupPlugin(channelId as never);
-  if (!plugin) {
-    throw new Error(`Expected bundled setup plugin: ${channelId}`);
-  }
-  setActivePluginRegistry(createTestRegistry([{ pluginId: channelId, plugin, source: "test" }]));
 }
 
 type SignalAfterAccountConfigWritten = NonNullable<
@@ -522,98 +540,29 @@ describe("channelsAddCommand", () => {
     expect(channelWizardMocks.setupChannels).not.toHaveBeenCalled();
   });
 
-  it.each([
-    {
-      channel: "telegram",
-      options: {},
-      env: { TELEGRAM_BOT_TOKEN: "" },
-      missing: ["TELEGRAM_BOT_TOKEN"],
-    },
-    {
-      channel: "slack",
-      options: {},
-      env: { SLACK_BOT_TOKEN: "xoxb-token", SLACK_APP_TOKEN: "" },
-      missing: ["SLACK_APP_TOKEN"],
-    },
-    {
-      channel: "buzz",
-      options: { relayUrl: "wss://buzz.example.com" },
-      env: { BUZZ_PRIVATE_KEY: "" },
-      missing: ["BUZZ_PRIVATE_KEY"],
-    },
-  ])("rejects $channel --use-env when declared env vars are missing", async (testCase) => {
-    for (const [name, value] of Object.entries(testCase.env)) {
-      vi.stubEnv(name, value);
-    }
-    await registerBundledSetupPlugin(testCase.channel);
+  it("rejects --use-env when every declared env var is missing", async () => {
+    vi.stubEnv("TYPED_CHAT_TOKEN", "");
+    vi.stubEnv("TYPED_CHAT_SECRET", "");
+    registerEnvContractSetupPlugin(["TYPED_CHAT_TOKEN", "TYPED_CHAT_SECRET"]);
     configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot });
 
-    await channelsAddCommand(
-      { channel: testCase.channel, useEnv: true, ...testCase.options },
-      runtime,
-      { hasFlags: true },
-    );
+    await channelsAddCommand({ channel: "typed-chat", useEnv: true }, runtime, { hasFlags: true });
 
-    for (const missing of testCase.missing) {
+    for (const missing of ["TYPED_CHAT_TOKEN", "TYPED_CHAT_SECRET"]) {
       expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining(missing));
     }
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
   });
 
-  it.each([
-    {
-      channel: "telegram",
-      env: { TELEGRAM_BOT_TOKEN: "telegram-token" },
-    },
-    {
-      channel: "slack",
-      env: { SLACK_BOT_TOKEN: "xoxb-token", SLACK_APP_TOKEN: "xapp-token" },
-    },
-  ])("commits $channel --use-env config when declared env vars are present", async (testCase) => {
-    for (const [name, value] of Object.entries(testCase.env)) {
-      vi.stubEnv(name, value);
-    }
-    await registerBundledSetupPlugin(testCase.channel);
+  it("commits --use-env config when the declared env vars are present", async () => {
+    vi.stubEnv("TYPED_CHAT_TOKEN", "typed-chat-token");
+    registerEnvContractSetupPlugin(["TYPED_CHAT_TOKEN"]);
     configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot });
 
-    await channelsAddCommand({ channel: testCase.channel, useEnv: true }, runtime, {
-      hasFlags: true,
-    });
+    await channelsAddCommand({ channel: "typed-chat", useEnv: true }, runtime, { hasFlags: true });
 
-    expect(writtenChannel(testCase.channel)).toEqual({ enabled: true });
-    expect(runtime.error).not.toHaveBeenCalled();
-    expect(runtime.exit).not.toHaveBeenCalled();
-  });
-
-  it("commits Slack HTTP --use-env config without SLACK_APP_TOKEN", async () => {
-    vi.stubEnv("SLACK_BOT_TOKEN", "xoxb-token");
-    vi.stubEnv("SLACK_APP_TOKEN", "");
-    await registerBundledSetupPlugin("slack");
-    const config: OpenClawConfig = {
-      channels: {
-        slack: {
-          mode: "http",
-          signingSecret: "test-signing-secret",
-        },
-      },
-    };
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      sourceConfig: config,
-      config,
-    });
-
-    await channelsAddCommand({ channel: "slack", useEnv: true }, runtime, {
-      hasFlags: true,
-    });
-
-    expect(writtenChannel("slack")).toMatchObject({
-      enabled: true,
-      mode: "http",
-      signingSecret: "test-signing-secret",
-    });
-    expect(writtenChannel("slack").appToken).toBeUndefined();
+    expect(writtenChannel("typed-chat")).toEqual({ enabled: true });
     expect(runtime.error).not.toHaveBeenCalled();
     expect(runtime.exit).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## What Problem This Solves

`src/commands/channels.add.test.ts > channelsAddCommand > rejects '<channel>' --use-env when declared env vars are missing` fails on current `main`. It presents two different ways depending on the checkout:

- **Timeout** — source checkout with no `dist/` tree: `Error: Test timed out in 120000ms`, with the run recording 381,893ms of test time for that one case.
- **Zero calls** — checkout with a stale `dist/` tree: the command succeeds and the expected `runtime.error` call never happens.

```
 ❯ |commands| src/commands/channels.add.test.ts (32 tests | 1 failed) 399681ms
     × rejects 'telegram' --use-env when declared env vars are missing 381893ms
 Test Files  1 failed (1)
      Tests  1 failed | 31 passed (32)
   Duration  407.34s
```

Anyone running this file from a source checkout hits a multi-minute hang or a silently vacuous pass, depending on what happens to be in their build tree.

## Why This Change Was Made

The `--use-env` rejection itself is correct and is not what fails. `resolveMissingSetupEnvMessage` (`src/channels/plugins/account-config-mutation.ts:33`) reads the plugin's declared `envVars` off `setupContract.metadata.fields` and rejects when they are missing; the `slack` and `buzz` rows of the same table passed in the failing run, as did the paired `commits telegram --use-env config when declared env vars are present` case.

The failure is in the test's fixture setup, before `channelsAddCommand` is invoked. The fixture loaded a **real bundled channel setup plugin** to obtain a `setupContract`. That entry resolves to `extensions/<id>/setup-entry.ts`, and `canTryNodeRequireBuiltModule` (`src/plugin-sdk/channel-entry-contract.ts:394`) only permits a native require for paths under `/dist/` or `/dist-runtime/`. So the load falls through to the plugin source loader and pulls roughly 3,200 modules through jiti — including `typebox` (660), `kysely` (254), and `execa` (109).

It is not channel-specific: whichever bundled setup plugin loads first pays 1–3 minutes and the rest ride the warm module graph.

This also explains the second symptom. `resolveBundledDirFromPackageRoot` (`src/plugins/bundled-dir.ts:163`) prefers `<root>/dist/extensions` in a source checkout. With a stale `dist/` the load was fast but resolved a pre-`envVars` artifact, so `resolveMissingSetupEnvMessage` returned `undefined` and the command succeeded. Both symptoms are one fact: **the fixture's identity and cost depended on the local build tree.**

This is the only unit test in the repo that loads a real bundled channel setup plugin through the plugin source loader — the other users of `getBundledChannelSetupPlugin` in tests either mock it or point at synthetic temp-dir fixtures.

The change is tests only; no production lines change.

- **`src/commands/channels.add.test.ts`** — replaces the real-bundled-plugin fixture with a fixture `setupContract` built through `defineChannelSetupContract`, matching the `typed-chat` idiom this file already uses for its other setup cases. Core rejection over a plugin-declared field is core policy, so a fixture contract proves it without consulting any build artifact.
- **`extensions/buzz/src/setup-core.test.ts`** — restores plugin-lane coverage that `BUZZ_PRIVATE_KEY` is the declared `--use-env` contract, in its current declarative form.
- **`extensions/telegram/src/setup-surface.test.ts`** — the same declaration assertion for `TELEGRAM_BOT_TOKEN`, which otherwise had no home outside the removed core row.

The Slack row is dropped rather than relocated: `extensions/slack/src/channel-actions-setup-status.contract.test.ts:121` already asserts exactly those cases in Slack's own lane.

Following review, the rejection case is also table-driven across three environments — both declared variables missing, and each one missing individually — so the all-required contract is proven against a partially supplied environment rather than only an empty one.

## User Impact

No runtime behavior changes; production LOC delta is **0**. `src/commands/channels.add.test.ts` goes from a 407s run with one failure to a 5.6s clean run, and stops depending on whether the developer happens to have a `dist/` tree. The `--use-env` rejection keeps its coverage, now at the correct boundaries: core policy against a fixture contract, and each plugin's own declared variables in that plugin's lane.

## Evidence

```
$ node scripts/run-vitest.mjs src/commands/channels.add.test.ts
 Test Files  1 passed (1)   Tests  30 passed (30)   Duration 5.6s     exit 0
   (before: 32 tests | 1 failed | 407.34s)

$ node scripts/run-vitest.mjs src/commands/channels.add.test.ts \
    extensions/buzz/src/setup-core.test.ts extensions/telegram/src/setup-surface.test.ts
 passed 3 Vitest shards in 18.36s                                    exit 0

$ pnpm format <3 paths>                                              exit 0
$ node scripts/run-oxlint.mjs <3 paths>                              exit 0
$ pnpm tsgo:core / tsgo:test:src / tsgo:extensions:test               exit 0
$ git diff --check                                                   clean
```

Measured fixture-load cost in a source checkout, which is the failure being removed:

```
getBundledChannelSetupPlugin(telegram) [first]: 344610ms
getBundledChannelSetupPlugin(slack)    [after]:    885ms
getBundledChannelSetupPlugin(buzz)     [after]:   2329ms

# reversed order, same worktree:
slack    [first]: 129180ms   (plugin-load-profile: sourceLoaderCallMs=128168.0)
telegram [after]:  73019ms
```

Both replacement tests were checked to still fail for the right reason, then reverted:

- Short-circuiting `resolveMissingSetupEnvMessage` reproduces the original signature (`expected "vi.fn()" to be called with arguments: [ StringContaining "TYPED_CHAT_TOKEN" ]`), and removing `envVars` from a plugin declaration fails the corresponding lane test.
- Replacing the all-required branch at `account-config-mutation.ts:46` with the `envVarMode: "any"` comparison fails **both** partial-environment cases while the both-missing case stays green — which is exactly why the both-missing case alone was not sufficient coverage.

## Note on the slow first load

The 1–3 minute first bundled-setup-plugin source load is a real cost on the dev path, but fixing it means changing production module-loading behavior, so it is deliberately out of scope here. It is filed separately as #122903. Two separable contributors, if a maintainer wants them pursued:

1. `canTryNodeRequireBuiltModule` refuses the native-TS-require hook that `src/channels/plugins/module-loader.ts` already uses. (Note: the obvious change here is *not* safe as-is — a native require of the setup entry currently fails with `ERR_PACKAGE_PATH_NOT_EXPORTED` via `unicorn-magic`, which is why #122903 asks for a graph fix rather than a loader flag.)
2. The Telegram setup surface statically reaches core internals despite `channel-entry-contract.ts` ("Setup loads stay light") and `src/channels/CLAUDE.md` naming `channel.setup.ts` a hot import path — e.g. `channel.setup.ts` → `setup-surface.ts` → `account-inspect.ts` → `openclaw/plugin-sdk/provider-auth` → `src/agents/auth-profiles/oauth.ts` → `src/config/config.ts` → … → `src/commands/doctor/shared/include-migration-ownership.ts`.

A correction to an earlier revision of this description: it compared the source-loader cost against "8.5s via a plain ESM `import()`". That comparison was not like-for-like — a plain `import()` of the setup entry resolves only the lazy contract (762ms, 11 modules), not the full graph the loader materializes. The meaningful comparison is the dist-backed load of the same plugin, ~8.9s.

---

**AI disclosure:** This change was written by an AI agent (Claude). Root-cause analysis, the fix, and all validation above were produced and run by the agent. No human has reviewed the diff line by line. Please review accordingly.
