### PR TITLE
fix(subagents): preserve announce drop vs none delivery reasons

### DIFF
--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -2146,14 +2146,9 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
-  it("preserves steer_dropped when completion direct delivery fails and fallback steering drops", async () => {
+  it("preserves visible_reply_missing when completion direct delivery fails and fallback steering drops", async () => {
     const callGateway = createGatewayMock({
-      result: {
-        deliveryStatus: {
-          status: "failed",
-          errorMessage: "requester wake failed",
-        },
-      },
+      result: { payloads: [{ text: "NO_REPLY" }] },
     });
     const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeMock(false);
     const result = await deliverSlackThreadAnnouncement({
@@ -2171,11 +2166,27 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expectRecordFields(result, {
       delivered: false,
       path: "direct",
-      error: "requester wake failed",
-      reason: "steer_dropped",
+      error: "completion agent did not produce a visible reply",
+      reason: "visible_reply_missing",
+      phases: [
+        {
+          phase: "direct-primary",
+          delivered: false,
+          path: "direct",
+          reason: "visible_reply_missing",
+          error: "completion agent did not produce a visible reply",
+        },
+        {
+          phase: "steer-fallback",
+          delivered: false,
+          path: "none",
+          reason: "steer_dropped",
+          error: undefined,
+        },
+      ],
     });
     expect(result.terminal).toBeUndefined();
-    expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(2);
+    expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(1);
     expect(callGateway).toHaveBeenCalled();
   });
 

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -2147,19 +2147,19 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   });
 
   it("preserves visible_reply_missing when completion direct delivery fails and fallback steering drops", async () => {
-    const callGateway = createGatewayMock({
-      result: { payloads: [{ text: "NO_REPLY" }] },
-    });
+    const callGateway = createPayloadGatewayMock();
+    const sendMessage = createSendMessageMock();
     const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeMock(false);
-    const result = await deliverSlackThreadAnnouncement({
+    const result = await deliverDiscordDirectMessageCompletion({
       callGateway,
+      sendMessage,
       isActive: true,
-      sessionId: "requester-session-1",
-      directIdempotencyKey: "announce-completion-steer-dropped",
       queueEmbeddedAgentMessageWithOutcome,
       internalEvents: taskCompletionEvents({
         childSessionId: "child-session-id",
-        taskLabel: "completion drop smoke",
+        status: "error",
+        statusLabel: "failed: all models failed",
+        result: "(no output)",
       }),
     });
 
@@ -2186,8 +2186,8 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       ],
     });
     expect(result.terminal).toBeUndefined();
-    expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(1);
-    expect(callGateway).toHaveBeenCalled();
+    expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
   });
 
   it("reports failure for Telegram DMs when announce-agent delivery fails", async () => {

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -1010,8 +1010,15 @@ describe("deliverSubagentAnnouncement active requester steering", () => {
       expectRecordFields(result, {
         delivered: fallsBack,
         path: fallsBack ? "direct" : "none",
+        ...(fallsBack ? {} : { reason: "steer_dropped" }),
         phases: [
-          { phase: "steer-primary", delivered: false, path: "none", error: undefined },
+          {
+            phase: "steer-primary",
+            delivered: false,
+            path: "none",
+            error: undefined,
+            ...(fallsBack ? {} : { reason: "steer_dropped" }),
+          },
           ...(fallsBack
             ? [{ phase: "direct-primary", delivered: true, path: "direct", error: undefined }]
             : []),

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -2146,6 +2146,39 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("preserves steer_dropped when completion direct delivery fails and fallback steering drops", async () => {
+    const callGateway = createGatewayMock({
+      result: {
+        deliveryStatus: {
+          status: "failed",
+          errorMessage: "requester wake failed",
+        },
+      },
+    });
+    const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeMock(false);
+    const result = await deliverSlackThreadAnnouncement({
+      callGateway,
+      isActive: true,
+      sessionId: "requester-session-1",
+      directIdempotencyKey: "announce-completion-steer-dropped",
+      queueEmbeddedAgentMessageWithOutcome,
+      internalEvents: taskCompletionEvents({
+        childSessionId: "child-session-id",
+        taskLabel: "completion drop smoke",
+      }),
+    });
+
+    expectRecordFields(result, {
+      delivered: false,
+      path: "direct",
+      error: "requester wake failed",
+      reason: "steer_dropped",
+    });
+    expect(result.terminal).toBeUndefined();
+    expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(2);
+    expect(callGateway).toHaveBeenCalled();
+  });
+
   it("reports failure for Telegram DMs when announce-agent delivery fails", async () => {
     const callGateway = createGatewayMock({
       result: {

--- a/src/agents/subagents/announce/subagent-announce-dispatch.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-dispatch.test.ts
@@ -175,6 +175,7 @@ describe("runSubagentAnnounceDispatch", () => {
     {
       name: "cannot deliver",
       steerStatus: "none" as const,
+      directReason: undefined,
       expectedReason: undefined,
       fallbackPhase: {
         phase: "steer-fallback" as const,
@@ -186,7 +187,21 @@ describe("runSubagentAnnounceDispatch", () => {
     {
       name: "drops the new item",
       steerStatus: "dropped" as const,
-      expectedReason: "steer_dropped" as const,
+      directReason: undefined,
+      expectedReason: undefined,
+      fallbackPhase: {
+        phase: "steer-fallback" as const,
+        delivered: false,
+        path: "none" as const,
+        reason: "steer_dropped" as const,
+        error: undefined,
+      },
+    },
+    {
+      name: "drops the new item after a visible reply is missing",
+      steerStatus: "dropped" as const,
+      directReason: "visible_reply_missing" as const,
+      expectedReason: "visible_reply_missing" as const,
       fallbackPhase: {
         phase: "steer-fallback" as const,
         delivered: false,
@@ -197,12 +212,13 @@ describe("runSubagentAnnounceDispatch", () => {
     },
   ])(
     "returns direct failure when completion fallback steering $name",
-    async ({ steerStatus, expectedReason, fallbackPhase }) => {
+    async ({ steerStatus, directReason, expectedReason, fallbackPhase }) => {
       const steer = vi.fn(async () => ({ status: steerStatus }));
       const direct = vi.fn(async () => ({
         delivered: false,
         path: "direct" as const,
         error: "failed",
+        ...(directReason ? { reason: directReason } : {}),
       }));
 
       const result = await runSubagentAnnounceDispatch({
@@ -217,7 +233,13 @@ describe("runSubagentAnnounceDispatch", () => {
       expect(result.reason).toBe(expectedReason);
       expect(result.terminal).toBeUndefined();
       expect(result.phases).toEqual([
-        { phase: "direct-primary", delivered: false, path: "direct", error: "failed" },
+        {
+          phase: "direct-primary",
+          delivered: false,
+          path: "direct",
+          error: "failed",
+          ...(directReason ? { reason: directReason } : {}),
+        },
         fallbackPhase,
       ]);
     },

--- a/src/agents/subagents/announce/subagent-announce-dispatch.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-dispatch.test.ts
@@ -175,6 +175,7 @@ describe("runSubagentAnnounceDispatch", () => {
     {
       name: "cannot deliver",
       steerStatus: "none" as const,
+      expectedReason: undefined,
       fallbackPhase: {
         phase: "steer-fallback" as const,
         delivered: false,
@@ -185,6 +186,7 @@ describe("runSubagentAnnounceDispatch", () => {
     {
       name: "drops the new item",
       steerStatus: "dropped" as const,
+      expectedReason: "steer_dropped" as const,
       fallbackPhase: {
         phase: "steer-fallback" as const,
         delivered: false,
@@ -195,7 +197,7 @@ describe("runSubagentAnnounceDispatch", () => {
     },
   ])(
     "returns direct failure when completion fallback steering $name",
-    async ({ steerStatus, fallbackPhase }) => {
+    async ({ steerStatus, expectedReason, fallbackPhase }) => {
       const steer = vi.fn(async () => ({ status: steerStatus }));
       const direct = vi.fn(async () => ({
         delivered: false,
@@ -212,7 +214,7 @@ describe("runSubagentAnnounceDispatch", () => {
       expect(result.delivered).toBe(false);
       expect(result.path).toBe("direct");
       expect(result.error).toBe("failed");
-      expect(result.reason).toBeUndefined();
+      expect(result.reason).toBe(expectedReason);
       expect(result.terminal).toBeUndefined();
       expect(result.phases).toEqual([
         { phase: "direct-primary", delivered: false, path: "direct", error: "failed" },

--- a/src/agents/subagents/announce/subagent-announce-dispatch.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-dispatch.test.ts
@@ -28,6 +28,7 @@ describe("runSubagentAnnounceDispatch", () => {
     expect(direct).toHaveBeenCalledTimes(1);
     expect(result.delivered).toBe(true);
     expect(result.path).toBe("direct");
+    expect(result.reason).toBeUndefined();
     expect(result.phases).toEqual([
       { phase: "steer-primary", delivered: false, path: "none", error: undefined },
       { phase: "direct-primary", delivered: true, path: "direct", error: undefined },
@@ -170,28 +171,55 @@ describe("runSubagentAnnounceDispatch", () => {
     ]);
   });
 
-  it("returns direct failure when completion fallback steering cannot deliver", async () => {
-    const steer = vi.fn(async () => ({ status: "none" }) as const);
-    const direct = vi.fn(async () => ({
-      delivered: false,
-      path: "direct" as const,
-      error: "failed",
-    }));
+  it.each([
+    {
+      name: "cannot deliver",
+      steerStatus: "none" as const,
+      fallbackPhase: {
+        phase: "steer-fallback" as const,
+        delivered: false,
+        path: "none" as const,
+        error: undefined,
+      },
+    },
+    {
+      name: "drops the new item",
+      steerStatus: "dropped" as const,
+      fallbackPhase: {
+        phase: "steer-fallback" as const,
+        delivered: false,
+        path: "none" as const,
+        reason: "steer_dropped" as const,
+        error: undefined,
+      },
+    },
+  ])(
+    "returns direct failure when completion fallback steering $name",
+    async ({ steerStatus, fallbackPhase }) => {
+      const steer = vi.fn(async () => ({ status: steerStatus }));
+      const direct = vi.fn(async () => ({
+        delivered: false,
+        path: "direct" as const,
+        error: "failed",
+      }));
 
-    const result = await runSubagentAnnounceDispatch({
-      expectsCompletionMessage: true,
-      steer,
-      direct,
-    });
+      const result = await runSubagentAnnounceDispatch({
+        expectsCompletionMessage: true,
+        steer,
+        direct,
+      });
 
-    expect(result.delivered).toBe(false);
-    expect(result.path).toBe("direct");
-    expect(result.error).toBe("failed");
-    expect(result.phases).toEqual([
-      { phase: "direct-primary", delivered: false, path: "direct", error: "failed" },
-      { phase: "steer-fallback", delivered: false, path: "none", error: undefined },
-    ]);
-  });
+      expect(result.delivered).toBe(false);
+      expect(result.path).toBe("direct");
+      expect(result.error).toBe("failed");
+      expect(result.reason).toBeUndefined();
+      expect(result.terminal).toBeUndefined();
+      expect(result.phases).toEqual([
+        { phase: "direct-primary", delivered: false, path: "direct", error: "failed" },
+        fallbackPhase,
+      ]);
+    },
+  );
 
   it("returns terminal source ownership loss from completion fallback steering", async () => {
     const steer = vi.fn(async () => ({ status: "source_owner_changed" }) as const);
@@ -230,7 +258,16 @@ describe("runSubagentAnnounceDispatch", () => {
     expect(result).toEqual({
       delivered: false,
       path: "none",
-      phases: [{ phase: "steer-primary", delivered: false, path: "none", error: undefined }],
+      reason: "steer_dropped",
+      phases: [
+        {
+          phase: "steer-primary",
+          delivered: false,
+          path: "none",
+          reason: "steer_dropped",
+          error: undefined,
+        },
+      ],
     });
   });
 

--- a/src/agents/subagents/announce/subagent-announce-dispatch.ts
+++ b/src/agents/subagents/announce/subagent-announce-dispatch.ts
@@ -77,18 +77,10 @@ function mapSteerOutcomeToDeliveryResult(
       disposition: "intentional_non_delivery",
     };
   }
-  // Dropped is a live-queue refusal, not a terminal ownership loss. Marking it
-  // terminal would replace a completion direct failure with this steer result.
-  if (outcome.status === "dropped") {
-    return {
-      delivered: false,
-      path: "none",
-      reason: "steer_dropped",
-    };
-  }
   return {
     delivered: false,
     path: "none",
+    ...(outcome.status === "dropped" ? { reason: "steer_dropped" } : {}),
   };
 }
 
@@ -182,9 +174,6 @@ export async function runSubagentAnnounceDispatch(params: {
     return withPhases(fallbackSteer);
   }
 
-  // Dropped fallback is not terminal, so completion keeps the failed direct
-  // result and its reason. The fallback phase already records steer_dropped
-  // for registry cleanup; overwriting reason would discard the direct
-  // failure classification.
+  // Keep the direct failure authoritative; dropped fallback remains in its phase.
   return withPhases(primaryDirect);
 }

--- a/src/agents/subagents/announce/subagent-announce-dispatch.ts
+++ b/src/agents/subagents/announce/subagent-announce-dispatch.ts
@@ -183,9 +183,8 @@ export async function runSubagentAnnounceDispatch(params: {
   }
 
   // Dropped fallback is not terminal, so completion keeps the failed direct
-  // result. Carry the fallback reason so registry cleanup can persist
-  // steer_dropped instead of only seeing path: "direct".
-  return withPhases(
-    fallbackSteer.reason ? { ...primaryDirect, reason: fallbackSteer.reason } : primaryDirect,
-  );
+  // result and its reason. The fallback phase already records steer_dropped
+  // for registry cleanup; overwriting reason would discard the direct
+  // failure classification.
+  return withPhases(primaryDirect);
 }

--- a/src/agents/subagents/announce/subagent-announce-dispatch.ts
+++ b/src/agents/subagents/announce/subagent-announce-dispatch.ts
@@ -20,6 +20,7 @@ type SubagentAnnounceDeliveryFailureReason =
   | "message_tool_delivery_missing"
   | "requester_abandoned"
   | "source_owner_changed"
+  | "steer_dropped"
   | "visible_reply_missing";
 
 type SubagentAnnounceSteerOutcome =
@@ -74,6 +75,15 @@ function mapSteerOutcomeToDeliveryResult(
       error: "subagent source lifecycle changed before completion delivery",
       terminal: true,
       disposition: "intentional_non_delivery",
+    };
+  }
+  // Dropped is a live-queue refusal, not a terminal ownership loss. Marking it
+  // terminal would replace a completion direct failure with this steer result.
+  if (outcome.status === "dropped") {
+    return {
+      delivered: false,
+      path: "none",
+      reason: "steer_dropped",
     };
   }
   return {

--- a/src/agents/subagents/announce/subagent-announce-dispatch.ts
+++ b/src/agents/subagents/announce/subagent-announce-dispatch.ts
@@ -182,5 +182,10 @@ export async function runSubagentAnnounceDispatch(params: {
     return withPhases(fallbackSteer);
   }
 
-  return withPhases(primaryDirect);
+  // Dropped fallback is not terminal, so completion keeps the failed direct
+  // result. Carry the fallback reason so registry cleanup can persist
+  // steer_dropped instead of only seeing path: "direct".
+  return withPhases(
+    fallbackSteer.reason ? { ...primaryDirect, reason: fallbackSteer.reason } : primaryDirect,
+  );
 }

--- a/src/agents/subagents/announce/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.format.e2e.test.ts
@@ -1923,8 +1923,16 @@ describe("subagent announce formatting", () => {
     });
 
     expect(delivery.delivered).toBe(false);
+    expect(delivery.reason).toBe("steer_dropped");
+    expect(delivery.terminal).toBeUndefined();
     expect(delivery.phases).toEqual([
-      { phase: "steer-primary", delivered: false, path: "none", error: undefined },
+      {
+        phase: "steer-primary",
+        delivered: false,
+        path: "none",
+        reason: "steer_dropped",
+        error: undefined,
+      },
     ]);
     expect(direct).not.toHaveBeenCalled();
   });

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
@@ -575,6 +575,7 @@ export const startSubagentAnnounceCleanupFlow = (
           }
         : undefined,
     onDeliveryResult: (delivery) => {
+      const previousDropReason = entry.delivery?.lastDropReason;
       if (!context.isCleanupAttemptCurrent(runId, entry, cleanupGeneration)) {
         retireSupersededCleanupInBackground(context, runId, entry, cleanupGeneration);
         return;
@@ -597,20 +598,13 @@ export const startSubagentAnnounceCleanupFlow = (
         latestDeliveryError = undefined;
         return;
       }
-      const steerDropped =
-        delivery.reason === "steer_dropped" ||
-        Boolean(delivery.phases?.some((phase) => phase.reason === "steer_dropped"));
-      if (steerDropped) {
-        // Live-queue refusals persist as steer_dropped even when completion
-        // keeps a failed direct reason. Collapsing those to sink_unavailable
-        // erases the only durable distinction from no viable requester.
-        ensureDeliveryState(entry).lastDropReason = "steer_dropped";
-      } else if (delivery.path === "none" && delivery.disposition !== "intentional_non_delivery") {
-        ensureDeliveryState(entry).lastDropReason = "sink_unavailable";
-      }
+      const deliveryState = ensureDeliveryState(entry);
       latestDeliveryError = formatAnnounceDeliveryError(delivery);
-      if (ensureDeliveryState(entry).lastError !== latestDeliveryError) {
-        ensureDeliveryState(entry).lastError = latestDeliveryError;
+      if (
+        deliveryState.lastError !== latestDeliveryError ||
+        deliveryState.lastDropReason !== previousDropReason
+      ) {
+        deliveryState.lastError = latestDeliveryError;
         params.persist(runId);
       }
     },

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
@@ -597,10 +597,13 @@ export const startSubagentAnnounceCleanupFlow = (
         latestDeliveryError = undefined;
         return;
       }
-      if (delivery.reason === "steer_dropped") {
-        // Live-queue refusals keep steer_dropped even when completion retains
-        // a failed direct path. Collapsing those to sink_unavailable erases
-        // the only durable distinction from no viable requester.
+      const steerDropped =
+        delivery.reason === "steer_dropped" ||
+        Boolean(delivery.phases?.some((phase) => phase.reason === "steer_dropped"));
+      if (steerDropped) {
+        // Live-queue refusals persist as steer_dropped even when completion
+        // keeps a failed direct reason. Collapsing those to sink_unavailable
+        // erases the only durable distinction from no viable requester.
         ensureDeliveryState(entry).lastDropReason = "steer_dropped";
       } else if (delivery.path === "none" && delivery.disposition !== "intentional_non_delivery") {
         ensureDeliveryState(entry).lastDropReason = "sink_unavailable";

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
@@ -598,7 +598,11 @@ export const startSubagentAnnounceCleanupFlow = (
         return;
       }
       if (delivery.path === "none" && delivery.disposition !== "intentional_non_delivery") {
-        ensureDeliveryState(entry).lastDropReason = "sink_unavailable";
+        // Live-queue refusals keep steer_dropped so monitors can tell them
+        // from no viable requester. Collapsing both to sink_unavailable
+        // erases the only durable distinction.
+        ensureDeliveryState(entry).lastDropReason =
+          delivery.reason === "steer_dropped" ? "steer_dropped" : "sink_unavailable";
       }
       latestDeliveryError = formatAnnounceDeliveryError(delivery);
       if (ensureDeliveryState(entry).lastError !== latestDeliveryError) {

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
@@ -597,12 +597,13 @@ export const startSubagentAnnounceCleanupFlow = (
         latestDeliveryError = undefined;
         return;
       }
-      if (delivery.path === "none" && delivery.disposition !== "intentional_non_delivery") {
-        // Live-queue refusals keep steer_dropped so monitors can tell them
-        // from no viable requester. Collapsing both to sink_unavailable
-        // erases the only durable distinction.
-        ensureDeliveryState(entry).lastDropReason =
-          delivery.reason === "steer_dropped" ? "steer_dropped" : "sink_unavailable";
+      if (delivery.reason === "steer_dropped") {
+        // Live-queue refusals keep steer_dropped even when completion retains
+        // a failed direct path. Collapsing those to sink_unavailable erases
+        // the only durable distinction from no viable requester.
+        ensureDeliveryState(entry).lastDropReason = "steer_dropped";
+      } else if (delivery.path === "none" && delivery.disposition !== "intentional_non_delivery") {
+        ensureDeliveryState(entry).lastDropReason = "sink_unavailable";
       }
       latestDeliveryError = formatAnnounceDeliveryError(delivery);
       if (ensureDeliveryState(entry).lastError !== latestDeliveryError) {

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-delivery.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-delivery.ts
@@ -83,6 +83,16 @@ export const recordAnnounceDeliveryResult = (
   if (typeof delivery.enqueuedAt === "number") {
     deliveryState.enqueuedAt ??= delivery.enqueuedAt;
   }
+  if (!delivery.delivered && delivery.disposition !== "intentional_non_delivery") {
+    if (
+      delivery.reason === "steer_dropped" ||
+      delivery.phases?.some((phase) => phase.reason === "steer_dropped")
+    ) {
+      deliveryState.lastDropReason = "steer_dropped";
+    } else if (delivery.path === "none") {
+      deliveryState.lastDropReason = "sink_unavailable";
+    }
+  }
   if (delivery.delivered) {
     const deliveredAt =
       typeof delivery.deliveredAt === "number" ? delivery.deliveredAt : Date.now();

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -2833,7 +2833,12 @@ describe("subagent registry lifecycle hardening", () => {
 
     const controller = createLifecycleController({ entry, persist, runSubagentAnnounceFlow });
 
-    await expect(completeRun(controller, entry, { triggerCleanup: true })).resolves.toBeUndefined();
+    await expect(
+      completeRun(controller, entry, {
+        triggerCleanup: true,
+        terminalReply: { disposition: "visible", text: "final completion reply" },
+      }),
+    ).resolves.toBeUndefined();
 
     await waitForLifecycleState(() => expect(entry.delivery?.lastDropReason).toBe(lastDropReason));
     expect(entry.delivery?.lastError).toBe(lastError);
@@ -2841,12 +2846,41 @@ describe("subagent registry lifecycle hardening", () => {
     expect(persist).toHaveBeenCalledWith(entry.runId);
   });
 
-  it("persists steer_dropped after completion visible_reply_missing plus dropped steer fallback", async () => {
+  it.each([
+    {
+      name: "persists a newly failed completion",
+      previousDropReason: undefined,
+      reusePreviousError: false,
+      persistCalls: 1,
+    },
+    {
+      name: "persists a changed drop reason when the direct error is unchanged",
+      previousDropReason: "sink_unavailable" as const,
+      reusePreviousError: true,
+      persistCalls: 1,
+    },
+    {
+      name: "does not persist unchanged completion diagnostics",
+      previousDropReason: "steer_dropped" as const,
+      reusePreviousError: true,
+      persistCalls: 0,
+    },
+  ])("$name before stalled announce bookkeeping settles", async (scenario) => {
+    const lastError = "failed; visible_reply_missing; direct-primary: failed";
     const persist = vi.fn();
     const entry = createRunEntry({
       endedAt: 4_000,
       expectsCompletionMessage: true,
       retainAttachmentsOnKeep: true,
+      delivery: {
+        status: "pending",
+        ...(scenario.reusePreviousError ? { lastError } : {}),
+        ...(scenario.previousDropReason ? { lastDropReason: scenario.previousDropReason } : {}),
+      },
+    });
+    let releaseAnnounce!: () => void;
+    const announcePending = new Promise<void>((resolve) => {
+      releaseAnnounce = resolve;
     });
     const runSubagentAnnounceFlow: LifecycleControllerParams["runSubagentAnnounceFlow"] = vi.fn(
       async (announceParams) => {
@@ -2856,25 +2890,38 @@ describe("subagent registry lifecycle hardening", () => {
           direct: async () => ({
             delivered: false,
             path: "direct",
-            error: "completion agent did not produce a visible reply",
+            error: "failed",
             reason: "visible_reply_missing",
           }),
         });
+        persist.mockClear();
         announceParams.onDeliveryResult?.(delivery);
+        await announcePending;
         return "retryable" as const;
       },
     );
-
     const controller = createLifecycleController({ entry, persist, runSubagentAnnounceFlow });
 
-    await expect(completeRun(controller, entry, { triggerCleanup: true })).resolves.toBeUndefined();
+    try {
+      await expect(
+        completeRun(controller, entry, {
+          triggerCleanup: true,
+          terminalReply: { disposition: "visible", text: "final completion reply" },
+        }),
+      ).resolves.toBeUndefined();
+      await waitForLifecycleState(() => expect(entry.delivery?.disposition).toBe("retryable"));
+      expect(entry.delivery?.lastDropReason).toBe("steer_dropped");
+      expect(entry.delivery?.lastError).toBe(lastError);
+      expect(entry.cleanupCompletedAt).toBeUndefined();
+      expect(persist).toHaveBeenCalledTimes(scenario.persistCalls);
+      if (scenario.persistCalls > 0) {
+        expect(persist).toHaveBeenCalledWith(entry.runId);
+      }
+    } finally {
+      releaseAnnounce();
+    }
 
-    await waitForLifecycleState(() => expect(entry.delivery?.lastDropReason).toBe("steer_dropped"));
-    expect(entry.delivery?.lastError).toBe(
-      "completion agent did not produce a visible reply; visible_reply_missing; direct-primary: completion agent did not produce a visible reply",
-    );
-    expect(entry.delivery?.status).toBe("suspended");
-    expect(persist).toHaveBeenCalledWith(entry.runId);
+    await waitForLifecycleState(() => expect(entry.delivery?.status).toBe("suspended"));
   });
 
   it("persists identified completion delivery before stalled announce bookkeeping settles", async () => {

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -2841,7 +2841,7 @@ describe("subagent registry lifecycle hardening", () => {
     expect(persist).toHaveBeenCalledWith(entry.runId);
   });
 
-  it("persists steer_dropped after completion direct failure plus dropped steer fallback", async () => {
+  it("persists steer_dropped after completion visible_reply_missing plus dropped steer fallback", async () => {
     const persist = vi.fn();
     const entry = createRunEntry({
       endedAt: 4_000,
@@ -2856,7 +2856,8 @@ describe("subagent registry lifecycle hardening", () => {
           direct: async () => ({
             delivered: false,
             path: "direct",
-            error: "failed",
+            error: "completion agent did not produce a visible reply",
+            reason: "visible_reply_missing",
           }),
         });
         announceParams.onDeliveryResult?.(delivery);
@@ -2869,7 +2870,9 @@ describe("subagent registry lifecycle hardening", () => {
     await expect(completeRun(controller, entry, { triggerCleanup: true })).resolves.toBeUndefined();
 
     await waitForLifecycleState(() => expect(entry.delivery?.lastDropReason).toBe("steer_dropped"));
-    expect(entry.delivery?.lastError).toBe("failed; steer_dropped; direct-primary: failed");
+    expect(entry.delivery?.lastError).toBe(
+      "completion agent did not produce a visible reply; visible_reply_missing; direct-primary: completion agent did not produce a visible reply",
+    );
     expect(entry.delivery?.status).toBe("suspended");
     expect(persist).toHaveBeenCalledWith(entry.runId);
   });

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -2794,6 +2794,50 @@ describe("subagent registry lifecycle hardening", () => {
     });
   });
 
+  it.each([
+    {
+      name: "persists steer_dropped when announce mapping preserves a live-queue refusal",
+      delivery: {
+        delivered: false as const,
+        path: "none" as const,
+        reason: "steer_dropped" as const,
+      },
+      lastDropReason: "steer_dropped",
+      lastError: "steer_dropped",
+    },
+    {
+      name: "persists sink_unavailable when announce mapping reports no viable requester",
+      delivery: {
+        delivered: false as const,
+        path: "none" as const,
+      },
+      lastDropReason: "sink_unavailable",
+      lastError: "delivery path none did not complete",
+    },
+  ])("$name", async ({ delivery, lastDropReason, lastError }) => {
+    const persist = vi.fn();
+    const entry = createRunEntry({
+      endedAt: 4_000,
+      expectsCompletionMessage: true,
+      retainAttachmentsOnKeep: true,
+    });
+    const runSubagentAnnounceFlow: LifecycleControllerParams["runSubagentAnnounceFlow"] = vi.fn(
+      async (announceParams) => {
+        announceParams.onDeliveryResult?.(delivery);
+        return "retryable" as const;
+      },
+    );
+
+    const controller = createLifecycleController({ entry, persist, runSubagentAnnounceFlow });
+
+    await expect(completeRun(controller, entry, { triggerCleanup: true })).resolves.toBeUndefined();
+
+    await waitForLifecycleState(() => expect(entry.delivery?.lastDropReason).toBe(lastDropReason));
+    expect(entry.delivery?.lastError).toBe(lastError);
+    expect(entry.delivery?.status).toBe("suspended");
+    expect(persist).toHaveBeenCalledWith(entry.runId);
+  });
+
   it("persists identified completion delivery before stalled announce bookkeeping settles", async () => {
     const persist = vi.fn();
     const entry = createRunEntry({

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -22,7 +22,10 @@ import {
   buildAnnounceIdempotencyKey,
 } from "../../announce-idempotency.js";
 import { createStructuredOutputTool } from "../../tools/structured-output-tool.js";
-import type { SubagentAnnounceDeliveryResult } from "../announce/subagent-announce-dispatch.js";
+import {
+  runSubagentAnnounceDispatch,
+  type SubagentAnnounceDeliveryResult,
+} from "../announce/subagent-announce-dispatch.js";
 import {
   SUBAGENT_ENDED_REASON_COMPLETE,
   SUBAGENT_ENDED_REASON_ERROR,
@@ -2834,6 +2837,39 @@ describe("subagent registry lifecycle hardening", () => {
 
     await waitForLifecycleState(() => expect(entry.delivery?.lastDropReason).toBe(lastDropReason));
     expect(entry.delivery?.lastError).toBe(lastError);
+    expect(entry.delivery?.status).toBe("suspended");
+    expect(persist).toHaveBeenCalledWith(entry.runId);
+  });
+
+  it("persists steer_dropped after completion direct failure plus dropped steer fallback", async () => {
+    const persist = vi.fn();
+    const entry = createRunEntry({
+      endedAt: 4_000,
+      expectsCompletionMessage: true,
+      retainAttachmentsOnKeep: true,
+    });
+    const runSubagentAnnounceFlow: LifecycleControllerParams["runSubagentAnnounceFlow"] = vi.fn(
+      async (announceParams) => {
+        const delivery = await runSubagentAnnounceDispatch({
+          expectsCompletionMessage: true,
+          steer: async () => ({ status: "dropped" }),
+          direct: async () => ({
+            delivered: false,
+            path: "direct",
+            error: "failed",
+          }),
+        });
+        announceParams.onDeliveryResult?.(delivery);
+        return "retryable" as const;
+      },
+    );
+
+    const controller = createLifecycleController({ entry, persist, runSubagentAnnounceFlow });
+
+    await expect(completeRun(controller, entry, { triggerCleanup: true })).resolves.toBeUndefined();
+
+    await waitForLifecycleState(() => expect(entry.delivery?.lastDropReason).toBe("steer_dropped"));
+    expect(entry.delivery?.lastError).toBe("failed; steer_dropped; direct-primary: failed");
     expect(entry.delivery?.status).toBe("suspended");
     expect(persist).toHaveBeenCalledWith(entry.runId);
   });

--- a/src/agents/subagents/registry/subagent-registry.types.ts
+++ b/src/agents/subagents/registry/subagent-registry.types.ts
@@ -170,6 +170,7 @@ export type SubagentCompletionDeliveryState = {
     | "queue_cap"
     | "parent_run_ended"
     | "sink_unavailable"
+    | "steer_dropped"
     | "dedupe"
     | "waiting_for_requester_turn";
 };


### PR DESCRIPTION
Closes #122615

## What Problem This Solves

Fixes an issue where operators monitoring subagent completion delivery could tell that an announce failed, but could not tell a live requester queue refusal (`dropped`) from no viable requester session (`none`). Both collapsed to `path: "none"` and persisted as `lastDropReason: "sink_unavailable"`. A failed completion direct delivery followed by a dropped steer fallback also kept only one reason, so either the direct classification or the queue refusal was lost.

## Why This Change Was Made

Dropped is not marked terminal, so completion still returns the failed direct result instead of replacing it with the steer miss. Dual-reason design: top-level `reason` stays the direct failure (`visible_reply_missing` / `message_tool_delivery_missing`); the fallback phase records `steer_dropped`; cleanup persists `lastDropReason: "steer_dropped"` from that phase without clobbering the direct code in `lastError`.

This does not add a direct-delivery fallback for a live requester that refused steering.

## User Impact

Managers and local monitors can distinguish a refused announce into an active requester from a missing requester session, including the completion path where direct delivery fails and steer fallback is dropped. Both the direct failure classification and the queue refusal remain visible.

## Evidence

Head: `05565da36288836ddc822e8eb377d6a9e3c198ff`

Wall-clock Node process (not Vitest). Isolated `HOME` / `OPENCLAW_STATE_DIR`. Drove production `runSubagentAnnounceFlow` → `deliverSubagentAnnouncement` → `runSubagentAnnounceDispatch` → `startSubagentAnnounceCleanupFlow`. Real `queueEmbeddedAgentMessageWithOutcomeAsync` against a registered non-streaming embedded requester run (`not_streaming` → dropped). Recording fake only at the gateway RPC client (empty announce-agent payloads / empty `chat.history`).

```
node v22.22.3
NODE_ENV=test
node --import tsx /tmp/subagent-announce-drop-trace.mts
sha=05565da36288836ddc822e8eb377d6a9e3c198ff
wall_sec=23.200
ok=true
```

After-fix owner/transport trace (redacted):

```json
{
  "topLevelReason": "visible_reply_missing",
  "phases": [
    {
      "phase": "direct-primary",
      "delivered": false,
      "path": "direct",
      "reason": "visible_reply_missing",
      "error": "completion agent did not produce a visible reply"
    },
    {
      "phase": "steer-fallback",
      "delivered": false,
      "path": "none",
      "reason": "steer_dropped"
    }
  ],
  "persistedAtOnDeliveryResult": {
    "lastDropReason": "steer_dropped",
    "lastError": "completion agent did not produce a visible reply; visible_reply_missing; direct-primary: completion agent did not produce a visible reply"
  },
  "lastDropReason": "steer_dropped",
  "queue_client_result": { "queued": false, "reason": "not_streaming", "gatewayHealth": "live" },
  "gateway_client": { "method": "agent", "expectFinal": true }
}
```

`lastDropReason` stayed `steer_dropped` after cleanup. Later retry bookkeeping rewrote `lastError` to `announce deferred or direct delivery failed`; that rewrite is existing pending-retry text, not a loss of `steer_dropped`.

Not live-run: no live Telegram/Slack/Discord network, no isolated gateway process, no live model provider, no packaged/Docker/Crabbox.

By: @felirami (acct 2014-02-21) | OpenClaw: 13 PRs, 0 issues, 1 commits/12mo | GitHub: 612 commits, 140 PRs, 11 issues, 1 reviews
