### PR TITLE
test(macos): remove residual smoke probes

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/LowCoverageViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/LowCoverageViewSmokeTests.swift
@@ -1,5 +1,3 @@
-import AppKit
-import SwiftUI
 import Testing
 @testable import OpenClaw
 
@@ -24,19 +22,5 @@ struct LowCoverageViewSmokeTests {
         controller.present()
         controller.dismiss()
         try? await Task.sleep(nanoseconds: 250_000_000)
-    }
-
-    @Test func `visual effect view hosts in NS hosting view`() {
-        let hosting = NSHostingView(rootView: VisualEffectView(material: .sidebar))
-        _ = hosting.fittingSize
-        hosting.rootView = VisualEffectView(material: .popover, emphasized: true)
-        _ = hosting.fittingSize
-    }
-
-    @Test func `dock icon manager updates visibility`() {
-        _ = NSApplication.shared
-        UserDefaults.standard.set(false, forKey: showDockIconKey)
-        DockIconManager.shared.updateDockVisibility()
-        DockIconManager.shared.temporarilyShowDock()
     }
 }


### PR DESCRIPTION
## What Problem This Solves

`LowCoverageViewSmokeTests` retained two assertion-free probes that did not establish observable behavior:

- `VisualEffectView` was mounted and measured twice with no expected outcome or regression provenance.
- the Dock visibility test queued two asynchronous operations, waited for neither, and wrote `UserDefaults.standard` even though production reads `AppDefaults.standard`.

## Why This Change Was Made

Delete those two probes and their now-unused AppKit/SwiftUI imports. Keep the Notify overlay replacement assertion and Talk overlay presentation/teardown smoke, both of which exercise real lifecycle behavior.

Production callers for `VisualEffectView` and `DockIconManager` remain unchanged.

## User Impact

No user-visible behavior changes. This removes 16 test lines with no production change.

## Evidence

- `swift test --package-path apps/macos --filter LowCoverageViewSmokeTests` passed: 2 tests in 1 suite.
- Swift formatting passed with zero changes required.
- Repository app changed-file gate passed, including Swift lint and all six selected macOS CI Vitest shards.
- The configured remote backend was unavailable because the `blacksmith` executable is not installed on this host, so the changed-file wrapper completed its documented local fallback.
- `git diff --check` passed.
- Structured branch autoreview found no accepted or actionable findings.
