### PR TITLE
improve: reduce media reply test startup time

### DIFF
--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -62,6 +62,13 @@ vi.mock("../../agents/harness/hook-helpers.js", () => ({
   runAgentHarnessBeforeMessageWriteHook: vi.fn((params: { message: unknown }) => params.message),
 }));
 
+// Provider policy projection belongs to its adapter and provider-local suites. These tests
+// exercise prepared reply orchestration and supply their own model/thinking facts.
+vi.mock("../../plugins/provider-policy-surface.js", () => ({
+  resolveDirectBundledProviderPolicySurface: () => null,
+  resolveTrustedExternalProviderPolicySurface: () => null,
+}));
+
 vi.mock("../../config/sessions/group.js", () => ({
   resolveGroupSessionKey: vi.fn().mockReturnValue(undefined),
 }));


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI bottleneck where the media-only prepared-reply suite loaded and transformed the bundled provider-policy public surface even though its 122 orchestration tests supply their own model and thinking facts.

## Why This Change Was Made

The suite now replaces the provider-policy loader at its ownership boundary. Provider projection remains covered by `provider-policy-surface.test.ts`, `provider-public-artifacts.test.ts`, and provider route/thinking suites; this suite continues to cover prepared reply admission, media, session, delivery, and injected runtime-thinking behavior.

No production code, CI job count, worker count, or shard count changes.

## User Impact

No runtime behavior changes. Contributors and CI spend less time running this focused auto-reply suite, with lower peak memory use.

## Evidence

Same fresh-cache command on Node 24.15.0, one worker:

```text
node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-run.media-only.test.ts --maxWorkers=1 --reporter=verbose

before: 74.12s wall, 122/122 passed, 1.91 GiB peak RSS
 after: 48.93s wall, 122/122 passed, 1.15 GiB peak RSS
change: 34.0% faster
```

The baseline and optimized runs both used distinct empty `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH` directories. Targeted format, lint, changed-lane classification (`coreTests` only), and `git diff --check` pass. Exact-head CI will supply test typechecking and the normal core test lane.

Test audit: all 122 behavioral assertions are retained. The mocked provider-policy projection is independently covered at its direct bundled and trusted-external owner boundaries; the thinking assertions here explicitly inject `modelState.resolveThinkingCatalog` facts.
