### PR TITLE
test(ui): remove duplicate stale plugin recovery test

### DIFF
--- a/ui/src/pages/plugin/plugin-page.lazy-load.test.ts
+++ b/ui/src/pages/plugin/plugin-page.lazy-load.test.ts
@@ -2,8 +2,6 @@ import { describe, expect, it, vi } from "vitest";
 import type { GatewayHelloOk } from "../../api/gateway.ts";
 import type { RouteId } from "../../app-route-paths.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
-import { scheduleStaleChunkReload } from "../../app/stale-chunk-reload.ts";
-import { CONTROL_UI_BUILD_INFO } from "../../build-info.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { PluginPage } from "./plugin-page.ts";
 
@@ -92,46 +90,6 @@ describe("PluginPage bundled view load failures", () => {
       expect(page.querySelector('[role="alert"]')).toBeNull();
     } finally {
       page.remove();
-    }
-  });
-
-  it("keeps stale recovery visible after this build already reloaded automatically", async () => {
-    const failedLoad = deferred<TestBundledView>();
-    const values = new Map<string, string>();
-    const storage = {
-      getItem: (key: string) => values.get(key) ?? null,
-      setItem: (key: string, value: string) => void values.set(key, value),
-    };
-    vi.spyOn(window, "sessionStorage", "get").mockReturnValue(storage as Storage);
-    const fetchMock = vi.fn<typeof fetch>(async () => new Response(null, { status: 200 }));
-    vi.stubGlobal("fetch", fetchMock);
-    await scheduleStaleChunkReload({
-      buildId: CONTROL_UI_BUILD_INFO.buildId,
-      now: () => Date.now() - 6_000,
-      reload: vi.fn(),
-      storage,
-    });
-    fetchMock.mockClear();
-    const page = createPage([failedLoad.promise]);
-    document.body.append(page);
-    try {
-      await waitForFast(() => expect(page.querySelector('[role="status"]')).not.toBeNull());
-      failedLoad.reject(new Error("Failed to fetch dynamically imported module"));
-      await waitForFast(() =>
-        expect(page.querySelector('[role="alert"]')?.textContent).toContain(
-          "Failed to fetch dynamically imported module",
-        ),
-      );
-
-      await Promise.resolve();
-      await page.updateComplete;
-
-      expect(fetchMock).not.toHaveBeenCalled();
-      expect(page.querySelector('[role="alert"]')).not.toBeNull();
-    } finally {
-      page.remove();
-      vi.unstubAllGlobals();
-      vi.restoreAllMocks();
     }
   });
 


### PR DESCRIPTION
## What Problem This Solves

`plugin-page.lazy-load.test.ts` repeated the stale-chunk recovery lifecycle already covered through the real browser boundary. The unit case seeded the reload marker and mocked storage, fetch, and dynamic loading internals, so it had to track implementation details without adding an independent failure mode.

## Why This Change Was Made

Delete the duplicate 42-line case and its now-unused imports. Keep the focused unit coverage for retry recovery and stale rejection ordering, while `plugin-bundled-view-recovery.e2e.test.ts` remains the authoritative stale-build lifecycle proof: it aborts the real bundled asset twice, observes the single automatic navigation, verifies the second failure stays visible, and recovers through a manual reload.

## User Impact

No user-visible behavior changes. This removes duplicated implementation-coupled test coverage with no production change.

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/plugin/plugin-page.lazy-load.test.ts ui/src/e2e/plugin-bundled-view-recovery.e2e.test.ts` — 3 retained tests passed.
- `node scripts/check-changed.mjs -- ui/src/pages/plugin/plugin-page.lazy-load.test.ts` — core-test/UI gate passed, including formatting, i18n verification, typecheck, lint, and dead-export scans. The configured remote backend was unavailable because the `blacksmith` executable is not installed on this host, so the wrapper completed its documented local fallback.
- `git diff --check origin/main...HEAD` — passed.
- Structured branch autoreview — no accepted or actionable findings.

Production delta is zero; tests are -42 lines.
