### PR TITLE
fix(codex): restore promoted approval regression coverage

### DIFF
--- a/extensions/codex/src/app-server/event-projector.native-finalization.test.ts
+++ b/extensions/codex/src/app-server/event-projector.native-finalization.test.ts
@@ -376,7 +376,7 @@ describe("CodexAppServerEventProjector native tool finalization", () => {
     expect(toolResult.status).toBe("completed");
     expect(toolResult.isError).toBe(false);
     expect(onToolResult).toHaveBeenCalledWith({
-      text: "🛠️ `run tests (workspace)`",
+      text: "🛠️ Bash",
     });
     expect(trajectoryRecorder.recordEvent).toHaveBeenCalledWith("tool.call", {
       threadId: THREAD_ID,

--- a/extensions/codex/src/app-server/event-projector.progress-echo.test.ts
+++ b/extensions/codex/src/app-server/event-projector.progress-echo.test.ts
@@ -23,7 +23,7 @@ describe("CodexAppServerEventProjector tool progress echo filtering", () => {
     const onToolResult = vi.fn();
     const projector = await createProjector({
       ...(await createParams()),
-      verboseLevel: "on",
+      verboseLevel: "full",
       onToolResult,
     });
 
@@ -71,7 +71,7 @@ describe("CodexAppServerEventProjector tool progress echo filtering", () => {
     const onToolResult = vi.fn();
     const projector = await createProjector({
       ...(await createParams()),
-      verboseLevel: "on",
+      verboseLevel: "full",
       onToolResult,
     });
     const command = "pnpm test";

--- a/extensions/codex/src/app-server/event-projector.replay-safety.test.ts
+++ b/extensions/codex/src/app-server/event-projector.replay-safety.test.ts
@@ -327,7 +327,7 @@ describe("CodexAppServerEventProjector replay safety and progress projection", (
     const onToolResult = vi.fn();
     const projector = await createProjector({
       ...(await createParams()),
-      verboseLevel: "on",
+      verboseLevel: "full",
       onAgentEvent,
       onToolResult,
     });

--- a/extensions/codex/src/app-server/run-attempt-test-harness.ts
+++ b/extensions/codex/src/app-server/run-attempt-test-harness.ts
@@ -14,6 +14,7 @@ import type { ExecApprovalsFile } from "openclaw/plugin-sdk/exec-approvals-runti
 import { clearInternalHooks, resetGlobalHookRunner } from "openclaw/plugin-sdk/hook-runtime";
 import { clearMemoryPluginState } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { clearPluginCommands } from "openclaw/plugin-sdk/plugin-runtime";
+import { createAgentHarnessHostCapabilitiesForTest } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { afterEach, beforeEach, expect, vi } from "vitest";
 import { defaultCodexAppInventoryCache } from "./app-inventory-cache.js";
@@ -82,6 +83,7 @@ const activeAppServerAttemptsForTest = new Set<{
   sessionId: string;
   sessionKey?: string;
 }>();
+const activeHarnessHostClosuresForTest = new Set<() => void>();
 
 type RunCodexAppServerAttemptOptions = Omit<
   NonNullable<Parameters<typeof runCodexAppServerAttemptImpl>[1]>,
@@ -268,6 +270,26 @@ export function createParams(
 
 export function createTestParams(): EmbeddedRunAttemptParams {
   return createParams(path.join(tempDir, "session.jsonl"), path.join(tempDir, "workspace"));
+}
+
+/** Replaces the lightweight default with the admitted host boundary used in production. */
+export async function bindProductionHarnessHostCapabilitiesForTest(
+  params: EmbeddedRunAttemptParams,
+): Promise<() => void> {
+  const { hostCapabilities: _hostCapabilities, ...attempt } = params;
+  const host = await createAgentHarnessHostCapabilitiesForTest({ attempt, pluginId: "codex" });
+  params.hostCapabilities = host.capabilities;
+  let active = true;
+  const close = () => {
+    if (!active) {
+      return;
+    }
+    active = false;
+    activeHarnessHostClosuresForTest.delete(close);
+    host.close();
+  };
+  activeHarnessHostClosuresForTest.add(close);
+  return close;
 }
 
 export function setCodexTestModelSupportsTools(
@@ -676,6 +698,9 @@ export function setupRunAttemptTestHooks(): void {
 
   afterEach(async () => {
     await drainActiveAppServerAttemptsForTest();
+    for (const close of activeHarnessHostClosuresForTest) {
+      close();
+    }
     await sandboxExecServerRegistry.closeAll();
     resetCodexAppServerClientFactoryForTest();
     clearRuntimeAuthProfileStoreSnapshots();

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
@@ -22,6 +22,7 @@ import { readAttemptTerminal } from "./attempt-terminal.test-helper.js";
 import { CodexAppServerRpcError } from "./client.js";
 import { nativeHookRelayUnregisterQueue } from "./native-hook-relay-state.js";
 import {
+  bindProductionHarnessHostCapabilitiesForTest,
   createParams,
   createResumeHarness,
   createStartedThreadHarness,
@@ -285,6 +286,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const params = createParams(sessionFile, workspaceDir);
     params.trigger = "user";
     params.approvalReviewerDeviceId = "device-tui-reviewer";
+    const closeHostCapabilities = await bindProductionHarnessHostCapabilitiesForTest(params);
 
     const run = runCodexAppServerAttempt(params, {
       nativeHookRelay: { enabled: true, events: ["pre_tool_use"] },
@@ -335,6 +337,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     );
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
+    closeHostCapabilities();
     testing.flushPendingCodexNativeHookRelayUnregistersForTests();
   });
 
@@ -360,6 +363,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const params = createParams(sessionFile, workspaceDir);
     params.trigger = "cron";
     params.onAgentEvent = vi.fn();
+    const closeHostCapabilities = await bindProductionHarnessHostCapabilitiesForTest(params);
 
     const run = runCodexAppServerAttempt(params, {
       nativeHookRelay: { enabled: true, events: ["pre_tool_use"] },
@@ -394,6 +398,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
+    closeHostCapabilities();
     testing.flushPendingCodexNativeHookRelayUnregistersForTests();
   });
 

--- a/src/plugin-sdk/plugin-test-runtime.ts
+++ b/src/plugin-sdk/plugin-test-runtime.ts
@@ -1,5 +1,45 @@
 // Focused public test helpers for plugin runtime, registry, and setup fixtures.
 
+import {
+  createOperationalRunInstanceRef,
+  prepareAgentRunAdmission,
+} from "../agents/admitted-run-context.js";
+import type { EmbeddedRunAttemptParams } from "../agents/embedded-agent-runner/run/types.js";
+import { createAgentHarnessHostCapabilities } from "../agents/harness/host-capability.js";
+
+type AgentHarnessHostTestAttempt = Omit<
+  EmbeddedRunAttemptParams,
+  "admittedRunContext" | "hostCapabilities"
+>;
+
+/** Builds the production admitted-run host boundary for plugin integration tests. */
+export async function createAgentHarnessHostCapabilitiesForTest(params: {
+  attempt: AgentHarnessHostTestAttempt;
+  pluginId: string;
+}) {
+  const admission = prepareAgentRunAdmission({
+    cfg: params.attempt.config ?? {},
+    facts: {
+      runId: params.attempt.runId,
+      agentId: params.attempt.agentId ?? "main",
+      ingress: { kind: "system", boundary: "plugin-test-runtime", state: "present" },
+    },
+    operationalRunInstance: createOperationalRunInstanceRef(params.attempt.runId),
+  });
+  const admittedRunContext = await admission.admit("plugin-harness", params.pluginId);
+  const host = createAgentHarnessHostCapabilities({
+    attempt: { ...params.attempt, admittedRunContext },
+    pluginId: params.pluginId,
+  });
+  return {
+    capabilities: host.capabilities,
+    close: () => {
+      host.close();
+      admission.close();
+    },
+  };
+}
+
 export { setDefaultChannelPluginRegistryForTests } from "../commands/channel-test-registry.js";
 export {
   createEmptyPluginRegistry,


### PR DESCRIPTION
Related: #120534

## What Problem This Solves

Fixes an issue where the full Codex plugin suite reported that promoted command and workspace-file approvals bypassed `before_tool_call`, including an unattended approval that appeared to accept when review was required.

The failing reading looked security-sensitive, but the production path was not regressed. The tests entered below the harness-selection boundary with a no-op V2 host capability added by #120534, so they no longer exercised the hook policy they asserted.

## Why This Change Was Made

The two policy-sensitive run-attempt fixtures now use the same admitted-run and closure-bound host-capability builders as production. This preserves #120534's authority model: the raw admitted context stays host-private, the Codex plugin receives only the bound capability, and hook results are revalidated before crossing the native action boundary.

Production caller trace:

- `src/agents/embedded-agent-runner/run/runtime-preparation.ts:512` resolves the canonical admitted context.
- `src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts:232` rejects dispatch without it.
- `src/agents/harness/selection.ts:716` strips private state and mints `createAgentHarnessHostCapabilities(...)` for the registered plugin owner.
- `src/agents/harness/host-capability.ts:242` invokes `runBeforeToolCallHook` through the closure-bound capability and revalidates authority after awaited policy work.
- `extensions/codex/harness.ts:230` passes the host-prepared V2 params into the Codex attempt.
- `extensions/codex/src/app-server/approval-bridge.ts:415` routes native relay decisions, and `:444` routes the remaining approval policy through that host capability.

The pinned Codex 0.147.0 source confirms these responses are enforceable protocol decisions: command/file `accept` and `decline` are distinct in [`item.rs`](https://github.com/openai/codex/blob/rust-v0.147.0/codex-rs/app-server-protocol/src/protocol/v2/item.rs#L59-L114), the approval request/response payloads are defined at [`item.rs`](https://github.com/openai/codex/blob/rust-v0.147.0/codex-rs/app-server-protocol/src/protocol/v2/item.rs#L1442-L1540), and app-server maps `decline` to denial in [`bespoke_event_handling.rs`](https://github.com/openai/codex/blob/rust-v0.147.0/codex-rs/app-server/src/bespoke_event_handling.rs#L1914-L2021).

The same full-suite audit found four unrelated stale projector assertions from #121600's privacy-safe verbose policy. Those exact test-only corrections were already validated on the release branch in #121946 and are forward-ported here. No production behavior changes.

## User Impact

No shipped runtime behavior changes. Maintainers regain trustworthy coverage that promoted Codex approvals flow through the native hook relay and fail closed when unattended review is required.

This removes the #120534 hook-relay reds and the four stale event-projector reds from the observed full Codex lane. PR #122831 separately owns the excluded media-understanding and thread-lifecycle failures; together these repairs unbreak that red main lane.

Production LOC: +0/-0. Tests and test support: +74/-4.

## Evidence

- Bisect: `run-attempt.native-hook-relay.test.ts` passed at `73a9eed95ba~1` and failed after `73a9eed95ba` (#120534).
- Before on unmodified `87b503675a3`: 2 failures / 18 passes; hook spy received 0 calls and the unattended response was `{ decision: "accept" }` instead of decline.
- After: `run-attempt.native-hook-relay.test.ts` — 20/20 passed.
- Requested focused set plus host boundary/projector coverage — 190/190 passed across three Vitest shards.
- Hook-relay adjacent suites — 122/122 passed.
- Projector regressions — 37/37 passed.
- `node scripts/check-changed.mjs -- <six touched files>` — passed on Blacksmith Testbox `tbx_01kzw3dnfyrzty7nzbbf35jh92`; run [31649403881](https://github.com/openclaw/openclaw/actions/runs/31649403881).
- Autoreview: clean, no accepted/actionable findings; patch correct at 0.99 confidence.

The original #120534 PR CI run [31457140740](https://github.com/openclaw/openclaw/actions/runs/31457140740) selected a compact core-only fallback because the large diff included `packages/**`; that fallback omitted all Codex extension tests. A separate CI-routing follow-up should preserve affected extension targets when mixed package/core changes fall back.
