### PR TITLE
fix(matrix): resolve exact room session routes

### DIFF
--- a/extensions/matrix/src/session-route.test.ts
+++ b/extensions/matrix/src/session-route.test.ts
@@ -336,14 +336,17 @@ describe("resolveMatrixOutboundSessionRoute", () => {
     expect(route?.recipientSessionExact).toBe(false);
   });
 
-  it("does not claim room ids when DMs are keyed by user identity", () => {
+  it.each([
+    ["legacy room ids", "!ops:example.org"],
+    ["server-less room ids", "!kyPsk-bXS5fEmaIzUxZHgs6QVNyVjlbTSjy_ZkN48Ss"],
+  ])("claims %s independently of DM session scope", (_name, target) => {
     const route = resolveMatrixOutboundSessionRoute({
       cfg: {},
       agentId: "main",
-      target: "!ops:example.org",
+      target,
     });
 
-    expect(route?.recipientSessionExact).toBe(false);
+    expect(route?.recipientSessionExact).toBe(true);
   });
 
   it("resolves per-room DM metadata from the base key when currentSessionKey has a thread suffix", async () => {

--- a/extensions/matrix/src/session-route.ts
+++ b/extensions/matrix/src/session-route.ts
@@ -107,7 +107,7 @@ export function resolveMatrixOutboundSessionRoute(params: ChannelOutboundSession
     accountId: effectiveAccountId,
     recipientSessionExact:
       target.kind === "room"
-        ? dmSessionScope === "per-room" && target.id.startsWith("!") && target.id.includes(":")
+        ? target.id.startsWith("!")
         : dmSessionScope === "per-user"
           ? isMatrixQualifiedUserId(target.id)
           : roomScopedDmId !== undefined,


### PR DESCRIPTION
AI-assisted: yes. I reviewed the implementation and validation results.

## What Problem This Solves

Explicit Matrix room delivery could not derive a session under the default DM scope. A canonical room target was marked non-exact, so delivery failed unless the caller supplied `--session-key`, even though Matrix already had an exact room identity.

## Why This Change Was Made

The Matrix plugin owns whether a normalized target is authoritative. This change treats `!`-prefixed room IDs as exact independently of the DM-only session scope while keeping room aliases (`#…`) non-authoritative. Generic delivery and binding ownership remain unchanged.

## User Impact

Commands targeting either legacy `!room:server` IDs or modern server-less room IDs can resolve their room session without a manually supplied session key. Alias and DM routing behavior is preserved.

## Evidence

- RED on the original base: `node scripts/run-vitest.mjs extensions/matrix/src/session-route.test.ts` — 1 failed, 14 passed; a canonical room was incorrectly non-exact under the default DM scope.
- After rebasing onto current `main`: `node scripts/run-vitest.mjs extensions/matrix/src/session-route.test.ts` — 16 passed.
- `node scripts/run-vitest.mjs src/infra/outbound/agent-delivery.test.ts` — 26 passed.
- `./node_modules/.bin/oxfmt --check extensions/matrix/src/session-route.ts extensions/matrix/src/session-route.test.ts` — passed.
- `node scripts/run-oxlint.mjs --type-aware extensions/matrix/src/session-route.ts extensions/matrix/src/session-route.test.ts` — passed with 0 warnings and 0 errors.
- `git diff --check origin/main...HEAD` — passed.

No live Matrix homeserver send was performed locally.

Fixes #122625
