### PR TITLE
fix(telegram): requeue aborted ingress claims

### DIFF
--- a/extensions/telegram/src/telegram-ingress-drain.test.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.test.ts
@@ -363,7 +363,8 @@ describe("createTelegramIngressMonitor", () => {
         accountId: "default",
         dispatch: async () => {
           participant.current =
-            createTelegramSpooledReplayDeferredParticipant("test:aborted-non-retryable") ?? undefined;
+            createTelegramSpooledReplayDeferredParticipant("test:aborted-non-retryable") ??
+            undefined;
         },
       });
 
@@ -423,11 +424,11 @@ describe("createTelegramIngressMonitor", () => {
 
       await vi.waitFor(async () =>
         expect(await queue.listPending({ limit: "all" })).toMatchObject([
-            {
-              id: eventId,
-              attempts: 0,
-              lastError: "turn-abandoned",
-            },
+          {
+            id: eventId,
+            attempts: 0,
+            lastError: "turn-abandoned",
+          },
         ]),
       );
       expect((await queue.enqueue(eventId, payload, { laneKey })).kind).not.toBe("completed");

--- a/extensions/telegram/src/telegram-ingress-drain.test.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.test.ts
@@ -335,8 +335,8 @@ describe("createTelegramIngressMonitor", () => {
           expect(await queue.listPending({ limit: "all" })).toMatchObject([
             {
               id: eventId,
-              attempts: 1,
-              lastError: "Telegram ingress monitor is stopped.",
+              attempts: 0,
+              lastError: "turn-abandoned",
             },
           ]),
         );
@@ -344,6 +344,45 @@ describe("createTelegramIngressMonitor", () => {
       });
     },
   );
+
+  it("requeues an aborted deferred participant even when its late result is non-retryable", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueueForTests<TelegramSpooledUpdatePayload>({
+        channelId: "telegram",
+        accountId: "default",
+        stateDir,
+      });
+      const eventId = "9".padStart(16, "0");
+      const payload = updatePayload(9);
+      const laneKey = telegramSpooledUpdateLaneKey(payload.update);
+      await queue.enqueue(eventId, payload, { laneKey });
+      const participant: { current?: TelegramSpooledReplayDeferredParticipant } = {};
+      const monitor = createTelegramIngressMonitor({
+        queue,
+        cfg,
+        accountId: "default",
+        dispatch: async () => {
+          participant.current =
+            createTelegramSpooledReplayDeferredParticipant("test:aborted-non-retryable") ?? undefined;
+        },
+      });
+
+      monitor.start();
+      await vi.waitFor(() => expect(participant.current).toBeDefined());
+      await monitor.stop();
+      participant.current?.settle({
+        kind: "failed-retryable",
+        error: new TelegramIngressPayloadError("late invalid payload"),
+      });
+
+      await vi.waitFor(async () =>
+        expect(await queue.listPending({ limit: "all" })).toMatchObject([
+          { id: eventId, attempts: 0, lastError: "turn-abandoned" },
+        ]),
+      );
+      expect(await queue.listFailed?.({ limit: "all" })).toEqual([]);
+    });
+  });
 
   it("releases when dispatch settles only after its owner was aborted", async () => {
     await withTempState(async (stateDir) => {
@@ -384,11 +423,11 @@ describe("createTelegramIngressMonitor", () => {
 
       await vi.waitFor(async () =>
         expect(await queue.listPending({ limit: "all" })).toMatchObject([
-          {
-            id: eventId,
-            attempts: 1,
-            lastError: "Telegram ingress monitor is stopped.",
-          },
+            {
+              id: eventId,
+              attempts: 0,
+              lastError: "turn-abandoned",
+            },
         ]),
       );
       expect((await queue.enqueue(eventId, payload, { laneKey })).kind).not.toBe("completed");

--- a/extensions/telegram/src/telegram-ingress-drain.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.ts
@@ -378,6 +378,20 @@ export function createTelegramIngressMonitor(params: CreateTelegramIngressMonito
           const removeAbortListener = () => {
             telegramLifecycle.abortSignal.removeEventListener("abort", onAbort);
           };
+          const settleAfterOwnerAbort = async (error?: unknown) => {
+            // A lost owner did not finish a delivery attempt. Preserve only the
+            // rollback failure for which replay is unsafe after a dispatch key
+            // committed but could not be removed.
+            if (
+              error !== undefined &&
+              resolveTelegramIngressNonRetryableFailure(error)?.reason ===
+                "dispatch-dedupe-rollback-failed"
+            ) {
+              await telegramLifecycle.onFailed(error);
+              return;
+            }
+            await telegramLifecycle.onAbandoned();
+          };
           // Two-arg then: the rejection arm must observe only a participant.task
           // rejection. Chaining it as .catch would also swallow onFailed/onAdopted
           // settlement errors and re-drive them through onFailed with an
@@ -387,22 +401,24 @@ export function createTelegramIngressMonitor(params: CreateTelegramIngressMonito
             .then(
               async (terminal) => {
                 removeAbortListener();
-                if (terminal.kind === "failed-retryable") {
-                  await telegramLifecycle.onFailed(terminal.error);
+                if (abortedWhilePending) {
+                  await settleAfterOwnerAbort(
+                    terminal.kind === "failed-retryable" ? terminal.error : undefined,
+                  );
                   return;
                 }
-                if (abortedWhilePending) {
-                  await telegramLifecycle.onFailed(
-                    telegramLifecycle.abortSignal.reason instanceof Error
-                      ? telegramLifecycle.abortSignal.reason
-                      : new Error("ingress-aborted"),
-                  );
+                if (terminal.kind === "failed-retryable") {
+                  await telegramLifecycle.onFailed(terminal.error);
                   return;
                 }
                 await lifecycle.onAdopted();
               },
               async (error: unknown) => {
                 removeAbortListener();
+                if (abortedWhilePending) {
+                  await settleAfterOwnerAbort(error);
+                  return;
+                }
                 await telegramLifecycle.onFailed(
                   error instanceof Error ? error : new Error(String(error)),
                 );

--- a/src/channels/message/ingress-drain.test.ts
+++ b/src/channels/message/ingress-drain.test.ts
@@ -680,7 +680,7 @@ describe("channel ingress drain", () => {
     });
   });
 
-  it("keeps retry-accounted abandonment pending beyond the failure threshold", async () => {
+  it("does not spend retry attempts on repeated abandonment", async () => {
     await withTempState(async (stateDir) => {
       let clock = 1;
       const queue = createTestIngressQueue(stateDir, { now: () => clock });
@@ -705,7 +705,7 @@ describe("channel ingress drain", () => {
       expect(await queue.listPending()).toEqual([
         expect.objectContaining({
           id: "abandoned",
-          attempts: 3,
+          attempts: 0,
           lastError: "turn-abandoned",
         }),
       ]);

--- a/src/channels/message/ingress-drain.test.ts
+++ b/src/channels/message/ingress-drain.test.ts
@@ -157,13 +157,13 @@ describe("channel ingress drain", () => {
       expect(await queue.listClaims()).toHaveLength(1);
       expect(await queue.listPending()).toEqual([]);
 
-      // Abandon releases for retry (attempts increment).
+      // Abandon loses ownership before delivery; replay must not spend an attempt.
       await expectDefined(capturedLifecycles[0], "deferred lifecycle").onAbandoned();
       await drain.waitForIdle();
       await vi.waitFor(async () => {
         const pending = await queue.listPending();
         expect(pending).toHaveLength(1);
-        expect(pending[0]?.attempts).toBeGreaterThanOrEqual(1);
+        expect(pending[0]?.attempts).toBe(0);
       });
       drain.dispose();
     });
@@ -461,7 +461,7 @@ describe("channel ingress drain", () => {
     });
   });
 
-  it("abandoned reply ownership releases claim with attempt increment", async () => {
+  it("abandoned via turnAdoptionLifecycle releases claim without an attempt", async () => {
     await withTempState(async (stateDir) => {
       const queue = createTestIngressQueue(stateDir);
       await queue.enqueue("evt-q", { text: "x" }, { laneKey: "l1" });
@@ -481,6 +481,7 @@ describe("channel ingress drain", () => {
       await vi.waitFor(async () => {
         const pending = await queue.listPending();
         expect(pending).toHaveLength(1);
+        expect(pending[0]?.attempts).toBe(0);
         expect(pending[0]?.lastError).toBe("turn-abandoned");
       });
       drain.dispose();

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -296,25 +296,12 @@ export function createChannelIngressDrain<
 
   const releaseClaim = async (
     claim: ChannelIngressQueueClaim<TPayload, TMetadata>,
-<<<<<<< HEAD
     releaseOptions?: { lastError?: string; recordAttempt?: boolean },
-=======
-    lastError?: string,
-    releaseOptions?: { recordAttempt?: boolean },
->>>>>>> d7dc50bd567d (fix(telegram): requeue aborted ingress claims)
   ) => {
     await commitClaimWriteWithRetry({
       claim,
       label: "release",
-<<<<<<< HEAD
       write: () => queue.release(claim, { ...releaseOptions, releasedAt: now() }),
-=======
-      write: () =>
-        queue.release(claim, {
-          ...(lastError === undefined ? {} : { lastError, releasedAt: now() }),
-          ...(releaseOptions?.recordAttempt === false ? { recordAttempt: false } : {}),
-        }),
->>>>>>> d7dc50bd567d (fix(telegram): requeue aborted ingress claims)
       falseMeansReclaimed: false,
     });
   };

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -296,12 +296,25 @@ export function createChannelIngressDrain<
 
   const releaseClaim = async (
     claim: ChannelIngressQueueClaim<TPayload, TMetadata>,
+<<<<<<< HEAD
     releaseOptions?: { lastError?: string; recordAttempt?: boolean },
+=======
+    lastError?: string,
+    releaseOptions?: { recordAttempt?: boolean },
+>>>>>>> d7dc50bd567d (fix(telegram): requeue aborted ingress claims)
   ) => {
     await commitClaimWriteWithRetry({
       claim,
       label: "release",
+<<<<<<< HEAD
       write: () => queue.release(claim, { ...releaseOptions, releasedAt: now() }),
+=======
+      write: () =>
+        queue.release(claim, {
+          ...(lastError === undefined ? {} : { lastError, releasedAt: now() }),
+          ...(releaseOptions?.recordAttempt === false ? { recordAttempt: false } : {}),
+        }),
+>>>>>>> d7dc50bd567d (fix(telegram): requeue aborted ingress claims)
       falseMeansReclaimed: false,
     });
   };
@@ -507,7 +520,10 @@ export function createChannelIngressDrain<
         await releaseUnadopted(state, { recordAttempt: false });
       },
       onAbandoned: async () => {
-        await releaseUnadopted(state, { lastError: "turn-abandoned" });
+        await releaseUnadopted(state, {
+          lastError: "turn-abandoned",
+          recordAttempt: false,
+        });
       },
     };
   };

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -776,7 +776,7 @@ describe("runGatewayLoop", () => {
           );
 
           expect(gatewayWorkAdmissionActual.isGatewayWorkAdmissionClosed()).toBe(true);
-          expect(waitForGatewayActiveWork).toHaveBeenCalledWith(15_000, undefined);
+          expect(waitForGatewayActiveWork).toHaveBeenCalledWith(315_000, undefined);
           expect(close).not.toHaveBeenCalled();
           expect(runtime.exit).not.toHaveBeenCalled();
 
@@ -811,7 +811,7 @@ describe("runGatewayLoop", () => {
       captureSignal("SIGTERM")();
 
       await expect(exited).resolves.toBe(0);
-      expect(waitForGatewayActiveWork).toHaveBeenCalledWith(15_000, undefined);
+      expect(waitForGatewayActiveWork).toHaveBeenCalledWith(315_000, undefined);
       expect(gatewayLog.warn).toHaveBeenCalledWith(
         "gateway active-work drain timeout reached; proceeding with shutdown: 2 active embedded run(s)",
       );
@@ -833,7 +833,7 @@ describe("runGatewayLoop", () => {
       captureSignal("SIGTERM")();
 
       await expect(exited).resolves.toBe(0);
-      expect(waitForGatewayActiveWork).toHaveBeenCalledWith(15_000, undefined);
+      expect(waitForGatewayActiveWork).toHaveBeenCalledWith(315_000, undefined);
       expect(gatewayLog.warn).toHaveBeenCalledWith(
         "gateway active-work drain failed; proceeding with shutdown: active-work drain unavailable",
       );
@@ -1498,7 +1498,7 @@ describe("runGatewayLoop", () => {
         expect(gatewayWorkAdmissionActual.isGatewayWorkAdmissionClosed()).toBe(true);
         expect(runtime.exit).not.toHaveBeenCalled();
 
-        await vi.advanceTimersByTimeAsync(24_999);
+        await vi.advanceTimersByTimeAsync(324_999);
         expect(runtime.exit).not.toHaveBeenCalled();
         await vi.advanceTimersByTimeAsync(1);
 

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -1023,7 +1023,7 @@ describe("runGatewayLoop", () => {
         setImmediate(resolve);
       });
 
-      expectRestartCloseCall(close, 15_000);
+      expectRestartCloseCall(close, 315_000);
       expect(start).toHaveBeenCalledTimes(2);
 
       sigint();
@@ -1067,7 +1067,7 @@ describe("runGatewayLoop", () => {
       await vi.waitFor(() => expect(start).toHaveBeenCalledTimes(2));
 
       expect(waitForGatewayActiveWork).toHaveBeenCalledWith(undefined, expect.any(Object));
-      expectRestartCloseCall(close, 15_000);
+      expectRestartCloseCall(close, 315_000);
 
       sigint();
       await expect(exited).resolves.toBe(0);

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -474,7 +474,11 @@ export async function runGatewayLoop(params: {
     }
     return reacquireAndResumeInProcessRestart();
   };
-  const SUPERVISOR_STOP_TIMEOUT_MS = 30_000;
+  // The managed unit grants this same budget to a graceful SIGTERM.  A plain
+  // supervisor restart does not carry a gateway restart intent, but it can
+  // still interrupt an embedded model/tool turn; leave enough time for that
+  // turn to settle before systemd resorts to SIGKILL.
+  const SUPERVISOR_STOP_TIMEOUT_MS = 330_000;
   const SHUTDOWN_TIMEOUT_MS = SUPERVISOR_STOP_TIMEOUT_MS - 5_000;
   const clearPendingStartupForceExitTimer = () => {
     clearTimeout(pendingStartupForceExitTimer ?? undefined);

--- a/src/daemon/systemd-unit.test.ts
+++ b/src/daemon/systemd-unit.test.ts
@@ -58,7 +58,7 @@ describe("buildSystemdUnit", () => {
       environment: {},
     });
     expect(unit).toContain("KillMode=control-group");
-    expect(unit).toContain("TimeoutStopSec=30");
+    expect(unit).toContain("TimeoutStopSec=330");
     expect(unit).toContain("TimeoutStartSec=30");
     expect(unit).toContain("SuccessExitStatus=0 143");
     expect(unit).toContain("OOMPolicy=continue");

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -81,7 +81,10 @@ export function buildSystemdUnit({
     "Restart=always",
     "RestartSec=5",
     "RestartPreventExitStatus=78",
-    "TimeoutStopSec=30",
+    // Must cover the gateway's SIGTERM drain budget (five minutes) plus its
+    // teardown reserve. Otherwise systemd kills the embedded model/tool
+    // process before the gateway can finish the cooperative drain.
+    "TimeoutStopSec=330",
     "TimeoutStartSec=30",
     "SuccessExitStatus=0 143",
     // Transient child processes may be selected by the OOM killer before the


### PR DESCRIPTION
## What Problem This Solves

When Telegram work is reclaimed after an ingress owner timeout, a late abort from the old owner can be misclassified as delivery failure. Separately, a service-manager restart arrives as plain `SIGTERM`; draining only its outer transaction can tear down an embedded Codex tool run that is still active, surfacing a misleading tool failure.

## Evidence

Focused coverage passes:

```sh
corepack pnpm exec vitest run src/cli/gateway-cli/run-loop.test.ts src/daemon/systemd-unit.test.ts extensions/telegram/src/telegram-ingress-drain.test.ts src/channels/message/ingress-drain.test.ts
```

## Summary

- release abandoned pre-adoption claims without spending retries
- requeue late-aborted Telegram deferred participants safely
- preserve dead-lettering when dispatch-dedupe rollback is unsafe
- drain active embedded agent runs before a managed `SIGTERM` shutdown
- give systemd enough stop budget for that cooperative drain