### PR TITLE
fix(tools): preserve partial web fetch status

### DIFF
--- a/src/agents/tools/web-fetch.provider-fallback.test.ts
+++ b/src/agents/tools/web-fetch.provider-fallback.test.ts
@@ -7,6 +7,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { setActiveDegradedSecretOwners } from "../../secrets/runtime-degraded-state.js";
 import { wrapExternalContent } from "../../security/external-content.js";
 import { withFetchPreconnect } from "../../test-utils/fetch-mock.js";
+import { getToolTerminalPresentation } from "../tool-terminal-presentation.js";
 import { createWebFetchTool } from "./web-fetch.js";
 import * as webGuardedFetch from "./web-guarded-fetch.js";
 
@@ -159,6 +160,57 @@ describe("web_fetch provider fallback normalization", () => {
     if (details.spill) {
       await rm(details.spill.path, { force: true });
     }
+  });
+
+  it("preserves short source-truncated provider results through cache and presentation", async () => {
+    global.fetch = withFetchPreconnect(
+      vi.fn(async () => {
+        throw new Error("network failed");
+      }),
+    );
+    const providerExecute = vi.fn(async () => ({
+      text: "partial provider body",
+      truncated: true,
+    }));
+    resolveWebFetchDefinitionMock.mockReturnValue({
+      provider: { id: "firecrawl" },
+      definition: {
+        description: "firecrawl",
+        parameters: {},
+        execute: providerExecute,
+      },
+    });
+    const tool = createWebFetchTool({
+      config: {
+        tools: { web: { fetch: { cacheTtlMinutes: 1 } } },
+      } as OpenClawConfig,
+      sandboxed: false,
+    });
+    const args = { url: "https://example.com/short-partial-provider" };
+
+    const first = await tool?.execute?.("short-partial-provider-first", args);
+    const second = await tool?.execute?.("short-partial-provider-second", args);
+    if (!first || !second) {
+      throw new Error("expected web_fetch results");
+    }
+    const firstDetails = first.details as {
+      truncated?: boolean;
+      spill?: { path: string };
+    };
+    const secondDetails = second?.details as {
+      cached?: boolean;
+      truncated?: boolean;
+      spill?: { path: string };
+    };
+    const terminalPresentation = tool ? getToolTerminalPresentation(tool) : undefined;
+
+    expect(firstDetails.truncated).toBe(true);
+    expect(firstDetails.spill).toBeUndefined();
+    expect(secondDetails.cached).toBe(true);
+    expect(secondDetails.truncated).toBe(true);
+    expect(secondDetails.spill).toBeUndefined();
+    expect(providerExecute).toHaveBeenCalledTimes(1);
+    expect(terminalPresentation?.({}, first)?.text).toContain("Truncated: yes");
   });
 
   it("keeps requested url and only accepts safe provider finalUrl values", async () => {

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -454,7 +454,7 @@ async function spillWebFetchContent(
   sourceTruncated = false,
 ): Promise<WebFetchWrappedContent> {
   if (!wrapped.truncated) {
-    return wrapped;
+    return sourceTruncated ? { ...wrapped, truncated: true } : wrapped;
   }
   // maxChars/maxCharsCap bound the model-visible return text. Recoverable spill
   // uses this fixed file cap so vanished pages can still be read after truncation.

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -707,10 +707,19 @@ describe("web_fetch extraction fallbacks", () => {
       firecrawl: { enabled: false },
     });
     const result = await tool?.execute?.("call", { url: "https://example.com/reset" });
-    const details = result?.details as { text?: string; warning?: string } | undefined;
+    const details = result?.details as
+      | {
+          text?: string;
+          warning?: string;
+          truncated?: boolean;
+          spill?: { path: string };
+        }
+      | undefined;
 
     expect(details?.text).toContain("partial");
+    expect(details?.truncated).toBe(true);
     expect(details?.warning).toContain("Response body incomplete after 7 bytes");
+    expect(details?.spill).toBeUndefined();
   });
 
   it("keeps DNS pinning for web_fetch by default even when HTTP_PROXY is configured", async () => {


### PR DESCRIPTION
## What Problem This Solves

`web_fetch` could receive a short partial response whose producer explicitly reported `truncated: true`, then return and cache it as `truncated: false` solely because the available text fit the local character cap. Provider fallbacks could therefore look completely successful with no remaining partial marker; direct stream-reset responses retained a warning, but terminal presentation still omitted truncation.

## Why This Change Was Made

`spillWebFetchContent` now preserves authoritative source truncation on its short-content early return:

- content that fits remains inline and creates no unnecessary spill file;
- provider and direct partial responses retain `truncated: true`;
- cache hits preserve the same truth;
- terminal presentation reports `Truncated: yes`.

The fix stays at the shared web-fetch content owner and does not change schemas, providers, networking, cache keys, or full-response behavior.

AI-assisted: yes. The defect was found by a frozen current-main Auto QA search-tool audit, independently verified across provider, direct-stream, cache, and presentation paths, then implemented after current-main path revalidation.

## User Impact

Agents no longer mistake short partial web responses for complete pages. They receive an explicit truncation signal even when all available partial content fits inline.

## Evidence

- Pre-fix focused regressions: 2 expected failures, 39 passes.
- Post-fix focused proof: `node scripts/run-vitest.mjs src/agents/tools/web-fetch.provider-fallback.test.ts src/agents/tools/web-tools.fetch.test.ts` — 41 tests passed.
- Provider regression proves short `truncated:true` fallback remains truncated through cache and terminal presentation, with no spill.
- Direct regression uses a real failing `ReadableStream`, preserves the retained-body warning and truncation truth, and creates no spill.
- Initial hosted gate caught a test-only type narrowing error before commit; an explicit result invariant fixed it without changing production.
- Final hosted changed gate: Testbox `tbx_01kzw4c3hyvfr1k5hq3eesjjzv`, run https://github.com/openclaw/openclaw/actions/runs/31650458925 — passed.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/31651195981 attempt 2 — passed at `b24adca8eb245f3aa6c907720fc56de383754a54`. Attempt 1 had one unrelated random-fixture redaction failure in `session-message-events.test.ts`; the failed jobs passed unchanged on rerun.
- Targeted formatting and `git diff --check` passed.
- Fresh local and complete-branch autoreviews: clean at 0.99 confidence.
- Production +1/−1 (net zero); tests +62/−1.
