### PR TITLE
test(discord): move ready abort proof to lifecycle

### DIFF
--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -380,6 +380,36 @@ describe("runDiscordGatewayLifecycle", () => {
     }
   });
 
+  it("returns promptly when abortSignal fires during the READY retry backoff", async () => {
+    vi.useFakeTimers();
+    try {
+      const abortController = new AbortController();
+      const { gateway } = createGatewayHarness();
+      const { lifecycleParams, threadStop, gatewaySupervisor } = createLifecycleHarness({
+        gateway,
+      });
+      lifecycleParams.abortSignal = abortController.signal;
+
+      const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+      await vi.advanceTimersByTimeAsync(15_250);
+      expect(gateway.disconnect).toHaveBeenCalledTimes(1);
+      expect(gateway.connect).toHaveBeenCalledTimes(1);
+      expect(waitForDiscordGatewayStopMock).not.toHaveBeenCalled();
+
+      abortController.abort(new Error("shutdown"));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(waitForDiscordGatewayStopMock).toHaveBeenCalledTimes(1);
+      await expect(lifecyclePromise).resolves.toBeUndefined();
+
+      expectLifecycleCleanup({ threadStop, waitCalls: 1, gatewaySupervisor });
+      expect(vi.getTimerCount()).toBe(0);
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(gateway.connect).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("waits for the stale startup socket to close before reconnecting", async () => {
     vi.useFakeTimers();
     try {
@@ -706,52 +736,6 @@ describe("runDiscordGatewayLifecycle", () => {
         (patch) =>
           patch.connected === true && patch.lifecycle === "ready" && patch.lastDisconnect === null,
       );
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-});
-
-describe("waitForGatewayReady", () => {
-  let waitForGatewayReady: (typeof import("../../test-api.js"))["discordGatewayLifecycleTesting"]["waitForGatewayReady"];
-
-  beforeAll(async () => {
-    waitForGatewayReady = (await import("../../test-api.js")).discordGatewayLifecycleTesting
-      .waitForGatewayReady;
-  });
-
-  it("returns promptly when abortSignal fires during the READY retry backoff", async () => {
-    vi.useFakeTimers();
-    try {
-      const controller = new AbortController();
-      const gateway = {
-        isConnected: false,
-        connect: vi.fn(),
-        disconnect: vi.fn(),
-        ws: null,
-      };
-      const runtime: RuntimeEnv = {
-        log: () => {},
-        error: () => {},
-        exit: () => {},
-      };
-
-      const readyPromise = waitForGatewayReady({
-        gateway,
-        abortSignal: controller.signal,
-        readyTimeoutMs: 200,
-        runtime,
-      });
-
-      await vi.advanceTimersByTimeAsync(250);
-      expect(gateway.connect).toHaveBeenCalledTimes(1);
-      controller.abort();
-
-      await expect(readyPromise).resolves.toBeUndefined();
-      expect(vi.getTimerCount()).toBe(0);
-      await vi.advanceTimersByTimeAsync(2_000);
-      expect(gateway.connect).toHaveBeenCalledTimes(1);
-      expect(gateway.disconnect).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -573,7 +573,3 @@ export async function runDiscordGatewayLifecycle(params: {
     params.threadBindings.stop();
   }
 }
-
-// Test-only surface. Re-exported from the plugin root `test-api.ts` entry so Knip's
-// production scan sees the consumer; tests import `testing` from `test-api.js`.
-export const testing = { waitForGatewayReady };

--- a/extensions/discord/test-api.ts
+++ b/extensions/discord/test-api.ts
@@ -1,2 +1,0 @@
-// Discord test API exposes the gateway lifecycle fixture.
-export { testing as discordGatewayLifecycleTesting } from "./src/monitor/provider.lifecycle.js";


### PR DESCRIPTION
## What Problem This Solves

The Discord READY-backoff abort regression was tested by exporting the private `waitForGatewayReady` helper through a production `testing` object and a plugin-root `test-api.ts` bridge. That kept an implementation seam alive even though the behavior belongs to the full gateway lifecycle.

## Why This Change Was Made

Move the regression through `runDiscordGatewayLifecycle`, where the channel-owned abort signal actually enters the lifecycle owner. The rewritten test proves startup reaches the READY retry backoff, abort immediately reaches the normal stop boundary, lifecycle cleanup runs, no retry timer remains, and no additional reconnect occurs.

Delete the now-unused production `testing` export and the entire Discord `test-api.ts` bridge. Discord's package metadata exposes only `index.ts`, and bundled public-surface tests explicitly exclude `test-api.js`, so this is not a public or shipped Plugin SDK contract.

## User Impact

No behavior change. The existing abort-aware retry remains intact, but its regression coverage now exercises the real owner boundary instead of a private helper.

Production delta is -6 lines; tests are -16 lines net.

## Evidence

- Rewritten focused regression passed through `runDiscordGatewayLifecycle`.
- Historical mutation proof: replacing the abort-aware sleep with the former bare timer failed in 1.8 seconds because `waitForDiscordGatewayStop` was not reached after abort; production was then restored.
- `node scripts/run-vitest.mjs extensions/discord/src/monitor/provider.lifecycle.test.ts extensions/discord/src/monitor.gateway.test.ts packages/retry/src/index.test.ts src/plugins/contracts/extension-test-api-consumption.test.ts src/plugins/bundled-plugin-metadata.test.ts` — 77 tests passed across four shards.
- `node scripts/check-changed.mjs -- extensions/discord/src/monitor/provider.lifecycle.ts extensions/discord/src/monitor/provider.lifecycle.test.ts extensions/discord/test-api.ts` — extension and extension-test gates passed, including API baseline, plugin boundaries, dead exports, both typechecks, lint, storage/media/runtime guards, and import cycles. The configured remote backend was unavailable because the `blacksmith` executable is not installed on this host, so the wrapper used its documented trusted-source local fallback.
- `git diff --check` — passed.
- Structured branch autoreview — no accepted or actionable findings.
