### PR TITLE
fix(ui): archived sessions leave sidebar after navigation

### DIFF
--- a/ui/src/components/app-sidebar-child-session-data.ts
+++ b/ui/src/components/app-sidebar-child-session-data.ts
@@ -110,7 +110,7 @@ export function preserveActiveSessionLineageRows(
     if (!parent) {
       break;
     }
-    preserved[parent[0]] = parent[1];
+    preserved[parent[0]] = parent[1].filter((row) => areUiSessionKeysEquivalent(row.key, childKey));
     childKey = parent[0];
   }
   return preserved;

--- a/ui/src/components/app-sidebar-child-session-data.ts
+++ b/ui/src/components/app-sidebar-child-session-data.ts
@@ -205,6 +205,14 @@ export function evictArchivedSessionLineage(
         row != null && areUiSessionKeysEquivalent(row.key, sessionKey),
     );
   if (selectedRow?.archived === true) {
+    // Navigation has ended the archived row's temporary presentation lease.
+    // Remove it from the child cache before the next canonical list refresh.
+    owner.childSessionRowsByParent = Object.fromEntries(
+      Object.entries(owner.childSessionRowsByParent).map(([parentKey, rows]) => [
+        parentKey,
+        rows.filter((row) => !areUiSessionKeysEquivalent(row.key, sessionKey)),
+      ]),
+    );
     owner.context?.sessions.reconcile(selectedRow, owner.sessionsResult?.defaults, {
       archivedFilter: "active",
     });

--- a/ui/src/e2e/session-management.archive.e2e.test.ts
+++ b/ui/src/e2e/session-management.archive.e2e.test.ts
@@ -614,6 +614,7 @@ suite.define(() => {
 
       await rowFor(target.key).click();
       await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(target.key));
+      await archivedRow.waitFor({ state: "detached", timeout: 10_000 });
 
       await gateway.setMethodResponse("sessions.list", sessionsListResponse([main, target]));
       let listRequestCount = (await gateway.getRequests("sessions.list")).length;
@@ -626,7 +627,6 @@ suite.define(() => {
       await expect
         .poll(async () => (await gateway.getRequests("sessions.list")).length)
         .toBeGreaterThan(listRequestCount);
-      await archivedRow.waitFor({ state: "detached", timeout: 10_000 });
 
       await gateway.setMethodResponse(
         "sessions.list",

--- a/ui/src/e2e/session-management.archive.e2e.test.ts
+++ b/ui/src/e2e/session-management.archive.e2e.test.ts
@@ -7,7 +7,6 @@ import {
   controlUiSessionUrl,
   createSessionManagementE2eSuite,
   installMockGateway,
-  navigateToControlUiSession,
   requireRecord,
   sessionRow,
   sessionsListResponse,
@@ -564,13 +563,27 @@ suite.define(() => {
     const page = await context.newPage();
     const baseTime = Date.parse("2026-07-01T16:00:00.000Z");
     const main = sessionRow("agent:main:main", "Main", baseTime);
+    const target = {
+      ...sessionRow(
+        "agent:main:dashboard:navigation-target",
+        "Navigation target",
+        baseTime - 1_000,
+      ),
+      parentSessionKey: main.key,
+      sessionId: "navigation-target",
+    };
     const archived = {
-      ...sessionRow("agent:main:navigation-archive", "Navigation archive", baseTime - 1_000),
+      ...sessionRow(
+        "agent:main:dashboard:navigation-archive",
+        "Navigation archive",
+        baseTime - 2_000,
+      ),
+      parentSessionKey: main.key,
       sessionId: "navigation-archive",
     };
     const gateway = await installMockGateway(page, {
       methodResponses: {
-        "sessions.list": sessionsListResponse([main, archived]),
+        "sessions.list": sessionsListResponse([main, target, archived]),
         "sessions.patch": {},
       },
       sessionKey: main.key,
@@ -599,16 +612,16 @@ suite.define(() => {
         .locator(".agent-chat__disabled-banner");
       await archivedNotice.waitFor({ state: "visible", timeout: 10_000 });
 
-      await navigateToControlUiSession(page, main.key);
-      await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(main.key));
+      await rowFor(target.key).click();
+      await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(target.key));
 
-      await gateway.setMethodResponse("sessions.list", sessionsListResponse([main]));
+      await gateway.setMethodResponse("sessions.list", sessionsListResponse([main, target]));
       let listRequestCount = (await gateway.getRequests("sessions.list")).length;
       await gateway.emitGatewayEvent("sessions.changed", {
-        ...main,
+        ...target,
         updatedAt: baseTime + 1_000,
         reason: "update",
-        sessionKey: main.key,
+        sessionKey: target.key,
       });
       await expect
         .poll(async () => (await gateway.getRequests("sessions.list")).length)
@@ -619,15 +632,16 @@ suite.define(() => {
         "sessions.list",
         sessionsListResponse([
           { ...main, updatedAt: baseTime + 2_000 },
+          { ...target, updatedAt: baseTime + 3_000 },
           { ...archived, archived: false, updatedAt: baseTime + 3_000 },
         ]),
       );
       listRequestCount = (await gateway.getRequests("sessions.list")).length;
       await gateway.emitGatewayEvent("sessions.changed", {
-        ...main,
+        ...target,
         updatedAt: baseTime + 2_000,
         reason: "update",
-        sessionKey: main.key,
+        sessionKey: target.key,
       });
       await expect
         .poll(async () => (await gateway.getRequests("sessions.list")).length)

--- a/ui/src/e2e/session-management.test-support.ts
+++ b/ui/src/e2e/session-management.test-support.ts
@@ -7,20 +7,13 @@ import {
   controlUiSessionPath,
   controlUiSessionUrl,
   installMockGateway,
-  navigateToControlUiSession,
   waitForConfirmModal,
   type MockGatewayControls,
   type MockGatewayRequest,
 } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-export {
-  controlUiSessionPath,
-  controlUiSessionUrl,
-  installMockGateway,
-  navigateToControlUiSession,
-  waitForConfirmModal,
-};
+export { controlUiSessionPath, controlUiSessionUrl, installMockGateway, waitForConfirmModal };
 
 export const collapsedSessionSectionsStorageKey = "openclaw:sidebar:sessions:collapsed-sections";
 export const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who archived a dashboard session would continue to see it in the Sessions sidebar after navigating to another session. The archived row disappeared only after a page refresh.

## Why This Change Was Made

A canonical session refresh may retain the selected session's lineage while its archived view remains open. The cache preserved every sibling in that lineage, and leaving the archived route reconciled session state without removing the archived child row. This change preserves only the routed ancestry row and evicts an archived child from the lineage cache when navigation ends its presentation lease.

This is a follow-up to #121868.

## User Impact

Archived sessions remain visible while selected, then disappear from the Sessions sidebar as soon as the user navigates elsewhere. Refreshing the page is not required.

## Evidence

- Live browser proof: [screen recording](https://github.com/user-attachments/assets/519f3827-bd28-49bf-8956-9b5ea7cedfdf).
- Focused Control UI mocked-Gateway E2E: 9 passed.
- The regression assertion fails on the pre-fix code because the archived row remains visible for 10 seconds after navigation.
- `oxfmt` and `git diff --check`: passed.
- Autoreview: no accepted or actionable findings.
