### PR TITLE
fix(discord): unblock ingress after retry exhaustion

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"a35378b670434316ba33a3ba4e595925be685daee9fb0f3c5989983525b18c50","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}
+{"contentHash":"812e818c8d7c013b2287c4502426123222037a4235e130a69481272912062866","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
@@ -1,1 +1,1 @@
-{"contentHash":"b9c074a11791688e63213f51099ea21745b0e554f63ed13e694ea34a3e4328ac","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
+{"contentHash":"f639fea8b8ee53626452bdbce156724b09a3a29bb05a134eb8e8f8fb8062d4da","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-core.json
@@ -1,1 +1,1 @@
-{"contentHash":"d8b7c867b29b4651375455e938ae634e7213e3e8c17444dc2b0ef091e46fda6c","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}
+{"contentHash":"02db4abe2f1f4578d438f7afacd68d44114e46b48b9582711e7e10191353e6c5","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
@@ -1,1 +1,1 @@
-{"contentHash":"883bbab77caeff122bf8b7505dc9299484fba601e285a42d2c457697b7590b8e","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}
+{"contentHash":"6826237a93cc52b6039fddbd4b4e0e00e82b5c83cbadd36a055a50ab0480879c","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-inbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-inbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"a10b2b86f7fec9a99f951656b882414b73d04b5e16313bf0747e883da50c37df","entrypoint":"channel-inbound","importSpecifier":"openclaw/plugin-sdk/channel-inbound"}
+{"contentHash":"e0eefe9ad871dbfe2bb8dac626e44ecfcd55c8b35667e9fd041799f2f45ea6ba","entrypoint":"channel-inbound","importSpecifier":"openclaw/plugin-sdk/channel-inbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-ingress-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-ingress-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"5ea7b454922c17117a2a34aae8f2bfd9a45666a7268dff223063bde72b379aff","entrypoint":"channel-ingress-runtime","importSpecifier":"openclaw/plugin-sdk/channel-ingress-runtime"}
+{"contentHash":"6f32863c74ad4ea076404754618d38015ad48281964f1fc24692aae8cd0fcad6","entrypoint":"channel-ingress-runtime","importSpecifier":"openclaw/plugin-sdk/channel-ingress-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-message.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-message.json
@@ -1,1 +1,1 @@
-{"contentHash":"2f85610859f047db1d76efbe52d9e63d8126ce8e944d53d6fdafb4e7f503b5dc","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}
+{"contentHash":"bc8881a906f40f0a3ede29eb83efc1e4d3e59b62c00154b2480d85d69cbe4010","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"6b1f575e77dc71e72c4b2575f366e7e9990d391e85364844e0ecec2146e7f902","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}
+{"contentHash":"f4b35d03ac9df9788462f3e50b64819ff85aba0245b1a51208a288bd994edb8e","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-pairing.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-pairing.json
@@ -1,1 +1,1 @@
-{"contentHash":"d92b60c0b7109446db7d24172281dfd6f79196d6428b8e6fd59e99a3d4d9f016","entrypoint":"channel-pairing","importSpecifier":"openclaw/plugin-sdk/channel-pairing"}
+{"contentHash":"d1c4d7478b9dcb6c4567cb599839c84b843e005ff39f5d31bc317f26d6745853","entrypoint":"channel-pairing","importSpecifier":"openclaw/plugin-sdk/channel-pairing"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
@@ -1,1 +1,1 @@
-{"contentHash":"72d713de6cb87ad8e6d9c49456477367a2d30c8157695ddb66ac57919558272b","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}
+{"contentHash":"80b5ab5fedd16c952c83747f4093db46e49640b3cfa1fdaa5a9727ff31edf0a7","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}

--- a/docs/.generated/plugin-sdk-api-baseline/core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/core.json
@@ -1,1 +1,1 @@
-{"contentHash":"2ccfe8eb85378f3be3f78f79f2638b00faa943e351ff69464bfed44ed63e09c1","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}
+{"contentHash":"edfa6b7a219aef521935ac17a20c5cd74e91bf4988eb3fad5ac75fc2e5015596","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}

--- a/docs/.generated/plugin-sdk-api-baseline/discord.json
+++ b/docs/.generated/plugin-sdk-api-baseline/discord.json
@@ -1,1 +1,1 @@
-{"contentHash":"d23cd5df763235dbe35ede1c23d26735f4c183b03dc216ac212aefe75c0c1f96","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}
+{"contentHash":"6490014377554ea6b62c657ab22c53fcec385b4ad24cdfccd95ebd9a79717e59","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}

--- a/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
+++ b/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
@@ -1,1 +1,1 @@
-{"contentHash":"f57a244e027b326090ed91cdc105c0c8c83b24318d99be0ec205fffd33504050","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}
+{"contentHash":"bb5122c6ac5f4dfe381493b9d128a303108434edca9434ad5528781d005271b8","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}

--- a/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"5008615c80d86383e18527d71442f1501e4f02bdb3faa1494a48edf40fd66f84","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}
+{"contentHash":"9060d4011e1249ca8aa0b01f2e2825d71b29eff14dc84f7f702440dc01e73460","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-command-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-command-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"be5d21b9760636dd2956ac64b786213532e74ebb4cd1cc844a923b7bd5949be7","entrypoint":"plugin-command-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-command-runtime"}
+{"contentHash":"45c491f92e76d0523e2fafc47f362620e2598a5fdef95aed50ce4e8ff108423d","entrypoint":"plugin-command-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-command-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
@@ -1,1 +1,1 @@
-{"contentHash":"6b73741c889f68cc19a5d1f8703df2eca650fe57803795045cff122d746cbb6a","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}
+{"contentHash":"a36c13699a318b3fb1b6701ab3280c45e5a4f5ca982cef29778d10af8a5ae97a","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"15704fc50b81cebceb677a5a69a7bc8c97afd962081c647de58a027bd816f19d","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}
+{"contentHash":"bdf0b57a425cac872d156021006cce6813893bee30e77c5ef4c055343697dba0","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"df8043d0630d95bc4c316da28bf675a713e7f1f0c304959d1b4b9c8b30fcbd0d","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
+{"contentHash":"62f6dc31a2b1789b3667fe16c2d465681aa4c01e2cd9b2a6da062fd995235963","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/runtime-store.json
+++ b/docs/.generated/plugin-sdk-api-baseline/runtime-store.json
@@ -1,1 +1,1 @@
-{"contentHash":"01918241de10b9b625379aa143ea2b3bee3ebf53369dde648c3402227d3cb5f7","entrypoint":"runtime-store","importSpecifier":"openclaw/plugin-sdk/runtime-store"}
+{"contentHash":"b33bfa1835dbfedd3fef5d48720d57cf166fd60dd21727f1c18c49162eb2ab87","entrypoint":"runtime-store","importSpecifier":"openclaw/plugin-sdk/runtime-store"}

--- a/docs/.generated/plugin-sdk-api-baseline/session-catalog.json
+++ b/docs/.generated/plugin-sdk-api-baseline/session-catalog.json
@@ -1,1 +1,1 @@
-{"contentHash":"7bae1f99dfbd5920f9fa2e82abfefdf11e28c3150f15b22ee3fcf115a4dcef19","entrypoint":"session-catalog","importSpecifier":"openclaw/plugin-sdk/session-catalog"}
+{"contentHash":"b8218ab6c7789147d0ced29d4dfa1487af511a2a91f12808587ee97c702947c9","entrypoint":"session-catalog","importSpecifier":"openclaw/plugin-sdk/session-catalog"}

--- a/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
+++ b/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
@@ -1,1 +1,1 @@
-{"contentHash":"8b0c71c8abe13163eee28ca65e6afb490d0ae3c16288292143ad021975b96ca6","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}
+{"contentHash":"3662752cd7db434787d728355a4fb46e8f4be5b88dece9c29d96225bc02da6db","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}

--- a/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
+++ b/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
@@ -1,1 +1,1 @@
-{"contentHash":"eb0096fd25551a7f4a58dcf6c6b53120f3f1ddc1248b2b962cca60c75f6daa12","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}
+{"contentHash":"66ab292503af6befc63d5962f3312a8ebab4ab3bf3a56f47fe4f6a465d7c40b9","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}

--- a/docs/plugins/sdk-channel-outbound.md
+++ b/docs/plugins/sdk-channel-outbound.md
@@ -47,13 +47,15 @@ the transport callback instead of dispatching an event that was not made
 durable. At claim time it decodes the versioned payload, re-runs `inspect`, and
 rejects an id or lane mismatch before delivery.
 
-`deliver` receives `onAdopted`, `onDeferred`, `onAdoptionFinalizing`,
-`onAbandoned`, and `abortSignal`. Returning without an explicit handoff marks a
-terminal no-dispatch event adopted. `admission` is always `exclusive`. A
-deferred handoff keeps the claim held, while shutdown or abort leaves unadopted
-work retryable. The monitor tracks delivery independently from claim settlement
-because adoption can tombstone a row before the channel's delivery promise
-returns.
+`deliver` receives `onAdopted`, `onDeferred`, `onAdoptionFinalizing`, `onFailed`,
+`onCancelled`, `onAbandoned`, and `abortSignal`. Use `onFailed` for delivery
+errors, `onCancelled` for explicit pre-adoption cancellation that must preserve
+retry accounting, and `onAbandoned` when a non-adopted turn should consume a
+retry attempt. Returning without an explicit handoff marks a terminal
+no-dispatch event adopted. `admission` is always `exclusive`. A deferred handoff
+keeps the claim held, while shutdown or abort leaves unadopted work retryable.
+The monitor tracks delivery independently from claim settlement because
+adoption can tombstone a row before the channel's delivery promise returns.
 
 Optional settings include custom append delays, a `drain` option block for
 advanced drain ordering/concurrency/retry policy, an external `abortSignal`, a

--- a/extensions/discord/src/monitor/inbound-job.test.ts
+++ b/extensions/discord/src/monitor/inbound-job.test.ts
@@ -123,6 +123,7 @@ describe("buildDiscordInboundJob", () => {
     const ingressSettlement = {
       settle: vi.fn(async () => {}),
       abandon: vi.fn(async () => {}),
+      cancel: vi.fn(async () => {}),
     };
     const job = buildDiscordInboundJob(ctx, { ingressSettlement });
     const overrideAbortController = new AbortController();

--- a/extensions/discord/src/monitor/inbound-job.ts
+++ b/extensions/discord/src/monitor/inbound-job.ts
@@ -26,6 +26,7 @@ export type DiscordInboundJob = {
   ingressSettlement?: {
     settle: () => Promise<void>;
     abandon: (error?: unknown) => Promise<void>;
+    cancel: () => Promise<void>;
   };
 };
 

--- a/extensions/discord/src/monitor/ingress.test.ts
+++ b/extensions/discord/src/monitor/ingress.test.ts
@@ -116,6 +116,31 @@ describe("Discord durable ingress", () => {
     });
   });
 
+  it("rejects unstable message identity before durable allocation", async () => {
+    await withQueue(async (queue) => {
+      const dispatch = vi.fn();
+      const monitor = createDiscordIngressMonitor({
+        accountId: "default",
+        client: {} as never,
+        runtime: runtime(),
+        queue,
+        dispatch,
+      });
+      monitor.start();
+      try {
+        const missingMessageId = { ...createRawMessage("missing"), id: undefined };
+        const missingChannelId = { ...createRawMessage("missing"), channel_id: undefined };
+
+        await expect(monitor.accept(missingMessageId as never)).rejects.toThrow("snowflake");
+        await expect(monitor.accept(missingChannelId as never)).rejects.toThrow("channel_id");
+        expect(await queue.listPending({ limit: "all" })).toEqual([]);
+        expect(dispatch).not.toHaveBeenCalled();
+      } finally {
+        await monitor.stop();
+      }
+    });
+  });
+
   it("recovers a claimed row with a fresh drain and dispatches it exactly once", async () => {
     await withQueue(async (queue) => {
       const monitors: DiscordIngressMonitor[] = [];

--- a/extensions/discord/src/monitor/ingress.ts
+++ b/extensions/discord/src/monitor/ingress.ts
@@ -3,6 +3,7 @@ import { GatewayDispatchEvents, type APIMessage } from "discord-api-types/v10";
 import {
   createChannelIngressError,
   createChannelIngressMonitor,
+  DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
   type ChannelIngressQueue,
   type ChannelIngressMonitorDeliveryResult,
   type ChannelIngressMonitorLifecycle,
@@ -147,6 +148,10 @@ export function createDiscordIngressMonitor(params: {
     },
     appendRetryDelaysMs: [0],
     drain: {
+      retryPolicy: {
+        maxAttempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+        deadLetterMinAgeMs: 0,
+      },
       resolveNonRetryableFailure: (error) => {
         if (error instanceof DiscordIngressPayloadError) {
           return { reason: "invalid-event", message: error.message };

--- a/extensions/discord/src/monitor/message-dispatcher.ts
+++ b/extensions/discord/src/monitor/message-dispatcher.ts
@@ -139,7 +139,7 @@ export function createDiscordMessageDispatcher(
           }
           const abortSignal = last.abortSignal;
           if (abortSignal?.aborted) {
-            await admissionLifecycle.onAbandoned();
+            await ingress.lifecycle?.onCancelled?.();
             return;
           }
           try {
@@ -157,7 +157,7 @@ export function createDiscordMessageDispatcher(
                 turnAdoptionLifecycle: admissionLifecycle,
               });
               if (abortSignal?.aborted) {
-                await ingress.abandon(abortSignal.reason);
+                await ingress.lifecycle?.onCancelled?.();
                 return;
               }
               if (!ctx) {
@@ -211,7 +211,7 @@ export function createDiscordMessageDispatcher(
               turnAdoptionLifecycle: admissionLifecycle,
             });
             if (abortSignal?.aborted) {
-              await ingress.abandon(abortSignal.reason);
+              await ingress.lifecycle?.onCancelled?.();
               return;
             }
             if (!ctx) {
@@ -232,7 +232,10 @@ export function createDiscordMessageDispatcher(
             }
             messageRunQueue.enqueue(buildDiscordInboundJob(ctx, { ingressSettlement: ingress }));
           } catch (error) {
-            await admissionLifecycle.onAbandoned();
+            if (abortSignal?.aborted) {
+              await ingress.lifecycle?.onCancelled?.();
+              return;
+            }
             throw error;
           }
         },
@@ -244,7 +247,7 @@ export function createDiscordMessageDispatcher(
     onCancel: (entries) => {
       for (const entry of entries) {
         pendingDebounceEntries.delete(entry);
-        const settlement = Promise.resolve(entry.turnAdoptionLifecycle?.onAbandoned())
+        const settlement = Promise.resolve(entry.turnAdoptionLifecycle?.onCancelled?.())
           .catch((error: unknown) => {
             params.runtime.error(
               danger(`discord ingress cancellation settlement failed: ${String(error)}`),
@@ -271,6 +274,10 @@ export function createDiscordMessageDispatcher(
         const reason = dispatcherShutdown.signal.aborted
           ? (dispatcherShutdown.signal.reason ?? new Error("discord dispatcher shut down"))
           : (options?.abortSignal?.reason ?? new Error("discord dispatch aborted"));
+        if (options?.turnAdoptionLifecycle?.onCancelled) {
+          await options.turnAdoptionLifecycle.onCancelled();
+          return { kind: "deferred" };
+        }
         return { kind: "failed-retryable", error: reason };
       }
       // Filter bot-own messages before they enter the debounce queue.

--- a/extensions/discord/src/monitor/message-dispatcher.ts
+++ b/extensions/discord/src/monitor/message-dispatcher.ts
@@ -139,7 +139,7 @@ export function createDiscordMessageDispatcher(
           }
           const abortSignal = last.abortSignal;
           if (abortSignal?.aborted) {
-            await ingress.lifecycle?.onCancelled?.();
+            await ingress.cancel();
             return;
           }
           try {
@@ -157,7 +157,7 @@ export function createDiscordMessageDispatcher(
                 turnAdoptionLifecycle: admissionLifecycle,
               });
               if (abortSignal?.aborted) {
-                await ingress.lifecycle?.onCancelled?.();
+                await ingress.cancel();
                 return;
               }
               if (!ctx) {
@@ -211,7 +211,7 @@ export function createDiscordMessageDispatcher(
               turnAdoptionLifecycle: admissionLifecycle,
             });
             if (abortSignal?.aborted) {
-              await ingress.lifecycle?.onCancelled?.();
+              await ingress.cancel();
               return;
             }
             if (!ctx) {
@@ -233,7 +233,7 @@ export function createDiscordMessageDispatcher(
             messageRunQueue.enqueue(buildDiscordInboundJob(ctx, { ingressSettlement: ingress }));
           } catch (error) {
             if (abortSignal?.aborted) {
-              await ingress.lifecycle?.onCancelled?.();
+              await ingress.cancel();
               return;
             }
             throw error;
@@ -247,7 +247,8 @@ export function createDiscordMessageDispatcher(
     onCancel: (entries) => {
       for (const entry of entries) {
         pendingDebounceEntries.delete(entry);
-        const settlement = Promise.resolve(entry.turnAdoptionLifecycle?.onCancelled?.())
+        const settlement = fanInChannelIngressLifecycles([entry.turnAdoptionLifecycle])
+          .cancel()
           .catch((error: unknown) => {
             params.runtime.error(
               danger(`discord ingress cancellation settlement failed: ${String(error)}`),
@@ -274,8 +275,8 @@ export function createDiscordMessageDispatcher(
         const reason = dispatcherShutdown.signal.aborted
           ? (dispatcherShutdown.signal.reason ?? new Error("discord dispatcher shut down"))
           : (options?.abortSignal?.reason ?? new Error("discord dispatch aborted"));
-        if (options?.turnAdoptionLifecycle?.onCancelled) {
-          await options.turnAdoptionLifecycle.onCancelled();
+        if (options?.turnAdoptionLifecycle) {
+          await fanInChannelIngressLifecycles([options.turnAdoptionLifecycle]).cancel();
           return { kind: "deferred" };
         }
         return { kind: "failed-retryable", error: reason };

--- a/extensions/discord/src/monitor/message-handler.ingress-recovery.test.ts
+++ b/extensions/discord/src/monitor/message-handler.ingress-recovery.test.ts
@@ -1,0 +1,263 @@
+// Discord tests cover durable retry recovery through full handler replacement.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { APIMessage } from "discord-api-types/v10";
+import {
+  type ChannelIngressQueue,
+  DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+} from "openclaw/plugin-sdk/channel-outbound";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { describe, expect, it, vi } from "vitest";
+import { createDiscordIngressMonitor } from "./ingress.js";
+import { createDiscordMessageHandler } from "./message-handler.js";
+import { createDiscordHandlerParams } from "./message-handler.test-helpers.js";
+
+type DiscordIngressPayload = {
+  version: 1;
+  receivedAt: number;
+  rawMessage: APIMessage;
+};
+
+type DiscordQueue = ChannelIngressQueue<DiscordIngressPayload>;
+
+function rawMessage(id: string, channelId = "lane-a"): APIMessage {
+  return {
+    id,
+    channel_id: channelId,
+    content: "hello",
+    author: {
+      id: "user-1",
+      username: "alice",
+      discriminator: "0",
+      avatar: null,
+    },
+    attachments: [],
+    embeds: [],
+    mentions: [],
+    mention_roles: [],
+    mention_everyone: false,
+    timestamp: new Date(0).toISOString(),
+    edited_timestamp: null,
+    components: [],
+    pinned: false,
+    type: 0,
+    tts: false,
+  } as unknown as APIMessage;
+}
+
+async function withQueue(run: (queue: DiscordQueue) => Promise<void>): Promise<void> {
+  const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-recovery-"));
+  const stateDir = await fs.realpath(created);
+  const queue = createChannelIngressQueueForTests<DiscordIngressPayload>({
+    channelId: "discord",
+    accountId: "default",
+    stateDir,
+  });
+  try {
+    await run(queue);
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+async function seedPendingFailure(params: {
+  queue: DiscordQueue;
+  id: string;
+  attempts: number;
+  laneKey?: string;
+}): Promise<void> {
+  await params.queue.enqueue(
+    params.id,
+    { version: 1, receivedAt: 1, rawMessage: rawMessage(params.id) },
+    { laneKey: params.laneKey ?? "channel:lane-a", receivedAt: 1 },
+  );
+  for (let attempt = 1; attempt <= params.attempts; attempt += 1) {
+    const claim = await params.queue.claim(params.id, { ownerId: `seed-${attempt}` });
+    if (!claim) {
+      throw new Error(`Expected ${params.id} to be claimable for seed attempt ${attempt}`);
+    }
+    await params.queue.release(claim, {
+      lastError: `prior genuine failure ${attempt}`,
+      releasedAt: 10 + attempt,
+    });
+  }
+}
+
+async function retryFacts(queue: DiscordQueue, id: string) {
+  const record = (await queue.listPending({ limit: "all" })).find((entry) => entry.id === id);
+  if (!record) {
+    throw new Error(`Expected pending Discord ingress row ${id}`);
+  }
+  return {
+    attempts: record.attempts,
+    lastAttemptAt: record.lastAttemptAt,
+    lastError: record.lastError,
+  };
+}
+
+function createHandler(params: {
+  queue: DiscordQueue;
+  preflight: (input: { data: { message?: { id?: string } } }) => Promise<null>;
+  debounceMs?: number;
+  beforeDispatch?: () => Promise<void>;
+}) {
+  const handlerParams = createDiscordHandlerParams();
+  handlerParams.cfg.messages = { inbound: { debounceMs: params.debounceMs ?? 0 } };
+  return createDiscordMessageHandler({
+    ...handlerParams,
+    client: {} as never,
+    testing: {
+      preflightDiscordMessage: params.preflight as never,
+      createIngressMonitor: (monitorParams) =>
+        createDiscordIngressMonitor({
+          ...monitorParams,
+          queue: params.queue,
+          dispatch: params.beforeDispatch
+            ? async (event, lifecycle) => {
+                await params.beforeDispatch?.();
+                return await monitorParams.dispatch(event, lifecycle);
+              }
+            : monitorParams.dispatch,
+        }),
+    },
+  });
+}
+
+describe("Discord durable ingress replacement recovery", () => {
+  it("terminally settles a preexisting exhausted poison row before its follower", async () => {
+    await withQueue(async (queue) => {
+      await seedPendingFailure({
+        queue,
+        id: "poison",
+        attempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+      });
+      await queue.enqueue(
+        "follower",
+        { version: 1, receivedAt: 2, rawMessage: rawMessage("follower") },
+        { laneKey: "channel:lane-a", receivedAt: 2 },
+      );
+      const dispatched: string[] = [];
+      const handler = createHandler({
+        queue,
+        preflight: vi.fn(async ({ data }) => {
+          const id = data.message?.id ?? "unknown";
+          dispatched.push(id);
+          if (id === "poison") {
+            throw new Error("recovered poison failure");
+          }
+          return null;
+        }),
+      });
+      try {
+        await vi.waitFor(async () => {
+          await expect(queue.enqueue("poison", {} as DiscordIngressPayload)).resolves.toMatchObject(
+            { kind: "failed", record: { reason: "retry-limit-exceeded" } },
+          );
+          await expect(
+            queue.enqueue("follower", {} as DiscordIngressPayload),
+          ).resolves.toMatchObject({ kind: "completed" });
+        });
+        expect(dispatched).toEqual(["poison", "follower"]);
+        expect(await queue.listPending({ limit: "all" })).toEqual([]);
+        expect(await queue.listClaims()).toEqual([]);
+      } finally {
+        await handler.deactivate();
+      }
+    });
+  });
+
+  it("preserves retry facts across every Discord cancellation route and replacement", async () => {
+    await withQueue(async (queue) => {
+      await seedPendingFailure({
+        queue,
+        id: "poison",
+        attempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS - 1,
+      });
+      await queue.enqueue(
+        "follower",
+        { version: 1, receivedAt: 2, rawMessage: rawMessage("follower") },
+        { laneKey: "channel:lane-a", receivedAt: 2 },
+      );
+      const expectedFacts = await retryFacts(queue, "poison");
+
+      const dispatchEntered = createDeferred<void>();
+      const releaseDispatch = createDeferred<void>();
+      const beforeDispatch = async () => {
+        dispatchEntered.resolve();
+        await releaseDispatch.promise;
+      };
+      const beforeDispatchPreflight = vi.fn(async () => null);
+      const beforeDispatchHandler = createHandler({
+        queue,
+        preflight: beforeDispatchPreflight,
+        beforeDispatch,
+      });
+      await dispatchEntered.promise;
+      const beforeDispatchStop = beforeDispatchHandler.deactivate();
+      await Promise.resolve();
+      releaseDispatch.resolve();
+      await beforeDispatchStop;
+      expect(beforeDispatchPreflight).not.toHaveBeenCalled();
+      expect(await retryFacts(queue, "poison")).toEqual(expectedFacts);
+
+      const bufferedPreflight = vi.fn(async () => null);
+      const bufferedHandler = createHandler({
+        queue,
+        preflight: bufferedPreflight,
+        debounceMs: 60_000,
+      });
+      await vi.waitFor(async () => expect(await queue.listClaims()).toHaveLength(1));
+      await bufferedHandler.deactivate();
+      expect(bufferedPreflight).not.toHaveBeenCalled();
+      expect(await retryFacts(queue, "poison")).toEqual(expectedFacts);
+
+      const preflightEntered = createDeferred<void>();
+      const releasePreflight = createDeferred<void>();
+      const activePreflight = vi.fn(async () => {
+        preflightEntered.resolve();
+        await releasePreflight.promise;
+        return null;
+      });
+      const activeHandler = createHandler({ queue, preflight: activePreflight });
+      await preflightEntered.promise;
+      const activeStop = activeHandler.deactivate();
+      await Promise.resolve();
+      releasePreflight.resolve();
+      await activeStop;
+      expect(activePreflight).toHaveBeenCalledTimes(1);
+      expect(await retryFacts(queue, "poison")).toEqual(expectedFacts);
+
+      const finalDispatches: string[] = [];
+      const replacement = createHandler({
+        queue,
+        preflight: vi.fn(async ({ data }) => {
+          const id = data.message?.id ?? "unknown";
+          finalDispatches.push(id);
+          if (id === "poison") {
+            throw new Error("final genuine failure");
+          }
+          return null;
+        }),
+      });
+      try {
+        await vi.waitFor(async () => {
+          await expect(queue.enqueue("poison", {} as DiscordIngressPayload)).resolves.toMatchObject(
+            { kind: "failed", record: { reason: "retry-limit-exceeded" } },
+          );
+          await expect(
+            queue.enqueue("follower", {} as DiscordIngressPayload),
+          ).resolves.toMatchObject({ kind: "completed" });
+        });
+        expect(finalDispatches).toEqual(["poison", "follower"]);
+      } finally {
+        await replacement.deactivate();
+      }
+    });
+  });
+});

--- a/extensions/discord/src/monitor/message-handler.ingress-recovery.test.ts
+++ b/extensions/discord/src/monitor/message-handler.ingress-recovery.test.ts
@@ -1,7 +1,4 @@
 // Discord tests cover durable retry recovery through full handler replacement.
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import type { APIMessage } from "discord-api-types/v10";
 import {
   type ChannelIngressQueue,
@@ -12,7 +9,8 @@ import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import { createDiscordIngressMonitor } from "./ingress.js";
 import { createDiscordMessageHandler } from "./message-handler.js";
 import { createDiscordHandlerParams } from "./message-handler.test-helpers.js";
@@ -24,6 +22,8 @@ type DiscordIngressPayload = {
 };
 
 type DiscordQueue = ChannelIngressQueue<DiscordIngressPayload>;
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function rawMessage(id: string, channelId = "lane-a"): APIMessage {
   return {
@@ -51,8 +51,7 @@ function rawMessage(id: string, channelId = "lane-a"): APIMessage {
 }
 
 async function withQueue(run: (queue: DiscordQueue) => Promise<void>): Promise<void> {
-  const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-recovery-"));
-  const stateDir = await fs.realpath(created);
+  const stateDir = tempDirs.make("openclaw-discord-recovery-");
   const queue = createChannelIngressQueueForTests<DiscordIngressPayload>({
     channelId: "discord",
     accountId: "default",
@@ -62,7 +61,6 @@ async function withQueue(run: (queue: DiscordQueue) => Promise<void>): Promise<v
     await run(queue);
   } finally {
     closeOpenClawStateDatabaseForTest();
-    await fs.rm(stateDir, { recursive: true, force: true });
   }
 }
 

--- a/extensions/discord/src/monitor/message-handler.ingress-recovery.test.ts
+++ b/extensions/discord/src/monitor/message-handler.ingress-recovery.test.ts
@@ -1,4 +1,7 @@
 // Discord tests cover durable retry recovery through full handler replacement.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type { APIMessage } from "discord-api-types/v10";
 import {
   type ChannelIngressQueue,
@@ -9,8 +12,7 @@ import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import { describe, expect, it, vi } from "vitest";
 import { createDiscordIngressMonitor } from "./ingress.js";
 import { createDiscordMessageHandler } from "./message-handler.js";
 import { createDiscordHandlerParams } from "./message-handler.test-helpers.js";
@@ -22,8 +24,6 @@ type DiscordIngressPayload = {
 };
 
 type DiscordQueue = ChannelIngressQueue<DiscordIngressPayload>;
-
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function rawMessage(id: string, channelId = "lane-a"): APIMessage {
   return {
@@ -51,7 +51,8 @@ function rawMessage(id: string, channelId = "lane-a"): APIMessage {
 }
 
 async function withQueue(run: (queue: DiscordQueue) => Promise<void>): Promise<void> {
-  const stateDir = tempDirs.make("openclaw-discord-recovery-");
+  const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-recovery-"));
+  const stateDir = await fs.realpath(created);
   const queue = createChannelIngressQueueForTests<DiscordIngressPayload>({
     channelId: "discord",
     accountId: "default",
@@ -61,6 +62,7 @@ async function withQueue(run: (queue: DiscordQueue) => Promise<void>): Promise<v
     await run(queue);
   } finally {
     closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
   }
 }
 

--- a/extensions/discord/src/monitor/message-handler.queue.test.ts
+++ b/extensions/discord/src/monitor/message-handler.queue.test.ts
@@ -1,9 +1,21 @@
 // Discord tests cover message handler.queue plugin behavior.
 import { getEventListeners } from "node:events";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { APIMessage } from "discord-api-types/v10";
+import {
+  type ChannelIngressQueue,
+  DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+} from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { DiscordIngressLifecycle } from "./ingress.js";
+import { createDiscordIngressMonitor, type DiscordIngressLifecycle } from "./ingress.js";
 import { createDiscordMessageHandler as createDurableDiscordMessageHandler } from "./message-handler.js";
 import {
   createDiscordMessageHandler,
@@ -35,6 +47,8 @@ function expectStatusPatch(setStatus: MockCallSource, expected: Record<string, u
 
 function createIngressLifecycle(): DiscordIngressLifecycle & {
   onAdopted: ReturnType<typeof vi.fn>;
+  onFailed: ReturnType<typeof vi.fn>;
+  onCancelled: ReturnType<typeof vi.fn>;
   onAbandoned: ReturnType<typeof vi.fn>;
 } {
   return {
@@ -42,8 +56,59 @@ function createIngressLifecycle(): DiscordIngressLifecycle & {
     onAdopted: vi.fn(async () => {}),
     onDeferred: vi.fn(),
     onAdoptionFinalizing: vi.fn(),
+    onFailed: vi.fn(async () => {}),
+    onCancelled: vi.fn(async () => {}),
     onAbandoned: vi.fn(async () => {}),
   };
+}
+
+type DiscordIngressPayload = {
+  version: 1;
+  receivedAt: number;
+  rawMessage: APIMessage;
+};
+
+async function withDiscordQueue<T>(
+  run: (queue: ChannelIngressQueue<DiscordIngressPayload>) => Promise<T>,
+): Promise<T> {
+  const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-handler-"));
+  const stateDir = await fs.realpath(created);
+  const queue = createChannelIngressQueueForTests<DiscordIngressPayload>({
+    channelId: "discord",
+    accountId: "default",
+    stateDir,
+  });
+  try {
+    return await run(queue);
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+function createRawMessage(id: string, channelId = "ch-1"): APIMessage {
+  return {
+    id,
+    channel_id: channelId,
+    content: "hello",
+    author: {
+      id: "user-1",
+      username: "alice",
+      discriminator: "0",
+      avatar: null,
+    },
+    attachments: [],
+    embeds: [],
+    mentions: [],
+    mention_roles: [],
+    mention_everyone: false,
+    timestamp: new Date().toISOString(),
+    edited_timestamp: null,
+    components: [],
+    pinned: false,
+    type: 0,
+    tts: false,
+  } as unknown as APIMessage;
 }
 
 async function flushQueueWork(): Promise<void> {
@@ -314,11 +379,31 @@ describe("createDiscordMessageHandler queue behavior", () => {
       turnAdoptionLifecycle: lifecycle,
     });
 
-    expect(result).toMatchObject({ kind: "failed-retryable" });
+    expect(result).toMatchObject({ kind: "deferred" });
+    expect(lifecycle.onCancelled).toHaveBeenCalledTimes(1);
     expect(lifecycle.onAdopted).not.toHaveBeenCalled();
   });
 
-  it("abandons a buffered ingress claim during deactivation", async () => {
+  it("reports a genuine pre-admission exception only through onFailed", async () => {
+    preflightDiscordMessageMock.mockReset();
+    processDiscordMessageMock.mockReset();
+    const failure = new Error("preflight failed");
+    preflightDiscordMessageMock.mockRejectedValue(failure);
+    const handler = createDiscordMessageHandler(createDiscordHandlerParams());
+    const lifecycle = createIngressLifecycle();
+
+    await expect(
+      handler(createTextMessageData("m-failed") as never, {} as never, {
+        turnAdoptionLifecycle: lifecycle,
+      }),
+    ).resolves.toEqual({ kind: "deferred" });
+
+    expect(lifecycle.onFailed).toHaveBeenCalledExactlyOnceWith(failure);
+    expect(lifecycle.onCancelled).not.toHaveBeenCalled();
+    expect(lifecycle.onAbandoned).not.toHaveBeenCalled();
+  });
+
+  it("cancels a buffered ingress claim during deactivation", async () => {
     preflightDiscordMessageMock.mockReset();
     processDiscordMessageMock.mockReset();
     const params = createDiscordHandlerParams();
@@ -332,11 +417,12 @@ describe("createDiscordMessageHandler queue behavior", () => {
     await handler.deactivate();
 
     expect(preflightDiscordMessageMock).not.toHaveBeenCalled();
-    expect(lifecycle.onAbandoned).toHaveBeenCalledTimes(1);
+    expect(lifecycle.onCancelled).toHaveBeenCalledTimes(1);
+    expect(lifecycle.onAbandoned).not.toHaveBeenCalled();
     expect(lifecycle.onAdopted).not.toHaveBeenCalled();
   });
 
-  it("waits for an active debounce flush and abandons it after shutdown", async () => {
+  it("waits for an active debounce flush and cancels it after shutdown", async () => {
     preflightDiscordMessageMock.mockReset();
     processDiscordMessageMock.mockReset();
     const preflightGate = createDeferred<void>();
@@ -360,7 +446,8 @@ describe("createDiscordMessageHandler queue behavior", () => {
 
     preflightGate.resolve();
     await Promise.all([handling, deactivation]);
-    expect(lifecycle.onAbandoned).toHaveBeenCalledTimes(1);
+    expect(lifecycle.onCancelled).toHaveBeenCalledTimes(1);
+    expect(lifecycle.onAbandoned).not.toHaveBeenCalled();
     expect(lifecycle.onAdopted).not.toHaveBeenCalled();
   });
 
@@ -392,6 +479,136 @@ describe("createDiscordMessageHandler queue behavior", () => {
     admissionGate.resolve();
     await Promise.all([handling, deactivation]);
     expect(stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("dead-letters an exhausted preflight failure and releases its Discord lane", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    try {
+      await withDiscordQueue(async (queue) => {
+        const attempted: string[] = [];
+        const preflight = vi.fn(async (params: { data: { message?: { id?: string } } }) => {
+          const id = params.data.message?.id ?? "unknown";
+          attempted.push(id);
+          if (id === "poison") {
+            throw new Error("deterministic preflight failure");
+          }
+          return null;
+        });
+        const params = createDiscordHandlerParams();
+        const handler = createDurableDiscordMessageHandler({
+          ...params,
+          client: {} as never,
+          testing: {
+            preflightDiscordMessage: preflight as never,
+            createIngressMonitor: (monitorParams) =>
+              createDiscordIngressMonitor({ ...monitorParams, queue }),
+          },
+        });
+        try {
+          await handler(createRawMessage("poison", "lane-a") as never, {} as never);
+          await handler(createRawMessage("follower", "lane-a") as never, {} as never);
+          await handler(createRawMessage("independent", "lane-b") as never, {} as never);
+
+          for (let attempt = 0; attempt < DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS; attempt += 1) {
+            await vi.advanceTimersByTimeAsync(3 * 60_000);
+          }
+
+          await vi.waitFor(() => expect(attempted).toContain("follower"));
+          expect(attempted.indexOf("independent")).toBeGreaterThanOrEqual(0);
+          expect(attempted.indexOf("independent")).toBeLessThan(attempted.indexOf("follower"));
+          expect(attempted.filter((id) => id === "poison")).toHaveLength(
+            DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+          );
+          await expect(queue.enqueue("poison", {} as DiscordIngressPayload)).resolves.toMatchObject(
+            {
+              kind: "failed",
+              record: { reason: "retry-limit-exceeded" },
+            },
+          );
+          await expect(
+            queue.enqueue("follower", {} as DiscordIngressPayload),
+          ).resolves.toMatchObject({ kind: "completed" });
+          const runtimeErrors = mockCalls(params.runtime.error as unknown as MockCallSource).map(
+            ([message]) => String(message),
+          );
+          expect(runtimeErrors.some((message) => message.includes("reached retry limit"))).toBe(
+            true,
+          );
+          expect(runtimeErrors.join("\n")).not.toContain("hello");
+        } finally {
+          await handler.deactivate();
+        }
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("preserves retry facts when deactivation cancels a durable Discord claim", async () => {
+    await withDiscordQueue(async (queue) => {
+      const raw = createRawMessage("cancelled", "lane-a");
+      await queue.enqueue(
+        "cancelled",
+        { version: 1, receivedAt: 10, rawMessage: raw },
+        { laneKey: "channel:lane-a", receivedAt: 10 },
+      );
+      const failedClaim = await queue.claim("cancelled", { ownerId: "failed-owner" });
+      expect(failedClaim).not.toBeNull();
+      if (!failedClaim) {
+        return;
+      }
+      await queue.release(failedClaim, {
+        lastError: "previous genuine failure",
+        releasedAt: 20,
+      });
+      const before = (await queue.listPending())[0];
+      const firstPreflight = vi.fn(async () => null);
+      const firstParams = createDiscordHandlerParams();
+      firstParams.cfg.messages = { inbound: { debounceMs: 60_000 } };
+      const first = createDurableDiscordMessageHandler({
+        ...firstParams,
+        client: {} as never,
+        testing: {
+          preflightDiscordMessage: firstPreflight as never,
+          createIngressMonitor: (monitorParams) =>
+            createDiscordIngressMonitor({ ...monitorParams, queue }),
+        },
+      });
+
+      await vi.waitFor(async () => expect(await queue.listClaims()).toHaveLength(1));
+      await first.deactivate();
+
+      expect(firstPreflight).not.toHaveBeenCalled();
+      expect(await queue.listPending()).toEqual([
+        expect.objectContaining({
+          id: "cancelled",
+          attempts: before?.attempts,
+          lastAttemptAt: before?.lastAttemptAt,
+          lastError: before?.lastError,
+        }),
+      ]);
+
+      const replacementPreflight = vi.fn(async () => null);
+      const replacementParams = createDiscordHandlerParams();
+      const replacement = createDurableDiscordMessageHandler({
+        ...replacementParams,
+        client: {} as never,
+        testing: {
+          preflightDiscordMessage: replacementPreflight as never,
+          createIngressMonitor: (monitorParams) =>
+            createDiscordIngressMonitor({ ...monitorParams, queue }),
+        },
+      });
+      try {
+        await vi.waitFor(() => expect(replacementPreflight).toHaveBeenCalledTimes(1));
+        await expect(
+          queue.enqueue("cancelled", {} as DiscordIngressPayload),
+        ).resolves.toMatchObject({ kind: "completed" });
+      } finally {
+        await replacement.deactivate();
+      }
+    });
   });
 
   it("does not abort concurrent runs with a Discord-owned channel timeout", async () => {

--- a/extensions/discord/src/monitor/message-handler.queue.test.ts
+++ b/extensions/discord/src/monitor/message-handler.queue.test.ts
@@ -1,8 +1,5 @@
 // Discord tests cover message handler.queue plugin behavior.
 import { getEventListeners } from "node:events";
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import type { APIMessage } from "discord-api-types/v10";
 import {
   type ChannelIngressQueue,
@@ -14,7 +11,8 @@ import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import { createDiscordIngressMonitor, type DiscordIngressLifecycle } from "./ingress.js";
 import { createDiscordMessageHandler as createDurableDiscordMessageHandler } from "./message-handler.js";
 import {
@@ -68,11 +66,12 @@ type DiscordIngressPayload = {
   rawMessage: APIMessage;
 };
 
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
 async function withDiscordQueue<T>(
   run: (queue: ChannelIngressQueue<DiscordIngressPayload>) => Promise<T>,
 ): Promise<T> {
-  const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-handler-"));
-  const stateDir = await fs.realpath(created);
+  const stateDir = tempDirs.make("openclaw-discord-handler-");
   const queue = createChannelIngressQueueForTests<DiscordIngressPayload>({
     channelId: "discord",
     accountId: "default",
@@ -82,7 +81,6 @@ async function withDiscordQueue<T>(
     return await run(queue);
   } finally {
     closeOpenClawStateDatabaseForTest();
-    await fs.rm(stateDir, { recursive: true, force: true });
   }
 }
 

--- a/extensions/discord/src/monitor/message-handler.queue.test.ts
+++ b/extensions/discord/src/monitor/message-handler.queue.test.ts
@@ -422,6 +422,30 @@ describe("createDiscordMessageHandler queue behavior", () => {
     expect(lifecycle.onAdopted).not.toHaveBeenCalled();
   });
 
+  it("settles every buffered claim when cancellation fan-in includes a legacy lifecycle", async () => {
+    preflightDiscordMessageMock.mockReset();
+    processDiscordMessageMock.mockReset();
+    const params = createDiscordHandlerParams();
+    params.cfg.messages = { inbound: { debounceMs: 60_000 } };
+    const handler = createDiscordMessageHandler(params);
+    const cancellable = createIngressLifecycle();
+    const legacy = createIngressLifecycle();
+    delete (legacy as Partial<typeof legacy>).onCancelled;
+
+    await handler(createTextMessageData("m-cancel-modern") as never, {} as never, {
+      turnAdoptionLifecycle: cancellable,
+    });
+    await handler(createTextMessageData("m-cancel-legacy") as never, {} as never, {
+      turnAdoptionLifecycle: legacy,
+    });
+    await handler.deactivate();
+
+    expect(preflightDiscordMessageMock).not.toHaveBeenCalled();
+    expect(cancellable.onCancelled).toHaveBeenCalledTimes(1);
+    expect(legacy.onAbandoned).toHaveBeenCalledTimes(1);
+    expect(legacy.onAdopted).not.toHaveBeenCalled();
+  });
+
   it("waits for an active debounce flush and cancels it after shutdown", async () => {
     preflightDiscordMessageMock.mockReset();
     processDiscordMessageMock.mockReset();

--- a/extensions/discord/src/monitor/message-handler.queue.test.ts
+++ b/extensions/discord/src/monitor/message-handler.queue.test.ts
@@ -1,5 +1,8 @@
 // Discord tests cover message handler.queue plugin behavior.
 import { getEventListeners } from "node:events";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type { APIMessage } from "discord-api-types/v10";
 import {
   type ChannelIngressQueue,
@@ -11,8 +14,7 @@ import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createDiscordIngressMonitor, type DiscordIngressLifecycle } from "./ingress.js";
 import { createDiscordMessageHandler as createDurableDiscordMessageHandler } from "./message-handler.js";
 import {
@@ -66,12 +68,11 @@ type DiscordIngressPayload = {
   rawMessage: APIMessage;
 };
 
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-
 async function withDiscordQueue<T>(
   run: (queue: ChannelIngressQueue<DiscordIngressPayload>) => Promise<T>,
 ): Promise<T> {
-  const stateDir = tempDirs.make("openclaw-discord-handler-");
+  const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-handler-"));
+  const stateDir = await fs.realpath(created);
   const queue = createChannelIngressQueueForTests<DiscordIngressPayload>({
     channelId: "discord",
     accountId: "default",
@@ -81,6 +82,7 @@ async function withDiscordQueue<T>(
     return await run(queue);
   } finally {
     closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
   }
 }
 

--- a/extensions/discord/src/monitor/message-handler.queue.test.ts
+++ b/extensions/discord/src/monitor/message-handler.queue.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { APIMessage } from "discord-api-types/v10";
+import { fanInChannelIngressLifecycles } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import {
   type ChannelIngressQueue,
   DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
@@ -15,6 +16,7 @@ import {
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildDiscordInboundJob } from "./inbound-job.js";
 import { createDiscordIngressMonitor, type DiscordIngressLifecycle } from "./ingress.js";
 import { createDiscordMessageHandler as createDurableDiscordMessageHandler } from "./message-handler.js";
 import {
@@ -22,10 +24,12 @@ import {
   preflightDiscordMessageMock,
   processDiscordMessageMock,
 } from "./message-handler.module-test-helpers.js";
+import { createBaseDiscordMessageContext } from "./message-handler.test-harness.js";
 import {
   createDiscordHandlerParams,
   createDiscordPreflightContext,
 } from "./message-handler.test-helpers.js";
+import { createDiscordMessageRunQueue } from "./message-run-queue.js";
 
 type SetStatusFn = (patch: Record<string, unknown>) => void;
 type MockCallSource = { mock: { calls: Array<Array<unknown>> } };
@@ -631,6 +635,88 @@ describe("createDiscordMessageHandler queue behavior", () => {
         ).resolves.toMatchObject({ kind: "completed" });
       } finally {
         await replacement.deactivate();
+      }
+    });
+  });
+
+  it("preserves retry facts when deactivation skips a queued durable Discord job", async () => {
+    await withDiscordQueue(async (queue) => {
+      const raw = createRawMessage("queued-cancelled", "lane-a");
+      await queue.enqueue(
+        "queued-cancelled",
+        { version: 1, receivedAt: 10, rawMessage: raw },
+        { laneKey: "channel:lane-a", receivedAt: 10 },
+      );
+      const failedClaim = await queue.claim("queued-cancelled", { ownerId: "failed-owner" });
+      expect(failedClaim).not.toBeNull();
+      if (!failedClaim) {
+        return;
+      }
+      await queue.release(failedClaim, {
+        lastError: "previous genuine failure",
+        releasedAt: 20,
+      });
+      const before = (await queue.listPending())[0];
+      const params = createDiscordHandlerParams();
+      const processDiscordMessage = vi.fn(async () => {});
+      const messageRunQueue = createDiscordMessageRunQueue({
+        runtime: params.runtime,
+        testing: { processDiscordMessage: processDiscordMessage as never },
+      });
+      const skipped = createDeferred<void>();
+      const monitor = createDiscordIngressMonitor({
+        accountId: "default",
+        client: {} as never,
+        runtime: params.runtime,
+        queue,
+        dispatch: async (_event, lifecycle) => {
+          const ingress = fanInChannelIngressLifecycles([lifecycle]);
+          messageRunQueue.enqueue(
+            buildDiscordInboundJob(await createBaseDiscordMessageContext(), {
+              ingressSettlement: ingress,
+            }),
+          );
+          await messageRunQueue.deactivate();
+          skipped.resolve();
+          return { kind: "deferred" };
+        },
+      });
+      monitor.start();
+      try {
+        await skipped.promise;
+        await monitor.stop();
+        expect(processDiscordMessage).not.toHaveBeenCalled();
+        expect(await queue.listPending()).toEqual([
+          expect.objectContaining({
+            id: "queued-cancelled",
+            attempts: before?.attempts,
+            lastAttemptAt: before?.lastAttemptAt,
+            lastError: before?.lastError,
+          }),
+        ]);
+      } finally {
+        await monitor.stop();
+        await messageRunQueue.deactivate();
+      }
+
+      const recovered = vi.fn(async (_event, lifecycle: DiscordIngressLifecycle) => {
+        await lifecycle.onAdopted();
+      });
+      const replacement = createDiscordIngressMonitor({
+        accountId: "default",
+        client: {} as never,
+        runtime: params.runtime,
+        queue,
+        dispatch: recovered,
+      });
+      replacement.start();
+      try {
+        await vi.waitFor(() => expect(recovered).toHaveBeenCalledTimes(1));
+        await expect(
+          queue.enqueue("queued-cancelled", {} as DiscordIngressPayload),
+        ).resolves.toMatchObject({ kind: "completed" });
+      } finally {
+        await replacement.stop();
       }
     });
   });

--- a/extensions/discord/src/monitor/message-handler.queue.test.ts
+++ b/extensions/discord/src/monitor/message-handler.queue.test.ts
@@ -639,6 +639,96 @@ describe("createDiscordMessageHandler queue behavior", () => {
     });
   });
 
+  it.each(["returns", "throws"] as const)(
+    "preserves retry facts when a started durable Discord job %s after cancellation",
+    async (outcome) => {
+      await withDiscordQueue(async (queue) => {
+        const id = `started-cancelled-${outcome}`;
+        const raw = createRawMessage(id, "lane-a");
+        await queue.enqueue(
+          id,
+          { version: 1, receivedAt: 10, rawMessage: raw },
+          { laneKey: "channel:lane-a", receivedAt: 10 },
+        );
+        const failedClaim = await queue.claim(id, { ownerId: "failed-owner" });
+        expect(failedClaim).not.toBeNull();
+        if (!failedClaim) {
+          return;
+        }
+        await queue.release(failedClaim, {
+          lastError: "previous genuine failure",
+          releasedAt: 20,
+        });
+        const before = (await queue.listPending())[0];
+        const processingStarted = createDeferred<void>();
+        const finishProcessing = createDeferred<void>();
+        let processingSignal: AbortSignal | undefined;
+        const processDiscordMessage = vi.fn(async (ctx: { abortSignal?: AbortSignal }) => {
+          processingSignal = ctx.abortSignal;
+          processingStarted.resolve();
+          await finishProcessing.promise;
+          if (outcome === "throws") {
+            throw new Error("processing stopped after cancellation");
+          }
+        });
+        const params = createDiscordHandlerParams();
+        const handler = createDurableDiscordMessageHandler({
+          ...params,
+          client: {} as never,
+          testing: {
+            preflightDiscordMessage: (async (preflightParams: {
+              abortSignal?: AbortSignal;
+              data: ReturnType<typeof createTextMessageData>;
+              turnAdoptionLifecycle?: DiscordIngressLifecycle;
+            }) => ({
+              ...createPreflightContextForMessage(preflightParams.data),
+              abortSignal: preflightParams.abortSignal,
+              turnAdoptionLifecycle: preflightParams.turnAdoptionLifecycle,
+            })) as never,
+            processDiscordMessage: processDiscordMessage as never,
+            createIngressMonitor: (monitorParams) =>
+              createDiscordIngressMonitor({ ...monitorParams, queue }),
+          },
+        });
+
+        await processingStarted.promise;
+        const deactivation = handler.deactivate();
+        await vi.waitFor(() => expect(processingSignal?.aborted).toBe(true));
+        finishProcessing.resolve();
+        await deactivation;
+
+        expect(await queue.listPending()).toEqual([
+          expect.objectContaining({
+            id,
+            attempts: before?.attempts,
+            lastAttemptAt: before?.lastAttemptAt,
+            lastError: before?.lastError,
+          }),
+        ]);
+
+        const recovered = vi.fn(async (_event, lifecycle: DiscordIngressLifecycle) => {
+          await lifecycle.onAdopted();
+        });
+        const replacement = createDiscordIngressMonitor({
+          accountId: "default",
+          client: {} as never,
+          runtime: params.runtime,
+          queue,
+          dispatch: recovered,
+        });
+        replacement.start();
+        try {
+          await vi.waitFor(() => expect(recovered).toHaveBeenCalledTimes(1));
+          await expect(queue.enqueue(id, {} as DiscordIngressPayload)).resolves.toMatchObject({
+            kind: "completed",
+          });
+        } finally {
+          await replacement.stop();
+        }
+      });
+    },
+  );
+
   it("preserves retry facts when deactivation skips a queued durable Discord job", async () => {
     await withDiscordQueue(async (queue) => {
       const raw = createRawMessage("queued-cancelled", "lane-a");

--- a/extensions/discord/src/monitor/message-run-queue.ts
+++ b/extensions/discord/src/monitor/message-run-queue.ts
@@ -45,12 +45,18 @@ async function processDiscordQueuedMessage(params: {
       (await loadMessageProcessRuntime()).processDiscordMessage;
     await processDiscordMessageImpl(materializeDiscordInboundJob(params.job, abortSignal));
     if (abortSignal?.aborted) {
-      await params.job.ingressSettlement?.abandon(abortSignal.reason);
+      // Cancellation ended ownership before delivery; retain prior retry facts
+      // so the durable claim can replay under a replacement lifecycle.
+      await params.job.ingressSettlement?.cancel();
     } else {
       await params.job.ingressSettlement?.settle();
     }
   } catch (error) {
-    await params.job.ingressSettlement?.abandon(error);
+    if (abortSignal?.aborted) {
+      await params.job.ingressSettlement?.cancel();
+    } else {
+      await params.job.ingressSettlement?.abandon(error);
+    }
     throw error;
   }
 }

--- a/extensions/discord/src/monitor/message-run-queue.ts
+++ b/extensions/discord/src/monitor/message-run-queue.ts
@@ -57,9 +57,7 @@ async function processDiscordQueuedMessage(params: {
 
 async function cleanupSkippedDiscordQueuedMessage(params: { job: DiscordInboundJob }) {
   // A skipped job never reached reply-lane adoption; reopen its durable claim.
-  await params.job.ingressSettlement?.abandon(
-    new Error("discord queued run skipped before processing"),
-  );
+  await params.job.ingressSettlement?.cancel();
 }
 
 export function createDiscordMessageRunQueue(

--- a/extensions/feishu/src/monitor.message-handler.ingress.test.ts
+++ b/extensions/feishu/src/monitor.message-handler.ingress.test.ts
@@ -1,11 +1,20 @@
-import { createTestInboundDebounceFlush } from "openclaw/plugin-sdk/channel-test-helpers";
-import { createNonExitingRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
 // Feishu ingress tests cover debounce ownership and constituent claim settlement.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
+import { DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS } from "openclaw/plugin-sdk/channel-outbound";
+import { createTestInboundDebounceFlush } from "openclaw/plugin-sdk/channel-test-helpers";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { createNonExitingRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig, PluginRuntime, RuntimeEnv } from "../runtime-api.js";
 import * as dedup from "./dedup.js";
 import type { FeishuMessageEvent } from "./event-types.js";
-import type { FeishuIngressLifecycle } from "./feishu-ingress.js";
+import { createFeishuDurableIngress, type FeishuIngressLifecycle } from "./feishu-ingress.js";
 import { createFeishuMessageReceiveHandler } from "./monitor.message-handler.js";
 
 type MessageReceiveHandlerContext = Parameters<typeof createFeishuMessageReceiveHandler>[0];
@@ -369,5 +378,145 @@ describe("Feishu durable ingress debounce lifecycle", () => {
 
     expect(harness.handleMessage).toHaveBeenCalledTimes(1);
     expect(second.calls.adopted).not.toHaveBeenCalled();
+  });
+
+  it("preserves abandon retry accounting, backoff, threshold, and restart behavior", async () => {
+    vi.useFakeTimers();
+    const now = Date.UTC(2026, 0, 2);
+    vi.setSystemTime(now);
+    const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-feishu-abandon-"));
+    const stateDir = await fs.realpath(created);
+    type Queue = NonNullable<Parameters<typeof createFeishuDurableIngress>[0]["queue"]>;
+    type Payload = Parameters<Queue["enqueue"]>[1];
+    const queue = createChannelIngressQueueForTests<Payload>({
+      channelId: "feishu",
+      accountId: "default",
+      stateDir,
+    });
+    const event = {
+      ...createTextEvent("evt-abandon-retry", "om-abandon-retry", "retry me"),
+      event_type: "im.message.receive_v1",
+    };
+    const handleMessage = vi.fn(async () => {
+      throw new Error("Feishu dispatch failed before adoption");
+    });
+    vi.spyOn(dedup, "claimUnprocessedFeishuMessage").mockImplementation(async () => ({
+      kind: "claimed",
+      handle: createClaim(`retry-${handleMessage.mock.calls.length}`),
+    }));
+
+    const createIntegratedIngress = () => {
+      const channelRuntime = {
+        commands: { isControlCommandMessage: () => false },
+        debounce: {
+          resolveInboundDebounceMs: () => 0,
+          createInboundDebouncer,
+        },
+      } as unknown as PluginRuntime["channel"];
+      const handler = createFeishuMessageReceiveHandler({
+        cfg: {} as ClawdbotConfig,
+        channelRuntime,
+        accountId: "default",
+        runtime: createNonExitingRuntimeEnv(),
+        chatHistories: new Map(),
+        handleMessage,
+        resolveDebounceText: () => "retry me",
+        hasProcessedMessage: vi.fn(async () => false),
+        getBotOpenId: () => "ou-bot",
+        resolveIngressLifecycle: (data) => ingress.resolveLifecycle(data),
+      });
+      const ingress = createFeishuDurableIngress({
+        accountId: "default",
+        queue,
+        dispatcher: { invoke: async (data: unknown) => await handler(data as never) } as never,
+        runtime: { error: vi.fn(), log: vi.fn() },
+        pollIntervalMs: 500,
+      });
+      return ingress;
+    };
+    const pendingAttempt = async (attempts: number) => {
+      let observed: Awaited<ReturnType<typeof queue.listPending>>[number] | undefined;
+      await vi.waitFor(async () => {
+        const pending = await queue.listPending({ limit: "all" });
+        expect(pending).toEqual([
+          expect.objectContaining({
+            id: "evt-abandon-retry",
+            attempts,
+            lastAttemptAt: expect.any(Number),
+            lastError: "turn-abandoned",
+          }),
+        ]);
+        observed = pending[0];
+      });
+      const lastAttemptAt = observed?.lastAttemptAt;
+      if (lastAttemptAt === undefined) {
+        throw new Error(`Missing Feishu retry timestamp for attempt ${attempts}`);
+      }
+      return { ...observed, lastAttemptAt };
+    };
+
+    try {
+      const first = createIntegratedIngress();
+      first.start();
+      await first.invokeWebhook(event);
+      const firstAttempt = await pendingAttempt(1);
+      expect(handleMessage).toHaveBeenCalledTimes(1);
+      await first.stop();
+
+      vi.setSystemTime(firstAttempt.lastAttemptAt + 999);
+      const blocked = createIntegratedIngress();
+      blocked.start();
+      await blocked.invokeWebhook(event);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(handleMessage).toHaveBeenCalledTimes(1);
+      await blocked.stop();
+
+      vi.setSystemTime(firstAttempt.lastAttemptAt + 1_001);
+      const second = createIntegratedIngress();
+      second.start();
+      await second.invokeWebhook(event);
+      const secondAttempt = await pendingAttempt(2);
+      expect(handleMessage).toHaveBeenCalledTimes(2);
+      await second.stop();
+
+      for (let attempt = 3; attempt < DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS; attempt += 1) {
+        const claim = await queue.claim("evt-abandon-retry", { ownerId: `seed-${attempt}` });
+        if (!claim) {
+          throw new Error(`Expected Feishu seed claim ${attempt}`);
+        }
+        await queue.release(claim, {
+          lastError: "turn-abandoned",
+          releasedAt: secondAttempt.lastAttemptAt,
+        });
+      }
+
+      vi.setSystemTime(secondAttempt.lastAttemptAt + 64_001);
+      const threshold = createIntegratedIngress();
+      threshold.start();
+      await threshold.invokeWebhook(event);
+      const thresholdAttempt = await pendingAttempt(DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS);
+      expect(handleMessage).toHaveBeenCalledTimes(3);
+      await threshold.stop();
+
+      vi.setSystemTime(thresholdAttempt.lastAttemptAt + 128_001);
+      const beyond = createIntegratedIngress();
+      beyond.start();
+      await beyond.invokeWebhook(event);
+      const beyondAttempt = await pendingAttempt(DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS + 1);
+      expect(handleMessage).toHaveBeenCalledTimes(4);
+      await beyond.stop();
+
+      vi.setSystemTime(beyondAttempt.lastAttemptAt + 1_000);
+      const blockedRestart = createIntegratedIngress();
+      blockedRestart.start();
+      await blockedRestart.invokeWebhook(event);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(handleMessage).toHaveBeenCalledTimes(4);
+      await blockedRestart.stop();
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+      await fs.rm(stateDir, { recursive: true, force: true });
+      vi.useRealTimers();
+    }
   });
 });

--- a/extensions/feishu/src/monitor.message-handler.ingress.test.ts
+++ b/extensions/feishu/src/monitor.message-handler.ingress.test.ts
@@ -1,7 +1,4 @@
 // Feishu ingress tests cover debounce ownership and constituent claim settlement.
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
 import { DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS } from "openclaw/plugin-sdk/channel-outbound";
 import { createTestInboundDebounceFlush } from "openclaw/plugin-sdk/channel-test-helpers";
@@ -11,6 +8,7 @@ import {
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { createNonExitingRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { ClawdbotConfig, PluginRuntime, RuntimeEnv } from "../runtime-api.js";
 import * as dedup from "./dedup.js";
 import type { FeishuMessageEvent } from "./event-types.js";
@@ -26,6 +24,8 @@ type DebounceFlush = ReturnType<
   Parameters<PluginRuntime["channel"]["debounce"]["createInboundDebouncer"]>[0]["onFlush"]
 >;
 type DebounceFlushFactory = typeof createTestInboundDebounceFlush;
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function createTextEvent(
   eventId: string,
@@ -384,8 +384,7 @@ describe("Feishu durable ingress debounce lifecycle", () => {
     vi.useFakeTimers();
     const now = Date.UTC(2026, 0, 2);
     vi.setSystemTime(now);
-    const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-feishu-abandon-"));
-    const stateDir = await fs.realpath(created);
+    const stateDir = tempDirs.make("openclaw-feishu-abandon-");
     type Queue = NonNullable<Parameters<typeof createFeishuDurableIngress>[0]["queue"]>;
     type Payload = Parameters<Queue["enqueue"]>[1];
     const queue = createChannelIngressQueueForTests<Payload>({
@@ -515,7 +514,6 @@ describe("Feishu durable ingress debounce lifecycle", () => {
       await blockedRestart.stop();
     } finally {
       closeOpenClawStateDatabaseForTest();
-      await fs.rm(stateDir, { recursive: true, force: true });
       vi.useRealTimers();
     }
   });

--- a/extensions/feishu/src/monitor.message-handler.ingress.test.ts
+++ b/extensions/feishu/src/monitor.message-handler.ingress.test.ts
@@ -1,4 +1,7 @@
 // Feishu ingress tests cover debounce ownership and constituent claim settlement.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
 import { DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS } from "openclaw/plugin-sdk/channel-outbound";
 import { createTestInboundDebounceFlush } from "openclaw/plugin-sdk/channel-test-helpers";
@@ -8,7 +11,6 @@ import {
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { createNonExitingRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { ClawdbotConfig, PluginRuntime, RuntimeEnv } from "../runtime-api.js";
 import * as dedup from "./dedup.js";
 import type { FeishuMessageEvent } from "./event-types.js";
@@ -24,8 +26,6 @@ type DebounceFlush = ReturnType<
   Parameters<PluginRuntime["channel"]["debounce"]["createInboundDebouncer"]>[0]["onFlush"]
 >;
 type DebounceFlushFactory = typeof createTestInboundDebounceFlush;
-
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function createTextEvent(
   eventId: string,
@@ -384,7 +384,8 @@ describe("Feishu durable ingress debounce lifecycle", () => {
     vi.useFakeTimers();
     const now = Date.UTC(2026, 0, 2);
     vi.setSystemTime(now);
-    const stateDir = tempDirs.make("openclaw-feishu-abandon-");
+    const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-feishu-abandon-"));
+    const stateDir = await fs.realpath(created);
     type Queue = NonNullable<Parameters<typeof createFeishuDurableIngress>[0]["queue"]>;
     type Payload = Parameters<Queue["enqueue"]>[1];
     const queue = createChannelIngressQueueForTests<Payload>({
@@ -514,6 +515,7 @@ describe("Feishu durable ingress debounce lifecycle", () => {
       await blockedRestart.stop();
     } finally {
       closeOpenClawStateDatabaseForTest();
+      await fs.rm(stateDir, { recursive: true, force: true });
       vi.useRealTimers();
     }
   });

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -2040,7 +2040,10 @@ describe("mattermost inbound user posts", () => {
           chatmode: "onmessage",
           dmPolicy: "open",
           groupPolicy: "open",
-          streaming: { mode: "block", preview: { toolProgress: true } },
+          streaming: {
+            mode: "block",
+            preview: { toolProgress: true, commandText: "raw" },
+          },
         },
       },
     };

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -1,6 +1,9 @@
 // Mattermost tests cover monitor.inbound system event plugin behavior.
 import { once } from "node:events";
+import fs from "node:fs/promises";
 import { createServer } from "node:http";
+import os from "node:os";
+import path from "node:path";
 import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
 import {
@@ -12,15 +15,12 @@ import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
-import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import type { MattermostPost } from "./client.js";
 import type { MattermostEventPayload } from "./monitor-websocket.js";
 import { monitorMattermostProvider } from "./monitor.js";
 import type { OpenClawConfig, ReplyPayload, RuntimeEnv } from "./runtime-api.js";
-
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 class FakeWebSocket {
   public readonly sent: string[] = [];
@@ -593,7 +593,8 @@ describe("mattermost inbound user posts", () => {
     vi.useFakeTimers();
     const now = Date.UTC(2026, 0, 2);
     vi.setSystemTime(now);
-    const stateDir = tempDirs.make("openclaw-mattermost-abandon-");
+    const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mattermost-abandon-"));
+    const stateDir = await fs.realpath(created);
     type Payload = { version: 1; receivedAt: number; rawEvent: string };
     const queue = createChannelIngressQueueForTests<Payload>({
       channelId: "mattermost",
@@ -723,6 +724,7 @@ describe("mattermost inbound user posts", () => {
       await Promise.allSettled(activeProviders.map(async (provider) => await provider.stop()));
       mockState.ingressQueue = undefined;
       closeOpenClawStateDatabaseForTest();
+      await fs.rm(stateDir, { recursive: true, force: true });
       vi.useRealTimers();
     }
   });

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -1,9 +1,6 @@
 // Mattermost tests cover monitor.inbound system event plugin behavior.
 import { once } from "node:events";
-import fs from "node:fs/promises";
 import { createServer } from "node:http";
-import os from "node:os";
-import path from "node:path";
 import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
 import {
@@ -15,12 +12,15 @@ import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
+import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import type { MattermostPost } from "./client.js";
 import type { MattermostEventPayload } from "./monitor-websocket.js";
 import { monitorMattermostProvider } from "./monitor.js";
 import type { OpenClawConfig, ReplyPayload, RuntimeEnv } from "./runtime-api.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 class FakeWebSocket {
   public readonly sent: string[] = [];
@@ -593,8 +593,7 @@ describe("mattermost inbound user posts", () => {
     vi.useFakeTimers();
     const now = Date.UTC(2026, 0, 2);
     vi.setSystemTime(now);
-    const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mattermost-abandon-"));
-    const stateDir = await fs.realpath(created);
+    const stateDir = tempDirs.make("openclaw-mattermost-abandon-");
     type Payload = { version: 1; receivedAt: number; rawEvent: string };
     const queue = createChannelIngressQueueForTests<Payload>({
       channelId: "mattermost",
@@ -724,7 +723,6 @@ describe("mattermost inbound user posts", () => {
       await Promise.allSettled(activeProviders.map(async (provider) => await provider.stop()));
       mockState.ingressQueue = undefined;
       closeOpenClawStateDatabaseForTest();
-      await fs.rm(stateDir, { recursive: true, force: true });
       vi.useRealTimers();
     }
   });

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -1,10 +1,20 @@
 // Mattermost tests cover monitor.inbound system event plugin behavior.
 import { once } from "node:events";
+import fs from "node:fs/promises";
 import { createServer } from "node:http";
+import os from "node:os";
+import path from "node:path";
 import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
-import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  createMessageReceiptFromOutboundResults,
+  DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+} from "openclaw/plugin-sdk/channel-outbound";
 import { createTestInboundDebounceFlush } from "openclaw/plugin-sdk/channel-test-helpers";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
 import type { MattermostPost } from "./client.js";
@@ -96,6 +106,7 @@ const mockState = vi.hoisted(() => ({
   enqueueSystemEvent: vi.fn(),
   fetchMattermostMe: vi.fn(),
   getGlobalHookRunner: vi.fn(),
+  ingressQueue: undefined as unknown,
   progressDrafts: [] as Array<{ getSnapshot: () => { lines: readonly unknown[] } }>,
   registerMattermostMonitorSlashCommands: vi.fn(),
   registerPluginHttpRoute: vi.fn(),
@@ -180,27 +191,36 @@ vi.mock("./monitor-ingress.js", async (importOriginal) => {
     ...actual,
     createMattermostIngressMonitor: (
       options: Parameters<typeof actual.createMattermostIngressMonitor>[0],
-    ) => ({
-      receive: async (rawEvent: string) => {
-        const payload = JSON.parse(rawEvent) as MattermostEventPayload;
-        const post =
-          typeof payload.data?.post === "string"
-            ? (JSON.parse(payload.data.post) as MattermostPost)
-            : (payload.data?.post as MattermostPost | undefined);
-        if (payload.event !== "posted" || !post) {
-          return;
-        }
-        await options.dispatch(post, payload, {
-          abortSignal: new AbortController().signal,
-          onAdopted: async () => {},
-          onDeferred: () => {},
-          onAdoptionFinalizing: () => {},
-          onAbandoned: async () => {},
+    ) => {
+      if (mockState.ingressQueue) {
+        return actual.createMattermostIngressMonitor({
+          ...options,
+          queue: mockState.ingressQueue as NonNullable<typeof options.queue>,
+          pollIntervalMs: 60_000,
         });
-      },
-      stop: async () => {},
-      waitForIdle: async () => {},
-    }),
+      }
+      return {
+        receive: async (rawEvent: string) => {
+          const payload = JSON.parse(rawEvent) as MattermostEventPayload;
+          const post =
+            typeof payload.data?.post === "string"
+              ? (JSON.parse(payload.data.post) as MattermostPost)
+              : (payload.data?.post as MattermostPost | undefined);
+          if (payload.event !== "posted" || !post) {
+            return;
+          }
+          await options.dispatch(post, payload, {
+            abortSignal: new AbortController().signal,
+            onAdopted: async () => {},
+            onDeferred: () => {},
+            onAdoptionFinalizing: () => {},
+            onAbandoned: async () => {},
+          });
+        },
+        stop: async () => {},
+        waitForIdle: async () => {},
+      };
+    },
   };
 });
 
@@ -534,6 +554,7 @@ describe("mattermost inbound user posts", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockState.abortController = undefined;
+    mockState.ingressQueue = undefined;
     mockState.progressDrafts.length = 0;
     mockState.getGlobalHookRunner.mockReturnValue(null);
     mockState.runtimeCore = createRuntimeCore(testConfig);
@@ -566,6 +587,146 @@ describe("mattermost inbound user posts", () => {
     mockState.dispatchInboundMessage.mockImplementation(async () => {
       mockState.abortController?.abort();
     });
+  });
+
+  it("preserves abandon retry accounting, backoff, threshold, and restart behavior", async () => {
+    vi.useFakeTimers();
+    const now = Date.UTC(2026, 0, 2);
+    vi.setSystemTime(now);
+    const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mattermost-abandon-"));
+    const stateDir = await fs.realpath(created);
+    type Payload = { version: 1; receivedAt: number; rawEvent: string };
+    const queue = createChannelIngressQueueForTests<Payload>({
+      channelId: "mattermost",
+      accountId: "default",
+      stateDir,
+    });
+    mockState.ingressQueue = queue;
+    mockState.runtimeCore = createRuntimeCore(testConfig, undefined, {
+      inboundDebounceMs: 0,
+      createInboundDebouncer,
+    });
+    mockState.dispatchInboundMessage.mockRejectedValue(
+      new Error("Mattermost dispatch failed before adoption"),
+    );
+
+    const activeProviders: Array<{ stop: () => Promise<void> }> = [];
+    const startProvider = async () => {
+      const socket = new FakeWebSocket();
+      const abortController = new AbortController();
+      const monitor = monitorMattermostProvider({
+        config: testConfig,
+        runtime: testRuntime(),
+        abortSignal: abortController.signal,
+        webSocketFactory: () => socket,
+      });
+      for (let tick = 0; tick < 20 && socket.openListenerCount === 0; tick += 1) {
+        await Promise.resolve();
+      }
+      expect(socket.openListenerCount).toBeGreaterThan(0);
+      socket.emitOpen();
+      let stopped = false;
+      const provider = {
+        socket,
+        stop: async () => {
+          if (stopped) {
+            return;
+          }
+          stopped = true;
+          abortController.abort();
+          socket.emitClose(1000);
+          await monitor;
+        },
+      };
+      activeProviders.push(provider);
+      return provider;
+    };
+    const send = async (provider: Awaited<ReturnType<typeof startProvider>>) => {
+      await emitMattermostChannelPost(provider.socket, {
+        id: "post-abandon-retry",
+        message: "retry me",
+      });
+    };
+    const pendingAttempt = async (attempts: number) => {
+      let observed: Awaited<ReturnType<typeof queue.listPending>>[number] | undefined;
+      await vi.waitFor(async () => {
+        const pending = await queue.listPending({ limit: "all" });
+        expect(pending).toEqual([
+          expect.objectContaining({
+            id: "post-abandon-retry",
+            attempts,
+            lastAttemptAt: expect.any(Number),
+            lastError: "turn-abandoned",
+          }),
+        ]);
+        observed = pending[0];
+      });
+      const lastAttemptAt = observed?.lastAttemptAt;
+      if (lastAttemptAt === undefined) {
+        throw new Error(`Missing Mattermost retry timestamp for attempt ${attempts}`);
+      }
+      return { ...observed, lastAttemptAt };
+    };
+
+    try {
+      const first = await startProvider();
+      await send(first);
+      const firstAttempt = await pendingAttempt(1);
+      expect(mockState.dispatchInboundMessage).toHaveBeenCalledTimes(1);
+      await first.stop();
+
+      vi.setSystemTime(firstAttempt.lastAttemptAt + 999);
+      const blocked = await startProvider();
+      await send(blocked);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockState.dispatchInboundMessage).toHaveBeenCalledTimes(1);
+      await blocked.stop();
+
+      vi.setSystemTime(firstAttempt.lastAttemptAt + 1_001);
+      const second = await startProvider();
+      await send(second);
+      const secondAttempt = await pendingAttempt(2);
+      expect(mockState.dispatchInboundMessage).toHaveBeenCalledTimes(2);
+      await second.stop();
+
+      for (let attempt = 3; attempt < DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS; attempt += 1) {
+        const claim = await queue.claim("post-abandon-retry", { ownerId: `seed-${attempt}` });
+        if (!claim) {
+          throw new Error(`Expected Mattermost seed claim ${attempt}`);
+        }
+        await queue.release(claim, {
+          lastError: "turn-abandoned",
+          releasedAt: secondAttempt.lastAttemptAt,
+        });
+      }
+
+      vi.setSystemTime(secondAttempt.lastAttemptAt + 64_001);
+      const threshold = await startProvider();
+      await send(threshold);
+      const thresholdAttempt = await pendingAttempt(DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS);
+      expect(mockState.dispatchInboundMessage).toHaveBeenCalledTimes(3);
+      await threshold.stop();
+
+      vi.setSystemTime(thresholdAttempt.lastAttemptAt + 128_001);
+      const beyond = await startProvider();
+      await send(beyond);
+      const beyondAttempt = await pendingAttempt(DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS + 1);
+      expect(mockState.dispatchInboundMessage).toHaveBeenCalledTimes(4);
+      await beyond.stop();
+
+      vi.setSystemTime(beyondAttempt.lastAttemptAt + 1_000);
+      const blockedRestart = await startProvider();
+      await send(blockedRestart);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockState.dispatchInboundMessage).toHaveBeenCalledTimes(4);
+      await blockedRestart.stop();
+    } finally {
+      await Promise.allSettled(activeProviders.map(async (provider) => await provider.stop()));
+      mockState.ingressQueue = undefined;
+      closeOpenClawStateDatabaseForTest();
+      await fs.rm(stateDir, { recursive: true, force: true });
+      vi.useRealTimers();
+    }
   });
 
   it("publishes recovering while API authentication retries, including 401", async () => {

--- a/extensions/msteams/src/monitor-handler/message-handler.ingress-lifecycle.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ingress-lifecycle.test.ts
@@ -1,7 +1,16 @@
 // Microsoft Teams tests cover durable claim ownership through inbound debounce.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
+import { DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../runtime-api.js";
+import { createMSTeamsIngress } from "../msteams-ingress.js";
 import type { MSTeamsIngressLifecycle } from "../msteams-ingress.js";
 import type { MSTeamsTurnContext } from "../sdk-types.js";
 import "./message-handler-mock-support.test-support.js";
@@ -155,5 +164,126 @@ describe("Microsoft Teams drain claim ownership", () => {
     await vi.waitFor(() => expect(lifecycle.adoptedCount()).toBe(1), { timeout: 5_000 });
     expect(runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
     expect(lifecycle.abandonedCount()).toBe(0);
+  });
+
+  it("preserves abandon retry accounting, backoff, threshold, and restart behavior", async () => {
+    vi.useFakeTimers();
+    const now = Date.UTC(2026, 0, 2);
+    vi.setSystemTime(now);
+    const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-abandon-"));
+    const stateDir = await fs.realpath(created);
+    type Queue = NonNullable<Parameters<typeof createMSTeamsIngress>[0]["queue"]>;
+    type Payload = Parameters<Queue["enqueue"]>[1];
+    const queue = createChannelIngressQueueForTests<Payload>({
+      channelId: "msteams",
+      accountId: "test-app",
+      stateDir,
+    });
+    const incoming = directActivity("activity-abandon", "retry me");
+    await queue.enqueue(
+      "activity-abandon",
+      { version: 1, receivedAt: now - 2 * 24 * 60 * 60_000, rawActivity: JSON.stringify(incoming) },
+      { laneKey: "dm-conversation", receivedAt: now - 2 * 24 * 60 * 60_000 },
+    );
+    const dispatchMock = runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher;
+    const priorImplementation = dispatchMock.getMockImplementation();
+    dispatchMock.mockRejectedValue(new Error("Microsoft Teams dispatch failed before adoption"));
+
+    const createIntegratedIngress = () => {
+      const handler = createHandler({
+        channels: { msteams: { dmPolicy: "open", allowFrom: ["*"] } },
+      } as OpenClawConfig);
+      return createMSTeamsIngress({
+        accountId: "test-app",
+        queue,
+        runtime: { error: vi.fn(), log: vi.fn() },
+        dispatch: async (activity, lifecycle) => await handler(context(activity), lifecycle),
+      });
+    };
+    const expectPendingAttempt = async (attempts: number) => {
+      let observed: Awaited<ReturnType<typeof queue.listPending>>[number] | undefined;
+      await vi.waitFor(async () => {
+        const pending = await queue.listPending({ limit: "all" });
+        expect(pending).toEqual([
+          expect.objectContaining({
+            id: "activity-abandon",
+            attempts,
+            lastAttemptAt: expect.any(Number),
+            lastError: "turn-abandoned",
+          }),
+        ]);
+        observed = pending[0];
+      });
+      const lastAttemptAt = observed?.lastAttemptAt;
+      if (lastAttemptAt === undefined) {
+        throw new Error(`Missing Microsoft Teams retry timestamp for attempt ${attempts}`);
+      }
+      return { ...observed, lastAttemptAt };
+    };
+
+    try {
+      const first = createIntegratedIngress();
+      first.start();
+      const firstAttempt = await expectPendingAttempt(1);
+      expect(dispatchMock).toHaveBeenCalledTimes(1);
+      await first.stop();
+
+      vi.setSystemTime(firstAttempt.lastAttemptAt + 999);
+      const second = createIntegratedIngress();
+      second.start();
+      await second.accept(incoming);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(dispatchMock).toHaveBeenCalledTimes(1);
+      await second.stop();
+      vi.setSystemTime(firstAttempt.lastAttemptAt + 1_001);
+      const afterBackoff = createIntegratedIngress();
+      afterBackoff.start();
+      await afterBackoff.accept(incoming);
+      const secondAttempt = await expectPendingAttempt(2);
+      expect(dispatchMock).toHaveBeenCalledTimes(2);
+      await afterBackoff.stop();
+
+      for (let attempt = 3; attempt < DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS; attempt += 1) {
+        const claim = await queue.claim("activity-abandon", { ownerId: `seed-${attempt}` });
+        if (!claim) {
+          throw new Error(`Expected Microsoft Teams seed claim ${attempt}`);
+        }
+        await queue.release(claim, {
+          lastError: "turn-abandoned",
+          releasedAt: secondAttempt.lastAttemptAt,
+        });
+      }
+      vi.setSystemTime(secondAttempt.lastAttemptAt + 64_001);
+      const threshold = createIntegratedIngress();
+      threshold.start();
+      await threshold.accept(incoming);
+      const thresholdAttempt = await expectPendingAttempt(DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS);
+      expect(dispatchMock).toHaveBeenCalledTimes(3);
+      await threshold.stop();
+
+      vi.setSystemTime(thresholdAttempt.lastAttemptAt + 128_001);
+      const beyond = createIntegratedIngress();
+      beyond.start();
+      await beyond.accept(incoming);
+      const beyondAttempt = await expectPendingAttempt(DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS + 1);
+      expect(dispatchMock).toHaveBeenCalledTimes(4);
+      await beyond.stop();
+
+      vi.setSystemTime(beyondAttempt.lastAttemptAt + 1_000);
+      const blockedRestart = createIntegratedIngress();
+      blockedRestart.start();
+      await blockedRestart.accept(incoming);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(dispatchMock).toHaveBeenCalledTimes(4);
+      await blockedRestart.stop();
+    } finally {
+      dispatchMock.mockReset();
+      if (priorImplementation) {
+        dispatchMock.mockImplementation(priorImplementation);
+      }
+      closeOpenClawStateDatabaseForTest();
+      await fs.rm(stateDir, { recursive: true, force: true });
+      vi.useRealTimers();
+    }
   });
 });

--- a/extensions/msteams/src/monitor-handler/message-handler.ingress-lifecycle.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ingress-lifecycle.test.ts
@@ -1,14 +1,12 @@
 // Microsoft Teams tests cover durable claim ownership through inbound debounce.
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
 import { DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS } from "openclaw/plugin-sdk/channel-outbound";
 import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../../runtime-api.js";
 import { createMSTeamsIngress } from "../msteams-ingress.js";
 import type { MSTeamsIngressLifecycle } from "../msteams-ingress.js";
@@ -19,6 +17,7 @@ import { createMSTeamsMessageHandler } from "./message-handler.js";
 import { buildChannelActivity, createMessageHandlerDeps } from "./message-handler.test-support.js";
 
 const runtimeApiMockState = getRuntimeApiMockState();
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function createLifecycle(): MSTeamsIngressLifecycle & {
   adoptedCount: () => number;
@@ -170,8 +169,7 @@ describe("Microsoft Teams drain claim ownership", () => {
     vi.useFakeTimers();
     const now = Date.UTC(2026, 0, 2);
     vi.setSystemTime(now);
-    const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-abandon-"));
-    const stateDir = await fs.realpath(created);
+    const stateDir = tempDirs.make("openclaw-msteams-abandon-");
     type Queue = NonNullable<Parameters<typeof createMSTeamsIngress>[0]["queue"]>;
     type Payload = Parameters<Queue["enqueue"]>[1];
     const queue = createChannelIngressQueueForTests<Payload>({
@@ -282,7 +280,6 @@ describe("Microsoft Teams drain claim ownership", () => {
         dispatchMock.mockImplementation(priorImplementation);
       }
       closeOpenClawStateDatabaseForTest();
-      await fs.rm(stateDir, { recursive: true, force: true });
       vi.useRealTimers();
     }
   });

--- a/extensions/msteams/src/monitor-handler/message-handler.ingress-lifecycle.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ingress-lifecycle.test.ts
@@ -1,12 +1,14 @@
 // Microsoft Teams tests cover durable claim ownership through inbound debounce.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
 import { DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS } from "openclaw/plugin-sdk/channel-outbound";
 import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../runtime-api.js";
 import { createMSTeamsIngress } from "../msteams-ingress.js";
 import type { MSTeamsIngressLifecycle } from "../msteams-ingress.js";
@@ -17,7 +19,6 @@ import { createMSTeamsMessageHandler } from "./message-handler.js";
 import { buildChannelActivity, createMessageHandlerDeps } from "./message-handler.test-support.js";
 
 const runtimeApiMockState = getRuntimeApiMockState();
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function createLifecycle(): MSTeamsIngressLifecycle & {
   adoptedCount: () => number;
@@ -169,7 +170,8 @@ describe("Microsoft Teams drain claim ownership", () => {
     vi.useFakeTimers();
     const now = Date.UTC(2026, 0, 2);
     vi.setSystemTime(now);
-    const stateDir = tempDirs.make("openclaw-msteams-abandon-");
+    const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-abandon-"));
+    const stateDir = await fs.realpath(created);
     type Queue = NonNullable<Parameters<typeof createMSTeamsIngress>[0]["queue"]>;
     type Payload = Parameters<Queue["enqueue"]>[1];
     const queue = createChannelIngressQueueForTests<Payload>({
@@ -280,6 +282,7 @@ describe("Microsoft Teams drain claim ownership", () => {
         dispatchMock.mockImplementation(priorImplementation);
       }
       closeOpenClawStateDatabaseForTest();
+      await fs.rm(stateDir, { recursive: true, force: true });
       vi.useRealTimers();
     }
   });

--- a/extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
+++ b/extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
@@ -1,6 +1,15 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 // Signal tests cover retry behavior for reply session initialization conflicts.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS } from "openclaw/plugin-sdk/channel-outbound";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { startSignalIngressMonitor } from "../signal-ingress.js";
 import type { SignalEventHandlerDeps } from "./event-handler.types.js";
 
 const [
@@ -322,6 +331,127 @@ describe("signal reply session init conflict retry", () => {
 
       expect(errorLogs.some((msg) => msg.includes("signal debounce flush failed"))).toBe(true);
     } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("preserves durable abandon accounting through backoff, threshold, and restart", async () => {
+    vi.useFakeTimers();
+    const now = Date.UTC(2026, 0, 2);
+    vi.setSystemTime(now);
+    const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-signal-abandon-"));
+    const stateDir = await fs.realpath(created);
+    type Queue = NonNullable<Parameters<typeof startSignalIngressMonitor>[0]["queue"]>;
+    type Payload = Parameters<Queue["enqueue"]>[1];
+    const queue = createChannelIngressQueueForTests<Payload>({
+      channelId: "signal",
+      accountId: "default",
+      stateDir,
+    });
+    const timestamp = 1_700_000_000_777;
+    const event = createSignalReceiveEvent({
+      timestamp,
+      dataMessage: { timestamp, message: "retry through durable ingress", attachments: [] },
+    });
+    const eventId = JSON.stringify(["number:+15550001111", timestamp]);
+    dispatchInboundMessageMock.mockRejectedValue(CONFLICT_ERROR);
+
+    const createIntegratedMonitor = async () => {
+      const tracked = createTrackedTaskHarness();
+      const handler = createSignalEventHandler(
+        createBaseSignalEventHandlerDeps({
+          cfg: { messages: { inbound: { debounceMs: 10 } } },
+          runTrackedTask: tracked.runTrackedTask,
+        }),
+      );
+      const monitor = await startSignalIngressMonitor({
+        accountId: "default",
+        queue,
+        dispatch: async (incoming, lifecycle) => await handler(incoming, lifecycle),
+        runtime: { error: vi.fn(), log: vi.fn() },
+      });
+      return { monitor, tracked };
+    };
+    const finishOuterAttempt = async (tracked: ReturnType<typeof createTrackedTaskHarness>) => {
+      await vi.advanceTimersByTimeAsync(10);
+      expect(tracked.tasks).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(7_000);
+      await Promise.all(tracked.tasks);
+    };
+    const pendingAttempt = async (attempts: number) => {
+      const pending = await queue.listPending({ limit: "all" });
+      expect(pending).toEqual([
+        expect.objectContaining({
+          id: eventId,
+          attempts,
+          lastAttemptAt: expect.any(Number),
+          lastError: "turn-abandoned",
+        }),
+      ]);
+      const record = pending[0];
+      const lastAttemptAt = record?.lastAttemptAt;
+      if (lastAttemptAt === undefined) {
+        throw new Error(`Missing Signal retry timestamp for attempt ${attempts}`);
+      }
+      return { ...record, lastAttemptAt };
+    };
+
+    try {
+      const first = await createIntegratedMonitor();
+      await first.monitor.receive(event);
+      await finishOuterAttempt(first.tracked);
+      const firstAttempt = await pendingAttempt(1);
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(4);
+      await first.monitor.stop();
+
+      vi.setSystemTime(firstAttempt.lastAttemptAt + 999);
+      const blocked = await createIntegratedMonitor();
+      await vi.advanceTimersByTimeAsync(10);
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(4);
+      expect(blocked.tracked.tasks).toHaveLength(0);
+      await blocked.monitor.stop();
+
+      vi.setSystemTime(firstAttempt.lastAttemptAt + 1_001);
+      const second = await createIntegratedMonitor();
+      await finishOuterAttempt(second.tracked);
+      const secondAttempt = await pendingAttempt(2);
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(8);
+      await second.monitor.stop();
+
+      for (let attempt = 3; attempt < DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS; attempt += 1) {
+        const claim = await queue.claim(eventId, { ownerId: `seed-${attempt}` });
+        if (!claim) {
+          throw new Error(`Expected Signal seed claim ${attempt}`);
+        }
+        await queue.release(claim, {
+          lastError: "turn-abandoned",
+          releasedAt: secondAttempt.lastAttemptAt,
+        });
+      }
+
+      vi.setSystemTime(secondAttempt.lastAttemptAt + 64_001);
+      const threshold = await createIntegratedMonitor();
+      await finishOuterAttempt(threshold.tracked);
+      const thresholdAttempt = await pendingAttempt(DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS);
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(12);
+      await threshold.monitor.stop();
+
+      vi.setSystemTime(thresholdAttempt.lastAttemptAt + 128_001);
+      const beyond = await createIntegratedMonitor();
+      await finishOuterAttempt(beyond.tracked);
+      const beyondAttempt = await pendingAttempt(DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS + 1);
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(16);
+      await beyond.monitor.stop();
+
+      vi.setSystemTime(beyondAttempt.lastAttemptAt + 1_000);
+      const blockedRestart = await createIntegratedMonitor();
+      await vi.advanceTimersByTimeAsync(10);
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(16);
+      expect(blockedRestart.tracked.tasks).toHaveLength(0);
+      await blockedRestart.monitor.stop();
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+      await fs.rm(stateDir, { recursive: true, force: true });
       vi.useRealTimers();
     }
   });

--- a/extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
+++ b/extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
@@ -1,14 +1,12 @@
 // Signal tests cover retry behavior for reply session initialization conflicts.
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import { startSignalIngressMonitor } from "../signal-ingress.js";
 import type { SignalEventHandlerDeps } from "./event-handler.types.js";
 
@@ -16,6 +14,8 @@ const [
   { createBaseSignalEventHandlerDeps, createSignalReceiveEvent },
   { createSignalEventHandler },
 ] = await Promise.all([import("./event-handler.test-harness.js"), import("./event-handler.js")]);
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const {
   sendTypingMock,
@@ -339,8 +339,7 @@ describe("signal reply session init conflict retry", () => {
     vi.useFakeTimers();
     const now = Date.UTC(2026, 0, 2);
     vi.setSystemTime(now);
-    const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-signal-abandon-"));
-    const stateDir = await fs.realpath(created);
+    const stateDir = tempDirs.make("openclaw-signal-abandon-");
     type Queue = NonNullable<Parameters<typeof startSignalIngressMonitor>[0]["queue"]>;
     type Payload = Parameters<Queue["enqueue"]>[1];
     const queue = createChannelIngressQueueForTests<Payload>({
@@ -451,7 +450,6 @@ describe("signal reply session init conflict retry", () => {
       await blockedRestart.monitor.stop();
     } finally {
       closeOpenClawStateDatabaseForTest();
-      await fs.rm(stateDir, { recursive: true, force: true });
       vi.useRealTimers();
     }
   });

--- a/extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
+++ b/extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
@@ -1,12 +1,14 @@
 // Signal tests cover retry behavior for reply session initialization conflicts.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { startSignalIngressMonitor } from "../signal-ingress.js";
 import type { SignalEventHandlerDeps } from "./event-handler.types.js";
 
@@ -14,8 +16,6 @@ const [
   { createBaseSignalEventHandlerDeps, createSignalReceiveEvent },
   { createSignalEventHandler },
 ] = await Promise.all([import("./event-handler.test-harness.js"), import("./event-handler.js")]);
-
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const {
   sendTypingMock,
@@ -339,7 +339,8 @@ describe("signal reply session init conflict retry", () => {
     vi.useFakeTimers();
     const now = Date.UTC(2026, 0, 2);
     vi.setSystemTime(now);
-    const stateDir = tempDirs.make("openclaw-signal-abandon-");
+    const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-signal-abandon-"));
+    const stateDir = await fs.realpath(created);
     type Queue = NonNullable<Parameters<typeof startSignalIngressMonitor>[0]["queue"]>;
     type Payload = Parameters<Queue["enqueue"]>[1];
     const queue = createChannelIngressQueueForTests<Payload>({
@@ -450,6 +451,7 @@ describe("signal reply session init conflict retry", () => {
       await blockedRestart.monitor.stop();
     } finally {
       closeOpenClawStateDatabaseForTest();
+      await fs.rm(stateDir, { recursive: true, force: true });
       vi.useRealTimers();
     }
   });

--- a/src/channels/message/ingress-drain-lifecycle.test.ts
+++ b/src/channels/message/ingress-drain-lifecycle.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { bindIngressLifecycleToReplyOptions } from "./ingress-drain-lifecycle.js";
+
+describe("channel ingress drain lifecycle", () => {
+  it("binds only the reply-lane ownership surface", async () => {
+    const abort = new AbortController();
+    const calls: string[] = [];
+    const bound = bindIngressLifecycleToReplyOptions({
+      abortSignal: abort.signal,
+      onAdoptionFinalizing: () => {
+        calls.push("finalizing");
+      },
+      onFailed: () => {
+        calls.push("failed");
+      },
+      onCancelled: () => {
+        calls.push("cancelled");
+      },
+      onAdopted: () => {
+        calls.push("adopted");
+      },
+      onDeferred: () => {
+        calls.push("deferred");
+      },
+      onAbandoned: () => {
+        calls.push("abandoned");
+      },
+    });
+
+    expect(bound.turnAdoptionLifecycle).toMatchObject({
+      admission: "exclusive",
+      abortSignal: abort.signal,
+    });
+    expect("onFailed" in bound.turnAdoptionLifecycle).toBe(false);
+    expect("onCancelled" in bound.turnAdoptionLifecycle).toBe(false);
+    expect("onAdopted" in bound).toBe(false);
+    expect(Object.keys(bound)).toEqual(["turnAdoptionLifecycle"]);
+    bound.turnAdoptionLifecycle.onDeferred();
+    await bound.turnAdoptionLifecycle.onAbandoned();
+    expect(calls).toEqual(["deferred", "abandoned"]);
+    calls.length = 0;
+    bound.turnAdoptionLifecycle.onDeferred();
+    await bound.turnAdoptionLifecycle.onAdopted();
+    expect(calls).toEqual(["deferred", "adopted"]);
+  });
+});

--- a/src/channels/message/ingress-drain-lifecycle.ts
+++ b/src/channels/message/ingress-drain-lifecycle.ts
@@ -1,0 +1,55 @@
+/** Full pre-adoption -> adoption ownership lifecycle for one claimed event. */
+export type ChannelIngressDispatchLifecycle = {
+  /** Pre-adoption only. After adopt the drain treats this signal as inert. */
+  abortSignal: AbortSignal;
+  /**
+   * Fires when recovery-relevant session/run state is durable.
+   * Drain completes (tombstones) the claim here -- never at settle.
+   */
+  onAdopted: () => void | Promise<void>;
+  /**
+   * Turn ownership deferred to reply-lane admission (queued followup).
+   * Claim remains held until adopted or abandoned.
+   */
+  onDeferred: () => void;
+  /**
+   * Durable adoption finalization is in progress (e.g. settlement hold while
+   * committing dedupe). Clears the pre-adoption stall watchdog so a timeout
+   * settlement cannot race and dead-letter an about-to-complete claim.
+   * Claim stays held until onAdopted / onAbandoned / fail.
+   */
+  onAdoptionFinalizing: () => void;
+  /** Deferred work terminally failed after dispatch returned. */
+  onFailed?: (error: unknown) => void | Promise<void>;
+  /** Explicit cancellation before adoption; releases without consuming retry budget. */
+  onCancelled?: () => void | Promise<void>;
+  /**
+   * Deferred turn finished without ever owning the reply lane.
+   * Drain releases the claim for retry.
+   */
+  onAbandoned: () => void | Promise<void>;
+};
+
+/** Maps a drain lifecycle onto the reply-lane ownership surface. */
+export function bindIngressLifecycleToReplyOptions(lifecycle: ChannelIngressDispatchLifecycle): {
+  turnAdoptionLifecycle: {
+    admission: "exclusive";
+    onAdopted: () => void | Promise<void>;
+    onDeferred: () => void;
+    onAbandoned: () => void | Promise<void>;
+    abortSignal: AbortSignal;
+  };
+} {
+  return {
+    turnAdoptionLifecycle: {
+      admission: "exclusive",
+      onAdopted: lifecycle.onAdopted,
+      onDeferred: lifecycle.onDeferred,
+      onAbandoned: lifecycle.onAbandoned,
+      abortSignal: lifecycle.abortSignal,
+    },
+  };
+}
+
+// onAdoptionFinalizing stays drain-only (not reply-options); channels call it
+// via the spooled-replay ALS lifecycle frame during settlement hold.

--- a/src/channels/message/ingress-drain.cancellation.test.ts
+++ b/src/channels/message/ingress-drain.cancellation.test.ts
@@ -1,0 +1,89 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { createChannelIngressDrain } from "./ingress-drain.js";
+import {
+  createTestIngressQueue,
+  type IngressDrainTestPayload as Payload,
+  withTempState,
+} from "./ingress-drain.test-helpers.js";
+
+type ChannelIngressDispatchLifecycle = Parameters<
+  Parameters<typeof createChannelIngressDrain>[0]["dispatchClaimedEvent"]
+>[1];
+
+describe("channel ingress drain cancellation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    closeOpenClawStateDatabaseForTest();
+  });
+
+  it("cancels unadopted work without changing its retry facts", async () => {
+    await withTempState(async (stateDir) => {
+      let clock = 100;
+      const queue = createTestIngressQueue(stateDir, { now: () => clock });
+      await queue.enqueue("evt-cancel", { text: "x" }, { laneKey: "l1", receivedAt: 1 });
+      const failedClaim = await queue.claim("evt-cancel", { ownerId: "failed-owner" });
+      expect(failedClaim).not.toBeNull();
+      if (!failedClaim) {
+        return;
+      }
+      await queue.release(failedClaim, { lastError: "previous failure", releasedAt: clock });
+      const before = (await queue.listPending())[0];
+      for (let cycle = 0; cycle < 3; cycle += 1) {
+        const lifecycles: ChannelIngressDispatchLifecycle[] = [];
+        clock += 1;
+        const drain = createChannelIngressDrain<Payload>({
+          queue,
+          now: () => clock,
+          retryPolicy: { baseMs: 0, maxMs: 0 },
+          dispatchClaimedEvent: async (_event, lifecycle) => {
+            lifecycles.push(lifecycle);
+            return { kind: "deferred" };
+          },
+        });
+
+        await drain.drainOnce();
+        await vi.waitFor(() => expect(lifecycles).toHaveLength(1));
+        await expectDefined(
+          expectDefined(lifecycles[0], "cancelled lifecycle").onCancelled,
+          "cancel callback",
+        )();
+        expect(await queue.listPending()).toEqual([
+          expect.objectContaining({
+            id: "evt-cancel",
+            attempts: before?.attempts,
+            lastAttemptAt: before?.lastAttemptAt,
+            lastError: before?.lastError,
+          }),
+        ]);
+        expect(await queue.listClaims()).toEqual([]);
+        drain.dispose();
+      }
+
+      const terminal = createChannelIngressDrain<Payload>({
+        queue,
+        now: () => clock,
+        retryPolicy: { maxAttempts: 2, deadLetterMinAgeMs: 0, baseMs: 0, maxMs: 0 },
+        dispatchClaimedEvent: async () => {
+          throw new Error("final genuine failure");
+        },
+      });
+      await terminal.drainOnce();
+      await terminal.waitForIdle();
+      expect(await queue.listFailed?.()).toEqual([
+        expect.objectContaining({
+          id: "evt-cancel",
+          attempts: 1,
+          reason: "retry-limit-exceeded",
+          message: "final genuine failure",
+        }),
+      ]);
+      terminal.dispose();
+    });
+  });
+});

--- a/src/channels/message/ingress-drain.test.ts
+++ b/src/channels/message/ingress-drain.test.ts
@@ -170,6 +170,149 @@ describe("channel ingress drain", () => {
     });
   });
 
+  it("cancels unadopted work without changing its retry facts", async () => {
+    await withTempState(async (stateDir) => {
+      let clock = 100;
+      const queue = createTestIngressQueue(stateDir, { now: () => clock });
+      await queue.enqueue("evt-cancel", { text: "x" }, { laneKey: "l1", receivedAt: 1 });
+      const failedClaim = await queue.claim("evt-cancel", { ownerId: "failed-owner" });
+      expect(failedClaim).not.toBeNull();
+      if (!failedClaim) {
+        return;
+      }
+      await queue.release(failedClaim, { lastError: "previous failure", releasedAt: clock });
+      const before = (await queue.listPending())[0];
+      for (let cycle = 0; cycle < 3; cycle += 1) {
+        const lifecycles: ChannelIngressDispatchLifecycle[] = [];
+        clock += 1;
+        const drain = createChannelIngressDrain<Payload>({
+          queue,
+          now: () => clock,
+          retryPolicy: { baseMs: 0, maxMs: 0 },
+          dispatchClaimedEvent: async (_event, lifecycle) => {
+            lifecycles.push(lifecycle);
+            return { kind: "deferred" };
+          },
+        });
+
+        await drain.drainOnce();
+        await vi.waitFor(() => expect(lifecycles).toHaveLength(1));
+        await expectDefined(
+          expectDefined(lifecycles[0], "cancelled lifecycle").onCancelled,
+          "cancel callback",
+        )();
+        expect(await queue.listPending()).toEqual([
+          expect.objectContaining({
+            id: "evt-cancel",
+            attempts: before?.attempts,
+            lastAttemptAt: before?.lastAttemptAt,
+            lastError: before?.lastError,
+          }),
+        ]);
+        expect(await queue.listClaims()).toEqual([]);
+        drain.dispose();
+      }
+
+      const terminal = createChannelIngressDrain<Payload>({
+        queue,
+        now: () => clock,
+        retryPolicy: { maxAttempts: 2, deadLetterMinAgeMs: 0, baseMs: 0, maxMs: 0 },
+        dispatchClaimedEvent: async () => {
+          throw new Error("final genuine failure");
+        },
+      });
+      await terminal.drainOnce();
+      await terminal.waitForIdle();
+      expect(await queue.listFailed?.()).toEqual([
+        expect.objectContaining({
+          id: "evt-cancel",
+          attempts: 1,
+          reason: "retry-limit-exceeded",
+          message: "final genuine failure",
+        }),
+      ]);
+      terminal.dispose();
+    });
+  });
+
+  it("keeps the lane owned until a dead-letter write commits", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue(stateDir);
+      await queue.enqueue("poison", { text: "bad" }, { laneKey: "shared", receivedAt: 1 });
+      await queue.enqueue("follower", { text: "good" }, { laneKey: "shared", receivedAt: 2 });
+      const fail = queue.fail.bind(queue);
+      let failAttempts = 0;
+      queue.fail = async (...args) => {
+        failAttempts += 1;
+        if (failAttempts < 3) {
+          throw new Error(`transient fail write ${failAttempts}`);
+        }
+        return await fail(...args);
+      };
+      const dispatched: string[] = [];
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        retryPolicy: { maxAttempts: 1, deadLetterMinAgeMs: 0 },
+        dispatchClaimedEvent: async (event, lifecycle) => {
+          dispatched.push(event.id);
+          if (event.id === "poison") {
+            throw new Error("poison delivery");
+          }
+          await lifecycle.onAdopted();
+        },
+      });
+
+      await drain.drainOnce();
+      const idle = drain.waitForIdle();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(failAttempts).toBe(1);
+      expect(drain.activeLaneKeys()).toEqual(new Set(["shared"]));
+      expect(await drain.drainOnce()).toEqual({ started: 0 });
+      expect(dispatched).toEqual(["poison"]);
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      await idle;
+      expect(failAttempts).toBe(3);
+      expect(await drain.drainOnce()).toEqual({ started: 1 });
+      await drain.waitForIdle();
+      expect(dispatched).toEqual(["poison", "follower"]);
+      drain.dispose();
+    });
+  });
+
+  it("keeps ownership when every dead-letter write fails", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue(stateDir);
+      await queue.enqueue("poison", { text: "bad" }, { laneKey: "shared", receivedAt: 1 });
+      await queue.enqueue("follower", { text: "good" }, { laneKey: "shared", receivedAt: 2 });
+      queue.fail = async () => {
+        throw new Error("persistent fail write");
+      };
+      const dispatched: string[] = [];
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        retryPolicy: { maxAttempts: 1, deadLetterMinAgeMs: 0 },
+        dispatchClaimedEvent: async (event) => {
+          dispatched.push(event.id);
+          throw new Error("poison delivery");
+        },
+      });
+
+      await drain.drainOnce();
+      const idle = drain.waitForIdle();
+      for (let attempt = 0; attempt < 8; attempt += 1) {
+        await vi.advanceTimersByTimeAsync(180_000);
+      }
+      await idle;
+
+      expect(dispatched).toEqual(["poison"]);
+      expect(drain.activeLaneKeys()).toEqual(new Set(["shared"]));
+      expect((await queue.listClaims()).map((claim) => claim.id)).toEqual(["poison"]);
+      expect(await drain.drainOnce()).toEqual({ started: 0 });
+      drain.dispose();
+    });
+  });
+
   it("holds lanes by default and releases only opted-in deferred lanes", async () => {
     for (const occupancy of ["hold", "release"] as const) {
       await withTempState(async (stateDir) => {
@@ -697,6 +840,39 @@ describe("channel ingress drain", () => {
     });
   });
 
+  it("keeps retry-accounted abandonment pending beyond the failure threshold", async () => {
+    await withTempState(async (stateDir) => {
+      let clock = 1;
+      const queue = createTestIngressQueue(stateDir, { now: () => clock });
+      await queue.enqueue("abandoned", { text: "x" }, { laneKey: "l", receivedAt: 1 });
+
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        clock += 1;
+        const drain = createChannelIngressDrain<Payload>({
+          queue,
+          now: () => clock,
+          retryPolicy: { maxAttempts: 1, deadLetterMinAgeMs: 0, baseMs: 0, maxMs: 0 },
+          dispatchClaimedEvent: async (_event, lifecycle) => {
+            await lifecycle.onAbandoned();
+            return { kind: "deferred" };
+          },
+        });
+        await drain.drainOnce();
+        await drain.waitForIdle();
+        drain.dispose();
+      }
+
+      expect(await queue.listPending()).toEqual([
+        expect.objectContaining({
+          id: "abandoned",
+          attempts: 3,
+          lastError: "turn-abandoned",
+        }),
+      ]);
+      expect(await queue.listFailed?.()).toEqual([]);
+    });
+  });
+
   it("bindIngressLifecycleToReplyOptions returns only turnAdoptionLifecycle", async () => {
     const abort = new AbortController();
     const calls: string[] = [];
@@ -707,6 +883,9 @@ describe("channel ingress drain", () => {
       },
       onFailed: () => {
         calls.push("failed");
+      },
+      onCancelled: () => {
+        calls.push("cancelled");
       },
       onAdopted: () => {
         calls.push("adopted");
@@ -721,6 +900,7 @@ describe("channel ingress drain", () => {
     expect(bound.turnAdoptionLifecycle.abortSignal).toBe(abort.signal);
     expect(bound.turnAdoptionLifecycle.admission).toBe("exclusive");
     expect("onFailed" in bound.turnAdoptionLifecycle).toBe(false);
+    expect("onCancelled" in bound.turnAdoptionLifecycle).toBe(false);
     expect("onAdopted" in bound).toBe(false);
     expect(Object.keys(bound)).toEqual(["turnAdoptionLifecycle"]);
     bound.turnAdoptionLifecycle.onDeferred();
@@ -1150,6 +1330,7 @@ describe("channel ingress drain", () => {
       onDeferred: () => {},
       onAdoptionFinalizing: () => {},
       onFailed: () => {},
+      onCancelled: () => {},
       onAbandoned: () => {},
     });
     expect(bound.turnAdoptionLifecycle.admission).toBe("exclusive");

--- a/src/channels/message/ingress-drain.test.ts
+++ b/src/channels/message/ingress-drain.test.ts
@@ -3,7 +3,6 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import {
-  bindIngressLifecycleToReplyOptions,
   createChannelIngressDrain,
   DEFAULT_INGRESS_ADOPTION_STALL_MS,
   isIngressAdoptionLostError,
@@ -167,71 +166,6 @@ describe("channel ingress drain", () => {
         expect(pending[0]?.attempts).toBeGreaterThanOrEqual(1);
       });
       drain.dispose();
-    });
-  });
-
-  it("cancels unadopted work without changing its retry facts", async () => {
-    await withTempState(async (stateDir) => {
-      let clock = 100;
-      const queue = createTestIngressQueue(stateDir, { now: () => clock });
-      await queue.enqueue("evt-cancel", { text: "x" }, { laneKey: "l1", receivedAt: 1 });
-      const failedClaim = await queue.claim("evt-cancel", { ownerId: "failed-owner" });
-      expect(failedClaim).not.toBeNull();
-      if (!failedClaim) {
-        return;
-      }
-      await queue.release(failedClaim, { lastError: "previous failure", releasedAt: clock });
-      const before = (await queue.listPending())[0];
-      for (let cycle = 0; cycle < 3; cycle += 1) {
-        const lifecycles: ChannelIngressDispatchLifecycle[] = [];
-        clock += 1;
-        const drain = createChannelIngressDrain<Payload>({
-          queue,
-          now: () => clock,
-          retryPolicy: { baseMs: 0, maxMs: 0 },
-          dispatchClaimedEvent: async (_event, lifecycle) => {
-            lifecycles.push(lifecycle);
-            return { kind: "deferred" };
-          },
-        });
-
-        await drain.drainOnce();
-        await vi.waitFor(() => expect(lifecycles).toHaveLength(1));
-        await expectDefined(
-          expectDefined(lifecycles[0], "cancelled lifecycle").onCancelled,
-          "cancel callback",
-        )();
-        expect(await queue.listPending()).toEqual([
-          expect.objectContaining({
-            id: "evt-cancel",
-            attempts: before?.attempts,
-            lastAttemptAt: before?.lastAttemptAt,
-            lastError: before?.lastError,
-          }),
-        ]);
-        expect(await queue.listClaims()).toEqual([]);
-        drain.dispose();
-      }
-
-      const terminal = createChannelIngressDrain<Payload>({
-        queue,
-        now: () => clock,
-        retryPolicy: { maxAttempts: 2, deadLetterMinAgeMs: 0, baseMs: 0, maxMs: 0 },
-        dispatchClaimedEvent: async () => {
-          throw new Error("final genuine failure");
-        },
-      });
-      await terminal.drainOnce();
-      await terminal.waitForIdle();
-      expect(await queue.listFailed?.()).toEqual([
-        expect.objectContaining({
-          id: "evt-cancel",
-          attempts: 1,
-          reason: "retry-limit-exceeded",
-          message: "final genuine failure",
-        }),
-      ]);
-      terminal.dispose();
     });
   });
 
@@ -521,7 +455,7 @@ describe("channel ingress drain", () => {
     });
   });
 
-  it("abandoned via turnAdoptionLifecycle releases claim with attempt increment", async () => {
+  it("abandoned reply ownership releases claim with attempt increment", async () => {
     await withTempState(async (stateDir) => {
       const queue = createTestIngressQueue(stateDir);
       await queue.enqueue("evt-q", { text: "x" }, { laneKey: "l1" });
@@ -529,10 +463,9 @@ describe("channel ingress drain", () => {
       const drain = createChannelIngressDrain<Payload>({
         queue,
         dispatchClaimedEvent: async (_event, lifecycle) => {
-          const bound = bindIngressLifecycleToReplyOptions(lifecycle);
-          bound.turnAdoptionLifecycle.onDeferred();
+          lifecycle.onDeferred();
           // Never admitted — abandon path releases claim.
-          await bound.turnAdoptionLifecycle.onAbandoned();
+          await lifecycle.onAbandoned();
           return { kind: "deferred" };
         },
       });
@@ -548,7 +481,7 @@ describe("channel ingress drain", () => {
     });
   });
 
-  it("queued deferral→admission completes the claim exactly once via turnAdoptionLifecycle", async () => {
+  it("queued deferral -> admission completes the claim exactly once", async () => {
     await withTempState(async (stateDir) => {
       const queue = createTestIngressQueue(stateDir);
       await queue.enqueue("evt-admit", { text: "x" }, { laneKey: "l1" });
@@ -557,13 +490,12 @@ describe("channel ingress drain", () => {
       const drain = createChannelIngressDrain<Payload>({
         queue,
         dispatchClaimedEvent: async (_event, lifecycle) => {
-          const bound = bindIngressLifecycleToReplyOptions(lifecycle);
           // Simulate queue enqueue (defer) then reply-lane admission (adopt).
-          bound.turnAdoptionLifecycle.onDeferred();
-          await bound.turnAdoptionLifecycle.onAdopted();
+          lifecycle.onDeferred();
+          await lifecycle.onAdopted();
           adoptCount += 1;
           // Second adopt from lifecycle must be a no-op for the claim.
-          await bound.turnAdoptionLifecycle.onAdopted();
+          await lifecycle.onAdopted();
           adoptCount += 1;
           return { kind: "deferred" };
         },
@@ -579,105 +511,6 @@ describe("channel ingress drain", () => {
       // No re-dispatch on later drain.
       const second = await drain.drainOnce();
       expect(second.started).toBe(0);
-      drain.dispose();
-    });
-  });
-
-  it("watchdog only guillotines pre-adoption stalls with handler-timeout", async () => {
-    await withTempState(async (stateDir) => {
-      let clock = 10_000;
-      const queue = createTestIngressQueue(stateDir, { now: () => clock });
-      await queue.enqueue("evt-stall", { text: "x" }, { laneKey: "l1" });
-
-      const drain = createChannelIngressDrain<Payload>({
-        queue,
-        now: () => clock,
-        adoptionStallTimeoutMs: 5_000,
-        dispatchClaimedEvent: async () => {
-          // Never adopt, never return — stall until watchdog.
-          await new Promise(() => {});
-        },
-      });
-
-      await drain.drainOnce();
-      clock += 5_000;
-      await vi.advanceTimersByTimeAsync(5_000);
-      await drain.waitForIdle();
-
-      // Failed tombstone, not pending retry.
-      const reenqueue = await queue.enqueue("evt-stall", { text: "x" });
-      expect(reenqueue.kind).toBe("failed");
-      if (reenqueue.kind === "failed") {
-        expect(reenqueue.record.reason).toBe("handler-timeout");
-      }
-      drain.dispose();
-    });
-  });
-
-  it("watchdog guillotines deferred phase (timer not cleared by deferral)", async () => {
-    await withTempState(async (stateDir) => {
-      let clock = 30_000;
-      const queue = createTestIngressQueue(stateDir, { now: () => clock });
-      await queue.enqueue("evt-def-stall", { text: "x" }, { laneKey: "l1" });
-
-      const drain = createChannelIngressDrain<Payload>({
-        queue,
-        now: () => clock,
-        adoptionStallTimeoutMs: 5_000,
-        dispatchClaimedEvent: async (_event, lifecycle) => {
-          lifecycle.onDeferred();
-          // Stay deferred without adoption — watchdog must still fire.
-          await new Promise(() => {});
-        },
-      });
-
-      await drain.drainOnce();
-      expect(await queue.listClaims()).toHaveLength(1);
-      clock += 5_000;
-      await vi.advanceTimersByTimeAsync(5_000);
-      await drain.waitForIdle();
-
-      const reenqueue = await queue.enqueue("evt-def-stall", { text: "x" });
-      expect(reenqueue.kind).toBe("failed");
-      if (reenqueue.kind === "failed") {
-        expect(reenqueue.record.reason).toBe("handler-timeout");
-      }
-      drain.dispose();
-    });
-  });
-
-  it("watchdog does not kill healthy long turns after adoption", async () => {
-    await withTempState(async (stateDir) => {
-      let clock = 20_000;
-      const queue = createTestIngressQueue(stateDir, { now: () => clock });
-      await queue.enqueue("evt-long", { text: "x" }, { laneKey: "l1" });
-
-      let settleResolve!: () => void;
-      const settleGate = new Promise<void>((resolve) => {
-        settleResolve = resolve;
-      });
-
-      const drain = createChannelIngressDrain<Payload>({
-        queue,
-        now: () => clock,
-        adoptionStallTimeoutMs: 1_000,
-        dispatchClaimedEvent: async (_event, lifecycle) => {
-          await lifecycle.onAdopted();
-          await settleGate;
-        },
-      });
-
-      await drain.drainOnce();
-      await vi.waitFor(async () => {
-        expect(await queue.listClaims()).toEqual([]);
-      });
-      clock += 60_000;
-      await vi.advanceTimersByTimeAsync(60_000);
-      // Still only completed — not failed by watchdog.
-      const status = await queue.enqueue("evt-long", { text: "x" });
-      expect(status.kind).toBe("completed");
-      settleResolve();
-      await drain.waitForIdle();
       drain.dispose();
     });
   });
@@ -871,45 +704,6 @@ describe("channel ingress drain", () => {
       ]);
       expect(await queue.listFailed?.()).toEqual([]);
     });
-  });
-
-  it("bindIngressLifecycleToReplyOptions returns only turnAdoptionLifecycle", async () => {
-    const abort = new AbortController();
-    const calls: string[] = [];
-    const bound = bindIngressLifecycleToReplyOptions({
-      abortSignal: abort.signal,
-      onAdoptionFinalizing: () => {
-        calls.push("finalizing");
-      },
-      onFailed: () => {
-        calls.push("failed");
-      },
-      onCancelled: () => {
-        calls.push("cancelled");
-      },
-      onAdopted: () => {
-        calls.push("adopted");
-      },
-      onDeferred: () => {
-        calls.push("deferred");
-      },
-      onAbandoned: () => {
-        calls.push("abandoned");
-      },
-    });
-    expect(bound.turnAdoptionLifecycle.abortSignal).toBe(abort.signal);
-    expect(bound.turnAdoptionLifecycle.admission).toBe("exclusive");
-    expect("onFailed" in bound.turnAdoptionLifecycle).toBe(false);
-    expect("onCancelled" in bound.turnAdoptionLifecycle).toBe(false);
-    expect("onAdopted" in bound).toBe(false);
-    expect(Object.keys(bound)).toEqual(["turnAdoptionLifecycle"]);
-    bound.turnAdoptionLifecycle.onDeferred();
-    await bound.turnAdoptionLifecycle.onAbandoned();
-    expect(calls).toEqual(["deferred", "abandoned"]);
-    calls.length = 0;
-    bound.turnAdoptionLifecycle.onDeferred();
-    await bound.turnAdoptionLifecycle.onAdopted();
-    expect(calls).toEqual(["deferred", "adopted"]);
   });
 
   it("refreshes active claims on claimLeaseMs/3 while deferred", async () => {
@@ -1320,19 +1114,5 @@ describe("channel ingress drain", () => {
       expect(again.kind).toBe("completed");
       drain.dispose();
     });
-  });
-
-  it("bindIngressLifecycleToReplyOptions marks exclusive admission", () => {
-    const abort = new AbortController();
-    const bound = bindIngressLifecycleToReplyOptions({
-      abortSignal: abort.signal,
-      onAdopted: async () => {},
-      onDeferred: () => {},
-      onAdoptionFinalizing: () => {},
-      onFailed: () => {},
-      onCancelled: () => {},
-      onAbandoned: () => {},
-    });
-    expect(bound.turnAdoptionLifecycle.admission).toBe("exclusive");
   });
 });

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -15,6 +15,7 @@ import {
   isLiveLocalIngressDrainOwner,
   registerLiveIngressDrainInstance,
 } from "./ingress-claim-owner.js";
+import type { ChannelIngressDispatchLifecycle } from "./ingress-drain-lifecycle.js";
 import {
   activeClaimKey,
   IngressAdoptionLostError,
@@ -25,6 +26,7 @@ import {
   type ChannelIngressDrainDispatchResult,
 } from "./ingress-drain-state.js";
 import { supersedeActiveStatesIfNeeded } from "./ingress-drain-supersede.js";
+export { bindIngressLifecycleToReplyOptions } from "./ingress-drain-lifecycle.js";
 export { isIngressAdoptionLostError } from "./ingress-drain-state.js";
 import type {
   ChannelIngressQueue,
@@ -45,38 +47,6 @@ export const DEFAULT_INGRESS_ADOPTION_STALL_MS = 5 * 60 * 1000;
 
 /** Bounded tombstone write retries — wedged ownership beats silent double-dispatch. */
 const INGRESS_TOMBSTONE_RETRY_MAX_ATTEMPTS = 8;
-
-/** Full pre-adoption → adoption ownership lifecycle for one claimed event. */
-type ChannelIngressDispatchLifecycle = {
-  /** Pre-adoption only. After adopt the drain treats this signal as inert. */
-  abortSignal: AbortSignal;
-  /**
-   * Fires when recovery-relevant session/run state is durable.
-   * Drain completes (tombstones) the claim here — never at settle.
-   */
-  onAdopted: () => void | Promise<void>;
-  /**
-   * Turn ownership deferred to reply-lane admission (queued followup).
-   * Claim remains held until adopted or abandoned.
-   */
-  onDeferred: () => void;
-  /**
-   * Durable adoption finalization is in progress (e.g. settlement hold while
-   * committing dedupe). Clears the pre-adoption stall watchdog so a timeout
-   * settlement cannot race and dead-letter an about-to-complete claim.
-   * Claim stays held until onAdopted / onAbandoned / fail.
-   */
-  onAdoptionFinalizing: () => void;
-  /** Deferred work terminally failed after dispatch returned. */
-  onFailed?: (error: unknown) => void | Promise<void>;
-  /** Explicit cancellation before adoption; releases without consuming retry budget. */
-  onCancelled?: () => void | Promise<void>;
-  /**
-   * Deferred turn finished without ever owning the reply lane.
-   * Drain releases the claim for retry.
-   */
-  onAbandoned: () => void | Promise<void>;
-};
 
 type DeferredLaneOccupancy = "hold" | "release";
 
@@ -133,34 +103,6 @@ export type ChannelIngressDrain = {
   waitForIdle: () => Promise<void>;
   dispose: () => void;
 };
-
-/**
- * Maps a drain lifecycle onto reply options.
- * Single surface: turnAdoptionLifecycle only.
- * Marks exclusive admission so collect isolation is not inferred from onAbandoned.
- */
-export function bindIngressLifecycleToReplyOptions(lifecycle: ChannelIngressDispatchLifecycle): {
-  turnAdoptionLifecycle: {
-    admission: "exclusive";
-    onAdopted: () => void | Promise<void>;
-    onDeferred: () => void;
-    onAbandoned: () => void | Promise<void>;
-    abortSignal: AbortSignal;
-  };
-} {
-  return {
-    turnAdoptionLifecycle: {
-      admission: "exclusive",
-      onAdopted: lifecycle.onAdopted,
-      onDeferred: lifecycle.onDeferred,
-      onAbandoned: lifecycle.onAbandoned,
-      abortSignal: lifecycle.abortSignal,
-    },
-  };
-}
-
-// onAdoptionFinalizing stays drain-only (not reply-options); channels call it
-// via the spooled-replay ALS lifecycle frame during settlement hold.
 
 /** Creates a channel-agnostic durable ingress drain over an existing queue. */
 export function createChannelIngressDrain<

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -69,6 +69,8 @@ type ChannelIngressDispatchLifecycle = {
   onAdoptionFinalizing: () => void;
   /** Deferred work terminally failed after dispatch returned. */
   onFailed?: (error: unknown) => void | Promise<void>;
+  /** Explicit cancellation before adoption; releases without consuming retry budget. */
+  onCancelled?: () => void | Promise<void>;
   /**
    * Deferred turn finished without ever owning the reply lane.
    * Drain releases the claim for retry.
@@ -347,13 +349,12 @@ export function createChannelIngressDrain<
 
   const releaseClaim = async (
     claim: ChannelIngressQueueClaim<TPayload, TMetadata>,
-    lastError?: string,
+    releaseOptions?: { lastError?: string; recordAttempt?: boolean },
   ) => {
     await commitClaimWriteWithRetry({
       claim,
       label: "release",
-      write: () =>
-        queue.release(claim, lastError === undefined ? {} : { lastError, releasedAt: now() }),
+      write: () => queue.release(claim, { ...releaseOptions, releasedAt: now() }),
       falseMeansReclaimed: false,
     });
   };
@@ -401,7 +402,7 @@ export function createChannelIngressDrain<
     }
     const displayId = claim.id.replace(/^0+(?=\d)/, "") || claim.id;
     log(`spooled update ${displayId} failed; keeping for retry: ${disposition.message}`);
-    await releaseClaim(claim, disposition.message);
+    await releaseClaim(claim, { lastError: disposition.message });
   };
 
   const createSettleOwner = (
@@ -468,6 +469,24 @@ export function createChannelIngressDrain<
     state.stallTimer.unref?.();
   };
 
+  const releaseUnadopted = async (
+    state: ActiveHandlerState<TPayload, TMetadata>,
+    releaseOptions: { lastError?: string; recordAttempt?: boolean },
+  ) => {
+    if (state.phase !== "deferred" && state.phase !== "dispatching") {
+      return;
+    }
+    if (state.guillotined || state.superseded) {
+      return;
+    }
+    clearStallTimer(state);
+    await state
+      .settleOnce(async () => {
+        await releaseClaim(state.claim, releaseOptions);
+      })
+      .catch(() => undefined);
+  };
+
   const createLifecycle = (
     state: ActiveHandlerState<TPayload, TMetadata>,
   ): ChannelIngressDispatchLifecycle => {
@@ -528,19 +547,13 @@ export function createChannelIngressDrain<
           await applyFailureDisposition(state.claim, error);
         });
       },
+      onCancelled: async () => {
+        // Cancellation means ownership ended before delivery, so preserve every
+        // prior retry fact while reopening the canonical row for replacement.
+        await releaseUnadopted(state, { recordAttempt: false });
+      },
       onAbandoned: async () => {
-        if (state.phase !== "deferred" && state.phase !== "dispatching") {
-          return;
-        }
-        if (state.guillotined || state.superseded) {
-          return;
-        }
-        clearStallTimer(state);
-        await state
-          .settleOnce(async () => {
-            await releaseClaim(state.claim, "turn-abandoned");
-          })
-          .catch(() => undefined);
+        await releaseUnadopted(state, { lastError: "turn-abandoned" });
       },
     };
   };

--- a/src/channels/message/ingress-drain.watchdog.test.ts
+++ b/src/channels/message/ingress-drain.watchdog.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { createChannelIngressDrain } from "./ingress-drain.js";
+import {
+  createTestIngressQueue,
+  type IngressDrainTestPayload as Payload,
+  withTempState,
+} from "./ingress-drain.test-helpers.js";
+
+describe("channel ingress drain watchdog", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    closeOpenClawStateDatabaseForTest();
+  });
+
+  it("guillotines pre-adoption stalls with handler-timeout", async () => {
+    await withTempState(async (stateDir) => {
+      let clock = 10_000;
+      const queue = createTestIngressQueue(stateDir, { now: () => clock });
+      await queue.enqueue("evt-stall", { text: "x" }, { laneKey: "l1" });
+
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        now: () => clock,
+        adoptionStallTimeoutMs: 5_000,
+        dispatchClaimedEvent: async () => {
+          // Never adopt, never return -- stall until watchdog.
+          await new Promise(() => {});
+        },
+      });
+
+      await drain.drainOnce();
+      clock += 5_000;
+      await vi.advanceTimersByTimeAsync(5_000);
+      await drain.waitForIdle();
+
+      const reenqueue = await queue.enqueue("evt-stall", { text: "x" });
+      expect(reenqueue.kind).toBe("failed");
+      if (reenqueue.kind === "failed") {
+        expect(reenqueue.record.reason).toBe("handler-timeout");
+      }
+      drain.dispose();
+    });
+  });
+
+  it("guillotines deferred stalls", async () => {
+    await withTempState(async (stateDir) => {
+      let clock = 30_000;
+      const queue = createTestIngressQueue(stateDir, { now: () => clock });
+      await queue.enqueue("evt-def-stall", { text: "x" }, { laneKey: "l1" });
+
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        now: () => clock,
+        adoptionStallTimeoutMs: 5_000,
+        dispatchClaimedEvent: async (_event, lifecycle) => {
+          lifecycle.onDeferred();
+          // Stay deferred without adoption -- watchdog must still fire.
+          await new Promise(() => {});
+        },
+      });
+
+      await drain.drainOnce();
+      expect(await queue.listClaims()).toHaveLength(1);
+      clock += 5_000;
+      await vi.advanceTimersByTimeAsync(5_000);
+      await drain.waitForIdle();
+
+      const reenqueue = await queue.enqueue("evt-def-stall", { text: "x" });
+      expect(reenqueue.kind).toBe("failed");
+      if (reenqueue.kind === "failed") {
+        expect(reenqueue.record.reason).toBe("handler-timeout");
+      }
+      drain.dispose();
+    });
+  });
+
+  it("does not kill healthy long turns after adoption", async () => {
+    await withTempState(async (stateDir) => {
+      let clock = 20_000;
+      const queue = createTestIngressQueue(stateDir, { now: () => clock });
+      await queue.enqueue("evt-long", { text: "x" }, { laneKey: "l1" });
+
+      let settleResolve!: () => void;
+      const settleGate = new Promise<void>((resolve) => {
+        settleResolve = resolve;
+      });
+
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        now: () => clock,
+        adoptionStallTimeoutMs: 1_000,
+        dispatchClaimedEvent: async (_event, lifecycle) => {
+          await lifecycle.onAdopted();
+          await settleGate;
+        },
+      });
+
+      await drain.drainOnce();
+      await vi.waitFor(async () => {
+        expect(await queue.listClaims()).toEqual([]);
+      });
+      clock += 60_000;
+      await vi.advanceTimersByTimeAsync(60_000);
+      const status = await queue.enqueue("evt-long", { text: "x" });
+      expect(status.kind).toBe("completed");
+      settleResolve();
+      await drain.waitForIdle();
+      drain.dispose();
+    });
+  });
+});

--- a/src/channels/message/ingress-monitor.ts
+++ b/src/channels/message/ingress-monitor.ts
@@ -65,6 +65,7 @@ export type ChannelIngressMonitorLifecycle = {
   onDeferred: () => void;
   onAdoptionFinalizing: () => void;
   onFailed?: (error: unknown) => void | Promise<void>;
+  onCancelled?: () => void | Promise<void>;
   onAbandoned: () => void | Promise<void>;
 };
 
@@ -368,6 +369,16 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
             settleDeferredClaim();
           }
         }
+        const settleDeferredLifecycle = async (settle: () => void | Promise<void>) => {
+          handedOff = true;
+          deferredHandoff = true;
+          try {
+            await settle();
+            requestDrain();
+          } finally {
+            settleDeferredClaim();
+          }
+        };
         const wrappedLifecycle: ChannelIngressMonitorLifecycle = {
           ...lifecycle,
           admission: "exclusive",
@@ -393,26 +404,9 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
             deferredHandoff = true;
             lifecycle.onAdoptionFinalizing();
           },
-          onFailed: async (error) => {
-            handedOff = true;
-            deferredHandoff = true;
-            try {
-              await lifecycle.onFailed?.(error);
-              requestDrain();
-            } finally {
-              settleDeferredClaim();
-            }
-          },
-          onAbandoned: async () => {
-            handedOff = true;
-            deferredHandoff = true;
-            try {
-              await lifecycle.onAbandoned();
-              requestDrain();
-            } finally {
-              settleDeferredClaim();
-            }
-          },
+          onFailed: (error) => settleDeferredLifecycle(() => lifecycle.onFailed?.(error)),
+          onCancelled: () => settleDeferredLifecycle(() => lifecycle.onCancelled?.()),
+          onAbandoned: () => settleDeferredLifecycle(() => lifecycle.onAbandoned()),
         };
 
         // Adoption can complete before delivery returns; track both lifetimes so stop

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -119,31 +119,65 @@ describe("channel ingress queue", () => {
   it("keeps channel and account queue identities unambiguous", async () => {
     await withTempState(async (stateDir) => {
       const first = createChannelIngressQueue<{ text: string }>({
-        channelId: "a",
-        accountId: "b:c",
+        channelId: "discord",
+        accountId: "account-a",
         stateDir,
       });
       const second = createChannelIngressQueue<{ text: string }>({
-        channelId: "a:b",
-        accountId: "c",
+        channelId: "discord",
+        accountId: "account-b",
         stateDir,
       });
 
-      expect(await first.enqueue("same-id", { text: "first" })).toMatchObject({
+      expect(
+        await first.enqueue("same-id", { text: "first" }, { laneKey: "channel:same-lane" }),
+      ).toMatchObject({
         kind: "accepted",
       });
-      expect(await second.enqueue("same-id", { text: "second" })).toMatchObject({
+      expect(
+        await second.enqueue("same-id", { text: "second" }, { laneKey: "channel:same-lane" }),
+      ).toMatchObject({
         kind: "accepted",
       });
 
-      await first.complete("same-id");
+      const firstClaim = await first.claim("same-id", { ownerId: "first-worker" });
+      expect(firstClaim).not.toBeNull();
+      if (!firstClaim) {
+        return;
+      }
+      await first.fail(firstClaim, { reason: "poison", failedAt: 20 });
 
       expect(await first.enqueue("same-id", { text: "first duplicate" })).toMatchObject({
-        kind: "completed",
+        kind: "failed",
       });
       expect(await second.enqueue("same-id", { text: "second duplicate" })).toMatchObject({
         kind: "pending",
         record: { payload: { text: "second" } },
+      });
+
+      if (!first.resubmit) {
+        return;
+      }
+      await expect(first.resubmit("same-id", { resubmittedAt: 30 })).resolves.toMatchObject({
+        kind: "resubmitted",
+        record: { attempts: 0, laneKey: "channel:same-lane", payload: { text: "first" } },
+      });
+      const resubmittedClaim = await first.claim("same-id", { ownerId: "replacement" });
+      const secondClaim = await second.claim("same-id", { ownerId: "second-worker" });
+      expect(resubmittedClaim).not.toBeNull();
+      expect(secondClaim).not.toBeNull();
+      if (!resubmittedClaim || !secondClaim) {
+        return;
+      }
+      await first.fail(resubmittedClaim, { reason: "poison-again", failedAt: 40 });
+      await second.complete(secondClaim, { completedAt: 40 });
+
+      expect(await first.prune({ failedTtlMs: 1, now: 42 })).toBe(1);
+      expect(await first.enqueue("same-id", { text: "fresh after prune" })).toMatchObject({
+        kind: "accepted",
+      });
+      expect(await second.enqueue("same-id", { text: "completed duplicate" })).toMatchObject({
+        kind: "completed",
       });
     });
   });

--- a/src/plugin-sdk/channel-ingress-runtime.test.ts
+++ b/src/plugin-sdk/channel-ingress-runtime.test.ts
@@ -76,6 +76,27 @@ describe("plugin-sdk/channel-ingress-runtime", () => {
     expect(fanInChannelIngressLifecycles([]).lifecycle).toBeUndefined();
   });
 
+  it("does not expose cancellation when a source cannot cancellation-settle", async () => {
+    const adopted = vi.fn(async () => {});
+    const cancelled = vi.fn(async () => {});
+    const createLifecycle = (onCancelled?: () => Promise<void>) => ({
+      abortSignal: new AbortController().signal,
+      onAdopted: adopted,
+      onDeferred: vi.fn(),
+      onAdoptionFinalizing: vi.fn(),
+      onFailed: vi.fn(async () => {}),
+      onAbandoned: vi.fn(async () => {}),
+      ...(onCancelled ? { onCancelled } : {}),
+    });
+    const combined = fanInChannelIngressLifecycles([createLifecycle(cancelled), createLifecycle()]);
+
+    expect(combined.lifecycle).not.toHaveProperty("onCancelled");
+    await combined.settle();
+
+    expect(adopted).toHaveBeenCalledTimes(2);
+    expect(cancelled).not.toHaveBeenCalled();
+  });
+
   it("can abandon claims after terminal settlement adoption fails", async () => {
     const abandoned = vi.fn(async () => {});
     const combined = fanInChannelIngressLifecycles([

--- a/src/plugin-sdk/channel-ingress-runtime.test.ts
+++ b/src/plugin-sdk/channel-ingress-runtime.test.ts
@@ -76,25 +76,33 @@ describe("plugin-sdk/channel-ingress-runtime", () => {
     expect(fanInChannelIngressLifecycles([]).lifecycle).toBeUndefined();
   });
 
-  it("does not expose cancellation when a source cannot cancellation-settle", async () => {
+  it("cancellation-settles every source in mixed capable and legacy fan-in", async () => {
     const adopted = vi.fn(async () => {});
     const cancelled = vi.fn(async () => {});
-    const createLifecycle = (onCancelled?: () => Promise<void>) => ({
+    const legacyAbandoned = vi.fn(async () => {});
+    const createLifecycle = (
+      onCancelled?: () => Promise<void>,
+      onAbandoned = vi.fn(async () => {}),
+    ) => ({
       abortSignal: new AbortController().signal,
       onAdopted: adopted,
       onDeferred: vi.fn(),
       onAdoptionFinalizing: vi.fn(),
       onFailed: vi.fn(async () => {}),
-      onAbandoned: vi.fn(async () => {}),
+      onAbandoned,
       ...(onCancelled ? { onCancelled } : {}),
     });
-    const combined = fanInChannelIngressLifecycles([createLifecycle(cancelled), createLifecycle()]);
+    const combined = fanInChannelIngressLifecycles([
+      createLifecycle(cancelled),
+      createLifecycle(undefined, legacyAbandoned),
+    ]);
 
     expect(combined.lifecycle).not.toHaveProperty("onCancelled");
-    await combined.settle();
+    await combined.cancel();
 
-    expect(adopted).toHaveBeenCalledTimes(2);
-    expect(cancelled).not.toHaveBeenCalled();
+    expect(adopted).not.toHaveBeenCalled();
+    expect(cancelled).toHaveBeenCalledOnce();
+    expect(legacyAbandoned).toHaveBeenCalledOnce();
   });
 
   it("can abandon claims after terminal settlement adoption fails", async () => {

--- a/src/plugin-sdk/channel-ingress-runtime.test.ts
+++ b/src/plugin-sdk/channel-ingress-runtime.test.ts
@@ -33,10 +33,13 @@ describe("plugin-sdk/channel-ingress-runtime", () => {
       onDeferred: vi.fn(),
       onAdoptionFinalizing: vi.fn(),
       onFailed: vi.fn(async () => {}),
+      onCancelled: vi.fn(async () => {}),
       onAbandoned: vi.fn(async () => {}),
     });
     const first = createLifecycle();
     const second = createLifecycle();
+    const cancellation = fanInChannelIngressLifecycles([first, second]);
+    await cancellation.lifecycle?.onCancelled?.();
     const combined = fanInChannelIngressLifecycles([undefined, first, second]);
 
     combined.lifecycle?.onAdoptionFinalizing();
@@ -49,6 +52,8 @@ describe("plugin-sdk/channel-ingress-runtime", () => {
     expect(second.onAdopted).toHaveBeenCalledOnce();
     expect(first.onAbandoned).not.toHaveBeenCalled();
     expect(second.onAbandoned).not.toHaveBeenCalled();
+    expect(first.onCancelled).toHaveBeenCalledOnce();
+    expect(second.onCancelled).toHaveBeenCalledOnce();
   });
 
   it("settles or abandons claims that no reply lane adopted", async () => {

--- a/src/plugin-sdk/channel-ingress-runtime.test.ts
+++ b/src/plugin-sdk/channel-ingress-runtime.test.ts
@@ -105,6 +105,28 @@ describe("plugin-sdk/channel-ingress-runtime", () => {
     expect(legacyAbandoned).toHaveBeenCalledOnce();
   });
 
+  it("preserves lifecycle receivers while fanning in cancellation", async () => {
+    const createLifecycle = () => ({
+      abortSignal: new AbortController().signal,
+      cancellationCount: 0,
+      onAdopted: vi.fn(async () => {}),
+      onDeferred: vi.fn(),
+      onAdoptionFinalizing: vi.fn(),
+      onFailed: vi.fn(async () => {}),
+      async onCancelled() {
+        this.cancellationCount += 1;
+      },
+      onAbandoned: vi.fn(async () => {}),
+    });
+    const first = createLifecycle();
+    const second = createLifecycle();
+
+    await fanInChannelIngressLifecycles([first, second]).lifecycle?.onCancelled?.();
+
+    expect(first.cancellationCount).toBe(1);
+    expect(second.cancellationCount).toBe(1);
+  });
+
   it("can abandon claims after terminal settlement adoption fails", async () => {
     const abandoned = vi.fn(async () => {});
     const combined = fanInChannelIngressLifecycles([

--- a/src/plugin-sdk/channel-ingress-runtime.ts
+++ b/src/plugin-sdk/channel-ingress-runtime.ts
@@ -128,6 +128,7 @@ export function fanInChannelIngressLifecycles(
   lifecycle: ChannelIngressLifecycle | undefined;
   settle: () => Promise<void>;
   abandon: (error?: unknown) => Promise<void>;
+  cancel: () => Promise<void>;
 } {
   const lifecycles = inputs.filter((lifecycle) => lifecycle !== undefined);
   const first = lifecycles[0];
@@ -136,6 +137,7 @@ export function fanInChannelIngressLifecycles(
       lifecycle: undefined,
       settle: async () => {},
       abandon: async () => {},
+      cancel: async () => {},
     };
   }
 
@@ -159,7 +161,6 @@ export function fanInChannelIngressLifecycles(
   const cancelAll =
     cancellationHandlers.length === lifecycles.length
       ? async () => {
-          handedOff = true;
           await Promise.all(cancellationHandlers.map(async (cancel) => await cancel()));
         }
       : undefined;
@@ -188,7 +189,14 @@ export function fanInChannelIngressLifecycles(
         handedOff = true;
         await failAll(error);
       },
-      ...(cancelAll ? { onCancelled: cancelAll } : {}),
+      ...(cancelAll
+        ? {
+            onCancelled: async () => {
+              handedOff = true;
+              await cancelAll();
+            },
+          }
+        : {}),
       onAbandoned: async () => {
         handedOff = true;
         await abandonAll();
@@ -205,6 +213,18 @@ export function fanInChannelIngressLifecycles(
       if (!handedOff) {
         handedOff = true;
         await abandonAll();
+      }
+    },
+    // Source-compatible lifecycles predate onCancelled. Settle each source through
+    // its strongest release callback so mixed fan-in cannot strand a durable claim.
+    cancel: async () => {
+      if (!handedOff) {
+        handedOff = true;
+        await Promise.all(
+          lifecycles.map(async (lifecycle) =>
+            lifecycle.onCancelled ? await lifecycle.onCancelled() : await lifecycle.onAbandoned(),
+          ),
+        );
       }
     },
   };

--- a/src/plugin-sdk/channel-ingress-runtime.ts
+++ b/src/plugin-sdk/channel-ingress-runtime.ts
@@ -153,17 +153,16 @@ export function fanInChannelIngressLifecycles(
   const failAll = async (error: unknown) => {
     await Promise.all(lifecycles.map(async (lifecycle) => await lifecycle.onFailed?.(error)));
   };
-  const cancellationHandlers = lifecycles.flatMap((lifecycle) =>
-    lifecycle.onCancelled ? [lifecycle.onCancelled] : [],
-  );
+  const supportsCancellation = lifecycles.every((lifecycle) => lifecycle.onCancelled !== undefined);
   // Omit aggregate cancellation unless every durable source supports it. Callers
   // can then use settle/abandon without an acknowledged-but-unsettled claim.
-  const cancelAll =
-    cancellationHandlers.length === lifecycles.length
-      ? async () => {
-          await Promise.all(cancellationHandlers.map(async (cancel) => await cancel()));
-        }
-      : undefined;
+  const cancelAll = async () => {
+    await Promise.all(
+      lifecycles.map(async (lifecycle) =>
+        lifecycle.onCancelled ? await lifecycle.onCancelled() : await lifecycle.onAbandoned(),
+      ),
+    );
+  };
   return {
     lifecycle: {
       abortSignal:
@@ -189,7 +188,7 @@ export function fanInChannelIngressLifecycles(
         handedOff = true;
         await failAll(error);
       },
-      ...(cancelAll
+      ...(supportsCancellation
         ? {
             onCancelled: async () => {
               handedOff = true;
@@ -220,11 +219,7 @@ export function fanInChannelIngressLifecycles(
     cancel: async () => {
       if (!handedOff) {
         handedOff = true;
-        await Promise.all(
-          lifecycles.map(async (lifecycle) =>
-            lifecycle.onCancelled ? await lifecycle.onCancelled() : await lifecycle.onAbandoned(),
-          ),
-        );
+        await cancelAll();
       }
     },
   };

--- a/src/plugin-sdk/channel-ingress-runtime.ts
+++ b/src/plugin-sdk/channel-ingress-runtime.ts
@@ -132,7 +132,11 @@ export function fanInChannelIngressLifecycles(
   const lifecycles = inputs.filter((lifecycle) => lifecycle !== undefined);
   const first = lifecycles[0];
   if (!first) {
-    return { lifecycle: undefined, settle: async () => {}, abandon: async () => {} };
+    return {
+      lifecycle: undefined,
+      settle: async () => {},
+      abandon: async () => {},
+    };
   }
 
   let handedOff = false;
@@ -147,7 +151,6 @@ export function fanInChannelIngressLifecycles(
   const failAll = async (error: unknown) => {
     await Promise.all(lifecycles.map(async (lifecycle) => await lifecycle.onFailed?.(error)));
   };
-
   return {
     lifecycle: {
       abortSignal:
@@ -172,6 +175,10 @@ export function fanInChannelIngressLifecycles(
       onFailed: async (error) => {
         handedOff = true;
         await failAll(error);
+      },
+      onCancelled: async () => {
+        handedOff = true;
+        await Promise.all(lifecycles.map(async (lifecycle) => await lifecycle.onCancelled?.()));
       },
       onAbandoned: async () => {
         handedOff = true;

--- a/src/plugin-sdk/channel-ingress-runtime.ts
+++ b/src/plugin-sdk/channel-ingress-runtime.ts
@@ -151,6 +151,18 @@ export function fanInChannelIngressLifecycles(
   const failAll = async (error: unknown) => {
     await Promise.all(lifecycles.map(async (lifecycle) => await lifecycle.onFailed?.(error)));
   };
+  const cancellationHandlers = lifecycles.flatMap((lifecycle) =>
+    lifecycle.onCancelled ? [lifecycle.onCancelled] : [],
+  );
+  // Omit aggregate cancellation unless every durable source supports it. Callers
+  // can then use settle/abandon without an acknowledged-but-unsettled claim.
+  const cancelAll =
+    cancellationHandlers.length === lifecycles.length
+      ? async () => {
+          handedOff = true;
+          await Promise.all(cancellationHandlers.map(async (cancel) => await cancel()));
+        }
+      : undefined;
   return {
     lifecycle: {
       abortSignal:
@@ -176,10 +188,7 @@ export function fanInChannelIngressLifecycles(
         handedOff = true;
         await failAll(error);
       },
-      onCancelled: async () => {
-        handedOff = true;
-        await Promise.all(lifecycles.map(async (lifecycle) => await lifecycle.onCancelled?.()));
-      },
+      ...(cancelAll ? { onCancelled: cancelAll } : {}),
       onAbandoned: async () => {
         handedOff = true;
         await abandonAll();


### PR DESCRIPTION
Closes #122465

## What Problem This Solves

A genuine Discord pre-admission failure was settled as turn-abandoned before the shared debouncer reported the error. The later onFailed callback could no longer update the durable claim, so an attempt-exhausted poison event remained pending and blocked every later message in its channel lane. Explicit shutdown cancellation also consumed retry facts even though no delivery attempt occurred.

## Why This Change Was Made

Separate delivery failure from cancellation at the ingress lifecycle owner. Genuine dispatcher exceptions flow to onFailed, while explicit abort, deactivation, and buffered cancellation use an optional ingress-only onCancelled callback that releases the claim without recording an attempt. Fan-in exposes cancellation only when every constituent lifecycle supports cancellation settlement, preserving settle/abandon fallback for mixed legacy sources. Discord retains the standard attempt limit and selects a zero minimum age for terminal retry disposition. Existing onAbandoned callers and model-visible turn adoption semantics remain unchanged.

## User Impact

A repeatedly failing Discord event now becomes a queryable retry-limit dead letter at the standard attempt threshold, allowing the next message in the same channel to run. Messages interrupted only by shutdown or cancellation remain replayable without losing retry budget or prior failure diagnostics.

## Evidence

The regression failed on prepared base 74d7147b1f802c8334b68fd102d2680f6adfca9e, reproducing turn-abandoned pending state and a blocked follower. After the controller-mandated rebase onto 52cda537a40ae4883de24d21f4b5806b9ea111a1, exact head b3eb6404160d0d0d396ccf91383b14649da40735 passed 238 focused tests across Discord, shared ingress, debounce, Plugin SDK, Signal, Mattermost, MS Teams, and Feishu plus all 32 Mattermost provider tests. Mixed capable/legacy cancellation uses one canonical fan-in cancel operation, and the Discord composition regression proves buffered deactivation settles every source. The exact-head build, all four typecheck lanes, SDK API/export/surface checks, and regenerated integrated API baselines passed. Fault-injection and two-account queue tests preserve durable settlement and isolation behavior.