### PR TITLE
fix(gateway): preserve explicit zero-byte artifact downloads

### DIFF
--- a/src/gateway/server-methods/artifacts-base64.ts
+++ b/src/gateway/server-methods/artifacts-base64.ts
@@ -52,7 +52,7 @@ export function readArtifactBase64Payload(
   value: string | undefined,
   opts: { includeData: boolean },
 ): ArtifactBase64Payload | undefined {
-  if (!value) {
+  if (value === undefined) {
     return undefined;
   }
   let encodedLength = 0;
@@ -82,9 +82,6 @@ export function readArtifactBase64Payload(
     if (data !== undefined) {
       data += normalizeArtifactBase64Char(char);
     }
-  }
-  if (encodedLength === 0) {
-    return undefined;
   }
   const remainder = encodedLength % 4;
   if ((padding > 0 && remainder !== 0) || remainder === 1) {

--- a/src/gateway/server-methods/artifacts-base64.ts
+++ b/src/gateway/server-methods/artifacts-base64.ts
@@ -55,6 +55,12 @@ export function readArtifactBase64Payload(
   if (value === undefined) {
     return undefined;
   }
+  if (value === "") {
+    return {
+      ...(opts.includeData ? { data: "" } : {}),
+      sizeBytes: 0,
+    };
+  }
   let encodedLength = 0;
   let padding = 0;
   let sawPadding = false;
@@ -85,6 +91,9 @@ export function readArtifactBase64Payload(
   }
   const remainder = encodedLength % 4;
   if ((padding > 0 && remainder !== 0) || remainder === 1) {
+    return undefined;
+  }
+  if (encodedLength === 0) {
     return undefined;
   }
   if (data !== undefined && padding === 0 && remainder > 0) {

--- a/src/gateway/server-methods/artifacts.test.ts
+++ b/src/gateway/server-methods/artifacts.test.ts
@@ -1037,43 +1037,39 @@ describe("artifacts RPC handlers", () => {
   });
 
   it.each([
-    { name: "direct empty data", block: { type: "file", data: "", sizeBytes: 0 } },
-    {
-      name: "empty data URL",
-      block: { type: "file", data: "data:application/octet-stream;base64," },
-    },
-    { name: "empty content field", block: { type: "file", content: "" } },
-    { name: "empty source data", block: { type: "file", source: { data: "" } } },
-  ])("preserves $name as a zero-byte bytes download", async ({ block }) => {
+    ["direct empty data", { type: "file", data: "", sizeBytes: 0 }, 0, ""],
+    ["empty data URL", { type: "file", data: "data:application/octet-stream;base64," }, 0, ""],
+    ["empty content field", { type: "file", content: "" }, 0, ""],
+    ["empty source data", { type: "file", source: { data: "" } }, 0, ""],
+    [
+      "padded data URL",
+      { type: "file", data: " data:application/octet-stream;base64,aGVsbG8= " },
+      5,
+      "aGVsbG8=",
+    ],
+  ])("preserves %s as a bytes download", async (_name, block, sizeBytes, data) => {
     mockedMessages([{ role: "assistant", content: [block], __openclaw: { seq: 9 } }]);
     const listed = await listArtifacts({ sessionKey: "agent:main:main" });
     const artifact = expectArtifactList(listed.calls).artifacts?.[0];
     const artifactId = requireNonEmptyString(artifact?.id, "expected listed artifact id");
-    expectFields(artifact, { sizeBytes: 0 });
+    expectFields(artifact, { sizeBytes });
     expectFields(artifact?.download, { mode: "bytes" });
     const download = await downloadArtifact({ sessionKey: "agent:main:main", artifactId });
     const downloadPayload = expectOkPayload(download.calls) as Record<string, unknown>;
-    expectFields(downloadPayload, { encoding: "base64", data: "" });
-    expectFields(downloadPayload.artifact as Record<string, unknown>, { sizeBytes: 0 });
+    expectFields(downloadPayload, { encoding: "base64", data });
+    expectFields(downloadPayload.artifact as Record<string, unknown>, { sizeBytes });
   });
 
-  it("keeps absent artifact data unsupported instead of synthesizing bytes", async () => {
-    mockedMessages([
-      {
-        role: "assistant",
-        content: [{ type: "file", title: "no-data.txt" }],
-        __openclaw: { seq: 12 },
-      },
-    ]);
+  it.each([
+    ["absent data", { type: "file", title: "no-data.txt" }],
+    ["whitespace-only data", { type: "file", data: "   " }],
+  ])("keeps %s unsupported instead of synthesizing bytes", async (_name, block) => {
+    mockedMessages([{ role: "assistant", content: [block], __openclaw: { seq: 12 } }]);
     const listed = await listArtifacts({ sessionKey: "agent:main:main" });
     const artifact = expectArtifactList(listed.calls).artifacts?.[0];
-    expectFields(artifact, { title: "no-data.txt" });
     expectFields(artifact?.download, { mode: "unsupported" });
     const artifactId = requireNonEmptyString(artifact?.id, "expected listed artifact id");
-    const download = await downloadArtifact({
-      sessionKey: "agent:main:main",
-      artifactId,
-    });
+    const download = await downloadArtifact({ sessionKey: "agent:main:main", artifactId });
     expectFields(expectErrorDetails(download.calls), { type: "artifact_download_unsupported" });
   });
 

--- a/src/gateway/server-methods/artifacts.test.ts
+++ b/src/gateway/server-methods/artifacts.test.ts
@@ -1036,6 +1036,47 @@ describe("artifacts RPC handlers", () => {
     });
   });
 
+  it.each([
+    { name: "direct empty data", block: { type: "file", data: "", sizeBytes: 0 } },
+    {
+      name: "empty data URL",
+      block: { type: "file", data: "data:application/octet-stream;base64," },
+    },
+    { name: "empty content field", block: { type: "file", content: "" } },
+    { name: "empty source data", block: { type: "file", source: { data: "" } } },
+  ])("preserves $name as a zero-byte bytes download", async ({ block }) => {
+    mockedMessages([{ role: "assistant", content: [block], __openclaw: { seq: 9 } }]);
+    const listed = await listArtifacts({ sessionKey: "agent:main:main" });
+    const artifact = expectArtifactList(listed.calls).artifacts?.[0];
+    const artifactId = requireNonEmptyString(artifact?.id, "expected listed artifact id");
+    expectFields(artifact, { sizeBytes: 0 });
+    expectFields(artifact?.download, { mode: "bytes" });
+    const download = await downloadArtifact({ sessionKey: "agent:main:main", artifactId });
+    const downloadPayload = expectOkPayload(download.calls) as Record<string, unknown>;
+    expectFields(downloadPayload, { encoding: "base64", data: "" });
+    expectFields(downloadPayload.artifact as Record<string, unknown>, { sizeBytes: 0 });
+  });
+
+  it("keeps absent artifact data unsupported instead of synthesizing bytes", async () => {
+    mockedMessages([
+      {
+        role: "assistant",
+        content: [{ type: "file", title: "no-data.txt" }],
+        __openclaw: { seq: 12 },
+      },
+    ]);
+    const listed = await listArtifacts({ sessionKey: "agent:main:main" });
+    const artifact = expectArtifactList(listed.calls).artifacts?.[0];
+    expectFields(artifact, { title: "no-data.txt" });
+    expectFields(artifact?.download, { mode: "unsupported" });
+    const artifactId = requireNonEmptyString(artifact?.id, "expected listed artifact id");
+    const download = await downloadArtifact({
+      sessionKey: "agent:main:main",
+      artifactId,
+    });
+    expectFields(expectErrorDetails(download.calls), { type: "artifact_download_unsupported" });
+  });
+
   it("treats unsafe artifact URLs as unsupported downloads", async () => {
     mockedMessages([
       {

--- a/src/gateway/server-methods/artifacts.ts
+++ b/src/gateway/server-methods/artifacts.ts
@@ -247,13 +247,13 @@ function resolveBlockDownload(
   mimeType?: string;
   sizeBytes?: number;
 } {
-  const data = asNonEmptyString(block.data);
-  const content = asNonEmptyString(block.content);
+  const data = typeof block.data === "string" ? block.data : undefined;
+  const content = typeof block.content === "string" ? block.content : undefined;
   const url = asNonEmptyString(block.url) ?? asNonEmptyString(block.openUrl);
   const imageUrl = mediaUrlValue(block.image_url);
   const audioUrl = asNonEmptyString(block.audio_url);
   const source = asOptionalRecord(block.source);
-  const sourceData = asNonEmptyString(source?.data);
+  const sourceData = typeof source?.data === "string" ? source.data : undefined;
   const sourceUrl = asNonEmptyString(source?.url);
   const dataUrl = [url, sourceUrl, imageUrl, audioUrl, data, content, sourceData].find(
     (value) => typeof value === "string" && /^data:/i.test(value),
@@ -284,7 +284,7 @@ function resolveBlockDownload(
   if (base64) {
     return {
       mode: "bytes",
-      ...(base64.data ? { data: base64.data } : {}),
+      ...(base64.data !== undefined ? { data: base64.data } : {}),
       mimeType,
       sizeBytes,
     };
@@ -310,9 +310,9 @@ function isArtifactBlock(block: Record<string, unknown>): boolean {
   ) {
     return true;
   }
-  return Boolean(
-    block.url || block.openUrl || block.data || block.source || block.image_url || block.audio_url,
-  );
+  return typeof block.data === "string"
+    ? true
+    : Boolean(block.url || block.openUrl || block.source || block.image_url || block.audio_url);
 }
 
 function collectArtifactsFromMessage(params: {
@@ -378,7 +378,7 @@ function collectArtifactsFromMessage(params: {
       messageSeq,
       source: "session-transcript",
       download: { mode: download.mode },
-      ...(download.data ? { data: download.data } : {}),
+      ...(download.data !== undefined ? { data: download.data } : {}),
       ...(download.url ? { url: download.url } : {}),
     };
     params.artifacts.push(summary);

--- a/src/gateway/server-methods/artifacts.ts
+++ b/src/gateway/server-methods/artifacts.ts
@@ -247,13 +247,13 @@ function resolveBlockDownload(
   mimeType?: string;
   sizeBytes?: number;
 } {
-  const data = typeof block.data === "string" ? block.data : undefined;
-  const content = typeof block.content === "string" ? block.content : undefined;
+  const data = block.data === "" ? "" : asNonEmptyString(block.data);
+  const content = block.content === "" ? "" : asNonEmptyString(block.content);
   const url = asNonEmptyString(block.url) ?? asNonEmptyString(block.openUrl);
   const imageUrl = mediaUrlValue(block.image_url);
   const audioUrl = asNonEmptyString(block.audio_url);
   const source = asOptionalRecord(block.source);
-  const sourceData = typeof source?.data === "string" ? source.data : undefined;
+  const sourceData = source?.data === "" ? "" : asNonEmptyString(source?.data);
   const sourceUrl = asNonEmptyString(source?.url);
   const dataUrl = [url, sourceUrl, imageUrl, audioUrl, data, content, sourceData].find(
     (value) => typeof value === "string" && /^data:/i.test(value),


### PR DESCRIPTION
## What Problem This Solves

A file with intentionally empty content (0 bytes, an empty base64 string) is listed as "unsupported" and cannot be downloaded, even though it is a valid artifact. The fix preserves explicit empty byte content as a downloadable zero-byte file.

- Problem: `artifacts.list`/`artifacts.get` project explicit empty base64 content (`data: ""` or `data:application/octet-stream;base64,`) as `unsupported`, and `artifacts.download` fails with `artifact_download_unsupported`
- Solution: Replace truthiness checks (empty string treated as missing) with presence checks (only `undefined` treated as missing) in the Gateway artifact projection
- What changed:
  - `src/gateway/server-methods/artifacts-base64.ts`: `readArtifactBase64Payload` no longer rejects an empty payload; the existing final return naturally produces `{ data: "", sizeBytes: 0 }`
  - `src/gateway/server-methods/artifacts.ts`: byte fields (`data`/`content`/`source.data`) read with presence semantics, `data` spread with `!== undefined`, `isArtifactBlock` recognizes explicit empty string data
  - `src/gateway/server-methods/artifacts.test.ts`: matrix coverage for direct empty data, empty base64 data URL, empty content, and empty source data
- What did NOT change: absent or malformed base64 stays `unsupported`; URL-mode artifacts, MIME handling, protocol schema, SDK, and UI are untouched

## Why This Change Was Made

The bug was introduced by `bb7150de94c` ("fix(gateway): reject malformed artifact base64", 2026-06-20), which added truthiness guards to reject malformed input but unintentionally also rejected explicit empty content. The protocol already permits zero-byte artifacts (`ArtifactsDownloadResultSchema.data` is `Type.String()`, `sizeBytes` allows `minimum 0`), so the defect is purely in the projection layer.

The narrowest maintainable fix is presence checking in the shared payload reader and the projection that selects download mode: only an exact empty string (`""`) is admitted as a zero-byte payload, while nonempty fields keep their established trimming and whitespace-only input stays rejected. We deliberately did not compensate in the SDK or UI because the artifact owner is the correct boundary: it distinguishes absent data from present empty data and retains `sizeBytes: 0`. Malformed base64 (invalid characters, bad padding, length remainder 1, whitespace-only) continues to be rejected by the existing validation loop.

This is a small bug fix (+6 net production LOC: the new exact-empty-string branch in `artifacts-base64.ts` and the restored whitespace-only rejection, plus net-zero changes in `artifacts.ts`); no refactor beyond the targeted presence checks is needed.

## User Impact

Agents and tools that intentionally produce an empty file or transcript artifact (e.g. an empty export, empty report, or 0-byte placeholder) can now list, inspect, and download it through `artifacts.list`/`artifacts.get`/`artifacts.download` with `mode: "bytes"`, `sizeBytes: 0`, and `data: ""`. Previously the artifact metadata appeared but download always failed with `artifact_download_unsupported`. No configuration changes are required.

## Evidence

Real runtime output from `node --import tsx` directly invoking the production function `readArtifactBase64Payload` on the fix branch:

```text
{"input":"data: \"\"","payload":{"data":"","sizeBytes":0}}
{"input":"data: \"data:application/octet-stream;base64,\"","payload":{"data":"","sizeBytes":0}}
{"input":"data: \"   \" (whitespace-only)","payload":null}
{"input":"data: \" data:application/octet-stream;base64,aGVsbG8= \" (padded)","payload":{"data":"aGVsbG8=","sizeBytes":5}}
{"input":"data: \"not-base64!\" (malformed)","payload":null}
{"input":"data: \"aGVsbG8=\" (valid)","payload":{"data":"aGVsbG8=","sizeBytes":5}}
```

The same command on unmodified `origin/main`:

```text
{"input":"data: \"\"","payload":null}
{"input":"data: \"data:application/octet-stream;base64,\"","payload":null}
{"input":"data: \"   \" (whitespace-only)","payload":null}
{"input":"data: \" data:application/octet-stream;base64,aGVsbG8= \" (padded)","payload":{"data":"aGVsbG8=","sizeBytes":5}}
{"input":"data: \"not-base64!\" (malformed)","payload":null}
{"input":"data: \"aGVsbG8=\" (valid)","payload":{"data":"aGVsbG8=","sizeBytes":5}}
```

Behavior matrix:

| Input form | Before (main) | After (this PR) |
|---|---|---|
| `data: ""` + `sizeBytes: 0` | mode `unsupported` | mode `bytes`, `sizeBytes: 0`, download `data: ""` |
| `data: "data:application/octet-stream;base64,"` | mode `unsupported` | mode `bytes`, `sizeBytes: 0`, download `data: ""` |
| `content: ""` | mode `unsupported` | mode `bytes`, `sizeBytes: 0` |
| `source.data: ""` | mode `unsupported` | mode `bytes`, `sizeBytes: 0` |
| `data: "   "` (whitespace-only) | mode `unsupported` | mode `unsupported` (unchanged, still rejected) |
| `data: " data:application/octet-stream;base64,aGVsbG8= "` (padded) | mode `bytes` | mode `bytes`, `data: "aGVsbG8="` (unchanged) |
| no data field (only title) | mode `unsupported` | mode `unsupported` (unchanged) |
| `data: "not-base64!"` | mode `unsupported` | mode `unsupported` (unchanged, malformed rejected) |

Regression suite: `artifacts.test.ts` 45/45 passed (four zero-byte variants, padded data URL, plus absent-data and whitespace-only guards). CI-like shard `gateway-methods` was run; the only failures are pre-existing environment issues (`git init -b main` requires Git 2.28+, the local runner has 2.27) in unrelated git-dependent suites (`projects`, `sessions-diff`, `worktrees`), not in the changed code.

What was not tested: no browser Control UI download flow was exercised; the protocol-level projection is fully covered and the UI consumer performs no presence filtering.

## AI Assistance

- AI-assisted: Yes
- Tools: Codex (GPT-5)
- Prompts / session excerpts: Full workflow run of the open-source-pr skill for #122802, from candidate recommendation through Step 5 implementation and verification; session log available on request
- Confirmed understanding of code changes: Yes — every changed line is explainable: presence vs truthiness semantics in the base64 reader and artifact projection, plus the matrix regression tests
- autoreview: N/A (skill not present in this environment)

Fixes #122802