### PR TITLE
fix(agents): repair extension fixtures for explicit ownership

### DIFF
--- a/extensions/codex/src/app-server/attempt-startup.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup.test.ts
@@ -63,7 +63,7 @@ function createAttemptParams(paths: AttemptPaths): EmbeddedRunAttemptParams {
     hostCapabilities: createCodexTestHostCapabilities(),
     prompt: "hello",
     sessionId: "session-1",
-    sessionKey: "agent:main:session-1",
+    sessionKey: "agent:agent-1:session-1",
     agentDir: paths.agentDir,
     sessionFile: paths.sessionFile,
     effectiveCwd: paths.cwd,

--- a/extensions/copilot/src/attempt.test.ts
+++ b/extensions/copilot/src/attempt.test.ts
@@ -486,10 +486,10 @@ function makeParams(
     runId: "run-1",
     sessionFile: "session.json",
     sessionId: "session-1",
-    sessionKey: "agent:main:session-1",
+    sessionKey: "agent:agent-1:session-1",
     sessionTarget: {
       sessionId: "session-1",
-      sessionKey: "agent:main:session-1",
+      sessionKey: "agent:agent-1:session-1",
       storePath: "openclaw-agent.sqlite",
     },
     timeoutMs: 5000,
@@ -1717,7 +1717,7 @@ describe("runCopilotAttempt", () => {
         modelId: "gpt-4o",
         modelProvider: "github-copilot",
         sessionId: "session-1",
-        sessionKey: "agent:main:session-1",
+        sessionKey: "agent:agent-1:session-1",
         workspaceDir: "C:\\workspace",
       }),
     );

--- a/extensions/copilot/src/tool-bridge.test.ts
+++ b/extensions/copilot/src/tool-bridge.test.ts
@@ -325,7 +325,7 @@ describe("createCopilotToolBridge", () => {
       attemptParams: {
         config: { tools: { toolSearch: true } },
         runId: "run-tool-search",
-        sessionKey: "agent:main:main",
+        sessionKey: "agent:agent-1:main",
       } as never,
       createOpenClawCodingTools,
       modelId: "gpt-4o",
@@ -359,7 +359,7 @@ describe("createCopilotToolBridge", () => {
       attemptParams: {
         config: { tools: { toolSearch: true } },
         runId: "run-tool-search",
-        sessionKey: "agent:main:main",
+        sessionKey: "agent:agent-1:main",
         toolsAllow: ["read"],
       } as never,
       createOpenClawCodingTools,
@@ -389,7 +389,7 @@ describe("createCopilotToolBridge", () => {
       attemptParams: {
         config: { tools: { toolSearch: true } },
         runId: "run-tool-search",
-        sessionKey: "agent:main:main",
+        sessionKey: "agent:agent-1:main",
         toolsAllow: ["read"],
       } as never,
       createOpenClawCodingTools,
@@ -412,7 +412,7 @@ describe("createCopilotToolBridge", () => {
       attemptParams: {
         config: { tools: { codeMode: true } },
         runId: "run-code-mode",
-        sessionKey: "agent:main:main",
+        sessionKey: "agent:agent-1:main",
       } as never,
       createOpenClawCodingTools,
       modelId: "gpt-4o",
@@ -457,7 +457,7 @@ describe("createCopilotToolBridge", () => {
         config: { tools: { codeMode: true } },
         hostCapabilities: { ...testHostCapabilities, bindToolSurface },
         runId: "run-code-mode-bound",
-        sessionKey: "agent:main:main",
+        sessionKey: "agent:agent-1:main",
       },
       createOpenClawCodingTools: async () => [makeTool({ execute: hiddenExecute, name: "read" })],
       modelId: "gpt-test",
@@ -503,7 +503,7 @@ describe("createCopilotToolBridge", () => {
       attemptParams: {
         config: { tools: { codeMode: false } },
         runId: "run-no-code-mode",
-        sessionKey: "agent:main:main",
+        sessionKey: "agent:agent-1:main",
       } as never,
       createOpenClawCodingTools: vi.fn(async () => [makeTool({ name: "read" })]),
       modelId: "gpt-4o",
@@ -525,7 +525,7 @@ describe("createCopilotToolBridge", () => {
       attemptParams: {
         config: { tools: { codeMode: true } },
         runId: "run-code-mode",
-        sessionKey: "agent:main:main",
+        sessionKey: "agent:agent-1:main",
         toolsAllow: ["read"],
       } as never,
       createOpenClawCodingTools,
@@ -550,7 +550,7 @@ describe("createCopilotToolBridge", () => {
       attemptParams: {
         config: { tools: { codeMode: true } },
         runId: "run-code-mode",
-        sessionKey: "agent:main:main",
+        sessionKey: "agent:agent-1:main",
         toolsAllow: ["read"],
       } as never,
       createOpenClawCodingTools,
@@ -923,8 +923,8 @@ describe("createCopilotToolBridge", () => {
         // sandbox key and the real run key is exposed as runSessionKey
         // so `session_status: "current"` resolves to the live session.
         attemptParams: {
-          sandboxSessionKey: "sandbox:agent:main",
-          sessionKey: "agent:main:main",
+          sandboxSessionKey: "sandbox:agent:agent-1",
+          sessionKey: "agent:agent-1:main",
         } as never,
         createOpenClawCodingTools,
         modelId: "gpt-4o",
@@ -933,8 +933,8 @@ describe("createCopilotToolBridge", () => {
       });
 
       const opts = getOpts();
-      expect(opts.sessionKey).toBe("sandbox:agent:main");
-      expect(opts.runSessionKey).toBe("agent:main:main");
+      expect(opts.sessionKey).toBe("sandbox:agent:agent-1");
+      expect(opts.runSessionKey).toBe("agent:agent-1:main");
     });
 
     it("derives runSessionKey as undefined when sandboxSessionKey equals sessionKey", async () => {
@@ -942,7 +942,7 @@ describe("createCopilotToolBridge", () => {
 
       await createCopilotToolBridge({
         agentId: "agent-1",
-        attemptParams: { sessionKey: "agent:main:main" } as never,
+        attemptParams: { sessionKey: "agent:agent-1:main" } as never,
         createOpenClawCodingTools,
         modelId: "gpt-4o",
         modelProvider: "github-copilot",
@@ -950,7 +950,7 @@ describe("createCopilotToolBridge", () => {
       });
 
       const opts = getOpts();
-      expect(opts.sessionKey).toBe("agent:main:main");
+      expect(opts.sessionKey).toBe("agent:agent-1:main");
       expect(opts.runSessionKey).toBeUndefined();
     });
 
@@ -1278,14 +1278,14 @@ describe("createCopilotToolBridge", () => {
               deny: ["exec", "process", "write", "edit", "ask_user"],
             },
             runId: "policy-run",
-            sessionKey: "agent:main:policy-session",
+            sessionKey: "agent:agent-1:policy-session",
             workspaceDir,
           } as never,
           createOpenClawCodingTools: createRealOpenClawCodingTools,
           modelId: "gpt-4o",
           modelProvider: "github-copilot",
           sessionId: "policy-session",
-          sessionKey: "agent:main:policy-session",
+          sessionKey: "agent:agent-1:policy-session",
           workspaceDir,
         });
         const names = result.sdkTools.map((tool) => tool.name);
@@ -2043,7 +2043,7 @@ describe("createCopilotToolBridge tool conversion", () => {
         config: { tools: { toolSearch: true } },
         observeToolTerminal,
         runId: "run-tool-search",
-        sessionKey: "agent:main:main",
+        sessionKey: "agent:agent-1:main",
       } as never,
       createOpenClawCodingTools: async (options: unknown) => {
         catalogExecutor = (options as { toolSearchCatalogExecutor?: CatalogExecutor })


### PR DESCRIPTION
Related: #114388
Unblocks: #122831

AI-assisted: yes (Codex).

## What Problem This Solves

Fixes an issue where full extension runs on `main` failed after #114388 made multi-agent ownership explicit. Several test fixtures supplied an explicit `agent-1` owner while retaining a `main`-scoped session key, so the intended `AgentSelectionRequiredError` invariant fired before the tests reached their real assertions.

The PR planner did not run these extension suites for #114388. A full Codex sweep exposed the known startup fixture failure, and a broader extension candidate sweep found the same contradiction in two shared Copilot fixtures.

## Why This Change Was Made

The fixtures now scope every synthetic session key to the explicit test agent. Production ownership resolution remains strict; this PR adds no fallback, compatibility path, or runtime behavior change.

The three other red Codex files on the pinned base are intentionally untouched because #122831 owns them. Full Codex proof therefore used this branch together with immutable #122831 head `b1b07c5fc619bfa9e60af83a7fcb669b6748c5b3` on an ephemeral Testbox.

## User Impact

There is no user-visible runtime change. Maintainers regain trustworthy Codex and Copilot extension coverage on `main`, including the suites that the original PR planner missed.

## Evidence

### Enumeration and regression proof

- Pinned base: `5c2e099374527072687116755208048632394a8e`.
- Full Codex Testbox sweep (`tbx_01kzw6sxk6sa00sqs6057tze4r`, [Actions run](https://github.com/openclaw/openclaw/actions/runs/31653019349)): 4 failing files / 16 failing tests / 8 unhandled errors before the fix.
  - In scope: `attempt-startup.test.ts` — 10/18 failed from `agent:main:session-1` versus explicit `agent-1`.
  - Owned by #122831 and not modified here: `thread-lifecycle.user-mcp-servers.test.ts` (1), `thread-lifecycle.test.ts` (2), `media-understanding-provider.test.ts` (3).
- `node scripts/run-vitest.mjs extensions/copilot/src/attempt.test.ts` before the fix: 151/151 failed, with the first failure at `resolveSessionAgentIds`.
- `node scripts/run-vitest.mjs extensions/copilot` then exposed the second shared fixture: `tool-bridge.test.ts` had 10 failures from the same owner/key contradiction.
- Static candidate sweep: `rg -l "agent-1\|agent:main:" extensions --type ts`, followed by caller inspection. No other Codex ownership mismatch remained outside the #122831-owned file.

### Passing proof

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/attempt-startup.test.ts` — 18/18 passed.
- `node scripts/run-vitest.mjs extensions/copilot/src/attempt.test.ts` — 151/151 passed.
- `node scripts/run-vitest.mjs extensions/copilot/src/tool-bridge.test.ts` — 83/83 passed.
- `node scripts/run-vitest.mjs extensions/copilot` — 20 files, 576/576 passed.
- Full Codex canonical shard sweep on Testbox `tbx_01kzw6sxk6sa00sqs6057tze4r`, current patch plus immutable #122831 head — 8/8 configs, 155 files, 3,591/3,591 tests passed. The aggregate config itself has a Testbox teardown defect (`Worker exited unexpectedly` after all files pass), so the green closeout uses the same eight leaf configs selected by the repository's full-suite planner.
- `node scripts/check-changed.mjs` after rebasing onto current `origin/main` — passed on Testbox `tbx_01kzw8tz89p4fef2vtxdnsqckp` ([Actions run](https://github.com/openclaw/openclaw/actions/runs/31655045643)); lane `extensionTests`, format/typecheck/lint/guards all green.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings.

Production LOC: +0/-0 (net 0) | Tests: +21/-21 (net 0).
