### PR TITLE
fix(skills): generalize freeform frontmatter value recovery beyond description

### DIFF
--- a/packages/markdown-core/src/frontmatter.test.ts
+++ b/packages/markdown-core/src/frontmatter.test.ts
@@ -141,6 +141,19 @@ read_when: signals: user announcing a conversion task
     expect(result.issues).toEqual([]);
   });
 
+  it("does not rewrite valid quoted sibling scalars with escape sequences", () => {
+    const content = `---
+name: sample-skill
+description: "line\\n: detail"
+read_when: signals: user announcing a conversion task
+---`;
+    const result = parseFrontmatterBlockResult(content);
+
+    expect(result.frontmatter.description).toBe("line\n: detail");
+    expect(result.frontmatter.read_when).toBe("signals: user announcing a conversion task");
+    expect(result.issues).toEqual([]);
+  });
+
   it("leaves valid YAML description semantics untouched", () => {
     expect(
       parseFrontmatterBlock(`---

--- a/packages/markdown-core/src/frontmatter.test.ts
+++ b/packages/markdown-core/src/frontmatter.test.ts
@@ -154,6 +154,28 @@ read_when: signals: user announcing a conversion task
     expect(result.issues).toEqual([]);
   });
 
+  it("recovers quoted freeform keys with colon-rich values", () => {
+    const content = `---
+name: sample-skill
+"description": signals: user announcing a conversion task
+---`;
+    const result = parseFrontmatterBlockResult(content);
+
+    expect(result.frontmatter.description).toBe("signals: user announcing a conversion task");
+    expect(result.issues).toEqual([]);
+  });
+
+  it("recovers single-quoted freeform keys with colon-rich values", () => {
+    const content = `---
+name: sample-skill
+'read_when': signals: user announcing a conversion task
+---`;
+    const result = parseFrontmatterBlockResult(content);
+
+    expect(result.frontmatter.read_when).toBe("signals: user announcing a conversion task");
+    expect(result.issues).toEqual([]);
+  });
+
   it("leaves valid YAML description semantics untouched", () => {
     expect(
       parseFrontmatterBlock(`---

--- a/packages/markdown-core/src/frontmatter.test.ts
+++ b/packages/markdown-core/src/frontmatter.test.ts
@@ -94,6 +94,40 @@ description: Use anime style IMPORTANT: Must be kawaii
     expect(result.issues).toEqual([]);
   });
 
+  it("normalizes colon-rich free-form fields other than description", () => {
+    const content = `---
+name: sample-skill
+read_when: signals: user announcing a conversion task
+---`;
+    const result = parseFrontmatterBlockResult(content);
+
+    expect(result.frontmatter.read_when).toBe("signals: user announcing a conversion task");
+    expect(result.issues).toEqual([]);
+  });
+
+  it("normalizes multiple colon-rich pure-text fields in one block", () => {
+    const content = `---
+name: sample-skill
+read_when: signals: user announcing a conversion task
+summary: handles formats: pdf and docx
+---`;
+    const result = parseFrontmatterBlockResult(content);
+
+    expect(result.frontmatter.read_when).toBe("signals: user announcing a conversion task");
+    expect(result.frontmatter.summary).toBe("handles formats: pdf and docx");
+    expect(result.issues).toEqual([]);
+  });
+
+  it("keeps structured fields strict when a pure-text field is normalized", () => {
+    const result = parseFrontmatterBlockResult(`---
+name: sample-skill
+read_when: signals: user announcing a conversion task
+metadata: [broken
+---`);
+
+    expect(result.issues[0]).toMatchObject({ code: "BAD_INDENT" });
+  });
+
   it("leaves valid YAML description semantics untouched", () => {
     expect(
       parseFrontmatterBlock(`---

--- a/packages/markdown-core/src/frontmatter.test.ts
+++ b/packages/markdown-core/src/frontmatter.test.ts
@@ -128,6 +128,19 @@ metadata: [broken
     expect(result.issues[0]).toMatchObject({ code: "BAD_INDENT" });
   });
 
+  it("does not rewrite valid sibling values when recovering a malformed field", () => {
+    const content = `---
+name: sample-skill
+description: text # note
+read_when: signals: user announcing a conversion task
+---`;
+    const result = parseFrontmatterBlockResult(content);
+
+    expect(result.frontmatter.description).toBe("text");
+    expect(result.frontmatter.read_when).toBe("signals: user announcing a conversion task");
+    expect(result.issues).toEqual([]);
+  });
+
   it("leaves valid YAML description semantics untouched", () => {
     expect(
       parseFrontmatterBlock(`---

--- a/packages/markdown-core/src/frontmatter.test.ts
+++ b/packages/markdown-core/src/frontmatter.test.ts
@@ -122,10 +122,23 @@ summary: handles formats: pdf and docx
     const result = parseFrontmatterBlockResult(`---
 name: sample-skill
 read_when: signals: user announcing a conversion task
-metadata: [broken
+metadata: owner: value
 ---`);
 
-    expect(result.issues[0]).toMatchObject({ code: "BAD_INDENT" });
+    expect(result.issues[0]).toMatchObject({ code: "BLOCK_AS_IMPLICIT_KEY" });
+  });
+
+  it("preserves valid structured siblings when pure-text fields are normalized", () => {
+    const result = parseFrontmatterBlockResult(`---
+name: sample-skill
+read_when: signals: user announcing a conversion task
+metadata:
+  openclaw:
+    emoji: beaker
+---`);
+
+    expect(result.frontmatter.metadata).toBe('{"openclaw":{"emoji":"beaker"}}');
+    expect(result.issues).toEqual([]);
   });
 
   it("does not rewrite valid sibling values when recovering a malformed field", () => {

--- a/packages/markdown-core/src/frontmatter.ts
+++ b/packages/markdown-core/src/frontmatter.ts
@@ -105,12 +105,14 @@ function normalizeFreeformFieldAtError(block: string): string {
   const lineEnd = block.indexOf("\n", pos);
   const end = lineEnd === -1 ? block.length : lineEnd;
   const line = block.slice(lineStart, end);
-  const match = line.match(/^([\w-]+):\s*(.*)$/);
-  const keyName = match?.[1];
+  // Match unquoted, double-quoted, and single-quoted freeform keys. Current
+  // main recovers all three for `description`; preserve that compatibility.
+  const match = line.match(/^(?:([\w-]+)|"([\w-]+)"|'([\w-]+)'):\s*(.*)$/);
+  const keyName = match?.[1] ?? match?.[2] ?? match?.[3];
   if (!keyName || !FREEFORM_TEXT_FIELDS.has(keyName)) {
     return block;
   }
-  const rawValue = match?.[2]?.trim();
+  const rawValue = match?.[4]?.trim();
   if (!rawValue || /^[|>](?:[1-9][+-]?|[+-][1-9]?)?$/.test(rawValue) || !/: /.test(rawValue)) {
     return block;
   }

--- a/packages/markdown-core/src/frontmatter.ts
+++ b/packages/markdown-core/src/frontmatter.ts
@@ -80,15 +80,20 @@ function parseLineFrontmatter(block: string): ParsedFrontmatter {
   return result;
 }
 
-function normalizeFreeformDescription(block: string): string {
+// Pure-text scalar fields whose inline values may legitimately contain a
+// colon+space. Restoring them keeps legacy single-line frontmatter loadable
+// without loosening strict parsing for structured fields like `metadata`.
+const FREEFORM_TEXT_FIELDS = new Set(["description", "read_when", "summary"]);
+
+function normalizeFreeformValue(block: string, keyName: string): string {
   const doc = parseDocument(block, { schema: "core", prettyErrors: false });
   if (!isMap(doc.contents)) {
     return block;
   }
-  const descriptionPair = doc.contents.items.find(
-    (pair) => isScalar(pair.key) && pair.key.value === "description",
+  const pair = doc.contents.items.find(
+    (candidate) => isScalar(candidate.key) && candidate.key.value === keyName,
   );
-  const keyStart = isNode(descriptionPair?.key) ? descriptionPair.key.range?.[0] : undefined;
+  const keyStart = isNode(pair?.key) ? pair.key.range?.[0] : undefined;
   if (keyStart === undefined) {
     return block;
   }
@@ -96,13 +101,21 @@ function normalizeFreeformDescription(block: string): string {
   const lineEnd = block.indexOf("\n", keyStart);
   const end = lineEnd === -1 ? block.length : lineEnd;
   const line = block.slice(lineStart, end);
-  const match = line.match(/^(?:description|"description"|'description'):\s*(.*)$/);
+  const match = line.match(/^(?:[^:\n]+|"[^"]+"|'[^']+'):\s*(.*)$/);
   const rawValue = match?.[1]?.trim();
   if (!rawValue || /^[|>](?:[1-9][+-]?|[+-][1-9]?)?$/.test(rawValue)) {
     return block;
   }
-  const replacement = `description: ${JSON.stringify(stripQuotes(rawValue))}`;
+  const replacement = `${keyName}: ${JSON.stringify(stripQuotes(rawValue))}`;
   return `${block.slice(0, lineStart)}${replacement}${block.slice(end)}`;
+}
+
+function normalizeFreeformTextFields(block: string): string {
+  let updated = block;
+  for (const field of FREEFORM_TEXT_FIELDS) {
+    updated = normalizeFreeformValue(updated, field);
+  }
+  return updated;
 }
 
 function parseYamlFrontmatterOnce(
@@ -184,7 +197,7 @@ function parseYamlFrontmatter(block: string): ParsedFrontmatterBlockResult {
   if (parsed.issues.length === 0) {
     return parsed;
   }
-  const recoveredBlock = normalizeFreeformDescription(block);
+  const recoveredBlock = normalizeFreeformTextFields(block);
   return recoveredBlock === block ? parsed : parseYamlFrontmatterOnce(recoveredBlock, fallback);
 }
 

--- a/packages/markdown-core/src/frontmatter.ts
+++ b/packages/markdown-core/src/frontmatter.ts
@@ -1,6 +1,6 @@
 // Markdown Core module implements frontmatter behavior.
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { isMap, isNode, isScalar, parseDocument } from "yaml";
+import { isMap, isNode, parseDocument } from "yaml";
 
 type ParsedFrontmatter = Record<string, string>;
 
@@ -85,43 +85,37 @@ function parseLineFrontmatter(block: string): ParsedFrontmatter {
 // without loosening strict parsing for structured fields like `metadata`.
 const FREEFORM_TEXT_FIELDS = new Set(["description", "read_when", "summary"]);
 
-function normalizeFreeformValue(block: string, keyName: string): string {
+// Recover only the field whose value actually triggers BLOCK_AS_IMPLICIT_KEY,
+// located via the YAML error position. Valid sibling scalars (quoted values
+// with escape sequences, commented values) are not rewritten, preserving
+// their YAML decode semantics.
+function normalizeFreeformFieldAtError(block: string): string {
   const doc = parseDocument(block, { schema: "core", prettyErrors: false });
-  if (!isMap(doc.contents)) {
+  if (doc.errors.length === 0 || !isMap(doc.contents)) {
     return block;
   }
-  const pair = doc.contents.items.find(
-    (candidate) => isScalar(candidate.key) && candidate.key.value === keyName,
+  const error = doc.errors.find(
+    (candidate) => candidate.code === "BLOCK_AS_IMPLICIT_KEY" && candidate.pos?.[0] !== undefined,
   );
-  const keyStart = isNode(pair?.key) ? pair.key.range?.[0] : undefined;
-  if (keyStart === undefined) {
+  const pos = error?.pos?.[0];
+  if (pos === undefined) {
     return block;
   }
-  const lineStart = block.lastIndexOf("\n", keyStart - 1) + 1;
-  const lineEnd = block.indexOf("\n", keyStart);
+  const lineStart = block.lastIndexOf("\n", pos) + 1;
+  const lineEnd = block.indexOf("\n", pos);
   const end = lineEnd === -1 ? block.length : lineEnd;
   const line = block.slice(lineStart, end);
-  const match = line.match(/^(?:[^:\n]+|"[^"]+"|'[^']+'):\s*(.*)$/);
-  const rawValue = match?.[1]?.trim();
-  if (!rawValue || /^[|>](?:[1-9][+-]?|[+-][1-9]?)?$/.test(rawValue)) {
+  const match = line.match(/^([\w-]+):\s*(.*)$/);
+  const keyName = match?.[1];
+  if (!keyName || !FREEFORM_TEXT_FIELDS.has(keyName)) {
     return block;
   }
-  // Only recover values whose inline colon+space triggers
-  // BLOCK_AS_IMPLICIT_KEY. Valid YAML scalars (e.g. `text # note`) are
-  // left untouched so their comment and quote semantics are preserved.
-  if (!/: /.test(rawValue)) {
+  const rawValue = match?.[2]?.trim();
+  if (!rawValue || /^[|>](?:[1-9][+-]?|[+-][1-9]?)?$/.test(rawValue) || !/: /.test(rawValue)) {
     return block;
   }
   const replacement = `${keyName}: ${JSON.stringify(stripQuotes(rawValue))}`;
   return `${block.slice(0, lineStart)}${replacement}${block.slice(end)}`;
-}
-
-function normalizeFreeformTextFields(block: string): string {
-  let updated = block;
-  for (const field of FREEFORM_TEXT_FIELDS) {
-    updated = normalizeFreeformValue(updated, field);
-  }
-  return updated;
 }
 
 function parseYamlFrontmatterOnce(
@@ -203,7 +197,20 @@ function parseYamlFrontmatter(block: string): ParsedFrontmatterBlockResult {
   if (parsed.issues.length === 0) {
     return parsed;
   }
-  const recoveredBlock = normalizeFreeformTextFields(block);
+  // Recover one error-located field per iteration, retrying parse each time,
+  // so multiple colon-rich fields are fixed without rewriting valid siblings.
+  let recoveredBlock = block;
+  for (let i = 0; i < FREEFORM_TEXT_FIELDS.size; i += 1) {
+    const next = normalizeFreeformFieldAtError(recoveredBlock);
+    if (next === recoveredBlock) {
+      break;
+    }
+    recoveredBlock = next;
+    const reparsed = parseYamlFrontmatterOnce(recoveredBlock, fallback);
+    if (reparsed.issues.length === 0) {
+      return reparsed;
+    }
+  }
   return recoveredBlock === block ? parsed : parseYamlFrontmatterOnce(recoveredBlock, fallback);
 }
 

--- a/packages/markdown-core/src/frontmatter.ts
+++ b/packages/markdown-core/src/frontmatter.ts
@@ -106,6 +106,12 @@ function normalizeFreeformValue(block: string, keyName: string): string {
   if (!rawValue || /^[|>](?:[1-9][+-]?|[+-][1-9]?)?$/.test(rawValue)) {
     return block;
   }
+  // Only recover values whose inline colon+space triggers
+  // BLOCK_AS_IMPLICIT_KEY. Valid YAML scalars (e.g. `text # note`) are
+  // left untouched so their comment and quote semantics are preserved.
+  if (!/: /.test(rawValue)) {
+    return block;
+  }
   const replacement = `${keyName}: ${JSON.stringify(stripQuotes(rawValue))}`;
   return `${block.slice(0, lineStart)}${replacement}${block.slice(end)}`;
 }

--- a/packages/markdown-core/src/frontmatter.ts
+++ b/packages/markdown-core/src/frontmatter.ts
@@ -113,7 +113,7 @@ function normalizeFreeformFieldAtError(block: string): string {
     return block;
   }
   const rawValue = match?.[4]?.trim();
-  if (!rawValue || /^[|>](?:[1-9][+-]?|[+-][1-9]?)?$/.test(rawValue) || !/: /.test(rawValue)) {
+  if (!rawValue || /^[|>](?:[1-9][+-]?|[+-][1-9]?)?$/.test(rawValue) || !rawValue.includes(": ")) {
     return block;
   }
   const replacement = `${keyName}: ${JSON.stringify(stripQuotes(rawValue))}`;

--- a/packages/markdown-core/src/frontmatter.ts
+++ b/packages/markdown-core/src/frontmatter.ts
@@ -1,6 +1,6 @@
 // Markdown Core module implements frontmatter behavior.
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { isMap, isNode, parseDocument } from "yaml";
+import { isAlias, isMap, isNode, isScalar, parseDocument } from "yaml";
 
 type ParsedFrontmatter = Record<string, string>;
 
@@ -80,24 +80,22 @@ function parseLineFrontmatter(block: string): ParsedFrontmatter {
   return result;
 }
 
-// Pure-text scalar fields whose inline values may legitimately contain a
-// colon+space. Restoring them keeps legacy single-line frontmatter loadable
-// without loosening strict parsing for structured fields like `metadata`.
 const FREEFORM_TEXT_FIELDS = new Set(["description", "read_when", "summary"]);
 
-// Recover only the field whose value actually triggers BLOCK_AS_IMPLICIT_KEY,
-// located via the YAML error position. Valid sibling scalars (quoted values
-// with escape sequences, commented values) are not rewritten, preserving
-// their YAML decode semantics.
 function normalizeFreeformFieldAtError(block: string): string {
   const doc = parseDocument(block, { schema: "core", prettyErrors: false });
-  if (doc.errors.length === 0 || !isMap(doc.contents)) {
+  if (!isMap(doc.contents)) {
     return block;
   }
-  const error = doc.errors.find(
-    (candidate) => candidate.code === "BLOCK_AS_IMPLICIT_KEY" && candidate.pos?.[0] !== undefined,
+  const error = doc.errors.find((candidate) => candidate.pos?.[0] !== undefined);
+  // Aliases fail during toJS without adding a document error position.
+  const descriptionAlias = doc.contents.items.find(
+    (candidate) =>
+      isScalar(candidate.key) && candidate.key.value === "description" && isAlias(candidate.value),
   );
-  const pos = error?.pos?.[0];
+  const pos =
+    error?.pos?.[0] ??
+    (isNode(descriptionAlias?.key) ? descriptionAlias.key.range?.[0] : undefined);
   if (pos === undefined) {
     return block;
   }
@@ -105,15 +103,22 @@ function normalizeFreeformFieldAtError(block: string): string {
   const lineEnd = block.indexOf("\n", pos);
   const end = lineEnd === -1 ? block.length : lineEnd;
   const line = block.slice(lineStart, end);
-  // Match unquoted, double-quoted, and single-quoted freeform keys. Current
-  // main recovers all three for `description`; preserve that compatibility.
   const match = line.match(/^(?:([\w-]+)|"([\w-]+)"|'([\w-]+)'):\s*(.*)$/);
   const keyName = match?.[1] ?? match?.[2] ?? match?.[3];
-  if (!keyName || !FREEFORM_TEXT_FIELDS.has(keyName)) {
-    return block;
-  }
   const rawValue = match?.[4]?.trim();
-  if (!rawValue || /^[|>](?:[1-9][+-]?|[+-][1-9]?)?$/.test(rawValue) || !rawValue.includes(": ")) {
+  const isTopLevelField = doc.contents.items.some(
+    (pair) => isScalar(pair.key) && pair.key.value === keyName && pair.key.range?.[0] === lineStart,
+  );
+  // Keep shipped description recovery; other text fields only recover colon-rich parser errors.
+  const recoverColonRichText = error?.code === "BLOCK_AS_IMPLICIT_KEY" && rawValue?.includes(": ");
+  if (
+    !keyName ||
+    !rawValue ||
+    !FREEFORM_TEXT_FIELDS.has(keyName) ||
+    !isTopLevelField ||
+    (keyName !== "description" && !recoverColonRichText) ||
+    /^[|>](?:[1-9][+-]?|[+-][1-9]?)?$/.test(rawValue)
+  ) {
     return block;
   }
   const replacement = `${keyName}: ${JSON.stringify(stripQuotes(rawValue))}`;


### PR DESCRIPTION
## What Problem This Solves

Workspace skills were silently omitted when a plain-text `read_when` or `summary` value contained an unquoted colon followed by a space.

For example, `read_when: signals: user announcing a conversion task` makes YAML report `BLOCK_AS_IMPLICIT_KEY`. The strict skill loader then rejects the complete skill.

This regressed behavior that stable OpenClaw releases accepted before strict frontmatter diagnostics landed in `0d31fbf5f0ec`.

Related to #122496.

## Why This Change Was Made

Markdown Core owns frontmatter parsing for every skill consumer. The repair keeps one canonical recovery loop there.

- `description` keeps its shipped recovery for punctuation, reserved characters, alias-like text, and colon-rich text.
- `read_when` and `summary` recover only when YAML reports `BLOCK_AS_IMPLICIT_KEY` on that exact top-level field and the value contains colon-space text.
- Structured fields such as `metadata` remain strict.
- Valid comments, quoted escapes, block scalars, and nested metadata retain normal YAML decoding.

The allowlist is closed: `description`, `read_when`, and `summary`. The parser does not recover arbitrary fields or arbitrary YAML failures.

## User Impact

Valid workspace skills with colon-rich `read_when` or `summary` text now appear in `openclaw skills list` and in the model's `<available_skills>` prompt.

Malformed structured metadata still rejects the skill with a visible diagnostic.

## Evidence

### Real workspace skill

The same disposable workspace contained a valid control skill, a colon-rich skill, and a skill with malformed structured metadata.

Current main `0bd5c6a43b7d71e61834abf2f4b0b74cc92d6e46`:

```text
skills list: control-proof
available-skills prompt contains colon-proof: false
structured-proof rejected: true
```

Repaired head `0ec7dfae2ab172a53c16bc836a292bbf40491b5d`:

```text
skills list: colon-proof, control-proof
available-skills prompt contains colon-proof: true
structured-proof rejected: true
parsed read_when: signals: user announcing a conversion task
parsed summary: handles formats: pdf and docx
valid nested metadata emoji: beaker
```

The proof ran a remote `pnpm build`, the real `openclaw skills list --json` command, the workspace loader, and the exact prompt snapshot builder. Testbox runs: [main red](https://github.com/openclaw/openclaw/actions/runs/33317044057), [head green](https://github.com/openclaw/openclaw/actions/runs/33317649809).

### Regression and focused tests

- Original PR head `1fb253abde03f65ada9540d167ae63d5782e42dd` failed three existing description-recovery tests.
- Exact repaired head passed 59 parser and skill-owner tests: [Testbox run](https://github.com/openclaw/openclaw/actions/runs/33317933706).
- Workspace loader and prompt suites passed 40 tests.
- Oxfmt, Oxlint, `git diff --check`, and Autoreview passed.

### Dependency contract

`packages/markdown-core/package.json` pins `yaml` 2.9.0. Its `YAMLError.pos` type provides the required source range, and `resolve-block-map.js` emits `BLOCK_AS_IMPLICIT_KEY` at the compact nested mapping offset. Alias conversion instead fails during `toJS`, so the repair retains the existing description-alias path without extending it to other fields.

### Production size

Production: +33 lines. Tests: +95 lines.

The absorbing refactor keeps one parser owner and one bounded retry loop. No consumer workaround, fallback parser, or second recovery path was added.
