### PR TITLE
fix(ci): run affected extension suites when changed-test planning falls back

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -653,6 +653,7 @@ jobs:
           const compactPlan =
             isCanonicalRepository && (eventName === "pull_request" || eventName === "push");
           let changedNodeTestShards = null;
+          let changedExtensionFallbackShards = [];
           if (
             compactPullRequest &&
             changedPaths &&
@@ -662,6 +663,18 @@ jobs:
               changedNodeTestShards = changedNodeTestPlan.createChangedNodeTestShards(changedPaths);
             } catch (error) {
               console.warn(`Changed Node test planning failed; using compact full suite: ${error}`);
+            }
+            if (
+              changedNodeTestShards === null &&
+              typeof changedNodeTestPlan.createChangedExtensionFallbackShards === "function"
+            ) {
+              try {
+                changedExtensionFallbackShards =
+                  changedNodeTestPlan.createChangedExtensionFallbackShards(changedPaths);
+              } catch (error) {
+                console.warn(`Changed extension fallback planning failed; using compact full suite: ${error}`);
+                changedExtensionFallbackShards = [];
+              }
             }
           }
           // Heavy packaging lanes run only when the diff touches surfaces they
@@ -706,10 +719,13 @@ jobs:
           const rawNodeTestShards = runNodeFull
             ? changedNodeTestShards
               ? changedNodeTestShards
-              : createNodeTestPlan({
-                  includeReleaseOnlyPluginShards: false,
-                  compact: compactPlan,
-                })
+              : [
+                  ...createNodeTestPlan({
+                    includeReleaseOnlyPluginShards: false,
+                    compact: compactPlan,
+                  }),
+                  ...changedExtensionFallbackShards,
+                ]
             : [];
           const assignVitestFsCacheWriter =
             typeof nodeTestPlan.assignVitestFsCacheWriter === "function"

--- a/scripts/lib/ci-changed-node-test-plan.mts
+++ b/scripts/lib/ci-changed-node-test-plan.mts
@@ -14,11 +14,16 @@ import {
   isPolicyTestOwnedPath,
   resolvePolicyTestTargets,
 } from "./ci-node-test-plan.mts";
+import {
+  createExtensionTestProcessTargetChunks,
+  resolveExtensionTestConfig,
+} from "./extension-test-plan.mts";
 import { buildPluginSdkEntrySources, publicPluginSdkEntrypoints } from "./plugin-sdk-entries.mts";
 
 type ChangedNodeTestShard = {
   checkName: string;
   configs: string[];
+  includePatterns?: string[];
   planConcurrency?: number;
   requiresDist: boolean;
   runner: string;
@@ -212,6 +217,166 @@ function createBoundaryShard() {
   };
 }
 
+function resolvePreciseChangedTargets(
+  changedPaths: string[],
+  cwd: string,
+  additionalTargets: string[] = [],
+) {
+  const resolveTargetPlan = (paths: string[]) =>
+    resolveChangedTestTargetPlan(paths, {
+      broad: true,
+      combineSiblingWithImportGraph: true,
+      cwd,
+      forceFullImportGraph: true,
+      includeExtensionImpact: false,
+    });
+  const plan =
+    changedPaths.length > 0
+      ? resolveTargetPlan(changedPaths)
+      : { mode: "targets" as const, targets: [] };
+  // Aggregate resolution must not let one precise path hide another path that
+  // contributes no tests. Partial plans silently drop coverage.
+  if (
+    changedPaths.some((changedPath) => {
+      const changedPathPlan = resolveTargetPlan([changedPath]);
+      return changedPathPlan.mode !== "targets" || changedPathPlan.targets.length === 0;
+    }) ||
+    plan.mode !== "targets"
+  ) {
+    return null;
+  }
+  const targets = [...new Set([...plan.targets, ...additionalTargets])];
+  if (
+    targets.length > MAX_CHANGED_NODE_TEST_TARGETS ||
+    targets.some(
+      (target) =>
+        /^test\/vitest\/vitest\.full-.*\.config\.ts$/u.test(target) ||
+        splitNodeTestConfigs.has(target),
+    ) ||
+    targets.some(
+      (target) =>
+        !isTestFileTarget(target) || findUnmatchedExplicitTestTargets([target], cwd).length > 0,
+    )
+  ) {
+    return null;
+  }
+
+  const targetPlans = targets.map((target) => ({
+    plans: buildVitestRunPlans([target], cwd),
+    target,
+  }));
+  if (
+    targetPlans.some(
+      ({ plans }) => plans.length === 0 || plans.some((targetPlan) => !targetPlan.includePatterns),
+    )
+  ) {
+    return null;
+  }
+  // Preserve special shard setup (for example Go and TUI PTY coverage) by using
+  // the compact plan until targeted jobs can carry per-config prerequisites.
+  if (
+    targetPlans.some(({ plans }) =>
+      plans.some(({ config }) => configsRequiringFullSuiteMetadata.has(config)),
+    )
+  ) {
+    return null;
+  }
+  return targetPlans.map(({ target }) => target);
+}
+
+function createChangedTargetShards(
+  targets: string[],
+  names: { checkName: string; shardName: string },
+) {
+  const targetChunks: string[][] = [];
+  for (let offset = 0; offset < targets.length; offset += CHANGED_NODE_TEST_TARGETS_PER_JOB) {
+    targetChunks.push(targets.slice(offset, offset + CHANGED_NODE_TEST_TARGETS_PER_JOB));
+  }
+  return targetChunks.map((chunk, index) => {
+    const suffix = targetChunks.length === 1 ? "" : `-${index + 1}`;
+    const shard: ChangedNodeTestShard = {
+      checkName: `${names.checkName}${suffix}`,
+      configs: [],
+      requiresDist: false,
+      runner: DEFAULT_NODE_TEST_RUNNER,
+      shardName: `${names.shardName}${suffix}`,
+      targets: chunk,
+    };
+    if (chunk.some((target) => SERIAL_CHANGED_TARGET_RE.test(target))) {
+      shard.planConcurrency = 1;
+    }
+    return shard;
+  });
+}
+
+function resolveChangedExtensionRoots(changedPaths: string[]) {
+  return [
+    ...new Set(
+      changedPaths.flatMap((changedPath) => {
+        const [, extensionId] = changedPath.split("/");
+        return extensionId ? [`extensions/${extensionId}`] : [];
+      }),
+    ),
+  ];
+}
+
+function createChangedExtensionConfigShards(extensionRoots: string[]) {
+  const rootsByConfig = new Map<string, string[]>();
+  for (const root of extensionRoots) {
+    const config = resolveExtensionTestConfig(root);
+    rootsByConfig.set(config, [...(rootsByConfig.get(config) ?? []), root]);
+  }
+  const plans: Array<{ config: string; includePatterns?: string[]; roots: string[] }> = [
+    ...rootsByConfig,
+  ].flatMap(([config, roots]) => {
+    const chunks = createExtensionTestProcessTargetChunks(config, roots);
+    return chunks.length > 1
+      ? chunks.map((includePatterns) => ({ config, includePatterns, roots }))
+      : [{ config, roots }];
+  });
+  return plans.map(({ config, includePatterns, roots }, index) => {
+    const suffix = plans.length === 1 ? "" : `-${index + 1}`;
+    const shard: ChangedNodeTestShard = {
+      checkName: `checks-node-changed-extensions-config${suffix}`,
+      configs: [config],
+      requiresDist: false,
+      runner: DEFAULT_NODE_TEST_RUNNER,
+      shardName: `changed-extensions-config${suffix}`,
+    };
+    if (includePatterns) {
+      shard.includePatterns = includePatterns;
+    }
+    if (roots.some((root) => SERIAL_CHANGED_TARGET_RE.test(`${root}/`))) {
+      shard.planConcurrency = 1;
+    }
+    return shard;
+  });
+}
+
+/**
+ * The fail-safe cause leaves the non-extension diff's extension impact unbounded,
+ * so whole extension configs are required; precise targets would under-cover.
+ */
+export function createChangedExtensionFallbackShards(
+  changedPaths: string[],
+  options: CwdOptions = {},
+): ChangedNodeTestShard[] {
+  const cwd = options.cwd ?? process.cwd();
+  const extensionPaths = changedPaths.filter((changedPath) =>
+    changedPath.startsWith("extensions/"),
+  );
+  if (extensionPaths.length === 0) {
+    return [];
+  }
+  const relevantPaths = extensionPaths.filter(
+    (changedPath) => existsSync(path.join(cwd, changedPath)) || !isTestFileTarget(changedPath),
+  );
+  if (relevantPaths.length === 0) {
+    return [];
+  }
+  return createChangedExtensionConfigShards(resolveChangedExtensionRoots(relevantPaths));
+}
+
 /**
  * Builds bounded PR jobs from precise changed-test targets.
  * Null means the caller must fail safe to the compact full-suite plan.
@@ -259,99 +424,21 @@ export function createChangedNodeTestShards(
     return null;
   }
 
-  const resolveTargetPlan = (paths: string[]) =>
-    resolveChangedTestTargetPlan(paths, {
-      broad: true,
-      combineSiblingWithImportGraph: true,
-      cwd,
-      forceFullImportGraph: true,
-      includeExtensionImpact: false,
-    });
-  const plan =
-    regularLivePaths.length > 0
-      ? resolveTargetPlan(regularLivePaths)
-      : { mode: "targets" as const, targets: [] };
-  // Aggregate resolution must not let one precise path hide another path that
-  // contributes no tests. Partial plans silently drop coverage.
-  if (
-    regularLivePaths.some((changedPath) => {
-      const changedPathPlan = resolveTargetPlan([changedPath]);
-      return changedPathPlan.mode !== "targets" || changedPathPlan.targets.length === 0;
-    })
-  ) {
-    return null;
-  }
-  if (plan.mode !== "targets") {
-    return null;
-  }
-  const targets = [...new Set([...plan.targets, ...[...policyTargetsByPath.values()].flat()])];
-  if (
-    targets.length > MAX_CHANGED_NODE_TEST_TARGETS ||
-    targets.some(
-      (target) =>
-        /^test\/vitest\/vitest\.full-.*\.config\.ts$/u.test(target) ||
-        splitNodeTestConfigs.has(target),
-    )
-  ) {
-    return null;
-  }
-
-  if (
-    targets.some(
-      (target) =>
-        !isTestFileTarget(target) || findUnmatchedExplicitTestTargets([target], cwd).length > 0,
-    )
-  ) {
-    return null;
-  }
-
-  const targetPlans = targets.map((target) => ({
-    plans: buildVitestRunPlans([target], cwd),
-    target,
-  }));
-  if (
-    targetPlans.some(
-      ({ plans }) => plans.length === 0 || plans.some((targetPlan) => !targetPlan.includePatterns),
-    )
-  ) {
-    return null;
-  }
-  // Preserve special shard setup (for example Go and TUI PTY coverage) by using
-  // the compact plan until targeted jobs can carry per-config prerequisites.
-  if (
-    targetPlans.some(({ plans }) =>
-      plans.some(({ config }) => configsRequiringFullSuiteMetadata.has(config)),
-    )
-  ) {
+  const targets = resolvePreciseChangedTargets(
+    regularLivePaths,
+    cwd,
+    [...policyTargetsByPath.values()].flat(),
+  );
+  if (targets === null) {
     return null;
   }
 
   // Boundary-config targets run as regular nondist targets: the boundary
   // suite scans the checked-out tree and never consumes the built dist.
-  const orderedTargets = targetPlans.map(({ target }) => target);
-  const targetChunks: string[][] = [];
-  for (
-    let offset = 0;
-    offset < orderedTargets.length;
-    offset += CHANGED_NODE_TEST_TARGETS_PER_JOB
-  ) {
-    targetChunks.push(orderedTargets.slice(offset, offset + CHANGED_NODE_TEST_TARGETS_PER_JOB));
-  }
   const shards = [
-    ...targetChunks.map((chunk, index) => {
-      const suffix = targetChunks.length === 1 ? "" : `-${index + 1}`;
-      const shard: ChangedNodeTestShard = {
-        checkName: `checks-node-changed${suffix}`,
-        configs: [],
-        requiresDist: false,
-        runner: DEFAULT_NODE_TEST_RUNNER,
-        shardName: `changed${suffix}`,
-        targets: chunk,
-      };
-      if (chunk.some((target) => SERIAL_CHANGED_TARGET_RE.test(target))) {
-        shard.planConcurrency = 1;
-      }
-      return shard;
+    ...createChangedTargetShards(targets, {
+      checkName: "checks-node-changed",
+      shardName: "changed",
     }),
     ...(hasBuildArtifactAffectingChange(changedPaths) ? [] : [createBoundaryShard()]),
   ];

--- a/test/scripts/ci-changed-node-test-plan.test.ts
+++ b/test/scripts/ci-changed-node-test-plan.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  createChangedExtensionFallbackShards,
   createChangedNodeTestShards,
   hasBuildArtifactAffectingChange,
   hasPromptSnapshotAffectingChange,
@@ -262,6 +263,95 @@ describe("CI changed Node test plan", () => {
     expect(
       createChangedNodeTestShards(["packages/gateway-protocol/src/frame-guards.ts"]),
     ).toBeNull();
+  });
+
+  it("supplements mixed package diffs with the affected extension config", () => {
+    const changedPaths = [
+      "packages/gateway-protocol/src/frame-guards.ts",
+      "extensions/codex/src/session-upstream-marker.ts",
+    ];
+
+    expect(createChangedNodeTestShards(changedPaths)).toBeNull();
+    expect(createChangedExtensionFallbackShards(changedPaths)).toEqual([
+      {
+        checkName: "checks-node-changed-extensions-config",
+        configs: ["test/vitest/vitest.extension-codex.config.ts"],
+        requiresDist: false,
+        runner: "blacksmith-8vcpu-ubuntu-2404",
+        shardName: "changed-extensions-config",
+      },
+    ]);
+  });
+
+  it("preserves Matrix process bounds in mixed package fallbacks", () => {
+    const shards = createChangedExtensionFallbackShards([
+      "packages/gateway-protocol/src/frame-guards.ts",
+      "extensions/matrix/src/channel.ts",
+    ]);
+    const targets = shards.flatMap((shard) => shard.includePatterns ?? []);
+
+    expect(shards.length).toBeGreaterThan(1);
+    expect(
+      shards.every(
+        (shard) =>
+          shard.configs[0] === "test/vitest/vitest.extension-matrix.config.ts" &&
+          (shard.includePatterns?.length ?? 0) > 0 &&
+          (shard.includePatterns?.length ?? 0) <= 40,
+      ),
+    ).toBe(true);
+    expect(targets.length).toBeGreaterThan(40);
+    expect(new Set(targets).size).toBe(targets.length);
+  });
+
+  it("skips extension fallback when no extension paths changed", () => {
+    expect(
+      createChangedExtensionFallbackShards([
+        "packages/gateway-protocol/src/frame-guards.ts",
+        "src/agents/live-model-filter.ts",
+      ]),
+    ).toEqual([]);
+  });
+
+  it("falls back to the affected extension config for deleted sources", () => {
+    const cwd = mkdtempSync(path.join(tmpdir(), "openclaw-ci-extension-fallback-"));
+    try {
+      expect(
+        createChangedExtensionFallbackShards(["extensions/codex/src/deleted-session-runtime.ts"], {
+          cwd,
+        }),
+      ).toEqual([
+        {
+          checkName: "checks-node-changed-extensions-config",
+          configs: ["test/vitest/vitest.extension-codex.config.ts"],
+          requiresDist: false,
+          runner: "blacksmith-8vcpu-ubuntu-2404",
+          shardName: "changed-extensions-config",
+        },
+      ]);
+      expect(
+        createChangedExtensionFallbackShards(
+          ["extensions/codex/src/deleted-session-runtime.test.ts"],
+          { cwd },
+        ),
+      ).toEqual([]);
+    } finally {
+      rmSync(cwd, { force: true, recursive: true });
+    }
+  });
+
+  it("serializes the Memory Core extension fallback config", () => {
+    expect(
+      createChangedExtensionFallbackShards(["extensions/memory-core/src/memory/mmr.ts"]),
+    ).toEqual([
+      {
+        checkName: "checks-node-changed-extensions-config",
+        configs: ["test/vitest/vitest.extension-memory.config.ts"],
+        planConcurrency: 1,
+        requiresDist: false,
+        runner: "blacksmith-8vcpu-ubuntu-2404",
+        shardName: "changed-extensions-config",
+      },
+    ]);
   });
 
   it("fails safe when a targeted config needs special shard setup", () => {

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -261,6 +261,29 @@ function runCiManifestFixture(options: {
                     : ["test/scripts/sqlite-sessions-transcripts-flip-proof.built-cli.e2e.test.ts"],
                 }]
               : null;
+          export const createChangedExtensionFallbackShards = (changedPaths) =>
+            changedPaths.some((changedPath) => changedPath.startsWith("extensions/"))
+              ? changedPaths.some((changedPath) => changedPath.startsWith("extensions/matrix/"))
+                ? [{
+                    checkName: "changed-extension-fallback-plan",
+                    configs: ["test/vitest/vitest.extension-matrix.config.ts"],
+                    includePatterns: [
+                      "extensions/matrix/src/client.test.ts",
+                      "extensions/matrix/src/monitor.test.ts",
+                    ],
+                    requiresDist: false,
+                    runner: "ubuntu-24.04",
+                    shardName: "changed-extension-fallback-plan",
+                  }]
+                : [{
+                  checkName: "changed-extension-fallback-plan",
+                  configs: [],
+                  requiresDist: false,
+                  runner: "ubuntu-24.04",
+                  shardName: "changed-extension-fallback-plan",
+                  targets: ["extensions/codex/src/focused.test.ts"],
+                }]
+              : [];
           export const hasBuildArtifactAffectingChange = (changedPaths) =>
             !changedPaths.includes("test/scripts/sqlite-sessions-transcripts-flip-proof.built-cli.e2e.test.ts");
           export const hasSqliteSessionLifecycleAffectingChange = (changedPaths) =>
@@ -5375,7 +5398,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
 
     const changedPullRequest = runCiManifestFixture({
       bundledPlanner: true,
-      changedPaths: ["src/focused.ts"],
+      changedPaths: ["src/focused.ts", "extensions/codex/src/focused.ts"],
       eventName: "pull_request",
     });
     expect(changedPullRequest.status, changedPullRequest.output).toBe(0);
@@ -5393,8 +5416,70 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
         targets: ["src/focused.test.ts"],
       }),
     ]);
+    expect(
+      JSON.parse(
+        expectDefined(
+          changedPullRequest.outputs.checks_node_core_nondist_matrix,
+          "changed PR node matrix output",
+        ),
+      ).include,
+    ).not.toContainEqual(
+      expect.objectContaining({ check_name: "changed-extension-fallback-plan" }),
+    );
     expect(changedPullRequest.outputs.run_checks_node_core_dist).toBe("true");
     expect(changedPullRequest.outputs.run_sqlite_session_lifecycle).toBe("false");
+
+    const mixedFallbackPullRequest = runCiManifestFixture({
+      bundledPlanner: true,
+      changedPaths: [
+        "packages/gateway-protocol/src/frame-guards.ts",
+        "extensions/codex/src/focused.ts",
+      ],
+      eventName: "pull_request",
+    });
+    expect(mixedFallbackPullRequest.status, mixedFallbackPullRequest.output).toBe(0);
+    expect(
+      JSON.parse(
+        expectDefined(
+          mixedFallbackPullRequest.outputs.checks_node_core_nondist_matrix,
+          "mixed fallback PR node matrix output",
+        ),
+      ).include,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ check_name: "bundled-node-plan" }),
+        expect.objectContaining({ check_name: "changed-extension-fallback-plan" }),
+      ]),
+    );
+
+    const matrixFallbackPullRequest = runCiManifestFixture({
+      bundledPlanner: true,
+      changedPaths: [
+        "packages/gateway-protocol/src/frame-guards.ts",
+        "extensions/matrix/src/channel.ts",
+      ],
+      eventName: "pull_request",
+    });
+    expect(matrixFallbackPullRequest.status, matrixFallbackPullRequest.output).toBe(0);
+    expect(
+      JSON.parse(
+        expectDefined(
+          matrixFallbackPullRequest.outputs.checks_node_core_nondist_matrix,
+          "Matrix fallback PR node matrix output",
+        ),
+      ).include,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          check_name: "changed-extension-fallback-plan",
+          configs: ["test/vitest/vitest.extension-matrix.config.ts"],
+          includePatterns: [
+            "extensions/matrix/src/client.test.ts",
+            "extensions/matrix/src/monitor.test.ts",
+          ],
+        }),
+      ]),
+    );
 
     const sqliteLifecyclePullRequest = runCiManifestFixture({
       bundledPlanner: true,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where mixed package and extension changes could pass PR CI without running any tests for the touched extensions. The changed-test planner's compact fallback silently drops all extension test coverage: `createChangedNodeTestShards` fails safe (returns `null`) for any diff touching `packages/**` because package-specifier consumers are invisible to the relative import graph, and CI's fallback compact plan is built from `createNodeTestShards`, whose `EXCLUDED_FULL_SUITE_SHARDS` excludes `test/vitest/vitest.full-extensions.config.ts`. Extension behavior suites only run on PRs through the precise changed plan, so mixed package+extension PRs ran zero extension tests.

Known escapes include PR #120534 (run 31457140740 had no Codex extension suite and broke `extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts` on `main`), plus #122163, #121522, and cd7b7f639da (which broke `media-understanding-provider.test.ts` and `thread-lifecycle.test.ts`).

## Why This Change Was Made

This adds `createChangedExtensionFallbackShards` in `scripts/lib/ci-changed-node-test-plan.mts`; the `ci.yml` preflight appends its shards to the compact fallback when the precise plan fails safe. The import is `typeof`-guarded so it remains compatible with frozen targets.

The supplement emits whole extension configs for the diff's touched extensions rather than precise targets. The fail-safe cause means the non-extension diff's impact on extension tests cannot be bounded by the import graph, so precise targets would under-cover. Deleted extension test files are ignored, and memory-core keeps its serial (`planConcurrency: 1`) contract. Shared target-resolution helpers were factored out of `createChangedNodeTestShards` with behavior unchanged.

Matrix keeps its canonical 40-file process bound in fallback mode: the planner reuses the existing extension process-target chunker and forwards each bounded include-pattern shard through the normal CI matrix contract.

Known remaining gap, intentionally left for follow-up: a `packages/core`-only diff with no extension files still falls back with no extension coverage, as before this PR.

## User Impact

PR CI can no longer land mixed package+extension diffs green without executing the touched extensions' test suites. There is no new config surface, and dispatch/release plans are unchanged.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/ci-changed-node-test-plan.test.ts test/scripts/ci-workflow-guards.test.ts test/scripts/ci-node-test-plan.test.ts` → 165 passed, 2 skipped.
- Post-rebase focused proof after the Matrix repair: `node scripts/run-vitest.mjs test/scripts/ci-changed-node-test-plan.test.ts test/scripts/ci-workflow-guards.test.ts` → 144 passed, 2 skipped.
- The workflow-guards suite executes the real `ci.yml` preflight script and asserts that the supplement shard appears in the node matrix exactly when the precise plan returns `null`, including forwarding bounded Matrix include patterns.
- Sanity: `createChangedExtensionFallbackShards(["packages/gateway-protocol/src/frame-guards.ts", "extensions/codex/src/session-upstream-marker.ts"])` → one shard with `configs: ["test/vitest/vitest.extension-codex.config.ts"]`.
- The pre-repair Matrix fallback produced one config-only shard; the regression now proves every Matrix fallback shard carries 1–40 unique test targets and the full inventory remains covered.
- Codex autoreview (`gpt-5.6-sol`, xhigh): clean, no actionable findings.

## Review follow-up

The exact-head ClawSweeper review identified that a config-only Matrix fallback would bypass Matrix's established 40-file process lifetime. This is addressed in the current head by reusing `createExtensionTestProcessTargetChunks`; focused planner and workflow tests cover the mixed package-plus-Matrix path.

## Red-main repair carried in this PR

Main independently landed the Control UI startup-JS gzip budget repair as add6b20bd28 with a 329483 B baseline. The redundant repair commit from this branch was therefore dropped during the rebase; this PR now carries only the changed-test planner fix and uses main's baseline unchanged.

CI run 31656209542 was green across build artifacts, QA smoke, and the other relevant lanes, but had a one-off `checks-ui-e2e` failure in job 94311332100: `ui/src/api/gateway.node.test.ts` failed its stale-runtime-import assertion. That test passes locally and is unrelated to this diff; a separate follow-up task tracks the flake.
