### PR TITLE
fix(ui): unblock builds after startup bundle growth

### DIFF
--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 328285,
-  "reason": "Gateway update outcome (#121686); Testbox-measured exact-head bytes",
-  "updatedAt": "2026-08-11"
+  "startupJsGzipBytes": 329465,
+  "reason": "Continue-in-terminal, new-session progress, and archived-session navigation; Linux CI exact-head bytes",
+  "updatedAt": "2026-08-13"
 }


### PR DESCRIPTION
Related: #121497

## What Problem This Solves

Resolves a problem where normal CI and every QA Smoke profile fail before testing because recent intentional Control UI startup features moved the Linux gzip measurement just beyond the recorded baseline tolerance.

## Why This Change Was Made

Record the highest exact-main Linux CI measurement, 329465 bytes, as the current startup baseline. The existing 1024-byte tolerance and 358400-byte hard cap remain unchanged, so this accounts for reviewed product growth without weakening the cumulative performance ceiling.

## User Impact

There is no runtime behavior change. OpenClaw changes can once again reach their actual build and QA checks instead of failing the shared Control UI accounting gate.

## Evidence

- Main CI run 31654396314 at `8733dcd05f91` measured 329446 bytes and failed against 328285 + 1024 bytes.
- Main CI run 31655352140 at `f24e164f694c` measured 329465 bytes and failed the same gate.
- PR run 31655039612 measured 329454-329483 bytes across build-artifacts and QA Smoke.
- PR run 31655397340 measured 329426-329445 bytes across build-artifacts and QA Smoke.
- Baseline remains 28935 bytes below the fixed 350 KiB cap.
- `git diff --check`
- JSON baseline/cap assertion
- Autoreview: clean, no accepted or actionable findings.
