### PR TITLE
fix(ui): stop sessions page from bypassing the shared refresh coordinator

### DIFF
--- a/ui/src/pages/sessions/sessions-page.test.ts
+++ b/ui/src/pages/sessions/sessions-page.test.ts
@@ -522,6 +522,56 @@ describe("sessions page lifecycle", () => {
     expect(list).not.toHaveBeenCalled();
   });
 
+  it("projects an in-place reconcile's row changes into the page-local result", async () => {
+    const initialResult = {
+      count: 1,
+      sessions: [{ key: "a", updatedAt: 1 }],
+    } as SessionsListResult;
+    const sharedListener: { current: ((snapshot: SessionCapability["state"]) => void) | null } = {
+      current: null,
+    };
+    const sharedState: SessionCapability["state"] = {
+      result: initialResult,
+      agentId: null,
+      modelOverrides: {},
+      loading: false,
+      error: null,
+      deletedSessions: [],
+      groups: [],
+      sectionOrder: [],
+    };
+    const list = vi.fn(async () => initialResult);
+    const sessions = createSessions({
+      state: sharedState,
+      list,
+      subscribe: (listener) => {
+        sharedListener.current = listener;
+        return () => {
+          sharedListener.current = null;
+        };
+      },
+    });
+    const { gateway } = createGateway({} as GatewayBrowserClient);
+    const context = createContext(gateway, sessions);
+    const page = await createRenderedPage(context, initialResult);
+    list.mockClear();
+
+    // An active session.message reconciles the shared roster's row in place
+    // (index.ts returns before scheduling a coordinator refresh), so `loading`
+    // never toggles for this publish.
+    const reconciled = {
+      count: 1,
+      sessions: [{ key: "a", updatedAt: 2 }],
+    } as SessionsListResult;
+    sharedListener.current?.({ ...sharedState, result: reconciled });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(list).not.toHaveBeenCalled();
+    expect(page.result?.sessions[0]?.updatedAt).toBe(2);
+  });
+
   it("reloads once the shared roster completes a debounced canonical refresh", async () => {
     const initialResult = { count: 1, sessions: [{ key: "a" }] } as SessionsListResult;
     const sharedListener: { current: ((snapshot: SessionCapability["state"]) => void) | null } = {

--- a/ui/src/pages/sessions/sessions-page.test.ts
+++ b/ui/src/pages/sessions/sessions-page.test.ts
@@ -480,6 +480,86 @@ describe("sessions page lifecycle", () => {
     expect(page.result?.sessions.map((session) => session.key)).toEqual(["fresh"]);
   });
 
+  it("does not issue a raw session list request for an in-place reconcile publish", async () => {
+    const initialResult = { count: 1, sessions: [{ key: "a" }] } as SessionsListResult;
+    const sharedListener: { current: ((snapshot: SessionCapability["state"]) => void) | null } = {
+      current: null,
+    };
+    const sharedState: SessionCapability["state"] = {
+      result: initialResult,
+      agentId: null,
+      modelOverrides: {},
+      loading: false,
+      error: null,
+      deletedSessions: [],
+      groups: [],
+      sectionOrder: [],
+    };
+    const list = vi.fn(async () => initialResult);
+    const sessions = createSessions({
+      state: sharedState,
+      list,
+      subscribe: (listener) => {
+        sharedListener.current = listener;
+        return () => {
+          sharedListener.current = null;
+        };
+      },
+    });
+    const { gateway } = createGateway({} as GatewayBrowserClient);
+    const context = createContext(gateway, sessions);
+    await createRenderedPage(context, initialResult);
+    list.mockClear();
+
+    // A shared-capability reconcile (event-refresh-coordinator.ts owns the
+    // debounced network refresh) replaces `result` without toggling `loading`.
+    const reconciled = { count: 1, sessions: [{ key: "b" }] } as SessionsListResult;
+    sharedListener.current?.({ ...sharedState, result: reconciled });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it("reloads once the shared roster completes a debounced canonical refresh", async () => {
+    const initialResult = { count: 1, sessions: [{ key: "a" }] } as SessionsListResult;
+    const sharedListener: { current: ((snapshot: SessionCapability["state"]) => void) | null } = {
+      current: null,
+    };
+    const sharedState: SessionCapability["state"] = {
+      result: initialResult,
+      agentId: null,
+      modelOverrides: {},
+      loading: false,
+      error: null,
+      deletedSessions: [],
+      groups: [],
+      sectionOrder: [],
+    };
+    const freshResult = { count: 1, sessions: [{ key: "fresh" }] } as SessionsListResult;
+    const list = vi.fn(async () => freshResult);
+    const sessions = createSessions({
+      state: sharedState,
+      list,
+      subscribe: (listener) => {
+        sharedListener.current = listener;
+        return () => {
+          sharedListener.current = null;
+        };
+      },
+    });
+    const { gateway } = createGateway({} as GatewayBrowserClient);
+    const context = createContext(gateway, sessions);
+    await createRenderedPage(context, initialResult);
+    list.mockClear();
+
+    sharedListener.current?.({ ...sharedState, loading: true });
+    sharedListener.current?.({ ...sharedState, result: freshResult, loading: false });
+
+    await vi.waitFor(() => expect(list).toHaveBeenCalledOnce());
+  });
+
   it("rejects session and checkpoint results after the sessions capability changes", async () => {
     const list = deferred<SessionsListResult | null>();
     const checkpoints = deferred<SessionCompactionCheckpoint[]>();

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -198,11 +198,16 @@ class SessionsPage extends OpenClawLightDomElement {
           }
           // Reload only once the shared roster's own debounced event-refresh
           // coordinator (event-refresh-coordinator.ts) completes a canonical
-          // fetch. In-place reconcile publishes also change `result` but never
-          // toggle loading, so reacting to every `resultChanged` here bypassed
-          // that coordinator and fired one raw sessions.list per session event.
+          // fetch; that is the only case that can add/remove/reorder rows.
+          // In-place reconcile publishes also change `result` but never toggle
+          // loading (e.g. an active session.message never schedules a
+          // coordinator refresh) — project their row updates into the
+          // page-local result directly instead of dropping them or issuing a
+          // raw sessions.list per event.
           if (refreshCompleted && resultChanged) {
             this.scheduleSessionReload();
+          } else if (resultChanged && snapshot.result) {
+            this.projectSharedSessionRows(snapshot.result);
           }
         });
         if (sourceChanged && this.routeDataInitialized) {
@@ -514,6 +519,26 @@ class SessionsPage extends OpenClawLightDomElement {
     this.ensureAgentIdentities(this.result);
     if (data.expandedSessionKey) {
       void this.loadCheckpoint(data.expandedSessionKey);
+    }
+  }
+
+  /** Merge rows the shared roster already reconciled into `this.result`, by key, with no network call. */
+  private projectSharedSessionRows(sharedResult: SessionsListResult) {
+    if (!this.result) {
+      return;
+    }
+    const sharedByKey = new Map(sharedResult.sessions.map((row) => [row.key, row]));
+    let changed = false;
+    const sessions = this.result.sessions.map((row) => {
+      const sharedRow = sharedByKey.get(row.key);
+      if (!sharedRow || sharedRow === row) {
+        return row;
+      }
+      changed = true;
+      return sharedRow;
+    });
+    if (changed) {
+      this.result = { ...this.result, sessions };
     }
   }
 

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -196,7 +196,12 @@ class SessionsPage extends OpenClawLightDomElement {
             this.ignorePendingSharedRefresh = false;
             return;
           }
-          if (resultChanged) {
+          // Reload only once the shared roster's own debounced event-refresh
+          // coordinator (event-refresh-coordinator.ts) completes a canonical
+          // fetch. In-place reconcile publishes also change `result` but never
+          // toggle loading, so reacting to every `resultChanged` here bypassed
+          // that coordinator and fired one raw sessions.list per session event.
+          if (refreshCompleted && resultChanged) {
             this.scheduleSessionReload();
           }
         });


### PR DESCRIPTION
<!-- AI-assisted PR: implemented and validated by an autonomous Claude agent. -->

Closes #122865

## What Problem This Solves

With the Sessions dashboard page open, the browser fires a redundant
`sessions.list` WebSocket request on nearly every gateway session event (chat
messages, tool progress, session lifecycle changes) — not just when the
shared session roster actually finishes a fresh fetch. With multiple
dashboard tabs open this compounds linearly, producing sustained elevated
Gateway CPU/load and log-noise memory-pressure warnings, as reported in
#122865 (102 `sessions.list` calls / 10 min with 2 tabs, dropping to 34/10 min
with 1 tab — i.e. redundant traffic even from a single tab).

## Why This Change Was Made

`ui/src/lib/sessions/index.ts` already reconciles most session events
in-place (no network call) and separately schedules a debounced canonical
refresh through `event-refresh-coordinator.ts` (200ms debounce, 1s max wait).
`openclaw-sessions-page` subscribes to that shared roster and reacted to
*every* published `result` change — including the in-place reconciles, which
never toggle `loading` — by calling `scheduleSessionReload()`, which issues
its own raw, uncoordinated `sessions.list` request via `loadSessions()`. This
bypassed the existing debounced coordinator entirely, so each event produced
an extra full round trip on top of (or ahead of) the coordinator's own
already-debounced fetch.

The fix keeps the shared roster's coordinator as the sole driver of
event-triggered refreshes: the page now reloads only when the shared roster
transitions `loading: true -> false` (`refreshCompleted`), i.e. when the
coordinator's own debounced canonical fetch actually completes. Reloads
triggered by explicit user/route/filter/connection actions
(`applyGatewaySnapshot`, `applyRouteData`, filter changes, explicit refresh)
are untouched.

## User Impact

Dashboard users (especially with multiple tabs open) see materially fewer
redundant `sessions.list` WebSocket calls and lower sustained Gateway
CPU/load from the Sessions page, with no change to how quickly the visible
session list reflects new activity (still bounded by the existing 200ms/1s
coordinator debounce).

## Evidence

Added a regression test that fails on the pre-fix code with the current
production data (`git checkout HEAD~1 -- ui/src/pages/sessions/sessions-page.ts`
against this branch, i.e. the code before this fix):

```
❯ |ui| ui/src/pages/sessions/sessions-page.test.ts (30 tests | 1 failed)
  × does not issue a raw session list request for an in-place reconcile publish

AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
Received:
  1st vi.fn() call:
    Array [ Object {
      "activeMinutes": undefined, "agentId": "main", "archivedFilter": "active",
      "includeGlobal": true, "includeUnknown": false, "limit": 50, "search": undefined,
    } ]
Number of calls: 1
 ❯ ui/src/pages/sessions/sessions-page.test.ts:518:22
```

After the fix, `node scripts/run-vitest.mjs ui/src/pages/sessions/sessions-page.test.ts`:

```
 Test Files  1 passed (1)
      Tests  30 passed (30)
```

Broader sibling coverage, unaffected:

```
$ node scripts/run-vitest.mjs ui/src/pages/sessions
 Test Files  5 passed (5)
      Tests  98 passed (98)

$ node scripts/run-vitest.mjs ui/src/lib/sessions
 Test Files  28 passed (28)
      Tests  270 passed (270)
```

Typecheck and lint on the touched files, both clean:

```
$ pnpm tsgo:ui        # exit 0, no output
$ pnpm tsgo:test:ui   # exit 0, no output
$ node scripts/run-oxlint.mjs ui/src/pages/sessions/sessions-page.ts ui/src/pages/sessions/sessions-page.test.ts   # exit 0
$ ./node_modules/.bin/oxfmt --check ui/src/pages/sessions/sessions-page.ts ui/src/pages/sessions/sessions-page.test.ts
All matched files use the correct format.
```

Production diff is a single 5-line condition change plus a comment
(`ui/src/pages/sessions/sessions-page.ts`, `+6/-1`); the rest of the diff is
the two new regression tests.


## Real Behavior Proof (after "preserve live in-place session updates" fix)

The prior evidence above was Vitest unit-level only. This adds a real-browser,
real-Gateway-protocol run through the actual production code path (no page-level
mocking of `ui/src/lib/sessions/index.ts` or `sessions-page.ts`), using the same
mock-Gateway Control UI E2E harness (`ui/src/test-helpers/control-ui-e2e.ts`) that
backs the `checks-ui-e2e-real-gateway` CI lane: a real Chromium browser driven by
Playwright, talking real Gateway wire-protocol frames to a Sessions dashboard page
built from this branch's code.

Scenario: open `/sessions`, let startup settle, then emit a real `session.message`
Gateway event shaped exactly like the server always sends it (`archived` is always
an explicit boolean per `buildGatewaySessionEventFields` in
`src/gateway/session-event-payload.ts:34`, never omitted) with `hasActiveRun: true`,
`status: "running"`, and a changed `label`, then a later distinct `sessions.changed`
event.

Command:
```
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts \
  --configLoader runner --reporter=verbose <ad-hoc-proof-spec>.e2e.test.ts
```

Output:
```
[proof] sessions.list calls before event: 3
[proof] row label + "Active run" title visible after in-place reconcile alone
[proof] sessions.list calls right after event: 3
[proof] sessions.list calls after sessions.changed: 5
 ✓ reflects an active session.message reconcile in the row without an extra sessions.list call

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

Reproduced identically across 3 consecutive runs. This shows, end to end:
- The active `session.message` reconcile updates the visible row in place (label
  and "Active run" status both change) with **zero** extra `sessions.list` calls
  (3 → 3) — the P2 finding's scenario, now covered live.
- A genuine `sessions.changed` event still drives the existing debounced
  coordinator refresh (3 → 5), so the canonical-refresh path this PR preserves is
  unaffected.

The ad hoc spec used for this run was a throwaway proof file, deleted after use;
it is not part of this PR's diff (see `ui/src/pages/sessions/sessions-page.test.ts`
for the committed regression coverage of the same in-place-projection behavior).
