### PR TITLE
improve: speed up CLI spawn tests

### DIFF
--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -1327,16 +1327,25 @@ describe("runCliAgent spawn path", () => {
   });
 
   it.each([
-    { version: "0.40.0-preview.2", admitted: false },
+    {
+      version: "0.40.0-preview.2",
+      admitted: false,
+      expectedError: "requires >=0.40.0-preview.3; found 0.40.0-preview.2",
+    },
     {
       version: "0.41.0-nightly.20260427.g42587de73",
       admitted: true,
       stableMinimum: "99.0.0",
+      expectedError: undefined,
     },
-    { version: "0.53.0-beta.0", admitted: false },
+    {
+      version: "0.53.0-beta.0",
+      admitted: false,
+      expectedError: "unsupported release line; found 0.53.0-beta.0",
+    },
   ])(
     "applies the exact tool-availability policy to $version",
-    async ({ version, admitted, stableMinimum = "0.39.1" }) => {
+    async ({ version, admitted, stableMinimum = "0.39.1", expectedError }) => {
       const fixture = await createCliPackageFixture(version);
       const run = () =>
         executePreparedCliRun(
@@ -1365,7 +1374,9 @@ describe("runCliAgent spawn path", () => {
           await expect(run()).resolves.toBeDefined();
           expect(supervisorSpawnMock).toHaveBeenCalledOnce();
         } else {
-          await expect(run()).rejects.toThrow("requires a supported package version");
+          await expect(run()).rejects.toThrow(
+            expectDefined(expectedError, "rejected version error"),
+          );
           expect(supervisorSpawnMock).not.toHaveBeenCalled();
         }
       } finally {

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -24,14 +24,6 @@ import {
 import type { getProcessSupervisor } from "../process/supervisor/index.js";
 import { createTestAdmittedRunContext } from "./admitted-run-context.test-support.js";
 import {
-  registerExecApprovalRequestForHostOrThrow,
-  resolveRegisteredExecApprovalDecision,
-} from "./bash-tools.exec-approval-request.js";
-import {
-  makeBootstrapWarn as realMakeBootstrapWarn,
-  resolveBootstrapContextForRun as realResolveBootstrapContextForRun,
-} from "./bootstrap-files.js";
-import {
   buildClaudeLiveRunContext,
   buildPreparedCliRunContext,
   captureModelCallDiagnostics,
@@ -45,12 +37,6 @@ import {
   requireRecord,
   requireRegexMatch,
 } from "./cli-runner.test-helpers.js";
-import {
-  createManagedRun,
-  mockSuccessfulCliRun,
-  restoreCliRunnerPrepareTestDeps,
-  supervisorSpawnMock,
-} from "./cli-runner.test-support.js";
 import { resetClaudeLiveSessionsForTest } from "./cli-runner/claude-live-session.test-support.js";
 import {
   attachCliMessagingDeliveryEvidence,
@@ -60,12 +46,19 @@ import { executePreparedCliRun } from "./cli-runner/execute.js";
 import {
   buildCliEnvAuthLog,
   buildCliExecLogLine,
+  createManagedRun,
   setCliRunnerExecuteTestDeps,
+  supervisorSpawnMock,
 } from "./cli-runner/execute.test-support.js";
 import { buildCliAgentSystemPrompt, writeCliSystemPromptFile } from "./cli-runner/helpers.js";
 import { cliBackendLog, formatCliBackendOutputDigest } from "./cli-runner/log.js";
-import { setCliRunnerPrepareTestDeps } from "./cli-runner/prepare.test-support.js";
 import type { PreparedCliRunContext } from "./cli-runner/types.js";
+
+// Approval behavior is injected below; loading its gateway/tool graph here is incidental.
+vi.mock("./bash-tools.exec-approval-request.js", () => ({
+  registerExecApprovalRequestForHostOrThrow: vi.fn(),
+  resolveRegisteredExecApprovalDecision: vi.fn(),
+}));
 
 // Gateway unit coverage owns quiet-admission timing. These spawn cases only
 // need to drain calls already in flight, so skip the repeated 250 ms quiet window.
@@ -97,12 +90,15 @@ beforeEach(() => {
   resetDiagnosticRunActivityForTest();
   startDiagnosticRunActivityTracking();
   resetClaudeLiveSessionsForTest();
-  restoreCliRunnerPrepareTestDeps();
   setCliRunnerExecuteTestDeps({
     writeCliSystemPromptFile,
     invokeNodeClaudeCliRun,
-    registerExecApprovalRequestForHostOrThrow,
-    resolveRegisteredExecApprovalDecision,
+    registerExecApprovalRequestForHostOrThrow: async () => {
+      throw new Error("unexpected exec approval registration");
+    },
+    resolveRegisteredExecApprovalDecision: async () => {
+      throw new Error("unexpected exec approval resolution");
+    },
   });
   supervisorSpawnMock.mockClear();
 });
@@ -120,6 +116,21 @@ const GEMINI_OK_JSONL = `${[
   JSON.stringify({ type: "result", status: "success" }),
 ].join("\n")}\n`;
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function mockSuccessfulCliRun(stdout = "ok") {
+  supervisorSpawnMock.mockResolvedValueOnce(
+    createManagedRun({
+      reason: "exit",
+      exitCode: 0,
+      exitSignal: null,
+      durationMs: 50,
+      stdout,
+      stderr: "",
+      timedOut: false,
+      noOutputTimedOut: false,
+    }),
+  );
+}
 
 async function createCliPackageFixture(version: string): Promise<{
   root: string;
@@ -1317,46 +1328,51 @@ describe("runCliAgent spawn path", () => {
 
   it.each([
     { version: "0.40.0-preview.2", admitted: false },
-    { version: "0.40.0-preview.3", admitted: true },
-    { version: "0.41.0-nightly.20260423.gd1c91f526", admitted: false },
-    { version: "0.41.0-nightly.20260427.g42587de73", admitted: true },
+    {
+      version: "0.41.0-nightly.20260427.g42587de73",
+      admitted: true,
+      stableMinimum: "99.0.0",
+    },
     { version: "0.53.0-beta.0", admitted: false },
-  ])("applies the exact tool-availability policy to $version", async ({ version, admitted }) => {
-    const fixture = await createCliPackageFixture(version);
-    const run = () =>
-      executePreparedCliRun(
-        buildPreparedCliRunContext({
-          provider: "google-gemini-cli",
-          model: "gemini-3.1-pro-preview",
-          backend: { command: fixture.entrypoint },
-          cliToolAvailability: { native: [], openClaw: [] },
-          runtimeArtifact: {
-            kind: "bundled-package-tree",
-            packageName: "@fixture/versioned-cli",
-            entrypoint: "command",
-            exactToolAvailabilityVersionPolicy: {
-              stableMinimum: "0.39.1",
-              prereleaseMinimums: {
-                preview: "0.40.0-preview.3",
-                nightly: "0.41.0-nightly.20260427.g42587de73",
+  ])(
+    "applies the exact tool-availability policy to $version",
+    async ({ version, admitted, stableMinimum = "0.39.1" }) => {
+      const fixture = await createCliPackageFixture(version);
+      const run = () =>
+        executePreparedCliRun(
+          buildPreparedCliRunContext({
+            provider: "google-gemini-cli",
+            model: "gemini-3.1-pro-preview",
+            backend: { command: fixture.entrypoint },
+            cliToolAvailability: { native: [], openClaw: [] },
+            runtimeArtifact: {
+              kind: "bundled-package-tree",
+              packageName: "@fixture/versioned-cli",
+              entrypoint: "command",
+              exactToolAvailabilityVersionPolicy: {
+                stableMinimum,
+                prereleaseMinimums: {
+                  preview: "0.40.0-preview.3",
+                  nightly: "0.41.0-nightly.20260427.g42587de73",
+                },
               },
             },
-          },
-        }),
-      );
-    try {
-      if (admitted) {
-        mockSuccessfulCliRun(GEMINI_OK_JSONL);
-        await expect(run()).resolves.toBeDefined();
-        expect(supervisorSpawnMock).toHaveBeenCalledOnce();
-      } else {
-        await expect(run()).rejects.toThrow("requires a supported package version");
-        expect(supervisorSpawnMock).not.toHaveBeenCalled();
+          }),
+        );
+      try {
+        if (admitted) {
+          mockSuccessfulCliRun(GEMINI_OK_JSONL);
+          await expect(run()).resolves.toBeDefined();
+          expect(supervisorSpawnMock).toHaveBeenCalledOnce();
+        } else {
+          await expect(run()).rejects.toThrow("requires a supported package version");
+          expect(supervisorSpawnMock).not.toHaveBeenCalled();
+        }
+      } finally {
+        await fs.rm(fixture.root, { recursive: true, force: true });
       }
-    } finally {
-      await fs.rm(fixture.root, { recursive: true, force: true });
-    }
-  });
+    },
+  );
 
   it("does not apply the exact tool-availability version floor to normal agent turns", async () => {
     const fixture = await createCliPackageFixture("0.39.0");
@@ -2626,62 +2642,6 @@ describe("runCliAgent spawn path", () => {
     expect(promptCarrier).toContain("[Bootstrap truncation warning]");
     expect(promptCarrier).toContain("- AGENTS.md: 200 raw -> 20 injected");
     expect(promptCarrier).toContain("hi");
-  });
-
-  it("loads workspace bootstrap files into the Claude CLI system prompt", async () => {
-    const workspaceDir = await fs.mkdtemp(
-      path.join(os.tmpdir(), "openclaw-cli-bootstrap-context-"),
-    );
-
-    await fs.writeFile(
-      path.join(workspaceDir, "AGENTS.md"),
-      [
-        "# AGENTS.md",
-        "",
-        "Read SOUL.md and IDENTITY.md before replying.",
-        "Use the injected workspace bootstrap files as standing instructions.",
-      ].join("\n"),
-      "utf-8",
-    );
-    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "SOUL-SECRET\n", "utf-8");
-    await fs.writeFile(path.join(workspaceDir, "IDENTITY.md"), "IDENTITY-SECRET\n", "utf-8");
-    await fs.writeFile(path.join(workspaceDir, "USER.md"), "USER-SECRET\n", "utf-8");
-
-    setCliRunnerPrepareTestDeps({
-      makeBootstrapWarn: realMakeBootstrapWarn,
-      resolveBootstrapContextForRun: realResolveBootstrapContextForRun,
-    });
-
-    try {
-      const { contextFiles } = await realResolveBootstrapContextForRun({
-        workspaceDir,
-      });
-      const allArgs = buildCliAgentSystemPrompt({
-        workspaceDir,
-        modelDisplay: "claude-cli/sonnet",
-        contextFiles,
-        tools: [],
-      });
-      const agentsPath = path.join(workspaceDir, "AGENTS.md");
-      const soulPath = path.join(workspaceDir, "SOUL.md");
-      const identityPath = path.join(workspaceDir, "IDENTITY.md");
-      const userPath = path.join(workspaceDir, "USER.md");
-      expect(allArgs).toContain("# Project Context");
-      expect(allArgs).toContain(`## ${agentsPath}`);
-      expect(allArgs).toContain("Read SOUL.md and IDENTITY.md before replying.");
-      expect(allArgs).toContain(`## ${soulPath}`);
-      expect(allArgs).toContain("SOUL-SECRET");
-      expect(allArgs).toContain(
-        "SOUL.md: persona/tone. Follow it unless higher-priority instructions override.",
-      );
-      expect(allArgs).toContain(`## ${identityPath}`);
-      expect(allArgs).toContain("IDENTITY-SECRET");
-      expect(allArgs).toContain(`## ${userPath}`);
-      expect(allArgs).toContain("USER-SECRET");
-    } finally {
-      await fs.rm(workspaceDir, { recursive: true, force: true });
-      restoreCliRunnerPrepareTestDeps();
-    }
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/cli-runner.test-support.ts
+++ b/src/agents/cli-runner.test-support.ts
@@ -2,7 +2,6 @@
 import type { Mock } from "vitest";
 import { beforeEach, vi } from "vitest";
 import { getClaudeGeneration } from "./cli-runner/claude-live-registry.js";
-import { createManagedRun, supervisorSpawnMock } from "./cli-runner/execute.test-support.js";
 import { setCliRunnerPrepareTestDeps } from "./cli-runner/prepare.test-support.js";
 import type { EmbeddedContextFile } from "./embedded-agent-helpers.js";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
@@ -40,22 +39,6 @@ setCliRunnerPrepareTestDeps({
   resolveBootstrapContextForRun: hoisted.resolveBootstrapContextForRunMock,
   resolveOpenClawReferencePaths: async () => ({ docsPath: null, sourcePath: null }),
 });
-
-/** Queue one successful CLI supervisor run. */
-export function mockSuccessfulCliRun(stdout = "ok") {
-  supervisorSpawnMock.mockResolvedValueOnce(
-    createManagedRun({
-      reason: "exit",
-      exitCode: 0,
-      exitSignal: null,
-      durationMs: 50,
-      stdout,
-      stderr: "",
-      timedOut: false,
-      noOutputTimedOut: false,
-    }),
-  );
-}
 
 /** Restore prepare-time CLI runner test dependencies after a test overrides them. */
 export function restoreCliRunnerPrepareTestDeps() {


### PR DESCRIPTION
## What Problem This Solves

The focused CLI spawn suite paid for preparation, bootstrap, and approval dependency graphs that its already-prepared execution tests do not use, making the file slow to start in CI.

## Why This Change Was Made

The suite now imports execution test support directly and mocks the approval leaf whose behavior each approval case already injects explicitly. It also removes a manually composed bootstrap duplicate and two redundant prerelease probes while preserving stable-floor, preview-line, nightly-line, unsupported-line, and normal-turn contracts. The retained preview and beta rejection rows assert their distinct policy messages, so they cannot collapse into one generic failure path.

No production code, workflow, shard, job, or worker count changes.

## User Impact

No user-visible behavior changes. Contributors and CI get faster focused CLI spawn coverage with less duplicate test maintenance.

## Evidence

Same fresh-cache command on base `2abe2e29bb46bcb97f6702eadafcdbcfebf8a960` and exact head `5a92a151bcd`:

```text
node scripts/run-vitest.mjs src/agents/cli-runner.spawn.test.ts \
  --maxWorkers=1 --reporter=verbose

                    Base       Head       Gain
Wall time           42.05s     25.04s     17.01s (40.5%)
Vitest duration     34.74s     18.39s     16.35s (47.1%)
Import duration     28.84s     13.45s     15.39s (53.4%)
Max RSS          1,143,236k   860,324k   282,912k (24.7%)
Tests                65         62
```

A second exact-head fresh-cache run was 23.92s; 62/62 tests passed in both runs.

Additional proof:

- 317/317 focused and sibling CLI runner tests passed across agents-core, agents-support, and e2e configs before the assertion-only review fix.
- The exact-head focused run proves the tightened preview/beta assertions.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs -- <changed files>` passed, including formatting, dead-export scan, core-test types, and oxlint.
- `pnpm tsgo:core` and `pnpm tsgo:core:test` passed.
- ClawSweeper found no patch defect at the previous head. Independent review found one missing preview-policy discriminator; exact head fixes it without restoring another process probe, and focused follow-up review is in progress.
