### PR TITLE
fix(ui): contain OAuth wizard modal content

### DIFF
--- a/ui/src/components/wizard-step-controls.ts
+++ b/ui/src/components/wizard-step-controls.ts
@@ -161,7 +161,12 @@ function renderContinueStep(props: WizardStepControlsProps) {
   return html`
     ${renderMessage(props)}
     ${step.externalUrl
-      ? html`<a class="btn btn--sm" href=${step.externalUrl} target="_blank" rel="noreferrer">
+      ? html`<a
+          class="btn btn--sm wizard-step__external-link"
+          href=${step.externalUrl}
+          target="_blank"
+          rel="noreferrer"
+        >
           ${t("modelSetup.wizard.openSignIn")}
         </a>`
       : nothing}

--- a/ui/src/e2e/model-setup.e2e.test.ts
+++ b/ui/src/e2e/model-setup.e2e.test.ts
@@ -284,13 +284,13 @@ suite.define(() => {
         const signInLink = page.getByRole("link", { name: "Open sign-in page" });
         await expect.poll(() => signInLink.getAttribute("href")).toBe(signInUrl);
         const wizardBody = page.locator(".model-setup-wizard__body");
-        expect(
-          await wizardBody.evaluate((element) => element.scrollWidth <= element.clientWidth),
-        ).toBe(true);
+        await expect
+          .poll(() => wizardBody.evaluate((element) => element.scrollWidth <= element.clientWidth))
+          .toBe(true);
         await page.setViewportSize({ height: 844, width: 390 });
-        expect(
-          await wizardBody.evaluate((element) => element.scrollWidth <= element.clientWidth),
-        ).toBe(true);
+        await expect
+          .poll(() => wizardBody.evaluate((element) => element.scrollWidth <= element.clientWidth))
+          .toBe(true);
         await page.getByRole("button", { name: "Continue" }).waitFor();
         await page.getByRole("button", { name: "Cancel" }).waitFor();
 

--- a/ui/src/e2e/model-setup.e2e.test.ts
+++ b/ui/src/e2e/model-setup.e2e.test.ts
@@ -182,6 +182,13 @@ suite.define(() => {
         viewport: { height: 900, width: 1280 },
       },
       async ({ page }) => {
+        const signInUrl = `https://example.com/device?${new URLSearchParams({
+          client_id: "device-code-client",
+          redirect_uri: "http://localhost:1455/auth/callback",
+          response_type: "code",
+          scope: "openid profile email offline_access",
+          state: "state-1".repeat(16),
+        })}`;
         const initialDetection = {
           candidates: [],
           manualProviders: [],
@@ -228,7 +235,8 @@ suite.define(() => {
                     id: "device-code",
                     type: "note",
                     title: "Authorize device",
-                    externalUrl: "https://example.com/device",
+                    message: `Open this URL in your local browser:\n\n${signInUrl}`,
+                    externalUrl: signInUrl,
                     deviceCode: { code: "ABCD-1234", expiresInMinutes: 14 },
                   },
                 },
@@ -274,7 +282,17 @@ suite.define(() => {
           });
         }
         const signInLink = page.getByRole("link", { name: "Open sign-in page" });
-        await expect.poll(() => signInLink.getAttribute("href")).toBe("https://example.com/device");
+        await expect.poll(() => signInLink.getAttribute("href")).toBe(signInUrl);
+        const wizardBody = page.locator(".model-setup-wizard__body");
+        expect(
+          await wizardBody.evaluate((element) => element.scrollWidth <= element.clientWidth),
+        ).toBe(true);
+        await page.setViewportSize({ height: 844, width: 390 });
+        expect(
+          await wizardBody.evaluate((element) => element.scrollWidth <= element.clientWidth),
+        ).toBe(true);
+        await page.getByRole("button", { name: "Continue" }).waitFor();
+        await page.getByRole("button", { name: "Cancel" }).waitFor();
 
         await gateway.setMethodResponse("openclaw.setup.detect", {
           ...initialDetection,

--- a/ui/src/pages/model-setup/wizard-view.ts
+++ b/ui/src/pages/model-setup/wizard-view.ts
@@ -77,6 +77,13 @@ export function renderModelSetupWizard(props: WizardViewProps): TemplateResult |
                         props.mode === "prepare" && props.state.step.type === "confirm"
                           ? t("modelSetup.wizard.continue")
                           : undefined,
+                      leadingAction: html`<button
+                        type="button"
+                        class="btn"
+                        @click=${props.onCancel}
+                      >
+                        ${t("common.cancel")}
+                      </button>`,
                       onValueChange: props.onValueChange,
                       onAnswer: props.onAnswer,
                     })}
@@ -85,9 +92,7 @@ export function renderModelSetupWizard(props: WizardViewProps): TemplateResult |
                       : nothing}
                   `}
         </div>
-        ${props.mode === "prepare" &&
-        props.state.phase === "step" &&
-        props.state.step.type === "confirm"
+        ${props.state.phase === "step"
           ? nothing
           : html`
               <div class="model-setup-wizard__footer">

--- a/ui/src/styles/model-setup.css
+++ b/ui/src/styles/model-setup.css
@@ -433,6 +433,7 @@
 
 .model-setup-wizard {
   display: grid;
+  min-width: 0;
   max-height: min(720px, calc(100dvh - 48px));
   overflow: hidden;
   border: 1px solid var(--border);
@@ -453,6 +454,8 @@
 
 .model-setup-wizard__body {
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  min-width: 0;
   gap: 14px;
   overflow: auto;
 }

--- a/ui/src/styles/wizard-step-controls.css
+++ b/ui/src/styles/wizard-step-controls.css
@@ -4,7 +4,13 @@
 }
 
 .wizard-step__message {
+  min-width: 0;
+  overflow-wrap: anywhere;
   white-space: pre-wrap;
+}
+
+.wizard-step__external-link {
+  justify-self: start;
 }
 
 .wizard-step__device-code {
@@ -70,6 +76,7 @@
 
 .wizard-step__actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users adding a provider through OAuth could see the Model Setup dialog expand past its frame when the provider returned a long authorization URL. The overflow clipped the URL and actions, while Cancel appeared in a detached footer.

## Why This Change Was Made

The shared wizard message layout now permits long unbroken content to shrink and wrap, and the external-link action remains content-sized. Model Setup also uses the existing shared leading-action seam so Cancel and Continue/Submit stay together in the active step action row.

This is AI-assisted. I inspected the implementation, reproduced the failure on the merge base, and reviewed the final branch.

## User Impact

OAuth and device-code setup dialogs remain contained at desktop and mobile widths. Long authorization URLs stay readable, the sign-in link stays compact, and the primary and cancel actions remain visible together.

## Evidence

### Interaction proof

The recording uses the real Control UI against deterministic mocked Gateway responses. It holds the initial state, performs the complete pairing transition at human-reviewable speed, and holds the verified result.

![OAuth modal fixed flow](https://raw.githubusercontent.com/Solvely-Colin/pr-proof-assets/main/openclaw-pr-122892/22c2721a6890dda19e5335935850fc1d95638853/oauth-modal-fixed-flow.gif)

### Before

`origin/main` with the same long OAuth URL fixture. The content column expands past the modal, clipping the sign-in action and Continue button; Cancel is isolated below.

![Before: overflowing OAuth modal](https://raw.githubusercontent.com/Solvely-Colin/pr-proof-assets/main/openclaw-pr-122892/22c2721a6890dda19e5335935850fc1d95638853/before.png)

### After

Reviewed head `22c2721a6890dda19e5335935850fc1d95638853`. The URL wraps within the dialog, the sign-in action is compact, and Cancel shares the action row with Continue.

![After: contained OAuth modal](https://raw.githubusercontent.com/Solvely-Colin/pr-proof-assets/main/openclaw-pr-122892/22c2721a6890dda19e5335935850fc1d95638853/after.png)

### Validation

- Regression proof: the updated browser E2E fails on `origin/main` at the desktop overflow assertion and passes on this head.
- `node scripts/run-vitest.mjs ui/src/pages/model-setup/view.test.ts` — 41 passed.
- Targeted Model Setup browser E2E — 5 passed, including polled zero-overflow assertions at desktop and 390 px widths.
- Blacksmith Testbox `tbx_01kzw9scwew16rczp1c6mc31mk`: `pnpm check:changed` (run: https://github.com/openclaw/openclaw/actions/runs/31655967430).
- `codex review --base origin/main` on exact head — no actionable defects; focused unit, E2E, style, build, visual, and merge-tree checks passed.
- Direct Codex protocol check: `../codex/codex-rs/app-server-protocol/src/protocol/v2/account.rs:132` defines ChatGPT login with structured `auth_url`, matching the UI's structured external-link path.
- Production delta: +21/−4 lines; test delta: +20/−2 lines. The production growth establishes the generic shrink/wrap invariant and reuses the existing shared wizard action-row seam.

Capture metadata and commands: https://github.com/Solvely-Colin/pr-proof-assets/tree/main/openclaw-pr-122892/22c2721a6890dda19e5335935850fc1d95638853
