### PR TITLE
fix(telegram): reject over-limit caption edits before hitting the Bot API

### DIFF
--- a/extensions/telegram/src/caption.ts
+++ b/extensions/telegram/src/caption.ts
@@ -1,7 +1,7 @@
 // Telegram plugin module implements caption behavior.
 import { countTelegramHtmlVisibleCharacters, resolveTelegramHtmlVisibleText } from "./format.js";
 
-const TELEGRAM_MAX_CAPTION_LENGTH = 1024;
+export const TELEGRAM_MAX_CAPTION_LENGTH = 1024;
 
 export function splitTelegramCaption(
   text?: string,

--- a/extensions/telegram/src/send-caption-editing.test.ts
+++ b/extensions/telegram/src/send-caption-editing.test.ts
@@ -46,4 +46,21 @@ describe("Telegram caption edits", () => {
       });
     },
   );
+
+  it("rejects over-limit captions locally without calling the Bot API", async () => {
+    loadConfig.mockReturnValue({ channels: { telegram: { botToken: "tok" } } });
+    const longCaption = "x".repeat(1500);
+
+    await expect(
+      editMessageTelegram("123456", 321, longCaption, {
+        cfg: { channels: { telegram: { botToken: "tok" } } },
+        token: "tok",
+        accountId: "default",
+        editMode: "caption",
+      }),
+    ).rejects.toThrow("Telegram captions are limited to 1024 characters (got 1500)");
+
+    expect(botApi.editMessageText).not.toHaveBeenCalled();
+    expect(botApi.editMessageCaption).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/telegram/src/send-edit.ts
+++ b/extensions/telegram/src/send-edit.ts
@@ -2,7 +2,12 @@ import type { Message } from "grammy/types";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveTelegramMessageThreadSpec } from "./bot/helpers.js";
 import type { TelegramInlineButtons } from "./button-types.js";
-import { renderTelegramHtmlText, telegramHtmlToPlainTextFallback } from "./format.js";
+import { TELEGRAM_MAX_CAPTION_LENGTH } from "./caption.js";
+import {
+  countTelegramHtmlVisibleCharacters,
+  renderTelegramHtmlText,
+  telegramHtmlToPlainTextFallback,
+} from "./format.js";
 import { buildInlineKeyboard } from "./inline-keyboard.js";
 import { isRecoverableTelegramNetworkError, isTelegramServerError } from "./network-errors.js";
 import {
@@ -215,8 +220,18 @@ async function editMessageTelegramWithContext(
     return accepted!.result;
   };
 
-  const performCaptionEdit = () =>
-    withTelegramPlainFallback({
+  const performCaptionEdit = () => {
+    // Telegram rejects captions over 1024 visible characters with
+    // "Bad Request: caption is too long". Fail locally with an actionable
+    // message instead of burning an API call that is guaranteed to fail; the
+    // send path already routes oversized captions through splitTelegramCaption.
+    const visibleCaptionLength = countTelegramHtmlVisibleCharacters(htmlText);
+    if (visibleCaptionLength > TELEGRAM_MAX_CAPTION_LENGTH || plainText.length > TELEGRAM_MAX_CAPTION_LENGTH) {
+      throw new Error(
+        `Telegram captions are limited to ${TELEGRAM_MAX_CAPTION_LENGTH} characters (got ${Math.max(visibleCaptionLength, plainText.length)}). Shorten the text or send it as a regular message instead.`,
+      );
+    }
+    return withTelegramPlainFallback({
       kind: "html",
       context: "editMessageCaption",
       plainText,
@@ -234,6 +249,7 @@ async function editMessageTelegramWithContext(
           (plainErr) => !isTelegramMessageNotModifiedError(plainErr),
         ),
     });
+  };
 
   let editedMessage: TelegramOutboundPromptContextMessage | true | undefined;
   try {


### PR DESCRIPTION
## Problem

`editMessageTelegramWithContext` (`extensions/telegram/src/send-edit.ts`) forwards arbitrarily long text to `editMessageCaption` unchanged:

```ts
const captionEditParams = { caption: htmlText, parse_mode: "HTML" };
```

Telegram caps captions at **1024 characters**. Any caption edit with more than 1024 visible characters — via the `editMessage` action with `caption`, or via `editMode: "auto"` falling back to a caption edit after `editMessageText` fails with "message has no text" — is guaranteed to fail with `Bad Request: caption is too long`, surfacing as a raw API error.

The send path already handles this exact limit: `splitTelegramCaption` (`extensions/telegram/src/caption.ts`) measures `countTelegramHtmlVisibleCharacters(renderedHtml)` against `TELEGRAM_MAX_CAPTION_LENGTH` and routes oversized captions to a follow-up text message. The edit path had no equivalent guard.

## Fix

Pre-check the caption length in `performCaptionEdit` with the same measure the send path uses (`countTelegramHtmlVisibleCharacters` vs `TELEGRAM_MAX_CAPTION_LENGTH`), and throw an actionable local error instead of burning an API call that is guaranteed to fail. The plain-text fallback caption (`plainText.length`) is checked too, since it can independently exceed the limit.

Truncating instead of throwing was considered and rejected: silently dropping content during an edit is worse than an actionable error the caller can retry with shorter text.

## Proof

Real run of the compiled dist (`openclaw@2026.8.1-beta.1`) with `channels.telegram.apiRoot` pointed at a local Bot API stub that enforces Telegram's documented 1024-character caption limit. Input: `editMessageTelegram(chatId, messageId, "x".repeat(1500), { editMode: "caption" })`.

Before the fix — the 1500-char caption is sent to the API unmodified and the edit fails with the raw API error:

```
[fake-telegram] editMessageCaption captionLength=1500 textLength=-
[telegram] editMessageCaption failed: Call to 'editMessageCaption' failed! (400: Bad Request: caption is too long)
[repro] editMessage threw: Call to 'editMessageCaption' failed! (400: Bad Request: caption is too long)
[repro] editMessageCaption requests received by API server: 1
```

After the fix — the call is rejected locally with an actionable message, no API request is made:

```
[repro] editMessage threw: Telegram captions are limited to 1024 characters (got 1500). Shorten the text or send it as a regular message instead.
[repro] editMessageCaption requests received by API server: 0
```

Regression check — a 500-char caption edit still succeeds:

```
[fake-telegram] editMessageCaption captionLength=500 textLength=-
[repro] result: {"ok":true,"messageId":"42","chatId":"123456"}
```

## Test plan

- [ ] `pnpm test` (telegram extension suites)
