### PR TITLE
test(openai): cover activation-name gating capability

### DIFF
--- a/extensions/openai/realtime-voice-provider-routing.test.ts
+++ b/extensions/openai/realtime-voice-provider-routing.test.ts
@@ -76,6 +76,7 @@ describe("OpenAI realtime voice provider routing", () => {
       supportsBargeIn: true,
       handlesInputAudioBargeIn: true,
       supportsToolCalls: true,
+      supportsActivationNameGating: true,
       supportsVideoFrames: true,
     });
   });


### PR DESCRIPTION
## What Problem This Solves

Resolves a regression where OpenAI realtime provider capability coverage on `main` rejects the intentional activation-name gating capability.

Related: https://github.com/openclaw/openclaw/pull/121894

## Why This Change Was Made

The provider already advertises `supportsActivationNameGating: true`. This updates only the exact expected capability object so the test covers the production contract; no runtime, auth, model, docs, or changelog behavior changes.

## User Impact

No runtime behavior changes. Maintainers regain a green focused routing test and explicit coverage for activation-name gating.

## Evidence

- Base `c2d8b3be4dde431a4fdb03645d2401c5d7b595e3`: focused routing test reproduced 28/29 passing; the sole exact-object mismatch was the missing expected `supportsActivationNameGating: true`.
- Head `6fa3bbbc8cdcf106e9444b3fe55500194d670097`: `node scripts/run-vitest.mjs extensions/openai/realtime-voice-provider-routing.test.ts` passes 29/29.
- `pnpm format extensions/openai/realtime-voice-provider-routing.test.ts`
- `git diff --check`
- LOC: production `+0/-0`; tests `+1/-0`; docs/generated `+0/-0`.
- Commit is signed and carries the Punchcard session trailer.

AI-assisted; reviewed and validated by the author.

Punchcard-Session: golden-meadow-cedar-dv



Punchcard-Receipt: `pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaV0Y2U1ZFNlNIMlY1U1FOR1BUMDlDWQB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl8zODZGRjVCMzQxQTI2NzQzQjJDREEzMEY0RAB3cmtfMDFLWk1RUDIxTkU5NEhUWjBUQUoxUEtUNzQAc2VzXzAxS1pNUVAzWjcySEY3OFgzRFBXWDZROU5SAGdvbGRlbi1tZWFkb3ctY2VkYXItZHYAb3BlbmNsYXcvb3BlbmNsYXcAADEyMjg5NQBmMGE4MjBiODlkNWQ2YjM2OGNkYzQwN2E5MjhkNjE2ZDkxMTQxYWNjMWI2MWNkNWE0YTIxMjdhNDljYjY5MDc5AHNpZ25pbmctdjEANWNMbXI2SWhwU2ZFMVNEQnVCVExYdTRDWVRvSEVRTkJKanR2aGtLR2FuLTZ1blFDMDdJbF8tWnlMVDNITFJIamtZRkxsVm5qZi1lVUFPY3Q4YnNqQmcAMjAyNi0wOC0xM1QwMjoyODo0OS4xMzRaAA.KSdawmgvvvelbT65CxSumBg8X2CFLW_VvUUrmAqAxWrDgJqzfQGRwVKLc-k48kP18HALGtBzBwSceXG2JwZ2AQ`
