### PR TITLE
fix(plugins): retain ownership for linked bundled plugins

### DIFF
--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -920,6 +920,118 @@ describe("discoverOpenClawPlugins", () => {
     expect(diagnostics).toStrictEqual([]);
   });
 
+  it("hydrates bundled pack ownership only from exact linked records", () => {
+    const stateDir = makeTempDir();
+    const packageRoot = path.join(stateDir, "node_modules", "openclaw");
+    const bundledRoot = path.join(packageRoot, "dist", "extensions");
+    const pluginDir = path.join(bundledRoot, "managed-pack");
+    const mismatchedSourceDir = path.join(stateDir, "mismatched-source");
+    mkdirSafe(pluginDir);
+    mkdirSafe(mismatchedSourceDir);
+    writePluginPackageManifest({
+      packageDir: pluginDir,
+      packageName: "@openclaw/managed-pack",
+      extensions: ["./one.js", "./two.js"],
+    });
+    writePluginManifest({ pluginDir, id: "managed-pack" });
+    writePluginEntry(path.join(pluginDir, "one.js"));
+    writePluginEntry(path.join(pluginDir, "two.js"));
+    const discover = (installRecords: Record<string, PluginInstallRecord>) =>
+      withOpenClawPackageArgv(packageRoot, () =>
+        discoverOpenClawPlugins({
+          env: buildDiscoveryEnvWithOverrides(stateDir, {
+            OPENCLAW_BUNDLED_PLUGINS_DIR: bundledRoot,
+          }),
+          installRecords,
+        }),
+      );
+    const matchingCandidates = (result: Awaited<ReturnType<typeof discoverOpenClawPlugins>>) =>
+      result.candidates.filter((candidate) => candidate.idHint.startsWith("managed-pack/"));
+    const linkedRecord = {
+      source: "path",
+      sourcePath: pluginDir,
+      installPath: pluginDir,
+    } satisfies PluginInstallRecord;
+
+    const linked = discover({ "package-owner": linkedRecord });
+    const linkedMatches = matchingCandidates(linked);
+    expect(linkedMatches).toHaveLength(2);
+    for (const candidate of linkedMatches) {
+      expectCandidateFields(candidate, {
+        origin: "bundled",
+        rootDir: fs.realpathSync(pluginDir),
+        installOwner: "package-owner",
+      });
+    }
+    expect(linked.diagnostics).toStrictEqual([]);
+
+    const ambiguousMatches = matchingCandidates(
+      discover({ "owner-one": linkedRecord, "owner-two": linkedRecord }),
+    );
+    expect(ambiguousMatches).toHaveLength(2);
+    for (const candidate of ambiguousMatches) {
+      expectCandidateFields(candidate, {
+        origin: "bundled",
+        installOwner: undefined,
+        installOwnerAmbiguous: true,
+      });
+    }
+
+    for (const source of ["npm", "git", "archive", "marketplace"] as const) {
+      const matches = matchingCandidates(
+        discover({ owner: { source, sourcePath: pluginDir, installPath: pluginDir } }),
+      );
+      expect(matches).toHaveLength(2);
+      for (const candidate of matches) {
+        expectCandidateFields(candidate, { origin: "bundled", installOwner: undefined });
+      }
+    }
+
+    const mismatchedMatches = matchingCandidates(
+      discover({
+        owner: {
+          source: "path",
+          sourcePath: mismatchedSourceDir,
+          installPath: pluginDir,
+        },
+      }),
+    );
+    expect(mismatchedMatches).toHaveLength(2);
+    for (const candidate of mismatchedMatches) {
+      expectCandidateFields(candidate, { origin: "bundled", installOwner: undefined });
+    }
+  });
+
+  it.runIf(canCreateDirectorySymlinks)("hydrates bundled ownership through a path alias", () => {
+    const stateDir = makeTempDir();
+    const packageRoot = path.join(stateDir, "node_modules", "openclaw");
+    const bundledRoot = path.join(packageRoot, "dist", "extensions");
+    const pluginDir = path.join(bundledRoot, "linked-bundled");
+    const aliasDir = path.join(stateDir, "linked-bundled-alias");
+    createPackagePluginWithEntry({
+      packageDir: pluginDir,
+      packageName: "@openclaw/linked-bundled",
+      pluginId: "linked-bundled",
+      entryPath: "index.js",
+    });
+    symlinkDirectory(pluginDir, aliasDir);
+
+    const { candidates } = withOpenClawPackageArgv(packageRoot, () =>
+      discoverOpenClawPlugins({
+        env: buildDiscoveryEnvWithOverrides(stateDir, {
+          OPENCLAW_BUNDLED_PLUGINS_DIR: bundledRoot,
+        }),
+        installRecords: {
+          "package-owner": { source: "path", sourcePath: aliasDir, installPath: pluginDir },
+        },
+      }),
+    );
+
+    const matches = candidates.filter((candidate) => candidate.idHint === "linked-bundled");
+    expect(matches).toHaveLength(1);
+    expectCandidateFields(matches[0], { origin: "bundled", installOwner: "package-owner" });
+  });
+
   it("loads package extension packs", async () => {
     const stateDir = makeTempDir();
     const globalExt = path.join(stateDir, "extensions", "pack");

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -391,6 +391,19 @@ function createDiscoveryResult(): PluginDiscoveryResult {
   };
 }
 
+function mergePluginCandidateInstallOwner(
+  target: PluginCandidate,
+  installOwner: string | undefined,
+  installOwnerAmbiguous = false,
+): void {
+  const targetOwner = resolvePluginCandidateInstallOwner(target);
+  const ambiguous =
+    isPluginCandidateInstallOwnerAmbiguous(target) ||
+    installOwnerAmbiguous ||
+    Boolean(targetOwner && installOwner && targetOwner !== installOwner);
+  recordPluginCandidateInstallOwner(target, ambiguous ? undefined : installOwner, ambiguous);
+}
+
 function mergeDiscoveryResult(
   target: PluginDiscoveryResult,
   source: PluginDiscoveryResult,
@@ -404,18 +417,11 @@ function mergeDiscoveryResult(
     const key = safeRealpathSync(candidate.source, realpathCache) ?? path.resolve(candidate.source);
     const existing = candidatesBySource.get(key);
     if (existing) {
-      const existingOwner = resolvePluginCandidateInstallOwner(existing);
-      const candidateOwner = resolvePluginCandidateInstallOwner(candidate);
-      const ownerConflict = existingOwner && candidateOwner && existingOwner !== candidateOwner;
-      if (
-        isPluginCandidateInstallOwnerAmbiguous(existing) ||
-        isPluginCandidateInstallOwnerAmbiguous(candidate) ||
-        ownerConflict
-      ) {
-        recordPluginCandidateInstallOwner(existing, undefined, true);
-      } else if (candidateOwner) {
-        recordPluginCandidateInstallOwner(existing, candidateOwner);
-      }
+      mergePluginCandidateInstallOwner(
+        existing,
+        resolvePluginCandidateInstallOwner(candidate),
+        isPluginCandidateInstallOwnerAmbiguous(candidate),
+      );
       continue;
     }
     candidatesBySource.set(key, candidate);
@@ -493,27 +499,29 @@ type InstalledPluginRecordPath = {
   installOwnerAmbiguous?: true;
 };
 
-function isLinkedLocalPluginRecord(params: {
+function resolveLinkedLocalPluginRecordPath(params: {
   record: PluginInstallRecord;
   env: NodeJS.ProcessEnv;
   realpathCache: Map<string, string>;
-}): boolean {
-  if (params.record.source !== "path") {
-    return false;
-  }
+}): string | undefined {
   if (
+    params.record.source !== "path" ||
     typeof params.record.sourcePath !== "string" ||
     !params.record.sourcePath.trim() ||
     typeof params.record.installPath !== "string" ||
     !params.record.installPath.trim()
   ) {
-    return false;
+    return undefined;
   }
-  return resolvesToSameDirectory(
+  const sourcePath = safeRealpathSync(
     resolveUserPath(params.record.sourcePath, params.env),
+    params.realpathCache,
+  );
+  const installPath = safeRealpathSync(
     resolveUserPath(params.record.installPath, params.env),
     params.realpathCache,
   );
+  return sourcePath && sourcePath === installPath ? installPath : undefined;
 }
 
 function collectInstalledPluginRecordPaths(
@@ -521,6 +529,7 @@ function collectInstalledPluginRecordPaths(
   env: NodeJS.ProcessEnv,
   realpathCache: Map<string, string>,
   diagnostics: PluginDiagnostic[],
+  candidates: PluginCandidate[],
 ): InstalledPluginRecordPath[] {
   const paths: InstalledPluginRecordPath[] = [];
   const byPath = new Map<string, InstalledPluginRecordPath>();
@@ -539,7 +548,21 @@ function collectInstalledPluginRecordPaths(
       continue;
     }
     const pathKey = safeRealpathSync(resolved, realpathCache) ?? path.resolve(resolved);
-    const requireBuiltRuntimeEntry = !isLinkedLocalPluginRecord({ record, env, realpathCache });
+    const linkedPath = resolveLinkedLocalPluginRecordPath({
+      record,
+      env,
+      realpathCache,
+    });
+    if (linkedPath) {
+      for (const candidate of candidates) {
+        if (
+          safeRealpathSync(candidate.packageDir ?? candidate.rootDir, realpathCache) === linkedPath
+        ) {
+          mergePluginCandidateInstallOwner(candidate, installOwner);
+        }
+      }
+    }
+    const requireBuiltRuntimeEntry = !linkedPath;
     const existing = byPath.get(pathKey);
     if (existing) {
       existing.requireBuiltRuntimeEntry ||= requireBuiltRuntimeEntry;
@@ -1641,6 +1664,7 @@ export function discoverOpenClawPlugins(params: {
           env,
           realpathCache,
           result.diagnostics,
+          result.candidates,
         );
         const installedPluginDirKeys = collectManagedPluginDirKeys(
           installedPaths.map((installedPath) => installedPath.path),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where linked bundled plugins could lose their authoritative install owner during discovery, causing lifecycle operations to fail closed even though the exact linked install record was present. This is the failure behind the bundled plugin lanes in Full Release Validation run 31633787765.

## Why This Change Was Made

Before shared candidate suppression, discovery now hydrates an existing bundled candidate only when a `path` install record has non-empty source and install paths, both canonical paths are equal, and that path exactly matches the candidate package root. The same owner-merge helper handles hydration and final candidate merging, so conflicting records remain ambiguous and fail closed.

Multi-entry packs hydrate every matching entry. npm, git, archive, marketplace, non-linked, and mismatched path records cannot claim bundled candidates. Candidate source, root, count, and `bundled` origin remain unchanged.

No persistence, mutation resolution, ownership guard, policy, fallback, compatibility, SQLite, release, or publishing behavior changes.

## User Impact

Operators can keep managing exactly linked bundled plugins without weakening ownership checks for other install sources.

Release-note context: preserve lifecycle ownership when a bundled plugin is also the target of an exact linked path install.

## Evidence

Head: `df2cc2d44c28973b7d6c44f63c3fe3a2db0d2237`

- Focused discovery suite: 110 passed.
- Install persistence, manifest registry, installed manifest registry, and uninstall ownership siblings: 155 passed.
- Production LOC: +44/-20, net +24. Tests: +112/-0.
- `git diff --check`: passed.
- Exact-head `checks-node-agentic-plugins`: stopped after a new broad failure signature appeared in `status.test.ts` (26 failures), `plugin-registry.test.ts`, installed-index suites, and `cli.test.ts` (17 failures).
- The prior campaign had installed-index/registry failures, but `status.test.ts` and `cli.test.ts` were green there. Per the validation stop rule, no Docker bundled lane, all-lane run, local review, or merge gate was dispatched.

This PR is intentionally draft until the new whole-shard regression is resolved within the existing two-file scope.
