### PR TITLE
test(commands): stub plugin metadata snapshot in onboard-inference test

### DIFF
--- a/src/commands/onboard-inference.test.ts
+++ b/src/commands/onboard-inference.test.ts
@@ -1,11 +1,60 @@
 // Inference backend detection tests cover the documented ladder and login-awareness.
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it, vi } from "vitest";
 import type { LocalCommandProbe } from "../system-agent/probes.js";
 import {
   ANTHROPIC_API_DEFAULT_MODEL_REF,
   CLAUDE_CLI_DEFAULT_MODEL_REF,
   detectInferenceBackends,
 } from "./onboard-inference.js";
+
+const emptyPluginMetadataSnapshot = vi.hoisted(() => ({
+  policyHash: "onboard-inference-test-empty-plugin-policy",
+  configFingerprint: "onboard-inference-test-empty-plugin-metadata",
+  index: {
+    version: 1,
+    hostContractVersion: "test",
+    compatRegistryVersion: "test",
+    migrationVersion: 1,
+    policyHash: "onboard-inference-test-empty-plugin-policy",
+    generatedAtMs: 0,
+    installRecords: {},
+    plugins: [],
+    diagnostics: [],
+  },
+  registryDiagnostics: [],
+  manifestRegistry: { plugins: [], diagnostics: [] },
+  plugins: [],
+  diagnostics: [],
+  byPluginId: new Map(),
+  normalizePluginId: (pluginId: string) => pluginId,
+  owners: {
+    channels: new Map(),
+    channelConfigs: new Map(),
+    providers: new Map(),
+    modelCatalogProviders: new Map(),
+    cliBackends: new Map(),
+    setupProviders: new Map(),
+    commandAliases: new Map(),
+    contracts: new Map(),
+  },
+  metrics: {
+    registrySnapshotMs: 0,
+    manifestRegistryMs: 0,
+    ownerMapsMs: 0,
+    totalMs: 0,
+    indexPluginCount: 0,
+    manifestPluginCount: 0,
+  },
+}));
+
+vi.mock("../plugins/current-plugin-metadata-snapshot.js", () => ({
+  getCurrentPluginMetadataSnapshot: () => emptyPluginMetadataSnapshot,
+}));
+
+afterAll(() => {
+  vi.doUnmock("../plugins/current-plugin-metadata-snapshot.js");
+  vi.resetModules();
+});
 
 function probeDeps(found: Record<string, boolean>) {
   return async (command: string): Promise<LocalCommandProbe> => ({


### PR DESCRIPTION
## What Problem This Solves

`src/commands/onboard-inference.test.ts` cold-discovered every bundled plugin manifest when the configured-model cases resolved model IDs without a current plugin metadata snapshot. That made one test account for nearly all of the file's runtime.

## Why This Change Was Made

The test now follows the existing model-selection mock pattern and supplies a complete empty plugin metadata snapshot. This keeps the assertions on inference-backend ordering while avoiding production plugin discovery. The mock is removed and the module cache reset after the file so non-isolated runs remain safe.

## User Impact

No production behavior changes. The 33-test file now completes below its 3-second target instead of spending about 19 seconds in cold manifest discovery.

## Evidence

- Before: `time node scripts/run-vitest.mjs src/commands/onboard-inference.test.ts` passed 33/33 tests; Vitest duration was 26.72s, including 18.83s test execution. Shell `real` was 194.45s because the command queued behind unrelated worktree tests.
- After: `time node scripts/run-vitest.mjs src/commands/onboard-inference.test.ts` passed 33/33 tests; Vitest duration was 2.57s, including 67ms test execution. Shell `real` was 56.21s because the command again queued behind unrelated worktree tests.
- `node scripts/check-changed.mjs -- src/commands/onboard-inference.test.ts` passed on Blacksmith Testbox, including formatting, core-test typecheck, lint, and repository guards.
- `git diff --check` passed.
