### PR TITLE
fix(zalo): keep packaged setup wizard loadable

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -211,6 +211,8 @@ const rootEntries = [
 const bundledPluginEntries = [
   "index.ts!",
   "setup-entry.ts!",
+  // Setup APIs may lazy-load this top-level package artifact by string specifier.
+  "setup-surface.ts!",
   // Core resolves these public plugin artifacts by basename rather than by a
   // static import from the plugin entry module.
   "*-api.ts!",

--- a/extensions/zalo/setup-api.ts
+++ b/extensions/zalo/setup-api.ts
@@ -1,7 +1,7 @@
 // Zalo API module exposes the plugin public contract.
 import { loadBundledEntryExportSync } from "openclaw/plugin-sdk/channel-entry-contract";
 
-type SetupSurfaceModule = typeof import("./src/setup-surface.js");
+type SetupSurfaceModule = typeof import("./setup-surface.js");
 
 function createLazyObjectValue<T extends object>(load: () => T): T {
   return new Proxy({} as T, {
@@ -23,7 +23,7 @@ function createLazyObjectValue<T extends object>(load: () => T): T {
 
 function loadSetupSurfaceModule(): SetupSurfaceModule {
   return loadBundledEntryExportSync<SetupSurfaceModule>(import.meta.url, {
-    specifier: "./src/setup-surface.js",
+    specifier: "./setup-surface.js",
   });
 }
 

--- a/extensions/zalo/setup-surface.ts
+++ b/extensions/zalo/setup-surface.ts
@@ -1,0 +1,2 @@
+// Zalo API module exposes the plugin public contract.
+export { zaloSetupAdapter, zaloSetupWizard } from "./src/setup-surface.js";

--- a/test/plugin-npm-runtime-build.test.ts
+++ b/test/plugin-npm-runtime-build.test.ts
@@ -1,4 +1,5 @@
 // Plugin npm runtime build tests validate plugin runtime package builds.
+import { spawnSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -10,11 +11,19 @@ import {
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  resolvePluginNpmCommand,
+  withAugmentedPluginNpmManifestForPackage,
+} from "../scripts/lib/plugin-npm-package-manifest.mts";
+import {
   buildPluginNpmRuntime,
   listMissingPluginNpmRuntimeHostExports,
   listPublishablePluginPackageDirs,
   resolvePluginNpmRuntimeBuildPlan,
 } from "../scripts/lib/plugin-npm-runtime-build.mts";
+import {
+  createPluginModuleLoaderCache,
+  getCachedPluginSourceModuleLoader,
+} from "../src/plugins/plugin-module-loader-cache.js";
 import { useAutoCleanupTempDirTracker } from "./helpers/temp-dir.js";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
@@ -218,6 +227,74 @@ describe("plugin npm runtime build planning", () => {
     );
     expect(plan.runtimeSetupEntry).toBe("./dist/setup-api.js");
     expect(plan.runtimeBuildOutputs).toContain("./dist/setup-api.js");
+  });
+
+  it("packs the Zalo public setup API with its lazy runtime surface", async () => {
+    const packageDir = path.join(repoRoot, "extensions", "zalo");
+    const plan = expectPluginNpmRuntimeBuildPlan(
+      await buildPluginNpmRuntime({
+        repoRoot,
+        packageDir,
+        logLevel: "silent",
+      }),
+    );
+    const consumerDir = tempDirs.make("openclaw-zalo-packed-setup-");
+    let packedFiles: string[] = [];
+    let setupApiPath = "";
+
+    withAugmentedPluginNpmManifestForPackage(
+      { repoRoot, packageDir, bundleDependencies: false },
+      () => {
+        const invocation = resolvePluginNpmCommand([
+          "pack",
+          "--json",
+          "--ignore-scripts",
+          "--pack-destination",
+          consumerDir,
+        ]);
+        const pack = spawnSync(invocation.command, invocation.args, {
+          cwd: packageDir,
+          encoding: "utf8",
+          ...(invocation.env ? { env: invocation.env } : {}),
+          ...(invocation.shell !== undefined ? { shell: invocation.shell } : {}),
+          stdio: ["ignore", "pipe", "pipe"],
+          ...(invocation.windowsVerbatimArguments !== undefined
+            ? { windowsVerbatimArguments: invocation.windowsVerbatimArguments }
+            : {}),
+        });
+        expect(pack.status, pack.stderr).toBe(0);
+        const [packedPackage] = JSON.parse(pack.stdout) as [
+          { filename: string; files: Array<{ path: string }> },
+        ];
+        packedFiles = packedPackage.files.map((file) => file.path);
+        const extract = spawnSync(
+          "tar",
+          ["-xzf", path.join(consumerDir, packedPackage.filename), "-C", consumerDir],
+          {
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "pipe"],
+          },
+        );
+        expect(extract.status, extract.stderr).toBe(0);
+        setupApiPath = path.join(consumerDir, "package", "dist", "setup-api.js");
+      },
+    );
+
+    expect(plan.runtimeBuildOutputs).toContain("./dist/setup-api.js");
+    const loadSetupApi = getCachedPluginSourceModuleLoader({
+      cache: createPluginModuleLoaderCache(),
+      modulePath: setupApiPath,
+      importerUrl: import.meta.url,
+      devSourceRoot: repoRoot,
+    });
+    const setupApi = loadSetupApi(setupApiPath) as {
+      zaloSetupWizard: { channel: string };
+    };
+    expect(setupApi.zaloSetupWizard.channel).toBe("zalo");
+    expect(plan.runtimeBuildOutputs).toContain("./dist/setup-surface.js");
+    expect(plan.runtimeBuildOutputs).not.toContain("./dist/src/setup-surface.js");
+    expect(packedFiles).toContain("dist/setup-surface.js");
+    expect(packedFiles).not.toContain("dist/src/setup-surface.js");
   });
 
   it("keeps published Codex runtime imports resolvable from the host package", async () => {


### PR DESCRIPTION
Closes #122801

## What Problem This Solves

Fixes an issue where operators installing the official Zalo plugin could complete installation but have the setup wizard fail at first access because its public setup API referenced a runtime path that the package build did not promise.

## Why This Change Was Made

The public setup API now lazy-loads a stable top-level package artifact. That artifact bundles the existing private setup implementation, so internal callers keep one source of truth while the published contract no longer depends on a nested build chunk. Knip now models the same generic top-level setup-surface convention instead of suppressing Zalo exports or adding a fake static import.

## User Impact

Packaged Zalo installs can load the setup wizard reliably. Source-checkout behavior and the private setup implementation remain unchanged.

## Evidence

- Tests-first reproduction failed at lazy property access with `ENOENT` for the packed `dist/src/setup-surface.js` path.
- Packed package regression builds Zalo, runs `npm pack`, extracts the tarball, loads `dist/setup-api.js` through the production module loader, and verifies `zaloSetupWizard.channel === "zalo"`.
- Package contract: `dist/setup-api.js` and `dist/setup-surface.js` are present; no `dist/src/setup-surface.js` contract is required.
- Post-rebase focused proof: package/runtime build tests 11/11 and Zalo setup/runtime tests 9/9.
- Post-rebase deadcode proof: production, full-tree, and script unused-export scans all passed with zero findings.
- Hosted changed gate passed on Testbox `tbx_01kzwb4zeghdw0e96nk7wc0h2j`: typecheck, lint, plugin boundaries, SDK API contract, deadcode, import cycles, and all selected guards green. Actions receipt: https://github.com/openclaw/openclaw/actions/runs/31657257118
- Earlier full Testbox build plus package/Zalo tests passed on run https://github.com/openclaw/openclaw/actions/runs/31649887554.
- Final integrated Codex autoreview: clean, no findings, confidence 0.99.

Production delta: +2 lines for the stable public artifact; tooling: +2 lines for the generic Knip entry; tests: +77 lines for the packed installed-layout regression.
