### PR TITLE
docs: document session and transcript fetching in the openclaw-debugging skill

### DIFF
--- a/.agents/skills/openclaw-debugging/SKILL.md
+++ b/.agents/skills/openclaw-debugging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openclaw-debugging
-description: Debug OpenClaw model, provider, tool-surface, code-mode, streaming, and live/Crabbox behavior by choosing the right logs, probes, and proof path before changing code.
+description: Debug OpenClaw model, provider, tool-surface, code-mode, streaming, and live/Crabbox behavior by choosing the right logs, probes, and proof path before changing code, including fetching stored sessions, transcripts, and attachments as evidence.
 ---
 
 # OpenClaw Debugging
@@ -76,6 +76,56 @@ openclaw logs --follow
 - **Live keys:** use the configured secret workflow for missing provider keys
   before saying live proof is blocked. Env checks are presence-only; never print
   secrets.
+
+## Fetching Sessions and Transcripts
+
+Use these paths when a bug report references a chat session and you need the
+actual transcript, sender attribution, or attachments as evidence.
+
+CLI first (needs a configured install; safe against a live gateway):
+
+```bash
+openclaw sessions list --agent <agentId> --json
+openclaw sessions tail
+openclaw sessions export-trajectory
+```
+
+Docs: `docs/reference/database-schemas.md` for the store layout,
+https://docs.openclaw.ai/cli/sessions for the CLI.
+
+Raw store (when the CLI is unavailable, e.g. inspecting a remote host over
+SSH, or you need event-level detail):
+
+- Per-agent data plane: `~/.openclaw/agents/<agentId>/agent/openclaw-agent.sqlite`.
+  Canonical schema: `src/state/openclaw-agent-schema.sql`.
+- Web chat URLs end in a session-id fragment: `/chat/<agentId>/<slug>-<hex>`.
+  Resolve it in `session_nodes`: `session_key LIKE '%<hex>%'` →
+  `current_session_id`, `display_name`. Key shape is
+  `agent:<agentId>:<surface>:<uuid>`; subagent sessions use surface `subagent`.
+- Transcript: `transcript_events` (`session_id`, `seq`, `event_json`).
+  `event_json.message` has `role` (`user`/`assistant`/`toolResult`) and
+  `content` (string, or parts of type `text`/`toolCall`/`image`).
+- Sender provenance: real user messages carry `message.__openclaw`
+  (`senderId`, `senderName`, `senderIsOwner`); runtime-synthesized inputs do
+  not. Use this to separate operator-authored text from injected prompts.
+- Full-text search across transcripts: `session_transcript_fts`.
+- Attachments: `media://inbound/<file>` URLs map to
+  `~/.openclaw/media/inbound/<file>`.
+
+Hosts without a `sqlite3` binary still have Node: `node:sqlite` needs no
+dependencies.
+
+```bash
+node -e 'const {DatabaseSync}=require("node:sqlite");
+const db=new DatabaseSync(process.argv[1],{readOnly:true});
+console.log(JSON.stringify(db.prepare(
+  "SELECT seq,event_json FROM transcript_events WHERE session_id=? ORDER BY seq"
+).all(process.argv[2])))' <db-path> <session-id>
+```
+
+Always open live stores `readOnly: true`; never write a running gateway's
+state (see Validation rules in the root `AGENTS.md`). For realistic-data
+work, copy the DB into a dev state dir first.
 
 ## Code Pointers
 


### PR DESCRIPTION
## What Problem This Solves

Agents debugging OpenClaw from a bug report that references a chat session had no documented path from a chat URL to the stored transcript, sender attribution, or attachments. That knowledge lived in individual maintainers' heads, so session-evidence lookups kept being re-derived (or skipped).

## Why This Change Was Made

Extends the existing `openclaw-debugging` skill with a "Fetching Sessions and Transcripts" section: the `openclaw sessions` CLI first, then the per-agent SQLite data plane (resolving `/chat/<agentId>/<slug>-<hex>` URL fragments via `session_nodes`, the `transcript_events` shape, `__openclaw` sender provenance for separating operator-authored from runtime-synthesized messages, `session_transcript_fts`, and `media://inbound` mapping), plus a dependency-free `node:sqlite` read-only recipe for hosts without a `sqlite3` binary. Read-only-against-live-gateway rules are restated inline.

## User Impact

No runtime change. Agents and maintainers get a documented, safe evidence path for session-referenced bug reports.

## Evidence

Docs-only diff (+51/−1 on one SKILL.md). `git diff --check` clean; `oxfmt --check` clean. The recipe was exercised for real while triaging a session-referenced bug batch: URL fragment → `session_nodes` → `transcript_events` → media files, on a host without `sqlite3`.
