### PR TITLE
fix: new-session image attachments can lack a preview when object URLs are unavailable

### DIFF
--- a/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
@@ -143,6 +143,29 @@ suite.define(() => {
     });
   });
 
+  it("previews and removes a picked image without object URL support", async () => {
+    await withNewSessionPage(async (page) => {
+      await page.addInitScript(() => {
+        Object.defineProperty(URL, "createObjectURL", { configurable: true, value: undefined });
+      });
+      await installMockGateway(page);
+      await page.goto(`${suite.server.baseUrl}new`);
+
+      await page
+        .locator(".agent-chat__photo-input")
+        .setInputFiles(path.join(process.cwd(), "ui/public/favicon-32.png"));
+
+      const attachment = page.locator(".chat-attachment-thumb");
+      const preview = attachment.locator('img[alt="Attachment preview"]');
+      await preview.waitFor({ state: "visible" });
+      await expect.poll(() => preview.getAttribute("src")).toMatch(/^data:image\/png;base64,/u);
+      await captureUiProof(page, "new-session-picked-image-preview.png");
+      await page.getByRole("button", { name: "Remove attachment" }).click();
+      await expect.poll(() => attachment.count()).toBe(0);
+      await captureUiProof(page, "new-session-picked-image-removed.png");
+    });
+  });
+
   it("shows the initial prompt while the newly created session is still running", async () => {
     await withNewSessionPage(async (page) => {
       const sessionKey = "agent:main:visible-initial-prompt";

--- a/ui/src/pages/chat/attachment-payload-store.ts
+++ b/ui/src/pages/chat/attachment-payload-store.ts
@@ -1,4 +1,3 @@
-// Control UI chat module implements attachment payload store behavior.
 import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
 
 type AttachmentPayload = {
@@ -45,10 +44,10 @@ export function getChatAttachmentDataUrl(attachment: ChatAttachment): string | n
   return attachment.dataUrl ?? payloads.get(attachment.id)?.dataUrl ?? null;
 }
 
+// Stored data URLs keep previews available when this browser cannot create object URLs.
 export function getChatAttachmentPreviewUrl(attachment: ChatAttachment): string | null {
-  return (
-    attachment.previewUrl ?? payloads.get(attachment.id)?.previewUrl ?? attachment.dataUrl ?? null
-  );
+  const storedPreview = payloads.get(attachment.id)?.previewUrl;
+  return attachment.previewUrl ?? storedPreview ?? getChatAttachmentDataUrl(attachment);
 }
 
 function cloneChatAttachmentMetadata(attachment: ChatAttachment): ChatAttachment {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an image added to the new-session composer could show no thumbnail preview even though the attachment itself was present and submitted correctly. The in-session composer showed a preview for the same file.

## Why This Change Was Made

`registerChatAttachmentPayload()` stores the FileReader data URL, but `getChatAttachmentPreviewUrl()` never fell back to that stored payload when `URL.createObjectURL` was unavailable or failed — it only consulted the attachment's own fields. The fix routes the preview lookup through the canonical `getChatAttachmentDataUrl()` so payload bytes always yield a preview. This repairs the shared payload owner used by both composers rather than adding new-session-only state.

## User Impact

Images attached in the new-session composer reliably show the same thumbnail preview (and removal control) as in-session attachments.

## Evidence

- New E2E (`ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts`): file-picker selection → visible thumbnail → removal, run with `URL.createObjectURL` disabled. Fails pre-fix (no thumbnail ever appears), passes post-fix. Visual proof captured via the mocked-Gateway harness.
- Full focused file: 12/12 passed.
- Note: with object URLs available, the picker path already previewed correctly in the harness, so the exact reporter-environment trigger remains unconfirmed; the proven fallback hole is fixed and the previously untested file-picker + removal path now has coverage.
- Production LOC net −1 (tests +23).
