### PR TITLE
fix: new-session default model shows unresolved alias and hides thinking levels

### DIFF
--- a/src/gateway/session-utils-store.ts
+++ b/src/gateway/session-utils-store.ts
@@ -11,7 +11,6 @@ import { resolveModelAgentRuntimeMetadata } from "../agents/agent-runtime-metada
 import {
   listAgentEntries,
   listAgentIds,
-  resolveAgentEffectiveModelPrimary,
   resolveAgentModelFallbacksOverride,
   resolveAgentWorkspaceDir,
 } from "../agents/agent-scope.js";
@@ -283,22 +282,18 @@ function normalizeFallbackList(values: readonly string[]): string[] {
 function resolveGatewayAgentModel(
   cfg: OpenClawConfig,
   agentId: string,
-): GatewayAgentRow["model"] | undefined {
+  resolvedModel: ReturnType<typeof resolveDefaultModelForAgent>,
+): NonNullable<GatewayAgentRow["model"]> {
   // Agent rows expose model identity to clients; credential-profile binding stays in
   // canonical config and is consumed only by execution-time model selection.
-  const primary = splitTrailingAuthProfile(
-    resolveAgentEffectiveModelPrimary(cfg, agentId) ?? "",
-  ).model;
+  const primary = `${resolvedModel.provider}/${resolvedModel.model}`;
   const fallbackOverride = resolveAgentModelFallbacksOverride(cfg, agentId);
   const defaultFallbacks = resolveAgentModelFallbackValues(cfg.agents?.defaults?.model);
   const fallbacks = normalizeFallbackList(
     (fallbackOverride ?? defaultFallbacks).map((value) => splitTrailingAuthProfile(value).model),
   );
-  if (!primary && fallbacks.length === 0) {
-    return undefined;
-  }
   return {
-    ...(primary ? { primary } : {}),
+    primary,
     ...(fallbacks.length > 0 ? { fallbacks } : {}),
   };
 }
@@ -344,8 +339,8 @@ export function listAgentsForGateway(
   const agents = roster.map((entry) => {
     const { id } = entry;
     const meta = configuredById.get(id);
-    const model = resolveGatewayAgentModel(cfg, id);
     const resolvedModel = resolveDefaultModelForAgent({ cfg, agentId: id });
+    const model = resolveGatewayAgentModel(cfg, id, resolvedModel);
     const sessionKey = resolveAgentMainSessionKey({ cfg, agentId: id });
     const agentRuntime = resolveModelAgentRuntimeMetadata({
       cfg,
@@ -382,7 +377,7 @@ export function listAgentsForGateway(
         thinkingOptions: thinkingProfile.thinkingLevels.map((level) => level.label),
         thinkingDefault: thinkingProfile.thinkingDefault,
       },
-      model ? { model } : {},
+      { model },
     );
   });
   return {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -3033,6 +3033,55 @@ describe("gateway session utils", () => {
     expect(agent?.thinkingDefault).toBe("medium");
     expect(agent?.thinkingLevels?.map((level) => level.id)).toContain("medium");
   });
+
+  describe("listAgentsForGateway resolved model projection", () => {
+    test("publishes one resolved identity for model, runtime, and thinking capabilities", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            model: {
+              primary: "clawrouter/openai/gpt-5.6",
+              fallbacks: ["openai/gpt-5.6-luna"],
+            },
+            models: {
+              "openai/gpt-5.6-sol": {
+                alias: "clawrouter/openai/gpt-5.6",
+                agentRuntime: { id: "codex" },
+              },
+            },
+          },
+          list: [{ id: "main", default: true }],
+        },
+      } as OpenClawConfig;
+      const catalog = [
+        {
+          provider: "openai",
+          id: "gpt-5.6-sol",
+          name: "GPT-5.6 Sol",
+          reasoning: true,
+        },
+      ];
+
+      const agent = listAgentsForGateway(cfg, catalog).agents[0];
+
+      expect(agent).toMatchObject({
+        model: {
+          primary: "openai/gpt-5.6-sol",
+          fallbacks: ["openai/gpt-5.6-luna"],
+        },
+        agentRuntime: { id: "codex", source: "model" },
+        thinkingDefault: "medium",
+      });
+      expect(agent?.thinkingLevels?.map((level) => level.id)).toEqual([
+        "off",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+      ]);
+      expect(agent?.thinkingOptions).toEqual(agent?.thinkingLevels?.map((level) => level.label));
+    });
+  });
 });
 
 describe("listSessionsFromStore selected model display", () => {

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -256,12 +256,22 @@ describe("new-session model runtime", () => {
       model: { primary: "openai/gpt-5.6-sol" },
       thinkingDefault: "high",
     });
+    expect(
+      container.querySelector(
+        '[data-chat-model-option="openai/gpt-5.6-sol"][data-chat-model-default="true"]',
+      )?.textContent,
+    ).toContain("GPT-5.6 Sol");
     expect(container.querySelector('[data-chat-model-select="true"]')?.textContent).toContain(
       "GPT-5.6 Sol",
     );
-    expect(container.querySelector('[data-chat-thinking-select="true"]')?.textContent).toContain(
-      "High",
-    );
+    const thinkingPicker = container.querySelector('[data-chat-thinking-select="true"]');
+    expect(thinkingPicker).not.toBeNull();
+    expect(thinkingPicker?.textContent).toContain("High");
+    expect(
+      container
+        .querySelector('[data-chat-thinking-slider="true"]')
+        ?.getAttribute("data-chat-thinking-values"),
+    ).toContain("high");
     expect(control.selected).toBe("");
     expect(control.thinkingLevel).toBe("");
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the new-session model picker's default entry displayed an unresolved model alias (e.g. a router-prefixed family ref) instead of the actual resolved default, and selecting that default hid the thinking-level picker even though the resolved model supports thinking levels. Explicitly selecting a sibling model showed the picker correctly.

## Why This Change Was Made

`agents.list` had a projection split: `GatewayAgentRow.model` was built from the raw configured primary while runtime and thinking metadata were derived from the resolved model — so displayed identity and capabilities described different models. `listAgentsForGateway()` now publishes the canonical resolved provider/model as the primary (same `resolvedModel` already feeding runtime/thinking metadata), preserving configured fallbacks. No UI aliasing, no hardcoded model ids.

## User Impact

The default entry in new-session (and any `agents.list` consumer) names the model that will actually run, and its capability surfaces (thinking levels) match that identity.

## Evidence

- Gateway regression: with a raw configured primary alias, the agent row previously published the alias; now publishes the resolved identity. Failed pre-fix, passes post-fix (`src/gateway/session-utils.test.ts`).
- Gateway suite 157/157; new-session UI 32/32; agent display compatibility 26/26.
- Codex runtime contracts verified directly in the sibling checkout (`codex-rs/app-server-protocol/.../model.rs`, `models-manager/models.json`).
- Compatibility: `agents.list[].model.primary` now carries resolved identity instead of the authored alias; Control UI settings, chat/new-session, TUI, and SDK pass-through consumers were checked.
- Production LOC net −5 (tests +59).
