### PR TITLE
fix: internal recovery prompts appear as operator-authored messages

### DIFF
--- a/src/agents/embedded-agent-runner/run.incomplete-turn.reasoning-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.reasoning-recovery.test.ts
@@ -213,7 +213,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     const secondCall = runAttemptCall(1);
     expect(secondCall.prompt).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
-    expect(secondCall.suppressNextUserMessagePersistence).toBe(false);
+    expect(secondCall.suppressNextUserMessagePersistence).toBe(true);
     expect(secondCall.skipPreparedUserTurnMessage).toBe(true);
     expectWarnMessageWith("empty response detected");
   });

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.settled-tool-continuation.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.settled-tool-continuation.test.ts
@@ -534,12 +534,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(runAttemptCall(1)).toMatchObject({
       prompt: REASONING_ONLY_RETRY_INSTRUCTION,
       skipPreparedUserTurnMessage: true,
-      suppressNextUserMessagePersistence: false,
+      suppressNextUserMessagePersistence: true,
     });
     expect(runAttemptCall(2)).toMatchObject({
       prompt: REASONING_ONLY_RETRY_INSTRUCTION,
       skipPreparedUserTurnMessage: true,
-      suppressNextUserMessagePersistence: false,
+      suppressNextUserMessagePersistence: true,
     });
   });
 });

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.settled-tool-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.settled-tool-recovery.test.ts
@@ -398,7 +398,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     const secondCall = runAttemptCall(1);
     expect(secondCall.prompt).toBe(REASONING_ONLY_RETRY_INSTRUCTION);
-    expect(secondCall.suppressNextUserMessagePersistence).toBe(false);
+    expect(secondCall.suppressNextUserMessagePersistence).toBe(true);
     expect(secondCall.skipPreparedUserTurnMessage).toBe(true);
     expectWarnMessageWith("reasoning-only assistant turn detected");
   });
@@ -472,7 +472,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(secondCall.prompt).toBe(SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION);
     expect(secondCall.disableTools).toBe(true);
     expect(secondCall.operation).toBe("settled-tool-finalization");
-    expect(secondCall.suppressNextUserMessagePersistence).toBe(false);
+    expect(secondCall.suppressNextUserMessagePersistence).toBe(true);
     expect(secondCall.skipPreparedUserTurnMessage).toBe(true);
     expectWarnMessageWith("settled post-tool turn lacked a final answer");
   });

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test-support.ts
@@ -409,9 +409,10 @@ async function runIncompleteTurnOwnerHarnessWithContext(
       attemptCompactionCount: finalized.attemptCompactionCount,
       replayState: { replayInvalid, hadPotentialSideEffects },
       activePromptPersisted,
-      activateInternalPrompt: (prompt, persisted) => {
+      activateInternalPrompt: (prompt) => {
         nextPrompt = prompt;
-        nextPromptPersisted = persisted;
+        nextPromptPersisted = true;
+        suppressNextUserMessagePersistence = true;
         skipPreparedUserTurnMessage = true;
       },
       setSuppressNextUserMessagePersistence: (value) => {

--- a/src/agents/embedded-agent-runner/run.session-prompt-state.test.ts
+++ b/src/agents/embedded-agent-runner/run.session-prompt-state.test.ts
@@ -250,19 +250,19 @@ describe("embedded run session prompt state", () => {
     expect(state.suppressNextUserMessagePersistence).toBe(false);
   });
 
-  it("preserves an unpersisted reasoning continuation across precheck compaction", async () => {
+  it("keeps an internal reasoning continuation hidden across precheck compaction", async () => {
     const reasoningContinuation =
       "The previous assistant turn recorded reasoning; continue to the visible answer.";
     const state = createState();
-    state.activateInternalPrompt(reasoningContinuation, false);
+    state.activateInternalPrompt(reasoningContinuation);
 
     await state.prepareCompactedTranscriptRetry();
 
     expect(state.activePrompt).toEqual({
       override: reasoningContinuation,
-      persisted: false,
+      persisted: true,
       internal: true,
     });
-    expect(state.suppressNextUserMessagePersistence).toBe(false);
+    expect(state.suppressNextUserMessagePersistence).toBe(true);
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt-transcript-persistence.e2e.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-transcript-persistence.e2e.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { readSessionTranscriptRawDelta } from "openclaw/plugin-sdk/session-transcript-runtime";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import {
   appendTranscriptMessage,
@@ -9,10 +9,16 @@ import {
 } from "../../../config/sessions/session-accessor.js";
 import { buildPersistedUserTurnMessage } from "../../../sessions/user-turn-transcript.js";
 import { captureEnv, setTestEnvValue } from "../../../test-utils/env.js";
+import { createOpenClawAgentHarness } from "../../harness/builtin-openclaw.js";
+import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import { convertToLlm } from "../../sessions/messages.js";
 import { SessionManager } from "../../sessions/session-manager.js";
 import { flushSessionManagerTranscript } from "./attempt-transcript-helpers.js";
 import { materializeProviderContext } from "./images.js";
+
+const runEmbeddedAttempt = vi.hoisted(() => vi.fn());
+
+vi.mock("./attempt.js", () => ({ runEmbeddedAttempt }));
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const MP4 = Buffer.from("0000001c6674797069736f6d0000000069736f6d0000000000000000", "hex");
@@ -44,6 +50,84 @@ function buildAssistantMessage(text: string) {
 }
 
 describe("embedded attempt transcript persistence", () => {
+  it("omits the host-private settled-turn recovery prompt from the raw transcript", async () => {
+    const dir = tempDirs.make("openclaw-settled-turn-finalization-");
+    const target = {
+      agentId: "main",
+      sessionId: "settled-turn-finalization",
+      sessionKey: "agent:main:settled-turn-finalization",
+      storePath: path.join(dir, "sessions.json"),
+    };
+    const recoveryPrompt =
+      "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch.";
+    const finalAssistant = buildAssistantMessage("Recovered final answer.");
+    await upsertSessionEntryCore(target, {
+      sessionId: target.sessionId,
+      updatedAt: 1,
+    });
+    await appendTranscriptMessage(target, {
+      cwd: dir,
+      eventId: "original-user",
+      message: { role: "user", content: "Original operator request." },
+      now: 1,
+    });
+
+    runEmbeddedAttempt.mockImplementationOnce(async (attempt) => {
+      const finalization = attempt as {
+        prompt: string;
+        suppressNextUserMessagePersistence?: boolean;
+      };
+      const sessionManager = guardSessionManager(SessionManager.open(target, dir), {
+        skipBeforeMessageWriteHooks: true,
+        suppressNextUserMessagePersistence: finalization.suppressNextUserMessagePersistence,
+      });
+      sessionManager.appendMessage({
+        role: "user",
+        content: [{ type: "text", text: finalization.prompt }],
+        timestamp: Date.now(),
+      });
+      sessionManager.appendMessage(finalAssistant);
+      flushSessionManagerTranscript(sessionManager);
+      return {
+        terminal: { kind: "ok" },
+        sessionIdUsed: target.sessionId,
+        messagesSnapshot: [finalAssistant],
+        assistantTexts: ["Recovered final answer."],
+        toolMetas: [],
+        lastAssistant: finalAssistant,
+        currentAttemptAssistant: finalAssistant,
+        currentAttemptCompletedAssistant: finalAssistant,
+        didSendViaMessagingTool: false,
+        didDeliverSourceReplyViaMessageTool: false,
+        didSendDeterministicApprovalPrompt: false,
+        messagingToolSentTexts: [],
+        messagingToolSentMediaUrls: [],
+        messagingToolSentTargets: [],
+        messagingToolSourceReplyPayloads: [],
+        hasToolMediaBlockReply: false,
+        cloudCodeAssistFormatError: false,
+        replayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+        currentAttemptReplayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+        itemLifecycle: { startedCount: 0, completedCount: 0, activeCount: 0 },
+      } as never;
+    });
+
+    await createOpenClawAgentHarness().finalizeSettledTurn?.({
+      attempt: { prompt: recoveryPrompt } as never,
+      settledAttempt: {} as never,
+    });
+
+    const raw = await readSessionTranscriptRawDelta({
+      ...target,
+      maxBytes: 100_000,
+      maxEvents: 100,
+    });
+    const serialized = JSON.stringify(raw);
+    expect(serialized).toContain("Original operator request.");
+    expect(serialized).toContain("Recovered final answer.");
+    expect(serialized).not.toContain(recoveryPrompt);
+  });
+
   it("replays native video after reopening the canonical transcript", async () => {
     const stateDir = tempDirs.make("openclaw-video-transcript-replay-");
     const inboundDir = path.join(stateDir, "media", "inbound");

--- a/src/agents/embedded-agent-runner/run/session-prompt-state.ts
+++ b/src/agents/embedded-agent-runner/run/session-prompt-state.ts
@@ -91,9 +91,10 @@ export function createEmbeddedRunSessionPromptState(input: {
     activeSessionFile = resolvedTarget.sessionKey;
     adoptSessionId(resolvedTarget.sessionId);
   };
-  const activateInternalPrompt = (prompt: string, persisted: boolean) => {
-    activePrompt = { override: prompt, persisted, internal: true };
-    suppressNextUserMessagePersistence = persisted;
+  // Internal control prompts are model-only context, never operator-authored transcript turns.
+  const activateInternalPrompt = (prompt: string) => {
+    activePrompt = { override: prompt, persisted: true, internal: true };
+    suppressNextUserMessagePersistence = true;
   };
   const onUserMessagePersisted: NonNullable<
     PreparedEmbeddedRunInput["runParams"]["onUserMessagePersisted"]
@@ -173,7 +174,7 @@ export function createEmbeddedRunSessionPromptState(input: {
     adoptSessionTarget,
     activateInternalPrompt,
     continueFromCurrentTranscript: () =>
-      activateInternalPrompt(MID_TURN_PRECHECK_CONTINUATION_PROMPT, true),
+      activateInternalPrompt(MID_TURN_PRECHECK_CONTINUATION_PROMPT),
     onUserMessagePersisted,
     waitForCurrentUserMessagePersistence,
     prepareCompactedTranscriptRetry: async () => {
@@ -181,7 +182,7 @@ export function createEmbeddedRunSessionPromptState(input: {
       if (activePrompt.internal) {
         suppressNextUserMessagePersistence = activePrompt.persisted;
       } else if (activePrompt.persisted) {
-        activateInternalPrompt(MID_TURN_PRECHECK_CONTINUATION_PROMPT, true);
+        activateInternalPrompt(MID_TURN_PRECHECK_CONTINUATION_PROMPT);
       }
     },
   };

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
@@ -178,6 +178,7 @@ async function runPreparedSettledTurnFinalization(input: {
         prompt: input.prompt,
         disableTools: true,
         skipPreparedUserTurnMessage: true,
+        suppressNextUserMessagePersistence: true,
         initialReplayState: { replayInvalid: false, hadPotentialSideEffects: false },
       },
       input.settledAttempt,

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -172,7 +172,7 @@ export async function resolveEmbeddedRunTerminal(input: {
   attemptCompactionCount: number;
   replayState: EmbeddedRunReplayState;
   activePromptPersisted: boolean;
-  activateInternalPrompt: (prompt: string, persisted: boolean) => void;
+  activateInternalPrompt: (prompt: string) => void;
   setSuppressNextUserMessagePersistence: (value: boolean) => void;
   armPostCompactionGuard: () => void;
   readTerminalToolPresentation: () => string | undefined;
@@ -268,7 +268,7 @@ export async function resolveEmbeddedRunTerminal(input: {
     retryState.reasoningOnlyAttempts < input.maxReasoningOnlyRetryAttempts
   ) {
     retryState.reasoningOnlyAttempts += 1;
-    input.activateInternalPrompt(nextReasoningOnlyRetryInstruction, false);
+    input.activateInternalPrompt(nextReasoningOnlyRetryInstruction);
     log.warn(
       `reasoning-only assistant turn detected: runId=${runParams.runId} sessionId=${runParams.sessionId} ` +
         `provider=${input.activeErrorContext.provider}/${input.activeErrorContext.model} — retrying ${retryState.reasoningOnlyAttempts}/${input.maxReasoningOnlyRetryAttempts} ` +
@@ -306,7 +306,7 @@ export async function resolveEmbeddedRunTerminal(input: {
     retryState.emptyResponseAttempts < input.maxEmptyResponseRetryAttempts
   ) {
     retryState.emptyResponseAttempts += 1;
-    input.activateInternalPrompt(nextEmptyResponseRetryInstruction, false);
+    input.activateInternalPrompt(nextEmptyResponseRetryInstruction);
     log.warn(
       `empty response detected: runId=${runParams.runId} sessionId=${runParams.sessionId} ` +
         `provider=${input.activeErrorContext.provider}/${input.activeErrorContext.model} — retrying ${retryState.emptyResponseAttempts}/${input.maxEmptyResponseRetryAttempts} ` +
@@ -426,7 +426,6 @@ export async function resolveEmbeddedRunTerminal(input: {
     retryState.beforeFinalizeRevisionAttempts += 1;
     input.activateInternalPrompt(
       `${BEFORE_AGENT_FINALIZE_RETRY_PROMPT_PREFIX}\n\n${beforeFinalizeRevisionReason}`,
-      true,
     );
     retryState.compactionContinuationInstruction = null;
     log.warn(

--- a/src/agents/harness/builtin-openclaw.test.ts
+++ b/src/agents/harness/builtin-openclaw.test.ts
@@ -83,6 +83,7 @@ describe("createOpenClawAgentHarness", () => {
         disableTools: true,
         disableTrajectory: true,
         skipPreparedUserTurnMessage: true,
+        suppressNextUserMessagePersistence: true,
         initialReplayState: { replayInvalid: false, hadPotentialSideEffects: false },
         operation: "settled-tool-finalization",
       }),

--- a/src/agents/harness/builtin-openclaw.ts
+++ b/src/agents/harness/builtin-openclaw.ts
@@ -73,6 +73,7 @@ function buildRestrictedFinalizationAttempt(
     disableTools: true,
     disableTrajectory: true,
     skipPreparedUserTurnMessage: true,
+    suppressNextUserMessagePersistence: true,
     initialReplayState: { replayInvalid: false, hadPotentialSideEffects: false },
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenClaw's incomplete-turn recovery prompt ("The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue…") was persisted into the visible transcript as a `role:"user"` message with no sender metadata — operators saw a ghost message they never wrote, attributed to them.

## Why This Change Was Made

Internal control prompts were submitted as ordinary user messages without persistence suppression. The settled-turn finalization path now sets `suppressNextUserMessagePersistence` at both the generic and built-in harness boundaries, and `activateInternalPrompt` uniformly treats every internal control prompt (settled-tool continuation, reasoning-only retry, empty-response retry, before-finalize revision) as model-only context — its `persisted` parameter is gone. The transcript keeps the real tool calls/results and the final assistant answer; it never invents an operator turn.

## User Impact

Operators no longer see system-generated "continue" prompts appearing as messages they authored. Multi-user sessions no longer misattribute runtime recovery text to a human.

## Evidence

- New raw-transcript E2E: drives a settled-tool finalization and asserts the canned prompt does not appear as a `role:"user"` row while the final answer persists. Failed pre-fix (found the ghost row), passes post-fix.
- Focused runs: 4 shards, 38 tests passed.
- Already-persisted ghost rows are intentionally left untouched (no brittle string migration).
- Production LOC net +2 — two persistence-suppression flags at the finalization boundaries plus a required invariant comment; the parameter removal absorbed the rest.
