### PR TITLE
fix(ci): prevent flaky extension wrapper SIGTERM test

### DIFF
--- a/test/scripts/control-ui-i18n.test.ts
+++ b/test/scripts/control-ui-i18n.test.ts
@@ -26,6 +26,7 @@ import {
   shouldReuseExistingTranslation,
 } from "../../scripts/control-ui-i18n.ts";
 import { collectControlUiRawCopyFromSource } from "../../scripts/lib/control-ui-i18n-raw-copy.ts";
+import { waitForPidFile } from "../helpers/process-wait.js";
 import { createTempDirTracker } from "../helpers/temp-dir.js";
 
 describe("control-ui-i18n generated ownership", () => {
@@ -467,7 +468,7 @@ describe("control-ui-i18n process runner", () => {
           }),
         ).rejects.toThrow(`timed out after 500ms`);
 
-        const grandchildPid = Number(readFileSync(markerPath, "utf8"));
+        const grandchildPid = await waitForPidFile(markerPath, 1_000);
         await waitForProcessExit(grandchildPid);
       } finally {
         tempDirs.cleanup();
@@ -541,13 +542,11 @@ describe("control-ui-i18n process runner", () => {
 
         try {
           const deadline = Date.now() + 30_000;
+          grandchildPid = await waitForPidFile(grandchildPidPath, 30_000);
           let fastReady = false;
           while (Date.now() < deadline) {
             try {
               fastReady = readFileSync(fastReadyPath, "utf8") === "ready";
-            } catch {}
-            try {
-              grandchildPid = Number(readFileSync(grandchildPidPath, "utf8"));
             } catch {}
             if (fastReady && grandchildPid > 0 && processIsAlive(grandchildPid)) {
               break;

--- a/test/scripts/test-extension.test.ts
+++ b/test/scripts/test-extension.test.ts
@@ -32,6 +32,7 @@ import {
   runExtensionBatchPlan,
 } from "../../scripts/test-extension-batch.mts";
 import { expectNoNodeFsScans } from "../../src/test-utils/fs-scan-assertions.js";
+import { waitForPidFile } from "../helpers/process-wait.js";
 import { extensionCatchAllExcludedTestRoots } from "../vitest/vitest.extensions.config.ts";
 
 const scriptPath = path.join(process.cwd(), "scripts", "test-extension.mts");
@@ -815,10 +816,8 @@ describe("scripts/test-extension.mts", () => {
       let descendantPid = 0;
 
       try {
-        await waitFor(() => fileExists(childPidPath), 5_000);
-        await waitFor(() => fileExists(descendantPidPath), 5_000);
-        childPid = Number(readFileSync(childPidPath, "utf8"));
-        descendantPid = Number(readFileSync(descendantPidPath, "utf8"));
+        childPid = await waitForPidFile(childPidPath, 5_000);
+        descendantPid = await waitForPidFile(descendantPidPath, 5_000);
         expect(Number.isInteger(childPid)).toBe(true);
         expect(Number.isInteger(descendantPid)).toBe(true);
 

--- a/test/scripts/test-live.test.ts
+++ b/test/scripts/test-live.test.ts
@@ -12,6 +12,7 @@ import {
   parseTestLiveArgs,
   resolveTestLiveHeartbeatMs,
 } from "../../scripts/test-live.mts";
+import { waitForPidFile } from "../helpers/process-wait.js";
 
 const posixIt = process.platform === "win32" ? it.skip : it;
 
@@ -108,10 +109,8 @@ describe("scripts/test-live", () => {
     let descendantPid = 0;
 
     try {
-      await waitFor(() => fileExists(childPidPath), 5_000);
-      await waitFor(() => fileExists(descendantPidPath), 5_000);
-      childPid = Number(readFileSync(childPidPath, "utf8"));
-      descendantPid = Number(readFileSync(descendantPidPath, "utf8"));
+      childPid = await waitForPidFile(childPidPath, 5_000);
+      descendantPid = await waitForPidFile(descendantPidPath, 5_000);
       expect(Number.isInteger(childPid)).toBe(true);
       expect(Number.isInteger(descendantPid)).toBe(true);
 
@@ -166,10 +165,8 @@ describe("scripts/test-live", () => {
     let descendantPid = 0;
 
     try {
-      await waitFor(() => fileExists(childPidPath), 5_000);
-      await waitFor(() => fileExists(descendantPidPath), 5_000);
-      childPid = Number(readFileSync(childPidPath, "utf8"));
-      descendantPid = Number(readFileSync(descendantPidPath, "utf8"));
+      childPid = await waitForPidFile(childPidPath, 5_000);
+      descendantPid = await waitForPidFile(descendantPidPath, 5_000);
 
       expect(await waitForClose(runner)).toEqual({ code: 1, signal: null });
       expect(Buffer.concat(stderr).toString("utf8")).toContain(

--- a/test/scripts/write-cli-startup-metadata.test.ts
+++ b/test/scripts/write-cli-startup-metadata.test.ts
@@ -9,6 +9,7 @@ import { pathToFileURL } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { resolveWindowsTaskkillPath } from "../../scripts/lib/windows-taskkill.mjs";
 import { testing } from "../../scripts/write-cli-startup-metadata.ts";
+import { waitForPidFile } from "../helpers/process-wait.js";
 import { createScriptTestHarness } from "./test-helpers.js";
 
 vi.mock("node:child_process", async (importOriginal) => {
@@ -470,7 +471,7 @@ describe("write-cli-startup-metadata", () => {
             (reason: unknown) => reason,
           );
 
-        grandchildPid = Number(readFileSync(grandchildPidPath, "utf8"));
+        grandchildPid = await waitForPidFile(grandchildPidPath, LOAD_SENSITIVE_PROCESS_TIMEOUT_MS);
         expect(error).toBeInstanceOf(Error);
         expect((error as Error).message).toContain("browser sentinel failure");
         expect(Date.now() - startedAt).toBeLessThan(LOAD_SENSITIVE_PROCESS_TIMEOUT_MS);
@@ -578,7 +579,7 @@ describe("write-cli-startup-metadata", () => {
         }),
       ).rejects.toThrow("render failed: timed out after 500ms");
 
-      const grandchildPid = Number(readFileSync(markerPath, "utf8"));
+      const grandchildPid = await waitForPidFile(markerPath, LOAD_SENSITIVE_PROCESS_TIMEOUT_MS);
       await waitForProcessExit(grandchildPid);
     },
   );
@@ -706,10 +707,8 @@ describe("write-cli-startup-metadata", () => {
 
       try {
         const deadline = Date.now() + LOAD_SENSITIVE_PROCESS_TIMEOUT_MS;
+        grandchildPid = await waitForPidFile(grandchildPidPath, LOAD_SENSITIVE_PROCESS_TIMEOUT_MS);
         while (Date.now() < deadline) {
-          try {
-            grandchildPid = Number(readFileSync(grandchildPidPath, "utf8"));
-          } catch {}
           let fastReady = false;
           try {
             fastReady = readFileSync(fastReadyPath, "utf8") === "ready";


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the core-tooling CI shard could intermittently fail while verifying extension-test wrapper termination on a loaded runner, even though the wrapper correctly forwarded SIGTERM and cleaned up its process group.

## Why This Change Was Made

The failed wait was the direct child PID check at `test/scripts/test-extension.test.ts:832`, after the wrapper had already closed with SIGTERM and the fake pnpm had recorded SIGTERM. The fixture waited only for the PID file to exist; plain `writeFileSync` can expose its open/truncate window, so the reader could observe an empty file, parse it as PID 0, accept it as an integer, and then keep treating `process.kill(0, 0)` as a live process-group check.

The affected test now uses the shared `waitForPidFile` helper, which waits for positive parsed PID contents. A follow-up sweep migrated the same copied readiness pattern in the live-test wrapper, CLI startup metadata, and Control UI i18n process-runner tests while preserving their existing wait budgets. The nonzero-exit CLI metadata case remains a direct read because its writer completes `writeFileSync` before scheduling stderr output and exit, and the reader runs only after process close.

## User Impact

No user-visible runtime behavior changes. Maintainers get deterministic SIGTERM wrapper coverage without spurious core-tooling CI failures under load.

## Evidence

- Before: [CI run 31653373036](https://github.com/openclaw/openclaw/actions/runs/31653373036), `core-tooling-4` / `checks-node-compact-small-13`, timed out at the child-death wait on `test/scripts/test-extension.test.ts:832` after signal delivery had succeeded.
- `node scripts/run-vitest.mjs test/scripts/test-extension.test.ts`: 158/158 tests passed.
- Bounded stress: the same focused command passed 5/5 sequential runs.
- Follow-up sweep: `test-live.test.ts` passed 8/8, `write-cli-startup-metadata.test.ts` passed 22/22, and `control-ui-i18n.test.ts` passed 19/19 via separate focused `node scripts/run-vitest.mjs <file>` runs.
- `node scripts/check-changed.mjs`: passed on Blacksmith Testbox `tbx_01kzwd9dwzw1ctww7ez1k7036b` after format, guards, typechecks, and lint; the stale merge base conservatively expanded this run beyond the three touched tests.
- `.agents/skills/autoreview/scripts/autoreview --mode local`: clean, no accepted/actionable findings.
- `git diff --check`: clean.
