### PR TITLE
fix: retrying a failed steer dead-ends after its target run exits

### DIFF
--- a/ui/src/pages/chat/chat-send-actions.ts
+++ b/ui/src/pages/chat/chat-send-actions.ts
@@ -168,7 +168,7 @@ export function moveQueuedChatMessage(host: ChatHost, id: string, toIndex: numbe
 }
 
 export async function retryQueuedChatMessage(host: ChatHost, id: string) {
-  const item = host.chatQueue.find((entry) => entry.id === id);
+  let item = host.chatQueue.find((entry) => entry.id === id);
   if (
     !item ||
     item.pendingRunId ||
@@ -180,23 +180,39 @@ export async function retryQueuedChatMessage(host: ChatHost, id: string) {
     return;
   }
   if (item.kind === "steered") {
-    if (!host.connected || !host.client || !hasAbortableSessionRun(host)) {
+    if (!host.connected || !host.client) {
       setChatError(host, t("chat.sendErrors.steerRunNoLongerActive"));
       return;
     }
-    const retry = updateQueuedMessage(host, id, (entry) => ({
-      ...entry,
-      sendAttempts: 0,
-      sendError: undefined,
-      sendRequestStartedAtMs: undefined,
-      sendState: "waiting-idle",
-    }));
-    if (!retry) {
+    if (hasAbortableSessionRun(host)) {
+      const retry = updateQueuedMessage(host, id, (entry) => ({
+        ...entry,
+        sendAttempts: 0,
+        sendError: undefined,
+        sendRequestStartedAtMs: undefined,
+        sendState: "waiting-idle",
+      }));
+      if (!retry) {
+        setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
+        return;
+      }
+      await steerQueuedChatMessageLifecycle(host, id, steerSendDependencies);
+      return;
+    }
+    const converted = updateQueuedMessage(host, id, (entry) => {
+      const {
+        kind: _kind,
+        pendingRunId: _pendingRunId,
+        steerTargetRunId: _steerTargetRunId,
+        ...queued
+      } = entry;
+      return resetRetryState(queued, reconnectSafeQueuedSendState(host));
+    });
+    if (!converted) {
       setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
       return;
     }
-    await steerQueuedChatMessageLifecycle(host, id, steerSendDependencies);
-    return;
+    item = converted;
   }
   let outbox = findStoredOutbox(host, item.id);
   if (!outbox) {

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -8797,13 +8797,14 @@ describe("handleSendChat", () => {
     ]);
     expect(host.lastError).toBe("no active turn to steer");
 
-    host.chatRunId = null;
+    host.connected = false;
     await retryQueuedChatMessage(host, original.id);
     expect(payloads).toHaveLength(1);
     expect(host.lastError).toBe(
       "This steer still targets the previous run, but that run is no longer active.",
     );
 
+    host.connected = true;
     host.chatRunId = "active-run";
     host.chatDisplayedLeafEntryId = "leaf-advanced-during-tool-work";
     await retryQueuedChatMessage(host, original.id);
@@ -8819,6 +8820,49 @@ describe("handleSendChat", () => {
       "leaf-active",
       "leaf-advanced-during-tool-work",
     ]);
+  });
+
+  it("retries a failed steer as a new turn when the session is idle", async () => {
+    const payloads: Array<Record<string, unknown>> = [];
+    const original = {
+      id: "idle-failed-steer",
+      text: "deliver this as a new turn",
+      createdAt: 1,
+      kind: "steered" as const,
+      sendAttempts: 1,
+      sendError: "The session switched branches — review and resend.",
+      sendRequestStartedAtMs: 123,
+      sendRunId: "previous-steer-request",
+      sendState: "failed" as const,
+      steerTargetRunId: "previous-run",
+      sessionKey: "agent:main:main",
+      agentId: "main",
+    };
+    const host = makeChatHost({
+      requestHandlers: {
+        "chat.history": idleChatHistory(original.sessionKey),
+        "chat.send": (params: unknown) => {
+          payloads.push(requireRecord(params, "idle steer retry payload"));
+          return { status: "ok", runId: "new-turn" };
+        },
+      },
+      chatError: "The session switched branches — review and resend.",
+      chatQueue: [original],
+      sessionKey: original.sessionKey,
+    });
+    expect(admitQueuedMessageForSession(host, host.sessionKey, original)).toBe(true);
+
+    await retryQueuedChatMessage(host, original.id);
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).toMatchObject({ message: original.text });
+    expect(payloads[0]).not.toHaveProperty("expectedRunId");
+    expect(payloads[0]).not.toHaveProperty("expectedLeafEntryId");
+    expect(payloads[0]).not.toHaveProperty("queueMode");
+    expect(payloads[0]?.idempotencyKey).not.toBe(original.sendRunId);
+    expect(host.chatQueue).toEqual([]);
+    expect(host.chatError).toBeNull();
+    expect(host.lastError).toBeNull();
   });
 
   it("fails a restored steer that predates durable target identity", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Control UI user who steers an active run at the wrong moment ends up with a permanently stuck message. When the steer misses its target run — the run rotates because a subagent completion wakes a new run, or the run ends during a connectivity blip — the message parks as a red **Failed** chip ("The session switched branches — review and resend."). Clicking **Retry** on the idle session then errors with "This steer still targets the previous run, but that run is no longer active." forever. The only way out is manually retyping the message and removing the chip.

## Why This Change Was Made

The retry handler ([`retryQueuedChatMessage`](https://github.com/openclaw/openclaw/blob/main/ui/src/pages/chat/chat-send-actions.ts)) only knew one way to retry a `steered` queue row: re-arm the steer against its original captured run. That binding is correct while the target run is alive (a steer must never inject into an unrelated successor run), but once the run is gone and the session is idle, refusing delivery serves nobody — the user's intent is simply "deliver this message."

Retry now distinguishes three states:

- **Disconnected** — unchanged: keep the existing error.
- **Active run present** — unchanged: re-arm the steer with its original durable run binding.
- **Session idle** — new: strip the steer identity (`kind`, `steerTargetRunId`, pending state), reset retry metadata with a fresh send run id, and fall through to the existing normal-send outbox path, so the message delivers as a fresh turn.

`steer-lifecycle.ts` semantics are untouched; no gateway/server changes.

## User Impact

A parked steer is no longer a dead end. On an idle session, Retry sends the message as a new turn — matching what the user wanted when they hit send. While a run is still active, steer retry behavior is unchanged.

## Evidence

- Regression test (fails pre-fix): `ui/src/pages/chat/chat-send.test.ts` — "retries a failed steer as a new turn when the session is idle" asserts the send goes out without `expectedRunId`/`expectedLeafEntryId`/`queueMode`, with a fresh idempotency key, and clears the queue row and error. Focused run: `node scripts/run-vitest.mjs ui/src/pages/chat/chat-send.test.ts` → 276 passed (275 + new test; pre-fix: 1 failed).
- Live dev-gateway proof (isolated `OPENCLAW_STATE_DIR`, port 1980x, real Anthropic provider, Playwright-recorded): a run ends during a connectivity blip, the steer targets the dead run and parks as Failed, then Retry is clicked on the idle session.

Before (current main): Retry dead-ends with "This steer still targets the previous run, but that run is no longer active."

https://github.com/user-attachments/assets/0fe18490-36bc-483a-bc0f-b8fc66b29ed5

After (this PR, same scenario): Retry converts the parked steer and the message delivers as a new turn; the model acts on it.

https://github.com/user-attachments/assets/11982366-c9e5-42d1-ba97-50e5b4cad8a3

- `oxfmt --check` clean on both files; `git diff --check` clean; Codex autoreview: no accepted/actionable findings.
