### PR TITLE
fix(ci): stop repeated cold dependency rebuilds

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -126,13 +126,13 @@ runs:
       if: inputs.sticky-disk == 'true'
       uses: useblacksmith/stickydisk@6d373c96a74cbde0c99fedc5ea5d3a7ba66ba494 # main (post-v1.4.0 hot-attach fix)
       with:
-        # One stable disk per Node line. v6 starts a fresh lineage for the
-        # preflight-serialized writer after Blacksmith acknowledged repeated v5
+        # One stable disk per Node line. v7 starts a fresh lineage for the
+        # preflight-serialized writer after Blacksmith acknowledged repeated v6
         # commits but kept restoring its original snapshot. The v2 per-PR/per-manifest-hash keys
         # saturated Blacksmith's installation-wide sticky-disk budget. Install
         # inputs, runner platform, and the exact Node patch live in the runtime
         # marker below, so changes refresh this disk in place.
-        key: ${{ github.repository }}-node-deps-bind-v6-${{ inputs.node-version }}
+        key: ${{ github.repository }}-node-deps-bind-v7-${{ inputs.node-version }}
         path: /var/tmp/openclaw-node-deps
         # Single semantic writer: only the designated trusted-push job may
         # commit, so pull_request clones stay read-only. Like every sticky

--- a/.github/retired-sticky-disks.json
+++ b/.github/retired-sticky-disks.json
@@ -20,6 +20,11 @@
     "region": "eu-west"
   },
   {
+    "key": "openclaw/openclaw-node-deps-bind-v6-24.x",
+    "architecture": "amd64",
+    "region": "eu-west"
+  },
+  {
     "key": "openclaw/openclaw-vitest-fs-v2-protected-Linux-X64-node-24.x",
     "architecture": "amd64",
     "region": "eu-west"

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -3027,7 +3027,7 @@ NODE
     // per-PR/per-manifest-hash keys saturated that cap. Install inputs and exact
     // runtime patches belong in the marker, not the backing-disk key.
     expect(mountStep.with.key).toBe(
-      "${{ github.repository }}-node-deps-bind-v6-${{ inputs.node-version }}",
+      "${{ github.repository }}-node-deps-bind-v7-${{ inputs.node-version }}",
     );
     expect(mountStep.with.commit).toBe(
       "${{ inputs.save-sticky-disk == 'true' && github.event_name != 'pull_request' && 'on-change' || 'false' }}",


### PR DESCRIPTION
Closes #122913

## What Problem This Solves

Fixes an issue where canonical `main` CI would repeatedly spend roughly 105–111 seconds reinstalling the same dependency fingerprint because the protected v6 StickyDisk lineage kept restoring its original stale generation after successful publication.

## Why This Change Was Made

Starts one fresh, stable v7 dependency-disk lineage at the existing setup owner and records the poisoned v6 key for exact allowlisted cleanup. The runtime fingerprint, sole-writer policy, publication guard, job count, runner routing, and coverage stay unchanged; this deliberately does not return to per-commit or per-manifest disk keys.

## User Impact

Canonical Node-relevant `main` cycles can return to exact-marker warm reuse after one required v7 seed build instead of serializing fanout behind the same cold install on every run.

## Evidence

Before the change, three consecutive canonical preflights requiring the same `v2-c2f4a1…` fingerprint each restored the old `v2-1c2732…` marker, rebuilt, forced a verified 73,728-byte allocation delta, and reported successful publication:

- [run 31656168594](https://github.com/openclaw/openclaw/actions/runs/31656168594/job/94311125830)
- [run 31657034715](https://github.com/openclaw/openclaw/actions/runs/31657034715/job/94313738599)
- [run 31657449883](https://github.com/openclaw/openclaw/actions/runs/31657449883/job/94315339697)

A prior healthy canonical run [31652568983](https://github.com/openclaw/openclaw/actions/runs/31652568983/job/94300844226) restored the exact marker/importers, skipped `pnpm install`, and did not publish a no-op snapshot.

Focused Node 24 / `CI=1` proof:

- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` — 117/117 passed
- `node --import tsx scripts/check-workflows.mts` — passed
- `node scripts/check-changed.mjs -- <changed files>` — passed (`testRoot`, `tooling`)
- `node scripts/docs-list.js` — passed
- `oxfmt --check` and `git diff --check` — passed
- Autoreview secret scan — clean; the Codex review executable is unavailable in this orb, so an independent exact-head review is being requested separately.

No Crabbox or Testbox execution was used.
