### PR TITLE
fix(plugins): repair status and CLI fixtures

### DIFF
--- a/src/plugins/cli.test.ts
+++ b/src/plugins/cli.test.ts
@@ -34,7 +34,12 @@ vi.mock("../config/plugin-auto-enable.js", () => ({
   applyPluginAutoEnable: (...args: unknown[]) => mocks.applyPluginAutoEnable(...args),
 }));
 
+vi.mock("../config/io.plugin-metadata.js", () => ({
+  resolveConfigWidePluginManifestRegistry: () => ({ plugins: [], diagnostics: [] }),
+}));
+
 vi.mock("./plugin-metadata-snapshot.js", () => ({
+  rebasePluginMetadataSnapshotManifestRegistry: <T>(snapshot: T) => snapshot,
   resolvePluginMetadataSnapshot: (...args: unknown[]) =>
     mocks.resolvePluginMetadataSnapshot(...args),
 }));

--- a/src/plugins/status.test-fixtures.ts
+++ b/src/plugins/status.test-fixtures.ts
@@ -7,6 +7,23 @@ import type { PluginHookName } from "./types.js";
 
 export { createPluginRecord };
 
+export function createInstalledPluginIndexSnapshot(
+  plugins: Array<Record<string, unknown>>,
+): Record<string, unknown> {
+  return {
+    version: 1,
+    warning: "test",
+    hostContractVersion: "test",
+    compatRegistryVersion: "test",
+    migrationVersion: 1,
+    policyHash: "test",
+    generatedAtMs: 0,
+    installRecords: {},
+    plugins,
+    diagnostics: [],
+  };
+}
+
 export const HOOK_ONLY_MESSAGE =
   "is hook-only. This remains a supported compatibility path, but it has not migrated to explicit capability registration yet.";
 export const DEPRECATED_MEMORY_EMBEDDING_PROVIDER_API_MESSAGE =

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -6,6 +6,7 @@ import type { PluginMemoryEmbeddingProviderRegistration } from "./registry.test-
 import {
   createCompatibilityNotice,
   createCustomHook,
+  createInstalledPluginIndexSnapshot,
   createPluginLoadResult,
   createPluginRecord,
   DEPRECATED_MEMORY_EMBEDDING_PROVIDER_API_MESSAGE,
@@ -58,6 +59,10 @@ vi.mock("../config/config.js", () => ({
   loadConfig: () => loadConfigMock(),
 }));
 
+vi.mock("../config/io.plugin-metadata.js", () => ({
+  resolveConfigWidePluginManifestRegistry: () => ({ plugins: [], diagnostics: [] }),
+}));
+
 vi.mock("../config/plugin-auto-enable.js", () => ({
   applyPluginAutoEnable: (...args: unknown[]) => applyPluginAutoEnableMock(...args),
 }));
@@ -91,6 +96,7 @@ vi.mock("./manifest-registry-installed.js", () => ({
 vi.mock("./plugin-metadata-snapshot.js", () => ({
   isPluginMetadataSnapshotCompatible: isPluginMetadataSnapshotCompatibleMock,
   loadPluginMetadataSnapshot: (params?: unknown) => loadPluginMetadataSnapshotMock(params),
+  rebasePluginMetadataSnapshotManifestRegistry: <T>(snapshot: T) => snapshot,
   resolvePluginMetadataSnapshot: (params?: { pluginMetadataSnapshot?: unknown }) =>
     params?.pluginMetadataSnapshot ?? loadPluginMetadataSnapshotMock(params),
 }));
@@ -118,6 +124,7 @@ vi.mock("./runtime.js", () => ({
 vi.mock("../agents/agent-scope.js", () => ({
   resolveAgentWorkspaceDir: () => undefined,
   resolveDefaultAgentId: () => "default",
+  tryResolveConfiguredAgentWorkspaceDir: () => undefined,
 }));
 
 vi.mock("../agents/workspace.js", () => ({
@@ -141,23 +148,6 @@ function setSinglePluginLoadResult(
     plugins: [plugin],
     ...overrides,
   });
-}
-
-function createInstalledPluginIndexSnapshot(
-  plugins: Array<Record<string, unknown>>,
-): Record<string, unknown> {
-  return {
-    version: 1,
-    warning: "test",
-    hostContractVersion: "test",
-    compatRegistryVersion: "test",
-    migrationVersion: 1,
-    policyHash: "test",
-    generatedAtMs: 0,
-    installRecords: {},
-    plugins,
-    diagnostics: [],
-  };
 }
 
 function expectInspectReport(


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/114388

## What Problem This Solves

Fixes an issue where the full plugin status and CLI test suites fail after plugin loading gained config-wide manifest registry, metadata rebase, and configured agent workspace resolution paths.

## Why This Change Was Made

Updates the existing full-suite mocks to match the current plugin load context and moves the existing installed-index builder into the fixture module already responsible for status fixture builders. Runtime discovery and plugin behavior are unchanged.

## User Impact

No user-visible runtime change. Maintainers regain deterministic status and CLI coverage for the current plugin loading contract.

## Evidence

- `pnpm format src/plugins/status.test.ts src/plugins/status.test-fixtures.ts src/plugins/cli.test.ts`
- `node scripts/run-vitest.mjs src/plugins/status.test.ts src/plugins/cli.test.ts` - 54/54 passed on the first run
- `node scripts/check-changed.mjs -- src/plugins/status.test.ts src/plugins/status.test-fixtures.ts src/plugins/cli.test.ts` - passed on Blacksmith Testbox
- `git diff origin/main...HEAD --check` - passed
- Tests/fixtures: +29/-17; production: +0/-0
- Exact changed-gate run: https://github.com/openclaw/openclaw/actions/runs/31659244179
- Hosted exact-head CI: 55 successful, 0 failing/cancelled/pending on `f18d71e82fb9ccb6210d07293028128c85535304`
- Hosted CI run: https://github.com/openclaw/openclaw/actions/runs/31659831077
- ClawSweeper exact-head review: no actionable findings; best-fix verdict is the narrow fixture repair
