### PR TITLE
fix: install the selected ClawHub publisher for duplicate slugs

### DIFF
--- a/src/gateway/server-methods/skills.search-detail.test.ts
+++ b/src/gateway/server-methods/skills.search-detail.test.ts
@@ -125,6 +125,34 @@ describe("skills.search handler", () => {
     expect(response).toEqual({ results: [] });
   });
 
+  it("returns publisher-qualified slugs without rewriting external sources", async () => {
+    searchSkillsFromClawHubMock.mockResolvedValue([
+      {
+        score: 2,
+        slug: "weather",
+        ownerHandle: "alice",
+        displayName: "Weather",
+      },
+      {
+        score: 1,
+        slug: "weather",
+        ownerHandle: "openclaw",
+        installRef: "skills-sh:openclaw/skills/weather",
+        displayName: "External Weather",
+      },
+    ]);
+
+    const { ok, response } = await callHandler("skills.search", { query: "weather" });
+
+    expect(ok).toBe(true);
+    expect(response).toMatchObject({
+      results: [
+        { slug: "@alice/weather", ownerHandle: "alice" },
+        { slug: "weather", installRef: "skills-sh:openclaw/skills/weather" },
+      ],
+    });
+  });
+
   it("returns error when ClawHub is unreachable", async () => {
     searchSkillsFromClawHubMock.mockRejectedValue(new Error("connection refused"));
 
@@ -191,6 +219,22 @@ describe("skills.detail handler", () => {
     expect(ok).toBe(true);
     expect(error).toBeUndefined();
     expect(response).toEqual(detail);
+  });
+
+  it("resolves detail for the selected publisher-qualified reference", async () => {
+    fetchClawHubSkillDetailMock.mockResolvedValue({
+      skill: { slug: "weather", displayName: "Weather", createdAt: 1, updatedAt: 2 },
+      owner: { handle: "alice" },
+    });
+
+    const { ok, error } = await callHandler("skills.detail", { slug: "@alice/weather" });
+
+    expect(ok).toBe(true);
+    expect(error).toBeUndefined();
+    expect(fetchClawHubSkillDetailMock).toHaveBeenCalledWith({
+      slug: "weather",
+      ownerHandle: "alice",
+    });
   });
 
   it("returns error when slug is not found", async () => {

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -34,6 +34,7 @@ import { getOrCreatePromise } from "../../shared/lazy-promise.js";
 import { updateSkillConfigEntry } from "../../skills/config/mutations.js";
 import { collectSkillBins } from "../../skills/discovery/bins.js";
 import { buildWorkspaceSkillStatus } from "../../skills/discovery/status.js";
+import { parseRequestedClawHubSkillRef } from "../../skills/lifecycle/clawhub-store.js";
 import {
   installSkillFromClawHub,
   readLocalSkillCardContentSync,
@@ -288,6 +289,15 @@ export const skillsHandlers: GatewayRequestHandlers = {
         query: (params as { query?: string }).query,
         limit: (params as { limit?: number }).limit,
       });
+      for (const result of results) {
+        const ownerHandle = normalizeOptionalString(result.ownerHandle)?.replace(/^@+/, "");
+        const installRef = normalizeOptionalString(result.installRef);
+        // Existing clients use slug as the selected identity. Qualify registry results here so
+        // every detail/install caller preserves the publisher without a second protocol field.
+        if (ownerHandle && !installRef?.startsWith("skills-sh:") && !result.slug.startsWith("@")) {
+          result.slug = `@${ownerHandle}/${result.slug}`;
+        }
+      }
       respond(true, { results }, undefined);
     } catch (err) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatErrorMessage(err)));
@@ -298,8 +308,10 @@ export const skillsHandlers: GatewayRequestHandlers = {
       return;
     }
     try {
+      const requested = parseRequestedClawHubSkillRef((params as { slug: string }).slug);
       const detail = await fetchClawHubSkillDetail({
-        slug: (params as { slug: string }).slug,
+        slug: requested.slug,
+        ...(requested.ownerHandle ? { ownerHandle: requested.ownerHandle } : {}),
       });
       respond(true, detail, undefined);
     } catch (err) {

--- a/ui/src/pages/skills/view.test.ts
+++ b/ui/src/pages/skills/view.test.ts
@@ -725,7 +725,7 @@ describe("renderSkills", () => {
           clawhubResults: [
             {
               score: 0.95,
-              slug: "github",
+              slug: "@openclaw/github",
               displayName: "GitHub",
               summary: "GitHub integration for OpenClaw",
               icon: `https://clawhub.ai/api/v1/skill-icons/${"a".repeat(64)}`,
@@ -761,9 +761,9 @@ describe("renderSkills", () => {
     installButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
     expect(onClawHubDetailOpen).toHaveBeenCalledTimes(1);
-    expect(onClawHubDetailOpen).toHaveBeenCalledWith("github");
+    expect(onClawHubDetailOpen).toHaveBeenCalledWith("@openclaw/github");
     expect(onClawHubInstall).toHaveBeenCalledTimes(1);
-    expect(onClawHubInstall).toHaveBeenCalledWith("github");
+    expect(onClawHubInstall).toHaveBeenCalledWith("@openclaw/github");
 
     onClawHubInstall.mockClear();
     showModal.mockClear();


### PR DESCRIPTION
Closes #117633

Supersedes #121518 with a narrower fix at the Gateway search/detail boundary.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users selecting a ClawHub skill would be unable to review or install it when multiple publishers used the same slug. The Control UI and native clients received only the bare slug, so the later detail request was ambiguous and ClawHub returned HTTP 409.

## Why This Change Was Made

The Gateway now returns publisher-qualified `@owner/slug` identities for registry-backed search results and parses that same existing reference format for detail lookup. Current clients already carry the returned `slug` unchanged into detail and install, so this fixes every client without a new protocol field or per-client migration; external `skills-sh:` results retain their existing bare-slug behavior.

Production diff: `+13/-1`. Test diff: `+47/-3`.

## User Impact

Users can distinguish duplicate-slug search results by publisher and review or install the exact result they selected. Existing external-source search results are unchanged.

## Evidence

- Exact head: `d6bd191bde178eb5e59fd35f3f7d811574be262f`
- Exact base: `cad7e7f9e1eef2ff20a3533d3be5026de5a5dfa4`
- Live ClawHub API on August 13, 2026:
  - Search for `imap-smtp-email` returned the same slug from `gzlicanyi`, `vthoram`, and `wangchenyu8`.
  - Bare `/api/v1/skills/imap-smtp-email` returned HTTP 409 `AMBIGUOUS_SKILL_SLUG`.
  - Adding `ownerHandle=gzlicanyi` returned HTTP 200 for that publisher.
- Red source proof on unmodified base `93cf912695e0616ce60a565689d25b971f576bd7`: Gateway detail forwarded `@alice/weather` as a bare API slug, and duplicate search results had no selected identity. Blacksmith run: https://github.com/openclaw/openclaw/actions/runs/31658259590
- Final-base green proof:
  - Gateway search/detail: `11/11`
  - Skills UI: `19/19`
  - ClawHub lifecycle: `17/17`
  - Browser selection flow: `1/1`, preserving `@vthoram/imap-smtp-email` in both detail and install requests
  - Formatting: clean
  - Blacksmith runs: https://github.com/openclaw/openclaw/actions/runs/31659951315 and https://github.com/openclaw/openclaw/actions/runs/31660049102
- Full `check:changed` passed on an immediately preceding canonical base. Later canonical movement did not touch Skills or ClawHub ownership; shared UI bootstrap movement triggered focused and browser reruns. The final rebase also picked up the unrelated canonical fix for the flaky `channels.add` CI timeout observed on the previous PR head.
- Source-blind artifact validation: PASS for publisher-distinct results, selected detail/install identity, and publisher display.
- Mandatory autoreview: clean, no accepted or actionable findings.

Implementation and review were AI-assisted. A maintainer directed the scope, verified the owner boundary, and reviewed the resulting diff and proof.
