### PR TITLE
fix(gateway): allow downloading zero-byte artifacts

### DIFF
--- a/src/gateway/server-methods/artifacts-base64.ts
+++ b/src/gateway/server-methods/artifacts-base64.ts
@@ -52,7 +52,7 @@ export function readArtifactBase64Payload(
   value: string | undefined,
   opts: { includeData: boolean },
 ): ArtifactBase64Payload | undefined {
-  if (!value) {
+  if (value === undefined) {
     return undefined;
   }
   let encodedLength = 0;
@@ -82,9 +82,6 @@ export function readArtifactBase64Payload(
     if (data !== undefined) {
       data += normalizeArtifactBase64Char(char);
     }
-  }
-  if (encodedLength === 0) {
-    return undefined;
   }
   const remainder = encodedLength % 4;
   if ((padding > 0 && remainder !== 0) || remainder === 1) {

--- a/src/gateway/server-methods/artifacts.test.ts
+++ b/src/gateway/server-methods/artifacts.test.ts
@@ -424,48 +424,28 @@ describe("artifacts RPC handlers", () => {
     },
     { data: "", sizeBytes: 0, title: "untyped.bin" },
   ])("lists, gets, and downloads the zero-byte $title artifact", async (block) => {
-    mockedMessages([
-      {
-        role: "assistant",
-        content: [block],
-        __openclaw: { seq: 2 },
-      },
-    ]);
-
-    const listed = await listArtifacts({ sessionKey: "agent:main:main" });
-    const artifact = expectFirstArtifact(listed.calls);
+    mockedMessages([{ role: "assistant", content: [block], __openclaw: { seq: 2 } }]);
+    const artifact = expectFirstArtifact(
+      (await listArtifacts({ sessionKey: "agent:main:main" })).calls,
+    );
     const artifactId = requireNonEmptyString(artifact?.id, "expected zero-byte artifact id");
-    expect(artifact).toMatchObject({ sizeBytes: 0, download: { mode: "bytes" } });
+    const expected = { id: artifactId, sizeBytes: 0, download: { mode: "bytes" } };
+    expect(artifact).toMatchObject(expected);
     expect(artifact).not.toHaveProperty("data");
-
     const get = await getArtifact({ sessionKey: "agent:main:main", artifactId });
     const getPayload = expectOkPayload(get.calls) as { artifact?: Record<string, unknown> };
-    expectFields(getPayload.artifact, { id: artifactId, sizeBytes: 0 });
-    expectFields(getPayload.artifact?.download, { mode: "bytes" });
+    expect(getPayload.artifact).toMatchObject(expected);
     expect(getPayload.artifact).not.toHaveProperty("data");
-
     const download = await downloadArtifact({ sessionKey: "agent:main:main", artifactId });
-    const downloadPayload = expectOkPayload(download.calls) as {
-      artifact?: Record<string, unknown>;
-    };
-    expectFields(downloadPayload, { encoding: "base64", data: "" });
-    expectFields(downloadPayload.artifact, { id: artifactId, sizeBytes: 0 });
-    expectFields(downloadPayload.artifact?.download, { mode: "bytes" });
+    const payload = expectOkPayload(download.calls) as { artifact?: Record<string, unknown> };
+    expectFields(payload, { encoding: "base64", data: "" });
+    expect(payload.artifact).toMatchObject(expected);
   });
-
   it.each([null, 0, false, {}])(
     "does not discover untyped non-string data as an artifact: %j",
     async (data) => {
-      mockedMessages([
-        {
-          role: "assistant",
-          content: [{ data }],
-          __openclaw: { seq: 2 },
-        },
-      ]);
-
+      mockedMessages([{ role: "assistant", content: [{ data }], __openclaw: { seq: 2 } }]);
       const listed = await listArtifacts({ sessionKey: "agent:main:main" });
-
       expect(expectArtifactList(listed.calls)).toEqual({ artifacts: [] });
     },
   );

--- a/src/gateway/server-methods/artifacts.test.ts
+++ b/src/gateway/server-methods/artifacts.test.ts
@@ -409,6 +409,50 @@ describe("artifacts RPC handlers", () => {
     expectFields(downloadPayload.artifact, { id: artifactId });
   });
 
+  it.each([
+    { type: "file", data: "", sizeBytes: 0, title: "direct.bin" },
+    {
+      type: "file",
+      source: { data: "", media_type: "application/octet-stream", sizeBytes: 0 },
+      title: "source.bin",
+    },
+    {
+      type: "file",
+      data: " data:application/octet-stream;base64, ",
+      sizeBytes: 0,
+      title: "data-url.bin",
+    },
+    { data: "", sizeBytes: 0, title: "untyped.bin" },
+  ])("lists, gets, and downloads the zero-byte $title artifact", async (block) => {
+    mockedMessages([
+      {
+        role: "assistant",
+        content: [block],
+        __openclaw: { seq: 2 },
+      },
+    ]);
+
+    const listed = await listArtifacts({ sessionKey: "agent:main:main" });
+    const artifact = expectFirstArtifact(listed.calls);
+    const artifactId = requireNonEmptyString(artifact?.id, "expected zero-byte artifact id");
+    expect(artifact).toMatchObject({ sizeBytes: 0, download: { mode: "bytes" } });
+    expect(artifact).not.toHaveProperty("data");
+
+    const get = await getArtifact({ sessionKey: "agent:main:main", artifactId });
+    const getPayload = expectOkPayload(get.calls) as { artifact?: Record<string, unknown> };
+    expectFields(getPayload.artifact, { id: artifactId, sizeBytes: 0 });
+    expectFields(getPayload.artifact?.download, { mode: "bytes" });
+    expect(getPayload.artifact).not.toHaveProperty("data");
+
+    const download = await downloadArtifact({ sessionKey: "agent:main:main", artifactId });
+    const downloadPayload = expectOkPayload(download.calls) as {
+      artifact?: Record<string, unknown>;
+    };
+    expectFields(downloadPayload, { encoding: "base64", data: "" });
+    expectFields(downloadPayload.artifact, { id: artifactId, sizeBytes: 0 });
+    expectFields(downloadPayload.artifact?.download, { mode: "bytes" });
+  });
+
   it("preserves managed artifact identity and returns a ticketed download URL", async () => {
     const artifactId = "artifact_managed_image_11111111-1111-4111-8111-111111111111";
     mockedMessages([

--- a/src/gateway/server-methods/artifacts.test.ts
+++ b/src/gateway/server-methods/artifacts.test.ts
@@ -453,6 +453,23 @@ describe("artifacts RPC handlers", () => {
     expectFields(downloadPayload.artifact?.download, { mode: "bytes" });
   });
 
+  it.each([null, 0, false, {}])(
+    "does not discover untyped non-string data as an artifact: %j",
+    async (data) => {
+      mockedMessages([
+        {
+          role: "assistant",
+          content: [{ data }],
+          __openclaw: { seq: 2 },
+        },
+      ]);
+
+      const listed = await listArtifacts({ sessionKey: "agent:main:main" });
+
+      expect(expectArtifactList(listed.calls)).toEqual({ artifacts: [] });
+    },
+  );
+
   it("preserves managed artifact identity and returns a ticketed download URL", async () => {
     const artifactId = "artifact_managed_image_11111111-1111-4111-8111-111111111111";
     mockedMessages([

--- a/src/gateway/server-methods/artifacts.ts
+++ b/src/gateway/server-methods/artifacts.ts
@@ -3,7 +3,10 @@
 import { createHash } from "node:crypto";
 import { isHttpUrl } from "@openclaw/net-policy/url-protocol";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
-import { normalizeOptionalString as asNonEmptyString } from "@openclaw/normalization-core/string-coerce";
+import {
+  normalizeOptionalString as asNonEmptyString,
+  readStringValue,
+} from "@openclaw/normalization-core/string-coerce";
 import {
   ErrorCodes,
   errorShape,
@@ -247,13 +250,13 @@ function resolveBlockDownload(
   mimeType?: string;
   sizeBytes?: number;
 } {
-  const data = asNonEmptyString(block.data);
-  const content = asNonEmptyString(block.content);
+  const data = readStringValue(block.data)?.trim();
+  const content = readStringValue(block.content)?.trim();
   const url = asNonEmptyString(block.url) ?? asNonEmptyString(block.openUrl);
   const imageUrl = mediaUrlValue(block.image_url);
   const audioUrl = asNonEmptyString(block.audio_url);
   const source = asOptionalRecord(block.source);
-  const sourceData = asNonEmptyString(source?.data);
+  const sourceData = readStringValue(source?.data)?.trim();
   const sourceUrl = asNonEmptyString(source?.url);
   const dataUrl = [url, sourceUrl, imageUrl, audioUrl, data, content, sourceData].find(
     (value) => typeof value === "string" && /^data:/i.test(value),
@@ -282,12 +285,7 @@ function resolveBlockDownload(
       ? Math.floor(explicitSize)
       : base64?.sizeBytes;
   if (base64) {
-    return {
-      mode: "bytes",
-      ...(base64.data ? { data: base64.data } : {}),
-      mimeType,
-      sizeBytes,
-    };
+    return { mode: "bytes", data: base64.data, mimeType, sizeBytes };
   }
   if (remoteUrl) {
     return { mode: "url", url: remoteUrl, mimeType, sizeBytes };
@@ -310,8 +308,9 @@ function isArtifactBlock(block: Record<string, unknown>): boolean {
   ) {
     return true;
   }
-  return Boolean(
-    block.url || block.openUrl || block.data || block.source || block.image_url || block.audio_url,
+  return (
+    block.data !== undefined ||
+    Boolean(block.url || block.openUrl || block.source || block.image_url || block.audio_url)
   );
 }
 
@@ -378,7 +377,7 @@ function collectArtifactsFromMessage(params: {
       messageSeq,
       source: "session-transcript",
       download: { mode: download.mode },
-      ...(download.data ? { data: download.data } : {}),
+      ...(download.data !== undefined ? { data: download.data } : {}),
       ...(download.url ? { url: download.url } : {}),
     };
     params.artifacts.push(summary);

--- a/src/gateway/server-methods/artifacts.ts
+++ b/src/gateway/server-methods/artifacts.ts
@@ -309,7 +309,7 @@ function isArtifactBlock(block: Record<string, unknown>): boolean {
     return true;
   }
   return (
-    block.data !== undefined ||
+    typeof block.data === "string" ||
     Boolean(block.url || block.openUrl || block.source || block.image_url || block.audio_url)
   );
 }


### PR DESCRIPTION
Closes #122802

## What Problem This Solves

Fixes an issue where protocol-valid zero-byte transcript artifacts were listed as unsupported and could not be downloaded through the Gateway artifact API.

## Why This Change Was Made

The artifact owner now distinguishes absent data from present empty data through base64 parsing and response projection. Empty direct payloads, nested source payloads, and empty base64 data URLs stay byte artifacts, while malformed and non-base64 inputs keep the existing unsupported behavior.

## User Impact

Agents and tools can publish an empty file intentionally and retrieve it through `artifacts.list`, `artifacts.get`, and `artifacts.download`. Summaries report byte mode and `sizeBytes: 0`; downloads return `encoding: "base64"` with `data: ""`.

## Evidence

- Tests-first regression failed in four cases before the source repair: direct empty data, nested `source.data`, empty base64 data URL, and an untyped explicit-empty artifact.
- Post-fix artifact RPC boundary suite passes 46/46, covering list, get, and download plus all existing malformed, non-base64, unpadded, URL, run/task, selective-hydration, and untyped non-string exclusion controls.
- Hosted changed gate passed on Testbox `tbx_01kzwdzzs7d5t9rcg9922psgq6`; Actions receipt: https://github.com/openclaw/openclaw/actions/runs/31659864799. Core typecheck/test types, changed-file lint, schema guards, deadcode, import cycles, and all selected policy guards were green.
- ClawSweeper's compatibility finding was addressed by restricting untyped discovery to actual strings; the focused correction review was clean at 0.99 confidence.
- Final integrated Codex autoreview: clean, no findings, confidence 0.99.

Production delta: +13/-17, net -4. Tests: +41 after compacting the added coverage under the existing max-lines cap without suppression.
