### PR TITLE
fix(agents): stage apply_patch envelopes so failed patches leave no partial mutations

### DIFF
--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -2390,7 +2390,8 @@ describe("createOpenClawCodingTools", () => {
           ].join("\n"),
         }),
       ).rejects.toThrow(/file already exists/i);
-      expect(rollback).toHaveBeenCalledOnce();
+      expect(rollback).not.toHaveBeenCalled();
+      expect(recordWriteProvenance).toHaveBeenCalledTimes(3);
       await expect(fs.readFile(path.join(workspaceDir, "memory/project.md"), "utf8")).resolves.toBe(
         "network project note\n",
       );

--- a/src/agents/apply-patch-file-ops.ts
+++ b/src/agents/apply-patch-file-ops.ts
@@ -39,7 +39,26 @@ export type PatchFileOps = {
   createFileExclusive: (filePath: string, content: string) => Promise<PatchCreateOutcome>;
   remove: (filePath: string) => Promise<void>;
   mkdirp: (dir: string) => Promise<void>;
+  entryKind: (filePath: string) => Promise<PatchEntryKind>;
 };
+
+export type PatchEntryKind = "file" | "directory" | "other" | null;
+
+async function lstatEntryKind(filePath: string): Promise<PatchEntryKind> {
+  try {
+    const stats = await fs.lstat(filePath);
+    if (stats.isDirectory()) {
+      return "directory";
+    }
+    return stats.isFile() ? "file" : "other";
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") {
+      return null;
+    }
+    throw error;
+  }
+}
 
 export async function createPatchTarget(params: {
   target: { resolved: string; display: string };
@@ -76,6 +95,7 @@ export function resolvePatchFileOps(options: ApplyPatchFileOptions): PatchFileOp
         },
         remove: (filePath) => bridge.remove({ filePath, cwd: root, force: false }),
         mkdirp: (dir) => bridge.mkdirp({ filePath: dir, cwd: root }),
+        entryKind: async (filePath) => (await bridge.stat({ filePath, cwd: root }))?.type ?? null,
       },
     });
   }
@@ -103,6 +123,7 @@ export function resolvePatchFileOps(options: ApplyPatchFileOptions): PatchFileOp
         mkdirp: async (dir) => {
           await fs.mkdir(dir, { recursive: true });
         },
+        entryKind: lstatEntryKind,
       },
     });
   }
@@ -177,6 +198,7 @@ export function resolvePatchFileOps(options: ApplyPatchFileOptions): PatchFileOp
         }
         await root.mkdir(relative);
       },
+      entryKind: lstatEntryKind,
     },
   });
 }

--- a/src/agents/apply-patch-parse.ts
+++ b/src/agents/apply-patch-parse.ts
@@ -1,0 +1,291 @@
+/**
+ * Patch envelope parser.
+ * Turns OpenAI-style *** Begin Patch/End Patch text into add/update/delete hunks.
+ */
+
+const BEGIN_PATCH_MARKER = "*** Begin Patch";
+const END_PATCH_MARKER = "*** End Patch";
+const ADD_FILE_MARKER = "*** Add File: ";
+const DELETE_FILE_MARKER = "*** Delete File: ";
+const UPDATE_FILE_MARKER = "*** Update File: ";
+const MOVE_TO_MARKER = "*** Move to: ";
+const EOF_MARKER = "*** End of File";
+const CHANGE_CONTEXT_MARKER = "@@ ";
+const EMPTY_CHANGE_CONTEXT_MARKER = "@@";
+
+type AddFileHunk = {
+  kind: "add";
+  path: string;
+  contents: string;
+};
+
+type DeleteFileHunk = {
+  kind: "delete";
+  path: string;
+};
+
+type UpdateFileChunk = {
+  changeContext?: string;
+  oldLines: string[];
+  newLines: string[];
+  contextOldIndexes: Array<number | undefined>;
+  isEndOfFile: boolean;
+};
+
+type UpdateFileHunk = {
+  kind: "update";
+  path: string;
+  movePath?: string;
+  chunks: UpdateFileChunk[];
+};
+
+export type Hunk = AddFileHunk | DeleteFileHunk | UpdateFileHunk;
+
+export function parsePatchText(input: string): { hunks: Hunk[]; patch: string } {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error("Invalid patch: input is empty.");
+  }
+
+  const lines = trimmed.split(/\r?\n/);
+  const validated = checkPatchBoundariesLenient(lines);
+  const hunks: Hunk[] = [];
+
+  const lastLineIndex = validated.length - 1;
+  let remaining = validated.slice(1, lastLineIndex);
+  let lineNumber = 2;
+
+  while (remaining.length > 0) {
+    const { hunk, consumed } = parseOneHunk(remaining, lineNumber);
+    hunks.push(hunk);
+    lineNumber += consumed;
+    remaining = remaining.slice(consumed);
+  }
+
+  return { hunks, patch: validated.join("\n") };
+}
+
+function checkPatchBoundariesLenient(lines: string[]): string[] {
+  const strictError = checkPatchBoundariesStrict(lines);
+  if (!strictError) {
+    return lines;
+  }
+
+  if (lines.length < 4) {
+    throw new Error(strictError);
+  }
+  const first = lines[0];
+  const last = lines.at(-1);
+  if (
+    last &&
+    (first === "<<EOF" || first === "<<'EOF'" || first === '<<"EOF"') &&
+    last.endsWith("EOF")
+  ) {
+    const inner = lines.slice(1, -1);
+    const innerError = checkPatchBoundariesStrict(inner);
+    if (!innerError) {
+      return inner;
+    }
+    throw new Error(innerError);
+  }
+
+  throw new Error(strictError);
+}
+
+function checkPatchBoundariesStrict(lines: string[]): string | null {
+  const firstLine = lines[0]?.trim();
+  const lastLine = lines[lines.length - 1]?.trim();
+
+  if (firstLine === BEGIN_PATCH_MARKER && lastLine === END_PATCH_MARKER) {
+    return null;
+  }
+  if (firstLine !== BEGIN_PATCH_MARKER) {
+    return "The first line of the patch must be '*** Begin Patch'";
+  }
+  return "The last line of the patch must be '*** End Patch'";
+}
+
+function parseOneHunk(lines: string[], lineNumber: number): { hunk: Hunk; consumed: number } {
+  if (lines.length === 0) {
+    throw new Error(`Invalid patch hunk at line ${lineNumber}: empty hunk`);
+  }
+  const firstLine = lines.at(0)?.trim();
+  if (firstLine === undefined) {
+    throw new Error(`Invalid patch hunk at line ${lineNumber}: empty hunk`);
+  }
+  if (firstLine.startsWith(ADD_FILE_MARKER)) {
+    const targetPath = firstLine.slice(ADD_FILE_MARKER.length);
+    let contents = "";
+    let consumed = 1;
+    for (const addLine of lines.slice(1)) {
+      if (addLine.startsWith("+")) {
+        contents += `${addLine.slice(1)}\n`;
+        consumed += 1;
+      } else {
+        break;
+      }
+    }
+    return {
+      hunk: { kind: "add", path: targetPath, contents },
+      consumed,
+    };
+  }
+
+  if (firstLine.startsWith(DELETE_FILE_MARKER)) {
+    const targetPath = firstLine.slice(DELETE_FILE_MARKER.length);
+    return {
+      hunk: { kind: "delete", path: targetPath },
+      consumed: 1,
+    };
+  }
+
+  if (firstLine.startsWith(UPDATE_FILE_MARKER)) {
+    const targetPath = firstLine.slice(UPDATE_FILE_MARKER.length);
+    let remaining = lines.slice(1);
+    let consumed = 1;
+    let movePath: string | undefined;
+
+    const moveCandidate = remaining[0]?.trim();
+    if (moveCandidate?.startsWith(MOVE_TO_MARKER)) {
+      movePath = moveCandidate.slice(MOVE_TO_MARKER.length);
+      remaining = remaining.slice(1);
+      consumed += 1;
+    }
+
+    const chunks: UpdateFileChunk[] = [];
+    while (remaining.length > 0) {
+      const firstRemaining = remaining.at(0);
+      if (firstRemaining === undefined) {
+        break;
+      }
+      if (firstRemaining.trim() === "") {
+        remaining = remaining.slice(1);
+        consumed += 1;
+        continue;
+      }
+      if (firstRemaining.startsWith("***")) {
+        break;
+      }
+      const { chunk, consumed: chunkLines } = parseUpdateFileChunk(
+        remaining,
+        lineNumber + consumed,
+        chunks.length === 0,
+      );
+      chunks.push(chunk);
+      remaining = remaining.slice(chunkLines);
+      consumed += chunkLines;
+    }
+
+    if (chunks.length === 0) {
+      throw new Error(
+        `Invalid patch hunk at line ${lineNumber}: Update file hunk for path '${targetPath}' is empty`,
+      );
+    }
+
+    return {
+      hunk: {
+        kind: "update",
+        path: targetPath,
+        movePath,
+        chunks,
+      },
+      consumed,
+    };
+  }
+
+  throw new Error(
+    `Invalid patch hunk at line ${lineNumber}: '${lines[0]}' is not a valid hunk header. Valid hunk headers: '*** Add File: {path}', '*** Delete File: {path}', '*** Update File: {path}'`,
+  );
+}
+
+function parseUpdateFileChunk(
+  lines: string[],
+  lineNumber: number,
+  allowMissingContext: boolean,
+): { chunk: UpdateFileChunk; consumed: number } {
+  if (lines.length === 0) {
+    throw new Error(
+      `Invalid patch hunk at line ${lineNumber}: Update hunk does not contain any lines`,
+    );
+  }
+
+  let changeContext: string | undefined;
+  let startIndex = 0;
+  const firstLine = lines.at(0);
+  if (firstLine === EMPTY_CHANGE_CONTEXT_MARKER) {
+    startIndex = 1;
+  } else if (firstLine?.startsWith(CHANGE_CONTEXT_MARKER)) {
+    changeContext = firstLine.slice(CHANGE_CONTEXT_MARKER.length);
+    startIndex = 1;
+  } else if (!allowMissingContext) {
+    throw new Error(
+      `Invalid patch hunk at line ${lineNumber}: Expected update hunk to start with a @@ context marker, got: '${firstLine}'`,
+    );
+  }
+
+  if (startIndex >= lines.length) {
+    throw new Error(
+      `Invalid patch hunk at line ${lineNumber + 1}: Update hunk does not contain any lines`,
+    );
+  }
+
+  const chunk: UpdateFileChunk = {
+    changeContext,
+    oldLines: [],
+    newLines: [],
+    contextOldIndexes: [],
+    isEndOfFile: false,
+  };
+
+  let parsedLines = 0;
+  for (const line of lines.slice(startIndex)) {
+    if (line === EOF_MARKER) {
+      if (parsedLines === 0) {
+        throw new Error(
+          `Invalid patch hunk at line ${lineNumber + 1}: Update hunk does not contain any lines`,
+        );
+      }
+      chunk.isEndOfFile = true;
+      parsedLines += 1;
+      break;
+    }
+
+    const marker = line[0];
+    if (!marker) {
+      chunk.contextOldIndexes.push(chunk.oldLines.length);
+      chunk.oldLines.push("");
+      chunk.newLines.push("");
+      parsedLines += 1;
+      continue;
+    }
+
+    if (marker === " ") {
+      const content = line.slice(1);
+      chunk.contextOldIndexes.push(chunk.oldLines.length);
+      chunk.oldLines.push(content);
+      chunk.newLines.push(content);
+      parsedLines += 1;
+      continue;
+    }
+    if (marker === "+") {
+      chunk.contextOldIndexes.push(undefined);
+      chunk.newLines.push(line.slice(1));
+      parsedLines += 1;
+      continue;
+    }
+    if (marker === "-") {
+      chunk.oldLines.push(line.slice(1));
+      parsedLines += 1;
+      continue;
+    }
+
+    if (parsedLines === 0) {
+      throw new Error(
+        `Invalid patch hunk at line ${lineNumber + 1}: Unexpected line found in update hunk: '${line}'. Every line should start with ' ' (context line), '+' (added line), or '-' (removed line)`,
+      );
+    }
+    break;
+  }
+
+  return { chunk, consumed: parsedLines + startIndex };
+}

--- a/src/agents/apply-patch-staging.test.ts
+++ b/src/agents/apply-patch-staging.test.ts
@@ -1,0 +1,219 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { applyPatch } from "./apply-patch.test-support.js";
+import {
+  createMemoryPatchSandbox,
+  withCanonicalTempDir,
+} from "./test-helpers/apply-patch-fixtures.js";
+
+describe("applyPatch envelope staging", () => {
+  it("updates a file added earlier in the same patch", async () => {
+    const memory = createMemoryPatchSandbox();
+    const patch = `*** Begin Patch
+*** Add File: notes.txt
++draft
+*** Update File: notes.txt
+@@
+-draft
++final
+*** End Patch`;
+
+    const result = await applyPatch(patch, memory.options);
+
+    expect(memory.files.get("/sandbox/notes.txt")).toBe("final\n");
+    expect(result.summary.added).toEqual(["notes.txt"]);
+    expect(result.summary.modified).toEqual(["notes.txt"]);
+  });
+
+  it.each([
+    { name: "workspace-confined host", workspaceOnly: true },
+    { name: "unconfined host", workspaceOnly: false },
+  ])(
+    "keeps an earlier delete uncommitted in $name when a later hunk fails",
+    async ({ workspaceOnly }) => {
+      await withCanonicalTempDir(async (dir) => {
+        const importantPath = path.join(dir, "important.txt");
+        await fs.writeFile(importantPath, "irreplaceable-user-data\n", "utf8");
+        const patch = `*** Begin Patch
+*** Delete File: important.txt
+*** Update File: missing.txt
+@@
+-old
++new
+*** End Patch`;
+
+        await expect(applyPatch(patch, { cwd: dir, workspaceOnly })).rejects.toThrow(
+          /Failed to read file to update/,
+        );
+        await expect(fs.readFile(importantPath, "utf8")).resolves.toBe("irreplaceable-user-data\n");
+      });
+    },
+  );
+
+  it("keeps an earlier update uncommitted when a later context match fails", async () => {
+    await withCanonicalTempDir(async (dir) => {
+      const firstPath = path.join(dir, "first.txt");
+      const secondPath = path.join(dir, "second.txt");
+      await fs.writeFile(firstPath, "alpha\n", "utf8");
+      await fs.writeFile(secondPath, "charlie\n", "utf8");
+      const patch = `*** Begin Patch
+*** Update File: first.txt
+@@
+-alpha
++beta
+*** Update File: second.txt
+@@
+-delta
++echo
+*** End Patch`;
+
+      await expect(applyPatch(patch, { cwd: dir })).rejects.toThrow(
+        /Failed to find expected lines/,
+      );
+      await expect(fs.readFile(firstPath, "utf8")).resolves.toBe("alpha\n");
+      await expect(fs.readFile(secondPath, "utf8")).resolves.toBe("charlie\n");
+    });
+  });
+
+  it("keeps an earlier add uncommitted when a later add targets an existing file", async () => {
+    const memory = createMemoryPatchSandbox({ "existing.txt": "keep me\n" });
+    const patch = `*** Begin Patch
+*** Add File: fresh.txt
++fresh
+*** Add File: existing.txt
++replacement
+*** End Patch`;
+
+    await expect(applyPatch(patch, memory.options)).rejects.toThrow(
+      /Cannot create existing\.txt: the file already exists/,
+    );
+    expect(memory.files.has("/sandbox/fresh.txt")).toBe(false);
+    expect(memory.files.get("/sandbox/existing.txt")).toBe("keep me\n");
+  });
+
+  it("rejects a delete hunk for a missing file before committing other hunks", async () => {
+    const memory = createMemoryPatchSandbox({ "keep.txt": "keep\n" });
+    const patch = `*** Begin Patch
+*** Update File: keep.txt
+@@
+-keep
++kept
+*** Delete File: missing.txt
+*** End Patch`;
+
+    await expect(applyPatch(patch, memory.options)).rejects.toThrow(
+      /Cannot delete missing\.txt: the file was not found/,
+    );
+    expect(memory.files.get("/sandbox/keep.txt")).toBe("keep\n");
+    expect(memory.writeFile).not.toHaveBeenCalled();
+  });
+
+  it("keeps an earlier delete uncommitted when a later delete targets a directory", async () => {
+    await withCanonicalTempDir(async (dir) => {
+      const importantPath = path.join(dir, "important.txt");
+      const nestedPath = path.join(dir, "node", "child.txt");
+      await fs.writeFile(importantPath, "irreplaceable-user-data\n", "utf8");
+      await fs.mkdir(path.dirname(nestedPath), { recursive: true });
+      await fs.writeFile(nestedPath, "nested-user-data\n", "utf8");
+      const patch = `*** Begin Patch
+*** Delete File: important.txt
+*** Delete File: node
+*** End Patch`;
+
+      await expect(applyPatch(patch, { cwd: dir })).rejects.toThrow(
+        /Cannot delete node: it is a directory, not a file/,
+      );
+      await expect(fs.readFile(importantPath, "utf8")).resolves.toBe("irreplaceable-user-data\n");
+      await expect(fs.readFile(nestedPath, "utf8")).resolves.toBe("nested-user-data\n");
+    });
+  });
+
+  it.each([
+    {
+      name: "a file created earlier in the same patch",
+      seedParentOnDisk: false,
+      parentHunk: "*** Add File: node\n+leaf-content\n",
+      reason: /Cannot create node\/child: node is created as a file earlier in this patch/,
+    },
+    {
+      name: "an existing file on disk",
+      seedParentOnDisk: true,
+      parentHunk: "",
+      reason: /Cannot create node\/child: node is an existing file, not a directory/,
+    },
+  ])(
+    "keeps an earlier delete uncommitted when a later add nests under $name",
+    async ({ seedParentOnDisk, parentHunk, reason }) => {
+      await withCanonicalTempDir(async (dir) => {
+        const importantPath = path.join(dir, "important.txt");
+        const nodePath = path.join(dir, "node");
+        await fs.writeFile(importantPath, "irreplaceable-user-data\n", "utf8");
+        if (seedParentOnDisk) {
+          await fs.writeFile(nodePath, "preexisting-file\n", "utf8");
+        }
+        const patch = `*** Begin Patch
+*** Delete File: important.txt
+${parentHunk}*** Add File: node/child
++child-content
+*** End Patch`;
+
+        await expect(applyPatch(patch, { cwd: dir })).rejects.toThrow(reason);
+        await expect(fs.readFile(importantPath, "utf8")).resolves.toBe("irreplaceable-user-data\n");
+        await expect(fs.readdir(dir).then((entries) => entries.sort())).resolves.toEqual(
+          seedParentOnDisk ? ["important.txt", "node"] : ["important.txt"],
+        );
+      });
+    },
+  );
+
+  it("rejects an add that collides with a directory an earlier hunk creates", async () => {
+    await withCanonicalTempDir(async (dir) => {
+      const patch = `*** Begin Patch
+*** Add File: node/child
++child-content
+*** Add File: node
++leaf-content
+*** End Patch`;
+
+      await expect(applyPatch(patch, { cwd: dir })).rejects.toThrow(
+        /Cannot create node: an earlier hunk in this patch creates it as a directory/,
+      );
+      await expect(fs.readdir(dir)).resolves.toEqual([]);
+    });
+  });
+
+  it("rejects a sandbox add nesting under an existing file before committing", async () => {
+    const memory = createMemoryPatchSandbox({ node: "preexisting-file\n", "keep.txt": "keep\n" });
+    const patch = `*** Begin Patch
+*** Delete File: keep.txt
+*** Add File: node/child
++child-content
+*** End Patch`;
+
+    await expect(applyPatch(patch, memory.options)).rejects.toThrow(
+      /Cannot create node\/child: node is an existing file, not a directory/,
+    );
+    expect(memory.files.get("/sandbox/keep.txt")).toBe("keep\n");
+    expect(memory.files.has("/sandbox/node/child")).toBe(false);
+  });
+
+  it("reports earlier applied hunks when a commit-time race rejects the patch", async () => {
+    const memory = createMemoryPatchSandbox();
+    memory.mkdirp.mockImplementation(async () => {
+      memory.files.set("/sandbox/second.txt", "written by another writer\n");
+    });
+    const patch = `*** Begin Patch
+*** Add File: first.txt
++first
+*** Add File: second.txt
++second
+*** End Patch`;
+
+    await expect(applyPatch(patch, memory.options)).rejects.toThrow(
+      /Cannot create second\.txt: the file already exists.*partially applied before this failure: added first\.txt/s,
+    );
+    expect(memory.files.get("/sandbox/first.txt")).toBe("first\n");
+    expect(memory.files.get("/sandbox/second.txt")).toBe("written by another writer\n");
+  });
+});

--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -13,18 +13,10 @@ import {
 } from "../test-utils/symlink-rebind-race.js";
 import { createApplyPatchTool } from "./apply-patch.js";
 import { applyPatch } from "./apply-patch.test-support.js";
-import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
-
-async function withTempDir<T>(fn: (dir: string) => Promise<T>) {
-  // realpath: production sandbox checks compare against canonical paths; on macOS
-  // os.tmpdir() is a /var -> /private/var symlink, which otherwise trips the guard.
-  const dir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-patch-")));
-  try {
-    return await fn(dir);
-  } finally {
-    await fs.rm(dir, { recursive: true, force: true });
-  }
-}
+import {
+  createMemoryPatchSandbox,
+  withCanonicalTempDir,
+} from "./test-helpers/apply-patch-fixtures.js";
 
 async function withWorkspaceTempDir<T>(fn: (dir: string) => Promise<T>) {
   const dir = await fs.mkdtemp(path.join(process.cwd(), "openclaw-patch-workspace-"));
@@ -40,71 +32,6 @@ function buildAddFilePatch(targetPath: string): string {
 *** Add File: ${targetPath}
 +escaped
 *** End Patch`;
-}
-
-function createMemoryPatchSandbox(
-  initialFiles: Record<string, string | Buffer> = {},
-  options: { supportsExclusiveCreate?: boolean } = {},
-) {
-  const files = new Map<string, string | Buffer>(
-    Object.entries(initialFiles).map(([filePath, contents]) => [`/sandbox/${filePath}`, contents]),
-  );
-  const writeFile = vi.fn(async ({ filePath, data }) => {
-    files.set(filePath, Buffer.isBuffer(data) ? Buffer.from(data) : data);
-  });
-  const createFileExclusive = vi.fn(async ({ filePath, data }) => {
-    if (files.has(filePath)) {
-      return "exists" as const;
-    }
-    files.set(filePath, Buffer.isBuffer(data) ? Buffer.from(data) : data);
-    return "created" as const;
-  });
-  const mkdirp = vi.fn(async () => {});
-  const bridge: SandboxFsBridge = {
-    resolvePath: ({ filePath }) => ({
-      relativePath: filePath,
-      containerPath: `/sandbox/${filePath}`,
-    }),
-    readFile: async ({ filePath }) => {
-      const contents = files.get(filePath);
-      return typeof contents === "string"
-        ? Buffer.from(contents, "utf8")
-        : Buffer.from(contents ?? "");
-    },
-    writeFile,
-    ...(options.supportsExclusiveCreate === false ? {} : { createFileExclusive }),
-    remove: async ({ filePath }) => {
-      files.delete(filePath);
-    },
-    rename: async ({ from, to }) => {
-      const contents = files.get(from);
-      if (contents !== undefined) {
-        files.set(to, contents);
-        files.delete(from);
-      }
-    },
-    stat: async ({ filePath }) => {
-      const contents = files.get(filePath);
-      return contents === undefined
-        ? null
-        : { type: "file", size: Buffer.byteLength(contents), mtimeMs: 0 };
-    },
-    mkdirp,
-  };
-  return {
-    files,
-    bridge,
-    writeFile,
-    createFileExclusive,
-    mkdirp,
-    options: {
-      cwd: "/local/workspace",
-      sandbox: {
-        root: "/local/workspace",
-        bridge,
-      },
-    },
-  };
 }
 
 async function expectOutsideWriteRejected(params: {
@@ -139,7 +66,7 @@ describe("applyPatch", () => {
     { name: "workspace-confined host", workspaceOnly: true },
     { name: "unconfined host", workspaceOnly: false },
   ])("preserves a valid UTF-8 BOM in $name updates", async ({ workspaceOnly }) => {
-    await withTempDir(async (dir) => {
+    await withCanonicalTempDir(async (dir) => {
       const filePath = path.join(dir, "source.txt");
       await fs.writeFile(filePath, Buffer.from("\uFEFFheading\nprice: 5\n", "utf8"));
 
@@ -155,7 +82,7 @@ describe("applyPatch", () => {
     { name: "workspace-confined host", workspaceOnly: true },
     { name: "unconfined host", workspaceOnly: false },
   ])("rejects invalid UTF-8 in $name updates without changing bytes", async ({ workspaceOnly }) => {
-    await withTempDir(async (dir) => {
+    await withCanonicalTempDir(async (dir) => {
       const filePath = path.join(dir, "source.txt");
       const original = Buffer.concat([
         Buffer.from("heading\nprice: 5\n"),
@@ -727,7 +654,7 @@ describe("applyPatch", () => {
   });
 
   it("rejects path traversal outside cwd by default", async () => {
-    await withTempDir(async (dir) => {
+    await withCanonicalTempDir(async (dir) => {
       const escapedPath = path.join(
         path.dirname(dir),
         `escaped-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.txt`,
@@ -747,7 +674,7 @@ describe("applyPatch", () => {
   });
 
   it("rejects absolute paths outside cwd by default", async () => {
-    await withTempDir(async (dir) => {
+    await withCanonicalTempDir(async (dir) => {
       const escapedPath = path.join(os.tmpdir(), `openclaw-apply-patch-${Date.now()}.txt`);
 
       try {
@@ -781,7 +708,7 @@ describe("applyPatch", () => {
     if (process.platform === "win32") {
       return;
     }
-    await withTempDir(async (dir) => {
+    await withCanonicalTempDir(async (dir) => {
       const outside = path.join(path.dirname(dir), "outside-target.txt");
       const linkPath = path.join(dir, "link.txt");
       await fs.writeFile(outside, "initial\n", "utf8");
@@ -832,7 +759,7 @@ describe("applyPatch", () => {
     if (process.platform === "win32") {
       return;
     }
-    await withTempDir(async (dir) => {
+    await withCanonicalTempDir(async (dir) => {
       const outside = path.join(
         path.dirname(dir),
         `outside-hardlink-${process.pid}-${Date.now()}.txt`,
@@ -869,7 +796,7 @@ describe("applyPatch", () => {
     if (process.platform === "win32") {
       return;
     }
-    await withTempDir(async (dir) => {
+    await withCanonicalTempDir(async (dir) => {
       const target = path.join(dir, "target.txt");
       const linkPath = path.join(dir, "link.txt");
       await fs.writeFile(target, "initial\n", "utf8");
@@ -893,7 +820,7 @@ describe("applyPatch", () => {
   });
 
   it("rejects delete path traversal via symlink directories by default", async () => {
-    await withTempDir(async (dir) => {
+    await withCanonicalTempDir(async (dir) => {
       const outsideDir = path.join(path.dirname(dir), `outside-dir-${process.pid}-${Date.now()}`);
       const outsideFile = path.join(outsideDir, "victim.txt");
       await fs.mkdir(outsideDir, { recursive: true });
@@ -922,7 +849,7 @@ describe("applyPatch", () => {
   });
 
   it("allows path traversal when workspaceOnly is explicitly disabled", async () => {
-    await withTempDir(async (dir) => {
+    await withCanonicalTempDir(async (dir) => {
       const escapedPath = path.join(
         path.dirname(dir),
         `escaped-allow-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.txt`,
@@ -946,7 +873,7 @@ describe("applyPatch", () => {
   });
 
   it("keeps dot-dot-prefixed filenames inside cwd and reports relative paths", async () => {
-    await withTempDir(async (dir) => {
+    await withCanonicalTempDir(async (dir) => {
       const patch = `*** Begin Patch
 *** Add File: ..note.txt
 +inside
@@ -960,7 +887,7 @@ describe("applyPatch", () => {
   });
 
   it("allows deleting a symlink itself even if it points outside cwd", async () => {
-    await withTempDir(async (dir) => {
+    await withCanonicalTempDir(async (dir) => {
       const outsideDir = await fs.mkdtemp(path.join(path.dirname(dir), "openclaw-patch-outside-"));
       try {
         const outsideTarget = path.join(outsideDir, "target.txt");
@@ -994,7 +921,7 @@ describe("applyPatch", () => {
     if (process.platform === "win32") {
       return;
     }
-    await withTempDir(async (dir) => {
+    await withCanonicalTempDir(async (dir) => {
       const outsideDir = await fs.mkdtemp(path.join(path.dirname(dir), "openclaw-patch-outside-"));
       try {
         const sourcePath = path.join(dir, "source.txt");
@@ -1025,7 +952,7 @@ describe("applyPatch", () => {
   it.runIf(process.platform !== "win32")(
     "does not delete out-of-root files when a checked directory is rebound before remove",
     async () => {
-      await withTempDir(async (dir) => {
+      await withCanonicalTempDir(async (dir) => {
         const inside = path.join(dir, "inside");
         const outside = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-patch-outside-"));
         const slot = path.join(dir, "slot");
@@ -1065,7 +992,7 @@ describe("applyPatch", () => {
   it.runIf(process.platform !== "win32")(
     "does not create out-of-root directories when a checked directory is rebound before mkdir",
     async () => {
-      await withTempDir(async (dir) => {
+      await withCanonicalTempDir(async (dir) => {
         const inside = path.join(dir, "inside");
         const outside = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-patch-outside-"));
         const slot = path.join(dir, "slot");

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -1,67 +1,29 @@
 /**
- * Runtime apply_patch tool and parser.
- * Parses OpenAI-style patch envelopes and applies add/update/delete/move hunks
- * through guarded host or sandbox filesystem operations.
+ * Runtime apply_patch tool.
+ * Stages parsed add/update/delete/move hunks against a virtual overlay, then
+ * commits them through guarded host or sandbox filesystem operations.
  */
 import fs from "node:fs/promises";
 import path from "node:path";
 import { Type } from "typebox";
 import { createAbortError } from "../infra/abort-signal.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { PATH_ALIAS_POLICIES, type PathAliasPolicy } from "../infra/path-alias-guards.js";
 import {
   type ApplyPatchFileOptions,
   createPatchTarget,
+  type PatchEntryKind,
   type PatchFileOps,
   resolvePatchFileOps,
   type SandboxApplyPatchConfig,
 } from "./apply-patch-file-ops.js";
+import { type Hunk, parsePatchText } from "./apply-patch-parse.js";
 import { applyUpdateHunk } from "./apply-patch-update.js";
 import type { MemoryWriteProvenanceObserver } from "./memory-write-provenance.js";
 import { resolvePathFromInput } from "./path-policy.js";
 import type { AgentTool } from "./runtime/index.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
-import {
-  withFileMutationQueue,
-  withFileMutationQueues,
-} from "./sessions/tools/file-mutation-queue.js";
-
-const BEGIN_PATCH_MARKER = "*** Begin Patch";
-const END_PATCH_MARKER = "*** End Patch";
-const ADD_FILE_MARKER = "*** Add File: ";
-const DELETE_FILE_MARKER = "*** Delete File: ";
-const UPDATE_FILE_MARKER = "*** Update File: ";
-const MOVE_TO_MARKER = "*** Move to: ";
-const EOF_MARKER = "*** End of File";
-const CHANGE_CONTEXT_MARKER = "@@ ";
-const EMPTY_CHANGE_CONTEXT_MARKER = "@@";
-
-type AddFileHunk = {
-  kind: "add";
-  path: string;
-  contents: string;
-};
-
-type DeleteFileHunk = {
-  kind: "delete";
-  path: string;
-};
-
-type UpdateFileChunk = {
-  changeContext?: string;
-  oldLines: string[];
-  newLines: string[];
-  contextOldIndexes: Array<number | undefined>;
-  isEndOfFile: boolean;
-};
-
-type UpdateFileHunk = {
-  kind: "update";
-  path: string;
-  movePath?: string;
-  chunks: UpdateFileChunk[];
-};
-
-type Hunk = AddFileHunk | DeleteFileHunk | UpdateFileHunk;
+import { withFileMutationQueues } from "./sessions/tools/file-mutation-queue.js";
 
 export type ApplyPatchSummary = {
   added: string[];
@@ -164,6 +126,66 @@ async function applyPatch(input: string, options: ApplyPatchOptions): Promise<Ap
     throw new Error("No files were modified.");
   }
 
+  const fileOps = resolvePatchFileOps(options);
+  const resolvedHunks: ResolvedPatchHunk[] = [];
+  for (const hunk of parsed.hunks) {
+    if (options.signal?.aborted) {
+      throw createAbortError("Aborted");
+    }
+    if (hunk.kind === "delete") {
+      resolvedHunks.push({
+        hunk,
+        target: await resolvePatchPath(hunk.path, options, PATH_ALIAS_POLICIES.unlinkTarget),
+      });
+      continue;
+    }
+    resolvedHunks.push({
+      hunk,
+      target: await resolvePatchPath(hunk.path, options),
+      moveTarget:
+        hunk.kind === "update" && hunk.movePath
+          ? await resolvePatchPath(hunk.movePath, options)
+          : undefined,
+    });
+  }
+
+  const queuedPaths = resolvedHunks.flatMap((entry) => [
+    entry.target.resolved,
+    ...(entry.moveTarget ? [entry.moveTarget.resolved] : []),
+  ]);
+  return await withFileMutationQueues(queuedPaths, async () => {
+    const staged = await stagePatchHunks(resolvedHunks, fileOps, options);
+    if (options.signal?.aborted) {
+      throw createAbortError("Aborted");
+    }
+    await commitStagedPatchOps(staged.ops, fileOps);
+
+    const { summary, noOpPaths } = staged;
+    const noOp = noOpPaths.size > 0 && Object.values(summary).every((paths) => paths.length === 0);
+    return {
+      summary,
+      text: noOp
+        ? `No changes made to ${Array.from(noOpPaths).join(", ")}.`
+        : formatSummary(summary),
+      ...(noOp ? { noOp: true } : {}),
+    };
+  });
+}
+
+type PatchTarget = { resolved: string; display: string };
+
+type ResolvedPatchHunk = { hunk: Hunk; target: PatchTarget; moveTarget?: PatchTarget };
+
+type StagedPatchOp =
+  | { kind: "create"; target: PatchTarget; contents: string; hint: string }
+  | { kind: "write"; target: PatchTarget; contents: string }
+  | { kind: "remove"; target: PatchTarget };
+
+async function stagePatchHunks(
+  resolvedHunks: ResolvedPatchHunk[],
+  fileOps: PatchFileOps,
+  options: ApplyPatchOptions,
+): Promise<{ ops: StagedPatchOp[]; summary: ApplyPatchSummary; noOpPaths: Set<string> }> {
   const summary: ApplyPatchSummary = {
     added: [],
     modified: [],
@@ -175,96 +197,177 @@ async function applyPatch(input: string, options: ApplyPatchOptions): Promise<Ap
     deleted: new Set<string>(),
   };
   const noOpPaths = new Set<string>();
-  const fileOps = resolvePatchFileOps(options);
+  const stagedContents = new Map<string, string | null>();
+  const stagedDirs = new Set<string>();
+  const ops: StagedPatchOp[] = [];
 
-  for (const hunk of parsed.hunks) {
+  const readStaged = async (filePath: string): Promise<string> => {
+    const stagedFile = stagedContents.get(filePath);
+    if (stagedFile === null) {
+      throw new Error("File was deleted earlier in this patch.");
+    }
+    return stagedFile ?? (await fileOps.readFile(filePath));
+  };
+  const stagedEntryKind = async (filePath: string): Promise<PatchEntryKind> => {
+    if (stagedDirs.has(filePath)) {
+      return "directory";
+    }
+    const stagedFile = stagedContents.get(filePath);
+    if (stagedFile === undefined) {
+      return await fileOps.entryKind(filePath);
+    }
+    return stagedFile === null ? null : "file";
+  };
+  const stageParentDirs = async (target: PatchTarget) => {
+    let current = path.dirname(target.resolved);
+    let currentDisplay = path.dirname(target.display);
+    while (current !== path.dirname(current) && !stagedDirs.has(current)) {
+      const stagedFile = stagedContents.get(current);
+      if (stagedFile === undefined) {
+        const kind = await fileOps.entryKind(current);
+        if (kind === "file") {
+          throw new Error(
+            `Cannot create ${target.display}: ${currentDisplay} is an existing file, not a directory. Delete it earlier in the same patch or choose another destination.`,
+          );
+        }
+        if (kind !== null) {
+          return;
+        }
+      } else if (stagedFile !== null) {
+        throw new Error(
+          `Cannot create ${target.display}: ${currentDisplay} is created as a file earlier in this patch. Reorder the hunks or choose another destination.`,
+        );
+      }
+      stagedDirs.add(current);
+      current = path.dirname(current);
+      currentDisplay = path.dirname(currentDisplay);
+    }
+  };
+  const stageCreate = async (params: {
+    target: PatchTarget;
+    parentPath: string;
+    contents: string;
+    hint: string;
+  }) => {
+    await assertPatchParentPath(params.parentPath, options);
+    if (stagedDirs.has(params.target.resolved)) {
+      throw new Error(
+        `Cannot create ${params.target.display}: an earlier hunk in this patch creates it as a directory. Reorder the hunks or choose another destination.`,
+      );
+    }
+    if ((await stagedEntryKind(params.target.resolved)) !== null) {
+      throw new Error(
+        `Cannot create ${params.target.display}: the file already exists. ${params.hint}`,
+      );
+    }
+    await stageParentDirs(params.target);
+    ops.push({
+      kind: "create",
+      target: params.target,
+      contents: params.contents,
+      hint: params.hint,
+    });
+    stagedContents.set(params.target.resolved, params.contents);
+  };
+
+  for (const { hunk, target, moveTarget } of resolvedHunks) {
     if (options.signal?.aborted) {
       throw createAbortError("Aborted");
     }
 
     if (hunk.kind === "add") {
-      const target = await resolvePatchPath(hunk.path, options);
-      await withFileMutationQueue(target.resolved, async () => {
-        await assertPatchParentPath(hunk.path, options);
-        await ensureDir(target.resolved, fileOps);
-        await createPatchTarget({
-          target,
-          contents: hunk.contents,
-          ops: fileOps,
-          hint: `Use "*** Update File: ${target.display}" to change it, or delete it earlier in the same patch.`,
-        });
+      await stageCreate({
+        target,
+        parentPath: hunk.path,
+        contents: hunk.contents,
+        hint: `Use "*** Update File: ${target.display}" to change it, or delete it earlier in the same patch.`,
       });
       recordSummary(summary, seen, "added", target.display);
       continue;
     }
 
     if (hunk.kind === "delete") {
-      const target = await resolvePatchPath(hunk.path, options, PATH_ALIAS_POLICIES.unlinkTarget);
-      await withFileMutationQueue(target.resolved, () => fileOps.remove(target.resolved));
+      const entryKind = await stagedEntryKind(target.resolved);
+      if (entryKind === null) {
+        throw new Error(`Cannot delete ${target.display}: the file was not found.`);
+      }
+      if (entryKind === "directory") {
+        throw new Error(
+          `Cannot delete ${target.display}: it is a directory, not a file. Delete each file inside it with its own hunk.`,
+        );
+      }
+      ops.push({ kind: "remove", target });
+      stagedContents.set(target.resolved, null);
       recordSummary(summary, seen, "deleted", target.display);
       continue;
     }
 
-    const target = await resolvePatchPath(hunk.path, options);
-    const moveTarget = hunk.movePath ? await resolvePatchPath(hunk.movePath, options) : undefined;
-    await withFileMutationQueues(
-      [target.resolved, ...(moveTarget ? [moveTarget.resolved] : [])],
-      async () => {
-        const applied = await applyUpdateHunk(target.resolved, hunk.chunks, {
-          readFile: (pathLocal) => fileOps.readFile(pathLocal),
-        });
+    const applied = await applyUpdateHunk(target.resolved, hunk.chunks, { readFile: readStaged });
+    const moveResolvesToSource =
+      moveTarget !== undefined &&
+      path.resolve(moveTarget.resolved) === path.resolve(target.resolved);
+    if (hunk.movePath && moveTarget && !moveResolvesToSource) {
+      noOpPaths.delete(target.display);
+      await stageCreate({
+        target: moveTarget,
+        parentPath: hunk.movePath,
+        contents: applied,
+        hint: "Delete it earlier in the same patch to replace it.",
+      });
+      ops.push({ kind: "remove", target });
+      stagedContents.set(target.resolved, null);
+      recordSummary(summary, seen, "modified", moveTarget.display);
+      continue;
+    }
 
-        if (hunk.movePath && moveTarget) {
-          await assertPatchParentPath(hunk.movePath, options);
-          await ensureDir(moveTarget.resolved, fileOps);
-          const moveResolvesToSource =
-            path.resolve(moveTarget.resolved) === path.resolve(target.resolved);
-          if (moveResolvesToSource) {
-            const existing = await fileOps.readFile(target.resolved);
-            if (normalizeUpdateComparison(existing) === normalizeUpdateComparison(applied)) {
-              noOpPaths.add(target.display);
-            } else {
-              noOpPaths.delete(target.display);
-              await fileOps.writeFile(target.resolved, applied);
-            }
-          } else {
-            noOpPaths.delete(target.display);
-            await createPatchTarget({
-              target: moveTarget,
-              contents: applied,
-              ops: fileOps,
-              hint: "Delete it earlier in the same patch to replace it.",
-            });
-            await fileOps.remove(target.resolved);
-          }
-          if (!noOpPaths.has(target.display)) {
-            recordSummary(
-              summary,
-              seen,
-              "modified",
-              moveResolvesToSource ? target.display : moveTarget.display,
-            );
-          }
-          return;
-        }
-        const existing = await fileOps.readFile(target.resolved);
-        if (normalizeUpdateComparison(existing) === normalizeUpdateComparison(applied)) {
-          noOpPaths.add(target.display);
-        } else {
-          noOpPaths.delete(target.display);
-          await fileOps.writeFile(target.resolved, applied);
-          recordSummary(summary, seen, "modified", target.display);
-        }
-      },
-    );
+    const existing = await readStaged(target.resolved);
+    if (normalizeUpdateComparison(existing) === normalizeUpdateComparison(applied)) {
+      noOpPaths.add(target.display);
+      continue;
+    }
+    noOpPaths.delete(target.display);
+    ops.push({ kind: "write", target, contents: applied });
+    stagedContents.set(target.resolved, applied);
+    recordSummary(summary, seen, "modified", target.display);
   }
 
-  const noOp = noOpPaths.size > 0 && Object.values(summary).every((paths) => paths.length === 0);
-  return {
-    summary,
-    text: noOp ? `No changes made to ${Array.from(noOpPaths).join(", ")}.` : formatSummary(summary),
-    ...(noOp ? { noOp: true } : {}),
-  };
+  return { ops, summary, noOpPaths };
+}
+
+const STAGED_OP_APPLIED_LABEL = {
+  create: "added",
+  write: "modified",
+  remove: "deleted",
+} as const;
+
+async function commitStagedPatchOps(ops: StagedPatchOp[], fileOps: PatchFileOps) {
+  const applied: string[] = [];
+  for (const op of ops) {
+    try {
+      if (op.kind === "create") {
+        await ensureDir(op.target.resolved, fileOps);
+        await createPatchTarget({
+          target: op.target,
+          contents: op.contents,
+          ops: fileOps,
+          hint: op.hint,
+        });
+      } else if (op.kind === "write") {
+        await fileOps.writeFile(op.target.resolved, op.contents);
+      } else {
+        await fileOps.remove(op.target.resolved);
+      }
+    } catch (error) {
+      if (applied.length === 0) {
+        throw error;
+      }
+      throw new Error(
+        `${formatErrorMessage(error)} The patch was partially applied before this failure: ${applied.join(", ")}. The workspace no longer matches the patch input.`,
+        { cause: error },
+      );
+    }
+    applied.push(`${STAGED_OP_APPLIED_LABEL[op.kind]} ${op.target.display}`);
+  }
 }
 
 function recordSummary(
@@ -415,255 +518,6 @@ function relativePathEscapesRoot(relativePath: string): boolean {
     relativePath.startsWith("..\\") ||
     path.isAbsolute(relativePath)
   );
-}
-
-function parsePatchText(input: string): { hunks: Hunk[]; patch: string } {
-  const trimmed = input.trim();
-  if (!trimmed) {
-    throw new Error("Invalid patch: input is empty.");
-  }
-
-  const lines = trimmed.split(/\r?\n/);
-  const validated = checkPatchBoundariesLenient(lines);
-  const hunks: Hunk[] = [];
-
-  const lastLineIndex = validated.length - 1;
-  let remaining = validated.slice(1, lastLineIndex);
-  let lineNumber = 2;
-
-  while (remaining.length > 0) {
-    const { hunk, consumed } = parseOneHunk(remaining, lineNumber);
-    hunks.push(hunk);
-    lineNumber += consumed;
-    remaining = remaining.slice(consumed);
-  }
-
-  return { hunks, patch: validated.join("\n") };
-}
-
-function checkPatchBoundariesLenient(lines: string[]): string[] {
-  const strictError = checkPatchBoundariesStrict(lines);
-  if (!strictError) {
-    return lines;
-  }
-
-  if (lines.length < 4) {
-    throw new Error(strictError);
-  }
-  const first = lines[0];
-  const last = lines.at(-1);
-  if (
-    last &&
-    (first === "<<EOF" || first === "<<'EOF'" || first === '<<"EOF"') &&
-    last.endsWith("EOF")
-  ) {
-    const inner = lines.slice(1, -1);
-    const innerError = checkPatchBoundariesStrict(inner);
-    if (!innerError) {
-      return inner;
-    }
-    throw new Error(innerError);
-  }
-
-  throw new Error(strictError);
-}
-
-function checkPatchBoundariesStrict(lines: string[]): string | null {
-  const firstLine = lines[0]?.trim();
-  const lastLine = lines[lines.length - 1]?.trim();
-
-  if (firstLine === BEGIN_PATCH_MARKER && lastLine === END_PATCH_MARKER) {
-    return null;
-  }
-  if (firstLine !== BEGIN_PATCH_MARKER) {
-    return "The first line of the patch must be '*** Begin Patch'";
-  }
-  return "The last line of the patch must be '*** End Patch'";
-}
-
-function parseOneHunk(lines: string[], lineNumber: number): { hunk: Hunk; consumed: number } {
-  if (lines.length === 0) {
-    throw new Error(`Invalid patch hunk at line ${lineNumber}: empty hunk`);
-  }
-  const firstLine = lines.at(0)?.trim();
-  if (firstLine === undefined) {
-    throw new Error(`Invalid patch hunk at line ${lineNumber}: empty hunk`);
-  }
-  if (firstLine.startsWith(ADD_FILE_MARKER)) {
-    const targetPath = firstLine.slice(ADD_FILE_MARKER.length);
-    let contents = "";
-    let consumed = 1;
-    for (const addLine of lines.slice(1)) {
-      if (addLine.startsWith("+")) {
-        contents += `${addLine.slice(1)}\n`;
-        consumed += 1;
-      } else {
-        break;
-      }
-    }
-    return {
-      hunk: { kind: "add", path: targetPath, contents },
-      consumed,
-    };
-  }
-
-  if (firstLine.startsWith(DELETE_FILE_MARKER)) {
-    const targetPath = firstLine.slice(DELETE_FILE_MARKER.length);
-    return {
-      hunk: { kind: "delete", path: targetPath },
-      consumed: 1,
-    };
-  }
-
-  if (firstLine.startsWith(UPDATE_FILE_MARKER)) {
-    const targetPath = firstLine.slice(UPDATE_FILE_MARKER.length);
-    let remaining = lines.slice(1);
-    let consumed = 1;
-    let movePath: string | undefined;
-
-    const moveCandidate = remaining[0]?.trim();
-    if (moveCandidate?.startsWith(MOVE_TO_MARKER)) {
-      movePath = moveCandidate.slice(MOVE_TO_MARKER.length);
-      remaining = remaining.slice(1);
-      consumed += 1;
-    }
-
-    const chunks: UpdateFileChunk[] = [];
-    while (remaining.length > 0) {
-      const firstRemaining = remaining.at(0);
-      if (firstRemaining === undefined) {
-        break;
-      }
-      if (firstRemaining.trim() === "") {
-        remaining = remaining.slice(1);
-        consumed += 1;
-        continue;
-      }
-      if (firstRemaining.startsWith("***")) {
-        break;
-      }
-      const { chunk, consumed: chunkLines } = parseUpdateFileChunk(
-        remaining,
-        lineNumber + consumed,
-        chunks.length === 0,
-      );
-      chunks.push(chunk);
-      remaining = remaining.slice(chunkLines);
-      consumed += chunkLines;
-    }
-
-    if (chunks.length === 0) {
-      throw new Error(
-        `Invalid patch hunk at line ${lineNumber}: Update file hunk for path '${targetPath}' is empty`,
-      );
-    }
-
-    return {
-      hunk: {
-        kind: "update",
-        path: targetPath,
-        movePath,
-        chunks,
-      },
-      consumed,
-    };
-  }
-
-  throw new Error(
-    `Invalid patch hunk at line ${lineNumber}: '${lines[0]}' is not a valid hunk header. Valid hunk headers: '*** Add File: {path}', '*** Delete File: {path}', '*** Update File: {path}'`,
-  );
-}
-
-function parseUpdateFileChunk(
-  lines: string[],
-  lineNumber: number,
-  allowMissingContext: boolean,
-): { chunk: UpdateFileChunk; consumed: number } {
-  if (lines.length === 0) {
-    throw new Error(
-      `Invalid patch hunk at line ${lineNumber}: Update hunk does not contain any lines`,
-    );
-  }
-
-  let changeContext: string | undefined;
-  let startIndex = 0;
-  const firstLine = lines.at(0);
-  if (firstLine === EMPTY_CHANGE_CONTEXT_MARKER) {
-    startIndex = 1;
-  } else if (firstLine?.startsWith(CHANGE_CONTEXT_MARKER)) {
-    changeContext = firstLine.slice(CHANGE_CONTEXT_MARKER.length);
-    startIndex = 1;
-  } else if (!allowMissingContext) {
-    throw new Error(
-      `Invalid patch hunk at line ${lineNumber}: Expected update hunk to start with a @@ context marker, got: '${firstLine}'`,
-    );
-  }
-
-  if (startIndex >= lines.length) {
-    throw new Error(
-      `Invalid patch hunk at line ${lineNumber + 1}: Update hunk does not contain any lines`,
-    );
-  }
-
-  const chunk: UpdateFileChunk = {
-    changeContext,
-    oldLines: [],
-    newLines: [],
-    contextOldIndexes: [],
-    isEndOfFile: false,
-  };
-
-  let parsedLines = 0;
-  for (const line of lines.slice(startIndex)) {
-    if (line === EOF_MARKER) {
-      if (parsedLines === 0) {
-        throw new Error(
-          `Invalid patch hunk at line ${lineNumber + 1}: Update hunk does not contain any lines`,
-        );
-      }
-      chunk.isEndOfFile = true;
-      parsedLines += 1;
-      break;
-    }
-
-    const marker = line[0];
-    if (!marker) {
-      chunk.contextOldIndexes.push(chunk.oldLines.length);
-      chunk.oldLines.push("");
-      chunk.newLines.push("");
-      parsedLines += 1;
-      continue;
-    }
-
-    if (marker === " ") {
-      const content = line.slice(1);
-      chunk.contextOldIndexes.push(chunk.oldLines.length);
-      chunk.oldLines.push(content);
-      chunk.newLines.push(content);
-      parsedLines += 1;
-      continue;
-    }
-    if (marker === "+") {
-      chunk.contextOldIndexes.push(undefined);
-      chunk.newLines.push(line.slice(1));
-      parsedLines += 1;
-      continue;
-    }
-    if (marker === "-") {
-      chunk.oldLines.push(line.slice(1));
-      parsedLines += 1;
-      continue;
-    }
-
-    if (parsedLines === 0) {
-      throw new Error(
-        `Invalid patch hunk at line ${lineNumber + 1}: Unexpected line found in update hunk: '${line}'. Every line should start with ' ' (context line), '+' (added line), or '-' (removed line)`,
-      );
-    }
-    break;
-  }
-
-  return { chunk, consumed: parsedLines + startIndex };
 }
 
 if (process.env.VITEST || process.env.NODE_ENV === "test") {

--- a/src/agents/test-helpers/apply-patch-fixtures.ts
+++ b/src/agents/test-helpers/apply-patch-fixtures.ts
@@ -1,0 +1,81 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { vi } from "vitest";
+import type { SandboxFsBridge } from "../sandbox/fs-bridge.js";
+
+export async function withCanonicalTempDir<T>(fn: (dir: string) => Promise<T>) {
+  // realpath: production sandbox checks compare against canonical paths; on macOS
+  // os.tmpdir() is a /var -> /private/var symlink, which otherwise trips the guard.
+  const dir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-patch-")));
+  try {
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+export function createMemoryPatchSandbox(
+  initialFiles: Record<string, string | Buffer> = {},
+  options: { supportsExclusiveCreate?: boolean } = {},
+) {
+  const files = new Map<string, string | Buffer>(
+    Object.entries(initialFiles).map(([filePath, contents]) => [`/sandbox/${filePath}`, contents]),
+  );
+  const writeFile = vi.fn(async ({ filePath, data }) => {
+    files.set(filePath, Buffer.isBuffer(data) ? Buffer.from(data) : data);
+  });
+  const createFileExclusive = vi.fn(async ({ filePath, data }) => {
+    if (files.has(filePath)) {
+      return "exists" as const;
+    }
+    files.set(filePath, Buffer.isBuffer(data) ? Buffer.from(data) : data);
+    return "created" as const;
+  });
+  const mkdirp = vi.fn(async () => {});
+  const bridge: SandboxFsBridge = {
+    resolvePath: ({ filePath }) => ({
+      relativePath: filePath,
+      containerPath: `/sandbox/${filePath}`,
+    }),
+    readFile: async ({ filePath }) => {
+      const contents = files.get(filePath);
+      return typeof contents === "string"
+        ? Buffer.from(contents, "utf8")
+        : Buffer.from(contents ?? "");
+    },
+    writeFile,
+    ...(options.supportsExclusiveCreate === false ? {} : { createFileExclusive }),
+    remove: async ({ filePath }) => {
+      files.delete(filePath);
+    },
+    rename: async ({ from, to }) => {
+      const contents = files.get(from);
+      if (contents !== undefined) {
+        files.set(to, contents);
+        files.delete(from);
+      }
+    },
+    stat: async ({ filePath }) => {
+      const contents = files.get(filePath);
+      return contents === undefined
+        ? null
+        : { type: "file", size: Buffer.byteLength(contents), mtimeMs: 0 };
+    },
+    mkdirp,
+  };
+  return {
+    files,
+    bridge,
+    writeFile,
+    createFileExclusive,
+    mkdirp,
+    options: {
+      cwd: "/local/workspace",
+      sandbox: {
+        root: "/local/workspace",
+        bridge,
+      },
+    },
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes #117742.

A multi-file `apply_patch` envelope was applied one hunk at a time, committing each mutation immediately. When a later hunk failed (missing file, context mismatch, destination conflict, path policy, abort), everything before it stayed committed while the tool call reported failure. The filed reproduction permanently deletes `important.txt` when a later hunk targets a nonexistent file, and the rejection text never reveals that the workspace changed. The tool is enabled by default and presented as a one-call multi-file operation, so any agent retrying a failed patch compounds the damage because the expected starting state no longer exists.

## Why This Change Was Made

Root cause: parsing catches only structural errors before mutation. Semantic and filesystem errors surface inside later hunks after earlier removals and writes have committed. The per-path mutation queue serializes one path but provides no envelope-level transaction.

The fix splits `applyPatch` into stage and commit phases inside one combined mutation queue over every path the envelope touches:

```ts
return await withFileMutationQueues(queuedPaths, async () => {
  const staged = await stagePatchHunks(resolvedHunks, fileOps, options);
  ...
  await commitStagedPatchOps(staged.ops, fileOps);
```

- `stagePatchHunks` validates every hunk against a virtual overlay of pending contents before anything touches disk: update hunks read and match context in memory, add and move destinations are checked for conflicts, deletes are checked for existence and entry kind, and intra-envelope ordering (documented Delete then Add replacement, update of a file added earlier) resolves through the overlay. Any staging failure rejects with zero mutations.
- `commitStagedPatchOps` then executes the precomputed operations in original hunk order. Exclusive creation remains the authoritative guard at commit time, so the existing mid-patch competing-writer behavior is preserved.
- A commit-phase failure (a true race or I/O error after staging passed) can still leave earlier operations durable; the rejection now names exactly which operations were applied instead of hiding them.
- Abort is honored during staging and immediately before commit, so an abort can no longer strand a half-applied envelope.

### Staged ancestor topology

The first revision of this PR staged file contents but not directory topology. Commit runs `mkdirp` for every created path, so an envelope that adds `node` and then `node/child` passed staging, committed `node` as a file, and then failed inside `mkdirp` with a preceding delete already durable. The same hole existed when `node` was an ordinary pre-existing file on disk, which is a failure main also has today.

The staging owner now models ancestors as well as contents. `stageParentDirs` walks each create destination's ancestors, consults the overlay first and the backend second, rejects when an ancestor is a file, and records the implicit directories the commit will create so a later hunk cannot occupy one of them. `PatchFileOps.exists` became `PatchFileOps.entryKind` to make that distinction available: the host backends map `lstat` to `file`, `directory`, or `other`, and the sandbox backend forwards the `type` its `stat` bridge already returns. Symlinks stay `other` and are never treated as files, so directory aliases keep resolving exactly as they do on the read path.

### Staged Delete File entry kind

The second revision staged deletes on existence alone, which ClawSweeper correctly flagged as P1. `stagedExists` returned true for any entry, including a directory, so an envelope that deletes `important.txt` and then targets a non-empty directory queued both, and the removal contract rejected the directory only during commit, after `important.txt` was already gone.

`stagedExists` is now `stagedEntryKind`, the same overlay-aware lookup returning the entry kind instead of a boolean, and the Delete File branch rejects a `directory` target during staging. That is the exact precondition every backend enforces later: the workspace-scoped host backend rejects a non-empty directory, the unconfined host backend rejects any directory through a non-recursive `fs.rm`, and the sandbox bridge removes with `force: false`. Deleting a symlink is untouched on the host backends and on the local sandbox bridge. The host backends classify a link through `lstat` as `other`, never `directory`. The local sandbox bridge is link-preserving for the same reason: `resolveAnchoredSandboxEntry` canonicalizes only the parent and applies the basename afterwards, and `buildStatPlan` runs `stat -c "%F|%s|%y"` without `-L`, so a link reports `symbolic link`, which `coerceStatType` maps to `other`.

### Known open item: remote sandbox directory aliases

The remote bridge does not share that contract. `createRemoteShellSandboxFsBridge` (`src/agents/sandbox/remote-fs-bridge.ts:341`) resolves the full container path to `canonicalPath` before statting it, so a symlink to a directory reports `directory`, while its `remove` pins the parent with `allowFinalSymlinkForUnlink: true` and unlinks the basename. On that backend the new staging rejection therefore refuses a `Delete File` that the remover would have unlinked. `SandboxFsBridge.stat` has no link-preserving option and the two in-repo bridges already disagree on final-link semantics under the same method name, so closing this means changing the shared sandbox bridge contract rather than patching apply_patch. That is a maintainer decision and it is open; the options and my preference are in the PR discussion.

### Production LOC

Production is 915 lines on main and 1082 lines here, net +167. Most of that is the staging owner this fix requires; there is no smaller expression of an envelope-level transaction than a validated overlay plus an ordered commit list. The entry-kind repair above accounts for 11 of those lines and stays inside the same owner rather than pushing a cross-hunk precondition down into a backend, which cannot enforce it. To keep the owner boundary readable, the envelope parser moved verbatim into a new `src/agents/apply-patch-parse.ts`, joining the existing `apply-patch-update.ts` and `apply-patch-file-ops.ts` family. That drops `apply-patch.ts` from 673 to 527 lines and clears the `max-lines` budget the topology fix would otherwise have exceeded, with no suppression added.

Novelty: no open PR touches this behavior. Closed PR #117990 verified write contents after reporting success, a different defect, and merged PR #114911 added exclusive destination creation while explicitly retaining per-hunk sequencing.

## User Impact

A failed `apply_patch` call no longer destroys or mutates workspace files for every predictable failure class: missing update target, context mismatch, add or move destination conflict, delete of a missing file, delete of a directory, a created or existing file standing in as the parent directory of a later hunk, path policy rejection, and abort. In the rare commit-time race window the tool now reports exactly what was applied instead of silently leaving the workspace changed.

Three behavior changes, all rejections that previously happened later and dirtier:

- Deleting a nonexistent file rejects with `Cannot delete <path>: the file was not found.` before any hunk commits.
- Deleting a directory rejects with `Cannot delete <path>: it is a directory, not a file.` during staging, instead of surfacing a backend `directory is not empty` error after earlier hunks committed. Deleting an empty directory through `Delete File` also stops working on the workspace-scoped host backend; it was never a documented patch operation, no coverage depended on it, and the unconfined host backend already rejected it.
- Nesting a new file under a path that is or becomes a file rejects during staging, naming the offending ancestor and the remedy, instead of surfacing a backend `directory component must be a directory` error after earlier hunks committed.

## Verification

- `node scripts/run-vitest.mjs src/agents/apply-patch.test.ts src/agents/apply-patch-staging.test.ts`: 64 passed. 11 of the 12 cases in `apply-patch-staging.test.ts` fail on pristine main for the intended reason (earlier delete, update, or add left committed; missing-file delete after a committed write; unreported partial application; file-as-parent conflicts and a directory Delete File target committing a preceding delete). The twelfth, an update of a file added earlier in the same envelope, already passes on main and is there as a contract guard.
- New entry-kind coverage: `keeps an earlier delete uncommitted when a later delete targets a directory` seeds `important.txt` plus a non-empty `node/`, submits a Delete File pair, and asserts both the file and the nested file survive the rejection. On pre-fix code it fails with `directory is not empty ... The patch was partially applied before this failure: deleted important.txt`.
- `node scripts/run-oxlint.mjs` clean on all four changed source files, including the `max-lines` budget that the parser extraction restored.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` both clean.
- `oxfmt` clean on all changed files.
- Topology coverage from the previous revision is unchanged: a table-driven pair proving a preceding delete survives when a later add nests under a file created earlier in the envelope and under a file already on disk; an add colliding with a directory an earlier hunk creates; and the same conflict through the sandbox backend, proving the `entryKind` wiring on the sibling surface.
- The shared temp-dir and memory-sandbox fixtures moved verbatim from `apply-patch.test.ts` to `src/agents/test-helpers/apply-patch-fixtures.ts` so both suites use one copy.
- One provenance assertion in `agent-tools.create-openclaw-coding-tools.test.ts` updated to the new contract: a conflicting `Add File` now rejects during staging before any provenance write happens, so no rollback fires.
- Pre-existing unrelated local failure: `agent-tools.create-openclaw-coding-tools.test.ts > resolves Unicode-equivalent filenames through sandbox operations` fails on this macOS box with and without this patch, from APFS Unicode normalization in the `read` tool. It is untouched by this change.

## Real behavior proof

Behavior addressed: A rejected multi-file apply_patch envelope left an earlier destructive hunk committed, permanently deleting a workspace file while the call reported failure, including when a later hunk nested a new file under a path that is or becomes a file, and when a later hunk targeted a directory for deletion.
Real environment tested: Production createApplyPatchTool execution with the default workspace-scoped host filesystem backend, driven on pristine main 9386ac096632509203dc94086d86d7b3de8bc30d and on this branch head 4f7339a8dd86e0751d53dab0265dbabe88786dea with identical inputs; the real patch parser, path guards, staging, commit, and on-disk workspace files stayed real and no external seam was replaced.
Exact steps or command run after this patch: `./node_modules/.bin/tsx apply-patch-envelope-proof.mts`, a driver that builds four real workspaces containing important.txt, constructs the tool with createApplyPatchTool({ cwd: workspace }), and submits one envelope per workspace whose first hunk deletes important.txt and whose later hunk fails: an update of a nonexistent file, an add of node followed by an add of node/child, an add of node/child where node is an ordinary file already on disk, and a Delete File targeting a non-empty node directory. A fifth workspace then checks the alias contract: `Delete File` on a symbolic link whose target is a directory outside the workspace, which must still unlink the link and leave the aliased data untouched.
Evidence after fix:
```
# BEFORE (pristine main 9386ac096632509203dc94086d86d7b3de8bc30d)
surface=createApplyPatchTool.execute
scenario=filed-report-delete-then-missing-update
  outcome=REJECTED Failed to read file to update /private/tmp/claude-501/-Users-yuvald-work/d2904593-84fd-4eb7-9409-842fbdf6ed18/scratchpad/proof-ws-before/filed-report-delete-then-missing-update/missing.txt: Failed boundary read for /private/tmp/claude-501/-Users-yuvald-work/d2904593-84fd-4eb7-9409-842fbdf6ed18/scratchpad/proof-ws-before/filed-report-delete-then-missing-update/missing.txt (path not found)
  important.txt=<DESTROYED>
  workspace_entries=
scenario=envelope-creates-parent-as-file
  outcome=REJECTED directory component must be a directory
  important.txt=<DESTROYED>
  workspace_entries=node
scenario=existing-file-as-parent
  outcome=REJECTED directory component must be a directory
  important.txt=<DESTROYED>
  workspace_entries=node
scenario=delete-then-directory-delete
  outcome=REJECTED directory is not empty
  important.txt=<DESTROYED>
  node/child.txt=nested-user-data
  workspace_entries=node

# AFTER (head 4f7339a8dd86e0751d53dab0265dbabe88786dea, identical inputs)
surface=createApplyPatchTool.execute
scenario=filed-report-delete-then-missing-update
  outcome=REJECTED Failed to read file to update /private/tmp/claude-501/-Users-yuvald-work/d2904593-84fd-4eb7-9409-842fbdf6ed18/scratchpad/proof-ws-after/filed-report-delete-then-missing-update/missing.txt: Failed boundary read for /private/tmp/claude-501/-Users-yuvald-work/d2904593-84fd-4eb7-9409-842fbdf6ed18/scratchpad/proof-ws-after/filed-report-delete-then-missing-update/missing.txt (path not found)
  important.txt=irreplaceable-user-data
  workspace_entries=important.txt
scenario=envelope-creates-parent-as-file
  outcome=REJECTED Cannot create node/child: node is created as a file earlier in this patch. Reorder the hunks or choose another destination.
  important.txt=irreplaceable-user-data
  workspace_entries=important.txt
scenario=existing-file-as-parent
  outcome=REJECTED Cannot create node/child: node is an existing file, not a directory. Delete it earlier in the same patch or choose another destination.
  important.txt=irreplaceable-user-data
  workspace_entries=important.txt,node
scenario=delete-then-directory-delete
  outcome=REJECTED Cannot delete node: it is a directory, not a file. Delete each file inside it with its own hunk.
  important.txt=irreplaceable-user-data
  node/child.txt=nested-user-data
  workspace_entries=important.txt,node

# ALIAS CONTRACT (head 4f7339a8dd86e0751d53dab0265dbabe88786dea)
surface=createApplyPatchTool.execute
scenario=delete-file-on-directory-alias
  alias_target_kind=directory
  outcome=APPLIED Success. Updated the following files: | D important.txt | D alias
  alias_entry_after=<UNLINKED>
  aliased_data_after=aliased-user-data
  workspace_entries=
```
Observed result after fix: All four envelopes still reject. On main every one of them permanently destroys important.txt and leaves the workspace holding whatever the failed envelope managed to commit. On this head important.txt survives with its original contents in all four, workspace_entries is exactly the seeded starting state, and the three topology and entry-kind rejections now name the offending path and the remedy instead of surfacing a backend message about a directory component or a directory that is not empty. On the host backends the alias contract is unchanged: `Delete File` on a symbolic link pointing at a directory still applies, unlinks the link itself, and leaves the aliased data readable, because `lstat` classifies a link as `other` and only a real `directory` is refused. This run does not cover the remote backend, whose differing link semantics are the open item named above.
What was not tested: The sandbox backend commit path was driven only through the in-repo memory bridge rather than a live container or a live remote host, so the remote-bridge link semantics named above are argued from source rather than driven, and abort-triggered variants were not driven live. A commit-phase I/O failure after staging passes can still leave earlier operations durable; that residual race window is reported in the rejection text instead of hidden.
