### PR TITLE
fix(slack): accept org-wide user IDs in Enterprise Grid policies

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -337,9 +337,10 @@ retain raw stable channel IDs and `channel:<id>` compatibility. The channel
 prefixes `slack:`, `group:`, and `mpim:` fail startup.
 
 Enterprise user policy entries in `allowFrom`, `reactionAllowlist`, and
-per-channel `users` must use `team:<team-id>:user:<user-id>` or `"*"`. A
-workspace-scoped sender never matches a bare user ID. Workspace installations
-retain raw stable user IDs, `slack:<user-id>`, and `user:<user-id>` compatibility.
+per-channel `users` accept raw stable Slack user IDs, `slack:<user-id>`,
+`user:<user-id>`, `team:<team-id>:user:<user-id>`, or `"*"`. Unqualified
+entries compare only the user ID and can match an org-wide user in any
+workspace. Qualified entries compare both the workspace and user ID.
 Enterprise `toolsBySender` keys accept raw stable user IDs, `id:<user-id>`,
 `channel:slack:<user-id>`, or `"*"`. Names, slugs, display names, and email
 addresses fail startup. IDs must use Slack's canonical uppercase prefix and body
@@ -359,9 +360,9 @@ rejected before authorization or system-event handling.
 Enterprise DMs support the same `disabled`, `open`, `allowlist`, and `pairing`
 policies as workspace installs. Pairing approvals are stored as
 `team:<team-id>:user:<user-id>` and are applied only to events from that
-workspace. Explicit account `allowFrom` entries use the same qualified form and
-apply only to that workspace; channel and sender policy continues to apply to
-channel messages.
+workspace. Explicit account `allowFrom` entries can omit the workspace for an
+org-wide user ID or include it to limit access to one workspace; channel and
+sender policy continues to apply to channel messages.
 
 ## Install
 

--- a/docs/gateway/config-channels.md
+++ b/docs/gateway/config-channels.md
@@ -468,9 +468,10 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 - Slack detects Enterprise Grid org-wide installations automatically from the
   bot token with `auth.test`; no installation-mode setting is required.
   Enterprise DMs support `disabled`, `open`, `allowlist`, and workspace-scoped
-  `pairing`. Channel and user policies must use
-  `team:<team-id>:channel:<channel-id>` or `team:<team-id>:user:<user-id>`;
-  bare IDs, mutable names, and unsupported channel prefixes fail startup.
+  `pairing`. Channel policies require `team:<team-id>:channel:<channel-id>`.
+  User policies accept either an org-wide stable user ID or
+  `team:<team-id>:user:<user-id>` for workspace scope. Mutable names and
+  unsupported channel prefixes fail startup.
   Mention-pattern channel scopes and static route-binding peers use
   workspace-qualified Slack targets.
   Direct Socket Mode or HTTP messages, mentions, workspace-qualified actions,

--- a/extensions/slack/src/monitor/allow-list.test.ts
+++ b/extensions/slack/src/monitor/allow-list.test.ts
@@ -91,14 +91,6 @@ describe("slack/allow-list", () => {
         teamId: "T22222222",
         id: "U01234567",
       }),
-    ).toEqual({ allowed: false });
-    expect(
-      resolveSlackAllowListMatch({
-        allowList: ["u01234567"],
-        teamId: "T22222222",
-        id: "U01234567",
-        allowUnscoped: true,
-      }),
     ).toEqual({ allowed: true, matchKey: "u01234567", matchSource: "id" });
   });
 

--- a/extensions/slack/src/monitor/allow-list.test.ts
+++ b/extensions/slack/src/monitor/allow-list.test.ts
@@ -5,6 +5,7 @@ import {
   normalizeAllowListLower,
   normalizeSlackSlug,
   resolveSlackAllowListMatch,
+  resolveSlackUserAllowListForTeam,
   resolveSlackUserAllowed,
 } from "./allow-list.js";
 
@@ -115,5 +116,14 @@ describe("slack/allow-list", () => {
         id: "B01234567",
       }),
     ).toEqual({ allowed: false });
+  });
+
+  it("preserves org-wide IDs and workspace-qualified user identities", () => {
+    expect(
+      resolveSlackUserAllowListForTeam({
+        allowList: ["W01234567", "team:T11111111:user:U01234567", "team:T22222222:user:U01234567"],
+        teamId: "T11111111",
+      }),
+    ).toEqual(["w01234567", "team:t11111111:user:u01234567"]);
   });
 });

--- a/extensions/slack/src/monitor/allow-list.ts
+++ b/extensions/slack/src/monitor/allow-list.ts
@@ -75,7 +75,6 @@ export function resolveSlackAllowListMatch(params: {
   id?: string;
   name?: string;
   allowNameMatching?: boolean;
-  allowUnscoped?: boolean;
 }): SlackAllowListMatch {
   const compiledAllowList = compileAllowlist(params.allowList);
   const teamId = normalizeOptionalLowercaseString(params.teamId);
@@ -100,13 +99,9 @@ export function resolveSlackAllowListMatch(params: {
         ] satisfies Array<{ value?: string; source: SlackAllowListSource }>)
       : []),
   ];
-  const candidates =
-    teamId && params.allowUnscoped !== true
-      ? scopedCandidates
-      : [...scopedCandidates, ...unscopedCandidates];
   return resolveCompiledAllowlistMatch({
     compiledAllowlist: compiledAllowList,
-    candidates,
+    candidates: [...scopedCandidates, ...unscopedCandidates],
   });
 }
 
@@ -116,7 +111,6 @@ export function allowListMatches(params: {
   id?: string;
   name?: string;
   allowNameMatching?: boolean;
-  allowUnscoped?: boolean;
 }) {
   return resolveSlackAllowListMatch(params).allowed;
 }
@@ -127,7 +121,6 @@ export function resolveSlackUserAllowed(params: {
   userId?: string;
   userName?: string;
   allowNameMatching?: boolean;
-  allowUnscoped?: boolean;
 }) {
   const allowList = normalizeAllowListLower(params.allowList);
   if (allowList.length === 0) {
@@ -139,7 +132,6 @@ export function resolveSlackUserAllowed(params: {
     id: params.userId,
     name: params.userName,
     allowNameMatching: params.allowNameMatching,
-    allowUnscoped: params.allowUnscoped,
   });
 }
 
@@ -147,7 +139,6 @@ export function resolveSlackUserAllowListForTeam(params: {
   allowList?: Array<string | number>;
   teamId?: string;
   preserveUnmatchedScopedEntries?: boolean;
-  allowUnscoped?: boolean;
 }): string[] {
   const allowList = normalizeAllowListLower(params.allowList);
   const teamId = normalizeOptionalLowercaseString(params.teamId);
@@ -156,12 +147,12 @@ export function resolveSlackUserAllowListForTeam(params: {
       return [entry];
     }
     if (!entry.startsWith("team:")) {
-      return params.allowUnscoped === true || params.preserveUnmatchedScopedEntries ? [entry] : [];
+      return [entry];
     }
     try {
       const target = parseSlackTarget(entry);
       if (target?.kind === "user" && target.teamId?.toLowerCase() === teamId) {
-        return params.allowUnscoped === true ? [target.id.toLowerCase()] : [entry];
+        return [target.id.toLowerCase()];
       }
       return params.preserveUnmatchedScopedEntries ? [entry] : [];
     } catch {

--- a/extensions/slack/src/monitor/allow-list.ts
+++ b/extensions/slack/src/monitor/allow-list.ts
@@ -152,7 +152,7 @@ export function resolveSlackUserAllowListForTeam(params: {
     try {
       const target = parseSlackTarget(entry);
       if (target?.kind === "user" && target.teamId?.toLowerCase() === teamId) {
-        return [target.id.toLowerCase()];
+        return [entry];
       }
       return params.preserveUnmatchedScopedEntries ? [entry] : [];
     } catch {

--- a/extensions/slack/src/monitor/allow-list.ts
+++ b/extensions/slack/src/monitor/allow-list.ts
@@ -13,6 +13,7 @@ import {
 import { parseSlackTarget } from "../target-parsing.js";
 
 const SLACK_SLUG_CACHE_MAX = 512;
+const SLACK_STABLE_USER_ID_RE = /^[ubw][a-z0-9]+$/;
 const slackSlugCache = new Map<string, string>();
 
 export function normalizeSlackSlug(raw?: string) {
@@ -54,7 +55,7 @@ export function normalizeSlackAllowOwnerEntry(entry: string): string | undefined
     return undefined;
   }
   const withoutPrefix = trimmed.replace(/^(slack:|user:)/, "");
-  return /^u[a-z0-9]+$/.test(withoutPrefix) ? withoutPrefix : undefined;
+  return SLACK_STABLE_USER_ID_RE.test(withoutPrefix) ? withoutPrefix : undefined;
 }
 
 export type SlackAllowListMatch = AllowlistMatch<

--- a/extensions/slack/src/monitor/auth.test.ts
+++ b/extensions/slack/src/monitor/auth.test.ts
@@ -195,13 +195,13 @@ describe("resolveSlackEffectiveAllowFrom", () => {
         includePairingStore: true,
         eventScope: { teamId: "T11111111", client: {} as never },
       }),
-    ).resolves.toEqual(["uconfig123", "ulegacy123", "u11111111"]);
+    ).resolves.toEqual(["uconfig123", "ulegacy123", "team:t11111111:user:u11111111"]);
     await expect(
       resolveSlackEffectiveAllowFrom(ctx, {
         includePairingStore: true,
         eventScope: { teamId: "T22222222", client: {} as never },
       }),
-    ).resolves.toEqual(["uconfig123", "ulegacy123", "u22222222"]);
+    ).resolves.toEqual(["uconfig123", "ulegacy123", "team:t22222222:user:u22222222"]);
     await expect(
       resolveSlackEffectiveAllowFrom(ctx, { includePairingStore: true }),
     ).resolves.toEqual(["uconfig123", "ulegacy123"]);
@@ -215,7 +215,7 @@ describe("resolveSlackEffectiveAllowFrom", () => {
       resolveSlackEffectiveAllowFrom(ctx, {
         eventScope: { teamId: "T11111111", client: {} as never },
       }),
-    ).resolves.toEqual(["u01234567"]);
+    ).resolves.toEqual(["team:t11111111:user:u01234567"]);
     await expect(
       resolveSlackEffectiveAllowFrom(ctx, {
         eventScope: { teamId: "T22222222", client: {} as never },

--- a/extensions/slack/src/monitor/auth.test.ts
+++ b/extensions/slack/src/monitor/auth.test.ts
@@ -119,6 +119,7 @@ function interactiveRequest(
 
 function makeChannelMemberAuth(
   conversationsMembers = vi.fn(async () => ({ members: ["UOWNER"], response_metadata: {} })),
+  allowFromLower = ["uowner"],
 ) {
   const ctx = {
     allowFrom: [],
@@ -132,7 +133,7 @@ function makeChannelMemberAuth(
       ctx,
       channelId: "C1",
       senderId: "U_BOT",
-      allowFromLower: ["uowner"],
+      allowFromLower,
     });
   return { authorize, conversationsMembers };
 }
@@ -358,6 +359,24 @@ describe("authorizeSlackSystemEventSender", () => {
       [{ token: "xoxb-test", channel: "C1", limit: 999, cursor: "cursor-next" }],
     ]);
   });
+
+  it.each([
+    ["an org-wide user ID", "w01234567", "W01234567"],
+    ["a prefixed org-wide user ID", "slack:w01234567", "W01234567"],
+    ["a bot ID", "b01234567", "B01234567"],
+    ["a prefixed bot ID", "user:b01234567", "B01234567"],
+  ])(
+    "authorizes bot room messages when %s identifies a present owner",
+    async (_name, entry, id) => {
+      const conversationsMembers = vi.fn(async () => ({
+        members: [id],
+        response_metadata: {},
+      }));
+      const { authorize } = makeChannelMemberAuth(conversationsMembers, [entry]);
+
+      await expect(authorize()).resolves.toBe(true);
+    },
+  );
 
   it.each([
     ["a repeated cursor", ["cursor-a", "cursor-a"]],

--- a/extensions/slack/src/monitor/auth.test.ts
+++ b/extensions/slack/src/monitor/auth.test.ts
@@ -195,16 +195,16 @@ describe("resolveSlackEffectiveAllowFrom", () => {
         includePairingStore: true,
         eventScope: { teamId: "T11111111", client: {} as never },
       }),
-    ).resolves.toEqual(["team:t11111111:user:u11111111"]);
+    ).resolves.toEqual(["uconfig123", "ulegacy123", "u11111111"]);
     await expect(
       resolveSlackEffectiveAllowFrom(ctx, {
         includePairingStore: true,
         eventScope: { teamId: "T22222222", client: {} as never },
       }),
-    ).resolves.toEqual(["team:t22222222:user:u22222222"]);
+    ).resolves.toEqual(["uconfig123", "ulegacy123", "u22222222"]);
     await expect(
       resolveSlackEffectiveAllowFrom(ctx, { includePairingStore: true }),
-    ).resolves.toEqual([]);
+    ).resolves.toEqual(["uconfig123", "ulegacy123"]);
   });
 
   it("keeps only configured users for the current Enterprise workspace", async () => {
@@ -215,7 +215,7 @@ describe("resolveSlackEffectiveAllowFrom", () => {
       resolveSlackEffectiveAllowFrom(ctx, {
         eventScope: { teamId: "T11111111", client: {} as never },
       }),
-    ).resolves.toEqual(["team:t11111111:user:u01234567"]);
+    ).resolves.toEqual(["u01234567"]);
     await expect(
       resolveSlackEffectiveAllowFrom(ctx, {
         eventScope: { teamId: "T22222222", client: {} as never },
@@ -514,24 +514,27 @@ describe("resolveSlackCommandIngress", () => {
     expect(result.senderAccess.gate?.allowed).toBe(allowed);
   });
 
-  it("does not authorize a bare user ID for an Enterprise workspace event", async () => {
-    const result = await resolveSlackCommandIngress({
-      ctx: makeAuthorizeCtx({
-        installationIdentity: { kind: "enterprise", enterpriseId: "E11111111" },
-      }),
-      teamId: "T11111111",
-      senderId: "U01234567",
-      channelType: "channel",
-      channelId: "C01234567",
-      ownerAllowFromLower: [],
-      channelUsers: ["U01234567"],
-      allowTextCommands: false,
-      hasControlCommand: false,
-    });
+  it.each(["T11111111", "T22222222"])(
+    "authorizes a bare org user ID for an Enterprise event in %s",
+    async (teamId) => {
+      const result = await resolveSlackCommandIngress({
+        ctx: makeAuthorizeCtx({
+          installationIdentity: { kind: "enterprise", enterpriseId: "E11111111" },
+        }),
+        teamId,
+        senderId: "W01234567",
+        channelType: "channel",
+        channelId: "C01234567",
+        ownerAllowFromLower: [],
+        channelUsers: ["W01234567"],
+        allowTextCommands: false,
+        hasControlCommand: false,
+      });
 
-    expect(result.senderAccess.decision).toBe("block");
-    expect(result.senderAccess.gate?.allowed).toBe(false);
-  });
+      expect(result.senderAccess.decision).toBe("allow");
+      expect(result.senderAccess.gate?.allowed).toBe(true);
+    },
+  );
 
   it("does not authorize commands when sender denial stops before the command gate", async () => {
     const result = await resolveSlackCommandIngress({

--- a/extensions/slack/src/monitor/auth.ts
+++ b/extensions/slack/src/monitor/auth.ts
@@ -128,14 +128,8 @@ const slackIngressIdentity = defineStableChannelIngressIdentity({
 function createSlackIngressSubject(params: {
   senderId: string;
   senderName?: string;
-  teamId?: string;
-  workspaceScoped?: boolean;
 }) {
-  const bareSenderId = normalizeSlackUserId(params.senderId);
-  const senderId =
-    params.workspaceScoped && params.teamId
-      ? `team:${params.teamId.toLowerCase()}:user:${bareSenderId}`
-      : bareSenderId;
+  const senderId = normalizeSlackUserId(params.senderId);
   const senderName = params.senderName?.trim().toLowerCase();
   const senderNameSlug = senderName ? normalizeSlackSlug(senderName) : undefined;
   return {
@@ -191,7 +185,6 @@ function buildBaseAllowFrom(ctx: SlackMonitorContext, teamId?: string): string[]
   return resolveSlackUserAllowListForTeam({
     allowList: ctx.allowFrom,
     teamId,
-    allowUnscoped: ctx.installationIdentity?.kind !== "enterprise",
   });
 }
 
@@ -215,28 +208,10 @@ export async function resolveSlackEffectiveAllowFrom(
   } catch {
     storeAllowFrom = [];
   }
-  if (ctx.installationIdentity?.kind !== "enterprise") {
-    return resolveSlackUserAllowListForTeam({
-      allowList: [...base, ...storeAllowFrom],
-      teamId,
-      allowUnscoped: true,
-    });
-  }
-  const normalizedTeamId = teamId?.toLowerCase();
-  if (!normalizedTeamId) {
-    return base;
-  }
-  const workspaceAllowFrom = storeAllowFrom.flatMap((entry) => {
-    try {
-      const target = parseSlackTarget(entry);
-      return target?.kind === "user" && target.teamId?.toLowerCase() === normalizedTeamId
-        ? [entry]
-        : [];
-    } catch {
-      return [];
-    }
+  return resolveSlackUserAllowListForTeam({
+    allowList: [...base, ...storeAllowFrom],
+    teamId,
   });
-  return normalizeAllowListLower([...base, ...workspaceAllowFrom]);
 }
 
 async function fetchSlackChannelMemberIds(
@@ -341,7 +316,6 @@ export async function authorizeSlackBotRoomMessage(params: {
       id: params.senderId,
       name: params.senderName,
       allowNameMatching: params.ctx.allowNameMatching,
-      allowUnscoped: params.ctx.installationIdentity?.kind !== "enterprise",
     })
   ) {
     return true;
@@ -406,16 +380,13 @@ export async function resolveSlackCommandIngress(params: {
   const isDirectMessage = params.channelType === "im";
   const isGroupDm = params.channelType === "mpim";
   const teamId = params.teamId ?? params.ctx.teamId;
-  const allowUnscoped = params.ctx.installationIdentity?.kind !== "enterprise";
   const ownerAllowFrom = resolveSlackUserAllowListForTeam({
     allowList: params.ownerAllowFromLower,
     teamId,
-    allowUnscoped,
   });
   const channelUsers = resolveSlackUserAllowListForTeam({
     allowList: params.channelUsers,
     teamId,
-    allowUnscoped,
   });
   const channelUsersConfigured =
     !isDirectMessage && !isGroupDm && normalizeAllowListLower(params.channelUsers).length > 0;
@@ -426,8 +397,6 @@ export async function resolveSlackCommandIngress(params: {
     subject: createSlackIngressSubject({
       senderId: params.senderId,
       senderName: params.senderName,
-      teamId,
-      workspaceScoped: !allowUnscoped,
     }),
     conversation: {
       kind: slackIngressConversationKind(params.channelType),
@@ -474,16 +443,13 @@ async function decideSlackSystemIngress(params: {
   const isDirectMessage = params.channelType === "im";
   const isGroupDm = params.channelType === "mpim";
   const teamId = params.teamId ?? params.ctx.teamId;
-  const allowUnscoped = params.ctx.installationIdentity?.kind !== "enterprise";
   const ownerAllowFromLower = resolveSlackUserAllowListForTeam({
     allowList: params.ownerAllowFromLower,
     teamId,
-    allowUnscoped,
   });
   const channelUsers = resolveSlackUserAllowListForTeam({
     allowList: params.channelUsers,
     teamId,
-    allowUnscoped,
   });
   const channelUsersConfigured =
     !isDirectMessage && !isGroupDm && normalizeAllowListLower(params.channelUsers).length > 0;
@@ -511,8 +477,6 @@ async function decideSlackSystemIngress(params: {
     createSlackIngressSubject({
       senderId: params.senderId,
       senderName,
-      teamId,
-      workspaceScoped: !allowUnscoped,
     });
   const resolver = createSlackIngressResolver(params.ctx);
   const input: Parameters<typeof resolver.message>[0] = {

--- a/extensions/slack/src/monitor/auth.ts
+++ b/extensions/slack/src/monitor/auth.ts
@@ -14,6 +14,7 @@ import {
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { collectSlackCursorPages } from "../cursor-pages.js";
 import { parseSlackTarget } from "../target-parsing.js";
 import {

--- a/extensions/slack/src/monitor/auth.ts
+++ b/extensions/slack/src/monitor/auth.ts
@@ -125,10 +125,7 @@ const slackIngressIdentity = defineStableChannelIngressIdentity({
   })),
 });
 
-function createSlackIngressSubject(params: {
-  senderId: string;
-  senderName?: string;
-}) {
+function createSlackIngressSubject(params: { senderId: string; senderName?: string }) {
   const senderId = normalizeSlackUserId(params.senderId);
   const senderName = params.senderName?.trim().toLowerCase();
   const senderNameSlug = senderName ? normalizeSlackSlug(senderName) : undefined;

--- a/extensions/slack/src/monitor/auth.ts
+++ b/extensions/slack/src/monitor/auth.ts
@@ -48,6 +48,8 @@ const CHANNEL_MEMBERS_CACHE_MAX = 512;
 const SLACK_CHANNEL_ID = "slack";
 const SLACK_USER_NAME_KIND =
   "plugin:slack-user-name" as const satisfies ChannelIngressIdentifierKind;
+const SLACK_WORKSPACE_USER_ID_KIND =
+  "plugin:slack-workspace-user-id" as const satisfies ChannelIngressIdentifierKind;
 
 export class SlackSystemEventAuthRetryError extends Error {}
 function normalizeSlackUserId(raw?: string | null): string {
@@ -66,7 +68,7 @@ function isSlackStableUserId(value: string): boolean {
   return /^[ubw][a-z0-9_]+$/i.test(value);
 }
 
-function normalizeSlackStableEntry(entry: string): string | null {
+function normalizeSlackWorkspaceUserEntry(entry: string): string | null {
   const normalized = entry.trim().toLowerCase();
   if (!normalized) {
     return null;
@@ -79,8 +81,20 @@ function normalizeSlackStableEntry(entry: string): string | null {
   } catch {
     return null;
   }
+  return null;
+}
+
+function normalizeSlackBareUserEntry(entry: string): string | null {
+  const normalized = entry.trim().toLowerCase();
+  if (!normalized || normalizeSlackWorkspaceUserEntry(normalized)) {
+    return null;
+  }
   const userId = normalizeSlackUserId(normalized);
   return isSlackStableUserId(userId) ? userId : null;
+}
+
+function normalizeSlackStableEntry(entry: string): string | null {
+  return normalizeSlackBareUserEntry(entry) ?? normalizeSlackWorkspaceUserEntry(entry);
 }
 
 function normalizeSlackNameEntry(entry: string): string | null {
@@ -107,31 +121,46 @@ function normalizeSlackNameSlugEntry(entry: string): string | null {
 const slackIngressIdentity = defineStableChannelIngressIdentity({
   key: "senderId",
   kind: "stable-id",
-  normalizeEntry: normalizeSlackStableEntry,
+  normalizeEntry: normalizeSlackBareUserEntry,
   normalizeSubject: normalizeSlackUserId,
   sensitivity: "pii",
-  aliases: (
-    [
-      ["senderName", normalizeSlackNameEntry],
-      ["senderNameSlug", normalizeSlackNameSlugEntry],
-    ] as const
-  ).map(([key, normalizeEntry]) => ({
-    key,
-    kind: SLACK_USER_NAME_KIND,
-    normalizeEntry,
-    normalizeSubject: normalizeSlackNameSubject,
-    dangerous: true,
-    sensitivity: "pii" as const,
-  })),
+  aliases: [
+    {
+      key: "workspaceSenderId",
+      kind: SLACK_WORKSPACE_USER_ID_KIND,
+      normalizeEntry: normalizeSlackWorkspaceUserEntry,
+      normalizeSubject: normalizeSlackWorkspaceUserEntry,
+      sensitivity: "pii",
+    },
+    ...(
+      [
+        ["senderName", normalizeSlackNameEntry],
+        ["senderNameSlug", normalizeSlackNameSlugEntry],
+      ] as const
+    ).map(([key, normalizeEntry]) => ({
+      key,
+      kind: SLACK_USER_NAME_KIND,
+      normalizeEntry,
+      normalizeSubject: normalizeSlackNameSubject,
+      dangerous: true,
+      sensitivity: "pii" as const,
+    })),
+  ],
 });
 
-function createSlackIngressSubject(params: { senderId: string; senderName?: string }) {
+function createSlackIngressSubject(params: {
+  senderId: string;
+  senderName?: string;
+  teamId?: string;
+}) {
   const senderId = normalizeSlackUserId(params.senderId);
+  const teamId = normalizeOptionalLowercaseString(params.teamId);
   const senderName = params.senderName?.trim().toLowerCase();
   const senderNameSlug = senderName ? normalizeSlackSlug(senderName) : undefined;
   return {
     stableId: senderId,
     aliases: {
+      workspaceSenderId: teamId && senderId ? `team:${teamId}:user:${senderId}` : undefined,
       senderName,
       senderNameSlug,
     },
@@ -394,6 +423,7 @@ export async function resolveSlackCommandIngress(params: {
     subject: createSlackIngressSubject({
       senderId: params.senderId,
       senderName: params.senderName,
+      teamId,
     }),
     conversation: {
       kind: slackIngressConversationKind(params.channelType),
@@ -474,6 +504,7 @@ async function decideSlackSystemIngress(params: {
     createSlackIngressSubject({
       senderId: params.senderId,
       senderName,
+      teamId,
     });
   const resolver = createSlackIngressResolver(params.ctx);
   const input: Parameters<typeof resolver.message>[0] = {

--- a/extensions/slack/src/monitor/channel-config.ts
+++ b/extensions/slack/src/monitor/channel-config.ts
@@ -122,9 +122,8 @@ export function resolveSlackChannelConfig(params: {
   const users = resolveSlackUserAllowListForTeam({
     allowList: firstDefined(resolved.users, fallback?.users),
     teamId: params.teamId,
-    allowUnscoped: params.allowUnscoped,
-    // Keeping unmatched entries preserves the configured allowlist gate; strict
-    // workspace ingress treats bare and differently scoped values as non-matching.
+    // Keeping unmatched entries preserves the configured allowlist gate;
+    // ingress treats differently scoped values as non-matching.
     preserveUnmatchedScopedEntries: true,
   });
   const skills = firstDefined(resolved.skills, fallback?.skills);

--- a/extensions/slack/src/monitor/dm-auth.test.ts
+++ b/extensions/slack/src/monitor/dm-auth.test.ts
@@ -87,18 +87,16 @@ describe("authorizeSlackDirectMessage", () => {
     expect(params.onUnauthorized).not.toHaveBeenCalled();
   });
 
-  it("keeps bare user ids scoped out of Enterprise DMs", async () => {
+  it("allows bare org user ids for Enterprise DMs", async () => {
     const params = makeParams("allowlist");
     params.ctx.installationIdentity = { kind: "enterprise", enterpriseId: "E11111111" };
     params.eventScope = { teamId: "T11111111", client: {} as never };
-    params.allowFromLower = ["u123"];
+    params.senderId = "W01234567";
+    params.allowFromLower = ["w01234567"];
 
-    await expect(authorizeSlackDirectMessage(params)).resolves.toBe(false);
+    await expect(authorizeSlackDirectMessage(params)).resolves.toBe(true);
 
-    expect(params.onUnauthorized).toHaveBeenCalledWith({
-      allowMatchMeta: "matchKey=none matchSource=none",
-      senderName: "Alice",
-    });
+    expect(params.onUnauthorized).not.toHaveBeenCalled();
   });
 
   it("creates independent pairing requests for the same user in two Grid workspaces", async () => {

--- a/extensions/slack/src/monitor/dm-auth.ts
+++ b/extensions/slack/src/monitor/dm-auth.ts
@@ -37,7 +37,6 @@ export async function authorizeSlackDirectMessage(params: {
     id: params.senderId,
     name: senderName,
     allowNameMatching: params.ctx.allowNameMatching,
-    allowUnscoped: params.ctx.installationIdentity?.kind !== "enterprise",
   });
   const allowMatchMeta = formatAllowlistMatchMeta(allowMatch);
   if (allowMatch.allowed) {

--- a/extensions/slack/src/monitor/enterprise-install.test.ts
+++ b/extensions/slack/src/monitor/enterprise-install.test.ts
@@ -93,7 +93,12 @@ describe("assertEnterpriseSlackPolicyConfig", () => {
       assertEnterpriseSlackPolicyConfig({
         accountId: "org",
         config: {
-          allowFrom: ["team:T01234567:user:U01234567"],
+          allowFrom: [
+            "U01234567",
+            "slack:W01234567",
+            "user:U12345678",
+            "team:T01234567:user:U01234567",
+          ],
           dm: {
             groupChannels: ["team:T01234567:channel:G01234567"],
           },
@@ -104,7 +109,12 @@ describe("assertEnterpriseSlackPolicyConfig", () => {
           },
           channels: {
             "team:T01234567:channel:C01234567": {
-              users: ["team:T01234567:user:U01234567", "team:T01234567:user:B01234567"],
+              users: [
+                "U01234567",
+                "slack:W01234567",
+                "user:B01234567",
+                "team:T01234567:user:U01234567",
+              ],
               toolsBySender: {
                 U01234567: {},
                 "id:W01234567": {},
@@ -116,7 +126,7 @@ describe("assertEnterpriseSlackPolicyConfig", () => {
             "*": {},
           },
           reactionNotifications: "allowlist",
-          reactionAllowlist: ["team:T01234567:user:U01234567"],
+          reactionAllowlist: ["W01234567", "team:T01234567:user:U01234567"],
         },
       }),
     ).not.toThrow();
@@ -145,17 +155,7 @@ describe("assertEnterpriseSlackPolicyConfig", () => {
 
   it.each<[string, SlackAccountConfig]>([
     ["channel ID", { channels: { C01234567: {} } }],
-    ["allowFrom user ID", { allowFrom: ["U01234567"] }],
     ["group DM channel ID", { dm: { groupChannels: ["G01234567"] } }],
-    ["reaction user ID", { reactionNotifications: "allowlist", reactionAllowlist: ["U01234567"] }],
-    [
-      "per-channel user ID",
-      {
-        channels: {
-          "team:T01234567:channel:C01234567": { users: ["U01234567"] },
-        },
-      },
-    ],
   ])("rejects unscoped Enterprise %s", (_label, config) => {
     expect(() => assertEnterpriseSlackPolicyConfig({ accountId: "org", config })).toThrow(
       /Slack Enterprise Grid/,

--- a/extensions/slack/src/monitor/enterprise-install.ts
+++ b/extensions/slack/src/monitor/enterprise-install.ts
@@ -58,7 +58,7 @@ function isWorkspaceScopedSlackChannelEntry(
   return isWorkspaceQualifiedSlackTarget(normalized, "channel");
 }
 
-function isWorkspaceScopedSlackAllowlistUserEntry(value: unknown): boolean {
+function isStableSlackAllowlistUserEntry(value: unknown): boolean {
   if (typeof value !== "string") {
     return false;
   }
@@ -66,7 +66,11 @@ function isWorkspaceScopedSlackAllowlistUserEntry(value: unknown): boolean {
   if (normalized === "*") {
     return true;
   }
-  return isWorkspaceQualifiedSlackTarget(normalized, "user");
+  if (isWorkspaceQualifiedSlackTarget(normalized, "user")) {
+    return true;
+  }
+  const prefixed = /^(?:slack|user):([BUW][A-Z0-9]{8,})$/.exec(normalized);
+  return Boolean(prefixed?.[1]) || SLACK_USER_ID_RE.test(normalized);
 }
 
 function isStableSlackToolsBySenderEntry(value: unknown): boolean {
@@ -135,7 +139,7 @@ export function assertEnterpriseSlackPolicyConfig(params: {
   assertStableEntries({
     values: config.allowFrom,
     path: `channels.slack.accounts.${accountId}.allowFrom`,
-    predicate: isWorkspaceScopedSlackAllowlistUserEntry,
+    predicate: isStableSlackAllowlistUserEntry,
   });
   assertStableEntries({
     values: config.dm?.groupChannels,
@@ -146,7 +150,7 @@ export function assertEnterpriseSlackPolicyConfig(params: {
     assertStableEntries({
       values: config.reactionAllowlist,
       path: `channels.slack.accounts.${accountId}.reactionAllowlist`,
-      predicate: isWorkspaceScopedSlackAllowlistUserEntry,
+      predicate: isStableSlackAllowlistUserEntry,
     });
   }
   for (const [channelKey, channel] of Object.entries(config.channels ?? {})) {
@@ -158,7 +162,7 @@ export function assertEnterpriseSlackPolicyConfig(params: {
     assertStableEntries({
       values: channel?.users,
       path: `channels.slack.accounts.${accountId}.channels.${channelKey}.users`,
-      predicate: isWorkspaceScopedSlackAllowlistUserEntry,
+      predicate: isStableSlackAllowlistUserEntry,
     });
     assertStableEntries({
       values: Object.keys(channel?.toolsBySender ?? {}),

--- a/extensions/slack/src/monitor/events/reactions.test.ts
+++ b/extensions/slack/src/monitor/events/reactions.test.ts
@@ -364,6 +364,33 @@ describe("registerSlackReactionEvents", () => {
     expect(resolveUserName).toHaveBeenCalledWith("U1", expect.objectContaining({ teamId: "T111" }));
   });
 
+  it("allows an unscoped org user reaction policy across Enterprise workspaces", async () => {
+    const harness = createSlackSystemEventTestHarness({
+      dmPolicy: "open",
+      reactionMode: "allowlist",
+      reactionAllowlist: ["W01234567"],
+    });
+    harness.ctx.installationIdentity = {
+      kind: "enterprise",
+      apiAppId: "A_GRID",
+      enterpriseId: "E_GRID",
+    };
+    registerSlackReactionEvents({ ctx: harness.ctx });
+    const handler = requireReactionHandler(
+      harness.getHandler("reaction_added") as ReactionHandler | null,
+      "added",
+    );
+
+    for (const teamId of ["T111", "T222"]) {
+      await handler({
+        event: buildReactionEvent({ user: "W01234567" }),
+        ...buildEnterpriseListenerArgs(teamId),
+      });
+    }
+
+    expect(reactionQueueMock).toHaveBeenCalledTimes(2);
+  });
+
   it("rejects enterprise reaction events without validated listener scope", async () => {
     const trackEvent = vi.fn();
     const harness = createSlackSystemEventTestHarness();

--- a/extensions/slack/src/monitor/events/reactions.ts
+++ b/extensions/slack/src/monitor/events/reactions.ts
@@ -36,7 +36,6 @@ function shouldEmitSlackReactionNotification(params: {
       id: event.user,
       name: actorName,
       allowNameMatching: ctx.allowNameMatching,
-      allowUnscoped: ctx.installationIdentity?.kind !== "enterprise",
     });
   }
   return ctx.reactionMode === "all";

--- a/extensions/slack/src/monitor/monitor.test.ts
+++ b/extensions/slack/src/monitor/monitor.test.ts
@@ -239,14 +239,14 @@ describe("resolveSlackChannelConfig", () => {
         channelId: "C01234567",
         channels,
       })?.users,
-    ).toEqual(["team:t11111111:user:u01234567", "team:t22222222:user:u12345678", "u23456789"]);
+    ).toEqual(["u01234567", "team:t22222222:user:u12345678", "u23456789"]);
     expect(
       resolveSlackChannelConfig({
         teamId: "T22222222",
         channelId: "C01234567",
         channels,
       })?.users,
-    ).toEqual(["team:t11111111:user:u01234567", "team:t22222222:user:u12345678", "u23456789"]);
+    ).toEqual(["team:t11111111:user:u01234567", "u12345678", "u23456789"]);
   });
 
   it("blocks channel-name route matches by default", () => {

--- a/extensions/slack/src/monitor/monitor.test.ts
+++ b/extensions/slack/src/monitor/monitor.test.ts
@@ -223,7 +223,7 @@ describe("resolveSlackChannelConfig", () => {
     );
   });
 
-  it("matches per-channel users only in their selected workspace", () => {
+  it("preserves org-wide and workspace-qualified per-channel user identities", () => {
     const channels = {
       "team:T11111111:channel:C01234567": {
         users: ["team:T11111111:user:U01234567", "team:T22222222:user:U12345678", "U23456789"],
@@ -239,14 +239,14 @@ describe("resolveSlackChannelConfig", () => {
         channelId: "C01234567",
         channels,
       })?.users,
-    ).toEqual(["u01234567", "team:t22222222:user:u12345678", "u23456789"]);
+    ).toEqual(["team:t11111111:user:u01234567", "team:t22222222:user:u12345678", "u23456789"]);
     expect(
       resolveSlackChannelConfig({
         teamId: "T22222222",
         channelId: "C01234567",
         channels,
       })?.users,
-    ).toEqual(["team:t11111111:user:u01234567", "u12345678", "u23456789"]);
+    ).toEqual(["team:t11111111:user:u01234567", "team:t22222222:user:u12345678", "u23456789"]);
   });
 
   it("blocks channel-name route matches by default", () => {


### PR DESCRIPTION
Related: #122346

## Summary

Enterprise Grid org installs can now use an organization-wide Slack user ID in `allowFrom`, `reactionAllowlist`, and per-channel `users` without redundantly qualifying it with a workspace ID.

An unqualified stable user ID compares only the user ID and can match that org-wide identity across workspaces. The existing `team:<team-id>:user:<user-id>` form remains workspace-scoped and compares both values. Channel policies remain workspace-qualified.

The OpenClaw owner is responsible for supplying an organization-wide ID in an unqualified selector. Slack's organization-wide and workspace-local user IDs are opaque and syntactically identical, so OpenClaw cannot determine their scope from the ID string.

## Runtime flow

Slack ingress now presents both forms to the shared authorization resolver: the raw sender ID for organization-wide policy and a workspace-qualified alias for narrower policy. Pairing approvals remain workspace-qualified. Owner-presence normalization accepts the same bare and prefixed `U`, `W`, and `B` forms as Enterprise policy validation.

## Validation

- Slack policy suite: 6 files, 158 tests passed.
- Formatting passed for all 14 changed files.
- Type-aware lint passed for all changed TypeScript files.
- Docs MDX validation passed across 772 files.
- GitHub CI on `3910edff072`: 69 passed, 0 failed, 0 pending.
- ClawSweeper's actionable owner-normalization finding was fixed in `3910edff072`; the maintainer accepted the documented unqualified-ID contract and collision tradeoff.
