### PR TITLE
fix(qa): preserve model-switch reads in Code Mode

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-events.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-events.ts
@@ -1,11 +1,7 @@
 // QA Lab mock provider output event builders.
 
 import type { StreamEvent } from "./mock-openai-contracts.js";
-import {
-  readTargetFromPrompt,
-  buildMockFunctionCall,
-  buildToolCallEventsWithArgs,
-} from "./mock-openai-tooling.js";
+import { buildMockFunctionCall } from "./mock-openai-tooling.js";
 
 export function buildFailedResponseEvents(): StreamEvent[] {
   const responseId = `resp_qa_failed_${Date.now()}`;
@@ -53,11 +49,6 @@ export function buildPartialFailureEvents(partialText: string): StreamEvent[] {
       },
     },
   ];
-}
-
-export function buildToolCallEvents(prompt: string): StreamEvent[] {
-  const targetPath = readTargetFromPrompt(prompt);
-  return buildToolCallEventsWithArgs("read", { path: targetPath });
 }
 
 export function buildReleaseAuditJson() {

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -6396,6 +6396,49 @@ Update and merge these partial structured summaries.`,
     expect(await response.text()).toContain('"name":"read"');
   });
 
+  it("routes the initial model-switch read through Anthropic guest Code Mode", async () => {
+    const server = await startMockServer();
+    const body = (await expectAnthropicMessagesJson(server, {
+      tools: [
+        {
+          name: "exec",
+          input_schema: {
+            type: "object",
+            properties: { code: { type: "string" } },
+            required: ["code"],
+          },
+        },
+        {
+          name: "wait",
+          input_schema: {
+            type: "object",
+            properties: { runId: { type: "string" } },
+            required: ["runId"],
+          },
+        },
+      ],
+      messages: [
+        makeAnthropicUserText(
+          "Read repo/qa/scenarios/index.yaml and summarize the QA scenario pack mission in one clause before any model switch.",
+        ),
+      ],
+    })) as {
+      stop_reason: string;
+      content: Array<Record<string, unknown>>;
+    };
+
+    expect(body.stop_reason).toBe("tool_use");
+    expect(body.content.find((block) => block.type === "tool_use")?.name).toBe("exec");
+
+    const debug = requireRecord(
+      await getJson(server, "/debug/last-request"),
+      "model switch Code Mode debug request",
+    );
+    expect(debug.plannedToolName).toBe("read");
+    expect(debug.plannedWireToolName).toBe("exec");
+    expect(debug.plannedToolArgs).toEqual({ path: "repo/qa/scenarios/index.yaml" });
+  });
+
   it("returns continuity language after the model-switch reread completes", async () => {
     const server = await startMockServer();
 

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -134,7 +134,6 @@ import {
   isHeartbeatPrompt,
 } from "./mock-openai-directives.js";
 import {
-  buildToolCallEvents,
   buildReleaseAuditJson,
   buildReleaseHandoffMarkdown,
   extractPlannedToolName,
@@ -2363,7 +2362,7 @@ async function buildResponsesPayload(
     });
   }
   if (!hasCompletedToolOutput && /\b(read|inspect|repo|docs|scenario|kickoff)\b/i.test(prompt)) {
-    return buildToolCallEvents(prompt);
+    return buildToolCallEventsWithArgs("read", { path: readTargetFromPrompt(prompt) });
   }
   if (/visible skill marker/i.test(prompt) && !hasCompletedToolOutput) {
     return buildAssistantEvents("VISIBLE-SKILL-OK");


### PR DESCRIPTION
## What Problem This Solves

The QA mock's generic planner emitted a raw `read` tool call for the initial model-switch scenario prompt. Anthropic guest Code Mode advertises only `exec` and `wait`, so the scenario failed with `Tool read not found` before producing a receipt.

## Why This Change Was Made

- Route the semantic `read` through the mock server's canonical Code Mode wrapper, which preserves `read` in planner/debug state while emitting wire tool `exec`.
- Delete the now-unused raw read-event helper.
- Cover the exact model-switch initial prompt against an Anthropic `/v1/messages` request exposing only guest Code Mode `exec` and `wait`.

Codex contract checked directly at `openai/codex` commit `414782450952a196bbb64b1605a458c2531c47b6`:

- `codex-rs/core/src/tools/code_mode/execute_spec.rs:7-36` publishes freeform `exec`.
- `codex-rs/core/src/tools/code_mode/wait_spec.rs:6-47` publishes `wait`.
- `codex-rs/core/src/tools/spec_plan.rs:475-532` makes `CodeModeOnly` expose those handlers while retaining nested tool specs.
- `codex-rs/core/src/tools/code_mode/execute_handler.rs:29-90` starts nested dispatch from `exec`.
- `codex-rs/core/src/tools/code_mode/mod.rs:238-277` dispatches nested calls as ordinary tool calls with Code Mode provenance.

## User Impact

The model-switch continuity QA scenario now follows the same semantic-tool/wire-tool contract as the rest of the mock planner. Product runtime, retries, receipts, lifecycle, gateway, and scenario configuration are unchanged.

## Evidence

- Focused regression: 1 passed, 266 skipped.
- Full `server.test.ts`: 267 passed.
- Exact scenario, committed retry settings, concurrency 1: primary successful tools `[read, exec]`; alternate `[read]`; both runs owned and visible; delivery sent with one result.
- Exact-head changed gate: passed on Blacksmith Testbox `tbx_01kzwf3zgyjayr471eknp9kkqa`.
- Exact-head CI: 56 successful jobs, zero failures (`31661083734`).
- Local structured autoreview: clean, no accepted/actionable findings.
- Local ClawSweeper exact-range review: no actionable bug, regression, security issue, or in-scope finding; it judged the canonical adapter reuse the best fix. Its neutral status only reflects the read-only sandbox blocking the Vitest lock, covered by the focused, full, and scenario runs above.
- Production LOC: +2/-12, net -10. Tests: +43/-0.
- `git diff --check`: clean.
