### PR TITLE
fix(whatsapp): retry durable admission instead of dropping inbound messages

### DIFF
--- a/extensions/whatsapp/src/inbound/admission-retry.ts
+++ b/extensions/whatsapp/src/inbound/admission-retry.ts
@@ -1,0 +1,90 @@
+// Whatsapp plugin module implements inbound admission retry behavior.
+import { sleep } from "openclaw/plugin-sdk/runtime-env";
+import { formatError } from "../session.js";
+import { WhatsAppIngressPermanentError } from "./durable-payload.js";
+import type { createWhatsAppIngressMonitor, WhatsAppIngressAdmission } from "./durable-receive.js";
+
+const INBOUND_ADMISSION_RETRY_INITIAL_DELAY_MS = 1_000;
+const INBOUND_ADMISSION_RETRY_MAX_DELAY_MS = 30_000;
+export const WHATSAPP_INBOUND_ADMISSION_CUSTODY_LIMIT = 500;
+
+type WhatsAppIngressMonitor = ReturnType<typeof createWhatsAppIngressMonitor>;
+type AdmissionLogger = {
+  warn: (fields: Record<string, unknown>, message: string) => void;
+  error: (fields: Record<string, unknown>, message: string) => void;
+};
+
+/**
+ * Owns WhatsApp inbound custody after the shared monitor's quick append retries give up. Baileys
+ * acks the stanza before `messages.upsert` fires, so nothing upstream can redeliver. Retries run
+ * on a FIFO chain, so a waiting retry holds the chain and no later arrival overtakes an earlier
+ * one, and custody is reserved per arriving batch so an outage cannot grow the process unbounded.
+ */
+export function createWhatsAppInboundAdmissionChain(
+  monitor: WhatsAppIngressMonitor,
+  logger: AdmissionLogger,
+  consoleLog: { error: (message: string) => void },
+) {
+  const retryAbort = new AbortController();
+  let tail: Promise<unknown> = Promise.resolve();
+  let custody = 0;
+
+  const reportDropped = (reason: string) => {
+    logger.error({ error: reason }, "failed persisting durable WhatsApp inbound; message dropped");
+    consoleLog.error(`Failed persisting durable WhatsApp inbound; dropped: ${reason}`);
+  };
+
+  return {
+    /** Holds custody for a whole arriving batch; past the limit the batch is dropped unrun. */
+    withCustody: async (count: number, deliver: () => Promise<void>) => {
+      if (count > 0 && custody >= WHATSAPP_INBOUND_ADMISSION_CUSTODY_LIMIT) {
+        reportDropped(
+          `durable admission custody limit of ${WHATSAPP_INBOUND_ADMISSION_CUSTODY_LIMIT} inbound messages reached; dropped ${count} arriving inbound`,
+        );
+        return;
+      }
+      custody += count;
+      try {
+        await deliver();
+      } finally {
+        custody -= count;
+      }
+    },
+    admitInArrivalOrder: (
+      admission: WhatsAppIngressAdmission,
+      receivedAt: number,
+    ): Promise<Awaited<ReturnType<WhatsAppIngressMonitor["admit"]>> | undefined> => {
+      const admitted = tail.then(async () => {
+        let delayMs = INBOUND_ADMISSION_RETRY_INITIAL_DELAY_MS;
+        for (;;) {
+          try {
+            return await monitor.admit(admission, { receivedAt });
+          } catch (error) {
+            const formattedError = formatError(error);
+            if (
+              error instanceof WhatsAppIngressPermanentError ||
+              monitor.isStopped() ||
+              retryAbort.signal.aborted
+            ) {
+              reportDropped(formattedError);
+              return undefined;
+            }
+            logger.warn(
+              { error: formattedError, retryDelayMs: delayMs },
+              "failed persisting durable WhatsApp inbound; retrying admission",
+            );
+            await sleep(delayMs, retryAbort.signal).catch(() => undefined);
+            delayMs = Math.min(delayMs * 2, INBOUND_ADMISSION_RETRY_MAX_DELAY_MS);
+          }
+        }
+      });
+      tail = admitted.catch(() => undefined);
+      return admitted;
+    },
+    /** Aborts pending retries before stopping the monitor so close cannot hang. */
+    stop: () => {
+      retryAbort.abort();
+      return monitor.stop();
+    },
+  };
+}

--- a/extensions/whatsapp/src/inbound/message-delivery.ts
+++ b/extensions/whatsapp/src/inbound/message-delivery.ts
@@ -19,6 +19,7 @@ import { maybeResolveWhatsAppQuestionReaction } from "../question-reactions.js";
 import { cacheInboundMessageMeta } from "../quoted-message.js";
 import type { OpenClawConfig } from "../runtime-api.js";
 import { formatError } from "../session.js";
+import { createWhatsAppInboundAdmissionChain } from "./admission-retry.js";
 import { requireWhatsAppInboundAdmission } from "./admission.js";
 import {
   createWhatsAppDurableInboundQueue,
@@ -67,14 +68,6 @@ function logWhatsAppVerbose(enabled: boolean | undefined, message: string) {
     return;
   }
   defaultRuntime.log(message);
-}
-
-function recordAcceptedInboundActivity(accountId: string): void {
-  recordChannelActivity({
-    channel: "whatsapp",
-    accountId,
-    direction: "inbound",
-  });
 }
 
 export type WhatsAppAppendReplyWindow = {
@@ -470,7 +463,11 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
       return "completed";
     }
 
-    recordAcceptedInboundActivity(options.accountId);
+    recordChannelActivity({
+      channel: "whatsapp",
+      accountId: options.accountId,
+      direction: "inbound",
+    });
     await enqueueInboundMessage(msg, inbound, enriched, {
       readReceipt: deliveryReadReceipt,
       receiveOrder: context.receiveOrder ?? context.receivedAt,
@@ -494,11 +491,14 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
     },
   });
 
-  const handleMessagesUpsert = async (upsert: { type?: string; messages?: Array<WAMessage> }) => {
-    if (upsert.type !== "notify" && upsert.type !== "append") {
-      return;
-    }
-    for (const msg of upsert.messages ?? []) {
+  const inboundAdmission = createWhatsAppInboundAdmissionChain(
+    durableInboundMonitor,
+    inboundLogger,
+    inboundConsoleLog,
+  );
+
+  const deliverUpsert = async (upsertType: "notify" | "append", messages: Array<WAMessage>) => {
+    for (const msg of messages) {
       rememberBaileysMessage(msg.key?.remoteJid, msg.key?.id, msg.message);
 
       const receiveOrder = nextReceiveOrder++;
@@ -518,7 +518,7 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
       }
 
       const receivedAt = Date.now();
-      const skipStaleAppend = shouldSkipStaleAppend(msg, upsert.type);
+      const skipStaleAppend = shouldSkipStaleAppend(msg, upsertType);
       const skipRecentOutboundEcho = shouldSkipRecentOutboundEcho(msg);
       const remoteJid = msg.key?.remoteJid;
       const id = msg.key?.id;
@@ -551,31 +551,19 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
           preparedInboundByDurableId.delete(durableId);
         }
       };
-      let result: Awaited<ReturnType<typeof durableInboundMonitor.admit>>;
-      try {
-        // Shared admission owns the serialized [0, 100, 300] append retries and
-        // returns the atomic accepted/pending/completed queue verdict.
-        result = await durableInboundMonitor.admit(
-          {
-            message: msg,
-            upsertType: upsert.type,
-            skipStaleAppend,
-            skipRecentOutboundEcho,
-            receivedAt,
-            receiveOrder,
-          },
-          { receivedAt },
-        );
-      } catch (error) {
+      const result = await inboundAdmission.admitInArrivalOrder(
+        {
+          message: msg,
+          upsertType,
+          skipStaleAppend,
+          skipRecentOutboundEcho,
+          receivedAt,
+          receiveOrder,
+        },
+        receivedAt,
+      );
+      if (!result) {
         finishPreparation(undefined);
-        const formattedError = formatError(error);
-        inboundLogger.error(
-          { error: formattedError },
-          "failed persisting durable WhatsApp inbound after retries; message dropped",
-        );
-        inboundConsoleLog.error(
-          `Failed persisting durable WhatsApp inbound after retries; message dropped: ${formattedError}`,
-        );
         continue;
       }
       if (result.kind === "durable" && result.queueResult.kind === "completed") {
@@ -603,6 +591,15 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
         finishPreparation(undefined);
       }
     }
+  };
+
+  const handleMessagesUpsert = async (upsert: { type?: string; messages?: Array<WAMessage> }) => {
+    const upsertType = upsert.type;
+    if (upsertType !== "notify" && upsertType !== "append") {
+      return;
+    }
+    const messages = upsert.messages ?? [];
+    await inboundAdmission.withCustody(messages.length, () => deliverUpsert(upsertType, messages));
   };
   const handleMessagesUpsertEvent = (upsert: { type?: string; messages?: Array<WAMessage> }) => {
     const task = handleMessagesUpsert(upsert).catch((err: unknown) => {
@@ -646,7 +643,7 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
       }
       await drainDebouncedInboundMessages();
     }
-    await durableInboundMonitor.stop();
+    await inboundAdmission.stop();
   };
   const drainInboundBeforeSocketCloseWithTimeout = async () => {
     let timeout: ReturnType<typeof setTimeout> | null = null;
@@ -670,7 +667,7 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
       }
       // Start abort/dispose even when channel work ignored the graceful bound;
       // a successor must not share this account queue with a live owner.
-      void durableInboundMonitor.stop();
+      void inboundAdmission.stop();
     }
   };
   let detachMessagesUpsert: (() => void) | undefined;

--- a/extensions/whatsapp/src/monitor-inbox.durable-admission-retry.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.durable-admission-retry.test.ts
@@ -1,0 +1,172 @@
+// WhatsApp monitor inbox durable admission retry behavior.
+import { randomUUID } from "node:crypto";
+import { readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { resetLogger, setLoggerOverride } from "openclaw/plugin-sdk/runtime-env";
+import { describe, expect, it, vi } from "vitest";
+import { WHATSAPP_INBOUND_ADMISSION_CUSTODY_LIMIT } from "./inbound/admission-retry.js";
+import { createWhatsAppDurableInboundQueue } from "./inbound/durable-receive.js";
+import {
+  inboundMessage,
+  installStreamsInboundMessageHooks,
+  nextMessageId,
+} from "./monitor-inbox.streams-inbound-messages.test-support.js";
+import {
+  buildNotifyMessageUpsert,
+  DEFAULT_ACCOUNT_ID,
+  startInboxMonitor,
+  waitForMessageCalls,
+  type InboxOnMessage,
+} from "./monitor-inbox.test-harness.js";
+
+function createFlakyDurableInboundQueue(failedAttempts: number) {
+  const realQueue = createWhatsAppDurableInboundQueue(DEFAULT_ACCOUNT_ID);
+  const attempts = { count: 0 };
+  const queue: typeof realQueue = {
+    ...realQueue,
+    enqueue: async (eventId, payload, options) => {
+      attempts.count += 1;
+      if (attempts.count <= failedAttempts) {
+        throw new Error("sqlite unavailable");
+      }
+      return realQueue.enqueue(eventId, payload, options);
+    },
+  };
+  return { queue, attempts };
+}
+
+describe("web monitor inbox durable admission retry", () => {
+  installStreamsInboundMessageHooks();
+
+  it("readmits the inbound message after transient durable append failure", async () => {
+    const { queue, attempts } = createFlakyDurableInboundQueue(3);
+    const onMessage = vi.fn(async () => {});
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      durableInboundQueue: queue,
+    });
+
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("admission-retry"),
+        remoteJid: "999@s.whatsapp.net",
+        text: "survives storage outage",
+        timestamp: 1_700_000_000,
+        pushName: "Tester",
+      }),
+    );
+
+    await waitForMessageCalls(onMessage, 1);
+    expect(attempts.count).toBeGreaterThanOrEqual(4);
+    expect(inboundMessage(onMessage).payload.body).toBe("survives storage outage");
+    await listener.close();
+  });
+
+  it("abandons admission retries when the inbound coordinator closes", async () => {
+    const { queue, attempts } = createFlakyDurableInboundQueue(Number.POSITIVE_INFINITY);
+    const onMessage = vi.fn(async () => {});
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      durableInboundQueue: queue,
+    });
+
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("admission-abandon"),
+        remoteJid: "999@s.whatsapp.net",
+        text: "storage never recovers",
+        timestamp: 1_700_000_000,
+        pushName: "Tester",
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(attempts.count).toBeGreaterThanOrEqual(3);
+    });
+    await listener.close();
+    const attemptsAfterClose = attempts.count;
+    await delay(1_500);
+    expect(attempts.count).toBe(attemptsAfterClose);
+    expect(onMessage).not.toHaveBeenCalled();
+  }, 15_000);
+
+  it("keeps same-chat arrival order while an earlier admission is still retrying", async () => {
+    const { queue } = createFlakyDurableInboundQueue(3);
+    const onMessage = vi.fn(async () => {});
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      durableInboundQueue: queue,
+    });
+
+    for (const text of ["first arrival", "second arrival"]) {
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("admission-order"),
+          remoteJid: "998@s.whatsapp.net",
+          text,
+          timestamp: 1_700_000_000,
+          pushName: "Tester",
+        }),
+      );
+    }
+
+    await waitForMessageCalls(onMessage, 2);
+    expect([
+      inboundMessage(onMessage, 0).payload.body,
+      inboundMessage(onMessage, 1).payload.body,
+    ]).toEqual(["first arrival", "second arrival"]);
+    await listener.close();
+  }, 20_000);
+
+  it("counts every message of one upsert batch against the admission custody limit", async () => {
+    const { queue, attempts } = createFlakyDurableInboundQueue(Number.POSITIVE_INFINITY);
+    const logPath = path.join(os.tmpdir(), `openclaw-admission-custody-${randomUUID()}.log`);
+    setLoggerOverride({ level: "trace", file: logPath });
+    const onMessage = vi.fn(async () => {});
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      durableInboundQueue: queue,
+    });
+
+    const batched: Array<unknown> = [];
+    for (let index = 0; index < WHATSAPP_INBOUND_ADMISSION_CUSTODY_LIMIT; index += 1) {
+      batched.push(
+        ...buildNotifyMessageUpsert({
+          id: nextMessageId("admission-custody"),
+          remoteJid: "997@s.whatsapp.net",
+          text: `batched ${index}`,
+          timestamp: 1_700_000_000,
+          pushName: "Tester",
+        }).messages,
+      );
+    }
+    sock.ev.emit("messages.upsert", { type: "notify", messages: batched });
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("admission-custody"),
+        remoteJid: "997@s.whatsapp.net",
+        text: "arrival past the limit",
+        timestamp: 1_700_000_000,
+        pushName: "Tester",
+      }),
+    );
+
+    await vi.waitFor(
+      async () => {
+        const logged = await readFile(logPath, "utf8").catch(() => "");
+        expect(logged).toContain(
+          `custody limit of ${WHATSAPP_INBOUND_ADMISSION_CUSTODY_LIMIT} inbound messages reached`,
+        );
+      },
+      { timeout: 10_000, interval: 50 },
+    );
+    expect(attempts.count).toBeLessThan(WHATSAPP_INBOUND_ADMISSION_CUSTODY_LIMIT);
+    expect(onMessage).not.toHaveBeenCalled();
+    await listener.close();
+    resetLogger();
+    setLoggerOverride(null);
+    await rm(logPath, { force: true });
+  }, 20_000);
+});


### PR DESCRIPTION
## What Problem This Solves
A valid inbound WhatsApp message is permanently lost when the durable ingress queue cannot accept the append, for example while SQLite is locked, full, or unavailable. The socket handler catches the admission failure, logs "message dropped", and moves on. Because Baileys has already consumed the `messages.upsert` event, there is no durable row, no retry record, and no replay path: the user's message is unrecoverable.

## Why This Change Was Made
`extensions/whatsapp/src/inbound/message-delivery.ts` wrapped `durableInboundMonitor.admit(...)` in a catch block that dropped the message after the shared monitor's three quick append attempts (`[0, 100, 300]` ms, `src/channels/message/ingress-monitor.ts`):

```ts
// before
} catch (error) {
  finishPreparation(undefined);
  const formattedError = formatError(error);
  inboundLogger.error(
    { error: formattedError },
    "failed persisting durable WhatsApp inbound after retries; message dropped",
  );
  ...
  continue;
}
```

Other channels propagate admission failure to a transport that can redeliver. WhatsApp has no such seam: Baileys acks the message stanza at the protocol level before `messages.upsert` fires, so the in-process handler is the last custody point. Dropping there loses the message for good.

A new `extensions/whatsapp/src/inbound/admission-retry.ts` owns inbound custody after the shared monitor gives up. It holds the FIFO admission chain, the retry loop, the custody counter, and the shutdown abort, and the coordinator drives it:

```ts
// after, admission-retry.ts
withCustody: async (count, deliver) => {
  if (count > 0 && custody >= WHATSAPP_INBOUND_ADMISSION_CUSTODY_LIMIT) {
    reportDropped(`durable admission custody limit of ... reached; dropped ${count} ...`);
    return;
  }
  custody += count;
  try {
    await deliver();
  } finally {
    custody -= count;
  }
},
admitInArrivalOrder: (admission, receivedAt) => {
  const admitted = tail.then(async () => {
    let delayMs = INBOUND_ADMISSION_RETRY_INITIAL_DELAY_MS;
    for (;;) {
      try {
        return await monitor.admit(admission, { receivedAt });
      } catch (error) {
        ...
        await sleep(delayMs, retryAbort.signal).catch(() => undefined);
        delayMs = Math.min(delayMs * 2, INBOUND_ADMISSION_RETRY_MAX_DELAY_MS);
      }
    }
  });
  tail = admitted.catch(() => undefined);
  return admitted;
},

// after, message-delivery.ts
const handleMessagesUpsert = async (upsert) => {
  ...
  const messages = upsert.messages ?? [];
  await inboundAdmission.withCustody(messages.length, () =>
    deliverUpsert(upsertType, messages),
  );
};
```

## Review findings addressed

**[P1] Account for every message in a batched upsert.** The finding was correct. Custody was incremented once per individual admission, so while the loop was blocked on a retrying head message, the remaining messages of the same `messages.upsert` were still retained by the handler and never counted. The cap therefore bounded concurrent handlers, not messages, and a batched upsert bypassed it.

Custody accounting moved from the individual admission to the arriving batch. `withCustody(count, deliver)` reserves for the whole upsert before anything is processed and releases in a `finally`, so every message of a batch is counted for exactly as long as the coordinator holds it, and the admission call no longer keeps a counter of its own. Reserving and releasing as one scoped operation also removes the chance of a caller leaking custody on an error path. An arrival that meets a coordinator already at the limit is dropped whole with the same operator-visible error, which now also names how many messages were dropped.

The resulting bound is "at most the limit, plus the one batch that crossed it". Because the reserve-and-check runs synchronously before the handler's first await, only one batch can cross at a time, so that overshoot is deterministic rather than unbounded. Allowing it is deliberate: rejecting a batch on its own size would drop part of any healthy upsert larger than the cap, including on a completely idle coordinator, which is a worse regression than the outage case the cap exists for.

The custody regression case was replaced rather than extended. `counts every message of one upsert batch against the admission custody limit` emits one notify upsert of `WHATSAPP_INBOUND_ADMISSION_CUSTODY_LIMIT` messages while the durable append is failing, then one further arrival, and requires that arrival to be dropped. Against the previous revision it fails, because the batch counted as one and the follow-up arrival entered retry instead of dropping. The earlier 501-separate-events case was removed; the batch case covers both the per-message accounting and the overflow drop.

Earlier findings from the previous round remain fixed in the diff. Retries still run on the coordinator-owned FIFO admission chain that mirrors the shared monitor's `scheduleAdmission` contract, so a waiting retry holds the chain and no later same-chat arrival can overtake it; `keeps same-chat arrival order while an earlier admission is still retrying` covers that.

**Stored data model.** The verdict flagged "serialized state: `extensions/whatsapp/src/monitor-inbox.durable-admission-retry.test.ts`" and asked for migration proof. That path is the regression file for this change. No table, column, or persisted shape is added, and the durable ingress queue schema is untouched, so no migration applies.

## Why this is the right boundary
The shared ingress monitor's bounded `[0, 100, 300]` retry contract is correct for channels whose transport redelivers on failure. Every sibling ingress caller (`discord`, `signal`, `imessage`, `slack`, `telegram`, `msteams`, `line`, `zalo`, `sms`, `nextcloud-talk`, `irc`, `tlon`, `twitch`, `mattermost`, `feishu`, `zalouser`) rethrows admission failure to its own transport reader or webhook response, so those transports retry and none of them is affected by this change. WhatsApp is the only caller that swallowed the failure, because it is the only one whose transport cannot redeliver. The knowledge that custody ends at the coordinator is therefore channel-owned, and so is the retry and the custody bound.

The retry keeps the original `receivedAt` and `receiveOrder` facts, reuses the channel's existing `WhatsAppIngressPermanentError` classification rather than inventing a second one, and reuses the shared `sleep(ms, signal)` helper. Shutdown aborts pending retries through an `AbortController` wired into both monitor stop paths, so socket close cannot hang on a retrying message.

## Production LOC and the file split
Production delta is +87: `message-delivery.ts` goes down by 3 lines (38 added, 41 removed) and the new `admission-retry.ts` is 90.

The split is not optional. `message-delivery.ts` is 697 lines on current main against a `max-lines` budget of 700, so this change had three lines of headroom, and repo policy forbids adding a `max-lines` suppression. Keeping the admission chain inside the coordinator failed the gate at 711 lines. Moving it out is also the better boundary: the retry policy, the FIFO chain, the custody counter, and the shutdown abort are one concern with one owner, and it is now directly reachable for its own coverage instead of being a closure inside a 700-line coordinator.

Two smaller cleanups came with it, both called out rather than hidden: `deliverUpsertMessages` is now `deliverUpsert` so its signature fits one line, and `recordAcceptedInboundActivity`, a single-use local wrapper around `recordChannelActivity`, is inlined at its one call site.

What the growth buys is three things the previous shape could not express: custody across a storage outage, a serialized arrival-order guarantee for retries, and a per-message custody bound that a batched upsert cannot bypass.

## Maintainer decision still open
The custody limit value is a channel policy choice, not a derived constant. This PR proposes 500 in-flight un-admitted inbound messages per WhatsApp coordinator: high enough that healthy bursts never reach it, low enough to bound outage memory. Raising it, lowering it, or making it operator-configurable is a maintainer call; the mechanism is in place either way.

The related merge-risk item is the same decision seen from the other side. A fixed volatile cap does intentionally drop inbound messages during a prolonged storage outage. That is a tradeoff needing owner acceptance rather than a code change: the alternative is unbounded coordinator memory during an outage, which the previous review round rejected. One consequence worth naming: an upsert dropped at the cap is returned early, so its messages are not added to the quoted-message cache and an approval reaction inside such a batch is not resolved. That only applies to a coordinator already holding 500 un-admitted messages.

## Verification
- `node scripts/run-vitest.mjs extensions/whatsapp/src/monitor-inbox.durable-admission-retry.test.ts extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts extensions/whatsapp/src/monitor-inbox.socket-lifecycle.test.ts extensions/whatsapp/src/monitor-inbox.append.test.ts extensions/whatsapp/src/monitor-inbox.access-and-echo.test.ts extensions/whatsapp/src/inbound/durable-receive.test.ts` - 6 files, 85 passed.
- The batch custody case fails against the previous revision of this branch for its intended reason (no overflow drop is ever emitted) and passes here.
- `node scripts/run-oxlint.mjs` clean on all three changed files, including `max-lines`, and `oxfmt --check` clean. `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json` reports no error in any WhatsApp file; its 13 reported errors are all in `extensions/cua-computer` and come from a `@trycua/cua-driver` type mismatch that is unrelated to this change and present without it.

## Real behavior proof
Behavior addressed: a valid inbound WhatsApp message arriving while the durable ingress queue cannot accept writes is silently and permanently lost instead of being delivered once storage recovers.
Real environment tested: the real WhatsApp inbound stack driven in a plain Node process on pristine main 9386ac096632509203dc94086d86d7b3de8bc30d and on PR head d3c049857ffa9d9b2e78c037b32df57c99d62d9a, identical inputs on both. Production `attachWebInboxToSocket` entry point, real attached socket session, real delivery coordinator, real shared ingress monitor, the real `PluginRuntime` from the production `createPluginRuntime()` factory, and the real on-disk SQLite ingress queue created by the production plugin state runtime under a fresh `OPENCLAW_STATE_DIR`. Upsert events are emitted through the real Baileys `makeEventBuffer` so they pass through the library's own buffering and emission code. The outage is a genuine SQLite write lock: a second `node:sqlite` connection to the same `state/openclaw.sqlite` file holds `BEGIN EXCLUSIVE` for 35 seconds and then rolls back.
Exact steps or command run after this patch: start the inbound stack against a fresh state directory, take an exclusive SQLite write lock on the ingress database from a second connection, emit two `messages.upsert` notify events for the same chat while the lock is held, hold the lock for 35 seconds, release it, then record which messages reached the gateway handler and in what order.
Evidence after fix:
```
# BEFORE (pristine main 9386ac09663)
[t+ 2629ms] inbound listener attached to socket
[t+ 4635ms] durable ingress database path /tmp/openclaw-proof-state-uRfw2N/state/openclaw.sqlite
[t+ 4636ms] durable ingress database write lock acquired by a second connection
[t+ 4640ms] emitted messages.upsert notify body="first arrival"
[t+11577ms] emitted messages.upsert notify body="second arrival"
[t+25083ms] runtime console: [whatsapp] Failed persisting durable WhatsApp inbound after retries; message dropped: database is locked
[t+43610ms] runtime console: [whatsapp] Failed persisting durable WhatsApp inbound after retries; message dropped: database is locked
[t+43616ms] delivered while durable storage unavailable: 0 of 2
[t+43617ms] durable ingress database write lock released
[t+63805ms] delivered after durable storage recovered: 0 of 2
[t+64271ms] delivery order: (nothing delivered)
[t+64277ms] runtime console lines reporting a dropped inbound message: 2

# AFTER (this patch, identical inputs, head d3c049857ffa)
[t+  121ms] inbound listener attached to socket
[t+ 2123ms] durable ingress database path /tmp/openclaw-proof-state-7VbTZQ/state/openclaw.sqlite
[t+ 2124ms] durable ingress database write lock acquired by a second connection
[t+ 2127ms] emitted messages.upsert notify body="first arrival"
[t+ 7381ms] emitted messages.upsert notify body="second arrival"
[t+42465ms] delivered while durable storage unavailable: 0 of 2
[t+42466ms] durable ingress database write lock released
[t+42598ms] gateway handler received inbound body="first arrival"
[t+42604ms] gateway handler received inbound body="second arrival"
[t+42967ms] delivered after durable storage recovered: 2 of 2
[t+42967ms] delivery order: first arrival then second arrival
[t+42967ms] runtime console lines reporting a dropped inbound message: 0
```
Observed result after fix: on pristine main both inbound messages are permanently lost during a 35 second SQLite write-lock outage and never arrive even after the lock is released, while the same run on this head holds both messages and hands both to the gateway handler in their original arrival order about 130 ms after the database accepts writes again.
What was not tested: no live WhatsApp account or Baileys network socket was driven, so the WhatsApp Web transport is the one boundary standing in for the network; the socket object is inert apart from its real Baileys event buffer, and everything from the `messages.upsert` event onward is production code against a real SQLite database, which is where the defect and the repair live because Baileys has already acked the stanza before that event fires. A storage outage that outlives the process still ends in the same logged drop as before, since only a durable row can survive a restart. Full build and full repository suites were not run.
