### PR TITLE
fix(gateway): stabilize sender avatar projection test

### DIFF
--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -26,6 +26,7 @@ import { appendAssistantMessageToSessionTranscript } from "../config/sessions/tr
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { claimAgentRunContext, clearAgentRunContext } from "../infra/agent-run-registry.js";
+import * as secureRandom from "../infra/secure-random.js";
 import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import * as transcriptEvents from "../sessions/transcript-events.js";
 import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
@@ -981,7 +982,17 @@ describe("session.message websocket events", () => {
     });
 
     const profile = withMockedDateNow(SHARED_REV, () => {
-      const created = ensureProfileForEmail("current-profile-display@example.com");
+      // Avoid random UUID spans such as `fc-...` that transcript redaction treats as secrets.
+      const created = (() => {
+        const profileIdSpy = vi
+          .spyOn(secureRandom, "generateSecureUuid")
+          .mockReturnValue("00000000-0000-4000-8000-000000000001");
+        try {
+          return ensureProfileForEmail("current-profile-display@example.com");
+        } finally {
+          profileIdSpy.mockRestore();
+        }
+      })();
       setDisplayName(created.id, "Old Display Name");
       expect(setAvatar(created.id, new Uint8Array([1, 2, 3]), "image/png").ok).toBe(true);
       return created;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the sender-avatar projection regression test could fail nondeterministically when its randomly generated profile UUID contained a substring matching an intentional secret-redaction prefix. Transcript persistence then correctly redacted the fixture ID, so the current-profile lookup became unresolved and the expected avatar URL disappeared.

This is separate from #122866. That PR's first CI attempt exposed the unrelated flake; its web-fetch change is not part of this PR.

## Why This Change Was Made

The test now scopes `generateSecureUuid` to a fixed redaction-safe UUID only while creating the profile fixture, restoring the spy in `finally`. Production secret redaction, profile resolution, avatar projection, and every existing assertion remain unchanged.

AI-assisted: yes. The CI failure was traced through transcript redaction, reproduced with the captured unlucky UUID, and independently reviewed after the focused fix.

## User Impact

There is no runtime behavior change. Maintainers get deterministic CI coverage for live `session.message`, `chat.history`, and `chat.message.get` sender/avatar parity without weakening production secret handling.

## Evidence

- Original failure: https://github.com/openclaw/openclaw/actions/runs/31651195981/attempts/1, job https://github.com/openclaw/openclaw/actions/runs/31651195981/job/94295867927 — the random UUID contained an `fc-` span, persisted as `cfbdcc33-9d9e-49ac-a4***`, and produced `senderProfileAvatarUrl: undefined`.
- The unchanged production redactor maps the captured UUID to the same masked form; the deterministic fixture UUID remains unchanged.
- Forced pre-fix focused reproduction with the captured UUID: 1 failed for the same sender ID/avatar mismatch.
- Post-fix focused proof: `node scripts/run-vitest.mjs src/gateway/session-message-events.test.ts -t "projects current revisioned sender avatars consistently across live events and RPC reads"` — 1 passed, 27 skipped.
- Full affected file: `node scripts/run-vitest.mjs src/gateway/session-message-events.test.ts` — 28 passed.
- Targeted formatting and `git diff --check` passed.
- Changed gate: Testbox `tbx_01kzwffn4tp1vf9kv02xn2jh1r`, https://github.com/openclaw/openclaw/actions/runs/31661192255 — exit 0; core-test typecheck and targeted oxlint passed.
- Fresh autoreview: clean, no accepted/actionable findings, 0.99 confidence.
- Production LOC: +0/−0. Tests: +12/−1.
