### PR TITLE
fix(discord): parse stringified components param from MCP transports

### DIFF
--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -852,6 +852,21 @@ describe("handleDiscordMessageAction", () => {
     });
   });
 
+  it("parses a stringified components param from MCP transports (#121778)", async () => {
+    const components = { blocks: [{ type: "text", text: "Pick one" }] };
+    // MCP transports deliver undeclared object params as JSON strings; the
+    // parsed spec must reach the action payload, not be silently dropped.
+    await handleDiscordMessageAction({
+      action: "send",
+      params: { message: "hello", components: JSON.stringify(components) },
+      cfg: discordConfig(),
+      toolContext: { currentChannelProvider: "discord", currentChannelId: "channel:123" },
+    });
+    expect(handleDiscordActionMock).toHaveBeenCalledTimes(1);
+    const [payload] = handleDiscordActionMock.mock.calls[0]!;
+    expect(payload).toMatchObject({ action: "sendMessage", components });
+  });
+
   it("downgrades chart-only presentations to Discord component text", async () => {
     const cfg = discordConfig();
 

--- a/extensions/discord/src/actions/handle-action.ts
+++ b/extensions/discord/src/actions/handle-action.ts
@@ -20,6 +20,7 @@ import {
   notifyDiscordActiveTurnThreadCreated,
   notifyDiscordActiveTurnThreadReplyDelivered,
 } from "../active-turn-thread-route.js";
+import { coerceDiscordComponentsParam } from "../components.js";
 import { discordInboundEventDelivery } from "../inbound-event-delivery.js";
 import {
   DISCORD_PRESENTATION_CAPABILITIES,
@@ -212,9 +213,10 @@ export async function handleDiscordMessageAction(
     const presentationFellBack = Boolean(
       generatedPresentationComponents && !presentationComponents,
     );
+    const componentsParam = coerceDiscordComponentsParam(params.components);
     const rawComponents = presentationFellBack
       ? undefined
-      : (params.components ??
+      : (componentsParam ??
         presentationComponents ??
         buildDiscordInteractiveComponents(normalizeLegacyInteractiveReply(params.interactive)));
     const hasComponents =

--- a/extensions/discord/src/actions/runtime.messaging.runtime.ts
+++ b/extensions/discord/src/actions/runtime.messaging.runtime.ts
@@ -1,5 +1,5 @@
 // Discord plugin module implements runtime.messaging behavior.
-import { readDiscordComponentSpec } from "../components.js";
+import { coerceDiscordComponentsParam, readDiscordComponentSpec } from "../components.js";
 import type { OpenClawConfig } from "../runtime-api.js";
 import { sendDiscordComponentMessage } from "../send.components.js";
 import {
@@ -43,6 +43,7 @@ export const discordMessagingActionRuntime = {
   listThreadsDiscord,
   pinMessageDiscord,
   reactMessageDiscord,
+  coerceDiscordComponentsParam,
   readDiscordComponentSpec,
   readMessagesDiscord,
   removeOwnReactionsDiscord,

--- a/extensions/discord/src/actions/runtime.messaging.send.ts
+++ b/extensions/discord/src/actions/runtime.messaging.send.ts
@@ -209,7 +209,9 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
       const silent = ctx.params.silent === true;
       const suppressEmbeds =
         ctx.params.suppressEmbeds === undefined ? undefined : ctx.params.suppressEmbeds === true;
-      const rawComponents = ctx.params.components;
+      const rawComponents = discordMessagingActionRuntime.coerceDiscordComponentsParam(
+        ctx.params.components,
+      );
       const componentSpec = hasDiscordComponentObjectKeys(rawComponents)
         ? discordMessagingActionRuntime.readDiscordComponentSpec(rawComponents)
         : null;

--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -2246,6 +2246,34 @@ describe("handleDiscordMessagingAction", () => {
     expect(sendOptions.mediaLocalRoots).toEqual(["/tmp/agent-root"]);
   });
 
+  it("parses a stringified components param from MCP transports (#121778)", async () => {
+    sendMessageDiscord.mockClear();
+    sendDiscordComponentMessage.mockClear();
+    const components = {
+      text: "Choose",
+      blocks: [{ type: "actions", buttons: [{ label: "Yes", callbackData: "yes" }] }],
+    };
+
+    await handleMessagingAction(
+      "sendMessage",
+      {
+        to: "channel:123",
+        content: "hello",
+        // MCP transports that stringify undeclared object params deliver
+        // `components` as a JSON string rather than a parsed object.
+        components: JSON.stringify(components),
+      },
+      enableAllActions,
+    );
+
+    // The stringified spec is parsed back into an object so the component-send
+    // path runs instead of degrading to a bare-caption text message.
+    expect(sendDiscordComponentMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessageDiscord).not.toHaveBeenCalled();
+    const payload = mockCall(sendDiscordComponentMessage, "sendDiscordComponentMessage", 0)[1];
+    expect(payload).toMatchObject(components);
+  });
+
   it("forwards the optional filename into sendMessageDiscord", async () => {
     sendMessageDiscord.mockClear();
     await handleMessagingAction(

--- a/extensions/discord/src/channel-actions.test.ts
+++ b/extensions/discord/src/channel-actions.test.ts
@@ -493,6 +493,57 @@ describe("discordMessageActions", () => {
     expect(prepared).toBeNull();
   });
 
+  it("parses a stringified components param from MCP transports (#121778)", async () => {
+    // MCP transports that stringify undeclared object parameters deliver
+    // `components` as a JSON string. The send path must coerce it back to an
+    // object so the component spec is recognized instead of silently dropped.
+    const components = {
+      text: "Choose",
+      blocks: [
+        {
+          type: "actions",
+          buttons: [{ label: "Yes", callbackData: "yes" }],
+        },
+      ],
+    };
+    const prepared = await discordMessageActions.prepareSendPayload?.({
+      ctx: {
+        channel: "discord",
+        action: "send",
+        cfg: {} as OpenClawConfig,
+        params: {
+          components: JSON.stringify(components),
+          embeds: undefined,
+        },
+      },
+      to: "channel:123",
+      payload: { text: "hello" },
+    });
+
+    expect(prepared).toEqual({
+      text: "hello",
+      channelData: { discord: { components } },
+    });
+  });
+
+  it("drops an unparseable stringified components param without throwing (#121778)", async () => {
+    const prepared = await discordMessageActions.prepareSendPayload?.({
+      ctx: {
+        channel: "discord",
+        action: "send",
+        cfg: {} as OpenClawConfig,
+        params: {
+          components: "not-json",
+          embeds: undefined,
+        },
+      },
+      to: "channel:123",
+      payload: { text: "hello" },
+    });
+
+    expect(prepared).toEqual({ text: "hello" });
+  });
+
   it("delegates action handling to the Discord action handler", async () => {
     const cfg = {
       channels: {

--- a/extensions/discord/src/channel-actions.ts
+++ b/extensions/discord/src/channel-actions.ts
@@ -11,7 +11,7 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runti
 import { extractToolSend } from "openclaw/plugin-sdk/tool-send";
 import { inspectDiscordAccount } from "./account-inspect.js";
 import { createDiscordActionGate, listDiscordAccountIds } from "./accounts.js";
-import { readDiscordComponentSpec } from "./components.js";
+import { coerceDiscordComponentsParam, readDiscordComponentSpec } from "./components.js";
 import { withDiscordInboundEventDeliveryMetadata } from "./inbound-event-delivery.js";
 import { isTrustedRequesterGuildAdminAction } from "./trusted-requester-actions.js";
 
@@ -201,7 +201,7 @@ export const discordMessageActions: ChannelMessageActionAdapter = {
       sessionKey: ctx.sessionKey,
       inboundEventKind: ctx.inboundEventKind,
     });
-    const rawComponents = ctx.params.components;
+    const rawComponents = coerceDiscordComponentsParam(ctx.params.components);
     if (typeof rawComponents === "function") {
       return null;
     }

--- a/extensions/discord/src/components.parse.ts
+++ b/extensions/discord/src/components.parse.ts
@@ -21,6 +21,24 @@ import type {
 
 export const DISCORD_COMPONENT_ATTACHMENT_PREFIX = "attachment://";
 
+/**
+ * Parses a stringified `components` param back into an object/array so the
+ * gate checks recognize it. MCP transports deliver undeclared object params as
+ * JSON strings; without this, a valid spec fails every gate and is silently
+ * dropped (#121778). Non-string and unparseable values pass through unchanged.
+ */
+export function coerceDiscordComponentsParam(raw: unknown): unknown {
+  if (typeof raw !== "string") {
+    return raw;
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : raw;
+  } catch {
+    return raw;
+  }
+}
+
 type DiscordComponentSeparatorSpacing = "small" | "large" | 1 | 2;
 
 const BLOCK_ALIASES = new Map<string, DiscordComponentBlock["type"]>([

--- a/extensions/discord/src/components.ts
+++ b/extensions/discord/src/components.ts
@@ -15,6 +15,7 @@ export {
 } from "./components.builders.js";
 export {
   DISCORD_COMPONENT_ATTACHMENT_PREFIX,
+  coerceDiscordComponentsParam,
   readDiscordComponentSpec,
   resolveDiscordComponentAttachmentName,
 } from "./components.parse.js";

--- a/extensions/discord/src/send.components.test.ts
+++ b/extensions/discord/src/send.components.test.ts
@@ -443,6 +443,41 @@ describe("sendDiscordComponentMessage classic message downgrade", () => {
     }
   });
 
+  it("retains components parsed from a stringified MCP param through a real REST request (#121778)", async () => {
+    // MCP transports deliver undeclared object params as JSON strings. The
+    // production gate coerces the string back into a spec (coerceDiscordComponentsParam
+    // -> readDiscordComponentSpec) before sendDiscordComponentMessage emits the
+    // real Discord request; this traces that chain against a real HTTP loopback.
+    const { coerceDiscordComponentsParam, readDiscordComponentSpec } =
+      await import("./components.parse.js");
+    const spec = {
+      text: "Choose",
+      blocks: [{ type: "actions", buttons: [{ label: "Yes", callbackData: "yes" }] }],
+    };
+    const loopback = await createDiscordLoopbackRest();
+    try {
+      const componentSpec = readDiscordComponentSpec(
+        coerceDiscordComponentsParam(JSON.stringify(spec)),
+      );
+      await sendDiscordComponentMessage("channel:789", componentSpec!, {
+        cfg: DISCORD_TEST_CFG,
+        rest: loopback.rest,
+        token: "test-token",
+      });
+
+      const post = loopback.requests.find((request) => request.method === "POST");
+      expect(post?.path).toContain("/channels/789/messages");
+      // The Components V2 payload (flags 32768) reached the real Discord request
+      // body with the button label and text content, instead of being silently
+      // dropped as it was before the coercion fix.
+      expect(post?.body).toContain('"flags":32768');
+      expect(post?.body).toContain('"content":"Choose"');
+      expect(post?.body).toContain('"label":"Yes"');
+    } finally {
+      await loopback.close();
+    }
+  });
+
   it("treats bare numeric component send targets as channels", async () => {
     const { rest, postMock, getMock } = makeDiscordRest();
     getMock.mockResolvedValueOnce({


### PR DESCRIPTION
Fixes #121778

## What Problem This Solves

When the `message` tool's `send` action carries a `components` argument over an MCP transport that serializes undeclared object parameters to JSON strings (observed via `claude-cli`-family MCP clients), the rich Components V2 payload is **silently discarded**. The message still sends with a valid success receipt, but degrades to a bare-caption text message — no error, warning, or indication that `components` was dropped. This is a message-loss bug on a default plugin path.

## Why This Change Was Made

`components` arrives as a JSON string (not a live object) on these transports because it isn't declared in the tool's exposed schema. Three independent call sites in `@openclaw/discord` each gate on the raw param with a `typeof`/`Array.isArray`/key-presence check that only recognizes an already-parsed object, so a string value fails every gate and is treated as absent:

1. `channel-actions.ts` `prepareSendPayload` — core channel-action send path
2. `handle-action.ts` `handleDiscordMessageAction` (`send` branch) — plugin action handler
3. `runtime.messaging.send.ts` `handleDiscordMessageSendAction` (`sendMessage` case) — runtime.messaging action

Per the issue, patching only one of the three does not fix a real end-to-end send; each is a distinct entry point that reads the raw `components` param.

The fix adds one shared `coerceDiscordComponentsParam` helper at the owner boundary (`components.parse.ts`) that parses a JSON string back into an object/array so the existing gate checks recognize it. Non-string values pass through unchanged; unparseable strings fall back to the raw value, so callers that already send a real object/array (or a malformed string) are unaffected. The helper is applied at all three gate sites. Downstream readers (`outbound-components.ts`, `outbound-payload.ts`) only see already-baked `channelData.discord.components`, so they need no change.

This is a canonical owner-boundary helper rather than three inline parse snippets: the three sites share identical boundary logic, so one helper (re-exported through `components.ts` and the `runtime.messaging.runtime.ts` barrel) removes the triplication and keeps the invariant in one place.

## User Impact

Component payloads sent through MCP-transports that stringify object args now reach Discord through all three send paths (`message` tool send, direct plugin action, and runtime.messaging). Operators using such MCP clients no longer see silent degradation to plain-text messages; existing callers sending real objects/arrays see no behavior change.

## Evidence

**Pre-fix reproduction (all three sites fail for the intended reason):**

Site 1 — `channel-actions.test.ts` "parses a stringified components param from MCP transports":
```
Expected: { text: "hello", channelData: { discord: { components: { blocks: [...], text: "Choose" } } } }
Received: { text: "hello" }   // components dropped
Tests  1 failed | 29 passed (30)
```

Site 2 — `handle-action.test.ts` "parses a stringified components param from MCP transports":
```
AssertionError: expected { action: 'sendMessage', …(12) } to match object { action: 'sendMessage', components }  // components absent — string dropped at the typeof==="object" gate
Tests  1 failed | 36 passed (37)
```

Site 3 — `runtime.test.ts` "parses a stringified components param from MCP transports":
```
expect(sendDiscordComponentMessage).toHaveBeenCalledTimes(1)  // was 0 — degraded to bare sendMessageDiscord
Tests  1 failed | 149 passed (150)
```

Pre-fix proof method: each prod gate file was reverted to the fix commit's parent (keeping the new test), the suite was run, and the new test failed for the intended reason; then the fix was restored.

**Real-behavior boundary trace (MCP-stringified param → real Discord REST request):**

`send.components.test.ts` "retains components parsed from a stringified MCP param through a real REST request" drives the production coerce→spec→send chain against a real HTTP loopback (`createDiscordLoopbackRest`), starting from `JSON.stringify(spec)` exactly as an MCP transport delivers it:

- Pre-fix (no coercion): `readDiscordComponentSpec(JSON.stringify(spec))` throws `components must be an object` at the `requireObject` gate — the stringified param is rejected and the spec is dropped before any send.
- Post-fix: `coerceDiscordComponentsParam` parses the string back into an object, `readDiscordComponentSpec` succeeds, and the real `sendDiscordComponentMessage` issues a real HTTP POST captured by the loopback:

```json
POST /channels/789/messages
{"components":[{"type":17,"components":[{"type":10,"content":"Choose"},{"type":1,"components":[{"type":2,"style":1,"custom_id":"occomp:cid=btn_fDsKnGmA","label":"Yes"}]}]}],"flags":32768,"nonce":"...","enforce_nonce":true}
```

The Components V2 payload (`flags: 32768`, `content: "Choose"`, button `label: "Yes"`) reaches the real Discord request body instead of being silently dropped. The `callbackData` is encoded into the component `custom_id` as designed, not sent as plaintext.

**Post-fix (all green):**
```
extensions/discord/src/actions/runtime.test.ts        150 passed
extensions/discord/src/actions/handle-action.test.ts   37 passed
extensions/discord/src/channel-actions.test.ts         30 passed
extensions/discord/src/send.components.test.ts          15 passed  (incl. real-REST loopback trace)
```

- tsgo typecheck: exit 0
- oxfmt: clean on all touched files
- oxlint max-lines: clean (the site-2 test uses a focused `toMatchObject` assertion on the parsed-components invariant rather than re-asserting the full payload already covered by the sibling "forwards top-level components" test, avoiding duplication and keeping the test file under its max-lines ceiling)
- Production LOC delta: net +24 (one shared 18-line helper at the owner boundary serving 3 real gate sites, replacing triplicated parse logic; test lines counted separately)

Note: a prior attempt (#121991) was closed by its own author without merge or maintainer rejection; this issue remains open.
