### PR TITLE
fix(ui): fence stale recovery scope work

### DIFF
--- a/ui/src/api/gateway.node.test.ts
+++ b/ui/src/api/gateway.node.test.ts
@@ -15,28 +15,24 @@ import {
 } from "../lib/nodes/index.ts";
 import * as nodes from "../lib/nodes/index.ts";
 import {
+  migrateCloudSessionRecoveryScope,
   readCloudSessionRecovery,
   writeCloudSessionRecovery,
 } from "../lib/sessions/cloud-recovery.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 
 const wsInstances = vi.hoisted((): MockWebSocket[] => []);
-const recoveryMigrationRuntimeLoad = vi.hoisted(() => {
-  let release = () => {};
-  let markStarted = () => {};
-  const started = new Promise<void>((resolve) => {
-    markStarted = resolve;
-  });
-  const pending = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  return { markStarted, pending, release, started };
-});
+const recoveryMigrationRuntimeMock = vi.hoisted(() => ({
+  loaded: vi.fn(),
+  migrate: vi.fn(),
+}));
 
-vi.mock("../lib/sessions/cloud-recovery-migration.runtime.ts", async (importOriginal) => {
-  recoveryMigrationRuntimeLoad.markStarted();
-  await recoveryMigrationRuntimeLoad.pending;
-  return await importOriginal();
+vi.mock("../lib/sessions/cloud-recovery-migration.runtime.ts", () => {
+  recoveryMigrationRuntimeMock.loaded();
+  return {
+    default: (gatewayUrl: string, sourceScope: string, destinationScope: string) =>
+      recoveryMigrationRuntimeMock.migrate(gatewayUrl, sourceScope, destinationScope),
+  };
 });
 
 const DEFAULT_GATEWAY_URL = "ws://127.0.0.1:18789";
@@ -412,6 +408,8 @@ describe("GatewayBrowserClient", () => {
     wsInstances.length = 0;
     loadOrCreateDeviceIdentityMock.mockReset();
     signDevicePayloadMock.mockClear();
+    recoveryMigrationRuntimeMock.loaded.mockClear();
+    recoveryMigrationRuntimeMock.migrate.mockImplementation(migrateCloudSessionRecoveryScope);
     loadOrCreateDeviceIdentityMock.mockResolvedValue({
       deviceId: "device-1",
       privateKey: "private-key", // pragma: allowlist secret
@@ -1085,6 +1083,13 @@ describe("GatewayBrowserClient", () => {
     useNodeFakeTimers();
     const sessionStorage = createStorageMock();
     vi.stubGlobal("sessionStorage", sessionStorage);
+    const digest = createDeferred<ArrayBuffer>();
+    const digestMock = vi.fn(() => digest.promise);
+    let requestId = 0;
+    vi.stubGlobal("crypto", {
+      randomUUID: () => `req-recovery-${++requestId}`,
+      subtle: { digest: digestMock },
+    });
     const legacyScope = createHash("sha256").update(STORED_CRED).digest("hex");
     const recovery = {
       sessionKey: "agent:cloud:stale",
@@ -1120,13 +1125,35 @@ describe("GatewayBrowserClient", () => {
         },
       },
     });
-    await recoveryMigrationRuntimeLoad.started;
+    await vi.waitFor(() => expect(digestMock).toHaveBeenCalledOnce());
+    expect(recoveryMigrationRuntimeMock.loaded).not.toHaveBeenCalled();
     expect(onRecoveryScopeChange).not.toHaveBeenCalled();
 
     firstWs.emitClose(1006, "socket lost");
     await vi.advanceTimersByTimeAsync(800);
     const secondWs = getLatestWebSocket();
-    const { connectFrame: secondConnect } = await continueConnect(secondWs, "nonce-current");
+    secondWs.emitOpen();
+
+    digest.resolve(Uint8Array.from(createHash("sha256").update(STORED_CRED).digest()).buffer);
+    await vi.waitFor(() => expect(recoveryMigrationRuntimeMock.loaded).toHaveBeenCalledOnce());
+
+    expect(onRecoveryScopeChange).not.toHaveBeenCalled();
+    expect(recoveryMigrationRuntimeMock.migrate).not.toHaveBeenCalled();
+    expect(client.recoveryScopeReady).toBe(false);
+    expect(readCloudSessionRecovery(DEFAULT_GATEWAY_URL, legacyScope, recovery.sessionKey)).toEqual(
+      recovery,
+    );
+    expect(
+      readCloudSessionRecovery(DEFAULT_GATEWAY_URL, "server-stale", recovery.sessionKey),
+    ).toBeNull();
+
+    secondWs.emitMessage({
+      type: "event",
+      event: "connect.challenge",
+      payload: { nonce: "nonce-current", ts: 1_800_000_000_000 },
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    const secondConnect = parseLatestConnectFrame(secondWs);
     secondWs.emitMessage({
       type: "res",
       id: secondConnect.id,
@@ -1143,11 +1170,13 @@ describe("GatewayBrowserClient", () => {
         },
       },
     });
-    await vi.advanceTimersByTimeAsync(0);
-    expect(onRecoveryScopeChange).not.toHaveBeenCalled();
-
-    recoveryMigrationRuntimeLoad.release();
     await vi.waitFor(() => expect(onRecoveryScopeChange).toHaveBeenCalledOnce());
+    expect(recoveryMigrationRuntimeMock.migrate).toHaveBeenCalledExactlyOnceWith(
+      DEFAULT_GATEWAY_URL,
+      legacyScope,
+      "server-current",
+    );
+    expect(client.recoveryScopeReady).toBe(true);
     expect(client.recoveryScope).toBe("server-current");
     expect(
       readCloudSessionRecovery(DEFAULT_GATEWAY_URL, legacyScope, recovery.sessionKey),
@@ -1159,6 +1188,7 @@ describe("GatewayBrowserClient", () => {
       readCloudSessionRecovery(DEFAULT_GATEWAY_URL, "server-current", recovery.sessionKey),
     ).toEqual({ ...recovery, recoveryScope: "server-current" });
     client.stop();
+    expect(client.recoveryScopeReady).toBe(false);
   });
 
   it("keeps stale credential recovery isolated across a shared-browser principal switch", async () => {
@@ -1199,8 +1229,6 @@ describe("GatewayBrowserClient", () => {
         },
       },
     });
-    recoveryMigrationRuntimeLoad.release();
-
     await vi.waitFor(() => expect(onRecoveryScopeChange).toHaveBeenCalledOnce());
     expect(client.recoveryScope).toBe(principalScope);
     expect(readCloudSessionRecovery(DEFAULT_GATEWAY_URL, legacyScope, recovery.sessionKey)).toEqual(

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -315,9 +315,8 @@ export class GatewayBrowserClient {
   private tickWatchTimer: ReturnType<typeof setInterval> | null = null;
   private pendingDeviceTokenRetry = false;
   private deviceTokenRetryBudgetUsed = false;
-  private recoveryScopeValue = "";
-  private recoveryScopeResolved = false;
-  private recoveryScopeGeneration = 0;
+  // Close/stop advances this generation before another socket can make stale hello work look active.
+  private recovery = { value: "", resolved: false, generation: 0 };
   private scopeUpgradeBinding: ScopeUpgradeBinding | null = null;
 
   constructor(private opts: GatewayBrowserClientOptions) {
@@ -345,6 +344,7 @@ export class GatewayBrowserClient {
       },
       resolveClose: (context) => this.resolveClose(context),
       onClose: (context, decision) => {
+        this.recovery = { ...this.recovery, generation: context.generation + 1, resolved: false };
         this.stopTickWatch();
         this.scopeUpgradeBinding = null;
         const error = context.connectFailure?.error;
@@ -399,6 +399,7 @@ export class GatewayBrowserClient {
 
   stop() {
     this.stopTickWatch();
+    this.recovery = { ...this.recovery, generation: this.recovery.generation + 1, resolved: false };
     this.client.stop();
     this.cancelScopeUpgrade();
     this.scopeUpgradeBinding = null;
@@ -411,11 +412,11 @@ export class GatewayBrowserClient {
   }
 
   get recoveryScope() {
-    return this.recoveryScopeValue;
+    return this.recovery.value;
   }
 
   get recoveryScopeReady() {
-    return this.recoveryScopeResolved;
+    return this.recovery.resolved;
   }
 
   get scopeUpgradeReady() {
@@ -441,8 +442,7 @@ export class GatewayBrowserClient {
     connectChallengeTs: number | null | undefined,
     generation: number,
   ): Promise<ConnectPlan> {
-    this.recoveryScopeGeneration = generation;
-    this.recoveryScopeResolved = false;
+    this.recovery = { ...this.recovery, generation, resolved: false };
     const role = CONTROL_UI_OPERATOR_ROLE;
     const client: GatewayConnectClientInfo = {
       id: this.opts.clientName ?? GATEWAY_CLIENT_NAMES.CONTROL_UI,
@@ -565,12 +565,12 @@ export class GatewayBrowserClient {
       serverScope && hello.auth?.recoveryMigrationAllowed === true && legacyScope
         ? (await import("../lib/sessions/cloud-recovery-migration.runtime.ts")).default
         : undefined;
-    if (plan.generation !== this.recoveryScopeGeneration || !this.client.connected) {
+    if (plan.generation !== this.recovery.generation || !this.client.connected) {
       return;
     }
     migrateRecoveryScope?.(this.opts.url, legacyScope, serverScope!);
-    this.recoveryScopeValue = serverScope ?? legacyScope;
-    this.recoveryScopeResolved = true;
+    this.recovery.value = serverScope ?? legacyScope;
+    this.recovery.resolved = true;
     this.opts.onRecoveryScopeChange?.();
   }
 


### PR DESCRIPTION
Related: #122885

## What Problem This Solves

Fixes an issue where Control UI reconnects could let retired recovery-scope work migrate cloud recovery data and publish readiness during a narrow socket-generation race.

CI run [31656209542](https://github.com/openclaw/openclaw/actions/runs/31656209542), job [94311332100](https://github.com/openclaw/openclaw/actions/runs/31656209542/job/94311332100), on merged PR #122885 exposed an unsupported Vitest async manual-mock concurrent-import race. Investigation also found a separate real client race: after socket 1 closed, socket 2 could already be open before its connect plan existed, leaving `connected` true while recovery ownership still named generation 1. A delayed hello could then migrate pending cloud recovery to the retired scope and publish readiness.

## Why This Change Was Made

The client now retires recovery generation and readiness on close and stop while retaining the post-await generation guard. The regression proof replaces the async import barrier with deterministic deferred Web Crypto and a synchronous migration-runtime wrapper, and verifies that only the current generation migrates exactly once.

## User Impact

Control UI reconnects no longer let retired recovery-scope work migrate or publish, preventing stale recovery state from becoming ready during reconnect. The deterministic fixture also removes the CI flake.

Release-note context: Control UI reconnects no longer let retired recovery-scope work migrate or publish.

## Evidence

- Pre-fix regression failed with the early zero-argument callback.
- Focused `ui/src/api/gateway.node.test.ts`: 60/60 green.
- Serial stress: 20/20 green.
- Testbox `tbx_01kzwfh6whjqcb4zgxxrjw3gjf` / Actions run [31661234675](https://github.com/openclaw/openclaw/actions/runs/31661234675) was green before a fixture-only final adjustment.
- Lead reran the final focused file: 60/60 green.
- `node scripts/check-changed.mjs --dry-run -- ui/src/api/gateway.ts ui/src/api/gateway.node.test.ts` selected `coreTests, ui`.
- Final Codex autoreview: clean.
- Exact-head CI: [run 31661841661](https://github.com/openclaw/openclaw/actions/runs/31661841661) green on `c6373b06c888583a98ec42dd7a154c04cb1c18b5`.

AI-assisted; implementation, proof, and final diff were maintainer-reviewed.
