### PR TITLE
fix(ai): honor embedded OpenAI transport policy

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.test.ts
@@ -1,10 +1,15 @@
 // Settlement liveness: a wedged block-reply flush must not park the turn.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { bindStreamLlmRuntime } from "../../../llm/model-runtime-binding.js";
 import { SessionManager } from "../../sessions/index.js";
 import { RUN_LIVENESS_JOIN_TIMEOUT_MS } from "./abortable.js";
-import { settleEmbeddedAttemptStream } from "./attempt-stream-settle.js";
+import {
+  prepareEmbeddedAttemptTransport,
+  settleEmbeddedAttemptStream,
+} from "./attempt-stream-settle.js";
 
 type SettleInput = Parameters<typeof settleEmbeddedAttemptStream>[0];
+type PrepareTransportInput = Parameters<typeof prepareEmbeddedAttemptTransport>[0];
 
 function createSettleFixture(overrides?: Partial<SettleInput>): SettleInput {
   const sessionManager = SessionManager.inMemory();
@@ -97,5 +102,69 @@ describe("settleEmbeddedAttemptStream liveness", () => {
     const result = await settleEmbeddedAttemptStream(input);
     expect(flushed).toHaveBeenCalledWith({ reason: "pre_compaction", attemptAccepted: false });
     expect(result.sessionIdUsed).toBe("sess-settle-1");
+  });
+});
+
+describe("prepareEmbeddedAttemptTransport", () => {
+  it("applies the prepared transport to the live agent owner", async () => {
+    const streamFn = vi.fn();
+    bindStreamLlmRuntime(streamFn, {
+      streamSimple: streamFn,
+      registry: { getApiProvider: () => undefined },
+    } as never);
+    const session = {
+      agent: {
+        streamFn,
+        transport: "auto",
+      },
+    };
+    const input = {
+      attempt: {
+        config: {},
+        model: {
+          api: "test-api",
+          provider: "test-provider",
+          id: "test-model",
+        },
+        modelId: "test-model",
+        provider: "test-provider",
+        promptCacheKey: undefined,
+        resolvedApiKey: undefined,
+        runId: "run-transport-1",
+        runtimePlan: {
+          auth: { forwardedAuthProfileId: undefined },
+          transport: {
+            resolveExtraParams: () => ({ transport: "sse" }),
+          },
+        },
+        sessionId: "sess-transport-1",
+      },
+      session,
+      settingsManager: {
+        getGlobalSettings: () => ({}),
+        getProjectSettings: () => ({}),
+      },
+      providerThinkingLevel: undefined,
+      sessionAgentId: "main",
+      workspaceDir: "/workspace",
+      workspaceOnly: false,
+      agentDir: "/agent",
+      abortSignal: new AbortController().signal,
+      getProviderRuntimeHandle: () => ({
+        provider: "test-provider",
+        modelId: "test-model",
+      }),
+      sandboxSessionKey: "agent:main:test",
+      codeModeControlsEnabled: false,
+      providerPromptState: {
+        state: {},
+        effectiveContextTokenBudget: 128_000,
+      },
+    } as unknown as PrepareTransportInput;
+
+    const result = await prepareEmbeddedAttemptTransport(input);
+
+    expect(result.effectiveAgentTransport).toBe("sse");
+    expect(session.agent.transport).toBe("sse");
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
@@ -629,6 +629,7 @@ export async function prepareEmbeddedAttemptTransport(input: {
         `(${attempt.provider}/${attempt.modelId})`,
     );
   }
+  session.agent.transport = effectiveAgentTransport;
   return {
     effectiveAgentTransport,
     effectiveExtraParams,


### PR DESCRIPTION
Closes #122936

## What Problem This Solves

Fixes an issue where embedded OpenAI turns would use WebSocket when the effective provider or operator transport policy selected SSE. This affected the direct API-key SSE default as well as explicit embedded transport configuration: diagnostics reported SSE while the live agent still forwarded its previous `auto` mode.

## Why This Change Was Made

The embedded transport owner already resolves one canonical `effectiveAgentTransport` per attempt. The fix applies that value to the mutable live `Agent.transport` field before execution, so provider calls, diagnostics, and cache policy all use the same transport. It adds no fallback, compatibility path, config surface, or parallel transport flow.

Provenance: clearly carried forward by #121305 (`b05a308351d9088342a1806d62f56fe5f2ec572a`), authored and merged by `@steipete` on 2026-08-10. The stream-transport consolidation computed the effective value but retained it only as attempt metadata.

## User Impact

Direct OpenAI API-key turns now honor the provider's SSE default, and explicit SSE/WebSocket selections reach the actual provider transport instead of being overridden by a stale session `auto` value. Operators get the configured connection, latency, continuation, retry, and failure semantics.

Production LOC: +1/-0 (net +1) | Tests: +70/-1

## Evidence

- **Regression-first owner test:** before the production change, the focused test failed with `expected "auto" to be "sse"`; after the fix, the live agent owner is `sse`.
- **Focused current-main proof:** 154 tests passed across:
  - `src/agents/embedded-agent-runner/run/attempt-stream-settle.test.ts`
  - `src/agents/embedded-agent-runner/extra-params.provider-runtime.test.ts`
  - `src/agents/embedded-agent-runner-extraparams.test.ts`
- **Authenticated embedded proof:** before the fix, the same exact turn emitted trusted `model.call.started transport=sse` plus an OpenAI WebSocket `response.create`; after the fix, it completed exactly with `transport=sse` and no WebSocket frame.
- **Authenticated direct OpenAI stress:** 70 turns completed on the official Responses API. Native SSE and cached WebSocket continuation each used one incremental input item on all warm turns. A real `previous_response_not_found` produced HTTP 400, recovered with full-history HTTP 200 in the same turn, and resumed from the repaired baseline. Claim contention, cleanup, and abort invalidation passed.
- **Authenticated native Codex proof using the same API key:** initial response completed in 1632 ms; resumed continuation in 1906 ms; resumed native shell-tool turn in 3848 ms. All exact outputs passed in an isolated temporary `CODEX_HOME`.
- **Independent review:** Codex autoreview, high reasoning, TruffleHog clean, no P0/P1 findings, overall correctness 0.91.
- **Static checks:** targeted oxfmt/oxlint and `git diff --check` passed; changed lanes are `core, coreTests`.

Proof gaps: the repository's broad embedded live suite skipped the env-only key as `auth drift`, and the official Codex plugin suite was stopped by the host's intentional `tools.exec.mode=deny` policy before inference. Neither failure reached provider transport. The isolated authenticated proofs above exercised the requested OpenAI and native Codex paths without modifying persistent operator policy.

AI-assisted: yes. The implementation and test were manually inspected and independently autoreviewed.
