### PR TITLE
test(extensions): remove duplicate runtime replays

### DIFF
--- a/extensions/msteams/src/monitor.conversation-allowlist.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.conversation-allowlist.lifecycle.test.ts
@@ -45,30 +45,12 @@ const keepHttpServerTaskAliveMock = vi.hoisted(() =>
   }),
 );
 
-vi.mock("../runtime-api.js", async () => {
-  const { normalizeOptionalString } = await import("openclaw/plugin-sdk/string-coerce-runtime");
+vi.mock("../runtime-api.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../runtime-api.js")>();
   return {
-    DEFAULT_WEBHOOK_MAX_BODY_BYTES: 1024 * 1024,
+    ...actual,
     isDangerousNameMatchingEnabled,
-    normalizeSecretInputString: normalizeOptionalString,
-    hasConfiguredSecretInput: (value: unknown) =>
-      typeof value === "string" && value.trim().length > 0,
-    normalizeResolvedSecretInputString: (params: { value?: unknown }) =>
-      typeof params?.value === "string" && params.value.trim() ? params.value.trim() : undefined,
     keepHttpServerTaskAlive: keepHttpServerTaskAliveMock,
-    mergeAllowlist: (params: { existing?: string[]; additions: string[] }) =>
-      Array.from(new Set([...(params.existing ?? []), ...params.additions])),
-    resolveChannelMediaMaxBytes: (params: {
-      cfg: OpenClawConfig;
-      resolveChannelLimitMb: (context: { cfg: OpenClawConfig }) => number | undefined;
-    }) => {
-      const mediaMaxMb =
-        params.resolveChannelLimitMb({ cfg: params.cfg }) ??
-        params.cfg.agents?.defaults?.mediaMaxMb;
-      return typeof mediaMaxMb === "number" && mediaMaxMb > 0
-        ? Math.floor(mediaMaxMb * 1024 * 1024)
-        : undefined;
-    },
     summarizeMapping: vi.fn(),
   };
 });

--- a/extensions/slack/src/monitor/provider.reconnect.test.ts
+++ b/extensions/slack/src/monitor/provider.reconnect.test.ts
@@ -231,18 +231,6 @@ describe("slack socket reconnect helpers", () => {
     await expect(waiter).resolves.toEqual({ event: "disconnect" });
   });
 
-  it("leaves transient socket errors to the native reconnect lifecycle", async () => {
-    const client = new FakeEmitter();
-    const app = { receiver: { client } };
-    const err = new Error("dns down");
-
-    const waiter = waitForSlackSocketDisconnect(app as never);
-    client.emit("error", err);
-    client.emit("disconnected");
-
-    await expect(waiter).resolves.toEqual({ event: "disconnect" });
-  });
-
   it("installs the disconnect waiter before socket start completes", async () => {
     const client = new FakeEmitter();
     const app = {


### PR DESCRIPTION
## What Problem This Solves

Two newly landed extension tests duplicated stronger owners:

- the MS Teams conversation-allowlist suite copied multiple runtime-barrel implementations, including media-size policy unrelated to the behavior under test;
- Slack replayed a transient socket error through a fake emitter even though the same error/close path is covered through a real `@slack/bolt` Socket Mode lifecycle.

## Why This Change Was Made

Have the MS Teams suite partially import the real `runtime-api.ts` module and override only the three behaviors it controls. Delete the Slack fake-emitter transient-error replay while retaining the real SDK/WebSocket reconnect regression.

## User Impact

No runtime behavior changes. Tests become less sensitive to runtime-barrel additions and preserve stronger dependency-backed lifecycle proof.

Production delta is zero; tests are -30 lines.

## Evidence

- `node scripts/run-vitest.mjs extensions/msteams/src/monitor.conversation-allowlist.lifecycle.test.ts extensions/msteams/src/monitor.lifecycle.test.ts extensions/slack/src/monitor/provider.interop.test.ts extensions/slack/src/monitor/provider.reconnect.test.ts` — 55 tests passed.
- `node scripts/check-changed.mjs -- <changed paths>` — extension-test gate passed, including format, plugin boundaries, dead exports, test typecheck, and lint. The configured remote backend was unavailable because the `blacksmith` executable is not installed locally, so the wrapper used its documented trusted-source fallback.
- `git diff --check` — passed.
- Structured uncommitted and rebased branch autoreviews — no accepted or actionable findings.
