### PR TITLE
fix(cli): avoid restart hint for unchanged config

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -461,7 +461,7 @@ After every successful `config set` / `config patch` / `config unset`, the CLI p
 | `Change will apply without restarting the gateway.` | Hot reload picks it up automatically.  |
 | `No gateway restart needed.`                        | Nothing runtime-relevant changed.      |
 
-Writes to `plugins.entries` (or any subpath) always require a restart, since the CLI cannot prove every plugin's reload metadata is loaded.
+Effective changes to `plugins.entries` (or any subpath) require a restart, since the CLI cannot prove every plugin's reload metadata is loaded. Idempotent writes with no effective diff report `No gateway restart needed.`
 
 ## Write safety
 

--- a/src/cli/config-cli-runner.ts
+++ b/src/cli/config-cli-runner.ts
@@ -235,10 +235,10 @@ export function configApplyHintForOperations(
     beforeConfig,
     afterConfig,
   );
-  if (
-    paths.length === 0 ||
-    paths.some((path) => path === "plugins.entries" || path.startsWith("plugins.entries."))
-  ) {
+  if (paths.length === 0) {
+    return "No gateway restart needed.";
+  }
+  if (paths.some((path) => path === "plugins.entries" || path.startsWith("plugins.entries."))) {
     return "Restart the gateway to apply.";
   }
   const plan = buildGatewayReloadPlan(paths, { candidateConfig: afterConfig });

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -4215,6 +4215,35 @@ describe("config cli", () => {
   });
 
   describe("config apply hints - issue #80722", () => {
+    it("prints a no-restart hint for a same-value config set", async () => {
+      setGatewaySnapshot();
+
+      await runConfigSet("gateway.port", "18789", "--strict-json");
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      expectLogIncludes("Updated gateway.port. No gateway restart needed.");
+      expectLogExcludes("Restart the gateway to apply.");
+      expectLogExcludes("Change will apply without restarting the gateway.");
+    });
+
+    it("prints a no-restart hint for a same-value config patch", async () => {
+      setGatewaySnapshot();
+      const pathname = writeTempJson5File("openclaw-config-patch-same-value", {
+        gateway: { port: 18789 },
+      });
+
+      try {
+        await runConfigCommand(["config", "patch", "--file", pathname]);
+      } finally {
+        fs.rmSync(pathname, { force: true });
+      }
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      expectLogIncludes("Applied 1 config update(s). No gateway restart needed.");
+      expectLogExcludes("Restart the gateway to apply.");
+      expectLogExcludes("Change will apply without restarting the gateway.");
+    });
+
     it("prints a hot-reload hint for agents.list model changes", async () => {
       const resolved: OpenClawConfig = {
         agents: {
@@ -4429,6 +4458,7 @@ describe("config cli", () => {
       expectLogIncludes("Updated plugins.entries.canvas.enabled");
       expectLogIncludes("Restart the gateway to apply.");
       expectLogExcludes("Change will apply without restarting the gateway.");
+      expectLogExcludes("No gateway restart needed.");
     });
 
     it("keeps the restart hint for mixed hot and restart batch updates", async () => {


### PR DESCRIPTION
## What Problem This Solves

Idempotent `openclaw config set` and `config patch` operations correctly produced an empty runtime diff but printed `Restart the gateway to apply.` This told operators to restart even though nothing runtime-relevant changed, contradicting the documented apply-hint contract.

## Why This Change Was Made

`configApplyHintForOperations` now distinguishes an empty diff before the conservative plugin-entry rule:

- empty diff → `No gateway restart needed.`;
- actual `plugins.entries` changes → restart remains required;
- hot-reload and mixed-change behavior remain unchanged;
- the config write, validation, and audit path still runs normally.

The repair stays at the shared CLI hint owner and adds focused same-value set/patch coverage in the existing config CLI suite.

AI-assisted: yes. The defect was found in a frozen current-main Auto QA CLI audit, independently verified against config diff ownership, docs, callers, and history, then revalidated after main advanced.

## User Impact

Operators no longer receive unnecessary restart instructions after writing a value that is already configured. Real restart-requiring changes still report the existing guidance.

## Evidence

- Pre-fix new regressions: 2 failures; 11 existing apply-hint cases passed.
- Post-fix focused CLI proof: 13 apply-hint cases passed.
- `diffConfigPaths` focused proof: 8 tests passed.
- Same-value set and patch still call the config writer exactly once.
- Changed `plugins.entries` remains restart-backed and explicitly excludes the no-restart hint.
- Initial hosted changed gate: Testbox `tbx_01kzwg60f9b01p7tycxyhkyq92`, run https://github.com/openclaw/openclaw/actions/runs/31661818847 — passed.
- ClawSweeper requested one public-doc clarification: only effective `plugins.entries` changes require restart; idempotent writes do not. `docs/cli/config.md` now states that contract explicitly.
- Final code+docs hosted gate: Testbox `tbx_01kzwhfyptvc19paxxpgz0cfaw`, run https://github.com/openclaw/openclaw/actions/runs/31663014345 — passed.
- `pnpm docs:list`, targeted formatting, focused tests, and `git diff --check` passed.
- Fresh local and final complete-branch autoreviews: clean at 0.99 confidence.
- Production +4/−4 (net zero); tests +30/−0; docs +1/−1.
