### PR TITLE
improve: speed up BTW agent tests

### DIFF
--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -10,6 +10,7 @@ import {
   mintSecretSentinel,
   resolveSecretSentinel,
 } from "../secrets/sentinel.js";
+import type { AgentHarnessHostCapabilities } from "./harness/host-capability-types.js";
 import type { AgentHarness } from "./harness/types.js";
 import type { AgentRuntimeAuthPlan } from "./runtime-plan/types.js";
 
@@ -43,7 +44,20 @@ const executePreparedCliRunMock = vi.fn();
 const diagDebugMock = vi.fn();
 const ensureSelectedAgentHarnessPluginMock = vi.fn();
 const createAgentHarnessHostCapabilitiesMock = vi.fn();
+const closeAgentHarnessHostCapabilitiesMock = vi.fn();
+const agentHarnessHostCapabilitiesMock: AgentHarnessHostCapabilities = Object.freeze({
+  kind: "agent-harness-host-capability",
+  version: 1,
+  assertActive: vi.fn(),
+  bindToolSurface: vi.fn((tools) => tools),
+  runBeforeToolCall: vi.fn(),
+  requestApproval: vi.fn(),
+  waitForApproval: vi.fn(),
+});
+const listSessionEntriesCoreMock = vi.fn();
+const loadSessionEntryMock = vi.fn();
 const loadTranscriptEventsMock = vi.fn();
+const builtInOpenClawHarnesses = new WeakSet<object>();
 const shouldPreferExplicitConfigApiKeyAuthMock = vi.fn((..._args: unknown[]) => false);
 const hasUsableCustomProviderApiKeyMock = vi.fn((..._args: unknown[]) => false);
 const resolveProviderEntryApiKeyProfileReferenceMock = vi.fn((_params?: unknown): unknown => ({
@@ -204,17 +218,30 @@ vi.mock("./harness/runtime-plugin.js", () => ({
     ensureSelectedAgentHarnessPluginMock(...args),
 }));
 
-vi.mock("./harness/host-capability.js", async () => {
-  const actual = await vi.importActual<typeof import("./harness/host-capability.js")>(
-    "./harness/host-capability.js",
-  );
+// Selection and host-capability owner suites execute the embedded runner and capability surface.
+// BTW only needs their identities while it verifies side-question orchestration.
+vi.mock("./harness/builtin-openclaw.js", () => ({
+  createOpenClawAgentHarness: (): AgentHarness => {
+    const harness: AgentHarness = {
+      id: "openclaw",
+      label: "OpenClaw embedded agent",
+      supports: () => ({ supported: true, priority: 0 }),
+      runAttempt: vi.fn(),
+    };
+    builtInOpenClawHarnesses.add(harness);
+    return harness;
+  },
+  isBuiltInOpenClawAgentHarness: (harness: AgentHarness) => builtInOpenClawHarnesses.has(harness),
+}));
+
+vi.mock("./harness/host-capability.js", () => {
   return {
-    ...actual,
-    createAgentHarnessHostCapabilities: (
-      params: Parameters<typeof actual.createAgentHarnessHostCapabilities>[0],
-    ) => {
+    createAgentHarnessHostCapabilities: (params: unknown) => {
       createAgentHarnessHostCapabilitiesMock(params);
-      return actual.createAgentHarnessHostCapabilities(params);
+      return {
+        capabilities: agentHarnessHostCapabilitiesMock,
+        close: closeAgentHarnessHostCapabilitiesMock,
+      };
     },
   };
 });
@@ -303,15 +330,11 @@ vi.mock("../logging/diagnostic.js", () => ({
   },
 }));
 
-vi.mock("../config/sessions/session-accessor.js", async () => {
-  const actual = await vi.importActual<typeof import("../config/sessions/session-accessor.js")>(
-    "../config/sessions/session-accessor.js",
-  );
-  return {
-    ...actual,
-    loadTranscriptEvents: (...args: unknown[]) => loadTranscriptEventsMock(...args),
-  };
-});
+vi.mock("../config/sessions/session-accessor.js", () => ({
+  listSessionEntriesCore: (...args: unknown[]) => listSessionEntriesCoreMock(...args),
+  loadSessionEntry: (...args: unknown[]) => loadSessionEntryMock(...args),
+  loadTranscriptEvents: (...args: unknown[]) => loadTranscriptEventsMock(...args),
+}));
 
 const { runBtwSideQuestion } = await import("./btw.js");
 const { clearAgentHarnesses, registerAgentHarness } = await import("./harness/registry.js");
@@ -673,6 +696,11 @@ describe("runBtwSideQuestion", () => {
     diagDebugMock.mockReset();
     ensureSelectedAgentHarnessPluginMock.mockReset();
     createAgentHarnessHostCapabilitiesMock.mockReset();
+    closeAgentHarnessHostCapabilitiesMock.mockReset();
+    listSessionEntriesCoreMock.mockReset();
+    listSessionEntriesCoreMock.mockReturnValue([]);
+    loadSessionEntryMock.mockReset();
+    loadSessionEntryMock.mockReturnValue(undefined);
     loadTranscriptEventsMock.mockReset();
     shouldPreferExplicitConfigApiKeyAuthMock.mockReset();
     shouldPreferExplicitConfigApiKeyAuthMock.mockReturnValue(false);
@@ -938,11 +966,21 @@ describe("runBtwSideQuestion", () => {
         }),
       }),
     );
+    expect(mockArg(codexSideQuestionMock, 0, 0)).toHaveProperty(
+      "hostCapabilities",
+      agentHarnessHostCapabilitiesMock,
+    );
     expect(createAgentHarnessHostCapabilitiesMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        attempt: expect.objectContaining({ runId: "btw-side-authority" }),
+        attempt: expect.objectContaining({
+          admittedRunContext: expect.objectContaining({
+            operationalRunInstance: expect.objectContaining({ runId: "btw-side-authority" }),
+          }),
+          runId: "btw-side-authority",
+        }),
       }),
     );
+    expect(closeAgentHarnessHostCapabilitiesMock).toHaveBeenCalledOnce();
     expect(resolveModelAsyncMock).toHaveBeenCalledWith(
       "openai",
       "gpt-5.5",
@@ -1246,7 +1284,7 @@ describe("runBtwSideQuestion", () => {
     );
   });
 
-  it("uses registry ownership rather than declared harness metadata for BTW approvals", async () => {
+  it("uses registry ownership and closes host capabilities when a BTW hook rejects", async () => {
     registerAgentHarness(
       {
         id: "spoofed",
@@ -1254,16 +1292,17 @@ describe("runBtwSideQuestion", () => {
         pluginId: "codex",
         supports: () => ({ supported: true, priority: 100 }),
         runAttempt: vi.fn(),
-        runSideQuestion: vi.fn().mockResolvedValue({ text: "Registry-owned answer." }),
+        runSideQuestion: vi.fn().mockRejectedValue(new Error("side question failed")),
       },
       { ownerPluginId: "actual-owner" },
     );
 
-    await expect(runSideQuestion()).resolves.toEqual({ text: "Registry-owned answer." });
+    await expect(runSideQuestion()).rejects.toThrow("side question failed");
 
     expect(createAgentHarnessHostCapabilitiesMock).toHaveBeenCalledWith(
       expect.objectContaining({ pluginId: "actual-owner" }),
     );
+    expect(closeAgentHarnessHostCapabilitiesMock).toHaveBeenCalledOnce();
   });
 
   it("reselects the Codex hook after resolving legacy openai-codex route state", async () => {
@@ -1401,34 +1440,6 @@ describe("runBtwSideQuestion", () => {
       messageProvider: "telegram",
       groupId: "deny-room",
       senderId: "restricted-sender",
-    });
-
-    expect(codexSideQuestionMock).toHaveBeenCalledOnce();
-    expect(mockArg(codexSideQuestionMock, 0, 0)).toMatchObject({ toolsAllow: [] });
-  });
-
-  it("prepares a narrow global policy before calling a plugin side-question hook", async () => {
-    const codexSideQuestionMock = registerCodexSideQuestionHarness();
-    mockOpenAIPlatformProfile();
-    resolveModelWithRegistryMock.mockReturnValue({
-      provider: "openai",
-      id: "gpt-5.5",
-      api: "openai-responses",
-    });
-    resolveModelAsyncMock.mockResolvedValue({
-      model: {
-        provider: "openai",
-        id: "gpt-5.5",
-        api: "openai-responses",
-        baseUrl: "https://api.openai.com/v1",
-      },
-    });
-
-    await runSideQuestion({
-      cfg: { tools: { allow: ["message"] } } as never,
-      provider: "openai",
-      model: "gpt-5.5",
-      sessionKey: DEFAULT_SESSION_KEY,
     });
 
     expect(codexSideQuestionMock).toHaveBeenCalledOnce();
@@ -2516,6 +2527,37 @@ describe("runBtwSideQuestion", () => {
     });
     expect(buildSessionContextMock).toHaveBeenCalledTimes(1);
     expect(buildSessionContextMock).toHaveBeenCalledWith([userEntry, assistantEntry]);
+  });
+
+  it("rejects a supplied session key that disagrees with an incomplete SQLite marker target", async () => {
+    const markerStorePath = "/tmp/marker-sessions.sqlite";
+    listSessionEntriesCoreMock.mockReturnValue([
+      {
+        sessionKey: "agent:main:matching",
+        entry: createSessionEntry(),
+      },
+    ]);
+    loadSessionEntryMock.mockReturnValue(createSessionEntry({ sessionId: "different-session" }));
+
+    await expect(
+      runMathSideQuestion({
+        sessionEntry: createSessionEntry({
+          sessionFile: `sqlite:main:session-1:${markerStorePath}`,
+        }),
+        storePath: undefined,
+      }),
+    ).rejects.toThrow("No active session context.");
+
+    expect(listSessionEntriesCoreMock).toHaveBeenCalledWith({
+      agentId: "main",
+      storePath: markerStorePath,
+    });
+    expect(loadSessionEntryMock).toHaveBeenCalledWith({
+      agentId: "main",
+      sessionKey: DEFAULT_SESSION_KEY,
+      storePath: markerStorePath,
+    });
+    expect(loadTranscriptEventsMock).not.toHaveBeenCalled();
   });
 
   it("falls back when the active run snapshot leaf no longer exists", async () => {


### PR DESCRIPTION
## What Problem This Solves

The focused BTW agent test suite spent most of its fresh-cache runtime loading the full embedded OpenClaw runner, host-capability owner, and session-accessor implementation even though its orchestration tests do not execute those owners. That made one test file take 46.92 seconds and about 1.12 GiB RSS locally.

## Why This Change Was Made

Use explicit lightweight fakes at those leaf boundaries while preserving the BTW-owned composition contracts:

- retain built-in harness identity versus forged metadata;
- verify the exact admitted host capability reaches the selected hook and closes on both success and rejection;
- keep all three session-accessor bindings and cover SQLite marker/session-key mismatch rejection;
- retain real owner coverage for embedded execution, capability internals, and accessor persistence;
- delete one duplicate narrow-global-policy process probe already table-driven by `harness/selection.test.ts`, while retaining the more discriminating channel sender deny-all handoff.

No production, workflow, shard, job, or worker-count changes.

## User Impact

No product behavior changes. CI spends less time and memory collecting the BTW suite, without adding workers.

## Evidence

Identical fresh-cache command before and after:

```bash
rm -rf /tmp/btw-round27-cache
/usr/bin/time -v env \
  PATH=/tmp/node-v24.15.0-linux-x64/bin:$PATH \
  OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/btw-round27-cache \
  OPENCLAW_VITEST_IMPORT_DURATIONS=1 \
  OPENCLAW_VITEST_PRINT_IMPORT_BREAKDOWN=1 \
  node scripts/run-vitest.mjs src/agents/btw.test.ts \
  --maxWorkers=1 --reporter=verbose
```

- Wall: **46.92s → 29.24s (37.7% faster)**
- Vitest: 40.13s → 22.51s (43.9% faster)
- Import: 26.78s → 9.61s (64.1% faster)
- RSS: 1,174,300 KiB → 779,196 KiB (33.6% lower)
- Focused suite: 56/56 passed
- Local changed gate: passed format, core test types, lint, dead exports, and guards. The configured remote router was unavailable before dispatch, so this used the documented `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1` local fallback.
- `git diff --check`: passed
- Structured autoreview preflight: TruffleHog clean; reviewer invocation unavailable because this orb has no `codex` executable.

Production/tooling LOC: +0/-0. Tests: +92/-50.

Codex contract check: sibling `../codex` exact source `codex-rs/app-server-protocol/src/protocol/v2/thread.rs` and `codex-rs/app-server/src/request_processors/thread_processor.rs` confirm `thread/fork` remains the ephemeral side-thread owner; no Codex or plugin implementation changed.
