### PR TITLE
fix(qa): prevent QA suites from migrating live state

### DIFF
--- a/extensions/qa-lab/src/auth-profile.fixture.ts
+++ b/extensions/qa-lab/src/auth-profile.fixture.ts
@@ -122,13 +122,17 @@ function normalizeAuthProfileSnapshot(value: unknown): QaAuthProfileSnapshot {
 
 export async function seedAuthProfiles(
   shape: QaAuthProfileShape,
-  agentDir: string,
+  params: { agentId: string; stateDir: string },
 ): Promise<QaAuthProfileSnapshot> {
   const snapshot = {
     version: QA_AUTH_PROFILE_STORE_VERSION,
     profiles: buildProfileMap(shape),
   };
-  await writeQaAuthProfiles({ agentDir, profiles: snapshot.profiles, replace: true });
+  await writeQaAuthProfiles({
+    ...params,
+    profiles: snapshot.profiles,
+    replace: true,
+  });
   return snapshot;
 }
 

--- a/extensions/qa-lab/src/codex-plugin-lifecycle.test.ts
+++ b/extensions/qa-lab/src/codex-plugin-lifecycle.test.ts
@@ -20,11 +20,12 @@ import { createTempDirHarness } from "./temp-dir.test-helper.js";
 
 const tempDirs = createTempDirHarness();
 
-async function createAgentDir(prefix: string) {
-  const root = await tempDirs.makeTempDir(prefix);
-  const agentDir = path.join(root, "agents", "qa", "agent");
+async function createAgentState(prefix: string) {
+  const stateDir = await tempDirs.makeTempDir(prefix);
+  const agentId = "qa";
+  const agentDir = path.join(stateDir, "agents", agentId, "agent");
   await fs.mkdir(agentDir, { recursive: true });
-  return agentDir;
+  return { agentDir, agentId, stateDir };
 }
 
 afterEach(async () => {
@@ -33,9 +34,9 @@ afterEach(async () => {
 
 describe("codex plugin lifecycle: cold install", () => {
   it("repairs a missing codex plugin before the retry succeeds without leaking to the API-key path", async () => {
-    const agentDir = await createAgentDir("qa-codex-plugin-cold-");
+    const { agentDir, agentId, stateDir } = await createAgentState("qa-codex-plugin-cold-");
     await removeCodexPluginFixture(agentDir);
-    await seedAuthProfiles("mixed", agentDir);
+    await seedAuthProfiles("mixed", { agentId, stateDir });
 
     const missing = evaluateCodexPluginLifecycle({
       plugin: await snapshotCodexPluginState(agentDir),
@@ -61,8 +62,8 @@ describe("codex plugin lifecycle: cold install", () => {
 
 describe("codex plugin lifecycle: OAuth-only with mixed profiles", () => {
   it("selects openai OAuth when openai API-key profiles are present", async () => {
-    const agentDir = await createAgentDir("qa-codex-auth-mixed-");
-    await seedAuthProfiles("mixed", agentDir);
+    const { agentDir, agentId, stateDir } = await createAgentState("qa-codex-auth-mixed-");
+    await seedAuthProfiles("mixed", { agentId, stateDir });
 
     const selection = resolveCodexAuthProfile(await snapshotAuthProfiles(agentDir));
 
@@ -104,9 +105,9 @@ describe("codex plugin lifecycle: doctor migration safety matrix", () => {
   ])(
     "keeps codex auth and strips stale OpenClaw runtime pins for $name",
     async ({ profileShape, config, expectedRemovedRuntimePins = [] }) => {
-      const agentDir = await createAgentDir("qa-codex-doctor-matrix-");
+      const { agentDir, agentId, stateDir } = await createAgentState("qa-codex-doctor-matrix-");
       await installCodexPluginFixture(agentDir);
-      await seedAuthProfiles(profileShape, agentDir);
+      await seedAuthProfiles(profileShape, { agentId, stateDir });
 
       const result = evaluateCodexPluginLifecycle({
         plugin: await snapshotCodexPluginState(agentDir),

--- a/extensions/qa-lab/src/providers/live-frontier/auth.ts
+++ b/extensions/qa-lab/src/providers/live-frontier/auth.ts
@@ -11,7 +11,7 @@ import {
   validateAnthropicSetupToken,
 } from "openclaw/plugin-sdk/provider-auth";
 import { normalizeStringEntries, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { resolveQaAgentAuthDir, writeQaAuthProfiles } from "../shared/auth-store.js";
+import { writeQaAuthProfiles } from "../shared/auth-store.js";
 
 export const QA_LIVE_ANTHROPIC_SETUP_TOKEN_ENV = "OPENCLAW_QA_LIVE_ANTHROPIC_SETUP_TOKEN";
 export const QA_LIVE_SETUP_TOKEN_VALUE_ENV = "OPENCLAW_LIVE_SETUP_TOKEN_VALUE";
@@ -197,7 +197,7 @@ export async function stageQaLiveAnthropicSetupToken(params: {
     return params.cfg;
   }
   await writeQaAuthProfiles({
-    agentDir: resolveQaAgentAuthDir({ stateDir: params.stateDir, agentId: "main" }),
+    agentId: "main",
     profiles: {
       [resolved.profileId]: {
         type: "token",
@@ -205,6 +205,7 @@ export async function stageQaLiveAnthropicSetupToken(params: {
         token: resolved.token,
       },
     },
+    stateDir: params.stateDir,
   });
   return applyAuthProfileConfig(params.cfg, {
     profileId: resolved.profileId,
@@ -260,8 +261,9 @@ export async function stageQaLiveApiKeyProfiles(params: {
   await Promise.all(
     agentIds.map((agentId) =>
       writeQaAuthProfiles({
-        agentDir: resolveQaAgentAuthDir({ stateDir: params.stateDir, agentId }),
+        agentId,
         profiles,
+        stateDir: params.stateDir,
       }),
     ),
   );

--- a/extensions/qa-lab/src/providers/shared/auth-store.test.ts
+++ b/extensions/qa-lab/src/providers/shared/auth-store.test.ts
@@ -1,26 +1,59 @@
 // Qa Lab tests cover the SQLite-backed auth store plugin behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import {
   loadAuthProfileStoreWithoutExternalProfiles,
   saveAuthProfileStore,
 } from "openclaw/plugin-sdk/agent-runtime";
-import { afterEach, describe, expect, it } from "vitest";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "openclaw/plugin-sdk/sqlite-runtime-testing";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTempDirHarness } from "../../temp-dir.test-helper.js";
 import { readQaAuthProfiles, writeQaAuthProfiles } from "./auth-store.js";
 
 const tempDirs = createTempDirHarness();
 
+async function createQaAuthState(prefix = "openclaw-qa-auth-store-") {
+  const stateDir = await tempDirs.makeTempDir(prefix);
+  const agentId = "main";
+  vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+  return {
+    agentDir: path.join(stateDir, "agents", agentId, "agent"),
+    agentId,
+    stateDir,
+  };
+}
+
 describe("QA auth profile store", () => {
   afterEach(async () => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    vi.unstubAllEnvs();
     await tempDirs.cleanup();
   });
 
-  it("writes new auth profiles to SQLite without creating legacy JSON", async () => {
-    const agentDir = await tempDirs.makeTempDir("openclaw-qa-auth-store-");
+  it("keeps inherited host shared state unchanged while staging isolated profiles", async () => {
+    const hostStateDir = await tempDirs.makeTempDir("openclaw-qa-auth-host-state-");
+    const qaStateDir = await tempDirs.makeTempDir("openclaw-qa-auth-isolated-state-");
+    const hostDatabase = openOpenClawStateDatabase({
+      env: { ...process.env, OPENCLAW_STATE_DIR: hostStateDir },
+    });
+    const hostDatabasePath = hostDatabase.path;
+    closeOpenClawStateDatabaseForTest();
+    const legacyHostDatabase = new DatabaseSync(hostDatabasePath);
+    legacyHostDatabase.exec(`
+      PRAGMA user_version = 6;
+      UPDATE schema_meta SET schema_version = 6 WHERE meta_key = 'primary';
+    `);
+    legacyHostDatabase.close();
+    vi.stubEnv("OPENCLAW_STATE_DIR", hostStateDir);
 
     await writeQaAuthProfiles({
-      agentDir,
+      agentId: "main",
       profiles: {
         "qa-mock-openai": {
           type: "api_key",
@@ -28,6 +61,41 @@ describe("QA auth profile store", () => {
           key: "qa-mock-not-a-real-key",
         },
       },
+      stateDir: qaStateDir,
+    });
+
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    const preservedHostDatabase = new DatabaseSync(hostDatabasePath, { readOnly: true });
+    expect(preservedHostDatabase.prepare("PRAGMA user_version").get()).toEqual({
+      user_version: 6,
+    });
+    expect(
+      preservedHostDatabase
+        .prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'")
+        .get(),
+    ).toEqual({ schema_version: 6 });
+    preservedHostDatabase.close();
+    vi.stubEnv("OPENCLAW_STATE_DIR", qaStateDir);
+    const qaAgentDir = path.join(qaStateDir, "agents", "main", "agent");
+    expect(readQaAuthProfiles(qaAgentDir).profiles).toMatchObject({
+      "qa-mock-openai": { provider: "openai" },
+    });
+  });
+
+  it("writes new auth profiles to SQLite without creating legacy JSON", async () => {
+    const { agentDir, agentId, stateDir } = await createQaAuthState();
+
+    await writeQaAuthProfiles({
+      agentId,
+      profiles: {
+        "qa-mock-openai": {
+          type: "api_key",
+          provider: "openai",
+          key: "qa-mock-not-a-real-key",
+        },
+      },
+      stateDir,
     });
 
     expect(readQaAuthProfiles(agentDir).profiles["qa-mock-openai"]).toMatchObject({
@@ -39,13 +107,14 @@ describe("QA auth profile store", () => {
   });
 
   it("refuses to bypass a pending legacy auth source", async () => {
-    const agentDir = await tempDirs.makeTempDir("openclaw-qa-auth-store-");
+    const { agentDir, agentId, stateDir } = await createQaAuthState();
     const authPath = path.join(agentDir, "auth-profiles.json");
+    await fs.mkdir(agentDir, { recursive: true });
     await fs.writeFile(authPath, "{not-json", "utf8");
 
     await expect(
       writeQaAuthProfiles({
-        agentDir,
+        agentId,
         profiles: {
           "qa-mock-openai": {
             type: "api_key",
@@ -53,15 +122,16 @@ describe("QA auth profile store", () => {
             key: "qa-mock-not-a-real-key",
           },
         },
+        stateDir,
       }),
     ).rejects.toThrow("requires legacy credential migration");
     await expect(fs.readFile(authPath, "utf8")).resolves.toBe("{not-json");
   });
 
   it("merges canonical API-key, token, and OAuth profile shapes", async () => {
-    const agentDir = await tempDirs.makeTempDir("openclaw-qa-auth-store-");
+    const { agentDir, agentId, stateDir } = await createQaAuthState();
     await writeQaAuthProfiles({
-      agentDir,
+      agentId,
       profiles: {
         existing: {
           type: "api_key",
@@ -81,10 +151,11 @@ describe("QA auth profile store", () => {
           expires: 1_900_000_000_000,
         },
       },
+      stateDir,
     });
 
     await writeQaAuthProfiles({
-      agentDir,
+      agentId,
       profiles: {
         "qa-mock-anthropic": {
           type: "api_key",
@@ -92,6 +163,7 @@ describe("QA auth profile store", () => {
           key: "qa-mock-not-a-real-key",
         },
       },
+      stateDir,
     });
 
     expect(readQaAuthProfiles(agentDir).profiles).toMatchObject({
@@ -103,7 +175,8 @@ describe("QA auth profile store", () => {
   });
 
   it("can replace an existing profile set for deterministic fixture seeding", async () => {
-    const agentDir = await tempDirs.makeTempDir("openclaw-qa-auth-store-");
+    const { agentDir, agentId, stateDir } = await createQaAuthState();
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
     saveAuthProfileStore(
       {
         version: 1,
@@ -119,11 +192,12 @@ describe("QA auth profile store", () => {
     );
 
     await writeQaAuthProfiles({
-      agentDir,
+      agentId,
       profiles: {
         current: { type: "api_key", provider: "anthropic", key: "qa-current-not-a-real-key" },
       },
       replace: true,
+      stateDir,
     });
 
     expect(Object.keys(readQaAuthProfiles(agentDir).profiles)).toEqual(["current"]);

--- a/extensions/qa-lab/src/providers/shared/auth-store.ts
+++ b/extensions/qa-lab/src/providers/shared/auth-store.ts
@@ -2,75 +2,49 @@
 import path from "node:path";
 import {
   loadAuthProfileStoreWithoutExternalProfiles,
-  saveAuthProfileStore,
-  type AuthProfileStore,
+  type AuthProfileCredential,
 } from "openclaw/plugin-sdk/agent-runtime";
+import { updateAuthProfileStoreWithLock } from "openclaw/plugin-sdk/provider-auth";
 
-type QaAuthProfileCredential =
-  | {
-      type: "api_key";
-      provider: string;
-      key?: string;
-      keyRef?: QaSecretRef;
-      displayName?: string;
-    }
-  | {
-      type: "token";
-      provider: string;
-      token?: string;
-      tokenRef?: QaSecretRef;
-      expires?: number;
-    }
-  | {
-      type: "oauth";
-      provider: string;
-      access?: string;
-      refresh?: string;
-      expires?: number;
-      idToken?: string;
-      clientId?: string;
-      enterpriseUrl?: string;
-      projectId?: string;
-      accountId?: string;
-      chatgptPlanType?: string;
-      oauthRef?: QaLegacyOAuthRef;
-    };
+type QaAuthProfileCredential = AuthProfileCredential;
 
-type QaSecretRef = {
-  source: "env" | "file" | "exec" | "store";
-  provider?: string;
-  id: string;
-};
-
-type QaLegacyOAuthRef = {
-  source: "openclaw-credentials";
-  provider: "openai";
-  id: string;
-};
-
-export function resolveQaAgentAuthDir(params: { stateDir: string; agentId: string }): string {
+function resolveQaAgentAuthDir(params: { stateDir: string; agentId: string }): string {
   return path.join(params.stateDir, "agents", params.agentId, "agent");
 }
 
 export async function writeQaAuthProfiles(params: {
-  agentDir: string;
+  agentId: string;
   profiles: Record<string, QaAuthProfileCredential>;
   replace?: boolean;
+  stateDir: string;
 }): Promise<void> {
-  const existing = loadAuthProfileStoreWithoutExternalProfiles(params.agentDir, {
-    inheritedAuthDir: params.agentDir,
+  const agentDir = resolveQaAgentAuthDir(params);
+  // Surface pending legacy-source errors before the locked updater, whose
+  // public failure contract is intentionally nullable.
+  loadAuthProfileStoreWithoutExternalProfiles(agentDir, { inheritedAuthDir: agentDir });
+  const updated = await updateAuthProfileStoreWithLock({
+    agentDir,
+    stateDir: params.stateDir,
+    saveOptions: {
+      filterExternalAuthProfiles: false,
+      syncExternalCli: false,
+    },
+    updater: (store) => {
+      store.version = 1;
+      store.profiles = params.replace
+        ? { ...params.profiles }
+        : { ...store.profiles, ...params.profiles };
+      if (params.replace) {
+        delete store.order;
+        delete store.lastGood;
+        delete store.usageStats;
+      }
+      return true;
+    },
   });
-  const nextStore: AuthProfileStore = params.replace
-    ? { version: 1, profiles: params.profiles as AuthProfileStore["profiles"] }
-    : {
-        ...existing,
-        version: 1,
-        profiles: { ...existing.profiles, ...params.profiles } as AuthProfileStore["profiles"],
-      };
-  saveAuthProfileStore(nextStore, params.agentDir, {
-    filterExternalAuthProfiles: false,
-    syncExternalCli: false,
-  });
+  if (!updated) {
+    throw new Error("Failed to stage the isolated QA auth profile store.");
+  }
 }
 
 export function readQaAuthProfiles(agentDir: string): {

--- a/extensions/qa-lab/src/providers/shared/mock-auth.ts
+++ b/extensions/qa-lab/src/providers/shared/mock-auth.ts
@@ -2,7 +2,7 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { applyAuthProfileConfig } from "openclaw/plugin-sdk/provider-auth-api-key";
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { resolveQaAgentAuthDir, writeQaAuthProfiles } from "./auth-store.js";
+import { writeQaAuthProfiles } from "./auth-store.js";
 
 /** Providers the mock harness stages placeholder credentials for by default. */
 const QA_MOCK_AUTH_PROVIDERS = Object.freeze(["openai", "anthropic"] as const);
@@ -44,7 +44,7 @@ export async function stageQaMockAuthProfiles(params: {
   let next = params.cfg;
   for (const agentId of agentIds) {
     await writeQaAuthProfiles({
-      agentDir: resolveQaAgentAuthDir({ stateDir: params.stateDir, agentId }),
+      agentId,
       profiles: Object.fromEntries(
         providers.map((provider) => [
           buildQaMockProfileId(provider),
@@ -56,6 +56,7 @@ export async function stageQaMockAuthProfiles(params: {
           },
         ]),
       ),
+      stateDir: params.stateDir,
     });
   }
   for (const provider of providers) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where running an isolated QA suite could migrate the operator's live shared state database when the QA binary supported a newer schema than the running Gateway. The older Gateway would then reject the migrated database, causing agent and heartbeat failures.

## Why This Change Was Made

QA auth staging now carries the isolated state directory and agent identity into the canonical locked auth-store update. Mock and live-provider staging therefore create and lease only the QA agent database and its matching QA shared state.

The change deliberately does not add a general mixed-version deployment fence. Supported deployment sequencing remains responsible for stopping an older Gateway before updating shared state.

## User Impact

Maintainers can run QA Lab host and live-channel scenarios alongside a running OpenClaw instance without QA auth setup migrating that instance's shared database.

## Evidence

- Regression proof: before the fix, staging an isolated auth profile changed an inherited host sentinel from schema 6 to schema 7; after the fix, both `PRAGMA user_version` and `schema_meta` remain at 6 while the QA agent receives its profile.
- Focused extension suite: 98/98 tests passed across the auth-store, Gateway child, and Codex lifecycle suites.
- Exact Docker-backed Matrix scenario passed on Blacksmith Testbox: [`matrix-streaming-replacement-retention`](https://github.com/openclaw/openclaw/actions/runs/31661358325).
- Scoped `check:changed` passed on Blacksmith Testbox: [run 31662806828](https://github.com/openclaw/openclaw/actions/runs/31662806828).
- Codex autoreview reported no accepted/actionable findings.
- Rebased onto current `origin/main`; the intervening commits did not touch QA auth staging or state ownership. The rebased commit has the same stable patch ID as the tested commit.

Production LOC: +40/-63 (net -23) | Tests/test support: +101/-22 (net +79)
