### PR TITLE
fix: manual onboarding honors explicit gateway settings

### DIFF
--- a/src/wizard/setup.gateway-config.test.ts
+++ b/src/wizard/setup.gateway-config.test.ts
@@ -41,7 +41,8 @@ describe("configureGatewayForSetup", () => {
     return buildWizardPrompter({
       select,
       text: vi.fn(async (paramsLocal) => {
-        const value = textQueue.shift() as string;
+        const hasQueuedValue = textQueue.length > 0;
+        const value = hasQueuedValue ? textQueue.shift() : paramsLocal.initialValue;
         const error = typeof value === "string" ? paramsLocal.validate?.(value) : undefined;
         if (error) {
           throw new Error(error);
@@ -104,6 +105,56 @@ describe("configureGatewayForSetup", () => {
 
     expect(result.settings.gatewayToken).toBe("generated-token");
     expect(result.nextConfig.gateway?.nodes?.commands).toBeUndefined();
+  });
+
+  it("seeds advanced gateway prompts from explicit classic options", async () => {
+    const gatewayDefaults = resolveQuickstartGatewayDefaults(
+      {},
+      {
+        gatewayPort: 19511,
+        gatewayBind: "lan",
+        gatewayAuth: "password",
+        gatewayPassword: "manual-gateway-password-placeholder",
+        tailscale: "off",
+      },
+    );
+    const select = vi.fn(async (params: WizardSelectParams<unknown>) => {
+      return params.initialValue ?? params.options[0]?.value;
+    }) as unknown as WizardPrompter["select"];
+    const text = vi.fn(async (params: { initialValue?: string }) => params.initialValue ?? "");
+    const confirm = vi.fn(
+      async (params: { initialValue?: boolean }) => params.initialValue ?? false,
+    );
+    const prompter = buildWizardPrompter({ select, text, confirm });
+
+    const result = await configureGatewayForSetup({
+      flow: "advanced",
+      baseConfig: {},
+      nextConfig: {},
+      localPort: gatewayDefaults.port,
+      quickstartGateway: gatewayDefaults,
+      prompter,
+      runtime: createRuntime(),
+    });
+
+    expect(text).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Gateway port", initialValue: "19511" }),
+    );
+    expect(select).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Gateway bind address", initialValue: "lan" }),
+    );
+    expect(select).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Gateway access protection", initialValue: "password" }),
+    );
+    expect(select).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Tailscale exposure", initialValue: "off" }),
+    );
+    expect(result.nextConfig.gateway).toMatchObject({
+      port: 19511,
+      bind: "lan",
+      auth: { mode: "password", password: "manual-gateway-password-placeholder" },
+      tailscale: { mode: "off" },
+    });
   });
 
   it.each(["1e3", "0x1000"])("rejects loose gateway port input: %s", async (port) => {
@@ -352,6 +403,42 @@ describe("configureGatewayForSetup", () => {
         nextConfig: {},
         localPort: 18789,
         quickstartGateway,
+        prompter: createPrompter({ selectQueue: [], textQueue: [] }),
+        runtime: createRuntime(),
+      });
+
+      expect(result.nextConfig.gateway?.auth).toEqual({
+        mode: "token",
+        token: {
+          source: "env",
+          provider: "default",
+          id: "OPENCLAW_GATEWAY_TOKEN",
+        },
+      });
+      expect(result.settings.gatewayToken).toBe("token-from-env-ref");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_TOKEN;
+      } else {
+        process.env.OPENCLAW_GATEWAY_TOKEN = previous;
+      }
+    }
+  });
+
+  it("seeds an explicit env token ref into advanced gateway setup", async () => {
+    const previous = process.env.OPENCLAW_GATEWAY_TOKEN;
+    process.env.OPENCLAW_GATEWAY_TOKEN = "token-from-env-ref";
+    try {
+      const gatewayDefaults = resolveQuickstartGatewayDefaults(
+        {},
+        { gatewayPort: 19511, gatewayTokenRefEnv: "OPENCLAW_GATEWAY_TOKEN" },
+      );
+      const result = await configureGatewayForSetup({
+        flow: "advanced",
+        baseConfig: {},
+        nextConfig: {},
+        localPort: gatewayDefaults.port,
+        quickstartGateway: gatewayDefaults,
         prompter: createPrompter({ selectQueue: [], textQueue: [] }),
         runtime: createRuntime(),
       });

--- a/src/wizard/setup.gateway-config.ts
+++ b/src/wizard/setup.gateway-config.ts
@@ -120,6 +120,7 @@ export async function configureGatewayForSetup(
               hint: t("wizard.gateway.bindCustomHint"),
             },
           ],
+          initialValue: quickstartGateway.bind,
         });
 
   let customBindHost = quickstartGateway.customBindHost;
@@ -149,7 +150,7 @@ export async function configureGatewayForSetup(
             },
             { value: "password", label: t("common.password") },
           ],
-          initialValue: "token",
+          initialValue: quickstartGateway.authMode,
         })) as GatewayAuthChoice);
 
   const tailscaleMode: GatewayWizardSettings["tailscaleMode"] =
@@ -158,6 +159,7 @@ export async function configureGatewayForSetup(
       : await prompter.select<GatewayWizardSettings["tailscaleMode"]>({
           message: t("wizard.gateway.tailscaleExposure"),
           options: getLocalizedTailscaleExposureOptions(),
+          initialValue: quickstartGateway.tailscaleMode,
         });
 
   // Detect Tailscale binary before proceeding with serve/funnel setup.
@@ -173,12 +175,12 @@ export async function configureGatewayForSetup(
     }
   }
 
-  let tailscaleResetOnExit = flow === "quickstart" ? quickstartGateway.tailscaleResetOnExit : false;
+  let tailscaleResetOnExit = quickstartGateway.tailscaleResetOnExit;
   if (tailscaleMode !== "off" && flow !== "quickstart") {
     await prompter.note(t("wizard.gatewayTailscale.docsNote"), "Tailscale");
     tailscaleResetOnExit = await prompter.confirm({
       message: t("wizard.gateway.tailscaleReset"),
-      initialValue: false,
+      initialValue: tailscaleResetOnExit,
     });
   }
 
@@ -207,11 +209,10 @@ export async function configureGatewayForSetup(
       value: quickstartGateway.token,
       defaults: nextConfig.secrets?.defaults,
     }).ref;
-    const tokenMode =
-      flow === "quickstart" && opts.secretInputMode !== "ref" // pragma: allowlist secret
-        ? quickstartTokenRef
-          ? "ref"
-          : "plaintext"
+    const tokenMode = quickstartTokenRef
+      ? "ref"
+      : flow === "quickstart" && opts.secretInputMode !== "ref" // pragma: allowlist secret
+        ? "plaintext"
         : await resolveSecretInputModeForEnvSelection({
             prompter,
             explicitMode: opts.secretInputMode,
@@ -224,7 +225,7 @@ export async function configureGatewayForSetup(
             },
           });
     if (tokenMode === "ref") {
-      if (flow === "quickstart" && quickstartTokenRef) {
+      if (quickstartTokenRef) {
         gatewayTokenInput = quickstartTokenRef;
         gatewayToken = await resolveSetupSecretInputString({
           config: nextConfig,
@@ -280,8 +281,13 @@ export async function configureGatewayForSetup(
   }
 
   if (authMode === "password") {
+    const existingPassword = normalizeSecretInputString(quickstartGateway.password);
+    const existingPasswordRef = resolveSecretInputRef({
+      value: quickstartGateway.password,
+      defaults: nextConfig.secrets?.defaults,
+    }).ref;
     let password: SecretInput | undefined =
-      flow === "quickstart" && quickstartGateway.password ? quickstartGateway.password : undefined;
+      flow === "quickstart" ? quickstartGateway.password : (existingPasswordRef ?? undefined);
     if (!password) {
       const selectedMode = await resolveSecretInputModeForEnvSelection({
         prompter,
@@ -305,13 +311,25 @@ export async function configureGatewayForSetup(
         });
         password = resolved.ref;
       } else {
-        password = normalizeWizardTextInput(
-          await prompter.text({
-            message: t("wizard.gateway.passwordPrompt"),
-            validate: validateGatewayPasswordInput,
-            sensitive: true,
-          }),
-        );
+        let passwordInput: string | undefined;
+        if (existingPassword) {
+          const keep = await prompter.confirm({
+            message: t("wizard.gateway.existingPasswordConfirm", {
+              password: maskApiKey(existingPassword),
+            }),
+            initialValue: true,
+          });
+          passwordInput = keep ? existingPassword : undefined;
+        }
+        password =
+          passwordInput ??
+          normalizeWizardTextInput(
+            await prompter.text({
+              message: t("wizard.gateway.passwordPrompt"),
+              validate: validateGatewayPasswordInput,
+              sensitive: true,
+            }),
+          );
       }
     }
     nextConfig = {

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -2544,6 +2544,78 @@ describe("runSetupWizard", () => {
     );
   });
 
+  it.each([
+    {
+      label: "explicit CLI gateway values",
+      gatewayOptions: {
+        gatewayPort: 19511,
+        gatewayBind: "lan" as const,
+        gatewayAuth: "password" as const,
+        gatewayToken: "manual-gateway-token-placeholder",
+        gatewayPassword: "manual-gateway-password-placeholder",
+        tailscale: "off" as const,
+        tailscaleResetOnExit: false,
+      },
+      expectedPort: 19511,
+      expectedProbeAuth: {
+        token: "manual-gateway-token-placeholder",
+        password: "manual-gateway-password-placeholder",
+      },
+    },
+    {
+      label: "derived port when gateway values are omitted",
+      gatewayOptions: {},
+      expectedPort: 18789,
+      expectedProbeAuth: {},
+    },
+  ])(
+    "uses the $label for the manual probe and port prompt",
+    async ({ gatewayOptions, expectedPort, expectedProbeAuth }) => {
+      const prompter = buildWizardPrompter({});
+      const runtime = createRuntime();
+
+      await runSetupWizard(
+        {
+          acceptRisk: true,
+          flow: "advanced",
+          mode: "local",
+          authChoice: "skip",
+          ...gatewayOptions,
+          installDaemon: false,
+          skipChannels: true,
+          skipSkills: true,
+          skipSearch: true,
+          skipHealth: true,
+          skipUi: true,
+        },
+        runtime,
+        prompter,
+      );
+
+      expectRecordFields(
+        getMockCallArg(probeGatewayReachable, 0, 0, "gateway probe"),
+        { url: `ws://127.0.0.1:${expectedPort}`, ...expectedProbeAuth },
+        "gateway probe params",
+      );
+      const gatewaySetup = expectRecordFields(
+        getMockCallArg(configureGatewayForSetup, 0, 0, "gateway setup"),
+        { localPort: expectedPort },
+        "gateway setup params",
+      );
+      if (gatewayOptions.gatewayPort !== undefined) {
+        expect(gatewaySetup.quickstartGateway).toMatchObject({
+          port: 19511,
+          bind: "lan",
+          authMode: "password",
+          token: "manual-gateway-token-placeholder",
+          password: "manual-gateway-password-placeholder",
+          tailscaleMode: "off",
+          tailscaleResetOnExit: false,
+        });
+      }
+    },
+  );
+
   it("passes secretInputMode through to local gateway config step", async () => {
     configureGatewayForSetup.mockClear();
     const prompter = buildWizardPrompter({});

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -4,7 +4,7 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { resolveOnboardingAgentTarget } from "../commands/onboard-agent-target.js";
 import type { GatewayAuthChoice, OnboardMode, OnboardOptions } from "../commands/onboard-types.js";
 import { hasResolvedRosterBeforeMigrations } from "../config/agent-roster-provenance.js";
-import { ConfigMutationConflictError, resolveGatewayPort } from "../config/config.js";
+import { ConfigMutationConflictError } from "../config/config.js";
 import { createMergePatch } from "../config/merge-patch.js";
 import { applyMergePatch } from "../config/merge-patch.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
@@ -289,7 +289,7 @@ async function runSetupWizardOnce(
 
   const quickstartGateway: QuickstartGatewayDefaults = resolveQuickstartGatewayDefaults(
     baseConfig,
-    wizardFlow === "quickstart" ? opts : undefined,
+    opts,
   );
 
   if (flow === "quickstart") {
@@ -341,13 +341,13 @@ async function runSetupWizardOnce(
     await prompter.note(quickstartLines.join("\n"), "QuickStart");
   }
 
-  const localPort = resolveGatewayPort(baseConfig);
+  const localPort = quickstartGateway.port;
   const localUrl = `ws://127.0.0.1:${localPort}`;
   let localGatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN;
   try {
     const resolvedGatewayToken = await resolveSetupSecretInputString({
       config: baseConfig,
-      value: baseConfig.gateway?.auth?.token,
+      value: quickstartGateway.token,
       path: "gateway.auth.token",
       env: process.env,
     });
@@ -367,7 +367,7 @@ async function runSetupWizardOnce(
   try {
     const resolvedGatewayPassword = await resolveSetupSecretInputString({
       config: baseConfig,
-      value: baseConfig.gateway?.auth?.password,
+      value: quickstartGateway.password,
       path: "gateway.auth.password",
       env: process.env,
     });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using classic manual onboarding with explicit local Gateway flags would see and accept stored/profile-derived defaults instead. In the reported `st1` reproduction, `--gateway-port 19501` still probed and prompted with the profile-derived port `21929`.

AI-assisted: yes.

## Why This Change Was Made

Manual setup now resolves stored/default Gateway values and CLI overrides through the same shared defaults seam already used by QuickStart. That one resolved object drives the local detection probe and seeds the existing advanced prompts, so operators can still edit every value before persistence.

The sibling audit covered every parsed local Gateway override: `--gateway-port`, `--gateway-bind`, `--gateway-auth`, `--gateway-token`, `--gateway-token-ref-env`, `--gateway-password`, `--tailscale`, and `--[no-]tailscale-reset-on-exit`. All shared the dropped-override boundary and now seed manual setup coherently. Remote URL/token options already use the separate remote seed path; `--secret-input-mode` was already consumed directly.

## User Impact

An explicit Gateway port is now the address manual onboarding probes and the default shown at the port prompt. Bind, auth/credentials, Tailscale mode, and reset-on-exit flags likewise become editable prompt defaults instead of being ignored. With no flags, the existing stored/profile-derived defaults remain unchanged.

## Evidence

Before:

```text
Local gateway (this machine) (No gateway detected (ws://127.0.0.1:21929))
Gateway port: 21929
```

The new regression was also run against pre-fix production code and failed for the intended reason:

```text
expected ws://127.0.0.1:19511
received ws://127.0.0.1:18789
```

After, from an exact-current Testbox build with isolated temporary HOME, scratch profile `mp1`, and `--gateway-port 19511`:

```text
Local gateway (this machine) (No gateway detected (ws://127.0.0.1:19511))
Gateway port: 19511
```

The wizard was timeout-aborted at the port prompt, before config persistence or daemon installation; the entire scratch HOME was removed. The build completed successfully. The wrapper itself returned nonzero because its post-timeout grep could not match Clack's character-by-character ANSI redraw, although both lines were visible in the captured terminal output.

Validation:

- `node scripts/run-vitest.mjs src/wizard/setup.test.ts src/wizard/setup.gateway-config.test.ts src/wizard/setup.shared.test.ts` — 76 passed on the rebased head
- `node scripts/check-changed.mjs` — passed on Testbox `tbx_01kzwgf7ymwc0zgedgf54wrrg8` ([run](https://github.com/openclaw/openclaw/actions/runs/31662071219))
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings
- Production LOC: +40/-22 (net +18); tests: +160/-1
