### PR TITLE
fix(openai): return structured failure for malformed OAuth token JSON

### DIFF
--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
@@ -356,6 +356,30 @@ describe("OpenAI Codex OAuth flow", () => {
     });
   });
 
+  it.each([
+    {
+      operation: "exchange" as const,
+      run: () =>
+        exchangeOpenAIAuthorizationCode("code", "verifier", resolveOpenAIRedirectUri("localhost")),
+    },
+    {
+      operation: "refresh" as const,
+      run: () => refreshOpenAIAccessToken("old-refresh-token"),
+    },
+  ])(
+    "returns a failed result when the token $operation response is malformed JSON",
+    async ({ operation, run }) => {
+      mockTokenResponseText('{"access_token":"access-token","refresh_to');
+
+      const result = await run();
+
+      expect(result).toEqual({
+        type: "failed",
+        message: `OpenAI Codex token ${operation} failed: response is not valid JSON`,
+      });
+    },
+  );
+
   it("times out token refresh requests", async () => {
     ssrfMocks.fetchWithSsrFGuard.mockRejectedValueOnce(timeoutError());
 

--- a/extensions/openai/openai-chatgpt-oauth-token.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth-token.runtime.ts
@@ -112,7 +112,15 @@ async function readOpenAITokenResponse(
       message: `OpenAI Codex token ${operation} failed (${response.status}): ${text || response.statusText}`,
     };
   }
-  const json = (await response.json()) as TokenResponseJson;
+  let json: TokenResponseJson;
+  try {
+    json = (await response.json()) as TokenResponseJson;
+  } catch {
+    return {
+      type: "failed",
+      message: `OpenAI Codex token ${operation} failed: response is not valid JSON`,
+    };
+  }
   if (!isRecord(json)) {
     return {
       type: "failed",


### PR DESCRIPTION
## Summary

fix(openai): return a structured failure instead of a raw `SyntaxError` when the ChatGPT OAuth token endpoint returns malformed JSON

## What Problem This Solves

During OpenAI Codex (ChatGPT) OAuth login, the CLI exchanges the authorization code at `https://auth.openai.com/oauth/token`. If that response body is truncated or otherwise not valid JSON — a proxy that interferes with the response, a captive portal, a partially read body — `response.json()` throws a raw `SyntaxError`.

**代码证据**: in `extensions/openai/openai-chatgpt-oauth-token.runtime.ts`:

- `exchangeOpenAIAuthorizationCode` calls `readOpenAITokenResponse(response, "exchange")` **outside** its `try/catch` (line 162); the `try` only covers `postTokenForm`.
- Inside `readOpenAITokenResponse` (line 115), `await response.json()` is unguarded.
- `refreshOpenAIAccessToken` wraps the exact same call in `try/catch` (line 179), so identical truncated input crashes the exchange path but is handled gracefully on the refresh path — proof that the escape on the exchange path is unintended.

User symptom: login aborts with an unhandled `SyntaxError: Unterminated string in JSON at position ...` instead of a readable "token exchange failed" error.

Trigger condition: any 2xx token response whose body is not parseable JSON. This is an edge case, but it hits exactly the users on flaky/proxied networks who most need a clear error.

## Root Cause

- Violated invariant: `readOpenAITokenResponse` can throw (from `response.json()`), but `exchangeOpenAIAuthorizationCode` is written as if it only ever returns a `TokenResult`.
- The unguarded `response.json()` on the exchange path exists since this file was created in commit `e7cba0e4d5d` (2026-07-15, #108592). Commit `3ec8af66d1e` (2026-08-05, #119628) factored the parsing into the shared `readOpenAITokenResponse` helper and kept the exchange call site outside the `try`. Commit `1802d85f3c` (2026-08-08, #120685) added envelope validation (null/array responses) but only covers JSON that parses successfully — the parse-throw case remained unhandled.

## Why This Fix

- Option A: wrap the `readOpenAITokenResponse` call in `exchangeOpenAIAuthorizationCode` with `try/catch`, mirroring the refresh path. Works, but keeps the fragile invariant — every future caller of the helper must remember it can throw.
- Option B (chosen): catch the parse failure inside `readOpenAITokenResponse` and return a `TokenFailure`. This fixes the throw at its source, both entry points benefit, and the helper becomes total: after the change it returns a structured result for non-OK status, malformed JSON, non-object envelopes, and missing fields alike.
- Not chosen: catching the error in the login UI layer — too far from the source and duplicates handling per caller.

## User Impact

- Affected scenarios: OpenAI Codex OAuth login (`exchangeOpenAIAuthorizationCode`) and token refresh behind proxies or flaky networks that truncate the JSON body.
- Before: a raw `SyntaxError` escapes `exchangeOpenAIAuthorizationCode` and crashes the login flow with an unreadable stack.
- After: login fails cleanly with `OpenAI Codex token exchange failed: response is not valid JSON`.
- Behavior change: the exchange path now reports a structured failure instead of throwing; well-formed responses are unaffected.

## Evidence

Real-transport fault injection, no stub of the code under test: the proof runs the production `openai-chatgpt-oauth-token.runtime.ts` end to end — the real `fetchWithSsrFGuard`, a real TCP+TLS connection, and a real local HTTPS server that answers the token POST with a truncated 200 JSON body (`{"access_token":"x","refresh_to`). Transport plumbing only (none of it touches the module under test): `dns.promises.lookup` maps `auth.openai.com` to `198.18.0.1` (the RFC 2544 benchmark range the module's own SSRF policy explicitly allows), `tls.connect` redirects that dial to the loopback server, and the server presents a self-signed cert. The server log confirms the real request arrives with `host=auth.openai.com`.

### Before (on main)

```bash
$ NODE_TLS_REJECT_UNAUTHORIZED=0 node node_modules/tsx/dist/cli.mjs proof-oauth-token-real-transport.mjs
[proof] server got POST /oauth/token host=auth.openai.com
[proof] FAIL exchange THREW: SyntaxError: Unterminated string in JSON at position 31 (line 1 column 32)
[proof] server got POST /oauth/token host=auth.openai.com
[proof] refresh result: {"type":"failed","message":"OpenAI Codex token refresh error: Unterminated string in JSON at position 31 (line 1 column 32)"}
[proof] RESULT: FAIL - 2 problem(s)
```

The exchange path lets the raw `SyntaxError` escape over a real TLS transport; the refresh path leaks the parser's raw message.

### After (with fix)

```bash
$ NODE_TLS_REJECT_UNAUTHORIZED=0 node node_modules/tsx/dist/cli.mjs proof-oauth-token-real-transport.mjs
[proof] server got POST /oauth/token host=auth.openai.com
[proof] exchange result: {"type":"failed","message":"OpenAI Codex token exchange failed: response is not valid JSON"}
[proof] OK exchange: structured failure, no exception
[proof] server got POST /oauth/token host=auth.openai.com
[proof] refresh result: {"type":"failed","message":"OpenAI Codex token refresh failed: response is not valid JSON"}
[proof] OK refresh: structured failure, no exception
[proof] RESULT: PASS - truncated token JSON over real TLS yields structured failures
```

**What was not tested:** a live exchange against the real `auth.openai.com` (requires a real ChatGPT authorization code); the truncated-body failure is delivered over a real TLS transport instead.

## Tests and Validation

- `npx vitest run extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts` — 21/21 passed, including 2 new regression cases: malformed JSON token response for both exchange and refresh now return `OpenAI Codex token <operation> failed: response is not valid JSON`.
- `npx oxlint --deny=warn` on both changed files — 0 warnings, 0 errors.
- Before/after real-behavior proof logs are embedded above.

## Regression Test Plan

- Coverage level: unit test on the real module with the SSRF guard mocked at the network boundary (existing pattern in this test file).
- Target test file: `extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts`
- Scenario locked in: a 200 token response with truncated JSON (`{"access_token":"access-token","refresh_to`) yields a structured `failed` result — never a thrown `SyntaxError` — for both `exchangeOpenAIAuthorizationCode` and `refreshOpenAIAccessToken`.
- Why this is the smallest reliable guardrail: it exercises the exact production entry points and the exact malformed input that previously crashed login.
