### PR TITLE
fix(onboard): imports work after runtime state initialization

### DIFF
--- a/src/wizard/setup.migration-import.test.ts
+++ b/src/wizard/setup.migration-import.test.ts
@@ -42,6 +42,21 @@ describe("setup migration import freshness", () => {
     expect(result).toEqual({ fresh: true, reasons: [] });
   });
 
+  it("allows runtime-only state scaffolding before import", async () => {
+    const root = tempRoots.make("openclaw-setup-migration-");
+    const stateDir = path.join(root, "state");
+    await writeFile(path.join(stateDir, "state", "openclaw.sqlite"), "runtime database\n");
+    await writeFile(path.join(stateDir, "tmp", "startup"), "runtime scratch\n");
+
+    const result = await inspectSetupMigrationFreshness({
+      baseConfig: {},
+      stateDir,
+      workspaceDir: path.join(root, "workspace"),
+    });
+
+    expect(result).toEqual({ fresh: true, reasons: [] });
+  });
+
   it("preserves the first-launch acknowledgement across the lock-time config reread", () => {
     expect(
       preserveSetupMigrationSecurityAcknowledgement(
@@ -68,11 +83,13 @@ describe("setup migration import freshness", () => {
     expect(result.reasons).toEqual(["existing config values are loaded"]);
   });
 
-  it("rejects existing config, workspace files, and state", async () => {
+  it("rejects existing config, workspace files, credentials, sessions, and agents", async () => {
     const root = tempRoots.make("openclaw-setup-migration-");
     const stateDir = path.join(root, "state");
     const workspaceDir = path.join(root, "workspace");
     await writeFile(path.join(workspaceDir, "MEMORY.md"), "existing memory\n");
+    await writeFile(path.join(stateDir, "credentials", "provider.json"), "{}\n");
+    await writeFile(path.join(stateDir, "sessions", "session.json"), "{}\n");
     await writeFile(path.join(stateDir, "agents", "main", "agent", "auth-profiles.json"), "{}\n");
 
     const result = await inspectSetupMigrationFreshness({
@@ -85,6 +102,8 @@ describe("setup migration import freshness", () => {
     expect(result.reasons).toEqual([
       "existing config values are loaded",
       "workspace MEMORY.md exists",
+      "state credentials/ exists",
+      "state sessions/ exists",
       "state agents/ exists",
     ]);
     expect(() => assertFreshSetupMigrationTarget(result)).toThrow(

--- a/src/wizard/setup.migration-snapshot.ts
+++ b/src/wizard/setup.migration-snapshot.ts
@@ -27,7 +27,8 @@ const MEANINGFUL_WORKSPACE_ENTRIES = [
   "MEMORY.md",
   "skills",
 ] as const;
-const MEANINGFUL_STATE_ENTRIES = ["credentials", "sessions", "agents", "state"] as const;
+const IMPORT_BLOCKING_STATE_ENTRIES = ["credentials", "sessions", "agents"] as const;
+const MIGRATION_TARGET_STATE_ENTRIES = [...IMPORT_BLOCKING_STATE_ENTRIES, "state"] as const;
 
 async function exists(candidate: string): Promise<boolean> {
   try {
@@ -107,7 +108,7 @@ export async function inspectSetupMigrationFreshness(params: {
   ) {
     reasons.push("workspace directory is not empty");
   }
-  for (const entry of MEANINGFUL_STATE_ENTRIES) {
+  for (const entry of IMPORT_BLOCKING_STATE_ENTRIES) {
     if (await hasDirectoryEntries(path.join(params.stateDir, entry))) {
       reasons.push(`state ${entry}/ exists`);
     }
@@ -234,7 +235,7 @@ export async function buildSetupMigrationTargetSnapshot(params: {
   const targetConfig = buildSetupMigrationSnapshotConfig(params.config);
   hash.update(`config:${JSON.stringify(canonicalizeSetupMigrationValue(targetConfig))}\0`);
   await hashTargetPath(hash, params.workspaceDir, "workspace");
-  for (const entry of MEANINGFUL_STATE_ENTRIES) {
+  for (const entry of MIGRATION_TARGET_STATE_ENTRIES) {
     await hashTargetPath(hash, path.join(params.stateDir, entry), `state/${entry}`);
   }
   return hash.digest("hex");
@@ -338,7 +339,7 @@ export function assertFreshSetupMigrationTarget(freshness: {
   if (freshness.fresh) {
     return;
   }
-  throw new Error(
+  throw new SetupMigrationFreshnessError(
     [
       "Migration import during onboarding requires a fresh OpenClaw setup.",
       "Create a fresh setup or reset config, credentials, sessions, and workspace before importing.",
@@ -348,3 +349,5 @@ export function assertFreshSetupMigrationTarget(freshness: {
     ].join("\n"),
   );
 }
+
+export class SetupMigrationFreshnessError extends Error {}

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -19,6 +19,7 @@ import type { ProviderAuthResult } from "../plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { WizardCancelledError, type WizardPrompter, type WizardSelectParams } from "./prompts.js";
 import { runSetupWizard } from "./setup.js";
+import { SetupMigrationFreshnessError } from "./setup.migration-snapshot.js";
 
 type ResolveProviderPluginChoice =
   typeof import("../plugins/provider-auth-choice.runtime.js").resolveProviderPluginChoice;
@@ -34,6 +35,8 @@ type PrepareAuthChoice = typeof import("../commands/auth-choice.js").prepareAuth
 type VerifySetupInferenceConfig =
   typeof import("../system-agent/setup-inference.js").verifySetupInferenceConfig;
 type ConfigureGatewayForSetup = typeof import("./setup.gateway-config.js").configureGatewayForSetup;
+type ListSetupMigrationOptions =
+  typeof import("./setup.migration-import.js").listSetupMigrationOptions;
 type RunSetupMigrationImport = typeof import("./setup.migration-import.js").runSetupMigrationImport;
 type RunSearchSetupFlow = typeof import("../flows/search-setup.js").runSearchSetupFlow;
 
@@ -129,7 +132,9 @@ const enableDefaultOnboardingInternalHooks = vi.hoisted(() =>
   })),
 );
 const detectSetupMigrationSources = vi.hoisted(() => vi.fn(async () => []));
-const listSetupMigrationOptions = vi.hoisted(() => vi.fn(async () => []));
+const listSetupMigrationOptions = vi.hoisted(() =>
+  vi.fn<ListSetupMigrationOptions>(async () => []),
+);
 const runSetupMigrationImport = vi.hoisted(() =>
   vi.fn<RunSetupMigrationImport>(async () => ({ kind: "no-imported-inference" })),
 );
@@ -1458,6 +1463,48 @@ describe("runSetupWizard", () => {
 
     expect(runSetupMigrationImport).toHaveBeenCalledOnce();
     expect(runSetupMemoryImportStep).not.toHaveBeenCalled();
+  });
+
+  it("returns to setup mode after an interactive import freshness rejection", async () => {
+    const workspaceDir = await makeCaseDir("import-freshness-retry-");
+    listSetupMigrationOptions.mockResolvedValueOnce([{ providerId: "hermes", label: "Hermes" }]);
+    runSetupMigrationImport.mockRejectedValueOnce(
+      new SetupMigrationFreshnessError(
+        "Migration import during onboarding requires a fresh OpenClaw setup.\nExisting setup:\n- state agents/ exists",
+      ),
+    );
+    const setupChoices: Array<"import:hermes" | "quickstart"> = ["import:hermes", "quickstart"];
+    const select = vi.fn(async ({ message }: WizardSelectParams<unknown>) => {
+      if (message === "Setup mode") {
+        return setupChoices.shift();
+      }
+      return "__skip__";
+    });
+    const prompter = buildWizardPrompter({ select: select as unknown as WizardPrompter["select"] });
+
+    await runSetupWizard(
+      {
+        acceptRisk: true,
+        authChoice: "skip",
+        installDaemon: false,
+        skipChannels: true,
+        skipSkills: true,
+        skipSearch: true,
+        skipHealth: true,
+        skipUi: true,
+        workspace: workspaceDir,
+      },
+      createRuntime(),
+      prompter,
+    );
+
+    expect(select.mock.calls.filter(([params]) => params.message === "Setup mode")).toHaveLength(2);
+    expect(runSetupMigrationImport).toHaveBeenCalledOnce();
+    expect(prompter.note).toHaveBeenCalledWith(
+      expect.stringContaining("state agents/ exists"),
+      "Existing config detected",
+    );
+    expect(finalizeSetupWizard).toHaveBeenCalledOnce();
   });
 
   it("continues onboarding after a recovered promotion", async () => {

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -28,6 +28,7 @@ import {
   listSetupMigrationOptions,
   runSetupMigrationImport,
 } from "./setup.migration-import.js";
+import { SetupMigrationFreshnessError } from "./setup.migration-snapshot.js";
 import { runSetupModelAuthStep, type SetupModelAuthCandidate } from "./setup.model-auth.js";
 import { resolveSetupSecretInputString } from "./setup.secret-input.js";
 import {
@@ -201,30 +202,30 @@ async function runSetupWizardOnce(
   const importIntent = Boolean(
     opts.importFrom?.trim() || opts.importSource?.trim() || opts.importSecrets,
   );
-  let flow: SetupFlowChoice =
-    explicitFlow ??
-    (importIntent
-      ? "import"
-      : await prompter.select({
-          message: t("wizard.setup.setupMode"),
-          options: [
-            ...(keepModelOption ? [keepModelOption] : []),
-            { value: "quickstart", label: t("wizard.setup.flowQuickstart"), hint: quickstartHint },
-            { value: "advanced", label: t("wizard.setup.flowAdvanced"), hint: manualHint },
-            ...importOptions,
-          ],
-          initialValue: hasExistingModelConfig ? "keep-model" : "quickstart",
-        }));
-
-  let keepExistingModelConfig = flow === "keep-model";
-  if (keepExistingModelConfig) {
-    flow = "quickstart";
-  }
-
-  if (opts.mode === "remote" && flow === "quickstart") {
-    await prompter.note(t("wizard.setup.quickstartOnlyLocal"), t("wizard.setup.quickstartTitle"));
-    flow = "advanced";
-  }
+  const promptSetupFlow = async (): Promise<SetupFlowChoice> =>
+    await prompter.select({
+      message: t("wizard.setup.setupMode"),
+      options: [
+        ...(keepModelOption ? [keepModelOption] : []),
+        { value: "quickstart", label: t("wizard.setup.flowQuickstart"), hint: quickstartHint },
+        { value: "advanced", label: t("wizard.setup.flowAdvanced"), hint: manualHint },
+        ...importOptions,
+      ],
+      initialValue: hasExistingModelConfig ? "keep-model" : "quickstart",
+    });
+  const normalizeSetupFlow = async (choice: SetupFlowChoice) => {
+    const keepExistingModelConfig = choice === "keep-model";
+    let flow = keepExistingModelConfig ? "quickstart" : choice;
+    if (opts.mode === "remote" && flow === "quickstart") {
+      await prompter.note(t("wizard.setup.quickstartOnlyLocal"), t("wizard.setup.quickstartTitle"));
+      flow = "advanced";
+    }
+    return { flow, keepExistingModelConfig };
+  };
+  const flowFromPrompt = explicitFlow === undefined && !importIntent;
+  let { flow, keepExistingModelConfig } = await normalizeSetupFlow(
+    explicitFlow ?? (importIntent ? "import" : await promptSetupFlow()),
+  );
 
   if (snapshot.exists && !keepExistingModelConfig) {
     await prompter.note(
@@ -233,41 +234,52 @@ async function runSetupWizardOnce(
     );
   }
 
-  const usedImportFlow = Boolean(opts.importFrom || isSetupImportFlowChoice(flow));
+  let usedImportFlow = false;
   let acknowledgeMigrationPromotion: (() => Promise<void>) | undefined;
   let importedInferenceVerified = false;
-  if (usedImportFlow) {
+  while (opts.importFrom || isSetupImportFlowChoice(flow)) {
     const importFrom = opts.importFrom ?? resolveImportProviderFromFlowChoice(flow);
     prompter.disableBackNavigation?.();
-    const migrationOutcome = await runSetupMigrationImport({
-      opts: {
-        ...opts,
-        ...(importFrom ? { importFrom } : {}),
-      },
-      baseConfig,
-      detections: migrationDetections,
-      prompter,
-      runtime,
-      readConfigFile: readValidSetupConfigFile,
-      async commitConfigFile(cfg, expectedConfig) {
-        const latest = await readSetupConfigFileSnapshot();
-        if (!latest.valid) {
-          throw new Error("Migration target config became invalid. Run `openclaw doctor`.");
-        }
-        const latestConfig = latest.exists ? (latest.sourceConfig ?? latest.config) : {};
-        if (!isDeepStrictEqual(latestConfig, expectedConfig)) {
-          throw new ConfigMutationConflictError("config changed during migration promotion", {
-            currentHash: latest.hash ?? null,
+    let migrationOutcome: Awaited<ReturnType<typeof runSetupMigrationImport>>;
+    try {
+      migrationOutcome = await runSetupMigrationImport({
+        opts: {
+          ...opts,
+          ...(importFrom ? { importFrom } : {}),
+        },
+        baseConfig,
+        detections: migrationDetections,
+        prompter,
+        runtime,
+        readConfigFile: readValidSetupConfigFile,
+        async commitConfigFile(cfg, expectedConfig) {
+          const latest = await readSetupConfigFileSnapshot();
+          if (!latest.valid) {
+            throw new Error("Migration target config became invalid. Run `openclaw doctor`.");
+          }
+          const latestConfig = latest.exists ? (latest.sourceConfig ?? latest.config) : {};
+          if (!isDeepStrictEqual(latestConfig, expectedConfig)) {
+            throw new ConfigMutationConflictError("config changed during migration promotion", {
+              currentHash: latest.hash ?? null,
+            });
+          }
+          return await writeWizardConfigFile(cfg, {
+            allowConfigSizeDrop: true,
+            baseSnapshot: latest,
+            ...(latest.hash !== undefined ? { baseHash: latest.hash } : {}),
           });
-        }
-        return await writeWizardConfigFile(cfg, {
-          allowConfigSizeDrop: true,
-          baseSnapshot: latest,
-          ...(latest.hash !== undefined ? { baseHash: latest.hash } : {}),
-        });
-      },
-      continueOnboarding: true,
-    });
+        },
+        continueOnboarding: true,
+      });
+    } catch (error) {
+      if (!(error instanceof SetupMigrationFreshnessError) || !flowFromPrompt) {
+        throw error;
+      }
+      await prompter.note(formatErrorMessage(error), t("wizard.setup.existingConfigTitle"));
+      ({ flow, keepExistingModelConfig } = await normalizeSetupFlow(await promptSetupFlow()));
+      continue;
+    }
+    usedImportFlow = true;
     acknowledgeMigrationPromotion = migrationOutcome.acknowledgePromotion;
     const migratedSnapshot = await readSetupConfigFileSnapshot();
     if (!migratedSnapshot.valid) {
@@ -282,6 +294,7 @@ async function runSetupWizardOnce(
       importedModelRef === migrationOutcome.modelRef;
     keepExistingModelConfig = importedInferenceVerified;
     flow = "quickstart";
+    break;
   }
   const wizardFlow: WizardFlow = flow === "advanced" ? "advanced" : "quickstart";
   const hasExplicitQuickstartGatewayOverrides =


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users choosing **Import from Claude**, **Import from Codex**, or **Import from Hermes** during first-run onboarding would be told the setup was not fresh and the wizard would exit. The state it rejected was the runtime SQLite scaffolding created by that same onboarding invocation.

AI-assisted; the implementation and evidence were reviewed and verified against the owning code paths.

## Why This Change Was Made

The onboarding freshness gate now treats config, credentials, sessions, agents, and workspace content as import-blocking user data while ignoring runtime-only `state/` and `tmp/` scaffolding. Transaction snapshot hashing still includes `state/`, preserving staged-import mutation detection.

Freshness refusal is now a typed error. When an import came from the interactive Setup mode menu, onboarding shows the detailed reason and returns to that menu; explicit import flags still fail loudly so requested automation is never silently dropped.

History confirms the intended boundary: the original fresh-import gate (`1fc5b2b7032`, PR #72646) protected real user data and checked `credentials/`, `sessions/`, and `agents/`. Generic `state/` was added later with staged target snapshots (`852548ce059`, PR #112798), unintentionally coupling runtime bookkeeping to freshness admission.

## User Impact

Brand-new profiles can now import Claude, Codex, or Hermes data even after onboarding initializes its state database. Existing config, credentials, sessions, agents, or workspace content still blocks the non-overwriting onboarding import with the specific surfaces listed.

If that protection triggers in the interactive wizard, users can choose another Setup mode without restarting onboarding.

## Evidence

Regression captured before the fix on Blacksmith Testbox: the new owner test failed with:

```text
expected { fresh: false, ... } to deeply equal { fresh: true, reasons: [] }
reasons: ["state state/ exists"]
```

Exact head `8661391c1d440a0986a1b59bcf700fe2b86f0233`:

- `node scripts/run-vitest.mjs src/wizard/setup.migration-import.test.ts src/wizard/setup.test.ts` — 61/61 passed.
- `node scripts/check-changed.mjs` — passed all selected core production/test typecheck, lint, formatting, architecture, dead-code, and guard lanes.
- `pnpm build` — passed on Blacksmith Testbox `tbx_01kzwhz68363ep6cneepjm8fqs`.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings.

Live built-CLI proof used only synthetic source fixtures and scratch profile `if1`; the profile was removed after each run:

```text
OpenClaw 2026.8.1 (8661391)
[state/db] state database schema migration pending; verifying integrity first
Migration preview: hermes
Source: /tmp/openclaw-if1-hermes-source.<random>
Target: /tmp/openclaw-if1-hermes-workspace.<random>
0 items, 0 conflicts, 0 sensitive items
Apply this migration now? Yes / No

OpenClaw 2026.8.1 (8661391)
[state/db] state database schema migration pending; verifying integrity first
Migration preview: codex
Source: /tmp/openclaw-if1-codex-source.<random>
Target: /tmp/openclaw-if1-codex-workspace.<random>
1 item, 0 conflicts, 0 sensitive items
Apply this migration now? Yes / No
```

Both runs stopped at the apply prompt; no source data was imported. A standalone fresh-profile `openclaw migrate codex --dry-run --json` also produced a valid one-item plan, confirming that the backup-backed standalone command does not use the onboarding freshness gate.
