### PR TITLE
fix: concurrent onboarding exits instead of hanging silently

### DIFF
--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -408,26 +408,18 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
     vi.clearAllMocks();
   });
 
-  it("serializes concurrent onboarding runs sharing one state directory", async () => {
+  it("rejects concurrent onboarding runs sharing one state directory", async () => {
     await withStateDir("state-concurrent-onboard-", async (stateDir) => {
-      let activeWorkspaceSetups = 0;
-      let maxActiveWorkspaceSetups = 0;
       let workspaceSetupCalls = 0;
       let releaseFirstSetup!: () => void;
       const firstSetupEntered = new Promise<void>((resolve) => {
         ensureWorkspaceAndSessionsMock.mockImplementation(async () => {
           workspaceSetupCalls += 1;
-          activeWorkspaceSetups += 1;
-          maxActiveWorkspaceSetups = Math.max(maxActiveWorkspaceSetups, activeWorkspaceSetups);
-          try {
-            if (workspaceSetupCalls === 1) {
-              resolve();
-              await new Promise<void>((release) => {
-                releaseFirstSetup = release;
-              });
-            }
-          } finally {
-            activeWorkspaceSetups -= 1;
+          if (workspaceSetupCalls === 1) {
+            resolve();
+            await new Promise<void>((release) => {
+              releaseFirstSetup = release;
+            });
           }
         });
       });
@@ -446,9 +438,10 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
         await firstSetupEntered;
         const readsBeforeSecond = readConfigFileSnapshotMock.mock.calls.length;
         const writesBeforeSecond = capturedReplaceConfigFileCalls.length;
-        const second = runNonInteractiveSetup(options, runtime);
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, 100);
+        await expect(runNonInteractiveSetup(options, runtime)).rejects.toMatchObject({
+          name: "SetupTargetLockedError",
+          code: "setup_target_locked",
+          holderPid: process.pid,
         });
 
         expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(readsBeforeSecond);
@@ -456,8 +449,8 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
         expect(ensureWorkspaceAndSessionsMock).toHaveBeenCalledOnce();
 
         releaseFirstSetup();
-        await Promise.all([first, second]);
-        expect(maxActiveWorkspaceSetups).toBe(1);
+        await first;
+        await runNonInteractiveSetup(options, runtime);
         expect(configWritePluginLeaseDepths).toHaveLength(2);
         expect(configWritePluginLeaseDepths.every((depth) => depth > 0)).toBe(true);
       } finally {

--- a/src/gateway/server-methods/setup-admission.ts
+++ b/src/gateway/server-methods/setup-admission.ts
@@ -1,6 +1,8 @@
 import { resolveStateDir } from "../../config/paths.js";
-import { FILE_LOCK_TIMEOUT_ERROR_CODE } from "../../infra/file-lock.js";
-import { withSetupMigrationTargetLock } from "../../wizard/setup.migration-snapshot.js";
+import {
+  SetupTargetLockedError,
+  withSetupMigrationTargetLock,
+} from "../../wizard/setup.migration-snapshot.js";
 
 export const SETUP_ADMISSION_BUSY_MESSAGE =
   "OpenClaw setup is already in progress; try again when it finishes.";
@@ -19,9 +21,9 @@ export async function runExclusiveSystemAgentSetupActivation<T>(
     return await task();
   };
   try {
-    return await withSetupMigrationTargetLock(resolveStateDir(), admittedTask, { wait: false });
+    return await withSetupMigrationTargetLock(resolveStateDir(), admittedTask);
   } catch (error) {
-    if (!admitted && (error as { code?: unknown }).code === FILE_LOCK_TIMEOUT_ERROR_CODE) {
+    if (!admitted && error instanceof SetupTargetLockedError) {
       throw new SetupAdmissionBusyError(SETUP_ADMISSION_BUSY_MESSAGE);
     }
     throw error;

--- a/src/wizard/setup.migration-snapshot.lock.test.ts
+++ b/src/wizard/setup.migration-snapshot.lock.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { withSetupMigrationTargetLock } from "./setup.migration-snapshot.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("setup migration target lock", () => {
+  it("rejects a concurrent profile operation with the active holder", async () => {
+    await withEnvAsync({ OPENCLAW_PROFILE: "lock-test" }, async () => {
+      const stateDir = tempDirs.make("openclaw-setup-target-lock-");
+      const firstAcquired = createDeferred();
+      const releaseFirst = createDeferred();
+      const first = withSetupMigrationTargetLock(stateDir, async () => {
+        firstAcquired.resolve();
+        await releaseFirst.promise;
+      });
+      await firstAcquired.promise;
+
+      let secondRan = false;
+      const second = withSetupMigrationTargetLock(stateDir, async () => {
+        secondRan = true;
+      });
+      let waitTimer: ReturnType<typeof setTimeout> | undefined;
+      const outcome = await Promise.race([
+        second.then(
+          () => ({ kind: "acquired" as const }),
+          (error: unknown) => ({ kind: "rejected" as const, error }),
+        ),
+        new Promise<{ kind: "waiting" }>((resolve) => {
+          waitTimer = setTimeout(() => resolve({ kind: "waiting" }), 1_000);
+        }),
+      ]);
+      clearTimeout(waitTimer);
+
+      releaseFirst.resolve();
+      await first;
+      if (outcome.kind === "waiting") {
+        await second;
+      }
+
+      expect(outcome.kind).toBe("rejected");
+      if (outcome.kind !== "rejected") {
+        return;
+      }
+      expect(outcome.error).toMatchObject({
+        name: "SetupTargetLockedError",
+        code: "setup_target_locked",
+        holderPid: process.pid,
+      });
+      expect((outcome.error as Error).message).toBe(
+        `Another onboarding/config operation is running for profile lock-test (pid ${process.pid}). Finish or abort it, then re-run.`,
+      );
+      expect(secondRan).toBe(false);
+
+      await expect(withSetupMigrationTargetLock(stateDir, async () => "ok")).resolves.toBe("ok");
+    });
+  });
+});

--- a/src/wizard/setup.migration-snapshot.ts
+++ b/src/wizard/setup.migration-snapshot.ts
@@ -5,14 +5,15 @@ import { createReadStream } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { withFileLock } from "../infra/file-lock.js";
+import { FILE_LOCK_TIMEOUT_ERROR_CODE, withFileLock } from "../infra/file-lock.js";
+import { readJsonFile } from "../infra/json-files.js";
 import { isNotFoundPathError } from "../infra/path-guards.js";
 import type { MigrationPlan } from "../plugins/types.js";
 import { resolveUserPath } from "../utils.js";
 import { canonicalizeSetupMigrationValue } from "./setup.migration-canonical.js";
 
 const ONBOARDING_TARGET_LOCK_OPTIONS = {
-  retries: { retries: 1_200, factor: 1, minTimeout: 500, maxTimeout: 500 },
+  retries: { retries: 0, factor: 1, minTimeout: 1, maxTimeout: 1 },
   stale: 30 * 60 * 1000,
   staleRecovery: "remove-if-unchanged" as const,
 };
@@ -28,6 +29,24 @@ const MEANINGFUL_WORKSPACE_ENTRIES = [
   "skills",
 ] as const;
 const MEANINGFUL_STATE_ENTRIES = ["credentials", "sessions", "agents", "state"] as const;
+
+export class SetupTargetLockedError extends Error {
+  readonly code = "setup_target_locked";
+
+  constructor(
+    public readonly holderPid: number | undefined,
+    profile: string | undefined,
+    cause: unknown,
+  ) {
+    const target = profile ? `profile ${profile}` : "the current profile";
+    const owner = holderPid === undefined ? "" : ` (pid ${holderPid})`;
+    super(
+      `Another onboarding/config operation is running for ${target}${owner}. Finish or abort it, then re-run.`,
+      { cause },
+    );
+    this.name = "SetupTargetLockedError";
+  }
+}
 
 async function exists(candidate: string): Promise<boolean> {
   try {
@@ -307,7 +326,6 @@ export async function prepareSetupMigrationAttemptBoundary(params: {
 export async function withSetupMigrationTargetLock<T>(
   stateDir: string,
   fn: () => Promise<T>,
-  options?: { wait?: boolean },
 ): Promise<T> {
   const resolvedStateDir = path.resolve(stateDir);
   const activeStateDir = activeSetupMigrationTargetLock.getStore();
@@ -319,16 +337,25 @@ export async function withSetupMigrationTargetLock<T>(
   }
   const migrationDir = path.join(resolvedStateDir, "migration");
   await fs.mkdir(migrationDir, { recursive: true, mode: 0o700 });
-  return await withFileLock(
-    path.join(migrationDir, "onboarding.lock-target"),
-    options?.wait === false
-      ? {
-          ...ONBOARDING_TARGET_LOCK_OPTIONS,
-          retries: { ...ONBOARDING_TARGET_LOCK_OPTIONS.retries, retries: 0 },
-        }
-      : ONBOARDING_TARGET_LOCK_OPTIONS,
-    async () => await activeSetupMigrationTargetLock.run(resolvedStateDir, fn),
-  );
+  const lockTarget = path.join(migrationDir, "onboarding.lock-target");
+  let acquired = false;
+  try {
+    return await withFileLock(lockTarget, ONBOARDING_TARGET_LOCK_OPTIONS, async () => {
+      acquired = true;
+      return await activeSetupMigrationTargetLock.run(resolvedStateDir, fn);
+    });
+  } catch (error) {
+    if (acquired || (error as { code?: unknown }).code !== FILE_LOCK_TIMEOUT_ERROR_CODE) {
+      throw error;
+    }
+    const payload = await readJsonFile<{ pid?: unknown }>(`${lockTarget}.lock`, {
+      maxBytes: 1_024,
+    });
+    const pid = payload?.pid;
+    const holderPid =
+      typeof pid === "number" && Number.isSafeInteger(pid) && pid > 0 ? pid : undefined;
+    throw new SetupTargetLockedError(holderPid, process.env.OPENCLAW_PROFILE?.trim(), error);
+  }
 }
 
 export function assertFreshSetupMigrationTarget(freshness: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where starting onboarding while another onboarding session held the same profile open at a prompt produced no output and waited for up to ten minutes. The non-interactive command looked permanently hung, and a second interactive command stopped before reaching its own security prompt.

## Why This Change Was Made

The shared onboarding target lock now rejects concurrent acquisition immediately with a typed, actionable error. When the lock payload is readable, the error identifies the active profile and holder PID; the existing Gateway setup admission path continues translating the owner error to its own busy result.

The lock still covers the complete interactive and non-interactive setup lifecycle, so normal single-instance protection and nested process-local acquisition are unchanged. This deliberately changes only admission semantics: an operator must finish or abort the active setup before retrying instead of silently queueing behind a prompt-held session.

Production LOC: **+46/-17 (net +29)**. Tests: **+72/-19 (net +53)**. The production growth is the typed owner error plus bounded, symlink-safe holder-payload read needed to report the actionable PID.

## User Impact

Concurrent onboarding now exits quickly and explains exactly what is blocking it. Operators no longer have to infer a hidden lock from an idle process or kill a command that appears frozen.

Ordinary `config set` remains independent: live pre-fix scope testing showed it completed and wrote config while onboarding sat at the first prompt, confirming this was the onboarding-target lock rather than the generic config-mutation lock or launcher respawn handshake.

AI-assisted: yes. The change and its tests were reviewed and validated by the author.

## Evidence

- **Before, exact reported build `239087d4487`:** an interactive holder owned `migration/onboarding.lock-target.lock`; the non-interactive contender emitted zero bytes for 1m47s until interrupted. `lsof` showed only TTY/kqueue/self-pipes, and 858/863 main-thread samples were in `uv_run -> uv__io_poll -> kevent`. A second interactive contender printed only its banner and then waited before the security prompt for 53s.
- **Wait-site proof:** `setupWizardCommand` holds `withSetupMigrationTargetLock` across the full session. Its policy was 1,200 fixed 500ms retries, a nominal 600-second silent wait. The contender had not reached the nested SQLite onboarding lease or config mutation.
- **Regression proof before fix:** the new real-lock test failed after its one-second guard with `expected rejected, received waiting`; it released the first holder and drained the contender cleanly.
- **Focused proof after fix:** `node scripts/run-vitest.mjs src/wizard/setup.migration-snapshot.lock.test.ts src/gateway/server-methods/setup-admission.test.ts src/commands/onboard-non-interactive.gateway.test.ts` — 3 files, 26 tests passed.
- **Changed-file gate:** `node scripts/check-changed.mjs` passed all selected typechecks, formatting, lint, dead-export, storage/sidecar, boundary, and import-cycle guards on Blacksmith Testbox `tbx_01kzwhcn0xvg2h0qc3hcrcz2kz` ([run](https://github.com/openclaw/openclaw/actions/runs/31662924977)).
- **Exact post-fix live proof:** after a full build on Testbox `tbx_01kzwjg4n7ym9mcqb0793fypgw`, Terminal A reached the `ch1` security prompt with holder PID 6738. The exact non-interactive contender exited 1 in **1.627s** with: `Another onboarding/config operation is running for profile ch1 (pid 6738). Finish or abort it, then re-run.` The scratch profile was removed, port 19513 was clear, and the Testbox stopped ([run](https://github.com/openclaw/openclaw/actions/runs/31663926840)).
- **Structured autoreview:** clean; no accepted/actionable findings.
- `git diff --check` passed. `CHANGELOG.md` was not edited.
