### PR TITLE
fix(cli): rejected profile commands no longer create state

### DIFF
--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -111,8 +111,12 @@ async function runCliProcess(params: {
   stateEnv?: (stateDir: string) => Record<string, string>;
   timeoutMs?: number;
   expectedExitCode?: number;
+  pristineHome?: boolean;
 }) {
-  const fixture = await createHelpProcessFixture(params.config);
+  const fixture = await createHelpProcessFixture(params.pristineHome ? undefined : params.config);
+  if (params.pristineHome) {
+    await fs.rm(fixture.stateDir, { force: true, recursive: true });
+  }
   if (params.stateEnv) {
     const lines = Object.entries(params.stateEnv(fixture.stateDir)).map(
       ([key, value]) => `${key}=${value}`,
@@ -151,9 +155,9 @@ async function runCliProcess(params: {
         NODE_ENV: undefined,
         NODE_OPTIONS: undefined,
         NODE_USE_SYSTEM_CA: "1",
-        OPENCLAW_CONFIG_PATH: fixture.configPath,
+        OPENCLAW_CONFIG_PATH: params.pristineHome ? undefined : fixture.configPath,
         OPENCLAW_NO_RESPAWN: params.allowRespawn ? undefined : "1",
-        OPENCLAW_STATE_DIR: fixture.stateDir,
+        OPENCLAW_STATE_DIR: params.pristineHome ? undefined : fixture.stateDir,
         VITEST: undefined,
         ...params.env,
       },
@@ -219,7 +223,7 @@ async function runCliProcess(params: {
       }),
     );
   }
-  return { stderr, stdout };
+  return { root: fixture.root, stderr, stdout };
 }
 
 function parseJsonLines(stdout: string): Array<Record<string, unknown>> {
@@ -367,6 +371,32 @@ describe("CLI help process exit", () => {
     expect(stderr).toBe("");
     expect(stdout.split(/\r?\n/u).find((line) => line.startsWith("Usage:"))).toBe(usage);
     expect(actionStarted).toBe(false);
+  });
+});
+
+describe("rejected CLI process state isolation", () => {
+  it("does not scaffold a selected profile before option validation", async () => {
+    const profile = "rejected-profile";
+    const result = await runCliProcess({
+      args: [
+        "onboard",
+        "--non-interactive",
+        "--accept-risk",
+        "--gateway-port",
+        "99999",
+        "--profile",
+        profile,
+      ],
+      expectedExitCode: 1,
+      pristineHome: true,
+    });
+
+    expect(result.stderr).toContain(
+      "Error: --gateway-port must be an integer between 1 and 65535.",
+    );
+    await expect(fs.access(path.join(result.root, `.openclaw-${profile}`))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 });
 

--- a/src/commands/doctor-config-preflight.process.test.ts
+++ b/src/commands/doctor-config-preflight.process.test.ts
@@ -173,7 +173,7 @@ describe.concurrent("gateway startup-migration refusal", () => {
     }
   }, 45_000);
 
-  it("reuses the state-migration checkpoint when the config file remains absent", async () => {
+  it("skips state-only checkpoint work when config and state remain absent", async () => {
     const root = await fs.promises.realpath(tempDirs.make("openclaw-configless-checkpoint-"));
     const runtimeRoot = createSourceRuntime(root);
     const stateDir = path.join(root, "state");
@@ -239,9 +239,12 @@ describe.concurrent("gateway startup-migration refusal", () => {
     const first = readResult(await run());
     const second = readResult(await run());
 
-    expect(first).toEqual({ activeLease: false, stateMigrationsImported: true });
+    // This direct preflight is state-only. Gateway startup requests the readiness checkpoint and
+    // still imports it; the preceding process case proves migration failures refuse readiness.
+    expect(first).toEqual({ activeLease: false, stateMigrationsImported: false });
     expect(second).toEqual({ activeLease: false, stateMigrationsImported: false });
     expect(fs.existsSync(configPath)).toBe(false);
+    expect(fs.existsSync(stateDir)).toBe(false);
   }, 150_000);
 
   it("reloads tool ownership after updater-managed manifest repair", async () => {

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -218,7 +218,7 @@ export async function runDoctorConfigPreflight(
   const gatewayStartupCheckpointRequired = options.requireStartupMigrationCheckpoint === true;
   const migrationCheckpointRequired =
     gatewayStartupCheckpointRequired || options.requireStateMigrationCheckpoint === true;
-  const migrationCheckpoint = migrationCheckpointRequired
+  let migrationCheckpoint = migrationCheckpointRequired
     ? await measurePreflightStep(
         "startup-checkpoint-import",
         () => import("../infra/startup-migration-checkpoint.js"),
@@ -341,6 +341,11 @@ export async function runDoctorConfigPreflight(
       );
       skipPristineStartupStateMigrations = pristineStatePlan.skipAllStateMigrations;
       skipPristineCoreStateMigrations ||= pristineStatePlan.skipCoreStateMigrations;
+    }
+    if (skipPristineStartupStateMigrations && !gatewayStartupCheckpointRequired) {
+      // A pristine non-Gateway command has nothing to checkpoint. Leave the state root absent
+      // until command execution reaches a real state consumer.
+      migrationCheckpoint = undefined;
     }
     // The gateway uses this last-moment guard to ensure its prepared config did not change before
     // any automatic migration mutates state. A rejected guard skips every state migration stage.

--- a/src/commands/doctor/shared/pristine-startup-state.test.ts
+++ b/src/commands/doctor/shared/pristine-startup-state.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import {
   canSkipPristineStartupStateMigrations,
   planPristineStartupConfigMigrations,
@@ -9,6 +10,7 @@ import {
 } from "./pristine-startup-state.js";
 
 const roots: string[] = [];
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function createFixture(config: Record<string, unknown>, stateEntries: string[] = []) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pristine-startup-"));
@@ -107,8 +109,7 @@ afterEach(() => {
 
 describe("pristine startup state", () => {
   it("accepts a missing explicitly selected profile root", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pristine-profile-"));
-    roots.push(root);
+    const root = tempDirs.make("openclaw-pristine-profile-");
     const stateDir = path.join(root, ".openclaw-typo");
     fs.mkdirSync(path.join(root, ".clawdbot"));
 

--- a/src/commands/doctor/shared/pristine-startup-state.test.ts
+++ b/src/commands/doctor/shared/pristine-startup-state.test.ts
@@ -106,6 +106,25 @@ afterEach(() => {
 });
 
 describe("pristine startup state", () => {
+  it("accepts a missing explicitly selected profile root", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pristine-profile-"));
+    roots.push(root);
+    const stateDir = path.join(root, ".openclaw-typo");
+    fs.mkdirSync(path.join(root, ".clawdbot"));
+
+    expect(
+      planPristineStartupStateMigrations({
+        HOME: root,
+        OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
+        OPENCLAW_STATE_DIR: stateDir,
+      }),
+    ).toEqual({
+      skipAllStateMigrations: true,
+      skipCoreStateMigrations: true,
+    });
+    expect(fs.existsSync(stateDir)).toBe(false);
+  });
+
   it("accepts the core-only Gateway benchmark config", () => {
     const env = createFixture({
       browser: { enabled: false },

--- a/src/commands/doctor/shared/pristine-startup-state.ts
+++ b/src/commands/doctor/shared/pristine-startup-state.ts
@@ -263,16 +263,20 @@ export function planPristineStartupStateMigrations(
   if (!homeDir) {
     return { skipAllStateMigrations: false, skipCoreStateMigrations: false };
   }
-  const legacyStateAbsent = resolveLegacyStateDirs(() => homeDir).every((legacyDir) => {
-    if (path.resolve(legacyDir) === path.resolve(stateDir)) {
-      return false;
-    }
-    return !fs.existsSync(legacyDir);
-  });
+  const explicitStateDir = env.OPENCLAW_STATE_DIR?.trim();
+  const legacyStateAbsent =
+    Boolean(explicitStateDir) ||
+    resolveLegacyStateDirs(() => homeDir).every((legacyDir) => {
+      if (path.resolve(legacyDir) === path.resolve(stateDir)) {
+        return false;
+      }
+      return !fs.existsSync(legacyDir);
+    });
   if (!legacyStateAbsent) {
     return { skipAllStateMigrations: false, skipCoreStateMigrations: false };
   }
-  const configPlan = planPristineStartupConfigMigrations(tryReadJsonSync(configPath), env);
+  const config = fs.existsSync(configPath) ? tryReadJsonSync(configPath) : {};
+  const configPlan = planPristineStartupConfigMigrations(config, env);
   return {
     skipAllStateMigrations: configPlan.skipAllStateMigrations,
     skipCoreStateMigrations: configPlan.skipCoreStateMigrations,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a rejected CLI invocation using a nonexistent named profile created that profile's state directory, initialized the shared SQLite database, and ran schema migrations before command option validation completed. A typo such as `--profile nmae` could therefore leave a fully scaffolded junk profile even though the command failed.

## Why This Change Was Made

Profile environment projection remains pure. The shared Doctor/config preflight now recognizes a missing explicitly selected state root as pristine and defers the non-Gateway migration checkpoint until command execution reaches a real state consumer. Gateway startup keeps its existing readiness checkpoint behavior, and there are no command-specific guards.

## User Impact

Rejected commands no longer leave profile directories, SQLite databases, or migration artifacts behind. Valid commands still create and migrate state on first real use.

AI-assisted: implementation and validation were performed with Codex; the resulting ownership boundary and tests were reviewed directly.

## Evidence

- Before the repair, the new real-process regression failed because `.openclaw-rejected-profile` existed after the invalid-port error.
- `node scripts/run-vitest.mjs src/cli/help-exit.process.test.ts -t 'does not scaffold a selected profile before option validation'`
- `node scripts/run-vitest.mjs src/commands/doctor/shared/pristine-startup-state.test.ts src/commands/doctor-config-preflight.state-migration.test.ts` (45 tests)
- `node scripts/check-changed.mjs` on Blacksmith Testbox `tbx_01kzwjg28gstmwwwaya1fgd7g0`: format, core/core-test types, lint, dead exports, schema guards, and import cycles passed with no temp-directory warnings.
- Exact-head `pnpm build` passed.
- Dist-backed isolated-home proof:
  - `node openclaw.mjs onboard --non-interactive --accept-risk --gateway-port 99999 --profile er9` exited 1 with the expected validation error, and `.openclaw-er9` was absent.
  - `node openclaw.mjs config set gateway.port 19999 --profile er9` exited 0, then `.openclaw-er9/state/openclaw.sqlite` existed.
  - The isolated home was removed after proof; the operator's real state and port 18789 were untouched.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output`: clean, no accepted/actionable findings.

Production LOC: +9 net. Test LOC: +50 net.
