### PR TITLE
fix(agents): report recovered compaction runs as completed

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-session-cleanup.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-cleanup.test.ts
@@ -97,6 +97,19 @@ describe("cleanupEmbeddedAttemptSessionPhase", () => {
     expect(input.emitDiagnosticRunCompleted).toHaveBeenCalledWith("completed", null, undefined);
   });
 
+  it("keeps compaction timeout observations abort-like only for cleanup", async () => {
+    const input = createInput();
+    const readState = input.readState;
+    input.readState = () => ({ ...readState(), timedOutDuringCompaction: true });
+
+    await cleanupEmbeddedAttemptSessionPhase(input as never);
+
+    expect(hoisted.cleanupEmbeddedAttemptResources).toHaveBeenCalledWith(
+      expect.objectContaining({ aborted: true }),
+    );
+    expect(input.emitDiagnosticRunCompleted).toHaveBeenCalledWith("completed", null, undefined);
+  });
+
   it("emits the before-agent blocked status and owner", async () => {
     const input = createInput({
       readState: () => ({

--- a/src/agents/embedded-agent-runner/run/attempt-session-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-settle.ts
@@ -175,6 +175,8 @@ export async function cleanupEmbeddedAttemptSessionPhase(
   const finalState = input.readState();
   const cleanupFailure = cleanupError;
   const beforeAgentRunBlocked = finalState.beforeAgentRunBlockedBy !== undefined;
+  const diagnosticTerminalAborted =
+    finalState.aborted || finalState.timedOut || finalState.idleTimedOut;
   input.emitDiagnosticRunCompleted?.(
     cleanupFailure
       ? "error"
@@ -182,10 +184,7 @@ export async function cleanupEmbeddedAttemptSessionPhase(
         ? "blocked"
         : finalState.promptError
           ? "error"
-          : finalState.aborted ||
-              finalState.timedOut ||
-              finalState.idleTimedOut ||
-              finalState.timedOutDuringCompaction
+          : diagnosticTerminalAborted
             ? "aborted"
             : "completed",
     cleanupFailure ?? finalState.promptError,


### PR DESCRIPTION
Closes #122969

## What Problem This Solves

Fixes an issue where a successfully recovered embedded-agent run could be returned as completed while diagnostics and exported telemetry reported it as aborted after an observation-only compaction timeout.

## Why This Change Was Made

Diagnostic completion now uses only actual terminal abort/timeout facts. Observation-only compaction timeouts remain abort-like for resource cleanup, preserving the existing protection against stranded idle waits without misclassifying the run outcome.

## User Impact

Operators and monitoring systems receive an accurate completed outcome for recovered runs instead of false abort metrics and trace attributes. Actual aborts, terminal timeouts, errors, and blocked runs are unchanged.

## Evidence

- Tests-first regression failed before the source repair: cleanup correctly received `aborted: true`, but the diagnostic expected `completed` and received `aborted`.
- Focused cleanup suite: 4/4 passed.
- Canonical terminal-outcome suite: 20/20 passed.
- Hosted changed gate passed on Testbox `tbx_01kzwm7gjbbtp8946nt1hxdajd`; Actions receipt: https://github.com/openclaw/openclaw/actions/runs/31665440271.
- Exact-head CI completed green: https://github.com/openclaw/openclaw/actions/runs/31665238251.
- Targeted formatting, lint, and `git diff --check` passed.
- Final integrated Codex autoreview: clean, no findings, confidence 0.99; TruffleHog clean.

Production delta: +3/-4, net -1. Tests: +13.