### PR TITLE
chore: add onboarding AI ownership regression proof

### DIFF
--- a/src/agents/embedded-agent-runner/run.inherited-auth-owner.test.ts
+++ b/src/agents/embedded-agent-runner/run.inherited-auth-owner.test.ts
@@ -1,0 +1,56 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { listAgentIds } from "../agent-scope-config.js";
+import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
+import {
+  loadRunOverflowCompactionHarness,
+  mockedAcquireAgentRunPreparedModelRuntime,
+  mockedBuildEmbeddedRunPayloads,
+  mockedRunEmbeddedAttempt,
+  overflowBaseRunParams,
+} from "./run.overflow-compaction.harness.js";
+
+function projectSetupExecutionConfig(source: OpenClawConfig): OpenClawConfig {
+  return {
+    ...source,
+    agents: {
+      ...source.agents,
+      entries: {
+        ...(source.agents?.entries ?? { main: {} }),
+        openclaw: {},
+      },
+    },
+  };
+}
+
+describe("embedded setup inference inherited auth owner", () => {
+  it.each([
+    { name: "a pre-roster config", source: {} },
+    { name: "a sole-agent config", source: { agents: { entries: { main: {} } } } },
+  ] satisfies Array<{ name: string; source: OpenClawConfig }>)(
+    "prepares the explicit main agent from $name",
+    async ({ name, source }) => {
+      const config = projectSetupExecutionConfig(source);
+      expect(listAgentIds(config)).toEqual(["main", "openclaw"]);
+
+      const { runEmbeddedAgent } = await loadRunOverflowCompactionHarness();
+      mockedBuildEmbeddedRunPayloads.mockReturnValue([{ text: "OK" }]);
+      mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ assistantTexts: ["OK"] }));
+
+      await runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        agentId: "main",
+        config,
+        runId: `run-setup-inference-owner-${name}`,
+      });
+
+      const preparedInput = mockedAcquireAgentRunPreparedModelRuntime.mock.calls[0]?.[0];
+      expect(preparedInput).toMatchObject({ agentId: "main", config });
+      expect(String(preparedInput?.inheritedAuthDir)).toSatisfy((value: string) =>
+        value.endsWith(path.join("agents", "main", "agent")),
+      );
+      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledOnce();
+    },
+  );
+});

--- a/src/commands/onboard-guided.inference.e2e.test.ts
+++ b/src/commands/onboard-guided.inference.e2e.test.ts
@@ -160,7 +160,9 @@ describe("guided onboarding inference composition", () => {
         }),
       );
       expect(mockOpenAi.requestBodies).toHaveLength(1);
-      expect(JSON.parse(mockOpenAi.requestBodies[0] ?? "{}")).toMatchObject({ model: "gpt-5.6" });
+      expect(JSON.parse(mockOpenAi.requestBodies[0] ?? "{}")).toMatchObject({
+        model: "gpt-5.6-sol",
+      });
       const notes = (prompter.note as ReturnType<typeof vi.fn>).mock.calls;
       const inferenceReadyIndex = notes.findIndex((call) => call[1] === "Inference ready");
       const postInferenceIndex = notes.findIndex(


### PR DESCRIPTION
Related: #114388
Related: #122889

## What Problem This Solves

Adds regression coverage for an issue where fresh operators testing AI access during interactive onboarding received a false `Multiple agents are configured` error before any provider request. The production repair landed concurrently in #122889 while this investigation was being validated; this PR preserves the missing onboarding-specific proof rather than duplicating that implementation.

## Why This Change Was Made

The setup inference route projects the internal `openclaw` execution agent alongside the operator's `main` agent. Before #122889, the embedded runner used ambient default-agent resolution for inherited authentication even though the run already carried explicit `agentId: main`; strict ownership from #114388 therefore saw `[main, openclaw]` and failed closed.

Current `main` now correctly uses `resolveLegacyInheritedAuthDir(config)` at the runner's prepared-runtime boundary. This PR adds a deterministic owner-level regression for both pre-roster and sole-agent wizard-shaped configs, and refreshes the guided mock-provider assertion to the current `gpt-5.6-sol` route.

## User Impact

No additional runtime behavior change beyond #122889. The onboarding regression is now covered at the exact embedded-runner owner boundary and by the existing guided mock-provider E2E, making a future return of the false ownership error visible in focused CI.

## Evidence

### Before

Fresh quickstart profile, Anthropic fake API key:

```text
Test AI access now with a live completion? Yes
AI access test failed: Multiple agents are configured, but this operation has no
explicit owner. Select an agent explicitly; CLI callers can pass --agent <id>, channels
can add a binding, and ambient services can set their agentId target.
```

The independent fresh manual Ollama/Gemma 4 reproduction reported the same terminal error before inference.

Temporary instrumentation at the exact throw printed:

```text
[wizard-agent-owner-debug] listAgentIds=["main","openclaw"]
```

`main` was the only operator agent. `openclaw` is the internal execution agent added by `src/system-agent/inference-route.ts`; the message described this projected runtime roster as operator multi-agent configuration.

### #114388 provenance

- `1ca60fbc3a3` changed `src/agents/agent-scope-config.ts` from ambient default selection to sole-agent-or-explicit selection (`resolveSoleAgentId` / strict `resolveDefaultAgentId`). Its PR body explicitly promised: “Single-agent installations continue to select their sole agent without extra configuration.”
- The same commit introduced `src/agents/legacy-inherited-auth-dir.ts` and migrated sibling prepared-model lookups in `src/agents/embedded-agent-runner/model.ts` to `resolveLegacyInheritedAuthDir`.
- `src/agents/embedded-agent-runner/run-orchestrator.ts` retained `resolveDefaultAgentDir(config)`. The wizard path was `src/wizard/setup.ts` → `src/wizard/setup.inference-verification.ts` → `src/system-agent/setup-inference-verify.ts` → projected execution config → embedded runner.
- #122889 independently corrected that missed runner call while fixing related explicit-owner failures, landing as `edb941a50822dff5eff727394cbe76febfcd223a` during this task.

### Regression and validation

- Regression demonstrated against the pre-fix runner call: both pre-roster and sole-agent cases failed with `AgentSelectionRequiredError`, `agentIds: ["main", "openclaw"]`, before the mocked provider attempt.
- Exact-head focused regression: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.inherited-auth-owner.test.ts` — 2 passed.
- Guided mock-provider E2E on Blacksmith Testbox `tbx_01kzwjx844g9j1svqshfs0cdhw`: 1 passed; the mock OpenAI provider received exactly one `gpt-5.6-sol` request.
- Exact-head `node scripts/check-changed.mjs`: green on Blacksmith Testbox `tbx_01kzwkw60fvy3mnmazwwzt3txv`, run https://github.com/openclaw/openclaw/actions/runs/31665127538.
- Live after proof using `node openclaw.mjs onboard --classic --flow quickstart --profile ao1 --gateway-port 19517` with a fake Anthropic key:

```text
AI access test failed: Authentication failed (provider returned HTTP 401).
```

No agent-owner error appeared. The `ao1` profile and `ai.openclaw.ao1` LaunchAgent were removed afterward; port 18789 and the real default profile were not used.

- Autoreview: clean, no accepted/actionable findings.
- LOC: production `+0/-0`; tests `+59/-1`.
