### PR TITLE
fix: full extension config fails on stale plugin tests

### DIFF
--- a/extensions/clickclack/src/inbound.mention-gating.test.ts
+++ b/extensions/clickclack/src/inbound.mention-gating.test.ts
@@ -572,11 +572,18 @@ describe("ClickClack inbound mention gating", () => {
         }),
         config: {
           agents: {
+            ownership: "explicit",
             entries: {
               research: { groupChat: { mentionPatterns: ["@research"] } },
               "service-bot": { groupChat: { mentionPatterns: ["@service"] } },
             },
           },
+          bindings: [
+            {
+              agentId: "service-bot",
+              match: { channel: "clickclack", accountId: "default" },
+            },
+          ],
           channels: {
             clickclack: {
               enabled: true,

--- a/extensions/policy/src/cli.test.ts
+++ b/extensions/policy/src/cli.test.ts
@@ -170,7 +170,7 @@ describe("policy commands", () => {
     vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
     await writeFixture(configPath, {
       plugins: { entries: { policy: { enabled: true, config: { enabled: true } } } },
-      agents: { entries: { main: { default: true }, family: {} } },
+      agents: { entries: { main: {} } },
       channels: { imessage: { enabled: false } },
       bindings: [],
     });

--- a/extensions/teams-meetings/src/node-host.test.ts
+++ b/extensions/teams-meetings/src/node-host.test.ts
@@ -7,8 +7,8 @@ vi.mock("node:child_process", async (importOriginal) => {
   return { ...actual, spawnSync: spawnSyncMock };
 });
 
-import { teamsMeetingsConfig } from "./config.js";
-import { handleTeamsMeetingsNodeHostCommand } from "./node-host.js";
+let teamsMeetingsConfig: (typeof import("./config.js"))["teamsMeetingsConfig"];
+let handleTeamsMeetingsNodeHostCommand: (typeof import("./node-host.js"))["handleTeamsMeetingsNodeHostCommand"];
 
 const successfulProbe = {
   pid: 123,
@@ -29,10 +29,13 @@ function setupParams() {
 }
 
 describe("Teams meeting node-host prerequisite deadline", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
     spawnSyncMock.mockReset();
     spawnSyncMock.mockReturnValue(successfulProbe);
+    ({ teamsMeetingsConfig } = await import("./config.js"));
+    ({ handleTeamsMeetingsNodeHostCommand } = await import("./node-host.js"));
   });
 
   afterEach(() => {

--- a/extensions/teams-meetings/src/node-invoke-policy.test.ts
+++ b/extensions/teams-meetings/src/node-invoke-policy.test.ts
@@ -32,6 +32,9 @@ describe("Microsoft Teams meetings node invoke policy", () => {
     expect(invokeNode).toHaveBeenCalledWith({
       params: {
         action: "setup",
+        audioBackend: "auto",
+        audioBufferBytes: 4_096,
+        audioFormat: "pcm16-24khz",
         audioInputCommand: ["trusted-input", "--read"],
         audioOutputCommand: ["trusted-output", "--write"],
         bargeInInputCommand: ["trusted-barge-in"],

--- a/extensions/zoom-meetings/src/node-invoke-policy.test.ts
+++ b/extensions/zoom-meetings/src/node-invoke-policy.test.ts
@@ -32,6 +32,9 @@ describe("Zoom meetings node invoke policy", () => {
     expect(invokeNode).toHaveBeenCalledWith({
       params: {
         action: "setup",
+        audioBackend: "auto",
+        audioBufferBytes: 4_096,
+        audioFormat: "pcm16-24khz",
         audioInputCommand: ["trusted-input", "--read"],
         audioOutputCommand: ["trusted-output", "--write"],
         bargeInInputCommand: ["trusted-barge-in"],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the full extensions Vitest config could fail on five stale plugin tests when an SDK-surface change selected full plugin impact, blocking unrelated pull requests even though current runtime behavior was correct.

## Why This Change Was Made

The test fixtures now express the canonical ownership and platform contracts they exercise: ClickClack has an explicit account-wide owner, the policy probe has a sole config owner, Teams and Zoom assert every trusted audio field forwarded by the shared policy, and the Teams node-host test mocks the platform before importing platform-derived defaults. This is test-only; production behavior is unchanged.

## User Impact

No user-visible runtime change. Maintainers regain reliable full-config plugin coverage across macOS and Linux without weakening the tests' original behavioral assertions.

## Evidence

Discovery context: PR #122955 triggered the full `test/vitest/vitest.extensions.config.ts` impact lane in [CI run 31663096663](https://github.com/openclaw/openclaw/actions/runs/31663096663). Job `checks-node-changed-extensions-config-2` reproduced all five stale files on current `main`, including the Linux-only Teams node-host failure.

Provenance:

- `extensions/clickclack/src/inbound.mention-gating.test.ts`: the managed-discussion coverage came from #115484 (`c0f8288daa4`); #114388 (`1ca60fbc3a3`) later made ambiguous multi-agent fallback fail closed, so the fixture now declares the required `clickclack:default` owner.
- `extensions/policy/src/cli.test.ts`: the authored-routing probe came from #111087 (`e27e2d08fd9`); #114388 removed ambient ownership from normalized multi-agent configs, so the fixture uses a sole `main` owner and reaches the intended findings exit code 1.
- `extensions/teams-meetings/src/node-invoke-policy.test.ts` and `extensions/zoom-meetings/src/node-invoke-policy.test.ts`: #118451 (`7d4066639ef`) added trusted `audioBackend`, `audioBufferBytes`, and `audioFormat` forwarding; both exact call-shape assertions now protect those fields.
- `extensions/teams-meetings/src/node-host.test.ts`: #111455 (`a45eaf6aee1`) added the sox deduplication regression; #118451 made default audio commands platform-dependent at module import, so the test now resets modules and mocks Darwin before importing defaults.

Proof:

- Each of the five touched files passed standalone with `node scripts/run-vitest.mjs <file>`.
- One combined invocation passed: 5 files, 61 tests.
- Exact scoped full-config invocation passed on Linux Blacksmith Testbox `tbx_01kzwm1c7g3rvs6v1rnpqbhw3n`: 73 files, 1,021 tests. [Run 31665272362](https://github.com/openclaw/openclaw/actions/runs/31665272362)
- `node scripts/check-changed.mjs -- <five changed files>` passed extension-test typecheck, lint, formatting, boundaries, and guards on Testbox `tbx_01kzwm4cag0t9rj4km8ybpmq1f`. [Run 31665353943](https://github.com/openclaw/openclaw/actions/runs/31665353943)
- Post-rebase combined invocation: 5 files, 61 tests passed.
- `git diff --check`: clean.
- Codex autoreview: clean, no accepted/actionable findings.

Production LOC: +0/-0 | Tests: +20/-4
