### PR TITLE
fix: isolated gateways list and open the operator's HOME Claude/Codex/OpenCode/Pi sessions

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"29e2f1aadc64c83fccf94d7fb4747b10e31bbe0922f4806ed3f23d8c1698e6c3","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}
+{"contentHash":"bcf629bcca94f799413fbbaf04e8de1cedd710857a00c0f64c882ba48df44f73","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
@@ -1,1 +1,1 @@
-{"contentHash":"8407ad2fc13c783155999acdbef231efe60ba69538448a955ff5f10888e51d31","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
+{"contentHash":"b7216755fd4c83a2a81fe41623235bef67d0988d9e5e26901a43e65e95860ec9","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-core.json
@@ -1,1 +1,1 @@
-{"contentHash":"f44495c27167838fbcdb0ba6afaafd770689e33bb57f725b45b8f9ac20af1565","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}
+{"contentHash":"cedc6067e323a9f9ff0c61cb737cc2ad973b70ebf5b5ae29f187eedc27f9b882","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
@@ -1,1 +1,1 @@
-{"contentHash":"29b2feadc45ec3f6c9a7281839142334bf1f8d4ab5fddbed200e99c5e2c51407","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}
+{"contentHash":"7a0f0878e1913fd0e541464f4b575c181fadf8f885d47678f1414f62abdf0f6d","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-message.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-message.json
@@ -1,1 +1,1 @@
-{"contentHash":"90a7e6988de562edab9ee28696207bba9fba6d83488dc62d9e0b893ca9603dc6","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}
+{"contentHash":"5505267ebfe5ee6386f84e2ea0324ff5000cf90b136125bab12310ba383b6bc9","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"43cedd1b0efa245682de25aa7922045223c58a004bd6a424f1c98968f50396bf","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}
+{"contentHash":"1bbe3bf5aad5279c01062cccb192a2e747c48901b0e0e9c85d8cd5f893e60d30","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
@@ -1,1 +1,1 @@
-{"contentHash":"f478b7aa4001f84bb97202d38a75807a67afc2f2c07e074f9121f30298e7493f","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}
+{"contentHash":"007d38922f73a566bb2a9402b91076cbc6b0b1dfc3ca163064270580e965297f","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}

--- a/docs/.generated/plugin-sdk-api-baseline/core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/core.json
@@ -1,1 +1,1 @@
-{"contentHash":"41d0227914b1eaf4f05dcbc6a92cbe1c824ae9415df8472a5edc0492f5b764ca","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}
+{"contentHash":"13e4fbbec6d396ef71c145c559e4f0930689bc1ac52bf683f61f5358dd184227","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}

--- a/docs/.generated/plugin-sdk-api-baseline/discord.json
+++ b/docs/.generated/plugin-sdk-api-baseline/discord.json
@@ -1,1 +1,1 @@
-{"contentHash":"2e71c5a50c2efb3af7410ffb1cf7b6a6321b4f279c78ab5377fc984321251697","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}
+{"contentHash":"9579726261565d48b97f87df9bec5e478e0185b35ebe6174f6cd790f6d3d346b","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}

--- a/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
+++ b/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
@@ -1,1 +1,1 @@
-{"contentHash":"afddb2d3e7f79b386ed6074f45f85419a0bcae5a6ce49c0157524851c7261d5e","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}
+{"contentHash":"268064ce1cf518a41eba3339543738cd2506f7910e0c436423d4d2ddf62d26e9","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}

--- a/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"a3a31f78a73ea9159d1779d354b84cff1036741ee3980367c5effc4dd29b1b67","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}
+{"contentHash":"07f0c3ef253015b7a8ca8360278b56417866f3b059cd27bc4823241583da2646","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
@@ -1,1 +1,1 @@
-{"contentHash":"64593f3e4ff693f2041d34fd5f3ee6e96795b9b2d49bbd60173d89da7d203494","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}
+{"contentHash":"a0b5e14ab9c15348f2a1005cb20c4115e5071b6284da9f888938c5a4ce4a0218","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"9e2037874e2efb4faa53078d6c71089927097ccf08ecb4ba5ca9bd3f4b64414a","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}
+{"contentHash":"89a926ac4304d771613473b4755b73eba0c443cb305cd97e40c41d88a93aa766","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"bd3c786f5753a95f03474833f1f5a8872c55ebdf3d541b96c558843e06d3aa44","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
+{"contentHash":"fb10154545dfef389f729c4e5d8683c0c3357761d8bdf63cc1e715b810fc107d","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/session-catalog.json
+++ b/docs/.generated/plugin-sdk-api-baseline/session-catalog.json
@@ -1,1 +1,1 @@
-{"contentHash":"b8218ab6c7789147d0ced29d4dfa1487af511a2a91f12808587ee97c702947c9","entrypoint":"session-catalog","importSpecifier":"openclaw/plugin-sdk/session-catalog"}
+{"contentHash":"f9eace4c0775da39877c48bee9cfffad21fa1bd1641a851184f3d83e685e88e7","entrypoint":"session-catalog","importSpecifier":"openclaw/plugin-sdk/session-catalog"}

--- a/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
+++ b/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
@@ -1,1 +1,1 @@
-{"contentHash":"abf5f77043e2e1b8210541ed48d6ab5e22ec475bf05484d5f6103f82cfdd9f38","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}
+{"contentHash":"811714654c527b871c1bcb61f96c94df1537035662894331535cc90c6027c401","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}

--- a/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
+++ b/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
@@ -1,1 +1,1 @@
-{"contentHash":"9c8a8d0ccdb9961abc35ca210b183a307df34e4ca2b1cf645d5db652cd7f8677","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}
+{"contentHash":"44a967b354fe930b97c169391484abe321732720f84cebbbeb288eb84562e6fe","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}

--- a/extensions/acpx/src/pi-session-catalog-plugin.ts
+++ b/extensions/acpx/src/pi-session-catalog-plugin.ts
@@ -102,11 +102,12 @@ export function registerPiSessionCatalog(api: OpenClawPluginApi): void {
   const provider: SessionCatalogProvider = {
     id: "pi",
     label: "Pi",
+    supportsProcessHomeIsolation: true,
     list: async (query) => await (await loadCatalogRuntime()).list(query),
     read: async (request) => await (await loadCatalogRuntime()).read(request),
     continueSession: async (request) => await (await loadCatalogRuntime()).continueSession(request),
-    checkUpstreamActivity: async (probes) =>
-      await (await loadCatalogRuntime()).checkUpstreamActivity(probes),
+    checkUpstreamActivity: async (probes, policy) =>
+      await (await loadCatalogRuntime()).checkUpstreamActivity(probes, policy),
     openTerminal: async (request) => await (await loadCatalogRuntime()).openTerminal(request),
   };
   api.registerSessionCatalog(provider);

--- a/extensions/acpx/src/pi-session-catalog-runtime.ts
+++ b/extensions/acpx/src/pi-session-catalog-runtime.ts
@@ -37,7 +37,7 @@ import {
   readLocalPiTranscriptPage,
   type PiSessionPage,
 } from "./pi-session-catalog.js";
-import { piSessionStoreAvailable } from "./pi-session-paths.js";
+import { piSessionStore, piSessionStoreAvailable } from "./pi-session-paths.js";
 import { checkPiUpstreamActivity, linkContinuedPiSession } from "./pi-session-upstream-activity.js";
 
 const LOCAL_HOST_ID = "gateway";
@@ -248,7 +248,13 @@ async function listPiHosts(
   const canContinue = resolvePiContinuationAvailability(api).available;
   const requested = query.hostIds ? new Set(query.hostIds) : undefined;
   const hosts: SessionCatalogHost[] = [];
-  if ((!requested || requested.has(LOCAL_HOST_ID)) && piSessionStoreAvailable(process.env)) {
+  const wantsLocal = !requested || requested.has(LOCAL_HOST_ID);
+  const localStore = wantsLocal ? piSessionStore(process.env) : undefined;
+  if (
+    localStore &&
+    (query.allowProcessHomeFallback !== false || !localStore.usesProcessHomeFallback) &&
+    piSessionStoreAvailable(process.env, localStore)
+  ) {
     try {
       hosts.push({
         hostId: LOCAL_HOST_ID,
@@ -507,6 +513,7 @@ async function readPiTranscript(
     throw new Error("cursor is invalid");
   }
   if (request.hostId === LOCAL_HOST_ID) {
+    assertPiLocalAccess(request.hostId, request.allowProcessHomeFallback);
     return await readLocalPiTranscriptPage({
       threadId: request.threadId,
       ...(request.limit ? { limit: request.limit } : {}),
@@ -542,6 +549,16 @@ async function readPiTranscript(
     hostId: request.hostId,
     label: nodeLabel(node),
   };
+}
+
+function assertPiLocalAccess(hostId: string, allowProcessHomeFallback?: boolean): void {
+  if (
+    hostId === LOCAL_HOST_ID &&
+    allowProcessHomeFallback === false &&
+    piSessionStore(process.env).usesProcessHomeFallback
+  ) {
+    throw new PiCatalogParamsError("local Pi sessions are unavailable in isolated state");
+  }
 }
 
 export async function listPiSessions(paramsJSON?: string | null): Promise<string> {
@@ -587,10 +604,23 @@ export function createPiSessionCatalogRuntime(api: OpenClawPluginApi) {
   return {
     list: async (query) => await listPiHosts(api, query),
     read: async (request) => await readPiTranscript(api.runtime, request),
-    continueSession: async (request) =>
-      await continuePiSession(api, request.hostId, request.threadId),
-    checkUpstreamActivity: checkPiUpstreamActivity,
-    openTerminal: async (request) => await openPiTerminal({ runtime: api.runtime, ...request }),
+    continueSession: async (request) => {
+      assertPiLocalAccess(request.hostId, request.allowProcessHomeFallback);
+      return await continuePiSession(api, request.hostId, request.threadId);
+    },
+    checkUpstreamActivity: (probes, policy) =>
+      checkPiUpstreamActivity(
+        probes.filter(
+          (probe) =>
+            probe.hostId !== LOCAL_HOST_ID ||
+            policy?.allowProcessHomeFallback !== false ||
+            !piSessionStore(process.env).usesProcessHomeFallback,
+        ),
+      ),
+    openTerminal: async (request) => {
+      assertPiLocalAccess(request.hostId, request.allowProcessHomeFallback);
+      return await openPiTerminal({ runtime: api.runtime, ...request });
+    },
   } satisfies Pick<
     SessionCatalogProvider,
     "list" | "read" | "continueSession" | "checkUpstreamActivity" | "openTerminal"

--- a/extensions/acpx/src/pi-session-catalog.test.ts
+++ b/extensions/acpx/src/pi-session-catalog.test.ts
@@ -193,11 +193,35 @@ describe("Pi session catalog", () => {
       registerNodeInvokePolicy: vi.fn(),
     } as unknown as OpenClawPluginApi);
     await expect(
-      provider!.read({ hostId: "gateway", threadId: "pi-session", limit: 2 }),
+      provider!.read({
+        allowProcessHomeFallback: false,
+        hostId: "gateway",
+        threadId: "pi-session",
+        limit: 2,
+      }),
     ).resolves.toMatchObject({ threadId: "pi-session", items: expect.any(Array) });
-    await expect(provider!.list({})).resolves.toEqual([
+    await expect(provider!.list({ allowProcessHomeFallback: false })).resolves.toEqual([
       expect.objectContaining({ hostId: "gateway", sessions: [expect.any(Object)] }),
     ]);
+
+    delete process.env.PI_CODING_AGENT_SESSION_DIR;
+    delete process.env.PI_CODING_AGENT_DIR;
+    process.env.HOME = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pi-isolated-home-"));
+    temporaryDirectories.push(process.env.HOME);
+    await expect(
+      provider!.continueSession?.({
+        allowProcessHomeFallback: false,
+        hostId: "gateway",
+        threadId: "pi-session",
+      }),
+    ).rejects.toThrow("local Pi sessions are unavailable in isolated state");
+    await expect(
+      provider!.openTerminal?.({
+        allowProcessHomeFallback: false,
+        hostId: "gateway",
+        threadId: "pi-session",
+      }),
+    ).rejects.toThrow("local Pi sessions are unavailable in isolated state");
   });
 
   it("recognizes Pi sessions when the agent directory uses a symlinked path", async () => {

--- a/extensions/acpx/src/pi-session-catalog.test.ts
+++ b/extensions/acpx/src/pi-session-catalog.test.ts
@@ -204,24 +204,18 @@ describe("Pi session catalog", () => {
       expect.objectContaining({ hostId: "gateway", sessions: [expect.any(Object)] }),
     ]);
 
-    delete process.env.PI_CODING_AGENT_SESSION_DIR;
-    delete process.env.PI_CODING_AGENT_DIR;
+    for (const key of ["PI_CODING_AGENT_SESSION_DIR", "PI_CODING_AGENT_DIR"] as const) {
+      delete process.env[key];
+    }
     process.env.HOME = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pi-isolated-home-"));
     temporaryDirectories.push(process.env.HOME);
-    await expect(
-      provider!.continueSession?.({
-        allowProcessHomeFallback: false,
-        hostId: "gateway",
-        threadId: "pi-session",
-      }),
-    ).rejects.toThrow("local Pi sessions are unavailable in isolated state");
-    await expect(
-      provider!.openTerminal?.({
-        allowProcessHomeFallback: false,
-        hostId: "gateway",
-        threadId: "pi-session",
-      }),
-    ).rejects.toThrow("local Pi sessions are unavailable in isolated state");
+    const request = { hostId: "gateway", threadId: "pi-session" };
+    const isolatedRequest = { ...request, allowProcessHomeFallback: false };
+    for (const operation of [provider!.continueSession, provider!.openTerminal]) {
+      await expect(operation?.(isolatedRequest)).rejects.toThrow(
+        "local Pi sessions are unavailable in isolated state",
+      );
+    }
   });
 
   it("recognizes Pi sessions when the agent directory uses a symlinked path", async () => {

--- a/extensions/acpx/src/pi-session-paths.test.ts
+++ b/extensions/acpx/src/pi-session-paths.test.ts
@@ -36,6 +36,7 @@ describe("Pi session paths", () => {
     expect(piSessionStore({ PI_CODING_AGENT_DIR: `  ${agentDir}  ` })).toEqual({
       root: path.join(agentDir, "sessions"),
       flat: false,
+      usesProcessHomeFallback: false,
     });
   });
 
@@ -57,6 +58,7 @@ describe("Pi session paths", () => {
     expect(piSessionStore(env, projectDirectory)).toEqual({
       root: path.join(projectDirectory, ".pi", "sessions"),
       flat: true,
+      usesProcessHomeFallback: false,
     });
 
     await fs.rm(path.join(projectDirectory, ".pi", "settings.json"));
@@ -67,6 +69,16 @@ describe("Pi session paths", () => {
     expect(piSessionStore(env, projectDirectory)).toEqual({
       root: path.join(agentDirectory, "custom-sessions"),
       flat: true,
+      usesProcessHomeFallback: false,
     });
+  });
+
+  it("marks only the default home-derived store as a process-HOME fallback", () => {
+    const home = path.join(os.tmpdir(), "pi-home");
+    expect(piSessionStore({ HOME: home }).usesProcessHomeFallback).toBe(true);
+    expect(
+      piSessionStore({ HOME: home, PI_CODING_AGENT_SESSION_DIR: path.join(home, "sessions") })
+        .usesProcessHomeFallback,
+    ).toBe(false);
   });
 });

--- a/extensions/acpx/src/pi-session-paths.ts
+++ b/extensions/acpx/src/pi-session-paths.ts
@@ -56,10 +56,14 @@ function settingsSessionDir(file: string): string | undefined {
 export function piSessionStore(
   env: NodeJS.ProcessEnv,
   cwd = process.cwd(),
-): { root: string; flat: boolean } {
+): { root: string; flat: boolean; usesProcessHomeFallback: boolean } {
   const customSessionDir = env.PI_CODING_AGENT_SESSION_DIR?.trim();
   if (customSessionDir) {
-    return { root: resolveConfiguredPath(customSessionDir, env), flat: true };
+    return {
+      root: resolveConfiguredPath(customSessionDir, env),
+      flat: true,
+      usesProcessHomeFallback: false,
+    };
   }
   const home = piHome(env);
   const customAgentDir = env.PI_CODING_AGENT_DIR?.trim();
@@ -71,15 +75,21 @@ export function piSessionStore(
     return {
       root: resolveConfiguredPath(projectSessionDir, env, path.join(cwd, ".pi")),
       flat: true,
+      usesProcessHomeFallback: false,
     };
   }
   const globalSessionDir = settingsSessionDir(path.join(agentDir, "settings.json"));
   if (globalSessionDir) {
-    return { root: resolveConfiguredPath(globalSessionDir, env, agentDir), flat: true };
+    return {
+      root: resolveConfiguredPath(globalSessionDir, env, agentDir),
+      flat: true,
+      usesProcessHomeFallback: false,
+    };
   }
   return {
     root: path.join(agentDir, "sessions"),
     flat: false,
+    usesProcessHomeFallback: !customAgentDir,
   };
 }
 
@@ -99,9 +109,12 @@ export function piAcpSessionStoreRoot(env: NodeJS.ProcessEnv): string | undefine
   return path.join(agentDir, "sessions");
 }
 
-export function piSessionStoreAvailable(env: NodeJS.ProcessEnv): boolean {
+export function piSessionStoreAvailable(
+  env: NodeJS.ProcessEnv,
+  store?: ReturnType<typeof piSessionStore>,
+): boolean {
   try {
-    return statSync(piSessionStore(env).root).isDirectory();
+    return statSync((store ?? piSessionStore(env)).root).isDirectory();
   } catch {
     return false;
   }

--- a/extensions/anthropic/session-catalog-registration.ts
+++ b/extensions/anthropic/session-catalog-registration.ts
@@ -43,8 +43,11 @@ function isClaudeSessionCatalogEnabled(pluginConfig: unknown): boolean {
 // Claude session store; otherwise the gateway must skip the node capability.
 function claudeProjectsAvailable(env: NodeJS.ProcessEnv): boolean {
   const homeDir = env.HOME?.trim() || env.USERPROFILE?.trim() || os.homedir();
+  const configDir = env.CLAUDE_CONFIG_DIR?.trim();
   try {
-    return statSync(path.join(homeDir, ".claude", "projects")).isDirectory();
+    return statSync(
+      path.join(configDir ? path.resolve(configDir) : path.join(homeDir, ".claude"), "projects"),
+    ).isDirectory();
   } catch {
     return false;
   }
@@ -62,6 +65,7 @@ function registerClaudeSessionCatalog(api: OpenClawPluginApi): void {
   const provider: SessionCatalogProvider = {
     id: "claude",
     label: "Claude Code",
+    supportsProcessHomeIsolation: true,
     resolveCreateSession: ({ agentId }) =>
       api.runtime.agent.resolveSessionCatalogCreateTarget({
         config: currentConfig(api),
@@ -76,8 +80,8 @@ function registerClaudeSessionCatalog(api: OpenClawPluginApi): void {
     startTerminalSession: async (request) =>
       await (await loadCatalogRuntime()).startTerminalSession(request),
     openTerminal: async (request) => await (await loadCatalogRuntime()).openTerminal(request),
-    checkUpstreamActivity: async (probes) =>
-      await (await loadCatalogRuntime()).checkUpstreamActivity(probes),
+    checkUpstreamActivity: async (probes, policy) =>
+      await (await loadCatalogRuntime()).checkUpstreamActivity(probes, policy),
   };
   api.registerSessionCatalog(provider);
 }

--- a/extensions/anthropic/session-catalog.test.ts
+++ b/extensions/anthropic/session-catalog.test.ts
@@ -69,6 +69,7 @@ function captureCatalogProvider(runtime: PluginRuntime): SessionCatalogProvider 
 const homes: string[] = [];
 const originalHome = process.env.HOME;
 const originalPath = process.env.PATH;
+const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
 const nodeHostMocks = vi.hoisted(() => ({
   runNodePtyCommand: vi.fn(async () => ({ exitCode: 0 })),
   userShellPaths: new Map<string, string>(),
@@ -491,6 +492,11 @@ afterEach(async () => {
   nodeHostMocks.userShellPaths.clear();
   process.env.HOME = originalHome;
   process.env.PATH = originalPath;
+  if (originalClaudeConfigDir === undefined) {
+    delete process.env.CLAUDE_CONFIG_DIR;
+  } else {
+    process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+  }
   await Promise.all(homes.splice(0).map((home) => fs.rm(home, { recursive: true, force: true })));
 });
 
@@ -542,6 +548,42 @@ describe("Claude session catalog", () => {
         [adoptedSourceKey("node:node-a", threadId), "agent:main:node"],
       ]),
     );
+  });
+
+  it("lists an explicit CLAUDE_CONFIG_DIR while isolated", async () => {
+    const home = await createHome();
+    const configParent = await createHome();
+    const sessionId = "explicit-config-root";
+    await writeProject({
+      home: configParent,
+      entries: [{ sessionId, summary: "Explicit config session", isSidechain: false }],
+      transcripts: { [sessionId]: [message(sessionId, "user", "explicit root", 1)] },
+    });
+    await writeDesktopMetadata(home, "private", {
+      cliSessionId: sessionId,
+      sessionId: "desktop-private",
+      title: "Private desktop title",
+    });
+    process.env.HOME = home;
+    process.env.CLAUDE_CONFIG_DIR = path.join(configParent, ".claude");
+    const provider = captureCatalogProvider({
+      nodes: { list: vi.fn().mockResolvedValue({ nodes: [] }) },
+    } as unknown as PluginRuntime);
+
+    await expect(
+      provider.list({ allowProcessHomeFallback: false, hostIds: ["gateway:local"] }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        hostId: "gateway:local",
+        sessions: [
+          expect.objectContaining({
+            threadId: sessionId,
+            name: "Explicit config session",
+            source: "claude-cli",
+          }),
+        ],
+      }),
+    ]);
   });
 
   it("preserves date-first parsing for numeric-looking index timestamps", async () => {
@@ -2601,7 +2643,7 @@ describe("Claude session catalog", () => {
     ]);
   });
 
-  it("omits the Gateway's same-install node host from native discovery", async () => {
+  it("keeps remote nodes while isolated state suppresses local HOME discovery", async () => {
     const home = await createHome();
     process.env.HOME = home;
     const invoke = vi.fn(async ({ nodeId }: { nodeId: string }) => ({
@@ -2639,9 +2681,47 @@ describe("Claude session catalog", () => {
       },
     } as unknown as PluginRuntime);
 
-    const hosts = await provider.list({});
+    const hosts = await provider.list({ allowProcessHomeFallback: false });
 
-    expect(hosts.map((host) => host.hostId)).toEqual(["gateway:local", "node:remote-node"]);
+    expect(hosts.map((host) => host.hostId)).toEqual(["node:remote-node"]);
+    await expect(
+      provider.read({
+        allowProcessHomeFallback: false,
+        hostId: "gateway:local",
+        threadId: "private-thread",
+      }),
+    ).rejects.toThrow("local Claude sessions are unavailable in isolated state");
+    await expect(
+      provider.continueSession?.({
+        allowProcessHomeFallback: false,
+        hostId: "gateway:local",
+        threadId: "private-thread",
+      }),
+    ).rejects.toThrow("local Claude sessions are unavailable in isolated state");
+    await expect(
+      provider.openTerminal?.({
+        allowProcessHomeFallback: false,
+        hostId: "gateway:local",
+        threadId: "private-thread",
+      }),
+    ).rejects.toThrow("local Claude sessions are unavailable in isolated state");
+    await expect(
+      provider.startTerminalSession?.({
+        allowProcessHomeFallback: false,
+        agentId: "main",
+        cwd: process.cwd(),
+      }),
+    ).rejects.toThrow("local Claude sessions are unavailable in isolated state");
+    // Node starts are outside the process-HOME guard: they must surface the
+    // truthful capability error, not the isolation rejection.
+    await expect(
+      provider.startTerminalSession?.({
+        allowProcessHomeFallback: false,
+        agentId: "main",
+        cwd: process.cwd(),
+        nodeId: "remote-node",
+      }),
+    ).rejects.toThrow("Paired-node Claude terminal start is unavailable");
     expect(invoke).toHaveBeenCalledTimes(1);
     expect(invoke).toHaveBeenCalledWith(expect.objectContaining({ nodeId: "remote-node" }));
   });

--- a/extensions/anthropic/session-catalog.ts
+++ b/extensions/anthropic/session-catalog.ts
@@ -426,8 +426,8 @@ async function childDirectories(root: string): Promise<string[]> {
   }
 }
 
-function projectsDir(homeDir: string): string {
-  return path.join(homeDir, ".claude", "projects");
+function projectsDir(homeDir: string, configDir?: string): string {
+  return path.join(configDir ?? path.join(homeDir, ".claude"), "projects");
 }
 
 async function readProjectsTreeSnapshot(root: string): Promise<ClaudeProjectsTreeSnapshot> {
@@ -512,6 +512,24 @@ function desktopSessionsDir(homeDir: string): string {
 
 function currentHomeDir(env: NodeJS.ProcessEnv = process.env): string {
   return env.HOME?.trim() || env.USERPROFILE?.trim() || os.homedir();
+}
+
+function configuredClaudeConfigDir(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const configured = env.CLAUDE_CONFIG_DIR?.trim();
+  return configured ? path.resolve(configured) : undefined;
+}
+
+function gatewayClaudeScanOptions(allowProcessHomeFallback?: boolean): {
+  configDir?: string;
+  includeDesktop: boolean;
+} {
+  const configDir = configuredClaudeConfigDir();
+  // Upstream Claude Code's "Respect CLAUDE_CONFIG_DIR everywhere" convention replaces ~/.claude.
+  // Claude Desktop stays HOME/Library-scoped, so isolated scans exclude its metadata.
+  return {
+    ...(configDir ? { configDir } : {}),
+    includeDesktop: allowProcessHomeFallback !== false,
+  };
 }
 
 async function readDesktopMetadata(homeDir: string): Promise<{
@@ -907,11 +925,14 @@ async function discoverCliRecords(
 async function scanClaudeSessions(
   homeDir: string,
   snapshot: ClaudeProjectsTreeSnapshot,
+  includeDesktop: boolean,
 ): Promise<{ records: CatalogRecord[]; complete: boolean }> {
   const context: ClaudeSessionScanContext = { ...snapshot, complete: true, safeFiles: new Map() };
   const [indexed, desktop] = await Promise.all([
     readIndexRecords(context),
-    readDesktopMetadata(homeDir),
+    includeDesktop
+      ? readDesktopMetadata(homeDir)
+      : Promise.resolve({ active: new Map(), archived: new Set<string>() }),
   ]);
   const records = indexed.records;
   await discoverCliRecords(context, records, indexed.sidechainIds);
@@ -963,15 +984,17 @@ async function scanClaudeSessions(
 
 async function listClaudeSessions(
   homeDir = currentHomeDir(),
-  options: { forceRefresh?: boolean } = {},
+  options: { forceRefresh?: boolean; configDir?: string; includeDesktop?: boolean } = {},
 ): Promise<CatalogRecord[]> {
-  const root = projectsDir(homeDir);
+  const root = projectsDir(homeDir, options.configDir);
+  const includeDesktop = options.includeDesktop !== false;
+  const cacheKey = `${root}\0${includeDesktop ? "desktop" : "cli"}`;
   const [treeSnapshot, desktopStoreAvailable] = await Promise.all([
     readProjectsTreeSnapshot(root),
-    desktopSessionStoreAvailable(homeDir),
+    includeDesktop ? desktopSessionStoreAvailable(homeDir) : Promise.resolve(false),
   ]);
   const now = Date.now();
-  const cached = claudeSessionScanCache.get(root);
+  const cached = claudeSessionScanCache.get(cacheKey);
   // Child membership + file mtime/size signatures invalidate CLI rows on the next poll; five minutes
   // backstops metadata anomalies. Desktop has a 60s bound when its macOS store exists; Linux skips it.
   // Specific-thread force refresh bypasses both, or a stale page could hide a just-created session.
@@ -983,10 +1006,15 @@ async function listClaudeSessions(
     cached.desktopStoreAvailable === desktopStoreAvailable &&
     (!desktopStoreAvailable || cached.desktopExpiresAt > now)
   ) {
-    setBoundedCache(claudeSessionScanCache, root, cached, MAX_CLAUDE_SESSION_SCAN_CACHE_ENTRIES);
+    setBoundedCache(
+      claudeSessionScanCache,
+      cacheKey,
+      cached,
+      MAX_CLAUDE_SESSION_SCAN_CACHE_ENTRIES,
+    );
     return await cached.records;
   }
-  const scan = scanClaudeSessions(homeDir, treeSnapshot);
+  const scan = scanClaudeSessions(homeDir, treeSnapshot, includeDesktop);
   let scanComplete = true;
   const records = scan.then((result) => {
     scanComplete = result.complete;
@@ -999,18 +1027,18 @@ async function listClaudeSessions(
     desktopExpiresAt: now + CLAUDE_DESKTOP_SCAN_TTL_MS,
     records,
   };
-  setBoundedCache(claudeSessionScanCache, root, entry, MAX_CLAUDE_SESSION_SCAN_CACHE_ENTRIES);
+  setBoundedCache(claudeSessionScanCache, cacheKey, entry, MAX_CLAUDE_SESSION_SCAN_CACHE_ENTRIES);
   try {
     const result = await records;
-    if (!scanComplete && claudeSessionScanCache.get(root) === entry) {
+    if (!scanComplete && claudeSessionScanCache.get(cacheKey) === entry) {
       // Partial results still serve this caller, but retry within 15s so transient per-file I/O
       // cannot hide recovered sessions behind the five-minute unchanged-tree backstop.
       entry.hardExpiresAt = Date.now() + CLAUDE_PARTIAL_SCAN_TTL_MS;
     }
     return result;
   } catch (error) {
-    if (claudeSessionScanCache.get(root) === entry) {
-      claudeSessionScanCache.delete(root);
+    if (claudeSessionScanCache.get(cacheKey) === entry) {
+      claudeSessionScanCache.delete(cacheKey);
     }
     throw error;
   }
@@ -1093,12 +1121,16 @@ function readListParams(value: unknown): {
 
 export async function listLocalClaudeSessionPage(
   value: unknown,
-  homeDir = currentHomeDir(),
+  homeDir?: string,
+  scanOptions?: { configDir?: string; includeDesktop?: boolean },
 ): Promise<ClaudeSessionCatalogPage> {
+  const resolvedHome = homeDir ?? currentHomeDir();
+  const resolvedScanOptions =
+    scanOptions ?? (homeDir === undefined ? gatewayClaudeScanOptions(true) : {});
   const params = readListParams(value);
   const offset = decodeOffset(params.cursor, "catalog");
   const search = params.searchTerm?.toLocaleLowerCase();
-  const records = (await listClaudeSessions(homeDir)).filter((record) => {
+  const records = (await listClaudeSessions(resolvedHome, resolvedScanOptions)).filter((record) => {
     if (!search) {
       return true;
     }
@@ -1147,18 +1179,22 @@ function readTranscriptParams(
 
 export async function readLocalClaudeTranscriptPage(
   value: unknown,
-  homeDir = currentHomeDir(),
+  homeDir?: string,
+  scanOptions?: { configDir?: string; includeDesktop?: boolean },
 ): Promise<Omit<ClaudeSessionTranscriptPage, "hostId" | "label">> {
+  const resolvedHome = homeDir ?? currentHomeDir();
+  const resolvedScanOptions =
+    scanOptions ?? (homeDir === undefined ? gatewayClaudeScanOptions(true) : {});
   const params = readTranscriptParams(value);
-  let filePath = (await listClaudeSessions(homeDir)).find(
+  let filePath = (await listClaudeSessions(resolvedHome, resolvedScanOptions)).find(
     (record) => record.threadId === params.threadId,
   )?.filePath;
   if (!filePath) {
     // A just-created session can race the stamp snapshot. Specific reads must retry against disk so
     // opening a new thread never fails only because the assembled catalog is still warm.
-    filePath = (await listClaudeSessions(homeDir, { forceRefresh: true })).find(
-      (record) => record.threadId === params.threadId,
-    )?.filePath;
+    filePath = (
+      await listClaudeSessions(resolvedHome, { ...resolvedScanOptions, forceRefresh: true })
+    ).find((record) => record.threadId === params.threadId)?.filePath;
   }
   if (!filePath) {
     throw new ClaudeCatalogParamsError("Claude session is unavailable");
@@ -1421,13 +1457,16 @@ function parseGatewayQuery(value: unknown): {
 async function listClaudeSessionCatalog(params: {
   runtime: PluginRuntime;
   query?: unknown;
+  allowProcessHomeFallback?: boolean;
   listNodes?: Parameters<SessionCatalogProvider["list"]>[0]["listNodes"];
   onHost?: (host: ClaudeSessionCatalogHost) => void;
 }): Promise<ClaudeSessionCatalogResult> {
   const query = parseGatewayQuery(params.query);
   const requested = query.hostIds ? new Set(query.hostIds) : undefined;
+  const scanOptions = gatewayClaudeScanOptions(params.allowProcessHomeFallback);
   const localHosts: Promise<ClaudeSessionCatalogHost>[] =
-    !requested || requested.has(CLAUDE_LOCAL_SESSION_HOST_ID)
+    (params.allowProcessHomeFallback !== false || scanOptions.configDir !== undefined) &&
+    (!requested || requested.has(CLAUDE_LOCAL_SESSION_HOST_ID))
       ? [
           (async () => {
             try {
@@ -1436,13 +1475,17 @@ async function listClaudeSessionCatalog(params: {
                 label: "Local Claude",
                 kind: "gateway",
                 connected: true,
-                ...(await listLocalClaudeSessionPage({
-                  limit: query.limitPerHost,
-                  ...(query.search ? { searchTerm: query.search } : {}),
-                  ...(query.cursors?.[CLAUDE_LOCAL_SESSION_HOST_ID] !== undefined
-                    ? { cursor: query.cursors[CLAUDE_LOCAL_SESSION_HOST_ID] }
-                    : {}),
-                })),
+                ...(await listLocalClaudeSessionPage(
+                  {
+                    limit: query.limitPerHost,
+                    ...(query.search ? { searchTerm: query.search } : {}),
+                    ...(query.cursors?.[CLAUDE_LOCAL_SESSION_HOST_ID] !== undefined
+                      ? { cursor: query.cursors[CLAUDE_LOCAL_SESSION_HOST_ID] }
+                      : {}),
+                  },
+                  currentHomeDir(),
+                  scanOptions,
+                )),
               };
             } catch {
               return {
@@ -1574,17 +1617,23 @@ async function readClaudeSessionTranscript(params: {
   threadId: string;
   cursor?: string;
   limit: number;
+  allowProcessHomeFallback?: boolean;
 }): Promise<ClaudeSessionTranscriptPage> {
   const cursor = readOptionalCursor(params.cursor, "transcript");
   if (params.hostId === CLAUDE_LOCAL_SESSION_HOST_ID) {
+    assertClaudeLocalAccess(params.hostId, params.allowProcessHomeFallback);
     return {
       hostId: params.hostId,
       label: "Local Claude",
-      ...(await readLocalClaudeTranscriptPage({
-        threadId: params.threadId,
-        limit: params.limit,
-        ...(cursor !== undefined ? { cursor } : {}),
-      })),
+      ...(await readLocalClaudeTranscriptPage(
+        {
+          threadId: params.threadId,
+          limit: params.limit,
+          ...(cursor !== undefined ? { cursor } : {}),
+        },
+        currentHomeDir(),
+        gatewayClaudeScanOptions(params.allowProcessHomeFallback),
+      )),
     };
   }
   if (!params.hostId.startsWith("node:")) {
@@ -1632,10 +1681,21 @@ async function readClaudeSessionTranscript(params: {
   };
 }
 
+function assertClaudeLocalAccess(hostId: string, allowProcessHomeFallback?: boolean): void {
+  if (
+    hostId === CLAUDE_LOCAL_SESSION_HOST_ID &&
+    allowProcessHomeFallback === false &&
+    configuredClaudeConfigDir() === undefined
+  ) {
+    throw new ClaudeCatalogParamsError("local Claude sessions are unavailable in isolated state");
+  }
+}
+
 async function readBoundedClaudeHistory(params: {
   runtime: PluginRuntime;
   hostId: string;
   threadId: string;
+  allowProcessHomeFallback?: boolean;
 }): Promise<ClaudeTranscriptItem[]> {
   const items: ClaudeTranscriptItem[] = [];
   let cursor: string | undefined;
@@ -1646,6 +1706,7 @@ async function readBoundedClaudeHistory(params: {
       hostId: params.hostId,
       threadId: params.threadId,
       limit: Math.min(MAX_TRANSCRIPT_LIMIT, CLAUDE_HISTORY_IMPORT_MAX_ITEMS - items.length),
+      allowProcessHomeFallback: params.allowProcessHomeFallback,
       ...(cursor ? { cursor } : {}),
     });
     for (const item of page.items) {
@@ -1699,7 +1760,9 @@ async function continueClaudeSession(
   api: OpenClawPluginApi,
   hostId: string,
   threadId: string,
+  allowProcessHomeFallback?: boolean,
 ): Promise<{ sessionKey: string }> {
+  const scanOptions = gatewayClaudeScanOptions(allowProcessHomeFallback);
   const sourceKey = adoptedSourceKey(hostId, threadId);
   const linkSession = async (sessionKey: string, history?: ClaudeTranscriptItem[]) =>
     await upstream.linkContinued({
@@ -1707,10 +1770,17 @@ async function continueClaudeSession(
       hostId,
       threadId,
       ...(history ? { history } : {}),
-      listLocalSessions: listClaudeSessions,
+      listLocalSessions: () => listClaudeSessions(currentHomeDir(), scanOptions),
       readRemote: async () =>
-        (await readClaudeSessionTranscript({ runtime: api.runtime, hostId, threadId, limit: 1 }))
-          .items,
+        (
+          await readClaudeSessionTranscript({
+            runtime: api.runtime,
+            hostId,
+            threadId,
+            limit: 1,
+            allowProcessHomeFallback,
+          })
+        ).items,
     });
   const existing = listBoundClaudeSessions(api).get(sourceKey);
   if (existing) {
@@ -1724,7 +1794,9 @@ async function continueClaudeSession(
     let nodeId: string | undefined;
     let record: ClaudeSessionCatalogSession | undefined;
     if (hostId === CLAUDE_LOCAL_SESSION_HOST_ID) {
-      record = (await listClaudeSessions()).find((candidate) => candidate.threadId === threadId);
+      record = (await listClaudeSessions(currentHomeDir(), scanOptions)).find(
+        (candidate) => candidate.threadId === threadId,
+      );
       if (!record || !isResumableClaudeSource(record.source)) {
         throw new ClaudeCatalogParamsError("only local Claude Code sessions can be continued");
       }
@@ -1761,7 +1833,12 @@ async function continueClaudeSession(
         throw new ClaudeCatalogParamsError("Claude session transcript is unavailable");
       }
     }
-    const history = await readBoundedClaudeHistory({ runtime: api.runtime, hostId, threadId });
+    const history = await readBoundedClaudeHistory({
+      runtime: api.runtime,
+      hostId,
+      threadId,
+      allowProcessHomeFallback,
+    });
     const config = currentClaudeSessionCatalogConfig(api);
     const adoptingAgentId = resolveDefaultAgentId(config);
     // Adopt onto the model this agent actually routes to the CLI backend; the
@@ -1915,48 +1992,84 @@ export function createClaudeSessionCatalogRuntime(
     list: async (query) => {
       const adopted = listBoundClaudeSessions(api, query.sessionEntries);
       const localCliAvailable = catalogTerminal.isClaudeCliAvailable();
-      const { listNodes, onHost, sessionEntries: _sessionEntries, ...gatewayQuery } = query;
+      const {
+        allowProcessHomeFallback,
+        listNodes,
+        onHost,
+        sessionEntries: _sessionEntries,
+        ...gatewayQuery
+      } = query;
       const mapHost = (host: ClaudeSessionCatalogHost) =>
         toGenericClaudeHost(host, adopted, localCliAvailable);
       const result = await listClaudeSessionCatalog({
         runtime: api.runtime,
         query: gatewayQuery,
+        allowProcessHomeFallback,
         listNodes,
         ...(onHost ? { onHost: (host) => onHost(mapHost(host)) } : {}),
       });
       return result.hosts.map(mapHost);
     },
     read: async (request) => {
+      const { allowProcessHomeFallback, ...catalogRequest } = request;
       const page = await readClaudeSessionTranscript({
         runtime: api.runtime,
-        hostId: request.hostId,
-        threadId: request.threadId,
-        cursor: request.cursor,
-        limit: request.limit ?? DEFAULT_TRANSCRIPT_LIMIT,
+        hostId: catalogRequest.hostId,
+        threadId: catalogRequest.threadId,
+        cursor: catalogRequest.cursor,
+        limit: catalogRequest.limit ?? DEFAULT_TRANSCRIPT_LIMIT,
+        allowProcessHomeFallback,
       });
       return { ...page, items: page.items.map(toGenericClaudeItem) };
     },
-    continueSession: async (request) =>
-      await continueClaudeSession(api, request.hostId, request.threadId),
-    startTerminalSession: (request) => catalogTerminal.startClaudeCatalogTerminal(request),
-    openTerminal: (request) =>
-      catalogTerminal.openClaudeCatalogTerminal({
+    continueSession: async (request) => {
+      assertClaudeLocalAccess(request.hostId, request.allowProcessHomeFallback);
+      return await continueClaudeSession(
+        api,
+        request.hostId,
+        request.threadId,
+        request.allowProcessHomeFallback,
+      );
+    },
+    startTerminalSession: async (request) => {
+      // Node launches run in the paired node's environment, not gateway HOME;
+      // only local starts fall under the process-HOME isolation guard.
+      if (!request.nodeId) {
+        assertClaudeLocalAccess(CLAUDE_LOCAL_SESSION_HOST_ID, request.allowProcessHomeFallback);
+      }
+      return await catalogTerminal.startClaudeCatalogTerminal(request);
+    },
+    openTerminal: async (request) => {
+      assertClaudeLocalAccess(request.hostId, request.allowProcessHomeFallback);
+      return await catalogTerminal.openClaudeCatalogTerminal({
         api,
         ...request,
-        listClaudeSessions,
+        listClaudeSessions: () =>
+          listClaudeSessions(
+            currentHomeDir(),
+            gatewayClaudeScanOptions(request.allowProcessHomeFallback),
+          ),
         resolveNodeClaudeRecord,
-      }),
-    checkUpstreamActivity: async (probes) =>
-      await upstream.checkClaudeUpstreamActivity(probes, async (probe) => {
+      });
+    },
+    checkUpstreamActivity: async (probes, policy) => {
+      const localAllowed =
+        policy?.allowProcessHomeFallback !== false || configuredClaudeConfigDir() !== undefined;
+      const eligible = probes.filter(
+        (probe) => probe.hostId !== CLAUDE_LOCAL_SESSION_HOST_ID || localAllowed,
+      );
+      return await upstream.checkClaudeUpstreamActivity(eligible, async (probe) => {
         return (
           await readClaudeSessionTranscript({
             runtime: api.runtime,
             hostId: probe.hostId,
             threadId: probe.threadId,
             limit: MAX_TRANSCRIPT_LIMIT,
+            allowProcessHomeFallback: policy?.allowProcessHomeFallback,
           })
         ).items;
-      }),
+      });
+    },
   };
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/beam/src/session-catalog.ts
+++ b/extensions/beam/src/session-catalog.ts
@@ -86,6 +86,7 @@ export function createBeamSessionCatalog(store: BeamStore): SessionCatalogProvid
   return {
     id: "beam",
     label: "Beam",
+    supportsProcessHomeIsolation: true,
     async list(params) {
       const search = params.search?.trim().toLowerCase();
       const sessions = (await store.list())

--- a/extensions/codex/src/session-catalog.test.ts
+++ b/extensions/codex/src/session-catalog.test.ts
@@ -14,6 +14,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import type { SessionCatalogProvider } from "openclaw/plugin-sdk/session-catalog";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveCodexAppServerHomeDir } from "./app-server/auth-start-options.js";
 import { resolveCodexAppServerUserHomeDir } from "./app-server/config.js";
@@ -1163,16 +1164,10 @@ describe("Codex supervision catalog", () => {
       config,
       runtime,
       control,
+      includeLocal: false,
     });
 
     expect(result.hosts).toEqual([
-      {
-        hostId: CODEX_LOCAL_SESSION_HOST_ID,
-        label: "Local Codex",
-        kind: "gateway",
-        connected: true,
-        sessions: [{ threadId: "local", status: "idle", archived: false }],
-      },
       {
         hostId: "node:devbox",
         label: "Dev Box",
@@ -1183,9 +1178,7 @@ describe("Codex supervision catalog", () => {
         sessions: [{ threadId: "remote", name: "Remote task", status: "idle", archived: false }],
       },
     ]);
-    expect(control.listPage).toHaveBeenCalledWith(
-      expect.not.objectContaining({ archived: expect.anything() }),
-    );
+    expect(control.listPage).not.toHaveBeenCalled();
     expect(invoke).toHaveBeenCalledWith(
       expect.objectContaining({
         nodeId: "devbox",
@@ -3362,6 +3355,38 @@ describe("Codex supervision actions", () => {
       model: "openai/gpt-5.6-sol",
       agentRuntime: "codex",
     });
+    await withEnvAsync({ CODEX_HOME: undefined }, async () => {
+      await expect(
+        provider?.continueSession?.({
+          allowProcessHomeFallback: false,
+          hostId: CODEX_LOCAL_SESSION_HOST_ID,
+          threadId: "thread-1",
+          clientScopes: ["operator.admin"],
+        }),
+      ).rejects.toThrow("local Codex sessions are unavailable in isolated state");
+      await expect(
+        provider?.archive?.({
+          allowProcessHomeFallback: false,
+          hostId: CODEX_LOCAL_SESSION_HOST_ID,
+          threadId: "thread-1",
+          confirmNoOtherRunner: true,
+        }),
+      ).rejects.toThrow("local Codex sessions are unavailable in isolated state");
+      await expect(
+        provider?.openTerminal?.({
+          allowProcessHomeFallback: false,
+          hostId: CODEX_LOCAL_SESSION_HOST_ID,
+          threadId: "thread-1",
+        }),
+      ).rejects.toThrow("local Codex sessions are unavailable in isolated state");
+      await expect(
+        provider?.startTerminalSession?.({
+          allowProcessHomeFallback: false,
+          agentId: "main",
+          cwd: process.cwd(),
+        }),
+      ).rejects.toThrow("local Codex sessions are unavailable in isolated state");
+    });
     await expect(
       provider?.archive?.({
         hostId: CODEX_LOCAL_SESSION_HOST_ID,
@@ -3378,6 +3403,7 @@ describe("Codex supervision actions", () => {
     ).resolves.toEqual({ ok: true });
     await expect(
       provider?.archive?.({
+        allowProcessHomeFallback: false,
         hostId: "node:devbox",
         threadId: "thread-remote",
         confirmNoOtherRunner: true,
@@ -3385,6 +3411,7 @@ describe("Codex supervision actions", () => {
     ).rejects.toThrow("paired-node Codex sessions are view-only");
     await expect(
       provider?.continueSession?.({
+        allowProcessHomeFallback: false,
         hostId: "node:devbox",
         threadId: "thread-remote",
         clientScopes: ["operator.admin"],

--- a/extensions/codex/src/session-catalog.ts
+++ b/extensions/codex/src/session-catalog.ts
@@ -598,11 +598,13 @@ async function listCodexSessionCatalog(params: {
   listNodes?: Parameters<SessionCatalogProvider["list"]>[0]["listNodes"];
   onHost?: (host: CodexSessionCatalogHost) => void;
   sessionEntries?: SessionCatalogEntrySnapshot;
+  includeLocal?: boolean;
 }): Promise<CodexSessionCatalogResult> {
   const query = readGatewayParams(params.query);
   const requestedHostIds = query.hostIds ? new Set(query.hostIds) : undefined;
   const localHosts =
-    !requestedHostIds || requestedHostIds.has(CODEX_LOCAL_SESSION_HOST_ID)
+    params.includeLocal !== false &&
+    (!requestedHostIds || requestedHostIds.has(CODEX_LOCAL_SESSION_HOST_ID))
       ? [
           listGatewayHost({
             bindingStore: params.bindingStore,
@@ -1441,9 +1443,28 @@ function registerCodexSessionCatalog(params: {
   getPluginConfig: () => unknown;
   getRuntimeConfig: () => OpenClawConfig | undefined;
 }): void {
+  const usesProcessHomeFallback = () => {
+    const start = resolveCodexSupervisionAppServerRuntimeOptions({
+      pluginConfig: params.getPluginConfig(),
+    }).start;
+    return (
+      start.transport === "stdio" && start.homeScope === "user" && !process.env.CODEX_HOME?.trim()
+    );
+  };
+  const assertLocalAccess = (hostId: string, allowProcessHomeFallback?: boolean) => {
+    if (
+      hostId === CODEX_LOCAL_SESSION_HOST_ID &&
+      allowProcessHomeFallback === false &&
+      usesProcessHomeFallback()
+    ) {
+      throw new CatalogParamsError("local Codex sessions are unavailable in isolated state");
+    }
+  };
+  const checkUpstreamActivity = upstream.createChecker(params);
   const provider: SessionCatalogProvider = {
     id: "codex",
     label: "Codex",
+    supportsProcessHomeIsolation: true,
     resolveCreateSession: ({ agentId }) =>
       resolveCodexCatalogCreateSession(
         params.getRuntimeConfig() ?? (params.api.config as OpenClawConfig),
@@ -1451,7 +1472,8 @@ function registerCodexSessionCatalog(params: {
       ),
     list: async (query) => {
       const localTerminalAvailable = resolveLocalCodexTerminalExecutable() !== undefined;
-      const { listNodes, onHost, sessionEntries, ...gatewayQuery } = query;
+      const { allowProcessHomeFallback, listNodes, onHost, sessionEntries, ...gatewayQuery } =
+        query;
       const mapHost = (host: CodexSessionCatalogHost) =>
         toGenericCatalogHost(host, localTerminalAvailable);
       return (
@@ -1463,22 +1485,26 @@ function registerCodexSessionCatalog(params: {
           query: gatewayQuery,
           listNodes,
           sessionEntries,
+          includeLocal: allowProcessHomeFallback !== false || !usesProcessHomeFallback(),
           ...(onHost ? { onHost: (host) => onHost(mapHost(host)) } : {}),
         })
       ).hosts.map(mapHost);
     },
     read: async (request) => {
+      const { allowProcessHomeFallback, ...catalogRequest } = request;
+      assertLocalAccess(catalogRequest.hostId, allowProcessHomeFallback);
       const page = await readCodexSessionTranscript({
         runtime: params.api.runtime,
         control: params.control,
-        hostId: request.hostId,
-        threadId: request.threadId,
-        cursor: request.cursor,
-        limit: request.limit ?? DEFAULT_TRANSCRIPT_PAGE_LIMIT,
+        hostId: catalogRequest.hostId,
+        threadId: catalogRequest.threadId,
+        cursor: catalogRequest.cursor,
+        limit: catalogRequest.limit ?? DEFAULT_TRANSCRIPT_PAGE_LIMIT,
       });
       return { ...page, items: page.items.map(toGenericTranscriptItem) };
     },
     continueSession: async (request) => {
+      assertLocalAccess(request.hostId, request.allowProcessHomeFallback);
       const config = params.getRuntimeConfig();
       if (!config) {
         throw new Error("OpenClaw runtime config is unavailable");
@@ -1508,8 +1534,17 @@ function registerCodexSessionCatalog(params: {
       });
       return codexUpstreamContinueResult(continued.sessionKey, request.threadId, upstreamBaseline);
     },
-    checkUpstreamActivity: upstream.createChecker(params),
+    checkUpstreamActivity: (probes, policy) =>
+      checkUpstreamActivity(
+        probes.filter(
+          (probe) =>
+            probe.hostId !== CODEX_LOCAL_SESSION_HOST_ID ||
+            policy?.allowProcessHomeFallback !== false ||
+            !usesProcessHomeFallback(),
+        ),
+      ),
     archive: async (request) => {
+      assertLocalAccess(request.hostId, request.allowProcessHomeFallback);
       const runnerConfirmation: unknown = request.confirmNoOtherRunner;
       if (runnerConfirmation !== true) {
         throw new CatalogParamsError(
@@ -1532,21 +1567,28 @@ function registerCodexSessionCatalog(params: {
       });
       return { ok: true };
     },
-    openTerminal: (request) =>
-      openCodexCatalogTerminal({
+    openTerminal: async (request) => {
+      assertLocalAccess(request.hostId, request.allowProcessHomeFallback);
+      return await openCodexCatalogTerminal({
         api: params.api,
         control: params.control,
         getPluginConfig: params.getPluginConfig,
         getRuntimeConfig: params.getRuntimeConfig,
         parseCatalogPage,
         ...request,
-      }),
-    startTerminalSession: (request) =>
-      startCodexCatalogTerminal({
+      });
+    },
+    startTerminalSession: async (request) => {
+      assertLocalAccess(
+        request.nodeId ? `node:${request.nodeId}` : CODEX_LOCAL_SESSION_HOST_ID,
+        request.allowProcessHomeFallback,
+      );
+      return await startCodexCatalogTerminal({
         getPluginConfig: params.getPluginConfig,
         getRuntimeConfig: params.getRuntimeConfig,
         ...request,
-      }),
+      });
+    },
   };
   params.api.registerSessionCatalog(provider);
 }

--- a/extensions/opencode/session-catalog-plugin.ts
+++ b/extensions/opencode/session-catalog-plugin.ts
@@ -171,6 +171,22 @@ function isOpenCodeSessionCatalogEnabled(pluginConfig: unknown): boolean {
   );
 }
 
+function openCodeUsesProcessHomeFallback(env: NodeJS.ProcessEnv): boolean {
+  return !env.OPENCODE_DB?.trim() && !path.isAbsolute(env.XDG_DATA_HOME?.trim() ?? "");
+}
+
+function assertOpenCodeLocalAccess(hostId: string, allowProcessHomeFallback?: boolean): void {
+  if (
+    hostId === LOCAL_HOST_ID &&
+    allowProcessHomeFallback === false &&
+    openCodeUsesProcessHomeFallback(process.env)
+  ) {
+    throw new OpenCodeCatalogParamsError(
+      "local OpenCode sessions are unavailable in isolated state",
+    );
+  }
+}
+
 function createOpenCodeSessionNodeHostCommands(
   api: OpenClawPluginApi,
 ): OpenClawPluginNodeHostCommand[] {
@@ -350,6 +366,7 @@ async function listOpenCodeHosts(
   const hosts: SessionCatalogHost[] = [];
   if (
     (!requested || requested.has(LOCAL_HOST_ID)) &&
+    (query.allowProcessHomeFallback !== false || !openCodeUsesProcessHomeFallback(process.env)) &&
     resolveNodeHostExecutable("opencode", {
       env: process.env,
       pathEnv: process.env.PATH ?? "",
@@ -411,6 +428,7 @@ async function readOpenCodeTranscript(
     throw new Error("cursor is invalid");
   }
   if (request.hostId === LOCAL_HOST_ID) {
+    assertOpenCodeLocalAccess(request.hostId, request.allowProcessHomeFallback);
     return await readLocalOpenCodeTranscriptPage({
       threadId: request.threadId,
       ...(request.limit ? { limit: request.limit } : {}),
@@ -564,18 +582,31 @@ export function registerOpenCodeSessionCatalog(api: OpenClawPluginApi): void {
   api.registerSessionCatalog({
     id: "opencode",
     label: "OpenCode",
+    supportsProcessHomeIsolation: true,
     list: async (query) => await listOpenCodeHosts(api, query),
     read: async (request) => await readOpenCodeTranscript(api.runtime, request),
-    continueSession: async (request) =>
-      await continueOpenCodeSession(api, request.hostId, request.threadId),
-    checkUpstreamActivity: checkOpenCodeUpstreamActivity,
-    openTerminal: async (request) =>
-      await openOpenCodeCatalogTerminal({
+    continueSession: async (request) => {
+      assertOpenCodeLocalAccess(request.hostId, request.allowProcessHomeFallback);
+      return await continueOpenCodeSession(api, request.hostId, request.threadId);
+    },
+    checkUpstreamActivity: (probes, policy) =>
+      checkOpenCodeUpstreamActivity(
+        probes.filter(
+          (probe) =>
+            probe.hostId !== LOCAL_HOST_ID ||
+            policy?.allowProcessHomeFallback !== false ||
+            !openCodeUsesProcessHomeFallback(process.env),
+        ),
+      ),
+    openTerminal: async (request) => {
+      assertOpenCodeLocalAccess(request.hostId, request.allowProcessHomeFallback);
+      return await openOpenCodeCatalogTerminal({
         runtime: api.runtime,
         ...request,
         parseNodeSessionPage,
         unwrapNodePayload,
-      }),
+      });
+    },
   });
   for (const command of createOpenCodeSessionNodeHostCommands(api)) {
     api.registerNodeHostCommand(command);

--- a/extensions/opencode/session-catalog.test.ts
+++ b/extensions/opencode/session-catalog.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import type { SessionTranscriptWriteLockContext } from "openclaw/plugin-sdk/session-transcript-runtime";
+import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 type ResolveAcpSessionAvailability =
@@ -454,6 +455,47 @@ describe("OpenCode session catalog", () => {
     await expect(provider!.list({})).resolves.toEqual([
       expect.objectContaining({ hostId: "gateway", sessions: [expect.any(Object)] }),
     ]);
+  });
+
+  itWithCli("allows a relative OPENCODE_DB as an explicit isolated-state root", async () => {
+    await installFakeOpenCode();
+    const { provider } = captureOpenCodeSessionRegistrations();
+
+    await withEnvAsync(
+      { OPENCODE_DB: undefined, XDG_DATA_HOME: undefined },
+      async () =>
+        await Promise.all([
+          expect(
+            provider!.list({ allowProcessHomeFallback: false, hostIds: ["gateway"] }),
+          ).resolves.toEqual([]),
+          expect(
+            provider!.continueSession?.({
+              allowProcessHomeFallback: false,
+              hostId: "gateway",
+              threadId: "ses_test",
+            }),
+          ).rejects.toThrow("local OpenCode sessions are unavailable in isolated state"),
+          expect(
+            provider!.openTerminal?.({
+              allowProcessHomeFallback: false,
+              hostId: "gateway",
+              threadId: "ses_test",
+            }),
+          ).rejects.toThrow("local OpenCode sessions are unavailable in isolated state"),
+        ]),
+    );
+    await withEnvAsync({ OPENCODE_DB: "relative.db", XDG_DATA_HOME: undefined }, async () => {
+      await expect(
+        provider!.list({ allowProcessHomeFallback: false, hostIds: ["gateway"] }),
+      ).resolves.toEqual([expect.objectContaining({ hostId: "gateway" })]);
+      await expect(
+        provider!.read({
+          allowProcessHomeFallback: false,
+          hostId: "gateway",
+          threadId: "ses_test",
+        }),
+      ).resolves.toMatchObject({ hostId: "gateway", threadId: "ses_test" });
+    });
   });
 
   itWithCli(

--- a/src/config/paths.test.ts
+++ b/src/config/paths.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import { resolveLegacyOAuthPath } from "../agents/auth-profiles/legacy-source-diagnostic.js";
 import { withTestDir } from "../test-helpers/temp-dir.js";
 import {
+  allowsProcessHomeSessionScan,
   CONFIG_PATH,
   DEFAULT_GATEWAY_PORT,
   isDefaultInstallIdentity,
@@ -50,6 +51,7 @@ describe("default install identity", () => {
     const configPath = path.join(stateDir, "openclaw.json");
 
     expect(isDefaultInstallIdentity({ HOME: home }, () => home)).toBe(true);
+    expect(allowsProcessHomeSessionScan({ HOME: home }, () => home)).toBe(true);
     expect(
       isDefaultInstallIdentity(
         { HOME: home, OPENCLAW_STATE_DIR: stateDir, OPENCLAW_CONFIG_PATH: configPath },
@@ -161,6 +163,17 @@ describe("default install identity", () => {
           () => home,
         ),
       ).toBe(true);
+      expect(
+        allowsProcessHomeSessionScan(
+          {
+            HOME: home,
+            OPENCLAW_PROFILE: "work",
+            OPENCLAW_STATE_DIR: profileStateDir,
+            OPENCLAW_CONFIG_PATH: path.join(profileStateDir, "openclaw.json"),
+          },
+          () => home,
+        ),
+      ).toBe(false);
       expect(
         isDefaultInstallIdentity(
           {

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -200,6 +200,15 @@ export function isDefaultInstallIdentity(
   );
 }
 
+/** Whether external session catalogs may inherit a scan root from process HOME. */
+export function allowsProcessHomeSessionScan(
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = resolveSystemAccountHomeDir,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return !isNamedProfile(env) && isDefaultInstallIdentity(env, homedir, platform);
+}
+
 export function normalizeStateDirEnv(env: NodeJS.ProcessEnv = process.env): void {
   const effectiveHomedir = () => resolveRequiredHomeDir(env, envHomedir(env));
   const openclawOverride = env.OPENCLAW_STATE_DIR?.trim();

--- a/src/gateway/server-methods/session-catalog-terminal-start.test.ts
+++ b/src/gateway/server-methods/session-catalog-terminal-start.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import type { SessionCatalogProvider } from "../../plugins/session-catalog.js";
+import { withEnvAsync } from "../../test-utils/env.js";
 import { catalogStartHandler } from "./session-catalog-terminal-start.js";
 
 function provider(overrides: Partial<SessionCatalogProvider> = {}): SessionCatalogProvider {
@@ -215,6 +216,54 @@ describe("sessions.catalog.startTerminal", () => {
     );
   });
 
+  it("rejects local terminal start for a named profile before provider fallback", async () => {
+    const cwd = process.cwd();
+    const startTerminalSession = vi.fn(async (request: { allowProcessHomeFallback?: boolean }) => {
+      throw new Error(
+        request.allowProcessHomeFallback === false
+          ? "local Test sessions are unavailable in isolated state"
+          : "unguarded local terminal start",
+      );
+    });
+    activeProvider = provider({ startTerminalSession: startTerminalSession as never });
+    const home = os.userInfo().homedir;
+    const stateDir = path.join(home, ".openclaw-dev");
+
+    const respond = await withEnvAsync(
+      {
+        HOME: home,
+        USERPROFILE: home,
+        OPENCLAW_HOME: undefined,
+        OPENCLAW_PROFILE: "dev",
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
+      },
+      async () =>
+        await call(
+          { catalogId: "codex", agentId: "main", cwd },
+          { gateway: { cliAgents: { enabled: true } } },
+          { connId: "conn-1", connect: { scopes: ["operator.admin"] } },
+          {
+            isTerminalEnabled: () => true,
+            terminalSessions: { open: vi.fn() },
+            resolveTerminalLaunchPolicy: () => ({
+              ok: true,
+              plan: { agentId: "main", cwd, shell: "/bin/zsh", args: [] },
+            }),
+            isConnectionActive: () => true,
+          },
+        ),
+    );
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        message: expect.stringContaining("local Test sessions are unavailable in isolated state"),
+      }),
+    );
+  });
+
   it("reuses terminal.open admission and manager ownership for terminal start", async () => {
     const cwd = process.cwd();
     const startTerminalSession = vi.fn(async () => ({
@@ -260,6 +309,7 @@ describe("sessions.catalog.startTerminal", () => {
     expect(resolveCreateTarget).toHaveBeenCalledWith("codex", "research", config);
     expect(startTerminalSession).toHaveBeenCalledWith({
       agentId: "research",
+      allowProcessHomeFallback: false,
       cwd,
       initialMessage: "Inspect the failing test",
     });
@@ -313,6 +363,7 @@ describe("sessions.catalog.startTerminal", () => {
 
     expect(startTerminalSession).toHaveBeenCalledWith({
       agentId: "main",
+      allowProcessHomeFallback: false,
       cwd: "/remote/worktree",
       nodeId: "remote",
     });

--- a/src/gateway/server-methods/session-catalog-terminal-start.ts
+++ b/src/gateway/server-methods/session-catalog-terminal-start.ts
@@ -6,6 +6,7 @@ import {
   type SessionsCatalogStartTerminalParams,
   validateSessionsCatalogStartTerminalParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { allowsProcessHomeSessionScan } from "../../config/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { SessionCatalogProvider } from "../../plugins/session-catalog.js";
 import type { GatewayRequestHandlers } from "./types.js";
@@ -140,6 +141,7 @@ export function catalogStartHandler(
       failureHint: "check the selected CLI, host, and terminal configuration, then retry",
       resolveCatalogPlan: async () => {
         const plan = await startTerminalSession.call(provider, {
+          allowProcessHomeFallback: allowsProcessHomeSessionScan(),
           agentId: request.agentId,
           cwd: request.cwd,
           ...(request.initialMessage !== undefined

--- a/src/gateway/server-methods/session-catalog.home-isolation.test.ts
+++ b/src/gateway/server-methods/session-catalog.home-isolation.test.ts
@@ -1,0 +1,153 @@
+import os from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import type { PluginRegistry } from "../../plugins/registry-types.js";
+import type { SessionCatalogProvider } from "../../plugins/session-catalog.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+
+type TestPluginRegistry = Omit<PluginRegistry, "sessionCatalogs"> & {
+  sessionCatalogs: Array<{ provider: SessionCatalogProvider }>;
+};
+
+const hoisted = vi.hoisted(() => ({
+  activeRegistry: {} as TestPluginRegistry,
+  listSessionEntriesReadOnly: vi.fn(() => []),
+}));
+
+vi.mock("../../plugins/runtime.js", () => ({
+  getActivePluginRegistry: () => hoisted.activeRegistry,
+  requireActivePluginRegistry: () => hoisted.activeRegistry,
+}));
+vi.mock("../../config/sessions/session-accessor.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../config/sessions/session-accessor.js")>()),
+  listSessionEntriesReadOnly: hoisted.listSessionEntriesReadOnly,
+}));
+
+const { sessionCatalogHandlers } = await import("./session-catalog.js");
+
+function provider(
+  id: string,
+  overrides: Partial<SessionCatalogProvider> = {},
+): SessionCatalogProvider {
+  return {
+    id,
+    label: id.toUpperCase(),
+    list: vi.fn(async () => []),
+    read: vi.fn(async ({ hostId, threadId }) => ({ hostId, threadId, items: [] })),
+    ...overrides,
+  };
+}
+
+async function call(
+  method: keyof typeof sessionCatalogHandlers,
+  params: unknown,
+  logGateway?: { warn: (message: string, fields?: Record<string, unknown>) => void },
+) {
+  const respond = vi.fn();
+  await sessionCatalogHandlers[method]?.({
+    params,
+    respond,
+    context: { getRuntimeConfig: () => ({}), ...(logGateway ? { logGateway } : {}) },
+  } as never);
+  return respond;
+}
+
+function withProfile<T>(profile: string | undefined, run: () => Promise<T>): Promise<T> {
+  const home = os.userInfo().homedir;
+  const stateDir = path.join(home, profile ? `.openclaw-${profile}` : ".openclaw");
+  return withEnvAsync(
+    {
+      HOME: home,
+      USERPROFILE: home,
+      OPENCLAW_HOME: undefined,
+      OPENCLAW_PROFILE: profile,
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
+    },
+    run,
+  );
+}
+
+describe("session catalog Gateway HOME isolation", () => {
+  beforeEach(() => {
+    hoisted.activeRegistry = createEmptyPluginRegistry() as TestPluginRegistry;
+    hoisted.listSessionEntriesReadOnly.mockReset().mockReturnValue([]);
+  });
+
+  it("suppresses only process-HOME local hosts for a named profile", async () => {
+    const localHost = {
+      hostId: "gateway:local",
+      label: "Local",
+      kind: "gateway" as const,
+      connected: true,
+      sessions: [],
+    };
+    const nodeHost = {
+      hostId: "node:devbox",
+      label: "Devbox",
+      kind: "node" as const,
+      connected: true,
+      nodeId: "devbox",
+      sessions: [],
+    };
+    const list = vi.fn(async (query: Parameters<SessionCatalogProvider["list"]>[0]) => [
+      ...(query.allowProcessHomeFallback === false ? [] : [localHost]),
+      nodeHost,
+    ]);
+    hoisted.activeRegistry.sessionCatalogs = [{ provider: provider("claude", { list }) }];
+    const logGateway = { warn: vi.fn() };
+
+    const defaultRespond = await withProfile(undefined, () =>
+      call("sessions.catalog.list", {}, logGateway),
+    );
+    expect(defaultRespond).toHaveBeenCalledWith(true, {
+      catalogs: [expect.objectContaining({ id: "claude", hosts: [localHost, nodeHost] })],
+    });
+
+    const respond = await withProfile("dev", () => call("sessions.catalog.list", {}, logGateway));
+    await withProfile("dev", () =>
+      call("sessions.catalog.list", { search: "second request" }, logGateway),
+    );
+
+    expect(list).toHaveBeenCalledTimes(3);
+    expect(respond).toHaveBeenCalledWith(true, {
+      catalogs: [expect.objectContaining({ id: "claude", hosts: [nodeHost] })],
+    });
+    expect(logGateway.warn).toHaveBeenCalledOnce();
+    expect(logGateway.warn).toHaveBeenCalledWith(
+      "external session catalog HOME fallback skipped: isolated state; configure an explicit root to enable",
+      { reason: "isolated_state" },
+    );
+  });
+
+  it.each([
+    ["continue", "continueSession", {}],
+    ["archive", "archive", { confirmNoOtherRunner: true }],
+  ] as const)("rejects a known local %s for a named profile", async (method, hook, extra) => {
+    const rejectLocal = vi.fn(async (request: { allowProcessHomeFallback?: boolean }) => {
+      if (request.allowProcessHomeFallback === false) {
+        throw new Error("local Test sessions are unavailable in isolated state");
+      }
+      return hook === "archive" ? { ok: true as const } : { sessionKey: "agent:main:known" };
+    });
+    hoisted.activeRegistry.sessionCatalogs = [
+      { provider: provider("test", { [hook]: rejectLocal } as Partial<SessionCatalogProvider>) },
+    ];
+
+    const respond = await withProfile("dev", () =>
+      call(`sessions.catalog.${method}`, {
+        catalogId: "test",
+        hostId: "gateway:local",
+        threadId: "known-thread",
+        ...extra,
+      }),
+    );
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "local Test sessions are unavailable in isolated state" }),
+    );
+  });
+});

--- a/src/gateway/server-methods/session-catalog.test.ts
+++ b/src/gateway/server-methods/session-catalog.test.ts
@@ -1,3 +1,5 @@
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
@@ -5,6 +7,7 @@ import { bindPluginRegistryRuntime } from "../../plugins/registry-runtime-bindin
 import type { PluginRegistry } from "../../plugins/registry-types.js";
 import { createPluginRuntime } from "../../plugins/runtime/index.js";
 import type { SessionCatalogProvider } from "../../plugins/session-catalog.js";
+import { withEnvAsync } from "../../test-utils/env.js";
 
 type TestPluginRegistry = Omit<PluginRegistry, "sessionCatalogs"> & {
   sessionCatalogs: Array<{
@@ -105,6 +108,22 @@ function startCall(
   return { completion, respond };
 }
 
+function withNamedProfile<T>(run: () => Promise<T>): Promise<T> {
+  const home = os.userInfo().homedir;
+  const stateDir = path.join(home, ".openclaw-dev");
+  return withEnvAsync(
+    {
+      HOME: home,
+      USERPROFILE: home,
+      OPENCLAW_HOME: undefined,
+      OPENCLAW_PROFILE: "dev",
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
+    },
+    run,
+  );
+}
+
 describe("session catalog Gateway methods", () => {
   beforeEach(() => {
     hoisted.activeRegistry = createEmptyPluginRegistry() as TestPluginRegistry;
@@ -113,6 +132,118 @@ describe("session catalog Gateway methods", () => {
     hoisted.recordSessionStateEvent.mockClear();
     hoisted.upsertSessionUpstreamLink.mockClear();
     conversationBindingMocks.bindPluginSessionConversation.mockClear();
+  });
+
+  it("suppresses only process-HOME local hosts for a named profile", async () => {
+    const localHost = {
+      hostId: "gateway:local",
+      label: "Local",
+      kind: "gateway" as const,
+      connected: true,
+      sessions: [],
+    };
+    const nodeHost = {
+      hostId: "node:devbox",
+      label: "Devbox",
+      kind: "node" as const,
+      connected: true,
+      nodeId: "devbox",
+      sessions: [],
+    };
+    const list = vi.fn(async (query: Parameters<SessionCatalogProvider["list"]>[0]) => {
+      const allowProcessHomeFallback = (query as { allowProcessHomeFallback?: boolean })
+        .allowProcessHomeFallback;
+      return [...(allowProcessHomeFallback === false ? [] : [localHost]), nodeHost];
+    });
+    hoisted.activeRegistry.sessionCatalogs = [{ provider: provider("claude", { list }) }];
+    const home = os.userInfo().homedir;
+    const defaultStateDir = path.join(home, ".openclaw");
+    const logGateway = { warn: vi.fn() };
+
+    const defaultRespond = await withEnvAsync(
+      {
+        HOME: home,
+        USERPROFILE: home,
+        OPENCLAW_HOME: undefined,
+        OPENCLAW_PROFILE: undefined,
+        OPENCLAW_STATE_DIR: defaultStateDir,
+        OPENCLAW_CONFIG_PATH: path.join(defaultStateDir, "openclaw.json"),
+      },
+      async () => await call("sessions.catalog.list", {}, {}, undefined, { logGateway }),
+    );
+    expect(defaultRespond).toHaveBeenCalledWith(true, {
+      catalogs: [expect.objectContaining({ id: "claude", hosts: [localHost, nodeHost] })],
+    });
+
+    const respond = await withNamedProfile(async () =>
+      call("sessions.catalog.list", {}, {}, undefined, { logGateway }),
+    );
+    await withNamedProfile(async () =>
+      call("sessions.catalog.list", { search: "second request" }, {}, undefined, { logGateway }),
+    );
+
+    expect(list).toHaveBeenCalledTimes(3);
+    expect(respond).toHaveBeenCalledWith(true, {
+      catalogs: [expect.objectContaining({ id: "claude", hosts: [nodeHost] })],
+    });
+    expect(logGateway.warn).toHaveBeenCalledOnce();
+    expect(logGateway.warn).toHaveBeenCalledWith(
+      "external session catalog HOME fallback skipped: isolated state; configure an explicit root to enable",
+      { reason: "isolated_state" },
+    );
+  });
+
+  it("rejects a known local continue for a named profile", async () => {
+    const continueSession = vi.fn(async (request: { allowProcessHomeFallback?: boolean }) => {
+      if (request.allowProcessHomeFallback === false) {
+        throw new Error("local Test sessions are unavailable in isolated state");
+      }
+      return { sessionKey: "agent:main:known" };
+    });
+    hoisted.activeRegistry.sessionCatalogs = [
+      { provider: provider("test", { continueSession: continueSession as never }) },
+    ];
+
+    const respond = await withNamedProfile(async () =>
+      call("sessions.catalog.continue", {
+        catalogId: "test",
+        hostId: "gateway:local",
+        threadId: "known-thread",
+      }),
+    );
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "local Test sessions are unavailable in isolated state" }),
+    );
+  });
+
+  it("rejects a known local archive for a named profile", async () => {
+    const archive = vi.fn(async (request: { allowProcessHomeFallback?: boolean }) => {
+      if (request.allowProcessHomeFallback === false) {
+        throw new Error("local Test sessions are unavailable in isolated state");
+      }
+      return { ok: true as const };
+    });
+    hoisted.activeRegistry.sessionCatalogs = [
+      { provider: provider("test", { archive: archive as never }) },
+    ];
+
+    const respond = await withNamedProfile(async () =>
+      call("sessions.catalog.archive", {
+        catalogId: "test",
+        hostId: "gateway:local",
+        threadId: "known-thread",
+        confirmNoOtherRunner: true,
+      }),
+    );
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "local Test sessions are unavailable in isolated state" }),
+    );
   });
 
   it("sorts catalogs and isolates provider failures", async () => {
@@ -814,6 +945,7 @@ describe("session catalog Gateway methods", () => {
       { connect: { scopes: ["operator.write", "operator.admin"] } },
     );
     expect(continueSession).toHaveBeenCalledWith({
+      allowProcessHomeFallback: false,
       hostId: "gateway:local",
       threadId: "thread-1",
       clientScopes: ["operator.write", "operator.admin"],
@@ -830,6 +962,7 @@ describe("session catalog Gateway methods", () => {
       threadId: "thread-1",
     });
     expect(continueSession).toHaveBeenCalledWith({
+      allowProcessHomeFallback: false,
       hostId: "gateway:local",
       threadId: "thread-1",
       clientScopes: [],

--- a/src/gateway/server-methods/session-catalog.test.ts
+++ b/src/gateway/server-methods/session-catalog.test.ts
@@ -1,5 +1,3 @@
-import os from "node:os";
-import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
@@ -7,7 +5,6 @@ import { bindPluginRegistryRuntime } from "../../plugins/registry-runtime-bindin
 import type { PluginRegistry } from "../../plugins/registry-types.js";
 import { createPluginRuntime } from "../../plugins/runtime/index.js";
 import type { SessionCatalogProvider } from "../../plugins/session-catalog.js";
-import { withEnvAsync } from "../../test-utils/env.js";
 
 type TestPluginRegistry = Omit<PluginRegistry, "sessionCatalogs"> & {
   sessionCatalogs: Array<{
@@ -108,22 +105,6 @@ function startCall(
   return { completion, respond };
 }
 
-function withNamedProfile<T>(run: () => Promise<T>): Promise<T> {
-  const home = os.userInfo().homedir;
-  const stateDir = path.join(home, ".openclaw-dev");
-  return withEnvAsync(
-    {
-      HOME: home,
-      USERPROFILE: home,
-      OPENCLAW_HOME: undefined,
-      OPENCLAW_PROFILE: "dev",
-      OPENCLAW_STATE_DIR: stateDir,
-      OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
-    },
-    run,
-  );
-}
-
 describe("session catalog Gateway methods", () => {
   beforeEach(() => {
     hoisted.activeRegistry = createEmptyPluginRegistry() as TestPluginRegistry;
@@ -132,118 +113,6 @@ describe("session catalog Gateway methods", () => {
     hoisted.recordSessionStateEvent.mockClear();
     hoisted.upsertSessionUpstreamLink.mockClear();
     conversationBindingMocks.bindPluginSessionConversation.mockClear();
-  });
-
-  it("suppresses only process-HOME local hosts for a named profile", async () => {
-    const localHost = {
-      hostId: "gateway:local",
-      label: "Local",
-      kind: "gateway" as const,
-      connected: true,
-      sessions: [],
-    };
-    const nodeHost = {
-      hostId: "node:devbox",
-      label: "Devbox",
-      kind: "node" as const,
-      connected: true,
-      nodeId: "devbox",
-      sessions: [],
-    };
-    const list = vi.fn(async (query: Parameters<SessionCatalogProvider["list"]>[0]) => {
-      const allowProcessHomeFallback = (query as { allowProcessHomeFallback?: boolean })
-        .allowProcessHomeFallback;
-      return [...(allowProcessHomeFallback === false ? [] : [localHost]), nodeHost];
-    });
-    hoisted.activeRegistry.sessionCatalogs = [{ provider: provider("claude", { list }) }];
-    const home = os.userInfo().homedir;
-    const defaultStateDir = path.join(home, ".openclaw");
-    const logGateway = { warn: vi.fn() };
-
-    const defaultRespond = await withEnvAsync(
-      {
-        HOME: home,
-        USERPROFILE: home,
-        OPENCLAW_HOME: undefined,
-        OPENCLAW_PROFILE: undefined,
-        OPENCLAW_STATE_DIR: defaultStateDir,
-        OPENCLAW_CONFIG_PATH: path.join(defaultStateDir, "openclaw.json"),
-      },
-      async () => await call("sessions.catalog.list", {}, {}, undefined, { logGateway }),
-    );
-    expect(defaultRespond).toHaveBeenCalledWith(true, {
-      catalogs: [expect.objectContaining({ id: "claude", hosts: [localHost, nodeHost] })],
-    });
-
-    const respond = await withNamedProfile(async () =>
-      call("sessions.catalog.list", {}, {}, undefined, { logGateway }),
-    );
-    await withNamedProfile(async () =>
-      call("sessions.catalog.list", { search: "second request" }, {}, undefined, { logGateway }),
-    );
-
-    expect(list).toHaveBeenCalledTimes(3);
-    expect(respond).toHaveBeenCalledWith(true, {
-      catalogs: [expect.objectContaining({ id: "claude", hosts: [nodeHost] })],
-    });
-    expect(logGateway.warn).toHaveBeenCalledOnce();
-    expect(logGateway.warn).toHaveBeenCalledWith(
-      "external session catalog HOME fallback skipped: isolated state; configure an explicit root to enable",
-      { reason: "isolated_state" },
-    );
-  });
-
-  it("rejects a known local continue for a named profile", async () => {
-    const continueSession = vi.fn(async (request: { allowProcessHomeFallback?: boolean }) => {
-      if (request.allowProcessHomeFallback === false) {
-        throw new Error("local Test sessions are unavailable in isolated state");
-      }
-      return { sessionKey: "agent:main:known" };
-    });
-    hoisted.activeRegistry.sessionCatalogs = [
-      { provider: provider("test", { continueSession: continueSession as never }) },
-    ];
-
-    const respond = await withNamedProfile(async () =>
-      call("sessions.catalog.continue", {
-        catalogId: "test",
-        hostId: "gateway:local",
-        threadId: "known-thread",
-      }),
-    );
-
-    expect(respond).toHaveBeenCalledWith(
-      false,
-      undefined,
-      expect.objectContaining({ message: "local Test sessions are unavailable in isolated state" }),
-    );
-  });
-
-  it("rejects a known local archive for a named profile", async () => {
-    const archive = vi.fn(async (request: { allowProcessHomeFallback?: boolean }) => {
-      if (request.allowProcessHomeFallback === false) {
-        throw new Error("local Test sessions are unavailable in isolated state");
-      }
-      return { ok: true as const };
-    });
-    hoisted.activeRegistry.sessionCatalogs = [
-      { provider: provider("test", { archive: archive as never }) },
-    ];
-
-    const respond = await withNamedProfile(async () =>
-      call("sessions.catalog.archive", {
-        catalogId: "test",
-        hostId: "gateway:local",
-        threadId: "known-thread",
-        confirmNoOtherRunner: true,
-      }),
-    );
-
-    expect(respond).toHaveBeenCalledWith(
-      false,
-      undefined,
-      expect.objectContaining({ message: "local Test sessions are unavailable in isolated state" }),
-    );
   });
 
   it("sorts catalogs and isolates provider failures", async () => {

--- a/src/gateway/server-methods/session-catalog.ts
+++ b/src/gateway/server-methods/session-catalog.ts
@@ -13,6 +13,7 @@ import {
   validateSessionsCatalogListParams,
   validateSessionsCatalogReadParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { allowsProcessHomeSessionScan } from "../../config/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import { getPluginRegistryRuntime } from "../../plugins/registry-runtime-binding.js";
@@ -41,6 +42,21 @@ const SESSION_CATALOG_SHARE_WINDOW_MS = 3_000;
 const SESSION_CATALOG_LIST_CACHE_MAX_ENTRIES = 128;
 const MAX_CONCURRENT_SESSION_CATALOG_LISTS = 4;
 const MAX_QUEUED_SESSION_CATALOG_LISTS = 32;
+const PROCESS_HOME_CATALOG_SKIP_MESSAGE =
+  "external session catalog HOME fallback skipped: isolated state; configure an explicit root to enable";
+
+let reportedProcessHomeCatalogSkip = false;
+
+function allowProcessHomeFallback(logGateway?: {
+  warn: (message: string, fields?: Record<string, unknown>) => void;
+}): boolean {
+  const allowed = allowsProcessHomeSessionScan();
+  if (!allowed && !reportedProcessHomeCatalogSkip && logGateway) {
+    reportedProcessHomeCatalogSkip = true;
+    logGateway.warn(PROCESS_HOME_CATALOG_SKIP_MESSAGE, { reason: "isolated_state" });
+  }
+  return allowed;
+}
 
 // Catalog adapters may scan local databases or invoke external CLIs. Bound the
 // expensive provider operation itself so adding providers cannot multiply the cap.
@@ -239,6 +255,7 @@ function sessionCatalogListKey(params: {
   agentId: string;
   request: SessionsCatalogListParams;
   search?: string;
+  allowProcessHomeFallback: boolean;
 }): string {
   const cursors = params.request.cursors
     ? Object.entries(params.request.cursors).toSorted(([left], [right]) =>
@@ -252,6 +269,7 @@ function sessionCatalogListKey(params: {
     params.request.limitPerHost ?? null,
     params.request.hostIds ?? null,
     cursors,
+    params.allowProcessHomeFallback,
   ]);
 }
 
@@ -367,12 +385,14 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
       return;
     }
     const search = normalizeSessionCatalogSearch(request.search);
+    const allowHomeFallback = allowProcessHomeFallback(context.logGateway);
     const progressId = request.progressId;
     const progressConnId = progressId && client?.connId ? client.connId : undefined;
     const listKey = sessionCatalogListKey({
       agentId: resolvedAgent.agentId,
       request,
       search,
+      allowProcessHomeFallback: allowHomeFallback,
     });
     const cache = catalogListCache(config, catalogRegistrations);
     const cached = cache.get(listKey);
@@ -442,6 +462,7 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
           try {
             const hosts = await sessionCatalogListAdmission.run(() =>
               provider.list({
+                allowProcessHomeFallback: allowHomeFallback,
                 search,
                 limitPerHost: request.limitPerHost,
                 hostIds: request.hostIds,
@@ -486,7 +507,7 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
     }
   },
 
-  "sessions.catalog.read": async ({ params, respond }) => {
+  "sessions.catalog.read": async ({ params, respond, context }) => {
     if (
       !assertValidParams(
         params,
@@ -504,7 +525,13 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
     }
     try {
       const { catalogId: _catalogId, ...providerRequest } = request;
-      respond(true, await provider.read(providerRequest));
+      respond(
+        true,
+        await provider.read({
+          ...providerRequest,
+          allowProcessHomeFallback: allowProcessHomeFallback(context.logGateway),
+        }),
+      );
     } catch (error) {
       const details = catalogError(error);
       respond(
@@ -515,7 +542,7 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
     }
   },
 
-  "sessions.catalog.continue": async ({ params, respond, client }) => {
+  "sessions.catalog.continue": async ({ params, respond, client, context }) => {
     if (
       !assertValidParams(
         params,
@@ -541,7 +568,11 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
       // Fail closed for unscoped callers: providers gate high-authority
       // continues (e.g. node-executing bindings) on these scopes.
       const clientScopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
-      const result = await provider.continueSession({ ...providerRequest, clientScopes });
+      const result = await provider.continueSession({
+        ...providerRequest,
+        allowProcessHomeFallback: allowProcessHomeFallback(context.logGateway),
+        clientScopes,
+      });
       if (result.conversationBinding) {
         // operator.write on Continue is the approval boundary. Per-turn plugin and
         // node command authorization still applies after this binding is installed.
@@ -599,7 +630,7 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
     resolveRegisteredCatalogCreateTarget,
   ),
 
-  "sessions.catalog.archive": async ({ params, respond }) => {
+  "sessions.catalog.archive": async ({ params, respond, context }) => {
     if (
       !assertValidParams(
         params,
@@ -621,7 +652,13 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
     }
     try {
       const { catalogId: _catalogId, ...providerRequest } = request;
-      respond(true, await provider.archive(providerRequest));
+      respond(
+        true,
+        await provider.archive({
+          ...providerRequest,
+          allowProcessHomeFallback: allowProcessHomeFallback(context.logGateway),
+        }),
+      );
     } catch (error) {
       const details = catalogError(error);
       respond(

--- a/src/gateway/server-methods/terminal.test.ts
+++ b/src/gateway/server-methods/terminal.test.ts
@@ -230,7 +230,11 @@ describe("terminal gateway policy", () => {
     );
     await expectDefined(terminalHandlers["terminal.open"], "terminal.open")(opts);
 
-    expect(openTerminal).toHaveBeenCalledWith({ hostId: "gateway:local", threadId: "thread" });
+    expect(openTerminal).toHaveBeenCalledWith({
+      allowProcessHomeFallback: false,
+      hostId: "gateway:local",
+      threadId: "thread",
+    });
     expect(sessions.open).toHaveBeenCalledWith(
       expect.objectContaining({
         shell: expect.any(String),

--- a/src/gateway/server-methods/terminal.ts
+++ b/src/gateway/server-methods/terminal.ts
@@ -19,6 +19,7 @@ import {
   validateTerminalResizeParams,
   validateTerminalUploadResult,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { allowsProcessHomeSessionScan } from "../../config/paths.js";
 import { NODE_TERMINAL_UPLOAD_COMMAND } from "../../infra/node-commands.js";
 import { mergeProcessEnv } from "../../infra/process-env.js";
 import type { TerminalUploadFile } from "../../infra/terminal-file-upload.js";
@@ -481,6 +482,7 @@ export const terminalHandlers: GatewayRequestHandlers = {
       const catalog = p.catalog;
       resolveCatalogPlan = async () =>
         await openTerminal.call(provider, {
+          allowProcessHomeFallback: allowsProcessHomeSessionScan(),
           hostId: catalog.hostId,
           threadId: catalog.threadId,
         });

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -1,5 +1,7 @@
 // Gateway plugin tests cover plugin loading, auto-enable, runtime registry setup,
 // request-scope injection, diagnostics, and handler dispatch integration.
+import os from "node:os";
+import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
@@ -16,6 +18,7 @@ import type { PluginRegistry } from "../plugins/registry.js";
 import { setActiveDegradedPlugins } from "../plugins/runtime-degraded-state.js";
 import type { PluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.test-fixtures.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
+import { withEnv } from "../test-utils/env.js";
 import type { GatewayRequestContext, GatewayRequestOptions } from "./server-methods/types.js";
 
 const loadOpenClawPlugins = vi.hoisted(() => vi.fn());
@@ -539,6 +542,38 @@ describe("loadGatewayPlugins", () => {
     });
     expect(getLastPluginLoadOption("onlyPluginIds")).toEqual(["discord", "telegram"]);
     expect(getLastPluginLoadOption("preferBuiltPluginArtifacts")).toBe(true);
+  });
+
+  test("injects the process HOME-isolation fact into registry construction", () => {
+    loadOpenClawPlugins.mockReturnValue(createRegistry([]));
+    const home = os.userInfo().homedir;
+    const defaultStateDir = path.join(home, ".openclaw");
+    withEnv(
+      {
+        HOME: home,
+        USERPROFILE: home,
+        OPENCLAW_HOME: undefined,
+        OPENCLAW_PROFILE: undefined,
+        OPENCLAW_STATE_DIR: defaultStateDir,
+        OPENCLAW_CONFIG_PATH: path.join(defaultStateDir, "openclaw.json"),
+      },
+      () => loadGatewayPluginsForTest(),
+    );
+    expect(getLastPluginLoadOption("allowProcessHomeSessionCatalogs")).toBe(true);
+
+    withEnv(
+      {
+        HOME: home,
+        USERPROFILE: home,
+        OPENCLAW_HOME: undefined,
+        OPENCLAW_PROFILE: "dev",
+        OPENCLAW_STATE_DIR: path.join(home, ".openclaw-dev"),
+        OPENCLAW_CONFIG_PATH: path.join(home, ".openclaw-dev", "openclaw.json"),
+      },
+      () => loadGatewayPluginsForTest(),
+    );
+
+    expect(getLastPluginLoadOption("allowProcessHomeSessionCatalogs")).toBe(false);
   });
 
   test("routes plugin registration logs through the plugin logger", () => {

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "node:crypto";
 import { performance } from "node:perf_hooks";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import type { AmbientEnvTriggerPolicy } from "../channels/config-presence.js";
+import { allowsProcessHomeSessionScan } from "../config/paths.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
@@ -462,6 +463,7 @@ export function loadGatewayPlugins(params: {
   ambientEnvTriggers?: AmbientEnvTriggerPolicy;
 }) {
   const started = performance.now();
+  const allowProcessHomeSessionCatalogs = allowsProcessHomeSessionScan();
   const activationAutoEnabled =
     params.activationSourceConfig !== undefined && params.autoEnabledReasons === undefined
       ? applyPluginAutoEnable({
@@ -535,6 +537,7 @@ export function loadGatewayPlugins(params: {
   const gatewayRuntimeBindings = getGatewayPluginRuntimeBindings();
   const pluginRegistry = loadAndActivateRootPluginRegistry({
     config: resolvedConfig,
+    allowProcessHomeSessionCatalogs,
     activationSourceConfig: params.activationSourceConfig ?? params.cfg,
     autoEnabledReasons: autoEnabled.autoEnabledReasons,
     workspaceDir: params.workspaceDir,

--- a/src/plugin-sdk/test-helpers/contracts-testkit.ts
+++ b/src/plugin-sdk/test-helpers/contracts-testkit.ts
@@ -18,7 +18,10 @@ export { registerProviders, requireProvider };
 /** Creates a minimal plugin registry fixture with quiet logger defaults. */
 export function createPluginRegistryFixture(
   config = {} as OpenClawConfig,
-  params: { hostServices?: PluginRegistryParams["hostServices"] } = {},
+  params: {
+    allowProcessHomeSessionCatalogs?: boolean;
+    hostServices?: PluginRegistryParams["hostServices"];
+  } = {},
 ) {
   return {
     config,
@@ -30,6 +33,7 @@ export function createPluginRegistryFixture(
         debug() {},
       },
       runtime: {} as PluginRuntime,
+      allowProcessHomeSessionCatalogs: params.allowProcessHomeSessionCatalogs ?? true,
       ...(params.hostServices ? { hostServices: params.hostServices } : {}),
     }),
   };

--- a/src/plugins/loader-load-context.ts
+++ b/src/plugins/loader-load-context.ts
@@ -189,6 +189,7 @@ function buildCacheKey(params: {
   runtimeBindingIdentity?: string;
   pluginSdkResolution?: PluginSdkResolutionPreference;
   coreGatewayMethodNames?: string[];
+  allowProcessHomeSessionCatalogs?: boolean;
   activate?: boolean;
 }): string {
   const discoveryContext = resolvePluginDiscoveryContext({
@@ -237,6 +238,7 @@ function buildCacheKey(params: {
       installs,
       loadPaths,
       activationMetadataKey: params.activationMetadataKey ?? "",
+      allowProcessHomeSessionCatalogs: params.allowProcessHomeSessionCatalogs !== false,
     },
   )}::${serializePluginIdScope(params.onlyPluginIds)}::${setupOnlyKey}::${setupOnlyModeKey}::${setupOnlyRequirementKey}::${params.channelPluginLoadIntent}::${bundledArtifactMode}::${rawConfigEnvMode}::${moduleLoadMode}::${discoveryMode}::${params.runtimeSubagentMode ?? "default"}::${params.runtimeBindingIdentity ?? "{}"}::${params.pluginSdkResolution ?? "auto"}::${JSON.stringify(params.coreGatewayMethodNames ?? [])}::${activationMode}`;
   return createHash("sha256").update(cacheIdentity).digest("hex");
@@ -387,6 +389,7 @@ export function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     runtimeBindingIdentity: resolveRuntimeBindingCacheIdentity(options.runtimeOptions),
     pluginSdkResolution: options.pluginSdkResolution,
     coreGatewayMethodNames,
+    allowProcessHomeSessionCatalogs: options.allowProcessHomeSessionCatalogs,
     activate: options.activate,
   });
   return {

--- a/src/plugins/loader-runtime-load.ts
+++ b/src/plugins/loader-runtime-load.ts
@@ -152,6 +152,7 @@ function loadOpenClawPluginsInternal(
     registryBuilder = createPluginRegistry({
       logger,
       runtime,
+      allowProcessHomeSessionCatalogs: options.allowProcessHomeSessionCatalogs ?? true,
       coreGatewayHandlers: options.coreGatewayHandlers as Record<string, GatewayRequestHandler>,
       ...(options.coreGatewayMethodNames !== undefined && {
         coreGatewayMethodNames: options.coreGatewayMethodNames,

--- a/src/plugins/loader-types.ts
+++ b/src/plugins/loader-types.ts
@@ -25,6 +25,8 @@ export type PluginLoadOptions = {
   logger?: PluginLogger;
   coreGatewayHandlers?: Record<string, GatewayRequestHandler>;
   coreGatewayMethodNames?: readonly string[];
+  /** Registry-construction fact supplied by the process composition root. */
+  allowProcessHomeSessionCatalogs?: boolean;
   hostServices?: PluginRegistryParams["hostServices"];
   runtimeOptions?: CreatePluginRuntimeOptions;
   startupTrace?: {

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -84,6 +84,17 @@ function setLoaderMetadataSnapshot(params: { pluginIds?: readonly string[] } = {
 }
 
 describe("resolvePluginLoadCacheContext", () => {
+  it("partitions process-HOME catalog registration policy", () => {
+    const processHomeKey = resolvePluginLoadCacheContext({
+      allowProcessHomeSessionCatalogs: true,
+    }).cacheKey;
+    const isolatedKey = resolvePluginLoadCacheContext({
+      allowProcessHomeSessionCatalogs: false,
+    }).cacheKey;
+
+    expect(isolatedKey).not.toBe(processHomeKey);
+  });
+
   it("partitions full and setup channel plugin load intent", () => {
     const fullKey = resolvePluginLoadCacheContext({ config: {} }).cacheKey;
     const setupKey = resolvePluginLoadCacheContext({

--- a/src/plugins/registry-registrars-network.mcp-resolver.test.ts
+++ b/src/plugins/registry-registrars-network.mcp-resolver.test.ts
@@ -1,14 +1,11 @@
 /** Verifies MCP connection resolver registration ownership is fail-closed. */
-import os from "node:os";
-import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { withEnv } from "../test-utils/env.js";
 import { createPluginRegistry } from "./registry.js";
 import type { PluginRuntime } from "./runtime/types.js";
 import { createPluginRecord } from "./status.test-fixtures.js";
 
-function createRegistryHarness() {
+function createRegistryHarness(allowProcessHomeSessionCatalogs = true) {
   const pluginRegistry = createPluginRegistry({
     logger: {
       info() {},
@@ -17,6 +14,7 @@ function createRegistryHarness() {
       debug() {},
     },
     runtime: {} as PluginRuntime,
+    allowProcessHomeSessionCatalogs,
     activateGlobalSideEffects: false,
   });
   const config = {} as OpenClawConfig;
@@ -79,35 +77,20 @@ describe("registerMcpServerConnectionResolver ownership", () => {
 });
 
 describe("registerSessionCatalog ownership", () => {
-  it("keeps providers registered for isolated profiles", () => {
-    const { pluginRegistry, apiFor } = createRegistryHarness();
-    const home = os.userInfo().homedir;
-    const stateDir = path.join(home, ".openclaw-dev");
-
-    withEnv(
-      {
-        HOME: home,
-        USERPROFILE: home,
-        OPENCLAW_HOME: undefined,
-        OPENCLAW_PROFILE: "dev",
-        OPENCLAW_STATE_DIR: stateDir,
-        OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
-      },
-      () =>
-        apiFor("catalog").registerSessionCatalog({
-          id: "catalog",
-          label: "Catalog",
-          supportsProcessHomeIsolation: true as const,
-          list: async () => [],
-          read: async ({ hostId, threadId }) => ({ hostId, threadId, items: [] }),
-        } as never),
-    );
+  it("keeps isolation-aware providers when process-HOME catalogs are disabled", () => {
+    const { pluginRegistry, apiFor } = createRegistryHarness(false);
+    apiFor("catalog").registerSessionCatalog({
+      id: "catalog",
+      label: "Catalog",
+      supportsProcessHomeIsolation: true,
+      list: async () => [],
+      read: async ({ hostId, threadId }) => ({ hostId, threadId, items: [] }),
+    });
 
     expect(pluginRegistry.registry.sessionCatalogs).toHaveLength(1);
   });
 
-  it("suppresses legacy providers only for isolated profiles", () => {
-    const home = os.userInfo().homedir;
+  it("suppresses legacy providers only when process-HOME catalogs are disabled", () => {
     const legacyProvider = {
       id: "legacy",
       label: "Legacy",
@@ -118,19 +101,8 @@ describe("registerSessionCatalog ownership", () => {
         items: [],
       }),
     };
-    const isolated = createRegistryHarness();
-    const stateDir = path.join(home, ".openclaw-dev");
-    withEnv(
-      {
-        HOME: home,
-        USERPROFILE: home,
-        OPENCLAW_HOME: undefined,
-        OPENCLAW_PROFILE: "dev",
-        OPENCLAW_STATE_DIR: stateDir,
-        OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
-      },
-      () => isolated.apiFor("legacy").registerSessionCatalog(legacyProvider),
-    );
+    const isolated = createRegistryHarness(false);
+    isolated.apiFor("legacy").registerSessionCatalog(legacyProvider);
     expect(isolated.pluginRegistry.registry.sessionCatalogs).toEqual([]);
     expect(isolated.pluginRegistry.registry.diagnostics).toContainEqual(
       expect.objectContaining({
@@ -140,18 +112,7 @@ describe("registerSessionCatalog ownership", () => {
     );
 
     const defaultIdentity = createRegistryHarness();
-    const defaultStateDir = path.join(home, ".openclaw");
-    withEnv(
-      {
-        HOME: home,
-        USERPROFILE: home,
-        OPENCLAW_HOME: undefined,
-        OPENCLAW_PROFILE: undefined,
-        OPENCLAW_STATE_DIR: defaultStateDir,
-        OPENCLAW_CONFIG_PATH: path.join(defaultStateDir, "openclaw.json"),
-      },
-      () => defaultIdentity.apiFor("legacy").registerSessionCatalog(legacyProvider),
-    );
+    defaultIdentity.apiFor("legacy").registerSessionCatalog(legacyProvider);
     expect(defaultIdentity.pluginRegistry.registry.sessionCatalogs).toHaveLength(1);
   });
 });

--- a/src/plugins/registry-registrars-network.mcp-resolver.test.ts
+++ b/src/plugins/registry-registrars-network.mcp-resolver.test.ts
@@ -1,6 +1,9 @@
 /** Verifies MCP connection resolver registration ownership is fail-closed. */
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withEnv } from "../test-utils/env.js";
 import { createPluginRegistry } from "./registry.js";
 import type { PluginRuntime } from "./runtime/types.js";
 import { createPluginRecord } from "./status.test-fixtures.js";
@@ -72,5 +75,83 @@ describe("registerMcpServerConnectionResolver ownership", () => {
     expect(
       pluginRegistry.registry.diagnostics.filter((diagnostic) => diagnostic.level === "error"),
     ).toEqual([]);
+  });
+});
+
+describe("registerSessionCatalog ownership", () => {
+  it("keeps providers registered for isolated profiles", () => {
+    const { pluginRegistry, apiFor } = createRegistryHarness();
+    const home = os.userInfo().homedir;
+    const stateDir = path.join(home, ".openclaw-dev");
+
+    withEnv(
+      {
+        HOME: home,
+        USERPROFILE: home,
+        OPENCLAW_HOME: undefined,
+        OPENCLAW_PROFILE: "dev",
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
+      },
+      () =>
+        apiFor("catalog").registerSessionCatalog({
+          id: "catalog",
+          label: "Catalog",
+          supportsProcessHomeIsolation: true as const,
+          list: async () => [],
+          read: async ({ hostId, threadId }) => ({ hostId, threadId, items: [] }),
+        } as never),
+    );
+
+    expect(pluginRegistry.registry.sessionCatalogs).toHaveLength(1);
+  });
+
+  it("suppresses legacy providers only for isolated profiles", () => {
+    const home = os.userInfo().homedir;
+    const legacyProvider = {
+      id: "legacy",
+      label: "Legacy",
+      list: async () => [],
+      read: async ({ hostId, threadId }: { hostId: string; threadId: string }) => ({
+        hostId,
+        threadId,
+        items: [],
+      }),
+    };
+    const isolated = createRegistryHarness();
+    const stateDir = path.join(home, ".openclaw-dev");
+    withEnv(
+      {
+        HOME: home,
+        USERPROFILE: home,
+        OPENCLAW_HOME: undefined,
+        OPENCLAW_PROFILE: "dev",
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
+      },
+      () => isolated.apiFor("legacy").registerSessionCatalog(legacyProvider),
+    );
+    expect(isolated.pluginRegistry.registry.sessionCatalogs).toEqual([]);
+    expect(isolated.pluginRegistry.registry.diagnostics).toContainEqual(
+      expect.objectContaining({
+        level: "warn",
+        message: expect.stringContaining("supportsProcessHomeIsolation"),
+      }),
+    );
+
+    const defaultIdentity = createRegistryHarness();
+    const defaultStateDir = path.join(home, ".openclaw");
+    withEnv(
+      {
+        HOME: home,
+        USERPROFILE: home,
+        OPENCLAW_HOME: undefined,
+        OPENCLAW_PROFILE: undefined,
+        OPENCLAW_STATE_DIR: defaultStateDir,
+        OPENCLAW_CONFIG_PATH: path.join(defaultStateDir, "openclaw.json"),
+      },
+      () => defaultIdentity.apiFor("legacy").registerSessionCatalog(legacyProvider),
+    );
+    expect(defaultIdentity.pluginRegistry.registry.sessionCatalogs).toHaveLength(1);
   });
 });

--- a/src/plugins/registry-registrars-network.ts
+++ b/src/plugins/registry-registrars-network.ts
@@ -1,5 +1,6 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
+import { allowsProcessHomeSessionScan } from "../config/paths.js";
 import { createPluginGatewayMethodDescriptor } from "../gateway/methods/registry.js";
 import type { OperatorScope } from "../gateway/operator-scopes.js";
 import type { GatewayRequestHandler, RespondFn } from "../gateway/server-methods/types.js";
@@ -40,6 +41,7 @@ function adaptPluginGatewayMethodHandler(handler: GatewayRequestHandler): Gatewa
 export function createNetworkRegistrars(state: PluginRegistryState) {
   const { registry, coreGatewayMethods, pluginsWithChannelRegistrationConflict, pushDiagnostic } =
     state;
+  let reportedLegacyCatalogSkip = false;
 
   const registerGatewayMethod = (
     record: PluginRecord,
@@ -91,6 +93,19 @@ export function createNetworkRegistrars(state: PluginRegistryState) {
         source: record.source,
         message: "session catalog requires non-empty id and label",
       });
+      return;
+    }
+    if (!allowsProcessHomeSessionScan() && provider.supportsProcessHomeIsolation !== true) {
+      if (!reportedLegacyCatalogSkip) {
+        reportedLegacyCatalogSkip = true;
+        pushDiagnostic({
+          level: "warn",
+          pluginId: record.id,
+          source: record.source,
+          message:
+            "external session catalog skipped in isolated state: provider must declare supportsProcessHomeIsolation",
+        });
+      }
       return;
     }
     const existing = registry.sessionCatalogs.find((entry) => entry.provider.id === id);

--- a/src/plugins/registry-registrars-network.ts
+++ b/src/plugins/registry-registrars-network.ts
@@ -1,6 +1,5 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
-import { allowsProcessHomeSessionScan } from "../config/paths.js";
 import { createPluginGatewayMethodDescriptor } from "../gateway/methods/registry.js";
 import type { OperatorScope } from "../gateway/operator-scopes.js";
 import type { GatewayRequestHandler, RespondFn } from "../gateway/server-methods/types.js";
@@ -95,7 +94,7 @@ export function createNetworkRegistrars(state: PluginRegistryState) {
       });
       return;
     }
-    if (!allowsProcessHomeSessionScan() && provider.supportsProcessHomeIsolation !== true) {
+    if (!state.allowProcessHomeSessionCatalogs && provider.supportsProcessHomeIsolation !== true) {
       if (!reportedLegacyCatalogSkip) {
         reportedLegacyCatalogSkip = true;
         pushDiagnostic({

--- a/src/plugins/registry-state.ts
+++ b/src/plugins/registry-state.ts
@@ -78,6 +78,7 @@ export function createPluginRegistryState(registryParams: PluginRegistryParams) 
   return {
     registry,
     registryParams,
+    allowProcessHomeSessionCatalogs: registryParams.allowProcessHomeSessionCatalogs ?? true,
     coreGatewayMethods: new Set(coreGatewayMethodNames),
     getHostCronService: () => registryParams.hostServices?.cron,
     pluginsWithChannelRegistrationConflict: new Set<string>(),

--- a/src/plugins/registry-types.ts
+++ b/src/plugins/registry-types.ts
@@ -584,6 +584,8 @@ export type PluginRegistryParams = {
   coreGatewayHandlers?: GatewayRequestHandlers;
   coreGatewayMethodNames?: readonly string[];
   runtime: PluginRuntime;
+  /** Process-owner policy for registering catalogs that may fall back to HOME. */
+  allowProcessHomeSessionCatalogs?: boolean;
   hostServices?: {
     /** May be a live accessor; plugin APIs must read it at call time. */
     cron?: import("../cron/service-contract.js").CronServiceContract;

--- a/src/plugins/session-catalog.ts
+++ b/src/plugins/session-catalog.ts
@@ -12,6 +12,8 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginRuntime } from "./runtime/types.js";
 
 export type SessionCatalogListProviderParams = {
+  /** False when Gateway-local scans must not inherit a root from process HOME. */
+  allowProcessHomeFallback?: boolean;
   /** Trimmed, non-empty search capped at 500 UTF-16 code units by the gateway. */
   search?: string;
   limitPerHost?: number;
@@ -24,17 +26,30 @@ export type SessionCatalogListProviderParams = {
   /** Publishes completed hosts without waiting for slower machines in the same list. */
   onHost?: (host: SessionCatalogHost) => void;
 };
-export type SessionCatalogReadProviderParams = Omit<SessionsCatalogReadParams, "catalogId">;
+export type SessionCatalogReadProviderParams = Omit<SessionsCatalogReadParams, "catalogId"> & {
+  /** False when Gateway-local reads must not inherit a root from process HOME. */
+  allowProcessHomeFallback?: boolean;
+};
 export type SessionCatalogContinueProviderParams = Omit<
   SessionsCatalogContinueParams,
   "catalogId"
 > & {
+  /** False when Gateway-local continuation must not inherit a root from process HOME. */
+  allowProcessHomeFallback?: boolean;
   /** Caller's gateway scopes so providers can gate high-authority continues up front. */
   clientScopes?: readonly string[];
 };
-export type SessionCatalogArchiveProviderParams = Omit<SessionsCatalogArchiveParams, "catalogId">;
+export type SessionCatalogArchiveProviderParams = Omit<
+  SessionsCatalogArchiveParams,
+  "catalogId"
+> & {
+  /** False when Gateway-local archive must not inherit a root from process HOME. */
+  allowProcessHomeFallback?: boolean;
+};
 
 export type SessionCatalogStartTerminalProviderParams = {
+  /** False when Gateway-local terminal start must not inherit process HOME. */
+  allowProcessHomeFallback?: boolean;
   agentId: string;
   cwd: string;
   initialMessage?: string;
@@ -149,6 +164,8 @@ type SessionCatalogCreateParams = {
 export type SessionCatalogProvider = {
   id: string;
   label: string;
+  /** Declares that every HOME-sensitive action honors the host isolation policy. */
+  supportsProcessHomeIsolation?: true;
   /** Config-derived target; the Gateway memoizes it for one runtime-config object identity. */
   resolveCreateSession?: (
     params: SessionCatalogCreateParams,
@@ -158,9 +175,13 @@ export type SessionCatalogProvider = {
   continueSession?: (
     params: SessionCatalogContinueProviderParams,
   ) => Promise<SessionCatalogContinueProviderResult>;
-  checkUpstreamActivity?: (probes: SessionUpstreamProbe[]) => Promise<SessionUpstreamActivity[]>;
+  checkUpstreamActivity?: (
+    probes: SessionUpstreamProbe[],
+    policy?: { allowProcessHomeFallback?: boolean },
+  ) => Promise<SessionUpstreamActivity[]>;
   archive?: (params: SessionCatalogArchiveProviderParams) => Promise<{ ok: true }>;
   openTerminal?: (request: {
+    allowProcessHomeFallback?: boolean;
     hostId: string;
     threadId: string;
   }) => Promise<SessionCatalogTerminalPlan>;

--- a/src/sessions/session-upstream-monitor.test.ts
+++ b/src/sessions/session-upstream-monitor.test.ts
@@ -122,6 +122,10 @@ describe("session upstream monitor", () => {
     expect(checkUpstreamActivity.mock.calls[1]?.[0]).toEqual([
       expect.objectContaining({ sessionKey: watched, marker: { offset: 8 } }),
     ]);
+    expect(checkUpstreamActivity.mock.calls.map((call) => call[1])).toEqual([
+      { allowProcessHomeFallback: false },
+      { allowProcessHomeFallback: false },
+    ]);
     const events = listSessionStateEventsSince(watched, "main", 0, 20, database).events;
     expect(events).toHaveLength(1);
     expect(events[0]).toEqual(
@@ -655,7 +659,9 @@ describe("session upstream monitor", () => {
       loadOwnRecentUserTexts: async () => [],
     });
 
-    expect(check).toHaveBeenCalledWith([expect.objectContaining({ marker: { offset: 0 } })]);
+    expect(check).toHaveBeenCalledWith([expect.objectContaining({ marker: { offset: 0 } })], {
+      allowProcessHomeFallback: false,
+    });
   });
 
   it("defers activity when a run starts during the provider scan", async () => {
@@ -820,9 +826,10 @@ describe("session upstream monitor", () => {
       isRunActive: () => false,
     });
 
-    expect(check).toHaveBeenCalledWith([
-      expect.objectContaining({ ownRecentUserTexts: ["exact decorated prompt"] }),
-    ]);
+    expect(check).toHaveBeenCalledWith(
+      [expect.objectContaining({ ownRecentUserTexts: ["exact decorated prompt"] })],
+      { allowProcessHomeFallback: false },
+    );
     expect(listSessionStateEventsSince(sessionKey, "main", 0, 20, database).events).toEqual([]);
   });
 
@@ -865,7 +872,9 @@ describe("session upstream monitor", () => {
       isRunActive: () => false,
     });
 
-    expect(check).toHaveBeenCalledWith([expect.objectContaining({ ownRecentUserTexts: [] })]);
+    expect(check).toHaveBeenCalledWith([expect.objectContaining({ ownRecentUserTexts: [] })], {
+      allowProcessHomeFallback: false,
+    });
     expect(listSessionStateEventsSince(sessionKey, "main", 0, 20, database).events).toEqual([
       expect.objectContaining({ kind: "human_direct_message", summary: "human message via pi" }),
     ]);

--- a/src/sessions/session-upstream-monitor.test.ts
+++ b/src/sessions/session-upstream-monitor.test.ts
@@ -116,16 +116,16 @@ describe("session upstream monitor", () => {
     });
 
     expect(checkUpstreamActivity).toHaveBeenCalledTimes(2);
-    expect(checkUpstreamActivity.mock.calls[0]?.[0]).toEqual([
-      expect.objectContaining({ sessionKey: watched, marker: { offset: 0 } }),
-    ]);
-    expect(checkUpstreamActivity.mock.calls[1]?.[0]).toEqual([
-      expect.objectContaining({ sessionKey: watched, marker: { offset: 8 } }),
-    ]);
-    expect(checkUpstreamActivity.mock.calls.map((call) => call[1])).toEqual([
+    expect(checkUpstreamActivity).toHaveBeenNthCalledWith(
+      1,
+      [expect.objectContaining({ sessionKey: watched, marker: { offset: 0 } })],
       { allowProcessHomeFallback: false },
+    );
+    expect(checkUpstreamActivity).toHaveBeenNthCalledWith(
+      2,
+      [expect.objectContaining({ sessionKey: watched, marker: { offset: 8 } })],
       { allowProcessHomeFallback: false },
-    ]);
+    );
     const events = listSessionStateEventsSince(watched, "main", 0, 20, database).events;
     expect(events).toHaveLength(1);
     expect(events[0]).toEqual(

--- a/src/sessions/session-upstream-monitor.ts
+++ b/src/sessions/session-upstream-monitor.ts
@@ -1,6 +1,7 @@
 /** Polls watched adopted sessions for direct upstream human activity. */
 import { createHash } from "node:crypto";
 import { isEmbeddedAgentRunActive } from "../agents/embedded-agent.js";
+import { allowsProcessHomeSessionScan } from "../config/paths.js";
 import { loadSessionEntryReadOnly } from "../config/sessions/session-accessor.js";
 import { resolveSessionStorePathForScope } from "../config/sessions/session-store-path.js";
 import { readRecentUserAssistantTextForSession } from "../config/sessions/transcript.js";
@@ -245,7 +246,9 @@ async function runSessionUpstreamMonitorTick(
       links.map((link) => [link.sessionKey, link.updatedAt]),
     );
     try {
-      const outcomes = await provider.checkUpstreamActivity(probes);
+      const outcomes = await provider.checkUpstreamActivity(probes, {
+        allowProcessHomeFallback: allowsProcessHomeSessionScan(options.env ?? process.env),
+      });
       if (options.signal?.aborted) {
         return;
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a gateway running on isolated state — a custom `OPENCLAW_STATE_DIR`/`OPENCLAW_CONFIG_PATH`/`OPENCLAW_HOME`, a relocated home, or any named `--profile` (including the `pnpm gateway:dev` instance) — would surface and serve the operator's real external harness sessions from the process `HOME`: Claude Code, Codex, OpenCode, and Pi stores appeared in the Control UI sidebar's external session catalogs, and their transcripts were readable, continuable, archivable, and reopenable in terminals. Isolated dev/test gateways listed the human operator's private session titles; recordings made against them leaked those titles.

## Why This Change Was Made

Maintainer decision: an isolated-state gateway must not inherit `HOME`. External session catalogs are an operator-machine feature; their process-HOME scans are only legitimate on the default install identity.

Enforcement is closed over the whole provider surface, not just listing:

- `allowsProcessHomeSessionScan()` (`src/config/paths.ts`) — true only for the default profile on the existing default-install-identity fact; `isDefaultInstallIdentity()` keeps its host-service meaning unchanged.
- Fail closed for unknown providers: in isolated state the registrar only admits catalog providers that declare `supportsProcessHomeIsolation: true`; legacy/third-party providers that cannot honor the contract are suppressed with a structured warning. All bundled providers declare it.
- Every HOME-sensitive verb receives the isolation flag and rejects HOME-fallback local targets: `list`, `read`, `continue` (transcript import), `archive` (native-thread mutation), terminal open/start, and upstream-activity probes. Paired-node hosts keep working (node scans run in the node's environment), and explicitly rooted local stores keep working even when isolated — the named enablement path: `CLAUDE_CONFIG_DIR`, `CODEX_HOME` / `appServer.homeScope: "agent"`, any non-empty `OPENCODE_DB`, and Pi's explicit session-dir settings.
- One structured gateway warning records the suppression (`external session catalog HOME fallback skipped: isolated state; configure an explicit root to enable`) — an intentional non-outcome, not silence.

Default-identity gateways are completely unchanged. No new config keys, env vars, or protocol changes; the SDK additions are additive optional fields.

## User Impact

Dev/test/profile gateways no longer display, read, or mutate the operator's private harness sessions. Multi-instance operators keep external catalogs by configuring explicit roots; the gateway warning names that path.

## Evidence

- Boundary regression tests fail pre-fix per guard: named-profile suppression at `sessions.catalog.list` (previously listed `gateway:local`), continue/archive rejection (previously accepted local targets), terminal-start guard (previously reached the local plan), legacy-provider registration suppression, and explicit-root listing while isolated (including `CLAUDE_CONFIG_DIR` and relative `OPENCODE_DB`). Focused runs: gateway/session-catalog + terminal + registrar + upstream-monitor (88 passed), bundled provider suites (285 passed), paths/config (138 passed).
- Live dev-gateway before/after, recorded per the AGENTS.md video-proof policy. Both runs use an isolated `OPENCLAW_STATE_DIR` and a **synthetic** `~/.claude` store seeded from test fixtures (`private-project` / `demo-session-1` — no real data).

Before (current main): the isolated gateway lists the HOME store in the sidebar (`CLAUDE CODE → private-project → demo-session-1`):

https://github.com/user-attachments/assets/f4b54d73-5b1e-4134-a830-373cf126503d

After (this PR, same inputs): no external catalog section; the gateway logs `external session catalog HOME fallback skipped: isolated state; configure an explicit root to enable`:

https://github.com/user-attachments/assets/67831a3b-dc7c-4552-bfc0-6531ce37305a

- Codex upstream contract verified directly in `../codex` source (`CODEX_HOME` → `~/.codex` fallback at `codex-rs/core/src/config/mod.rs`; `thread/list` reads the configured store).
- Production delta +~420/-~100 across core seam + four bundled providers; growth carries the privacy boundary (per-verb enforcement + capability contract) — a narrower diff would leave bypass verbs open, which review rounds proved concretely.
- SDK baseline check, targeted oxfmt/oxlint, `git diff --check` clean; Codex autoreview iterated four rounds (registration-only → scan-time seam preserving node hosts → continue/archive guards → terminal verbs + fail-closed capability + `CLAUDE_CONFIG_DIR`) and the final round is clean.
