### PR TITLE
fix: chat jumps from latest as composer grows

### DIFF
--- a/ui/src/e2e/chat-flow.streaming.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.streaming.e2e.test.ts
@@ -253,6 +253,83 @@ suite.define(() => {
     }
   });
 
+  it("keeps a bottom-anchored transcript pinned while the composer grows", async () => {
+    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const baseTs = Date.now() - 100_000;
+    const historyMessages = Array.from({ length: 50 }, (_, index) => ({
+      content: [
+        {
+          text: `Composer resize history ${index}\n${"extra transcript line\n".repeat(4)}`,
+          type: "text",
+        },
+      ],
+      role: index % 2 === 0 ? "assistant" : "user",
+      timestamp: baseTs + index,
+    }));
+    await installMockGateway(page, { historyMessages });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await page.getByText("Composer resize history 49").waitFor({ timeout: 10_000 });
+      await expect
+        .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
+        .toBeLessThanOrEqual(CHAT_TRANSCRIPT_END_THRESHOLD_PX);
+      await waitForChatScrollIdle(page);
+
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      for (let line = 1; line <= 8; line += 1) {
+        await composer.fill(
+          Array.from({ length: line }, (_, index) => `Growing composer line ${index + 1}`).join(
+            "\n",
+          ),
+        );
+        await waitForChatScrollIdle(page);
+        expect(
+          await chatThreadDistanceFromBottom(page),
+          `composer line count ${line}`,
+        ).toBeLessThanOrEqual(CHAT_TRANSCRIPT_END_THRESHOLD_PX);
+      }
+      if (artifactDir) {
+        await mkdir(artifactDir, { recursive: true });
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(artifactDir, "composer-resize-pinned.png"),
+        });
+      }
+
+      await composer.fill("Growing composer line 1");
+      await waitForChatScrollIdle(page);
+      await scrollChatThreadToTop(page);
+      const readingScrollTop = await page
+        .locator(".chat-thread")
+        .evaluate((element) => element.scrollTop);
+      await composer.fill(
+        Array.from({ length: 8 }, (_, index) => `Reading composer line ${index + 1}`).join("\n"),
+      );
+      await waitForChatScrollIdle(page);
+      expect(
+        await page
+          .locator(".chat-thread")
+          .evaluate((element, initial) => Math.abs(element.scrollTop - initial), readingScrollTop),
+      ).toBeLessThanOrEqual(1);
+
+      if (artifactDir) {
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(artifactDir, "composer-resize-manual-scroll.png"),
+        });
+      }
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("renders stable markdown during a streaming chat turn and finalizes the tail", async () => {
     const context = await suite.newBrowserContext({
       locale: "en-US",

--- a/ui/src/pages/chat/components/chat-composer-dom.ts
+++ b/ui/src/pages/chat/components/chat-composer-dom.ts
@@ -1,3 +1,5 @@
+import { captureChatSessionScrollPosition } from "../scroll.ts";
+
 const COMPOSER_CHROME_INTERACTIVE_SELECTOR = [
   "a[href]",
   "button",
@@ -126,6 +128,10 @@ function updateTextareaOverflow(el: HTMLTextAreaElement) {
 }
 
 export function adjustTextareaHeight(el: HTMLTextAreaElement) {
+  const thread = el.closest(".chat")?.querySelector<HTMLElement>(".chat-thread") ?? null;
+  const preserveBottomAnchor = thread
+    ? captureChatSessionScrollPosition(thread).anchorToEnd
+    : false;
   // Hide the browser's scrollbar while measuring; restore it only when the
   // final CSS-constrained height actually clips the draft.
   el.style.overflowY = "hidden";
@@ -137,6 +143,11 @@ export function adjustTextareaHeight(el: HTMLTextAreaElement) {
   const maxHeight = pixelMaxHeight ? Number(pixelMaxHeight[1]) : 150;
   el.style.height = `${Math.min(el.scrollHeight, maxHeight)}px`;
   updateTextareaOverflow(el);
+  // Once capped, the textarea can perturb the sibling transcript without
+  // resizing its viewport, so ResizeObserver has no correction to apply.
+  if (thread && preserveBottomAnchor) {
+    thread.scrollTop = thread.scrollHeight;
+  }
 }
 
 export function observeTextareaOverflow(el: HTMLTextAreaElement) {


### PR DESCRIPTION
## New behavior

Growing a multiline chat draft now keeps the transcript on the latest message, including when the composer reaches its height limit. Readers who have scrolled up stay at the same reading position.

Previously, the capped transition could leave the transcript 86 px above the latest message because it changed the available scroll extent without resizing the transcript viewport.

## Visual proof

https://github.com/user-attachments/assets/e3ab2f88-abf9-476d-bc02-379ab960562d

**What this shows:** The synchronized A/B recording grows the same draft from one through eight lines. The direct base moves from 0 to 86 px above the latest message; this branch remains at 0 px throughout. Both sides then repeat the interaction while scrolled up and preserve the reader's position.

**State:** Captured against direct base `f70d5b8ba588` on the left and the patch-identical PR head on the right, using `/chat`, the same 50-message mocked-Gateway history, a 1280×900 viewport, and the same deliberate input sequence. The current exact head is `6a87698d5d36` on direct base `f94f9453147f`; its two-file patch keeps the same stable patch ID (`6fa05f0419da8dd0ca96a8e47059aa2921245443`). Re-running the regression on the current direct base still fails at composer line 7 with an 86 px gap, while the exact head remains within the 8 px end threshold and leaves a manually scrolled reader in place.

### Before — direct base

![Direct base leaves the transcript 86 pixels above the latest message after the composer grows](https://github.com/user-attachments/assets/5f2b8d38-13d0-4cb7-94ab-2de2209c50b7)

**What this shows:** After eight lines, the direct base is 86 px above the latest message and exposes the “Scroll to latest” control.

### Now — this branch

![PR branch keeps the latest message anchored after the composer grows](https://github.com/user-attachments/assets/6e8170a7-f49f-4a24-a3df-a97930bb9ff2)

**What this shows:** After the same eight-line input, the branch remains 0 px from the latest message and does not show the recovery control.

### Scrolled-up reader

![PR branch preserves a manually scrolled reading position while the composer grows](https://github.com/user-attachments/assets/dae11f89-696a-4b75-9023-b543e664c326)

**What this shows:** Growing the composer while scrolled up moves the reading position by 0 px, so the fix does not force readers back to the latest message.

## How to verify

1. Open a chat with enough history to overflow the transcript.
2. Stay at the latest message and grow the composer from one through eight lines.
3. Confirm the transcript remains within the shared 8 px end threshold at every step.
4. Scroll up and grow the composer again; confirm the reading offset does not move.

## Implementation notes

The composer snapshots whether its sibling transcript is already end-anchored before changing textarea height, then restores only that existing anchor immediately afterward. A transcript `ResizeObserver` cannot own this repair because the failing capped transition changes the sibling scroll extent without resizing the transcript viewport.

The +11 production lines are the smallest owner-boundary fix: separate pre-layout capture and post-layout restoration are both required, and the code reuses the existing shared end-threshold helper. No net-neutral alternative can preserve both bottom anchoring and a scrolled-up reader through the no-resize transition.

