### PR TITLE
fix(ci): repair plugin fixture contracts

### DIFF
--- a/src/plugins/plugin-lookup-table.test.ts
+++ b/src/plugins/plugin-lookup-table.test.ts
@@ -32,6 +32,15 @@ vi.mock("../channels/config-presence.js", () => ({
     env: NodeJS.ProcessEnv,
     options?: { includePersistedAuthState?: boolean },
   ) => listPotentialConfiguredChannelIds(config, env, options),
+  listPotentialConfiguredChannelPresenceSignals: (
+    config: OpenClawConfig,
+    env: NodeJS.ProcessEnv,
+    options?: { includePersistedAuthState?: boolean },
+  ) =>
+    listPotentialConfiguredChannelIds(config, env, options).map((channelId: string) => ({
+      channelId,
+      source: "env" as const,
+    })),
   listExplicitlyDisabledChannelIdsForConfig: (config: OpenClawConfig) =>
     listExplicitlyDisabledChannelIdsForConfig(config),
 }));

--- a/src/plugins/runtime/metadata-registry-loader.test.ts
+++ b/src/plugins/runtime/metadata-registry-loader.test.ts
@@ -24,7 +24,11 @@ vi.mock("../loader.js", () => ({
 }));
 
 vi.mock("../../agents/agent-scope.js", () => ({
+  listAgentEntries: vi.fn<typeof import("../../agents/agent-scope.js").listAgentEntries>(() => []),
   resolveAgentWorkspaceDir: () => "/resolved-workspace",
+  tryResolveConfiguredAgentWorkspaceDir: vi.fn<
+    typeof import("../../agents/agent-scope.js").tryResolveConfiguredAgentWorkspaceDir
+  >(() => "/resolved-workspace"),
   resolveDefaultAgentId: () => "default",
 }));
 

--- a/src/plugins/runtime/runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/runtime-registry-loader.test.ts
@@ -19,8 +19,15 @@ const mocks = vi.hoisted(() => ({
     vi.fn<typeof import("../plugin-metadata-snapshot.js").resolvePluginMetadataSnapshot>(),
   isPluginMetadataSnapshotCompatible:
     vi.fn<typeof import("../plugin-metadata-snapshot.js").isPluginMetadataSnapshotCompatible>(),
+  rebasePluginMetadataSnapshotManifestRegistry: vi.fn<
+    typeof import("../plugin-metadata-snapshot.js").rebasePluginMetadataSnapshotManifestRegistry
+  >((snapshot) => snapshot),
+  listAgentEntries: vi.fn<typeof import("../../agents/agent-scope.js").listAgentEntries>(() => []),
   resolveAgentWorkspaceDir: vi.fn<
     typeof import("../../agents/agent-scope.js").resolveAgentWorkspaceDir
+  >(() => "/resolved-workspace"),
+  tryResolveConfiguredAgentWorkspaceDir: vi.fn<
+    typeof import("../../agents/agent-scope.js").tryResolveConfiguredAgentWorkspaceDir
   >(() => "/resolved-workspace"),
   resolveDefaultAgentId: vi.fn<typeof import("../../agents/agent-scope.js").resolveDefaultAgentId>(
     () => "default",
@@ -63,11 +70,19 @@ vi.mock("../plugin-metadata-snapshot.js", () => ({
   isPluginMetadataSnapshotCompatible: (
     ...args: Parameters<typeof mocks.isPluginMetadataSnapshotCompatible>
   ) => mocks.isPluginMetadataSnapshotCompatible(...args),
+  rebasePluginMetadataSnapshotManifestRegistry: (
+    ...args: Parameters<typeof mocks.rebasePluginMetadataSnapshotManifestRegistry>
+  ) => mocks.rebasePluginMetadataSnapshotManifestRegistry(...args),
 }));
 
 vi.mock("../../agents/agent-scope.js", () => ({
+  listAgentEntries: (...args: Parameters<typeof mocks.listAgentEntries>) =>
+    mocks.listAgentEntries(...args),
   resolveAgentWorkspaceDir: (...args: Parameters<typeof mocks.resolveAgentWorkspaceDir>) =>
     mocks.resolveAgentWorkspaceDir(...args),
+  tryResolveConfiguredAgentWorkspaceDir: (
+    ...args: Parameters<typeof mocks.tryResolveConfiguredAgentWorkspaceDir>
+  ) => mocks.tryResolveConfiguredAgentWorkspaceDir(...args),
   resolveDefaultAgentId: (...args: Parameters<typeof mocks.resolveDefaultAgentId>) =>
     mocks.resolveDefaultAgentId(...args),
 }));
@@ -107,7 +122,10 @@ function requireLoadOptions(): Record<string, unknown> {
 describe("ensurePluginRegistryLoaded", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.resolvePluginMetadataSnapshot.mockReset();
+    mocks.resolvePluginMetadataSnapshot.mockReset().mockReturnValue({
+      index: { installRecords: {}, plugins: [{ pluginId: "openai" }] },
+      manifestRegistry: { plugins: [], diagnostics: [] },
+    } as never);
     mocks.isPluginMetadataSnapshotCompatible.mockReturnValue(true);
     mocks.applyPluginAutoEnable.mockImplementation((params) => ({
       config: params.config ?? {},

--- a/src/plugins/status-effective-plugin-discovery.test.ts
+++ b/src/plugins/status-effective-plugin-discovery.test.ts
@@ -3,22 +3,23 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeEach, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { clearCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
 import { createColdPluginFixture } from "./test-helpers/cold-plugin-fixtures.js";
 
 const counters = vi.hoisted(() => ({ manifestRegistryRebuilds: 0, discoveryScans: 0 }));
 
-vi.mock("./plugin-registry-contributions.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./plugin-registry-contributions.js")>();
+vi.mock("../config/io.plugin-metadata.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/io.plugin-metadata.js")>();
   return {
     ...actual,
-    loadPluginManifestRegistryForPluginRegistry: (
-      ...args: Parameters<typeof actual.loadPluginManifestRegistryForPluginRegistry>
+    resolveConfigWidePluginManifestRegistry: (
+      ...args: Parameters<typeof actual.resolveConfigWidePluginManifestRegistry>
     ) => {
       counters.manifestRegistryRebuilds += 1;
-      return actual.loadPluginManifestRegistryForPluginRegistry(...args);
+      return actual.resolveConfigWidePluginManifestRegistry(...args);
     },
   };
 });
@@ -89,9 +90,14 @@ function countResolve(metadataSnapshot: PluginMetadataSnapshot): {
 }
 
 beforeEach(() => {
+  clearCurrentPluginMetadataSnapshot();
   vi.stubEnv("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
   vi.stubEnv("OPENCLAW_HOME", path.join(tempRoot, "home"));
   vi.stubEnv("OPENCLAW_STATE_DIR", path.join(tempRoot, "state"));
+});
+
+afterEach(() => {
+  clearCurrentPluginMetadataSnapshot();
 });
 
 afterAll(() => {
@@ -117,11 +123,16 @@ it("only reuses a snapshot that answers for the whole config", () => {
   const env = process.env;
   const withoutSnapshot = resolveEffectivePluginIds({ config, env });
   const full = countResolve(loadPluginMetadataSnapshot({ config, env }));
+  clearCurrentPluginMetadataSnapshot();
   // `recordPluginInstallSource` asks for one plugin's effective state, which scopes the
   // snapshot to that plugin and truncates its manifest set to that plugin alone.
-  const scoped = countResolve(
-    loadPluginMetadataSnapshot({ config, env, pluginIds: ["other-plugin"] }),
-  );
+  const scopedSnapshot = loadPluginMetadataSnapshot({
+    config,
+    env,
+    pluginIds: ["other-plugin"],
+  });
+  clearCurrentPluginMetadataSnapshot();
+  const scoped = countResolve(scopedSnapshot);
 
   expect({ full: full.ids, scoped: scoped.ids }).toEqual({
     full: withoutSnapshot,


### PR DESCRIPTION
## Summary

- align plugin test doubles with the current channel-presence and agent-workspace contracts
- keep runtime metadata fixtures complete enough for registry-loader tests
- isolate process-current plugin metadata state and count rebuilds at the current config metadata owner

## Why

The plugin qualification shard exposed stale test fixtures after the production contracts moved. The failures were in test doubles and process-local test state, not runtime behavior.

## Scope

- four plugin test files only
- production LOC: 0
- no registry/index, discovery policy, retry, timeout, or ownership changes

## Validation

- focused four-file Vitest: 31 passed
- targeted formatting: passed
- `git diff --check`: passed
- exact changed-file gate on Blacksmith Testbox: passed
- local autoreview: clean, no actionable findings

Blacksmith Testbox changed-file proof: https://github.com/openclaw/openclaw/actions/runs/31662263744

The canonical plugin shard also ran with fail-fast disabled. All four touched files passed; its remaining failures are independent qualification lanes and are intentionally outside this PR.

Canonical plugin shard: https://github.com/openclaw/openclaw/actions/runs/31662514825
