### PR TITLE
fix(gateway): preserve system agent ownership

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"e02eb48d126866582b0c2d89f29ae36ed3042eee6e4ad1878e3e352dc7ab58d0","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}
+{"contentHash":"217a982536f2e60f08287ddfa0cb0ce76bead1b5f6a962635f68a3f09cfed955","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"d09d23506269b7ca94b52c5e038b26fe9269a8cfc485ce513ee31aa056eece07","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}
+{"contentHash":"e02eb48d126866582b0c2d89f29ae36ed3042eee6e4ad1878e3e352dc7ab58d0","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
@@ -1,1 +1,1 @@
-{"contentHash":"7d8aaaa9fb94273576d7f4d37d56b5bd2613d3c147dea202f410b67bcc9710b1","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
+{"contentHash":"745b6376dc744050f9c9602c6530703eca683fa2cd4a3520efafb8b3a611d93f","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
@@ -1,1 +1,1 @@
-{"contentHash":"2ba58871e5ca61397755a3bdb98bd6beca75d6e3b5400331c6381041f3aa3d6f","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
+{"contentHash":"7d8aaaa9fb94273576d7f4d37d56b5bd2613d3c147dea202f410b67bcc9710b1","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-core.json
@@ -1,1 +1,1 @@
-{"contentHash":"7be931b151b8394b819b6956fd58d2b39163bb5ca0d4954d71caa7b5148405be","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}
+{"contentHash":"2e41ca681490aaea3880512777c6e42bb945e3c19b6a1a0ae8082c5a5d69a787","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-core.json
@@ -1,1 +1,1 @@
-{"contentHash":"b9fc667192c85df94b1768bc92bc4b621f19afad4e9838fca3886f3bb36b50c9","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}
+{"contentHash":"7be931b151b8394b819b6956fd58d2b39163bb5ca0d4954d71caa7b5148405be","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
@@ -1,1 +1,1 @@
-{"contentHash":"a4de0e245a75d79ad66f8bf13b9eb3adbd6a0248cc49986fb046b990db6b14b7","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}
+{"contentHash":"2c81d755d3e0c828dd70d5aa083bf96e10a202d35e781db9df90c035205ad4a1","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
@@ -1,1 +1,1 @@
-{"contentHash":"2c81d755d3e0c828dd70d5aa083bf96e10a202d35e781db9df90c035205ad4a1","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}
+{"contentHash":"c1ec7b510bc71f3dcbda3da1e389536818088a0a5624b269c731aa8ceb0bcc5d","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-message.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-message.json
@@ -1,1 +1,1 @@
-{"contentHash":"37fbd8b64464417ae39dcbd88b3457703ff77cbadd765e80505d7f51cc3c2f29","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}
+{"contentHash":"eee5b7e929fd8b1ed3033e7828c05742ac9490506d5ebc80087b830510c15473","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-message.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-message.json
@@ -1,1 +1,1 @@
-{"contentHash":"6c0acdac3db1c698033694ca41efad5bdbe7edf8634f78c5ac9e333ddb94124f","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}
+{"contentHash":"37fbd8b64464417ae39dcbd88b3457703ff77cbadd765e80505d7f51cc3c2f29","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"d78f16a5d500b1f29db2bf91a602694bda455d4bad196f46762f7256eaff767a","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}
+{"contentHash":"1aa4d0540178a6a8ab2eab4cebfb205604fd46a73de21b2f07cda94e01740608","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"20da7d32e9a7937993a7529a5744b6b3457d00c92c7a5ec44f4524459ce7400c","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}
+{"contentHash":"d78f16a5d500b1f29db2bf91a602694bda455d4bad196f46762f7256eaff767a","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
@@ -1,1 +1,1 @@
-{"contentHash":"ce27ae6e3f4b61d18bdaff383135dec6b0a3f020901984a4d7883c766e63129a","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}
+{"contentHash":"c0b16981f5e6401a455a1970f2ff427652b251ab1bbaa29aaf7092d0c3e54a19","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
@@ -1,1 +1,1 @@
-{"contentHash":"c0b16981f5e6401a455a1970f2ff427652b251ab1bbaa29aaf7092d0c3e54a19","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}
+{"contentHash":"709ac41f57c2327e19c241f8cb399752cf9e0294f00243e21c24698b06c480b6","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}

--- a/docs/.generated/plugin-sdk-api-baseline/core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/core.json
@@ -1,1 +1,1 @@
-{"contentHash":"167ca860b15990c05eaad49e7f2a39e38812d1245011f85e2d536b7d7eb93265","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}
+{"contentHash":"6bbb5472cee9d3970ce3aced7e6fb305e5bf6a0e99b93c8393f07f0560ddc3ea","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}

--- a/docs/.generated/plugin-sdk-api-baseline/core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/core.json
@@ -1,1 +1,1 @@
-{"contentHash":"6bbb5472cee9d3970ce3aced7e6fb305e5bf6a0e99b93c8393f07f0560ddc3ea","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}
+{"contentHash":"65b5c7028bd61f6208a3f69b870bb5b783b03005ceaba75c1d0d54ce7c82f293","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}

--- a/docs/.generated/plugin-sdk-api-baseline/discord.json
+++ b/docs/.generated/plugin-sdk-api-baseline/discord.json
@@ -1,1 +1,1 @@
-{"contentHash":"c5c5a37bc949bfb4166f511a846a4e8273fb639c46f9fa4e5bb78a4ab71dbfab","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}
+{"contentHash":"d1cee3a09c0a0ea1e33b0dde86e1a5999105dd685ad4ccfcb0104ae0f45a207b","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}

--- a/docs/.generated/plugin-sdk-api-baseline/discord.json
+++ b/docs/.generated/plugin-sdk-api-baseline/discord.json
@@ -1,1 +1,1 @@
-{"contentHash":"d1cee3a09c0a0ea1e33b0dde86e1a5999105dd685ad4ccfcb0104ae0f45a207b","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}
+{"contentHash":"65c0ba8a1690c042f0db0b9ab3433d257177734d5b83ff41d418f6b0cb817301","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}

--- a/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
+++ b/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
@@ -1,1 +1,1 @@
-{"contentHash":"ab3965e7bb6ce3e1e9e6b684c01e7929980402aaabb12f9750db4c2b04034622","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}
+{"contentHash":"06accd633da656b31eb725ac89acc06edaca5f84eb06ca62ca5f5b3a30fe4b2e","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}

--- a/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
+++ b/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
@@ -1,1 +1,1 @@
-{"contentHash":"06accd633da656b31eb725ac89acc06edaca5f84eb06ca62ca5f5b3a30fe4b2e","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}
+{"contentHash":"39982625a0bb3d57be7180289dd824a89c514285dd62433005e42c2da866e0c6","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}

--- a/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"1335062907a7948a67c59f4320899aaaf33bbea92001675c12ec392e552d1411","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}
+{"contentHash":"6cc98a5bfbe618ab913b1d493070279d8be3a230f40a98fe67e84c64c7b86fc4","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"6cc98a5bfbe618ab913b1d493070279d8be3a230f40a98fe67e84c64c7b86fc4","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}
+{"contentHash":"9462b8d4ca13d7669da993a6b94d4add39ee1f95979e11c636348f008ee087a0","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
@@ -1,1 +1,1 @@
-{"contentHash":"61ce616f617990cc9d587083fa4343ceebada919d26af7215872c2083afa227c","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}
+{"contentHash":"3247b08bfc168591580c57393621143028070133f483a39518955c6f010a0dc4","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
@@ -1,1 +1,1 @@
-{"contentHash":"7233fde521fda9b80333647953bcb0611133e044920b25bd1554b56d2efe4af9","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}
+{"contentHash":"61ce616f617990cc9d587083fa4343ceebada919d26af7215872c2083afa227c","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"f8cb0f7099d821e549298c3aeea7b318f2113bbaa8e7327b6cc9d426646338eb","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}
+{"contentHash":"936059292ea538ea8118ac479121b97c8d700526be71b93016678821b59c86e6","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"644411a0c68bc01afaa7d8ad9d7a00ce03d8000268b4ceca19ca94642591b8ae","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}
+{"contentHash":"f8cb0f7099d821e549298c3aeea7b318f2113bbaa8e7327b6cc9d426646338eb","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"48db4b215ec59052eb2746253a2b26ef359ca457a055f6ba9399fe7793136b3e","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
+{"contentHash":"49563f6f32ae3ac798763943dfa47d79c50c2146cc8ab7bcd3cd8c565e29785e","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"285f430aa7b02b6311bd6c1763840245c6b144e2210fac97d664e4ce44ea0d27","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
+{"contentHash":"48db4b215ec59052eb2746253a2b26ef359ca457a055f6ba9399fe7793136b3e","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
+++ b/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
@@ -1,1 +1,1 @@
-{"contentHash":"f1d7b7cc4bcc833e2d82f34f65ca3e5f4c181b9cc2241013a85748679475ba4c","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}
+{"contentHash":"bf6001fd4e14f91ed6dde159c7bb7046814dedad33953a9ce473e2d8bd8fb3d4","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}

--- a/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
+++ b/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
@@ -1,1 +1,1 @@
-{"contentHash":"d77aac23178bb63cad9dcfc7d8e91f3fd37b5d4f44a4221ea1fa2ff259ccf64c","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}
+{"contentHash":"f1d7b7cc4bcc833e2d82f34f65ca3e5f4c181b9cc2241013a85748679475ba4c","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}

--- a/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
+++ b/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
@@ -1,1 +1,1 @@
-{"contentHash":"32962700af15e8ffaa754d301ffb8a1766a70c162c060a36c61d3aca4ef93adf","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}
+{"contentHash":"a73d6fd876fa9a2a32fdd0972f8655a5160652c6bbbbc93ee8e5a03787dbb0be","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}

--- a/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
+++ b/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
@@ -1,1 +1,1 @@
-{"contentHash":"291f8c385ad37dbafeeab36f8725a9b0e459e670f5db17d5d77a683f87ce830e","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}
+{"contentHash":"32962700af15e8ffaa754d301ffb8a1766a70c162c060a36c61d3aca4ef93adf","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -1,6 +1,9 @@
 /** Resolves configured agent ids, directories, workspaces, and merged agent defaults. */
 import path from "node:path";
-import { readStringValue } from "@openclaw/normalization-core/string-coerce";
+import {
+  normalizeOptionalString,
+  readStringValue,
+} from "@openclaw/normalization-core/string-coerce";
 import { getRetainedLegacyDefaultAgentId } from "../config/legacy.default-agent-owner-state.js";
 import { hasExplicitModelPolicyAllow } from "../config/model-policy-allowlist-migration.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -214,6 +217,26 @@ export function tryResolveLegacyCompatibilityAgentId(cfg: OpenClawConfig): strin
   return retainedAgentId && listAgentIds(cfg).includes(retainedAgentId)
     ? retainedAgentId
     : tryResolveDefaultAgentId(cfg);
+}
+
+/** Resolves the configured owner for ambient system work and explicit consults. */
+export function resolveSystemAgentTargetAgentId(
+  cfg: OpenClawConfig,
+  requestedAgentId?: string,
+): string {
+  const configuredAgentId =
+    normalizeOptionalString(requestedAgentId) ??
+    normalizeOptionalString(cfg.agents?.defaults?.systemAgent?.agentId);
+  if (configuredAgentId) {
+    return normalizeAgentId(configuredAgentId);
+  }
+  return normalizeAgentId(
+    tryResolveLegacyCompatibilityAgentId(cfg) ??
+      resolveDefaultAgentId(cfg, {
+        surface: "system-agent consult routing",
+        hint: "Set agents.defaults.systemAgent.agentId or pass an explicit consult agent id.",
+      }),
+  );
 }
 
 /** @deprecated Use resolveSoleAgentId; accepts raw shipped markers only for input compatibility. */

--- a/src/commands/doctor/shared/default-agent-role-materialization.test.ts
+++ b/src/commands/doctor/shared/default-agent-role-materialization.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { listAgentEntries, resolveDefaultAgentId } from "../../../agents/agent-scope-config.js";
+import { resolveSystemAgentTargetAgentId } from "../../../agents/agent-scope-config.js";
 import { materializeLegacyDefaultAgentRoles } from "../../../config/legacy.default-agent-roles.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { resolveCronJobEffectiveAgentId } from "../../../cron/agent-id.js";
 import { resolveHeartbeatAgents } from "../../../infra/heartbeat-runner.js";
 import { resolveAgentRoute } from "../../../routing/resolve-route.js";
-import { resolveSystemAgentTargetAgentId } from "../../../system-agent/inference-route.js";
 import { resolveTalkSessionAgentId, resolveTalkTargetAgentId } from "../../../talk/agent-target.js";
 
 function materializeDefaultAgentRoles(cfg: OpenClawConfig) {

--- a/src/config/sessions/main-session.runtime.ts
+++ b/src/config/sessions/main-session.runtime.ts
@@ -1,8 +1,8 @@
 // Runtime main-session lookup binds the config-backed helper for callers without config access.
 import { getRuntimeConfig } from "../io.js";
-import { resolveMainSessionKey } from "./main-session.js";
+import { resolveSystemMainSessionKey } from "./main-session.js";
 
 /** Resolves the main session key from the active runtime config. */
 export function resolveMainSessionKeyFromConfig(): string {
-  return resolveMainSessionKey(getRuntimeConfig());
+  return resolveSystemMainSessionKey(getRuntimeConfig());
 }

--- a/src/config/sessions/main-session.ts
+++ b/src/config/sessions/main-session.ts
@@ -1,4 +1,8 @@
-import { listAgentIds, resolveDefaultAgentId } from "../../agents/agent-scope-config.js";
+import {
+  listAgentIds,
+  resolveDefaultAgentId,
+  resolveSystemAgentTargetAgentId,
+} from "../../agents/agent-scope-config.js";
 // Main-session keys normalize configured agents and legacy aliases into store keys.
 import {
   normalizeAgentId,
@@ -31,6 +35,11 @@ export function resolveMainSessionKey(cfg: OpenClawConfig): string {
     mainKey: cfg.session?.mainKey,
     sessionScope: cfg.session?.scope,
   });
+}
+
+/** Resolves the main session owned by configured ambient system work. */
+export function resolveSystemMainSessionKey(cfg: OpenClawConfig): string {
+  return resolveAgentMainSessionKey({ cfg, agentId: resolveSystemAgentTargetAgentId(cfg) });
 }
 
 /** Stable fingerprint for the config values that canonicalize chat session keys. */

--- a/src/config/sessions/main-session.ts
+++ b/src/config/sessions/main-session.ts
@@ -37,9 +37,25 @@ export function resolveMainSessionKey(cfg: OpenClawConfig): string {
   });
 }
 
+/** Resolves the owner and canonical session target for ambient system work. */
+export function resolveSystemMainSessionTarget(cfg: OpenClawConfig): {
+  agentId: string;
+  sessionKey: string;
+} {
+  const agentId = resolveSystemAgentTargetAgentId(cfg);
+  return {
+    agentId,
+    sessionKey: resolveCanonicalMainSessionKey({
+      agentId,
+      mainKey: cfg.session?.mainKey,
+      sessionScope: cfg.session?.scope,
+    }),
+  };
+}
+
 /** Resolves the main session owned by configured ambient system work. */
 export function resolveSystemMainSessionKey(cfg: OpenClawConfig): string {
-  return resolveAgentMainSessionKey({ cfg, agentId: resolveSystemAgentTargetAgentId(cfg) });
+  return resolveSystemMainSessionTarget(cfg).sessionKey;
 }
 
 /** Stable fingerprint for the config values that canonicalize chat session keys. */

--- a/src/gateway/server-methods/health.owner-routing.test.ts
+++ b/src/gateway/server-methods/health.owner-routing.test.ts
@@ -1,0 +1,64 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../../config/config.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { withStateDirEnv } from "../../test-helpers/state-dir-env.js";
+import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
+import { healthHandlers } from "./health.js";
+
+afterEach(() => {
+  resetConfigRuntimeState();
+});
+
+async function callStatus(config: OpenClawConfig) {
+  setRuntimeConfigSnapshot(config, config);
+  const respond = vi.fn();
+  await healthHandlers.status!({
+    req: {} as never,
+    params: { includeChannelSummary: false },
+    respond: respond as never,
+    context: {} as never,
+    client: { connect: { role: "operator", scopes: ["operator.read"] } } as never,
+    isWebchatConnect: () => false,
+  });
+  return respond;
+}
+
+describe("Gateway status owner routing", () => {
+  it("uses the configured system owner without making public main aliases implicit", async () => {
+    await withStateDirEnv("openclaw-gateway-status-owner-", async ({ stateDir }) => {
+      const config = {
+        agents: {
+          ownership: "explicit",
+          defaults: { systemAgent: { agentId: "main" } },
+          entries: { main: {}, molty: {} },
+        },
+        session: { store: path.join(stateDir, "agents", "{agentId}", "sessions.json") },
+      } satisfies OpenClawConfig;
+
+      const respond = await callStatus(config);
+
+      expect(respond).toHaveBeenCalledTimes(1);
+      expect(respond.mock.calls[0]?.[0]).toBe(true);
+      expect(respond.mock.calls[0]?.[2]).toBeUndefined();
+      expect(resolveRequestedSessionAgentId(config, "main")).toMatchObject({ ok: false });
+      expect(resolveRequestedSessionAgentId(config, "agent:molty:main")).toEqual({
+        ok: true,
+        agentId: "molty",
+      });
+    });
+  });
+
+  it("keeps single-agent status unchanged", async () => {
+    await withStateDirEnv("openclaw-gateway-status-single-", async ({ stateDir }) => {
+      const respond = await callStatus({
+        agents: { entries: { main: {} } },
+        session: { store: path.join(stateDir, "sessions.json") },
+      });
+
+      expect(respond).toHaveBeenCalledTimes(1);
+      expect(respond.mock.calls[0]?.[0]).toBe(true);
+      expect(respond.mock.calls[0]?.[2]).toBeUndefined();
+    });
+  });
+});

--- a/src/gateway/server-methods/system-event-routing.test.ts
+++ b/src/gateway/server-methods/system-event-routing.test.ts
@@ -107,6 +107,44 @@ describe("system-event routing", () => {
     expect(respond).toHaveBeenCalledWith(true, { ok: true }, undefined);
   });
 
+  it("keeps ambient explicit-owner events on the global session queue", async () => {
+    const respond = vi.fn();
+    const request = {
+      params: { text: "Wake the system owner.", wake: true },
+      respond,
+      context: {
+        broadcast: vi.fn(),
+        incrementPresenceVersion: vi.fn(() => 1),
+        getHealthVersion: vi.fn(() => 1),
+        getRuntimeConfig: vi.fn(() => ({
+          session: { scope: "global" },
+          agents: {
+            ownership: "explicit",
+            defaults: { systemAgent: { agentId: "main" } },
+            entries: { main: {}, molty: {} },
+          },
+        })),
+      },
+    } as unknown as GatewayRequestHandlerOptions;
+
+    await expectDefined(
+      systemHandlers["system-event"],
+      'systemHandlers["system-event"] test invariant',
+    )(request);
+
+    expect(peekSystemEvents("global")).toEqual(["Wake the system owner."]);
+    expect(peekSystemEvents("agent:main:main")).toEqual([]);
+    expect(mocks.requestHeartbeat).toHaveBeenCalledWith({
+      source: "notifications-event",
+      intent: "immediate",
+      reason: "wake",
+      agentId: "main",
+      sessionKey: "global",
+      heartbeat: { target: "last" },
+    });
+    expect(respond).toHaveBeenCalledWith(true, { ok: true }, undefined);
+  });
+
   it("rejects immediate wakes for unconfigured agents", async () => {
     const respond = vi.fn();
     const request = {

--- a/src/gateway/server-methods/system.ts
+++ b/src/gateway/server-methods/system.ts
@@ -23,7 +23,7 @@ import {
 } from "../../agents/utility-model.js";
 import { tryResolveLegacyCompatibilityAgentId } from "../../config/legacy.default-agent-owner.js";
 import { resolveGatewayPort, resolveStateDir } from "../../config/paths.js";
-import { resolveMainSessionKeyFromConfig } from "../../config/sessions.js";
+import { resolveSystemMainSessionTarget } from "../../config/sessions.js";
 import { resolveAdvertisedLanHostCore } from "../../infra/advertised-lan-host.js";
 import {
   loadOrCreateProcessDeviceIdentity,
@@ -171,7 +171,10 @@ export const systemHandlers: GatewayRequestHandlers = {
       respond(false, undefined, requestedOwner.error);
       return;
     }
-    const sessionKey = requestedSessionKey ?? resolveMainSessionKeyFromConfig();
+    const systemTarget = requestedSessionKey
+      ? { agentId: requestedOwner?.agentId, sessionKey: requestedSessionKey }
+      : resolveSystemMainSessionTarget(cfg);
+    const { agentId: eventOwnerAgentId, sessionKey } = systemTarget;
     const wake = params.wake === true;
     const isNodePresenceLine = text.startsWith("Node:");
     if (wake && isNodePresenceLine) {
@@ -183,21 +186,23 @@ export const systemHandlers: GatewayRequestHandlers = {
       return;
     }
     if (wake && requestedSessionKey) {
-      const targetAgentId = normalizeAgentId(
+      const requestedAgentId = normalizeAgentId(
         requestedOwner?.agentId ?? resolveAgentIdFromSessionKey(requestedSessionKey),
       );
       const configuredAgentIds = listAgentIds(cfg).map(normalizeAgentId);
-      if (!configuredAgentIds.includes(targetAgentId)) {
+      if (!configuredAgentIds.includes(requestedAgentId)) {
         respond(
           false,
           undefined,
-          errorShape(ErrorCodes.INVALID_REQUEST, `Unknown agent id "${targetAgentId}"`),
+          errorShape(ErrorCodes.INVALID_REQUEST, `Unknown agent id "${requestedAgentId}"`),
         );
         return;
       }
       // A targeted wake starts a model run. Require a live persisted session
       // so malformed keys cannot create phantom work under agent defaults.
-      const targetSession = loadGatewaySessionRow(requestedSessionKey, { agentId: targetAgentId });
+      const targetSession = loadGatewaySessionRow(requestedSessionKey, {
+        agentId: requestedAgentId,
+      });
       if (!targetSession || targetSession.archived) {
         respond(
           false,
@@ -300,8 +305,8 @@ export const systemHandlers: GatewayRequestHandlers = {
           };
           enqueueSystemEvent(
             deltaText,
-            requestedOwner
-              ? withSystemEventOwner(eventOptions, requestedOwner.agentId)
+            eventOwnerAgentId
+              ? withSystemEventOwner(eventOptions, eventOwnerAgentId)
               : eventOptions,
           );
         }
@@ -310,7 +315,7 @@ export const systemHandlers: GatewayRequestHandlers = {
       const eventOptions = { sessionKey };
       enqueueSystemEvent(
         text,
-        requestedOwner ? withSystemEventOwner(eventOptions, requestedOwner.agentId) : eventOptions,
+        eventOwnerAgentId ? withSystemEventOwner(eventOptions, eventOwnerAgentId) : eventOptions,
       );
       if (wake) {
         // Targeted admin events may need a proactive response. Carry the exact
@@ -321,6 +326,7 @@ export const systemHandlers: GatewayRequestHandlers = {
           // The dispatcher recognizes "wake" as a payload-bearing run, so an
           // empty HEARTBEAT.md cannot suppress this queued system event.
           reason: "wake",
+          ...(!requestedSessionKey && eventOwnerAgentId ? { agentId: eventOwnerAgentId } : {}),
           sessionKey,
           heartbeat: { target: "last" },
         });

--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -16,6 +16,10 @@ const enqueueSystemEventMock = vi.fn();
 const requestHeartbeatMock = vi.fn();
 const runCronIsolatedAgentTurnMock = vi.fn();
 const resolveMainSessionKeyMock = vi.fn(() => "main-session");
+const resolveAgentMainSessionKeyMock = vi.fn(
+  (params: { cfg?: { session?: { mainKey?: string } }; agentId: string }) =>
+    `agent:${params.agentId}:${params.cfg?.session?.mainKey ?? "main"}`,
+);
 const mainRosterConfig = (): OpenClawConfig => ({
   agents: { entries: { main: {} } },
 });
@@ -51,10 +55,7 @@ vi.mock("../../config/sessions.js", () => ({
   resolveMainSessionKey: vi.fn((cfg?: { session?: { mainKey?: string; scope?: string } }) =>
     cfg?.session?.scope === "global" ? "global" : `agent:main:${cfg?.session?.mainKey ?? "main"}`,
   ),
-  resolveAgentMainSessionKey: vi.fn(
-    (params: { cfg?: { session?: { mainKey?: string } }; agentId: string }) =>
-      `agent:${params.agentId}:${params.cfg?.session?.mainKey ?? "main"}`,
-  ),
+  resolveAgentMainSessionKey: resolveAgentMainSessionKeyMock,
 }));
 vi.mock("../../config/io.js", () => ({
   getRuntimeConfig: loadConfigMock,
@@ -218,6 +219,33 @@ describe("dispatchAgentHook trust handling", () => {
       intent: "immediate",
       reason: "hook:wake",
       agentId: "hooks",
+    });
+  });
+
+  it("keeps the resolved owner when a multi-agent wake omits agentId", () => {
+    loadConfigMock.mockReturnValue({
+      agents: {
+        ownership: "explicit",
+        defaults: { systemAgent: { agentId: "main" } },
+        entries: { main: {}, molty: {} },
+      },
+    });
+
+    dispatchWakeHook({ text: "Mapped wake", mode: "now" }, "molty");
+
+    expect(resolveAgentMainSessionKeyMock).toHaveBeenCalledWith({
+      cfg: expect.any(Object),
+      agentId: "molty",
+    });
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith("Mapped wake", {
+      sessionKey: "agent:molty:main",
+    });
+    expect(requestHeartbeatMock).toHaveBeenCalledWith({
+      source: "hook",
+      intent: "immediate",
+      reason: "hook:wake",
+      agentId: "molty",
+      sessionKey: "agent:molty:main",
     });
   });
 
@@ -890,10 +918,9 @@ describe("dispatchAgentHook trust handling", () => {
     expect(requestHeartbeatMock.mock.calls[0]?.[0]?.sessionKey).toBeUndefined();
   });
 
-  it("omits the default agentId from the announce wake when no agent is named", async () => {
-    // An unnamed hook resolves its event session from fresh config at announce
-    // time; pairing the dispatch-time default agent with that session could
-    // wake a stale agent after a default-agent reload.
+  it("carries the accepted owner on an unnamed hook announce wake", async () => {
+    // Admission freezes the effective owner. Keep it paired with the scoped
+    // event session instead of rediscovering an ambient default at completion.
     runCronIsolatedAgentTurnMock.mockResolvedValueOnce({
       status: "ok",
       summary: "done",
@@ -913,9 +940,9 @@ describe("dispatchAgentHook trust handling", () => {
       source: "hook",
       intent: "immediate",
       reason: expect.stringMatching(/^hook:[0-9a-f-]+$/),
+      agentId: "main",
       sessionKey: "agent:main:main",
     });
-    expect(wake.agentId).toBeUndefined();
   });
 
   it("keeps global-scope error events and wakes on the selected agent", async () => {

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -13,7 +13,6 @@ import { getRuntimeConfig } from "../../config/io.js";
 import {
   canonicalizeMainSessionAlias,
   resolveAgentMainSessionKey,
-  resolveMainSessionKey,
   resolveMainSessionKeyFromConfig,
 } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -62,7 +61,6 @@ type HookEventTarget = {
 function resolveHookEventTarget(params: {
   cfg: OpenClawConfig;
   resolvedAgentId: string;
-  explicitAgentId?: string;
   sessionKey?: string;
 }): HookEventTarget {
   if (params.cfg.session?.scope === "global") {
@@ -83,15 +81,10 @@ function resolveHookEventTarget(params: {
           mainKey: params.cfg.session?.mainKey,
         }),
       })
-    : params.explicitAgentId
-      ? resolveAgentMainSessionKey({ cfg: params.cfg, agentId: params.explicitAgentId })
-      : resolveMainSessionKey(params.cfg);
+    : resolveAgentMainSessionKey({ cfg: params.cfg, agentId: params.resolvedAgentId });
   return {
     eventSessionKey,
-    heartbeatTarget: {
-      ...(params.explicitAgentId ? { agentId: params.explicitAgentId } : {}),
-      sessionKey: eventSessionKey,
-    },
+    heartbeatTarget: { agentId: params.resolvedAgentId, sessionKey: eventSessionKey },
   };
 }
 
@@ -453,12 +446,11 @@ export function createGatewayHooksRequestHandler(params: {
             });
             return;
           }
-          // Keep an omitted agent omitted for event routing so global session scope
-          // stays global; runner identity is frozen separately via accepted agentId.
+          // The accepted agent is the stable owner. Global scope stays global;
+          // other events keep that owner in their agent-qualified session key.
           hookEventTarget = resolveHookEventTarget({
             cfg,
             resolvedAgentId: agentId,
-            explicitAgentId: acceptedValue.agentId,
           });
           const { runCronIsolatedAgentTurn } = await loadIsolatedAgentModule();
           // Lazy module loading is the last Gateway-owned async boundary before

--- a/src/plugins/management-service.owner-routing.test.ts
+++ b/src/plugins/management-service.owner-routing.test.ts
@@ -1,0 +1,35 @@
+import { expect, it, vi } from "vitest";
+
+const metadata = vi.hoisted(() => vi.fn());
+
+vi.mock("./plugin-metadata-snapshot.js", () => ({
+  loadPluginMetadataSnapshot: (...args: unknown[]) => metadata(...args),
+  resolvePluginMetadataSnapshot: (...args: unknown[]) => metadata(...args),
+}));
+
+const { listManagedPlugins } = await import("./management-service.js");
+
+it("loads plugin metadata from the explicit system-owner workspace", async () => {
+  const config = {
+    agents: {
+      ownership: "explicit" as const,
+      defaults: { systemAgent: { agentId: "research" } },
+      entries: { main: {}, research: { workspace: "~/research-workspace" } },
+    },
+  };
+  const env = { HOME: "/tmp/openclaw-managed-plugin-home" };
+  metadata.mockReturnValue({
+    index: { plugins: [], installRecords: {} },
+    byPluginId: new Map(),
+    diagnostics: [],
+    normalizePluginId: (pluginId: string) => pluginId,
+  });
+
+  await listManagedPlugins({ config, env, officialCatalog: { entries: [] } });
+
+  expect(metadata).toHaveBeenCalledWith({
+    config,
+    env,
+    workspaceDir: "/tmp/openclaw-managed-plugin-home/research-workspace",
+  });
+});

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -3,7 +3,10 @@ import path from "node:path";
 import { asSafeIntegerInRange } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope-config.js";
+import {
+  resolveAgentWorkspaceDir,
+  resolveSystemAgentTargetAgentId,
+} from "../agents/agent-scope-config.js";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import { collectChangedPaths } from "../config/config-change-paths.js";
 import {
@@ -653,7 +656,7 @@ function resolveManagedPluginMetadataParams(config: OpenClawConfig, env: NodeJS.
   return {
     config,
     env,
-    workspaceDir: resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config), env),
+    workspaceDir: resolveAgentWorkspaceDir(config, resolveSystemAgentTargetAgentId(config), env),
   };
 }
 

--- a/src/status/summary.ts
+++ b/src/status/summary.ts
@@ -6,7 +6,7 @@ import { resolveAgentConfig } from "../agents/agent-scope.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { areRuntimeModelRefsEquivalent } from "../agents/model-runtime-aliases.js";
 import { getRuntimeConfig, projectConfigOntoRuntimeSourceSnapshot } from "../config/config.js";
-import { resolveMainSessionKey } from "../config/sessions/main-session.js";
+import { resolveSystemMainSessionKey } from "../config/sessions/main-session.js";
 import {
   hasSessionActiveAutoModelFallback,
   hasSessionAutoModelFallbackProvenance,
@@ -376,7 +376,7 @@ export async function getStatusSummary(
         }),
       )
     : [];
-  const mainSessionKey = resolveMainSessionKey(cfg);
+  const mainSessionKey = resolveSystemMainSessionKey(cfg);
   const queuedSystemEvents = peekSystemEvents(mainSessionKey);
   const taskMaintenanceModule = await loadTaskRegistryMaintenanceModule();
   taskMaintenanceModule.configureTaskRegistryMaintenance();

--- a/src/system-agent/inference-fallback.ts
+++ b/src/system-agent/inference-fallback.ts
@@ -1,5 +1,6 @@
 // Provider-neutral live inference ladder for OpenClaw sessions.
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { resolveSystemAgentTargetAgentId } from "../agents/agent-scope-config.js";
 import { listAgentIds, tryResolveDefaultAgentId } from "../agents/agent-scope.js";
 import { hasAvailableAuthForProvider } from "../agents/model-auth.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -7,7 +8,6 @@ import { normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
   resolveSystemAgentConfiguredRouteFromConfig,
-  resolveSystemAgentTargetAgentId,
   type SystemAgentConfiguredRoute,
 } from "./inference-route.js";
 import { verifySetupInference, type BoundVerifySetupInferenceResult } from "./setup-inference.js";

--- a/src/system-agent/inference-route.ts
+++ b/src/system-agent/inference-route.ts
@@ -1,12 +1,10 @@
 // Resolves the configured default agent route shared by OpenClaw inference calls.
 import { isDeepStrictEqual } from "node:util";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   listAgentEntries,
-  resolveDefaultAgentId,
+  resolveSystemAgentTargetAgentId,
   toAgentEntriesRecord,
-  tryResolveLegacyCompatibilityAgentId,
 } from "../agents/agent-scope-config.js";
 import {
   cliBackendAcceptsAuthProfileForwarding,
@@ -32,25 +30,6 @@ export type SystemAgentConfiguredRoute = {
       agentHarnessRuntimeOverride?: string;
     }
 );
-
-export function resolveSystemAgentTargetAgentId(
-  config: OpenClawConfig,
-  requestedAgentId?: string,
-): string {
-  const configuredAgentId =
-    normalizeOptionalString(requestedAgentId) ??
-    normalizeOptionalString(config.agents?.defaults?.systemAgent?.agentId);
-  if (configuredAgentId) {
-    return normalizeAgentId(configuredAgentId);
-  }
-  return normalizeAgentId(
-    tryResolveLegacyCompatibilityAgentId(config) ??
-      resolveDefaultAgentId(config, {
-        surface: "system-agent consult routing",
-        hint: "Set agents.defaults.systemAgent.agentId or pass an explicit consult agent id.",
-      }),
-  );
-}
 
 export type SystemAgentConfiguredRouteDeps = {
   readConfigFileSnapshot?: typeof import("../config/config.js").readConfigFileSnapshot;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where multi-agent Gateways with an explicit system-agent owner remained healthy, but status, hooks and cron main-session work, and plugin prewarm failed when server-owned operations fell back to unscoped `main`.

## Why This Change Was Made

Carry the configured or admitted owner through ambient system paths and centralize that resolution in the agent-scope configuration owner. The owner-aware system target preserves literal `global` session routing while carrying the configured owner separately. Public unscoped requests remain fail-closed, so this does not restore the retired implicit-default behavior.

## User Impact

Status and background work function on explicit multi-agent installations without restoring retired defaults. Single-agent installations and global-session queue semantics are unchanged.

## Evidence

- Sanitized live Molty evidence reproduced `AgentSelectionRequiredError` from status plus owner loss in agent-scoped hook/cron and plugin-prewarm lanes while the Gateway and channels remained healthy.
- Final focused regression run: 56 tests passed across status, system-event global routing, hooks, plugin metadata, and default-agent role materialization.
- Targeted `oxfmt`, type-aware `oxlint`, `git diff --check`, changed-file classification, core production/test type lanes, and local build passed.
- Mandatory branch and review-fix autoreviews plus TruffleHog scans are clean with no accepted/actionable findings.
- The first exact-head CI run exposed deterministic Plugin SDK declaration-closure hash drift from the resolver relocation. The generator-owned baseline was refreshed without adding or removing entrypoints or import specifiers, and its check is clean.
- ClawSweeper’s sole actionable finding was applied: ambient explicit-owner events now retain the literal `global` queue, carry the owner separately into the wake, and have focused Gateway regression coverage. Its other Rank-up moves described the same compatibility/session-state repair and are resolved; policy does not require a re-review because the fresh review is under 12 hours old and the post-review behavior change only addresses that finding.
- Post-deployment live proof is pending and will be performed by the deployment owner after merge.
- AI-assisted: Yes (Codex). No screenshot is needed for this server-side behavior repair.
