### PR TITLE
fix(sessions): pinned conversations survive maintenance

### DIFF
--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -1660,6 +1660,77 @@ describe("sqlite session normalization", () => {
     ).toEqual(["agent:main:newer", "agent:main:newest"]);
   });
 
+  it("preserves pinned SQLite entries and transcripts during write-triggered capping", async () => {
+    vi.mocked(getRuntimeConfig).mockReturnValue({
+      session: {
+        maintenance: {
+          mode: "enforce",
+          pruneAfter: "365d",
+          maxEntries: 2,
+        },
+      },
+    });
+    const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
+    const scopeFor = (sessionKey: string) => ({
+      agentId: "main",
+      env,
+      sessionKey,
+      storePath: paths.sqlitePath,
+    });
+    const pinnedKey = "agent:main:pinned-dashboard";
+    const pinnedSessionId = "pinned-dashboard-session";
+    const pinnedTranscriptEvent = {
+      id: "pinned-event",
+      timestamp: new Date().toISOString(),
+      type: "metadata",
+    };
+
+    await patchSessionEntryCore(
+      scopeFor(pinnedKey),
+      () => ({ sessionId: pinnedSessionId, updatedAt: 1, pinnedAt: 2 }),
+      {
+        fallbackEntry: { sessionId: pinnedSessionId, updatedAt: 1, pinnedAt: 2 },
+        replaceEntry: true,
+        skipMaintenance: true,
+      },
+    );
+    await appendTranscriptEvent(
+      { ...scopeFor(pinnedKey), sessionId: pinnedSessionId },
+      pinnedTranscriptEvent,
+    );
+    await patchSessionEntryCore(
+      scopeFor("agent:main:recent-dashboard"),
+      () => ({ sessionId: "recent-dashboard-session", updatedAt: 3 }),
+      {
+        fallbackEntry: { sessionId: "recent-dashboard-session", updatedAt: 3 },
+        replaceEntry: true,
+        skipMaintenance: true,
+      },
+    );
+
+    await patchSessionEntryCore(
+      scopeFor("agent:main:maintenance-trigger"),
+      () => ({ sessionId: "maintenance-trigger-session", updatedAt: 4 }),
+      {
+        fallbackEntry: { sessionId: "maintenance-trigger-session", updatedAt: 4 },
+        replaceEntry: true,
+      },
+    );
+
+    expect(loadSessionEntry(scopeFor(pinnedKey))).toMatchObject({
+      pinnedAt: 2,
+      sessionId: pinnedSessionId,
+    });
+    await expect(
+      loadTranscriptEvents({
+        agentId: "main",
+        env,
+        sessionId: pinnedSessionId,
+        storePath: paths.sqlitePath,
+      }),
+    ).resolves.toEqual([pinnedTranscriptEvent]);
+  });
+
   it("preserves an admitted SQLite session when another session triggers maintenance", async () => {
     vi.mocked(getRuntimeConfig).mockReturnValue({
       session: {

--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -428,8 +428,8 @@ export function shouldPreserveMaintenanceEntry(params: {
   entry: SessionEntry | undefined;
   preserveKeys?: ReadonlySet<string>;
 }): boolean {
-  // Archived sessions are user-shelved; only an explicit sessions.delete may remove them.
-  if (params.entry?.archivedAt !== undefined) {
+  // Archived and pinned sessions are user-retained; only an explicit user action may release them.
+  if (params.entry?.archivedAt !== undefined || params.entry?.pinnedAt !== undefined) {
     return true;
   }
   // A model lock is durable harness ownership, not merely a UI restriction.

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -142,6 +142,20 @@ describe("pruneStaleEntries", () => {
     expect(pruneStaleEntries(store, 30 * DAY_MS)).toBe(1);
     expect(store.archived).toBeUndefined();
   });
+
+  it("preserves pinned entries until they are unpinned", () => {
+    const now = Date.now();
+    const store = makeStore([
+      ["pinned", { ...makeEntry(now - 31 * DAY_MS), pinnedAt: now - DAY_MS }],
+    ]);
+
+    expect(pruneStaleEntries(store, 30 * DAY_MS)).toBe(0);
+    expect(store).toHaveProperty("pinned");
+
+    delete store.pinned?.pinnedAt;
+    expect(pruneStaleEntries(store, 30 * DAY_MS)).toBe(1);
+    expect(store.pinned).toBeUndefined();
+  });
 });
 
 describe("resolveQuotaSuspensionEntryMaintenance", () => {
@@ -706,6 +720,20 @@ describe("capEntryCount", () => {
 
     expect(capEntryCount(store, 2)).toBe(1);
     expect(store).toHaveProperty("archived");
+    expect(store).toHaveProperty("recent");
+    expect(store.old).toBeUndefined();
+  });
+
+  it("preserves pinned sessions when capping", () => {
+    const now = Date.now();
+    const store = makeStore([
+      ["pinned", { ...makeEntry(now - 10 * DAY_MS), pinnedAt: now - 5 * DAY_MS }],
+      ["recent", makeEntry(now)],
+      ["old", makeEntry(now - DAY_MS)],
+    ]);
+
+    expect(capEntryCount(store, 2)).toBe(1);
+    expect(store).toHaveProperty("pinned");
     expect(store).toHaveProperty("recent");
     expect(store.old).toBeUndefined();
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who pinned a dashboard conversation could still lose it when automatic session maintenance pruned stale entries or enforced the entry cap.

## Why This Change Was Made

Pinned sessions now use the same shared maintenance-immunity predicate as archived sessions. The change covers both age pruning and count capping, including the SQLite write-triggered path that owns the persisted row and transcript.

This PR intentionally does not change how protected entries are counted against `maxEntries`; that separate quota-accounting defect is handled by #123014.

AI-assisted; the implementation and tests were reviewed against the full maintenance path.

## User Impact

Pinned conversations and their transcripts remain available until the user explicitly unpins or deletes them, even when session maintenance runs.

## Regression Window

Pinning was introduced by [#98510](https://github.com/openclaw/openclaw/pull/98510) on July 4, 2026 without adding `pinnedAt` to the maintenance-preservation predicate. This is an initial feature omission rather than a later regression from working pin protection.

The first affected tagged build is `v2026.7.1-beta.3`; the first affected stable release is [v2026.7.1](https://github.com/openclaw/openclaw/releases/tag/v2026.7.1). The `v2026.7.1-1` and `v2026.7.1-2` stable updates also contain the defect.

## Evidence

- Blacksmith Testbox `tbx_01kzwna4cy4rfha44hgsw6jkqb`: targeted formatting passed.
- Focused Vitest: `store.pruning.test.ts` and `session-accessor.conformance.test.ts`, 112/112 tests passed.
- Regression coverage proves stale pruning, entry capping, and real SQLite row/transcript preservation.
- Changed-surface production/test types, targeted lint, formatting, SDK/boundary, database-first, import-cycle, dependency, and architecture guards passed.
- The aggregate changed gate's env-var ratchet is independently red on current `main` (503 actual vs 502 budget); this diff adds no environment-variable surface. All remaining planned commands passed when run against the correct `bac7a792601` base.
- Autoreview: Codex `gpt-5.6-sol` / high reasoning reported no accepted or actionable findings.
