### PR TITLE
fix(ui): open the current session desktop directly

### DIFF
--- a/ui/src/components/desktop/desktop-panel-state.ts
+++ b/ui/src/components/desktop/desktop-panel-state.ts
@@ -1,0 +1,31 @@
+import { html, nothing } from "lit";
+import { t } from "../../i18n/index.ts";
+
+export type DesktopPanelState =
+  | "picker"
+  | "inventory-error"
+  | "credentials"
+  | "connecting"
+  | "connected"
+  | "disconnected";
+
+export function renderDesktopPanelRecovery(props: {
+  inventoryError: boolean;
+  reason: string | null;
+  onRetry: () => void;
+}) {
+  return html`
+    <div class="desktop-status">
+      ${props.inventoryError
+        ? nothing
+        : html`<div>
+            ${t("desktop.disconnected", {
+              reason: props.reason ?? t("desktop.unknownReason"),
+            })}
+          </div>`}
+      <button class="desktop-button desktop-button--primary" type="button" @click=${props.onRetry}>
+        ${t(props.inventoryError ? "common.retry" : "desktop.reconnect")}
+      </button>
+    </div>
+  `;
+}

--- a/ui/src/components/desktop/desktop-panel.ts
+++ b/ui/src/components/desktop/desktop-panel.ts
@@ -23,6 +23,7 @@ import { desktopAppIcon, desktopAppLabel } from "./desktop-app-presentation.ts";
 import { DesktopClient, type DesktopConnectionHandle } from "./desktop-client.ts";
 import { desktopCredentialRequirement } from "./desktop-panel-credentials.ts";
 import { desktopPanelLauncherStyles } from "./desktop-panel-launcher-styles.ts";
+import { type DesktopPanelState, renderDesktopPanelRecovery } from "./desktop-panel-state.ts";
 import { desktopPanelStyles } from "./desktop-panel-styles.ts";
 import { desktopSourceForEnvironment } from "./desktop-source.ts";
 
@@ -39,7 +40,6 @@ const panelLayout = createDockPanelLayout({
   defaultHeight: 420,
   defaultWidth: 560,
 });
-type DesktopPanelState = "picker" | "credentials" | "connecting" | "connected" | "disconnected";
 type DesktopAppId = WorkerDesktopAppId;
 type DesktopCredentials = { username?: string; password?: string };
 type PendingDesktopConnection = {
@@ -211,11 +211,18 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
 
   private async connectRequestedEnvironment(environmentId: string): Promise<void> {
     this.returnToPicker();
+    this.environmentId = environmentId;
     this.state = "connecting";
-    const inventoryLoaded = await this.refreshEnvironments(this.operationId);
-    if (inventoryLoaded) {
-      void this.connectEnvironment(environmentId, false);
+    const operationId = this.operationId;
+    const inventoryLoaded = await this.refreshEnvironments(operationId);
+    if (operationId !== this.operationId) {
+      return;
     }
+    if (!inventoryLoaded) {
+      this.state = "inventory-error";
+      return;
+    }
+    void this.connectEnvironment(environmentId, false);
   }
 
   private async connectEnvironment(
@@ -231,11 +238,11 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
       this.clearLaunchState();
       this.credentials = undefined;
       this.credentialAuth = undefined;
-      this.desktopApps = [
-        ...(this.environments.find((environment) => environment.id === environmentId)?.worker
-          ?.desktopApps ?? []),
-      ];
     }
+    this.desktopApps = [
+      ...(this.environments.find((environment) => environment.id === environmentId)?.worker
+        ?.desktopApps ?? []),
+    ];
     this.disconnectConnection();
     const operationId = this.operationId;
     const environment = this.environments.find((candidate) => candidate.id === environmentId) ?? {
@@ -630,27 +637,6 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
     `;
   }
 
-  private renderDisconnected() {
-    return html`
-      <div class="desktop-status">
-        <div>
-          ${t("desktop.disconnected", {
-            reason: this.disconnectedReason ?? t("desktop.unknownReason"),
-          })}
-        </div>
-        <button
-          class="desktop-button desktop-button--primary"
-          type="button"
-          @click=${() =>
-            this.environmentId &&
-            void this.connectEnvironment(this.environmentId, this.controlling)}
-        >
-          ${t("desktop.reconnect")}
-        </button>
-      </div>
-    `;
-  }
-
   private renderCredentials() {
     const ardAccount = this.credentialAuth === "ard-account";
     return html`
@@ -712,10 +698,18 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
               : nothing}
           ${this.state === "picker"
             ? this.renderPicker()
-            : this.state === "credentials"
-              ? this.renderCredentials()
-              : this.state === "disconnected"
-                ? this.renderDisconnected()
+            : this.state === "inventory-error" || this.state === "disconnected"
+              ? renderDesktopPanelRecovery({
+                  inventoryError: this.state === "inventory-error",
+                  reason: this.disconnectedReason,
+                  onRetry: () =>
+                    this.environmentId &&
+                    void (this.state === "inventory-error"
+                      ? this.connectRequestedEnvironment(this.environmentId)
+                      : this.connectEnvironment(this.environmentId, this.controlling)),
+                })
+              : this.state === "credentials"
+                ? this.renderCredentials()
                 : this.renderConnection()}
         </div>
       </section>

--- a/ui/src/components/desktop/desktop-panel.ts
+++ b/ui/src/components/desktop/desktop-panel.ts
@@ -24,6 +24,7 @@ import { DesktopClient, type DesktopConnectionHandle } from "./desktop-client.ts
 import { desktopCredentialRequirement } from "./desktop-panel-credentials.ts";
 import { desktopPanelLauncherStyles } from "./desktop-panel-launcher-styles.ts";
 import { desktopPanelStyles } from "./desktop-panel-styles.ts";
+import { desktopSourceForEnvironment } from "./desktop-source.ts";
 
 const CLOSE_GLYPH = svg`<svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><path d="M4 4l8 8M12 4l-8 8" /></svg>`;
 const DOCK_BOTTOM_GLYPH = svg`<svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.3"><rect x="2" y="2.5" width="12" height="11" rx="1.5" /><path d="M2 10h12" /></svg>`;
@@ -48,16 +49,6 @@ type PendingDesktopConnection = {
   operationId: number;
 };
 type ObservedDesktopConnection = PendingDesktopConnection & { observed: DesktopObserveResult };
-
-function desktopSourceForEnvironment(environment: Pick<EnvironmentSummary, "id">): DesktopSource {
-  if (environment.id === "gateway") {
-    return { kind: "host" };
-  }
-  if (environment.id.startsWith("node:") && environment.id.length > "node:".length) {
-    return { kind: "node", nodeId: environment.id.slice("node:".length) };
-  }
-  return { kind: "environment", environmentId: environment.id };
-}
 
 /** `<openclaw-desktop-panel>` — dockable RFB access to Gateway desktop sources. */
 class OpenClawDesktopPanel extends OpenClawLitElement {
@@ -151,7 +142,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
     const wasOpen = this.dockLayout.open;
     this.dockLayout.setOpen(true);
     if (detail?.environmentId) {
-      void this.connectEnvironment(detail.environmentId, false);
+      void this.connectRequestedEnvironment(detail.environmentId);
     } else if (!wasOpen) {
       void this.refreshEnvironments();
     } else if (detail?.open !== true) {
@@ -191,28 +182,39 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
     this.launchErrorText = null;
   }
 
-  private async refreshEnvironments(): Promise<void> {
+  private async refreshEnvironments(expectedOperationId?: number): Promise<boolean> {
     const client = this.client;
     if (!client || !this.available) {
-      return;
+      return false;
     }
-    const operationId = ++this.operationId;
+    const operationId = expectedOperationId ?? ++this.operationId;
     this.loading = true;
     this.errorText = null;
     try {
       const result = await client.request<EnvironmentsListResult>("environments.list", {});
       if (operationId !== this.operationId) {
-        return;
+        return false;
       }
       this.environments = result.environments.filter((environment) => environment.desktop === true);
+      return true;
     } catch (error) {
       if (operationId === this.operationId) {
         this.errorText = t("desktop.errors.listFailed", { error: formatUiError(error) });
       }
+      return false;
     } finally {
       if (operationId === this.operationId) {
         this.loading = false;
       }
+    }
+  }
+
+  private async connectRequestedEnvironment(environmentId: string): Promise<void> {
+    this.returnToPicker();
+    this.state = "connecting";
+    const inventoryLoaded = await this.refreshEnvironments(this.operationId);
+    if (inventoryLoaded) {
+      void this.connectEnvironment(environmentId, false);
     }
   }
 

--- a/ui/src/components/desktop/desktop-source.ts
+++ b/ui/src/components/desktop/desktop-source.ts
@@ -1,0 +1,13 @@
+import type { DesktopSource, EnvironmentSummary } from "@openclaw/gateway-protocol";
+
+export function desktopSourceForEnvironment(
+  environment: Pick<EnvironmentSummary, "id">,
+): DesktopSource {
+  if (environment.id === "gateway") {
+    return { kind: "host" };
+  }
+  if (environment.id.startsWith("node:") && environment.id.length > "node:".length) {
+    return { kind: "node", nodeId: environment.id.slice("node:".length) };
+  }
+  return { kind: "environment", environmentId: environment.id };
+}

--- a/ui/src/e2e/desktop-panel.e2e.test.ts
+++ b/ui/src/e2e/desktop-panel.e2e.test.ts
@@ -27,6 +27,21 @@ function sessionsList(placement: "local" | "active") {
   };
 }
 
+const workerDesktopEnvironment = {
+  id: "worker-desktop-1",
+  type: "worker",
+  status: "available",
+  desktop: true,
+  worker: {
+    providerId: "crabbox",
+    state: "attached",
+    ageMs: 1_000,
+    attachedSessionIds: ["main"],
+    tunnelStatus: "connected",
+    desktopApps: ["browser", "terminal"],
+  },
+} as const;
+
 async function openPalette(page: import("playwright").Page) {
   await page.evaluate(() => {
     window.dispatchEvent(new CustomEvent("openclaw:command-palette-open"));
@@ -130,22 +145,7 @@ suite.define(() => {
         methodResponses: {
           "sessions.list": sessionsList("active"),
           "environments.list": {
-            environments: [
-              {
-                id: "worker-desktop-1",
-                type: "worker",
-                status: "available",
-                desktop: true,
-                worker: {
-                  providerId: "crabbox",
-                  state: "attached",
-                  ageMs: 1_000,
-                  attachedSessionIds: ["main"],
-                  tunnelStatus: "connected",
-                  desktopApps: ["browser", "terminal"],
-                },
-              },
-            ],
+            environments: [workerDesktopEnvironment],
           },
           "desktop.observe": {
             transport: "rfb",
@@ -240,6 +240,32 @@ suite.define(() => {
       expect(await gateway.getRequests("desktop.observe")).toHaveLength(0);
       expect(await panel.getByText("Desktop sources", { exact: true }).count()).toBe(0);
       expect(await panel.getByText("This machine", { exact: true }).count()).toBe(0);
+
+      await gateway.setMethodResponse("environments.list", {
+        environments: [workerDesktopEnvironment],
+      });
+      await installDesktopClientFake(panel);
+      const requestCount = (await gateway.getRequests()).length;
+      await panel.getByRole("button", { name: "Retry", exact: true }).click();
+
+      await expect
+        .poll(async () => (await gateway.getRequests("environments.list")).length)
+        .toBe(2);
+      const observeRequest = await gateway.waitForRequest("desktop.observe");
+      expect(observeRequest.params).toEqual({
+        source: { kind: "environment", environmentId: "worker-desktop-1" },
+        control: false,
+      });
+      expect(
+        (await gateway.getRequests())
+          .slice(requestCount)
+          .filter((request) => ["environments.list", "desktop.observe"].includes(request.method))
+          .map((request) => request.method),
+      ).toEqual(["environments.list", "desktop.observe"]);
+      await panel.getByRole("button", { name: "Browser", exact: true }).waitFor();
+      await panel.getByRole("button", { name: "Terminal", exact: true }).waitFor();
+      expect(await panel.getAttribute("data-connect-count")).toBe("1");
+      expect(await panel.getByText("Desktop sources", { exact: true }).count()).toBe(0);
     });
   });
 

--- a/ui/src/e2e/desktop-panel.e2e.test.ts
+++ b/ui/src/e2e/desktop-panel.e2e.test.ts
@@ -43,6 +43,16 @@ async function openDesktopPanel(page: import("playwright").Page) {
   return panel;
 }
 
+async function openDirectDesktop(page: import("playwright").Page, environmentId: string) {
+  await page.evaluate((targetEnvironmentId) => {
+    window.dispatchEvent(
+      new CustomEvent("openclaw:desktop-toggle", {
+        detail: { open: true, environmentId: targetEnvironmentId },
+      }),
+    );
+  }, environmentId);
+}
+
 async function installDesktopClientFake(panel: import("playwright").Locator) {
   await panel.evaluate((element) => {
     (
@@ -105,8 +115,174 @@ suite.define(() => {
       expect(await page.getByRole("option", { name: "Desktop", exact: true }).count()).toBe(1);
 
       await page.getByRole("option", { name: "Desktop", exact: true }).click();
-      await page.locator("openclaw-desktop-panel section[aria-label='Desktop']").waitFor();
+      const panel = page.locator("openclaw-desktop-panel");
+      await panel.locator("section[aria-label='Desktop']").waitFor();
+      await panel.getByText("Desktop sources", { exact: true }).waitFor();
       await gateway.waitForRequest("environments.list");
+      expect(await gateway.getRequests("desktop.observe")).toHaveLength(0);
+    });
+  });
+
+  it("refreshes direct-target inventory before observing the exact worker", async () => {
+    await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: ["desktop.launch", "desktop.observe", "environments.list"],
+        methodResponses: {
+          "sessions.list": sessionsList("active"),
+          "environments.list": {
+            environments: [
+              {
+                id: "worker-desktop-1",
+                type: "worker",
+                status: "available",
+                desktop: true,
+                worker: {
+                  providerId: "crabbox",
+                  state: "attached",
+                  ageMs: 1_000,
+                  attachedSessionIds: ["main"],
+                  tunnelStatus: "connected",
+                  desktopApps: ["browser", "terminal"],
+                },
+              },
+            ],
+          },
+          "desktop.observe": {
+            transport: "rfb",
+            wsPath: "/desktop/observe?token=direct",
+            expiresAtMs: 60_000,
+            control: false,
+          },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const panel = page.locator("openclaw-desktop-panel");
+      await installDesktopClientFake(panel);
+      const requestCount = (await gateway.getRequests()).length;
+
+      await openDirectDesktop(page, "worker-desktop-1");
+
+      const observeRequest = await gateway.waitForRequest("desktop.observe");
+      expect(observeRequest.params).toEqual({
+        source: { kind: "environment", environmentId: "worker-desktop-1" },
+        control: false,
+      });
+      expect(
+        (await gateway.getRequests())
+          .slice(requestCount)
+          .filter((request) => ["environments.list", "desktop.observe"].includes(request.method))
+          .map((request) => request.method),
+      ).toEqual(["environments.list", "desktop.observe"]);
+      expect(await panel.getByText("Desktop sources", { exact: true }).count()).toBe(0);
+      await panel.getByRole("button", { name: "Browser", exact: true }).waitFor();
+      await panel.getByRole("button", { name: "Terminal", exact: true }).waitFor();
+    });
+  });
+
+  it("reports an unavailable direct target without showing another source", async () => {
+    await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: ["desktop.observe", "environments.list"],
+        methodResponses: {
+          "sessions.list": sessionsList("active"),
+          "environments.list": {
+            environments: [{ id: "gateway", type: "local", status: "available", desktop: true }],
+          },
+          "desktop.observe": {
+            __mockError: {
+              code: "UNAVAILABLE",
+              message: "requested worker desktop is temporarily unavailable",
+            },
+          },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+
+      await openDirectDesktop(page, "missing-worker");
+
+      const observeRequest = await gateway.waitForRequest("desktop.observe");
+      expect(observeRequest.params).toEqual({
+        source: { kind: "environment", environmentId: "missing-worker" },
+        control: false,
+      });
+      const panel = page.locator("openclaw-desktop-panel");
+      await panel.getByText(/requested worker desktop is temporarily unavailable/).waitFor();
+      expect(await panel.getByText("Desktop sources", { exact: true }).count()).toBe(0);
+      expect(await panel.getByText("This machine", { exact: true }).count()).toBe(0);
+    });
+  });
+
+  it("shows direct-target inventory failure without observing or falling back", async () => {
+    await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: ["desktop.observe", "environments.list"],
+        methodResponses: {
+          "sessions.list": sessionsList("active"),
+          "environments.list": {
+            __mockError: {
+              code: "UNAVAILABLE",
+              message: "desktop inventory is temporarily unavailable",
+            },
+          },
+          "desktop.observe": {
+            transport: "rfb",
+            wsPath: "/desktop/observe?token=degraded",
+            expiresAtMs: 60_000,
+            control: false,
+          },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await openDirectDesktop(page, "worker-desktop-1");
+
+      const panel = page.locator("openclaw-desktop-panel");
+      await panel.getByRole("alert").filter({ hasText: "inventory" }).waitFor();
+      expect(await gateway.getRequests("desktop.observe")).toHaveLength(0);
+      expect(await panel.getByText("Desktop sources", { exact: true }).count()).toBe(0);
+      expect(await panel.getByText("This machine", { exact: true }).count()).toBe(0);
+    });
+  });
+
+  it("does not observe a direct target after its inventory refresh is closed", async () => {
+    await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: ["desktop.observe", "environments.list"],
+        methodResponses: {
+          "sessions.list": sessionsList("active"),
+          "environments.list": { environments: [] },
+          "desktop.observe": {
+            transport: "rfb",
+            wsPath: "/desktop/observe?token=stale",
+            expiresAtMs: 60_000,
+            control: false,
+          },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.deferNext("environments.list");
+      const inventoryCount = (await gateway.getRequests("environments.list")).length;
+
+      await openDirectDesktop(page, "worker-desktop-1");
+      await expect
+        .poll(async () => (await gateway.getRequests("environments.list")).length)
+        .toBe(inventoryCount + 1);
+      await page.evaluate(() => {
+        window.dispatchEvent(
+          new CustomEvent("openclaw:desktop-toggle", { detail: { open: false } }),
+        );
+      });
+      await gateway.resolveDeferred("environments.list", { environments: [] });
+      await page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+          }),
+      );
+
+      expect(
+        await page.locator("openclaw-desktop-panel section[aria-label='Desktop']").count(),
+      ).toBe(0);
+      expect(await gateway.getRequests("desktop.observe")).toHaveLength(0);
     });
   });
 

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -25,7 +25,7 @@ import {
 } from "../../lib/sessions/session-key.ts";
 import { isActiveTask } from "../../lib/tasks/data.ts";
 import { renderBoardViewSwitch } from "./board-session-surface.ts";
-import { resolveChatPanePlacement } from "./chat-pane-placement.ts";
+import { resolveChatPaneDesktopTarget, resolveChatPanePlacement } from "./chat-pane-placement.ts";
 import { ChatPaneSessionMenu } from "./chat-pane-session-menu.ts";
 import { readChatSessionActionAccess } from "./chat-session-action-access.ts";
 import { resolveChatAgentId } from "./chat-state-route.ts";
@@ -192,13 +192,19 @@ export abstract class ChatPaneHeader extends ChatPaneSessionMenu {
         ? { "continue-in-terminal": continueInTerminalDisabledReason }
         : {}),
     };
-    const desktopPanelAvailable = isDesktopPanelAvailable(this.context.gateway.snapshot);
-    const openDesktopPanel = () =>
+    const desktopEnvironmentId = resolveChatPaneDesktopTarget(row);
+    const desktopPanelAvailable =
+      desktopEnvironmentId !== null && isDesktopPanelAvailable(this.context.gateway.snapshot);
+    const openDesktopPanel = () => {
+      if (!desktopEnvironmentId) {
+        return;
+      }
       window.dispatchEvent(
         new CustomEvent<DesktopPanelToggleDetail>(DESKTOP_PANEL_TOGGLE_EVENT, {
-          detail: { open: true },
+          detail: { open: true, environmentId: desktopEnvironmentId },
         }),
       );
+    };
     const browserPanelAction = sessionWorkspace.onToggleBrowser
       ? html`<openclaw-tooltip .content=${t("browser.toggle")}>
           <button

--- a/ui/src/pages/chat/chat-pane-placement.ts
+++ b/ui/src/pages/chat/chat-pane-placement.ts
@@ -1,3 +1,4 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
@@ -5,9 +6,26 @@ import {
   requestCloudWorkerStop,
   resolveCloudWorkerStopAction,
 } from "../../components/cloud-worker-stop.ts";
+import { isCloudWorkerPlacementState } from "../../components/session-row-badges.ts";
 import { t } from "../../i18n/index.ts";
 import { readSessionMethodAccess } from "../../lib/session-method-access.ts";
 import { parseAgentSessionKey } from "../../lib/sessions/session-key.ts";
+
+export function resolveChatPaneDesktopTarget(
+  session: GatewaySessionRow | undefined,
+): string | null {
+  if (!session) {
+    return null;
+  }
+  const placement = session.placement;
+  if (isCloudWorkerPlacementState(placement?.state)) {
+    return "environmentId" in placement
+      ? (normalizeOptionalString(placement.environmentId) ?? null)
+      : null;
+  }
+  const execNode = normalizeOptionalString(session.execNode);
+  return execNode ? `node:${execNode}` : "gateway";
+}
 
 export function resolveChatPanePlacement(params: {
   gatewaySnapshot: ApplicationGatewaySnapshot;

--- a/ui/src/pages/chat/chat-pane-terminal.test.ts
+++ b/ui/src/pages/chat/chat-pane-terminal.test.ts
@@ -168,7 +168,7 @@ describe("chat pane terminal action", () => {
     }
   });
 
-  it("renders desktop controls for local sessions when the source RPC is available", () => {
+  it("targets the selected session from the desktop controls", () => {
     const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
     const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
     const localSession = {
@@ -176,12 +176,8 @@ describe("chat pane terminal action", () => {
       kind: "direct",
       updatedAt: 0,
     } satisfies GatewaySessionRow;
-    const cloudSession = {
-      ...localSession,
-      placement: { state: "active" } as GatewaySessionRow["placement"],
-    } satisfies GatewaySessionRow;
     const container = document.createElement("div");
-    const renderHeader = (session: GatewaySessionRow) => {
+    const renderHeader = (session: GatewaySessionRow | undefined) => {
       render(
         pane.renderPaneHeader(
           createSessionWorkspaceProps(state),
@@ -202,30 +198,80 @@ describe("chat pane terminal action", () => {
         ?.panelActions.map((action) => action.id) ?? [];
     const snapshot = pane.context.gateway.snapshot;
     snapshot.hello = desktopHello([], ["operator.admin"]);
-    renderHeader(cloudSession);
+    renderHeader(localSession);
     expect(container.querySelector('[aria-label="Toggle desktop panel"]')).toBeNull();
 
     snapshot.hello = desktopHello(["desktop.observe"], ["operator.admin"]);
-    renderHeader(localSession);
-    expect(container.querySelector('[aria-label="Toggle desktop panel"]')).not.toBeNull();
-    expect(panelActionIds()).toContain("desktop");
-
     const events: CustomEvent<DesktopPanelToggleDetail>[] = [];
     const listener = (event: Event) => events.push(event as CustomEvent<DesktopPanelToggleDetail>);
     window.addEventListener(DESKTOP_PANEL_TOGGLE_EVENT, listener);
     try {
-      renderHeader(localSession);
-      const button = container.querySelector<HTMLButtonElement>(
-        '[aria-label="Toggle desktop panel"]',
-      );
-      expect(button).not.toBeNull();
-      expect(panelActionIds()).toContain("desktop");
-      button?.click();
-      expect(events).toHaveLength(1);
-      expect(events[0]?.detail).toEqual({ open: true });
+      const targetCases: Array<{
+        name: string;
+        session: GatewaySessionRow;
+        environmentId: string;
+      }> = [
+        { name: "local", session: localSession, environmentId: "gateway" },
+        {
+          name: "cloud",
+          session: {
+            ...localSession,
+            execNode: "stale-node",
+            placement: {
+              state: "active",
+              environmentId: "worker-desktop-1",
+            } as GatewaySessionRow["placement"],
+          },
+          environmentId: "worker-desktop-1",
+        },
+        {
+          name: "node",
+          session: { ...localSession, execNode: "  paired-node  " },
+          environmentId: "node:paired-node",
+        },
+        {
+          name: "reclaimed",
+          session: {
+            ...localSession,
+            execNode: " reclaimed-node ",
+            placement: {
+              state: "reclaimed",
+              environmentId: "former-worker",
+            } as GatewaySessionRow["placement"],
+          },
+          environmentId: "node:reclaimed-node",
+        },
+      ];
+      for (const testCase of targetCases) {
+        renderHeader(testCase.session);
+        const button = container.querySelector<HTMLButtonElement>(
+          '[aria-label="Toggle desktop panel"]',
+        );
+        expect(button, testCase.name).not.toBeNull();
+        expect(panelActionIds(), testCase.name).toContain("desktop");
+        button?.click();
+        expect(events.at(-1)?.detail, testCase.name).toEqual({
+          open: true,
+          environmentId: testCase.environmentId,
+        });
+      }
+
+      const eventCount = events.length;
+      renderHeader({
+        ...localSession,
+        execNode: "must-not-fall-back",
+        placement: { state: "requested" } as GatewaySessionRow["placement"],
+      });
+      expect(container.querySelector('[aria-label="Toggle desktop panel"]')).toBeNull();
+      expect(panelActionIds()).not.toContain("desktop");
+      expect(events).toHaveLength(eventCount);
+
+      renderHeader(undefined);
+      expect(container.querySelector('[aria-label="Toggle desktop panel"]')).toBeNull();
+      expect(panelActionIds()).not.toContain("desktop");
 
       snapshot.hello = desktopHello(["desktop.observe"], ["operator.read"]);
-      renderHeader(cloudSession);
+      renderHeader(localSession);
       expect(container.querySelector('[aria-label="Toggle desktop panel"]')).toBeNull();
     } finally {
       window.removeEventListener(DESKTOP_PANEL_TOGGLE_EVENT, listener);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening **Desktop** from a chat session were shown the Gateway-wide **Desktop sources** picker and had to choose a second time, even though the session already has one authoritative execution environment.

## Why This Change Was Made

The chat header now resolves the current session directly to its Gateway host, cloud-worker environment, or execution node and passes that target to the Desktop panel. Direct activation refreshes the environment inventory before observing so worker app metadata remains available, while unresolved remote placements never fall back to another machine. The command-palette Desktop action remains the explicit global source picker.

## User Impact

Clicking **Desktop** inside a local, cloud, or node-hosted session now opens that session's desktop immediately. Users no longer need to select **This machine** or another already-known source a second time.

## Evidence

- Regression proof before the fix: the local-session header emitted only `{ open: true }` instead of targeting `gateway`.
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane-terminal.test.ts` — 9 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/desktop-panel.e2e.test.ts` — 12 passed.
- `node scripts/check-changed.mjs -- <seven changed UI paths>` — passed after remote Testbox was unavailable and the repository wrapper fell back to local execution.
- Fresh Codex autoreview — clean, no accepted/actionable findings.
- Production LOC: +113/-49 (net +64); tests: +270/-22.
- Before (current Team production): clicking **Desktop** opens the Gateway-wide source picker and requires a second **Connect** action.

  ![Before: session Desktop opens the source picker](https://github.com/user-attachments/assets/898cd769-7657-4a5f-a3e6-a9635e5d989b)

- After, live on Team at the first PR head `84a63af11ea0ed2fe791fa4b219a83e6b2505609`: one **Desktop** click goes directly through **Connecting to desktop…** to the real XFCE/RFB canvas. No source picker or second **Connect** action appears. Final head `dad46ead768712c99ff7341f47ff6af2b225c7e4` adds only the review-requested retry state for inventory failures; the successful routing path shown here is unchanged.

https://github.com/user-attachments/assets/81d541e4-97d8-4d80-817d-961ce99f8d1b

  ![After: session Desktop is connected directly](https://github.com/user-attachments/assets/fb651086-cf8f-4382-be13-fb612dee6f9e)

- Live deployment proof: cold build with cache disabled, non-interactive Doctor, `/healthz` 200, `/readyz` 200, exact deployed source SHA verified before recording. Team was then restored to current `main` with auto-update enabled.
- Review recovery proof on final head: the inventory-failure E2E now shows **Retry**, performs a second `environments.list`, observes the same retained worker target, and never exposes the source picker.

AI-assisted change; implementation and behavior were independently reviewed and verified against the owning UI and Gateway boundaries.
