### PR TITLE
fix(agents): report headless wall-clock expiry consistently

### DIFF
--- a/src/agents/code-mode-headless.ts
+++ b/src/agents/code-mode-headless.ts
@@ -99,10 +99,9 @@ async function runHeadlessWorkerLeg(params: {
 }): Promise<CodeModeWorkerResult> {
   const remainingMs = remainingHeadlessMs(params.deadline);
   const timeoutMs = Math.max(1, Math.min(params.config.timeoutMs, remainingMs));
-  const workerTimeoutMs = Math.max(
-    1,
-    Math.min(remainingMs, timeoutMs + CODE_MODE_WORKER_WATCHDOG_GRACE_MS),
-  );
+  // Let the headless abort scope own the wall-clock deadline. Capping the host
+  // watchdog to the same deadline makes its internal timeout message race the scope.
+  const workerTimeoutMs = timeoutMs + CODE_MODE_WORKER_WATCHDOG_GRACE_MS;
   return await runCodeModeWorker(
     {
       ...params.input,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a headless Code Mode wall-clock expiry could intermittently report the internal `code mode worker timeout exceeded` message instead of the owning headless timeout message. This was observed in PR #122955 CI run 31666366638 even though the timeout code remained correct.

## Why This Change Was Made

The headless path capped both the guest timeout and the host worker watchdog to the same remaining wall-clock deadline. The two timers could therefore expire together, letting the internal watchdog win the message race. The worker watchdog now retains the existing two-second grace used by the resumable Code Mode paths, while the headless abort scope remains the sole owner of the wall-clock deadline.

## User Impact

Headless wall-clock expiry is now classified and reported consistently. Guest execution time and the outer wall-clock limit are unchanged; only the later host watchdog keeps its intended cleanup grace.

AI-assisted; I reviewed and understand the change.

## Evidence

- Before: [PR #122955 CI run 31666366638](https://github.com/openclaw/openclaw/actions/runs/31666366638), `agentic-agents-core-runtime`, failed with expected `code mode timeout exceeded` and received `code mode worker timeout exceeded`.
- Before, standalone Linux reproduction: [Blacksmith Testbox run 31666974106](https://github.com/openclaw/openclaw/actions/runs/31666974106) failed `node scripts/run-vitest.mjs src/agents/code-mode-headless.test.ts` with the same message race, ruling out sibling fake-timer leakage.
- After, rebased head: [Blacksmith Testbox run 31667289740](https://github.com/openclaw/openclaw/actions/runs/31667289740) passed the same focused file, 64/64 tests.
- `node_modules/.bin/oxfmt --check src/agents/code-mode-headless.ts` passed on Testbox.
- `git diff --check` passed.
- Structured Codex autoreview reported no accepted/actionable findings.
- `node scripts/check-changed.mjs -- src/agents/code-mode-headless.ts` reached the repository env-var ratchet but is currently blocked by unrelated base drift: current `origin/main` contains 503 distinct `OPENCLAW_*` names against the existing budget of 502. This patch adds no environment variable.

Production LOC: +3/-4 (net -1). Tests: +0/-0; the existing boundary regression failed before the fix and passes after it.
