### PR TITLE
improve: speed up MCP runtime tests

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -28,6 +28,15 @@ import type { SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
 import { writeExecutable } from "./bundle-mcp-shared.test-harness.js";
 import { updateMcpAppModelContext } from "./mcp-app-model-context.js";
 
+const pluginToolMetadata = vi.hoisted(() => new WeakMap<object, unknown>());
+
+vi.mock("../plugins/tools.js", () => ({
+  getPluginToolMeta: (tool: object) => pluginToolMetadata.get(tool),
+  setPluginToolMeta: (tool: object, metadata: unknown) => {
+    pluginToolMetadata.set(tool, metadata);
+  },
+}));
+
 vi.mock("./embedded-agent-mcp.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./embedded-agent-mcp.js")>();
   return {
@@ -50,6 +59,13 @@ vi.mock("./embedded-agent-mcp.js", async (importOriginal) => {
     },
   };
 });
+
+vi.mock("./mcp-auth-profile.js", () => ({
+  resolveMcpAuthProfileId: () => undefined,
+  withMcpAuthProfileBearer: () => {
+    throw new Error("Unexpected auth-profile transport in MCP runtime test");
+  },
+}));
 
 const tempDirs: string[] = [];
 const tempDirTracker = useAutoCleanupTempDirTracker(afterEach);
@@ -1477,46 +1493,6 @@ describe("session MCP runtime", () => {
 
       expect(catalog.tools).toHaveLength(1);
       expect(catalog.tools[0]?.description).toBe(`${safePrefix}...`);
-    } finally {
-      await runtime.dispose();
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
-  });
-
-  it("rejects adversarial MCP tool filters without regex backtracking", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-linear-filter-"));
-    const serverPath = path.join(tempDir, "linear-filter.mjs");
-    const logPath = path.join(tempDir, "server.log");
-    await writeListToolsMcpServer({
-      filePath: serverPath,
-      logPath,
-      tools: [
-        {
-          name: `${"a".repeat(64)}c`,
-          inputSchema: { type: "object", properties: {} },
-        },
-      ],
-    });
-
-    const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-linear-tool-filter",
-      sessionKey: "agent:test:session-linear-tool-filter",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            docs: {
-              command: process.execPath,
-              args: [serverPath],
-              toolFilter: { include: [`${"*a".repeat(24)}*b`] },
-            },
-          },
-        },
-      },
-    });
-
-    try {
-      expect((await runtime.getCatalog()).tools).toEqual([]);
     } finally {
       await runtime.dispose();
       await fs.rm(tempDir, { recursive: true, force: true });

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -81,7 +81,7 @@ import {
 import { getOpenClawStateRuntimeSchema } from "./openclaw-state-schema-compatibility.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.js";
 
-const OPENCLAW_STATE_MIGRATION_ASSERTIONS = {
+const STATE_MIGRATION_ASSERTIONS = {
   5: assertOpenClawStateDatabaseV5ForMigration,
   6: assertOpenClawStateDatabaseV6ForMigration,
 } as const;
@@ -178,7 +178,7 @@ function repairOpenClawStateDatabaseSchemaWithWriteAccess(
             allowedMissingTables: LAZY_ADDITIVE_STATE_TABLES,
           });
         } else if (previousVersion === 5 || previousVersion === 6) {
-          OPENCLAW_STATE_MIGRATION_ASSERTIONS[previousVersion](db, { pathname });
+          STATE_MIGRATION_ASSERTIONS[previousVersion](db, { pathname });
         }
         if (rebuiltIndexNames.size === 0) {
           assertSqliteIntegrity(db, pathname);
@@ -366,7 +366,7 @@ function ensureSchema(db: DatabaseSync, pathname: string, env: NodeJS.ProcessEnv
           ensureAdditiveStateColumns(db);
           assertCurrentStateRuntimeSchema(db, pathname);
         } else if (previousVersion === 5 || previousVersion === 6) {
-          OPENCLAW_STATE_MIGRATION_ASSERTIONS[previousVersion](db, { pathname });
+          STATE_MIGRATION_ASSERTIONS[previousVersion](db, { pathname });
         }
         dropLegacyStateTables(db);
         migrateRetiredCommitmentsSchema(db, previousVersion);


### PR DESCRIPTION
## What Problem This Solves

The 92-case session MCP runtime suite spent most of its fresh-cache wall time importing broad plugin-registry and auth-profile runtime graphs unrelated to the lifecycle, catalog, requester-scope, and transport contracts it owns.

## Why This Change Was Made

The suite now uses explicit test-local implementations for plugin-tool metadata and the unused auth-profile leaves. Its fixtures do not configure auth profiles or OAuth; dedicated `mcp-auth-profile.test.ts` and `mcp-transport.test.ts` retain the real bearer/transport contracts. The embedded loader keeps a narrow real call-through for this suite's `agent-bundle-probe` fixture. The separate Agent Plugins composition test runs after mock/module reset and loads the real modules.

The duplicate adversarial tool-filter subprocess test was removed: `agent-bundle-mcp-filter.test.ts` already applies a substantially larger hostile pattern/value directly to the exact linear matcher, while the retained runtime include/exclude test still proves filter wiring and catalog counts.

This also repairs current `main`'s env-var-count gate by renaming a newly introduced internal constant that accidentally looked like a public `OPENCLAW_*` environment variable; behavior is unchanged.

## User Impact

No product behavior changes. Focused MCP runtime CI becomes faster and uses roughly 217 MiB less peak RSS without adding workers or shards.

## Evidence

Identical fresh-cache command on the same orb, Node 24.15.0, single worker:

```text
node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime.test.ts \
  --maxWorkers=1 --reporter=verbose
```

with unique `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH` values and import timing enabled:

| Metric | Before | After | Gain |
| --- | ---: | ---: | ---: |
| Wall | 25.12s | 16.68s | 8.44s (33.6%) |
| Vitest | 18.21s | 10.28s | 7.93s (43.5%) |
| Import | 10.95s | 3.20s | 7.75s (70.8%) |
| Peak RSS | 765,988 KiB | 543,988 KiB | 222,000 KiB (29.0%) |

Verification:
- Focused benchmark: 91/91 passed.
- Runtime plus filter/materialization/auth/transport/Agent Plugins owners: 125/125 passed across the relevant shards.
- `src/state/openclaw-state-db.test.ts`: 143/143 passed.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs -- ...`: passed all selected core/type/lint/guard lanes.
- `git diff --check`: passed.

Autoreview preflight and TruffleHog passed, but this orb does not have a supported reviewer CLI installed (`codex` missing), so exact-head CI and independent PR review remain the landing gates.
