### PR TITLE
fix(telegram): stop tracking unsent media in streaming block replies

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch-reply.ts
+++ b/extensions/telegram/src/bot-message-dispatch-reply.ts
@@ -439,7 +439,10 @@ export async function deliverReply(
     if (finalization && turn.bufferedFinalSettlement) {
       turn.bufferedFinalSettlement.visibleReplySent ||= blockDelivered;
     }
-    trackBlockMedia(turn, blockDelivered, info.kind, effectivePayload);
+    // Streaming block segments deliver text only (finalizePreview strips media in
+    // lane-delivery-text-deliverer). Media is tracked after a real sendPayload in
+    // the non-segmented branches below; recording it here lets the final dedup
+    // drop attachments that were never actually sent.
     return toTelegramReplyDeliveryResult(blockDelivered, finalization);
   }
 


### PR DESCRIPTION
## What Problem This Solves

When a Telegram streamed block reply carries **both text and media**, the text is split into lane segments and streamed as a draft preview, but the media is never delivered during the block phase. Despite that, `trackBlockMedia` at `bot-message-dispatch-reply.ts:442` recorded every `effectivePayload.mediaUrls` into `turn.sentBlockMediaUrls` based on text-delivery success (`blockDelivered`). Later, the final reply's `deduplicateBlockSentMedia` removed those URLs because they appeared "already sent." The attachment was therefore **never delivered to the user**, with no error to the caller.

## Why This Change Was Made

`trackBlockMedia(turn, blockDelivered, info.kind, effectivePayload)` in the streaming-segment path (`segments.length > 0`) incorrectly used `blockDelivered` (text-delivery success) as proof that media was sent. Streaming block segments deliver **text only** — `finalizePreview` is `false` for block replies (`lane-delivery-text-deliverer.ts:411-412`), so `deliverLaneText` strips media via `textOnlyPayload` (`:116-125`) and the media-send branch (`:455`, guarded by `finalizePreview && reply.hasMedia`) is skipped.

Media that **is** actually sent is already tracked after a real `sendPayload` call in the non-segmented branches (`:468`, `:488`). The segment-path call at `:442` was spurious — relocated by a pure refactor (#122091) that moved existing controller logic without re-deriving the tracking condition.

## User Impact

When an agent's reply is streamed to Telegram (the default for supported providers) and includes both text and an attachment (image/file), the **attachment is silently dropped** — the user receives only the text. The agent believes it sent the attachment (no error). This affects all streamed Telegram replies with media.

## Evidence

**Root cause verification** (code read on main `90beb639e7e`):
- `bot-message-dispatch-reply.ts:442` — `trackBlockMedia(turn, blockDelivered, info.kind, effectivePayload)` in `segments.length > 0` branch; `blockDelivered` comes from text-segment delivery (`:425`), not media delivery.
- `trackBlockMedia` (`:189-200`) — records `payload.mediaUrls` into `turn.sentBlockMediaUrls` when `delivered && kind === "block"`.
- `deduplicateBlockSentMedia` (`:216`, final phase) — filters out `sentBlockMediaUrls` from final payload → media dropped.
- `lane-delivery-text-deliverer.ts:411-412` — `finalizePreview = false` for block → media stripped (`:116-125`), media-send skipped (`:455`).
- Non-segmented branches (`:468`, `:488`) already call `trackBlockMedia` after real `sendPayload` — correct.

**Tests**: `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch` → 247 passed (17 files), no regressions.

**Production LOC**: +3 comment / -1 call (net +2 comment lines, -1 functional line).

**Note on test coverage**: `deliverReply` has no dedicated integration test (no `bot-message-dispatch-reply.test.ts`); the `media-dedup.test.ts` suite covers the pure `deduplicateBlockSentMedia` function but not the caller's tracking condition. The spurious `trackBlockMedia` call was relocated by refactor #122091 (2026-08-11) without re-deriving the text-vs-media delivery distinction, so it was never caught.
