### PR TITLE
fix(e2e): declare agents-delete fixture owners

### DIFF
--- a/scripts/e2e/lib/fixtures/workspace.mjs
+++ b/scripts/e2e/lib/fixtures/workspace.mjs
@@ -30,6 +30,8 @@ function writeAgentsDeleteConfig() {
   fs.mkdirSync(sharedWorkspace, { recursive: true });
   writeJson(path.join(stateDir, "openclaw.json"), {
     agents: {
+      ownership: "explicit",
+      defaults: { heartbeat: { agentId: "main" } },
       entries: {
         main: { workspace: sharedWorkspace },
         ops: { workspace: sharedWorkspace },

--- a/test/scripts/fixtures-workspace.test.ts
+++ b/test/scripts/fixtures-workspace.test.ts
@@ -21,6 +21,17 @@ function runAgentsDeleteAssert(root: string, outputPath: string, env: Record<str
   });
 }
 
+function runAgentsDeleteConfig(root: string) {
+  const stateDir = path.join(root, "state");
+  const workspace = path.join(root, "workspace");
+  mkdirSync(stateDir, { recursive: true });
+  const result = spawnSync(process.execPath, [FIXTURE_SCRIPT, "agents-delete-config"], {
+    encoding: "utf8",
+    env: { ...process.env, OPENCLAW_STATE_DIR: stateDir, SHARED_WORKSPACE: workspace },
+  });
+  return { result, stateDir, workspace };
+}
+
 function runOpenWebUiWorkspace(workspaceDir: string) {
   return spawnSync(process.execPath, [FIXTURE_SCRIPT, "openwebui-workspace"], {
     encoding: "utf8",
@@ -32,6 +43,18 @@ function runOpenWebUiWorkspace(workspaceDir: string) {
 }
 
 describe("workspace fixture assertions", () => {
+  it("writes explicit owners for the shared-workspace agents", () => {
+    const root = tempDirs.make("openclaw-fixture-workspace-");
+    const { result, stateDir, workspace } = runAgentsDeleteConfig(root);
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(readFileSync(path.join(stateDir, "openclaw.json"), "utf8")).agents).toEqual({
+      ownership: "explicit",
+      defaults: { heartbeat: { agentId: "main" } },
+      entries: { main: { workspace }, ops: { workspace } },
+    });
+  });
+
   it("prepares Open WebUI without retired workspace setup state", () => {
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-fixture-workspace-"));
     const workspaceDir = path.join(root, "workspace");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the agents-delete shared-workspace Docker E2E lane could not start the gateway after multi-agent ownership validation became explicit.

## Why This Change Was Made

The fixture now declares the two-agent roster as explicitly owned and assigns ambient heartbeat scheduling to `main`. A focused fixture test locks the complete generated agents configuration.

## User Impact

No production behavior changes. Main qualification can exercise the shared-workspace agent deletion flow instead of failing during gateway startup.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/fixtures-workspace.test.ts src/config/zod-schema.agents.test.ts` — 6/6 and 17/17 passed.
- `bash scripts/e2e/agents-delete-shared-workspace-docker.sh` — passed locally against the rebased branch.
- `node scripts/check-changed.mjs -- scripts/e2e/lib/fixtures/workspace.mjs test/scripts/fixtures-workspace.test.ts` — passed on Blacksmith Testbox `tbx_01kzwnwkatpcn1n72a3tv1k36s`.
- `git diff --check` — passed.
