### PR TITLE
fix(signal): fail probe when RPC verification fails

### DIFF
--- a/extensions/signal/src/core.test.ts
+++ b/extensions/signal/src/core.test.ts
@@ -218,6 +218,26 @@ describe("probeSignal", () => {
     expect(res.status).toBe(200);
   });
 
+  it("returns ok=false when the version RPC fails after a successful check", async () => {
+    vi.spyOn(clientModule, "signalCheck").mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+      error: null,
+    });
+    vi.spyOn(clientModule, "signalRpcRequest").mockRejectedValueOnce(
+      new Error("Signal RPC returned malformed JSON"),
+    );
+
+    const res = await probeSignal("http://127.0.0.1:8080", 1000);
+
+    expect(res).toMatchObject({
+      ok: false,
+      status: 204,
+      error: "Signal RPC returned malformed JSON",
+      version: null,
+    });
+  });
+
   it("preserves every version reported by a Signal REST container", async () => {
     vi.spyOn(clientModule, "signalCheck").mockResolvedValueOnce({
       ok: true,

--- a/extensions/signal/src/probe.ts
+++ b/extensions/signal/src/probe.ts
@@ -79,7 +79,7 @@ async function probeSignalTransport(
     } catch (error) {
       result.error = formatErrorMessage(error);
     }
-    return { ...result, ok: true, status: check.status ?? null };
+    return { ...result, ok: result.error === null, status: check.status ?? null };
   });
 }
 


### PR DESCRIPTION
Closes #122995

## What Problem This Solves

Fixes an issue where Signal channel status could report `works` after the external/native JSON-RPC version check failed, as long as the shallow HTTP check succeeded.

## Why This Change Was Made

The Signal probe now derives its canonical `ok` outcome from the existing recorded RPC error. The plugin continues to preserve the shallow HTTP status, parsed version, error text, timing, transport detection, and container receive checks; Gateway status behavior already handles `ok:false` correctly.

## User Impact

Operators now see `probe failed` and the real Signal RPC diagnostic instead of a false-green `works` result when the configured send transport is unusable.

## Evidence

- Tests-first regression failed before the source repair: expected `ok:false`, received `ok:true`; the status, error, and null version were already preserved.
- Focused Signal core suite: 61/61 passed.
- Exact-head CI completed green: https://github.com/openclaw/openclaw/actions/runs/31667635596.
- A standalone Testbox changed-gate attempt (`tbx_01kzwpp15z8pbf1wv4xdaz1kmt`, https://github.com/openclaw/openclaw/actions/runs/31667709014) stopped before Signal checks on the stale branch base because the env-var ratchet miscounted internal constant `OPENCLAW_STATE_MIGRATION_ASSERTIONS`; current main already fixed that unrelated false positive in `e4e558df215a`, and the exact merge-ref CI above is green.
- Targeted formatting, extension lint, and `git diff --check` passed.
- Final integrated Codex autoreview: clean, no findings, confidence 0.99; TruffleHog clean.
- Exact-head ClawSweeper review reported no findings and named this producer-side repair the best solution: https://github.com/openclaw/openclaw/pull/123001#issuecomment-5276219455.

Production delta: +1/-1, net 0. Tests: +20.