### PR TITLE
fix: prevent $-pattern injection in tilde expansion across extensions

### DIFF
--- a/extensions/browser/src/browser/config.test.ts
+++ b/extensions/browser/src/browser/config.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { createOpenClawTestState, type OpenClawTestState } from "openclaw/plugin-sdk/test-state";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { BrowserConfig, BrowserProfileConfig } from "../config/config.js";
 import { resolveUserPath } from "../utils.js";
 import {
@@ -156,6 +156,17 @@ describe("browser config", () => {
       },
     });
     expect(resolveProfile(resolved, "work")?.cdpPort).toBe(20123);
+  });
+
+  it("keeps literal $ patterns in home when expanding a tilde executable path", () => {
+    const spy = vi.spyOn(os, "homedir").mockReturnValue("/home/$&user");
+    try {
+      expect(resolveBrowserConfig({ executablePath: "~/chrome-bin" }).executablePath).toBe(
+        path.resolve("/home/$&user/chrome-bin"),
+      );
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("does not assign an implicit extension relay an explicitly pinned extension port", () => {

--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -183,7 +183,7 @@ function normalizeExecutablePath(raw: string | undefined): string | undefined {
   if (!/^~(?=$|[\\/])/.test(value)) {
     return value;
   }
-  return path.resolve(value.replace(/^~(?=$|[\\/])/, os.homedir()));
+  return path.resolve(value.replace(/^~(?=$|[\\/])/, () => os.homedir()));
 }
 
 function normalizeExistingSessionCdpUrl(

--- a/extensions/imessage/src/cli-path.test.ts
+++ b/extensions/imessage/src/cli-path.test.ts
@@ -1,0 +1,21 @@
+// Imessage plugin tests cover CLI path tilde expansion.
+import { describe, expect, it } from "vitest";
+import { expandIMessageUserPath } from "./cli-path.js";
+
+describe("expandIMessageUserPath", () => {
+  it("does not interpret $ patterns in home when expanding tildes", () => {
+    const previous = process.env.HOME;
+    process.env.HOME = "/home/user$&d";
+    try {
+      expect(expandIMessageUserPath("~/Library/Messages/chat.db")).toBe(
+        "/home/user$&d/Library/Messages/chat.db",
+      );
+    } finally {
+      if (previous === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previous;
+      }
+    }
+  });
+});

--- a/extensions/imessage/src/cli-path.ts
+++ b/extensions/imessage/src/cli-path.ts
@@ -35,7 +35,7 @@ export function expandIMessageUserPath(value: string): string {
     return value;
   }
   const home = resolveIMessageHomeDir();
-  return home ? value.replace(/^~(?=$|[\\/])/, home) : value;
+  return home ? value.replace(/^~(?=$|[\\/])/, () => home) : value;
 }
 
 function resolveIMessageExecutable(cliPath: string): string | undefined {

--- a/extensions/memory-lancedb/doctor-contract-api.test.ts
+++ b/extensions/memory-lancedb/doctor-contract-api.test.ts
@@ -121,6 +121,47 @@ describe("memory-lancedb doctor migration", () => {
     migratedConnection.close();
   });
 
+  test("keeps literal $ patterns in home when expanding a tilde dbPath", async () => {
+    const home = path.join(getTmpDir(), "home$&d");
+    const dollarDbPath = path.join(home, "lancedb-dollar");
+    const connection = await lancedb.connect(dollarDbPath);
+    const table = await connection.createTable("memories", [
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        text: "legacy shared memory",
+        vector: [1, 0],
+        importance: 0.7,
+        category: "fact",
+        createdAt: 1,
+      },
+    ]);
+    table.close();
+    connection.close();
+
+    const config = {
+      agents: { list: [{ id: "main", default: true }] },
+      plugins: {
+        entries: {
+          "memory-lancedb": {
+            config: { dbPath: "~/lancedb-dollar" },
+          },
+        },
+      },
+    };
+    const params = {
+      config,
+      env: { ...process.env, HOME: home },
+      stateDir: getTmpDir(),
+      oauthDir: path.join(getTmpDir(), "oauth"),
+      context: unusedDoctorContext,
+    };
+    const migration = expectDefined(stateMigrations[0], "memory-lancedb state migration");
+
+    await expect(migration.detectLegacyState(params)).resolves.toMatchObject({
+      preview: [expect.stringContaining(dollarDbPath)],
+    });
+  });
+
   test("deletes only structurally complete legacy envelope rows", async () => {
     const benignRows = [
       {

--- a/extensions/memory-lancedb/doctor-contract-api.ts
+++ b/extensions/memory-lancedb/doctor-contract-api.ts
@@ -115,7 +115,7 @@ function resolveConfiguredDbPath(
     return configured;
   }
   if (configured.startsWith("~")) {
-    return path.resolve(configured.replace(/^~(?=$|[\\/])/, resolveHome(env)));
+    return path.resolve(configured.replace(/^~(?=$|[\\/])/, () => resolveHome(env)));
   }
   // Plugin runtime api.resolvePath() anchors relative paths at this same root.
   return path.resolve(pluginRoot, configured);

--- a/extensions/migrate-claude/helpers.ts
+++ b/extensions/migrate-claude/helpers.ts
@@ -15,7 +15,7 @@ export function resolveHomePath(input: string): string {
   if (!trimmed) {
     return trimmed;
   }
-  return path.resolve(trimmed.replace(/^~(?=$|[\\/])/u, os.homedir()));
+  return path.resolve(trimmed.replace(/^~(?=$|[\\/])/u, () => os.homedir()));
 }
 
 export async function exists(filePath: string): Promise<boolean> {

--- a/extensions/migrate-claude/provider.test.ts
+++ b/extensions/migrate-claude/provider.test.ts
@@ -61,6 +61,15 @@ describe("Claude migration provider", () => {
     }
   });
 
+  it("keeps literal $ patterns in home when expanding tildes", () => {
+    const spy = vi.spyOn(os, "homedir").mockReturnValue("/home/$&user");
+    try {
+      expect(resolveHomePath("~/.claude")).toBe(path.resolve("/home/$&user/.claude"));
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   it("rejects missing Claude sources before planning", async () => {
     const root = testWorkspace.dir;
     const source = path.join(root, "missing");

--- a/extensions/migrate-hermes/helpers.ts
+++ b/extensions/migrate-hermes/helpers.ts
@@ -19,7 +19,7 @@ const EDGE_DASHES_RE = /^-+|-+$/g;
 
 export function resolveHomePath(input: string): string {
   const value = input.trim();
-  return value ? path.resolve(value.replace(HOME_SHORTHAND_RE, os.homedir())) : value;
+  return value ? path.resolve(value.replace(HOME_SHORTHAND_RE, () => os.homedir())) : value;
 }
 
 export async function exists(filePath: string): Promise<boolean> {

--- a/extensions/migrate-hermes/provider.test.ts
+++ b/extensions/migrate-hermes/provider.test.ts
@@ -8,7 +8,7 @@ import {
   tempWorkspace,
   type TempWorkspace,
 } from "openclaw/plugin-sdk/temp-path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveHomePath } from "./helpers.js";
 import pluginEntry from "./index.js";
 import { HERMES_REASON_INCLUDE_SECRETS } from "./items.js";
@@ -53,6 +53,15 @@ describe("Hermes migration provider", () => {
       } else {
         process.env.OPENCLAW_HOME = previous;
       }
+    }
+  });
+
+  it("keeps literal $ patterns in home when expanding tildes", () => {
+    const spy = vi.spyOn(os, "homedir").mockReturnValue("/home/$&user");
+    try {
+      expect(resolveHomePath("~/.hermes")).toBe(path.resolve("/home/$&user/.hermes"));
+    } finally {
+      spy.mockRestore();
     }
   });
 

--- a/extensions/onepassword/onepassword-secret-ref-resolver.js
+++ b/extensions/onepassword/onepassword-secret-ref-resolver.js
@@ -89,7 +89,7 @@ function resolveOpenClawHome() {
     return resolveOsHome();
   }
   if (explicit === "~" || explicit.startsWith("~/") || explicit.startsWith("~\\")) {
-    return path.resolve(explicit.replace(/^~(?=$|[\\/])/u, resolveOsHome()));
+    return path.resolve(explicit.replace(/^~(?=$|[\\/])/u, () => resolveOsHome()));
   }
   return path.resolve(explicit);
 }
@@ -98,7 +98,7 @@ function resolveStateDir() {
   const override = process.env.OPENCLAW_STATE_DIR?.trim();
   if (override) {
     if (override === "~" || override.startsWith("~/") || override.startsWith("~\\")) {
-      return path.resolve(override.replace(/^~(?=$|[\\/])/u, resolveOpenClawHome()));
+      return path.resolve(override.replace(/^~(?=$|[\\/])/u, () => resolveOpenClawHome()));
     }
     return path.resolve(override);
   }

--- a/extensions/onepassword/src/secret-ref-resolver.test.ts
+++ b/extensions/onepassword/src/secret-ref-resolver.test.ts
@@ -681,6 +681,45 @@ process.stdout.write("not-a-real-value");
   );
 
   it.runIf(process.platform !== "win32")(
+    "keeps literal $ patterns in home when expanding the tilde state dir",
+    async () => {
+      const home = path.join(fixtureWorkspace.dir, "home$&d");
+      const tokenDir = path.join(home, "oc-state", "credentials", "onepassword");
+      const opPath = path.join(fixtureWorkspace.dir, "op");
+      fs.mkdirSync(tokenDir, { recursive: true });
+      fs.writeFileSync(path.join(tokenDir, "service-account-token"), "dollar-token", {
+        mode: 0o600,
+      });
+      fs.writeFileSync(
+        opPath,
+        `#!${getTrustedNodePath()}\nprocess.stdout.write(process.env.OP_SERVICE_ACCOUNT_TOKEN);\n`,
+        { mode: 0o755 },
+      );
+
+      const result = await runResolver({
+        request: {
+          protocolVersion: 1,
+          provider: "onepassword",
+          ids: ["op://Engineering/OpenRouter/apiKey"],
+        },
+        env: {
+          CLAW_1PASSWORD_OP: opPath,
+          HOME: home,
+          OPENCLAW_HOME: "",
+          OPENCLAW_PROFILE: "",
+          OPENCLAW_STATE_DIR: "~/oc-state",
+        },
+        token: null,
+      });
+
+      expect(result).toMatchObject({ code: 0, stderr: "" });
+      expect(JSON.parse(result.stdout).values).toEqual({
+        "op://Engineering/OpenRouter/apiKey": "dollar-token",
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "does not include failed child output in resolver errors",
     async () => {
       const tempDir = fixtureWorkspace.dir;

--- a/extensions/onepassword/src/secret-ref-resolver.test.ts
+++ b/extensions/onepassword/src/secret-ref-resolver.test.ts
@@ -720,6 +720,45 @@ process.stdout.write("not-a-real-value");
   );
 
   it.runIf(process.platform !== "win32")(
+    "keeps literal $ patterns in HOME when expanding a tilde OPENCLAW_HOME",
+    async () => {
+      const home = path.join(fixtureWorkspace.dir, "home$&d");
+      const tokenDir = path.join(home, "oc-home", ".openclaw", "credentials", "onepassword");
+      const opPath = path.join(fixtureWorkspace.dir, "op");
+      fs.mkdirSync(tokenDir, { recursive: true });
+      fs.writeFileSync(path.join(tokenDir, "service-account-token"), "home-token", {
+        mode: 0o600,
+      });
+      fs.writeFileSync(
+        opPath,
+        `#!${getTrustedNodePath()}\nprocess.stdout.write(process.env.OP_SERVICE_ACCOUNT_TOKEN);\n`,
+        { mode: 0o755 },
+      );
+
+      const result = await runResolver({
+        request: {
+          protocolVersion: 1,
+          provider: "onepassword",
+          ids: ["op://Engineering/OpenRouter/apiKey"],
+        },
+        env: {
+          CLAW_1PASSWORD_OP: opPath,
+          HOME: home,
+          OPENCLAW_HOME: "~/oc-home",
+          OPENCLAW_PROFILE: "",
+          OPENCLAW_STATE_DIR: "",
+        },
+        token: null,
+      });
+
+      expect(result).toMatchObject({ code: 0, stderr: "" });
+      expect(JSON.parse(result.stdout).values).toEqual({
+        "op://Engineering/OpenRouter/apiKey": "home-token",
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "does not include failed child output in resolver errors",
     async () => {
       const tempDir = fixtureWorkspace.dir;

--- a/extensions/voice-call/doctor-contract-api.test.ts
+++ b/extensions/voice-call/doctor-contract-api.test.ts
@@ -270,6 +270,37 @@ describe("voice-call doctor state migration", () => {
     );
   });
 
+  it("keeps literal $ patterns in home when resolving a tilde-configured store", async () => {
+    const dollarHome = path.join(stateDir, "home$&d");
+    const dollarStorePath = path.join(dollarHome, "dollar-store");
+    const call = makePersistedCall({
+      callId: "call-dollar-home",
+      providerCallId: "provider-dollar-home",
+    });
+    await fs.mkdir(dollarStorePath, { recursive: true });
+    writeLegacyCallsJsonl(dollarStorePath, [call]);
+    const dollarEnv = { ...process.env, HOME: dollarHome, OPENCLAW_STATE_DIR: stateDir };
+
+    const migration = expectDefined(stateMigrations[0], "voice-call state migration");
+    const params = {
+      config: {
+        plugins: {
+          entries: {
+            "voice-call": { config: { store: "~/dollar-store" } },
+          },
+        },
+      },
+      env: dollarEnv,
+      stateDir,
+      oauthDir: path.join(stateDir, "oauth"),
+      context: createDoctorContext(dollarEnv),
+    };
+
+    await expect(migration.detectLegacyState(params)).resolves.toMatchObject({
+      preview: [expect.stringContaining("1 record")],
+    });
+  });
+
   it("repairs the plugin-local SQLite schema without a legacy call log", async () => {
     const databasePath = path.join(storePath, "state", "openclaw.sqlite");
     await fs.mkdir(path.dirname(databasePath), { recursive: true });

--- a/extensions/voice-call/doctor-contract-api.ts
+++ b/extensions/voice-call/doctor-contract-api.ts
@@ -65,7 +65,7 @@ function resolveUserPath(input: string, env: NodeJS.ProcessEnv): string {
     return trimmed;
   }
   if (trimmed.startsWith("~")) {
-    return path.resolve(trimmed.replace(/^~(?=$|[\\/])/, resolveHome(env)));
+    return path.resolve(trimmed.replace(/^~(?=$|[\\/])/, () => resolveHome(env)));
   }
   return path.resolve(trimmed);
 }

--- a/extensions/voice-call/src/utils.test.ts
+++ b/extensions/voice-call/src/utils.test.ts
@@ -1,7 +1,7 @@
 // Voice Call tests cover utils plugin behavior.
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { resolveUserPath } from "./utils.js";
 
 describe("resolveUserPath", () => {
@@ -14,5 +14,16 @@ describe("resolveUserPath", () => {
       path.resolve(os.homedir(), "voice-call/config.json"),
     );
     expect(resolveUserPath("./voice-call")).toBe(path.resolve("./voice-call"));
+  });
+
+  it("does not interpret $ patterns in home when expanding tildes", () => {
+    const spy = vi.spyOn(os, "homedir").mockReturnValue("/home/$&user");
+    try {
+      expect(resolveUserPath("~/voice-call/config.json")).toBe(
+        path.resolve("/home/$&user/voice-call/config.json"),
+      );
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/extensions/voice-call/src/utils.ts
+++ b/extensions/voice-call/src/utils.ts
@@ -11,7 +11,7 @@ export function resolveUserPath(input: string): string {
     return trimmed;
   }
   if (trimmed.startsWith("~")) {
-    const expanded = trimmed.replace(/^~(?=$|[\\/])/, os.homedir());
+    const expanded = trimmed.replace(/^~(?=$|[\\/])/, () => os.homedir());
     return path.resolve(expanded);
   }
   return path.resolve(trimmed);

--- a/packages/memory-host-sdk/src/host/config-utils.test.ts
+++ b/packages/memory-host-sdk/src/host/config-utils.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   normalizeConfiguredMemoryExtraPaths,
@@ -33,6 +34,16 @@ describe("resolveMemoryHostAgentWorkspaceDir", () => {
         OPENCLAW_WORKSPACE_DIR: "/srv/openclaw-workspace",
       }),
     ).toBe("/srv/openclaw-workspace");
+  });
+
+  it("keeps literal $ patterns in home when expanding tilde workspace paths", () => {
+    expect(
+      resolveMemoryHostAgentWorkspaceDir(
+        { agents: { entries: { support: { workspace: "~/ws" } } } },
+        "support",
+        { HOME: "/home/peter$&mall", OPENCLAW_HOME: "~/oc" },
+      ),
+    ).toBe(path.resolve("/home/peter$&mall/oc/ws"));
   });
 });
 

--- a/packages/memory-host-sdk/src/host/config-utils.ts
+++ b/packages/memory-host-sdk/src/host/config-utils.ts
@@ -155,7 +155,7 @@ function resolveRequiredHomeDir(
 ): string {
   const explicitHome = normalizeHomeValue(env.OPENCLAW_HOME);
   const rawHome = explicitHome
-    ? explicitHome.replace(/^~(?=$|[\\/])/, resolveRawOsHomeDir(env, homedir) ?? "")
+    ? explicitHome.replace(/^~(?=$|[\\/])/, () => resolveRawOsHomeDir(env, homedir) ?? "")
     : resolveRawOsHomeDir(env, homedir);
   return rawHome ? path.resolve(rawHome) : path.resolve(process.cwd());
 }
@@ -171,7 +171,9 @@ function resolveMemoryHostUserPath(
     return trimmed;
   }
   if (trimmed.startsWith("~")) {
-    return path.resolve(trimmed.replace(/^~(?=$|[\\/])/, resolveRequiredHomeDir(env, homedir)));
+    return path.resolve(
+      trimmed.replace(/^~(?=$|[\\/])/, () => resolveRequiredHomeDir(env, homedir)),
+    );
   }
   return path.resolve(trimmed);
 }


### PR DESCRIPTION
## What Problem This Solves

Eleven call sites across extensions and memory-host-sdk expand leading `~` using `String.replace(regex, homeVariable)`. When the home directory (or `OPENCLAW_HOME`/`OPENCLAW_STATE_DIR`) contains `$&`, `$1`–`$9`, `` $` ``, or `$'`, JavaScript interprets these as special replacement patterns — silently corrupting the resolved path (`/home/$&user` + `~/state` → `/home/~user/state`).

This is the same bug class already fixed in `packages/terminal-core/src/display-string.ts` (#111398) and the core home-dir resolver (PR #122991). This PR covers the remaining extension and package sibling call sites.

## Why This Change Was Made

`String.replace(regex, stringReplacement)` interprets `$` sequences in the replacement. `String.replace(regex, () => value)` treats the return value literally. Each call site switches from the string form to the function form — minimal, established pattern, zero behavioral change for normal (non-`$`) home paths.

## User Impact

When a user's home directory contains `$` characters — CI runners, test harnesses, special-character usernames — these extensions resolve CLI paths, config, state, credentials, and migration sources to the **wrong location**, causing broken iMessage CLI discovery, 1Password secret resolution failures (token file not found), doctor contracts and migrations pointing at nonexistent paths.

## Evidence

### Runtime probe through the real changed owners (before → after)

`node --import tsx /tmp/verify-tilde-dollar.mjs` imports the actual resolver modules from this branch and expands `~` paths with `HOME=/home/probe$&user`. Run once against the pre-fix production files (`git checkout 683d37a35f2 -- <9 files>`), then against the fixed head:

```
########## BEFORE (pre-fix production code at base 683d37a35f2) ##########
FAIL imessage expandIMessageUserPath
     home:     /home/probe$&user
     resolved: /home/probe~user/Library/Messages/chat.db
FAIL migrate-claude resolveHomePath      resolved: /home/probe~user/.claude
FAIL migrate-hermes resolveHomePath      resolved: /home/probe~user/.hermes
FAIL voice-call resolveUserPath          resolved: /home/probe~user/voice-call/config.json
FAIL browser resolveBrowserConfig executablePath      resolved: /home/probe~user/chrome-bin
FAIL memory-host-sdk resolveMemoryHostAgentWorkspaceDir  resolved: /home/probe~user/oc/ws
PROBE FAIL (6 owners corrupted the $ pattern)

########## AFTER (fixed production code at PR head) ##########
PASS imessage expandIMessageUserPath
     home:     /home/probe$&user
     resolved: /home/probe$&user/Library/Messages/chat.db
PASS migrate-claude resolveHomePath      resolved: /home/probe$&user/.claude
PASS migrate-hermes resolveHomePath      resolved: /home/probe$&user/.hermes
PASS voice-call resolveUserPath          resolved: /home/probe$&user/voice-call/config.json
PASS browser resolveBrowserConfig executablePath      resolved: /home/probe$&user/chrome-bin
PASS memory-host-sdk resolveMemoryHostAgentWorkspaceDir  resolved: /home/probe$&user/oc/ws
PROBE PASS (literal $ preserved at every owner)
```

(Full per-case expected/resolved lines are in the run log; paths above are the probe's fake home, no real user paths involved.)

### Owner-level literal-dollar regressions at every changed resolver

Each new test was run against the pre-fix production files (checked out from base `683d37a35f2`) and **failed for the right reason**, then passed again after restoring the fixed files:

| Owner | Test (public seam) | Pre-fix | Post-fix |
|---|---|---|---|
| iMessage | `extensions/imessage/src/cli-path.test.ts` — `expandIMessageUserPath` | FAIL | pass |
| browser | `config.test.ts` — `resolveBrowserConfig({executablePath: "~/chrome-bin"})` | FAIL | 71 passed \| 1 skipped |
| migrate-claude | `provider.test.ts` — `resolveHomePath("~/.claude")` | FAIL | 20 passed |
| migrate-hermes | `provider.test.ts` — `resolveHomePath("~/.hermes")` | FAIL | 15 passed |
| onepassword | `secret-ref-resolver.test.ts` — two real resolver subprocess cases: `OPENCLAW_STATE_DIR=~/oc-state` and `OPENCLAW_HOME=~/oc-home` (both tilde branches) with literal-`$` HOME, each asserting the token is read from the correctly expanded dir | see note | CI |
| memory-lancedb | `doctor-contract-api.test.ts` — doctor `detectLegacyState` with `dbPath: "~/lancedb-dollar"`, asserts preview contains the literal-`$` db path | FAIL | 4 passed |
| voice-call doctor | `doctor-contract-api.test.ts` — `detectLegacyState` with `store: "~/dollar-store"`, asserts the legacy log is found through the tilde-expanded store | FAIL | 7 passed |
| memory-host-sdk | `config-utils.test.ts` — `resolveMemoryHostAgentWorkspaceDir` with tilde workspace + tilde `OPENCLAW_HOME` (covers both fixed lines) | FAIL (`/home/peter~mall/oc/ws` vs `/home/peter$&mall/oc/ws`) | 4 passed |

Example pre-fix failure output (memory-host-sdk): `AssertionError: expected '/home/peter~mall/oc/ws' to be '/home/peter$&mall/oc/ws'` — the `$&` → `~` corruption directly.

**OnePassword note**: this sandbox's filesystem makes `resolveTrustedExecutablePath` reject the staged op fixture ("path is writable by another user"), so all subprocess-based onepassword tests — including the pre-existing ones — fail identically on this machine regardless of this diff (same 11 pre-existing failures reproduce on a clean `upstream/main` checkout here). The new case follows the exact template of the CI-green `accepts the broker token file through a hardlink` / `reads the service token from the selected profile state directory` tests and is verified by the changed-extensions CI shard on this head.

### Focused local runs (node 26.5.0; CI truth is Linux Node 24; exact head `499b22866a7` on latest `main`)

- `node scripts/run-vitest.mjs <each of the 8 owner test files>` → all green post-fix (counts above), each new case red pre-fix
- `git diff --check` → clean; `pnpm format` (oxfmt) on all touched test files → no changes
- `node scripts/check-changed.mjs --dry-run -- extensions/imessage/src/cli-path.ts extensions/onepassword/onepassword-secret-ref-resolver.js` → dry-run plans only

### CI red-shard attribution (head `6bb8873fd2e` and earlier)

`checks-node-changed-extensions-config-2` (`extensions/imessage/src/conversation-route.test.ts`) and `config-3` (`extensions/memory-lancedb/embeddings.lifecycle.test.ts`) reproduce identically on clean `upstream/main`; `config-1` (`extension-install.test.ts` + two `pw-tools-core` files) passes locally on this branch and main — runner/environment-specific. None of the failing files or their modules are in this diff. No code changes included for them.

### CI (exact head `499b22866a7`)

Full CI matrix green: [run 32099145684](https://github.com/openclaw/openclaw/actions/runs/32099145684) (all owner regressions + both onepassword tilde branches included).

### Untested scope

- No live Gateway boot, live channel, or real `op` CLI run; the 1Password path is proven through the subprocess contract test in CI (local trust-chain limitation above).
- Probe and tests use fake literal-`$` homes, not a real `$`-named user account.

**Production LOC**: net 0 (11 callback substitutions across 9 files, unchanged from review). Tests: +174 / −2.

**Affected call sites** (all verified on main before this PR):
- `extensions/voice-call/src/utils.ts:14` + `extensions/voice-call/doctor-contract-api.ts:68`
- `extensions/browser/src/browser/config.ts:186`
- `extensions/migrate-claude/helpers.ts:18` + `extensions/migrate-hermes/helpers.ts:22`
- `extensions/memory-lancedb/doctor-contract-api.ts:104`
- `packages/memory-host-sdk/src/host/config-utils.ts:158,174`
- `extensions/imessage/src/cli-path.ts:38` (reviewer-identified)
- `extensions/onepassword/onepassword-secret-ref-resolver.js:92,101` (reviewer-identified, 2 sites)
