### PR TITLE
fix(agent): finish turns when providers fail after tools complete

### DIFF
--- a/extensions/codex/src/app-server/event-projector.terminal-errors.test.ts
+++ b/extensions/codex/src/app-server/event-projector.terminal-errors.test.ts
@@ -198,6 +198,23 @@ describe("CodexAppServerEventProjector terminal errors", () => {
     expect(result.lastAssistant).toBeUndefined();
   });
 
+  it.each([
+    { codexErrorInfo: "serverOverloaded", expected: true },
+    { codexErrorInfo: "usageLimitExceeded", expected: false },
+    { codexErrorInfo: "unauthorized", expected: false },
+  ])(
+    "projects $codexErrorInfo terminal error recovery eligibility as $expected",
+    async ({ codexErrorInfo, expected }) => {
+      const projector = await createProjector();
+
+      await projector.handleNotification(
+        appServerError({ message: "provider failure", willRetry: false, codexErrorInfo }),
+      );
+
+      expect(projector.settledTurnFailureFinalizationAllowed).toBe(expected);
+    },
+  );
+
   it("uses Codex rate-limit resets for usage-limit app-server errors", async () => {
     const resetsAt = Math.ceil(Date.now() / 1000) + 120;
     const projector = await createProjector(undefined, {

--- a/extensions/codex/src/app-server/event-projector.test-harness.ts
+++ b/extensions/codex/src/app-server/event-projector.test-harness.ts
@@ -283,11 +283,12 @@ export function agentMessageDelta(delta: string, itemId = "msg-1"): ProjectorNot
 export function appServerError(params: {
   message: string;
   willRetry: boolean;
+  codexErrorInfo?: string;
 }): ProjectorNotification {
   return forCurrentTurn("error", {
     error: {
       message: params.message,
-      codexErrorInfo: null,
+      codexErrorInfo: params.codexErrorInfo ?? null,
       additionalDetails: null,
     },
     willRetry: params.willRetry,

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -76,6 +76,8 @@ export class CodexAppServerEventProjector {
   private readonly toolProgressProjection: CodexToolProgressProjection;
   private readonly toolTranscriptProjection: CodexToolTranscriptProjection;
   private completedTurn: CodexTurn | undefined;
+  /** Structured overloads may continue once the exact settled transcript is captured. */
+  settledTurnFailureFinalizationAllowed = false;
   private promptError: unknown;
   private promptErrorSource: AttemptFailureSource | null = null;
   private synthesizedMissingToolResultError: string | null = null;
@@ -284,6 +286,9 @@ export class CodexAppServerEventProjector {
         if (params.willRetry === true) {
           break;
         }
+        this.settledTurnFailureFinalizationAllowed =
+          (isJsonObject(params.error) ? params.error.codexErrorInfo : undefined) ===
+          "serverOverloaded";
         this.promptError = this.formatCodexErrorMessage(params) ?? "codex app-server error";
         this.promptErrorSource = "prompt";
         break;
@@ -493,6 +498,8 @@ export class CodexAppServerEventProjector {
       return;
     }
     this.completedTurn = turn;
+    this.settledTurnFailureFinalizationAllowed =
+      turn.status === "failed" && turn.error?.codexErrorInfo === "serverOverloaded";
     if (turn.status !== "completed") {
       this.responseCompletions.clear();
     }

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -323,7 +323,6 @@ export async function finalizeCodexAttempt(
   const { assistantTranscriptOwned, assistantTranscriptIdempotencyKey, terminalAnchor } =
     mirrorOutcome;
   const shouldCaptureSettledTurnFinalizationContext =
-    turnSucceeded &&
     result.assistantTexts.every((text) => !text.trim()) &&
     result.messagesSnapshot.some((message) => message.role === "toolResult");
   const settledTurnFinalizationContext = shouldCaptureSettledTurnFinalizationContext

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -324,7 +324,8 @@ export async function finalizeCodexAttempt(
     mirrorOutcome;
   const shouldCaptureSettledTurnFinalizationContext =
     result.assistantTexts.every((text) => !text.trim()) &&
-    result.messagesSnapshot.some((message) => message.role === "toolResult");
+    result.messagesSnapshot.some((message) => message.role === "toolResult") &&
+    (!finalPromptError || activeProjector.settledTurnFailureFinalizationAllowed);
   const settledTurnFinalizationContext = shouldCaptureSettledTurnFinalizationContext
     ? await captureCodexSettledTurnFinalizationContext({
         ...activeTranscriptTarget,

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3912,17 +3912,34 @@ describe("runCodexAppServerAttempt", () => {
   });
 
   it.each([
-    { label: "completed turn", failure: undefined },
+    { label: "completed turn", failure: undefined, expectedContext: true },
     {
-      label: "provider error after the tool result",
+      label: "provider overload after the tool result",
       failure: {
         message: "Selected model is at capacity. Please try a different model.",
         codexErrorInfo: "serverOverloaded",
       },
+      expectedContext: true,
+    },
+    {
+      label: "usage limit after the tool result",
+      failure: {
+        message: "Usage limit exceeded.",
+        codexErrorInfo: "usageLimitExceeded",
+      },
+      expectedContext: false,
+    },
+    {
+      label: "unauthorized response after the tool result",
+      failure: {
+        message: "Unauthorized.",
+        codexErrorInfo: "unauthorized",
+      },
+      expectedContext: false,
     },
   ])(
     "captures the complete mirrored branch through a settled tool-result boundary for a $label",
-    async ({ failure }) => {
+    async ({ failure, expectedContext }) => {
       const storePath = path.join(tempDir, "settled-finalization-context.sqlite");
       const sessionId = "session-settled-finalization-context";
       const sessionFile = `agent:main:${sessionId}`;
@@ -3969,16 +3986,19 @@ describe("runCodexAppServerAttempt", () => {
         await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
       }
       const result = await run;
-      expect(readAttemptTerminal(result).promptError).toBe(failure?.message ?? null);
-      expect(result.settledTurnFinalizationContext).toMatchObject({
-        source: "openclaw-transcript",
-        messages: [
-          expect.objectContaining({ role: "user" }),
-          expect.objectContaining({ role: "assistant" }),
-          expect.objectContaining({ role: "toolResult", toolCallId: "tool-settled" }),
-        ],
-      });
-      expect(Object.isFrozen(result.settledTurnFinalizationContext?.messages)).toBe(true);
+      expect(Boolean(readAttemptTerminal(result).promptError)).toBe(Boolean(failure));
+      expect(Boolean(result.settledTurnFinalizationContext)).toBe(expectedContext);
+      if (result.settledTurnFinalizationContext) {
+        expect(result.settledTurnFinalizationContext).toMatchObject({
+          source: "openclaw-transcript",
+          messages: [
+            expect.objectContaining({ role: "user" }),
+            expect.objectContaining({ role: "assistant" }),
+            expect.objectContaining({ role: "toolResult", toolCallId: "tool-settled" }),
+          ],
+        });
+        expect(Object.isFrozen(result.settledTurnFinalizationContext.messages)).toBe(true);
+      }
     },
   );
   it("preserves every command failure from official app-server events", async () => {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3911,59 +3911,76 @@ describe("runCodexAppServerAttempt", () => {
     });
   });
 
-  it("captures the complete mirrored branch through a settled tool-result boundary", async () => {
-    const storePath = path.join(tempDir, "settled-finalization-context.sqlite");
-    const sessionId = "session-settled-finalization-context";
-    const sessionFile = `agent:main:${sessionId}`;
-    const workspaceDir = path.join(tempDir, "workspace-settled-finalization-context");
-    const harness = createStartedThreadHarness();
-    const params = createParams(sessionFile, workspaceDir);
-    await attachSqliteSessionTarget(params, storePath, sessionId);
-    params.prompt = "Send the update to Alice.";
-    const run = runCodexAppServerAttempt(params);
-    await harness.waitForMethod("turn/start");
-    await harness.notify(
-      itemNotification("item/started", {
-        type: "commandExecution",
-        id: "tool-settled",
-        command: "echo sent-to-alice",
-        cwd: workspaceDir,
-        processId: null,
-        source: "agent",
-        status: "inProgress",
-        commandActions: [],
-        aggregatedOutput: null,
-        exitCode: null,
-        durationMs: null,
-      }),
-    );
-    await harness.notify(
-      itemNotification("item/completed", {
-        type: "commandExecution",
-        id: "tool-settled",
-        command: "echo sent-to-alice",
-        cwd: workspaceDir,
-        processId: 42,
-        source: "agent",
-        status: "completed",
-        commandActions: [],
-        aggregatedOutput: "sent-to-alice\n",
-        exitCode: 0,
-        durationMs: 12,
-      }),
-    );
-    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
-    const result = await run;
-    expect(result.settledTurnFinalizationContext).toMatchObject({
-      source: "openclaw-transcript",
-      messages: [
-        expect.objectContaining({ role: "user" }),
-        expect.objectContaining({ role: "assistant" }),
-        expect.objectContaining({ role: "toolResult", toolCallId: "tool-settled" }),
-      ],
-    });
-    expect(Object.isFrozen(result.settledTurnFinalizationContext?.messages)).toBe(true);
-  });
+  it.each([
+    { label: "completed turn", failure: undefined },
+    {
+      label: "provider error after the tool result",
+      failure: {
+        message: "Selected model is at capacity. Please try a different model.",
+        codexErrorInfo: "serverOverloaded",
+      },
+    },
+  ])(
+    "captures the complete mirrored branch through a settled tool-result boundary for a $label",
+    async ({ failure }) => {
+      const storePath = path.join(tempDir, "settled-finalization-context.sqlite");
+      const sessionId = "session-settled-finalization-context";
+      const sessionFile = `agent:main:${sessionId}`;
+      const workspaceDir = path.join(tempDir, "workspace-settled-finalization-context");
+      const harness = createStartedThreadHarness();
+      const params = createParams(sessionFile, workspaceDir);
+      await attachSqliteSessionTarget(params, storePath, sessionId);
+      params.prompt = "Send the update to Alice.";
+      const run = runCodexAppServerAttempt(params);
+      await harness.waitForMethod("turn/start");
+      await harness.notify(
+        itemNotification("item/started", {
+          type: "commandExecution",
+          id: "tool-settled",
+          command: "echo sent-to-alice",
+          cwd: workspaceDir,
+          processId: null,
+          source: "agent",
+          status: "inProgress",
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        }),
+      );
+      await harness.notify(
+        itemNotification("item/completed", {
+          type: "commandExecution",
+          id: "tool-settled",
+          command: "echo sent-to-alice",
+          cwd: workspaceDir,
+          processId: 42,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: "sent-to-alice\n",
+          exitCode: 0,
+          durationMs: 12,
+        }),
+      );
+      if (failure) {
+        await harness.notify(turnCompleted({ id: "turn-1", status: "failed", error: failure }));
+      } else {
+        await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+      }
+      const result = await run;
+      expect(readAttemptTerminal(result).promptError).toBe(failure?.message ?? null);
+      expect(result.settledTurnFinalizationContext).toMatchObject({
+        source: "openclaw-transcript",
+        messages: [
+          expect.objectContaining({ role: "user" }),
+          expect.objectContaining({ role: "assistant" }),
+          expect.objectContaining({ role: "toolResult", toolCallId: "tool-settled" }),
+        ],
+      });
+      expect(Object.isFrozen(result.settledTurnFinalizationContext?.messages)).toBe(true);
+    },
+  );
   it("preserves every command failure from official app-server events", async () => {
     const sessionFile = path.join(tempDir, "session-multi-command-failure.jsonl");
     const workspaceDir = path.join(tempDir, "workspace-multi-command-failure");

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.settled-tool-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.settled-tool-recovery.test.ts
@@ -1,5 +1,6 @@
 // Focused incomplete-turn behavior coverage.
 import { beforeEach, describe, expect, it } from "vitest";
+import { getReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
 import {
   REASONING_ONLY_RETRY_INSTRUCTION,
   SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION,
@@ -451,10 +452,17 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       .mockReturnValueOnce([])
       .mockReturnValueOnce([{ text: "Write completed. Here is the final answer." }]);
 
-    const result = await runEmbeddedAgent(makeRunParams("run-tool-use-terminal-continuation"));
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-tool-use-terminal-continuation", {
+        sourceReplyDeliveryMode: "message_tool_only",
+      }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads?.[0]?.text).toBe("Write completed. Here is the final answer.");
+    expect(getReplyPayloadMetadata(result.payloads?.[0] ?? {})).toMatchObject({
+      deliverDespiteSourceReplySuppression: true,
+    });
     expect(result.latestMcpAppChannelView).toEqual({ viewId: "view-after-tools" });
     expect(result.successfulCronAdds).toBe(1);
     expect(result.meta.toolSummary).toEqual({

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.settled-tool-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.settled-tool-recovery.test.ts
@@ -403,7 +403,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expectWarnMessageWith("reasoning-only assistant turn detected");
   });
 
-  it("continues once after settled side-effecting tools finish without a final answer", async () => {
+  it("finalizes once after a provider error follows settled side-effecting tools", async () => {
     const toolUseAssistant = makeLastAssistant({
       stopReason: "toolUse",
       content: [
@@ -421,6 +421,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       markUserMessagePersisted(attemptParams);
       return makeAttemptResult({
         assistantTexts: [],
+        promptError: new Error("Selected model is at capacity. Please try a different model."),
+        promptErrorSource: "prompt",
         latestMcpAppChannelView: { viewId: "view-after-tools" },
         toolMetas: [{ toolName: "write", meta: "path=note.txt" }, { toolName: "cron" }],
         successfulNestedToolNames: ["read"],

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.settled-tool-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.settled-tool-recovery.test.ts
@@ -424,6 +424,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         assistantTexts: [],
         promptError: new Error("Selected model is at capacity. Please try a different model."),
         promptErrorSource: "prompt",
+        settledTurnFinalizationContext: {
+          source: "openclaw-transcript",
+          messages: settledToolResults,
+        },
         latestMcpAppChannelView: { viewId: "view-after-tools" },
         toolMetas: [{ toolName: "write", meta: "path=note.txt" }, { toolName: "cron" }],
         successfulNestedToolNames: ["read"],
@@ -486,6 +490,39 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(secondCall.skipPreparedUserTurnMessage).toBe(true);
     expectWarnMessageWith("settled post-tool turn lacked a final answer");
   });
+
+  it.each(["usageLimitExceeded", "unauthorized"])(
+    "does not finalize settled tools after a %s provider failure",
+    async (failure) => {
+      const toolUseAssistant = makeLastAssistant({
+        stopReason: "toolUse",
+        content: [{ type: "toolCall", id: "tool_write", name: "write", arguments: {} }],
+      });
+      mockedClassifyFailoverReason.mockReturnValue(null);
+      mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams) => {
+        markUserMessagePersisted(attemptParams);
+        return makeAttemptResult({
+          assistantTexts: [],
+          promptError: new Error(failure),
+          promptErrorSource: "prompt",
+          toolMetas: [{ toolName: "write" }],
+          itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+          messagesSnapshot: [
+            toolUseAssistant,
+            { role: "toolResult", toolCallId: "tool_write", toolName: "write", isError: false },
+          ] as unknown as EmbeddedRunAttemptResult["messagesSnapshot"],
+          lastAssistant: toolUseAssistant,
+          currentAttemptAssistant: toolUseAssistant,
+        });
+      });
+
+      const result = await runEmbeddedAgent(makeRunParams(`run-settled-${failure}`));
+
+      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+      expect(result.payloads?.[0]?.text).toContain("couldn't generate a response");
+      expect(result.meta.error?.fallbackSafe).toBe(false);
+    },
+  );
 
   it.each([
     { label: "interactive user", trigger: "user" as const },

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.terminal-evidence.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.terminal-evidence.test.ts
@@ -120,7 +120,6 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     const instruction = resolveSettledToolTerminalContinuationInstruction(
       makeSettledContinuationParams(makeSettledIdleWriteAttempt(), {
         timedOut: true,
-        promptError: new Error("LLM idle timeout"),
       }),
     );
 
@@ -164,27 +163,16 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       aborted: false,
       timedOut: false,
     },
-    {
-      label: "prompt error without idle timeout",
-      terminal: { kind: "ok" } as const,
-      aborted: false,
-      timedOut: false,
-      promptError: new Error("closed"),
-    },
-  ])(
-    "does not finalize settled tools after a $label",
-    ({ terminal, aborted, timedOut, promptError }) => {
-      const instruction = resolveSettledToolTerminalContinuationInstruction(
-        makeSettledContinuationParams(makeSettledIdleWriteAttempt({ terminal }), {
-          aborted,
-          timedOut,
-          promptError,
-        }),
-      );
+  ])("does not finalize settled tools after a $label", ({ terminal, aborted, timedOut }) => {
+    const instruction = resolveSettledToolTerminalContinuationInstruction(
+      makeSettledContinuationParams(makeSettledIdleWriteAttempt({ terminal }), {
+        aborted,
+        timedOut,
+      }),
+    );
 
-      expect(instruction).toBeNull();
-    },
-  );
+    expect(instruction).toBeNull();
+  });
 
   it("does not use a settled prior-turn batch to authorize idle-timeout finalization", () => {
     const instruction = resolveSettledToolTerminalContinuationInstruction(

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.terminal-evidence.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.terminal-evidence.test.ts
@@ -128,6 +128,43 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
 
   it.each([
     {
+      label: "provider failure with finalization context",
+      hasContext: true,
+      expectedContinuation: true,
+    },
+    {
+      label: "provider failure without finalization context",
+      hasContext: false,
+      expectedContinuation: false,
+    },
+  ])(
+    "$label after settled tools returns continuation=$expectedContinuation",
+    ({ hasContext, expectedContinuation }) => {
+      const attempt = makeSettledIdleWriteAttempt({
+        terminal: { kind: "failed", source: "prompt", error: new Error("provider failure") },
+      });
+      const instruction = resolveSettledToolTerminalContinuationInstruction(
+        makeSettledContinuationParams(
+          hasContext
+            ? {
+                ...attempt,
+                settledTurnFinalizationContext: {
+                  source: "openclaw-transcript",
+                  messages: attempt.messagesSnapshot,
+                },
+              }
+            : attempt,
+        ),
+      );
+
+      expect(instruction === SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION).toBe(
+        expectedContinuation,
+      );
+    },
+  );
+
+  it.each([
+    {
       label: "external abort",
       terminal: { kind: "timeout", phase: "prompt", source: "external" } as const,
       aborted: true,

--- a/src/agents/embedded-agent-runner/run/incomplete-turn-classification.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-classification.ts
@@ -34,6 +34,7 @@ export type IncompleteTurnAttempt = Pick<
   | "messagesSnapshot"
   | "replayMetadata"
   | "currentAttemptReplayMetadata"
+  | "settledTurnFinalizationContext"
   | "terminal"
   | "toolMetas"
 > &

--- a/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
@@ -314,6 +314,7 @@ export function resolveSettledToolTerminalContinuationInstruction(params: {
     params.hasTerminalToolPresentation ||
     params.aborted ||
     ((params.timedOut || params.attempt.terminal.kind === "timeout") && !idlePromptTimeout) ||
+    (terminal.kind === "failed" && !params.attempt.settledTurnFinalizationContext) ||
     (assistant?.stopReason === "toolUse" ? !allToolsProvenSettled : !emptyStopAfterSettledTools) ||
     hasUnsettledToolError ||
     hasAsyncActivity(params.attempt.toolMetas) ||

--- a/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
@@ -220,7 +220,6 @@ export function resolveSettledToolTerminalContinuationInstruction(params: {
   payloadCount: number;
   hasTerminalToolPresentation?: boolean;
   aborted: boolean;
-  promptError?: unknown;
   timedOut: boolean;
   attempt: IncompleteTurnAttempt;
 }): string | null {
@@ -314,10 +313,7 @@ export function resolveSettledToolTerminalContinuationInstruction(params: {
     params.payloadCount !== 0 ||
     params.hasTerminalToolPresentation ||
     params.aborted ||
-    ((params.promptError != null ||
-      params.timedOut ||
-      params.attempt.terminal.kind === "timeout") &&
-      !idlePromptTimeout) ||
+    ((params.timedOut || params.attempt.terminal.kind === "timeout") && !idlePromptTimeout) ||
     (assistant?.stopReason === "toolUse" ? !allToolsProvenSettled : !emptyStopAfterSettledTools) ||
     hasUnsettledToolError ||
     hasAsyncActivity(params.attempt.toolMetas) ||

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
@@ -1,3 +1,4 @@
+import { markReplyPayloadForSourceSuppressionDelivery } from "../../../auto-reply/reply-payload.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { resolveSettledTurnFinalizationText } from "../../harness/settled-turn-finalization-result.js";
 import type {
@@ -134,6 +135,9 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
       lastRunPromptUsage,
       terminalState,
     });
+    // The isolated finalizer cannot call a message tool. Its answer is
+    // host-owned recovery output and must cross that source-reply suppression.
+    finalizedPrepared.payloadsWithToolMedia?.forEach(markReplyPayloadForSourceSuppressionDelivery);
     // A failure-honest final answer cannot turn a settled cron denial into success.
     prepared = { ...finalizedPrepared, failureSignal: settledFailureSignal };
     return {

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -90,7 +90,6 @@ export function resolveSettledTurnFinalizationRequest(input: {
   }
   const terminalAborted = isEmbeddedRunTerminalAbort(input.terminalState.outcome);
   const terminalTimedOut = isEmbeddedRunTerminalTimeout(input.terminalState.outcome);
-  const { promptError } = projectAgentRunAttemptTerminal(input.attempt.terminal);
   const silentToolResultReplyPayload = resolveSilentToolResultReplyPayload({
     isCronTrigger: input.runParams.trigger === "cron",
     payloadCount: input.payloadsWithToolMedia?.length ?? 0,
@@ -143,7 +142,6 @@ export function resolveSettledTurnFinalizationRequest(input: {
     payloadCount,
     hasTerminalToolPresentation: input.hasTerminalToolPresentation,
     aborted: terminalAborted,
-    promptError,
     timedOut: terminalTimedOut,
     attempt: input.attempt,
   });


### PR DESCRIPTION
## What Problem This Solves

A provider can fail after tools already completed. OpenClaw then warned that actions might have run instead of safely finishing the response; recovered Codex answers could also be suppressed on message-tool-only channels.

## Fix

- Capture the exact frozen settled transcript after successful turns and structured Codex `serverOverloaded` failures. The context itself is the single finalization authority; no new SDK capability flag.
- Run the existing isolated, tools-disabled finalizer only from that context. Usage-limit, unauthorized, unknown, partial, and unproven failures remain fail-closed.
- Mark finalizer text as host-owned delivery because that isolated run cannot call a channel message tool.

Original tools are never replayed.

## Proof

- Regression test fails on pre-fix code: a completed side-effecting tool followed by provider failure performs no finalization and surfaces the incomplete-turn fallback. Fixed code performs one isolated finalizer and never reruns the tool.
- Codex boundary tests prove both official failed-turn and terminal-error overload producers capture the settled context; usage-limit and unauthorized failures do not.
- Focused exact-head suites: 195 tests passed. Production/test typechecks, plugin SDK API baseline, full lint, format, build, and `git diff --check` passed.
- Exact CI run `31672578857`: all selected checks and aggregate gate passed.
- Production: `+16/-9` (net `+7`). Tests/support: `+204/-77`.

### Redacted Telegram QA transcript

Exact head: `d3eb7ab82d8fe5ed989cec3559c39b9d647b0149`. Real Telegram QA user through TDLib; fresh isolated Gateway; synthetic Codex app-server fixture.

```text
QA user -> bot: [synthetic settled-tool overload recovery prompt]
bot -> QA user: Working / Bash
fixture: command completed; side-effect log appended once
fixture: structured serverOverloaded terminal error
Gateway: running isolated settled-turn finalization
bot -> QA user: OPENCLAW_E2E_SETTLED_ERROR_RECOVERED
bot edit: 1 tool call / 1s
```

Observed counts: Telegram messages `2`, edits `1`, side-effect log lines `1`, Codex request/event records `36`. Forbidden output counts: incomplete-turn fallback `0`, finalization failure `0`, scary warning `0`. Account, chat, message, run, session, and trace identifiers redacted.
### Pinned Codex contract

OpenClaw pins `@openai/codex` 0.147.0 (`rust-v0.147.0`, commit `be6e8eac029b183056b7e4402879f15d2c85f61b`). Direct source inspection proves:

- Tool calls are recorded before execution, all tool futures are drained into transcript results, and tool calls force a follow-up sampling request ([stream_events_utils.rs](https://github.com/openai/codex/blob/be6e8eac029b183056b7e4402879f15d2c85f61b/codex-rs/core/src/stream_events_utils.rs#L296-L327), [turn.rs](https://github.com/openai/codex/blob/be6e8eac029b183056b7e4402879f15d2c85f61b/codex-rs/core/src/session/turn.rs#L2086-L2110)).
- `ServerOverloaded` is structured and non-retryable; app-server preserves it on the terminal `will_retry: false` error while transient retries use `will_retry: true` ([error.rs](https://github.com/openai/codex/blob/be6e8eac029b183056b7e4402879f15d2c85f61b/codex-rs/protocol/src/error.rs#L362-L386), [shared.rs](https://github.com/openai/codex/blob/be6e8eac029b183056b7e4402879f15d2c85f61b/codex-rs/app-server-protocol/src/protocol/v2/shared.rs#L70-L128), [bespoke_event_handling.rs](https://github.com/openai/codex/blob/be6e8eac029b183056b7e4402879f15d2c85f61b/codex-rs/app-server/src/bespoke_event_handling.rs#L920-L975)).
- A failed follow-up emits the turn-error lifecycle and can return with no assistant message ([turn.rs](https://github.com/openai/codex/blob/be6e8eac029b183056b7e4402879f15d2c85f61b/codex-rs/core/src/session/turn.rs#L520-L552)).