### PR TITLE
fix(cli): let plugin install proceed when the outgoing schema rejects channel config (#122716)

### DIFF
--- a/src/cli/plugins-install-config.test.ts
+++ b/src/cli/plugins-install-config.test.ts
@@ -304,6 +304,122 @@ describe("loadConfigForInstall", () => {
     expect(result.config.plugins?.load?.paths).toEqual(["/keep"]);
   });
 
+  it("allows install when the outgoing plugin schema rejects channel config written for the incoming version", async () => {
+    const snapshotCfg = {
+      channels: {
+        signal: {
+          account: "+15550001234",
+          apiMode: "native",
+          autoStart: false,
+          httpHost: "127.0.0.1",
+          httpPort: 8081,
+        },
+      },
+    } as unknown as OpenClawConfig;
+    readConfigFileSnapshotMock.mockResolvedValue(
+      makeSnapshot({
+        parsed: {
+          channels: {
+            signal: {
+              account: "+15550001234",
+              apiMode: "native",
+              autoStart: false,
+              httpHost: "127.0.0.1",
+              httpPort: 8081,
+            },
+          },
+        },
+        config: snapshotCfg,
+        issues: [
+          {
+            path: "channels.signal",
+            message:
+              'invalid config for plugin signal: must not have additional properties: "apiMode", "autoStart", "httpHost", "httpPort"',
+          },
+        ],
+      }),
+    );
+
+    const request = resolvePluginInstallRequestContext({
+      rawSpec: "@openclaw/signal@2026.7.2-beta.7",
+    });
+    if (!request.ok) {
+      throw new Error(request.error);
+    }
+    expect(request.request.bundledPluginId).toBe("signal");
+    expect(request.request.allowInvalidConfigRecovery).toBe(true);
+
+    const result = await loadConfigForInstall(request.request);
+    // The config written for the incoming schema survives the swap instead of
+    // deadlocking the upgrade against the outgoing plugin's schema.
+    expect(result.config.channels?.signal).toEqual(snapshotCfg.channels?.signal);
+  });
+
+  it("allows nested channel schema rejections for the requested plugin during recovery", async () => {
+    const snapshotCfg = {
+      channels: {
+        signal: { transport: { kind: "external-native", url: "http://127.0.0.1:8081" } },
+      },
+    } as unknown as OpenClawConfig;
+    readConfigFileSnapshotMock.mockResolvedValue(
+      makeSnapshot({
+        parsed: {
+          channels: { signal: { transport: { kind: "external-native" } } },
+        },
+        config: snapshotCfg,
+        issues: [
+          {
+            path: "channels.signal.transport.kind",
+            message: "invalid config for plugin signal: must be equal to one of the allowed values",
+          },
+        ],
+      }),
+    );
+
+    const request = resolvePluginInstallRequestContext({ rawSpec: "@openclaw/signal" });
+    if (!request.ok) {
+      throw new Error(request.error);
+    }
+
+    const result = await loadConfigForInstall(request.request);
+    expect(result.config.channels?.signal).toEqual(snapshotCfg.channels?.signal);
+  });
+
+  it("still rejects channel schema rejections for a different plugin during recovery", async () => {
+    // signal's schema rejection must not be swept into a discord install recovery.
+    readConfigFileSnapshotMock.mockResolvedValue(
+      makeSnapshot({
+        parsed: { channels: { signal: { apiMode: "native" } } },
+        config: { channels: { signal: { apiMode: "native" } } } as unknown as OpenClawConfig,
+        issues: [
+          {
+            path: "channels.signal",
+            message:
+              'invalid config for plugin signal: must not have additional properties: "apiMode"',
+          },
+        ],
+      }),
+    );
+
+    await expect(loadConfigForInstall(discordNpmRequest)).rejects.toThrow(
+      "Config invalid outside the plugin recovery path for discord",
+    );
+  });
+
+  it("still rejects channel issues that are not schema rejections of the requested plugin", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue(
+      makeSnapshot({
+        parsed: { channels: { discord: { token: 1 } } },
+        config: { channels: { discord: { token: 1 } } } as unknown as OpenClawConfig,
+        issues: [{ path: "channels.discord", message: "must be object" }],
+      }),
+    );
+
+    await expect(loadConfigForInstall(discordNpmRequest)).rejects.toThrow(
+      "Config invalid outside the plugin recovery path for discord",
+    );
+  });
+
   it("does not let a stale legacy install record override the canonical record", async () => {
     const snapshotCfg = {
       plugins: {

--- a/src/cli/plugins-install-config.ts
+++ b/src/cli/plugins-install-config.ts
@@ -84,9 +84,18 @@ function isAllowedPluginRecoveryIssue(
   if (!pluginId) {
     return false;
   }
+  const channelPath = `channels.${pluginId}`;
   return (
-    (issue.path === `channels.${pluginId}` &&
-      issue.message === `unknown channel id: ${pluginId}`) ||
+    (issue.path === channelPath && issue.message === `unknown channel id: ${pluginId}`) ||
+    // The installed (outgoing) plugin's schema rejects channels.<pluginId>
+    // config written for the incoming version (e.g. flat keys vs a nested
+    // transport object). The install swaps that schema, so the rejection must
+    // not deadlock the upgrade: the incoming version validates the config
+    // after the swap, and genuinely malformed config still surfaces there.
+    (typeof issue.path === "string" &&
+      (issue.path === channelPath || issue.path.startsWith(`${channelPath}.`)) &&
+      typeof issue.message === "string" &&
+      issue.message.startsWith(`invalid config for plugin ${pluginId}:`)) ||
     isOwnedMissingPluginLoadPathIssue(issue, ownedLoadPaths) ||
     (issue.path === `plugins.entries.${pluginId}` &&
       typeof issue.message === "string" &&


### PR DESCRIPTION
## What Problem This Solves

Upgrading an external channel plugin can deadlock: `openclaw plugins install <plugin>@<new-version>` validates `channels.<plugin>` against the **currently installed (outgoing)** plugin's schema, and the recovery filter in `src/cli/plugins-install-config.ts` (`isAllowedPluginRecoveryIssue`) only recognizes four issue shapes — `unknown channel id`, missing plugin load paths, `plugins.entries.<id>` compiled-runtime failures, and `tools.web.search.provider` — none of which match a channel-schema rejection. The install then fails with:

```text
Config invalid outside the plugin recovery path for signal; run 'openclaw doctor --fix' before reinstalling it.
```

Concretely (from #122716): `@openclaw/signal` 2026.7.1 → 2026.7.2-beta.7 moved config from flat keys (`apiMode`, `autoStart`, `httpHost`, `httpPort`) to a nested `transport: { kind, url }` object. Write the new shape → the outgoing plugin rejects it (`invalid config for plugin signal: must not have additional properties: ...`); keep the old shape → the incoming plugin rejects it after install. No ordering works, and `doctor --fix` cannot help because the config is valid for the target version, not the installed one.

## Why

- The recovery path exists precisely so an install can proceed when the config is invalid **in ways the install itself repairs**. Swapping the plugin is exactly that repair: the incoming version's schema is what validates `channels.<plugin>` after the swap, so the outgoing version's schema rejection of config written for the incoming version is a *scheduled* incompatibility, not a real config defect.
- The rejection is scoped tightly: the issue must target `channels.<pluginId>` (exact or nested path) **and** carry the `invalid config for plugin <pluginId>:` prefix that `formatChannelConfigIssueMessage` stamps (src/config/validation.ts). A genuinely malformed config still fails validation against the incoming schema after the install, with a correct, actionable error — strictly better than the current dead end.
- The allowlist gate is unchanged: this only applies when the request already resolved `bundledPluginId` + `allowInvalidConfigRecovery` (the plugin's package.json opts in via `openclaw.install.allowInvalidConfigRecovery`, as `@openclaw/signal`, discord, slack, matrix, etc. do).

## User Impact

- `openclaw plugins install '@openclaw/signal@2026.7.2-beta.7' --force` (and equivalent channel-plugin upgrades) now proceeds when the config was written for the incoming schema, instead of deadlocking with a `doctor --fix` hint that cannot fix it.
- Config written for the incoming version is preserved verbatim through the swap; the stash-and-restore workaround from the issue is no longer needed.
- Other plugins' channel rejections and non-schema channel errors are still blocked exactly as before (covered by regression tests).

## Evidence

New regression tests (`src/cli/plugins-install-config.test.ts`) — **fail on pre-fix `main`**:

```text
$ pnpm vitest run src/cli/plugins-install-config.test.ts -t "outgoing plugin schema rejects|nested channel schema rejections"
 × allows install when the outgoing plugin schema rejects channel config written for the incoming version 368ms
 × allows nested channel schema rejections for the requested plugin during recovery 92ms
```

**Pass post-fix** — full file (48 tests) plus the install preflight suite (72 total across both files):

```text
$ pnpm vitest run src/cli/plugins-install-config.test.ts
 Test Files  1 passed (1)
      Tests  48 passed (48)
```

The negative guards also pass: a schema rejection for a *different* plugin (`channels.signal` during a discord install) and a non-schema channel issue (`must be object`) still throw `Config invalid outside the plugin recovery path` — the allowlist was widened, not opened.

Lint clean:

```text
$ pnpm exec oxlint src/cli/plugins-install-config.ts src/cli/plugins-install-config.test.ts
Found 0 warnings and 0 errors.
```

Note: the exact operator command from #122716 (`plugins install '@openclaw/signal@2026.7.2-beta.7' --force`) requires a live npm/registry environment; the recovery boundary it exercises is covered by the unit harness above, which reproduces the reported issue shape (`invalid config for plugin signal: must not have additional properties: "apiMode", ...` at `channels.signal`).

[AI-assisted] Implementation and evidence generated with agent tooling.
