### PR TITLE
fix(ui): stop limited Custodian access prompting Gateway updates

### DIFF
--- a/ui/src/e2e/device-scope-upgrade.e2e.test.ts
+++ b/ui/src/e2e/device-scope-upgrade.e2e.test.ts
@@ -194,6 +194,24 @@ describeControlUiE2e("Control UI live device scope upgrade", () => {
     },
   );
 
+  it("does not misreport limited Custodian access as an outdated Gateway", async () => {
+    const context = await createContext();
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat", ...SCOPE_UPGRADE_METHODS],
+      operatorScopes: LIMITED_SCOPES,
+    });
+
+    await page.goto(`${server.baseUrl}custodian?intent=new-agent`);
+    await page.getByText("This browser has limited access.", { exact: true }).waitFor();
+
+    expect(
+      await page.getByText("Update the Gateway to continue setup with OpenClaw.").count(),
+    ).toBe(0);
+    expect(await gateway.getRequests("openclaw.chat")).toHaveLength(0);
+    await captureProof(page, "custodian-limited.png");
+  });
+
   it("keeps manual repair guidance when the banner module fails to load", async () => {
     const context = await createContext();
     const page = await context.newPage();

--- a/ui/src/pages/custodian/custodian-page-agent-create.test.ts
+++ b/ui/src/pages/custodian/custodian-page-agent-create.test.ts
@@ -117,7 +117,7 @@ describe("custodian new-agent flow", () => {
     expect(request.mock.calls[0]?.[1]).toMatchObject({ welcomeVariant: "new-agent" });
   });
 
-  it("does not start new-agent chat with read-only operator access", async () => {
+  it("does not misreport limited access as an outdated Gateway", async () => {
     const request = vi.fn();
     const { context } = createContext(request);
     context.gateway.snapshot.hello = {
@@ -125,10 +125,11 @@ describe("custodian new-agent flow", () => {
       auth: { role: "operator", scopes: ["operator.read"] },
     };
 
-    await mountPage(context);
+    const page = await mountPage(context);
     await Promise.resolve();
 
     expect(request).not.toHaveBeenCalled();
+    expect(page.querySelector('[role="alert"]')).toBeNull();
   });
 
   it("refreshes the roster and opens the created agent hatch session", async () => {

--- a/ui/src/pages/custodian/custodian-session-store.ts
+++ b/ui/src/pages/custodian/custodian-session-store.ts
@@ -450,6 +450,7 @@ export class CustodianSessionStore {
     const client = snapshot.phase === "connected" ? snapshot.client : null;
     const chatSupported =
       client !== null && canCallGatewayMethod(snapshot, "openclaw.chat", "operator.admin");
+    const chatUnsupported = isGatewayMethodAdvertised(snapshot, "openclaw.chat") === false;
     const configuredInferenceState = this.resolveConfiguredInferenceState();
     const inferenceStateChanged = configuredInferenceState !== this.configuredInferenceState;
     this.configuredInferenceState = configuredInferenceState;
@@ -489,7 +490,7 @@ export class CustodianSessionStore {
       if (!chatSupported) {
         this.sessionStarted = false;
         this.abandonPendingUserTurn(pendingParams);
-        this.error = t("custodian.unsupportedGateway");
+        this.error = chatUnsupported ? t("custodian.unsupportedGateway") : null;
         return;
       }
       this.chatAvailable = true;
@@ -506,7 +507,7 @@ export class CustodianSessionStore {
       return;
     }
     if (!chatSupported) {
-      this.error = t("custodian.unsupportedGateway");
+      this.error = chatUnsupported ? t("custodian.unsupportedGateway") : null;
       return;
     }
     if (configuredInferenceState === "unresolved") {


### PR DESCRIPTION
Related: #121459

## What Problem This Solves

Fixes an issue where users opening Ask OpenClaw with a limited browser would see “Update the Gateway” even when the connected Gateway advertised `openclaw.chat` and only `operator.admin` access was missing.

PR #121459 added the cross-route limited-access banner and admin-request flow, which resolved the immediate dead end. Custodian still independently classified every unavailable chat call as an outdated Gateway, leaving a contradictory red error below that banner.

## Why This Change Was Made

Custodian now reserves its Gateway-update error for explicit `openclaw.chat` method absence. Missing administrator scope still keeps chat unavailable, while the app-shell scope-upgrade banner remains the canonical owner of permission guidance and the **Request admin** action.

The original old-Gateway branch remains covered. This is AI-assisted work; I reviewed the owner path, history, tests, and final diff.

## User Impact

Limited browsers now see the actionable administrator-access banner without a false instruction to update a current Gateway. Operators connected to a genuinely older Gateway still see the update prompt.

Release-note context: Control UI Custodian no longer mistakes limited browser permissions for an outdated Gateway.

## Evidence

### Before

A limited browser incorrectly displayed the Gateway-update error:

![Custodian showing the false Gateway update error](https://github.com/user-attachments/assets/94a19323-dda2-43ae-a2e5-ed87f9c1ab77)

### After

The same limited-scope scenario shows the canonical access banner and **Request admin** action, with no local Gateway-update error:

![Custodian showing the limited-access banner without the false error](https://github.com/user-attachments/assets/3e43fa6b-95b2-437d-a6c2-cb89ee9f5d73)

- Pre-fix regression proof: `custodian-page-agent-create.test.ts` failed with received text “Update the Gateway to continue setup with OpenClaw.” on Testbox `tbx_01kzwnevnxhpd56jg5ng3ybmgx` ([run](https://github.com/openclaw/openclaw/actions/runs/31666586135)).
- Focused final proof: 33/33 Custodian tests passed on Testbox `tbx_01kzwp3qjsnkgk3z5beajwkey4` ([run](https://github.com/openclaw/openclaw/actions/runs/31667178472)).
- Browser boundary proof: 7/7 device scope-upgrade E2E tests passed, including the new limited-Custodian case; screenshot above was captured from that rendered browser run.
- Changed-file gate passed: formatting, i18n verification, dependency guards, dead-code scan, core-test and UI TypeScript checks, and changed-file lint.
- Final autoreview: clean, no accepted/actionable findings.
- Surface: production `+3/-2` (net `+1`); tests `+21/-2` (net `+19`).
