### PR TITLE
feat(worker): expose supervised terminal outcomes

### DIFF
--- a/docs/plan/runners.md
+++ b/docs/plan/runners.md
@@ -24,7 +24,7 @@ advances a milestone.
 | 4   | Picker: grouping, placement, liveness, enrichment          | in progress | #120804, #122531, #122635, #122774, #122923 |
 | F   | Real-wire session boundary harness                         | landed      | #121212                                     |
 | 5   | Public worker ingress path                                 | landed      | #122578, #122643                            |
-| 6   | Node worker provider (device runners)                      | in progress | #122683, #122769, #122829, #122939          |
+| 6   | Node worker provider (device runners)                      | in progress | #122683, #122769, #122829, #122939, #123013 |
 | 7   | Bundle push consent + runner updates                       | not started | —                                           |
 | 8   | Stop-and-continue moves                                    | not started | —                                           |
 | 9   | Deletions (ssh sandbox, openshell, exec-host clones, …)    | not started | —                                           |

--- a/src/node-host/invoke-worker-supervisor.test.ts
+++ b/src/node-host/invoke-worker-supervisor.test.ts
@@ -161,13 +161,17 @@ describe("node-host worker supervisor commands", () => {
     expect(payload).not.toHaveProperty("errorText");
   });
 
-  it("omits completed worker output from the durable wire receipt", async () => {
+  it("returns completed worker output without internal process fields", async () => {
     const input = launchInput();
-    const privatePath = "/private/workspaces/session-1/secret.txt";
+    const resultJson = JSON.stringify({
+      status: "completed",
+      transcriptLeafId: "leaf-1",
+      transcriptNextSeq: 2,
+    });
     const receipt: NodeWorkerLaunchReceipt = {
       ...fullReceipt(input),
       state: "completed",
-      resultJson: JSON.stringify({ argv: ["worker", "--internal-worker-ipc"], privatePath }),
+      resultJson,
       completedAtMs: 12,
     };
 
@@ -177,10 +181,7 @@ describe("node-host worker supervisor commands", () => {
       supervisor: supervisorWith(receipt),
     });
 
-    const raw = result?.payloadJSON ?? "";
-    expect(raw).not.toContain("argv");
-    expect(raw).not.toContain(privatePath);
-    expect(JSON.parse(raw)).toEqual({
+    expect(JSON.parse(result?.payloadJSON ?? "{}")).toEqual({
       launchId: input.launchId,
       planHash: receipt.planHash,
       environmentId: input.descriptor.admission.environmentId,
@@ -189,6 +190,42 @@ describe("node-host worker supervisor commands", () => {
       placementGeneration: input.placementGeneration,
       runId: input.descriptor.assignment.runId,
       state: "completed",
+      resultJson,
+    });
+    const payload = JSON.parse(result?.payloadJSON ?? "{}") as Record<string, unknown>;
+    expect(payload).not.toHaveProperty("supervisor");
+    expect(payload).not.toHaveProperty("worker");
+    expect(payload).not.toHaveProperty("gatewayNamespace");
+    expect(payload).not.toHaveProperty("descriptor");
+    expect(payload).not.toHaveProperty("errorText");
+  });
+
+  it("returns failed worker diagnostics without completed output", async () => {
+    const input = launchInput();
+    const receipt: NodeWorkerLaunchReceipt = {
+      ...fullReceipt(input),
+      state: "failed",
+      worker: null,
+      errorText: "worker exited before completion",
+      completedAtMs: 12,
+    };
+
+    const { result } = await invokePrivate({
+      command: NODE_WORKER_SUPERVISOR_STATUS_COMMAND,
+      paramsJSON: JSON.stringify({ launchId: input.launchId }),
+      supervisor: supervisorWith(receipt),
+    });
+
+    expect(JSON.parse(result?.payloadJSON ?? "{}")).toEqual({
+      launchId: input.launchId,
+      planHash: receipt.planHash,
+      environmentId: input.descriptor.admission.environmentId,
+      sessionId: input.descriptor.admission.sessionId,
+      ownerEpoch: input.descriptor.admission.ownerEpoch,
+      placementGeneration: input.placementGeneration,
+      runId: input.descriptor.assignment.runId,
+      state: "failed",
+      errorText: receipt.errorText,
     });
   });
 
@@ -224,6 +261,27 @@ describe("node-host worker supervisor commands", () => {
     expect(mocks.launch.mock.calls).toHaveLength(0);
     expect(mocks.status.mock.calls).toHaveLength(0);
     expect(mocks.cancel.mock.calls).toHaveLength(0);
+  });
+
+  it("fails closed when a durable terminal receipt is inconsistent", async () => {
+    const input = launchInput();
+    const receipt: NodeWorkerLaunchReceipt = {
+      ...fullReceipt(input),
+      state: "completed",
+      resultJson: null,
+      completedAtMs: 12,
+    };
+
+    const { result } = await invokePrivate({
+      command: NODE_WORKER_SUPERVISOR_STATUS_COMMAND,
+      paramsJSON: JSON.stringify({ launchId: input.launchId }),
+      supervisor: supervisorWith(receipt),
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { code: "UNAVAILABLE", message: "node worker supervisor command failed" },
+    });
   });
 
   it("returns a bounded generic error without leaking supervisor details", async () => {

--- a/src/node-host/node-worker-launch-store.ts
+++ b/src/node-host/node-worker-launch-store.ts
@@ -11,11 +11,11 @@ import {
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "../state/openclaw-state-schema.js";
+import type { NodeWorkerSupervisorIdentity } from "../worker/node-supervisor-protocol.js";
 import {
   inspectNodeWorkerProcessIdentity,
   type NodeWorkerProcessIdentity,
 } from "./node-worker-process-identity.js";
-import type { NodeWorkerSupervisorIdentity } from "./node-worker-supervisor-identity.js";
 
 type NodeWorkerLaunchState =
   | "pending"

--- a/src/node-host/node-worker-supervisor-contract.ts
+++ b/src/node-host/node-worker-supervisor-contract.ts
@@ -1,30 +1,22 @@
-import { createHash } from "node:crypto";
-import { stableStringify } from "@openclaw/normalization-core";
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
-  parseWorkerLaunchDescriptor,
-  type WorkerLaunchDescriptor,
-} from "../worker/launch-descriptor.js";
+  parseNodeWorkerSupervisorReceipt,
+  type NodeWorkerLaunchInput,
+  type NodeWorkerSupervisorIdentity,
+  type NodeWorkerSupervisorReceipt,
+} from "../worker/node-supervisor-protocol.js";
 import type { NodeWorkerLaunchReceipt } from "./node-worker-launch-store.js";
-import type { NodeWorkerSupervisorIdentity } from "./node-worker-supervisor-identity.js";
 
-export type { NodeWorkerSupervisorIdentity } from "./node-worker-supervisor-identity.js";
-
-const IDENTIFIER_MAX_CHARS = 256;
-const GATEWAY_NAMESPACE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
-const NODE_WORKER_SUPERVISOR_CANCEL_REQUEST_MAX_BYTES = 4 * 1024;
-
-export type NodeWorkerLaunchInput = {
-  launchId: string;
-  gatewayNamespace: string;
-  bundleHash: string;
-  placementGeneration: number;
-  descriptor: WorkerLaunchDescriptor;
-};
-
-export type NodeWorkerSupervisorReceipt = NodeWorkerSupervisorIdentity & {
-  state: "pending" | "running" | "completed" | "failed" | "interrupted" | "cancelled";
-};
+export {
+  nodeWorkerPlanHash,
+  parseNodeWorkerCancelInput,
+  parseNodeWorkerLaunchInput,
+  parseNodeWorkerLookupInput,
+} from "../worker/node-supervisor-protocol.js";
+export type {
+  NodeWorkerLaunchInput,
+  NodeWorkerSupervisorIdentity,
+  NodeWorkerSupervisorReceipt,
+} from "../worker/node-supervisor-protocol.js";
 
 export type NodeWorkerSupervisorControl = {
   launch(input: NodeWorkerLaunchInput): Promise<NodeWorkerLaunchReceipt>;
@@ -32,152 +24,10 @@ export type NodeWorkerSupervisorControl = {
   cancel(expected: NodeWorkerSupervisorIdentity): Promise<NodeWorkerLaunchReceipt | undefined>;
 };
 
-function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
-  return (
-    Object.keys(value).length === keys.length && keys.every((key) => Object.hasOwn(value, key))
-  );
-}
-
-function requireIdentifier(value: unknown, label: string): string {
-  if (
-    typeof value !== "string" ||
-    value.length === 0 ||
-    value.length > IDENTIFIER_MAX_CHARS ||
-    value.trim() !== value ||
-    value.includes("\0")
-  ) {
-    throw new Error(`INVALID_REQUEST: ${label} must be a bounded non-empty identifier`);
-  }
-  return value;
-}
-
-function requireNonNegativeInteger(value: unknown, label: string): number {
-  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
-    throw new Error(`INVALID_REQUEST: ${label} must be a non-negative safe integer`);
-  }
-  return value;
-}
-
-function decodeRequest(raw?: string | null): unknown {
-  if (!raw) {
-    throw new Error("INVALID_REQUEST: paramsJSON required");
-  }
-  try {
-    return JSON.parse(raw) as unknown;
-  } catch {
-    throw new Error("INVALID_REQUEST: paramsJSON malformed JSON");
-  }
-}
-
-export function parseNodeWorkerLaunchInput(raw?: string | null): NodeWorkerLaunchInput {
-  const value = decodeRequest(raw);
-  if (
-    !isRecord(value) ||
-    !hasExactKeys(value, [
-      "launchId",
-      "gatewayNamespace",
-      "bundleHash",
-      "placementGeneration",
-      "descriptor",
-    ])
-  ) {
-    throw new Error("INVALID_REQUEST: invalid node worker launch request");
-  }
-  const launchId = requireIdentifier(value.launchId, "launchId");
-  const gatewayNamespace = requireIdentifier(value.gatewayNamespace, "gatewayNamespace");
-  if (!GATEWAY_NAMESPACE_PATTERN.test(gatewayNamespace)) {
-    throw new Error("INVALID_REQUEST: gatewayNamespace must be a safe bounded path component");
-  }
-  if (typeof value.bundleHash !== "string" || !/^[a-f0-9]{64}$/u.test(value.bundleHash)) {
-    throw new Error("INVALID_REQUEST: bundleHash must be 64 lowercase hexadecimal characters");
-  }
-  let descriptor: WorkerLaunchDescriptor;
-  try {
-    descriptor = parseWorkerLaunchDescriptor(value.descriptor);
-  } catch {
-    throw new Error("INVALID_REQUEST: invalid worker launch descriptor");
-  }
-  if (descriptor.admission.handshake.bundleHash !== value.bundleHash) {
-    throw new Error("INVALID_REQUEST: descriptor bundle hash does not match bundleHash");
-  }
-  return {
-    launchId,
-    gatewayNamespace,
-    bundleHash: value.bundleHash,
-    placementGeneration: requireNonNegativeInteger(
-      value.placementGeneration,
-      "placementGeneration",
-    ),
-    descriptor,
-  };
-}
-
-export function parseNodeWorkerLookupInput(raw?: string | null): { launchId: string } {
-  const value = decodeRequest(raw);
-  if (!isRecord(value) || !hasExactKeys(value, ["launchId"])) {
-    throw new Error("INVALID_REQUEST: invalid node worker lookup request");
-  }
-  return { launchId: requireIdentifier(value.launchId, "launchId") };
-}
-
-export function parseNodeWorkerCancelInput(raw?: string | null): NodeWorkerSupervisorIdentity {
-  if (!raw || Buffer.byteLength(raw, "utf8") > NODE_WORKER_SUPERVISOR_CANCEL_REQUEST_MAX_BYTES) {
-    throw new Error("INVALID_REQUEST: invalid node worker cancel request");
-  }
-  const value = decodeRequest(raw);
-  if (
-    !isRecord(value) ||
-    !hasExactKeys(value, [
-      "launchId",
-      "planHash",
-      "environmentId",
-      "sessionId",
-      "ownerEpoch",
-      "placementGeneration",
-      "runId",
-    ])
-  ) {
-    throw new Error("INVALID_REQUEST: invalid node worker cancel request");
-  }
-  if (typeof value.planHash !== "string" || !/^[a-f0-9]{64}$/u.test(value.planHash)) {
-    throw new Error("INVALID_REQUEST: planHash must be 64 lowercase hexadecimal characters");
-  }
-  return {
-    launchId: requireIdentifier(value.launchId, "launchId"),
-    planHash: value.planHash,
-    environmentId: requireIdentifier(value.environmentId, "environmentId"),
-    sessionId: requireIdentifier(value.sessionId, "sessionId"),
-    ownerEpoch: requireNonNegativeInteger(value.ownerEpoch, "ownerEpoch"),
-    placementGeneration: requireNonNegativeInteger(
-      value.placementGeneration,
-      "placementGeneration",
-    ),
-    runId: requireIdentifier(value.runId, "runId"),
-  };
-}
-
-export function nodeWorkerPlanHash(
-  input: Pick<
-    NodeWorkerLaunchInput,
-    "bundleHash" | "descriptor" | "gatewayNamespace" | "placementGeneration"
-  >,
-): string {
-  return createHash("sha256")
-    .update(
-      stableStringify({
-        bundleHash: input.bundleHash,
-        descriptor: input.descriptor,
-        gatewayNamespace: input.gatewayNamespace,
-        placementGeneration: input.placementGeneration,
-      }),
-    )
-    .digest("hex");
-}
-
 export function projectNodeWorkerSupervisorReceipt(
   receipt: NodeWorkerLaunchReceipt,
 ): NodeWorkerSupervisorReceipt {
-  return {
+  const identity = {
     launchId: receipt.launchId,
     planHash: receipt.planHash,
     environmentId: receipt.environmentId,
@@ -185,6 +35,18 @@ export function projectNodeWorkerSupervisorReceipt(
     ownerEpoch: receipt.ownerEpoch,
     placementGeneration: receipt.placementGeneration,
     runId: receipt.runId,
-    state: receipt.state,
   };
+  const projected =
+    receipt.state === "completed"
+      ? { ...identity, state: receipt.state, resultJson: receipt.resultJson }
+      : receipt.state === "failed" ||
+          receipt.state === "interrupted" ||
+          receipt.state === "cancelled"
+        ? { ...identity, state: receipt.state, errorText: receipt.errorText }
+        : { ...identity, state: receipt.state };
+  const parsed = parseNodeWorkerSupervisorReceipt(projected);
+  if (!parsed) {
+    throw new Error("node worker supervisor durable receipt is inconsistent");
+  }
+  return parsed;
 }

--- a/src/node-host/node-worker-supervisor-identity.ts
+++ b/src/node-host/node-worker-supervisor-identity.ts
@@ -1,9 +1,0 @@
-export type NodeWorkerSupervisorIdentity = {
-  launchId: string;
-  planHash: string;
-  environmentId: string;
-  sessionId: string;
-  ownerEpoch: number;
-  placementGeneration: number;
-  runId: string;
-};

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -81,7 +81,7 @@ import {
 import { getOpenClawStateRuntimeSchema } from "./openclaw-state-schema-compatibility.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.js";
 
-const OPENCLAW_STATE_MIGRATION_ASSERTIONS = {
+const STATE_MIGRATION_ASSERTIONS = {
   5: assertOpenClawStateDatabaseV5ForMigration,
   6: assertOpenClawStateDatabaseV6ForMigration,
 } as const;
@@ -178,7 +178,7 @@ function repairOpenClawStateDatabaseSchemaWithWriteAccess(
             allowedMissingTables: LAZY_ADDITIVE_STATE_TABLES,
           });
         } else if (previousVersion === 5 || previousVersion === 6) {
-          OPENCLAW_STATE_MIGRATION_ASSERTIONS[previousVersion](db, { pathname });
+          STATE_MIGRATION_ASSERTIONS[previousVersion](db, { pathname });
         }
         if (rebuiltIndexNames.size === 0) {
           assertSqliteIntegrity(db, pathname);
@@ -366,7 +366,7 @@ function ensureSchema(db: DatabaseSync, pathname: string, env: NodeJS.ProcessEnv
           ensureAdditiveStateColumns(db);
           assertCurrentStateRuntimeSchema(db, pathname);
         } else if (previousVersion === 5 || previousVersion === 6) {
-          OPENCLAW_STATE_MIGRATION_ASSERTIONS[previousVersion](db, { pathname });
+          STATE_MIGRATION_ASSERTIONS[previousVersion](db, { pathname });
         }
         dropLegacyStateTables(db);
         migrateRetiredCommitmentsSchema(db, previousVersion);

--- a/src/worker/node-supervisor-protocol.test.ts
+++ b/src/worker/node-supervisor-protocol.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseNodeWorkerSupervisorReceipt,
+  type NodeWorkerSupervisorIdentity,
+} from "./node-supervisor-protocol.js";
+
+const RESULT_JSON_MAX_BYTES = 64 * 1024;
+const ERROR_TEXT_MAX_BYTES = 4 * 1024;
+
+const identity: NodeWorkerSupervisorIdentity = {
+  launchId: "launch-1",
+  planHash: "a".repeat(64),
+  environmentId: "environment-1",
+  sessionId: "session-1",
+  ownerEpoch: 3,
+  placementGeneration: 4,
+  runId: "run-1",
+};
+
+describe("node worker supervisor wire receipt", () => {
+  it.each([
+    { ...identity, state: "pending" },
+    { ...identity, state: "running" },
+    {
+      ...identity,
+      state: "completed",
+      resultJson: JSON.stringify({ status: "completed", transcriptNextSeq: 2 }),
+    },
+    { ...identity, state: "failed", errorText: "worker exited before completion" },
+    { ...identity, state: "interrupted", errorText: "node host stopped" },
+    { ...identity, state: "cancelled", errorText: "node worker launch cancelled" },
+  ])("round-trips the closed $state receipt", (receipt) => {
+    expect(parseNodeWorkerSupervisorReceipt(receipt)).toEqual(receipt);
+  });
+
+  it.each([
+    { name: "extra field", receipt: { ...identity, state: "running", workerPid: 123 } },
+    { name: "missing plan hash", receipt: { ...identity, planHash: undefined, state: "running" } },
+    { name: "completed without output", receipt: { ...identity, state: "completed" } },
+    {
+      name: "completed with malformed output",
+      receipt: { ...identity, state: "completed", resultJson: "{" },
+    },
+    {
+      name: "oversized completed output",
+      receipt: {
+        ...identity,
+        state: "completed",
+        resultJson: JSON.stringify({ text: "x".repeat(RESULT_JSON_MAX_BYTES) }),
+      },
+    },
+    { name: "failed without error", receipt: { ...identity, state: "failed" } },
+    {
+      name: "multiline error",
+      receipt: { ...identity, state: "failed", errorText: "first\nsecond" },
+    },
+    {
+      name: "oversized error",
+      receipt: {
+        ...identity,
+        state: "failed",
+        errorText: "x".repeat(ERROR_TEXT_MAX_BYTES + 1),
+      },
+    },
+  ])("rejects $name", ({ receipt }) => {
+    expect(parseNodeWorkerSupervisorReceipt(receipt)).toBeNull();
+  });
+
+  it("rejects non-object values without throwing", () => {
+    expect(parseNodeWorkerSupervisorReceipt("{")).toBeNull();
+    expect(parseNodeWorkerSupervisorReceipt(null)).toBeNull();
+  });
+});

--- a/src/worker/node-supervisor-protocol.ts
+++ b/src/worker/node-supervisor-protocol.ts
@@ -1,0 +1,288 @@
+import { createHash } from "node:crypto";
+import { stableStringify } from "@openclaw/normalization-core";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { parseWorkerLaunchDescriptor, type WorkerLaunchDescriptor } from "./launch-descriptor.js";
+
+const IDENTIFIER_MAX_CHARS = 256;
+const GATEWAY_NAMESPACE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
+const NODE_WORKER_SUPERVISOR_CANCEL_REQUEST_MAX_BYTES = 4 * 1024;
+const NODE_WORKER_RESULT_JSON_MAX_BYTES = 64 * 1024;
+const NODE_WORKER_ERROR_TEXT_MAX_BYTES = 4 * 1024;
+
+export type NodeWorkerLaunchInput = {
+  launchId: string;
+  gatewayNamespace: string;
+  bundleHash: string;
+  placementGeneration: number;
+  descriptor: WorkerLaunchDescriptor;
+};
+
+export type NodeWorkerSupervisorIdentity = {
+  launchId: string;
+  planHash: string;
+  environmentId: string;
+  sessionId: string;
+  ownerEpoch: number;
+  placementGeneration: number;
+  runId: string;
+};
+
+type NodeWorkerSupervisorActiveReceipt = NodeWorkerSupervisorIdentity & {
+  state: "pending" | "running";
+};
+
+type NodeWorkerSupervisorCompletedReceipt = NodeWorkerSupervisorIdentity & {
+  state: "completed";
+  resultJson: string;
+};
+
+type NodeWorkerSupervisorErrorReceipt = NodeWorkerSupervisorIdentity & {
+  state: "failed" | "interrupted" | "cancelled";
+  errorText: string;
+};
+
+export type NodeWorkerSupervisorReceipt =
+  | NodeWorkerSupervisorActiveReceipt
+  | NodeWorkerSupervisorCompletedReceipt
+  | NodeWorkerSupervisorErrorReceipt;
+
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  return (
+    Object.keys(value).length === keys.length && keys.every((key) => Object.hasOwn(value, key))
+  );
+}
+
+function isIdentifier(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= IDENTIFIER_MAX_CHARS &&
+    value.trim() === value &&
+    !value.includes("\0")
+  );
+}
+
+function requireIdentifier(value: unknown, label: string): string {
+  if (!isIdentifier(value)) {
+    throw new Error(`INVALID_REQUEST: ${label} must be a bounded non-empty identifier`);
+  }
+  return value;
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function requireNonNegativeInteger(value: unknown, label: string): number {
+  if (!isNonNegativeInteger(value)) {
+    throw new Error(`INVALID_REQUEST: ${label} must be a non-negative safe integer`);
+  }
+  return value;
+}
+
+function isPlanHash(value: unknown): value is string {
+  return typeof value === "string" && /^[a-f0-9]{64}$/u.test(value);
+}
+
+function decodeRequest(raw?: string | null): unknown {
+  if (!raw) {
+    throw new Error("INVALID_REQUEST: paramsJSON required");
+  }
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    throw new Error("INVALID_REQUEST: paramsJSON malformed JSON");
+  }
+}
+
+export function parseNodeWorkerLaunchInput(raw?: string | null): NodeWorkerLaunchInput {
+  const value = decodeRequest(raw);
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, [
+      "launchId",
+      "gatewayNamespace",
+      "bundleHash",
+      "placementGeneration",
+      "descriptor",
+    ])
+  ) {
+    throw new Error("INVALID_REQUEST: invalid node worker launch request");
+  }
+  const launchId = requireIdentifier(value.launchId, "launchId");
+  const gatewayNamespace = requireIdentifier(value.gatewayNamespace, "gatewayNamespace");
+  if (!GATEWAY_NAMESPACE_PATTERN.test(gatewayNamespace)) {
+    throw new Error("INVALID_REQUEST: gatewayNamespace must be a safe bounded path component");
+  }
+  if (!isPlanHash(value.bundleHash)) {
+    throw new Error("INVALID_REQUEST: bundleHash must be 64 lowercase hexadecimal characters");
+  }
+  let descriptor: WorkerLaunchDescriptor;
+  try {
+    descriptor = parseWorkerLaunchDescriptor(value.descriptor);
+  } catch {
+    throw new Error("INVALID_REQUEST: invalid worker launch descriptor");
+  }
+  if (descriptor.admission.handshake.bundleHash !== value.bundleHash) {
+    throw new Error("INVALID_REQUEST: descriptor bundle hash does not match bundleHash");
+  }
+  return {
+    launchId,
+    gatewayNamespace,
+    bundleHash: value.bundleHash,
+    placementGeneration: requireNonNegativeInteger(
+      value.placementGeneration,
+      "placementGeneration",
+    ),
+    descriptor,
+  };
+}
+
+export function parseNodeWorkerLookupInput(raw?: string | null): { launchId: string } {
+  const value = decodeRequest(raw);
+  if (!isRecord(value) || !hasExactKeys(value, ["launchId"])) {
+    throw new Error("INVALID_REQUEST: invalid node worker lookup request");
+  }
+  return { launchId: requireIdentifier(value.launchId, "launchId") };
+}
+
+export function parseNodeWorkerCancelInput(raw?: string | null): NodeWorkerSupervisorIdentity {
+  if (!raw || Buffer.byteLength(raw, "utf8") > NODE_WORKER_SUPERVISOR_CANCEL_REQUEST_MAX_BYTES) {
+    throw new Error("INVALID_REQUEST: invalid node worker cancel request");
+  }
+  const value = decodeRequest(raw);
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, [
+      "launchId",
+      "planHash",
+      "environmentId",
+      "sessionId",
+      "ownerEpoch",
+      "placementGeneration",
+      "runId",
+    ])
+  ) {
+    throw new Error("INVALID_REQUEST: invalid node worker cancel request");
+  }
+  if (!isPlanHash(value.planHash)) {
+    throw new Error("INVALID_REQUEST: planHash must be 64 lowercase hexadecimal characters");
+  }
+  return {
+    launchId: requireIdentifier(value.launchId, "launchId"),
+    planHash: value.planHash,
+    environmentId: requireIdentifier(value.environmentId, "environmentId"),
+    sessionId: requireIdentifier(value.sessionId, "sessionId"),
+    ownerEpoch: requireNonNegativeInteger(value.ownerEpoch, "ownerEpoch"),
+    placementGeneration: requireNonNegativeInteger(
+      value.placementGeneration,
+      "placementGeneration",
+    ),
+    runId: requireIdentifier(value.runId, "runId"),
+  };
+}
+
+export function nodeWorkerPlanHash(
+  input: Pick<
+    NodeWorkerLaunchInput,
+    "bundleHash" | "descriptor" | "gatewayNamespace" | "placementGeneration"
+  >,
+): string {
+  return createHash("sha256")
+    .update(
+      stableStringify({
+        bundleHash: input.bundleHash,
+        descriptor: input.descriptor,
+        gatewayNamespace: input.gatewayNamespace,
+        placementGeneration: input.placementGeneration,
+      }),
+    )
+    .digest("hex");
+}
+
+const RECEIPT_IDENTITY_KEYS = [
+  "launchId",
+  "planHash",
+  "environmentId",
+  "sessionId",
+  "ownerEpoch",
+  "placementGeneration",
+  "runId",
+] as const;
+
+function parseReceiptIdentity(value: Record<string, unknown>): NodeWorkerSupervisorIdentity | null {
+  if (
+    !isIdentifier(value.launchId) ||
+    !isPlanHash(value.planHash) ||
+    !isIdentifier(value.environmentId) ||
+    !isIdentifier(value.sessionId) ||
+    !isNonNegativeInteger(value.ownerEpoch) ||
+    !isNonNegativeInteger(value.placementGeneration) ||
+    !isIdentifier(value.runId)
+  ) {
+    return null;
+  }
+  return {
+    launchId: value.launchId,
+    planHash: value.planHash,
+    environmentId: value.environmentId,
+    sessionId: value.sessionId,
+    ownerEpoch: value.ownerEpoch,
+    placementGeneration: value.placementGeneration,
+    runId: value.runId,
+  };
+}
+
+function isBoundedResultJson(value: unknown): value is string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    Buffer.byteLength(value, "utf8") > NODE_WORKER_RESULT_JSON_MAX_BYTES
+  ) {
+    return false;
+  }
+  try {
+    return isRecord(JSON.parse(value) as unknown);
+  } catch {
+    return false;
+  }
+}
+
+function isBoundedErrorText(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    Buffer.byteLength(value, "utf8") <= NODE_WORKER_ERROR_TEXT_MAX_BYTES &&
+    !/[\r\n]/u.test(value)
+  );
+}
+
+export function parseNodeWorkerSupervisorReceipt(
+  value: unknown,
+): NodeWorkerSupervisorReceipt | null {
+  if (!isRecord(value) || typeof value.state !== "string") {
+    return null;
+  }
+  const identity = parseReceiptIdentity(value);
+  if (!identity) {
+    return null;
+  }
+  if (value.state === "pending" || value.state === "running") {
+    return hasExactKeys(value, [...RECEIPT_IDENTITY_KEYS, "state"])
+      ? { ...identity, state: value.state }
+      : null;
+  }
+  if (value.state === "completed") {
+    return hasExactKeys(value, [...RECEIPT_IDENTITY_KEYS, "state", "resultJson"]) &&
+      isBoundedResultJson(value.resultJson)
+      ? { ...identity, state: value.state, resultJson: value.resultJson }
+      : null;
+  }
+  if (value.state === "failed" || value.state === "interrupted" || value.state === "cancelled") {
+    return hasExactKeys(value, [...RECEIPT_IDENTITY_KEYS, "state", "errorText"]) &&
+      isBoundedErrorText(value.errorText)
+      ? { ...identity, state: value.state, errorText: value.errorText }
+      : null;
+  }
+  return null;
+}


### PR DESCRIPTION
## What Problem This Solves

The durable node worker supervisor can report that a turn completed or failed, but its private Gateway receipt exposes only identity and state. A Gateway-side node launch client therefore cannot collect the bounded worker runtime JSON that the existing turn launcher consumes, or the redacted diagnostic for a failed child.

## Why This Change Was Made

This moves the private launch/request/identity DTOs and plan hash into a worker-owned shared contract, then makes terminal receipts a closed discriminated union:

- `pending` / `running` carry identity and state only;
- `completed` additionally carries bounded, valid JSON (`resultJson`);
- `failed` / `interrupted` / `cancelled` additionally carry bounded single-line `errorText`.

The node-host projection validates every durable receipt before it crosses the private capability-bound transport. Inconsistent rows fail closed as a generic supervisor error. PIDs, process identities, gateway namespace, descriptor, credential, timestamps, and filesystem internals remain absent. Request parsing and plan hashing keep one canonical worker-owned implementation; the obsolete node-host identity module is removed.

This is deliberately a prerequisite, not device turn launch. It does not enable `sessions.dispatch({ deviceId })`, create a node tunnel, install bundles, synthesize `SpawnResult`, or bypass the existing workspace-transfer gate.

The patch also repairs an inherited red-main CI failure by renaming an internal migration-assertion map that accidentally matched the `OPENCLAW_*` environment-variable ratchet. The ratchet stays at 502; no environment surface is added.

## User Impact

No user-visible device-runner capability is enabled yet. This gives the next Gateway adapter a strict, replayable terminal-result seam without exposing node-host internals or weakening the private supervisor boundary.

## Evidence

- Pre-fix regression: `node scripts/run-vitest.mjs src/node-host/invoke-worker-supervisor.test.ts` failed because a completed receipt omitted `resultJson`.
- Broad supervisor proof: 61 tests passed across the shared protocol, worker runtime result, private invocation, real process supervision/recovery, and node runtime integration.
- Shared wire-contract proof: 15 closed-shape/bounds tests passed, including malformed/extra fields, missing terminal data, invalid JSON, multiline diagnostics, and byte ceilings.
- Red-main repair proof: `OPENCLAW_* count 502/502`; `src/state/openclaw-state-db.test.ts` passed 142 tests with one skip.
- Canonical changed gate passed after trusted-source local fallback because no remote provider was ready: formatting, unchanged Plugin SDK API baseline, dead exports, production/test types, full core lint, schema/database/auth/pairing guards, and zero runtime cycles.
- Final structured review and secret scan: clean.
- `git diff --check`: clean.

LOC classification against the branch base:

- production: +322/−181, net +141;
- tests: +138/−7, net +131.

The production growth is the strict terminal receipt parser and bounded union required by the forthcoming launch adapter; moving the existing request/identity/hash contract removes duplicate ownership rather than preserving a compatibility facade.
