### PR TITLE
fix: prevent $-pattern injection in prompt template and approval substitution

### DIFF
--- a/packages/agent-core/src/harness/prompt-template-arguments.test.ts
+++ b/packages/agent-core/src/harness/prompt-template-arguments.test.ts
@@ -8,4 +8,10 @@ describe("prompt template arguments", () => {
     expect(parseCommandArgs("first '' third")).toEqual(["first", "", "third"]);
     expect(substituteArgs("$1|$2|$3", parseCommandArgs('first "" third'))).toBe("first||third");
   });
+
+  it("preserves literal dollar sequences in $ARGUMENTS and $@ substitution", () => {
+    const args = parseCommandArgs("price $$ and $& here");
+    expect(substituteArgs("Args: $ARGUMENTS", args)).toBe("Args: price $$ and $& here");
+    expect(substituteArgs("Args: $@", args)).toBe("Args: price $$ and $& here");
+  });
 });

--- a/packages/agent-core/src/harness/prompt-template-arguments.test.ts
+++ b/packages/agent-core/src/harness/prompt-template-arguments.test.ts
@@ -14,4 +14,9 @@ describe("prompt template arguments", () => {
     expect(substituteArgs("Args: $ARGUMENTS", args)).toBe("Args: price $$ and $& here");
     expect(substituteArgs("Args: $@", args)).toBe("Args: price $$ and $& here");
   });
+
+  it("resolves every placeholder in one pass so inserted arguments are never re-expanded", () => {
+    expect(substituteArgs("$1 $@", ["$ARGUMENTS", "safe"])).toBe("$ARGUMENTS $ARGUMENTS safe");
+    expect(substituteArgs("$1 ${@:2:1}", ["$@", "$ARGUMENTS", "safe"])).toBe("$@ $ARGUMENTS");
+  });
 });

--- a/packages/agent-core/src/harness/prompt-template-arguments.ts
+++ b/packages/agent-core/src/harness/prompt-template-arguments.ts
@@ -48,39 +48,40 @@ export function parseCommandArgs(argsString: string): string[] {
  * loading or invocation.
  */
 export function substituteArgs(content: string, args: string[]): string {
-  let result = content;
-  result = result.replace(/\$(\d+)/g, (_, num: string) => {
-    const parsed = parseStrictNonNegativeInteger(num);
-    if (parsed === undefined || parsed <= 0) {
-      return "";
-    }
-    return args[parsed - 1] ?? "";
-  });
-  result = result.replace(
-    /\$\{@:(\d+)(?::(\d+))?\}/g,
-    (_, startStr: string, lengthStr?: string) => {
-      const parsedStart = parseStrictNonNegativeInteger(startStr);
-      if (parsedStart === undefined) {
-        return "";
-      }
-      // Keep shell-style `${@:0:...}` compatibility: start 0 includes `$0` in shell, but
-      // prompt templates have no command name, so it maps to the first provided argument.
-      let start = parsedStart - 1;
-      if (start < 0) {
-        start = 0;
-      }
-      if (lengthStr) {
-        const length = parseStrictNonNegativeInteger(lengthStr);
-        if (length === undefined) {
+  const allArgs = args.join(" ");
+  // Single-pass substitution: an argument inserted for one placeholder must never
+  // be re-interpreted by a later placeholder pass (e.g. `$1` inserting `$ARGUMENTS`).
+  return content.replace(
+    /\$(\d+)|\$\{@:(\d+)(?::(\d+))?\}|\$ARGUMENTS|\$@/g,
+    (_match, num: string | undefined, startStr: string | undefined, lengthStr?: string) => {
+      if (num !== undefined) {
+        const parsed = parseStrictNonNegativeInteger(num);
+        if (parsed === undefined || parsed <= 0) {
           return "";
         }
-        return args.slice(start, start + length).join(" ");
+        return args[parsed - 1] ?? "";
       }
-      return args.slice(start).join(" ");
+      if (startStr !== undefined) {
+        const parsedStart = parseStrictNonNegativeInteger(startStr);
+        if (parsedStart === undefined) {
+          return "";
+        }
+        // Keep shell-style `${@:0:...}` compatibility: start 0 includes `$0` in shell, but
+        // prompt templates have no command name, so it maps to the first provided argument.
+        let start = parsedStart - 1;
+        if (start < 0) {
+          start = 0;
+        }
+        if (lengthStr) {
+          const length = parseStrictNonNegativeInteger(lengthStr);
+          if (length === undefined) {
+            return "";
+          }
+          return args.slice(start, start + length).join(" ");
+        }
+        return args.slice(start).join(" ");
+      }
+      return allArgs;
     },
   );
-  const allArgs = args.join(" ");
-  result = result.replace(/\$ARGUMENTS/g, () => allArgs);
-  result = result.replace(/\$@/g, () => allArgs);
-  return result;
 }

--- a/packages/agent-core/src/harness/prompt-template-arguments.ts
+++ b/packages/agent-core/src/harness/prompt-template-arguments.ts
@@ -80,7 +80,7 @@ export function substituteArgs(content: string, args: string[]): string {
     },
   );
   const allArgs = args.join(" ");
-  result = result.replace(/\$ARGUMENTS/g, allArgs);
-  result = result.replace(/\$@/g, allArgs);
+  result = result.replace(/\$ARGUMENTS/g, () => allArgs);
+  result = result.replace(/\$@/g, () => allArgs);
   return result;
 }

--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -762,6 +762,39 @@ describe("handleInlineActions", () => {
     );
   });
 
+  it("keeps literal $ patterns in bundle command arguments", async () => {
+    const typing = createTypingController();
+    handleCommandsMock.mockResolvedValue({ shouldContinue: false, reply: { text: "done" } });
+    const ctx = buildTestCtx({
+      Body: "/office_hours price $$ and $& here",
+      CommandBody: "/office_hours price $$ and $& here",
+    });
+    const skillCommands = officeHoursSkillCommands();
+
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: "/office_hours price $$ and $& here",
+      command: {
+        isAuthorizedSender: true,
+        rawBodyNormalized: "/office_hours price $$ and $& here",
+        commandBodyNormalized: "/office_hours price $$ and $& here",
+      },
+      overrides: {
+        allowTextCommands: true,
+        cfg: { commands: { text: true } },
+        skillCommands,
+      },
+    });
+
+    expect(result).toEqual({ kind: "reply", reply: { text: "done" } });
+    expect(ctx.Body).toBe("Act as an engineering advisor.\n\nFocus on:\nprice $$ and $& here");
+    const commandArgs = mockObjectArg(handleCommandsMock, "handleCommands");
+    expect(requireRecord(commandArgs.ctx, "handleCommands ctx").Body).toBe(
+      "Act as an engineering advisor.\n\nFocus on:\nprice $$ and $& here",
+    );
+  });
+
   it("loads workspace skills when /skill gets an empty preloaded command list", async () => {
     const typing = createTypingController();
     handleCommandsMock.mockResolvedValue({ shouldContinue: false, reply: { text: "done" } });

--- a/src/plugin-sdk/approval-reaction-runtime.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.ts
@@ -458,10 +458,7 @@ export function buildApprovalReactionPromptPayloadForRequest(params: {
 }
 
 function replaceApprovalIdPlaceholder(text: string | undefined, approvalId: string): string {
-  // Function replacement preserves literal `$` sequences so an approvalId
-  // containing `$&`/`$1`-`$9`/`$$` is not interpreted as a replacement pattern.
-  // Mirrors the escape already applied in extensions/imessage/src/approval-text.ts.
-  return (text ?? "").replace(/\/approve\s+<id>/g, () => `/approve ${approvalId}`);
+  return (text ?? "").replace(/\/approve\s+<id>/g, `/approve ${approvalId}`);
 }
 
 /** Build reaction and manual-fallback pending approval content for a prepared view. */

--- a/src/plugin-sdk/approval-reaction-runtime.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.ts
@@ -458,7 +458,10 @@ export function buildApprovalReactionPromptPayloadForRequest(params: {
 }
 
 function replaceApprovalIdPlaceholder(text: string | undefined, approvalId: string): string {
-  return (text ?? "").replace(/\/approve\s+<id>/g, `/approve ${approvalId}`);
+  // Function replacement preserves literal `$` sequences so an approvalId
+  // containing `$&`/`$1`-`$9`/`$$` is not interpreted as a replacement pattern.
+  // Mirrors the escape already applied in extensions/imessage/src/approval-text.ts.
+  return (text ?? "").replace(/\/approve\s+<id>/g, () => `/approve ${approvalId}`);
 }
 
 /** Build reaction and manual-fallback pending approval content for a prepared view. */

--- a/src/skills/discovery/chat-command-invocation.ts
+++ b/src/skills/discovery/chat-command-invocation.ts
@@ -162,7 +162,7 @@ export function resolveSkillCommandInvocation(params: {
 export function expandBundleCommandPromptTemplate(template: string, args?: string): string {
   const normalizedArgs = args?.trim() ?? "";
   const rendered = template.includes("$ARGUMENTS")
-    ? template.replaceAll("$ARGUMENTS", normalizedArgs)
+    ? template.replaceAll("$ARGUMENTS", () => normalizedArgs)
     : template;
   if (!normalizedArgs || template.includes("$ARGUMENTS")) {
     return rendered.trim();


### PR DESCRIPTION
## What Problem This Solves

Two call sites used `String.replace`/`replaceAll` with a **string replacement** fed a runtime variable. JavaScript interprets `$&`, `$1`–`$9`, `` $` ``, `$'` in string replacements, so user-supplied content containing `$` is silently corrupted:

1. **`packages/agent-core/src/harness/prompt-template-arguments.ts:83-84`** — `$ARGUMENTS` and `$@` substitution corrupts slash-command args containing `$` (e.g. shell variables, prices). `$$` collapses to `$`, `$&` becomes the entire match.
2. Bundle command template expansion — `replaceAll("$ARGUMENTS", normalizedArgs)` as a string replacement re-interprets `$` patterns from `skillInvocation.args`; the rendered result feeds agent prompt fields. (Owner moved during this PR's lifetime: originally `src/auto-reply/reply/get-reply-inline-actions.ts`, extracted upstream to `src/skills/discovery/chat-command-invocation.ts` in #125554-era refactoring; this branch follows the invariant to the new owner.)

## Why This Change Was Made

`String.replace(regex, () => value)` treats the return value literally — no `$` interpretation. Each call site switches from the string form to the function form. Same fix pattern as #111398 (terminal-core display-string) and the core home-dir resolver PR #122991.

(An initially included third call site — the plugin-SDK `replaceApprovalIdPlaceholder` — was removed per review: that helper has no canonical `/approve <id>` placeholder producer in the plugin-SDK manual fallback path, so the rewrite was unproven.)

## User Impact

When a user runs a slash command (or bundle command) with arguments containing `$` — e.g. `fix $HOME variable`, `price is $$5` — the args are mangled before reaching the model: `$$` collapses to `$`, `$&` re-expands to the template placeholder text. The model sees corrupted input and acts on wrong data.

## Evidence

### Runtime probe through the real prompt-template owner (before → after)

`node --import tsx /tmp/verify-prompt-dollar.mjs` imports the real `substituteArgs` module from this branch:

```
########## BEFORE (pre-fix production code at base 683d37a35f2) ##########
FAIL substituteArgs keeps literal $ patterns
  args:     ["price","$$ and $& here","$`tail","$'quote"]
  rendered: "Quote for: price\nDetails: $$ and $& here $`tail $'quote\nEverything: price $ and $ARGUMENTS here Quote for: price\nDetails: … $`tail $'quote"   (all four $ patterns corrupted / re-expanded)
PROBE FAIL

########## AFTER (fixed production code at PR head) ##########
PASS substituteArgs keeps literal $ patterns
  rendered: "Quote for: price\nDetails: $$ and $& here $`tail $'quote\nEverything: price $$ and $& here $`tail $'quote"
PROBE PASS
```

### Owner-boundary regressions (both red-green verified)

- `packages/agent-core/src/harness/prompt-template-arguments.test.ts`: `substituteArgs("Args: $ARGUMENTS", parseCommandArgs("price $$ and $& here"))` must stay literal.
  - **Red (pre-fix)**: `expected 'Args: price $ and $ARGUMENTS here'`.
- `src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts`: new case **"keeps literal $ patterns in bundle command arguments"** drives the actual changed route end-to-end through `runTestInlineActions` (real `handleInlineActions`, real skill-command rewriting) with `/office_hours price $$ and $& here`, asserting both `ctx.Body` and the `handleCommands` prompt body keep `price $$ and $& here` literally.
  - **Red (pre-fix)**: `AssertionError: expected 'Act as an engineering advisor.\n\nFoc…' to be '…'` — the rendered prompt had `$$`/`$&` re-expanded.
  - **Green (post-fix)**: full file 32 passed.

### Single-pass placeholder resolution (addresses review finding)

`substituteArgs` previously ran four sequential replace passes (`$1`…, `${@:N}`, `$ARGUMENTS`, `$@`), so text inserted by an early pass could be re-interpreted by a later one. It now resolves every placeholder in **one** combined pass; an inserted argument is final data.

- Red (pre-fix, four-pass): `AssertionError: expected '$ARGUMENTS safe $ARGUMENTS safe' to be '$ARGUMENTS $ARGUMENTS safe'` for `substituteArgs("$1 $@", ["$ARGUMENTS", "safe"])` — exactly the review's reproduction.
- Green: `substituteArgs("$1 $@", ["$ARGUMENTS", "safe"]) === "$ARGUMENTS $ARGUMENTS safe"`, plus `substituteArgs("$1 ${@:2:1}", ["$@", "$ARGUMENTS", "safe"]) === "$@ $ARGUMENTS"`.
- Runtime probe (`node --import tsx /tmp/verify-prompt-dollar.mjs`) now prints `PASS substituteArgs resolves all placeholders in one pass` alongside the literal-`$` PASS above.

### Tests (rebased onto latest `main` incl. the chat-command extraction, exact head `91cb18b38f2`)

- `node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts` → 35 passed (red-green re-verified on the new `chat-command-invocation.ts` owner: reverting only that file to `main` makes the literal-`$` case fail)
- `node scripts/run-vitest.mjs packages/agent-core/src/harness/prompt-template-arguments.test.ts` → 3 passed
- `git diff --check` → clean

### Prior CI red-shard attribution (superseded head)

On head `cb60ffe9f61`, `checks-node-compact-small-12` failed at `test/scripts/install-sh.test.ts > install.sh > bounds installer npm prefix probes during finalization helpers`. That test passes 88/88 on latest `main` locally (node 26.5.0) and touches the installer, unrelated to this diff — runner/flaky-specific, not introduced by this PR.

**Production LOC**: the two substitutions became one single-pass resolver (+6 net in `prompt-template-arguments.ts`, callback form retained); `chat-command-invocation.ts` net 0. Test LOC: +46.

**Sibling already fixed**: `packages/terminal-core/src/display-string.ts:53` (#111398) uses the callback form for the same `$`-expansion invariant.

### CI (exact head `91cb18b38f2`)

Full CI matrix green: [run 32098907313](https://github.com/openclaw/openclaw/actions/runs/32098907313).
