### PR TITLE
fix(ci): align Mattermost raw command preview fixture

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -1879,7 +1879,10 @@ describe("mattermost inbound user posts", () => {
           chatmode: "onmessage",
           dmPolicy: "open",
           groupPolicy: "open",
-          streaming: { mode: "block", preview: { toolProgress: true } },
+          streaming: {
+            mode: "block",
+            preview: { toolProgress: true, commandText: "raw" },
+          },
         },
       },
     };


### PR DESCRIPTION
## What Problem This Solves

Fixes a `main` extension-shard failure where the Mattermost interleaved tool-preview test expected raw command text while its fixture enabled only tool labels.

## Why This Change Was Made

The fixture now explicitly selects `commandText: "raw"`, matching the assertions for `pwd`, `ls -alh`, and `whoami`. Runtime behavior is unchanged; this is the narrow configuration correction for the existing test contract.

## User Impact

No user-visible behavior change. Mattermost extension validation now exercises the intended raw-command preview mode instead of failing against the default status-only rendering.

## Evidence

- Before: the focused test failed because the draft contained only `Bash` status labels and not `pwd`.
- `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts -t 'preserves text-tool-text boundaries while grouping interleaved tool updates'` - passed, 1 test.
- `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts` - passed, 31 tests.
- `node scripts/check-changed.mjs -- extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts` - passed on Blacksmith Testbox `tbx_01kzwrhxpzx4cneamve4w9ts28` ([run](https://github.com/openclaw/openclaw/actions/runs/31669523507)).
- `pnpm format extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts` - passed.
- `git diff --check` - passed.
- Production LOC: +0/-0. Tests: +4/-1.
