### PR TITLE
fix(ui): contain long sharing member labels

### DIFF
--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -481,11 +481,18 @@ suite.define(() => {
     sessions.count = 1;
     sessions.creators = [{ id: "profile-ada", label: "Ada" }];
     sessions.sessions = [activeSession];
-    const humanIdentities = Array.from({ length: 30 }, (_, index) => ({
-      type: "human" as const,
-      id: `profile-member-${index}`,
-      label: `Member ${index + 1}`,
-    }));
+    const longMemberLabel =
+      "Alexandria Montgomery-Santiago from the International Collaboration Working Group";
+    const longMemberId = `profile:${"member-without-a-display-name-".repeat(6)}`;
+    const humanIdentities = [
+      { type: "human" as const, id: "profile-long-name", label: longMemberLabel },
+      { type: "human" as const, id: longMemberId },
+      ...Array.from({ length: 28 }, (_, index) => ({
+        type: "human" as const,
+        id: `profile-member-${index}`,
+        label: `Member ${index + 1}`,
+      })),
+    ];
     const channelIdentities = [
       { type: "human" as const, id: "channel:chn_design", label: "Design" },
       { type: "human" as const, id: "discord:channel:operations", label: "Operations" },
@@ -502,12 +509,41 @@ suite.define(() => {
         "session.visibility.set",
       ],
       operatorScopes: ["operator.read", "operator.write"],
-      historyMessages: [{ role: "assistant", content: [{ type: "text", text: "Ready." }] }],
+      historyMessages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "Share the launch review with the design and operations groups, then summarize the open decisions.",
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "I prepared the rollout summary, linked the review notes, and kept the workspace visible to collaborators.",
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "Add the remaining members and confirm the sharing policy before the handoff.",
+            },
+          ],
+        },
+        { role: "assistant", content: [{ type: "text", text: "Ready." }] },
+      ],
       methodResponses: {
         "sessions.list": sessions,
         "session.members.list": {
           sessionKey: "agent:main:ada",
-          members: [],
+          members: [{ identityId: longMemberId, addedBy: "profile-ada", addedAt: 1 }],
           identities: [...humanIdentities, ...channelIdentities],
           role: "owner",
           allowedVisibilities: ["shared", "read-only", "suggest", "draft"],
@@ -526,9 +562,29 @@ suite.define(() => {
       const animations = [...element.getAnimations(), ...(menu?.getAnimations() ?? [])];
       await Promise.all(animations.map((animation) => animation.finished.catch(() => {})));
     });
+    const longNameItem = dropdown.locator('wa-dropdown-item[value="member:profile-long-name"]');
+    const longIdItem = dropdown.locator(`wa-dropdown-item[value="member:${longMemberId}"]`);
+
+    await longIdItem.scrollIntoViewIfNeeded();
+    const selectedIndicator = longIdItem.locator('[slot="details"]');
+    await expectBrowser(selectedIndicator).toBeVisible();
+    const selectedIndicatorContained = await longIdItem.evaluate((item) => {
+      const indicator = item.querySelector<HTMLElement>('[slot="details"]');
+      const itemRect = item.getBoundingClientRect();
+      const indicatorRect = indicator?.getBoundingClientRect();
+      return Boolean(
+        indicatorRect &&
+        indicatorRect.left >= itemRect.left &&
+        indicatorRect.right <= itemRect.right,
+      );
+    });
+    expect(selectedIndicatorContained).toBe(true);
 
     const beforeScroll = await dropdown.evaluate((element) => {
       const menu = element.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
+      if (menu) {
+        menu.scrollTop = 0;
+      }
       const visibilityTitle = element.querySelector<HTMLElement>(
         ".chat-pane__sharing-visibility-title",
       );
@@ -537,6 +593,10 @@ suite.define(() => {
       ];
       const membersTitle = element.querySelector<HTMLElement>(".chat-pane__sharing-members-title");
       const firstMember = element.querySelector<HTMLElement>(".chat-pane__sharing-member");
+      const longLabels = [
+        ...element.querySelectorAll<HTMLElement>(".chat-pane__sharing-member-label"),
+      ].slice(0, 2);
+      const menuRect = menu?.getBoundingClientRect();
       const previousVisibilityRect = visibilityItems.at(-2)?.getBoundingClientRect();
       const lastVisibilityRect = visibilityItems.at(-1)?.getBoundingClientRect();
       const membersTitleRect = membersTitle?.getBoundingClientRect();
@@ -545,6 +605,13 @@ suite.define(() => {
         menuTop: menu?.getBoundingClientRect().top ?? 0,
         scrollHeight: menu?.scrollHeight ?? 0,
         clientHeight: menu?.clientHeight ?? 0,
+        scrollWidth: menu?.scrollWidth ?? 0,
+        clientWidth: menu?.clientWidth ?? 0,
+        longLabelsContained: longLabels.every((label) => {
+          const rect = label.getBoundingClientRect();
+          return menuRect ? rect.left >= menuRect.left && rect.right <= menuRect.right : false;
+        }),
+        longLabelsOverflow: longLabels.every((label) => label.scrollWidth > label.clientWidth),
         firstMemberTop: firstMember?.getBoundingClientRect().top ?? 0,
         groupGap:
           membersTitleRect && lastVisibilityRect
@@ -594,6 +661,9 @@ suite.define(() => {
 
     expect(beforeScroll.menuHeight).toBeLessThanOrEqual(421);
     expect(beforeScroll.scrollHeight).toBeGreaterThan(beforeScroll.clientHeight);
+    expect(beforeScroll.scrollWidth).toBe(beforeScroll.clientWidth);
+    expect(beforeScroll.longLabelsContained).toBe(true);
+    expect(beforeScroll.longLabelsOverflow).toBe(true);
     expect(beforeScroll.membersTitleInset).toBe(beforeScroll.firstMemberInset);
     expect(beforeScroll.groupGap).toBeGreaterThanOrEqual(8);
     expect(beforeScroll.groupGap).toBeGreaterThan(beforeScroll.rowGap + 6);
@@ -608,6 +678,14 @@ suite.define(() => {
       dropdown.locator(".chat-pane__sharing-member openclaw-session-owner-chip"),
     ).toHaveCount(30);
     await expectBrowser(dropdown.locator(".chat-pane__sharing-channel-icon")).toHaveCount(2);
+    expect(
+      await longNameItem.locator(".chat-pane__sharing-member-label").getAttribute("title"),
+    ).toBe(longMemberLabel);
+    expect(await longIdItem.locator(".chat-pane__sharing-member-label").getAttribute("title")).toBe(
+      longMemberId,
+    );
+    await expectBrowser(selectedIndicator).toHaveCount(1);
+    expect(await selectedIndicator.getAttribute("aria-label")).not.toBeNull();
   });
 
   it("clears a selected draft mode when sharing policy becomes unavailable", async () => {

--- a/ui/src/pages/chat/components/chat-session-sharing.test.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.test.ts
@@ -191,8 +191,16 @@ describe("chat session sharing menu", () => {
             sessionKey: "agent:main:main",
             members: [{ identityId: "alice", addedBy: "owner", addedAt: 1 }],
             identities: [
-              { type: "human", id: "alice", label: "Alice" },
-              { type: "human", id: "bob", label: "Bob" },
+              {
+                type: "human",
+                id: "alice",
+                label: "Alice with a very long selected member display name",
+              },
+              {
+                type: "human",
+                id: "bob",
+                label: "Bob with a very long available member display name",
+              },
             ],
             role: "owner",
             allowedVisibilities: ["shared", "read-only"],
@@ -217,6 +225,15 @@ describe("chat session sharing menu", () => {
     expect(
       root.querySelector('wa-dropdown-item[value="member:bob"]')?.hasAttribute("disabled"),
     ).toBe(true);
+    for (const identityId of ["alice", "bob"]) {
+      const item = root.querySelector<HTMLElement>(
+        `wa-dropdown-item[value="member:${identityId}"]`,
+      );
+      expect(item?.title).toBe("Requires write");
+      expect(item?.querySelector(".chat-pane__sharing-member-label")?.hasAttribute("title")).toBe(
+        false,
+      );
+    }
 
     dropdown?.dispatchEvent(new CustomEvent("wa-show"));
     dropdown?.dispatchEvent(

--- a/ui/src/pages/chat/components/chat-session-sharing.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.ts
@@ -183,12 +183,15 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps) {
                               ? renderSessionOwnerChip(identity, "header")
                               : icons.bot}
                         </span>
-                        <span class="chat-pane__sharing-member-label"
+                        <span
+                          class="chat-pane__sharing-member-label"
+                          title=${disabledReason ? nothing : (identity.label ?? identity.id)}
                           >${identity.label ?? identity.id}</span
                         >
                         ${members.has(identity.id)
                           ? html`<span
                               slot="details"
+                              class="session-menu__check"
                               aria-label=${t("chat.sessionSharing.selected")}
                               >${icons.check}</span
                             >`

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -641,6 +641,7 @@ openclaw-chat-pane {
 }
 
 .chat-pane__sharing-member-label {
+  display: block;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
Closes #122980

## Problem

The fixed-width session sharing menu could still acquire horizontal overflow when a member had a very long display name or no display name and therefore rendered a long identity ID. On current `main`, the focused browser regression measured a 258px client width and a 1106px scroll width.

The label span had `overflow: hidden` and `text-overflow: ellipsis`, but it remained inline inside Web Awesome's shrinkable label slot. It therefore did not establish the overflow box needed for ellipsis.

## Proposed fix

In this PR, the member label becomes a block overflow box within the existing dropdown-item label slot. The row keeps its fixed menu width, avatar or channel icon, vertical scrolling, and selection rail. The full display name or identity ID remains available through the label's native title.

The selected-member check now uses the existing session-menu check styling so it retains a visible, fixed-size details box when the adjacent label truncates.

## Evidence

Focused browser regression:

- Before: 1 failed, 10 passed; `scrollWidth=1106`, `clientWidth=258`.
- In this PR: 11 passed; horizontal width is contained, both long labels have real text overflow, the menu still scrolls vertically, the selected check is visible and contained, and enabled labels retain their full values in `title`.
- Changed-file validation: format, typechecks, lint, i18n, dead-code, dependency guards, and focused UI tests passed.
- Disabled guidance regression: the pre-fix focused component test failed because long add/remove labels retained their own title; the corrected head passed 9/9 and keeps each disabled reason on the row for both actions.

### Full context

| Theme | Before | In this PR |
| --- | --- | --- |
| Light | <img width="640" alt="Light theme before: realistic shared chat with the long member name and identity ID extending beyond the 260px sharing menu" src="https://github.com/user-attachments/assets/5f2f4aa1-78b2-496f-b995-7f4687a03ba7" /> | <img width="640" alt="Light theme in this PR: realistic shared chat with both long member rows truncated inside the sharing menu and the selected-member check visible" src="https://github.com/user-attachments/assets/51bbd5c3-4742-470c-b462-83a6f9c10f50" /> |
| Dark | <img width="640" alt="Dark theme before: realistic shared chat with the long member name and identity ID extending beyond the 260px sharing menu" src="https://github.com/user-attachments/assets/00261075-ac40-4209-a3f5-5e624aba0007" /> | <img width="640" alt="Dark theme in this PR: realistic shared chat with both long member rows truncated inside the sharing menu and the selected-member check visible" src="https://github.com/user-attachments/assets/35f65e4c-1de8-498a-aa2f-c34fd8a16aaa" /> |

### State matrix

| State | Light before | Light in this PR | Dark before | Dark in this PR |
| --- | --- | --- | --- | --- |
| Default | <img width="260" alt="Light default member row before" src="https://github.com/user-attachments/assets/0ec81022-c277-4c2d-9549-9815c7ab227c" /> | <img width="260" alt="Light default member row in this PR" src="https://github.com/user-attachments/assets/9c32bd00-4840-469a-b7ec-87b9dcad4d7b" /> | <img width="260" alt="Dark default member row before" src="https://github.com/user-attachments/assets/cf25f286-bb2d-45ce-86e9-3e30ce76fa13" /> | <img width="260" alt="Dark default member row in this PR" src="https://github.com/user-attachments/assets/9e3ba328-3f93-426f-afa1-86bb41e07c37" /> |
| Hover | <img width="260" alt="Light long-name hover row before, overflowing the crop" src="https://github.com/user-attachments/assets/b211d373-3b92-40cc-91a1-47c39a5ef949" /> | <img width="260" alt="Light long-name hover row in this PR, truncated with ellipsis" src="https://github.com/user-attachments/assets/dede366b-f839-4f01-beb9-8db61e4460f6" /> | <img width="260" alt="Dark long-name hover row before, overflowing the crop" src="https://github.com/user-attachments/assets/d278472a-373a-4e7f-bf48-0f930ba7d8e8" /> | <img width="260" alt="Dark long-name hover row in this PR, truncated with ellipsis" src="https://github.com/user-attachments/assets/4a0f1d97-b2a0-40fe-b361-d29e1364757a" /> |
| Focus | <img width="260" alt="Light long-name focus row before, overflowing the crop" src="https://github.com/user-attachments/assets/0c640128-6e90-4295-a407-fe1710001375" /> | <img width="260" alt="Light long-name focus row in this PR, truncated with ellipsis and focus ring retained" src="https://github.com/user-attachments/assets/ac78b0ba-fcd1-4eb0-ae61-83bb40c5aec1" /> | <img width="260" alt="Dark long-name focus row before, overflowing the crop" src="https://github.com/user-attachments/assets/2aa6dc7f-1685-459b-9f28-1b3e5ebdaec5" /> | <img width="260" alt="Dark long-name focus row in this PR, truncated with ellipsis and focus ring retained" src="https://github.com/user-attachments/assets/5199e19a-17b3-46d3-b669-376729372965" /> |
| Selected long ID | <img width="260" alt="Light selected long-ID row before, overflowing the crop and obscuring the trailing selection rail" src="https://github.com/user-attachments/assets/f0f9f892-3e4f-43bc-ab6e-dcf6853a60d3" /> | <img width="260" alt="Light selected long-ID row in this PR, truncated with the trailing check visible" src="https://github.com/user-attachments/assets/0e358aab-26f5-4add-ad12-ddfa0ba0b05a" /> | <img width="260" alt="Dark selected long-ID row before, overflowing the crop and obscuring the trailing selection rail" src="https://github.com/user-attachments/assets/d9548306-dbcd-42bf-aa75-454e3633c65e" /> | <img width="260" alt="Dark selected long-ID row in this PR, truncated with the trailing check visible" src="https://github.com/user-attachments/assets/17af9e12-1690-4455-aa37-13bfd655142e" /> |
| Overflow / long name | <img width="260" alt="Light long member name before, extending past the row" src="https://github.com/user-attachments/assets/c6b92b4d-2b93-4f83-a88c-0366c7118edd" /> | <img width="260" alt="Light long member name in this PR, ending in an ellipsis inside the row" src="https://github.com/user-attachments/assets/26cfa929-90be-4332-b80b-09701ed34058" /> | <img width="260" alt="Dark long member name before, extending past the row" src="https://github.com/user-attachments/assets/03171781-6460-47f9-9cdb-e61592e3fb96" /> | <img width="260" alt="Dark long member name in this PR, ending in an ellipsis inside the row" src="https://github.com/user-attachments/assets/9627dd4f-f900-45f3-b06a-6d64c0131e8a" /> |

## Scope

- Architectural owner: the session-sharing member row and its label/details layout.
- Production delta: +5 / -1 lines (net +4). The additions establish the overflow box, expose the full value, and preserve the selected-state rail.
- Test delta: +104 / -9 lines. The high-volume browser scenario covers long display names, long fallback IDs, horizontal containment, real ellipsis, full-value access, selection, and vertical scrolling; the component scenario covers disabled add/remove title precedence.
- No config, protocol, storage, dependency, or public API changes.
