### PR TITLE
test(extensions): scope remaining multi-agent fixtures to explicit owners

### DIFF
--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -2259,7 +2259,7 @@ describe("createTelegramBot", () => {
         defaults: {
           model: "openai/gpt-4.1",
         },
-        list: [{ id: "agent-a" }, { id: "agent-b" }],
+        list: [{ id: "agent-a", default: true }, { id: "agent-b" }],
       },
       channels: {
         telegram: { dmPolicy: "open", allowFrom: ["*"] },
@@ -3689,7 +3689,7 @@ describe("createTelegramBot", () => {
         },
       },
       agents: {
-        list: [{ id: "agent-a" }, { id: "agent-b" }],
+        list: [{ id: "agent-a", default: true }, { id: "agent-b" }],
       },
       bindings: [
         {
@@ -3763,8 +3763,9 @@ describe("createTelegramBot", () => {
         },
       },
       agents: {
-        list: [{ id: "topic-a" }, { id: "topic-b" }],
+        list: [{ id: "topic-a", default: true }, { id: "topic-b" }],
       },
+      bindings: [{ agentId: "topic-a", match: { channel: "telegram", accountId: "default" } }],
     });
     loadConfig.mockImplementation(configForTopicAgent);
 
@@ -5052,7 +5053,7 @@ describe("createTelegramBot", () => {
         },
       },
       agents: {
-        list: [{ id: "agent-a" }, { id: "agent-b" }],
+        list: [{ id: "agent-a", default: true }, { id: "agent-b" }],
       },
       bindings: [
         {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where unrelated SDK-surface pull requests could fail the full extension configuration because four Telegram reload fixtures still constructed ambiguous multi-agent startup state after #114388. The failures were observed in Actions run 31666366638 after the earlier partial sweeps in #122883 and #122978.

## Why This Change Was Made

The fixtures now declare the startup owner required by the Telegram message-context cache. The existing mutable account bindings remain intact, and the topic case adds a stable default Telegram binding, so the assertions still prove that per-target routing changes are reloaded without recreating the bot.

## User Impact

No production behavior changes. Extension CI no longer trips over these stale multi-agent Telegram fixtures when validating unrelated changes.

## Evidence

- Before: `extensions/telegram/src/bot.create-telegram-bot.test.ts` reproduced four `AgentSelectionRequiredError` failures (140 passed, 4 failed).
- After: the same file passes 144/144 tests.
- Full prescribed extension config: 393 files passed, 1 skipped; 5,117 tests passed, 57 skipped; zero `AgentSelectionRequiredError` failures and no other failing classes.
- `node scripts/check-changed.mjs -- extensions/telegram/src/bot.create-telegram-bot.test.ts` passed on [Actions run 31670562016](https://github.com/openclaw/openclaw/actions/runs/31670562016), including extension test typecheck and lint.
- `git diff --check` is clean.
- Structured autoreview reported no accepted or actionable findings.

Original failing evidence: [Actions run 31666366638](https://github.com/openclaw/openclaw/actions/runs/31666366638).
