### PR TITLE
fix(sqlite): preserve Windows private-directory diagnostics

### DIFF
--- a/src/infra/sqlite-private-directory.test.ts
+++ b/src/infra/sqlite-private-directory.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const childProcess = vi.hoisted(() => ({
+  execFile: vi.fn(),
+  execFileSync: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => childProcess);
+vi.mock("./resolve-system-bin.js", () => ({
+  resolveSystemBin: () => "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+}));
+vi.mock("./windows-encoding.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./windows-encoding.js")>();
+  return {
+    ...actual,
+    decodeWindowsOutputBuffer: (params: { buffer: Buffer }) =>
+      actual.decodeWindowsOutputBuffer({ ...params, platform: "win32", windowsEncoding: "gbk" }),
+  };
+});
+
+import {
+  createPrivateSqliteDirectory,
+  createPrivateSqliteTempDirectorySync,
+} from "./sqlite-private-directory.js";
+
+function errorCause(error: unknown): Error {
+  expect(error).toBeInstanceOf(Error);
+  const cause = (error as Error & { cause?: unknown }).cause;
+  expect(cause).toBeInstanceOf(Error);
+  return cause as Error;
+}
+
+describe("private Windows SQLite directory diagnostics", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    childProcess.execFile.mockReset();
+    childProcess.execFileSync.mockReset();
+  });
+
+  it("reports bounded async stderr without retaining the child-process error", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const original = Object.assign(
+      new Error("Command failed: powershell -EncodedCommand secret-payload"),
+      {
+        cmd: "powershell -EncodedCommand secret-payload",
+        code: 7,
+        killed: true,
+        signal: "SIGTERM",
+      },
+    );
+    childProcess.execFile.mockImplementation((_file, _args, _options, callback) => {
+      callback(
+        original,
+        Buffer.from("stdout fallback"),
+        Buffer.concat([
+          Buffer.from([0xb2, 0xe2, 0xca, 0xd4]),
+          Buffer.from(
+            ` useful stderr\n-EncodedCommand secret\nbenign after redaction ${"tail ".repeat(250)}`,
+          ),
+        ]),
+      );
+    });
+
+    const error = await createPrivateSqliteDirectory("C:\\private").catch(
+      (cause: unknown) => cause,
+    );
+    const cause = errorCause(error);
+    expect(cause.message).toContain("exit=7, killed=true, signal=SIGTERM");
+    expect(cause.message).toContain("测试");
+    expect(cause.message).toContain("stderr: 测试 useful stderr");
+    expect(cause.message).toContain("benign after redaction");
+    expect(cause.message).not.toContain("stdout fallback");
+    expect(cause.message).not.toContain("EncodedCommand");
+    expect(cause.message.length).toBeLessThanOrEqual(1100);
+    expect(cause).not.toBe(original);
+    expect((cause as Error & { cause?: unknown; cmd?: unknown }).cause).toBeUndefined();
+    expect((cause as Error & { cmd?: unknown }).cmd).toBeUndefined();
+  });
+
+  it("reports sync status and string codes from sanitized stderr", () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    childProcess.execFileSync.mockImplementation(() => {
+      throw Object.assign(new Error("powershell -EncodedCommand secret"), {
+        code: "ETIMEDOUT",
+        status: 1,
+        stderr: Buffer.from("native directory creation failed"),
+        stdout: Buffer.from("stdout fallback"),
+      });
+    });
+
+    let error: unknown;
+    try {
+      createPrivateSqliteTempDirectorySync("C:\\root", "stage-");
+    } catch (cause) {
+      error = cause;
+    }
+    expect(errorCause(error).message).toBe(
+      "PowerShell failed (status=1, code=ETIMEDOUT); stderr: native directory creation failed",
+    );
+  });
+
+  it("preserves the EEXIST contract from child output", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    childProcess.execFile.mockImplementation((_file, _args, _options, callback) => {
+      callback(new Error("failed"), "", "OPENCLAW_SQLITE_DIRECTORY_EXISTS");
+    });
+
+    const error = await createPrivateSqliteDirectory("C:\\existing").catch(
+      (cause: unknown) => cause,
+    );
+    expect(error).toMatchObject({
+      code: "EEXIST",
+      message: "Private SQLite directory already exists: C:\\existing",
+    });
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+  });
+});

--- a/src/infra/sqlite-private-directory.ts
+++ b/src/infra/sqlite-private-directory.ts
@@ -4,7 +4,9 @@ import { randomUUID } from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveSystemBin } from "./resolve-system-bin.js";
+import { decodeWindowsOutputBuffer } from "./windows-encoding.js";
 
 const SQLITE_DIRECTORY_MODE = 0o700;
 const WINDOWS_DIRECTORY_EXISTS_MARKER = "OPENCLAW_SQLITE_DIRECTORY_EXISTS";
@@ -71,19 +73,77 @@ public static class OpenClawPrivateDirectory
 }
 `;
 
-function runPrivateDirectoryPowerShell(powershell: string, encodedCommand: string): Promise<void> {
+function failureText(value: unknown): string {
+  const text = Buffer.isBuffer(value)
+    ? decodeWindowsOutputBuffer({ buffer: value })
+    : typeof value === "string"
+      ? value
+      : "";
+  return truncateUtf16Safe(
+    text
+      .split(/\r?\n/u)
+      .filter((line) => !line.toLowerCase().includes("encodedcommand"))
+      .join("\n")
+      .trim(),
+    1000,
+  );
+}
+
+function privateDirectoryError(
+  directoryPath: string,
+  error: unknown,
+  stdout?: unknown,
+  stderr?: unknown,
+): Error {
+  const failure = error && typeof error === "object" ? (error as Record<string, unknown>) : {};
+  if (
+    [error, stderr, stdout, failure.stderr, failure.stdout].some((value) =>
+      String(value).includes(WINDOWS_DIRECTORY_EXISTS_MARKER),
+    )
+  ) {
+    const existsError = new Error(`Private SQLite directory already exists: ${directoryPath}`);
+    (existsError as NodeJS.ErrnoException).code = "EEXIST";
+    return existsError;
+  }
+  const status = [
+    typeof failure.status === "number" ? `status=${failure.status}` : "",
+    typeof failure.code === "number"
+      ? `exit=${failure.code}`
+      : typeof failure.code === "string"
+        ? `code=${failure.code}`
+        : "",
+    typeof failure.killed === "boolean" ? `killed=${failure.killed}` : "",
+    typeof failure.signal === "string" ? `signal=${failure.signal}` : "",
+  ].filter(Boolean);
+  const stderrText = failureText(stderr) || failureText(failure.stderr);
+  const stdoutText = failureText(stdout) || failureText(failure.stdout);
+  const detail = stderrText ? `stderr: ${stderrText}` : stdoutText ? `stdout: ${stdoutText}` : "";
+  const cause = new Error(
+    `PowerShell failed${status.length ? ` (${status.join(", ")})` : ""}${detail ? `; ${detail}` : ""}`,
+  );
+  return new Error(`Unable to create private Windows SQLite directory: ${directoryPath}`, {
+    cause,
+  });
+}
+
+function runPrivateDirectoryPowerShell(
+  directoryPath: string,
+  powershell: string,
+  encodedCommand: string,
+): Promise<void> {
   return new Promise((resolve, reject) => {
     execFile(
       powershell,
       ["-NoLogo", "-NoProfile", "-NonInteractive", "-EncodedCommand", encodedCommand],
       {
+        encoding: "buffer",
         maxBuffer: 64 * 1024,
         timeout: 10_000,
         windowsHide: true,
       },
-      (error) => {
+      (error, stdout, stderr) => {
         if (error) {
-          reject(new Error(error.message, { cause: error }));
+          reject(privateDirectoryError(directoryPath, error, stdout, stderr));
           return;
         }
         resolve();
@@ -129,17 +189,6 @@ function resolvePrivateDirectoryPowerShell(directoryPath: string): {
   };
 }
 
-function privateDirectoryError(directoryPath: string, error: unknown): Error {
-  if (String(error).includes(WINDOWS_DIRECTORY_EXISTS_MARKER)) {
-    const existsError = new Error(`Private SQLite directory already exists: ${directoryPath}`);
-    (existsError as NodeJS.ErrnoException).code = "EEXIST";
-    return existsError;
-  }
-  return new Error(`Unable to create private Windows SQLite directory: ${directoryPath}`, {
-    cause: error,
-  });
-}
-
 export async function createPrivateSqliteDirectory(directoryPath: string): Promise<void> {
   if (process.platform !== "win32") {
     await fs.mkdir(directoryPath, { mode: SQLITE_DIRECTORY_MODE });
@@ -147,11 +196,7 @@ export async function createPrivateSqliteDirectory(directoryPath: string): Promi
   }
   // This raw Win32 call bypasses Node's automatic long-path normalization.
   const { encodedCommand, powershell } = resolvePrivateDirectoryPowerShell(directoryPath);
-  try {
-    await runPrivateDirectoryPowerShell(powershell, encodedCommand);
-  } catch (error) {
-    throw privateDirectoryError(directoryPath, error);
-  }
+  await runPrivateDirectoryPowerShell(directoryPath, powershell, encodedCommand);
 }
 
 function createPrivateSqliteDirectorySync(directoryPath: string): void {

--- a/src/infra/sqlite-private-directory.windows.test.ts
+++ b/src/infra/sqlite-private-directory.windows.test.ts
@@ -1,0 +1,28 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { createPrivateSqliteDirectory } from "./sqlite-private-directory.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("private SQLite directory creation on Windows", () => {
+  it.runIf(process.platform === "win32")(
+    "surfaces native stderr without exposing the encoded command",
+    async () => {
+      const root = tempDirs.make("openclaw-sqlite-private-directory-");
+      const regularFile = path.join(root, "parent-file");
+      await fs.writeFile(regularFile, "not a directory");
+
+      const error = await createPrivateSqliteDirectory(path.join(regularFile, "child")).catch(
+        (cause: unknown) => cause,
+      );
+      expect(error).toBeInstanceOf(Error);
+      const child = (error as Error & { cause?: unknown }).cause;
+      expect(child).toBeInstanceOf(Error);
+      expect((child as Error).message).toMatch(/\bexit=1\b/u);
+      expect((child as Error).message).toContain("stderr:");
+      expect((child as Error).message).not.toContain("EncodedCommand");
+    },
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Windows packaged-fresh startup failures during private SQLite staging-directory creation exposed the full PowerShell invocation and encoded command while hiding the bounded native error detail needed to diagnose the failure.

## Why This Change Was Made

Replace the raw child-process error cause with a bounded diagnostic receipt containing decoded and sanitized stderr (or stdout fallback) plus exit/status, string error code, killed, and signal metadata. Existing ACL creation, PowerShell command, 10-second timeout, 64 KiB buffer cap, EEXIST mapping, long-path handling, and sync/async behavior remain unchanged.

The async path captures buffers and uses the canonical Windows output decoder before UTF-16-safe truncation, so localized diagnostics remain readable without leaking the encoded command or original child-process error graph.

No existing bounded child-process receipt abstraction fits this owner boundary. The shared process runner exposes a broader execution contract and would add coupling for one private PowerShell operation, while downstream snapshot callers do not own the raw stderr/stdout or process metadata needed to sanitize it correctly. Keeping the receipt beside this invocation is the narrow producer-side fix and shares one formatter across its sync and async paths.

## User Impact

Windows operators now receive actionable private-directory creation failures without encoded command payloads appearing anywhere in the returned error graph.

## Evidence

- Exact head: `89eebd8d0d101e9ee12174a2ab3c5325a8572a9e`.
- Focused local proof: `node scripts/run-vitest.mjs src/infra/sqlite-private-directory.test.ts src/infra/sqlite-private-directory.windows.test.ts src/snapshot/local-repository.windows.test.ts` passed (3 passed; native Windows and long-path tests platform-gated locally).
- Exact-head changed gate: local fallback passed after two Blacksmith Testbox leases stopped during warmup before executing the command (`tbx_01kzwtyj1013pyhkds43ptq65y`, `tbx_01kzwv0jpjjxkg7t3rcgtv705v`).
- Prior-head changed-surface Testbox: `tbx_01kzwsvz2tyxzr4aqgcgc46jas`, GitHub Actions run `31670821912`, passed.
- Full Release Validation run `31671256815` failed before creating its selected child: GitHub returned HTTP 500 for the workflow dispatch, and no Windows suite ran.
- The first classified infrastructure retry ran the selected `cross-os` child at the prior code-equivalent head after the parent dispatch HTTP 500: run `31672489326`.
- Prior-head Windows packaged-fresh proof uses `mode=fresh`, `cross_os_suite_filter=windows/packaged-fresh`, and `fail_fast=false`: run `31673500358`.
- `git diff --check` passed.
- Production LOC: `+64/-19` (net `+45`). Tests: `+145/-0`.

## Scope

- Three `src/infra` files only: production owner, async/sync mocked tests, and native Windows regression.
- No changelog, package scripts, timeout, ACL, retry, fallback, or PowerShell command changes.
