### PR TITLE
chore(config): speed up IO compatibility tests

### DIFF
--- a/src/config/io.compat.test.ts
+++ b/src/config/io.compat.test.ts
@@ -2,10 +2,45 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { withTempDir } from "../test-utils/temp-dir.js";
 import { VERSION } from "../version.js";
-import { createConfigIO } from "./io.js";
+import { createConfigIO } from "./io.factory.js";
 import { normalizeExecSafeBinProfilesInConfig } from "./normalize-exec-safe-bin.js";
-import { withTempHome } from "./test-helpers.js";
+
+vi.mock("../commands/doctor/shared/legacy-config-compat.js", () => ({
+  applyLegacyDoctorMigrations: () => {
+    throw new Error("config IO compatibility tests must not enter recovery migration");
+  },
+}));
+
+vi.mock("../plugins/gateway-startup-plugin-ids.js", () => ({
+  createConfigValidationMetadataPluginIdScope: (params: {
+    config: { plugins?: { entries?: Record<string, unknown> } };
+  }) => {
+    const configuredPluginIds = Object.keys(params.config.plugins?.entries ?? {}).toSorted();
+    const removedPluginIds = new Set(["google-antigravity-auth", "google-gemini-cli-auth"]);
+    if (configuredPluginIds.some((pluginId) => !removedPluginIds.has(pluginId))) {
+      throw new Error("config IO compatibility tests require real metadata for active plugins");
+    }
+    return {
+      key: `io-compat:${configuredPluginIds.join(",")}`,
+      resolve: () => [],
+    };
+  },
+}));
+
+vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
+  rebasePluginMetadataSnapshotManifestRegistry: () => {
+    throw new Error("config IO compatibility tests must not materialize metadata snapshots");
+  },
+  resolvePluginMetadataSnapshot: () => ({
+    manifestRegistry: { plugins: [], diagnostics: [] },
+  }),
+}));
+
+function withTempHome<T>(run: (home: string) => Promise<T>): Promise<T> {
+  return withTempDir("openclaw-config-compat-", run);
+}
 
 async function writeConfig(
   home: string,
@@ -61,71 +96,27 @@ describe("config io paths", () => {
     });
   });
 
-  it.each(["lan", "loopback", "tailnet", "auto", "custom", undefined] as const)(
-    "keeps canonical gateway bind %s byte-identical during load",
-    async (bind) => {
-      await withTempHome(async (home) => {
-        const configPath = path.join(home, ".openclaw", "openclaw.json");
-        await fs.mkdir(path.dirname(configPath), { recursive: true });
-        const gateway = {
-          mode: "local" as const,
-          ...(bind ? { bind } : {}),
-          ...(bind === "custom" ? { customBindHost: "127.0.0.1" } : {}),
-        };
-        const raw = `${JSON.stringify({ gateway }, null, 2)}\n`;
-        await fs.writeFile(configPath, raw, "utf-8");
-        const io = createConfigIO({
-          configPath,
-          env: { HOME: home } as NodeJS.ProcessEnv,
-          homedir: () => home,
-        });
-
-        const config = io.loadConfig();
-
-        expect(config.gateway?.bind).toBe(bind);
-        await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(raw);
-      });
-    },
-  );
-
-  it("logs validation warnings with real line breaks", async () => {
+  it("keeps canonical custom gateway bind byte-identical during load", async () => {
     await withTempHome(async (home) => {
       const configPath = path.join(home, ".openclaw", "openclaw.json");
       await fs.mkdir(path.dirname(configPath), { recursive: true });
-      await fs.writeFile(
-        configPath,
-        JSON.stringify(
-          {
-            plugins: {
-              entries: {
-                "google-antigravity-auth": {
-                  enabled: false,
-                  config: { stale: true },
-                },
-              },
-            },
-          },
-          null,
-          2,
-        ),
-      );
-      const logger = {
-        error: vi.fn(),
-        warn: vi.fn(),
+      const gateway = {
+        mode: "local" as const,
+        bind: "custom" as const,
+        customBindHost: "127.0.0.1",
       };
-
+      const raw = `${JSON.stringify({ gateway }, null, 2)}\n`;
+      await fs.writeFile(configPath, raw, "utf-8");
       const io = createConfigIO({
         configPath,
         env: { HOME: home } as NodeJS.ProcessEnv,
         homedir: () => home,
-        logger,
       });
-      io.loadConfig();
 
-      expect(logger.warn).toHaveBeenCalledWith(
-        "Config warnings:\n- plugins.entries.google-antigravity-auth: plugin removed: google-antigravity-auth (stale config entry ignored; remove it from plugins config)",
-      );
-      expect(logger.warn).not.toHaveBeenCalledWith("Config warnings:\\n");
+      const config = io.loadConfig();
+
+      expect(config.gateway).toMatchObject({ bind: "custom", customBindHost: "127.0.0.1" });
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(raw);
     });
   });
 
@@ -155,6 +146,9 @@ describe("config io paths", () => {
       load();
       load();
       expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenCalledWith(
+        "Config warnings:\n- plugins.entries.google-antigravity-auth: plugin removed: google-antigravity-auth (stale config entry ignored; remove it from plugins config)",
+      );
 
       createConfigIO({
         configPath,


### PR DESCRIPTION
## What Problem This Solves

The focused config IO compatibility suite pays for unrelated global test-home cleanup, Doctor recovery migrations, public config facade exports, and plugin metadata discovery. Its six-row canonical bind process table also duplicates stronger Gateway startup coverage, making focused config feedback unnecessarily slow.

## Why This Change Was Made

Use the prepared `createConfigIO` factory directly, replace unrelated import graphs with narrow fail-fast test fakes, and use the lightweight temp-directory owner because every filesystem case injects `env` and `homedir`. Keep the discriminating `custom` bind load probe, while the Gateway E2E owner retains the exact six-row `lan`/`loopback`/`tailnet`/`auto`/`custom`/default persistence matrix. Fold the exact newline-format assertion into the warning fingerprint lifecycle test instead of launching a duplicate load case.

The metadata fakes export every runtime binding loaded by this path. Active plugin entries fail fast rather than silently using an empty registry, snapshot materialization fails fast, and recovery migration fails fast. Real plugin metadata snapshot/rebase, validation scope selection, removed-plugin diagnostics, and Doctor migration behavior remain in their owner suites.

## User Impact

No runtime or user-visible behavior changes. Developers get faster focused feedback from `src/config/io.compat.test.ts` without adding workers or changing CI topology.

## Evidence

Identical fresh-cache, one-worker command on Node 24.15.0:

```bash
rm -rf <fresh-cache>
/usr/bin/time -v env \
  OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=<fresh-cache> \
  OPENCLAW_VITEST_IMPORT_DURATIONS=1 \
  OPENCLAW_VITEST_PRINT_IMPORT_BREAKDOWN=1 \
  node scripts/run-vitest.mjs src/config/io.compat.test.ts \
  --maxWorkers=1 --reporter=verbose
```

- Wall: 20.43s → 13.37s (−7.06s, **34.6%**)
- Vitest: 13.85s → 6.83s (−7.02s, **50.7%**)
- Import: 9.95s → 5.72s (−4.23s, **42.5%**)
- Test execution: 3.49s → 0.718s (−2.772s, **79.4%**)
- Peak RSS: 432,924 KiB → 376,464 KiB (−56,460 KiB / 55.1 MiB, **13.0%**)
- Changed suite: **9/9 passed**
- Focused changed + owner proof: **139/139 passed** across config IO compatibility, config IO plugin-metadata composition, plugin validation, plugin metadata snapshot, and Doctor session migration suites
- `oxfmt --check src/config/io.compat.test.ts`: passed
- focused Oxlint: 0 warnings / 0 errors
- `git diff --check`: passed
- test temp-directory migration report: no new warnings

Production: +0/−0 | Tooling/workflows: +0/−0 | Tests: +51/−57 (net −6)