### PR TITLE
fix(ci): restore Discord lint after thread coverage

### DIFF
--- a/extensions/discord/src/send.creates-thread.test.ts
+++ b/extensions/discord/src/send.creates-thread.test.ts
@@ -1,11 +1,18 @@
 import { ChannelType, MessageFlags, Routes } from "discord-api-types/v10";
 // Discord tests cover send.creates thread plugin behavior.
-import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { loadWebMediaRaw } from "openclaw/plugin-sdk/web-media";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { RateLimitError } from "./internal/discord.js";
-import { hasDiscordMessageCreateAmbiguity } from "./retry.js";
-import { makeDiscordRest } from "./send.test-harness.js";
+import {
+  discordClientOpts,
+  DISCORD_TEST_CFG,
+  makeDiscordRest,
+  type MockCallSource,
+  requireRecord,
+  requestBody,
+  requestPath,
+  timerDelayAt,
+} from "./send.test-harness.js";
 
 vi.mock("openclaw/plugin-sdk/web-media", async () => {
   const { discordWebMediaMockFactory } = await import("./send.test-harness.js");
@@ -27,55 +34,6 @@ let sendStickerDiscord: typeof import("./send.js").sendStickerDiscord;
 let timeoutMemberDiscord: typeof import("./send.js").timeoutMemberDiscord;
 let uploadEmojiDiscord: typeof import("./send.js").uploadEmojiDiscord;
 let uploadStickerDiscord: typeof import("./send.js").uploadStickerDiscord;
-
-const DISCORD_TEST_CFG = {
-  channels: {
-    discord: {
-      accounts: {
-        default: {},
-      },
-    },
-  },
-};
-
-function discordClientOpts(rest: ReturnType<typeof makeDiscordRest>["rest"]) {
-  return { cfg: DISCORD_TEST_CFG, rest, token: "t" };
-}
-
-type MockCallSource = {
-  mock: {
-    calls: ArrayLike<ReadonlyArray<unknown>>;
-  };
-};
-
-const requireRecord = createRequireRecord("object", "expected-label");
-
-function mockArg(source: MockCallSource, callIndex: number, argIndex: number, label: string) {
-  const call = source.mock.calls[callIndex];
-  if (!call) {
-    throw new Error(`expected mock call: ${label}`);
-  }
-  return call[argIndex];
-}
-
-function requestOptions(source: MockCallSource, callIndex = 0) {
-  return requireRecord(
-    mockArg(source, callIndex, 1, `request options ${callIndex}`),
-    "request options",
-  );
-}
-
-function requestPath(source: MockCallSource, callIndex = 0) {
-  return mockArg(source, callIndex, 0, `request path ${callIndex}`);
-}
-
-function requestBody(source: MockCallSource, callIndex = 0) {
-  return requireRecord(requestOptions(source, callIndex).body, `request body ${callIndex}`);
-}
-
-function timerDelayAt(source: MockCallSource, callIndex = 0) {
-  return mockArg(source, callIndex, 1, `timer delay ${callIndex}`);
-}
 
 function createDiscordForumPayloadHarness(parentType: ChannelType = ChannelType.GuildForum) {
   const parentId = "700";
@@ -303,110 +261,6 @@ describe("sendMessageDiscord", () => {
     });
   });
 
-  it("keeps forum starter messages within Discord's content limit", async () => {
-    const { rest, getMock, postMock } = makeDiscordRest();
-    getMock.mockResolvedValue({ type: ChannelType.GuildForum });
-    postMock.mockResolvedValue({ id: "t1" });
-    const content = "a".repeat(2001);
-
-    await createThreadDiscord("chan1", { name: "thread", content }, discordClientOpts(rest));
-
-    expect(postMock).toHaveBeenCalledTimes(2);
-    expect(requestBody(postMock as unknown as MockCallSource, 0)).toEqual({
-      name: "thread",
-      message: { content: "a".repeat(2000) },
-    });
-    expect(requestPath(postMock as unknown as MockCallSource, 1)).toBe(
-      Routes.channelMessages("t1"),
-    );
-    expect(requestBody(postMock as unknown as MockCallSource, 1)).toMatchObject({
-      content: "a",
-      enforce_nonce: true,
-    });
-  });
-
-  it("keeps sub-limit multi-line forum content in one starter message", async () => {
-    const { rest, getMock, postMock } = makeDiscordRest();
-    getMock.mockResolvedValue({ type: ChannelType.GuildForum });
-    postMock.mockResolvedValue({ id: "t1" });
-    const content = Array.from({ length: 18 }, (_, index) => `line ${index + 1}`).join("\n");
-
-    await createThreadDiscord("chan1", { name: "thread", content }, discordClientOpts(rest));
-
-    expect(postMock).toHaveBeenCalledTimes(1);
-    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({
-      name: "thread",
-      message: { content },
-    });
-  });
-
-  it("reports a delivered forum starter when a continuation chunk fails", async () => {
-    const { rest, getMock, postMock } = makeDiscordRest();
-    getMock.mockResolvedValue({ type: ChannelType.GuildForum });
-    postMock
-      .mockResolvedValueOnce({ id: "t1", message: { id: "starter1", channel_id: "t1" } })
-      .mockRejectedValueOnce(Object.assign(new Error("missing access"), { status: 403 }));
-
-    let thrown: unknown;
-    try {
-      await createThreadDiscord(
-        "chan1",
-        { name: "thread", content: "a".repeat(2001) },
-        discordClientOpts(rest),
-      );
-    } catch (error) {
-      thrown = error;
-    }
-
-    expect(thrown).toBeInstanceOf(DiscordThreadInitialMessageError);
-    expect(requireRecord(thrown, "thread initial message error").initialMessageDelivery).toEqual({
-      starterMessageDelivered: true,
-      deliveredChunkCount: 1,
-      deliveredMessageIds: ["starter1"],
-      failedChunkDelivery: "not_delivered",
-      failedChunkIndex: 1,
-      totalChunkCount: 2,
-    });
-  });
-
-  it("reports an exhausted ambiguous forum continuation as unknown delivery", async () => {
-    const { rest, getMock, postMock } = makeDiscordRest();
-    getMock.mockResolvedValue({ type: ChannelType.GuildForum });
-    const ambiguous = Object.assign(new Error("response lost"), { status: 502 });
-    postMock
-      .mockResolvedValueOnce({ id: "t1", message: { id: "starter1", channel_id: "t1" } })
-      .mockRejectedValue(ambiguous);
-
-    let thrown: unknown;
-    try {
-      await createThreadDiscord(
-        "chan1",
-        { name: "thread", content: "a".repeat(2001) },
-        {
-          ...discordClientOpts(rest),
-          retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
-        },
-      );
-    } catch (error) {
-      thrown = error;
-    }
-
-    expect(postMock).toHaveBeenCalledTimes(3);
-    expect(thrown).toBeInstanceOf(DiscordThreadInitialMessageError);
-    expect(hasDiscordMessageCreateAmbiguity(thrown)).toBe(true);
-    expect(requireRecord(thrown, "thread initial message error").message).toContain(
-      "delivery of the remaining initial content could not be confirmed",
-    );
-    expect(requireRecord(thrown, "thread initial message error").initialMessageDelivery).toEqual({
-      starterMessageDelivered: true,
-      deliveredChunkCount: 1,
-      deliveredMessageIds: ["starter1"],
-      failedChunkDelivery: "unknown",
-      failedChunkIndex: 1,
-      totalChunkCount: 2,
-    });
-  });
-
   it("inherits default_auto_archive_duration for forum threads", async () => {
     const { rest, getMock, postMock } = makeDiscordRest();
     getMock.mockResolvedValue({
@@ -566,140 +420,6 @@ describe("sendMessageDiscord", () => {
       content: "Hello thread!",
       enforce_nonce: true,
     });
-  });
-
-  it("chunks long initial messages for non-forum threads", async () => {
-    const { rest, getMock, postMock } = makeDiscordRest();
-    getMock.mockResolvedValue({ type: ChannelType.GuildText });
-    postMock.mockResolvedValue({ id: "t1" });
-    const content = "a".repeat(2001);
-
-    await createThreadDiscord("chan1", { name: "thread", content }, discordClientOpts(rest));
-
-    expect(postMock).toHaveBeenCalledTimes(3);
-    expect(requestPath(postMock as unknown as MockCallSource, 1)).toBe(
-      Routes.channelMessages("t1"),
-    );
-    expect(requestBody(postMock as unknown as MockCallSource, 1)).toMatchObject({
-      content: "a".repeat(2000),
-      enforce_nonce: true,
-    });
-    expect(requestPath(postMock as unknown as MockCallSource, 2)).toBe(
-      Routes.channelMessages("t1"),
-    );
-    expect(requestBody(postMock as unknown as MockCallSource, 2)).toMatchObject({
-      content: "a",
-      enforce_nonce: true,
-    });
-  });
-
-  it("keeps sub-limit multi-line non-forum content in one initial message", async () => {
-    const { rest, getMock, postMock } = makeDiscordRest();
-    getMock.mockResolvedValue({ type: ChannelType.GuildText });
-    postMock.mockResolvedValue({ id: "t1", channel_id: "t1" });
-    const content = Array.from({ length: 18 }, (_, index) => `line ${index + 1}`).join("\n");
-
-    await createThreadDiscord("chan1", { name: "thread", content }, discordClientOpts(rest));
-
-    expect(postMock).toHaveBeenCalledTimes(2);
-    expect(requestBody(postMock as unknown as MockCallSource, 1)).toMatchObject({ content });
-  });
-
-  it("reports delivered non-forum chunks when a later chunk fails", async () => {
-    const { rest, getMock, postMock } = makeDiscordRest();
-    getMock.mockResolvedValue({ type: ChannelType.GuildText });
-    postMock
-      .mockResolvedValueOnce({ id: "t1", name: "thread", type: ChannelType.PublicThread })
-      .mockResolvedValueOnce({ id: "msg1", channel_id: "t1" })
-      .mockRejectedValueOnce(Object.assign(new Error("missing access"), { status: 403 }));
-
-    let thrown: unknown;
-    try {
-      await createThreadDiscord(
-        "chan1",
-        { name: "thread", content: "a".repeat(4001) },
-        discordClientOpts(rest),
-      );
-    } catch (error) {
-      thrown = error;
-    }
-
-    expect(thrown).toBeInstanceOf(DiscordThreadInitialMessageError);
-    expect(requireRecord(thrown, "thread initial message error").initialMessageDelivery).toEqual({
-      starterMessageDelivered: false,
-      deliveredChunkCount: 1,
-      deliveredMessageIds: ["msg1"],
-      failedChunkDelivery: "not_delivered",
-      failedChunkIndex: 1,
-      totalChunkCount: 3,
-    });
-  });
-
-  it("reports an exhausted ambiguous non-forum chunk as unknown delivery", async () => {
-    const { rest, getMock, postMock } = makeDiscordRest();
-    getMock.mockResolvedValue({ type: ChannelType.GuildText });
-    const ambiguous = Object.assign(new Error("response lost"), { status: 502 });
-    postMock
-      .mockResolvedValueOnce({ id: "t1", name: "thread", type: ChannelType.PublicThread })
-      .mockResolvedValueOnce({ id: "msg1", channel_id: "t1" })
-      .mockRejectedValue(ambiguous);
-
-    let thrown: unknown;
-    try {
-      await createThreadDiscord(
-        "chan1",
-        { name: "thread", content: "a".repeat(4001) },
-        {
-          ...discordClientOpts(rest),
-          retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
-        },
-      );
-    } catch (error) {
-      thrown = error;
-    }
-
-    expect(postMock).toHaveBeenCalledTimes(4);
-    expect(thrown).toBeInstanceOf(DiscordThreadInitialMessageError);
-    expect(hasDiscordMessageCreateAmbiguity(thrown)).toBe(true);
-    expect(requireRecord(thrown, "thread initial message error").message).toContain(
-      "delivery of the remaining initial content could not be confirmed",
-    );
-    expect(requireRecord(thrown, "thread initial message error").initialMessageDelivery).toEqual({
-      starterMessageDelivered: false,
-      deliveredChunkCount: 1,
-      deliveredMessageIds: ["msg1"],
-      failedChunkDelivery: "unknown",
-      failedChunkIndex: 1,
-      totalChunkCount: 3,
-    });
-  });
-
-  it("retries continuation sends with a stable nonce per chunk", async () => {
-    const { rest, getMock, postMock } = makeDiscordRest();
-    getMock.mockResolvedValue({ type: ChannelType.GuildText });
-    postMock
-      .mockResolvedValueOnce({ id: "t1", name: "thread", type: ChannelType.PublicThread })
-      .mockRejectedValueOnce(Object.assign(new Error("bad gateway"), { status: 502 }))
-      .mockResolvedValueOnce({ id: "msg1", channel_id: "t1" })
-      .mockResolvedValueOnce({ id: "msg2", channel_id: "t1" });
-
-    await createThreadDiscord(
-      "chan1",
-      { name: "thread", content: "a".repeat(2001) },
-      {
-        ...discordClientOpts(rest),
-        retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
-      },
-    );
-
-    expect(postMock).toHaveBeenCalledTimes(4);
-    const firstAttempt = requestBody(postMock as unknown as MockCallSource, 1);
-    const retryAttempt = requestBody(postMock as unknown as MockCallSource, 2);
-    const nextChunk = requestBody(postMock as unknown as MockCallSource, 3);
-    expect(firstAttempt.enforce_nonce).toBe(true);
-    expect(retryAttempt.nonce).toBe(firstAttempt.nonce);
-    expect(nextChunk.enforce_nonce).toBe(true);
-    expect(nextChunk.nonce).not.toBe(firstAttempt.nonce);
   });
 
   it("keeps created non-forum thread details when initial message send fails", async () => {

--- a/extensions/discord/src/send.test-harness.ts
+++ b/extensions/discord/src/send.test-harness.ts
@@ -1,6 +1,7 @@
 // Discord plugin module implements send harness behavior.
 import { createServer } from "node:http";
 import type { MockFn } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { vi } from "vitest";
 import { RequestClient } from "./internal/discord.js";
 
@@ -24,6 +25,60 @@ type DiscordLoopbackRequest = {
   method: string | undefined;
   path: string | undefined;
 };
+
+export const DISCORD_TEST_CFG = {
+  channels: {
+    discord: {
+      accounts: {
+        default: {},
+      },
+    },
+  },
+};
+
+export type MockCallSource = {
+  mock: {
+    calls: ArrayLike<ReadonlyArray<unknown>>;
+  };
+};
+
+export const requireRecord = createRequireRecord("object", "expected-label");
+
+export function discordClientOpts(rest: ReturnType<typeof makeDiscordRest>["rest"]) {
+  return { cfg: DISCORD_TEST_CFG, rest, token: "t" };
+}
+
+export function mockArg(
+  source: MockCallSource,
+  callIndex: number,
+  argIndex: number,
+  label: string,
+) {
+  const call = source.mock.calls[callIndex];
+  if (!call) {
+    throw new Error(`expected mock call: ${label}`);
+  }
+  return call[argIndex];
+}
+
+export function requestOptions(source: MockCallSource, callIndex = 0) {
+  return requireRecord(
+    mockArg(source, callIndex, 1, `request options ${callIndex}`),
+    "request options",
+  );
+}
+
+export function requestPath(source: MockCallSource, callIndex = 0) {
+  return mockArg(source, callIndex, 0, `request path ${callIndex}`);
+}
+
+export function requestBody(source: MockCallSource, callIndex = 0) {
+  return requireRecord(requestOptions(source, callIndex).body, `request body ${callIndex}`);
+}
+
+export function timerDelayAt(source: MockCallSource, callIndex = 0) {
+  return mockArg(source, callIndex, 1, `timer delay ${callIndex}`);
+}
 
 export async function createDiscordLoopbackRest(options?: {
   respond?: (request: DiscordLoopbackRequest) => unknown;

--- a/extensions/discord/src/send.thread-initial-chunks.test.ts
+++ b/extensions/discord/src/send.thread-initial-chunks.test.ts
@@ -1,0 +1,251 @@
+import { ChannelType, Routes } from "discord-api-types/v10";
+import { describe, expect, it } from "vitest";
+import { hasDiscordMessageCreateAmbiguity } from "./retry.js";
+import { createThreadDiscord, DiscordThreadInitialMessageError } from "./send.messages.js";
+import {
+  discordClientOpts,
+  type MockCallSource,
+  requireRecord,
+  requestBody,
+  requestPath,
+} from "./send.test-harness.js";
+
+describe("createThreadDiscord initial chunks", () => {
+  it("keeps forum starter messages within Discord's content limit", async () => {
+    const { rest, getMock, postMock } = makeDiscordRest();
+    getMock.mockResolvedValue({ type: ChannelType.GuildForum });
+    postMock.mockResolvedValue({ id: "t1" });
+    const content = "a".repeat(2001);
+
+    await createThreadDiscord("chan1", { name: "thread", content }, discordClientOpts(rest));
+
+    expect(postMock).toHaveBeenCalledTimes(2);
+    expect(requestBody(postMock as unknown as MockCallSource, 0)).toEqual({
+      name: "thread",
+      message: { content: "a".repeat(2000) },
+    });
+    expect(requestPath(postMock as unknown as MockCallSource, 1)).toBe(
+      Routes.channelMessages("t1"),
+    );
+    expect(requestBody(postMock as unknown as MockCallSource, 1)).toMatchObject({
+      content: "a",
+      enforce_nonce: true,
+    });
+  });
+
+  it("keeps sub-limit multi-line forum content in one starter message", async () => {
+    const { rest, getMock, postMock } = makeDiscordRest();
+    getMock.mockResolvedValue({ type: ChannelType.GuildForum });
+    postMock.mockResolvedValue({ id: "t1" });
+    const content = Array.from({ length: 18 }, (_, index) => `line ${index + 1}`).join("\n");
+
+    await createThreadDiscord("chan1", { name: "thread", content }, discordClientOpts(rest));
+
+    expect(postMock).toHaveBeenCalledTimes(1);
+    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({
+      name: "thread",
+      message: { content },
+    });
+  });
+
+  it("reports a delivered forum starter when a continuation chunk fails", async () => {
+    const { rest, getMock, postMock } = makeDiscordRest();
+    getMock.mockResolvedValue({ type: ChannelType.GuildForum });
+    postMock
+      .mockResolvedValueOnce({ id: "t1", message: { id: "starter1", channel_id: "t1" } })
+      .mockRejectedValueOnce(Object.assign(new Error("missing access"), { status: 403 }));
+
+    let thrown: unknown;
+    try {
+      await createThreadDiscord(
+        "chan1",
+        { name: "thread", content: "a".repeat(2001) },
+        discordClientOpts(rest),
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(DiscordThreadInitialMessageError);
+    expect(requireRecord(thrown, "thread initial message error").initialMessageDelivery).toEqual({
+      starterMessageDelivered: true,
+      deliveredChunkCount: 1,
+      deliveredMessageIds: ["starter1"],
+      failedChunkDelivery: "not_delivered",
+      failedChunkIndex: 1,
+      totalChunkCount: 2,
+    });
+  });
+
+  it("reports an exhausted ambiguous forum continuation as unknown delivery", async () => {
+    const { rest, getMock, postMock } = makeDiscordRest();
+    getMock.mockResolvedValue({ type: ChannelType.GuildForum });
+    const ambiguous = Object.assign(new Error("response lost"), { status: 502 });
+    postMock
+      .mockResolvedValueOnce({ id: "t1", message: { id: "starter1", channel_id: "t1" } })
+      .mockRejectedValue(ambiguous);
+
+    let thrown: unknown;
+    try {
+      await createThreadDiscord(
+        "chan1",
+        { name: "thread", content: "a".repeat(2001) },
+        {
+          ...discordClientOpts(rest),
+          retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+        },
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(postMock).toHaveBeenCalledTimes(3);
+    expect(thrown).toBeInstanceOf(DiscordThreadInitialMessageError);
+    expect(hasDiscordMessageCreateAmbiguity(thrown)).toBe(true);
+    expect(requireRecord(thrown, "thread initial message error").message).toContain(
+      "delivery of the remaining initial content could not be confirmed",
+    );
+    expect(requireRecord(thrown, "thread initial message error").initialMessageDelivery).toEqual({
+      starterMessageDelivered: true,
+      deliveredChunkCount: 1,
+      deliveredMessageIds: ["starter1"],
+      failedChunkDelivery: "unknown",
+      failedChunkIndex: 1,
+      totalChunkCount: 2,
+    });
+  });
+
+  it("chunks long initial messages for non-forum threads", async () => {
+    const { rest, getMock, postMock } = makeDiscordRest();
+    getMock.mockResolvedValue({ type: ChannelType.GuildText });
+    postMock.mockResolvedValue({ id: "t1" });
+    const content = "a".repeat(2001);
+
+    await createThreadDiscord("chan1", { name: "thread", content }, discordClientOpts(rest));
+
+    expect(postMock).toHaveBeenCalledTimes(3);
+    expect(requestPath(postMock as unknown as MockCallSource, 1)).toBe(
+      Routes.channelMessages("t1"),
+    );
+    expect(requestBody(postMock as unknown as MockCallSource, 1)).toMatchObject({
+      content: "a".repeat(2000),
+      enforce_nonce: true,
+    });
+    expect(requestPath(postMock as unknown as MockCallSource, 2)).toBe(
+      Routes.channelMessages("t1"),
+    );
+    expect(requestBody(postMock as unknown as MockCallSource, 2)).toMatchObject({
+      content: "a",
+      enforce_nonce: true,
+    });
+  });
+
+  it("keeps sub-limit multi-line non-forum content in one initial message", async () => {
+    const { rest, getMock, postMock } = makeDiscordRest();
+    getMock.mockResolvedValue({ type: ChannelType.GuildText });
+    postMock.mockResolvedValue({ id: "t1", channel_id: "t1" });
+    const content = Array.from({ length: 18 }, (_, index) => `line ${index + 1}`).join("\n");
+
+    await createThreadDiscord("chan1", { name: "thread", content }, discordClientOpts(rest));
+
+    expect(postMock).toHaveBeenCalledTimes(2);
+    expect(requestBody(postMock as unknown as MockCallSource, 1)).toMatchObject({ content });
+  });
+
+  it("reports delivered non-forum chunks when a later chunk fails", async () => {
+    const { rest, getMock, postMock } = makeDiscordRest();
+    getMock.mockResolvedValue({ type: ChannelType.GuildText });
+    postMock
+      .mockResolvedValueOnce({ id: "t1", name: "thread", type: ChannelType.PublicThread })
+      .mockResolvedValueOnce({ id: "msg1", channel_id: "t1" })
+      .mockRejectedValueOnce(Object.assign(new Error("missing access"), { status: 403 }));
+
+    let thrown: unknown;
+    try {
+      await createThreadDiscord(
+        "chan1",
+        { name: "thread", content: "a".repeat(4001) },
+        discordClientOpts(rest),
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(DiscordThreadInitialMessageError);
+    expect(requireRecord(thrown, "thread initial message error").initialMessageDelivery).toEqual({
+      starterMessageDelivered: false,
+      deliveredChunkCount: 1,
+      deliveredMessageIds: ["msg1"],
+      failedChunkDelivery: "not_delivered",
+      failedChunkIndex: 1,
+      totalChunkCount: 3,
+    });
+  });
+
+  it("reports an exhausted ambiguous non-forum chunk as unknown delivery", async () => {
+    const { rest, getMock, postMock } = makeDiscordRest();
+    getMock.mockResolvedValue({ type: ChannelType.GuildText });
+    const ambiguous = Object.assign(new Error("response lost"), { status: 502 });
+    postMock
+      .mockResolvedValueOnce({ id: "t1", name: "thread", type: ChannelType.PublicThread })
+      .mockResolvedValueOnce({ id: "msg1", channel_id: "t1" })
+      .mockRejectedValue(ambiguous);
+
+    let thrown: unknown;
+    try {
+      await createThreadDiscord(
+        "chan1",
+        { name: "thread", content: "a".repeat(4001) },
+        {
+          ...discordClientOpts(rest),
+          retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+        },
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(postMock).toHaveBeenCalledTimes(4);
+    expect(thrown).toBeInstanceOf(DiscordThreadInitialMessageError);
+    expect(hasDiscordMessageCreateAmbiguity(thrown)).toBe(true);
+    expect(requireRecord(thrown, "thread initial message error").message).toContain(
+      "delivery of the remaining initial content could not be confirmed",
+    );
+    expect(requireRecord(thrown, "thread initial message error").initialMessageDelivery).toEqual({
+      starterMessageDelivered: false,
+      deliveredChunkCount: 1,
+      deliveredMessageIds: ["msg1"],
+      failedChunkDelivery: "unknown",
+      failedChunkIndex: 1,
+      totalChunkCount: 3,
+    });
+  });
+
+  it("retries continuation sends with a stable nonce per chunk", async () => {
+    const { rest, getMock, postMock } = makeDiscordRest();
+    getMock.mockResolvedValue({ type: ChannelType.GuildText });
+    postMock
+      .mockResolvedValueOnce({ id: "t1", name: "thread", type: ChannelType.PublicThread })
+      .mockRejectedValueOnce(Object.assign(new Error("bad gateway"), { status: 502 }))
+      .mockResolvedValueOnce({ id: "msg1", channel_id: "t1" })
+      .mockResolvedValueOnce({ id: "msg2", channel_id: "t1" });
+
+    await createThreadDiscord(
+      "chan1",
+      { name: "thread", content: "a".repeat(2001) },
+      {
+        ...discordClientOpts(rest),
+        retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+      },
+    );
+
+    expect(postMock).toHaveBeenCalledTimes(4);
+    const firstAttempt = requestBody(postMock as unknown as MockCallSource, 1);
+    const retryAttempt = requestBody(postMock as unknown as MockCallSource, 2);
+    const nextChunk = requestBody(postMock as unknown as MockCallSource, 3);
+    expect(firstAttempt.enforce_nonce).toBe(true);
+    expect(retryAttempt.nonce).toBe(firstAttempt.nonce);
+    expect(nextChunk.enforce_nonce).toBe(true);
+    expect(nextChunk.nonce).not.toBe(firstAttempt.nonce);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where main CI failed its extension lint gate after Discord thread-initial-message regression coverage pushed `send.creates-thread.test.ts` beyond the repository max-lines limit.

## Why This Change Was Made

The new thread chunking and partial-delivery regressions now live in a focused test module. Shared Discord REST assertion helpers moved into the existing test harness so both suites use one canonical helper path without weakening the max-lines rule or dropping coverage.

## User Impact

No user-visible behavior changes. This restores the blocking main CI gate while preserving the Discord thread chunking regressions.

## Evidence

- Failing exact-main CI: https://github.com/openclaw/openclaw/actions/runs/31670422830 (`check-lint`: `send.creates-thread.test.ts` exceeded max-lines).
- `pnpm dlx oxlint@1.75.0 extensions/discord/src/send.creates-thread.test.ts extensions/discord/src/send.thread-initial-chunks.test.ts extensions/discord/src/send.test-harness.ts`
- `pnpm dlx oxfmt@0.60.0 --check extensions/discord/src/send.creates-thread.test.ts extensions/discord/src/send.thread-initial-chunks.test.ts extensions/discord/src/send.test-harness.ts`
- `git diff --check`
- Autoreview: clean, no accepted/actionable findings.
- Blacksmith Testbox focused Vitest proof was attempted twice but unavailable (scheduler 429, then an immediately stopped lease); exact-head PR CI is the remaining test proof.
