### PR TITLE
fix(telegram): prevent multi-agent cache ownership startup failures

### DIFF
--- a/extensions/telegram/src/account-owner.test.ts
+++ b/extensions/telegram/src/account-owner.test.ts
@@ -1,0 +1,42 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { describe, expect, it } from "vitest";
+import { resolveTelegramAccountOwnerAgentId } from "./account-owner.js";
+
+describe("resolveTelegramAccountOwnerAgentId", () => {
+  it("resolves distinct routed owners for Telegram accounts", () => {
+    const cfg = {
+      agents: {
+        ownership: "explicit",
+        entries: { main: {}, ops: {}, research: {} },
+      },
+      channels: {
+        telegram: {
+          accounts: {
+            primary: { botToken: "123456:primary" },
+            alerts: { botToken: "123456:alerts" },
+          },
+        },
+      },
+      bindings: [
+        { agentId: "main", match: { channel: "telegram", accountId: "primary" } },
+        { agentId: "ops", match: { channel: "telegram", accountId: "alerts" } },
+      ],
+    } as OpenClawConfig;
+
+    expect(resolveTelegramAccountOwnerAgentId({ cfg, accountId: "primary" })).toBe("main");
+    expect(resolveTelegramAccountOwnerAgentId({ cfg, accountId: "alerts" })).toBe("ops");
+  });
+
+  it("rejects explicit multi-agent ownership without an account route", () => {
+    const cfg = {
+      agents: {
+        ownership: "explicit",
+        entries: { main: {}, ops: {} },
+      },
+    } as OpenClawConfig;
+
+    expect(() => resolveTelegramAccountOwnerAgentId({ cfg, accountId: "default" })).toThrow(
+      /Add a channel-wide binding for telegram:default/,
+    );
+  });
+});

--- a/extensions/telegram/src/account-owner.ts
+++ b/extensions/telegram/src/account-owner.ts
@@ -1,0 +1,14 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
+
+/** Resolves the agent that owns account-scoped Telegram runtime state. */
+export function resolveTelegramAccountOwnerAgentId(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): string {
+  return resolveAgentRoute({
+    cfg: params.cfg,
+    channel: "telegram",
+    accountId: params.accountId,
+  }).agentId;
+}

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -26,6 +26,7 @@ import {
 import type { MessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import { resolveTelegramAccountOwnerAgentId } from "./account-owner.js";
 import {
   createTelegramActionGate,
   resolveDefaultTelegramAccountId,
@@ -154,8 +155,9 @@ function readTelegramThreadId(params: Record<string, unknown>) {
 }
 
 function resolveActionTopicNameCacheScope(cfg: OpenClawConfig, accountId?: string | null): string {
+  const resolvedAccountId = accountId ?? resolveDefaultTelegramAccountId(cfg);
   const storePath = resolveStorePath(cfg.session?.store, {
-    agentId: accountId ?? resolveDefaultTelegramAccountId(cfg),
+    agentId: resolveTelegramAccountOwnerAgentId({ cfg, accountId: resolvedAccountId }),
   });
   return resolveTopicNameCacheScope(storePath);
 }

--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -22,6 +22,7 @@ import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { createNonExitingRuntime, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveTelegramAccountOwnerAgentId } from "./account-owner.js";
 import { getOrCreateAccountThrottler } from "./account-throttler.js";
 import { resolveTelegramAccount } from "./accounts.js";
 import { normalizeTelegramApiRoot } from "./api-root.js";
@@ -43,7 +44,6 @@ import {
 } from "./bot-processing-outcome.js";
 import { createTelegramUpdateTracker } from "./bot-update-tracker.js";
 import type { TelegramUpdateKeyContext } from "./bot-updates.js";
-import { resolveDefaultAgentId } from "./bot.agent.runtime.js";
 import { apiThrottler, Bot, sequentialize, type ApiClientOptions } from "./bot.runtime.js";
 import type { TelegramBotOptions } from "./bot.types.js";
 import { buildTelegramGroupPeerId } from "./bot/helpers.js";
@@ -95,6 +95,10 @@ export function createTelegramBotCore(
     cfg,
     accountId: opts.accountId,
   });
+  const ownerAgentId =
+    opts.ownerAgentId?.trim() ||
+    resolveTelegramAccountOwnerAgentId({ cfg, accountId: account.accountId });
+  const runtimeOpts = { ...opts, ownerAgentId };
   const threadBindingPolicy = resolveThreadBindingSpawnPolicy({
     cfg,
     channel: "telegram",
@@ -279,7 +283,7 @@ export function createTelegramBotCore(
     accountId: account.accountId,
     cfg,
     telegramCfg,
-    opts,
+    opts: runtimeOpts,
   });
   const groupHistories = new Map<string, HistoryEntry[]>();
   const botHistorySender = buildTelegramSelfSenderName(account.name, opts.botInfo);
@@ -328,7 +332,7 @@ export function createTelegramBotCore(
     sessionKey?: string;
     cfg: OpenClawConfig;
   }) => {
-    const agentId = params.agentId ?? resolveDefaultAgentId(params.cfg);
+    const agentId = params.agentId ?? ownerAgentId;
     const sessionKey =
       params.sessionKey ??
       `agent:${agentId}:telegram:group:${buildTelegramGroupPeerId(params.chatId, params.messageThreadId)}`;
@@ -394,7 +398,7 @@ export function createTelegramBotCore(
     resolveTelegramGroupConfig,
     sendChatActionHandler,
     runtime,
-    opts,
+    opts: runtimeOpts,
     telegramDeps,
   });
 
@@ -410,7 +414,7 @@ export function createTelegramBotCore(
     resolveGroupPolicy,
     resolveTelegramGroupConfig,
     shouldSkipUpdate,
-    opts,
+    opts: runtimeOpts,
     telegramDeps: {
       ...telegramDeps,
       sendMessageTelegram: defaultTelegramNativeCommandDeps.sendMessageTelegram,
@@ -420,8 +424,9 @@ export function createTelegramBotCore(
   registerTelegramHandlers({
     cfg,
     accountId: account.accountId,
+    ownerAgentId,
     bot,
-    opts,
+    opts: runtimeOpts,
     telegramTransport,
     runtime,
     mediaMaxBytes,

--- a/extensions/telegram/src/bot-handlers.agent.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.agent.runtime.ts
@@ -1,6 +1,2 @@
 // Telegram plugin module implements bot handlers.agent behavior.
-export {
-  resolveAgentDir,
-  resolveDefaultAgentId,
-  resolveDefaultModelForAgent,
-} from "openclaw/plugin-sdk/agent-runtime";
+export { resolveAgentDir, resolveDefaultModelForAgent } from "openclaw/plugin-sdk/agent-runtime";

--- a/extensions/telegram/src/bot-handlers.callback-router.ts
+++ b/extensions/telegram/src/bot-handlers.callback-router.ts
@@ -13,11 +13,7 @@ import {
   hasTelegramApprovalCallbackPrefix,
   parseTelegramApprovalCallbackData,
 } from "./approval-callback-data.js";
-import {
-  resolveAgentDir,
-  resolveDefaultAgentId,
-  resolveDefaultModelForAgent,
-} from "./bot-handlers.agent.runtime.js";
+import { resolveAgentDir, resolveDefaultModelForAgent } from "./bot-handlers.agent.runtime.js";
 import {
   createTelegramCallbackMessageActions,
   handleTelegramQuestionCallback,
@@ -464,7 +460,18 @@ async function handleTelegramModelCallback(params: {
     if (page === undefined) {
       return true;
     }
-    const agentId = paginationMatch[2]?.trim() || resolveDefaultAgentId(runtimeCfg);
+    const agentId =
+      paginationMatch[2]?.trim() ||
+      messageRuntime.resolveTelegramSessionState({
+        chatId,
+        isGroup,
+        isForum,
+        messageThreadId,
+        resolvedThreadId,
+        botHasTopicsEnabled: resolveTelegramBotHasTopicsEnabled(ctx.me),
+        senderId,
+        runtimeCfg,
+      }).agentId;
     const result = await retryModelAction(async () => {
       const skillCommands = telegramDeps.listSkillCommandsForAgents({
         cfg: runtimeCfg,

--- a/extensions/telegram/src/bot-handlers.event-bindings.ts
+++ b/extensions/telegram/src/bot-handlers.event-bindings.ts
@@ -58,7 +58,7 @@ export function createTelegramEventBindings({
   authorization,
   registerMessages,
 }: CreateTelegramEventBindingsOptions): TelegramEventBindings {
-  const { accountId, bot, cfg, runtime, shouldSkipUpdate, telegramDeps } = params;
+  const { accountId, ownerAgentId, bot, cfg, runtime, shouldSkipUpdate, telegramDeps } = params;
   const { authorizeTelegramEventSender, resolveTelegramEventAuthorizationContext } = authorization;
   const {
     buildSyntheticContext,
@@ -95,7 +95,10 @@ export function createTelegramEventBindings({
         }
         if (
           reactionMode === "own" &&
-          !telegramDeps.wasSentByBot(chatId, messageId, authorizationCfg)
+          !telegramDeps.wasSentByBot(chatId, messageId, authorizationCfg, {
+            accountId,
+            agentId: ownerAgentId,
+          })
         ) {
           logVerbose(
             `telegram: skipped reaction on msg ${messageId} in chat ${chatId} (own mode, not sent by bot)`,

--- a/extensions/telegram/src/bot-handlers.message-context.runtime.test.ts
+++ b/extensions/telegram/src/bot-handlers.message-context.runtime.test.ts
@@ -1,8 +1,11 @@
 // Telegram tests cover forum topic recovery from the real message cache.
 import type { Message } from "grammy/types";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { beforeEach, describe, expect, it } from "vitest";
-import { createTelegramMessageContextRuntime } from "./bot-handlers.message-context.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createTelegramMessageContextRuntime,
+  createTelegramMessageSessionRuntime,
+} from "./bot-handlers.message-context.js";
 import type { RegisterTelegramHandlerParams } from "./bot-handlers.types.js";
 import { resetTelegramMessageCacheForTest } from "./runtime.test-support.js";
 
@@ -21,6 +24,7 @@ function createRuntime() {
   return createTelegramMessageContextRuntime({
     cfg,
     accountId: "default",
+    ownerAgentId: "main",
     opts: { token: "test" },
     telegramCfg: {},
     telegramDeps: {
@@ -43,6 +47,52 @@ function forumMessage(messageId: number, threadId?: number): Message {
 describe("resolveCachedMessageThreadSpec", () => {
   beforeEach(() => {
     resetTelegramMessageCacheForTest();
+  });
+
+  it("keeps account cache ownership separate from a topic-routed session owner", () => {
+    const resolveStorePath = vi.fn(
+      (_store, options: { agentId?: string }) =>
+        `/tmp/openclaw-telegram-owner-${options.agentId}.json`,
+    );
+    const cfg = {
+      agents: {
+        ownership: "explicit",
+        entries: { main: {}, ops: {}, research: {} },
+      },
+      bindings: [{ agentId: "main", match: { channel: "telegram", accountId: "*" } }],
+    } as OpenClawConfig;
+    createTelegramMessageContextRuntime({
+      cfg,
+      accountId: "primary",
+      ownerAgentId: "main",
+      opts: { token: "test" },
+      telegramCfg: {},
+      telegramDeps: { resolveStorePath } as RegisterTelegramHandlerParams["telegramDeps"],
+    });
+    const sessionRuntime = createTelegramMessageSessionRuntime({
+      accountId: "primary",
+      resolveTelegramGroupConfig: () => ({ topicConfig: { agentId: "research" } }),
+      telegramDeps: { resolveStorePath } as RegisterTelegramHandlerParams["telegramDeps"],
+    });
+
+    const session = sessionRuntime.resolveTelegramSessionState({
+      chatId: CHAT_ID,
+      isGroup: true,
+      isForum: true,
+      messageThreadId: TOPIC_ID,
+      senderId: 10,
+      runtimeCfg: cfg,
+    });
+
+    expect(resolveStorePath.mock.calls.map(([, options]) => options?.agentId)).toEqual([
+      "main",
+      "research",
+    ]);
+    expect(session).toMatchObject({
+      agentId: "research",
+      storePath: "/tmp/openclaw-telegram-owner-research.json",
+    });
+    expect(session.sessionKey).toContain("agent:research:");
   });
 
   it("recovers the topic of a recorded forum message", async () => {

--- a/extensions/telegram/src/bot-handlers.message-context.runtime.test.ts
+++ b/extensions/telegram/src/bot-handlers.message-context.runtime.test.ts
@@ -67,12 +67,16 @@ describe("resolveCachedMessageThreadSpec", () => {
       ownerAgentId: "main",
       opts: { token: "test" },
       telegramCfg: {},
-      telegramDeps: { resolveStorePath } as RegisterTelegramHandlerParams["telegramDeps"],
+      telegramDeps: {
+        resolveStorePath,
+      } as unknown as RegisterTelegramHandlerParams["telegramDeps"],
     });
     const sessionRuntime = createTelegramMessageSessionRuntime({
       accountId: "primary",
       resolveTelegramGroupConfig: () => ({ topicConfig: { agentId: "research" } }),
-      telegramDeps: { resolveStorePath } as RegisterTelegramHandlerParams["telegramDeps"],
+      telegramDeps: {
+        resolveStorePath,
+      } as unknown as RegisterTelegramHandlerParams["telegramDeps"],
     });
 
     const session = sessionRuntime.resolveTelegramSessionState({

--- a/extensions/telegram/src/bot-handlers.message-context.ts
+++ b/extensions/telegram/src/bot-handlers.message-context.ts
@@ -1,5 +1,4 @@
 import type { Message } from "grammy/types";
-import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 import { formatMediaPlaceholderText } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveStoredModelOverride } from "openclaw/plugin-sdk/command-auth-native";
 import type { OpenClawConfig, TelegramAccountConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -293,17 +292,18 @@ export function createTelegramMessageSessionRuntime({
 export function createTelegramMessageContextRuntime({
   cfg,
   accountId,
+  ownerAgentId,
   opts,
   telegramCfg,
   telegramDeps,
 }: Pick<
   RegisterTelegramHandlerParams,
-  "cfg" | "accountId" | "opts" | "telegramCfg" | "telegramDeps"
+  "cfg" | "accountId" | "ownerAgentId" | "opts" | "telegramCfg" | "telegramDeps"
 >) {
   const messageCache = createTelegramMessageCache({
     scope: resolveTelegramMessageCacheScope(
       telegramDeps.resolveStorePath(cfg.session?.store, {
-        agentId: cfg.agents ? resolveDefaultAgentId(cfg) : "main",
+        agentId: ownerAgentId,
       }),
     ),
   });

--- a/extensions/telegram/src/bot-handlers.message-pipeline.ts
+++ b/extensions/telegram/src/bot-handlers.message-pipeline.ts
@@ -161,6 +161,7 @@ function resolveRetainedTelegramMedia(params: {
 export function createTelegramMessagePipeline({
   cfg,
   accountId,
+  ownerAgentId,
   bot,
   opts,
   telegramTransport,
@@ -210,6 +211,7 @@ export function createTelegramMessagePipeline({
   } = createTelegramMessageContextRuntime({
     cfg,
     accountId,
+    ownerAgentId,
     opts,
     telegramCfg,
     telegramDeps,

--- a/extensions/telegram/src/bot-handlers.reaction.runtime.test.ts
+++ b/extensions/telegram/src/bot-handlers.reaction.runtime.test.ts
@@ -55,6 +55,7 @@ function registerHandler(cfg: OpenClawConfig): ReactionHandler {
   const handlers = new Map<string, ReactionHandler>();
   const params: RegisterTelegramHandlerParams = {
     accountId: "default",
+    ownerAgentId: "main",
     bot: {
       on: (name: string, handler: ReactionHandler) => {
         handlers.set(name, handler);

--- a/extensions/telegram/src/bot-handlers.runtime.test.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.test.ts
@@ -13,6 +13,7 @@ describe("registerTelegramHandlers", () => {
     const params: RegisterTelegramHandlerParams = {
       cfg: {},
       accountId: "default",
+      ownerAgentId: "main",
       bot,
       mediaMaxBytes: 1,
       opts: { token: "tok" },

--- a/extensions/telegram/src/bot-handlers.types.ts
+++ b/extensions/telegram/src/bot-handlers.types.ts
@@ -73,6 +73,7 @@ type TelegramHandlerLogger = {
 export type RegisterTelegramHandlerParams = {
   cfg: OpenClawConfig;
   accountId: string;
+  ownerAgentId: string;
   bot: Bot;
   mediaMaxBytes: number;
   opts: TelegramBotOptions;

--- a/extensions/telegram/src/bot-message-context.prompt-context.test.ts
+++ b/extensions/telegram/src/bot-message-context.prompt-context.test.ts
@@ -123,6 +123,7 @@ describe("buildTelegramMessageContext prompt context", () => {
     const messageContextRuntime = createTelegramMessageContextRuntime({
       cfg: registrationCfg,
       accountId: "default",
+      ownerAgentId: "main",
       opts: {
         token: "test-token",
         botInfo: { id: 7, username: "bot", first_name: "Bot" },
@@ -209,6 +210,7 @@ describe("buildTelegramMessageContext prompt context", () => {
     const messageContextRuntime = createTelegramMessageContextRuntime({
       cfg,
       accountId: "default",
+      ownerAgentId: "main",
       opts: {
         token: "test-token",
         botInfo: { id: 7, username: "bot", first_name: "Bot" },

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -17,6 +17,7 @@ import {
   expandTelegramAllowFromWithAccessGroups,
   resolveTelegramDmAllow,
 } from "./access-groups.js";
+import { resolveTelegramAccountOwnerAgentId } from "./account-owner.js";
 import { resolveDefaultTelegramAccountId } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import {
@@ -127,6 +128,7 @@ export const buildTelegramMessageContext = async ({
   bot,
   cfg,
   account,
+  ownerAgentId,
   historyLimit,
   dmHistoryLimit,
   groupHistories,
@@ -178,7 +180,9 @@ export const buildTelegramMessageContext = async ({
     const topicNameCacheScope = resolveTopicNameCacheScope(
       await resolveTelegramMessageContextStorePath({
         cfg,
-        agentId: account.accountId,
+        agentId:
+          ownerAgentId?.trim() ||
+          resolveTelegramAccountOwnerAgentId({ cfg, accountId: account.accountId }),
         sessionRuntime,
       }),
     );

--- a/extensions/telegram/src/bot-message-context.types.ts
+++ b/extensions/telegram/src/bot-message-context.types.ts
@@ -102,6 +102,7 @@ export type BuildTelegramMessageContextParams = {
   bot: Bot;
   cfg: OpenClawConfig;
   account: { accountId: string };
+  ownerAgentId?: string;
   historyLimit: number;
   dmHistoryLimit: number;
   groupHistories: Map<string, HistoryEntry[]>;

--- a/extensions/telegram/src/bot-message-dispatch-delivery.ts
+++ b/extensions/telegram/src/bot-message-dispatch-delivery.ts
@@ -119,6 +119,7 @@ async function recordPromptContextMessage(
     turn.telegramDeps.recordOutboundMessageForPromptContext ?? recordOutboundMessageForPromptContext
   )({
     cfg: turn.cfg,
+    ownerAgentId: turn.opts.ownerAgentId,
     account: {
       accountId: context.route.accountId,
       ...(turn.telegramCfg.name !== undefined ? { name: turn.telegramCfg.name } : {}),
@@ -167,6 +168,7 @@ function createDeliveryBaseOptions(turn: Turn) {
   const { context } = turn;
   return {
     cfg: turn.cfg,
+    ownerAgentId: turn.opts.ownerAgentId,
     chatId: String(context.chatId),
     accountId: context.route.accountId,
     sessionKeyForInternalHooks: context.ctxPayload.SessionKey,

--- a/extensions/telegram/src/bot-message-dispatch-draft.ts
+++ b/extensions/telegram/src/bot-message-dispatch-draft.ts
@@ -125,12 +125,16 @@ export function createDraftState(params: TurnConfig): TelegramDraftStateSlice {
               }
             : {}),
           onProviderMessage: async (message) => {
-            recordSentMessage(params.context.chatId, message.message_id, params.cfg);
+            recordSentMessage(params.context.chatId, message.message_id, params.cfg, {
+              accountId: params.context.route.accountId,
+              agentId: params.opts.ownerAgentId,
+            });
             await (
               params.telegramDeps.recordOutboundMessageForPromptContext ??
               recordOutboundMessageForPromptContext
             )({
               cfg: params.cfg,
+              ownerAgentId: params.opts.ownerAgentId,
               account: {
                 accountId: params.context.route.accountId,
                 ...(params.telegramCfg.name !== undefined ? { name: params.telegramCfg.name } : {}),

--- a/extensions/telegram/src/bot-message-dispatch.types.ts
+++ b/extensions/telegram/src/bot-message-dispatch.types.ts
@@ -35,7 +35,7 @@ export type DispatchTelegramMessageParams = {
   textLimit: number;
   telegramCfg: TelegramAccountConfig;
   telegramDeps?: TelegramBotDeps;
-  opts: Pick<TelegramBotOptions, "token" | "mediaMaxMb">;
+  opts: Pick<TelegramBotOptions, "token" | "mediaMaxMb" | "ownerAgentId">;
   retryDispatchErrors?: boolean;
   suppressFailureFallback?: boolean;
   /**

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -67,7 +67,10 @@ type TelegramMessageProcessorDeps = Omit<
 > & {
   runtime: RuntimeEnv;
   telegramDeps: TelegramBotDeps;
-  opts: Pick<TelegramBotOptions, "token" | "allowFrom" | "groupAllowFrom" | "replyToMode">;
+  opts: Pick<
+    TelegramBotOptions,
+    "token" | "ownerAgentId" | "allowFrom" | "groupAllowFrom" | "replyToMode"
+  >;
 };
 
 export function resolveTelegramMessageTurnSettings(params: {
@@ -197,6 +200,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
       bot,
       cfg: turnCfg,
       account,
+      ownerAgentId: opts.ownerAgentId,
       historyLimit: turnSettings.historyLimit,
       dmHistoryLimit: turnSettings.dmHistoryLimit,
       groupHistories,

--- a/extensions/telegram/src/bot-native-command-dispatch.ts
+++ b/extensions/telegram/src/bot-native-command-dispatch.ts
@@ -20,6 +20,7 @@ import {
 import { danger, logVerbose, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { expandTelegramAllowFromWithAccessGroups } from "./access-groups.js";
+import { resolveTelegramAccountOwnerAgentId } from "./account-owner.js";
 import { resolveTelegramAccount } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { normalizeDmAllowFromWithStore, resolveTelegramEffectiveDmPolicy } from "./bot-access.js";
@@ -100,7 +101,13 @@ export type TelegramCommandExecutorParams = {
   telegramDeps?: TelegramNativeCommandDeps;
   opts: Pick<
     TelegramBotOptions,
-    "token" | "botInfo" | "allowFrom" | "groupAllowFrom" | "replyToMode" | "accountAbortSignal"
+    | "token"
+    | "ownerAgentId"
+    | "botInfo"
+    | "allowFrom"
+    | "groupAllowFrom"
+    | "replyToMode"
+    | "accountAbortSignal"
   >;
 };
 
@@ -447,6 +454,7 @@ export async function prepareTelegramCommandDispatch(
     policySessionKey?: string;
   }): DeliveryBaseOptions => ({
     cfg: runtimeCfg,
+    ownerAgentId: params.opts.ownerAgentId,
     chatId: String(auth.chatId),
     accountId: route.accountId,
     sessionKeyForInternalHooks: keys?.sessionKeyForInternalHooks,
@@ -505,7 +513,12 @@ export async function dispatchTelegramBuiltinTurn(params: {
   if (dispatch.isForum && dispatch.resolvedThreadId != null) {
     try {
       const storePath = resolveStorePath(dispatch.runtimeCfg.session?.store, {
-        agentId: dispatch.route.accountId,
+        agentId:
+          dispatch.opts.ownerAgentId ??
+          resolveTelegramAccountOwnerAgentId({
+            cfg: dispatch.runtimeCfg,
+            accountId: dispatch.route.accountId,
+          }),
       });
       topicName = await getTopicName(
         dispatch.chatId,

--- a/extensions/telegram/src/bot-native-command-plugins.ts
+++ b/extensions/telegram/src/bot-native-command-plugins.ts
@@ -281,7 +281,10 @@ export async function executeTelegramPluginCommand(
           buttons: telegramResultData?.buttons,
         },
       );
-      recordSentMessage(dispatch.chatId, progressMessageId, dispatch.runtimeCfg);
+      recordSentMessage(dispatch.chatId, progressMessageId, dispatch.runtimeCfg, {
+        accountId: dispatch.route.accountId,
+        agentId: dispatch.opts.ownerAgentId,
+      });
       emitTelegramMessageSentHooks({
         sessionKeyForInternalHooks: dispatch.targetSessionKey,
         chatId: String(dispatch.chatId),

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -64,7 +64,13 @@ type RegisterTelegramNativeCommandsParams = {
   telegramDeps?: TelegramNativeCommandDeps;
   opts: Pick<
     TelegramBotOptions,
-    "token" | "botInfo" | "allowFrom" | "groupAllowFrom" | "replyToMode" | "accountAbortSignal"
+    | "token"
+    | "ownerAgentId"
+    | "botInfo"
+    | "allowFrom"
+    | "groupAllowFrom"
+    | "replyToMode"
+    | "accountAbortSignal"
   >;
 };
 

--- a/extensions/telegram/src/bot.agent.runtime.ts
+++ b/extensions/telegram/src/bot.agent.runtime.ts
@@ -1,2 +1,0 @@
-// Telegram plugin module implements bot.agent behavior.
-export { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";

--- a/extensions/telegram/src/bot.forum-ingress.response-body-timeout.integration.test.ts
+++ b/extensions/telegram/src/bot.forum-ingress.response-body-timeout.integration.test.ts
@@ -94,6 +94,7 @@ describe("Telegram supergroup ingress with a stalled Bot API response body", () 
     };
     const params: RegisterTelegramHandlerParams = {
       accountId: "default",
+      ownerAgentId: "main",
       bot,
       cfg: {},
       mediaMaxBytes: 1,

--- a/extensions/telegram/src/bot.media.e2e.test-harness.ts
+++ b/extensions/telegram/src/bot.media.e2e.test-harness.ts
@@ -361,14 +361,9 @@ vi.doMock("./bot-message-context.session.runtime.js", async () => {
   };
 });
 
-vi.mock("./bot.agent.runtime.js", () => ({
-  resolveDefaultAgentId: vi.fn(() => "default"),
-}));
-
 vi.mock("./bot-handlers.agent.runtime.js", () => ({
   resolveAgentDir: vi.fn(() => "/tmp/agent"),
   resolveAgentWorkspaceDir: vi.fn(() => "/tmp/workspace"),
-  resolveDefaultAgentId: vi.fn(() => "default"),
   resolveDefaultModelForAgent: vi.fn(() => ({
     provider: "openai",
     model: "gpt-test",

--- a/extensions/telegram/src/bot.types.ts
+++ b/extensions/telegram/src/bot.types.ts
@@ -8,6 +8,8 @@ import type { TelegramTransport } from "./fetch.js";
 export type TelegramBotOptions = {
   token: string;
   accountId?: string;
+  /** Agent that owns account-scoped Telegram runtime state. */
+  ownerAgentId?: string;
   runtime?: RuntimeEnv;
   requireMention?: boolean;
   allowFrom?: Array<string | number>;

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -738,11 +738,16 @@ export async function deliverReplies(params: {
     deliveredCount: 0,
     ...(params.promptContextSequence ? { promptContext: params.promptContextSequence } : {}),
   };
-  const recordMessageId = (messageId: number) =>
-    recordSentMessage(params.chatId, messageId, params.cfg, {
-      accountId: params.accountId,
-      agentId: params.ownerAgentId,
-    });
+  const recordMessageId = (messageId: number) => {
+    if (params.accountId || params.ownerAgentId) {
+      recordSentMessage(params.chatId, messageId, params.cfg, {
+        accountId: params.accountId,
+        agentId: params.ownerAgentId,
+      });
+      return;
+    }
+    recordSentMessage(params.chatId, messageId, params.cfg);
+  };
   const mediaLoader = params.mediaLoader ?? loadWebMedia;
   const transcriptMirror = params.transcriptMirror;
   const deliveredContents: Array<{ text: string; mediaUrls: string[] }> = [];

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -686,6 +686,7 @@ export function emitTelegramMessageSentHooks(params: EmitMessageSentHookParams):
 export async function deliverReplies(params: {
   replies: ReplyPayload[];
   cfg?: import("openclaw/plugin-sdk/config-contracts").OpenClawConfig;
+  ownerAgentId?: string;
   chatId: string;
   accountId?: string;
   sessionKeyForInternalHooks?: string;
@@ -738,7 +739,10 @@ export async function deliverReplies(params: {
     ...(params.promptContextSequence ? { promptContext: params.promptContextSequence } : {}),
   };
   const recordMessageId = (messageId: number) =>
-    recordSentMessage(params.chatId, messageId, params.cfg);
+    recordSentMessage(params.chatId, messageId, params.cfg, {
+      accountId: params.accountId,
+      agentId: params.ownerAgentId,
+    });
   const mediaLoader = params.mediaLoader ?? loadWebMedia;
   const transcriptMirror = params.transcriptMirror;
   const deliveredContents: Array<{ text: string; mediaUrls: string[] }> = [];

--- a/extensions/telegram/src/channel.gateway.test.ts
+++ b/extensions/telegram/src/channel.gateway.test.ts
@@ -211,6 +211,7 @@ function startTelegramAccount(
 function latestMonitorOptions(): {
   token?: string;
   accountId?: string;
+  ownerAgentId?: string;
   useWebhook?: boolean;
   botInfo?: unknown;
 } {
@@ -328,6 +329,60 @@ describe("telegramPlugin gateway startup", () => {
     expect(monitorOptions.token).toBe("123456:bad-token");
     expect(monitorOptions.accountId).toBe("default");
     expect(monitorOptions.useWebhook).toBe(false);
+  });
+
+  it("starts a multi-agent account with its routed owner", async () => {
+    installTelegramRuntime();
+    probeTelegram.mockResolvedValue({
+      ok: false,
+      status: 500,
+      error: "Bad Gateway",
+      elapsedMs: 12,
+    });
+    monitorTelegramProvider.mockResolvedValue(undefined);
+    const cfg = {
+      agents: {
+        ownership: "explicit",
+        entries: { main: {}, ops: {}, research: {} },
+      },
+      channels: { telegram: { botToken: "123456:bad-token" } },
+      bindings: [{ agentId: "main", match: { channel: "telegram", accountId: "*" } }],
+    } as OpenClawConfig;
+    const account = telegramPlugin.config.resolveAccount(cfg, "default");
+    const startAccount = telegramPlugin.gateway?.startAccount;
+    if (!startAccount) {
+      throw new Error("expected Telegram startAccount gateway handler");
+    }
+
+    await startAccount(createStartAccountContext({ account, cfg }));
+
+    expect(latestMonitorOptions()).toMatchObject({
+      accountId: "default",
+      ownerAgentId: "main",
+    });
+  });
+
+  it("rejects genuinely ambiguous multi-agent account ownership before startup", async () => {
+    installTelegramRuntime();
+    const cfg = {
+      agents: {
+        ownership: "explicit",
+        entries: { main: {}, ops: {}, research: {} },
+      },
+      channels: { telegram: { botToken: "123456:bad-token" } },
+    } as OpenClawConfig;
+    const account = telegramPlugin.config.resolveAccount(cfg, "default");
+    const startAccount = telegramPlugin.gateway?.startAccount;
+    if (!startAccount) {
+      throw new Error("expected Telegram startAccount gateway handler");
+    }
+
+    await expect(startAccount(createStartAccountContext({ account, cfg }))).rejects.toMatchObject({
+      name: "AgentSelectionRequiredError",
+      code: "AGENT_SELECTION_REQUIRED",
+    });
+    expect(probeTelegram).not.toHaveBeenCalled();
+    expect(monitorTelegramProvider).not.toHaveBeenCalled();
   });
 
   it("uses the getMe request guard for startup probe timeout", async () => {

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -29,7 +29,7 @@ import { createChannelDirectoryAdapter } from "openclaw/plugin-sdk/directory-run
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { channelBlockedPatch } from "openclaw/plugin-sdk/gateway-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
-import type { RoutePeer } from "openclaw/plugin-sdk/routing";
+import { resolveAgentRoute, type RoutePeer } from "openclaw/plugin-sdk/routing";
 import {
   createComputedAccountStatusAdapter,
   createDefaultChannelRuntimeState,
@@ -1058,6 +1058,11 @@ export const telegramPlugin = createChatChannelPlugin({
     gateway: {
       startAccount: async (ctx) => {
         const account = ctx.account;
+        const ownerAgentId = resolveAgentRoute({
+          cfg: ctx.cfg,
+          channel: "telegram",
+          accountId: account.accountId,
+        }).agentId;
         const setStatus = createAccountStatusSink({
           accountId: account.accountId,
           setStatus: ctx.setStatus,
@@ -1140,6 +1145,7 @@ export const telegramPlugin = createChatChannelPlugin({
         return resolveTelegramMonitor()({
           token,
           accountId: account.accountId,
+          ownerAgentId,
           config: ctx.cfg,
           runtime: ctx.runtime,
           channelRuntime: ctx.channelRuntime,

--- a/extensions/telegram/src/message-topic-binding.test.ts
+++ b/extensions/telegram/src/message-topic-binding.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { resolveTelegramMessageCacheScope } from "./message-cache-persistence.js";
 import { createTelegramMessageCache } from "./message-cache.js";
 import { resolveTelegramMessageMutationChatId } from "./message-topic-binding.js";
+import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
 import { setTelegramRuntime } from "./runtime.js";
 import {
   clearTelegramRuntimeForTest,
@@ -249,6 +250,39 @@ describe("Telegram message topic binding", () => {
         cfg,
         accountId: "default",
         context: delegatedContext(),
+      }),
+    ).resolves.toBe("-1001");
+  });
+
+  it("reads an outbound topic binding from the routed account owner's cache after restart", async () => {
+    const multiAgentCfg = {
+      agents: {
+        ownership: "explicit",
+        entries: { main: {}, ops: {}, research: {} },
+      },
+      channels: {
+        telegram: { accounts: { alerts: { botToken: "123456:alerts" } } },
+      },
+      bindings: [{ agentId: "ops", match: { channel: "telegram", accountId: "alerts" } }],
+      session: { store: "/tmp/openclaw-telegram-topic-owner/{agentId}/sessions.json" },
+    } as OpenClawConfig;
+    await recordOutboundMessageForPromptContext({
+      cfg: multiAgentCfg,
+      account: { accountId: "alerts", name: "Alerts" },
+      chatId: -1001,
+      message: topicMessage(902, 77),
+      messageId: 902,
+      successfulSendThread: { scope: "forum", id: 77 },
+    });
+    resetTelegramMessageCacheForTest();
+
+    await expect(
+      resolveTelegramMessageMutationChatId({
+        chatId: "-1001:topic:77",
+        messageId: 902,
+        cfg: multiAgentCfg,
+        accountId: "alerts",
+        context: delegatedContext({ requesterAccountId: "alerts" }),
       }),
     ).resolves.toBe("-1001");
   });

--- a/extensions/telegram/src/message-topic-binding.ts
+++ b/extensions/telegram/src/message-topic-binding.ts
@@ -1,6 +1,5 @@
 // Telegram provider-owned authorization for message mutations in forum topics.
 import { normalizeAccountId, normalizeOptionalAccountId } from "openclaw/plugin-sdk/account-core";
-import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 import type {
   ChannelMessageActionContext,
   ChannelThreadingToolContext,
@@ -8,6 +7,7 @@ import type {
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import { resolveTelegramAccountOwnerAgentId } from "./account-owner.js";
 import { resolveDefaultTelegramAccountId } from "./accounts.js";
 import { resolveTelegramMessageCacheScope } from "./message-cache-persistence.js";
 import {
@@ -115,7 +115,10 @@ export async function resolveTelegramMessageMutationChatId(params: {
   const cache = createTelegramMessageCache({
     scope: resolveTelegramMessageCacheScope(
       resolveStorePath(params.cfg.session?.store, {
-        agentId: params.cfg.agents ? resolveDefaultAgentId(params.cfg) : "main",
+        agentId: resolveTelegramAccountOwnerAgentId({
+          cfg: params.cfg,
+          accountId: selectedAccountId,
+        }),
       }),
     ),
   });

--- a/extensions/telegram/src/monitor.test.ts
+++ b/extensions/telegram/src/monitor.test.ts
@@ -934,10 +934,11 @@ describe("monitorTelegramProvider (grammY)", () => {
     });
 
     const webhookCall = latestMockCall(startTelegramWebhookSpy, "startTelegramWebhook") as [
-      { host?: string; setStatus?: unknown },
+      { host?: string; ownerAgentId?: string; setStatus?: unknown },
     ];
     const webhookOptions = webhookCall[0];
     expect(webhookOptions?.host).toBe("0.0.0.0");
+    expect(webhookOptions?.ownerAgentId).toBe("main");
     expect(webhookOptions?.setStatus).toBe(setStatus);
     expect(runSpy).not.toHaveBeenCalled();
   });

--- a/extensions/telegram/src/monitor.ts
+++ b/extensions/telegram/src/monitor.ts
@@ -13,6 +13,7 @@ import {
 } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
+import { resolveTelegramAccountOwnerAgentId } from "./account-owner.js";
 import { resolveTelegramAccount } from "./accounts.js";
 import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { isTelegramExecApprovalHandlerConfigured } from "./exec-approvals.js";
@@ -139,6 +140,9 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       cfg,
       accountId: opts.accountId,
     });
+    const ownerAgentId =
+      opts.ownerAgentId?.trim() ||
+      resolveTelegramAccountOwnerAgentId({ cfg, accountId: account.accountId });
     const token = opts.token?.trim() || account.token;
     if (!token) {
       throw new Error(
@@ -164,6 +168,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       await startTelegramWebhook({
         token,
         accountId: account.accountId,
+        ownerAgentId,
         config: cfg,
         path: opts.webhookPath,
         port: opts.webhookPort,
@@ -268,6 +273,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         token,
         config: cfg,
         accountId: account.accountId,
+        ownerAgentId,
         runtime: opts.runtime,
         proxyFetch,
         botInfo: opts.botInfo,

--- a/extensions/telegram/src/monitor.types.ts
+++ b/extensions/telegram/src/monitor.types.ts
@@ -10,6 +10,7 @@ import type { TelegramBotInfo } from "./bot-info.js";
 export type MonitorTelegramOpts = {
   token?: string;
   accountId?: string;
+  ownerAgentId?: string;
   config?: OpenClawConfig;
   runtime?: RuntimeEnv;
   channelRuntime?: ChannelRuntimeSurface;

--- a/extensions/telegram/src/outbound-message-context.ts
+++ b/extensions/telegram/src/outbound-message-context.ts
@@ -1,9 +1,9 @@
 // Telegram plugin module implements outbound message context behavior.
 import type { Message } from "grammy/types";
-import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import { resolveTelegramAccountOwnerAgentId } from "./account-owner.js";
 import type { TelegramThreadSpec } from "./bot/helpers.js";
 import { buildTelegramSelfSenderName } from "./group-history-window.js";
 import { resolveTelegramMessageCacheScope } from "./message-cache-persistence.js";
@@ -139,6 +139,8 @@ export async function recordOutboundMessageForPromptContext(params: {
   successfulSendThread?: TelegramThreadSpec;
   promptContextTimestampMs?: number;
   promptContextProjection?: TelegramPromptContextProjection;
+  /** Pre-resolved account owner from the active Telegram runtime. */
+  ownerAgentId?: string;
   /** Edits refresh an existing cache entry without inserting another self-history turn. */
   recordGroupHistory?: boolean;
 }): Promise<boolean> {
@@ -155,7 +157,12 @@ export async function recordOutboundMessageForPromptContext(params: {
     const cache = createTelegramMessageCache({
       scope: resolveTelegramMessageCacheScope(
         resolveStorePath(params.cfg.session?.store, {
-          agentId: params.cfg.agents ? resolveDefaultAgentId(params.cfg) : "main",
+          agentId:
+            params.ownerAgentId?.trim() ||
+            resolveTelegramAccountOwnerAgentId({
+              cfg: params.cfg,
+              accountId: params.account.accountId,
+            }),
         }),
       ),
     });

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -952,6 +952,7 @@ describe("TelegramPollingSession", () => {
       token: "tok",
       config: {},
       accountId: "default",
+      ownerAgentId: "ops",
       runtime: undefined,
       proxyFetch: undefined,
       abortSignal: abort.signal,
@@ -970,6 +971,7 @@ describe("TelegramPollingSession", () => {
     expect(
       mockObjectArg(createTelegramBotMock, "createTelegramBot").minimumClientTimeoutSeconds,
     ).toBe(45);
+    expect(mockObjectArg(createTelegramBotMock, "createTelegramBot").ownerAgentId).toBe("ops");
     expect(computeBackoffMock).toHaveBeenCalledTimes(1);
     expect(computeBackoffMock).toHaveBeenCalledWith(
       {

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -86,6 +86,7 @@ type TelegramPollingSessionOpts = {
   token: string;
   config: NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
   accountId: string;
+  ownerAgentId?: string;
   runtime: Parameters<typeof createTelegramBot>[0]["runtime"];
   proxyFetch: Parameters<typeof createTelegramBot>[0]["proxyFetch"];
   botInfo?: Parameters<typeof createTelegramBot>[0]["botInfo"];
@@ -310,6 +311,7 @@ export class TelegramPollingSession {
         proxyFetch: this.opts.proxyFetch,
         config: this.opts.config,
         accountId: this.opts.accountId,
+        ownerAgentId: this.opts.ownerAgentId,
         botInfo: this.opts.botInfo,
         ...(botApiAbortSignal ? { fetchAbortSignal: botApiAbortSignal } : {}),
         ...(this.opts.abortSignal ? { accountAbortSignal: this.opts.abortSignal } : {}),

--- a/extensions/telegram/src/progress-draft-preview.test.ts
+++ b/extensions/telegram/src/progress-draft-preview.test.ts
@@ -5,13 +5,16 @@ import { describe, expect, it } from "vitest";
 import { renderTelegramProgressDraftPreview } from "./progress-draft-preview.js";
 
 function renderToolLine(name: string) {
-  const line = buildChannelProgressDraftLine({
-    event: "tool",
-    toolCallId: "call-1",
-    name,
-    phase: "start",
-    args: { command: "echo alpha", description: "print text" },
-  });
+  const line = buildChannelProgressDraftLine(
+    {
+      event: "tool",
+      toolCallId: "call-1",
+      name,
+      phase: "start",
+      args: { command: "echo alpha", description: "print text" },
+    },
+    { commandText: "raw" },
+  );
   if (!line) {
     throw new Error(`expected a progress line for ${name}`);
   }

--- a/extensions/telegram/src/send-context.ts
+++ b/extensions/telegram/src/send-context.ts
@@ -7,6 +7,7 @@ import { createChannelApiRetryRunner, type RetryConfig } from "openclaw/plugin-s
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveTelegramAccountOwnerAgentId } from "./account-owner.js";
 import { getOrCreateAccountThrottler } from "./account-throttler.js";
 import { type ResolvedTelegramAccount, resolveTelegramAccount } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
@@ -427,6 +428,7 @@ export async function withTelegramNativeQuoteFallback<T>(params: {
 export type TelegramApiContext = {
   cfg: OpenClawConfig;
   account: ResolvedTelegramAccount;
+  ownerAgentId: string;
   api: TelegramApi;
   clientOptionsLease?: TelegramClientOptionsLease | undefined;
 };
@@ -459,6 +461,7 @@ export function resolveTelegramApiContext(opts: {
   return {
     cfg,
     account,
+    ownerAgentId: resolveTelegramAccountOwnerAgentId({ cfg, accountId: account.accountId }),
     api,
     ...(clientOptionsLease ? { clientOptionsLease } : {}),
   };

--- a/extensions/telegram/src/send-message-text.ts
+++ b/extensions/telegram/src/send-message-text.ts
@@ -66,6 +66,7 @@ function buildTelegramTextSendReceipt(params: {
 
 export function createTelegramTextSender(config: {
   cfg: OpenClawConfig;
+  ownerAgentId: string;
   account: ResolvedTelegramAccount;
   api: TelegramApi;
   chatId: string;
@@ -97,6 +98,7 @@ export function createTelegramTextSender(config: {
 }) {
   const {
     cfg,
+    ownerAgentId,
     account,
     api,
     chatId,
@@ -226,7 +228,10 @@ export function createTelegramTextSender(config: {
         await beforeFirstAccepted?.();
       }
       sentChunkCount += 1;
-      recordSentMessage(chatId, messageId, cfg);
+      recordSentMessage(chatId, messageId, cfg, {
+        accountId: account.accountId,
+        agentId: ownerAgentId,
+      });
       await reportDelivery(
         messageId,
         params.result?.chat?.id ?? chatId,

--- a/extensions/telegram/src/send-message.ts
+++ b/extensions/telegram/src/send-message.ts
@@ -68,7 +68,7 @@ async function sendMessageTelegramWithContext(
   opts: TelegramSendOpts,
   apiContext: TelegramApiContext,
 ): Promise<TelegramSendResult> {
-  const { cfg, account, api } = apiContext;
+  const { cfg, account, api, ownerAgentId } = apiContext;
   const botUserId = resolveTelegramBotUserIdFromToken(opts.token || account.token);
   const {
     chatId,
@@ -111,6 +111,7 @@ async function sendMessageTelegramWithContext(
     const projection = plan?.cursor.take(plan.finalPart && finalPart);
     const recorded = await recordOutboundMessageForPromptContext({
       cfg,
+      ownerAgentId,
       account,
       ...(botUserId !== undefined ? { botUserId } : {}),
       chatId,
@@ -165,6 +166,7 @@ async function sendMessageTelegramWithContext(
 
   const { sendChunkedText } = createTelegramTextSender({
     cfg,
+    ownerAgentId,
     account,
     api,
     chatId,
@@ -336,7 +338,10 @@ async function sendMessageTelegramWithContext(
     const acceptedMediaParams = toAcceptedThreadScopedParams(mediaDelivery.acceptedParams);
     const mediaMessageId = resolveTelegramMessageIdOrThrow(result, "media send");
     const resolvedChatId = String(result?.chat?.id ?? chatId);
-    recordSentMessage(chatId, mediaMessageId, cfg);
+    recordSentMessage(chatId, mediaMessageId, cfg, {
+      accountId: account.accountId,
+      agentId: ownerAgentId,
+    });
     let mediaDeliveryResult: TelegramSendResult | undefined;
     let mediaPromptRecorded = false;
     const reportMediaDelivery = async (hasInlineKeyboard: boolean) => {

--- a/extensions/telegram/src/send-outbound.ts
+++ b/extensions/telegram/src/send-outbound.ts
@@ -170,9 +170,12 @@ export async function finalizeTelegramOutbound(params: {
   onDeliveryResult?: TelegramSendOpts["onDeliveryResult"];
   beforeActivity?: (result: { messageId: string; chatId: string }) => void;
 }): Promise<TelegramSendResult> {
-  const { cfg, account } = params.context;
+  const { cfg, account, ownerAgentId } = params.context;
   const messageId = resolveTelegramMessageIdOrThrow(params.result, params.resultContext);
-  recordSentMessage(params.prepared.chatId, messageId, cfg);
+  recordSentMessage(params.prepared.chatId, messageId, cfg, {
+    accountId: account.accountId,
+    agentId: ownerAgentId,
+  });
   const resultIds = await reportTelegramProviderDelivery({
     message: params.result,
     messageId,
@@ -185,6 +188,7 @@ export async function finalizeTelegramOutbound(params: {
   );
   const recorded = await recordOutboundMessageForPromptContext({
     cfg,
+    ownerAgentId,
     account,
     botUserId: params.botUserId,
     chatId: params.prepared.chatId,

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import type { Bot } from "grammy";
 import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
   createPluginStateKeyedStoreForTests,
@@ -587,6 +588,38 @@ describe("sent-message-cache", () => {
       fs.rmSync(customStorePath, { force: true });
       fs.rmSync(`${customStorePath}.telegram-sent-messages.json`, { force: true });
     }
+  });
+
+  it("keeps sent-message ownership isolated across differently routed accounts", () => {
+    const multiAgentCfg = {
+      agents: {
+        ownership: "explicit",
+        entries: { main: {}, ops: {} },
+      },
+      channels: {
+        telegram: {
+          accounts: {
+            primary: { botToken: "123456:primary" },
+            alerts: { botToken: "123456:alerts" },
+          },
+        },
+      },
+      bindings: [
+        { agentId: "main", match: { channel: "telegram", accountId: "primary" } },
+        { agentId: "ops", match: { channel: "telegram", accountId: "alerts" } },
+      ],
+      session: {
+        store: "/tmp/openclaw-telegram-sent-owner/{agentId}/sessions.json",
+      },
+    } as OpenClawConfig;
+
+    recordSentMessage(123, 1, multiAgentCfg, { accountId: "primary" });
+
+    expect(wasSentByBot(123, 1, multiAgentCfg, { accountId: "primary" })).toBe(true);
+    expect(wasSentByBot(123, 1, multiAgentCfg, { accountId: "alerts" })).toBe(false);
+
+    recordSentMessage(123, 1, multiAgentCfg, { accountId: "alerts" });
+    expect(wasSentByBot(123, 1, multiAgentCfg, { accountId: "alerts" })).toBe(true);
   });
 
   it("shares sent-message state across distinct module instances", async () => {

--- a/extensions/telegram/src/sent-message-cache.legacy-state.ts
+++ b/extensions/telegram/src/sent-message-cache.legacy-state.ts
@@ -5,9 +5,9 @@
 // legacy-state import, so it stays a leaf.
 import { createHash } from "node:crypto";
 import fs from "node:fs";
-import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-scope-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-paths";
+import { resolveTelegramAccountOwnerAgentId } from "./account-owner.js";
 
 export const TTL_MS = 24 * 60 * 60 * 1000;
 export const TELEGRAM_SENT_MESSAGE_CACHE_NAMESPACE = "telegram.sent-messages";
@@ -20,22 +20,39 @@ export type PersistedSentMessage = {
   timestamp: number;
 };
 
-export type SentMessageConfig = Pick<OpenClawConfig, "agents" | "session">;
+export type SentMessageConfig = Pick<
+  OpenClawConfig,
+  "agents" | "bindings" | "channels" | "session"
+>;
 
-function resolveSentMessageAgentId(cfg?: SentMessageConfig, agentId?: string): string {
-  return agentId?.trim() || (cfg?.agents ? resolveDefaultAgentId(cfg as OpenClawConfig) : "main");
+function resolveSentMessageAgentId(
+  cfg?: SentMessageConfig,
+  owner?: { accountId?: string; agentId?: string },
+): string {
+  return (
+    owner?.agentId?.trim() ||
+    (cfg
+      ? resolveTelegramAccountOwnerAgentId({
+          cfg: cfg as OpenClawConfig,
+          accountId: owner?.accountId,
+        })
+      : "main")
+  );
 }
 
 function sentMessageScopeKeyForStorePath(storePath: string): string {
   return createHash("sha256").update(storePath, "utf8").digest("hex").slice(0, 24);
 }
 
-export function resolveSentMessageScopeKey(cfg?: SentMessageConfig, agentId?: string): string {
+export function resolveSentMessageScopeKey(
+  cfg?: SentMessageConfig,
+  owner?: { accountId?: string; agentId?: string },
+): string {
   // This 24-hour cache follows the current agent owner. Do not revive a prior owner's
   // transient bucket when the configured default changes.
   return sentMessageScopeKeyForStorePath(
     resolveStorePath(cfg?.session?.store, {
-      agentId: resolveSentMessageAgentId(cfg, agentId),
+      agentId: resolveSentMessageAgentId(cfg, owner),
     }),
   );
 }
@@ -47,9 +64,12 @@ export function sentMessageEntryKey(scopeKey: string, chatId: string, messageId:
     .slice(0, 32);
 }
 
-function resolveSentMessageStorePath(cfg?: SentMessageConfig, agentId?: string): string {
+function resolveSentMessageStorePath(
+  cfg?: SentMessageConfig,
+  owner?: { accountId?: string; agentId?: string },
+): string {
   return `${resolveStorePath(cfg?.session?.store, {
-    agentId: resolveSentMessageAgentId(cfg, agentId),
+    agentId: resolveSentMessageAgentId(cfg, owner),
   })}.telegram-sent-messages.json`;
 }
 
@@ -89,8 +109,9 @@ export function listTelegramLegacySentMessageCacheEntries(params: {
 }): Array<{ key: string; value: PersistedSentMessage; ttlMs?: number; timestamp?: number }> {
   const scopeKey = params.targetStorePath
     ? sentMessageScopeKeyForStorePath(params.targetStorePath)
-    : resolveSentMessageScopeKey(params.cfg, params.agentId);
-  const filePath = params.persistedPath ?? resolveSentMessageStorePath(params.cfg, params.agentId);
+    : resolveSentMessageScopeKey(params.cfg, { agentId: params.agentId });
+  const filePath =
+    params.persistedPath ?? resolveSentMessageStorePath(params.cfg, { agentId: params.agentId });
   const legacy = fs.existsSync(filePath)
     ? readLegacySentMessages(filePath)
     : new Map<string, Map<string, number>>();

--- a/extensions/telegram/src/sent-message-cache.ts
+++ b/extensions/telegram/src/sent-message-cache.ts
@@ -95,9 +95,14 @@ function readPersistedSentMessages(scopeKey: string): SentMessageStore {
   return store;
 }
 
-function getSentMessageBucket(cfg?: SentMessageConfig): SentMessageBucket {
+type SentMessageOwner = { accountId?: string; agentId?: string };
+
+function getSentMessageBucket(
+  cfg?: SentMessageConfig,
+  owner?: SentMessageOwner,
+): SentMessageBucket {
   const state = getSentMessageState();
-  const scopeKey = resolveSentMessageScopeKey(cfg);
+  const scopeKey = resolveSentMessageScopeKey(cfg, owner);
   const existing = state.bucketsByScope.get(scopeKey);
   if (existing) {
     return existing;
@@ -111,8 +116,8 @@ function getSentMessageBucket(cfg?: SentMessageConfig): SentMessageBucket {
   return bucket;
 }
 
-function getSentMessages(cfg?: SentMessageConfig): SentMessageStore {
-  return getSentMessageBucket(cfg).store;
+function getSentMessages(cfg?: SentMessageConfig, owner?: SentMessageOwner): SentMessageStore {
+  return getSentMessageBucket(cfg, owner).store;
 }
 
 function persistSentMessage(
@@ -132,11 +137,12 @@ export function recordSentMessage(
   chatId: number | string,
   messageId: number,
   cfg?: SentMessageConfig,
+  owner?: SentMessageOwner,
 ): void {
   const scopeKey = String(chatId);
   const idKey = String(messageId);
   const now = Date.now();
-  const bucket = getSentMessageBucket(cfg);
+  const bucket = getSentMessageBucket(cfg, owner);
   const { store } = bucket;
   let entry = store.get(scopeKey);
   if (!entry) {
@@ -159,10 +165,11 @@ export function wasSentByBot(
   chatId: number | string,
   messageId: number,
   cfg?: SentMessageConfig,
+  owner?: SentMessageOwner,
 ): boolean {
   const scopeKey = String(chatId);
   const idKey = String(messageId);
-  const store = getSentMessages(cfg);
+  const store = getSentMessages(cfg, owner);
   const entry = store.get(scopeKey);
   if (!entry) {
     return false;

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -247,7 +247,10 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
     }
     return "telegram:approval";
   }
-  const threadSpec = msg ? resolveTelegramMessageThreadSpec(msg) : undefined;
+  // Raw durable-ingress fixtures and malformed updates can carry a partial
+  // message. Treat missing chat identity as an unknown lane instead of
+  // crashing before the queue records the update.
+  const threadSpec = msg?.chat ? resolveTelegramMessageThreadSpec(msg) : undefined;
   const threadId =
     threadSpec?.scope === "dm"
       ? shouldUseTelegramDmThreadSession({

--- a/extensions/telegram/src/state-migrations.ts
+++ b/extensions/telegram/src/state-migrations.ts
@@ -4,10 +4,10 @@ import path from "node:path";
 import { listAgentIds } from "openclaw/plugin-sdk/agent-scope-runtime";
 import type { ChannelLegacyStateMigrationPlan } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { fileExists } from "openclaw/plugin-sdk/security-runtime";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-paths";
 import { isRecord, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveTelegramAccountOwnerAgentId } from "./account-owner.js";
 import { listTelegramAccountIds, resolveDefaultTelegramAccountId } from "./account-selection.js";
 import {
   listTelegramLegacyBotInfoCacheEntries,
@@ -93,9 +93,7 @@ function resolveTelegramLegacyStateOwnerAgentId(cfg: OpenClawConfig): string {
   const accountIds =
     configuredAccountIds.length > 0 ? configuredAccountIds : [resolveDefaultTelegramAccountId(cfg)];
   const ownerAgentIds = uniqueStrings(
-    accountIds.map(
-      (accountId) => resolveAgentRoute({ cfg, channel: "telegram", accountId }).agentId,
-    ),
+    accountIds.map((accountId) => resolveTelegramAccountOwnerAgentId({ cfg, accountId })),
   );
   if (ownerAgentIds.length === 1) {
     return ownerAgentIds[0]!;

--- a/extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts
+++ b/extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts
@@ -62,14 +62,9 @@ vi.mock("./telegram-media.runtime.js", async (importOriginal) => {
   };
 });
 
-vi.mock("./bot.agent.runtime.js", () => ({
-  resolveDefaultAgentId: vi.fn(() => "default"),
-}));
-
 vi.mock("./bot-handlers.agent.runtime.js", () => ({
   resolveAgentDir: vi.fn(() => "/tmp/agent"),
   resolveAgentWorkspaceDir: vi.fn(() => "/tmp/workspace"),
-  resolveDefaultAgentId: vi.fn(() => "default"),
   resolveDefaultModelForAgent: vi.fn(() => ({ provider: "openai", model: "gpt-test" })),
 }));
 

--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -599,6 +599,7 @@ describe("startTelegramWebhook", () => {
       {
         secret: TELEGRAM_SECRET,
         accountId: "opie",
+        ownerAgentId: "ops",
         config: cfg,
         runtime: { log: runtimeLog, error: vi.fn(), exit: vi.fn() },
         setStatus,
@@ -609,6 +610,7 @@ describe("startTelegramWebhook", () => {
           "createTelegramBot params",
         );
         expect(botParams.accountId).toBe("opie");
+        expect(botParams.ownerAgentId).toBe("ops");
         expect(requireRecord(botParams.config, "telegram config").bindings).toEqual([]);
         expect(botParams.telegramTransport).toBeDefined();
         const health = await fetch(`http://127.0.0.1:${port}/healthz`);

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -296,6 +296,7 @@ function resolveTelegramWebhookRateLimitKey(
 export async function startTelegramWebhook(opts: {
   token: string;
   accountId?: string;
+  ownerAgentId?: string;
   config?: OpenClawConfig;
   path?: string;
   port?: number;
@@ -360,6 +361,7 @@ export async function startTelegramWebhook(opts: {
     accountAbortSignal,
     config: opts.config,
     accountId: opts.accountId,
+    ownerAgentId: opts.ownerAgentId,
     telegramTransport,
   });
   const runShutdownPhase = async (


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram could fail to start in an explicit multi-agent installation even when the Telegram account had an unambiguous channel binding. Account-scoped message and topic caches still asked for a global default agent, so valid routing such as a wildcard Telegram binding to `main` raised `AgentSelectionRequiredError` before polling became ready.

## Why This Change Was Made

Telegram now resolves the account owner once at account startup and carries that immutable owner through polling, webhook, bot, message-context, outbound-context, topic-cache, and sent-message-cache paths. Conversation and topic sessions continue to use their independently routed agent; genuine account ownership ambiguity still fails closed before startup.

## User Impact

Explicit multi-agent Telegram installations start normally when each account has a clear binding. Multiple Telegram accounts can own separate cache scopes, while topic-bound conversations continue using their configured session agent without splitting the account-wide reply cache.

## Evidence

- `node scripts/run-vitest.mjs extensions/telegram/src/account-owner.test.ts extensions/telegram/src/channel.gateway.test.ts extensions/telegram/src/bot-handlers.message-context.runtime.test.ts extensions/telegram/src/message-topic-binding.test.ts extensions/telegram/src/send.test.ts` — 295 tests passed.
- Focused polling/webhook owner propagation — 2 tests passed.
- `node scripts/run-vitest.mjs extensions/telegram/src/monitor.test.ts -- -t 'passes configured webhookHost to webhook listener'` — passed.
- `node scripts/run-vitest.mjs extensions/telegram/src/state-migrations.test.ts extensions/telegram/src/action-runtime.test.ts` — 125 tests passed.
- `pnpm tsgo:extensions` — passed.
- Autoreview — no actionable findings.

Production growth is the explicit account-owner boundary and propagation needed to keep every account-scoped Telegram cache aligned with routing. Tests separately cover wildcard ownership, genuine ambiguity, divergent accounts, topic/session divergence, restart persistence, polling, and webhook propagation.
