### PR TITLE
chore(discord): split send behavior tests

### DIFF
--- a/extensions/discord/src/send.creates-thread.test.ts
+++ b/extensions/discord/src/send.creates-thread.test.ts
@@ -1,32 +1,25 @@
-import { ChannelType, MessageFlags, Routes } from "discord-api-types/v10";
+import { ChannelType, Routes } from "discord-api-types/v10";
 // Discord tests cover send.creates thread plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
-import { loadWebMediaRaw } from "openclaw/plugin-sdk/web-media";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { RateLimitError } from "./internal/discord.js";
 import { hasDiscordMessageCreateAmbiguity } from "./retry.js";
-import { makeDiscordRest } from "./send.test-harness.js";
+import {
+  makeDiscordRest,
+  readDiscordRequestBody,
+  readDiscordRequestPath,
+  type DiscordMockCallSource,
+} from "./send.test-harness.js";
 
 vi.mock("openclaw/plugin-sdk/web-media", async () => {
   const { discordWebMediaMockFactory } = await import("./send.test-harness.js");
   return discordWebMediaMockFactory();
 });
 
-let addRoleDiscord: typeof import("./send.js").addRoleDiscord;
-let banMemberDiscord: typeof import("./send.js").banMemberDiscord;
 let createThreadDiscord: typeof import("./send.js").createThreadDiscord;
 let discordOutbound: typeof import("./outbound-adapter.js").discordOutbound;
 let DiscordThreadInitialMessageError: typeof import("./send.js").DiscordThreadInitialMessageError;
-let listGuildEmojisDiscord: typeof import("./send.js").listGuildEmojisDiscord;
 let listThreadsDiscord: typeof import("./send.js").listThreadsDiscord;
-let reactMessageDiscord: typeof import("./send.js").reactMessageDiscord;
-let removeRoleDiscord: typeof import("./send.js").removeRoleDiscord;
 let sendMessageDiscord: typeof import("./send.js").sendMessageDiscord;
-let sendPollDiscord: typeof import("./send.js").sendPollDiscord;
-let sendStickerDiscord: typeof import("./send.js").sendStickerDiscord;
-let timeoutMemberDiscord: typeof import("./send.js").timeoutMemberDiscord;
-let uploadEmojiDiscord: typeof import("./send.js").uploadEmojiDiscord;
-let uploadStickerDiscord: typeof import("./send.js").uploadStickerDiscord;
 
 const DISCORD_TEST_CFG = {
   channels: {
@@ -42,40 +35,7 @@ function discordClientOpts(rest: ReturnType<typeof makeDiscordRest>["rest"]) {
   return { cfg: DISCORD_TEST_CFG, rest, token: "t" };
 }
 
-type MockCallSource = {
-  mock: {
-    calls: ArrayLike<ReadonlyArray<unknown>>;
-  };
-};
-
 const requireRecord = createRequireRecord("object", "expected-label");
-
-function mockArg(source: MockCallSource, callIndex: number, argIndex: number, label: string) {
-  const call = source.mock.calls[callIndex];
-  if (!call) {
-    throw new Error(`expected mock call: ${label}`);
-  }
-  return call[argIndex];
-}
-
-function requestOptions(source: MockCallSource, callIndex = 0) {
-  return requireRecord(
-    mockArg(source, callIndex, 1, `request options ${callIndex}`),
-    "request options",
-  );
-}
-
-function requestPath(source: MockCallSource, callIndex = 0) {
-  return mockArg(source, callIndex, 0, `request path ${callIndex}`);
-}
-
-function requestBody(source: MockCallSource, callIndex = 0) {
-  return requireRecord(requestOptions(source, callIndex).body, `request body ${callIndex}`);
-}
-
-function timerDelayAt(source: MockCallSource, callIndex = 0) {
-  return mockArg(source, callIndex, 1, `timer delay ${callIndex}`);
-}
 
 function createDiscordForumPayloadHarness(parentType: ChannelType = ChannelType.GuildForum) {
   const parentId = "700";
@@ -135,40 +95,12 @@ function createDiscordForumPayloadHarness(parentType: ChannelType = ChannelType.
   };
 }
 
-function createRateLimitError(
-  response: Response,
-  body: { message: string; retry_after: number; global: boolean },
-  request?: Request,
-): RateLimitError {
-  const fallbackRequest =
-    request ??
-    new Request("https://discord.com/api/v10/channels/789/messages", {
-      method: "POST",
-    });
-  const RateLimitErrorCtor = RateLimitError as unknown as new (
-    response: Response,
-    body: { message: string; retry_after: number; global: boolean },
-    request?: Request,
-  ) => RateLimitError;
-  return new RateLimitErrorCtor(response, body, fallbackRequest);
-}
-
 beforeAll(async () => {
   ({
-    addRoleDiscord,
-    banMemberDiscord,
     createThreadDiscord,
     DiscordThreadInitialMessageError,
-    listGuildEmojisDiscord,
     listThreadsDiscord,
-    reactMessageDiscord,
-    removeRoleDiscord,
     sendMessageDiscord,
-    sendPollDiscord,
-    sendStickerDiscord,
-    timeoutMemberDiscord,
-    uploadEmojiDiscord,
-    uploadStickerDiscord,
   } = await import("./send.js"));
   ({ discordOutbound } = await import("./outbound-adapter.js"));
 });
@@ -286,8 +218,12 @@ describe("sendMessageDiscord", () => {
       discordClientOpts(rest),
     );
     expect(getMock).not.toHaveBeenCalled();
-    expect(requestPath(postMock as unknown as MockCallSource)).toBe(Routes.threads("chan1", "m1"));
-    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({ name: "thread" });
+    expect(readDiscordRequestPath(postMock as unknown as DiscordMockCallSource)).toBe(
+      Routes.threads("chan1", "m1"),
+    );
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource)).toEqual({
+      name: "thread",
+    });
   });
 
   it("creates forum threads with an initial message", async () => {
@@ -296,8 +232,10 @@ describe("sendMessageDiscord", () => {
     postMock.mockResolvedValue({ id: "t1" });
     await createThreadDiscord("chan1", { name: "thread" }, discordClientOpts(rest));
     expect(getMock).toHaveBeenCalledWith(Routes.channel("chan1"));
-    expect(requestPath(postMock as unknown as MockCallSource)).toBe(Routes.threads("chan1"));
-    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({
+    expect(readDiscordRequestPath(postMock as unknown as DiscordMockCallSource)).toBe(
+      Routes.threads("chan1"),
+    );
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource)).toEqual({
       name: "thread",
       message: { content: "thread" },
     });
@@ -312,14 +250,14 @@ describe("sendMessageDiscord", () => {
     await createThreadDiscord("chan1", { name: "thread", content }, discordClientOpts(rest));
 
     expect(postMock).toHaveBeenCalledTimes(2);
-    expect(requestBody(postMock as unknown as MockCallSource, 0)).toEqual({
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource, 0)).toEqual({
       name: "thread",
       message: { content: "a".repeat(2000) },
     });
-    expect(requestPath(postMock as unknown as MockCallSource, 1)).toBe(
+    expect(readDiscordRequestPath(postMock as unknown as DiscordMockCallSource, 1)).toBe(
       Routes.channelMessages("t1"),
     );
-    expect(requestBody(postMock as unknown as MockCallSource, 1)).toMatchObject({
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource, 1)).toMatchObject({
       content: "a",
       enforce_nonce: true,
     });
@@ -334,7 +272,7 @@ describe("sendMessageDiscord", () => {
     await createThreadDiscord("chan1", { name: "thread", content }, discordClientOpts(rest));
 
     expect(postMock).toHaveBeenCalledTimes(1);
-    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource)).toEqual({
       name: "thread",
       message: { content },
     });
@@ -415,7 +353,7 @@ describe("sendMessageDiscord", () => {
     });
     postMock.mockResolvedValue({ id: "t1" });
     await createThreadDiscord("chan1", { name: "thread" }, discordClientOpts(rest));
-    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource)).toEqual({
       name: "thread",
       auto_archive_duration: 1440,
       message: { content: "thread" },
@@ -430,7 +368,7 @@ describe("sendMessageDiscord", () => {
     });
     postMock.mockResolvedValue({ id: "t1" });
     await createThreadDiscord("chan1", { name: "thread" }, discordClientOpts(rest));
-    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource)).toEqual({
       name: "thread",
       auto_archive_duration: 10080,
       type: ChannelType.PublicThread,
@@ -449,7 +387,7 @@ describe("sendMessageDiscord", () => {
       { name: "thread", autoArchiveMinutes: 4320 },
       discordClientOpts(rest),
     );
-    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource)).toEqual({
       name: "thread",
       auto_archive_duration: 4320,
       message: { content: "thread" },
@@ -465,7 +403,7 @@ describe("sendMessageDiscord", () => {
       discordClientOpts(rest),
     );
     expect(getMock).not.toHaveBeenCalled();
-    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource)).toEqual({
       name: "thread",
       auto_archive_duration: 4320,
     });
@@ -480,8 +418,10 @@ describe("sendMessageDiscord", () => {
       { name: "thread", content: "initial forum post" },
       discordClientOpts(rest),
     );
-    expect(requestPath(postMock as unknown as MockCallSource)).toBe(Routes.threads("chan1"));
-    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({
+    expect(readDiscordRequestPath(postMock as unknown as DiscordMockCallSource)).toBe(
+      Routes.threads("chan1"),
+    );
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource)).toEqual({
       name: "thread",
       message: { content: "initial forum post" },
     });
@@ -496,8 +436,10 @@ describe("sendMessageDiscord", () => {
       { name: "tagged post", appliedTags: ["tag1", "tag2"] },
       discordClientOpts(rest),
     );
-    expect(requestPath(postMock as unknown as MockCallSource)).toBe(Routes.threads("chan1"));
-    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({
+    expect(readDiscordRequestPath(postMock as unknown as DiscordMockCallSource)).toBe(
+      Routes.threads("chan1"),
+    );
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource)).toEqual({
       name: "tagged post",
       message: { content: "tagged post" },
       applied_tags: ["tag1", "tag2"],
@@ -513,8 +455,12 @@ describe("sendMessageDiscord", () => {
       { name: "thread", appliedTags: ["tag1"] },
       discordClientOpts(rest),
     );
-    expect(requestPath(postMock as unknown as MockCallSource)).toBe(Routes.threads("chan1"));
-    expect("applied_tags" in requestBody(postMock as unknown as MockCallSource)).toBe(false);
+    expect(readDiscordRequestPath(postMock as unknown as DiscordMockCallSource)).toBe(
+      Routes.threads("chan1"),
+    );
+    expect(
+      "applied_tags" in readDiscordRequestBody(postMock as unknown as DiscordMockCallSource),
+    ).toBe(false);
   });
 
   it("falls back when channel lookup is unavailable", async () => {
@@ -522,9 +468,15 @@ describe("sendMessageDiscord", () => {
     getMock.mockRejectedValue(new Error("lookup failed"));
     postMock.mockResolvedValue({ id: "t1" });
     await createThreadDiscord("chan1", { name: "thread" }, discordClientOpts(rest));
-    expect(requestPath(postMock as unknown as MockCallSource)).toBe(Routes.threads("chan1"));
-    expect(requestBody(postMock as unknown as MockCallSource).name).toBe("thread");
-    expect(requestBody(postMock as unknown as MockCallSource).type).toBe(ChannelType.PublicThread);
+    expect(readDiscordRequestPath(postMock as unknown as DiscordMockCallSource)).toBe(
+      Routes.threads("chan1"),
+    );
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource).name).toBe(
+      "thread",
+    );
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource).type).toBe(
+      ChannelType.PublicThread,
+    );
   });
 
   it("respects explicit thread type for standalone threads", async () => {
@@ -537,9 +489,15 @@ describe("sendMessageDiscord", () => {
       discordClientOpts(rest),
     );
     expect(getMock).toHaveBeenCalledWith(Routes.channel("chan1"));
-    expect(requestPath(postMock as unknown as MockCallSource)).toBe(Routes.threads("chan1"));
-    expect(requestBody(postMock as unknown as MockCallSource).name).toBe("thread");
-    expect(requestBody(postMock as unknown as MockCallSource).type).toBe(ChannelType.PrivateThread);
+    expect(readDiscordRequestPath(postMock as unknown as DiscordMockCallSource)).toBe(
+      Routes.threads("chan1"),
+    );
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource).name).toBe(
+      "thread",
+    );
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource).type).toBe(
+      ChannelType.PrivateThread,
+    );
   });
 
   it("sends initial message for non-forum threads with content", async () => {
@@ -553,16 +511,20 @@ describe("sendMessageDiscord", () => {
     );
     expect(postMock).toHaveBeenCalledTimes(2);
     // First call: create thread
-    expect(requestPath(postMock as unknown as MockCallSource, 0)).toBe(Routes.threads("chan1"));
-    expect(requestBody(postMock as unknown as MockCallSource, 0).name).toBe("thread");
-    expect(requestBody(postMock as unknown as MockCallSource, 0).type).toBe(
+    expect(readDiscordRequestPath(postMock as unknown as DiscordMockCallSource, 0)).toBe(
+      Routes.threads("chan1"),
+    );
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource, 0).name).toBe(
+      "thread",
+    );
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource, 0).type).toBe(
       ChannelType.PublicThread,
     );
     // Second call: send message to thread
-    expect(requestPath(postMock as unknown as MockCallSource, 1)).toBe(
+    expect(readDiscordRequestPath(postMock as unknown as DiscordMockCallSource, 1)).toBe(
       Routes.channelMessages("t1"),
     );
-    expect(requestBody(postMock as unknown as MockCallSource, 1)).toMatchObject({
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource, 1)).toMatchObject({
       content: "Hello thread!",
       enforce_nonce: true,
     });
@@ -577,17 +539,17 @@ describe("sendMessageDiscord", () => {
     await createThreadDiscord("chan1", { name: "thread", content }, discordClientOpts(rest));
 
     expect(postMock).toHaveBeenCalledTimes(3);
-    expect(requestPath(postMock as unknown as MockCallSource, 1)).toBe(
+    expect(readDiscordRequestPath(postMock as unknown as DiscordMockCallSource, 1)).toBe(
       Routes.channelMessages("t1"),
     );
-    expect(requestBody(postMock as unknown as MockCallSource, 1)).toMatchObject({
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource, 1)).toMatchObject({
       content: "a".repeat(2000),
       enforce_nonce: true,
     });
-    expect(requestPath(postMock as unknown as MockCallSource, 2)).toBe(
+    expect(readDiscordRequestPath(postMock as unknown as DiscordMockCallSource, 2)).toBe(
       Routes.channelMessages("t1"),
     );
-    expect(requestBody(postMock as unknown as MockCallSource, 2)).toMatchObject({
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource, 2)).toMatchObject({
       content: "a",
       enforce_nonce: true,
     });
@@ -602,7 +564,9 @@ describe("sendMessageDiscord", () => {
     await createThreadDiscord("chan1", { name: "thread", content }, discordClientOpts(rest));
 
     expect(postMock).toHaveBeenCalledTimes(2);
-    expect(requestBody(postMock as unknown as MockCallSource, 1)).toMatchObject({ content });
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource, 1)).toMatchObject({
+      content,
+    });
   });
 
   it("reports delivered non-forum chunks when a later chunk fails", async () => {
@@ -693,9 +657,9 @@ describe("sendMessageDiscord", () => {
     );
 
     expect(postMock).toHaveBeenCalledTimes(4);
-    const firstAttempt = requestBody(postMock as unknown as MockCallSource, 1);
-    const retryAttempt = requestBody(postMock as unknown as MockCallSource, 2);
-    const nextChunk = requestBody(postMock as unknown as MockCallSource, 3);
+    const firstAttempt = readDiscordRequestBody(postMock as unknown as DiscordMockCallSource, 1);
+    const retryAttempt = readDiscordRequestBody(postMock as unknown as DiscordMockCallSource, 2);
+    const nextChunk = readDiscordRequestBody(postMock as unknown as DiscordMockCallSource, 3);
     expect(firstAttempt.enforce_nonce).toBe(true);
     expect(retryAttempt.nonce).toBe(firstAttempt.nonce);
     expect(nextChunk.enforce_nonce).toBe(true);
@@ -740,15 +704,17 @@ describe("sendMessageDiscord", () => {
     expect(getMock).not.toHaveBeenCalled();
     expect(postMock).toHaveBeenCalledTimes(2);
     // First call: create thread from message
-    expect(requestPath(postMock as unknown as MockCallSource, 0)).toBe(
+    expect(readDiscordRequestPath(postMock as unknown as DiscordMockCallSource, 0)).toBe(
       Routes.threads("chan1", "m1"),
     );
-    expect(requestBody(postMock as unknown as MockCallSource, 0)).toEqual({ name: "thread" });
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource, 0)).toEqual({
+      name: "thread",
+    });
     // Second call: send message to thread
-    expect(requestPath(postMock as unknown as MockCallSource, 1)).toBe(
+    expect(readDiscordRequestPath(postMock as unknown as DiscordMockCallSource, 1)).toBe(
       Routes.channelMessages("t1"),
     );
-    expect(requestBody(postMock as unknown as MockCallSource, 1)).toMatchObject({
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource, 1)).toMatchObject({
       content: "Discussion here",
       enforce_nonce: true,
     });
@@ -759,457 +725,5 @@ describe("sendMessageDiscord", () => {
     getMock.mockResolvedValue({ threads: [] });
     await listThreadsDiscord({ guildId: "g1" }, discordClientOpts(rest));
     expect(getMock).toHaveBeenCalledWith(Routes.guildActiveThreads("g1"));
-  });
-
-  it("times out a member", async () => {
-    const { rest, patchMock } = makeDiscordRest();
-    patchMock.mockResolvedValue({ id: "m1" });
-    await timeoutMemberDiscord(
-      { guildId: "g1", userId: "u1", durationMinutes: 10 },
-      discordClientOpts(rest),
-    );
-    expect(requestPath(patchMock as unknown as MockCallSource)).toBe(
-      Routes.guildMember("g1", "u1"),
-    );
-    expect(
-      requestBody(patchMock as unknown as MockCallSource).communication_disabled_until,
-    ).toBeTypeOf("string");
-  });
-
-  it("rejects timeout durations outside Date range", async () => {
-    const { rest, patchMock } = makeDiscordRest();
-
-    await expect(
-      timeoutMemberDiscord(
-        { guildId: "g1", userId: "u1", durationMinutes: 8_640_000_000_000_001 },
-        discordClientOpts(rest),
-      ),
-    ).rejects.toThrow("Discord timeout duration is outside the supported Date range");
-    expect(patchMock).not.toHaveBeenCalled();
-  });
-
-  it("rejects timeout durations that overflow from the current clock", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(8_640_000_000_000_000));
-    const { rest, patchMock } = makeDiscordRest();
-
-    await expect(
-      timeoutMemberDiscord(
-        { guildId: "g1", userId: "u1", durationMinutes: 1 },
-        discordClientOpts(rest),
-      ),
-    ).rejects.toThrow("Discord timeout duration is outside the supported Date range");
-    expect(patchMock).not.toHaveBeenCalled();
-  });
-
-  it("adds and removes roles", async () => {
-    const { rest, putMock, deleteMock } = makeDiscordRest();
-    putMock.mockResolvedValue({});
-    deleteMock.mockResolvedValue({});
-    await addRoleDiscord({ guildId: "g1", userId: "u1", roleId: "r1" }, discordClientOpts(rest));
-    await removeRoleDiscord({ guildId: "g1", userId: "u1", roleId: "r1" }, discordClientOpts(rest));
-    expect(putMock).toHaveBeenCalledWith(Routes.guildMemberRole("g1", "u1", "r1"));
-    expect(deleteMock).toHaveBeenCalledWith(Routes.guildMemberRole("g1", "u1", "r1"));
-  });
-
-  it("bans a member", async () => {
-    const { rest, putMock } = makeDiscordRest();
-    putMock.mockResolvedValue({});
-    await banMemberDiscord(
-      { guildId: "g1", userId: "u1", deleteMessageDays: 2 },
-      discordClientOpts(rest),
-    );
-    expect(requestPath(putMock as unknown as MockCallSource)).toBe(Routes.guildBan("g1", "u1"));
-    expect(requestBody(putMock as unknown as MockCallSource)).toEqual({ delete_message_days: 2 });
-  });
-});
-
-describe("listGuildEmojisDiscord", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("lists emojis for a guild", async () => {
-    const { rest, getMock } = makeDiscordRest();
-    getMock.mockResolvedValue([{ id: "e1", name: "party" }]);
-    await listGuildEmojisDiscord("g1", discordClientOpts(rest));
-    expect(getMock).toHaveBeenCalledWith(Routes.guildEmojis("g1"));
-  });
-});
-
-describe("uploadEmojiDiscord", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("uploads emoji assets", async () => {
-    const { rest, postMock } = makeDiscordRest();
-    postMock.mockResolvedValue({ id: "e1" });
-    await uploadEmojiDiscord(
-      {
-        guildId: "g1",
-        name: "party_blob",
-        mediaUrl: "file:///tmp/party.png",
-        roleIds: ["r1"],
-      },
-      discordClientOpts(rest),
-    );
-    expect(requestPath(postMock as unknown as MockCallSource)).toBe(Routes.guildEmojis("g1"));
-    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({
-      name: "party_blob",
-      image: "data:image/png;base64,aW1n",
-      roles: ["r1"],
-    });
-    expect(loadWebMediaRaw).toHaveBeenCalledWith("file:///tmp/party.png", 256 * 1024);
-  });
-});
-
-describe("uploadStickerDiscord", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("uploads sticker assets", async () => {
-    const { rest, postMock } = makeDiscordRest();
-    postMock.mockResolvedValue({ id: "s1" });
-    await uploadStickerDiscord(
-      {
-        guildId: "g1",
-        name: "openclaw_wave",
-        description: "OpenClaw waving",
-        tags: "👋",
-        mediaUrl: "file:///tmp/wave.png",
-      },
-      discordClientOpts(rest),
-    );
-    expect(requestPath(postMock as unknown as MockCallSource)).toBe(Routes.guildStickers("g1"));
-    const stickerBody = requestBody(postMock as unknown as MockCallSource);
-    expect(stickerBody.name).toBe("openclaw_wave");
-    expect(stickerBody.description).toBe("OpenClaw waving");
-    expect(stickerBody.tags).toBe("👋");
-    const files = stickerBody.files as Array<{ name?: string; contentType?: string }>;
-    expect(files).toHaveLength(1);
-    expect(files[0]?.name).toBe("asset.png");
-    expect(files[0]?.contentType).toBe("image/png");
-    expect(loadWebMediaRaw).toHaveBeenCalledWith("file:///tmp/wave.png", 512 * 1024);
-  });
-});
-
-describe("sendStickerDiscord", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("sends sticker payloads", async () => {
-    const { rest, postMock } = makeDiscordRest();
-    postMock.mockResolvedValue({ id: "msg1", channel_id: "789" });
-    const res = await sendStickerDiscord("channel:789", ["123"], {
-      cfg: DISCORD_TEST_CFG,
-      rest,
-      token: "t",
-      content: "hiya",
-    });
-    expect(res.messageId).toBe("msg1");
-    expect(res.channelId).toBe("789");
-    expect(res.receipt.parts[0]?.platformMessageId).toBe("msg1");
-    expect(res.receipt.parts[0]?.kind).toBe("card");
-    expect(requestPath(postMock as unknown as MockCallSource)).toBe(Routes.channelMessages("789"));
-    expect(requestBody(postMock as unknown as MockCallSource)).toMatchObject({
-      content: "hiya",
-      flags: MessageFlags.SuppressEmbeds,
-      sticker_ids: ["123"],
-      enforce_nonce: true,
-    });
-    expect(requestBody(postMock as unknown as MockCallSource).nonce).toMatch(/^[0-9a-f]{24}$/);
-  });
-
-  it("allows sticker content link embeds when disabled", async () => {
-    const { rest, postMock } = makeDiscordRest();
-    postMock.mockResolvedValue({ id: "msg1", channel_id: "789" });
-    await sendStickerDiscord("channel:789", ["123"], {
-      cfg: DISCORD_TEST_CFG,
-      rest,
-      token: "t",
-      content: "https://example.com",
-      suppressEmbeds: false,
-    });
-
-    expect(requestBody(postMock as unknown as MockCallSource)).toMatchObject({
-      content: "https://example.com",
-      sticker_ids: ["123"],
-      enforce_nonce: true,
-    });
-    expect(requestBody(postMock as unknown as MockCallSource).nonce).toMatch(/^[0-9a-f]{24}$/);
-  });
-
-  it("reuses a single nonce across a retried 502 for stickers", async () => {
-    const { rest, postMock } = makeDiscordRest();
-    postMock
-      .mockRejectedValueOnce(Object.assign(new Error("bad gateway"), { status: 502 }))
-      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" });
-    await sendStickerDiscord("channel:789", ["123"], {
-      cfg: DISCORD_TEST_CFG,
-      rest,
-      token: "t",
-      content: "hiya",
-      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
-    });
-    expect(postMock).toHaveBeenCalledTimes(2);
-    const firstNonce = requestBody(postMock as unknown as MockCallSource, 0).nonce;
-    const secondNonce = requestBody(postMock as unknown as MockCallSource, 1).nonce;
-    expect(firstNonce).toMatch(/^[0-9a-f]{24}$/);
-    expect(secondNonce).toBe(firstNonce);
-  });
-});
-
-describe("sendPollDiscord", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("sends polls with answers", async () => {
-    const { rest, postMock } = makeDiscordRest();
-    postMock.mockResolvedValue({ id: "msg1", channel_id: "789" });
-    const res = await sendPollDiscord(
-      "channel:789",
-      {
-        question: "Lunch?",
-        options: ["Pizza", "Sushi"],
-      },
-      {
-        cfg: DISCORD_TEST_CFG,
-        rest,
-        token: "t",
-      },
-    );
-    expect(res.messageId).toBe("msg1");
-    expect(res.channelId).toBe("789");
-    expect(res.receipt.parts[0]?.platformMessageId).toBe("msg1");
-    expect(res.receipt.parts[0]?.kind).toBe("card");
-    expect(requestPath(postMock as unknown as MockCallSource)).toBe(Routes.channelMessages("789"));
-    expect(requestBody(postMock as unknown as MockCallSource).flags).toBe(
-      MessageFlags.SuppressEmbeds,
-    );
-    expect(requestBody(postMock as unknown as MockCallSource).poll).toEqual({
-      question: { text: "Lunch?" },
-      answers: [{ poll_media: { text: "Pizza" } }, { poll_media: { text: "Sushi" } }],
-      duration: 24,
-      allow_multiselect: false,
-      layout_type: 1,
-    });
-    expect(requestBody(postMock as unknown as MockCallSource)).toMatchObject({
-      enforce_nonce: true,
-    });
-    expect(requestBody(postMock as unknown as MockCallSource).nonce).toMatch(/^[0-9a-f]{24}$/);
-  });
-
-  it("reuses a single nonce across a retried 502 for polls", async () => {
-    const { rest, postMock } = makeDiscordRest();
-    postMock
-      .mockRejectedValueOnce(Object.assign(new Error("bad gateway"), { status: 502 }))
-      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" });
-    await sendPollDiscord(
-      "channel:789",
-      {
-        question: "Lunch?",
-        options: ["Pizza", "Sushi"],
-      },
-      {
-        cfg: DISCORD_TEST_CFG,
-        rest,
-        token: "t",
-        retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
-      },
-    );
-    expect(postMock).toHaveBeenCalledTimes(2);
-    const firstNonce = requestBody(postMock as unknown as MockCallSource, 0).nonce;
-    const secondNonce = requestBody(postMock as unknown as MockCallSource, 1).nonce;
-    expect(firstNonce).toMatch(/^[0-9a-f]{24}$/);
-    expect(secondNonce).toBe(firstNonce);
-  });
-
-  it("combines silent and suppress-embeds flags for polls", async () => {
-    const { rest, postMock } = makeDiscordRest();
-    postMock.mockResolvedValue({ id: "msg1", channel_id: "789" });
-    await sendPollDiscord(
-      "channel:789",
-      {
-        question: "Lunch?",
-        options: ["Pizza", "Sushi"],
-      },
-      {
-        cfg: DISCORD_TEST_CFG,
-        rest,
-        token: "t",
-        content: "https://example.com",
-        silent: true,
-      },
-    );
-
-    expect(requestBody(postMock as unknown as MockCallSource).flags).toBe(
-      MessageFlags.SuppressEmbeds | MessageFlags.SuppressNotifications,
-    );
-  });
-});
-
-function createMockRateLimitError(retryAfter = 0.001): RateLimitError {
-  const request = new Request("https://discord.com/api/v10/channels/789/messages", {
-    method: "POST",
-  });
-  const response = new Response(null, {
-    status: 429,
-    headers: {
-      "X-RateLimit-Scope": "user",
-      "X-RateLimit-Bucket": "test-bucket",
-    },
-  });
-  return createRateLimitError(
-    response,
-    {
-      message: "You are being rate limited.",
-      retry_after: retryAfter,
-      global: false,
-    },
-    request,
-  );
-}
-
-describe("retry rate limits", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("retries on Discord rate limits", async () => {
-    const { rest, postMock } = makeDiscordRest();
-    const rateLimitError = createMockRateLimitError(0);
-
-    postMock
-      .mockRejectedValueOnce(rateLimitError)
-      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" });
-
-    const res = await sendMessageDiscord("channel:789", "hello", {
-      cfg: DISCORD_TEST_CFG,
-      rest,
-      token: "t",
-      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
-    });
-
-    expect(res.messageId).toBe("msg1");
-    expect(postMock).toHaveBeenCalledTimes(2);
-  });
-
-  it("uses retry_after delays when rate limited", async () => {
-    const setTimeoutSpy = vi.spyOn(global, "setTimeout");
-    try {
-      const { rest, postMock } = makeDiscordRest();
-      const rateLimitError = createMockRateLimitError(0.001);
-
-      postMock
-        .mockRejectedValueOnce(rateLimitError)
-        .mockResolvedValueOnce({ id: "msg1", channel_id: "789" });
-
-      const promise = sendMessageDiscord("channel:789", "hello", {
-        cfg: DISCORD_TEST_CFG,
-        rest,
-        token: "t",
-        retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 1000, jitter: 0 },
-      });
-
-      const result = await promise;
-      expect(result.messageId).toBe("msg1");
-      expect(result.channelId).toBe("789");
-      expect(result.receipt.primaryPlatformMessageId).toBe("msg1");
-      expect(result.receipt.platformMessageIds).toEqual(["msg1"]);
-      expect(timerDelayAt(setTimeoutSpy as unknown as MockCallSource)).toBe(1);
-    } finally {
-      setTimeoutSpy.mockRestore();
-    }
-  });
-
-  it("stops after max retry attempts", async () => {
-    const { rest, postMock } = makeDiscordRest();
-    const rateLimitError = createMockRateLimitError(0);
-
-    postMock.mockRejectedValue(rateLimitError);
-
-    await expect(
-      sendMessageDiscord("channel:789", "hello", {
-        cfg: DISCORD_TEST_CFG,
-        rest,
-        token: "t",
-        retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
-      }),
-    ).rejects.toBeInstanceOf(RateLimitError);
-    expect(postMock).toHaveBeenCalledTimes(2);
-  });
-
-  it("does not retry permanent non-rate-limit errors", async () => {
-    const { rest, postMock } = makeDiscordRest();
-    postMock.mockRejectedValueOnce(new Error("invalid request"));
-
-    await expect(
-      sendMessageDiscord("channel:789", "hello", discordClientOpts(rest)),
-    ).rejects.toThrow("invalid request");
-    expect(postMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("retries ambiguous network errors with one stable enforced nonce", async () => {
-    const { rest, postMock } = makeDiscordRest();
-    postMock
-      .mockRejectedValueOnce(new TypeError("fetch failed"))
-      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" });
-
-    const result = await sendMessageDiscord("channel:789", "hello", {
-      cfg: DISCORD_TEST_CFG,
-      rest,
-      token: "t",
-      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
-    });
-
-    expect(result.messageId).toBe("msg1");
-    expect(postMock).toHaveBeenCalledTimes(2);
-    const firstBody = requestBody(postMock as unknown as MockCallSource, 0);
-    const secondBody = requestBody(postMock as unknown as MockCallSource, 1);
-    expect(firstBody.enforce_nonce).toBe(true);
-    expect(secondBody.nonce).toBe(firstBody.nonce);
-  });
-
-  it("retries reactions on rate limits", async () => {
-    const { rest, putMock } = makeDiscordRest();
-    const rateLimitError = createMockRateLimitError(0);
-
-    putMock.mockRejectedValueOnce(rateLimitError).mockResolvedValueOnce(undefined);
-
-    const res = await reactMessageDiscord("chan1", "msg1", "ok", {
-      cfg: DISCORD_TEST_CFG,
-      rest,
-      token: "t",
-      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
-    });
-
-    expect(res.ok).toBe(true);
-    expect(putMock).toHaveBeenCalledTimes(2);
-  });
-
-  it("retries media upload without duplicating overflow text", async () => {
-    const { rest, postMock } = makeDiscordRest();
-    const rateLimitError = createMockRateLimitError(0);
-    const text = "a".repeat(2005);
-
-    postMock
-      .mockRejectedValueOnce(rateLimitError)
-      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" })
-      .mockResolvedValueOnce({ id: "msg2", channel_id: "789" });
-
-    const res = await sendMessageDiscord("channel:789", text, {
-      cfg: DISCORD_TEST_CFG,
-      rest,
-      token: "t",
-      mediaUrl: "https://example.com/photo.jpg",
-      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
-    });
-
-    expect(res.messageId).toBe("msg1");
-    expect(postMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/extensions/discord/src/send.emojis-stickers.test.ts
+++ b/extensions/discord/src/send.emojis-stickers.test.ts
@@ -1,0 +1,114 @@
+import { Routes } from "discord-api-types/v10";
+import { loadWebMediaRaw } from "openclaw/plugin-sdk/web-media";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  makeDiscordRest,
+  readDiscordRequestBody,
+  readDiscordRequestPath,
+  type DiscordMockCallSource,
+} from "./send.test-harness.js";
+
+vi.mock("openclaw/plugin-sdk/web-media", async () => {
+  const { discordWebMediaMockFactory } = await import("./send.test-harness.js");
+  return discordWebMediaMockFactory();
+});
+
+let listGuildEmojisDiscord: typeof import("./send.emojis-stickers.js").listGuildEmojisDiscord;
+let uploadEmojiDiscord: typeof import("./send.emojis-stickers.js").uploadEmojiDiscord;
+let uploadStickerDiscord: typeof import("./send.emojis-stickers.js").uploadStickerDiscord;
+
+const DISCORD_TEST_CFG = {
+  channels: {
+    discord: {
+      accounts: {
+        default: {},
+      },
+    },
+  },
+};
+
+function discordClientOpts(rest: ReturnType<typeof makeDiscordRest>["rest"]) {
+  return { cfg: DISCORD_TEST_CFG, rest, token: "t" };
+}
+
+beforeAll(async () => {
+  ({ listGuildEmojisDiscord, uploadEmojiDiscord, uploadStickerDiscord } =
+    await import("./send.emojis-stickers.js"));
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterAll(() => {
+  vi.doUnmock("openclaw/plugin-sdk/web-media");
+});
+
+describe("listGuildEmojisDiscord", () => {
+  it("lists emojis for a guild", async () => {
+    const { rest, getMock } = makeDiscordRest();
+    getMock.mockResolvedValue([{ id: "e1", name: "party" }]);
+
+    await listGuildEmojisDiscord("g1", discordClientOpts(rest));
+
+    expect(getMock).toHaveBeenCalledWith(Routes.guildEmojis("g1"));
+  });
+});
+
+describe("uploadEmojiDiscord", () => {
+  it("uploads emoji assets", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock.mockResolvedValue({ id: "e1" });
+
+    await uploadEmojiDiscord(
+      {
+        guildId: "g1",
+        name: "party_blob",
+        mediaUrl: "file:///tmp/party.png",
+        roleIds: ["r1"],
+      },
+      discordClientOpts(rest),
+    );
+
+    expect(readDiscordRequestPath(postMock as unknown as DiscordMockCallSource)).toBe(
+      Routes.guildEmojis("g1"),
+    );
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource)).toEqual({
+      name: "party_blob",
+      image: "data:image/png;base64,aW1n",
+      roles: ["r1"],
+    });
+    expect(loadWebMediaRaw).toHaveBeenCalledWith("file:///tmp/party.png", 256 * 1024);
+  });
+});
+
+describe("uploadStickerDiscord", () => {
+  it("uploads sticker assets", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock.mockResolvedValue({ id: "s1" });
+
+    await uploadStickerDiscord(
+      {
+        guildId: "g1",
+        name: "openclaw_wave",
+        description: "OpenClaw waving",
+        tags: "👋",
+        mediaUrl: "file:///tmp/wave.png",
+      },
+      discordClientOpts(rest),
+    );
+
+    expect(readDiscordRequestPath(postMock as unknown as DiscordMockCallSource)).toBe(
+      Routes.guildStickers("g1"),
+    );
+    const stickerBody = readDiscordRequestBody(postMock as unknown as DiscordMockCallSource);
+    expect(stickerBody.name).toBe("openclaw_wave");
+    expect(stickerBody.description).toBe("OpenClaw waving");
+    expect(stickerBody.tags).toBe("👋");
+    const files = stickerBody.files as Array<{ name?: string; contentType?: string }>;
+    expect(files).toHaveLength(1);
+    expect(files[0]?.name).toBe("asset.png");
+    expect(files[0]?.contentType).toBe("image/png");
+    expect(loadWebMediaRaw).toHaveBeenCalledWith("file:///tmp/wave.png", 512 * 1024);
+  });
+});

--- a/extensions/discord/src/send.guild-actions.test.ts
+++ b/extensions/discord/src/send.guild-actions.test.ts
@@ -1,0 +1,107 @@
+import { Routes } from "discord-api-types/v10";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  addRoleDiscord,
+  banMemberDiscord,
+  removeRoleDiscord,
+  timeoutMemberDiscord,
+} from "./send.guild.js";
+import {
+  makeDiscordRest,
+  readDiscordRequestBody,
+  readDiscordRequestPath,
+  type DiscordMockCallSource,
+} from "./send.test-harness.js";
+
+const DISCORD_TEST_CFG = {
+  channels: {
+    discord: {
+      accounts: {
+        default: {},
+      },
+    },
+  },
+};
+
+function discordClientOpts(rest: ReturnType<typeof makeDiscordRest>["rest"]) {
+  return { cfg: DISCORD_TEST_CFG, rest, token: "t" };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("Discord guild member actions", () => {
+  it("times out a member", async () => {
+    const { rest, patchMock } = makeDiscordRest();
+    patchMock.mockResolvedValue({ id: "m1" });
+
+    await timeoutMemberDiscord(
+      { guildId: "g1", userId: "u1", durationMinutes: 10 },
+      discordClientOpts(rest),
+    );
+
+    expect(readDiscordRequestPath(patchMock as unknown as DiscordMockCallSource)).toBe(
+      Routes.guildMember("g1", "u1"),
+    );
+    expect(
+      readDiscordRequestBody(patchMock as unknown as DiscordMockCallSource)
+        .communication_disabled_until,
+    ).toBeTypeOf("string");
+  });
+
+  it("rejects timeout durations outside Date range", async () => {
+    const { rest, patchMock } = makeDiscordRest();
+
+    await expect(
+      timeoutMemberDiscord(
+        { guildId: "g1", userId: "u1", durationMinutes: 8_640_000_000_000_001 },
+        discordClientOpts(rest),
+      ),
+    ).rejects.toThrow("Discord timeout duration is outside the supported Date range");
+    expect(patchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects timeout durations that overflow from the current clock", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(8_640_000_000_000_000));
+    const { rest, patchMock } = makeDiscordRest();
+
+    await expect(
+      timeoutMemberDiscord(
+        { guildId: "g1", userId: "u1", durationMinutes: 1 },
+        discordClientOpts(rest),
+      ),
+    ).rejects.toThrow("Discord timeout duration is outside the supported Date range");
+    expect(patchMock).not.toHaveBeenCalled();
+  });
+
+  it("adds and removes roles", async () => {
+    const { rest, putMock, deleteMock } = makeDiscordRest();
+    putMock.mockResolvedValue({});
+    deleteMock.mockResolvedValue({});
+
+    await addRoleDiscord({ guildId: "g1", userId: "u1", roleId: "r1" }, discordClientOpts(rest));
+    await removeRoleDiscord({ guildId: "g1", userId: "u1", roleId: "r1" }, discordClientOpts(rest));
+
+    expect(putMock).toHaveBeenCalledWith(Routes.guildMemberRole("g1", "u1", "r1"));
+    expect(deleteMock).toHaveBeenCalledWith(Routes.guildMemberRole("g1", "u1", "r1"));
+  });
+
+  it("bans a member", async () => {
+    const { rest, putMock } = makeDiscordRest();
+    putMock.mockResolvedValue({});
+
+    await banMemberDiscord(
+      { guildId: "g1", userId: "u1", deleteMessageDays: 2 },
+      discordClientOpts(rest),
+    );
+
+    expect(readDiscordRequestPath(putMock as unknown as DiscordMockCallSource)).toBe(
+      Routes.guildBan("g1", "u1"),
+    );
+    expect(readDiscordRequestBody(putMock as unknown as DiscordMockCallSource)).toEqual({
+      delete_message_days: 2,
+    });
+  });
+});

--- a/extensions/discord/src/send.retry-integration.test.ts
+++ b/extensions/discord/src/send.retry-integration.test.ts
@@ -1,0 +1,200 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { RateLimitError } from "./internal/discord.js";
+import {
+  makeDiscordRest,
+  readDiscordRequestBody,
+  readMockTimerDelay,
+  type DiscordMockCallSource,
+} from "./send.test-harness.js";
+
+vi.mock("openclaw/plugin-sdk/web-media", async () => {
+  const { discordWebMediaMockFactory } = await import("./send.test-harness.js");
+  return discordWebMediaMockFactory();
+});
+
+let reactMessageDiscord: typeof import("./send.reactions.js").reactMessageDiscord;
+let sendMessageDiscord: typeof import("./send.outbound.js").sendMessageDiscord;
+
+const DISCORD_TEST_CFG = {
+  channels: {
+    discord: {
+      accounts: {
+        default: {},
+      },
+    },
+  },
+};
+
+function discordClientOpts(rest: ReturnType<typeof makeDiscordRest>["rest"]) {
+  return { cfg: DISCORD_TEST_CFG, rest, token: "t" };
+}
+
+function createMockRateLimitError(retryAfter = 0.001): RateLimitError {
+  const request = new Request("https://discord.com/api/v10/channels/789/messages", {
+    method: "POST",
+  });
+  const response = new Response(null, {
+    status: 429,
+    headers: {
+      "X-RateLimit-Scope": "user",
+      "X-RateLimit-Bucket": "test-bucket",
+    },
+  });
+  const RateLimitErrorCtor = RateLimitError as unknown as new (
+    response: Response,
+    body: { message: string; retry_after: number; global: boolean },
+    request?: Request,
+  ) => RateLimitError;
+  return new RateLimitErrorCtor(
+    response,
+    {
+      message: "You are being rate limited.",
+      retry_after: retryAfter,
+      global: false,
+    },
+    request,
+  );
+}
+
+beforeAll(async () => {
+  ({ sendMessageDiscord } = await import("./send.outbound.js"));
+  ({ reactMessageDiscord } = await import("./send.reactions.js"));
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterAll(() => {
+  vi.doUnmock("openclaw/plugin-sdk/web-media");
+});
+
+describe("Discord send retry integration", () => {
+  it("retries on Discord rate limits", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    const rateLimitError = createMockRateLimitError(0);
+    postMock
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" });
+
+    const result = await sendMessageDiscord("channel:789", "hello", {
+      cfg: DISCORD_TEST_CFG,
+      rest,
+      token: "t",
+      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+    });
+
+    expect(result.messageId).toBe("msg1");
+    expect(postMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses retry_after delays when rate limited", async () => {
+    const setTimeoutSpy = vi.spyOn(global, "setTimeout");
+    const { rest, postMock } = makeDiscordRest();
+    const rateLimitError = createMockRateLimitError(0.001);
+    postMock
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" });
+
+    const result = await sendMessageDiscord("channel:789", "hello", {
+      cfg: DISCORD_TEST_CFG,
+      rest,
+      token: "t",
+      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 1000, jitter: 0 },
+    });
+
+    expect(result.messageId).toBe("msg1");
+    expect(result.channelId).toBe("789");
+    expect(result.receipt.primaryPlatformMessageId).toBe("msg1");
+    expect(result.receipt.platformMessageIds).toEqual(["msg1"]);
+    expect(readMockTimerDelay(setTimeoutSpy as unknown as DiscordMockCallSource)).toBe(1);
+  });
+
+  it("stops after max retry attempts", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    const rateLimitError = createMockRateLimitError(0);
+    postMock.mockRejectedValue(rateLimitError);
+
+    await expect(
+      sendMessageDiscord("channel:789", "hello", {
+        cfg: DISCORD_TEST_CFG,
+        rest,
+        token: "t",
+        retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+      }),
+    ).rejects.toBeInstanceOf(RateLimitError);
+    expect(postMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry permanent non-rate-limit errors", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock.mockRejectedValueOnce(new Error("invalid request"));
+
+    await expect(
+      sendMessageDiscord("channel:789", "hello", discordClientOpts(rest)),
+    ).rejects.toThrow("invalid request");
+    expect(postMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries ambiguous network errors with one stable enforced nonce", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" });
+
+    const result = await sendMessageDiscord("channel:789", "hello", {
+      cfg: DISCORD_TEST_CFG,
+      rest,
+      token: "t",
+      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+    });
+
+    expect(result.messageId).toBe("msg1");
+    expect(postMock).toHaveBeenCalledTimes(2);
+    const firstBody = readDiscordRequestBody(postMock as unknown as DiscordMockCallSource, 0);
+    const secondBody = readDiscordRequestBody(postMock as unknown as DiscordMockCallSource, 1);
+    expect(firstBody.enforce_nonce).toBe(true);
+    expect(secondBody.nonce).toBe(firstBody.nonce);
+  });
+
+  it("retries reactions on rate limits", async () => {
+    const { rest, putMock } = makeDiscordRest();
+    const rateLimitError = createMockRateLimitError(0);
+    putMock.mockRejectedValueOnce(rateLimitError).mockResolvedValueOnce(undefined);
+
+    const result = await reactMessageDiscord("chan1", "msg1", "ok", {
+      cfg: DISCORD_TEST_CFG,
+      rest,
+      token: "t",
+      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(putMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries media upload without duplicating overflow text", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    const rateLimitError = createMockRateLimitError(0);
+    const text = "a".repeat(2005);
+    postMock
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" })
+      .mockResolvedValueOnce({ id: "msg2", channel_id: "789" });
+
+    const result = await sendMessageDiscord("channel:789", text, {
+      cfg: DISCORD_TEST_CFG,
+      rest,
+      token: "t",
+      mediaUrl: "https://example.com/photo.jpg",
+      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+    });
+
+    expect(result.messageId).toBe("msg1");
+    expect(postMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/extensions/discord/src/send.structured.test.ts
+++ b/extensions/discord/src/send.structured.test.ts
@@ -1,0 +1,204 @@
+import { MessageFlags, Routes } from "discord-api-types/v10";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { sendPollDiscord, sendStickerDiscord } from "./send.outbound.js";
+import {
+  makeDiscordRest,
+  readDiscordRequestBody,
+  readDiscordRequestPath,
+  type DiscordMockCallSource,
+} from "./send.test-harness.js";
+
+const DISCORD_TEST_CFG = {
+  channels: {
+    discord: {
+      accounts: {
+        default: {},
+      },
+    },
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("sendStickerDiscord", () => {
+  it("sends sticker payloads", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock.mockResolvedValue({ id: "msg1", channel_id: "789" });
+
+    const result = await sendStickerDiscord("channel:789", ["123"], {
+      cfg: DISCORD_TEST_CFG,
+      rest,
+      token: "t",
+      content: "hiya",
+    });
+
+    expect(result.messageId).toBe("msg1");
+    expect(result.channelId).toBe("789");
+    expect(result.receipt.parts[0]?.platformMessageId).toBe("msg1");
+    expect(result.receipt.parts[0]?.kind).toBe("card");
+    expect(readDiscordRequestPath(postMock as unknown as DiscordMockCallSource)).toBe(
+      Routes.channelMessages("789"),
+    );
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource)).toMatchObject({
+      content: "hiya",
+      flags: MessageFlags.SuppressEmbeds,
+      sticker_ids: ["123"],
+      enforce_nonce: true,
+    });
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource).nonce).toMatch(
+      /^[0-9a-f]{24}$/,
+    );
+  });
+
+  it("allows sticker content link embeds when disabled", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock.mockResolvedValue({ id: "msg1", channel_id: "789" });
+
+    await sendStickerDiscord("channel:789", ["123"], {
+      cfg: DISCORD_TEST_CFG,
+      rest,
+      token: "t",
+      content: "https://example.com",
+      suppressEmbeds: false,
+    });
+
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource)).toMatchObject({
+      content: "https://example.com",
+      sticker_ids: ["123"],
+      enforce_nonce: true,
+    });
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource).nonce).toMatch(
+      /^[0-9a-f]{24}$/,
+    );
+  });
+
+  it("reuses a single nonce across a retried 502 for stickers", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock
+      .mockRejectedValueOnce(Object.assign(new Error("bad gateway"), { status: 502 }))
+      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" });
+
+    await sendStickerDiscord("channel:789", ["123"], {
+      cfg: DISCORD_TEST_CFG,
+      rest,
+      token: "t",
+      content: "hiya",
+      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+    });
+
+    expect(postMock).toHaveBeenCalledTimes(2);
+    const firstNonce = readDiscordRequestBody(
+      postMock as unknown as DiscordMockCallSource,
+      0,
+    ).nonce;
+    const secondNonce = readDiscordRequestBody(
+      postMock as unknown as DiscordMockCallSource,
+      1,
+    ).nonce;
+    expect(firstNonce).toMatch(/^[0-9a-f]{24}$/);
+    expect(secondNonce).toBe(firstNonce);
+  });
+});
+
+describe("sendPollDiscord", () => {
+  it("sends polls with answers", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock.mockResolvedValue({ id: "msg1", channel_id: "789" });
+
+    const result = await sendPollDiscord(
+      "channel:789",
+      {
+        question: "Lunch?",
+        options: ["Pizza", "Sushi"],
+      },
+      {
+        cfg: DISCORD_TEST_CFG,
+        rest,
+        token: "t",
+      },
+    );
+
+    expect(result.messageId).toBe("msg1");
+    expect(result.channelId).toBe("789");
+    expect(result.receipt.parts[0]?.platformMessageId).toBe("msg1");
+    expect(result.receipt.parts[0]?.kind).toBe("card");
+    expect(readDiscordRequestPath(postMock as unknown as DiscordMockCallSource)).toBe(
+      Routes.channelMessages("789"),
+    );
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource).flags).toBe(
+      MessageFlags.SuppressEmbeds,
+    );
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource).poll).toEqual({
+      question: { text: "Lunch?" },
+      answers: [{ poll_media: { text: "Pizza" } }, { poll_media: { text: "Sushi" } }],
+      duration: 24,
+      allow_multiselect: false,
+      layout_type: 1,
+    });
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource)).toMatchObject({
+      enforce_nonce: true,
+    });
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource).nonce).toMatch(
+      /^[0-9a-f]{24}$/,
+    );
+  });
+
+  it("reuses a single nonce across a retried 502 for polls", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock
+      .mockRejectedValueOnce(Object.assign(new Error("bad gateway"), { status: 502 }))
+      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" });
+
+    await sendPollDiscord(
+      "channel:789",
+      {
+        question: "Lunch?",
+        options: ["Pizza", "Sushi"],
+      },
+      {
+        cfg: DISCORD_TEST_CFG,
+        rest,
+        token: "t",
+        retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+      },
+    );
+
+    expect(postMock).toHaveBeenCalledTimes(2);
+    const firstNonce = readDiscordRequestBody(
+      postMock as unknown as DiscordMockCallSource,
+      0,
+    ).nonce;
+    const secondNonce = readDiscordRequestBody(
+      postMock as unknown as DiscordMockCallSource,
+      1,
+    ).nonce;
+    expect(firstNonce).toMatch(/^[0-9a-f]{24}$/);
+    expect(secondNonce).toBe(firstNonce);
+  });
+
+  it("combines silent and suppress-embeds flags for polls", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock.mockResolvedValue({ id: "msg1", channel_id: "789" });
+
+    await sendPollDiscord(
+      "channel:789",
+      {
+        question: "Lunch?",
+        options: ["Pizza", "Sushi"],
+      },
+      {
+        cfg: DISCORD_TEST_CFG,
+        rest,
+        token: "t",
+        content: "https://example.com",
+        silent: true,
+      },
+    );
+
+    expect(readDiscordRequestBody(postMock as unknown as DiscordMockCallSource).flags).toBe(
+      MessageFlags.SuppressEmbeds | MessageFlags.SuppressNotifications,
+    );
+  });
+});

--- a/extensions/discord/src/send.test-harness.ts
+++ b/extensions/discord/src/send.test-harness.ts
@@ -1,6 +1,7 @@
 // Discord plugin module implements send harness behavior.
 import { createServer } from "node:http";
 import type { MockFn } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { vi } from "vitest";
 import { RequestClient } from "./internal/discord.js";
 
@@ -24,6 +25,43 @@ type DiscordLoopbackRequest = {
   method: string | undefined;
   path: string | undefined;
 };
+
+export type DiscordMockCallSource = {
+  mock: {
+    calls: ArrayLike<ReadonlyArray<unknown>>;
+  };
+};
+
+const requireRecord = createRequireRecord("object", "expected-label");
+
+function readMockArg(
+  source: DiscordMockCallSource,
+  callIndex: number,
+  argIndex: number,
+  label: string,
+) {
+  const call = source.mock.calls[callIndex];
+  if (!call) {
+    throw new Error(`expected mock call: ${label}`);
+  }
+  return call[argIndex];
+}
+
+export function readDiscordRequestPath(source: DiscordMockCallSource, callIndex = 0) {
+  return readMockArg(source, callIndex, 0, `request path ${callIndex}`);
+}
+
+export function readDiscordRequestBody(source: DiscordMockCallSource, callIndex = 0) {
+  const options = requireRecord(
+    readMockArg(source, callIndex, 1, `request options ${callIndex}`),
+    "request options",
+  );
+  return requireRecord(options.body, `request body ${callIndex}`);
+}
+
+export function readMockTimerDelay(source: DiscordMockCallSource, callIndex = 0) {
+  return readMockArg(source, callIndex, 1, `timer delay ${callIndex}`);
+}
 
 export async function createDiscordLoopbackRest(options?: {
   respond?: (request: DiscordLoopbackRequest) => unknown;


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI max-lines failure in the Discord send coverage, where unrelated thread, guild-action, asset, structured-message, and retry scenarios had accumulated in one oversized test module.

## Why This Change Was Made

The coverage is split along the production owner boundaries while retaining every assertion. Shared REST mock readers moved into the existing Discord send test harness so the focused suites do not duplicate parsing logic.

## User Impact

No production behavior changes. Discord send tests remain complete and can grow within focused modules without violating the repository line-count budget.

## Evidence

- Focused Discord suite: 5 files, 51 tests passed on Blacksmith Testbox.
- Targeted formatting and oxlint: clean.
- `check:test-types`: clean.
- `check:changed`: clean, including max-lines ratchet and extension type/lint gates.
- Autoreview: no accepted or actionable findings.
