### PR TITLE
fix(ci): isolate Discord retry coverage

### DIFF
--- a/extensions/discord/src/send.creates-thread.test.ts
+++ b/extensions/discord/src/send.creates-thread.test.ts
@@ -3,13 +3,11 @@ import { ChannelType, MessageFlags, Routes } from "discord-api-types/v10";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { loadWebMediaRaw } from "openclaw/plugin-sdk/web-media";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { RateLimitError } from "./internal/discord.js";
 import {
   makeDiscordRest,
+  type MockCallSource,
   requestBody,
   requestPath,
-  timerDelayAt,
-  type MockCallSource,
 } from "./send.test-harness.js";
 
 vi.mock("openclaw/plugin-sdk/web-media", async () => {
@@ -24,7 +22,6 @@ let discordOutbound: typeof import("./outbound-adapter.js").discordOutbound;
 let DiscordThreadInitialMessageError: typeof import("./send.js").DiscordThreadInitialMessageError;
 let listGuildEmojisDiscord: typeof import("./send.js").listGuildEmojisDiscord;
 let listThreadsDiscord: typeof import("./send.js").listThreadsDiscord;
-let reactMessageDiscord: typeof import("./send.js").reactMessageDiscord;
 let removeRoleDiscord: typeof import("./send.js").removeRoleDiscord;
 let sendMessageDiscord: typeof import("./send.js").sendMessageDiscord;
 let sendPollDiscord: typeof import("./send.js").sendPollDiscord;
@@ -107,24 +104,6 @@ function createDiscordForumPayloadHarness(parentType: ChannelType = ChannelType.
   };
 }
 
-function createRateLimitError(
-  response: Response,
-  body: { message: string; retry_after: number; global: boolean },
-  request?: Request,
-): RateLimitError {
-  const fallbackRequest =
-    request ??
-    new Request("https://discord.com/api/v10/channels/789/messages", {
-      method: "POST",
-    });
-  const RateLimitErrorCtor = RateLimitError as unknown as new (
-    response: Response,
-    body: { message: string; retry_after: number; global: boolean },
-    request?: Request,
-  ) => RateLimitError;
-  return new RateLimitErrorCtor(response, body, fallbackRequest);
-}
-
 beforeAll(async () => {
   ({
     addRoleDiscord,
@@ -133,7 +112,6 @@ beforeAll(async () => {
     DiscordThreadInitialMessageError,
     listGuildEmojisDiscord,
     listThreadsDiscord,
-    reactMessageDiscord,
     removeRoleDiscord,
     sendMessageDiscord,
     sendPollDiscord,
@@ -783,167 +761,5 @@ describe("sendPollDiscord", () => {
     expect(requestBody(postMock as unknown as MockCallSource).flags).toBe(
       MessageFlags.SuppressEmbeds | MessageFlags.SuppressNotifications,
     );
-  });
-});
-
-function createMockRateLimitError(retryAfter = 0.001): RateLimitError {
-  const request = new Request("https://discord.com/api/v10/channels/789/messages", {
-    method: "POST",
-  });
-  const response = new Response(null, {
-    status: 429,
-    headers: {
-      "X-RateLimit-Scope": "user",
-      "X-RateLimit-Bucket": "test-bucket",
-    },
-  });
-  return createRateLimitError(
-    response,
-    {
-      message: "You are being rate limited.",
-      retry_after: retryAfter,
-      global: false,
-    },
-    request,
-  );
-}
-
-describe("retry rate limits", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("retries on Discord rate limits", async () => {
-    const { rest, postMock } = makeDiscordRest();
-    const rateLimitError = createMockRateLimitError(0);
-
-    postMock
-      .mockRejectedValueOnce(rateLimitError)
-      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" });
-
-    const res = await sendMessageDiscord("channel:789", "hello", {
-      cfg: DISCORD_TEST_CFG,
-      rest,
-      token: "t",
-      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
-    });
-
-    expect(res.messageId).toBe("msg1");
-    expect(postMock).toHaveBeenCalledTimes(2);
-  });
-
-  it("uses retry_after delays when rate limited", async () => {
-    const setTimeoutSpy = vi.spyOn(global, "setTimeout");
-    try {
-      const { rest, postMock } = makeDiscordRest();
-      const rateLimitError = createMockRateLimitError(0.001);
-
-      postMock
-        .mockRejectedValueOnce(rateLimitError)
-        .mockResolvedValueOnce({ id: "msg1", channel_id: "789" });
-
-      const promise = sendMessageDiscord("channel:789", "hello", {
-        cfg: DISCORD_TEST_CFG,
-        rest,
-        token: "t",
-        retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 1000, jitter: 0 },
-      });
-
-      const result = await promise;
-      expect(result.messageId).toBe("msg1");
-      expect(result.channelId).toBe("789");
-      expect(result.receipt.primaryPlatformMessageId).toBe("msg1");
-      expect(result.receipt.platformMessageIds).toEqual(["msg1"]);
-      expect(timerDelayAt(setTimeoutSpy as unknown as MockCallSource)).toBe(1);
-    } finally {
-      setTimeoutSpy.mockRestore();
-    }
-  });
-
-  it("stops after max retry attempts", async () => {
-    const { rest, postMock } = makeDiscordRest();
-    const rateLimitError = createMockRateLimitError(0);
-
-    postMock.mockRejectedValue(rateLimitError);
-
-    await expect(
-      sendMessageDiscord("channel:789", "hello", {
-        cfg: DISCORD_TEST_CFG,
-        rest,
-        token: "t",
-        retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
-      }),
-    ).rejects.toBeInstanceOf(RateLimitError);
-    expect(postMock).toHaveBeenCalledTimes(2);
-  });
-
-  it("does not retry permanent non-rate-limit errors", async () => {
-    const { rest, postMock } = makeDiscordRest();
-    postMock.mockRejectedValueOnce(new Error("invalid request"));
-
-    await expect(
-      sendMessageDiscord("channel:789", "hello", discordClientOpts(rest)),
-    ).rejects.toThrow("invalid request");
-    expect(postMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("retries ambiguous network errors with one stable enforced nonce", async () => {
-    const { rest, postMock } = makeDiscordRest();
-    postMock
-      .mockRejectedValueOnce(new TypeError("fetch failed"))
-      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" });
-
-    const result = await sendMessageDiscord("channel:789", "hello", {
-      cfg: DISCORD_TEST_CFG,
-      rest,
-      token: "t",
-      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
-    });
-
-    expect(result.messageId).toBe("msg1");
-    expect(postMock).toHaveBeenCalledTimes(2);
-    const firstBody = requestBody(postMock as unknown as MockCallSource, 0);
-    const secondBody = requestBody(postMock as unknown as MockCallSource, 1);
-    expect(firstBody.enforce_nonce).toBe(true);
-    expect(secondBody.nonce).toBe(firstBody.nonce);
-  });
-
-  it("retries reactions on rate limits", async () => {
-    const { rest, putMock } = makeDiscordRest();
-    const rateLimitError = createMockRateLimitError(0);
-
-    putMock.mockRejectedValueOnce(rateLimitError).mockResolvedValueOnce(undefined);
-
-    const res = await reactMessageDiscord("chan1", "msg1", "ok", {
-      cfg: DISCORD_TEST_CFG,
-      rest,
-      token: "t",
-      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
-    });
-
-    expect(res.ok).toBe(true);
-    expect(putMock).toHaveBeenCalledTimes(2);
-  });
-
-  it("retries media upload without duplicating overflow text", async () => {
-    const { rest, postMock } = makeDiscordRest();
-    const rateLimitError = createMockRateLimitError(0);
-    const text = "a".repeat(2005);
-
-    postMock
-      .mockRejectedValueOnce(rateLimitError)
-      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" })
-      .mockResolvedValueOnce({ id: "msg2", channel_id: "789" });
-
-    const res = await sendMessageDiscord("channel:789", text, {
-      cfg: DISCORD_TEST_CFG,
-      rest,
-      token: "t",
-      mediaUrl: "https://example.com/photo.jpg",
-      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
-    });
-
-    expect(res.messageId).toBe("msg1");
-    expect(postMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/extensions/discord/src/send.retry.test.ts
+++ b/extensions/discord/src/send.retry.test.ts
@@ -1,0 +1,227 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { RateLimitError } from "./internal/discord.js";
+import {
+  makeDiscordRest,
+  type MockCallSource,
+  requestBody,
+  timerDelayAt,
+} from "./send.test-harness.js";
+
+vi.mock("openclaw/plugin-sdk/web-media", async () => {
+  const { discordWebMediaMockFactory } = await import("./send.test-harness.js");
+  return discordWebMediaMockFactory();
+});
+
+let reactMessageDiscord: typeof import("./send.js").reactMessageDiscord;
+let sendMessageDiscord: typeof import("./send.js").sendMessageDiscord;
+
+const DISCORD_TEST_CFG = {
+  channels: {
+    discord: {
+      accounts: {
+        default: {},
+      },
+    },
+  },
+};
+
+function discordClientOpts(rest: ReturnType<typeof makeDiscordRest>["rest"]) {
+  return { cfg: DISCORD_TEST_CFG, rest, token: "t" };
+}
+
+function createRateLimitError(
+  response: Response,
+  body: { message: string; retry_after: number; global: boolean },
+  request?: Request,
+): RateLimitError {
+  const fallbackRequest =
+    request ??
+    new Request("https://discord.com/api/v10/channels/789/messages", {
+      method: "POST",
+    });
+  const RateLimitErrorCtor = RateLimitError as unknown as new (
+    response: Response,
+    body: { message: string; retry_after: number; global: boolean },
+    request?: Request,
+  ) => RateLimitError;
+  return new RateLimitErrorCtor(response, body, fallbackRequest);
+}
+
+function createMockRateLimitError(retryAfter = 0.001): RateLimitError {
+  const request = new Request("https://discord.com/api/v10/channels/789/messages", {
+    method: "POST",
+  });
+  const response = new Response(null, {
+    status: 429,
+    headers: {
+      "X-RateLimit-Scope": "user",
+      "X-RateLimit-Bucket": "test-bucket",
+    },
+  });
+  return createRateLimitError(
+    response,
+    {
+      message: "You are being rate limited.",
+      retry_after: retryAfter,
+      global: false,
+    },
+    request,
+  );
+}
+
+beforeAll(async () => {
+  ({ reactMessageDiscord, sendMessageDiscord } = await import("./send.js"));
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+afterAll(() => {
+  vi.doUnmock("openclaw/plugin-sdk/web-media");
+});
+
+describe("retry rate limits", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("retries on Discord rate limits", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    const rateLimitError = createMockRateLimitError(0);
+
+    postMock
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" });
+
+    const res = await sendMessageDiscord("channel:789", "hello", {
+      cfg: DISCORD_TEST_CFG,
+      rest,
+      token: "t",
+      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+    });
+
+    expect(res.messageId).toBe("msg1");
+    expect(postMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses retry_after delays when rate limited", async () => {
+    const setTimeoutSpy = vi.spyOn(global, "setTimeout");
+    try {
+      const { rest, postMock } = makeDiscordRest();
+      const rateLimitError = createMockRateLimitError(0.001);
+
+      postMock
+        .mockRejectedValueOnce(rateLimitError)
+        .mockResolvedValueOnce({ id: "msg1", channel_id: "789" });
+
+      const promise = sendMessageDiscord("channel:789", "hello", {
+        cfg: DISCORD_TEST_CFG,
+        rest,
+        token: "t",
+        retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 1000, jitter: 0 },
+      });
+
+      const result = await promise;
+      expect(result.messageId).toBe("msg1");
+      expect(result.channelId).toBe("789");
+      expect(result.receipt.primaryPlatformMessageId).toBe("msg1");
+      expect(result.receipt.platformMessageIds).toEqual(["msg1"]);
+      expect(timerDelayAt(setTimeoutSpy as unknown as MockCallSource)).toBe(1);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
+  it("stops after max retry attempts", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    const rateLimitError = createMockRateLimitError(0);
+
+    postMock.mockRejectedValue(rateLimitError);
+
+    await expect(
+      sendMessageDiscord("channel:789", "hello", {
+        cfg: DISCORD_TEST_CFG,
+        rest,
+        token: "t",
+        retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+      }),
+    ).rejects.toBeInstanceOf(RateLimitError);
+    expect(postMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry permanent non-rate-limit errors", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock.mockRejectedValueOnce(new Error("invalid request"));
+
+    await expect(
+      sendMessageDiscord("channel:789", "hello", discordClientOpts(rest)),
+    ).rejects.toThrow("invalid request");
+    expect(postMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries ambiguous network errors with one stable enforced nonce", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" });
+
+    const result = await sendMessageDiscord("channel:789", "hello", {
+      cfg: DISCORD_TEST_CFG,
+      rest,
+      token: "t",
+      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+    });
+
+    expect(result.messageId).toBe("msg1");
+    expect(postMock).toHaveBeenCalledTimes(2);
+    const firstBody = requestBody(postMock as unknown as MockCallSource, 0);
+    const secondBody = requestBody(postMock as unknown as MockCallSource, 1);
+    expect(firstBody.enforce_nonce).toBe(true);
+    expect(secondBody.nonce).toBe(firstBody.nonce);
+  });
+
+  it("retries reactions on rate limits", async () => {
+    const { rest, putMock } = makeDiscordRest();
+    const rateLimitError = createMockRateLimitError(0);
+
+    putMock.mockRejectedValueOnce(rateLimitError).mockResolvedValueOnce(undefined);
+
+    const res = await reactMessageDiscord("chan1", "msg1", "ok", {
+      cfg: DISCORD_TEST_CFG,
+      rest,
+      token: "t",
+      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+    });
+
+    expect(res.ok).toBe(true);
+    expect(putMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries media upload without duplicating overflow text", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    const rateLimitError = createMockRateLimitError(0);
+    const text = "a".repeat(2005);
+
+    postMock
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" })
+      .mockResolvedValueOnce({ id: "msg2", channel_id: "789" });
+
+    const res = await sendMessageDiscord("channel:789", text, {
+      cfg: DISCORD_TEST_CFG,
+      rest,
+      token: "t",
+      mediaUrl: "https://example.com/photo.jpg",
+      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+    });
+
+    expect(res.messageId).toBe("msg1");
+    expect(postMock).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI maintenance problem where Discord retry coverage remained inside the thread-creation test file after the first max-lines repair, leaving unrelated test concerns coupled and reducing the file's remaining line-budget margin.

## Why This Change Was Made

Moves the seven existing retry tests and their retry-only setup into `send.retry.test.ts`. Assertions, retry configuration, timer checks, media mocking, and dynamic send imports are unchanged; production code, config, baselines, and changelog remain untouched.

## User Impact

No user-visible behavior changes. Discord send retry coverage remains identical while the test suite is easier to keep below the repository max-lines limit.

## Evidence

- `node scripts/run-vitest.mjs extensions/discord/src/send.creates-thread.test.ts extensions/discord/src/send.creates-thread.chunking.test.ts extensions/discord/src/send.retry.test.ts` - 3 files, 51 tests passed.
- `pnpm check:max-lines-ratchet` - passed with 918 grandfathered suppressions.
- `pnpm exec oxfmt --check extensions/discord/src/send.creates-thread.test.ts extensions/discord/src/send.retry.test.ts` - passed.
- `git diff --check origin/main...HEAD` - passed.
- `pnpm check:changed -- extensions/discord/src/send.creates-thread.test.ts extensions/discord/src/send.retry.test.ts` - all touched-surface guards passed through dead-code validation. The local typecheck then resolved stale shared `node_modules` with `string-width@4.2.3` and failed at `packages/terminal-core/src/ansi.ts(194,38)`; current source pins `string-width@8.2.2`, so this local result is non-authoritative dependency drift. No install was run in the Codex worktree; exact remote CI is required.
