### PR TITLE
feat(worker): add durable node launch adapter

### DIFF
--- a/docs/plan/runners.md
+++ b/docs/plan/runners.md
@@ -13,22 +13,22 @@ Proposal, revision 2. Supersedes revision 1 in place (2026-08-11, operator
 decision). Implementation in progress; update this table in every PR that
 advances a milestone.
 
-| #   | Milestone                                                  | Status      | PRs                                         |
-| --- | ---------------------------------------------------------- | ----------- | ------------------------------------------- |
-| 0   | This plan (revision 2)                                     | landed      | #122454                                     |
-| 1a  | Naming: session copy revert                                | landed      | #120667                                     |
-| 1b  | Naming: devices consolidation                              | landed      | #120689                                     |
-| 1c  | Cleanup: node-pairing → device-pairing merge               | landed      | #120726                                     |
-| 2   | `openclaw resume` + web Continue in terminal               | in progress | #120664, #122870                            |
-| 3   | `openclaw connect` one-paste onboarding + `/j/` join route | in progress | #120768, #122499                            |
-| 4   | Picker: grouping, placement, liveness, enrichment          | in progress | #120804, #122531, #122635, #122774, #122923 |
-| F   | Real-wire session boundary harness                         | landed      | #121212                                     |
-| 5   | Public worker ingress path                                 | landed      | #122578, #122643                            |
-| 6   | Node worker provider (device runners)                      | in progress | #122683, #122769, #122829, #122939, #123013 |
-| 7   | Bundle push consent + runner updates                       | not started | —                                           |
-| 8   | Stop-and-continue moves                                    | not started | —                                           |
-| 9   | Deletions (ssh sandbox, openshell, exec-host clones, …)    | not started | —                                           |
-| 10  | Cloud convergence (provisioners run `openclaw connect`)    | not started | —                                           |
+| #   | Milestone                                                  | Status      | PRs                                                  |
+| --- | ---------------------------------------------------------- | ----------- | ---------------------------------------------------- |
+| 0   | This plan (revision 2)                                     | landed      | #122454                                              |
+| 1a  | Naming: session copy revert                                | landed      | #120667                                              |
+| 1b  | Naming: devices consolidation                              | landed      | #120689                                              |
+| 1c  | Cleanup: node-pairing → device-pairing merge               | landed      | #120726                                              |
+| 2   | `openclaw resume` + web Continue in terminal               | in progress | #120664, #122870                                     |
+| 3   | `openclaw connect` one-paste onboarding + `/j/` join route | in progress | #120768, #122499                                     |
+| 4   | Picker: grouping, placement, liveness, enrichment          | in progress | #120804, #122531, #122635, #122774, #122923          |
+| F   | Real-wire session boundary harness                         | landed      | #121212                                              |
+| 5   | Public worker ingress path                                 | landed      | #122578, #122643                                     |
+| 6   | Node worker provider (device runners)                      | in progress | #122683, #122769, #122829, #122939, #123013, #123033 |
+| 7   | Bundle push consent + runner updates                       | not started | —                                                    |
+| 8   | Stop-and-continue moves                                    | not started | —                                                    |
+| 9   | Deletions (ssh sandbox, openshell, exec-host clones, …)    | not started | —                                                    |
+| 10  | Cloud convergence (provisioners run `openclaw connect`)    | not started | —                                                    |
 
 Revision history: revision 1 (2026-08-08) established the session/runner
 vocabulary, the naming rulings, and the milestone skeleton after a

--- a/src/gateway/worker-environments/device-provider.ts
+++ b/src/gateway/worker-environments/device-provider.ts
@@ -10,6 +10,7 @@ import type {
   NodeWorkerSupervisorNodeProof,
   NodeWorkerSupervisorTransport,
 } from "../node-registry-private.js";
+import { createNodeWorkerLaunchAdapter } from "./node-launch-adapter.js";
 import type { WorkerEnvironmentServiceContract } from "./service-contract.js";
 
 export const DEVICE_WORKER_PROVIDER_ID = "device";
@@ -61,6 +62,7 @@ function deviceLeaseId(deviceId: string, operationId: string): string {
 /** Core runtime for already-paired node hosts; pairing remains the durable trust owner. */
 export function createDeviceWorkerRuntime(options: DeviceWorkerRuntimeOptions) {
   let nodeTransport: NodeWorkerSupervisorTransport | undefined;
+  const launchAdapter = createNodeWorkerLaunchAdapter({ getTransport: () => nodeTransport });
   const findConnectedNode = async (deviceId: string) =>
     (await nodeTransport?.listCurrentNodes())?.find(
       (node) => node.nodeId === deviceId && isSessionCapableNode(node),
@@ -103,6 +105,7 @@ export function createDeviceWorkerRuntime(options: DeviceWorkerRuntimeOptions) {
   return {
     provider,
     isAvailable,
+    launchNodeWorker: launchAdapter.launch,
     bindNodeTransport: (transport: NodeWorkerSupervisorTransport) => {
       nodeTransport = transport;
     },

--- a/src/gateway/worker-environments/node-launch-adapter.test.ts
+++ b/src/gateway/worker-environments/node-launch-adapter.test.ts
@@ -1,0 +1,431 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  GATEWAY_CLIENT_IDS,
+  GATEWAY_CLIENT_MODES,
+} from "../../../packages/gateway-protocol/src/client-info.js";
+import {
+  WORKER_PROTOCOL_FEATURES,
+  WORKER_RPC_SET_VERSION,
+} from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
+import { NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE } from "../../infra/node-worker-supervisor-dialect.js";
+import {
+  nodeWorkerPlanHash,
+  type NodeWorkerLaunchInput,
+  type NodeWorkerSupervisorReceipt,
+} from "../../worker/node-supervisor-protocol.js";
+import type {
+  NodeWorkerSupervisorNodeProof,
+  NodeWorkerSupervisorTransport,
+} from "../node-registry-private.js";
+import { createNodeWorkerLaunchAdapter } from "./node-launch-adapter.js";
+
+const DEVICE_ID = "device-session-host";
+
+function nodeProof(connId = "conn-1"): NodeWorkerSupervisorNodeProof {
+  return {
+    nodeId: DEVICE_ID,
+    connId,
+    pairingIdentity: "identity-1",
+    pairingGeneration: "generation-1",
+    clientId: GATEWAY_CLIENT_IDS.NODE_HOST,
+    clientMode: GATEWAY_CLIENT_MODES.NODE,
+    protocolFeature: NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
+    commands: ["system.run"],
+  };
+}
+
+function launchInput(): NodeWorkerLaunchInput {
+  const bundleHash = "a".repeat(64);
+  return {
+    launchId: "turn-1",
+    gatewayNamespace: "gateway-1",
+    bundleHash,
+    placementGeneration: 4,
+    descriptor: {
+      version: 3,
+      connectionEndpoint: {
+        kind: "websocket",
+        url: "wss://gateway.example/__openclaw__/worker",
+      },
+      admission: {
+        environmentId: "environment-1",
+        credential: "worker-fixture-value",
+        sessionId: "session-1",
+        ownerEpoch: 3,
+        rpcSetVersion: WORKER_RPC_SET_VERSION,
+        handshake: {
+          bundleHash,
+          openclawVersion: "2026.8.1",
+          protocolFeatures: [...WORKER_PROTOCOL_FEATURES],
+        },
+      },
+      assignment: {
+        agentId: "agent-1",
+        operationalRunInstance: { instanceId: "instance-1", runId: "run-1" },
+        agentRuntimeIdentityToken: "signed-runtime-token",
+        runId: "run-1",
+        turnId: "turn-1",
+        prompt: "Inspect the workspace.",
+        suppressPromptTranscript: true,
+        workspaceDir: "/tmp/openclaw-worker/workspace",
+        modelRef: { provider: "provider-1", model: "model-1" },
+        inferenceOptions: {},
+        initialMessages: [],
+        transcript: { baseLeafId: null, nextSeq: 1 },
+        liveEvents: { ackedSeq: 0, nextSeq: 1 },
+        toolAuthority: { allowedToolNames: [] },
+      },
+    },
+  };
+}
+
+function receipt(
+  input: NodeWorkerLaunchInput,
+  state: NodeWorkerSupervisorReceipt["state"],
+): NodeWorkerSupervisorReceipt {
+  const identity = {
+    launchId: input.launchId,
+    planHash: nodeWorkerPlanHash(input),
+    environmentId: input.descriptor.admission.environmentId,
+    sessionId: input.descriptor.admission.sessionId,
+    ownerEpoch: input.descriptor.admission.ownerEpoch,
+    placementGeneration: input.placementGeneration,
+    runId: input.descriptor.assignment.runId,
+  };
+  if (state === "completed") {
+    return {
+      ...identity,
+      state,
+      resultJson: JSON.stringify({
+        status: "completed",
+        transcriptLeafId: "leaf-1",
+        transcriptNextSeq: 2,
+      }),
+    };
+  }
+  if (state === "failed" || state === "interrupted" || state === "cancelled") {
+    return { ...identity, state, errorText: `worker ${state}` };
+  }
+  return { ...identity, state };
+}
+
+function wire(payload: NodeWorkerSupervisorReceipt | null) {
+  return { ok: true, payloadJSON: JSON.stringify(payload) };
+}
+
+function transportWith(
+  invoke: NodeWorkerSupervisorTransport["invoke"],
+  listCurrentNodes: NodeWorkerSupervisorTransport["listCurrentNodes"] = async () => [nodeProof()],
+): NodeWorkerSupervisorTransport {
+  return { invoke, listCurrentNodes };
+}
+
+function launchRequest(input = launchInput()) {
+  return {
+    deviceId: DEVICE_ID,
+    input,
+    isDispatchAuthorized: () => true,
+    isCancellationAuthorized: () => true,
+    timeoutMs: 10_000,
+  };
+}
+
+describe("node worker launch adapter", () => {
+  it("launches once, polls status, and returns the exact completed receipt", async () => {
+    const input = launchInput();
+    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async (request) =>
+      request.command === "worker.supervisor.launch.v1"
+        ? wire(receipt(input, "running"))
+        : wire(receipt(input, "completed")),
+    );
+    const adapter = createNodeWorkerLaunchAdapter({
+      getTransport: () => transportWith(invoke),
+      sleep: async () => {},
+    });
+
+    await expect(adapter.launch(launchRequest(input))).resolves.toEqual(
+      receipt(input, "completed"),
+    );
+    expect(invoke.mock.calls.map(([request]) => request.command)).toEqual([
+      "worker.supervisor.launch.v1",
+      "worker.supervisor.status.v1",
+    ]);
+  });
+
+  it("reacquires the node and replays the identical launch after ambiguous disconnect", async () => {
+    const input = launchInput();
+    let launchCalls = 0;
+    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async (request) => {
+      if (request.command !== "worker.supervisor.launch.v1") {
+        throw new Error("unexpected status call");
+      }
+      launchCalls += 1;
+      request.onDispatchReady?.(`invoke-${launchCalls}`);
+      return launchCalls === 1
+        ? { ok: false, error: { code: "DISCONNECTED", message: "node disconnected" } }
+        : wire(receipt(input, "completed"));
+    });
+    let listCalls = 0;
+    const listCurrentNodes = vi.fn(async () => [nodeProof(`conn-${++listCalls}`)]);
+    const adapter = createNodeWorkerLaunchAdapter({
+      getTransport: () => transportWith(invoke, listCurrentNodes),
+      sleep: async () => {},
+    });
+
+    await expect(adapter.launch(launchRequest(input))).resolves.toEqual(
+      receipt(input, "completed"),
+    );
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(invoke.mock.calls[0]?.[0].params).toEqual(input);
+    expect(invoke.mock.calls[1]?.[0].params).toEqual(input);
+    expect(invoke.mock.calls[0]?.[0].node.connId).toBe("conn-1");
+    expect(invoke.mock.calls[1]?.[0].node.connId).toBe("conn-2");
+  });
+
+  it("snapshots the launch plan before asynchronous node discovery", async () => {
+    const input = launchInput();
+    const expectedInput = structuredClone(input);
+    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async (request) => {
+      expect(request.params).toEqual(expectedInput);
+      return wire(receipt(expectedInput, "completed"));
+    });
+    const listCurrentNodes = vi.fn(async () => {
+      input.descriptor.assignment.prompt = "mutated after launch call";
+      return [nodeProof()];
+    });
+    const adapter = createNodeWorkerLaunchAdapter({
+      getTransport: () => transportWith(invoke, listCurrentNodes),
+    });
+
+    await expect(adapter.launch(launchRequest(input))).resolves.toEqual(
+      receipt(expectedInput, "completed"),
+    );
+    expect(input.descriptor.assignment.prompt).toBe("mutated after launch call");
+  });
+
+  it("replays launch when status cannot find the durable receipt", async () => {
+    const input = launchInput();
+    const responses = [
+      wire(receipt(input, "running")),
+      wire(null),
+      wire(receipt(input, "completed")),
+    ];
+    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async () => responses.shift()!);
+    const adapter = createNodeWorkerLaunchAdapter({
+      getTransport: () => transportWith(invoke),
+      sleep: async () => {},
+    });
+
+    await expect(adapter.launch(launchRequest(input))).resolves.toEqual(
+      receipt(input, "completed"),
+    );
+    expect(invoke.mock.calls.map(([request]) => request.command)).toEqual([
+      "worker.supervisor.launch.v1",
+      "worker.supervisor.status.v1",
+      "worker.supervisor.launch.v1",
+    ]);
+  });
+
+  it("cancels before rejecting a post-dispatch identity mismatch", async () => {
+    const input = launchInput();
+    const mismatched = { ...receipt(input, "completed"), environmentId: "environment-other" };
+    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async (request) => {
+      if (request.command === "worker.supervisor.cancel.v1") {
+        return wire(receipt(input, "cancelled"));
+      }
+      request.onDispatchReady?.("invoke-1");
+      return wire(mismatched);
+    });
+    const adapter = createNodeWorkerLaunchAdapter({
+      getTransport: () => transportWith(invoke),
+    });
+
+    await expect(adapter.launch(launchRequest(input))).rejects.toThrow(
+      "node worker supervisor receipt identity mismatch",
+    );
+    expect(invoke.mock.calls.map(([request]) => request.command)).toEqual([
+      "worker.supervisor.launch.v1",
+      "worker.supervisor.cancel.v1",
+    ]);
+  });
+
+  it("retries a timed-out launch RPC within the overall deadline", async () => {
+    const input = launchInput();
+    let launchCalls = 0;
+    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async (request) => {
+      launchCalls += 1;
+      request.onDispatchReady?.(`invoke-${launchCalls}`);
+      return launchCalls === 1
+        ? await new Promise<never>(() => {})
+        : wire(receipt(input, "completed"));
+    });
+    const adapter = createNodeWorkerLaunchAdapter({
+      getTransport: () => transportWith(invoke),
+      rpcTimeoutMs: 10,
+      sleep: async () => {},
+    });
+
+    await expect(adapter.launch({ ...launchRequest(input), timeoutMs: 100 })).resolves.toEqual(
+      receipt(input, "completed"),
+    );
+    expect(invoke).toHaveBeenCalledTimes(2);
+  });
+
+  it("durably cancels after caller abort and returns the terminal cancellation receipt", async () => {
+    const input = launchInput();
+    const controller = new AbortController();
+    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async (request) => {
+      if (request.command === "worker.supervisor.cancel.v1") {
+        expect(request.params).toEqual(
+          expect.objectContaining({
+            launchId: input.launchId,
+            planHash: nodeWorkerPlanHash(input),
+          }),
+        );
+        return wire(receipt(input, "cancelled"));
+      }
+      request.onDispatchReady?.("invoke-1");
+      return wire(receipt(input, "running"));
+    });
+    const adapter = createNodeWorkerLaunchAdapter({
+      getTransport: () => transportWith(invoke),
+      sleep: async () => {
+        controller.abort();
+      },
+    });
+
+    await expect(
+      adapter.launch({ ...launchRequest(input), signal: controller.signal }),
+    ).resolves.toEqual(receipt(input, "cancelled"));
+    expect(invoke.mock.calls.at(-1)?.[0].command).toBe("worker.supervisor.cancel.v1");
+  });
+
+  it("keeps cancelling through missing and active receipts until terminal", async () => {
+    const input = launchInput();
+    const controller = new AbortController();
+    const cancelResponses = [
+      wire(null),
+      wire(receipt(input, "running")),
+      wire(receipt(input, "cancelled")),
+    ];
+    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async (request) => {
+      if (request.command === "worker.supervisor.cancel.v1") {
+        return cancelResponses.shift()!;
+      }
+      request.onDispatchReady?.("invoke-1");
+      return wire(receipt(input, "running"));
+    });
+    const adapter = createNodeWorkerLaunchAdapter({
+      getTransport: () => transportWith(invoke),
+      pollIntervalMs: 1,
+      sleep: async () => {
+        controller.abort();
+      },
+    });
+
+    await expect(
+      adapter.launch({ ...launchRequest(input), signal: controller.signal }),
+    ).resolves.toEqual(receipt(input, "cancelled"));
+    expect(
+      invoke.mock.calls.filter(([request]) => request.command === "worker.supervisor.cancel.v1"),
+    ).toHaveLength(3);
+  });
+
+  it("retries a timed-out cancellation RPC within one cleanup deadline", async () => {
+    const input = launchInput();
+    const controller = new AbortController();
+    let cancelCalls = 0;
+    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async (request) => {
+      if (request.command === "worker.supervisor.cancel.v1") {
+        cancelCalls += 1;
+        return cancelCalls === 1
+          ? await new Promise<never>(() => {})
+          : wire(receipt(input, "cancelled"));
+      }
+      request.onDispatchReady?.("invoke-1");
+      return wire(receipt(input, "running"));
+    });
+    const adapter = createNodeWorkerLaunchAdapter({
+      getTransport: () => transportWith(invoke),
+      rpcTimeoutMs: 10,
+      cancellationTimeoutMs: 100,
+      sleep: async () => {
+        controller.abort();
+      },
+    });
+
+    await expect(
+      adapter.launch({ ...launchRequest(input), signal: controller.signal }),
+    ).resolves.toEqual(receipt(input, "cancelled"));
+    expect(cancelCalls).toBe(2);
+  });
+
+  it("uses distinct cancellation authority after dispatch authority closes", async () => {
+    const input = launchInput();
+    let dispatchAuthorized = true;
+    const cancelAuthorized = vi.fn(() => true);
+    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async (request) => {
+      if (request.command === "worker.supervisor.cancel.v1") {
+        return wire(receipt(input, "cancelled"));
+      }
+      request.onDispatchReady?.("invoke-1");
+      return wire(receipt(input, "running"));
+    });
+    const adapter = createNodeWorkerLaunchAdapter({
+      getTransport: () => transportWith(invoke),
+      sleep: async () => {
+        dispatchAuthorized = false;
+      },
+    });
+
+    await expect(
+      adapter.launch({
+        ...launchRequest(input),
+        isDispatchAuthorized: () => dispatchAuthorized,
+        isCancellationAuthorized: cancelAuthorized,
+      }),
+    ).resolves.toEqual(receipt(input, "cancelled"));
+    expect(cancelAuthorized).toHaveBeenCalled();
+    expect(invoke.mock.calls.at(-1)?.[0].command).toBe("worker.supervisor.cancel.v1");
+  });
+
+  it("bounds node discovery with the overall launch deadline", async () => {
+    const input = launchInput();
+    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>();
+    const listCurrentNodes = vi.fn(async () => await new Promise<never>(() => {}));
+    const adapter = createNodeWorkerLaunchAdapter({
+      getTransport: () => transportWith(invoke, listCurrentNodes),
+    });
+
+    await expect(adapter.launch({ ...launchRequest(input), timeoutMs: 25 })).rejects.toThrow(
+      "node worker launch timed out",
+    );
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("reports unknown cancellation outcome after a hard cancellation deadline", async () => {
+    const input = launchInput();
+    const controller = new AbortController();
+    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async (request) => {
+      if (request.command === "worker.supervisor.cancel.v1") {
+        return await new Promise<never>(() => {});
+      }
+      request.onDispatchReady?.("invoke-1");
+      return wire(receipt(input, "running"));
+    });
+    const adapter = createNodeWorkerLaunchAdapter({
+      getTransport: () => transportWith(invoke),
+      cancellationTimeoutMs: 25,
+      sleep: async () => {
+        controller.abort();
+      },
+    });
+
+    await expect(
+      adapter.launch({ ...launchRequest(input), signal: controller.signal }),
+    ).rejects.toThrow("node worker launch failed and cancellation could not be confirmed");
+    expect(
+      invoke.mock.calls.filter(([request]) => request.command === "worker.supervisor.cancel.v1"),
+    ).toHaveLength(1);
+  });
+});

--- a/src/gateway/worker-environments/node-launch-adapter.ts
+++ b/src/gateway/worker-environments/node-launch-adapter.ts
@@ -1,0 +1,473 @@
+import { sleepWithAbort } from "../../infra/backoff.js";
+import {
+  NODE_WORKER_SUPERVISOR_CANCEL_COMMAND,
+  NODE_WORKER_SUPERVISOR_LAUNCH_COMMAND,
+  NODE_WORKER_SUPERVISOR_STATUS_COMMAND,
+} from "../../infra/node-commands.js";
+import {
+  nodeWorkerPlanHash,
+  parseNodeWorkerLaunchInput,
+  parseNodeWorkerSupervisorReceipt,
+  type NodeWorkerLaunchInput,
+  type NodeWorkerSupervisorIdentity,
+  type NodeWorkerSupervisorReceipt,
+} from "../../worker/node-supervisor-protocol.js";
+import type {
+  NodeWorkerSupervisorNodeProof,
+  NodeWorkerSupervisorTransport,
+} from "../node-registry-private.js";
+
+const DEFAULT_RPC_TIMEOUT_MS = 30_000;
+const DEFAULT_POLL_INTERVAL_MS = 250;
+const MAX_RETRY_DELAY_MS = 2_000;
+const DEFAULT_CANCELLATION_TIMEOUT_MS = 30_000;
+
+const RETRYABLE_TRANSPORT_CODES = new Set([
+  "DISCONNECTED",
+  "NOT_CONNECTED",
+  "PAIRING_CHANGED",
+  "PRIVATE_DIALECT_UNAVAILABLE",
+  "ROUTE_CHANGED",
+  "TIMEOUT",
+  "UNAVAILABLE",
+]);
+
+type TerminalNodeWorkerSupervisorReceipt = Extract<
+  NodeWorkerSupervisorReceipt,
+  { state: "completed" | "failed" | "interrupted" | "cancelled" }
+>;
+
+type DeviceWorkerLaunchRequest = {
+  deviceId: string;
+  input: NodeWorkerLaunchInput;
+  isDispatchAuthorized: () => boolean;
+  isCancellationAuthorized: () => boolean;
+  timeoutMs: number;
+  signal?: AbortSignal;
+};
+
+type NodeWorkerLaunchAdapterOptions = {
+  getTransport: () => NodeWorkerSupervisorTransport | undefined;
+  now?: () => number;
+  sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+  rpcTimeoutMs?: number;
+  pollIntervalMs?: number;
+  cancellationTimeoutMs?: number;
+};
+
+type OperationDeadline = {
+  expiresAtMs: number;
+  signal: AbortSignal;
+  remainingMs: () => number;
+  dispose: () => void;
+};
+
+class NodeWorkerLaunchTransportError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+function isTerminalReceipt(
+  receipt: NodeWorkerSupervisorReceipt,
+): receipt is TerminalNodeWorkerSupervisorReceipt {
+  return (
+    receipt.state === "completed" ||
+    receipt.state === "failed" ||
+    receipt.state === "interrupted" ||
+    receipt.state === "cancelled"
+  );
+}
+
+function snapshotLaunchInput(input: NodeWorkerLaunchInput): NodeWorkerLaunchInput {
+  let encoded: string;
+  try {
+    encoded = JSON.stringify(input);
+  } catch {
+    throw new Error("node worker launch input is not serializable");
+  }
+  return parseNodeWorkerLaunchInput(encoded);
+}
+
+function expectedIdentity(input: NodeWorkerLaunchInput): NodeWorkerSupervisorIdentity {
+  if (input.launchId !== input.descriptor.assignment.turnId) {
+    throw new Error("node worker launch ID must match the durable turn ID");
+  }
+  return {
+    launchId: input.launchId,
+    planHash: nodeWorkerPlanHash(input),
+    environmentId: input.descriptor.admission.environmentId,
+    sessionId: input.descriptor.admission.sessionId,
+    ownerEpoch: input.descriptor.admission.ownerEpoch,
+    placementGeneration: input.placementGeneration,
+    runId: input.descriptor.assignment.runId,
+  };
+}
+
+function receiptMatchesIdentity(
+  receipt: NodeWorkerSupervisorReceipt,
+  expected: NodeWorkerSupervisorIdentity,
+): boolean {
+  return (
+    receipt.launchId === expected.launchId &&
+    receipt.planHash === expected.planHash &&
+    receipt.environmentId === expected.environmentId &&
+    receipt.sessionId === expected.sessionId &&
+    receipt.ownerEpoch === expected.ownerEpoch &&
+    receipt.placementGeneration === expected.placementGeneration &&
+    receipt.runId === expected.runId
+  );
+}
+
+function parseInvokeReceipt(
+  payloadJSON: string | null | undefined,
+): NodeWorkerSupervisorReceipt | null {
+  if (!payloadJSON) {
+    throw new Error("node worker supervisor response omitted payload JSON");
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(payloadJSON) as unknown;
+  } catch {
+    throw new Error("node worker supervisor response contained malformed JSON");
+  }
+  if (value === null) {
+    return null;
+  }
+  const receipt = parseNodeWorkerSupervisorReceipt(value);
+  if (!receipt) {
+    throw new Error("node worker supervisor response violated the private receipt contract");
+  }
+  return receipt;
+}
+
+function signalError(signal: AbortSignal, fallback: string): Error {
+  return signal.reason instanceof Error ? signal.reason : new Error(fallback);
+}
+
+function raceWithSignal<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    return Promise.reject(signalError(signal, "node worker operation aborted"));
+  }
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(signalError(signal, "node worker operation aborted"));
+    signal.addEventListener("abort", onAbort, { once: true });
+    void operation.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error instanceof Error ? error : new Error("node worker operation failed"));
+      },
+    );
+  });
+}
+
+function createDeadline(params: {
+  now: () => number;
+  timeoutMs: number;
+  signal?: AbortSignal;
+  label: string;
+}): OperationDeadline {
+  if (!Number.isFinite(params.timeoutMs) || params.timeoutMs <= 0) {
+    throw new Error(`${params.label} timeout must be a positive finite number`);
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(new Error(`${params.label} timed out`)),
+    params.timeoutMs,
+  );
+  timer.unref?.();
+  const signal = params.signal
+    ? AbortSignal.any([params.signal, controller.signal])
+    : controller.signal;
+  const expiresAtMs = params.now() + params.timeoutMs;
+  return {
+    expiresAtMs,
+    signal,
+    remainingMs: () => Math.max(0, expiresAtMs - params.now()),
+    dispose: () => clearTimeout(timer),
+  };
+}
+
+export function createNodeWorkerLaunchAdapter(options: NodeWorkerLaunchAdapterOptions) {
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep ?? sleepWithAbort;
+  const rpcTimeoutMs = options.rpcTimeoutMs ?? DEFAULT_RPC_TIMEOUT_MS;
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const cancellationTimeoutMs = options.cancellationTimeoutMs ?? DEFAULT_CANCELLATION_TIMEOUT_MS;
+
+  const findNode = async (params: {
+    transport: NodeWorkerSupervisorTransport;
+    deviceId: string;
+    signal: AbortSignal;
+  }): Promise<NodeWorkerSupervisorNodeProof> => {
+    let nodes: readonly NodeWorkerSupervisorNodeProof[];
+    try {
+      nodes = await raceWithSignal(params.transport.listCurrentNodes(), params.signal);
+    } catch (error) {
+      if (params.signal.aborted) {
+        throw error;
+      }
+      throw new NodeWorkerLaunchTransportError(
+        "UNAVAILABLE",
+        "device worker node discovery is unavailable",
+      );
+    }
+    const node = nodes.find(
+      (candidate) =>
+        candidate.nodeId === params.deviceId && candidate.commands.includes("system.run"),
+    );
+    if (!node) {
+      throw new NodeWorkerLaunchTransportError(
+        "NOT_CONNECTED",
+        "device worker node is not currently connected",
+      );
+    }
+    return node;
+  };
+
+  const invoke = async (params: {
+    deviceId: string;
+    command:
+      | typeof NODE_WORKER_SUPERVISOR_LAUNCH_COMMAND
+      | typeof NODE_WORKER_SUPERVISOR_STATUS_COMMAND
+      | typeof NODE_WORKER_SUPERVISOR_CANCEL_COMMAND;
+    payload: unknown;
+    isAuthorized: () => boolean;
+    deadline: OperationDeadline;
+    onDispatchReady?: () => void;
+  }): Promise<NodeWorkerSupervisorReceipt | null> => {
+    if (!params.isAuthorized()) {
+      throw new NodeWorkerLaunchTransportError(
+        "APPROVAL_AUTHORITY_CLOSED",
+        "node worker authority closed",
+      );
+    }
+    const remainingMs = params.deadline.remainingMs();
+    if (remainingMs <= 0 || params.deadline.signal.aborted) {
+      throw params.deadline.signal.reason ?? new Error("node worker operation timed out");
+    }
+    const transport = options.getTransport();
+    if (!transport) {
+      throw new NodeWorkerLaunchTransportError(
+        "UNAVAILABLE",
+        "device worker node transport is unavailable",
+      );
+    }
+    const rpcController = new AbortController();
+    const rpcBudgetMs = Math.max(1, Math.min(rpcTimeoutMs, remainingMs));
+    const rpcTimer = setTimeout(
+      () => rpcController.abort(new Error("node worker RPC timed out")),
+      rpcBudgetMs,
+    );
+    rpcTimer.unref?.();
+    const signal = AbortSignal.any([params.deadline.signal, rpcController.signal]);
+    try {
+      const node = await findNode({ transport, deviceId: params.deviceId, signal });
+      const operation = transport.invoke({
+        node,
+        command: params.command,
+        params: params.payload,
+        timeoutMs: rpcBudgetMs,
+        signal,
+        idempotencyKey:
+          params.command === NODE_WORKER_SUPERVISOR_LAUNCH_COMMAND &&
+          typeof params.payload === "object" &&
+          params.payload !== null &&
+          "launchId" in params.payload &&
+          typeof params.payload.launchId === "string"
+            ? params.payload.launchId
+            : undefined,
+        isDispatchAuthorized: params.isAuthorized,
+        ...(params.onDispatchReady ? { onDispatchReady: params.onDispatchReady } : {}),
+      });
+      const result = await raceWithSignal(operation, signal);
+      if (!result.ok) {
+        const code = result.error?.code ?? "UNAVAILABLE";
+        throw new NodeWorkerLaunchTransportError(
+          code,
+          `node worker supervisor invocation failed (${code})`,
+        );
+      }
+      return parseInvokeReceipt(result.payloadJSON);
+    } catch (error) {
+      if (rpcController.signal.aborted && !params.deadline.signal.aborted) {
+        throw new NodeWorkerLaunchTransportError("TIMEOUT", "node worker RPC timed out");
+      }
+      throw error;
+    } finally {
+      clearTimeout(rpcTimer);
+    }
+  };
+
+  const validateReceipt = (
+    receipt: NodeWorkerSupervisorReceipt,
+    expected: NodeWorkerSupervisorIdentity,
+  ): NodeWorkerSupervisorReceipt => {
+    if (!receiptMatchesIdentity(receipt, expected)) {
+      throw new Error("node worker supervisor receipt identity mismatch");
+    }
+    return receipt;
+  };
+
+  const waitBeforeRetry = async (params: {
+    delayMs: number;
+    deadline: OperationDeadline;
+  }): Promise<number> => {
+    const remainingMs = params.deadline.remainingMs();
+    if (remainingMs <= 0 || params.deadline.signal.aborted) {
+      throw params.deadline.signal.reason ?? new Error("node worker operation timed out");
+    }
+    await raceWithSignal(
+      sleep(Math.min(params.delayMs, remainingMs), params.deadline.signal),
+      params.deadline.signal,
+    );
+    return Math.min(params.delayMs * 2, MAX_RETRY_DELAY_MS);
+  };
+
+  const cancelUntilTerminal = async (params: {
+    request: DeviceWorkerLaunchRequest;
+    expected: NodeWorkerSupervisorIdentity;
+  }): Promise<TerminalNodeWorkerSupervisorReceipt> => {
+    const deadline = createDeadline({
+      now,
+      timeoutMs: cancellationTimeoutMs,
+      label: "node worker cancellation",
+    });
+    let delayMs = pollIntervalMs;
+    try {
+      while (!deadline.signal.aborted && deadline.remainingMs() > 0) {
+        if (!params.request.isCancellationAuthorized()) {
+          throw new Error("node worker cancellation authority closed before terminal settlement");
+        }
+        try {
+          const receipt = await invoke({
+            deviceId: params.request.deviceId,
+            command: NODE_WORKER_SUPERVISOR_CANCEL_COMMAND,
+            payload: params.expected,
+            isAuthorized: params.request.isCancellationAuthorized,
+            deadline,
+          });
+          if (receipt) {
+            const validated = validateReceipt(receipt, params.expected);
+            if (isTerminalReceipt(validated)) {
+              return validated;
+            }
+            delayMs = pollIntervalMs;
+          }
+        } catch (error) {
+          if (deadline.signal.aborted) {
+            break;
+          }
+          if (
+            !(error instanceof NodeWorkerLaunchTransportError) ||
+            !RETRYABLE_TRANSPORT_CODES.has(error.code)
+          ) {
+            throw error;
+          }
+        }
+        delayMs = await waitBeforeRetry({ delayMs, deadline });
+      }
+    } finally {
+      deadline.dispose();
+    }
+    throw new Error("node worker cancellation outcome is unknown after transport loss");
+  };
+
+  const launch = async (
+    request: DeviceWorkerLaunchRequest,
+  ): Promise<TerminalNodeWorkerSupervisorReceipt> => {
+    const input = snapshotLaunchInput(request.input);
+    const stableRequest = { ...request, input };
+    const expected = expectedIdentity(input);
+    const deadline = createDeadline({
+      now,
+      timeoutMs: request.timeoutMs,
+      ...(request.signal ? { signal: request.signal } : {}),
+      label: "node worker launch",
+    });
+    let mayHaveLaunched = false;
+    let pollStatus = false;
+    let delayMs = pollIntervalMs;
+    try {
+      while (true) {
+        if (deadline.signal.aborted) {
+          throw signalError(deadline.signal, "node worker launch aborted");
+        }
+        if (!stableRequest.isDispatchAuthorized()) {
+          throw new Error("node worker launch authority closed");
+        }
+        try {
+          const receipt = await invoke({
+            deviceId: stableRequest.deviceId,
+            command: pollStatus
+              ? NODE_WORKER_SUPERVISOR_STATUS_COMMAND
+              : NODE_WORKER_SUPERVISOR_LAUNCH_COMMAND,
+            payload: pollStatus ? { launchId: input.launchId } : input,
+            isAuthorized: stableRequest.isDispatchAuthorized,
+            deadline,
+            ...(!pollStatus
+              ? {
+                  onDispatchReady: () => {
+                    mayHaveLaunched = true;
+                  },
+                }
+              : {}),
+          });
+          if (!receipt) {
+            pollStatus = false;
+          } else {
+            const validated = validateReceipt(receipt, expected);
+            mayHaveLaunched = true;
+            if (isTerminalReceipt(validated)) {
+              return validated;
+            }
+            pollStatus = true;
+            delayMs = pollIntervalMs;
+          }
+        } catch (error) {
+          if (deadline.signal.aborted || !stableRequest.isDispatchAuthorized()) {
+            throw error;
+          }
+          if (
+            !(error instanceof NodeWorkerLaunchTransportError) ||
+            !RETRYABLE_TRANSPORT_CODES.has(error.code)
+          ) {
+            throw error;
+          }
+          pollStatus = false;
+        }
+        delayMs = await waitBeforeRetry({ delayMs, deadline });
+      }
+    } catch (error) {
+      if (!mayHaveLaunched) {
+        throw error;
+      }
+      let terminal: TerminalNodeWorkerSupervisorReceipt;
+      try {
+        terminal = await cancelUntilTerminal({ request: stableRequest, expected });
+      } catch (cancelError) {
+        throw Object.assign(
+          new Error("node worker launch failed and cancellation could not be confirmed", {
+            cause: error instanceof Error ? error : new Error("node worker launch failed"),
+          }),
+          { cancellationError: cancelError },
+        );
+      }
+      if (deadline.signal.aborted || !stableRequest.isDispatchAuthorized()) {
+        return terminal;
+      }
+      throw error;
+    } finally {
+      deadline.dispose();
+    }
+  };
+
+  return { launch };
+}


### PR DESCRIPTION
## What Problem This Solves

The Gateway has a private generation-fenced node supervisor transport and can now collect bounded terminal outcomes, but no Gateway owner turns those primitives into one durable launch lifecycle. Callers would otherwise have to reimplement ambiguous-dispatch replay, status polling, reconnect recovery, exact receipt validation, and cancellation settlement—and a naïve implementation can orphan a worker after a lost response or stale authority.

## Why This Change Was Made

This adds one worker-environment-owned node launch adapter and makes `createDeviceWorkerRuntime` its production owner. The adapter accepts an already-complete node launch input and:

- validates and snapshots the complete launch plan before the first await;
- requires `launchId === descriptor.assignment.turnId` and computes the expected plan identity locally;
- reacquires the current private node proof for every launch/status/cancel RPC;
- replays the identical durable launch after ambiguous disconnect, route change, pairing change, timeout, or missing status;
- validates every returned immutable identity before accepting state or terminal output;
- hard-bounds node discovery, each RPC, retry sleeps, the overall launch, and the independent cancellation window;
- requires separate dispatch and cancellation authority closures;
- treats missing/active cancellation receipts as unresolved until terminal settlement;
- performs durable cancellation through one outer settlement owner after every post-dispatch abort, authority closure, or protocol failure;
- preserves the original launch error and cancellation error when cleanup cannot be confirmed.

This intentionally returns the terminal supervisor receipt, not a synthetic `SpawnResult`. It does not create a node tunnel, public worker endpoint, gateway namespace, bundle installation, workspace sync/reconciliation, active placement, or successful `sessions.dispatch({ deviceId })`. The existing visible device transport/workspace gate remains unchanged.

## User Impact

No user-visible device-runner capability is enabled yet. This establishes the safe launch/replay/cancel owner that the later node execution tunnel can consume without duplicating lifecycle policy or weakening authority.

## Evidence

- Focused adapter/provider suite: 17 tests passed.
- Adapter + provider + private node-registry transport proof: 121 tests passed.
- Regression coverage includes immutable snapshot under caller mutation, current-proof reacquisition, ambiguous same-plan replay, missing-status replay, post-dispatch identity mismatch cleanup, caller abort, dispatch-authority closure with independent cancellation authority, missing/active cancellation receipts, launch RPC timeout replay, cancellation RPC timeout replay, hanging discovery deadline, and one hard cancellation window.
- Three adversarial review cycles found eight concrete lifecycle bugs; all were repaired. Final independent review: clean.
- Core and core-test typechecks: clean.
- Focused production/test lint: clean.
- Canonical changed gate passed after trusted-source local fallback because no remote provider was ready: formatting, unchanged Plugin SDK API baseline, dead exports, production/test types, core lint, native schema/database/auth/pairing guards, and zero runtime cycles.
- Final structured review and secret scan: clean.
- `git diff --check`: clean.

LOC classification:

- production: +476/−0;
- tests: +431/−0.

The production growth is the new launch authority/lifecycle capability itself. No parallel public path, compatibility shim, fallback execution mode, config surface, schema version, or protocol version is added.
