### PR TITLE
fix(ci): validate duplicate coverage on frozen targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2435,7 +2435,11 @@ jobs:
               fi
               pnpm tool-display:check
               pnpm check:host-env-policy:swift
-              pnpm dup:check
+              if [[ "$FROZEN_TARGET" == "true" ]]; then
+                pnpm dup:check:coverage
+              else
+                pnpm dup:check
+              fi
               if has_package_script "check:coercion-helpers"; then
                 pnpm check:coercion-helpers
               elif [[ "$HISTORICAL_TARGET" == "true" ]]; then

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4947,6 +4947,13 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(parsedWorkflow.jobs.preflight.outputs.frozen_target).toBe(
       "${{ steps.manifest.outputs.frozen_target }}",
     );
+    expect(preflightGuards).toContain(
+      'if [[ "$FROZEN_TARGET" == "true" ]]; then\n' +
+        "                pnpm dup:check:coverage\n" +
+        "              else\n" +
+        "                pnpm dup:check\n" +
+        "              fi",
+    );
     expect(npmLockGuards).toContain("pnpm deps:npm-lock:check");
     expect(preflightGuards).toContain("pnpm deps:patches:check");
     expect(preflightGuards).toContain('has_package_script "check:coercion-helpers"');


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation problem where frozen targets run the full duplicate scan instead of the compatibility-safe target-coverage check.

## Why This Change Was Made

The guards shard now selects `dup:check:coverage` only when `FROZEN_TARGET=true` and preserves `dup:check` for current targets. The workflow contract test pins both branches.

## User Impact

No runtime user impact. Maintainers can validate frozen release candidates without weakening duplicate checks on current development targets.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` (115 passed, 2 skipped)
- `actionlint .github/workflows/ci.yml`
- `./node_modules/.bin/oxfmt --check .github/workflows/ci.yml test/scripts/ci-workflow-guards.test.ts`
- `git diff --check`
- local autoreview: clean, no accepted/actionable findings

AI-assisted: yes.
