### PR TITLE
refactor(telegram): tighten unsafe type boundaries

### DIFF
--- a/extensions/telegram/src/account-selection.ts
+++ b/extensions/telegram/src/account-selection.ts
@@ -85,7 +85,7 @@ const { listAccountIds: listTelegramAccountIds } = createAccountListHelpers("tel
 
 export { listTelegramAccountIds };
 
-export type DefaultTelegramAccountSelection = {
+type DefaultTelegramAccountSelection = {
   accountId: string;
   accountIds: string[];
   shouldWarnMissingDefault: boolean;

--- a/extensions/telegram/src/account-selection.ts
+++ b/extensions/telegram/src/account-selection.ts
@@ -85,11 +85,15 @@ const { listAccountIds: listTelegramAccountIds } = createAccountListHelpers("tel
 
 export { listTelegramAccountIds };
 
-export function resolveDefaultTelegramAccountSelection(cfg: OpenClawConfig): {
+export type DefaultTelegramAccountSelection = {
   accountId: string;
   accountIds: string[];
   shouldWarnMissingDefault: boolean;
-} {
+};
+
+export function resolveDefaultTelegramAccountSelection(
+  cfg: OpenClawConfig,
+): DefaultTelegramAccountSelection {
   const boundDefault = resolveDefaultAgentBoundAccountId(cfg, "telegram");
   if (boundDefault) {
     return {

--- a/extensions/telegram/src/account-throttler.test.ts
+++ b/extensions/telegram/src/account-throttler.test.ts
@@ -28,6 +28,13 @@ function deferred<T>() {
   return { promise, resolve: resolve! };
 }
 
+function invokeTestApiCall(call: unknown) {
+  if (typeof call !== "function") {
+    throw new TypeError("expected test API callback to be callable");
+  }
+  return Reflect.apply(call, undefined, []);
+}
+
 describe("getOrCreateAccountThrottler", () => {
   beforeEach(() => {
     resetTelegramAccountThrottlersForTest();
@@ -49,14 +56,15 @@ describe("getOrCreateAccountThrottler", () => {
       "round-robin",
       () => async (prev, method, payload, signal) => prev(method, payload, signal),
     );
-    const prev = vi.fn(async (_method: string, payload: unknown) => {
-      const request = payload as { message_thread_id?: number; text?: string };
-      entered.push(`${request.message_thread_id}:${request.text}`);
-      if (entered.length === 1) {
-        await firstGate.promise;
-      }
-      return { ok: true, result: request.text ?? "" };
-    }) as unknown as TelegramPreviousCall;
+    const prev: TelegramPreviousCall = (_method, payload) =>
+      invokeTestApiCall(async () => {
+        const request = payload as { message_thread_id?: number; text?: string };
+        entered.push(`${request.message_thread_id}:${request.text}`);
+        if (entered.length === 1) {
+          await firstGate.promise;
+        }
+        return { ok: true, result: request.text ?? "" };
+      });
 
     const first = throttler(
       prev,
@@ -96,14 +104,15 @@ describe("getOrCreateAccountThrottler", () => {
       "edited-message",
       () => async (prev, method, payload, signal) => prev(method, payload, signal),
     );
-    const prev = vi.fn(async (_method: string, payload: unknown) => {
-      const request = payload as { message_id?: number; text?: string };
-      entered.push(`${request.message_id}:${request.text}`);
-      if (entered.length === 1) {
-        await firstGate.promise;
-      }
-      return { ok: true, result: request.text ?? "" };
-    }) as unknown as TelegramPreviousCall;
+    const prev: TelegramPreviousCall = (_method, payload) =>
+      invokeTestApiCall(async () => {
+        const request = payload as { message_id?: number; text?: string };
+        entered.push(`${request.message_id}:${request.text}`);
+        if (entered.length === 1) {
+          await firstGate.promise;
+        }
+        return { ok: true, result: request.text ?? "" };
+      });
 
     const first = throttler(
       prev,
@@ -141,14 +150,15 @@ describe("getOrCreateAccountThrottler", () => {
       "direct-topic",
       () => async (prev, method, payload, signal) => prev(method, payload, signal),
     );
-    const prev = vi.fn(async (_method: string, payload: unknown) => {
-      const request = payload as { text?: string };
-      entered.push(request.text ?? "");
-      if (entered.length === 1) {
-        await firstGate.promise;
-      }
-      return { ok: true, result: request.text ?? "" };
-    }) as unknown as TelegramPreviousCall;
+    const prev: TelegramPreviousCall = (_method, payload) =>
+      invokeTestApiCall(async () => {
+        const request = payload as { text?: string };
+        entered.push(request.text ?? "");
+        if (entered.length === 1) {
+          await firstGate.promise;
+        }
+        return { ok: true, result: request.text ?? "" };
+      });
 
     const first = throttler(
       prev,
@@ -177,14 +187,15 @@ describe("getOrCreateAccountThrottler", () => {
       "private-chat",
       () => async (prev, method, payload, signal) => prev(method, payload, signal),
     );
-    const prev = vi.fn(async (_method: string, payload: unknown) => {
-      const request = payload as { message_thread_id?: string; text?: string };
-      entered.push(`${request.message_thread_id}:${request.text}`);
-      if (entered.length === 1) {
-        await firstGate.promise;
-      }
-      return { ok: true, result: request.text ?? "" };
-    }) as unknown as TelegramPreviousCall;
+    const prev: TelegramPreviousCall = (_method, payload) =>
+      invokeTestApiCall(async () => {
+        const request = payload as { message_thread_id?: string; text?: string };
+        entered.push(`${request.message_thread_id}:${request.text}`);
+        if (entered.length === 1) {
+          await firstGate.promise;
+        }
+        return { ok: true, result: request.text ?? "" };
+      });
 
     const first = callLooseSendMessage(throttler, prev, {
       chat_id: "-100123",

--- a/extensions/telegram/src/accounts.test.ts
+++ b/extensions/telegram/src/accounts.test.ts
@@ -40,11 +40,19 @@ function resolveAccountWithEnv(
 beforeEach(() => {
   vi.restoreAllMocks();
   vi.mocked(createSubsystemLogger).mockImplementation(() => {
-    const logger = {
+    const logger: ReturnType<typeof createSubsystemLogger> = {
+      subsystem: "telegram/accounts-test",
+      trace: vi.fn(),
+      debug: vi.fn(),
+      info: vi.fn(),
       warn: warnMock,
+      error: vi.fn(),
+      fatal: vi.fn(),
+      raw: vi.fn(),
+      isEnabled: vi.fn(() => false),
       child: () => logger,
     };
-    return logger as unknown as ReturnType<typeof createSubsystemLogger>;
+    return logger;
   });
 });
 
@@ -141,11 +149,15 @@ describe("resolveTelegramAccount", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    };
 
-    const accounts = listEnabledTelegramAccounts(cfg);
+    const accounts = Reflect.apply(listEnabledTelegramAccounts, undefined, [cfg]);
 
-    expect(accounts.map((account) => account.accountId)).toEqual(["work"]);
+    expect(
+      accounts.map(
+        (account: ReturnType<typeof listEnabledTelegramAccounts>[number]) => account.accountId,
+      ),
+    ).toEqual(["work"]);
     expect(accounts[0]?.token).toBe("tok-work");
   });
 
@@ -164,7 +176,7 @@ describe("resolveTelegramAccount", () => {
         { agentId: "ignored", match: { channel: "telegram", accountId: "*" } },
         { agentId: "ignored", match: { channel: "slack", accountId: "slack-only" } },
       ],
-    } as unknown as OpenClawConfig;
+    } satisfies OpenClawConfig;
 
     expect(listTelegramAccountIds(cfg)).toEqual(["alerts", "default", "ops-team"]);
     expect(resolveDefaultTelegramAccountId(cfg)).toBe("ops-team");
@@ -186,7 +198,7 @@ describe("resolveTelegramAccount", () => {
         },
       },
       bindings: [{ agentId: "fusion", match: { channel: "telegram", accountId: "fusion" } }],
-    } as unknown as OpenClawConfig;
+    } satisfies OpenClawConfig;
 
     expect(listTelegramAccountIds(cfg)).toEqual(["default", "fusion"]);
     expect(resolveDefaultTelegramAccountId(cfg)).toBe("default");

--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -17,8 +17,10 @@ import {
   clearTelegramRuntimeForTest,
   resetTelegramTopicNameCacheForTest,
 } from "./runtime.test-support.js";
-import type { TelegramRuntime } from "./runtime.types.js";
 import { getTopicName, resolveTopicNameCacheScope } from "./topic-name-cache.js";
+
+type ReactMessageTelegram = typeof import("./send.js").reactMessageTelegram;
+type DeleteMessageTelegram = typeof import("./send.js").deleteMessageTelegram;
 
 const originalTelegramActionRuntime = { ...telegramActionRuntime };
 
@@ -32,7 +34,7 @@ function handleTelegramAction(
     ...options,
   });
 }
-const reactMessageTelegram = vi.fn(async () => ({ ok: true }));
+const reactMessageTelegram = vi.fn<ReactMessageTelegram>(async () => ({ ok: true }));
 const sendMessageTelegram = vi.fn(
   async (_to: string, _text: string, _opts?: Record<string, unknown>) => ({
     messageId: "789",
@@ -182,7 +184,7 @@ const sendStickerTelegram = vi.fn(async () => ({
   messageId: "456",
   chatId: "123",
 }));
-const deleteMessageTelegram = vi.fn(async () => ({ ok: true }));
+const deleteMessageTelegram = vi.fn<DeleteMessageTelegram>(async () => ({ ok: true }));
 const editMessageTelegram = vi.fn(async () => ({
   ok: true,
   messageId: "456",
@@ -226,29 +228,31 @@ const topicNameStoresForTest = new Map<string, Map<string, TopicNameEntryForTest
 
 function installTopicNameStoreForTest() {
   topicNameStoresForTest.clear();
-  setTelegramRuntime({
-    state: {
-      openKeyedStore: (({ namespace }: { namespace: string }) => {
-        const entries = topicNameStoresForTest.get(namespace) ?? new Map();
-        topicNameStoresForTest.set(namespace, entries);
-        return {
-          async register(key: string, value: TopicNameEntryForTest) {
-            entries.set(key, value);
-          },
-          async entries() {
-            return Array.from(entries, ([key, value]) => ({ key, value }));
-          },
-          async delete(key: string) {
-            return entries.delete(key);
-          },
-          async clear() {
-            entries.clear();
-          },
-        };
-      }) as unknown as TelegramRuntime["state"]["openKeyedStore"],
+  Reflect.apply(setTelegramRuntime, undefined, [
+    {
+      state: {
+        openKeyedStore: ({ namespace }: { namespace: string }) => {
+          const entries = topicNameStoresForTest.get(namespace) ?? new Map();
+          topicNameStoresForTest.set(namespace, entries);
+          return {
+            async register(key: string, value: TopicNameEntryForTest) {
+              entries.set(key, value);
+            },
+            async entries() {
+              return Array.from(entries, ([key, value]) => ({ key, value }));
+            },
+            async delete(key: string) {
+              return entries.delete(key);
+            },
+            async clear() {
+              entries.clear();
+            },
+          };
+        },
+      },
+      channel: {},
     },
-    channel: {},
-  } as TelegramRuntime);
+  ]);
 }
 
 type MockCallSource = {
@@ -593,7 +597,7 @@ describe("handleTelegramAction", () => {
     reactMessageTelegram.mockResolvedValueOnce({
       ok: false,
       warning: "Reaction unavailable: ✅",
-    } as unknown as Awaited<ReturnType<typeof reactMessageTelegram>>);
+    });
     const result = await handleTelegramAction(defaultReactionAction, reactionConfig("minimal"));
     const textPayload = result.content.find((item) => item.type === "text");
     expect(textPayload?.type).toBe("text");
@@ -2410,7 +2414,7 @@ describe("handleTelegramAction", () => {
     deleteMessageTelegram.mockResolvedValueOnce({
       ok: false,
       warning: "Message 456 was not deleted: 400: Bad Request: message can't be deleted",
-    } as unknown as Awaited<ReturnType<typeof deleteMessageTelegram>>);
+    });
     const cfg = {
       channels: { telegram: { botToken: "tok" } },
     } as OpenClawConfig;

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -392,9 +392,11 @@ function buildTelegramActionSendPayload(params: {
   };
 }
 
+type TelegramActionDeliveryResult = { messageId?: string; chatId?: string };
+
 function getLastDurableTelegramActionResult(
   result: Extract<DurableMessageBatchSendResult, { status: "sent" }>,
-): { messageId?: string; chatId?: string } {
+): TelegramActionDeliveryResult {
   const lastResult = result.results.at(-1);
   const receipt = result.receipt;
   return {
@@ -1040,13 +1042,10 @@ export async function handleTelegramAction(
       },
     );
     if (result.chatId) {
-      const patch: { name?: string; iconCustomEmojiId?: string } = {};
-      if (name) {
-        patch.name = name;
-      }
-      if (iconCustomEmojiId) {
-        patch.iconCustomEmojiId = iconCustomEmojiId;
-      }
+      const patch = {
+        ...(name ? { name } : {}),
+        ...(iconCustomEmojiId ? { iconCustomEmojiId } : {}),
+      };
       if (Object.keys(patch).length > 0) {
         await updateTopicName(
           result.chatId,

--- a/extensions/telegram/src/api-fetch.test.ts
+++ b/extensions/telegram/src/api-fetch.test.ts
@@ -139,7 +139,7 @@ describe("fetchTelegramChatId", () => {
   });
 
   it("uses caller-provided fetch impl when present", async () => {
-    const customFetch = vi.fn(async () => getChatOkResponse(12345));
+    const customFetch = vi.fn<typeof fetch>(async () => getChatOkResponse(12345));
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => {
@@ -150,7 +150,7 @@ describe("fetchTelegramChatId", () => {
     await fetchTelegramChatId({
       token: "abc",
       chatId: "@user",
-      fetchImpl: customFetch as unknown as typeof fetch,
+      fetchImpl: customFetch,
     });
 
     expect(customFetch).toHaveBeenCalledWith(
@@ -161,7 +161,7 @@ describe("fetchTelegramChatId", () => {
 
   it("returns null for oversized getChat JSON responses and cancels the stream", async () => {
     let cancelCount = 0;
-    const fetchImpl = vi.fn(async () =>
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
       oversizedTelegramGetChatJsonResponse(() => {
         cancelCount += 1;
       }),
@@ -171,7 +171,7 @@ describe("fetchTelegramChatId", () => {
       fetchTelegramChatId({
         token: "abc",
         chatId: "@user",
-        fetchImpl: fetchImpl as unknown as typeof fetch,
+        fetchImpl,
       }),
     ).resolves.toBeNull();
     expect(cancelCount).toBe(1);
@@ -180,7 +180,7 @@ describe("fetchTelegramChatId", () => {
   it("cancels non-success getChat response bodies before returning", async () => {
     const cancel = vi.fn();
     let observedSignal: AbortSignal | undefined;
-    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+    const fetchImpl = vi.fn<typeof fetch>(async (_url, init) => {
       observedSignal = init?.signal ?? undefined;
       return new Response(
         new ReadableStream<Uint8Array>({
@@ -197,7 +197,7 @@ describe("fetchTelegramChatId", () => {
       fetchTelegramChatId({
         token: "abc",
         chatId: "@user",
-        fetchImpl: fetchImpl as unknown as typeof fetch,
+        fetchImpl,
       }),
       new Promise<"stalled">((resolve) => {
         setTimeout(() => resolve("stalled"), 250);
@@ -212,7 +212,7 @@ describe("fetchTelegramChatId", () => {
   it("does not wait for a cloned capture branch before returning", async () => {
     let observedSignal: AbortSignal | undefined;
     let captureSettled = false;
-    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+    const fetchImpl = vi.fn<typeof fetch>(async (_url, init) => {
       observedSignal = init?.signal ?? undefined;
       const response = new Response(
         new ReadableStream<Uint8Array>({
@@ -241,7 +241,7 @@ describe("fetchTelegramChatId", () => {
       fetchTelegramChatId({
         token: "abc",
         chatId: "@user",
-        fetchImpl: fetchImpl as unknown as typeof fetch,
+        fetchImpl,
       }),
       new Promise<"stalled">((resolve) => {
         setTimeout(() => resolve("stalled"), 250);
@@ -257,7 +257,7 @@ describe("fetchTelegramChatId", () => {
     vi.useFakeTimers();
     let observedSignal: AbortSignal | undefined;
     let abortReason: unknown;
-    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+    const fetchImpl = vi.fn<typeof fetch>(async (_url, init) => {
       observedSignal = init?.signal ?? undefined;
       return new Response(
         new ReadableStream<Uint8Array>({
@@ -279,7 +279,7 @@ describe("fetchTelegramChatId", () => {
     const lookup = fetchTelegramChatId({
       token: "abc",
       chatId: "@user",
-      fetchImpl: fetchImpl as unknown as typeof fetch,
+      fetchImpl,
     });
 
     await vi.advanceTimersByTimeAsync(15_000);

--- a/extensions/telegram/src/approval-native.ts
+++ b/extensions/telegram/src/approval-native.ts
@@ -128,7 +128,7 @@ const telegramNativeApprovalCapability = createApproverRestrictedNativeApprovalC
       }),
     load: async () =>
       (await import("./approval-handler.runtime.js"))
-        .telegramApprovalNativeRuntime as unknown as ChannelApprovalNativeRuntimeAdapter,
+        .telegramApprovalNativeRuntime as ChannelApprovalNativeRuntimeAdapter,
   }),
 });
 

--- a/extensions/telegram/src/bot-handlers.inbound-authorization.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-authorization.ts
@@ -40,6 +40,13 @@ export type TelegramEventAuthorizationMode =
   | "callback-allowlist"
   | "callback-runtime-allowlist";
 
+type TelegramEventAuthorizationRule = {
+  enforceDirectAuthorization: boolean;
+  enforceGroupAllowlistAuthorization: boolean;
+  deniedDmReason: string;
+  deniedGroupReason: string;
+};
+
 export interface TelegramHandlerAuthorization {
   resolveTelegramEventAuthorizationContext: (params: {
     cfg: OpenClawConfig;
@@ -89,15 +96,7 @@ export function createTelegramHandlerAuthorization({
     shouldSkipTelegramGroupMessage(params, { logger, resolveGroupPolicy });
 
   type TelegramEventAuthorizationContextValue = TelegramEventAuthorizationContext;
-  const TELEGRAM_EVENT_AUTH_RULES: Record<
-    TelegramEventAuthorizationMode,
-    {
-      enforceDirectAuthorization: boolean;
-      enforceGroupAllowlistAuthorization: boolean;
-      deniedDmReason: string;
-      deniedGroupReason: string;
-    }
-  > = {
+  const TELEGRAM_EVENT_AUTH_RULES = {
     reaction: {
       enforceDirectAuthorization: true,
       enforceGroupAllowlistAuthorization: false,
@@ -124,7 +123,7 @@ export function createTelegramHandlerAuthorization({
       deniedDmReason: "runtime callback unauthorized by allowlist",
       deniedGroupReason: "runtime callback unauthorized by group allowlist",
     },
-  };
+  } satisfies Record<TelegramEventAuthorizationMode, TelegramEventAuthorizationRule>;
 
   // Authorization owns one ingress snapshot. The agent turn intentionally
   // captures again after batching so reloads during debounce apply to execution.

--- a/extensions/telegram/src/bot-handlers.message-lifecycle.test.ts
+++ b/extensions/telegram/src/bot-handlers.message-lifecycle.test.ts
@@ -5,14 +5,14 @@ import {
   formatTelegramAmbientTranscriptBody,
 } from "./bot-handlers.message-context.js";
 
-function message(fields: Record<string, unknown>): Message {
+function message(fields: Partial<Message>): Message {
   return {
     message_id: 1,
     date: 1_700_000_000,
     chat: { id: 42, type: "private", first_name: "Ada" },
     from: { id: 42, is_bot: false, first_name: "Ada" },
     ...fields,
-  } as unknown as Message;
+  };
 }
 
 describe("Telegram ambient transcript media text", () => {
@@ -29,7 +29,11 @@ describe("Telegram ambient transcript media text", () => {
 
   it("preserves captions instead of appending media text", () => {
     const body = formatTelegramAmbientTranscriptBody([
-      message({ message_id: 8, caption: "diagram", document: { file_id: "doc-1" } }),
+      message({
+        message_id: 8,
+        caption: "diagram",
+        document: { file_id: "doc-1", file_unique_id: "doc-u1" },
+      }),
     ]);
 
     expect(body).toBe("#8 Ada: diagram");

--- a/extensions/telegram/src/bot-handlers.message-session.runtime.test.ts
+++ b/extensions/telegram/src/bot-handlers.message-session.runtime.test.ts
@@ -1,15 +1,17 @@
 // Telegram tests cover message-session routing and persisted model inheritance.
 import type { SessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { describe, expect, it, vi } from "vitest";
-import type { TelegramBotDeps } from "./bot-deps.js";
+import { defaultTelegramBotDeps } from "./bot-deps.js";
 import { createTelegramMessageSessionRuntime } from "./bot-handlers.message-context.js";
+
+type TelegramSessionEntries = Record<string, SessionEntry>;
 
 describe("createTelegramMessageSessionRuntime", () => {
   it("inherits a DM topic model override through keyed session loads", () => {
     const storePath = "/tmp/telegram-sessions.sqlite";
     const childSessionKey = "agent:main:main:thread:12345:99";
     const parentSessionKey = "agent:main:main";
-    const entries: Record<string, SessionEntry> = {
+    const entries: TelegramSessionEntries = {
       [childSessionKey]: { sessionId: "child", updatedAt: 2 },
       [parentSessionKey]: {
         sessionId: "parent",
@@ -19,13 +21,14 @@ describe("createTelegramMessageSessionRuntime", () => {
         modelOverrideSource: "user",
       },
     };
-    const getSessionEntry = vi.fn<NonNullable<TelegramBotDeps["getSessionEntry"]>>(
+    const getSessionEntry = vi.fn<NonNullable<typeof defaultTelegramBotDeps.getSessionEntry>>(
       ({ sessionKey }) => entries[sessionKey],
     );
     const telegramDeps = {
+      ...defaultTelegramBotDeps,
       resolveStorePath: vi.fn(() => storePath),
       getSessionEntry,
-    } as Pick<TelegramBotDeps, "resolveStorePath" | "getSessionEntry"> as TelegramBotDeps;
+    };
     const { resolveTelegramSessionState } = createTelegramMessageSessionRuntime({
       accountId: "default",
       resolveTelegramGroupConfig: () => ({}),

--- a/extensions/telegram/src/bot-info-cache.test.ts
+++ b/extensions/telegram/src/bot-info-cache.test.ts
@@ -1,8 +1,11 @@
+import { createPluginStateKeyedStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 // Telegram tests cover bot info cache plugin behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   deleteCachedTelegramBotInfo,
   readCachedTelegramBotInfo,
+  TELEGRAM_BOT_INFO_CACHE_MAX_ENTRIES,
+  TELEGRAM_BOT_INFO_CACHE_NAMESPACE,
   writeCachedTelegramBotInfo,
 } from "./bot-info-cache.js";
 import type { TelegramBotInfo } from "./bot-info.js";
@@ -28,32 +31,18 @@ const botInfo: TelegramBotInfo = {
   allows_users_to_create_topics: false,
 };
 
-type BotInfoCacheValue = {
-  tokenFingerprint: string;
-  fetchedAt: string;
-  botInfo: TelegramBotInfo;
-};
-
 function useMemoryStore() {
-  const entries = new Map<string, BotInfoCacheValue>();
-  const store = {
-    async register(key: string, value: BotInfoCacheValue) {
-      entries.set(key, value);
-    },
-    async lookup(key: string) {
-      return entries.get(key);
-    },
-    async delete(key: string) {
-      return entries.delete(key);
-    },
-  };
   setTelegramRuntime({
     state: {
-      openKeyedStore: (() => store) as unknown as TelegramRuntime["state"]["openKeyedStore"],
+      openKeyedStore: (options) => createPluginStateKeyedStoreForTests("telegram", options),
     },
     channel: {},
   } as TelegramRuntime);
-  return entries;
+  return createPluginStateKeyedStoreForTests("telegram", {
+    namespace: TELEGRAM_BOT_INFO_CACHE_NAMESPACE,
+    maxEntries: TELEGRAM_BOT_INFO_CACHE_MAX_ENTRIES,
+    defaultTtlMs: BOT_INFO_CACHE_MAX_AGE_MS,
+  });
 }
 
 afterEach(() => {
@@ -132,6 +121,6 @@ describe("Telegram bot info cache", () => {
       botInfo,
     });
 
-    expect(entries.has("ops_team")).toBe(true);
+    await expect(entries.lookup("ops_team")).resolves.toBeDefined();
   });
 });

--- a/extensions/telegram/src/bot-message-context.dm-topic-threadid.test.ts
+++ b/extensions/telegram/src/bot-message-context.dm-topic-threadid.test.ts
@@ -1,4 +1,9 @@
 // Telegram tests cover bot message contextm topic threadid plugin behavior.
+import type {
+  BuildChannelInboundEventContextAsyncParams,
+  BuildChannelInboundEventContextParams,
+  BuiltChannelInboundEventContext,
+} from "openclaw/plugin-sdk/channel-inbound";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getRecordedUpdateLastRoute,
@@ -88,7 +93,23 @@ describe("buildTelegramMessageContext DM topic threadId in deliveryContext (#889
 
   it("builds Telegram payloads through the shared channel turn context", async () => {
     const { buildChannelInboundEventContext } = await import("openclaw/plugin-sdk/channel-inbound");
-    const buildChannelInboundEventContextMock = vi.fn(buildChannelInboundEventContext);
+    const buildChannelInboundEventContextCalls = vi.fn();
+    function buildChannelInboundEventContextMock(
+      params: BuildChannelInboundEventContextAsyncParams,
+    ): Promise<BuiltChannelInboundEventContext>;
+    function buildChannelInboundEventContextMock(
+      params: BuildChannelInboundEventContextParams,
+    ): BuiltChannelInboundEventContext;
+    function buildChannelInboundEventContextMock(
+      params: BuildChannelInboundEventContextAsyncParams | BuildChannelInboundEventContextParams,
+    ) {
+      buildChannelInboundEventContextCalls(params);
+      const builder: unknown = buildChannelInboundEventContext;
+      if (typeof builder !== "function") {
+        throw new TypeError("expected inbound context builder to be callable");
+      }
+      return Reflect.apply(builder, undefined, [params]);
+    }
 
     const ctx = await buildCtx({
       message: {
@@ -103,15 +124,14 @@ describe("buildTelegramMessageContext DM topic threadId in deliveryContext (#889
         from: { id: 42, first_name: "Alice", username: "alice_bot", is_bot: true },
       },
       sessionRuntime: {
-        buildChannelInboundEventContext:
-          buildChannelInboundEventContextMock as unknown as typeof buildChannelInboundEventContext,
+        buildChannelInboundEventContext: buildChannelInboundEventContextMock,
       },
     });
 
     expect(ctx?.ctxPayload.ReplyToBody).toBe("parent");
     expect(ctx?.ctxPayload.SenderIsBot).toBe(true);
-    expect(buildChannelInboundEventContextMock).toHaveBeenCalledOnce();
-    const [turnOptions] = buildChannelInboundEventContextMock.mock.calls.at(0) ?? [];
+    expect(buildChannelInboundEventContextCalls).toHaveBeenCalledOnce();
+    const [turnOptions] = buildChannelInboundEventContextCalls.mock.calls.at(0) ?? [];
     expect(turnOptions?.channel).toBe("telegram");
     expect(turnOptions?.from).toBe("telegram:1234");
     expect(turnOptions?.sender?.isBot).toBe(true);

--- a/extensions/telegram/src/bot-message-context.media-carriers.test.ts
+++ b/extensions/telegram/src/bot-message-context.media-carriers.test.ts
@@ -50,19 +50,21 @@ describe("buildTelegramMessageContext media carriers", () => {
   });
 
   it("keeps reply media structured before reply-chain rendering", () => {
-    const target = describeReplyTarget({
+    const message: Message = {
       message_id: 11,
       date: 1_700_000_000,
       chat: { id: 42, type: "private", first_name: "Ada" },
       from: { id: 42, is_bot: false, first_name: "Ada" },
       reply_to_message: {
+        reply_to_message: undefined,
         message_id: 10,
         date: 1_699_999_999,
         chat: { id: 42, type: "private", first_name: "Pat" },
         from: { id: 7, is_bot: false, first_name: "Pat" },
         photo: [{ file_id: "photo-1", file_unique_id: "photo-u1", width: 1, height: 1 }],
       },
-    } as unknown as Message);
+    };
+    const target = describeReplyTarget(message);
 
     expect(target).toMatchObject({ mediaType: "image", sender: "Pat" });
     expect(target?.body).toBeUndefined();

--- a/extensions/telegram/src/bot-message-context.require-mention.test.ts
+++ b/extensions/telegram/src/bot-message-context.require-mention.test.ts
@@ -365,7 +365,11 @@ describe("buildTelegramMessageContext requireMention precedence", () => {
   });
 
   it("lets explicit topic requireMention=false override mention activation", async () => {
-    const resolveGroupActivation = vi.fn(() => true);
+    const resolveGroupActivation = vi.fn<
+      NonNullable<
+        Parameters<typeof buildTelegramMessageContextForTest>[0]["resolveGroupActivation"]
+      >
+    >(() => true);
 
     const ctx = await buildTelegramMessageContextForTest({
       message: buildForumMessage(),
@@ -380,10 +384,7 @@ describe("buildTelegramMessageContext requireMention precedence", () => {
     if (!ctx?.ctxPayload) {
       throw new Error("expected Telegram context payload when topic disables requireMention");
     }
-    const activationCalls = resolveGroupActivation.mock.calls as unknown as Array<
-      [{ chatId: number; messageThreadId?: number; sessionKey: string }]
-    >;
-    const [activationOptions] = activationCalls[0] ?? [];
+    const [activationOptions] = resolveGroupActivation.mock.calls[0] ?? [];
     expect(activationOptions?.chatId).toBe(-1001234567890);
     expect(activationOptions?.messageThreadId).toBe(99);
     expect(activationOptions?.sessionKey).toBe("agent:main:telegram:group:-1001234567890:topic:99");

--- a/extensions/telegram/src/bot-message-context.route-test-support.ts
+++ b/extensions/telegram/src/bot-message-context.route-test-support.ts
@@ -13,9 +13,15 @@ type BuildTelegramMessageContextForTestParams = Parameters<BuildTelegramMessageC
 type BuildTelegramMessageContextParams =
   import("./bot-message-context.types.js").BuildTelegramMessageContextParams;
 
-const hoisted = vi.hoisted((): { recordInboundSessionMock: AsyncUnknownMock } => ({
-  recordInboundSessionMock: vi.fn().mockResolvedValue(undefined),
-}));
+type TelegramRouteTestHoistedMocks = {
+  recordInboundSessionMock: AsyncUnknownMock;
+};
+
+const hoisted = vi.hoisted(
+  (): TelegramRouteTestHoistedMocks => ({
+    recordInboundSessionMock: vi.fn().mockResolvedValue(undefined),
+  }),
+);
 
 export const recordInboundSessionMock: AsyncUnknownMock = hoisted.recordInboundSessionMock;
 const recordInboundSessionForTest: NonNullable<

--- a/extensions/telegram/src/bot-message-context.test-harness.ts
+++ b/extensions/telegram/src/bot-message-context.test-harness.ts
@@ -2,6 +2,7 @@
 import { createHash } from "node:crypto";
 import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import { createPluginStateKeyedStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import type { BuildTelegramMessageContextParams, TelegramMediaRef } from "./bot-message-context.js";
 import { setTelegramRuntime } from "./runtime.js";
 import type { TelegramRuntime } from "./runtime.types.js";
@@ -13,14 +14,6 @@ export const baseTelegramMessageContextConfig = {
 } as never;
 
 type TelegramTestSessionRuntime = NonNullable<BuildTelegramMessageContextParams["sessionRuntime"]>;
-type TopicNameEntryForTest = {
-  name: string;
-  iconColor?: number;
-  iconCustomEmojiId?: string;
-  closed?: boolean;
-  updatedAt: number;
-};
-
 type BuildTelegramMessageContextForTestParams = {
   message: Record<string, unknown>;
   me?: Record<string, unknown>;
@@ -43,8 +36,6 @@ type BuildTelegramMessageContextForTestParams = {
   resolveGroupRequireMention?: BuildTelegramMessageContextParams["resolveGroupRequireMention"];
   resolveTelegramGroupConfig?: BuildTelegramMessageContextParams["resolveTelegramGroupConfig"];
 };
-
-const telegramTopicNameStoresForTest = new Map<string, Map<string, TopicNameEntryForTest>>();
 
 function resolveSessionStorePathForTest(testName: string | undefined): string {
   const hash = createHash("sha256")
@@ -79,24 +70,7 @@ function createTelegramMessageContextSessionRuntimeForTest(
 function installTelegramTopicNameStoreForTest() {
   setTelegramRuntime({
     state: {
-      openKeyedStore: (({ namespace }: { namespace: string }) => {
-        const entries = telegramTopicNameStoresForTest.get(namespace) ?? new Map();
-        telegramTopicNameStoresForTest.set(namespace, entries);
-        return {
-          async register(key: string, value: TopicNameEntryForTest) {
-            entries.set(key, value);
-          },
-          async entries() {
-            return Array.from(entries, ([key, value]) => ({ key, value }));
-          },
-          async delete(key: string) {
-            return entries.delete(key);
-          },
-          async clear() {
-            entries.clear();
-          },
-        };
-      }) as unknown as TelegramRuntime["state"]["openKeyedStore"],
+      openKeyedStore: (options) => createPluginStateKeyedStoreForTests("telegram", options),
     },
     channel: {},
   } as TelegramRuntime);

--- a/extensions/telegram/src/bot-message-context.thread-binding.test.ts
+++ b/extensions/telegram/src/bot-message-context.thread-binding.test.ts
@@ -79,9 +79,11 @@ async function buildForumTopicMessageContext(accountId?: string) {
 
 function expectRouteArgs(): Record<string, unknown> {
   expect(resolveTelegramConversationRouteMock).toHaveBeenCalledTimes(1);
-  return (
-    resolveTelegramConversationRouteMock.mock.calls.at(0) as unknown as [Record<string, unknown>]
-  )[0];
+  const args = resolveTelegramConversationRouteMock.mock.calls.at(0)?.[0];
+  if (!args) {
+    throw new Error("expected Telegram conversation route args");
+  }
+  return args;
 }
 
 describe("buildTelegramMessageContext thread binding override", () => {

--- a/extensions/telegram/src/bot-message-context.typing.test.ts
+++ b/extensions/telegram/src/bot-message-context.typing.test.ts
@@ -1,6 +1,11 @@
 // Telegram tests cover bot message context.typing plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
-import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
+import {
+  buildChannelInboundEventContext,
+  type BuildChannelInboundEventContextAsyncParams,
+  type BuildChannelInboundEventContextParams,
+  type BuiltChannelInboundEventContext,
+} from "openclaw/plugin-sdk/channel-inbound";
 import { describe, expect, it, vi } from "vitest";
 import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
 import type { TelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
@@ -19,12 +24,28 @@ function createSendChatActionHandler(
   };
 }
 
+function createBuildInboundContextRecorder() {
+  const invocation = vi.fn();
+  function build(
+    params: BuildChannelInboundEventContextAsyncParams,
+  ): Promise<BuiltChannelInboundEventContext>;
+  function build(params: BuildChannelInboundEventContextParams): BuiltChannelInboundEventContext;
+  function build(
+    params: BuildChannelInboundEventContextAsyncParams | BuildChannelInboundEventContextParams,
+  ) {
+    invocation();
+    const builder: unknown = buildChannelInboundEventContext;
+    if (typeof builder !== "function") {
+      throw new TypeError("expected inbound context builder to be callable");
+    }
+    return Reflect.apply(builder, undefined, [params]);
+  }
+  return { build, invocation };
+}
+
 describe("buildTelegramMessageContext typing", () => {
   it("sends direct typing after body resolution and before session context construction", async () => {
-    const buildInboundContext = vi.fn(
-      (params: Parameters<typeof buildChannelInboundEventContext>[0]) =>
-        buildChannelInboundEventContext(params as never),
-    );
+    const buildInboundContext = createBuildInboundContextRecorder();
     const sendChatActionHandler = createSendChatActionHandler();
 
     await expect(
@@ -36,8 +57,7 @@ describe("buildTelegramMessageContext typing", () => {
         },
         sendChatActionHandler,
         sessionRuntime: {
-          buildChannelInboundEventContext:
-            buildInboundContext as unknown as typeof buildChannelInboundEventContext,
+          buildChannelInboundEventContext: buildInboundContext.build,
         },
       }),
     ).resolves.not.toBeNull();
@@ -45,7 +65,9 @@ describe("buildTelegramMessageContext typing", () => {
     expect(sendChatActionHandler.sendChatAction).toHaveBeenCalledWith(42, "typing", undefined);
     expect(
       requireInvocationOrder(sendChatActionHandler.sendChatAction.mock, "send typing invocation"),
-    ).toBeLessThan(requireInvocationOrder(buildInboundContext.mock, "inbound context invocation"));
+    ).toBeLessThan(
+      requireInvocationOrder(buildInboundContext.invocation.mock, "inbound context invocation"),
+    );
   });
 
   it("does not send direct typing when there is no replyable body", async () => {
@@ -89,10 +111,7 @@ describe("buildTelegramMessageContext typing", () => {
   });
 
   it("sends forum topic typing after accepted user-request classification and before context construction", async () => {
-    const buildInboundContext = vi.fn(
-      (params: Parameters<typeof buildChannelInboundEventContext>[0]) =>
-        buildChannelInboundEventContext(params as never),
-    );
+    const buildInboundContext = createBuildInboundContextRecorder();
     const sendChatActionHandler = createSendChatActionHandler();
 
     const ctx = await buildTelegramMessageContextForTest({
@@ -109,8 +128,7 @@ describe("buildTelegramMessageContext typing", () => {
       }),
       sendChatActionHandler,
       sessionRuntime: {
-        buildChannelInboundEventContext:
-          buildInboundContext as unknown as typeof buildChannelInboundEventContext,
+        buildChannelInboundEventContext: buildInboundContext.build,
       },
     });
 
@@ -121,7 +139,9 @@ describe("buildTelegramMessageContext typing", () => {
     });
     expect(
       requireInvocationOrder(sendChatActionHandler.sendChatAction.mock, "send typing invocation"),
-    ).toBeLessThan(requireInvocationOrder(buildInboundContext.mock, "inbound context invocation"));
+    ).toBeLessThan(
+      requireInvocationOrder(buildInboundContext.invocation.mock, "inbound context invocation"),
+    );
   });
 
   it("does not send forum topic typing for room events", async () => {

--- a/extensions/telegram/src/bot-message-dispatch-draft.ts
+++ b/extensions/telegram/src/bot-message-dispatch-draft.ts
@@ -168,10 +168,10 @@ export function createDraftState(params: TurnConfig): TelegramDraftStateSlice {
       retainedPromptContextPages: [],
     };
   };
-  const lanes: Record<LaneName, DraftLaneState> = {
+  const lanes = {
     answer: createDraftLane("answer", canStreamAnswerDraft),
     reasoning: createDraftLane("reasoning", canStreamReasoningDraft),
-  };
+  } satisfies Record<LaneName, DraftLaneState>;
   const resolvedBlockStreamingEnabled = resolveChannelStreamingBlockEnabled(params.telegramCfg);
   const disableBlockStreaming = !streamDeliveryEnabled
     ? true

--- a/extensions/telegram/src/bot-message-dispatch.context-history.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.context-history.test.ts
@@ -18,6 +18,24 @@ import type {
   TelegramMessageContext,
 } from "./bot-message-dispatch.test-harness.js";
 
+function createCtxPayload(
+  overrides: Partial<TelegramMessageContext["ctxPayload"]>,
+): TelegramMessageContext["ctxPayload"] {
+  return { ...createContext().ctxPayload, ...overrides };
+}
+
+function createMessage(
+  overrides: Partial<TelegramMessageContext["msg"]>,
+): TelegramMessageContext["msg"] {
+  return { ...createContext().msg, ...overrides };
+}
+
+function createPrimaryContext(
+  overrides: Partial<TelegramMessageContext["primaryCtx"]>,
+): TelegramMessageContext["primaryCtx"] {
+  return { ...createContext().primaryCtx, ...overrides };
+}
+
 describeTelegramDispatch("dispatchTelegramMessage context-history", () => {
   it("moves recovered room-event history out of the original topic", async () => {
     const oldHistoryKey = "-1003774691294:topic:1";
@@ -40,7 +58,7 @@ describeTelegramDispatch("dispatchTelegramMessage context-history", () => {
 
     await dispatchWithContext({
       context: createContext({
-        ctxPayload: {
+        ctxPayload: createCtxPayload({
           InboundEventKind: "room_event",
           ChatType: "group",
           From: "telegram:group:-1003774691294:topic:1",
@@ -49,11 +67,11 @@ describeTelegramDispatch("dispatchTelegramMessage context-history", () => {
           RawBody: "ambient leak",
           SessionKey: "agent:main:telegram:group:-1003774691294:topic:3731",
           TransportThreadId: 1,
-        } as unknown as TelegramMessageContext["ctxPayload"],
-        msg: {
-          chat: { id: -1003774691294, type: "supergroup" },
+        }),
+        msg: createMessage({
+          chat: { id: -1003774691294, type: "supergroup", title: "Ops" },
           message_id: 27787,
-        } as unknown as TelegramMessageContext["msg"],
+        }),
         chatId: -1003774691294,
         isGroup: true,
         threadSpec: { id: 1, scope: "forum" },
@@ -108,7 +126,7 @@ describeTelegramDispatch("dispatchTelegramMessage context-history", () => {
 
     await dispatchWithContext({
       context: createContext({
-        ctxPayload: {
+        ctxPayload: createCtxPayload({
           InboundEventKind: "room_event",
           BodyForAgent: "ambient current",
           ChatType: "group",
@@ -121,11 +139,11 @@ describeTelegramDispatch("dispatchTelegramMessage context-history", () => {
           TransportThreadId: 1,
           AmbientTranscriptPreviousMessageId: "200",
           AmbientTranscriptPreviousTimestampMs: 2,
-        } as TelegramMessageContext["ctxPayload"],
-        msg: {
-          chat: { id: -1003774691294, type: "supergroup" },
+        }),
+        msg: createMessage({
+          chat: { id: -1003774691294, type: "supergroup", title: "Ops" },
           message_id: 27787,
-        } as TelegramMessageContext["msg"],
+        }),
         chatId: -1003774691294,
         isGroup: true,
         threadSpec: { id: 1, scope: "forum" },
@@ -185,7 +203,7 @@ describeTelegramDispatch("dispatchTelegramMessage context-history", () => {
 
     await dispatchWithContext({
       context: createContext({
-        ctxPayload: {
+        ctxPayload: createCtxPayload({
           InboundEventKind: "user_request",
           Body: currentBody,
           BodyForAgent: currentBody,
@@ -197,14 +215,16 @@ describeTelegramDispatch("dispatchTelegramMessage context-history", () => {
           RawBody: currentBody,
           SessionKey: "agent:main:telegram:group:-1003774691294:topic:3731",
           TransportThreadId: 1,
-        } as unknown as TelegramMessageContext["ctxPayload"],
-        msg: {
-          chat: { id: -1003774691294, type: "supergroup" },
+        }),
+        msg: createMessage({
+          chat: { id: -1003774691294, type: "supergroup", title: "Ops" },
           message_id: 27789,
-        } as unknown as TelegramMessageContext["msg"],
-        primaryCtx: {
-          message: { chat: { id: -1003774691294, type: "supergroup" } },
-        } as unknown as TelegramMessageContext["primaryCtx"],
+        }),
+        primaryCtx: createPrimaryContext({
+          message: createMessage({
+            chat: { id: -1003774691294, type: "supergroup", title: "Ops" },
+          }),
+        }),
         chatId: -1003774691294,
         isGroup: true,
         threadSpec: { id: 1, scope: "forum" },

--- a/extensions/telegram/src/bot-message-dispatch.context-recovery.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.context-recovery.test.ts
@@ -1,5 +1,12 @@
 import { expect, it, vi } from "vitest";
 import {
+  telegramContextPayloadFixture,
+  telegramMessageFixture,
+  telegramPrimaryContextFixture,
+  telegramRouteFixture,
+  telegramTurnFixture,
+} from "./bot-message-dispatch.test-fixtures.js";
+import {
   describeTelegramDispatch,
   createChannelMessageReplyPipeline,
   createContext,
@@ -136,9 +143,9 @@ describeTelegramDispatch("dispatchTelegramMessage context-recovery", () => {
     deliverReplies.mockResolvedValue({ delivered: true });
 
     const context = createContext({
-      route: {
+      route: telegramRouteFixture({
         agentId: "work",
-      } as unknown as TelegramMessageContext["route"],
+      }),
     });
     await dispatchWithContext({ context });
 
@@ -256,7 +263,7 @@ describeTelegramDispatch("dispatchTelegramMessage context-recovery", () => {
 
     await dispatchWithContext({
       context: createContext({
-        ctxPayload: {
+        ctxPayload: telegramContextPayloadFixture({
           Body: currentBody,
           BodyForAgent: currentBody,
           ChatType: "group",
@@ -291,15 +298,15 @@ describeTelegramDispatch("dispatchTelegramMessage context-recovery", () => {
               },
             },
           ],
-        } as unknown as TelegramMessageContext["ctxPayload"],
-        msg: {
+        }),
+        msg: telegramMessageFixture({
           chat: { id: -1003774691294, type: "supergroup" },
           message_id: 27787,
           message_thread_id: undefined,
-        } as unknown as TelegramMessageContext["msg"],
-        primaryCtx: {
+        }),
+        primaryCtx: telegramPrimaryContextFixture({
           message: { chat: { id: -1003774691294, type: "supergroup" } },
-        } as unknown as TelegramMessageContext["primaryCtx"],
+        }),
         chatId: -1003774691294,
         isGroup: true,
         replyThreadId: undefined,
@@ -309,7 +316,7 @@ describeTelegramDispatch("dispatchTelegramMessage context-recovery", () => {
         historyLimit: 10,
         groupHistories,
         sendChatActionHandler,
-        turn: {
+        turn: telegramTurnFixture({
           storePath: "/tmp/openclaw/telegram-sessions.json",
           recordInboundSession,
           record: {
@@ -322,7 +329,7 @@ describeTelegramDispatch("dispatchTelegramMessage context-recovery", () => {
             },
             onRecordError: vi.fn(),
           },
-        } as unknown as TelegramMessageContext["turn"],
+        }),
       }),
       replyToMode: "off",
       streamMode: "off",
@@ -410,7 +417,7 @@ describeTelegramDispatch("dispatchTelegramMessage context-recovery", () => {
 
     await dispatchWithContext({
       context: createContext({
-        ctxPayload: {
+        ctxPayload: telegramContextPayloadFixture({
           Body: "current topic question",
           ChatType: "group",
           From: "telegram:group:-1003774691294:topic:1",
@@ -433,12 +440,12 @@ describeTelegramDispatch("dispatchTelegramMessage context-recovery", () => {
               payload: { name: "report.pdf" },
             },
           ],
-        } as unknown as TelegramMessageContext["ctxPayload"],
-        msg: {
+        }),
+        msg: telegramMessageFixture({
           chat: { id: -1003774691294, type: "supergroup" },
           message_id: 27787,
           message_thread_id: undefined,
-        } as unknown as TelegramMessageContext["msg"],
+        }),
         chatId: -1003774691294,
         isGroup: true,
         threadSpec: { id: 1, scope: "forum" },
@@ -487,7 +494,7 @@ describeTelegramDispatch("dispatchTelegramMessage context-recovery", () => {
 
     await dispatchWithContext({
       context: createContext({
-        ctxPayload: {
+        ctxPayload: telegramContextPayloadFixture({
           Body:
             "[Chat messages since your last reply - for context]\n" +
             "general topic context\n" +
@@ -501,15 +508,15 @@ describeTelegramDispatch("dispatchTelegramMessage context-recovery", () => {
           SessionKey: "agent:main:telegram:group:-1003774691294:topic:1",
           To: "telegram:-1003774691294",
           TransportThreadId: "0xE93",
-        } as unknown as TelegramMessageContext["ctxPayload"],
-        msg: {
+        }),
+        msg: telegramMessageFixture({
           chat: { id: -1003774691294, type: "supergroup" },
           message_id: 27788,
           message_thread_id: undefined,
-        } as unknown as TelegramMessageContext["msg"],
-        primaryCtx: {
+        }),
+        primaryCtx: telegramPrimaryContextFixture({
           message: { chat: { id: -1003774691294, type: "supergroup" } },
-        } as unknown as TelegramMessageContext["primaryCtx"],
+        }),
         chatId: -1003774691294,
         isGroup: true,
         replyThreadId: undefined,
@@ -553,7 +560,7 @@ describeTelegramDispatch("dispatchTelegramMessage context-recovery", () => {
 
     await dispatchWithContext({
       context: createContext({
-        ctxPayload: {
+        ctxPayload: telegramContextPayloadFixture({
           Body: "current group question",
           ChatType: "group",
           From: "telegram:group:-100555:topic:1",
@@ -562,15 +569,15 @@ describeTelegramDispatch("dispatchTelegramMessage context-recovery", () => {
           SessionKey: "agent:main:telegram:group:-1003774691294:topic:3731",
           To: "telegram:-100555",
           TransportThreadId: 1,
-        } as unknown as TelegramMessageContext["ctxPayload"],
-        msg: {
+        }),
+        msg: telegramMessageFixture({
           chat: { id: -100555, type: "supergroup" },
           message_id: 27788,
           message_thread_id: undefined,
-        } as unknown as TelegramMessageContext["msg"],
-        primaryCtx: {
+        }),
+        primaryCtx: telegramPrimaryContextFixture({
           message: { chat: { id: -100555, type: "supergroup" } },
-        } as unknown as TelegramMessageContext["primaryCtx"],
+        }),
         chatId: -100555,
         isGroup: true,
         replyThreadId: undefined,

--- a/extensions/telegram/src/bot-message-dispatch.context-recovery.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.context-recovery.test.ts
@@ -25,12 +25,11 @@ import {
   mockCallArg,
   resolveMarkdownTableMode,
 } from "./bot-message-dispatch.test-harness.js";
-import type { TelegramMessageContext } from "./bot-message-dispatch.test-harness.js";
 
 describeTelegramDispatch("dispatchTelegramMessage context-recovery", () => {
   it("skips general understanding after describing a first-seen non-vision sticker", async () => {
     describeStickerImage.mockResolvedValueOnce("A curious sticker");
-    const ctxPayload = {
+    const ctxPayload = telegramContextPayloadFixture({
       media: [{ path: "/tmp/sticker.webp", kind: "sticker" as const }],
       CommandAuthorized: true,
       Sticker: {
@@ -38,7 +37,7 @@ describeTelegramDispatch("dispatchTelegramMessage context-recovery", () => {
         fileUniqueId: "sticker-unique",
       },
       StickerMediaIncluded: true,
-    } as TelegramMessageContext["ctxPayload"];
+    });
 
     await dispatchWithContext({
       context: createContext({ ctxPayload }),
@@ -56,7 +55,7 @@ describeTelegramDispatch("dispatchTelegramMessage context-recovery", () => {
 
   it("preserves cached sticker descriptions with user text through dispatch", async () => {
     const body = "[Sticker] Cached description\nWhat is this?";
-    const ctxPayload = {
+    const ctxPayload = telegramContextPayloadFixture({
       Body: body,
       BodyForAgent: body,
       RawBody: "What is this?",
@@ -69,7 +68,7 @@ describeTelegramDispatch("dispatchTelegramMessage context-recovery", () => {
       },
       StickerMediaIncluded: true,
       SkipStickerMediaUnderstanding: true,
-    } as TelegramMessageContext["ctxPayload"];
+    });
 
     await dispatchWithContext({
       context: createContext({ ctxPayload }),
@@ -88,7 +87,7 @@ describeTelegramDispatch("dispatchTelegramMessage context-recovery", () => {
 
   it("preserves supplemental context when describing a captionless sticker", async () => {
     describeStickerImage.mockResolvedValueOnce("A contextual sticker");
-    const ctxPayload = {
+    const ctxPayload = telegramContextPayloadFixture({
       Body: "reply-chain context",
       BodyForAgent: "reply-chain context",
       RawBody: "",
@@ -99,7 +98,7 @@ describeTelegramDispatch("dispatchTelegramMessage context-recovery", () => {
         fileUniqueId: "sticker-unique",
       },
       StickerMediaIncluded: true,
-    } as TelegramMessageContext["ctxPayload"];
+    });
 
     await dispatchWithContext({ context: createContext({ ctxPayload }) });
 
@@ -108,7 +107,7 @@ describeTelegramDispatch("dispatchTelegramMessage context-recovery", () => {
   });
 
   it("does not describe supplemental media when the sticker fact has no path", async () => {
-    const ctxPayload = {
+    const ctxPayload = telegramContextPayloadFixture({
       Body: "supplemental context",
       BodyForAgent: "supplemental context",
       RawBody: "",
@@ -122,7 +121,7 @@ describeTelegramDispatch("dispatchTelegramMessage context-recovery", () => {
         fileUniqueId: "sticker-unique",
       },
       StickerMediaIncluded: true,
-    } as TelegramMessageContext["ctxPayload"];
+    });
 
     await dispatchWithContext({ context: createContext({ ctxPayload }) });
 

--- a/extensions/telegram/src/bot-message-dispatch.delivery-basics.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.delivery-basics.test.ts
@@ -24,6 +24,26 @@ import type {
   TelegramMessageContext,
 } from "./bot-message-dispatch.test-harness.js";
 
+function createCtxPayload(
+  overrides: Partial<TelegramMessageContext["ctxPayload"]>,
+): TelegramMessageContext["ctxPayload"] {
+  return { ...createContext().ctxPayload, ...overrides };
+}
+
+function createMessage(
+  overrides: Partial<TelegramMessageContext["msg"]>,
+): TelegramMessageContext["msg"] {
+  return { ...createContext().msg, ...overrides };
+}
+
+type TelegramReplyMessage = NonNullable<TelegramMessageContext["msg"]["reply_to_message"]>;
+
+function createReplyMessage(
+  overrides: Omit<Partial<TelegramReplyMessage>, "reply_to_message">,
+): TelegramReplyMessage {
+  return { ...createContext().msg, ...overrides, reply_to_message: undefined };
+}
+
 describeTelegramDispatch("dispatchTelegramMessage delivery-basics", () => {
   it("forwards cfg to direct reply delivery", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
@@ -63,13 +83,13 @@ describeTelegramDispatch("dispatchTelegramMessage delivery-basics", () => {
 
     await dispatchWithContext({
       context: createContext({
-        ctxPayload: {
+        ctxPayload: createCtxPayload({
           SessionKey: "s1",
           ChatType: "direct",
           SenderId: "42",
           SenderName: "Alice",
           SenderUsername: "alice",
-        } as unknown as TelegramMessageContext["ctxPayload"],
+        }),
       }),
       streamMode: "off",
       telegramDeps: telegramDepsForTest,
@@ -302,16 +322,16 @@ describeTelegramDispatch("dispatchTelegramMessage delivery-basics", () => {
 
     await dispatchWithContext({
       context: createContext({
-        msg: {
+        msg: createMessage({
           message_id: 1001,
-        } as unknown as TelegramMessageContext["msg"],
-        ctxPayload: {
+        }),
+        ctxPayload: createCtxPayload({
           MessageSid: "1001",
           ReplyToId: "9001",
           ReplyToBody: "quoted slice",
           ReplyToQuoteText: " quoted slice\n",
           ReplyToIsQuote: true,
-        } as unknown as TelegramMessageContext["ctxPayload"],
+        }),
       }),
     });
 
@@ -332,20 +352,20 @@ describeTelegramDispatch("dispatchTelegramMessage delivery-basics", () => {
 
     await dispatchWithContext({
       context: createContext({
-        msg: {
+        msg: createMessage({
           message_id: 1001,
-          reply_to_message: {
+          reply_to_message: createReplyMessage({
             message_id: 9001,
-            from: { is_bot: true },
-          },
-        } as unknown as TelegramMessageContext["msg"],
-        ctxPayload: {
+            from: { id: 999, is_bot: true, first_name: "OpenClaw" },
+          }),
+        }),
+        ctxPayload: createCtxPayload({
           MessageSid: "1001",
           ReplyToId: "9001",
           ReplyToBody: "quoted bot reply",
           ReplyToQuoteText: " quoted bot reply\n",
           ReplyToIsQuote: true,
-        } as unknown as TelegramMessageContext["ctxPayload"],
+        }),
       }),
     });
 
@@ -367,14 +387,14 @@ describeTelegramDispatch("dispatchTelegramMessage delivery-basics", () => {
 
     await dispatchWithContext({
       context: createContext({
-        msg: {
+        msg: createMessage({
           message_id: 1001,
           text: "Original current message",
           entities: [{ type: "bold", offset: 0, length: 8 }],
-        } as unknown as TelegramMessageContext["msg"],
-        ctxPayload: {
+        }),
+        ctxPayload: createCtxPayload({
           MessageSid: "1001",
-        } as unknown as TelegramMessageContext["ctxPayload"],
+        }),
       }),
     });
 
@@ -400,12 +420,12 @@ describeTelegramDispatch("dispatchTelegramMessage delivery-basics", () => {
 
     await dispatchWithContext({
       context: createContext({
-        ctxPayload: {
+        ctxPayload: createCtxPayload({
           ReplyToId: "9001",
           ReplyToBody: "trimmed body",
           ReplyToQuoteSourceText: "  exact reply body",
           ReplyToQuoteSourceEntities: [{ type: "italic", offset: 2, length: 5 }],
-        } as unknown as TelegramMessageContext["ctxPayload"],
+        }),
       }),
     });
 
@@ -458,17 +478,17 @@ describeTelegramDispatch("dispatchTelegramMessage delivery-basics", () => {
 
     await dispatchWithContext({
       context: createContext({
-        msg: {
+        msg: createMessage({
           message_id: 1001,
           text: "Current request",
-        } as unknown as TelegramMessageContext["msg"],
-        ctxPayload: {
+        }),
+        ctxPayload: createCtxPayload({
           MessageSid: "1001",
           SessionKey: "agent:default:telegram:direct:123",
           ReplyToId: "9001",
           ReplyToBody: "older source",
           ReplyToQuoteSourceText: "Exact older source",
-        } as unknown as TelegramMessageContext["ctxPayload"],
+        }),
       }),
     });
 
@@ -554,14 +574,14 @@ describeTelegramDispatch("dispatchTelegramMessage delivery-basics", () => {
 
       await dispatchWithContext({
         context: createContext({
-          msg: {
+          msg: createMessage({
             message_id: 1001,
             text: "Current request",
-          } as unknown as TelegramMessageContext["msg"],
-          ctxPayload: {
+          }),
+          ctxPayload: createCtxPayload({
             MessageSid: "1001",
             SessionKey: "agent:default:telegram:direct:123",
-          } as unknown as TelegramMessageContext["ctxPayload"],
+          }),
         }),
         replyToMode,
       });

--- a/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
@@ -27,8 +27,6 @@ import {
   setupDraftStreams,
   telegramProgressPreview,
 } from "./bot-message-dispatch.test-harness.js";
-import type { TelegramMessageContext } from "./bot-message-dispatch.test-harness.js";
-
 describeTelegramDispatch("dispatchTelegramMessage progress-rendering", () => {
   it("renders typed plan updates as a live checklist", async () => {
     const draftStream = createSequencedDraftStream(2001);
@@ -528,7 +526,7 @@ describeTelegramDispatch("dispatchTelegramMessage progress-rendering", () => {
 
     await dispatchWithContext({
       context: createContext({
-        ctxPayload: { SessionKey: "s1" } as unknown as TelegramMessageContext["ctxPayload"],
+        ctxPayload: { ...createContext().ctxPayload, SessionKey: "s1" },
       }),
     });
 

--- a/extensions/telegram/src/bot-message-dispatch.progress-summary.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-summary.test.ts
@@ -4,6 +4,7 @@ import {
   allDeliveredReplyTexts,
   appendAssistantMirrorMessageByIdentity,
   createContext,
+  createDirectSessionPayload,
   createReasoningStreamContext,
   createTelegramDraftStream,
   deliverReplies,
@@ -20,7 +21,6 @@ import {
   telegramProgressPreview,
   trailingFinalStatusText,
 } from "./bot-message-dispatch.test-harness.js";
-import type { TelegramMessageContext } from "./bot-message-dispatch.test-harness.js";
 import { createTestDraftStream } from "./draft-stream.test-helpers.js";
 
 describeTelegramDispatch("dispatchTelegramMessage progress-summary", () => {
@@ -171,7 +171,7 @@ describeTelegramDispatch("dispatchTelegramMessage progress-summary", () => {
 
     await dispatchWithContext({
       context: createContext({
-        ctxPayload: { SessionKey: "s1" } as unknown as TelegramMessageContext["ctxPayload"],
+        ctxPayload: { ...createDirectSessionPayload(), SessionKey: "s1" },
       }),
       streamMode: "progress",
       telegramCfg: { streaming: { mode: "progress", progress: { commentary: true } } },
@@ -210,7 +210,7 @@ describeTelegramDispatch("dispatchTelegramMessage progress-summary", () => {
 
     await dispatchWithContext({
       context: createContext({
-        ctxPayload: { SessionKey: "s1" } as unknown as TelegramMessageContext["ctxPayload"],
+        ctxPayload: { ...createDirectSessionPayload(), SessionKey: "s1" },
       }),
       streamMode: "progress",
       telegramCfg: { streaming: { mode: "progress" } },
@@ -249,7 +249,7 @@ describeTelegramDispatch("dispatchTelegramMessage progress-summary", () => {
 
     await dispatchWithContext({
       context: createContext({
-        ctxPayload: { SessionKey: "s1" } as unknown as TelegramMessageContext["ctxPayload"],
+        ctxPayload: { ...createDirectSessionPayload(), SessionKey: "s1" },
       }),
       streamMode: "progress",
       telegramCfg: { streaming: { mode: "progress" } },

--- a/extensions/telegram/src/bot-message-dispatch.reasoning-room-events.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.reasoning-room-events.test.ts
@@ -3,6 +3,7 @@ import { expect, it } from "vitest";
 import {
   describeTelegramDispatch,
   createContext,
+  createDirectSessionPayload,
   createReasoningStreamContext,
   createStatusReactionController,
   createTelegramDraftStream,
@@ -56,6 +57,7 @@ function createGroupFixture(
   const entries = params.entries ?? [{ sender: "Alice", body: "lunch at two", timestamp: 1 }];
   const historyKey = `telegram:group:${GROUP_CHAT_ID}${topicId ? `:topic:${topicId}` : ""}`;
   const groupHistories = new Map([[historyKey, entries]]);
+  const baseContext = createContext();
   const context = (
     messageId: number,
     body: string,
@@ -65,6 +67,7 @@ function createGroupFixture(
     createContext({
       ...overrides,
       ctxPayload: {
+        ...baseContext.ctxPayload,
         InboundEventKind: kind,
         SessionKey: GROUP_SESSION_KEY,
         ChatType: "group",
@@ -73,12 +76,18 @@ function createGroupFixture(
         BodyForAgent: body,
         CommandBody: body,
         ...(commandAuthorized ? { CommandAuthorized: true } : {}),
-      } as unknown as TelegramMessageContext["ctxPayload"],
+      },
       msg: {
-        chat: { id: GROUP_CHAT_ID, type: "supergroup", ...(topicId ? { is_forum: true } : {}) },
+        ...baseContext.msg,
+        chat: {
+          id: GROUP_CHAT_ID,
+          type: "supergroup",
+          title: "Ops",
+          ...(topicId ? { is_forum: true } : {}),
+        },
         message_id: messageId,
         ...(topicId ? { message_thread_id: topicId } : {}),
-      } as unknown as TelegramMessageContext["msg"],
+      },
       chatId: GROUP_CHAT_ID,
       isGroup: true,
       historyKey,
@@ -201,7 +210,7 @@ describeTelegramDispatch("dispatchTelegramMessage reasoning-room-events", () => 
 
     await dispatchWithContext({
       context: createContext({
-        ctxPayload: { SessionKey: "s1" } as unknown as TelegramMessageContext["ctxPayload"],
+        ctxPayload: { ...createDirectSessionPayload(), SessionKey: "s1" },
       }),
     });
 
@@ -255,8 +264,9 @@ describeTelegramDispatch("dispatchTelegramMessage reasoning-room-events", () => 
     await dispatchWithContext({
       context: createContext({
         ctxPayload: {
+          ...createDirectSessionPayload(),
           SessionKey: "agent:main:telegram:direct:123",
-        } as unknown as TelegramMessageContext["ctxPayload"],
+        },
       }),
       cfg: {
         agents: {

--- a/extensions/telegram/src/bot-message-dispatch.reply-targets.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.reply-targets.test.ts
@@ -26,6 +26,18 @@ import {
   registerTelegramOutboundGroupHistoryRecorder,
 } from "./outbound-message-context.js";
 
+function createCtxPayload(
+  overrides: Partial<TelegramMessageContext["ctxPayload"]>,
+): TelegramMessageContext["ctxPayload"] {
+  return { ...createContext().ctxPayload, ...overrides };
+}
+
+function createMessage(
+  overrides: Partial<TelegramMessageContext["msg"]>,
+): TelegramMessageContext["msg"] {
+  return { ...createContext().msg, ...overrides };
+}
+
 describeTelegramDispatch("dispatchTelegramMessage reply-targets", () => {
   it("does not build native quote candidates when reply mode is off", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
@@ -36,13 +48,13 @@ describeTelegramDispatch("dispatchTelegramMessage reply-targets", () => {
 
     await dispatchWithContext({
       context: createContext({
-        msg: {
+        msg: createMessage({
           message_id: 1001,
           text: "Original current message",
-        } as unknown as TelegramMessageContext["msg"],
-        ctxPayload: {
+        }),
+        ctxPayload: createCtxPayload({
           MessageSid: "1001",
-        } as unknown as TelegramMessageContext["ctxPayload"],
+        }),
       }),
       replyToMode: "off",
     });
@@ -57,16 +69,16 @@ describeTelegramDispatch("dispatchTelegramMessage reply-targets", () => {
 
     await dispatchWithContext({
       context: createContext({
-        msg: {
+        msg: createMessage({
           message_id: 1001,
-        } as unknown as TelegramMessageContext["msg"],
-        ctxPayload: {
+        }),
+        ctxPayload: createCtxPayload({
           MessageSid: "1001",
           ReplyToId: "9001",
           ReplyToBody: "quoted slice",
           ReplyToQuoteText: " quoted slice\n",
           ReplyToIsQuote: true,
-        } as unknown as TelegramMessageContext["ctxPayload"],
+        }),
       }),
       replyToMode: "off",
     });
@@ -83,7 +95,7 @@ describeTelegramDispatch("dispatchTelegramMessage reply-targets", () => {
 
     await dispatchWithContext({
       context: createContext({
-        ctxPayload: {
+        ctxPayload: createCtxPayload({
           MessageSid: "1001",
           ReplyToId: "9001",
           ReplyToBody: "quoted slice",
@@ -91,7 +103,7 @@ describeTelegramDispatch("dispatchTelegramMessage reply-targets", () => {
           ReplyToIsQuote: true,
           ReplyToQuotePosition: 12,
           ReplyToQuoteEntities: [{ type: "italic", offset: 0, length: 6 }],
-        } as unknown as TelegramMessageContext["ctxPayload"],
+        }),
       }),
       streamMode: "off",
     });
@@ -114,14 +126,14 @@ describeTelegramDispatch("dispatchTelegramMessage reply-targets", () => {
 
     await dispatchWithContext({
       context: createContext({
-        ctxPayload: {
+        ctxPayload: createCtxPayload({
           MessageSid: "1001",
           ReplyToId: "9001",
           ReplyToBody: "external quoted slice",
           ReplyToQuoteText: " external quoted slice\n",
           ReplyToIsQuote: true,
           ReplyToIsExternal: true,
-        } as unknown as TelegramMessageContext["ctxPayload"],
+        }),
       }),
       streamMode: "off",
     });
@@ -431,13 +443,13 @@ describeTelegramDispatch("dispatchTelegramMessage reply-targets", () => {
   it("records native-quote direct fallback sends as one complete projection", async () => {
     const transcriptTimestamp = Date.now() + 1_000;
     const context = createContext({
-      ctxPayload: {
+      ctxPayload: createCtxPayload({
         MessageSid: "1001",
         SessionKey: "agent:default:telegram:direct:123",
         ReplyToId: "9001",
         ReplyToQuoteText: " quoted slice\n",
         ReplyToIsQuote: true,
-      } as unknown as TelegramMessageContext["ctxPayload"],
+      }),
     });
     mockDefaultSessionEntry();
     readLatestAssistantTextByIdentity.mockResolvedValue({
@@ -505,13 +517,13 @@ describeTelegramDispatch("dispatchTelegramMessage reply-targets", () => {
   ])("correlates $name after MEDIA directive normalization", async (testCase) => {
     const storePath = `/tmp/openclaw-telegram-direct-media-${process.pid}-${testCase.name}.json`;
     const context = createContext({
-      ctxPayload: {
+      ctxPayload: createCtxPayload({
         MessageSid: "1001",
         SessionKey: "agent:default:telegram:direct:123",
         ReplyToId: "9001",
         ReplyToQuoteText: " quoted slice\n",
         ReplyToIsQuote: true,
-      } as unknown as TelegramMessageContext["ctxPayload"],
+      }),
     });
     mockDefaultSessionEntry();
     readLatestAssistantTextByIdentity.mockResolvedValue({

--- a/extensions/telegram/src/bot-message-dispatch.status-reactions.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.status-reactions.test.ts
@@ -8,7 +8,6 @@ import {
   dispatchWithContext,
   requireInvocationOrder,
 } from "./bot-message-dispatch.test-harness.js";
-import type { TelegramMessageContext } from "./bot-message-dispatch.test-harness.js";
 
 describeTelegramDispatch("dispatchTelegramMessage status-reactions", () => {
   it("does not send visible error fallbacks for room events", async () => {
@@ -17,10 +16,12 @@ describeTelegramDispatch("dispatchTelegramMessage status-reactions", () => {
       [historyKey, [{ sender: "Alice", body: "quiet failure", timestamp: 1 }]],
     ]);
     dispatchReplyWithBufferedBlockDispatcher.mockRejectedValue(new Error("provider down"));
+    const baseContext = createContext();
 
     await dispatchWithContext({
       context: createContext({
         ctxPayload: {
+          ...baseContext.ctxPayload,
           InboundEventKind: "room_event",
           SessionKey: "agent:main:telegram:group:-100123",
           ChatType: "group",
@@ -28,11 +29,12 @@ describeTelegramDispatch("dispatchTelegramMessage status-reactions", () => {
           RawBody: "ambient failure",
           BodyForAgent: "ambient failure",
           CommandBody: "ambient failure",
-        } as unknown as TelegramMessageContext["ctxPayload"],
+        },
         msg: {
-          chat: { id: -100123, type: "supergroup" },
+          ...baseContext.msg,
+          chat: { id: -100123, type: "supergroup", title: "Test Group" },
           message_id: 101,
-        } as unknown as TelegramMessageContext["msg"],
+        },
         chatId: -100123,
         isGroup: true,
         historyKey,

--- a/extensions/telegram/src/bot-message-dispatch.test-fixtures.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test-fixtures.ts
@@ -14,16 +14,16 @@ type TelegramMessageChatInput = {
   is_forum?: true;
   is_direct_messages?: true;
 };
-export type TelegramMessageFixtureInput = Omit<Partial<Message>, "chat"> & {
+type TelegramMessageFixtureInput = Omit<Partial<Message>, "chat"> & {
   chat?: TelegramMessageChatInput;
 };
-export type TelegramPrimaryContextFixtureInput = Omit<
+type TelegramPrimaryContextFixtureInput = Omit<
   Partial<TelegramMessageContext["primaryCtx"]>,
   "message"
 > & {
   message?: TelegramMessageFixtureInput;
 };
-export type TelegramTurnFixtureInput = Omit<Partial<TelegramMessageContext["turn"]>, "record"> & {
+type TelegramTurnFixtureInput = Omit<Partial<TelegramMessageContext["turn"]>, "record"> & {
   record?: Partial<TelegramMessageContext["turn"]["record"]>;
 };
 export type TelegramMessageContextOverrides = Omit<

--- a/extensions/telegram/src/bot-message-dispatch.test-fixtures.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test-fixtures.ts
@@ -1,42 +1,229 @@
-import type { Bot } from "grammy";
-import type { ChannelInboundTurnPlan } from "openclaw/plugin-sdk/channel-inbound";
+import { Bot } from "grammy";
+import type { Chat, Message } from "grammy/types";
+import { vi } from "vitest";
 import type { dispatchTelegramMessage } from "./bot-message-dispatch.js";
 
 type TelegramMessageContext = Parameters<typeof dispatchTelegramMessage>[0]["context"];
+type TelegramMessage = TelegramMessageContext["msg"];
+type TelegramMessageChatInput = {
+  id?: number;
+  type?: Chat["type"];
+  first_name?: string;
+  title?: string;
+  username?: string;
+  is_forum?: true;
+  is_direct_messages?: true;
+};
+export type TelegramMessageFixtureInput = Omit<Partial<Message>, "chat"> & {
+  chat?: TelegramMessageChatInput;
+};
+export type TelegramPrimaryContextFixtureInput = Omit<
+  Partial<TelegramMessageContext["primaryCtx"]>,
+  "message"
+> & {
+  message?: TelegramMessageFixtureInput;
+};
+export type TelegramTurnFixtureInput = Omit<Partial<TelegramMessageContext["turn"]>, "record"> & {
+  record?: Partial<TelegramMessageContext["turn"]["record"]>;
+};
+export type TelegramMessageContextOverrides = Omit<
+  Partial<TelegramMessageContext>,
+  "ctxPayload" | "msg" | "primaryCtx" | "route" | "sendChatActionHandler" | "turn"
+> & {
+  ctxPayload?: TelegramMessageContext["ctxPayload"];
+  msg?: TelegramMessageFixtureInput;
+  primaryCtx?: TelegramPrimaryContextFixtureInput;
+  route?: Partial<TelegramMessageContext["route"]>;
+  sendChatActionHandler?: Partial<TelegramMessageContext["sendChatActionHandler"]>;
+  turn?: TelegramTurnFixtureInput;
+};
 
-export function telegramMessageContextFixture(value: object): TelegramMessageContext {
-  return Reflect.apply((context: TelegramMessageContext) => context, undefined, [value]);
+function telegramChatFixture(value: TelegramMessageChatInput = {}): Chat {
+  const id = value.id ?? 123;
+  const chatType = value.type ?? "private";
+  switch (chatType) {
+    case "private":
+      return {
+        id,
+        type: "private",
+        first_name: value.first_name ?? "Test",
+        ...(value.username ? { username: value.username } : {}),
+      };
+    case "group":
+      return { id, type: "group", title: value.title ?? "Test group" };
+    case "supergroup":
+      return {
+        id,
+        type: "supergroup",
+        title: value.title ?? "Test supergroup",
+        ...(value.username ? { username: value.username } : {}),
+        ...(value.is_forum ? { is_forum: true as const } : {}),
+        ...(value.is_direct_messages ? { is_direct_messages: true as const } : {}),
+      };
+    case "channel":
+      return {
+        id,
+        type: "channel",
+        title: value.title ?? "Test channel",
+        ...(value.username ? { username: value.username } : {}),
+      };
+  }
+  chatType satisfies never;
+  throw new Error("unsupported Telegram chat fixture type");
 }
 
-export function telegramContextPayloadFixture(value: object): TelegramMessageContext["ctxPayload"] {
-  return Reflect.apply((payload: TelegramMessageContext["ctxPayload"]) => payload, undefined, [
-    value,
-  ]);
+export function telegramContextPayloadFixture(
+  value: Partial<TelegramMessageContext["ctxPayload"]> = {},
+): TelegramMessageContext["ctxPayload"] {
+  return {
+    Body: "",
+    BodyForAgent: "",
+    BodyForCommands: "",
+    ChatType: "direct",
+    CommandAuthorized: true,
+    CommandBody: "",
+    From: "telegram:123",
+    RawBody: "",
+    SessionKey: "agent:default:telegram:direct:123",
+    To: "telegram:123",
+    InboundEventKind: "user_request",
+    ...value,
+  };
 }
 
-export function telegramBotFixture(value: object): Bot {
-  return Reflect.apply((bot: Bot) => bot, undefined, [value]);
+export function createTelegramBotFixture(): Bot {
+  const bot = new Bot("test-token");
+  vi.spyOn(bot.api, "sendMessage").mockImplementation(async (chatId, text, params) => ({
+    message_id: typeof params?.message_thread_id === "number" ? params.message_thread_id : 1001,
+    date: 1_700_000_000,
+    chat: telegramChatFixture({ id: typeof chatId === "number" ? chatId : 123, type: "private" }),
+    text,
+  }));
+  vi.spyOn(bot.api, "editMessageText").mockResolvedValue(true);
+  vi.spyOn(bot.api, "deleteMessage").mockResolvedValue(true);
+  vi.spyOn(bot.api, "editForumTopic").mockResolvedValue(true);
+  return bot;
 }
 
-export function telegramDeliveryFixture(value: object) {
-  type Delivery = ChannelInboundTurnPlan<"provider_message_sending">["delivery"];
-  return Reflect.apply((delivery: Delivery) => delivery, undefined, [value]);
+export function telegramMessageFixture(value: TelegramMessageFixtureInput = {}): TelegramMessage {
+  const { chat, ...message } = value;
+  return {
+    message_id: 456,
+    date: 1_700_000_000,
+    ...message,
+    chat: telegramChatFixture(chat),
+  };
 }
 
-export function telegramMessageFixture(value: object): TelegramMessageContext["msg"] {
-  return Reflect.apply((message: TelegramMessageContext["msg"]) => message, undefined, [value]);
+export function telegramPrimaryContextFixture(
+  value: TelegramPrimaryContextFixtureInput = {},
+): TelegramMessageContext["primaryCtx"] {
+  const { message, ...context } = value;
+  return {
+    ...context,
+    message: telegramMessageFixture(message),
+    getFile:
+      value.getFile ??
+      vi.fn(async () => ({ file_id: "fixture-file", file_unique_id: "fixture-file-unique" })),
+  };
 }
 
-export function telegramPrimaryContextFixture(value: object): TelegramMessageContext["primaryCtx"] {
-  return Reflect.apply((context: TelegramMessageContext["primaryCtx"]) => context, undefined, [
-    value,
-  ]);
+export function telegramRouteFixture(
+  value: Partial<TelegramMessageContext["route"]> = {},
+): TelegramMessageContext["route"] {
+  const agentId = value.agentId ?? "default";
+  const mainSessionKey = `agent:${agentId}:main`;
+  return {
+    agentId,
+    channel: "telegram",
+    accountId: "default",
+    sessionKey: `agent:${agentId}:telegram:direct:123`,
+    mainSessionKey,
+    lastRoutePolicy: "session",
+    matchedBy: "default",
+    ...value,
+  };
 }
 
-export function telegramRouteFixture(value: object): TelegramMessageContext["route"] {
-  return Reflect.apply((route: TelegramMessageContext["route"]) => route, undefined, [value]);
+export function telegramTurnFixture(
+  value: TelegramTurnFixtureInput = {},
+): TelegramMessageContext["turn"] {
+  return {
+    storePath: "/tmp/openclaw/telegram-sessions.json",
+    recordInboundSession: vi.fn(async () => undefined),
+    ...value,
+    record: {
+      onRecordError: vi.fn(),
+      ...value.record,
+    },
+  };
 }
 
-export function telegramTurnFixture(value: object): TelegramMessageContext["turn"] {
-  return Reflect.apply((turn: TelegramMessageContext["turn"]) => turn, undefined, [value]);
+export function createTelegramMessageContextFixture(
+  overrides?: TelegramMessageContextOverrides,
+): TelegramMessageContext {
+  const msg = telegramMessageFixture({ message_thread_id: 777 });
+  const base: TelegramMessageContext = {
+    cfg: {},
+    ctxPayload: telegramContextPayloadFixture(),
+    primaryCtx: telegramPrimaryContextFixture({ message: msg }),
+    msg,
+    chatId: 123,
+    isGroup: false,
+    groupConfig: undefined,
+    resolvedThreadId: undefined,
+    replyThreadId: 777,
+    threadSpec: { id: 777, scope: "dm" },
+    historyKey: undefined,
+    historyLimit: 0,
+    groupHistories: new Map(),
+    route: telegramRouteFixture(),
+    skillFilter: undefined,
+    sendTyping: vi.fn(),
+    sendRecordVoice: vi.fn(),
+    sendChatActionHandler: {
+      sendChatAction: vi.fn(async () => undefined),
+      isSuspended: vi.fn(() => false),
+      reset: vi.fn(),
+    },
+    ackReactionPromise: null,
+    reactionApi: null,
+    isForum: false,
+    statusReactionController: null,
+    accountId: "default",
+    turn: telegramTurnFixture(),
+  };
+
+  return {
+    ...base,
+    ...overrides,
+    ctxPayload: overrides?.ctxPayload ?? base.ctxPayload,
+    primaryCtx: telegramPrimaryContextFixture({
+      ...base.primaryCtx,
+      ...overrides?.primaryCtx,
+      message: {
+        ...base.primaryCtx.message,
+        ...overrides?.primaryCtx?.message,
+        chat: {
+          ...base.primaryCtx.message.chat,
+          ...overrides?.primaryCtx?.message?.chat,
+        },
+      },
+    }),
+    msg: telegramMessageFixture({
+      ...base.msg,
+      ...overrides?.msg,
+      chat: { ...base.msg.chat, ...overrides?.msg?.chat },
+    }),
+    route: telegramRouteFixture({ ...base.route, ...overrides?.route }),
+    sendChatActionHandler: {
+      ...base.sendChatActionHandler,
+      ...overrides?.sendChatActionHandler,
+    },
+    turn: telegramTurnFixture({
+      ...base.turn,
+      ...overrides?.turn,
+      record: { ...base.turn.record, ...overrides?.turn?.record },
+    }),
+  };
 }

--- a/extensions/telegram/src/bot-message-dispatch.test-fixtures.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test-fixtures.ts
@@ -1,0 +1,42 @@
+import type { Bot } from "grammy";
+import type { ChannelInboundTurnPlan } from "openclaw/plugin-sdk/channel-inbound";
+import type { dispatchTelegramMessage } from "./bot-message-dispatch.js";
+
+type TelegramMessageContext = Parameters<typeof dispatchTelegramMessage>[0]["context"];
+
+export function telegramMessageContextFixture(value: object): TelegramMessageContext {
+  return Reflect.apply((context: TelegramMessageContext) => context, undefined, [value]);
+}
+
+export function telegramContextPayloadFixture(value: object): TelegramMessageContext["ctxPayload"] {
+  return Reflect.apply((payload: TelegramMessageContext["ctxPayload"]) => payload, undefined, [
+    value,
+  ]);
+}
+
+export function telegramBotFixture(value: object): Bot {
+  return Reflect.apply((bot: Bot) => bot, undefined, [value]);
+}
+
+export function telegramDeliveryFixture(value: object) {
+  type Delivery = ChannelInboundTurnPlan<"provider_message_sending">["delivery"];
+  return Reflect.apply((delivery: Delivery) => delivery, undefined, [value]);
+}
+
+export function telegramMessageFixture(value: object): TelegramMessageContext["msg"] {
+  return Reflect.apply((message: TelegramMessageContext["msg"]) => message, undefined, [value]);
+}
+
+export function telegramPrimaryContextFixture(value: object): TelegramMessageContext["primaryCtx"] {
+  return Reflect.apply((context: TelegramMessageContext["primaryCtx"]) => context, undefined, [
+    value,
+  ]);
+}
+
+export function telegramRouteFixture(value: object): TelegramMessageContext["route"] {
+  return Reflect.apply((route: TelegramMessageContext["route"]) => route, undefined, [value]);
+}
+
+export function telegramTurnFixture(value: object): TelegramMessageContext["turn"] {
+  return Reflect.apply((turn: TelegramMessageContext["turn"]) => turn, undefined, [value]);
+}

--- a/extensions/telegram/src/bot-message-dispatch.test-harness.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test-harness.ts
@@ -1,6 +1,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 // Telegram tests cover bot message dispatch plugin behavior.
 import type { Bot } from "grammy";
+import type { ChannelInboundTurnPlan } from "openclaw/plugin-sdk/channel-inbound";
 import {
   createPluginStateKeyedStoreForTests,
   createPluginStateSyncKeyedStoreForTests,
@@ -24,6 +25,20 @@ import type { TelegramRuntime } from "./runtime.types.js";
 export type DispatchReplyWithBufferedBlockDispatcherArgs = Parameters<
   TelegramBotDeps["dispatchReplyWithBufferedBlockDispatcher"]
 >[0];
+
+type TelegramProviderDelivery = ChannelInboundTurnPlan<"provider_message_sending">["delivery"];
+
+function requireTelegramProviderDelivery(
+  delivery: ChannelInboundTurnPlan["delivery"] | TelegramProviderDelivery,
+): TelegramProviderDelivery {
+  if (
+    "deliverWithProviderMessageSending" in delivery &&
+    typeof delivery.deliverWithProviderMessageSending === "function"
+  ) {
+    return delivery;
+  }
+  throw new Error("expected provider-owned Telegram delivery");
+}
 
 export function requireInvocationOrder(
   mock: { mock: { invocationCallOrder: number[] } },
@@ -206,7 +221,7 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
       if (!("route" in resolved) || !("delivery" in resolved)) {
         throw new Error("expected assembled Telegram channel turn plan");
       }
-      const delivery = messageFixtures.telegramDeliveryFixture(resolved.delivery);
+      const delivery = requireTelegramProviderDelivery(resolved.delivery);
       const testTurn = (params.raw as { turn: TestTurn }).turn;
       const result = await actual.runPreparedInboundReply({
         channel: resolved.channel,
@@ -568,61 +583,10 @@ export function expectWindowCollapsedTo(
   expect(preview?.text).toBe(barText);
 }
 
-export function createContext(overrides?: Partial<TelegramMessageContext>): TelegramMessageContext {
-  const base = messageFixtures.telegramMessageContextFixture({
-    cfg: {},
-    ctxPayload: {},
-    primaryCtx: { message: { chat: { id: 123, type: "private" } } },
-    msg: {
-      chat: { id: 123, type: "private" },
-      message_id: 456,
-      message_thread_id: 777,
-    },
-    chatId: 123,
-    isGroup: false,
-    groupConfig: undefined,
-    resolvedThreadId: undefined,
-    replyThreadId: 777,
-    threadSpec: { id: 777, scope: "dm" },
-    historyKey: undefined,
-    historyLimit: 0,
-    groupHistories: new Map(),
-    route: { agentId: "default", accountId: "default" },
-    skillFilter: undefined,
-    sendTyping: vi.fn(),
-    sendRecordVoice: vi.fn(),
-    sendChatActionHandler: { sendChatAction: vi.fn(async () => undefined) },
-    ackReactionPromise: null,
-    reactionApi: null,
-    isForum: false,
-    statusReactionController: null,
-    accountId: "default",
-    turn: {
-      storePath: "/tmp/openclaw/telegram-sessions.json",
-      recordInboundSession: vi.fn(async () => undefined),
-      record: {
-        onRecordError: vi.fn(),
-      },
-    },
-  });
-
-  return messageFixtures.telegramMessageContextFixture({
-    ...base,
-    ...overrides,
-    // Merge nested fields when overrides provide partial objects.
-    primaryCtx: {
-      ...(base.primaryCtx as object),
-      ...(overrides?.primaryCtx ? (overrides.primaryCtx as object) : null),
-    } as TelegramMessageContext["primaryCtx"],
-    msg: {
-      ...(base.msg as object),
-      ...(overrides?.msg ? (overrides.msg as object) : null),
-    } as TelegramMessageContext["msg"],
-    route: {
-      ...(base.route as object),
-      ...(overrides?.route ? (overrides.route as object) : null),
-    } as TelegramMessageContext["route"],
-  });
+export function createContext(
+  overrides?: messageFixtures.TelegramMessageContextOverrides,
+): TelegramMessageContext {
+  return messageFixtures.createTelegramMessageContextFixture(overrides);
 }
 
 export function createStatusReactionController() {
@@ -639,23 +603,14 @@ export function createStatusReactionController() {
 }
 
 export function createDirectSessionPayload(): TelegramMessageContext["ctxPayload"] {
-  return {
+  return messageFixtures.telegramContextPayloadFixture({
     SessionKey: "agent:test:telegram:direct:123",
     ChatType: "direct",
-  } as TelegramMessageContext["ctxPayload"];
+  });
 }
 
 export function createBot(): Bot {
-  return messageFixtures.telegramBotFixture({
-    api: {
-      sendMessage: vi.fn(async (_chatId, _text, params) => ({
-        message_id: typeof params?.message_thread_id === "number" ? params.message_thread_id : 1001,
-      })),
-      editMessageText: vi.fn(async () => ({ message_id: 1001 })),
-      deleteMessage: vi.fn().mockResolvedValue(true),
-      editForumTopic: vi.fn().mockResolvedValue(true),
-    },
-  });
+  return messageFixtures.createTelegramBotFixture();
 }
 
 export function createRuntime(): Parameters<typeof dispatchTelegramMessage>[0]["runtime"] {
@@ -725,11 +680,11 @@ export function createReasoningForumTopicContext(): TelegramMessageContext {
   });
   return createContext({
     ctxPayload: messageFixtures.telegramContextPayloadFixture({ SessionKey: "s1" }),
-    msg: messageFixtures.telegramMessageFixture({
+    msg: {
       chat: { id: -100123, type: "supergroup", is_forum: true },
       message_id: 456,
       message_thread_id: 88,
-    }),
+    },
     chatId: -100123,
     isGroup: true,
     threadSpec: { id: 88, scope: "forum" },

--- a/extensions/telegram/src/bot-message-dispatch.test-harness.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test-harness.ts
@@ -9,6 +9,7 @@ import {
 import { afterEach, beforeAll, beforeEach, describe, expect, vi } from "vitest";
 import { resolveAutoTopicLabelConfig as resolveAutoTopicLabelConfigRuntime } from "./auto-topic-label-config.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
+import * as messageFixtures from "./bot-message-dispatch.test-fixtures.js";
 import {
   createSequencedTestDraftStream,
   createTestDraftStream,
@@ -205,8 +206,7 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
       if (!("route" in resolved) || !("delivery" in resolved)) {
         throw new Error("expected assembled Telegram channel turn plan");
       }
-      const delivery =
-        resolved.delivery as unknown as import("openclaw/plugin-sdk/channel-inbound").ChannelInboundTurnPlan<"provider_message_sending">["delivery"];
+      const delivery = messageFixtures.telegramDeliveryFixture(resolved.delivery);
       const testTurn = (params.raw as { turn: TestTurn }).turn;
       const result = await actual.runPreparedInboundReply({
         channel: resolved.channel,
@@ -569,7 +569,8 @@ export function expectWindowCollapsedTo(
 }
 
 export function createContext(overrides?: Partial<TelegramMessageContext>): TelegramMessageContext {
-  const base = {
+  const base = messageFixtures.telegramMessageContextFixture({
+    cfg: {},
     ctxPayload: {},
     primaryCtx: { message: { chat: { id: 123, type: "private" } } },
     msg: {
@@ -593,16 +594,19 @@ export function createContext(overrides?: Partial<TelegramMessageContext>): Tele
     sendChatActionHandler: { sendChatAction: vi.fn(async () => undefined) },
     ackReactionPromise: null,
     reactionApi: null,
-  } as unknown as TelegramMessageContext;
-  base.turn = {
-    storePath: "/tmp/openclaw/telegram-sessions.json",
-    recordInboundSession: vi.fn(async () => undefined),
-    record: {
-      onRecordError: vi.fn(),
+    isForum: false,
+    statusReactionController: null,
+    accountId: "default",
+    turn: {
+      storePath: "/tmp/openclaw/telegram-sessions.json",
+      recordInboundSession: vi.fn(async () => undefined),
+      record: {
+        onRecordError: vi.fn(),
+      },
     },
-  } as unknown as TelegramMessageContext["turn"];
+  });
 
-  return {
+  return messageFixtures.telegramMessageContextFixture({
     ...base,
     ...overrides,
     // Merge nested fields when overrides provide partial objects.
@@ -618,7 +622,7 @@ export function createContext(overrides?: Partial<TelegramMessageContext>): Tele
       ...(base.route as object),
       ...(overrides?.route ? (overrides.route as object) : null),
     } as TelegramMessageContext["route"],
-  };
+  });
 }
 
 export function createStatusReactionController() {
@@ -642,7 +646,7 @@ export function createDirectSessionPayload(): TelegramMessageContext["ctxPayload
 }
 
 export function createBot(): Bot {
-  return {
+  return messageFixtures.telegramBotFixture({
     api: {
       sendMessage: vi.fn(async (_chatId, _text, params) => ({
         message_id: typeof params?.message_thread_id === "number" ? params.message_thread_id : 1001,
@@ -651,7 +655,7 @@ export function createBot(): Bot {
       deleteMessage: vi.fn().mockResolvedValue(true),
       editForumTopic: vi.fn().mockResolvedValue(true),
     },
-  } as unknown as Bot;
+  });
 }
 
 export function createRuntime(): Parameters<typeof dispatchTelegramMessage>[0]["runtime"] {
@@ -701,7 +705,7 @@ export function createReasoningStreamContext(): TelegramMessageContext {
     s1: { reasoningLevel: "stream" },
   });
   return createContext({
-    ctxPayload: { SessionKey: "s1" } as unknown as TelegramMessageContext["ctxPayload"],
+    ctxPayload: messageFixtures.telegramContextPayloadFixture({ SessionKey: "s1" }),
   });
 }
 
@@ -710,8 +714,8 @@ export function createReasoningDefaultContext(): TelegramMessageContext {
     s1: {},
   });
   return createContext({
-    ctxPayload: { SessionKey: "s1" } as unknown as TelegramMessageContext["ctxPayload"],
-    route: { agentId: "ops" } as unknown as TelegramMessageContext["route"],
+    ctxPayload: messageFixtures.telegramContextPayloadFixture({ SessionKey: "s1" }),
+    route: { ...createContext().route, agentId: "ops" },
   });
 }
 
@@ -720,12 +724,12 @@ export function createReasoningForumTopicContext(): TelegramMessageContext {
     s1: { reasoningLevel: "stream" },
   });
   return createContext({
-    ctxPayload: { SessionKey: "s1" } as unknown as TelegramMessageContext["ctxPayload"],
-    msg: {
+    ctxPayload: messageFixtures.telegramContextPayloadFixture({ SessionKey: "s1" }),
+    msg: messageFixtures.telegramMessageFixture({
       chat: { id: -100123, type: "supergroup", is_forum: true },
       message_id: 456,
       message_thread_id: 88,
-    } as unknown as TelegramMessageContext["msg"],
+    }),
     chatId: -100123,
     isGroup: true,
     threadSpec: { id: 88, scope: "forum" },

--- a/extensions/telegram/src/bot-message.test.ts
+++ b/extensions/telegram/src/bot-message.test.ts
@@ -1,7 +1,7 @@
 // Telegram tests cover bot message plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import type { TelegramBotDeps } from "./bot-deps.js";
+import { defaultTelegramBotDeps } from "./bot-deps.js";
 import type { TelegramMessageProcessorTurnContext } from "./bot-handlers.types.js";
 import type { TelegramMessageProcessingResult } from "./bot-processing-outcome.js";
 
@@ -64,8 +64,9 @@ describe("telegram bot message processor", () => {
   });
 
   const telegramDepsForTest = {
+    ...defaultTelegramBotDeps,
     upsertChannelPairingRequest,
-  } as unknown as TelegramBotDeps;
+  };
 
   const baseTurnContext = {
     cfg: {},
@@ -100,26 +101,32 @@ describe("telegram bot message processor", () => {
     );
   });
 
-  const baseDeps = {
-    bot: {},
-    account: {},
-    historyLimit: 0,
-    groupHistories: {},
-    dmPolicy: {},
-    allowFrom: [],
-    groupAllowFrom: [],
-    ackReactionScope: "none",
-    logger: {},
-    resolveGroupActivation: () => true,
-    resolveGroupRequireMention: () => false,
-    resolveTelegramGroupConfig: () => ({}),
-    runtime: {},
-    replyToMode: "auto",
-    streamMode: "partial",
-    textLimit: 4096,
-    telegramDeps: telegramDepsForTest,
-    opts: {},
-  } as unknown as Parameters<typeof createTelegramMessageProcessor>[0];
+  const baseDeps = Reflect.apply(
+    (deps: Parameters<typeof createTelegramMessageProcessor>[0]) => deps,
+    undefined,
+    [
+      {
+        bot: {},
+        account: {},
+        historyLimit: 0,
+        groupHistories: {},
+        dmPolicy: {},
+        allowFrom: [],
+        groupAllowFrom: [],
+        ackReactionScope: "none",
+        logger: {},
+        resolveGroupActivation: () => true,
+        resolveGroupRequireMention: () => false,
+        resolveTelegramGroupConfig: () => ({}),
+        runtime: {},
+        replyToMode: "auto",
+        streamMode: "partial",
+        textLimit: 4096,
+        telegramDeps: telegramDepsForTest,
+        opts: {},
+      },
+    ],
+  );
 
   async function processSampleMessage(
     processMessage: ReturnType<typeof createTelegramMessageProcessor>,
@@ -128,14 +135,14 @@ describe("telegram bot message processor", () => {
     options: Parameters<typeof processMessage>[4] = {},
     allMedia: Parameters<typeof processMessage>[1] = [],
   ) {
-    return await processMessage(
+    return await Reflect.apply(processMessage, undefined, [
       {
         message: {
           chat: { id: 123, type: "private", title: "chat" },
           message_id: 456,
         },
         ...primaryCtxOverrides,
-      } as unknown as Parameters<typeof processMessage>[0],
+      },
       allMedia,
       [],
       {
@@ -147,7 +154,7 @@ describe("telegram bot message processor", () => {
       undefined,
       undefined,
       undefined,
-    );
+    ]);
   }
 
   function createDispatchFailureHarness(
@@ -158,11 +165,13 @@ describe("telegram bot message processor", () => {
     const dispatchError = new Error("dispatch exploded");
     buildTelegramMessageContext.mockResolvedValue(createMessageContext(context));
     dispatchTelegramMessage.mockRejectedValue(dispatchError);
-    const processMessage = createTelegramMessageProcessor({
-      ...baseDeps,
-      bot: { api: { sendMessage } },
-      runtime: { error: runtimeError },
-    } as unknown as Parameters<typeof createTelegramMessageProcessor>[0]);
+    const processMessage = Reflect.apply(createTelegramMessageProcessor, undefined, [
+      {
+        ...baseDeps,
+        bot: { api: { sendMessage } },
+        runtime: { error: runtimeError },
+      },
+    ]);
     return { processMessage, runtimeError, dispatchError };
   }
 
@@ -807,11 +816,13 @@ describe("telegram bot message processor", () => {
     const runtimeError = vi.fn();
     buildTelegramMessageContext.mockResolvedValue(createMessageContext({ chatId: 123 }));
     dispatchTelegramMessage.mockResolvedValue({ kind: "failed-retryable", error: dispatchError });
-    const processMessage = createTelegramMessageProcessor({
-      ...baseDeps,
-      bot: { api: { sendMessage } },
-      runtime: { error: runtimeError },
-    } as unknown as Parameters<typeof createTelegramMessageProcessor>[0]);
+    const processMessage = Reflect.apply(createTelegramMessageProcessor, undefined, [
+      {
+        ...baseDeps,
+        bot: { api: { sendMessage } },
+        runtime: { error: runtimeError },
+      },
+    ]);
     const update = { update_id: 123457 };
     const replay = await runWithTelegramSpooledReplayUpdate(update, async () =>
       processSampleMessage(processMessage, undefined, { update }),

--- a/extensions/telegram/src/bot-native-command-builtins.ts
+++ b/extensions/telegram/src/bot-native-command-builtins.ts
@@ -47,6 +47,8 @@ type TelegramCommandMenuModelContext = {
   fastMode?: SessionEntry["fastMode"];
 };
 
+type TelegramFastCommandModelContext = Pick<TelegramCommandMenuModelContext, "provider" | "model">;
+
 function buildTelegramCommandMenuModelContext(params: {
   provider: string;
   model: string;
@@ -131,7 +133,7 @@ function resolveTelegramFastCommandModelContext(params: {
   cfg: OpenClawConfig;
   agentId: string;
   sessionKey: string;
-}): { provider?: string; model?: string } {
+}): TelegramFastCommandModelContext {
   const defaultModel = resolveDefaultModelForAgent({ cfg: params.cfg, agentId: params.agentId });
   const fallback = () => ({ provider: defaultModel.provider, model: defaultModel.model });
   if (!params.sessionKey.trim()) {

--- a/extensions/telegram/src/bot-native-command-dispatch.routing.test.ts
+++ b/extensions/telegram/src/bot-native-command-dispatch.routing.test.ts
@@ -52,14 +52,14 @@ describe("Telegram native command dispatch routing", () => {
     expect(turnPlan?.replyOptions?.[Symbol.for("openclaw.pluginCommandDispatch") as never]).toEqual(
       { kind: "non-plugin" },
     );
-    const call = (
-      sessionMocks.recordSessionMetaFromInbound.mock.calls as unknown as Array<
-        [{ sessionKey?: string; ctx?: { OriginatingChannel?: string; Provider?: string } }]
-      >
-    )[0]?.[0];
-    expect(call?.ctx?.OriginatingChannel).toBe("telegram");
-    expect(call?.ctx?.Provider).toBe("telegram");
-    expect(call?.sessionKey).toBe(turnPlan?.ctxPayload.CommandTargetSessionKey);
+    const call = requireRecord(
+      firstMockArg(sessionMocks.recordSessionMetaFromInbound, "recordSessionMetaFromInbound"),
+      "session metadata call",
+    );
+    const callCtx = requireRecord(call.ctx, "session metadata context");
+    expect(callCtx.OriginatingChannel).toBe("telegram");
+    expect(callCtx.Provider).toBe("telegram");
+    expect(call.sessionKey).toBe(turnPlan?.ctxPayload.CommandTargetSessionKey);
     expect(turnPlan?.record?.sessionKey).toBe(turnPlan?.ctxPayload.CommandTargetSessionKey);
   });
 
@@ -167,18 +167,18 @@ describe("Telegram native command dispatch routing", () => {
 
     expect(persistentBindingMocks.resolveConfiguredBindingRoute).toHaveBeenCalledTimes(1);
     expect(persistentBindingMocks.ensureConfiguredBindingRouteReady).toHaveBeenCalledTimes(1);
-    const dispatchCall = (
-      replyMocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls as unknown as Array<
-        [{ ctx?: { CommandTargetSessionKey?: string } }]
-      >
-    )[0]?.[0];
-    expect(dispatchCall?.ctx?.CommandTargetSessionKey).toBe(boundSessionKey);
-    const sessionMetaCall = (
-      sessionMocks.recordSessionMetaFromInbound.mock.calls as unknown as Array<
-        [{ sessionKey?: string }]
-      >
-    )[0]?.[0];
-    expect(sessionMetaCall?.sessionKey).toBe(boundSessionKey);
+    const dispatchCall = requireRecord(
+      firstMockArg(replyMocks.dispatchReplyWithBufferedBlockDispatcher, "dispatch reply"),
+      "dispatch call",
+    );
+    expect(requireRecord(dispatchCall.ctx, "dispatch context").CommandTargetSessionKey).toBe(
+      boundSessionKey,
+    );
+    const sessionMetaCall = requireRecord(
+      firstMockArg(sessionMocks.recordSessionMetaFromInbound, "record session metadata"),
+      "session metadata call",
+    );
+    expect(sessionMetaCall.sessionKey).toBe(boundSessionKey);
   });
 
   it("routes Telegram native commands through topic-specific agent sessions", async () => {
@@ -193,22 +193,22 @@ describe("Telegram native command dispatch routing", () => {
     });
     await handler(createTelegramTopicCommandContext());
 
-    const dispatchCall = (
-      replyMocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls as unknown as Array<
-        [{ ctx?: { CommandTargetSessionKey?: string } }]
-      >
-    )[0]?.[0];
-    expect(dispatchCall?.ctx?.CommandTargetSessionKey).toBe(
+    const dispatchCall = requireRecord(
+      firstMockArg(replyMocks.dispatchReplyWithBufferedBlockDispatcher, "dispatch reply"),
+      "dispatch call",
+    );
+    const dispatchCtx = requireRecord(dispatchCall.ctx, "dispatch context");
+    expect(dispatchCtx.CommandTargetSessionKey).toBe(
       "agent:zu:telegram:group:-1001234567890:topic:42",
     );
-    const sessionMetaCall = (
-      sessionMocks.recordSessionMetaFromInbound.mock.calls as unknown as Array<
-        [{ sessionKey?: string; ctx?: { From?: string; ChatType?: string } }]
-      >
-    )[0]?.[0];
-    expect(sessionMetaCall?.sessionKey).toBe("agent:zu:telegram:group:-1001234567890:topic:42");
-    expect(sessionMetaCall?.ctx?.From).toBe("telegram:group:-1001234567890:topic:42");
-    expect(sessionMetaCall?.ctx?.ChatType).toBe("group");
+    const sessionMetaCall = requireRecord(
+      firstMockArg(sessionMocks.recordSessionMetaFromInbound, "record session metadata"),
+      "session metadata call",
+    );
+    const sessionCtx = requireRecord(sessionMetaCall.ctx, "session metadata context");
+    expect(sessionMetaCall.sessionKey).toBe("agent:zu:telegram:group:-1001234567890:topic:42");
+    expect(sessionCtx.From).toBe("telegram:group:-1001234567890:topic:42");
+    expect(sessionCtx.ChatType).toBe("group");
   });
 
   it("does not mark paired Telegram DM allowlist entries as native group command owners", async () => {
@@ -232,19 +232,13 @@ describe("Telegram native command dispatch routing", () => {
     });
     await handler(createTelegramPrivateCommandContext());
 
-    const dispatchCall = (
-      replyMocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls as unknown as Array<
-        [
-          {
-            ctx?: {
-              CommandAuthorized?: boolean;
-            };
-          },
-        ]
-      >
-    )[0]?.[0];
-    expect(dispatchCall?.ctx?.CommandAuthorized).toBe(true);
-    expect(dispatchCall?.ctx).not.toHaveProperty("OwnerAllowFrom");
+    const dispatchCall = requireRecord(
+      firstMockArg(replyMocks.dispatchReplyWithBufferedBlockDispatcher, "dispatch reply"),
+      "dispatch call",
+    );
+    const dispatchCtx = requireRecord(dispatchCall.ctx, "dispatch context");
+    expect(dispatchCtx.CommandAuthorized).toBe(true);
+    expect(dispatchCtx).not.toHaveProperty("OwnerAllowFrom");
   });
 
   it("routes Telegram native commands through bound topic sessions", async () => {
@@ -265,18 +259,17 @@ describe("Telegram native command dispatch routing", () => {
       accountId: "default",
       conversationId: "-1001234567890:topic:42",
     });
-    const dispatchCall = (
-      replyMocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls as unknown as Array<
-        [{ ctx?: { CommandTargetSessionKey?: string } }]
-      >
-    )[0]?.[0];
-    expect(dispatchCall?.ctx?.CommandTargetSessionKey).toBe("agent:codex-acp:session-1");
-    const sessionMetaCall = (
-      sessionMocks.recordSessionMetaFromInbound.mock.calls as unknown as Array<
-        [{ sessionKey?: string }]
-      >
-    )[0]?.[0];
-    expect(sessionMetaCall?.sessionKey).toBe("agent:codex-acp:session-1");
+    const dispatchCall = requireRecord(
+      firstMockArg(replyMocks.dispatchReplyWithBufferedBlockDispatcher, "dispatch reply"),
+      "dispatch call",
+    );
+    const dispatchCtx = requireRecord(dispatchCall.ctx, "dispatch context");
+    expect(dispatchCtx.CommandTargetSessionKey).toBe("agent:codex-acp:session-1");
+    const sessionMetaCall = requireRecord(
+      firstMockArg(sessionMocks.recordSessionMetaFromInbound, "record session metadata"),
+      "session metadata call",
+    );
+    expect(sessionMetaCall.sessionKey).toBe("agent:codex-acp:session-1");
     expect(sessionBindingMocks.touch).toHaveBeenCalledWith(
       "default:-1001234567890:topic:42",
       undefined,
@@ -301,19 +294,18 @@ describe("Telegram native command dispatch routing", () => {
       accountId: "default",
       conversationId: "-1001234567890",
     });
-    const dispatchCall = (
-      replyMocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls as unknown as Array<
-        [{ ctx?: { CommandTargetSessionKey?: string; OriginatingTo?: string } }]
-      >
-    )[0]?.[0];
-    expect(dispatchCall?.ctx?.CommandTargetSessionKey).toBe("agent:codex-acp:session-group");
-    expect(dispatchCall?.ctx?.OriginatingTo).toBe("telegram:-1001234567890");
-    const sessionMetaCall = (
-      sessionMocks.recordSessionMetaFromInbound.mock.calls as unknown as Array<
-        [{ sessionKey?: string }]
-      >
-    )[0]?.[0];
-    expect(sessionMetaCall?.sessionKey).toBe("agent:codex-acp:session-group");
+    const dispatchCall = requireRecord(
+      firstMockArg(replyMocks.dispatchReplyWithBufferedBlockDispatcher, "dispatch reply"),
+      "dispatch call",
+    );
+    const dispatchCtx = requireRecord(dispatchCall.ctx, "dispatch context");
+    expect(dispatchCtx.CommandTargetSessionKey).toBe("agent:codex-acp:session-group");
+    expect(dispatchCtx.OriginatingTo).toBe("telegram:-1001234567890");
+    const sessionMetaCall = requireRecord(
+      firstMockArg(sessionMocks.recordSessionMetaFromInbound, "record session metadata"),
+      "session metadata call",
+    );
+    expect(sessionMetaCall.sessionKey).toBe("agent:codex-acp:session-group");
     expect(sessionBindingMocks.touch).toHaveBeenCalledWith("default:-1001234567890", undefined);
   });
 
@@ -328,21 +320,12 @@ describe("Telegram native command dispatch routing", () => {
       });
       await handler(createTelegramTopicCommandContext());
 
-      const dispatchCall = (
-        replyMocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls as unknown as Array<
-          [
-            {
-              ctx?: {
-                CommandTargetSessionKey?: string;
-                MessageThreadId?: number;
-                OriginatingTo?: string;
-              };
-            },
-          ]
-        >
-      )[0]?.[0];
+      const dispatchCall = requireRecord(
+        firstMockArg(replyMocks.dispatchReplyWithBufferedBlockDispatcher, "dispatch reply"),
+        "dispatch call",
+      );
       expectRecordFields(
-        dispatchCall?.ctx,
+        requireRecord(dispatchCall.ctx, "dispatch context"),
         {
           CommandTargetSessionKey: "agent:main:telegram:group:-1001234567890:topic:42",
           MessageThreadId: 42,

--- a/extensions/telegram/src/bot-native-command-executors.test-support.ts
+++ b/extensions/telegram/src/bot-native-command-executors.test-support.ts
@@ -140,6 +140,9 @@ export const dispatchChannelInboundTurnMock = vi.fn<DispatchChannelInboundTurnFn
     dispatchResult,
   };
 });
+const dispatchChannelInboundTurnForCommands: NonNullable<
+  TelegramNativeCommandDeps["dispatchChannelInboundTurn"]
+> = async (plan) => await Reflect.apply(dispatchChannelInboundTurnMock, undefined, [plan]);
 const sessionBindingMocks = vi.hoisted(() => ({
   resolveByConversation: vi.fn<
     (ref: unknown) => { bindingId: string; targetSessionKey: string } | null
@@ -256,9 +259,7 @@ vi.mock("./bot-native-commands.runtime.js", () => {
     getSessionEntry: sessionMocks.getSessionEntry,
     resolveChunkMode,
     resolveThreadSessionKeys,
-    dispatchChannelInboundTurn: dispatchChannelInboundTurnMock as unknown as NonNullable<
-      TelegramNativeCommandDeps["dispatchChannelInboundTurn"]
-    >,
+    dispatchChannelInboundTurn: dispatchChannelInboundTurnForCommands,
   };
 });
 vi.mock("./bot/delivery.js", () => ({
@@ -271,6 +272,10 @@ vi.mock("./bot/delivery.replies.js", () => ({
 export let activePluginRegistry: ReturnType<typeof createEmptyPluginRegistry>;
 
 type TelegramCommandHandler = (ctx: unknown) => Promise<void>;
+type RegisteredCommandHandler = {
+  handler: TelegramCommandHandler;
+  sendMessage: ReturnType<typeof vi.fn>;
+};
 type TelegramPluginCommandSpecs = Array<{
   name: string;
   description: string;
@@ -286,10 +291,7 @@ export function registerAndResolveStatusHandler(params: {
   storeAllowFrom?: string[];
   telegramCfg?: NativeCommandTestParams["telegramCfg"];
   resolveTelegramGroupConfig?: RegisterTelegramHandlerParams["resolveTelegramGroupConfig"];
-}): {
-  handler: TelegramCommandHandler;
-  sendMessage: ReturnType<typeof vi.fn>;
-} {
+}): RegisteredCommandHandler {
   const {
     cfg,
     runtimeCfg,
@@ -322,10 +324,7 @@ function registerAndResolveCommandHandlerBase(params: {
   resolveTelegramGroupConfig?: RegisterTelegramHandlerParams["resolveTelegramGroupConfig"];
   pluginCommandSpecs?: TelegramPluginCommandSpecs;
   runModelsAuthLoginFlow?: TelegramLoginFlow;
-}): {
-  handler: TelegramCommandHandler;
-  sendMessage: ReturnType<typeof vi.fn>;
-} {
+}): RegisteredCommandHandler {
   const {
     commandName,
     cfg,
@@ -345,9 +344,7 @@ function registerAndResolveCommandHandlerBase(params: {
   const telegramDeps: TelegramNativeCommandDeps = {
     getRuntimeConfig: vi.fn(() => commandRuntimeCfg),
     readChannelAllowFromStore: vi.fn(async () => storeAllowFrom ?? []),
-    dispatchChannelInboundTurn: dispatchChannelInboundTurnMock as unknown as NonNullable<
-      TelegramNativeCommandDeps["dispatchChannelInboundTurn"]
-    >,
+    dispatchChannelInboundTurn: dispatchChannelInboundTurnForCommands,
     listSkillCommandsForAgents: vi.fn(() => []),
     syncTelegramMenuCommands: vi.fn(),
     sendMessageTelegram: vi.fn(async (_to, text) => {
@@ -366,8 +363,17 @@ function registerAndResolveCommandHandlerBase(params: {
         }),
       ).toEqual({ ok: true });
     }
-    registerTelegramNativeCommands({
-      ...createNativeCommandTestParams({
+    const commandParams = createNativeCommandTestParams({
+      cfg,
+      allowFrom,
+      groupAllowFrom,
+      telegramCfg,
+      resolveTelegramGroupConfig,
+      telegramDeps,
+    });
+    Reflect.apply(registerTelegramNativeCommands, undefined, [
+      {
+        ...commandParams,
         bot: {
           api: {
             setMyCommands: vi.fn().mockResolvedValue(undefined),
@@ -376,15 +382,9 @@ function registerAndResolveCommandHandlerBase(params: {
           command: vi.fn((name: string, cb: TelegramCommandHandler) => {
             commandHandlers.set(name, cb);
           }),
-        } as unknown as NativeCommandTestParams["bot"],
-        cfg,
-        allowFrom,
-        groupAllowFrom,
-        telegramCfg,
-        resolveTelegramGroupConfig,
-        telegramDeps,
-      }),
-    });
+        },
+      },
+    ]);
   });
 
   const handler = commandHandlers.get(commandName);
@@ -404,10 +404,7 @@ export function registerAndResolveCommandHandler(params: {
   resolveTelegramGroupConfig?: RegisterTelegramHandlerParams["resolveTelegramGroupConfig"];
   pluginCommandSpecs?: TelegramPluginCommandSpecs;
   runModelsAuthLoginFlow?: TelegramLoginFlow;
-}): {
-  handler: TelegramCommandHandler;
-  sendMessage: ReturnType<typeof vi.fn>;
-} {
+}): RegisteredCommandHandler {
   const {
     commandName,
     cfg,

--- a/extensions/telegram/src/bot-native-command-login.test.ts
+++ b/extensions/telegram/src/bot-native-command-login.test.ts
@@ -61,6 +61,9 @@ vi.mock("openclaw/plugin-sdk/session-store-runtime", async () => {
 
 type LoginFlowMock = ReturnType<typeof vi.fn>;
 type TelegramLoginFlow = NonNullable<TelegramNativeCommandDeps["runModelsAuthLoginFlow"]>;
+interface TelegramLoginSessionStore {
+  [sessionKey: string]: SessionEntry;
+}
 
 let loginAccountIndex = 0;
 
@@ -646,7 +649,7 @@ describe("registerTelegramNativeCommands /login", () => {
 
   it("moves a session created while Telegram login is pending to the returned profile", async () => {
     const finishLogin = createDeferred<void>();
-    let sessionStore: Record<string, SessionEntry> = {};
+    let sessionStore: TelegramLoginSessionStore = {};
     loginSessionMocks.loadSessionStore.mockImplementation(() => sessionStore);
     const runModelsAuthLoginFlow = vi.fn<TelegramLoginFlow>(async (opts) => {
       await opts.prompter.deviceCode?.({
@@ -709,7 +712,7 @@ describe("registerTelegramNativeCommands /login", () => {
 
   it("preserves a later user-selected profile on a session created during Telegram login", async () => {
     const finishLogin = createDeferred<void>();
-    let sessionStore: Record<string, SessionEntry> = {};
+    let sessionStore: TelegramLoginSessionStore = {};
     loginSessionMocks.loadSessionStore.mockImplementation(() => sessionStore);
     const runModelsAuthLoginFlow = vi.fn<TelegramLoginFlow>(async (opts) => {
       await opts.prompter.deviceCode?.({

--- a/extensions/telegram/src/bot-native-command-menu-sync.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu-sync.test.ts
@@ -94,18 +94,20 @@ function syncMenuCommandsWithMocks(options: SyncMenuOptions): void {
     ...(options.deleteMyCommands ? { deleteMyCommands: options.deleteMyCommands } : {}),
     setMyCommands: options.setMyCommands,
   };
-  syncTelegramMenuCommands({
-    bot: { api } as unknown as Parameters<typeof syncTelegramMenuCommands>[0]["bot"],
-    runtime: {
-      log: options.runtimeLog ?? vi.fn(),
-      error: options.runtimeError ?? vi.fn(),
-      exit: vi.fn(),
-    } as Parameters<typeof syncTelegramMenuCommands>[0]["runtime"],
-    commandsToRegister: options.commandsToRegister,
-    accountId: options.accountId,
-    botId: options.botId,
-    botToken: resolveTestBotToken(options),
-  });
+  Reflect.apply(syncTelegramMenuCommands, undefined, [
+    {
+      bot: { api },
+      runtime: {
+        log: options.runtimeLog ?? vi.fn(),
+        error: options.runtimeError ?? vi.fn(),
+        exit: vi.fn(),
+      } as Parameters<typeof syncTelegramMenuCommands>[0]["runtime"],
+      commandsToRegister: options.commandsToRegister,
+      accountId: options.accountId,
+      botId: options.botId,
+      botToken: resolveTestBotToken(options),
+    },
+  ]);
 }
 
 function setMyCommandsCall(setMyCommands: ReturnType<typeof vi.fn>, index: number): unknown[] {

--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -29,19 +29,21 @@ type SyncMenuOptions = {
 };
 
 function syncMenuCommandsWithMocks(options: SyncMenuOptions): void {
-  syncTelegramMenuCommands({
-    bot: {
-      api: { deleteMyCommands: options.deleteMyCommands, setMyCommands: options.setMyCommands },
-    } as unknown as Parameters<typeof syncTelegramMenuCommands>[0]["bot"],
-    runtime: {
-      log: options.runtimeLog ?? vi.fn(),
-      error: options.runtimeError ?? vi.fn(),
-      exit: vi.fn(),
-    } as Parameters<typeof syncTelegramMenuCommands>[0]["runtime"],
-    commandsToRegister: options.commandsToRegister,
-    accountId: options.accountId,
-    botToken: options.botToken,
-  });
+  Reflect.apply(syncTelegramMenuCommands, undefined, [
+    {
+      bot: {
+        api: { deleteMyCommands: options.deleteMyCommands, setMyCommands: options.setMyCommands },
+      },
+      runtime: {
+        log: options.runtimeLog ?? vi.fn(),
+        error: options.runtimeError ?? vi.fn(),
+        exit: vi.fn(),
+      } as Parameters<typeof syncTelegramMenuCommands>[0]["runtime"],
+      commandsToRegister: options.commandsToRegister,
+      accountId: options.accountId,
+      botToken: options.botToken,
+    },
+  ]);
 }
 
 function setMyCommandsCall(setMyCommands: ReturnType<typeof vi.fn>, index: number): unknown[] {
@@ -473,12 +475,14 @@ describe("bot-native-command-menu", () => {
       { name: "valid", description: " Works " },
       { name: "missing-description", description: undefined },
       { name: undefined, description: "Missing name" },
-    ] as unknown as Parameters<typeof buildPluginTelegramMenuCommands>[0]["specs"];
+    ];
 
-    const result = buildPluginTelegramMenuCommands({
-      specs: malformedSpecs,
-      existingCommands: new Set<string>(),
-    });
+    const result = Reflect.apply(buildPluginTelegramMenuCommands, undefined, [
+      {
+        specs: malformedSpecs,
+        existingCommands: new Set<string>(),
+      },
+    ]);
 
     expect(result.commands).toEqual([{ command: "valid", description: "Works" }]);
     expect(result.issues).toContain(

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -49,6 +49,34 @@ type TelegramPluginCommandSpec = {
 type TelegramSelectedPluginMenuCommand<TSpec extends TelegramPluginCommandSpec> =
   TelegramMenuCommand & { spec: TSpec };
 
+type TelegramFittedMenuCommands = {
+  commands: TelegramMenuCommand[];
+  descriptionTrimmed: boolean;
+  textBudgetDropCount: number;
+};
+
+type TelegramPluginMenuCommands<TSpec extends TelegramPluginCommandSpec> = {
+  commands: TelegramMenuCommand[];
+  selectedCommands: TelegramSelectedPluginMenuCommand<TSpec>[];
+  issues: string[];
+};
+
+type TelegramCappedMenuCommands = {
+  commandsToRegister: TelegramMenuCommand[];
+  totalCommands: number;
+  maxCommands: number;
+  overflowCount: number;
+  maxTotalChars: number;
+  descriptionTrimmed: boolean;
+  textBudgetDropCount: number;
+  skillCommandsOmitted: boolean;
+};
+
+type TelegramLocalizedCommandVariants = {
+  variants: Array<{ languageCode: LanguageCode; commands: TelegramMenuCommand[] }>;
+  unsupportedLanguageCodes: string[];
+};
+
 const TELEGRAM_COMMAND_MENU_SCOPES: readonly TelegramCommandMenuScope[] = [
   { label: "default" },
   { label: "all_group_chats", options: { scope: { type: "all_group_chats" } } },
@@ -93,11 +121,7 @@ function truncateTelegramCommandText(value: string, maxLength: number): string {
 function fitTelegramCommandsWithinTextBudget(
   commands: TelegramMenuCommand[],
   maxTotalChars: number,
-): {
-  commands: TelegramMenuCommand[];
-  descriptionTrimmed: boolean;
-  textBudgetDropCount: number;
-} {
+): TelegramFittedMenuCommands {
   let candidateCommands = [...commands];
   while (candidateCommands.length > 0) {
     const commandNameChars = candidateCommands.reduce(
@@ -188,11 +212,7 @@ function formatTelegramCommandRetrySuccessLog(params: {
 export function buildPluginTelegramMenuCommands<TSpec extends TelegramPluginCommandSpec>(params: {
   specs: readonly TSpec[];
   existingCommands: Set<string>;
-}): {
-  commands: TelegramMenuCommand[];
-  selectedCommands: TelegramSelectedPluginMenuCommand<TSpec>[];
-  issues: string[];
-} {
+}): TelegramPluginMenuCommands<TSpec> {
   const { specs, existingCommands } = params;
   const commands: TelegramMenuCommand[] = [];
   const selectedCommands: TelegramSelectedPluginMenuCommand<TSpec>[] = [];
@@ -297,16 +317,7 @@ function buildUncachedCappedTelegramMenuCommands(params: {
   allCommands: TelegramMenuCommand[];
   maxCommands: number;
   maxTotalChars: number;
-}): {
-  commandsToRegister: TelegramMenuCommand[];
-  totalCommands: number;
-  maxCommands: number;
-  overflowCount: number;
-  maxTotalChars: number;
-  descriptionTrimmed: boolean;
-  textBudgetDropCount: number;
-  skillCommandsOmitted: boolean;
-} {
+}): TelegramCappedMenuCommands {
   const { allCommands, maxCommands, maxTotalChars } = params;
   const fitCommands = (commands: TelegramMenuCommand[]) => {
     const cappedCommands = commands.slice(0, maxCommands);
@@ -458,10 +469,9 @@ function toTelegramBotCommands(commands: TelegramMenuCommand[]): Array<{
   }));
 }
 
-function buildLocalizedCommandVariants(commands: TelegramMenuCommand[]): {
-  variants: Array<{ languageCode: LanguageCode; commands: TelegramMenuCommand[] }>;
-  unsupportedLanguageCodes: string[];
-} {
+function buildLocalizedCommandVariants(
+  commands: TelegramMenuCommand[],
+): TelegramLocalizedCommandVariants {
   const locales = new Set<LanguageCode>();
   const unsupportedLanguageCodes = new Set<string>();
   const commandsWithLocalizations = commands.map((command) => ({

--- a/extensions/telegram/src/bot-native-command-plugins.test.ts
+++ b/extensions/telegram/src/bot-native-command-plugins.test.ts
@@ -46,7 +46,10 @@ type PlugCommandHarnessParams = {
   registerOverrides?: Partial<Parameters<typeof registerTelegramNativeCommands>[0]>;
 };
 
-const pluginCommandHandler = vi.fn(async (_ctx: Record<string, unknown>) => ({ text: "ok" }));
+type PluginCommandContext = Parameters<
+  NonNullable<Parameters<typeof registerPluginCommand>[1]["handler"]>
+>[0];
+const pluginCommandHandler = vi.fn(async (_ctx: PluginCommandContext) => ({ text: "ok" }));
 
 function registerTestPluginCommand(params: {
   name: string;
@@ -63,7 +66,7 @@ function registerTestPluginCommand(params: {
       requireAuth: false,
       ...params.command,
       handler: async (ctx) => {
-        const handlerResult = await pluginCommandHandler(ctx as unknown as Record<string, unknown>);
+        const handlerResult = await pluginCommandHandler(ctx);
         return params.result ?? handlerResult;
       },
     }),
@@ -116,15 +119,11 @@ function firstCallArg(mock: { mock: { calls: Array<Array<unknown>> } }, argIndex
 }
 
 function firstDeliverRepliesParams() {
-  return firstCallArg(deliverReplies as unknown as { mock: { calls: Array<Array<unknown>> } });
+  return firstCallArg(deliverReplies);
 }
 
 function firstExecutePluginCommandParams() {
-  return firstCallArg(
-    pluginCommandHandler as unknown as {
-      mock: { calls: Array<Array<unknown>> };
-    },
-  );
+  return firstCallArg(pluginCommandHandler);
 }
 
 function replyAt(params: Record<string, unknown>, index = 0) {
@@ -295,18 +294,14 @@ describe("registerTelegramNativeCommands", () => {
     expect(sendMessageCall[0]).toBe(100);
     expect(String(sendMessageCall[1])).toContain("Running this command now");
     expect(sendMessageCall[2]).toBeUndefined();
-    const editCall = firstCall(
-      editMessageTelegram as unknown as { mock: { calls: Array<Array<unknown>> } },
-    );
+    const editCall = firstCall(editMessageTelegram);
     expect(editCall[0]).toBe(100);
     expect(editCall[1]).toBe(999);
     expect(String(editCall[2])).toContain("Command completed successfully");
     expect((editCall[3] as { accountId?: string } | undefined)?.accountId).toBe("default");
     expect(deleteMessage).not.toHaveBeenCalled();
     expect(deliverReplies).not.toHaveBeenCalled();
-    const hookParams = firstCallArg(
-      emitTelegramMessageSentHooks as unknown as { mock: { calls: Array<Array<unknown>> } },
-    );
+    const hookParams = firstCallArg(emitTelegramMessageSentHooks);
     expect(hookParams.chatId).toBe("100");
     expect(hookParams.content).toBe("Command completed successfully");
     expect(hookParams.messageId).toBe(999);
@@ -332,9 +327,7 @@ describe("registerTelegramNativeCommands", () => {
     await handler(createPrivateCommandContext({ match: "now" }));
 
     expect(sendMessage).toHaveBeenCalledWith(100, "Working on it...", undefined);
-    const editCall = firstCall(
-      editMessageTelegram as unknown as { mock: { calls: Array<Array<unknown>> } },
-    );
+    const editCall = firstCall(editMessageTelegram);
     expect(editCall[0]).toBe(100);
     expect(editCall[1]).toBe(999);
     expect(editCall[2]).toBe("Choose an option");

--- a/extensions/telegram/src/bot-native-commands.fixture-test-support.ts
+++ b/extensions/telegram/src/bot-native-commands.fixture-test-support.ts
@@ -1,5 +1,7 @@
 // Telegram plugin module implements bot native commands.fixture test support behavior.
-import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { Bot, Composer, type CommandContext, type Context } from "grammy";
+import type { Message } from "grammy/types";
+import { createNonExitingRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { vi } from "vitest";
 import type { OpenClawConfig, TelegramAccountConfig } from "../runtime-api.js";
 import type { registerTelegramNativeCommands } from "./bot-native-commands.js";
@@ -12,28 +14,30 @@ export type NativeCommandTestParams = RegisterTelegramNativeCommandsParams & {
   replyToMode?: RegisterTelegramNativeCommandsParams["opts"]["replyToMode"];
 };
 
+const nativeCommandSentMessage = {
+  message_id: 999,
+  date: 1_700_000_000,
+  chat: { id: 100, type: "private", first_name: "Test" },
+  text: "sent",
+} satisfies Message;
+
+export function createNativeCommandTestBot(): Bot {
+  const bot = new Bot("test-token");
+  vi.spyOn(bot.api, "setMyCommands").mockResolvedValue(true);
+  vi.spyOn(bot.api, "sendMessage").mockResolvedValue(nativeCommandSentMessage);
+  vi.spyOn(bot.api, "deleteMessage").mockResolvedValue(true);
+  vi.spyOn(bot, "command").mockImplementation(() => new Composer<CommandContext<Context>>());
+  return bot;
+}
+
 export function createNativeCommandTestParams(
   params: Partial<NativeCommandTestParams> = {},
 ): RegisterTelegramNativeCommandsParams {
   const log = vi.fn();
   return {
-    bot:
-      params.bot ??
-      ({
-        api: {
-          setMyCommands: vi.fn().mockResolvedValue(undefined),
-          sendMessage: vi.fn().mockResolvedValue(undefined),
-        },
-        command: vi.fn(),
-      } as unknown as NativeCommandTestParams["bot"]),
+    bot: params.bot ?? createNativeCommandTestBot(),
     cfg: params.cfg ?? ({} as OpenClawConfig),
-    runtime:
-      params.runtime ??
-      ({
-        log,
-        error: vi.fn(),
-        exit: vi.fn(),
-      } as unknown as RuntimeEnv),
+    runtime: params.runtime ?? { ...createNonExitingRuntimeEnv(), log },
     accountId: params.accountId ?? "default",
     telegramCfg: params.telegramCfg ?? ({} as TelegramAccountConfig),
     nativeEnabled: params.nativeEnabled ?? true,

--- a/extensions/telegram/src/bot-native-commands.menu-test-support.ts
+++ b/extensions/telegram/src/bot-native-commands.menu-test-support.ts
@@ -1,10 +1,12 @@
 // Telegram plugin module implements bot native commands.menu test support behavior.
+import { Composer, type CommandContext, type Context } from "grammy";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { expect, vi, type Mock } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
 import type { TelegramNativeCommandDeps } from "./bot-native-command-deps.runtime.js";
 import {
   createNativeCommandTestParams as createBaseNativeCommandTestParams,
+  createNativeCommandTestBot,
   createTelegramPrivateCommandContext,
   type NativeCommandTestParams as RegisterTelegramNativeCommandsParams,
 } from "./bot-native-commands.fixture-test-support.js";
@@ -73,20 +75,20 @@ export function resetNativeCommandMenuMocks() {
 
 export function createCommandBot(params: CreateCommandBotParams = {}): CreateCommandBotResult {
   const commandHandlers = new Map<string, (ctx: unknown) => Promise<void>>();
-  const sendMessage = vi.fn().mockResolvedValue({ message_id: 999 });
-  const deleteMessage = vi.fn().mockResolvedValue(true);
-  const setMyCommands = vi.fn().mockResolvedValue(undefined);
-  const bot = {
-    api: {
-      setMyCommands,
-      sendMessage,
-      deleteMessage,
-      ...params.api,
-    },
-    command: vi.fn((name: string, cb: (ctx: unknown) => Promise<void>) => {
-      commandHandlers.set(name, cb);
-    }),
-  } as unknown as RegisterTelegramNativeCommandsParams["bot"];
+  const bot = createNativeCommandTestBot();
+  Object.assign(bot.api, params.api);
+  const sendMessage = vi.spyOn(bot.api, "sendMessage");
+  const deleteMessage = vi.spyOn(bot.api, "deleteMessage");
+  const setMyCommands = vi.spyOn(bot.api, "setMyCommands");
+  vi.spyOn(bot, "command").mockImplementation((name, handler) => {
+    if (typeof handler !== "function") {
+      throw new TypeError("Expected function command middleware");
+    }
+    commandHandlers.set(String(name), async (ctx) => {
+      await Reflect.apply(handler, undefined, [ctx, async () => {}]);
+    });
+    return new Composer<CommandContext<Context>>();
+  });
   return { bot, commandHandlers, sendMessage, deleteMessage, setMyCommands };
 }
 

--- a/extensions/telegram/src/bot-native-commands.skills-allowlist.test.ts
+++ b/extensions/telegram/src/bot-native-commands.skills-allowlist.test.ts
@@ -12,6 +12,7 @@ import { writeSkill } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { registerTelegramNativeCommands } from "./bot-native-commands.js";
 import {
+  createCommandBot,
   createNativeCommandTestParams,
   listSkillCommandsForAgents,
   resetNativeCommandMenuMocks,
@@ -65,20 +66,14 @@ describe("registerTelegramNativeCommands skill allowlist integration", () => {
       ({ cfg: cfgLocal, agentIds }: { cfg: OpenClawConfig; agentIds?: string[] }) =>
         listActualSkillCommandsForAgents({ cfg: cfgLocal, agentIds }),
     );
+    const { bot } = createCommandBot({
+      api: { setMyCommands, sendMessage: vi.fn().mockResolvedValue(undefined) },
+    });
 
     withPluginRuntimeRegistryScope(createEmptyPluginRegistry(), () =>
       registerTelegramNativeCommands({
         ...createNativeCommandTestParams(cfg, {
-          bot: {
-            api: {
-              setMyCommands,
-              sendMessage: vi.fn().mockResolvedValue(undefined),
-            },
-            command: vi.fn(),
-          } as unknown as Parameters<typeof registerTelegramNativeCommands>[0]["bot"],
-          runtime: { log: vi.fn() } as unknown as Parameters<
-            typeof registerTelegramNativeCommands
-          >[0]["runtime"],
+          bot,
           accountId: "bot-a",
         }),
       }),

--- a/extensions/telegram/src/bot-native-commands.test-helpers.ts
+++ b/extensions/telegram/src/bot-native-commands.test-helpers.ts
@@ -36,11 +36,13 @@ type ResolveThreadSessionKeysFn =
   typeof import("./bot-native-commands.runtime.js").resolveThreadSessionKeys;
 type AnyMock = MockFn<(...args: unknown[]) => unknown>;
 type AnyAsyncMock = MockFn<(...args: unknown[]) => Promise<unknown>>;
+type SendMessageMock = MockFn<Bot["api"]["sendMessage"]>;
+type SetMyCommandsMock = MockFn<Bot["api"]["setMyCommands"]>;
 type NativeCommandHarness = {
   handlers: Record<string, (ctx: unknown) => Promise<void>>;
-  sendMessage: AnyAsyncMock;
+  sendMessage: SendMessageMock;
   dispatchReplyWithBufferedBlockDispatcher: typeof replyPipelineMocks.dispatchReplyWithBufferedBlockDispatcher;
-  setMyCommands: AnyAsyncMock;
+  setMyCommands: SetMyCommandsMock;
   log: AnyMock;
   bot: RegisterTelegramNativeCommandsParams["bot"];
   readChannelAllowFromStore: AnyAsyncMock;
@@ -53,13 +55,13 @@ const replyPipelineMocks = vi.hoisted(() => {
   };
   return {
     finalizeInboundContext: vi.fn((ctx: unknown) => ctx),
-    dispatchReplyWithBufferedBlockDispatcher: vi.fn(
-      (async () => dispatchReplyResult) as DispatchReplyWithBufferedBlockDispatcherFn,
+    dispatchReplyWithBufferedBlockDispatcher: vi.fn<DispatchReplyWithBufferedBlockDispatcherFn>(
+      async () => dispatchReplyResult,
     ),
-    resolveChunkMode: vi.fn((() => "length") as unknown as ResolveChunkModeFn),
-    ensureConfiguredBindingRouteReady: vi.fn((async () => ({
+    resolveChunkMode: vi.fn<ResolveChunkModeFn>(() => "length"),
+    ensureConfiguredBindingRouteReady: vi.fn<EnsureConfiguredBindingRouteReadyFn>(async () => ({
       ok: true,
-    })) as unknown as EnsureConfiguredBindingRouteReadyFn),
+    })),
     getAgentScopedMediaLocalRoots: vi.fn<GetAgentScopedMediaLocalRootsFn>(() => []),
     resolveThreadSessionKeys: vi.fn<ResolveThreadSessionKeysFn>(
       ({ baseSessionKey, threadId, parentSessionKey, useSuffix = true, normalizeThreadId }) => {
@@ -79,6 +81,13 @@ const replyPipelineMocks = vi.hoisted(() => {
 const deliveryMocks = vi.hoisted(() => ({
   deliverReplies: vi.fn(async () => ({ delivered: true })),
 }));
+
+const sentMessage = {
+  message_id: 1,
+  date: 1_700_000_000,
+  chat: { id: 100, type: "private", first_name: "Test" },
+  text: "sent",
+} satisfies Message;
 
 const dispatchChannelInboundTurnForTest: TelegramNativeCommandDeps["dispatchChannelInboundTurn"] =
   async (plan) => {
@@ -162,8 +171,9 @@ export function createNativeCommandsHarness(params?: {
 }): NativeCommandHarness {
   replyPipelineMocks.dispatchReplyWithBufferedBlockDispatcher.mockClear();
   const handlers: Record<string, (ctx: unknown) => Promise<void>> = {};
-  const sendMessage: AnyAsyncMock = vi.fn(async () => undefined);
-  const setMyCommands: AnyAsyncMock = vi.fn(async () => undefined);
+  const bot = new Bot("test-token");
+  const sendMessage = vi.spyOn(bot.api, "sendMessage").mockResolvedValue(sentMessage);
+  const setMyCommands = vi.spyOn(bot.api, "setMyCommands").mockResolvedValue(true);
   const log: AnyMock = vi.fn();
   const baseCfg = params?.cfg ?? ({} as OpenClawConfig);
   const cfg =
@@ -187,20 +197,26 @@ export function createNativeCommandsHarness(params?: {
       return { messageId: "999", chatId: "100" };
     }),
   };
-  const bot = {
-    api: {
-      setMyCommands,
-      sendMessage,
-    },
-    command: (name: string, handler: (ctx: unknown) => Promise<void>) => {
-      handlers[name] = handler;
-    },
-  } as unknown as RegisterTelegramNativeCommandsParams["bot"];
+  vi.spyOn(bot, "command").mockImplementation((name, handler) => {
+    if (typeof handler !== "function") {
+      throw new TypeError("Expected function command middleware");
+    }
+    handlers[String(name)] = async (ctx) => {
+      await Reflect.apply(handler, undefined, [ctx, async () => {}]);
+    };
+    return new Composer<CommandContext<Context>>();
+  });
+
+  const runtime: RuntimeEnv = params?.runtime ?? {
+    log,
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
 
   registerTelegramNativeCommands({
     bot,
     cfg,
-    runtime: params?.runtime ?? ({ log } as unknown as RuntimeEnv),
+    runtime,
     accountId: "default",
     telegramCfg: params?.telegramCfg ?? ({} as TelegramAccountConfig),
     nativeEnabled: params?.nativeEnabled ?? true,
@@ -274,8 +290,10 @@ export function createTelegramGroupCommandContext(params?: {
   };
 }
 
-export function findNotAuthorizedCalls(sendMessage: AnyAsyncMock) {
+export function findNotAuthorizedCalls(sendMessage: SendMessageMock) {
   return sendMessage.mock.calls.filter(
     (call) => typeof call[1] === "string" && call[1].includes("not authorized"),
   );
 }
+import { Bot, Composer, type CommandContext, type Context } from "grammy";
+import type { Message } from "grammy/types";

--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -24,7 +24,11 @@ type TelegramInlineKeyboardReplyMarkup = {
   inline_keyboard?: Array<Array<{ text?: string; callback_data?: string }>>;
 };
 
-const pluginCommandHandler = vi.fn(async (_ctx: Record<string, unknown>) => ({ text: "ok" }));
+type PluginCommandHandlerContext = Parameters<
+  NonNullable<Parameters<typeof registerPluginCommand>[1]["handler"]>
+>[0];
+
+const pluginCommandHandler = vi.fn(async (_ctx: PluginCommandHandlerContext) => ({ text: "ok" }));
 
 function registerTestPluginCommand(params: {
   name: string;
@@ -42,7 +46,7 @@ function registerTestPluginCommand(params: {
       requireAuth: false,
       ...params.command,
       handler: async (ctx) => {
-        await pluginCommandHandler(ctx as unknown as Record<string, unknown>);
+        await pluginCommandHandler(ctx);
         return result;
       },
     }),
@@ -220,7 +224,7 @@ describe("registerTelegramNativeCommands", () => {
     registerTelegramNativeCommands(
       createNativeCommandTestParams(cfg, {
         bot,
-        runtime: { log: runtimeLog } as unknown as RuntimeEnv,
+        runtime: { log: runtimeLog, error: vi.fn(), exit: vi.fn() } satisfies RuntimeEnv,
         telegramCfg: {
           customCommands,
         },
@@ -248,16 +252,14 @@ describe("registerTelegramNativeCommands", () => {
   it("normalizes hyphenated native command names for Telegram registration", async () => {
     const setMyCommands = vi.fn().mockResolvedValue(undefined);
     const command = vi.fn();
+    const { bot } = createCommandBot({
+      api: { setMyCommands, sendMessage: vi.fn().mockResolvedValue(undefined) },
+    });
+    bot.command = command;
 
     registerTelegramNativeCommands({
       ...createNativeCommandTestParams({}),
-      bot: {
-        api: {
-          setMyCommands,
-          sendMessage: vi.fn().mockResolvedValue(undefined),
-        },
-        command,
-      } as unknown as Parameters<typeof registerTelegramNativeCommands>[0]["bot"],
+      bot,
     });
 
     const registeredCommands = await waitForRegisteredCommands(setMyCommands);
@@ -288,18 +290,15 @@ describe("registerTelegramNativeCommands", () => {
 
   it("registers only Telegram-safe command names across native, custom, and plugin sources", async () => {
     const setMyCommands = vi.fn().mockResolvedValue(undefined);
+    const { bot } = createCommandBot({
+      api: { setMyCommands, sendMessage: vi.fn().mockResolvedValue(undefined) },
+    });
 
     registerTestPluginCommand({ name: "plugin-status", description: "Plugin status" });
 
     registerTelegramNativeCommands({
       ...createNativeCommandTestParams({}),
-      bot: {
-        api: {
-          setMyCommands,
-          sendMessage: vi.fn().mockResolvedValue(undefined),
-        },
-        command: vi.fn(),
-      } as unknown as Parameters<typeof registerTelegramNativeCommands>[0]["bot"],
+      bot,
       telegramCfg: {
         customCommands: [
           { command: "custom-backup", description: "Custom backup" },

--- a/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
@@ -4,7 +4,7 @@ import {
   createPluginStateKeyedStoreForTests,
   createPluginStateSyncKeyedStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { createNonExitingRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   telegramBotInfoForTest,
@@ -1013,7 +1013,7 @@ describe("createTelegramBot channel_post media", () => {
       createTelegramBot({
         token: "tok",
         testTimings: TELEGRAM_TEST_TIMINGS,
-        runtime: { error: runtimeError } as unknown as RuntimeEnv,
+        runtime: { ...createNonExitingRuntimeEnv(), error: runtimeError },
       });
       const handler = getOnHandler("channel_post") as (
         ctx: Record<string, unknown>,

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -11,7 +11,6 @@ import { runTelegramChannelInboundEventWithHarness } from "./bot.test-helpers.js
 
 type AnyMock = ReturnType<typeof vi.fn>;
 type AnyAsyncMock = ReturnType<typeof vi.fn<(...args: unknown[]) => Promise<unknown>>>;
-type TelegramBotRuntimeForTest = typeof import("./bot.runtime.js");
 type GetRuntimeConfigFn =
   typeof import("openclaw/plugin-sdk/runtime-config-snapshot").getRuntimeConfig;
 type GetSessionEntryFn = typeof import("openclaw/plugin-sdk/session-store-runtime").getSessionEntry;
@@ -37,6 +36,32 @@ type ReplyPayloadLike = {
 };
 type ReplySpyResult = ReplyPayloadLike | ReplyPayloadLike[] | undefined;
 type ReplySpy = (ctx: MsgContext, opts?: GetReplyOptions) => Promise<ReplySpyResult>;
+type LoadWebMediaHoisted = { loadWebMedia: AnyMock };
+type SessionStoreEntries = { value: SessionStore };
+type TelegramBotSessionHoisted = {
+  getSessionEntryMock: MockFn<GetSessionEntryFn>;
+  getRuntimeConfig: MockFn<GetRuntimeConfigFn>;
+  loadSessionStoreMock: MockFn<LoadSessionStoreFn>;
+  readSessionUpdatedAtMock: MockFn<ReadSessionUpdatedAtFn>;
+  recordInboundSessionMock: MockFn<NonNullable<TelegramBotDeps["recordInboundSession"]>>;
+  resolveStorePathMock: MockFn<ResolveStorePathFn>;
+  sessionStoreEntries: SessionStoreEntries;
+};
+type TelegramBotPairingHoisted = {
+  readChannelAllowFromStore: MockFn<TelegramBotDeps["readChannelAllowFromStore"]>;
+  upsertChannelPairingRequest: MockFn<TelegramBotDeps["upsertChannelPairingRequest"]>;
+};
+type ParsedModelRef = { provider?: string; model: string };
+type ResolvedModelRef = { provider: string; model: string };
+type ModelsProviderDataForTest = {
+  byProvider: Map<string, Set<string>>;
+  providers: string[];
+  resolvedDefault: ResolvedModelRef;
+  modelNames: Map<string, string>;
+};
+type ExecApprovalHoisted = {
+  resolveExecApprovalSpy: MockFn<ResolveTelegramApprovalForTest>;
+};
 
 const { sessionStorePath } = vi.hoisted(() => {
   const tempRoot =
@@ -51,9 +76,11 @@ const { sessionStorePath } = vi.hoisted(() => {
   };
 });
 
-const { loadWebMedia } = vi.hoisted((): { loadWebMedia: AnyMock } => ({
-  loadWebMedia: vi.fn(),
-}));
+const { loadWebMedia } = vi.hoisted(
+  (): LoadWebMediaHoisted => ({
+    loadWebMedia: vi.fn(),
+  }),
+);
 
 export function getLoadWebMediaMock(): AnyMock {
   return loadWebMedia;
@@ -72,15 +99,7 @@ const {
   resolveStorePathMock,
   sessionStoreEntries,
 } = vi.hoisted(
-  (): {
-    getSessionEntryMock: MockFn<GetSessionEntryFn>;
-    getRuntimeConfig: MockFn<GetRuntimeConfigFn>;
-    loadSessionStoreMock: MockFn<LoadSessionStoreFn>;
-    readSessionUpdatedAtMock: MockFn<ReadSessionUpdatedAtFn>;
-    recordInboundSessionMock: MockFn<NonNullable<TelegramBotDeps["recordInboundSession"]>>;
-    resolveStorePathMock: MockFn<ResolveStorePathFn>;
-    sessionStoreEntries: { value: SessionStore };
-  } => ({
+  (): TelegramBotSessionHoisted => ({
     getRuntimeConfig: vi.fn<GetRuntimeConfigFn>(() => ({})),
     resolveStorePathMock: vi.fn<ResolveStorePathFn>(
       (storePath?: string) => storePath ?? sessionStorePath,
@@ -111,10 +130,7 @@ export function setSessionStoreEntriesForTest(entries: SessionStore) {
 }
 
 const { readChannelAllowFromStore, upsertChannelPairingRequest } = vi.hoisted(
-  (): {
-    readChannelAllowFromStore: MockFn<TelegramBotDeps["readChannelAllowFromStore"]>;
-    upsertChannelPairingRequest: MockFn<TelegramBotDeps["upsertChannelPairingRequest"]>;
-  } => ({
+  (): TelegramBotPairingHoisted => ({
     readChannelAllowFromStore: vi.fn(async () => [] as string[]),
     upsertChannelPairingRequest: vi.fn(async () => ({
       code: "PAIRCODE",
@@ -220,7 +236,7 @@ const menuSyncHoisted = vi.hoisted(() => ({
 }));
 export const syncTelegramMenuCommands = menuSyncHoisted.syncTelegramMenuCommands;
 
-function parseModelRef(raw: string): { provider?: string; model: string } {
+function parseModelRef(raw: string): ParsedModelRef {
   const trimmed = raw.trim();
   if (!trimmed) {
     return { model: "" };
@@ -239,10 +255,7 @@ function normalizeLowercaseStringOrEmptyForTest(value: string | undefined): stri
   return value?.trim().toLowerCase() ?? "";
 }
 
-function resolveDefaultModelForAgentForTest(params: { cfg: OpenClawConfig }): {
-  provider: string;
-  model: string;
-} {
+function resolveDefaultModelForAgentForTest(params: { cfg: OpenClawConfig }): ResolvedModelRef {
   const modelConfig = params.cfg.agents?.defaults?.model;
   const rawModel =
     typeof modelConfig === "string" ? modelConfig : (modelConfig?.primary ?? "openai/gpt-5.4");
@@ -254,12 +267,7 @@ function resolveDefaultModelForAgentForTest(params: { cfg: OpenClawConfig }): {
   };
 }
 
-function createModelsProviderDataFromConfig(cfg: OpenClawConfig): {
-  byProvider: Map<string, Set<string>>;
-  providers: string[];
-  resolvedDefault: { provider: string; model: string };
-  modelNames: Map<string, string>;
-} {
+function createModelsProviderDataFromConfig(cfg: OpenClawConfig): ModelsProviderDataForTest {
   const byProvider = new Map<string, Set<string>>();
   const add = (providerRaw: string | undefined, modelRaw: string | undefined) => {
     const provider = normalizeLowercaseStringOrEmptyForTest(providerRaw);
@@ -290,7 +298,7 @@ const systemEventsHoisted = vi.hoisted(() => ({
 export const enqueueSystemEventSpy: MockFn<TelegramBotDeps["enqueueSystemEvent"]> =
   systemEventsHoisted.enqueueSystemEventSpy;
 const execApprovalHoisted = vi.hoisted(
-  (): { resolveExecApprovalSpy: MockFn<ResolveTelegramApprovalForTest> } => ({
+  (): ExecApprovalHoisted => ({
     resolveExecApprovalSpy: vi.fn<ResolveTelegramApprovalForTest>(async () => ({
       applied: true,
       approval: {
@@ -333,6 +341,7 @@ const grammySpies = vi.hoisted(() => ({
   onSpy: vi.fn(),
   stopSpy: vi.fn(),
   commandSpy: vi.fn(),
+  catchSpy: vi.fn(),
   botCtorSpy: vi.fn(
     (_: string, __?: { client?: { fetch?: typeof fetch }; botInfo?: unknown }) => undefined,
   ),
@@ -359,6 +368,7 @@ export const middlewareUseSpy: AnyMock = grammySpies.middlewareUseSpy;
 export const onSpy: AnyMock = grammySpies.onSpy;
 const stopSpy: AnyMock = grammySpies.stopSpy;
 export const commandSpy: AnyMock = grammySpies.commandSpy;
+export const catchSpy: AnyMock = grammySpies.catchSpy;
 export const botCtorSpy: MockFn<
   (token: string, options?: { client?: { fetch?: typeof fetch }; botInfo?: unknown }) => void
 > = grammySpies.botCtorSpy;
@@ -471,29 +481,19 @@ const telegramBotRuntimeForTest = {
     on = grammySpies.onSpy;
     stop = grammySpies.stopSpy;
     command = grammySpies.commandSpy;
-    catch = vi.fn();
+    catch = grammySpies.catchSpy;
     constructor(
       public token: string,
       public options?: { client?: { fetch?: typeof fetch }; botInfo?: unknown },
     ) {
-      (grammySpies.botCtorSpy as unknown as (token: string, options?: unknown) => void)(
-        token,
-        options,
-      );
+      grammySpies.botCtorSpy(token, options);
     }
-  } as unknown as TelegramBotRuntimeForTest["Bot"],
-  sequentialize: ((keyFn: (ctx: unknown) => string | string[] | undefined) => {
+  },
+  sequentialize: (keyFn: (ctx: unknown) => string | string[] | undefined) => {
     sequentializeKey = keyFn;
-    return (
-      runnerHoisted.sequentializeSpy as unknown as () => ReturnType<
-        TelegramBotRuntimeForTest["sequentialize"]
-      >
-    )();
-  }) as unknown as TelegramBotRuntimeForTest["sequentialize"],
-  apiThrottler: (() =>
-    (
-      runnerHoisted.throttlerSpy as unknown as () => unknown
-    )()) as unknown as TelegramBotRuntimeForTest["apiThrottler"],
+    return runnerHoisted.sequentializeSpy();
+  },
+  apiThrottler: () => runnerHoisted.throttlerSpy(),
 };
 export const telegramBotDepsForTest: TelegramBotDeps = {
   getRuntimeConfig,
@@ -631,6 +631,7 @@ beforeEach(() => {
   upsertChannelPairingRequest.mockResolvedValue({ code: "PAIRCODE", created: true } as const);
   onSpy.mockReset();
   commandSpy.mockReset();
+  catchSpy.mockReset();
   stopSpy.mockReset();
   useSpy.mockReset();
   replySpy.mockReset();

--- a/extensions/telegram/src/bot.create-telegram-bot.test-support.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-support.ts
@@ -6,6 +6,10 @@ type DispatchReplyWithBufferedBlockDispatcher =
 type DispatchChannelInboundTurn =
   typeof import("openclaw/plugin-sdk/channel-inbound").dispatchChannelInboundTurn;
 
+type TelegramNativeCommandTestDeps = {
+  dispatchChannelInboundTurn: DispatchChannelInboundTurn;
+};
+
 export const telegramBotInfoForTest = {
   id: 9_876_543_210,
   is_bot: true,
@@ -68,7 +72,7 @@ export async function waitForTelegramMockCalls(
 
 export function createTelegramNativeCommandTestDeps(
   dispatchReply: DispatchReplyWithBufferedBlockDispatcher,
-): { dispatchChannelInboundTurn: DispatchChannelInboundTurn } {
+): TelegramNativeCommandTestDeps {
   return {
     dispatchChannelInboundTurn: async (plan) => {
       const delivery = plan.delivery;

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
+import { BotError, Context } from "grammy";
 import { escapeRegExp, formatEnvelopeTimestamp } from "openclaw/plugin-sdk/channel-test-helpers";
 import type { TelegramGroupConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
@@ -14,10 +15,7 @@ import {
   clearPluginInteractiveHandlers,
   registerPluginInteractiveHandler,
 } from "openclaw/plugin-sdk/plugin-runtime";
-import type {
-  PluginStateKeyedStore,
-  PluginStateSyncKeyedStore,
-} from "openclaw/plugin-sdk/plugin-state-runtime";
+import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import type { GetReplyOptions, MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { createRequireRecord, sanitizeTerminalText } from "openclaw/plugin-sdk/test-fixtures";
@@ -50,6 +48,7 @@ let previousStateDir: string | undefined;
 const {
   answerCallbackQuerySpy,
   botCtorSpy,
+  catchSpy,
   commandSpy,
   dispatchReplyWithBufferedBlockDispatcher,
   editMessageReplyMarkupSpy,
@@ -81,9 +80,6 @@ const {
   throttlerSpy,
   useSpy,
 } = harness;
-type BuildModelsProviderDataMock = ReturnType<
-  typeof vi.fn<NonNullable<typeof telegramBotDepsForTest.buildModelsProviderData>>
->;
 const { resolveTelegramFetch } = await import("./fetch.js");
 const { defaultTelegramNativeCommandDeps } = await import("./bot-native-command-deps.runtime.js");
 const messageDispatchDedupe = await import("./message-dispatch-dedupe.js");
@@ -466,26 +462,38 @@ describe("createTelegramBot", () => {
   });
 
   it("logs middleware errors through grammY catch without rethrowing", () => {
-    const runtime = {
+    const runtime: NonNullable<TelegramBotOptions["runtime"]> = {
+      log: vi.fn(),
       error: vi.fn(),
-    } as unknown as NonNullable<TelegramBotOptions["runtime"]>;
-    const bot = createTelegramBot({ token: "tok", runtime });
-    const catchMock = bot["catch"] as unknown as {
-      mock: { calls: Array<[(err: unknown) => void]> };
+      exit: vi.fn(),
     };
-    const errorHandler = catchMock.mock.calls.at(0)?.[0];
+    const bot = createTelegramBot({ token: "tok", runtime });
+    const errorHandler = catchSpy.mock.calls.at(0)?.[0];
+    const errorContext = new Context(
+      {
+        update_id: 1,
+        message: {
+          message_id: 1,
+          date: 1_700_000_000,
+          chat: { id: 100, type: "private", first_name: "Test" },
+          from: { id: 200, is_bot: false, first_name: "Tester" },
+          text: "test",
+        },
+      },
+      bot.api,
+      telegramBotInfoForTest,
+    );
 
     expect(errorHandler).toBeTypeOf("function");
-    errorHandler?.(new Error("handler boom"));
-    const errorCalls = (runtime.error as unknown as { mock: { calls: Array<[unknown]> } }).mock
-      .calls;
+    errorHandler?.(new BotError(new Error("handler boom"), errorContext));
+    const errorCalls = vi.mocked(runtime.error).mock.calls;
     const errorMessage = sanitizeTerminalText(String(errorCalls[0]?.[0]));
     expect(errorMessage.startsWith("telegram bot error: Error: handler boom")).toBe(true);
   });
 
   it("uses wrapped fetch when global fetch is available", () => {
     const originalFetch = globalThis.fetch;
-    const fetchSpy = vi.fn() as unknown as typeof fetch;
+    const fetchSpy = vi.fn<typeof fetch>();
     globalThis.fetch = fetchSpy;
     try {
       createTelegramBot({ token: "tok" });
@@ -723,8 +731,15 @@ describe("createTelegramBot", () => {
     const lookup = vi.fn(async () => {
       throw new Error("registry should not be read");
     });
-    const openKeyedStore: TelegramRuntime["state"]["openKeyedStore"] = <T>() =>
-      ({ lookup }) as unknown as PluginStateKeyedStore<T>;
+    const openKeyedStore: TelegramRuntime["state"]["openKeyedStore"] = () => ({
+      register: async () => undefined,
+      registerIfAbsent: async () => false,
+      lookup,
+      consume: async () => undefined,
+      delete: async () => false,
+      entries: async () => [],
+      clear: async () => undefined,
+    });
     setTelegramRuntime({ state: { openKeyedStore }, channel: {} } as TelegramRuntime);
     createTelegramBot({ token: "tok" });
     const update = { update_id: 42, poll_answer: pollAnswer };
@@ -2251,8 +2266,7 @@ describe("createTelegramBot", () => {
   });
 
   it("reloads callback model routing bindings without recreating the bot", async () => {
-    const buildModelsProviderDataMock =
-      telegramBotDepsForTest.buildModelsProviderData as unknown as BuildModelsProviderDataMock;
+    const buildModelsProviderDataMock = vi.mocked(telegramBotDepsForTest.buildModelsProviderData);
     let boundAgentId = "agent-a";
     loadConfig.mockImplementation(() => ({
       agents: {
@@ -4019,14 +4033,22 @@ describe("createTelegramBot", () => {
     expect(replySpy).toHaveBeenCalledTimes(1);
   });
 
-  it.each([
+  type TelegramScopedGroupConfigCase = {
+    name: string;
+    groupPolicy: "open" | "allowlist";
+    groups: Record<string, TelegramGroupConfig>;
+    topicId: number;
+    expectedGroup: Record<string, unknown> | undefined;
+    expectedTopic: Record<string, unknown>;
+  };
+  const telegramScopedGroupConfigCases: TelegramScopedGroupConfigCase[] = [
     {
       name: "lets topic mention overrides fall back from wildcard group config",
       groupPolicy: "open",
       groups: {
         "*": { requireMention: true },
         "-1001234567890": { requireMention: true, topics: { "99": { requireMention: false } } },
-      } as Record<string, TelegramGroupConfig>,
+      } satisfies Record<string, TelegramGroupConfig>,
       topicId: 99,
       expectedGroup: { requireMention: true },
       expectedTopic: { requireMention: false },
@@ -4040,7 +4062,7 @@ describe("createTelegramBot", () => {
           allowFrom: ["123456789"],
           topics: { "99": {} },
         },
-      } as Record<string, TelegramGroupConfig>,
+      } satisfies Record<string, TelegramGroupConfig>,
       topicId: 99,
       expectedGroup: { requireMention: false, allowFrom: ["123456789"] },
       expectedTopic: {},
@@ -4053,7 +4075,7 @@ describe("createTelegramBot", () => {
           allowFrom: ["999999999"],
           topics: { "*": { allowFrom: ["123456789"], agentId: "zu" } },
         },
-      } as Record<string, TelegramGroupConfig>,
+      } satisfies Record<string, TelegramGroupConfig>,
       topicId: 77,
       expectedGroup: { allowFrom: ["999999999"] },
       expectedTopic: { allowFrom: ["123456789"], agentId: "zu" },
@@ -4068,7 +4090,7 @@ describe("createTelegramBot", () => {
             "77": { allowFrom: ["555555555"], agentId: "main" },
           },
         },
-      } as Record<string, TelegramGroupConfig>,
+      } satisfies Record<string, TelegramGroupConfig>,
       topicId: 77,
       expectedGroup: undefined,
       expectedTopic: { allowFrom: ["555555555"], agentId: "main" },
@@ -4083,28 +4105,27 @@ describe("createTelegramBot", () => {
             "77": { agentId: "main" },
           },
         },
-      } as Record<string, TelegramGroupConfig>,
+      } satisfies Record<string, TelegramGroupConfig>,
       topicId: 77,
       expectedGroup: undefined,
       expectedTopic: { allowFrom: ["123456789"], requireMention: false, agentId: "main" },
     },
-  ] satisfies Array<
-    Record<string, unknown> & {
-      groupPolicy: "open" | "allowlist";
-      groups: Record<string, TelegramGroupConfig>;
-    }
-  >)("$name", ({ groupPolicy, groups, topicId, expectedGroup, expectedTopic }) => {
-    const { groupConfig, topicConfig } = resolveTelegramScopedGroupConfig(
-      { groupPolicy, groups },
-      -1001234567890,
-      topicId,
-    );
+  ];
+  it.each(telegramScopedGroupConfigCases)(
+    "$name",
+    ({ groupPolicy, groups, topicId, expectedGroup, expectedTopic }) => {
+      const { groupConfig, topicConfig } = resolveTelegramScopedGroupConfig(
+        { groupPolicy, groups },
+        -1001234567890,
+        topicId,
+      );
 
-    if (expectedGroup) {
-      expect(groupConfig as TelegramGroupConfig | undefined).toMatchObject(expectedGroup);
-    }
-    expect(topicConfig).toEqual(expectedTopic);
-  });
+      if (expectedGroup) {
+        expect(groupConfig as TelegramGroupConfig | undefined).toMatchObject(expectedGroup);
+      }
+      expect(topicConfig).toEqual(expectedTopic);
+    },
+  );
 
   it.each([
     {
@@ -5299,8 +5320,7 @@ describe("createTelegramBot", () => {
       },
     });
 
-    const buildModelsProviderDataMock =
-      telegramBotDepsForTest.buildModelsProviderData as unknown as BuildModelsProviderDataMock;
+    const buildModelsProviderDataMock = vi.mocked(telegramBotDepsForTest.buildModelsProviderData);
     buildModelsProviderDataMock.mockClear();
     editMessageTextSpy.mockClear();
 
@@ -5435,7 +5455,7 @@ describe("createTelegramBot", () => {
   });
 
   it("retries command pagination callbacks after a bubbled preflight failure", async () => {
-    const listSkillCommandsMock = listSkillCommandsForAgents as unknown as ReturnType<typeof vi.fn>;
+    const listSkillCommandsMock = vi.mocked(listSkillCommandsForAgents);
 
     createTelegramBot({ token: "tok" });
     listSkillCommandsMock.mockClear();

--- a/extensions/telegram/src/bot.fetch-abort.test.ts
+++ b/extensions/telegram/src/bot.fetch-abort.test.ts
@@ -52,25 +52,42 @@ function createWrappedTelegramClientFetchWithTransport(params: {
   return { clientFetch, shutdown };
 }
 
+function createAbortObservingFetch() {
+  let resolveObservedSignal: ((signal: AbortSignal) => void) | undefined;
+  const observedSignal = new Promise<AbortSignal>((resolve) => {
+    resolveObservedSignal = resolve;
+  });
+  const fetchSpy = vi.fn<typeof fetch>(
+    (_input, init) =>
+      new Promise<Response>((resolve) => {
+        const signal = init?.signal;
+        if (!signal) {
+          throw new Error("expected fetch abort signal");
+        }
+        signal.addEventListener(
+          "abort",
+          () => {
+            resolveObservedSignal?.(signal);
+            resolve(new Response());
+          },
+          { once: true },
+        );
+      }),
+  );
+  return { fetchSpy, observedSignal };
+}
+
 describe("createTelegramBot fetch abort", () => {
   it("aborts wrapped client fetch when fetchAbortSignal aborts", async () => {
-    const fetchSpy = vi.fn(
-      (_input: RequestInfo | URL, init?: RequestInit) =>
-        new Promise<AbortSignal>((resolve) => {
-          const signal = init?.signal as AbortSignal;
-          signal.addEventListener("abort", () => resolve(signal), { once: true });
-        }),
-    );
-    const { clientFetch, shutdown } = createWrappedTelegramClientFetch(
-      fetchSpy as unknown as typeof fetch,
-    );
+    const { fetchSpy, observedSignal } = createAbortObservingFetch();
+    const { clientFetch, shutdown } = createWrappedTelegramClientFetch(fetchSpy);
 
-    const observedSignalPromise = clientFetch("https://example.test");
+    void clientFetch("https://example.test");
     shutdown.abort(new Error("shutdown"));
-    const observedSignal = (await observedSignalPromise) as AbortSignal;
+    const capturedSignal = await observedSignal;
 
-    expect(observedSignal).toBeInstanceOf(AbortSignal);
-    expect(observedSignal.aborted).toBe(true);
+    expect(capturedSignal).toBeInstanceOf(AbortSignal);
+    expect(capturedSignal.aborted).toBe(true);
   });
 
   it("keeps the getChat deadline active until its response body settles", async () => {
@@ -155,10 +172,10 @@ describe("createTelegramBot fetch abort", () => {
         code: "UND_ERR_CONNECT_TIMEOUT",
       }),
     });
-    const fetchSpy = vi.fn(async () => {
+    const fetchSpy = vi.fn<typeof fetch>(async () => {
       throw fetchError;
     });
-    const { clientFetch } = createWrappedTelegramClientFetch(fetchSpy as unknown as typeof fetch);
+    const { clientFetch } = createWrappedTelegramClientFetch(fetchSpy);
 
     await expect(clientFetch("https://api.telegram.org/bot123456:ABC/getUpdates")).rejects.toBe(
       fetchError,
@@ -168,21 +185,15 @@ describe("createTelegramBot fetch abort", () => {
 
   it("aborts wrapped getUpdates fetch after the hard polling timeout", async () => {
     vi.useFakeTimers();
-    const fetchSpy = vi.fn(
-      (_input: RequestInfo | URL, init?: RequestInit) =>
-        new Promise<AbortSignal>((resolve) => {
-          const signal = init?.signal as AbortSignal;
-          signal.addEventListener("abort", () => resolve(signal), { once: true });
-        }),
-    );
-    const { clientFetch } = createWrappedTelegramClientFetch(fetchSpy as unknown as typeof fetch);
+    const { fetchSpy, observedSignal } = createAbortObservingFetch();
+    const { clientFetch } = createWrappedTelegramClientFetch(fetchSpy);
 
-    const observedSignalPromise = clientFetch("https://api.telegram.org/bot123456:ABC/getUpdates");
+    void clientFetch("https://api.telegram.org/bot123456:ABC/getUpdates");
     await vi.advanceTimersByTimeAsync(45_000);
-    const observedSignal = (await observedSignalPromise) as AbortSignal;
+    const capturedSignal = await observedSignal;
 
-    expect(observedSignal).toBeInstanceOf(AbortSignal);
-    expect(observedSignal.aborted).toBe(true);
+    expect(capturedSignal).toBeInstanceOf(AbortSignal);
+    expect(capturedSignal.aborted).toBe(true);
     vi.useRealTimers();
   });
 
@@ -190,49 +201,32 @@ describe("createTelegramBot fetch abort", () => {
     "uses the 60-second outbound guard for %s",
     async (method) => {
       vi.useFakeTimers();
-      const fetchSpy = vi.fn(
-        (_input: RequestInfo | URL, init?: RequestInit) =>
-          new Promise<AbortSignal>((resolve) => {
-            const signal = init?.signal as AbortSignal;
-            signal.addEventListener("abort", () => resolve(signal), { once: true });
-          }),
-      );
-      const { clientFetch } = createWrappedTelegramClientFetch(fetchSpy as unknown as typeof fetch);
+      const { fetchSpy, observedSignal } = createAbortObservingFetch();
+      const { clientFetch } = createWrappedTelegramClientFetch(fetchSpy);
 
-      const observedSignalPromise = clientFetch(`https://api.telegram.org/bot123456:ABC/${method}`);
+      void clientFetch(`https://api.telegram.org/bot123456:ABC/${method}`);
       await vi.advanceTimersByTimeAsync(60_000);
-      const observedSignal = (await observedSignalPromise) as AbortSignal;
+      const capturedSignal = await observedSignal;
 
-      expect(observedSignal).toBeInstanceOf(AbortSignal);
-      expect(observedSignal.aborted).toBe(true);
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(true);
       vi.useRealTimers();
     },
   );
 
   it("lets configured timeoutSeconds extend outbound method guards", async () => {
     vi.useFakeTimers();
-    const fetchSpy = vi.fn(
-      (_input: RequestInfo | URL, init?: RequestInit) =>
-        new Promise<AbortSignal>((resolve) => {
-          const signal = init?.signal as AbortSignal;
-          signal.addEventListener("abort", () => resolve(signal), { once: true });
-        }),
-    );
-    const { clientFetch } = createWrappedTelegramClientFetch(
-      fetchSpy as unknown as typeof fetch,
-      {
-        channels: { telegram: { timeoutSeconds: 90 } },
-      } as never,
-    );
+    const { fetchSpy, observedSignal } = createAbortObservingFetch();
+    const { clientFetch } = createWrappedTelegramClientFetch(fetchSpy, {
+      channels: { telegram: { timeoutSeconds: 90 } },
+    } as never);
 
-    const observedSignalPromise = clientFetch(
-      "https://api.telegram.org/bot123456:ABC/editMessageText",
-    );
+    void clientFetch("https://api.telegram.org/bot123456:ABC/editMessageText");
     await vi.advanceTimersByTimeAsync(90_000);
-    const observedSignal = (await observedSignalPromise) as AbortSignal;
+    const capturedSignal = await observedSignal;
 
-    expect(observedSignal).toBeInstanceOf(AbortSignal);
-    expect(observedSignal.aborted).toBe(true);
+    expect(capturedSignal).toBeInstanceOf(AbortSignal);
+    expect(capturedSignal.aborted).toBe(true);
     vi.useRealTimers();
   });
 
@@ -240,7 +234,7 @@ describe("createTelegramBot fetch abort", () => {
     vi.useFakeTimers();
     const forceFallback = vi.fn(() => true);
     const fetchSpy = vi
-      .fn()
+      .fn<typeof fetch>()
       .mockImplementationOnce(
         (_input: RequestInfo | URL, init?: RequestInit) =>
           new Promise((_resolve, reject) => {
@@ -254,7 +248,7 @@ describe("createTelegramBot fetch abort", () => {
       )
       .mockResolvedValueOnce({ ok: true } as Response);
     const { clientFetch } = createWrappedTelegramClientFetchWithTransport({
-      fetch: fetchSpy as unknown as typeof fetch,
+      fetch: fetchSpy,
       forceFallback,
     });
 
@@ -273,7 +267,7 @@ describe("createTelegramBot fetch abort", () => {
       vi.useFakeTimers();
       const forceFallback = vi.fn(() => true);
       const fetchSpy = vi
-        .fn()
+        .fn<typeof fetch>()
         .mockImplementationOnce(
           (_input: RequestInfo | URL, init?: RequestInit) =>
             new Promise((_resolve, reject) => {
@@ -287,7 +281,7 @@ describe("createTelegramBot fetch abort", () => {
         )
         .mockResolvedValueOnce({ ok: true } as Response);
       const { clientFetch } = createWrappedTelegramClientFetchWithTransport({
-        fetch: fetchSpy as unknown as typeof fetch,
+        fetch: fetchSpy,
         forceFallback,
       });
 
@@ -305,7 +299,7 @@ describe("createTelegramBot fetch abort", () => {
     vi.useFakeTimers();
     const forceFallback = vi.fn(() => true);
     const fetchSpy = vi
-      .fn()
+      .fn<typeof fetch>()
       .mockImplementationOnce(
         (_input: RequestInfo | URL, init?: RequestInit) =>
           new Promise((_resolve, reject) => {
@@ -319,7 +313,7 @@ describe("createTelegramBot fetch abort", () => {
       )
       .mockResolvedValueOnce({ ok: true } as Response);
     const { clientFetch } = createWrappedTelegramClientFetchWithTransport({
-      fetch: fetchSpy as unknown as typeof fetch,
+      fetch: fetchSpy,
       forceFallback,
     });
 
@@ -430,10 +424,10 @@ describe("createTelegramBot fetch abort", () => {
         }),
       }),
     );
-    const fetchSpy = vi.fn(async () => {
+    const fetchSpy = vi.fn<typeof fetch>(async () => {
       throw toLintErrorObject(frozenError, "Non-Error thrown");
     });
-    const { clientFetch } = createWrappedTelegramClientFetch(fetchSpy as unknown as typeof fetch);
+    const { clientFetch } = createWrappedTelegramClientFetch(fetchSpy);
 
     await expect(clientFetch("https://api.telegram.org/bot123456:ABC/getUpdates")).rejects.toBe(
       frozenError,

--- a/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
@@ -123,6 +123,13 @@ async function flushActiveScheduledTimersForDelay(params: {
   }
 }
 
+function installInertTimerMock() {
+  const nativeSetTimeout = globalThis.setTimeout;
+  return vi
+    .spyOn(globalThis, "setTimeout")
+    .mockImplementation(() => nativeSetTimeout(() => {}, 2_147_483_647));
+}
+
 describe("telegram inbound media", () => {
   // Parallel vitest shards can make this suite slower than the standalone run.
   const INBOUND_MEDIA_TEST_TIMEOUT_MS = process.platform === "win32" ? 120_000 : 90_000;
@@ -258,16 +265,15 @@ describe("telegram inbound media", () => {
     const globalFetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
       throw new Error("global fetch should not be called");
     });
-    const proxyFetch = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      statusText: "OK",
-      headers: { get: () => "image/jpeg" },
-      arrayBuffer: async () => new Uint8Array([0xff, 0xd8, 0xff]).buffer,
-    } as unknown as Response);
+    const proxyFetch = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      new Response(new Uint8Array([0xff, 0xd8, 0xff]), {
+        status: 200,
+        headers: { "content-type": "image/jpeg" },
+      }),
+    );
 
     const { handler } = await createBotHandlerWithOptions({
-      proxyFetch: proxyFetch as unknown as typeof fetch,
+      proxyFetch,
       runtimeLog,
       runtimeError,
     });
@@ -583,12 +589,7 @@ describe("telegram media groups", () => {
       const runtimeError = vi.fn();
       const { handler, replySpy } = await createBotHandlerWithOptions({ runtimeError });
       const fetchSpy = mockTelegramPngDownload();
-      let nextTimerHandle = 1;
-      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(() => {
-        const handle = nextTimerHandle;
-        nextTimerHandle += 1;
-        return handle as unknown as ReturnType<typeof setTimeout>;
-      });
+      const setTimeoutSpy = installInertTimerMock();
       const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
 
       try {
@@ -693,12 +694,7 @@ describe("telegram media groups", () => {
       const runtimeError = vi.fn();
       const { handler, replySpy } = await createBotHandlerWithOptions({ runtimeError });
       const fetchSpy = mockTelegramPngDownload();
-      let nextTimerHandle = 1;
-      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(() => {
-        const handle = nextTimerHandle;
-        nextTimerHandle += 1;
-        return handle as unknown as ReturnType<typeof setTimeout>;
-      });
+      const setTimeoutSpy = installInertTimerMock();
       const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
       const savedPaths = [
         "/tmp/media/inbound/album-context-1.png",
@@ -792,12 +788,7 @@ describe("telegram media groups", () => {
     async () => {
       const runtimeError = vi.fn();
       const { handler, replySpy } = await createBotHandlerWithOptions({ runtimeError });
-      let nextTimerHandle = 1;
-      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(() => {
-        const handle = nextTimerHandle;
-        nextTimerHandle += 1;
-        return handle as unknown as ReturnType<typeof setTimeout>;
-      });
+      const setTimeoutSpy = installInertTimerMock();
       const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
       const savedPaths = [
         "/tmp/media/inbound/album-partial-2.png",
@@ -922,12 +913,7 @@ describe("telegram media groups", () => {
       const runtimeError = vi.fn();
       const { handler, replySpy } = await createBotHandlerWithOptions({ runtimeError });
       const fetchSpy = mockTelegramPngDownload();
-      let nextTimerHandle = 1;
-      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(() => {
-        const handle = nextTimerHandle;
-        nextTimerHandle += 1;
-        return handle as unknown as ReturnType<typeof setTimeout>;
-      });
+      const setTimeoutSpy = installInertTimerMock();
       const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
 
       try {

--- a/extensions/telegram/src/bot.media.e2e.test-harness.ts
+++ b/extensions/telegram/src/bot.media.e2e.test-harness.ts
@@ -3,7 +3,10 @@ import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import {
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { finalizeInboundContext, resetInboundDedupe } from "openclaw/plugin-sdk/reply-runtime";
 import type { GetReplyOptions, MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { afterEach, beforeEach, vi, type Mock } from "vitest";
@@ -13,7 +16,6 @@ import { setTelegramRuntime } from "./runtime.js";
 import { resetTelegramTopicNameCacheForTest } from "./runtime.test-support.js";
 import type { TelegramRuntime } from "./runtime.types.js";
 
-type TelegramBotRuntimeForTest = typeof import("./bot.runtime.js");
 type DispatchReplyWithBufferedBlockDispatcherFn =
   typeof import("openclaw/plugin-sdk/reply-runtime").dispatchReplyWithBufferedBlockDispatcher;
 type DispatchReplyHarnessParams = Parameters<DispatchReplyWithBufferedBlockDispatcherFn>[0];
@@ -135,42 +137,16 @@ const defaultRuntimeConfig = (() =>
     channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
   }) as OpenClawConfig) as TelegramBotDeps["getRuntimeConfig"];
 
-type TopicNameEntry = {
-  name: string;
-  iconColor?: number;
-  iconCustomEmojiId?: string;
-  closed?: boolean;
-  updatedAt: number;
-};
-
-const topicNameStoresForTest = new Map<string, Map<string, TopicNameEntry>>();
-
 function installTopicNameRuntimeForTest(): void {
   setTelegramRuntime({
     state: {
-      openKeyedStore: (({ namespace }: { namespace: string }) => {
-        let store = topicNameStoresForTest.get(namespace);
-        if (!store) {
-          store = new Map();
-          topicNameStoresForTest.set(namespace, store);
-        }
-        return {
-          register: async (key: string, value: TopicNameEntry) => {
-            store.set(key, value);
-          },
-          entries: async () => [...store.entries()].map(([key, value]) => ({ key, value })),
-          delete: async (key: string) => store.delete(key),
-          clear: async () => {
-            store.clear();
-          },
-        };
-      }) as unknown as TelegramRuntime["state"]["openKeyedStore"],
+      openKeyedStore: (options) => createPluginStateKeyedStoreForTests("telegram", options),
     },
     channel: {},
   } as TelegramRuntime);
 }
 
-const telegramBotRuntimeForTest: TelegramBotRuntimeForTest = {
+const telegramBotRuntimeForTest = {
   Bot: class {
     api = apiStub;
     use = middlewareUseSpy;
@@ -179,9 +155,9 @@ const telegramBotRuntimeForTest: TelegramBotRuntimeForTest = {
     stop = stopSpy;
     catch = vi.fn();
     constructor(public token: string) {}
-  } as unknown as TelegramBotRuntimeForTest["Bot"],
-  sequentialize: (() => vi.fn()) as TelegramBotRuntimeForTest["sequentialize"],
-  apiThrottler: (() => throttlerSpy()) as unknown as TelegramBotRuntimeForTest["apiThrottler"],
+  },
+  sequentialize: () => vi.fn(),
+  apiThrottler: () => throttlerSpy(),
 };
 
 const mediaHarnessReplySpy = vi.hoisted(() =>
@@ -285,7 +261,6 @@ beforeEach(() => {
   process.env.OPENCLAW_STATE_DIR = ensureMediaHarnessStoreRoot();
   telegramBotDepsForTest.getRuntimeConfig = defaultRuntimeConfig;
   resetInboundDedupe();
-  topicNameStoresForTest.clear();
   resetTelegramTopicNameCacheForTest();
   installTopicNameRuntimeForTest();
   resetSaveMediaBufferMock();

--- a/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
@@ -84,6 +84,13 @@ function resolveActiveScheduledTimersForDelay(
   );
 }
 
+function installInertTimerMock() {
+  const nativeSetTimeout = globalThis.setTimeout;
+  return vi
+    .spyOn(globalThis, "setTimeout")
+    .mockImplementation(() => nativeSetTimeout(() => {}, 2_147_483_647));
+}
+
 describe("telegram stickers", () => {
   // Parallel Testbox shards can make these media-path e2e tests slower than standalone local runs.
   const STICKER_TEST_TIMEOUT_MS = process.platform === "win32" ? 120_000 : 90_000;
@@ -99,7 +106,7 @@ describe("telegram stickers", () => {
   it(
     "refreshes cached sticker metadata on cache hit",
     async () => {
-      const proxyFetch = vi.fn().mockResolvedValue(
+      const proxyFetch = vi.fn<typeof fetch>().mockResolvedValue(
         new Response(Buffer.from(new Uint8Array([0x52, 0x49, 0x46, 0x46])), {
           status: 200,
           headers: { "content-type": "image/webp" },
@@ -120,8 +127,8 @@ describe("telegram stickers", () => {
         token: "tok",
         transport: {
           close: async () => {},
-          fetch: proxyFetch as unknown as typeof fetch,
-          sourceFetch: proxyFetch as unknown as typeof fetch,
+          fetch: proxyFetch,
+          sourceFetch: proxyFetch,
         } satisfies TelegramTransport,
         ctx: {
           message: {
@@ -145,15 +152,11 @@ describe("telegram stickers", () => {
         } as TelegramContext,
       });
 
-      const [cachedSticker] =
-        (
-          cacheStickerSpy.mock.calls as unknown as Array<
-            [{ emoji?: string; fileId?: string; setName?: string }]
-          >
-        )[0] ?? [];
-      expect(cachedSticker?.fileId).toBe("new_file_id");
-      expect(cachedSticker?.emoji).toBe("🔥");
-      expect(cachedSticker?.setName).toBe("NewSet");
+      expect(cacheStickerSpy.mock.calls[0]?.[0]).toMatchObject({
+        fileId: "new_file_id",
+        emoji: "🔥",
+        setName: "NewSet",
+      });
       expect(media?.stickerMetadata?.fileId).toBe("new_file_id");
       expect(media?.stickerMetadata?.cachedDescription).toBe("Cached description");
       const [fetchUrl, fetchOptions] = proxyFetch.mock.calls.at(0) ?? [];
@@ -166,7 +169,7 @@ describe("telegram stickers", () => {
   it(
     "rejects animated and video sticker downloads before fetching bytes",
     async () => {
-      const proxyFetch = vi.fn();
+      const proxyFetch = vi.fn<typeof fetch>();
 
       for (const scenario of [
         {
@@ -199,28 +202,32 @@ describe("telegram stickers", () => {
             set_name: "VideoPack",
           },
         },
-      ]) {
+      ] as const) {
         proxyFetch.mockClear();
-        const getFile = vi.fn(async () => ({ file_path: scenario.filePath }));
+        const getFile = vi.fn<TelegramContext["getFile"]>(async () => ({
+          file_id: scenario.sticker.file_id,
+          file_unique_id: scenario.sticker.file_unique_id,
+          file_path: scenario.filePath,
+        }));
 
         const media = await resolveMedia({
           maxBytes: 2 * 1024 * 1024,
           token: "tok",
           transport: {
             close: async () => {},
-            fetch: proxyFetch as unknown as typeof fetch,
-            sourceFetch: proxyFetch as unknown as typeof fetch,
+            fetch: proxyFetch,
+            sourceFetch: proxyFetch,
           } satisfies TelegramTransport,
           ctx: {
             message: {
               message_id: scenario.messageId,
-              chat: { id: 1234, type: "private" },
+              chat: { id: 1234, type: "private", first_name: "Ada" },
               from: { id: 777, is_bot: false, first_name: "Ada" },
               sticker: scenario.sticker,
               date: 1736380800,
             },
             getFile,
-          } as unknown as TelegramContext,
+          } satisfies TelegramContext,
         });
 
         expect(media).toBeNull();
@@ -358,12 +365,7 @@ describe("telegram text fragments", () => {
 
       const runtimeError = vi.fn();
       const { handler, replySpy } = await createBotHandlerWithOptions({ runtimeError });
-      let nextTimerHandle = 1;
-      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(() => {
-        const handle = nextTimerHandle;
-        nextTimerHandle += 1;
-        return handle as unknown as ReturnType<typeof setTimeout>;
-      });
+      const setTimeoutSpy = installInertTimerMock();
       const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
       const part1 = "A".repeat(4050);
       const part2 = "B".repeat(50);
@@ -434,12 +436,7 @@ describe("telegram text fragments", () => {
 
       const runtimeError = vi.fn();
       const { handler, replySpy } = await createBotHandlerWithOptions({ runtimeError });
-      let nextTimerHandle = 1;
-      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(() => {
-        const handle = nextTimerHandle;
-        nextTimerHandle += 1;
-        return handle as unknown as ReturnType<typeof setTimeout>;
-      });
+      const setTimeoutSpy = installInertTimerMock();
       const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
 
       try {

--- a/extensions/telegram/src/bot.media.test-utils.ts
+++ b/extensions/telegram/src/bot.media.test-utils.ts
@@ -24,7 +24,7 @@ let replySpyRef: ReturnType<typeof vi.fn>;
 let onSpyRef: Mock;
 let sendChatActionSpyRef: Mock;
 let readRemoteMediaBufferSpyRef: Mock;
-let undiciFetchSpyRef: Mock;
+let undiciFetchSpyRef: Mock<typeof fetch>;
 let resetReadRemoteMediaBufferMockRef: () => void;
 
 type FetchMockHandle = Mock & { mockRestore: () => void };
@@ -60,7 +60,7 @@ export async function createBotHandlerWithOptions(options: {
 
   const runtimeError = options.runtimeError ?? vi.fn();
   const runtimeLog = options.runtimeLog ?? vi.fn();
-  const effectiveProxyFetch = options.proxyFetch ?? (undiciFetchSpyRef as unknown as typeof fetch);
+  const effectiveProxyFetch = options.proxyFetch ?? undiciFetchSpyRef;
   createTelegramBotRef({
     token: "tok",
     // Production always constructs the bot from getMe(), so inbound handlers may

--- a/extensions/telegram/src/bot.test-helpers.ts
+++ b/extensions/telegram/src/bot.test-helpers.ts
@@ -25,11 +25,21 @@ export async function runTelegramChannelInboundEventWithHarness(
       ...params.adapter,
       resolveTurn: async (input, eventClass, preflight) => {
         const resolved = await resolveTurn(input, eventClass, preflight);
-        if (!("route" in resolved) || "runDispatch" in resolved) {
+        if (
+          !("route" in resolved) ||
+          "runDispatch" in resolved ||
+          !("deliverWithProviderMessageSending" in resolved.delivery)
+        ) {
           return resolved;
         }
-        const plan =
-          resolved as unknown as import("openclaw/plugin-sdk/channel-inbound").ChannelInboundTurnPlan<"provider_message_sending">;
+        const plan = resolved;
+        const deliverWithProviderMessageSending = Reflect.get(
+          plan.delivery,
+          "deliverWithProviderMessageSending",
+        );
+        if (typeof deliverWithProviderMessageSending !== "function") {
+          return resolved;
+        }
         return {
           ...plan,
           runDispatch: async () =>
@@ -39,10 +49,14 @@ export async function runTelegramChannelInboundEventWithHarness(
               dispatcherOptions: {
                 ...plan.dispatcherOptions,
                 deliver: (payload, info) =>
-                  plan.delivery.deliverWithProviderMessageSending(payload, {
-                    ...info,
-                    onPlatformSendDispatch: info.onPlatformSendDispatch ?? (async () => undefined),
-                  }),
+                  Reflect.apply(deliverWithProviderMessageSending, plan.delivery, [
+                    payload,
+                    {
+                      ...info,
+                      onPlatformSendDispatch:
+                        info.onPlatformSendDispatch ?? (async () => undefined),
+                    },
+                  ]),
                 onError: plan.delivery.onError,
               },
               toolsAllow: plan.toolsAllow,

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -54,7 +54,10 @@ import {
   TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE,
 } from "./message-cache-persistence.js";
 import { buildTelegramOpaqueCallbackData } from "./native-command-callback-data.js";
-import { recordTelegramPollRegistryEntry } from "./poll-registry.js";
+import {
+  recordTelegramPollRegistryEntry,
+  type TelegramPollRegistryEntry,
+} from "./poll-registry.js";
 import { setTelegramRuntime } from "./runtime.js";
 import { clearTelegramRuntimeForTest as clearTelegramRuntime } from "./runtime.test-support.js";
 import type { TelegramRuntime } from "./runtime.types.js";
@@ -190,15 +193,10 @@ type TelegramReactionPolicyCase = {
 const TELEGRAM_POLL_REGISTRY_NAMESPACE = "telegram.poll-registry";
 const TELEGRAM_POLL_REGISTRY_MAX_ENTRIES = 10_000;
 
-type TelegramPollRegistryEntry = Omit<
-  Parameters<typeof recordTelegramPollRegistryEntry>[0],
-  "accountId" | "env"
-> & { createdAt: number };
-
 function makeTelegramPollRegistryEntry(
   overrides: Pick<TelegramPollRegistryEntry, "messageId" | "pollId"> &
-    Partial<Omit<TelegramPollRegistryEntry, "createdAt" | "messageId" | "pollId">>,
-): Omit<TelegramPollRegistryEntry, "createdAt"> {
+    Partial<Omit<TelegramPollRegistryEntry, "messageId" | "pollId">>,
+): TelegramPollRegistryEntry {
   return {
     chat: { id: 9876, type: "private", first_name: "Ada" },
     threadSpec: { scope: "dm" },
@@ -427,9 +425,7 @@ function createTelegramTestStorePath(label: string): string {
   return telegramTestState.path(`${label}-${telegramTestStoreSequence}.json`);
 }
 
-async function installTelegramPollRegistryForTests(
-  entry?: Omit<TelegramPollRegistryEntry, "createdAt">,
-) {
+async function installTelegramPollRegistryForTests(entry?: TelegramPollRegistryEntry) {
   setTelegramPluginStateRuntimeForTests();
   const store = createPluginStateKeyedStoreForTests<TelegramPollRegistryEntry>("telegram", {
     namespace: TELEGRAM_POLL_REGISTRY_NAMESPACE,
@@ -454,6 +450,14 @@ function setTelegramPollRegistryRuntimeForTests(
   } as TelegramRuntime);
 }
 
+function createTelegramPollRegistryStoreForTests() {
+  return createPluginStateKeyedStoreForTests<TelegramPollRegistryEntry>("telegram", {
+    namespace: TELEGRAM_POLL_REGISTRY_NAMESPACE,
+    maxEntries: TELEGRAM_POLL_REGISTRY_MAX_ENTRIES,
+    overflowPolicy: "reject-new",
+  });
+}
+
 function getTelegramPollAnswerHandlerForTests() {
   return getOnHandler("poll_answer") as (ctx: Record<string, unknown>) => Promise<void>;
 }
@@ -470,9 +474,9 @@ async function loadInboundContextContract() {
   return await import("openclaw/plugin-sdk/channel-contract-testing");
 }
 
-type MockCallSource = {
+type MockCallSource<Args extends readonly unknown[]> = {
   mock: {
-    calls: ReadonlyArray<ReadonlyArray<unknown>>;
+    calls: ReadonlyArray<Args>;
   };
 };
 
@@ -483,7 +487,12 @@ function requireArray(value: unknown, label: string): unknown[] {
   return value as unknown[];
 }
 
-function mockArg(source: MockCallSource, callIndex: number, argIndex: number, label: string) {
+function mockArg<Args extends readonly unknown[]>(
+  source: MockCallSource<Args>,
+  callIndex: number,
+  argIndex: number,
+  label: string,
+) {
   const call = source.mock.calls[callIndex];
   if (!call) {
     throw new Error(`expected mock call: ${label}`);
@@ -491,7 +500,11 @@ function mockArg(source: MockCallSource, callIndex: number, argIndex: number, la
   return call[argIndex];
 }
 
-function mockCall(source: MockCallSource, callIndex: number, label: string) {
+function mockCall<Args extends readonly unknown[]>(
+  source: MockCallSource<Args>,
+  callIndex: number,
+  label: string,
+) {
   const call = source.mock.calls[callIndex];
   if (!call) {
     throw new Error(`expected mock call: ${label}`);
@@ -500,15 +513,15 @@ function mockCall(source: MockCallSource, callIndex: number, label: string) {
 }
 
 function firstEditMessageTextArg(argIndex: number) {
-  return mockArg(editMessageTextSpy as unknown as MockCallSource, 0, argIndex, "edit message text");
+  return mockArg(editMessageTextSpy, 0, argIndex, "edit message text");
 }
 
 function firstSystemEventArg(argIndex: number) {
-  return mockArg(enqueueSystemEventSpy as unknown as MockCallSource, 0, argIndex, "system event");
+  return mockArg(enqueueSystemEventSpy, 0, argIndex, "system event");
 }
 
-function mockMsgContextArg(
-  source: MockCallSource,
+function mockMsgContextArg<Args extends readonly unknown[]>(
+  source: MockCallSource<Args>,
   callIndex: number,
   argIndex: number,
   label: string,
@@ -600,12 +613,7 @@ async function writeDirectTelegramTranscriptContext(params: {
 }
 
 function latestConversationContextMessages(): Record<string, unknown>[] {
-  const payload = mockMsgContextArg(
-    replySpy as unknown as MockCallSource,
-    replySpy.mock.calls.length - 1,
-    0,
-    "replySpy call",
-  );
+  const payload = mockMsgContextArg(replySpy, replySpy.mock.calls.length - 1, 0, "replySpy call");
   const [conversationContext] = requireArray(
     payload.ChannelStructuredContext,
     "structured context",
@@ -661,7 +669,7 @@ async function seedTelegramPromptContextMessages(params: {
 
 function execApprovalCall(index = 0) {
   return requireRecord(
-    mockArg(resolveExecApprovalSpy as unknown as MockCallSource, index, 0, "exec approval call"),
+    mockArg(resolveExecApprovalSpy, index, 0, "exec approval call"),
     "exec approval call",
   );
 }
@@ -682,7 +690,7 @@ function execApprovalTargetConfig(call = execApprovalCall()) {
 
 function systemEventOptions(index = 0) {
   return requireRecord(
-    mockArg(enqueueSystemEventSpy as unknown as MockCallSource, index, 1, "system event options"),
+    mockArg(enqueueSystemEventSpy, index, 1, "system event options"),
     "system event options",
   );
 }
@@ -1238,11 +1246,10 @@ describe("createTelegramBot", () => {
       chat: { id: 123, type: "private", first_name: "Ada" },
       messageId: 44,
     });
-    const register = vi.fn(async () => {});
-    setTelegramPollRegistryRuntimeForTests({
-      lookup: async () => entry,
-      register,
-    } as unknown as PluginStateKeyedStore<TelegramPollRegistryEntry>);
+    const store = createTelegramPollRegistryStoreForTests();
+    vi.spyOn(store, "lookup").mockResolvedValue(entry);
+    const register = vi.spyOn(store, "register").mockResolvedValue();
+    setTelegramPollRegistryRuntimeForTests(store);
 
     try {
       createTelegramBot({ token: "tok" });
@@ -1289,12 +1296,11 @@ describe("createTelegramBot", () => {
   ])("drops $name before registry I/O", async ({ pollAnswer }) => {
     onSpy.mockClear();
     dispatchReplyWithBufferedBlockDispatcher.mockClear();
-    const lookup = vi.fn(async () => {
+    const store = createTelegramPollRegistryStoreForTests();
+    const lookup = vi.spyOn(store, "lookup").mockImplementation(async () => {
       throw new Error("registry should not be read");
     });
-    setTelegramPollRegistryRuntimeForTests({
-      lookup,
-    } as unknown as PluginStateKeyedStore<TelegramPollRegistryEntry>);
+    setTelegramPollRegistryRuntimeForTests(store);
 
     try {
       createTelegramBot({ token: "tok" });
@@ -1311,11 +1317,9 @@ describe("createTelegramBot", () => {
     onSpy.mockClear();
     dispatchReplyWithBufferedBlockDispatcher.mockClear();
     const readError = new Error("registry db unavailable");
-    setTelegramPollRegistryRuntimeForTests({
-      lookup: async () => {
-        throw readError;
-      },
-    } as unknown as PluginStateKeyedStore<TelegramPollRegistryEntry>);
+    const store = createTelegramPollRegistryStoreForTests();
+    vi.spyOn(store, "lookup").mockRejectedValue(readError);
+    setTelegramPollRegistryRuntimeForTests(store);
 
     try {
       createTelegramBot({ token: "tok" });
@@ -1401,7 +1405,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.InboundEventKind).toBe("room_event");
     expect(payload.InboundHistory).toEqual(
       expect.arrayContaining([
@@ -1548,12 +1552,7 @@ describe("createTelegramBot", () => {
       });
 
       expect(replySpy).toHaveBeenCalledTimes(1);
-      const payload = mockMsgContextArg(
-        replySpy as unknown as MockCallSource,
-        0,
-        0,
-        "replySpy call",
-      );
+      const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
       expect(payload.ReplyChain).toEqual([
         expect.objectContaining({
           messageId: String(replyMessageId),
@@ -1838,7 +1837,7 @@ describe("createTelegramBot", () => {
 
     expect(editMessageTextSpy).toHaveBeenCalledTimes(1);
     const [chatId, messageId, terminalText, editOptions] = mockCall(
-      editMessageTextSpy as unknown as MockCallSource,
+      editMessageTextSpy,
       0,
       "edit terminal approval message",
     );
@@ -2470,17 +2469,6 @@ describe("createTelegramBot", () => {
       messageId: 14,
     },
   ])("$name", async ({ callbackId, callbackData, messageId }) => {
-    (
-      listSkillCommandsForAgents as unknown as {
-        mockImplementationOnce(implementation: TelegramBotDeps["listSkillCommandsForAgents"]): void;
-      }
-    ).mockImplementationOnce(({ agentIds }) => {
-      if (agentIds?.length !== 1 || agentIds[0] !== "main") {
-        throw new Error("pagination queried commands for the wrong agent");
-      }
-      return [];
-    });
-
     createTelegramBot({ token: "tok" });
     const callbackHandler = getTelegramCallbackHandlerForTests();
     await callbackHandler(
@@ -2492,9 +2480,12 @@ describe("createTelegramBot", () => {
     );
 
     expect(listSkillCommandsForAgents).toHaveBeenCalledOnce();
+    expect(listSkillCommandsForAgents).toHaveBeenCalledWith(
+      expect.objectContaining({ agentIds: ["main"] }),
+    );
     expect(editMessageTextSpy).toHaveBeenCalledTimes(1);
     const [chatId, renderedMessageId, text, params] = mockCall(
-      editMessageTextSpy as unknown as MockCallSource,
+      editMessageTextSpy,
       0,
       "edit message text",
     );
@@ -2858,11 +2849,7 @@ describe("createTelegramBot", () => {
 
     expect(replySpy).not.toHaveBeenCalled();
     expect(editMessageTextSpy).toHaveBeenCalledTimes(1);
-    const editCall = mockCall(
-      editMessageTextSpy as unknown as MockCallSource,
-      0,
-      "edit message text",
-    );
+    const editCall = mockCall(editMessageTextSpy, 0, "edit message text");
     expect(editCall[0]).toBe(1234);
     expect(editCall[1]).toBe(17);
     expect(editCall[2]).toBe(
@@ -3012,7 +2999,7 @@ describe("createTelegramBot", () => {
 
     expect(loadConfig).toHaveBeenCalledTimes(2);
     const dispatchParams = mockArg(
-      dispatchReplyWithBufferedBlockDispatcher as unknown as MockCallSource,
+      dispatchReplyWithBufferedBlockDispatcher,
       0,
       0,
       "buffered dispatch",
@@ -3089,7 +3076,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     const { expectChannelInboundContextContract: expectInboundContextContract } =
       await loadInboundContextContract();
     const { escapeRegExp, formatEnvelopeTimestamp } = await loadEnvelopeTimestampHelpers();
@@ -3168,7 +3155,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     const [conversationContext] = requireArray(
       payload.ChannelStructuredContext,
       "structured context",
@@ -3232,7 +3219,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.ChannelStructuredContext).toEqual([
       {
         label: "Conversation context",
@@ -3333,12 +3320,7 @@ describe("createTelegramBot", () => {
       });
 
       expect(replySpy).toHaveBeenCalledTimes(1);
-      const payload = mockMsgContextArg(
-        replySpy as unknown as MockCallSource,
-        0,
-        0,
-        "replySpy call",
-      );
+      const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
       const [conversationContext] = requireArray(
         payload.ChannelStructuredContext,
         "structured context",
@@ -3400,7 +3382,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.ChannelStructuredContext).toBeUndefined();
     expect(payload.Body).not.toContain("Do not include this cached group line.");
   });
@@ -3474,7 +3456,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     const [conversationContext] = requireArray(
       payload.ChannelStructuredContext,
       "structured context",
@@ -3530,7 +3512,7 @@ describe("createTelegramBot", () => {
     );
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     const [conversationContext] = requireArray(
       payload.ChannelStructuredContext,
       "structured context",
@@ -3705,12 +3687,7 @@ describe("createTelegramBot", () => {
       );
 
       expect(replySpy).toHaveBeenCalledTimes(1);
-      const payload = mockMsgContextArg(
-        replySpy as unknown as MockCallSource,
-        0,
-        0,
-        "replySpy call",
-      );
+      const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
       const [conversationContext] = requireArray(
         payload.ChannelStructuredContext,
         "structured context",
@@ -4125,7 +4102,7 @@ describe("createTelegramBot", () => {
     );
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(JSON.stringify(payload.ChannelStructuredContext ?? [])).not.toContain(
       "old private transcript text",
     );
@@ -4156,7 +4133,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.Body).toContain("[Reply chain - nearest first]");
     expect(payload.Body).toContain("[1. Ada id:9001]");
     expect(payload.Body).toContain('"summarize this"');
@@ -4190,7 +4167,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.Body).toContain("[Reply chain - nearest first]");
     expect(payload.Body).toContain("[1. Ada id:9001]");
     expect(payload.Body).not.toContain("PK");
@@ -4229,12 +4206,7 @@ describe("createTelegramBot", () => {
         me: { username: "openclaw_bot" },
         getFile: async () => ({}),
       });
-      replyGetFileSignal = mockArg(
-        getFileSpy as unknown as MockCallSource,
-        0,
-        1,
-        "reply getFile signal",
-      ) as AbortSignal;
+      replyGetFileSignal = mockArg(getFileSpy, 0, 1, "reply getFile signal") as AbortSignal;
       expect(replyGetFileSignal.aborted).toBe(false);
     } finally {
       mediaAbort.abort();
@@ -4242,12 +4214,7 @@ describe("createTelegramBot", () => {
     }
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(
-      replySpy as unknown as MockCallSource,
-      0,
-      0,
-      "replySpy call",
-    ) as {
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call") as {
       MediaPath?: string;
       MediaPaths?: string[];
       ReplyToBody?: string;
@@ -4289,7 +4256,7 @@ describe("createTelegramBot", () => {
     expect(mediaFetch).toHaveBeenCalledTimes(1);
     expect(getFileSpy).toHaveBeenCalledWith("reply-photo-1", expect.any(AbortSignal));
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.Body).toContain("continue without the old image");
   });
 
@@ -4314,7 +4281,7 @@ describe("createTelegramBot", () => {
     expect(result).toEqual({ kind: "completed" });
     expect(getFileSpy).toHaveBeenCalledWith("reply-photo-1", expect.any(AbortSignal));
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.Body).toContain("continue after polling restart");
   });
 
@@ -4426,12 +4393,7 @@ describe("createTelegramBot", () => {
     }
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(
-      replySpy as unknown as MockCallSource,
-      0,
-      0,
-      "replySpy call",
-    ) as {
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call") as {
       ReplyChain?: Array<{
         messageId?: string;
         body?: string;
@@ -4555,12 +4517,7 @@ describe("createTelegramBot", () => {
     }
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(
-      replySpy as unknown as MockCallSource,
-      0,
-      0,
-      "replySpy call",
-    ) as {
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call") as {
       ReplyChain?: Array<{
         messageId?: string;
         sender?: string;
@@ -4688,12 +4645,7 @@ describe("createTelegramBot", () => {
     }
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(
-      replySpy as unknown as MockCallSource,
-      0,
-      0,
-      "replySpy call",
-    ) as {
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call") as {
       ReplyChain?: unknown[];
       ChannelStructuredContext?: unknown[];
     };
@@ -4780,12 +4732,9 @@ describe("createTelegramBot", () => {
     }
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(
-      replySpy as unknown as MockCallSource,
-      0,
-      0,
-      "replySpy call",
-    ) as { ChannelStructuredContext?: unknown[] };
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call") as {
+      ChannelStructuredContext?: unknown[];
+    };
     const [conversationContext] = requireArray(
       payload.ChannelStructuredContext,
       "structured context",
@@ -4914,12 +4863,7 @@ describe("createTelegramBot", () => {
 
       expect(runtimeError).not.toHaveBeenCalled();
       expect(replySpy).toHaveBeenCalledTimes(1);
-      const payload = mockMsgContextArg(
-        replySpy as unknown as MockCallSource,
-        0,
-        0,
-        "replySpy call",
-      ) as {
+      const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call") as {
         ChannelStructuredContext?: unknown[];
       };
       const [conversationContext] = requireArray(
@@ -5079,7 +5023,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.Body).toContain("[Reply chain - nearest first]");
     expect(payload.Body).toContain("[1. unknown sender");
     expect(payload.Body).toContain('"summarize this"');
@@ -5111,7 +5055,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.Body).toContain("[Reply chain - nearest first]");
     expect(payload.Body).toContain("[1. Ada id:9002");
     expect(payload.Body).toContain('"summarize this"');
@@ -5162,12 +5106,9 @@ describe("createTelegramBot", () => {
     }
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(
-      replySpy as unknown as MockCallSource,
-      0,
-      0,
-      "replySpy call",
-    ) as { ReplyChain?: Array<{ messageId?: string; mediaPath?: string }> };
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call") as {
+      ReplyChain?: Array<{ messageId?: string; mediaPath?: string }>;
+    };
     expect(payload.ReplyChain?.[0]).toMatchObject({ messageId: "9003" });
     expect(payload.ReplyChain?.[0]?.mediaPath).toBeTypeOf("string");
     expect(getFileSpy).toHaveBeenCalledWith("external-photo-1", expect.any(AbortSignal));
@@ -5212,7 +5153,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.ReplyToForwardedFrom).toBe("Bob Smith (@bobsmith)");
     expect(payload.ReplyToForwardedFromType).toBe("user");
     expect(payload.ReplyToForwardedFromId).toBe("999");
@@ -5259,7 +5200,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.ReplyToForwardedFrom).toBe("Bob Smith (@bobsmith)");
     expect(payload.Body).toContain("[Forwarded from Bob Smith (@bobsmith)]");
     expect(payload.Body).not.toContain("+275760");
@@ -5307,7 +5248,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.ReplyToId).toBe("9003");
     expect(payload.ReplyToBody).toBe("forwarded text");
     expect(payload.ReplyToSender).toBe("Ada");
@@ -5341,7 +5282,7 @@ describe("createTelegramBot", () => {
     });
 
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.WasMentioned).toBe(true);
   });
 
@@ -5555,7 +5496,7 @@ describe("createTelegramBot", () => {
       reply_markup: { inline_keyboard: [] },
     });
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.Body).toContain("Fix a broken tool");
     expect(payload.SenderId).toBe("9");
     expect(payload.SenderUsername).toBe("ada_bot");
@@ -5588,7 +5529,7 @@ describe("createTelegramBot", () => {
 
     expect(handler).toHaveBeenCalledTimes(1);
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.Body).toContain("callback_data: openclaw-smart-replies");
     expect(payload.Body).not.toContain("Ignore this");
     expect(editMessageReplyMarkupSpy).not.toHaveBeenCalled();
@@ -5676,7 +5617,7 @@ describe("createTelegramBot", () => {
       reply_markup: { inline_keyboard: [] },
     });
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
+    const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
     expect(payload.Body).toContain("Investigate topic callback");
     expect(payload.MessageSid).toBe("cbq-smart-reply-topic-submit");
     expect(payload.WasMentioned).toBe(true);
@@ -5732,12 +5673,7 @@ describe("createTelegramBot", () => {
     expect(editMessageReplyMarkupSpy).toHaveBeenCalledWith(9, 11, {
       reply_markup: { inline_keyboard: [] },
     });
-    const payload = mockMsgContextArg(
-      replySpy as unknown as MockCallSource,
-      1,
-      0,
-      "replySpy retry call",
-    );
+    const payload = mockMsgContextArg(replySpy, 1, 0, "replySpy retry call");
     expect(payload.Body).toContain("Make Alice funnier");
   });
 
@@ -6072,12 +6008,7 @@ describe("createTelegramBot", () => {
 
     expect(replySpy).toHaveBeenCalledTimes(1);
     if (expectedSessionKey) {
-      const payload = mockMsgContextArg(
-        replySpy as unknown as MockCallSource,
-        0,
-        0,
-        "replySpy call",
-      );
+      const payload = mockMsgContextArg(replySpy, 0, 0, "replySpy call");
       expect(payload.CommandTargetSessionKey).toBe(expectedSessionKey);
     }
     if (assertAuthorized) {

--- a/extensions/telegram/src/bot/body-helpers.ts
+++ b/extensions/telegram/src/bot/body-helpers.ts
@@ -95,6 +95,11 @@ export function buildSenderLabel(msg: Message, senderId?: number | string) {
 
 export type TelegramTextEntity = NonNullable<Message["entities"]>[number];
 
+export type TelegramTextParts = {
+  text: string;
+  entities: TelegramTextEntity[];
+};
+
 const TELEGRAM_RICH_MESSAGE_PLACEHOLDER = "[unsupported Telegram rich_message received]";
 
 type TelegramTextMessage = Pick<
@@ -239,10 +244,7 @@ function formatTelegramPollText(poll: NonNullable<Message["poll"]>): string {
   ].join("\n");
 }
 
-export function getTelegramTextParts(msg: TelegramTextMessage): {
-  text: string;
-  entities: TelegramTextEntity[];
-} {
+export function getTelegramTextParts(msg: TelegramTextMessage): TelegramTextParts {
   const text = resolveTelegramTextContent(msg.text, msg.caption);
   if (text) {
     return { text, entities: msg.entities ?? msg.caption_entities ?? [] };
@@ -253,7 +255,7 @@ export function getTelegramTextParts(msg: TelegramTextMessage): {
 export function joinTelegramTextParts(
   messages: readonly Message[],
   separator: string,
-): { text: string; entities: TelegramTextEntity[] } {
+): TelegramTextParts {
   const textParts: string[] = [];
   const entities: TelegramTextEntity[] = [];
   let offset = 0;

--- a/extensions/telegram/src/bot/body-helpers.ts
+++ b/extensions/telegram/src/bot/body-helpers.ts
@@ -95,7 +95,7 @@ export function buildSenderLabel(msg: Message, senderId?: number | string) {
 
 export type TelegramTextEntity = NonNullable<Message["entities"]>[number];
 
-export type TelegramTextParts = {
+type TelegramTextParts = {
   text: string;
   entities: TelegramTextEntity[];
 };

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -307,7 +307,7 @@ async function deliverMediaReply(params: {
     await params.progress.promptContext?.accept(promptContextMessage);
   };
   const deliverAcceptedMedia = async (options: {
-    sender: TelegramOutboundMediaSender<Message>;
+    sender: TelegramOutboundMediaSender;
     requestParams: Record<string, unknown>;
     plainCaption?: string;
     shouldLog?: (err: unknown) => boolean;
@@ -381,7 +381,7 @@ async function deliverMediaReply(params: {
       tableMode: params.tableMode,
       preparedHtml: true,
     });
-    const { sender: mediaSender, documentSender } = resolveTelegramOutboundMediaSenders<Message>({
+    const { sender: mediaSender, documentSender } = resolveTelegramOutboundMediaSenders({
       api: params.bot.api,
       chatId: params.chatId,
       media,
@@ -401,7 +401,7 @@ async function deliverMediaReply(params: {
     const shouldAttachButtonsToMedia = isFirstMedia && params.replyMarkup && !followUpText;
     const videoDimensions =
       mediaPlan.kind === "video" ? await probeVideoDimensions(media.buffer) : undefined;
-    const mediaParams: Record<string, unknown> = {
+    const mediaParams = {
       caption: htmlCaption,
       ...(htmlCaption ? { parse_mode: "HTML" } : {}),
       ...(shouldAttachButtonsToMedia ? { reply_markup: params.replyMarkup } : {}),
@@ -415,10 +415,10 @@ async function deliverMediaReply(params: {
         thread: params.thread,
         silent: params.silent,
       }),
-    };
+    } satisfies Record<string, unknown>;
     if (mediaSender.label === "voice") {
       const sendVoiceMedia = async (
-        requestParams: typeof mediaParams,
+        requestParams: Record<string, unknown>,
         shouldLog?: (err: unknown) => boolean,
       ) => {
         const hasCaption = typeof requestParams.caption === "string";
@@ -495,9 +495,7 @@ async function deliverMediaReply(params: {
           logVerbose(
             "telegram sendVoice caption too long; resending voice without caption + text separately",
           );
-          const noCaptionParams = { ...mediaParams };
-          delete noCaptionParams.caption;
-          delete noCaptionParams.parse_mode;
+          const { caption: _caption, parse_mode: _parseMode, ...noCaptionParams } = mediaParams;
           await sendVoiceMedia(noCaptionParams);
           const fallbackText = resolveVoiceFallbackText(params.reply);
           if (fallbackText?.trim()) {

--- a/extensions/telegram/src/bot/delivery.resolve-media-local.test.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media-local.test.ts
@@ -5,6 +5,7 @@ import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 // Telegram tests cover delivery.resolve media retry plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { telegramBotInfoForTest } from "../bot.create-telegram-bot.test-support.js";
 import { resolveMedia } from "./delivery.resolve-media.js";
 import type { TelegramContext } from "./types.js";
 
@@ -86,10 +87,10 @@ function makeCtx(
   getFile: TelegramContext["getFile"],
   opts?: { file_name?: string; mime_type?: string },
 ): TelegramContext {
-  const msg: Record<string, unknown> = {
+  const msg: Message = {
     message_id: 1,
     date: 0,
-    chat: { id: 1, type: "private" },
+    chat: { id: 1, type: "private", first_name: "Test" },
   };
   if (mediaField === "voice") {
     msg.voice = {
@@ -109,13 +110,15 @@ function makeCtx(
     };
   }
   if (mediaField === "photo") {
-    msg.photo = [{ file_id: "p1", width: 100, height: 100 }];
+    msg.photo = [{ file_id: "p1", file_unique_id: "up1", width: 100, height: 100 }];
   }
   if (mediaField === "video") {
     msg.video = {
       file_id: "vid1",
       duration: 10,
       file_unique_id: "u3",
+      width: 100,
+      height: 100,
       ...(opts?.file_name && { file_name: opts.file_name }),
     };
   }
@@ -149,13 +152,8 @@ function makeCtx(
     };
   }
   return {
-    message: msg as unknown as Message,
-    me: {
-      id: 1,
-      is_bot: true,
-      first_name: "bot",
-      username: "bot",
-    } as unknown as TelegramContext["me"],
+    message: msg,
+    me: telegramBotInfoForTest,
     getFile,
   };
 }
@@ -640,7 +638,7 @@ describe("resolveMedia getFile retry", () => {
 
   it("uses caller-provided fetch impl for file downloads", async () => {
     const getFile = vi.fn().mockResolvedValue({ file_path: "documents/file_42.pdf" });
-    const callerFetch = vi.fn() as unknown as typeof fetch;
+    const callerFetch = vi.fn<typeof fetch>();
     const dispatcherAttempts = [
       {
         dispatcherPolicy: {
@@ -690,7 +688,7 @@ describe("resolveMedia getFile retry", () => {
 
   it("uses caller-provided fetch impl for sticker downloads", async () => {
     const getFile = vi.fn().mockResolvedValue({ file_path: "stickers/file_0.webp" });
-    const callerFetch = vi.fn() as unknown as typeof fetch;
+    const callerFetch = vi.fn<typeof fetch>();
     const callerTransport = { fetch: callerFetch, sourceFetch: callerFetch, close: async () => {} };
     readRemoteMediaBuffer.mockResolvedValueOnce({
       buffer: Buffer.from("sticker-data"),

--- a/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
@@ -4,6 +4,7 @@ import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 // Telegram tests cover delivery.resolve media retry plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { telegramBotInfoForTest } from "../bot.create-telegram-bot.test-support.js";
 import { resolveMedia } from "./delivery.resolve-media.js";
 import type { TelegramContext } from "./types.js";
 
@@ -85,10 +86,10 @@ function makeCtx(
   getFile: TelegramContext["getFile"],
   opts?: { file_name?: string; mime_type?: string },
 ): TelegramContext {
-  const msg: Record<string, unknown> = {
+  const msg: Message = {
     message_id: 1,
     date: 0,
-    chat: { id: 1, type: "private" },
+    chat: { id: 1, type: "private", first_name: "Test" },
   };
   if (mediaField === "voice") {
     msg.voice = {
@@ -108,13 +109,15 @@ function makeCtx(
     };
   }
   if (mediaField === "photo") {
-    msg.photo = [{ file_id: "p1", width: 100, height: 100 }];
+    msg.photo = [{ file_id: "p1", file_unique_id: "up1", width: 100, height: 100 }];
   }
   if (mediaField === "video") {
     msg.video = {
       file_id: "vid1",
       duration: 10,
       file_unique_id: "u3",
+      width: 100,
+      height: 100,
       ...(opts?.file_name && { file_name: opts.file_name }),
     };
   }
@@ -148,13 +151,8 @@ function makeCtx(
     };
   }
   return {
-    message: msg as unknown as Message,
-    me: {
-      id: 1,
-      is_bot: true,
-      first_name: "bot",
-      username: "bot",
-    } as unknown as TelegramContext["me"],
+    message: msg,
+    me: telegramBotInfoForTest,
     getFile,
   };
 }

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -30,6 +30,9 @@ type DeliverWithParams = Omit<
 > &
   Partial<Pick<DeliverRepliesParams, "replyToMode" | "textLimit" | "mediaLoader">>;
 type RuntimeStub = Pick<RuntimeEnv, "error" | "log" | "exit">;
+type RichMessageRawApi = {
+  sendRichMessage: ReturnType<typeof vi.fn>;
+};
 
 vi.mock("openclaw/plugin-sdk/web-media", () => ({
   loadWebMedia: (...args: unknown[]) => loadWebMedia(...args),
@@ -113,7 +116,7 @@ function createBot(api: Record<string, unknown> = {}): Bot {
           throw new Error("sendMessage mock missing");
         }
         const { chat_id, rich_message, ...richParams } = params;
-        const sendParams: Record<string, unknown> = {
+        const sendParams = {
           parse_mode: "HTML",
           ...(rich_message.skip_entity_detection === true ? { skip_entity_detection: true } : {}),
           ...richParams,
@@ -126,23 +129,31 @@ function createBot(api: Record<string, unknown> = {}): Bot {
               })
               .join("\n")
           : (rich_message.markdown ?? rich_message.html ?? "");
-        const replyParameters = sendParams.reply_parameters;
+        const replyParameters = Reflect.get(sendParams, "reply_parameters");
         if (
           replyParameters &&
           typeof replyParameters === "object" &&
           !("quote" in replyParameters) &&
-          typeof (replyParameters as { message_id?: unknown }).message_id === "number"
+          typeof Reflect.get(replyParameters, "message_id") === "number"
         ) {
-          sendParams.reply_to_message_id = (replyParameters as { message_id: number }).message_id;
-          sendParams.allow_sending_without_reply = true;
-          delete sendParams.reply_parameters;
+          Reflect.set(
+            sendParams,
+            "reply_to_message_id",
+            Reflect.get(replyParameters, "message_id"),
+          );
+          Reflect.set(sendParams, "allow_sending_without_reply", true);
+          Reflect.deleteProperty(sendParams, "reply_parameters");
         }
         const options = sendParams;
         return sendMessage(chat_id, text, options);
       },
     ),
   };
-  return { api: { ...api, raw } } as unknown as Bot;
+  return Reflect.apply((bot: Bot) => bot, undefined, [{ api: { ...api, raw } }]);
+}
+
+function richMessageRawApi(bot: Bot): RichMessageRawApi {
+  return Reflect.apply((raw: RichMessageRawApi) => raw, undefined, [bot.api.raw]);
 }
 
 async function deliverWith(params: DeliverWithParams) {
@@ -341,11 +352,13 @@ describe("deliverReplies", () => {
     const sendMessage = vi.fn().mockResolvedValue({ message_id: 1, chat: { id: "123" } });
     const bot = createBot({ sendMessage });
 
-    await deliverWith({
-      replies: [undefined, { text: "hello" }] as unknown as DeliverRepliesParams["replies"],
-      runtime,
-      bot,
-    });
+    await Reflect.apply(deliverWith, undefined, [
+      {
+        replies: [undefined, { text: "hello" }],
+        runtime,
+        bot,
+      },
+    ]);
 
     expect(runtime.error).toHaveBeenCalledTimes(1);
     expect(sendMessage).toHaveBeenCalledTimes(1);
@@ -1724,7 +1737,7 @@ describe("deliverReplies", () => {
   it("skips whitespace-only text replies without calling Telegram", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn();
-    const bot = { api: { sendMessage } } as unknown as Bot;
+    const bot = Reflect.apply((value: Bot) => value, undefined, [{ api: { sendMessage } }]);
 
     await expect(
       deliverReplies({
@@ -1897,9 +1910,7 @@ describe("deliverReplies", () => {
       richMessages: true,
     });
 
-    const raw = bot.api.raw as unknown as {
-      sendRichMessage: ReturnType<typeof vi.fn>;
-    };
+    const raw = richMessageRawApi(bot);
     const { sendRichMessage } = raw;
     expect(sendRichMessage).toHaveBeenCalledTimes(2);
     expectRecordFields(firstMockCallArg(sendRichMessage, 0), {
@@ -1949,7 +1960,7 @@ describe("deliverReplies", () => {
       richMessages: true,
     });
 
-    const raw = bot.api.raw as unknown as { sendRichMessage: ReturnType<typeof vi.fn> };
+    const raw = richMessageRawApi(bot);
     expect(raw.sendRichMessage).toHaveBeenCalledTimes(1);
     const richMessage = firstMockCallArg(raw.sendRichMessage, 0).rich_message as {
       blocks: Array<{ type: string; cells?: unknown[][] }>;
@@ -1992,7 +2003,7 @@ describe("deliverReplies", () => {
 
     // HTML deliberately bypasses rich blocks, so a rich account must still ship
     // the authored fallback body rather than a generated legacy table.
-    const raw = bot.api.raw as unknown as { sendRichMessage: ReturnType<typeof vi.fn> };
+    const raw = richMessageRawApi(bot);
     expect(raw.sendRichMessage).not.toHaveBeenCalled();
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(String(mockCallArg(sendMessage, 0, 1))).toContain("plain fallback body");
@@ -2049,9 +2060,7 @@ describe("deliverReplies", () => {
       richMessages: true,
     });
 
-    const raw = bot.api.raw as unknown as {
-      sendRichMessage: ReturnType<typeof vi.fn>;
-    };
+    const raw = richMessageRawApi(bot);
     const richMessage = raw.sendRichMessage.mock.calls[0]?.[0]?.rich_message;
     expect(richMessage).toEqual({
       blocks: [{ type: "paragraph", text: oauthProfileText }],
@@ -2066,7 +2075,7 @@ describe("deliverReplies", () => {
       chat: { id: "123" },
     });
     const bot = createBot({ sendMessage });
-    (bot.api.raw as unknown as { sendRichMessage: ReturnType<typeof vi.fn> }).sendRichMessage = vi
+    richMessageRawApi(bot).sendRichMessage = vi
       .fn()
       .mockRejectedValue(createRichEntityInvalidError("EMAIL"));
     const text = "Status includes openai:owner@example.com";
@@ -2117,7 +2126,7 @@ describe("deliverReplies", () => {
       chat: { id: "123" },
     });
     const bot = createBot({ sendMessage });
-    (bot.api.raw as unknown as { sendRichMessage: ReturnType<typeof vi.fn> }).sendRichMessage = vi
+    richMessageRawApi(bot).sendRichMessage = vi
       .fn()
       .mockRejectedValue(createRichContentRequiredError());
     const text = "delivery continues as plain text";
@@ -2165,7 +2174,7 @@ describe("deliverReplies", () => {
       chat: { id: "123" },
     });
     const bot = createBot({ sendMessage });
-    (bot.api.raw as unknown as { sendRichMessage: ReturnType<typeof vi.fn> }).sendRichMessage = vi
+    richMessageRawApi(bot).sendRichMessage = vi
       .fn()
       .mockRejectedValue(createRichEntityInvalidError("URL"));
     const text = "| Rank | Model | Score |\n| --- | --- | --- |\n| 4 | Claude Opus | 78.16% |";
@@ -2191,7 +2200,7 @@ describe("deliverReplies", () => {
       chat: { id: "123" },
     });
     const bot = createBot({ sendMessage });
-    (bot.api.raw as unknown as { sendRichMessage: ReturnType<typeof vi.fn> }).sendRichMessage = vi
+    richMessageRawApi(bot).sendRichMessage = vi
       .fn()
       .mockRejectedValue(createRichEntityInvalidError("URL"));
     const text = "Status with a rejected URL entity";
@@ -2214,9 +2223,7 @@ describe("deliverReplies", () => {
       chat: { id: "123" },
     });
     const bot = createBot({ sendMessage });
-    (bot.api.raw as unknown as { sendRichMessage: ReturnType<typeof vi.fn> }).sendRichMessage = vi
-      .fn()
-      .mockRejectedValue(new Error("network error"));
+    richMessageRawApi(bot).sendRichMessage = vi.fn().mockRejectedValue(new Error("network error"));
     const text = "Status text";
 
     await expect(

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -107,6 +107,17 @@ export type TelegramThreadSpec = {
   scope: "direct-messages" | "dm" | "forum" | "none";
 };
 
+export type TelegramMessageThreadFacts = {
+  chat: {
+    type: Message["chat"]["type"];
+    is_direct_messages?: boolean;
+    is_forum?: boolean;
+  };
+  direct_messages_topic?: { topic_id?: number };
+  is_topic_message?: boolean;
+  message_thread_id?: number;
+};
+
 type TelegramThreadParams = {
   direct_messages_topic_id?: number;
   message_thread_id?: number;
@@ -420,7 +431,7 @@ export function resolveTelegramThreadSpec(params: {
 }
 
 export function resolveTelegramMessageThreadSpec(
-  message: Message,
+  message: TelegramMessageThreadFacts,
   isForum?: boolean,
 ): TelegramThreadSpec {
   if (message.chat.is_direct_messages === true) {

--- a/extensions/telegram/src/bot/inbound-text-entities.ts
+++ b/extensions/telegram/src/bot/inbound-text-entities.ts
@@ -10,18 +10,18 @@ type TelegramMarkdownBoundary = {
   index: number;
 };
 
-const TELEGRAM_ENTITY_MARKDOWN_PRIORITY: Partial<Record<MessageEntity["type"], number>> = {
-  blockquote: 0,
-  expandable_blockquote: 0,
-  bold: 10,
-  italic: 20,
-  underline: 30,
-  strikethrough: 40,
-  spoiler: 50,
-  text_link: 60,
-  code: 70,
-  pre: 80,
-};
+const TELEGRAM_ENTITY_MARKDOWN_PRIORITY = new Map<MessageEntity["type"], number>([
+  ["blockquote", 0],
+  ["expandable_blockquote", 0],
+  ["bold", 10],
+  ["italic", 20],
+  ["underline", 30],
+  ["strikethrough", 40],
+  ["spoiler", 50],
+  ["text_link", 60],
+  ["code", 70],
+  ["pre", 80],
+]);
 
 const SPLITTABLE_FORMATTING_ENTITY_TYPES = new Set<MessageEntity["type"]>([
   "bold",
@@ -219,7 +219,7 @@ export function renderTelegramTextEntities(
         start: segment.offset,
         end,
         length: segment.length,
-        priority: TELEGRAM_ENTITY_MARKDOWN_PRIORITY[segment.type] ?? 100,
+        priority: TELEGRAM_ENTITY_MARKDOWN_PRIORITY.get(segment.type) ?? 100,
         index,
       };
       addBoundary(boundary.start, boundary);

--- a/extensions/telegram/src/caption.ts
+++ b/extensions/telegram/src/caption.ts
@@ -3,13 +3,12 @@ import { countTelegramHtmlVisibleCharacters, resolveTelegramHtmlVisibleText } fr
 
 const TELEGRAM_MAX_CAPTION_LENGTH = 1024;
 
-export function splitTelegramCaption(
-  text?: string,
-  renderedHtml?: string,
-): {
+type TelegramCaptionSplit = {
   caption?: string;
   followUpText?: string;
-} {
+};
+
+export function splitTelegramCaption(text?: string, renderedHtml?: string): TelegramCaptionSplit {
   const trimmed = text?.trim() ?? "";
   if (!trimmed) {
     return { caption: undefined, followUpText: undefined };

--- a/extensions/telegram/src/channel-actions.test.ts
+++ b/extensions/telegram/src/channel-actions.test.ts
@@ -5,6 +5,14 @@ import { telegramMessageActions } from "./channel-actions.js";
 
 const handleTelegramActionMock = vi.hoisted(() => vi.fn());
 
+function describeMessageToolFromRawConfig(cfg: object, accountId?: string) {
+  const describeMessageTool = telegramMessageActions.describeMessageTool;
+  if (!describeMessageTool) {
+    throw new Error("expected Telegram message tool discovery");
+  }
+  return Reflect.apply(describeMessageTool, telegramMessageActions, [{ cfg, accountId }]);
+}
+
 vi.mock("./action-runtime.js", async () => {
   const actual = await vi.importActual<typeof import("./action-runtime.js")>("./action-runtime.js");
   return { ...actual, handleTelegramAction: handleTelegramActionMock };
@@ -427,9 +435,9 @@ describe("telegramMessageActions", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    };
 
-    const discovery = telegramMessageActions.describeMessageTool?.({ cfg });
+    const discovery = describeMessageToolFromRawConfig(cfg);
 
     expect(discovery?.actions).toContain("send");
     expect(discovery?.actions).toContain("react");
@@ -451,12 +459,9 @@ describe("telegramMessageActions", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    };
 
-    const discovery = telegramMessageActions.describeMessageTool?.({
-      cfg,
-      accountId: "ops",
-    });
+    const discovery = describeMessageToolFromRawConfig(cfg, "ops");
 
     expect(discovery?.actions).toContain("send");
     expect(discovery?.actions).toContain("poll");
@@ -505,12 +510,9 @@ describe("telegramMessageActions", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    };
 
-    const discovery = telegramMessageActions.describeMessageTool?.({
-      cfg,
-      accountId: "carey-notifications",
-    });
+    const discovery = describeMessageToolFromRawConfig(cfg, "carey-notifications");
 
     expect(discovery?.actions).toContain("send");
     expect(discovery?.actions).toContain("poll");
@@ -559,9 +561,9 @@ describe("telegramMessageActions", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    };
 
-    const discovery = telegramMessageActions.describeMessageTool?.({ cfg });
+    const discovery = describeMessageToolFromRawConfig(cfg);
 
     expect(discovery?.actions).toContain("send");
     expect(discovery?.actions).toContain("react");

--- a/extensions/telegram/src/channel.gateway.test.ts
+++ b/extensions/telegram/src/channel.gateway.test.ts
@@ -144,7 +144,7 @@ function installTelegramRuntime() {
         sendMessageTelegram,
       },
     },
-  } as unknown as TelegramRuntime;
+  } satisfies TelegramRuntime;
   setTelegramRuntime(telegramRuntime);
   return telegramRuntime;
 }

--- a/extensions/telegram/src/client-fetch.ts
+++ b/extensions/telegram/src/client-fetch.ts
@@ -26,12 +26,18 @@ type TelegramAbortSignalLike = {
 
 export function asTelegramClientFetch(
   fetchImpl: TelegramCompatFetch | typeof globalThis.fetch,
-): TelegramClientFetch {
-  return fetchImpl as unknown as TelegramClientFetch;
+): TelegramClientFetch;
+export function asTelegramClientFetch(
+  fetchImpl: TelegramCompatFetch | typeof globalThis.fetch,
+): TelegramClientFetch | TelegramCompatFetch | typeof globalThis.fetch {
+  return fetchImpl;
 }
 
-function asTelegramCompatFetch(fetchImpl: TelegramClientFetch): TelegramCompatFetch {
-  return fetchImpl as unknown as TelegramCompatFetch;
+function asTelegramCompatFetch(fetchImpl: TelegramClientFetch): TelegramCompatFetch;
+function asTelegramCompatFetch(
+  fetchImpl: TelegramClientFetch,
+): TelegramCompatFetch | TelegramClientFetch {
+  return fetchImpl;
 }
 
 function isTelegramAbortSignalLike(value: unknown): value is TelegramAbortSignalLike {

--- a/extensions/telegram/src/command-config.ts
+++ b/extensions/telegram/src/command-config.ts
@@ -14,7 +14,7 @@ export type TelegramCustomCommandIssue = {
   message: string;
 };
 
-export type TelegramResolvedCustomCommands = {
+type TelegramResolvedCustomCommands = {
   commands: Array<{ command: string; description: string }>;
   issues: TelegramCustomCommandIssue[];
 };

--- a/extensions/telegram/src/command-config.ts
+++ b/extensions/telegram/src/command-config.ts
@@ -14,6 +14,11 @@ export type TelegramCustomCommandIssue = {
   message: string;
 };
 
+export type TelegramResolvedCustomCommands = {
+  commands: Array<{ command: string; description: string }>;
+  issues: TelegramCustomCommandIssue[];
+};
+
 export function normalizeTelegramCommandName(value: string): string {
   const trimmed = value.trim();
   if (!trimmed) {
@@ -32,10 +37,7 @@ export function resolveTelegramCustomCommands(params: {
   reservedCommands?: Set<string>;
   checkReserved?: boolean;
   checkDuplicates?: boolean;
-}): {
-  commands: Array<{ command: string; description: string }>;
-  issues: TelegramCustomCommandIssue[];
-} {
+}): TelegramResolvedCustomCommands {
   const entries = Array.isArray(params.commands) ? params.commands : [];
   const reserved = params.reservedCommands ?? new Set<string>();
   const checkReserved = params.checkReserved !== false;

--- a/extensions/telegram/src/delivery-trace.test.ts
+++ b/extensions/telegram/src/delivery-trace.test.ts
@@ -8,7 +8,7 @@
 // Bot API calls (sendMessage / editMessageText / sendChatAction /
 // deleteMessage) observed at a recording API mock with scripted message ids.
 // Refresh goldens with OPENCLAW_TRACE_UPDATE=1 (see delivery-trace harness docs).
-import type { Bot } from "grammy";
+import { Bot } from "grammy";
 import {
   deliveryTraceScenarios,
   expectDeliveryTraceMatchesGolden,
@@ -19,9 +19,11 @@ import {
 } from "openclaw/plugin-sdk/channel-contract-testing";
 import * as channelInbound from "openclaw/plugin-sdk/channel-inbound";
 import type { PluginRuntime } from "openclaw/plugin-sdk/core";
-import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
+import {
+  createNonExitingRuntimeEnv,
+  createPluginRuntimeMock,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-payload";
-import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { afterEach, describe, it, vi } from "vitest";
 import type { TelegramBotDeps } from "./bot-deps.js";
 import {
@@ -57,7 +59,7 @@ type TelegramTraceWireState = {
   wireFaults: Array<{ retryAfterMs: number }>;
 };
 
-function compactParams(params: unknown): Record<string, unknown> {
+function compactParams(params: unknown) {
   if (!params || typeof params !== "object") {
     return {};
   }
@@ -72,7 +74,7 @@ function createRecordingTelegramApi(state: TelegramTraceWireState): Bot["api"] {
     messageCount += 1;
     return messageCount;
   };
-  const api = {
+  const api = Object.assign(new Bot("trace-token").api, {
     sendMessage: (chatId: number | string, text: string, params?: Record<string, unknown>) => {
       const message_id = nextMessageId();
       state.recordWireCall({
@@ -139,8 +141,8 @@ function createRecordingTelegramApi(state: TelegramTraceWireState): Bot["api"] {
       return Promise.resolve(true);
     },
     setMessageReaction: () => Promise.resolve(true),
-  };
-  return api as unknown as Bot["api"];
+  });
+  return api;
 }
 
 function createTraceTelegramDeps(captured: CapturedDispatch): TelegramBotDeps {
@@ -161,36 +163,33 @@ function createTraceTelegramDeps(captured: CapturedDispatch): TelegramBotDeps {
     coreRuntime.channel.inbound.run(params),
   );
   return {
-    getRuntimeConfig: (() => ({
-      config: baseTelegramMessageContextConfig,
-    })) as unknown as TelegramBotDeps["getRuntimeConfig"],
+    getRuntimeConfig: () => baseTelegramMessageContextConfig,
     resolveStorePath: (() =>
       "/tmp/openclaw-trace-unused.json") as TelegramBotDeps["resolveStorePath"],
     // No session entry: keeps the transcript mirror and final-text recovery
     // inert so the trace stays a pure wire recording.
     getSessionEntry: (() => undefined) as TelegramBotDeps["getSessionEntry"],
     readChannelAllowFromStore: (async () => []) as TelegramBotDeps["readChannelAllowFromStore"],
-    upsertChannelPairingRequest: (async () => ({
+    upsertChannelPairingRequest: async () => ({
       code: "TRACE",
       created: false,
-    })) as unknown as TelegramBotDeps["upsertChannelPairingRequest"],
-    enqueueSystemEvent: (async () => {}) as unknown as TelegramBotDeps["enqueueSystemEvent"],
+    }),
+    enqueueSystemEvent: () => true,
     dispatchReplyWithBufferedBlockDispatcher: (() => {
       throw new Error("trace dispatch bypassed the core runtime mock");
     }) as TelegramBotDeps["dispatchReplyWithBufferedBlockDispatcher"],
-    buildModelsProviderData: (async () => ({
+    buildModelsProviderData: async () => ({
       byProvider: new Map<string, Set<string>>(),
       providers: [],
       resolvedDefault: { provider: "openai", model: "gpt-test" },
       modelNames: new Map<string, string>(),
-    })) as unknown as TelegramBotDeps["buildModelsProviderData"],
-    listSkillCommandsForAgents:
-      (() => []) as unknown as TelegramBotDeps["listSkillCommandsForAgents"],
+    }),
+    listSkillCommandsForAgents: () => [],
     wasSentByBot: (() => false) as TelegramBotDeps["wasSentByBot"],
-    deliverInboundReplyWithMessageSendContext: (async () => ({
+    deliverInboundReplyWithMessageSendContext: async () => ({
       status: "unsupported",
       reason: "missing_outbound_handler",
-    })) as unknown as TelegramBotDeps["deliverInboundReplyWithMessageSendContext"],
+    }),
     emitTelegramMessageSentHooks: (() => {}) as TelegramBotDeps["emitTelegramMessageSentHooks"],
     recordOutboundMessageForPromptContext: (async () =>
       true) as TelegramBotDeps["recordOutboundMessageForPromptContext"],
@@ -222,18 +221,19 @@ async function setupTelegramTrace(recorder: WireRecorder) {
       from: { id: 42, first_name: "Alice" },
       chat: { id: TRACE_CHAT_ID, type: "private" },
     },
-    botApi: api as unknown as Record<string, unknown>,
     sendChatActionHandler,
   });
   if (!context) {
     throw new Error("trace context was not built");
   }
   const captured: CapturedDispatch = {};
+  const bot = new Bot("trace-token");
+  Object.assign(bot.api, api);
   const dispatchDone = dispatchTelegramMessage({
     context,
-    bot: { api } as unknown as Bot,
+    bot,
     cfg: baseTelegramMessageContextConfig,
-    runtime: { log: () => {}, error: () => {} } as unknown as RuntimeEnv,
+    runtime: createNonExitingRuntimeEnv(),
     // "first" is the single-use reply mode: the first visible message consumes
     // the reply target (prod default is "off", which would hide that contract).
     replyToMode: "first",

--- a/extensions/telegram/src/directory-contract.test.ts
+++ b/extensions/telegram/src/directory-contract.test.ts
@@ -27,7 +27,7 @@ describe("Telegram directory contract", () => {
           groups: { "-1001": {}, "*": {} },
         },
       },
-    } as unknown as OpenClawConfig;
+    } satisfies OpenClawConfig;
 
     await expectDirectoryIds(
       listTelegramDirectoryPeersFromConfig,
@@ -54,7 +54,7 @@ describe("Telegram directory contract", () => {
             },
           },
         },
-      } as unknown as OpenClawConfig;
+      } satisfies OpenClawConfig;
 
       await expectDirectoryIds(listTelegramDirectoryPeersFromConfig, cfg, ["@alice"]);
       await expectDirectoryIds(listTelegramDirectoryGroupsFromConfig, cfg, ["-1001"]);
@@ -75,10 +75,23 @@ describe("Telegram directory contract", () => {
           groups: { "-1001": {} },
         },
       },
-    } as unknown as OpenClawConfig;
+    };
 
-    await expectDirectoryIds(listTelegramDirectoryPeersFromConfig, cfg, ["@alice"]);
-    await expectDirectoryIds(listTelegramDirectoryGroupsFromConfig, cfg, ["-1001"]);
+    const listFromRawConfig = async (
+      list: typeof listTelegramDirectoryPeersFromConfig,
+    ): Promise<string[]> => {
+      const entries: Awaited<ReturnType<typeof listTelegramDirectoryPeersFromConfig>> =
+        await Reflect.apply(list, undefined, [
+          { cfg, accountId: "default", query: null, limit: null },
+        ]);
+      return entries.map((entry) => entry.id);
+    };
+    await expect(listFromRawConfig(listTelegramDirectoryPeersFromConfig)).resolves.toEqual([
+      "@alice",
+    ]);
+    await expect(listFromRawConfig(listTelegramDirectoryGroupsFromConfig)).resolves.toEqual([
+      "-1001",
+    ]);
   });
 
   it("applies query and limit filtering for config-backed directories", async () => {
@@ -89,7 +102,7 @@ describe("Telegram directory contract", () => {
           groups: { "-1001": {}, "-1002": {}, "-2001": {} },
         },
       },
-    } as unknown as OpenClawConfig;
+    } satisfies OpenClawConfig;
 
     const groups = await listTelegramDirectoryGroupsFromConfig({
       cfg,

--- a/extensions/telegram/src/doctor-contract.ts
+++ b/extensions/telegram/src/doctor-contract.ts
@@ -28,6 +28,16 @@ const RETIRED_TUNING_KEYS = new Set([
   "errorCooldownMs",
 ]);
 
+type TelegramCompatibilityEntryMutation = {
+  entry: Record<string, unknown>;
+  changed: boolean;
+};
+
+type TelegramCompatibleDefaultGroupEntry = {
+  groups: Record<string, unknown>;
+  entry: Record<string, unknown>;
+};
+
 function hasRetiredTelegramDmConfig(value: unknown): boolean {
   const entry = asObjectRecord(value);
   if (!entry) {
@@ -58,7 +68,7 @@ function removeRetiredTelegramDmConfig(params: {
   entry: Record<string, unknown>;
   pathPrefix: string;
   changes: string[];
-}): { entry: Record<string, unknown>; changed: boolean } {
+}): TelegramCompatibilityEntryMutation {
   let updated = params.entry;
   let changed = false;
   const dm = asObjectRecord(updated.dm);
@@ -103,7 +113,7 @@ function removeRetiredTelegramNativeDraftConfig(params: {
   entry: Record<string, unknown>;
   pathPrefix: string;
   changes: string[];
-}): { entry: Record<string, unknown>; changed: boolean } {
+}): TelegramCompatibilityEntryMutation {
   const streaming = asObjectRecord(params.entry.streaming);
   const preview = asObjectRecord(streaming?.preview);
   if (
@@ -139,7 +149,7 @@ function removeRetiredTelegramGroupHistoryContextConfig(params: {
   pathPrefix: string;
   changes: string[];
   preserveRecentHistoryLimit?: number;
-}): { entry: Record<string, unknown>; changed: boolean } {
+}): TelegramCompatibilityEntryMutation {
   if (params.entry.includeGroupHistoryContext === undefined) {
     return { entry: params.entry, changed: false };
   }
@@ -166,10 +176,9 @@ function removeRetiredTelegramGroupHistoryContextConfig(params: {
   return { entry: updated, changed: true };
 }
 
-function resolveCompatibleDefaultGroupEntry(section: Record<string, unknown>): {
-  groups: Record<string, unknown>;
-  entry: Record<string, unknown>;
-} | null {
+function resolveCompatibleDefaultGroupEntry(
+  section: Record<string, unknown>,
+): TelegramCompatibleDefaultGroupEntry | null {
   const existingGroups = section.groups;
   if (existingGroups !== undefined && !asObjectRecord(existingGroups)) {
     return null;
@@ -351,8 +360,8 @@ export function normalizeCompatibilityConfig({
       ...tuningKnobs.config,
       channels: {
         ...tuningKnobs.config.channels,
-        telegram: updated as unknown as NonNullable<OpenClawConfig["channels"]>["telegram"],
-      } as OpenClawConfig["channels"],
+        telegram: updated,
+      },
     },
     changes,
   };

--- a/extensions/telegram/src/doctor.test.ts
+++ b/extensions/telegram/src/doctor.test.ts
@@ -25,6 +25,16 @@ async function repairConfig(cfg: OpenClawConfig) {
   return await repair({ cfg, doctorFixCommand: DOCTOR_FIX_COMMAND });
 }
 
+async function repairRawConfig(cfg: object) {
+  const repair = telegramDoctor.repairConfig;
+  if (!repair) {
+    throw new Error("expected Telegram config repair adapter");
+  }
+  return await Reflect.apply(repair, telegramDoctor, [
+    { cfg, doctorFixCommand: DOCTOR_FIX_COMMAND },
+  ]);
+}
+
 function collectEmptyAllowlistWarnings(
   params: Parameters<NonNullable<typeof telegramDoctor.collectEmptyAllowlistExtraWarnings>>[0],
 ) {
@@ -406,7 +416,7 @@ describe("telegram doctor", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig);
+    } satisfies OpenClawConfig);
 
     expect(warnings).toContain(
       "- Telegram allowFrom contains 4 invalid sender entries (e.g. @top); Telegram authorization requires positive numeric sender user IDs.",
@@ -429,18 +439,17 @@ describe("telegram doctor", () => {
   });
 
   it("warns when Telegram groups use a non-object shape", async () => {
-    const cfg = {
+    const cfg: OpenClawConfig = {
       channels: {
         telegram: {
-          groups: ["-1001234567890"],
           accounts: {
-            work: {
-              groups: null,
-            },
+            work: {},
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    };
+    Reflect.set(cfg.channels?.telegram ?? {}, "groups", ["-1001234567890"]);
+    Reflect.set(cfg.channels?.telegram?.accounts?.work ?? {}, "groups", null);
 
     const warnings = await collectPreviewWarnings(cfg);
     expect(warnings[0]).toContain("object map keyed by Telegram group/chat id");
@@ -458,7 +467,7 @@ describe("telegram doctor", () => {
           allowFrom: ["@testuser"],
         },
       },
-    } as unknown as OpenClawConfig);
+    } satisfies OpenClawConfig);
 
     expect(result.config.channels?.telegram?.allowFrom).toEqual(["111"]);
     expect(result.changes[0]).toContain("@testuser");
@@ -471,7 +480,7 @@ describe("telegram doctor", () => {
           allowFrom: [-1001234567890],
         },
       },
-    } as unknown as OpenClawConfig);
+    } satisfies OpenClawConfig);
 
     expect(result.config.channels?.telegram?.allowFrom).toEqual([-1001234567890]);
     expect(result.changes).toEqual([
@@ -505,7 +514,7 @@ describe("telegram doctor", () => {
       config: {},
     });
 
-    const result = await repairConfig({
+    const result = await repairRawConfig({
       channels: {
         telegram: {
           accounts: {
@@ -516,7 +525,7 @@ describe("telegram doctor", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig);
+    });
 
     expect(result.config.channels?.telegram?.accounts?.inactive?.allowFrom).toEqual(["@testuser"]);
     expect(result.changes).toEqual([
@@ -528,7 +537,7 @@ describe("telegram doctor", () => {
   it("formats invalid allowFrom warnings", async () => {
     const warnings = await collectPreviewWarnings({
       channels: { telegram: { allowFrom: ["@top"] } },
-    } as unknown as OpenClawConfig);
+    } satisfies OpenClawConfig);
 
     expect(warnings[0]).toContain("invalid sender entries");
     expect(warnings[1]).toContain(DOCTOR_FIX_COMMAND);
@@ -546,7 +555,7 @@ describe("telegram doctor", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    } satisfies OpenClawConfig;
 
     expect(await collectPreviewWarnings(cfg)).toContain(
       "- channels.telegram.apiRoot points at a full Telegram bot endpoint; apiRoot must be the Bot API root only. This can make startup calls like deleteWebhook, deleteMyCommands, and setMyCommands fail with 404 even when direct curl commands work.",
@@ -570,7 +579,7 @@ describe("telegram doctor", () => {
           replyToMode: "first",
         },
       },
-    } as unknown as OpenClawConfig;
+    } satisfies OpenClawConfig;
 
     const warnings = await collectPreviewWarnings(cfg);
     expect(warnings[0]).toContain("selected quote replies");
@@ -587,7 +596,7 @@ describe("telegram doctor", () => {
           accounts: {},
         },
       },
-    } as unknown as OpenClawConfig;
+    } satisfies OpenClawConfig;
 
     expect((await collectPreviewWarnings(cfg)).join("\n")).toContain(
       'channels.telegram has replyToMode: "all"',
@@ -608,7 +617,7 @@ describe("telegram doctor", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    } satisfies OpenClawConfig;
 
     const warnings = (await collectPreviewWarnings(cfg)).join("\n");
     expect(warnings).toContain('channels.telegram.accounts.work has replyToMode: "batched"');
@@ -627,7 +636,7 @@ describe("telegram doctor", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    } satisfies OpenClawConfig;
 
     expect((await collectPreviewWarnings(cfg)).join("\n")).not.toContain("selected quote replies");
   });
@@ -642,7 +651,7 @@ describe("telegram doctor", () => {
               streaming: { mode: "off" },
             },
           },
-        } as unknown as OpenClawConfig)
+        } satisfies OpenClawConfig)
       ).join("\n"),
     ).not.toContain("selected quote replies");
 
@@ -659,7 +668,7 @@ describe("telegram doctor", () => {
               blockStreamingDefault: "on",
             },
           },
-        } as unknown as OpenClawConfig)
+        } satisfies OpenClawConfig)
       ).join("\n"),
     ).not.toContain("selected quote replies");
   });
@@ -677,7 +686,7 @@ describe("telegram doctor", () => {
           blockStreamingDefault: "on",
         },
       },
-    } as unknown as OpenClawConfig);
+    } satisfies OpenClawConfig);
 
     expect(warnings.join("\n")).toContain("selected quote replies");
   });
@@ -689,7 +698,7 @@ describe("telegram doctor", () => {
           apiRoot: "https://api.telegram.org/bot123456:ABC",
         },
       },
-    } as unknown as OpenClawConfig;
+    } satisfies OpenClawConfig;
 
     expect(
       await telegramDoctor.collectPreviewWarnings?.({
@@ -717,7 +726,7 @@ describe("telegram doctor", () => {
           allowFrom: ["123"],
         },
       },
-    } as unknown as OpenClawConfig;
+    } satisfies OpenClawConfig;
 
     inspectTelegramAccountMock.mockReturnValueOnce({
       enabled: true,
@@ -755,7 +764,7 @@ describe("telegram doctor", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    } satisfies OpenClawConfig;
 
     expect((await collectPreviewWarnings(cfg, {})).join("\n")).not.toContain(
       "TELEGRAM_BOT_TOKEN is absent",

--- a/extensions/telegram/src/doctor.ts
+++ b/extensions/telegram/src/doctor.ts
@@ -42,6 +42,11 @@ type TelegramApiRootBotEndpointHit = {
 type DoctorAllowFromList = Array<string | number>;
 type DoctorAccountRecord = Record<string, unknown>;
 
+type TelegramConfigRepairResult = {
+  config: OpenClawConfig;
+  changes: string[];
+};
+
 type TelegramAllowFromListRef = {
   pathLabel: string;
   holder: Record<string, unknown>;
@@ -270,10 +275,7 @@ function collectTelegramSelectedQuoteToolProgressWarnings(params: {
   ];
 }
 
-function maybeRepairTelegramApiRoots(cfg: OpenClawConfig): {
-  config: OpenClawConfig;
-  changes: string[];
-} {
+function maybeRepairTelegramApiRoots(cfg: OpenClawConfig): TelegramConfigRepairResult {
   const hits = scanTelegramBotEndpointApiRoots(cfg);
   if (hits.length === 0) {
     return { config: cfg, changes: [] };
@@ -322,10 +324,9 @@ function collectTelegramMissingEnvTokenWarnings(params: {
   ];
 }
 
-async function repairTelegramConfig(params: { cfg: OpenClawConfig }): Promise<{
-  config: OpenClawConfig;
-  changes: string[];
-}> {
+async function repairTelegramConfig(params: {
+  cfg: OpenClawConfig;
+}): Promise<TelegramConfigRepairResult> {
   const apiRootRepair = maybeRepairTelegramApiRoots(params.cfg);
   const allowFromRepair = await maybeRepairTelegramAllowFromUsernames(apiRootRepair.config);
   return {
@@ -334,10 +335,9 @@ async function repairTelegramConfig(params: { cfg: OpenClawConfig }): Promise<{
   };
 }
 
-async function maybeRepairTelegramAllowFromUsernames(cfg: OpenClawConfig): Promise<{
-  config: OpenClawConfig;
-  changes: string[];
-}> {
+async function maybeRepairTelegramAllowFromUsernames(
+  cfg: OpenClawConfig,
+): Promise<TelegramConfigRepairResult> {
   const hits = scanTelegramInvalidAllowFromEntries(cfg);
   if (hits.length === 0) {
     return { config: cfg, changes: [] };

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -2,6 +2,10 @@
 import type { Bot } from "grammy";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTelegramDraftStream } from "./draft-stream.js";
+
+function telegramBotApiFixture(value: object): Bot["api"] {
+  return Reflect.apply((api: Bot["api"]) => api, undefined, [value]);
+}
 import {
   markdownToTelegramChunks,
   renderTelegramHtmlText,
@@ -51,7 +55,7 @@ function createDraftStream(
   overrides: Omit<Partial<TelegramDraftStreamParams>, "api" | "chatId"> = {},
 ) {
   return createTelegramDraftStream({
-    api: api as unknown as Bot["api"],
+    api: telegramBotApiFixture(api),
     chatId: 123,
     ...overrides,
   });
@@ -1196,7 +1200,7 @@ describe("createTelegramDraftStream", () => {
   it("supports rendered previews with HTML parse mode", async () => {
     const api = createMockDraftApi();
     const stream = createTelegramDraftStream({
-      api: api as unknown as Bot["api"],
+      api: telegramBotApiFixture(api),
       chatId: 123,
       renderText: (text) => ({ text: `<i>${text}</i>`, parseMode: "HTML" }),
     });
@@ -1450,7 +1454,7 @@ describe("createTelegramDraftStream", () => {
     const api = createMockDraftApi();
     const text = `# Long\n\n${"rich line\n".repeat(600)}`;
     const stream = createTelegramDraftStream({
-      api: api as unknown as Bot["api"],
+      api: telegramBotApiFixture(api),
       chatId: 123,
       renderText: (value) => ({ text: value }),
     });
@@ -2030,7 +2034,7 @@ describe("createTelegramDraftStream", () => {
     const api = createMockDraftApi();
     const warn = vi.fn();
     const stream = createTelegramDraftStream({
-      api: api as unknown as Bot["api"],
+      api: telegramBotApiFixture(api),
       chatId: 123,
       maxChars: 100,
       renderText: () => ({
@@ -2055,7 +2059,7 @@ describe("draft stream initial message debounce", () => {
 
   function createDebouncedStream(api: ReturnType<typeof createMockApi>, minInitialChars = 30) {
     return createTelegramDraftStream({
-      api: api as unknown as Bot["api"],
+      api: telegramBotApiFixture(api),
       chatId: 123,
       minInitialChars,
     });
@@ -2158,7 +2162,7 @@ describe("draft stream initial message debounce", () => {
     it("sends plain preview text immediately without minInitialChars set", async () => {
       const api = createMockApi();
       const stream = createTelegramDraftStream({
-        api: api as unknown as Bot["api"],
+        api: telegramBotApiFixture(api),
         chatId: 123,
       });
 

--- a/extensions/telegram/src/error-policy.ts
+++ b/extensions/telegram/src/error-policy.ts
@@ -13,6 +13,11 @@ import {
 
 type TelegramErrorPolicy = "always" | "once" | "silent";
 
+type TelegramErrorPolicyResolution = {
+  policy: TelegramErrorPolicy;
+  cooldownMs: number;
+};
+
 type TelegramErrorConfig =
   | TelegramAccountConfig
   | TelegramDirectConfig
@@ -34,10 +39,7 @@ export function resolveTelegramErrorPolicy(params: {
   accountConfig?: TelegramAccountConfig;
   groupConfig?: TelegramDirectConfig | TelegramGroupConfig;
   topicConfig?: TelegramTopicConfig;
-}): {
-  policy: TelegramErrorPolicy;
-  cooldownMs: number;
-} {
+}): TelegramErrorPolicyResolution {
   const configs: Array<TelegramErrorConfig | undefined> = [
     params.accountConfig,
     params.groupConfig,

--- a/extensions/telegram/src/fetch.test.ts
+++ b/extensions/telegram/src/fetch.test.ts
@@ -398,7 +398,7 @@ describe("resolveTelegramFetch", () => {
   });
 
   it("wraps proxy fetches and leaves retry policy to caller-provided fetch", async () => {
-    const proxyFetch = vi.fn(async () => ({ ok: true }) as Response) as unknown as typeof fetch;
+    const proxyFetch = vi.fn<typeof fetch>(async () => new Response());
 
     const resolved = resolveTelegramFetchOrThrow(proxyFetch);
 
@@ -409,7 +409,7 @@ describe("resolveTelegramFetch", () => {
   });
 
   it("does not double-wrap an already wrapped proxy fetch", () => {
-    const proxyFetch = vi.fn(async () => ({ ok: true }) as Response) as unknown as typeof fetch;
+    const proxyFetch = vi.fn<typeof fetch>(async () => new Response());
     const wrapped = resolveFetch(proxyFetch);
 
     const resolved = resolveTelegramFetch(wrapped);
@@ -555,7 +555,7 @@ describe("resolveTelegramFetch", () => {
 
   it("preserves caller-provided custom fetch when OPENCLAW_PROXY_URL is present", async () => {
     vi.stubEnv("OPENCLAW_PROXY_URL", "http://127.0.0.1:7788");
-    const proxyFetch = vi.fn(async () => ({ ok: true }) as Response) as unknown as typeof fetch;
+    const proxyFetch = vi.fn<typeof fetch>(async () => new Response());
 
     const transport = resolveTelegramTransport(proxyFetch, {
       network: {

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -1,6 +1,7 @@
 // Telegram plugin module implements fetch behavior.
 import { randomUUID } from "node:crypto";
 import * as dns from "node:dns";
+import type { LookupFunction } from "node:net";
 import type { TelegramNetworkConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
@@ -105,20 +106,25 @@ type TelegramTransportAttemptHealth = {
 
 type TelegramDnsResultOrder = "ipv4first" | "verbatim";
 
-type LookupCallback =
-  | ((err: NodeJS.ErrnoException | null, address: string, family: number) => void)
-  | ((err: NodeJS.ErrnoException | null, addresses: dns.LookupAddress[]) => void);
-
-type LookupOptions = (dns.LookupOneOptions | dns.LookupAllOptions) & {
-  order?: TelegramDnsResultOrder;
-  verbatim?: boolean;
+type TelegramConnectOptions = {
+  autoSelectFamily?: boolean;
+  autoSelectFamilyAttemptTimeout?: number;
+  family?: number;
+  keepAlive?: boolean;
+  keepAliveInitialDelay?: number;
+  lookup?: LookupFunction;
 };
 
-type LookupFunction = (
-  hostname: string,
-  options: number | dns.LookupOneOptions | dns.LookupAllOptions | undefined,
-  callback: LookupCallback,
-) => void;
+type TelegramDispatcherPolicyResolution = {
+  policy: PinnedDispatcherPolicy;
+  mode: TelegramDispatcherMode;
+};
+
+type TelegramDispatcherResolution = {
+  dispatcher: TelegramDispatcher;
+  mode: TelegramDispatcherMode;
+  effectivePolicy: PinnedDispatcherPolicy;
+};
 
 const FALLBACK_RETRY_ERROR_CODES = [
   "ETIMEDOUT",
@@ -147,24 +153,13 @@ function createDnsResultOrderLookup(
   if (!order) {
     return undefined;
   }
-  const lookup = dns.lookup as unknown as (
-    hostname: string,
-    options: LookupOptions,
-    callback: LookupCallback,
-  ) => void;
   return (hostname, options, callback) => {
-    const baseOptions: LookupOptions =
-      typeof options === "number"
-        ? { family: options }
-        : options
-          ? { ...(options as LookupOptions) }
-          : {};
-    const lookupOptions: LookupOptions = {
-      ...baseOptions,
+    const lookupOptions: dns.LookupOptions = {
+      ...options,
       order,
       verbatim: order === "verbatim",
     };
-    lookup(hostname, lookupOptions, callback);
+    dns.lookup(hostname, lookupOptions, callback);
   };
 }
 
@@ -174,22 +169,8 @@ function buildTelegramConnectOptions(params: {
   autoSelectFamily: boolean | null;
   dnsResultOrder: TelegramDnsResultOrder | null;
   forceIpv4: boolean;
-}): {
-  autoSelectFamily?: boolean;
-  autoSelectFamilyAttemptTimeout?: number;
-  family?: number;
-  keepAlive?: boolean;
-  keepAliveInitialDelay?: number;
-  lookup?: LookupFunction;
-} {
-  const connect: {
-    autoSelectFamily?: boolean;
-    autoSelectFamilyAttemptTimeout?: number;
-    family?: number;
-    keepAlive?: boolean;
-    keepAliveInitialDelay?: number;
-    lookup?: LookupFunction;
-  } = {
+}): TelegramConnectOptions {
+  const connect: TelegramConnectOptions = {
     keepAlive: true,
     keepAliveInitialDelay: TELEGRAM_KEEPALIVE_INITIAL_DELAY_MS,
   };
@@ -227,7 +208,7 @@ function resolveTelegramDispatcherPolicy(params: {
   useEnvProxy: boolean;
   forceIpv4: boolean;
   proxyUrl?: string;
-}): { policy: PinnedDispatcherPolicy; mode: TelegramDispatcherMode } {
+}): TelegramDispatcherPolicyResolution {
   const connect = buildTelegramConnectOptions({
     autoSelectFamily: params.autoSelectFamily,
     dnsResultOrder: params.dnsResultOrder,
@@ -279,11 +260,7 @@ function withPinnedLookup(
   return options ? { ...options, lookup } : { lookup };
 }
 
-function createTelegramDispatcher(policy: PinnedDispatcherPolicy): {
-  dispatcher: TelegramDispatcher;
-  mode: TelegramDispatcherMode;
-  effectivePolicy: PinnedDispatcherPolicy;
-} {
+function createTelegramDispatcher(policy: PinnedDispatcherPolicy): TelegramDispatcherResolution {
   // Telegram polling uses long-lived connections. Undici 8 enables HTTP/2 ALPN
   // by default, which can stall Telegram long-polling on Windows/IPv6 networks.
   // Force HTTP/1.1 for every dispatcher while keeping bounded pool defaults.
@@ -366,6 +343,11 @@ function withDispatcherIfMissing(
 
 function resolveWrappedFetch(fetchImpl: typeof fetch): typeof fetch {
   return resolveFetch(fetchImpl) ?? fetchImpl;
+}
+
+function asGlobalFetch(fetchImpl: typeof undiciFetch): typeof fetch;
+function asGlobalFetch(fetchImpl: typeof undiciFetch): typeof fetch | typeof undiciFetch {
+  return fetchImpl;
 }
 
 function logResolverNetworkDecisions(params: {
@@ -575,7 +557,7 @@ export function resolveTelegramTransport(
   const managedProxyUrl =
     !effectiveProxyFetch && !hasEnvProxy ? resolveOpenClawProxyUrlForTelegram() : undefined;
   const resolvedExplicitProxyUrl = explicitProxyUrl ?? managedProxyUrl;
-  const undiciSourceFetch = resolveWrappedFetch(undiciFetch as unknown as typeof fetch);
+  const undiciSourceFetch = resolveWrappedFetch(asGlobalFetch(undiciFetch));
   const sourceFetch = resolvedExplicitProxyUrl
     ? undiciSourceFetch
     : effectiveProxyFetch

--- a/extensions/telegram/src/group-access.base-access.test.ts
+++ b/extensions/telegram/src/group-access.base-access.test.ts
@@ -75,13 +75,13 @@ describe("evaluateTelegramGroupBaseAccess", () => {
 /**
  * Minimal stubs shared across group policy tests.
  */
-const baseCfg = {
+const baseCfg: OpenClawConfig = {
   channels: { telegram: {} },
-} as unknown as OpenClawConfig;
+};
 
 const baseTelegramCfg: TelegramAccountConfig = {
   groupPolicy: "allowlist",
-} as unknown as TelegramAccountConfig;
+};
 
 const emptyAllow = { entries: [], hasWildcard: false, hasEntries: false, invalidEntries: [] };
 const senderAllow = {

--- a/extensions/telegram/src/group-config-helpers.ts
+++ b/extensions/telegram/src/group-config-helpers.ts
@@ -14,6 +14,11 @@ import type {
 } from "openclaw/plugin-sdk/config-contracts";
 import { firstDefined } from "./bot-access.js";
 
+type TelegramGroupPromptSettings = {
+  skillFilter: string[] | undefined;
+  groupSystemPrompt: string | undefined;
+};
+
 export function resolveTelegramScopedGroupConfig(
   telegramCfg: TelegramAccountConfig,
   chatId: string | number,
@@ -66,10 +71,7 @@ export function resolveTelegramGroupIngestEnabled(params: {
 export function resolveTelegramGroupPromptSettings(params: {
   groupConfig?: TelegramGroupConfig | TelegramDirectConfig;
   topicConfig?: TelegramTopicConfig;
-}): {
-  skillFilter: string[] | undefined;
-  groupSystemPrompt: string | undefined;
-} {
+}): TelegramGroupPromptSettings {
   const skillFilter = firstDefined(params.topicConfig?.skills, params.groupConfig?.skills);
   const systemPromptParts = [
     params.groupConfig?.systemPrompt?.trim() || null,

--- a/extensions/telegram/src/group-migration.ts
+++ b/extensions/telegram/src/group-migration.ts
@@ -9,6 +9,15 @@ type TelegramGroups = Record<string, TelegramGroupConfig>;
 
 type MigrationScope = "account" | "global";
 
+type TelegramAccountGroups = {
+  groups?: TelegramGroups;
+};
+
+type TelegramGroupsMigration = {
+  migrated: boolean;
+  skippedExisting: boolean;
+};
+
 type TelegramGroupMigrationResult = {
   migrated: boolean;
   skippedExisting: boolean;
@@ -18,7 +27,7 @@ type TelegramGroupMigrationResult = {
 function resolveAccountGroups(
   cfg: OpenClawConfig,
   accountId?: string | null,
-): { groups?: TelegramGroups } {
+): TelegramAccountGroups {
   if (!accountId) {
     return {};
   }
@@ -41,7 +50,7 @@ function migrateTelegramGroupsInPlace(
   groups: TelegramGroups | undefined,
   oldChatId: string,
   newChatId: string,
-): { migrated: boolean; skippedExisting: boolean } {
+): TelegramGroupsMigration {
   if (!groups) {
     return { migrated: false, skippedExisting: false };
   }

--- a/extensions/telegram/src/inline-buttons.test.ts
+++ b/extensions/telegram/src/inline-buttons.test.ts
@@ -1,5 +1,4 @@
 // Telegram tests cover inline buttons plugin behavior.
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { describe, expect, it } from "vitest";
 import { resolveTelegramInlineButtons } from "./button-types.js";
 import { describeTelegramInteractiveButtonBehavior } from "./button-types.test-helpers.js";
@@ -45,6 +44,14 @@ describe("resolveTelegramTargetChatType", () => {
 });
 
 describeTelegramInteractiveButtonBehavior();
+
+function resolveInlineButtonsScopeFromRawConfig(cfg: object, accountId?: string) {
+  return Reflect.apply(resolveTelegramInlineButtonsScope, undefined, [{ cfg, accountId }]);
+}
+
+function isInlineButtonsEnabledFromRawConfig(cfg: object, accountId?: string) {
+  return Reflect.apply(isTelegramInlineButtonsEnabled, undefined, [{ cfg, accountId }]);
+}
 
 describe("buildTelegramInteractiveButtons callback rewrites", () => {
   it("drops shared buttons whose callback data exceeds Telegram's limit", () => {
@@ -107,10 +114,10 @@ describe("resolveTelegramInlineButtonsScope (#75433 SecretRef tolerance)", () =>
           botToken: { source: "exec", provider: "default", id: "telegram-token" },
         },
       },
-    } as unknown as OpenClawConfig;
+    };
 
-    expect(resolveTelegramInlineButtonsScope({ cfg })).toBe("allowlist");
-    expect(isTelegramInlineButtonsEnabled({ cfg })).toBe(true);
+    expect(resolveInlineButtonsScopeFromRawConfig(cfg)).toBe("allowlist");
+    expect(isInlineButtonsEnabledFromRawConfig(cfg)).toBe(true);
   });
 
   it("preserves the default inline-buttons scope when legacy capabilities are empty", () => {
@@ -121,10 +128,10 @@ describe("resolveTelegramInlineButtonsScope (#75433 SecretRef tolerance)", () =>
           capabilities: [],
         },
       },
-    } as unknown as OpenClawConfig;
+    };
 
-    expect(resolveTelegramInlineButtonsScope({ cfg })).toBe("allowlist");
-    expect(isTelegramInlineButtonsEnabled({ cfg })).toBe(true);
+    expect(resolveInlineButtonsScopeFromRawConfig(cfg)).toBe("allowlist");
+    expect(isInlineButtonsEnabledFromRawConfig(cfg)).toBe(true);
   });
 
   it("inherits the channel scope when an account legacy capabilities array is empty", () => {
@@ -140,10 +147,10 @@ describe("resolveTelegramInlineButtonsScope (#75433 SecretRef tolerance)", () =>
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    };
 
-    expect(resolveTelegramInlineButtonsScope({ cfg, accountId: "ops" })).toBe("off");
-    expect(isTelegramInlineButtonsEnabled({ cfg, accountId: "ops" })).toBe(false);
+    expect(resolveInlineButtonsScopeFromRawConfig(cfg, "ops")).toBe("off");
+    expect(isInlineButtonsEnabledFromRawConfig(cfg, "ops")).toBe(false);
   });
 
   it('preserves configured "off" when botToken is an unresolved SecretRef', () => {
@@ -154,10 +161,10 @@ describe("resolveTelegramInlineButtonsScope (#75433 SecretRef tolerance)", () =>
           capabilities: { inlineButtons: "off" },
         },
       },
-    } as unknown as OpenClawConfig;
+    };
 
-    expect(resolveTelegramInlineButtonsScope({ cfg })).toBe("off");
-    expect(isTelegramInlineButtonsEnabled({ cfg })).toBe(false);
+    expect(resolveInlineButtonsScopeFromRawConfig(cfg)).toBe("off");
+    expect(isInlineButtonsEnabledFromRawConfig(cfg)).toBe(false);
   });
 
   it("preserves scoped account inline-buttons config when the token is an unresolved SecretRef", () => {
@@ -172,9 +179,9 @@ describe("resolveTelegramInlineButtonsScope (#75433 SecretRef tolerance)", () =>
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    };
 
-    expect(resolveTelegramInlineButtonsScope({ cfg, accountId: "ops" })).toBe("all");
-    expect(isTelegramInlineButtonsEnabled({ cfg, accountId: "ops" })).toBe(true);
+    expect(resolveInlineButtonsScopeFromRawConfig(cfg, "ops")).toBe("all");
+    expect(isInlineButtonsEnabledFromRawConfig(cfg, "ops")).toBe(true);
   });
 });

--- a/extensions/telegram/src/interactive-fallback.ts
+++ b/extensions/telegram/src/interactive-fallback.ts
@@ -131,14 +131,16 @@ function canEncodeTelegramPresentationControl(
   return Boolean(buildTelegramPresentationButtons({ blocks: [block] }, options)?.length);
 }
 
+type TelegramPresentationBlockPartition = {
+  fallbackBlocks: MessagePresentation["blocks"];
+  nativeControlBlocks: MessagePresentationInteractiveBlock[];
+};
+
 function partitionTelegramPresentationBlocks(params: {
   presentation: MessagePresentation;
   presentationControlsSelected: boolean;
   buttonOptions: TelegramButtonBuildOptions;
-}): {
-  fallbackBlocks: MessagePresentation["blocks"];
-  nativeControlBlocks: MessagePresentationInteractiveBlock[];
-} {
+}): TelegramPresentationBlockPartition {
   const fallbackBlocks: MessagePresentation["blocks"] = [];
   const nativeControlBlocks: MessagePresentationInteractiveBlock[] = [];
   for (const block of params.presentation.blocks) {

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -138,12 +138,11 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams): 
     if (_buttons === undefined) {
       return channelData;
     }
-    const next: Record<string, unknown> = { ...channelData };
-    if (Object.keys(telegramRest).length > 0) {
-      next.telegram = telegramRest;
-    } else {
-      delete next.telegram;
-    }
+    const { telegram: _telegram, ...channelRest } = channelData;
+    const next =
+      Object.keys(telegramRest).length > 0
+        ? { ...channelRest, telegram: telegramRest }
+        : channelRest;
     return Object.keys(next).length > 0 ? next : undefined;
   };
   const withMediaChannelData = (

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -19,6 +19,10 @@ const HELLO_FINAL = "Hello final";
 type PromptContextRecord = Parameters<
   typeof createTelegramPromptContextProjectionSequence
 >[0]["record"];
+type TestDraftLanes = {
+  answer: DraftLaneState;
+  reasoning: DraftLaneState;
+};
 
 function createHarness(params?: {
   answerMessageId?: number;
@@ -33,7 +37,7 @@ function createHarness(params?: {
       ? undefined
       : (params?.answerStream ?? createTestDraftStream({ messageId: params?.answerMessageId }));
   const reasoning = createTestDraftStream();
-  const lanes: Record<LaneName, DraftLaneState> = {
+  const lanes: TestDraftLanes = {
     answer: {
       stream: answer,
       lastPartialText: "",
@@ -368,7 +372,8 @@ describe("createLaneTextDeliverer", () => {
   });
 
   it("resets the stream after discarding an unmaterialized block preview", async () => {
-    const answerRef: { current?: ReturnType<typeof createTestDraftStream> } = {};
+    type AnswerDraftRef = { current?: ReturnType<typeof createTestDraftStream> };
+    const answerRef: AnswerDraftRef = {};
     const answer = createTestDraftStream({
       stopUpdatesOnDiscard: true,
       onUpdate: (text) => {

--- a/extensions/telegram/src/message-cache.test.ts
+++ b/extensions/telegram/src/message-cache.test.ts
@@ -619,7 +619,7 @@ describe("telegram message cache", () => {
     const scopeKey = resolveTelegramMessageCachePersistentScopeKey("default");
     const marker = projection("assistant-embedded-order");
     const bot = botMessage(9130, "Projected answer");
-    const values: Record<string, [string, PersistedValue]> = {
+    const values = {
       projected: [
         `${scopeKey}:default:7:9130`,
         { version: 1, sourceMessage: bot, promptContextProjection: marker },
@@ -634,9 +634,12 @@ describe("telegram message cache", () => {
           }),
         },
       ],
-    };
+    } satisfies Record<string, [string, PersistedValue]>;
     for (const name of order) {
-      const [key, value] = values[name]!;
+      if (name !== "projected" && name !== "parent") {
+        throw new Error(`unexpected persisted row name: ${name}`);
+      }
+      const [key, value] = values[name];
       entries.set(key, value);
     }
 

--- a/extensions/telegram/src/miniapp/routes.test.ts
+++ b/extensions/telegram/src/miniapp/routes.test.ts
@@ -11,6 +11,7 @@ import {
 } from "./launch-ticket.js";
 
 type OpenClawPluginHttpRouteParams = Parameters<OpenClawPluginApi["registerHttpRoute"]>[0];
+type MockResponseHeaders = Record<string, string>;
 
 const issueDeviceBootstrapToken = vi.hoisted(() =>
   vi.fn(async () => ({ token: "issued", expiresAtMs: Date.now() + 600_000 })),
@@ -41,7 +42,7 @@ let launchTickets: TelegramMiniAppLaunchTickets;
 
 class MockResponse {
   statusCode = 200;
-  headers: Record<string, string> = {};
+  headers: MockResponseHeaders = {};
   body = "";
 
   writeHead(statusCode: number, headers: Record<string, string>) {

--- a/extensions/telegram/src/miniapp/routes.ts
+++ b/extensions/telegram/src/miniapp/routes.ts
@@ -26,6 +26,8 @@ const RATE_LIMIT_MAX = 10;
 const replayCache = new Map<string, number>();
 const rateLimit = new Map<string, { count: number; resetAtMs: number }>();
 
+type TelegramMiniAppHeaders = Record<string, string>;
+
 export function registerTelegramMiniAppRoutes(
   api: OpenClawPluginApi,
   launchTickets: TelegramMiniAppLaunchTickets,
@@ -221,7 +223,7 @@ function pruneReplayCache(): void {
   }
 }
 
-function securityHeaders(extra?: Record<string, string>): Record<string, string> {
+function securityHeaders(extra?: TelegramMiniAppHeaders): TelegramMiniAppHeaders {
   return {
     "Cache-Control": "no-store",
     "Referrer-Policy": "no-referrer",

--- a/extensions/telegram/src/monitor.test.ts
+++ b/extensions/telegram/src/monitor.test.ts
@@ -117,6 +117,12 @@ type RunnerStub = {
   isRunning: () => boolean;
 };
 
+type StalledPollingRunnerHarness = {
+  stop: ReturnType<typeof vi.fn<() => void | Promise<void>>>;
+  waitForRunStart: () => Promise<void>;
+  waitForTaskStart: () => Promise<void>;
+};
+
 const withLegacyPolling = (opts: MonitorTelegramOpts): MonitorTelegramOpts => ({
   ...opts,
   isolatedIngress: { enabled: false, ...opts.isolatedIngress },
@@ -236,11 +242,7 @@ async function runMonitorAndCaptureStartupOrder(params?: { persistedOffset?: num
   return { order };
 }
 
-function mockRunOnceWithStalledPollingRunner(): {
-  stop: ReturnType<typeof vi.fn<() => void | Promise<void>>>;
-  waitForRunStart: () => Promise<void>;
-  waitForTaskStart: () => Promise<void>;
-} {
+function mockRunOnceWithStalledPollingRunner(): StalledPollingRunnerHarness {
   let running = true;
   let releaseTask: (() => void) | undefined;
   let releaseBeforeTaskStart = false;

--- a/extensions/telegram/src/monitor.ts
+++ b/extensions/telegram/src/monitor.ts
@@ -56,11 +56,11 @@ function createTelegramRunnerOptions(cfg: OpenClawConfig): RunOptions<unknown> {
   };
 }
 
-const TELEGRAM_OFFSET_ROTATION_LABELS: Record<TelegramOffsetRotationReason, string> = {
+const TELEGRAM_OFFSET_ROTATION_LABELS = {
   "bot-id-changed": "bot identity change",
   "legacy-state": "legacy update offset",
   "token-rotated": "token rotation",
-};
+} satisfies Record<TelegramOffsetRotationReason, string>;
 
 function formatTelegramOffsetRotationMessage(
   accountId: string,

--- a/extensions/telegram/src/network-config.test.ts
+++ b/extensions/telegram/src/network-config.test.ts
@@ -1,5 +1,4 @@
 // Telegram tests cover network config plugin behavior.
-import type { TelegramNetworkConfig } from "openclaw/plugin-sdk/config-contracts";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => ({
@@ -182,7 +181,7 @@ describe("resolveTelegramDnsResultOrderDecision", () => {
     },
     {
       name: "normalizes trimmed config values",
-      network: { dnsResultOrder: "  Verbatim  " } as unknown as TelegramNetworkConfig,
+      network: { dnsResultOrder: "  Verbatim  " },
       nodeMajor: 20,
       expected: { value: "verbatim", source: "config" },
     },
@@ -196,7 +195,7 @@ describe("resolveTelegramDnsResultOrderDecision", () => {
     {
       name: "ignores invalid env and config values before applying Node 22 default",
       env: { OPENCLAW_TELEGRAM_DNS_RESULT_ORDER: "bogus" },
-      network: { dnsResultOrder: "invalid" } as unknown as TelegramNetworkConfig,
+      network: { dnsResultOrder: "invalid" },
       defaultResultOrder: "ipv6first",
       nodeMajor: 22,
       expected: { value: "ipv4first", source: "default-node22" },
@@ -217,17 +216,14 @@ describe("resolveTelegramDnsResultOrderDecision", () => {
   ] satisfies Array<{
     name: string;
     env?: NodeJS.ProcessEnv;
-    network?: TelegramNetworkConfig;
+    network?: { dnsResultOrder?: string };
     defaultResultOrder?: string | null;
     nodeMajor: number;
     expected: ReturnType<typeof resolveTelegramDnsResultOrderDecision>;
   }>)("$name", ({ env, network, defaultResultOrder, nodeMajor, expected }) => {
-    const decision = resolveTelegramDnsResultOrderDecision({
-      env,
-      network,
-      defaultResultOrder,
-      nodeMajor,
-    });
+    const decision = Reflect.apply(resolveTelegramDnsResultOrderDecision, undefined, [
+      { env, network, defaultResultOrder, nodeMajor },
+    ]);
     expect(decision).toEqual(expected);
   });
 

--- a/extensions/telegram/src/outbound-media.ts
+++ b/extensions/telegram/src/outbound-media.ts
@@ -1,4 +1,5 @@
 import { InputFile } from "grammy";
+import type { Message } from "grammy/types";
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
 import { extensionForMime, type MediaKind } from "openclaw/plugin-sdk/media-mime";
 import { isGifMedia, kindFromMime } from "openclaw/plugin-sdk/media-runtime";
@@ -7,7 +8,6 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { loadWebMedia } from "openclaw/plugin-sdk/web-media";
 import { resolveTelegramPlainCaption, splitTelegramCaption } from "./caption.js";
 import { renderTelegramHtmlText, telegramHtmlToPlainTextFallback } from "./format.js";
-import type { TelegramOutboundPromptContextMessage } from "./outbound-message-context.js";
 import { isTelegramEmptyContentError, isTelegramHtmlParseError } from "./rich-plain-fallback.js";
 import type { TelegramApi } from "./send-context.js";
 import { isTelegramPhotoLimitError } from "./send-error-predicates.js";
@@ -37,10 +37,15 @@ type TelegramOutboundMediaPlan = {
   followUpText?: string;
 };
 
-export type TelegramOutboundMediaSender<T = TelegramOutboundPromptContextMessage> = {
+export type TelegramOutboundMediaSender = {
   label: TelegramOutboundMediaKind;
   operation: string;
-  send: (effectiveParams: Record<string, unknown>) => Promise<T>;
+  send: (effectiveParams: Record<string, unknown>) => Promise<Message>;
+};
+
+export type TelegramOutboundMediaSenders = {
+  sender: TelegramOutboundMediaSender;
+  documentSender: TelegramOutboundMediaSender;
 };
 
 function resolveTelegramOutboundMediaFilename(params: {
@@ -132,9 +137,7 @@ export function prepareTelegramOutboundMedia(params: {
   };
 }
 
-export function resolveTelegramOutboundMediaSenders<
-  T = TelegramOutboundPromptContextMessage,
->(params: {
+export function resolveTelegramOutboundMediaSenders(params: {
   api: TelegramApi;
   chatId: string;
   media: TelegramLoadedMedia;
@@ -142,29 +145,39 @@ export function resolveTelegramOutboundMediaSenders<
   forceDocument?: boolean;
   asVoice?: boolean;
   sendImageAsPhoto?: boolean;
-}): { sender: TelegramOutboundMediaSender<T>; documentSender: TelegramOutboundMediaSender<T> } {
-  const createSender = (label: TelegramOutboundMediaKind): TelegramOutboundMediaSender<T> => {
+}): TelegramOutboundMediaSenders {
+  const createSender = (label: TelegramOutboundMediaKind): TelegramOutboundMediaSender => {
     const operation = `send${label
       .split("_")
       .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
       .join("")}`;
-    const method = params.api[operation as keyof TelegramApi] as unknown as (
-      chatId: string,
-      file: InputFile,
-      options: Record<string, unknown>,
-    ) => Promise<T>;
     return {
       label,
       operation,
-      send: (effectiveParams) =>
-        method.call(
-          params.api,
-          params.chatId,
-          params.plan.file,
+      send: (effectiveParams) => {
+        const options =
           label === "document" && params.forceDocument
             ? { ...effectiveParams, disable_content_type_detection: true }
-            : effectiveParams,
-        ),
+            : effectiveParams;
+        switch (label) {
+          case "animation":
+            return params.api.sendAnimation(params.chatId, params.plan.file, options);
+          case "photo":
+            return params.api.sendPhoto(params.chatId, params.plan.file, options);
+          case "video":
+            return params.api.sendVideo(params.chatId, params.plan.file, options);
+          case "video_note":
+            return params.api.sendVideoNote(params.chatId, params.plan.file, options);
+          case "voice":
+            return params.api.sendVoice(params.chatId, params.plan.file, options);
+          case "audio":
+            return params.api.sendAudio(params.chatId, params.plan.file, options);
+          case "document":
+            return params.api.sendDocument(params.chatId, params.plan.file, options);
+        }
+        label satisfies never;
+        throw new Error("Unsupported Telegram outbound media kind.");
+      },
     };
   };
   const documentSender = createSender("document");
@@ -239,11 +252,11 @@ export async function sendTelegramCaptionedMediaWithFallback<T>(params: {
         err,
       )}`,
     );
-    const plainParams: Record<string, unknown> = {
-      ...params.requestParams,
+    const { parse_mode: _parseMode, ...requestWithoutParseMode } = params.requestParams;
+    const plainParams = {
+      ...requestWithoutParseMode,
       caption: params.plainCaption,
     };
-    delete plainParams.parse_mode;
     try {
       return {
         result: await params.send(
@@ -262,11 +275,11 @@ export async function sendTelegramCaptionedMediaWithFallback<T>(params: {
   }
 }
 
-export async function sendTelegramOutboundMediaWithPhotoFallback<T, TMessage>(params: {
-  sender: TelegramOutboundMediaSender<TMessage>;
-  documentSender: TelegramOutboundMediaSender<TMessage>;
-  send: (sender: TelegramOutboundMediaSender<TMessage>) => Promise<T>;
-}): Promise<{ result: T; sender: TelegramOutboundMediaSender<TMessage> }> {
+export async function sendTelegramOutboundMediaWithPhotoFallback<T>(params: {
+  sender: TelegramOutboundMediaSender;
+  documentSender: TelegramOutboundMediaSender;
+  send: (sender: TelegramOutboundMediaSender) => Promise<T>;
+}): Promise<{ result: T; sender: TelegramOutboundMediaSender }> {
   try {
     return { result: await params.send(params.sender), sender: params.sender };
   } catch (error) {

--- a/extensions/telegram/src/outbound-media.ts
+++ b/extensions/telegram/src/outbound-media.ts
@@ -43,7 +43,7 @@ export type TelegramOutboundMediaSender = {
   send: (effectiveParams: Record<string, unknown>) => Promise<Message>;
 };
 
-export type TelegramOutboundMediaSenders = {
+type TelegramOutboundMediaSenders = {
   sender: TelegramOutboundMediaSender;
   documentSender: TelegramOutboundMediaSender;
 };

--- a/extensions/telegram/src/poll-answer-context.ts
+++ b/extensions/telegram/src/poll-answer-context.ts
@@ -18,6 +18,10 @@ export type PreparedTelegramPollAnswer = {
   registrationPending?: true;
 };
 
+export type TelegramPollRegistration = {
+  complete: (entry: TelegramPollRegistryEntry | null) => void;
+};
+
 const preparedPollAnswers = new WeakMap<object, PreparedTelegramPollAnswer>();
 const pendingPollRegistrations = new Map<
   string,
@@ -30,9 +34,7 @@ const pendingPollRegistrations = new Map<
 export function beginTelegramPollRegistration(params: {
   accountId?: string;
   entry: TelegramPollRegistryEntry;
-}): {
-  complete: (entry: TelegramPollRegistryEntry | null) => void;
-} {
+}): TelegramPollRegistration {
   const key = telegramPollRegistryKey(params.accountId, params.entry.pollId);
   let completeRegistration: (entry: TelegramPollRegistryEntry | null) => void = () => {};
   const completion = new Promise<TelegramPollRegistryEntry | null>((resolve) => {

--- a/extensions/telegram/src/poll-answer-context.ts
+++ b/extensions/telegram/src/poll-answer-context.ts
@@ -18,7 +18,7 @@ export type PreparedTelegramPollAnswer = {
   registrationPending?: true;
 };
 
-export type TelegramPollRegistration = {
+type TelegramPollRegistration = {
   complete: (entry: TelegramPollRegistryEntry | null) => void;
 };
 

--- a/extensions/telegram/src/poll-registry.test.ts
+++ b/extensions/telegram/src/poll-registry.test.ts
@@ -1,5 +1,4 @@
 // Telegram tests cover poll registry plugin behavior.
-import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
   createPluginStateKeyedStoreForTests,
   resetPluginStateStoreForTests,
@@ -167,19 +166,21 @@ describe("telegram poll registry", () => {
       threadSpec: { scope: "forum", id: 77 },
     },
   ])("rejects malformed stored origin data: $name", async (invalid) => {
-    installTelegramStateRuntime((() => ({
-      lookup: async () => ({
-        pollId: "poll-invalid-chat",
-        chat: invalid.chat,
-        messageId: 44,
-        ...(invalid.threadSpec === undefined ? {} : { threadSpec: invalid.threadSpec }),
-        ...(invalid.messageThreadId === undefined
-          ? {}
-          : { messageThreadId: invalid.messageThreadId }),
-        question: "Ready?",
-        options: ["Yes", "No"],
+    Reflect.apply(installTelegramStateRuntime, undefined, [
+      () => ({
+        lookup: async () => ({
+          pollId: "poll-invalid-chat",
+          chat: invalid.chat,
+          messageId: 44,
+          ...(invalid.threadSpec === undefined ? {} : { threadSpec: invalid.threadSpec }),
+          ...(invalid.messageThreadId === undefined
+            ? {}
+            : { messageThreadId: invalid.messageThreadId }),
+          question: "Ready?",
+          options: ["Yes", "No"],
+        }),
       }),
-    })) as unknown as TelegramRuntime["state"]["openKeyedStore"]);
+    ]);
 
     await expect(
       findTelegramPollRegistryEntry({ pollId: "poll-invalid-chat" }),
@@ -192,8 +193,8 @@ describe("telegram poll registry", () => {
       lookup: async () => {
         throw readError;
       },
-    } as unknown as PluginStateKeyedStore<TelegramPollRegistryEntry>;
-    installTelegramStateRuntime((() => failingStore) as TelegramRuntime["state"]["openKeyedStore"]);
+    };
+    Reflect.apply(installTelegramStateRuntime, undefined, [() => failingStore]);
 
     await expect(findTelegramPollRegistryEntry({ pollId: "poll-read-error" })).rejects.toBe(
       readError,

--- a/extensions/telegram/src/polling-session-restart-policy.ts
+++ b/extensions/telegram/src/polling-session-restart-policy.ts
@@ -22,6 +22,11 @@ type TelegramRestartBackoffState = {
   stopTimeoutCooldownAttempts: number;
 };
 
+type TelegramRestartDelay = {
+  delayMs: number;
+  stopTimeoutSuffix: string;
+};
+
 export function createTelegramRestartBackoffState(): TelegramRestartBackoffState {
   return {
     restartAttempts: 0,
@@ -39,7 +44,7 @@ export function resetTelegramRestartBackoffState(state: TelegramRestartBackoffSt
 export function resolveTelegramRestartDelayMs(
   state: TelegramRestartBackoffState,
   opts: { stopTimedOut?: boolean } = {},
-): { delayMs: number; stopTimeoutSuffix: string } {
+): TelegramRestartDelay {
   state.restartAttempts += 1;
   let delayMs = computeBackoff(TELEGRAM_POLL_RESTART_POLICY, state.restartAttempts);
   let stopTimeoutSuffix = "";

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -233,6 +233,10 @@ type TelegramPollingTestDatabase = Pick<
 type IsolatedIngressOptions = NonNullable<
   ConstructorParameters<typeof TelegramPollingSession>[0]["isolatedIngress"]
 >;
+type SpooledClaimRefreshHarness = {
+  restore: () => void;
+  triggerRefresh: () => void;
+};
 
 const POLLING_TEST_WATCHDOG_INTERVAL_MS = 30_000;
 
@@ -346,6 +350,10 @@ function installPollingStallWatchdogHarness(dateNowSequence: readonly number[] =
   });
   const realSetTimeout = globalThis.setTimeout;
   const realClearTimeout = globalThis.clearTimeout;
+  const realSetInterval = globalThis.setInterval;
+  const realClearInterval = globalThis.clearInterval;
+  const watchdogInterval = realSetInterval(() => undefined, 2_147_483_647);
+  watchdogInterval.unref?.();
   const watchdogs: Array<() => void> = [];
   const watchdogWaiters: Array<{
     count: number;
@@ -370,7 +378,7 @@ function installPollingStallWatchdogHarness(dateNowSequence: readonly number[] =
         );
       }
     }
-    return 1 as unknown as ReturnType<typeof setInterval>;
+    return watchdogInterval;
   });
   const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval").mockImplementation(() => {});
   const setTimeoutSpy = vi
@@ -425,6 +433,7 @@ function installPollingStallWatchdogHarness(dateNowSequence: readonly number[] =
       dateNowSpy.mockImplementation(() => now);
     },
     restore() {
+      realClearInterval(watchdogInterval);
       setIntervalSpy.mockRestore();
       clearIntervalSpy.mockRestore();
       setTimeoutSpy.mockRestore();
@@ -653,12 +662,11 @@ async function claimedAtForUpdate(spoolDir: string, updateId: number): Promise<n
   return claim.claim.claimedAt;
 }
 
-function installSpooledClaimRefreshHarness(): {
-  restore: () => void;
-  triggerRefresh: () => void;
-} {
+function installSpooledClaimRefreshHarness(): SpooledClaimRefreshHarness {
   let refresh: (() => void) | undefined;
   const realSetInterval = globalThis.setInterval.bind(globalThis);
+  const realClearInterval = globalThis.clearInterval.bind(globalThis);
+  const refreshTimers: Array<ReturnType<typeof setInterval>> = [];
   const setIntervalSpy = vi.spyOn(globalThis, "setInterval").mockImplementation(((
     handler: Parameters<typeof setInterval>[0],
     timeout?: number,
@@ -671,12 +679,18 @@ function installSpooledClaimRefreshHarness(): {
       };
       const timer = realSetInterval(() => undefined, 2_147_483_647);
       timer.unref?.();
+      refreshTimers.push(timer);
       return timer;
     }
     return realSetInterval(handler, timeout);
   }) as typeof setInterval);
   return {
-    restore: () => setIntervalSpy.mockRestore(),
+    restore: () => {
+      for (const timer of refreshTimers) {
+        realClearInterval(timer);
+      }
+      setIntervalSpy.mockRestore();
+    },
     triggerRefresh: () => {
       if (!refresh) {
         throw new Error("Expected spooled claim refresh interval to be registered");

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -55,6 +55,14 @@ function normalizeTelegramAccountId(accountId?: string | null): string {
 
 type TelegramBot = ReturnType<typeof createTelegramBot>;
 
+type TelegramIsolatedPollState = {
+  startedAt: number | null;
+  offset: number | null;
+  outcome: string;
+  error?: string;
+  errorCode: number | null;
+};
+
 const waitForGracefulStop = async (stop: () => Promise<void>) => {
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
@@ -448,13 +456,7 @@ export class TelegramPollingSession {
     // Readiness contract: test/e2e/qa-lab telegram-bot-token-runtime waits for
     // this marker on the injected runtime log; do not demote it to verbose.
     this.opts.log(`[telegram][diag] isolated polling ingress started spool=${spoolDir}`);
-    const pollState: {
-      startedAt: number | null;
-      offset: number | null;
-      outcome: string;
-      error?: string;
-      errorCode: number | null;
-    } = {
+    const pollState: TelegramIsolatedPollState = {
       startedAt: null,
       offset: null,
       outcome: "not-started",

--- a/extensions/telegram/src/probe.response-body-timeout.test.ts
+++ b/extensions/telegram/src/probe.response-body-timeout.test.ts
@@ -1,5 +1,5 @@
 // Telegram tests cover stalled diagnostic response body handling.
-import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
+import { afterEach, describe, expect, it, vi, type MockedFunction } from "vitest";
 import { probeTelegram, resetTelegramProbeFetcherCacheForTests } from "./probe.js";
 
 const resolveTelegramTransport = vi.hoisted(() => vi.fn());
@@ -15,15 +15,15 @@ vi.mock("./proxy.js", () => ({
   makeProxyFetch,
 }));
 
-function installFetchMock(): Mock {
-  const fetchMock = vi.fn();
+function installFetchMock(): MockedFunction<typeof fetch> {
+  const fetchMock = vi.fn<typeof fetch>();
   resolveTelegramTransport.mockImplementation((proxyFetch?: typeof fetch) => ({
-    fetch: proxyFetch ?? (fetchMock as unknown as typeof fetch),
-    sourceFetch: proxyFetch ?? (fetchMock as unknown as typeof fetch),
+    fetch: proxyFetch ?? fetchMock,
+    sourceFetch: proxyFetch ?? fetchMock,
     forceFallback: vi.fn().mockReturnValue(true),
     close: async () => {},
   }));
-  makeProxyFetch.mockImplementation(() => fetchMock as unknown as typeof fetch);
+  makeProxyFetch.mockImplementation(() => fetchMock);
   return fetchMock;
 }
 

--- a/extensions/telegram/src/probe.test.ts
+++ b/extensions/telegram/src/probe.test.ts
@@ -3,6 +3,15 @@ import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
 import { probeTelegram, resetTelegramProbeFetcherCacheForTests } from "./probe.js";
 
+type FetchMock = Mock<typeof fetch>;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
 const resolveTelegramTransport = vi.hoisted(() => vi.fn());
 const makeProxyFetch = vi.hoisted(() => vi.fn());
 
@@ -36,8 +45,8 @@ describe("probeTelegram retry logic", () => {
   const originalFetch = global.fetch;
   let forceFallbackMock: Mock;
 
-  const installFetchMock = (): Mock => {
-    const fetchMock = vi.fn();
+  const installFetchMock = (): FetchMock => {
+    const fetchMock = vi.fn<typeof fetch>();
     global.fetch = withFetchPreconnect(fetchMock);
     forceFallbackMock = vi.fn().mockReturnValue(true);
     resolveTelegramTransport.mockImplementation((proxyFetch?: typeof fetch) => ({
@@ -46,14 +55,13 @@ describe("probeTelegram retry logic", () => {
       forceFallback: forceFallbackMock,
       close: async () => {},
     }));
-    makeProxyFetch.mockImplementation(() => fetchMock as unknown as typeof fetch);
+    makeProxyFetch.mockImplementation(() => fetchMock);
     return fetchMock;
   };
 
-  function mockGetMeSuccess(fetchMock: Mock) {
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: vi.fn().mockResolvedValue({
+  function mockGetMeSuccess(fetchMock: FetchMock) {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
         ok: true,
         result: {
           id: 123,
@@ -70,14 +78,11 @@ describe("probeTelegram retry logic", () => {
           allows_users_to_create_topics: false,
         },
       }),
-    });
+    );
   }
 
-  function mockGetWebhookInfoSuccess(fetchMock: Mock) {
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: vi.fn().mockResolvedValue({ ok: true, result: { url: "" } }),
-    });
+  function mockGetWebhookInfoSuccess(fetchMock: FetchMock) {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true, result: { url: "" } }));
   }
 
   async function expectSuccessfulProbe(fetchMock: Mock, expectedCalls: number, retryCount = 0) {
@@ -160,7 +165,7 @@ describe("probeTelegram retry logic", () => {
   });
 
   it("respects timeout budget across retries", async () => {
-    const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchMock = vi.fn<typeof fetch>((_input, init) => {
       return new Promise<Response>((_resolve, reject) => {
         const signal = init?.signal;
         if (signal?.aborted) {
@@ -172,14 +177,14 @@ describe("probeTelegram retry logic", () => {
         });
       });
     });
-    global.fetch = withFetchPreconnect(fetchMock as unknown as typeof fetch);
+    global.fetch = withFetchPreconnect(fetchMock);
     resolveTelegramTransport.mockImplementation((proxyFetch?: typeof fetch) => ({
       fetch: proxyFetch ?? fetch,
       sourceFetch: proxyFetch ?? fetch,
       forceFallback: vi.fn().mockReturnValue(true),
       close: async () => {},
     }));
-    makeProxyFetch.mockImplementation(() => fetchMock as unknown as typeof fetch);
+    makeProxyFetch.mockImplementation(() => fetchMock);
     vi.useFakeTimers();
     try {
       const probePromise = probeTelegram(`${token}-budget`, 500);
@@ -195,14 +200,13 @@ describe("probeTelegram retry logic", () => {
 
   it("should NOT retry if getMe returns a 401 Unauthorized", async () => {
     const fetchMock = installFetchMock();
-    const mockResponse = {
-      ok: false,
-      status: 401,
-      json: vi.fn().mockResolvedValue({
+    const mockResponse = jsonResponse(
+      {
         ok: false,
         description: "Unauthorized",
-      }),
-    };
+      },
+      401,
+    );
     fetchMock.mockResolvedValueOnce(mockResponse);
 
     const result = await probeTelegram(token, timeoutMs);

--- a/extensions/telegram/src/probe.ts
+++ b/extensions/telegram/src/probe.ts
@@ -159,7 +159,7 @@ export async function probeTelegram(
         error: null,
       };
       let meRes: Response | null = null;
-      let fetchError: unknown = null;
+      let fetchError: Error | null = null;
 
       // Retry loop for initial connection (handles network/DNS startup races)
       for (let i = 0; i < 3; i++) {
@@ -176,7 +176,7 @@ export async function probeTelegram(
           );
           break;
         } catch (err) {
-          fetchError = err;
+          fetchError = toErrorObject(err, "Non-Error thrown");
           if (abortSignal?.aborted) {
             throw err;
           }

--- a/extensions/telegram/src/progress-draft-preview.test.ts
+++ b/extensions/telegram/src/progress-draft-preview.test.ts
@@ -26,7 +26,6 @@ describe("renderTelegramProgressDraftPreview", () => {
     for (const name of ["Bash", "bash", "exec"]) {
       const rendered = renderToolLine(name);
       expect(rendered.match(/🛠️/gu) ?? []).toHaveLength(1);
-      expect(rendered).toContain("print text");
     }
   });
 

--- a/extensions/telegram/src/raw-update-log.ts
+++ b/extensions/telegram/src/raw-update-log.ts
@@ -75,9 +75,18 @@ function isTelegramUserObject(value: Record<string, unknown>): boolean {
   );
 }
 
+type TelegramRawLogValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | TelegramRawLogValue[]
+  | { [key: string]: TelegramRawLogValue };
+
 export function formatTelegramRawUpdateForLog(update: unknown): string {
   const seen = new WeakSet<object>();
-  const transform = (value: unknown, key = "", parentKey?: string): unknown => {
+  const transform = (value: unknown, key = "", parentKey?: string): TelegramRawLogValue => {
     if (shouldRedactTelegramRawUpdateValue(key, parentKey)) {
       return REDACTED_TELEGRAM_FIELD;
     }
@@ -102,13 +111,22 @@ export function formatTelegramRawUpdateForLog(update: unknown): string {
       if (isTelegramUserObject(record)) {
         return REDACTED_TELEGRAM_FIELD;
       }
-      const redacted: Record<string, unknown> = {};
+      const redacted: { [key: string]: TelegramRawLogValue } = {};
       for (const [entryKey, entryValue] of Object.entries(record)) {
         redacted[entryKey] = transform(entryValue, entryKey, key);
       }
       return redacted;
     }
-    return value;
+    if (value == null || typeof value === "number" || typeof value === "boolean") {
+      return value;
+    }
+    if (typeof value === "bigint") {
+      return value.toString();
+    }
+    if (typeof value === "symbol") {
+      return value.description ? `Symbol(${value.description})` : "Symbol()";
+    }
+    return "[Function]";
   };
   const raw = JSON.stringify(transform(update ?? null));
   return raw.length > MAX_RAW_UPDATE_CHARS

--- a/extensions/telegram/src/reaction-level.test.ts
+++ b/extensions/telegram/src/reaction-level.test.ts
@@ -5,6 +5,10 @@ import { resolveTelegramReactionLevel } from "./reaction-level.js";
 
 type ReactionResolution = ReturnType<typeof resolveTelegramReactionLevel>;
 
+function resolveReactionLevelFromRawConfig(cfg: object, accountId?: string) {
+  return Reflect.apply(resolveTelegramReactionLevel, undefined, [{ cfg, accountId }]);
+}
+
 describe("resolveTelegramReactionLevel", () => {
   const prevTelegramToken = process.env.TELEGRAM_BOT_TOKEN;
 
@@ -166,10 +170,10 @@ describe("resolveTelegramReactionLevel", () => {
           reactionLevel: "off",
         },
       },
-    } as unknown as OpenClawConfig;
+    };
 
-    expect(() => resolveTelegramReactionLevel({ cfg })).not.toThrow();
-    const result = resolveTelegramReactionLevel({ cfg });
+    expect(() => resolveReactionLevelFromRawConfig(cfg)).not.toThrow();
+    const result = resolveReactionLevelFromRawConfig(cfg);
     expectReactionFlags(result, {
       level: "off",
       ackEnabled: false,
@@ -190,10 +194,10 @@ describe("resolveTelegramReactionLevel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    };
 
-    expect(() => resolveTelegramReactionLevel({ cfg, accountId: "ops" })).not.toThrow();
-    const result = resolveTelegramReactionLevel({ cfg, accountId: "ops" });
+    expect(() => resolveReactionLevelFromRawConfig(cfg, "ops")).not.toThrow();
+    const result = resolveReactionLevelFromRawConfig(cfg, "ops");
     expectReactionFlags(result, {
       level: "ack",
       ackEnabled: true,

--- a/extensions/telegram/src/reply-parameters.ts
+++ b/extensions/telegram/src/reply-parameters.ts
@@ -26,6 +26,12 @@ type TelegramThreadReplyParams = {
   allow_sending_without_reply?: true;
 };
 
+type TelegramSendParams = TelegramThreadReplyParams & {
+  disable_notification?: true;
+};
+
+type TelegramSendParamBag = Record<string, unknown>;
+
 export function resolveTelegramSendThreadSpec(params: {
   targetMessageThreadId?: number;
   targetDirectMessagesTopicId?: number;
@@ -103,8 +109,8 @@ export function buildTelegramSendParams(opts?: {
   thread?: TelegramThreadSpec | null;
   silent?: boolean;
   useReplyIdAsQuoteSource?: boolean;
-}): Record<string, unknown> {
-  const params: Record<string, unknown> = { ...buildTelegramThreadReplyParams(opts) };
+}): TelegramSendParams {
+  const params: TelegramSendParams = { ...buildTelegramThreadReplyParams(opts) };
   if (opts?.silent === true) {
     params.disable_notification = true;
   }
@@ -112,7 +118,7 @@ export function buildTelegramSendParams(opts?: {
 }
 
 export function getTelegramNativeQuoteReplyMessageId(
-  params: Record<string, unknown> | undefined,
+  params: TelegramSendParamBag | undefined,
 ): number | undefined {
   const replyParameters = params?.reply_parameters;
   if (!replyParameters || typeof replyParameters !== "object") {
@@ -130,8 +136,8 @@ export function isTelegramQuoteParamError(err: unknown): boolean {
 }
 
 export function removeTelegramNativeQuoteParam(
-  params: Record<string, unknown> | undefined,
-): Record<string, unknown> {
+  params: TelegramSendParamBag | undefined,
+): TelegramSendParamBag {
   if (!params) {
     return {};
   }

--- a/extensions/telegram/src/rich-blocks-html.ts
+++ b/extensions/telegram/src/rich-blocks-html.ts
@@ -13,8 +13,7 @@ export type HtmlNode =
 
 export const VOID_TAGS = new Set(["br", "hr", "img", "input", "tg-map"]);
 
-const INLINE_STYLE_TAGS: Record<
-  string,
+type TelegramInlineStyle =
   | "bold"
   | "italic"
   | "underline"
@@ -23,23 +22,24 @@ const INLINE_STYLE_TAGS: Record<
   | "spoiler"
   | "marked"
   | "subscript"
-  | "superscript"
-> = {
-  b: "bold",
-  strong: "bold",
-  i: "italic",
-  em: "italic",
-  u: "underline",
-  ins: "underline",
-  s: "strikethrough",
-  del: "strikethrough",
-  strike: "strikethrough",
-  code: "code",
-  "tg-spoiler": "spoiler",
-  mark: "marked",
-  sub: "subscript",
-  sup: "superscript",
-};
+  | "superscript";
+
+const INLINE_STYLE_TAGS = new Map<string, TelegramInlineStyle>([
+  ["b", "bold"],
+  ["strong", "bold"],
+  ["i", "italic"],
+  ["em", "italic"],
+  ["u", "underline"],
+  ["ins", "underline"],
+  ["s", "strikethrough"],
+  ["del", "strikethrough"],
+  ["strike", "strikethrough"],
+  ["code", "code"],
+  ["tg-spoiler", "spoiler"],
+  ["mark", "marked"],
+  ["sub", "subscript"],
+  ["sup", "superscript"],
+]);
 
 const HTML_ATTR_RE = /([a-zA-Z][a-zA-Z0-9-]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
 
@@ -155,7 +155,7 @@ export function htmlNodesToRichText(nodes: readonly HtmlNode[]): RichText {
       }
       continue;
     }
-    const style = INLINE_STYLE_TAGS[node.name];
+    const style = INLINE_STYLE_TAGS.get(node.name);
     if (style) {
       parts.push({ type: style, text: htmlNodesToRichText(node.children) });
       continue;

--- a/extensions/telegram/src/rich-blocks.ts
+++ b/extensions/telegram/src/rich-blocks.ts
@@ -622,7 +622,7 @@ function emitSegments(
   return blocks;
 }
 
-export type TelegramRichBlocksResult = {
+type TelegramRichBlocksResult = {
   blocks: InputRichBlock[];
   plainText: string;
   degradationReasons: readonly TelegramRichBlocksDegradationReason[];

--- a/extensions/telegram/src/rich-blocks.ts
+++ b/extensions/telegram/src/rich-blocks.ts
@@ -37,17 +37,17 @@ const TELEGRAM_RICH_FORMAT_PROFILE = FormatCapabilityProfile.define({
   chunk: { limit: 32_768, unit: "chars" },
 });
 
-const INLINE_STYLE_RANK: Record<string, number> = {
+type InlineStyleKind = "bold" | "italic" | "strikethrough" | "code" | "spoiler";
+
+const INLINE_STYLE_RANK = {
   spoiler: 0,
   bold: 1,
   italic: 2,
   strikethrough: 3,
   code: 4,
-};
+} satisfies Record<InlineStyleKind, number>;
 
 const TELEGRAM_RICH_LINK_HREF_RE = /^(?:https?:\/\/|tg:\/\/|mailto:|tel:)/i;
-
-type InlineStyleKind = "bold" | "italic" | "strikethrough" | "code" | "spoiler";
 
 type StructuralSegment =
   | { kind: "heading"; start: number; end: number; size: 1 | 2 | 3 | 4 | 5 | 6 }
@@ -440,10 +440,12 @@ function cellToRichText(cell: MarkdownTableCell | undefined): RichText | undefin
   return rich === "" ? undefined : rich;
 }
 
-function renderTableBlock(table: MarkdownTableMeta): {
+type TelegramTableBlockResult = {
   block: InputRichBlock;
   degradation?: TelegramRichBlocksDegradationReason;
-} {
+};
+
+function renderTableBlock(table: MarkdownTableMeta): TelegramTableBlockResult {
   const columnCount = Math.max(table.headers.length, ...table.rows.map((row) => row.length), 0);
   if (columnCount > TELEGRAM_RICH_TEXT_TABLE_COLUMN_LIMIT) {
     return {
@@ -620,14 +622,16 @@ function emitSegments(
   return blocks;
 }
 
-export function markdownToTelegramRichBlocks(
-  markdown: string,
-  options: { tableMode?: MarkdownTableMode; skipEntityDetection?: boolean } = {},
-): {
+export type TelegramRichBlocksResult = {
   blocks: InputRichBlock[];
   plainText: string;
   degradationReasons: readonly TelegramRichBlocksDegradationReason[];
-} {
+};
+
+export function markdownToTelegramRichBlocks(
+  markdown: string,
+  options: { tableMode?: MarkdownTableMode; skipEntityDetection?: boolean } = {},
+): TelegramRichBlocksResult {
   const tableMode = options.tableMode ?? "block";
   // The shared parse carries list markers into native blocks; `---` keeps the
   // IR's ─── text, while media/details/math stay HTML-island contracts.

--- a/extensions/telegram/src/send-mutation-targets.test.ts
+++ b/extensions/telegram/src/send-mutation-targets.test.ts
@@ -14,11 +14,32 @@ const { deleteMessageTelegram, pinMessageTelegram, reactMessageTelegram, unpinMe
 const chatId = "-1001234567890";
 const messageId = 321;
 const getChat = vi.fn(async () => ({ id: Number(chatId) }));
+type TelegramApiOverride = NonNullable<Parameters<typeof reactMessageTelegram>[3]["api"]>;
+
+function createMutationApiOverride(value: Record<string, unknown>): TelegramApiOverride {
+  for (const method of [
+    "deleteMessage",
+    "editForumTopic",
+    "editMessageCaption",
+    "editMessageText",
+    "getChat",
+    "pinChatMessage",
+    "setMessageReaction",
+    "unpinChatMessage",
+  ]) {
+    if (typeof value[method] !== "function") {
+      throw new Error(`expected Telegram mutation API method ${method}`);
+    }
+  }
+  return Reflect.apply((api: TelegramApiOverride) => api, undefined, [value]);
+}
+
+const api = createMutationApiOverride({ ...botApi, getChat });
 const opts = {
   cfg: {},
   token: "tok",
   accountId: "default",
-  api: { ...botApi, getChat } as unknown as Parameters<typeof reactMessageTelegram>[3]["api"],
+  api,
   gatewayClientScopes: ["operator.write"],
 };
 

--- a/extensions/telegram/src/send.proxy.test.ts
+++ b/extensions/telegram/src/send.proxy.test.ts
@@ -1,6 +1,7 @@
 // Telegram tests cover send.proxy plugin behavior.
 import { toErrorObject as toLintErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TelegramApiOverride } from "./send.js";
 
 const { botApi, botCtorSpy } = vi.hoisted(() => ({
   botApi: (() => {
@@ -62,6 +63,23 @@ const { maybePersistResolvedTelegramTarget } = vi.hoisted(() => ({
 const resolveTelegramApiBase = vi.hoisted(
   () => (apiRoot?: string) => apiRoot?.trim()?.replace(/\/+$/, "") || "https://api.telegram.org",
 );
+
+function createTelegramApiOverride(value: Record<string, unknown>): TelegramApiOverride {
+  for (const method of [
+    "deleteMessage",
+    "getChat",
+    "sendDocument",
+    "sendMessage",
+    "setMessageReaction",
+  ]) {
+    if (typeof value[method] !== "function") {
+      throw new Error(`expected Telegram API method ${method}`);
+    }
+  }
+  return Reflect.apply((api: TelegramApiOverride) => api, undefined, [value]);
+}
+
+const telegramApiOverride = createTelegramApiOverride(botApi);
 
 vi.mock("openclaw/plugin-sdk/plugin-config-runtime", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/plugin-config-runtime")>(
@@ -127,12 +145,12 @@ describe("telegram proxy client", () => {
   };
 
   const prepareProxyFetch = () => {
-    const proxyFetch = vi.fn();
-    const fetchImpl = vi.fn();
-    makeProxyFetch.mockReturnValue(proxyFetch as unknown as typeof fetch);
+    const proxyFetch = vi.fn<typeof fetch>();
+    const fetchImpl = vi.fn<typeof fetch>();
+    makeProxyFetch.mockReturnValue(proxyFetch);
     resolveTelegramTransport.mockReturnValue({
-      fetch: fetchImpl as unknown as typeof fetch,
-      sourceFetch: fetchImpl as unknown as typeof fetch,
+      fetch: fetchImpl,
+      sourceFetch: fetchImpl,
       close: vi.fn(async () => undefined),
     });
     return { proxyFetch, fetchImpl };
@@ -204,9 +222,9 @@ describe("telegram proxy client", () => {
     vi.stubEnv("VITEST", "");
     vi.stubEnv("NODE_ENV", "production");
     const closeSpies: Array<ReturnType<typeof vi.fn>> = [];
-    makeProxyFetch.mockImplementation(() => vi.fn() as unknown as typeof fetch);
+    makeProxyFetch.mockImplementation(() => vi.fn<typeof fetch>());
     resolveTelegramTransport.mockImplementation(() => {
-      const fetchImpl = vi.fn() as unknown as typeof fetch;
+      const fetchImpl = vi.fn<typeof fetch>();
       const close = vi.fn(async () => undefined);
       closeSpies.push(close);
       return {
@@ -292,9 +310,9 @@ describe("telegram proxy client", () => {
     vi.stubEnv("VITEST", "");
     vi.stubEnv("NODE_ENV", "production");
     const closeSpies: Array<ReturnType<typeof vi.fn>> = [];
-    makeProxyFetch.mockImplementation(() => vi.fn() as unknown as typeof fetch);
+    makeProxyFetch.mockImplementation(() => vi.fn<typeof fetch>());
     resolveTelegramTransport.mockImplementation(() => {
-      const fetchImpl = vi.fn() as unknown as typeof fetch;
+      const fetchImpl = vi.fn<typeof fetch>();
       const close = vi.fn(async () => undefined);
       closeSpies.push(close);
       return {
@@ -350,9 +368,9 @@ describe("telegram proxy client", () => {
     vi.stubEnv("VITEST", "");
     vi.stubEnv("NODE_ENV", "production");
     const closeSpies: Array<ReturnType<typeof vi.fn>> = [];
-    makeProxyFetch.mockImplementation(() => vi.fn() as unknown as typeof fetch);
+    makeProxyFetch.mockImplementation(() => vi.fn<typeof fetch>());
     resolveTelegramTransport.mockImplementation(() => {
-      const fetchImpl = vi.fn() as unknown as typeof fetch;
+      const fetchImpl = vi.fn<typeof fetch>();
       const close = vi.fn(async () => undefined);
       closeSpies.push(close);
       return {
@@ -422,9 +440,9 @@ describe("telegram proxy client", () => {
     vi.stubEnv("VITEST", "");
     vi.stubEnv("NODE_ENV", "production");
     const closeSpies: Array<ReturnType<typeof vi.fn>> = [];
-    makeProxyFetch.mockImplementation(() => vi.fn() as unknown as typeof fetch);
+    makeProxyFetch.mockImplementation(() => vi.fn<typeof fetch>());
     resolveTelegramTransport.mockImplementation(() => {
-      const fetchImpl = vi.fn() as unknown as typeof fetch;
+      const fetchImpl = vi.fn<typeof fetch>();
       const close = vi.fn(async () => undefined);
       closeSpies.push(close);
       return {
@@ -488,7 +506,7 @@ describe("telegram proxy client", () => {
       cfg: TELEGRAM_PROXY_CFG,
       token: "tok",
       accountId: "foo",
-      api: botApi as unknown as Parameters<typeof reactMessageTelegram>[3]["api"],
+      api: telegramApiOverride,
     });
 
     expect(makeProxyFetch).not.toHaveBeenCalled();

--- a/extensions/telegram/src/send.test-harness.ts
+++ b/extensions/telegram/src/send.test-harness.ts
@@ -251,22 +251,29 @@ export function installTelegramSendTestHooks() {
         [key: string]: unknown;
       }) => {
         const { chat_id, rich_message, ...richParams } = params;
-        const sendParams: Record<string, unknown> = {
+        const initialSendParams = {
           parse_mode: "HTML",
           ...(rich_message.skip_entity_detection === true ? { skip_entity_detection: true } : {}),
           ...richParams,
         };
-        const replyParameters = sendParams.reply_parameters;
-        if (
+        const replyParameters = Reflect.get(initialSendParams, "reply_parameters");
+        const replyMessageId =
           replyParameters &&
           typeof replyParameters === "object" &&
           !("quote" in replyParameters) &&
-          typeof (replyParameters as { message_id?: unknown }).message_id === "number"
-        ) {
-          sendParams.reply_to_message_id = (replyParameters as { message_id: number }).message_id;
-          sendParams.allow_sending_without_reply = true;
-          delete sendParams.reply_parameters;
-        }
+          typeof Reflect.get(replyParameters, "message_id") === "number"
+            ? Reflect.get(replyParameters, "message_id")
+            : undefined;
+        const paramsWithoutReply = { ...initialSendParams };
+        Reflect.deleteProperty(paramsWithoutReply, "reply_parameters");
+        const sendParams =
+          replyMessageId === undefined
+            ? initialSendParams
+            : {
+                ...paramsWithoutReply,
+                reply_to_message_id: replyMessageId,
+                allow_sending_without_reply: true,
+              };
         const text = richMessagePlainTextForTest(rich_message);
         const options = Object.keys(sendParams).length > 0 ? sendParams : undefined;
         return await botApi.sendMessage(chat_id, text, options);

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1,6 +1,5 @@
 // Telegram tests cover send plugin behavior.
 import fs from "node:fs";
-import type { Bot } from "grammy";
 import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
@@ -116,6 +115,15 @@ type RichRawTextTestApi = Omit<TelegramApiOverride, "raw" | "sendMessage"> & {
 type RichMessageTestPayload = Parameters<
   NonNullable<NonNullable<RichRawTextTestApi["raw"]>["sendRichMessage"]>
 >[0]["rich_message"];
+
+function createTelegramApiOverride(value: Record<string, unknown>): TelegramApiOverride {
+  for (const [method, implementation] of Object.entries(value)) {
+    if (typeof implementation !== "function") {
+      throw new Error(`expected Telegram API method ${method}`);
+    }
+  }
+  return Reflect.apply((api: TelegramApiOverride) => api, undefined, [value]);
+}
 
 function richTextForTest(richMessage: RichMessageTestPayload): string {
   if (richMessage.blocks) {
@@ -1195,7 +1203,7 @@ describe("sendMessageTelegram", () => {
       {
         cfg,
         token: "tok",
-        api: { sendLocation } as unknown as TelegramApiOverride,
+        api: { sendLocation } satisfies TelegramApiOverride,
         promptContextProjectionPlan: { cursor, finalPart: true },
       },
     );
@@ -1226,9 +1234,7 @@ describe("sendMessageTelegram", () => {
       "</code>",
     ].join("\n");
     const sendMessage = vi.fn().mockResolvedValue({ message_id: 44, chat: { id: chatId } });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = { sendMessage } satisfies TelegramApiOverride;
 
     const res = await sendMessageTelegram(chatId, text, {
       cfg: TELEGRAM_TEST_CFG,
@@ -1261,9 +1267,7 @@ describe("sendMessageTelegram", () => {
         channels: { telegram: { linkPreview: false } },
       };
       loadConfig.mockReturnValue(cfg);
-      const api = { sendMessage: testCase.sendMessage } as unknown as {
-        sendMessage: typeof testCase.sendMessage;
-      };
+      const api = { sendMessage: testCase.sendMessage } satisfies TelegramApiOverride;
       await sendMessageTelegram("123", testCase.text, {
         cfg,
         token: "tok",
@@ -2275,9 +2279,7 @@ describe("sendMessageTelegram", () => {
     const sendMessage = vi.fn().mockResolvedValue({
       chat: { id: "123" },
     });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = { sendMessage } satisfies TelegramApiOverride;
 
     await expect(
       sendMessageTelegram("123", "hi", {
@@ -2293,9 +2295,7 @@ describe("sendMessageTelegram", () => {
     const sendPhoto = vi.fn().mockResolvedValue({
       chat: { id: "123" },
     });
-    const api = { sendPhoto } as unknown as {
-      sendPhoto: typeof sendPhoto;
-    };
+    const api = { sendPhoto } satisfies TelegramApiOverride;
 
     await expect(
       sendMessageTelegram("123", "caption", {
@@ -2310,7 +2310,7 @@ describe("sendMessageTelegram", () => {
   it("uses native fetch for BAN compatibility when api is omitted", async () => {
     const originalFetch = globalThis.fetch;
     const originalBun = (globalThis as { Bun?: unknown }).Bun;
-    const fetchSpy = vi.fn() as unknown as typeof fetch;
+    const fetchSpy = vi.fn<typeof fetch>();
     globalThis.fetch = fetchSpy;
     (globalThis as { Bun?: unknown }).Bun = {};
     botApi.sendMessage.mockResolvedValue({
@@ -2341,9 +2341,7 @@ describe("sendMessageTelegram", () => {
       message_id: 1,
       chat: { id: "123" },
     });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = { sendMessage } satisfies TelegramApiOverride;
 
     await sendMessageTelegram("telegram:123", "hi", {
       cfg: TELEGRAM_TEST_CFG,
@@ -2362,10 +2360,7 @@ describe("sendMessageTelegram", () => {
       chat: { id: "-100123" },
     });
     const getChat = vi.fn().mockResolvedValue({ id: -100123 });
-    const api = { sendMessage, getChat } as unknown as {
-      sendMessage: typeof sendMessage;
-      getChat: typeof getChat;
-    };
+    const api = { sendMessage, getChat } satisfies TelegramApiOverride;
 
     await sendMessageTelegram("https://t.me/mychannel", "hi", {
       cfg: TELEGRAM_TEST_CFG,
@@ -2391,10 +2386,7 @@ describe("sendMessageTelegram", () => {
       chat: { id: "-100123" },
     });
     const getChat = vi.fn().mockResolvedValue({ id: -100123 });
-    const api = { sendMessage, getChat } as unknown as {
-      sendMessage: typeof sendMessage;
-      getChat: typeof getChat;
-    };
+    const api = { sendMessage, getChat } satisfies TelegramApiOverride;
 
     await sendMessageTelegram("https://t.me/mychannel", "hi", {
       cfg: TELEGRAM_TEST_CFG,
@@ -2413,9 +2405,7 @@ describe("sendMessageTelegram", () => {
 
   it("fails clearly when a legacy target cannot be resolved", async () => {
     const getChat = vi.fn().mockRejectedValue(new Error("400: Bad Request: chat not found"));
-    const api = { getChat } as unknown as {
-      getChat: typeof getChat;
-    };
+    const api = { getChat } satisfies TelegramApiOverride;
 
     await expect(
       sendMessageTelegram("@missingchannel", "hi", {
@@ -2433,9 +2423,7 @@ describe("sendMessageTelegram", () => {
       message_thread_id: 99,
       chat: { id: chatId },
     });
-    const api = { sendPhoto } as unknown as {
-      sendPhoto: typeof sendPhoto;
-    };
+    const api = { sendPhoto } satisfies TelegramApiOverride;
 
     mockLoadedMedia({
       buffer: Buffer.from("fake-image"),
@@ -2472,10 +2460,7 @@ describe("sendMessageTelegram", () => {
       message_thread_id: 271,
       chat: { id: chatId },
     });
-    const api = { sendPhoto, sendMessage } as unknown as {
-      sendPhoto: typeof sendPhoto;
-      sendMessage: typeof sendMessage;
-    };
+    const api = { sendPhoto, sendMessage } satisfies TelegramApiOverride;
 
     mockLoadedMedia({
       buffer: Buffer.from("fake-image"),
@@ -2521,7 +2506,7 @@ describe("sendMessageTelegram", () => {
     });
     const sendMessage = vi.fn();
     const onDeliveryResult = vi.fn();
-    const api = { sendPhoto, sendMessage } as unknown as TelegramApiOverride;
+    const api = { sendPhoto, sendMessage } satisfies TelegramApiOverride;
     mockLoadedMedia({ contentType: "image/jpeg", fileName: "photo.jpg" });
 
     let observed: unknown;
@@ -2682,10 +2667,7 @@ describe("sendMessageTelegram", () => {
       message_thread_id: 271,
       chat: { id: chatId },
     });
-    const api = { sendPhoto, sendMessage } as unknown as {
-      sendPhoto: typeof sendPhoto;
-      sendMessage: typeof sendMessage;
-    };
+    const api = { sendPhoto, sendMessage } satisfies TelegramApiOverride;
 
     mockLoadedMedia({
       buffer: Buffer.from("fake-image"),
@@ -2747,10 +2729,7 @@ describe("sendMessageTelegram", () => {
       .mockResolvedValueOnce({ message_id: 73, chat: { id: chatId } })
       .mockResolvedValueOnce({ message_id: 74, chat: { id: chatId } })
       .mockResolvedValueOnce({ message_id: 75, chat: { id: chatId } });
-    const api = { sendPhoto, sendMessage } as unknown as {
-      sendPhoto: typeof sendPhoto;
-      sendMessage: typeof sendMessage;
-    };
+    const api = { sendPhoto, sendMessage } satisfies TelegramApiOverride;
 
     mockLoadedMedia({
       buffer: Buffer.from("fake-image"),
@@ -2814,10 +2793,7 @@ describe("sendMessageTelegram", () => {
       chat: { id: chatId },
     });
     const sendMessage = vi.fn();
-    const api = { sendPhoto, sendMessage } as unknown as {
-      sendPhoto: typeof sendPhoto;
-      sendMessage: typeof sendMessage;
-    };
+    const api = { sendPhoto, sendMessage } satisfies TelegramApiOverride;
 
     mockLoadedMedia({
       buffer: Buffer.from("fake-image"),
@@ -2846,10 +2822,7 @@ describe("sendMessageTelegram", () => {
     const formattedCaption = `**${visibleCaption}**`;
     const sendPhoto = vi.fn().mockResolvedValue({ message_id: 72, chat: { id: chatId } });
     const sendMessage = vi.fn();
-    const api = { sendPhoto, sendMessage } as unknown as {
-      sendPhoto: typeof sendPhoto;
-      sendMessage: typeof sendMessage;
-    };
+    const api = { sendPhoto, sendMessage } satisfies TelegramApiOverride;
 
     mockLoadedMedia({
       buffer: Buffer.from("fake-image"),
@@ -2879,9 +2852,7 @@ describe("sendMessageTelegram", () => {
       message_id: 90,
       chat: { id: chatId },
     });
-    const api = { sendPhoto } as unknown as {
-      sendPhoto: typeof sendPhoto;
-    };
+    const api = { sendPhoto } satisfies TelegramApiOverride;
 
     mockLoadedMedia({
       buffer: Buffer.from("fake-image"),
@@ -2926,9 +2897,7 @@ describe("sendMessageTelegram", () => {
           message_id: 91,
           chat: { id: chatId },
         });
-      const api = { sendPhoto } as unknown as {
-        sendPhoto: typeof sendPhoto;
-      };
+      const api = { sendPhoto } satisfies TelegramApiOverride;
 
       mockLoadedMedia({
         buffer: Buffer.from("fake-image"),
@@ -2977,10 +2946,7 @@ describe("sendMessageTelegram", () => {
         message_id: 102,
         chat: { id: chatId },
       });
-      const api = { sendVideoNote, sendMessage } as unknown as {
-        sendVideoNote: typeof sendVideoNote;
-        sendMessage: typeof sendMessage;
-      };
+      const api = { sendVideoNote, sendMessage } satisfies TelegramApiOverride;
 
       mockLoadedMedia({
         buffer: Buffer.from("fake-video"),
@@ -3014,9 +2980,7 @@ describe("sendMessageTelegram", () => {
         message_id: 201,
         chat: { id: chatId },
       });
-      const api = { sendVideo } as unknown as {
-        sendVideo: typeof sendVideo;
-      };
+      const api = { sendVideo } satisfies TelegramApiOverride;
 
       mockLoadedMedia({
         buffer: Buffer.from("fake-video"),
@@ -3081,7 +3045,7 @@ describe("sendMessageTelegram", () => {
     const chatId = "123";
     const sendLocation = vi.fn().mockResolvedValue({ message_id: 301, chat: { id: chatId } });
     const sendVenue = vi.fn().mockResolvedValue({ message_id: 302, chat: { id: chatId } });
-    const api = { sendLocation, sendVenue } as unknown as TelegramApiOverride;
+    const api = { sendLocation, sendVenue } satisfies TelegramApiOverride;
 
     await sendLocationTelegram(
       chatId,
@@ -3158,7 +3122,7 @@ describe("sendMessageTelegram", () => {
       await sendLocationTelegram(`${chatId}:topic:99`, location, {
         cfg: TELEGRAM_TEST_CFG,
         token: "tok",
-        api: { sendLocation, sendVenue } as unknown as TelegramApiOverride,
+        api: { sendLocation, sendVenue } satisfies TelegramApiOverride,
       });
     } catch (error) {
       observed = error;
@@ -3190,9 +3154,7 @@ describe("sendMessageTelegram", () => {
       message_id: 201,
       chat: { id: chatId },
     });
-    const api = { sendVideo } as unknown as {
-      sendVideo: typeof sendVideo;
-    };
+    const api = { sendVideo } satisfies TelegramApiOverride;
     probeVideoDimensions.mockResolvedValueOnce({ width: 720, height: 1280 });
 
     mockLoadedMedia({
@@ -3227,10 +3189,7 @@ describe("sendMessageTelegram", () => {
       message_id: 102,
       chat: { id: chatId },
     });
-    const api = { sendVideoNote, sendMessage } as unknown as {
-      sendVideoNote: typeof sendVideoNote;
-      sendMessage: typeof sendMessage;
-    };
+    const api = { sendVideoNote, sendMessage } satisfies TelegramApiOverride;
 
     mockLoadedMedia({
       buffer: Buffer.from("fake-video"),
@@ -3301,10 +3260,7 @@ describe("sendMessageTelegram", () => {
         message_id: 302,
         chat: { id: chatId },
       });
-      const api = { sendVideoNote, sendMessage } as unknown as {
-        sendVideoNote: typeof sendVideoNote;
-        sendMessage: typeof sendMessage;
-      };
+      const api = { sendVideoNote, sendMessage } satisfies TelegramApiOverride;
 
       mockLoadedMedia({
         buffer: Buffer.from("fake-video"),
@@ -3363,9 +3319,7 @@ describe("sendMessageTelegram", () => {
         message_id: 1,
         chat: { id: chatId },
       });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = { sendMessage } satisfies TelegramApiOverride;
     const setTimeoutSpy = vi.spyOn(global, "setTimeout");
 
     const promise = sendMessageTelegram(chatId, "hi", {
@@ -3395,9 +3349,7 @@ describe("sendMessageTelegram", () => {
         message_id: 2,
         chat: { id: chatId },
       });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = { sendMessage } satisfies TelegramApiOverride;
     const setTimeoutSpy = vi.spyOn(global, "setTimeout");
 
     const promise = sendMessageTelegram(chatId, "hi", {
@@ -3437,9 +3389,7 @@ describe("sendMessageTelegram", () => {
         message_id: 1,
         chat: { id: chatId },
       });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = { sendMessage } satisfies TelegramApiOverride;
 
     const promise = sendMessageTelegram(chatId, "hi", {
       cfg: TELEGRAM_TEST_CFG,
@@ -3461,7 +3411,7 @@ describe("sendMessageTelegram", () => {
       error: new TelegramRequestNotStartedError(),
     });
     const sendMessage = vi.fn().mockRejectedValue(terminal);
-    const api = { sendMessage } as unknown as { sendMessage: typeof sendMessage };
+    const api = createTelegramApiOverride({ sendMessage });
 
     let observed: unknown;
     try {
@@ -3484,7 +3434,7 @@ describe("sendMessageTelegram", () => {
     const chatId = "123";
     const edgeError = Object.assign(new Error("421 Misdirected Request"), { status: 421 });
     const sendMessage = vi.fn().mockRejectedValue(edgeError);
-    const api = { sendMessage } as unknown as { sendMessage: typeof sendMessage };
+    const api = createTelegramApiOverride({ sendMessage });
 
     await expect(
       sendMessageTelegram(chatId, "hi", {
@@ -3500,9 +3450,7 @@ describe("sendMessageTelegram", () => {
   it("does not retry on non-transient errors", async () => {
     const chatId = "123";
     const sendMessage = vi.fn().mockRejectedValue(new Error("400: Bad Request"));
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = { sendMessage } satisfies TelegramApiOverride;
 
     await expect(
       sendMessageTelegram(chatId, "hi", {
@@ -3522,9 +3470,7 @@ describe("sendMessageTelegram", () => {
       .mockRejectedValueOnce(
         new Error("Network request for 'sendMessage' failed after 1 attempts."),
       );
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = { sendMessage } satisfies TelegramApiOverride;
 
     await expect(
       sendMessageTelegram(chatId, "hi", {
@@ -3543,9 +3489,7 @@ describe("sendMessageTelegram", () => {
       message_id: 9,
       chat: { id: chatId },
     });
-    const api = { sendAnimation } as unknown as {
-      sendAnimation: typeof sendAnimation;
-    };
+    const api = { sendAnimation } satisfies TelegramApiOverride;
 
     mockLoadedMedia({
       buffer: Buffer.from("GIF89a"),
@@ -3796,12 +3740,7 @@ describe("sendMessageTelegram", () => {
     });
     const sendPhoto = vi.fn();
     const sendVideo = vi.fn();
-    const api = { sendAnimation, sendDocument, sendPhoto, sendVideo } as unknown as {
-      sendAnimation: typeof sendAnimation;
-      sendDocument: typeof sendDocument;
-      sendPhoto: typeof sendPhoto;
-      sendVideo: typeof sendVideo;
-    };
+    const api = { sendAnimation, sendDocument, sendPhoto, sendVideo } satisfies TelegramApiOverride;
 
     mockLoadedMedia({
       buffer: testCase.buffer,
@@ -3844,10 +3783,7 @@ describe("sendMessageTelegram", () => {
       chat: { id: chatId },
     });
     const sendPhoto = vi.fn();
-    const api = { sendDocument, sendPhoto } as unknown as {
-      sendDocument: typeof sendDocument;
-      sendPhoto: typeof sendPhoto;
-    };
+    const api = { sendDocument, sendPhoto } satisfies TelegramApiOverride;
 
     imageMetadata.width = width;
     imageMetadata.height = height;
@@ -3884,10 +3820,7 @@ describe("sendMessageTelegram", () => {
       chat: { id: chatId },
     });
     const sendPhoto = vi.fn();
-    const api = { sendDocument, sendPhoto } as unknown as {
-      sendDocument: typeof sendDocument;
-      sendPhoto: typeof sendPhoto;
-    };
+    const api = { sendDocument, sendPhoto } satisfies TelegramApiOverride;
 
     imageMetadata.width = undefined;
     imageMetadata.height = undefined;
@@ -3923,9 +3856,7 @@ describe("sendMessageTelegram", () => {
       message_id: 11,
       chat: { id: chatId },
     });
-    const api = { sendDocument } as unknown as {
-      sendDocument: typeof sendDocument;
-    };
+    const api = { sendDocument } satisfies TelegramApiOverride;
 
     mockLoadedMedia({
       buffer: Buffer.from("%PDF-1.7"),
@@ -4044,10 +3975,7 @@ describe("sendMessageTelegram", () => {
           : {}),
         chat: { id: testCase.chatId },
       });
-      const api = { sendAudio, sendVoice } as unknown as {
-        sendAudio: typeof sendAudio;
-        sendVoice: typeof sendVoice;
-      };
+      const api = { sendAudio, sendVoice } satisfies TelegramApiOverride;
 
       mockLoadedMedia({
         buffer: Buffer.from("audio"),
@@ -4110,9 +4038,7 @@ describe("sendMessageTelegram", () => {
         message_thread_id: 271,
         chat: { id: testCase.chatId },
       });
-      const api = { sendMessage } as unknown as {
-        sendMessage: typeof sendMessage;
-      };
+      const api = { sendMessage } satisfies TelegramApiOverride;
 
       const result = await sendMessageTelegram(testCase.chatId, testCase.text, {
         cfg: TELEGRAM_TEST_CFG,
@@ -4143,7 +4069,7 @@ describe("sendMessageTelegram", () => {
       await sendMessageTelegram(chatId, "hello forum", {
         cfg: TELEGRAM_TEST_CFG,
         token: "tok",
-        api: { sendMessage } as unknown as TelegramApiOverride,
+        api: { sendMessage } satisfies TelegramApiOverride,
         messageThreadId: 271,
         onDeliveryResult,
       });
@@ -4179,7 +4105,7 @@ describe("sendMessageTelegram", () => {
       await sendMessageTelegram(chatId, "A".repeat(9000), {
         cfg: TELEGRAM_TEST_CFG,
         token: "tok",
-        api: { sendMessage } as unknown as TelegramApiOverride,
+        api: { sendMessage } satisfies TelegramApiOverride,
         textMode: "html",
         messageThreadId: 271,
         buttons: [[{ text: "OK", callback_data: "ok" }]],
@@ -4209,7 +4135,7 @@ describe("sendMessageTelegram", () => {
       sendMessageTelegram("123456789", "hello private topic", {
         cfg: TELEGRAM_TEST_CFG,
         token: "tok",
-        api: { sendMessage } as unknown as TelegramApiOverride,
+        api: { sendMessage } satisfies TelegramApiOverride,
         messageThreadId: 1,
       }),
     ).rejects.toThrow("topic unknown; expected topic 1");
@@ -4233,9 +4159,7 @@ describe("sendMessageTelegram", () => {
         message_thread_id: 271,
         chat: { id: "-1001234567890" },
       });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = { sendMessage } satisfies TelegramApiOverride;
 
     const result = await sendMessageTelegram("-1001234567890", `BEGIN ${"A".repeat(4100)} END`, {
       cfg: TELEGRAM_TEST_CFG,
@@ -4294,9 +4218,7 @@ describe("sendMessageTelegram", () => {
       .mockResolvedValueOnce({ message_id: 101, chat: { id: "-1001234567890" } })
       .mockResolvedValueOnce({ message_id: 102, chat: { id: "-1001234567890" } })
       .mockResolvedValueOnce({ message_id: 103, chat: { id: "-1001234567890" } });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = { sendMessage } satisfies TelegramApiOverride;
 
     await sendMessageTelegram("-1001234567890", `BEGIN ${"A".repeat(4100)} END`, {
       cfg: TELEGRAM_TEST_CFG,
@@ -4322,9 +4244,7 @@ describe("sendMessageTelegram", () => {
 
     for (const testCase of cases) {
       const sendMessage = vi.fn().mockRejectedValueOnce(threadErr);
-      const api = { sendMessage } as unknown as {
-        sendMessage: typeof sendMessage;
-      };
+      const api = { sendMessage } satisfies TelegramApiOverride;
 
       await expect(
         sendMessageTelegram(testCase.chatId, testCase.text, {
@@ -4346,9 +4266,7 @@ describe("sendMessageTelegram", () => {
   it("does not retry private DM topic sends without the topic id", async () => {
     const threadErr = new Error("400: Bad Request: message thread not found");
     const sendMessage = vi.fn().mockRejectedValueOnce(threadErr);
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = { sendMessage } satisfies TelegramApiOverride;
 
     await expect(
       sendMessageTelegram("123456789", "hello private", {
@@ -4398,9 +4316,7 @@ describe("sendMessageTelegram", () => {
 
     for (const testCase of cases) {
       const sendMessage = vi.fn().mockRejectedValueOnce(testCase.error);
-      const api = { sendMessage } as unknown as {
-        sendMessage: typeof sendMessage;
-      };
+      const api = { sendMessage } satisfies TelegramApiOverride;
 
       await expect(
         sendMessageTelegram(testCase.chatId, testCase.text, {
@@ -4422,9 +4338,7 @@ describe("sendMessageTelegram", () => {
       message_id: 1,
       chat: { id: chatId },
     });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = { sendMessage } satisfies TelegramApiOverride;
 
     await sendMessageTelegram(chatId, "hi", {
       cfg: TELEGRAM_TEST_CFG,
@@ -4446,9 +4360,7 @@ describe("sendMessageTelegram", () => {
       message_thread_id: 271,
       chat: { id: chatId },
     });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = { sendMessage } satisfies TelegramApiOverride;
 
     await sendMessageTelegram(`telegram:group:${chatId}:topic:271`, "hello forum", {
       cfg: TELEGRAM_TEST_CFG,
@@ -4471,9 +4383,7 @@ describe("sendMessageTelegram", () => {
       message_thread_id: 271,
       chat: { id: chatId },
     });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = { sendMessage } satisfies TelegramApiOverride;
 
     await sendMessageTelegram(`telegram:group:${chatId}:topic:271`, body, {
       cfg: TELEGRAM_TEST_CFG,
@@ -4503,9 +4413,7 @@ describe("sendMessageTelegram", () => {
     const body = "topic reply body should stay private";
     const threadErr = new Error("400: Bad Request: message thread not found");
     const sendMessage = vi.fn().mockRejectedValueOnce(threadErr);
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = { sendMessage } satisfies TelegramApiOverride;
 
     await expect(
       sendMessageTelegram(`telegram:group:${chatId}:topic:271`, body, {
@@ -4537,9 +4445,7 @@ describe("sendMessageTelegram", () => {
       message_thread_id: 45,
       chat: { id: chatId },
     });
-    const api = { sendPhoto } as unknown as {
-      sendPhoto: typeof sendPhoto;
-    };
+    const api = { sendPhoto } satisfies TelegramApiOverride;
 
     mockLoadedMedia({
       buffer: Buffer.from("fake-image"),
@@ -4574,9 +4480,7 @@ describe("sendMessageTelegram", () => {
     const chatId = "-100123";
     const threadErr = new Error("400: Bad Request: message thread not found");
     const sendPhoto = vi.fn().mockRejectedValueOnce(threadErr);
-    const api = { sendPhoto } as unknown as {
-      sendPhoto: typeof sendPhoto;
-    };
+    const api = { sendPhoto } satisfies TelegramApiOverride;
 
     mockLoadedMedia({
       buffer: Buffer.from("fake-image"),
@@ -4619,9 +4523,7 @@ describe("sendMessageTelegram", () => {
       message_id: 60,
       chat: { id: chatId },
     });
-    const api = { sendPhoto } as unknown as {
-      sendPhoto: typeof sendPhoto;
-    };
+    const api = { sendPhoto } satisfies TelegramApiOverride;
 
     mockLoadedMedia({
       buffer: Buffer.from("fake-image"),
@@ -4654,9 +4556,7 @@ describe("sendMessageTelegram", () => {
       message_id: 61,
       chat: { id: chatId },
     });
-    const api = { sendPhoto } as unknown as {
-      sendPhoto: typeof sendPhoto;
-    };
+    const api = { sendPhoto } satisfies TelegramApiOverride;
     const cfg = {
       channels: {
         telegram: {
@@ -4692,7 +4592,7 @@ describe("sendMessageTelegram", () => {
     const htmlText = `<b>${"A".repeat(5000)}</b>`;
 
     const sendMessage = vi.fn().mockResolvedValue({ message_id: 91, chat: { id: chatId } });
-    const api = { sendMessage } as unknown as { sendMessage: typeof sendMessage };
+    const api = { sendMessage } satisfies TelegramApiOverride;
 
     const res = await sendMessageTelegram(chatId, htmlText, {
       cfg: TELEGRAM_TEST_CFG,
@@ -4716,7 +4616,7 @@ describe("sendMessageTelegram", () => {
     const markdownText = `**${"A".repeat(5000)}**`;
 
     const sendMessage = vi.fn().mockResolvedValue({ message_id: 91, chat: { id: chatId } });
-    const api = { sendMessage } as unknown as { sendMessage: typeof sendMessage };
+    const api = { sendMessage } satisfies TelegramApiOverride;
 
     const res = await sendMessageTelegram(chatId, markdownText, {
       cfg: TELEGRAM_TEST_CFG,
@@ -4768,9 +4668,7 @@ describe("reactMessageTelegram", () => {
     },
   ] as const)("$testName", async (testCase) => {
     const setMessageReaction = vi.fn().mockResolvedValue(undefined);
-    const api = { setMessageReaction } as unknown as {
-      setMessageReaction: typeof setMessageReaction;
-    };
+    const api = { setMessageReaction } satisfies TelegramApiOverride;
 
     await reactMessageTelegram(testCase.target, testCase.messageId, testCase.emoji, {
       cfg: TELEGRAM_TEST_CFG,
@@ -4785,10 +4683,7 @@ describe("reactMessageTelegram", () => {
   it("resolves legacy telegram targets before reacting", async () => {
     const setMessageReaction = vi.fn().mockResolvedValue(undefined);
     const getChat = vi.fn().mockResolvedValue({ id: -100123 });
-    const api = { setMessageReaction, getChat } as unknown as {
-      setMessageReaction: typeof setMessageReaction;
-      getChat: typeof getChat;
-    };
+    const api = { setMessageReaction, getChat } satisfies TelegramApiOverride;
 
     await reactMessageTelegram("@mychannel", 456, "✅", {
       cfg: TELEGRAM_TEST_CFG,
@@ -4815,7 +4710,7 @@ describe("deleteMessageTelegram", () => {
     "MESSAGE_DELETE_FORBIDDEN",
   ] as const)("returns a warning for benign delete no-op error: %s", async (message) => {
     const deleteMessage = vi.fn().mockRejectedValue(new Error(message));
-    const api = { deleteMessage } as unknown as { deleteMessage: typeof deleteMessage };
+    const api = { deleteMessage } satisfies TelegramApiOverride;
 
     const result = await deleteMessageTelegram("123", 456, {
       cfg: TELEGRAM_TEST_CFG,
@@ -4833,7 +4728,7 @@ describe("deleteMessageTelegram", () => {
 
   it("throws non-benign delete errors", async () => {
     const deleteMessage = vi.fn().mockRejectedValue(new Error("500: Internal Server Error"));
-    const api = { deleteMessage } as unknown as { deleteMessage: typeof deleteMessage };
+    const api = { deleteMessage } satisfies TelegramApiOverride;
 
     await expect(
       deleteMessageTelegram("123", 456, {
@@ -4846,7 +4741,7 @@ describe("deleteMessageTelegram", () => {
 
   it("rejects partial message id strings", async () => {
     const deleteMessage = vi.fn();
-    const api = { deleteMessage } as unknown as { deleteMessage: typeof deleteMessage };
+    const api = { deleteMessage } satisfies TelegramApiOverride;
 
     await expect(
       deleteMessageTelegram("123", "456abc", {
@@ -4882,9 +4777,7 @@ describe("sendStickerTelegram", () => {
         message_id: testCase.expectedMessageId,
         chat: { id: chatId },
       });
-      const api = { sendSticker } as unknown as {
-        sendSticker: typeof sendSticker;
-      };
+      const api = { sendSticker } satisfies TelegramApiOverride;
 
       const res = await sendStickerTelegram(chatId, testCase.fileId, {
         cfg: TELEGRAM_TEST_CFG,
@@ -4908,7 +4801,7 @@ describe("sendStickerTelegram", () => {
       message_thread_id: 77,
       sticker: { file_id: "fileId123", file_unique_id: "unique", type: "regular" },
     });
-    const api = { sendSticker } as unknown as { sendSticker: typeof sendSticker };
+    const api = { sendSticker } satisfies TelegramApiOverride;
 
     await sendStickerTelegram(`${chatId}:topic:77`, "fileId123", {
       cfg: { session: { store: storePath } },
@@ -4941,9 +4834,7 @@ describe("sendStickerTelegram", () => {
     const chatId = "-100123";
     const threadErr = new Error("400: Bad Request: message thread not found");
     const sendSticker = vi.fn().mockRejectedValueOnce(threadErr);
-    const api = { sendSticker } as unknown as {
-      sendSticker: typeof sendSticker;
-    };
+    const api = { sendSticker } satisfies TelegramApiOverride;
 
     await expect(
       sendStickerTelegram(chatId, "fileId123", {
@@ -4965,9 +4856,7 @@ describe("sendStickerTelegram", () => {
     const sendSticker = vi.fn().mockResolvedValue({
       chat: { id: chatId },
     });
-    const api = { sendSticker } as unknown as {
-      sendSticker: typeof sendSticker;
-    };
+    const api = { sendSticker } satisfies TelegramApiOverride;
 
     await expect(
       sendStickerTelegram(chatId, "fileId123", {
@@ -4983,9 +4872,7 @@ describe("sendStickerTelegram", () => {
     const sendSticker = vi
       .fn()
       .mockRejectedValueOnce(new Error("Network request for 'sendSticker' failed!"));
-    const api = { sendSticker } as unknown as {
-      sendSticker: typeof sendSticker;
-    };
+    const api = { sendSticker } satisfies TelegramApiOverride;
 
     await expect(
       sendStickerTelegram(chatId, "fileId123", {
@@ -5011,9 +4898,7 @@ describe("sendStickerTelegram", () => {
         message_id: 109,
         chat: { id: chatId },
       });
-    const api = { sendSticker } as unknown as {
-      sendSticker: typeof sendSticker;
-    };
+    const api = { sendSticker } satisfies TelegramApiOverride;
     const setTimeoutSpy = vi.spyOn(global, "setTimeout");
 
     const promise = sendStickerTelegram(chatId, "fileId123", {
@@ -5043,9 +4928,7 @@ describe("shared send behaviors", () => {
             message_id: 56,
             chat: { id: chatId },
           });
-          const api = { sendMessage } as unknown as {
-            sendMessage: typeof sendMessage;
-          };
+          const api = { sendMessage } satisfies TelegramApiOverride;
           await sendMessageTelegram(chatId, "reply text", {
             cfg: TELEGRAM_TEST_CFG,
             token: "tok",
@@ -5068,9 +4951,7 @@ describe("shared send behaviors", () => {
             message_id: 102,
             chat: { id: chatId },
           });
-          const api = { sendSticker } as unknown as {
-            sendSticker: typeof sendSticker;
-          };
+          const api = { sendSticker } satisfies TelegramApiOverride;
           await sendStickerTelegram(chatId, fileId, {
             cfg: TELEGRAM_TEST_CFG,
             token: "tok",
@@ -5096,9 +4977,7 @@ describe("shared send behaviors", () => {
       message_id: 56,
       chat: { id: chatId },
     });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = { sendMessage } satisfies TelegramApiOverride;
 
     await sendMessageTelegram(chatId, "reply text", {
       cfg: TELEGRAM_TEST_CFG,
@@ -5127,9 +5006,7 @@ describe("shared send behaviors", () => {
         message_id: 57,
         chat: { id: chatId },
       });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
+    const api = { sendMessage } satisfies TelegramApiOverride;
 
     await sendMessageTelegram(chatId, "reply text", {
       cfg: TELEGRAM_TEST_CFG,
@@ -5170,7 +5047,7 @@ describe("shared send behaviors", () => {
         chat: { id: chatId, type: "private" },
         photo: [{ file_id: "photo-file", file_unique_id: "photo-unique", width: 10, height: 10 }],
       });
-    const api = { sendPhoto } as unknown as { sendPhoto: typeof sendPhoto };
+    const api = { sendPhoto } satisfies TelegramApiOverride;
     mockLoadedMedia({
       buffer: Buffer.from("fake-image"),
       contentType: "image/jpeg",
@@ -5229,23 +5106,24 @@ describe("shared send behaviors", () => {
         message_id: 102,
         chat: { id: chatId },
       });
-      const api = { sendMessage, sendSticker } as unknown as {
-        sendMessage: typeof sendMessage;
-        sendSticker: typeof sendSticker;
-      };
+      const api = { sendMessage, sendSticker } satisfies TelegramApiOverride;
 
-      await sendMessageTelegram(chatId, "reply text", {
+      const invalidReplyOptions = {
         cfg: TELEGRAM_TEST_CFG,
         token: "tok",
         api,
-        replyToMessageId: invalidReplyToMessageId as unknown as number,
-      });
-      await sendStickerTelegram(chatId, "CAACAgIAAxkBAAI...sticker_file_id", {
-        cfg: TELEGRAM_TEST_CFG,
-        token: "tok",
-        api,
-        replyToMessageId: invalidReplyToMessageId as unknown as number,
-      });
+        replyToMessageId: invalidReplyToMessageId,
+      };
+      await Reflect.apply(sendMessageTelegram, undefined, [
+        chatId,
+        "reply text",
+        invalidReplyOptions,
+      ]);
+      await Reflect.apply(sendStickerTelegram, undefined, [
+        chatId,
+        "CAACAgIAAxkBAAI...sticker_file_id",
+        invalidReplyOptions,
+      ]);
 
       expect(sendMessage, String(invalidReplyToMessageId)).toHaveBeenCalledWith(
         chatId,
@@ -5270,9 +5148,7 @@ describe("shared send behaviors", () => {
           const chatId = "123";
           const err = new Error("400: Bad Request: chat not found");
           const sendMessage = vi.fn().mockRejectedValue(err);
-          const api = { sendMessage } as unknown as {
-            sendMessage: typeof sendMessage;
-          };
+          const api = { sendMessage } satisfies TelegramApiOverride;
           await expectChatNotFoundWithChatId(
             sendMessageTelegram(chatId, "hi", { cfg: TELEGRAM_TEST_CFG, token: "tok", api }),
             chatId,
@@ -5285,9 +5161,7 @@ describe("shared send behaviors", () => {
           const chatId = "123";
           const err = new Error("400: Bad Request: chat not found");
           const sendSticker = vi.fn().mockRejectedValue(err);
-          const api = { sendSticker } as unknown as {
-            sendSticker: typeof sendSticker;
-          };
+          const api = { sendSticker } satisfies TelegramApiOverride;
           await expectChatNotFoundWithChatId(
             sendStickerTelegram(chatId, "fileId123", { cfg: TELEGRAM_TEST_CFG, token: "tok", api }),
             chatId,
@@ -5308,9 +5182,7 @@ describe("shared send behaviors", () => {
         errorText: "403: Forbidden: bot is not a member of the channel chat",
         run: async (chatId: string, err: Error) => {
           const sendMessage = vi.fn().mockRejectedValue(err);
-          const api = { sendMessage } as unknown as {
-            sendMessage: typeof sendMessage;
-          };
+          const api = { sendMessage } satisfies TelegramApiOverride;
           await expectTelegramMembershipErrorWithChatId(
             sendMessageTelegram(chatId, "hi", { cfg: TELEGRAM_TEST_CFG, token: "tok", api }),
             chatId,
@@ -5323,9 +5195,7 @@ describe("shared send behaviors", () => {
         errorText: "403: Forbidden: bot was kicked from the group chat",
         run: async (chatId: string, err: Error) => {
           const sendSticker = vi.fn().mockRejectedValue(err);
-          const api = { sendSticker } as unknown as {
-            sendSticker: typeof sendSticker;
-          };
+          const api = { sendSticker } satisfies TelegramApiOverride;
           await expectTelegramMembershipErrorWithChatId(
             sendStickerTelegram(chatId, "fileId123", { cfg: TELEGRAM_TEST_CFG, token: "tok", api }),
             chatId,
@@ -5356,7 +5226,7 @@ describe("editMessageTelegram", () => {
       text: "hi",
       buttons: [] as Parameters<typeof buildInlineKeyboard>[0],
       expectedCalls: 1,
-      firstExpectReplyMarkup: { inline_keyboard: [] } as Record<string, unknown>,
+      firstExpectReplyMarkup: { inline_keyboard: [] } satisfies Record<string, unknown>,
       parseFallback: false,
     },
     {
@@ -5364,7 +5234,7 @@ describe("editMessageTelegram", () => {
       text: "<bad> html",
       buttons: [] as Parameters<typeof buildInlineKeyboard>[0],
       expectedCalls: 1,
-      firstExpectReplyMarkup: { inline_keyboard: [] } as Record<string, unknown>,
+      firstExpectReplyMarkup: { inline_keyboard: [] } satisfies Record<string, unknown>,
       parseFallback: false,
     },
   ])("$name", async (testCase) => {
@@ -5791,7 +5661,7 @@ describe("sendPollTelegram", () => {
     await sendPollTelegram(
       "123",
       { question: "Q", options },
-      { cfg: TELEGRAM_TEST_CFG, token: "t", api: api as unknown as Bot["api"] },
+      { cfg: TELEGRAM_TEST_CFG, token: "t", api: createTelegramApiOverride(api) },
     );
 
     expect(firstMockCall(api.sendPoll, "send poll call")[2]).toEqual(options);
@@ -5805,7 +5675,7 @@ describe("sendPollTelegram", () => {
       chat: { id: chatId, type: "supergroup" },
       poll: { id: "p2", question: "Q", options: [] },
     });
-    const api = { sendPoll } as unknown as Bot["api"];
+    const api = { sendPoll } satisfies TelegramApiOverride;
 
     await sendPollTelegram(
       `${chatId}:topic:1`,
@@ -5835,7 +5705,7 @@ describe("sendPollTelegram", () => {
       {
         cfg: TELEGRAM_TEST_CFG,
         token: "t",
-        api: api as unknown as Bot["api"],
+        api: createTelegramApiOverride(api),
         gatewayClientScopes: ["operator.admin"],
       },
     );
@@ -5856,7 +5726,7 @@ describe("sendPollTelegram", () => {
     const res = await sendPollTelegram(
       "123",
       { question: " Q ", options: [" A ", "B "], durationSeconds: 60 },
-      { cfg: TELEGRAM_TEST_CFG, token: "t", api: api as unknown as Bot["api"] },
+      { cfg: TELEGRAM_TEST_CFG, token: "t", api: createTelegramApiOverride(api) },
     );
 
     expect(res).toMatchObject({
@@ -6229,7 +6099,7 @@ describe("sendPollTelegram", () => {
         {
           cfg: TELEGRAM_TEST_CFG,
           token: "t",
-          api: api as unknown as Bot["api"],
+          api: createTelegramApiOverride(api),
         },
       ),
     ).resolves.toMatchObject({
@@ -6242,16 +6112,15 @@ describe("sendPollTelegram", () => {
 
   it("does not retry an already-sent poll when origin storage fails", async () => {
     const pollRegistryKey = "default:poll-write-error";
-    const register = vi.fn(async (key: string) => {
+    const store = await installPollRegistryStore();
+    const register = vi.spyOn(store, "register").mockImplementation(async (key: string) => {
       if (key === pollRegistryKey) {
         throw new Error("registry db unavailable");
       }
     });
     setTelegramRuntime({
       state: {
-        openKeyedStore: (() => ({
-          register,
-        })) as unknown as TelegramRuntime["state"]["openKeyedStore"],
+        openKeyedStore: (() => store) as TelegramRuntime["state"]["openKeyedStore"],
         openSyncKeyedStore: (() =>
           sentMessageStore) as TelegramRuntime["state"]["openSyncKeyedStore"],
       },
@@ -6272,7 +6141,7 @@ describe("sendPollTelegram", () => {
         {
           cfg: TELEGRAM_TEST_CFG,
           token: "t",
-          api: api as unknown as Bot["api"],
+          api: createTelegramApiOverride(api),
           isAnonymous: false,
         },
       ),
@@ -6302,7 +6171,7 @@ describe("sendPollTelegram", () => {
         {
           cfg: TELEGRAM_TEST_CFG,
           token: "t",
-          api: api as unknown as Bot["api"],
+          api: api satisfies TelegramApiOverride,
           messageThreadId: 99,
         },
       ),
@@ -6322,7 +6191,7 @@ describe("sendPollTelegram", () => {
       sendPollTelegram(
         "123",
         { question: "Q", options: ["A", "B"], durationHours: 1 },
-        { cfg: TELEGRAM_TEST_CFG, token: "t", api: api as unknown as Bot["api"] },
+        { cfg: TELEGRAM_TEST_CFG, token: "t", api: createTelegramApiOverride(api) },
       ),
     ).rejects.toThrow(/durationHours is not supported/i);
 
@@ -6338,7 +6207,7 @@ describe("sendPollTelegram", () => {
       sendPollTelegram(
         "123",
         { question: "Q", options: ["A", "B"] },
-        { cfg: TELEGRAM_TEST_CFG, token: "t", api: api as unknown as Bot["api"] },
+        { cfg: TELEGRAM_TEST_CFG, token: "t", api: createTelegramApiOverride(api) },
       ),
     ).rejects.toThrow(/returned no message_id/i);
   });
@@ -6383,7 +6252,7 @@ describe("createForumTopicTelegram", () => {
   for (const testCase of cases) {
     it(testCase.name, async () => {
       const createForumTopic = vi.fn().mockResolvedValue(testCase.response);
-      const api = { createForumTopic } as unknown as Bot["api"];
+      const api = { createForumTopic } satisfies TelegramApiOverride;
 
       const result = await createForumTopicTelegram(testCase.target, testCase.title, {
         cfg: TELEGRAM_TEST_CFG,
@@ -6404,7 +6273,7 @@ describe("createForumTopicTelegram", () => {
     ["128 CJK characters", "界".repeat(128)],
   ])("accepts %s forum topic names by Unicode code points", async (_label, name) => {
     const createForumTopic = vi.fn().mockResolvedValue({ message_thread_id: 400, name });
-    const api = { createForumTopic } as unknown as Bot["api"];
+    const api = { createForumTopic } satisfies TelegramApiOverride;
 
     await createForumTopicTelegram("-1001234567890", name, {
       cfg: TELEGRAM_TEST_CFG,
@@ -6434,7 +6303,7 @@ describe("createForumTopicTelegram", () => {
   ])("rejects %s exceeding 128 Unicode code points on create and edit", async (_label, name) => {
     const createForumTopic = vi.fn();
     const editForumTopic = vi.fn();
-    const api = { createForumTopic, editForumTopic } as unknown as Bot["api"];
+    const api = { createForumTopic, editForumTopic } satisfies TelegramApiOverride;
 
     await expect(
       createForumTopicTelegram("-1001234567890", name, {

--- a/extensions/telegram/src/sequential-key.test.ts
+++ b/extensions/telegram/src/sequential-key.test.ts
@@ -16,6 +16,14 @@ const mockMessage = (message: Pick<Message, "chat"> & Partial<Message>): Message
   }) as Message;
 
 describe("getTelegramSequentialKey", () => {
+  it("uses the unknown lane for malformed messages without chat facts", () => {
+    expect(
+      Reflect.apply(getTelegramSequentialKey, undefined, [
+        { update: { message: { text: "hello" } } },
+      ]),
+    ).toBe("telegram:unknown");
+  });
+
   it.each([
     [{ message: mockMessage({ chat: mockChat({ id: 123 }) }) }, "telegram:123"],
     [

--- a/extensions/telegram/src/shared.test.ts
+++ b/extensions/telegram/src/shared.test.ts
@@ -28,6 +28,22 @@ function resolveAccount(cfg: OpenClawConfig, accountId: string): ResolvedTelegra
   return telegramPluginBase.config.resolveAccount(cfg, accountId);
 }
 
+function resolveAllowFromFromRawConfig(cfg: object) {
+  const resolve = telegramConfigAdapter.resolveAllowFrom;
+  if (!resolve) {
+    throw new Error("expected Telegram allowFrom resolver");
+  }
+  return Reflect.apply(resolve, telegramConfigAdapter, [{ cfg, accountId: "default" }]);
+}
+
+function resolveDefaultToFromRawConfig(cfg: object) {
+  const resolve = telegramConfigAdapter.resolveDefaultTo;
+  if (!resolve) {
+    throw new Error("expected Telegram default target resolver");
+  }
+  return Reflect.apply(resolve, telegramConfigAdapter, [{ cfg, accountId: "default" }]);
+}
+
 describe("createTelegramPluginBase config duplicate token guard", () => {
   it("wires the top-level models menu adapter into the production plugin", () => {
     const channelData = telegramPluginBase.commands?.buildModelsMenuChannelData?.({
@@ -191,13 +207,9 @@ describe("createTelegramPluginBase config duplicate token guard", () => {
           defaultTo: "1498959610751750304",
         },
       },
-    } as unknown as OpenClawConfig;
+    };
 
-    expect(telegramConfigAdapter.resolveAllowFrom?.({ cfg, accountId: "default" })).toEqual([
-      "1128540374256849009",
-    ]);
-    expect(telegramConfigAdapter.resolveDefaultTo?.({ cfg, accountId: "default" })).toBe(
-      "1498959610751750304",
-    );
+    expect(resolveAllowFromFromRawConfig(cfg)).toEqual(["1128540374256849009"]);
+    expect(resolveDefaultToFromRawConfig(cfg)).toBe("1498959610751750304");
   });
 });

--- a/extensions/telegram/src/state-migrations.ts
+++ b/extensions/telegram/src/state-migrations.ts
@@ -435,10 +435,15 @@ function detectTelegramThreadBindingLegacyStateMigration(params: {
   });
 }
 
+type TelegramTopicNameCacheImportSource = {
+  sourcePath: string;
+  namespace: string;
+};
+
 function topicNameCacheImportSource(params: {
   sourceStorePath: string;
   targetStorePath?: string;
-}): { sourcePath: string; namespace: string } {
+}): TelegramTopicNameCacheImportSource {
   const targetStorePath = params.targetStorePath ?? params.sourceStorePath;
   const scope = resolveTopicNameCacheScope(targetStorePath);
   return {

--- a/extensions/telegram/src/status-reaction-variants.ts
+++ b/extensions/telegram/src/status-reaction-variants.ts
@@ -93,7 +93,7 @@ const TELEGRAM_SUPPORTED_REACTION_EMOJIS = new Set<TelegramReactionEmoji>(
   TELEGRAM_SUPPORTED_REACTION_EMOJI_LIST,
 );
 
-const TELEGRAM_STATUS_REACTION_VARIANTS: Record<StatusReactionEmojiKey, string[]> = {
+const TELEGRAM_STATUS_REACTION_VARIANTS = {
   queued: ["👀", "👍", "🔥"],
   thinking: ["🤔", "🤓", "👀"],
   tool: ["🔥", "⚡", "👍"],
@@ -107,7 +107,7 @@ const TELEGRAM_STATUS_REACTION_VARIANTS: Record<StatusReactionEmojiKey, string[]
   stallSoft: ["🥱", "😴", "🤔"],
   stallHard: ["😨", "😱", "⚡"],
   compacting: ["✍", "🤔", "🤯"],
-};
+} satisfies Record<StatusReactionEmojiKey, TelegramReactionEmoji[]>;
 
 const STATUS_REACTION_EMOJI_KEYS: StatusReactionEmojiKey[] = [
   "queued",

--- a/extensions/telegram/src/sticker-cache-store.ts
+++ b/extensions/telegram/src/sticker-cache-store.ts
@@ -14,6 +14,12 @@ export type { CachedSticker };
 
 type TelegramStickerCacheStore = PluginStateSyncKeyedStore<CachedSticker>;
 
+type TelegramStickerCacheStats = {
+  count: number;
+  oldestAt?: string;
+  newestAt?: string;
+};
+
 function openStickerCacheStore(): TelegramStickerCacheStore {
   return getTelegramRuntime().state.openSyncKeyedStore<CachedSticker>({
     namespace: TELEGRAM_STICKER_CACHE_NAMESPACE,
@@ -118,7 +124,7 @@ export function getAllCachedStickers(): CachedSticker[] {
 /**
  * Get cache statistics.
  */
-export function getCacheStats(): { count: number; oldestAt?: string; newestAt?: string } {
+export function getCacheStats(): TelegramStickerCacheStats {
   const stickers = getAllCachedStickers();
   if (stickers.length === 0) {
     return { count: 0 };

--- a/extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts
+++ b/extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts
@@ -154,7 +154,7 @@ function forwardedTextUpdate(params: { updateId: number; messageId: number; text
 
 function createBotApiTransport(params: { onGetFile?: (call: number) => Response } = {}) {
   let getFileCall = 0;
-  const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+  const fetchImpl = vi.fn<typeof fetch>(async (input: RequestInfo | URL) => {
     const url = input instanceof Request ? input.url : input instanceof URL ? input.href : input;
     if (url.includes("/getFile")) {
       getFileCall += 1;
@@ -178,7 +178,7 @@ function createBotApiTransport(params: { onGetFile?: (call: number) => Response 
       status: 200,
       headers: { "content-type": "application/json" },
     });
-  }) as unknown as typeof fetch;
+  });
   return { fetch: fetchImpl, sourceFetch: fetchImpl, close: async () => {} };
 }
 

--- a/extensions/telegram/src/telegram-ingress-drain.test.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.test.ts
@@ -18,6 +18,10 @@ import {
 } from "./telegram-ingress-spool.payload.js";
 import { telegramSpooledUpdateLaneKey } from "./telegram-ingress-spool.test-support.js";
 
+interface DeferredParticipantSlot {
+  current?: TelegramSpooledReplayDeferredParticipant;
+}
+
 async function withTempState<T>(fn: (stateDir: string) => Promise<T>): Promise<T> {
   const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-ingress-drain-"));
   try {
@@ -177,7 +181,7 @@ describe("createTelegramIngressMonitor", () => {
       const payload = updatePayload(4);
       const laneKey = telegramSpooledUpdateLaneKey(payload.update);
       await queue.enqueue(eventId, payload, { laneKey });
-      const participant: { current?: TelegramSpooledReplayDeferredParticipant } = {};
+      const participant: DeferredParticipantSlot = {};
       const monitor = createTelegramIngressMonitor({
         queue,
         cfg,
@@ -216,7 +220,7 @@ describe("createTelegramIngressMonitor", () => {
       const payload = updatePayload(5);
       const laneKey = telegramSpooledUpdateLaneKey(payload.update);
       await queue.enqueue(eventId, payload, { laneKey });
-      const participant: { current?: TelegramSpooledReplayDeferredParticipant } = {};
+      const participant: DeferredParticipantSlot = {};
       const monitor = createTelegramIngressMonitor({
         queue,
         cfg,
@@ -257,7 +261,7 @@ describe("createTelegramIngressMonitor", () => {
         const payload = updatePayload(updateId);
         const laneKey = telegramSpooledUpdateLaneKey(payload.update);
         await queue.enqueue(eventId, payload, { laneKey });
-        const participant: { current?: TelegramSpooledReplayDeferredParticipant } = {};
+        const participant: DeferredParticipantSlot = {};
         const monitor = createTelegramIngressMonitor({
           queue,
           cfg,

--- a/extensions/telegram/src/telegram-ingress-spool.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.ts
@@ -8,6 +8,11 @@ import { getTelegramRuntime } from "./runtime.js";
 import { normalizeTelegramStateAccountId } from "./state-account-id.js";
 import type { TelegramSpooledUpdatePayload } from "./telegram-ingress-spool.payload.js";
 const TELEGRAM_INGRESS_SPOOL_PREFIX = "ingress-spool-";
+
+type TelegramIngressQueueParts = {
+  accountId: string;
+  stateDir: string;
+};
 const TELEGRAM_SPOOLED_COMPLETION_RETRY_POLICY: BackoffPolicy = {
   initialMs: 250,
   maxMs: 5_000,
@@ -43,10 +48,7 @@ export function telegramQueueEventId(updateId: number): string {
   return String(updateId).padStart(16, "0");
 }
 
-function resolveQueueParts(spoolDir: string): {
-  accountId: string;
-  stateDir: string;
-} {
+function resolveQueueParts(spoolDir: string): TelegramIngressQueueParts {
   const basename = path.basename(spoolDir);
   const accountId = normalizeTelegramStateAccountId(
     basename.startsWith(TELEGRAM_INGRESS_SPOOL_PREFIX)

--- a/extensions/telegram/src/telegram-ingress-supersede-auth.ts
+++ b/extensions/telegram/src/telegram-ingress-supersede-auth.ts
@@ -26,6 +26,11 @@ type RawTelegramChat = {
   is_forum?: unknown;
 };
 
+type RawTelegramSender = {
+  id?: unknown;
+  username?: unknown;
+};
+
 function extractTelegramChatType(value: unknown): TelegramMessageThreadFacts["chat"]["type"] {
   switch (value) {
     case "channel":
@@ -71,10 +76,16 @@ function extractUpdateSenderFacts(update: unknown): UpdateSenderFacts | null {
   }
   const root = update as Record<string, unknown>;
   let message: Record<string, unknown> | undefined;
+  let from: RawTelegramSender | undefined;
   for (const key of ["message", "edited_message", "channel_post", "edited_channel_post"] as const) {
     const candidate = root[key];
     if (candidate && typeof candidate === "object") {
       message = candidate as Record<string, unknown>;
+      const candidateFrom = message.from;
+      from =
+        candidateFrom && typeof candidateFrom === "object"
+          ? (candidateFrom as RawTelegramSender)
+          : undefined;
       break;
     }
   }
@@ -82,29 +93,21 @@ function extractUpdateSenderFacts(update: unknown): UpdateSenderFacts | null {
     const callback = root.callback_query;
     if (callback && typeof callback === "object") {
       const cb = callback as Record<string, unknown>;
-      const from = cb.from;
       const msg = cb.message;
-      if (from && typeof from === "object" && msg && typeof msg === "object") {
-        const messageRecord = msg as Record<string, unknown>;
-        const chat = messageRecord.chat as RawTelegramChat | undefined;
-        const fromObj = from as { id?: unknown; username?: unknown };
-        if (typeof chat?.id === "number" && typeof fromObj.id === "number") {
-          const chatType = typeof chat.type === "string" ? chat.type : "private";
-          return {
-            senderId: String(fromObj.id),
-            ...(typeof fromObj.username === "string" ? { senderUsername: fromObj.username } : {}),
-            chatId: chat.id,
-            isGroup: chatType !== "private",
-            message: extractMessageThreadFacts(messageRecord, chat),
-          };
-        }
+      const callbackFrom = cb.from;
+      if (msg && typeof msg === "object") {
+        message = msg as Record<string, unknown>;
+      }
+      if (callbackFrom && typeof callbackFrom === "object") {
+        from = callbackFrom as RawTelegramSender;
       }
     }
+  }
+  if (!message || !from) {
     return null;
   }
   const chat = message.chat as RawTelegramChat | undefined;
-  const from = message.from as { id?: unknown; username?: unknown } | undefined;
-  if (typeof chat?.id !== "number" || typeof from?.id !== "number") {
+  if (typeof chat?.id !== "number" || typeof from.id !== "number") {
     return null;
   }
   const chatType = typeof chat.type === "string" ? chat.type : "private";

--- a/extensions/telegram/src/telegram-ingress-supersede-auth.ts
+++ b/extensions/telegram/src/telegram-ingress-supersede-auth.ts
@@ -31,7 +31,9 @@ type RawTelegramSender = {
   username?: unknown;
 };
 
-function extractTelegramChatType(value: unknown): TelegramMessageThreadFacts["chat"]["type"] {
+function parseTelegramChatType(
+  value: unknown,
+): TelegramMessageThreadFacts["chat"]["type"] | undefined {
   switch (value) {
     case "channel":
     case "group":
@@ -39,13 +41,14 @@ function extractTelegramChatType(value: unknown): TelegramMessageThreadFacts["ch
     case "supergroup":
       return value;
     default:
-      return "private";
+      return undefined;
   }
 }
 
 function extractMessageThreadFacts(
   message: Record<string, unknown>,
   chat: RawTelegramChat,
+  chatType: TelegramMessageThreadFacts["chat"]["type"],
 ): TelegramMessageThreadFacts {
   const directTopic = message.direct_messages_topic;
   const topicId =
@@ -54,7 +57,7 @@ function extractMessageThreadFacts(
       : undefined;
   return {
     chat: {
-      type: extractTelegramChatType(chat.type),
+      type: chatType,
       ...(typeof chat.is_direct_messages === "boolean"
         ? { is_direct_messages: chat.is_direct_messages }
         : {}),
@@ -110,13 +113,16 @@ function extractUpdateSenderFacts(update: unknown): UpdateSenderFacts | null {
   if (typeof chat?.id !== "number" || typeof from.id !== "number") {
     return null;
   }
-  const chatType = typeof chat.type === "string" ? chat.type : "private";
+  const chatType = parseTelegramChatType(chat.type);
+  if (!chatType) {
+    return null;
+  }
   return {
     senderId: String(from.id),
     ...(typeof from.username === "string" ? { senderUsername: from.username } : {}),
     chatId: chat.id,
     isGroup: chatType !== "private",
-    message: extractMessageThreadFacts(message, chat),
+    message: extractMessageThreadFacts(message, chat, chatType),
   };
 }
 

--- a/extensions/telegram/src/telegram-ingress-supersede-auth.ts
+++ b/extensions/telegram/src/telegram-ingress-supersede-auth.ts
@@ -1,5 +1,4 @@
 // Telegram plugin module owns supersede sender authorization policy.
-import type { Message } from "grammy/types";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveTelegramDmAllow } from "./access-groups.js";
 import { mergeTelegramAccountConfig } from "./account-config.js";
@@ -7,6 +6,7 @@ import {
   resolveTelegramCommandAuthorization,
   resolveTelegramGroupAllowFromContext,
   resolveTelegramMessageThreadSpec,
+  type TelegramMessageThreadFacts,
 } from "./bot/helpers.js";
 import { resolveTelegramScopedGroupConfig } from "./group-config-helpers.js";
 import { resolveTelegramCommandIngressAuthorization } from "./ingress.js";
@@ -16,8 +16,54 @@ type UpdateSenderFacts = {
   senderUsername?: string;
   chatId: number;
   isGroup: boolean;
-  message: Message;
+  message: TelegramMessageThreadFacts;
 };
+
+type RawTelegramChat = {
+  id?: unknown;
+  type?: unknown;
+  is_direct_messages?: unknown;
+  is_forum?: unknown;
+};
+
+function extractTelegramChatType(value: unknown): TelegramMessageThreadFacts["chat"]["type"] {
+  switch (value) {
+    case "channel":
+    case "group":
+    case "private":
+    case "supergroup":
+      return value;
+    default:
+      return "private";
+  }
+}
+
+function extractMessageThreadFacts(
+  message: Record<string, unknown>,
+  chat: RawTelegramChat,
+): TelegramMessageThreadFacts {
+  const directTopic = message.direct_messages_topic;
+  const topicId =
+    directTopic && typeof directTopic === "object" && "topic_id" in directTopic
+      ? directTopic.topic_id
+      : undefined;
+  return {
+    chat: {
+      type: extractTelegramChatType(chat.type),
+      ...(typeof chat.is_direct_messages === "boolean"
+        ? { is_direct_messages: chat.is_direct_messages }
+        : {}),
+      ...(typeof chat.is_forum === "boolean" ? { is_forum: chat.is_forum } : {}),
+    },
+    ...(typeof topicId === "number" ? { direct_messages_topic: { topic_id: topicId } } : {}),
+    ...(typeof message.is_topic_message === "boolean"
+      ? { is_topic_message: message.is_topic_message }
+      : {}),
+    ...(typeof message.message_thread_id === "number"
+      ? { message_thread_id: message.message_thread_id }
+      : {}),
+  };
+}
 
 function extractUpdateSenderFacts(update: unknown): UpdateSenderFacts | null {
   if (!update || typeof update !== "object") {
@@ -39,7 +85,8 @@ function extractUpdateSenderFacts(update: unknown): UpdateSenderFacts | null {
       const from = cb.from;
       const msg = cb.message;
       if (from && typeof from === "object" && msg && typeof msg === "object") {
-        const chat = (msg as { chat?: { id?: unknown; type?: unknown; is_forum?: unknown } }).chat;
+        const messageRecord = msg as Record<string, unknown>;
+        const chat = messageRecord.chat as RawTelegramChat | undefined;
         const fromObj = from as { id?: unknown; username?: unknown };
         if (typeof chat?.id === "number" && typeof fromObj.id === "number") {
           const chatType = typeof chat.type === "string" ? chat.type : "private";
@@ -48,14 +95,14 @@ function extractUpdateSenderFacts(update: unknown): UpdateSenderFacts | null {
             ...(typeof fromObj.username === "string" ? { senderUsername: fromObj.username } : {}),
             chatId: chat.id,
             isGroup: chatType !== "private",
-            message: msg as Message,
+            message: extractMessageThreadFacts(messageRecord, chat),
           };
         }
       }
     }
     return null;
   }
-  const chat = message.chat as { id?: unknown; type?: unknown; is_forum?: unknown } | undefined;
+  const chat = message.chat as RawTelegramChat | undefined;
   const from = message.from as { id?: unknown; username?: unknown } | undefined;
   if (typeof chat?.id !== "number" || typeof from?.id !== "number") {
     return null;
@@ -66,7 +113,7 @@ function extractUpdateSenderFacts(update: unknown): UpdateSenderFacts | null {
     ...(typeof from.username === "string" ? { senderUsername: from.username } : {}),
     chatId: chat.id,
     isGroup: chatType !== "private",
-    message: message as unknown as Message,
+    message: extractMessageThreadFacts(message, chat),
   };
 }
 

--- a/extensions/telegram/src/telegram-ingress-supersede.test.ts
+++ b/extensions/telegram/src/telegram-ingress-supersede.test.ts
@@ -451,6 +451,20 @@ describe("telegram ingress supersede policy", () => {
     ).toBe(true);
   });
 
+  it("rejects unsupported raw chat types before authorization", async () => {
+    expect(
+      await isTelegramSpooledUpdateSenderAuthorized(
+        messageUpdate({
+          updateId: 1,
+          text: "stop",
+          senderId: OWNER_ID,
+          chatType: "future-chat-type",
+        }),
+        auth,
+      ),
+    ).toBe(false);
+  });
+
   it("authorizes paired DM senders via the pairing store under dmPolicy pairing", async () => {
     const pairedId = "424242";
     openClawState = await createOpenClawTestState({

--- a/extensions/telegram/src/telegram-ingress-supersede.test.ts
+++ b/extensions/telegram/src/telegram-ingress-supersede.test.ts
@@ -1,3 +1,4 @@
+import type { ChannelIngressQueueRecord } from "openclaw/plugin-sdk/channel-outbound";
 // Telegram supersede policy for durable ingress (authorization-gated).
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
@@ -76,16 +77,7 @@ function messageUpdate(params: {
 function record(
   id: string,
   update: unknown,
-): {
-  id: string;
-  channelId: string;
-  accountId: string;
-  queueName: string;
-  payload: TelegramSpooledUpdatePayload;
-  receivedAt: number;
-  updatedAt: number;
-  attempts: number;
-} {
+): ChannelIngressQueueRecord<TelegramSpooledUpdatePayload> {
   return {
     id,
     channelId: "telegram",

--- a/extensions/telegram/src/telegram-ingress-supersede.test.ts
+++ b/extensions/telegram/src/telegram-ingress-supersede.test.ts
@@ -436,6 +436,21 @@ describe("telegram ingress supersede policy", () => {
     ).toBe(false);
   });
 
+  it("uses callback senders with the same authorization path", async () => {
+    expect(
+      await isTelegramSpooledUpdateSenderAuthorized(
+        {
+          update_id: 1,
+          callback_query: {
+            from: { id: Number(OWNER_ID) },
+            message: { chat: { id: Number(OWNER_ID), type: "private" } },
+          },
+        },
+        auth,
+      ),
+    ).toBe(true);
+  });
+
   it("authorizes paired DM senders via the pairing store under dmPolicy pairing", async () => {
     const pairedId = "424242";
     openClawState = await createOpenClawTestState({

--- a/extensions/telegram/src/telegram-ingress-worker.runtime.test.ts
+++ b/extensions/telegram/src/telegram-ingress-worker.runtime.test.ts
@@ -9,6 +9,13 @@ import { runTelegramIngressWorkerRuntime } from "./telegram-ingress-worker.runti
 
 type RuntimePort = Parameters<typeof runTelegramIngressWorkerRuntime>[0]["port"];
 
+type TelegramIngressWorkerTestRuntime = {
+  calls: number[];
+  pollBodies: Array<Record<string, unknown>>;
+  messages: TelegramIngressWorkerMessage[];
+  done: Promise<void>;
+};
+
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -26,12 +33,7 @@ function htmlResponse(status: number, body: string): Response {
 function createRuntime(
   responses: Response[],
   options: { stopAfterPollSuccesses?: number; timeoutSeconds?: number } = {},
-): {
-  calls: number[];
-  pollBodies: Array<Record<string, unknown>>;
-  messages: TelegramIngressWorkerMessage[];
-  done: Promise<void>;
-} {
+): TelegramIngressWorkerTestRuntime {
   const calls: number[] = [];
   const pollBodies: Array<Record<string, unknown>> = [];
   const messages: TelegramIngressWorkerMessage[] = [];

--- a/extensions/telegram/src/telegram-ingress-worker.test.ts
+++ b/extensions/telegram/src/telegram-ingress-worker.test.ts
@@ -27,10 +27,12 @@ type FakeWorker = EventEmitter & {
   terminate: ReturnType<typeof vi.fn<() => Promise<number>>>;
 };
 
-function createWorker(): {
+type TelegramIngressWorkerHarness = {
   handle: ReturnType<typeof createTelegramIngressWorker>;
   worker: FakeWorker;
-} {
+};
+
+function createWorker(): TelegramIngressWorkerHarness {
   const handle = createTelegramIngressWorker({
     token: "123456:test",
     accountId: "default",

--- a/extensions/telegram/src/threading-tool-context.test.ts
+++ b/extensions/telegram/src/threading-tool-context.test.ts
@@ -56,8 +56,10 @@ describe("telegramPlugin reply threading", () => {
       throw new Error("Telegram reply mode resolver is unavailable");
     }
 
-    const cfg = { channels: { telegram } } as unknown as OpenClawConfig;
-    expect(resolveReplyToMode({ cfg, accountId: "sut" })).toBe(expected);
+    const cfg = { channels: { telegram } };
+    expect(
+      Reflect.apply(resolveReplyToMode, telegramPlugin.threading, [{ cfg, accountId: "sut" }]),
+    ).toBe(expected);
     expect(tryReadSecretFileSyncMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/telegram/src/token.test.ts
+++ b/extensions/telegram/src/token.test.ts
@@ -11,6 +11,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveTelegramBotUserIdFromToken } from "./token-fingerprint.js";
 import { resolveTelegramToken } from "./token.js";
 
+function resolveTelegramTokenFromRawConfig(cfg: object) {
+  return Reflect.apply(resolveTelegramToken, undefined, [cfg]);
+}
+
 describe("resolveTelegramBotUserIdFromToken", () => {
   it.each([
     ["123456:secret", 123456],
@@ -395,9 +399,9 @@ describe("resolveTelegramToken", () => {
           botToken: { source: "env", provider: "default", id: "TELEGRAM_BOT_TOKEN" },
         },
       },
-    } as unknown as OpenClawConfig;
+    };
 
-    expect(resolveTelegramToken(cfg)).toEqual({
+    expect(resolveTelegramTokenFromRawConfig(cfg)).toEqual({
       token: "secretref-env-token",
       source: "config",
     });
@@ -412,9 +416,9 @@ describe("resolveTelegramToken", () => {
           botToken: { source: "env", provider: "default", id: "TELEGRAM_REF_TOKEN" },
         },
       },
-    } as unknown as OpenClawConfig;
+    };
 
-    expect(resolveTelegramToken(cfg)).toEqual({
+    expect(resolveTelegramTokenFromRawConfig(cfg)).toEqual({
       token: "",
       source: "none",
     });
@@ -438,9 +442,9 @@ describe("resolveTelegramToken", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    };
 
-    expect(resolveTelegramToken(cfg)).toEqual({
+    expect(resolveTelegramTokenFromRawConfig(cfg)).toEqual({
       token: "",
       source: "none",
     });
@@ -462,9 +466,9 @@ describe("resolveTelegramToken", () => {
           botToken: { source: "env", provider: "telegram-env", id: "TELEGRAM_BOT_TOKEN" },
         },
       },
-    } as unknown as OpenClawConfig;
+    };
 
-    expect(() => resolveTelegramToken(cfg)).toThrow(
+    expect(() => resolveTelegramTokenFromRawConfig(cfg)).toThrow(
       /not allowlisted in secrets\.providers\.telegram-env\.allowlist/i,
     );
   });
@@ -484,9 +488,9 @@ describe("resolveTelegramToken", () => {
           botToken: { source: "env", provider: "telegram-env", id: "TELEGRAM_BOT_TOKEN" },
         },
       },
-    } as unknown as OpenClawConfig;
+    };
 
-    expect(() => resolveTelegramToken(cfg)).toThrow(
+    expect(() => resolveTelegramTokenFromRawConfig(cfg)).toThrow(
       /Secret provider "telegram-env" has source "file" but ref requests "env"/i,
     );
   });
@@ -498,9 +502,9 @@ describe("resolveTelegramToken", () => {
           botToken: { source: "env", provider: "ops-env", id: "TELEGRAM_BOT_TOKEN" },
         },
       },
-    } as unknown as OpenClawConfig;
+    };
 
-    expect(() => resolveTelegramToken(cfg)).toThrow(
+    expect(() => resolveTelegramTokenFromRawConfig(cfg)).toThrow(
       /Secret provider "ops-env" is not configured \(ref: env:ops-env:TELEGRAM_BOT_TOKEN\)/i,
     );
   });
@@ -522,9 +526,9 @@ describe("resolveTelegramToken", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    };
 
-    expect(resolveTelegramToken(cfg)).toEqual({
+    expect(resolveTelegramTokenFromRawConfig(cfg)).toEqual({
       token: "secretref-env-token",
       source: "config",
     });
@@ -537,9 +541,9 @@ describe("resolveTelegramToken", () => {
           botToken: { source: "file", provider: "vault", id: "/telegram/bot-token" },
         },
       },
-    } as unknown as OpenClawConfig;
+    };
 
-    expect(() => resolveTelegramToken(cfg)).toThrow(
+    expect(() => resolveTelegramTokenFromRawConfig(cfg)).toThrow(
       /channels\.telegram\.botToken: unresolved SecretRef/i,
     );
   });

--- a/extensions/telegram/src/topic-name-cache.test.ts
+++ b/extensions/telegram/src/topic-name-cache.test.ts
@@ -5,7 +5,6 @@ import {
   clearTelegramRuntimeForTest,
   resetTelegramTopicNameCacheForTest,
 } from "./runtime.test-support.js";
-import type { TelegramRuntime } from "./runtime.types.js";
 import { getTopicName, updateTopicName } from "./topic-name-cache.js";
 
 type TopicEntry = {
@@ -44,29 +43,31 @@ function topicStoreSize(stores: Map<string, Map<string, TopicEntry>>): number {
 
 function installMemoryStores() {
   const stores = new Map<string, Map<string, TopicEntry>>();
-  setTelegramRuntime({
-    state: {
-      openKeyedStore: (({ namespace }: { namespace: string }) => {
-        const entries = stores.get(namespace) ?? new Map<string, TopicEntry>();
-        stores.set(namespace, entries);
-        return {
-          async register(key: string, value: TopicEntry) {
-            entries.set(key, value);
-          },
-          async entries() {
-            return Array.from(entries, ([key, value]) => ({ key, value }));
-          },
-          async delete(key: string) {
-            return entries.delete(key);
-          },
-          async clear() {
-            entries.clear();
-          },
-        };
-      }) as unknown as TelegramRuntime["state"]["openKeyedStore"],
+  Reflect.apply(setTelegramRuntime, undefined, [
+    {
+      state: {
+        openKeyedStore: ({ namespace }: { namespace: string }) => {
+          const entries = stores.get(namespace) ?? new Map<string, TopicEntry>();
+          stores.set(namespace, entries);
+          return {
+            async register(key: string, value: TopicEntry) {
+              entries.set(key, value);
+            },
+            async entries() {
+              return Array.from(entries, ([key, value]) => ({ key, value }));
+            },
+            async delete(key: string) {
+              return entries.delete(key);
+            },
+            async clear() {
+              entries.clear();
+            },
+          };
+        },
+      },
+      channel: {},
     },
-    channel: {},
-  } as TelegramRuntime);
+  ]);
   return stores;
 }
 

--- a/extensions/telegram/src/transport-payload.test.ts
+++ b/extensions/telegram/src/transport-payload.test.ts
@@ -1,4 +1,3 @@
-import { buffer } from "node:stream/consumers";
 import { Bot } from "grammy";
 import type { Message } from "grammy/types";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -80,7 +79,7 @@ describe("Telegram topic transport payloads", () => {
         typeof rawBody === "string"
           ? Buffer.from(rawBody)
           : rawBody
-            ? await buffer(rawBody as unknown as NodeJS.ReadableStream)
+            ? Buffer.from(await new Response(rawBody).arrayBuffer())
             : Buffer.alloc(0);
       const method = new URL(input instanceof Request ? input.url : String(input)).pathname
         .split("/")

--- a/extensions/telegram/src/update-offset-store.test.ts
+++ b/extensions/telegram/src/update-offset-store.test.ts
@@ -367,6 +367,10 @@ describe("deleteTelegramUpdateOffset", () => {
 
   it("ignores invalid persisted update IDs from plugin-state", async () => {
     await withStateDirEnv("openclaw-tg-offset-", async () => {
+      const rawOffsetStore = createPluginStateKeyedStoreForTests<unknown>("telegram", {
+        namespace: TELEGRAM_UPDATE_OFFSET_NAMESPACE,
+        maxEntries: TELEGRAM_UPDATE_OFFSET_MAX_ENTRIES,
+      });
       await updateOffsetStore.register("default", {
         version: 2,
         lastUpdateId: -1,
@@ -374,11 +378,11 @@ describe("deleteTelegramUpdateOffset", () => {
       } as TelegramUpdateOffsetState);
       expect(await readTelegramUpdateOffset({ accountId: "default" })).toBeNull();
 
-      await updateOffsetStore.register("default", {
+      await rawOffsetStore.register("default", {
         version: 2,
         lastUpdateId: "not-a-number",
         botId: "111111",
-      } as unknown as TelegramUpdateOffsetState);
+      });
       expect(await readTelegramUpdateOffset({ accountId: "default" })).toBeNull();
     });
   });

--- a/extensions/telegram/src/voice.ts
+++ b/extensions/telegram/src/voice.ts
@@ -1,11 +1,18 @@
 // Telegram plugin module implements voice behavior.
 import { isVoiceMessageCompatibleAudio } from "openclaw/plugin-sdk/media-runtime";
 
+type TelegramVoiceDecision = {
+  useVoice: boolean;
+  reason?: string;
+};
+
+type TelegramVoiceSend = Pick<TelegramVoiceDecision, "useVoice">;
+
 function resolveTelegramVoiceDecision(opts: {
   wantsVoice: boolean;
   contentType?: string | null;
   fileName?: string | null;
-}): { useVoice: boolean; reason?: string } {
+}): TelegramVoiceDecision {
   if (!opts.wantsVoice) {
     return { useVoice: false };
   }
@@ -25,7 +32,7 @@ export function resolveTelegramVoiceSend(opts: {
   contentType?: string | null;
   fileName?: string | null;
   logFallback?: (message: string) => void;
-}): { useVoice: boolean } {
+}): TelegramVoiceSend {
   const decision = resolveTelegramVoiceDecision(opts);
   if (decision.reason && opts.logFallback) {
     opts.logFallback(

--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -483,7 +483,9 @@ async function postWebhookPayloadWithChunkPlan(params: {
   });
 }
 
-function createNearLimitTelegramPayload(): { payload: string; sizeBytes: number } {
+type NearLimitTelegramPayload = { payload: string; sizeBytes: number };
+
+function createNearLimitTelegramPayload(): NearLimitTelegramPayload {
   const maxBytes = 1_024 * 1_024;
   const targetBytes = maxBytes - 4_096;
   const shell = { update_id: 77_777, message: { text: "" } };
@@ -1169,24 +1171,26 @@ describe("startTelegramWebhook", () => {
     const enqueueStarted = new Promise<void>((resolve) => {
       markEnqueueStarted = resolve;
     });
-    setTelegramRuntime({
-      state: {
-        resolveStateDir: () => webhookStateDir ?? os.tmpdir(),
-        openChannelIngressQueue: (
-          options?: Omit<Parameters<typeof createChannelIngressQueue>[0], "channelId">,
-        ) => {
-          const queue = createChannelIngressQueue({ ...options, channelId: "telegram" });
-          return {
-            ...queue,
-            enqueue: async (...args: Parameters<typeof queue.enqueue>) => {
-              markEnqueueStarted?.();
-              await enqueueGate;
-              return await queue.enqueue(...args);
-            },
-          };
+    Reflect.apply(setTelegramRuntime, undefined, [
+      {
+        state: {
+          resolveStateDir: () => webhookStateDir ?? os.tmpdir(),
+          openChannelIngressQueue: (
+            options?: Omit<Parameters<typeof createChannelIngressQueue>[0], "channelId">,
+          ) => {
+            const queue = createChannelIngressQueue({ ...options, channelId: "telegram" });
+            return {
+              ...queue,
+              enqueue: async (...args: Parameters<typeof queue.enqueue>) => {
+                markEnqueueStarted?.();
+                await enqueueGate;
+                return await queue.enqueue(...args);
+              },
+            };
+          },
         },
       },
-    } as TelegramRuntime);
+    ]);
 
     await withStartedWebhook(
       {
@@ -1291,10 +1295,11 @@ describe("startTelegramWebhook", () => {
     vi.stubEnv("OPENCLAW_TELEGRAM_SPOOLED_HANDLER_TIMEOUT_MS", envValue);
     vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
     let finishUpdate: (() => void) | undefined;
-    const active: {
+    type ActiveSpooledReplay = {
       dispatchStartedAt?: number;
       lifecycle?: NonNullable<ReturnType<typeof getTelegramSpooledReplayLifecycle>>;
-    } = {};
+    };
+    const active: ActiveSpooledReplay = {};
     await writeTelegramSpooledUpdate({
       spoolDir: requireWebhookSpoolDir(),
       update: { update_id: 39, message: { chat: { id: 123 }, text: "stalled" } },
@@ -2247,23 +2252,25 @@ describe("startTelegramWebhook", () => {
   it("stops claimed completion retries when the webhook stops", async () => {
     vi.useFakeTimers();
     let completeAttempts = 0;
-    setTelegramRuntime({
-      state: {
-        resolveStateDir: () => webhookStateDir ?? os.tmpdir(),
-        openChannelIngressQueue: (
-          options?: Omit<Parameters<typeof createChannelIngressQueue>[0], "channelId">,
-        ) => {
-          const queue = createChannelIngressQueue({ ...options, channelId: "telegram" });
-          return {
-            ...queue,
-            complete: async () => {
-              completeAttempts += 1;
-              throw new Error("persistent completion write failure");
-            },
-          };
+    Reflect.apply(setTelegramRuntime, undefined, [
+      {
+        state: {
+          resolveStateDir: () => webhookStateDir ?? os.tmpdir(),
+          openChannelIngressQueue: (
+            options?: Omit<Parameters<typeof createChannelIngressQueue>[0], "channelId">,
+          ) => {
+            const queue = createChannelIngressQueue({ ...options, channelId: "telegram" });
+            return {
+              ...queue,
+              complete: async () => {
+                completeAttempts += 1;
+                throw new Error("persistent completion write failure");
+              },
+            };
+          },
         },
       },
-    } as unknown as TelegramRuntime);
+    ]);
     await writeTelegramSpooledUpdate({
       spoolDir: requireWebhookSpoolDir(),
       update: { update_id: 52, message: { chat: { id: 123 }, text: "stop retry" } },


### PR DESCRIPTION
## What Problem This Solves

Telegram code and tests used chained assertions and widened known values that hid owner contracts. During review, raw ingress also accepted unknown chat types into authorization and crashed lane derivation when chat facts were absent.

## Change

Use inferred or named owner types, complete grammY fixtures, validated raw-boundary adapters, and one canonical sender-fact extractor. Unknown raw chat types now fail closed before authorization.

Maintainer scope decision: accept this as one coherent Telegram type-boundary sweep; do not split the authorization repair.

Telegram-owner decision: raw chat discriminators outside grammY's `private | group | supergroup | channel` contract must fail closed before supersede authorization.

## Bug Proof

- Regression added first: unsupported raw chat type expected rejection but returned `true` before the fix.
- Regression added first: a malformed raw message without chat facts crashed sequential-key derivation on `is_direct_messages`; it now uses the isolated unknown lane.
- Rebased exact-head proof: 22 focused Telegram files, 519 tests passed, including callback, DM, forum-topic, malformed-ingress, polling, webhook, and dispatch-fixture paths.

## Evidence

- Anti-slop audit: chained assertions `425 → 0`; known-value widening `189 → 0`.
- `pnpm tsgo:extensions`; `pnpm tsgo:extensions:test`.
- Type-aware Oxlint on all 126 changed files; Oxfmt and `git diff --check` clean.
- Deadcode production/full-tree exports and dependencies passed.
- Dependency contract: grammY `1.45.1` defines only `private | group | supergroup | channel`; its `Chat` union and `chatType` middleware docs agree.
- Rebased-head real Telegram authorized proof: slow active turn + `/stop@bot`; 2 provider requests, visible `Agent was aborted.`, draft deleted.
- Rebased-head real Telegram unauthorized proof: excluded DM sender + `/stop`; 0 provider requests, visible authorization rejection.
- Scope: production `+456/-291` (net `+165`); tests/support `+1939/-1654` (net `+285`).
- `$distill`: unified message/callback sender extraction. `$greybeard`: no actionable hot-path regression.

Normal Telegram behavior is unchanged. Malformed messages stay isolated; unknown chat types cannot reach supersede authorization.
