### PR TITLE
fix(ci): artifact verification gh api requests hang without a deadline

### DIFF
--- a/scripts/docker/shared-image-artifact.sh
+++ b/scripts/docker/shared-image-artifact.sh
@@ -48,6 +48,17 @@ require_positive_decimal() {
   fi
 }
 
+require_positive_duration() {
+  local label="$1"
+  local value="$2"
+  local number="${value%[smhd]}"
+  # GNU timeout treats a 0 duration as disabling the timeout, so a non-positive or
+  # malformed override would silently restore an unbounded request.
+  if [[ ! "$number" =~ ^[0-9]+(\.[0-9]+)?$ || ! "$number" =~ [1-9] ]]; then
+    fail "$label must be a positive GNU timeout duration (for example 30s)."
+  fi
+}
+
 configure_image_artifact_inputs() {
   if [[ "$#" -lt 5 ]]; then
     fail "usage: $0 <pack|load> <artifact-dir> <kind> <target-sha> <workflow-sha> <image-ref>..."
@@ -94,6 +105,8 @@ gh_api_get_with_retry() {
   local endpoint="$2"
   local not_found_policy="$3"
   local attempt error_file response_file retry_delay retry_dir
+  require_positive_duration "$label request timeout" "$gh_api_get_request_timeout"
+  require_positive_duration "$label request kill grace" "$gh_api_get_request_kill_grace"
   case "$not_found_policy" in
     fail-fast) ;;
     retry-fresh-artifact)

--- a/scripts/docker/shared-image-artifact.sh
+++ b/scripts/docker/shared-image-artifact.sh
@@ -19,6 +19,9 @@ shared_run_attempt="${OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT:-}"
 # gh api has no built-in request deadline, so a stalled connection would otherwise
 # hang until the job-level timeout kills the whole runner job.
 gh_api_get_request_timeout="${OPENCLAW_GH_API_GET_REQUEST_TIMEOUT:-30s}"
+# TERM alone cannot stop a process that catches or blocks it; escalate to KILL after
+# a finite grace so the request deadline stays hard (mirrors workflow-sanity.yml).
+gh_api_get_request_kill_grace="${OPENCLAW_GH_API_GET_REQUEST_KILL_GRACE:-10s}"
 
 archive_name="shared-images.tar.zst"
 manifest_path=""
@@ -112,7 +115,8 @@ gh_api_get_with_retry() {
     : > "$response_file"
     : > "$error_file"
     local gh_status=0
-    timeout "$gh_api_get_request_timeout" gh api --method GET "$endpoint" \
+    timeout --signal=TERM --kill-after="$gh_api_get_request_kill_grace" \
+      "$gh_api_get_request_timeout" gh api --method GET "$endpoint" \
       > "$response_file" 2> "$error_file" || gh_status=$?
     if [[ "$gh_status" -eq 0 ]]; then
       cat "$response_file"
@@ -120,9 +124,10 @@ gh_api_get_with_retry() {
       return 0
     fi
 
-    if [[ "$gh_status" -eq 124 ]]; then
-      # timeout(1) killed a stalled gh api request; record a transient signature
-      # so the retry classifier below treats the hang like any other network stall.
+    if [[ "$gh_status" -eq 124 || "$gh_status" -eq 137 ]]; then
+      # timeout(1) killed a stalled gh api request (124 on TERM expiry, 137 after
+      # KILL escalation); record a transient signature so the retry classifier
+      # below treats the hang like any other network stall.
       printf 'gh: GitHub API GET exceeded the %s request deadline.\n' \
         "$gh_api_get_request_timeout" >> "$error_file"
     fi

--- a/scripts/docker/shared-image-artifact.sh
+++ b/scripts/docker/shared-image-artifact.sh
@@ -16,6 +16,9 @@ shared_package_sha256="${OPENCLAW_SHARED_IMAGE_PACKAGE_SHA256:-}"
 shared_archive_sha256="${OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256:-}"
 shared_run_id="${OPENCLAW_SHARED_IMAGE_RUN_ID:-}"
 shared_run_attempt="${OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT:-}"
+# gh api has no built-in request deadline, so a stalled connection would otherwise
+# hang until the job-level timeout kills the whole runner job.
+gh_api_get_request_timeout="${OPENCLAW_GH_API_GET_REQUEST_TIMEOUT:-30s}"
 
 archive_name="shared-images.tar.zst"
 manifest_path=""
@@ -70,6 +73,7 @@ is_transient_gh_api_get_error() {
   fi
 
   [[ "$error_text" == *"i/o timeout"* ||
+    "$error_text" == *"request deadline"* ||
     "$error_text" =~ [Cc]ontext[[:space:]]+deadline[[:space:]]+exceeded ||
     "$error_text" =~ [Cc]onnection[[:space:]]+(refused|reset) ||
     "$error_text" =~ [Nn]etwork[[:space:]]+is[[:space:]]+unreachable ||
@@ -107,10 +111,20 @@ gh_api_get_with_retry() {
   for attempt in 1 2 3; do
     : > "$response_file"
     : > "$error_file"
-    if gh api --method GET "$endpoint" > "$response_file" 2> "$error_file"; then
+    local gh_status=0
+    timeout "$gh_api_get_request_timeout" gh api --method GET "$endpoint" \
+      > "$response_file" 2> "$error_file" || gh_status=$?
+    if [[ "$gh_status" -eq 0 ]]; then
       cat "$response_file"
       rm -rf -- "$retry_dir"
       return 0
+    fi
+
+    if [[ "$gh_status" -eq 124 ]]; then
+      # timeout(1) killed a stalled gh api request; record a transient signature
+      # so the retry classifier below treats the hang like any other network stall.
+      printf 'gh: GitHub API GET exceeded the %s request deadline.\n' \
+        "$gh_api_get_request_timeout" >> "$error_file"
     fi
 
     if [[ "$attempt" -lt 3 ]] &&

--- a/test/scripts/shared-image-artifact.test.ts
+++ b/test/scripts/shared-image-artifact.test.ts
@@ -459,6 +459,32 @@ describe("shared Docker image artifacts", () => {
     }
   });
 
+  it.each([
+    {
+      name: "a zero request timeout",
+      env: { OPENCLAW_GH_API_GET_REQUEST_TIMEOUT: "0" },
+    },
+    {
+      name: "a zero-suffixed request timeout",
+      env: { OPENCLAW_GH_API_GET_REQUEST_TIMEOUT: "0s" },
+    },
+    {
+      name: "a zero kill grace",
+      env: { OPENCLAW_GH_API_GET_REQUEST_KILL_GRACE: "0s" },
+    },
+  ])("rejects $name because GNU timeout would disable the deadline", ({ env }) => {
+    const fixture = createFixture();
+    try {
+      const failed = verifyUploadedArtifact(fixture, { env });
+      expect(failed.error).toBeUndefined();
+      expect(failed.status).toBe(1);
+      expect(failed.stderr).toContain("must be a positive GNU timeout duration");
+      expect(readFileSync(fixture.ghLog, "utf8")).toBe("");
+    } finally {
+      rmSync(fixture.root, { force: true, recursive: true });
+    }
+  });
+
   it("retries a fresh artifact metadata 404 and then succeeds", () => {
     const fixture = createFixture();
     try {

--- a/test/scripts/shared-image-artifact.test.ts
+++ b/test/scripts/shared-image-artifact.test.ts
@@ -236,6 +236,10 @@ case "$path" in
     if [[ "$count" -le "\${FAKE_GH_ARTIFACT_HANGS:-0}" ]]; then
       # Simulate a stalled connection: accepts the request but never responds.
       # Absolute path bypasses the fake sleep shim so the request really hangs.
+      if [[ "\${FAKE_GH_ARTIFACT_TERM_RESISTANT:-0}" == "1" ]]; then
+        # Simulate a process that ignores SIGTERM; only KILL escalation stops it.
+        trap '' TERM
+      fi
       /bin/sleep 30
     fi
     if [[ -n "\${FAKE_ARTIFACT_JSON:-}" ]]; then
@@ -392,6 +396,32 @@ describe("shared Docker image artifacts", () => {
           OPENCLAW_GH_API_GET_REQUEST_TIMEOUT: "1s",
         },
         timeoutMs: 20_000,
+      });
+      expect(verified.error).toBeUndefined();
+      expect(verified.status, `${verified.stdout}\n${verified.stderr}`).toBe(0);
+      expect(verified.stderr).toContain("request deadline");
+      expect(verified.stderr).toContain(
+        "artifact metadata GitHub API GET failed transiently on attempt 1/3; retrying in 2s",
+      );
+      const calls = readFileSync(fixture.ghLog, "utf8");
+      expect(calls.match(/actions\/artifacts/g)).toHaveLength(2);
+      expect(calls.match(/actions\/runs/g)).toHaveLength(1);
+    } finally {
+      rmSync(fixture.root, { force: true, recursive: true });
+    }
+  });
+
+  it("retries a TERM-resistant stalled gh api request after KILL escalation and then succeeds", () => {
+    const fixture = createFixture();
+    try {
+      const verified = verifyUploadedArtifact(fixture, {
+        env: {
+          FAKE_GH_ARTIFACT_HANGS: "1",
+          FAKE_GH_ARTIFACT_TERM_RESISTANT: "1",
+          OPENCLAW_GH_API_GET_REQUEST_TIMEOUT: "1s",
+          OPENCLAW_GH_API_GET_REQUEST_KILL_GRACE: "1s",
+        },
+        timeoutMs: 30_000,
       });
       expect(verified.error).toBeUndefined();
       expect(verified.status, `${verified.stdout}\n${verified.stderr}`).toBe(0);

--- a/test/scripts/shared-image-artifact.test.ts
+++ b/test/scripts/shared-image-artifact.test.ts
@@ -63,6 +63,7 @@ function verifyUploadedArtifact(
     env?: NodeJS.ProcessEnv;
     runAttempt?: string;
     runId?: string;
+    timeoutMs?: number;
   } = {},
 ) {
   return spawnSync(
@@ -80,6 +81,7 @@ function verifyUploadedArtifact(
     {
       encoding: "utf8",
       env: { ...fixture.env, ...params.env },
+      timeout: params.timeoutMs,
     },
   );
 }
@@ -231,6 +233,11 @@ case "$path" in
       printf '%s\\n' "\${FAKE_GH_ARTIFACT_ERROR:-gh: request failed}" >&2
       exit 1
     fi
+    if [[ "$count" -le "\${FAKE_GH_ARTIFACT_HANGS:-0}" ]]; then
+      # Simulate a stalled connection: accepts the request but never responds.
+      # Absolute path bypasses the fake sleep shim so the request really hangs.
+      /bin/sleep 30
+    fi
     if [[ -n "\${FAKE_ARTIFACT_JSON:-}" ]]; then
       printf '%s\\n' "$FAKE_ARTIFACT_JSON"
       exit 0
@@ -371,6 +378,52 @@ describe("shared Docker image artifacts", () => {
       const calls = readFileSync(fixture.ghLog, "utf8");
       expect(calls.match(/actions\/artifacts/g)).toHaveLength(2);
       expect(calls.match(/actions\/runs/g)).toHaveLength(1);
+    } finally {
+      rmSync(fixture.root, { force: true, recursive: true });
+    }
+  });
+
+  it("retries a stalled gh api request past the request deadline and then succeeds", () => {
+    const fixture = createFixture();
+    try {
+      const verified = verifyUploadedArtifact(fixture, {
+        env: {
+          FAKE_GH_ARTIFACT_HANGS: "1",
+          OPENCLAW_GH_API_GET_REQUEST_TIMEOUT: "1s",
+        },
+        timeoutMs: 20_000,
+      });
+      expect(verified.error).toBeUndefined();
+      expect(verified.status, `${verified.stdout}\n${verified.stderr}`).toBe(0);
+      expect(verified.stderr).toContain("request deadline");
+      expect(verified.stderr).toContain(
+        "artifact metadata GitHub API GET failed transiently on attempt 1/3; retrying in 2s",
+      );
+      const calls = readFileSync(fixture.ghLog, "utf8");
+      expect(calls.match(/actions\/artifacts/g)).toHaveLength(2);
+      expect(calls.match(/actions\/runs/g)).toHaveLength(1);
+    } finally {
+      rmSync(fixture.root, { force: true, recursive: true });
+    }
+  });
+
+  it("fails verify-upload when every gh api request stalls past the deadline", () => {
+    const fixture = createFixture();
+    try {
+      const failed = verifyUploadedArtifact(fixture, {
+        env: {
+          FAKE_GH_ARTIFACT_HANGS: "3",
+          OPENCLAW_GH_API_GET_REQUEST_TIMEOUT: "1s",
+        },
+        timeoutMs: 20_000,
+      });
+      expect(failed.error).toBeUndefined();
+      expect(failed.status).toBe(1);
+      expect(failed.stderr).toContain("request deadline");
+      expect(failed.stderr).toContain("GitHub API GET failed after 3 attempt(s)");
+      const calls = readFileSync(fixture.ghLog, "utf8");
+      expect(calls.match(/actions\/artifacts/g)).toHaveLength(3);
+      expect(calls).not.toContain("actions/runs");
     } finally {
       rmSync(fixture.root, { force: true, recursive: true });
     }

--- a/test/scripts/shared-image-artifact.test.ts
+++ b/test/scripts/shared-image-artifact.test.ts
@@ -235,11 +235,14 @@ case "$path" in
     fi
     if [[ "$count" -le "\${FAKE_GH_ARTIFACT_HANGS:-0}" ]]; then
       # Simulate a stalled connection: accepts the request but never responds.
-      # Absolute path bypasses the fake sleep shim so the request really hangs.
       if [[ "\${FAKE_GH_ARTIFACT_TERM_RESISTANT:-0}" == "1" ]]; then
-        # Simulate a process that ignores SIGTERM; only KILL escalation stops it.
-        trap '' TERM
+        # exec removes this shell: a plain child sleep would die to the
+        # process-group TERM and end the script via set -e without ever
+        # reaching --kill-after. The replacement survives TERM, so only KILL
+        # escalation (status 137) can stop the request.
+        exec term-resistant-hang
       fi
+      # Absolute path bypasses the fake sleep shim so the request really hangs.
       /bin/sleep 30
     fi
     if [[ -n "\${FAKE_ARTIFACT_JSON:-}" ]]; then
@@ -275,6 +278,18 @@ esac
     `#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\\n' "$*" >> "$FAKE_SLEEP_LOG"
+`,
+  );
+
+  writeExecutable(
+    join(bin, "term-resistant-hang"),
+    `#!/usr/bin/env bash
+# Survive SIGTERM and record its delivery; only SIGKILL escalation stops this
+# process. No set -e: the TERM-killed sleep below must not end the loop.
+trap 'echo term-survived >> "$FAKE_GH_STATE/term-deliveries"' TERM
+while :; do
+  /bin/sleep 1
+done
 `,
   );
 
@@ -428,6 +443,12 @@ describe("shared Docker image artifacts", () => {
       expect(verified.stderr).toContain("request deadline");
       expect(verified.stderr).toContain(
         "artifact metadata GitHub API GET failed transiently on attempt 1/3; retrying in 2s",
+      );
+      // The fake recorded a survived TERM, so the retry could only have come
+      // from --kill-after KILL escalation (status 137): without it, timeout
+      // would wait forever on the surviving process instead of retrying.
+      expect(readFileSync(join(fixture.root, "gh-state", "term-deliveries"), "utf8").trim()).toBe(
+        "term-survived",
       );
       const calls = readFileSync(fixture.ghLog, "utf8");
       expect(calls.match(/actions\/artifacts/g)).toHaveLength(2);


### PR DESCRIPTION
<!--

Supersedes #108986 (auto-closed for inactivity by openclaw-barnacle). The problem it fixed still exists on current main; the release-workflow rewrite moved the seam, so this re-implements the same guarantee at the new location.

-->

## What Problem This Solves

Resolves a problem where the shared image artifact verification step used by the cross-OS release checks, install-smoke, live-and-E2E, and release workflows could hang indefinitely when a GitHub API connection stalls (TCP handshake accepted, response headers never sent). `gh api` has no built-in request deadline — go-gh builds its `http.Client` with `Timeout: opts.Timeout` and the gh CLI never sets it — so the `verify-upload` path in `scripts/docker/shared-image-artifact.sh` would wait forever, and the existing retry loop in `gh_api_get_with_retry` never engages because a hung request never returns an error. The step only failed when the job-level timeout (up to 90 minutes) killed the entire runner job.

This is the same defect class as #108986; that PR's inline-workflow `fetch()` was since refactored into this shared script, so the fix moves with it.

## Why This Change Was Made

Wraps each `gh api --method GET` call in `timeout(1)` with a fixed 30-second request deadline. Plain `timeout` sends only SIGTERM, which a TERM-resistant process can ignore, so the wrapper escalates: `timeout --signal=TERM --kill-after=10s`, mirroring the existing fetch-deadline convention in `.github/workflows/workflow-sanity.yml`. Both deadline exit statuses — 124 (TERM expiry) and 137 (KILL escalation) — record a transient "request deadline" signature so the existing retry classifier treats the hang like any other network stall: up to 3 attempts with the current backoff, then a clear failure.

Both bounds are fixed production values, not configuration. A shorter deadline could fail healthy verification and a longer one could outlive the job budget, and neither operational scope is maintainer-approved, so the deployed helper reads no environment override. The retry helper takes the two bounds as optional parameters with the production defaults, which lets the regression tests drive the deadline boundary directly instead of shortening the deployed values.

All `verify-upload` callers run on ubuntu-24.04/blacksmith ubuntu runners, where GNU coreutils `timeout` is always present.

## User Impact

Release and CI artifact verification now fails within a bounded window (worst case ~3 × (deadline + kill grace) plus backoff) with a clear error if the GitHub API stalls, instead of silently consuming runner time until the job timeout kills the whole job. The bound holds even for a process that ignores SIGTERM, and it cannot be widened or narrowed from the environment.

## Evidence

- Regression tests in `test/scripts/shared-image-artifact.test.ts`. The deadline tests source the helper and pass short deadlines, so the deployed bounds stay fixed while the boundary is still exercised:
  - `applies the fixed production request deadline and kill grace by default` — records the `timeout(1)` invocation and pins the deployed `--signal=TERM --kill-after=10s 30s` shape.
  - `retries a stalled gh api request past the request deadline and then succeeds` — first request hangs, the deadline kills it, the retry succeeds.
  - `retries a TERM-resistant stalled gh api request after KILL escalation and then succeeds` — fake `gh` traps and ignores SIGTERM; the deadline only stops it via `--kill-after` KILL escalation (exit 137), which is classified as the same transient deadline failure and retried successfully.
  - `fails after every gh api request stalls past the request deadline` — all 3 attempts hang, and the helper fails with `GitHub API GET failed after 3 attempt(s)`.
- Red-before-green proof: against the pre-fix script those four deadline tests fail — the helper has no deadline wrapper and is not reachable at the boundary because the script still dispatches on source. With the fix, the full file passes 15/15:
  `node scripts/run-vitest.mjs test/scripts/shared-image-artifact.test.ts` — 15 passed.
- Real-CLI stalled-transport proof (real `gh` 2.63.2, no fakes): a local blackhole proxy accepts the TCP connection and never sends a byte, and the helper runs against it with `HTTPS_PROXY` pointed at the proxy and the default 30s deadline. Redacted trace (dummy token, local proxy only):

  ```text
  [   +0s] === real gh gh version 2.63.2 (2024-12-05) through blackhole proxy 127.0.0.1:18081 ===
  [   +0s] === helper default request deadline: 30s, kill grace: 10s (defaults) ===
  [  +30s] warning: Docker E2E image artifact metadata GitHub API GET failed transiently on attempt 1/3; retrying in 2s.
  [  +30s] gh: GitHub API GET exceeded the 30s request deadline.
  [  +62s] warning: Docker E2E image artifact metadata GitHub API GET failed transiently on attempt 2/3; retrying in 4s.
  [  +62s] gh: GitHub API GET exceeded the 30s request deadline.
  [  +96s] gh: GitHub API GET exceeded the 30s request deadline.
  [  +96s] Docker E2E image artifact metadata GitHub API GET failed after 3 attempt(s).
  [  +96s] === helper exit status: 1 ===
  ```

  Each stalled request is cut off at exactly the 30s deadline, both retries engage with the expected backoff, and the step fails bounded at +96s instead of hanging until the job timeout.
- `bash -n` syntax check clean; `git diff --check` clean; `pnpm tsgo:test:root` clean.



Fixes #130570
