### PR TITLE
fix(release): make validation fail-fast optional

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -45,6 +45,11 @@ on:
         required: false
         default: false
         type: boolean
+      fail_fast:
+        description: Cancel each child workflow after its first failed job; false collects independent failures to completion
+        required: false
+        default: false
+        type: boolean
       rerun_group:
         description: Validation group to run
         required: false
@@ -177,6 +182,7 @@ jobs:
           CODEX_PLUGIN_SPEC: ${{ inputs.codex_plugin_spec }}
           RELEASE_PROFILE: ${{ inputs.release_profile }}
           RUN_RELEASE_SOAK: ${{ inputs.run_release_soak || inputs.release_profile == 'stable' || inputs.release_profile == 'full' }}
+          FAIL_FAST: ${{ inputs.fail_fast }}
           RERUN_GROUP: ${{ inputs.rerun_group }}
           LIVE_SUITE_FILTER: ${{ inputs.live_suite_filter }}
           CROSS_OS_SUITE_FILTER: ${{ inputs.cross_os_suite_filter }}
@@ -188,6 +194,7 @@ jobs:
             echo "- Target SHA: \`${TARGET_SHA}\`"
             echo "- Child workflow ref: \`${CHILD_WORKFLOW_REF}\`"
             echo "- Release soak lanes: \`${RUN_RELEASE_SOAK}\`"
+            echo "- Fail fast: \`${FAIL_FAST}\`"
             echo "- Rerun group: \`${RERUN_GROUP}\`"
             if [[ -n "${LIVE_SUITE_FILTER// }" ]]; then
               echo "- Live suite filter: \`${LIVE_SUITE_FILTER}\`"
@@ -395,6 +402,7 @@ jobs:
           TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
           CHILD_WORKFLOW_REF: ${{ github.ref_name }}
           PARENT_WORKFLOW_SHA: ${{ github.sha }}
+          FAIL_FAST: ${{ inputs.fail_fast }}
         run: |
           set -euo pipefail
 
@@ -487,7 +495,10 @@ jobs:
               gh_with_retry api --paginate "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs?per_page=100" --jq '.jobs[]'
             }
 
-            fail_fast_failed_jobs() {
+            cancel_on_failed_jobs_when_enabled() {
+              if [[ "$FAIL_FAST" != "true" ]]; then
+                return 0
+              fi
               local failed_jobs_json
               failed_jobs_json="$(
                 fetch_child_jobs |
@@ -526,7 +537,7 @@ jobs:
               fi
               poll_count=$((poll_count + 1))
               if (( poll_count % 2 == 0 )); then
-                fail_fast_failed_jobs
+                cancel_on_failed_jobs_when_enabled
               fi
               if (( poll_count % 10 == 0 )); then
                 echo "Still waiting on ${workflow}: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
@@ -585,6 +596,7 @@ jobs:
           TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
           CHILD_WORKFLOW_REF: ${{ github.ref_name }}
           PARENT_WORKFLOW_SHA: ${{ github.sha }}
+          FAIL_FAST: ${{ inputs.fail_fast }}
         run: |
           set -euo pipefail
 
@@ -677,7 +689,10 @@ jobs:
               gh_with_retry api --paginate "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs?per_page=100" --jq '.jobs[]'
             }
 
-            fail_fast_failed_jobs() {
+            cancel_on_failed_jobs_when_enabled() {
+              if [[ "$FAIL_FAST" != "true" ]]; then
+                return 0
+              fi
               local failed_jobs_json
               failed_jobs_json="$(
                 fetch_child_jobs |
@@ -716,7 +731,7 @@ jobs:
               fi
               poll_count=$((poll_count + 1))
               if (( poll_count % 2 == 0 )); then
-                fail_fast_failed_jobs
+                cancel_on_failed_jobs_when_enabled
               fi
               if (( poll_count % 10 == 0 )); then
                 echo "Still waiting on ${workflow}: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
@@ -772,6 +787,7 @@ jobs:
           MODE: ${{ inputs.mode }}
           RELEASE_PROFILE: ${{ inputs.release_profile }}
           RUN_RELEASE_SOAK: ${{ inputs.run_release_soak || inputs.release_profile == 'stable' || inputs.release_profile == 'full' }}
+          FAIL_FAST: ${{ inputs.fail_fast }}
           RERUN_GROUP: ${{ inputs.rerun_group }}
           LIVE_SUITE_FILTER: ${{ inputs.live_suite_filter }}
           CROSS_OS_SUITE_FILTER: ${{ inputs.cross_os_suite_filter }}
@@ -910,7 +926,10 @@ jobs:
               [[ "$saw_advisory" == "1" && "$failed" == "0" ]]
             }
 
-            fail_fast_failed_jobs() {
+            cancel_on_failed_jobs_when_enabled() {
+              if [[ "$FAIL_FAST" != "true" ]]; then
+                return 0
+              fi
               local failed_jobs_json
               if [[ "$workflow" == "openclaw-release-checks.yml" && "$CHILD_WORKFLOW_REF" =~ ^tideclaw/alpha/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z$ ]]; then
                 return 0
@@ -952,7 +971,7 @@ jobs:
               fi
               poll_count=$((poll_count + 1))
               if (( poll_count % 2 == 0 )); then
-                fail_fast_failed_jobs
+                cancel_on_failed_jobs_when_enabled
               fi
               if (( poll_count % 10 == 0 )); then
                 echo "Still waiting on ${workflow}: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
@@ -1026,6 +1045,7 @@ jobs:
             -f mode="$MODE"
             -f release_profile="$RELEASE_PROFILE"
             -f run_release_soak="$RUN_RELEASE_SOAK"
+            -f fail_fast="$FAIL_FAST"
             -f rerun_group="$child_rerun_group"
           )
           if [[ -n "${LIVE_SUITE_FILTER// }" ]]; then
@@ -1071,6 +1091,7 @@ jobs:
           PACKAGE_SPEC: ${{ inputs.npm_telegram_package_spec || inputs.release_package_spec }}
           PROVIDER_MODE: ${{ inputs.npm_telegram_provider_mode }}
           SCENARIO: ${{ inputs.npm_telegram_scenario }}
+          FAIL_FAST: ${{ inputs.fail_fast }}
         run: |
           set -euo pipefail
 
@@ -1176,7 +1197,10 @@ jobs:
             exit 1
           fi
 
-          fail_fast_failed_jobs() {
+          cancel_on_failed_jobs_when_enabled() {
+            if [[ "$FAIL_FAST" != "true" ]]; then
+              return 0
+            fi
             local failed_jobs_json
             failed_jobs_json="$(
               gh_with_retry run view "$run_id" --json jobs \
@@ -1199,7 +1223,7 @@ jobs:
             fi
             poll_count=$((poll_count + 1))
             if (( poll_count % 2 == 0 )); then
-              fail_fast_failed_jobs
+              cancel_on_failed_jobs_when_enabled
             fi
             if (( poll_count % 10 == 0 )); then
               echo "Still waiting on npm-telegram-beta-e2e.yml: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -46,6 +46,11 @@ on:
         required: false
         default: false
         type: boolean
+      fail_fast:
+        description: Stop the Matrix QA lane after its first failed check or scenario
+        required: false
+        default: false
+        type: boolean
       run_maturity_scorecard:
         description: Render advisory maturity scorecard release docs; default release checks rely on dedicated package, QA, live, and E2E gates
         required: false
@@ -118,6 +123,7 @@ jobs:
       mode: ${{ steps.inputs.outputs.mode }}
       release_profile: ${{ steps.inputs.outputs.release_profile }}
       run_release_soak: ${{ steps.inputs.outputs.run_release_soak }}
+      fail_fast: ${{ steps.inputs.outputs.fail_fast }}
       run_maturity_scorecard: ${{ steps.inputs.outputs.run_maturity_scorecard }}
       rerun_group: ${{ steps.inputs.outputs.rerun_group }}
       live_suite_filter: ${{ steps.inputs.outputs.live_suite_filter }}
@@ -292,6 +298,7 @@ jobs:
           RELEASE_MODE_INPUT: ${{ inputs.mode }}
           RELEASE_PROFILE_INPUT: ${{ inputs.release_profile }}
           RELEASE_RUN_RELEASE_SOAK_INPUT: ${{ inputs.run_release_soak }}
+          RELEASE_FAIL_FAST_INPUT: ${{ inputs.fail_fast }}
           RELEASE_RUN_MATURITY_SCORECARD_INPUT: ${{ inputs.run_maturity_scorecard }}
           RELEASE_RERUN_GROUP_INPUT: ${{ inputs.rerun_group }}
           RELEASE_LIVE_SUITE_FILTER_INPUT: ${{ inputs.live_suite_filter }}
@@ -332,6 +339,12 @@ jobs:
             run_release_soak=false
           else
             run_release_soak=true
+          fi
+          fail_fast="$(printf '%s' "$RELEASE_FAIL_FAST_INPUT" | tr '[:upper:]' '[:lower:]')"
+          if [[ "$fail_fast" != "true" && "$fail_fast" != "1" && "$fail_fast" != "yes" ]]; then
+            fail_fast=false
+          else
+            fail_fast=true
           fi
           run_maturity_scorecard="$(printf '%s' "$RELEASE_RUN_MATURITY_SCORECARD_INPUT" | tr '[:upper:]' '[:lower:]')"
           if [[ "$run_maturity_scorecard" != "true" && "$run_maturity_scorecard" != "1" && "$run_maturity_scorecard" != "yes" ]]; then
@@ -442,6 +455,7 @@ jobs:
             printf 'mode=%s\n' "$RELEASE_MODE_INPUT"
             printf 'release_profile=%s\n' "$release_profile"
             printf 'run_release_soak=%s\n' "$run_release_soak"
+            printf 'fail_fast=%s\n' "$fail_fast"
             printf 'run_maturity_scorecard=%s\n' "$run_maturity_scorecard"
             printf 'rerun_group=%s\n' "$RELEASE_RERUN_GROUP_INPUT"
             printf 'live_suite_filter=%s\n' "$RELEASE_LIVE_SUITE_FILTER_INPUT"
@@ -465,6 +479,7 @@ jobs:
           RELEASE_MODE: ${{ inputs.mode }}
           RELEASE_PROFILE: ${{ steps.inputs.outputs.release_profile }}
           RUN_RELEASE_SOAK: ${{ steps.inputs.outputs.run_release_soak }}
+          FAIL_FAST: ${{ steps.inputs.outputs.fail_fast }}
           RUN_MATURITY_SCORECARD: ${{ steps.inputs.outputs.run_maturity_scorecard }}
           RELEASE_RERUN_GROUP: ${{ inputs.rerun_group }}
           RELEASE_LIVE_SUITE_FILTER: ${{ inputs.live_suite_filter }}
@@ -483,6 +498,7 @@ jobs:
             echo "- Cross-OS mode: \`${RELEASE_MODE}\`"
             echo "- Release profile: \`${RELEASE_PROFILE}\`"
             echo "- Release soak lanes: \`${RUN_RELEASE_SOAK}\`"
+            echo "- Matrix QA fail fast: \`${FAIL_FAST}\`"
             echo "- Maturity scorecard docs: \`${RUN_MATURITY_SCORECARD}\`"
             echo "- Rerun group: \`${RELEASE_RERUN_GROUP}\`"
             if [[ -n "${RELEASE_LIVE_SUITE_FILTER// }" ]]; then
@@ -1408,6 +1424,7 @@ jobs:
           OPENCLAW_QA_REDACT_PUBLIC_METADATA: "1"
           OPENCLAW_QA_MATRIX_CANARY_TIMEOUT_MS: "90000"
           OPENCLAW_QA_MATRIX_NO_REPLY_WINDOW_MS: "3000"
+          FAIL_FAST: ${{ needs.resolve_target.outputs.fail_fast }}
         run: |
           set -euo pipefail
 
@@ -1422,7 +1439,7 @@ jobs:
             --profile fast \
             --fast
           )
-          if pnpm openclaw qa matrix --help 2>/dev/null | grep -F -q -- "--fail-fast"; then
+          if [[ "$FAIL_FAST" == "true" ]] && pnpm openclaw qa matrix --help 2>/dev/null | grep -F -q -- "--fail-fast"; then
             matrix_args+=(--fail-fast)
           fi
 

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1931,6 +1931,7 @@ describe("package artifact reuse", () => {
     expect(npmTelegramJob.if).not.toContain("inputs.rerun_group == 'all'");
     expect(dispatchStep.env).toEqual({
       CHILD_WORKFLOW_REF: "${{ github.ref_name }}",
+      FAIL_FAST: "${{ inputs.fail_fast }}",
       GH_TOKEN: "${{ github.token }}",
       PACKAGE_SPEC: "${{ inputs.npm_telegram_package_spec || inputs.release_package_spec }}",
       PARENT_WORKFLOW_SHA: "${{ github.sha }}",

--- a/test/scripts/release-no-push-workflow.test.ts
+++ b/test/scripts/release-no-push-workflow.test.ts
@@ -75,6 +75,26 @@ function expectReadOnlyPackagePermission(workflowJob: WorkflowJob): void {
 }
 
 describe("release validation no-push transport", () => {
+  it("collects child failures by default and propagates explicit fail-fast", () => {
+    const fullReleaseSource = readFileSync(FULL_RELEASE, "utf8");
+    const fullRelease = readWorkflow(FULL_RELEASE);
+    const releaseChecksSource = readFileSync(RELEASE_CHECKS, "utf8");
+    const releaseChecks = readWorkflow(RELEASE_CHECKS);
+
+    expect(fullRelease.on?.workflow_dispatch?.inputs?.fail_fast).toMatchObject({
+      default: false,
+      type: "boolean",
+    });
+    expect(fullReleaseSource.match(/if \[\[ "\$FAIL_FAST" != "true" \]\]; then/gu)).toHaveLength(4);
+    expect(fullReleaseSource).toContain('-f fail_fast="$FAIL_FAST"');
+    expect(releaseChecks.on?.workflow_dispatch?.inputs?.fail_fast).toMatchObject({
+      default: false,
+      type: "boolean",
+    });
+    expect(releaseChecksSource).toContain("FAIL_FAST: ${{ needs.resolve_target.outputs.fail_fast }}");
+    expect(releaseChecksSource).toContain('if [[ "$FAIL_FAST" == "true" ]]');
+  });
+
   it("does not persist Git credentials in validation checkouts", () => {
     for (const workflowPath of [PLUGIN_PRERELEASE, RELEASE_CHECKS]) {
       const workflow = readWorkflow(workflowPath);


### PR DESCRIPTION
## What Problem This Solves

A transiently canceled child job in Full Release Validation caused the dispatcher to cancel the entire Release Checks child workflow. The resulting `live_test_image_ready` failure was a cascading harness failure, not a package or runtime regression.

## Why This Change Was Made

This adapts the already-shipped mainline release-harness policy for the frozen extended-stable release candidate: collect independent child failures by default, while preserving opt-in cancellation when `fail_fast=true`. The value is propagated to Release Checks so Matrix QA only receives its native fail-fast flag when explicitly requested.

## User Impact

No runtime, package, tag, registry, or publication behavior changes. Full validation now preserves independent diagnostic results after an interrupted child job instead of converting it into a cancellation cascade.

## Evidence

- Fresh autoreview: clean; patch correct (0.89 confidence).
- `actionlint .github/workflows/full-release-validation.yml .github/workflows/openclaw-release-checks.yml`
- Focused workflow-contract test: `node scripts/run-vitest.mjs test/scripts/release-no-push-workflow.test.ts`
- Exact-branch remote changed gate is running in Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31674521846
- Mainline precedent: cb023bb1fb39dd05c57578845d8aa277dae4f5d6.