### PR TITLE
chore(nostr): stop leaking private key test fixtures

### DIFF
--- a/extensions/nostr/src/channel.test.ts
+++ b/extensions/nostr/src/channel.test.ts
@@ -5,7 +5,8 @@ import {
   runSetupWizardConfigure,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import type { WizardPrompter } from "openclaw/plugin-sdk/plugin-test-runtime";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { withEnv } from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
 import { nostrPlugin } from "./channel.js";
 import { normalizePubkey } from "./nostr-key-utils.js";
@@ -18,10 +19,6 @@ import {
   createConfiguredNostrCfg,
 } from "./test-fixtures.js";
 import { listNostrAccountIds, resolveDefaultNostrAccountId, resolveNostrAccount } from "./types.js";
-
-afterEach(() => {
-  vi.unstubAllEnvs();
-});
 
 describe("nostr target classification", () => {
   it("accepts only valid direct-message public keys", () => {
@@ -437,8 +434,9 @@ describe("nostr unresolved SecretRef privateKey", () => {
   it.each(unresolvedSecretRefPrivateKeyCases)(
     "$name does not treat unresolved SecretRef privateKey as configured",
     ({ assert }) => {
-      vi.stubEnv("NOSTR_PRIVATE_KEY", TEST_HEX_PRIVATE_KEY);
-      assert(createUnresolvedNostrPrivateKeyCfg());
+      withEnv({ NOSTR_PRIVATE_KEY: TEST_HEX_PRIVATE_KEY }, () => {
+        assert(createUnresolvedNostrPrivateKeyCfg());
+      });
     },
   );
 });
@@ -515,13 +513,13 @@ describe("nostr account helpers", () => {
     });
 
     it("resolves the default account private key from NOSTR_PRIVATE_KEY", () => {
-      vi.stubEnv("NOSTR_PRIVATE_KEY", TEST_HEX_PRIVATE_KEY);
+      withEnv({ NOSTR_PRIVATE_KEY: TEST_HEX_PRIVATE_KEY }, () => {
+        const account = resolveNostrAccount({ cfg: { channels: { nostr: { enabled: true } } } });
 
-      const account = resolveNostrAccount({ cfg: { channels: { nostr: { enabled: true } } } });
-
-      expect(account.configured).toBe(true);
-      expect(account.privateKey).toBe(TEST_HEX_PRIVATE_KEY);
-      expect(account.publicKey).toMatch(/^[0-9a-f]{64}$/);
+        expect(account.configured).toBe(true);
+        expect(account.privateKey).toBe(TEST_HEX_PRIVATE_KEY);
+        expect(account.publicKey).toMatch(/^[0-9a-f]{64}$/);
+      });
     });
 
     it("handles disabled channel", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the non-isolated extension-messaging shard could leak the synthetic Nostr private key fixture into later no-environment assertions, producing four deterministic failures in `extensions/nostr/src/channel.test.ts`.

Original failures:
- https://github.com/openclaw/openclaw/actions/runs/31672706165/job/94360719261
- https://github.com/openclaw/openclaw/actions/runs/31672706165/job/94361877203

## Why This Change Was Made

The env-setting tests now use the existing lexical `withEnv` helper through the public plugin test facade, which restores `NOSTR_PRIVATE_KEY` in `finally`. The redundant file-global `afterEach(vi.unstubAllEnvs)` hook is removed, avoiding Vitest's shared env-stub bookkeeping as the cleanup owner.

Provenance: commit `99d662473cb` introduced the leaking setter and global cleanup together.

## User Impact

No runtime or user-visible behavior changes. This stabilizes the extension-messaging CI shard; production LOC delta is zero and the test diff is +11/-13.

## Evidence

- Exact extension-messaging order proof on Vitest 4.1.10: https://github.com/openclaw/openclaw/actions/runs/31673663743
  - Nostr: 45/45 passed
  - Full lane: 131 files / 1411 tests passed
- Exact Nostr oxlint: https://github.com/openclaw/openclaw/actions/runs/31674537443 — 0 warnings, 0 errors
- `check:changed` policy, formatting, boundary, dependency, dead-export, and extension-test typecheck gates passed before its prepared checkout over-selected unrelated core/UI lint work: https://github.com/openclaw/openclaw/actions/runs/31673891206
- Independent autoreview: no accepted/actionable findings; patch correct (0.99 confidence)
