### PR TITLE
fix(failover): classify transient Undici error codes

### DIFF
--- a/src/agents/embedded-agent-helpers/assistant-message-failures.test.ts
+++ b/src/agents/embedded-agent-helpers/assistant-message-failures.test.ts
@@ -25,6 +25,24 @@ describe("classifyAssistantFailoverReason", () => {
     expect(classifyAssistantFailoverReason(opencodeGoStalledStreamError)).toBe("timeout");
   });
 
+  it.each([
+    "UND_ERR_CONNECT_TIMEOUT",
+    "UND_ERR_DNS_RESOLVE_FAILED",
+    "UND_ERR_CONNECT",
+    "UND_ERR_SOCKET",
+    "UND_ERR_HEADERS_TIMEOUT",
+    "UND_ERR_BODY_TIMEOUT",
+  ])("classifies structured %s assistant errors as timeouts", (errorCode) => {
+    expect(
+      classifyAssistantFailoverReason({
+        ...opencodeGoStalledStreamError,
+        provider: "demo-provider",
+        errorCode,
+        errorMessage: "provider connection closed",
+      }),
+    ).toBe("timeout");
+  });
+
   it("does not classify caller-aborted assistant messages as provider failover", () => {
     expect(
       classifyAssistantFailoverReason({

--- a/src/agents/embedded-agent-helpers/assistant-message-failures.test.ts
+++ b/src/agents/embedded-agent-helpers/assistant-message-failures.test.ts
@@ -26,6 +26,7 @@ describe("classifyAssistantFailoverReason", () => {
   });
 
   it.each([
+    "ENOTFOUND",
     "UND_ERR_CONNECT_TIMEOUT",
     "UND_ERR_DNS_RESOLVE_FAILED",
     "UND_ERR_CONNECT",

--- a/src/agents/failover/classification-rules.ts
+++ b/src/agents/failover/classification-rules.ts
@@ -22,6 +22,13 @@ const TIMEOUT_ERROR_CODES = new Set([
   "EPIPE",
   "EAI_AGAIN",
   "ERR_STREAM_PREMATURE_CLOSE",
+  // Keep these aligned with src/infra/retryable-network-errors.ts.
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_DNS_RESOLVE_FAILED",
+  "UND_ERR_CONNECT",
+  "UND_ERR_SOCKET",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_BODY_TIMEOUT",
 ]);
 const NO_BODY_HTTP_WRAPPER_RE =
   /^(?:no body(?: response)?|no response body|status code \(no body\))$/i;

--- a/src/agents/failover/classification-rules.ts
+++ b/src/agents/failover/classification-rules.ts
@@ -1,4 +1,5 @@
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import { isTransientNetworkError } from "../../infra/retryable-network-errors.js";
 import {
   extractLeadingHttpStatus,
   parseApiErrorInfo,
@@ -9,26 +10,10 @@ import {
   isRateLimitErrorMessage,
 } from "./message-patterns.js";
 import type { FailoverClassification, FailoverReason, FailoverSignal } from "./signal.js";
-const TIMEOUT_ERROR_CODES = new Set([
-  "ETIMEDOUT",
-  "ESOCKETTIMEDOUT",
-  "ECONNRESET",
-  "ECONNABORTED",
-  "ECONNREFUSED",
-  "ENETUNREACH",
-  "EHOSTUNREACH",
+const FAILOVER_TIMEOUT_ERROR_CODES = new Set([
   "EHOSTDOWN",
   "ENETRESET",
-  "EPIPE",
-  "EAI_AGAIN",
   "ERR_STREAM_PREMATURE_CLOSE",
-  // Keep these aligned with src/infra/retryable-network-errors.ts.
-  "UND_ERR_CONNECT_TIMEOUT",
-  "UND_ERR_DNS_RESOLVE_FAILED",
-  "UND_ERR_CONNECT",
-  "UND_ERR_SOCKET",
-  "UND_ERR_HEADERS_TIMEOUT",
-  "UND_ERR_BODY_TIMEOUT",
 ]);
 const NO_BODY_HTTP_WRAPPER_RE =
   /^(?:no body(?: response)?|no response body|status code \(no body\))$/i;
@@ -349,7 +334,10 @@ export function classifyFailoverReasonFromCode(raw: string | undefined): Failove
     case "OVERLOADED_ERROR":
       return "overloaded";
     default:
-      return TIMEOUT_ERROR_CODES.has(normalized) ? "timeout" : null;
+      return FAILOVER_TIMEOUT_ERROR_CODES.has(normalized) ||
+        isTransientNetworkError({ code: normalized })
+        ? "timeout"
+        : null;
   }
 }
 export function classifyCoreFailoverReasonFromErrorType(

--- a/src/agents/failover/retry-evidence.ts
+++ b/src/agents/failover/retry-evidence.ts
@@ -1,5 +1,6 @@
 import { parseRetryAfterHttpDateMs } from "@openclaw/ai/internal/retry-after";
 import milliseconds from "ms";
+import { isTransientNetworkError } from "../../infra/retryable-network-errors.js";
 import {
   extractErrorHttpStatus,
   extractLeadingHttpStatus,
@@ -48,12 +49,13 @@ function resolveRetrySignalStatus(signal: Pick<FailoverSignal, "message" | "stat
 
 /** Narrow evidence that replaying the same assistant request may succeed within this session. */
 export function hasTransientRetryEvidence(
-  signal: Pick<FailoverSignal, "message" | "status">,
+  signal: Pick<FailoverSignal, "code" | "message" | "status">,
 ): boolean {
   const status = resolveRetrySignalStatus(signal);
   return (
     (status !== undefined && RETRYABLE_HTTP_STATUS_CODES.has(status)) ||
-    TRANSIENT_RETRY_EVIDENCE_RE.test(signal.message ?? "")
+    TRANSIENT_RETRY_EVIDENCE_RE.test(signal.message ?? "") ||
+    isTransientNetworkError({ code: signal.code })
   );
 }
 

--- a/src/llm/utils/retry.test.ts
+++ b/src/llm/utils/retry.test.ts
@@ -55,6 +55,15 @@ describe("isRetryableAssistantError", () => {
     ).toBe(false);
   });
 
+  it("retries a structured transient Undici error", () => {
+    expect(
+      isRetryableAssistantError({
+        ...errorMessage("provider connection closed"),
+        errorCode: "UND_ERR_HEADERS_TIMEOUT",
+      }),
+    ).toBe(true);
+  });
+
   it.each([
     "An error occurred while processing your request. You can retry your request.",
     "The system encountered an unexpected error. Try your request again.",

--- a/src/llm/utils/retry.ts
+++ b/src/llm/utils/retry.ts
@@ -36,6 +36,8 @@ export function isRetryableAssistantError(message: AssistantMessage): boolean {
   const signal = {
     message: errorMessage,
     provider: message.provider,
+    code: message.errorCode,
+    errorType: message.errorType,
     ...(status === undefined ? {} : { status }),
   };
   const classification = classifyFailoverSignal(signal);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agent runs could stop without retry or failover when a transient transport failure was preserved only as a structured error code and its message did not identify the network failure.

## Why This Change Was Made

Assistant retry now forwards structured `errorCode` / `errorType` fields into the failover signal. Core failover classification reuses the existing shared transient-network matcher rather than maintaining a second Undici-only policy, while the three failover-specific codes remain local to failover.

## User Impact

Transient connection, DNS, socket, and response-timeout failures can now follow the normal retry and failover policy instead of ending the agent run. This adds no API, config, schema, migration, or default change.

## Evidence

### Exact-head real transport fault

Verified at `b5b4a9bf11fad122732171f695fd13a0caf120c3` with a disposable, secretless loopback harness:

1. A real Undici `request()` POST was sent to a local TCP server that accepted the connection but withheld response headers (`headersTimeout: 50`).
2. Undici emitted an actual `HeadersTimeoutError` carrying `UND_ERR_HEADERS_TIMEOUT`.
3. That caught error object was passed unchanged to production `failTransportStream`; the harness did **not** construct or assign an assistant `errorCode`.
4. Production transport projection preserved the code, embedded-agent failover classified it as `timeout`, and outer assistant retry accepted it.

```text
$ node --import tsx scripts/pr-123042-transport-proof.mts
{
  "head": "b5b4a9bf11fad122732171f695fd13a0caf120c3",
  "transport": "Undici request -> loopback headers timeout -> OpenClaw transport projection",
  "sourceErrorName": "HeadersTimeoutError",
  "sourceErrorCode": "UND_ERR_HEADERS_TIMEOUT",
  "stopReason": "error",
  "projectedErrorCode": "UND_ERR_HEADERS_TIMEOUT",
  "failoverReason": "timeout",
  "retryable": true
}
```

The disposable proof script and server were removed after the run; no branch files or credentials were used.

### Regression and review evidence

- Pre-fix focused regression: structured `ENOTFOUND` returned no failover classification on maintainer parent `0934155784f2759210024fe8dfe7a830ae990f7f`.
- Exact-head focused tests: `node scripts/run-vitest.mjs src/agents/embedded-agent-helpers/assistant-message-failures.test.ts src/llm/utils/retry.test.ts` — pass.
- Exact-head changed-file gate — pass.
- Exact-head local ClawSweeper — no findings.
- Exact-head autoreview — no findings.
- Canonical shared-policy precedent: #122535 added these transient transport codes to `src/infra/retryable-network-errors.ts`; this PR now consumes that owner directly.

AI-assisted: built with Codex
