### PR TITLE
fix(plugins): restore CLI policy after retained reinstall

### DIFF
--- a/src/plugins/install-persistence.test.ts
+++ b/src/plugins/install-persistence.test.ts
@@ -44,6 +44,7 @@ function expectRuntimeLogIncludes(fragment: string) {
 function createManifestRecord(
   id: string,
   overrides: Partial<PluginManifestRecord> = {},
+  owner = id,
 ): PluginManifestRecord {
   const rootDir = path.join(os.tmpdir(), "openclaw-plugin-fixtures", id);
   return recordPluginManifestInstallOwner(
@@ -60,7 +61,7 @@ function createManifestRecord(
       manifestPath: path.join(rootDir, "openclaw.plugin.json"),
       ...overrides,
     },
-    id,
+    owner,
   );
 }
 
@@ -621,26 +622,20 @@ describe("persistPluginInstall", () => {
     expect(clearPluginRegistryLoadCacheMock).not.toHaveBeenCalled();
   });
 
-  it("removes stale denylist entries before enabling installed plugins", async () => {
+  it("restores runtime child policy when reinstalling its package owner", async () => {
     const { persistPluginInstall } = await import("./install-persistence.js");
     const baseConfig = {
       plugins: {
-        deny: ["alpha", "other"],
+        allow: ["memory-core"],
+        deny: ["demo-plugin-npm", "other"],
       },
     } as OpenClawConfig;
-    const enabledConfig = {
-      plugins: {
-        deny: ["other"],
-        entries: {
-          alpha: { enabled: true },
-        },
-      },
-    } as OpenClawConfig;
-    enablePluginInConfigMock.mockImplementation((...args: unknown[]) => {
-      const [cfg, pluginId] = args as [OpenClawConfig, string];
-      expect(pluginId).toBe("alpha");
-      expect(cfg.plugins?.deny).toEqual(["other"]);
-      return { config: enabledConfig, enabled: true };
+    setInstalledPluginIndexInstallRecords({
+      "demo-package": { source: "npm", spec: "@openclaw/demo-package@0.0.1" },
+    });
+    loadPluginManifestRegistryMock.mockReturnValue({
+      plugins: [createManifestRecord("demo-plugin-npm", {}, "demo-package")],
+      diagnostics: [],
     });
 
     const next = await persistPluginInstall({
@@ -649,15 +644,17 @@ describe("persistPluginInstall", () => {
         baseHash: "config-1",
         writeOptions: installWriteOptions,
       },
-      pluginId: "alpha",
+      pluginId: "demo-package",
       install: {
         source: "npm",
-        spec: "alpha@1.0.0",
-        installPath: "/tmp/alpha",
+        spec: "@openclaw/demo-package@0.0.1",
+        installPath: "/tmp/demo-package",
       },
     });
 
-    expect(next).toEqual(enabledConfig);
+    expect(next.plugins?.allow).toEqual(["memory-core", "demo-plugin-npm"]);
+    expect(next.plugins?.deny).toEqual(["other"]);
+    expect(enablePluginInConfigMock).toHaveBeenCalledTimes(1);
   });
 
   it("scopes runtime kind lookup to the selected plugin when metadata omits kind", async () => {

--- a/src/plugins/install-persistence.ts
+++ b/src/plugins/install-persistence.ts
@@ -579,28 +579,20 @@ export async function persistPluginInstall(params: {
 
   let next = reconciledConfig;
   const enabledPluginIds: string[] = [];
-  const preserveExistingPolicy = previousInstall !== undefined;
   for (const pluginId of ownedPluginIds) {
     const configEnablement = enablementByPluginId.get(pluginId) ?? { mode: "ready" as const };
     const explicitlyDisabled = reconciledConfig.plugins?.entries?.[pluginId]?.enabled === false;
-    const existingAllow = reconciledConfig.plugins?.allow ?? [];
-    const blockedByExistingPolicy =
-      preserveExistingPolicy &&
-      ((reconciledConfig.plugins?.deny ?? []).includes(pluginId) ||
-        (existingAllow.length > 0 && !existingAllow.includes(pluginId)));
     if (configEnablement.mode === "missing") {
       next = prepareConfigForDisabledInstall(next, pluginId);
     }
     if (params.enable === false) {
       continue;
     }
-    if (!preserveExistingPolicy) {
-      next = removeInstalledPluginFromDenylist(
-        addInstalledPluginToAllowlist(next, pluginId),
-        pluginId,
-      );
-    }
-    if (configEnablement.mode !== "ready" || explicitlyDisabled || blockedByExistingPolicy) {
+    next = removeInstalledPluginFromDenylist(
+      addInstalledPluginToAllowlist(next, pluginId),
+      pluginId,
+    );
+    if (configEnablement.mode !== "ready" || explicitlyDisabled) {
       continue;
     }
     const enabled = enablePluginInConfig(next, pluginId, { updateChannelConfig: false });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where reinstalling an npm plugin after `plugins uninstall --keep-files` could leave the plugin excluded by a restrictive `plugins.allow` policy, so its CLI command remained unavailable even though reinstall succeeded.

## Why This Change Was Made

Install persistence treated any existing install record as authority to preserve stale allow/deny policy. Explicit install and reinstall now restore each manifest-owned runtime child to `plugins.allow` and remove it from `plugins.deny`, while retaining the existing missing-configuration, explicitly-disabled-entry, and `enable: false` gates.

The architectural owner is plugin install persistence. The fix removes the duplicate `preserveExistingPolicy` / `existingAllow` / `blockedByExistingPolicy` branch and keeps policy mutation in the canonical owned-child loop.

Production LOC: `+5/-13` (net `-8`). Tests: `+17/-20` (net `-3`).

## User Impact

Operators can uninstall an npm plugin while retaining files and reinstall it without manually repairing `plugins.allow` before using the plugin's CLI surface.

## Evidence

- Reproduced on current `main` with `OPENCLAW_PLUGIN_LIFECYCLE_TRACE=1 OPENCLAW_PLUGINS_E2E_CLAWHUB=0 pnpm test:docker:plugins`: `demo-npm` was rejected because restrictive policy omitted owner plugin `demo-plugin-npm`.
- Focused regression: `src/plugins/install-persistence.test.ts` passes 18/18.
- Package-update sibling: `src/plugins/plugin-package-update.test.ts` passes 3/3.
- Changed-surface Testbox `tbx_01kzwyrp0m6pfhyd0yspwxegms`: core/core-test typechecks, targeted lint, formatting, boundaries, and guards pass.
- Repaired plugins-offline Testbox `tbx_01kzwz4ntbh9cgb7vg1q1cftsz`: full Docker plugin install/update/uninstall/reinstall flow passes with `OK`.

The standalone warning-sink sibling has an unchanged `main` fixture defect in two new-install cases: mocked manifests lack authoritative install-owner metadata and fail before this policy branch. Its two retained-install warning cases pass; this PR does not widen into that separate fixture repair.
