### PR TITLE
fix: agents_list reports routing alias instead of the resolved model

### DIFF
--- a/src/agents/tools/agents-list-tool.test.ts
+++ b/src/agents/tools/agents-list-tool.test.ts
@@ -83,6 +83,49 @@ describe("agents_list tool", () => {
     });
   });
 
+  it("resolves configured model aliases to the canonical model identity", async () => {
+    // Routing aliases are transport-level names; the tool must publish the
+    // resolved model that will actually run so spawn decisions see one identity.
+    loadConfigMock.mockReturnValue({
+      agents: {
+        defaults: {
+          model: {
+            primary: "clawrouter/openai/gpt-5.6",
+            fallbacks: ["openai/gpt-5.6-luna"],
+          },
+          models: {
+            "openai/gpt-5.6-sol": {
+              alias: "clawrouter/openai/gpt-5.6",
+              agentRuntime: { id: "codex" },
+            },
+          },
+          subagents: { allowAgents: ["main"] },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    } as unknown as OpenClawConfig);
+
+    const result = await createAgentsListTool({ agentSessionKey: "agent:main:main" }).execute(
+      "call",
+      {},
+    );
+    const details = result.details as AgentListDetails;
+
+    expect(details).toStrictEqual({
+      requester: "main",
+      allowAny: false,
+      agents: [
+        {
+          id: "main",
+          name: undefined,
+          configured: true,
+          model: "openai/gpt-5.6-sol",
+          agentRuntime: { id: "codex", source: "model" },
+        },
+      ],
+    });
+  });
+
   it("does not advertise stale allowlist-only targets as spawnable agents", async () => {
     // Allowlist entries are permissions, not agent definitions; stale ids should
     // not be presented as runnable subagents.
@@ -132,7 +175,7 @@ describe("agents_list tool", () => {
           id: "main",
           name: undefined,
           configured: true,
-          model: undefined,
+          model: "openai/gpt-5.6-sol",
           agentRuntime: { id: "codex", source: "implicit" },
         },
       ],
@@ -201,7 +244,7 @@ describe("agents_list tool", () => {
           id: "strict",
           name: undefined,
           configured: true,
-          model: undefined,
+          model: "openai/gpt-5.6-sol",
           agentRuntime: { id: "codex", source: "implicit" },
         },
       ],

--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -8,11 +8,7 @@ import { getRuntimeConfig } from "../../config/config.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { resolveModelAgentRuntimeMetadata } from "../agent-runtime-metadata.js";
 import { listAgentEntries, listAgentIds } from "../agent-scope-config.js";
-import {
-  resolveAgentConfig,
-  resolveAgentEffectiveModelPrimary,
-  resolveSessionAgentIds,
-} from "../agent-scope.js";
+import { resolveAgentConfig, resolveSessionAgentIds } from "../agent-scope.js";
 import { resolveDefaultModelForAgent } from "../model-selection.js";
 import { resolveSubagentAllowedTargetIds } from "../subagents/spawn/subagent-target-policy.js";
 import type { AnyAgentTool } from "./common.js";
@@ -132,8 +128,10 @@ export function createAgentsListTool(opts?: {
         .toSorted((a, b) => a.localeCompare(b));
       const ordered = all.includes(requesterAgentId) ? [requesterAgentId, ...rest] : rest;
       const agents: AgentListEntry[] = ordered.map((id) => {
-        const model = resolveAgentEffectiveModelPrimary(cfg, id);
         const resolvedModel = resolveDefaultModelForAgent({ cfg, agentId: id });
+        // Publish the resolved identity (aliases are routing-only) so the model
+        // field matches the agentRuntime derived from the same resolvedModel.
+        const model = `${resolvedModel.provider}/${resolvedModel.model}`;
         const agentRuntime = resolveModelAgentRuntimeMetadata({
           cfg,
           agentId: id,


### PR DESCRIPTION
Related: #122907 (same invariant fixed on the gateway `agents.list` surface)
Related gap finding: `agents-list-model-alias` (free-text issue, evidence level B — runtime before/after repro)

## What Problem This Solves

Fixes an issue where the `agents_list` tool reported a routing-layer model alias (e.g. a ClawHub router ref such as `clawrouter/openai/gpt-5.6`) as an agent's `model`, while the same entry's `agentRuntime` was derived from the resolved model. Agents consuming the tool for subagent spawn and model decisions saw two contradictory identities for the same agent.

## Why This Change Was Made

`agents_list` had the same projection split that gateway `agents.list` had before #122907: the `model` field came from the raw configured primary (`resolveAgentEffectiveModelPrimary`, aliases unresolved) while runtime metadata used `resolveDefaultModelForAgent`. The tool now publishes the canonical resolved provider/model — the same `resolvedModel` already feeding `agentRuntime` — so displayed identity and capabilities describe one model. Aliases remain routing-only; no hardcoded model ids. Agents without a configured model now see the resolved default model (previously `model` was omitted), consistent with the runtime metadata already emitted.

## User Impact

Agents using `agents_list` see the model that will actually run instead of a routing token, keeping spawn/runtime decisions consistent. Operator-facing surfaces (`models` CLI, system-agent overview) still show the authored config value.

## Evidence

### CI proof: resolved model identity from an initialized config (before/after)

Real behavior proved at exact immutable heads through the production config pipeline: a real `openclaw.json` is written into an isolated state dir (`OPENCLAW_STATE_DIR` under a temp `HOME`) and loaded by the real config loader — no config mocks — then the real `agents_list` tool executes and its output is captured. The identical scenario runs at both SHAs; machine-readable `[proof]` markers record the observed behavior.

- Before (main): `7eaf2fccf7ca9f2c22215324e3b5a04e19ac02e6`
- After (PR head): `bf93d5aaf8269898710e4bf82fe94496eddce4a9`
- Proof run: https://github.com/xialonglee/openclaw/actions/runs/31687675150
- Artifact download: https://github.com/xialonglee/openclaw/actions/runs/31687675150/artifacts/9176117557

Before markers (raw routing alias leaks into `model`; unconfigured agent omits `model`):

```text
[proof] scene=alias-model mode=before status=pass observed_model=clawrouter/openai/gpt-5.6 observed_runtime=codex/model expected_model=clawrouter/openai/gpt-5.6
[proof] scene=no-model mode=before status=pass model_present=false observed_model=<absent> observed_runtime=codex/implicit expected_model=<absent>
[proof] scene=plain-model mode=before status=pass observed_model=openai/gpt-5.5 observed_runtime=codex/model expected_model=openai/gpt-5.5
```

After markers (resolved canonical model published; resolved default now visible):

```text
[proof] scene=alias-model mode=after status=pass observed_model=openai/gpt-5.6-sol observed_runtime=codex/model expected_model=openai/gpt-5.6-sol
[proof] scene=no-model mode=after status=pass model_present=true observed_model=openai/gpt-5.6-sol observed_runtime=codex/implicit expected_model=openai/gpt-5.6-sol
[proof] scene=plain-model mode=after status=pass observed_model=openai/gpt-5.5 observed_runtime=codex/model expected_model=openai/gpt-5.5
```

- `src/agents/tools/agents-list-tool.test.ts`: 7 passed — new regression test covers the alias scenario; the two `model: undefined` expectations updated to the resolved default.
- `tsgo:core` (incremental): clean. `oxlint`: 0 warnings / 0 errors. `oxfmt`, `git diff --check`: clean.
- Review: `openclaw-pr-review` passed with best-fix verdict `best`.
