### PR TITLE
fix(doctor): stop after failed config migration writes

### DIFF
--- a/src/flows/doctor-core-checks.runtime.test.ts
+++ b/src/flows/doctor-core-checks.runtime.test.ts
@@ -714,13 +714,17 @@ describe("doctor provider catalog projection checks", () => {
     });
   });
 
-  it("loads full provider registrations for static catalog validation", async () => {
-    await collectProviderCatalogProjectionFindings({});
+  it("loads full provider registrations without selecting a default workspace", async () => {
+    const cfg = { agents: { list: [{ id: "alpha", default: true }, { id: "beta" }] } };
+    await collectProviderCatalogProjectionFindings(cfg);
 
     expect(mocks.resolvePluginProvidersCore).toHaveBeenCalledWith(
       expect.not.objectContaining({
         discoveryEntriesOnly: true,
       }),
+    );
+    expect(mocks.resolvePluginProvidersCore).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceDir: undefined }),
     );
   });
 

--- a/src/flows/doctor-core-checks.runtime.ts
+++ b/src/flows/doctor-core-checks.runtime.ts
@@ -10,7 +10,7 @@ import {
   listAgentIds,
   resolveAgentDir,
   resolveAgentWorkspaceDir,
-  resolveDefaultAgentId,
+  tryResolveSoleAgentId,
 } from "../agents/agent-scope.js";
 import { createOpenClawCodingTools } from "../agents/agent-tools.js";
 import { resolveEffectiveToolPolicy } from "../agents/agent-tools.policy.js";
@@ -53,7 +53,7 @@ import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.typ
 import { getPluginToolMeta, setPluginToolMeta } from "../plugins/tools.js";
 import type { ProviderCatalogOrder, ProviderPlugin } from "../plugins/types.js";
 import { normalizeAgentId } from "../routing/session-key.js";
-import { buildWorkspaceSkillStatus, type SkillStatusEntry } from "../skills/discovery/status.js";
+import { buildWorkspaceSkillStatus } from "../skills/discovery/status.js";
 import type { HealthCheckContext, HealthFinding } from "./health-checks.js";
 
 type BundleMcpToolRuntime = Awaited<ReturnType<typeof createBundleMcpToolRuntime>>;
@@ -64,12 +64,10 @@ function formatGatewayHealthTarget(url: string): string {
   return redactSensitiveUrlLikeString(url);
 }
 
-export function detectUnavailableSkills(cfg: OpenClawConfig): SkillStatusEntry[] {
-  const agentId = resolveDefaultAgentId(cfg);
-  const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+export function detectUnavailableSkills(cfg: OpenClawConfig, workspaceDir: string) {
   const report = buildWorkspaceSkillStatus(workspaceDir, {
     config: cfg,
-    agentId,
+    agentId: tryResolveSoleAgentId(cfg),
   });
   return collectUnavailableAgentSkills(report);
 }
@@ -618,11 +616,11 @@ function groupProviderCatalogsForDoctor(providers: readonly ProviderPlugin[]): {
 
 export async function collectProviderCatalogProjectionFindings(
   cfg: OpenClawConfig,
+  workspaceDir?: string,
 ): Promise<readonly HealthFinding[]> {
   const { runProviderStaticCatalog } = await import("../plugins/provider-discovery.js");
   const { resolvePluginProvidersCore } = await import("../plugins/providers.runtime.js");
   const env = process.env;
-  const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
   let providers: Awaited<ReturnType<typeof resolvePluginProvidersCore>>;
   try {
     providers = resolvePluginProvidersCore({

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -498,6 +498,7 @@ describe("CORE_HEALTH_CHECKS", () => {
 
   it("converts unavailable skills into repair-capable health findings", async () => {
     const unavailableSkill = createSkill();
+    const detectUnavailableSkills = vi.fn(async () => [unavailableSkill]);
     const cfg: OpenClawConfig = {
       agents: {
         defaults: {
@@ -507,18 +508,20 @@ describe("CORE_HEALTH_CHECKS", () => {
       },
     };
     const check = getCheck(
-      createCoreHealthChecks(
-        createDeps({
-          async detectUnavailableSkills(): Promise<readonly SkillStatusEntry[]> {
-            return [unavailableSkill];
-          },
-        }),
-      ),
+      createCoreHealthChecks(createDeps({ detectUnavailableSkills })),
       "core/doctor/skills-readiness",
     );
 
     expect(check).toMatchObject({ defaultEnabled: false });
     expect(check["repair"]).toBeTypeOf("function");
+    await expect(
+      check.detect({
+        mode: "lint",
+        runtime,
+        cfg: { agents: { list: [{ id: "alpha", default: true }, { id: "beta" }] } },
+      }),
+    ).resolves.toEqual([]);
+    expect(detectUnavailableSkills).not.toHaveBeenCalled();
 
     const findings = await check.detect({
       mode: "lint",
@@ -1043,6 +1046,7 @@ describe("core/doctor/bootstrap-size", () => {
           list: [{ id: "custom-agent", default: true, bootstrapMaxChars: 10_000 }],
         },
       },
+      cwd: tmp,
     });
 
     expect(findings).toContainEqual(
@@ -1053,5 +1057,20 @@ describe("core/doctor/bootstrap-size", () => {
         fixHint: expect.stringContaining("agents.entries.*.bootstrapMaxChars"),
       }),
     );
+    await expect(
+      check.detect({
+        mode: "lint",
+        runtime,
+        cfg: {
+          agents: {
+            defaults: { bootstrapMaxChars: 20_000 },
+            list: [
+              { id: "alpha", default: true, workspace: tmp, bootstrapMaxChars: 10_000 },
+              { id: "beta" },
+            ],
+          },
+        },
+      }),
+    ).resolves.toEqual([]);
   });
 });

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -1,6 +1,6 @@
 // Doctor core checks collect environment, config, and runtime readiness diagnostics.
 import path from "node:path";
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { tryResolveSoleAgentId } from "../agents/agent-scope.js";
 import { isExperimentalClawsEnabled } from "../claws/experimental.js";
 import {
   detectLegacyClawdBrowserProfileResidue,
@@ -73,7 +73,7 @@ const loadDoctorCoreChecksRuntimeModule = async () =>
 const loadDoctorWorkspaceModule = async () => await import("../commands/doctor-workspace.js");
 
 export type CoreHealthCheckDeps = {
-  readonly detectUnavailableSkills: (cfg: OpenClawConfig) => Promise<readonly SkillStatusEntry[]>;
+  readonly detectUnavailableSkills: typeof detectUnavailableSkillsWithRuntime;
   readonly collectSecurityWarnings: (cfg: OpenClawConfig) => Promise<readonly string[]>;
   readonly collectWorkspaceSuggestionNotes: (workspaceDir: string) => Promise<readonly string[]>;
   readonly collectRuntimeToolSchemaFindings: (
@@ -93,10 +93,10 @@ export type CoreHealthCheckDeps = {
 };
 
 async function detectUnavailableSkillsWithRuntime(
-  cfg: OpenClawConfig,
+  ctx: HealthCheckContext,
 ): Promise<readonly SkillStatusEntry[]> {
   const runtime = await loadDoctorCoreChecksRuntimeModule();
-  return runtime.detectUnavailableSkills(cfg);
+  return ctx.cwd ? runtime.detectUnavailableSkills(ctx.cfg, ctx.cwd) : [];
 }
 
 async function collectSecurityWarningsWithRuntime(cfg: OpenClawConfig): Promise<readonly string[]> {
@@ -139,7 +139,7 @@ async function collectProviderCatalogProjectionFindingsWithRuntime(
   ctx: HealthCheckContext,
 ): Promise<readonly HealthFinding[]> {
   const runtime = await loadDoctorCoreChecksRuntimeModule();
-  return runtime.collectProviderCatalogProjectionFindings(ctx.cfg);
+  return runtime.collectProviderCatalogProjectionFindings(ctx.cfg, ctx.cwd);
 }
 
 async function collectLocalAudioAccelerationFindingsWithRuntime(): Promise<
@@ -560,13 +560,16 @@ const bootstrapSizeCheck: HealthCheck = {
   description: "Workspace bootstrap files fit within configured injection limits.",
   source: "doctor",
   async detect(ctx) {
+    if (!ctx.cwd) {
+      return [];
+    }
     const { buildBootstrapInjectionStats, analyzeBootstrapBudget } =
       await import("../agents/bootstrap-budget.js");
     const { resolveBootstrapContextForRun } = await import("../agents/bootstrap-files.js");
     const { resolveBootstrapMaxChars, resolveBootstrapTotalMaxChars } =
       await import("../agents/embedded-agent-helpers.js");
-    const defaultAgentId = resolveDefaultAgentId(ctx.cfg);
-    const workspaceDir = resolveAgentWorkspaceDir(ctx.cfg, defaultAgentId);
+    const defaultAgentId = tryResolveSoleAgentId(ctx.cfg);
+    const workspaceDir = ctx.cwd;
     const { bootstrapFiles, contextFiles } = await resolveBootstrapContextForRun({
       workspaceDir,
       config: ctx.cfg,
@@ -1037,15 +1040,14 @@ function createSkillsReadinessCheck(
         runWithPluginMetadataSnapshot?: PluginMetadataSnapshotScopeRunner;
       }
     ).runWithPluginMetadataSnapshot;
-    const detect = () => deps.detectUnavailableSkills(ctx.cfg);
+    const detect = ctx.cwd ? () => deps.detectUnavailableSkills(ctx) : async () => [];
     if (!runWithPluginMetadataSnapshot) {
       return await detect();
     }
-    const defaultAgentId = resolveDefaultAgentId(ctx.cfg);
     return await runWithPluginMetadataSnapshot(
       {
         config: ctx.cfg,
-        workspaceDir: resolveAgentWorkspaceDir(ctx.cfg, defaultAgentId),
+        workspaceDir: ctx.cwd,
       },
       detect,
     );

--- a/src/flows/doctor-health-contribution-core.ts
+++ b/src/flows/doctor-health-contribution-core.ts
@@ -2,6 +2,7 @@ import type {
   DoctorHealthCheckContext,
   DoctorHealthFlowContext,
 } from "./doctor-health-contribution-types.js";
+import { resolveDoctorWorkspaceDir } from "./doctor-health-contribution-utils.js";
 import { renderStructuredHealthFindings } from "./doctor-health-contribution.js";
 import type { HealthCheck, HealthFinding } from "./health-checks.js";
 
@@ -29,11 +30,9 @@ export async function runStructuredHealthRepairs(
   const { registerBundledHealthChecks } = await import("./bundled-health-checks.js");
   const { listExtensionHealthChecksForDoctor } = await loadHealthCheckRegistryModule();
   const { runDoctorHealthRepairs } = await import("./doctor-repair-flow.js");
-  const { resolveAgentWorkspaceDir, resolveDefaultAgentId } =
-    await import("../agents/agent-scope.js");
   const { note } = await import("../../packages/terminal-core/src/note.js");
 
-  const workspaceDir = resolveAgentWorkspaceDir(ctx.cfg, resolveDefaultAgentId(ctx.cfg));
+  const workspaceDir = resolveDoctorWorkspaceDir(ctx.cfg, ctx.env);
   registerBundledHealthChecks({ cfg: ctx.cfg, cwd: workspaceDir });
   const checks = listExtensionHealthChecksForDoctor(await resolveCoreChecks());
   const result = await runDoctorHealthRepairs(
@@ -64,8 +63,6 @@ export async function runCoreContributionHealth(
   }
   const { CORE_HEALTH_CHECKS } = await import("./doctor-core-checks.js");
   const { runDoctorHealthRepairs } = await import("./doctor-repair-flow.js");
-  const { resolveAgentWorkspaceDir, resolveDefaultAgentId } =
-    await import("../agents/agent-scope.js");
   const { note } = await import("../../packages/terminal-core/src/note.js");
 
   const selectedIds = new Set(checkIds);
@@ -73,7 +70,7 @@ export async function runCoreContributionHealth(
   if (checks.length === 0) {
     return;
   }
-  const workspaceDir = resolveAgentWorkspaceDir(ctx.cfg, resolveDefaultAgentId(ctx.cfg));
+  const workspaceDir = resolveDoctorWorkspaceDir(ctx.cfg, ctx.env);
   const dryRun = !ctx.prompter.shouldRepair;
   const result = await runDoctorHealthRepairs(
     withDoctorHealthCheckFacts(ctx, {
@@ -119,8 +116,6 @@ export async function runCoreHealthFindingNote(
   checkId: string,
 ): Promise<void> {
   const { CORE_HEALTH_CHECKS } = await import("./doctor-core-checks.js");
-  const { resolveAgentWorkspaceDir, resolveDefaultAgentId } =
-    await import("../agents/agent-scope.js");
   const { note } = await import("../../packages/terminal-core/src/note.js");
 
   const check = CORE_HEALTH_CHECKS.find((candidate) => candidate.id === checkId);
@@ -132,7 +127,7 @@ export async function runCoreHealthFindingNote(
       mode: "doctor" as const,
       runtime: ctx.runtime,
       cfg: ctx.cfg,
-      cwd: resolveAgentWorkspaceDir(ctx.cfg, resolveDefaultAgentId(ctx.cfg)),
+      cwd: resolveDoctorWorkspaceDir(ctx.cfg, ctx.env),
       configPath: ctx.configPath,
       allowExecSecretRefs: ctx.options.allowExec === true,
     }),

--- a/src/flows/doctor-health-contribution-types.ts
+++ b/src/flows/doctor-health-contribution-types.ts
@@ -63,6 +63,7 @@ export type DoctorHealthCheckContext = HealthCheckContext & {
 export type DoctorHealthContribution = FlowContribution & {
   kind: "core";
   surface: "health";
+  required?: true;
   healthChecks: readonly HealthCheckInput[];
   healthCheckIds: readonly string[];
   run: (ctx: DoctorHealthFlowContext) => Promise<void>;

--- a/src/flows/doctor-health-contribution-utils.ts
+++ b/src/flows/doctor-health-contribution-utils.ts
@@ -1,3 +1,4 @@
+import { resolveAgentWorkspaceDir, tryResolveSoleAgentId } from "../agents/agent-scope.js";
 import { isLegacyParentWritableUpdateDoctorPass } from "../commands/doctor/shared/update-phase.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { DoctorHealthFlowContext } from "./doctor-health-contribution-types.js";
@@ -11,6 +12,10 @@ export function isUpdateDoctorRun(
 
 export function resolveDoctorMode(cfg: OpenClawConfig): "local" | "remote" {
   return cfg.gateway?.mode === "remote" ? "remote" : "local";
+}
+export function resolveDoctorWorkspaceDir(cfg: OpenClawConfig, env = process.env) {
+  const agentId = tryResolveSoleAgentId(cfg);
+  return agentId ? resolveAgentWorkspaceDir(cfg, agentId, env) : undefined;
 }
 
 export function resolveLegacyParentVersionOverride(ctx: DoctorHealthFlowContext): {

--- a/src/flows/doctor-health-contribution.ts
+++ b/src/flows/doctor-health-contribution.ts
@@ -3,6 +3,7 @@ import type {
   DoctorHealthContribution,
   DoctorHealthFlowContext,
 } from "./doctor-health-contribution-types.js";
+import { resolveDoctorWorkspaceDir } from "./doctor-health-contribution-utils.js";
 import type { HealthCheckInput } from "./health-check-runner-types.js";
 import type { HealthFinding } from "./health-checks.js";
 
@@ -12,6 +13,7 @@ export function createDoctorHealthContribution(params: {
   healthCheckIds?: readonly string[];
   healthChecks?: DoctorContributionHealthCheck | readonly DoctorContributionHealthCheck[];
   hint?: string;
+  required?: true;
   run?: (ctx: DoctorHealthFlowContext) => Promise<void>;
 }): DoctorHealthContribution {
   const healthChecks = normalizeHealthChecks(params.id, params.healthChecks);
@@ -31,6 +33,7 @@ export function createDoctorHealthContribution(params: {
     source: "doctor",
     healthChecks,
     healthCheckIds,
+    ...(params.required ? { required: true as const } : {}),
     run:
       params.run ??
       ((ctx) =>
@@ -89,12 +92,7 @@ async function runStructuredDoctorHealthContribution(params: {
     throw new Error(`doctor contribution ${params.contributionId} has no structured health`);
   }
   const { runDoctorHealthRepairs } = await import("./doctor-repair-flow.js");
-  const { resolveAgentWorkspaceDir, resolveDefaultAgentId } =
-    await import("../agents/agent-scope.js");
-  const workspaceDir = resolveAgentWorkspaceDir(
-    params.ctx.cfg,
-    resolveDefaultAgentId(params.ctx.cfg),
-  );
+  const workspaceDir = resolveDoctorWorkspaceDir(params.ctx.cfg, params.ctx.env);
   const dryRun = !params.ctx.prompter.shouldRepair;
   const result = await runDoctorHealthRepairs(
     {

--- a/src/flows/doctor-health-contributions-initial.ts
+++ b/src/flows/doctor-health-contributions-initial.ts
@@ -59,6 +59,7 @@ export function resolveInitialDoctorHealthContributions(params: {
     createDoctorHealthContribution({
       id: "doctor:write-config-migrations",
       label: "Write config migrations",
+      required: true,
       run: runInitialConfigWriteHealth,
     }),
     createDoctorHealthContribution({

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -104,6 +104,7 @@ const mocks = vi.hoisted(() => ({
   }),
   listAgentIds: vi.fn<(_cfg: OpenClawConfig) => string[]>(() => ["default"]),
   listAgentEntries: vi.fn(() => [{ id: "default" }]),
+  tryResolveSoleAgentId: vi.fn<(_cfg: OpenClawConfig) => string | undefined>(() => "default"),
   resolveAgentWorkspaceDir: vi.fn<(_cfg: OpenClawConfig, agentId: string) => string>(
     () => "/tmp/openclaw-workspace",
   ),
@@ -389,6 +390,7 @@ vi.mock("../commands/doctor-browser.js", () => ({
 vi.mock("../agents/agent-scope.js", () => ({
   listAgentIds: mocks.listAgentIds,
   listAgentEntries: mocks.listAgentEntries,
+  tryResolveSoleAgentId: mocks.tryResolveSoleAgentId,
   resolveAgentWorkspaceDir: mocks.resolveAgentWorkspaceDir,
   tryResolveConfiguredAgentWorkspaceDir: mocks.tryResolveConfiguredAgentWorkspaceDir,
   resolveDefaultAgentId: mocks.resolveDefaultAgentId,
@@ -708,6 +710,8 @@ describe("doctor health contributions", () => {
     mocks.listAgentIds.mockReturnValue(["default"]);
     mocks.listAgentEntries.mockReset();
     mocks.listAgentEntries.mockReturnValue([{ id: "default" }]);
+    mocks.tryResolveSoleAgentId.mockReset();
+    mocks.tryResolveSoleAgentId.mockReturnValue("default");
     mocks.resolveDefaultAgentId.mockReset();
     mocks.resolveDefaultAgentId.mockReturnValue("default");
     mocks.resolveAgentContextLimits.mockReset();
@@ -825,7 +829,7 @@ describe("doctor health contributions", () => {
     vi.restoreAllMocks();
   });
 
-  it("continues after one doctor contribution throws", async () => {
+  it("continues after an advisory doctor contribution throws", async () => {
     const laterRun = vi.fn(async () => undefined);
     const contributions = [
       createDoctorHealthContribution({
@@ -860,6 +864,38 @@ describe("doctor health contributions", () => {
       "doctor:test-failure run failed: media migration required",
       "Doctor warnings",
     );
+  });
+
+  it("rejects a failed initial config write before later work runs", async () => {
+    const laterRun = vi.fn(async () => undefined);
+    const cfg = { gateway: { mode: "invalid" } } as unknown as OpenClawConfig;
+    const ctx = {
+      cfg,
+      cfgForPersistence: structuredClone(cfg),
+      configResult: { cfg, shouldWriteConfig: true },
+      configPath: "/tmp/fake-openclaw.json",
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(true),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: {},
+      env: {},
+    } as DoctorContributionRunContext;
+    mocks.replaceConfigFile.mockRejectedValueOnce(new Error("Config validation failed"));
+
+    await expect(
+      runDoctorHealthContributionList(ctx, [
+        requireDoctorContribution("doctor:write-config-migrations"),
+        createDoctorHealthContribution({
+          id: "doctor:test-later",
+          label: "Test later",
+          run: laterRun,
+        }),
+      ]),
+    ).rejects.toThrow("Config validation failed");
+
+    expect(laterRun).not.toHaveBeenCalled();
+    expect(ctx.configResultWriteCommitted).not.toBe(true);
+    expect(ctx.cfgForPersistence).toEqual(cfg);
   });
 
   it("keeps legacy plugin manifest lint opt-in for structured findings", async () => {
@@ -1002,8 +1038,10 @@ describe("doctor health contributions", () => {
     );
   });
 
-  it("writes a successful config migration once across both write phases", async () => {
-    const cfg = { gateway: { mode: "local" } } as OpenClawConfig;
+  it("persists migrated Discord config once across both write phases", async () => {
+    const cfg = {
+      channels: { discord: { streaming: { mode: "partial" } } },
+    } as OpenClawConfig;
     const ctx = {
       cfg,
       cfgForPersistence: structuredClone(cfg),
@@ -1020,6 +1058,9 @@ describe("doctor health contributions", () => {
     await requireDoctorContribution("doctor:write-config").run(ctx);
 
     expect(mocks.replaceConfigFile).toHaveBeenCalledOnce();
+    expect(mocks.replaceConfigFile).toHaveBeenCalledWith(
+      expect.objectContaining({ nextConfig: cfg }),
+    );
     expect(ctx.configResultWriteCommitted).toBe(true);
     expect(ctx.cfgForPersistence).toEqual(ctx.cfg);
   });
@@ -2966,6 +3007,52 @@ describe("doctor health contributions", () => {
     expect(ctx.cfgForPersistence).toEqual({});
     expect(ctx.runtime.error).toHaveBeenCalledWith("structured warning");
     expect(ctx.runtime.log).toHaveBeenCalledWith("changed from structured health");
+  });
+
+  it.each([
+    ["explicit multi-agent config", undefined, undefined],
+    ["sole-agent config", "default", "/tmp/openclaw-workspace"],
+  ])("uses %s workspace scope for metadata and structured health", async (_, soleAgentId, cwd) => {
+    mocks.tryResolveSoleAgentId.mockReturnValue(soleAgentId);
+    const runWithPluginMetadataSnapshot = vi.fn(
+      async (_scope: unknown, run: () => Promise<void>) => await run(),
+    );
+    const contribution = createDoctorHealthContribution({
+      id: "doctor:test-workspace-scope",
+      label: "Test workspace scope",
+      healthChecks: {
+        description: "test workspace scope",
+        detect: vi.fn(async () => []),
+      },
+    });
+    const ctx = {
+      cfg: { agents: { ownership: "explicit" } },
+      cfgForPersistence: {},
+      configResult: { cfg: {} },
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(true),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: {},
+      configPath: "/tmp/fake-openclaw.json",
+      env: {},
+      runWithPluginMetadataSnapshot,
+    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+
+    await runDoctorHealthContributionList(ctx, [contribution]);
+
+    expect(runWithPluginMetadataSnapshot).toHaveBeenCalledWith(
+      { config: ctx.cfg, workspaceDir: cwd },
+      expect.any(Function),
+    );
+    expect(mocks.runDoctorHealthRepairs).toHaveBeenCalledWith(expect.objectContaining({ cwd }), {
+      checks: contribution.healthChecks,
+      dryRun: false,
+    });
+    if (soleAgentId === undefined) {
+      expect(mocks.resolveAgentWorkspaceDir).not.toHaveBeenCalled();
+    } else {
+      expect(mocks.resolveAgentWorkspaceDir).toHaveBeenCalledWith(ctx.cfg, soleAgentId, ctx.env);
+    }
   });
 
   it("renders findings from structured health when legacy run is omitted", async () => {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -12,6 +12,7 @@ import type {
   DoctorHealthFlowContext,
 } from "./doctor-health-contribution-types.js";
 import { resolveDoctorMode } from "./doctor-health-contribution-utils.js";
+import { resolveDoctorWorkspaceDir } from "./doctor-health-contribution-utils.js";
 import { createDoctorHealthContribution } from "./doctor-health-contribution.js";
 import { resolveFinalDoctorHealthContributions } from "./doctor-health-contributions-final.js";
 import { resolveInitialDoctorHealthContributions } from "./doctor-health-contributions-initial.js";
@@ -438,17 +439,12 @@ async function runDoctorHealthContributionList(
         await contribution.run(ctx);
         continue;
       }
-      const { resolveAgentWorkspaceDir, resolveDefaultAgentId } =
-        await import("../agents/agent-scope.js");
-      const workspaceDir = resolveAgentWorkspaceDir(
-        ctx.cfg,
-        resolveDefaultAgentId(ctx.cfg),
-        ctx.env ?? process.env,
-      );
+      const workspaceDir = resolveDoctorWorkspaceDir(ctx.cfg, ctx.env);
       await runWithPluginMetadataSnapshot({ config: ctx.cfg, workspaceDir }, () =>
         contribution.run(ctx),
       );
     } catch (error) {
+      await (contribution.required ? Promise.reject(error as Error) : Promise.resolve());
       const { note } = await loadNoteModule();
       note(`${contribution.id} run failed: ${scrubDoctorErrorMessage(error)}`, "Doctor warnings");
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw doctor --fix` could continue after its initial migrated-config write failed, leaving upgrade diagnostics to run against state that was never persisted. Explicit multi-agent configurations could also be evaluated through an arbitrary default-agent workspace during health orchestration.

## Why This Change Was Made

Doctor health contributions now carry a typed required/advisory failure policy. The initial config migration write is the sole required contribution and aborts the sequence on failure; diagnostics remain warning-and-continue.

All shared Doctor health paths use one sole-agent-or-undefined workspace resolver, matching config-flow semantics. Provider-catalog validation receives that resolved scope, while workspace-specific skills-readiness and bootstrap checks skip when no sole workspace exists. No check reselects a configured default agent.

Production delta: `+35/-39` (net `-4`). Tests: `+122/-12` (net `+110`).

## User Impact

Failed migration writes are visible failures and stop dependent Doctor work. Successful Discord compatibility migrations still reach the atomic writer. Sole-agent workspaces remain available, while explicit multi-agent configurations no longer borrow an arbitrary workspace for provider, skill, or bootstrap inspection.

## Evidence

- `node scripts/run-vitest.mjs src/flows/doctor-health-contributions.test.ts`
  - 110 passed
- `node scripts/run-vitest.mjs src/flows/doctor-core-checks.test.ts`
  - 26 passed
- `node scripts/run-vitest.mjs src/flows/doctor-core-checks.runtime.test.ts`
  - 34 passed
- `node scripts/run-vitest.mjs src/commands/doctor-config-flow.test.ts -t "materializes ambient roles for a multi-agent configured default|preserves discord streaming intent while stripping unsupported keys on repair"`
  - 2 passed, 61 skipped
- targeted `oxlint`, `oxfmt --check`, and `git diff --check`
  - passed
- `node scripts/check-changed.mjs --dry-run -- <touched paths>`
  - classified `core, coreTests`; full delegated fan-out remains deferred while shared release capacity is reserved

AI-assisted: yes. The implementation and proof were reviewed by the author.
