### PR TITLE
fix(msteams): require dot boundary for shared-link host suffix match

### DIFF
--- a/extensions/msteams/src/attachments.test.ts
+++ b/extensions/msteams/src/attachments.test.ts
@@ -718,9 +718,15 @@ describe("msteams attachments", () => {
         expect(tokenProvider.getAccessToken).toHaveBeenCalled();
       });
 
-      it("falls through to direct fetch for non-shared-link URLs", async () => {
-        const directUrl = createTestUrl("direct.pdf");
-        const fetchMock = createOkFetchMock(CONTENT_TYPE_APPLICATION_PDF, "pdf");
+      it("keeps look-alike hosts out of Graph shares and auth fallback", async () => {
+        const directUrl = "https://notonedrive.com/direct.pdf";
+        const tokenProvider = createTokenProvider();
+        const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+          const url = resolveRequestUrl(input);
+          return url.startsWith(GRAPH_SHARES_URL_PREFIX)
+            ? createTextResponse("unauthorized", 401)
+            : createBufferResponse(PDF_BUFFER, CONTENT_TYPE_APPLICATION_PDF);
+        });
         detectMimeMock.mockResolvedValueOnce(CONTENT_TYPE_APPLICATION_PDF);
         saveMediaBufferMock.mockResolvedValueOnce({
           id: "saved.pdf",
@@ -729,9 +735,13 @@ describe("msteams attachments", () => {
           contentType: CONTENT_TYPE_APPLICATION_PDF,
         });
 
-        const media = await downloadAttachmentsWithFetch(
-          createPdfAttachments(directUrl),
-          fetchMock,
+        const media = await downloadMSTeamsAttachments(
+          buildDownloadParams(createPdfAttachments(directUrl), {
+            tokenProvider,
+            allowHosts: ["notonedrive.com", GRAPH_HOST],
+            authAllowHosts: [GRAPH_HOST],
+            fetchFn: asFetchFn(fetchMock),
+          }),
         );
 
         expectAttachmentMediaLength(media, 1);
@@ -742,6 +752,7 @@ describe("msteams attachments", () => {
         // Should have hit the original host, NOT graph shares.
         expect(calledUrls).toContain(directUrl);
         expect(calledUrls.some((url) => url.startsWith(GRAPH_SHARES_URL_PREFIX))).toBe(false);
+        expect(tokenProvider.getAccessToken).not.toHaveBeenCalled();
       });
     });
 

--- a/extensions/msteams/src/attachments.test.ts
+++ b/extensions/msteams/src/attachments.test.ts
@@ -754,6 +754,24 @@ describe("msteams attachments", () => {
         expect(calledUrls.some((url) => url.startsWith(GRAPH_SHARES_URL_PREFIX))).toBe(false);
         expect(tokenProvider.getAccessToken).not.toHaveBeenCalled();
       });
+
+      it("rejects non-HTTPS shared-link hosts before fetch or auth fallback", async () => {
+        const tokenProvider = createTokenProvider();
+        const fetchMock = vi.fn(async () => createTextResponse("unauthorized", 401));
+
+        await downloadAttachmentsWithFetch(
+          createPdfAttachments("http://onedrive.com/direct.pdf"),
+          fetchMock,
+          {
+            tokenProvider,
+            allowHosts: ["onedrive.com", GRAPH_HOST],
+            authAllowHosts: [GRAPH_HOST],
+          },
+          { expectFetchCalled: false },
+        );
+
+        expect(tokenProvider.getAccessToken).not.toHaveBeenCalled();
+      });
     });
 
     describe("error logging (issue #63396)", () => {

--- a/extensions/msteams/src/attachments/shared.test.ts
+++ b/extensions/msteams/src/attachments/shared.test.ts
@@ -534,6 +534,10 @@ describe("Graph shared-link helpers", () => {
     ["https://graph.microsoft.com/v1.0/me", false],
     ["https://smba.trafficmanager.net/amer/v3", false],
     ["https://example.com/file.pdf", false],
+    ["https://notonedrive.com/x", false],
+    ["https://evil1drv.ms/x", false],
+    ["https://fakeonedrive.live.com/x", false],
+    ["https://evilsharepoint.com/x", false],
     ["not-a-url", false],
   ])("isGraphSharedLinkUrl(%s) === %s", (url, expected) => {
     expect(isGraphSharedLinkUrl(url)).toBe(expected);

--- a/extensions/msteams/src/attachments/shared.test.ts
+++ b/extensions/msteams/src/attachments/shared.test.ts
@@ -538,6 +538,7 @@ describe("Graph shared-link helpers", () => {
     ["https://evil1drv.ms/x", false],
     ["https://fakeonedrive.live.com/x", false],
     ["https://evilsharepoint.com/x", false],
+    ["http://onedrive.com/x", false],
     ["not-a-url", false],
   ])("isGraphSharedLinkUrl(%s) === %s", (url, expected) => {
     expect(isGraphSharedLinkUrl(url)).toBe(expected);

--- a/extensions/msteams/src/attachments/shared.ts
+++ b/extensions/msteams/src/attachments/shared.ts
@@ -165,17 +165,17 @@ const GRAPH_SHARED_LINK_HOST_SUFFIXES = [
  * than directly.
  */
 function isGraphSharedLinkUrl(url: string): boolean {
-  let host: string;
+  let parsed: URL;
   try {
-    host = normalizeLowercaseStringOrEmpty(new URL(url).hostname);
+    parsed = new URL(url);
   } catch {
     return false;
   }
-  if (!host) {
+  const host = normalizeLowercaseStringOrEmpty(parsed.hostname);
+  if (parsed.protocol !== "https:" || !host) {
     return false;
   }
-  // Match on a dot boundary so look-alike hosts such as "evil1drv.ms" or
-  // "notonedrive.com" are not treated as shared-link hosts.
+  // Only HTTPS URLs on a DNS label boundary may select the authenticated Graph path.
   return GRAPH_SHARED_LINK_HOST_SUFFIXES.some(
     (suffix) => host === suffix || host.endsWith(suffix.startsWith(".") ? suffix : `.${suffix}`),
   );

--- a/extensions/msteams/src/attachments/shared.ts
+++ b/extensions/msteams/src/attachments/shared.ts
@@ -174,7 +174,11 @@ function isGraphSharedLinkUrl(url: string): boolean {
   if (!host) {
     return false;
   }
-  return GRAPH_SHARED_LINK_HOST_SUFFIXES.some((suffix) => host === suffix || host.endsWith(suffix));
+  // Match on a dot boundary so look-alike hosts such as "evil1drv.ms" or
+  // "notonedrive.com" are not treated as shared-link hosts.
+  return GRAPH_SHARED_LINK_HOST_SUFFIXES.some(
+    (suffix) => host === suffix || host.endsWith(suffix.startsWith(".") ? suffix : `.${suffix}`),
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

fix(msteams): require a dot boundary when matching OneDrive/SharePoint shared-link host suffixes, so look-alike hosts like `evil1drv.ms` or `notonedrive.com` are no longer rewritten to the Graph shares endpoint

## What Problem This Solves

When an MSTeams attachment URL points at a OneDrive/SharePoint shared link, the downloader rewrites it to the Graph `/shares/{shareId}/driveItem/content` endpoint instead of fetching it directly. The classifier decides this by matching the URL host against a suffix list (`1drv.ms`, `onedrive.com`, `onedrive.live.com`, `.sharepoint.com`, ...).

**代码证据**: in `extensions/msteams/src/attachments/shared.ts`, `isGraphSharedLinkUrl` used:

```ts
GRAPH_SHARED_LINK_HOST_SUFFIXES.some((suffix) => host === suffix || host.endsWith(suffix))
```

For the bare (non-dot-prefixed) suffixes this has no label boundary: `evil1drv.ms`.endsWith(`1drv.ms`) and `notonedrive.com`.endsWith(`onedrive.com`) are both `true`.

The impact is not just misclassification: `tryBuildGraphSharesUrlForSharedLink` base64url-encodes the *attacker-controlled* URL into a Graph `/shares/` API path, so a look-alike host gets its content fetched through the Graph shares flow (with Graph credentials attached) instead of being treated as an ordinary external download.

Trigger condition: any attachment URL whose host ends with the literal string `1drv.ms`, `onedrive.com`, or `onedrive.live.com` without being those hosts or their subdomains.

## Root Cause

- Violated invariant: the shared-link rewrite is an authentication-boundary decision (content is fetched via the Graph API with its auth context), but the host check was a raw suffix match.
- The suffix list mixes dot-prefixed entries (`.sharepoint.com`, which carry their own boundary) with bare entries (`1drv.ms`, `onedrive.com`, `onedrive.live.com`, which do not), and the matcher treated both forms identically.

## Why This Fix

- Option A: rewrite the suffix list so every entry is dot-prefixed and keep `host === suffix || host.endsWith(suffix)`. Works, but loses the exact-host matches for `1drv.ms`/`onedrive.com` apex hosts unless extra entries are added.
- Option B (chosen): keep the list as-is and make the matcher boundary-aware: `host === suffix || host.endsWith(suffix.startsWith(".") ? suffix : "." + suffix)`. Bare suffixes now require a dot boundary for subdomain matches while exact matches still pass; dot-prefixed entries behave exactly as before.
- Not chosen: switching to a full allowlist of known hosts — the SharePoint tenant space (`*.sharepoint.com` etc.) is intentionally open-ended.

## User Impact

- Affected scenarios: MSTeams attachments whose URL host is a look-alike of a OneDrive host (e.g. `https://notonedrive.com/x`, `https://evil1drv.ms/x`, `https://fakeonedrive.live.com/x`).
- Before: such URLs were treated as shared links and rewritten to `https://graph.microsoft.com/v1.0/shares/u!<base64url(attacker-url)>/driveItem/content`.
- After: only genuine OneDrive/SharePoint hosts (exact or proper subdomains) are rewritten; look-alikes fall through to the normal download path.
- Behavior change: legitimate shared links (`https://1drv.ms/b/s!...`, `https://onedrive.live.com/view.aspx?...`, `https://contoso.sharepoint.com/...`) are unaffected.

## Evidence

- **Behavior or issue addressed:** look-alike hosts sharing OneDrive suffixes were classified as shared links and rewritten to the Graph shares endpoint.
- **Real environment tested:** worktree `wt-msteams-attachment-host-boundary` on latest `origin/main`, running the real exported `tryBuildGraphSharesUrlForSharedLink` from `extensions/msteams/src/attachments/shared.ts` via tsx. No mocks: this is a pure URL-classification function.
- **Exact steps or command run after this patch:**
  ```bash
  $ node node_modules/tsx/dist/cli.mjs msteams-attachment-host-boundary.proof.mjs
  $ npx vitest run extensions/msteams/src/attachments/shared.test.ts
  ```
- **Evidence after fix (8/8 PASS):**
  ```bash
  PASS https://notonedrive.com/x -> shared-link=false
  PASS https://evil1drv.ms/x -> shared-link=false
  PASS https://fakeonedrive.live.com/x -> shared-link=false
  PASS https://evilsharepoint.com/x -> shared-link=false
  PASS https://contoso.sharepoint.com/x -> shared-link=true
  PASS https://onedrive.com/share/abc -> shared-link=true
  PASS https://1drv.ms/b/s!AkxYabc -> shared-link=true
  PASS https://onedrive.live.com/view.aspx?resid=ABC -> shared-link=true
  RESULT: ALL PASS
  ```

**Before (on main, same script, exit code 1):**

```bash
FAIL https://notonedrive.com/x -> shared-link=true rewritten=https://graph.microsoft.com/v1.0/shares/u!aHR0cHM6Ly9ub3RvbmVkcml2ZS5jb20veA/driveItem/content
FAIL https://evil1drv.ms/x -> shared-link=true rewritten=https://graph.microsoft.com/v1.0/shares/u!aHR0cHM6Ly9ldmlsMWRydi5tcy94/driveItem/content
FAIL https://fakeonedrive.live.com/x -> shared-link=true rewritten=...
RESULT: 3 FAILURES (bug present)
```

- **What was not tested:** a live Microsoft tenant call. That is not required for this deterministic pre-I/O routing boundary; the production downloader test uses mocked network I/O to observe the selected URL and token behavior.

## Real Behavior Proof

Maintainer validation ran the real production `downloadMSTeamsAttachments` path at exact head `5f6c0f00bde747f8b459f4cdb403f294ba81da3e` in fresh sanitized AWS Crabbox leases. Both used `--no-hydrate`; the trusted bootstrap verified no instance-role credentials, and each lease had public networking with no Tailscale. Fail-fast sentinels covered injected/global fetch, Graph request, DNS resolution, and token-provider boundaries.

HTTP trusted-host rejection (run `run_8ab7c935e8e7`):

```json
{"head":"5f6c0f00bde747f8b459f4cdb403f294ba81da3e","input":"http://onedrive.com/direct.pdf","networkRequests":0,"graphRequests":0,"dnsResolutions":0,"tokenRequests":0,"media":[{"kind":"document","hasPath":false}],"result":"rejected-before-io"}
```

HTTPS look-alike rejection under the real default attachment policy, with no allowlist overrides (run `run_b2af35a5d7ab`):

```json
{"head":"5f6c0f00bde747f8b459f4cdb403f294ba81da3e","policy":"default","input":"https://notonedrive.com/direct.pdf","networkRequests":0,"graphRequests":0,"dnsResolutions":0,"tokenRequests":0,"media":[{"kind":"document","hasPath":false}],"result":"rejected-before-io"}
```

Both commands exited 0 with empty stderr, proving the forbidden inputs stop before Graph dispatch, DNS/network I/O, or token acquisition.

## Tests and Validation

- `npx vitest run extensions/msteams/src/attachments/shared.test.ts` — 56/56 passed, including new regression cases in the `isGraphSharedLinkUrl` matrix: `notonedrive.com`, `evil1drv.ms`, `fakeonedrive.live.com`, and `evilsharepoint.com` all classify as non-shared-link.
- `npx oxlint --deny=warn` on both changed files — 0 warnings, 0 errors.
- Before/after real-behavior proof logs are embedded above.

## Regression Test Plan

- Coverage level: unit test on the real exported classifier (existing `it.each` matrix in the test file).
- Target test file: `extensions/msteams/src/attachments/shared.test.ts`
- Scenario locked in: suffix-sharing look-alike hosts never classify as shared links, while legitimate OneDrive/SharePoint hosts (apex and subdomains) still do.
- Why this is the smallest reliable guardrail: it pins the exact matcher that gates the Graph shares rewrite, using the exact look-alike inputs that previously passed.

