### PR TITLE
fix(minimax): match CN host on a dot boundary for region detection

### DIFF
--- a/extensions/minimax/src/minimax-web-search-provider.runtime.ts
+++ b/extensions/minimax/src/minimax-web-search-provider.runtime.ts
@@ -69,10 +69,20 @@ function isMiniMaxCnHost(value: string | undefined): boolean {
   if (!trimmed) {
     return false;
   }
+  // Match the host only, on a dot boundary, so look-alike hosts such as
+  // "notminimaxi.com" are not mistaken for the CN endpoint.
+  const isCnHostname = (hostname: string) =>
+    hostname === "minimaxi.com" || hostname.endsWith(".minimaxi.com");
   try {
-    return new URL(trimmed).hostname.endsWith("minimaxi.com");
+    return isCnHostname(new URL(trimmed).hostname);
   } catch {
-    return trimmed.includes("minimaxi.com");
+    try {
+      // Scheme-less values (e.g. "api.minimaxi.com/anthropic"): prepend a
+      // scheme so only the host is inspected, never the path or query.
+      return isCnHostname(new URL(`https://${trimmed}`).hostname);
+    } catch {
+      return false;
+    }
   }
 }
 

--- a/extensions/minimax/src/minimax-web-search-provider.test.ts
+++ b/extensions/minimax/src/minimax-web-search-provider.test.ts
@@ -134,6 +134,24 @@ describe("minimax web search provider", () => {
       expect(resolveMiniMaxRegion()).toBe("cn");
     });
 
+    it("infers cn from the apex CN domain", () => {
+      process.env.MINIMAX_API_HOST = "https://minimaxi.com";
+      expect(resolveMiniMaxRegion()).toBe("cn");
+    });
+
+    it("returns global for look-alike hosts sharing the minimaxi.com suffix", () => {
+      for (const host of [
+        "https://notminimaxi.com",
+        "https://evilnotminimaxi.com/v1",
+        "notminimaxi.com",
+        "https://minimaxi.com.evil.com",
+        "https://example.com/redir?u=minimaxi.com",
+      ]) {
+        process.env.MINIMAX_API_HOST = host;
+        expect(resolveMiniMaxRegion()).toBe("global");
+      }
+    });
+
     it("infers cn from model provider base URL", () => {
       const cnConfig = {
         models: {


### PR DESCRIPTION
## Summary

fix(minimax): bind CN region detection to the `minimaxi.com` host on a dot boundary, so look-alike hosts such as `notminimaxi.com` no longer route web search to the CN endpoint

## What Problem This Solves

The MiniMax web search provider infers the region (`cn` vs `global`) from `MINIMAX_API_HOST` or the configured provider base URL, and picks the search endpoint accordingly (`https://api.minimaxi.com/v1/coding_plan/search` for CN, `https://api.minimax.io/v1/coding_plan/search` for global).

**代码证据**: in `extensions/minimax/src/minimax-web-search-provider.runtime.ts`, `isMiniMaxCnHost` used:

- `new URL(trimmed).hostname.endsWith("minimaxi.com")` — matches any host that merely *ends* with the string, e.g. `notminimaxi.com` or `evilnotminimaxi.com`.
- `trimmed.includes("minimaxi.com")` as the fallback for scheme-less values — a pure substring check that also matches look-alike hosts.

So a misspelled or maliciously crafted host like `MINIMAX_API_HOST=https://notminimaxi.com` was classified as CN, and search traffic (including the query and the `Authorization: Bearer <key>` header) would be sent to the CN search endpoint derived from that wrong classification.

Trigger condition: any host value that ends with the literal string `minimaxi.com` without being `minimaxi.com` or a subdomain of it.

## Root Cause

- Violated invariant: region inference is a security-relevant routing decision (it selects which endpoint receives queries and credentials), but the host check was a suffix/substring match instead of a dot-boundary host match.
- `endsWith("minimaxi.com")` has no label boundary: `notminimaxi.com`.endsWith(`minimaxi.com`) is `true`. The scheme-less fallback `includes(...)` is weaker still.

## Why This Fix

- Option A: keep `endsWith` but prepend a dot (`endsWith(".minimaxi.com")`). Handles the URL-parseable path but leaves the scheme-less substring fallback untouched.
- Option B (chosen): extract a single `isCnHostname` predicate — `hostname === "minimaxi.com" || hostname.endsWith(".minimaxi.com")` — and use it for both paths; for scheme-less values, prepend `https://` so only the host is inspected (never the path or query), and return `false` if the value still cannot be parsed.
- Not chosen: a regex over the raw string — duplicates URL parsing logic and still mixes host and non-host content.

## User Impact

- Affected scenarios: users setting `MINIMAX_API_HOST` or a provider `baseUrl` to a host that shares the `minimaxi.com` suffix (typo'd or look-alike domains).
- Before: such hosts were classified as CN and search requests were routed to the CN endpoint.
- After: only `minimaxi.com` and its subdomains classify as CN; everything else falls back to global.
- Behavior change: legitimate CN endpoints (`https://api.minimaxi.com`, `https://minimaxi.com`, `https://api.minimaxi.com/anthropic`) are unaffected — still classified as CN.

## Real Behavior Proof

- **Behavior or issue addressed:** look-alike hosts sharing the `minimaxi.com` suffix were classified as CN, routing MiniMax web search to the wrong (CN) endpoint.
- **Real environment tested:** worktree `wt-minimax-cn-host-boundary` on latest `origin/main`, Node v24.19.0, importing the real `extensions/minimax/src/minimax-web-search-provider.runtime.ts` via tsx and calling the exported `testing.resolveMiniMaxRegion` / `testing.resolveMiniMaxEndpoint` with `MINIMAX_API_HOST` set per case. No mocks of the functions under test.
- **Exact steps or command run after this patch:**
  ```bash
  $ node node_modules/tsx/dist/cli.mjs minimax-cn-host-boundary.proof.mjs
  $ npx vitest run extensions/minimax/src/minimax-web-search-provider.test.ts
  ```
- **Evidence after fix (8/8 PASS):**
  ```bash
  PASS MINIMAX_API_HOST=https://api.minimaxi.com -> region=cn
  PASS MINIMAX_API_HOST=https://api.minimaxi.com/anthropic -> region=cn
  PASS MINIMAX_API_HOST=https://minimaxi.com -> region=cn
  PASS MINIMAX_API_HOST=https://api.minimax.io -> region=global
  PASS MINIMAX_API_HOST=https://notminimaxi.com -> region=global
  PASS MINIMAX_API_HOST=https://evilnotminimaxi.com/v1 -> region=global
  PASS MINIMAX_API_HOST=notminimaxi.com -> region=global
  PASS MINIMAX_API_HOST=https://example.com/redir?u=minimaxi.com -> region=global
  RESULT: ALL PASS
  ```

**Before (on main, same script, exit code 1):**

```bash
FAIL MINIMAX_API_HOST=https://notminimaxi.com -> region=cn (expected global), endpoint=https://api.minimaxi.com/v1/coding_plan/search
FAIL MINIMAX_API_HOST=https://evilnotminimaxi.com/v1 -> region=cn (expected global)
FAIL MINIMAX_API_HOST=notminimaxi.com -> region=cn (expected global)
RESULT: 3 case(s) show WRONG region/endpoint
```

- **What was not tested:** a live search request against the real MiniMax endpoints (requires valid credentials); the proof exercises the real region/endpoint resolution code paths end to end.

## Tests and Validation

- `npx vitest run extensions/minimax/src/minimax-web-search-provider.test.ts` — 23/23 passed, including new regression cases: apex CN domain still classifies as CN; `https://notminimaxi.com`, `https://evilnotminimaxi.com/v1`, scheme-less `notminimaxi.com`, `https://minimaxi.com.evil.com`, and a query-string-only mention all classify as global.
- `npx oxlint --deny=warn` on both changed files — 0 warnings, 0 errors.
- Before/after real-behavior proof logs are embedded above.

## Regression Test Plan

- Coverage level: unit tests on the real exported `resolveMiniMaxRegion` / `resolveMiniMaxEndpoint` (via the module's `testing` surface), with `MINIMAX_API_HOST` as the input vector.
- Target test file: `extensions/minimax/src/minimax-web-search-provider.test.ts`
- Scenario locked in: suffix-sharing look-alike hosts (`notminimaxi.com`, with scheme, with path, scheme-less) and non-host mentions (query string) never classify as CN, while the real CN hosts (`api.minimaxi.com`, apex `minimaxi.com`) still do.
- Why this is the smallest reliable guardrail: it pins the exact predicate that makes the routing decision, using the exact inputs that previously misclassified.
