### PR TITLE
fix(cron): use plain-text envelope to avoid DeepSeek bracket-grammar deprioritization

### DIFF
--- a/extensions/memory-core/src/dreaming-shared.test.ts
+++ b/extensions/memory-core/src/dreaming-shared.test.ts
@@ -13,6 +13,10 @@ describe("includesSystemEventToken", () => {
     expect(includesSystemEventToken(`[cron:abc-123] ${TOKEN}`, TOKEN)).toBe(true);
   });
 
+  it("matches a token wrapped by the plain-text `cron job <id> <name>:` envelope (current form, #123041)", () => {
+    expect(includesSystemEventToken(`cron job abc-123 patrol: ${TOKEN}`, TOKEN)).toBe(true);
+  });
+
   it("matches the token on its own line within multiline content", () => {
     expect(includesSystemEventToken(`leading text\n${TOKEN}\ntrailing`, TOKEN)).toBe(true);
   });

--- a/extensions/memory-core/src/dreaming-shared.ts
+++ b/extensions/memory-core/src/dreaming-shared.ts
@@ -48,10 +48,16 @@ export function includesSystemEventToken(cleanedBody: string, eventText: string)
     if (trimmed === normalizedEventText) {
       return true;
     }
-    // Isolated cron turns wrap the payload with a `[cron:<id>] ...` prefix; strip
-    // that one known wrapper before matching so the dream sentinel still triggers
+    // Isolated cron turns wrap the payload with a cron envelope prefix; strip
+    // the one known wrapper before matching so the dream sentinel still triggers
     // without falling back to a broad substring match (which would let any user
-    // message embedding the token surface as a dream cron firing).
-    return trimmed.replace(/^\[cron:[^\]]+\]\s*/, "") === normalizedEventText;
+    // message embedding the token surface as a dream cron firing). Two envelope
+    // shapes are accepted: legacy `[cron:<id> <name>]`/`[Cron:<id> <name>]`
+    // (bracket grammar, present in history) and the current plain-text
+    // `cron job <id> <name>:` form (see #123041).
+    const stripped = trimmed
+      .replace(/^\[cron:[^\]]+\]\s*/i, "")
+      .replace(/^cron job [^\n:]+:\s*/i, "");
+    return stripped === normalizedEventText;
   });
 }

--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -1012,6 +1012,38 @@ describe("buildSessionEntry", () => {
     },
   );
 
+  it("does not wipe an archive when a user message starts with the plain-text cron envelope (#123041)", async () => {
+    const archivePath = path.join(tmpDir, "ordinary.jsonl.deleted.2026-02-16T22-27-33.000Z");
+    const messages = [
+      { role: "user", content: "Remember before: project codename is Atlas." },
+      { role: "assistant", content: "Saved project codename Atlas." },
+      {
+        role: "user",
+        content: "cron job daily-digest nightly: why did my digest job fail last night?",
+      },
+      { role: "assistant", content: "The digest job failed because the API token expired." },
+      { role: "user", content: "Please remember: my preferred vendor is Acme Robotics." },
+      { role: "assistant", content: "Noted. Acme Robotics." },
+    ];
+    const jsonlLines = messages.map((message) => JSON.stringify({ type: "message", message }));
+    fsSync.writeFileSync(archivePath, jsonlLines.join("\n"));
+
+    const entry = requireSessionEntry(await buildSessionEntry(archivePath));
+
+    expect(entry.generatedByCronRun).toBeFalsy();
+    // The plain-text cron prompt is filtered out (same as legacy `[cron:`);
+    // the surrounding ordinary messages survive.
+    expect(entry.content).toBe(
+      [
+        "User: Remember before: project codename is Atlas.",
+        "Assistant: Saved project codename Atlas.",
+        "Assistant: The digest job failed because the API token expired.",
+        "User: Please remember: my preferred vendor is Acme Robotics.",
+        "Assistant: Noted. Acme Robotics.",
+      ].join("\n"),
+    );
+  });
+
   it("keeps cron-run reset archives opaque when session metadata preserves the cron key", async () => {
     const archivePath = path.join(tmpDir, "cron-run.jsonl.reset.2026-02-16T22-26-33.000Z");
     const jsonlLines = [

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -53,7 +53,11 @@ export {
 const SESSION_EXPORT_CONTENT_WRAP_CHARS = 800;
 const SESSION_ENTRY_PARSE_YIELD_LINES = 250;
 const MAX_DATE_TIMESTAMP_MS = 8_640_000_000_000_000;
-const DIRECT_CRON_PROMPT_RE = /^\[cron:[^\]]+\]\s*/;
+// Cron-prompt envelope. Two shapes: legacy bracket `[cron:<...>]`/`[Cron:<...>]`
+// (present in history) and the current plain-text `cron job <id> <name>:` form
+// (see #123041). Plain text avoids the DeepSeek bracket-grammar deprioritization
+// trigger; both are matched so legacy transcripts still classify as cron prompts.
+const DIRECT_CRON_PROMPT_RE = /^(?:\[cron:[^\]]+\]\s*|cron job [^\n:]+:\s*)/i;
 
 export type SessionFileEntry = {
   path: string;

--- a/src/cron/isolated-agent.session-identity.test.ts
+++ b/src/cron/isolated-agent.session-identity.test.ts
@@ -168,7 +168,10 @@ describe("runCronIsolatedAgentTurn session identity", () => {
 
       const call = lastEmbeddedAgentCall();
       const lines = (call.prompt ?? "").split("\n");
-      expect(lines[0]).toContain("[cron:job-1");
+      // The envelope is plain text (`cron job <id> <name>:`) so DeepSeek's edge
+      // does not deprioritize the request via the `[cron:` bracket grammar (see
+      // #123041); recognizers match both this form and legacy `[cron:` transcripts.
+      expect(lines[0]).toContain("cron job job-1 job-1:");
       expect(lines[0]).toContain("do it");
       expect(lines[1]).toMatch(/^Current time: .+ \(.+\)$/);
       expect(lines[2]).toMatch(/^Reference UTC: \d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC$/);

--- a/src/cron/isolated-agent/run-prepare.ts
+++ b/src/cron/isolated-agent/run-prepare.ts
@@ -542,7 +542,12 @@ export async function prepareCronRunContext(params: {
     const message = currentConversationContext
       ? `${currentConversationContext}\n\n${originalMessage}`
       : originalMessage;
-    const base = `[cron:${input.job.id} ${input.job.name}] ${message}`.trim();
+    // Plain-text envelope (no brackets): DeepSeek's edge deprioritizes requests
+    // whose user message carries the `[cron:` bracket grammar (case- and
+    // position-independent — see #123041). Plain text avoids the trigger
+    // structurally; recognizers match both this form and legacy `[cron:`/
+    // `[Cron:` transcripts so history stays parseable. See #123041.
+    const base = `cron job ${input.job.id} ${input.job.name}: ${message}`.trim();
     const isExternalHook =
       hookExternalContentSource !== undefined || isExternalHookSession(baseSessionKey);
     const allowUnsafeExternalContent =

--- a/src/cron/isolated-agent/run.cron-envelope-shape.test.ts
+++ b/src/cron/isolated-agent/run.cron-envelope-shape.test.ts
@@ -1,0 +1,78 @@
+// Canonical-form guard for the isolated-cron agentTurn envelope (see #123041).
+// DeepSeek's API edge deprioritizes requests whose user message carries the
+// `[cron:` bracket grammar (case- and position-independent). The producer must
+// emit a plain-text envelope so the bracket grammar never reaches the model;
+// recognizers still read legacy `[cron:`/`[Cron:` transcripts from history.
+// This guard would have caught a regression to bracket grammar before it ships.
+import "../isolated-agent.mocks.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as modelThinkingDefault from "../../agents/model-thinking-default.js";
+import {
+  DEFAULT_AGENT_TURN_PAYLOAD,
+  runCronTurn,
+  withTempHome,
+} from "../isolated-agent.turn-test-helpers.js";
+import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
+import {
+  makeCronSession,
+  mockRunCronFallbackPassthrough,
+  resetRunCronIsolatedAgentTurnHarness,
+  resolveCronSessionMock,
+  runEmbeddedAgentMock,
+} from "./run.test-harness.js";
+
+setupRunCronIsolatedAgentTurnSuite();
+
+// Matches the `[cron:` bracket grammar in any case, at any position. A freshly
+// generated cron user message must NEVER match this — that is the canonical
+// form this guard enforces.
+const CRON_BRACKET_GRAMMAR_RE = /\[[cC][rR][oO][nN]:/;
+
+function lastEmbeddedAgentPrompt(): string {
+  const calls = runEmbeddedAgentMock.mock.calls;
+  const call = calls[calls.length - 1];
+  if (!call) {
+    throw new Error("expected runEmbeddedAgent call");
+  }
+  const value = call[0];
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("expected runEmbeddedAgent call payload");
+  }
+  const prompt = (value as { prompt?: unknown }).prompt;
+  if (typeof prompt !== "string") {
+    throw new Error("expected runEmbeddedAgent prompt to be a string");
+  }
+  return prompt;
+}
+
+describe("runCronIsolatedAgentTurn cron envelope canonical form", () => {
+  beforeEach(() => {
+    resetRunCronIsolatedAgentTurnHarness();
+    resolveCronSessionMock.mockReturnValue(makeCronSession());
+    vi.spyOn(modelThinkingDefault, "resolveThinkingDefault").mockReturnValue("off");
+    mockRunCronFallbackPassthrough();
+    runEmbeddedAgentMock.mockClear();
+  });
+
+  it("does not emit the `[cron:` bracket grammar in the agentTurn user message (any case, any position)", async () => {
+    await withTempHome(async (home) => {
+      await runCronTurn(home, { jobPayload: DEFAULT_AGENT_TURN_PAYLOAD });
+    });
+
+    const prompt = lastEmbeddedAgentPrompt();
+    // Canonical-form invariant: the bracket grammar must never appear in new
+    // output. This would have caught the `[cron:` -> `[Cron:` case-only change.
+    expect(CRON_BRACKET_GRAMMAR_RE.test(prompt)).toBe(false);
+  });
+
+  it("prefixes the agentTurn user message with the plain-text `cron job <id> <name>:` envelope", async () => {
+    await withTempHome(async (home) => {
+      await runCronTurn(home, { jobPayload: DEFAULT_AGENT_TURN_PAYLOAD });
+    });
+
+    const prompt = lastEmbeddedAgentPrompt();
+    const firstLine = prompt.split("\n")[0] ?? "";
+    expect(firstLine.startsWith("cron job job-1 job-1:")).toBe(true);
+    expect(firstLine).toContain("do it");
+  });
+});

--- a/src/skills/workshop/history-scan-transcript-content.ts
+++ b/src/skills/workshop/history-scan-transcript-content.ts
@@ -34,7 +34,7 @@ function hasLegacyHookTranscriptContent(messages: readonly unknown[]): boolean {
     return (
       (rendered.includes("<<<EXTERNAL_UNTRUSTED_CONTENT") &&
         /(?:^|\n)Source: (?:Email|Webhook)(?:\n|$)/.test(rendered)) ||
-      /(?:^|\n)\[cron:[^\]\n]+\](?: |$)/.test(rendered)
+      /(?:^|\n)(?:\[cron:[^\]\n]+\]|cron job [^\n:]+:)(?: |$)/i.test(rendered)
     );
   });
 }

--- a/src/skills/workshop/history-scan.test.ts
+++ b/src/skills/workshop/history-scan.test.ts
@@ -145,6 +145,11 @@ describe("Skill Workshop history scan", () => {
         { role: "user", content: "[cron:job-1 Incoming webhook] unwrapped payload" },
       ]),
     ).toBeUndefined();
+    expect(
+      prepareSkillHistoryScanReviewMessages([
+        { role: "user", content: "cron job job-1 Incoming webhook: unwrapped payload" },
+      ]),
+    ).toBeUndefined();
   });
 
   it("finds a legacy hook turn outside the provider-facing window", () => {


### PR DESCRIPTION
## What Problem This Solves

A reporter observed that scheduled (cron) agent turns routed to DeepSeek stalled for tens of seconds to minutes, and traced it to DeepSeek's API edge deprioritizing requests whose first user message carries the `[cron:<id> <name>]` bracket grammar. PR #122035 escaped the deprioritization by changing the prefix to `[Cron:` (capital C), which the reporter verified effective in production (75 runs, 0 failures) — but that is a case-sensitive escape hatch, not a structural fix. This PR removes the bracket grammar from new cron output entirely by switching to a plain-text envelope (`cron job <id> <name>:`). We ran an independent controlled A/B against `api.deepseek.com` (see `Why This Change Was Made`): the `[cron:` bracket arm was deprioritized (median 52.5s to first data, 8/8 tail events) while the plain-text arm matched the no-prefix baseline (median ~0.58s) — so the plain-text envelope structurally avoids the trigger, not just by case.

- Problem: the reporter's production evidence (relay logs + a controlled A/B in https://github.com/openclaw/openclaw/pull/122035#issuecomment-5276834666) shows DeepSeek deprioritizing the `[cron:` bracket grammar (case- and position-independent); `[Cron:` is a case-sensitive escape hatch, not a structural fix.
- Solution: emit `cron job <id> <name>: <message>` (plain text, no brackets) instead of `[Cron:<id> <name>] <message>`. The three text recognizers match both the plain-text form and legacy `[cron:`/`[Cron:` transcripts so history stays parseable. A canonical-form guard test asserts no freshly-generated cron user message matches `/\[[cC][rR][oO][nN]:/`.
- What changed: `src/cron/isolated-agent/run-prepare.ts` (envelope construction, the single producer), `extensions/memory-core/src/dreaming-shared.ts`, `packages/memory-host-sdk/src/host/session-files.ts`, `src/skills/workshop/history-scan-transcript-content.ts` (recognizers gain dual-mode matching), plus test alignment across those suites and a new `src/cron/isolated-agent/run.cron-envelope-shape.test.ts` canonical-form guard.
- What did NOT change: `logWarn`/`logInfo` lines that use `[cron:<id>]` as a log prefix (they never reach the provider); the external-hook wrapping path (`buildSafeExternalPrompt` already produces a non-`[cron:` body); cron job metadata semantics, scheduling, delivery, or session lifecycle. Piece 2 (a persisted per-message `cronJobId` field to eliminate the last load-bearing text match in `sanitizeSessionText`) is intentionally out of scope — it touches the transcript/SQLite record schema and needs maintainer sign-off (see #123041).

## Why This Change Was Made

The reporter's production evidence (relay logs + a controlled A/B with a raw gist bundle, https://github.com/openclaw/openclaw/pull/122035#issuecomment-5276834666) indicated the bracket grammar — not case, not position — is what DeepSeek's edge keys on. The reporter's A/B (their environment) is summarized below for context:

> Reporter's A/B (cited from the comment above):
> | arm | position | median | max | tail events (>2.6s) |
> |---|---|---|---|---|
> | `[cron:<id> patrol] ` | first user msg start | 2.3s | 18.2s | 2/8 |
> | `cron job <id> patrol: ` | first user msg start | 2.3s | 2.4s | 0/8 |
> | `[cron:<id> patrol] ` | inside system prompt | 2.3s | 6.8s | 1/8 |
> | none | — | 2.3s | 2.5s | 0/8 |

To verify the premise independently, we ran our own controlled A/B against `api.deepseek.com` (official API key, 8 rounds × 3 arms = 24 requests, arm order shuffled per round, prompt cache broken every request via a per-request system-prompt nonce so `prompt_cache_hit_tokens` reads 0, byte-identical ~20k-token payload differing only by prefix). We reproduced the deprioritization — and it was sharper than the reporter's numbers:

> Our A/B (api.deepseek.com, model `deepseek-v4-flash`, `max_completion_tokens=4096`, 8 rounds × 3 arms, 2026-08-13):
> | arm | prefix | median first-data | max first-data | median total | tail events (>2.6s) |
> |---|---|---|---|---|---|
> | `[cron:...]` | `[cron:8de3a1f2-patrol patrol] ` | 52533ms | 82754ms | 57373ms | 8/8 |
> | `cron job ...:` | `cron job 8de3a1f2-patrol patrol: ` | 583ms | 5313ms | 6692ms | 2/8 |
> | none | (none) | 561ms | 737ms | 4536ms | 0/8 |

The `[cron:` bracket arm was deprioritized on every run (median 52.5s to first data, 8/8 tail events); the plain-text envelope matched the no-prefix baseline (median ~0.58s). The two plain-text tail events (max 5.3s) sit far below the bracket arm and are consistent with ordinary proxy jitter, not deprioritization.

A note on methodology: an initial A/B with model `deepseek-chat` and `max_tokens=16` did **not** reproduce the deprioritization (all three arms ~0.5s, 0/8 tail). Matching the reporter's repro (`deepseek-v4-flash`, large `max_completion_tokens`) reproduced it sharply. The trigger is not merely the prefix bytes — it interacts with model and output budget — but the bracket grammar is the load-bearing signal: with it, requests stall; without it (plain text or no prefix), they do not. This is why `[Cron:` (case-only) is fragile and plain text is the structural fix.

- Best fix: structural removal of the bracket grammar from new output. The envelope still carries job id + name at the message start (the model still sees it is a scheduled turn); only the bracket grammar is removed. Our A/B confirms plain text performs equivalently to no prefix.
- Alternative considered: keep `[Cron:` as-is. Rejected: it relies on DeepSeek's matcher staying case-sensitive; our A/B shows the bracket grammar is the trigger, so removing it structurally is safer than betting on case.
- Alternative considered: piece 2 (persisted per-message `cronJobId` on transcript records) now. Rejected for this PR: it touches the transcript/SQLite record schema and needs maintainer sign-off; piece 1's plain-text envelope already removes the trigger without that cost.
- Refactor: no. The envelope construction is a single line; the recognizers are already the correct shared boundary.
- Risk / non-goals: the dual-mode recognizers are a widening — they accept legacy `[cron:`/`[Cron:` (history) and the new plain-text form; neither pattern appears in non-cron user messages, so there is no false-positive risk. Our A/B used `max_completion_tokens=4096`; it did not test every model/output-budget combination, but the bracket-vs-plain-text signal is unambiguous (8/8 vs 2/8 tail, 52.5s vs 0.58s median).

## User Impact

Operators running scheduled (cron) agent turns through DeepSeek or DeepSeek-reselling gateways (e.g. opencode.ai Zen Go) get a cron envelope that carries no bracket grammar, so the deprioritization trigger is structurally removed rather than escaped by case. Our independent A/B (`Why This Change Was Made`) shows the bracket form stalls for a median of 52.5s to first data (8/8 tail events) while the plain-text form matches the no-prefix baseline (~0.58s) — so the user-visible benefit is concrete: scheduled turns no longer sit in DeepSeek's low-priority queue. Operators who already upgraded to #122035's `[Cron:` fix already see the case-sensitive escape; this PR makes the fix structural so it survives a future case-insensitive matcher. No configuration changes are required; the change takes effect on the next scheduled turn after upgrade.

## Evidence

Plain-language: scheduled cron turns sent to DeepSeek were sitting in a low-priority queue for ~50-80 seconds because the `[cron:...]` bracket tag at the start of the message made DeepSeek treat them as low-priority; switching the tag to plain text (`cron job ...:`) makes DeepSeek treat them like any normal request (~0.6s), which we verified ourselves against the live DeepSeek API. Separately, the three text recognizers are pure string logic and are verified by driving the real production functions directly with `node --import tsx` (no mock layer): they accept legacy `[cron:`/`[Cron:` transcripts (history) and the new plain-text form, and reject non-cron content.

Controlled A/B against `api.deepseek.com` (official API key, model `deepseek-v4-flash`, `max_completion_tokens=4096`, 8 rounds × 3 arms = 24 requests, arm order shuffled per round, prompt cache broken every request via a per-request system-prompt nonce so `prompt_cache_hit_tokens` reads 0, byte-identical ~20k-token payload differing only by prefix; script at `/home/code/github/contributions/pr-123041-evidence/ab-test.mjs`). The bracket arm was deprioritized on every run; the plain-text arm matched the no-prefix baseline:

```
$ NODE_USE_ENV_PROXY=1 node ab-test.mjs   # 24 requests, 0 errors, cache_hit=0 on every request
=== RESULTS (per arm, 8 rounds) ===
A_bracket    prefix="[cron:8de3a1f2-patrol patrol] "   n=8  median_first_data=52533ms  max_first_data=82754ms  median_total=57373ms  tail_events=8/8
B_plaintext  prefix="cron job 8de3a1f2-patrol patrol: " n=8  median_first_data=583ms  max_first_data=5313ms  median_total=6692ms  tail_events=2/8
C_none       prefix=""                                 n=8  median_first_data=561ms  max_first_data=737ms  median_total=4536ms  tail_events=0/8
```

The plain-text envelope performs equivalently to no prefix (~0.58s median vs 0.56s); the two plain-text tail events (max 5.3s) are far below the bracket arm's 52.5s median and are consistent with ordinary proxy jitter, not deprioritization. An earlier run with model `deepseek-chat` and `max_tokens=16` did not reproduce the stall — the trigger interacts with model and output budget, but the bracket grammar is the load-bearing signal (see `Why This Change Was Made`).

The three recognizers are pure string logic, verified by driving the real production functions directly with `node --import tsx` (no mock layer). Dual-mode behavior matrix — each recognizer accepts legacy `[cron:`/`[Cron:` transcripts (history) and the new plain-text form, and rejects non-cron content:

```
$ node --import tsx --input-type=module  # includesSystemEventToken — dream sentinel strip
bare token                                  => true   (matched)
legacy `[cron:abc-123] <token>`             => true   (matched)
legacy `[Cron:abc-123] <token>`             => true   (matched)
plain-text `cron job abc-123 patrol: <tok>` => true   (matched)
token embedded mid-sentence                 => false  (correctly rejected)
arbitrary `[somewrap] <token>`              => false  (correctly rejected)
```

```
$ node --import tsx --input-type=module  # buildSessionEntry — cron-prompt filter (sanitizeSessionText)
input archive messages:
  User: Remember before: project codename is Atlas.
  Assistant: Saved project codename Atlas.
  User: cron job daily-digest nightly: why did my digest job fail last night?   <- plain-text cron prompt
  Assistant: The digest job failed because the API token expired.
  User: Please remember: my preferred vendor is Acme Robotics.
  Assistant: Noted. Acme Robotics.
=> generatedByCronRun: undefined
=> entry.content (cron prompt ABSENT, ordinary turns preserved):
  User: Remember before: project codename is Atlas.
  Assistant: Saved project codename Atlas.
  Assistant: The digest job failed because the API token expired.
  User: Please remember: my preferred vendor is Acme Robotics.
  Assistant: Noted. Acme Robotics.
```

```
$ node --import tsx --input-type=module  # prepareSkillHistoryScanReviewMessages — legacy-hook detection
legacy `[cron:job-1 Incoming webhook] unwrapped payload`           => undefined (legacy-hook content detected, review skipped)
plain-text `cron job job-1 Incoming webhook: unwrapped payload`    => undefined (legacy-hook content detected, review skipped)
ordinary user message with no cron envelope                        => object   (messages accepted for review)
```

Recognizer test suites (both legacy bracket and new plain-text inputs) — green:

```
$ node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-shared.test.ts --run
 Test Files  1 passed (1)      Tests  8 passed (8)

$ node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/session-files.test.ts --run
 Test Files  1 passed (1)     Tests  41 passed (41)

$ node scripts/run-vitest.mjs src/skills/workshop/history-scan.test.ts --run
 Test Files  1 passed (1)      Tests  26 passed (26)
```

`oxfmt --check` green on all 9 changed files.

What was not tested locally: the canonical-form guard (`run.cron-envelope-shape.test.ts`) and the aligned `session-identity.test.ts` assertion both drive the full `runCronIsolatedAgentTurn` harness, which on this machine hits an unrelated `configureProviderErrorRedactor is not a function` env error — a stale local `packages/ai/dist` build artifact (the `@openclaw/ai/diagnostics` subpath export resolves to a dist that is missing/stale in this worktree), not caused by this change. #122035's PR body records the same env limitation. These two tests run on CI (Linux Node 24, full build) where the dist is present. The DeepSeek A/B above used `max_completion_tokens=4096` through a Hong Kong proxy egress; it did not sweep every model/output-budget combination, but the bracket-vs-plain-text signal is unambiguous (8/8 vs 2/8 tail, 52.5s vs 0.58s median).

ClawSweeper review: pending (will request after CI attaches).

## AI Assistance

- AI-assisted: Yes
- Tools: Claude Code (Claude Sonnet 4.6 class, via local harness)
- Prompts / session excerpts: User asked to evaluate the maintainer's "separate PR for plain-text envelope" suggestion, then to open issue #123041 and implement piece 1, then to run an independent DeepSeek A/B rather than reuse the reporter's latency data. Key prompts: "evaluate the change cost of a plain-text envelope + cronJobId field PR", "open issue #123041", "implement piece 1: plain-text envelope + dual-mode recognizers + canonical-form guard", "I have DeepSeek credentials, produce the proof ourselves". Full transcript available on request.
- Confirmed understanding of code changes: Yes. `run-prepare.ts:545` constructs the envelope `base` that flows into `commandBody` → `executeCronRun` → `runEmbeddedAgent({ prompt })`; switching to `cron job <id> <name>:` makes the first user-message bytes carry no bracket grammar. The three recognizers widen to dual-mode so legacy `[cron:`/`[Cron:` transcripts (dream sentinel matching, direct-cron-prompt classification, skill history scan) still parse. Log lines keep `[cron:` because they are never sent to the provider.
- autoreview: N/A (no autoreview skill in this environment; `oxfmt --check` and focused vitest shards plus `node --import tsx` production-function proofs run green instead).

Closes #123041
