### PR TITLE
fix(release): repair beta.2 validation blockers (r20)

### DIFF
--- a/extensions/matrix/src/matrix/monitor/route.test.ts
+++ b/extensions/matrix/src/matrix/monitor/route.test.ts
@@ -18,6 +18,16 @@ const baseCfg = {
   },
 } satisfies OpenClawConfig;
 
+const threadCfg = {
+  ...baseCfg,
+  bindings: [
+    {
+      agentId: "main",
+      match: { channel: "matrix", accountId: "ops" },
+    },
+  ],
+} satisfies OpenClawConfig;
+
 type RouteBinding = NonNullable<OpenClawConfig["bindings"]>[number];
 type RoutePeer = NonNullable<RouteBinding["match"]["peer"]>;
 
@@ -213,7 +223,7 @@ describe("resolveMatrixInboundRoute thread-isolated sessions", () => {
 
   it("scopes session key to thread when a thread id is provided", () => {
     const { route } = resolveMatrixInboundRoute({
-      cfg: baseCfg as never,
+      cfg: threadCfg as never,
       accountId: "ops",
       roomId: "!room:example.org",
       senderId: "@alice:example.org",
@@ -229,7 +239,7 @@ describe("resolveMatrixInboundRoute thread-isolated sessions", () => {
 
   it("preserves mixed-case matrix thread ids in session keys", () => {
     const { route } = resolveMatrixInboundRoute({
-      cfg: baseCfg as never,
+      cfg: threadCfg as never,
       accountId: "ops",
       roomId: "!room:example.org",
       senderId: "@alice:example.org",
@@ -243,7 +253,7 @@ describe("resolveMatrixInboundRoute thread-isolated sessions", () => {
 
   it("does not scope session key when thread id is absent", () => {
     const { route } = resolveMatrixInboundRoute({
-      cfg: baseCfg as never,
+      cfg: threadCfg as never,
       accountId: "ops",
       roomId: "!room:example.org",
       senderId: "@alice:example.org",

--- a/extensions/telegram/src/bot-handlers.message-context.ts
+++ b/extensions/telegram/src/bot-handlers.message-context.ts
@@ -1,9 +1,9 @@
 import type { Message } from "grammy/types";
-import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 import { formatMediaPlaceholderText } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveStoredModelOverride } from "openclaw/plugin-sdk/command-auth-native";
 import type { OpenClawConfig, TelegramAccountConfig } from "openclaw/plugin-sdk/config-contracts";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "openclaw/plugin-sdk/reply-history";
+import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import {
   getSessionEntry,
   readAmbientTranscriptWatermark,
@@ -300,11 +300,14 @@ export function createTelegramMessageContextRuntime({
   RegisterTelegramHandlerParams,
   "cfg" | "accountId" | "opts" | "telegramCfg" | "telegramDeps"
 >) {
+  const messageCacheAgentId = resolveAgentRoute({
+    cfg,
+    channel: "telegram",
+    accountId,
+  }).agentId;
   const messageCache = createTelegramMessageCache({
     scope: resolveTelegramMessageCacheScope(
-      telegramDeps.resolveStorePath(cfg.session?.store, {
-        agentId: cfg.agents ? resolveDefaultAgentId(cfg) : "main",
-      }),
+      telegramDeps.resolveStorePath(cfg.session?.store, { agentId: messageCacheAgentId }),
     ),
   });
   const resolvePromptSender = (

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -3765,6 +3765,12 @@ describe("createTelegramBot", () => {
       agents: {
         list: [{ id: "topic-a" }, { id: "topic-b" }],
       },
+      bindings: [
+        {
+          agentId: "topic-a",
+          match: { channel: "telegram", accountId: "default" },
+        },
+      ],
     });
     loadConfig.mockImplementation(configForTopicAgent);
 

--- a/package.json
+++ b/package.json
@@ -1851,7 +1851,7 @@
     "test:docker:update-migration": "env OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE=1 OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC=${OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC:-openclaw@2026.4.23} OPENCLAW_UPGRADE_SURVIVOR_SCENARIO=${OPENCLAW_UPGRADE_SURVIVOR_SCENARIO:-plugin-deps-cleanup} bash scripts/e2e/upgrade-survivor-docker.sh",
     "test:docker:update-restart-auth": "env OPENCLAW_UPGRADE_SURVIVOR_UPDATE_RESTART_MODE=auto-auth OPENCLAW_UPGRADE_SURVIVOR_DOCKER_RUN_TIMEOUT=${OPENCLAW_UPGRADE_SURVIVOR_DOCKER_RUN_TIMEOUT:-1500s} bash scripts/e2e/upgrade-survivor-docker.sh",
     "test:docker:update-run-package-self-upgrade": "bash scripts/e2e/update-run-package-self-upgrade-docker.sh",
-    "test:docker:upgrade-survivor": "bash scripts/e2e/upgrade-survivor-docker.sh",
+    "test:docker:upgrade-survivor": "node --import tsx scripts/run-with-env.mts OPENCLAW_DOCKER_ALL_LANES=upgrade-survivor -- node scripts/test-docker-all.mjs",
     "test:env-mutations:report": "node --import tsx scripts/test-env-mutation-report.ts",
     "test:skip-inventory:report": "node --import tsx scripts/test-skip-inventory.ts",
     "test:type-suppression-inventory:report": "node --import tsx scripts/type-suppression-inventory.ts",

--- a/scripts/e2e/lib/fixtures/workspace.mjs
+++ b/scripts/e2e/lib/fixtures/workspace.mjs
@@ -30,6 +30,7 @@ function writeAgentsDeleteConfig() {
   fs.mkdirSync(sharedWorkspace, { recursive: true });
   writeJson(path.join(stateDir, "openclaw.json"), {
     agents: {
+      ownership: "explicit",
       entries: {
         main: { workspace: sharedWorkspace },
         ops: { workspace: sharedWorkspace },

--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -893,8 +893,8 @@ function assertSessionMetadataMigrated(stateDir) {
         `legacy session transcript was not moved for ${sessionId}`,
       );
       assert(
-        entry?.sessionFile === expectedPath,
-        `legacy session row still points at the old sessions directory for ${sessionId}`,
+        !Object.hasOwn(entry ?? {}, "sessionFile"),
+        `legacy session row retained retired sessionFile metadata for ${sessionId}`,
       );
     }
   }

--- a/scripts/lib/openclaw-test-state.mts
+++ b/scripts/lib/openclaw-test-state.mts
@@ -134,6 +134,7 @@ function scenarioConfig(scenario: string, options: TestStateOptions = {}) {
           },
           contextTokens: 64000,
           skills: ["memory"],
+          sessionStore: { agentId: "main" },
         },
         entries: {
           main: {
@@ -478,7 +479,10 @@ OPENCLAW_TEST_STATE_JSON
       "contextTokens": 64000,
       "skills": [
         "memory"
-      ]
+      ],
+      "sessionStore": {
+        "agentId": "main"
+      }
     },
     "entries": {
       "main": {

--- a/scripts/package-openclaw-for-docker.mts
+++ b/scripts/package-openclaw-for-docker.mts
@@ -104,6 +104,18 @@ function hasErrorCode(error: unknown, code: string) {
   return isRecord(error) && error.code === code;
 }
 
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch (error) {
+    if (hasErrorCode(error, "ENOENT")) {
+      return false;
+    }
+    throw error;
+  }
+}
+
 const ACTIVE_CHILD_KILLERS = new Set<KillChild>();
 const PACKAGE_BUILD_PLUGIN_SELECTION_ENV_NAMES = [
   "OPENCLAW_EXTENSIONS",
@@ -628,6 +640,10 @@ export async function prepareBundledAiRuntimePackage(
 ) {
   const packageJsonPath = path.join(sourceDir, "package.json");
   const aiRuntimePackageJsonPath = path.join(sourceDir, "packages", "ai", "package.json");
+  const normalizationCoreWorkspacePath = path.join(sourceDir, "packages", "normalization-core");
+  const aiPackNodeModulesPath = path.join(sourceDir, "packages", "ai", "node_modules");
+  const aiPackDependencyScopePath = path.join(aiPackNodeModulesPath, "@openclaw");
+  const aiPackNormalizationCorePath = path.join(aiPackDependencyScopePath, "normalization-core");
   const aiRuntimePath = path.join(sourceDir, "node_modules", "@openclaw", "ai");
   const aiRuntimeBackupPath = path.join(
     sourceDir,
@@ -721,18 +737,45 @@ export async function prepareBundledAiRuntimePackage(
   };
 
   try {
-    await runCaptureImpl(
-      "pnpm",
-      ["--dir", "packages/ai", "pack", "--silent", "--pack-destination", outputDir],
-      sourceDir,
-      {
-        deferForwardedSignalExit: true,
-        timeoutMs: resolveTimeoutMs(
-          "OPENCLAW_DOCKER_PACKAGE_PACK_TIMEOUT_MS",
-          DEFAULT_PACKAGE_PACK_TIMEOUT_MS,
-        ),
-      },
-    );
+    const hadAiPackNodeModules = await pathExists(aiPackNodeModulesPath);
+    const hadAiPackDependencyScope = await pathExists(aiPackDependencyScopePath);
+    const stagedAiPackNormalizationCore =
+      !(await pathExists(aiPackNormalizationCorePath)) &&
+      (await pathExists(path.join(normalizationCoreWorkspacePath, "package.json")));
+    if (stagedAiPackNormalizationCore) {
+      await fs.mkdir(aiPackDependencyScopePath, { recursive: true });
+      await fs.symlink(
+        process.platform === "win32"
+          ? normalizationCoreWorkspacePath
+          : path.relative(aiPackDependencyScopePath, normalizationCoreWorkspacePath),
+        aiPackNormalizationCorePath,
+        process.platform === "win32" ? "junction" : "dir",
+      );
+    }
+    try {
+      await runCaptureImpl(
+        "pnpm",
+        ["--dir", "packages/ai", "pack", "--silent", "--pack-destination", outputDir],
+        sourceDir,
+        {
+          deferForwardedSignalExit: true,
+          timeoutMs: resolveTimeoutMs(
+            "OPENCLAW_DOCKER_PACKAGE_PACK_TIMEOUT_MS",
+            DEFAULT_PACKAGE_PACK_TIMEOUT_MS,
+          ),
+        },
+      );
+    } finally {
+      if (stagedAiPackNormalizationCore) {
+        await fs.rm(aiPackNormalizationCorePath, { force: true });
+        if (!hadAiPackDependencyScope) {
+          await fs.rm(aiPackDependencyScopePath, { force: true, recursive: true });
+        }
+        if (!hadAiPackNodeModules) {
+          await fs.rm(aiPackNodeModulesPath, { force: true, recursive: true });
+        }
+      }
+    }
     packedAiTarballs = (await fs.readdir(outputDir))
       .filter(isPackedAiRuntimeTarball)
       .map((filename) => path.join(outputDir, filename));

--- a/scripts/test-docker-all.mts
+++ b/scripts/test-docker-all.mts
@@ -1284,13 +1284,7 @@ async function prepareDockerCandidate(
       delete candidateEnv[key];
     }
     candidateEnv.OPENCLAW_DOCKER_E2E_SELECTED_SHA = sourceSha;
-    await prepareOpenClawPackage(candidateEnv, logDir);
-    const packagePath = candidateEnv.OPENCLAW_CURRENT_PACKAGE_TGZ!;
-    const packed = inspectNpmPackageTarball(packagePath);
     const version = rootPackageVersion(ROOT_DIR);
-    if (packed.packageJson.name !== "openclaw" || packed.packageJson.version !== version) {
-      throw new Error("packed Docker candidate name or version differs from the root package");
-    }
     const registry = preparePrepublishPluginRegistry({
       allowCreate: true,
       baseEnv: candidateEnv,
@@ -1299,6 +1293,12 @@ async function prepareDockerCandidate(
       plan,
       sourceSha,
     });
+    await prepareOpenClawPackage(candidateEnv, logDir);
+    const packagePath = candidateEnv.OPENCLAW_CURRENT_PACKAGE_TGZ!;
+    const packed = inspectNpmPackageTarball(packagePath);
+    if (packed.packageJson.name !== "openclaw" || packed.packageJson.version !== version) {
+      throw new Error("packed Docker candidate name or version differs from the root package");
+    }
     candidate = {
       package: { path: packagePath, name: packed.packageJson.name, version, sha256: packed.sha256 },
       registry,
@@ -1962,6 +1962,18 @@ async function main() {
     );
   }
 
+  const needsCurrentTreePackage =
+    lanesNeedOpenClawPackage(scheduledLanes) && !baseEnv.OPENCLAW_CURRENT_PACKAGE_TGZ;
+  preparePrepublishPluginRegistry({
+    allowCreate: needsCurrentTreePackage,
+    baseEnv,
+    candidateVersion: rootPackageVersion(ROOT_DIR),
+    logDir,
+    plan,
+    sourceSha: gitOutput(ROOT_DIR, ["rev-parse", "HEAD"]),
+  });
+  validateDockerCandidateEnvironment(baseEnv, plan);
+
   await runPhase(
     phases,
     "docker-preflight",
@@ -1974,23 +1986,13 @@ async function main() {
       });
     },
   );
-  let preparedCurrentTreePackage = false;
   if (lanesNeedOpenClawPackage(scheduledLanes)) {
     await runPhase(phases, "prepare-openclaw-package", {}, async () => {
-      preparedCurrentTreePackage = await prepareOpenClawPackage(baseEnv, logDir);
+      await prepareOpenClawPackage(baseEnv, logDir);
     });
   } else {
     console.log("==> OpenClaw package: not needed for selected lanes");
   }
-  preparePrepublishPluginRegistry({
-    allowCreate: preparedCurrentTreePackage,
-    baseEnv,
-    candidateVersion: rootPackageVersion(ROOT_DIR),
-    logDir,
-    plan,
-    sourceSha: gitOutput(ROOT_DIR, ["rev-parse", "HEAD"]),
-  });
-  validateDockerCandidateEnvironment(baseEnv, plan);
 
   if (buildEnabled) {
     const buildEntries: ForegroundEntry[] = [];

--- a/scripts/test-docker-all.mts
+++ b/scripts/test-docker-all.mts
@@ -1186,7 +1186,7 @@ async function prepareOpenClawPackage(baseEnv: NodeJS.ProcessEnv, logDir: string
     baseEnv.OPENCLAW_BUNDLED_CHANNEL_HOST_BUILD = "0";
     baseEnv.OPENCLAW_NPM_ONBOARD_HOST_BUILD = "0";
     console.log(`==> OpenClaw package: ${packageTgz}`);
-    return;
+    return false;
   }
 
   const packDir = path.join(logDir, "openclaw-package");
@@ -1205,6 +1205,67 @@ async function prepareOpenClawPackage(baseEnv: NodeJS.ProcessEnv, logDir: string
   baseEnv.OPENCLAW_BUNDLED_CHANNEL_HOST_BUILD = "0";
   baseEnv.OPENCLAW_NPM_ONBOARD_HOST_BUILD = "0";
   console.log(`==> OpenClaw package: ${baseEnv.OPENCLAW_CURRENT_PACKAGE_TGZ}`);
+  return true;
+}
+
+type PreparedPrepublishPluginRegistry = {
+  candidateVersion: string;
+  dir: string;
+  manifestSha256: string;
+};
+
+function preparePrepublishPluginRegistry(params: {
+  allowCreate: boolean;
+  baseEnv: NodeJS.ProcessEnv;
+  candidateVersion: string;
+  logDir: string;
+  plan: DockerCandidatePlan;
+  sourceSha: string;
+}): PreparedPrepublishPluginRegistry | null {
+  if (!params.plan.needs.prepublishPluginRegistry) {
+    return null;
+  }
+  const supplied = readCompleteTuple(
+    params.baseEnv,
+    REGISTRY_ENV_KEYS,
+    "Docker candidate registry",
+  );
+  if (supplied) {
+    params.baseEnv.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR = path.resolve(
+      supplied.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR,
+    );
+    validateRegistryEnvironment(params.baseEnv, params.plan);
+    return {
+      candidateVersion: supplied.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION,
+      dir: params.baseEnv.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR,
+      manifestSha256: supplied.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256,
+    };
+  }
+  if (!params.allowCreate) {
+    throw new Error(
+      "Docker plan requires a prepublish plugin registry tuple for the supplied package",
+    );
+  }
+
+  const registryDir = path.join(params.logDir, "prepublish-plugin-registry");
+  fs.rmSync(registryDir, { force: true, recursive: true });
+  const artifact = createPrepublishPluginRegistryArtifact({
+    repoRoot: ROOT_DIR,
+    outputDir: registryDir,
+    sourceSha: params.sourceSha,
+    candidateVersion: params.candidateVersion,
+    requiredPackages: params.plan.requiredPrepublishPluginPackages,
+  });
+  params.baseEnv.OPENCLAW_DOCKER_E2E_SELECTED_SHA = params.sourceSha;
+  params.baseEnv.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR = registryDir;
+  params.baseEnv.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION = params.candidateVersion;
+  params.baseEnv.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256 = artifact.manifestSha256;
+  validateRegistryEnvironment(params.baseEnv, params.plan);
+  return {
+    candidateVersion: params.candidateVersion,
+    dir: registryDir,
+    manifestSha256: artifact.manifestSha256,
+  };
 }
 
 async function prepareDockerCandidate(
@@ -1222,6 +1283,7 @@ async function prepareDockerCandidate(
     for (const key of [...CANDIDATE_ENV_KEYS, ...REGISTRY_ENV_KEYS]) {
       delete candidateEnv[key];
     }
+    candidateEnv.OPENCLAW_DOCKER_E2E_SELECTED_SHA = sourceSha;
     await prepareOpenClawPackage(candidateEnv, logDir);
     const packagePath = candidateEnv.OPENCLAW_CURRENT_PACKAGE_TGZ!;
     const packed = inspectNpmPackageTarball(packagePath);
@@ -1229,23 +1291,14 @@ async function prepareDockerCandidate(
     if (packed.packageJson.name !== "openclaw" || packed.packageJson.version !== version) {
       throw new Error("packed Docker candidate name or version differs from the root package");
     }
-    let registry = null;
-    if (plan.needs.prepublishPluginRegistry) {
-      const registryDir = path.join(logDir, "prepublish-plugin-registry");
-      fs.rmSync(registryDir, { force: true, recursive: true });
-      const artifact = createPrepublishPluginRegistryArtifact({
-        repoRoot: ROOT_DIR,
-        outputDir: registryDir,
-        sourceSha,
-        candidateVersion: version,
-        requiredPackages: plan.requiredPrepublishPluginPackages,
-      });
-      registry = {
-        dir: registryDir,
-        candidateVersion: version,
-        manifestSha256: artifact.manifestSha256,
-      };
-    }
+    const registry = preparePrepublishPluginRegistry({
+      allowCreate: true,
+      baseEnv: candidateEnv,
+      candidateVersion: version,
+      logDir,
+      plan,
+      sourceSha,
+    });
     candidate = {
       package: { path: packagePath, name: packed.packageJson.name, version, sha256: packed.sha256 },
       registry,
@@ -1921,13 +1974,23 @@ async function main() {
       });
     },
   );
+  let preparedCurrentTreePackage = false;
   if (lanesNeedOpenClawPackage(scheduledLanes)) {
     await runPhase(phases, "prepare-openclaw-package", {}, async () => {
-      await prepareOpenClawPackage(baseEnv, logDir);
+      preparedCurrentTreePackage = await prepareOpenClawPackage(baseEnv, logDir);
     });
   } else {
     console.log("==> OpenClaw package: not needed for selected lanes");
   }
+  preparePrepublishPluginRegistry({
+    allowCreate: preparedCurrentTreePackage,
+    baseEnv,
+    candidateVersion: rootPackageVersion(ROOT_DIR),
+    logDir,
+    plan,
+    sourceSha: gitOutput(ROOT_DIR, ["rev-parse", "HEAD"]),
+  });
+  validateDockerCandidateEnvironment(baseEnv, plan);
 
   if (buildEnabled) {
     const buildEntries: ForegroundEntry[] = [];

--- a/src/cli/plugins-cli-test-helpers.ts
+++ b/src/cli/plugins-cli-test-helpers.ts
@@ -38,6 +38,8 @@ type WritePersistedInstalledPluginIndexInstallRecordsFn =
   (typeof import("../plugins/installed-plugin-index-records.js"))["writePersistedInstalledPluginIndexInstallRecords"];
 type WritePersistedInstalledPluginIndexInstallRecordsWithLeaseFn =
   (typeof import("../plugins/installed-plugin-index-records.js"))["writePersistedInstalledPluginIndexInstallRecordsWithLease"];
+type ReadPersistedInstalledPluginIndexInstallRecordsFn =
+  (typeof import("../plugins/installed-plugin-index-records.js"))["readPersistedInstalledPluginIndexInstallRecords"];
 type PluginInstallRecordMap = Record<string, PluginInstallRecord>;
 
 function createEmptyUninstallActions() {
@@ -55,6 +57,7 @@ function createEmptyUninstallActions() {
 }
 
 let mockInstalledPluginIndexInstallRecords: PluginInstallRecordMap = {};
+let mockPersistedPluginInstallRecords: PluginInstallRecordMap = {};
 let mockHookInstallRecords: Record<string, HookInstallRecord> = {};
 let mockInstalledPluginIndexRevision = 0;
 
@@ -112,9 +115,14 @@ export const recordPluginInstallMock: UnknownMock = vi.fn();
 const loadInstalledPluginIndexInstallRecords: AsyncUnknownMock = vi.fn(async () =>
   clonePluginInstallRecords(mockInstalledPluginIndexInstallRecords),
 );
+const readPersistedInstalledPluginIndexInstallRecords: Mock<ReadPersistedInstalledPluginIndexInstallRecordsFn> =
+  vi.fn<ReadPersistedInstalledPluginIndexInstallRecordsFn>(async () =>
+    clonePluginInstallRecords(mockPersistedPluginInstallRecords),
+  );
 const writePersistedInstalledPluginIndexInstallRecords: Mock<WritePersistedInstalledPluginIndexInstallRecordsFn> =
   vi.fn<WritePersistedInstalledPluginIndexInstallRecordsFn>(async (records) => {
     mockInstalledPluginIndexInstallRecords = clonePluginInstallRecords(records);
+    mockPersistedPluginInstallRecords = clonePluginInstallRecords(records);
     return "/tmp/openclaw-state/openclaw.sqlite";
   });
 export const readPersistedInstalledPluginIndexMock: Mock<ReadPersistedInstalledPluginIndexFn> =
@@ -123,6 +131,7 @@ export const writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock: Mock
   vi.fn<WritePersistedInstalledPluginIndexInstallRecordsWithLeaseFn>(async (records) => {
     const previous = await readPersistedInstalledPluginIndexMock();
     mockInstalledPluginIndexInstallRecords = clonePluginInstallRecords(records);
+    mockPersistedPluginInstallRecords = clonePluginInstallRecords(records);
     mockInstalledPluginIndexRevision += 1;
     return { previous, revision: mockInstalledPluginIndexRevision };
   });
@@ -132,6 +141,9 @@ export const restorePersistedInstalledPluginIndexIfCurrentMock: Mock<RestorePers
       return false;
     }
     mockInstalledPluginIndexInstallRecords = clonePluginInstallRecords(
+      (index?.installRecords ?? {}) as PluginInstallRecordMap,
+    );
+    mockPersistedPluginInstallRecords = clonePluginInstallRecords(
       (index?.installRecords ?? {}) as PluginInstallRecordMap,
     );
     mockInstalledPluginIndexRevision += 1;
@@ -214,6 +226,12 @@ export { runtimeErrors, pluginsCliRuntimeLogs };
 
 export function setInstalledPluginIndexInstallRecords(records: PluginInstallRecordMap): void {
   mockInstalledPluginIndexInstallRecords = clonePluginInstallRecords(records);
+  mockPersistedPluginInstallRecords = clonePluginInstallRecords(records);
+}
+
+export function setRecoveredPluginInstallRecords(records: PluginInstallRecordMap): void {
+  mockInstalledPluginIndexInstallRecords = clonePluginInstallRecords(records);
+  mockPersistedPluginInstallRecords = {};
 }
 
 function restoreRuntimeCaptureMocks() {
@@ -373,6 +391,10 @@ vi.mock("../plugins/installed-plugin-index-records.js", async (importOriginal) =
     ...actual,
     loadInstalledPluginIndexInstallRecords: ((...args: unknown[]) =>
       invokeMock<unknown[], unknown>(loadInstalledPluginIndexInstallRecords, ...args)) as (
+      ...args: unknown[]
+    ) => unknown,
+    readPersistedInstalledPluginIndexInstallRecords: ((...args: unknown[]) =>
+      invokeMock<unknown[], unknown>(readPersistedInstalledPluginIndexInstallRecords, ...args)) as (
       ...args: unknown[]
     ) => unknown,
     writePersistedInstalledPluginIndexInstallRecords: ((...args: unknown[]) =>
@@ -842,8 +864,10 @@ export function resetPluginsCliTestState() {
   enablePluginInConfigMock.mockReset();
   recordPluginInstallMock.mockReset();
   mockInstalledPluginIndexInstallRecords = {};
+  mockPersistedPluginInstallRecords = {};
   mockInstalledPluginIndexRevision = 0;
   loadInstalledPluginIndexInstallRecords.mockReset();
+  readPersistedInstalledPluginIndexInstallRecords.mockReset();
   writePersistedInstalledPluginIndexInstallRecords.mockReset();
   writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock.mockReset();
   readPersistedInstalledPluginIndexMock.mockReset();
@@ -932,8 +956,12 @@ export function resetPluginsCliTestState() {
   loadInstalledPluginIndexInstallRecords.mockImplementation(async () =>
     clonePluginInstallRecords(mockInstalledPluginIndexInstallRecords),
   );
+  readPersistedInstalledPluginIndexInstallRecords.mockImplementation(async () =>
+    clonePluginInstallRecords(mockPersistedPluginInstallRecords),
+  );
   writePersistedInstalledPluginIndexInstallRecords.mockImplementation(async (records) => {
     mockInstalledPluginIndexInstallRecords = clonePluginInstallRecords(records);
+    mockPersistedPluginInstallRecords = clonePluginInstallRecords(records);
     return "/tmp/openclaw-state/openclaw.sqlite";
   });
   readPersistedInstalledPluginIndexMock.mockResolvedValue(null);
@@ -941,6 +969,7 @@ export function resetPluginsCliTestState() {
     async (records) => {
       const previous = await readPersistedInstalledPluginIndexMock();
       mockInstalledPluginIndexInstallRecords = clonePluginInstallRecords(records);
+      mockPersistedPluginInstallRecords = clonePluginInstallRecords(records);
       mockInstalledPluginIndexRevision += 1;
       return { previous, revision: mockInstalledPluginIndexRevision };
     },
@@ -951,6 +980,9 @@ export function resetPluginsCliTestState() {
         return false;
       }
       mockInstalledPluginIndexInstallRecords = clonePluginInstallRecords(
+        (index?.installRecords ?? {}) as PluginInstallRecordMap,
+      );
+      mockPersistedPluginInstallRecords = clonePluginInstallRecords(
         (index?.installRecords ?? {}) as PluginInstallRecordMap,
       );
       mockInstalledPluginIndexRevision += 1;

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { withTempHome } from "openclaw/plugin-sdk/test-env";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { tryResolveLegacyCompatibilityAgentId } from "../agents/agent-scope.js";
 import { migratePersistedImplicitMainRoster } from "../config/legacy.roster.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { writeChannelPairingStateSnapshot } from "../pairing/pairing-store-sqlite.test-helpers.js";
@@ -1752,6 +1753,7 @@ describe("doctor config flow", () => {
     expect(result.cfg.agents).not.toHaveProperty("list");
     expect(result.cfg.agents?.entries?.main).not.toHaveProperty("default");
     expect(result.cfg.agents?.ownership).toBe("explicit");
+    expect(tryResolveLegacyCompatibilityAgentId(result.cfg)).toBe("main");
 
     const secondRun = await runDoctorConfigWithInput({
       config: result.cfg,

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -542,6 +542,9 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     note,
   });
   const cfg = finalized.cfg;
+  if (legacyDefaultAgentId) {
+    retainLegacyDefaultAgentId(cfg, legacyDefaultAgentId);
+  }
   const shouldWriteConfig = finalized.shouldWriteConfig && !legacyMigrationBlocksWrite;
   const singleTopLevelIncludeWrite =
     shouldWriteConfig &&

--- a/src/flows/doctor-health-contribution-core.ts
+++ b/src/flows/doctor-health-contribution-core.ts
@@ -2,7 +2,10 @@ import type {
   DoctorHealthCheckContext,
   DoctorHealthFlowContext,
 } from "./doctor-health-contribution-types.js";
-import { renderStructuredHealthFindings } from "./doctor-health-contribution.js";
+import {
+  renderStructuredHealthFindings,
+  resolveDoctorHealthWorkspaceDir,
+} from "./doctor-health-contribution.js";
 import type { HealthCheck, HealthFinding } from "./health-checks.js";
 
 const loadHealthCheckRegistryModule = async () => await import("./health-check-registry.js");
@@ -29,11 +32,9 @@ export async function runStructuredHealthRepairs(
   const { registerBundledHealthChecks } = await import("./bundled-health-checks.js");
   const { listExtensionHealthChecksForDoctor } = await loadHealthCheckRegistryModule();
   const { runDoctorHealthRepairs } = await import("./doctor-repair-flow.js");
-  const { resolveAgentWorkspaceDir, resolveDefaultAgentId } =
-    await import("../agents/agent-scope.js");
   const { note } = await import("../../packages/terminal-core/src/note.js");
 
-  const workspaceDir = resolveAgentWorkspaceDir(ctx.cfg, resolveDefaultAgentId(ctx.cfg));
+  const workspaceDir = await resolveDoctorHealthWorkspaceDir(ctx);
   registerBundledHealthChecks({ cfg: ctx.cfg, cwd: workspaceDir });
   const checks = listExtensionHealthChecksForDoctor(await resolveCoreChecks());
   const result = await runDoctorHealthRepairs(
@@ -64,8 +65,6 @@ export async function runCoreContributionHealth(
   }
   const { CORE_HEALTH_CHECKS } = await import("./doctor-core-checks.js");
   const { runDoctorHealthRepairs } = await import("./doctor-repair-flow.js");
-  const { resolveAgentWorkspaceDir, resolveDefaultAgentId } =
-    await import("../agents/agent-scope.js");
   const { note } = await import("../../packages/terminal-core/src/note.js");
 
   const selectedIds = new Set(checkIds);
@@ -73,7 +72,7 @@ export async function runCoreContributionHealth(
   if (checks.length === 0) {
     return;
   }
-  const workspaceDir = resolveAgentWorkspaceDir(ctx.cfg, resolveDefaultAgentId(ctx.cfg));
+  const workspaceDir = await resolveDoctorHealthWorkspaceDir(ctx);
   const dryRun = !ctx.prompter.shouldRepair;
   const result = await runDoctorHealthRepairs(
     withDoctorHealthCheckFacts(ctx, {
@@ -119,20 +118,19 @@ export async function runCoreHealthFindingNote(
   checkId: string,
 ): Promise<void> {
   const { CORE_HEALTH_CHECKS } = await import("./doctor-core-checks.js");
-  const { resolveAgentWorkspaceDir, resolveDefaultAgentId } =
-    await import("../agents/agent-scope.js");
   const { note } = await import("../../packages/terminal-core/src/note.js");
 
   const check = CORE_HEALTH_CHECKS.find((candidate) => candidate.id === checkId);
   if (!check) {
     return;
   }
+  const workspaceDir = await resolveDoctorHealthWorkspaceDir(ctx);
   const findings = await check.detect(
     withDoctorHealthCheckFacts(ctx, {
       mode: "doctor" as const,
       runtime: ctx.runtime,
       cfg: ctx.cfg,
-      cwd: resolveAgentWorkspaceDir(ctx.cfg, resolveDefaultAgentId(ctx.cfg)),
+      cwd: workspaceDir,
       configPath: ctx.configPath,
       allowExecSecretRefs: ctx.options.allowExec === true,
     }),

--- a/src/flows/doctor-health-contribution.ts
+++ b/src/flows/doctor-health-contribution.ts
@@ -80,6 +80,15 @@ function deriveCoreHealthCheckId(contributionId: string): string {
     : `core/doctor/${contributionId}`;
 }
 
+export async function resolveDoctorHealthWorkspaceDir(
+  ctx: DoctorHealthFlowContext,
+): Promise<string> {
+  const { resolveAgentWorkspaceDir, resolveDefaultAgentId, tryResolveLegacyCompatibilityAgentId } =
+    await import("../agents/agent-scope.js");
+  const agentId = tryResolveLegacyCompatibilityAgentId(ctx.cfg) ?? resolveDefaultAgentId(ctx.cfg);
+  return resolveAgentWorkspaceDir(ctx.cfg, agentId, ctx.env ?? process.env);
+}
+
 async function runStructuredDoctorHealthContribution(params: {
   contributionId: string;
   ctx: DoctorHealthFlowContext;
@@ -89,12 +98,7 @@ async function runStructuredDoctorHealthContribution(params: {
     throw new Error(`doctor contribution ${params.contributionId} has no structured health`);
   }
   const { runDoctorHealthRepairs } = await import("./doctor-repair-flow.js");
-  const { resolveAgentWorkspaceDir, resolveDefaultAgentId } =
-    await import("../agents/agent-scope.js");
-  const workspaceDir = resolveAgentWorkspaceDir(
-    params.ctx.cfg,
-    resolveDefaultAgentId(params.ctx.cfg),
-  );
+  const workspaceDir = await resolveDoctorHealthWorkspaceDir(params.ctx);
   const dryRun = !params.ctx.prompter.shouldRepair;
   const result = await runDoctorHealthRepairs(
     {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -108,6 +108,9 @@ const mocks = vi.hoisted(() => ({
     () => "/tmp/openclaw-workspace",
   ),
   tryResolveConfiguredAgentWorkspaceDir: vi.fn(() => "/tmp/openclaw-workspace"),
+  tryResolveLegacyCompatibilityAgentId: vi.fn<(_cfg: OpenClawConfig) => string | undefined>(
+    () => undefined,
+  ),
   resolveDefaultAgentId: vi.fn<(_cfg: OpenClawConfig) => string>(() => "default"),
   resolveAgentContextLimits: vi.fn(
     (cfg: { agents?: { defaults?: { contextLimits?: unknown } } }) =>
@@ -391,6 +394,7 @@ vi.mock("../agents/agent-scope.js", () => ({
   listAgentEntries: mocks.listAgentEntries,
   resolveAgentWorkspaceDir: mocks.resolveAgentWorkspaceDir,
   tryResolveConfiguredAgentWorkspaceDir: mocks.tryResolveConfiguredAgentWorkspaceDir,
+  tryResolveLegacyCompatibilityAgentId: mocks.tryResolveLegacyCompatibilityAgentId,
   resolveDefaultAgentId: mocks.resolveDefaultAgentId,
   resolveAgentContextLimits: mocks.resolveAgentContextLimits,
 }));
@@ -708,6 +712,8 @@ describe("doctor health contributions", () => {
     mocks.listAgentIds.mockReturnValue(["default"]);
     mocks.listAgentEntries.mockReset();
     mocks.listAgentEntries.mockReturnValue([{ id: "default" }]);
+    mocks.tryResolveLegacyCompatibilityAgentId.mockReset();
+    mocks.tryResolveLegacyCompatibilityAgentId.mockReturnValue(undefined);
     mocks.resolveDefaultAgentId.mockReset();
     mocks.resolveDefaultAgentId.mockReturnValue("default");
     mocks.resolveAgentContextLimits.mockReset();
@@ -860,6 +866,44 @@ describe("doctor health contributions", () => {
       "doctor:test-failure run failed: media migration required",
       "Doctor warnings",
     );
+  });
+
+  it("uses retained migration ownership for plugin metadata health scopes", async () => {
+    const run = vi.fn(async () => undefined);
+    const runWithPluginMetadataSnapshot = vi.fn(
+      async (
+        params: { config: OpenClawConfig; workspaceDir?: string },
+        scopedRun: () => Promise<void>,
+      ) => {
+        expect(params.workspaceDir).toBe("/tmp/openclaw-workspace");
+        await scopedRun();
+      },
+    );
+    mocks.tryResolveLegacyCompatibilityAgentId.mockReturnValue("main");
+    mocks.resolveDefaultAgentId.mockImplementation(() => {
+      throw new Error("raw default resolver must not run");
+    });
+    const cfg = { agents: { entries: { main: {}, ops: {} } } } as OpenClawConfig;
+    const ctx = {
+      cfg,
+      cfgForPersistence: cfg,
+      configResult: { cfg },
+      configPath: "/tmp/fake-openclaw.json",
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(true),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: {},
+      env: {},
+      runWithPluginMetadataSnapshot,
+    } as DoctorContributionRunContext;
+
+    await runDoctorHealthContributionList(ctx, [
+      createDoctorHealthContribution({ id: "doctor:test-owner", label: "Test owner", run }),
+    ]);
+
+    expect(run).toHaveBeenCalledOnce();
+    expect(mocks.resolveAgentWorkspaceDir).toHaveBeenCalledWith(cfg, "main", {});
+    expect(runWithPluginMetadataSnapshot).toHaveBeenCalledOnce();
   });
 
   it("keeps legacy plugin manifest lint opt-in for structured findings", async () => {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -12,7 +12,10 @@ import type {
   DoctorHealthFlowContext,
 } from "./doctor-health-contribution-types.js";
 import { resolveDoctorMode } from "./doctor-health-contribution-utils.js";
-import { createDoctorHealthContribution } from "./doctor-health-contribution.js";
+import {
+  createDoctorHealthContribution,
+  resolveDoctorHealthWorkspaceDir,
+} from "./doctor-health-contribution.js";
 import { resolveFinalDoctorHealthContributions } from "./doctor-health-contributions-final.js";
 import { resolveInitialDoctorHealthContributions } from "./doctor-health-contributions-initial.js";
 import { normalizeHealthCheck } from "./health-check-adapter.js";
@@ -438,13 +441,7 @@ async function runDoctorHealthContributionList(
         await contribution.run(ctx);
         continue;
       }
-      const { resolveAgentWorkspaceDir, resolveDefaultAgentId } =
-        await import("../agents/agent-scope.js");
-      const workspaceDir = resolveAgentWorkspaceDir(
-        ctx.cfg,
-        resolveDefaultAgentId(ctx.cfg),
-        ctx.env ?? process.env,
-      );
+      const workspaceDir = await resolveDoctorHealthWorkspaceDir(ctx);
       await runWithPluginMetadataSnapshot({ config: ctx.cfg, workspaceDir }, () =>
         contribution.run(ctx),
       );

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -277,9 +277,10 @@ function tryResolveDoctorStateMigrationAgentId(cfg: OpenClawConfig): string | un
 }
 
 function tryResolveDoctorSessionMigrationAgentId(cfg: OpenClawConfig): string | undefined {
+  const hasExplicitSessionStoreOwner = Boolean(cfg.agents?.defaults?.sessionStore?.agentId?.trim());
   return (
     tryResolveDoctorStateMigrationAgentId(cfg) ??
-    (!isPerAgentSessionStoreConfig(cfg.session?.store)
+    (hasExplicitSessionStoreOwner || !isPerAgentSessionStoreConfig(cfg.session?.store)
       ? resolveSessionStoreCompatibilityAgentId(cfg)
       : undefined)
   );

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -1253,6 +1253,42 @@ describe("state migrations", () => {
     await expectMissingPath(path.join(stateDir, "credentials", "chatapp-allowFrom.json"));
   });
 
+  it("migrates the legacy session store for an explicit fixed-store owner", async () => {
+    const root = await createTempDir();
+    const stateDir = path.join(root, ".openclaw");
+    const env = createEnv(stateDir);
+    const legacyStorePath = path.join(stateDir, "sessions", "sessions.json");
+    await fs.mkdir(path.dirname(legacyStorePath), { recursive: true });
+    await fs.writeFile(
+      legacyStorePath,
+      JSON.stringify({
+        "agent:main:main": { sessionId: "legacy-main", updatedAt: 20 },
+      }),
+      "utf8",
+    );
+    const cfg = {
+      agents: {
+        ownership: "explicit",
+        defaults: { sessionStore: { agentId: "main" } },
+        entries: { main: {}, ops: {} },
+      },
+    } satisfies OpenClawConfig;
+
+    const detected = await detectLegacyStateMigrations({ cfg, env, homedir: () => root });
+    expect(detected.targetAgentId).toBe("main");
+    expect(detected.sessions.hasLegacy).toBe(true);
+
+    await runLegacyStateMigrations({ detected, config: cfg, now: () => 1234 });
+
+    const targetStorePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+    const store = JSON.parse(await fs.readFile(targetStorePath, "utf8")) as Record<
+      string,
+      { sessionId: string }
+    >;
+    expect(store["agent:main:main"]?.sessionId).toBe("legacy-main");
+    await expectMissingPath(legacyStorePath);
+  });
+
   it("canonicalizes parsed owners before removing the legacy store", async () => {
     const root = await createTempDir();
     const stateDir = path.join(root, ".openclaw");

--- a/src/plugins/install-persistence.test.ts
+++ b/src/plugins/install-persistence.test.ts
@@ -1,4 +1,3 @@
-// Plugin install persistence tests cover saving installed plugin records after install.
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -16,6 +15,7 @@ import {
   resetPluginsCliTestState,
   pluginsCliRuntimeLogs,
   setInstalledPluginIndexInstallRecords,
+  setRecoveredPluginInstallRecords,
   configWriteMock,
   writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock,
   applyPluginUninstallDirectoryRemovalMock,
@@ -105,12 +105,18 @@ describe("persistPluginInstall", () => {
         },
       },
     } as OpenClawConfig;
+    const install = {
+      source: "npm" as const,
+      spec: "alpha@1.0.0",
+      installPath: "/tmp/alpha",
+    };
     enablePluginInConfigMock.mockImplementation((...args: unknown[]) => {
       const [cfg, pluginId] = args as [OpenClawConfig, string];
       expect(pluginId).toBe("alpha");
       expect(cfg.plugins?.allow).toEqual(["memory-core", "alpha"]);
       return { config: enabledConfig, enabled: true };
     });
+    setRecoveredPluginInstallRecords({ alpha: install });
 
     const next = await persistPluginInstall({
       snapshot: {
@@ -125,11 +131,7 @@ describe("persistPluginInstall", () => {
         },
       },
       pluginId: "alpha",
-      install: {
-        source: "npm",
-        spec: "alpha@1.0.0",
-        installPath: "/tmp/alpha",
-      },
+      install,
     });
 
     expect(next).toEqual(enabledConfig);

--- a/src/plugins/install-persistence.ts
+++ b/src/plugins/install-persistence.ts
@@ -26,6 +26,7 @@ import { commitPluginInstallRecordsWithConfig } from "./install-record-commit.js
 import type { PluginInstallLogger } from "./install-types.js";
 import {
   loadInstalledPluginIndexInstallRecords,
+  readPersistedInstalledPluginIndexInstallRecords,
   recordPluginInstallInRecords,
   withoutPluginInstallRecords,
 } from "./installed-plugin-index-records.js";
@@ -494,12 +495,20 @@ export async function persistPluginInstall(params: {
     }
     runtime.log(theme.warn(message));
   };
-  const installRecords = await tracePluginLifecyclePhaseAsync(
+  const { installRecords, persistedInstallRecords } = await tracePluginLifecyclePhaseAsync(
     "install records load",
-    () => loadInstalledPluginIndexInstallRecords(),
+    async () => {
+      const [records, persisted] = await Promise.all([
+        loadInstalledPluginIndexInstallRecords(),
+        readPersistedInstalledPluginIndexInstallRecords(),
+      ]);
+      return { installRecords: records, persistedInstallRecords: persisted };
+    },
     { command: "install" },
   );
-  const previousInstall = installRecords[params.pluginId];
+  // Managed npm recovery sees the just-installed package before its first ledger commit.
+  // Only durable prior ownership preserves an operator's existing allow/deny policy.
+  const previousInstall = persistedInstallRecords?.[params.pluginId];
   const replacedInstallRemoval = resolveReplacedManagedInstallRemoval({
     pluginId: params.pluginId,
     previousInstall,

--- a/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
@@ -483,8 +483,19 @@ describe("package-openclaw-for-docker", () => {
       2,
     )}\n`;
     const installedAiPath = path.join(sourceDir, "node_modules", "@openclaw", "ai");
+    const normalizationCoreWorkspace = path.join(sourceDir, "packages", "normalization-core");
+    const aiPackNormalizationCore = path.join(
+      sourceDir,
+      "packages",
+      "ai",
+      "node_modules",
+      "@openclaw",
+      "normalization-core",
+    );
     fs.mkdirSync(path.join(sourceDir, "packages", "ai"), { recursive: true });
     fs.writeFileSync(path.join(sourceDir, "packages", "ai", "package.json"), "{}\n");
+    fs.mkdirSync(normalizationCoreWorkspace, { recursive: true });
+    fs.writeFileSync(path.join(normalizationCoreWorkspace, "package.json"), "{}\n");
     fs.mkdirSync(installedAiPath, { recursive: true });
     fs.writeFileSync(path.join(installedAiPath, "original-marker"), "workspace package");
     fs.writeFileSync(packageJsonPath, originalPackageJson);
@@ -494,6 +505,9 @@ describe("package-openclaw-for-docker", () => {
         sourceDir,
         outputDir,
         async (command: string, args: string[], cwd: string) => {
+          expect(fs.realpathSync(aiPackNormalizationCore)).toBe(
+            fs.realpathSync(normalizationCoreWorkspace),
+          );
           expect({ args, command, cwd }).toEqual({
             args: ["--dir", "packages/ai", "pack", "--silent", "--pack-destination", outputDir],
             command: "pnpm",
@@ -543,6 +557,7 @@ describe("package-openclaw-for-docker", () => {
         "workspace package",
       );
       expect(fs.existsSync(path.join(outputDir, "openclaw-ai-2026.6.17.tgz"))).toBe(false);
+      expect(fs.existsSync(aiPackNormalizationCore)).toBe(false);
     } finally {
       fs.rmSync(sourceDir, { recursive: true, force: true });
       fs.rmSync(outputDir, { recursive: true, force: true });

--- a/test/package-scripts.test.ts
+++ b/test/package-scripts.test.ts
@@ -140,6 +140,12 @@ describe("package scripts", () => {
     );
   });
 
+  it("prepares unpublished plugin companions for the upgrade survivor", () => {
+    expect(readPackageJson().scripts["test:docker:upgrade-survivor"]).toBe(
+      "node --import tsx scripts/run-with-env.mts OPENCLAW_DOCKER_ALL_LANES=upgrade-survivor -- node scripts/test-docker-all.mjs",
+    );
+  });
+
   it("runs browser extension bootstrap E2E against real Chromium", () => {
     expect(readPackageJson().scripts["test:e2e:browser-extension"]).toBe(
       "node --import tsx scripts/run-with-env.mts PLAYWRIGHT_BROWSERS_PATH=.artifacts/playwright-browsers -- node --import tsx scripts/ensure-playwright-chromium.mts --require-playwright-chromium && node --import tsx scripts/run-with-env.mts PLAYWRIGHT_BROWSERS_PATH=.artifacts/playwright-browsers OPENCLAW_BROWSER_EXTENSION_E2E=1 OPENCLAW_E2E_WORKERS=1 -- node scripts/run-vitest.mjs extensions/browser/chrome-extension/bootstrap.chromium.test.ts",

--- a/test/scripts/docker-all-scheduler.test.ts
+++ b/test/scripts/docker-all-scheduler.test.ts
@@ -15,6 +15,7 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import { DEFAULT_RESOURCE_LIMITS } from "../../scripts/lib/docker-e2e-plan.mts";
@@ -514,7 +515,10 @@ describe("scripts/test-docker-all scheduler", () => {
     expect(captured.OPENCLAW_DOCKER_E2E_SELECTED_SHA).toBe(fixture.sourceSha);
     expect(captured.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION).toBe(fixture.version);
     expect(captured.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256).toMatch(/^[0-9a-f]{64}$/u);
-    const registryDir = captured.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR;
+    const registryDir = expectDefined(
+      captured.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR,
+      "captured prepublish plugin registry directory",
+    );
     expect(path.isAbsolute(registryDir)).toBe(true);
     const manifest = JSON.parse(
       readFileSync(path.join(registryDir, "prepublish-plugin-registry.json"), "utf8"),

--- a/test/scripts/docker-all-scheduler.test.ts
+++ b/test/scripts/docker-all-scheduler.test.ts
@@ -221,6 +221,79 @@ function runCandidatePrep(fixture: ReturnType<typeof candidateFixture>) {
   return { manifestPath, result };
 }
 
+function addPrepublishPluginSchedulerFixture(fixture: ReturnType<typeof candidateFixture>) {
+  const packageNames = ["@openclaw/codex", "@openclaw/discord", "@openclaw/whatsapp"];
+  for (const packageName of packageNames) {
+    const packageDir = path.join(fixture.root, "extensions", packageName.split("/")[1]!);
+    mkdirSync(packageDir, { recursive: true });
+    writeFileSync(
+      path.join(packageDir, "package.json"),
+      JSON.stringify({
+        name: packageName,
+        version: fixture.version,
+        openclaw: { release: { publishToNpm: true } },
+      }),
+    );
+  }
+
+  const scriptsLibDir = path.join(fixture.root, "scripts", "lib");
+  mkdirSync(scriptsLibDir, { recursive: true });
+  writeFileSync(path.join(scriptsLibDir, "plugin-npm-runtime-build.mjs"), "process.exit(0);\n");
+  writeFileSync(
+    path.join(scriptsLibDir, "plugin-npm-package-manifest.mjs"),
+    `import { spawnSync } from "node:child_process";
+import path from "node:path";
+const runIndex = process.argv.indexOf("--run");
+const separator = process.argv.indexOf("--");
+const packageDir = process.argv[runIndex + 1];
+const command = process.argv[separator + 1];
+const args = process.argv.slice(separator + 2);
+const result = spawnSync(command, args, {
+  cwd: path.resolve(process.cwd(), packageDir),
+  stdio: "inherit",
+});
+process.exit(result.status ?? 1);
+`,
+  );
+
+  const survivorScript = path.join(fixture.root, "scripts", "e2e", "upgrade-survivor-docker.sh");
+  mkdirSync(path.dirname(survivorScript), { recursive: true });
+  writeFileSync(
+    survivorScript,
+    `#!/usr/bin/env bash
+set -euo pipefail
+node - <<'NODE'
+const fs = require("node:fs");
+const keys = [
+  "OPENCLAW_DOCKER_E2E_SELECTED_SHA",
+  "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR",
+  "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION",
+  "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256",
+];
+fs.writeFileSync(
+  process.env.OPENCLAW_TEST_ENV_CAPTURE,
+  JSON.stringify(Object.fromEntries(keys.map((key) => [key, process.env[key]]))),
+);
+NODE
+`,
+  );
+  chmodSync(survivorScript, 0o755);
+
+  execFileSync("git", ["add", "."], { cwd: fixture.root });
+  execFileSync(
+    "git",
+    ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-qm", "companions"],
+    { cwd: fixture.root },
+  );
+  return {
+    ...fixture,
+    sourceSha: execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: fixture.root,
+      encoding: "utf8",
+    }).trim(),
+  };
+}
+
 function addRegistry(
   fixture: ReturnType<typeof candidateFixture>,
   packageNames = ["@openclaw/discord", "@openclaw/feishu"],
@@ -403,6 +476,89 @@ describe("scripts/test-docker-all scheduler", () => {
     const result = runCandidatePrep(fixture).result;
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("working-tree changes");
+  });
+
+  posixIt("prepares required plugin companions for normal current-tree execution", () => {
+    const fixture = addPrepublishPluginSchedulerFixture(candidateFixture());
+    const capturePath = path.join(fixture.root, "lane-env.json");
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    for (const key of [
+      "OPENCLAW_DOCKER_E2E_SELECTED_SHA",
+      "OPENCLAW_CURRENT_PACKAGE_TGZ",
+      "OPENCLAW_CURRENT_PACKAGE_VERSION",
+      "OPENCLAW_CURRENT_PACKAGE_SHA256",
+      "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR",
+      "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION",
+      "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256",
+    ]) {
+      delete env[key];
+    }
+    Object.assign(env, {
+      OPENCLAW_DOCKER_ALL_BUILD: "0",
+      OPENCLAW_DOCKER_ALL_LANES: "upgrade-survivor",
+      OPENCLAW_DOCKER_ALL_LOG_DIR: path.join(fixture.root, "logs"),
+      OPENCLAW_DOCKER_ALL_PREFLIGHT: "0",
+      OPENCLAW_DOCKER_ALL_TIMINGS: "0",
+      OPENCLAW_DOCKER_E2E_REPO_ROOT: fixture.root,
+      OPENCLAW_TEST_ENV_CAPTURE: capturePath,
+    });
+
+    const result = spawnSync(process.execPath, ["scripts/test-docker-all.mjs"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    const captured = JSON.parse(readFileSync(capturePath, "utf8")) as Record<string, string>;
+    expect(captured.OPENCLAW_DOCKER_E2E_SELECTED_SHA).toBe(fixture.sourceSha);
+    expect(captured.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION).toBe(fixture.version);
+    expect(captured.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256).toMatch(/^[0-9a-f]{64}$/u);
+    const registryDir = captured.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR;
+    expect(path.isAbsolute(registryDir)).toBe(true);
+    const manifest = JSON.parse(
+      readFileSync(path.join(registryDir, "prepublish-plugin-registry.json"), "utf8"),
+    ) as { packages: Array<{ name: string }> };
+    expect(manifest.packages.map((entry) => entry.name)).toEqual([
+      "@openclaw/codex",
+      "@openclaw/discord",
+      "@openclaw/whatsapp",
+    ]);
+  });
+
+  posixIt("rejects a supplied package without its required plugin registry", () => {
+    const fixture = candidateFixture();
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    for (const key of [
+      "OPENCLAW_DOCKER_E2E_SELECTED_SHA",
+      "OPENCLAW_CURRENT_PACKAGE_VERSION",
+      "OPENCLAW_CURRENT_PACKAGE_SHA256",
+      "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR",
+      "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION",
+      "OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256",
+    ]) {
+      delete env[key];
+    }
+    Object.assign(env, {
+      OPENCLAW_CURRENT_PACKAGE_TGZ: fixture.packagePath,
+      OPENCLAW_DOCKER_ALL_BUILD: "0",
+      OPENCLAW_DOCKER_ALL_LANES: "upgrade-survivor",
+      OPENCLAW_DOCKER_ALL_LOG_DIR: path.join(fixture.root, "logs"),
+      OPENCLAW_DOCKER_ALL_PREFLIGHT: "0",
+      OPENCLAW_DOCKER_ALL_TIMINGS: "0",
+      OPENCLAW_DOCKER_E2E_REPO_ROOT: fixture.root,
+    });
+
+    const result = spawnSync(process.execPath, ["scripts/test-docker-all.mjs"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "requires a prepublish plugin registry tuple for the supplied package",
+    );
   });
 
   it.each([

--- a/test/scripts/fixtures-workspace.test.ts
+++ b/test/scripts/fixtures-workspace.test.ts
@@ -21,6 +21,17 @@ function runAgentsDeleteAssert(root: string, outputPath: string, env: Record<str
   });
 }
 
+function runAgentsDeleteConfig(stateDir: string, workspace: string) {
+  return spawnSync(process.execPath, [FIXTURE_SCRIPT, "agents-delete-config"], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      OPENCLAW_STATE_DIR: stateDir,
+      SHARED_WORKSPACE: workspace,
+    },
+  });
+}
+
 function runOpenWebUiWorkspace(workspaceDir: string) {
   return spawnSync(process.execPath, [FIXTURE_SCRIPT, "openwebui-workspace"], {
     encoding: "utf8",
@@ -32,6 +43,19 @@ function runOpenWebUiWorkspace(workspaceDir: string) {
 }
 
 describe("workspace fixture assertions", () => {
+  it("writes an explicit multi-agent delete fixture", () => {
+    const root = tempDirs.make("openclaw-fixture-workspace-");
+    const stateDir = path.join(root, "state");
+    const workspace = path.join(root, "workspace");
+
+    const result = runAgentsDeleteConfig(stateDir, workspace);
+
+    expect(result.status, result.stderr).toBe(0);
+    const config = JSON.parse(readFileSync(path.join(stateDir, "openclaw.json"), "utf8"));
+    expect(config.agents.ownership).toBe("explicit");
+    expect(Object.keys(config.agents.entries)).toEqual(["main", "ops"]);
+  });
+
   it("prepares Open WebUI without retired workspace setup state", () => {
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-fixture-workspace-"));
     const workspaceDir = path.join(root, "workspace");

--- a/test/scripts/openclaw-test-state.test.ts
+++ b/test/scripts/openclaw-test-state.test.ts
@@ -234,6 +234,7 @@ describe("scripts/lib/openclaw-test-state", () => {
         },
       });
       expect(payload.config.agents.ownership).toBe("explicit");
+      expect(payload.config.agents.defaults.sessionStore).toEqual({ agentId: "main" });
       expect(Object.keys(payload.config.agents.entries)).toEqual(["main", "ops"]);
       expect(payload.config.agents).not.toHaveProperty("list");
       for (const agent of Object.values(payload.config.agents.entries)) {
@@ -285,6 +286,7 @@ describe("scripts/lib/openclaw-test-state", () => {
       ]);
       const upgradeConfig = JSON.parse(upgradeProbe.stdout);
       expect(upgradeConfig.agents.ownership).toBe("explicit");
+      expect(upgradeConfig.agents.defaults.sessionStore).toEqual({ agentId: "main" });
       expect(Object.keys(upgradeConfig.agents.entries)).toEqual(["main", "ops"]);
       expect(upgradeConfig.agents).not.toHaveProperty("list");
       for (const agent of Object.values(upgradeConfig.agents.entries)) {

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -91,14 +91,9 @@ function writeMigratedSessionState(stateDir: string): void {
 }
 
 function createMigratedSessionFileStore(
-  stateDir: string,
   options: { includePrompt?: boolean } = {},
 ): Record<string, Record<string, unknown>> {
-  const agentSessionsDir = join(stateDir, "agents", "main", "sessions");
-  const main: Record<string, unknown> = {
-    sessionId: "upgrade-main-session",
-    sessionFile: join(agentSessionsDir, "upgrade-main-session.jsonl"),
-  };
+  const main: Record<string, unknown> = { sessionId: "upgrade-main-session" };
   if (options.includePrompt !== false) {
     main.skillsSnapshot = {
       prompt: "legacy prompt survives as metadata",
@@ -106,14 +101,8 @@ function createMigratedSessionFileStore(
   }
   return {
     "agent:main:main": main,
-    "agent:main:+15551234567": {
-      sessionId: "upgrade-direct-session",
-      sessionFile: join(agentSessionsDir, "upgrade-direct-session.jsonl"),
-    },
-    "agent:main:slack:channel:cupgrade": {
-      sessionId: "upgrade-group-session",
-      sessionFile: join(agentSessionsDir, "upgrade-group-session.jsonl"),
-    },
+    "agent:main:+15551234567": { sessionId: "upgrade-direct-session" },
+    "agent:main:slack:channel:cupgrade": { sessionId: "upgrade-group-session" },
   };
 }
 
@@ -123,10 +112,7 @@ function writeMigratedSessionFiles(
 ): void {
   const agentSessionsDir = join(stateDir, "agents", "main", "sessions");
   mkdirSync(agentSessionsDir, { recursive: true });
-  writeJson(
-    join(agentSessionsDir, "sessions.json"),
-    createMigratedSessionFileStore(stateDir, options),
-  );
+  writeJson(join(agentSessionsDir, "sessions.json"), createMigratedSessionFileStore(options));
   for (const sessionId of [
     "upgrade-main-session",
     "upgrade-direct-session",
@@ -162,7 +148,7 @@ function writeLegacyCacheSessionState(
     const insert = db.prepare(
       "INSERT INTO cache_entries (scope, key, value_json) VALUES (?, ?, ?)",
     );
-    for (const [key, entry] of Object.entries(createMigratedSessionFileStore(stateDir, options))) {
+    for (const [key, entry] of Object.entries(createMigratedSessionFileStore(options))) {
       insert.run("session_entries", key, JSON.stringify(entry));
     }
   } finally {
@@ -187,7 +173,7 @@ function writeLegacySessionEntriesState(stateDir: string): void {
       INSERT INTO session_entries (session_key, session_id, entry_json, updated_at)
       VALUES (?, ?, ?, ?)
     `);
-    for (const [key, entry] of Object.entries(createMigratedSessionFileStore(stateDir))) {
+    for (const [key, entry] of Object.entries(createMigratedSessionFileStore())) {
       const sessionId = entry.sessionId;
       if (typeof sessionId !== "string") {
         throw new TypeError(`missing fixture session id for ${key}`);


### PR DESCRIPTION
## What Problem This Solves

The rebased `2026.8.1-beta.2` candidate exposed several release-blocking ownership and packaging failures: recovered npm installs were mistaken for durable prior installs, Doctor lost explicit upgrade-state ownership, the direct upgrade fixture could not migrate its legacy session store, artifact-only AI packing lacked its workspace dependency link, Telegram cache initialization ignored account routing, and normal Docker scheduling did not prepare unpublished external plugin companions.

## Why This Change Was Made

The repair keeps each invariant at its owner boundary:

- plugin policy preservation now consults only durable install-ledger records;
- Doctor retains and consumes explicit migration ownership before state migration and across finalized health checks;
- canonical session migration removes retired file locators while the survivor harness verifies transcript relocation separately;
- package preparation stages only the workspace link needed for `@openclaw/ai` packing and cleans it afterward;
- Telegram derives cache scope from the account's canonical route;
- Docker candidate preparation creates the prerelease plugin registry before core build mutations, injects the immutable tuple into normal lanes, and rejects caller-supplied core tarballs without matching companions.

This PR targets a dedicated signing base. It does not move or overwrite `release/2026.8.1`, which is currently owned by the independent r19 validation line.

## User Impact

Upgrades from shipped multi-agent state can migrate legacy sessions without leaving invalid ownership or retired metadata behind. First-time npm plugin installs still update restrictive allowlists even when recovery discovers the newly installed package. Release Docker validation can exercise unpublished Discord, WhatsApp, and Codex companions from exact candidate artifacts instead of falling through to public npm. Telegram message-cache scope remains aligned with the configured account owner.

## Evidence

- Focused Vitest proof: migration/fixture suites (86), Doctor state migrations and survivor assertions (116), scheduler/planner/package-script suites (153), plugin install persistence (18), plus the previously completed Telegram, Matrix, Doctor, package, and tooling suites.
- Regression proof failed before the migration-owner fix with `sessions.hasLegacy === false`, then passed after the owner-boundary repair.
- Frozen-base changed gate passed every production/static lane, SDK guard, lint/format guard, and five typecheck lanes; the final test-root narrowing repair then passed test-root typecheck and all 48 scheduler tests on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31678150238
- Fresh structured autoreview completed with no accepted/actionable findings; secret scan clean.
- Exact upgrade-survivor release workflow proof remains to run against the GitHub-signed immutable SHA created by this PR. Testbox patch sync cannot satisfy the registry packer's clean-HEAD provenance contract, so that evidence must come from the exact-ref release workflow.

No changelog, tag, publication, or release is included.
