### PR TITLE
fix(memory-wiki): guard malformed wiki_apply input

### DIFF
--- a/extensions/memory-wiki/src/apply.ts
+++ b/extensions/memory-wiki/src/apply.ts
@@ -6,7 +6,11 @@ import {
 } from "openclaw/plugin-sdk/memory-host-markdown";
 import { readFiniteNumberParam } from "openclaw/plugin-sdk/param-readers";
 import { FsSafeError, root as fsRoot } from "openclaw/plugin-sdk/security-runtime";
-import { normalizeStringEntries, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  asNonArrayRecord,
+  normalizeStringEntries,
+  uniqueStrings,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 import { compileMemoryWikiVault, type CompileMemoryWikiResult } from "./compile.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
 import {
@@ -100,7 +104,7 @@ function normalizeMemoryWikiMutationOp(
 }
 
 export function normalizeMemoryWikiMutationInput(rawParams: unknown): ApplyMemoryWikiMutation {
-  const params = rawParams as {
+  const params = asNonArrayRecord(rawParams) as {
     op: MemoryWikiMutationInputOp;
     title?: string;
     body?: string;

--- a/extensions/memory-wiki/src/tool.test.ts
+++ b/extensions/memory-wiki/src/tool.test.ts
@@ -65,6 +65,18 @@ describe("memory-wiki tools", () => {
     expect(evidenceProperties.confidence).toEqual({ type: "number", minimum: 0, maximum: 1 });
   });
 
+  it("rejects non-object wiki_apply arguments without throwing a TypeError", async () => {
+    const { config } = await harness.createVault({ initialize: true });
+    const tool = createWikiApplyTool(config);
+
+    await expect(tool.execute("malformed-null", null)).rejects.toThrow(
+      "wiki mutation requires lookup for update_metadata.",
+    );
+    await expect(tool.execute("malformed-undefined", undefined)).rejects.toThrow(
+      "wiki mutation requires lookup for update_metadata.",
+    );
+  });
+
   it("returns tool-safe relative report paths from wiki_lint", async () => {
     const { rootDir, config } = await harness.createVault({ initialize: true });
     await fs.mkdir(path.join(rootDir, "syntheses"), { recursive: true });


### PR DESCRIPTION
## Summary

- Guard `wiki_apply` against null, undefined, array, and primitive raw parameters by reusing the existing non-array record coercion helper.
- Keep the existing mutation validation behavior and add regression coverage for malformed inputs.

## What Problem This Solves

Malformed tool payloads can reach the production `wiki_apply` executor after schema erasure. Before this change, a null payload crashed while reading `op` instead of returning the plugin's normal validation error.

## Why This Change Was Made

The adjacent merged `wiki_get` hardening uses `asNonArrayRecord` at the same plugin boundary. Reusing that helper is the smallest policy-neutral fix and preserves the existing `lookup` validation path for non-object inputs.

## User Impact

Malformed `wiki_apply` calls now fail with a stable tool validation error. Valid synthesis and metadata mutations retain their existing behavior and storage boundaries.

## Evidence

- Real call chain proof exercised `createWikiApplyTool(...).execute` with an isolated configured vault, the production compiler, and the actual SQLite-backed `memory-wiki` plugin blob store. No mocks or copied helper logic were used.
- The same command, entrypoint, input, and dependency boundary ran on base `7eaf2fccf7ca9f2c22215324e3b5a04e19ac02e6` and head `905d5db03440f80d156b24ae8dbf4fa96c13f603`.
- Before-fix base: malformed `null` reached `TypeError: Cannot read properties of null (reading 'op')`; the valid `create_synthesis` path still wrote the page and refreshed `index.md`, with one real SQLite blob.
- After-fix head: malformed `null` returns `Error: wiki mutation requires lookup for update_metadata.`; the same valid path still writes the page and refreshes `index.md`, with one real SQLite blob.
- Unchanged control: the valid `create_synthesis` path remains successful on the exact head.
- Full proof source and raw transcript are retained in the local workflow evidence artifacts; the structured receipt hashes the comparable results.
- Canonical precedent: merged sibling `openclaw/openclaw#122549` hardens the adjacent `wiki_get` production boundary with the same `asNonArrayRecord` helper.
- Duplicate disposition: open `openclaw/openclaw#113746` overlaps these files for batch automation, but does not implement malformed-input validation; treat it as file-conflict/rebase risk, not a behavioral duplicate.

```text
base 7eaf2fccf7ca9f2c22215324e3b5a04e19ac02e6: malformed=TypeError; valid=changed:true,pageExists:true,indexUpdated:true,sqlite.blobCount:1
head 905d5db03440f80d156b24ae8dbf4fa96c13f603: malformed=validation error; valid=changed:true,pageExists:true,indexUpdated:true,sqlite.blobCount:1
negative-control exact head: valid create_synthesis remains successful
```

<details>
<summary>Live proof source</summary>

```ts
import fs from "node:fs/promises";
import path from "node:path";
import { DatabaseSync } from "node:sqlite";
import { pathToFileURL } from "node:url";

function flag(name: string): string {
  const index = process.argv.indexOf(name);
  const value = index >= 0 ? process.argv[index + 1] : undefined;
  if (!value) throw new Error(`Missing ${name}`);
  return value;
}

async function load<T>(repoRoot: string, relativePath: string): Promise<T> {
  return (await import(pathToFileURL(path.join(repoRoot, relativePath)).href)) as T;
}

async function main(): Promise<void> {
  const repoRoot = path.resolve(flag("--repo"));
  const runRoot = path.resolve(flag("--run-root"));
  const vaultRoot = path.join(runRoot, "vault");
  const stateRoot = path.join(runRoot, "state");
  process.env.OPENCLAW_STATE_DIR = stateRoot;
  const { createPluginStateKeyedStore, closePluginStateDatabase } = await load<any>(repoRoot, "src/plugin-state/plugin-state-store.ts");
  const { createPluginBlobStore } = await load<any>(repoRoot, "src/plugin-state/plugin-blob-store.ts");
  const { resolveMemoryWikiConfig } = await load<any>(repoRoot, "extensions/memory-wiki/src/config.ts");
  const { createMemoryWikiCompiledCacheStore, configureMemoryWikiCompiledCacheStore } = await load<any>(repoRoot, "extensions/memory-wiki/src/compiled-cache.ts");
  const { createMemoryWikiSourceSyncStateStore, configureMemoryWikiSourceSyncStateStore } = await load<any>(repoRoot, "extensions/memory-wiki/src/source-sync-state.ts");
  const { createMemoryWikiImportRunStateStore, configureMemoryWikiImportRunStateStore } = await load<any>(repoRoot, "extensions/memory-wiki/src/import-runs-state.ts");
  const { initializeMemoryWikiVault } = await load<any>(repoRoot, "extensions/memory-wiki/src/vault.ts");
  const { createWikiApplyTool } = await load<any>(repoRoot, "extensions/memory-wiki/src/tool.ts");
  const openKeyedStore = <T>(options: any) => createPluginStateKeyedStore<T>("memory-wiki", options);
  configureMemoryWikiSourceSyncStateStore(createMemoryWikiSourceSyncStateStore(openKeyedStore));
  configureMemoryWikiImportRunStateStore(createMemoryWikiImportRunStateStore(openKeyedStore));
  configureMemoryWikiCompiledCacheStore(createMemoryWikiCompiledCacheStore((options: any) => createPluginBlobStore("memory-wiki", options)));
  const config = resolveMemoryWikiConfig({ vaultMode: "isolated", vault: { scope: "global", path: vaultRoot, renderMode: "native" }, bridge: { enabled: false } });
  await fs.mkdir(runRoot, { recursive: true });
  await initializeMemoryWikiVault(config);
  const tool = createWikiApplyTool(config);
  let malformed: { ok: boolean; error?: string };
  try {
    await tool.execute("live-proof-malformed", null);
    malformed = { ok: true };
  } catch (error) {
    malformed = { ok: false, error: String(error) };
  }
  const validResult = await tool.execute("live-proof-valid", {
    op: "create_synthesis",
    title: "Live Proof Synthesis",
    body: "This page was created through the production wiki_apply tool boundary.",
    sourceIds: ["live-proof.source"],
  });
  const page = await fs.readFile(path.join(vaultRoot, "syntheses", "live-proof-synthesis.md"), "utf8");
  const index = await fs.readFile(path.join(vaultRoot, "index.md"), "utf8");
  const database = new DatabaseSync(path.join(stateRoot, "state", "openclaw.sqlite"));
  const stateCount = Number(database.prepare("SELECT COUNT(*) AS count FROM plugin_state_entries WHERE plugin_id = ?").get("memory-wiki").count);
  const blobCount = Number(database.prepare("SELECT COUNT(*) AS count FROM plugin_blob_entries WHERE plugin_id = ?").get("memory-wiki").count);
  database.close();
  closePluginStateDatabase();
  console.log(JSON.stringify({ malformed, valid: { operation: validResult.details?.operation, changed: validResult.details?.changed, pagePath: validResult.details?.pagePath }, filesystem: { pageExists: page.includes("Live Proof Synthesis"), productionBoundaryMarker: page.includes("production wiki_apply tool boundary"), indexUpdated: index.includes("Live Proof Synthesis") }, sqlite: { stateCount, blobCount } }, null, 2));
}

main().catch((error) => {
  console.error(error);
  process.exitCode = 1;
});
```

</details>

## Tests

- `node scripts/run-vitest.mjs run extensions/memory-wiki/src/apply.test.ts extensions/memory-wiki/src/tool.test.ts` (13 passed)

AI-assisted: built with Codex
