### PR TITLE
fix: prevent transcript media crashes on sparse attachments

### DIFF
--- a/src/media/media-facts.persisted.test.ts
+++ b/src/media/media-facts.persisted.test.ts
@@ -76,6 +76,21 @@ describe("canonical persisted media", () => {
     );
   });
 
+  it("normalizes serialized sparse nulls without losing attachment positions", () => {
+    const media = readPersistedMediaFacts({
+      __openclaw: { media: [null, canonicalFact] },
+    });
+
+    expect(media).toHaveLength(2);
+    expect(media?.[0]).toMatchObject({
+      path: undefined,
+      contentType: undefined,
+      kind: undefined,
+      transcribed: false,
+    });
+    expect(media?.[1]).toMatchObject({ ...canonicalFact, kind: "image" });
+  });
+
   it("copies transcription and workspace metadata while preserving adjacent metadata", () => {
     const result = canonicalizePersistedUserMessageMedia({
       MediaPaths: ["/media/a.ogg", "/media/b.png"],

--- a/src/media/media-facts.ts
+++ b/src/media/media-facts.ts
@@ -9,6 +9,7 @@ import {
   asFiniteNumberInRange,
   asPositiveSafeInteger as normalizePositiveInteger,
 } from "@openclaw/normalization-core/number-coercion";
+import { asNonArrayRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { PromptImageOrderEntry } from "./prompt-image-order.js";
 
@@ -69,16 +70,14 @@ export function readRuntimePromptMediaFacts(message: object): MediaFact[] | unde
 /** Reads the canonical persisted media envelope without consulting legacy top-level fields. */
 export function readPersistedMediaFacts(message: object): MediaFact[] | undefined {
   const media = readPersistedMediaFactInputs(message);
-  return media ? normalizeMediaFacts(media) : undefined;
+  return media?.map((entry, index) => normalizeMediaFact<MediaFactInput>(entry, index));
 }
 
-function readPersistedMediaFactInputs(message: object): MediaFactInput[] | undefined {
-  const metadata = (message as Record<string, unknown>)["__openclaw"];
-  const media =
-    metadata && typeof metadata === "object" && !Array.isArray(metadata)
-      ? (metadata as Record<string, unknown>).media
-      : undefined;
-  return Array.isArray(media) ? (media as MediaFactInput[]) : undefined;
+function readPersistedMediaFactInputs(message: object): Array<MediaFactInput | null> | undefined {
+  const metadata = asNonArrayRecord(asNonArrayRecord(message)["__openclaw"]);
+  return Array.isArray(metadata.media)
+    ? (metadata.media as Array<MediaFactInput | null>)
+    : undefined;
 }
 
 const LEGACY_MEDIA_CONTEXT_KEYS = [
@@ -122,7 +121,7 @@ export function hasMeaningfulRetiredMediaCarrier(message: object): boolean {
   if (resolveMediaFacts(retired as MediaFactSource).some(isMeaningfulMediaFact)) {
     return true;
   }
-  const canonical = normalizeMediaFacts(readPersistedMediaFactInputs(message));
+  const canonical = readPersistedMediaFacts(message) ?? [];
   if (canonical.length === 0) {
     return false;
   }
@@ -199,7 +198,10 @@ export function canonicalizePersistedUserMessageMedia<T extends object>(
   const topLevelMedia = Array.isArray(record.media)
     ? (record.media as readonly MediaFactInput[])
     : undefined;
-  const source: MediaFactSource = { ...record, media: canonical ?? topLevelMedia };
+  const source: MediaFactSource = {
+    ...record,
+    media: (canonical ?? topLevelMedia) as readonly MediaFactInput[] | undefined,
+  };
   const hasAmbiguousLegacyAlignment = hasAmbiguousSparseLegacyMediaAlignment(source);
   if (hadLegacy && hasAmbiguousLegacyAlignment) {
     throw new Error("legacy media arrays have ambiguous sparse positional alignment");
@@ -248,11 +250,7 @@ export function canonicalizePersistedUserMessageMedia<T extends object>(
   for (const key of PERSISTED_LEGACY_MEDIA_KEYS) {
     delete next[key];
   }
-  const metadata = record["__openclaw"];
-  const openclaw =
-    metadata && typeof metadata === "object" && !Array.isArray(metadata)
-      ? { ...(metadata as Record<string, unknown>) }
-      : {};
+  const openclaw = { ...asNonArrayRecord(record["__openclaw"]) };
   if (media.length > 0 || canonical !== undefined || topLevelMedia !== undefined) {
     openclaw.media = media;
   }
@@ -362,35 +360,37 @@ type MediaFactSource = MediaFactLegacyProjection & {
 };
 
 function normalizeMediaFact<TInput extends MediaFactInput>(
-  media: TInput,
+  media: TInput | null,
   index: number,
   defaults: MediaFactDefaults<TInput> = {},
 ): MediaFact {
-  const workspaceDir = normalizeOptionalString(media.workspaceDir) ?? defaults.workspaceDir;
-  const contentType = normalizeOptionalString(media.contentType);
-  const durationMs = normalizePositiveInteger(media.durationMs);
-  const width = normalizePositiveInteger(media.width);
-  const height = normalizePositiveInteger(media.height);
-  const normalized: MediaFact = {
-    path: normalizeOptionalString(media.path),
-    url: normalizeOptionalString(media.url),
+  // Sparse arrays serialize missing attachment positions as null; persisted
+  // slots must remain empty facts instead of crashing transcript hydration.
+  const input = asNonArrayRecord(media) as TInput;
+  const workspaceDir = normalizeOptionalString(input.workspaceDir) ?? defaults.workspaceDir;
+  const contentType = normalizeOptionalString(input.contentType);
+  const durationMs = normalizePositiveInteger(input.durationMs);
+  const width = normalizePositiveInteger(input.width);
+  const height = normalizePositiveInteger(input.height);
+  return {
+    path: normalizeOptionalString(input.path),
+    url: normalizeOptionalString(input.url),
     contentType,
     kind:
-      media.kind ??
+      input.kind ??
       defaults.kind ??
       (isGenericBinaryMediaContentType(contentType) ? undefined : kindFromMime(contentType)),
-    fileName: normalizeOptionalString(media.fileName),
-    sizeBytes: normalizeNonNegativeNumber(media.sizeBytes),
+    fileName: normalizeOptionalString(input.fileName),
+    sizeBytes: normalizeNonNegativeNumber(input.sizeBytes),
     ...(durationMs ? { durationMs } : {}),
     ...(width ? { width } : {}),
     ...(height ? { height } : {}),
-    transcribed: media.transcribed === true || defaults.transcribed?.(media, index) === true,
-    messageId: normalizeOptionalString(media.messageId) ?? defaults.messageId,
+    transcribed: input.transcribed === true || defaults.transcribed?.(input, index) === true,
+    messageId: normalizeOptionalString(input.messageId) ?? defaults.messageId,
     ...(workspaceDir ? { workspaceDir } : {}),
-    ...(media.staged === true ? { staged: true } : {}),
-    ...(media.hydrationSuppressed === true ? { hydrationSuppressed: true } : {}),
+    ...(input.staged === true ? { staged: true } : {}),
+    ...(input.hydrationSuppressed === true ? { hydrationSuppressed: true } : {}),
   };
-  return normalized;
 }
 
 /** True when every path-bearing canonical fact has explicit staging proof. */


### PR DESCRIPTION
## What Problem This Solves

Fixes a transcript media crash when canonical persisted attachment arrays contain a serialized sparse slot (`null`). JSON turns array holes into `null`, but normalization previously dereferenced every slot as an object.

## Why This Change Was Made

The canonical persisted boundary accepts nullable slots and the existing `normalizeMediaFact` owner converts any non-object slot to an aligned empty fact. The public `media-facts` facade and its signatures remain unchanged. SQLite remains the sole transcript store; there is no schema, migration, fallback reader, or sidecar change.

The lean repair keeps normalization in its existing owner. Production is net-zero by judgment (`src/media/media-facts.ts` +32/-32); the existing persisted-media suite adds 15 regression-test lines.

## User Impact

Stored chats with sparse attachment positions render and replay without crashing. Valid facts keep their existing normalization, MIME classification, defaults, staging markers, hydration-suppression markers, and array positions.

## Evidence

- Before: a direct current-main probe of `__openclaw.media: [null, {...}]` threw `TypeError: Cannot read properties of null (reading 'workspaceDir')`.
- After rebase: `src/media/media-facts.persisted.test.ts` passes 30/30 through the public reader, including `[null, validFact]` position preservation.
- Architecture: the exact rebased patch reports 0 Madge cycles; two-file formatting and `git diff --check` pass.
- Testbox: [run 31937071628](https://github.com/openclaw/openclaw/actions/runs/31937071628) passed the focused regression and Madge proof. Its later invocation of a legacy API-baseline helper failed because live `main` removed that script; no media check failed.
- Fresh rebased-head autoreview: clean, no accepted/actionable findings (`patch is correct`, 0.98).
- Storage compatibility: facts remain in canonical `__openclaw.media` JSON inside SQLite `transcript_events.event_json`. No DDL or schema-version change is present.
- Health recovery: prior red CI was mass capacity cancellation. This commit was rebased without media-path overlap onto live `origin/main`.
- Publication base/head: `b097aaab206171b7f7ad3722e69651a8fbfbeb16` / `d5a4937d2034c0ca8bdc9bb91b06a27e1d4778ce`.
- Agent transcript omitted: publication consent was not granted for this wave.

- [x] AI-assisted; I understand the change and validated the owner, callers, storage boundary, and affected behavior.
