### PR TITLE
fix(agents): unblock session turns after embedded runs stall

### DIFF
--- a/src/agents/embedded-agent-runner/run/lane-controller.attempt-controls.test.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.attempt-controls.test.ts
@@ -96,6 +96,39 @@ afterEach(async () => {
 
 describe("runtime-owned lane deadline handoff", () => {
   test.each([
+    { name: "bounded", kind: "bounded" },
+    { name: "unlimited", kind: "unlimited" },
+  ] as const)("publishes $name deadlines to nested session and global leases", async ({ kind }) => {
+    const { controller, createAttemptControls } = await createRunController();
+    const entered = createDeferred();
+    const finished = createDeferred();
+    const run = controller.enqueueSession(() =>
+      controller.enqueueGlobal(async () => {
+        entered.resolve();
+        await finished.promise;
+        return { meta: { durationMs: 1 } };
+      }),
+    );
+    const observed = run.catch((error: unknown) => error);
+    cleanups.push(async () => {
+      finished.resolve();
+      await observed;
+    });
+    await entered.promise;
+
+    const controls = createAttemptControls();
+    controls.onAttemptDeadlineChanged(
+      kind === "bounded" ? { kind, deadlineAtMs: Date.now() + RUNTIME_TIMEOUT_MS } : { kind },
+    );
+    await vi.advanceTimersByTimeAsync(1_000 + EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS + 1);
+
+    expect(controller.abortSignal.aborted).toBe(false);
+    expect(getCommandLaneSnapshot(GLOBAL_LANE).activeCount).toBe(1);
+    finished.resolve();
+    await expect(observed).resolves.toMatchObject({ meta: { durationMs: 1 } });
+  });
+
+  test.each([
     { name: "seeded bounded", kind: "bounded", initialTimeoutMs: RUNTIME_TIMEOUT_MS },
     { name: "seeded unlimited", kind: "unlimited", initialTimeoutMs: MAX_TIMER_TIMEOUT_MS },
     { name: "runtime bounded", kind: "bounded", initialTimeoutMs: undefined },

--- a/src/agents/embedded-agent-runner/run/lane-controller.test.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.test.ts
@@ -1,0 +1,293 @@
+import { setTimeout as delay } from "node:timers/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { getAgentEventLifecycleGeneration } from "../../../infra/agent-events.js";
+import {
+  enqueueCommandInLane,
+  getCommandLaneSnapshot,
+  setCommandLaneConcurrency,
+} from "../../../process/command-queue.js";
+import { resetCommandQueueStateForTest } from "../../../process/command-queue.test-support.js";
+import type { CommandQueueEnqueueFn } from "../../../process/command-queue.types.js";
+import { createEmbeddedRunLaneController } from "./lane-controller.js";
+import type { RunEmbeddedAgentParams } from "./params.js";
+
+type LaneTestParams = RunEmbeddedAgentParams & { sessionFile: string };
+
+function createLaneController(params: {
+  sessionLane: string;
+  globalLane?: string;
+  runId: string;
+  enqueue?: CommandQueueEnqueueFn;
+}) {
+  let runParams: LaneTestParams = {
+    sessionId: params.runId,
+    sessionFile: `${params.runId}.jsonl`,
+    workspaceDir: "/tmp/openclaw-lane-controller-test",
+    prompt: "test",
+    timeoutMs: 1,
+    runId: params.runId,
+    trigger: "user",
+    ...(params.enqueue ? { enqueue: params.enqueue } : {}),
+  };
+  let lifecycleGeneration = getAgentEventLifecycleGeneration();
+
+  return createEmbeddedRunLaneController({
+    getLifecycleGeneration: () => lifecycleGeneration,
+    getParams: () => runParams,
+    globalLane: params.globalLane ?? "test:embedded-global",
+    initialQueuedLifecycleGeneration: lifecycleGeneration,
+    sessionLane: params.sessionLane,
+    setLifecycleGeneration: (generation) => {
+      lifecycleGeneration = generation;
+    },
+    setParams: (nextParams) => {
+      runParams = nextParams;
+    },
+  });
+}
+
+describe("embedded run session lane", () => {
+  afterEach(() => {
+    resetCommandQueueStateForTest();
+  });
+
+  it("passes the run deadline and lifecycle signals into injected session queues", async () => {
+    let observedOptions: Parameters<CommandQueueEnqueueFn>[1];
+    const enqueue: CommandQueueEnqueueFn = async (task, options) => {
+      observedOptions = options;
+      return await task();
+    };
+    const controller = createLaneController({
+      sessionLane: "test:injected-session-deadline",
+      runId: "injected-session-deadline",
+      enqueue,
+    });
+
+    await expect(controller.enqueueSession(async () => "finished")).resolves.toBe("finished");
+    expect(observedOptions).toMatchObject({
+      priority: "foreground",
+      taskTimeoutMs: 30_001,
+      taskTimeoutAbortGraceMs: 30_000,
+      taskTimeoutAbortSignal: controller.laneTaskAbortController.signal,
+      taskTimeoutReleaseSignal: controller.laneTaskReleaseController.signal,
+    });
+    expect(observedOptions?.taskTimeoutProgressAtMs?.()).toEqual(expect.any(Number));
+  });
+
+  it.each(["deadline", "release"] as const)(
+    "releases all queued session turns when the active turn reaches its %s",
+    async (termination) => {
+      const sessionLane = `test:session-stall-${termination}`;
+      setCommandLaneConcurrency(sessionLane, 1);
+      const stalledController = createLaneController({
+        sessionLane,
+        runId: `stalled-${termination}`,
+      });
+      const stalled = stalledController.enqueueSession(
+        async () => await new Promise<never>(() => {}),
+        { taskTimeoutMs: 25 },
+      );
+      const stalledFailure = expect(stalled).rejects.toMatchObject({
+        name: "CommandLaneTaskTimeoutError",
+      });
+      const successors = Array.from({ length: 10 }, (_, index) => {
+        const controller = createLaneController({
+          sessionLane,
+          runId: `successor-${termination}-${index}`,
+        });
+        return controller.enqueueSession(async () => index);
+      });
+
+      expect(getCommandLaneSnapshot(sessionLane)).toMatchObject({
+        activeCount: 1,
+        queuedCount: 10,
+      });
+
+      if (termination === "release") {
+        stalledController.laneTaskReleaseController.abort();
+      }
+
+      await stalledFailure;
+      await expect(Promise.all(successors)).resolves.toEqual(
+        Array.from({ length: 10 }, (_, index) => index),
+      );
+      expect(getCommandLaneSnapshot(sessionLane)).toMatchObject({
+        activeCount: 0,
+        queuedCount: 0,
+      });
+    },
+  );
+
+  it("keeps a session alive while its run waits for healthy global-lane admission", async () => {
+    const sessionLane = "test:session-global-admission";
+    const globalLane = "test:global-admission";
+    setCommandLaneConcurrency(globalLane, 1);
+
+    let releaseGlobalLane: () => void = () => {};
+    const globalLaneGate = new Promise<void>((resolve) => {
+      releaseGlobalLane = resolve;
+    });
+    const globalBlocker = enqueueCommandInLane(globalLane, async () => {
+      await globalLaneGate;
+    });
+    const controller = createLaneController({
+      sessionLane,
+      globalLane,
+      runId: "healthy-global-admission",
+    });
+    const run = controller.enqueueSession(
+      async () => await controller.enqueueGlobal(async () => ({ meta: { durationMs: 1 } })),
+      { taskTimeoutMs: 25 },
+    );
+
+    try {
+      await delay(100);
+      expect(getCommandLaneSnapshot(sessionLane)).toMatchObject({
+        activeCount: 1,
+        queuedCount: 0,
+      });
+      expect(getCommandLaneSnapshot(globalLane)).toMatchObject({
+        activeCount: 1,
+        queuedCount: 1,
+      });
+
+      releaseGlobalLane();
+      await globalBlocker;
+      await expect(run).resolves.toMatchObject({ meta: { durationMs: 1 } });
+      expect(getCommandLaneSnapshot(sessionLane)).toMatchObject({
+        activeCount: 0,
+        queuedCount: 0,
+      });
+    } finally {
+      releaseGlobalLane();
+    }
+  });
+
+  it("keeps the session lease alive until every concurrent global admission settles", async () => {
+    const sessionLane = "test:session-concurrent-global-admission";
+    const globalLane = "test:concurrent-global-admission";
+    setCommandLaneConcurrency(globalLane, 1);
+
+    let releaseInterveningGlobalTask: () => void = () => {};
+    const interveningGlobalGate = new Promise<void>((resolve) => {
+      releaseInterveningGlobalTask = resolve;
+    });
+    let markInterveningGlobalTaskStarted: () => void = () => {};
+    const interveningGlobalTaskStarted = new Promise<void>((resolve) => {
+      markInterveningGlobalTaskStarted = resolve;
+    });
+    const controller = createLaneController({
+      sessionLane,
+      globalLane,
+      runId: "healthy-concurrent-global-admission",
+    });
+    const run = controller.enqueueSession(
+      async () => {
+        const firstGlobalAdmission = controller.enqueueGlobal(async () => ({
+          meta: { durationMs: 1 },
+        }));
+        const interveningGlobalTask = enqueueCommandInLane(
+          globalLane,
+          async () => {
+            markInterveningGlobalTaskStarted();
+            await interveningGlobalGate;
+          },
+          { priority: "foreground" },
+        );
+        const secondGlobalAdmission = controller.enqueueGlobal(async () => ({
+          meta: { durationMs: 2 },
+        }));
+        return await Promise.all([
+          firstGlobalAdmission,
+          interveningGlobalTask,
+          secondGlobalAdmission,
+        ]);
+      },
+      { taskTimeoutMs: 25 },
+    );
+
+    try {
+      await interveningGlobalTaskStarted;
+      await delay(75);
+      expect(getCommandLaneSnapshot(sessionLane)).toMatchObject({
+        activeCount: 1,
+        queuedCount: 0,
+      });
+      expect(getCommandLaneSnapshot(globalLane)).toMatchObject({
+        activeCount: 1,
+        queuedCount: 1,
+      });
+
+      releaseInterveningGlobalTask();
+      await expect(run).resolves.toEqual([
+        { meta: { durationMs: 1 } },
+        undefined,
+        { meta: { durationMs: 2 } },
+      ]);
+      expect(getCommandLaneSnapshot(sessionLane)).toMatchObject({
+        activeCount: 0,
+        queuedCount: 0,
+      });
+    } finally {
+      releaseInterveningGlobalTask();
+    }
+  });
+
+  it("times out a stalled global task while another global admission keeps the session alive", async () => {
+    const sessionLane = "test:session-stalled-global-with-successor";
+    const globalLane = "test:stalled-global-with-successor";
+    setCommandLaneConcurrency(globalLane, 1);
+
+    let markStalledGlobalTaskStarted: () => void = () => {};
+    const stalledGlobalTaskStarted = new Promise<void>((resolve) => {
+      markStalledGlobalTaskStarted = resolve;
+    });
+    const controller = createLaneController({
+      sessionLane,
+      globalLane,
+      runId: "stalled-global-with-successor",
+    });
+    const run = controller.enqueueSession(
+      async () => {
+        const stalledGlobalAdmission = controller.enqueueGlobal(
+          async () => {
+            markStalledGlobalTaskStarted();
+            return await new Promise<never>(() => {});
+          },
+          { taskTimeoutMs: 25 },
+        );
+        const stalledGlobalFailure = expect(stalledGlobalAdmission).rejects.toMatchObject({
+          name: "CommandLaneTaskTimeoutError",
+        });
+        const successorGlobalAdmission = controller.enqueueGlobal(async () => ({
+          meta: { durationMs: 1 },
+        }));
+
+        await stalledGlobalFailure;
+        return await successorGlobalAdmission;
+      },
+      { taskTimeoutMs: 25 },
+    );
+    const completedRun = expect(run).resolves.toEqual({ meta: { durationMs: 1 } });
+
+    await stalledGlobalTaskStarted;
+    expect(getCommandLaneSnapshot(sessionLane)).toMatchObject({
+      activeCount: 1,
+      queuedCount: 0,
+    });
+    expect(getCommandLaneSnapshot(globalLane)).toMatchObject({
+      activeCount: 1,
+      queuedCount: 1,
+    });
+
+    await completedRun;
+    expect(getCommandLaneSnapshot(sessionLane)).toMatchObject({
+      activeCount: 0,
+      queuedCount: 0,
+    });
+    expect(getCommandLaneSnapshot(globalLane)).toMatchObject({
+      activeCount: 0,
+      queuedCount: 0,
+    });
+  });
+});

--- a/src/agents/embedded-agent-runner/run/lane-controller.test.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.test.ts
@@ -1,5 +1,6 @@
 import { setTimeout as delay } from "node:timers/promises";
 import { afterEach, describe, expect, it } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import { getAgentEventLifecycleGeneration } from "../../../infra/agent-events.js";
 import {
   enqueueCommandInLane,
@@ -46,6 +47,10 @@ function createLaneController(params: {
   });
 }
 
+function expectLaneCounts(lane: string, activeCount: number, queuedCount: number) {
+  expect(getCommandLaneSnapshot(lane)).toMatchObject({ activeCount, queuedCount });
+}
+
 describe("embedded run session lane", () => {
   afterEach(() => {
     resetCommandQueueStateForTest();
@@ -90,92 +95,31 @@ describe("embedded run session lane", () => {
       const stalledFailure = expect(stalled).rejects.toMatchObject({
         name: "CommandLaneTaskTimeoutError",
       });
-      const successors = Array.from({ length: 10 }, (_, index) => {
-        const controller = createLaneController({
-          sessionLane,
-          runId: `successor-${termination}-${index}`,
-        });
-        return controller.enqueueSession(async () => index);
+      const successorController = createLaneController({
+        sessionLane,
+        runId: `successor-${termination}`,
       });
+      const successor = successorController.enqueueSession(async () => "finished");
 
-      expect(getCommandLaneSnapshot(sessionLane)).toMatchObject({
-        activeCount: 1,
-        queuedCount: 10,
-      });
+      expectLaneCounts(sessionLane, 1, 1);
 
       if (termination === "release") {
         stalledController.laneTaskReleaseController.abort();
       }
 
       await stalledFailure;
-      await expect(Promise.all(successors)).resolves.toEqual(
-        Array.from({ length: 10 }, (_, index) => index),
-      );
-      expect(getCommandLaneSnapshot(sessionLane)).toMatchObject({
-        activeCount: 0,
-        queuedCount: 0,
-      });
+      await expect(successor).resolves.toBe("finished");
+      expectLaneCounts(sessionLane, 0, 0);
     },
   );
-
-  it("keeps a session alive while its run waits for healthy global-lane admission", async () => {
-    const sessionLane = "test:session-global-admission";
-    const globalLane = "test:global-admission";
-    setCommandLaneConcurrency(globalLane, 1);
-
-    let releaseGlobalLane: () => void = () => {};
-    const globalLaneGate = new Promise<void>((resolve) => {
-      releaseGlobalLane = resolve;
-    });
-    const globalBlocker = enqueueCommandInLane(globalLane, async () => {
-      await globalLaneGate;
-    });
-    const controller = createLaneController({
-      sessionLane,
-      globalLane,
-      runId: "healthy-global-admission",
-    });
-    const run = controller.enqueueSession(
-      async () => await controller.enqueueGlobal(async () => ({ meta: { durationMs: 1 } })),
-      { taskTimeoutMs: 25 },
-    );
-
-    try {
-      await delay(100);
-      expect(getCommandLaneSnapshot(sessionLane)).toMatchObject({
-        activeCount: 1,
-        queuedCount: 0,
-      });
-      expect(getCommandLaneSnapshot(globalLane)).toMatchObject({
-        activeCount: 1,
-        queuedCount: 1,
-      });
-
-      releaseGlobalLane();
-      await globalBlocker;
-      await expect(run).resolves.toMatchObject({ meta: { durationMs: 1 } });
-      expect(getCommandLaneSnapshot(sessionLane)).toMatchObject({
-        activeCount: 0,
-        queuedCount: 0,
-      });
-    } finally {
-      releaseGlobalLane();
-    }
-  });
 
   it("keeps the session lease alive until every concurrent global admission settles", async () => {
     const sessionLane = "test:session-concurrent-global-admission";
     const globalLane = "test:concurrent-global-admission";
     setCommandLaneConcurrency(globalLane, 1);
 
-    let releaseInterveningGlobalTask: () => void = () => {};
-    const interveningGlobalGate = new Promise<void>((resolve) => {
-      releaseInterveningGlobalTask = resolve;
-    });
-    let markInterveningGlobalTaskStarted: () => void = () => {};
-    const interveningGlobalTaskStarted = new Promise<void>((resolve) => {
-      markInterveningGlobalTaskStarted = resolve;
-    });
+    const interveningGlobalGate = createDeferred();
+    const interveningGlobalTaskStarted = createDeferred();
     const controller = createLaneController({
       sessionLane,
       globalLane,
@@ -189,8 +133,8 @@ describe("embedded run session lane", () => {
         const interveningGlobalTask = enqueueCommandInLane(
           globalLane,
           async () => {
-            markInterveningGlobalTaskStarted();
-            await interveningGlobalGate;
+            interveningGlobalTaskStarted.resolve();
+            await interveningGlobalGate.promise;
           },
           { priority: "foreground" },
         );
@@ -207,29 +151,20 @@ describe("embedded run session lane", () => {
     );
 
     try {
-      await interveningGlobalTaskStarted;
+      await interveningGlobalTaskStarted.promise;
       await delay(75);
-      expect(getCommandLaneSnapshot(sessionLane)).toMatchObject({
-        activeCount: 1,
-        queuedCount: 0,
-      });
-      expect(getCommandLaneSnapshot(globalLane)).toMatchObject({
-        activeCount: 1,
-        queuedCount: 1,
-      });
+      expectLaneCounts(sessionLane, 1, 0);
+      expectLaneCounts(globalLane, 1, 1);
 
-      releaseInterveningGlobalTask();
+      interveningGlobalGate.resolve();
       await expect(run).resolves.toEqual([
         { meta: { durationMs: 1 } },
         undefined,
         { meta: { durationMs: 2 } },
       ]);
-      expect(getCommandLaneSnapshot(sessionLane)).toMatchObject({
-        activeCount: 0,
-        queuedCount: 0,
-      });
+      expectLaneCounts(sessionLane, 0, 0);
     } finally {
-      releaseInterveningGlobalTask();
+      interveningGlobalGate.resolve();
     }
   });
 
@@ -238,10 +173,7 @@ describe("embedded run session lane", () => {
     const globalLane = "test:stalled-global-with-successor";
     setCommandLaneConcurrency(globalLane, 1);
 
-    let markStalledGlobalTaskStarted: () => void = () => {};
-    const stalledGlobalTaskStarted = new Promise<void>((resolve) => {
-      markStalledGlobalTaskStarted = resolve;
-    });
+    const stalledGlobalTaskStarted = createDeferred();
     const controller = createLaneController({
       sessionLane,
       globalLane,
@@ -251,7 +183,7 @@ describe("embedded run session lane", () => {
       async () => {
         const stalledGlobalAdmission = controller.enqueueGlobal(
           async () => {
-            markStalledGlobalTaskStarted();
+            stalledGlobalTaskStarted.resolve();
             return await new Promise<never>(() => {});
           },
           { taskTimeoutMs: 25 },
@@ -270,24 +202,12 @@ describe("embedded run session lane", () => {
     );
     const completedRun = expect(run).resolves.toEqual({ meta: { durationMs: 1 } });
 
-    await stalledGlobalTaskStarted;
-    expect(getCommandLaneSnapshot(sessionLane)).toMatchObject({
-      activeCount: 1,
-      queuedCount: 0,
-    });
-    expect(getCommandLaneSnapshot(globalLane)).toMatchObject({
-      activeCount: 1,
-      queuedCount: 1,
-    });
+    await stalledGlobalTaskStarted.promise;
+    expectLaneCounts(sessionLane, 1, 0);
+    expectLaneCounts(globalLane, 1, 1);
 
     await completedRun;
-    expect(getCommandLaneSnapshot(sessionLane)).toMatchObject({
-      activeCount: 0,
-      queuedCount: 0,
-    });
-    expect(getCommandLaneSnapshot(globalLane)).toMatchObject({
-      activeCount: 0,
-      queuedCount: 0,
-    });
+    expectLaneCounts(sessionLane, 0, 0);
+    expectLaneCounts(globalLane, 0, 0);
   });
 });

--- a/src/agents/embedded-agent-runner/run/lane-controller.test.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.test.ts
@@ -47,7 +47,14 @@ function createLaneController(params: {
   });
 }
 
-function expectLaneCounts(lane: string, activeCount: number, queuedCount: number) {
+async function expectLaneCounts(lane: string, activeCount: number, queuedCount: number) {
+  for (let turn = 0; turn < 20; turn += 1) {
+    const snapshot = getCommandLaneSnapshot(lane);
+    if (snapshot.activeCount === activeCount && snapshot.queuedCount === queuedCount) {
+      break;
+    }
+    await delay(0);
+  }
   expect(getCommandLaneSnapshot(lane)).toMatchObject({ activeCount, queuedCount });
 }
 
@@ -101,7 +108,7 @@ describe("embedded run session lane", () => {
       });
       const successor = successorController.enqueueSession(async () => "finished");
 
-      expectLaneCounts(sessionLane, 1, 1);
+      await expectLaneCounts(sessionLane, 1, 1);
 
       if (termination === "release") {
         stalledController.laneTaskReleaseController.abort();
@@ -109,7 +116,7 @@ describe("embedded run session lane", () => {
 
       await stalledFailure;
       await expect(successor).resolves.toBe("finished");
-      expectLaneCounts(sessionLane, 0, 0);
+      await expectLaneCounts(sessionLane, 0, 0);
     },
   );
 
@@ -153,8 +160,8 @@ describe("embedded run session lane", () => {
     try {
       await interveningGlobalTaskStarted.promise;
       await delay(75);
-      expectLaneCounts(sessionLane, 1, 0);
-      expectLaneCounts(globalLane, 1, 1);
+      await expectLaneCounts(sessionLane, 1, 0);
+      await expectLaneCounts(globalLane, 1, 1);
 
       interveningGlobalGate.resolve();
       await expect(run).resolves.toEqual([
@@ -162,7 +169,7 @@ describe("embedded run session lane", () => {
         undefined,
         { meta: { durationMs: 2 } },
       ]);
-      expectLaneCounts(sessionLane, 0, 0);
+      await expectLaneCounts(sessionLane, 0, 0);
     } finally {
       interveningGlobalGate.resolve();
     }
@@ -203,11 +210,11 @@ describe("embedded run session lane", () => {
     const completedRun = expect(run).resolves.toEqual({ meta: { durationMs: 1 } });
 
     await stalledGlobalTaskStarted.promise;
-    expectLaneCounts(sessionLane, 1, 0);
-    expectLaneCounts(globalLane, 1, 1);
+    await expectLaneCounts(sessionLane, 1, 0);
+    await expectLaneCounts(globalLane, 1, 1);
 
     await completedRun;
-    expectLaneCounts(sessionLane, 0, 0);
-    expectLaneCounts(globalLane, 0, 0);
+    await expectLaneCounts(sessionLane, 0, 0);
+    await expectLaneCounts(globalLane, 0, 0);
   });
 });

--- a/src/agents/embedded-agent-runner/run/lane-controller.test.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.test.ts
@@ -120,6 +120,44 @@ describe("embedded run session lane", () => {
     },
   );
 
+  it("prevents timed-out session work from resuming into global admission", async () => {
+    const sessionLane = "test:session-timeout-late-resumption";
+    const globalLane = "test:global-timeout-late-resumption";
+    const maintenanceGate = createDeferred();
+    const lateTaskSettled = createDeferred();
+    let enteredGlobalAdmission = false;
+    const controller = createLaneController({
+      sessionLane,
+      globalLane,
+      runId: "session-timeout-late-resumption",
+    });
+
+    const timedOut = controller.enqueueSession(
+      async () => {
+        try {
+          await maintenanceGate.promise;
+          controller.throwIfAborted();
+          return await controller.enqueueGlobal(async () => {
+            enteredGlobalAdmission = true;
+            return { meta: { durationMs: 1 } };
+          });
+        } finally {
+          lateTaskSettled.resolve();
+        }
+      },
+      { taskTimeoutMs: 25 },
+    );
+
+    await expect(timedOut).rejects.toMatchObject({ name: "CommandLaneTaskTimeoutError" });
+    expect(controller.abortSignal.aborted).toBe(true);
+
+    maintenanceGate.resolve();
+    await lateTaskSettled.promise;
+    expect(enteredGlobalAdmission).toBe(false);
+    await expectLaneCounts(sessionLane, 0, 0);
+    await expectLaneCounts(globalLane, 0, 0);
+  });
+
   it("keeps the session lease alive until every concurrent global admission settles", async () => {
     const sessionLane = "test:session-concurrent-global-admission";
     const globalLane = "test:concurrent-global-admission";

--- a/src/agents/embedded-agent-runner/run/lane-controller.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.ts
@@ -44,6 +44,7 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
   const laneTaskAbortController = new AbortController();
   const laneTaskReleaseController = new AbortController();
   let laneTaskProgressAtMs = Date.now();
+  let pendingGlobalLaneAdmissions = 0;
   let releaseQueuedRunContext: ReturnType<typeof retainQueuedAgentRunContext>;
   let queuedRunAbortSignal: AbortSignal | undefined;
 
@@ -75,11 +76,19 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     abortError.name = "AbortError";
     throw abortError;
   };
-  const withLaneTimeout = (opts?: CommandQueueEnqueueOptions) =>
+  const withLaneTimeout = (
+    opts?: CommandQueueEnqueueOptions,
+    allowPendingGlobalAdmissionHeartbeat = false,
+  ) =>
     withEmbeddedRunLaneTimeout(
       {
         ...opts,
-        taskTimeoutProgressAtMs: () => laneTaskProgressAtMs,
+        // Only the outer session lease may count queued global admission as
+        // progress; an admitted global task must still time out when it stalls.
+        taskTimeoutProgressAtMs: () =>
+          allowPendingGlobalAdmissionHeartbeat && pendingGlobalLaneAdmissions > 0
+            ? Date.now()
+            : laneTaskProgressAtMs,
         taskTimeoutAbortSignal: laneTaskAbortController.signal,
         taskTimeoutAbortGraceMs: EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS,
         taskTimeoutReleaseSignal: laneTaskReleaseController.signal,
@@ -120,11 +129,22 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     // Global-lane admission is healthy waiting, not run execution. Keep reply
     // staleness and stuck recovery fenced until this queue grants capacity.
     options.getParams().replyOperation?.markWaitingForGlobalLane();
+    pendingGlobalLaneAdmissions += 1;
+    let waitingForGlobalLaneAdmission = true;
+    const finishGlobalLaneAdmission = () => {
+      if (!waitingForGlobalLaneAdmission) {
+        return;
+      }
+      waitingForGlobalLaneAdmission = false;
+      pendingGlobalLaneAdmissions -= 1;
+    };
     const globalOpts: CommandQueueEnqueueOptions = {
       ...opts,
       priority: sessionQueuePriority,
     };
     const taskWithCurrentLifecycle = async () => {
+      finishGlobalLaneAdmission();
+      noteLaneTaskProgress();
       let params = options.getParams();
       params.onLaneWait?.({ waitMs: 0, queuedAhead: 0, waiting: false });
       params.replyOperation?.markGlobalLaneWaitEnded();
@@ -191,15 +211,22 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
       );
     };
     const params = options.getParams();
-    if (params.enqueue) {
-      return params.enqueue(taskWithCurrentLifecycle, withLaneTimeout(withRunLaneWait(globalOpts)));
+    try {
+      if (params.enqueue) {
+        return params
+          .enqueue(taskWithCurrentLifecycle, withLaneTimeout(withRunLaneWait(globalOpts)))
+          .finally(finishGlobalLaneAdmission);
+      }
+      noteLaneWaitIfBusy(options.globalLane);
+      return enqueueCommandInLane(
+        options.globalLane,
+        taskWithCurrentLifecycle,
+        withLaneTimeout(withRunLaneWait(globalOpts)),
+      ).finally(finishGlobalLaneAdmission);
+    } catch (error) {
+      finishGlobalLaneAdmission();
+      throw error;
     }
-    noteLaneWaitIfBusy(options.globalLane);
-    return enqueueCommandInLane(
-      options.globalLane,
-      taskWithCurrentLifecycle,
-      withLaneTimeout(withRunLaneWait(globalOpts)),
-    );
   };
   const enqueueSession = <T>(task: () => Promise<T>, opts?: CommandQueueEnqueueOptions) => {
     const sessionOpts: CommandQueueEnqueueOptions = { ...opts, priority: sessionQueuePriority };
@@ -224,13 +251,16 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     let queuedRun: Promise<T>;
     try {
       if (params.enqueue) {
-        queuedRun = params.enqueue(taskWithLaneAdmission, withRunLaneWait(sessionOpts));
+        queuedRun = params.enqueue(
+          taskWithLaneAdmission,
+          withLaneTimeout(withRunLaneWait(sessionOpts), true),
+        );
       } else {
         noteLaneWaitIfBusy(options.sessionLane);
         queuedRun = enqueueCommandInLane(
           options.sessionLane,
           taskWithLaneAdmission,
-          withRunLaneWait(sessionOpts),
+          withLaneTimeout(withRunLaneWait(sessionOpts), true),
         );
       }
     } catch (error) {

--- a/src/agents/embedded-agent-runner/run/lane-controller.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.ts
@@ -80,6 +80,7 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
         : deadline;
     notifyLaneTaskDeadline?.(laneTaskDeadline);
   };
+  let pendingGlobalLaneAdmissions = 0;
   let releaseQueuedRunContext: ReturnType<typeof retainQueuedAgentRunContext>;
   let queuedRunAbortSignal: AbortSignal | undefined;
   let releaseCapacityWait: (() => void) | undefined;
@@ -208,12 +209,20 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     abortError.name = "AbortError";
     throw abortError;
   };
-  const withLaneTimeout = (opts?: CommandQueueEnqueueOptions) =>
+  const withLaneTimeout = (
+    opts?: CommandQueueEnqueueOptions,
+    allowPendingGlobalAdmissionHeartbeat = false,
+  ) =>
     withEmbeddedRunLaneTimeout(
       {
         ...opts,
         abortSignal,
-        taskTimeoutProgressAtMs: () => laneTaskProgressAtMs,
+        // Only the outer session lease may count queued global admission as
+        // progress; an admitted global task must still time out when it stalls.
+        taskTimeoutProgressAtMs: () =>
+          allowPendingGlobalAdmissionHeartbeat && pendingGlobalLaneAdmissions > 0
+            ? Date.now()
+            : laneTaskProgressAtMs,
         taskTimeoutSubscribe: (onDeadline) => {
           notifyLaneTaskDeadline = onDeadline;
           onDeadline(laneTaskDeadline);
@@ -263,6 +272,15 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     // Global-lane admission is healthy waiting, not run execution. Keep reply
     // staleness and stuck recovery fenced until this queue grants capacity.
     options.getParams().replyOperation?.markWaitingForGlobalLane();
+    pendingGlobalLaneAdmissions += 1;
+    let waitingForGlobalLaneAdmission = true;
+    const finishGlobalLaneAdmission = () => {
+      if (!waitingForGlobalLaneAdmission) {
+        return;
+      }
+      waitingForGlobalLaneAdmission = false;
+      pendingGlobalLaneAdmissions -= 1;
+    };
     const globalOpts: CommandQueueEnqueueOptions = {
       ...opts,
       priority: isBackgroundWorkLane(options.globalLane)
@@ -272,6 +290,8 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     };
     const taskWithCurrentLifecycle = async () => {
       endCapacityWait();
+      finishGlobalLaneAdmission();
+      noteLaneTaskProgress();
       let params = options.getParams();
       params.replyOperation?.markGlobalLaneWaitEnded();
       throwIfAborted();
@@ -344,20 +364,25 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     };
     const params = options.getParams();
     let queuedRun: Promise<EmbeddedAgentRunResult>;
-    if (params.enqueue) {
-      queuedRun = params.enqueue(
-        taskWithCurrentLifecycle,
-        withLaneTimeout(withRunLaneWait(globalOpts)),
-      );
-    } else {
-      noteLaneWaitIfBusy(options.globalLane);
-      queuedRun = enqueueCommandInLane(
-        options.globalLane,
-        taskWithCurrentLifecycle,
-        withLaneTimeout(withRunLaneWait(globalOpts)),
-      );
+    try {
+      if (params.enqueue) {
+        queuedRun = params.enqueue(
+          taskWithCurrentLifecycle,
+          withLaneTimeout(withRunLaneWait(globalOpts)),
+        );
+      } else {
+        noteLaneWaitIfBusy(options.globalLane);
+        queuedRun = enqueueCommandInLane(
+          options.globalLane,
+          taskWithCurrentLifecycle,
+          withLaneTimeout(withRunLaneWait(globalOpts)),
+        );
+      }
+    } catch (error) {
+      finishGlobalLaneAdmission();
+      throw error;
     }
-    return queuedRun.catch((error: unknown) => {
+    return queuedRun.finally(finishGlobalLaneAdmission).catch((error: unknown) => {
       if (isCommandLaneTaskTimeoutError(error)) {
         // Releasing the queue slot must also retire the attempt's action signal.
         laneTaskAbortController.abort(error);
@@ -400,13 +425,16 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
       let queuedRun: Promise<T>;
       try {
         if (params.enqueue) {
-          queuedRun = params.enqueue(admittedTask, withRunLaneWait(sessionOpts));
+          queuedRun = params.enqueue(
+            admittedTask,
+            withLaneTimeout(withRunLaneWait(sessionOpts), true),
+          );
         } else {
           noteLaneWaitIfBusy(options.sessionLane);
           queuedRun = enqueueCommandInLane(
             options.sessionLane,
             admittedTask,
-            withRunLaneWait(sessionOpts),
+            withLaneTimeout(withRunLaneWait(sessionOpts), true),
           );
         }
       } catch (error) {

--- a/src/agents/embedded-agent-runner/run/lane-controller.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.ts
@@ -439,9 +439,19 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
         releaseQueuedContext("abandoned");
         throw error;
       }
-      return await queuedRun.finally(() => {
-        releaseQueuedContext("abandoned");
-      });
+      return await queuedRun
+        .finally(() => {
+          releaseQueuedContext("abandoned");
+        })
+        .catch((error: unknown) => {
+          if (isCommandLaneTaskTimeoutError(error)) {
+            // The queue race releases its slot before the underlying task settles.
+            // Retire that task's run signal so deferred maintenance cannot resume
+            // into global or writer admission after a successor takes the session.
+            laneTaskAbortController.abort(error);
+          }
+          throw error;
+        });
     } finally {
       releaseForeground?.();
     }

--- a/src/agents/embedded-agent-runner/run/lane-controller.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.ts
@@ -67,9 +67,9 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
   ]);
   let laneTaskProgressAtMs = Date.now();
   let laneTaskDeadline: CommandQueueTaskDeadline | undefined;
-  let notifyLaneTaskDeadline:
-    | ((deadline: CommandQueueTaskDeadline | undefined) => void)
-    | undefined;
+  const laneTaskDeadlineSubscribers = new Set<
+    (deadline: CommandQueueTaskDeadline | undefined) => void
+  >();
   const setLaneTaskDeadline = (deadline: CommandQueueTaskDeadline | undefined) => {
     laneTaskDeadline =
       deadline?.kind === "bounded"
@@ -78,7 +78,9 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
             deadlineAtMs: deadline.deadlineAtMs + EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS,
           }
         : deadline;
-    notifyLaneTaskDeadline?.(laneTaskDeadline);
+    for (const notifyDeadline of laneTaskDeadlineSubscribers) {
+      notifyDeadline(laneTaskDeadline);
+    }
   };
   let pendingGlobalLaneAdmissions = 0;
   let releaseQueuedRunContext: ReturnType<typeof retainQueuedAgentRunContext>;
@@ -224,13 +226,9 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
             ? Date.now()
             : laneTaskProgressAtMs,
         taskTimeoutSubscribe: (onDeadline) => {
-          notifyLaneTaskDeadline = onDeadline;
+          laneTaskDeadlineSubscribers.add(onDeadline);
           onDeadline(laneTaskDeadline);
-          return () => {
-            if (notifyLaneTaskDeadline === onDeadline) {
-              notifyLaneTaskDeadline = undefined;
-            }
-          };
+          return () => laneTaskDeadlineSubscribers.delete(onDeadline);
         },
         taskTimeoutAbortSignal: abortSignal,
         taskTimeoutAbortGraceMs: EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where an embedded agent run that stalled while owning its session lane could block every later turn for that session indefinitely. A healthy wait for global-lane capacity could also be mistaken for a stalled run once the session lease became bounded.

## Why This Change Was Made

The embedded lane controller now applies the attempt-owned deadline, abort grace, and release signal to both default and injected session queues. Only the outer session lease treats pending global-lane admission as healthy progress; admitted global work keeps its strict timeout, and concurrent or failed admissions release their heartbeat ownership exactly once.

This keeps timeout policy at the session/global composition owner. The rebase preserves current main's capacity-wait projection (`onQueued` plus exact release) and composes the lane-lease accounting with it. Generic queue behavior, lifecycle rotation, writer claims, placement admission, and run-context retention are unchanged. Unrelated embedded-runner roster fixture churn from the preserved source remains excluded because it is not required by the lane invariant.

Production delta: +42/-12 (net +30). Test delta: +213, trimmed from +293 by removing 80 lines (27.3%) of subsumed/fanout coverage. The production growth adds the missing bounded outer lease and concurrency-safe nested-admission ownership; implementing it downstream or in the generic queue would duplicate or misplace policy.

## User Impact

Later turns for the same agent session can proceed after a stalled embedded run reaches its deadline or is released. Runs that are merely waiting for healthy global capacity remain alive, while genuinely stalled admitted global work still times out.

## Evidence

- Exact rebase base/head: `0955169bbad5431f5b708fd1494aabcd7ad594f2` / `ac703174eec1ca93548f11298fa83dd7af41f173`.
- Exact-head focused proof: `node scripts/run-vitest.mjs` across the lane-controller, queue-liveness, lifecycle, and writer-claim suites passed 4 files / 37 tests. This includes the capacity-projection overlap introduced by #133470.
- Exact-head static proof: direct oxfmt check, `git diff --check`, and conflict-marker scan passed. Changed-gate classification selected `core, coreTests`.
- Fresh exact-head P1 autoreview returned no accepted/actionable findings (`patch is correct`, confidence 0.91).
- Exact-head CI [run 33342444282](https://github.com/openclaw/openclaw/actions/runs/33342444282) is green after one failed-job retry; the first attempt's sole failure was an unrelated 300-second Gateway health lifecycle test hang. Final rollup: 235 checks, zero pending or failed.
- Exact-head ClawSweeper review: [durable verdict](https://github.com/openclaw/openclaw/pull/123055#issuecomment-5277806756), Platinum Hermit 4/6, Findings None, Security None, best-fix judgment yes.
- Live-main drift through `0b392310b92d90bd37b884c4469b0ec799ad2521` changes neither owned file; final synthetic merge-tree proof is clean (`fea5074032f6397ae26c1b2d36fb2dd9da71b484`), and GitHub reports `MERGEABLE` / `CLEAN`.
- Original immutable remote proof provider: `blacksmith-testbox`; reusable lease `tbx_01kzwznhtmsrkt3nr1dqzs6gmj` (`tidal-crab`); backing [Actions run 31677094954](https://github.com/openclaw/openclaw/actions/runs/31677094954), job `94373939834`.
- On that immutable run, the pre-fix focused reproduction failed 4/6, the identical post-fix command passed 6/6, the controller plus lifecycle/queue-liveness/writer-claim siblings passed 30/30, and `pnpm check:changed` passed.
- Final-base historical focused proof: Testbox `tbx_01kzx1djav9aqn9hg88cdfp7gm` (`violet-crab`), [Actions run 31679212952](https://github.com/openclaw/openclaw/actions/runs/31679212952), job `94380567103`; 6/6 passed.
