### PR TITLE
fix(linux-node): bound GeoClue epoch parsing to the valid Date range

### DIFF
--- a/extensions/linux-node/src/commands.test.ts
+++ b/extensions/linux-node/src/commands.test.ts
@@ -302,6 +302,36 @@ describe("linux-node commands", () => {
     ).resolves.toContain('"timestamp":"2026-07-13T12:00:10.000Z"');
   });
 
+  it("falls back to the local clock when the GeoClue epoch exceeds the Date range", async () => {
+    const output = `\nNew location:\nLatitude: 48\nLongitude: 16\nAccuracy: 25 meters\nTimestamp: now (99999999999999999 seconds since the Epoch)\n`;
+    const harness = createHarness({
+      runCommand: async () => success(output),
+    });
+
+    const payload = JSON.parse(await harness.command("location.get").handle()) as Record<
+      string,
+      unknown
+    >;
+
+    expect(payload.timestamp).toBe("2026-07-13T12:00:10.000Z");
+  });
+
+  it("omits non-finite altitude, speed, and heading fields from the location payload", async () => {
+    const output = `\nNew location:\nLatitude: 48\nLongitude: 16\nAccuracy: 25 meters\nAltitude: 1.2.3 meters\nSpeed: -. meters/second\nHeading: 270°\nTimestamp: now (1783944000 seconds since the Epoch)\n`;
+    const harness = createHarness({
+      runCommand: async () => success(output),
+    });
+
+    const payload = JSON.parse(await harness.command("location.get").handle()) as Record<
+      string,
+      unknown
+    >;
+
+    expect(payload).not.toHaveProperty("altitudeMeters");
+    expect(payload).not.toHaveProperty("speedMps");
+    expect(payload.headingDeg).toBe(270);
+  });
+
   it("returns stable location timeout and unavailable errors", async () => {
     const timeout = createHarness({ runCommand: async () => success("") });
     await expect(timeout.command("location.get").handle()).rejects.toThrow(

--- a/extensions/linux-node/src/location.ts
+++ b/extensions/linux-node/src/location.ts
@@ -31,6 +31,14 @@ function isLocationDisabledOutput(output: string): boolean {
   return /Geolocation disabled|disallowed, no agent|AccessDenied|not authorized/iu.test(output);
 }
 
+function parseOptionalFiniteNumber(raw: string | undefined): number | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : undefined;
+}
+
 function parseLocationOutput(
   output: string,
   now: () => Date,
@@ -68,12 +76,16 @@ function parseLocationOutput(
       continue;
     }
     const epochSeconds = /\((\d+)\s+seconds since the Epoch\)/u.exec(block)?.[1];
-    const altitude = /Altitude:\s*([-+\d.]+)/u.exec(block)?.[1];
-    const speed = /Speed:\s*([-+\d.]+)/u.exec(block)?.[1];
-    const heading = /Heading:\s*([-+\d.]+)/u.exec(block)?.[1];
-    const timestamp = epochSeconds
-      ? new Date(Number(epochSeconds) * 1000).toISOString()
-      : now().toISOString();
+    const altitudeMeters = parseOptionalFiniteNumber(/Altitude:\s*([-+\d.]+)/u.exec(block)?.[1]);
+    const speedMps = parseOptionalFiniteNumber(/Speed:\s*([-+\d.]+)/u.exec(block)?.[1]);
+    const headingDeg = parseOptionalFiniteNumber(/Heading:\s*([-+\d.]+)/u.exec(block)?.[1]);
+    const epochMs = epochSeconds === undefined ? Number.NaN : Number(epochSeconds) * 1000;
+    // GeoClue epochs can exceed Date's valid range (±8.64e15 ms); fall back to
+    // the local clock instead of letting toISOString() throw a RangeError.
+    const timestamp =
+      Number.isFinite(epochMs) && Math.abs(epochMs) <= 8.64e15
+        ? new Date(epochMs).toISOString()
+        : now().toISOString();
     if (
       maxAgeMs !== undefined &&
       now().getTime() - Date.parse(timestamp) >= maxAgeMs + GEOCLUE_TIMESTAMP_RESOLUTION_MS
@@ -84,9 +96,9 @@ function parseLocationOutput(
       lat,
       lon,
       accuracyMeters,
-      ...(altitude !== undefined ? { altitudeMeters: Number(altitude) } : {}),
-      ...(speed !== undefined ? { speedMps: Number(speed) } : {}),
-      ...(heading !== undefined ? { headingDeg: Number(heading) } : {}),
+      ...(altitudeMeters !== undefined ? { altitudeMeters } : {}),
+      ...(speedMps !== undefined ? { speedMps } : {}),
+      ...(headingDeg !== undefined ? { headingDeg } : {}),
       timestamp,
     };
   }


### PR DESCRIPTION
## Summary

fix(linux-node): bound GeoClue epoch parsing to the valid Date range so `location.get` falls back to the local clock instead of crashing with a `RangeError`

## What Problem This Solves

The linux-node extension's `location.get` command runs GeoClue's `where-am-i` demo and parses its text output. The timestamp line is parsed as `(<n> seconds since the Epoch)` and converted with `new Date(Number(epochSeconds) * 1000).toISOString()`.

`Date` only supports ±8.64e15 ms. A GeoClue fix reporting a bogus/corrupt epoch beyond that range (observed on devices with a broken clock or a noisy D-Bus provider) makes `toISOString()` throw `RangeError: Invalid time value`. The exception escapes `parseLocationOutput` and aborts the whole `location.get` call — the node returns an internal error instead of a perfectly usable position fix (lat/lon/accuracy parsed fine).

Two related parsing gaps in the same function: `Altitude`/`Speed`/`Heading` values that parse to non-finite numbers (e.g. `Altitude: 1.2.3 meters` → `Number("1.2.3")` = `NaN`) were included in the payload, and `JSON.stringify` serializes `NaN` as `null` — so downstream consumers receive `altitudeMeters: null` despite the field being typed `number`.

**代码证据**: in `extensions/linux-node/src/location.ts` (on current main):

- `const timestamp = epochSeconds ? new Date(Number(epochSeconds) * 1000).toISOString() : now().toISOString();` — no bounds check before `toISOString()`.
- `...(altitude !== undefined ? { altitudeMeters: Number(altitude) } : {})` (and the same for speed/heading) — no `Number.isFinite` guard, so `NaN` leaks into the payload.

Trigger condition: any GeoClue output block whose epoch exceeds ~±285,616 years in milliseconds, or whose optional fields don't parse to finite numbers. Edge case, but it crashes an otherwise successful location read.

## Root Cause

- Bug introduced by commit `92cca9343ea` (2026-07-14, #107193, the commit that added the linux-node location command).
- Violated invariant: the parser assumes any integer matched by `\((\d+)\s+seconds since the Epoch\)` is a valid `Date` input. JS `Date` only accepts |ms| ≤ 8.64e15; `new Date(NaN).toISOString()` and out-of-range values both throw.
- Same for the optional numeric fields: the regex `[-+\d.]+` matches strings like `1.2.3` that are not valid numbers, and the result was used unchecked.

## Why This Fix

- Option A: clamp the epoch to the Date range and keep the (meaningless) clamped timestamp. Rejected: a clamped timestamp is silently wrong data, worse than a fresh local one.
- Option B (chosen): treat out-of-range epochs like a missing epoch — fall back to `now()`, matching the existing "no epoch" path; and route the optional fields through a `parseOptionalFiniteNumber` helper that drops non-finite values (field omitted entirely, never `null`).
- Not chosen: rejecting the whole fix when the epoch is out of range — the position data is still valid; only the timestamp is untrustworthy.

## User Impact

- Affected scenarios: `location.get` on Linux nodes where GeoClue reports a corrupt/huge epoch, or malformed optional fields.
- Before: `location.get` fails with an unhandled `RangeError: Invalid time value`; or the JSON payload contains `altitudeMeters: null` / `speedMps: null`.
- After: the command returns the fix with the local clock as timestamp; non-finite optional fields are omitted from the payload.
- Behavior change: out-of-range epochs now yield `now()` instead of throwing. This is strictly better — the previous behavior was a crash, and the fresh-timestamp fallback already existed for the no-epoch case.

## Real Behavior Proof

### Before (on main)

```bash
$ node node_modules/tsx/dist/cli.mjs proof-linux-node-location.mjs
FAIL huge-epoch location threw: RangeError: Invalid time value
FAIL optional-field handling wrong: {"lat":48,"lon":16,"accuracyMeters":25,"altitudeMeters":null,"speedMps":null,"headingDeg":270,"timestamp":"2026-07-13T12:00:00.000Z",...}
RESULT: 2 FAILURES (bug present)
```

### After (with fix)

```bash
$ node node_modules/tsx/dist/cli.mjs proof-linux-node-location.mjs
PASS huge-epoch location returns timestamp=2026-07-13T12:00:10.000Z (local clock fallback)
PASS non-finite altitude/speed omitted, heading kept: {"lat":48,"lon":16,"accuracyMeters":25,"headingDeg":270,"timestamp":"2026-07-13T12:00:00.000Z","isPrecise":true,"source":"unknown"}
RESULT: ALL PASS
```

The proof runs the real `createLinuxNodeCommands` from `extensions/linux-node/src/commands.ts` (Node v24, tsx); only the process boundary (`runCommand`) is stubbed with real-shaped GeoClue output — the same stubbing pattern the vitest suite uses.

## Tests and Validation

- `npx vitest run extensions/linux-node/src/commands.test.ts` — all location tests pass, including 2 new regression cases: huge-epoch fallback to the local clock, and omission of non-finite altitude/speed/heading. (One pre-existing camera test, `lists only V4L2 nodes...`, fails identically on unmodified main in this Windows environment — unrelated to this change.)
- `npx oxlint --deny=warn` on both changed files — 0 warnings, 0 errors.
- Before/after real-behavior proof logs are embedded above.
