### PR TITLE
fix(gateway): prevent duplicate admission for pipelined connects

### DIFF
--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -3,6 +3,8 @@
 export const MAX_PAYLOAD_BYTES = 25 * 1024 * 1024;
 export const MAX_BUFFERED_BYTES = 50 * 1024 * 1024; // per-connection send buffer limit (2x max payload)
 export const MAX_PREAUTH_PAYLOAD_BYTES = 64 * 1024;
+// Keep the consecutive lazy-load and async-handshake ingress queues equally bounded.
+export const MAX_QUEUED_GATEWAY_PREAUTH_FRAMES = 16;
 
 const DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES = 6 * 1024 * 1024; // keep history responses comfortably under client WS limits
 const maxChatHistoryMessagesBytes = DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES;

--- a/src/gateway/server/ws-connection.startup.test.ts
+++ b/src/gateway/server/ws-connection.startup.test.ts
@@ -51,6 +51,7 @@ import {
 import * as gatewayAuth from "../auth.js";
 import { buildDeviceAuthPayload } from "../device-auth.js";
 import { createWorkerEnvironmentStore } from "../worker-environments/store.js";
+import { MAX_QUEUED_GATEWAY_PREAUTH_FRAMES } from "../server-constants.js";
 import { attachGatewayWsConnectionHandler } from "./ws-connection.js";
 import {
   attachGatewayWsForTest,
@@ -58,7 +59,6 @@ import {
   createGatewayWsTestRequestContext,
   createGatewayWsTestSocket,
 } from "./ws-connection.test-helpers.js";
-import { MAX_QUEUED_GATEWAY_PREAUTH_FRAMES } from "./ws-connection/preauth-ingress.js";
 
 type StartupConnectResponse = {
   type?: unknown;

--- a/src/gateway/server/ws-connection.startup.test.ts
+++ b/src/gateway/server/ws-connection.startup.test.ts
@@ -301,8 +301,8 @@ describe("attachGatewayWsConnectionHandler startup readiness", () => {
         },
       });
 
-    socket.emit("message", connectFrame("connect-1"));
-    socket.emit("message", connectFrame("connect-2"));
+    socket.emit("message", Buffer.from(connectFrame("connect-1")));
+    socket.emit("message", Buffer.from(connectFrame("connect-2")));
     await vi.dynamicImportSettled();
 
     await vi.waitFor(() => {
@@ -363,24 +363,26 @@ describe("attachGatewayWsConnectionHandler startup readiness", () => {
       });
       socket.emit(
         "message",
-        JSON.stringify({
-          type: "req",
-          id: "connect-1",
-          method: "connect",
-          params: {
-            minProtocol: PROTOCOL_VERSION,
-            maxProtocol: PROTOCOL_VERSION,
-            client: {
-              id: GATEWAY_CLIENT_NAMES.CLI,
-              version: "dev",
-              platform: "test",
-              mode: GATEWAY_CLIENT_MODES.CLI,
+        Buffer.from(
+          JSON.stringify({
+            type: "req",
+            id: "connect-1",
+            method: "connect",
+            params: {
+              minProtocol: PROTOCOL_VERSION,
+              maxProtocol: PROTOCOL_VERSION,
+              client: {
+                id: GATEWAY_CLIENT_NAMES.CLI,
+                version: "dev",
+                platform: "test",
+                mode: GATEWAY_CLIENT_MODES.CLI,
+              },
+              role: "operator",
+              scopes: ["operator.read"],
+              caps: [],
             },
-            role: "operator",
-            scopes: ["operator.read"],
-            caps: [],
-          },
-        }),
+          }),
+        ),
       );
 
       // The handler is lazy-loaded; wait for its actual frame instead of a one-second poll.

--- a/src/gateway/server/ws-connection.startup.test.ts
+++ b/src/gateway/server/ws-connection.startup.test.ts
@@ -50,8 +50,8 @@ import {
 } from "../auth-rate-limit.js";
 import * as gatewayAuth from "../auth.js";
 import { buildDeviceAuthPayload } from "../device-auth.js";
-import { createWorkerEnvironmentStore } from "../worker-environments/store.js";
 import { MAX_QUEUED_GATEWAY_PREAUTH_FRAMES } from "../server-constants.js";
+import { createWorkerEnvironmentStore } from "../worker-environments/store.js";
 import { attachGatewayWsConnectionHandler } from "./ws-connection.js";
 import {
   attachGatewayWsForTest,
@@ -180,36 +180,38 @@ async function attachStartupNodeConnect(params: {
   markGatewayRestartDraining();
   socket.emit(
     "message",
-    JSON.stringify({
-      type: "req",
-      id: "startup-node-connect",
-      method: "connect",
-      params: {
-        minProtocol: PROTOCOL_VERSION,
-        maxProtocol: PROTOCOL_VERSION,
-        client: {
-          id: GATEWAY_CLIENT_NAMES.NODE_HOST,
-          version: "dev",
-          platform: "linux",
-          mode: GATEWAY_CLIENT_MODES.NODE,
+    Buffer.from(
+      JSON.stringify({
+        type: "req",
+        id: "startup-node-connect",
+        method: "connect",
+        params: {
+          minProtocol: PROTOCOL_VERSION,
+          maxProtocol: PROTOCOL_VERSION,
+          client: {
+            id: GATEWAY_CLIENT_NAMES.NODE_HOST,
+            version: "dev",
+            platform: "linux",
+            mode: GATEWAY_CLIENT_MODES.NODE,
+          },
+          role: "node",
+          scopes: [],
+          caps: [],
+          commands: [],
+          auth: {
+            ...(params.bootstrapToken ? { bootstrapToken: params.bootstrapToken } : {}),
+            ...(params.sharedToken ? { token: params.sharedToken } : {}),
+          },
+          device: {
+            id: identity.deviceId,
+            publicKey,
+            signature: signDevicePayload(identity.privateKeyPem, devicePayload),
+            signedAt,
+            nonce,
+          },
         },
-        role: "node",
-        scopes: [],
-        caps: [],
-        commands: [],
-        auth: {
-          ...(params.bootstrapToken ? { bootstrapToken: params.bootstrapToken } : {}),
-          ...(params.sharedToken ? { token: params.sharedToken } : {}),
-        },
-        device: {
-          id: identity.deviceId,
-          publicKey,
-          signature: signDevicePayload(identity.privateKeyPem, devicePayload),
-          signedAt,
-          nonce,
-        },
-      },
-    }),
+      }),
+    ),
   );
   const response = async () => {
     await vi.waitFor(() => {

--- a/src/gateway/server/ws-connection.startup.test.ts
+++ b/src/gateway/server/ws-connection.startup.test.ts
@@ -58,6 +58,7 @@ import {
   createGatewayWsTestRequestContext,
   createGatewayWsTestSocket,
 } from "./ws-connection.test-helpers.js";
+import { MAX_QUEUED_GATEWAY_PREAUTH_FRAMES } from "./ws-connection/preauth-ingress.js";
 
 type StartupConnectResponse = {
   type?: unknown;
@@ -262,6 +263,27 @@ function seedProvisioningNodeSetup() {
 }
 
 describe("attachGatewayWsConnectionHandler startup readiness", () => {
+  it("applies the shared preauth queue limit while the message handler loads", async () => {
+    const socket = createGatewayWsTestSocket();
+
+    attachGatewayWsForTest({
+      attach: attachGatewayWsConnectionHandler,
+      socket,
+      options: {
+        getResolvedAuth: () => ({ mode: "none", allowTailscale: false }),
+        buildRequestContext: () => createGatewayWsTestRequestContext() as never,
+      },
+    });
+
+    for (let index = 0; index <= MAX_QUEUED_GATEWAY_PREAUTH_FRAMES; index += 1) {
+      socket.emit("message", Buffer.from(`queued-${index}`));
+    }
+
+    expect(socket.close).toHaveBeenCalledWith(1008, "gateway message handler loading");
+    socket.emit("close", 1008, Buffer.from("gateway message handler loading"));
+    await vi.dynamicImportSettled();
+  });
+
   it("admits only one of two connect frames that race during lazy handler loading", async () => {
     const sent: unknown[] = [];
     const clients = new Set<unknown>();

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -54,6 +54,7 @@ import {
   GatewayNodeLifecycleDispatchTracker,
   NODE_LIFECYCLE_DISPATCH_DRAIN_TIMEOUT_MS,
 } from "./ws-connection/node-lifecycle-dispatch.js";
+import { MAX_QUEUED_GATEWAY_PREAUTH_FRAMES } from "./ws-connection/preauth-ingress.js";
 import {
   attachWorkerWsMessageHandler,
   type WorkerConnectionService,
@@ -70,7 +71,6 @@ import {
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
-const MAX_QUEUED_MESSAGE_HANDLER_FRAMES = 16;
 const unauthorizedCloseBeforeConnectLogLimiter = new HandshakeAuthLogLimiter();
 type GatewayWsSharedHandlerParams = {
   wss: WebSocketServer;
@@ -123,7 +123,7 @@ function attachGatewayWsMessageHandlerOnDemand(
 ): void {
   const queued: RawData[] = [];
   const queueMessage = (data: RawData) => {
-    if (queued.length >= MAX_QUEUED_MESSAGE_HANDLER_FRAMES) {
+    if (queued.length >= MAX_QUEUED_GATEWAY_PREAUTH_FRAMES) {
       params.setCloseCause("message-handler-loading-overflow", {
         queuedFrames: queued.length,
       });

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -25,6 +25,7 @@ import {
   MAX_BUFFERED_BYTES,
   MAX_PAYLOAD_BYTES,
   MAX_PREAUTH_PAYLOAD_BYTES,
+  MAX_QUEUED_GATEWAY_PREAUTH_FRAMES,
 } from "../server-constants.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../server-methods/types.js";
 import { formatError } from "../server-utils.js";
@@ -54,7 +55,6 @@ import {
   GatewayNodeLifecycleDispatchTracker,
   NODE_LIFECYCLE_DISPATCH_DRAIN_TIMEOUT_MS,
 } from "./ws-connection/node-lifecycle-dispatch.js";
-import { MAX_QUEUED_GATEWAY_PREAUTH_FRAMES } from "./ws-connection/preauth-ingress.js";
 import {
   attachWorkerWsMessageHandler,
   type WorkerConnectionService,

--- a/src/gateway/server/ws-connection/connect-session.ts
+++ b/src/gateway/server/ws-connection/connect-session.ts
@@ -516,8 +516,7 @@ export async function attachAuthenticatedGatewayConnect(
     });
     return;
   }
-  // Node identity and pairing checks can yield before registration. Keep the
-  // preauth watchdog live until this socket actually owns its admitted client.
+  // Keep the preauth watchdog and payload cap until this socket owns the admitted client.
   clearHandshakeTimer();
   setSocketMaxPayload(socket, MAX_PAYLOAD_BYTES);
   setHandshakeState("connected");

--- a/src/gateway/server/ws-connection/connect-session.ts
+++ b/src/gateway/server/ws-connection/connect-session.ts
@@ -382,7 +382,6 @@ export async function attachAuthenticatedGatewayConnect(
       `legacy node protocol accepted conn=${connId} client=${formatForLog(clientLabel)} v${formatForLog(connectParams.client.version)} min=${minProtocol} max=${maxProtocol} current=${PROTOCOL_VERSION}; upgrade recommended`,
     );
   }
-  clearHandshakeTimer();
   const nextClient: GatewayWsClient = {
     socket,
     connect: connectParams,
@@ -441,8 +440,6 @@ export async function attachAuthenticatedGatewayConnect(
       expiresAtMs: entry.expiresAtMs,
     });
   }
-  setSocketMaxPayload(socket, MAX_PAYLOAD_BYTES);
-
   // Version mismatch: kick the local node host so the OS supervisor restarts it.
   // Only applies when the connecting node is the same-install local node (verified by
   // matching instanceId against the local node-host config row). SSH-tunneled remote
@@ -519,6 +516,10 @@ export async function attachAuthenticatedGatewayConnect(
     });
     return;
   }
+  // Node identity and pairing checks can yield before registration. Keep the
+  // preauth watchdog live until this socket actually owns its admitted client.
+  clearHandshakeTimer();
+  setSocketMaxPayload(socket, MAX_PAYLOAD_BYTES);
   setHandshakeState("connected");
   advanceHandshakePhase("session_attached");
   logWs("in", "connect", {

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -147,6 +147,7 @@ vi.mock("../health-state.js", () => ({
 }));
 
 import { attachGatewayWsMessageHandler } from "./message-handler.js";
+import { MAX_QUEUED_GATEWAY_PREAUTH_FRAMES } from "./preauth-ingress.js";
 
 const DEVICE_TOKEN_MUTATION_PARAMS = {
   deviceId: "device-1",
@@ -800,7 +801,7 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
       caps: [],
     };
 
-    for (let index = 0; index < 18; index += 1) {
+    for (let index = 0; index < MAX_QUEUED_GATEWAY_PREAUTH_FRAMES + 2; index += 1) {
       harness.sendConnect(`overflow-connect-${index}`, connectParams);
     }
 
@@ -808,7 +809,7 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
       expect(close).toHaveBeenCalledWith(1008, "too many pending handshake frames");
     });
     expect(setCloseCause).toHaveBeenCalledWith("handshake-message-overflow", {
-      queuedFrames: 16,
+      queuedFrames: MAX_QUEUED_GATEWAY_PREAUTH_FRAMES,
     });
     expect(harness.client).toBeNull();
     expect(harness.setClient).not.toHaveBeenCalled();

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -8,7 +8,6 @@ import { ConnectErrorDetailCodes } from "../../../../packages/gateway-protocol/s
 import { ErrorCodes, PROTOCOL_VERSION } from "../../../../packages/gateway-protocol/src/index.js";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import { prepareSystemAgentRunAdmission } from "../../../agents/admitted-run-context.js";
-import * as nodePairingState from "../../../infra/device-pairing-node-state.js";
 import {
   onInternalDiagnosticEvent,
   resetDiagnosticEventsForTest,
@@ -32,7 +31,11 @@ import type { HealthSummary } from "../../health/types.js";
 import type { GatewayAttributedIngress } from "../../ingress-attribution.js";
 import { getGatewayLocalUserIngress } from "../../local-user-ingress.js";
 import { getOperatorApprovalRuntimeToken } from "../../operator-approval-runtime-token.js";
-import { MAX_PAYLOAD_BYTES, MAX_PREAUTH_PAYLOAD_BYTES } from "../../server-constants.js";
+import {
+  MAX_PAYLOAD_BYTES,
+  MAX_PREAUTH_PAYLOAD_BYTES,
+  MAX_QUEUED_GATEWAY_PREAUTH_FRAMES,
+} from "../../server-constants.js";
 import { handleGatewayRequest } from "../../server-methods.js";
 import { resolveGatewayCronCreatorAuthorityAdmission } from "../../server-methods/cron-creator-authority-admission.js";
 import type { GatewayRequestContext } from "../../server-methods/types.js";
@@ -42,8 +45,6 @@ import {
 } from "../../server-shared-auth-generation.js";
 import { resolveSharedGatewaySessionGeneration } from "../ws-shared-generation.js";
 import { resolvePinnedClientMetadata } from "./connect-device-metadata.js";
-import * as connectNodeSession from "./connect-node-session.js";
-import { attachAuthenticatedGatewayConnect } from "./connect-session.js";
 import { GatewayNodeLifecycleDispatchTracker } from "./node-lifecycle-dispatch.js";
 
 const {
@@ -147,7 +148,6 @@ vi.mock("../health-state.js", () => ({
 }));
 
 import { attachGatewayWsMessageHandler } from "./message-handler.js";
-import { MAX_QUEUED_GATEWAY_PREAUTH_FRAMES } from "./preauth-ingress.js";
 
 const DEVICE_TOKEN_MUTATION_PARAMS = {
   deviceId: "device-1",
@@ -155,6 +155,18 @@ const DEVICE_TOKEN_MUTATION_PARAMS = {
 } as const satisfies Record<string, unknown>;
 const NODE_PAIR_REMOVE_PARAMS = {
   nodeId: "device-1",
+} as const satisfies Record<string, unknown>;
+const BACKEND_CONNECT_PARAMS = {
+  minProtocol: PROTOCOL_VERSION,
+  maxProtocol: PROTOCOL_VERSION,
+  client: {
+    id: "gateway-client",
+    version: "dev",
+    platform: "test",
+    mode: "backend",
+  },
+  role: "operator",
+  caps: [],
 } as const satisfies Record<string, unknown>;
 
 function waitForFast(assertion: () => void | Promise<void>) {
@@ -592,18 +604,7 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
     const receiver = Reflect.get(harness.socket as object, "_receiver") as object;
     expect(Reflect.get(receiver, "_maxPayload")).toBe(MAX_PREAUTH_PAYLOAD_BYTES);
 
-    harness.sendConnect("watchdog-connect", {
-      minProtocol: PROTOCOL_VERSION,
-      maxProtocol: PROTOCOL_VERSION,
-      client: {
-        id: "gateway-client",
-        version: "dev",
-        platform: "test",
-        mode: "backend",
-      },
-      role: "operator",
-      caps: [],
-    });
+    harness.sendConnect("watchdog-connect", BACKEND_CONNECT_PARAMS);
 
     await waitForFast(() => {
       expect(harness.setClient).toHaveBeenCalledOnce();
@@ -614,114 +615,6 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
     expect(harness.setClient.mock.invocationCallOrder[0]).toBeLessThan(
       clearHandshakeTimer.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
     );
-  });
-
-  it("keeps the watchdog and preauth cap while node pairing revalidation is pending", async () => {
-    const prepareNodeConnect = vi
-      .spyOn(connectNodeSession, "prepareGatewayNodeConnect")
-      .mockResolvedValue(true);
-    let resolveRevalidation!: (value: null) => void;
-    const pendingRevalidation = new Promise<null>((resolve) => {
-      resolveRevalidation = resolve;
-    });
-    const captureNodePairingState = vi
-      .spyOn(nodePairingState, "captureAuthenticatedNodePairingState")
-      .mockResolvedValueOnce({
-        identity: { nodeId: "watchdog-node", key: "watchdog-identity" },
-        generation: { nodeId: "watchdog-node", key: "watchdog-generation" },
-      })
-      .mockReturnValueOnce(pendingRevalidation);
-    const clearHandshakeTimer = vi.fn();
-    const setClient = vi.fn(() => true);
-    const close = createCloseMock();
-    const logger = createLogger();
-    const connectParams = {
-      minProtocol: PROTOCOL_VERSION,
-      maxProtocol: PROTOCOL_VERSION,
-      client: {
-        id: "node-host",
-        version: "dev",
-        platform: "test",
-        mode: "node",
-        instanceId: "watchdog-node",
-      },
-      role: "node",
-      scopes: [],
-      auth: { deviceToken: "watchdog-token" },
-      device: { id: "watchdog-node" },
-    };
-    const context = {
-      handler: {
-        socket: { _receiver: { _maxPayload: MAX_PREAUTH_PAYLOAD_BYTES } },
-        upgradeReq: { headers: {} },
-        connId: "conn-pending-node-watchdog",
-        remoteAddr: "127.0.0.1",
-        pluginNodeCapabilities: [],
-        buildRequestContext: () => ({}),
-        close,
-        isClosed: () => false,
-        clearHandshakeTimer,
-        setClient,
-        setHandshakeState: vi.fn(),
-        advanceHandshakePhase: vi.fn(),
-        setCloseCause: vi.fn(),
-        logGateway: logger,
-        logWsControl: logger,
-      },
-      connectParams,
-      isLocalClient: true,
-      reportedClientIp: "127.0.0.1",
-      runDetachedConnectWork: vi.fn(),
-      isWebchatConnect: () => false,
-      clientLabel: "node-host",
-      clientMeta: {},
-      markHandshakeFailure: vi.fn(),
-      sendHandshakeErrorResponse: vi.fn(),
-      releasePendingNodePairingCleanup: vi.fn(async () => {}),
-      pendingNodePairingCleanup: {},
-      configSnapshot: loadConfigMock(),
-    } as unknown as Parameters<typeof attachAuthenticatedGatewayConnect>[0];
-    const state = {
-      minProtocol: PROTOCOL_VERSION,
-      maxProtocol: PROTOCOL_VERSION,
-      usesLegacyNodeProtocol: false,
-      role: "node",
-      scopes: [],
-      device: { id: "watchdog-node" },
-      devicePublicKey: "watchdog-public-key",
-      deviceToken: { token: "watchdog-token" },
-      authResult: { ok: true },
-      authMethod: "device-token",
-      pairingLocality: "local",
-      sessionUsesSharedGatewayAuth: false,
-      controlUiDeviceAuthMigrationPending: false,
-      bootstrapDeviceTokens: [],
-    } as unknown as Parameters<typeof attachAuthenticatedGatewayConnect>[1];
-
-    try {
-      const pendingAdmission = attachAuthenticatedGatewayConnect(context, state);
-      await waitForFast(() => {
-        expect(captureNodePairingState).toHaveBeenCalledTimes(2);
-      });
-      expect(clearHandshakeTimer).not.toHaveBeenCalled();
-      expect(setClient).not.toHaveBeenCalled();
-      expect(context.handler.socket).toMatchObject({
-        _receiver: { _maxPayload: MAX_PREAUTH_PAYLOAD_BYTES },
-      });
-      resolveRevalidation(null);
-      await pendingAdmission;
-
-      expect(close).toHaveBeenCalledOnce();
-      expect(close).toHaveBeenCalledWith(1008, "node pairing changed during connect");
-      expect(clearHandshakeTimer).not.toHaveBeenCalled();
-      expect(setClient).not.toHaveBeenCalled();
-      expect(context.handler.socket).toMatchObject({
-        _receiver: { _maxPayload: MAX_PREAUTH_PAYLOAD_BYTES },
-      });
-    } finally {
-      captureNodePairingState.mockRestore();
-      prepareNodeConnect.mockRestore();
-    }
   });
 
   it("rejects an oversized queued frame before the initial handshake completes", async () => {
@@ -739,22 +632,9 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
       refreshHealthSnapshot,
       setCloseCause,
     });
-    const connectParams = {
-      minProtocol: PROTOCOL_VERSION,
-      maxProtocol: PROTOCOL_VERSION,
-      client: {
-        id: "gateway-client",
-        version: "dev",
-        platform: "test",
-        mode: "backend",
-      },
-      role: "operator",
-      caps: [],
-    };
-
-    harness.sendConnect("connect-before-oversized-frame", connectParams);
+    harness.sendConnect("connect-before-oversized-frame", BACKEND_CONNECT_PARAMS);
     harness.sendConnect("oversized-queued-connect", {
-      ...connectParams,
+      ...BACKEND_CONNECT_PARAMS,
       pathEnv: "x".repeat(MAX_PREAUTH_PAYLOAD_BYTES + 1),
     });
 
@@ -788,21 +668,8 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
       isClosed: () => closed,
       setCloseCause,
     });
-    const connectParams = {
-      minProtocol: PROTOCOL_VERSION,
-      maxProtocol: PROTOCOL_VERSION,
-      client: {
-        id: "gateway-client",
-        version: "dev",
-        platform: "test",
-        mode: "backend",
-      },
-      role: "operator",
-      caps: [],
-    };
-
     for (let index = 0; index < MAX_QUEUED_GATEWAY_PREAUTH_FRAMES + 2; index += 1) {
-      harness.sendConnect(`overflow-connect-${index}`, connectParams);
+      harness.sendConnect(`overflow-connect-${index}`, BACKEND_CONNECT_PARAMS);
     }
 
     await waitForFast(() => {
@@ -844,26 +711,13 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
         refreshHealthSnapshot,
         socket: serverSocket,
       });
-      const connectParams = {
-        minProtocol: PROTOCOL_VERSION,
-        maxProtocol: PROTOCOL_VERSION,
-        client: {
-          id: "gateway-client",
-          version: "dev",
-          platform: "test",
-          mode: "backend",
-        },
-        role: "operator",
-        caps: [],
-      };
-
       for (let index = 0; index < 8; index += 1) {
         socket.send(
           JSON.stringify({
             type: "req",
             id: `real-connect-${index}`,
             method: "connect",
-            params: connectParams,
+            params: BACKEND_CONNECT_PARAMS,
           }),
         );
       }

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -1,11 +1,14 @@
 // WebSocket message-handler health tests cover post-connect startup-unavailable and health-gated dispatch.
+import { once } from "node:events";
 import type { IncomingMessage } from "node:http";
+import type { AddressInfo } from "node:net";
 import { beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
-import type { WebSocket } from "ws";
+import { WebSocket, WebSocketServer } from "ws";
 import { ConnectErrorDetailCodes } from "../../../../packages/gateway-protocol/src/connect-error-details.js";
 import { ErrorCodes, PROTOCOL_VERSION } from "../../../../packages/gateway-protocol/src/index.js";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import { prepareSystemAgentRunAdmission } from "../../../agents/admitted-run-context.js";
+import * as nodePairingState from "../../../infra/device-pairing-node-state.js";
 import {
   onInternalDiagnosticEvent,
   resetDiagnosticEventsForTest,
@@ -29,6 +32,7 @@ import type { HealthSummary } from "../../health/types.js";
 import type { GatewayAttributedIngress } from "../../ingress-attribution.js";
 import { getGatewayLocalUserIngress } from "../../local-user-ingress.js";
 import { getOperatorApprovalRuntimeToken } from "../../operator-approval-runtime-token.js";
+import { MAX_PAYLOAD_BYTES, MAX_PREAUTH_PAYLOAD_BYTES } from "../../server-constants.js";
 import { handleGatewayRequest } from "../../server-methods.js";
 import { resolveGatewayCronCreatorAuthorityAdmission } from "../../server-methods/cron-creator-authority-admission.js";
 import type { GatewayRequestContext } from "../../server-methods/types.js";
@@ -38,6 +42,8 @@ import {
 } from "../../server-shared-auth-generation.js";
 import { resolveSharedGatewaySessionGeneration } from "../ws-shared-generation.js";
 import { resolvePinnedClientMetadata } from "./connect-device-metadata.js";
+import * as connectNodeSession from "./connect-node-session.js";
+import { attachAuthenticatedGatewayConnect } from "./connect-session.js";
 import { GatewayNodeLifecycleDispatchTracker } from "./node-lifecycle-dispatch.js";
 
 const {
@@ -268,6 +274,7 @@ function captureSecurityEvents(): {
 function attachGatewayHarness(options: {
   connId: string;
   connectNonce: string;
+  socket?: WebSocket;
   refreshHealthSnapshot?: GatewayRequestContext["refreshHealthSnapshot"];
   requestOrigin?: string;
   requestHost?: string;
@@ -282,21 +289,24 @@ function attachGatewayHarness(options: {
   close?: CloseGatewayConnection;
   isClosed?: () => boolean;
   setCloseCause?: SetCloseCause;
+  clearHandshakeTimer?: () => void;
 }) {
   const socketSend = vi.fn((_payload: string, cb?: (err?: Error) => void) => {
     cb?.();
   });
-  let onMessage: ((data: string) => void) | undefined;
-  const socket = {
-    _receiver: {},
-    send: socketSend,
-    on: vi.fn((event: string, handler: (data: string) => void) => {
-      if (event === "message") {
-        onMessage = handler;
-      }
-      return socket;
-    }),
-  } as unknown as WebSocket;
+  let onMessage: ((data: Buffer) => void) | undefined;
+  const socket =
+    options.socket ??
+    ({
+      _receiver: { _maxPayload: MAX_PREAUTH_PAYLOAD_BYTES },
+      send: socketSend,
+      on: vi.fn((event: string, handler: (data: Buffer) => void) => {
+        if (event === "message") {
+          onMessage = handler;
+        }
+        return socket;
+      }),
+    } as unknown as WebSocket);
   const send = vi.fn((_frame: unknown) => ({ kind: "sent" }) as const);
   let client: unknown = options.client ?? null;
   const requestHost = options.requestHost ?? "127.0.0.1:19001";
@@ -307,6 +317,7 @@ function attachGatewayHarness(options: {
     allowTailscale: false,
   };
   const advanceHandshakePhase = vi.fn();
+  const clearHandshakeTimer = options.clearHandshakeTimer ?? vi.fn();
   const logWsControl = createLogger();
   const refreshConnectedUserProfile = vi.fn<
     NonNullable<GatewayRequestContext["refreshConnectedUserProfile"]>
@@ -323,6 +334,13 @@ function attachGatewayHarness(options: {
         updatedAt: profile.updatedAt,
       });
     }
+  });
+  const setClient = vi.fn((next: unknown) => {
+    if (options.isClosed?.()) {
+      return false;
+    }
+    client = next;
+    return true;
   });
   attachGatewayWsMessageHandler({
     socket,
@@ -366,12 +384,9 @@ function attachGatewayHarness(options: {
     send,
     close: options.close ?? createCloseMock(),
     isClosed: options.isClosed ?? vi.fn(() => false),
-    clearHandshakeTimer: vi.fn(),
+    clearHandshakeTimer,
     getClient: () => client as never,
-    setClient: (next) => {
-      client = next;
-      return true;
-    },
+    setClient,
     setHandshakeState: vi.fn(),
     advanceHandshakePhase,
     setCloseCause: options.setCloseCause ?? createSetCloseCauseMock(),
@@ -381,15 +396,23 @@ function attachGatewayHarness(options: {
     logHealth: createLogger() as never,
     logWsControl: logWsControl as never,
   });
-  if (onMessage === undefined) {
+  if (onMessage === undefined && !options.socket) {
     throw new Error("expected websocket message handler");
   }
-  const sendMessage = onMessage;
+  const sendMessage = (data: string) => {
+    if (!onMessage) {
+      throw new Error("synthetic websocket message handler is unavailable for a real socket");
+    }
+    onMessage(Buffer.from(data));
+  };
   return {
     advanceHandshakePhase,
+    clearHandshakeTimer,
     logWsControl,
     refreshConnectedUserProfile,
     send,
+    setClient,
+    socket,
     socketSend,
     sendRequest: (
       id: string,
@@ -556,6 +579,323 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
         });
       },
     );
+  });
+
+  it("keeps the handshake watchdog until the client is registered", async () => {
+    const clearHandshakeTimer = vi.fn();
+    const harness = attachGatewayHarness({
+      connId: "conn-watchdog-client-ownership",
+      connectNonce: "nonce-watchdog-client-ownership",
+      clearHandshakeTimer,
+    });
+    const receiver = Reflect.get(harness.socket as object, "_receiver") as object;
+    expect(Reflect.get(receiver, "_maxPayload")).toBe(MAX_PREAUTH_PAYLOAD_BYTES);
+
+    harness.sendConnect("watchdog-connect", {
+      minProtocol: PROTOCOL_VERSION,
+      maxProtocol: PROTOCOL_VERSION,
+      client: {
+        id: "gateway-client",
+        version: "dev",
+        platform: "test",
+        mode: "backend",
+      },
+      role: "operator",
+      caps: [],
+    });
+
+    await waitForFast(() => {
+      expect(harness.setClient).toHaveBeenCalledOnce();
+      expect(clearHandshakeTimer).toHaveBeenCalledOnce();
+      expect(harness.socketSend).toHaveBeenCalledOnce();
+    });
+    expect(Reflect.get(receiver, "_maxPayload")).toBe(MAX_PAYLOAD_BYTES);
+    expect(harness.setClient.mock.invocationCallOrder[0]).toBeLessThan(
+      clearHandshakeTimer.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+  });
+
+  it("keeps the watchdog and preauth cap while node pairing revalidation is pending", async () => {
+    const prepareNodeConnect = vi
+      .spyOn(connectNodeSession, "prepareGatewayNodeConnect")
+      .mockResolvedValue(true);
+    let resolveRevalidation!: (value: null) => void;
+    const pendingRevalidation = new Promise<null>((resolve) => {
+      resolveRevalidation = resolve;
+    });
+    const captureNodePairingState = vi
+      .spyOn(nodePairingState, "captureAuthenticatedNodePairingState")
+      .mockResolvedValueOnce({
+        identity: { nodeId: "watchdog-node", key: "watchdog-identity" },
+        generation: { nodeId: "watchdog-node", key: "watchdog-generation" },
+      })
+      .mockReturnValueOnce(pendingRevalidation);
+    const clearHandshakeTimer = vi.fn();
+    const setClient = vi.fn(() => true);
+    const close = createCloseMock();
+    const logger = createLogger();
+    const connectParams = {
+      minProtocol: PROTOCOL_VERSION,
+      maxProtocol: PROTOCOL_VERSION,
+      client: {
+        id: "node-host",
+        version: "dev",
+        platform: "test",
+        mode: "node",
+        instanceId: "watchdog-node",
+      },
+      role: "node",
+      scopes: [],
+      auth: { deviceToken: "watchdog-token" },
+      device: { id: "watchdog-node" },
+    };
+    const context = {
+      handler: {
+        socket: { _receiver: { _maxPayload: MAX_PREAUTH_PAYLOAD_BYTES } },
+        upgradeReq: { headers: {} },
+        connId: "conn-pending-node-watchdog",
+        remoteAddr: "127.0.0.1",
+        pluginNodeCapabilities: [],
+        buildRequestContext: () => ({}),
+        close,
+        isClosed: () => false,
+        clearHandshakeTimer,
+        setClient,
+        setHandshakeState: vi.fn(),
+        advanceHandshakePhase: vi.fn(),
+        setCloseCause: vi.fn(),
+        logGateway: logger,
+        logWsControl: logger,
+      },
+      connectParams,
+      isLocalClient: true,
+      reportedClientIp: "127.0.0.1",
+      runDetachedConnectWork: vi.fn(),
+      isWebchatConnect: () => false,
+      clientLabel: "node-host",
+      clientMeta: {},
+      markHandshakeFailure: vi.fn(),
+      sendHandshakeErrorResponse: vi.fn(),
+      releasePendingNodePairingCleanup: vi.fn(async () => {}),
+      pendingNodePairingCleanup: {},
+      configSnapshot: loadConfigMock(),
+    } as unknown as Parameters<typeof attachAuthenticatedGatewayConnect>[0];
+    const state = {
+      minProtocol: PROTOCOL_VERSION,
+      maxProtocol: PROTOCOL_VERSION,
+      usesLegacyNodeProtocol: false,
+      role: "node",
+      scopes: [],
+      device: { id: "watchdog-node" },
+      devicePublicKey: "watchdog-public-key",
+      deviceToken: { token: "watchdog-token" },
+      authResult: { ok: true },
+      authMethod: "device-token",
+      pairingLocality: "local",
+      sessionUsesSharedGatewayAuth: false,
+      controlUiDeviceAuthMigrationPending: false,
+      bootstrapDeviceTokens: [],
+    } as unknown as Parameters<typeof attachAuthenticatedGatewayConnect>[1];
+
+    try {
+      const pendingAdmission = attachAuthenticatedGatewayConnect(context, state);
+      await waitForFast(() => {
+        expect(captureNodePairingState).toHaveBeenCalledTimes(2);
+      });
+      expect(clearHandshakeTimer).not.toHaveBeenCalled();
+      expect(setClient).not.toHaveBeenCalled();
+      expect(context.handler.socket).toMatchObject({
+        _receiver: { _maxPayload: MAX_PREAUTH_PAYLOAD_BYTES },
+      });
+      resolveRevalidation(null);
+      await pendingAdmission;
+
+      expect(close).toHaveBeenCalledOnce();
+      expect(close).toHaveBeenCalledWith(1008, "node pairing changed during connect");
+      expect(clearHandshakeTimer).not.toHaveBeenCalled();
+      expect(setClient).not.toHaveBeenCalled();
+      expect(context.handler.socket).toMatchObject({
+        _receiver: { _maxPayload: MAX_PREAUTH_PAYLOAD_BYTES },
+      });
+    } finally {
+      captureNodePairingState.mockRestore();
+      prepareNodeConnect.mockRestore();
+    }
+  });
+
+  it("rejects an oversized queued frame before the initial handshake completes", async () => {
+    let closed = false;
+    const close = vi.fn<CloseGatewayConnection>(() => {
+      closed = true;
+    });
+    const setCloseCause = createSetCloseCauseMock();
+    const refreshHealthSnapshot = vi.fn(async () => createHealthSummary());
+    const harness = attachGatewayHarness({
+      connId: "conn-oversized-queued-connect",
+      connectNonce: "nonce-oversized-queued-connect",
+      close,
+      isClosed: () => closed,
+      refreshHealthSnapshot,
+      setCloseCause,
+    });
+    const connectParams = {
+      minProtocol: PROTOCOL_VERSION,
+      maxProtocol: PROTOCOL_VERSION,
+      client: {
+        id: "gateway-client",
+        version: "dev",
+        platform: "test",
+        mode: "backend",
+      },
+      role: "operator",
+      caps: [],
+    };
+
+    harness.sendConnect("connect-before-oversized-frame", connectParams);
+    harness.sendConnect("oversized-queued-connect", {
+      ...connectParams,
+      pathEnv: "x".repeat(MAX_PREAUTH_PAYLOAD_BYTES + 1),
+    });
+
+    await waitForFast(() => {
+      expect(close).toHaveBeenCalledWith(1009, "preauth payload too large");
+      expect(setCloseCause).toHaveBeenCalledWith(
+        "preauth-payload-too-large",
+        expect.objectContaining({
+          limitBytes: MAX_PREAUTH_PAYLOAD_BYTES,
+          payloadBytes: expect.any(Number),
+        }),
+      );
+    });
+    expect(harness.client).toBeNull();
+    expect(harness.setClient).not.toHaveBeenCalled();
+    expect(harness.socketSend).not.toHaveBeenCalled();
+    expect(refreshHealthSnapshot).not.toHaveBeenCalled();
+    expect(handleGatewayRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects a seventeenth frame queued behind the initial handshake", async () => {
+    let closed = false;
+    const close = vi.fn<CloseGatewayConnection>(() => {
+      closed = true;
+    });
+    const setCloseCause = createSetCloseCauseMock();
+    const harness = attachGatewayHarness({
+      connId: "conn-handshake-frame-overflow",
+      connectNonce: "nonce-handshake-frame-overflow",
+      close,
+      isClosed: () => closed,
+      setCloseCause,
+    });
+    const connectParams = {
+      minProtocol: PROTOCOL_VERSION,
+      maxProtocol: PROTOCOL_VERSION,
+      client: {
+        id: "gateway-client",
+        version: "dev",
+        platform: "test",
+        mode: "backend",
+      },
+      role: "operator",
+      caps: [],
+    };
+
+    for (let index = 0; index < 18; index += 1) {
+      harness.sendConnect(`overflow-connect-${index}`, connectParams);
+    }
+
+    await waitForFast(() => {
+      expect(close).toHaveBeenCalledWith(1008, "too many pending handshake frames");
+    });
+    expect(setCloseCause).toHaveBeenCalledWith("handshake-message-overflow", {
+      queuedFrames: 16,
+    });
+    expect(harness.client).toBeNull();
+    expect(harness.setClient).not.toHaveBeenCalled();
+  });
+
+  it("sends one hello then dispatches pipelined frames on a real WebSocket", async () => {
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+      throw new Error("expected the WebSocket server to bind an ephemeral TCP port");
+    }
+
+    const connection = once(server, "connection");
+    const socket = new WebSocket(`ws://127.0.0.1:${(address as AddressInfo).port}`);
+    const receivedFrames: Array<{ id?: string; ok?: boolean; payload?: { type?: string } }> = [];
+    socket.on("message", (data) => {
+      const payload = Buffer.isBuffer(data) ? data : Buffer.from(data as ArrayBuffer);
+      receivedFrames.push(JSON.parse(payload.toString("utf8")) as (typeof receivedFrames)[number]);
+    });
+
+    try {
+      await once(socket, "open");
+      const [serverSocket] = (await connection) as [WebSocket, IncomingMessage];
+      const refreshHealthSnapshot = vi.fn(async () => createHealthSummary());
+      const harness = attachGatewayHarness({
+        connId: "conn-real-pipelined-connect",
+        connectNonce: "nonce-real-pipelined-connect",
+        refreshHealthSnapshot,
+        socket: serverSocket,
+      });
+      const connectParams = {
+        minProtocol: PROTOCOL_VERSION,
+        maxProtocol: PROTOCOL_VERSION,
+        client: {
+          id: "gateway-client",
+          version: "dev",
+          platform: "test",
+          mode: "backend",
+        },
+        role: "operator",
+        caps: [],
+      };
+
+      for (let index = 0; index < 8; index += 1) {
+        socket.send(
+          JSON.stringify({
+            type: "req",
+            id: `real-connect-${index}`,
+            method: "connect",
+            params: connectParams,
+          }),
+        );
+      }
+
+      await waitForFast(() => {
+        expect(harness.setClient).toHaveBeenCalledOnce();
+        expect(receivedFrames).toHaveLength(1);
+        expect(receivedFrames[0]).toMatchObject({
+          id: "real-connect-0",
+          ok: true,
+          payload: { type: "hello-ok" },
+        });
+        expect(refreshHealthSnapshot).toHaveBeenCalledOnce();
+        expect(handleGatewayRequest).toHaveBeenCalledTimes(7);
+      });
+      expect(vi.mocked(handleGatewayRequest).mock.calls.map(([call]) => call.req.id)).toEqual([
+        "real-connect-1",
+        "real-connect-2",
+        "real-connect-3",
+        "real-connect-4",
+        "real-connect-5",
+        "real-connect-6",
+        "real-connect-7",
+      ]);
+    } finally {
+      socket.terminate();
+      for (const client of server.clients) {
+        client.terminate();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   });
 
   it("closes invalidated clients before dispatching queued requests", () => {

--- a/src/gateway/server/ws-connection/message-handler.suspension-admission.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.suspension-admission.test.ts
@@ -57,9 +57,7 @@ function createLogger() {
   };
 }
 
-function attachHarness(
-  params: { deferSocketSend?: boolean; startupPending?: boolean } = {},
-) {
+function attachHarness(params: { deferSocketSend?: boolean; startupPending?: boolean } = {}) {
   let onMessage: ((data: WebSocket.RawData) => void) | undefined;
   let finishSocketSend: (() => void) | undefined;
   let client: unknown = null;

--- a/src/gateway/server/ws-connection/message-handler.suspension-admission.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.suspension-admission.test.ts
@@ -57,8 +57,10 @@ function createLogger() {
   };
 }
 
-function attachHarness(params: { deferSocketSend?: boolean; startupPending?: boolean } = {}) {
-  let onMessage: ((data: string) => void) | undefined;
+function attachHarness(
+  params: { deferSocketSend?: boolean; startupPending?: boolean } = {},
+) {
+  let onMessage: ((data: WebSocket.RawData) => void) | undefined;
   let finishSocketSend: (() => void) | undefined;
   let client: unknown = null;
   const socketSend = vi.fn((_payload: string, callback?: (error?: Error) => void) => {
@@ -71,7 +73,7 @@ function attachHarness(params: { deferSocketSend?: boolean; startupPending?: boo
   const socket = {
     _receiver: {},
     send: socketSend,
-    on: vi.fn((event: string, handler: (data: string) => void) => {
+    on: vi.fn((event: string, handler: (data: WebSocket.RawData) => void) => {
       if (event === "message") {
         onMessage = handler;
       }
@@ -140,84 +142,92 @@ function attachHarness(params: { deferSocketSend?: boolean; startupPending?: boo
     },
     sendConnect: () =>
       onMessage?.(
-        JSON.stringify({
-          type: "req",
-          id: "connect-1",
-          method: "connect",
-          params: {
-            minProtocol: PROTOCOL_VERSION,
-            maxProtocol: PROTOCOL_VERSION,
-            client: {
-              id: "gateway-client",
-              version: "dev",
-              platform: "test",
-              mode: "backend",
+        Buffer.from(
+          JSON.stringify({
+            type: "req",
+            id: "connect-1",
+            method: "connect",
+            params: {
+              minProtocol: PROTOCOL_VERSION,
+              maxProtocol: PROTOCOL_VERSION,
+              client: {
+                id: "gateway-client",
+                version: "dev",
+                platform: "test",
+                mode: "backend",
+              },
+              role: "operator",
+              scopes: [],
+              caps: [],
             },
-            role: "operator",
-            scopes: [],
-            caps: [],
-          },
-        }),
+          }),
+        ),
       ),
     sendNodeConnect: () =>
       onMessage?.(
-        JSON.stringify({
-          type: "req",
-          id: "node-connect-1",
-          method: "connect",
-          params: {
-            minProtocol: PROTOCOL_VERSION,
-            maxProtocol: PROTOCOL_VERSION,
-            client: {
-              id: "gateway-client",
-              version: "dev",
-              platform: "test",
-              mode: "backend",
+        Buffer.from(
+          JSON.stringify({
+            type: "req",
+            id: "node-connect-1",
+            method: "connect",
+            params: {
+              minProtocol: PROTOCOL_VERSION,
+              maxProtocol: PROTOCOL_VERSION,
+              client: {
+                id: "gateway-client",
+                version: "dev",
+                platform: "test",
+                mode: "backend",
+              },
+              role: "node",
+              scopes: [],
+              caps: [],
             },
-            role: "node",
-            scopes: [],
-            caps: [],
-          },
-        }),
+          }),
+        ),
       ),
     sendWorkerConnect: () =>
       onMessage?.(
-        JSON.stringify({
-          type: "req",
-          id: "worker-connect",
-          method: "connect",
-          params: { role: "worker" },
-        }),
+        Buffer.from(
+          JSON.stringify({
+            type: "req",
+            id: "worker-connect",
+            method: "connect",
+            params: { role: "worker" },
+          }),
+        ),
       ),
     sendStartupNodeConnect: () =>
       onMessage?.(
-        JSON.stringify({
-          type: "req",
-          id: "startup-node-connect",
-          method: "connect",
-          params: {
-            minProtocol: PROTOCOL_VERSION,
-            maxProtocol: PROTOCOL_VERSION,
-            client: {
-              id: "node-host",
-              version: "dev",
-              platform: "linux",
-              mode: "node",
+        Buffer.from(
+          JSON.stringify({
+            type: "req",
+            id: "startup-node-connect",
+            method: "connect",
+            params: {
+              minProtocol: PROTOCOL_VERSION,
+              maxProtocol: PROTOCOL_VERSION,
+              client: {
+                id: "node-host",
+                version: "dev",
+                platform: "linux",
+                mode: "node",
+              },
+              role: "node",
+              scopes: [],
+              caps: [],
+              commands: [],
+              auth: { bootstrapToken: "startup-bootstrap-token" },
+              device: {
+                id: "startup-node-device",
+                publicKey: "startup-node-public-key",
+                signature: "startup-node-signature",
+                signedAt: Date.now(),
+                nonce: "suspension-connect-nonce",
+              },
             },
-            role: "node",
-            scopes: [],
-            caps: [],
-            commands: [],
-            auth: { bootstrapToken: "startup-bootstrap-token" },
-            device: {
-              id: "startup-node-device",
-              publicKey: "startup-node-public-key",
-              signature: "startup-node-signature",
-              signedAt: Date.now(),
-              nonce: "suspension-connect-nonce",
-            },
-          },
-        }),
+          }),
+        ),
       ),
     send,
     setCloseCause,

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -35,7 +35,10 @@ import {
 import { isWebchatClient } from "../../../utils/message-channel.js";
 import { isLocalishHost, isLoopbackAddress } from "../../net.js";
 import { resolveNodePairingClientIpSource } from "../../node-pairing-auto-approve.js";
-import { MAX_PREAUTH_PAYLOAD_BYTES } from "../../server-constants.js";
+import {
+  MAX_PREAUTH_PAYLOAD_BYTES,
+  MAX_QUEUED_GATEWAY_PREAUTH_FRAMES,
+} from "../../server-constants.js";
 import { formatForLog, logWs } from "../../ws-log.js";
 import { truncateCloseReason } from "../close-reason.js";
 import { createGatewayAuthenticatedRequestDispatcher } from "./authenticated-request-dispatch.js";
@@ -52,7 +55,6 @@ export type {
   GatewayWsMessageHandlerParams,
   WsOriginCheckMetrics,
 } from "./message-handler-types.js";
-import { MAX_QUEUED_GATEWAY_PREAUTH_FRAMES } from "./preauth-ingress.js";
 
 const GATEWAY_WORK_ADMISSION_RETRY_AFTER_MS = 1_000;
 const GATEWAY_WORK_ADMISSION_CLOSE_CODE = 1013;
@@ -468,10 +470,6 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
   };
 
   const handleIncomingMessage = async (data: RawData) => {
-    if (getClient()) {
-      await handleMessage(data);
-      return;
-    }
     const admission = tryBeginGatewayRootWorkAdmission();
     if (!admission) {
       if (
@@ -517,14 +515,13 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
     }
   };
 
-  let handshakeInProgress = false;
-  const queuedHandshakeFrames: RawData[] = [];
+  let queuedHandshakeFrames: RawData[] | undefined;
 
   const onMessage = (data: RawData): void => {
     if (isClosed()) {
       return;
     }
-    if (handshakeInProgress) {
+    if (queuedHandshakeFrames) {
       // Keep the preauth cap authoritative for pipelined frames until this
       // connection actually owns an admitted client.
       if (!getClient() && rejectOversizedPreauthFrame(data)) {
@@ -545,19 +542,17 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
     }
 
     if (getClient()) {
-      void runWithDiagnosticTraceContext(createDiagnosticTraceContext(), () =>
-        handleIncomingMessage(data),
-      );
+      void runWithDiagnosticTraceContext(createDiagnosticTraceContext(), () => handleMessage(data));
       return;
     }
 
     // Reserve the first handshake only; flush later frames after hello so normal RPCs stay parallel.
-    handshakeInProgress = true;
+    queuedHandshakeFrames = [];
     void runWithDiagnosticTraceContext(createDiagnosticTraceContext(), () =>
       handleIncomingMessage(data),
     ).finally(() => {
-      handshakeInProgress = false;
-      const frames = queuedHandshakeFrames.splice(0);
+      const frames = queuedHandshakeFrames?.splice(0) ?? [];
+      queuedHandshakeFrames = undefined;
       if (isClosed()) {
         return;
       }

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -52,10 +52,10 @@ export type {
   GatewayWsMessageHandlerParams,
   WsOriginCheckMetrics,
 } from "./message-handler-types.js";
+import { MAX_QUEUED_GATEWAY_PREAUTH_FRAMES } from "./preauth-ingress.js";
 
 const GATEWAY_WORK_ADMISSION_RETRY_AFTER_MS = 1_000;
 const GATEWAY_WORK_ADMISSION_CLOSE_CODE = 1013;
-const MAX_QUEUED_GATEWAY_HANDSHAKE_FRAMES = 16;
 function claimsWorkerConnectionIdentity(value: unknown): boolean {
   if (!value || typeof value !== "object") {
     return false;
@@ -531,7 +531,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
         queuedHandshakeFrames.length = 0;
         return;
       }
-      if (queuedHandshakeFrames.length >= MAX_QUEUED_GATEWAY_HANDSHAKE_FRAMES) {
+      if (queuedHandshakeFrames.length >= MAX_QUEUED_GATEWAY_PREAUTH_FRAMES) {
         setHandshakeState("failed");
         setCloseCause("handshake-message-overflow", {
           queuedFrames: queuedHandshakeFrames.length,

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -55,6 +55,7 @@ export type {
 
 const GATEWAY_WORK_ADMISSION_RETRY_AFTER_MS = 1_000;
 const GATEWAY_WORK_ADMISSION_CLOSE_CODE = 1013;
+const MAX_QUEUED_GATEWAY_HANDSHAKE_FRAMES = 16;
 function claimsWorkerConnectionIdentity(value: unknown): boolean {
   if (!value || typeof value !== "object") {
     return false;
@@ -165,25 +166,32 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
     void runWithGatewayIndependentRootWorkAdmission(run).catch(onError);
   };
 
+  const rejectOversizedPreauthFrame = (data: RawData): boolean => {
+    const payloadBytes = rawDataByteLength(data);
+    if (payloadBytes <= MAX_PREAUTH_PAYLOAD_BYTES) {
+      return false;
+    }
+    logRejectedLargePayload({
+      surface: "gateway.ws.preauth",
+      bytes: payloadBytes,
+      limitBytes: MAX_PREAUTH_PAYLOAD_BYTES,
+      reason: "preauth_frame_limit",
+    });
+    setHandshakeState("failed");
+    setCloseCause("preauth-payload-too-large", {
+      payloadBytes,
+      limitBytes: MAX_PREAUTH_PAYLOAD_BYTES,
+    });
+    close(1009, "preauth payload too large");
+    return true;
+  };
+
   const handleMessage = async (data: RawData) => {
     if (isClosed()) {
       return;
     }
 
-    const preauthPayloadBytes = !getClient() ? rawDataByteLength(data) : undefined;
-    if (preauthPayloadBytes !== undefined && preauthPayloadBytes > MAX_PREAUTH_PAYLOAD_BYTES) {
-      logRejectedLargePayload({
-        surface: "gateway.ws.preauth",
-        bytes: preauthPayloadBytes,
-        limitBytes: MAX_PREAUTH_PAYLOAD_BYTES,
-        reason: "preauth_frame_limit",
-      });
-      setHandshakeState("failed");
-      setCloseCause("preauth-payload-too-large", {
-        payloadBytes: preauthPayloadBytes,
-        limitBytes: MAX_PREAUTH_PAYLOAD_BYTES,
-      });
-      close(1009, "preauth payload too large");
+    if (!getClient() && rejectOversizedPreauthFrame(data)) {
       return;
     }
 
@@ -509,9 +517,55 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
     }
   };
 
-  socket.on("message", (data) => {
+  let handshakeInProgress = false;
+  const queuedHandshakeFrames: RawData[] = [];
+
+  const onMessage = (data: RawData): void => {
+    if (isClosed()) {
+      return;
+    }
+    if (handshakeInProgress) {
+      // Keep the preauth cap authoritative for pipelined frames until this
+      // connection actually owns an admitted client.
+      if (!getClient() && rejectOversizedPreauthFrame(data)) {
+        queuedHandshakeFrames.length = 0;
+        return;
+      }
+      if (queuedHandshakeFrames.length >= MAX_QUEUED_GATEWAY_HANDSHAKE_FRAMES) {
+        setHandshakeState("failed");
+        setCloseCause("handshake-message-overflow", {
+          queuedFrames: queuedHandshakeFrames.length,
+        });
+        queuedHandshakeFrames.length = 0;
+        close(1008, "too many pending handshake frames");
+        return;
+      }
+      queuedHandshakeFrames.push(data);
+      return;
+    }
+
+    if (getClient()) {
+      void runWithDiagnosticTraceContext(createDiagnosticTraceContext(), () =>
+        handleIncomingMessage(data),
+      );
+      return;
+    }
+
+    // Reserve the first handshake only; flush later frames after hello so normal RPCs stay parallel.
+    handshakeInProgress = true;
     void runWithDiagnosticTraceContext(createDiagnosticTraceContext(), () =>
       handleIncomingMessage(data),
-    );
-  });
+    ).finally(() => {
+      handshakeInProgress = false;
+      const frames = queuedHandshakeFrames.splice(0);
+      if (isClosed()) {
+        return;
+      }
+      for (const frame of frames) {
+        onMessage(frame);
+      }
+    });
+  };
+
+  socket.on("message", onMessage);
 }

--- a/src/gateway/server/ws-connection/preauth-ingress.ts
+++ b/src/gateway/server/ws-connection/preauth-ingress.ts
@@ -1,0 +1,3 @@
+// Lazy handler loading and async handshake admission are consecutive pre-auth stages.
+// Keep one queue ceiling so neither stage can drift into a weaker ingress policy.
+export const MAX_QUEUED_GATEWAY_PREAUTH_FRAMES = 16;

--- a/src/gateway/server/ws-connection/preauth-ingress.ts
+++ b/src/gateway/server/ws-connection/preauth-ingress.ts
@@ -1,3 +1,0 @@
-// Lazy handler loading and async handshake admission are consecutive pre-auth stages.
-// Keep one queue ceiling so neither stage can drift into a weaker ingress policy.
-export const MAX_QUEUED_GATEWAY_PREAUTH_FRAMES = 16;

--- a/test/clawrouter-managed-gateway.e2e.test.ts
+++ b/test/clawrouter-managed-gateway.e2e.test.ts
@@ -70,7 +70,10 @@ describe("ClawRouter managed gateway contract", () => {
             },
           },
           logging: { file: logFile },
-          agents: { defaults: { model: { primary: MODEL_REF } } },
+          agents: {
+            defaults: { model: { primary: MODEL_REF } },
+            entries: { main: {} },
+          },
         },
         null,
         2,

--- a/test/clawrouter-managed-gateway.e2e.test.ts
+++ b/test/clawrouter-managed-gateway.e2e.test.ts
@@ -70,10 +70,7 @@ describe("ClawRouter managed gateway contract", () => {
             },
           },
           logging: { file: logFile },
-          agents: {
-            defaults: { model: { primary: MODEL_REF } },
-            entries: { main: {} },
-          },
+          agents: { defaults: { model: { primary: MODEL_REF } } },
         },
         null,
         2,

--- a/test/gateway-queued-session-rotation.e2e.test.ts
+++ b/test/gateway-queued-session-rotation.e2e.test.ts
@@ -221,7 +221,9 @@ describe("Gateway queued session rotation", () => {
             skills: [],
             skipBootstrap: true,
           },
-          list: [{ id: "main", default: true, model: { primary: modelRef }, skills: [] }],
+          entries: {
+            main: { model: { primary: modelRef }, skills: [] },
+          },
         },
         tools: { profile: "minimal" },
         models: {

--- a/test/gateway-queued-session-rotation.e2e.test.ts
+++ b/test/gateway-queued-session-rotation.e2e.test.ts
@@ -221,9 +221,7 @@ describe("Gateway queued session rotation", () => {
             skills: [],
             skipBootstrap: true,
           },
-          entries: {
-            main: { model: { primary: modelRef }, skills: [] },
-          },
+          list: [{ id: "main", default: true, model: { primary: modelRef }, skills: [] }],
         },
         tools: { profile: "minimal" },
         models: {


### PR DESCRIPTION
<!-- AI-assisted change. No linked issue was provided. -->

## What Problem This Solves

When authentication, pairing, or migration revalidation yields, multiple pre-auth WebSocket frames can enter Gateway connect admission concurrently. That permits duplicate session finalization and mutable admission side effects on one socket.

## Why This Change Was Made

The socket ingress now reserves exactly one unauthenticated handshake and queues later frames behind it. The queue:

- preserves each frame's existing 64 KiB pre-auth payload ceiling;
- shares the existing 16-frame pre-auth ingress budget used while the handler loads;
- is discarded on overflow, close, or failed hello delivery; and
- is replayed through the normal authenticated dispatcher only after the complete connect transaction settles, including bootstrap-token bookkeeping and hello delivery.

This serializes only pre-auth admission. After hello succeeds, the existing parallel RPC dispatcher remains unchanged.

The full-handshake release point matters: an earlier version released queued RPCs immediately after `setClient`, which could run them before one-time bootstrap bookkeeping or hello delivery completed. The current implementation removes that window.

## Compatibility

OpenClaw's TypeScript, Swift, and Android clients all await the connect response/hello before sending normal RPCs. The 16-frame limit therefore affects only clients that pipeline more than fifteen frames before the server has completed hello. That traffic was never a valid way to establish multiple sessions and already encountered the same bound during lazy handler loading.

## Evidence

- Current-main focused Gateway proof: 4 files / 99 tests passed.
- Gateway client handshake proof: 1 file / 13 tests passed.
- Regressions cover duplicate connect admission, 64 KiB queued-frame enforcement, the 17th-frame boundary, real-WebSocket ordered replay, withholding RPCs until hello completes, and discarding queued RPCs when hello delivery fails.
- `pnpm check:changed` passed on the pre-rebase implementation; the exact-head run after a disjoint current-main rebase is recorded in the latest review comment.

No Gateway protocol or configuration contract changes.
