### PR TITLE
fix(plugins): preserve bundled install ownership

### DIFF
--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -1380,6 +1380,65 @@ describe("discoverOpenClawPlugins", () => {
     ).toBe(true);
   });
 
+  it("adds managed ownership to bundled candidates deduplicated in the shared scan", () => {
+    const stateDir = makeTempDir();
+    const bundledDir = path.join(stateDir, "bundled");
+    const plainDir = path.join(bundledDir, "plain");
+    const packageDir = path.join(bundledDir, "package");
+    mkdirSafe(plainDir);
+    mkdirSafe(packageDir);
+    writePluginManifest({ pluginDir: plainDir, id: "plain" });
+    writePluginEntry(path.join(plainDir, "index.js"));
+    writePluginPackageManifest({
+      packageDir,
+      packageName: "@openclaw/package",
+      extensions: ["./index.js"],
+    });
+    writePluginManifest({ pluginDir: packageDir, id: "package" });
+    writePluginEntry(path.join(packageDir, "index.js"));
+    const env = buildDiscoveryEnvWithOverrides(stateDir, {
+      OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir,
+    });
+    const installRecords = {
+      "plain-owner": { source: "path", installPath: plainDir },
+      "package-owner": { source: "path", installPath: packageDir },
+    } satisfies Record<string, PluginInstallRecord>;
+
+    const result = discoverOpenClawPlugins({ env, installRecords });
+
+    expectCandidateSource(result.candidates, "plain", path.join(plainDir, "index.js"));
+    expectCandidateFields(requireCandidateById(result.candidates, "plain"), {
+      origin: "bundled",
+      packageName: undefined,
+      installOwner: "plain-owner",
+    });
+    expectCandidateSource(result.candidates, "package", path.join(packageDir, "index.js"));
+    expectCandidateFields(requireCandidateById(result.candidates, "package"), {
+      origin: "bundled",
+      packageName: "@openclaw/package",
+      installOwner: "package-owner",
+    });
+
+    const ambiguous = discoverOpenClawPlugins({
+      env,
+      installRecords: {
+        ...installRecords,
+        "other-owner": installRecords["plain-owner"],
+      },
+    });
+
+    expectCandidateFields(requireCandidateById(ambiguous.candidates, "plain"), {
+      origin: "bundled",
+      installOwner: undefined,
+      installOwnerAmbiguous: true,
+    });
+    expectDiagnostic({
+      diagnostics: ambiguous.diagnostics,
+      level: "error",
+      messageIncludes: "multiple plugin install records claim the same package path",
+    });
+  });
+
   it("reuses one filesystem realpath lookup per package root within a discovery run", () => {
     const stateDir = makeTempDir();
     const packageDir = path.join(stateDir, "extensions", "pack");

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -391,6 +391,24 @@ function createDiscoveryResult(): PluginDiscoveryResult {
   };
 }
 
+function mergeCandidateInstallOwner(
+  existing: PluginCandidate,
+  candidateOwner: string | undefined,
+  candidateOwnerAmbiguous: boolean,
+): void {
+  const existingOwner = resolvePluginCandidateInstallOwner(existing);
+  const ownerConflict = existingOwner && candidateOwner && existingOwner !== candidateOwner;
+  if (
+    isPluginCandidateInstallOwnerAmbiguous(existing) ||
+    candidateOwnerAmbiguous ||
+    ownerConflict
+  ) {
+    recordPluginCandidateInstallOwner(existing, undefined, true);
+  } else if (candidateOwner) {
+    recordPluginCandidateInstallOwner(existing, candidateOwner);
+  }
+}
+
 function mergeDiscoveryResult(
   target: PluginDiscoveryResult,
   source: PluginDiscoveryResult,
@@ -404,18 +422,11 @@ function mergeDiscoveryResult(
     const key = safeRealpathSync(candidate.source, realpathCache) ?? path.resolve(candidate.source);
     const existing = candidatesBySource.get(key);
     if (existing) {
-      const existingOwner = resolvePluginCandidateInstallOwner(existing);
-      const candidateOwner = resolvePluginCandidateInstallOwner(candidate);
-      const ownerConflict = existingOwner && candidateOwner && existingOwner !== candidateOwner;
-      if (
-        isPluginCandidateInstallOwnerAmbiguous(existing) ||
-        isPluginCandidateInstallOwnerAmbiguous(candidate) ||
-        ownerConflict
-      ) {
-        recordPluginCandidateInstallOwner(existing, undefined, true);
-      } else if (candidateOwner) {
-        recordPluginCandidateInstallOwner(existing, candidateOwner);
-      }
+      mergeCandidateInstallOwner(
+        existing,
+        resolvePluginCandidateInstallOwner(candidate),
+        isPluginCandidateInstallOwnerAmbiguous(candidate),
+      );
       continue;
     }
     candidatesBySource.set(key, candidate);
@@ -802,6 +813,14 @@ function addCandidate(params: {
 }) {
   const resolved = path.resolve(params.source);
   if (params.seen.has(resolved)) {
+    const existing = params.candidates.find((candidate) => candidate.source === resolved);
+    if (existing) {
+      mergeCandidateInstallOwner(
+        existing,
+        params.installOwner,
+        params.installOwnerAmbiguous === true,
+      );
+    }
     return;
   }
   const resolvedRoot =


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a bundled plugin discovered before its managed install record could lose package ownership during same-scan source deduplication. Lifecycle actions then lacked the authoritative install owner even though the install ledger claimed the same plugin root.

## Why This Change Was Made

Discovery now merges only install-owner and ambiguity metadata into the retained first candidate before returning from same-pass deduplication. Bundled precedence, origin, package metadata, and source stay unchanged; conflicting install records still fail closed as ambiguous with the existing diagnostic.

Root cause: `addCandidate` returned on its `seen` check before ownership from the later managed-install pass reached the retained bundled candidate.

Production delta: `+31/-12` (`+19` net), justified by restoring the lifecycle ownership boundary without replacing or revalidating the retained candidate. Test delta: `+59`.

## User Impact

Operators can use managed lifecycle actions for package-less and package-backed bundled plugins whose install records point at the same discovered root. Conflicting ownership remains unavailable rather than selecting an unsafe owner.

## Evidence

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/plugins/discovery.test.ts src/plugins/manifest-registry-installed.test.ts src/plugins/install-persistence.test.ts`
  - 3 files passed, 146 tests passed
- `node scripts/check-changed.mjs -- src/plugins/discovery.ts src/plugins/discovery.test.ts`
  - passed on Blacksmith Testbox
- `pnpm format:check src/plugins/discovery.ts src/plugins/discovery.test.ts`
- `git diff --check`
- exact-head autoreview: clean, no accepted/actionable findings
- exact-head local ClawSweeper review: `nothing_found`, high confidence, best-fix verdict

The heavy bundled-plugin shard is deferred, not waived, while beta.2 validation capacity is reserved. Exact-head ordinary CI and ClawSweeper review remain required before merge.

AI-assisted: yes. I reviewed and understand the implementation and tests.
