### PR TITLE
fix(xai): report lazy voice bridge connect failure as a terminal error

### DIFF
--- a/extensions/google/index.test.ts
+++ b/extensions/google/index.test.ts
@@ -656,6 +656,129 @@ describe("google provider plugin hooks", () => {
     bridge.close();
   });
 
+  it("reports and cleans up a lazy realtime connect failure before reconnecting", async () => {
+    const failure = new Error("Google realtime connect rejected");
+    const errorCallbackFailure = new Error("Google realtime error callback rejected");
+    const closeCallbackFailure = new Error("Google realtime close callback rejected");
+    const cleanupFailure = new Error("Google realtime cleanup rejected");
+    const failed = createMockRealtimeBridge(async () => {
+      throw failure;
+    });
+    failed.close.mockImplementationOnce(() => {
+      throw cleanupFailure;
+    });
+    const reconnected = createMockRealtimeBridge();
+    createRealtimeBridgeMock
+      .mockReturnValueOnce(failed.bridge)
+      .mockReturnValueOnce(reconnected.bridge);
+    const callbackOrder: string[] = [];
+    const onError = vi.fn((error: Error) => {
+      callbackOrder.push(`error:${error.message}`);
+      throw errorCallbackFailure;
+    });
+    const onClose = vi.fn((reason: "completed" | "error") => {
+      callbackOrder.push(`close:${reason}`);
+      throw closeCallbackFailure;
+    });
+    const { bridge } = createLazyRealtimeBridge(onError, undefined, onClose);
+
+    bridge.sendAudio(Buffer.from([0x01]));
+    bridge.sendUserMessage?.("discarded");
+    await expect(bridge.connect()).rejects.toBe(failure);
+    bridge.sendAudio(Buffer.from([0x02]));
+    bridge.sendUserMessage?.("also discarded");
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError).toHaveBeenCalledWith(failure);
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledWith("error");
+    expect(callbackOrder).toEqual(["error:Google realtime connect rejected", "close:error"]);
+    expect(failed.close).toHaveBeenCalledOnce();
+
+    const reconnectPromise = bridge.connect();
+    bridge.sendAudio(Buffer.from([0x03]));
+    bridge.sendUserMessage?.("accepted");
+    await reconnectPromise;
+    signalRealtimeBridgeReady();
+
+    expect(createRealtimeBridgeMock).toHaveBeenCalledTimes(2);
+    expect(reconnected.sendAudio).toHaveBeenCalledOnce();
+    expect(reconnected.sendAudio).toHaveBeenCalledWith(Buffer.from([0x03]));
+    expect(reconnected.sendUserMessage).toHaveBeenCalledOnce();
+    expect(reconnected.sendUserMessage).toHaveBeenCalledWith("accepted");
+  });
+
+  it("reports one terminal error when concurrent lazy connects reject together", async () => {
+    const failure = new Error("shared Google realtime connect rejected");
+    const connecting = createDeferred<void>();
+    const loaded = createMockRealtimeBridge(() => connecting.promise);
+    createRealtimeBridgeMock.mockReturnValue(loaded.bridge);
+    const onError = vi.fn();
+    const onClose = vi.fn();
+    const { bridge } = createLazyRealtimeBridge(onError, undefined, onClose);
+
+    const firstConnect = bridge.connect();
+    const secondConnect = bridge.connect();
+    const connectResults = Promise.allSettled([firstConnect, secondConnect]);
+    await vi.waitFor(() => expect(loaded.connect).toHaveBeenCalledTimes(2));
+    connecting.reject(failure);
+
+    expect(await connectResults).toEqual([
+      { status: "rejected", reason: failure },
+      { status: "rejected", reason: failure },
+    ]);
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError).toHaveBeenCalledWith(failure);
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledWith("error");
+    expect(loaded.close).toHaveBeenCalledOnce();
+  });
+
+  it("does not leak a superseded lazy connect rejection into its replacement", async () => {
+    const failure = new Error("superseded Google realtime connect rejected");
+    const firstConnect = createDeferred<void>();
+    const stale = createMockRealtimeBridge(() => firstConnect.promise);
+    const replacement = createMockRealtimeBridge();
+    createRealtimeBridgeMock
+      .mockReturnValueOnce(stale.bridge)
+      .mockReturnValueOnce(replacement.bridge);
+    const onError = vi.fn();
+    const onClose = vi.fn();
+    const { bridge } = createLazyRealtimeBridge(onError, undefined, onClose);
+
+    const staleConnect = bridge.connect();
+    const staleConnectResult = expect(staleConnect).rejects.toBe(failure);
+    await vi.waitFor(() => expect(stale.connect).toHaveBeenCalledOnce());
+    signalRealtimeBridgeClose("error");
+    await bridge.connect();
+    firstConnect.reject(failure);
+    await staleConnectResult;
+
+    expect(createRealtimeBridgeMock).toHaveBeenCalledTimes(2);
+    expect(replacement.connect).toHaveBeenCalledOnce();
+    expect(stale.close).toHaveBeenCalledOnce();
+    expect(replacement.close).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledWith("error");
+  });
+
+  it("reports explicit lazy realtime close once when the provider also reports completion", async () => {
+    const loaded = createMockRealtimeBridge();
+    createRealtimeBridgeMock.mockReturnValue(loaded.bridge);
+    const onClose = vi.fn();
+    const { bridge } = createLazyRealtimeBridge(vi.fn(), undefined, onClose);
+
+    await bridge.connect();
+    loaded.close.mockImplementation(() => signalRealtimeBridgeClose("completed"));
+    bridge.close();
+    bridge.close();
+
+    expect(loaded.close).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledWith("completed");
+  });
+
   it("preserves queued user messages until the loaded bridge reports ready", async () => {
     const connected = createDeferred<void>();
     const loaded = createMockRealtimeBridge(() => connected.promise);

--- a/extensions/google/index.ts
+++ b/extensions/google/index.ts
@@ -211,37 +211,83 @@ function createLazyGoogleRealtimeVoiceBridge(
   let bridge: RealtimeVoiceBridge | undefined;
   let bridgePromise: Promise<RealtimeVoiceBridge> | undefined;
   let bridgeReady = false;
-  let bridgeClosed = false;
   let closed = false;
   // Provider close is terminal for input admission. Only an explicit connect()
   // call may reopen it; late callbacks and microphone frames stay ignored.
   let providerTerminated = false;
+  let generation = 0;
   let latestMediaTimestamp: number | undefined;
   let pendingGreeting: string | undefined;
   // Lazy startup keeps the newest microphone tail when loading stalls.
   const pendingAudio = createRealtimeVoiceAudioQueue("drop-oldest");
   const pendingUserMessages: string[] = [];
   let pendingUserMessageBytes = 0;
+  const closedBridges = new WeakSet<RealtimeVoiceBridge>();
+  const clearPendingInput = () => {
+    pendingAudio.clear();
+    pendingUserMessages.length = 0;
+    pendingUserMessageBytes = 0;
+    pendingGreeting = undefined;
+    latestMediaTimestamp = undefined;
+  };
+  const isCurrentNonterminalGeneration = (candidate: number) =>
+    candidate === generation && !providerTerminated;
   // Loading and connecting finish on separate async boundaries. Keep close ownership
   // here so either late completion closes the provider bridge exactly once.
   const closeBridge = (loadedBridge = bridge) => {
-    if (!loadedBridge || bridgeClosed) {
+    if (!loadedBridge || closedBridges.has(loadedBridge)) {
       return;
     }
-    bridgeClosed = true;
+    closedBridges.add(loadedBridge);
     loadedBridge.close();
+  };
+  const emitTerminal = (terminalGeneration: number, reason: "completed" | "error") => {
+    if (!isCurrentNonterminalGeneration(terminalGeneration)) {
+      return;
+    }
+    bridgeReady = false;
+    providerTerminated = true;
+    clearPendingInput();
+    req.onClose?.(reason);
+  };
+  const throwTerminalBridgeError = (
+    terminalGeneration: number,
+    loadedBridge: RealtimeVoiceBridge,
+    primaryError: unknown,
+  ): never => {
+    if (isCurrentNonterminalGeneration(terminalGeneration)) {
+      try {
+        req.onError?.(
+          primaryError instanceof Error ? primaryError : new Error(String(primaryError)),
+        );
+      } catch {
+        // Consumer callback failures cannot prevent terminal cleanup or replace the provider failure.
+      }
+      try {
+        emitTerminal(terminalGeneration, "error");
+      } catch {
+        // Consumer callback failures cannot prevent cleanup or replace the provider failure.
+      }
+    }
+    try {
+      closeBridge(loadedBridge);
+    } catch {
+      // Cleanup failures cannot replace the provider failure.
+    }
+    throw primaryError;
   };
   const loadBridge = async () => {
     if (!bridgePromise) {
+      const loadGeneration = generation;
       bridgePromise = loadGoogleRealtimeVoiceProvider().then((provider) =>
         provider.createBridge({
           ...req,
           onReady: () => {
-            if (closed || providerTerminated) {
+            if (loadGeneration !== generation || closed || providerTerminated) {
               return;
             }
             req.onReady?.();
-            if (closed || providerTerminated || !bridge) {
+            if (loadGeneration !== generation || closed || providerTerminated || !bridge) {
               return;
             }
             bridgeReady = true;
@@ -250,10 +296,7 @@ function createLazyGoogleRealtimeVoiceBridge(
             flushPending(bridge);
           },
           onClose: (reason) => {
-            bridgeReady = false;
-            providerTerminated = true;
-            pendingAudio.clear();
-            req.onClose?.(reason);
+            emitTerminal(loadGeneration, reason);
           },
         }),
       );
@@ -297,21 +340,25 @@ function createLazyGoogleRealtimeVoiceBridge(
     },
     supportsToolResultSuppression: false,
     connect: async () => {
+      if (providerTerminated) {
+        generation += 1;
+        bridge = undefined;
+        bridgePromise = undefined;
+        bridgeReady = false;
+        providerTerminated = false;
+      }
+      const connectGeneration = generation;
       const loadedBridge = await loadBridge();
-      if (closed) {
+      if (connectGeneration !== generation || closed) {
         closeBridge(loadedBridge);
         return;
       }
-      providerTerminated = false;
       try {
         await loadedBridge.connect();
       } catch (error) {
-        bridgeReady = false;
-        providerTerminated = true;
-        pendingAudio.clear();
-        throw error;
+        throwTerminalBridgeError(connectGeneration, loadedBridge, error);
       }
-      if (closed) {
+      if (connectGeneration !== generation || closed) {
         closeBridge(loadedBridge);
       }
     },
@@ -326,14 +373,14 @@ function createLazyGoogleRealtimeVoiceBridge(
       pendingAudio.enqueue(audio);
     },
     setMediaTimestamp: (ts) => {
-      if (closed) {
+      if (closed || providerTerminated) {
         return;
       }
       latestMediaTimestamp = ts;
       bridge?.setMediaTimestamp(ts);
     },
     sendUserMessage: (text) => {
-      if (closed) {
+      if (closed || providerTerminated) {
         return;
       }
       if (bridgeReady && bridge) {
@@ -354,7 +401,7 @@ function createLazyGoogleRealtimeVoiceBridge(
       pendingUserMessageBytes += messageBytes;
     },
     triggerGreeting: (instructions) => {
-      if (closed) {
+      if (closed || providerTerminated) {
         return;
       }
       if (bridgeReady && bridge) {
@@ -368,14 +415,17 @@ function createLazyGoogleRealtimeVoiceBridge(
       requireBridge().submitToolResult(callId, result, options),
     acknowledgeMark: () => requireBridge().acknowledgeMark(),
     close: () => {
+      if (closed) {
+        return;
+      }
+      const closeGeneration = generation;
       closed = true;
       bridgeReady = false;
-      providerTerminated = true;
-      pendingAudio.clear();
-      pendingUserMessages.length = 0;
-      pendingUserMessageBytes = 0;
-      pendingGreeting = undefined;
+      clearPendingInput();
       closeBridge();
+      // A bridge closed before its first connect has no provider-owned
+      // connection to report the terminal outcome.
+      emitTerminal(closeGeneration, "completed");
     },
     isConnected: () => bridge?.isConnected() ?? false,
   };

--- a/extensions/xai/lazy-capability-providers.test.ts
+++ b/extensions/xai/lazy-capability-providers.test.ts
@@ -704,18 +704,21 @@ describe("xAI lazy capability providers", () => {
     expect(onClose).toHaveBeenCalledWith("completed");
   });
 
-  it("keeps a replacement voice generation open after closing a pending connect", async () => {
+  it("keeps a replacement voice generation open when a superseded connect rejects", async () => {
+    const failure = new Error("superseded voice connect rejected");
     const firstConnect = createDeferred<void>();
     runtimeMocks.voiceConnect
       .mockReturnValueOnce(firstConnect.promise)
       .mockResolvedValueOnce(undefined);
     const lazy = await loadLazyProviders();
+    const onError = vi.fn();
     const onClose = vi.fn();
     const bridge = lazy
       .createLazyXaiRealtimeVoiceProvider()
-      .createBridge(createVoiceRequest({ onClose }));
+      .createBridge(createVoiceRequest({ onError, onClose }));
 
     const staleConnect = bridge.connect();
+    const staleConnectResult = expect(staleConnect).rejects.toBe(failure);
     await vi.waitFor(() => expect(runtimeMocks.voiceConnect).toHaveBeenCalledOnce());
     const staleRequest = runtimeMocks.createVoiceBridge.mock.calls[0]?.[0] as
       | RealtimeVoiceBridgeCreateRequest
@@ -725,14 +728,16 @@ describe("xAI lazy capability providers", () => {
     await replacementConnect;
     staleRequest?.onClose?.("error");
     bridge.sendUserMessage?.("replacement-still-open");
-    firstConnect.resolve();
-    await staleConnect;
+    firstConnect.reject(failure);
+    await staleConnectResult;
 
     expect(runtimeMocks.voiceConnect).toHaveBeenCalledTimes(2);
     expect(runtimeMocks.createVoiceBridge).toHaveBeenCalledTimes(2);
     expect(runtimeMocks.voiceClose).toHaveBeenCalledOnce();
     expect(runtimeMocks.voiceSendUserMessage).toHaveBeenCalledWith("replacement-still-open");
+    expect(onError).not.toHaveBeenCalled();
     expect(onClose).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledWith("completed");
   });
 
   it("ignores nonterminal callbacks from a superseded voice generation", async () => {
@@ -825,15 +830,18 @@ describe("xAI lazy capability providers", () => {
 
   it("reports queued voice flush failure as a terminal error", async () => {
     const failure = new Error("tool result rejected");
+    const callbackFailure = new Error("voice close callback rejected");
     runtimeMocks.voiceSubmitToolResult.mockRejectedValueOnce(failure);
     const lazy = await loadLazyProviders();
-    const onClose = vi.fn();
+    const onClose = vi.fn(() => {
+      throw callbackFailure;
+    });
     const bridge = lazy
       .createLazyXaiRealtimeVoiceProvider()
       .createBridge(createVoiceRequest({ onClose }));
 
     await bridge.submitToolResult("call-1", { text: "queued" });
-    await expect(bridge.connect()).rejects.toThrow(failure);
+    await expect(bridge.connect()).rejects.toBe(failure);
     const loadedRequest = runtimeMocks.createVoiceBridge.mock.calls[0]?.[0] as
       | RealtimeVoiceBridgeCreateRequest
       | undefined;
@@ -848,14 +856,28 @@ describe("xAI lazy capability providers", () => {
 
   it("reports voice connect failure as a terminal error", async () => {
     const failure = new Error("voice connect rejected");
+    const errorCallbackFailure = new Error("voice error callback rejected");
+    const closeCallbackFailure = new Error("voice close callback rejected");
+    const cleanupFailure = new Error("voice cleanup rejected");
+    const callbackOrder: string[] = [];
     runtimeMocks.voiceConnect.mockRejectedValueOnce(failure);
+    runtimeMocks.voiceClose.mockImplementationOnce(() => {
+      throw cleanupFailure;
+    });
     const lazy = await loadLazyProviders();
-    const onClose = vi.fn();
+    const onError = vi.fn((error: Error) => {
+      callbackOrder.push(`error:${error.message}`);
+      throw errorCallbackFailure;
+    });
+    const onClose = vi.fn(() => {
+      callbackOrder.push("close:error");
+      throw closeCallbackFailure;
+    });
     const bridge = lazy
       .createLazyXaiRealtimeVoiceProvider()
-      .createBridge(createVoiceRequest({ onClose }));
+      .createBridge(createVoiceRequest({ onError, onClose }));
 
-    await expect(bridge.connect()).rejects.toThrow(failure);
+    await expect(bridge.connect()).rejects.toBe(failure);
     const loadedRequest = runtimeMocks.createVoiceBridge.mock.calls[0]?.[0] as
       | RealtimeVoiceBridgeCreateRequest
       | undefined;
@@ -864,8 +886,11 @@ describe("xAI lazy capability providers", () => {
 
     expect(runtimeMocks.voiceClose).toHaveBeenCalledOnce();
     expect(runtimeMocks.voiceSendAudio).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError).toHaveBeenCalledWith(failure);
     expect(onClose).toHaveBeenCalledOnce();
     expect(onClose).toHaveBeenCalledWith("error");
+    expect(callbackOrder).toEqual(["error:voice connect rejected", "close:error"]);
   });
 
   it("reopens voice only after an explicit connect following provider termination", async () => {

--- a/extensions/xai/lazy-capability-providers.test.ts
+++ b/extensions/xai/lazy-capability-providers.test.ts
@@ -846,6 +846,28 @@ describe("xAI lazy capability providers", () => {
     expect(onClose).toHaveBeenCalledWith("error");
   });
 
+  it("reports voice connect failure as a terminal error", async () => {
+    const failure = new Error("voice connect rejected");
+    runtimeMocks.voiceConnect.mockRejectedValueOnce(failure);
+    const lazy = await loadLazyProviders();
+    const onClose = vi.fn();
+    const bridge = lazy
+      .createLazyXaiRealtimeVoiceProvider()
+      .createBridge(createVoiceRequest({ onClose }));
+
+    await expect(bridge.connect()).rejects.toThrow(failure);
+    const loadedRequest = runtimeMocks.createVoiceBridge.mock.calls[0]?.[0] as
+      | RealtimeVoiceBridgeCreateRequest
+      | undefined;
+    loadedRequest?.onClose?.("completed");
+    bridge.sendAudio(Buffer.from([0x01]));
+
+    expect(runtimeMocks.voiceClose).toHaveBeenCalledOnce();
+    expect(runtimeMocks.voiceSendAudio).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledWith("error");
+  });
+
   it("reopens voice only after an explicit connect following provider termination", async () => {
     const lazy = await loadLazyProviders();
     const onClose = vi.fn();

--- a/extensions/xai/lazy-capability-providers.ts
+++ b/extensions/xai/lazy-capability-providers.ts
@@ -438,11 +438,11 @@ function createLazyXaiRealtimeVoiceBridge(
         try {
           await loadedBridge.connect();
         } catch (error) {
-          if (connectGeneration === generation) {
-            acceptsInput = false;
-            terminalGeneration = connectGeneration;
-            clearPendingInput();
-          }
+          // A failed connect is terminal for this generation: report it like the
+          // queued-flush failure path and close the loaded bridge so its
+          // resources are not leaked.
+          emitTerminal(connectGeneration, "error");
+          closeBridge(loadedBridge);
           throw error;
         }
         if (connectGeneration !== generation || !acceptsCurrentInput()) {

--- a/extensions/xai/lazy-capability-providers.ts
+++ b/extensions/xai/lazy-capability-providers.ts
@@ -254,11 +254,13 @@ function createLazyXaiRealtimeVoiceBridge(
     pendingToolResultCount = 0;
     pendingToolResultBytes = 0;
   };
+  const isCurrentNonterminalGeneration = (candidate: number) =>
+    candidate === generation && terminalGeneration !== candidate;
   const emitTerminal = (
     terminalForGeneration: number,
     outcome: Parameters<NonNullable<RealtimeVoiceBridgeCreateRequest["onClose"]>>[0],
   ) => {
-    if (terminalForGeneration !== generation || terminalGeneration === terminalForGeneration) {
+    if (!isCurrentNonterminalGeneration(terminalForGeneration)) {
       return;
     }
     terminalGeneration = terminalForGeneration;
@@ -273,8 +275,34 @@ function createLazyXaiRealtimeVoiceBridge(
     closedBridges.add(loadedBridge);
     loadedBridge.close();
   };
+  const throwTerminalBridgeError = (
+    terminalForGeneration: number,
+    loadedBridge: RealtimeVoiceBridge,
+    primaryError: unknown,
+  ): never => {
+    if (isCurrentNonterminalGeneration(terminalForGeneration)) {
+      try {
+        req.onError?.(
+          primaryError instanceof Error ? primaryError : new Error(String(primaryError)),
+        );
+      } catch {
+        // Consumer callback failures cannot prevent terminal cleanup or replace the provider failure.
+      }
+      try {
+        emitTerminal(terminalForGeneration, "error");
+      } catch {
+        // Consumer callback failures cannot prevent cleanup or replace the provider failure.
+      }
+    }
+    try {
+      closeBridge(loadedBridge);
+    } catch {
+      // Cleanup failures cannot replace the provider failure.
+    }
+    throw primaryError;
+  };
   const acceptsProviderCallback = (callbackGeneration: number) =>
-    callbackGeneration === generation && !closed && terminalGeneration !== callbackGeneration;
+    !closed && isCurrentNonterminalGeneration(callbackGeneration);
   const guardProviderCallback = <TArgs extends unknown[]>(
     callbackGeneration: number,
     callback: (...args: TArgs) => void,
@@ -438,12 +466,7 @@ function createLazyXaiRealtimeVoiceBridge(
         try {
           await loadedBridge.connect();
         } catch (error) {
-          // A failed connect is terminal for this generation: report it like the
-          // queued-flush failure path and close the loaded bridge so its
-          // resources are not leaked.
-          emitTerminal(connectGeneration, "error");
-          closeBridge(loadedBridge);
-          throw error;
+          throwTerminalBridgeError(connectGeneration, loadedBridge, error);
         }
         if (connectGeneration !== generation || !acceptsCurrentInput()) {
           closeBridge(loadedBridge);
@@ -452,9 +475,7 @@ function createLazyXaiRealtimeVoiceBridge(
         try {
           await flushPendingInput(loadedBridge, connectGeneration);
         } catch (error) {
-          emitTerminal(connectGeneration, "error");
-          closeBridge(loadedBridge);
-          throw error;
+          throwTerminalBridgeError(connectGeneration, loadedBridge, error);
         }
         if (connectGeneration !== generation || !acceptsCurrentInput()) {
           closeBridge(loadedBridge);


### PR DESCRIPTION
## Summary

fix(xai): report a lazy realtime voice bridge `connect()` failure as a terminal `error` and close the loaded bridge, instead of leaking it silently

## What Problem This Solves

The xAI extension lazily loads its realtime voice runtime: `createLazyXaiRealtimeVoiceProvider().createBridge(req)` returns a wrapper that only imports the real provider and creates the real bridge on first use. Callers rely on `req.onClose(outcome)` to learn the terminal state of the bridge.

When the loaded bridge's `connect()` rejects (network failure, auth rejection, WebSocket error), the wrapper's connect promise rejects — but:

- `req.onClose` is **never called**, so the caller (e.g. the talk/voice session layer) never learns the bridge is dead and waits indefinitely for a terminal outcome.
- The loaded bridge is **never closed**, leaking its resources (sockets, timers).
- Input sent after the failed connect is silently accepted into the pending queue even though the generation is already terminal.

The adjacent queued-flush failure path (failure while replaying pending input after a successful connect) already does all of this correctly — `emitTerminal(connectGeneration, "error")` + `closeBridge(loadedBridge)` — which is exactly the contract the connect path violates.

**代码证据**: in `extensions/xai/lazy-capability-providers.ts`, `createLazyXaiRealtimeVoiceBridge`'s `connect()`:

```ts
try {
  await loadedBridge.connect();
} catch (error) {
  if (connectGeneration === generation) {
    acceptsInput = false;
    terminalGeneration = connectGeneration;
    clearPendingInput();
  }
  throw error;   // no req.onClose("error"), no closeBridge(loadedBridge)
}
```

Trigger condition: any rejection from the real voice bridge's `connect()`.

## Root Cause

- The lazy voice bridge wrapper was introduced by commit `e35d22807e5` (2026-08-05, #119374, "perf(xai): lazy-load optional capability runtimes").
- Violated invariant: every code path that terminates a bridge generation must report exactly one terminal outcome via `req.onClose` and release the loaded bridge. The connect-failure path marks the generation terminal *internally* (`terminalGeneration = connectGeneration`) without performing the external half of the contract.
- The inconsistency with the flush-failure path (same function, ~10 lines below) shows the omission was accidental, not a design choice.

## Why This Fix

- Option A: leave reporting to callers — every caller would need to pair a `connect()` rejection with a synthetic `onClose("error")`. Rejected: duplicates terminal-state logic per caller and still leaks the loaded bridge.
- Option B (chosen): mirror the flush-failure path in the connect catch — `emitTerminal(connectGeneration, "error"); closeBridge(loadedBridge); throw error;`. `emitTerminal` already dedupes (one terminal outcome per generation) and clears pending input; `closeBridge` already dedupes via a WeakSet. A late provider-reported `onClose("completed")` after the failure is ignored, and post-failure `sendAudio` is dropped by the existing terminal checks.
- Not chosen: calling `req.onClose` directly without `emitTerminal` — would bypass the generation guard and could double-report against a concurrent provider close.

## User Impact

- Affected scenarios: xAI realtime voice (talk mode) sessions where the voice WebSocket connect fails.
- Before: the session hangs with no terminal outcome; the underlying bridge is leaked; late audio is silently queued.
- After: the caller receives exactly one `onClose("error")`, the loaded bridge is closed immediately, and the `connect()` rejection still propagates.
- Behavior change: callers now observe a terminal `error` outcome for failed voice connects. This is strictly better — the previous behavior was an indefinite hang plus a resource leak.

## Evidence

Real stack, no mocks of anything under test: the proof drives the **real lazy wrapper** (`extensions/xai/lazy-capability-providers.ts`), the **real dynamically imported** `realtime-voice-provider.js`, the **real `XaiRealtimeVoiceBridge`**, and a real `ws` client dialing a real closed loopback TCP port — producing a genuine `ECONNREFUSED` network failure. The only "fake" element is the absence of a listening server, i.e. the failure itself is a real transport-level connect failure.

### Before (on main)

```bash
$ node node_modules/tsx/dist/cli.mjs proof-xai-connect-real.mjs
[proof] target: real ws dial to closed port 127.0.0.1:50208
[proof] connect() rejected with: connect ECONNREFUSED 127.0.0.1:50208
[proof] req.onClose calls: []
[proof] isConnected() after failure: false
[proof] RESULT: FAIL - req.onClose must be called exactly once with "error", got []
```

### After (with fix, rebased on latest main)

```bash
$ node node_modules/tsx/dist/cli.mjs proof-xai-connect-real.mjs
[proof] target: real ws dial to closed port 127.0.0.1:50749
[proof] connect() rejected with: connect ECONNREFUSED 127.0.0.1:50749
[proof] req.onClose calls: ["error"]
[proof] isConnected() after failure: false
[proof] RESULT: PASS - real connect failure emits exactly one terminal onClose("error") and propagates
```

Same real rejection on both runs; only the fixed wrapper reports the terminal outcome to the caller. Post-failure `sendAudio` is dropped (`isConnected()` stays false, pending queue cleared by the terminal path).

**What was not tested:** a live connection to `wss://api.x.ai` with real credentials; the failure is exercised at the real transport boundary (TCP refusal) instead, which traverses the identical `connect()` rejection path in the real bridge.

## Tests and Validation

- `npx vitest run extensions/xai/lazy-capability-providers.test.ts` — 30/30 passed, including the regression test `reports voice connect failure as a terminal error` (connect rejection propagates, loaded bridge closed once, `onClose` called exactly once with `"error"`, late provider close ignored, post-failure `sendAudio` dropped).
- `npx oxlint --deny=warn` on both changed files — 0 warnings, 0 errors.
- Before/after real-behavior proof logs are embedded above (real transport failure, not a stubbed provider).
