### PR TITLE
fix(release): align survivor session metadata assertion

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -869,8 +869,8 @@ function assertSessionMetadataMigrated(stateDir) {
         `legacy session transcript was not moved for ${sessionId}`,
       );
       assert(
-        entry?.sessionFile === expectedPath,
-        `legacy session row still points at the old sessions directory for ${sessionId}`,
+        !Object.hasOwn(entry ?? {}, "sessionFile"),
+        `legacy session row retained retired sessionFile metadata for ${sessionId}`,
       );
     }
   }

--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -835,11 +835,17 @@ function assertSessionMetadataMigrated(stateDir) {
   assert(main?.sessionId === LEGACY_SESSION_MAIN_ID, "main legacy session row missing");
   assert(direct?.sessionId === LEGACY_SESSION_DIRECT_ID, "direct legacy session row missing");
   assert(group?.sessionId === LEGACY_SESSION_GROUP_ID, "channel legacy session row missing");
-  const migratedSessionIds = [
-    LEGACY_SESSION_MAIN_ID,
-    LEGACY_SESSION_DIRECT_ID,
-    LEGACY_SESSION_GROUP_ID,
+  const migratedSessions = [
+    [LEGACY_SESSION_MAIN_ID, main],
+    [LEGACY_SESSION_DIRECT_ID, direct],
+    [LEGACY_SESSION_GROUP_ID, group],
   ];
+  for (const [sessionId, entry] of migratedSessions) {
+    assert(
+      !Object.hasOwn(entry ?? {}, "sessionFile"),
+      `legacy session row retained retired sessionFile metadata for ${sessionId}`,
+    );
+  }
   if (source !== "file") {
     const dbPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
     const db = new DatabaseSync(dbPath, { readOnly: true });
@@ -847,7 +853,7 @@ function assertSessionMetadataMigrated(stateDir) {
       const count = db.prepare(
         "SELECT COUNT(*) AS count FROM transcript_events WHERE session_id = ?",
       );
-      for (const sessionId of migratedSessionIds) {
+      for (const [sessionId] of migratedSessions) {
         const row = count.get(sessionId);
         assert(
           Number(row?.count ?? 0) > 0,
@@ -858,19 +864,11 @@ function assertSessionMetadataMigrated(stateDir) {
       db.close();
     }
   } else {
-    for (const [sessionId, entry] of [
-      [LEGACY_SESSION_MAIN_ID, main],
-      [LEGACY_SESSION_DIRECT_ID, direct],
-      [LEGACY_SESSION_GROUP_ID, group],
-    ]) {
+    for (const [sessionId] of migratedSessions) {
       const expectedPath = path.join(agentSessionsDir, `${sessionId}.jsonl`);
       assert(
         fs.existsSync(expectedPath),
         `legacy session transcript was not moved for ${sessionId}`,
-      );
-      assert(
-        !Object.hasOwn(entry ?? {}, "sessionFile"),
-        `legacy session row retained retired sessionFile metadata for ${sessionId}`,
       );
     }
   }

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -580,6 +580,27 @@ describe("upgrade survivor assertions", () => {
     ).not.toThrow();
   });
 
+  it("rejects retired sessionFile metadata in SQLite-backed session rows", () => {
+    expect(() =>
+      runSessionStateAssertion((stateDir) => {
+        writeMigratedSessionState(stateDir);
+        const db = new DatabaseSync(
+          join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite"),
+        );
+        try {
+          db.prepare("UPDATE session_nodes SET entry_json = ? WHERE session_key = ?").run(
+            JSON.stringify({
+              sessionFile: join(stateDir, "sessions", "upgrade-main-session.jsonl"),
+            }),
+            "agent:main:main",
+          );
+        } finally {
+          db.close();
+        }
+      }),
+    ).toThrow(/retained retired sessionFile metadata/);
+  });
+
   it("rejects ClawHub npm-pack installs outside the managed extensions root", () => {
     const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-survivor-outside-"));
     try {

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -91,14 +91,9 @@ function writeMigratedSessionState(stateDir: string): void {
 }
 
 function createMigratedSessionFileStore(
-  stateDir: string,
   options: { includePrompt?: boolean } = {},
 ): Record<string, Record<string, unknown>> {
-  const agentSessionsDir = join(stateDir, "agents", "main", "sessions");
-  const main: Record<string, unknown> = {
-    sessionId: "upgrade-main-session",
-    sessionFile: join(agentSessionsDir, "upgrade-main-session.jsonl"),
-  };
+  const main: Record<string, unknown> = { sessionId: "upgrade-main-session" };
   if (options.includePrompt !== false) {
     main.skillsSnapshot = {
       prompt: "legacy prompt survives as metadata",
@@ -106,14 +101,8 @@ function createMigratedSessionFileStore(
   }
   return {
     "agent:main:main": main,
-    "agent:main:+15551234567": {
-      sessionId: "upgrade-direct-session",
-      sessionFile: join(agentSessionsDir, "upgrade-direct-session.jsonl"),
-    },
-    "agent:main:slack:channel:cupgrade": {
-      sessionId: "upgrade-group-session",
-      sessionFile: join(agentSessionsDir, "upgrade-group-session.jsonl"),
-    },
+    "agent:main:+15551234567": { sessionId: "upgrade-direct-session" },
+    "agent:main:slack:channel:cupgrade": { sessionId: "upgrade-group-session" },
   };
 }
 
@@ -123,10 +112,7 @@ function writeMigratedSessionFiles(
 ): void {
   const agentSessionsDir = join(stateDir, "agents", "main", "sessions");
   mkdirSync(agentSessionsDir, { recursive: true });
-  writeJson(
-    join(agentSessionsDir, "sessions.json"),
-    createMigratedSessionFileStore(stateDir, options),
-  );
+  writeJson(join(agentSessionsDir, "sessions.json"), createMigratedSessionFileStore(options));
   for (const sessionId of [
     "upgrade-main-session",
     "upgrade-direct-session",
@@ -162,7 +148,7 @@ function writeLegacyCacheSessionState(
     const insert = db.prepare(
       "INSERT INTO cache_entries (scope, key, value_json) VALUES (?, ?, ?)",
     );
-    for (const [key, entry] of Object.entries(createMigratedSessionFileStore(stateDir, options))) {
+    for (const [key, entry] of Object.entries(createMigratedSessionFileStore(options))) {
       insert.run("session_entries", key, JSON.stringify(entry));
     }
   } finally {
@@ -187,7 +173,7 @@ function writeLegacySessionEntriesState(stateDir: string): void {
       INSERT INTO session_entries (session_key, session_id, entry_json, updated_at)
       VALUES (?, ?, ?, ?)
     `);
-    for (const [key, entry] of Object.entries(createMigratedSessionFileStore(stateDir))) {
+    for (const [key, entry] of Object.entries(createMigratedSessionFileStore())) {
       const sessionId = entry.sessionId;
       if (typeof sessionId !== "string") {
         throw new TypeError(`missing fixture session id for ${key}`);


### PR DESCRIPTION
## What Problem This Solves

The trusted `main` release harness still required migrated file-backed session rows to retain `sessionFile`. Canonical session persistence intentionally retired that locator and stores transcript bytes separately, so exact-ref release validation failed after the signed candidate had correctly migrated the transcript and removed the legacy metadata.

Observed failure: https://github.com/openclaw/openclaw/actions/runs/31679241095

## Why This Change Was Made

Keep the two owned invariants separate:

- the migrated transcript file must exist under the canonical agent session directory;
- the persisted session row must not contain retired `sessionFile` metadata.

The survivor fixture now models the canonical row shape instead of reintroducing the retired field. No runtime behavior, compatibility path, or fallback changes.

## User Impact

Release validation no longer rejects correct upgrades after session locator retirement. A real missing transcript still fails the existing file-existence assertion, while retained legacy metadata now fails with an accurate diagnostic.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/upgrade-survivor-assertions.test.ts` — 20 passed.
- Fresh structured autoreview — no accepted/actionable findings; secret scan clean.
- The signed candidate run prepared package, image, and prerelease plugin companions successfully before failing only on the stale trusted-harness assertion.

No changelog change is required; this is trusted release-harness alignment.
