### PR TITLE
fix: gateway restart avoids false failure when systemd probe is unavailable

### DIFF
--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -268,25 +268,25 @@ describe("runServiceRestart token drift", () => {
     );
   });
 
-  it("restarts an installed managed service when its loaded-state probe is unavailable", async () => {
+  it("restarts an installed system-scope service when its loaded-state probe is unavailable", async () => {
     service.isLoaded.mockRejectedValue(
       new Error(
         "systemctl is-enabled unavailable: Command failed during launch or output capture (EACCES)",
       ),
     );
-    service.readCommand.mockResolvedValue({
-      programArguments: ["/usr/bin/openclaw", "gateway", "run"],
-      environment: {},
-    });
+    service.readCommand.mockResolvedValue(null);
+    const hasInstalledDefinition = vi.fn(async () => true);
     const postRestartCheck = vi.fn(async () => {});
 
     await expect(
       runServiceRestart({
         ...createServiceRunArgs(),
+        service: { ...service, hasInstalledDefinition } as GatewayService,
         postRestartCheck,
       }),
     ).resolves.toBe(true);
 
+    expect(hasInstalledDefinition).toHaveBeenCalledWith({ env: process.env });
     expect(service.restart).toHaveBeenCalledTimes(1);
     expect(postRestartCheck).toHaveBeenCalledTimes(1);
     expect(readJsonLog<{ ok?: boolean; result?: string }>()).toMatchObject({

--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -268,6 +268,33 @@ describe("runServiceRestart token drift", () => {
     );
   });
 
+  it("restarts an installed managed service when its loaded-state probe is unavailable", async () => {
+    service.isLoaded.mockRejectedValue(
+      new Error(
+        "systemctl is-enabled unavailable: Command failed during launch or output capture (EACCES)",
+      ),
+    );
+    service.readCommand.mockResolvedValue({
+      programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+      environment: {},
+    });
+    const postRestartCheck = vi.fn(async () => {});
+
+    await expect(
+      runServiceRestart({
+        ...createServiceRunArgs(),
+        postRestartCheck,
+      }),
+    ).resolves.toBe(true);
+
+    expect(service.restart).toHaveBeenCalledTimes(1);
+    expect(postRestartCheck).toHaveBeenCalledTimes(1);
+    expect(readJsonLog<{ ok?: boolean; result?: string }>()).toMatchObject({
+      ok: true,
+      result: "restarted",
+    });
+  });
+
   it("aborts loaded-service mutation when the service guard rejects", async () => {
     const repairLoadedService = vi.fn();
 

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -124,11 +124,20 @@ async function resolveServiceLoadedOrFail(params: {
   serviceNoun: string;
   service: GatewayService;
   fail: ReturnType<typeof createDaemonActionContext>["fail"];
+  acceptInstalledDefinition?: boolean;
 }): Promise<boolean | null> {
   // Returning null keeps failure emission centralized in the caller's action context.
   try {
     return await params.service.isLoaded({ env: process.env });
   } catch (err) {
+    // An installed definition still identifies the native manager when the
+    // loaded-state probe is unavailable; restart and Gateway health stay authoritative.
+    if (
+      params.acceptInstalledDefinition &&
+      (await params.service.readCommand(process.env).catch(() => null))
+    ) {
+      return true;
+    }
     params.fail(`${params.serviceNoun} service check failed: ${String(err)}`);
     return null;
   }
@@ -514,6 +523,7 @@ export async function runServiceRestart(params: {
     serviceNoun: params.serviceNoun,
     service: params.service,
     fail,
+    acceptInstalledDefinition: true,
   });
   if (loaded === null) {
     return false;
@@ -679,21 +689,11 @@ export async function runServiceRestart(params: {
         }
       }
     }
-    let restarted = loaded;
-    if (loaded) {
-      try {
-        restarted = await params.service.isLoaded({ env: process.env });
-      } catch {
-        restarted = true;
-      }
-    } else if (recoveredLoadedState !== null) {
-      restarted = recoveredLoadedState;
-    }
     emit({
       ok: true,
       result: "restarted",
       message: handledRecovery?.message ?? handledRepair?.message,
-      service: buildDaemonServiceSnapshot(params.service, restarted),
+      service: buildDaemonServiceSnapshot(params.service, loaded || recoveredLoadedState === true),
       warnings: warnings.length ? warnings : undefined,
     });
     const actionMessage = handledRecovery?.message ?? handledRepair?.message;

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -130,13 +130,15 @@ async function resolveServiceLoadedOrFail(params: {
   try {
     return await params.service.isLoaded({ env: process.env });
   } catch (err) {
-    // An installed definition still identifies the native manager when the
-    // loaded-state probe is unavailable; restart and Gateway health stay authoritative.
-    if (
-      params.acceptInstalledDefinition &&
-      (await params.service.readCommand(process.env).catch(() => null))
-    ) {
-      return true;
+    if (params.acceptInstalledDefinition) {
+      // The adapter owns platform-specific install discovery; systemd spans
+      // user, system, marker-owned, and dueling definitions.
+      const installed = params.service.hasInstalledDefinition
+        ? await params.service.hasInstalledDefinition({ env: process.env }).catch(() => false)
+        : Boolean(await params.service.readCommand(process.env).catch(() => null));
+      if (installed) {
+        return true;
+      }
     }
     params.fail(`${params.serviceNoun} service check failed: ${String(err)}`);
     return null;

--- a/src/daemon/node-service.ts
+++ b/src/daemon/node-service.ts
@@ -26,6 +26,7 @@ function withNodeInstallEnv(args: GatewayServiceInstallArgs): GatewayServiceInst
 /** Returns a service controller bound to node-host labels across all platforms. */
 export function resolveNodeService(): GatewayService {
   const base = resolveGatewayService();
+  const hasInstalledDefinition = base.hasInstalledDefinition;
   return {
     ...base,
     stage: (args) => base.stage(withNodeInstallEnv(args)),
@@ -39,6 +40,9 @@ export function resolveNodeService(): GatewayService {
       // wedged service manager instead of hanging the whole status command.
       return base.isLoaded({ env: withNodeServiceEnv(args.env ?? {}), timeoutMs: args.timeoutMs });
     },
+    hasInstalledDefinition: hasInstalledDefinition
+      ? (args) => hasInstalledDefinition({ ...args, env: withNodeServiceEnv(args.env ?? {}) })
+      : undefined,
     readCommand: (env) => base.readCommand(withNodeServiceEnv(env)),
     readRuntime: (env, opts) => base.readRuntime(withNodeServiceEnv(env), opts),
   };

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -46,6 +46,7 @@ import type {
   GatewayServiceState,
 } from "./service-types.js";
 import {
+  findInstalledSystemdGatewayScope,
   installSystemdService,
   isSystemdServiceEnabled,
   readSystemdServiceExecStart,
@@ -84,6 +85,7 @@ export type GatewayService = {
   restart: (args: GatewayServiceControlArgs) => Promise<GatewayServiceRestartResult>;
   isLoaded: (args: GatewayServiceEnvArgs) => Promise<boolean>;
   isEnabled?: (args: GatewayServiceEnvArgs) => Promise<boolean>;
+  hasInstalledDefinition?: (args: GatewayServiceEnvArgs) => Promise<boolean>;
   readCommand: (env: GatewayServiceEnv) => Promise<GatewayServiceCommandConfig | null>;
   readRuntime: (
     env: GatewayServiceEnv,
@@ -354,6 +356,8 @@ const GATEWAY_SERVICE_REGISTRY: Record<SupportedGatewayServicePlatform, GatewayS
     stop: stopSystemdService,
     restart: restartSystemdService,
     isLoaded: isSystemdServiceEnabled,
+    hasInstalledDefinition: async ({ env }) =>
+      (await findInstalledSystemdGatewayScope(env ?? process.env)) !== null,
     readCommand: readSystemdServiceExecStart,
     readRuntime: readSystemdServiceRuntime,
   },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw gateway restart` could receive a failure when the service loaded-state probe could not launch `systemctl is-enabled`, even though an installed systemd unit existed and the Gateway restart path was otherwise recoverable.

The reported Team Hetzner incident surfaced as `Gateway service check failed: Error: systemctl is-enabled unavailable: Command failed during launch or output capture (EACCES)` while the Gateway itself recovered with healthy readiness.

## Why This Change Was Made

Restart now asks the platform service adapter whether an installed definition exists when the preliminary loaded-state probe is unavailable. Linux uses the canonical systemd scope detector, covering user-scope, system-scope, marker-owned, and existing user-first/dueling semantics. The native restart command and the existing Gateway health/readiness check remain authoritative, so real systemd restart failures and unhealthy restart outcomes still fail.

The redundant post-success loaded-state reprobe was removed from the emitted snapshot path; restart success now carries forward the already established managed/recovered state. Node service adapters preserve their node-specific identity when using the new installation predicate.

AI-assisted: yes (Claude Code and Codex).

## User Impact

Operators no longer see a false restart failure solely because `systemctl is-enabled` could not be launched or captured. Missing service definitions still fail the service check, native service-manager errors still fail the restart, and a Gateway that does not recover health/readiness still fails with the existing diagnostics.

## Evidence

- Regression proven against the pre-fix and initially pushed production paths:
  - `node scripts/run-vitest.mjs src/cli/daemon-cli/lifecycle-core.test.ts -t "restarts an installed system-scope service when its loaded-state probe is unavailable"`
  - Failed with `promise rejected "Error: __exit__:1" instead of resolving` at the service loaded-state check.
- Focused post-fix proof:
  - `node scripts/run-vitest.mjs src/cli/daemon-cli/lifecycle-core.test.ts src/cli/daemon-cli/lifecycle.test.ts src/daemon/service.test.ts src/daemon/systemd.test.ts`
  - 249 tests passed across the lifecycle, service-adapter, and systemd suites.
  - The regression models a system-scope installation by returning no user-unit command while the adapter-owned installed-definition predicate succeeds.
  - Existing coverage confirms service-manager restart errors and unhealthy Gateway restart outcomes still fail.
- Static proof:
  - `oxfmt --check` on all four changed files: clean.
  - Targeted Oxlint on all four changed files: clean.
  - `git diff --check`: clean.
  - Changed-lane classification: `core, coreTests`.
- Independent Codex-backed autoreview: clean after the initial patch and after the system-scope review fix; no accepted/actionable findings.
- ClawSweeper's initial system-scope finding was addressed by moving installation detection to the platform adapter boundary.
- Production LOC: +21/-11 (net +10) for the adapter capability and Node identity forwarding. Tests: +27/-0.

Live proof gap: this PR does not restart the operator-owned Team Hetzner Gateway. The exact EACCES condition is covered deterministically at the lifecycle owner boundary; exact-head CI/Testbox evidence will be required before merge.
