### PR TITLE
fix(msteams): dedupe poll vote selections before maxSelections truncation

### DIFF
--- a/extensions/msteams/src/polls.test.ts
+++ b/extensions/msteams/src/polls.test.ts
@@ -71,6 +71,29 @@ describe("msteams polls", () => {
     }
     expect(stored.votes["user-1"]).toEqual(["0"]);
   });
+
+  it("deduplicates selections before enforcing maxSelections", async () => {
+    const home = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-polls-"));
+    const store = createMSTeamsPollStoreState({ homedir: () => home });
+    await store.createPoll({
+      id: "poll-dedupe",
+      question: "Pick two",
+      options: ["A", "B", "C"],
+      maxSelections: 2,
+      createdAt: new Date().toISOString(),
+      votes: {},
+    });
+    await store.recordVote({
+      pollId: "poll-dedupe",
+      voterId: "user-1",
+      selections: ["0", "0", "1"],
+    });
+    const stored = await store.getPoll("poll-dedupe");
+    if (!stored) {
+      throw new Error("expected stored poll after recordVote");
+    }
+    expect(stored.votes["user-1"]).toEqual(["0", "1"]);
+  });
 });
 
 describe("state poll store", () => {

--- a/extensions/msteams/src/polls.ts
+++ b/extensions/msteams/src/polls.ts
@@ -298,10 +298,8 @@ function normalizeMSTeamsPollSelections(poll: MSTeamsPoll, selections: string[])
     .filter((value): value is number => value !== undefined)
     .filter((value) => value >= 0 && value < poll.options.length)
     .map((value) => String(value));
-  // Deduplicate before truncating: a duplicated choice must not consume a
-  // selection slot and starve later distinct choices.
-  const unique = uniqueStrings(mapped);
-  return maxSelections > 1 ? unique.slice(0, maxSelections) : unique.slice(0, 1);
+  // Deduplicate first so repeats do not consume selection slots.
+  return uniqueStrings(mapped).slice(0, maxSelections);
 }
 
 export function splitMSTeamsPoll(poll: MSTeamsPoll): {

--- a/extensions/msteams/src/polls.ts
+++ b/extensions/msteams/src/polls.ts
@@ -298,8 +298,10 @@ function normalizeMSTeamsPollSelections(poll: MSTeamsPoll, selections: string[])
     .filter((value): value is number => value !== undefined)
     .filter((value) => value >= 0 && value < poll.options.length)
     .map((value) => String(value));
-  const limited = maxSelections > 1 ? mapped.slice(0, maxSelections) : mapped.slice(0, 1);
-  return uniqueStrings(limited);
+  // Deduplicate before truncating: a duplicated choice must not consume a
+  // selection slot and starve later distinct choices.
+  const unique = uniqueStrings(mapped);
+  return maxSelections > 1 ? unique.slice(0, maxSelections) : unique.slice(0, 1);
 }
 
 export function splitMSTeamsPoll(poll: MSTeamsPoll): {


### PR DESCRIPTION
## Summary

fix(msteams): deduplicate poll vote selections before enforcing `maxSelections`, so a duplicated choice no longer consumes a slot and drops a voter's later distinct choice

## What Problem This Solves

MSTeams polls allow up to `maxSelections` choices per voter. An Adaptive Card submits the voter's choices as a comma-joined string (e.g. `"0,0,1"`), which `extractMSTeamsPollVote` splits into `["0", "0", "1"]`. Card submit actions can legitimately contain duplicate values (double-submits, card state quirks), and the normalization layer is responsible for cleaning them up.

`normalizeMSTeamsPollSelections` in `extensions/msteams/src/polls.ts` currently **truncates before deduplicating**:

```ts
const limited = maxSelections > 1 ? mapped.slice(0, maxSelections) : mapped.slice(0, 1);
return uniqueStrings(limited);
```

So `["0", "0", "1"]` with `maxSelections = 2` is sliced to `["0", "0"]` first, and deduplication then yields `["0"]` — the voter's second distinct choice `"1"` is silently dropped. The stored vote under-counts the voter's intent and the poll tally is wrong.

**代码证据**: `extensions/msteams/src/polls.ts`, `normalizeMSTeamsPollSelections` — `mapped.slice(0, maxSelections)` runs before `uniqueStrings(...)`.

Trigger condition: any vote whose raw selections contain a duplicate within the first `maxSelections` entries, followed by a distinct choice. Easily hit when a card posts duplicate choice values.

## Root Cause

- The truncate-then-dedupe order exists since the poll store was introduced in commit `bca2501c7f7` (2026-05-27, when `polls.ts` was added).
- Violated invariant: `maxSelections` is a limit on the number of **distinct** choices a voter may make. Applying the limit to the raw (possibly duplicated) list conflates "slots" with "distinct choices".
- Trigger: `selections = ["0", "0", "1"]`, `maxSelections = 2` → stored `["0"]` instead of `["0", "1"]`.

## Why This Fix

- Option A: dedupe before truncate (chosen) — `uniqueStrings(mapped).slice(0, maxSelections)`. One-line reorder; matches the semantic meaning of `maxSelections`; first-occurrence order is preserved so voter intent ranking is unchanged.
- Option B: reject votes containing duplicates — changes API behavior and punishes voters for card/client quirks; too strict.
- Not chosen: counting duplicates as one during slicing (equivalent to A but more code).

## User Impact

- Affected scenarios: MSTeams poll votes with duplicated choice values in the submitted selection list.
- Before: later distinct choices are silently dropped from the stored vote; poll results are under-counted.
- After: duplicates collapse first, then the limit applies — `["0", "0", "1"]` with `maxSelections = 2` stores `["0", "1"]`.
- Behavior change: votes with duplicates now record all distinct choices up to the limit. This matches the documented meaning of `maxSelections`.

## Real Behavior Proof

Real channel-boundary proof: a real-shaped Teams Adaptive Card vote invoke is driven through the **real registered `app.on("card.action")` handler** in `extensions/msteams/src/monitor.ts` (captured via a Bot Framework mock app — the same seam the repo's `monitor.lifecycle` tests use), through the real `extractMSTeamsPollVote`, the real authorization gate, and into the **real poll store** (`createMSTeamsPollStoreState` on the repo's own in-memory plugin-state test runtime). Nothing in the vote-handling path is mocked; only the Teams SDK module boundary is substituted.

### Before (on main)

```bash
$ node node_modules/tsx/dist/cli.mjs proof-msteams-polls-channel.mjs
[proof] card.action response: {"statusCode":200,...,"value":"Vote recorded."}
[proof] stored vote for aad-user-proof: ["0"]
[proof] RESULT: FAIL - expected stored ["0","1"] and "Vote recorded.", got stored ["0"] response "Vote recorded."
```

### After (with fix)

```bash
$ node node_modules/tsx/dist/cli.mjs proof-msteams-polls-channel.mjs
[proof] card.action response: {"statusCode":200,...,"value":"Vote recorded."}
[proof] stored vote for aad-user-proof: ["0","1"]
[proof] RESULT: PASS - vote through the real channel handler stored ["0","1"]
```

The invoke posts `choices: "0,0,1"` (a duplicated `"0"` then a distinct `"1"`) against a poll with `maxSelections: 2`. On main the duplicate consumes both slots and `"1"` is silently dropped even though Teams reports "Vote recorded."; with the fix both distinct choices are stored.

**What was not tested:** a live Teams tenant round-trip (requires real Bot Framework credentials); the vote traverses the real registered channel handler, real extraction, real auth gate, and real store.

## Tests and Validation

- `npx vitest run extensions/msteams/src/polls.test.ts` — 11/11 passed, including the new regression test `deduplicates selections before enforcing maxSelections` (`["0","0","1"]` with `maxSelections = 2` stores `["0","1"]`).
- `npx oxlint --deny=warn` on both changed files — 0 warnings, 0 errors.
- Before/after real-behavior proof logs are embedded above.
