### PR TITLE
fix(ui): deduplicate projects in the What picker

### DIFF
--- a/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
@@ -422,7 +422,7 @@ suite.define(() => {
     });
   });
 
-  it("uses identity-scoped server project recents instead of the shared roster", async () => {
+  it("uses identity-scoped server recents without duplicating registered projects", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -452,7 +452,14 @@ suite.define(() => {
       methodResponses: {
         "projects.list": {
           projects: [{ id: "registered", displayName: "Registered", source: "registered" }],
-          recents: [{ kind: "project", projectId: "registered", displayName: "Registered" }],
+          recents: [
+            { kind: "project", projectId: "registered", displayName: "Registered" },
+            {
+              kind: "folder",
+              folder: `${WORKSPACE}/scratch`,
+              displayName: "scratch",
+            },
+          ],
         },
         "sessions.list": {
           count: 1,
@@ -474,10 +481,13 @@ suite.define(() => {
       const trigger = page.locator("#new-session-project-trigger");
       await trigger.click();
       expect(await page.locator('[data-value="recent::/shared"]').count()).toBe(0);
-      const recent = page.locator('[data-value="recent-project:registered"]');
-      await recent.waitFor();
-      await captureProjectUiProof(page, "identity-project-recents.png");
-      await recent.click();
+      expect(await page.locator('[data-value="recent-project:registered"]').count()).toBe(0);
+      const project = page.locator('[data-value="project:registered"]');
+      const recentFolder = page.locator(`[data-value="recent::${WORKSPACE}/scratch"]`);
+      await project.waitFor();
+      await recentFolder.waitFor();
+      await captureProjectUiProof(page, "identity-project-recents-after.png");
+      await project.click();
       await page.locator(".new-session-page__message").fill("continue registered work");
       await page.getByRole("button", { name: "Start session" }).click();
       const create = await gateway.waitForRequest("sessions.create");

--- a/ui/src/pages/new-session/project-chip.test.ts
+++ b/ui/src/pages/new-session/project-chip.test.ts
@@ -63,6 +63,26 @@ describe("What chip state", () => {
     },
   );
 
+  it("omits project recents already shown in the project list", () => {
+    const folderRecent = {
+      kind: "folder" as const,
+      folder: "/workspace/scratch",
+      displayName: "scratch",
+    };
+    const state = resolveProjectChip({
+      folder: "",
+      workspace: "/workspace",
+      projectId: "",
+      selectedRemoteProject: null,
+      projects,
+      recents: [{ kind: "project", projectId: "openclaw", displayName: "OpenClaw" }, folderRecent],
+      projectQuery: "",
+      execNode: "",
+    });
+
+    expect(state.recents).toEqual([folderRecent]);
+  });
+
   it.each([
     ["https://github.com/openclaw/openclaw.git", true],
     ["git@github.com:openclaw/openclaw.git", true],

--- a/ui/src/pages/new-session/project-chip.ts
+++ b/ui/src/pages/new-session/project-chip.ts
@@ -74,7 +74,7 @@ export function resolveProjectChip(params: {
         )
       : normalizedQuery
         ? []
-        : params.recents,
+        : params.recents.filter((recent) => recent.kind === "folder"),
     showWorkspace:
       mode === "projects" &&
       (!normalizedQuery ||


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening **New session → What** saw the same registered project twice when that project was also present in identity-scoped recents.

The regression was introduced by #121816 when identity-scoped `projects.list` recents began including project-backed rows, then carried forward by #122938 when that rendering moved into the split What picker.

## Why This Change Was Made

The picker now treats the registered project list as the canonical presentation of projects and keeps only distinct folder locations in **Recent** when using the default projects mode. Gateway recency data and protocol behavior remain unchanged; node-path and search behavior are unchanged.

This change was AI-assisted. The implementation and proof were reviewed, and no agent transcript is included.

## User Impact

Each registered project appears once in the What picker. Distinct folder recents remain available, and selecting a registered project still creates the session with its `projectId`.

## Evidence

Before:

![Before: registered project duplicated in the What picker](https://github.com/user-attachments/assets/50613374-6ab1-439c-a6a3-f8d659a8a51e)

After:

![After: one registered project row with the distinct scratch folder recent preserved](https://github.com/user-attachments/assets/e2d0b97c-4c54-4ab1-9ed5-a1f9578d54c6)

Pre-fix focused proof failed with the intended single failure because the project-backed recent remained alongside the registered project:

```text
node scripts/run-vitest.mjs ui/src/pages/new-session/project-chip.test.ts
```

Passing proof:

```text
node scripts/run-vitest.mjs ui/src/pages/new-session/project-chip.test.ts
OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts -t 'uses identity-scoped server recents without duplicating registered projects'
node scripts/check-changed.mjs -- ui/src/pages/new-session/project-chip.ts ui/src/pages/new-session/project-chip.test.ts ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
git diff --check
```

The changed gate attempted Blacksmith/Testbox, found provider authentication unavailable, used the approved trusted local fallback, and exited 0. Fresh autoreview completed cleanly with no accepted/actionable findings. Source-blind behavior validation passed 5/5: one project row, distinct scratch-folder recent preserved, shared roster omitted, and project selection creates the session with `projectId`.

Production LOC: +1/-1 (net 0). Tests: +36/-6 (net +30).

The regression test protects one visible row per registered project while preserving distinct folder recents. Prior coverage omitted the project/folder overlap, and the prior E2E asserted the duplicate; the change introduces no test-only production seam.
