### PR TITLE
fix(ui): explain rejected folders outside the workspace

### DIFF
--- a/ui/src/e2e/new-session-page.operator-scopes.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.operator-scopes.e2e.test.ts
@@ -185,6 +185,58 @@ suite.define(() => {
     }
   });
 
+  it("explains when browsing outside the workspace requires admin scope", async () => {
+    const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
+    const page = await context.newPage();
+    const workspace = "/home/peter/openclaw";
+    const gateway = await installMockGateway(page, {
+      workspace,
+      workspaceGit: true,
+      featureMethods: ["chat.metadata", "chat.startup", "fs.listDir", "worktrees.branches"],
+      operatorScopes: ["operator.read", "operator.write"],
+      methodResponses: {
+        "fs.listDir": { path: workspace, home: "/home/peter", entries: [] },
+        "worktrees.branches": { branches: [], repositoryStatus: "not_git" },
+      },
+    });
+    try {
+      await page.goto(`${suite.server.baseUrl}new`);
+      await page.locator("#new-session-project-trigger").click();
+      await page.getByRole("button", { name: "Browse folders" }).click();
+      await expect(gateway.waitForRequest("fs.listDir")).resolves.toMatchObject({
+        params: { path: workspace },
+      });
+
+      const pathInput = page.locator("input.new-session-page__browser-path");
+      await expect.poll(() => pathInput.inputValue()).toBe(workspace);
+      await gateway.deferNext("fs.listDir", { path: "/tmp" });
+      await pathInput.fill("/tmp");
+      await pathInput.press("Enter");
+      await expect.poll(async () => (await gateway.getRequests("fs.listDir")).length).toBe(2);
+      expect((await gateway.getRequests("fs.listDir"))[1]?.params).toEqual({ path: "/tmp" });
+      await gateway.rejectDeferred("fs.listDir", {
+        code: "FORBIDDEN",
+        message: "Folder access was denied.",
+        details: {
+          code: "MISSING_SCOPE",
+          missingScope: "operator.admin",
+          requiredScopes: ["operator.admin"],
+        },
+      });
+
+      await expect.poll(async () => (await gateway.getRequests("fs.listDir")).length).toBe(3);
+      expect((await gateway.getRequests("fs.listDir"))[2]?.params).toEqual({});
+      await expect.poll(() => pathInput.inputValue()).toBe(workspace);
+      await pollLocatorText(
+        page.locator(".new-session-page__browser .new-session-page__error"),
+      ).toContain(
+        "To browse outside agent workspaces, request admin in the access banner, then approve in Devices.",
+      );
+    } finally {
+      await context.close();
+    }
+  });
+
   it("keeps a canonical browser selection submittable for a symlinked workspace alias", async () => {
     const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
     const page = await context.newPage();

--- a/ui/src/pages/new-session/draft-place-browser.ts
+++ b/ui/src/pages/new-session/draft-place-browser.ts
@@ -1,4 +1,5 @@
 import { initialState, Task, TaskStatus } from "@lit/task";
+import { readMissingScopeError } from "@openclaw/gateway-client/browser";
 import type { ReactiveControllerHost } from "lit";
 import type {
   FsListDirResult,
@@ -372,7 +373,7 @@ export class DraftPlaceBrowser {
     this.loadBrowser(path);
   }
 
-  loadBrowser(path: string | undefined) {
+  loadBrowser(path: string | undefined, retainedError: string | null = null) {
     const snapshot = this.read();
     const gatewaySnapshot = snapshot.context?.gateway.snapshot;
     const client = gatewaySnapshot?.client;
@@ -390,7 +391,7 @@ export class DraftPlaceBrowser {
     }
     const requestId = ++this.browserRequestToken;
     this.browserLoadingValue = true;
-    this.browserErrorValue = null;
+    this.browserErrorValue = retainedError;
     this.browserProjectPathValue = null;
     this.browserListingValue = null;
     this.browserPathDraftValue = path ?? "";
@@ -432,12 +433,17 @@ export class DraftPlaceBrowser {
         }
         this.callbacks.requestUpdate();
       })
-      .catch(() => {
+      .catch((error: unknown) => {
         if (requestId !== this.browserRequestToken) {
           return;
         }
         if (path) {
-          this.loadBrowser(undefined);
+          this.loadBrowser(
+            undefined,
+            !target.nodeId && readMissingScopeError(error)?.missingScope === "operator.admin"
+              ? t("newSession.browseRequiresAdmin")
+              : t("newSession.browserLoadFailed"),
+          );
           return;
         }
         this.browserErrorValue = t("newSession.browserLoadFailed");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users on a write-scoped, non-admin connection could type an absolute folder outside the workspace in the new-session folder browser and see the picker silently reset to the workspace root after the Gateway rejected the path.

Related context: #104238, #121417, and #122413.

## Why This Change Was Made

The browser now retains the typed Gateway `MISSING_SCOPE` result across the existing root fallback and displays the existing admin guidance. The Gateway remains the sole owner of workspace containment policy; the UI consumes its structured error contract instead of inferring policy from paths or messages.

## User Impact

Users now get actionable inline guidance when browsing outside agent workspaces requires admin access, while the usable root fallback remains intact. Other rejected typed paths show the existing generic browser failure instead of disappearing silently.

## Evidence

- Regression proof before the production edit: the focused mocked Chromium/Gateway E2E failed with 1 failed and 9 passed because no inline guidance appeared.
- Passing focused proof after the fix and again after rebasing onto current `origin/main`: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.operator-scopes.e2e.test.ts` — 1 file passed, 10/10 tests (12.93s on the rebased head).
- Selected changed gate: `node scripts/check-changed.mjs -- ui/src/pages/new-session/draft-place-browser.ts ui/src/e2e/new-session-page.operator-scopes.e2e.test.ts` passed its selected UI/type/lint/guard set. Testbox authentication was unavailable, so the wrapper used its documented trusted-source local fallback; the first pass found one explicit-unknown lint annotation, which was fixed before the full selected gate passed.
- Fresh uncommitted autoreview: clean, with no accepted/actionable findings.
- Source-blind behavior validation: 6/6 clauses passed with no blockers.
- `git diff --check` and oxfmt check: clean.
- Production LOC: +10/-4 (net +6). Tests: +52/-0. The production growth preserves the structured authorization failure across the pre-existing root recovery path without duplicating Gateway containment policy.

Before — the rejected navigation silently reset:

![Before: rejected out-of-workspace navigation silently resets](https://github.com/user-attachments/assets/6efd4cc6-629c-4142-9666-31329f27a29c)

After — the root fallback remains usable and inline admin guidance is visible:

![After: root fallback with inline admin guidance](https://github.com/user-attachments/assets/4b68e52c-0a0c-4a97-b556-5e31e3227725)

AI-assisted: this fix and its regression coverage were developed with an AI coding assistant, then reviewed and validated against the owner boundary and user-visible behavior. No agent transcript is included.
